### PR TITLE
Fix settings dialog overlay stacking above chat header

### DIFF
--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -654,7 +654,7 @@ function GeneralCompareHeader({
   return (
     <div
       className={cn(
-        "pointer-events-none relative z-[65] flex h-[48px] shrink-0 items-start gap-2 bg-background pt-[var(--studio-chat-header-padding-top,11px)]",
+        "pointer-events-none relative z-40 flex h-[48px] shrink-0 items-start gap-2 bg-background pt-[var(--studio-chat-header-padding-top,11px)]",
         side === "left"
           ? pinned
             ? "pl-12 pr-3 md:pl-2"
@@ -2388,7 +2388,7 @@ export function ChatPage({
         )}
         <div
           className={cn(
-            "pointer-events-none absolute top-[var(--studio-content-top-inset,0px)] left-0 right-[10px] z-[66] flex h-[var(--studio-chat-header-height,48px)] shrink-0 items-start bg-background pt-[var(--studio-chat-header-padding-top,11px)] pr-[calc(0.5rem+var(--studio-chat-header-right-inset,var(--studio-window-control-inset,0px)))]",
+            "pointer-events-none absolute top-[var(--studio-content-top-inset,0px)] left-0 right-[10px] z-40 flex h-[var(--studio-chat-header-height,48px)] shrink-0 items-start bg-background pt-[var(--studio-chat-header-padding-top,11px)] pr-[calc(0.5rem+var(--studio-chat-header-right-inset,var(--studio-window-control-inset,0px)))]",
             isMobile
               ? "pl-12"
               : pinned


### PR DESCRIPTION
## Summary

The chat header used z-[65]/z-[66], while shared dialog overlays render at z-50. That let the model-selector header remain above the Settings overlay, creating a bright bar at the top when Settings opened.

- lower the chat header/model selector stacking level below shared dialogs
- apply the same stacking fix to compare-mode chat headers
- leave shared dialog and popover z-index behavior unchanged

Before:
<img width="2702" height="1516" alt="image" src="https://github.com/user-attachments/assets/d88455a1-1db0-4a54-9910-f2f2c7cd3bcc" />

After:
<img width="3838" height="1948" alt="image" src="https://github.com/user-attachments/assets/e0522181-a4dd-4265-ba19-7e5249356c63" />




