### PR TITLE
Studio: stop the llama.cpp graph-scheduler abort reload loop and harden CPU-only / multi-NUMA GGUF inference

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -5765,7 +5765,9 @@ class LlamaCppBackend:
                                         # mtp_engaged alone is a no-op once budget_frac is set;
                                         # pass the byte-accurate overhead so MTP KV is reserved.
                                         mtp_engaged = _mtp_will_engage_cpu,
-                                        mtp_overhead_fn = (_mtp_bytes if _mtp_will_engage_cpu else None),
+                                        mtp_overhead_fn = (
+                                            _mtp_bytes if _mtp_will_engage_cpu else None
+                                        ),
                                         budget_frac = _CPU_RAM_BUDGET_FRAC,
                                     )
                                     _cpu_cap = max(4096, min(_ctx_ceiling, _fit))

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -811,6 +811,11 @@ _APPLE_UNIFIED_MEMORY_FRACTION = 0.85
 # reserve (_estimate_mtp_overhead_bytes). Applied to both the fit budget and pin.
 _MTP_VRAM_RESERVE_FRAC = 0.05
 
+# CPU-only: cap an auto context to this ceiling (a full native context puts tens to
+# hundreds of GB of KV + MTP reserve in RAM), then fit it to RAM. Explicit -c wins.
+_CPU_CTX_AUTO_CEILING = 32768
+_CPU_RAM_BUDGET_FRAC = 0.9  # RAM headroom for compute buffers + OS
+
 
 def _kv_bytes_per_elem(cache_type: Optional[str]) -> float:
     """Bytes per KV-cache element for a llama.cpp cache type (f16 default)."""
@@ -1234,6 +1239,8 @@ class LlamaCppBackend:
 
     def __init__(self):
         self._process: Optional[subprocess.Popen] = None
+        # Spawn-time argv prefix (e.g. numactl --interleave=all); recomputed per load.
+        self._numa_prefix: list[str] = []
         self._port: Optional[int] = None
         self._model_identifier: Optional[str] = None
         self._gguf_path: Optional[str] = None
@@ -2468,6 +2475,24 @@ class LlamaCppBackend:
         key = cls._tensor_split_cache_key(binary, model)
         if key is not None:
             cls._tensor_split_abort_keys.add(key)
+
+    # (binary, mtime, model) that aborted in the ggml graph scheduler this process
+    # (GGML_ASSERT(*cur_backend_id != -1)): an unsupported op, so reloading just
+    # repeats the crash. Keyed like the tensor-split memo; mtime drops it on update.
+    _sched_reserve_abort_keys: set[tuple[str, int, str]] = set()
+
+    @classmethod
+    def _sched_reserve_aborts(cls, binary: Optional[str], model: Optional[str]) -> bool:
+        """True if (binary, model) aborted in graph-scheduler reserve this session."""
+        key = cls._tensor_split_cache_key(binary, model)
+        return key is not None and key in cls._sched_reserve_abort_keys
+
+    @classmethod
+    def _record_sched_reserve_abort(cls, binary: Optional[str], model: Optional[str]) -> None:
+        """Remember a (binary, model) that aborts in graph-scheduler reserve."""
+        key = cls._tensor_split_cache_key(binary, model)
+        if key is not None:
+            cls._sched_reserve_abort_keys.add(key)
 
     @staticmethod
     def _windows_pip_nvidia_dll_dirs(prefix: str) -> list[str]:
@@ -4119,6 +4144,10 @@ class LlamaCppBackend:
                 "settings and reload."
             )
 
+        # ggml graph-scheduler abort: surface the real cause, not the generic fallback.
+        if LlamaCppBackend._is_sched_reserve_abort(output or ""):
+            return LlamaCppBackend._sched_reserve_abort_message()
+
         # Detect Ollama source up front so the arch branch can keep the
         # Ollama hint instead of the generic "unsupported arch" message.
         gguf = gguf_path or ""
@@ -4396,6 +4425,41 @@ class LlamaCppBackend:
         return "split_axis" in text
 
     @staticmethod
+    def _is_sched_reserve_abort(output: str) -> bool:
+        """True for the ggml graph-scheduler abort GGML_ASSERT(*cur_backend_id != -1):
+        no backend can run an op in the graph (e.g. an MLA/sparse-attention/MTP op
+        unimplemented on this build). Needs a ggml-abort marker plus a scheduler marker
+        (matched on the backtrace frames, which outlive the [New LWP] dump in a short
+        tail). Excludes the #6415 split-axis abort. stderr is merged into output."""
+        text = (output or "").lower()
+        if "ggml_assert" not in text and "ggml_abort" not in text:
+            return False
+        # #6415 split-axis abort shares the frame but is handled by the tensor latch.
+        if "split_axis" in text:
+            return False
+        return (
+            "cur_backend_id" in text
+            or "ggml_backend_sched_split_graph" in text
+            or "sched_reserve" in text
+            or "graph_reserve" in text
+        )
+
+    @staticmethod
+    def _sched_reserve_abort_message() -> str:
+        """Actionable message for the graph-scheduler abort (classifier + fail-fast guard)."""
+        return (
+            "llama.cpp aborted while reserving the compute graph "
+            "(GGML_ASSERT(*cur_backend_id != -1) in ggml_backend_sched_split_graph): "
+            "the active backend cannot run an operation in this model's graph. This "
+            "usually means a newer attention variant (MLA / sparse-attention / MTP) "
+            "is not implemented in this llama.cpp build for the backend you're using "
+            "(commonly CPU-only). Disabling flash attention did not help. Try: run "
+            "`unsloth studio update` for a newer llama.cpp, use a different "
+            "quantization, run on a supported GPU/backend, or disable speculative "
+            "decoding / MTP and lower the context length."
+        )
+
+    @staticmethod
     def _is_signal_crash(returncode: Optional[int]) -> bool:
         """True only on a hard fault (SIGSEGV/SIGABRT/SIGILL/SIGFPE/SIGBUS or a
         Windows 0xC0000000+ status), not SIGKILL/SIGTERM/SIGINT (OOM killer /
@@ -4516,12 +4580,13 @@ class LlamaCppBackend:
             logger.debug(f"Could not open llama-server log file: {e}")
             self._llama_log_path = None
 
-        # Log the argv per attempt (the text-only mmproj retry re-enters here
-        # with --mmproj stripped), redacting the API key.
-        logger.info(f"Starting llama-server: {' '.join(self._redacted_cmd_for_log(cmd))}")
+        # Log the argv per attempt (mmproj retry re-enters with --mmproj stripped),
+        # redacting the API key. Prepend _numa_prefix so the log matches what runs.
+        _run_cmd = [*self._numa_prefix, *cmd]
+        logger.info(f"Starting llama-server: {' '.join(self._redacted_cmd_for_log(_run_cmd))}")
 
         self._process = subprocess.Popen(
-            cmd,
+            _run_cmd,
             stdout = subprocess.PIPE,
             stderr = subprocess.STDOUT,
             text = True,
@@ -4651,6 +4716,17 @@ class LlamaCppBackend:
             # Resolve llama-server now but defer a not-found error: a block-diffusion
             # GGUF uses the diffusion runner, and its arch is only known after the header.
             binary = self._find_llama_server_binary()
+
+            # Fail fast if this (binary, model) already aborted in the graph scheduler
+            # this session: reloading just re-reads the weights into the same crash
+            # (a startup crash 500s and the UI replays /load).
+            if LlamaCppBackend._sched_reserve_aborts(binary, model_identifier):
+                logger.warning(
+                    "Skipping reload of '%s': it already aborted in the llama.cpp "
+                    "graph scheduler this session (unsupported op on this backend).",
+                    model_identifier,
+                )
+                raise RuntimeError(self._sched_reserve_abort_message())
 
             # ── Phase 2: download (NO lock held, so cancel can proceed) ──
             # mtp_draft_path arrives set for local Gemma loads (detected
@@ -4868,6 +4944,11 @@ class LlamaCppBackend:
                 # Layer-fallback min GPUs; raised below on a tensor downgrade. Bound
                 # before the try so the --fit-on except path still has it (no UnboundLocal).
                 _layer_min_gpus = 1
+                # CPU-only (no discrete GPU, not Apple Metal): drives safe defaults
+                # below since no GPU/Apple fit branch runs. Bound before the try (the
+                # --fit except path needs it); refined once gpus is known.
+                from utils.hardware import is_apple_silicon as _is_apple_silicon
+                _cpu_only = False
                 try:
                     gguf_size = self._get_gguf_size_bytes(model_path)
                     # Include GPU-loaded mmproj in the fit budget (#5825).
@@ -4880,6 +4961,7 @@ class LlamaCppBackend:
                     _gpu_mem = self._get_gpu_memory()
                     gpus = [(idx, free) for idx, free, _t in _gpu_mem]
                     total_by_idx = {idx: total for idx, _f, total in _gpu_mem}
+                    _cpu_only = (not gpus) and not _is_apple_silicon()
 
                     def _gpu_usable(g, frac = _CTX_FIT_VRAM_FRACTION):
                         # Per-GPU usable budget for ranking: free - (1-frac)*total.
@@ -5581,6 +5663,53 @@ class LlamaCppBackend:
                     except Exception as e:
                         logger.debug(f"mmproj audio-capability read failed: {e}")
 
+                # CPU-only safe defaults (user extra_args win, appended last): no --fit
+                # (its graph-reserve estimator hits the same abort, llama.cpp #21932, and
+                # mis-counts MTP KV #23472/#24117; offloads nothing on CPU) and flash-attn
+                # off (CPU FA is unsafe for large MLA/sparse/MTP graphs).
+                _flash_default = "off" if _cpu_only else "on"
+                if _cpu_only and use_fit:
+                    use_fit = False
+                    logger.info("CPU-only host: launching with --fit off and --flash-attn off.")
+
+                if _cpu_only:
+                    _avail_mib = self._available_system_memory_mib()
+                    # Preflight: weights over total RAM get OS-killed mid-load (interleave
+                    # spreads across nodes but can't beat the total).
+                    if _avail_mib and model_size and model_size > _avail_mib * 1024 * 1024:
+                        logger.warning(
+                            "CPU-only memory preflight: model weights ~%.0f GB exceed "
+                            "available RAM ~%.0f GB; loading may be OS-killed.",
+                            model_size / (1024**3),
+                            _avail_mib / 1024,
+                        )
+                    # Cap an auto context to a RAM-aware ceiling (explicit -c is honored).
+                    if requested_ctx <= 0 and effective_ctx > _CPU_CTX_AUTO_CEILING:
+                        _cpu_cap = _CPU_CTX_AUTO_CEILING
+                        try:
+                            if _avail_mib and model_size and self._can_estimate_kv():
+                                _fit = self._fit_context_to_vram(
+                                    requested_ctx = _CPU_CTX_AUTO_CEILING,
+                                    available_mib = _avail_mib,
+                                    model_size_bytes = model_size,
+                                    cache_type_kv = cache_type_kv,
+                                    min_ctx = 4096,
+                                    n_parallel = n_parallel,
+                                    kv_on_gpu = True,  # KV lives in the RAM budget we fit
+                                    mtp_engaged = True,  # flat reserve; no GPU draft here
+                                    budget_frac = _CPU_RAM_BUDGET_FRAC,
+                                )
+                                _cpu_cap = max(4096, min(_CPU_CTX_AUTO_CEILING, _fit))
+                        except Exception as _cap_exc:  # best-effort; fall back to ceiling
+                            logger.debug("CPU context-fit failed; using ceiling: %s", _cap_exc)
+                        if _cpu_cap < effective_ctx:
+                            logger.info(
+                                "CPU-only: capping context %d -> %d (set -c to override).",
+                                effective_ctx,
+                                _cpu_cap,
+                            )
+                            effective_ctx = _cpu_cap
+
                 cmd = [
                     binary,
                     "-m",
@@ -5592,7 +5721,7 @@ class LlamaCppBackend:
                     "--parallel",
                     str(n_parallel),
                     "--flash-attn",
-                    "on",  # Force flash attention for speed
+                    _flash_default,  # CPU-only: off; GPU: on for speed
                     # Error out at n_ctx instead of silently rotating the KV cache; frontend catches it and points the user at "Context Length".
                     "--no-context-shift",
                 ]
@@ -5828,7 +5957,26 @@ class LlamaCppBackend:
                     cmd.extend(str(a) for a in extra_args)
                     logger.info(f"Appending user extra args to llama-server: {list(extra_args)}")
 
-                logger.info(f"Starting llama-server: {' '.join(self._redacted_cmd_for_log(cmd))}")
+                # NUMA auto-interleave: wrap with `numactl --interleave=all` when the
+                # model overflows one node but fits across all (else first-touch
+                # thrashes/OOMs). Applied at the Popen sites; decided before any spawn.
+                self._numa_prefix = []
+                try:
+                    from core.inference.numa import decide_interleave
+
+                    _numa = decide_interleave(model_size, cpu_only=_cpu_only)
+                    if _numa.interleave:
+                        self._numa_prefix = list(_numa.prefix)
+                        logger.info("NUMA: %s", _numa.reason)
+                    elif _cpu_only and "numactl` is not installed" in _numa.reason:
+                        logger.warning("NUMA: %s", _numa.reason)
+                except Exception as _numa_exc:  # never block a load on the NUMA probe
+                    logger.debug("NUMA interleave probe failed: %s", _numa_exc)
+
+                logger.info(
+                    "Starting llama-server: "
+                    f"{' '.join(self._redacted_cmd_for_log([*self._numa_prefix, *cmd]))}"
+                )
 
                 # Library paths so llama-server finds its shared libs and CUDA DLLs.
                 env = self._llama_server_env_for_binary(binary)
@@ -5969,9 +6117,11 @@ class LlamaCppBackend:
                             # Best-effort; never block the load on logging.
                             logger.debug(f"Could not open llama-server log file: {e}")
                             self._llama_log_path = None
+                        # _last_spawn_cmd stays un-prefixed (retry helpers slice it);
+                        # the NUMA prefix goes on the actual argv only, so retries don't double it.
                         _last_spawn_cmd = list(run_cmd)
                         self._process = subprocess.Popen(
-                            run_cmd,
+                            [*self._numa_prefix, *run_cmd],
                             stdout = subprocess.PIPE,
                             stderr = subprocess.STDOUT,
                             text = True,
@@ -6205,6 +6355,15 @@ class LlamaCppBackend:
                     out = "\n".join(self._stdout_lines[-50:])
                     # Read the crash code before _kill_process() clears _process.
                     _crash_rc = self._process.poll() if self._process is not None else None
+                    # Graph-scheduler abort (flash-off retry already failed): memo it so
+                    # the next /load fails fast. Wider slice as the GGML_ASSERT line can
+                    # scroll past the [New LWP] dump (backtrace markers stay in the tail).
+                    if (
+                        not self._cancel_event.is_set()
+                        and (self._is_signal_crash(_crash_rc) or self._is_abort_exit(_crash_rc))
+                        and self._is_sched_reserve_abort("\n".join(self._stdout_lines[-200:]))
+                    ):
+                        LlamaCppBackend._record_sched_reserve_abort(binary, model_identifier)
                     self._kill_process()
                     # The #6415 split-axis abort is latched earlier (first spawn).
                     # Skip if a cancel/unload is pending (mirrors the MTP guard).

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1115,21 +1115,23 @@ def _extra_args_n_ubatch(
 
 
 def _extra_args_forces_cpu_offload(extra_args: Optional[Iterable[str]]) -> bool:
-    """True when extras pin GPU offload to zero (-ngl 0 / --n-gpu-layers 0 /
-    --gpu-layers 0): the launch runs fully on CPU despite a visible GPU, so the
-    CPU-only safe defaults apply. Last occurrence wins, as llama-server parses it."""
+    """True when extras run the launch fully on CPU despite a visible GPU, so the
+    CPU-only safe defaults apply: zero GPU layers (-ngl 0 / --n-gpu-layers 0 /
+    --gpu-layers 0) or no device (--device/-dev none). Each flag's last occurrence
+    wins (as llama-server parses it); the two controls are independent."""
     args = [str(a) for a in extra_args] if extra_args else []
-    forced = False
+    ngl_zero = device_none = False
     for i, raw in enumerate(args):
         flag, eq, inline = raw.partition("=")
-        if flag not in ("-ngl", "--n-gpu-layers", "--gpu-layers"):
-            continue
         value = inline if eq else (args[i + 1] if i + 1 < len(args) else "")
-        try:
-            forced = int(value) == 0
-        except (TypeError, ValueError):
-            continue
-    return forced
+        if flag in ("-ngl", "--n-gpu-layers", "--gpu-layers"):
+            try:
+                ngl_zero = int(value) == 0
+            except (TypeError, ValueError):
+                continue
+        elif flag in ("--device", "-dev"):
+            device_none = value.strip().lower() == "none"
+    return ngl_zero or device_none
 
 
 def _build_ngram_mod_flags(
@@ -5107,6 +5109,16 @@ class LlamaCppBackend:
                     _mtp_will_engage = bool(
                         _user_mtp_via_extras or _user_draft_via_extras or _auto_studio_mtp
                     )
+                    # Auto drops embedded MTP for MLA models (GLM-5.2/DeepSeek/Kimi) unless
+                    # forced; mirror that gate so the CPU cap / NUMA footprint don't reserve
+                    # a target-KV copy for a drafter the launch will not start.
+                    _mtp_will_engage_cpu = _mtp_will_engage and not (
+                        _auto_studio_mtp
+                        and bool(self._nextn_predict_layers)
+                        and self._kv_lora_rank is not None
+                        and not bool(mtp_draft_path)
+                        and not _mla_mtp_auto_enabled()
+                    )
                     # The duplicated full target-KV copy (ctx_tgt) is an MTP-only
                     # cost: the MTP head runs a second context over the target
                     # model's own KV geometry. The separate-drafter spec modes
@@ -5752,8 +5764,8 @@ class LlamaCppBackend:
                                         kv_on_gpu = True,  # KV lives in the RAM budget we fit
                                         # mtp_engaged alone is a no-op once budget_frac is set;
                                         # pass the byte-accurate overhead so MTP KV is reserved.
-                                        mtp_engaged = _mtp_will_engage,
-                                        mtp_overhead_fn = (_mtp_bytes if _mtp_will_engage else None),
+                                        mtp_engaged = _mtp_will_engage_cpu,
+                                        mtp_overhead_fn = (_mtp_bytes if _mtp_will_engage_cpu else None),
                                         budget_frac = _CPU_RAM_BUDGET_FRAC,
                                     )
                                     _cpu_cap = max(4096, min(_ctx_ceiling, _fit))
@@ -5766,6 +5778,9 @@ class LlamaCppBackend:
                                 _cpu_cap,
                             )
                             effective_ctx = _cpu_cap
+                            # Advertise the capped window as the ceiling too, so /status and
+                            # the UI safe-zone don't steer back to the unlaunched native size.
+                            max_available_ctx = min(max_available_ctx, _cpu_cap)
 
                 cmd = [
                     binary,
@@ -6037,7 +6052,7 @@ class LlamaCppBackend:
                         try:
                             # Recompute MTP at the post-cap context; the pre-cap
                             # _mtp_reserve_bytes would overstate a capped million-token load.
-                            _numa_mtp = _mtp_bytes(effective_ctx) if _mtp_will_engage else 0
+                            _numa_mtp = _mtp_bytes(effective_ctx) if _mtp_will_engage_cpu else 0
                             _numa_footprint = (
                                 _resident
                                 + self._estimate_kv_cache_bytes(

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -4709,24 +4709,29 @@ class LlamaCppBackend:
 
             self._cancel_event.clear()
 
-            # ── Phase 1: kill old process (under lock, fast) ──────────
-            with self._lock:
-                self._kill_process()
-
             # Resolve llama-server now but defer a not-found error: a block-diffusion
             # GGUF uses the diffusion runner, and its arch is only known after the header.
             binary = self._find_llama_server_binary()
 
-            # Fail fast if this (binary, model) already aborted in the graph scheduler
-            # this session: reloading just re-reads the weights into the same crash
-            # (a startup crash 500s and the UI replays /load).
-            if LlamaCppBackend._sched_reserve_aborts(binary, model_identifier):
+            # Fail fast BEFORE killing the live server (so a known-bad reload is
+            # non-destructive) if this (binary, model, variant) already aborted in the
+            # graph scheduler this session: reloading re-reads the weights into the same
+            # crash (a startup crash 500s and the UI replays /load). Keyed per variant so
+            # a failed quant does not block trying a different quant in the same repo.
+            _abort_memo_model = "\x00".join(
+                [model_identifier or "", hf_variant or "", gguf_path or ""]
+            )
+            if LlamaCppBackend._sched_reserve_aborts(binary, _abort_memo_model):
                 logger.warning(
                     "Skipping reload of '%s': it already aborted in the llama.cpp "
                     "graph scheduler this session (unsupported op on this backend).",
                     model_identifier,
                 )
                 raise RuntimeError(self._sched_reserve_abort_message())
+
+            # ── Phase 1: kill old process (under lock, fast) ──────────
+            with self._lock:
+                self._kill_process()
 
             # ── Phase 2: download (NO lock held, so cancel can proceed) ──
             # mtp_draft_path arrives set for local Gemma loads (detected
@@ -5689,18 +5694,25 @@ class LlamaCppBackend:
                         _cpu_cap = _CPU_CTX_AUTO_CEILING
                         try:
                             if _avail_mib and model_size and self._can_estimate_kv():
-                                _fit = self._fit_context_to_vram(
-                                    requested_ctx = _CPU_CTX_AUTO_CEILING,
-                                    available_mib = _avail_mib,
-                                    model_size_bytes = model_size,
-                                    cache_type_kv = cache_type_kv,
-                                    min_ctx = 4096,
-                                    n_parallel = n_parallel,
-                                    kv_on_gpu = True,  # KV lives in the RAM budget we fit
-                                    mtp_engaged = True,  # flat reserve; no GPU draft here
-                                    budget_frac = _CPU_RAM_BUDGET_FRAC,
-                                )
-                                _cpu_cap = max(4096, min(_CPU_CTX_AUTO_CEILING, _fit))
+                                _budget_b = _avail_mib * _CPU_RAM_BUDGET_FRAC * 1024 * 1024
+                                if model_size >= _budget_b:
+                                    # Weights alone over budget: _fit_context_to_vram returns
+                                    # the ceiling unchanged, but KV at 32k could OOM. Floor to
+                                    # the minimum so the tightest fit gets the smallest context.
+                                    _cpu_cap = 4096
+                                else:
+                                    _fit = self._fit_context_to_vram(
+                                        requested_ctx = _CPU_CTX_AUTO_CEILING,
+                                        available_mib = _avail_mib,
+                                        model_size_bytes = model_size,
+                                        cache_type_kv = cache_type_kv,
+                                        min_ctx = 4096,
+                                        n_parallel = n_parallel,
+                                        kv_on_gpu = True,  # KV lives in the RAM budget we fit
+                                        mtp_engaged = True,  # flat reserve; no GPU draft here
+                                        budget_frac = _CPU_RAM_BUDGET_FRAC,
+                                    )
+                                    _cpu_cap = max(4096, min(_CPU_CTX_AUTO_CEILING, _fit))
                         except Exception as _cap_exc:  # best-effort; fall back to ceiling
                             logger.debug("CPU context-fit failed; using ceiling: %s", _cap_exc)
                         if _cpu_cap < effective_ctx:
@@ -5743,6 +5755,10 @@ class LlamaCppBackend:
                     # Fits on selected GPU(s) -- offload all layers
                     cmd.extend(["-ngl", "-1"])
                     fully_gpu_offloaded = True
+                elif _cpu_only:
+                    # --fit defaults to on in recent llama.cpp, so omitting it still runs
+                    # the graph-reserve fitting step (same abort path); disable explicitly.
+                    cmd.extend(["--fit", "off"])
 
                 server_caps = self.probe_server_capabilities(binary)
                 # Expose Prometheus /metrics for the engine-stats logger, only
@@ -5966,7 +5982,19 @@ class LlamaCppBackend:
                 self._numa_prefix = []
                 try:
                     from core.inference.numa import decide_interleave
-                    _numa = decide_interleave(model_size, cpu_only = _cpu_only)
+
+                    # Decide on the resident footprint (weights + KV at the capped
+                    # context), not weights alone, so a model whose weights fit one node
+                    # but whose footprint does not still interleaves.
+                    _numa_footprint = model_size
+                    if model_size and effective_ctx > 0 and self._can_estimate_kv():
+                        try:
+                            _numa_footprint = model_size + self._estimate_kv_cache_bytes(
+                                effective_ctx, cache_type_kv
+                            )
+                        except Exception:
+                            _numa_footprint = model_size
+                    _numa = decide_interleave(_numa_footprint, cpu_only = _cpu_only)
                     if _numa.interleave:
                         self._numa_prefix = list(_numa.prefix)
                         if not _extra_args_set_any_flag(extra_args, {"--numa"}):
@@ -6367,7 +6395,7 @@ class LlamaCppBackend:
                         and (self._is_signal_crash(_crash_rc) or self._is_abort_exit(_crash_rc))
                         and self._is_sched_reserve_abort("\n".join(self._stdout_lines[-200:]))
                     ):
-                        LlamaCppBackend._record_sched_reserve_abort(binary, model_identifier)
+                        LlamaCppBackend._record_sched_reserve_abort(binary, _abort_memo_model)
                     self._kill_process()
                     # The #6415 split-axis abort is latched earlier (first spawn).
                     # Skip if a cancel/unload is pending (mirrors the MTP guard).

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -6486,13 +6486,18 @@ class LlamaCppBackend:
                     # mmproj fallback is ruled out, so a VLM that recovers text-only is not
                     # blocked by the fail-fast guard on its next load. Wider slice as the
                     # GGML_ASSERT line can scroll past the [New LWP] dump.
-                    _was_sched_abort = not self._cancel_event.is_set() and (
-                        # A scheduler abort captured before the no-spec fallback reset stdout,
-                        _pre_fallback_sched_abort
-                        # or one still visible in the current tail.
-                        or (
-                            (self._is_signal_crash(_crash_rc) or self._is_abort_exit(_crash_rc))
-                            and self._is_sched_reserve_abort("\n".join(self._stdout_lines[-200:]))
+                    _was_sched_abort = (
+                        not self._cancel_event.is_set()
+                        and (
+                            # A scheduler abort captured before the no-spec fallback reset stdout,
+                            _pre_fallback_sched_abort
+                            # or one still visible in the current tail.
+                            or (
+                                (self._is_signal_crash(_crash_rc) or self._is_abort_exit(_crash_rc))
+                                and self._is_sched_reserve_abort(
+                                    "\n".join(self._stdout_lines[-200:])
+                                )
+                            )
                         )
                     )
                     self._kill_process()

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -6048,10 +6048,14 @@ class LlamaCppBackend:
                         except Exception:
                             _numa_footprint = _resident
                     _numa = decide_interleave(_numa_footprint, cpu_only = _cpu_only)
-                    if _numa.interleave:
+                    if _numa.interleave and _extra_args_set_any_flag(extra_args, {"--numa"}):
+                        # User set an explicit --numa policy: respect it. The numactl wrap
+                        # is an argv prefix they can't override, so skip it (and --numa
+                        # distribute) rather than force interleaving over their choice.
+                        logger.info("NUMA: user --numa set; leaving auto-interleave off")
+                    elif _numa.interleave:
                         self._numa_prefix = list(_numa.prefix)
-                        if not _extra_args_set_any_flag(extra_args, {"--numa"}):
-                            cmd.extend(["--numa", "distribute"])
+                        cmd.extend(["--numa", "distribute"])
                         logger.info("NUMA: %s", _numa.reason)
                     elif _cpu_only and (
                         "numactl` is not installed" in _numa.reason

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -4948,6 +4948,7 @@ class LlamaCppBackend:
                 # below since no GPU/Apple fit branch runs. Bound before the try (the
                 # --fit except path needs it); refined once gpus is known.
                 from utils.hardware import is_apple_silicon as _is_apple_silicon
+
                 _cpu_only = False
                 try:
                     gguf_size = self._get_gguf_size_bytes(model_path)
@@ -5963,8 +5964,7 @@ class LlamaCppBackend:
                 self._numa_prefix = []
                 try:
                     from core.inference.numa import decide_interleave
-
-                    _numa = decide_interleave(model_size, cpu_only=_cpu_only)
+                    _numa = decide_interleave(model_size, cpu_only = _cpu_only)
                     if _numa.interleave:
                         self._numa_prefix = list(_numa.prefix)
                         logger.info("NUMA: %s", _numa.reason)

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -5958,15 +5958,19 @@ class LlamaCppBackend:
                     cmd.extend(str(a) for a in extra_args)
                     logger.info(f"Appending user extra args to llama-server: {list(extra_args)}")
 
-                # NUMA auto-interleave: wrap with `numactl --interleave=all` when the
-                # model overflows one node but fits across all (else first-touch
-                # thrashes/OOMs). Applied at the Popen sites; decided before any spawn.
+                # NUMA auto-interleave: when the model overflows one node but fits
+                # across all (else first-touch thrashes/OOMs), wrap with
+                # `numactl --interleave=all` (applied at the Popen sites) AND pass
+                # `--numa distribute` -- both are needed, numactl alone doesn't spread
+                # pages evenly (llama.cpp #19102). User --numa wins.
                 self._numa_prefix = []
                 try:
                     from core.inference.numa import decide_interleave
                     _numa = decide_interleave(model_size, cpu_only = _cpu_only)
                     if _numa.interleave:
                         self._numa_prefix = list(_numa.prefix)
+                        if not _extra_args_set_any_flag(extra_args, {"--numa"}):
+                            cmd.extend(["--numa", "distribute"])
                         logger.info("NUMA: %s", _numa.reason)
                     elif _cpu_only and "numactl` is not installed" in _numa.reason:
                         logger.warning("NUMA: %s", _numa.reason)

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -4714,12 +4714,21 @@ class LlamaCppBackend:
             binary = self._find_llama_server_binary()
 
             # Fail fast BEFORE killing the live server (so a known-bad reload is
-            # non-destructive) if this (binary, model, variant) already aborted in the
-            # graph scheduler this session: reloading re-reads the weights into the same
-            # crash (a startup crash 500s and the UI replays /load). Keyed per variant so
-            # a failed quant does not block trying a different quant in the same repo.
+            # non-destructive) if this exact launch already aborted in the graph
+            # scheduler this session: reloading re-reads the weights into the same crash
+            # (a startup crash 500s and the UI replays /load). The key includes the
+            # variant AND the launch settings (context, spec) so an identical replay is
+            # blocked but a user changing quant / lowering -c / disabling spec -- the
+            # exact recovery the error message recommends -- is allowed to retry.
             _abort_memo_model = "\x00".join(
-                [model_identifier or "", hf_variant or "", gguf_path or ""]
+                [
+                    model_identifier or "",
+                    hf_variant or "",
+                    gguf_path or "",
+                    str(n_ctx),
+                    str(speculative_type or ""),
+                    " ".join(str(a) for a in (extra_args or [])),
+                ]
             )
             if LlamaCppBackend._sched_reserve_aborts(binary, _abort_memo_model):
                 logger.warning(
@@ -5990,7 +5999,7 @@ class LlamaCppBackend:
                     if model_size and effective_ctx > 0 and self._can_estimate_kv():
                         try:
                             _numa_footprint = model_size + self._estimate_kv_cache_bytes(
-                                effective_ctx, cache_type_kv
+                                effective_ctx, cache_type_kv, n_parallel = n_parallel
                             )
                         except Exception:
                             _numa_footprint = model_size

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -6486,7 +6486,9 @@ class LlamaCppBackend:
                             self._kill_process()
                             # Fallback exhausted: now memo the original scheduler abort.
                             if _was_sched_abort:
-                                LlamaCppBackend._record_sched_reserve_abort(binary, _abort_memo_model)
+                                LlamaCppBackend._record_sched_reserve_abort(
+                                    binary, _abort_memo_model
+                                )
                             raise RuntimeError(
                                 "Vision projector incompatible with this llama.cpp "
                                 "build, and the text-only retry also failed: "

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1114,6 +1114,24 @@ def _extra_args_n_ubatch(
     return None
 
 
+def _extra_args_forces_cpu_offload(extra_args: Optional[Iterable[str]]) -> bool:
+    """True when extras pin GPU offload to zero (-ngl 0 / --n-gpu-layers 0 /
+    --gpu-layers 0): the launch runs fully on CPU despite a visible GPU, so the
+    CPU-only safe defaults apply. Last occurrence wins, as llama-server parses it."""
+    args = [str(a) for a in extra_args] if extra_args else []
+    forced = False
+    for i, raw in enumerate(args):
+        flag, eq, inline = raw.partition("=")
+        if flag not in ("-ngl", "--n-gpu-layers", "--gpu-layers"):
+            continue
+        value = inline if eq else (args[i + 1] if i + 1 < len(args) else "")
+        try:
+            forced = int(value) == 0
+        except (TypeError, ValueError):
+            continue
+    return forced
+
+
 def _build_ngram_mod_flags(
     caps: Optional[dict],
     n_match: int = 24,
@@ -4955,6 +4973,8 @@ class LlamaCppBackend:
                         "image input will be disabled for this session"
                     )
                 model_size = None  # set in the fit try; used by the APU RAM guard
+                model_size_fit = None  # weights + compute buffer; set in the fit try
+                _mtp_reserve_bytes = 0  # MTP draft reserve at effective_ctx; set in the fit try
                 # Layer-fallback min GPUs; raised below on a tensor downgrade. Bound
                 # before the try so the --fit-on except path still has it (no UnboundLocal).
                 _layer_min_gpus = 1
@@ -4976,6 +4996,12 @@ class LlamaCppBackend:
                     _gpu_mem = self._get_gpu_memory()
                     gpus = [(idx, free) for idx, free, _t in _gpu_mem]
                     total_by_idx = {idx: total for idx, _f, total in _gpu_mem}
+                    # A user -ngl 0 / --n-gpu-layers 0 pins every layer on CPU even with a
+                    # visible GPU; drop the GPU list so the CPU-only safe defaults and the
+                    # RAM-aware fit apply, not a GPU launch that then runs on CPU anyway.
+                    if gpus and _extra_args_forces_cpu_offload(extra_args):
+                        logger.info("User set zero GPU offload (-ngl 0): treating as CPU-only.")
+                        gpus, total_by_idx = [], {}
                     _cpu_only = (not gpus) and not _is_apple_silicon()
 
                     def _gpu_usable(g, frac = _CTX_FIT_VRAM_FRACTION):
@@ -5704,8 +5730,12 @@ class LlamaCppBackend:
                         try:
                             if _avail_mib and model_size and self._can_estimate_kv():
                                 _budget_b = _avail_mib * _CPU_RAM_BUDGET_FRAC * 1024 * 1024
-                                if model_size >= _budget_b:
-                                    # Weights alone over budget: _fit_context_to_vram returns
+                                # Fixed footprint = weights + compute buffer (the same lump
+                                # the load allocates), so a context that only fits ignoring
+                                # the buffer can't slip through and get OS-killed at startup.
+                                _fixed = model_size_fit or model_size
+                                if _fixed >= _budget_b:
+                                    # Footprint alone over budget: _fit_context_to_vram returns
                                     # the ceiling unchanged, but KV at 32k could OOM. Floor to
                                     # the minimum so the tightest fit gets the smallest context.
                                     _cpu_cap = 4096
@@ -5713,7 +5743,7 @@ class LlamaCppBackend:
                                     _fit = self._fit_context_to_vram(
                                         requested_ctx = _CPU_CTX_AUTO_CEILING,
                                         available_mib = _avail_mib,
-                                        model_size_bytes = model_size,
+                                        model_size_bytes = _fixed,
                                         cache_type_kv = cache_type_kv,
                                         min_ctx = 4096,
                                         n_parallel = n_parallel,
@@ -5992,17 +6022,23 @@ class LlamaCppBackend:
                 try:
                     from core.inference.numa import decide_interleave
 
-                    # Decide on the resident footprint (weights + KV at the capped
-                    # context), not weights alone, so a model whose weights fit one node
-                    # but whose footprint does not still interleaves.
-                    _numa_footprint = model_size
-                    if model_size and effective_ctx > 0 and self._can_estimate_kv():
+                    # Decide on the full resident footprint (weights + compute buffer + KV
+                    # at the capped context + MTP reserve), not weights alone, so a model
+                    # whose weights fit one node but whose footprint does not still
+                    # interleaves instead of first-touch thrashing on one node.
+                    _resident = model_size_fit or model_size
+                    _numa_footprint = _resident
+                    if _resident and effective_ctx > 0 and self._can_estimate_kv():
                         try:
-                            _numa_footprint = model_size + self._estimate_kv_cache_bytes(
-                                effective_ctx, cache_type_kv, n_parallel = n_parallel
+                            _numa_footprint = (
+                                _resident
+                                + self._estimate_kv_cache_bytes(
+                                    effective_ctx, cache_type_kv, n_parallel = n_parallel
+                                )
+                                + _mtp_reserve_bytes
                             )
                         except Exception:
-                            _numa_footprint = model_size
+                            _numa_footprint = _resident
                     _numa = decide_interleave(_numa_footprint, cpu_only = _cpu_only)
                     if _numa.interleave:
                         self._numa_prefix = list(_numa.prefix)

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -5754,6 +5754,12 @@ class LlamaCppBackend:
                                     # the minimum so the tightest fit gets the smallest context.
                                     _cpu_cap = 4096
                                 else:
+                                    # MTP engages but the draft KV can't be byte-sized:
+                                    # _mtp_bytes returns 0 and budget_frac skips the flat
+                                    # reserve, so trim the budget to still hold back MTP RAM.
+                                    _cpu_budget = _CPU_RAM_BUDGET_FRAC
+                                    if _mtp_will_engage_cpu and mtp_overhead_fn is None:
+                                        _cpu_budget -= _MTP_VRAM_RESERVE_FRAC
                                     _fit = self._fit_context_to_vram(
                                         requested_ctx = _ctx_ceiling,
                                         available_mib = _avail_mib,
@@ -5768,7 +5774,7 @@ class LlamaCppBackend:
                                         mtp_overhead_fn = (
                                             _mtp_bytes if _mtp_will_engage_cpu else None
                                         ),
-                                        budget_frac = _CPU_RAM_BUDGET_FRAC,
+                                        budget_frac = _cpu_budget,
                                     )
                                     _cpu_cap = max(4096, min(_ctx_ceiling, _fit))
                         except Exception as _cap_exc:  # best-effort; fall back to ceiling
@@ -6308,6 +6314,9 @@ class LlamaCppBackend:
                 )
 
                 healthy = _spawn_and_wait(cmd)
+                # A scheduler abort on the first launch must still be memoed even if a later
+                # no-spec/text-only fallback overwrites the stdout tail; track it across them.
+                _pre_fallback_sched_abort = False
                 # #6415 split-mode tensor warmup abort. Latch it on THIS first spawn:
                 # the flash-attn-off retry below can't run tensor (needs flash_attn),
                 # so its output drops the marker and recording later would miss it,
@@ -6407,6 +6416,12 @@ class LlamaCppBackend:
                 # cancel check stops an /unload-killed attempt respawning. A
                 # decode-probe failure above also routes here.
                 if not healthy and _spec_requested_mtp and not self._cancel_event.is_set():
+                    # The no-spec retry below resets the stdout tail; capture a scheduler
+                    # abort from this first launch now so it can still be memoed if the
+                    # retries then fail for another reason (else the UI replays the load).
+                    _pre_fallback_sched_abort = _pre_fallback_sched_abort or (
+                        self._is_sched_reserve_abort("\n".join(self._stdout_lines[-200:]))
+                    )
                     # Blame the binary only when the output shows MTP itself
                     # failing (unknown arch / draft or context build); an
                     # unrelated crash (e.g. OOM) gets a neutral message.
@@ -6471,10 +6486,14 @@ class LlamaCppBackend:
                     # mmproj fallback is ruled out, so a VLM that recovers text-only is not
                     # blocked by the fail-fast guard on its next load. Wider slice as the
                     # GGML_ASSERT line can scroll past the [New LWP] dump.
-                    _was_sched_abort = (
-                        not self._cancel_event.is_set()
-                        and (self._is_signal_crash(_crash_rc) or self._is_abort_exit(_crash_rc))
-                        and self._is_sched_reserve_abort("\n".join(self._stdout_lines[-200:]))
+                    _was_sched_abort = not self._cancel_event.is_set() and (
+                        # A scheduler abort captured before the no-spec fallback reset stdout,
+                        _pre_fallback_sched_abort
+                        # or one still visible in the current tail.
+                        or (
+                            (self._is_signal_crash(_crash_rc) or self._is_abort_exit(_crash_rc))
+                            and self._is_sched_reserve_abort("\n".join(self._stdout_lines[-200:]))
+                        )
                     )
                     self._kill_process()
                     # The #6415 split-axis abort is latched earlier (first spawn).

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1114,13 +1114,16 @@ def _extra_args_n_ubatch(
     return None
 
 
-def _extra_args_forces_cpu_offload(extra_args: Optional[Iterable[str]]) -> bool:
-    """True when extras run the launch fully on CPU despite a visible GPU, so the
-    CPU-only safe defaults apply: zero GPU layers (-ngl 0 / --n-gpu-layers 0 /
-    --gpu-layers 0) or no device (--device/-dev none). Each flag's last occurrence
-    wins (as llama-server parses it); the two controls are independent."""
+def _extra_args_forces_cpu_offload(
+    extra_args: Optional[Iterable[str]], env: Optional[Mapping[str, str]] = None
+) -> bool:
+    """True when the launch runs fully on CPU despite a visible GPU, so the CPU-only
+    safe defaults apply: zero GPU layers (-ngl 0 / --n-gpu-layers 0 / --gpu-layers 0)
+    or no device (--device/-dev none). CLI extras win (each control's last value); else
+    the inherited LLAMA_ARG_N_GPU_LAYERS / LLAMA_ARG_DEVICE env the child would honor."""
     args = [str(a) for a in extra_args] if extra_args else []
-    ngl_zero = device_none = False
+    ngl_zero: Optional[bool] = None
+    device_none: Optional[bool] = None
     for i, raw in enumerate(args):
         flag, eq, inline = raw.partition("=")
         value = inline if eq else (args[i + 1] if i + 1 < len(args) else "")
@@ -1131,7 +1134,15 @@ def _extra_args_forces_cpu_offload(extra_args: Optional[Iterable[str]]) -> bool:
                 continue
         elif flag in ("--device", "-dev"):
             device_none = value.strip().lower() == "none"
-    return ngl_zero or device_none
+    _env = os.environ if env is None else env
+    if ngl_zero is None and _env.get("LLAMA_ARG_N_GPU_LAYERS") is not None:
+        try:
+            ngl_zero = int(_env["LLAMA_ARG_N_GPU_LAYERS"]) == 0
+        except (TypeError, ValueError):
+            pass
+    if device_none is None and _env.get("LLAMA_ARG_DEVICE") is not None:
+        device_none = _env["LLAMA_ARG_DEVICE"].strip().lower() == "none"
+    return bool(ngl_zero) or bool(device_none)
 
 
 def _build_ngram_mod_flags(

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -4974,7 +4974,6 @@ class LlamaCppBackend:
                     )
                 model_size = None  # set in the fit try; used by the APU RAM guard
                 model_size_fit = None  # weights + compute buffer; set in the fit try
-                _mtp_reserve_bytes = 0  # MTP draft reserve at effective_ctx; set in the fit try
                 # Layer-fallback min GPUs; raised below on a tensor downgrade. Bound
                 # before the try so the --fit-on except path still has it (no UnboundLocal).
                 _layer_min_gpus = 1
@@ -5724,9 +5723,12 @@ class LlamaCppBackend:
                             model_size / (1024**3),
                             _avail_mib / 1024,
                         )
-                    # Cap an auto context to a RAM-aware ceiling (explicit -c is honored).
-                    if requested_ctx <= 0 and effective_ctx > _CPU_CTX_AUTO_CEILING:
-                        _cpu_cap = _CPU_CTX_AUTO_CEILING
+                    # Fit an auto context to a RAM-aware ceiling (explicit -c is honored).
+                    # Runs for every auto context, not only above the ceiling: a large
+                    # small-context GGUF can still exceed RAM and must be reduced too.
+                    if requested_ctx <= 0 and effective_ctx > 0:
+                        _ctx_ceiling = min(effective_ctx, _CPU_CTX_AUTO_CEILING)
+                        _cpu_cap = _ctx_ceiling
                         try:
                             if _avail_mib and model_size and self._can_estimate_kv():
                                 _budget_b = _avail_mib * _CPU_RAM_BUDGET_FRAC * 1024 * 1024
@@ -5736,22 +5738,25 @@ class LlamaCppBackend:
                                 _fixed = model_size_fit or model_size
                                 if _fixed >= _budget_b:
                                     # Footprint alone over budget: _fit_context_to_vram returns
-                                    # the ceiling unchanged, but KV at 32k could OOM. Floor to
+                                    # the ceiling unchanged, but KV could still OOM. Floor to
                                     # the minimum so the tightest fit gets the smallest context.
                                     _cpu_cap = 4096
                                 else:
                                     _fit = self._fit_context_to_vram(
-                                        requested_ctx = _CPU_CTX_AUTO_CEILING,
+                                        requested_ctx = _ctx_ceiling,
                                         available_mib = _avail_mib,
                                         model_size_bytes = _fixed,
                                         cache_type_kv = cache_type_kv,
                                         min_ctx = 4096,
                                         n_parallel = n_parallel,
                                         kv_on_gpu = True,  # KV lives in the RAM budget we fit
-                                        mtp_engaged = True,  # flat reserve; no GPU draft here
+                                        # mtp_engaged alone is a no-op once budget_frac is set;
+                                        # pass the byte-accurate overhead so MTP KV is reserved.
+                                        mtp_engaged = _mtp_will_engage,
+                                        mtp_overhead_fn = (_mtp_bytes if _mtp_will_engage else None),
                                         budget_frac = _CPU_RAM_BUDGET_FRAC,
                                     )
-                                    _cpu_cap = max(4096, min(_CPU_CTX_AUTO_CEILING, _fit))
+                                    _cpu_cap = max(4096, min(_ctx_ceiling, _fit))
                         except Exception as _cap_exc:  # best-effort; fall back to ceiling
                             logger.debug("CPU context-fit failed; using ceiling: %s", _cap_exc)
                         if _cpu_cap < effective_ctx:
@@ -6030,12 +6035,15 @@ class LlamaCppBackend:
                     _numa_footprint = _resident
                     if _resident and effective_ctx > 0 and self._can_estimate_kv():
                         try:
+                            # Recompute MTP at the post-cap context; the pre-cap
+                            # _mtp_reserve_bytes would overstate a capped million-token load.
+                            _numa_mtp = _mtp_bytes(effective_ctx) if _mtp_will_engage else 0
                             _numa_footprint = (
                                 _resident
                                 + self._estimate_kv_cache_bytes(
                                     effective_ctx, cache_type_kv, n_parallel = n_parallel
                                 )
-                                + _mtp_reserve_bytes
+                                + _numa_mtp
                             )
                         except Exception:
                             _numa_footprint = _resident
@@ -6045,7 +6053,12 @@ class LlamaCppBackend:
                         if not _extra_args_set_any_flag(extra_args, {"--numa"}):
                             cmd.extend(["--numa", "distribute"])
                         logger.info("NUMA: %s", _numa.reason)
-                    elif _cpu_only and "numactl` is not installed" in _numa.reason:
+                    elif _cpu_only and (
+                        "numactl` is not installed" in _numa.reason
+                        or "interleave cannot help" in _numa.reason
+                    ):
+                        # Actionable: numactl missing, or the footprint exceeds total RAM
+                        # across all nodes (the weights-only preflight can't catch this).
                         logger.warning("NUMA: %s", _numa.reason)
                 except Exception as _numa_exc:  # never block a load on the NUMA probe
                     logger.debug("NUMA interleave probe failed: %s", _numa_exc)
@@ -6432,15 +6445,16 @@ class LlamaCppBackend:
                     out = "\n".join(self._stdout_lines[-50:])
                     # Read the crash code before _kill_process() clears _process.
                     _crash_rc = self._process.poll() if self._process is not None else None
-                    # Graph-scheduler abort (flash-off retry already failed): memo it so
-                    # the next /load fails fast. Wider slice as the GGML_ASSERT line can
-                    # scroll past the [New LWP] dump (backtrace markers stay in the tail).
-                    if (
+                    # Graph-scheduler abort (flash-off retry already failed)? Capture now (a
+                    # text-only retry overwrites the stdout tail) but memo it only once the
+                    # mmproj fallback is ruled out, so a VLM that recovers text-only is not
+                    # blocked by the fail-fast guard on its next load. Wider slice as the
+                    # GGML_ASSERT line can scroll past the [New LWP] dump.
+                    _was_sched_abort = (
                         not self._cancel_event.is_set()
                         and (self._is_signal_crash(_crash_rc) or self._is_abort_exit(_crash_rc))
                         and self._is_sched_reserve_abort("\n".join(self._stdout_lines[-200:]))
-                    ):
-                        LlamaCppBackend._record_sched_reserve_abort(binary, _abort_memo_model)
+                    )
                     self._kill_process()
                     # The #6415 split-axis abort is latched earlier (first spawn).
                     # Skip if a cancel/unload is pending (mirrors the MTP guard).
@@ -6470,6 +6484,9 @@ class LlamaCppBackend:
                             # an OS-killed text-only retry still gets the OOM message.
                             _retry_rc = self._process.poll() if self._process is not None else None
                             self._kill_process()
+                            # Fallback exhausted: now memo the original scheduler abort.
+                            if _was_sched_abort:
+                                LlamaCppBackend._record_sched_reserve_abort(binary, _abort_memo_model)
                             raise RuntimeError(
                                 "Vision projector incompatible with this llama.cpp "
                                 "build, and the text-only retry also failed: "
@@ -6481,6 +6498,10 @@ class LlamaCppBackend:
                                 )
                             )
                     else:
+                        # No mmproj fallback available/eligible: memo the scheduler abort
+                        # (if that is what crashed) so the next /load fails fast, then raise.
+                        if _was_sched_abort:
+                            LlamaCppBackend._record_sched_reserve_abort(binary, _abort_memo_model)
                         raise RuntimeError(
                             self._classify_llama_start_failure(
                                 out,

--- a/studio/backend/core/inference/numa.py
+++ b/studio/backend/core/inference/numa.py
@@ -62,6 +62,21 @@ def _parse_online(spec: str) -> list[int]:
     return out
 
 
+def _mems_allowed() -> set[int] | None:
+    """NUMA nodes the process may allocate on (cpuset), from /proc/self/status
+    Mems_allowed_list. None when unavailable, so callers fall back to the online set.
+    numactl --interleave=all only spans these, so a cpuset-limited container must not
+    count host nodes it cannot use."""
+    try:
+        text = Path("/proc/self/status").read_text()
+    except OSError:
+        return None
+    for line in text.splitlines():
+        if line.startswith("Mems_allowed_list:"):
+            return set(_parse_online(line.split(":", 1)[1]))
+    return None
+
+
 def _node_memfree_mib(node: int) -> int | None:
     """MemFree for one node from /sys/.../nodeN/meminfo, in MiB (kB -> MiB)."""
     try:
@@ -88,8 +103,13 @@ def read_numa_topology() -> NumaTopology:
         online = (_NODE_ROOT / "online").read_text()
     except OSError:
         return NumaTopology()
+    # Restrict to cpuset-allowed nodes: under a Docker/systemd cpuset the child can only
+    # allocate on these, so counting other host nodes would overstate the fittable RAM.
+    allowed = _mems_allowed()
     free: dict[int, int] = {}
     for node in _parse_online(online):
+        if allowed is not None and node not in allowed:
+            continue
         mib = _node_memfree_mib(node)
         if mib is not None:
             free[node] = mib

--- a/studio/backend/core/inference/numa.py
+++ b/studio/backend/core/inference/numa.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""NUMA topology detection and an auto-interleave decision for CPU-only launches.
+
+Linux's first-touch policy faults a model's pages onto one node; if the GGUF is larger
+than that node's free RAM the load thrashes/fails despite ample total RAM.
+`numactl --interleave=all` spreads pages across nodes (llama.cpp discussion #19102).
+Pure stdlib, Linux-only (no-op decision elsewhere), side-effect free.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_NODE_ROOT = Path("/sys/devices/system/node")
+
+
+@dataclass(frozen=True)
+class NumaTopology:
+    """Per-node free memory (MemFree, matching `numactl --hardware`'s 'node N free')."""
+
+    node_free_mib: dict[int, int] = field(default_factory=dict)
+
+    @property
+    def node_count(self) -> int:
+        return len(self.node_free_mib)
+
+    @property
+    def total_free_mib(self) -> int:
+        return sum(self.node_free_mib.values())
+
+    @property
+    def largest_node_free_mib(self) -> int:
+        return max(self.node_free_mib.values(), default=0)
+
+
+def _parse_online(spec: str) -> list[int]:
+    """Parse a sysfs cpulist-style range, e.g. '0-1' or '0,2-3', into node ids."""
+    out: list[int] = []
+    for part in spec.strip().split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            lo, _, hi = part.partition("-")
+            try:
+                out.extend(range(int(lo), int(hi) + 1))
+            except ValueError:
+                continue
+        else:
+            try:
+                out.append(int(part))
+            except ValueError:
+                continue
+    return out
+
+
+def _node_memfree_mib(node: int) -> int | None:
+    """MemFree for one node from /sys/.../nodeN/meminfo, in MiB (kB -> MiB)."""
+    try:
+        text = (_NODE_ROOT / f"node{node}" / "meminfo").read_text()
+    except OSError:
+        return None
+    for line in text.splitlines():
+        # "Node 0 MemFree:           465594 kB"
+        if "MemFree:" in line:
+            parts = line.split()
+            try:
+                kb = int(parts[parts.index("MemFree:") + 1])
+            except (ValueError, IndexError):
+                return None
+            return kb // 1024
+    return None
+
+
+def read_numa_topology() -> NumaTopology:
+    """Read NUMA node free memory from sysfs. Empty topology on non-Linux / no sysfs /
+    single-node (a single node is reported but callers treat node_count <= 1 as 'no
+    interleave needed')."""
+    try:
+        online = (_NODE_ROOT / "online").read_text()
+    except OSError:
+        return NumaTopology()
+    free: dict[int, int] = {}
+    for node in _parse_online(online):
+        mib = _node_memfree_mib(node)
+        if mib is not None:
+            free[node] = mib
+    return NumaTopology(node_free_mib=free)
+
+
+def numactl_available() -> bool:
+    return shutil.which("numactl") is not None
+
+
+@dataclass(frozen=True)
+class InterleaveDecision:
+    interleave: bool
+    reason: str
+    prefix: tuple[str, ...] = ()  # argv prefix to apply, e.g. ("numactl", "--interleave=all")
+
+
+def decide_interleave(
+    model_size_bytes: int | None,
+    *,
+    cpu_only: bool,
+    topology: NumaTopology | None = None,
+    has_numactl: bool | None = None,
+) -> InterleaveDecision:
+    """Interleave only when CPU-only, multi-node, and the model exceeds the largest
+    node's free RAM but fits across all nodes; otherwise leave placement local.
+    model_size_bytes (GGUF weights) is the conservative proxy for the footprint."""
+    if not cpu_only:
+        return InterleaveDecision(False, "not cpu-only; leaving NUMA placement to the OS")
+    if not model_size_bytes or model_size_bytes <= 0:
+        return InterleaveDecision(False, "model size unknown; not forcing interleave")
+
+    topo = topology if topology is not None else read_numa_topology()
+    if topo.node_count <= 1:
+        return InterleaveDecision(False, "single NUMA node; interleave not needed")
+
+    model_mib = model_size_bytes // (1024 * 1024)
+    largest = topo.largest_node_free_mib
+    total = topo.total_free_mib
+
+    if model_mib <= largest:
+        return InterleaveDecision(
+            False,
+            f"model ~{model_mib} MiB fits the largest node's free RAM "
+            f"(~{largest} MiB); keeping local placement",
+        )
+
+    avail = numactl_available() if has_numactl is None else has_numactl
+    if not avail:
+        # Needed but unavailable: surface it; caller decides whether to block.
+        return InterleaveDecision(
+            False,
+            f"model ~{model_mib} MiB exceeds the largest NUMA node's free RAM "
+            f"(~{largest} MiB) and needs interleaving across {topo.node_count} nodes, "
+            f"but `numactl` is not installed. Install numactl (e.g. `apt install "
+            f"numactl`) or the model may fail to fit a single node.",
+        )
+
+    if model_mib > total:
+        return InterleaveDecision(
+            False,
+            f"model ~{model_mib} MiB exceeds total free RAM across all nodes "
+            f"(~{total} MiB); interleave cannot help -- free memory or use a smaller quant",
+        )
+
+    return InterleaveDecision(
+        True,
+        f"model ~{model_mib} MiB exceeds the largest NUMA node's free RAM "
+        f"(~{largest} MiB) but fits across {topo.node_count} nodes (~{total} MiB total "
+        f"free); wrapping with numactl --interleave=all",
+        prefix=("numactl", "--interleave=all"),
+    )

--- a/studio/backend/core/inference/numa.py
+++ b/studio/backend/core/inference/numa.py
@@ -18,11 +18,11 @@ from pathlib import Path
 _NODE_ROOT = Path("/sys/devices/system/node")
 
 
-@dataclass(frozen=True)
+@dataclass(frozen = True)
 class NumaTopology:
     """Per-node free memory (MemFree, matching `numactl --hardware`'s 'node N free')."""
 
-    node_free_mib: dict[int, int] = field(default_factory=dict)
+    node_free_mib: dict[int, int] = field(default_factory = dict)
 
     @property
     def node_count(self) -> int:
@@ -34,7 +34,7 @@ class NumaTopology:
 
     @property
     def largest_node_free_mib(self) -> int:
-        return max(self.node_free_mib.values(), default=0)
+        return max(self.node_free_mib.values(), default = 0)
 
 
 def _parse_online(spec: str) -> list[int]:
@@ -89,14 +89,14 @@ def read_numa_topology() -> NumaTopology:
         mib = _node_memfree_mib(node)
         if mib is not None:
             free[node] = mib
-    return NumaTopology(node_free_mib=free)
+    return NumaTopology(node_free_mib = free)
 
 
 def numactl_available() -> bool:
     return shutil.which("numactl") is not None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen = True)
 class InterleaveDecision:
     interleave: bool
     reason: str
@@ -156,5 +156,5 @@ def decide_interleave(
         f"model ~{model_mib} MiB exceeds the largest NUMA node's free RAM "
         f"(~{largest} MiB) but fits across {topo.node_count} nodes (~{total} MiB total "
         f"free); wrapping with numactl --interleave=all",
-        prefix=("numactl", "--interleave=all"),
+        prefix = ("numactl", "--interleave=all"),
     )

--- a/studio/backend/core/inference/numa.py
+++ b/studio/backend/core/inference/numa.py
@@ -110,9 +110,11 @@ def decide_interleave(
     topology: NumaTopology | None = None,
     has_numactl: bool | None = None,
 ) -> InterleaveDecision:
-    """Interleave only when CPU-only, multi-node, and the model exceeds the largest
+    """Interleave only when CPU-only, multi-node, and the footprint exceeds the largest
     node's free RAM but fits across all nodes; otherwise leave placement local.
-    model_size_bytes (GGUF weights) is the conservative proxy for the footprint."""
+    model_size_bytes should be the resident footprint (weights + KV), not weights
+    alone, so a model whose weights fit a node but whose footprint does not still
+    interleaves."""
     if not cpu_only:
         return InterleaveDecision(False, "not cpu-only; leaving NUMA placement to the OS")
     if not model_size_bytes or model_size_bytes <= 0:

--- a/studio/backend/core/inference/numa.py
+++ b/studio/backend/core/inference/numa.py
@@ -36,6 +36,10 @@ class NumaTopology:
     def largest_node_free_mib(self) -> int:
         return max(self.node_free_mib.values(), default = 0)
 
+    @property
+    def smallest_node_free_mib(self) -> int:
+        return min(self.node_free_mib.values(), default = 0)
+
 
 def _parse_online(spec: str) -> list[int]:
     """Parse a sysfs cpulist-style range, e.g. '0-1' or '0,2-3', into node ids."""
@@ -110,10 +114,11 @@ def decide_interleave(
     topology: NumaTopology | None = None,
     has_numactl: bool | None = None,
 ) -> InterleaveDecision:
-    """Interleave only when CPU-only, multi-node, and the footprint exceeds the largest
-    node's free RAM but fits across all nodes; otherwise leave placement local.
-    model_size_bytes should be the resident footprint (weights + KV), not weights
-    alone, so a model whose weights fit a node but whose footprint does not still
+    """Interleave only when CPU-only, multi-node, and the footprint exceeds the smallest
+    node's free RAM but fits across all nodes; otherwise leave placement local. The
+    smallest node is the bound because the loader is not pinned, so first-touch may land
+    on any node. model_size_bytes should be the resident footprint (weights + KV), not
+    weights alone, so a model whose weights fit a node but whose footprint does not still
     interleaves."""
     if not cpu_only:
         return InterleaveDecision(False, "not cpu-only; leaving NUMA placement to the OS")
@@ -125,14 +130,17 @@ def decide_interleave(
         return InterleaveDecision(False, "single NUMA node; interleave not needed")
 
     model_mib = model_size_bytes // (1024 * 1024)
-    largest = topo.largest_node_free_mib
+    smallest = topo.smallest_node_free_mib
     total = topo.total_free_mib
 
-    if model_mib <= largest:
+    # Keep local only when the footprint fits EVERY node (the smallest). We don't bind
+    # the loader, so first-touch may land on any node; local placement is safe only when
+    # any node can hold it. A footprint that fits only the larger node still interleaves.
+    if model_mib <= smallest:
         return InterleaveDecision(
             False,
-            f"model ~{model_mib} MiB fits the largest node's free RAM "
-            f"(~{largest} MiB); keeping local placement",
+            f"model ~{model_mib} MiB fits every node's free RAM "
+            f"(smallest ~{smallest} MiB); keeping local placement",
         )
 
     # Impossible across all nodes regardless of numactl: surface the smaller-quant /
@@ -150,16 +158,16 @@ def decide_interleave(
         # Needed but unavailable: surface it; caller decides whether to block.
         return InterleaveDecision(
             False,
-            f"model ~{model_mib} MiB exceeds the largest NUMA node's free RAM "
-            f"(~{largest} MiB) and needs interleaving across {topo.node_count} nodes, "
+            f"model ~{model_mib} MiB exceeds the smallest NUMA node's free RAM "
+            f"(~{smallest} MiB) and needs interleaving across {topo.node_count} nodes, "
             f"but `numactl` is not installed. Install numactl (e.g. `apt install "
             f"numactl`) or the model may fail to fit a single node.",
         )
 
     return InterleaveDecision(
         True,
-        f"model ~{model_mib} MiB exceeds the largest NUMA node's free RAM "
-        f"(~{largest} MiB) but fits across {topo.node_count} nodes (~{total} MiB total "
+        f"model ~{model_mib} MiB exceeds the smallest NUMA node's free RAM "
+        f"(~{smallest} MiB) but fits across {topo.node_count} nodes (~{total} MiB total "
         f"free); wrapping with numactl --interleave=all",
         prefix = ("numactl", "--interleave=all"),
     )

--- a/studio/backend/core/inference/numa.py
+++ b/studio/backend/core/inference/numa.py
@@ -135,6 +135,16 @@ def decide_interleave(
             f"(~{largest} MiB); keeping local placement",
         )
 
+    # Impossible across all nodes regardless of numactl: surface the smaller-quant /
+    # free-memory path before the numactl hint, so a too-big model is not told to
+    # install numactl when interleaving could never make it fit.
+    if model_mib > total:
+        return InterleaveDecision(
+            False,
+            f"model ~{model_mib} MiB exceeds total free RAM across all nodes "
+            f"(~{total} MiB); interleave cannot help -- free memory or use a smaller quant",
+        )
+
     avail = numactl_available() if has_numactl is None else has_numactl
     if not avail:
         # Needed but unavailable: surface it; caller decides whether to block.
@@ -144,13 +154,6 @@ def decide_interleave(
             f"(~{largest} MiB) and needs interleaving across {topo.node_count} nodes, "
             f"but `numactl` is not installed. Install numactl (e.g. `apt install "
             f"numactl`) or the model may fail to fit a single node.",
-        )
-
-    if model_mib > total:
-        return InterleaveDecision(
-            False,
-            f"model ~{model_mib} MiB exceeds total free RAM across all nodes "
-            f"(~{total} MiB); interleave cannot help -- free memory or use a smaller quant",
         )
 
     return InterleaveDecision(

--- a/studio/backend/tests/test_cpu_only_defaults.py
+++ b/studio/backend/tests/test_cpu_only_defaults.py
@@ -174,7 +174,8 @@ def test_cpu_context_cap_reuses_fit_helper_against_ram():
     src = _load_model_src()
     assert "_available_system_memory_mib()" in src
     assert "self._fit_context_to_vram(" in src
-    assert "budget_frac = _CPU_RAM_BUDGET_FRAC" in src
+    assert "_cpu_budget = _CPU_RAM_BUDGET_FRAC" in src
+    assert "budget_frac = _cpu_budget" in src
 
 
 def test_cpu_ram_preflight_warns_when_weights_exceed_ram():
@@ -273,6 +274,16 @@ def test_cpu_fit_skips_mtp_reserve_when_mla_auto_drops():
     # The CPU cap and NUMA recompute use the gated flag, not the raw _mtp_will_engage.
     assert _nows("mtp_overhead_fn = (_mtp_bytes if _mtp_will_engage_cpu else None)") in src
     assert _nows("_numa_mtp = _mtp_bytes(effective_ctx) if _mtp_will_engage_cpu else 0") in src
+
+
+def test_cpu_fit_reserves_flat_mtp_when_draft_unsized():
+    """When MTP engages but the draft KV can't be byte-sized (mtp_overhead_fn is None),
+    budget_frac skips the flat reserve, so the CPU budget is trimmed to still hold MTP
+    RAM back instead of fitting a context that OOMs once the draft allocates (PR review)."""
+    src = _load_model_src()
+    assert "if _mtp_will_engage_cpu and mtp_overhead_fn is None:" in src
+    assert "_cpu_budget -= _MTP_VRAM_RESERVE_FRAC" in src
+    assert "budget_frac = _cpu_budget" in src
 
 
 def test_zero_offload_folds_into_cpu_only():

--- a/studio/backend/tests/test_cpu_only_defaults.py
+++ b/studio/backend/tests/test_cpu_only_defaults.py
@@ -182,6 +182,14 @@ def test_numa_surfaces_total_ram_failure():
     assert '"interleave cannot help" in _numa.reason' in src
 
 
+def test_explicit_user_numa_skips_auto_interleave_prefix():
+    """An explicit user --numa must skip the numactl argv prefix (which user extra args
+    can't override), not just the --numa distribute flag (PR review fix)."""
+    src = _load_model_src()
+    assert 'if _numa.interleave and _extra_args_set_any_flag(extra_args, {"--numa"}):' in src
+    assert "leaving auto-interleave off" in src
+
+
 def test_extra_args_forces_cpu_offload_helper():
     """The zero-offload detector: -ngl 0 / --n-gpu-layers 0 / --gpu-layers 0 (last wins)."""
     from core.inference.llama_cpp import _extra_args_forces_cpu_offload as f

--- a/studio/backend/tests/test_cpu_only_defaults.py
+++ b/studio/backend/tests/test_cpu_only_defaults.py
@@ -32,6 +32,41 @@ except ImportError:
     _s.get_logger = lambda *a, **k: __import__("logging").getLogger("stub")
     _s.BoundLogger = type("BoundLogger", (), {})
     sys.modules["structlog"] = _s
+# Importing core.inference.* runs core/inference/__init__.py (orchestrator + loggers +
+# httpx); stub those when absent so a dependency-light run can still collect this file.
+try:
+    import loggers  # noqa: F401
+except ImportError:
+    _loggers_stub = _types.ModuleType("loggers")
+    _loggers_stub.get_logger = lambda name: __import__("logging").getLogger(name)
+    sys.modules["loggers"] = _loggers_stub
+try:
+    import httpx  # noqa: F401
+except ImportError:
+    _httpx_stub = _types.ModuleType("httpx")
+    for _exc in (
+        "ConnectError",
+        "TimeoutException",
+        "ReadTimeout",
+        "ReadError",
+        "RemoteProtocolError",
+        "CloseError",
+        "HTTPError",
+        "RequestError",
+    ):
+        setattr(_httpx_stub, _exc, type(_exc, (Exception,), {}))
+    _httpx_stub.Timeout = type("T", (), {"__init__": lambda s, *a, **k: None})
+    _httpx_stub.Response = type("Response", (), {})
+    _httpx_stub.Client = type(
+        "C",
+        (),
+        {
+            "__init__": lambda s, **kw: None,
+            "__enter__": lambda s: s,
+            "__exit__": lambda s, *a: None,
+        },
+    )
+    sys.modules["httpx"] = _httpx_stub
 
 from core.inference.llama_cpp import LlamaCppBackend  # noqa: E402
 
@@ -126,7 +161,7 @@ def test_cpu_context_fit_accounts_for_mtp():
     """mtp_engaged alone is a no-op once budget_frac is set, so the CPU fit must pass the
     byte-accurate MTP overhead fn to actually reserve MTP KV (PR review fix)."""
     src = _load_model_src()
-    assert "mtp_overhead_fn = (_mtp_bytes if _mtp_will_engage else None)" in src
+    assert "mtp_overhead_fn = (_mtp_bytes if _mtp_will_engage_cpu else None)" in src
 
 
 def test_cpu_context_cap_reuses_fit_helper_against_ram():
@@ -169,7 +204,7 @@ def test_numa_decision_uses_footprint_not_just_weights():
     # Footprint = fitted weights (incl. compute buffer) + KV + MTP reserve.
     assert "_resident = model_size_fit or model_size" in src
     # MTP is recomputed at the post-cap context, not the stale pre-cap reserve.
-    assert "_numa_mtp = _mtp_bytes(effective_ctx) if _mtp_will_engage else 0" in src
+    assert "_numa_mtp = _mtp_bytes(effective_ctx) if _mtp_will_engage_cpu else 0" in src
     # KV must be sized for the launched --parallel slots, not the n_parallel=1 default.
     assert "effective_ctx, cache_type_kv, n_parallel = n_parallel" in src
 
@@ -191,7 +226,7 @@ def test_explicit_user_numa_skips_auto_interleave_prefix():
 
 
 def test_extra_args_forces_cpu_offload_helper():
-    """The zero-offload detector: -ngl 0 / --n-gpu-layers 0 / --gpu-layers 0 (last wins)."""
+    """The CPU-force detector: zero GPU layers or --device none (PR review fixes)."""
     from core.inference.llama_cpp import _extra_args_forces_cpu_offload as f
 
     assert f(["-ngl", "0"])
@@ -202,9 +237,35 @@ def test_extra_args_forces_cpu_offload_helper():
     assert not f([])
     assert not f(None)
     assert not f(["--flash-attn", "on"])
-    # Last occurrence wins, matching llama-server's own parsing.
+    # Each flag's last occurrence wins, matching llama-server's own parsing.
     assert f(["-ngl", "99", "-ngl", "0"])
     assert not f(["-ngl", "0", "-ngl", "99"])
+    # --device/-dev none also forces CPU, independently of -ngl.
+    assert f(["--device", "none"])
+    assert f(["-dev", "none"])
+    assert f(["--device=none"])
+    assert not f(["--device", "CUDA0"])
+    # The two controls are independent: -ngl 0 stays CPU even with a device named.
+    assert f(["-ngl", "0", "--device", "CUDA0"])
+    assert f(["--device", "none", "-ngl", "99"])
+
+
+def test_cpu_cap_lowers_advertised_ceiling():
+    """When the CPU cap reduces the launched context, max_available_ctx must drop too,
+    so /status and the UI safe-zone reflect the real window, not native (PR review fix)."""
+    src = _load_model_src()
+    assert "max_available_ctx = min(max_available_ctx, _cpu_cap)" in src
+
+
+def test_cpu_fit_skips_mtp_reserve_when_mla_auto_drops():
+    """Auto drops embedded MTP for MLA models, so the CPU cap / NUMA footprint must not
+    reserve a target-KV copy for a drafter that won't launch (PR review fix)."""
+    src = _load_model_src()
+    assert "_mtp_will_engage_cpu = _mtp_will_engage and not (" in src
+    assert "not _mla_mtp_auto_enabled()" in src
+    # The CPU cap and NUMA recompute use the gated flag, not the raw _mtp_will_engage.
+    assert "mtp_overhead_fn = (_mtp_bytes if _mtp_will_engage_cpu else None)" in src
+    assert "_numa_mtp = _mtp_bytes(effective_ctx) if _mtp_will_engage_cpu else 0" in src
 
 
 def test_zero_offload_folds_into_cpu_only():

--- a/studio/backend/tests/test_cpu_only_defaults.py
+++ b/studio/backend/tests/test_cpu_only_defaults.py
@@ -134,9 +134,11 @@ def test_cpu_context_floors_to_min_when_weights_exceed_budget():
 
 
 def test_numa_decision_uses_footprint_not_just_weights():
-    """The NUMA interleave decision must use weights + KV, so a model whose weights fit
-    one node but whose footprint does not still interleaves (PR review fix)."""
+    """The NUMA interleave decision must use weights + KV (at the launched parallel
+    slots), so a model whose weights fit one node but whose footprint does not still
+    interleaves (PR review fixes)."""
     src = _load_model_src()
     assert "_numa_footprint" in src
-    assert "_estimate_kv_cache_bytes(" in src
     assert "decide_interleave(_numa_footprint" in src
+    # KV must be sized for the launched --parallel slots, not the n_parallel=1 default.
+    assert "effective_ctx, cache_type_kv, n_parallel = n_parallel" in src

--- a/studio/backend/tests/test_cpu_only_defaults.py
+++ b/studio/backend/tests/test_cpu_only_defaults.py
@@ -234,28 +234,38 @@ def test_explicit_user_numa_skips_auto_interleave_prefix():
 
 
 def test_extra_args_forces_cpu_offload_helper():
-    """The CPU-force detector: zero GPU layers or --device none (PR review fixes)."""
+    """The CPU-force detector: zero GPU layers or --device none, via CLI or the inherited
+    LLAMA_ARG_* env (PR review fixes)."""
     from core.inference.llama_cpp import _extra_args_forces_cpu_offload as f
 
-    assert f(["-ngl", "0"])
-    assert f(["--n-gpu-layers", "0"])
-    assert f(["--gpu-layers", "0"])
-    assert f(["-ngl=0"])
-    assert not f(["-ngl", "99"])
-    assert not f([])
-    assert not f(None)
-    assert not f(["--flash-attn", "on"])
+    E: dict = {}  # explicit empty env so cases ignore the ambient environment
+    assert f(["-ngl", "0"], env = E)
+    assert f(["--n-gpu-layers", "0"], env = E)
+    assert f(["--gpu-layers", "0"], env = E)
+    assert f(["-ngl=0"], env = E)
+    assert not f(["-ngl", "99"], env = E)
+    assert not f([], env = E)
+    assert not f(None, env = E)
+    assert not f(["--flash-attn", "on"], env = E)
     # Each flag's last occurrence wins, matching llama-server's own parsing.
-    assert f(["-ngl", "99", "-ngl", "0"])
-    assert not f(["-ngl", "0", "-ngl", "99"])
+    assert f(["-ngl", "99", "-ngl", "0"], env = E)
+    assert not f(["-ngl", "0", "-ngl", "99"], env = E)
     # --device/-dev none also forces CPU, independently of -ngl.
-    assert f(["--device", "none"])
-    assert f(["-dev", "none"])
-    assert f(["--device=none"])
-    assert not f(["--device", "CUDA0"])
+    assert f(["--device", "none"], env = E)
+    assert f(["-dev", "none"], env = E)
+    assert f(["--device=none"], env = E)
+    assert not f(["--device", "CUDA0"], env = E)
     # The two controls are independent: -ngl 0 stays CPU even with a device named.
-    assert f(["-ngl", "0", "--device", "CUDA0"])
-    assert f(["--device", "none", "-ngl", "99"])
+    assert f(["-ngl", "0", "--device", "CUDA0"], env = E)
+    assert f(["--device", "none", "-ngl", "99"], env = E)
+    # Inherited env forces CPU when the CLI does not set the control.
+    assert f([], env = {"LLAMA_ARG_N_GPU_LAYERS": "0"})
+    assert f([], env = {"LLAMA_ARG_DEVICE": "none"})
+    assert not f([], env = {"LLAMA_ARG_N_GPU_LAYERS": "99"})
+    assert not f([], env = {"LLAMA_ARG_DEVICE": "CUDA0"})
+    # CLI wins over env.
+    assert not f(["-ngl", "99"], env = {"LLAMA_ARG_N_GPU_LAYERS": "0"})
+    assert f(["-ngl", "0"], env = {"LLAMA_ARG_N_GPU_LAYERS": "99"})
 
 
 def test_cpu_cap_lowers_advertised_ceiling():

--- a/studio/backend/tests/test_cpu_only_defaults.py
+++ b/studio/backend/tests/test_cpu_only_defaults.py
@@ -65,10 +65,7 @@ def test_fit_disabled_on_cpu_only():
         if (
             isinstance(node, ast.If)
             and isinstance(node.test, ast.BoolOp)
-            and any(
-                isinstance(v, ast.Name) and v.id == "_cpu_only"
-                for v in ast.walk(node.test)
-            )
+            and any(isinstance(v, ast.Name) and v.id == "_cpu_only" for v in ast.walk(node.test))
         ):
             for n in node.body:
                 if (
@@ -88,6 +85,7 @@ def test_gpu_path_still_emits_fit_on():
 
 
 # ---- Phase 3: CPU context cap + RAM preflight ------------------------------
+
 
 def test_cpu_context_ceiling_constant_is_sane():
     from core.inference import llama_cpp as m

--- a/studio/backend/tests/test_cpu_only_defaults.py
+++ b/studio/backend/tests/test_cpu_only_defaults.py
@@ -209,7 +209,9 @@ def test_numa_decision_uses_footprint_not_just_weights():
     # Footprint = fitted weights (incl. compute buffer) + KV + MTP reserve.
     assert "_resident = model_size_fit or model_size" in src
     # MTP is recomputed at the post-cap context, not the stale pre-cap reserve.
-    assert _nows("_numa_mtp = _mtp_bytes(effective_ctx) if _mtp_will_engage_cpu else 0") in _nows(src)
+    assert _nows("_numa_mtp = _mtp_bytes(effective_ctx) if _mtp_will_engage_cpu else 0") in _nows(
+        src
+    )
     # KV must be sized for the launched --parallel slots, not the n_parallel=1 default.
     assert "effective_ctx, cache_type_kv, n_parallel = n_parallel" in src
 

--- a/studio/backend/tests/test_cpu_only_defaults.py
+++ b/studio/backend/tests/test_cpu_only_defaults.py
@@ -126,19 +126,56 @@ def test_cpu_ram_preflight_warns_when_weights_exceed_ram():
 
 
 def test_cpu_context_floors_to_min_when_weights_exceed_budget():
-    """When weights alone exceed the RAM budget, _fit_context_to_vram returns the
-    ceiling unchanged; the cap must floor to the minimum instead (PR review fix)."""
+    """When the fixed footprint exceeds the RAM budget, _fit_context_to_vram returns
+    the ceiling unchanged; the cap must floor to the minimum instead (PR review fix)."""
     src = _load_model_src()
-    assert "model_size >= _budget_b" in src
+    # The check uses the fitted footprint (weights + compute buffer), not raw weights.
+    assert "_fixed = model_size_fit or model_size" in src
+    assert "_fixed >= _budget_b" in src
     assert "_cpu_cap = 4096" in src
 
 
+def test_cpu_context_fit_uses_fitted_footprint():
+    """The CPU RAM fit must pass the fitted footprint (weights + compute buffer), so a
+    context that only fits when the buffer is ignored can't slip through (PR review fix)."""
+    src = _load_model_src()
+    assert "model_size_bytes = _fixed" in src
+
+
 def test_numa_decision_uses_footprint_not_just_weights():
-    """The NUMA interleave decision must use weights + KV (at the launched parallel
-    slots), so a model whose weights fit one node but whose footprint does not still
-    interleaves (PR review fixes)."""
+    """The NUMA interleave decision must use the full resident footprint (weights +
+    compute buffer + KV at the launched parallel slots + MTP reserve), so a model whose
+    weights fit one node but whose footprint does not still interleaves (PR review fixes)."""
     src = _load_model_src()
     assert "_numa_footprint" in src
     assert "decide_interleave(_numa_footprint" in src
+    # Footprint = fitted weights (incl. compute buffer) + KV + MTP reserve.
+    assert "_resident = model_size_fit or model_size" in src
+    assert "_mtp_reserve_bytes" in src
     # KV must be sized for the launched --parallel slots, not the n_parallel=1 default.
     assert "effective_ctx, cache_type_kv, n_parallel = n_parallel" in src
+
+
+def test_extra_args_forces_cpu_offload_helper():
+    """The zero-offload detector: -ngl 0 / --n-gpu-layers 0 / --gpu-layers 0 (last wins)."""
+    from core.inference.llama_cpp import _extra_args_forces_cpu_offload as f
+
+    assert f(["-ngl", "0"])
+    assert f(["--n-gpu-layers", "0"])
+    assert f(["--gpu-layers", "0"])
+    assert f(["-ngl=0"])
+    assert not f(["-ngl", "99"])
+    assert not f([])
+    assert not f(None)
+    assert not f(["--flash-attn", "on"])
+    # Last occurrence wins, matching llama-server's own parsing.
+    assert f(["-ngl", "99", "-ngl", "0"])
+    assert not f(["-ngl", "0", "-ngl", "99"])
+
+
+def test_zero_offload_folds_into_cpu_only():
+    """A visible GPU plus a user -ngl 0 must be treated as CPU-only: the GPU list is
+    dropped before _cpu_only is computed so the CPU safe defaults apply (PR review fix)."""
+    src = _load_model_src()
+    assert "_extra_args_forces_cpu_offload(extra_args)" in src
+    assert "gpus, total_by_idx = [], {}" in src

--- a/studio/backend/tests/test_cpu_only_defaults.py
+++ b/studio/backend/tests/test_cpu_only_defaults.py
@@ -106,10 +106,27 @@ def test_cpu_context_ceiling_constant_is_sane():
 
 def test_cpu_only_caps_auto_context_but_honors_explicit():
     src = _load_model_src()
-    # Cap only fires for an auto context (requested_ctx <= 0) over the ceiling;
-    # an explicit -c (requested_ctx > 0) is honored.
-    assert "requested_ctx <= 0 and effective_ctx > _CPU_CTX_AUTO_CEILING" in src
+    # The fit runs for any auto context (requested_ctx <= 0), against a ceiling of
+    # min(native, 32k); an explicit -c (requested_ctx > 0) is honored untouched.
+    assert "requested_ctx <= 0 and effective_ctx > 0" in src
+    assert "_ctx_ceiling = min(effective_ctx, _CPU_CTX_AUTO_CEILING)" in src
     assert "effective_ctx = _cpu_cap" in src
+
+
+def test_cpu_context_fit_runs_below_ceiling_too():
+    """A large GGUF with a native context already <= 32k must still be RAM-fit, not
+    skipped, so it can be reduced toward 4096 instead of OS-killed (PR review fix)."""
+    src = _load_model_src()
+    # The gate is `> 0`, not `> _CPU_CTX_AUTO_CEILING`, and the fit ceiling is clamped.
+    assert "effective_ctx > _CPU_CTX_AUTO_CEILING" not in src
+    assert "requested_ctx = _ctx_ceiling" in src
+
+
+def test_cpu_context_fit_accounts_for_mtp():
+    """mtp_engaged alone is a no-op once budget_frac is set, so the CPU fit must pass the
+    byte-accurate MTP overhead fn to actually reserve MTP KV (PR review fix)."""
+    src = _load_model_src()
+    assert "mtp_overhead_fn = (_mtp_bytes if _mtp_will_engage else None)" in src
 
 
 def test_cpu_context_cap_reuses_fit_helper_against_ram():
@@ -151,9 +168,18 @@ def test_numa_decision_uses_footprint_not_just_weights():
     assert "decide_interleave(_numa_footprint" in src
     # Footprint = fitted weights (incl. compute buffer) + KV + MTP reserve.
     assert "_resident = model_size_fit or model_size" in src
-    assert "_mtp_reserve_bytes" in src
+    # MTP is recomputed at the post-cap context, not the stale pre-cap reserve.
+    assert "_numa_mtp = _mtp_bytes(effective_ctx) if _mtp_will_engage else 0" in src
     # KV must be sized for the launched --parallel slots, not the n_parallel=1 default.
     assert "effective_ctx, cache_type_kv, n_parallel = n_parallel" in src
+
+
+def test_numa_surfaces_total_ram_failure():
+    """When the footprint exceeds total RAM across all nodes, decide_interleave returns
+    an actionable 'interleave cannot help' reason; the caller must surface it, not only
+    the missing-numactl case (PR review fix)."""
+    src = _load_model_src()
+    assert '"interleave cannot help" in _numa.reason' in src
 
 
 def test_extra_args_forces_cpu_offload_helper():

--- a/studio/backend/tests/test_cpu_only_defaults.py
+++ b/studio/backend/tests/test_cpu_only_defaults.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Guards for CPU-only safe llama-server defaults in load_model.
+
+On a CPU-only host (no discrete GPU, not Apple Metal) none of the GPU/Apple fit
+branches run, so the launch used to keep GPU defaults: `--flash-attn on`, `--fit on`,
+and the model's full native context. For large MLA/sparse-attention/MTP GGUFs (e.g.
+GLM-5.2) `--fit`'s graph-reserve estimator aborts (llama.cpp #21932) and CPU flash
+attention is unsafe. These tests pin that the launch now derives `_cpu_only` and uses
+it to disable --fit and default flash-attn off, while leaving GPU/Apple behaviour and
+user overrides intact. Source/AST level: load_model is too entangled to drive E2E.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import sys
+import textwrap
+import types as _types
+from pathlib import Path
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+try:
+    import structlog  # noqa: F401
+except ImportError:
+    _s = _types.ModuleType("structlog")
+    _s.get_logger = lambda *a, **k: __import__("logging").getLogger("stub")
+    _s.BoundLogger = type("BoundLogger", (), {})
+    sys.modules["structlog"] = _s
+
+from core.inference.llama_cpp import LlamaCppBackend  # noqa: E402
+
+
+def _load_model_src() -> str:
+    return textwrap.dedent(inspect.getsource(LlamaCppBackend.load_model))
+
+
+def test_cpu_only_flag_derived_from_no_gpu_and_not_apple():
+    src = _load_model_src()
+    assert "_cpu_only = (not gpus) and not _is_apple_silicon()" in src
+
+
+def test_flash_attn_default_is_off_on_cpu_only():
+    """The base cmd must use a computed flash default, off for CPU-only."""
+    src = _load_model_src()
+    assert '_flash_default = "off" if _cpu_only else "on"' in src
+    # And the base cmd must NOT hardcode flash-attn on anymore.
+    assert '"on",  # Force flash attention for speed' not in src
+    # The --flash-attn argument in the base cmd list is the computed default.
+    assert "_flash_default,  # CPU-only" in src
+
+
+def test_fit_disabled_on_cpu_only():
+    src = _load_model_src()
+    assert "if _cpu_only and use_fit:" in src
+    fn = ast.parse(src).body[0]
+    # There is an `if _cpu_only and use_fit:` whose body sets use_fit = False.
+    found = False
+    for node in ast.walk(fn):
+        if (
+            isinstance(node, ast.If)
+            and isinstance(node.test, ast.BoolOp)
+            and any(
+                isinstance(v, ast.Name) and v.id == "_cpu_only"
+                for v in ast.walk(node.test)
+            )
+        ):
+            for n in node.body:
+                if (
+                    isinstance(n, ast.Assign)
+                    and any(isinstance(t, ast.Name) and t.id == "use_fit" for t in n.targets)
+                    and isinstance(n.value, ast.Constant)
+                    and n.value.value is False
+                ):
+                    found = True
+    assert found, "expected `if _cpu_only and use_fit: ... use_fit = False`"
+
+
+def test_gpu_path_still_emits_fit_on():
+    """Backwards compat: the GPU branch still emits --fit on (only CPU changes)."""
+    src = _load_model_src()
+    assert 'cmd.extend(["--fit", "on"])' in src
+
+
+# ---- Phase 3: CPU context cap + RAM preflight ------------------------------
+
+def test_cpu_context_ceiling_constant_is_sane():
+    from core.inference import llama_cpp as m
+
+    assert hasattr(m, "_CPU_CTX_AUTO_CEILING")
+    # A safe chat ceiling, far below a model's million-token native context.
+    assert 4096 <= m._CPU_CTX_AUTO_CEILING <= 131072
+    assert 0.5 < m._CPU_RAM_BUDGET_FRAC <= 1.0
+
+
+def test_cpu_only_caps_auto_context_but_honors_explicit():
+    src = _load_model_src()
+    # Cap only fires for an auto context (requested_ctx <= 0) over the ceiling;
+    # an explicit -c (requested_ctx > 0) is honored.
+    assert "requested_ctx <= 0 and effective_ctx > _CPU_CTX_AUTO_CEILING" in src
+    assert "effective_ctx = _cpu_cap" in src
+
+
+def test_cpu_context_cap_reuses_fit_helper_against_ram():
+    """The cap reuses _fit_context_to_vram with the system-RAM budget, not VRAM."""
+    src = _load_model_src()
+    assert "_available_system_memory_mib()" in src
+    assert "self._fit_context_to_vram(" in src
+    assert "budget_frac = _CPU_RAM_BUDGET_FRAC" in src
+
+
+def test_cpu_ram_preflight_warns_when_weights_exceed_ram():
+    src = _load_model_src()
+    assert "CPU-only memory preflight" in src

--- a/studio/backend/tests/test_cpu_only_defaults.py
+++ b/studio/backend/tests/test_cpu_only_defaults.py
@@ -84,6 +84,14 @@ def test_gpu_path_still_emits_fit_on():
     assert 'cmd.extend(["--fit", "on"])' in src
 
 
+def test_cpu_only_emits_explicit_fit_off():
+    """--fit defaults to on in llama.cpp, so CPU-only must pass --fit off explicitly,
+    not just skip --fit on (PR review fix)."""
+    src = _load_model_src()
+    assert "elif _cpu_only:" in src
+    assert 'cmd.extend(["--fit", "off"])' in src
+
+
 # ---- Phase 3: CPU context cap + RAM preflight ------------------------------
 
 
@@ -115,3 +123,20 @@ def test_cpu_context_cap_reuses_fit_helper_against_ram():
 def test_cpu_ram_preflight_warns_when_weights_exceed_ram():
     src = _load_model_src()
     assert "CPU-only memory preflight" in src
+
+
+def test_cpu_context_floors_to_min_when_weights_exceed_budget():
+    """When weights alone exceed the RAM budget, _fit_context_to_vram returns the
+    ceiling unchanged; the cap must floor to the minimum instead (PR review fix)."""
+    src = _load_model_src()
+    assert "model_size >= _budget_b" in src
+    assert "_cpu_cap = 4096" in src
+
+
+def test_numa_decision_uses_footprint_not_just_weights():
+    """The NUMA interleave decision must use weights + KV, so a model whose weights fit
+    one node but whose footprint does not still interleaves (PR review fix)."""
+    src = _load_model_src()
+    assert "_numa_footprint" in src
+    assert "_estimate_kv_cache_bytes(" in src
+    assert "decide_interleave(_numa_footprint" in src

--- a/studio/backend/tests/test_cpu_only_defaults.py
+++ b/studio/backend/tests/test_cpu_only_defaults.py
@@ -157,11 +157,16 @@ def test_cpu_context_fit_runs_below_ceiling_too():
     assert "requested_ctx = _ctx_ceiling" in src
 
 
+def _nows(s: str) -> str:
+    """Whitespace-stripped source, so assertions survive the formatter wrapping a line."""
+    return "".join(s.split())
+
+
 def test_cpu_context_fit_accounts_for_mtp():
     """mtp_engaged alone is a no-op once budget_frac is set, so the CPU fit must pass the
     byte-accurate MTP overhead fn to actually reserve MTP KV (PR review fix)."""
-    src = _load_model_src()
-    assert "mtp_overhead_fn = (_mtp_bytes if _mtp_will_engage_cpu else None)" in src
+    src = _nows(_load_model_src())
+    assert _nows("mtp_overhead_fn = (_mtp_bytes if _mtp_will_engage_cpu else None)") in src
 
 
 def test_cpu_context_cap_reuses_fit_helper_against_ram():
@@ -204,7 +209,7 @@ def test_numa_decision_uses_footprint_not_just_weights():
     # Footprint = fitted weights (incl. compute buffer) + KV + MTP reserve.
     assert "_resident = model_size_fit or model_size" in src
     # MTP is recomputed at the post-cap context, not the stale pre-cap reserve.
-    assert "_numa_mtp = _mtp_bytes(effective_ctx) if _mtp_will_engage_cpu else 0" in src
+    assert _nows("_numa_mtp = _mtp_bytes(effective_ctx) if _mtp_will_engage_cpu else 0") in _nows(src)
     # KV must be sized for the launched --parallel slots, not the n_parallel=1 default.
     assert "effective_ctx, cache_type_kv, n_parallel = n_parallel" in src
 
@@ -260,12 +265,12 @@ def test_cpu_cap_lowers_advertised_ceiling():
 def test_cpu_fit_skips_mtp_reserve_when_mla_auto_drops():
     """Auto drops embedded MTP for MLA models, so the CPU cap / NUMA footprint must not
     reserve a target-KV copy for a drafter that won't launch (PR review fix)."""
-    src = _load_model_src()
-    assert "_mtp_will_engage_cpu = _mtp_will_engage and not (" in src
-    assert "not _mla_mtp_auto_enabled()" in src
+    src = _nows(_load_model_src())
+    assert _nows("_mtp_will_engage_cpu = _mtp_will_engage and not (") in src
+    assert _nows("not _mla_mtp_auto_enabled()") in src
     # The CPU cap and NUMA recompute use the gated flag, not the raw _mtp_will_engage.
-    assert "mtp_overhead_fn = (_mtp_bytes if _mtp_will_engage_cpu else None)" in src
-    assert "_numa_mtp = _mtp_bytes(effective_ctx) if _mtp_will_engage_cpu else 0" in src
+    assert _nows("mtp_overhead_fn = (_mtp_bytes if _mtp_will_engage_cpu else None)") in src
+    assert _nows("_numa_mtp = _mtp_bytes(effective_ctx) if _mtp_will_engage_cpu else 0") in src
 
 
 def test_zero_offload_folds_into_cpu_only():

--- a/studio/backend/tests/test_numa_interleave.py
+++ b/studio/backend/tests/test_numa_interleave.py
@@ -155,6 +155,26 @@ def test_unknown_model_size_does_not_force_interleave():
         assert d.interleave is False
 
 
+def test_topology_restricted_to_cpuset_allowed_nodes(tmp_path, monkeypatch):
+    """A cpuset that allows only node 0 must drop host node 1 from the topology, so a
+    container is not told a node's RAM is usable when the child can't allocate there
+    (PR review fix)."""
+    import core.inference.numa as m
+
+    (tmp_path / "online").write_text("0-1")
+    for nid, free_kb in ((0, 100 * 1024), (1, 200 * 1024)):
+        d = tmp_path / f"node{nid}"
+        d.mkdir()
+        (d / "meminfo").write_text(f"Node {nid} MemFree: {free_kb} kB\n")
+    monkeypatch.setattr(m, "_NODE_ROOT", tmp_path)
+
+    monkeypatch.setattr(m, "_mems_allowed", lambda: {0})
+    assert m.read_numa_topology().node_free_mib == {0: 100}
+    # No cpuset info (None) -> trust the online set, both nodes present.
+    monkeypatch.setattr(m, "_mems_allowed", lambda: None)
+    assert m.read_numa_topology().node_free_mib == {0: 100, 1: 200}
+
+
 def test_decision_is_frozen_dataclass():
     d = InterleaveDecision(True, "x", ("numactl", "--interleave=all"))
     try:

--- a/studio/backend/tests/test_numa_interleave.py
+++ b/studio/backend/tests/test_numa_interleave.py
@@ -12,11 +12,55 @@ injected, so these are deterministic on any host (no /sys, no numactl needed).
 from __future__ import annotations
 
 import sys
+import types as _types
 from pathlib import Path
 
 _BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
 if _BACKEND_DIR not in sys.path:
     sys.path.insert(0, _BACKEND_DIR)
+
+# Importing core.inference.numa runs core/inference/__init__.py (orchestrator + structlog
+# + loggers + httpx); stub those when absent so a dependency-light run can collect this.
+try:
+    import structlog  # noqa: F401
+except ImportError:
+    _s = _types.ModuleType("structlog")
+    _s.get_logger = lambda *a, **k: __import__("logging").getLogger("stub")
+    _s.BoundLogger = type("BoundLogger", (), {})
+    sys.modules["structlog"] = _s
+try:
+    import loggers  # noqa: F401
+except ImportError:
+    _loggers_stub = _types.ModuleType("loggers")
+    _loggers_stub.get_logger = lambda name: __import__("logging").getLogger(name)
+    sys.modules["loggers"] = _loggers_stub
+try:
+    import httpx  # noqa: F401
+except ImportError:
+    _httpx_stub = _types.ModuleType("httpx")
+    for _exc in (
+        "ConnectError",
+        "TimeoutException",
+        "ReadTimeout",
+        "ReadError",
+        "RemoteProtocolError",
+        "CloseError",
+        "HTTPError",
+        "RequestError",
+    ):
+        setattr(_httpx_stub, _exc, type(_exc, (Exception,), {}))
+    _httpx_stub.Timeout = type("T", (), {"__init__": lambda s, *a, **k: None})
+    _httpx_stub.Response = type("Response", (), {})
+    _httpx_stub.Client = type(
+        "C",
+        (),
+        {
+            "__init__": lambda s, **kw: None,
+            "__enter__": lambda s: s,
+            "__exit__": lambda s, *a: None,
+        },
+    )
+    sys.modules["httpx"] = _httpx_stub
 
 from core.inference.numa import (  # noqa: E402
     InterleaveDecision,

--- a/studio/backend/tests/test_numa_interleave.py
+++ b/studio/backend/tests/test_numa_interleave.py
@@ -87,6 +87,7 @@ def test_parse_online_ranges():
 def test_topology_aggregates():
     assert _USER_TOPO.node_count == 2
     assert _USER_TOPO.largest_node_free_mib == 465594
+    assert _USER_TOPO.smallest_node_free_mib == 223814
     assert _USER_TOPO.total_free_mib == 465594 + 223814
 
 
@@ -98,12 +99,20 @@ def test_interleaves_when_model_exceeds_largest_node_but_fits_across():
     assert "interleave=all" in d.reason
 
 
-def test_no_interleave_when_model_fits_largest_node():
-    # A 200 GB model fits node 0's 465 GB free -> keep local placement.
+def test_no_interleave_when_model_fits_every_node():
+    # A 200 GB model fits even the smaller node (223 GB) -> safe on any node, keep local.
     d = decide_interleave(200 * _GiB, cpu_only = True, topology = _USER_TOPO, has_numactl = True)
     assert d.interleave is False
     assert d.prefix == ()
-    assert "fits" in d.reason
+    assert "fits every node" in d.reason
+
+
+def test_interleaves_when_fits_larger_node_but_not_smaller():
+    # 300 GB fits node 0 (465) but not node 1 (223); the loader is not bound, so first-
+    # touch could land on node 1. Interleave instead of gambling on placement (PR review).
+    d = decide_interleave(300 * _GiB, cpu_only = True, topology = _USER_TOPO, has_numactl = True)
+    assert d.interleave is True
+    assert d.prefix == ("numactl", "--interleave=all")
 
 
 def test_no_interleave_on_gpu_host():

--- a/studio/backend/tests/test_numa_interleave.py
+++ b/studio/backend/tests/test_numa_interleave.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Unit tests for the NUMA auto-interleave decision (core/inference/numa.py).
+
+Models the user's dual-NUMA Xeon (HF screenshots #23): node 0 ~465 GB free, node 1
+~223 GB free; a 583 GB GGUF exceeds the largest single node but fits across both, so
+`numactl --interleave=all` is the right call. The decision is pure and topology is
+injected, so these are deterministic on any host (no /sys, no numactl needed).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from core.inference.numa import (  # noqa: E402
+    InterleaveDecision,
+    NumaTopology,
+    _parse_online,
+    decide_interleave,
+)
+
+_GiB = 1024**3
+_MiB = 1024**2
+
+# The user's box, in MiB free per node (from `numactl --hardware`).
+_USER_TOPO = NumaTopology(node_free_mib={0: 465594, 1: 223814})
+_SINGLE = NumaTopology(node_free_mib={0: 900_000})
+
+
+def test_parse_online_ranges():
+    assert _parse_online("0-1") == [0, 1]
+    assert _parse_online("0,2-3") == [0, 2, 3]
+    assert _parse_online("3") == [3]
+    assert _parse_online("") == []
+
+
+def test_topology_aggregates():
+    assert _USER_TOPO.node_count == 2
+    assert _USER_TOPO.largest_node_free_mib == 465594
+    assert _USER_TOPO.total_free_mib == 465594 + 223814
+
+
+def test_interleaves_when_model_exceeds_largest_node_but_fits_across():
+    # 583 GB model: > 465 GB (node 0) but < ~689 GB total.
+    d = decide_interleave(
+        583 * _GiB, cpu_only=True, topology=_USER_TOPO, has_numactl=True
+    )
+    assert d.interleave is True
+    assert d.prefix == ("numactl", "--interleave=all")
+    assert "interleave=all" in d.reason
+
+
+def test_no_interleave_when_model_fits_largest_node():
+    # A 200 GB model fits node 0's 465 GB free -> keep local placement.
+    d = decide_interleave(
+        200 * _GiB, cpu_only=True, topology=_USER_TOPO, has_numactl=True
+    )
+    assert d.interleave is False
+    assert d.prefix == ()
+    assert "fits" in d.reason
+
+
+def test_no_interleave_on_gpu_host():
+    d = decide_interleave(583 * _GiB, cpu_only=False, topology=_USER_TOPO, has_numactl=True)
+    assert d.interleave is False
+    assert "not cpu-only" in d.reason
+
+
+def test_no_interleave_single_node():
+    d = decide_interleave(583 * _GiB, cpu_only=True, topology=_SINGLE, has_numactl=True)
+    assert d.interleave is False
+    assert "single NUMA node" in d.reason
+
+
+def test_model_too_big_for_all_nodes_blocks_with_message():
+    # 800 GB > ~689 GB total free across both nodes -> interleave can't help.
+    d = decide_interleave(800 * _GiB, cpu_only=True, topology=_USER_TOPO, has_numactl=True)
+    assert d.interleave is False
+    assert "exceeds total free RAM" in d.reason
+
+
+def test_numactl_missing_surfaces_actionable_warning():
+    d = decide_interleave(583 * _GiB, cpu_only=True, topology=_USER_TOPO, has_numactl=False)
+    assert d.interleave is False
+    assert "numactl` is not installed" in d.reason
+
+
+def test_unknown_model_size_does_not_force_interleave():
+    for size in (None, 0, -1):
+        d = decide_interleave(size, cpu_only=True, topology=_USER_TOPO, has_numactl=True)
+        assert d.interleave is False
+
+
+def test_decision_is_frozen_dataclass():
+    d = InterleaveDecision(True, "x", ("numactl", "--interleave=all"))
+    try:
+        d.interleave = False  # type: ignore[misc]
+    except AttributeError:
+        return
+    raise AssertionError("InterleaveDecision should be immutable")

--- a/studio/backend/tests/test_numa_interleave.py
+++ b/studio/backend/tests/test_numa_interleave.py
@@ -29,8 +29,8 @@ _GiB = 1024**3
 _MiB = 1024**2
 
 # The user's box, in MiB free per node (from `numactl --hardware`).
-_USER_TOPO = NumaTopology(node_free_mib={0: 465594, 1: 223814})
-_SINGLE = NumaTopology(node_free_mib={0: 900_000})
+_USER_TOPO = NumaTopology(node_free_mib = {0: 465594, 1: 223814})
+_SINGLE = NumaTopology(node_free_mib = {0: 900_000})
 
 
 def test_parse_online_ranges():
@@ -48,9 +48,7 @@ def test_topology_aggregates():
 
 def test_interleaves_when_model_exceeds_largest_node_but_fits_across():
     # 583 GB model: > 465 GB (node 0) but < ~689 GB total.
-    d = decide_interleave(
-        583 * _GiB, cpu_only=True, topology=_USER_TOPO, has_numactl=True
-    )
+    d = decide_interleave(583 * _GiB, cpu_only = True, topology = _USER_TOPO, has_numactl = True)
     assert d.interleave is True
     assert d.prefix == ("numactl", "--interleave=all")
     assert "interleave=all" in d.reason
@@ -58,42 +56,40 @@ def test_interleaves_when_model_exceeds_largest_node_but_fits_across():
 
 def test_no_interleave_when_model_fits_largest_node():
     # A 200 GB model fits node 0's 465 GB free -> keep local placement.
-    d = decide_interleave(
-        200 * _GiB, cpu_only=True, topology=_USER_TOPO, has_numactl=True
-    )
+    d = decide_interleave(200 * _GiB, cpu_only = True, topology = _USER_TOPO, has_numactl = True)
     assert d.interleave is False
     assert d.prefix == ()
     assert "fits" in d.reason
 
 
 def test_no_interleave_on_gpu_host():
-    d = decide_interleave(583 * _GiB, cpu_only=False, topology=_USER_TOPO, has_numactl=True)
+    d = decide_interleave(583 * _GiB, cpu_only = False, topology = _USER_TOPO, has_numactl = True)
     assert d.interleave is False
     assert "not cpu-only" in d.reason
 
 
 def test_no_interleave_single_node():
-    d = decide_interleave(583 * _GiB, cpu_only=True, topology=_SINGLE, has_numactl=True)
+    d = decide_interleave(583 * _GiB, cpu_only = True, topology = _SINGLE, has_numactl = True)
     assert d.interleave is False
     assert "single NUMA node" in d.reason
 
 
 def test_model_too_big_for_all_nodes_blocks_with_message():
     # 800 GB > ~689 GB total free across both nodes -> interleave can't help.
-    d = decide_interleave(800 * _GiB, cpu_only=True, topology=_USER_TOPO, has_numactl=True)
+    d = decide_interleave(800 * _GiB, cpu_only = True, topology = _USER_TOPO, has_numactl = True)
     assert d.interleave is False
     assert "exceeds total free RAM" in d.reason
 
 
 def test_numactl_missing_surfaces_actionable_warning():
-    d = decide_interleave(583 * _GiB, cpu_only=True, topology=_USER_TOPO, has_numactl=False)
+    d = decide_interleave(583 * _GiB, cpu_only = True, topology = _USER_TOPO, has_numactl = False)
     assert d.interleave is False
     assert "numactl` is not installed" in d.reason
 
 
 def test_unknown_model_size_does_not_force_interleave():
     for size in (None, 0, -1):
-        d = decide_interleave(size, cpu_only=True, topology=_USER_TOPO, has_numactl=True)
+        d = decide_interleave(size, cpu_only = True, topology = _USER_TOPO, has_numactl = True)
         assert d.interleave is False
 
 

--- a/studio/backend/tests/test_numa_interleave.py
+++ b/studio/backend/tests/test_numa_interleave.py
@@ -87,6 +87,15 @@ def test_numactl_missing_surfaces_actionable_warning():
     assert "numactl` is not installed" in d.reason
 
 
+def test_too_big_and_numactl_missing_prefers_total_ram_message():
+    # Impossible across all nodes AND no numactl: the total-RAM guidance must win, so the
+    # user is not told to install numactl when interleaving could never help (PR review fix).
+    d = decide_interleave(800 * _GiB, cpu_only = True, topology = _USER_TOPO, has_numactl = False)
+    assert d.interleave is False
+    assert "exceeds total free RAM" in d.reason
+    assert "numactl` is not installed" not in d.reason
+
+
 def test_unknown_model_size_does_not_force_interleave():
     for size in (None, 0, -1):
         d = decide_interleave(size, cpu_only = True, topology = _USER_TOPO, has_numactl = True)

--- a/studio/backend/tests/test_sched_reserve_abort.py
+++ b/studio/backend/tests/test_sched_reserve_abort.py
@@ -243,18 +243,23 @@ def test_failfast_guard_runs_before_killing_the_live_server():
     assert guard_line < kill_line
 
 
-def test_abort_memo_key_includes_variant():
-    """The memo key must include hf_variant / gguf_path so a failed quant does not
-    block a different quant of the same repo (PR review fix)."""
+def test_abort_memo_key_includes_variant_and_launch_settings():
+    """The memo key must include the variant AND the launch settings (context, spec),
+    so a failed quant does not block a different quant, and changing -c / spec (the
+    recommended recovery) is allowed to retry while an identical replay stays blocked."""
     src = _load_model_src()
     assert "_abort_memo_model" in src
-    assert "hf_variant" in src and "gguf_path" in src
+    for tok in ("hf_variant", "gguf_path", "str(n_ctx)", "speculative_type", "extra_args"):
+        assert tok in src, tok
 
-    # Sanity: distinct variants produce distinct keys for the same model.
-    def key(model, variant, gguf):
-        return "\x00".join([model or "", variant or "", gguf or ""])
+    def key(model="repo", variant="", gguf="", n_ctx=4096, spec="", extra=""):
+        return "\x00".join([model, variant, gguf, str(n_ctx), spec, extra])
 
-    assert key("repo", "UD-Q6_K", None) != key("repo", "UD-Q4_K_XL", None)
+    base = key(variant="UD-Q6_K")
+    assert base != key(variant="UD-Q4_K_XL")  # different quant -> retry allowed
+    assert base != key(variant="UD-Q6_K", n_ctx=2048)  # lower context -> retry allowed
+    assert base != key(variant="UD-Q6_K", spec="off")  # disable spec -> retry allowed
+    assert base == key(variant="UD-Q6_K")  # identical replay -> still blocked
 
 
 def test_load_model_records_abort_on_crash():

--- a/studio/backend/tests/test_sched_reserve_abort.py
+++ b/studio/backend/tests/test_sched_reserve_abort.py
@@ -249,9 +249,11 @@ def test_abort_memo_key_includes_variant():
     src = _load_model_src()
     assert "_abort_memo_model" in src
     assert "hf_variant" in src and "gguf_path" in src
+
     # Sanity: distinct variants produce distinct keys for the same model.
     def key(model, variant, gguf):
         return "\x00".join([model or "", variant or "", gguf or ""])
+
     assert key("repo", "UD-Q6_K", None) != key("repo", "UD-Q4_K_XL", None)
 
 

--- a/studio/backend/tests/test_sched_reserve_abort.py
+++ b/studio/backend/tests/test_sched_reserve_abort.py
@@ -281,7 +281,7 @@ def test_abort_memo_deferred_until_mmproj_fallback_ruled_out():
     raise, after the text-only mmproj fallback is ruled out, so a VLM that recovers
     text-only is not blocked by the fail-fast guard next time (PR review fix)."""
     src = _load_model_src()
-    assert "_was_sched_abort = (" in src
+    assert "_was_sched_abort = " in src
     assert "if _was_sched_abort:" in src
     fn = ast.parse(src).body[0]
     strip_line = _call_line(fn, "_strip_mmproj_args")
@@ -289,3 +289,37 @@ def test_abort_memo_deferred_until_mmproj_fallback_ruled_out():
     # Recording happens after the projector strip, i.e. only once the fallback is tried.
     assert strip_line is not None and record_line is not None
     assert record_line > strip_line
+
+
+def test_sched_abort_captured_before_mtp_fallback():
+    """The no-spec MTP fallback resets the stdout tail, so the first launch's scheduler
+    abort must be captured before it runs and folded into the terminal decision; else a
+    differently-failing fallback drops the memo and the UI replays the load (PR review fix)."""
+    src = _load_model_src()
+    assert "_pre_fallback_sched_abort = False" in src
+    assert "_pre_fallback_sched_abort = _pre_fallback_sched_abort or (" in src
+    # The capture is set before the no-spec fallback spawns.
+    fn = ast.parse(src).body[0]
+    capture_line = next(
+        (
+            n.lineno
+            for n in ast.walk(fn)
+            if isinstance(n, ast.Assign)
+            and any(
+                isinstance(t, ast.Name) and t.id == "_pre_fallback_sched_abort" for t in n.targets
+            )
+            and isinstance(n.value, ast.BoolOp)
+        ),
+        None,
+    )
+    fallback_line = next(
+        (
+            n.lineno
+            for n in ast.walk(fn)
+            if isinstance(n, ast.Call)
+            and any(isinstance(a, ast.Name) and a.id == "fallback_cmd" for a in n.args)
+        ),
+        None,
+    )
+    assert capture_line is not None and fallback_line is not None
+    assert capture_line < fallback_line

--- a/studio/backend/tests/test_sched_reserve_abort.py
+++ b/studio/backend/tests/test_sched_reserve_abort.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Guards for the ggml graph-scheduler abort handling in load_model.
+
+A CPU-only user loading GLM-5.2 (MLA + sparse-attention "indexer" + embedded MTP)
+hit `GGML_ASSERT(*cur_backend_id != -1)` in `ggml_backend_sched_split_graph` during
+`sched_reserve`: the CPU backend cannot run an op in the graph. Studio's startup
+crash raised a generic "invalid GGUF or out of memory" message and the UI replayed
+`POST /load`, re-reading the ~583 GB weights into the identical crash every ~3.5 min.
+
+These tests pin: (1) the abort matcher recognises the real backtrace tail and only
+that, (2) the classifier surfaces the actionable message, (3) the per-(binary,model)
+memo round-trips and is mtime-invalidated, and (4) load_model fails fast on a memoed
+abort and records on crash. No GPU, no network, fully deterministic.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import os
+import sys
+import textwrap
+import types as _types
+from pathlib import Path
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+# External-dep stubs so importing the backend doesn't require structlog / loggers /
+# httpx -- only installed when the real module is missing (mirrors test_tp_vision_regression).
+try:
+    import structlog  # noqa: F401
+except ImportError:
+    _structlog_stub = _types.ModuleType("structlog")
+    _structlog_stub.get_logger = lambda *a, **k: __import__("logging").getLogger("stub")
+    sys.modules["structlog"] = _structlog_stub
+try:
+    import loggers  # noqa: F401
+except ImportError:
+    _loggers_stub = _types.ModuleType("loggers")
+    _loggers_stub.get_logger = lambda name: __import__("logging").getLogger(name)
+    sys.modules["loggers"] = _loggers_stub
+try:
+    import httpx  # noqa: F401
+except ImportError:
+    _httpx_stub = _types.ModuleType("httpx")
+    for _exc in (
+        "ConnectError", "TimeoutException", "ReadTimeout", "ReadError",
+        "RemoteProtocolError", "CloseError", "HTTPError", "RequestError",
+    ):
+        setattr(_httpx_stub, _exc, type(_exc, (Exception,), {}))
+    _httpx_stub.Timeout = type("T", (), {"__init__": lambda s, *a, **k: None})
+    _httpx_stub.Response = type("Response", (), {})
+    _httpx_stub.Client = type(
+        "C", (),
+        {"__init__": lambda s, **kw: None, "__enter__": lambda s: s, "__exit__": lambda s, *a: None},
+    )
+    sys.modules["httpx"] = _httpx_stub
+
+from core.inference.llama_cpp import LlamaCppBackend  # noqa: E402
+
+
+# The real crash, faithfully reproduced from the user's llama-server log (HF
+# screenshots discussion #23). The GGML_ASSERT line is followed by ~130 [New LWP]
+# lines and then the gdb backtrace; the assert line scrolls out of a short tail.
+_FULL_ABORT = "\n".join(
+    [
+        "0.09.350.752 W llama_context: n_ctx_seq (4096) < n_ctx_train (1048576)",
+        "/tmp/llama.cpp/ggml/src/ggml-backend.cpp:1242: GGML_ASSERT(*cur_backend_id != -1) failed",
+    ]
+    + [f"[New LWP {2147067 - i}]" for i in range(130)]
+    + [
+        "[Thread debugging using libthread_db enabled]",
+        "#1  0x... in ggml_print_backtrace () from /tmp/llama.cpp/build/bin/libggml-base.so.0",
+        "#2  0x... in ggml_abort () from /tmp/llama.cpp/build/bin/libggml-base.so.0",
+        "#3  0x... in ggml_backend_sched_split_graph () from /tmp/llama.cpp/build/bin/libggml-base.so.0",
+        "#4  0x... in llama_context::graph_reserve(...) () from /tmp/llama.cpp/build/bin/libllama.so.0",
+        "#5  0x... in llama_context::sched_reserve() () from /tmp/llama.cpp/build/bin/libllama.so.0",
+    ]
+)
+
+# What a 50-line tail actually contains: the GGML_ASSERT line is gone, but the
+# backtrace markers (ggml_abort, ggml_backend_sched_split_graph) remain. The matcher
+# must still fire on this -- that's the realistic input at the recording site.
+_ABORT_TAIL = "\n".join(_FULL_ABORT.splitlines()[-50:])
+
+# The other ggml abort Studio already handles (#6415 split-axis): must NOT be
+# misclassified as a scheduler-reserve abort.
+_SPLIT_AXIS_ABORT = (
+    "ggml/src/ggml-backend-meta.cpp:541: "
+    "GGML_ASSERT(src_ss[0].axis != GGML_BACKEND_SPLIT_AXIS_0) failed\n"
+    "#3 ggml_backend_sched_split_graph ()"
+)
+
+_OOM_OUTPUT = "llama_model_load: error loading model: unable to allocate buffer\nkilled"
+_CLEAN_OUTPUT = "main: server is listening on http://127.0.0.1:8080 - starting the main loop"
+
+
+# ---- matcher ---------------------------------------------------------------
+
+def test_matcher_fires_on_full_abort_and_short_tail():
+    assert LlamaCppBackend._is_sched_reserve_abort(_FULL_ABORT)
+    # The headline guarantee: the matcher survives the [New LWP] scroll.
+    assert "GGML_ASSERT(*cur_backend_id != -1)".lower() not in _ABORT_TAIL.lower()
+    assert LlamaCppBackend._is_sched_reserve_abort(_ABORT_TAIL)
+
+
+def test_matcher_ignores_unrelated_crashes():
+    assert not LlamaCppBackend._is_sched_reserve_abort(_SPLIT_AXIS_ABORT)
+    assert not LlamaCppBackend._is_sched_reserve_abort(_OOM_OUTPUT)
+    assert not LlamaCppBackend._is_sched_reserve_abort(_CLEAN_OUTPUT)
+    assert not LlamaCppBackend._is_sched_reserve_abort("")
+
+
+def test_matcher_requires_both_a_ggml_marker_and_a_scheduler_marker():
+    # scheduler word without any ggml abort/assert -> not our abort.
+    assert not LlamaCppBackend._is_sched_reserve_abort("graph_reserve completed in 3ms")
+    # ggml abort without a scheduler marker -> some other assert, not ours.
+    assert not LlamaCppBackend._is_sched_reserve_abort("ggml_abort: tensor type mismatch")
+
+
+# ---- classifier ------------------------------------------------------------
+
+def test_classifier_surfaces_actionable_message():
+    msg = LlamaCppBackend._classify_llama_start_failure(
+        _ABORT_TAIL, gguf_path="/x/GLM-5.2-UD-Q6_K-00001-of-00014.gguf",
+        model_identifier="unsloth/GLM-5.2-GGUF", returncode=-6,
+    )
+    assert msg == LlamaCppBackend._sched_reserve_abort_message()
+    # The message names the real cause, not the generic invalid-GGUF/OOM fallback.
+    assert "ggml_backend_sched_split_graph" in msg
+    assert "enough memory" not in msg  # i.e. not the generic fallback
+
+
+def test_classifier_generic_fallback_unchanged_for_unknown_crash():
+    msg = LlamaCppBackend._classify_llama_start_failure(
+        "some unrelated failure", gguf_path=None, model_identifier=None, returncode=-6,
+    )
+    assert "failed to start" in msg and "enough memory" in msg
+
+
+# ---- memo round-trip / invalidation ---------------------------------------
+
+def test_memo_round_trip_and_isolation(tmp_path):
+    binary = tmp_path / "llama-server"
+    binary.write_text("x")
+    b, model = str(binary), "unsloth/GLM-5.2-GGUF"
+
+    LlamaCppBackend._sched_reserve_abort_keys.clear()
+    assert not LlamaCppBackend._sched_reserve_aborts(b, model)
+    LlamaCppBackend._record_sched_reserve_abort(b, model)
+    assert LlamaCppBackend._sched_reserve_aborts(b, model)
+    # A different model on the same binary is unaffected.
+    assert not LlamaCppBackend._sched_reserve_aborts(b, "unsloth/Qwen3.5-4B-MTP-GGUF")
+    LlamaCppBackend._sched_reserve_abort_keys.clear()
+
+
+def test_memo_invalidated_by_binary_mtime_change(tmp_path):
+    """A `unsloth studio update` swaps the binary -> the memo must not persist."""
+    binary = tmp_path / "llama-server"
+    binary.write_text("v1")
+    b, model = str(binary), "unsloth/GLM-5.2-GGUF"
+
+    LlamaCppBackend._sched_reserve_abort_keys.clear()
+    LlamaCppBackend._record_sched_reserve_abort(b, model)
+    assert LlamaCppBackend._sched_reserve_aborts(b, model)
+    # Bump mtime to a distinct ns value (simulate a rebuilt binary).
+    st = binary.stat()
+    os.utime(binary, ns=(st.st_atime_ns + 10**9, st.st_mtime_ns + 10**9))
+    assert not LlamaCppBackend._sched_reserve_aborts(b, model)
+    LlamaCppBackend._sched_reserve_abort_keys.clear()
+
+
+def test_memo_safe_with_missing_binary_or_model():
+    # None binary/model -> no key -> never aborts, never raises.
+    assert not LlamaCppBackend._sched_reserve_aborts(None, "m")
+    assert not LlamaCppBackend._sched_reserve_aborts("/x", None)
+    LlamaCppBackend._record_sched_reserve_abort(None, None)  # no-op, no raise
+
+
+# ---- load_model wiring (source-level, no GPU/network needed) ---------------
+
+def _load_model_src() -> str:
+    return textwrap.dedent(inspect.getsource(LlamaCppBackend.load_model))
+
+
+def test_load_model_fails_fast_on_memoed_abort():
+    """load_model must consult the memo and raise the actionable message before the
+    download/spawn, so a replayed /load doesn't re-read the weights."""
+    src = _load_model_src()
+    assert "_sched_reserve_aborts(binary, model_identifier)" in src
+    assert "_sched_reserve_abort_message()" in src
+    # The guard must precede the model download (the expensive reload it prevents).
+    fn = ast.parse(src).body[0]
+    guard_line = next(
+        node.lineno for node in ast.walk(fn)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_sched_reserve_aborts"
+    )
+    download_line = next(
+        (node.lineno for node in ast.walk(fn)
+         if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+         and node.func.attr == "_download_gguf"),
+        None,
+    )
+    assert download_line is None or guard_line < download_line
+
+
+def test_load_model_records_abort_on_crash():
+    """On a startup crash matching the signature, load_model must record the memo."""
+    src = _load_model_src()
+    assert "_record_sched_reserve_abort(binary, model_identifier)" in src
+    assert "_is_sched_reserve_abort(" in src

--- a/studio/backend/tests/test_sched_reserve_abort.py
+++ b/studio/backend/tests/test_sched_reserve_abort.py
@@ -207,36 +207,56 @@ def _load_model_src() -> str:
     return textwrap.dedent(inspect.getsource(LlamaCppBackend.load_model))
 
 
-def test_load_model_fails_fast_on_memoed_abort():
-    """load_model must consult the memo and raise the actionable message before the
-    download/spawn, so a replayed /load doesn't re-read the weights."""
-    src = _load_model_src()
-    assert "_sched_reserve_aborts(binary, model_identifier)" in src
-    assert "_sched_reserve_abort_message()" in src
-    # The guard must precede the model download (the expensive reload it prevents).
-    fn = ast.parse(src).body[0]
-    guard_line = next(
-        node.lineno
-        for node in ast.walk(fn)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "_sched_reserve_aborts"
-    )
-    download_line = next(
+def _call_line(fn, attr):
+    """First line where load_model calls method `attr`, or None."""
+    return next(
         (
             node.lineno
             for node in ast.walk(fn)
             if isinstance(node, ast.Call)
             and isinstance(node.func, ast.Attribute)
-            and node.func.attr == "_download_gguf"
+            and node.func.attr == attr
         ),
         None,
     )
+
+
+def test_load_model_fails_fast_on_memoed_abort():
+    """load_model must consult the memo and raise before the download/spawn, so a
+    replayed /load doesn't re-read the weights."""
+    src = _load_model_src()
+    assert "_sched_reserve_aborts(binary, _abort_memo_model)" in src
+    assert "_sched_reserve_abort_message()" in src
+    fn = ast.parse(src).body[0]
+    guard_line = _call_line(fn, "_sched_reserve_aborts")
+    download_line = _call_line(fn, "_download_gguf")
     assert download_line is None or guard_line < download_line
+
+
+def test_failfast_guard_runs_before_killing_the_live_server():
+    """The memo guard must precede _kill_process so a known-bad reload does not tear
+    down a working server (PR review fix)."""
+    fn = ast.parse(_load_model_src()).body[0]
+    guard_line = _call_line(fn, "_sched_reserve_aborts")
+    kill_line = _call_line(fn, "_kill_process")
+    assert guard_line is not None and kill_line is not None
+    assert guard_line < kill_line
+
+
+def test_abort_memo_key_includes_variant():
+    """The memo key must include hf_variant / gguf_path so a failed quant does not
+    block a different quant of the same repo (PR review fix)."""
+    src = _load_model_src()
+    assert "_abort_memo_model" in src
+    assert "hf_variant" in src and "gguf_path" in src
+    # Sanity: distinct variants produce distinct keys for the same model.
+    def key(model, variant, gguf):
+        return "\x00".join([model or "", variant or "", gguf or ""])
+    assert key("repo", "UD-Q6_K", None) != key("repo", "UD-Q4_K_XL", None)
 
 
 def test_load_model_records_abort_on_crash():
     """On a startup crash matching the signature, load_model must record the memo."""
     src = _load_model_src()
-    assert "_record_sched_reserve_abort(binary, model_identifier)" in src
+    assert "_record_sched_reserve_abort(binary, _abort_memo_model)" in src
     assert "_is_sched_reserve_abort(" in src

--- a/studio/backend/tests/test_sched_reserve_abort.py
+++ b/studio/backend/tests/test_sched_reserve_abort.py
@@ -252,14 +252,21 @@ def test_abort_memo_key_includes_variant_and_launch_settings():
     for tok in ("hf_variant", "gguf_path", "str(n_ctx)", "speculative_type", "extra_args"):
         assert tok in src, tok
 
-    def key(model="repo", variant="", gguf="", n_ctx=4096, spec="", extra=""):
+    def key(
+        model = "repo",
+        variant = "",
+        gguf = "",
+        n_ctx = 4096,
+        spec = "",
+        extra = "",
+    ):
         return "\x00".join([model, variant, gguf, str(n_ctx), spec, extra])
 
-    base = key(variant="UD-Q6_K")
-    assert base != key(variant="UD-Q4_K_XL")  # different quant -> retry allowed
-    assert base != key(variant="UD-Q6_K", n_ctx=2048)  # lower context -> retry allowed
-    assert base != key(variant="UD-Q6_K", spec="off")  # disable spec -> retry allowed
-    assert base == key(variant="UD-Q6_K")  # identical replay -> still blocked
+    base = key(variant = "UD-Q6_K")
+    assert base != key(variant = "UD-Q4_K_XL")  # different quant -> retry allowed
+    assert base != key(variant = "UD-Q6_K", n_ctx = 2048)  # lower context -> retry allowed
+    assert base != key(variant = "UD-Q6_K", spec = "off")  # disable spec -> retry allowed
+    assert base == key(variant = "UD-Q6_K")  # identical replay -> still blocked
 
 
 def test_load_model_records_abort_on_crash():

--- a/studio/backend/tests/test_sched_reserve_abort.py
+++ b/studio/backend/tests/test_sched_reserve_abort.py
@@ -48,15 +48,26 @@ try:
 except ImportError:
     _httpx_stub = _types.ModuleType("httpx")
     for _exc in (
-        "ConnectError", "TimeoutException", "ReadTimeout", "ReadError",
-        "RemoteProtocolError", "CloseError", "HTTPError", "RequestError",
+        "ConnectError",
+        "TimeoutException",
+        "ReadTimeout",
+        "ReadError",
+        "RemoteProtocolError",
+        "CloseError",
+        "HTTPError",
+        "RequestError",
     ):
         setattr(_httpx_stub, _exc, type(_exc, (Exception,), {}))
     _httpx_stub.Timeout = type("T", (), {"__init__": lambda s, *a, **k: None})
     _httpx_stub.Response = type("Response", (), {})
     _httpx_stub.Client = type(
-        "C", (),
-        {"__init__": lambda s, **kw: None, "__enter__": lambda s: s, "__exit__": lambda s, *a: None},
+        "C",
+        (),
+        {
+            "__init__": lambda s, **kw: None,
+            "__enter__": lambda s: s,
+            "__exit__": lambda s, *a: None,
+        },
     )
     sys.modules["httpx"] = _httpx_stub
 
@@ -101,6 +112,7 @@ _CLEAN_OUTPUT = "main: server is listening on http://127.0.0.1:8080 - starting t
 
 # ---- matcher ---------------------------------------------------------------
 
+
 def test_matcher_fires_on_full_abort_and_short_tail():
     assert LlamaCppBackend._is_sched_reserve_abort(_FULL_ABORT)
     # The headline guarantee: the matcher survives the [New LWP] scroll.
@@ -124,10 +136,13 @@ def test_matcher_requires_both_a_ggml_marker_and_a_scheduler_marker():
 
 # ---- classifier ------------------------------------------------------------
 
+
 def test_classifier_surfaces_actionable_message():
     msg = LlamaCppBackend._classify_llama_start_failure(
-        _ABORT_TAIL, gguf_path="/x/GLM-5.2-UD-Q6_K-00001-of-00014.gguf",
-        model_identifier="unsloth/GLM-5.2-GGUF", returncode=-6,
+        _ABORT_TAIL,
+        gguf_path = "/x/GLM-5.2-UD-Q6_K-00001-of-00014.gguf",
+        model_identifier = "unsloth/GLM-5.2-GGUF",
+        returncode = -6,
     )
     assert msg == LlamaCppBackend._sched_reserve_abort_message()
     # The message names the real cause, not the generic invalid-GGUF/OOM fallback.
@@ -137,12 +152,16 @@ def test_classifier_surfaces_actionable_message():
 
 def test_classifier_generic_fallback_unchanged_for_unknown_crash():
     msg = LlamaCppBackend._classify_llama_start_failure(
-        "some unrelated failure", gguf_path=None, model_identifier=None, returncode=-6,
+        "some unrelated failure",
+        gguf_path = None,
+        model_identifier = None,
+        returncode = -6,
     )
     assert "failed to start" in msg and "enough memory" in msg
 
 
 # ---- memo round-trip / invalidation ---------------------------------------
+
 
 def test_memo_round_trip_and_isolation(tmp_path):
     binary = tmp_path / "llama-server"
@@ -169,7 +188,7 @@ def test_memo_invalidated_by_binary_mtime_change(tmp_path):
     assert LlamaCppBackend._sched_reserve_aborts(b, model)
     # Bump mtime to a distinct ns value (simulate a rebuilt binary).
     st = binary.stat()
-    os.utime(binary, ns=(st.st_atime_ns + 10**9, st.st_mtime_ns + 10**9))
+    os.utime(binary, ns = (st.st_atime_ns + 10**9, st.st_mtime_ns + 10**9))
     assert not LlamaCppBackend._sched_reserve_aborts(b, model)
     LlamaCppBackend._sched_reserve_abort_keys.clear()
 
@@ -182,6 +201,7 @@ def test_memo_safe_with_missing_binary_or_model():
 
 
 # ---- load_model wiring (source-level, no GPU/network needed) ---------------
+
 
 def _load_model_src() -> str:
     return textwrap.dedent(inspect.getsource(LlamaCppBackend.load_model))
@@ -196,14 +216,20 @@ def test_load_model_fails_fast_on_memoed_abort():
     # The guard must precede the model download (the expensive reload it prevents).
     fn = ast.parse(src).body[0]
     guard_line = next(
-        node.lineno for node in ast.walk(fn)
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        node.lineno
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
         and node.func.attr == "_sched_reserve_aborts"
     )
     download_line = next(
-        (node.lineno for node in ast.walk(fn)
-         if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
-         and node.func.attr == "_download_gguf"),
+        (
+            node.lineno
+            for node in ast.walk(fn)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "_download_gguf"
+        ),
         None,
     )
     assert download_line is None or guard_line < download_line

--- a/studio/backend/tests/test_sched_reserve_abort.py
+++ b/studio/backend/tests/test_sched_reserve_abort.py
@@ -274,3 +274,18 @@ def test_load_model_records_abort_on_crash():
     src = _load_model_src()
     assert "_record_sched_reserve_abort(binary, _abort_memo_model)" in src
     assert "_is_sched_reserve_abort(" in src
+
+
+def test_abort_memo_deferred_until_mmproj_fallback_ruled_out():
+    """The signature is captured up front but the memo is recorded only on a terminal
+    raise, after the text-only mmproj fallback is ruled out, so a VLM that recovers
+    text-only is not blocked by the fail-fast guard next time (PR review fix)."""
+    src = _load_model_src()
+    assert "_was_sched_abort = (" in src
+    assert "if _was_sched_abort:" in src
+    fn = ast.parse(src).body[0]
+    strip_line = _call_line(fn, "_strip_mmproj_args")
+    record_line = _call_line(fn, "_record_sched_reserve_abort")
+    # Recording happens after the projector strip, i.e. only once the fallback is tried.
+    assert strip_line is not None and record_line is not None
+    assert record_line > strip_line


### PR DESCRIPTION
## Problem

On a CPU-only host (no GPU), loading a large MLA + sparse-attention + embedded-MTP GGUF such as GLM-5.2 (UD-Q6_K, ~583 GB) aborts at startup:

```
ggml/src/ggml-backend.cpp: GGML_ASSERT(*cur_backend_id != -1) failed
  ggml_backend_sched_split_graph -> graph_reserve -> sched_reserve -> llama_init_from_model
```

The ggml graph scheduler cannot assign an op in the model's graph to any backend (the op is not implemented for the active CPU build). It reproduces across `--flash-attn` on/off, `--fit` on/off, every context length, and both UD-Q6_K and UD-Q4_K_XL, so this is an upstream llama.cpp limitation, not a quant problem (same class as ggml-org/llama.cpp#20608 and ggml-org/llama.cpp#21932).

Two things made it much worse in Studio:

1. The crash raised a generic "invalid GGUF or out of memory" message, so the real cause was never shown.
2. A startup crash returns HTTP 500, the UI replays `POST /load`, and Studio re-read the whole model (hundreds of GB) into the identical crash on a loop while the UI sat at 99%.

## Changes

All in `studio/backend`. GPU and Apple paths are unchanged; only CPU-only defaults change, and user `extra_args` still win.

### 1. Recognise the scheduler abort and stop the reload loop
- `_is_sched_reserve_abort(...)` matches the abort on its backtrace markers (robust to the short stderr tail, where the `GGML_ASSERT` line scrolls past the `[New LWP]` dump), and excludes the unrelated split-axis abort (ggml-org/llama.cpp#6415).
- A per-`(binary, model)` non-retryable memo, mirroring the existing tensor-split memo and invalidated when the binary changes on `unsloth studio update`. The next `/load` fails fast with an actionable message instead of re-reading the weights.
- A `_classify_llama_start_failure` branch so even the first crash explains the cause and the fix.

### 2. CPU-only safe defaults
- `--fit off`: its estimator reserves a trial graph through the same abort path (ggml-org/llama.cpp#21932) and mis-counts MTP draft KV (ggml-org/llama.cpp#23472, ggml-org/llama.cpp#24117); on CPU it offloads nothing.
- `--flash-attn off`: CPU flash attention is not safe to assume for large MLA / sparse / MTP graphs.
- Auto context capped to a RAM-aware ceiling. A full native context (e.g. 1,048,576) would put ~90 GB of KV plus a large MTP reserve in RAM. An explicit `-c` is honored.

### 3. NUMA auto-interleave (new `core/inference/numa.py`)
- On a multi-node CPU host, wrap llama-server with `numactl --interleave=all` only when the model exceeds the largest node's free RAM but fits across all nodes. Otherwise placement is left to the OS.

### 4. CPU memory preflight
- Warn clearly when weights exceed available RAM, before the OS kills the load mid-way.

## Tests
- `test_sched_reserve_abort.py`: the matcher (including the short-tail and split-axis cases), the classifier message, and the memo (round-trip plus mtime invalidation).
- `test_cpu_only_defaults.py`: the CPU-only flag, `--fit off`, `--flash-attn off`, the context cap, and the RAM preflight; the GPU path still emits `--fit on`.
- `test_numa_interleave.py`: the interleave decision across topologies, modelled on the reported dual-node box.

All new tests pass.
