### PR TITLE
Studio: keep "Fine-tuned" compare label clear of the floating top right controls

### DIFF
--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -606,7 +606,7 @@ const LoraCompareContent = memo(function LoraCompareContent({
           handleName="lora"
           borderClassName="border-t border-border/60 md:border-t-0 md:border-l"
           header={
-            <div className="shrink-0 py-1.5 pl-3 text-start md:text-end md:pr-[calc(4rem+var(--studio-chat-header-right-inset,var(--studio-window-control-inset,0px)))]">
+            <div className="shrink-0 px-3 py-1.5 text-start md:text-end md:pr-[calc(4rem+var(--studio-chat-header-right-inset,var(--studio-window-control-inset,0px)))]">
               <span className="text-[10px] font-semibold uppercase tracking-wider text-primary">
                 Fine-tuned
               </span>

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -606,7 +606,7 @@ const LoraCompareContent = memo(function LoraCompareContent({
           handleName="lora"
           borderClassName="border-t border-border/60 md:border-t-0 md:border-l"
           header={
-            <div className="shrink-0 px-3 py-1.5 text-start md:text-end">
+            <div className="shrink-0 py-1.5 pl-3 text-start md:text-end md:pr-[calc(4rem+var(--studio-chat-header-right-inset,var(--studio-window-control-inset,0px)))]">
               <span className="text-[10px] font-semibold uppercase tracking-wider text-primary">
                 Fine-tuned
               </span>


### PR DESCRIPTION
The compare view right-aligned the "Fine-tuned" header into the top right corner, where it overlapped the floating window/settings controls.

Before:
<img width="1463" height="761" alt="Screenshot 2026-06-29 at 10 32 32 PM" src="https://github.com/user-attachments/assets/5239e8f2-51a5-4fca-ae51-820656ace0f1" />


After:
<img width="1589" height="963" alt="Screenshot 2026-06-30 at 2 27 43 AM" src="https://github.com/user-attachments/assets/25a4b3a1-73ee-4c44-9bdf-d2337ea6f2ea" />
