### PR TITLE
Fix on-device locations dialog layout

### DIFF
--- a/studio/frontend/src/features/hub/catalog/on-device-folders-dialog.tsx
+++ b/studio/frontend/src/features/hub/catalog/on-device-folders-dialog.tsx
@@ -180,7 +180,7 @@ export function OnDeviceFoldersDialog({
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent
-          className="max-w-[600px] gap-0 overflow-hidden p-0"
+          className="gap-0 overflow-hidden p-0 sm:max-w-[620px] lg:max-w-[660px] xl:max-w-[680px] [&_[data-slot=dialog-close]]:right-3 [&_[data-slot=dialog-close]]:top-3"
           overlayClassName="bg-black/20 backdrop-blur-none"
         >
           <DialogHeader className="border-b border-border/60 px-5 py-4">
@@ -319,7 +319,12 @@ export function OnDeviceFoldersDialog({
                     return (
                       <div
                         key={folder.id}
-                        className="flex min-h-12 items-center gap-3 border-b border-border/50 px-3 py-2 last:border-b-0"
+                        className={cn(
+                          "grid min-h-12 w-full items-center gap-3 border-b border-border/50 px-3 py-2 last:border-b-0",
+                          isTauri
+                            ? "grid-cols-[2rem_minmax(0,1fr)_2rem_2rem]"
+                            : "grid-cols-[2rem_minmax(0,1fr)_2rem]",
+                        )}
                       >
                         <div className="flex size-8 shrink-0 items-center justify-center rounded-[9px] bg-muted text-muted-foreground">
                           <HugeiconsIcon
@@ -328,13 +333,19 @@ export function OnDeviceFoldersDialog({
                             className="size-4"
                           />
                         </div>
-                        <div className="min-w-0 flex-1">
-                          <p className="truncate text-[12.5px] font-medium text-foreground">
+                        <div className="min-w-0 overflow-hidden">
+                          <p
+                            className="block w-full truncate text-[12.5px] font-medium text-foreground"
+                            title={pathTail(folder.path)}
+                          >
                             {pathTail(folder.path)}
                           </p>
                           <Tooltip>
                             <TooltipTrigger asChild={true}>
-                              <p className="truncate font-mono text-[10.5px] text-muted-foreground">
+                              <p
+                                className="block w-full truncate font-mono text-[10.5px] text-muted-foreground"
+                                title={folder.path}
+                              >
                                 {folder.path}
                               </p>
                             </TooltipTrigger>

--- a/studio/frontend/src/features/hub/catalog/on-device-folders-dialog.tsx
+++ b/studio/frontend/src/features/hub/catalog/on-device-folders-dialog.tsx
@@ -344,7 +344,6 @@ export function OnDeviceFoldersDialog({
                             <TooltipTrigger asChild={true}>
                               <p
                                 className="block w-full truncate font-mono text-[10.5px] text-muted-foreground"
-                                title={folder.path}
                               >
                                 {folder.path}
                               </p>


### PR DESCRIPTION
## Summary

Before:
<img width="831" height="601" alt="image" src="https://github.com/user-attachments/assets/3f8b4d4e-0834-49ef-bb52-019c486341ea" />
<img width="781" height="568" alt="image" src="https://github.com/user-attachments/assets/67c31557-3900-48a1-b802-1d7f05ea14a4" />

After:
<img width="1072" height="517" alt="image" src="https://github.com/user-attachments/assets/9adeb7bb-8609-40bc-8dce-6b0fd8f76a8b" />


- Slightly widens the on-device locations dialog while keeping the large-screen max width restrained.
- Fixes long indexed location names and paths overflowing their row by using fixed action columns and a minmax(0, 1fr) path column.
- Aligns the dialog close button with the compact header spacing.

## Testing

- npm run typecheck