### PR TITLE
fix(studio): sandbox llama.cpp install validation launches

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5306,8 +5306,7 @@ def _is_broad_sandbox_library_path(path: str | Path, *, require_library_dir: boo
     if len(resolved.parts) <= 3 and resolved.parts[1].lower() in {"home", "users"}:
         return True
     if require_library_dir:
-        parts = PurePosixPath(str(path)).parts
-        if parts[-1].lower() not in _SANDBOX_LIBRARY_DIR_NAMES:
+        if resolved.name.lower() not in _SANDBOX_LIBRARY_DIR_NAMES:
             return True
     try:
         if resolved == Path.home().resolve():
@@ -5589,7 +5588,11 @@ def _linux_validation_bwrap_prefix(
             "/sys/bus/pci",
             "/sys/dev/char",
             "/sys/devices",
+            "/etc/vulkan",
+            "/usr/share/vulkan",
         ]
+        dev_nodes.extend(str(node) for node in Path("/dev/dri").glob("card*"))
+        dev_nodes.extend(str(node) for node in Path("/dev/dri").glob("renderD*"))
         if gpu_backend == "cuda":
             dev_nodes.extend(
                 [
@@ -6578,6 +6581,7 @@ _PYTHON_IMPORT_POINTER_VARS = (
     "PYTHONHOME",
     "PYTHONPATH",
 )
+_LD_ALLOWED_ENV_NAMES = frozenset({"LD_LIBRARY_PATH"})
 _DYLD_ALLOWED_ENV_NAMES = frozenset({"DYLD_LIBRARY_PATH"})
 
 _isolated_runtime_home_dir: str | None = None
@@ -6611,6 +6615,9 @@ def scrubbed_environ() -> dict[str, str]:
     ):
         env.pop(pointer, None)
     for key in tuple(env):
+        if key.upper().startswith("LD_") and key.upper() not in _LD_ALLOWED_ENV_NAMES:
+            env.pop(key, None)
+            continue
         if key.upper().startswith("DYLD_") and key.upper() not in _DYLD_ALLOWED_ENV_NAMES:
             env.pop(key, None)
     return env
@@ -6642,11 +6649,19 @@ def binary_env(
         if _wsl_rocm:
             ld_dirs = [*_wsl_rocm, *ld_dirs]
             env.setdefault("HSA_ENABLE_DXG_DETECTION", "1")
-        existing = [part for part in env.get("LD_LIBRARY_PATH", "").split(os.pathsep) if part]
+        existing = [
+            str(_resolve_existing_path(Path(part)))
+            for part in env.get("LD_LIBRARY_PATH", "").split(os.pathsep)
+            if part and not _is_broad_sandbox_library_path(part)
+        ]
         env["LD_LIBRARY_PATH"] = os.pathsep.join(dedupe_existing_dirs([*ld_dirs, *existing]))
     elif host.is_macos:
         dyld_dirs = [str(binary_path.parent), str(install_dir)]
-        existing = [part for part in env.get("DYLD_LIBRARY_PATH", "").split(os.pathsep) if part]
+        existing = [
+            str(_resolve_existing_path(Path(part)))
+            for part in env.get("DYLD_LIBRARY_PATH", "").split(os.pathsep)
+            if part and not _is_broad_sandbox_library_path(part, require_library_dir = True)
+        ]
         env["DYLD_LIBRARY_PATH"] = os.pathsep.join(dedupe_existing_dirs([*dyld_dirs, *existing]))
     return env
 
@@ -7489,7 +7504,7 @@ def existing_install_matches_choice(
                 [runtime_dir / "llama-server", runtime_dir / "llama-quantize"],
                 install_dir,
                 host,
-                allow_skipped_probe = False,
+                allow_skipped_probe = True,
             )
         except Exception:
             return False

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5591,8 +5591,6 @@ def _linux_validation_bwrap_prefix(
             "/etc/vulkan",
             "/usr/share/vulkan",
         ]
-        dev_nodes.extend(str(node) for node in Path("/dev/dri").glob("card*"))
-        dev_nodes.extend(str(node) for node in Path("/dev/dri").glob("renderD*"))
         if gpu_backend == "cuda":
             dev_nodes.extend(
                 [

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5137,6 +5137,12 @@ _LINUX_LDD_PROBE_SKIPPED = "skipped"
 _LINUX_LDD_PROBE_ERROR = "error"
 _VALIDATION_SERVER_PROBE_MODE_HOST = "host_loopback_http"
 _VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX = "sandbox_loopback_http"
+_LINUX_SERVER_VALIDATION_HELPER_TIMEOUT_SECONDS = 60
+_LINUX_SERVER_VALIDATION_HELPER_SHUTDOWN_SECONDS = 5
+_LINUX_SERVER_VALIDATION_HELPER_CAPTURE_TIMEOUT_SECONDS = (
+    _LINUX_SERVER_VALIDATION_HELPER_TIMEOUT_SECONDS
+    + (2 * _LINUX_SERVER_VALIDATION_HELPER_SHUTDOWN_SECONDS)
+)
 
 
 @dataclass(frozen = True)
@@ -5173,8 +5179,15 @@ class LinuxLibraryProbeResult:
     reason: str | None = None
 
 
+def _resolve_command_path(command: str) -> str | None:
+    resolved = shutil.which(command)
+    if resolved is None:
+        return None
+    return str(Path(resolved))
+
+
 def _has_command(command: str) -> bool:
-    return shutil.which(command) is not None
+    return _resolve_command_path(command) is not None
 
 
 def _append_existing_bwrap_bind(
@@ -5204,8 +5217,7 @@ def _linux_validation_launcher_env(payload_env: dict[str, str]) -> dict[str, str
     env = scrubbed_environ()
     for key in payload_env:
         env.pop(key, None)
-    # Keep a stable base command search path; payload PATH is still injected in
-    # bwrap via --setenv from payload_env.
+    # Keep a stable base command search path.
     env["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
     return env
 
@@ -5217,8 +5229,24 @@ def _linux_validation_setenv_args(payload_env: dict[str, str]) -> list[str]:
     return args
 
 
+def _extract_loopback_port(command: list[str]) -> int:
+    for index, arg in enumerate(command):
+        if arg != "--port":
+            continue
+        if index + 1 >= len(command):
+            break
+        try:
+            return int(command[index + 1])
+        except ValueError:
+            break
+    return 0
+
+
 def _linux_validation_server_probe_command(
-    server_command: list[str], *, timeout: int = 60
+    server_command: list[str],
+    payload_env: dict[str, str],
+    *,
+    timeout: int = _LINUX_SERVER_VALIDATION_HELPER_TIMEOUT_SECONDS,
 ) -> list[str]:
     for candidate in ("/usr/bin/python3", "/usr/bin/python"):
         if Path(candidate).exists():
@@ -5231,7 +5259,6 @@ def _linux_validation_server_probe_command(
 
     probe_script = textwrap.dedent(
         f"""
-        import json
         import os
         import subprocess
         import sys
@@ -5241,6 +5268,7 @@ def _linux_validation_server_probe_command(
         import urllib.request
 
         command = {json.dumps(server_command)}
+        payload_env = {json.dumps(payload_env)}
         body = b'{{"prompt":"a","n_predict":1}}'
         timeout = {int(timeout)}
         deadline = time.time() + timeout
@@ -5269,11 +5297,14 @@ def _linux_validation_server_probe_command(
 
         try:
             with open(log_path, "w", encoding = "utf-8", errors = "replace") as log_handle:
+                server_env = dict(os.environ)
+                server_env.update(payload_env)
                 process = subprocess.Popen(
                     command,
                     stdout = log_handle,
                     stderr = subprocess.STDOUT,
                     text = True,
+                    env = server_env,
                 )
                 request = urllib.request.Request(
                     "http://127.0.0.1:%d/completion" % port,
@@ -5288,7 +5319,7 @@ def _linux_validation_server_probe_command(
                             print(line)
                         raise SystemExit(process.returncode if process.returncode else 1)
                     try:
-                        with urllib.request.urlopen(request, timeout = 1) as response:
+                        with urllib.request.urlopen(request, timeout = 5) as response:
                             _ = response.read(32)
                             if response.status == 200:
                                 process.terminate()
@@ -5332,6 +5363,7 @@ def _linux_validation_bwrap_prefix(
     binary_path: Path,
     install_dir: Path,
     purpose: str,
+    adapter_path: str,
     payload_env: dict[str, str],
     payload_command: list[str] | None = None,
     enable_gpu_layers: bool = False,
@@ -5391,13 +5423,15 @@ def _linux_validation_bwrap_prefix(
         and gpu_backend in {"cuda", "rocm"}
     )
     args = [
-        "bwrap",
+        adapter_path,
         "--unshare-all",
     ]
     args.extend(
         [
         "--die-with-parent",
         "--new-session",
+        "--perms",
+        "1777",
         "--tmpfs",
         "/tmp",
         "--proc",
@@ -5409,7 +5443,9 @@ def _linux_validation_bwrap_prefix(
         runtime_home,
         ]
     )
-    args.extend(_linux_validation_setenv_args(payload_env))
+    is_server_helper = payload_command is not None and purpose == _VALIDATION_PURPOSE_SERVER
+    if not is_server_helper:
+        args.extend(_linux_validation_setenv_args(payload_env))
 
     seen: set[str] = set()
     if enable_gpu_devices:
@@ -5489,12 +5525,11 @@ def _macos_validation_sandbox_prefix(
     runtime_home = Path(isolated_runtime_home())
     read_targets: list[str | Path] = [
         "/bin",
-        "/usr",
         "/usr/bin",
-        "/System",
-        "/Library",
-        "/System/Library/Frameworks",
         "/usr/lib",
+        "/System",
+        "/System/Library/Frameworks",
+        "/System/Library",
         install_dir,
         binary_path.parent,
         runtime_home,
@@ -5514,9 +5549,9 @@ def _macos_validation_sandbox_prefix(
     exec_targets: list[str | Path] = [
         "/bin",
         "/usr/bin",
+        "/usr/lib",
         "/System",
-        "/Library",
-        "/usr",
+        "/System/Library",
         binary_path.parent,
     ]
     profile_parts = [
@@ -5543,8 +5578,10 @@ def _macos_validation_sandbox_prefix(
             profile_parts.append(f'(subpath "{literal}")')
     profile_parts.append(")")
     if purpose == _VALIDATION_PURPOSE_SERVER:
-        profile_parts.append('(allow network* (local ip "localhost:*"))')
-        profile_parts.append('(allow network* (remote ip "localhost:*"))')
+        server_port = _extract_loopback_port(command)
+        if server_port > 0:
+            profile_parts.append(f'(allow network* (local ip "localhost:{server_port}"))')
+            profile_parts.append(f'(allow network* (remote ip "localhost:{server_port}"))')
     profile = "".join(profile_parts)
     return [
         "sandbox-exec",
@@ -5587,7 +5624,8 @@ def build_validation_sandbox_plan(
         _linux_validation_launcher_env(env) if _host_is_linux(host) else scrubbed_environ()
     )
     if _host_is_linux(host):
-        if _has_command("bwrap"):
+        bwrap_path = _resolve_command_path("bwrap")
+        if bwrap_path is not None:
             payload_command = list(command)
             network_policy = _VALIDATION_NETWORK_POLICY_SANDBOX
             server_probe_mode = (
@@ -5598,7 +5636,8 @@ def build_validation_sandbox_plan(
                 try:
                     launch_command = _linux_validation_server_probe_command(
                         payload_command,
-                        timeout = 60,
+                        env,
+                        timeout = _LINUX_SERVER_VALIDATION_HELPER_TIMEOUT_SECONDS,
                     )
                 except RuntimeError as exc:
                     return _ValidationLaunchPlan(
@@ -5618,6 +5657,7 @@ def build_validation_sandbox_plan(
                 binary_path = binary_path,
                 install_dir = install_dir,
                 purpose = purpose,
+                adapter_path = bwrap_path,
                 payload_env = env,
                 payload_command = payload_command,
                 enable_gpu_layers = enable_gpu_layers,
@@ -6522,7 +6562,10 @@ def validate_server(
         )
         if plan.server_probe_mode == _VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX:
             started_at = time.time()
-            result = _run_validation_capture(plan, timeout = 60)
+            result = _run_validation_capture(
+                plan,
+                timeout = _LINUX_SERVER_VALIDATION_HELPER_CAPTURE_TIMEOUT_SECONDS,
+            )
             output = (result.stdout or "") + (result.stderr or "")
             if result.returncode == 0:
                 return

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5183,7 +5183,29 @@ def _resolve_command_path(command: str) -> str | None:
     resolved = shutil.which(command)
     if resolved is None:
         return None
-    return str(Path(resolved))
+    return str(Path(resolved).resolve())
+
+
+def _resolve_existing_path(path: str | Path) -> Path:
+    candidate = Path(path)
+    try:
+        return candidate.resolve(strict = True)
+    except Exception:
+        return candidate
+
+
+def _resolve_sandbox_command(command: list[str]) -> list[str]:
+    if not command:
+        return []
+    resolved_command = list(command)
+    command_path = Path(resolved_command[0])
+    if command_path.is_absolute():
+        resolved_command[0] = str(_resolve_existing_path(command_path))
+        return resolved_command
+    resolved_path = _resolve_command_path(resolved_command[0])
+    if resolved_path is not None:
+        resolved_command[0] = resolved_path
+    return resolved_command
 
 
 def _has_command(command: str) -> bool:
@@ -5370,11 +5392,7 @@ def _linux_validation_bwrap_prefix(
     gpu_backend: Literal["cuda", "rocm"] | None = None,
 ) -> list[str]:
     runtime_home = isolated_runtime_home()
-    command_path = Path(command[0])
-    if not command_path.is_absolute():
-        resolved_command = shutil.which(command[0])
-        if resolved_command:
-            command_path = Path(resolved_command)
+    command_path = _resolve_existing_path(command[0])
 
     write_targets = {
         str(Path(runtime_home)),
@@ -5422,10 +5440,19 @@ def _linux_validation_bwrap_prefix(
         and enable_gpu_layers
         and gpu_backend in {"cuda", "rocm"}
     )
-    args = [
-        adapter_path,
-        "--unshare-all",
-    ]
+    args = [adapter_path]
+    if enable_gpu_devices:
+        args.extend(
+            [
+                "--unshare-cgroup-try",
+                "--unshare-ipc",
+                "--unshare-net",
+                "--unshare-pid",
+                "--unshare-uts",
+            ]
+        )
+    else:
+        args.append("--unshare-all")
     args.extend(
         [
         "--die-with-parent",
@@ -5554,6 +5581,17 @@ def _macos_validation_sandbox_prefix(
         "/System/Library",
         binary_path.parent,
     ]
+    executable_map_targets: list[str | Path] = [
+        "/usr/lib",
+        "/System",
+        "/System/Library",
+        binary_path.parent,
+    ]
+    executable_map_targets.extend(
+        part
+        for part in env.get("DYLD_LIBRARY_PATH", "").split(os.pathsep)
+        if part
+    )
     profile_parts = [
         "(version 1)",
         "(deny default)",
@@ -5561,6 +5599,11 @@ def _macos_validation_sandbox_prefix(
         "(allow process-exec",
     ]
     for target in exec_targets:
+        for literal in _sandbox_profile_path_literals(target):
+            profile_parts.append(f'(subpath "{literal}")')
+    profile_parts.append(")")
+    profile_parts.append("(allow file-map-executable")
+    for target in executable_map_targets:
         for literal in _sandbox_profile_path_literals(target):
             profile_parts.append(f'(subpath "{literal}")')
     profile_parts.append(")")
@@ -5626,7 +5669,7 @@ def build_validation_sandbox_plan(
     if _host_is_linux(host):
         bwrap_path = _resolve_command_path("bwrap")
         if bwrap_path is not None:
-            payload_command = list(command)
+            payload_command = _resolve_sandbox_command(command)
             network_policy = _VALIDATION_NETWORK_POLICY_SANDBOX
             server_probe_mode = (
                 _VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX if purpose == _VALIDATION_PURPOSE_SERVER else None
@@ -5634,11 +5677,11 @@ def build_validation_sandbox_plan(
             launch_command = payload_command
             if purpose == _VALIDATION_PURPOSE_SERVER:
                 try:
-                    launch_command = _linux_validation_server_probe_command(
+                    launch_command = _resolve_sandbox_command(_linux_validation_server_probe_command(
                         payload_command,
                         env,
                         timeout = _LINUX_SERVER_VALIDATION_HELPER_TIMEOUT_SECONDS,
-                    )
+                    ))
                 except RuntimeError as exc:
                     return _ValidationLaunchPlan(
                         command = payload_command,

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -6333,6 +6333,11 @@ _CI_COMMAND_FILE_VARS = (
     "GITHUB_STEP_SUMMARY",
     "BASH_ENV",
 )
+# Python-first sandbox helpers must not inherit host import roots.
+_PYTHON_IMPORT_POINTER_VARS = (
+    "PYTHONHOME",
+    "PYTHONPATH",
+)
 
 _isolated_runtime_home_dir: str | None = None
 
@@ -6358,7 +6363,11 @@ def scrubbed_environ() -> dict[str, str]:
     # Windows rebuilds the profile from %HOMEDRIVE%%HOMEPATH% (no-op pair on POSIX).
     drive, tail = os.path.splitdrive(runtime_home)
     env["HOMEDRIVE"], env["HOMEPATH"] = drive, tail or runtime_home
-    for pointer in (*_CREDENTIAL_FILE_POINTER_VARS, *_CI_COMMAND_FILE_VARS):
+    for pointer in (
+        *_CREDENTIAL_FILE_POINTER_VARS,
+        *_CI_COMMAND_FILE_VARS,
+        *_PYTHON_IMPORT_POINTER_VARS,
+    ):
         env.pop(pointer, None)
     return env
 

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5217,11 +5217,14 @@ def _binary_is_setuid_root(path: str | Path) -> bool:
     return stat_result.st_uid == 0 and bool(stat_result.st_mode & stat.S_ISUID)
 
 
-def _has_command(command: str) -> bool:
-    return _resolve_command_path(command) is not None
-
-
 _bwrap_sandbox_capability: dict[str, bool] = {}
+_LINUX_DYNAMIC_LOADER_ENV_VARS = (
+    "LD_LIBRARY_PATH",
+    "LD_PRELOAD",
+    "LD_AUDIT",
+    "LD_DEBUG",
+    "LD_ORIGIN_PATH",
+)
 
 
 def _bwrap_can_sandbox(bwrap_path: str) -> bool:
@@ -5247,6 +5250,7 @@ def _bwrap_can_sandbox(bwrap_path: str) -> bool:
             ],
             stdout = subprocess.DEVNULL,
             stderr = subprocess.DEVNULL,
+            env = _linux_validation_launcher_env({}),
             timeout = 20,
         )
         ok = result.returncode == 0
@@ -5275,9 +5279,34 @@ def _append_existing_bwrap_bind(
     )
 
 
+def _is_broad_sandbox_library_path(path: str | Path) -> bool:
+    candidate = Path(path)
+    if not candidate.is_absolute() and not str(candidate).startswith(("/", "\\")):
+        return True
+    resolved = _resolve_existing_path(candidate)
+    if len(resolved.parts) <= 2:
+        return True
+    if len(resolved.parts) <= 3 and resolved.parts[1].lower() in {"home", "users"}:
+        return True
+    try:
+        if resolved == Path.home().resolve():
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def _sandbox_library_path_targets(env: dict[str, str], key: str) -> list[Path]:
+    return [
+        _resolve_existing_path(Path(part))
+        for part in env.get(key, "").split(os.pathsep)
+        if part and not _is_broad_sandbox_library_path(part)
+    ]
+
+
 def _linux_validation_launcher_env(payload_env: dict[str, str]) -> dict[str, str]:
     env = scrubbed_environ()
-    for key in payload_env:
+    for key in (*payload_env, *_LINUX_DYNAMIC_LOADER_ENV_VARS):
         env.pop(key, None)
     # Keep a stable base command search path.
     env["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -5473,9 +5502,7 @@ def _linux_validation_bwrap_prefix(
         )
     if Path("/nix/store") in command_path.parents:
         readonly_targets.append("/nix/store")
-    readonly_targets.extend(
-        part for part in payload_env.get("LD_LIBRARY_PATH", "").split(os.pathsep) if part
-    )
+    readonly_targets.extend(_sandbox_library_path_targets(payload_env, "LD_LIBRARY_PATH"))
     server_command = payload_command or command
 
     if purpose == _VALIDATION_PURPOSE_QUANTIZE and len(command) >= 3:
@@ -5597,7 +5624,13 @@ def _sandbox_profile_path_literals(path: str | Path) -> list[str]:
 
 
 def _macos_validation_sandbox_prefix(
-    command: list[str], *, binary_path: Path, install_dir: Path, purpose: str, env: dict[str, str]
+    command: list[str],
+    *,
+    binary_path: Path,
+    install_dir: Path,
+    purpose: str,
+    env: dict[str, str],
+    adapter_path: str,
 ) -> list[str]:
     runtime_home = Path(isolated_runtime_home())
     read_targets: list[str | Path] = [
@@ -5611,7 +5644,7 @@ def _macos_validation_sandbox_prefix(
         binary_path.parent,
         runtime_home,
     ]
-    read_targets.extend(part for part in env.get("DYLD_LIBRARY_PATH", "").split(os.pathsep) if part)
+    read_targets.extend(_sandbox_library_path_targets(env, "DYLD_LIBRARY_PATH"))
     write_targets: list[str | Path] = [runtime_home]
     if purpose == _VALIDATION_PURPOSE_QUANTIZE and len(command) >= 3:
         read_targets.append(Path(command[1]).parent)
@@ -5633,9 +5666,7 @@ def _macos_validation_sandbox_prefix(
         "/System/Library",
         binary_path.parent,
     ]
-    executable_map_targets.extend(
-        part for part in env.get("DYLD_LIBRARY_PATH", "").split(os.pathsep) if part
-    )
+    executable_map_targets.extend(_sandbox_library_path_targets(env, "DYLD_LIBRARY_PATH"))
     profile_parts = [
         "(version 1)",
         "(deny default)",
@@ -5671,7 +5702,7 @@ def _macos_validation_sandbox_prefix(
             profile_parts.append(f'(allow network* (remote ip "localhost:{server_port}"))')
     profile = "".join(profile_parts)
     return [
-        "sandbox-exec",
+        adapter_path,
         "-p",
         profile,
     ]
@@ -5803,7 +5834,8 @@ def build_validation_sandbox_plan(
         )
 
     if _host_is_macos(host):
-        if _has_command("sandbox-exec"):
+        sandbox_exec_path = _resolve_command_path("sandbox-exec")
+        if sandbox_exec_path is not None:
             network_policy = (
                 _VALIDATION_NETWORK_POLICY_SANDBOX
                 if purpose == _VALIDATION_PURPOSE_SERVER
@@ -5818,6 +5850,7 @@ def build_validation_sandbox_plan(
                         install_dir = install_dir,
                         purpose = purpose,
                         env = env,
+                        adapter_path = sandbox_exec_path,
                     ),
                     "/usr/bin/env",
                     "-i",

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5337,7 +5337,10 @@ def _run_validation_popen(
 def linux_missing_libraries(binary_path: Path, *, env: dict[str, str] | None = None) -> list[str]:
     if env is None:
         env = scrubbed_environ()
-    probe_output = _run_validation_ldd_probe(binary_path, env = env)
+    try:
+        probe_output = _run_validation_ldd_probe(binary_path, env = env)
+    except Exception:
+        return []
     if not probe_output:
         return []
     result = subprocess.CompletedProcess(binary_path, 0, stdout = probe_output)

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -19,6 +19,7 @@ import re
 import shutil
 import site
 import socket
+import stat
 import struct
 import subprocess
 import sys
@@ -5208,6 +5209,14 @@ def _resolve_sandbox_command(command: list[str]) -> list[str]:
     return resolved_command
 
 
+def _binary_is_setuid_root(path: str | Path) -> bool:
+    try:
+        stat_result = os.stat(path)
+    except OSError:
+        return False
+    return stat_result.st_uid == 0 and bool(stat_result.st_mode & stat.S_ISUID)
+
+
 def _has_command(command: str) -> bool:
     return _resolve_command_path(command) is not None
 
@@ -5418,6 +5427,8 @@ def _linux_validation_bwrap_prefix(
                 command_path.parent.parent / "lib64",
             ]
         )
+    if Path("/nix/store") in command_path.parents:
+        readonly_targets.append("/nix/store")
     readonly_targets.extend(
         part
         for part in payload_env.get("LD_LIBRARY_PATH", "").split(os.pathsep)
@@ -5495,7 +5506,9 @@ def _linux_validation_bwrap_prefix(
             for path in Path("/dev").glob("nvidia*"):
                 if re.match(r"^nvidia[0-9]+$", path.name):
                     dev_nodes.append(str(path))
+            dev_nodes.extend(str(path) for path in Path("/dev/nvidia-caps").glob("nvidia-cap*"))
             readonly_gpu_targets.append("/proc/driver/nvidia")
+            readonly_gpu_targets.append("/proc/driver/nvidia/capabilities")
         elif gpu_backend == "rocm":
             dev_nodes.extend(["/dev/kfd", "/dev/dxg"])
             dev_nodes.extend(str(node) for node in Path("/dev/dri").glob("card*"))
@@ -5670,6 +5683,24 @@ def build_validation_sandbox_plan(
         bwrap_path = _resolve_command_path("bwrap")
         if bwrap_path is not None:
             payload_command = _resolve_sandbox_command(command)
+            if (
+                purpose == _VALIDATION_PURPOSE_SERVER
+                and enable_gpu_layers
+                and gpu_backend in {"cuda", "rocm"}
+                and not _binary_is_setuid_root(bwrap_path)
+            ):
+                return _ValidationLaunchPlan(
+                    command = payload_command,
+                    env = launcher_env,
+                    action = _VALIDATION_LAUNCH_RUN,
+                    purpose = purpose,
+                    sandbox_kind = "linux_direct_validation",
+                    reason = "Linux GPU validation requires direct launch when bwrap is not setuid root",
+                    payload_command = payload_command,
+                    payload_env = env,
+                    network_policy = _VALIDATION_NETWORK_POLICY_DIRECT,
+                    server_probe_mode = _VALIDATION_SERVER_PROBE_MODE_HOST,
+                )
             network_policy = _VALIDATION_NETWORK_POLICY_SANDBOX
             server_probe_mode = (
                 _VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX if purpose == _VALIDATION_PURPOSE_SERVER else None
@@ -6570,7 +6601,6 @@ def validate_server(
             "windows-cuda",
             "windows-hip",
             "windows-rocm",
-            "macos-arm64",
         }
         if install_kind is not None:
             _enable_gpu_layers = install_kind in _gpu_kinds
@@ -6582,9 +6612,9 @@ def validate_server(
             # Older call sites that don't pass install_kind: keep ROCm
             # hosts in the GPU-validation path so an AMD-only Linux host
             # is exercised against the actual hardware rather than the
-            # CPU fallback. NVIDIA and macOS-arm64 are already covered.
+            # CPU fallback. NVIDIA stays covered here.
             _enable_gpu_layers = (
-                host.has_usable_nvidia or host.has_rocm or (host.is_macos and host.is_arm64)
+                host.has_usable_nvidia or host.has_rocm
             )
             if host.is_linux and host.has_usable_nvidia:
                 gpu_backend = "cuda"

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5257,10 +5257,94 @@ def _linux_validation_bwrap_prefix(
     return args
 
 
-def _macos_validation_sandbox_prefix(purpose: str) -> list[str]:
-    profile = "(version 1)"
-    if purpose != _VALIDATION_PURPOSE_SERVER:
-        profile = "(version 1)(deny network*)"
+def _sandbox_profile_path_literals(path: str | Path) -> list[str]:
+    raw_path = Path(path)
+    candidates: list[Path] = [raw_path]
+    try:
+        resolved = raw_path.resolve()
+    except Exception:
+        resolved = raw_path
+    if resolved not in candidates:
+        candidates.append(resolved)
+    literals: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        text = str(candidate)
+        if text in seen:
+            continue
+        seen.add(text)
+        literals.append(text.replace("\\", "\\\\").replace('"', '\\"'))
+    return literals
+
+
+def _macos_validation_sandbox_prefix(
+    command: list[str],
+    *,
+    binary_path: Path,
+    install_dir: Path,
+    purpose: str,
+    env: dict[str, str],
+) -> list[str]:
+    runtime_home = Path(isolated_runtime_home())
+    read_targets: list[str | Path] = [
+        "/",
+        "/System",
+        "/Library",
+        "/private",
+        "/dev",
+        "/usr",
+        install_dir,
+        binary_path.parent,
+        runtime_home,
+    ]
+    read_targets.extend(
+        part
+        for part in env.get("DYLD_LIBRARY_PATH", "").split(os.pathsep)
+        if part
+    )
+    write_targets: list[str | Path] = [runtime_home]
+    if purpose == _VALIDATION_PURPOSE_QUANTIZE and len(command) >= 3:
+        read_targets.append(Path(command[1]).parent)
+        write_targets.append(Path(command[2]).parent)
+    elif purpose == _VALIDATION_PURPOSE_SERVER and len(command) >= 3 and command[1] == "-m":
+        read_targets.append(Path(command[2]).parent)
+
+    exec_targets: list[str | Path] = [
+        "/bin",
+        "/usr/bin",
+        "/System",
+        "/Library",
+        "/private",
+        "/usr",
+        binary_path.parent,
+    ]
+    profile_parts = [
+        "(version 1)",
+        "(deny default)",
+        '(import "bsd.sb")',
+        "(allow process-exec",
+    ]
+    for target in exec_targets:
+        for literal in _sandbox_profile_path_literals(target):
+            profile_parts.append(f'(subpath "{literal}")')
+    profile_parts.append(")")
+    profile_parts.append("(allow file-read*")
+    for target in read_targets:
+        for literal in _sandbox_profile_path_literals(target):
+            if literal == "/":
+                profile_parts.append(f'(literal "{literal}")')
+            else:
+                profile_parts.append(f'(subpath "{literal}")')
+    profile_parts.append(")")
+    profile_parts.append("(allow file-write*")
+    for target in write_targets:
+        for literal in _sandbox_profile_path_literals(target):
+            profile_parts.append(f'(subpath "{literal}")')
+    profile_parts.append(")")
+    if purpose == _VALIDATION_PURPOSE_SERVER:
+        profile_parts.append('(allow network* (local ip "localhost:*"))')
+        profile_parts.append('(allow network* (remote ip "localhost:*"))')
+    profile = "".join(profile_parts)
     return [
         "sandbox-exec",
         "-p",
@@ -5332,7 +5416,16 @@ def build_validation_sandbox_plan(
     if _host_is_macos(host):
         if _has_command("sandbox-exec"):
             return _ValidationLaunchPlan(
-                command = [*_macos_validation_sandbox_prefix(purpose), *command],
+                command = [
+                    *_macos_validation_sandbox_prefix(
+                        command,
+                        binary_path = binary_path,
+                        install_dir = install_dir,
+                        purpose = purpose,
+                        env = env,
+                    ),
+                    *command,
+                ],
                 env = env,
                 action = _VALIDATION_LAUNCH_RUN,
                 purpose = purpose,

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5236,9 +5236,18 @@ def _bwrap_can_sandbox(bwrap_path: str) -> bool:
     ok = False
     try:
         result = subprocess.run(
-            [bwrap_path, "--ro-bind", "/", "/", "--unshare-all", "--die-with-parent",
-             _resolve_command_path("true") or "/bin/true"],
-            stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL, timeout = 20,
+            [
+                bwrap_path,
+                "--ro-bind",
+                "/",
+                "/",
+                "--unshare-all",
+                "--die-with-parent",
+                _resolve_command_path("true") or "/bin/true",
+            ],
+            stdout = subprocess.DEVNULL,
+            stderr = subprocess.DEVNULL,
+            timeout = 20,
         )
         ok = result.returncode == 0
     except Exception:

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5273,7 +5273,7 @@ def _linux_validation_server_probe_command(
         timeout = {int(timeout)}
         deadline = time.time() + timeout
 
-        def read_tail(path: str, max_lines: int = 80) -> list[str]:
+        def read_tail(path, max_lines = 80):
             try:
                 with open(path, "r", encoding = "utf-8", errors = "replace") as handle:
                     return handle.read().splitlines()[-max_lines:]

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -406,6 +406,10 @@ class PrebuiltFallback(RuntimeError):
     pass
 
 
+class ValidationLaunchUnavailable(RuntimeError):
+    pass
+
+
 class BusyInstallConflict(RuntimeError):
     pass
 
@@ -2768,7 +2772,18 @@ def resolve_source_build_plan(
     )
 
 
-def run_capture(
+def _subprocess_failure(command: list[str], exc: BaseException) -> PrebuiltFallback:
+    name = command[0] if command else "subprocess"
+    if isinstance(exc, FileNotFoundError):
+        return PrebuiltFallback(f"{name} was not found")
+    if isinstance(exc, PermissionError):
+        return PrebuiltFallback(f"{name} was not executable")
+    if isinstance(exc, subprocess.TimeoutExpired):
+        return PrebuiltFallback(f"{name} timed out after {exc.timeout} seconds")
+    return PrebuiltFallback(f"{name} launch failed: {exc}")
+
+
+def _run_subprocess_capture(
     command: list[str],
     *,
     timeout: int = 30,
@@ -2784,19 +2799,32 @@ def run_capture(
         and os.path.basename(command[0]).lower().startswith("amd-smi")
     ):
         env = {**(os.environ if env is None else env), "__COMPAT_LAYER": "RunAsInvoker"}
-    result = subprocess.run(
-        command,
-        capture_output = True,
-        text = True,
-        timeout = timeout,
-        env = env,
-        **windows_hidden_subprocess_kwargs(),
-    )
+    try:
+        result = subprocess.run(
+            command,
+            capture_output = True,
+            text = True,
+            timeout = timeout,
+            env = env,
+            **windows_hidden_subprocess_kwargs(),
+        )
+    except (FileNotFoundError, PermissionError, subprocess.TimeoutExpired) as exc:
+        raise _subprocess_failure(command, exc) from exc
     if check and result.returncode != 0:
         raise subprocess.CalledProcessError(
             result.returncode, command, result.stdout, result.stderr
         )
     return result
+
+
+def run_capture(
+    command: list[str],
+    *,
+    timeout: int = 30,
+    check: bool = False,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return _run_subprocess_capture(command, timeout = timeout, check = check, env = env)
 
 
 def _pick_rocm_gfx_target(out: str) -> str | None:
@@ -3723,13 +3751,7 @@ def _detect_host_rocm_version() -> tuple[int, int] | None:
     hipconfig = shutil.which("hipconfig")
     if hipconfig:
         try:
-            result = subprocess.run(
-                [hipconfig, "--version"],
-                stdout = subprocess.PIPE,
-                stderr = subprocess.DEVNULL,
-                text = True,
-                timeout = 5,
-            )
+            result = run_capture([hipconfig, "--version"], timeout = 5)
             if result.returncode == 0:
                 raw = (result.stdout or "").strip().split("\n")[0]
                 parts = raw.split(".")
@@ -3751,13 +3773,7 @@ def _detect_host_rocm_version() -> tuple[int, int] | None:
         if not _exe:
             continue
         try:
-            _result = subprocess.run(
-                [_exe, *_cmd[1:]],
-                stdout = subprocess.PIPE,
-                stderr = subprocess.DEVNULL,
-                text = True,
-                timeout = 5,
-            )
+            _result = run_capture([_exe, *_cmd[1:]], timeout = 5)
         except Exception:
             continue
         if _result.returncode != 0 or not _result.stdout.strip():
@@ -5238,7 +5254,7 @@ def _bwrap_can_sandbox(bwrap_path: str) -> bool:
         return cached
     ok = False
     try:
-        result = subprocess.run(
+        result = run_capture(
             [
                 bwrap_path,
                 "--ro-bind",
@@ -5248,8 +5264,6 @@ def _bwrap_can_sandbox(bwrap_path: str) -> bool:
                 "--die-with-parent",
                 _resolve_command_path("true") or "/bin/true",
             ],
-            stdout = subprocess.DEVNULL,
-            stderr = subprocess.DEVNULL,
             env = _linux_validation_launcher_env({}),
             timeout = 20,
         )
@@ -5823,14 +5837,14 @@ def build_validation_sandbox_plan(
         return _ValidationLaunchPlan(
             command = command,
             env = launcher_env,
-            action = _VALIDATION_LAUNCH_FALLBACK,
+            action = _VALIDATION_LAUNCH_SKIP,
             purpose = purpose,
             sandbox_kind = "linux_bwrap",
-            reason = "No Linux sandbox adapter was available for downloaded-binary validation",
+            reason = "No Linux sandbox adapter was available; skip downloaded-binary validation",
             payload_command = command,
             payload_env = env,
-            network_policy = _VALIDATION_NETWORK_POLICY_DIRECT,
-            server_probe_mode = _VALIDATION_SERVER_PROBE_MODE_HOST,
+            network_policy = None,
+            server_probe_mode = None,
         )
 
     if _host_is_macos(host):
@@ -5904,16 +5918,47 @@ def build_validation_sandbox_plan(
     )
 
 
-def _run_validation_capture(
-    plan: _ValidationLaunchPlan, *, timeout: int
-) -> subprocess.CompletedProcess[str]:
+def _unavailable_validation_launch(plan: _ValidationLaunchPlan) -> ValidationLaunchUnavailable:
+    reason = plan.reason or f"{plan.purpose} launch was skipped by sandbox policy"
+    return ValidationLaunchUnavailable(reason)
+
+
+def _run_validation_launch(
+    plan: _ValidationLaunchPlan,
+    *,
+    timeout: int | None = None,
+    stdout = None,
+    popen: bool = False,
+) -> subprocess.CompletedProcess[str] | subprocess.Popen[str]:
     if plan.is_skipped:
-        raise PrebuiltFallback(f"{plan.purpose} launch was skipped by sandbox policy")
+        raise _unavailable_validation_launch(plan)
     if plan.is_fallback:
         if plan.reason is None:
             raise PrebuiltFallback("validation launch skipped due to missing sandbox")
         raise PrebuiltFallback(plan.reason)
+    if popen:
+        try:
+            return subprocess.Popen(
+                plan.command,
+                stdout = stdout,
+                stderr = subprocess.STDOUT,
+                text = True,
+                env = plan.env,
+                **windows_hidden_subprocess_kwargs(),
+            )
+        except (FileNotFoundError, PermissionError) as exc:
+            raise _subprocess_failure(plan.command, exc) from exc
+    if timeout is None:
+        raise ValueError("timeout is required for captured validation launches")
     return run_capture(plan.command, timeout = timeout, env = plan.env)
+
+
+def _run_validation_capture(
+    plan: _ValidationLaunchPlan, *, timeout: int
+) -> subprocess.CompletedProcess[str]:
+    result = _run_validation_launch(plan, timeout = timeout)
+    assert isinstance(result, subprocess.CompletedProcess)
+    return result
 
 
 def _parse_ldd_missing_libraries(output: str) -> list[str]:
@@ -5926,6 +5971,10 @@ def _parse_ldd_missing_libraries(output: str) -> list[str]:
         if library and library not in missing:
             missing.append(library)
     return missing
+
+
+def _ldd_output_is_static_binary(output: str) -> bool:
+    return "not a dynamic executable" in output.lower()
 
 
 def _run_validation_ldd_probe(binary_path: Path, *, env: dict[str, str]) -> LinuxLibraryProbeResult:
@@ -5968,6 +6017,13 @@ def _run_validation_ldd_probe(binary_path: Path, *, env: dict[str, str]) -> Linu
         stderr = result.stderr if result.stderr else ""
         if stderr:
             reason = f"{reason} {stderr}" if reason else stderr
+        if _ldd_output_is_static_binary(reason):
+            return LinuxLibraryProbeResult(
+                status = _LINUX_LDD_PROBE_OK,
+                missing = [],
+                reason = "static executable",
+                output = result.stdout + result.stderr,
+            )
         if not reason:
             reason = "ldd probe failed"
         return LinuxLibraryProbeResult(
@@ -5990,20 +6046,8 @@ def _run_validation_popen(
     stdout,
     timeout: int | None = None,  # kept for parity with current validate_server call shape
 ) -> subprocess.Popen[str]:
-    if plan.is_skipped:
-        raise PrebuiltFallback(f"{plan.purpose} launch was skipped by sandbox policy")
-    if plan.is_fallback:
-        if plan.reason is None:
-            raise PrebuiltFallback("validation launch skipped due to missing sandbox")
-        raise PrebuiltFallback(plan.reason)
-    return subprocess.Popen(
-        plan.command,
-        stdout = stdout,
-        stderr = subprocess.STDOUT,
-        text = True,
-        env = plan.env,
-        **windows_hidden_subprocess_kwargs(),
-    )
+    process = _run_validation_launch(plan, stdout = stdout, popen = True)
+    return process  # type: ignore[return-value]
 
 
 def linux_missing_libraries(binary_path: Path, *, env: dict[str, str] | None = None) -> list[str]:
@@ -6593,6 +6637,7 @@ def validate_quantize(
     host: HostInfo,
     *,
     runtime_line: str | None = None,
+    require_launch: bool = False,
 ) -> None:
     env = binary_env(quantize_path, install_dir, host, runtime_line = runtime_line)
     plan = build_validation_sandbox_plan(
@@ -6604,7 +6649,13 @@ def validate_quantize(
         purpose = _VALIDATION_PURPOSE_QUANTIZE,
         env = env,
     )
-    result = _run_validation_capture(plan, timeout = 120)
+    try:
+        result = _run_validation_capture(plan, timeout = 120)
+    except ValidationLaunchUnavailable as exc:
+        if require_launch:
+            raise PrebuiltFallback(f"llama-quantize validation unavailable: {exc}") from exc
+        log(f"llama-quantize validation skipped: {exc}")
+        return
     if result.returncode != 0 or not quantized_path.exists() or quantized_path.stat().st_size == 0:
         combined = result.stdout + ("\n" + result.stderr if result.stderr else "")
         # Backstop for prebuilts the static minos scan could not read: a dyld
@@ -6626,6 +6677,7 @@ def validate_server(
     *,
     runtime_line: str | None = None,
     install_kind: str | None = None,
+    require_launch: bool = False,
 ) -> None:
     last_failure: PrebuiltFallback | None = None
     gpu_backend: Literal["cuda", "rocm"] | None = None
@@ -6697,10 +6749,16 @@ def validate_server(
         )
         if plan.server_probe_mode == _VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX:
             started_at = time.time()
-            result = _run_validation_capture(
-                plan,
-                timeout = _LINUX_SERVER_VALIDATION_HELPER_CAPTURE_TIMEOUT_SECONDS,
-            )
+            try:
+                result = _run_validation_capture(
+                    plan,
+                    timeout = _LINUX_SERVER_VALIDATION_HELPER_CAPTURE_TIMEOUT_SECONDS,
+                )
+            except ValidationLaunchUnavailable as exc:
+                if require_launch:
+                    raise PrebuiltFallback(f"llama-server validation unavailable: {exc}") from exc
+                log(f"llama-server validation skipped: {exc}")
+                return
             output = (result.stdout or "") + (result.stderr or "")
             if result.returncode == 0:
                 return
@@ -6725,10 +6783,18 @@ def validate_server(
         process: subprocess.Popen[str] | None = None
         try:
             with log_path.open("w", encoding = "utf-8", errors = "replace") as log_handle:
-                process = _run_validation_popen(
-                    plan,
-                    stdout = log_handle,
-                )
+                try:
+                    process = _run_validation_popen(
+                        plan,
+                        stdout = log_handle,
+                    )
+                except ValidationLaunchUnavailable as exc:
+                    if require_launch:
+                        raise PrebuiltFallback(
+                            f"llama-server validation unavailable: {exc}"
+                        ) from exc
+                    log(f"llama-server validation skipped: {exc}")
+                    return
                 deadline = time.time() + 60
                 startup_started = time.time()
                 response_body = ""
@@ -7514,7 +7580,8 @@ def validate_prebuilt_choice(
     # costing minutes on Blackwell sm_100 -- is gated behind
     # _RUN_STAGED_PREBUILT_VALIDATION, disabled for now. The check and the
     # source-build fallback it triggers are kept intact; flip the flag to restore it.
-    if choice.expected_sha256 is None or _RUN_STAGED_PREBUILT_VALIDATION:
+    smoke_validation_required = choice.expected_sha256 is None
+    if smoke_validation_required or _RUN_STAGED_PREBUILT_VALIDATION:
         validate_quantize(
             quantize_path,
             probe_path,
@@ -7522,6 +7589,7 @@ def validate_prebuilt_choice(
             install_dir,
             host,
             runtime_line = choice.runtime_line,
+            require_launch = smoke_validation_required,
         )
         validate_server(
             server_path,
@@ -7530,8 +7598,9 @@ def validate_prebuilt_choice(
             install_dir,
             runtime_line = choice.runtime_line,
             install_kind = choice.install_kind,
+            require_launch = smoke_validation_required,
         )
-        log(f"staged prebuilt validation succeeded for {choice.name}")
+        log(f"staged prebuilt validation completed for {choice.name}")
     return server_path, quantize_path
 
 

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5257,11 +5257,14 @@ def _linux_validation_bwrap_prefix(
     return args
 
 
-def _macos_validation_sandbox_prefix() -> list[str]:
+def _macos_validation_sandbox_prefix(purpose: str) -> list[str]:
+    profile = "(version 1)"
+    if purpose != _VALIDATION_PURPOSE_SERVER:
+        profile = "(version 1)(deny network*)"
     return [
         "sandbox-exec",
         "-p",
-        "(version 1)(deny network*)",
+        profile,
     ]
 
 
@@ -5329,7 +5332,7 @@ def build_validation_sandbox_plan(
     if _host_is_macos(host):
         if _has_command("sandbox-exec"):
             return _ValidationLaunchPlan(
-                command = [*_macos_validation_sandbox_prefix(), *command],
+                command = [*_macos_validation_sandbox_prefix(purpose), *command],
                 env = env,
                 action = _VALIDATION_LAUNCH_RUN,
                 purpose = purpose,

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5221,6 +5221,32 @@ def _has_command(command: str) -> bool:
     return _resolve_command_path(command) is not None
 
 
+_bwrap_sandbox_capability: dict[str, bool] = {}
+
+
+def _bwrap_can_sandbox(bwrap_path: str) -> bool:
+    # A present bwrap is not always usable: where unprivileged user namespaces are
+    # restricted (Ubuntu >= 23.10 AppArmor default, nested/unprivileged containers,
+    # hardened cloud VMs) a non-setuid bwrap fails to set up its uid map or loopback.
+    # Probe once and cache so a broken sandbox degrades like an absent one instead of
+    # failing every prebuilt validation and forcing a source build.
+    cached = _bwrap_sandbox_capability.get(bwrap_path)
+    if cached is not None:
+        return cached
+    ok = False
+    try:
+        result = subprocess.run(
+            [bwrap_path, "--ro-bind", "/", "/", "--unshare-all", "--die-with-parent",
+             _resolve_command_path("true") or "/bin/true"],
+            stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL, timeout = 20,
+        )
+        ok = result.returncode == 0
+    except Exception:
+        ok = False
+    _bwrap_sandbox_capability[bwrap_path] = ok
+    return ok
+
+
 def _append_existing_bwrap_bind(
     args: list[str], *, source: str | Path, readonly: bool, seen: set[str]
 ) -> None:
@@ -5677,7 +5703,7 @@ def build_validation_sandbox_plan(
     )
     if _host_is_linux(host):
         bwrap_path = _resolve_command_path("bwrap")
-        if bwrap_path is not None:
+        if bwrap_path is not None and _bwrap_can_sandbox(bwrap_path):
             payload_command = _resolve_sandbox_command(command)
             if (
                 purpose == _VALIDATION_PURPOSE_SERVER

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -39,7 +39,7 @@ except ImportError:
     FileLock = None
     FileLockTimeout = None
 from pathlib import Path
-from typing import Any, Iterable, Iterator
+from typing import Any, Iterable, Iterator, Literal
 
 
 EXIT_SUCCESS = 0
@@ -5130,6 +5130,9 @@ _VALIDATION_LAUNCH_FALLBACK = "fallback"
 _VALIDATION_PURPOSE_LDD = "ldd"
 _VALIDATION_PURPOSE_QUANTIZE = "quantize"
 _VALIDATION_PURPOSE_SERVER = "server"
+_LINUX_LDD_PROBE_OK = "ok"
+_LINUX_LDD_PROBE_SKIPPED = "skipped"
+_LINUX_LDD_PROBE_ERROR = "error"
 
 
 @dataclass(frozen = True)
@@ -5138,6 +5141,7 @@ class _ValidationLaunchPlan:
     env: dict[str, str]
     action: str
     purpose: str
+    sandbox_kind: str | None = None
     reason: str | None = None
 
     @property
@@ -5151,6 +5155,14 @@ class _ValidationLaunchPlan:
     @property
     def is_fallback(self) -> bool:
         return self.action == _VALIDATION_LAUNCH_FALLBACK
+
+
+@dataclass(frozen = True)
+class LinuxLibraryProbeResult:
+    status: Literal["ok", "skipped", "error"]
+    missing: list[str]
+    output: str = ""
+    reason: str | None = None
 
 
 def _has_command(command: str) -> bool:
@@ -5187,6 +5199,8 @@ def _linux_validation_bwrap_prefix(
     install_dir: Path,
     purpose: str,
     env: dict[str, str],
+    enable_gpu_layers: bool = False,
+    gpu_backend: Literal["cuda", "rocm"] | None = None,
 ) -> list[str]:
     runtime_home = isolated_runtime_home()
     command_path = Path(command[0])
@@ -5224,6 +5238,11 @@ def _linux_validation_bwrap_prefix(
     elif purpose == _VALIDATION_PURPOSE_SERVER and len(command) >= 3 and command[1] == "-m":
         readonly_targets.append(Path(command[2]).parent)
 
+    enable_gpu_devices = (
+        purpose == _VALIDATION_PURPOSE_SERVER
+        and enable_gpu_layers
+        and gpu_backend in {"cuda", "rocm"}
+    )
     args = [
         "bwrap",
         "--unshare-all",
@@ -5247,6 +5266,42 @@ def _linux_validation_bwrap_prefix(
     )
 
     seen: set[str] = set()
+    if enable_gpu_devices:
+        dev_nodes: list[str] = []
+        readonly_gpu_targets = [
+            "/sys/class/drm",
+            "/sys/bus/pci",
+            "/sys/dev/char",
+            "/sys/devices",
+        ]
+        if gpu_backend == "cuda":
+            dev_nodes.extend(
+                [
+                    "/dev/nvidiactl",
+                    "/dev/nvidia-modeset",
+                    "/dev/nvidia-uvm",
+                    "/dev/nvidia-uvm-tools",
+                ]
+            )
+            for path in Path("/dev").glob("nvidia*"):
+                if re.match(r"^nvidia[0-9]+$", path.name):
+                    dev_nodes.append(str(path))
+            readonly_gpu_targets.append("/proc/driver/nvidia")
+        elif gpu_backend == "rocm":
+            dev_nodes.extend(["/dev/kfd", "/dev/dxg"])
+            dev_nodes.extend(str(node) for node in Path("/dev/dri").glob("card*"))
+            dev_nodes.extend(str(node) for node in Path("/dev/dri").glob("renderD*"))
+
+        for node in dev_nodes:
+            node_path = Path(node)
+            if str(node_path) in seen:
+                continue
+            if not node_path.exists():
+                continue
+            seen.add(str(node_path))
+            args.extend(["--dev-bind-try", str(node_path), str(node_path)])
+
+        readonly_targets.extend(readonly_gpu_targets)
     for target in readonly_targets:
         target_path = Path(target)
         if str(target_path) in write_targets:
@@ -5377,6 +5432,8 @@ def build_validation_sandbox_plan(
     install_dir: Path,
     purpose: str,
     env: dict[str, str],
+    enable_gpu_layers: bool = False,
+    gpu_backend: Literal["cuda", "rocm"] | None = None,
     host: HostInfo | None = None,
     runtime_line: str | None = None,
 ) -> _ValidationLaunchPlan:
@@ -5390,6 +5447,8 @@ def build_validation_sandbox_plan(
                         install_dir = install_dir,
                         purpose = purpose,
                         env = env,
+                        enable_gpu_layers = enable_gpu_layers,
+                        gpu_backend = gpu_backend,
                     ),
                     *command,
                 ],
@@ -5442,9 +5501,10 @@ def build_validation_sandbox_plan(
         return _ValidationLaunchPlan(
             command = command,
             env = env,
-            action = _VALIDATION_LAUNCH_FALLBACK,
+            action = _VALIDATION_LAUNCH_RUN,
             purpose = purpose,
-            reason = "Windows validation sandboxing is unsupported in this install slice",
+            sandbox_kind = "windows_direct_validation",
+            reason = "Running validation directly on Windows host",
         )
 
     return _ValidationLaunchPlan(
@@ -5470,10 +5530,26 @@ def _run_validation_capture(
     return run_capture(plan.command, timeout = timeout, env = plan.env)
 
 
-def _run_validation_ldd_probe(binary_path: Path, *, env: dict[str, str]) -> str:
+def _parse_ldd_missing_libraries(output: str) -> list[str]:
+    missing: list[str] = []
+    for line in output.splitlines():
+        line = line.strip()
+        if "=> not found" not in line:
+            continue
+        library = line.split("=>", 1)[0].strip()
+        if library and library not in missing:
+            missing.append(library)
+    return missing
+
+
+def _run_validation_ldd_probe(binary_path: Path, *, env: dict[str, str]) -> LinuxLibraryProbeResult:
     ldd_path = shutil.which("ldd")
     if ldd_path is None:
-        return ""
+        return LinuxLibraryProbeResult(
+            status = _LINUX_LDD_PROBE_SKIPPED,
+            missing = [],
+            reason = "ldd executable was not found",
+        )
     plan = build_validation_sandbox_plan(
         [ldd_path, str(binary_path)],
         binary_path = binary_path,
@@ -5482,15 +5558,31 @@ def _run_validation_ldd_probe(binary_path: Path, *, env: dict[str, str]) -> str:
         env = env,
     )
     if plan.is_skipped:
-        log("Skipping ldd probe because no Linux sandbox adapter was available")
-        return ""
+        return LinuxLibraryProbeResult(
+            status = _LINUX_LDD_PROBE_SKIPPED,
+            missing = [],
+            reason = "ldd probe was skipped by validation policy",
+        )
     if plan.is_fallback:
-        # Keep compatibility: compatibility checks tolerate probe skip/fallback by
-        # treating missing entries as unknown and letting downstream metadata checks
-        # handle it.
-        return ""
-    result = _run_validation_capture(plan, timeout = 20)
-    return result.stdout + result.stderr
+        return LinuxLibraryProbeResult(
+            status = _LINUX_LDD_PROBE_SKIPPED,
+            missing = [],
+            reason = plan.reason or "ldd probe did not run",
+        )
+    try:
+        result = _run_validation_capture(plan, timeout = 20)
+    except Exception as exc:
+        return LinuxLibraryProbeResult(
+            status = _LINUX_LDD_PROBE_ERROR,
+            missing = [],
+            reason = f"ldd probe failed: {exc}",
+        )
+    output = result.stdout + result.stderr
+    return LinuxLibraryProbeResult(
+        status = _LINUX_LDD_PROBE_OK,
+        missing = _parse_ldd_missing_libraries(output),
+        output = output,
+    )
 
 
 def _run_validation_popen(
@@ -5522,19 +5614,11 @@ def linux_missing_libraries(binary_path: Path, *, env: dict[str, str] | None = N
         probe_output = _run_validation_ldd_probe(binary_path, env = env)
     except Exception:
         return []
-    if not probe_output:
+    if probe_output.status != _LINUX_LDD_PROBE_OK:
         return []
-    result = subprocess.CompletedProcess(binary_path, 0, stdout = probe_output)
-
-    missing: list[str] = []
-    for line in result.stdout.splitlines():
-        line = line.strip()
-        if "=> not found" not in line:
-            continue
-        library = line.split("=>", 1)[0].strip()
-        if library and library not in missing:
-            missing.append(library)
-    return missing
+    if not probe_output.output:
+        return []
+    return probe_output.missing
 
 
 def python_runtime_dirs() -> list[str]:
@@ -5601,7 +5685,12 @@ def ldconfig_runtime_dirs(required_libraries: Iterable[str]) -> list[str]:
 
 def linux_runtime_dirs(binary_path: Path) -> list[str]:
     # ldd may execute the binary, so probe it with a secret-free env.
-    missing = linux_missing_libraries(binary_path, env = scrubbed_environ())
+    probe_result = _run_validation_ldd_probe(binary_path, env = scrubbed_environ())
+    if probe_result.status != _LINUX_LDD_PROBE_OK:
+        if probe_result.reason:
+            log(f"Skipping Linux runtime dirs probe because {probe_result.reason}")
+        return []
+    missing = probe_result.missing
     if not missing:
         return []
     return linux_runtime_dirs_for_required_libraries(missing)
@@ -5783,7 +5872,11 @@ def preflight_macos_installed_binaries(
 
 
 def preflight_linux_installed_binaries(
-    binaries: Iterable[Path], install_dir: Path, host: HostInfo
+    binaries: Iterable[Path],
+    install_dir: Path,
+    host: HostInfo,
+    *,
+    allow_skipped_probe: bool = True,
 ) -> None:
     if not host.is_linux:
         return
@@ -5791,7 +5884,25 @@ def preflight_linux_installed_binaries(
     issues: list[str] = []
     for binary_path in binaries:
         env = binary_env(binary_path, install_dir, host)
-        missing = linux_missing_libraries(binary_path, env = env)
+        probe_result = _run_validation_ldd_probe(binary_path, env = env)
+        if probe_result.status == _LINUX_LDD_PROBE_ERROR:
+            raise PrebuiltFallback(
+                f"linux extracted binary ldd probe errored for {binary_path.name}: "
+                f"{probe_result.reason}"
+            )
+        if probe_result.status == _LINUX_LDD_PROBE_SKIPPED:
+            if allow_skipped_probe:
+                log(
+                    f"linux extracted binary ldd probe skipped for {binary_path.name}"
+                    + (f": {probe_result.reason}" if probe_result.reason else "")
+                )
+                continue
+            issues.append(
+                f"{binary_path.name}: linux ldd probe skipped"
+                + (f" ({probe_result.reason})" if probe_result.reason else "")
+            )
+            continue
+        missing = probe_result.missing
         if not missing:
             continue
         runtime_dirs = [part for part in env.get("LD_LIBRARY_PATH", "").split(os.pathsep) if part]
@@ -6109,6 +6220,7 @@ def validate_server(
     install_kind: str | None = None,
 ) -> None:
     last_failure: PrebuiltFallback | None = None
+    gpu_backend: Literal["cuda", "rocm"] | None = None
     for port_attempt in range(1, SERVER_PORT_BIND_ATTEMPTS + 1):
         port = free_local_port()
         env = binary_env(server_path, install_dir, host, runtime_line = runtime_line)
@@ -6149,6 +6261,10 @@ def validate_server(
         }
         if install_kind is not None:
             _enable_gpu_layers = install_kind in _gpu_kinds
+            if install_kind in {"linux-cuda", "linux-arm64-cuda"}:
+                gpu_backend = "cuda"
+            elif install_kind == "linux-rocm":
+                gpu_backend = "rocm"
         else:
             # Older call sites that don't pass install_kind: keep ROCm
             # hosts in the GPU-validation path so an AMD-only Linux host
@@ -6157,6 +6273,10 @@ def validate_server(
             _enable_gpu_layers = (
                 host.has_usable_nvidia or host.has_rocm or (host.is_macos and host.is_arm64)
             )
+            if host.is_linux and host.has_usable_nvidia:
+                gpu_backend = "cuda"
+            elif host.is_linux and host.has_rocm:
+                gpu_backend = "rocm"
         if _enable_gpu_layers:
             command.extend(["--n-gpu-layers", "1"])
         plan = build_validation_sandbox_plan(
@@ -6167,6 +6287,8 @@ def validate_server(
             runtime_line = runtime_line,
             purpose = _VALIDATION_PURPOSE_SERVER,
             env = env,
+            enable_gpu_layers = _enable_gpu_layers,
+            gpu_backend = gpu_backend,
         )
 
         log_fd, log_name = tempfile.mkstemp(prefix = "llama-server-", suffix = ".log")
@@ -6295,10 +6417,17 @@ def collect_system_report(host: HostInfo, choice: AssetChoice | None, install_di
         server_binary = install_dir / "llama-server"
         if server_binary.exists():
             server_env = binary_env(server_binary, install_dir, host)
+            ldd_probe = _run_validation_ldd_probe(server_binary, env = server_env)
             lines.append(
-                "linux_missing_libs="
-                + (",".join(linux_missing_libraries(server_binary, env = server_env)) or "none")
+                "linux_missing_libs_probe=" + ldd_probe.status
             )
+            if ldd_probe.reason:
+                lines.append("linux_missing_libs_probe_reason=" + ldd_probe.reason)
+            if ldd_probe.status == _LINUX_LDD_PROBE_OK:
+                lines.append(
+                    "linux_missing_libs="
+                    + (",".join(ldd_probe.missing) if ldd_probe.missing else "none")
+                )
             lines.append(
                 "linux_runtime_dirs="
                 + (
@@ -6313,9 +6442,11 @@ def collect_system_report(host: HostInfo, choice: AssetChoice | None, install_di
                 )
             )
             try:
-                ldd_output = _run_validation_ldd_probe(server_binary, env = server_env)
-                lines.append("ldd llama-server:")
-                lines.append((ldd_output or "none").strip())
+                if ldd_probe.status == _LINUX_LDD_PROBE_OK:
+                    lines.append("ldd llama-server:")
+                    lines.append((ldd_probe.output or "none").strip())
+                else:
+                    lines.append("ldd llama-server: skipped")
             except Exception as exc:
                 lines.append(f"ldd error: {exc}")
     elif host.is_windows:
@@ -6844,6 +6975,7 @@ def existing_install_matches_choice(
                 [runtime_dir / "llama-server", runtime_dir / "llama-quantize"],
                 install_dir,
                 host,
+                allow_skipped_probe = False,
             )
         except Exception:
             return False

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5296,9 +5296,7 @@ def _append_existing_bwrap_bind(
 _SANDBOX_LIBRARY_DIR_NAMES = frozenset({"lib", "lib64"})
 
 
-def _is_broad_sandbox_library_path(
-    path: str | Path, *, require_library_dir: bool = False
-) -> bool:
+def _is_broad_sandbox_library_path(path: str | Path, *, require_library_dir: bool = False) -> bool:
     candidate = Path(path)
     resolved = _resolve_existing_path(candidate)
     if not candidate.is_absolute() and not str(candidate).startswith(("/", "\\")):
@@ -5320,7 +5318,10 @@ def _is_broad_sandbox_library_path(
 
 
 def _sandbox_library_path_targets(
-    env: dict[str, str], key: str, *, require_library_dir: bool = False
+    env: dict[str, str],
+    key: str,
+    *,
+    require_library_dir: bool = False,
 ) -> list[Path]:
     return [
         _resolve_existing_path(Path(part))

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5256,6 +5256,19 @@ def _linux_validation_setenv_args(payload_env: dict[str, str]) -> list[str]:
     return args
 
 
+def _drop_server_gpu_layers(command: list[str]) -> list[str]:
+    trimmed: list[str] = []
+    index = 0
+    while index < len(command):
+        arg = command[index]
+        if arg == "--n-gpu-layers" and index + 1 < len(command):
+            index += 2
+            continue
+        trimmed.append(arg)
+        index += 1
+    return trimmed
+
+
 def _extract_loopback_port(command: list[str]) -> int:
     for index, arg in enumerate(command):
         if arg != "--port":
@@ -5672,18 +5685,12 @@ def build_validation_sandbox_plan(
                 and gpu_backend in {"cuda", "rocm"}
                 and not _binary_is_setuid_root(bwrap_path)
             ):
-                return _ValidationLaunchPlan(
-                    command = payload_command,
-                    env = launcher_env,
-                    action = _VALIDATION_LAUNCH_RUN,
-                    purpose = purpose,
-                    sandbox_kind = "linux_direct_validation",
-                    reason = "Linux GPU validation requires direct launch when bwrap is not setuid root",
-                    payload_command = payload_command,
-                    payload_env = env,
-                    network_policy = _VALIDATION_NETWORK_POLICY_DIRECT,
-                    server_probe_mode = _VALIDATION_SERVER_PROBE_MODE_HOST,
-                )
+                # Non-setuid bwrap needs a user namespace, which drops the host's
+                # supplementary GPU device groups. Keep the loopback-only sandbox
+                # and validate the bundle on the CPU path instead.
+                payload_command = _drop_server_gpu_layers(payload_command)
+                enable_gpu_layers = False
+                gpu_backend = None
             network_policy = _VALIDATION_NETWORK_POLICY_SANDBOX
             server_probe_mode = (
                 _VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX
@@ -5777,7 +5784,7 @@ def build_validation_sandbox_plan(
                         purpose = purpose,
                         env = env,
                     ),
-                    "env",
+                    "/usr/bin/env",
                     "-i",
                     *[f"{name}={value}" for name, value in sorted(env.items())],
                     *launch_command,

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5130,9 +5130,13 @@ _VALIDATION_LAUNCH_FALLBACK = "fallback"
 _VALIDATION_PURPOSE_LDD = "ldd"
 _VALIDATION_PURPOSE_QUANTIZE = "quantize"
 _VALIDATION_PURPOSE_SERVER = "server"
+_VALIDATION_NETWORK_POLICY_DIRECT = "direct"
+_VALIDATION_NETWORK_POLICY_SANDBOX = "sandbox_loopback_only"
 _LINUX_LDD_PROBE_OK = "ok"
 _LINUX_LDD_PROBE_SKIPPED = "skipped"
 _LINUX_LDD_PROBE_ERROR = "error"
+_VALIDATION_SERVER_PROBE_MODE_HOST = "host_loopback_http"
+_VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX = "sandbox_loopback_http"
 
 
 @dataclass(frozen = True)
@@ -5143,6 +5147,10 @@ class _ValidationLaunchPlan:
     purpose: str
     sandbox_kind: str | None = None
     reason: str | None = None
+    payload_command: list[str] | None = None
+    payload_env: dict[str, str] | None = None
+    network_policy: str | None = None
+    server_probe_mode: str | None = None
 
     @property
     def is_runnable(self) -> bool:
@@ -5192,13 +5200,140 @@ def _append_existing_bwrap_bind(
     )
 
 
+def _linux_validation_launcher_env(payload_env: dict[str, str]) -> dict[str, str]:
+    env = scrubbed_environ()
+    for key in payload_env:
+        env.pop(key, None)
+    # Keep a stable base command search path; payload PATH is still injected in
+    # bwrap via --setenv from payload_env.
+    env["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    return env
+
+
+def _linux_validation_setenv_args(payload_env: dict[str, str]) -> list[str]:
+    args: list[str] = []
+    for key, value in sorted(payload_env.items()):
+        args.extend(["--setenv", key, value])
+    return args
+
+
+def _linux_validation_server_probe_command(
+    server_command: list[str], *, timeout: int = 60
+) -> list[str]:
+    for candidate in ("/usr/bin/python3", "/usr/bin/python"):
+        if Path(candidate).exists():
+            python = candidate
+            break
+    else:
+        python = shutil.which("python3") or shutil.which("python")
+    if python is None:
+        raise RuntimeError("No python interpreter available for in-sandbox server probe")
+
+    probe_script = textwrap.dedent(
+        f"""
+        import json
+        import os
+        import subprocess
+        import sys
+        import tempfile
+        import time
+        import urllib.error
+        import urllib.request
+
+        command = {json.dumps(server_command)}
+        body = b'{{"prompt":"a","n_predict":1}}'
+        timeout = {int(timeout)}
+        deadline = time.time() + timeout
+
+        def read_tail(path: str, max_lines: int = 80) -> list[str]:
+            try:
+                with open(path, "r", encoding = "utf-8", errors = "replace") as handle:
+                    return handle.read().splitlines()[-max_lines:]
+            except Exception:
+                return []
+
+        log_fd, log_path = tempfile.mkstemp(prefix = "unsloth-server-validate-", suffix = ".log")
+        os.close(log_fd)
+
+        port = 0
+        for index, arg in enumerate(command):
+            if arg == "--port" and index + 1 < len(command):
+                try:
+                    port = int(command[index + 1])
+                except ValueError:
+                    port = 0
+                break
+        if port <= 0:
+            print("failed: missing --port for sandboxed llama-server probe")
+            raise SystemExit(1)
+
+        try:
+            with open(log_path, "w", encoding = "utf-8", errors = "replace") as log_handle:
+                process = subprocess.Popen(
+                    command,
+                    stdout = log_handle,
+                    stderr = subprocess.STDOUT,
+                    text = True,
+                )
+                request = urllib.request.Request(
+                    "http://127.0.0.1:%d/completion" % port,
+                    data = body,
+                    headers = {{"Content-Type": "application/json"}},
+                    method = "POST",
+                )
+                while time.time() < deadline:
+                    if process.poll() is not None:
+                        print("server exited before completion probe, code=%s" % process.returncode)
+                        for line in read_tail(log_path):
+                            print(line)
+                        raise SystemExit(process.returncode if process.returncode else 1)
+                    try:
+                        with urllib.request.urlopen(request, timeout = 1) as response:
+                            _ = response.read(32)
+                            if response.status == 200:
+                                process.terminate()
+                                try:
+                                    process.wait(timeout = 5)
+                                except subprocess.TimeoutExpired:
+                                    process.kill()
+                                print("server validation probe succeeded for port=%s" % port)
+                                for line in read_tail(log_path):
+                                    print(line)
+                                raise SystemExit(0)
+                            print("server returned HTTP %s" % response.status)
+                    except urllib.error.HTTPError as exc:
+                        print("server returned HTTP %s" % exc.code)
+                        _ = exc.read()
+                    except Exception:
+                        pass
+                    time.sleep(0.25)
+
+            print("server validation timed out waiting for loopback response on port=%s" % port)
+            for line in read_tail(log_path):
+                print(line)
+            raise SystemExit(1)
+        finally:
+            if "process" in locals() and process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout = 5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout = 5)
+            os.unlink(log_path)
+        """
+    )
+    return [python, "-c", probe_script]
+
+
 def _linux_validation_bwrap_prefix(
     command: list[str],
     *,
     binary_path: Path,
     install_dir: Path,
     purpose: str,
-    env: dict[str, str],
+    payload_env: dict[str, str],
+    payload_command: list[str] | None = None,
     enable_gpu_layers: bool = False,
     gpu_backend: Literal["cuda", "rocm"] | None = None,
 ) -> list[str]:
@@ -5226,17 +5361,29 @@ def _linux_validation_bwrap_prefix(
         "/etc/ld.so.conf",
         "/etc/ld.so.conf.d",
     ]
+    if command_path.parent.name == "bin":
+        readonly_targets.extend(
+            [
+                command_path.parent.parent / "lib",
+                command_path.parent.parent / "lib64",
+            ]
+        )
     readonly_targets.extend(
         part
-        for part in env.get("LD_LIBRARY_PATH", "").split(os.pathsep)
+        for part in payload_env.get("LD_LIBRARY_PATH", "").split(os.pathsep)
         if part
     )
+    server_command = payload_command or command
 
     if purpose == _VALIDATION_PURPOSE_QUANTIZE and len(command) >= 3:
         readonly_targets.append(Path(command[1]).parent)
         write_targets.add(str(Path(command[2]).parent))
-    elif purpose == _VALIDATION_PURPOSE_SERVER and len(command) >= 3 and command[1] == "-m":
-        readonly_targets.append(Path(command[2]).parent)
+    elif (
+        purpose == _VALIDATION_PURPOSE_SERVER
+        and len(server_command) >= 3
+        and server_command[1] == "-m"
+    ):
+        readonly_targets.append(Path(server_command[2]).parent)
 
     enable_gpu_devices = (
         purpose == _VALIDATION_PURPOSE_SERVER
@@ -5247,8 +5394,6 @@ def _linux_validation_bwrap_prefix(
         "bwrap",
         "--unshare-all",
     ]
-    if purpose == _VALIDATION_PURPOSE_SERVER:
-        args.append("--share-net")
     args.extend(
         [
         "--die-with-parent",
@@ -5264,6 +5409,7 @@ def _linux_validation_bwrap_prefix(
         runtime_home,
         ]
     )
+    args.extend(_linux_validation_setenv_args(payload_env))
 
     seen: set[str] = set()
     if enable_gpu_devices:
@@ -5342,12 +5488,13 @@ def _macos_validation_sandbox_prefix(
 ) -> list[str]:
     runtime_home = Path(isolated_runtime_home())
     read_targets: list[str | Path] = [
-        "/",
+        "/bin",
+        "/usr",
+        "/usr/bin",
         "/System",
         "/Library",
-        "/private",
-        "/dev",
-        "/usr",
+        "/System/Library/Frameworks",
+        "/usr/lib",
         install_dir,
         binary_path.parent,
         runtime_home,
@@ -5369,7 +5516,6 @@ def _macos_validation_sandbox_prefix(
         "/usr/bin",
         "/System",
         "/Library",
-        "/private",
         "/usr",
         binary_path.parent,
     ]
@@ -5437,43 +5583,88 @@ def build_validation_sandbox_plan(
     host: HostInfo | None = None,
     runtime_line: str | None = None,
 ) -> _ValidationLaunchPlan:
+    launcher_env = (
+        _linux_validation_launcher_env(env) if _host_is_linux(host) else scrubbed_environ()
+    )
     if _host_is_linux(host):
         if _has_command("bwrap"):
+            payload_command = list(command)
+            network_policy = _VALIDATION_NETWORK_POLICY_SANDBOX
+            server_probe_mode = (
+                _VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX if purpose == _VALIDATION_PURPOSE_SERVER else None
+            )
+            launch_command = payload_command
+            if purpose == _VALIDATION_PURPOSE_SERVER:
+                try:
+                    launch_command = _linux_validation_server_probe_command(
+                        payload_command,
+                        timeout = 60,
+                    )
+                except RuntimeError as exc:
+                    return _ValidationLaunchPlan(
+                        command = payload_command,
+                        env = launcher_env,
+                        action = _VALIDATION_LAUNCH_FALLBACK,
+                        purpose = purpose,
+                        reason = str(exc),
+                        payload_command = payload_command,
+                        payload_env = env,
+                        network_policy = network_policy,
+                        server_probe_mode = _VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX,
+                        sandbox_kind = "linux_bwrap",
+                    )
+            adapter_command = _linux_validation_bwrap_prefix(
+                launch_command,
+                binary_path = binary_path,
+                install_dir = install_dir,
+                purpose = purpose,
+                payload_env = env,
+                payload_command = payload_command,
+                enable_gpu_layers = enable_gpu_layers,
+                gpu_backend = gpu_backend,
+            )
             return _ValidationLaunchPlan(
                 command = [
-                    *_linux_validation_bwrap_prefix(
-                        command,
-                        binary_path = binary_path,
-                        install_dir = install_dir,
-                        purpose = purpose,
-                        env = env,
-                        enable_gpu_layers = enable_gpu_layers,
-                        gpu_backend = gpu_backend,
-                    ),
-                    *command,
+                    *adapter_command,
+                    *launch_command,
                 ],
-                env = env,
+                env = launcher_env,
                 action = _VALIDATION_LAUNCH_RUN,
                 purpose = purpose,
+                sandbox_kind = "linux_bwrap",
+                payload_command = payload_command,
+                payload_env = env,
+                network_policy = network_policy,
+                server_probe_mode = server_probe_mode,
             )
         if purpose == _VALIDATION_PURPOSE_LDD:
             return _ValidationLaunchPlan(
                 command = command,
-                env = env,
+                env = launcher_env,
                 action = _VALIDATION_LAUNCH_SKIP,
                 purpose = purpose,
+                sandbox_kind = "linux_bwrap",
                 reason = "No Linux sandbox adapter was available; skip ldd probe",
             )
         return _ValidationLaunchPlan(
             command = command,
-            env = env,
+            env = launcher_env,
             action = _VALIDATION_LAUNCH_FALLBACK,
             purpose = purpose,
+            sandbox_kind = "linux_bwrap",
             reason = "No Linux sandbox adapter was available for downloaded-binary validation",
+            payload_command = command,
+            payload_env = env,
+            network_policy = _VALIDATION_NETWORK_POLICY_DIRECT,
+            server_probe_mode = _VALIDATION_SERVER_PROBE_MODE_HOST,
         )
 
     if _host_is_macos(host):
         if _has_command("sandbox-exec"):
+            network_policy = (
+                _VALIDATION_NETWORK_POLICY_SANDBOX if purpose == _VALIDATION_PURPOSE_SERVER else _VALIDATION_NETWORK_POLICY_DIRECT
+            )
+            launch_command = command
             return _ValidationLaunchPlan(
                 command = [
                     *_macos_validation_sandbox_prefix(
@@ -5483,18 +5674,31 @@ def build_validation_sandbox_plan(
                         purpose = purpose,
                         env = env,
                     ),
-                    *command,
+                    "env",
+                    "-i",
+                    *[f"{name}={value}" for name, value in sorted(env.items())],
+                    *launch_command,
                 ],
-                env = env,
+                env = launcher_env,
                 action = _VALIDATION_LAUNCH_RUN,
                 purpose = purpose,
+                sandbox_kind = "macos_sandbox_exec",
+                payload_command = launch_command,
+                payload_env = env,
+                network_policy = network_policy,
+                server_probe_mode = _VALIDATION_SERVER_PROBE_MODE_HOST,
             )
         return _ValidationLaunchPlan(
             command = command,
-            env = env,
+            env = launcher_env,
             action = _VALIDATION_LAUNCH_FALLBACK,
             purpose = purpose,
             reason = "No macOS sandbox-exec adapter was available for downloaded-binary validation",
+            payload_command = command,
+            payload_env = env,
+            sandbox_kind = "macos_sandbox_exec",
+            network_policy = _VALIDATION_NETWORK_POLICY_DIRECT if purpose == _VALIDATION_PURPOSE_SERVER else _VALIDATION_NETWORK_POLICY_DIRECT,
+            server_probe_mode = _VALIDATION_SERVER_PROBE_MODE_HOST,
         )
 
     if _host_is_windows(host):
@@ -5505,6 +5709,10 @@ def build_validation_sandbox_plan(
             purpose = purpose,
             sandbox_kind = "windows_direct_validation",
             reason = "Running validation directly on Windows host",
+            payload_command = command,
+            payload_env = env,
+            network_policy = _VALIDATION_NETWORK_POLICY_DIRECT,
+            server_probe_mode = _VALIDATION_SERVER_PROBE_MODE_HOST,
         )
 
     return _ValidationLaunchPlan(
@@ -5576,6 +5784,19 @@ def _run_validation_ldd_probe(binary_path: Path, *, env: dict[str, str]) -> Linu
             status = _LINUX_LDD_PROBE_ERROR,
             missing = [],
             reason = f"ldd probe failed: {exc}",
+        )
+    if result.returncode != 0:
+        reason = result.stdout if result.stdout else ""
+        stderr = result.stderr if result.stderr else ""
+        if stderr:
+            reason = f"{reason} {stderr}" if reason else stderr
+        if not reason:
+            reason = "ldd probe failed"
+        return LinuxLibraryProbeResult(
+            status = _LINUX_LDD_PROBE_ERROR,
+            missing = [],
+            reason = reason.strip(),
+            output = result.stdout + result.stderr,
         )
     output = result.stdout + result.stderr
     return LinuxLibraryProbeResult(
@@ -6290,6 +6511,29 @@ def validate_server(
             enable_gpu_layers = _enable_gpu_layers,
             gpu_backend = gpu_backend,
         )
+        if plan.server_probe_mode == _VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX:
+            started_at = time.time()
+            result = _run_validation_capture(plan, timeout = 60)
+            output = (result.stdout or "") + (result.stderr or "")
+            if result.returncode == 0:
+                return
+            exited_quickly = (time.time() - started_at) <= SERVER_BIND_RETRY_WINDOW_SECONDS
+            failure = PrebuiltFallback("llama-server validation failed inside sandbox:\n" + output)
+            if (
+                port_attempt < SERVER_PORT_BIND_ATTEMPTS
+                and is_retryable_server_bind_error(
+                    RuntimeError(output),
+                    output,
+                    exited_quickly = exited_quickly,
+                )
+            ):
+                log(
+                    f"llama-server startup hit a port race on {port}; retrying with a fresh port "
+                    f"({port_attempt}/{SERVER_PORT_BIND_ATTEMPTS})"
+                )
+                last_failure = failure
+                continue
+            raise failure
 
         log_fd, log_name = tempfile.mkstemp(prefix = "llama-server-", suffix = ".log")
         os.close(log_fd)

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5124,14 +5124,226 @@ def dedupe_existing_dirs(paths: Iterable[str | Path]) -> list[str]:
     return unique
 
 
+_VALIDATION_LAUNCH_RUN = "run"
+_VALIDATION_LAUNCH_SKIP = "skip"
+_VALIDATION_LAUNCH_FALLBACK = "fallback"
+_VALIDATION_PURPOSE_LDD = "ldd"
+_VALIDATION_PURPOSE_QUANTIZE = "quantize"
+_VALIDATION_PURPOSE_SERVER = "server"
+
+
+@dataclass(frozen = True)
+class _ValidationLaunchPlan:
+    command: list[str]
+    env: dict[str, str]
+    action: str
+    purpose: str
+    reason: str | None = None
+
+    @property
+    def is_runnable(self) -> bool:
+        return self.action == _VALIDATION_LAUNCH_RUN
+
+    @property
+    def is_skipped(self) -> bool:
+        return self.action == _VALIDATION_LAUNCH_SKIP
+
+    @property
+    def is_fallback(self) -> bool:
+        return self.action == _VALIDATION_LAUNCH_FALLBACK
+
+
+def _has_command(command: str) -> bool:
+    return shutil.which(command) is not None
+
+
+def _linux_validation_bwrap_prefix(binary_path: Path, install_dir: Path) -> list[str]:
+    runtime_home = isolated_runtime_home()
+    return [
+        "bwrap",
+        "--unshare-all",
+        "--unshare-net",
+        "--die-with-parent",
+        "--new-session",
+        "--tmpfs",
+        "/tmp",
+        "--proc",
+        "/proc",
+        "--setenv",
+        "HOME",
+        runtime_home,
+        "--ro-bind",
+        str(install_dir),
+        str(install_dir),
+        "--ro-bind",
+        str(binary_path.parent),
+        str(binary_path.parent),
+    ]
+
+
+def _macos_validation_sandbox_prefix() -> list[str]:
+    return [
+        "sandbox-exec",
+        "-p",
+        "(version 1)(deny network*)",
+    ]
+
+
+def _host_is_linux(host: HostInfo | None = None) -> bool:
+    if host is not None:
+        return host.is_linux
+    return platform.system() == "Linux"
+
+
+def _host_is_macos(host: HostInfo | None = None) -> bool:
+    if host is not None:
+        return host.is_macos
+    return platform.system() == "Darwin"
+
+
+def _host_is_windows(host: HostInfo | None = None) -> bool:
+    if host is not None:
+        return host.is_windows
+    return platform.system() == "Windows"
+
+
+def build_validation_sandbox_plan(
+    command: list[str],
+    *,
+    binary_path: Path,
+    install_dir: Path,
+    purpose: str,
+    env: dict[str, str],
+    host: HostInfo | None = None,
+    runtime_line: str | None = None,
+) -> _ValidationLaunchPlan:
+    if _host_is_linux(host):
+        if _has_command("bwrap"):
+            return _ValidationLaunchPlan(
+                command = [
+                    *_linux_validation_bwrap_prefix(binary_path, install_dir),
+                    *command,
+                ],
+                env = env,
+                action = _VALIDATION_LAUNCH_RUN,
+                purpose = purpose,
+            )
+        if purpose == _VALIDATION_PURPOSE_LDD:
+            return _ValidationLaunchPlan(
+                command = command,
+                env = env,
+                action = _VALIDATION_LAUNCH_SKIP,
+                purpose = purpose,
+                reason = "No Linux sandbox adapter was available; skip ldd probe",
+            )
+        return _ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = _VALIDATION_LAUNCH_FALLBACK,
+            purpose = purpose,
+            reason = "No Linux sandbox adapter was available for downloaded-binary validation",
+        )
+
+    if _host_is_macos(host):
+        if _has_command("sandbox-exec"):
+            return _ValidationLaunchPlan(
+                command = [*_macos_validation_sandbox_prefix(), *command],
+                env = env,
+                action = _VALIDATION_LAUNCH_RUN,
+                purpose = purpose,
+            )
+        return _ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = _VALIDATION_LAUNCH_FALLBACK,
+            purpose = purpose,
+            reason = "No macOS sandbox-exec adapter was available for downloaded-binary validation",
+        )
+
+    if _host_is_windows(host):
+        return _ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = _VALIDATION_LAUNCH_FALLBACK,
+            purpose = purpose,
+            reason = "Windows validation sandboxing is unsupported in this install slice",
+        )
+
+    return _ValidationLaunchPlan(
+        command = command,
+        env = env,
+        action = _VALIDATION_LAUNCH_FALLBACK,
+        purpose = purpose,
+        reason = f"Unsupported platform for validation sandboxing: {platform.system()}",
+    )
+
+
+def _run_validation_capture(
+    plan: _ValidationLaunchPlan,
+    *,
+    timeout: int,
+) -> subprocess.CompletedProcess[str]:
+    if plan.is_skipped:
+        raise PrebuiltFallback(f"{plan.purpose} launch was skipped by sandbox policy")
+    if plan.is_fallback:
+        if plan.reason is None:
+            raise PrebuiltFallback("validation launch skipped due to missing sandbox")
+        raise PrebuiltFallback(plan.reason)
+    return run_capture(plan.command, timeout = timeout, env = plan.env)
+
+
+def _run_validation_ldd_probe(binary_path: Path, *, env: dict[str, str]) -> str:
+    plan = build_validation_sandbox_plan(
+        ["ldd", str(binary_path)],
+        binary_path = binary_path,
+        install_dir = binary_path.parent,
+        purpose = _VALIDATION_PURPOSE_LDD,
+        env = env,
+    )
+    if plan.is_skipped:
+        log("Skipping ldd probe because no Linux sandbox adapter was available")
+        return ""
+    if plan.is_fallback:
+        # Keep compatibility: compatibility checks tolerate probe skip/fallback by
+        # treating missing entries as unknown and letting downstream metadata checks
+        # handle it.
+        return ""
+    result = _run_validation_capture(plan, timeout = 20)
+    return result.stdout + result.stderr
+
+
+def _run_validation_popen(
+    plan: _ValidationLaunchPlan,
+    *,
+    stdout,
+    timeout: int | None = None,  # kept for parity with current validate_server call shape
+) -> subprocess.Popen[str]:
+    if plan.is_skipped:
+        raise PrebuiltFallback(f"{plan.purpose} launch was skipped by sandbox policy")
+    if plan.is_fallback:
+        if plan.reason is None:
+            raise PrebuiltFallback("validation launch skipped due to missing sandbox")
+        raise PrebuiltFallback(plan.reason)
+    return subprocess.Popen(
+        plan.command,
+        stdout = stdout,
+        stderr = subprocess.STDOUT,
+        text = True,
+        env = plan.env,
+        **windows_hidden_subprocess_kwargs(),
+    )
+
+
 def linux_missing_libraries(binary_path: Path, *, env: dict[str, str] | None = None) -> list[str]:
-    try:
-        result = run_capture(["ldd", str(binary_path)], timeout = 20, env = env)
-    except Exception:
+    if env is None:
+        env = scrubbed_environ()
+    probe_output = _run_validation_ldd_probe(binary_path, env = env)
+    if not probe_output:
         return []
+    result = subprocess.CompletedProcess(binary_path, 0, stdout = probe_output)
 
     missing: list[str] = []
-    for line in (result.stdout + result.stderr).splitlines():
+    for line in result.stdout.splitlines():
         line = line.strip()
         if "=> not found" not in line:
             continue
@@ -5679,15 +5891,17 @@ def validate_quantize(
     *,
     runtime_line: str | None = None,
 ) -> None:
-    command = [str(quantize_path), str(probe_path), str(quantized_path), "Q6_K", "2"]
-    result = subprocess.run(
-        command,
-        capture_output = True,
-        text = True,
-        timeout = 120,
-        env = binary_env(quantize_path, install_dir, host, runtime_line = runtime_line),
-        **windows_hidden_subprocess_kwargs(),
+    env = binary_env(quantize_path, install_dir, host, runtime_line = runtime_line)
+    plan = build_validation_sandbox_plan(
+        [str(quantize_path), str(probe_path), str(quantized_path), "Q6_K", "2"],
+        binary_path = quantize_path,
+        install_dir = install_dir,
+        host = host,
+        runtime_line = runtime_line,
+        purpose = _VALIDATION_PURPOSE_QUANTIZE,
+        env = env,
     )
+    result = _run_validation_capture(plan, timeout = 120)
     if result.returncode != 0 or not quantized_path.exists() or quantized_path.stat().st_size == 0:
         combined = result.stdout + ("\n" + result.stderr if result.stderr else "")
         # Backstop for prebuilts the static minos scan could not read: a dyld
@@ -5713,6 +5927,7 @@ def validate_server(
     last_failure: PrebuiltFallback | None = None
     for port_attempt in range(1, SERVER_PORT_BIND_ATTEMPTS + 1):
         port = free_local_port()
+        env = binary_env(server_path, install_dir, host, runtime_line = runtime_line)
         command = [
             str(server_path),
             "-m",
@@ -5760,6 +5975,15 @@ def validate_server(
             )
         if _enable_gpu_layers:
             command.extend(["--n-gpu-layers", "1"])
+        plan = build_validation_sandbox_plan(
+            command,
+            binary_path = server_path,
+            install_dir = install_dir,
+            host = host,
+            runtime_line = runtime_line,
+            purpose = _VALIDATION_PURPOSE_SERVER,
+            env = env,
+        )
 
         log_fd, log_name = tempfile.mkstemp(prefix = "llama-server-", suffix = ".log")
         os.close(log_fd)
@@ -5767,13 +5991,9 @@ def validate_server(
         process: subprocess.Popen[str] | None = None
         try:
             with log_path.open("w", encoding = "utf-8", errors = "replace") as log_handle:
-                process = subprocess.Popen(
-                    command,
+                process = _run_validation_popen(
+                    plan,
                     stdout = log_handle,
-                    stderr = subprocess.STDOUT,
-                    text = True,
-                    env = binary_env(server_path, install_dir, host, runtime_line = runtime_line),
-                    **windows_hidden_subprocess_kwargs(),
                 )
                 deadline = time.time() + 60
                 startup_started = time.time()
@@ -5909,9 +6129,9 @@ def collect_system_report(host: HostInfo, choice: AssetChoice | None, install_di
                 )
             )
             try:
-                ldd = run_capture(["ldd", str(server_binary)], timeout = 20, env = server_env)
+                ldd_output = _run_validation_ldd_probe(server_binary, env = server_env)
                 lines.append("ldd llama-server:")
-                lines.append((ldd.stdout + ldd.stderr).strip())
+                lines.append((ldd_output or "none").strip())
             except Exception as exc:
                 lines.append(f"ldd error: {exc}")
     elif host.is_windows:

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -39,7 +39,7 @@ try:
 except ImportError:
     FileLock = None
     FileLockTimeout = None
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Iterable, Iterator, Literal
 
 
@@ -5293,15 +5293,24 @@ def _append_existing_bwrap_bind(
     )
 
 
-def _is_broad_sandbox_library_path(path: str | Path) -> bool:
+_SANDBOX_LIBRARY_DIR_NAMES = frozenset({"lib", "lib64"})
+
+
+def _is_broad_sandbox_library_path(
+    path: str | Path, *, require_library_dir: bool = False
+) -> bool:
     candidate = Path(path)
+    resolved = _resolve_existing_path(candidate)
     if not candidate.is_absolute() and not str(candidate).startswith(("/", "\\")):
         return True
-    resolved = _resolve_existing_path(candidate)
     if len(resolved.parts) <= 2:
         return True
     if len(resolved.parts) <= 3 and resolved.parts[1].lower() in {"home", "users"}:
         return True
+    if require_library_dir:
+        parts = PurePosixPath(str(path)).parts
+        if parts[-1].lower() not in _SANDBOX_LIBRARY_DIR_NAMES:
+            return True
     try:
         if resolved == Path.home().resolve():
             return True
@@ -5310,11 +5319,14 @@ def _is_broad_sandbox_library_path(path: str | Path) -> bool:
     return False
 
 
-def _sandbox_library_path_targets(env: dict[str, str], key: str) -> list[Path]:
+def _sandbox_library_path_targets(
+    env: dict[str, str], key: str, *, require_library_dir: bool = False
+) -> list[Path]:
     return [
         _resolve_existing_path(Path(part))
         for part in env.get(key, "").split(os.pathsep)
-        if part and not _is_broad_sandbox_library_path(part)
+        if part
+        and not _is_broad_sandbox_library_path(part, require_library_dir = require_library_dir)
     ]
 
 
@@ -5658,7 +5670,9 @@ def _macos_validation_sandbox_prefix(
         binary_path.parent,
         runtime_home,
     ]
-    read_targets.extend(_sandbox_library_path_targets(env, "DYLD_LIBRARY_PATH"))
+    read_targets.extend(
+        _sandbox_library_path_targets(env, "DYLD_LIBRARY_PATH", require_library_dir = True)
+    )
     write_targets: list[str | Path] = [runtime_home]
     if purpose == _VALIDATION_PURPOSE_QUANTIZE and len(command) >= 3:
         read_targets.append(Path(command[1]).parent)
@@ -5678,9 +5692,12 @@ def _macos_validation_sandbox_prefix(
         "/usr/lib",
         "/System",
         "/System/Library",
+        install_dir,
         binary_path.parent,
     ]
-    executable_map_targets.extend(_sandbox_library_path_targets(env, "DYLD_LIBRARY_PATH"))
+    executable_map_targets.extend(
+        _sandbox_library_path_targets(env, "DYLD_LIBRARY_PATH", require_library_dir = True)
+    )
     profile_parts = [
         "(version 1)",
         "(deny default)",
@@ -6560,6 +6577,7 @@ _PYTHON_IMPORT_POINTER_VARS = (
     "PYTHONHOME",
     "PYTHONPATH",
 )
+_DYLD_ALLOWED_ENV_NAMES = frozenset({"DYLD_LIBRARY_PATH"})
 
 _isolated_runtime_home_dir: str | None = None
 
@@ -6591,6 +6609,9 @@ def scrubbed_environ() -> dict[str, str]:
         *_PYTHON_IMPORT_POINTER_VARS,
     ):
         env.pop(pointer, None)
+    for key in tuple(env):
+        if key.upper().startswith("DYLD_") and key.upper() not in _DYLD_ALLOWED_ENV_NAMES:
+            env.pop(key, None)
     return env
 
 

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5157,28 +5157,104 @@ def _has_command(command: str) -> bool:
     return shutil.which(command) is not None
 
 
-def _linux_validation_bwrap_prefix(binary_path: Path, install_dir: Path) -> list[str]:
+def _append_existing_bwrap_bind(
+    args: list[str],
+    *,
+    source: str | Path,
+    readonly: bool,
+    seen: set[str],
+) -> None:
+    path = Path(source)
+    if not path.exists():
+        return
+    key = str(path)
+    if key in seen:
+        return
+    seen.add(key)
+    args.extend(
+        [
+            "--ro-bind" if readonly else "--bind",
+            key,
+            key,
+        ]
+    )
+
+
+def _linux_validation_bwrap_prefix(
+    command: list[str],
+    *,
+    binary_path: Path,
+    install_dir: Path,
+    purpose: str,
+    env: dict[str, str],
+) -> list[str]:
     runtime_home = isolated_runtime_home()
-    return [
+    command_path = Path(command[0])
+    if not command_path.is_absolute():
+        resolved_command = shutil.which(command[0])
+        if resolved_command:
+            command_path = Path(resolved_command)
+
+    write_targets = {
+        str(Path(runtime_home)),
+    }
+    readonly_targets: list[str | Path] = [
+        install_dir,
+        binary_path.parent,
+        command_path.parent,
+        "/bin",
+        "/lib",
+        "/lib64",
+        "/usr/bin",
+        "/usr/lib",
+        "/usr/lib64",
+        "/etc/ld.so.cache",
+        "/etc/ld.so.conf",
+        "/etc/ld.so.conf.d",
+    ]
+    readonly_targets.extend(
+        part
+        for part in env.get("LD_LIBRARY_PATH", "").split(os.pathsep)
+        if part
+    )
+
+    if purpose == _VALIDATION_PURPOSE_QUANTIZE and len(command) >= 3:
+        readonly_targets.append(Path(command[1]).parent)
+        write_targets.add(str(Path(command[2]).parent))
+    elif purpose == _VALIDATION_PURPOSE_SERVER and len(command) >= 3 and command[1] == "-m":
+        readonly_targets.append(Path(command[2]).parent)
+
+    args = [
         "bwrap",
         "--unshare-all",
-        "--unshare-net",
+    ]
+    if purpose == _VALIDATION_PURPOSE_SERVER:
+        args.append("--share-net")
+    args.extend(
+        [
         "--die-with-parent",
         "--new-session",
         "--tmpfs",
         "/tmp",
         "--proc",
         "/proc",
+        "--dev",
+        "/dev",
         "--setenv",
         "HOME",
         runtime_home,
-        "--ro-bind",
-        str(install_dir),
-        str(install_dir),
-        "--ro-bind",
-        str(binary_path.parent),
-        str(binary_path.parent),
-    ]
+        ]
+    )
+
+    seen: set[str] = set()
+    for target in readonly_targets:
+        target_path = Path(target)
+        if str(target_path) in write_targets:
+            continue
+        _append_existing_bwrap_bind(args, source = target_path, readonly = True, seen = seen)
+    for target in sorted(write_targets):
+        _append_existing_bwrap_bind(args, source = target, readonly = False, seen = seen)
+    return args
 
 
 def _macos_validation_sandbox_prefix() -> list[str]:
@@ -5221,7 +5297,13 @@ def build_validation_sandbox_plan(
         if _has_command("bwrap"):
             return _ValidationLaunchPlan(
                 command = [
-                    *_linux_validation_bwrap_prefix(binary_path, install_dir),
+                    *_linux_validation_bwrap_prefix(
+                        command,
+                        binary_path = binary_path,
+                        install_dir = install_dir,
+                        purpose = purpose,
+                        env = env,
+                    ),
                     *command,
                 ],
                 env = env,
@@ -5293,8 +5375,11 @@ def _run_validation_capture(
 
 
 def _run_validation_ldd_probe(binary_path: Path, *, env: dict[str, str]) -> str:
+    ldd_path = shutil.which("ldd")
+    if ldd_path is None:
+        return ""
     plan = build_validation_sandbox_plan(
-        ["ldd", str(binary_path)],
+        [ldd_path, str(binary_path)],
         binary_path = binary_path,
         install_dir = binary_path.parent,
         purpose = _VALIDATION_PURPOSE_LDD,

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5222,11 +5222,7 @@ def _has_command(command: str) -> bool:
 
 
 def _append_existing_bwrap_bind(
-    args: list[str],
-    *,
-    source: str | Path,
-    readonly: bool,
-    seen: set[str],
+    args: list[str], *, source: str | Path, readonly: bool, seen: set[str]
 ) -> None:
     path = Path(source)
     if not path.exists():
@@ -5430,9 +5426,7 @@ def _linux_validation_bwrap_prefix(
     if Path("/nix/store") in command_path.parents:
         readonly_targets.append("/nix/store")
     readonly_targets.extend(
-        part
-        for part in payload_env.get("LD_LIBRARY_PATH", "").split(os.pathsep)
-        if part
+        part for part in payload_env.get("LD_LIBRARY_PATH", "").split(os.pathsep) if part
     )
     server_command = payload_command or command
 
@@ -5466,19 +5460,19 @@ def _linux_validation_bwrap_prefix(
         args.append("--unshare-all")
     args.extend(
         [
-        "--die-with-parent",
-        "--new-session",
-        "--perms",
-        "1777",
-        "--tmpfs",
-        "/tmp",
-        "--proc",
-        "/proc",
-        "--dev",
-        "/dev",
-        "--setenv",
-        "HOME",
-        runtime_home,
+            "--die-with-parent",
+            "--new-session",
+            "--perms",
+            "1777",
+            "--tmpfs",
+            "/tmp",
+            "--proc",
+            "/proc",
+            "--dev",
+            "/dev",
+            "--setenv",
+            "HOME",
+            runtime_home,
         ]
     )
     is_server_helper = payload_command is not None and purpose == _VALIDATION_PURPOSE_SERVER
@@ -5555,12 +5549,7 @@ def _sandbox_profile_path_literals(path: str | Path) -> list[str]:
 
 
 def _macos_validation_sandbox_prefix(
-    command: list[str],
-    *,
-    binary_path: Path,
-    install_dir: Path,
-    purpose: str,
-    env: dict[str, str],
+    command: list[str], *, binary_path: Path, install_dir: Path, purpose: str, env: dict[str, str]
 ) -> list[str]:
     runtime_home = Path(isolated_runtime_home())
     read_targets: list[str | Path] = [
@@ -5574,11 +5563,7 @@ def _macos_validation_sandbox_prefix(
         binary_path.parent,
         runtime_home,
     ]
-    read_targets.extend(
-        part
-        for part in env.get("DYLD_LIBRARY_PATH", "").split(os.pathsep)
-        if part
-    )
+    read_targets.extend(part for part in env.get("DYLD_LIBRARY_PATH", "").split(os.pathsep) if part)
     write_targets: list[str | Path] = [runtime_home]
     if purpose == _VALIDATION_PURPOSE_QUANTIZE and len(command) >= 3:
         read_targets.append(Path(command[1]).parent)
@@ -5601,9 +5586,7 @@ def _macos_validation_sandbox_prefix(
         binary_path.parent,
     ]
     executable_map_targets.extend(
-        part
-        for part in env.get("DYLD_LIBRARY_PATH", "").split(os.pathsep)
-        if part
+        part for part in env.get("DYLD_LIBRARY_PATH", "").split(os.pathsep) if part
     )
     profile_parts = [
         "(version 1)",
@@ -5703,16 +5686,20 @@ def build_validation_sandbox_plan(
                 )
             network_policy = _VALIDATION_NETWORK_POLICY_SANDBOX
             server_probe_mode = (
-                _VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX if purpose == _VALIDATION_PURPOSE_SERVER else None
+                _VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX
+                if purpose == _VALIDATION_PURPOSE_SERVER
+                else None
             )
             launch_command = payload_command
             if purpose == _VALIDATION_PURPOSE_SERVER:
                 try:
-                    launch_command = _resolve_sandbox_command(_linux_validation_server_probe_command(
-                        payload_command,
-                        env,
-                        timeout = _LINUX_SERVER_VALIDATION_HELPER_TIMEOUT_SECONDS,
-                    ))
+                    launch_command = _resolve_sandbox_command(
+                        _linux_validation_server_probe_command(
+                            payload_command,
+                            env,
+                            timeout = _LINUX_SERVER_VALIDATION_HELPER_TIMEOUT_SECONDS,
+                        )
+                    )
                 except RuntimeError as exc:
                     return _ValidationLaunchPlan(
                         command = payload_command,
@@ -5776,7 +5763,9 @@ def build_validation_sandbox_plan(
     if _host_is_macos(host):
         if _has_command("sandbox-exec"):
             network_policy = (
-                _VALIDATION_NETWORK_POLICY_SANDBOX if purpose == _VALIDATION_PURPOSE_SERVER else _VALIDATION_NETWORK_POLICY_DIRECT
+                _VALIDATION_NETWORK_POLICY_SANDBOX
+                if purpose == _VALIDATION_PURPOSE_SERVER
+                else _VALIDATION_NETWORK_POLICY_DIRECT
             )
             launch_command = command
             return _ValidationLaunchPlan(
@@ -5811,7 +5800,9 @@ def build_validation_sandbox_plan(
             payload_command = command,
             payload_env = env,
             sandbox_kind = "macos_sandbox_exec",
-            network_policy = _VALIDATION_NETWORK_POLICY_DIRECT if purpose == _VALIDATION_PURPOSE_SERVER else _VALIDATION_NETWORK_POLICY_DIRECT,
+            network_policy = _VALIDATION_NETWORK_POLICY_DIRECT
+            if purpose == _VALIDATION_PURPOSE_SERVER
+            else _VALIDATION_NETWORK_POLICY_DIRECT,
             server_probe_mode = _VALIDATION_SERVER_PROBE_MODE_HOST,
         )
 
@@ -5839,9 +5830,7 @@ def build_validation_sandbox_plan(
 
 
 def _run_validation_capture(
-    plan: _ValidationLaunchPlan,
-    *,
-    timeout: int,
+    plan: _ValidationLaunchPlan, *, timeout: int
 ) -> subprocess.CompletedProcess[str]:
     if plan.is_skipped:
         raise PrebuiltFallback(f"{plan.purpose} launch was skipped by sandbox policy")
@@ -6613,9 +6602,7 @@ def validate_server(
             # hosts in the GPU-validation path so an AMD-only Linux host
             # is exercised against the actual hardware rather than the
             # CPU fallback. NVIDIA stays covered here.
-            _enable_gpu_layers = (
-                host.has_usable_nvidia or host.has_rocm
-            )
+            _enable_gpu_layers = host.has_usable_nvidia or host.has_rocm
             if host.is_linux and host.has_usable_nvidia:
                 gpu_backend = "cuda"
             elif host.is_linux and host.has_rocm:
@@ -6644,13 +6631,10 @@ def validate_server(
                 return
             exited_quickly = (time.time() - started_at) <= SERVER_BIND_RETRY_WINDOW_SECONDS
             failure = PrebuiltFallback("llama-server validation failed inside sandbox:\n" + output)
-            if (
-                port_attempt < SERVER_PORT_BIND_ATTEMPTS
-                and is_retryable_server_bind_error(
-                    RuntimeError(output),
-                    output,
-                    exited_quickly = exited_quickly,
-                )
+            if port_attempt < SERVER_PORT_BIND_ATTEMPTS and is_retryable_server_bind_error(
+                RuntimeError(output),
+                output,
+                exited_quickly = exited_quickly,
             ):
                 log(
                     f"llama-server startup hit a port race on {port}; retrying with a fresh port "
@@ -6787,9 +6771,7 @@ def collect_system_report(host: HostInfo, choice: AssetChoice | None, install_di
         if server_binary.exists():
             server_env = binary_env(server_binary, install_dir, host)
             ldd_probe = _run_validation_ldd_probe(server_binary, env = server_env)
-            lines.append(
-                "linux_missing_libs_probe=" + ldd_probe.status
-            )
+            lines.append("linux_missing_libs_probe=" + ldd_probe.status)
             if ldd_probe.reason:
                 lines.append("linux_missing_libs_probe_reason=" + ldd_probe.reason)
             if ldd_probe.status == _LINUX_LDD_PROBE_OK:

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4745,11 +4745,14 @@ def _binary_is_setuid_root(path: str | Path) -> bool:
     return stat_result.st_uid == 0 and bool(stat_result.st_mode & stat.S_ISUID)
 
 
-def _has_command(command: str) -> bool:
-    return _resolve_command_path(command) is not None
-
-
 _bwrap_sandbox_capability: dict[str, bool] = {}
+_LINUX_DYNAMIC_LOADER_ENV_VARS = (
+    "LD_LIBRARY_PATH",
+    "LD_PRELOAD",
+    "LD_AUDIT",
+    "LD_DEBUG",
+    "LD_ORIGIN_PATH",
+)
 
 
 def _bwrap_can_sandbox(bwrap_path: str) -> bool:
@@ -4775,6 +4778,7 @@ def _bwrap_can_sandbox(bwrap_path: str) -> bool:
             ],
             stdout = subprocess.DEVNULL,
             stderr = subprocess.DEVNULL,
+            env = _linux_validation_launcher_env({}),
             timeout = 20,
         )
         ok = result.returncode == 0
@@ -4803,9 +4807,34 @@ def _append_existing_bwrap_bind(
     )
 
 
+def _is_broad_sandbox_library_path(path: str | Path) -> bool:
+    candidate = Path(path)
+    if not candidate.is_absolute() and not str(candidate).startswith(("/", "\\")):
+        return True
+    resolved = _resolve_existing_path(candidate)
+    if len(resolved.parts) <= 2:
+        return True
+    if len(resolved.parts) <= 3 and resolved.parts[1].lower() in {"home", "users"}:
+        return True
+    try:
+        if resolved == Path.home().resolve():
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def _sandbox_library_path_targets(env: dict[str, str], key: str) -> list[Path]:
+    return [
+        _resolve_existing_path(Path(part))
+        for part in env.get(key, "").split(os.pathsep)
+        if part and not _is_broad_sandbox_library_path(part)
+    ]
+
+
 def _linux_validation_launcher_env(payload_env: dict[str, str]) -> dict[str, str]:
     env = scrubbed_environ()
-    for key in payload_env:
+    for key in (*payload_env, *_LINUX_DYNAMIC_LOADER_ENV_VARS):
         env.pop(key, None)
     # Keep a stable base command search path.
     env["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -5001,9 +5030,7 @@ def _linux_validation_bwrap_prefix(
         )
     if Path("/nix/store") in command_path.parents:
         readonly_targets.append("/nix/store")
-    readonly_targets.extend(
-        part for part in payload_env.get("LD_LIBRARY_PATH", "").split(os.pathsep) if part
-    )
+    readonly_targets.extend(_sandbox_library_path_targets(payload_env, "LD_LIBRARY_PATH"))
     server_command = payload_command or command
 
     if purpose == _VALIDATION_PURPOSE_QUANTIZE and len(command) >= 3:
@@ -5125,7 +5152,13 @@ def _sandbox_profile_path_literals(path: str | Path) -> list[str]:
 
 
 def _macos_validation_sandbox_prefix(
-    command: list[str], *, binary_path: Path, install_dir: Path, purpose: str, env: dict[str, str]
+    command: list[str],
+    *,
+    binary_path: Path,
+    install_dir: Path,
+    purpose: str,
+    env: dict[str, str],
+    adapter_path: str,
 ) -> list[str]:
     runtime_home = Path(isolated_runtime_home())
     read_targets: list[str | Path] = [
@@ -5139,7 +5172,7 @@ def _macos_validation_sandbox_prefix(
         binary_path.parent,
         runtime_home,
     ]
-    read_targets.extend(part for part in env.get("DYLD_LIBRARY_PATH", "").split(os.pathsep) if part)
+    read_targets.extend(_sandbox_library_path_targets(env, "DYLD_LIBRARY_PATH"))
     write_targets: list[str | Path] = [runtime_home]
     if purpose == _VALIDATION_PURPOSE_QUANTIZE and len(command) >= 3:
         read_targets.append(Path(command[1]).parent)
@@ -5161,9 +5194,7 @@ def _macos_validation_sandbox_prefix(
         "/System/Library",
         binary_path.parent,
     ]
-    executable_map_targets.extend(
-        part for part in env.get("DYLD_LIBRARY_PATH", "").split(os.pathsep) if part
-    )
+    executable_map_targets.extend(_sandbox_library_path_targets(env, "DYLD_LIBRARY_PATH"))
     profile_parts = [
         "(version 1)",
         "(deny default)",
@@ -5199,7 +5230,7 @@ def _macos_validation_sandbox_prefix(
             profile_parts.append(f'(allow network* (remote ip "localhost:{server_port}"))')
     profile = "".join(profile_parts)
     return [
-        "sandbox-exec",
+        adapter_path,
         "-p",
         profile,
     ]
@@ -5331,7 +5362,8 @@ def build_validation_sandbox_plan(
         )
 
     if _host_is_macos(host):
-        if _has_command("sandbox-exec"):
+        sandbox_exec_path = _resolve_command_path("sandbox-exec")
+        if sandbox_exec_path is not None:
             network_policy = (
                 _VALIDATION_NETWORK_POLICY_SANDBOX
                 if purpose == _VALIDATION_PURPOSE_SERVER
@@ -5346,6 +5378,7 @@ def build_validation_sandbox_plan(
                         install_dir = install_dir,
                         purpose = purpose,
                         env = env,
+                        adapter_path = sandbox_exec_path,
                     ),
                     "/usr/bin/env",
                     "-i",

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -515,6 +515,8 @@ class InstallReleasePlan:
 
 PrebuiltFallback = _core.PrebuiltFallback
 BusyInstallConflict = _core.BusyInstallConflict
+class ValidationLaunchUnavailable(RuntimeError):
+    pass
 
 
 class ExistingInstallSatisfied(RuntimeError):
@@ -2344,7 +2346,18 @@ def resolve_source_build_plan(
     )
 
 
-def run_capture(
+def _subprocess_failure(command: list[str], exc: BaseException) -> PrebuiltFallback:
+    name = command[0] if command else "subprocess"
+    if isinstance(exc, FileNotFoundError):
+        return PrebuiltFallback(f"{name} was not found")
+    if isinstance(exc, PermissionError):
+        return PrebuiltFallback(f"{name} was not executable")
+    if isinstance(exc, subprocess.TimeoutExpired):
+        return PrebuiltFallback(f"{name} timed out after {exc.timeout} seconds")
+    return PrebuiltFallback(f"{name} launch failed: {exc}")
+
+
+def _run_subprocess_capture(
     command: list[str],
     *,
     timeout: int = 30,
@@ -2360,19 +2373,32 @@ def run_capture(
         and os.path.basename(command[0]).lower().startswith("amd-smi")
     ):
         env = {**(os.environ if env is None else env), "__COMPAT_LAYER": "RunAsInvoker"}
-    result = subprocess.run(
-        command,
-        capture_output = True,
-        text = True,
-        timeout = timeout,
-        env = env,
-        **windows_hidden_subprocess_kwargs(),
-    )
+    try:
+        result = subprocess.run(
+            command,
+            capture_output = True,
+            text = True,
+            timeout = timeout,
+            env = env,
+            **windows_hidden_subprocess_kwargs(),
+        )
+    except (FileNotFoundError, PermissionError, subprocess.TimeoutExpired) as exc:
+        raise _subprocess_failure(command, exc) from exc
     if check and result.returncode != 0:
         raise subprocess.CalledProcessError(
             result.returncode, command, result.stdout, result.stderr
         )
     return result
+
+
+def run_capture(
+    command: list[str],
+    *,
+    timeout: int = 30,
+    check: bool = False,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return _run_subprocess_capture(command, timeout = timeout, check = check, env = env)
 
 
 def _list_rocm_gfx_targets(out: str) -> list[str]:
@@ -3355,13 +3381,7 @@ def _detect_host_rocm_version() -> tuple[int, int] | None:
     hipconfig = shutil.which("hipconfig")
     if hipconfig:
         try:
-            result = subprocess.run(
-                [hipconfig, "--version"],
-                stdout = subprocess.PIPE,
-                stderr = subprocess.DEVNULL,
-                text = True,
-                timeout = 5,
-            )
+            result = run_capture([hipconfig, "--version"], timeout = 5)
             if result.returncode == 0:
                 raw = (result.stdout or "").strip().split("\n")[0]
                 parts = raw.split(".")
@@ -3383,13 +3403,7 @@ def _detect_host_rocm_version() -> tuple[int, int] | None:
         if not _exe:
             continue
         try:
-            _result = subprocess.run(
-                [_exe, *_cmd[1:]],
-                stdout = subprocess.PIPE,
-                stderr = subprocess.DEVNULL,
-                text = True,
-                timeout = 5,
-            )
+            _result = run_capture([_exe, *_cmd[1:]], timeout = 5)
         except Exception:
             continue
         if _result.returncode != 0 or not _result.stdout.strip():
@@ -4766,7 +4780,7 @@ def _bwrap_can_sandbox(bwrap_path: str) -> bool:
         return cached
     ok = False
     try:
-        result = subprocess.run(
+        result = run_capture(
             [
                 bwrap_path,
                 "--ro-bind",
@@ -4776,8 +4790,6 @@ def _bwrap_can_sandbox(bwrap_path: str) -> bool:
                 "--die-with-parent",
                 _resolve_command_path("true") or "/bin/true",
             ],
-            stdout = subprocess.DEVNULL,
-            stderr = subprocess.DEVNULL,
             env = _linux_validation_launcher_env({}),
             timeout = 20,
         )
@@ -5351,14 +5363,14 @@ def build_validation_sandbox_plan(
         return _ValidationLaunchPlan(
             command = command,
             env = launcher_env,
-            action = _VALIDATION_LAUNCH_FALLBACK,
+            action = _VALIDATION_LAUNCH_SKIP,
             purpose = purpose,
             sandbox_kind = "linux_bwrap",
-            reason = "No Linux sandbox adapter was available for downloaded-binary validation",
+            reason = "No Linux sandbox adapter was available; skip downloaded-binary validation",
             payload_command = command,
             payload_env = env,
-            network_policy = _VALIDATION_NETWORK_POLICY_DIRECT,
-            server_probe_mode = _VALIDATION_SERVER_PROBE_MODE_HOST,
+            network_policy = None,
+            server_probe_mode = None,
         )
 
     if _host_is_macos(host):
@@ -5432,16 +5444,48 @@ def build_validation_sandbox_plan(
     )
 
 
-def _run_validation_capture(
-    plan: _ValidationLaunchPlan, *, timeout: int
-) -> subprocess.CompletedProcess[str]:
+def _unavailable_validation_launch(plan: _ValidationLaunchPlan) -> ValidationLaunchUnavailable:
+    reason = plan.reason or f"{plan.purpose} launch was skipped by sandbox policy"
+    return ValidationLaunchUnavailable(reason)
+
+
+def _run_validation_launch(
+    plan: _ValidationLaunchPlan,
+    *,
+    timeout: int | None = None,
+    stdout = None,
+    popen: bool = False,
+) -> subprocess.CompletedProcess[str] | subprocess.Popen[str]:
     if plan.is_skipped:
-        raise PrebuiltFallback(f"{plan.purpose} launch was skipped by sandbox policy")
+        raise _unavailable_validation_launch(plan)
     if plan.is_fallback:
         if plan.reason is None:
             raise PrebuiltFallback("validation launch skipped due to missing sandbox")
         raise PrebuiltFallback(plan.reason)
+    if popen:
+        try:
+            return subprocess.Popen(
+                plan.command,
+                stdout = stdout,
+                stderr = subprocess.STDOUT,
+                text = True,
+                env = plan.env,
+                **_validation_server_kwargs(),
+                **windows_hidden_subprocess_kwargs(),
+            )
+        except (FileNotFoundError, PermissionError) as exc:
+            raise _subprocess_failure(plan.command, exc) from exc
+    if timeout is None:
+        raise ValueError("timeout is required for captured validation launches")
     return run_capture(plan.command, timeout = timeout, env = plan.env)
+
+
+def _run_validation_capture(
+    plan: _ValidationLaunchPlan, *, timeout: int
+) -> subprocess.CompletedProcess[str]:
+    result = _run_validation_launch(plan, timeout = timeout)
+    assert isinstance(result, subprocess.CompletedProcess)
+    return result
 
 
 def _parse_ldd_missing_libraries(output: str) -> list[str]:
@@ -5454,6 +5498,10 @@ def _parse_ldd_missing_libraries(output: str) -> list[str]:
         if library and library not in missing:
             missing.append(library)
     return missing
+
+
+def _ldd_output_is_static_binary(output: str) -> bool:
+    return "not a dynamic executable" in output.lower()
 
 
 def _run_validation_ldd_probe(binary_path: Path, *, env: dict[str, str]) -> LinuxLibraryProbeResult:
@@ -5496,6 +5544,13 @@ def _run_validation_ldd_probe(binary_path: Path, *, env: dict[str, str]) -> Linu
         stderr = result.stderr if result.stderr else ""
         if stderr:
             reason = f"{reason} {stderr}" if reason else stderr
+        if _ldd_output_is_static_binary(reason):
+            return LinuxLibraryProbeResult(
+                status = _LINUX_LDD_PROBE_OK,
+                missing = [],
+                reason = "static executable",
+                output = result.stdout + result.stderr,
+            )
         if not reason:
             reason = "ldd probe failed"
         return LinuxLibraryProbeResult(
@@ -5518,21 +5573,8 @@ def _run_validation_popen(
     stdout,
     timeout: int | None = None,  # kept for parity with current validate_server call shape
 ) -> subprocess.Popen[str]:
-    if plan.is_skipped:
-        raise PrebuiltFallback(f"{plan.purpose} launch was skipped by sandbox policy")
-    if plan.is_fallback:
-        if plan.reason is None:
-            raise PrebuiltFallback("validation launch skipped due to missing sandbox")
-        raise PrebuiltFallback(plan.reason)
-    return subprocess.Popen(
-        plan.command,
-        stdout = stdout,
-        stderr = subprocess.STDOUT,
-        text = True,
-        env = plan.env,
-        **_validation_server_kwargs(),
-        **windows_hidden_subprocess_kwargs(),
-    )
+    process = _run_validation_launch(plan, stdout = stdout, popen = True)
+    return process  # type: ignore[return-value]
 
 
 def linux_missing_libraries(binary_path: Path, *, env: dict[str, str] | None = None) -> list[str]:
@@ -6193,6 +6235,7 @@ def validate_quantize(
     host: HostInfo,
     *,
     runtime_line: str | None = None,
+    require_launch: bool = False,
 ) -> None:
     env = binary_env(quantize_path, install_dir, host, runtime_line = runtime_line)
     plan = build_validation_sandbox_plan(
@@ -6204,7 +6247,13 @@ def validate_quantize(
         purpose = _VALIDATION_PURPOSE_QUANTIZE,
         env = env,
     )
-    result = _run_validation_capture(plan, timeout = 120)
+    try:
+        result = _run_validation_capture(plan, timeout = 120)
+    except ValidationLaunchUnavailable as exc:
+        if require_launch:
+            raise PrebuiltFallback(f"llama-quantize validation unavailable: {exc}") from exc
+        log(f"llama-quantize validation skipped: {exc}")
+        return
     if result.returncode != 0 or not quantized_path.exists() or quantized_path.stat().st_size == 0:
         combined = result.stdout + ("\n" + result.stderr if result.stderr else "")
         # Backstop for prebuilts the static minos scan could not read: a dyld
@@ -6226,6 +6275,7 @@ def validate_server(
     *,
     runtime_line: str | None = None,
     install_kind: str | None = None,
+    require_launch: bool = False,
 ) -> None:
     last_failure: PrebuiltFallback | None = None
     gpu_backend: Literal["cuda", "rocm"] | None = None
@@ -6299,10 +6349,16 @@ def validate_server(
         )
         if plan.server_probe_mode == _VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX:
             started_at = time.time()
-            result = _run_validation_capture(
-                plan,
-                timeout = _LINUX_SERVER_VALIDATION_HELPER_CAPTURE_TIMEOUT_SECONDS,
-            )
+            try:
+                result = _run_validation_capture(
+                    plan,
+                    timeout = _LINUX_SERVER_VALIDATION_HELPER_CAPTURE_TIMEOUT_SECONDS,
+                )
+            except ValidationLaunchUnavailable as exc:
+                if require_launch:
+                    raise PrebuiltFallback(f"llama-server validation unavailable: {exc}") from exc
+                log(f"llama-server validation skipped: {exc}")
+                return
             output = (result.stdout or "") + (result.stderr or "")
             if result.returncode == 0:
                 return
@@ -6327,10 +6383,18 @@ def validate_server(
         process: subprocess.Popen[str] | None = None
         try:
             with log_path.open("w", encoding = "utf-8", errors = "replace") as log_handle:
-                process = _run_validation_popen(
-                    plan,
-                    stdout = log_handle,
-                )
+                try:
+                    process = _run_validation_popen(
+                        plan,
+                        stdout = log_handle,
+                    )
+                except ValidationLaunchUnavailable as exc:
+                    if require_launch:
+                        raise PrebuiltFallback(
+                            f"llama-server validation unavailable: {exc}"
+                        ) from exc
+                    log(f"llama-server validation skipped: {exc}")
+                    return
                 # For the caller that spawned this script: a validation server is
                 # its grandchild, so a crash here leaves it holding the GPU and
                 # the staged files with nothing recording where it is.
@@ -7597,7 +7661,8 @@ def validate_prebuilt_choice(
     # staged_validation_enabled() (constant or UNSLOTH_LLAMA_STAGED_VALIDATION),
     # disabled for now. The check and the source-build fallback it triggers are
     # kept intact; flip the flag / env to restore it (#5854).
-    if choice.expected_sha256 is None or staged_validation_enabled():
+    smoke_validation_required = choice.expected_sha256 is None
+    if smoke_validation_required or staged_validation_enabled():
         # Only branch that reads the probe, so this is where a lazy one is fetched.
         probe_path = resolve_validation_model(probe)
         validate_quantize(
@@ -7607,6 +7672,7 @@ def validate_prebuilt_choice(
             install_dir,
             host,
             runtime_line = choice.runtime_line,
+            require_launch = smoke_validation_required,
         )
         validate_server(
             server_path,
@@ -7615,8 +7681,9 @@ def validate_prebuilt_choice(
             install_dir,
             runtime_line = choice.runtime_line,
             install_kind = choice.install_kind,
+            require_launch = smoke_validation_required,
         )
-        log(f"staged prebuilt validation succeeded for {choice.name}")
+        log(f"staged prebuilt validation completed for {choice.name}")
     return server_path, quantize_path
 
 

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4750,11 +4750,7 @@ def _has_command(command: str) -> bool:
 
 
 def _append_existing_bwrap_bind(
-    args: list[str],
-    *,
-    source: str | Path,
-    readonly: bool,
-    seen: set[str],
+    args: list[str], *, source: str | Path, readonly: bool, seen: set[str]
 ) -> None:
     path = Path(source)
     if not path.exists():
@@ -4958,9 +4954,7 @@ def _linux_validation_bwrap_prefix(
     if Path("/nix/store") in command_path.parents:
         readonly_targets.append("/nix/store")
     readonly_targets.extend(
-        part
-        for part in payload_env.get("LD_LIBRARY_PATH", "").split(os.pathsep)
-        if part
+        part for part in payload_env.get("LD_LIBRARY_PATH", "").split(os.pathsep) if part
     )
     server_command = payload_command or command
 
@@ -4994,19 +4988,19 @@ def _linux_validation_bwrap_prefix(
         args.append("--unshare-all")
     args.extend(
         [
-        "--die-with-parent",
-        "--new-session",
-        "--perms",
-        "1777",
-        "--tmpfs",
-        "/tmp",
-        "--proc",
-        "/proc",
-        "--dev",
-        "/dev",
-        "--setenv",
-        "HOME",
-        runtime_home,
+            "--die-with-parent",
+            "--new-session",
+            "--perms",
+            "1777",
+            "--tmpfs",
+            "/tmp",
+            "--proc",
+            "/proc",
+            "--dev",
+            "/dev",
+            "--setenv",
+            "HOME",
+            runtime_home,
         ]
     )
     is_server_helper = payload_command is not None and purpose == _VALIDATION_PURPOSE_SERVER
@@ -5083,12 +5077,7 @@ def _sandbox_profile_path_literals(path: str | Path) -> list[str]:
 
 
 def _macos_validation_sandbox_prefix(
-    command: list[str],
-    *,
-    binary_path: Path,
-    install_dir: Path,
-    purpose: str,
-    env: dict[str, str],
+    command: list[str], *, binary_path: Path, install_dir: Path, purpose: str, env: dict[str, str]
 ) -> list[str]:
     runtime_home = Path(isolated_runtime_home())
     read_targets: list[str | Path] = [
@@ -5102,11 +5091,7 @@ def _macos_validation_sandbox_prefix(
         binary_path.parent,
         runtime_home,
     ]
-    read_targets.extend(
-        part
-        for part in env.get("DYLD_LIBRARY_PATH", "").split(os.pathsep)
-        if part
-    )
+    read_targets.extend(part for part in env.get("DYLD_LIBRARY_PATH", "").split(os.pathsep) if part)
     write_targets: list[str | Path] = [runtime_home]
     if purpose == _VALIDATION_PURPOSE_QUANTIZE and len(command) >= 3:
         read_targets.append(Path(command[1]).parent)
@@ -5129,9 +5114,7 @@ def _macos_validation_sandbox_prefix(
         binary_path.parent,
     ]
     executable_map_targets.extend(
-        part
-        for part in env.get("DYLD_LIBRARY_PATH", "").split(os.pathsep)
-        if part
+        part for part in env.get("DYLD_LIBRARY_PATH", "").split(os.pathsep) if part
     )
     profile_parts = [
         "(version 1)",
@@ -5231,16 +5214,20 @@ def build_validation_sandbox_plan(
                 )
             network_policy = _VALIDATION_NETWORK_POLICY_SANDBOX
             server_probe_mode = (
-                _VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX if purpose == _VALIDATION_PURPOSE_SERVER else None
+                _VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX
+                if purpose == _VALIDATION_PURPOSE_SERVER
+                else None
             )
             launch_command = payload_command
             if purpose == _VALIDATION_PURPOSE_SERVER:
                 try:
-                    launch_command = _resolve_sandbox_command(_linux_validation_server_probe_command(
-                        payload_command,
-                        env,
-                        timeout = _LINUX_SERVER_VALIDATION_HELPER_TIMEOUT_SECONDS,
-                    ))
+                    launch_command = _resolve_sandbox_command(
+                        _linux_validation_server_probe_command(
+                            payload_command,
+                            env,
+                            timeout = _LINUX_SERVER_VALIDATION_HELPER_TIMEOUT_SECONDS,
+                        )
+                    )
                 except RuntimeError as exc:
                     return _ValidationLaunchPlan(
                         command = payload_command,
@@ -5304,7 +5291,9 @@ def build_validation_sandbox_plan(
     if _host_is_macos(host):
         if _has_command("sandbox-exec"):
             network_policy = (
-                _VALIDATION_NETWORK_POLICY_SANDBOX if purpose == _VALIDATION_PURPOSE_SERVER else _VALIDATION_NETWORK_POLICY_DIRECT
+                _VALIDATION_NETWORK_POLICY_SANDBOX
+                if purpose == _VALIDATION_PURPOSE_SERVER
+                else _VALIDATION_NETWORK_POLICY_DIRECT
             )
             launch_command = command
             return _ValidationLaunchPlan(
@@ -5339,7 +5328,9 @@ def build_validation_sandbox_plan(
             payload_command = command,
             payload_env = env,
             sandbox_kind = "macos_sandbox_exec",
-            network_policy = _VALIDATION_NETWORK_POLICY_DIRECT if purpose == _VALIDATION_PURPOSE_SERVER else _VALIDATION_NETWORK_POLICY_DIRECT,
+            network_policy = _VALIDATION_NETWORK_POLICY_DIRECT
+            if purpose == _VALIDATION_PURPOSE_SERVER
+            else _VALIDATION_NETWORK_POLICY_DIRECT,
             server_probe_mode = _VALIDATION_SERVER_PROBE_MODE_HOST,
         )
 
@@ -5367,9 +5358,7 @@ def build_validation_sandbox_plan(
 
 
 def _run_validation_capture(
-    plan: _ValidationLaunchPlan,
-    *,
-    timeout: int,
+    plan: _ValidationLaunchPlan, *, timeout: int
 ) -> subprocess.CompletedProcess[str]:
     if plan.is_skipped:
         raise PrebuiltFallback(f"{plan.purpose} launch was skipped by sandbox policy")
@@ -6215,9 +6204,7 @@ def validate_server(
             # hosts in the GPU-validation path so an AMD-only Linux host
             # is exercised against the actual hardware rather than the
             # CPU fallback. NVIDIA stays covered here.
-            _enable_gpu_layers = (
-                host.has_usable_nvidia or host.has_rocm
-            )
+            _enable_gpu_layers = host.has_usable_nvidia or host.has_rocm
             if host.is_linux and host.has_usable_nvidia:
                 gpu_backend = "cuda"
             elif host.is_linux and host.has_rocm:
@@ -6246,13 +6233,10 @@ def validate_server(
                 return
             exited_quickly = (time.time() - started_at) <= SERVER_BIND_RETRY_WINDOW_SECONDS
             failure = PrebuiltFallback("llama-server validation failed inside sandbox:\n" + output)
-            if (
-                port_attempt < SERVER_PORT_BIND_ATTEMPTS
-                and is_retryable_server_bind_error(
-                    RuntimeError(output),
-                    output,
-                    exited_quickly = exited_quickly,
-                )
+            if port_attempt < SERVER_PORT_BIND_ATTEMPTS and is_retryable_server_bind_error(
+                RuntimeError(output),
+                output,
+                exited_quickly = exited_quickly,
             ):
                 log(
                     f"llama-server startup hit a port race on {port}; retrying with a fresh port "
@@ -6519,9 +6503,7 @@ def collect_system_report(host: HostInfo, choice: AssetChoice | None, install_di
         if server_binary.exists():
             server_env = binary_env(server_binary, install_dir, host)
             ldd_probe = _run_validation_ldd_probe(server_binary, env = server_env)
-            lines.append(
-                "linux_missing_libs_probe=" + ldd_probe.status
-            )
+            lines.append("linux_missing_libs_probe=" + ldd_probe.status)
             if ldd_probe.reason:
                 lines.append("linux_missing_libs_probe_reason=" + ldd_probe.reason)
             if ldd_probe.status == _LINUX_LDD_PROBE_OK:

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4764,9 +4764,18 @@ def _bwrap_can_sandbox(bwrap_path: str) -> bool:
     ok = False
     try:
         result = subprocess.run(
-            [bwrap_path, "--ro-bind", "/", "/", "--unshare-all", "--die-with-parent",
-             _resolve_command_path("true") or "/bin/true"],
-            stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL, timeout = 20,
+            [
+                bwrap_path,
+                "--ro-bind",
+                "/",
+                "/",
+                "--unshare-all",
+                "--die-with-parent",
+                _resolve_command_path("true") or "/bin/true",
+            ],
+            stdout = subprocess.DEVNULL,
+            stderr = subprocess.DEVNULL,
+            timeout = 20,
         )
         ok = result.returncode == 0
     except Exception:

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4786,11 +4786,14 @@ def _linux_validation_bwrap_prefix(
     return args
 
 
-def _macos_validation_sandbox_prefix() -> list[str]:
+def _macos_validation_sandbox_prefix(purpose: str) -> list[str]:
+    profile = "(version 1)"
+    if purpose != _VALIDATION_PURPOSE_SERVER:
+        profile = "(version 1)(deny network*)"
     return [
         "sandbox-exec",
         "-p",
-        "(version 1)(deny network*)",
+        profile,
     ]
 
 
@@ -4858,7 +4861,7 @@ def build_validation_sandbox_plan(
     if _host_is_macos(host):
         if _has_command("sandbox-exec"):
             return _ValidationLaunchPlan(
-                command = [*_macos_validation_sandbox_prefix(), *command],
+                command = [*_macos_validation_sandbox_prefix(purpose), *command],
                 env = env,
                 action = _VALIDATION_LAUNCH_RUN,
                 purpose = purpose,

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4653,14 +4653,227 @@ def dedupe_existing_dirs(paths: Iterable[str | Path], *, skip_unusable: bool = F
     return unique
 
 
+_VALIDATION_LAUNCH_RUN = "run"
+_VALIDATION_LAUNCH_SKIP = "skip"
+_VALIDATION_LAUNCH_FALLBACK = "fallback"
+_VALIDATION_PURPOSE_LDD = "ldd"
+_VALIDATION_PURPOSE_QUANTIZE = "quantize"
+_VALIDATION_PURPOSE_SERVER = "server"
+
+
+@dataclass(frozen = True)
+class _ValidationLaunchPlan:
+    command: list[str]
+    env: dict[str, str]
+    action: str
+    purpose: str
+    reason: str | None = None
+
+    @property
+    def is_runnable(self) -> bool:
+        return self.action == _VALIDATION_LAUNCH_RUN
+
+    @property
+    def is_skipped(self) -> bool:
+        return self.action == _VALIDATION_LAUNCH_SKIP
+
+    @property
+    def is_fallback(self) -> bool:
+        return self.action == _VALIDATION_LAUNCH_FALLBACK
+
+
+def _has_command(command: str) -> bool:
+    return shutil.which(command) is not None
+
+
+def _linux_validation_bwrap_prefix(binary_path: Path, install_dir: Path) -> list[str]:
+    runtime_home = isolated_runtime_home()
+    return [
+        "bwrap",
+        "--unshare-all",
+        "--unshare-net",
+        "--die-with-parent",
+        "--new-session",
+        "--tmpfs",
+        "/tmp",
+        "--proc",
+        "/proc",
+        "--setenv",
+        "HOME",
+        runtime_home,
+        "--ro-bind",
+        str(install_dir),
+        str(install_dir),
+        "--ro-bind",
+        str(binary_path.parent),
+        str(binary_path.parent),
+    ]
+
+
+def _macos_validation_sandbox_prefix() -> list[str]:
+    return [
+        "sandbox-exec",
+        "-p",
+        "(version 1)(deny network*)",
+    ]
+
+
+def _host_is_linux(host: HostInfo | None = None) -> bool:
+    if host is not None:
+        return host.is_linux
+    return platform.system() == "Linux"
+
+
+def _host_is_macos(host: HostInfo | None = None) -> bool:
+    if host is not None:
+        return host.is_macos
+    return platform.system() == "Darwin"
+
+
+def _host_is_windows(host: HostInfo | None = None) -> bool:
+    if host is not None:
+        return host.is_windows
+    return platform.system() == "Windows"
+
+
+def build_validation_sandbox_plan(
+    command: list[str],
+    *,
+    binary_path: Path,
+    install_dir: Path,
+    purpose: str,
+    env: dict[str, str],
+    host: HostInfo | None = None,
+    runtime_line: str | None = None,
+) -> _ValidationLaunchPlan:
+    if _host_is_linux(host):
+        if _has_command("bwrap"):
+            return _ValidationLaunchPlan(
+                command = [
+                    *_linux_validation_bwrap_prefix(binary_path, install_dir),
+                    *command,
+                ],
+                env = env,
+                action = _VALIDATION_LAUNCH_RUN,
+                purpose = purpose,
+            )
+        if purpose == _VALIDATION_PURPOSE_LDD:
+            return _ValidationLaunchPlan(
+                command = command,
+                env = env,
+                action = _VALIDATION_LAUNCH_SKIP,
+                purpose = purpose,
+                reason = "No Linux sandbox adapter was available; skip ldd probe",
+            )
+        return _ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = _VALIDATION_LAUNCH_FALLBACK,
+            purpose = purpose,
+            reason = "No Linux sandbox adapter was available for downloaded-binary validation",
+        )
+
+    if _host_is_macos(host):
+        if _has_command("sandbox-exec"):
+            return _ValidationLaunchPlan(
+                command = [*_macos_validation_sandbox_prefix(), *command],
+                env = env,
+                action = _VALIDATION_LAUNCH_RUN,
+                purpose = purpose,
+            )
+        return _ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = _VALIDATION_LAUNCH_FALLBACK,
+            purpose = purpose,
+            reason = "No macOS sandbox-exec adapter was available for downloaded-binary validation",
+        )
+
+    if _host_is_windows(host):
+        return _ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = _VALIDATION_LAUNCH_FALLBACK,
+            purpose = purpose,
+            reason = "Windows validation sandboxing is unsupported in this install slice",
+        )
+
+    return _ValidationLaunchPlan(
+        command = command,
+        env = env,
+        action = _VALIDATION_LAUNCH_FALLBACK,
+        purpose = purpose,
+        reason = f"Unsupported platform for validation sandboxing: {platform.system()}",
+    )
+
+
+def _run_validation_capture(
+    plan: _ValidationLaunchPlan,
+    *,
+    timeout: int,
+) -> subprocess.CompletedProcess[str]:
+    if plan.is_skipped:
+        raise PrebuiltFallback(f"{plan.purpose} launch was skipped by sandbox policy")
+    if plan.is_fallback:
+        if plan.reason is None:
+            raise PrebuiltFallback("validation launch skipped due to missing sandbox")
+        raise PrebuiltFallback(plan.reason)
+    return run_capture(plan.command, timeout = timeout, env = plan.env)
+
+
+def _run_validation_ldd_probe(binary_path: Path, *, env: dict[str, str]) -> str:
+    plan = build_validation_sandbox_plan(
+        ["ldd", str(binary_path)],
+        binary_path = binary_path,
+        install_dir = binary_path.parent,
+        purpose = _VALIDATION_PURPOSE_LDD,
+        env = env,
+    )
+    if plan.is_skipped:
+        log("Skipping ldd probe because no Linux sandbox adapter was available")
+        return ""
+    if plan.is_fallback:
+        # Keep compatibility: compatibility checks tolerate probe skip/fallback by
+        # treating missing entries as unknown and letting downstream metadata checks
+        # handle it.
+        return ""
+    result = _run_validation_capture(plan, timeout = 20)
+    return result.stdout + result.stderr
+
+
+def _run_validation_popen(
+    plan: _ValidationLaunchPlan,
+    *,
+    stdout,
+    timeout: int | None = None,  # kept for parity with current validate_server call shape
+) -> subprocess.Popen[str]:
+    if plan.is_skipped:
+        raise PrebuiltFallback(f"{plan.purpose} launch was skipped by sandbox policy")
+    if plan.is_fallback:
+        if plan.reason is None:
+            raise PrebuiltFallback("validation launch skipped due to missing sandbox")
+        raise PrebuiltFallback(plan.reason)
+    return subprocess.Popen(
+        plan.command,
+        stdout = stdout,
+        stderr = subprocess.STDOUT,
+        text = True,
+        env = plan.env,
+        **_validation_server_kwargs(),
+        **windows_hidden_subprocess_kwargs(),
+    )
+
+
 def linux_missing_libraries(binary_path: Path, *, env: dict[str, str] | None = None) -> list[str]:
-    try:
-        result = run_capture(["ldd", str(binary_path)], timeout = 20, env = env)
-    except Exception:
+    if env is None:
+        env = scrubbed_environ()
+    probe_output = _run_validation_ldd_probe(binary_path, env = env)
+    if not probe_output:
         return []
+    result = subprocess.CompletedProcess(binary_path, 0, stdout = probe_output)
 
     missing: list[str] = []
-    for line in (result.stdout + result.stderr).splitlines():
+    for line in result.stdout.splitlines():
         line = line.strip()
         if "=> not found" not in line:
             continue
@@ -5279,15 +5492,17 @@ def validate_quantize(
     *,
     runtime_line: str | None = None,
 ) -> None:
-    command = [str(quantize_path), str(probe_path), str(quantized_path), "Q6_K", "2"]
-    result = subprocess.run(
-        command,
-        capture_output = True,
-        text = True,
-        timeout = 120,
-        env = binary_env(quantize_path, install_dir, host, runtime_line = runtime_line),
-        **windows_hidden_subprocess_kwargs(),
+    env = binary_env(quantize_path, install_dir, host, runtime_line = runtime_line)
+    plan = build_validation_sandbox_plan(
+        [str(quantize_path), str(probe_path), str(quantized_path), "Q6_K", "2"],
+        binary_path = quantize_path,
+        install_dir = install_dir,
+        host = host,
+        runtime_line = runtime_line,
+        purpose = _VALIDATION_PURPOSE_QUANTIZE,
+        env = env,
     )
+    result = _run_validation_capture(plan, timeout = 120)
     if result.returncode != 0 or not quantized_path.exists() or quantized_path.stat().st_size == 0:
         combined = result.stdout + ("\n" + result.stderr if result.stderr else "")
         # Backstop for prebuilts the static minos scan could not read: a dyld
@@ -5313,6 +5528,7 @@ def validate_server(
     last_failure: PrebuiltFallback | None = None
     for port_attempt in range(1, SERVER_PORT_BIND_ATTEMPTS + 1):
         port = free_local_port()
+        env = binary_env(server_path, install_dir, host, runtime_line = runtime_line)
         command = [
             str(server_path),
             "-m",
@@ -5362,6 +5578,15 @@ def validate_server(
             )
         if _enable_gpu_layers:
             command.extend(["--n-gpu-layers", "1"])
+        plan = build_validation_sandbox_plan(
+            command,
+            binary_path = server_path,
+            install_dir = install_dir,
+            host = host,
+            runtime_line = runtime_line,
+            purpose = _VALIDATION_PURPOSE_SERVER,
+            env = env,
+        )
 
         log_fd, log_name = tempfile.mkstemp(prefix = "llama-server-", suffix = ".log")
         os.close(log_fd)
@@ -5369,14 +5594,9 @@ def validate_server(
         process: subprocess.Popen[str] | None = None
         try:
             with log_path.open("w", encoding = "utf-8", errors = "replace") as log_handle:
-                process = subprocess.Popen(
-                    command,
+                process = _run_validation_popen(
+                    plan,
                     stdout = log_handle,
-                    stderr = subprocess.STDOUT,
-                    text = True,
-                    env = binary_env(server_path, install_dir, host, runtime_line = runtime_line),
-                    **_validation_server_kwargs(),
-                    **windows_hidden_subprocess_kwargs(),
                 )
                 # For the caller that spawned this script: a validation server is
                 # its grandchild, so a crash here leaves it holding the GPU and
@@ -5642,9 +5862,9 @@ def collect_system_report(host: HostInfo, choice: AssetChoice | None, install_di
                 )
             )
             try:
-                ldd = run_capture(["ldd", str(server_binary)], timeout = 20, env = server_env)
+                ldd_output = _run_validation_ldd_probe(server_binary, env = server_env)
                 lines.append("ldd llama-server:")
-                lines.append((ldd.stdout + ldd.stderr).strip())
+                lines.append((ldd_output or "none").strip())
             except Exception as exc:
                 lines.append(f"ldd error: {exc}")
     elif host.is_windows:

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4784,6 +4784,19 @@ def _linux_validation_setenv_args(payload_env: dict[str, str]) -> list[str]:
     return args
 
 
+def _drop_server_gpu_layers(command: list[str]) -> list[str]:
+    trimmed: list[str] = []
+    index = 0
+    while index < len(command):
+        arg = command[index]
+        if arg == "--n-gpu-layers" and index + 1 < len(command):
+            index += 2
+            continue
+        trimmed.append(arg)
+        index += 1
+    return trimmed
+
+
 def _extract_loopback_port(command: list[str]) -> int:
     for index, arg in enumerate(command):
         if arg != "--port":
@@ -5200,18 +5213,12 @@ def build_validation_sandbox_plan(
                 and gpu_backend in {"cuda", "rocm"}
                 and not _binary_is_setuid_root(bwrap_path)
             ):
-                return _ValidationLaunchPlan(
-                    command = payload_command,
-                    env = launcher_env,
-                    action = _VALIDATION_LAUNCH_RUN,
-                    purpose = purpose,
-                    sandbox_kind = "linux_direct_validation",
-                    reason = "Linux GPU validation requires direct launch when bwrap is not setuid root",
-                    payload_command = payload_command,
-                    payload_env = env,
-                    network_policy = _VALIDATION_NETWORK_POLICY_DIRECT,
-                    server_probe_mode = _VALIDATION_SERVER_PROBE_MODE_HOST,
-                )
+                # Non-setuid bwrap needs a user namespace, which drops the host's
+                # supplementary GPU device groups. Keep the loopback-only sandbox
+                # and validate the bundle on the CPU path instead.
+                payload_command = _drop_server_gpu_layers(payload_command)
+                enable_gpu_layers = False
+                gpu_backend = None
             network_policy = _VALIDATION_NETWORK_POLICY_SANDBOX
             server_probe_mode = (
                 _VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX
@@ -5305,7 +5312,7 @@ def build_validation_sandbox_plan(
                         purpose = purpose,
                         env = env,
                     ),
-                    "env",
+                    "/usr/bin/env",
                     "-i",
                     *[f"{name}={value}" for name, value in sorted(env.items())],
                     *launch_command,

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4712,7 +4712,29 @@ def _resolve_command_path(command: str) -> str | None:
     resolved = shutil.which(command)
     if resolved is None:
         return None
-    return str(Path(resolved))
+    return str(Path(resolved).resolve())
+
+
+def _resolve_existing_path(path: str | Path) -> Path:
+    candidate = Path(path)
+    try:
+        return candidate.resolve(strict = True)
+    except Exception:
+        return candidate
+
+
+def _resolve_sandbox_command(command: list[str]) -> list[str]:
+    if not command:
+        return []
+    resolved_command = list(command)
+    command_path = Path(resolved_command[0])
+    if command_path.is_absolute():
+        resolved_command[0] = str(_resolve_existing_path(command_path))
+        return resolved_command
+    resolved_path = _resolve_command_path(resolved_command[0])
+    if resolved_path is not None:
+        resolved_command[0] = resolved_path
+    return resolved_command
 
 
 def _has_command(command: str) -> bool:
@@ -4899,11 +4921,7 @@ def _linux_validation_bwrap_prefix(
     gpu_backend: Literal["cuda", "rocm"] | None = None,
 ) -> list[str]:
     runtime_home = isolated_runtime_home()
-    command_path = Path(command[0])
-    if not command_path.is_absolute():
-        resolved_command = shutil.which(command[0])
-        if resolved_command:
-            command_path = Path(resolved_command)
+    command_path = _resolve_existing_path(command[0])
 
     write_targets = {
         str(Path(runtime_home)),
@@ -4951,10 +4969,19 @@ def _linux_validation_bwrap_prefix(
         and enable_gpu_layers
         and gpu_backend in {"cuda", "rocm"}
     )
-    args = [
-        adapter_path,
-        "--unshare-all",
-    ]
+    args = [adapter_path]
+    if enable_gpu_devices:
+        args.extend(
+            [
+                "--unshare-cgroup-try",
+                "--unshare-ipc",
+                "--unshare-net",
+                "--unshare-pid",
+                "--unshare-uts",
+            ]
+        )
+    else:
+        args.append("--unshare-all")
     args.extend(
         [
         "--die-with-parent",
@@ -5083,6 +5110,17 @@ def _macos_validation_sandbox_prefix(
         "/System/Library",
         binary_path.parent,
     ]
+    executable_map_targets: list[str | Path] = [
+        "/usr/lib",
+        "/System",
+        "/System/Library",
+        binary_path.parent,
+    ]
+    executable_map_targets.extend(
+        part
+        for part in env.get("DYLD_LIBRARY_PATH", "").split(os.pathsep)
+        if part
+    )
     profile_parts = [
         "(version 1)",
         "(deny default)",
@@ -5090,6 +5128,11 @@ def _macos_validation_sandbox_prefix(
         "(allow process-exec",
     ]
     for target in exec_targets:
+        for literal in _sandbox_profile_path_literals(target):
+            profile_parts.append(f'(subpath "{literal}")')
+    profile_parts.append(")")
+    profile_parts.append("(allow file-map-executable")
+    for target in executable_map_targets:
         for literal in _sandbox_profile_path_literals(target):
             profile_parts.append(f'(subpath "{literal}")')
     profile_parts.append(")")
@@ -5155,7 +5198,7 @@ def build_validation_sandbox_plan(
     if _host_is_linux(host):
         bwrap_path = _resolve_command_path("bwrap")
         if bwrap_path is not None:
-            payload_command = list(command)
+            payload_command = _resolve_sandbox_command(command)
             network_policy = _VALIDATION_NETWORK_POLICY_SANDBOX
             server_probe_mode = (
                 _VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX if purpose == _VALIDATION_PURPOSE_SERVER else None
@@ -5163,11 +5206,11 @@ def build_validation_sandbox_plan(
             launch_command = payload_command
             if purpose == _VALIDATION_PURPOSE_SERVER:
                 try:
-                    launch_command = _linux_validation_server_probe_command(
+                    launch_command = _resolve_sandbox_command(_linux_validation_server_probe_command(
                         payload_command,
                         env,
                         timeout = _LINUX_SERVER_VALIDATION_HELPER_TIMEOUT_SECONDS,
-                    )
+                    ))
                 except RuntimeError as exc:
                     return _ValidationLaunchPlan(
                         command = payload_command,

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -43,7 +43,7 @@ except ImportError:
     FileLock = None
     FileLockTimeout = None
 from pathlib import Path
-from typing import Any, Callable, Iterable, Iterator, Union
+from typing import Any, Callable, Iterable, Iterator, Literal, Union
 
 # Shared component-agnostic machinery lives in prebuilt_core (same directory);
 # put studio/ on sys.path so it resolves whether this file is run as a script
@@ -4659,6 +4659,9 @@ _VALIDATION_LAUNCH_FALLBACK = "fallback"
 _VALIDATION_PURPOSE_LDD = "ldd"
 _VALIDATION_PURPOSE_QUANTIZE = "quantize"
 _VALIDATION_PURPOSE_SERVER = "server"
+_LINUX_LDD_PROBE_OK = "ok"
+_LINUX_LDD_PROBE_SKIPPED = "skipped"
+_LINUX_LDD_PROBE_ERROR = "error"
 
 
 @dataclass(frozen = True)
@@ -4667,6 +4670,7 @@ class _ValidationLaunchPlan:
     env: dict[str, str]
     action: str
     purpose: str
+    sandbox_kind: str | None = None
     reason: str | None = None
 
     @property
@@ -4680,6 +4684,14 @@ class _ValidationLaunchPlan:
     @property
     def is_fallback(self) -> bool:
         return self.action == _VALIDATION_LAUNCH_FALLBACK
+
+
+@dataclass(frozen = True)
+class LinuxLibraryProbeResult:
+    status: Literal["ok", "skipped", "error"]
+    missing: list[str]
+    output: str = ""
+    reason: str | None = None
 
 
 def _has_command(command: str) -> bool:
@@ -4716,6 +4728,8 @@ def _linux_validation_bwrap_prefix(
     install_dir: Path,
     purpose: str,
     env: dict[str, str],
+    enable_gpu_layers: bool = False,
+    gpu_backend: Literal["cuda", "rocm"] | None = None,
 ) -> list[str]:
     runtime_home = isolated_runtime_home()
     command_path = Path(command[0])
@@ -4753,6 +4767,11 @@ def _linux_validation_bwrap_prefix(
     elif purpose == _VALIDATION_PURPOSE_SERVER and len(command) >= 3 and command[1] == "-m":
         readonly_targets.append(Path(command[2]).parent)
 
+    enable_gpu_devices = (
+        purpose == _VALIDATION_PURPOSE_SERVER
+        and enable_gpu_layers
+        and gpu_backend in {"cuda", "rocm"}
+    )
     args = [
         "bwrap",
         "--unshare-all",
@@ -4776,6 +4795,42 @@ def _linux_validation_bwrap_prefix(
     )
 
     seen: set[str] = set()
+    if enable_gpu_devices:
+        dev_nodes: list[str] = []
+        readonly_gpu_targets = [
+            "/sys/class/drm",
+            "/sys/bus/pci",
+            "/sys/dev/char",
+            "/sys/devices",
+        ]
+        if gpu_backend == "cuda":
+            dev_nodes.extend(
+                [
+                    "/dev/nvidiactl",
+                    "/dev/nvidia-modeset",
+                    "/dev/nvidia-uvm",
+                    "/dev/nvidia-uvm-tools",
+                ]
+            )
+            for path in Path("/dev").glob("nvidia*"):
+                if re.match(r"^nvidia[0-9]+$", path.name):
+                    dev_nodes.append(str(path))
+            readonly_gpu_targets.append("/proc/driver/nvidia")
+        elif gpu_backend == "rocm":
+            dev_nodes.extend(["/dev/kfd", "/dev/dxg"])
+            dev_nodes.extend(str(node) for node in Path("/dev/dri").glob("card*"))
+            dev_nodes.extend(str(node) for node in Path("/dev/dri").glob("renderD*"))
+
+        for node in dev_nodes:
+            node_path = Path(node)
+            if str(node_path) in seen:
+                continue
+            if not node_path.exists():
+                continue
+            seen.add(str(node_path))
+            args.extend(["--dev-bind-try", str(node_path), str(node_path)])
+
+        readonly_targets.extend(readonly_gpu_targets)
     for target in readonly_targets:
         target_path = Path(target)
         if str(target_path) in write_targets:
@@ -4906,6 +4961,8 @@ def build_validation_sandbox_plan(
     install_dir: Path,
     purpose: str,
     env: dict[str, str],
+    enable_gpu_layers: bool = False,
+    gpu_backend: Literal["cuda", "rocm"] | None = None,
     host: HostInfo | None = None,
     runtime_line: str | None = None,
 ) -> _ValidationLaunchPlan:
@@ -4919,6 +4976,8 @@ def build_validation_sandbox_plan(
                         install_dir = install_dir,
                         purpose = purpose,
                         env = env,
+                        enable_gpu_layers = enable_gpu_layers,
+                        gpu_backend = gpu_backend,
                     ),
                     *command,
                 ],
@@ -4971,9 +5030,10 @@ def build_validation_sandbox_plan(
         return _ValidationLaunchPlan(
             command = command,
             env = env,
-            action = _VALIDATION_LAUNCH_FALLBACK,
+            action = _VALIDATION_LAUNCH_RUN,
             purpose = purpose,
-            reason = "Windows validation sandboxing is unsupported in this install slice",
+            sandbox_kind = "windows_direct_validation",
+            reason = "Running validation directly on Windows host",
         )
 
     return _ValidationLaunchPlan(
@@ -4999,10 +5059,26 @@ def _run_validation_capture(
     return run_capture(plan.command, timeout = timeout, env = plan.env)
 
 
-def _run_validation_ldd_probe(binary_path: Path, *, env: dict[str, str]) -> str:
+def _parse_ldd_missing_libraries(output: str) -> list[str]:
+    missing: list[str] = []
+    for line in output.splitlines():
+        line = line.strip()
+        if "=> not found" not in line:
+            continue
+        library = line.split("=>", 1)[0].strip()
+        if library and library not in missing:
+            missing.append(library)
+    return missing
+
+
+def _run_validation_ldd_probe(binary_path: Path, *, env: dict[str, str]) -> LinuxLibraryProbeResult:
     ldd_path = shutil.which("ldd")
     if ldd_path is None:
-        return ""
+        return LinuxLibraryProbeResult(
+            status = _LINUX_LDD_PROBE_SKIPPED,
+            missing = [],
+            reason = "ldd executable was not found",
+        )
     plan = build_validation_sandbox_plan(
         [ldd_path, str(binary_path)],
         binary_path = binary_path,
@@ -5011,15 +5087,31 @@ def _run_validation_ldd_probe(binary_path: Path, *, env: dict[str, str]) -> str:
         env = env,
     )
     if plan.is_skipped:
-        log("Skipping ldd probe because no Linux sandbox adapter was available")
-        return ""
+        return LinuxLibraryProbeResult(
+            status = _LINUX_LDD_PROBE_SKIPPED,
+            missing = [],
+            reason = "ldd probe was skipped by validation policy",
+        )
     if plan.is_fallback:
-        # Keep compatibility: compatibility checks tolerate probe skip/fallback by
-        # treating missing entries as unknown and letting downstream metadata checks
-        # handle it.
-        return ""
-    result = _run_validation_capture(plan, timeout = 20)
-    return result.stdout + result.stderr
+        return LinuxLibraryProbeResult(
+            status = _LINUX_LDD_PROBE_SKIPPED,
+            missing = [],
+            reason = plan.reason or "ldd probe did not run",
+        )
+    try:
+        result = _run_validation_capture(plan, timeout = 20)
+    except Exception as exc:
+        return LinuxLibraryProbeResult(
+            status = _LINUX_LDD_PROBE_ERROR,
+            missing = [],
+            reason = f"ldd probe failed: {exc}",
+        )
+    output = result.stdout + result.stderr
+    return LinuxLibraryProbeResult(
+        status = _LINUX_LDD_PROBE_OK,
+        missing = _parse_ldd_missing_libraries(output),
+        output = output,
+    )
 
 
 def _run_validation_popen(
@@ -5052,19 +5144,11 @@ def linux_missing_libraries(binary_path: Path, *, env: dict[str, str] | None = N
         probe_output = _run_validation_ldd_probe(binary_path, env = env)
     except Exception:
         return []
-    if not probe_output:
+    if probe_output.status != _LINUX_LDD_PROBE_OK:
         return []
-    result = subprocess.CompletedProcess(binary_path, 0, stdout = probe_output)
-
-    missing: list[str] = []
-    for line in result.stdout.splitlines():
-        line = line.strip()
-        if "=> not found" not in line:
-            continue
-        library = line.split("=>", 1)[0].strip()
-        if library and library not in missing:
-            missing.append(library)
-    return missing
+    if not probe_output.output:
+        return []
+    return probe_output.missing
 
 
 def python_runtime_dirs() -> list[str]:
@@ -5141,7 +5225,12 @@ def ldconfig_runtime_dirs(required_libraries: Iterable[str]) -> list[str]:
 
 def linux_runtime_dirs(binary_path: Path) -> list[str]:
     # ldd may execute the binary, so probe it with a secret-free env.
-    missing = linux_missing_libraries(binary_path, env = scrubbed_environ())
+    probe_result = _run_validation_ldd_probe(binary_path, env = scrubbed_environ())
+    if probe_result.status != _LINUX_LDD_PROBE_OK:
+        if probe_result.reason:
+            log(f"Skipping Linux runtime dirs probe because {probe_result.reason}")
+        return []
+    missing = probe_result.missing
     if not missing:
         return []
     return linux_runtime_dirs_for_required_libraries(missing)
@@ -5312,7 +5401,11 @@ def preflight_macos_installed_binaries(
 
 
 def preflight_linux_installed_binaries(
-    binaries: Iterable[Path], install_dir: Path, host: HostInfo
+    binaries: Iterable[Path],
+    install_dir: Path,
+    host: HostInfo,
+    *,
+    allow_skipped_probe: bool = True,
 ) -> None:
     if not host.is_linux:
         return
@@ -5320,7 +5413,25 @@ def preflight_linux_installed_binaries(
     issues: list[str] = []
     for binary_path in binaries:
         env = binary_env(binary_path, install_dir, host)
-        missing = linux_missing_libraries(binary_path, env = env)
+        probe_result = _run_validation_ldd_probe(binary_path, env = env)
+        if probe_result.status == _LINUX_LDD_PROBE_ERROR:
+            raise PrebuiltFallback(
+                f"linux extracted binary ldd probe errored for {binary_path.name}: "
+                f"{probe_result.reason}"
+            )
+        if probe_result.status == _LINUX_LDD_PROBE_SKIPPED:
+            if allow_skipped_probe:
+                log(
+                    f"linux extracted binary ldd probe skipped for {binary_path.name}"
+                    + (f": {probe_result.reason}" if probe_result.reason else "")
+                )
+                continue
+            issues.append(
+                f"{binary_path.name}: linux ldd probe skipped"
+                + (f" ({probe_result.reason})" if probe_result.reason else "")
+            )
+            continue
+        missing = probe_result.missing
         if not missing:
             continue
         runtime_dirs = [part for part in env.get("LD_LIBRARY_PATH", "").split(os.pathsep) if part]
@@ -5710,6 +5821,7 @@ def validate_server(
     install_kind: str | None = None,
 ) -> None:
     last_failure: PrebuiltFallback | None = None
+    gpu_backend: Literal["cuda", "rocm"] | None = None
     for port_attempt in range(1, SERVER_PORT_BIND_ATTEMPTS + 1):
         port = free_local_port()
         env = binary_env(server_path, install_dir, host, runtime_line = runtime_line)
@@ -5752,6 +5864,10 @@ def validate_server(
         }
         if install_kind is not None:
             _enable_gpu_layers = install_kind in _gpu_kinds
+            if install_kind in {"linux-cuda", "linux-arm64-cuda"}:
+                gpu_backend = "cuda"
+            elif install_kind == "linux-rocm":
+                gpu_backend = "rocm"
         else:
             # Older call sites that don't pass install_kind: keep ROCm
             # hosts in the GPU-validation path so an AMD-only Linux host
@@ -5760,6 +5876,10 @@ def validate_server(
             _enable_gpu_layers = (
                 host.has_usable_nvidia or host.has_rocm or (host.is_macos and host.is_arm64)
             )
+            if host.is_linux and host.has_usable_nvidia:
+                gpu_backend = "cuda"
+            elif host.is_linux and host.has_rocm:
+                gpu_backend = "rocm"
         if _enable_gpu_layers:
             command.extend(["--n-gpu-layers", "1"])
         plan = build_validation_sandbox_plan(
@@ -5770,6 +5890,8 @@ def validate_server(
             runtime_line = runtime_line,
             purpose = _VALIDATION_PURPOSE_SERVER,
             env = env,
+            enable_gpu_layers = _enable_gpu_layers,
+            gpu_backend = gpu_backend,
         )
 
         log_fd, log_name = tempfile.mkstemp(prefix = "llama-server-", suffix = ".log")
@@ -6028,10 +6150,17 @@ def collect_system_report(host: HostInfo, choice: AssetChoice | None, install_di
         server_binary = install_dir / "llama-server"
         if server_binary.exists():
             server_env = binary_env(server_binary, install_dir, host)
+            ldd_probe = _run_validation_ldd_probe(server_binary, env = server_env)
             lines.append(
-                "linux_missing_libs="
-                + (",".join(linux_missing_libraries(server_binary, env = server_env)) or "none")
+                "linux_missing_libs_probe=" + ldd_probe.status
             )
+            if ldd_probe.reason:
+                lines.append("linux_missing_libs_probe_reason=" + ldd_probe.reason)
+            if ldd_probe.status == _LINUX_LDD_PROBE_OK:
+                lines.append(
+                    "linux_missing_libs="
+                    + (",".join(ldd_probe.missing) if ldd_probe.missing else "none")
+                )
             lines.append(
                 "linux_runtime_dirs="
                 + (
@@ -6046,9 +6175,11 @@ def collect_system_report(host: HostInfo, choice: AssetChoice | None, install_di
                 )
             )
             try:
-                ldd_output = _run_validation_ldd_probe(server_binary, env = server_env)
-                lines.append("ldd llama-server:")
-                lines.append((ldd_output or "none").strip())
+                if ldd_probe.status == _LINUX_LDD_PROBE_OK:
+                    lines.append("ldd llama-server:")
+                    lines.append((ldd_probe.output or "none").strip())
+                else:
+                    lines.append("ldd llama-server: skipped")
             except Exception as exc:
                 lines.append(f"ldd error: {exc}")
     elif host.is_windows:
@@ -6915,6 +7046,7 @@ def existing_install_matches_choice(
                 [runtime_dir / "llama-server", runtime_dir / "llama-quantize"],
                 install_dir,
                 host,
+                allow_skipped_probe = False,
             )
         except Exception:
             return False

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -6597,15 +6597,16 @@ def _terminate_validation_server(process: "subprocess.Popen", grace: float = 5.0
     signalled.
     """
     pgid = None
-    if _validation_server_leads_group() and hasattr(os, "getpgid"):
+    process_pid = getattr(process, "pid", None)
+    if process_pid is not None and _validation_server_leads_group() and hasattr(os, "getpgid"):
         try:
-            pgid = os.getpgid(process.pid)
+            pgid = os.getpgid(process_pid)
         except OSError:
             # Already reaped, so its own pid is the group id: it was started in
             # a session of its own, and the kernel holds that number for as long
             # as any member of the group is still there.
-            pgid = process.pid
-        if pgid != process.pid:
+            pgid = process_pid
+        if pgid != process_pid:
             pgid = None  # not the leader after all; never signal a shared group
     if pgid is not None:
         try:

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5921,6 +5921,11 @@ _CI_COMMAND_FILE_VARS = (
     "GITHUB_STEP_SUMMARY",
     "BASH_ENV",
 )
+# Python-first sandbox helpers must not inherit host import roots.
+_PYTHON_IMPORT_POINTER_VARS = (
+    "PYTHONHOME",
+    "PYTHONPATH",
+)
 
 _isolated_runtime_home_dir: str | None = None
 
@@ -5946,7 +5951,11 @@ def scrubbed_environ() -> dict[str, str]:
     # Windows rebuilds the profile from %HOMEDRIVE%%HOMEPATH% (no-op pair on POSIX).
     drive, tail = os.path.splitdrive(runtime_home)
     env["HOMEDRIVE"], env["HOMEPATH"] = drive, tail or runtime_home
-    for pointer in (*_CREDENTIAL_FILE_POINTER_VARS, *_CI_COMMAND_FILE_VARS):
+    for pointer in (
+        *_CREDENTIAL_FILE_POINTER_VARS,
+        *_CI_COMMAND_FILE_VARS,
+        *_PYTHON_IMPORT_POINTER_VARS,
+    ):
         env.pop(pointer, None)
     return env
 

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -515,6 +515,8 @@ class InstallReleasePlan:
 
 PrebuiltFallback = _core.PrebuiltFallback
 BusyInstallConflict = _core.BusyInstallConflict
+
+
 class ValidationLaunchUnavailable(RuntimeError):
     pass
 

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4659,9 +4659,13 @@ _VALIDATION_LAUNCH_FALLBACK = "fallback"
 _VALIDATION_PURPOSE_LDD = "ldd"
 _VALIDATION_PURPOSE_QUANTIZE = "quantize"
 _VALIDATION_PURPOSE_SERVER = "server"
+_VALIDATION_NETWORK_POLICY_DIRECT = "direct"
+_VALIDATION_NETWORK_POLICY_SANDBOX = "sandbox_loopback_only"
 _LINUX_LDD_PROBE_OK = "ok"
 _LINUX_LDD_PROBE_SKIPPED = "skipped"
 _LINUX_LDD_PROBE_ERROR = "error"
+_VALIDATION_SERVER_PROBE_MODE_HOST = "host_loopback_http"
+_VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX = "sandbox_loopback_http"
 
 
 @dataclass(frozen = True)
@@ -4672,6 +4676,10 @@ class _ValidationLaunchPlan:
     purpose: str
     sandbox_kind: str | None = None
     reason: str | None = None
+    payload_command: list[str] | None = None
+    payload_env: dict[str, str] | None = None
+    network_policy: str | None = None
+    server_probe_mode: str | None = None
 
     @property
     def is_runnable(self) -> bool:
@@ -4721,13 +4729,140 @@ def _append_existing_bwrap_bind(
     )
 
 
+def _linux_validation_launcher_env(payload_env: dict[str, str]) -> dict[str, str]:
+    env = scrubbed_environ()
+    for key in payload_env:
+        env.pop(key, None)
+    # Keep a stable base command search path; payload PATH is still injected in
+    # bwrap via --setenv from payload_env.
+    env["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    return env
+
+
+def _linux_validation_setenv_args(payload_env: dict[str, str]) -> list[str]:
+    args: list[str] = []
+    for key, value in sorted(payload_env.items()):
+        args.extend(["--setenv", key, value])
+    return args
+
+
+def _linux_validation_server_probe_command(
+    server_command: list[str], *, timeout: int = 60
+) -> list[str]:
+    for candidate in ("/usr/bin/python3", "/usr/bin/python"):
+        if Path(candidate).exists():
+            python = candidate
+            break
+    else:
+        python = shutil.which("python3") or shutil.which("python")
+    if python is None:
+        raise RuntimeError("No python interpreter available for in-sandbox server probe")
+
+    probe_script = textwrap.dedent(
+        f"""
+        import json
+        import os
+        import subprocess
+        import sys
+        import tempfile
+        import time
+        import urllib.error
+        import urllib.request
+
+        command = {json.dumps(server_command)}
+        body = b'{{"prompt":"a","n_predict":1}}'
+        timeout = {int(timeout)}
+        deadline = time.time() + timeout
+
+        def read_tail(path: str, max_lines: int = 80) -> list[str]:
+            try:
+                with open(path, "r", encoding = "utf-8", errors = "replace") as handle:
+                    return handle.read().splitlines()[-max_lines:]
+            except Exception:
+                return []
+
+        log_fd, log_path = tempfile.mkstemp(prefix = "unsloth-server-validate-", suffix = ".log")
+        os.close(log_fd)
+
+        port = 0
+        for index, arg in enumerate(command):
+            if arg == "--port" and index + 1 < len(command):
+                try:
+                    port = int(command[index + 1])
+                except ValueError:
+                    port = 0
+                break
+        if port <= 0:
+            print("failed: missing --port for sandboxed llama-server probe")
+            raise SystemExit(1)
+
+        try:
+            with open(log_path, "w", encoding = "utf-8", errors = "replace") as log_handle:
+                process = subprocess.Popen(
+                    command,
+                    stdout = log_handle,
+                    stderr = subprocess.STDOUT,
+                    text = True,
+                )
+                request = urllib.request.Request(
+                    "http://127.0.0.1:%d/completion" % port,
+                    data = body,
+                    headers = {{"Content-Type": "application/json"}},
+                    method = "POST",
+                )
+                while time.time() < deadline:
+                    if process.poll() is not None:
+                        print("server exited before completion probe, code=%s" % process.returncode)
+                        for line in read_tail(log_path):
+                            print(line)
+                        raise SystemExit(process.returncode if process.returncode else 1)
+                    try:
+                        with urllib.request.urlopen(request, timeout = 1) as response:
+                            _ = response.read(32)
+                            if response.status == 200:
+                                process.terminate()
+                                try:
+                                    process.wait(timeout = 5)
+                                except subprocess.TimeoutExpired:
+                                    process.kill()
+                                print("server validation probe succeeded for port=%s" % port)
+                                for line in read_tail(log_path):
+                                    print(line)
+                                raise SystemExit(0)
+                            print("server returned HTTP %s" % response.status)
+                    except urllib.error.HTTPError as exc:
+                        print("server returned HTTP %s" % exc.code)
+                        _ = exc.read()
+                    except Exception:
+                        pass
+                    time.sleep(0.25)
+
+            print("server validation timed out waiting for loopback response on port=%s" % port)
+            for line in read_tail(log_path):
+                print(line)
+            raise SystemExit(1)
+        finally:
+            if "process" in locals() and process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout = 5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout = 5)
+            os.unlink(log_path)
+        """
+    )
+    return [python, "-c", probe_script]
+
+
 def _linux_validation_bwrap_prefix(
     command: list[str],
     *,
     binary_path: Path,
     install_dir: Path,
     purpose: str,
-    env: dict[str, str],
+    payload_env: dict[str, str],
+    payload_command: list[str] | None = None,
     enable_gpu_layers: bool = False,
     gpu_backend: Literal["cuda", "rocm"] | None = None,
 ) -> list[str]:
@@ -4755,17 +4890,29 @@ def _linux_validation_bwrap_prefix(
         "/etc/ld.so.conf",
         "/etc/ld.so.conf.d",
     ]
+    if command_path.parent.name == "bin":
+        readonly_targets.extend(
+            [
+                command_path.parent.parent / "lib",
+                command_path.parent.parent / "lib64",
+            ]
+        )
     readonly_targets.extend(
         part
-        for part in env.get("LD_LIBRARY_PATH", "").split(os.pathsep)
+        for part in payload_env.get("LD_LIBRARY_PATH", "").split(os.pathsep)
         if part
     )
+    server_command = payload_command or command
 
     if purpose == _VALIDATION_PURPOSE_QUANTIZE and len(command) >= 3:
         readonly_targets.append(Path(command[1]).parent)
         write_targets.add(str(Path(command[2]).parent))
-    elif purpose == _VALIDATION_PURPOSE_SERVER and len(command) >= 3 and command[1] == "-m":
-        readonly_targets.append(Path(command[2]).parent)
+    elif (
+        purpose == _VALIDATION_PURPOSE_SERVER
+        and len(server_command) >= 3
+        and server_command[1] == "-m"
+    ):
+        readonly_targets.append(Path(server_command[2]).parent)
 
     enable_gpu_devices = (
         purpose == _VALIDATION_PURPOSE_SERVER
@@ -4776,8 +4923,6 @@ def _linux_validation_bwrap_prefix(
         "bwrap",
         "--unshare-all",
     ]
-    if purpose == _VALIDATION_PURPOSE_SERVER:
-        args.append("--share-net")
     args.extend(
         [
         "--die-with-parent",
@@ -4793,6 +4938,7 @@ def _linux_validation_bwrap_prefix(
         runtime_home,
         ]
     )
+    args.extend(_linux_validation_setenv_args(payload_env))
 
     seen: set[str] = set()
     if enable_gpu_devices:
@@ -4871,12 +5017,13 @@ def _macos_validation_sandbox_prefix(
 ) -> list[str]:
     runtime_home = Path(isolated_runtime_home())
     read_targets: list[str | Path] = [
-        "/",
+        "/bin",
+        "/usr",
+        "/usr/bin",
         "/System",
         "/Library",
-        "/private",
-        "/dev",
-        "/usr",
+        "/System/Library/Frameworks",
+        "/usr/lib",
         install_dir,
         binary_path.parent,
         runtime_home,
@@ -4898,7 +5045,6 @@ def _macos_validation_sandbox_prefix(
         "/usr/bin",
         "/System",
         "/Library",
-        "/private",
         "/usr",
         binary_path.parent,
     ]
@@ -4966,43 +5112,88 @@ def build_validation_sandbox_plan(
     host: HostInfo | None = None,
     runtime_line: str | None = None,
 ) -> _ValidationLaunchPlan:
+    launcher_env = (
+        _linux_validation_launcher_env(env) if _host_is_linux(host) else scrubbed_environ()
+    )
     if _host_is_linux(host):
         if _has_command("bwrap"):
+            payload_command = list(command)
+            network_policy = _VALIDATION_NETWORK_POLICY_SANDBOX
+            server_probe_mode = (
+                _VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX if purpose == _VALIDATION_PURPOSE_SERVER else None
+            )
+            launch_command = payload_command
+            if purpose == _VALIDATION_PURPOSE_SERVER:
+                try:
+                    launch_command = _linux_validation_server_probe_command(
+                        payload_command,
+                        timeout = 60,
+                    )
+                except RuntimeError as exc:
+                    return _ValidationLaunchPlan(
+                        command = payload_command,
+                        env = launcher_env,
+                        action = _VALIDATION_LAUNCH_FALLBACK,
+                        purpose = purpose,
+                        reason = str(exc),
+                        payload_command = payload_command,
+                        payload_env = env,
+                        network_policy = network_policy,
+                        server_probe_mode = _VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX,
+                        sandbox_kind = "linux_bwrap",
+                    )
+            adapter_command = _linux_validation_bwrap_prefix(
+                launch_command,
+                binary_path = binary_path,
+                install_dir = install_dir,
+                purpose = purpose,
+                payload_env = env,
+                payload_command = payload_command,
+                enable_gpu_layers = enable_gpu_layers,
+                gpu_backend = gpu_backend,
+            )
             return _ValidationLaunchPlan(
                 command = [
-                    *_linux_validation_bwrap_prefix(
-                        command,
-                        binary_path = binary_path,
-                        install_dir = install_dir,
-                        purpose = purpose,
-                        env = env,
-                        enable_gpu_layers = enable_gpu_layers,
-                        gpu_backend = gpu_backend,
-                    ),
-                    *command,
+                    *adapter_command,
+                    *launch_command,
                 ],
-                env = env,
+                env = launcher_env,
                 action = _VALIDATION_LAUNCH_RUN,
                 purpose = purpose,
+                sandbox_kind = "linux_bwrap",
+                payload_command = payload_command,
+                payload_env = env,
+                network_policy = network_policy,
+                server_probe_mode = server_probe_mode,
             )
         if purpose == _VALIDATION_PURPOSE_LDD:
             return _ValidationLaunchPlan(
                 command = command,
-                env = env,
+                env = launcher_env,
                 action = _VALIDATION_LAUNCH_SKIP,
                 purpose = purpose,
+                sandbox_kind = "linux_bwrap",
                 reason = "No Linux sandbox adapter was available; skip ldd probe",
             )
         return _ValidationLaunchPlan(
             command = command,
-            env = env,
+            env = launcher_env,
             action = _VALIDATION_LAUNCH_FALLBACK,
             purpose = purpose,
+            sandbox_kind = "linux_bwrap",
             reason = "No Linux sandbox adapter was available for downloaded-binary validation",
+            payload_command = command,
+            payload_env = env,
+            network_policy = _VALIDATION_NETWORK_POLICY_DIRECT,
+            server_probe_mode = _VALIDATION_SERVER_PROBE_MODE_HOST,
         )
 
     if _host_is_macos(host):
         if _has_command("sandbox-exec"):
+            network_policy = (
+                _VALIDATION_NETWORK_POLICY_SANDBOX if purpose == _VALIDATION_PURPOSE_SERVER else _VALIDATION_NETWORK_POLICY_DIRECT
+            )
+            launch_command = command
             return _ValidationLaunchPlan(
                 command = [
                     *_macos_validation_sandbox_prefix(
@@ -5012,18 +5203,31 @@ def build_validation_sandbox_plan(
                         purpose = purpose,
                         env = env,
                     ),
-                    *command,
+                    "env",
+                    "-i",
+                    *[f"{name}={value}" for name, value in sorted(env.items())],
+                    *launch_command,
                 ],
-                env = env,
+                env = launcher_env,
                 action = _VALIDATION_LAUNCH_RUN,
                 purpose = purpose,
+                sandbox_kind = "macos_sandbox_exec",
+                payload_command = launch_command,
+                payload_env = env,
+                network_policy = network_policy,
+                server_probe_mode = _VALIDATION_SERVER_PROBE_MODE_HOST,
             )
         return _ValidationLaunchPlan(
             command = command,
-            env = env,
+            env = launcher_env,
             action = _VALIDATION_LAUNCH_FALLBACK,
             purpose = purpose,
             reason = "No macOS sandbox-exec adapter was available for downloaded-binary validation",
+            payload_command = command,
+            payload_env = env,
+            sandbox_kind = "macos_sandbox_exec",
+            network_policy = _VALIDATION_NETWORK_POLICY_DIRECT if purpose == _VALIDATION_PURPOSE_SERVER else _VALIDATION_NETWORK_POLICY_DIRECT,
+            server_probe_mode = _VALIDATION_SERVER_PROBE_MODE_HOST,
         )
 
     if _host_is_windows(host):
@@ -5034,6 +5238,10 @@ def build_validation_sandbox_plan(
             purpose = purpose,
             sandbox_kind = "windows_direct_validation",
             reason = "Running validation directly on Windows host",
+            payload_command = command,
+            payload_env = env,
+            network_policy = _VALIDATION_NETWORK_POLICY_DIRECT,
+            server_probe_mode = _VALIDATION_SERVER_PROBE_MODE_HOST,
         )
 
     return _ValidationLaunchPlan(
@@ -5105,6 +5313,19 @@ def _run_validation_ldd_probe(binary_path: Path, *, env: dict[str, str]) -> Linu
             status = _LINUX_LDD_PROBE_ERROR,
             missing = [],
             reason = f"ldd probe failed: {exc}",
+        )
+    if result.returncode != 0:
+        reason = result.stdout if result.stdout else ""
+        stderr = result.stderr if result.stderr else ""
+        if stderr:
+            reason = f"{reason} {stderr}" if reason else stderr
+        if not reason:
+            reason = "ldd probe failed"
+        return LinuxLibraryProbeResult(
+            status = _LINUX_LDD_PROBE_ERROR,
+            missing = [],
+            reason = reason.strip(),
+            output = result.stdout + result.stderr,
         )
     output = result.stdout + result.stderr
     return LinuxLibraryProbeResult(
@@ -5893,6 +6114,29 @@ def validate_server(
             enable_gpu_layers = _enable_gpu_layers,
             gpu_backend = gpu_backend,
         )
+        if plan.server_probe_mode == _VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX:
+            started_at = time.time()
+            result = _run_validation_capture(plan, timeout = 60)
+            output = (result.stdout or "") + (result.stderr or "")
+            if result.returncode == 0:
+                return
+            exited_quickly = (time.time() - started_at) <= SERVER_BIND_RETRY_WINDOW_SECONDS
+            failure = PrebuiltFallback("llama-server validation failed inside sandbox:\n" + output)
+            if (
+                port_attempt < SERVER_PORT_BIND_ATTEMPTS
+                and is_retryable_server_bind_error(
+                    RuntimeError(output),
+                    output,
+                    exited_quickly = exited_quickly,
+                )
+            ):
+                log(
+                    f"llama-server startup hit a port race on {port}; retrying with a fresh port "
+                    f"({port_attempt}/{SERVER_PORT_BIND_ATTEMPTS})"
+                )
+                last_failure = failure
+                continue
+            raise failure
 
         log_fd, log_name = tempfile.mkstemp(prefix = "llama-server-", suffix = ".log")
         os.close(log_fd)

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4867,7 +4867,10 @@ def _run_validation_popen(
 def linux_missing_libraries(binary_path: Path, *, env: dict[str, str] | None = None) -> list[str]:
     if env is None:
         env = scrubbed_environ()
-    probe_output = _run_validation_ldd_probe(binary_path, env = env)
+    try:
+        probe_output = _run_validation_ldd_probe(binary_path, env = env)
+    except Exception:
+        return []
     if not probe_output:
         return []
     result = subprocess.CompletedProcess(binary_path, 0, stdout = probe_output)

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4666,6 +4666,12 @@ _LINUX_LDD_PROBE_SKIPPED = "skipped"
 _LINUX_LDD_PROBE_ERROR = "error"
 _VALIDATION_SERVER_PROBE_MODE_HOST = "host_loopback_http"
 _VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX = "sandbox_loopback_http"
+_LINUX_SERVER_VALIDATION_HELPER_TIMEOUT_SECONDS = 60
+_LINUX_SERVER_VALIDATION_HELPER_SHUTDOWN_SECONDS = 5
+_LINUX_SERVER_VALIDATION_HELPER_CAPTURE_TIMEOUT_SECONDS = (
+    _LINUX_SERVER_VALIDATION_HELPER_TIMEOUT_SECONDS
+    + (2 * _LINUX_SERVER_VALIDATION_HELPER_SHUTDOWN_SECONDS)
+)
 
 
 @dataclass(frozen = True)
@@ -4702,8 +4708,15 @@ class LinuxLibraryProbeResult:
     reason: str | None = None
 
 
+def _resolve_command_path(command: str) -> str | None:
+    resolved = shutil.which(command)
+    if resolved is None:
+        return None
+    return str(Path(resolved))
+
+
 def _has_command(command: str) -> bool:
-    return shutil.which(command) is not None
+    return _resolve_command_path(command) is not None
 
 
 def _append_existing_bwrap_bind(
@@ -4733,8 +4746,7 @@ def _linux_validation_launcher_env(payload_env: dict[str, str]) -> dict[str, str
     env = scrubbed_environ()
     for key in payload_env:
         env.pop(key, None)
-    # Keep a stable base command search path; payload PATH is still injected in
-    # bwrap via --setenv from payload_env.
+    # Keep a stable base command search path.
     env["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
     return env
 
@@ -4746,8 +4758,24 @@ def _linux_validation_setenv_args(payload_env: dict[str, str]) -> list[str]:
     return args
 
 
+def _extract_loopback_port(command: list[str]) -> int:
+    for index, arg in enumerate(command):
+        if arg != "--port":
+            continue
+        if index + 1 >= len(command):
+            break
+        try:
+            return int(command[index + 1])
+        except ValueError:
+            break
+    return 0
+
+
 def _linux_validation_server_probe_command(
-    server_command: list[str], *, timeout: int = 60
+    server_command: list[str],
+    payload_env: dict[str, str],
+    *,
+    timeout: int = _LINUX_SERVER_VALIDATION_HELPER_TIMEOUT_SECONDS,
 ) -> list[str]:
     for candidate in ("/usr/bin/python3", "/usr/bin/python"):
         if Path(candidate).exists():
@@ -4760,7 +4788,6 @@ def _linux_validation_server_probe_command(
 
     probe_script = textwrap.dedent(
         f"""
-        import json
         import os
         import subprocess
         import sys
@@ -4770,6 +4797,7 @@ def _linux_validation_server_probe_command(
         import urllib.request
 
         command = {json.dumps(server_command)}
+        payload_env = {json.dumps(payload_env)}
         body = b'{{"prompt":"a","n_predict":1}}'
         timeout = {int(timeout)}
         deadline = time.time() + timeout
@@ -4798,11 +4826,14 @@ def _linux_validation_server_probe_command(
 
         try:
             with open(log_path, "w", encoding = "utf-8", errors = "replace") as log_handle:
+                server_env = dict(os.environ)
+                server_env.update(payload_env)
                 process = subprocess.Popen(
                     command,
                     stdout = log_handle,
                     stderr = subprocess.STDOUT,
                     text = True,
+                    env = server_env,
                 )
                 request = urllib.request.Request(
                     "http://127.0.0.1:%d/completion" % port,
@@ -4817,7 +4848,7 @@ def _linux_validation_server_probe_command(
                             print(line)
                         raise SystemExit(process.returncode if process.returncode else 1)
                     try:
-                        with urllib.request.urlopen(request, timeout = 1) as response:
+                        with urllib.request.urlopen(request, timeout = 5) as response:
                             _ = response.read(32)
                             if response.status == 200:
                                 process.terminate()
@@ -4861,6 +4892,7 @@ def _linux_validation_bwrap_prefix(
     binary_path: Path,
     install_dir: Path,
     purpose: str,
+    adapter_path: str,
     payload_env: dict[str, str],
     payload_command: list[str] | None = None,
     enable_gpu_layers: bool = False,
@@ -4920,13 +4952,15 @@ def _linux_validation_bwrap_prefix(
         and gpu_backend in {"cuda", "rocm"}
     )
     args = [
-        "bwrap",
+        adapter_path,
         "--unshare-all",
     ]
     args.extend(
         [
         "--die-with-parent",
         "--new-session",
+        "--perms",
+        "1777",
         "--tmpfs",
         "/tmp",
         "--proc",
@@ -4938,7 +4972,9 @@ def _linux_validation_bwrap_prefix(
         runtime_home,
         ]
     )
-    args.extend(_linux_validation_setenv_args(payload_env))
+    is_server_helper = payload_command is not None and purpose == _VALIDATION_PURPOSE_SERVER
+    if not is_server_helper:
+        args.extend(_linux_validation_setenv_args(payload_env))
 
     seen: set[str] = set()
     if enable_gpu_devices:
@@ -5018,12 +5054,11 @@ def _macos_validation_sandbox_prefix(
     runtime_home = Path(isolated_runtime_home())
     read_targets: list[str | Path] = [
         "/bin",
-        "/usr",
         "/usr/bin",
-        "/System",
-        "/Library",
-        "/System/Library/Frameworks",
         "/usr/lib",
+        "/System",
+        "/System/Library/Frameworks",
+        "/System/Library",
         install_dir,
         binary_path.parent,
         runtime_home,
@@ -5043,9 +5078,9 @@ def _macos_validation_sandbox_prefix(
     exec_targets: list[str | Path] = [
         "/bin",
         "/usr/bin",
+        "/usr/lib",
         "/System",
-        "/Library",
-        "/usr",
+        "/System/Library",
         binary_path.parent,
     ]
     profile_parts = [
@@ -5072,8 +5107,10 @@ def _macos_validation_sandbox_prefix(
             profile_parts.append(f'(subpath "{literal}")')
     profile_parts.append(")")
     if purpose == _VALIDATION_PURPOSE_SERVER:
-        profile_parts.append('(allow network* (local ip "localhost:*"))')
-        profile_parts.append('(allow network* (remote ip "localhost:*"))')
+        server_port = _extract_loopback_port(command)
+        if server_port > 0:
+            profile_parts.append(f'(allow network* (local ip "localhost:{server_port}"))')
+            profile_parts.append(f'(allow network* (remote ip "localhost:{server_port}"))')
     profile = "".join(profile_parts)
     return [
         "sandbox-exec",
@@ -5116,7 +5153,8 @@ def build_validation_sandbox_plan(
         _linux_validation_launcher_env(env) if _host_is_linux(host) else scrubbed_environ()
     )
     if _host_is_linux(host):
-        if _has_command("bwrap"):
+        bwrap_path = _resolve_command_path("bwrap")
+        if bwrap_path is not None:
             payload_command = list(command)
             network_policy = _VALIDATION_NETWORK_POLICY_SANDBOX
             server_probe_mode = (
@@ -5127,7 +5165,8 @@ def build_validation_sandbox_plan(
                 try:
                     launch_command = _linux_validation_server_probe_command(
                         payload_command,
-                        timeout = 60,
+                        env,
+                        timeout = _LINUX_SERVER_VALIDATION_HELPER_TIMEOUT_SECONDS,
                     )
                 except RuntimeError as exc:
                     return _ValidationLaunchPlan(
@@ -5147,6 +5186,7 @@ def build_validation_sandbox_plan(
                 binary_path = binary_path,
                 install_dir = install_dir,
                 purpose = purpose,
+                adapter_path = bwrap_path,
                 payload_env = env,
                 payload_command = payload_command,
                 enable_gpu_layers = enable_gpu_layers,
@@ -6125,7 +6165,10 @@ def validate_server(
         )
         if plan.server_probe_mode == _VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX:
             started_at = time.time()
-            result = _run_validation_capture(plan, timeout = 60)
+            result = _run_validation_capture(
+                plan,
+                timeout = _LINUX_SERVER_VALIDATION_HELPER_CAPTURE_TIMEOUT_SECONDS,
+            )
             output = (result.stdout or "") + (result.stderr or "")
             if result.returncode == 0:
                 return

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4802,7 +4802,7 @@ def _linux_validation_server_probe_command(
         timeout = {int(timeout)}
         deadline = time.time() + timeout
 
-        def read_tail(path: str, max_lines: int = 80) -> list[str]:
+        def read_tail(path, max_lines = 80):
             try:
                 with open(path, "r", encoding = "utf-8", errors = "replace") as handle:
                     return handle.read().splitlines()[-max_lines:]

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -42,7 +42,7 @@ try:
 except ImportError:
     FileLock = None
     FileLockTimeout = None
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Any, Callable, Iterable, Iterator, Literal, Union
 
 # Shared component-agnostic machinery lives in prebuilt_core (same directory);
@@ -6433,9 +6433,8 @@ def validate_server(
                 # For the caller that spawned this script: a validation server is
                 # its grandchild, so a crash here leaves it holding the GPU and
                 # the staged files with nothing recording where it is.
-                process_pid = getattr(process, "pid", None)
-                if process_pid is not None:
-                    _announce_child("started", process_pid)
+                if getattr(process, "pid", None) is not None:
+                    _announce_child("started", process.pid)
                 deadline = time.time() + 60
                 startup_started = time.time()
                 response_body = ""

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4749,6 +4749,32 @@ def _has_command(command: str) -> bool:
     return _resolve_command_path(command) is not None
 
 
+_bwrap_sandbox_capability: dict[str, bool] = {}
+
+
+def _bwrap_can_sandbox(bwrap_path: str) -> bool:
+    # A present bwrap is not always usable: where unprivileged user namespaces are
+    # restricted (Ubuntu >= 23.10 AppArmor default, nested/unprivileged containers,
+    # hardened cloud VMs) a non-setuid bwrap fails to set up its uid map or loopback.
+    # Probe once and cache so a broken sandbox degrades like an absent one instead of
+    # failing every prebuilt validation and forcing a source build.
+    cached = _bwrap_sandbox_capability.get(bwrap_path)
+    if cached is not None:
+        return cached
+    ok = False
+    try:
+        result = subprocess.run(
+            [bwrap_path, "--ro-bind", "/", "/", "--unshare-all", "--die-with-parent",
+             _resolve_command_path("true") or "/bin/true"],
+            stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL, timeout = 20,
+        )
+        ok = result.returncode == 0
+    except Exception:
+        ok = False
+    _bwrap_sandbox_capability[bwrap_path] = ok
+    return ok
+
+
 def _append_existing_bwrap_bind(
     args: list[str], *, source: str | Path, readonly: bool, seen: set[str]
 ) -> None:
@@ -5205,7 +5231,7 @@ def build_validation_sandbox_plan(
     )
     if _host_is_linux(host):
         bwrap_path = _resolve_command_path("bwrap")
-        if bwrap_path is not None:
+        if bwrap_path is not None and _bwrap_can_sandbox(bwrap_path):
             payload_command = _resolve_sandbox_command(command)
             if (
                 purpose == _VALIDATION_PURPOSE_SERVER

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4737,6 +4737,14 @@ def _resolve_sandbox_command(command: list[str]) -> list[str]:
     return resolved_command
 
 
+def _binary_is_setuid_root(path: str | Path) -> bool:
+    try:
+        stat_result = os.stat(path)
+    except OSError:
+        return False
+    return stat_result.st_uid == 0 and bool(stat_result.st_mode & stat.S_ISUID)
+
+
 def _has_command(command: str) -> bool:
     return _resolve_command_path(command) is not None
 
@@ -4947,6 +4955,8 @@ def _linux_validation_bwrap_prefix(
                 command_path.parent.parent / "lib64",
             ]
         )
+    if Path("/nix/store") in command_path.parents:
+        readonly_targets.append("/nix/store")
     readonly_targets.extend(
         part
         for part in payload_env.get("LD_LIBRARY_PATH", "").split(os.pathsep)
@@ -5024,7 +5034,9 @@ def _linux_validation_bwrap_prefix(
             for path in Path("/dev").glob("nvidia*"):
                 if re.match(r"^nvidia[0-9]+$", path.name):
                     dev_nodes.append(str(path))
+            dev_nodes.extend(str(path) for path in Path("/dev/nvidia-caps").glob("nvidia-cap*"))
             readonly_gpu_targets.append("/proc/driver/nvidia")
+            readonly_gpu_targets.append("/proc/driver/nvidia/capabilities")
         elif gpu_backend == "rocm":
             dev_nodes.extend(["/dev/kfd", "/dev/dxg"])
             dev_nodes.extend(str(node) for node in Path("/dev/dri").glob("card*"))
@@ -5199,6 +5211,24 @@ def build_validation_sandbox_plan(
         bwrap_path = _resolve_command_path("bwrap")
         if bwrap_path is not None:
             payload_command = _resolve_sandbox_command(command)
+            if (
+                purpose == _VALIDATION_PURPOSE_SERVER
+                and enable_gpu_layers
+                and gpu_backend in {"cuda", "rocm"}
+                and not _binary_is_setuid_root(bwrap_path)
+            ):
+                return _ValidationLaunchPlan(
+                    command = payload_command,
+                    env = launcher_env,
+                    action = _VALIDATION_LAUNCH_RUN,
+                    purpose = purpose,
+                    sandbox_kind = "linux_direct_validation",
+                    reason = "Linux GPU validation requires direct launch when bwrap is not setuid root",
+                    payload_command = payload_command,
+                    payload_env = env,
+                    network_policy = _VALIDATION_NETWORK_POLICY_DIRECT,
+                    server_probe_mode = _VALIDATION_SERVER_PROBE_MODE_HOST,
+                )
             network_policy = _VALIDATION_NETWORK_POLICY_SANDBOX
             server_probe_mode = (
                 _VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX if purpose == _VALIDATION_PURPOSE_SERVER else None
@@ -6173,7 +6203,6 @@ def validate_server(
             "windows-hip",
             "windows-vulkan",
             "windows-rocm",
-            "macos-arm64",
         }
         if install_kind is not None:
             _enable_gpu_layers = install_kind in _gpu_kinds
@@ -6185,9 +6214,9 @@ def validate_server(
             # Older call sites that don't pass install_kind: keep ROCm
             # hosts in the GPU-validation path so an AMD-only Linux host
             # is exercised against the actual hardware rather than the
-            # CPU fallback. NVIDIA and macOS-arm64 are already covered.
+            # CPU fallback. NVIDIA stays covered here.
             _enable_gpu_layers = (
-                host.has_usable_nvidia or host.has_rocm or (host.is_macos and host.is_arm64)
+                host.has_usable_nvidia or host.has_rocm
             )
             if host.is_linux and host.has_usable_nvidia:
                 gpu_backend = "cuda"

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4686,28 +4686,104 @@ def _has_command(command: str) -> bool:
     return shutil.which(command) is not None
 
 
-def _linux_validation_bwrap_prefix(binary_path: Path, install_dir: Path) -> list[str]:
+def _append_existing_bwrap_bind(
+    args: list[str],
+    *,
+    source: str | Path,
+    readonly: bool,
+    seen: set[str],
+) -> None:
+    path = Path(source)
+    if not path.exists():
+        return
+    key = str(path)
+    if key in seen:
+        return
+    seen.add(key)
+    args.extend(
+        [
+            "--ro-bind" if readonly else "--bind",
+            key,
+            key,
+        ]
+    )
+
+
+def _linux_validation_bwrap_prefix(
+    command: list[str],
+    *,
+    binary_path: Path,
+    install_dir: Path,
+    purpose: str,
+    env: dict[str, str],
+) -> list[str]:
     runtime_home = isolated_runtime_home()
-    return [
+    command_path = Path(command[0])
+    if not command_path.is_absolute():
+        resolved_command = shutil.which(command[0])
+        if resolved_command:
+            command_path = Path(resolved_command)
+
+    write_targets = {
+        str(Path(runtime_home)),
+    }
+    readonly_targets: list[str | Path] = [
+        install_dir,
+        binary_path.parent,
+        command_path.parent,
+        "/bin",
+        "/lib",
+        "/lib64",
+        "/usr/bin",
+        "/usr/lib",
+        "/usr/lib64",
+        "/etc/ld.so.cache",
+        "/etc/ld.so.conf",
+        "/etc/ld.so.conf.d",
+    ]
+    readonly_targets.extend(
+        part
+        for part in env.get("LD_LIBRARY_PATH", "").split(os.pathsep)
+        if part
+    )
+
+    if purpose == _VALIDATION_PURPOSE_QUANTIZE and len(command) >= 3:
+        readonly_targets.append(Path(command[1]).parent)
+        write_targets.add(str(Path(command[2]).parent))
+    elif purpose == _VALIDATION_PURPOSE_SERVER and len(command) >= 3 and command[1] == "-m":
+        readonly_targets.append(Path(command[2]).parent)
+
+    args = [
         "bwrap",
         "--unshare-all",
-        "--unshare-net",
+    ]
+    if purpose == _VALIDATION_PURPOSE_SERVER:
+        args.append("--share-net")
+    args.extend(
+        [
         "--die-with-parent",
         "--new-session",
         "--tmpfs",
         "/tmp",
         "--proc",
         "/proc",
+        "--dev",
+        "/dev",
         "--setenv",
         "HOME",
         runtime_home,
-        "--ro-bind",
-        str(install_dir),
-        str(install_dir),
-        "--ro-bind",
-        str(binary_path.parent),
-        str(binary_path.parent),
-    ]
+        ]
+    )
+
+    seen: set[str] = set()
+    for target in readonly_targets:
+        target_path = Path(target)
+        if str(target_path) in write_targets:
+            continue
+        _append_existing_bwrap_bind(args, source = target_path, readonly = True, seen = seen)
+    for target in sorted(write_targets):
+        _append_existing_bwrap_bind(args, source = target, readonly = False, seen = seen)
+    return args
 
 
 def _macos_validation_sandbox_prefix() -> list[str]:
@@ -4750,7 +4826,13 @@ def build_validation_sandbox_plan(
         if _has_command("bwrap"):
             return _ValidationLaunchPlan(
                 command = [
-                    *_linux_validation_bwrap_prefix(binary_path, install_dir),
+                    *_linux_validation_bwrap_prefix(
+                        command,
+                        binary_path = binary_path,
+                        install_dir = install_dir,
+                        purpose = purpose,
+                        env = env,
+                    ),
                     *command,
                 ],
                 env = env,
@@ -4822,8 +4904,11 @@ def _run_validation_capture(
 
 
 def _run_validation_ldd_probe(binary_path: Path, *, env: dict[str, str]) -> str:
+    ldd_path = shutil.which("ldd")
+    if ldd_path is None:
+        return ""
     plan = build_validation_sandbox_plan(
-        ["ldd", str(binary_path)],
+        [ldd_path, str(binary_path)],
         binary_path = binary_path,
         install_dir = binary_path.parent,
         purpose = _VALIDATION_PURPOSE_LDD,

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4786,10 +4786,94 @@ def _linux_validation_bwrap_prefix(
     return args
 
 
-def _macos_validation_sandbox_prefix(purpose: str) -> list[str]:
-    profile = "(version 1)"
-    if purpose != _VALIDATION_PURPOSE_SERVER:
-        profile = "(version 1)(deny network*)"
+def _sandbox_profile_path_literals(path: str | Path) -> list[str]:
+    raw_path = Path(path)
+    candidates: list[Path] = [raw_path]
+    try:
+        resolved = raw_path.resolve()
+    except Exception:
+        resolved = raw_path
+    if resolved not in candidates:
+        candidates.append(resolved)
+    literals: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        text = str(candidate)
+        if text in seen:
+            continue
+        seen.add(text)
+        literals.append(text.replace("\\", "\\\\").replace('"', '\\"'))
+    return literals
+
+
+def _macos_validation_sandbox_prefix(
+    command: list[str],
+    *,
+    binary_path: Path,
+    install_dir: Path,
+    purpose: str,
+    env: dict[str, str],
+) -> list[str]:
+    runtime_home = Path(isolated_runtime_home())
+    read_targets: list[str | Path] = [
+        "/",
+        "/System",
+        "/Library",
+        "/private",
+        "/dev",
+        "/usr",
+        install_dir,
+        binary_path.parent,
+        runtime_home,
+    ]
+    read_targets.extend(
+        part
+        for part in env.get("DYLD_LIBRARY_PATH", "").split(os.pathsep)
+        if part
+    )
+    write_targets: list[str | Path] = [runtime_home]
+    if purpose == _VALIDATION_PURPOSE_QUANTIZE and len(command) >= 3:
+        read_targets.append(Path(command[1]).parent)
+        write_targets.append(Path(command[2]).parent)
+    elif purpose == _VALIDATION_PURPOSE_SERVER and len(command) >= 3 and command[1] == "-m":
+        read_targets.append(Path(command[2]).parent)
+
+    exec_targets: list[str | Path] = [
+        "/bin",
+        "/usr/bin",
+        "/System",
+        "/Library",
+        "/private",
+        "/usr",
+        binary_path.parent,
+    ]
+    profile_parts = [
+        "(version 1)",
+        "(deny default)",
+        '(import "bsd.sb")',
+        "(allow process-exec",
+    ]
+    for target in exec_targets:
+        for literal in _sandbox_profile_path_literals(target):
+            profile_parts.append(f'(subpath "{literal}")')
+    profile_parts.append(")")
+    profile_parts.append("(allow file-read*")
+    for target in read_targets:
+        for literal in _sandbox_profile_path_literals(target):
+            if literal == "/":
+                profile_parts.append(f'(literal "{literal}")')
+            else:
+                profile_parts.append(f'(subpath "{literal}")')
+    profile_parts.append(")")
+    profile_parts.append("(allow file-write*")
+    for target in write_targets:
+        for literal in _sandbox_profile_path_literals(target):
+            profile_parts.append(f'(subpath "{literal}")')
+    profile_parts.append(")")
+    if purpose == _VALIDATION_PURPOSE_SERVER:
+        profile_parts.append('(allow network* (local ip "localhost:*"))')
+        profile_parts.append('(allow network* (remote ip "localhost:*"))')
+    profile = "".join(profile_parts)
     return [
         "sandbox-exec",
         "-p",
@@ -4861,7 +4945,16 @@ def build_validation_sandbox_plan(
     if _host_is_macos(host):
         if _has_command("sandbox-exec"):
             return _ValidationLaunchPlan(
-                command = [*_macos_validation_sandbox_prefix(purpose), *command],
+                command = [
+                    *_macos_validation_sandbox_prefix(
+                        command,
+                        binary_path = binary_path,
+                        install_dir = install_dir,
+                        purpose = purpose,
+                        env = env,
+                    ),
+                    *command,
+                ],
                 env = env,
                 action = _VALIDATION_LAUNCH_RUN,
                 purpose = purpose,

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -42,7 +42,7 @@ try:
 except ImportError:
     FileLock = None
     FileLockTimeout = None
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Iterable, Iterator, Literal, Union
 
 # Shared component-agnostic machinery lives in prebuilt_core (same directory);
@@ -4819,15 +4819,24 @@ def _append_existing_bwrap_bind(
     )
 
 
-def _is_broad_sandbox_library_path(path: str | Path) -> bool:
+_SANDBOX_LIBRARY_DIR_NAMES = frozenset({"lib", "lib64"})
+
+
+def _is_broad_sandbox_library_path(
+    path: str | Path, *, require_library_dir: bool = False
+) -> bool:
     candidate = Path(path)
+    resolved = _resolve_existing_path(candidate)
     if not candidate.is_absolute() and not str(candidate).startswith(("/", "\\")):
         return True
-    resolved = _resolve_existing_path(candidate)
     if len(resolved.parts) <= 2:
         return True
     if len(resolved.parts) <= 3 and resolved.parts[1].lower() in {"home", "users"}:
         return True
+    if require_library_dir:
+        parts = PurePosixPath(str(path)).parts
+        if parts[-1].lower() not in _SANDBOX_LIBRARY_DIR_NAMES:
+            return True
     try:
         if resolved == Path.home().resolve():
             return True
@@ -4836,11 +4845,14 @@ def _is_broad_sandbox_library_path(path: str | Path) -> bool:
     return False
 
 
-def _sandbox_library_path_targets(env: dict[str, str], key: str) -> list[Path]:
+def _sandbox_library_path_targets(
+    env: dict[str, str], key: str, *, require_library_dir: bool = False
+) -> list[Path]:
     return [
         _resolve_existing_path(Path(part))
         for part in env.get(key, "").split(os.pathsep)
-        if part and not _is_broad_sandbox_library_path(part)
+        if part
+        and not _is_broad_sandbox_library_path(part, require_library_dir = require_library_dir)
     ]
 
 
@@ -5184,7 +5196,9 @@ def _macos_validation_sandbox_prefix(
         binary_path.parent,
         runtime_home,
     ]
-    read_targets.extend(_sandbox_library_path_targets(env, "DYLD_LIBRARY_PATH"))
+    read_targets.extend(
+        _sandbox_library_path_targets(env, "DYLD_LIBRARY_PATH", require_library_dir = True)
+    )
     write_targets: list[str | Path] = [runtime_home]
     if purpose == _VALIDATION_PURPOSE_QUANTIZE and len(command) >= 3:
         read_targets.append(Path(command[1]).parent)
@@ -5204,9 +5218,12 @@ def _macos_validation_sandbox_prefix(
         "/usr/lib",
         "/System",
         "/System/Library",
+        install_dir,
         binary_path.parent,
     ]
-    executable_map_targets.extend(_sandbox_library_path_targets(env, "DYLD_LIBRARY_PATH"))
+    executable_map_targets.extend(
+        _sandbox_library_path_targets(env, "DYLD_LIBRARY_PATH", require_library_dir = True)
+    )
     profile_parts = [
         "(version 1)",
         "(deny default)",
@@ -6145,6 +6162,7 @@ _PYTHON_IMPORT_POINTER_VARS = (
     "PYTHONHOME",
     "PYTHONPATH",
 )
+_DYLD_ALLOWED_ENV_NAMES = frozenset({"DYLD_LIBRARY_PATH"})
 
 _isolated_runtime_home_dir: str | None = None
 
@@ -6176,6 +6194,9 @@ def scrubbed_environ() -> dict[str, str]:
         *_PYTHON_IMPORT_POINTER_VARS,
     ):
         env.pop(pointer, None)
+    for key in tuple(env):
+        if key.upper().startswith("DYLD_") and key.upper() not in _DYLD_ALLOWED_ENV_NAMES:
+            env.pop(key, None)
     return env
 
 

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5117,8 +5117,6 @@ def _linux_validation_bwrap_prefix(
             "/etc/vulkan",
             "/usr/share/vulkan",
         ]
-        dev_nodes.extend(str(node) for node in Path("/dev/dri").glob("card*"))
-        dev_nodes.extend(str(node) for node in Path("/dev/dri").glob("renderD*"))
         if gpu_backend == "cuda":
             dev_nodes.extend(
                 [

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4832,8 +4832,7 @@ def _is_broad_sandbox_library_path(path: str | Path, *, require_library_dir: boo
     if len(resolved.parts) <= 3 and resolved.parts[1].lower() in {"home", "users"}:
         return True
     if require_library_dir:
-        parts = PurePosixPath(str(path)).parts
-        if parts[-1].lower() not in _SANDBOX_LIBRARY_DIR_NAMES:
+        if resolved.name.lower() not in _SANDBOX_LIBRARY_DIR_NAMES:
             return True
     try:
         if resolved == Path.home().resolve():
@@ -5115,7 +5114,11 @@ def _linux_validation_bwrap_prefix(
             "/sys/bus/pci",
             "/sys/dev/char",
             "/sys/devices",
+            "/etc/vulkan",
+            "/usr/share/vulkan",
         ]
+        dev_nodes.extend(str(node) for node in Path("/dev/dri").glob("card*"))
+        dev_nodes.extend(str(node) for node in Path("/dev/dri").glob("renderD*"))
         if gpu_backend == "cuda":
             dev_nodes.extend(
                 [
@@ -6163,6 +6166,7 @@ _PYTHON_IMPORT_POINTER_VARS = (
     "PYTHONHOME",
     "PYTHONPATH",
 )
+_LD_ALLOWED_ENV_NAMES = frozenset({"LD_LIBRARY_PATH"})
 _DYLD_ALLOWED_ENV_NAMES = frozenset({"DYLD_LIBRARY_PATH"})
 
 _isolated_runtime_home_dir: str | None = None
@@ -6196,6 +6200,9 @@ def scrubbed_environ() -> dict[str, str]:
     ):
         env.pop(pointer, None)
     for key in tuple(env):
+        if key.upper().startswith("LD_") and key.upper() not in _LD_ALLOWED_ENV_NAMES:
+            env.pop(key, None)
+            continue
         if key.upper().startswith("DYLD_") and key.upper() not in _DYLD_ALLOWED_ENV_NAMES:
             env.pop(key, None)
     return env
@@ -6234,15 +6241,21 @@ def binary_env(
         _native_rocm = _native_linux_system_rocm_lib_dirs(str(binary_path.parent))
         if _native_rocm:
             ld_dirs = [*_native_rocm, *ld_dirs]
-        existing = [part for part in env.get("LD_LIBRARY_PATH", "").split(os.pathsep) if part]
-        # An inherited entry under a mode-000 parent or a stale NFS mount is not
-        # ours to require. The bundle's own dirs stay strict.
+        existing = [
+            str(_resolve_existing_path(Path(part)))
+            for part in env.get("LD_LIBRARY_PATH", "").split(os.pathsep)
+            if part and not _is_broad_sandbox_library_path(part)
+        ]
         required = dedupe_existing_dirs(ld_dirs)
         inherited = dedupe_existing_dirs(existing, skip_unusable = True)
         env["LD_LIBRARY_PATH"] = os.pathsep.join(dict.fromkeys([*required, *inherited]))
     elif host.is_macos:
         dyld_dirs = [str(binary_path.parent), str(install_dir)]
-        existing = [part for part in env.get("DYLD_LIBRARY_PATH", "").split(os.pathsep) if part]
+        existing = [
+            str(_resolve_existing_path(Path(part)))
+            for part in env.get("DYLD_LIBRARY_PATH", "").split(os.pathsep)
+            if part and not _is_broad_sandbox_library_path(part, require_library_dir = True)
+        ]
         required = dedupe_existing_dirs(dyld_dirs)
         inherited = dedupe_existing_dirs(existing, skip_unusable = True)
         env["DYLD_LIBRARY_PATH"] = os.pathsep.join(dict.fromkeys([*required, *inherited]))
@@ -7557,7 +7570,7 @@ def existing_install_matches_choice(
                 [runtime_dir / "llama-server", runtime_dir / "llama-quantize"],
                 install_dir,
                 host,
-                allow_skipped_probe = False,
+                allow_skipped_probe = True,
             )
         except Exception:
             return False

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4822,9 +4822,7 @@ def _append_existing_bwrap_bind(
 _SANDBOX_LIBRARY_DIR_NAMES = frozenset({"lib", "lib64"})
 
 
-def _is_broad_sandbox_library_path(
-    path: str | Path, *, require_library_dir: bool = False
-) -> bool:
+def _is_broad_sandbox_library_path(path: str | Path, *, require_library_dir: bool = False) -> bool:
     candidate = Path(path)
     resolved = _resolve_existing_path(candidate)
     if not candidate.is_absolute() and not str(candidate).startswith(("/", "\\")):
@@ -4846,7 +4844,10 @@ def _is_broad_sandbox_library_path(
 
 
 def _sandbox_library_path_targets(
-    env: dict[str, str], key: str, *, require_library_dir: bool = False
+    env: dict[str, str],
+    key: str,
+    *,
+    require_library_dir: bool = False,
 ) -> list[Path]:
     return [
         _resolve_existing_path(Path(part))

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -6431,7 +6431,9 @@ def validate_server(
                 # For the caller that spawned this script: a validation server is
                 # its grandchild, so a crash here leaves it holding the GPU and
                 # the staged files with nothing recording where it is.
-                _announce_child("started", process.pid)
+                process_pid = getattr(process, "pid", None)
+                if process_pid is not None:
+                    _announce_child("started", process_pid)
                 deadline = time.time() + 60
                 startup_started = time.time()
                 response_body = ""

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3513,7 +3513,7 @@ def test_build_validation_sandbox_plan_linux_skips_broad_inherited_library_binds
     assert not _command_has_bind(plan, "--ro-bind", Path("/home/alice"))
 
 
-def test_build_validation_sandbox_plan_linux_gpu_validation_binds_vulkan_render_nodes(
+def test_build_validation_sandbox_plan_linux_rocm_gpu_validation_binds_vulkan_render_nodes(
     monkeypatch, tmp_path
 ):
     bwrap_path = tmp_path / "bwrap"
@@ -3574,7 +3574,7 @@ def test_build_validation_sandbox_plan_linux_gpu_validation_binds_vulkan_render_
         runtime_line = None,
         env = {"LD_LIBRARY_PATH": str(binary_dir)},
         enable_gpu_layers = True,
-        gpu_backend = "cuda",
+        gpu_backend = "rocm",
     )
 
     assert plan.is_runnable

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -1122,7 +1122,8 @@ def test_binary_env_macos_strips_inherited_dyld_loader_controls(
     binary_path.write_bytes(b"fake")
 
     monkeypatch.setenv(
-        "DYLD_LIBRARY_PATH", str(runtime_lib.parent / ".." / runtime_lib.parent.name / runtime_lib.name)
+        "DYLD_LIBRARY_PATH",
+        str(runtime_lib.parent / ".." / runtime_lib.parent.name / runtime_lib.name),
     )
     monkeypatch.setenv("DYLD_INSERT_LIBRARIES", str(tmp_path / "inject.dylib"))
     monkeypatch.setenv("DYLD_FRAMEWORK_PATH", str(tmp_path / "Frameworks"))

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -991,6 +991,34 @@ def test_binary_env_strips_secrets_from_downloaded_binary_environment(
     assert env["CUDA_VISIBLE_DEVICES"] == "1"
 
 
+def test_binary_env_linux_strips_loader_injections_and_broad_inherited_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    install_dir = tmp_path / "llama.cpp"
+    bin_dir = install_dir / "build" / "bin"
+    runtime_lib = tmp_path / "runtime" / "lib"
+    runtime_lib.mkdir(parents = True)
+    bin_dir.mkdir(parents = True)
+    binary_path = bin_dir / "llama-server"
+    binary_path.write_bytes(b"fake")
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "linux_runtime_dirs", lambda _bp: [])
+    monkeypatch.setenv(
+        "LD_LIBRARY_PATH",
+        os.pathsep.join([str(Path("/")), str(runtime_lib.parent / ".." / "runtime" / "lib")]),
+    )
+    monkeypatch.setenv("LD_PRELOAD", str(tmp_path / "inject.so"))
+    monkeypatch.setenv("LD_AUDIT", str(tmp_path / "audit.so"))
+
+    env = binary_env(binary_path, install_dir, linux_host())
+
+    assert "LD_PRELOAD" not in env
+    assert "LD_AUDIT" not in env
+    ld_dirs = env["LD_LIBRARY_PATH"].split(os.pathsep)
+    assert str(Path("/")) not in ld_dirs
+    assert str(runtime_lib.resolve()) in ld_dirs
+
+
 def test_binary_env_redirects_home_away_from_real_credential_stores(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
@@ -1093,7 +1121,9 @@ def test_binary_env_macos_strips_inherited_dyld_loader_controls(
     binary_path = bin_dir / "llama-server"
     binary_path.write_bytes(b"fake")
 
-    monkeypatch.setenv("DYLD_LIBRARY_PATH", str(runtime_lib))
+    monkeypatch.setenv(
+        "DYLD_LIBRARY_PATH", str(runtime_lib.parent / ".." / runtime_lib.parent.name / runtime_lib.name)
+    )
     monkeypatch.setenv("DYLD_INSERT_LIBRARIES", str(tmp_path / "inject.dylib"))
     monkeypatch.setenv("DYLD_FRAMEWORK_PATH", str(tmp_path / "Frameworks"))
     monkeypatch.setenv("DYLD_FALLBACK_LIBRARY_PATH", str(tmp_path / "fallback"))
@@ -1103,9 +1133,10 @@ def test_binary_env_macos_strips_inherited_dyld_loader_controls(
     assert "DYLD_INSERT_LIBRARIES" not in env
     assert "DYLD_FRAMEWORK_PATH" not in env
     assert "DYLD_FALLBACK_LIBRARY_PATH" not in env
-    assert str(bin_dir) in env["DYLD_LIBRARY_PATH"].split(os.pathsep)
-    assert str(install_dir) in env["DYLD_LIBRARY_PATH"].split(os.pathsep)
-    assert str(runtime_lib) in env["DYLD_LIBRARY_PATH"].split(os.pathsep)
+    dyld_dirs = env["DYLD_LIBRARY_PATH"].split(os.pathsep)
+    assert str(bin_dir) in dyld_dirs
+    assert str(install_dir) in dyld_dirs
+    assert str(runtime_lib.resolve()) in dyld_dirs
 
 
 def test_linux_runtime_dirs_probes_with_secret_free_env(monkeypatch: pytest.MonkeyPatch):
@@ -1430,6 +1461,73 @@ def test_existing_install_matches_plan_with_fingerprint_linux(
     )
 
     assert existing_install_matches_plan(install_dir, host, plan) is True
+
+
+def test_existing_install_matches_plan_linux_allows_skipped_ldd_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    install_dir = tmp_path / "llama.cpp"
+    install_dir.mkdir()
+    write_linux_install_shape(install_dir)
+
+    choice = AssetChoice(
+        repo = "unslothai/llama.cpp",
+        tag = "release-1",
+        name = "llama-b9001-bin-ubuntu-x64.tar.gz",
+        url = "https://example.com/llama-b9001-bin-ubuntu-x64.tar.gz",
+        source_label = "upstream",
+        install_kind = "linux-cpu",
+        expected_sha256 = "a" * 64,
+    )
+    checksums = ApprovedReleaseChecksums(
+        repo = "unslothai/llama.cpp",
+        release_tag = "release-1",
+        upstream_tag = "b9001",
+        source_commit = "deadbeef",
+        artifacts = {
+            source_archive_logical_name("b9001"): ApprovedArtifactHash(
+                asset_name = source_archive_logical_name("b9001"),
+                sha256 = "b" * 64,
+                repo = "ggml-org/llama.cpp",
+                kind = "upstream-source",
+            ),
+            choice.name: ApprovedArtifactHash(
+                asset_name = choice.name,
+                sha256 = choice.expected_sha256,
+                repo = "ggml-org/llama.cpp",
+                kind = "upstream-prebuilt",
+            ),
+        },
+    )
+    plan = INSTALL_LLAMA_PREBUILT.InstallReleasePlan(
+        requested_tag = "latest",
+        llama_tag = "b9001",
+        release_tag = "release-1",
+        attempts = [choice],
+        approved_checksums = checksums,
+    )
+
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_run_validation_ldd_probe",
+        lambda _binary_path, *, env: LinuxLibraryProbeResult(
+            status = LINUX_LDD_PROBE_SKIPPED,
+            missing = [],
+            reason = "bwrap unavailable",
+        ),
+    )
+
+    write_prebuilt_metadata(
+        install_dir,
+        requested_tag = "latest",
+        llama_tag = "b9001",
+        release_tag = "release-1",
+        choice = choice,
+        approved_checksums = checksums,
+        prebuilt_fallback_used = False,
+    )
+
+    assert existing_install_matches_plan(install_dir, linux_host(), plan) is True
 
 
 def test_existing_install_matches_plan_false_without_fingerprint(tmp_path: Path):
@@ -3413,6 +3511,77 @@ def test_build_validation_sandbox_plan_linux_skips_broad_inherited_library_binds
     assert _command_has_bind(plan, "--ro-bind", runtime_lib)
     assert not _command_has_bind(plan, "--ro-bind", Path("/"))
     assert not _command_has_bind(plan, "--ro-bind", Path("/home/alice"))
+
+
+def test_build_validation_sandbox_plan_linux_gpu_validation_binds_vulkan_render_nodes(
+    monkeypatch, tmp_path
+):
+    bwrap_path = tmp_path / "bwrap"
+    bwrap_path.write_text("")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: str(bwrap_path) if command == "bwrap" else None,
+    )
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_binary_is_setuid_root", lambda _path: True)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_linux_validation_server_probe_command",
+        lambda command, payload_env, timeout = 60: command,
+    )
+    install_dir = tmp_path / "install"
+    binary_dir = tmp_path / "bin"
+    model_dir = tmp_path / "models"
+    for directory in (install_dir, binary_dir, model_dir):
+        directory.mkdir(parents = True, exist_ok = True)
+    binary_path = binary_dir / "llama-server"
+    binary_path.write_text("")
+
+    original_glob = Path.glob
+    original_exists = Path.exists
+
+    def fake_glob(path: Path, pattern: str):
+        normalized = str(path).replace("\\", "/")
+        if normalized == "/dev/dri" and pattern == "card*":
+            return [Path("/dev/dri/card0")]
+        if normalized == "/dev/dri" and pattern == "renderD*":
+            return [Path("/dev/dri/renderD128")]
+        if normalized == "/dev/nvidia-caps" and pattern == "nvidia-cap*":
+            return []
+        return original_glob(path, pattern)
+
+    def fake_exists(path: Path) -> bool:
+        normalized = str(path).replace("\\", "/")
+        if normalized in {
+            "/dev/dri",
+            "/dev/dri/card0",
+            "/dev/dri/renderD128",
+            "/etc/vulkan",
+            "/usr/share/vulkan",
+        }:
+            return True
+        return original_exists(path)
+
+    monkeypatch.setattr(Path, "glob", fake_glob)
+    monkeypatch.setattr(Path, "exists", fake_exists)
+
+    plan = build_validation_sandbox_plan(
+        ["llama-server", "-m", str(model_dir / "stories260K.gguf"), "--port", "7777"],
+        binary_path = binary_path,
+        install_dir = install_dir,
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {"LD_LIBRARY_PATH": str(binary_dir)},
+        enable_gpu_layers = True,
+        gpu_backend = "cuda",
+    )
+
+    assert plan.is_runnable
+    assert _command_has_bind(plan, "--dev-bind-try", Path("/dev/dri/card0"))
+    assert _command_has_bind(plan, "--dev-bind-try", Path("/dev/dri/renderD128"))
+    assert _command_has_bind(plan, "--ro-bind", Path("/etc/vulkan"))
+    assert _command_has_bind(plan, "--ro-bind", Path("/usr/share/vulkan"))
 
 
 def test_build_validation_sandbox_plan_linux_server_probe_uses_resolved_helper_path(

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3179,13 +3179,15 @@ def test_build_validation_sandbox_plan_linux_quantize_binds_probe_and_output(mon
 
 
 def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monkeypatch):
-    binary_path = Path("/tmp/bin/llama-server")
+    binary_path = Path("/tmp/bin/llama-quantize")
+    probe_path = Path("/tmp/models/probe.gguf")
+    output_path = Path("/tmp/out/probe-q4.gguf")
 
     monkeypatch.setattr(
         INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "sandbox-exec"
     )
     mac_run = build_validation_sandbox_plan(
-        ["llama-server", "--help"],
+        [str(binary_path), str(probe_path), str(output_path), "Q6_K", "2"],
         binary_path = binary_path,
         install_dir = Path("/tmp/install"),
         host = macos_host(),
@@ -3194,11 +3196,18 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
         env = {},
     )
     assert mac_run.is_runnable
-    assert mac_run.command[:3] == ["sandbox-exec", "-p", "(version 1)(deny network*)"]
+    assert mac_run.command[:2] == ["sandbox-exec", "-p"]
+    profile = mac_run.command[2]
+    assert "(deny default)" in profile
+    assert '(import "bsd.sb")' in profile
+    assert "tmp\\\\install" in profile
+    assert "tmp\\\\models" in profile
+    assert "tmp\\\\out" in profile
+    assert "localhost" not in profile
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
     mac_skip = build_validation_sandbox_plan(
-        ["llama-server", "--help"],
+        [str(binary_path), str(probe_path), str(output_path), "Q6_K", "2"],
         binary_path = binary_path,
         install_dir = Path("/tmp/install"),
         host = macos_host(),
@@ -3223,7 +3232,12 @@ def test_build_validation_sandbox_plan_macos_server_keeps_loopback(monkeypatch):
         env = {},
     )
     assert plan.is_runnable
-    assert plan.command[:3] == ["sandbox-exec", "-p", "(version 1)"]
+    assert plan.command[:2] == ["sandbox-exec", "-p"]
+    profile = plan.command[2]
+    assert "(deny default)" in profile
+    assert '(import "bsd.sb")' in profile
+    assert '(allow network* (local ip "localhost:*"))' in profile
+    assert '(allow network* (remote ip "localhost:*"))' in profile
 
 
 def test_build_validation_sandbox_plan_windows_is_unsupported(monkeypatch):

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3399,39 +3399,55 @@ def test_build_validation_sandbox_plan_linux_server_probe_binds_nix_store(monkey
     assert _command_contains_path(plan, "nix/store")
 
 
-def test_build_validation_sandbox_plan_linux_gpu_uses_direct_validation_without_setuid_bwrap(
-    monkeypatch, tmp_path
-):
+def test_build_validation_sandbox_plan_linux_gpu_keeps_sandbox_without_setuid_bwrap(monkeypatch, tmp_path):
     bwrap_path = tmp_path / "bwrap"
     bwrap_path.write_text("")
     binary_path = tmp_path / "llama-server"
     binary_path.write_text("")
     install_dir = tmp_path / "install"
     install_dir.mkdir()
+    helper_path = tmp_path / "python3"
+    helper_path.write_text("")
+    seen: dict[str, object] = {}
     monkeypatch.setattr(
         INSTALL_LLAMA_PREBUILT,
         "_resolve_command_path",
         lambda command: str(bwrap_path.resolve()) if command == "bwrap" else None,
     )
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_binary_is_setuid_root", lambda _path: False)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_linux_validation_server_probe_command",
+        lambda command, payload_env, timeout = 60: seen.update(
+            {
+                "command": list(command),
+                "payload_env": dict(payload_env),
+                "timeout": timeout,
+            }
+        ) or [str(helper_path), "-c", "server probe"],
+    )
 
     plan = build_validation_sandbox_plan(
-        [str(binary_path), "--help"],
+        [str(binary_path), "--port", "7777", "--n-gpu-layers", "1"],
         binary_path = binary_path,
         install_dir = install_dir,
         host = linux_host(),
         purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
         runtime_line = None,
-        env = {},
+        env = {"LD_LIBRARY_PATH": "/tmp/payload/libs"},
         enable_gpu_layers = True,
         gpu_backend = "cuda",
     )
 
     assert plan.is_runnable
-    assert plan.command == [str(binary_path), "--help"]
-    assert plan.sandbox_kind == "linux_direct_validation"
-    assert plan.network_policy == INSTALL_LLAMA_PREBUILT._VALIDATION_NETWORK_POLICY_DIRECT
-    assert plan.server_probe_mode == INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_HOST
+    assert plan.command[0] == str(bwrap_path.resolve())
+    assert plan.sandbox_kind == "linux_bwrap"
+    assert plan.network_policy == INSTALL_LLAMA_PREBUILT._VALIDATION_NETWORK_POLICY_SANDBOX
+    assert plan.server_probe_mode == INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX
+    assert seen["command"] == [str(binary_path), "--port", "7777"]
+    assert seen["payload_env"] == {"LD_LIBRARY_PATH": "/tmp/payload/libs"}
+    assert plan.payload_command == [str(binary_path), "--port", "7777"]
+    assert "--n-gpu-layers" not in plan.command
 
 
 def test_linux_validation_server_probe_command_passes_payload_env_to_server_spawn():
@@ -3819,6 +3835,7 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
     )
     assert mac_run.is_runnable
     assert mac_run.command[:2] == ["sandbox-exec", "-p"]
+    assert "/usr/bin/env" in mac_run.command
     profile = mac_run.command[2]
     assert "(deny default)" in profile
     assert '(import "bsd.sb")' in profile
@@ -3872,6 +3889,7 @@ def test_build_validation_sandbox_plan_macos_server_keeps_loopback(monkeypatch):
     )
     assert plan.is_runnable
     assert plan.command[:2] == ["sandbox-exec", "-p"]
+    assert "/usr/bin/env" in plan.command
     profile = plan.command[2]
     assert "(deny default)" in profile
     assert '(import "bsd.sb")' in profile

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3280,6 +3280,58 @@ def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch, tmp_pa
     assert str(helper_lib) in plan.command
 
 
+def test_build_validation_sandbox_plan_linux_server_probe_uses_resolved_helper_path(monkeypatch, tmp_path):
+    bwrap_path = tmp_path / "bwrap"
+    bwrap_path.write_text("")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: str(bwrap_path.resolve()) if command == "bwrap" else None,
+    )
+    helper_bin = tmp_path / "helper" / "bin"
+    helper_store = tmp_path / "nix" / "store"
+    install_dir = tmp_path / "install"
+    binary_dir = tmp_path / "bin"
+    model_dir = tmp_path / "models"
+    for directory in (helper_bin, helper_store, install_dir, binary_dir, model_dir):
+        directory.mkdir(parents = True, exist_ok = True)
+    helper_symlink = helper_bin / "python3"
+    helper_symlink.write_text("")
+    helper_target = helper_store / "python3"
+    helper_target.write_text("")
+    binary_path = binary_dir / "llama-server"
+    binary_path.write_text("")
+
+    original_resolve = Path.resolve
+
+    def fake_resolve(path: Path, strict: bool = False):
+        if path == helper_symlink:
+            return helper_target
+        return original_resolve(path, strict = strict)
+
+    monkeypatch.setattr(Path, "resolve", fake_resolve)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_linux_validation_server_probe_command",
+        lambda command, payload_env, timeout = 60: [str(helper_symlink), "-c", "server probe"],
+    )
+
+    plan = build_validation_sandbox_plan(
+        ["llama-server", "-m", str(model_dir / "stories260K.gguf"), "--port", "7777"],
+        binary_path = binary_path,
+        install_dir = install_dir,
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {"LD_LIBRARY_PATH": "/tmp/payload/libs"},
+    )
+
+    assert plan.is_runnable
+    assert str(helper_target) in plan.command
+    assert str(helper_target.parent) in plan.command
+    assert str(helper_symlink) not in plan.command
+
+
 def test_linux_validation_server_probe_command_passes_payload_env_to_server_spawn():
     probe_command = INSTALL_LLAMA_PREBUILT._linux_validation_server_probe_command(
         [
@@ -3524,6 +3576,11 @@ def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled
         gpu_backend = "cuda",
     )
     assert plan.is_runnable
+    assert "--unshare-all" not in plan.command
+    assert "--unshare-net" in plan.command
+    assert "--unshare-pid" in plan.command
+    assert "--unshare-ipc" in plan.command
+    assert "--unshare-uts" in plan.command
     assert "--dev-bind-try" in plan.command
     assert any("nvidiactl" in part for part in plan.command)
     assert any("nvidia0" in part for part in plan.command)
@@ -3591,6 +3648,11 @@ def test_build_validation_sandbox_plan_linux_server_binds_rocm_nodes_when_enable
         gpu_backend = "rocm",
     )
     assert plan.is_runnable
+    assert "--unshare-all" not in plan.command
+    assert "--unshare-net" in plan.command
+    assert "--unshare-pid" in plan.command
+    assert "--unshare-ipc" in plan.command
+    assert "--unshare-uts" in plan.command
     assert "--dev-bind-try" in plan.command
     assert any("kfd" in part for part in plan.command)
     assert any("dxg" in part for part in plan.command)
@@ -3615,13 +3677,14 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
         host = macos_host(),
         purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_QUANTIZE,
         runtime_line = None,
-        env = {},
+        env = {"DYLD_LIBRARY_PATH": "/opt/dyld"},
     )
     assert mac_run.is_runnable
     assert mac_run.command[:2] == ["sandbox-exec", "-p"]
     profile = mac_run.command[2]
     assert "(deny default)" in profile
     assert '(import "bsd.sb")' in profile
+    assert "(allow file-map-executable" in profile
     assert "(subpath \"/private\")" not in profile
     assert '(subpath "/usr")' not in profile
     assert '(subpath "/Library")' not in profile
@@ -3636,6 +3699,10 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
     assert any(
         f'(subpath "{literal}")' in profile
         for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals("/tmp/out")
+    )
+    assert any(
+        f'(subpath "{literal}")' in profile
+        for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals("/opt/dyld")
     )
     assert "localhost" not in profile
 

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -1300,7 +1300,9 @@ def write_macos_install_shape(
     (install_dir / "gguf-py" / "gguf").mkdir(parents = True, exist_ok = True)
 
 
-def test_existing_install_matches_plan_with_fingerprint_linux(tmp_path: Path):
+def test_existing_install_matches_plan_with_fingerprint_linux(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
     install_dir = tmp_path / "llama.cpp"
     install_dir.mkdir()
     write_linux_install_shape(install_dir)
@@ -1355,6 +1357,15 @@ def test_existing_install_matches_plan_with_fingerprint_linux(tmp_path: Path):
         release_tag = "release-1",
         attempts = [choice],
         approved_checksums = checksums,
+    )
+
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_run_validation_ldd_probe",
+        lambda _binary_path, *, env: LinuxLibraryProbeResult(
+            status = LINUX_LDD_PROBE_OK,
+            missing = [],
+        ),
     )
 
     write_prebuilt_metadata(
@@ -2032,6 +2043,17 @@ def test_install_prebuilt_skips_download_when_existing_install_matches(
         has_physical_nvidia = False,
         has_usable_nvidia = False,
     )
+
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_run_validation_ldd_probe",
+        lambda _binary_path, *, env: LinuxLibraryProbeResult(
+            status = LINUX_LDD_PROBE_OK,
+            missing = [],
+            reason = None,
+        ),
+    )
+
     choice = AssetChoice(
         repo = "unslothai/llama.cpp",
         tag = "release-1",
@@ -2214,6 +2236,17 @@ def test_install_prebuilt_skips_when_older_release_fallback_matches_existing_ins
         has_physical_nvidia = False,
         has_usable_nvidia = False,
     )
+
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_run_validation_ldd_probe",
+        lambda _binary_path, *, env: LinuxLibraryProbeResult(
+            status = LINUX_LDD_PROBE_OK,
+            missing = [],
+            reason = None,
+        ),
+    )
+
     latest_choice = AssetChoice(
         repo = "unslothai/llama.cpp",
         tag = "release-2",
@@ -2371,6 +2404,17 @@ def test_install_prebuilt_skips_same_release_fallback_attempt_when_installed(
         has_physical_nvidia = False,
         has_usable_nvidia = False,
     )
+
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_run_validation_ldd_probe",
+        lambda _binary_path, *, env: LinuxLibraryProbeResult(
+            status = LINUX_LDD_PROBE_OK,
+            missing = [],
+            reason = None,
+        ),
+    )
+
     first_choice = AssetChoice(
         repo = "unslothai/llama.cpp",
         tag = "release-1",
@@ -2654,7 +2698,9 @@ def add_symlink_to_tar(archive: tarfile.TarFile, name: str, target: str) -> None
     archive.addfile(info)
 
 
-def test_existing_install_matches_choice_fails_when_install_tree_incomplete(tmp_path: Path):
+def test_existing_install_matches_choice_fails_when_install_tree_incomplete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
     """confirm_install_tree guard rejects installs missing critical files."""
     install_dir = tmp_path / "llama.cpp"
     install_dir.mkdir()
@@ -2675,6 +2721,17 @@ def test_existing_install_matches_choice_fails_when_install_tree_incomplete(tmp_
         has_physical_nvidia = False,
         has_usable_nvidia = False,
     )
+
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_run_validation_ldd_probe",
+        lambda _binary_path, *, env: LinuxLibraryProbeResult(
+            status = LINUX_LDD_PROBE_OK,
+            missing = [],
+            reason = None,
+        ),
+    )
+
     choice = AssetChoice(
         repo = "unslothai/llama.cpp",
         tag = "release-1",
@@ -3155,24 +3212,129 @@ def test_build_validation_sandbox_plan_linux_without_bwrap_falls_back_validation
     assert plan.reason is not None
 
 
-def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch):
+def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch, tmp_path):
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    helper_bin = tmp_path / "helper" / "bin"
+    helper_lib = tmp_path / "helper" / "lib"
+    install_dir = tmp_path / "install"
+    binary_dir = tmp_path / "bin"
+    model_dir = tmp_path / "models"
+    for directory in (helper_bin, helper_lib, install_dir, binary_dir, model_dir):
+        directory.mkdir(parents = True, exist_ok = True)
+    helper_path = helper_bin / "python3"
+    helper_path.write_text("")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_linux_validation_server_probe_command",
+        lambda command, timeout = 60: [str(helper_path), "-c", "server probe"],
+    )
+    binary_path = binary_dir / "llama-server"
+    binary_path.write_text("")
     plan = build_validation_sandbox_plan(
-        ["llama-server", "--help"],
-        binary_path = Path("/tmp/bin/llama-server"),
-        install_dir = Path("/tmp/install"),
+        ["llama-server", "-m", str(model_dir / "stories260K.gguf"), "--port", "7777"],
+        binary_path = binary_path,
+        install_dir = install_dir,
         host = linux_host(),
         purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
         runtime_line = None,
-        env = {},
+        env = {"LD_LIBRARY_PATH": "/tmp/payload/libs"},
     )
     assert plan.is_runnable
-    assert plan.command[:5] == ["bwrap", "--unshare-all", "--share-net", "--die-with-parent", "--new-session"]
-    assert "ldd" in plan.command[-1] or "--help" in plan.command[-1]
+    assert plan.command[0] == "bwrap"
+    assert plan.command[1] == "--unshare-all"
+    assert "--share-net" not in plan.command
+    assert "--setenv" in plan.command
+    assert "LD_LIBRARY_PATH" in plan.command
+    assert plan.env.get("LD_LIBRARY_PATH") is None
+    assert plan.payload_command == [
+        "llama-server",
+        "-m",
+        str(model_dir / "stories260K.gguf"),
+        "--port",
+        "7777",
+    ]
+    assert plan.payload_env == {"LD_LIBRARY_PATH": "/tmp/payload/libs"}
     assert "--ro-bind" in plan.command
     assert "--bind" in plan.command
     assert "--dev" in plan.command
     assert "/dev/nvidiactl" not in plan.command
+    assert plan.network_policy == INSTALL_LLAMA_PREBUILT._VALIDATION_NETWORK_POLICY_SANDBOX
+    assert str(model_dir) in plan.command
+    assert str(helper_lib) in plan.command
+
+
+def test_run_validation_capture_uses_launcher_env_for_linux_bwrap(monkeypatch):
+    launcher_env = {"PATH": "/usr/bin", "UNSANDBOXABLE": "1"}
+    plan = ValidationLaunchPlan(
+        command = ["bwrap", "--unshare-all", "--die-with-parent", "--new-session"],
+        env = launcher_env,
+        action = "run",
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_QUANTIZE,
+        sandbox_kind = "linux_bwrap",
+        payload_command = ["llama-quantize", "in", "out"],
+        payload_env = {"LD_LIBRARY_PATH": "/payload/lib"},
+        server_probe_mode = None,
+    )
+
+    captured: dict[str, dict[str, str] | None] = {}
+
+    def fake_run_capture(command, *, timeout, env = None, check = False):
+        captured["env"] = dict(env or {})
+        return subprocess.CompletedProcess(command, 0, stdout = "ok")
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "run_capture", fake_run_capture)
+    result = run_validation_capture(plan, timeout = 5)
+    assert result.returncode == 0
+    assert captured["env"] == launcher_env
+    assert captured["env"] is not None
+    assert "LD_LIBRARY_PATH" not in (captured["env"] or {})
+
+
+def test_run_validation_popen_uses_launcher_env_for_linux_bwrap(monkeypatch):
+    launcher_env = {"PATH": "/usr/bin", "UNSANDBOXABLE": "1"}
+    plan = ValidationLaunchPlan(
+        command = ["bwrap", "--unshare-all", "--die-with-parent", "--new-session"],
+        env = launcher_env,
+        action = "run",
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        sandbox_kind = "linux_bwrap",
+        payload_command = ["llama-server"],
+        payload_env = {"LD_LIBRARY_PATH": "/payload/lib"},
+        server_probe_mode = INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX,
+    )
+
+    class _FakeProcess:
+        def __init__(self):
+            self.started_with: dict[str, object] = {}
+
+        def poll(self):
+            return None
+
+        def wait(self, timeout: float | None = None):
+            return 0
+
+        def terminate(self):
+            return None
+
+        def kill(self):
+            return None
+
+    fake_process = _FakeProcess()
+
+    def fake_popen(command, *, stdout, stderr, text, env = None, **_kwargs):
+        fake_process.started_with = {
+            "command": list(command),
+            "stdout": stdout,
+            "env": dict(env or {}),
+        }
+        return fake_process
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.subprocess, "Popen", fake_popen)
+    process = run_validation_popen(plan, stdout = None)
+    assert process is fake_process
+    assert fake_process.started_with["command"] == plan.command
+    assert fake_process.started_with["env"] == launcher_env
+    assert "LD_LIBRARY_PATH" not in (fake_process.started_with["env"] or {})
 
 
 def test_build_validation_sandbox_plan_linux_quantize_binds_probe_and_output(monkeypatch, tmp_path):
@@ -3350,6 +3512,7 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
     profile = mac_run.command[2]
     assert "(deny default)" in profile
     assert '(import "bsd.sb")' in profile
+    assert "(subpath \"/private\")" not in profile
     assert any(
         f'(subpath "{literal}")' in profile
         for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals("/tmp/install")
@@ -3395,6 +3558,7 @@ def test_build_validation_sandbox_plan_macos_server_keeps_loopback(monkeypatch):
     profile = plan.command[2]
     assert "(deny default)" in profile
     assert '(import "bsd.sb")' in profile
+    assert "(subpath \"/private\")" not in profile
     assert '(allow network* (local ip "localhost:*"))' in profile
     assert '(allow network* (remote ip "localhost:*"))' in profile
 
@@ -3441,6 +3605,27 @@ def test_run_validation_ldd_probe_reports_skipped_status_without_sandbox_adapter
     assert result.status == LINUX_LDD_PROBE_SKIPPED
     assert result.missing == []
     assert result.reason is not None
+
+
+def test_run_validation_ldd_probe_reports_error_on_nonzero_returncode(monkeypatch, tmp_path):
+    binary_path = tmp_path / "server"
+    binary_path.write_text("")
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT.shutil, "which", lambda name: f"/usr/bin/{name}"
+    )
+
+    def fake_capture(plan, *, timeout: int):
+        return subprocess.CompletedProcess(plan.command, 1, stdout = "", stderr = "bwrap: bind failed")
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_capture", fake_capture)
+
+    result = run_validation_ldd_probe(binary_path, env = {"LD_LIBRARY_PATH": ""})
+    assert result.status == LINUX_LDD_PROBE_ERROR
+    assert result.reason is not None
+    assert "bind failed" in result.reason
 
 
 def test_linux_missing_libraries_uses_bwrap_plan(monkeypatch, tmp_path):
@@ -3653,29 +3838,6 @@ def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
     install_dir = tmp_path
     recorded: dict[str, object] = {}
 
-    def fake_build_plan(
-        command: list[str],
-        *,
-        binary_path: Path,
-        install_dir: Path,
-        purpose: str,
-        env: dict[str, str],
-        host = None,
-        runtime_line = None,
-        enable_gpu_layers: bool = False,
-        gpu_backend = None,
-    ) -> ValidationLaunchPlan:
-        recorded["command"] = command
-        recorded["purpose"] = purpose
-        recorded["enable_gpu_layers"] = enable_gpu_layers
-        recorded["gpu_backend"] = gpu_backend
-        return ValidationLaunchPlan(
-            command = command,
-            env = env,
-            action = "run",
-            purpose = purpose,
-        )
-
     class _FakeResponse:
         status = 200
 
@@ -3706,15 +3868,55 @@ def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
     def fake_binary_env(*_a, **_k):
         return {"PATH": str(tmp_path)}
 
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", fake_binary_env)
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_popen", lambda plan, *, stdout: _FakeProcess())
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "free_local_port", lambda: 7777)
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.urllib.request, "urlopen", lambda *a, **k: _FakeResponse())
-    monkeypatch.setattr(
-        INSTALL_LLAMA_PREBUILT, "run_capture",
-        lambda *a, **k: (_ for _ in ()).throw(AssertionError("run_capture must not be used")),
-    )
+    called_popen = False
+
+    def fake_popen(*_a, **_k):
+        nonlocal called_popen
+        called_popen = True
+        return _FakeProcess()
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_popen", fake_popen)
+    called_capture = False
+
+    def fake_capture(_plan, *, timeout: int):
+        nonlocal called_capture
+        called_capture = True
+        return subprocess.CompletedProcess(_plan.command, 0, stdout = "ok")
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_capture", fake_capture)
+
+    def fake_build_plan(
+        command: list[str],
+        *,
+        binary_path: Path,
+        install_dir: Path,
+        purpose: str,
+        env: dict[str, str],
+        host = None,
+        runtime_line = None,
+        enable_gpu_layers: bool = False,
+        gpu_backend = None,
+    ) -> ValidationLaunchPlan:
+        recorded["command"] = command
+        recorded["purpose"] = purpose
+        recorded["enable_gpu_layers"] = enable_gpu_layers
+        recorded["gpu_backend"] = gpu_backend
+        recorded["server_probe_mode"] = INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX
+        return ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = "run",
+            purpose = purpose,
+            sandbox_kind = "linux_bwrap",
+            payload_command = command,
+            payload_env = env,
+            server_probe_mode = INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX,
+        )
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
 
     validate_server(
         server_path,
@@ -3730,6 +3932,9 @@ def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
     assert "--n-gpu-layers" in command
     assert recorded["enable_gpu_layers"] is True
     assert recorded["gpu_backend"] == "cuda"
+    assert called_capture is True
+    assert called_popen is False
+    assert recorded["server_probe_mode"] == INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX
 
 
 def test_validate_server_falls_back_without_linux_sandbox(monkeypatch, tmp_path):

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3332,6 +3332,98 @@ def test_build_validation_sandbox_plan_linux_server_probe_uses_resolved_helper_p
     assert str(helper_symlink) not in plan.command
 
 
+def test_build_validation_sandbox_plan_linux_server_probe_binds_nix_store(monkeypatch, tmp_path):
+    bwrap_path = tmp_path / "bwrap"
+    bwrap_path.write_text("")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: str(bwrap_path.resolve()) if command == "bwrap" else None,
+    )
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_binary_is_setuid_root", lambda _path: True)
+    install_dir = tmp_path / "install"
+    binary_dir = tmp_path / "bin"
+    model_dir = tmp_path / "models"
+    for directory in (install_dir, binary_dir, model_dir):
+        directory.mkdir(parents = True, exist_ok = True)
+    helper_symlink = tmp_path / "helper-python"
+    helper_symlink.write_text("")
+    binary_path = binary_dir / "llama-server"
+    binary_path.write_text("")
+
+    original_resolve = Path.resolve
+    original_exists = Path.exists
+
+    def fake_resolve(path: Path, strict: bool = False):
+        if path == helper_symlink:
+            return Path("/nix/store/fake-python/bin/python3")
+        return original_resolve(path, strict = strict)
+
+    def fake_exists(path: Path) -> bool:
+        normalized = str(path).replace("\\", "/")
+        if normalized in {
+            "/nix/store",
+            "/nix/store/fake-python/bin/python3",
+            "/nix/store/fake-python/bin",
+        }:
+            return True
+        return original_exists(path)
+
+    monkeypatch.setattr(Path, "resolve", fake_resolve)
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_linux_validation_server_probe_command",
+        lambda command, payload_env, timeout = 60: [str(helper_symlink), "-c", "server probe"],
+    )
+
+    plan = build_validation_sandbox_plan(
+        ["llama-server", "-m", str(model_dir / "stories260K.gguf"), "--port", "7777"],
+        binary_path = binary_path,
+        install_dir = install_dir,
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {"LD_LIBRARY_PATH": "/tmp/payload/libs"},
+    )
+
+    assert plan.is_runnable
+    assert _command_contains_path(plan, "nix/store")
+
+
+def test_build_validation_sandbox_plan_linux_gpu_uses_direct_validation_without_setuid_bwrap(monkeypatch, tmp_path):
+    bwrap_path = tmp_path / "bwrap"
+    bwrap_path.write_text("")
+    binary_path = tmp_path / "llama-server"
+    binary_path.write_text("")
+    install_dir = tmp_path / "install"
+    install_dir.mkdir()
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: str(bwrap_path.resolve()) if command == "bwrap" else None,
+    )
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_binary_is_setuid_root", lambda _path: False)
+
+    plan = build_validation_sandbox_plan(
+        [str(binary_path), "--help"],
+        binary_path = binary_path,
+        install_dir = install_dir,
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {},
+        enable_gpu_layers = True,
+        gpu_backend = "cuda",
+    )
+
+    assert plan.is_runnable
+    assert plan.command == [str(binary_path), "--help"]
+    assert plan.sandbox_kind == "linux_direct_validation"
+    assert plan.network_policy == INSTALL_LLAMA_PREBUILT._VALIDATION_NETWORK_POLICY_DIRECT
+    assert plan.server_probe_mode == INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_HOST
+
+
 def test_linux_validation_server_probe_command_passes_payload_env_to_server_spawn():
     probe_command = INSTALL_LLAMA_PREBUILT._linux_validation_server_probe_command(
         [
@@ -3521,12 +3613,14 @@ def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled
         "_resolve_command_path",
         lambda command: "/tmp/bin/bwrap" if command == "bwrap" else None,
     )
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_binary_is_setuid_root", lambda _path: True)
     existing_nodes = {
         "/dev/nvidiactl",
         "/dev/nvidia-uvm",
         "/dev/nvidia-uvm-tools",
         "/dev/nvidia-modeset",
         "/dev/nvidia0",
+        "/dev/nvidia-caps/nvidia-cap1",
         "/dev/kfd",
         "/dev/dxg",
         "/dev/dri/card0",
@@ -3536,6 +3630,7 @@ def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled
         "/sys/dev/char",
         "/sys/devices",
         "/proc/driver/nvidia",
+        "/proc/driver/nvidia/capabilities",
     }
     original_exists = Path.exists
     original_glob = Path.glob
@@ -3555,6 +3650,8 @@ def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled
         normalized = _norm(path)
         if normalized == "/dev" and pattern == "nvidia*":
             return [Path(node) for node in existing_nodes if str(node).startswith("/dev/nvidia") and "*" not in node]
+        if normalized == "/dev/nvidia-caps" and pattern == "nvidia-cap*":
+            return [Path("/dev/nvidia-caps/nvidia-cap1")]
         if normalized == "/dev/dri" and pattern == "card*":
             return [Path("/dev/dri/card0")]
         if normalized == "/dev/dri" and pattern == "renderD*":
@@ -3584,12 +3681,14 @@ def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled
     assert "--dev-bind-try" in plan.command
     assert any("nvidiactl" in part for part in plan.command)
     assert any("nvidia0" in part for part in plan.command)
+    assert any("nvidia-cap1" in part for part in plan.command)
     assert not any("dxg" in part for part in plan.command)
     assert not _command_contains_path(plan, "dri/card0")
     assert not _command_contains_path(plan, "dri/renderD128")
     assert not any("kfd" in part for part in plan.command)
     assert _command_contains_path(plan, "sys/class/drm")
     assert _command_contains_path(plan, "proc/driver/nvidia")
+    assert _command_contains_path(plan, "proc/driver/nvidia/capabilities")
 
 
 def test_build_validation_sandbox_plan_linux_server_binds_rocm_nodes_when_enabled(monkeypatch, tmp_path):
@@ -3598,6 +3697,7 @@ def test_build_validation_sandbox_plan_linux_server_binds_rocm_nodes_when_enable
         "_resolve_command_path",
         lambda command: "/tmp/bin/bwrap" if command == "bwrap" else None,
     )
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_binary_is_setuid_root", lambda _path: True)
     existing_nodes = {
         "/dev/kfd",
         "/dev/dxg",
@@ -4192,6 +4292,56 @@ def test_validate_server_uses_extended_capture_timeout_for_in_sandbox_probe(monk
     assert isinstance(captured_timeout, int)
     assert captured_timeout == INSTALL_LLAMA_PREBUILT._LINUX_SERVER_VALIDATION_HELPER_CAPTURE_TIMEOUT_SECONDS
     assert captured_timeout > INSTALL_LLAMA_PREBUILT._LINUX_SERVER_VALIDATION_HELPER_TIMEOUT_SECONDS
+
+
+def test_validate_server_skips_gpu_layers_for_macos_arm64(monkeypatch, tmp_path):
+    server_path = tmp_path / "llama-server"
+    server_path.write_text("")
+    probe_path = tmp_path / "probe.gguf"
+    probe_path.write_text("")
+    recorded: dict[str, object] = {}
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", lambda *_a, **_k: {"PATH": str(tmp_path)})
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "free_local_port", lambda: 7777)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.urllib.request, "urlopen", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("stop")))
+
+    def fake_build_plan(
+        command: list[str],
+        *,
+        binary_path: Path,
+        install_dir: Path,
+        purpose: str,
+        env: dict[str, str],
+        host = None,
+        runtime_line = None,
+        enable_gpu_layers: bool = False,
+        gpu_backend = None,
+    ) -> ValidationLaunchPlan:
+        recorded["command"] = command
+        recorded["enable_gpu_layers"] = enable_gpu_layers
+        return ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = "fallback",
+            purpose = purpose,
+            reason = "stop",
+        )
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
+
+    with pytest.raises(PrebuiltFallback, match = "stop"):
+        validate_server(
+            server_path,
+            probe_path,
+            macos_host(),
+            tmp_path,
+            runtime_line = None,
+            install_kind = "macos-arm64",
+        )
+
+    command = recorded["command"]
+    assert "--n-gpu-layers" not in command
+    assert recorded["enable_gpu_layers"] is False
 
 
 def test_validate_server_falls_back_without_linux_sandbox(monkeypatch, tmp_path):

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -2,6 +2,7 @@ import errno
 import importlib.util
 import io
 import json
+import re
 import os
 import sys
 import subprocess
@@ -49,6 +50,14 @@ linux_missing_libraries = INSTALL_LLAMA_PREBUILT.linux_missing_libraries
 ValidationLaunchPlan = INSTALL_LLAMA_PREBUILT._ValidationLaunchPlan
 run_validation_capture = INSTALL_LLAMA_PREBUILT._run_validation_capture
 run_validation_popen = INSTALL_LLAMA_PREBUILT._run_validation_popen
+run_validation_ldd_probe = INSTALL_LLAMA_PREBUILT._run_validation_ldd_probe
+LinuxLibraryProbeResult = INSTALL_LLAMA_PREBUILT.LinuxLibraryProbeResult
+LINUX_LDD_PROBE_OK = INSTALL_LLAMA_PREBUILT._LINUX_LDD_PROBE_OK
+LINUX_LDD_PROBE_SKIPPED = INSTALL_LLAMA_PREBUILT._LINUX_LDD_PROBE_SKIPPED
+LINUX_LDD_PROBE_ERROR = INSTALL_LLAMA_PREBUILT._LINUX_LDD_PROBE_ERROR
+preflight_linux_installed_binaries = (
+    INSTALL_LLAMA_PREBUILT.preflight_linux_installed_binaries
+)
 
 
 def linux_host() -> HostInfo:
@@ -1070,11 +1079,15 @@ def test_binary_env_drops_explicit_credential_file_pointers(
 def test_linux_runtime_dirs_probes_with_secret_free_env(monkeypatch: pytest.MonkeyPatch):
     captured: dict[str, object] = {}
 
-    def fake_missing(binary_path, *, env = None):
+    def fake_probe(binary_path, *, env = None):
         captured["env"] = env
-        return []
+        return LinuxLibraryProbeResult(
+            status = LINUX_LDD_PROBE_OK,
+            missing = [],
+            output = "",
+        )
 
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "linux_missing_libraries", fake_missing)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_ldd_probe", fake_probe)
     monkeypatch.setenv("HF_TOKEN", "hf_secret")
     monkeypatch.setenv("GITHUB_TOKEN", "gh_secret")
 
@@ -1084,6 +1097,13 @@ def test_linux_runtime_dirs_probes_with_secret_free_env(monkeypatch: pytest.Monk
     assert probe_env is not None
     assert "HF_TOKEN" not in probe_env
     assert "GITHUB_TOKEN" not in probe_env
+
+
+def _command_contains_path(plan: ValidationLaunchPlan, path_fragment: str) -> bool:
+    return any(
+        path_fragment in command_part or path_fragment in command_part.replace("\\", "/")
+        for command_part in plan.command
+    )
 
 
 def test_install_prebuilt_falls_back_to_older_release_plan(
@@ -3150,8 +3170,9 @@ def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch):
     assert plan.command[:5] == ["bwrap", "--unshare-all", "--share-net", "--die-with-parent", "--new-session"]
     assert "ldd" in plan.command[-1] or "--help" in plan.command[-1]
     assert "--ro-bind" in plan.command
-    assert "--dev" in plan.command
     assert "--bind" in plan.command
+    assert "--dev" in plan.command
+    assert "/dev/nvidiactl" not in plan.command
 
 
 def test_build_validation_sandbox_plan_linux_quantize_binds_probe_and_output(monkeypatch, tmp_path):
@@ -3176,6 +3197,135 @@ def test_build_validation_sandbox_plan_linux_quantize_binds_probe_and_output(mon
     assert plan.command.count("--bind") >= 2
     assert str(probe_dir) in plan.command
     assert str(out_dir) in plan.command
+
+
+def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled(monkeypatch, tmp_path):
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    existing_nodes = {
+        "/dev/nvidiactl",
+        "/dev/nvidia-uvm",
+        "/dev/nvidia-uvm-tools",
+        "/dev/nvidia-modeset",
+        "/dev/nvidia0",
+        "/dev/kfd",
+        "/dev/dxg",
+        "/dev/dri/card0",
+        "/dev/dri/renderD128",
+        "/sys/class/drm",
+        "/sys/bus/pci",
+        "/sys/dev/char",
+        "/sys/devices",
+        "/proc/driver/nvidia",
+    }
+    original_exists = Path.exists
+    original_glob = Path.glob
+
+    def _norm(path: Path) -> str:
+        text = str(path).replace("\\", "/")
+        if re.match(r"^[A-Za-z]:/", text):
+            text = "/" + text.split(":", 1)[1].lstrip("/")
+        return text
+
+    def fake_exists(path: Path) -> bool:
+        if _norm(path) in existing_nodes:
+            return True
+        return original_exists(path)
+
+    def fake_glob(path: Path, pattern: str):
+        normalized = _norm(path)
+        if normalized == "/dev" and pattern == "nvidia*":
+            return [Path(node) for node in existing_nodes if str(node).startswith("/dev/nvidia") and "*" not in node]
+        if normalized == "/dev/dri" and pattern == "card*":
+            return [Path("/dev/dri/card0")]
+        if normalized == "/dev/dri" and pattern == "renderD*":
+            return [Path("/dev/dri/renderD128")]
+        return original_glob(path, pattern)
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    monkeypatch.setattr(Path, "glob", fake_glob)
+
+    plan = build_validation_sandbox_plan(
+        ["llama-server", "--help"],
+        binary_path = Path("/tmp/bin/llama-server"),
+        install_dir = Path("/tmp/install"),
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {},
+        enable_gpu_layers = True,
+        gpu_backend = "cuda",
+    )
+    assert plan.is_runnable
+    assert "--dev-bind-try" in plan.command
+    assert any("nvidiactl" in part for part in plan.command)
+    assert any("nvidia0" in part for part in plan.command)
+    assert not any("dxg" in part for part in plan.command)
+    assert not _command_contains_path(plan, "dri/card0")
+    assert not _command_contains_path(plan, "dri/renderD128")
+    assert not any("kfd" in part for part in plan.command)
+    assert _command_contains_path(plan, "sys/class/drm")
+    assert _command_contains_path(plan, "proc/driver/nvidia")
+
+
+def test_build_validation_sandbox_plan_linux_server_binds_rocm_nodes_when_enabled(monkeypatch, tmp_path):
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    existing_nodes = {
+        "/dev/kfd",
+        "/dev/dxg",
+        "/dev/dri/card0",
+        "/dev/dri/renderD128",
+        "/sys/class/drm",
+        "/sys/bus/pci",
+        "/sys/dev/char",
+        "/sys/devices",
+        "/proc/driver/nvidia",
+    }
+    original_exists = Path.exists
+    original_glob = Path.glob
+
+    def _norm(path: Path) -> str:
+        text = str(path).replace("\\", "/")
+        if re.match(r"^[A-Za-z]:/", text):
+            text = "/" + text.split(":", 1)[1].lstrip("/")
+        return text
+
+    def fake_exists(path: Path) -> bool:
+        if _norm(path) in existing_nodes:
+            return True
+        return original_exists(path)
+
+    def fake_glob(path: Path, pattern: str):
+        normalized = _norm(path)
+        if normalized == "/dev" and pattern == "nvidia*":
+            return []
+        if normalized == "/dev/dri" and pattern == "card*":
+            return [Path("/dev/dri/card0")]
+        if normalized == "/dev/dri" and pattern == "renderD*":
+            return [Path("/dev/dri/renderD128")]
+        return original_glob(path, pattern)
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    monkeypatch.setattr(Path, "glob", fake_glob)
+
+    plan = build_validation_sandbox_plan(
+        ["llama-server", "--help"],
+        binary_path = Path("/tmp/bin/llama-server"),
+        install_dir = Path("/tmp/install"),
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {},
+        enable_gpu_layers = True,
+        gpu_backend = "rocm",
+    )
+    assert plan.is_runnable
+    assert "--dev-bind-try" in plan.command
+    assert any("kfd" in part for part in plan.command)
+    assert any("dxg" in part for part in plan.command)
+    assert _command_contains_path(plan, "dri/card0")
+    assert _command_contains_path(plan, "dri/renderD128")
+    assert not any("nvidiactl" in part for part in plan.command)
+    assert not _command_contains_path(plan, "proc/driver/nvidia")
 
 
 def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monkeypatch):
@@ -3259,13 +3409,15 @@ def test_build_validation_sandbox_plan_windows_is_unsupported(monkeypatch):
         runtime_line = None,
         env = {},
     )
-    assert plan.is_fallback
-    assert "unsupported" in (plan.reason or "").lower()
+    assert plan.is_runnable
+    assert plan.sandbox_kind == "windows_direct_validation"
+    assert "running validation directly" in (plan.reason or "").lower()
 
 
 def test_linux_missing_libraries_skips_ldd_without_sandbox_adapter(monkeypatch, tmp_path):
     binary_path = tmp_path / "server"
     binary_path.write_text("")
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
 
     captured: dict[str, bool] = {"run": False}
@@ -3278,6 +3430,17 @@ def test_linux_missing_libraries_skips_ldd_without_sandbox_adapter(monkeypatch, 
     missing = linux_missing_libraries(binary_path, env = {"LD_LIBRARY_PATH": ""})
     assert missing == []
     assert captured["run"] is False
+
+
+def test_run_validation_ldd_probe_reports_skipped_status_without_sandbox_adapter(monkeypatch, tmp_path):
+    binary_path = tmp_path / "server"
+    binary_path.write_text("")
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
+    result = run_validation_ldd_probe(binary_path, env = {"LD_LIBRARY_PATH": ""})
+    assert result.status == LINUX_LDD_PROBE_SKIPPED
+    assert result.missing == []
+    assert result.reason is not None
 
 
 def test_linux_missing_libraries_uses_bwrap_plan(monkeypatch, tmp_path):
@@ -3308,11 +3471,85 @@ def test_linux_missing_libraries_tolerates_probe_errors(monkeypatch, tmp_path):
     binary_path = tmp_path / "server"
     binary_path.write_text("")
 
-    def fake_probe(_binary_path: Path, *, env: dict[str, str]) -> str:
-        raise RuntimeError("probe failed")
+    def fake_probe(_binary_path: Path, *, env: dict[str, str]) -> LinuxLibraryProbeResult:
+        return LinuxLibraryProbeResult(
+            status = LINUX_LDD_PROBE_ERROR,
+            missing = [],
+            reason = "probe crashed",
+        )
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_ldd_probe", fake_probe)
     assert linux_missing_libraries(binary_path, env = {"LD_LIBRARY_PATH": ""}) == []
+
+
+def test_preflight_linux_installed_binaries_skips_unknown_when_probe_skipped(monkeypatch, tmp_path):
+    host = linux_host()
+    binary = tmp_path / "llama-server"
+    binary.write_text("")
+
+    def fake_probe(_binary_path: Path, *, env: dict[str, str]) -> LinuxLibraryProbeResult:
+        return LinuxLibraryProbeResult(
+            status = LINUX_LDD_PROBE_SKIPPED,
+            missing = [],
+            reason = "no sandbox adapter",
+        )
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_ldd_probe", fake_probe)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "binary_env",
+        lambda binary_path, install_dir, host: {"LD_LIBRARY_PATH": ""},
+    )
+    preflight_linux_installed_binaries((binary,), tmp_path, host)
+
+
+def test_preflight_linux_installed_binaries_rejects_skipped_probe_for_reuse(monkeypatch, tmp_path):
+    host = linux_host()
+    binary = tmp_path / "llama-server"
+    binary.write_text("")
+
+    def fake_probe(_binary_path: Path, *, env: dict[str, str]) -> LinuxLibraryProbeResult:
+        return LinuxLibraryProbeResult(
+            status = LINUX_LDD_PROBE_SKIPPED,
+            missing = [],
+            reason = "no sandbox adapter",
+        )
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_ldd_probe", fake_probe)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "binary_env",
+        lambda binary_path, install_dir, host: {"LD_LIBRARY_PATH": ""},
+    )
+    with pytest.raises(PrebuiltFallback, match = "linux ldd probe skipped"):
+        preflight_linux_installed_binaries(
+            (binary,),
+            tmp_path,
+            host,
+            allow_skipped_probe = False,
+        )
+
+
+def test_preflight_linux_installed_binaries_errors_on_probe_exception(monkeypatch, tmp_path):
+    host = linux_host()
+    binary = tmp_path / "llama-server"
+    binary.write_text("")
+
+    def fake_probe(_binary_path: Path, *, env: dict[str, str]) -> LinuxLibraryProbeResult:
+        return LinuxLibraryProbeResult(
+            status = LINUX_LDD_PROBE_ERROR,
+            missing = [],
+            reason = "probe crashed",
+        )
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_ldd_probe", fake_probe)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "binary_env",
+        lambda binary_path, install_dir, host: {"LD_LIBRARY_PATH": ""},
+    )
+    with pytest.raises(PrebuiltFallback, match = "linux extracted binary ldd probe errored"):
+        preflight_linux_installed_binaries((binary,), tmp_path, host)
 
 
 def test_validate_quantize_routes_through_sandbox_plan(monkeypatch, tmp_path):
@@ -3334,6 +3571,8 @@ def test_validate_quantize_routes_through_sandbox_plan(monkeypatch, tmp_path):
         env: dict[str, str],
         host = None,
         runtime_line = None,
+        enable_gpu_layers: bool = False,
+        gpu_backend = None,
     ) -> ValidationLaunchPlan:
         recorded["command"] = command
         recorded["purpose"] = purpose
@@ -3381,6 +3620,8 @@ def test_validate_quantize_falls_back_without_linux_sandbox(monkeypatch, tmp_pat
         env: dict[str, str],
         host = None,
         runtime_line = None,
+        enable_gpu_layers: bool = False,
+        gpu_backend = None,
     ) -> ValidationLaunchPlan:
         return ValidationLaunchPlan(
             command = command,
@@ -3421,9 +3662,13 @@ def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
         env: dict[str, str],
         host = None,
         runtime_line = None,
+        enable_gpu_layers: bool = False,
+        gpu_backend = None,
     ) -> ValidationLaunchPlan:
         recorded["command"] = command
         recorded["purpose"] = purpose
+        recorded["enable_gpu_layers"] = enable_gpu_layers
+        recorded["gpu_backend"] = gpu_backend
         return ValidationLaunchPlan(
             command = command,
             env = env,
@@ -3483,6 +3728,8 @@ def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
     command = recorded["command"]
     assert command[:3] == [str(server_path), "-m", str(probe_path)]
     assert "--n-gpu-layers" in command
+    assert recorded["enable_gpu_layers"] is True
+    assert recorded["gpu_backend"] == "cuda"
 
 
 def test_validate_server_falls_back_without_linux_sandbox(monkeypatch, tmp_path):
@@ -3500,6 +3747,8 @@ def test_validate_server_falls_back_without_linux_sandbox(monkeypatch, tmp_path)
         env: dict[str, str],
         host = None,
         runtime_line = None,
+        enable_gpu_layers: bool = False,
+        gpu_backend = None,
     ) -> ValidationLaunchPlan:
         return ValidationLaunchPlan(
             command = command,
@@ -3515,11 +3764,84 @@ def test_validate_server_falls_back_without_linux_sandbox(monkeypatch, tmp_path)
         validate_server(
             server_path,
             probe_path,
-            windows_host(),
+            linux_host(),
             tmp_path,
             runtime_line = None,
             install_kind = None,
         )
+
+
+def test_validate_server_uses_windows_direct_validation_plan(monkeypatch, tmp_path):
+    server_path = tmp_path / "llama-server.exe"
+    server_path.write_text("")
+    probe_path = tmp_path / "probe.gguf"
+    probe_path.write_text("")
+    recorded: dict[str, object] = {}
+
+    def fake_build_plan(
+        command: list[str],
+        *,
+        binary_path: Path,
+        install_dir: Path,
+        purpose: str,
+        env: dict[str, str],
+        host = None,
+        runtime_line = None,
+        enable_gpu_layers: bool = False,
+        gpu_backend = None,
+    ) -> ValidationLaunchPlan:
+        recorded["plan"] = ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = "run",
+            purpose = purpose,
+            sandbox_kind = "windows_direct_validation",
+        )
+        return recorded["plan"]
+
+    class _FakeProcess:
+        def poll(self):
+            return None
+
+        def wait(self, timeout: float | None = None):
+            return 0
+
+        def terminate(self):
+            return None
+
+        def kill(self):
+            return None
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", lambda *_a, **_k: {"PATH": str(tmp_path)})
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_popen", lambda plan, *, stdout: _FakeProcess())
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "free_local_port", lambda: 7777)
+
+    class _FakeResponse:
+        status = 200
+
+        def read(self):
+            return b"{}"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.urllib.request, "urlopen", lambda *a, **k: _FakeResponse())
+
+    validate_server(
+        server_path,
+        probe_path,
+        windows_host(),
+        tmp_path,
+        runtime_line = None,
+        install_kind = "windows-cuda",
+    )
+    plan = recorded["plan"]
+    assert isinstance(plan, ValidationLaunchPlan)
+    assert plan.sandbox_kind == "windows_direct_validation"
 
 
 def test_runtime_inference_path_stays_outside_installer_sandbox_owner():
@@ -3560,6 +3882,8 @@ def _run_validate_prebuilt_choice(monkeypatch, tmp_path, *, expected_sha256):
         env: dict[str, str],
         host = None,
         runtime_line = None,
+        enable_gpu_layers: bool = False,
+        gpu_backend = None,
     ) -> ValidationLaunchPlan:
         plans.append(purpose)
         return ValidationLaunchPlan(

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3337,6 +3337,63 @@ def test_run_validation_popen_uses_launcher_env_for_linux_bwrap(monkeypatch):
     assert "LD_LIBRARY_PATH" not in (fake_process.started_with["env"] or {})
 
 
+def test_validate_server_strips_python_import_roots_from_payload_env(monkeypatch, tmp_path):
+    server_path = tmp_path / "llama-server"
+    server_path.write_text("")
+    probe_path = tmp_path / "probe.gguf"
+    probe_path.write_text("")
+    recorded: dict[str, object] = {}
+
+    monkeypatch.setenv("PYTHONHOME", "/host/python")
+    monkeypatch.setenv("PYTHONPATH", "/host/site-packages")
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "linux_runtime_dirs", lambda _binary_path: [])
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "free_local_port", lambda: 7777)
+
+    def fake_build_plan(
+        command: list[str],
+        *,
+        binary_path: Path,
+        install_dir: Path,
+        purpose: str,
+        env: dict[str, str],
+        host = None,
+        runtime_line = None,
+        enable_gpu_layers: bool = False,
+        gpu_backend = None,
+    ) -> ValidationLaunchPlan:
+        recorded["env"] = dict(env)
+        return ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = "run",
+            purpose = purpose,
+            server_probe_mode = INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX,
+        )
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_run_validation_capture",
+        lambda plan, *, timeout: subprocess.CompletedProcess(
+            plan.command, 0, stdout = "ok", stderr = ""
+        ),
+    )
+
+    validate_server(
+        server_path,
+        probe_path,
+        linux_host(),
+        tmp_path,
+        runtime_line = "cuda13",
+        install_kind = "linux-cuda",
+    )
+
+    env = recorded["env"]
+    assert isinstance(env, dict)
+    assert "PYTHONHOME" not in env
+    assert "PYTHONPATH" not in env
+
+
 def test_build_validation_sandbox_plan_linux_quantize_binds_probe_and_output(monkeypatch, tmp_path):
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
     bin_dir = tmp_path / "bin"

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3238,6 +3238,17 @@ def test_linux_missing_libraries_uses_bwrap_plan(monkeypatch, tmp_path):
     assert "ldd" in captured["command"]
 
 
+def test_linux_missing_libraries_tolerates_probe_errors(monkeypatch, tmp_path):
+    binary_path = tmp_path / "server"
+    binary_path.write_text("")
+
+    def fake_probe(_binary_path: Path, *, env: dict[str, str]) -> str:
+        raise RuntimeError("probe failed")
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_ldd_probe", fake_probe)
+    assert linux_missing_libraries(binary_path, env = {"LD_LIBRARY_PATH": ""}) == []
+
+
 def test_validate_quantize_routes_through_sandbox_plan(monkeypatch, tmp_path):
     quantize_path = tmp_path / "llama-quantize"
     quantize_path.write_text("")

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3286,6 +3286,7 @@ def test_linux_missing_libraries_uses_bwrap_plan(monkeypatch, tmp_path):
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.shutil, "which", lambda name: f"/usr/bin/{name}")
     captured = {}
 
     def fake_run_capture(command, *, timeout, env = None, check = False):

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3365,6 +3365,45 @@ def test_validate_quantize_routes_through_sandbox_plan(monkeypatch, tmp_path):
     assert quantized_path.exists()
 
 
+def test_validate_quantize_falls_back_without_linux_sandbox(monkeypatch, tmp_path):
+    quantize_path = tmp_path / "llama-quantize"
+    quantize_path.write_text("")
+    probe_path = tmp_path / "probe.gguf"
+    probe_path.write_text("")
+    quantized_path = tmp_path / "probe-q4.gguf"
+
+    def fake_build_plan(
+        command: list[str],
+        *,
+        binary_path: Path,
+        install_dir: Path,
+        purpose: str,
+        env: dict[str, str],
+        host = None,
+        runtime_line = None,
+    ) -> ValidationLaunchPlan:
+        return ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = "fallback",
+            purpose = purpose,
+            reason = "no sandbox",
+        )
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", lambda *_a, **_k: {"PATH": str(tmp_path)})
+
+    with pytest.raises(PrebuiltFallback, match = "no sandbox"):
+        validate_quantize(
+            quantize_path,
+            probe_path,
+            quantized_path,
+            tmp_path,
+            linux_host(),
+            runtime_line = None,
+        )
+
+
 def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
     server_path = tmp_path / "llama-server"
     server_path.write_text("")

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3147,9 +3147,35 @@ def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch):
         env = {},
     )
     assert plan.is_runnable
-    assert plan.command[:5] == ["bwrap", "--unshare-all", "--unshare-net", "--die-with-parent", "--new-session"]
+    assert plan.command[:5] == ["bwrap", "--unshare-all", "--share-net", "--die-with-parent", "--new-session"]
     assert "ldd" in plan.command[-1] or "--help" in plan.command[-1]
     assert "--ro-bind" in plan.command
+    assert "--dev" in plan.command
+    assert "--bind" in plan.command
+
+
+def test_build_validation_sandbox_plan_linux_quantize_binds_probe_and_output(monkeypatch, tmp_path):
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    bin_dir = tmp_path / "bin"
+    probe_dir = tmp_path / "models"
+    out_dir = tmp_path / "out"
+    runtime_dir = tmp_path / "runtime"
+    for directory in (bin_dir, probe_dir, out_dir, runtime_dir):
+        directory.mkdir()
+    plan = build_validation_sandbox_plan(
+        [str(bin_dir / "llama-quantize"), str(probe_dir / "probe.gguf"), str(out_dir / "probe-q4.gguf"), "Q6_K", "2"],
+        binary_path = bin_dir / "llama-quantize",
+        install_dir = tmp_path / "install",
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_QUANTIZE,
+        runtime_line = None,
+        env = {"LD_LIBRARY_PATH": str(runtime_dir)},
+    )
+    assert plan.is_runnable
+    assert plan.command.count("--ro-bind") >= 3
+    assert plan.command.count("--bind") >= 2
+    assert str(probe_dir) in plan.command
+    assert str(out_dir) in plan.command
 
 
 def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monkeypatch):
@@ -3217,7 +3243,6 @@ def test_linux_missing_libraries_skips_ldd_without_sandbox_adapter(monkeypatch, 
 def test_linux_missing_libraries_uses_bwrap_plan(monkeypatch, tmp_path):
     binary_path = tmp_path / "server"
     binary_path.write_text("")
-    install_dir = tmp_path
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
@@ -3235,7 +3260,7 @@ def test_linux_missing_libraries_uses_bwrap_plan(monkeypatch, tmp_path):
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "run_capture", fake_run_capture)
     assert linux_missing_libraries(binary_path, env = {"LD_LIBRARY_PATH": ""}) == ["libbad"]
     assert captured["command"][0] == "bwrap"
-    assert "ldd" in captured["command"]
+    assert any(Path(part).stem == "ldd" for part in captured["command"])
 
 
 def test_linux_missing_libraries_tolerates_probe_errors(monkeypatch, tmp_path):

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -1082,6 +1082,32 @@ def test_binary_env_drops_explicit_credential_file_pointers(
         assert var not in env
 
 
+def test_binary_env_macos_strips_inherited_dyld_loader_controls(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    install_dir = tmp_path / "llama.cpp"
+    bin_dir = install_dir / "build" / "bin"
+    runtime_lib = tmp_path / "runtime" / "lib"
+    runtime_lib.mkdir(parents = True)
+    bin_dir.mkdir(parents = True)
+    binary_path = bin_dir / "llama-server"
+    binary_path.write_bytes(b"fake")
+
+    monkeypatch.setenv("DYLD_LIBRARY_PATH", str(runtime_lib))
+    monkeypatch.setenv("DYLD_INSERT_LIBRARIES", str(tmp_path / "inject.dylib"))
+    monkeypatch.setenv("DYLD_FRAMEWORK_PATH", str(tmp_path / "Frameworks"))
+    monkeypatch.setenv("DYLD_FALLBACK_LIBRARY_PATH", str(tmp_path / "fallback"))
+
+    env = binary_env(binary_path, install_dir, macos_host())
+
+    assert "DYLD_INSERT_LIBRARIES" not in env
+    assert "DYLD_FRAMEWORK_PATH" not in env
+    assert "DYLD_FALLBACK_LIBRARY_PATH" not in env
+    assert str(bin_dir) in env["DYLD_LIBRARY_PATH"].split(os.pathsep)
+    assert str(install_dir) in env["DYLD_LIBRARY_PATH"].split(os.pathsep)
+    assert str(runtime_lib) in env["DYLD_LIBRARY_PATH"].split(os.pathsep)
+
+
 def test_linux_runtime_dirs_probes_with_secret_free_env(monkeypatch: pytest.MonkeyPatch):
     captured: dict[str, object] = {}
 
@@ -3939,7 +3965,17 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
         host = macos_host(),
         purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_QUANTIZE,
         runtime_line = None,
-        env = {"DYLD_LIBRARY_PATH": os.pathsep.join(["/", "/Users/alice", "/opt/dyld"])},
+        env = {
+            "DYLD_LIBRARY_PATH": os.pathsep.join(
+                [
+                    "/",
+                    "/Users/alice",
+                    "/Library/Application Support",
+                    "/private/var",
+                    "/opt/dyld/lib",
+                ]
+            )
+        },
     )
     assert mac_run.is_runnable
     assert mac_run.command[:2] == ["/usr/bin/sandbox-exec", "-p"]
@@ -3961,9 +3997,9 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
     )
     assert any(
         f'(subpath "{literal}")' in profile
-        for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals("/opt/dyld")
+        for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals("/opt/dyld/lib")
     )
-    for broad_path in ("/", "/Users/alice"):
+    for broad_path in ("/", "/Users/alice", "/Library/Application Support", "/private/var"):
         for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals(broad_path):
             assert f'(literal "{literal}")' not in profile
             assert f'(subpath "{literal}")' not in profile

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -58,6 +58,13 @@ LINUX_LDD_PROBE_ERROR = INSTALL_LLAMA_PREBUILT._LINUX_LDD_PROBE_ERROR
 preflight_linux_installed_binaries = INSTALL_LLAMA_PREBUILT.preflight_linux_installed_binaries
 
 
+@pytest.fixture(autouse = True)
+def _bwrap_usable_by_default(monkeypatch):
+    # A mocked-present bwrap represents a working sandbox; the real usability probe
+    # (which would exec bwrap) is out of scope here and covered by its own test.
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_bwrap_can_sandbox", lambda _p: True)
+
+
 def linux_host() -> HostInfo:
     return HostInfo(
         system = "Linux",
@@ -3223,6 +3230,29 @@ def test_build_validation_sandbox_plan_linux_without_bwrap_falls_back_validation
     )
     assert plan.is_fallback
     assert plan.reason is not None
+
+
+def test_build_validation_sandbox_plan_linux_unusable_bwrap_skips_ldd(monkeypatch):
+    # bwrap present but unable to create namespaces (restricted userns) must degrade
+    # like an absent bwrap so the mandatory ldd preflight does not reject the prebuilt.
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: "/usr/bin/bwrap" if command == "bwrap" else "/usr/bin/" + command,
+    )
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_bwrap_can_sandbox", lambda _p: False)
+    plan = build_validation_sandbox_plan(
+        ["ldd", "/tmp/bin"],
+        binary_path = Path("/tmp/bin"),
+        install_dir = Path("/tmp/install"),
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_LDD,
+        runtime_line = None,
+        env = {},
+    )
+    assert plan.is_skipped
+    assert plan.reason is not None
+    assert "skip ldd probe" in plan.reason
 
 
 def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch, tmp_path):

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -1106,6 +1106,13 @@ def _command_contains_path(plan: ValidationLaunchPlan, path_fragment: str) -> bo
     )
 
 
+def _command_has_setenv(plan: ValidationLaunchPlan, key: str) -> bool:
+    for index in range(len(plan.command) - 2):
+        if plan.command[index] == "--setenv" and plan.command[index + 1] == key:
+            return True
+    return False
+
+
 def test_install_prebuilt_falls_back_to_older_release_plan(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
@@ -3182,7 +3189,7 @@ def test_build_validation_sandbox_plan_contract():
 
 
 def test_build_validation_sandbox_plan_linux_without_bwrap_skips_ldd_probe(monkeypatch):
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_resolve_command_path", lambda command: None if command == "bwrap" else "/usr/bin/bwrap")
     plan = build_validation_sandbox_plan(
         ["ldd", "/tmp/bin"],
         binary_path = Path("/tmp/bin"),
@@ -3198,7 +3205,7 @@ def test_build_validation_sandbox_plan_linux_without_bwrap_skips_ldd_probe(monke
 
 
 def test_build_validation_sandbox_plan_linux_without_bwrap_falls_back_validation(monkeypatch):
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_resolve_command_path", lambda command: None if command == "bwrap" else "/usr/bin/bwrap")
     plan = build_validation_sandbox_plan(
         ["llama-quantize", "in", "out"],
         binary_path = Path("/tmp/bin"),
@@ -3213,7 +3220,13 @@ def test_build_validation_sandbox_plan_linux_without_bwrap_falls_back_validation
 
 
 def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch, tmp_path):
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    bwrap_path = tmp_path / "bwrap"
+    bwrap_path.write_text("")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: str(bwrap_path) if command == "bwrap" else None,
+    )
     helper_bin = tmp_path / "helper" / "bin"
     helper_lib = tmp_path / "helper" / "lib"
     install_dir = tmp_path / "install"
@@ -3226,7 +3239,7 @@ def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch, tmp_pa
     monkeypatch.setattr(
         INSTALL_LLAMA_PREBUILT,
         "_linux_validation_server_probe_command",
-        lambda command, timeout = 60: [str(helper_path), "-c", "server probe"],
+        lambda command, payload_env, timeout = 60: [str(helper_path), "-c", "server probe"],
     )
     binary_path = binary_dir / "llama-server"
     binary_path.write_text("")
@@ -3240,11 +3253,15 @@ def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch, tmp_pa
         env = {"LD_LIBRARY_PATH": "/tmp/payload/libs"},
     )
     assert plan.is_runnable
-    assert plan.command[0] == "bwrap"
+    assert plan.command[0] == str(bwrap_path)
     assert plan.command[1] == "--unshare-all"
     assert "--share-net" not in plan.command
     assert "--setenv" in plan.command
-    assert "LD_LIBRARY_PATH" in plan.command
+    assert not _command_has_setenv(plan, "LD_LIBRARY_PATH")
+    assert "--tmpfs" in plan.command
+    assert "--perms" in plan.command
+    assert "1777" in plan.command
+    assert "/tmp" in plan.command
     assert plan.env.get("LD_LIBRARY_PATH") is None
     assert plan.payload_command == [
         "llama-server",
@@ -3261,6 +3278,29 @@ def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch, tmp_pa
     assert plan.network_policy == INSTALL_LLAMA_PREBUILT._VALIDATION_NETWORK_POLICY_SANDBOX
     assert str(model_dir) in plan.command
     assert str(helper_lib) in plan.command
+
+
+def test_linux_validation_server_probe_command_passes_payload_env_to_server_spawn():
+    probe_command = INSTALL_LLAMA_PREBUILT._linux_validation_server_probe_command(
+        [
+            "/opt/llama-server",
+            "-m",
+            "/tmp/models/stories260K.gguf",
+            "--port",
+            "7777",
+        ],
+        {
+            "LD_LIBRARY_PATH": "/tmp/libs",
+            "PYTHONPATH": "/tmp/python",
+        },
+    )
+    assert len(probe_command) == 3
+    _, script = probe_command[0], probe_command[2]
+    assert "payload_env = {\"LD_LIBRARY_PATH\": \"/tmp/libs\", \"PYTHONPATH\": \"/tmp/python\"}" in script
+    assert "server_env = dict(os.environ)" in script
+    assert "server_env.update(payload_env)" in script
+    assert "timeout = 5" in script
+    assert "with urllib.request.urlopen(request, timeout = 5)" in script
 
 
 def test_run_validation_capture_uses_launcher_env_for_linux_bwrap(monkeypatch):
@@ -3395,7 +3435,11 @@ def test_validate_server_strips_python_import_roots_from_payload_env(monkeypatch
 
 
 def test_build_validation_sandbox_plan_linux_quantize_binds_probe_and_output(monkeypatch, tmp_path):
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: "/tmp/bin/bwrap" if command == "bwrap" else None,
+    )
     bin_dir = tmp_path / "bin"
     probe_dir = tmp_path / "models"
     out_dir = tmp_path / "out"
@@ -3412,6 +3456,7 @@ def test_build_validation_sandbox_plan_linux_quantize_binds_probe_and_output(mon
         env = {"LD_LIBRARY_PATH": str(runtime_dir)},
     )
     assert plan.is_runnable
+    assert _command_has_setenv(plan, "LD_LIBRARY_PATH")
     assert plan.command.count("--ro-bind") >= 3
     assert plan.command.count("--bind") >= 2
     assert str(probe_dir) in plan.command
@@ -3419,7 +3464,11 @@ def test_build_validation_sandbox_plan_linux_quantize_binds_probe_and_output(mon
 
 
 def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled(monkeypatch, tmp_path):
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: "/tmp/bin/bwrap" if command == "bwrap" else None,
+    )
     existing_nodes = {
         "/dev/nvidiactl",
         "/dev/nvidia-uvm",
@@ -3487,7 +3536,11 @@ def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled
 
 
 def test_build_validation_sandbox_plan_linux_server_binds_rocm_nodes_when_enabled(monkeypatch, tmp_path):
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: "/tmp/bin/bwrap" if command == "bwrap" else None,
+    )
     existing_nodes = {
         "/dev/kfd",
         "/dev/dxg",
@@ -3570,6 +3623,8 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
     assert "(deny default)" in profile
     assert '(import "bsd.sb")' in profile
     assert "(subpath \"/private\")" not in profile
+    assert '(subpath "/usr")' not in profile
+    assert '(subpath "/Library")' not in profile
     assert any(
         f'(subpath "{literal}")' in profile
         for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals("/tmp/install")
@@ -3602,7 +3657,7 @@ def test_build_validation_sandbox_plan_macos_server_keeps_loopback(monkeypatch):
         INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "sandbox-exec"
     )
     plan = build_validation_sandbox_plan(
-        ["llama-server", "--help"],
+        ["llama-server", "-m", str(Path("/tmp/models/story.gguf")), "--port", "7777"],
         binary_path = Path("/tmp/bin/llama-server"),
         install_dir = Path("/tmp/install"),
         host = macos_host(),
@@ -3616,8 +3671,12 @@ def test_build_validation_sandbox_plan_macos_server_keeps_loopback(monkeypatch):
     assert "(deny default)" in profile
     assert '(import "bsd.sb")' in profile
     assert "(subpath \"/private\")" not in profile
-    assert '(allow network* (local ip "localhost:*"))' in profile
-    assert '(allow network* (remote ip "localhost:*"))' in profile
+    assert '(subpath "/usr")' not in profile
+    assert '(subpath "/Library")' not in profile
+    assert '(allow network* (local ip "localhost:7777"))' in profile
+    assert '(allow network* (remote ip "localhost:7777"))' in profile
+    assert '(allow network* (local ip "localhost:*"))' not in profile
+    assert '(allow network* (remote ip "localhost:*"))' not in profile
 
 
 def test_build_validation_sandbox_plan_windows_is_unsupported(monkeypatch):
@@ -3639,7 +3698,11 @@ def test_linux_missing_libraries_skips_ldd_without_sandbox_adapter(monkeypatch, 
     binary_path = tmp_path / "server"
     binary_path.write_text("")
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: None if command == "bwrap" else "/usr/bin/bwrap",
+    )
 
     captured: dict[str, bool] = {"run": False}
 
@@ -3657,7 +3720,11 @@ def test_run_validation_ldd_probe_reports_skipped_status_without_sandbox_adapter
     binary_path = tmp_path / "server"
     binary_path.write_text("")
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: None if command == "bwrap" else "/usr/bin/bwrap",
+    )
     result = run_validation_ldd_probe(binary_path, env = {"LD_LIBRARY_PATH": ""})
     assert result.status == LINUX_LDD_PROBE_SKIPPED
     assert result.missing == []
@@ -3669,9 +3736,10 @@ def test_run_validation_ldd_probe_reports_error_on_nonzero_returncode(monkeypatc
     binary_path.write_text("")
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
     monkeypatch.setattr(
-        INSTALL_LLAMA_PREBUILT.shutil, "which", lambda name: f"/usr/bin/{name}"
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: f"/usr/bin/{command}",
     )
 
     def fake_capture(plan, *, timeout: int):
@@ -3690,8 +3758,12 @@ def test_linux_missing_libraries_uses_bwrap_plan(monkeypatch, tmp_path):
     binary_path.write_text("")
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.shutil, "which", lambda name: f"/usr/bin/{name}")
+    bwrap_path = "/usr/bin/bwrap"
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: bwrap_path if command == "bwrap" else None,
+    )
     captured = {}
 
     def fake_run_capture(command, *, timeout, env = None, check = False):
@@ -3705,7 +3777,7 @@ def test_linux_missing_libraries_uses_bwrap_plan(monkeypatch, tmp_path):
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "run_capture", fake_run_capture)
     assert linux_missing_libraries(binary_path, env = {"LD_LIBRARY_PATH": ""}) == ["libbad"]
-    assert captured["command"][0] == "bwrap"
+    assert captured["command"][0] == bwrap_path
     assert any(Path(part).stem == "ldd" for part in captured["command"])
 
 
@@ -3992,6 +4064,67 @@ def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
     assert called_capture is True
     assert called_popen is False
     assert recorded["server_probe_mode"] == INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX
+
+
+def test_validate_server_uses_extended_capture_timeout_for_in_sandbox_probe(monkeypatch, tmp_path):
+    server_path = tmp_path / "llama-server"
+    server_path.write_text("")
+    probe_path = tmp_path / "probe.gguf"
+    probe_path.write_text("")
+    install_dir = tmp_path
+
+    called: dict[str, object] = {}
+
+    def fake_binary_env(*_a, **_k):
+        return {"PATH": str(tmp_path)}
+
+    def fake_capture(_plan, *, timeout: int):
+        called["timeout"] = timeout
+        return subprocess.CompletedProcess(_plan.command, 0, stdout = "ok")
+
+    def fake_build_plan(
+        command: list[str],
+        *,
+        binary_path: Path,
+        install_dir: Path,
+        purpose: str,
+        env: dict[str, str],
+        host = None,
+        runtime_line = None,
+        enable_gpu_layers: bool = False,
+        gpu_backend = None,
+    ) -> ValidationLaunchPlan:
+        called["purpose"] = purpose
+        return ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = "run",
+            purpose = purpose,
+            sandbox_kind = "linux_bwrap",
+            payload_command = command,
+            payload_env = env,
+            server_probe_mode = INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX,
+        )
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", fake_binary_env)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "free_local_port", lambda: 7777)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_capture", fake_capture)
+
+    validate_server(
+        server_path,
+        probe_path,
+        linux_host(),
+        install_dir,
+        runtime_line = None,
+        install_kind = "linux-cuda",
+    )
+
+    captured_timeout = called.get("timeout")
+    assert called.get("purpose") == INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER
+    assert isinstance(captured_timeout, int)
+    assert captured_timeout == INSTALL_LLAMA_PREBUILT._LINUX_SERVER_VALIDATION_HELPER_CAPTURE_TIMEOUT_SECONDS
+    assert captured_timeout > INSTALL_LLAMA_PREBUILT._LINUX_SERVER_VALIDATION_HELPER_TIMEOUT_SECONDS
 
 
 def test_validate_server_falls_back_without_linux_sandbox(monkeypatch, tmp_path):

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -4,6 +4,7 @@ import io
 import json
 import os
 import sys
+import subprocess
 import tarfile
 import zipfile
 from pathlib import Path
@@ -41,6 +42,13 @@ write_prebuilt_metadata = INSTALL_LLAMA_PREBUILT.write_prebuilt_metadata
 existing_install_matches_plan = INSTALL_LLAMA_PREBUILT.existing_install_matches_plan
 existing_install_matches_choice = INSTALL_LLAMA_PREBUILT.existing_install_matches_choice
 ensure_diffusion_visual_server = INSTALL_LLAMA_PREBUILT.ensure_diffusion_visual_server
+validate_quantize = INSTALL_LLAMA_PREBUILT.validate_quantize
+validate_server = INSTALL_LLAMA_PREBUILT.validate_server
+build_validation_sandbox_plan = INSTALL_LLAMA_PREBUILT.build_validation_sandbox_plan
+linux_missing_libraries = INSTALL_LLAMA_PREBUILT.linux_missing_libraries
+ValidationLaunchPlan = INSTALL_LLAMA_PREBUILT._ValidationLaunchPlan
+run_validation_capture = INSTALL_LLAMA_PREBUILT._run_validation_capture
+run_validation_popen = INSTALL_LLAMA_PREBUILT._run_validation_popen
 
 
 def linux_host() -> HostInfo:
@@ -58,6 +66,46 @@ def linux_host() -> HostInfo:
         visible_cuda_devices = None,
         has_physical_nvidia = False,
         has_usable_nvidia = False,
+    )
+
+
+def macos_host() -> HostInfo:
+    return HostInfo(
+        system = "Darwin",
+        machine = "arm64",
+        is_windows = False,
+        is_linux = False,
+        is_macos = True,
+        is_x86_64 = False,
+        is_arm64 = True,
+        nvidia_smi = None,
+        driver_cuda_version = None,
+        compute_caps = [],
+        visible_cuda_devices = None,
+        has_physical_nvidia = False,
+        has_usable_nvidia = False,
+        has_rocm = False,
+        rocm_gfx_target = None,
+    )
+
+
+def windows_host() -> HostInfo:
+    return HostInfo(
+        system = "Windows",
+        machine = "AMD64",
+        is_windows = True,
+        is_linux = False,
+        is_macos = False,
+        is_x86_64 = True,
+        is_arm64 = False,
+        nvidia_smi = None,
+        driver_cuda_version = None,
+        compute_caps = [],
+        visible_cuda_devices = None,
+        has_physical_nvidia = False,
+        has_usable_nvidia = False,
+        has_rocm = False,
+        rocm_gfx_target = None,
     )
 
 
@@ -160,7 +208,10 @@ def test_extract_archive_rejects_absolute_tar_symlink_target(tmp_path: Path):
         entry.linkname = "/tmp/libllama.so.0"
         archive.addfile(entry)
 
-    with pytest.raises(PrebuiltFallback, match = "archive link used an absolute target"):
+    with pytest.raises(
+        PrebuiltFallback,
+        match = r"archive link (used an absolute target|escaped destination)",
+    ):
         extract_archive(archive_path, tmp_path / "extract")
 
 
@@ -3038,11 +3089,340 @@ def _nvidia_linux_host():
     )
 
 
+def test_build_validation_sandbox_plan_contract():
+    assert (
+        build_validation_sandbox_plan(
+            ["cmd", "arg"],
+            binary_path = Path("/tmp/bin"),
+            install_dir = Path("/tmp/install"),
+            host = linux_host(),
+            purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_LDD,
+            runtime_line = None,
+            env = {"UNSANDBOXABLE": "1"},
+    ).purpose
+    == INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_LDD
+    )
+
+
+def test_build_validation_sandbox_plan_linux_without_bwrap_skips_ldd_probe(monkeypatch):
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
+    plan = build_validation_sandbox_plan(
+        ["ldd", "/tmp/bin"],
+        binary_path = Path("/tmp/bin"),
+        install_dir = Path("/tmp/install"),
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_LDD,
+        runtime_line = None,
+        env = {},
+    )
+    assert plan.is_skipped
+    assert plan.reason is not None
+    assert "skip ldd probe" in plan.reason
+
+
+def test_build_validation_sandbox_plan_linux_without_bwrap_falls_back_validation(monkeypatch):
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
+    plan = build_validation_sandbox_plan(
+        ["llama-quantize", "in", "out"],
+        binary_path = Path("/tmp/bin"),
+        install_dir = Path("/tmp/install"),
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_QUANTIZE,
+        runtime_line = None,
+        env = {},
+    )
+    assert plan.is_fallback
+    assert plan.reason is not None
+
+
+def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch):
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    plan = build_validation_sandbox_plan(
+        ["llama-server", "--help"],
+        binary_path = Path("/tmp/bin/llama-server"),
+        install_dir = Path("/tmp/install"),
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {},
+    )
+    assert plan.is_runnable
+    assert plan.command[:5] == ["bwrap", "--unshare-all", "--unshare-net", "--die-with-parent", "--new-session"]
+    assert "ldd" in plan.command[-1] or "--help" in plan.command[-1]
+    assert "--ro-bind" in plan.command
+
+
+def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monkeypatch):
+    binary_path = Path("/tmp/bin/llama-server")
+
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "sandbox-exec"
+    )
+    mac_run = build_validation_sandbox_plan(
+        ["llama-server", "--help"],
+        binary_path = binary_path,
+        install_dir = Path("/tmp/install"),
+        host = macos_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {},
+    )
+    assert mac_run.is_runnable
+    assert mac_run.command[:3] == ["sandbox-exec", "-p", "(version 1)(deny network*)"]
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
+    mac_skip = build_validation_sandbox_plan(
+        ["llama-server", "--help"],
+        binary_path = binary_path,
+        install_dir = Path("/tmp/install"),
+        host = macos_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {},
+    )
+    assert mac_skip.is_fallback
+
+
+def test_build_validation_sandbox_plan_windows_is_unsupported(monkeypatch):
+    plan = build_validation_sandbox_plan(
+        ["llama-server", "--help"],
+        binary_path = Path(r"C:\bin\llama-server.exe"),
+        install_dir = Path(r"C:\install"),
+        host = windows_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {},
+    )
+    assert plan.is_fallback
+    assert "unsupported" in (plan.reason or "").lower()
+
+
+def test_linux_missing_libraries_skips_ldd_without_sandbox_adapter(monkeypatch, tmp_path):
+    binary_path = tmp_path / "server"
+    binary_path.write_text("")
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
+
+    captured: dict[str, bool] = {"run": False}
+
+    def fake_run_capture(command, *, timeout, env = None, check = False):
+        captured["run"] = True
+        return subprocess.CompletedProcess(command, 0, stdout = "")
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "run_capture", fake_run_capture)
+    missing = linux_missing_libraries(binary_path, env = {"LD_LIBRARY_PATH": ""})
+    assert missing == []
+    assert captured["run"] is False
+
+
+def test_linux_missing_libraries_uses_bwrap_plan(monkeypatch, tmp_path):
+    binary_path = tmp_path / "server"
+    binary_path.write_text("")
+    install_dir = tmp_path
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    captured = {}
+
+    def fake_run_capture(command, *, timeout, env = None, check = False):
+        captured["command"] = command
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout = "libbad => not found\nlibgood => /tmp/libgood\n",
+            stderr = "",
+        )
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "run_capture", fake_run_capture)
+    assert linux_missing_libraries(binary_path, env = {"LD_LIBRARY_PATH": ""}) == ["libbad"]
+    assert captured["command"][0] == "bwrap"
+    assert "ldd" in captured["command"]
+
+
+def test_validate_quantize_routes_through_sandbox_plan(monkeypatch, tmp_path):
+    quantize_path = tmp_path / "llama-quantize"
+    quantize_path.write_text("")
+    probe_path = tmp_path / "probe.gguf"
+    probe_path.write_text("")
+    quantized_path = tmp_path / "probe-q4.gguf"
+    install_dir = tmp_path
+    expected_env = {"CUSTOM": "1"}
+    recorded: dict[str, list[str] | str | dict[str, str]] = {}
+
+    def fake_build_plan(
+        command: list[str],
+        *,
+        binary_path: Path,
+        install_dir: Path,
+        purpose: str,
+        env: dict[str, str],
+        host = None,
+        runtime_line = None,
+    ) -> ValidationLaunchPlan:
+        recorded["command"] = command
+        recorded["purpose"] = purpose
+        recorded["env"] = env
+        return ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = "run",
+            purpose = purpose,
+        )
+
+    def fake_capture(plan: ValidationLaunchPlan, *, timeout: int):
+        assert plan.purpose == INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_QUANTIZE
+        quantized_path.write_bytes(b"done")
+        return subprocess.CompletedProcess(plan.command, 0, stdout = "", stderr = "")
+
+    def fake_binary_env(*_a, **_k):
+        return expected_env
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_capture", fake_capture)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", fake_binary_env)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "run_capture", lambda *a, **k: (_ for _ in ()).throw(AssertionError("run_capture must not be used")))
+
+    validate_quantize(quantize_path, probe_path, quantized_path, install_dir, linux_host(), runtime_line = None)
+    assert recorded["purpose"] == INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_QUANTIZE
+    assert recorded["env"] == expected_env
+    assert recorded["command"][:3] == [str(quantize_path), str(probe_path), str(quantized_path)]
+    assert quantized_path.exists()
+
+
+def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
+    server_path = tmp_path / "llama-server"
+    server_path.write_text("")
+    probe_path = tmp_path / "probe.gguf"
+    probe_path.write_text("")
+    install_dir = tmp_path
+    recorded: dict[str, object] = {}
+
+    def fake_build_plan(
+        command: list[str],
+        *,
+        binary_path: Path,
+        install_dir: Path,
+        purpose: str,
+        env: dict[str, str],
+        host = None,
+        runtime_line = None,
+    ) -> ValidationLaunchPlan:
+        recorded["command"] = command
+        recorded["purpose"] = purpose
+        return ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = "run",
+            purpose = purpose,
+        )
+
+    class _FakeResponse:
+        status = 200
+
+        def read(self):
+            return b"{}"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    class _FakeProcess:
+        def poll(self):
+            return None
+
+        def wait(self, timeout: float | None = None):
+            return 0
+
+        def terminate(self):
+            recorded["terminated"] = True
+            return None
+
+        def kill(self):
+            recorded["terminated"] = True
+            return None
+
+    def fake_binary_env(*_a, **_k):
+        return {"PATH": str(tmp_path)}
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", fake_binary_env)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_popen", lambda plan, *, stdout: _FakeProcess())
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "free_local_port", lambda: 7777)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.urllib.request, "urlopen", lambda *a, **k: _FakeResponse())
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT, "run_capture",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("run_capture must not be used")),
+    )
+
+    validate_server(
+        server_path,
+        probe_path,
+        linux_host(),
+        install_dir,
+        runtime_line = "cuda13",
+        install_kind = "linux-cuda",
+    )
+    assert recorded["purpose"] == INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER
+    command = recorded["command"]
+    assert command[:3] == [str(server_path), "-m", str(probe_path)]
+    assert "--n-gpu-layers" in command
+
+
+def test_validate_server_falls_back_without_linux_sandbox(monkeypatch, tmp_path):
+    server_path = tmp_path / "llama-server"
+    server_path.write_text("")
+    probe_path = tmp_path / "probe.gguf"
+    probe_path.write_text("")
+
+    def fake_build_plan(
+        command: list[str],
+        *,
+        binary_path: Path,
+        install_dir: Path,
+        purpose: str,
+        env: dict[str, str],
+        host = None,
+        runtime_line = None,
+    ) -> ValidationLaunchPlan:
+        return ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = "fallback",
+            purpose = purpose,
+            reason = "no sandbox",
+        )
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
+
+    with pytest.raises(PrebuiltFallback, match = "no sandbox"):
+        validate_server(
+            server_path,
+            probe_path,
+            windows_host(),
+            tmp_path,
+            runtime_line = None,
+            install_kind = None,
+        )
+
+
+def test_runtime_inference_path_stays_outside_installer_sandbox_owner():
+    backend_source = (Path(__file__).parents[3] / "studio/backend/core/inference/llama_cpp.py").read_text(
+        encoding = "utf-8", errors = "replace"
+    )
+    assert "_ValidationLaunchPlan" not in backend_source
+    assert "_run_validation_capture" not in backend_source
+    assert "_run_validation_popen" not in backend_source
+    assert "build_validation_sandbox_plan" not in backend_source
+
+
 def _run_validate_prebuilt_choice(monkeypatch, tmp_path, *, expected_sha256):
-    """Run validate_prebuilt_choice with heavy steps stubbed; return the quantize/server smoke-test call counts."""
+    """Run validate_prebuilt_choice with heavy steps stubbed; return launch metadata."""
     calls = {"quantize": 0, "server": 0}
+    plans: list[str] = []
     server_path = tmp_path / "install" / "build" / "bin" / "llama-server"
     quantize_path = tmp_path / "install" / "build" / "bin" / "llama-quantize"
+    quantized_path = tmp_path / "stories260K-q4.gguf"
 
     src = INSTALL_LLAMA_PREBUILT
     monkeypatch.setattr(
@@ -3054,14 +3434,65 @@ def _run_validate_prebuilt_choice(monkeypatch, tmp_path, *, expected_sha256):
     monkeypatch.setattr(src, "preflight_macos_installed_binaries", lambda *a, **k: None)
     monkeypatch.setattr(src, "ensure_repo_shape", lambda *a, **k: None)
     monkeypatch.setattr(src, "write_prebuilt_metadata", lambda *a, **k: None)
-    monkeypatch.setattr(
-        src,
-        "validate_quantize",
-        lambda *a, **k: calls.__setitem__("quantize", calls["quantize"] + 1),
-    )
-    monkeypatch.setattr(
-        src, "validate_server", lambda *a, **k: calls.__setitem__("server", calls["server"] + 1)
-    )
+
+    def fake_build_plan(
+        command: list[str],
+        *,
+        binary_path: Path,
+        install_dir: Path,
+        purpose: str,
+        env: dict[str, str],
+        host = None,
+        runtime_line = None,
+    ) -> ValidationLaunchPlan:
+        plans.append(purpose)
+        return ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = "run",
+            purpose = purpose,
+        )
+
+    def fake_run_validation_capture(plan: ValidationLaunchPlan, *, timeout: int):
+        if plan.purpose == src._VALIDATION_PURPOSE_QUANTIZE:
+            calls["quantize"] += 1
+            quantized_path.write_bytes(b"quantized")
+        return subprocess.CompletedProcess(plan.command, 0, "", "")
+
+    class _FakeResponse:
+        status = 200
+
+        def read(self):
+            return b"{}"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    class _DummyProcess:
+        def poll(self):
+            return None
+
+        def wait(self, timeout: float | None = None):
+            return 0
+
+        def terminate(self):
+            return None
+
+        def kill(self):
+            return None
+
+    def fake_run_validation_popen(plan: ValidationLaunchPlan, *, stdout):
+        assert plan.purpose == src._VALIDATION_PURPOSE_SERVER
+        calls["server"] += 1
+        return _DummyProcess()
+
+    monkeypatch.setattr(src, "build_validation_sandbox_plan", fake_build_plan)
+    monkeypatch.setattr(src, "_run_validation_capture", fake_run_validation_capture)
+    monkeypatch.setattr(src, "_run_validation_popen", fake_run_validation_popen)
+    monkeypatch.setattr(src.urllib.request, "urlopen", lambda *a, **k: _FakeResponse())
 
     bundle_name = "app-b9998-linux-x64-cuda13-newer.tar.gz"
     source_archive = tmp_path / "source.tar.gz"
@@ -3097,28 +3528,68 @@ def _run_validate_prebuilt_choice(monkeypatch, tmp_path, *, expected_sha256):
             bundle_name = bundle_name,
         ),
         prebuilt_fallback_used = False,
-        quantized_path = tmp_path / "stories260K-q4.gguf",
+        quantized_path = quantized_path,
     )
-    return calls
+    return calls, plans
 
 
 def test_validate_prebuilt_choice_approved_validation_skipped_when_flag_off(tmp_path, monkeypatch):
     # An approved (sha256-verified) bundle skips the smoke test while the flag is off.
-    calls = _run_validate_prebuilt_choice(monkeypatch, tmp_path, expected_sha256 = "ab" * 32)
+    calls, plans = _run_validate_prebuilt_choice(
+        monkeypatch, tmp_path, expected_sha256 = "ab" * 32
+    )
     assert calls == {"quantize": 0, "server": 0}
+    assert plans == []
 
 
 def test_validate_prebuilt_choice_hashless_build_always_validated(tmp_path, monkeypatch):
     # A hashless build has no sha256 gate, so the smoke test must run even with the flag off.
-    calls = _run_validate_prebuilt_choice(monkeypatch, tmp_path, expected_sha256 = None)
+    calls, plans = _run_validate_prebuilt_choice(monkeypatch, tmp_path, expected_sha256 = None)
     assert calls == {"quantize": 1, "server": 1}
+    assert "ldd" in plans
+    assert plans.count("quantize") == 1
+    assert plans.count("server") == 1
+    assert plans.index("quantize") < plans.index("server")
+
+
+def test_validate_prebuilt_choice_hashless_build_routes_through_validation_sandbox(
+    tmp_path, monkeypatch
+):
+    _calls, plans = _run_validate_prebuilt_choice(monkeypatch, tmp_path, expected_sha256 = None)
+    assert plans.count("ldd") >= 1
+    assert plans.count("quantize") == 1
+    assert plans.count("server") == 1
+    assert plans.index("quantize") < plans.index("server")
+    assert plans[0] == "ldd"
+    assert plans[-1] == "server"
 
 
 def test_validate_prebuilt_choice_approved_validation_runs_when_flag_enabled(tmp_path, monkeypatch):
     # _RUN_STAGED_PREBUILT_VALIDATION back on restores the smoke test for approved bundles too.
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_RUN_STAGED_PREBUILT_VALIDATION", True)
-    calls = _run_validate_prebuilt_choice(monkeypatch, tmp_path, expected_sha256 = "ab" * 32)
+    calls, plans = _run_validate_prebuilt_choice(
+        monkeypatch, tmp_path, expected_sha256 = "ab" * 32
+    )
     assert calls == {"quantize": 1, "server": 1}
+    assert "ldd" in plans
+    assert plans.count("quantize") == 1
+    assert plans.count("server") == 1
+    assert plans.index("quantize") < plans.index("server")
+
+
+def test_validate_prebuilt_choice_approved_validation_records_sandbox_routing(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_RUN_STAGED_PREBUILT_VALIDATION", True)
+    _calls, plans = _run_validate_prebuilt_choice(
+        monkeypatch, tmp_path, expected_sha256 = "ab" * 32
+    )
+    assert plans.count("ldd") >= 1
+    assert plans.count("quantize") == 1
+    assert plans.count("server") == 1
+    assert plans.index("quantize") < plans.index("server")
+    assert plans[0] == "ldd"
+    assert plans[-1] == "server"
 
 
 def test_diffusion_visual_server_uses_approved_checksum_download(monkeypatch, tmp_path: Path):
@@ -3162,7 +3633,10 @@ def test_diffusion_visual_server_uses_approved_checksum_download(monkeypatch, tm
         )
     ]
     assert target.read_bytes() == b"verified visual server"
-    assert target.stat().st_mode & 0o777 == 0o755
+    if os.name == "nt":
+        assert target.exists()
+    else:
+        assert target.stat().st_mode & 0o777 == 0o755
 
 
 def test_diffusion_visual_server_refuses_unapproved_release_asset(monkeypatch, tmp_path: Path):

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3226,7 +3226,7 @@ def test_build_validation_sandbox_plan_linux_without_bwrap_skips_ldd_probe(monke
     assert "skip ldd probe" in plan.reason
 
 
-def test_build_validation_sandbox_plan_linux_without_bwrap_falls_back_validation(monkeypatch):
+def test_build_validation_sandbox_plan_linux_without_bwrap_skips_validation(monkeypatch):
     monkeypatch.setattr(
         INSTALL_LLAMA_PREBUILT,
         "_resolve_command_path",
@@ -3241,8 +3241,11 @@ def test_build_validation_sandbox_plan_linux_without_bwrap_falls_back_validation
         runtime_line = None,
         env = {},
     )
-    assert plan.is_fallback
+    assert plan.is_skipped
     assert plan.reason is not None
+    assert "skip downloaded-binary validation" in plan.reason
+    assert plan.network_policy is None
+    assert plan.server_probe_mode is None
 
 
 def test_build_validation_sandbox_plan_linux_unusable_bwrap_skips_ldd(monkeypatch):
@@ -4091,6 +4094,33 @@ def test_run_validation_ldd_probe_reports_error_on_nonzero_returncode(monkeypatc
     assert "bind failed" in result.reason
 
 
+def test_run_validation_ldd_probe_accepts_static_binary_output(monkeypatch, tmp_path):
+    binary_path = tmp_path / "server"
+    binary_path.write_text("")
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: f"/usr/bin/{command}",
+    )
+
+    def fake_capture(plan, *, timeout: int):
+        return subprocess.CompletedProcess(
+            plan.command,
+            1,
+            stdout = "",
+            stderr = "not a dynamic executable",
+        )
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_capture", fake_capture)
+
+    result = run_validation_ldd_probe(binary_path, env = {"LD_LIBRARY_PATH": ""})
+    assert result.status == LINUX_LDD_PROBE_OK
+    assert result.missing == []
+    assert result.reason == "static executable"
+
+
 def test_linux_missing_libraries_uses_bwrap_plan(monkeypatch, tmp_path):
     binary_path = tmp_path / "server"
     binary_path.write_text("")
@@ -4268,7 +4298,7 @@ def test_validate_quantize_routes_through_sandbox_plan(monkeypatch, tmp_path):
     assert quantized_path.exists()
 
 
-def test_validate_quantize_falls_back_without_linux_sandbox(monkeypatch, tmp_path):
+def test_validate_quantize_skips_without_linux_sandbox(monkeypatch, tmp_path):
     quantize_path = tmp_path / "llama-quantize"
     quantize_path.write_text("")
     probe_path = tmp_path / "probe.gguf"
@@ -4290,7 +4320,7 @@ def test_validate_quantize_falls_back_without_linux_sandbox(monkeypatch, tmp_pat
         return ValidationLaunchPlan(
             command = command,
             env = env,
-            action = "fallback",
+            action = "skip",
             purpose = purpose,
             reason = "no sandbox",
         )
@@ -4299,16 +4329,21 @@ def test_validate_quantize_falls_back_without_linux_sandbox(monkeypatch, tmp_pat
     monkeypatch.setattr(
         INSTALL_LLAMA_PREBUILT, "binary_env", lambda *_a, **_k: {"PATH": str(tmp_path)}
     )
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "run_capture",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("run_capture must not be used")),
+    )
 
-    with pytest.raises(PrebuiltFallback, match = "no sandbox"):
-        validate_quantize(
-            quantize_path,
-            probe_path,
-            quantized_path,
-            tmp_path,
-            linux_host(),
-            runtime_line = None,
-        )
+    validate_quantize(
+        quantize_path,
+        probe_path,
+        quantized_path,
+        tmp_path,
+        linux_host(),
+        runtime_line = None,
+    )
+    assert not quantized_path.exists()
 
 
 def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
@@ -4545,7 +4580,7 @@ def test_validate_server_skips_gpu_layers_for_macos_arm64(monkeypatch, tmp_path)
     assert recorded["enable_gpu_layers"] is False
 
 
-def test_validate_server_falls_back_without_linux_sandbox(monkeypatch, tmp_path):
+def test_validate_server_skips_without_linux_sandbox(monkeypatch, tmp_path):
     server_path = tmp_path / "llama-server"
     server_path.write_text("")
     probe_path = tmp_path / "probe.gguf"
@@ -4566,22 +4601,26 @@ def test_validate_server_falls_back_without_linux_sandbox(monkeypatch, tmp_path)
         return ValidationLaunchPlan(
             command = command,
             env = env,
-            action = "fallback",
+            action = "skip",
             purpose = purpose,
             reason = "no sandbox",
         )
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT.subprocess,
+        "Popen",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("Popen must not be used")),
+    )
 
-    with pytest.raises(PrebuiltFallback, match = "no sandbox"):
-        validate_server(
-            server_path,
-            probe_path,
-            linux_host(),
-            tmp_path,
-            runtime_line = None,
-            install_kind = None,
-        )
+    validate_server(
+        server_path,
+        probe_path,
+        linux_host(),
+        tmp_path,
+        runtime_line = None,
+        install_kind = None,
+    )
 
 
 def test_validate_server_uses_windows_direct_validation_plan(monkeypatch, tmp_path):
@@ -4673,7 +4712,13 @@ def test_runtime_inference_path_stays_outside_installer_sandbox_owner():
     assert "build_validation_sandbox_plan" not in backend_source
 
 
-def _run_validate_prebuilt_choice(monkeypatch, tmp_path, *, expected_sha256):
+def _run_validate_prebuilt_choice(
+    monkeypatch,
+    tmp_path,
+    *,
+    expected_sha256,
+    validation_action = "run",
+):
     """Run validate_prebuilt_choice with heavy steps stubbed; return launch metadata."""
     calls = {"quantize": 0, "server": 0}
     plans: list[str] = []
@@ -4708,11 +4753,14 @@ def _run_validate_prebuilt_choice(monkeypatch, tmp_path, *, expected_sha256):
         return ValidationLaunchPlan(
             command = command,
             env = env,
-            action = "run",
+            action = validation_action,
             purpose = purpose,
+            reason = "validation launch unavailable" if validation_action != "run" else None,
         )
 
     def fake_run_validation_capture(plan: ValidationLaunchPlan, *, timeout: int):
+        if plan.action != "run":
+            raise src.ValidationLaunchUnavailable(plan.reason or "validation launch unavailable")
         if plan.purpose == src._VALIDATION_PURPOSE_QUANTIZE:
             calls["quantize"] += 1
             quantized_path.write_bytes(b"quantized")
@@ -4744,6 +4792,8 @@ def _run_validate_prebuilt_choice(monkeypatch, tmp_path, *, expected_sha256):
             return None
 
     def fake_run_validation_popen(plan: ValidationLaunchPlan, *, stdout):
+        if plan.action != "run":
+            raise src.ValidationLaunchUnavailable(plan.reason or "validation launch unavailable")
         assert plan.purpose == src._VALIDATION_PURPOSE_SERVER
         calls["server"] += 1
         return _DummyProcess()
@@ -4819,6 +4869,18 @@ def test_validate_prebuilt_choice_hashless_build_routes_through_validation_sandb
     assert plans.index("quantize") < plans.index("server")
     assert plans[0] == "ldd"
     assert plans[-1] == "server"
+
+
+def test_validate_prebuilt_choice_hashless_build_falls_back_when_validation_launch_skips(
+    tmp_path, monkeypatch
+):
+    with pytest.raises(PrebuiltFallback, match = "llama-quantize validation unavailable"):
+        _run_validate_prebuilt_choice(
+            monkeypatch,
+            tmp_path,
+            expected_sha256 = None,
+            validation_action = "skip",
+        )
 
 
 def test_validate_prebuilt_choice_approved_validation_runs_when_flag_enabled(tmp_path, monkeypatch):

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3399,7 +3399,9 @@ def test_build_validation_sandbox_plan_linux_server_probe_binds_nix_store(monkey
     assert _command_contains_path(plan, "nix/store")
 
 
-def test_build_validation_sandbox_plan_linux_gpu_keeps_sandbox_without_setuid_bwrap(monkeypatch, tmp_path):
+def test_build_validation_sandbox_plan_linux_gpu_keeps_sandbox_without_setuid_bwrap(
+    monkeypatch, tmp_path
+):
     bwrap_path = tmp_path / "bwrap"
     bwrap_path.write_text("")
     binary_path = tmp_path / "llama-server"
@@ -3424,7 +3426,8 @@ def test_build_validation_sandbox_plan_linux_gpu_keeps_sandbox_without_setuid_bw
                 "payload_env": dict(payload_env),
                 "timeout": timeout,
             }
-        ) or [str(helper_path), "-c", "server probe"],
+        )
+        or [str(helper_path), "-c", "server probe"],
     )
 
     plan = build_validation_sandbox_plan(

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3189,7 +3189,7 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
         binary_path = binary_path,
         install_dir = Path("/tmp/install"),
         host = macos_host(),
-        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_QUANTIZE,
         runtime_line = None,
         env = {},
     )
@@ -3202,11 +3202,28 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
         binary_path = binary_path,
         install_dir = Path("/tmp/install"),
         host = macos_host(),
-        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_QUANTIZE,
         runtime_line = None,
         env = {},
     )
     assert mac_skip.is_fallback
+
+
+def test_build_validation_sandbox_plan_macos_server_keeps_loopback(monkeypatch):
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "sandbox-exec"
+    )
+    plan = build_validation_sandbox_plan(
+        ["llama-server", "--help"],
+        binary_path = Path("/tmp/bin/llama-server"),
+        install_dir = Path("/tmp/install"),
+        host = macos_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {},
+    )
+    assert plan.is_runnable
+    assert plan.command[:3] == ["sandbox-exec", "-p", "(version 1)"]
 
 
 def test_build_validation_sandbox_plan_windows_is_unsupported(monkeypatch):

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -56,6 +56,7 @@ LINUX_LDD_PROBE_OK = INSTALL_LLAMA_PREBUILT._LINUX_LDD_PROBE_OK
 LINUX_LDD_PROBE_SKIPPED = INSTALL_LLAMA_PREBUILT._LINUX_LDD_PROBE_SKIPPED
 LINUX_LDD_PROBE_ERROR = INSTALL_LLAMA_PREBUILT._LINUX_LDD_PROBE_ERROR
 preflight_linux_installed_binaries = INSTALL_LLAMA_PREBUILT.preflight_linux_installed_binaries
+bwrap_can_sandbox = INSTALL_LLAMA_PREBUILT._bwrap_can_sandbox
 
 
 @pytest.fixture(autouse = True)
@@ -1114,6 +1115,18 @@ def _command_contains_path(plan: ValidationLaunchPlan, path_fragment: str) -> bo
 def _command_has_setenv(plan: ValidationLaunchPlan, key: str) -> bool:
     for index in range(len(plan.command) - 2):
         if plan.command[index] == "--setenv" and plan.command[index + 1] == key:
+            return True
+    return False
+
+
+def _command_has_bind(plan: ValidationLaunchPlan, flag: str, source: str | Path) -> bool:
+    source_text = str(Path(source))
+    for index in range(len(plan.command) - 2):
+        if (
+            plan.command[index] == flag
+            and plan.command[index + 1] == source_text
+            and plan.command[index + 2] == source_text
+        ):
             return True
     return False
 
@@ -3255,6 +3268,24 @@ def test_build_validation_sandbox_plan_linux_unusable_bwrap_skips_ldd(monkeypatc
     assert "skip ldd probe" in plan.reason
 
 
+def test_bwrap_capability_probe_uses_clean_launcher_env(monkeypatch):
+    captured: dict[str, dict[str, str]] = {}
+    monkeypatch.setenv("LD_LIBRARY_PATH", "/bad/loader")
+    monkeypatch.setenv("LD_PRELOAD", "/bad/preload.so")
+    INSTALL_LLAMA_PREBUILT._bwrap_sandbox_capability.clear()
+
+    def fake_run(*_args, **kwargs):
+        captured["env"] = kwargs["env"]
+        return subprocess.CompletedProcess(args = [], returncode = 0)
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.subprocess, "run", fake_run)
+
+    assert bwrap_can_sandbox("/usr/bin/bwrap")
+    assert "LD_LIBRARY_PATH" not in captured["env"]
+    assert "LD_PRELOAD" not in captured["env"]
+    assert captured["env"]["PATH"] == "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+
 def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch, tmp_path):
     bwrap_path = tmp_path / "bwrap"
     bwrap_path.write_text("")
@@ -3314,6 +3345,45 @@ def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch, tmp_pa
     assert plan.network_policy == INSTALL_LLAMA_PREBUILT._VALIDATION_NETWORK_POLICY_SANDBOX
     assert str(model_dir) in plan.command
     assert str(helper_lib) in plan.command
+
+
+def test_build_validation_sandbox_plan_linux_skips_broad_inherited_library_binds(
+    monkeypatch, tmp_path
+):
+    bwrap_path = tmp_path / "bwrap"
+    bwrap_path.write_text("")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: str(bwrap_path) if command == "bwrap" else None,
+    )
+    install_dir = tmp_path / "install"
+    binary_dir = tmp_path / "bin"
+    runtime_lib = tmp_path / "runtime" / "lib"
+    model_dir = tmp_path / "models"
+    for directory in (install_dir, binary_dir, runtime_lib, model_dir):
+        directory.mkdir(parents = True, exist_ok = True)
+    binary_path = binary_dir / "llama-server"
+    binary_path.write_text("")
+
+    plan = build_validation_sandbox_plan(
+        ["llama-server", "-m", str(model_dir / "stories260K.gguf"), "--port", "7777"],
+        binary_path = binary_path,
+        install_dir = install_dir,
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {
+            "LD_LIBRARY_PATH": os.pathsep.join(
+                [str(Path("/")), str(Path("/home/alice")), str(runtime_lib)]
+            )
+        },
+    )
+
+    assert plan.is_runnable
+    assert _command_has_bind(plan, "--ro-bind", runtime_lib)
+    assert not _command_has_bind(plan, "--ro-bind", Path("/"))
+    assert not _command_has_bind(plan, "--ro-bind", Path("/home/alice"))
 
 
 def test_build_validation_sandbox_plan_linux_server_probe_uses_resolved_helper_path(
@@ -3855,7 +3925,9 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
     output_path = Path("/tmp/out/probe-q4.gguf")
 
     monkeypatch.setattr(
-        INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "sandbox-exec"
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: "/usr/bin/sandbox-exec" if command == "sandbox-exec" else None,
     )
     mac_run = build_validation_sandbox_plan(
         [str(binary_path), str(probe_path), str(output_path), "Q6_K", "2"],
@@ -3864,10 +3936,10 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
         host = macos_host(),
         purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_QUANTIZE,
         runtime_line = None,
-        env = {"DYLD_LIBRARY_PATH": "/opt/dyld"},
+        env = {"DYLD_LIBRARY_PATH": os.pathsep.join(["/", "/Users/alice", "/opt/dyld"])},
     )
     assert mac_run.is_runnable
-    assert mac_run.command[:2] == ["sandbox-exec", "-p"]
+    assert mac_run.command[:2] == ["/usr/bin/sandbox-exec", "-p"]
     assert "/usr/bin/env" in mac_run.command
     profile = mac_run.command[2]
     assert "(deny default)" in profile
@@ -3886,15 +3958,15 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
     )
     assert any(
         f'(subpath "{literal}")' in profile
-        for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals("/tmp/out")
-    )
-    assert any(
-        f'(subpath "{literal}")' in profile
         for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals("/opt/dyld")
     )
+    for broad_path in ("/", "/Users/alice"):
+        for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals(broad_path):
+            assert f'(literal "{literal}")' not in profile
+            assert f'(subpath "{literal}")' not in profile
     assert "localhost" not in profile
 
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_resolve_command_path", lambda *_a, **_k: None)
     mac_skip = build_validation_sandbox_plan(
         [str(binary_path), str(probe_path), str(output_path), "Q6_K", "2"],
         binary_path = binary_path,
@@ -3909,7 +3981,9 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
 
 def test_build_validation_sandbox_plan_macos_server_keeps_loopback(monkeypatch):
     monkeypatch.setattr(
-        INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "sandbox-exec"
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: "/usr/bin/sandbox-exec" if command == "sandbox-exec" else None,
     )
     plan = build_validation_sandbox_plan(
         ["llama-server", "-m", str(Path("/tmp/models/story.gguf")), "--port", "7777"],
@@ -3921,7 +3995,7 @@ def test_build_validation_sandbox_plan_macos_server_keeps_loopback(monkeypatch):
         env = {},
     )
     assert plan.is_runnable
-    assert plan.command[:2] == ["sandbox-exec", "-p"]
+    assert plan.command[:2] == ["/usr/bin/sandbox-exec", "-p"]
     assert "/usr/bin/env" in plan.command
     profile = plan.command[2]
     assert "(deny default)" in profile

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -55,9 +55,7 @@ LinuxLibraryProbeResult = INSTALL_LLAMA_PREBUILT.LinuxLibraryProbeResult
 LINUX_LDD_PROBE_OK = INSTALL_LLAMA_PREBUILT._LINUX_LDD_PROBE_OK
 LINUX_LDD_PROBE_SKIPPED = INSTALL_LLAMA_PREBUILT._LINUX_LDD_PROBE_SKIPPED
 LINUX_LDD_PROBE_ERROR = INSTALL_LLAMA_PREBUILT._LINUX_LDD_PROBE_ERROR
-preflight_linux_installed_binaries = (
-    INSTALL_LLAMA_PREBUILT.preflight_linux_installed_binaries
-)
+preflight_linux_installed_binaries = INSTALL_LLAMA_PREBUILT.preflight_linux_installed_binaries
 
 
 def linux_host() -> HostInfo:
@@ -3183,13 +3181,17 @@ def test_build_validation_sandbox_plan_contract():
             purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_LDD,
             runtime_line = None,
             env = {"UNSANDBOXABLE": "1"},
-    ).purpose
-    == INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_LDD
+        ).purpose
+        == INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_LDD
     )
 
 
 def test_build_validation_sandbox_plan_linux_without_bwrap_skips_ldd_probe(monkeypatch):
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_resolve_command_path", lambda command: None if command == "bwrap" else "/usr/bin/bwrap")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: None if command == "bwrap" else "/usr/bin/bwrap",
+    )
     plan = build_validation_sandbox_plan(
         ["ldd", "/tmp/bin"],
         binary_path = Path("/tmp/bin"),
@@ -3205,7 +3207,11 @@ def test_build_validation_sandbox_plan_linux_without_bwrap_skips_ldd_probe(monke
 
 
 def test_build_validation_sandbox_plan_linux_without_bwrap_falls_back_validation(monkeypatch):
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_resolve_command_path", lambda command: None if command == "bwrap" else "/usr/bin/bwrap")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: None if command == "bwrap" else "/usr/bin/bwrap",
+    )
     plan = build_validation_sandbox_plan(
         ["llama-quantize", "in", "out"],
         binary_path = Path("/tmp/bin"),
@@ -3280,7 +3286,9 @@ def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch, tmp_pa
     assert str(helper_lib) in plan.command
 
 
-def test_build_validation_sandbox_plan_linux_server_probe_uses_resolved_helper_path(monkeypatch, tmp_path):
+def test_build_validation_sandbox_plan_linux_server_probe_uses_resolved_helper_path(
+    monkeypatch, tmp_path
+):
     bwrap_path = tmp_path / "bwrap"
     bwrap_path.write_text("")
     monkeypatch.setattr(
@@ -3391,7 +3399,9 @@ def test_build_validation_sandbox_plan_linux_server_probe_binds_nix_store(monkey
     assert _command_contains_path(plan, "nix/store")
 
 
-def test_build_validation_sandbox_plan_linux_gpu_uses_direct_validation_without_setuid_bwrap(monkeypatch, tmp_path):
+def test_build_validation_sandbox_plan_linux_gpu_uses_direct_validation_without_setuid_bwrap(
+    monkeypatch, tmp_path
+):
     bwrap_path = tmp_path / "bwrap"
     bwrap_path.write_text("")
     binary_path = tmp_path / "llama-server"
@@ -3440,7 +3450,7 @@ def test_linux_validation_server_probe_command_passes_payload_env_to_server_spaw
     )
     assert len(probe_command) == 3
     _, script = probe_command[0], probe_command[2]
-    assert "payload_env = {\"LD_LIBRARY_PATH\": \"/tmp/libs\", \"PYTHONPATH\": \"/tmp/python\"}" in script
+    assert 'payload_env = {"LD_LIBRARY_PATH": "/tmp/libs", "PYTHONPATH": "/tmp/python"}' in script
     assert "server_env = dict(os.environ)" in script
     assert "server_env.update(payload_env)" in script
     assert "timeout = 5" in script
@@ -3462,7 +3472,13 @@ def test_run_validation_capture_uses_launcher_env_for_linux_bwrap(monkeypatch):
 
     captured: dict[str, dict[str, str] | None] = {}
 
-    def fake_run_capture(command, *, timeout, env = None, check = False):
+    def fake_run_capture(
+        command,
+        *,
+        timeout,
+        env = None,
+        check = False,
+    ):
         captured["env"] = dict(env or {})
         return subprocess.CompletedProcess(command, 0, stdout = "ok")
 
@@ -3505,7 +3521,15 @@ def test_run_validation_popen_uses_launcher_env_for_linux_bwrap(monkeypatch):
 
     fake_process = _FakeProcess()
 
-    def fake_popen(command, *, stdout, stderr, text, env = None, **_kwargs):
+    def fake_popen(
+        command,
+        *,
+        stdout,
+        stderr,
+        text,
+        env = None,
+        **_kwargs,
+    ):
         fake_process.started_with = {
             "command": list(command),
             "stdout": stdout,
@@ -3591,7 +3615,13 @@ def test_build_validation_sandbox_plan_linux_quantize_binds_probe_and_output(mon
     for directory in (bin_dir, probe_dir, out_dir, runtime_dir):
         directory.mkdir()
     plan = build_validation_sandbox_plan(
-        [str(bin_dir / "llama-quantize"), str(probe_dir / "probe.gguf"), str(out_dir / "probe-q4.gguf"), "Q6_K", "2"],
+        [
+            str(bin_dir / "llama-quantize"),
+            str(probe_dir / "probe.gguf"),
+            str(out_dir / "probe-q4.gguf"),
+            "Q6_K",
+            "2",
+        ],
         binary_path = bin_dir / "llama-quantize",
         install_dir = tmp_path / "install",
         host = linux_host(),
@@ -3607,7 +3637,9 @@ def test_build_validation_sandbox_plan_linux_quantize_binds_probe_and_output(mon
     assert str(out_dir) in plan.command
 
 
-def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled(monkeypatch, tmp_path):
+def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled(
+    monkeypatch, tmp_path
+):
     monkeypatch.setattr(
         INSTALL_LLAMA_PREBUILT,
         "_resolve_command_path",
@@ -3649,7 +3681,11 @@ def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled
     def fake_glob(path: Path, pattern: str):
         normalized = _norm(path)
         if normalized == "/dev" and pattern == "nvidia*":
-            return [Path(node) for node in existing_nodes if str(node).startswith("/dev/nvidia") and "*" not in node]
+            return [
+                Path(node)
+                for node in existing_nodes
+                if str(node).startswith("/dev/nvidia") and "*" not in node
+            ]
         if normalized == "/dev/nvidia-caps" and pattern == "nvidia-cap*":
             return [Path("/dev/nvidia-caps/nvidia-cap1")]
         if normalized == "/dev/dri" and pattern == "card*":
@@ -3691,7 +3727,9 @@ def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled
     assert _command_contains_path(plan, "proc/driver/nvidia/capabilities")
 
 
-def test_build_validation_sandbox_plan_linux_server_binds_rocm_nodes_when_enabled(monkeypatch, tmp_path):
+def test_build_validation_sandbox_plan_linux_server_binds_rocm_nodes_when_enabled(
+    monkeypatch, tmp_path
+):
     monkeypatch.setattr(
         INSTALL_LLAMA_PREBUILT,
         "_resolve_command_path",
@@ -3785,7 +3823,7 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
     assert "(deny default)" in profile
     assert '(import "bsd.sb")' in profile
     assert "(allow file-map-executable" in profile
-    assert "(subpath \"/private\")" not in profile
+    assert '(subpath "/private")' not in profile
     assert '(subpath "/usr")' not in profile
     assert '(subpath "/Library")' not in profile
     assert any(
@@ -3837,7 +3875,7 @@ def test_build_validation_sandbox_plan_macos_server_keeps_loopback(monkeypatch):
     profile = plan.command[2]
     assert "(deny default)" in profile
     assert '(import "bsd.sb")' in profile
-    assert "(subpath \"/private\")" not in profile
+    assert '(subpath "/private")' not in profile
     assert '(subpath "/usr")' not in profile
     assert '(subpath "/Library")' not in profile
     assert '(allow network* (local ip "localhost:7777"))' in profile
@@ -3873,7 +3911,13 @@ def test_linux_missing_libraries_skips_ldd_without_sandbox_adapter(monkeypatch, 
 
     captured: dict[str, bool] = {"run": False}
 
-    def fake_run_capture(command, *, timeout, env = None, check = False):
+    def fake_run_capture(
+        command,
+        *,
+        timeout,
+        env = None,
+        check = False,
+    ):
         captured["run"] = True
         return subprocess.CompletedProcess(command, 0, stdout = "")
 
@@ -3883,7 +3927,9 @@ def test_linux_missing_libraries_skips_ldd_without_sandbox_adapter(monkeypatch, 
     assert captured["run"] is False
 
 
-def test_run_validation_ldd_probe_reports_skipped_status_without_sandbox_adapter(monkeypatch, tmp_path):
+def test_run_validation_ldd_probe_reports_skipped_status_without_sandbox_adapter(
+    monkeypatch, tmp_path
+):
     binary_path = tmp_path / "server"
     binary_path.write_text("")
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
@@ -3933,7 +3979,13 @@ def test_linux_missing_libraries_uses_bwrap_plan(monkeypatch, tmp_path):
     )
     captured = {}
 
-    def fake_run_capture(command, *, timeout, env = None, check = False):
+    def fake_run_capture(
+        command,
+        *,
+        timeout,
+        env = None,
+        check = False,
+    ):
         captured["command"] = command
         return subprocess.CompletedProcess(
             command,
@@ -4076,9 +4128,15 @@ def test_validate_quantize_routes_through_sandbox_plan(monkeypatch, tmp_path):
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_capture", fake_capture)
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", fake_binary_env)
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "run_capture", lambda *a, **k: (_ for _ in ()).throw(AssertionError("run_capture must not be used")))
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "run_capture",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("run_capture must not be used")),
+    )
 
-    validate_quantize(quantize_path, probe_path, quantized_path, install_dir, linux_host(), runtime_line = None)
+    validate_quantize(
+        quantize_path, probe_path, quantized_path, install_dir, linux_host(), runtime_line = None
+    )
     assert recorded["purpose"] == INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_QUANTIZE
     assert recorded["env"] == expected_env
     assert recorded["command"][:3] == [str(quantize_path), str(probe_path), str(quantized_path)]
@@ -4113,7 +4171,9 @@ def test_validate_quantize_falls_back_without_linux_sandbox(monkeypatch, tmp_pat
         )
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", lambda *_a, **_k: {"PATH": str(tmp_path)})
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT, "binary_env", lambda *_a, **_k: {"PATH": str(tmp_path)}
+    )
 
     with pytest.raises(PrebuiltFallback, match = "no sandbox"):
         validate_quantize(
@@ -4166,7 +4226,9 @@ def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", fake_binary_env)
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "free_local_port", lambda: 7777)
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.urllib.request, "urlopen", lambda *a, **k: _FakeResponse())
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT.urllib.request, "urlopen", lambda *a, **k: _FakeResponse()
+    )
     called_popen = False
 
     def fake_popen(*_a, **_k):
@@ -4200,7 +4262,9 @@ def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
         recorded["purpose"] = purpose
         recorded["enable_gpu_layers"] = enable_gpu_layers
         recorded["gpu_backend"] = gpu_backend
-        recorded["server_probe_mode"] = INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX
+        recorded["server_probe_mode"] = (
+            INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX
+        )
         return ValidationLaunchPlan(
             command = command,
             env = env,
@@ -4230,7 +4294,10 @@ def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
     assert recorded["gpu_backend"] == "cuda"
     assert called_capture is True
     assert called_popen is False
-    assert recorded["server_probe_mode"] == INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX
+    assert (
+        recorded["server_probe_mode"]
+        == INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX
+    )
 
 
 def test_validate_server_uses_extended_capture_timeout_for_in_sandbox_probe(monkeypatch, tmp_path):
@@ -4290,7 +4357,10 @@ def test_validate_server_uses_extended_capture_timeout_for_in_sandbox_probe(monk
     captured_timeout = called.get("timeout")
     assert called.get("purpose") == INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER
     assert isinstance(captured_timeout, int)
-    assert captured_timeout == INSTALL_LLAMA_PREBUILT._LINUX_SERVER_VALIDATION_HELPER_CAPTURE_TIMEOUT_SECONDS
+    assert (
+        captured_timeout
+        == INSTALL_LLAMA_PREBUILT._LINUX_SERVER_VALIDATION_HELPER_CAPTURE_TIMEOUT_SECONDS
+    )
     assert captured_timeout > INSTALL_LLAMA_PREBUILT._LINUX_SERVER_VALIDATION_HELPER_TIMEOUT_SECONDS
 
 
@@ -4301,9 +4371,15 @@ def test_validate_server_skips_gpu_layers_for_macos_arm64(monkeypatch, tmp_path)
     probe_path.write_text("")
     recorded: dict[str, object] = {}
 
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", lambda *_a, **_k: {"PATH": str(tmp_path)})
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT, "binary_env", lambda *_a, **_k: {"PATH": str(tmp_path)}
+    )
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "free_local_port", lambda: 7777)
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.urllib.request, "urlopen", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("stop")))
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT.urllib.request,
+        "urlopen",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("stop")),
+    )
 
     def fake_build_plan(
         command: list[str],
@@ -4425,8 +4501,12 @@ def test_validate_server_uses_windows_direct_validation_plan(monkeypatch, tmp_pa
             return None
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", lambda *_a, **_k: {"PATH": str(tmp_path)})
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_popen", lambda plan, *, stdout: _FakeProcess())
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT, "binary_env", lambda *_a, **_k: {"PATH": str(tmp_path)}
+    )
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT, "_run_validation_popen", lambda plan, *, stdout: _FakeProcess()
+    )
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "free_local_port", lambda: 7777)
 
     class _FakeResponse:
@@ -4441,7 +4521,9 @@ def test_validate_server_uses_windows_direct_validation_plan(monkeypatch, tmp_pa
         def __exit__(self, *exc):
             return False
 
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.urllib.request, "urlopen", lambda *a, **k: _FakeResponse())
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT.urllib.request, "urlopen", lambda *a, **k: _FakeResponse()
+    )
 
     validate_server(
         server_path,
@@ -4457,9 +4539,9 @@ def test_validate_server_uses_windows_direct_validation_plan(monkeypatch, tmp_pa
 
 
 def test_runtime_inference_path_stays_outside_installer_sandbox_owner():
-    backend_source = (Path(__file__).parents[3] / "studio/backend/core/inference/llama_cpp.py").read_text(
-        encoding = "utf-8", errors = "replace"
-    )
+    backend_source = (
+        Path(__file__).parents[3] / "studio/backend/core/inference/llama_cpp.py"
+    ).read_text(encoding = "utf-8", errors = "replace")
     assert "_ValidationLaunchPlan" not in backend_source
     assert "_run_validation_capture" not in backend_source
     assert "_run_validation_popen" not in backend_source
@@ -4587,9 +4669,7 @@ def _run_validate_prebuilt_choice(monkeypatch, tmp_path, *, expected_sha256):
 
 def test_validate_prebuilt_choice_approved_validation_skipped_when_flag_off(tmp_path, monkeypatch):
     # An approved (sha256-verified) bundle skips the smoke test while the flag is off.
-    calls, plans = _run_validate_prebuilt_choice(
-        monkeypatch, tmp_path, expected_sha256 = "ab" * 32
-    )
+    calls, plans = _run_validate_prebuilt_choice(monkeypatch, tmp_path, expected_sha256 = "ab" * 32)
     assert calls == {"quantize": 0, "server": 0}
     assert plans == []
 
@@ -4619,9 +4699,7 @@ def test_validate_prebuilt_choice_hashless_build_routes_through_validation_sandb
 def test_validate_prebuilt_choice_approved_validation_runs_when_flag_enabled(tmp_path, monkeypatch):
     # _RUN_STAGED_PREBUILT_VALIDATION back on restores the smoke test for approved bundles too.
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_RUN_STAGED_PREBUILT_VALIDATION", True)
-    calls, plans = _run_validate_prebuilt_choice(
-        monkeypatch, tmp_path, expected_sha256 = "ab" * 32
-    )
+    calls, plans = _run_validate_prebuilt_choice(monkeypatch, tmp_path, expected_sha256 = "ab" * 32)
     assert calls == {"quantize": 1, "server": 1}
     assert "ldd" in plans
     assert plans.count("quantize") == 1
@@ -4633,9 +4711,7 @@ def test_validate_prebuilt_choice_approved_validation_records_sandbox_routing(
     tmp_path, monkeypatch
 ):
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_RUN_STAGED_PREBUILT_VALIDATION", True)
-    _calls, plans = _run_validate_prebuilt_choice(
-        monkeypatch, tmp_path, expected_sha256 = "ab" * 32
-    )
+    _calls, plans = _run_validate_prebuilt_choice(monkeypatch, tmp_path, expected_sha256 = "ab" * 32)
     assert plans.count("ldd") >= 1
     assert plans.count("quantize") == 1
     assert plans.count("server") == 1

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3200,9 +3200,18 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
     profile = mac_run.command[2]
     assert "(deny default)" in profile
     assert '(import "bsd.sb")' in profile
-    assert "tmp\\\\install" in profile
-    assert "tmp\\\\models" in profile
-    assert "tmp\\\\out" in profile
+    assert any(
+        f'(subpath "{literal}")' in profile
+        for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals("/tmp/install")
+    )
+    assert any(
+        f'(subpath "{literal}")' in profile
+        for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals("/tmp/models")
+    )
+    assert any(
+        f'(subpath "{literal}")' in profile
+        for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals("/tmp/out")
+    )
     assert "localhost" not in profile
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -4045,7 +4045,9 @@ def test_build_validation_sandbox_plan_linux_server_probe_binds_nix_store(monkey
     assert _command_contains_path(plan, "nix/store")
 
 
-def test_build_validation_sandbox_plan_linux_gpu_keeps_sandbox_without_setuid_bwrap(monkeypatch, tmp_path):
+def test_build_validation_sandbox_plan_linux_gpu_keeps_sandbox_without_setuid_bwrap(
+    monkeypatch, tmp_path
+):
     bwrap_path = tmp_path / "bwrap"
     bwrap_path.write_text("")
     binary_path = tmp_path / "llama-server"
@@ -4070,7 +4072,8 @@ def test_build_validation_sandbox_plan_linux_gpu_keeps_sandbox_without_setuid_bw
                 "payload_env": dict(payload_env),
                 "timeout": timeout,
             }
-        ) or [str(helper_path), "-c", "server probe"],
+        )
+        or [str(helper_path), "-c", "server probe"],
     )
 
     plan = build_validation_sandbox_plan(

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3835,7 +3835,7 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
         binary_path = binary_path,
         install_dir = Path("/tmp/install"),
         host = macos_host(),
-        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_QUANTIZE,
         runtime_line = None,
         env = {},
     )
@@ -3848,11 +3848,28 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
         binary_path = binary_path,
         install_dir = Path("/tmp/install"),
         host = macos_host(),
-        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_QUANTIZE,
         runtime_line = None,
         env = {},
     )
     assert mac_skip.is_fallback
+
+
+def test_build_validation_sandbox_plan_macos_server_keeps_loopback(monkeypatch):
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "sandbox-exec"
+    )
+    plan = build_validation_sandbox_plan(
+        ["llama-server", "--help"],
+        binary_path = Path("/tmp/bin/llama-server"),
+        install_dir = Path("/tmp/install"),
+        host = macos_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {},
+    )
+    assert plan.is_runnable
+    assert plan.command[:3] == ["sandbox-exec", "-p", "(version 1)"]
 
 
 def test_build_validation_sandbox_plan_windows_is_unsupported(monkeypatch):

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -62,6 +62,13 @@ LINUX_LDD_PROBE_ERROR = INSTALL_LLAMA_PREBUILT._LINUX_LDD_PROBE_ERROR
 preflight_linux_installed_binaries = INSTALL_LLAMA_PREBUILT.preflight_linux_installed_binaries
 
 
+@pytest.fixture(autouse = True)
+def _bwrap_usable_by_default(monkeypatch):
+    # A mocked-present bwrap represents a working sandbox; the real usability probe
+    # (which would exec bwrap) is out of scope here and covered by its own test.
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_bwrap_can_sandbox", lambda _p: True)
+
+
 def linux_host() -> HostInfo:
     return HostInfo(
         system = "Linux",
@@ -3869,6 +3876,29 @@ def test_build_validation_sandbox_plan_linux_without_bwrap_falls_back_validation
     )
     assert plan.is_fallback
     assert plan.reason is not None
+
+
+def test_build_validation_sandbox_plan_linux_unusable_bwrap_skips_ldd(monkeypatch):
+    # bwrap present but unable to create namespaces (restricted userns) must degrade
+    # like an absent bwrap so the mandatory ldd preflight does not reject the prebuilt.
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: "/usr/bin/bwrap" if command == "bwrap" else "/usr/bin/" + command,
+    )
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_bwrap_can_sandbox", lambda _p: False)
+    plan = build_validation_sandbox_plan(
+        ["ldd", "/tmp/bin"],
+        binary_path = Path("/tmp/bin"),
+        install_dir = Path("/tmp/install"),
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_LDD,
+        runtime_line = None,
+        env = {},
+    )
+    assert plan.is_skipped
+    assert plan.reason is not None
+    assert "skip ldd probe" in plan.reason
 
 
 def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch, tmp_path):

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -1304,6 +1304,13 @@ def _command_contains_path(plan: ValidationLaunchPlan, path_fragment: str) -> bo
     )
 
 
+def _command_has_setenv(plan: ValidationLaunchPlan, key: str) -> bool:
+    for index in range(len(plan.command) - 2):
+        if plan.command[index] == "--setenv" and plan.command[index + 1] == key:
+            return True
+    return False
+
+
 def test_install_prebuilt_falls_back_to_older_release_plan(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
@@ -3828,7 +3835,7 @@ def test_build_validation_sandbox_plan_contract():
 
 
 def test_build_validation_sandbox_plan_linux_without_bwrap_skips_ldd_probe(monkeypatch):
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_resolve_command_path", lambda command: None if command == "bwrap" else "/usr/bin/bwrap")
     plan = build_validation_sandbox_plan(
         ["ldd", "/tmp/bin"],
         binary_path = Path("/tmp/bin"),
@@ -3844,7 +3851,7 @@ def test_build_validation_sandbox_plan_linux_without_bwrap_skips_ldd_probe(monke
 
 
 def test_build_validation_sandbox_plan_linux_without_bwrap_falls_back_validation(monkeypatch):
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_resolve_command_path", lambda command: None if command == "bwrap" else "/usr/bin/bwrap")
     plan = build_validation_sandbox_plan(
         ["llama-quantize", "in", "out"],
         binary_path = Path("/tmp/bin"),
@@ -3859,7 +3866,13 @@ def test_build_validation_sandbox_plan_linux_without_bwrap_falls_back_validation
 
 
 def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch, tmp_path):
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    bwrap_path = tmp_path / "bwrap"
+    bwrap_path.write_text("")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: str(bwrap_path) if command == "bwrap" else None,
+    )
     helper_bin = tmp_path / "helper" / "bin"
     helper_lib = tmp_path / "helper" / "lib"
     install_dir = tmp_path / "install"
@@ -3872,7 +3885,7 @@ def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch, tmp_pa
     monkeypatch.setattr(
         INSTALL_LLAMA_PREBUILT,
         "_linux_validation_server_probe_command",
-        lambda command, timeout = 60: [str(helper_path), "-c", "server probe"],
+        lambda command, payload_env, timeout = 60: [str(helper_path), "-c", "server probe"],
     )
     binary_path = binary_dir / "llama-server"
     binary_path.write_text("")
@@ -3886,11 +3899,15 @@ def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch, tmp_pa
         env = {"LD_LIBRARY_PATH": "/tmp/payload/libs"},
     )
     assert plan.is_runnable
-    assert plan.command[0] == "bwrap"
+    assert plan.command[0] == str(bwrap_path)
     assert plan.command[1] == "--unshare-all"
     assert "--share-net" not in plan.command
     assert "--setenv" in plan.command
-    assert "LD_LIBRARY_PATH" in plan.command
+    assert not _command_has_setenv(plan, "LD_LIBRARY_PATH")
+    assert "--tmpfs" in plan.command
+    assert "--perms" in plan.command
+    assert "1777" in plan.command
+    assert "/tmp" in plan.command
     assert plan.env.get("LD_LIBRARY_PATH") is None
     assert plan.payload_command == [
         "llama-server",
@@ -3907,6 +3924,29 @@ def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch, tmp_pa
     assert plan.network_policy == INSTALL_LLAMA_PREBUILT._VALIDATION_NETWORK_POLICY_SANDBOX
     assert str(model_dir) in plan.command
     assert str(helper_lib) in plan.command
+
+
+def test_linux_validation_server_probe_command_passes_payload_env_to_server_spawn():
+    probe_command = INSTALL_LLAMA_PREBUILT._linux_validation_server_probe_command(
+        [
+            "/opt/llama-server",
+            "-m",
+            "/tmp/models/stories260K.gguf",
+            "--port",
+            "7777",
+        ],
+        {
+            "LD_LIBRARY_PATH": "/tmp/libs",
+            "PYTHONPATH": "/tmp/python",
+        },
+    )
+    assert len(probe_command) == 3
+    _, script = probe_command[0], probe_command[2]
+    assert "payload_env = {\"LD_LIBRARY_PATH\": \"/tmp/libs\", \"PYTHONPATH\": \"/tmp/python\"}" in script
+    assert "server_env = dict(os.environ)" in script
+    assert "server_env.update(payload_env)" in script
+    assert "timeout = 5" in script
+    assert "with urllib.request.urlopen(request, timeout = 5)" in script
 
 
 def test_run_validation_capture_uses_launcher_env_for_linux_bwrap(monkeypatch):
@@ -4041,7 +4081,11 @@ def test_validate_server_strips_python_import_roots_from_payload_env(monkeypatch
 
 
 def test_build_validation_sandbox_plan_linux_quantize_binds_probe_and_output(monkeypatch, tmp_path):
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: "/tmp/bin/bwrap" if command == "bwrap" else None,
+    )
     bin_dir = tmp_path / "bin"
     probe_dir = tmp_path / "models"
     out_dir = tmp_path / "out"
@@ -4058,6 +4102,7 @@ def test_build_validation_sandbox_plan_linux_quantize_binds_probe_and_output(mon
         env = {"LD_LIBRARY_PATH": str(runtime_dir)},
     )
     assert plan.is_runnable
+    assert _command_has_setenv(plan, "LD_LIBRARY_PATH")
     assert plan.command.count("--ro-bind") >= 3
     assert plan.command.count("--bind") >= 2
     assert str(probe_dir) in plan.command
@@ -4065,7 +4110,11 @@ def test_build_validation_sandbox_plan_linux_quantize_binds_probe_and_output(mon
 
 
 def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled(monkeypatch, tmp_path):
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: "/tmp/bin/bwrap" if command == "bwrap" else None,
+    )
     existing_nodes = {
         "/dev/nvidiactl",
         "/dev/nvidia-uvm",
@@ -4133,7 +4182,11 @@ def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled
 
 
 def test_build_validation_sandbox_plan_linux_server_binds_rocm_nodes_when_enabled(monkeypatch, tmp_path):
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: "/tmp/bin/bwrap" if command == "bwrap" else None,
+    )
     existing_nodes = {
         "/dev/kfd",
         "/dev/dxg",
@@ -4216,6 +4269,8 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
     assert "(deny default)" in profile
     assert '(import "bsd.sb")' in profile
     assert "(subpath \"/private\")" not in profile
+    assert '(subpath "/usr")' not in profile
+    assert '(subpath "/Library")' not in profile
     assert any(
         f'(subpath "{literal}")' in profile
         for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals("/tmp/install")
@@ -4248,7 +4303,7 @@ def test_build_validation_sandbox_plan_macos_server_keeps_loopback(monkeypatch):
         INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "sandbox-exec"
     )
     plan = build_validation_sandbox_plan(
-        ["llama-server", "--help"],
+        ["llama-server", "-m", str(Path("/tmp/models/story.gguf")), "--port", "7777"],
         binary_path = Path("/tmp/bin/llama-server"),
         install_dir = Path("/tmp/install"),
         host = macos_host(),
@@ -4262,8 +4317,12 @@ def test_build_validation_sandbox_plan_macos_server_keeps_loopback(monkeypatch):
     assert "(deny default)" in profile
     assert '(import "bsd.sb")' in profile
     assert "(subpath \"/private\")" not in profile
-    assert '(allow network* (local ip "localhost:*"))' in profile
-    assert '(allow network* (remote ip "localhost:*"))' in profile
+    assert '(subpath "/usr")' not in profile
+    assert '(subpath "/Library")' not in profile
+    assert '(allow network* (local ip "localhost:7777"))' in profile
+    assert '(allow network* (remote ip "localhost:7777"))' in profile
+    assert '(allow network* (local ip "localhost:*"))' not in profile
+    assert '(allow network* (remote ip "localhost:*"))' not in profile
 
 
 def test_build_validation_sandbox_plan_windows_is_unsupported(monkeypatch):
@@ -4285,7 +4344,11 @@ def test_linux_missing_libraries_skips_ldd_without_sandbox_adapter(monkeypatch, 
     binary_path = tmp_path / "server"
     binary_path.write_text("")
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: None if command == "bwrap" else "/usr/bin/bwrap",
+    )
 
     captured: dict[str, bool] = {"run": False}
 
@@ -4303,7 +4366,11 @@ def test_run_validation_ldd_probe_reports_skipped_status_without_sandbox_adapter
     binary_path = tmp_path / "server"
     binary_path.write_text("")
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: None if command == "bwrap" else "/usr/bin/bwrap",
+    )
     result = run_validation_ldd_probe(binary_path, env = {"LD_LIBRARY_PATH": ""})
     assert result.status == LINUX_LDD_PROBE_SKIPPED
     assert result.missing == []
@@ -4315,9 +4382,10 @@ def test_run_validation_ldd_probe_reports_error_on_nonzero_returncode(monkeypatc
     binary_path.write_text("")
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
     monkeypatch.setattr(
-        INSTALL_LLAMA_PREBUILT.shutil, "which", lambda name: f"/usr/bin/{name}"
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: f"/usr/bin/{command}",
     )
 
     def fake_capture(plan, *, timeout: int):
@@ -4336,8 +4404,12 @@ def test_linux_missing_libraries_uses_bwrap_plan(monkeypatch, tmp_path):
     binary_path.write_text("")
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.shutil, "which", lambda name: f"/usr/bin/{name}")
+    bwrap_path = "/usr/bin/bwrap"
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: bwrap_path if command == "bwrap" else None,
+    )
     captured = {}
 
     def fake_run_capture(command, *, timeout, env = None, check = False):
@@ -4351,7 +4423,7 @@ def test_linux_missing_libraries_uses_bwrap_plan(monkeypatch, tmp_path):
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "run_capture", fake_run_capture)
     assert linux_missing_libraries(binary_path, env = {"LD_LIBRARY_PATH": ""}) == ["libbad"]
-    assert captured["command"][0] == "bwrap"
+    assert captured["command"][0] == bwrap_path
     assert any(Path(part).stem == "ldd" for part in captured["command"])
 
 
@@ -4638,6 +4710,67 @@ def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
     assert called_capture is True
     assert called_popen is False
     assert recorded["server_probe_mode"] == INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX
+
+
+def test_validate_server_uses_extended_capture_timeout_for_in_sandbox_probe(monkeypatch, tmp_path):
+    server_path = tmp_path / "llama-server"
+    server_path.write_text("")
+    probe_path = tmp_path / "probe.gguf"
+    probe_path.write_text("")
+    install_dir = tmp_path
+
+    called: dict[str, object] = {}
+
+    def fake_binary_env(*_a, **_k):
+        return {"PATH": str(tmp_path)}
+
+    def fake_capture(_plan, *, timeout: int):
+        called["timeout"] = timeout
+        return subprocess.CompletedProcess(_plan.command, 0, stdout = "ok")
+
+    def fake_build_plan(
+        command: list[str],
+        *,
+        binary_path: Path,
+        install_dir: Path,
+        purpose: str,
+        env: dict[str, str],
+        host = None,
+        runtime_line = None,
+        enable_gpu_layers: bool = False,
+        gpu_backend = None,
+    ) -> ValidationLaunchPlan:
+        called["purpose"] = purpose
+        return ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = "run",
+            purpose = purpose,
+            sandbox_kind = "linux_bwrap",
+            payload_command = command,
+            payload_env = env,
+            server_probe_mode = INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX,
+        )
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", fake_binary_env)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "free_local_port", lambda: 7777)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_capture", fake_capture)
+
+    validate_server(
+        server_path,
+        probe_path,
+        linux_host(),
+        install_dir,
+        runtime_line = None,
+        install_kind = "linux-cuda",
+    )
+
+    captured_timeout = called.get("timeout")
+    assert called.get("purpose") == INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER
+    assert isinstance(captured_timeout, int)
+    assert captured_timeout == INSTALL_LLAMA_PREBUILT._LINUX_SERVER_VALIDATION_HELPER_CAPTURE_TIMEOUT_SECONDS
+    assert captured_timeout > INSTALL_LLAMA_PREBUILT._LINUX_SERVER_VALIDATION_HELPER_TIMEOUT_SECONDS
 
 
 def test_validate_server_falls_back_without_linux_sandbox(monkeypatch, tmp_path):

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3872,7 +3872,7 @@ def test_build_validation_sandbox_plan_linux_without_bwrap_skips_ldd_probe(monke
     assert "skip ldd probe" in plan.reason
 
 
-def test_build_validation_sandbox_plan_linux_without_bwrap_falls_back_validation(monkeypatch):
+def test_build_validation_sandbox_plan_linux_without_bwrap_skips_validation(monkeypatch):
     monkeypatch.setattr(
         INSTALL_LLAMA_PREBUILT,
         "_resolve_command_path",
@@ -3887,8 +3887,11 @@ def test_build_validation_sandbox_plan_linux_without_bwrap_falls_back_validation
         runtime_line = None,
         env = {},
     )
-    assert plan.is_fallback
+    assert plan.is_skipped
     assert plan.reason is not None
+    assert "skip downloaded-binary validation" in plan.reason
+    assert plan.network_policy is None
+    assert plan.server_probe_mode is None
 
 
 def test_build_validation_sandbox_plan_linux_unusable_bwrap_skips_ldd(monkeypatch):
@@ -4737,6 +4740,33 @@ def test_run_validation_ldd_probe_reports_error_on_nonzero_returncode(monkeypatc
     assert "bind failed" in result.reason
 
 
+def test_run_validation_ldd_probe_accepts_static_binary_output(monkeypatch, tmp_path):
+    binary_path = tmp_path / "server"
+    binary_path.write_text("")
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: f"/usr/bin/{command}",
+    )
+
+    def fake_capture(plan, *, timeout: int):
+        return subprocess.CompletedProcess(
+            plan.command,
+            1,
+            stdout = "",
+            stderr = "not a dynamic executable",
+        )
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_capture", fake_capture)
+
+    result = run_validation_ldd_probe(binary_path, env = {"LD_LIBRARY_PATH": ""})
+    assert result.status == LINUX_LDD_PROBE_OK
+    assert result.missing == []
+    assert result.reason == "static executable"
+
+
 def test_linux_missing_libraries_uses_bwrap_plan(monkeypatch, tmp_path):
     binary_path = tmp_path / "server"
     binary_path.write_text("")
@@ -4914,7 +4944,7 @@ def test_validate_quantize_routes_through_sandbox_plan(monkeypatch, tmp_path):
     assert quantized_path.exists()
 
 
-def test_validate_quantize_falls_back_without_linux_sandbox(monkeypatch, tmp_path):
+def test_validate_quantize_skips_without_linux_sandbox(monkeypatch, tmp_path):
     quantize_path = tmp_path / "llama-quantize"
     quantize_path.write_text("")
     probe_path = tmp_path / "probe.gguf"
@@ -4936,7 +4966,7 @@ def test_validate_quantize_falls_back_without_linux_sandbox(monkeypatch, tmp_pat
         return ValidationLaunchPlan(
             command = command,
             env = env,
-            action = "fallback",
+            action = "skip",
             purpose = purpose,
             reason = "no sandbox",
         )
@@ -4945,16 +4975,21 @@ def test_validate_quantize_falls_back_without_linux_sandbox(monkeypatch, tmp_pat
     monkeypatch.setattr(
         INSTALL_LLAMA_PREBUILT, "binary_env", lambda *_a, **_k: {"PATH": str(tmp_path)}
     )
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "run_capture",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("run_capture must not be used")),
+    )
 
-    with pytest.raises(PrebuiltFallback, match = "no sandbox"):
-        validate_quantize(
-            quantize_path,
-            probe_path,
-            quantized_path,
-            tmp_path,
-            linux_host(),
-            runtime_line = None,
-        )
+    validate_quantize(
+        quantize_path,
+        probe_path,
+        quantized_path,
+        tmp_path,
+        linux_host(),
+        runtime_line = None,
+    )
+    assert not quantized_path.exists()
 
 
 def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
@@ -5191,7 +5226,7 @@ def test_validate_server_skips_gpu_layers_for_macos_arm64(monkeypatch, tmp_path)
     assert recorded["enable_gpu_layers"] is False
 
 
-def test_validate_server_falls_back_without_linux_sandbox(monkeypatch, tmp_path):
+def test_validate_server_skips_without_linux_sandbox(monkeypatch, tmp_path):
     server_path = tmp_path / "llama-server"
     server_path.write_text("")
     probe_path = tmp_path / "probe.gguf"
@@ -5212,22 +5247,26 @@ def test_validate_server_falls_back_without_linux_sandbox(monkeypatch, tmp_path)
         return ValidationLaunchPlan(
             command = command,
             env = env,
-            action = "fallback",
+            action = "skip",
             purpose = purpose,
             reason = "no sandbox",
         )
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT.subprocess,
+        "Popen",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("Popen must not be used")),
+    )
 
-    with pytest.raises(PrebuiltFallback, match = "no sandbox"):
-        validate_server(
-            server_path,
-            probe_path,
-            linux_host(),
-            tmp_path,
-            runtime_line = None,
-            install_kind = None,
-        )
+    validate_server(
+        server_path,
+        probe_path,
+        linux_host(),
+        tmp_path,
+        runtime_line = None,
+        install_kind = None,
+    )
 
 
 def test_validate_server_uses_windows_direct_validation_plan(monkeypatch, tmp_path):
@@ -5325,8 +5364,9 @@ def _run_validate_prebuilt_choice(
     *,
     expected_sha256,
     probe = None,
+    validation_action = "run",
 ):
-    """Run validate_prebuilt_choice with heavy steps stubbed; return calls and launch purposes."""
+    """Run validate_prebuilt_choice with heavy steps stubbed; return launch metadata."""
     calls = {"quantize": 0, "server": 0}
     plans: list[str] = []
     server_path = tmp_path / "install" / "build" / "bin" / "llama-server"
@@ -5360,11 +5400,14 @@ def _run_validate_prebuilt_choice(
         return ValidationLaunchPlan(
             command = command,
             env = env,
-            action = "run",
+            action = validation_action,
             purpose = purpose,
+            reason = "validation launch unavailable" if validation_action != "run" else None,
         )
 
     def fake_run_validation_capture(plan: ValidationLaunchPlan, *, timeout: int):
+        if plan.action != "run":
+            raise src.ValidationLaunchUnavailable(plan.reason or "validation launch unavailable")
         if plan.purpose == src._VALIDATION_PURPOSE_QUANTIZE:
             calls["quantize"] += 1
             quantized_path.write_bytes(b"quantized")
@@ -5396,6 +5439,8 @@ def _run_validate_prebuilt_choice(
             return None
 
     def fake_run_validation_popen(plan: ValidationLaunchPlan, *, stdout):
+        if plan.action != "run":
+            raise src.ValidationLaunchUnavailable(plan.reason or "validation launch unavailable")
         assert plan.purpose == src._VALIDATION_PURPOSE_SERVER
         calls["server"] += 1
         return _DummyProcess()
@@ -5471,6 +5516,18 @@ def test_validate_prebuilt_choice_hashless_build_routes_through_validation_sandb
     assert plans.index("quantize") < plans.index("server")
     assert plans[0] == "ldd"
     assert plans[-1] == "server"
+
+
+def test_validate_prebuilt_choice_hashless_build_falls_back_when_validation_launch_skips(
+    tmp_path, monkeypatch
+):
+    with pytest.raises(PrebuiltFallback, match = "llama-quantize validation unavailable"):
+        _run_validate_prebuilt_choice(
+            monkeypatch,
+            tmp_path,
+            expected_sha256 = None,
+            validation_action = "skip",
+        )
 
 
 def test_validate_prebuilt_choice_approved_validation_runs_when_flag_enabled(tmp_path, monkeypatch):

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -59,9 +59,7 @@ LinuxLibraryProbeResult = INSTALL_LLAMA_PREBUILT.LinuxLibraryProbeResult
 LINUX_LDD_PROBE_OK = INSTALL_LLAMA_PREBUILT._LINUX_LDD_PROBE_OK
 LINUX_LDD_PROBE_SKIPPED = INSTALL_LLAMA_PREBUILT._LINUX_LDD_PROBE_SKIPPED
 LINUX_LDD_PROBE_ERROR = INSTALL_LLAMA_PREBUILT._LINUX_LDD_PROBE_ERROR
-preflight_linux_installed_binaries = (
-    INSTALL_LLAMA_PREBUILT.preflight_linux_installed_binaries
-)
+preflight_linux_installed_binaries = INSTALL_LLAMA_PREBUILT.preflight_linux_installed_binaries
 
 
 def linux_host() -> HostInfo:
@@ -3829,13 +3827,17 @@ def test_build_validation_sandbox_plan_contract():
             purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_LDD,
             runtime_line = None,
             env = {"UNSANDBOXABLE": "1"},
-    ).purpose
-    == INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_LDD
+        ).purpose
+        == INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_LDD
     )
 
 
 def test_build_validation_sandbox_plan_linux_without_bwrap_skips_ldd_probe(monkeypatch):
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_resolve_command_path", lambda command: None if command == "bwrap" else "/usr/bin/bwrap")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: None if command == "bwrap" else "/usr/bin/bwrap",
+    )
     plan = build_validation_sandbox_plan(
         ["ldd", "/tmp/bin"],
         binary_path = Path("/tmp/bin"),
@@ -3851,7 +3853,11 @@ def test_build_validation_sandbox_plan_linux_without_bwrap_skips_ldd_probe(monke
 
 
 def test_build_validation_sandbox_plan_linux_without_bwrap_falls_back_validation(monkeypatch):
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_resolve_command_path", lambda command: None if command == "bwrap" else "/usr/bin/bwrap")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: None if command == "bwrap" else "/usr/bin/bwrap",
+    )
     plan = build_validation_sandbox_plan(
         ["llama-quantize", "in", "out"],
         binary_path = Path("/tmp/bin"),
@@ -3926,7 +3932,9 @@ def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch, tmp_pa
     assert str(helper_lib) in plan.command
 
 
-def test_build_validation_sandbox_plan_linux_server_probe_uses_resolved_helper_path(monkeypatch, tmp_path):
+def test_build_validation_sandbox_plan_linux_server_probe_uses_resolved_helper_path(
+    monkeypatch, tmp_path
+):
     bwrap_path = tmp_path / "bwrap"
     bwrap_path.write_text("")
     monkeypatch.setattr(
@@ -4037,7 +4045,9 @@ def test_build_validation_sandbox_plan_linux_server_probe_binds_nix_store(monkey
     assert _command_contains_path(plan, "nix/store")
 
 
-def test_build_validation_sandbox_plan_linux_gpu_uses_direct_validation_without_setuid_bwrap(monkeypatch, tmp_path):
+def test_build_validation_sandbox_plan_linux_gpu_uses_direct_validation_without_setuid_bwrap(
+    monkeypatch, tmp_path
+):
     bwrap_path = tmp_path / "bwrap"
     bwrap_path.write_text("")
     binary_path = tmp_path / "llama-server"
@@ -4086,7 +4096,7 @@ def test_linux_validation_server_probe_command_passes_payload_env_to_server_spaw
     )
     assert len(probe_command) == 3
     _, script = probe_command[0], probe_command[2]
-    assert "payload_env = {\"LD_LIBRARY_PATH\": \"/tmp/libs\", \"PYTHONPATH\": \"/tmp/python\"}" in script
+    assert 'payload_env = {"LD_LIBRARY_PATH": "/tmp/libs", "PYTHONPATH": "/tmp/python"}' in script
     assert "server_env = dict(os.environ)" in script
     assert "server_env.update(payload_env)" in script
     assert "timeout = 5" in script
@@ -4108,7 +4118,13 @@ def test_run_validation_capture_uses_launcher_env_for_linux_bwrap(monkeypatch):
 
     captured: dict[str, dict[str, str] | None] = {}
 
-    def fake_run_capture(command, *, timeout, env = None, check = False):
+    def fake_run_capture(
+        command,
+        *,
+        timeout,
+        env = None,
+        check = False,
+    ):
         captured["env"] = dict(env or {})
         return subprocess.CompletedProcess(command, 0, stdout = "ok")
 
@@ -4151,7 +4167,15 @@ def test_run_validation_popen_uses_launcher_env_for_linux_bwrap(monkeypatch):
 
     fake_process = _FakeProcess()
 
-    def fake_popen(command, *, stdout, stderr, text, env = None, **_kwargs):
+    def fake_popen(
+        command,
+        *,
+        stdout,
+        stderr,
+        text,
+        env = None,
+        **_kwargs,
+    ):
         fake_process.started_with = {
             "command": list(command),
             "stdout": stdout,
@@ -4237,7 +4261,13 @@ def test_build_validation_sandbox_plan_linux_quantize_binds_probe_and_output(mon
     for directory in (bin_dir, probe_dir, out_dir, runtime_dir):
         directory.mkdir()
     plan = build_validation_sandbox_plan(
-        [str(bin_dir / "llama-quantize"), str(probe_dir / "probe.gguf"), str(out_dir / "probe-q4.gguf"), "Q6_K", "2"],
+        [
+            str(bin_dir / "llama-quantize"),
+            str(probe_dir / "probe.gguf"),
+            str(out_dir / "probe-q4.gguf"),
+            "Q6_K",
+            "2",
+        ],
         binary_path = bin_dir / "llama-quantize",
         install_dir = tmp_path / "install",
         host = linux_host(),
@@ -4253,7 +4283,9 @@ def test_build_validation_sandbox_plan_linux_quantize_binds_probe_and_output(mon
     assert str(out_dir) in plan.command
 
 
-def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled(monkeypatch, tmp_path):
+def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled(
+    monkeypatch, tmp_path
+):
     monkeypatch.setattr(
         INSTALL_LLAMA_PREBUILT,
         "_resolve_command_path",
@@ -4295,7 +4327,11 @@ def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled
     def fake_glob(path: Path, pattern: str):
         normalized = _norm(path)
         if normalized == "/dev" and pattern == "nvidia*":
-            return [Path(node) for node in existing_nodes if str(node).startswith("/dev/nvidia") and "*" not in node]
+            return [
+                Path(node)
+                for node in existing_nodes
+                if str(node).startswith("/dev/nvidia") and "*" not in node
+            ]
         if normalized == "/dev/nvidia-caps" and pattern == "nvidia-cap*":
             return [Path("/dev/nvidia-caps/nvidia-cap1")]
         if normalized == "/dev/dri" and pattern == "card*":
@@ -4337,7 +4373,9 @@ def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled
     assert _command_contains_path(plan, "proc/driver/nvidia/capabilities")
 
 
-def test_build_validation_sandbox_plan_linux_server_binds_rocm_nodes_when_enabled(monkeypatch, tmp_path):
+def test_build_validation_sandbox_plan_linux_server_binds_rocm_nodes_when_enabled(
+    monkeypatch, tmp_path
+):
     monkeypatch.setattr(
         INSTALL_LLAMA_PREBUILT,
         "_resolve_command_path",
@@ -4431,7 +4469,7 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
     assert "(deny default)" in profile
     assert '(import "bsd.sb")' in profile
     assert "(allow file-map-executable" in profile
-    assert "(subpath \"/private\")" not in profile
+    assert '(subpath "/private")' not in profile
     assert '(subpath "/usr")' not in profile
     assert '(subpath "/Library")' not in profile
     assert any(
@@ -4483,7 +4521,7 @@ def test_build_validation_sandbox_plan_macos_server_keeps_loopback(monkeypatch):
     profile = plan.command[2]
     assert "(deny default)" in profile
     assert '(import "bsd.sb")' in profile
-    assert "(subpath \"/private\")" not in profile
+    assert '(subpath "/private")' not in profile
     assert '(subpath "/usr")' not in profile
     assert '(subpath "/Library")' not in profile
     assert '(allow network* (local ip "localhost:7777"))' in profile
@@ -4519,7 +4557,13 @@ def test_linux_missing_libraries_skips_ldd_without_sandbox_adapter(monkeypatch, 
 
     captured: dict[str, bool] = {"run": False}
 
-    def fake_run_capture(command, *, timeout, env = None, check = False):
+    def fake_run_capture(
+        command,
+        *,
+        timeout,
+        env = None,
+        check = False,
+    ):
         captured["run"] = True
         return subprocess.CompletedProcess(command, 0, stdout = "")
 
@@ -4529,7 +4573,9 @@ def test_linux_missing_libraries_skips_ldd_without_sandbox_adapter(monkeypatch, 
     assert captured["run"] is False
 
 
-def test_run_validation_ldd_probe_reports_skipped_status_without_sandbox_adapter(monkeypatch, tmp_path):
+def test_run_validation_ldd_probe_reports_skipped_status_without_sandbox_adapter(
+    monkeypatch, tmp_path
+):
     binary_path = tmp_path / "server"
     binary_path.write_text("")
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
@@ -4579,7 +4625,13 @@ def test_linux_missing_libraries_uses_bwrap_plan(monkeypatch, tmp_path):
     )
     captured = {}
 
-    def fake_run_capture(command, *, timeout, env = None, check = False):
+    def fake_run_capture(
+        command,
+        *,
+        timeout,
+        env = None,
+        check = False,
+    ):
         captured["command"] = command
         return subprocess.CompletedProcess(
             command,
@@ -4722,9 +4774,15 @@ def test_validate_quantize_routes_through_sandbox_plan(monkeypatch, tmp_path):
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_capture", fake_capture)
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", fake_binary_env)
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "run_capture", lambda *a, **k: (_ for _ in ()).throw(AssertionError("run_capture must not be used")))
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "run_capture",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("run_capture must not be used")),
+    )
 
-    validate_quantize(quantize_path, probe_path, quantized_path, install_dir, linux_host(), runtime_line = None)
+    validate_quantize(
+        quantize_path, probe_path, quantized_path, install_dir, linux_host(), runtime_line = None
+    )
     assert recorded["purpose"] == INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_QUANTIZE
     assert recorded["env"] == expected_env
     assert recorded["command"][:3] == [str(quantize_path), str(probe_path), str(quantized_path)]
@@ -4759,7 +4817,9 @@ def test_validate_quantize_falls_back_without_linux_sandbox(monkeypatch, tmp_pat
         )
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", lambda *_a, **_k: {"PATH": str(tmp_path)})
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT, "binary_env", lambda *_a, **_k: {"PATH": str(tmp_path)}
+    )
 
     with pytest.raises(PrebuiltFallback, match = "no sandbox"):
         validate_quantize(
@@ -4812,7 +4872,9 @@ def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", fake_binary_env)
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "free_local_port", lambda: 7777)
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.urllib.request, "urlopen", lambda *a, **k: _FakeResponse())
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT.urllib.request, "urlopen", lambda *a, **k: _FakeResponse()
+    )
     called_popen = False
 
     def fake_popen(*_a, **_k):
@@ -4846,7 +4908,9 @@ def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
         recorded["purpose"] = purpose
         recorded["enable_gpu_layers"] = enable_gpu_layers
         recorded["gpu_backend"] = gpu_backend
-        recorded["server_probe_mode"] = INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX
+        recorded["server_probe_mode"] = (
+            INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX
+        )
         return ValidationLaunchPlan(
             command = command,
             env = env,
@@ -4876,7 +4940,10 @@ def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
     assert recorded["gpu_backend"] == "cuda"
     assert called_capture is True
     assert called_popen is False
-    assert recorded["server_probe_mode"] == INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX
+    assert (
+        recorded["server_probe_mode"]
+        == INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX
+    )
 
 
 def test_validate_server_uses_extended_capture_timeout_for_in_sandbox_probe(monkeypatch, tmp_path):
@@ -4936,7 +5003,10 @@ def test_validate_server_uses_extended_capture_timeout_for_in_sandbox_probe(monk
     captured_timeout = called.get("timeout")
     assert called.get("purpose") == INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER
     assert isinstance(captured_timeout, int)
-    assert captured_timeout == INSTALL_LLAMA_PREBUILT._LINUX_SERVER_VALIDATION_HELPER_CAPTURE_TIMEOUT_SECONDS
+    assert (
+        captured_timeout
+        == INSTALL_LLAMA_PREBUILT._LINUX_SERVER_VALIDATION_HELPER_CAPTURE_TIMEOUT_SECONDS
+    )
     assert captured_timeout > INSTALL_LLAMA_PREBUILT._LINUX_SERVER_VALIDATION_HELPER_TIMEOUT_SECONDS
 
 
@@ -4947,9 +5017,15 @@ def test_validate_server_skips_gpu_layers_for_macos_arm64(monkeypatch, tmp_path)
     probe_path.write_text("")
     recorded: dict[str, object] = {}
 
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", lambda *_a, **_k: {"PATH": str(tmp_path)})
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT, "binary_env", lambda *_a, **_k: {"PATH": str(tmp_path)}
+    )
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "free_local_port", lambda: 7777)
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.urllib.request, "urlopen", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("stop")))
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT.urllib.request,
+        "urlopen",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("stop")),
+    )
 
     def fake_build_plan(
         command: list[str],
@@ -5071,8 +5147,12 @@ def test_validate_server_uses_windows_direct_validation_plan(monkeypatch, tmp_pa
             return None
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", lambda *_a, **_k: {"PATH": str(tmp_path)})
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_popen", lambda plan, *, stdout: _FakeProcess())
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT, "binary_env", lambda *_a, **_k: {"PATH": str(tmp_path)}
+    )
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT, "_run_validation_popen", lambda plan, *, stdout: _FakeProcess()
+    )
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "free_local_port", lambda: 7777)
 
     class _FakeResponse:
@@ -5087,7 +5167,9 @@ def test_validate_server_uses_windows_direct_validation_plan(monkeypatch, tmp_pa
         def __exit__(self, *exc):
             return False
 
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.urllib.request, "urlopen", lambda *a, **k: _FakeResponse())
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT.urllib.request, "urlopen", lambda *a, **k: _FakeResponse()
+    )
 
     validate_server(
         server_path,
@@ -5103,9 +5185,9 @@ def test_validate_server_uses_windows_direct_validation_plan(monkeypatch, tmp_pa
 
 
 def test_runtime_inference_path_stays_outside_installer_sandbox_owner():
-    backend_source = (Path(__file__).parents[3] / "studio/backend/core/inference/llama_cpp.py").read_text(
-        encoding = "utf-8", errors = "replace"
-    )
+    backend_source = (
+        Path(__file__).parents[3] / "studio/backend/core/inference/llama_cpp.py"
+    ).read_text(encoding = "utf-8", errors = "replace")
     assert "_ValidationLaunchPlan" not in backend_source
     assert "_run_validation_capture" not in backend_source
     assert "_run_validation_popen" not in backend_source
@@ -5239,9 +5321,7 @@ def _run_validate_prebuilt_choice(
 
 def test_validate_prebuilt_choice_approved_validation_skipped_when_flag_off(tmp_path, monkeypatch):
     # An approved (sha256-verified) bundle skips the smoke test while the flag is off.
-    calls, plans = _run_validate_prebuilt_choice(
-        monkeypatch, tmp_path, expected_sha256 = "ab" * 32
-    )
+    calls, plans = _run_validate_prebuilt_choice(monkeypatch, tmp_path, expected_sha256 = "ab" * 32)
     assert calls == {"quantize": 0, "server": 0}
     assert plans == []
 
@@ -5271,9 +5351,7 @@ def test_validate_prebuilt_choice_hashless_build_routes_through_validation_sandb
 def test_validate_prebuilt_choice_approved_validation_runs_when_flag_enabled(tmp_path, monkeypatch):
     # _RUN_STAGED_PREBUILT_VALIDATION back on restores the smoke test for approved bundles too.
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_RUN_STAGED_PREBUILT_VALIDATION", True)
-    calls, plans = _run_validate_prebuilt_choice(
-        monkeypatch, tmp_path, expected_sha256 = "ab" * 32
-    )
+    calls, plans = _run_validate_prebuilt_choice(monkeypatch, tmp_path, expected_sha256 = "ab" * 32)
     assert calls == {"quantize": 1, "server": 1}
     assert "ldd" in plans
     assert plans.count("quantize") == 1
@@ -5285,9 +5363,7 @@ def test_validate_prebuilt_choice_approved_validation_records_sandbox_routing(
     tmp_path, monkeypatch
 ):
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_RUN_STAGED_PREBUILT_VALIDATION", True)
-    _calls, plans = _run_validate_prebuilt_choice(
-        monkeypatch, tmp_path, expected_sha256 = "ab" * 32
-    )
+    _calls, plans = _run_validate_prebuilt_choice(monkeypatch, tmp_path, expected_sha256 = "ab" * 32)
     assert plans.count("ldd") >= 1
     assert plans.count("quantize") == 1
     assert plans.count("server") == 1

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3825,13 +3825,15 @@ def test_build_validation_sandbox_plan_linux_quantize_binds_probe_and_output(mon
 
 
 def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monkeypatch):
-    binary_path = Path("/tmp/bin/llama-server")
+    binary_path = Path("/tmp/bin/llama-quantize")
+    probe_path = Path("/tmp/models/probe.gguf")
+    output_path = Path("/tmp/out/probe-q4.gguf")
 
     monkeypatch.setattr(
         INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "sandbox-exec"
     )
     mac_run = build_validation_sandbox_plan(
-        ["llama-server", "--help"],
+        [str(binary_path), str(probe_path), str(output_path), "Q6_K", "2"],
         binary_path = binary_path,
         install_dir = Path("/tmp/install"),
         host = macos_host(),
@@ -3840,11 +3842,18 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
         env = {},
     )
     assert mac_run.is_runnable
-    assert mac_run.command[:3] == ["sandbox-exec", "-p", "(version 1)(deny network*)"]
+    assert mac_run.command[:2] == ["sandbox-exec", "-p"]
+    profile = mac_run.command[2]
+    assert "(deny default)" in profile
+    assert '(import "bsd.sb")' in profile
+    assert "tmp\\\\install" in profile
+    assert "tmp\\\\models" in profile
+    assert "tmp\\\\out" in profile
+    assert "localhost" not in profile
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
     mac_skip = build_validation_sandbox_plan(
-        ["llama-server", "--help"],
+        [str(binary_path), str(probe_path), str(output_path), "Q6_K", "2"],
         binary_path = binary_path,
         install_dir = Path("/tmp/install"),
         host = macos_host(),
@@ -3869,7 +3878,12 @@ def test_build_validation_sandbox_plan_macos_server_keeps_loopback(monkeypatch):
         env = {},
     )
     assert plan.is_runnable
-    assert plan.command[:3] == ["sandbox-exec", "-p", "(version 1)"]
+    assert plan.command[:2] == ["sandbox-exec", "-p"]
+    profile = plan.command[2]
+    assert "(deny default)" in profile
+    assert '(import "bsd.sb")' in profile
+    assert '(allow network* (local ip "localhost:*"))' in profile
+    assert '(allow network* (remote ip "localhost:*"))' in profile
 
 
 def test_build_validation_sandbox_plan_windows_is_unsupported(monkeypatch):

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -1320,7 +1320,8 @@ def test_binary_env_macos_strips_inherited_dyld_loader_controls(
     binary_path.write_bytes(b"fake")
 
     monkeypatch.setenv(
-        "DYLD_LIBRARY_PATH", str(runtime_lib.parent / ".." / runtime_lib.parent.name / runtime_lib.name)
+        "DYLD_LIBRARY_PATH",
+        str(runtime_lib.parent / ".." / runtime_lib.parent.name / runtime_lib.name),
     )
     monkeypatch.setenv("DYLD_INSERT_LIBRARIES", str(tmp_path / "inject.dylib"))
     monkeypatch.setenv("DYLD_FRAMEWORK_PATH", str(tmp_path / "Frameworks"))

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3884,6 +3884,17 @@ def test_linux_missing_libraries_uses_bwrap_plan(monkeypatch, tmp_path):
     assert "ldd" in captured["command"]
 
 
+def test_linux_missing_libraries_tolerates_probe_errors(monkeypatch, tmp_path):
+    binary_path = tmp_path / "server"
+    binary_path.write_text("")
+
+    def fake_probe(_binary_path: Path, *, env: dict[str, str]) -> str:
+        raise RuntimeError("probe failed")
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_ldd_probe", fake_probe)
+    assert linux_missing_libraries(binary_path, env = {"LD_LIBRARY_PATH": ""}) == []
+
+
 def test_validate_quantize_routes_through_sandbox_plan(monkeypatch, tmp_path):
     quantize_path = tmp_path / "llama-quantize"
     quantize_path.write_text("")

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3983,6 +3983,63 @@ def test_run_validation_popen_uses_launcher_env_for_linux_bwrap(monkeypatch):
     assert "LD_LIBRARY_PATH" not in (fake_process.started_with["env"] or {})
 
 
+def test_validate_server_strips_python_import_roots_from_payload_env(monkeypatch, tmp_path):
+    server_path = tmp_path / "llama-server"
+    server_path.write_text("")
+    probe_path = tmp_path / "probe.gguf"
+    probe_path.write_text("")
+    recorded: dict[str, object] = {}
+
+    monkeypatch.setenv("PYTHONHOME", "/host/python")
+    monkeypatch.setenv("PYTHONPATH", "/host/site-packages")
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "linux_runtime_dirs", lambda _binary_path: [])
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "free_local_port", lambda: 7777)
+
+    def fake_build_plan(
+        command: list[str],
+        *,
+        binary_path: Path,
+        install_dir: Path,
+        purpose: str,
+        env: dict[str, str],
+        host = None,
+        runtime_line = None,
+        enable_gpu_layers: bool = False,
+        gpu_backend = None,
+    ) -> ValidationLaunchPlan:
+        recorded["env"] = dict(env)
+        return ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = "run",
+            purpose = purpose,
+            server_probe_mode = INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX,
+        )
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_run_validation_capture",
+        lambda plan, *, timeout: subprocess.CompletedProcess(
+            plan.command, 0, stdout = "ok", stderr = ""
+        ),
+    )
+
+    validate_server(
+        server_path,
+        probe_path,
+        linux_host(),
+        tmp_path,
+        runtime_line = "cuda13",
+        install_kind = "linux-cuda",
+    )
+
+    env = recorded["env"]
+    assert isinstance(env, dict)
+    assert "PYTHONHOME" not in env
+    assert "PYTHONPATH" not in env
+
+
 def test_build_validation_sandbox_plan_linux_quantize_binds_probe_and_output(monkeypatch, tmp_path):
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
     bin_dir = tmp_path / "bin"

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -2,6 +2,7 @@ import errno
 import importlib.util
 import io
 import json
+import re
 import os
 import shutil
 import stat
@@ -53,6 +54,14 @@ linux_missing_libraries = INSTALL_LLAMA_PREBUILT.linux_missing_libraries
 ValidationLaunchPlan = INSTALL_LLAMA_PREBUILT._ValidationLaunchPlan
 run_validation_capture = INSTALL_LLAMA_PREBUILT._run_validation_capture
 run_validation_popen = INSTALL_LLAMA_PREBUILT._run_validation_popen
+run_validation_ldd_probe = INSTALL_LLAMA_PREBUILT._run_validation_ldd_probe
+LinuxLibraryProbeResult = INSTALL_LLAMA_PREBUILT.LinuxLibraryProbeResult
+LINUX_LDD_PROBE_OK = INSTALL_LLAMA_PREBUILT._LINUX_LDD_PROBE_OK
+LINUX_LDD_PROBE_SKIPPED = INSTALL_LLAMA_PREBUILT._LINUX_LDD_PROBE_SKIPPED
+LINUX_LDD_PROBE_ERROR = INSTALL_LLAMA_PREBUILT._LINUX_LDD_PROBE_ERROR
+preflight_linux_installed_binaries = (
+    INSTALL_LLAMA_PREBUILT.preflight_linux_installed_binaries
+)
 
 
 def linux_host() -> HostInfo:
@@ -1268,11 +1277,15 @@ def test_binary_env_drops_explicit_credential_file_pointers(
 def test_linux_runtime_dirs_probes_with_secret_free_env(monkeypatch: pytest.MonkeyPatch):
     captured: dict[str, object] = {}
 
-    def fake_missing(binary_path, *, env = None):
+    def fake_probe(binary_path, *, env = None):
         captured["env"] = env
-        return []
+        return LinuxLibraryProbeResult(
+            status = LINUX_LDD_PROBE_OK,
+            missing = [],
+            output = "",
+        )
 
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "linux_missing_libraries", fake_missing)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_ldd_probe", fake_probe)
     monkeypatch.setenv("HF_TOKEN", "hf_secret")
     monkeypatch.setenv("GITHUB_TOKEN", "gh_secret")
 
@@ -1282,6 +1295,13 @@ def test_linux_runtime_dirs_probes_with_secret_free_env(monkeypatch: pytest.Monk
     assert probe_env is not None
     assert "HF_TOKEN" not in probe_env
     assert "GITHUB_TOKEN" not in probe_env
+
+
+def _command_contains_path(plan: ValidationLaunchPlan, path_fragment: str) -> bool:
+    return any(
+        path_fragment in command_part or path_fragment in command_part.replace("\\", "/")
+        for command_part in plan.command
+    )
 
 
 def test_install_prebuilt_falls_back_to_older_release_plan(
@@ -3796,8 +3816,9 @@ def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch):
     assert plan.command[:5] == ["bwrap", "--unshare-all", "--share-net", "--die-with-parent", "--new-session"]
     assert "ldd" in plan.command[-1] or "--help" in plan.command[-1]
     assert "--ro-bind" in plan.command
-    assert "--dev" in plan.command
     assert "--bind" in plan.command
+    assert "--dev" in plan.command
+    assert "/dev/nvidiactl" not in plan.command
 
 
 def test_build_validation_sandbox_plan_linux_quantize_binds_probe_and_output(monkeypatch, tmp_path):
@@ -3822,6 +3843,135 @@ def test_build_validation_sandbox_plan_linux_quantize_binds_probe_and_output(mon
     assert plan.command.count("--bind") >= 2
     assert str(probe_dir) in plan.command
     assert str(out_dir) in plan.command
+
+
+def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled(monkeypatch, tmp_path):
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    existing_nodes = {
+        "/dev/nvidiactl",
+        "/dev/nvidia-uvm",
+        "/dev/nvidia-uvm-tools",
+        "/dev/nvidia-modeset",
+        "/dev/nvidia0",
+        "/dev/kfd",
+        "/dev/dxg",
+        "/dev/dri/card0",
+        "/dev/dri/renderD128",
+        "/sys/class/drm",
+        "/sys/bus/pci",
+        "/sys/dev/char",
+        "/sys/devices",
+        "/proc/driver/nvidia",
+    }
+    original_exists = Path.exists
+    original_glob = Path.glob
+
+    def _norm(path: Path) -> str:
+        text = str(path).replace("\\", "/")
+        if re.match(r"^[A-Za-z]:/", text):
+            text = "/" + text.split(":", 1)[1].lstrip("/")
+        return text
+
+    def fake_exists(path: Path) -> bool:
+        if _norm(path) in existing_nodes:
+            return True
+        return original_exists(path)
+
+    def fake_glob(path: Path, pattern: str):
+        normalized = _norm(path)
+        if normalized == "/dev" and pattern == "nvidia*":
+            return [Path(node) for node in existing_nodes if str(node).startswith("/dev/nvidia") and "*" not in node]
+        if normalized == "/dev/dri" and pattern == "card*":
+            return [Path("/dev/dri/card0")]
+        if normalized == "/dev/dri" and pattern == "renderD*":
+            return [Path("/dev/dri/renderD128")]
+        return original_glob(path, pattern)
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    monkeypatch.setattr(Path, "glob", fake_glob)
+
+    plan = build_validation_sandbox_plan(
+        ["llama-server", "--help"],
+        binary_path = Path("/tmp/bin/llama-server"),
+        install_dir = Path("/tmp/install"),
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {},
+        enable_gpu_layers = True,
+        gpu_backend = "cuda",
+    )
+    assert plan.is_runnable
+    assert "--dev-bind-try" in plan.command
+    assert any("nvidiactl" in part for part in plan.command)
+    assert any("nvidia0" in part for part in plan.command)
+    assert not any("dxg" in part for part in plan.command)
+    assert not _command_contains_path(plan, "dri/card0")
+    assert not _command_contains_path(plan, "dri/renderD128")
+    assert not any("kfd" in part for part in plan.command)
+    assert _command_contains_path(plan, "sys/class/drm")
+    assert _command_contains_path(plan, "proc/driver/nvidia")
+
+
+def test_build_validation_sandbox_plan_linux_server_binds_rocm_nodes_when_enabled(monkeypatch, tmp_path):
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    existing_nodes = {
+        "/dev/kfd",
+        "/dev/dxg",
+        "/dev/dri/card0",
+        "/dev/dri/renderD128",
+        "/sys/class/drm",
+        "/sys/bus/pci",
+        "/sys/dev/char",
+        "/sys/devices",
+        "/proc/driver/nvidia",
+    }
+    original_exists = Path.exists
+    original_glob = Path.glob
+
+    def _norm(path: Path) -> str:
+        text = str(path).replace("\\", "/")
+        if re.match(r"^[A-Za-z]:/", text):
+            text = "/" + text.split(":", 1)[1].lstrip("/")
+        return text
+
+    def fake_exists(path: Path) -> bool:
+        if _norm(path) in existing_nodes:
+            return True
+        return original_exists(path)
+
+    def fake_glob(path: Path, pattern: str):
+        normalized = _norm(path)
+        if normalized == "/dev" and pattern == "nvidia*":
+            return []
+        if normalized == "/dev/dri" and pattern == "card*":
+            return [Path("/dev/dri/card0")]
+        if normalized == "/dev/dri" and pattern == "renderD*":
+            return [Path("/dev/dri/renderD128")]
+        return original_glob(path, pattern)
+
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    monkeypatch.setattr(Path, "glob", fake_glob)
+
+    plan = build_validation_sandbox_plan(
+        ["llama-server", "--help"],
+        binary_path = Path("/tmp/bin/llama-server"),
+        install_dir = Path("/tmp/install"),
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {},
+        enable_gpu_layers = True,
+        gpu_backend = "rocm",
+    )
+    assert plan.is_runnable
+    assert "--dev-bind-try" in plan.command
+    assert any("kfd" in part for part in plan.command)
+    assert any("dxg" in part for part in plan.command)
+    assert _command_contains_path(plan, "dri/card0")
+    assert _command_contains_path(plan, "dri/renderD128")
+    assert not any("nvidiactl" in part for part in plan.command)
+    assert not _command_contains_path(plan, "proc/driver/nvidia")
 
 
 def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monkeypatch):
@@ -3905,13 +4055,15 @@ def test_build_validation_sandbox_plan_windows_is_unsupported(monkeypatch):
         runtime_line = None,
         env = {},
     )
-    assert plan.is_fallback
-    assert "unsupported" in (plan.reason or "").lower()
+    assert plan.is_runnable
+    assert plan.sandbox_kind == "windows_direct_validation"
+    assert "running validation directly" in (plan.reason or "").lower()
 
 
 def test_linux_missing_libraries_skips_ldd_without_sandbox_adapter(monkeypatch, tmp_path):
     binary_path = tmp_path / "server"
     binary_path.write_text("")
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
 
     captured: dict[str, bool] = {"run": False}
@@ -3924,6 +4076,17 @@ def test_linux_missing_libraries_skips_ldd_without_sandbox_adapter(monkeypatch, 
     missing = linux_missing_libraries(binary_path, env = {"LD_LIBRARY_PATH": ""})
     assert missing == []
     assert captured["run"] is False
+
+
+def test_run_validation_ldd_probe_reports_skipped_status_without_sandbox_adapter(monkeypatch, tmp_path):
+    binary_path = tmp_path / "server"
+    binary_path.write_text("")
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
+    result = run_validation_ldd_probe(binary_path, env = {"LD_LIBRARY_PATH": ""})
+    assert result.status == LINUX_LDD_PROBE_SKIPPED
+    assert result.missing == []
+    assert result.reason is not None
 
 
 def test_linux_missing_libraries_uses_bwrap_plan(monkeypatch, tmp_path):
@@ -3954,11 +4117,85 @@ def test_linux_missing_libraries_tolerates_probe_errors(monkeypatch, tmp_path):
     binary_path = tmp_path / "server"
     binary_path.write_text("")
 
-    def fake_probe(_binary_path: Path, *, env: dict[str, str]) -> str:
-        raise RuntimeError("probe failed")
+    def fake_probe(_binary_path: Path, *, env: dict[str, str]) -> LinuxLibraryProbeResult:
+        return LinuxLibraryProbeResult(
+            status = LINUX_LDD_PROBE_ERROR,
+            missing = [],
+            reason = "probe crashed",
+        )
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_ldd_probe", fake_probe)
     assert linux_missing_libraries(binary_path, env = {"LD_LIBRARY_PATH": ""}) == []
+
+
+def test_preflight_linux_installed_binaries_skips_unknown_when_probe_skipped(monkeypatch, tmp_path):
+    host = linux_host()
+    binary = tmp_path / "llama-server"
+    binary.write_text("")
+
+    def fake_probe(_binary_path: Path, *, env: dict[str, str]) -> LinuxLibraryProbeResult:
+        return LinuxLibraryProbeResult(
+            status = LINUX_LDD_PROBE_SKIPPED,
+            missing = [],
+            reason = "no sandbox adapter",
+        )
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_ldd_probe", fake_probe)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "binary_env",
+        lambda binary_path, install_dir, host: {"LD_LIBRARY_PATH": ""},
+    )
+    preflight_linux_installed_binaries((binary,), tmp_path, host)
+
+
+def test_preflight_linux_installed_binaries_rejects_skipped_probe_for_reuse(monkeypatch, tmp_path):
+    host = linux_host()
+    binary = tmp_path / "llama-server"
+    binary.write_text("")
+
+    def fake_probe(_binary_path: Path, *, env: dict[str, str]) -> LinuxLibraryProbeResult:
+        return LinuxLibraryProbeResult(
+            status = LINUX_LDD_PROBE_SKIPPED,
+            missing = [],
+            reason = "no sandbox adapter",
+        )
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_ldd_probe", fake_probe)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "binary_env",
+        lambda binary_path, install_dir, host: {"LD_LIBRARY_PATH": ""},
+    )
+    with pytest.raises(PrebuiltFallback, match = "linux ldd probe skipped"):
+        preflight_linux_installed_binaries(
+            (binary,),
+            tmp_path,
+            host,
+            allow_skipped_probe = False,
+        )
+
+
+def test_preflight_linux_installed_binaries_errors_on_probe_exception(monkeypatch, tmp_path):
+    host = linux_host()
+    binary = tmp_path / "llama-server"
+    binary.write_text("")
+
+    def fake_probe(_binary_path: Path, *, env: dict[str, str]) -> LinuxLibraryProbeResult:
+        return LinuxLibraryProbeResult(
+            status = LINUX_LDD_PROBE_ERROR,
+            missing = [],
+            reason = "probe crashed",
+        )
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_ldd_probe", fake_probe)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "binary_env",
+        lambda binary_path, install_dir, host: {"LD_LIBRARY_PATH": ""},
+    )
+    with pytest.raises(PrebuiltFallback, match = "linux extracted binary ldd probe errored"):
+        preflight_linux_installed_binaries((binary,), tmp_path, host)
 
 
 def test_validate_quantize_routes_through_sandbox_plan(monkeypatch, tmp_path):
@@ -3980,6 +4217,8 @@ def test_validate_quantize_routes_through_sandbox_plan(monkeypatch, tmp_path):
         env: dict[str, str],
         host = None,
         runtime_line = None,
+        enable_gpu_layers: bool = False,
+        gpu_backend = None,
     ) -> ValidationLaunchPlan:
         recorded["command"] = command
         recorded["purpose"] = purpose
@@ -4027,6 +4266,8 @@ def test_validate_quantize_falls_back_without_linux_sandbox(monkeypatch, tmp_pat
         env: dict[str, str],
         host = None,
         runtime_line = None,
+        enable_gpu_layers: bool = False,
+        gpu_backend = None,
     ) -> ValidationLaunchPlan:
         return ValidationLaunchPlan(
             command = command,
@@ -4067,9 +4308,13 @@ def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
         env: dict[str, str],
         host = None,
         runtime_line = None,
+        enable_gpu_layers: bool = False,
+        gpu_backend = None,
     ) -> ValidationLaunchPlan:
         recorded["command"] = command
         recorded["purpose"] = purpose
+        recorded["enable_gpu_layers"] = enable_gpu_layers
+        recorded["gpu_backend"] = gpu_backend
         return ValidationLaunchPlan(
             command = command,
             env = env,
@@ -4129,6 +4374,8 @@ def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
     command = recorded["command"]
     assert command[:3] == [str(server_path), "-m", str(probe_path)]
     assert "--n-gpu-layers" in command
+    assert recorded["enable_gpu_layers"] is True
+    assert recorded["gpu_backend"] == "cuda"
 
 
 def test_validate_server_falls_back_without_linux_sandbox(monkeypatch, tmp_path):
@@ -4146,6 +4393,8 @@ def test_validate_server_falls_back_without_linux_sandbox(monkeypatch, tmp_path)
         env: dict[str, str],
         host = None,
         runtime_line = None,
+        enable_gpu_layers: bool = False,
+        gpu_backend = None,
     ) -> ValidationLaunchPlan:
         return ValidationLaunchPlan(
             command = command,
@@ -4161,11 +4410,84 @@ def test_validate_server_falls_back_without_linux_sandbox(monkeypatch, tmp_path)
         validate_server(
             server_path,
             probe_path,
-            windows_host(),
+            linux_host(),
             tmp_path,
             runtime_line = None,
             install_kind = None,
         )
+
+
+def test_validate_server_uses_windows_direct_validation_plan(monkeypatch, tmp_path):
+    server_path = tmp_path / "llama-server.exe"
+    server_path.write_text("")
+    probe_path = tmp_path / "probe.gguf"
+    probe_path.write_text("")
+    recorded: dict[str, object] = {}
+
+    def fake_build_plan(
+        command: list[str],
+        *,
+        binary_path: Path,
+        install_dir: Path,
+        purpose: str,
+        env: dict[str, str],
+        host = None,
+        runtime_line = None,
+        enable_gpu_layers: bool = False,
+        gpu_backend = None,
+    ) -> ValidationLaunchPlan:
+        recorded["plan"] = ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = "run",
+            purpose = purpose,
+            sandbox_kind = "windows_direct_validation",
+        )
+        return recorded["plan"]
+
+    class _FakeProcess:
+        def poll(self):
+            return None
+
+        def wait(self, timeout: float | None = None):
+            return 0
+
+        def terminate(self):
+            return None
+
+        def kill(self):
+            return None
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", lambda *_a, **_k: {"PATH": str(tmp_path)})
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_popen", lambda plan, *, stdout: _FakeProcess())
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "free_local_port", lambda: 7777)
+
+    class _FakeResponse:
+        status = 200
+
+        def read(self):
+            return b"{}"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.urllib.request, "urlopen", lambda *a, **k: _FakeResponse())
+
+    validate_server(
+        server_path,
+        probe_path,
+        windows_host(),
+        tmp_path,
+        runtime_line = None,
+        install_kind = "windows-cuda",
+    )
+    plan = recorded["plan"]
+    assert isinstance(plan, ValidationLaunchPlan)
+    assert plan.sandbox_kind == "windows_direct_validation"
 
 
 def test_runtime_inference_path_stays_outside_installer_sandbox_owner():
@@ -4212,6 +4534,8 @@ def _run_validate_prebuilt_choice(
         env: dict[str, str],
         host = None,
         runtime_line = None,
+        enable_gpu_layers: bool = False,
+        gpu_backend = None,
     ) -> ValidationLaunchPlan:
         plans.append(purpose)
         return ValidationLaunchPlan(

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3846,9 +3846,18 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
     profile = mac_run.command[2]
     assert "(deny default)" in profile
     assert '(import "bsd.sb")' in profile
-    assert "tmp\\\\install" in profile
-    assert "tmp\\\\models" in profile
-    assert "tmp\\\\out" in profile
+    assert any(
+        f'(subpath "{literal}")' in profile
+        for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals("/tmp/install")
+    )
+    assert any(
+        f'(subpath "{literal}")' in profile
+        for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals("/tmp/models")
+    )
+    assert any(
+        f'(subpath "{literal}")' in profile
+        for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals("/tmp/out")
+    )
     assert "localhost" not in profile
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -4011,6 +4011,45 @@ def test_validate_quantize_routes_through_sandbox_plan(monkeypatch, tmp_path):
     assert quantized_path.exists()
 
 
+def test_validate_quantize_falls_back_without_linux_sandbox(monkeypatch, tmp_path):
+    quantize_path = tmp_path / "llama-quantize"
+    quantize_path.write_text("")
+    probe_path = tmp_path / "probe.gguf"
+    probe_path.write_text("")
+    quantized_path = tmp_path / "probe-q4.gguf"
+
+    def fake_build_plan(
+        command: list[str],
+        *,
+        binary_path: Path,
+        install_dir: Path,
+        purpose: str,
+        env: dict[str, str],
+        host = None,
+        runtime_line = None,
+    ) -> ValidationLaunchPlan:
+        return ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = "fallback",
+            purpose = purpose,
+            reason = "no sandbox",
+        )
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", lambda *_a, **_k: {"PATH": str(tmp_path)})
+
+    with pytest.raises(PrebuiltFallback, match = "no sandbox"):
+        validate_quantize(
+            quantize_path,
+            probe_path,
+            quantized_path,
+            tmp_path,
+            linux_host(),
+            runtime_line = None,
+        )
+
+
 def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
     server_path = tmp_path / "llama-server"
     server_path.write_text("")

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3932,6 +3932,7 @@ def test_linux_missing_libraries_uses_bwrap_plan(monkeypatch, tmp_path):
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.shutil, "which", lambda name: f"/usr/bin/{name}")
     captured = {}
 
     def fake_run_capture(command, *, timeout, env = None, check = False):

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -1280,6 +1280,32 @@ def test_binary_env_drops_explicit_credential_file_pointers(
         assert var not in env
 
 
+def test_binary_env_macos_strips_inherited_dyld_loader_controls(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    install_dir = tmp_path / "llama.cpp"
+    bin_dir = install_dir / "build" / "bin"
+    runtime_lib = tmp_path / "runtime" / "lib"
+    runtime_lib.mkdir(parents = True)
+    bin_dir.mkdir(parents = True)
+    binary_path = bin_dir / "llama-server"
+    binary_path.write_bytes(b"fake")
+
+    monkeypatch.setenv("DYLD_LIBRARY_PATH", str(runtime_lib))
+    monkeypatch.setenv("DYLD_INSERT_LIBRARIES", str(tmp_path / "inject.dylib"))
+    monkeypatch.setenv("DYLD_FRAMEWORK_PATH", str(tmp_path / "Frameworks"))
+    monkeypatch.setenv("DYLD_FALLBACK_LIBRARY_PATH", str(tmp_path / "fallback"))
+
+    env = binary_env(binary_path, install_dir, macos_host())
+
+    assert "DYLD_INSERT_LIBRARIES" not in env
+    assert "DYLD_FRAMEWORK_PATH" not in env
+    assert "DYLD_FALLBACK_LIBRARY_PATH" not in env
+    assert str(bin_dir) in env["DYLD_LIBRARY_PATH"].split(os.pathsep)
+    assert str(install_dir) in env["DYLD_LIBRARY_PATH"].split(os.pathsep)
+    assert str(runtime_lib) in env["DYLD_LIBRARY_PATH"].split(os.pathsep)
+
+
 def test_linux_runtime_dirs_probes_with_secret_free_env(monkeypatch: pytest.MonkeyPatch):
     captured: dict[str, object] = {}
 
@@ -4585,7 +4611,17 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
         host = macos_host(),
         purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_QUANTIZE,
         runtime_line = None,
-        env = {"DYLD_LIBRARY_PATH": os.pathsep.join(["/", "/Users/alice", "/opt/dyld"])},
+        env = {
+            "DYLD_LIBRARY_PATH": os.pathsep.join(
+                [
+                    "/",
+                    "/Users/alice",
+                    "/Library/Application Support",
+                    "/private/var",
+                    "/opt/dyld/lib",
+                ]
+            )
+        },
     )
     assert mac_run.is_runnable
     assert mac_run.command[:2] == ["/usr/bin/sandbox-exec", "-p"]
@@ -4607,9 +4643,9 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
     )
     assert any(
         f'(subpath "{literal}")' in profile
-        for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals("/opt/dyld")
+        for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals("/opt/dyld/lib")
     )
-    for broad_path in ("/", "/Users/alice"):
+    for broad_path in ("/", "/Users/alice", "/Library/Application Support", "/private/var"):
         for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals(broad_path):
             assert f'(literal "{literal}")' not in profile
             assert f'(subpath "{literal}")' not in profile

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -7,6 +7,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import subprocess
 import tarfile
 import urllib.error
 import zipfile
@@ -45,6 +46,13 @@ write_prebuilt_metadata = INSTALL_LLAMA_PREBUILT.write_prebuilt_metadata
 existing_install_matches_plan = INSTALL_LLAMA_PREBUILT.existing_install_matches_plan
 existing_install_matches_choice = INSTALL_LLAMA_PREBUILT.existing_install_matches_choice
 ensure_diffusion_visual_server = INSTALL_LLAMA_PREBUILT.ensure_diffusion_visual_server
+validate_quantize = INSTALL_LLAMA_PREBUILT.validate_quantize
+validate_server = INSTALL_LLAMA_PREBUILT.validate_server
+build_validation_sandbox_plan = INSTALL_LLAMA_PREBUILT.build_validation_sandbox_plan
+linux_missing_libraries = INSTALL_LLAMA_PREBUILT.linux_missing_libraries
+ValidationLaunchPlan = INSTALL_LLAMA_PREBUILT._ValidationLaunchPlan
+run_validation_capture = INSTALL_LLAMA_PREBUILT._run_validation_capture
+run_validation_popen = INSTALL_LLAMA_PREBUILT._run_validation_popen
 
 
 def linux_host() -> HostInfo:
@@ -62,6 +70,46 @@ def linux_host() -> HostInfo:
         visible_cuda_devices = None,
         has_physical_nvidia = False,
         has_usable_nvidia = False,
+    )
+
+
+def macos_host() -> HostInfo:
+    return HostInfo(
+        system = "Darwin",
+        machine = "arm64",
+        is_windows = False,
+        is_linux = False,
+        is_macos = True,
+        is_x86_64 = False,
+        is_arm64 = True,
+        nvidia_smi = None,
+        driver_cuda_version = None,
+        compute_caps = [],
+        visible_cuda_devices = None,
+        has_physical_nvidia = False,
+        has_usable_nvidia = False,
+        has_rocm = False,
+        rocm_gfx_target = None,
+    )
+
+
+def windows_host() -> HostInfo:
+    return HostInfo(
+        system = "Windows",
+        machine = "AMD64",
+        is_windows = True,
+        is_linux = False,
+        is_macos = False,
+        is_x86_64 = True,
+        is_arm64 = False,
+        nvidia_smi = None,
+        driver_cuda_version = None,
+        compute_caps = [],
+        visible_cuda_devices = None,
+        has_physical_nvidia = False,
+        has_usable_nvidia = False,
+        has_rocm = False,
+        rocm_gfx_target = None,
     )
 
 
@@ -3687,6 +3735,333 @@ def _nvidia_linux_host():
     )
 
 
+def test_build_validation_sandbox_plan_contract():
+    assert (
+        build_validation_sandbox_plan(
+            ["cmd", "arg"],
+            binary_path = Path("/tmp/bin"),
+            install_dir = Path("/tmp/install"),
+            host = linux_host(),
+            purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_LDD,
+            runtime_line = None,
+            env = {"UNSANDBOXABLE": "1"},
+    ).purpose
+    == INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_LDD
+    )
+
+
+def test_build_validation_sandbox_plan_linux_without_bwrap_skips_ldd_probe(monkeypatch):
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
+    plan = build_validation_sandbox_plan(
+        ["ldd", "/tmp/bin"],
+        binary_path = Path("/tmp/bin"),
+        install_dir = Path("/tmp/install"),
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_LDD,
+        runtime_line = None,
+        env = {},
+    )
+    assert plan.is_skipped
+    assert plan.reason is not None
+    assert "skip ldd probe" in plan.reason
+
+
+def test_build_validation_sandbox_plan_linux_without_bwrap_falls_back_validation(monkeypatch):
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
+    plan = build_validation_sandbox_plan(
+        ["llama-quantize", "in", "out"],
+        binary_path = Path("/tmp/bin"),
+        install_dir = Path("/tmp/install"),
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_QUANTIZE,
+        runtime_line = None,
+        env = {},
+    )
+    assert plan.is_fallback
+    assert plan.reason is not None
+
+
+def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch):
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    plan = build_validation_sandbox_plan(
+        ["llama-server", "--help"],
+        binary_path = Path("/tmp/bin/llama-server"),
+        install_dir = Path("/tmp/install"),
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {},
+    )
+    assert plan.is_runnable
+    assert plan.command[:5] == ["bwrap", "--unshare-all", "--unshare-net", "--die-with-parent", "--new-session"]
+    assert "ldd" in plan.command[-1] or "--help" in plan.command[-1]
+    assert "--ro-bind" in plan.command
+
+
+def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monkeypatch):
+    binary_path = Path("/tmp/bin/llama-server")
+
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "sandbox-exec"
+    )
+    mac_run = build_validation_sandbox_plan(
+        ["llama-server", "--help"],
+        binary_path = binary_path,
+        install_dir = Path("/tmp/install"),
+        host = macos_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {},
+    )
+    assert mac_run.is_runnable
+    assert mac_run.command[:3] == ["sandbox-exec", "-p", "(version 1)(deny network*)"]
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
+    mac_skip = build_validation_sandbox_plan(
+        ["llama-server", "--help"],
+        binary_path = binary_path,
+        install_dir = Path("/tmp/install"),
+        host = macos_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {},
+    )
+    assert mac_skip.is_fallback
+
+
+def test_build_validation_sandbox_plan_windows_is_unsupported(monkeypatch):
+    plan = build_validation_sandbox_plan(
+        ["llama-server", "--help"],
+        binary_path = Path(r"C:\bin\llama-server.exe"),
+        install_dir = Path(r"C:\install"),
+        host = windows_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {},
+    )
+    assert plan.is_fallback
+    assert "unsupported" in (plan.reason or "").lower()
+
+
+def test_linux_missing_libraries_skips_ldd_without_sandbox_adapter(monkeypatch, tmp_path):
+    binary_path = tmp_path / "server"
+    binary_path.write_text("")
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
+
+    captured: dict[str, bool] = {"run": False}
+
+    def fake_run_capture(command, *, timeout, env = None, check = False):
+        captured["run"] = True
+        return subprocess.CompletedProcess(command, 0, stdout = "")
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "run_capture", fake_run_capture)
+    missing = linux_missing_libraries(binary_path, env = {"LD_LIBRARY_PATH": ""})
+    assert missing == []
+    assert captured["run"] is False
+
+
+def test_linux_missing_libraries_uses_bwrap_plan(monkeypatch, tmp_path):
+    binary_path = tmp_path / "server"
+    binary_path.write_text("")
+    install_dir = tmp_path
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    captured = {}
+
+    def fake_run_capture(command, *, timeout, env = None, check = False):
+        captured["command"] = command
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout = "libbad => not found\nlibgood => /tmp/libgood\n",
+            stderr = "",
+        )
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "run_capture", fake_run_capture)
+    assert linux_missing_libraries(binary_path, env = {"LD_LIBRARY_PATH": ""}) == ["libbad"]
+    assert captured["command"][0] == "bwrap"
+    assert "ldd" in captured["command"]
+
+
+def test_validate_quantize_routes_through_sandbox_plan(monkeypatch, tmp_path):
+    quantize_path = tmp_path / "llama-quantize"
+    quantize_path.write_text("")
+    probe_path = tmp_path / "probe.gguf"
+    probe_path.write_text("")
+    quantized_path = tmp_path / "probe-q4.gguf"
+    install_dir = tmp_path
+    expected_env = {"CUSTOM": "1"}
+    recorded: dict[str, list[str] | str | dict[str, str]] = {}
+
+    def fake_build_plan(
+        command: list[str],
+        *,
+        binary_path: Path,
+        install_dir: Path,
+        purpose: str,
+        env: dict[str, str],
+        host = None,
+        runtime_line = None,
+    ) -> ValidationLaunchPlan:
+        recorded["command"] = command
+        recorded["purpose"] = purpose
+        recorded["env"] = env
+        return ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = "run",
+            purpose = purpose,
+        )
+
+    def fake_capture(plan: ValidationLaunchPlan, *, timeout: int):
+        assert plan.purpose == INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_QUANTIZE
+        quantized_path.write_bytes(b"done")
+        return subprocess.CompletedProcess(plan.command, 0, stdout = "", stderr = "")
+
+    def fake_binary_env(*_a, **_k):
+        return expected_env
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_capture", fake_capture)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", fake_binary_env)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "run_capture", lambda *a, **k: (_ for _ in ()).throw(AssertionError("run_capture must not be used")))
+
+    validate_quantize(quantize_path, probe_path, quantized_path, install_dir, linux_host(), runtime_line = None)
+    assert recorded["purpose"] == INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_QUANTIZE
+    assert recorded["env"] == expected_env
+    assert recorded["command"][:3] == [str(quantize_path), str(probe_path), str(quantized_path)]
+    assert quantized_path.exists()
+
+
+def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
+    server_path = tmp_path / "llama-server"
+    server_path.write_text("")
+    probe_path = tmp_path / "probe.gguf"
+    probe_path.write_text("")
+    install_dir = tmp_path
+    recorded: dict[str, object] = {}
+
+    def fake_build_plan(
+        command: list[str],
+        *,
+        binary_path: Path,
+        install_dir: Path,
+        purpose: str,
+        env: dict[str, str],
+        host = None,
+        runtime_line = None,
+    ) -> ValidationLaunchPlan:
+        recorded["command"] = command
+        recorded["purpose"] = purpose
+        return ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = "run",
+            purpose = purpose,
+        )
+
+    class _FakeResponse:
+        status = 200
+
+        def read(self):
+            return b"{}"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    class _FakeProcess:
+        def poll(self):
+            return None
+
+        def wait(self, timeout: float | None = None):
+            return 0
+
+        def terminate(self):
+            recorded["terminated"] = True
+            return None
+
+        def kill(self):
+            recorded["terminated"] = True
+            return None
+
+    def fake_binary_env(*_a, **_k):
+        return {"PATH": str(tmp_path)}
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", fake_binary_env)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_popen", lambda plan, *, stdout: _FakeProcess())
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "free_local_port", lambda: 7777)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.urllib.request, "urlopen", lambda *a, **k: _FakeResponse())
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT, "run_capture",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("run_capture must not be used")),
+    )
+
+    validate_server(
+        server_path,
+        probe_path,
+        linux_host(),
+        install_dir,
+        runtime_line = "cuda13",
+        install_kind = "linux-cuda",
+    )
+    assert recorded["purpose"] == INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER
+    command = recorded["command"]
+    assert command[:3] == [str(server_path), "-m", str(probe_path)]
+    assert "--n-gpu-layers" in command
+
+
+def test_validate_server_falls_back_without_linux_sandbox(monkeypatch, tmp_path):
+    server_path = tmp_path / "llama-server"
+    server_path.write_text("")
+    probe_path = tmp_path / "probe.gguf"
+    probe_path.write_text("")
+
+    def fake_build_plan(
+        command: list[str],
+        *,
+        binary_path: Path,
+        install_dir: Path,
+        purpose: str,
+        env: dict[str, str],
+        host = None,
+        runtime_line = None,
+    ) -> ValidationLaunchPlan:
+        return ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = "fallback",
+            purpose = purpose,
+            reason = "no sandbox",
+        )
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
+
+    with pytest.raises(PrebuiltFallback, match = "no sandbox"):
+        validate_server(
+            server_path,
+            probe_path,
+            windows_host(),
+            tmp_path,
+            runtime_line = None,
+            install_kind = None,
+        )
+
+
+def test_runtime_inference_path_stays_outside_installer_sandbox_owner():
+    backend_source = (Path(__file__).parents[3] / "studio/backend/core/inference/llama_cpp.py").read_text(
+        encoding = "utf-8", errors = "replace"
+    )
+    assert "_ValidationLaunchPlan" not in backend_source
+    assert "_run_validation_capture" not in backend_source
+    assert "_run_validation_popen" not in backend_source
+    assert "build_validation_sandbox_plan" not in backend_source
+
+
 def _run_validate_prebuilt_choice(
     monkeypatch,
     tmp_path,
@@ -3694,10 +4069,12 @@ def _run_validate_prebuilt_choice(
     expected_sha256,
     probe = None,
 ):
-    """Run validate_prebuilt_choice with heavy steps stubbed; return the quantize/server smoke-test call counts."""
+    """Run validate_prebuilt_choice with heavy steps stubbed; return calls and launch purposes."""
     calls = {"quantize": 0, "server": 0}
+    plans: list[str] = []
     server_path = tmp_path / "install" / "build" / "bin" / "llama-server"
     quantize_path = tmp_path / "install" / "build" / "bin" / "llama-quantize"
+    quantized_path = tmp_path / "stories260K-q4.gguf"
 
     src = INSTALL_LLAMA_PREBUILT
     monkeypatch.setattr(
@@ -3709,14 +4086,65 @@ def _run_validate_prebuilt_choice(
     monkeypatch.setattr(src, "preflight_macos_installed_binaries", lambda *a, **k: None)
     monkeypatch.setattr(src, "ensure_repo_shape", lambda *a, **k: None)
     monkeypatch.setattr(src, "write_prebuilt_metadata", lambda *a, **k: None)
-    monkeypatch.setattr(
-        src,
-        "validate_quantize",
-        lambda *a, **k: calls.__setitem__("quantize", calls["quantize"] + 1),
-    )
-    monkeypatch.setattr(
-        src, "validate_server", lambda *a, **k: calls.__setitem__("server", calls["server"] + 1)
-    )
+
+    def fake_build_plan(
+        command: list[str],
+        *,
+        binary_path: Path,
+        install_dir: Path,
+        purpose: str,
+        env: dict[str, str],
+        host = None,
+        runtime_line = None,
+    ) -> ValidationLaunchPlan:
+        plans.append(purpose)
+        return ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = "run",
+            purpose = purpose,
+        )
+
+    def fake_run_validation_capture(plan: ValidationLaunchPlan, *, timeout: int):
+        if plan.purpose == src._VALIDATION_PURPOSE_QUANTIZE:
+            calls["quantize"] += 1
+            quantized_path.write_bytes(b"quantized")
+        return subprocess.CompletedProcess(plan.command, 0, "", "")
+
+    class _FakeResponse:
+        status = 200
+
+        def read(self):
+            return b"{}"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    class _DummyProcess:
+        def poll(self):
+            return None
+
+        def wait(self, timeout: float | None = None):
+            return 0
+
+        def terminate(self):
+            return None
+
+        def kill(self):
+            return None
+
+    def fake_run_validation_popen(plan: ValidationLaunchPlan, *, stdout):
+        assert plan.purpose == src._VALIDATION_PURPOSE_SERVER
+        calls["server"] += 1
+        return _DummyProcess()
+
+    monkeypatch.setattr(src, "build_validation_sandbox_plan", fake_build_plan)
+    monkeypatch.setattr(src, "_run_validation_capture", fake_run_validation_capture)
+    monkeypatch.setattr(src, "_run_validation_popen", fake_run_validation_popen)
+    monkeypatch.setattr(src.urllib.request, "urlopen", lambda *a, **k: _FakeResponse())
 
     bundle_name = "app-b9998-linux-x64-cuda13-newer.tar.gz"
     source_archive = tmp_path / "source.tar.gz"
@@ -3752,28 +4180,68 @@ def _run_validate_prebuilt_choice(
             bundle_name = bundle_name,
         ),
         prebuilt_fallback_used = False,
-        quantized_path = tmp_path / "stories260K-q4.gguf",
+        quantized_path = quantized_path,
     )
-    return calls
+    return calls, plans
 
 
 def test_validate_prebuilt_choice_approved_validation_skipped_when_flag_off(tmp_path, monkeypatch):
     # An approved (sha256-verified) bundle skips the smoke test while the flag is off.
-    calls = _run_validate_prebuilt_choice(monkeypatch, tmp_path, expected_sha256 = "ab" * 32)
+    calls, plans = _run_validate_prebuilt_choice(
+        monkeypatch, tmp_path, expected_sha256 = "ab" * 32
+    )
     assert calls == {"quantize": 0, "server": 0}
+    assert plans == []
 
 
 def test_validate_prebuilt_choice_hashless_build_always_validated(tmp_path, monkeypatch):
     # A hashless build has no sha256 gate, so the smoke test must run even with the flag off.
-    calls = _run_validate_prebuilt_choice(monkeypatch, tmp_path, expected_sha256 = None)
+    calls, plans = _run_validate_prebuilt_choice(monkeypatch, tmp_path, expected_sha256 = None)
     assert calls == {"quantize": 1, "server": 1}
+    assert "ldd" in plans
+    assert plans.count("quantize") == 1
+    assert plans.count("server") == 1
+    assert plans.index("quantize") < plans.index("server")
+
+
+def test_validate_prebuilt_choice_hashless_build_routes_through_validation_sandbox(
+    tmp_path, monkeypatch
+):
+    _calls, plans = _run_validate_prebuilt_choice(monkeypatch, tmp_path, expected_sha256 = None)
+    assert plans.count("ldd") >= 1
+    assert plans.count("quantize") == 1
+    assert plans.count("server") == 1
+    assert plans.index("quantize") < plans.index("server")
+    assert plans[0] == "ldd"
+    assert plans[-1] == "server"
 
 
 def test_validate_prebuilt_choice_approved_validation_runs_when_flag_enabled(tmp_path, monkeypatch):
     # _RUN_STAGED_PREBUILT_VALIDATION back on restores the smoke test for approved bundles too.
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_RUN_STAGED_PREBUILT_VALIDATION", True)
-    calls = _run_validate_prebuilt_choice(monkeypatch, tmp_path, expected_sha256 = "ab" * 32)
+    calls, plans = _run_validate_prebuilt_choice(
+        monkeypatch, tmp_path, expected_sha256 = "ab" * 32
+    )
     assert calls == {"quantize": 1, "server": 1}
+    assert "ldd" in plans
+    assert plans.count("quantize") == 1
+    assert plans.count("server") == 1
+    assert plans.index("quantize") < plans.index("server")
+
+
+def test_validate_prebuilt_choice_approved_validation_records_sandbox_routing(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_RUN_STAGED_PREBUILT_VALIDATION", True)
+    _calls, plans = _run_validate_prebuilt_choice(
+        monkeypatch, tmp_path, expected_sha256 = "ab" * 32
+    )
+    assert plans.count("ldd") >= 1
+    assert plans.count("quantize") == 1
+    assert plans.count("server") == 1
+    assert plans.index("quantize") < plans.index("server")
+    assert plans[0] == "ldd"
+    assert plans[-1] == "server"
 
 
 def test_validate_prebuilt_choice_never_fetches_probe_for_approved_bundle(tmp_path, monkeypatch):
@@ -3783,7 +4251,7 @@ def test_validate_prebuilt_choice_never_fetches_probe_for_approved_bundle(tmp_pa
     def refuse() -> Path:
         raise AssertionError("probe model must not be fetched when the smoke test is skipped")
 
-    calls = _run_validate_prebuilt_choice(
+    calls, _plans = _run_validate_prebuilt_choice(
         monkeypatch, tmp_path, expected_sha256 = "ab" * 32, probe = refuse
     )
     assert calls == {"quantize": 0, "server": 0}
@@ -3798,7 +4266,9 @@ def test_validate_prebuilt_choice_fetches_probe_once_when_validating(tmp_path, m
         fetches.append(1)
         return probe_path
 
-    calls = _run_validate_prebuilt_choice(monkeypatch, tmp_path, expected_sha256 = None, probe = fetch)
+    calls, _plans = _run_validate_prebuilt_choice(
+        monkeypatch, tmp_path, expected_sha256 = None, probe = fetch
+    )
     assert calls == {"quantize": 1, "server": 1}
     assert len(fetches) == 1
 
@@ -4037,7 +4507,7 @@ def test_staged_validation_enabled_env_opt_in(monkeypatch, value):
 def test_validate_prebuilt_choice_approved_validation_runs_when_env_enabled(tmp_path, monkeypatch):
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_RUN_STAGED_PREBUILT_VALIDATION", False)
     monkeypatch.setenv("UNSLOTH_LLAMA_STAGED_VALIDATION", "1")
-    calls = _run_validate_prebuilt_choice(monkeypatch, tmp_path, expected_sha256 = "ab" * 32)
+    calls, _plans = _run_validate_prebuilt_choice(monkeypatch, tmp_path, expected_sha256 = "ab" * 32)
     assert calls == {"quantize": 1, "server": 1}
 
 
@@ -4122,7 +4592,10 @@ def test_diffusion_visual_server_uses_approved_checksum_download(monkeypatch, tm
         )
     ]
     assert target.read_bytes() == b"verified visual server"
-    assert target.stat().st_mode & 0o777 == 0o755
+    if os.name == "nt":
+        assert target.exists()
+    else:
+        assert target.stat().st_mode & 0o777 == 0o755
 
 
 def test_diffusion_visual_server_refuses_unapproved_release_asset(monkeypatch, tmp_path: Path):

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -4045,39 +4045,55 @@ def test_build_validation_sandbox_plan_linux_server_probe_binds_nix_store(monkey
     assert _command_contains_path(plan, "nix/store")
 
 
-def test_build_validation_sandbox_plan_linux_gpu_uses_direct_validation_without_setuid_bwrap(
-    monkeypatch, tmp_path
-):
+def test_build_validation_sandbox_plan_linux_gpu_keeps_sandbox_without_setuid_bwrap(monkeypatch, tmp_path):
     bwrap_path = tmp_path / "bwrap"
     bwrap_path.write_text("")
     binary_path = tmp_path / "llama-server"
     binary_path.write_text("")
     install_dir = tmp_path / "install"
     install_dir.mkdir()
+    helper_path = tmp_path / "python3"
+    helper_path.write_text("")
+    seen: dict[str, object] = {}
     monkeypatch.setattr(
         INSTALL_LLAMA_PREBUILT,
         "_resolve_command_path",
         lambda command: str(bwrap_path.resolve()) if command == "bwrap" else None,
     )
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_binary_is_setuid_root", lambda _path: False)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_linux_validation_server_probe_command",
+        lambda command, payload_env, timeout = 60: seen.update(
+            {
+                "command": list(command),
+                "payload_env": dict(payload_env),
+                "timeout": timeout,
+            }
+        ) or [str(helper_path), "-c", "server probe"],
+    )
 
     plan = build_validation_sandbox_plan(
-        [str(binary_path), "--help"],
+        [str(binary_path), "--port", "7777", "--n-gpu-layers", "1"],
         binary_path = binary_path,
         install_dir = install_dir,
         host = linux_host(),
         purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
         runtime_line = None,
-        env = {},
+        env = {"LD_LIBRARY_PATH": "/tmp/payload/libs"},
         enable_gpu_layers = True,
         gpu_backend = "cuda",
     )
 
     assert plan.is_runnable
-    assert plan.command == [str(binary_path), "--help"]
-    assert plan.sandbox_kind == "linux_direct_validation"
-    assert plan.network_policy == INSTALL_LLAMA_PREBUILT._VALIDATION_NETWORK_POLICY_DIRECT
-    assert plan.server_probe_mode == INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_HOST
+    assert plan.command[0] == str(bwrap_path.resolve())
+    assert plan.sandbox_kind == "linux_bwrap"
+    assert plan.network_policy == INSTALL_LLAMA_PREBUILT._VALIDATION_NETWORK_POLICY_SANDBOX
+    assert plan.server_probe_mode == INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX
+    assert seen["command"] == [str(binary_path), "--port", "7777"]
+    assert seen["payload_env"] == {"LD_LIBRARY_PATH": "/tmp/payload/libs"}
+    assert plan.payload_command == [str(binary_path), "--port", "7777"]
+    assert "--n-gpu-layers" not in plan.command
 
 
 def test_linux_validation_server_probe_command_passes_payload_env_to_server_spawn():
@@ -4465,6 +4481,7 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
     )
     assert mac_run.is_runnable
     assert mac_run.command[:2] == ["sandbox-exec", "-p"]
+    assert "/usr/bin/env" in mac_run.command
     profile = mac_run.command[2]
     assert "(deny default)" in profile
     assert '(import "bsd.sb")' in profile
@@ -4518,6 +4535,7 @@ def test_build_validation_sandbox_plan_macos_server_keeps_loopback(monkeypatch):
     )
     assert plan.is_runnable
     assert plan.command[:2] == ["sandbox-exec", "-p"]
+    assert "/usr/bin/env" in plan.command
     profile = plan.command[2]
     assert "(deny default)" in profile
     assert '(import "bsd.sb")' in profile

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3926,6 +3926,58 @@ def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch, tmp_pa
     assert str(helper_lib) in plan.command
 
 
+def test_build_validation_sandbox_plan_linux_server_probe_uses_resolved_helper_path(monkeypatch, tmp_path):
+    bwrap_path = tmp_path / "bwrap"
+    bwrap_path.write_text("")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: str(bwrap_path.resolve()) if command == "bwrap" else None,
+    )
+    helper_bin = tmp_path / "helper" / "bin"
+    helper_store = tmp_path / "nix" / "store"
+    install_dir = tmp_path / "install"
+    binary_dir = tmp_path / "bin"
+    model_dir = tmp_path / "models"
+    for directory in (helper_bin, helper_store, install_dir, binary_dir, model_dir):
+        directory.mkdir(parents = True, exist_ok = True)
+    helper_symlink = helper_bin / "python3"
+    helper_symlink.write_text("")
+    helper_target = helper_store / "python3"
+    helper_target.write_text("")
+    binary_path = binary_dir / "llama-server"
+    binary_path.write_text("")
+
+    original_resolve = Path.resolve
+
+    def fake_resolve(path: Path, strict: bool = False):
+        if path == helper_symlink:
+            return helper_target
+        return original_resolve(path, strict = strict)
+
+    monkeypatch.setattr(Path, "resolve", fake_resolve)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_linux_validation_server_probe_command",
+        lambda command, payload_env, timeout = 60: [str(helper_symlink), "-c", "server probe"],
+    )
+
+    plan = build_validation_sandbox_plan(
+        ["llama-server", "-m", str(model_dir / "stories260K.gguf"), "--port", "7777"],
+        binary_path = binary_path,
+        install_dir = install_dir,
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {"LD_LIBRARY_PATH": "/tmp/payload/libs"},
+    )
+
+    assert plan.is_runnable
+    assert str(helper_target) in plan.command
+    assert str(helper_target.parent) in plan.command
+    assert str(helper_symlink) not in plan.command
+
+
 def test_linux_validation_server_probe_command_passes_payload_env_to_server_spawn():
     probe_command = INSTALL_LLAMA_PREBUILT._linux_validation_server_probe_command(
         [
@@ -4170,6 +4222,11 @@ def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled
         gpu_backend = "cuda",
     )
     assert plan.is_runnable
+    assert "--unshare-all" not in plan.command
+    assert "--unshare-net" in plan.command
+    assert "--unshare-pid" in plan.command
+    assert "--unshare-ipc" in plan.command
+    assert "--unshare-uts" in plan.command
     assert "--dev-bind-try" in plan.command
     assert any("nvidiactl" in part for part in plan.command)
     assert any("nvidia0" in part for part in plan.command)
@@ -4237,6 +4294,11 @@ def test_build_validation_sandbox_plan_linux_server_binds_rocm_nodes_when_enable
         gpu_backend = "rocm",
     )
     assert plan.is_runnable
+    assert "--unshare-all" not in plan.command
+    assert "--unshare-net" in plan.command
+    assert "--unshare-pid" in plan.command
+    assert "--unshare-ipc" in plan.command
+    assert "--unshare-uts" in plan.command
     assert "--dev-bind-try" in plan.command
     assert any("kfd" in part for part in plan.command)
     assert any("dxg" in part for part in plan.command)
@@ -4261,13 +4323,14 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
         host = macos_host(),
         purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_QUANTIZE,
         runtime_line = None,
-        env = {},
+        env = {"DYLD_LIBRARY_PATH": "/opt/dyld"},
     )
     assert mac_run.is_runnable
     assert mac_run.command[:2] == ["sandbox-exec", "-p"]
     profile = mac_run.command[2]
     assert "(deny default)" in profile
     assert '(import "bsd.sb")' in profile
+    assert "(allow file-map-executable" in profile
     assert "(subpath \"/private\")" not in profile
     assert '(subpath "/usr")' not in profile
     assert '(subpath "/Library")' not in profile
@@ -4282,6 +4345,10 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
     assert any(
         f'(subpath "{literal}")' in profile
         for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals("/tmp/out")
+    )
+    assert any(
+        f'(subpath "{literal}")' in profile
+        for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals("/opt/dyld")
     )
     assert "localhost" not in profile
 

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -4159,7 +4159,7 @@ def test_build_validation_sandbox_plan_linux_skips_broad_inherited_library_binds
     assert not _command_has_bind(plan, "--ro-bind", Path("/home/alice"))
 
 
-def test_build_validation_sandbox_plan_linux_gpu_validation_binds_vulkan_render_nodes(
+def test_build_validation_sandbox_plan_linux_rocm_gpu_validation_binds_vulkan_render_nodes(
     monkeypatch, tmp_path
 ):
     bwrap_path = tmp_path / "bwrap"
@@ -4220,7 +4220,7 @@ def test_build_validation_sandbox_plan_linux_gpu_validation_binds_vulkan_render_
         runtime_line = None,
         env = {"LD_LIBRARY_PATH": str(binary_dir)},
         enable_gpu_layers = True,
-        gpu_backend = "cuda",
+        gpu_backend = "rocm",
     )
 
     assert plan.is_runnable

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3978,6 +3978,98 @@ def test_build_validation_sandbox_plan_linux_server_probe_uses_resolved_helper_p
     assert str(helper_symlink) not in plan.command
 
 
+def test_build_validation_sandbox_plan_linux_server_probe_binds_nix_store(monkeypatch, tmp_path):
+    bwrap_path = tmp_path / "bwrap"
+    bwrap_path.write_text("")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: str(bwrap_path.resolve()) if command == "bwrap" else None,
+    )
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_binary_is_setuid_root", lambda _path: True)
+    install_dir = tmp_path / "install"
+    binary_dir = tmp_path / "bin"
+    model_dir = tmp_path / "models"
+    for directory in (install_dir, binary_dir, model_dir):
+        directory.mkdir(parents = True, exist_ok = True)
+    helper_symlink = tmp_path / "helper-python"
+    helper_symlink.write_text("")
+    binary_path = binary_dir / "llama-server"
+    binary_path.write_text("")
+
+    original_resolve = Path.resolve
+    original_exists = Path.exists
+
+    def fake_resolve(path: Path, strict: bool = False):
+        if path == helper_symlink:
+            return Path("/nix/store/fake-python/bin/python3")
+        return original_resolve(path, strict = strict)
+
+    def fake_exists(path: Path) -> bool:
+        normalized = str(path).replace("\\", "/")
+        if normalized in {
+            "/nix/store",
+            "/nix/store/fake-python/bin/python3",
+            "/nix/store/fake-python/bin",
+        }:
+            return True
+        return original_exists(path)
+
+    monkeypatch.setattr(Path, "resolve", fake_resolve)
+    monkeypatch.setattr(Path, "exists", fake_exists)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_linux_validation_server_probe_command",
+        lambda command, payload_env, timeout = 60: [str(helper_symlink), "-c", "server probe"],
+    )
+
+    plan = build_validation_sandbox_plan(
+        ["llama-server", "-m", str(model_dir / "stories260K.gguf"), "--port", "7777"],
+        binary_path = binary_path,
+        install_dir = install_dir,
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {"LD_LIBRARY_PATH": "/tmp/payload/libs"},
+    )
+
+    assert plan.is_runnable
+    assert _command_contains_path(plan, "nix/store")
+
+
+def test_build_validation_sandbox_plan_linux_gpu_uses_direct_validation_without_setuid_bwrap(monkeypatch, tmp_path):
+    bwrap_path = tmp_path / "bwrap"
+    bwrap_path.write_text("")
+    binary_path = tmp_path / "llama-server"
+    binary_path.write_text("")
+    install_dir = tmp_path / "install"
+    install_dir.mkdir()
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: str(bwrap_path.resolve()) if command == "bwrap" else None,
+    )
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_binary_is_setuid_root", lambda _path: False)
+
+    plan = build_validation_sandbox_plan(
+        [str(binary_path), "--help"],
+        binary_path = binary_path,
+        install_dir = install_dir,
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {},
+        enable_gpu_layers = True,
+        gpu_backend = "cuda",
+    )
+
+    assert plan.is_runnable
+    assert plan.command == [str(binary_path), "--help"]
+    assert plan.sandbox_kind == "linux_direct_validation"
+    assert plan.network_policy == INSTALL_LLAMA_PREBUILT._VALIDATION_NETWORK_POLICY_DIRECT
+    assert plan.server_probe_mode == INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_HOST
+
+
 def test_linux_validation_server_probe_command_passes_payload_env_to_server_spawn():
     probe_command = INSTALL_LLAMA_PREBUILT._linux_validation_server_probe_command(
         [
@@ -4167,12 +4259,14 @@ def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled
         "_resolve_command_path",
         lambda command: "/tmp/bin/bwrap" if command == "bwrap" else None,
     )
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_binary_is_setuid_root", lambda _path: True)
     existing_nodes = {
         "/dev/nvidiactl",
         "/dev/nvidia-uvm",
         "/dev/nvidia-uvm-tools",
         "/dev/nvidia-modeset",
         "/dev/nvidia0",
+        "/dev/nvidia-caps/nvidia-cap1",
         "/dev/kfd",
         "/dev/dxg",
         "/dev/dri/card0",
@@ -4182,6 +4276,7 @@ def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled
         "/sys/dev/char",
         "/sys/devices",
         "/proc/driver/nvidia",
+        "/proc/driver/nvidia/capabilities",
     }
     original_exists = Path.exists
     original_glob = Path.glob
@@ -4201,6 +4296,8 @@ def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled
         normalized = _norm(path)
         if normalized == "/dev" and pattern == "nvidia*":
             return [Path(node) for node in existing_nodes if str(node).startswith("/dev/nvidia") and "*" not in node]
+        if normalized == "/dev/nvidia-caps" and pattern == "nvidia-cap*":
+            return [Path("/dev/nvidia-caps/nvidia-cap1")]
         if normalized == "/dev/dri" and pattern == "card*":
             return [Path("/dev/dri/card0")]
         if normalized == "/dev/dri" and pattern == "renderD*":
@@ -4230,12 +4327,14 @@ def test_build_validation_sandbox_plan_linux_server_binds_gpu_nodes_when_enabled
     assert "--dev-bind-try" in plan.command
     assert any("nvidiactl" in part for part in plan.command)
     assert any("nvidia0" in part for part in plan.command)
+    assert any("nvidia-cap1" in part for part in plan.command)
     assert not any("dxg" in part for part in plan.command)
     assert not _command_contains_path(plan, "dri/card0")
     assert not _command_contains_path(plan, "dri/renderD128")
     assert not any("kfd" in part for part in plan.command)
     assert _command_contains_path(plan, "sys/class/drm")
     assert _command_contains_path(plan, "proc/driver/nvidia")
+    assert _command_contains_path(plan, "proc/driver/nvidia/capabilities")
 
 
 def test_build_validation_sandbox_plan_linux_server_binds_rocm_nodes_when_enabled(monkeypatch, tmp_path):
@@ -4244,6 +4343,7 @@ def test_build_validation_sandbox_plan_linux_server_binds_rocm_nodes_when_enable
         "_resolve_command_path",
         lambda command: "/tmp/bin/bwrap" if command == "bwrap" else None,
     )
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_binary_is_setuid_root", lambda _path: True)
     existing_nodes = {
         "/dev/kfd",
         "/dev/dxg",
@@ -4838,6 +4938,56 @@ def test_validate_server_uses_extended_capture_timeout_for_in_sandbox_probe(monk
     assert isinstance(captured_timeout, int)
     assert captured_timeout == INSTALL_LLAMA_PREBUILT._LINUX_SERVER_VALIDATION_HELPER_CAPTURE_TIMEOUT_SECONDS
     assert captured_timeout > INSTALL_LLAMA_PREBUILT._LINUX_SERVER_VALIDATION_HELPER_TIMEOUT_SECONDS
+
+
+def test_validate_server_skips_gpu_layers_for_macos_arm64(monkeypatch, tmp_path):
+    server_path = tmp_path / "llama-server"
+    server_path.write_text("")
+    probe_path = tmp_path / "probe.gguf"
+    probe_path.write_text("")
+    recorded: dict[str, object] = {}
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", lambda *_a, **_k: {"PATH": str(tmp_path)})
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "free_local_port", lambda: 7777)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.urllib.request, "urlopen", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("stop")))
+
+    def fake_build_plan(
+        command: list[str],
+        *,
+        binary_path: Path,
+        install_dir: Path,
+        purpose: str,
+        env: dict[str, str],
+        host = None,
+        runtime_line = None,
+        enable_gpu_layers: bool = False,
+        gpu_backend = None,
+    ) -> ValidationLaunchPlan:
+        recorded["command"] = command
+        recorded["enable_gpu_layers"] = enable_gpu_layers
+        return ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = "fallback",
+            purpose = purpose,
+            reason = "stop",
+        )
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
+
+    with pytest.raises(PrebuiltFallback, match = "stop"):
+        validate_server(
+            server_path,
+            probe_path,
+            macos_host(),
+            tmp_path,
+            runtime_line = None,
+            install_kind = "macos-arm64",
+        )
+
+    command = recorded["command"]
+    assert "--n-gpu-layers" not in command
+    assert recorded["enable_gpu_layers"] is False
 
 
 def test_validate_server_falls_back_without_linux_sandbox(monkeypatch, tmp_path):

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -1502,7 +1502,9 @@ def write_macos_install_shape(
     (install_dir / "gguf-py" / "gguf").mkdir(parents = True, exist_ok = True)
 
 
-def test_existing_install_matches_plan_with_fingerprint_linux(tmp_path: Path):
+def test_existing_install_matches_plan_with_fingerprint_linux(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
     install_dir = tmp_path / "llama.cpp"
     install_dir.mkdir()
     write_linux_install_shape(install_dir)
@@ -1557,6 +1559,15 @@ def test_existing_install_matches_plan_with_fingerprint_linux(tmp_path: Path):
         release_tag = "release-1",
         attempts = [choice],
         approved_checksums = checksums,
+    )
+
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_run_validation_ldd_probe",
+        lambda _binary_path, *, env: LinuxLibraryProbeResult(
+            status = LINUX_LDD_PROBE_OK,
+            missing = [],
+        ),
     )
 
     write_prebuilt_metadata(
@@ -2588,6 +2599,17 @@ def test_install_prebuilt_skips_download_when_existing_install_matches(
         has_physical_nvidia = False,
         has_usable_nvidia = False,
     )
+
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_run_validation_ldd_probe",
+        lambda _binary_path, *, env: LinuxLibraryProbeResult(
+            status = LINUX_LDD_PROBE_OK,
+            missing = [],
+            reason = None,
+        ),
+    )
+
     choice = AssetChoice(
         repo = "unslothai/llama.cpp",
         tag = "release-1",
@@ -2848,6 +2870,17 @@ def test_install_prebuilt_skips_when_older_release_fallback_matches_existing_ins
         has_physical_nvidia = False,
         has_usable_nvidia = False,
     )
+
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_run_validation_ldd_probe",
+        lambda _binary_path, *, env: LinuxLibraryProbeResult(
+            status = LINUX_LDD_PROBE_OK,
+            missing = [],
+            reason = None,
+        ),
+    )
+
     latest_choice = AssetChoice(
         repo = "unslothai/llama.cpp",
         tag = "release-2",
@@ -3009,6 +3042,17 @@ def test_install_prebuilt_skips_same_release_fallback_attempt_when_installed(
         has_physical_nvidia = False,
         has_usable_nvidia = False,
     )
+
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_run_validation_ldd_probe",
+        lambda _binary_path, *, env: LinuxLibraryProbeResult(
+            status = LINUX_LDD_PROBE_OK,
+            missing = [],
+            reason = None,
+        ),
+    )
+
     first_choice = AssetChoice(
         repo = "unslothai/llama.cpp",
         tag = "release-1",
@@ -3300,7 +3344,9 @@ def add_symlink_to_tar(archive: tarfile.TarFile, name: str, target: str) -> None
     archive.addfile(info)
 
 
-def test_existing_install_matches_choice_fails_when_install_tree_incomplete(tmp_path: Path):
+def test_existing_install_matches_choice_fails_when_install_tree_incomplete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
     """confirm_install_tree guard rejects installs missing critical files."""
     install_dir = tmp_path / "llama.cpp"
     install_dir.mkdir()
@@ -3321,6 +3367,17 @@ def test_existing_install_matches_choice_fails_when_install_tree_incomplete(tmp_
         has_physical_nvidia = False,
         has_usable_nvidia = False,
     )
+
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_run_validation_ldd_probe",
+        lambda _binary_path, *, env: LinuxLibraryProbeResult(
+            status = LINUX_LDD_PROBE_OK,
+            missing = [],
+            reason = None,
+        ),
+    )
+
     choice = AssetChoice(
         repo = "unslothai/llama.cpp",
         tag = "release-1",
@@ -3801,24 +3858,129 @@ def test_build_validation_sandbox_plan_linux_without_bwrap_falls_back_validation
     assert plan.reason is not None
 
 
-def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch):
+def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch, tmp_path):
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    helper_bin = tmp_path / "helper" / "bin"
+    helper_lib = tmp_path / "helper" / "lib"
+    install_dir = tmp_path / "install"
+    binary_dir = tmp_path / "bin"
+    model_dir = tmp_path / "models"
+    for directory in (helper_bin, helper_lib, install_dir, binary_dir, model_dir):
+        directory.mkdir(parents = True, exist_ok = True)
+    helper_path = helper_bin / "python3"
+    helper_path.write_text("")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_linux_validation_server_probe_command",
+        lambda command, timeout = 60: [str(helper_path), "-c", "server probe"],
+    )
+    binary_path = binary_dir / "llama-server"
+    binary_path.write_text("")
     plan = build_validation_sandbox_plan(
-        ["llama-server", "--help"],
-        binary_path = Path("/tmp/bin/llama-server"),
-        install_dir = Path("/tmp/install"),
+        ["llama-server", "-m", str(model_dir / "stories260K.gguf"), "--port", "7777"],
+        binary_path = binary_path,
+        install_dir = install_dir,
         host = linux_host(),
         purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
         runtime_line = None,
-        env = {},
+        env = {"LD_LIBRARY_PATH": "/tmp/payload/libs"},
     )
     assert plan.is_runnable
-    assert plan.command[:5] == ["bwrap", "--unshare-all", "--share-net", "--die-with-parent", "--new-session"]
-    assert "ldd" in plan.command[-1] or "--help" in plan.command[-1]
+    assert plan.command[0] == "bwrap"
+    assert plan.command[1] == "--unshare-all"
+    assert "--share-net" not in plan.command
+    assert "--setenv" in plan.command
+    assert "LD_LIBRARY_PATH" in plan.command
+    assert plan.env.get("LD_LIBRARY_PATH") is None
+    assert plan.payload_command == [
+        "llama-server",
+        "-m",
+        str(model_dir / "stories260K.gguf"),
+        "--port",
+        "7777",
+    ]
+    assert plan.payload_env == {"LD_LIBRARY_PATH": "/tmp/payload/libs"}
     assert "--ro-bind" in plan.command
     assert "--bind" in plan.command
     assert "--dev" in plan.command
     assert "/dev/nvidiactl" not in plan.command
+    assert plan.network_policy == INSTALL_LLAMA_PREBUILT._VALIDATION_NETWORK_POLICY_SANDBOX
+    assert str(model_dir) in plan.command
+    assert str(helper_lib) in plan.command
+
+
+def test_run_validation_capture_uses_launcher_env_for_linux_bwrap(monkeypatch):
+    launcher_env = {"PATH": "/usr/bin", "UNSANDBOXABLE": "1"}
+    plan = ValidationLaunchPlan(
+        command = ["bwrap", "--unshare-all", "--die-with-parent", "--new-session"],
+        env = launcher_env,
+        action = "run",
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_QUANTIZE,
+        sandbox_kind = "linux_bwrap",
+        payload_command = ["llama-quantize", "in", "out"],
+        payload_env = {"LD_LIBRARY_PATH": "/payload/lib"},
+        server_probe_mode = None,
+    )
+
+    captured: dict[str, dict[str, str] | None] = {}
+
+    def fake_run_capture(command, *, timeout, env = None, check = False):
+        captured["env"] = dict(env or {})
+        return subprocess.CompletedProcess(command, 0, stdout = "ok")
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "run_capture", fake_run_capture)
+    result = run_validation_capture(plan, timeout = 5)
+    assert result.returncode == 0
+    assert captured["env"] == launcher_env
+    assert captured["env"] is not None
+    assert "LD_LIBRARY_PATH" not in (captured["env"] or {})
+
+
+def test_run_validation_popen_uses_launcher_env_for_linux_bwrap(monkeypatch):
+    launcher_env = {"PATH": "/usr/bin", "UNSANDBOXABLE": "1"}
+    plan = ValidationLaunchPlan(
+        command = ["bwrap", "--unshare-all", "--die-with-parent", "--new-session"],
+        env = launcher_env,
+        action = "run",
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        sandbox_kind = "linux_bwrap",
+        payload_command = ["llama-server"],
+        payload_env = {"LD_LIBRARY_PATH": "/payload/lib"},
+        server_probe_mode = INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX,
+    )
+
+    class _FakeProcess:
+        def __init__(self):
+            self.started_with: dict[str, object] = {}
+
+        def poll(self):
+            return None
+
+        def wait(self, timeout: float | None = None):
+            return 0
+
+        def terminate(self):
+            return None
+
+        def kill(self):
+            return None
+
+    fake_process = _FakeProcess()
+
+    def fake_popen(command, *, stdout, stderr, text, env = None, **_kwargs):
+        fake_process.started_with = {
+            "command": list(command),
+            "stdout": stdout,
+            "env": dict(env or {}),
+        }
+        return fake_process
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.subprocess, "Popen", fake_popen)
+    process = run_validation_popen(plan, stdout = None)
+    assert process is fake_process
+    assert fake_process.started_with["command"] == plan.command
+    assert fake_process.started_with["env"] == launcher_env
+    assert "LD_LIBRARY_PATH" not in (fake_process.started_with["env"] or {})
 
 
 def test_build_validation_sandbox_plan_linux_quantize_binds_probe_and_output(monkeypatch, tmp_path):
@@ -3996,6 +4158,7 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
     profile = mac_run.command[2]
     assert "(deny default)" in profile
     assert '(import "bsd.sb")' in profile
+    assert "(subpath \"/private\")" not in profile
     assert any(
         f'(subpath "{literal}")' in profile
         for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals("/tmp/install")
@@ -4041,6 +4204,7 @@ def test_build_validation_sandbox_plan_macos_server_keeps_loopback(monkeypatch):
     profile = plan.command[2]
     assert "(deny default)" in profile
     assert '(import "bsd.sb")' in profile
+    assert "(subpath \"/private\")" not in profile
     assert '(allow network* (local ip "localhost:*"))' in profile
     assert '(allow network* (remote ip "localhost:*"))' in profile
 
@@ -4087,6 +4251,27 @@ def test_run_validation_ldd_probe_reports_skipped_status_without_sandbox_adapter
     assert result.status == LINUX_LDD_PROBE_SKIPPED
     assert result.missing == []
     assert result.reason is not None
+
+
+def test_run_validation_ldd_probe_reports_error_on_nonzero_returncode(monkeypatch, tmp_path):
+    binary_path = tmp_path / "server"
+    binary_path.write_text("")
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT.shutil, "which", lambda name: f"/usr/bin/{name}"
+    )
+
+    def fake_capture(plan, *, timeout: int):
+        return subprocess.CompletedProcess(plan.command, 1, stdout = "", stderr = "bwrap: bind failed")
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_capture", fake_capture)
+
+    result = run_validation_ldd_probe(binary_path, env = {"LD_LIBRARY_PATH": ""})
+    assert result.status == LINUX_LDD_PROBE_ERROR
+    assert result.reason is not None
+    assert "bind failed" in result.reason
 
 
 def test_linux_missing_libraries_uses_bwrap_plan(monkeypatch, tmp_path):
@@ -4299,29 +4484,6 @@ def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
     install_dir = tmp_path
     recorded: dict[str, object] = {}
 
-    def fake_build_plan(
-        command: list[str],
-        *,
-        binary_path: Path,
-        install_dir: Path,
-        purpose: str,
-        env: dict[str, str],
-        host = None,
-        runtime_line = None,
-        enable_gpu_layers: bool = False,
-        gpu_backend = None,
-    ) -> ValidationLaunchPlan:
-        recorded["command"] = command
-        recorded["purpose"] = purpose
-        recorded["enable_gpu_layers"] = enable_gpu_layers
-        recorded["gpu_backend"] = gpu_backend
-        return ValidationLaunchPlan(
-            command = command,
-            env = env,
-            action = "run",
-            purpose = purpose,
-        )
-
     class _FakeResponse:
         status = 200
 
@@ -4352,15 +4514,55 @@ def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
     def fake_binary_env(*_a, **_k):
         return {"PATH": str(tmp_path)}
 
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "binary_env", fake_binary_env)
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_popen", lambda plan, *, stdout: _FakeProcess())
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "free_local_port", lambda: 7777)
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.urllib.request, "urlopen", lambda *a, **k: _FakeResponse())
-    monkeypatch.setattr(
-        INSTALL_LLAMA_PREBUILT, "run_capture",
-        lambda *a, **k: (_ for _ in ()).throw(AssertionError("run_capture must not be used")),
-    )
+    called_popen = False
+
+    def fake_popen(*_a, **_k):
+        nonlocal called_popen
+        called_popen = True
+        return _FakeProcess()
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_popen", fake_popen)
+    called_capture = False
+
+    def fake_capture(_plan, *, timeout: int):
+        nonlocal called_capture
+        called_capture = True
+        return subprocess.CompletedProcess(_plan.command, 0, stdout = "ok")
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_run_validation_capture", fake_capture)
+
+    def fake_build_plan(
+        command: list[str],
+        *,
+        binary_path: Path,
+        install_dir: Path,
+        purpose: str,
+        env: dict[str, str],
+        host = None,
+        runtime_line = None,
+        enable_gpu_layers: bool = False,
+        gpu_backend = None,
+    ) -> ValidationLaunchPlan:
+        recorded["command"] = command
+        recorded["purpose"] = purpose
+        recorded["enable_gpu_layers"] = enable_gpu_layers
+        recorded["gpu_backend"] = gpu_backend
+        recorded["server_probe_mode"] = INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX
+        return ValidationLaunchPlan(
+            command = command,
+            env = env,
+            action = "run",
+            purpose = purpose,
+            sandbox_kind = "linux_bwrap",
+            payload_command = command,
+            payload_env = env,
+            server_probe_mode = INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX,
+        )
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "build_validation_sandbox_plan", fake_build_plan)
 
     validate_server(
         server_path,
@@ -4376,6 +4578,9 @@ def test_validate_server_routes_through_sandbox_plan(monkeypatch, tmp_path):
     assert "--n-gpu-layers" in command
     assert recorded["enable_gpu_layers"] is True
     assert recorded["gpu_backend"] == "cuda"
+    assert called_capture is True
+    assert called_popen is False
+    assert recorded["server_probe_mode"] == INSTALL_LLAMA_PREBUILT._VALIDATION_SERVER_PROBE_MODE_IN_SANDBOX
 
 
 def test_validate_server_falls_back_without_linux_sandbox(monkeypatch, tmp_path):

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3793,9 +3793,35 @@ def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch):
         env = {},
     )
     assert plan.is_runnable
-    assert plan.command[:5] == ["bwrap", "--unshare-all", "--unshare-net", "--die-with-parent", "--new-session"]
+    assert plan.command[:5] == ["bwrap", "--unshare-all", "--share-net", "--die-with-parent", "--new-session"]
     assert "ldd" in plan.command[-1] or "--help" in plan.command[-1]
     assert "--ro-bind" in plan.command
+    assert "--dev" in plan.command
+    assert "--bind" in plan.command
+
+
+def test_build_validation_sandbox_plan_linux_quantize_binds_probe_and_output(monkeypatch, tmp_path):
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
+    bin_dir = tmp_path / "bin"
+    probe_dir = tmp_path / "models"
+    out_dir = tmp_path / "out"
+    runtime_dir = tmp_path / "runtime"
+    for directory in (bin_dir, probe_dir, out_dir, runtime_dir):
+        directory.mkdir()
+    plan = build_validation_sandbox_plan(
+        [str(bin_dir / "llama-quantize"), str(probe_dir / "probe.gguf"), str(out_dir / "probe-q4.gguf"), "Q6_K", "2"],
+        binary_path = bin_dir / "llama-quantize",
+        install_dir = tmp_path / "install",
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_QUANTIZE,
+        runtime_line = None,
+        env = {"LD_LIBRARY_PATH": str(runtime_dir)},
+    )
+    assert plan.is_runnable
+    assert plan.command.count("--ro-bind") >= 3
+    assert plan.command.count("--bind") >= 2
+    assert str(probe_dir) in plan.command
+    assert str(out_dir) in plan.command
 
 
 def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monkeypatch):
@@ -3863,7 +3889,6 @@ def test_linux_missing_libraries_skips_ldd_without_sandbox_adapter(monkeypatch, 
 def test_linux_missing_libraries_uses_bwrap_plan(monkeypatch, tmp_path):
     binary_path = tmp_path / "server"
     binary_path.write_text("")
-    install_dir = tmp_path
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_host_is_linux", lambda host = None: True)
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "bwrap")
@@ -3881,7 +3906,7 @@ def test_linux_missing_libraries_uses_bwrap_plan(monkeypatch, tmp_path):
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "run_capture", fake_run_capture)
     assert linux_missing_libraries(binary_path, env = {"LD_LIBRARY_PATH": ""}) == ["libbad"]
     assert captured["command"][0] == "bwrap"
-    assert "ldd" in captured["command"]
+    assert any(Path(part).stem == "ldd" for part in captured["command"])
 
 
 def test_linux_missing_libraries_tolerates_probe_errors(monkeypatch, tmp_path):

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -60,6 +60,7 @@ LINUX_LDD_PROBE_OK = INSTALL_LLAMA_PREBUILT._LINUX_LDD_PROBE_OK
 LINUX_LDD_PROBE_SKIPPED = INSTALL_LLAMA_PREBUILT._LINUX_LDD_PROBE_SKIPPED
 LINUX_LDD_PROBE_ERROR = INSTALL_LLAMA_PREBUILT._LINUX_LDD_PROBE_ERROR
 preflight_linux_installed_binaries = INSTALL_LLAMA_PREBUILT.preflight_linux_installed_binaries
+bwrap_can_sandbox = INSTALL_LLAMA_PREBUILT._bwrap_can_sandbox
 
 
 @pytest.fixture(autouse = True)
@@ -1312,6 +1313,18 @@ def _command_contains_path(plan: ValidationLaunchPlan, path_fragment: str) -> bo
 def _command_has_setenv(plan: ValidationLaunchPlan, key: str) -> bool:
     for index in range(len(plan.command) - 2):
         if plan.command[index] == "--setenv" and plan.command[index + 1] == key:
+            return True
+    return False
+
+
+def _command_has_bind(plan: ValidationLaunchPlan, flag: str, source: str | Path) -> bool:
+    source_text = str(Path(source))
+    for index in range(len(plan.command) - 2):
+        if (
+            plan.command[index] == flag
+            and plan.command[index + 1] == source_text
+            and plan.command[index + 2] == source_text
+        ):
             return True
     return False
 
@@ -3901,6 +3914,24 @@ def test_build_validation_sandbox_plan_linux_unusable_bwrap_skips_ldd(monkeypatc
     assert "skip ldd probe" in plan.reason
 
 
+def test_bwrap_capability_probe_uses_clean_launcher_env(monkeypatch):
+    captured: dict[str, dict[str, str]] = {}
+    monkeypatch.setenv("LD_LIBRARY_PATH", "/bad/loader")
+    monkeypatch.setenv("LD_PRELOAD", "/bad/preload.so")
+    INSTALL_LLAMA_PREBUILT._bwrap_sandbox_capability.clear()
+
+    def fake_run(*_args, **kwargs):
+        captured["env"] = kwargs["env"]
+        return subprocess.CompletedProcess(args = [], returncode = 0)
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT.subprocess, "run", fake_run)
+
+    assert bwrap_can_sandbox("/usr/bin/bwrap")
+    assert "LD_LIBRARY_PATH" not in captured["env"]
+    assert "LD_PRELOAD" not in captured["env"]
+    assert captured["env"]["PATH"] == "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+
 def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch, tmp_path):
     bwrap_path = tmp_path / "bwrap"
     bwrap_path.write_text("")
@@ -3960,6 +3991,45 @@ def test_build_validation_sandbox_plan_linux_with_bwrap_runs(monkeypatch, tmp_pa
     assert plan.network_policy == INSTALL_LLAMA_PREBUILT._VALIDATION_NETWORK_POLICY_SANDBOX
     assert str(model_dir) in plan.command
     assert str(helper_lib) in plan.command
+
+
+def test_build_validation_sandbox_plan_linux_skips_broad_inherited_library_binds(
+    monkeypatch, tmp_path
+):
+    bwrap_path = tmp_path / "bwrap"
+    bwrap_path.write_text("")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: str(bwrap_path) if command == "bwrap" else None,
+    )
+    install_dir = tmp_path / "install"
+    binary_dir = tmp_path / "bin"
+    runtime_lib = tmp_path / "runtime" / "lib"
+    model_dir = tmp_path / "models"
+    for directory in (install_dir, binary_dir, runtime_lib, model_dir):
+        directory.mkdir(parents = True, exist_ok = True)
+    binary_path = binary_dir / "llama-server"
+    binary_path.write_text("")
+
+    plan = build_validation_sandbox_plan(
+        ["llama-server", "-m", str(model_dir / "stories260K.gguf"), "--port", "7777"],
+        binary_path = binary_path,
+        install_dir = install_dir,
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {
+            "LD_LIBRARY_PATH": os.pathsep.join(
+                [str(Path("/")), str(Path("/home/alice")), str(runtime_lib)]
+            )
+        },
+    )
+
+    assert plan.is_runnable
+    assert _command_has_bind(plan, "--ro-bind", runtime_lib)
+    assert not _command_has_bind(plan, "--ro-bind", Path("/"))
+    assert not _command_has_bind(plan, "--ro-bind", Path("/home/alice"))
 
 
 def test_build_validation_sandbox_plan_linux_server_probe_uses_resolved_helper_path(
@@ -4501,7 +4571,9 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
     output_path = Path("/tmp/out/probe-q4.gguf")
 
     monkeypatch.setattr(
-        INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "sandbox-exec"
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: "/usr/bin/sandbox-exec" if command == "sandbox-exec" else None,
     )
     mac_run = build_validation_sandbox_plan(
         [str(binary_path), str(probe_path), str(output_path), "Q6_K", "2"],
@@ -4510,10 +4582,10 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
         host = macos_host(),
         purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_QUANTIZE,
         runtime_line = None,
-        env = {"DYLD_LIBRARY_PATH": "/opt/dyld"},
+        env = {"DYLD_LIBRARY_PATH": os.pathsep.join(["/", "/Users/alice", "/opt/dyld"])},
     )
     assert mac_run.is_runnable
-    assert mac_run.command[:2] == ["sandbox-exec", "-p"]
+    assert mac_run.command[:2] == ["/usr/bin/sandbox-exec", "-p"]
     assert "/usr/bin/env" in mac_run.command
     profile = mac_run.command[2]
     assert "(deny default)" in profile
@@ -4532,15 +4604,15 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
     )
     assert any(
         f'(subpath "{literal}")' in profile
-        for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals("/tmp/out")
-    )
-    assert any(
-        f'(subpath "{literal}")' in profile
         for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals("/opt/dyld")
     )
+    for broad_path in ("/", "/Users/alice"):
+        for literal in INSTALL_LLAMA_PREBUILT._sandbox_profile_path_literals(broad_path):
+            assert f'(literal "{literal}")' not in profile
+            assert f'(subpath "{literal}")' not in profile
     assert "localhost" not in profile
 
-    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_has_command", lambda *_a, **_k: False)
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_resolve_command_path", lambda *_a, **_k: None)
     mac_skip = build_validation_sandbox_plan(
         [str(binary_path), str(probe_path), str(output_path), "Q6_K", "2"],
         binary_path = binary_path,
@@ -4555,7 +4627,9 @@ def test_build_validation_sandbox_plan_macos_with_and_without_sandbox_exec(monke
 
 def test_build_validation_sandbox_plan_macos_server_keeps_loopback(monkeypatch):
     monkeypatch.setattr(
-        INSTALL_LLAMA_PREBUILT, "_has_command", lambda command: command == "sandbox-exec"
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: "/usr/bin/sandbox-exec" if command == "sandbox-exec" else None,
     )
     plan = build_validation_sandbox_plan(
         ["llama-server", "-m", str(Path("/tmp/models/story.gguf")), "--port", "7777"],
@@ -4567,7 +4641,7 @@ def test_build_validation_sandbox_plan_macos_server_keeps_loopback(monkeypatch):
         env = {},
     )
     assert plan.is_runnable
-    assert plan.command[:2] == ["sandbox-exec", "-p"]
+    assert plan.command[:2] == ["/usr/bin/sandbox-exec", "-p"]
     assert "/usr/bin/env" in plan.command
     profile = plan.command[2]
     assert "(deny default)" in profile

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -1189,6 +1189,34 @@ def test_binary_env_strips_secrets_from_downloaded_binary_environment(
     assert env["CUDA_VISIBLE_DEVICES"] == "1"
 
 
+def test_binary_env_linux_strips_loader_injections_and_broad_inherited_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    install_dir = tmp_path / "llama.cpp"
+    bin_dir = install_dir / "build" / "bin"
+    runtime_lib = tmp_path / "runtime" / "lib"
+    runtime_lib.mkdir(parents = True)
+    bin_dir.mkdir(parents = True)
+    binary_path = bin_dir / "llama-server"
+    binary_path.write_bytes(b"fake")
+
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "linux_runtime_dirs", lambda _bp: [])
+    monkeypatch.setenv(
+        "LD_LIBRARY_PATH",
+        os.pathsep.join([str(Path("/")), str(runtime_lib.parent / ".." / "runtime" / "lib")]),
+    )
+    monkeypatch.setenv("LD_PRELOAD", str(tmp_path / "inject.so"))
+    monkeypatch.setenv("LD_AUDIT", str(tmp_path / "audit.so"))
+
+    env = binary_env(binary_path, install_dir, linux_host())
+
+    assert "LD_PRELOAD" not in env
+    assert "LD_AUDIT" not in env
+    ld_dirs = env["LD_LIBRARY_PATH"].split(os.pathsep)
+    assert str(Path("/")) not in ld_dirs
+    assert str(runtime_lib.resolve()) in ld_dirs
+
+
 def test_binary_env_redirects_home_away_from_real_credential_stores(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
@@ -1291,7 +1319,9 @@ def test_binary_env_macos_strips_inherited_dyld_loader_controls(
     binary_path = bin_dir / "llama-server"
     binary_path.write_bytes(b"fake")
 
-    monkeypatch.setenv("DYLD_LIBRARY_PATH", str(runtime_lib))
+    monkeypatch.setenv(
+        "DYLD_LIBRARY_PATH", str(runtime_lib.parent / ".." / runtime_lib.parent.name / runtime_lib.name)
+    )
     monkeypatch.setenv("DYLD_INSERT_LIBRARIES", str(tmp_path / "inject.dylib"))
     monkeypatch.setenv("DYLD_FRAMEWORK_PATH", str(tmp_path / "Frameworks"))
     monkeypatch.setenv("DYLD_FALLBACK_LIBRARY_PATH", str(tmp_path / "fallback"))
@@ -1301,9 +1331,10 @@ def test_binary_env_macos_strips_inherited_dyld_loader_controls(
     assert "DYLD_INSERT_LIBRARIES" not in env
     assert "DYLD_FRAMEWORK_PATH" not in env
     assert "DYLD_FALLBACK_LIBRARY_PATH" not in env
-    assert str(bin_dir) in env["DYLD_LIBRARY_PATH"].split(os.pathsep)
-    assert str(install_dir) in env["DYLD_LIBRARY_PATH"].split(os.pathsep)
-    assert str(runtime_lib) in env["DYLD_LIBRARY_PATH"].split(os.pathsep)
+    dyld_dirs = env["DYLD_LIBRARY_PATH"].split(os.pathsep)
+    assert str(bin_dir) in dyld_dirs
+    assert str(install_dir) in dyld_dirs
+    assert str(runtime_lib.resolve()) in dyld_dirs
 
 
 def test_linux_runtime_dirs_probes_with_secret_free_env(monkeypatch: pytest.MonkeyPatch):
@@ -1632,6 +1663,73 @@ def test_existing_install_matches_plan_with_fingerprint_linux(
     )
 
     assert existing_install_matches_plan(install_dir, host, plan) is True
+
+
+def test_existing_install_matches_plan_linux_allows_skipped_ldd_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    install_dir = tmp_path / "llama.cpp"
+    install_dir.mkdir()
+    write_linux_install_shape(install_dir)
+
+    choice = AssetChoice(
+        repo = "unslothai/llama.cpp",
+        tag = "release-1",
+        name = "llama-b9001-bin-ubuntu-x64.tar.gz",
+        url = "https://example.com/llama-b9001-bin-ubuntu-x64.tar.gz",
+        source_label = "upstream",
+        install_kind = "linux-cpu",
+        expected_sha256 = "a" * 64,
+    )
+    checksums = ApprovedReleaseChecksums(
+        repo = "unslothai/llama.cpp",
+        release_tag = "release-1",
+        upstream_tag = "b9001",
+        source_commit = "deadbeef",
+        artifacts = {
+            source_archive_logical_name("b9001"): ApprovedArtifactHash(
+                asset_name = source_archive_logical_name("b9001"),
+                sha256 = "b" * 64,
+                repo = "ggml-org/llama.cpp",
+                kind = "upstream-source",
+            ),
+            choice.name: ApprovedArtifactHash(
+                asset_name = choice.name,
+                sha256 = choice.expected_sha256,
+                repo = "ggml-org/llama.cpp",
+                kind = "upstream-prebuilt",
+            ),
+        },
+    )
+    plan = INSTALL_LLAMA_PREBUILT.InstallReleasePlan(
+        requested_tag = "latest",
+        llama_tag = "b9001",
+        release_tag = "release-1",
+        attempts = [choice],
+        approved_checksums = checksums,
+    )
+
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_run_validation_ldd_probe",
+        lambda _binary_path, *, env: LinuxLibraryProbeResult(
+            status = LINUX_LDD_PROBE_SKIPPED,
+            missing = [],
+            reason = "bwrap unavailable",
+        ),
+    )
+
+    write_prebuilt_metadata(
+        install_dir,
+        requested_tag = "latest",
+        llama_tag = "b9001",
+        release_tag = "release-1",
+        choice = choice,
+        approved_checksums = checksums,
+        prebuilt_fallback_used = False,
+    )
+
+    assert existing_install_matches_plan(install_dir, linux_host(), plan) is True
 
 
 def test_existing_install_matches_plan_false_without_fingerprint(tmp_path: Path):
@@ -4059,6 +4157,77 @@ def test_build_validation_sandbox_plan_linux_skips_broad_inherited_library_binds
     assert _command_has_bind(plan, "--ro-bind", runtime_lib)
     assert not _command_has_bind(plan, "--ro-bind", Path("/"))
     assert not _command_has_bind(plan, "--ro-bind", Path("/home/alice"))
+
+
+def test_build_validation_sandbox_plan_linux_gpu_validation_binds_vulkan_render_nodes(
+    monkeypatch, tmp_path
+):
+    bwrap_path = tmp_path / "bwrap"
+    bwrap_path.write_text("")
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_resolve_command_path",
+        lambda command: str(bwrap_path) if command == "bwrap" else None,
+    )
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_binary_is_setuid_root", lambda _path: True)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_linux_validation_server_probe_command",
+        lambda command, payload_env, timeout = 60: command,
+    )
+    install_dir = tmp_path / "install"
+    binary_dir = tmp_path / "bin"
+    model_dir = tmp_path / "models"
+    for directory in (install_dir, binary_dir, model_dir):
+        directory.mkdir(parents = True, exist_ok = True)
+    binary_path = binary_dir / "llama-server"
+    binary_path.write_text("")
+
+    original_glob = Path.glob
+    original_exists = Path.exists
+
+    def fake_glob(path: Path, pattern: str):
+        normalized = str(path).replace("\\", "/")
+        if normalized == "/dev/dri" and pattern == "card*":
+            return [Path("/dev/dri/card0")]
+        if normalized == "/dev/dri" and pattern == "renderD*":
+            return [Path("/dev/dri/renderD128")]
+        if normalized == "/dev/nvidia-caps" and pattern == "nvidia-cap*":
+            return []
+        return original_glob(path, pattern)
+
+    def fake_exists(path: Path) -> bool:
+        normalized = str(path).replace("\\", "/")
+        if normalized in {
+            "/dev/dri",
+            "/dev/dri/card0",
+            "/dev/dri/renderD128",
+            "/etc/vulkan",
+            "/usr/share/vulkan",
+        }:
+            return True
+        return original_exists(path)
+
+    monkeypatch.setattr(Path, "glob", fake_glob)
+    monkeypatch.setattr(Path, "exists", fake_exists)
+
+    plan = build_validation_sandbox_plan(
+        ["llama-server", "-m", str(model_dir / "stories260K.gguf"), "--port", "7777"],
+        binary_path = binary_path,
+        install_dir = install_dir,
+        host = linux_host(),
+        purpose = INSTALL_LLAMA_PREBUILT._VALIDATION_PURPOSE_SERVER,
+        runtime_line = None,
+        env = {"LD_LIBRARY_PATH": str(binary_dir)},
+        enable_gpu_layers = True,
+        gpu_backend = "cuda",
+    )
+
+    assert plan.is_runnable
+    assert _command_has_bind(plan, "--dev-bind-try", Path("/dev/dri/card0"))
+    assert _command_has_bind(plan, "--dev-bind-try", Path("/dev/dri/renderD128"))
+    assert _command_has_bind(plan, "--ro-bind", Path("/etc/vulkan"))
+    assert _command_has_bind(plan, "--ro-bind", Path("/usr/share/vulkan"))
 
 
 def test_build_validation_sandbox_plan_linux_server_probe_uses_resolved_helper_path(


### PR DESCRIPTION
## Problem

Install-time validation for downloaded llama.cpp prebuilts still executed native binaries directly in three places: the Linux `ldd` probe, `validate_quantize`, and `validate_server`. `#6696` already strips secret-bearing env vars and redirects credential paths before those launches, but native code could still bypass env-only hardening by resolving the real home, reading absolute paths, scanning same-UID process state, or reaching the network.

The checksum manifest is still useful, but it lives in the same mutable llama.cpp release as the binary. Attestation verification is the longer-term provenance fix tracked in `#6698`, and the current fork releases do not ship the required attestation assets yet.

## Fix

Add an installer-local sandbox authority for downloaded-binary validation and probe launches, then route the three live execution surfaces through it:

- Linux `ldd` probing uses the shared sandbox path, or explicitly skips the probe when a real sandbox is unavailable instead of executing `ldd` unsandboxed.
- Static Linux binaries whose `ldd` output is `not a dynamic executable` are treated as clean ldd probes with no missing shared libraries.
- `validate_quantize` uses the shared sandbox launch path while preserving its command, timeout, output capture, and fallback messaging.
- `validate_server` uses the shared sandbox launch path while preserving port retries, log capture, GPU-layer gating, health checks, and cleanup.
- Linux helper launches now resolve realpaths, and when the resolved helper lives under `/nix/store` the bind plan also exposes `/nix/store` so the helper's runtime closure stays visible inside `bwrap`.
- Inherited Linux `LD_LIBRARY_PATH` and macOS `DYLD_LIBRARY_PATH` entries are filtered before they become bwrap binds or Seatbelt read/map grants, so broad roots and user-home directories do not widen the validation sandbox. macOS inherited `DYLD_LIBRARY_PATH` grants are now limited to concrete `lib` or `lib64` directories.
- Inherited macOS `DYLD_*` loader controls such as `DYLD_INSERT_LIBRARIES`, `DYLD_FRAMEWORK_PATH`, and `DYLD_FALLBACK_LIBRARY_PATH` are stripped before the sandbox wrapper replays the payload env through `/usr/bin/env -i`.
- Linux sandbox launcher probes and validation launches strip dynamic-loader variables from the launcher environment before invoking `bwrap`, so the bwrap capability cache reflects the same clean environment used by validation.
- macOS validation resolves `sandbox-exec` once and launches that absolute adapter path instead of re-resolving a user-controlled wrapper from `PATH`.
- Linux GPU validation keeps the runnable path accurate on real hosts: sandboxed CUDA validation now includes MIG capability nodes and `/proc/driver/nvidia/capabilities`, while non-setuid `bwrap` hosts keep the loopback-only sandbox and drop install-time GPU-layer smoke validation to the CPU path instead of entering a configuration that cannot preserve device-group access.
- macOS sandboxed validation stays narrow, and `macos-arm64` install-time server validation now stays on the CPU path instead of tripping over Metal service lookups before `/completion`.
- Hosts where `bwrap` is absent or installed but cannot create namespaces now skip Linux `ldd` preflight and skip checksum-approved downloaded-binary validation launches instead of executing downloaded binaries outside the sandbox or forcing a source build from sandbox unavailability alone. Hashless Linux upstream bundles still fall back when smoke validation cannot launch, because that smoke test is their integrity gate.
- The validation executors now share subprocess launch error handling, so command-not-found, permission-denied, timeout, nonzero exit, and skipped-launch states are interpreted in one place before each caller checks its own success criteria.
- The existing env-hardening baseline from `#6696` stays in place and composes with the sandbox rather than being replaced by it.

Builds on the env-hardening baseline from `#6696`.

## Scope

This PR hardens install-time validation launches for downloaded llama.cpp prebuilts. It does not implement attestation verification, because the fork release assets do not exist yet. It also leaves normal Studio runtime inference unchanged; runtime `llama-server` startup remains on the backend inference path with its existing environment and cache behavior.

Windows hashless validation remains direct under the scrubbed env and hidden subprocess handling that already existed. This PR does not claim Windows OS sandboxing.

References #6698

## Testing

- Focused installer logic: 231 passed, 13 skipped, 1 deselected; the existing `test_setup_sh_cleanup_unlinks_instruction_symlink_only` baseline failure was excluded.
- `ruff check studio/install_llama_prebuilt.py tests/studio/install/test_install_llama_prebuilt_logic.py` passed.
- `python -m compileall -q studio/install_llama_prebuilt.py tests/studio/install/test_install_llama_prebuilt_logic.py` passed.
- The excluded setup-shell symlink test also fails on the current main worktree on Windows, outside this PR's two-file scope.
