### PR TITLE
Reduce comments across recent fixes

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -7457,9 +7457,8 @@ class LlamaCppBackend:
                 return False
 
             try:
-                # trust_env=False: never route the loopback health probe through
-                # an ambient HTTP(S)_PROXY. A proxy that 503s for 127.0.0.1 makes
-                # the probe loop until timeout and hangs Studio load.
+                # trust_env=False: skip ambient HTTP(S)_PROXY, which if it 503s
+                # for 127.0.0.1 loops the probe until timeout and hangs load.
                 resp = httpx.get(url, timeout = 2.0, trust_env = False)
                 if resp.status_code == 200:
                     return True

--- a/tests/python/test_change_system_message.py
+++ b/tests/python/test_change_system_message.py
@@ -7,9 +7,7 @@ import pytest
 
 
 def _load_change_system_message():
-    # Extract just _change_system_message from chat_templates.py so the test runs
-    # without importing unsloth (which needs unsloth_zoo / a GPU). Same pattern as
-    # tests/saving/test_is_gpt_oss_detection.py.
+    # Extract _change_system_message without importing unsloth (needs unsloth_zoo / a GPU).
     source = Path(__file__).parents[2] / "unsloth" / "chat_templates.py"
     tree = ast.parse(source.read_text(encoding = "utf-8"))
     funcs = [
@@ -28,12 +26,11 @@ def _load_change_system_message():
     return namespace["_change_system_message"]
 
 
-CUSTOM = "mycustom"  # not in DEFAULT_SYSTEM_MESSAGE -> no predefined default
+CUSTOM = "mycustom"  # no predefined default
 
 
 def test_custom_template_fills_placeholder():
-    # A custom template with a {system_message} placeholder must be filled, not
-    # left with the literal placeholder.
+    # A {system_message} placeholder must be filled, not left literal.
     fn = _load_change_system_message()
     template, used = fn("System: {system_message}\nUser:", CUSTOM, "You are a pirate")
     assert template == "System: You are a pirate\nUser:"
@@ -42,9 +39,8 @@ def test_custom_template_fills_placeholder():
 
 
 def test_custom_template_preserves_backslashes():
-    # Why str.replace and not re.sub: a system message with backslashes (Windows
-    # paths, LaTeX, group-like text) must be inserted verbatim. re.sub treats the
-    # replacement specially -- r"C:\Users" raises bad-escape, r"\1" is a group ref.
+    # str.replace not re.sub: re.sub treats backslashes specially (r"C:\Users"
+    # bad-escape, r"\1" group ref), so messages must be inserted verbatim.
     fn = _load_change_system_message()
     for msg in (r"C:\Users\me", r"\frac{a}{b}", r"see \1 here"):
         template, used = fn("System: {system_message}", CUSTOM, msg)
@@ -53,8 +49,7 @@ def test_custom_template_preserves_backslashes():
 
 
 def test_custom_template_requires_system_message():
-    # A custom template with a placeholder but no system message must raise,
-    # rather than silently leaving the placeholder in.
+    # A placeholder with no system message must raise, not stay literal.
     fn = _load_change_system_message()
     with pytest.raises(ValueError):
         fn("System: {system_message}", CUSTOM, None)
@@ -67,7 +62,7 @@ def test_custom_template_without_placeholder_unchanged():
 
 
 def test_predefined_template_uses_default_then_override():
-    # Predefined templates with a default are unaffected by the change.
+    # Predefined templates with a default are unaffected.
     fn = _load_change_system_message()
     t1, u1 = fn("System: {system_message}", "unsloth", None)
     assert t1 == "System: You are a helpful assistant to the user"

--- a/tests/saving/test_is_gpt_oss_detection.py
+++ b/tests/saving/test_is_gpt_oss_detection.py
@@ -4,9 +4,7 @@ from pathlib import Path
 
 
 def _load_is_gpt_oss():
-    # Extract just the helper from save.py so the test runs without importing
-    # unsloth (which requires unsloth_zoo / a GPU), matching the pattern used by
-    # test_qwen3_5_vlm_full_finetune_key_remap.py.
+    # Extract _is_gpt_oss without importing unsloth (needs unsloth_zoo / a GPU).
     source = Path(__file__).parents[2] / "unsloth" / "save.py"
     tree = ast.parse(source.read_text(encoding = "utf-8"))
     helpers = [
@@ -31,9 +29,7 @@ def _model(architectures = None, model_type = None):
 
 
 def test_detects_gpt_oss_by_architecture():
-    # config.architectures is a list, so detection must use membership, not ==.
-    # A model that declares GptOssForCausalLM but has no matching model_type must
-    # still be routed to the mxfp4 save path.
+    # architectures is a list, so detection must use membership, not ==.
     is_gpt_oss = _load_is_gpt_oss()
     assert is_gpt_oss(_model(architectures = ["GptOssForCausalLM"])) is True
     assert is_gpt_oss(_model(architectures = ["GptOssForCausalLM"], model_type = "gpt_oss")) is True

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -1807,10 +1807,8 @@ def _change_system_message(template: str, type_chat_template: str, system_messag
     # For predefined templates, check if default system message exists
     default_system_message = DEFAULT_SYSTEM_MESSAGE.get(f"{type_chat_template}", None)
 
-    # Custom templates have no predefined default, but may still carry a
-    # {system_message} placeholder. Handle it before the no-default early return
-    # below, which would otherwise leave the literal "{system_message}" in the
-    # template. A placeholder with no system message is an error, not a no-op.
+    # Custom templates have no default but may carry a {system_message} placeholder;
+    # fill it before the no-default return below. A missing message here is an error.
     if default_system_message is None and "{system_message}" in template:
         if system_message is None:
             raise ValueError("Unsloth: You need to provide a system message for custom templates.")

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -1501,12 +1501,10 @@ _PEFT_TENSOR_PARALLEL_FALLBACK_SYMBOLS = (
 
 
 def _extract_peft_tensor_parallel_imported_symbols():
-    """Return names PEFT expects from ``transformers.integrations.tensor_parallel``.
+    """Return names PEFT imports from ``transformers.integrations.tensor_parallel``.
 
-    The supported PEFT import line is the one in
-    ``peft.utils.save_and_load._maybe_shard_state_dict_for_tp`` for fast
-    LoRA adapter checkpoints. Parse that source to avoid stale hard-coded
-    symbol lists.
+    Parsed from ``peft.utils.save_and_load._maybe_shard_state_dict_for_tp`` to
+    avoid a stale hard-coded symbol list.
     """
     try:
         import peft.utils.save_and_load as _save_and_load
@@ -1564,12 +1562,11 @@ def _raise_on_peft_tensor_parallel_symbol_use(symbol_name):
 
 
 def fix_peft_transformers_tensor_parallel_import_compat():
-    """Preserve existing ``transformers.integrations.tensor_parallel`` objects, then add
-    lightweight placeholders for symbols that PEFT expects but this transformers
-    build omits.
+    """Add placeholders to ``transformers.integrations.tensor_parallel`` for symbols
+    PEFT expects but this transformers build omits, keeping existing objects.
 
-    Returns ``True`` when patched, ``False`` when no patch is needed, and
-    ``None`` when transformers / PEFT context is absent.
+    Returns ``True`` when patched, ``False`` when no patch is needed, ``None``
+    when transformers / PEFT context is absent.
     """
     try:
         tensor_parallel_spec = importlib.util.find_spec("transformers.integrations.tensor_parallel")


### PR DESCRIPTION
## Summary

Follow-up cleanup that condenses the comments and docstrings added by a handful of recently merged fixes. The goal is shorter, clearer comments: obvious lines are trimmed, verbose multi-line blocks collapse to one or two lines, and the genuinely useful rationale is kept but shortened.

This is a comments-and-whitespace-only change. No code was modified.

## What changed

- `unsloth/chat_templates.py`: shortened the custom-template placeholder note in `_change_system_message`.
- `unsloth/import_fixes.py`: trimmed the two PEFT tensor-parallel docstrings while keeping the parse-source rationale and the return-value contract.
- `tests/python/test_change_system_message.py`: condensed the extraction note and the per-test comments, keeping the shortened "str.replace not re.sub" backslash rationale.
- `tests/saving/test_is_gpt_oss_detection.py`: condensed the extraction note and the membership-check comment.
- `studio/backend/core/inference/llama_cpp.py`: shortened the `trust_env=False` health-probe comment.

## Verification

`comment_tools.py check` confirms the diff is comment-only: with docstring edits treated as comments, all 5 changed files report code unchanged (comments only). Every changed file also passes `python -m py_compile`.
