### PR TITLE
Studio RAG: fix RTL/Indic PDF corruption and dropped DOCX tables

### DIFF
--- a/studio/backend/core/rag/parsers.py
+++ b/studio/backend/core/rag/parsers.py
@@ -357,12 +357,14 @@ def _docx_table_rows(table) -> list[str]:
     Merged cells repeat across spanned columns, so dedup by the underlying <w:tc>."""
     rows: list[str] = []
     for row in table.rows:
-        seen: set[int] = set()
+        seen: set = set()
         cells: list[str] = []
         for cell in row.cells:
-            if id(cell._tc) in seen:
+            # ._tc is the underlying <w:tc> lxml element (hashable); merged cells repeat
+            # across spanned columns and share one _tc, so dedup on it.
+            if cell._tc in seen:
                 continue
-            seen.add(id(cell._tc))
+            seen.add(cell._tc)
             # Collapse internal newlines/whitespace so a multi-paragraph cell stays on one
             # row; keep empty cells so columns still line up across rows.
             cells.append(" ".join(cell.text.split()))

--- a/studio/backend/core/rag/parsers.py
+++ b/studio/backend/core/rag/parsers.py
@@ -354,20 +354,20 @@ def render_pdf_pages(
 
 def _docx_table_rows(table) -> list[str]:
     """Each row as pipe-joined cell text (the locator splits anchors on pipes).
-    Columns stay aligned to the layout grid (a merged cell fills its spanned slots,
+    Columns stay aligned to the layout grid (merged cells fill their spanned slots,
     skipped leading/trailing grid columns become empty fields). Cells are walked in
     document order so a nested table, and any text after it, flattens in place."""
     from docx.table import Table
     from docx.text.paragraph import Paragraph
 
     rows: list[str] = []
+    seen: set = set()  # <w:tc> already emitted; dedups merges spanning columns or rows
     for row in table.rows:
         cells: list[str] = [""] * getattr(row, "grid_cols_before", 0)
         trailing: list[str] = []  # nested rows + any post-nested text, kept in order
-        seen: set = set()
         for cell in row.cells:
-            # row.cells repeats a merged cell (shared <w:tc>) once per spanned column:
-            # emit its text once then placeholders so field counts match sibling rows.
+            # A merged cell shares one <w:tc> across the columns and rows it spans:
+            # emit its text once, then placeholders, so columns and rows stay aligned.
             if cell._tc in seen:
                 cells.append("")
                 continue

--- a/studio/backend/core/rag/parsers.py
+++ b/studio/backend/core/rag/parsers.py
@@ -354,13 +354,16 @@ def render_pdf_pages(
 
 def _docx_table_rows(table) -> list[str]:
     """Each row as pipe-joined cell text (the locator splits anchors on pipes).
-    Keeps columns aligned to the layout grid: a merged cell fills its spanned slots
-    (text once, then placeholders), skipped leading/trailing grid columns become
-    empty fields, and tables nested in a cell are flattened in place."""
+    Columns stay aligned to the layout grid (a merged cell fills its spanned slots,
+    skipped leading/trailing grid columns become empty fields). Cells are walked in
+    document order so a nested table, and any text after it, flattens in place."""
+    from docx.table import Table
+    from docx.text.paragraph import Paragraph
+
     rows: list[str] = []
     for row in table.rows:
         cells: list[str] = [""] * getattr(row, "grid_cols_before", 0)
-        nested: list = []
+        trailing: list[str] = []  # nested rows + any post-nested text, kept in order
         seen: set = set()
         for cell in row.cells:
             # row.cells repeats a merged cell (shared <w:tc>) once per spanned column:
@@ -369,14 +372,23 @@ def _docx_table_rows(table) -> list[str]:
                 cells.append("")
                 continue
             seen.add(cell._tc)
-            # Collapse in-cell newlines; keep empty cells so columns line up.
-            cells.append(" ".join(cell.text.split()))
-            nested.extend(cell.tables)  # cell.text ignores nested tables
+            # Paragraph text before the first nested table is the aligned field; the
+            # nested table and anything after it flatten below the row, in order.
+            field: list[str] = []
+            after_table = False
+            for item in cell.iter_inner_content():
+                if isinstance(item, Table):
+                    after_table = True
+                    trailing.extend(_docx_table_rows(item))
+                elif isinstance(item, Paragraph):
+                    text = " ".join(item.text.split())  # collapse in-cell newlines
+                    if text:
+                        (trailing if after_table else field).append(text)
+            cells.append(" ".join(field))  # empty cells kept so columns line up
         cells.extend([""] * getattr(row, "grid_cols_after", 0))
         if any(c.strip() for c in cells):
             rows.append(" | ".join(cells))
-        for inner in nested:
-            rows.extend(_docx_table_rows(inner))
+        rows.extend(trailing)
     return rows
 
 

--- a/studio/backend/core/rag/parsers.py
+++ b/studio/backend/core/rag/parsers.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from dataclasses import dataclass
 from html.parser import HTMLParser
 
@@ -69,6 +70,39 @@ def _html(raw: str) -> list[Page]:
     return [_page("\n".join(parser.out), 1)]
 
 
+# pymupdf4llm rebuilds text from positioned glyphs, which mangles complex-shaping
+# scripts (RTL Arabic/Hebrew emerge as shaped Presentation Forms, Indic matras drop to
+# U+FFFD) and can silently drop most of a heavy-RTL page. When Markdown trips these
+# signals we fall back to PyMuPDF's logical-order get_text(). Thresholds mirror the chat
+# extractor guard (unslothai/unsloth#5351 review).
+_SHAPED_PRESENTATION_FORMS = re.compile("[\ufb1d-\ufdff\ufe70-\ufefc]")
+_PDF_FALLBACK_MIN_BAD_GLYPHS = 5
+_PDF_FALLBACK_BAD_GLYPH_RATIO = 0.0005
+_PDF_INCOMPLETE_RATIO = 0.75
+_PDF_INCOMPLETE_MIN_LETTERS = 200
+
+
+def _markdown_corrupted(text: str) -> bool:
+    """True when pymupdf4llm's glyph reconstruction mangled the text: shaped RTL
+    Presentation Forms or U+FFFD replacements above a small floor/ratio (so a lone
+    legitimate shaped glyph does not force the fallback)."""
+    if not text:
+        return False
+    threshold = max(_PDF_FALLBACK_MIN_BAD_GLYPHS, _PDF_FALLBACK_BAD_GLYPH_RATIO * len(text))
+    shaped = len(_SHAPED_PRESENTATION_FORMS.findall(text))
+    return shaped > threshold or text.count("\ufffd") > threshold
+
+
+def _markdown_incomplete(markdown: str, plain: str) -> bool:
+    """True when ``markdown`` holds far fewer letters than the raw ``get_text`` layer -- a
+    coarse guard for heavy-RTL pages pymupdf4llm silently drops without shaped glyphs."""
+    plain_letters = sum(1 for c in plain if c.isalnum())
+    if plain_letters < _PDF_INCOMPLETE_MIN_LETTERS:
+        return False
+    markdown_letters = sum(1 for c in markdown if c.isalnum())
+    return markdown_letters < _PDF_INCOMPLETE_RATIO * plain_letters
+
+
 def _pdf_markdown(doc) -> list[str] | None:
     """Per-page layout-aware Markdown (tables, headings, lists) via pymupdf4llm; index
     i maps to page i+1. Returns None when the lib is missing, extraction fails, or the
@@ -100,9 +134,19 @@ def _pdf(path: str, want_images: bool) -> tuple[list[Page], list[ParsedImage]]:
     try:
         md = _pdf_markdown(doc) if config.PDF_MARKDOWN else None
         for i, page in enumerate(doc):
-            # Prefer layout-aware Markdown (keeps tables/headings legible for retrieval);
-            # fall back to plain text when Markdown is off, unavailable, or empty here.
-            text = (md[i] if md else "") or page.get_text("text") or ""
+            plain = page.get_text("text") or ""
+            candidate = md[i] if md else ""
+            # Prefer layout-aware Markdown (keeps tables/headings legible for retrieval),
+            # but drop to PyMuPDF's logical-order text when Markdown is off/empty or when
+            # pymupdf4llm mangled it (RTL/Indic) or dropped most of the page.
+            if (
+                candidate
+                and not _markdown_corrupted(candidate)
+                and not _markdown_incomplete(candidate, plain)
+            ):
+                text = candidate
+            else:
+                text = plain
             pages.append(_page(text, i + 1))
             if want_images:
                 for img in page.get_images(full = True):
@@ -308,12 +352,40 @@ def render_pdf_pages(
         doc.close()
 
 
+def _docx_table_rows(table) -> list[str]:
+    """Each row as pipe-joined cell text (the locator splits anchors on pipes).
+    Merged cells repeat across spanned columns, so dedup by the underlying <w:tc>."""
+    rows: list[str] = []
+    for row in table.rows:
+        seen: set[int] = set()
+        cells: list[str] = []
+        for cell in row.cells:
+            if id(cell._tc) in seen:
+                continue
+            seen.add(id(cell._tc))
+            value = cell.text.strip()
+            if value:
+                cells.append(value)
+        if cells:
+            rows.append(" | ".join(cells))
+    return rows
+
+
 def _docx(path: str) -> list[Page]:
     import docx
+    from docx.table import Table
+    from docx.text.paragraph import Paragraph
 
     document = docx.Document(path)
-    text = "\n".join(p.text for p in document.paragraphs)
-    return [_page(text, None)]
+    lines: list[str] = []
+    # Walk body content in document order: paragraphs alone drop tables entirely.
+    for block in document.iter_inner_content():
+        if isinstance(block, Paragraph):
+            if block.text.strip():
+                lines.append(block.text)
+        elif isinstance(block, Table):
+            lines.extend(_docx_table_rows(block))
+    return [_page("\n".join(lines), None)]
 
 
 def parse(path: str, *, want_images: bool = False):

--- a/studio/backend/core/rag/parsers.py
+++ b/studio/backend/core/rag/parsers.py
@@ -354,22 +354,29 @@ def render_pdf_pages(
 
 def _docx_table_rows(table) -> list[str]:
     """Each row as pipe-joined cell text (the locator splits anchors on pipes).
-    Merged cells repeat across spanned columns, so dedup by the underlying <w:tc>."""
+    Keeps columns aligned to the layout grid: a merged cell fills its spanned slots
+    (text once, then placeholders), skipped leading/trailing grid columns become
+    empty fields, and tables nested in a cell are flattened in place."""
     rows: list[str] = []
     for row in table.rows:
+        cells: list[str] = [""] * getattr(row, "grid_cols_before", 0)
+        nested: list = []
         seen: set = set()
-        cells: list[str] = []
         for cell in row.cells:
-            # ._tc is the underlying <w:tc> lxml element (hashable); merged cells repeat
-            # across spanned columns and share one _tc, so dedup on it.
+            # row.cells repeats a merged cell (shared <w:tc>) once per spanned column:
+            # emit its text once then placeholders so field counts match sibling rows.
             if cell._tc in seen:
+                cells.append("")
                 continue
             seen.add(cell._tc)
-            # Collapse internal newlines/whitespace so a multi-paragraph cell stays on one
-            # row; keep empty cells so columns still line up across rows.
+            # Collapse in-cell newlines; keep empty cells so columns line up.
             cells.append(" ".join(cell.text.split()))
-        if any(cells):
+            nested.extend(cell.tables)  # cell.text ignores nested tables
+        cells.extend([""] * getattr(row, "grid_cols_after", 0))
+        if any(c.strip() for c in cells):
             rows.append(" | ".join(cells))
+        for inner in nested:
+            rows.extend(_docx_table_rows(inner))
     return rows
 
 

--- a/studio/backend/core/rag/parsers.py
+++ b/studio/backend/core/rag/parsers.py
@@ -363,10 +363,10 @@ def _docx_table_rows(table) -> list[str]:
             if id(cell._tc) in seen:
                 continue
             seen.add(id(cell._tc))
-            value = cell.text.strip()
-            if value:
-                cells.append(value)
-        if cells:
+            # Collapse internal newlines/whitespace so a multi-paragraph cell stays on one
+            # row; keep empty cells so columns still line up across rows.
+            cells.append(" ".join(cell.text.split()))
+        if any(cells):
             rows.append(" | ".join(cells))
     return rows
 

--- a/studio/backend/tests/test_rag_parsing.py
+++ b/studio/backend/tests/test_rag_parsing.py
@@ -251,3 +251,25 @@ def test_docx_flattens_nested_table(tmp_path):
 
     text = "\n".join(p.text for p in parsers.parse(str(path)))
     assert "NESTED-A | NESTED-B" in text  # nested table flattened, not dropped
+
+
+def test_docx_nested_table_keeps_in_cell_order(tmp_path):
+    # A cell holding paragraph, nested table, paragraph must serialize in that order
+    # (cell.text alone would emit both paragraphs before the nested rows).
+    pytest.importorskip("docx")
+    import docx
+
+    from core.rag import parsers
+
+    document = docx.Document()
+    cell = document.add_table(rows = 1, cols = 1).cell(0, 0)
+    cell.text = "before"
+    nested = cell.add_table(rows = 1, cols = 2)
+    nested.cell(0, 0).text = "NESTED-A"
+    nested.cell(0, 1).text = "NESTED-B"
+    cell.add_paragraph("after")
+    path = tmp_path / "nested_order.docx"
+    document.save(str(path))
+
+    text = "\n".join(p.text for p in parsers.parse(str(path)))
+    assert text.index("before") < text.index("NESTED-A") < text.index("after")

--- a/studio/backend/tests/test_rag_parsing.py
+++ b/studio/backend/tests/test_rag_parsing.py
@@ -152,3 +152,29 @@ def test_docx_extracts_table_cells(tmp_path):
     assert all(v in text for v in ("NAME", "SCORE", "Alice", "97pts"))  # cells kept
     assert "Alice | 97pts" in text  # row cells joined
     assert text.index("Intro") < text.index("NAME") < text.index("Outro")  # order kept
+
+
+def test_docx_table_keeps_columns_and_collapses_cell_newlines(tmp_path):
+    # Empty cells are kept (so columns stay aligned across rows) and a cell's internal
+    # newlines are collapsed to spaces (so a multi-paragraph cell can't break the row).
+    pytest.importorskip("docx")
+    import docx
+
+    from core.rag import parsers
+
+    document = docx.Document()
+    table = document.add_table(rows = 2, cols = 3)
+    table.cell(0, 0).text = "A"
+    table.cell(0, 1).text = ""  # empty middle cell
+    table.cell(0, 2).text = "C"
+    multiline = table.cell(1, 0)
+    multiline.text = "line1"
+    multiline.add_paragraph("line2")  # cell now holds an internal newline
+    table.cell(1, 1).text = "mid"
+    table.cell(1, 2).text = "end"
+    path = tmp_path / "aligned.docx"
+    document.save(str(path))
+
+    text = "\n".join(p.text for p in parsers.parse(str(path)))
+    assert "A |  | C" in text  # empty cell preserved -> columns line up
+    assert "line1 line2 | mid | end" in text  # internal newline collapsed to a space

--- a/studio/backend/tests/test_rag_parsing.py
+++ b/studio/backend/tests/test_rag_parsing.py
@@ -86,3 +86,69 @@ def test_pdf_markdown_falls_back_when_lib_missing(tmp_path, monkeypatch):
     _table_pdf(pdf)
     pages = parsers.parse(str(pdf))
     assert pages and "Quarter" in pages[0].text
+
+
+def _long_text_pdf(path):
+    import pymupdf
+
+    doc = pymupdf.open()
+    page = doc.new_page()
+    body = "The quick brown fox jumps over the lazy dog. " * 12  # >200 letters
+    page.insert_textbox(pymupdf.Rect(40, 40, 550, 750), body, fontsize = 11)
+    doc.save(str(path))
+    doc.close()
+
+
+def test_pdf_markdown_corruption_falls_back_to_plain(tmp_path, monkeypatch):
+    # pymupdf4llm can emit shaped RTL Presentation Forms for Arabic/Hebrew; the parser
+    # detects that and uses PyMuPDF's logical-order text instead of the mangled Markdown.
+    from core.rag import config, parsers
+
+    monkeypatch.setattr(config, "PDF_MARKDOWN", True)
+    shaped = "".join(chr(c) for c in range(0xFE8D, 0xFEA0)) * 20  # heavy shaped forms
+    monkeypatch.setattr(parsers, "_pdf_markdown", lambda doc: [shaped] * doc.page_count)
+    pdf = tmp_path / "table.pdf"
+    _table_pdf(pdf)
+    text = "\n".join(p.text for p in parsers.parse(str(pdf)))
+    assert "Quarter" in text  # real logical-order text recovered
+    assert not parsers._markdown_corrupted(text)  # shaped garbage not carried through
+
+
+def test_pdf_markdown_incomplete_falls_back_to_plain(tmp_path, monkeypatch):
+    # If pymupdf4llm silently drops most of a page, the parser prefers the fuller raw layer.
+    from core.rag import config, parsers
+
+    monkeypatch.setattr(config, "PDF_MARKDOWN", True)
+    monkeypatch.setattr(parsers, "_pdf_markdown", lambda doc: ["x"] * doc.page_count)
+    pdf = tmp_path / "long.pdf"
+    _long_text_pdf(pdf)
+    text = "\n".join(p.text for p in parsers.parse(str(pdf)))
+    assert "quick brown fox" in text  # fuller raw layer used, not the near-empty Markdown
+
+
+def _docx_with_table(path):
+    import docx
+
+    document = docx.Document()
+    document.add_paragraph("Intro before table.")
+    table = document.add_table(rows = 2, cols = 2)
+    table.cell(0, 0).text = "NAME"
+    table.cell(0, 1).text = "SCORE"
+    table.cell(1, 0).text = "Alice"
+    table.cell(1, 1).text = "97pts"
+    document.add_paragraph("Outro after table.")
+    document.save(str(path))
+
+
+def test_docx_extracts_table_cells(tmp_path):
+    # document.paragraphs alone drops tables; the parser walks body content in order so
+    # table cells survive (pipe-joined, which the preview locator anchors on).
+    pytest.importorskip("docx")
+    from core.rag import parsers
+
+    docx_path = tmp_path / "t.docx"
+    _docx_with_table(docx_path)
+    text = "\n".join(p.text for p in parsers.parse(str(docx_path)))
+    assert all(v in text for v in ("NAME", "SCORE", "Alice", "97pts"))  # cells kept
+    assert "Alice | 97pts" in text  # row cells joined
+    assert text.index("Intro") < text.index("NAME") < text.index("Outro")  # order kept

--- a/studio/backend/tests/test_rag_parsing.py
+++ b/studio/backend/tests/test_rag_parsing.py
@@ -178,3 +178,24 @@ def test_docx_table_keeps_columns_and_collapses_cell_newlines(tmp_path):
     text = "\n".join(p.text for p in parsers.parse(str(path)))
     assert "A |  | C" in text  # empty cell preserved -> columns line up
     assert "line1 line2 | mid | end" in text  # internal newline collapsed to a space
+
+
+def test_docx_table_dedups_merged_cells(tmp_path):
+    # A horizontally merged cell repeats across the spanned columns; dedup on the shared
+    # <w:tc> so it appears once, not once per column it spans.
+    pytest.importorskip("docx")
+    import docx
+
+    from core.rag import parsers
+
+    document = docx.Document()
+    table = document.add_table(rows = 1, cols = 3)
+    table.cell(0, 0).text = "WIDE"
+    table.cell(0, 2).text = "END"
+    table.cell(0, 0).merge(table.cell(0, 1))  # span the first two columns
+    path = tmp_path / "merged.docx"
+    document.save(str(path))
+
+    text = "\n".join(p.text for p in parsers.parse(str(path)))
+    assert text.count("WIDE") == 1  # merged cell not duplicated across spanned columns
+    assert "WIDE | END" in text

--- a/studio/backend/tests/test_rag_parsing.py
+++ b/studio/backend/tests/test_rag_parsing.py
@@ -180,22 +180,74 @@ def test_docx_table_keeps_columns_and_collapses_cell_newlines(tmp_path):
     assert "line1 line2 | mid | end" in text  # internal newline collapsed to a space
 
 
-def test_docx_table_dedups_merged_cells(tmp_path):
-    # A horizontally merged cell repeats across the spanned columns; dedup on the shared
-    # <w:tc> so it appears once, not once per column it spans.
+def test_docx_table_merged_cell_keeps_grid_alignment(tmp_path):
+    # A horizontally merged cell repeats across the spanned columns: emit its text once
+    # then a placeholder, so the row keeps as many fields as its siblings (columns stay
+    # aligned) without duplicating the merged text.
     pytest.importorskip("docx")
     import docx
 
     from core.rag import parsers
 
     document = docx.Document()
-    table = document.add_table(rows = 1, cols = 3)
+    table = document.add_table(rows = 2, cols = 3)
     table.cell(0, 0).text = "WIDE"
     table.cell(0, 2).text = "END"
     table.cell(0, 0).merge(table.cell(0, 1))  # span the first two columns
+    table.cell(1, 0).text = "a"
+    table.cell(1, 1).text = "b"
+    table.cell(1, 2).text = "c"
     path = tmp_path / "merged.docx"
     document.save(str(path))
 
     text = "\n".join(p.text for p in parsers.parse(str(path)))
     assert text.count("WIDE") == 1  # merged cell not duplicated across spanned columns
-    assert "WIDE | END" in text
+    assert "WIDE |  | END" in text  # placeholder keeps 3 fields, aligned with "a | b | c"
+    assert "a | b | c" in text
+
+
+def test_docx_table_pads_omitted_grid_columns(tmp_path):
+    # A row that skips leading grid columns exposes the gap via grid_cols_before; pad it
+    # with empty fields so the value stays under the right header instead of shifting left.
+    pytest.importorskip("docx")
+    import docx
+    from docx.oxml.ns import qn
+
+    from core.rag import parsers
+
+    document = docx.Document()
+    table = document.add_table(rows = 2, cols = 3)
+    table.cell(0, 0).text = "H1"
+    table.cell(0, 1).text = "H2"
+    table.cell(0, 2).text = "H3"
+    tr = table.rows[1]._tr  # drop the first cell and mark it skipped via <w:gridBefore>
+    tr.remove(tr.tc_lst[0])
+    trPr = tr.get_or_add_trPr()
+    trPr.insert(0, trPr.makeelement(qn("w:gridBefore"), {qn("w:val"): "1"}))
+    table.rows[1].cells[0].text = "X"  # sits in column 2
+    path = tmp_path / "gap.docx"
+    document.save(str(path))
+
+    text = "\n".join(p.text for p in parsers.parse(str(path)))
+    assert " | X | " in text  # leading gap padded so X lines up under H2, not H1
+
+
+def test_docx_flattens_nested_table(tmp_path):
+    # cell.text ignores tables nested inside a cell; walk cell.tables so nested rows are
+    # not silently dropped from the indexed text.
+    pytest.importorskip("docx")
+    import docx
+
+    from core.rag import parsers
+
+    document = docx.Document()
+    outer = document.add_table(rows = 1, cols = 1).cell(0, 0)
+    outer.text = "outer"
+    nested = outer.add_table(rows = 1, cols = 2)
+    nested.cell(0, 0).text = "NESTED-A"
+    nested.cell(0, 1).text = "NESTED-B"
+    path = tmp_path / "nested.docx"
+    document.save(str(path))
+
+    text = "\n".join(p.text for p in parsers.parse(str(path)))
+    assert "NESTED-A | NESTED-B" in text  # nested table flattened, not dropped

--- a/studio/backend/tests/test_rag_parsing.py
+++ b/studio/backend/tests/test_rag_parsing.py
@@ -273,3 +273,25 @@ def test_docx_nested_table_keeps_in_cell_order(tmp_path):
 
     text = "\n".join(p.text for p in parsers.parse(str(path)))
     assert text.index("before") < text.index("NESTED-A") < text.index("after")
+
+
+def test_docx_table_vertical_merge_emitted_once(tmp_path):
+    # A vertically merged cell maps every continuation row back to the origin <w:tc>;
+    # emit it once and leave placeholders below so a row-spanning label isn't repeated.
+    pytest.importorskip("docx")
+    import docx
+
+    from core.rag import parsers
+
+    document = docx.Document()
+    table = document.add_table(rows = 3, cols = 2)
+    table.cell(0, 0).merge(table.cell(1, 0)).merge(table.cell(2, 0)).text = "SECTION"
+    table.cell(0, 1).text = "r0"
+    table.cell(1, 1).text = "r1"
+    table.cell(2, 1).text = "r2"
+    path = tmp_path / "vmerge.docx"
+    document.save(str(path))
+
+    text = "\n".join(p.text for p in parsers.parse(str(path)))
+    assert text.count("SECTION") == 1  # not repeated on each spanned row
+    assert "SECTION | r0" in text and " | r1" in text and " | r2" in text


### PR DESCRIPTION
## Background

In the #5351 review, oobabooga reported that Studio document extraction broke on RTL/Indic PDFs (Arabic, Hebrew, Hindi, Thai) and on DOCX tables. That fix targets `core/chat/document_extractor.py` (the chat attachment extractor). The RAG knowledge-base parser at `core/rag/parsers.py` is a separate module that #6693 switched to prefer `pymupdf4llm.to_markdown`, so it has the same two problems and does not benefit from the chat-side fix. This ports the equivalent guards to the RAG parser.

## Problems

1. RTL / Indic PDFs. `pymupdf4llm.to_markdown` rebuilds text from positioned glyphs, so RTL Arabic/Hebrew come back as shaped Presentation Forms and Indic combining marks drop to `U+FFFD`; it can also silently drop most of a heavy-RTL page. `_pdf` only fell back to `get_text` when the Markdown was empty, so corrupted-but-non-empty Markdown was indexed as-is.
2. DOCX tables. `_docx` used `"\n".join(p.text for p in document.paragraphs)`, and `document.paragraphs` excludes table cells, so table content was dropped entirely.

## Fix

- `_pdf`: per page, compare the Markdown candidate against PyMuPDF's logical-order `get_text()`. Use `get_text` when the Markdown is corrupted (shaped Presentation Forms `U+FB1D-FDFF`/`U+FE70-FEFC` or `U+FFFD` above a small floor/ratio) or incomplete (far fewer alphanumerics than the raw layer). Latin PDFs are unchanged and keep Markdown tables/headings.
- `_docx`: walk body content in document order with `iter_inner_content()` (python-docx is pinned at 1.2.0), emitting each table row as pipe-joined cells, deduped across merged cells. The preview locator already splits anchors on pipes.

Thresholds mirror the chat-extractor guard so behavior matches across the two paths.

## Verification

- `pytest studio/backend/tests -k rag`: 205 passed, 1 skipped.
- New tests: corrupted-Markdown fallback, incomplete-Markdown fallback, and DOCX table-cell extraction (cells present, pipe-joined, document order preserved).
- Detector unit-checks: shaped RTL flagged; logical-order Arabic and a lone shaped glyph are not; length guard only triggers on pages with >= 200 letters.
- `ruff` clean.

## Note

If oobabooga's shared `utils/pdf_text.py` lands on main, the RAG parser's local `_markdown_corrupted` / `_markdown_incomplete` can be de-duplicated against it in a follow-up. Kept local here so this change is self-contained and does not depend on an unmerged PR.
