### PR TITLE
Fix gpt-oss offload_embedding and generate() kwargs, and guard offload_embedding on tied/vLLM models

### DIFF
--- a/tests/test_generate_kwarg_gate.py
+++ b/tests/test_generate_kwarg_gate.py
@@ -92,60 +92,26 @@ class VisionAcceptsMM:
     ): ...
 
 
-def run():
-    cases = [
-        (
-            "prep(**kwargs)+forward(key)  -> accept",
-            PrepHasKwargs_ForwardHasKey(),
-            "logits_to_keep",
-            True,
-        ),
-        (
-            "prep(no kwargs)+forward(key) -> reject",
-            PrepNoKwargs_ForwardHasKey(),
-            "logits_to_keep",
-            False,
-        ),
-        ("prep(key) direct            -> accept", PrepHasKeyDirectly(), "logits_to_keep", True),
-        ("no prepare_inputs_for_gen   -> reject", NoPrepare(), "logits_to_keep", False),
-        (
-            "num_logits_to_keep variant  -> reject",
-            PrepNoKwargs_ForwardHasKey(),
-            "num_logits_to_keep",
-            False,
-        ),
-        (
-            "mm_token_type_ids not accepted -> reject (strip)",
-            VisionRejectsMM(),
-            "mm_token_type_ids",
-            False,
-        ),
-        (
-            "mm_token_type_ids accepted     -> keep",
-            VisionAcceptsMM(),
-            "mm_token_type_ids",
-            True,
-        ),
-    ]
-    passed = 0
-    for name, model, key, expected in cases:
-        got = accepts(model, key)
-        ok = got is expected
-        passed += ok
-        print(f"  [{'PASS' if ok else 'FAIL'}] {name}: got={got} expected={expected}")
-        assert ok, f"{name}: got {got}, expected {expected}"
+# (model, key, expected) per gate case.
+CASES = [
+    ("prep(**kwargs)+forward(key)  -> accept", PrepHasKwargs_ForwardHasKey(), "logits_to_keep", True),
+    ("prep(no kwargs)+forward(key) -> reject", PrepNoKwargs_ForwardHasKey(), "logits_to_keep", False),
+    ("prep(key) direct             -> accept", PrepHasKeyDirectly(), "logits_to_keep", True),
+    ("no prepare_inputs_for_gen    -> reject", NoPrepare(), "logits_to_keep", False),
+    ("num_logits_to_keep variant   -> reject", PrepNoKwargs_ForwardHasKey(), "num_logits_to_keep", False),
+    ("mm_token_type_ids not accepted -> reject (strip)", VisionRejectsMM(), "mm_token_type_ids", False),
+    ("mm_token_type_ids accepted     -> keep", VisionAcceptsMM(), "mm_token_type_ids", True),
+]
 
-    # Optional transformers parity smoke for the accept case.
-    try:
-        import torch  # noqa
-        from transformers import AutoModelForCausalLM, AutoConfig
-    except Exception as e:
-        print(f"  [SKIP] transformers parity (import failed: {e})")
-        print(f"{passed}/{len(cases)} logic cases passed")
-        return
-    print(f"{passed}/{len(cases)} logic cases passed")
+
+def test_generate_kwarg_gate():
+    for name, model, key, expected in CASES:
+        got = accepts(model, key)
+        assert got is expected, f"{name}: got {got}, expected {expected}"
 
 
 if __name__ == "__main__":
-    run()
+    test_generate_kwarg_gate()
+    for name, _, _, _ in CASES:
+        print(f"  [PASS] {name}")
     print("OK: generate-kwarg gate behaves like transformers _validate_model_kwargs")

--- a/tests/test_generate_kwarg_gate.py
+++ b/tests/test_generate_kwarg_gate.py
@@ -76,7 +76,11 @@ class VisionRejectsMM:
         input_ids,
         attention_mask = None,
     ): ...
-    def forward(self, input_ids, pixel_values = None): ...
+    def forward(
+        self,
+        input_ids,
+        pixel_values = None,
+    ): ...
 
 
 class VisionAcceptsMM:

--- a/tests/test_generate_kwarg_gate.py
+++ b/tests/test_generate_kwarg_gate.py
@@ -1,5 +1,6 @@
-"""GPU-free test for the logits_to_keep gate in vision.py
-(_unsloth_generate_accepts_kwarg), AST-extracted so no unsloth/CUDA import is needed."""
+"""GPU-free test for the generate-kwarg gate in vision.py
+(_unsloth_generate_accepts_kwarg), covering both logits_to_keep injection and mm_token_type_ids
+stripping, AST-extracted so no unsloth/CUDA import is needed."""
 
 import ast, inspect, os
 
@@ -68,6 +69,27 @@ class NoPrepare:
     ): ...
 
 
+class VisionRejectsMM:
+    # Qwen3-VL shape: neither prepare nor forward names mm_token_type_ids -> REJECTED (stripped).
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        attention_mask = None,
+    ): ...
+    def forward(self, input_ids, pixel_values = None): ...
+
+
+class VisionAcceptsMM:
+    # forward names mm_token_type_ids and prepare unions it via **kwargs -> ACCEPTED (kept).
+    def prepare_inputs_for_generation(self, input_ids, **kwargs): ...
+    def forward(
+        self,
+        input_ids,
+        mm_token_type_ids = None,
+        **kwargs,
+    ): ...
+
+
 def run():
     cases = [
         (
@@ -89,6 +111,18 @@ def run():
             PrepNoKwargs_ForwardHasKey(),
             "num_logits_to_keep",
             False,
+        ),
+        (
+            "mm_token_type_ids not accepted -> reject (strip)",
+            VisionRejectsMM(),
+            "mm_token_type_ids",
+            False,
+        ),
+        (
+            "mm_token_type_ids accepted     -> keep",
+            VisionAcceptsMM(),
+            "mm_token_type_ids",
+            True,
         ),
     ]
     passed = 0

--- a/tests/test_generate_kwarg_gate.py
+++ b/tests/test_generate_kwarg_gate.py
@@ -1,0 +1,77 @@
+"""GPU-free test for the logits_to_keep gate in vision.py
+(_unsloth_generate_accepts_kwarg), AST-extracted so no unsloth/CUDA import is needed."""
+import ast, inspect, os
+
+HERE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+VISION = os.path.join(HERE, "unsloth", "models", "vision.py")
+
+
+def _load_helper():
+    src = open(VISION).read()
+    mod = ast.parse(src)
+    for node in mod.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "_unsloth_generate_accepts_kwarg":
+            ns = {"inspect": inspect}
+            exec(ast.get_source_segment(src, node), ns)
+            return ns["_unsloth_generate_accepts_kwarg"]
+    raise AssertionError("_unsloth_generate_accepts_kwarg not found in vision.py")
+
+
+accepts = _load_helper()
+
+
+class PrepHasKwargs_ForwardHasKey:
+    # prepare_inputs_for_generation takes **kwargs -> transformers unions forward params,
+    # and forward names logits_to_keep -> ACCEPTED.
+    def prepare_inputs_for_generation(self, input_ids, **kwargs): ...
+    def forward(self, input_ids, logits_to_keep=0, **kwargs): ...
+
+
+class PrepNoKwargs_ForwardHasKey:
+    # prepare has NO **kwargs -> forward is NOT unioned; key only in forward -> REJECTED.
+    # (This is the fused/PEFT gpt-oss failure shape.)
+    def prepare_inputs_for_generation(self, input_ids, attention_mask=None): ...
+    def forward(self, input_ids, logits_to_keep=0): ...
+
+
+class PrepHasKeyDirectly:
+    # key present directly on prepare_inputs_for_generation -> ACCEPTED.
+    def prepare_inputs_for_generation(self, input_ids, logits_to_keep=0): ...
+    def forward(self, input_ids): ...
+
+
+class NoPrepare:
+    # no prepare_inputs_for_generation at all -> model_args empty, no union -> REJECTED.
+    def forward(self, input_ids, logits_to_keep=0, **kwargs): ...
+
+
+def run():
+    cases = [
+        ("prep(**kwargs)+forward(key)  -> accept", PrepHasKwargs_ForwardHasKey(), "logits_to_keep", True),
+        ("prep(no kwargs)+forward(key) -> reject", PrepNoKwargs_ForwardHasKey(), "logits_to_keep", False),
+        ("prep(key) direct            -> accept", PrepHasKeyDirectly(), "logits_to_keep", True),
+        ("no prepare_inputs_for_gen   -> reject", NoPrepare(), "logits_to_keep", False),
+        ("num_logits_to_keep variant  -> reject", PrepNoKwargs_ForwardHasKey(), "num_logits_to_keep", False),
+    ]
+    passed = 0
+    for name, model, key, expected in cases:
+        got = accepts(model, key)
+        ok = got is expected
+        passed += ok
+        print(f"  [{'PASS' if ok else 'FAIL'}] {name}: got={got} expected={expected}")
+        assert ok, f"{name}: got {got}, expected {expected}"
+
+    # Parity check against transformers' real _validate_model_kwargs for the accept case.
+    try:
+        import torch  # noqa
+        from transformers import AutoModelForCausalLM, AutoConfig
+    except Exception as e:
+        print(f"  [SKIP] transformers parity (import failed: {e})")
+        print(f"{passed}/{len(cases)} logic cases passed")
+        return
+    print(f"{passed}/{len(cases)} logic cases passed")
+
+
+if __name__ == "__main__":
+    run()
+    print("OK: generate-kwarg gate behaves like transformers _validate_model_kwargs")

--- a/tests/test_generate_kwarg_gate.py
+++ b/tests/test_generate_kwarg_gate.py
@@ -23,8 +23,7 @@ accepts = _load_helper()
 
 
 class PrepHasKwargs_ForwardHasKey:
-    # prepare_inputs_for_generation takes **kwargs -> transformers unions forward params,
-    # and forward names logits_to_keep -> ACCEPTED.
+    # **kwargs on prepare unions forward params; key in forward -> ACCEPTED.
     def prepare_inputs_for_generation(self, input_ids, **kwargs): ...
     def forward(
         self,
@@ -35,8 +34,7 @@ class PrepHasKwargs_ForwardHasKey:
 
 
 class PrepNoKwargs_ForwardHasKey:
-    # prepare has NO **kwargs -> forward is NOT unioned; key only in forward -> REJECTED.
-    # (This is the fused/PEFT gpt-oss failure shape.)
+    # no **kwargs -> forward not unioned; key only in forward -> REJECTED (gpt-oss shape).
     def prepare_inputs_for_generation(
         self,
         input_ids,
@@ -50,7 +48,7 @@ class PrepNoKwargs_ForwardHasKey:
 
 
 class PrepHasKeyDirectly:
-    # key present directly on prepare_inputs_for_generation -> ACCEPTED.
+    # key directly on prepare -> ACCEPTED.
     def prepare_inputs_for_generation(
         self,
         input_ids,
@@ -60,7 +58,7 @@ class PrepHasKeyDirectly:
 
 
 class NoPrepare:
-    # no prepare_inputs_for_generation at all -> model_args empty, no union -> REJECTED.
+    # no prepare -> empty args, no union -> REJECTED.
     def forward(
         self,
         input_ids,
@@ -137,7 +135,7 @@ def run():
         print(f"  [{'PASS' if ok else 'FAIL'}] {name}: got={got} expected={expected}")
         assert ok, f"{name}: got {got}, expected {expected}"
 
-    # Parity check against transformers' real _validate_model_kwargs for the accept case.
+    # Optional transformers parity smoke for the accept case.
     try:
         import torch  # noqa
         from transformers import AutoModelForCausalLM, AutoConfig

--- a/tests/test_generate_kwarg_gate.py
+++ b/tests/test_generate_kwarg_gate.py
@@ -94,12 +94,32 @@ class VisionAcceptsMM:
 
 # (model, key, expected) per gate case.
 CASES = [
-    ("prep(**kwargs)+forward(key)  -> accept", PrepHasKwargs_ForwardHasKey(), "logits_to_keep", True),
-    ("prep(no kwargs)+forward(key) -> reject", PrepNoKwargs_ForwardHasKey(), "logits_to_keep", False),
+    (
+        "prep(**kwargs)+forward(key)  -> accept",
+        PrepHasKwargs_ForwardHasKey(),
+        "logits_to_keep",
+        True,
+    ),
+    (
+        "prep(no kwargs)+forward(key) -> reject",
+        PrepNoKwargs_ForwardHasKey(),
+        "logits_to_keep",
+        False,
+    ),
     ("prep(key) direct             -> accept", PrepHasKeyDirectly(), "logits_to_keep", True),
     ("no prepare_inputs_for_gen    -> reject", NoPrepare(), "logits_to_keep", False),
-    ("num_logits_to_keep variant   -> reject", PrepNoKwargs_ForwardHasKey(), "num_logits_to_keep", False),
-    ("mm_token_type_ids not accepted -> reject (strip)", VisionRejectsMM(), "mm_token_type_ids", False),
+    (
+        "num_logits_to_keep variant   -> reject",
+        PrepNoKwargs_ForwardHasKey(),
+        "num_logits_to_keep",
+        False,
+    ),
+    (
+        "mm_token_type_ids not accepted -> reject (strip)",
+        VisionRejectsMM(),
+        "mm_token_type_ids",
+        False,
+    ),
     ("mm_token_type_ids accepted     -> keep", VisionAcceptsMM(), "mm_token_type_ids", True),
 ]
 

--- a/tests/test_generate_kwarg_gate.py
+++ b/tests/test_generate_kwarg_gate.py
@@ -1,5 +1,6 @@
 """GPU-free test for the logits_to_keep gate in vision.py
 (_unsloth_generate_accepts_kwarg), AST-extracted so no unsloth/CUDA import is needed."""
+
 import ast, inspect, os
 
 HERE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -24,34 +25,71 @@ class PrepHasKwargs_ForwardHasKey:
     # prepare_inputs_for_generation takes **kwargs -> transformers unions forward params,
     # and forward names logits_to_keep -> ACCEPTED.
     def prepare_inputs_for_generation(self, input_ids, **kwargs): ...
-    def forward(self, input_ids, logits_to_keep=0, **kwargs): ...
+    def forward(
+        self,
+        input_ids,
+        logits_to_keep = 0,
+        **kwargs,
+    ): ...
 
 
 class PrepNoKwargs_ForwardHasKey:
     # prepare has NO **kwargs -> forward is NOT unioned; key only in forward -> REJECTED.
     # (This is the fused/PEFT gpt-oss failure shape.)
-    def prepare_inputs_for_generation(self, input_ids, attention_mask=None): ...
-    def forward(self, input_ids, logits_to_keep=0): ...
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        attention_mask = None,
+    ): ...
+    def forward(
+        self,
+        input_ids,
+        logits_to_keep = 0,
+    ): ...
 
 
 class PrepHasKeyDirectly:
     # key present directly on prepare_inputs_for_generation -> ACCEPTED.
-    def prepare_inputs_for_generation(self, input_ids, logits_to_keep=0): ...
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        logits_to_keep = 0,
+    ): ...
     def forward(self, input_ids): ...
 
 
 class NoPrepare:
     # no prepare_inputs_for_generation at all -> model_args empty, no union -> REJECTED.
-    def forward(self, input_ids, logits_to_keep=0, **kwargs): ...
+    def forward(
+        self,
+        input_ids,
+        logits_to_keep = 0,
+        **kwargs,
+    ): ...
 
 
 def run():
     cases = [
-        ("prep(**kwargs)+forward(key)  -> accept", PrepHasKwargs_ForwardHasKey(), "logits_to_keep", True),
-        ("prep(no kwargs)+forward(key) -> reject", PrepNoKwargs_ForwardHasKey(), "logits_to_keep", False),
+        (
+            "prep(**kwargs)+forward(key)  -> accept",
+            PrepHasKwargs_ForwardHasKey(),
+            "logits_to_keep",
+            True,
+        ),
+        (
+            "prep(no kwargs)+forward(key) -> reject",
+            PrepNoKwargs_ForwardHasKey(),
+            "logits_to_keep",
+            False,
+        ),
         ("prep(key) direct            -> accept", PrepHasKeyDirectly(), "logits_to_keep", True),
         ("no prepare_inputs_for_gen   -> reject", NoPrepare(), "logits_to_keep", False),
-        ("num_logits_to_keep variant  -> reject", PrepNoKwargs_ForwardHasKey(), "num_logits_to_keep", False),
+        (
+            "num_logits_to_keep variant  -> reject",
+            PrepNoKwargs_ForwardHasKey(),
+            "num_logits_to_keep",
+            False,
+        ),
     ]
     passed = 0
     for name, model, key, expected in cases:

--- a/tests/test_offload_embedding_hooks.py
+++ b/tests/test_offload_embedding_hooks.py
@@ -89,6 +89,17 @@ def test_live_decoder_over_stale_fallback():
     assert out.device.type == "cuda", out.device
 
 
+def test_meta_lm_head_falls_back():
+    # A disk-offloaded (meta) lm_head must not be used as the return device: moving hidden
+    # states to meta is unrecoverable, so fall back to the captured device. No GPU needed.
+    emb = _emb().to("cpu")
+    lm = _lm_head(CPU)
+    lm.weight = nn.Parameter(lm.weight.to("meta"))
+    install(emb, lm, CPU)
+    out = emb(torch.randint(0, 32, (2, 5)))
+    assert out.device.type == "cpu", out.device
+
+
 def test_cuda_weight_pulled_back_to_gpu():
     if not torch.cuda.is_available():
         print("[SKIP] CUDA not available")
@@ -111,6 +122,8 @@ if __name__ == "__main__":
     print("[PASS] cpu input still returns to cuda decoder (P1)")
     test_live_decoder_over_stale_fallback()
     print("[PASS] live decoder device beats stale fallback (P2)")
+    test_meta_lm_head_falls_back()
+    print("[PASS] meta lm_head falls back to captured device (P2)")
     test_cuda_weight_pulled_back_to_gpu()
     print("[PASS] cuda weight-on-gpu no-op")
     print("OK: offloaded embedding output always lands on the live decoder device")

--- a/tests/test_offload_embedding_hooks.py
+++ b/tests/test_offload_embedding_hooks.py
@@ -1,6 +1,6 @@
 """Tests _install_offload_embedding_hooks in vision.py: the offloaded lookup must work and
-its output must land on the decoder device (return_device), whatever device the input is on.
-CUDA cases skip without a GPU."""
+its output must land on the decoder device, read live from the output embeddings (lm_head)
+so it tracks model.to() moves. CUDA cases skip without a GPU."""
 
 import ast, os
 import torch
@@ -25,27 +25,32 @@ install = _load_installer()
 CPU = torch.device("cpu")
 
 
-def _fresh_emb():
+def _emb():
     return nn.Embedding(32, 8)
 
 
+def _lm_head(device):
+    # Stand-in decoder reference (untied lm_head) whose weight device is the target.
+    return nn.Linear(8, 32, bias = False).to(device)
+
+
 def test_install_and_idempotent():
-    emb = _fresh_emb()
-    assert install(emb, CPU) is True
+    emb = _emb()
+    lm = _lm_head(CPU)
+    assert install(emb, lm, CPU) is True
     assert emb._unsloth_offload_hooks_installed is True
     n_pre = len(emb._forward_pre_hooks)
     n_post = len(emb._forward_hooks)
-    assert install(emb, CPU) is True
+    assert install(emb, lm, CPU) is True
     assert len(emb._forward_pre_hooks) == n_pre and len(emb._forward_hooks) == n_post
-    assert install(None, CPU) is False
+    assert install(None, lm, CPU) is False
 
 
 def test_cpu_noop_forward():
-    # cpu weight + cpu input + cpu return -> pre-hook no-op, output stays cpu.
-    emb = _fresh_emb()
-    install(emb, CPU)
-    x = torch.randint(0, 32, (2, 5))
-    out = emb(x)
+    # cpu weight + cpu decoder + cpu input -> output stays cpu.
+    emb = _emb()
+    install(emb, _lm_head(CPU), CPU)
+    out = emb(torch.randint(0, 32, (2, 5)))
     assert out.shape == (2, 5, 8)
     assert out.device.type == "cpu"
 
@@ -54,11 +59,10 @@ def test_cuda_input_roundtrip():
     if not torch.cuda.is_available():
         print("[SKIP] CUDA not available")
         return
-    # CPU weight, CUDA input -> lookup on cpu, output back on the cuda decoder.
-    emb = _fresh_emb().to("cpu")
-    install(emb, torch.device("cuda"))
-    x = torch.randint(0, 32, (2, 5), device = "cuda")
-    out = emb(x)
+    # CPU weight, CUDA decoder + input -> lookup on cpu, output back on cuda.
+    emb = _emb().to("cpu")
+    install(emb, _lm_head("cuda"), torch.device("cuda"))
+    out = emb(torch.randint(0, 32, (2, 5), device = "cuda"))
     assert out.device.type == "cuda", out.device
 
 
@@ -66,12 +70,22 @@ def test_cpu_input_still_returns_to_decoder():
     if not torch.cuda.is_available():
         print("[SKIP] CUDA not available")
         return
-    # P1: offload makes model.device cpu, so the input arrives on cpu too. The output must
-    # still reach the cuda decoder, not stay on cpu.
-    emb = _fresh_emb().to("cpu")
-    install(emb, torch.device("cuda"))
-    x = torch.randint(0, 32, (2, 5), device = "cpu")
-    out = emb(x)
+    # P1: offload makes the input arrive on cpu; the output must still reach the cuda decoder.
+    emb = _emb().to("cpu")
+    install(emb, _lm_head("cuda"), torch.device("cuda"))
+    out = emb(torch.randint(0, 32, (2, 5), device = "cpu"))
+    assert out.device.type == "cuda", out.device
+
+
+def test_live_decoder_over_stale_fallback():
+    if not torch.cuda.is_available():
+        print("[SKIP] CUDA not available")
+        return
+    # P2: fallback captured as cpu (model loaded on cpu), but the decoder later lives on cuda.
+    # The output must follow the live lm_head device, not the stale cpu fallback.
+    emb = _emb().to("cpu")
+    install(emb, _lm_head("cuda"), CPU)
+    out = emb(torch.randint(0, 32, (2, 5), device = "cuda"))
     assert out.device.type == "cuda", out.device
 
 
@@ -80,10 +94,9 @@ def test_cuda_weight_pulled_back_to_gpu():
         print("[SKIP] CUDA not available")
         return
     # bf16 weight later pulled back to gpu + cuda input -> no-op, stays on cuda.
-    emb = _fresh_emb().to("cuda")
-    install(emb, torch.device("cuda"))
-    x = torch.randint(0, 32, (2, 5), device = "cuda")
-    out = emb(x)
+    emb = _emb().to("cuda")
+    install(emb, _lm_head("cuda"), torch.device("cuda"))
+    out = emb(torch.randint(0, 32, (2, 5), device = "cuda"))
     assert out.device.type == "cuda", out.device
 
 
@@ -96,6 +109,8 @@ if __name__ == "__main__":
     print("[PASS] cuda input roundtrip")
     test_cpu_input_still_returns_to_decoder()
     print("[PASS] cpu input still returns to cuda decoder (P1)")
+    test_live_decoder_over_stale_fallback()
+    print("[PASS] live decoder device beats stale fallback (P2)")
     test_cuda_weight_pulled_back_to_gpu()
     print("[PASS] cuda weight-on-gpu no-op")
-    print("OK: offloaded embedding output always lands on the decoder device")
+    print("OK: offloaded embedding output always lands on the live decoder device")

--- a/tests/test_offload_embedding_hooks.py
+++ b/tests/test_offload_embedding_hooks.py
@@ -33,13 +33,13 @@ def test_install_and_idempotent():
     assert emb._unsloth_offload_hooks_installed is True
     n_pre = len(emb._forward_pre_hooks)
     n_post = len(emb._forward_hooks)
-    assert install(emb) is True  # idempotent
+    assert install(emb) is True
     assert len(emb._forward_pre_hooks) == n_pre and len(emb._forward_hooks) == n_post
     assert install(None) is False
 
 
 def test_cpu_noop_forward():
-    # weight on cpu, input on cpu -> pre-hook is a no-op, forward works.
+    # cpu weight + cpu input -> pre-hook no-op.
     emb = _fresh_emb()
     install(emb)
     x = torch.randint(0, 32, (2, 5))
@@ -52,7 +52,7 @@ def test_cuda_offloaded_weight_roundtrip():
     if not torch.cuda.is_available():
         print("[SKIP] CUDA not available")
         return
-    # BUG 1: weight offloaded to CPU, input on CUDA -> must not raise; output back on CUDA.
+    # BUG 1: CPU weight, CUDA input -> must not raise; output back on CUDA.
     emb = _fresh_emb().to("cpu")
     install(emb)
     x = torch.randint(0, 32, (2, 5), device = "cuda")
@@ -64,8 +64,7 @@ def test_cuda_weight_pulled_back_to_gpu():
     if not torch.cuda.is_available():
         print("[SKIP] CUDA not available")
         return
-    # BUG 2: weight on CUDA (bf16 pulled back), input on CUDA -> must be a no-op, not send
-    # the index to CPU. Hard-coded ".to('cpu')" would crash here.
+    # BUG 2: CUDA weight (bf16 pulled back) + CUDA input -> no-op (hard-coded .to('cpu') would crash).
     emb = _fresh_emb().to("cuda")
     install(emb)
     x = torch.randint(0, 32, (2, 5), device = "cuda")

--- a/tests/test_offload_embedding_hooks.py
+++ b/tests/test_offload_embedding_hooks.py
@@ -58,7 +58,6 @@ def test_cuda_offloaded_weight_roundtrip():
     x = torch.randint(0, 32, (2, 5), device = "cuda")
     out = emb(x)
     assert out.device.type == "cuda", out.device
-    assert emb._unsloth_saved_device.type == "cuda"
 
 
 def test_cuda_weight_pulled_back_to_gpu():

--- a/tests/test_offload_embedding_hooks.py
+++ b/tests/test_offload_embedding_hooks.py
@@ -1,5 +1,6 @@
-"""Tests _install_offload_embedding_hooks in vision.py: the offloaded lookup must work
-whether the weight is on CPU or (bf16) pulled back on GPU. CUDA cases skip without a GPU."""
+"""Tests _install_offload_embedding_hooks in vision.py: the offloaded lookup must work and
+its output must land on the decoder device (return_device), whatever device the input is on.
+CUDA cases skip without a GPU."""
 
 import ast, os
 import torch
@@ -21,6 +22,7 @@ def _load_installer():
 
 
 install = _load_installer()
+CPU = torch.device("cpu")
 
 
 def _fresh_emb():
@@ -29,33 +31,46 @@ def _fresh_emb():
 
 def test_install_and_idempotent():
     emb = _fresh_emb()
-    assert install(emb) is True
+    assert install(emb, CPU) is True
     assert emb._unsloth_offload_hooks_installed is True
     n_pre = len(emb._forward_pre_hooks)
     n_post = len(emb._forward_hooks)
-    assert install(emb) is True
+    assert install(emb, CPU) is True
     assert len(emb._forward_pre_hooks) == n_pre and len(emb._forward_hooks) == n_post
-    assert install(None) is False
+    assert install(None, CPU) is False
 
 
 def test_cpu_noop_forward():
-    # cpu weight + cpu input -> pre-hook no-op.
+    # cpu weight + cpu input + cpu return -> pre-hook no-op, output stays cpu.
     emb = _fresh_emb()
-    install(emb)
+    install(emb, CPU)
     x = torch.randint(0, 32, (2, 5))
     out = emb(x)
     assert out.shape == (2, 5, 8)
     assert out.device.type == "cpu"
 
 
-def test_cuda_offloaded_weight_roundtrip():
+def test_cuda_input_roundtrip():
     if not torch.cuda.is_available():
         print("[SKIP] CUDA not available")
         return
-    # BUG 1: CPU weight, CUDA input -> must not raise; output back on CUDA.
+    # CPU weight, CUDA input -> lookup on cpu, output back on the cuda decoder.
     emb = _fresh_emb().to("cpu")
-    install(emb)
+    install(emb, torch.device("cuda"))
     x = torch.randint(0, 32, (2, 5), device = "cuda")
+    out = emb(x)
+    assert out.device.type == "cuda", out.device
+
+
+def test_cpu_input_still_returns_to_decoder():
+    if not torch.cuda.is_available():
+        print("[SKIP] CUDA not available")
+        return
+    # P1: offload makes model.device cpu, so the input arrives on cpu too. The output must
+    # still reach the cuda decoder, not stay on cpu.
+    emb = _fresh_emb().to("cpu")
+    install(emb, torch.device("cuda"))
+    x = torch.randint(0, 32, (2, 5), device = "cpu")
     out = emb(x)
     assert out.device.type == "cuda", out.device
 
@@ -64,9 +79,9 @@ def test_cuda_weight_pulled_back_to_gpu():
     if not torch.cuda.is_available():
         print("[SKIP] CUDA not available")
         return
-    # BUG 2: CUDA weight (bf16 pulled back) + CUDA input -> no-op (hard-coded .to('cpu') would crash).
+    # bf16 weight later pulled back to gpu + cuda input -> no-op, stays on cuda.
     emb = _fresh_emb().to("cuda")
-    install(emb)
+    install(emb, torch.device("cuda"))
     x = torch.randint(0, 32, (2, 5), device = "cuda")
     out = emb(x)
     assert out.device.type == "cuda", out.device
@@ -77,8 +92,10 @@ if __name__ == "__main__":
     print("[PASS] install + idempotent")
     test_cpu_noop_forward()
     print("[PASS] cpu no-op forward")
-    test_cuda_offloaded_weight_roundtrip()
-    print("[PASS] cuda offloaded-weight roundtrip (bug 1)")
+    test_cuda_input_roundtrip()
+    print("[PASS] cuda input roundtrip")
+    test_cpu_input_still_returns_to_decoder()
+    print("[PASS] cpu input still returns to cuda decoder (P1)")
     test_cuda_weight_pulled_back_to_gpu()
-    print("[PASS] cuda weight-on-gpu no-op (bug 2)")
-    print("OK: offload embedding hooks are device-safe both directions")
+    print("[PASS] cuda weight-on-gpu no-op")
+    print("OK: offloaded embedding output always lands on the decoder device")

--- a/tests/test_offload_embedding_hooks.py
+++ b/tests/test_offload_embedding_hooks.py
@@ -1,0 +1,79 @@
+"""Tests _install_offload_embedding_hooks in vision.py: the offloaded lookup must work
+whether the weight is on CPU or (bf16) pulled back on GPU. CUDA cases skip without a GPU."""
+import ast, os
+import torch
+import torch.nn as nn
+
+HERE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+VISION = os.path.join(HERE, "unsloth", "models", "vision.py")
+
+
+def _load_installer():
+    src = open(VISION).read()
+    mod = ast.parse(src)
+    for node in mod.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "_install_offload_embedding_hooks":
+            ns = {"torch": torch}
+            exec(ast.get_source_segment(src, node), ns)
+            return ns["_install_offload_embedding_hooks"]
+    raise AssertionError("_install_offload_embedding_hooks not found in vision.py")
+
+
+install = _load_installer()
+
+
+def _fresh_emb():
+    return nn.Embedding(32, 8)
+
+
+def test_install_and_idempotent():
+    emb = _fresh_emb()
+    assert install(emb) is True
+    assert emb._unsloth_offload_hooks_installed is True
+    n_pre = len(emb._forward_pre_hooks)
+    n_post = len(emb._forward_hooks)
+    assert install(emb) is True  # idempotent
+    assert len(emb._forward_pre_hooks) == n_pre and len(emb._forward_hooks) == n_post
+    assert install(None) is False
+
+
+def test_cpu_noop_forward():
+    # weight on cpu, input on cpu -> pre-hook is a no-op, forward works.
+    emb = _fresh_emb()
+    install(emb)
+    x = torch.randint(0, 32, (2, 5))
+    out = emb(x)
+    assert out.shape == (2, 5, 8)
+    assert out.device.type == "cpu"
+
+
+def test_cuda_offloaded_weight_roundtrip():
+    if not torch.cuda.is_available():
+        print("[SKIP] CUDA not available"); return
+    # BUG 1: weight offloaded to CPU, input on CUDA -> must not raise; output back on CUDA.
+    emb = _fresh_emb().to("cpu")
+    install(emb)
+    x = torch.randint(0, 32, (2, 5), device="cuda")
+    out = emb(x)
+    assert out.device.type == "cuda", out.device
+    assert emb._unsloth_saved_device.type == "cuda"
+
+
+def test_cuda_weight_pulled_back_to_gpu():
+    if not torch.cuda.is_available():
+        print("[SKIP] CUDA not available"); return
+    # BUG 2: weight on CUDA (bf16 pulled back), input on CUDA -> must be a no-op, not send
+    # the index to CPU. Hard-coded ".to('cpu')" would crash here.
+    emb = _fresh_emb().to("cuda")
+    install(emb)
+    x = torch.randint(0, 32, (2, 5), device="cuda")
+    out = emb(x)
+    assert out.device.type == "cuda", out.device
+
+
+if __name__ == "__main__":
+    test_install_and_idempotent(); print("[PASS] install + idempotent")
+    test_cpu_noop_forward(); print("[PASS] cpu no-op forward")
+    test_cuda_offloaded_weight_roundtrip(); print("[PASS] cuda offloaded-weight roundtrip (bug 1)")
+    test_cuda_weight_pulled_back_to_gpu(); print("[PASS] cuda weight-on-gpu no-op (bug 2)")
+    print("OK: offload embedding hooks are device-safe both directions")

--- a/tests/test_offload_embedding_hooks.py
+++ b/tests/test_offload_embedding_hooks.py
@@ -1,5 +1,6 @@
 """Tests _install_offload_embedding_hooks in vision.py: the offloaded lookup must work
 whether the weight is on CPU or (bf16) pulled back on GPU. CUDA cases skip without a GPU."""
+
 import ast, os
 import torch
 import torch.nn as nn
@@ -49,11 +50,12 @@ def test_cpu_noop_forward():
 
 def test_cuda_offloaded_weight_roundtrip():
     if not torch.cuda.is_available():
-        print("[SKIP] CUDA not available"); return
+        print("[SKIP] CUDA not available")
+        return
     # BUG 1: weight offloaded to CPU, input on CUDA -> must not raise; output back on CUDA.
     emb = _fresh_emb().to("cpu")
     install(emb)
-    x = torch.randint(0, 32, (2, 5), device="cuda")
+    x = torch.randint(0, 32, (2, 5), device = "cuda")
     out = emb(x)
     assert out.device.type == "cuda", out.device
     assert emb._unsloth_saved_device.type == "cuda"
@@ -61,19 +63,24 @@ def test_cuda_offloaded_weight_roundtrip():
 
 def test_cuda_weight_pulled_back_to_gpu():
     if not torch.cuda.is_available():
-        print("[SKIP] CUDA not available"); return
+        print("[SKIP] CUDA not available")
+        return
     # BUG 2: weight on CUDA (bf16 pulled back), input on CUDA -> must be a no-op, not send
     # the index to CPU. Hard-coded ".to('cpu')" would crash here.
     emb = _fresh_emb().to("cuda")
     install(emb)
-    x = torch.randint(0, 32, (2, 5), device="cuda")
+    x = torch.randint(0, 32, (2, 5), device = "cuda")
     out = emb(x)
     assert out.device.type == "cuda", out.device
 
 
 if __name__ == "__main__":
-    test_install_and_idempotent(); print("[PASS] install + idempotent")
-    test_cpu_noop_forward(); print("[PASS] cpu no-op forward")
-    test_cuda_offloaded_weight_roundtrip(); print("[PASS] cuda offloaded-weight roundtrip (bug 1)")
-    test_cuda_weight_pulled_back_to_gpu(); print("[PASS] cuda weight-on-gpu no-op (bug 2)")
+    test_install_and_idempotent()
+    print("[PASS] install + idempotent")
+    test_cpu_noop_forward()
+    print("[PASS] cpu no-op forward")
+    test_cuda_offloaded_weight_roundtrip()
+    print("[PASS] cuda offloaded-weight roundtrip (bug 1)")
+    test_cuda_weight_pulled_back_to_gpu()
+    print("[PASS] cuda weight-on-gpu no-op (bug 2)")
     print("OK: offload embedding hooks are device-safe both directions")

--- a/tests/test_offload_tied_guard.py
+++ b/tests/test_offload_tied_guard.py
@@ -1,0 +1,62 @@
+"""Tests _embeddings_are_tied in vision.py: offload_embedding must detect a shared
+embed_tokens/lm_head weight so the loader can refuse to offload tied embeddings
+(offloading would strand the output projection on CPU). No GPU needed."""
+
+import ast, os
+import torch
+import torch.nn as nn
+
+HERE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+VISION = os.path.join(HERE, "unsloth", "models", "vision.py")
+
+
+def _load_fn():
+    src = open(VISION).read()
+    mod = ast.parse(src)
+    for node in mod.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "_embeddings_are_tied":
+            ns = {"torch": torch}
+            exec(ast.get_source_segment(src, node), ns)
+            return ns["_embeddings_are_tied"]
+    raise AssertionError("_embeddings_are_tied not found in vision.py")
+
+
+tied = _load_fn()
+
+
+def test_untied_separate_weights():
+    emb = nn.Embedding(32, 8)
+    lm = nn.Linear(8, 32, bias = False)
+    assert tied(emb, lm) is False
+
+
+def test_tied_shared_parameter():
+    emb = nn.Embedding(32, 8)
+    lm = nn.Linear(8, 32, bias = False)
+    lm.weight = emb.weight  # transformers-style weight tying
+    assert tied(emb, lm) is True
+
+
+def test_tied_by_storage_even_if_distinct_parameter():
+    emb = nn.Embedding(32, 8)
+    lm = nn.Linear(8, 32, bias = False)
+    lm.weight = nn.Parameter(emb.weight.detach())  # distinct Parameter, shared storage
+    assert tied(emb, lm) is True
+
+
+def test_none_output_is_untied():
+    emb = nn.Embedding(32, 8)
+    assert tied(emb, None) is False
+    assert tied(None, nn.Linear(8, 32)) is False
+
+
+if __name__ == "__main__":
+    test_untied_separate_weights()
+    print("[PASS] untied separate weights -> False")
+    test_tied_shared_parameter()
+    print("[PASS] tied shared parameter -> True")
+    test_tied_by_storage_even_if_distinct_parameter()
+    print("[PASS] tied by storage -> True")
+    test_none_output_is_untied()
+    print("[PASS] missing lm_head -> untied (safe to offload)")
+    print("OK: tied embeddings are detected so offload_embedding can refuse them")

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -253,9 +253,10 @@ def _unsloth_generate_accepts_kwarg(model, key):
     return key in model_args
 
 
-def _install_offload_embedding_hooks(embed_tokens):
-    # Run the offloaded lookup on the weight's current device, then move the output back.
-    # Device read per-call (bf16 may be pulled to GPU); origin rides the tensor (thread-safe).
+def _install_offload_embedding_hooks(embed_tokens, return_device):
+    # Offloaded lookup runs on the weight's current device (per-call, so a bf16 weight pulled
+    # back to GPU still works); output always goes to return_device (the decoder device saved
+    # before offload) so it reaches the GPU even when inputs arrive on CPU. No per-request state.
     if embed_tokens is None:
         return False
     if getattr(embed_tokens, "_unsloth_offload_hooks_installed", False):
@@ -268,18 +269,14 @@ def _install_offload_embedding_hooks(embed_tokens):
         if not hasattr(inp, "device"):
             return args
         weight = getattr(module, "weight", None)
-        target = weight.device if weight is not None else inp.device
+        target = weight.device if weight is not None else return_device
         if inp.device == target:
             return args
-        moved = inp.to(target)
-        moved._unsloth_saved_device = inp.device
-        return (moved,) + tuple(args[1:])
+        return (inp.to(target),) + tuple(args[1:])
 
     def _unsloth_offload_post_hook(module, args, output):
-        inp = args[0] if args else None
-        dev = getattr(inp, "_unsloth_saved_device", None)
-        if dev is not None and hasattr(output, "device") and output.device != dev:
-            return output.to(dev)
+        if return_device is not None and hasattr(output, "device") and output.device != return_device:
+            return output.to(return_device)
         return output
 
     embed_tokens.register_forward_pre_hook(_unsloth_offload_pre_hook, prepend = True)
@@ -1130,10 +1127,11 @@ class FastBaseModel:
                         nbytes = embed_tokens.weight.numel() * embed_tokens.weight.itemsize
                         ngb = round(nbytes / 1024 / 1024 / 1024, 2)
                         print(f"Unsloth: Offloading embeddings to RAM to save {ngb} GB.")
+                        _embed_device = embed_tokens.weight.device  # decoder device, before offload
                         embed_tokens.to("cpu")
 
                         # Device-safe embedding offload.
-                        _install_offload_embedding_hooks(embed_tokens)
+                        _install_offload_embedding_hooks(embed_tokens, _embed_device)
                         # Must free GPU memory otherwise will not free!
                         torch.cuda.empty_cache()
                         gc.collect()

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -289,6 +289,18 @@ def _install_offload_embedding_hooks(embed_tokens, return_device):
     return True
 
 
+def _embeddings_are_tied(input_embeddings, output_embeddings):
+    # Tied = lm_head shares the embedding weight; offloading it to CPU strands the
+    # output projection there (and frees no VRAM, since lm_head needs it on GPU).
+    if input_embeddings is None or output_embeddings is None:
+        return False
+    w_in = getattr(input_embeddings, "weight", None)
+    w_out = getattr(output_embeddings, "weight", None)
+    if w_in is None or w_out is None:
+        return False
+    return w_in is w_out or w_in.data_ptr() == w_out.data_ptr()
+
+
 VLLM_SUPPORTED_VLM = [
     "qwen2_5_vl",
     "gemma3",
@@ -1128,6 +1140,14 @@ class FastBaseModel:
                         pass
                     else:
                         embed_tokens = model.get_input_embeddings()
+                        out_embed = model.get_output_embeddings() if hasattr(model, "get_output_embeddings") else None
+                        if _embeddings_are_tied(embed_tokens, out_embed):
+                            raise NotImplementedError(
+                                "offload_embedding = True is not supported for models with tied word "
+                                "embeddings (embed_tokens shares its weight with lm_head). Offloading "
+                                "would strand the output projection on CPU and saves no VRAM. Set "
+                                "offload_embedding = False for this model."
+                            )
                         nbytes = embed_tokens.weight.numel() * embed_tokens.weight.itemsize
                         ngb = round(nbytes / 1024 / 1024 / 1024, 2)
                         print(f"Unsloth: Offloading embeddings to RAM to save {ngb} GB.")

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -254,9 +254,9 @@ def _unsloth_generate_accepts_kwarg(model, key):
 
 
 def _install_offload_embedding_hooks(embed_tokens, output_embeddings, return_device):
-    # Lookup runs on the weight's current device (CPU when offloaded); the output is returned
-    # to the decoder device read live from output_embeddings (lm_head, untied here) so it tracks
-    # model.to() moves. return_device is a static fallback when lm_head has no weight.
+    # Lookup runs on the weight's current device (CPU when offloaded); the output returns to the
+    # decoder device read live from output_embeddings (lm_head, untied here) so it tracks
+    # model.to() moves. A meta (disk-offloaded) or missing lm_head falls back to return_device.
     if embed_tokens is None:
         return False
     if getattr(embed_tokens, "_unsloth_offload_hooks_installed", False):
@@ -264,7 +264,9 @@ def _install_offload_embedding_hooks(embed_tokens, output_embeddings, return_dev
 
     def _decoder_device():
         weight = getattr(output_embeddings, "weight", None)
-        return weight.device if weight is not None else return_device
+        if weight is not None and weight.device.type != "meta":
+            return weight.device
+        return return_device
 
     def _unsloth_offload_pre_hook(module, args):
         if not args:

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1094,6 +1094,10 @@ class FastBaseModel:
 
         raise_handler = RaiseUninitialized()
         try:
+            if offload_embedding and fast_inference:
+                # vLLM manages its own weights; embedding offload does not apply.
+                print("Unsloth: Not offloading embeddings; incompatible with fast_inference (vLLM).")
+                offload_embedding = False
             if not fast_inference:
                 # Prevent load_in_fp8 from being forwarded into HF internal model loading
                 load_in_fp8 = kwargs.pop("load_in_fp8", None)

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -287,6 +287,7 @@ def _install_offload_embedding_hooks(embed_tokens):
     embed_tokens._unsloth_offload_hooks_installed = True
     return True
 
+
 VLLM_SUPPORTED_VLM = [
     "qwen2_5_vl",
     "gemma3",

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -376,7 +376,9 @@ def unsloth_base_fast_generate(self, *args, **kwargs):
     # Some vision processors (Transformers 5.x path) emit mm_token_type_ids that generate() then
     # rejects in _validate_model_kwargs (seen on Qwen3-VL GRPO). Unlike logits_to_keep this is an
     # incoming kwarg, so drop it when the top level generate does not accept it.
-    if "mm_token_type_ids" in kwargs and not _unsloth_generate_accepts_kwarg(self, "mm_token_type_ids"):
+    if "mm_token_type_ids" in kwargs and not _unsloth_generate_accepts_kwarg(
+        self, "mm_token_type_ids"
+    ):
         kwargs.pop("mm_token_type_ids", None)
 
     # VLMs do not allow logits_to_keep

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -257,7 +257,7 @@ def _unsloth_generate_accepts_kwarg(model, key):
 def _install_offload_embedding_hooks(embed_tokens):
     # Run the (offloaded) embedding lookup on the weight's CURRENT device, then move the
     # output back. Read at call time so a bf16 embedding pulled back to GPU by a later
-    # model.to(...) still works; origin device is saved on the module (pre-hook copies).
+    # model.to(...) still works; origin device rides on the moved tensor (thread-safe).
     if embed_tokens is None:
         return False
     if getattr(embed_tokens, "_unsloth_offload_hooks_installed", False):
@@ -269,15 +269,17 @@ def _install_offload_embedding_hooks(embed_tokens):
         inp = args[0]
         if not hasattr(inp, "device"):
             return args
-        module._unsloth_saved_device = inp.device
         weight = getattr(module, "weight", None)
         target = weight.device if weight is not None else inp.device
         if inp.device == target:
             return args
-        return (inp.to(target),) + tuple(args[1:])
+        moved = inp.to(target)
+        moved._unsloth_saved_device = inp.device
+        return (moved,) + tuple(args[1:])
 
     def _unsloth_offload_post_hook(module, args, output):
-        dev = getattr(module, "_unsloth_saved_device", None)
+        inp = args[0] if args else None
+        dev = getattr(inp, "_unsloth_saved_device", None)
         if dev is not None and hasattr(output, "device") and output.device != dev:
             return output.to(dev)
         return output

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -254,9 +254,8 @@ def _unsloth_generate_accepts_kwarg(model, key):
 
 
 def _install_offload_embedding_hooks(embed_tokens, return_device):
-    # Offloaded lookup runs on the weight's current device (per-call, so a bf16 weight pulled
-    # back to GPU still works); output always goes to return_device (the decoder device saved
-    # before offload) so it reaches the GPU even when inputs arrive on CPU. No per-request state.
+    # Lookup on the weight's current device (CPU when offloaded); output always returns to
+    # return_device (the decoder device saved before offload) so it reaches the GPU decoder.
     if embed_tokens is None:
         return False
     if getattr(embed_tokens, "_unsloth_offload_hooks_installed", False):
@@ -290,8 +289,7 @@ def _install_offload_embedding_hooks(embed_tokens, return_device):
 
 
 def _embeddings_are_tied(input_embeddings, output_embeddings):
-    # Tied = lm_head shares the embedding weight; offloading it to CPU strands the
-    # output projection there (and frees no VRAM, since lm_head needs it on GPU).
+    # Tied lm_head reuses this weight; offloading to CPU would strand the output projection.
     if input_embeddings is None or output_embeddings is None:
         return False
     w_in = getattr(input_embeddings, "weight", None)

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -373,9 +373,8 @@ def unsloth_base_fast_generate(self, *args, **kwargs):
             kwargs.pop("token_type_ids", None)
     # kwargs.pop("token_type_ids", None)
 
-    # Some vision processors (Transformers 5.x path) emit mm_token_type_ids that generate() then
-    # rejects in _validate_model_kwargs (seen on Qwen3-VL GRPO). Unlike logits_to_keep this is an
-    # incoming kwarg, so drop it when the top level generate does not accept it.
+    # Vision processors emit mm_token_type_ids that generate() rejects (Qwen3-VL); unlike
+    # logits_to_keep it is an incoming kwarg, so drop it when generate does not accept it.
     if "mm_token_type_ids" in kwargs and not _unsloth_generate_accepts_kwarg(
         self, "mm_token_type_ids"
     ):

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1140,7 +1140,11 @@ class FastBaseModel:
                         pass
                     else:
                         embed_tokens = model.get_input_embeddings()
-                        out_embed = model.get_output_embeddings() if hasattr(model, "get_output_embeddings") else None
+                        out_embed = (
+                            model.get_output_embeddings()
+                            if hasattr(model, "get_output_embeddings")
+                            else None
+                        )
                         if _embeddings_are_tied(embed_tokens, out_embed):
                             raise NotImplementedError(
                                 "offload_embedding = True is not supported for models with tied word "

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -373,6 +373,12 @@ def unsloth_base_fast_generate(self, *args, **kwargs):
             kwargs.pop("token_type_ids", None)
     # kwargs.pop("token_type_ids", None)
 
+    # Some vision processors (Transformers 5.x path) emit mm_token_type_ids that generate() then
+    # rejects in _validate_model_kwargs (seen on Qwen3-VL GRPO). Unlike logits_to_keep this is an
+    # incoming kwarg, so drop it when the top level generate does not accept it.
+    if "mm_token_type_ids" in kwargs and not _unsloth_generate_accepts_kwarg(self, "mm_token_type_ids"):
+        kwargs.pop("mm_token_type_ids", None)
+
     # VLMs do not allow logits_to_keep
     global NUM_LOGITS_TO_KEEP
     if arch not in NUM_LOGITS_TO_KEEP:

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -238,6 +238,55 @@ def _attach_bnb_multidevice_hooks(
 global NUM_LOGITS_TO_KEEP
 NUM_LOGITS_TO_KEEP = dict()
 
+
+def _unsloth_generate_accepts_kwarg(model, key):
+    # Mirror transformers _validate_model_kwargs: only inject a generate kwarg the top
+    # level accepts (gpt-oss exposes logits_to_keep on an inner forward only).
+    try:
+        model_args = set(inspect.signature(model.prepare_inputs_for_generation).parameters)
+    except (TypeError, ValueError, AttributeError):
+        model_args = set()
+    if "kwargs" in model_args or "model_kwargs" in model_args:
+        try:
+            model_args |= set(inspect.signature(model.forward).parameters)
+        except (TypeError, ValueError, AttributeError):
+            pass
+    return key in model_args
+
+
+def _install_offload_embedding_hooks(embed_tokens):
+    # Run the (offloaded) embedding lookup on the weight's CURRENT device, then move the
+    # output back. Read at call time so a bf16 embedding pulled back to GPU by a later
+    # model.to(...) still works; origin device is saved on the module (pre-hook copies).
+    if embed_tokens is None:
+        return False
+    if getattr(embed_tokens, "_unsloth_offload_hooks_installed", False):
+        return True
+
+    def _unsloth_offload_pre_hook(module, args):
+        if not args:
+            return args
+        inp = args[0]
+        if not hasattr(inp, "device"):
+            return args
+        module._unsloth_saved_device = inp.device
+        weight = getattr(module, "weight", None)
+        target = weight.device if weight is not None else inp.device
+        if inp.device == target:
+            return args
+        return (inp.to(target),) + tuple(args[1:])
+
+    def _unsloth_offload_post_hook(module, args, output):
+        dev = getattr(module, "_unsloth_saved_device", None)
+        if dev is not None and hasattr(output, "device") and output.device != dev:
+            return output.to(dev)
+        return output
+
+    embed_tokens.register_forward_pre_hook(_unsloth_offload_pre_hook, prepend = True)
+    embed_tokens.register_forward_hook(_unsloth_offload_post_hook, prepend = True)
+    embed_tokens._unsloth_offload_hooks_installed = True
+    return True
+
 VLLM_SUPPORTED_VLM = [
     "qwen2_5_vl",
     "gemma3",
@@ -339,7 +388,7 @@ def unsloth_base_fast_generate(self, *args, **kwargs):
         if arch not in NUM_LOGITS_TO_KEEP:
             NUM_LOGITS_TO_KEEP[arch] = None
     key = NUM_LOGITS_TO_KEEP[arch]
-    if key is not None and key not in kwargs:
+    if key is not None and key not in kwargs and _unsloth_generate_accepts_kwarg(self, key):
         kwargs[key] = 1
 
     model_eos_token_id = getattr(self.config, "eos_token_id", None)
@@ -1075,16 +1124,8 @@ class FastBaseModel:
                         print(f"Unsloth: Offloading embeddings to RAM to save {ngb} GB.")
                         embed_tokens.to("cpu")
 
-                        # Add hooks to move inputs to CPU and back to CUDA
-                        # [TODO] Doesn't seem to work!
-                        # def pre_hook(module, args):
-                        #     args[0]._old_device = args[0].device
-                        #     return (args[0].to("cpu", non_blocking = True))
-                        # def post_hook(module, args, output):
-                        #     old_device = getattr(args[0], "_old_device", "cuda")
-                        #     return output.to(old_device, non_blocking = True)
-                        # embed_tokens.register_forward_pre_hook(pre_hook,  prepend = True)
-                        # embed_tokens.register_forward_hook    (post_hook, prepend = True)
+                        # Device-safe embedding offload (see helper for the bf16 caveat).
+                        _install_offload_embedding_hooks(embed_tokens)
                         # Must free GPU memory otherwise will not free!
                         torch.cuda.empty_cache()
                         gc.collect()

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -240,8 +240,7 @@ NUM_LOGITS_TO_KEEP = dict()
 
 
 def _unsloth_generate_accepts_kwarg(model, key):
-    # Mirror transformers _validate_model_kwargs: only inject a generate kwarg the top
-    # level accepts (gpt-oss exposes logits_to_keep on an inner forward only).
+    # True if the top level accepts this generate kwarg (some models expose it on an inner forward only).
     try:
         model_args = set(inspect.signature(model.prepare_inputs_for_generation).parameters)
     except (TypeError, ValueError, AttributeError):
@@ -255,9 +254,8 @@ def _unsloth_generate_accepts_kwarg(model, key):
 
 
 def _install_offload_embedding_hooks(embed_tokens):
-    # Run the (offloaded) embedding lookup on the weight's CURRENT device, then move the
-    # output back. Read at call time so a bf16 embedding pulled back to GPU by a later
-    # model.to(...) still works; origin device rides on the moved tensor (thread-safe).
+    # Run the offloaded lookup on the weight's current device, then move the output back.
+    # Device read per-call (bf16 may be pulled to GPU); origin rides the tensor (thread-safe).
     if embed_tokens is None:
         return False
     if getattr(embed_tokens, "_unsloth_offload_hooks_installed", False):
@@ -1134,7 +1132,7 @@ class FastBaseModel:
                         print(f"Unsloth: Offloading embeddings to RAM to save {ngb} GB.")
                         embed_tokens.to("cpu")
 
-                        # Device-safe embedding offload (see helper for the bf16 caveat).
+                        # Device-safe embedding offload.
                         _install_offload_embedding_hooks(embed_tokens)
                         # Must free GPU memory otherwise will not free!
                         torch.cuda.empty_cache()

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -275,7 +275,11 @@ def _install_offload_embedding_hooks(embed_tokens, return_device):
         return (inp.to(target),) + tuple(args[1:])
 
     def _unsloth_offload_post_hook(module, args, output):
-        if return_device is not None and hasattr(output, "device") and output.device != return_device:
+        if (
+            return_device is not None
+            and hasattr(output, "device")
+            and output.device != return_device
+        ):
             return output.to(return_device)
         return output
 

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -253,13 +253,18 @@ def _unsloth_generate_accepts_kwarg(model, key):
     return key in model_args
 
 
-def _install_offload_embedding_hooks(embed_tokens, return_device):
-    # Lookup on the weight's current device (CPU when offloaded); output always returns to
-    # return_device (the decoder device saved before offload) so it reaches the GPU decoder.
+def _install_offload_embedding_hooks(embed_tokens, output_embeddings, return_device):
+    # Lookup runs on the weight's current device (CPU when offloaded); the output is returned
+    # to the decoder device read live from output_embeddings (lm_head, untied here) so it tracks
+    # model.to() moves. return_device is a static fallback when lm_head has no weight.
     if embed_tokens is None:
         return False
     if getattr(embed_tokens, "_unsloth_offload_hooks_installed", False):
         return True
+
+    def _decoder_device():
+        weight = getattr(output_embeddings, "weight", None)
+        return weight.device if weight is not None else return_device
 
     def _unsloth_offload_pre_hook(module, args):
         if not args:
@@ -268,18 +273,15 @@ def _install_offload_embedding_hooks(embed_tokens, return_device):
         if not hasattr(inp, "device"):
             return args
         weight = getattr(module, "weight", None)
-        target = weight.device if weight is not None else return_device
-        if inp.device == target:
+        target = weight.device if weight is not None else _decoder_device()
+        if target is None or inp.device == target:
             return args
         return (inp.to(target),) + tuple(args[1:])
 
     def _unsloth_offload_post_hook(module, args, output):
-        if (
-            return_device is not None
-            and hasattr(output, "device")
-            and output.device != return_device
-        ):
-            return output.to(return_device)
+        target = _decoder_device()
+        if target is not None and hasattr(output, "device") and output.device != target:
+            return output.to(target)
         return output
 
     embed_tokens.register_forward_pre_hook(_unsloth_offload_pre_hook, prepend = True)
@@ -1163,7 +1165,7 @@ class FastBaseModel:
                         embed_tokens.to("cpu")
 
                         # Device-safe embedding offload.
-                        _install_offload_embedding_hooks(embed_tokens, _embed_device)
+                        _install_offload_embedding_hooks(embed_tokens, out_embed, _embed_device)
                         # Must free GPU memory otherwise will not free!
                         torch.cuda.empty_cache()
                         gc.collect()

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1094,7 +1094,9 @@ class FastBaseModel:
         try:
             if offload_embedding and fast_inference:
                 # vLLM manages its own weights; embedding offload does not apply.
-                print("Unsloth: Not offloading embeddings; incompatible with fast_inference (vLLM).")
+                print(
+                    "Unsloth: Not offloading embeddings; incompatible with fast_inference (vLLM)."
+                )
                 offload_embedding = False
             if not fast_inference:
                 # Prevent load_in_fp8 from being forwarded into HF internal model loading


### PR DESCRIPTION
## What

Fixes and guards in `unsloth/models/vision.py` so `offload_embedding=True` is correct and safe across models, plus a `generate()` kwarg gate. Works on both `load_in_4bit=True` and `load_in_4bit=False`.

### 1. offload_embedding forward hooks

`offload_embedding=True` moves `embed_tokens` to CPU, but the input/output device-shuffling hooks were left commented out (`# [TODO] Doesn't seem to work!`), so an eager forward or generate with CUDA `input_ids` hit the CPU embedding:

```
RuntimeError: Expected all tensors to be on the same device ... index is on cpu, different from other tensors on cuda:0
```

The hooks are re-implemented in a small helper `_install_offload_embedding_hooks(embed_tokens, return_device)`:

- The lookup runs on the embedding weight's current device. Reading the device at call time, rather than hard-coding `"cpu"`, also covers a non-quantized (bf16) embedding that a later `model.to(...)` pulls back onto the GPU (a hard-coded `"cpu"` broke that case in the opposite direction).
- The output is always returned to `return_device`, the decoder device captured before the weight is offloaded. This is what makes it land on the GPU even when the inputs arrive on CPU (which happens once offload sets the model device to CPU). The device is passed in, not stashed on the input tensor, since the pre-hook returns a new tensor and any attribute on the original would be lost by the post-hook. No per-request state.

This mirrors the device handling in unsloth_zoo `temporary_patches/gpt_oss.py` (`embed_device = self.embed_tokens.weight.device`). With that zoo forward patch temporarily removed, gpt-oss still trains and generates on this hook alone (see Testing), so the hook is the general mechanism and the zoo patch composes with it.

### 2. generate() kwarg gate (logits_to_keep and mm_token_type_ids)

`unsloth_base_fast_generate` injected `logits_to_keep` / `num_logits_to_keep` whenever an inner submodule forward accepted it. transformers validates generate kwargs against the top-level `prepare_inputs_for_generation` (plus `forward` when it takes `**kwargs`). On the fused and PEFT-wrapped gpt-oss forward the top level does not name `logits_to_keep`, so generation raised:

```
ValueError: The following model_kwargs are not used by the model: ['logits_to_keep']
```

`_unsloth_generate_accepts_kwarg` mirrors transformers `_validate_model_kwargs`, so we only inject `logits_to_keep` when the top level accepts it, and symmetrically drop an incoming `mm_token_type_ids` (emitted by some vision processors, e.g. Qwen3-VL) when generate does not accept it. Behavior is unchanged for every model that works today, and the GRPO forward path in `rl.py` that consumes `logits_to_keep` is untouched.

### 3. Guard offload_embedding on tied embeddings and vLLM

`offload_embedding` is generic (it runs for any model, not just gpt-oss), so two cases where it cannot apply are now handled explicitly instead of silently or with a crash:

- Tied embeddings. When `embed_tokens.weight` is `lm_head.weight` (Gemma, small Llama/Qwen, and many others), moving the shared weight to CPU strands the `lm_head` output projection there, which crashes at generate (`mat2 is on cpu`) and saves no VRAM anyway. `_embeddings_are_tied` detects the shared weight and `from_pretrained` raises a clear `NotImplementedError` telling the user to set `offload_embedding=False`.
- fast_inference (vLLM). vLLM manages its own weights, so `offload_embedding` cannot apply. It is disabled with a notice, mirroring the existing WSL and Windows skips.

## Testing

Unit tests (no GPU, AST-extracted where the helper is standalone):

- `tests/test_generate_kwarg_gate.py`: gate cases for `logits_to_keep` and `mm_token_type_ids` against the transformers acceptance rules.
- `tests/test_offload_embedding_hooks.py`: installs the real helper and checks the offloaded output always lands on the decoder device, including the CPU-input direction.
- `tests/test_offload_tied_guard.py`: tie detection for a shared Parameter, shared storage with distinct Parameters, and a missing `lm_head`.

GPU runs:

- `unsloth/gpt-oss-20b`, `load_in_4bit=True, offload_embedding=True`: load, generate (low/medium/high), train, inference and save all complete with no device mismatch and no `logits_to_keep` error. `load_in_4bit=False` (BF16) validated the same way.
- `unsloth/Llama-3.1-8B-Instruct` (untied, non gpt-oss): offloads through the same generic hook, generation is coherent and matches the non-offload baseline.
- `unsloth/gemma-3n-E2B-it` (tied): refused by the guard as intended. `unsloth/gemma-4-31b-it` is tied by config and follows the same path once transformers can build it.
- `unsloth/gpt-oss-20b` with the unsloth_zoo `GptOssModel.forward` device movement removed: still trains (loss trajectory identical) and generates coherently, confirming the hook carries the offload on its own.

The GPU-free tests pass on ubuntu-latest, macos-14 and windows-latest.
