### PR TITLE
Studio RAG: disable trust_env on loopback llama-server httpx clients

### DIFF
--- a/studio/backend/core/rag/captioner.py
+++ b/studio/backend/core/rag/captioner.py
@@ -128,6 +128,8 @@ def _vision_complete(
             json = payload,
             timeout = timeout,
             headers = _vision_auth_headers(),
+            # trust_env=False: base_url is the loopback backend; skip any HTTP(S)_PROXY.
+            trust_env = False,
         )
         r.raise_for_status()
         text = r.json()["choices"][0]["message"]["content"]

--- a/studio/backend/core/rag/embed_llama_server.py
+++ b/studio/backend/core/rag/embed_llama_server.py
@@ -61,9 +61,9 @@ class LlamaServerBackend:
         self._binary: str | None = None
         # Sticky after an auto GPU start fails: later spawns stay on CPU.
         self._force_cpu = False
-        # Pooled client; requests pass full URLs, so a respawn's new port needs
-        # no rebuild.
-        self._client = httpx.Client(timeout = config.EMBED_REQUEST_TIMEOUT_S)
+        # Pooled client; requests pass full URLs, so a respawn's new port needs no
+        # rebuild. trust_env=False keeps the loopback embedder off any HTTP(S)_PROXY.
+        self._client = httpx.Client(timeout = config.EMBED_REQUEST_TIMEOUT_S, trust_env = False)
         atexit.register(self._shutdown)
 
     @property
@@ -305,7 +305,8 @@ class LlamaServerBackend:
                 logger.error("llama-server embedder exited early (code %s)", code)
                 return False
             try:
-                if httpx.get(url, timeout = 2.0).status_code == 200:
+                # trust_env=False: a proxy that 503s 127.0.0.1 must not block this probe.
+                if httpx.get(url, timeout = 2.0, trust_env = False).status_code == 200:
                     return True
             except (*_TRANSPORT_ERRORS, httpx.TimeoutException):
                 pass

--- a/studio/backend/core/rag/embed_llama_server.py
+++ b/studio/backend/core/rag/embed_llama_server.py
@@ -61,8 +61,7 @@ class LlamaServerBackend:
         self._binary: str | None = None
         # Sticky after an auto GPU start fails: later spawns stay on CPU.
         self._force_cpu = False
-        # Pooled client; requests pass full URLs, so a respawn's new port needs no
-        # rebuild. trust_env=False keeps the loopback embedder off any HTTP(S)_PROXY.
+        # Pooled client (full URLs per request survive a respawn); trust_env=False skips HTTP(S)_PROXY.
         self._client = httpx.Client(timeout = config.EMBED_REQUEST_TIMEOUT_S, trust_env = False)
         atexit.register(self._shutdown)
 

--- a/studio/backend/tests/test_rag_captioning.py
+++ b/studio/backend/tests/test_rag_captioning.py
@@ -182,7 +182,7 @@ def test_vision_complete_sends_auth_header(monkeypatch):
     )
     assert out == "ok"
     assert captured["headers"] == {"Authorization": "Bearer secret"}
-    assert captured["trust_env"] is False  # loopback backend: ignore ambient proxy
+    assert captured["trust_env"] is False
 
 
 def test_vision_complete_omits_header_when_unauthenticated(monkeypatch):
@@ -207,7 +207,7 @@ def test_vision_complete_omits_header_when_unauthenticated(monkeypatch):
     monkeypatch.setattr(httpx, "post", fake_post)
     captioner._vision_complete("http://x", "local", b"i", prompt = "p", timeout = 5.0, max_tokens = 8)
     assert captured["headers"] is None
-    assert captured["trust_env"] is False  # loopback backend: ignore ambient proxy
+    assert captured["trust_env"] is False
 
 
 def test_merge_page_captions_dedups():

--- a/studio/backend/tests/test_rag_captioning.py
+++ b/studio/backend/tests/test_rag_captioning.py
@@ -172,8 +172,8 @@ def test_vision_complete_sends_auth_header(monkeypatch):
         def json(self):
             return {"choices": [{"message": {"content": "ok"}}]}
 
-    def fake_post(url, *, json, timeout, headers):
-        captured.update(url = url, headers = headers)
+    def fake_post(url, *, json, timeout, headers, trust_env):
+        captured.update(url = url, headers = headers, trust_env = trust_env)
         return _Resp()
 
     monkeypatch.setattr(httpx, "post", fake_post)
@@ -182,6 +182,7 @@ def test_vision_complete_sends_auth_header(monkeypatch):
     )
     assert out == "ok"
     assert captured["headers"] == {"Authorization": "Bearer secret"}
+    assert captured["trust_env"] is False  # loopback backend: ignore ambient proxy
 
 
 def test_vision_complete_omits_header_when_unauthenticated(monkeypatch):
@@ -198,13 +199,15 @@ def test_vision_complete_omits_header_when_unauthenticated(monkeypatch):
         def json(self):
             return {"choices": [{"message": {"content": "ok"}}]}
 
-    def fake_post(url, *, json, timeout, headers):
+    def fake_post(url, *, json, timeout, headers, trust_env):
         captured["headers"] = headers
+        captured["trust_env"] = trust_env
         return _Resp()
 
     monkeypatch.setattr(httpx, "post", fake_post)
     captioner._vision_complete("http://x", "local", b"i", prompt = "p", timeout = 5.0, max_tokens = 8)
     assert captured["headers"] is None
+    assert captured["trust_env"] is False  # loopback backend: ignore ambient proxy
 
 
 def test_merge_page_captions_dedups():

--- a/studio/backend/tests/test_rag_loopback_trust_env.py
+++ b/studio/backend/tests/test_rag_loopback_trust_env.py
@@ -1,0 +1,54 @@
+"""AST test locking in the RAG loopback trust_env fix: every httpx client/call in the RAG
+package (all target the local 127.0.0.1 llama-server) must set trust_env=False."""
+import ast
+import os
+
+RAG_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "core", "rag")
+HTTPX_CALLEES = {"get", "post", "stream", "request", "Client", "AsyncClient"}
+
+
+def _httpx_calls(path):
+    with open(path) as f:
+        tree = ast.parse(f.read(), filename=path)
+    calls = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        # match httpx.<callee>(...)
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr in HTTPX_CALLEES
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "httpx"
+        ):
+            calls.append(node)
+    return calls
+
+
+def _sets_trust_env_false(call):
+    for kw in call.keywords:
+        if kw.arg == "trust_env" and isinstance(kw.value, ast.Constant) and kw.value.value is False:
+            return True
+    return False
+
+
+def test_rag_loopback_httpx_clients_disable_trust_env():
+    checked = 0
+    for fname in ("embed_llama_server.py", "captioner.py"):
+        path = os.path.join(RAG_DIR, fname)
+        assert os.path.exists(path), f"missing {path}"
+        calls = _httpx_calls(path)
+        assert calls, f"expected httpx calls in {fname}"
+        for call in calls:
+            checked += 1
+            assert _sets_trust_env_false(call), (
+                f"httpx.{call.func.attr} at {fname}:{call.lineno} must set trust_env=False "
+                f"(loopback llama-server client must not honor ambient HTTP(S)_PROXY)"
+            )
+    assert checked >= 3, f"expected at least 3 loopback httpx calls, found {checked}"
+
+
+if __name__ == "__main__":
+    test_rag_loopback_httpx_clients_disable_trust_env()
+    print("OK: all RAG loopback httpx clients set trust_env=False")

--- a/studio/backend/tests/test_rag_loopback_trust_env.py
+++ b/studio/backend/tests/test_rag_loopback_trust_env.py
@@ -16,7 +16,6 @@ def _httpx_calls(path):
         if not isinstance(node, ast.Call):
             continue
         func = node.func
-        # match httpx.<callee>(...)
         if (
             isinstance(func, ast.Attribute)
             and func.attr in HTTPX_CALLEES

--- a/studio/backend/tests/test_rag_loopback_trust_env.py
+++ b/studio/backend/tests/test_rag_loopback_trust_env.py
@@ -9,7 +9,7 @@ HTTPX_CALLEES = {"get", "post", "stream", "request", "Client", "AsyncClient"}
 
 
 def _httpx_calls(path):
-    with open(path) as f:
+    with open(path, encoding = "utf-8") as f:
         tree = ast.parse(f.read(), filename = path)
     calls = []
     for node in ast.walk(tree):
@@ -34,13 +34,11 @@ def _sets_trust_env_false(call):
 
 
 def test_rag_loopback_httpx_clients_disable_trust_env():
+    # Scan every .py in the package so a new file with an httpx call can't bypass this.
     checked = 0
-    for fname in ("embed_llama_server.py", "captioner.py"):
+    for fname in sorted(f for f in os.listdir(RAG_DIR) if f.endswith(".py")):
         path = os.path.join(RAG_DIR, fname)
-        assert os.path.exists(path), f"missing {path}"
-        calls = _httpx_calls(path)
-        assert calls, f"expected httpx calls in {fname}"
-        for call in calls:
+        for call in _httpx_calls(path):
             checked += 1
             assert _sets_trust_env_false(call), (
                 f"httpx.{call.func.attr} at {fname}:{call.lineno} must set trust_env=False "

--- a/studio/backend/tests/test_rag_loopback_trust_env.py
+++ b/studio/backend/tests/test_rag_loopback_trust_env.py
@@ -1,5 +1,6 @@
 """AST test locking in the RAG loopback trust_env fix: every httpx client/call in the RAG
 package (all target the local 127.0.0.1 llama-server) must set trust_env=False."""
+
 import ast
 import os
 
@@ -9,7 +10,7 @@ HTTPX_CALLEES = {"get", "post", "stream", "request", "Client", "AsyncClient"}
 
 def _httpx_calls(path):
     with open(path) as f:
-        tree = ast.parse(f.read(), filename=path)
+        tree = ast.parse(f.read(), filename = path)
     calls = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):


### PR DESCRIPTION
## What

The RAG embedder (`embed_llama_server.py`) and the vision captioner (`captioner.py`) talk to the local 127.0.0.1 llama-server over httpx with the default `trust_env=True`. An ambient `HTTP_PROXY` or `HTTPS_PROXY` that returns 503 for loopback then breaks embedder startup and captioning.

This sets `trust_env=False` on the three loopback clients:

- `embed_llama_server.py`: the pooled `httpx.Client` and the `/health` probe `httpx.get`
- `captioner.py`: the `httpx.post` to `{base_url}/v1/chat/completions`

It matches the fix already applied to the main llama_cpp and inference clients. External provider calls (OpenAI, Anthropic, Gemini, huggingface.co) are untouched, so they still honor a configured proxy.

## Testing

Added `studio/backend/tests/test_rag_loopback_trust_env.py`, an AST check asserting every httpx call in the RAG package sets `trust_env=False`. Verified against a local loopback server behind a 503 proxy: all three calls reach the server with `trust_env=False`, and fail through the proxy with `trust_env=True`. Passes on ubuntu-latest, macos-14 and windows-latest.
