### PR TITLE
Keep the JS-bundle scan check size-agnostic so the baseline does not drift

### DIFF
--- a/scripts/scan_packages.py
+++ b/scripts/scan_packages.py
@@ -1208,9 +1208,10 @@ def check_js_file(content: str, filename: str, package: str) -> list[Finding]:
                 HIGH,
                 package,
                 filename,
-                f"Python wheel ships large ({len(content) // 1024} KB) JS bundle "
-                "(uncommon; manually review)",
-                "",
+                # Size stays in evidence, not the check label, so the baseline key
+                # does not drift when a wheel's bundle grows by a few KB.
+                "Python wheel ships large JS bundle (uncommon; manually review)",
+                f"{len(content) // 1024} KB JS bundle",
             )
         )
     return findings

--- a/scripts/scan_packages_baseline.json
+++ b/scripts/scan_packages_baseline.json
@@ -1181,7 +1181,7 @@
     {
       "package": "tensorboard",
       "file": "tensorboard/plugins/projector/tf_projector_plugin/projector_binary.js",
-      "check": "Python wheel ships large (1918 KB) JS bundle (uncommon; manually review)",
+      "check": "Python wheel ships large JS bundle (uncommon; manually review)",
       "severity": "HIGH",
       "evidence": ""
     },


### PR DESCRIPTION
## Problem

The `pip scan-packages :: studio` and `:: extras` shards of the security-audit workflow are red on `main`, each failing on a single non-baselined HIGH: tensorboard's `projector_binary.js` "large JS bundle" finding.

Root cause is baseline drift, not a real security issue. `check_js_file` builds the finding's `check` label with the bundle's KB size embedded:

```
f"Python wheel ships large ({len(content) // 1024} KB) JS bundle (uncommon; manually review)"
```

The baseline matches on `(package, package-relative file, check)`, so the size is part of the match key. The reviewed entry was recorded at `1918 KB`; a newer tensorboard ships `1933 KB`, so the entry stopped matching and the benign HIGH resurfaced and red-failed the gate.

tensorboard cannot be dropped to sidestep this: it backs the `enable_tensorboard` training-logging path in `studio/backend/core/training/`, and it is also transitively required (`descript-audio-codec` -> `descript-audiotools` -> `tensorboard`), which is why the studio shard flags it even though that shard does not read `extras.txt`.

## Fix

Move the size out of the `check` label into the `evidence` field (evidence is shown for review but is not part of the match key), and keep the label constant. Update the single tensorboard baseline entry to the size-agnostic label. The finding is suppressed again and will not re-break when the bundle grows by a few KB on a future release.

## Verification

- `python scripts/scan_packages.py -r <tensorboard>` now suppresses the HIGH via the baseline and exits 0 (only a non-gating MEDIUM remains).
- `pytest tests/security/test_scan_packages.py` passes (46 passed); no test references the label string.
- `ruff check scripts/scan_packages.py` clean; baseline JSON parses, entry count unchanged.
