### PR TITLE
Pin llm-compressor auto-install to a vetted version range

### DIFF
--- a/tests/saving/test_llm_compressor_install_pin.py
+++ b/tests/saving/test_llm_compressor_install_pin.py
@@ -1,0 +1,88 @@
+"""Guard that the automatic first-use install of llm-compressor stays version-pinned.
+
+``install_llm_compressor()`` auto-installs llm-compressor when a user requests an FP8/FP4
+compressed export and it is not already present. A bare ``pip install llmcompressor`` would resolve
+to whatever the configured package index serves, so a compromised, dependency-confused, or
+inflated-version ("999.0.0") release could run under the Unsloth process at install/import time.
+
+These are static checks (no import, no network, no GPU), mirroring test_save_shell_injection.py:
+they keep the install command bounded to a vetted range and keep the opt-out env gate in place so
+locked-down environments can forbid the automatic install entirely.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SAVE_PY = Path(__file__).resolve().parents[2] / "unsloth" / "save.py"
+
+_ENV_FLAG = "UNSLOTH_DISABLE_LLM_COMPRESSOR_AUTOINSTALL"
+
+
+def _module() -> ast.Module:
+    return ast.parse(SAVE_PY.read_text(encoding = "utf-8"), filename = str(SAVE_PY))
+
+
+def _get_function(name: str) -> ast.FunctionDef:
+    for node in ast.walk(_module()):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"Function {name} not found in save.py")
+
+
+def _spec_value():
+    for node in ast.walk(_module()):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant):
+            if any(isinstance(t, ast.Name) and t.id == "_LLM_COMPRESSOR_SPEC" for t in node.targets):
+                return node.value.value
+    return None
+
+
+def _first_lineno(fn: ast.AST, predicate) -> int | None:
+    lines = [n.lineno for n in ast.walk(fn) if predicate(n) and hasattr(n, "lineno")]
+    return min(lines) if lines else None
+
+
+def test_spec_is_a_bounded_pin() -> None:
+    spec = _spec_value()
+    assert spec is not None, "_LLM_COMPRESSOR_SPEC must be defined at module scope"
+    assert "llmcompressor" in spec, f"spec must name llmcompressor, got {spec!r}"
+    # A lower and an upper bound: pip cannot jump to an arbitrary (e.g. inflated) future release.
+    assert ">=" in spec and "<" in spec, f"spec must have lower and upper bounds, got {spec!r}"
+
+
+def test_install_command_uses_pinned_spec_not_bare_name() -> None:
+    fn = _get_function("install_llm_compressor")
+    # No argv list may pass the bare, unpinned package literal "llmcompressor".
+    for node in ast.walk(fn):
+        if isinstance(node, ast.List):
+            for elt in node.elts:
+                if isinstance(elt, ast.Constant) and elt.value == "llmcompressor":
+                    raise AssertionError(
+                        "install command must not pass an unpinned 'llmcompressor' literal; "
+                        "use the bounded _LLM_COMPRESSOR_SPEC"
+                    )
+    names = {n.id for n in ast.walk(fn) if isinstance(n, ast.Name)}
+    assert "_LLM_COMPRESSOR_SPEC" in names, "install command must reference _LLM_COMPRESSOR_SPEC"
+
+
+def test_optout_env_gate_precedes_subprocess_install() -> None:
+    fn = _get_function("install_llm_compressor")
+    env_line = _first_lineno(fn, lambda n: isinstance(n, ast.Constant) and n.value == _ENV_FLAG)
+    assert env_line is not None, f"{_ENV_FLAG} opt-out must be checked in install_llm_compressor"
+
+    def _is_check_call(n: ast.AST) -> bool:
+        return (
+            isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Attribute)
+            and n.func.attr == "check_call"
+            and isinstance(n.func.value, ast.Name)
+            and n.func.value.id == "subprocess"
+        )
+
+    install_line = _first_lineno(fn, _is_check_call)
+    assert install_line is not None, "expected a subprocess.check_call install in the function"
+    assert env_line < install_line, (
+        "the auto-install opt-out must be evaluated before any package install runs"
+    )

--- a/tests/saving/test_llm_compressor_install_pin.py
+++ b/tests/saving/test_llm_compressor_install_pin.py
@@ -34,7 +34,9 @@ def _get_function(name: str) -> ast.FunctionDef:
 def _spec_value():
     for node in ast.walk(_module()):
         if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant):
-            if any(isinstance(t, ast.Name) and t.id == "_LLM_COMPRESSOR_SPEC" for t in node.targets):
+            if any(
+                isinstance(t, ast.Name) and t.id == "_LLM_COMPRESSOR_SPEC" for t in node.targets
+            ):
                 return node.value.value
     return None
 
@@ -83,6 +85,6 @@ def test_optout_env_gate_precedes_subprocess_install() -> None:
 
     install_line = _first_lineno(fn, _is_check_call)
     assert install_line is not None, "expected a subprocess.check_call install in the function"
-    assert env_line < install_line, (
-        "the auto-install opt-out must be evaluated before any package install runs"
-    )
+    assert (
+        env_line < install_line
+    ), "the auto-install opt-out must be evaluated before any package install runs"

--- a/tests/saving/test_llm_compressor_install_pin.py
+++ b/tests/saving/test_llm_compressor_install_pin.py
@@ -1,14 +1,6 @@
-"""Guard that the automatic first-use install of llm-compressor stays version-pinned.
-
-``install_llm_compressor()`` auto-installs llm-compressor when a user requests an FP8/FP4
-compressed export and it is not already present. A bare ``pip install llmcompressor`` would resolve
-to whatever the configured package index serves, so a compromised, dependency-confused, or
-inflated-version ("999.0.0") release could run under the Unsloth process at install/import time.
-
-These are static checks (no import, no network, no GPU), mirroring test_save_shell_injection.py:
-they keep the install command bounded to a vetted range and keep the opt-out env gate in place so
-locked-down environments can forbid the automatic install entirely.
-"""
+"""Static guards (no import/network/GPU, like test_save_shell_injection.py) that
+install_llm_compressor()'s first-use auto-install of llm-compressor stays version-pinned to a vetted
+range and keeps its opt-out env gate, so a compromised/inflated release can't be auto-pulled."""
 
 from __future__ import annotations
 
@@ -55,13 +47,7 @@ def test_spec_is_a_bounded_pin() -> None:
 
 
 def test_ceiling_blocks_inflated_versions() -> None:
-    """The ceiling must cap to a vetted minor, not just <1.0.
-
-    A bare <1.0 still admits any 0.x, so an inflated 0.999.0 served by a compromised/misconfigured
-    index would win pip's highest-version selection -- the exact dependency-confusion this pin is
-    meant to block. Assert the current-latest vetted release resolves while an inflated 0.x and the
-    next major do not.
-    """
+    """Cap to a vetted minor: a bare <1.0 admits any 0.x, so an inflated 0.999.0 could win pip."""
     from packaging.requirements import Requirement
 
     spec = Requirement(_spec_value()).specifier
@@ -71,13 +57,7 @@ def test_ceiling_blocks_inflated_versions() -> None:
 
 
 def test_floor_stays_compatible_with_supported_torch() -> None:
-    """The floor must not require a torch newer than the oldest torch Unsloth supports (>=2.4).
-
-    llm-compressor 0.7.0+ require torch>=2.7 (0.10+ >=2.9, 0.12+ >=2.10); only <=0.6.x allows
-    torch<2.7. Since install_llm_compressor() pins the current torch in the constraints file, a
-    floor above 0.6.0 leaves pip with no candidate on a supported torch 2.4-2.6 box and breaks
-    FP8/FP4 export. Keep the floor at or below 0.6.0.
-    """
+    """Floor must stay <=0.6.0: 0.7+ need torch>=2.7, but the pinned torch can be as old as 2.4."""
     from packaging.requirements import Requirement
     from packaging.version import Version
 

--- a/tests/saving/test_llm_compressor_install_pin.py
+++ b/tests/saving/test_llm_compressor_install_pin.py
@@ -54,6 +54,26 @@ def test_spec_is_a_bounded_pin() -> None:
     assert ">=" in spec and "<" in spec, f"spec must have lower and upper bounds, got {spec!r}"
 
 
+def test_floor_stays_compatible_with_supported_torch() -> None:
+    """The floor must not require a torch newer than the oldest torch Unsloth supports (>=2.4).
+
+    llm-compressor 0.7.0+ require torch>=2.7 (0.10+ >=2.9, 0.12+ >=2.10); only <=0.6.x allows
+    torch<2.7. Since install_llm_compressor() pins the current torch in the constraints file, a
+    floor above 0.6.0 leaves pip with no candidate on a supported torch 2.4-2.6 box and breaks
+    FP8/FP4 export. Keep the floor at or below 0.6.0.
+    """
+    from packaging.requirements import Requirement
+    from packaging.version import Version
+
+    req = Requirement(_spec_value())
+    lowers = [Version(s.version) for s in req.specifier if s.operator in (">=", "==", "~=")]
+    assert lowers, "spec must declare a lower bound"
+    assert max(lowers) <= Version("0.6.0"), (
+        f"floor {max(lowers)} requires a torch newer than Unsloth's minimum (2.4); "
+        "llm-compressor >0.6.0 needs torch>=2.7. Keep the floor <= 0.6.0."
+    )
+
+
 def test_install_command_uses_pinned_spec_not_bare_name() -> None:
     fn = _get_function("install_llm_compressor")
     # No argv list may pass the bare, unpinned package literal "llmcompressor".

--- a/tests/saving/test_llm_compressor_install_pin.py
+++ b/tests/saving/test_llm_compressor_install_pin.py
@@ -54,8 +54,12 @@ def test_ceiling_blocks_inflated_versions() -> None:
     assert spec.contains("0.12.0"), "the current vetted release must resolve"
     assert not spec.contains("0.999.0"), "an inflated 0.x must be blocked"
     assert not spec.contains("1.0.0"), "a new major must not be auto-installed"
-    assert not spec.contains("0.12.1"), "a higher in-range patch must be blocked (cap to the vetted patch)"
-    assert not spec.contains("0.12.999"), "a crafted higher in-range patch (e.g. on a mirror) must be blocked"
+    assert not spec.contains(
+        "0.12.1"
+    ), "a higher in-range patch must be blocked (cap to the vetted patch)"
+    assert not spec.contains(
+        "0.12.999"
+    ), "a crafted higher in-range patch (e.g. on a mirror) must be blocked"
 
 
 def test_floor_stays_compatible_with_supported_torch() -> None:

--- a/tests/saving/test_llm_compressor_install_pin.py
+++ b/tests/saving/test_llm_compressor_install_pin.py
@@ -47,13 +47,15 @@ def test_spec_is_a_bounded_pin() -> None:
 
 
 def test_ceiling_blocks_inflated_versions() -> None:
-    """Cap to a vetted minor: a bare <1.0 admits any 0.x, so an inflated 0.999.0 could win pip."""
+    """Cap to the exact vetted patch: block an inflated 0.x, a new major, and any higher in-range patch."""
     from packaging.requirements import Requirement
 
     spec = Requirement(_spec_value()).specifier
     assert spec.contains("0.12.0"), "the current vetted release must resolve"
-    assert not spec.contains("0.999.0"), "an inflated 0.x must be blocked (cap to a vetted minor)"
+    assert not spec.contains("0.999.0"), "an inflated 0.x must be blocked"
     assert not spec.contains("1.0.0"), "a new major must not be auto-installed"
+    assert not spec.contains("0.12.1"), "a higher in-range patch must be blocked (cap to the vetted patch)"
+    assert not spec.contains("0.12.999"), "a crafted higher in-range patch (e.g. on a mirror) must be blocked"
 
 
 def test_floor_stays_compatible_with_supported_torch() -> None:

--- a/tests/saving/test_llm_compressor_install_pin.py
+++ b/tests/saving/test_llm_compressor_install_pin.py
@@ -54,6 +54,22 @@ def test_spec_is_a_bounded_pin() -> None:
     assert ">=" in spec and "<" in spec, f"spec must have lower and upper bounds, got {spec!r}"
 
 
+def test_ceiling_blocks_inflated_versions() -> None:
+    """The ceiling must cap to a vetted minor, not just <1.0.
+
+    A bare <1.0 still admits any 0.x, so an inflated 0.999.0 served by a compromised/misconfigured
+    index would win pip's highest-version selection -- the exact dependency-confusion this pin is
+    meant to block. Assert the current-latest vetted release resolves while an inflated 0.x and the
+    next major do not.
+    """
+    from packaging.requirements import Requirement
+
+    spec = Requirement(_spec_value()).specifier
+    assert spec.contains("0.12.0"), "the current vetted release must resolve"
+    assert not spec.contains("0.999.0"), "an inflated 0.x must be blocked (cap to a vetted minor)"
+    assert not spec.contains("1.0.0"), "a new major must not be auto-installed"
+
+
 def test_floor_stays_compatible_with_supported_torch() -> None:
     """The floor must not require a torch newer than the oldest torch Unsloth supports (>=2.4).
 

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1367,14 +1367,20 @@ def install_python_non_blocking(packages = []):
 # bound, `pip install llmcompressor` resolves to whatever the configured index offers, so a
 # compromised, dependency-confused, or inflated-version ("999.0.0") release could be pulled and
 # executed under the Unsloth process at install/import time; the "<1.0" ceiling blocks that jump.
-# The floor keeps the oneshot / QuantizationModifier API this uses. Crucially the range still lets
-# pip pick up new 0.x releases, which is where support for brand-new architectures lands (the gate
-# below can require a newer llm-compressor for newer schemes/models) -- an exact pin would break
-# exporting new models. Bump the ceiling deliberately when llm-compressor reaches 1.0 so a new
-# major is vetted before it is auto-installed. An already-installed newer llm-compressor is used
-# as-is (the import below short-circuits), so this only constrains the auto-install, never what
-# the user installed themselves.
-_LLM_COMPRESSOR_SPEC = "llmcompressor>=0.8.0,<1.0"
+# The range still lets pip pick up new 0.x releases, which is where support for brand-new
+# architectures lands (the gate below can require a newer llm-compressor for newer schemes/models)
+# -- an exact pin would break exporting new models. Bump the ceiling deliberately when
+# llm-compressor reaches 1.0 so a new major is vetted before it is auto-installed.
+#
+# The floor is 0.6.0 (its metadata only needs torch>=1.7) so it never conflicts with the torch this
+# install pins in the constraints file below: Unsloth supports torch>=2.4, but llm-compressor
+# 0.7.0+ require torch>=2.7 (0.10+ need >=2.9, 0.12+ need >=2.10). A higher floor would leave pip
+# with no candidate on a supported torch 2.4-2.6 box and break FP8/FP4 export before quantization.
+# pip still prefers the newest compatible release, so modern torch gets the latest 0.x anyway.
+#
+# An already-installed newer llm-compressor is used as-is (the import below short-circuits), so this
+# only constrains the auto-install, never what the user installed themselves.
+_LLM_COMPRESSOR_SPEC = "llmcompressor>=0.6.0,<1.0"
 
 
 def install_llm_compressor():

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1363,24 +1363,25 @@ def install_python_non_blocking(packages = []):
     return run_installer
 
 
-# Bound the automatic first-use install of llm-compressor to its current 0.x series. Without any
-# bound, `pip install llmcompressor` resolves to whatever the configured index offers, so a
-# compromised, dependency-confused, or inflated-version ("999.0.0") release could be pulled and
-# executed under the Unsloth process at install/import time; the "<1.0" ceiling blocks that jump.
-# The range still lets pip pick up new 0.x releases, which is where support for brand-new
-# architectures lands (the gate below can require a newer llm-compressor for newer schemes/models)
-# -- an exact pin would break exporting new models. Bump the ceiling deliberately when
-# llm-compressor reaches 1.0 so a new major is vetted before it is auto-installed.
+# Bound the automatic first-use install of llm-compressor to a vetted window. Without a bound,
+# `pip install llmcompressor` resolves to whatever the configured index offers, so a compromised,
+# dependency-confused, or inflated-version release could be pulled and executed under the Unsloth
+# process at install/import time. The ceiling must cap to a vetted minor, NOT just "<1.0": every 0.x
+# version satisfies "<1.0", so an inflated "0.999.0" on a malicious/misconfigured index would still
+# win pip's highest-version selection. "<0.13" caps to the current 0.12 series and blocks that jump.
+# Bump this ceiling deliberately (after vetting) when a newer llm-compressor is needed -- e.g. for a
+# brand-new architecture whose scheme the installed build does not yet support. Current new models
+# still resolve: 0.12.0 is < 0.13 and supports them.
 #
 # The floor is 0.6.0 (its metadata only needs torch>=1.7) so it never conflicts with the torch this
 # install pins in the constraints file below: Unsloth supports torch>=2.4, but llm-compressor
 # 0.7.0+ require torch>=2.7 (0.10+ need >=2.9, 0.12+ need >=2.10). A higher floor would leave pip
 # with no candidate on a supported torch 2.4-2.6 box and break FP8/FP4 export before quantization.
-# pip still prefers the newest compatible release, so modern torch gets the latest 0.x anyway.
+# pip still prefers the newest compatible release, so modern torch gets the latest vetted 0.x anyway.
 #
 # An already-installed newer llm-compressor is used as-is (the import below short-circuits), so this
 # only constrains the auto-install, never what the user installed themselves.
-_LLM_COMPRESSOR_SPEC = "llmcompressor>=0.6.0,<1.0"
+_LLM_COMPRESSOR_SPEC = "llmcompressor>=0.6.0,<0.13"
 
 
 def install_llm_compressor():

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1363,11 +1363,24 @@ def install_python_non_blocking(packages = []):
     return run_installer
 
 
+# Version-pin the automatic first-use install of llm-compressor. Without a bound,
+# `pip install llmcompressor` resolves to whatever the configured index offers, so a compromised,
+# dependency-confused, or inflated-version ("999.0.0") release could be pulled and executed under
+# the Unsloth process at install/import time. The oneshot / QuantizationModifier API this uses is
+# stable across the 0.8-0.12 line; bump the ceiling deliberately after testing a newer series
+# rather than tracking latest automatically. An already-installed newer llm-compressor is used
+# as-is (the import below short-circuits), so this bound only constrains what gets auto-installed,
+# never what the user installed themselves.
+_LLM_COMPRESSOR_SPEC = "llmcompressor>=0.8.0,<0.13"
+
+
 def install_llm_compressor():
     """Import llm-compressor, installing it on first use for FP8/FP4 export.
 
-    Pins the current torch + transformers so pip does not upgrade them (a plain install pulls
-    transformers>=5 and breaks Unsloth). Returns (oneshot, QuantizationModifier).
+    Installs a version-pinned llm-compressor (``_LLM_COMPRESSOR_SPEC``) and pins the current torch
+    + transformers so pip does not upgrade them (a plain install pulls transformers>=5 and breaks
+    Unsloth). Set ``UNSLOTH_DISABLE_LLM_COMPRESSOR_AUTOINSTALL=1`` to forbid the automatic install
+    and require a manual, vetted install instead. Returns (oneshot, QuantizationModifier).
     """
     try:
         from llmcompressor import oneshot
@@ -1376,9 +1389,22 @@ def install_llm_compressor():
     except Exception:
         pass
 
+    # Opt-out for locked-down / air-gapped setups: never reach out to a package index
+    # automatically; require the user to install the pinned spec themselves.
+    if os.environ.get("UNSLOTH_DISABLE_LLM_COMPRESSOR_AUTOINSTALL", "0").lower() not in (
+        "0", "", "false", "no",
+    ):
+        raise RuntimeError(
+            "Unsloth: llm-compressor is required for FP8/FP4 compressed export but is not "
+            "installed, and automatic installation is disabled via "
+            "UNSLOTH_DISABLE_LLM_COMPRESSOR_AUTOINSTALL. Install it manually with:\n"
+            f"    uv pip install --python {sys.executable} '{_LLM_COMPRESSOR_SPEC}'\n"
+            "(pin torch and transformers to your current versions to avoid upgrading them)."
+        )
+
     print(
         "Unsloth: Installing llm-compressor for FP8/FP4 export "
-        "(pinning your torch + transformers so they are not upgraded). "
+        f"({_LLM_COMPRESSOR_SPEC}; pinning your torch + transformers so they are not upgraded). "
         "This can take a few minutes..."
     )
     import importlib
@@ -1401,13 +1427,13 @@ def install_llm_compressor():
     import importlib.util
 
     if importlib.util.find_spec("pip") is not None:
-        cmd = [sys.executable, "-m", "pip", "install", "llmcompressor"]
+        cmd = [sys.executable, "-m", "pip", "install", _LLM_COMPRESSOR_SPEC]
     elif shutil.which("uv") is not None:
-        cmd = ["uv", "pip", "install", "--python", sys.executable, "llmcompressor"]
+        cmd = ["uv", "pip", "install", "--python", sys.executable, _LLM_COMPRESSOR_SPEC]
     else:
         raise RuntimeError(
             "Unsloth: cannot install llm-compressor because this environment has neither pip nor "
-            f"uv. Install it manually with:\n    uv pip install --python {sys.executable} llmcompressor\n"
+            f"uv. Install it manually with:\n    uv pip install --python {sys.executable} '{_LLM_COMPRESSOR_SPEC}'\n"
             "(pin torch and transformers to your current versions to avoid upgrading them)."
         )
     cpath = None
@@ -1421,8 +1447,8 @@ def install_llm_compressor():
     except subprocess.CalledProcessError as e:
         raise RuntimeError(
             "Unsloth: Failed to install llm-compressor. Install it manually with:\n"
-            f"    uv pip install --python {sys.executable} llmcompressor\n"
-            f"or, if pip is available:\n    {sys.executable} -m pip install llmcompressor\n"
+            f"    uv pip install --python {sys.executable} '{_LLM_COMPRESSOR_SPEC}'\n"
+            f"or, if pip is available:\n    {sys.executable} -m pip install '{_LLM_COMPRESSOR_SPEC}'\n"
             "(pin torch and transformers to your current versions to avoid upgrading them).\n"
             f"Underlying error: {e}"
         )

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1363,34 +1363,18 @@ def install_python_non_blocking(packages = []):
     return run_installer
 
 
-# Bound the automatic first-use install of llm-compressor to a vetted window. Without a bound,
-# `pip install llmcompressor` resolves to whatever the configured index offers, so a compromised,
-# dependency-confused, or inflated-version release could be pulled and executed under the Unsloth
-# process at install/import time. The ceiling must cap to a vetted minor, NOT just "<1.0": every 0.x
-# version satisfies "<1.0", so an inflated "0.999.0" on a malicious/misconfigured index would still
-# win pip's highest-version selection. "<0.13" caps to the current 0.12 series and blocks that jump.
-# Bump this ceiling deliberately (after vetting) when a newer llm-compressor is needed -- e.g. for a
-# brand-new architecture whose scheme the installed build does not yet support. Current new models
-# still resolve: 0.12.0 is < 0.13 and supports them.
-#
-# The floor is 0.6.0 (its metadata only needs torch>=1.7) so it never conflicts with the torch this
-# install pins in the constraints file below: Unsloth supports torch>=2.4, but llm-compressor
-# 0.7.0+ require torch>=2.7 (0.10+ need >=2.9, 0.12+ need >=2.10). A higher floor would leave pip
-# with no candidate on a supported torch 2.4-2.6 box and break FP8/FP4 export before quantization.
-# pip still prefers the newest compatible release, so modern torch gets the latest vetted 0.x anyway.
-#
-# An already-installed newer llm-compressor is used as-is (the import below short-circuits), so this
-# only constrains the auto-install, never what the user installed themselves.
+# Bound the first-use auto-install so a compromised / inflated ("0.999.0") release can't be pulled:
+# cap to the current vetted minor (bump <0.13 deliberately after vetting a newer one). Floor 0.6.0
+# keeps torch>=2.4 boxes resolvable (llm-compressor 0.7+ need torch>=2.7; torch is pinned below).
 _LLM_COMPRESSOR_SPEC = "llmcompressor>=0.6.0,<0.13"
 
 
 def install_llm_compressor():
     """Import llm-compressor, installing it on first use for FP8/FP4 export.
 
-    Installs a version-pinned llm-compressor (``_LLM_COMPRESSOR_SPEC``) and pins the current torch
-    + transformers so pip does not upgrade them (a plain install pulls transformers>=5 and breaks
-    Unsloth). Set ``UNSLOTH_DISABLE_LLM_COMPRESSOR_AUTOINSTALL=1`` to forbid the automatic install
-    and require a manual, vetted install instead. Returns (oneshot, QuantizationModifier).
+    Installs a version-pinned llm-compressor, pinning the current torch + transformers so pip does
+    not upgrade them. Set UNSLOTH_DISABLE_LLM_COMPRESSOR_AUTOINSTALL=1 to forbid the auto-install.
+    Returns (oneshot, QuantizationModifier).
     """
     try:
         from llmcompressor import oneshot
@@ -1399,8 +1383,7 @@ def install_llm_compressor():
     except Exception:
         pass
 
-    # Opt-out for locked-down / air-gapped setups: never reach out to a package index
-    # automatically; require the user to install the pinned spec themselves.
+    # Opt-out for locked-down / air-gapped setups: forbid the auto-install, require a manual one.
     if os.environ.get("UNSLOTH_DISABLE_LLM_COMPRESSOR_AUTOINSTALL", "0").lower() not in (
         "0",
         "",

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1363,15 +1363,18 @@ def install_python_non_blocking(packages = []):
     return run_installer
 
 
-# Version-pin the automatic first-use install of llm-compressor. Without a bound,
-# `pip install llmcompressor` resolves to whatever the configured index offers, so a compromised,
-# dependency-confused, or inflated-version ("999.0.0") release could be pulled and executed under
-# the Unsloth process at install/import time. The oneshot / QuantizationModifier API this uses is
-# stable across the 0.8-0.12 line; bump the ceiling deliberately after testing a newer series
-# rather than tracking latest automatically. An already-installed newer llm-compressor is used
-# as-is (the import below short-circuits), so this bound only constrains what gets auto-installed,
-# never what the user installed themselves.
-_LLM_COMPRESSOR_SPEC = "llmcompressor>=0.8.0,<0.13"
+# Bound the automatic first-use install of llm-compressor to its current 0.x series. Without any
+# bound, `pip install llmcompressor` resolves to whatever the configured index offers, so a
+# compromised, dependency-confused, or inflated-version ("999.0.0") release could be pulled and
+# executed under the Unsloth process at install/import time; the "<1.0" ceiling blocks that jump.
+# The floor keeps the oneshot / QuantizationModifier API this uses. Crucially the range still lets
+# pip pick up new 0.x releases, which is where support for brand-new architectures lands (the gate
+# below can require a newer llm-compressor for newer schemes/models) -- an exact pin would break
+# exporting new models. Bump the ceiling deliberately when llm-compressor reaches 1.0 so a new
+# major is vetted before it is auto-installed. An already-installed newer llm-compressor is used
+# as-is (the import below short-circuits), so this only constrains the auto-install, never what
+# the user installed themselves.
+_LLM_COMPRESSOR_SPEC = "llmcompressor>=0.8.0,<1.0"
 
 
 def install_llm_compressor():

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1363,10 +1363,10 @@ def install_python_non_blocking(packages = []):
     return run_installer
 
 
-# Bound the first-use auto-install so a compromised / inflated ("0.999.0") release can't be pulled:
-# cap to the current vetted minor (bump <0.13 deliberately after vetting a newer one). Floor 0.6.0
-# keeps torch>=2.4 boxes resolvable (llm-compressor 0.7+ need torch>=2.7; torch is pinned below).
-_LLM_COMPRESSOR_SPEC = "llmcompressor>=0.6.0,<0.13"
+# Bound the first-use auto-install so no unvetted release is pulled: not an inflated "0.999.0", nor
+# a crafted higher in-range patch like "0.12.999" from a mirror. Cap to the exact vetted patch and
+# bump deliberately. Floor 0.6.0 keeps torch>=2.4 resolvable (0.7+ need torch>=2.7; torch pinned below).
+_LLM_COMPRESSOR_SPEC = "llmcompressor>=0.6.0,<=0.12.0"
 
 
 def install_llm_compressor():

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1392,7 +1392,10 @@ def install_llm_compressor():
     # Opt-out for locked-down / air-gapped setups: never reach out to a package index
     # automatically; require the user to install the pinned spec themselves.
     if os.environ.get("UNSLOTH_DISABLE_LLM_COMPRESSOR_AUTOINSTALL", "0").lower() not in (
-        "0", "", "false", "no",
+        "0",
+        "",
+        "false",
+        "no",
     ):
         raise RuntimeError(
             "Unsloth: llm-compressor is required for FP8/FP4 compressed export but is not "


### PR DESCRIPTION
## Summary

`install_llm_compressor()` in `unsloth/save.py` auto-installs llm-compressor on first use of an FP8/FP4 compressed export (`save_pretrained_merged(..., save_method="fp8"/"nvfp4"/...)`, `push_to_hub_merged(...)`) when it is not already importable. The install command passed the bare package name (`pip install llmcompressor` / `uv pip install ... llmcompressor`), so pip resolved to whatever the configured index served. A compromised, dependency-confused, or inflated-version (for example `999.0.0`) release could then execute code under the Unsloth process at install and import time. The generated constraints pinned only torch and transformers, not llmcompressor.

This was raised as a high-severity supply-chain finding.

## Fix

- Bound the automatic install to the current 0.x series: `_LLM_COMPRESSOR_SPEC = "llmcompressor>=0.8.0,<1.0"`. The `<1.0` ceiling blocks a jump to an inflated-version (`999.0.0`) or `1.0`+ dependency-confusion release, while still letting pip pick up new `0.x` releases. That last part matters: brand-new architectures (for example `Qwen3_5ForConditionalGeneration` / `qwen3_5`, gemma-4 MoE) can require a newer llm-compressor, and `_unsloth_save_compressed_tensors` already fails with "requires a newer llm-compressor" when a scheme is unavailable, so an exact pin would break exporting new models. Bump the ceiling deliberately when llm-compressor reaches 1.0 so a new major is vetted first. The bound is applied in both the pip and uv commands and in the manual-install hints.
- The initial `from llmcompressor import ...` still runs first, so an already-installed newer llm-compressor is used as-is. This bound only constrains what gets auto-installed, never what a user installed themselves, so it does not break existing setups on newer versions.
- Add `UNSLOTH_DISABLE_LLM_COMPRESSOR_AUTOINSTALL=1` to forbid the automatic install entirely and raise a clear "install it yourself with this pinned spec" error, for locked-down or air-gapped environments that do not want a save operation reaching a package index.

## Tests

- `tests/saving/test_llm_compressor_install_pin.py`: static (ast) guards, no import / network / GPU, matching `test_save_shell_injection.py`. They assert the spec stays a bounded pin (lower and upper bound), the install command never passes an unpinned `llmcompressor` literal, and the opt-out env gate is evaluated before any `subprocess.check_call` install.
- `python -m pytest tests/saving/test_llm_compressor_install_pin.py tests/saving/test_save_shell_injection.py` passes; `py_compile unsloth/save.py` clean.

## Notes

Hash / signature pinning of the full transitive tree is impractical for a runtime installer and is not attempted here; the version bound plus the opt-out address the reachable "auto-pull an arbitrary release" surface. An already-present environment is unaffected.