### PR TITLE
Tool-call healing (default on) and opt-in nudging for the client-tool passthrough

### DIFF
--- a/studio/backend/core/inference/anthropic_compat.py
+++ b/studio/backend/core/inference/anthropic_compat.py
@@ -503,6 +503,7 @@ class AnthropicPassthroughEmitter:
     def enable_healing(
         self,
         allowed_tools: set,
+        tools: Optional[list] = None,
         *,
         disable_parallel_tool_use: bool = False,
     ) -> None:
@@ -514,7 +515,7 @@ class AnthropicPassthroughEmitter:
         """
         from core.inference.passthrough_healing import StreamToolCallHealer
 
-        self._healer = StreamToolCallHealer(allowed_tools)
+        self._healer = StreamToolCallHealer(allowed_tools, tools)
         self._heal_disable_parallel = disable_parallel_tool_use
 
     def start(

--- a/studio/backend/core/inference/anthropic_compat.py
+++ b/studio/backend/core/inference/anthropic_compat.py
@@ -501,7 +501,10 @@ class AnthropicPassthroughEmitter:
         self._heal_disable_parallel = False
 
     def enable_healing(
-        self, allowed_tools: set, *, disable_parallel_tool_use: bool = False
+        self,
+        allowed_tools: set,
+        *,
+        disable_parallel_tool_use: bool = False,
     ) -> None:
         """Promote text-form tool calls in streamed content to tool_use blocks.
 

--- a/studio/backend/core/inference/anthropic_compat.py
+++ b/studio/backend/core/inference/anthropic_compat.py
@@ -494,6 +494,25 @@ class AnthropicPassthroughEmitter:
         self._usage: dict = {}
         self._stop_reason: str = "end_turn"
         self._stop_sequence: Optional[str] = None
+        # Optional text-form tool-call healing (client-tool passthrough only).
+        self._healer = None
+        self._healed_tool_use = False
+        self._healed_call_count = 0
+        self._heal_disable_parallel = False
+
+    def enable_healing(
+        self, allowed_tools: set, *, disable_parallel_tool_use: bool = False
+    ) -> None:
+        """Promote text-form tool calls in streamed content to tool_use blocks.
+
+        Only calls naming a tool in ``allowed_tools`` (the client's declared
+        tools) are promoted; everything else streams as text exactly as before.
+        Never enabled for Studio's own tool loop.
+        """
+        from core.inference.passthrough_healing import StreamToolCallHealer
+
+        self._healer = StreamToolCallHealer(allowed_tools)
+        self._heal_disable_parallel = disable_parallel_tool_use
 
     def start(
         self,
@@ -542,23 +561,26 @@ class AnthropicPassthroughEmitter:
         delta = choice.get("delta") or {}
         finish_reason = choice.get("finish_reason")
 
+        # ── Structured tool calls take precedence over healing ──
+        # Grammar mode worked: flush anything the healer held (it preceded the
+        # call in the model's output) and relay verbatim from here on.
+        if delta.get("tool_calls") and self._healer is not None and not self._healer.dormant:
+            for kind, value in self._healer.structured_tool_call_seen():
+                if kind == "text" and value:
+                    events.extend(self._emit_text_delta(value))
+
         # ── Text content ──
         content = delta.get("content")
-        if content:
-            if self._current_block_type != "text":
-                if self._current_block_type is not None:
-                    events.append(self._close_current_block())
-                events.extend(self._open_text_block())
-            events.append(
-                build_anthropic_sse_event(
-                    "content_block_delta",
-                    {
-                        "type": "content_block_delta",
-                        "index": self.block_index,
-                        "delta": {"type": "text_delta", "text": content},
-                    },
-                )
-            )
+        if content and self._healer is not None and not self._healer.dormant:
+            # Route text through the healer: held/promoted portions become
+            # synthetic tool_use blocks, the rest streams as text unchanged.
+            for kind, value in self._healer.feed(content):
+                if kind == "text":
+                    events.extend(self._emit_text_delta(value))
+                else:
+                    events.extend(self._emit_healed_tool_use(value))
+        elif content:
+            events.extend(self._emit_text_delta(content))
 
         # ── Tool calls (streaming deltas) ──
         tool_calls = delta.get("tool_calls") or []
@@ -618,6 +640,17 @@ class AnthropicPassthroughEmitter:
 
     def finish(self) -> list[str]:
         events: list[str] = []
+        if self._healer is not None:
+            # Last-chance heal of any held residue (e.g. an unclosed tool block).
+            for kind, value in self._healer.finalize():
+                if kind == "text" and value:
+                    events.extend(self._emit_text_delta(value))
+                elif kind == "tool_call":
+                    events.extend(self._emit_healed_tool_use(value))
+        if self._healed_tool_use and self._stop_reason != "max_tokens":
+            # A promoted call must stop for tool use; a truncation still wins
+            # (its arguments may be incomplete).
+            self._stop_reason = "tool_use"
         if self._current_block_type is not None:
             events.append(self._close_current_block())
         events.append(
@@ -639,6 +672,72 @@ class AnthropicPassthroughEmitter:
                 {"type": "message_stop"},
             )
         )
+        return events
+
+    def _emit_text_delta(self, content: str) -> list[str]:
+        events: list[str] = []
+        if self._current_block_type != "text":
+            if self._current_block_type is not None:
+                events.append(self._close_current_block())
+            events.extend(self._open_text_block())
+        events.append(
+            build_anthropic_sse_event(
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": self.block_index,
+                    "delta": {"type": "text_delta", "text": content},
+                },
+            )
+        )
+        return events
+
+    def _emit_healed_tool_use(self, call: dict) -> list[str]:
+        # A healed call arrives complete, so its tool_use block opens, carries
+        # one input_json_delta, and closes immediately; an open text block is
+        # closed first (only the safe prefix ever streamed into it).
+        if self._heal_disable_parallel and self._healed_call_count >= 1:
+            return []
+        events: list[str] = []
+        if self._current_block_type is not None:
+            events.append(self._close_current_block())
+        function = call.get("function") or {}
+        tool_id = anthropic_tool_use_id("")
+        self.block_index += 1
+        self._current_block_type = "tool_use"
+        events.append(
+            build_anthropic_sse_event(
+                "content_block_start",
+                {
+                    "type": "content_block_start",
+                    "index": self.block_index,
+                    "content_block": {
+                        "type": "tool_use",
+                        "id": tool_id,
+                        "name": function.get("name", ""),
+                        "input": {},
+                    },
+                },
+            )
+        )
+        arguments = function.get("arguments") or ""
+        if arguments:
+            events.append(
+                build_anthropic_sse_event(
+                    "content_block_delta",
+                    {
+                        "type": "content_block_delta",
+                        "index": self.block_index,
+                        "delta": {
+                            "type": "input_json_delta",
+                            "partial_json": arguments,
+                        },
+                    },
+                )
+            )
+        events.append(self._close_current_block())
+        self._healed_tool_use = True
+        self._healed_call_count += 1
         return events
 
     def _open_text_block(self) -> list[str]:

--- a/studio/backend/core/inference/anthropic_compat.py
+++ b/studio/backend/core/inference/anthropic_compat.py
@@ -590,6 +590,16 @@ class AnthropicPassthroughEmitter:
         for tc in tool_calls:
             tc_idx = tc.get("index", 0)
             fn = tc.get("function") or {}
+            if (
+                self._heal_disable_parallel
+                and tc_idx not in self._tool_call_states
+                and (self._healed_call_count + len(self._tool_call_states)) >= 1
+            ):
+                # disable_parallel_tool_use: a healed call already consumed the
+                # single allowed slot. The caller's chunk-level cap only sees
+                # native indexes, so drop this native call (and its later
+                # argument deltas, which never allocate a state either).
+                continue
             if tc_idx not in self._tool_call_states:
                 # New tool call — close prior block, open tool_use block
                 if self._current_block_type is not None:
@@ -699,7 +709,10 @@ class AnthropicPassthroughEmitter:
         # A healed call arrives complete, so its tool_use block opens, carries
         # one input_json_delta, and closes immediately; an open text block is
         # closed first (only the safe prefix ever streamed into it).
-        if self._heal_disable_parallel and self._healed_call_count >= 1:
+        if self._heal_disable_parallel and (
+            self._healed_call_count + len(self._tool_call_states)
+        ) >= 1:
+            # Healed and native calls share the single allowed slot.
             return []
         events: list[str] = []
         if self._current_block_type is not None:

--- a/studio/backend/core/inference/anthropic_compat.py
+++ b/studio/backend/core/inference/anthropic_compat.py
@@ -709,9 +709,10 @@ class AnthropicPassthroughEmitter:
         # A healed call arrives complete, so its tool_use block opens, carries
         # one input_json_delta, and closes immediately; an open text block is
         # closed first (only the safe prefix ever streamed into it).
-        if self._heal_disable_parallel and (
-            self._healed_call_count + len(self._tool_call_states)
-        ) >= 1:
+        if (
+            self._heal_disable_parallel
+            and (self._healed_call_count + len(self._tool_call_states)) >= 1
+        ):
             # Healed and native calls share the single allowed slot.
             return []
         events: list[str] = []

--- a/studio/backend/core/inference/passthrough_healing.py
+++ b/studio/backend/core/inference/passthrough_healing.py
@@ -190,7 +190,6 @@ def _remove_spans(text: str, spans: list) -> str:
     return "".join(pieces)
 
 
-
 def heal_openai_message_events(
     msg: dict,
     allowed_tools: set,
@@ -207,9 +206,7 @@ def heal_openai_message_events(
     pos = 0
     call_count = 0
     for call, (start, end) in zip(parsed, spans):
-        promoted = _promote(
-            [call], allowed_tools, id_offset = call_count, tool_schemas = tool_schemas
-        )
+        promoted = _promote([call], allowed_tools, id_offset = call_count, tool_schemas = tool_schemas)
         if promoted:
             if content[pos:start]:
                 events.append(("text", content[pos:start]))
@@ -256,7 +253,6 @@ def _earliest_signal(buffer: str) -> int:
         if index >= 0 and (best < 0 or index < best):
             best = index
     return best
-
 
 
 def _closed_signal_span(buffer: str) -> Optional[tuple[int, int]]:

--- a/studio/backend/core/inference/passthrough_healing.py
+++ b/studio/backend/core/inference/passthrough_healing.py
@@ -341,7 +341,11 @@ def response_has_promotable_calls(data: Any, allowed_tools: set) -> bool:
         return False
     tool_calls = message.get("tool_calls")
     if tool_calls:
-        return any(
+        # ALL structured calls must be declared: the caller forwards the whole
+        # list (and a parallel cap could keep only the FIRST one), so a mixed
+        # response with a single hallucinated name could still hand the client
+        # an undeclared tool.
+        return all(
             isinstance(tc, dict)
             and isinstance(tc.get("function"), dict)
             and tc["function"].get("name") in allowed_tools

--- a/studio/backend/core/inference/passthrough_healing.py
+++ b/studio/backend/core/inference/passthrough_healing.py
@@ -45,15 +45,27 @@ _MAX_SIGNAL_LEN = max(len(s) for s in TOOL_XML_SIGNALS)
 _MAX_HOLD_CHARS = 64 * 1024
 
 
-def heal_gate(auto_heal: Optional[bool], tools: Optional[list]) -> Optional[set]:
+def heal_gate(
+    auto_heal: Optional[bool],
+    tools: Optional[list],
+    tool_choice: Any = None,
+) -> Optional[set]:
     """Return the declared client-tool name set when healing applies, else None.
 
     ``tools`` is the OpenAI-shaped list forwarded to llama-server
     (``[{"type": "function", "function": {"name": ...}}, ...]``). The name set
     doubles as the promotion allowlist so healed calls can never invent a tool
     the client did not declare.
+
+    ``tool_choice`` (OpenAI shape) constrains the allowlist so healing never
+    contradicts the request: ``"none"`` forbids tool calls outright (text-form
+    markup stays text), and a forced ``{"type": "function", "function":
+    {"name": N}}`` narrows promotion to that one function. ``"auto"`` /
+    ``"required"`` / absent keep the full declared set.
     """
     if _HEALING_DISABLED or auto_heal is False:
+        return None
+    if tool_choice == "none":
         return None
     names = set()
     for tool in tools or []:
@@ -62,6 +74,11 @@ def heal_gate(auto_heal: Optional[bool], tools: Optional[list]) -> Optional[set]
         function = tool.get("function")
         if isinstance(function, dict) and isinstance(function.get("name"), str):
             names.add(function["name"])
+    if isinstance(tool_choice, dict):
+        function = tool_choice.get("function")
+        forced = function.get("name") if isinstance(function, dict) else None
+        if isinstance(forced, str):
+            names &= {forced}
     return names or None
 
 

--- a/studio/backend/core/inference/passthrough_healing.py
+++ b/studio/backend/core/inference/passthrough_healing.py
@@ -240,23 +240,32 @@ class StreamToolCallHealer:
         return events
 
 
-def _last_assistant_text(data: Any) -> str:
-    """First-choice assistant content of a non-streaming chat response, or ''."""
+def _first_choice_message(data: Any) -> Optional[dict]:
+    """First-choice message dict of a non-streaming chat response, else None.
+
+    Upstream error bodies can carry ``"message": null`` (or no choices at all),
+    so never assume the shape: a non-dict message means "nothing to heal".
+    """
     try:
         message = data["choices"][0]["message"]
-        content = message.get("content")
-        return content if isinstance(content, str) else ""
     except (KeyError, IndexError, TypeError):
-        return ""
+        return None
+    return message if isinstance(message, dict) else None
+
+
+def _last_assistant_text(data: Any) -> str:
+    """First-choice assistant content of a non-streaming chat response, or ''."""
+    message = _first_choice_message(data)
+    content = message.get("content") if message else None
+    return content if isinstance(content, str) else ""
 
 
 def response_has_promotable_calls(data: Any, allowed_tools: set) -> bool:
     """True when a non-streaming chat response carries a usable tool call
     (structured, or text-form that healing would promote). Used to decide
     whether a nudge retry actually improved on the original response."""
-    try:
-        message = data["choices"][0]["message"]
-    except (KeyError, IndexError, TypeError):
+    message = _first_choice_message(data)
+    if not message:
         return False
     if message.get("tool_calls"):
         return True
@@ -275,11 +284,8 @@ def nudge_should_retry(data: Any, allowed_tools: Optional[set]) -> bool:
     """
     if not allowed_tools:
         return False
-    try:
-        message = data["choices"][0]["message"]
-    except (KeyError, IndexError, TypeError):
-        return False
-    if message.get("tool_calls"):
+    message = _first_choice_message(data)
+    if not message or message.get("tool_calls"):
         return False
     text = message.get("content")
     if not isinstance(text, str) or not has_tool_signal(text):

--- a/studio/backend/core/inference/passthrough_healing.py
+++ b/studio/backend/core/inference/passthrough_healing.py
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Tool-call healing for the client-tool passthrough.
+
+With server-side tools disabled (``unsloth run --disable-tools``, every
+``unsloth start`` coding agent), requests carrying the client's own ``tools``
+bypass Studio's tool loop and are relayed to/from llama-server verbatim. Small
+GGUF models often emit their tool calls as TEXT (``<tool_call>{...}</tool_call>``,
+Gemma ``<|tool_call>...``, ``<function=...>`` XML) instead of structured
+``tool_calls`` -- on the passthrough that text reaches the agent as prose and
+the turn dies. This module promotes such text back into structured calls on the
+RESPONSE side only: the upstream request body is never touched, no extra
+generation is issued, so llama-server slot/KV-cache reuse is byte-identical.
+
+Healing only ever fires when the request declared client tools, and only
+promotes calls whose function name exactly matches a declared tool. Responses
+without a tool signal, requests without tools, and Studio's own enable-tools
+loop are untouched. Per-request opt-out: ``auto_heal_tool_calls: false``.
+Process kill-switch: ``UNSLOTH_DISABLE_TOOL_CALL_HEALING=1``.
+"""
+
+import json
+import os
+from typing import Any, Optional
+
+from core.inference.tool_call_parser import TOOL_XML_SIGNALS, has_tool_signal
+from core.inference.tool_loop_controller import coerce_tool_arguments
+from core.tool_healing import parse_tool_calls_from_text, strip_tool_call_markup
+
+# Read once at import (same convention as the other UNSLOTH_* switches).
+_HEALING_DISABLED = os.environ.get("UNSLOTH_DISABLE_TOOL_CALL_HEALING", "0") == "1"
+
+_MAX_SIGNAL_LEN = max(len(s) for s in TOOL_XML_SIGNALS)
+# A suspected-but-unclosed tool block larger than this is declared a false
+# alarm and flushed, bounding memory on a model rambling XML-lookalike text.
+_MAX_HOLD_CHARS = 64 * 1024
+
+
+def heal_gate(auto_heal: Optional[bool], tools: Optional[list]) -> Optional[set]:
+    """Return the declared client-tool name set when healing applies, else None.
+
+    ``tools`` is the OpenAI-shaped list forwarded to llama-server
+    (``[{"type": "function", "function": {"name": ...}}, ...]``). The name set
+    doubles as the promotion allowlist so healed calls can never invent a tool
+    the client did not declare.
+    """
+    if _HEALING_DISABLED or auto_heal is False:
+        return None
+    names = set()
+    for tool in tools or []:
+        if not isinstance(tool, dict):
+            continue
+        function = tool.get("function")
+        if isinstance(function, dict) and isinstance(function.get("name"), str):
+            names.add(function["name"])
+    return names or None
+
+
+def _promote(calls: list, allowed_tools: set, id_offset: int = 0) -> list:
+    """Filter parsed calls to declared tools and normalize their arguments.
+
+    ``function.arguments`` leaves ``parse_tool_calls_from_text`` as whatever the
+    model wrote; OpenAI clients require a JSON-object string, so coerce through
+    the same canonical-key healing the enable-tools loop uses.
+    """
+    promoted = []
+    for call in calls:
+        function = call.get("function") if isinstance(call, dict) else None
+        name = function.get("name") if isinstance(function, dict) else None
+        if name not in allowed_tools:
+            continue
+        coerced = coerce_tool_arguments(function.get("arguments"), heal = True, tool_name = name)
+        promoted.append(
+            {
+                "id": f"call_{id_offset + len(promoted)}",
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "arguments": json.dumps(coerced.arguments, ensure_ascii = False),
+                },
+            }
+        )
+    return promoted
+
+
+def heal_openai_message(msg: dict, allowed_tools: set) -> bool:
+    """Promote text-form tool calls in a non-streaming OpenAI message. In place.
+
+    No-op (returns False) unless the message has NO structured ``tool_calls``
+    (grammar mode already worked when it does) and its content carries a tool
+    signal that parses into at least one declared tool.
+    """
+    if not isinstance(msg, dict) or msg.get("tool_calls"):
+        return False
+    content = msg.get("content")
+    if not isinstance(content, str) or not has_tool_signal(content):
+        return False
+    calls = _promote(
+        parse_tool_calls_from_text(content, allow_incomplete = False), allowed_tools
+    )
+    if not calls:
+        return False
+    msg["tool_calls"] = calls
+    # OpenAI requires content = null on a pure tool-call turn.
+    msg["content"] = strip_tool_call_markup(content, final = True) or None
+    return True
+
+
+def _earliest_signal(buffer: str) -> int:
+    best = -1
+    for signal in TOOL_XML_SIGNALS:
+        index = buffer.find(signal)
+        if index >= 0 and (best < 0 or index < best):
+            best = index
+    return best
+
+
+def _partial_signal_suffix(buffer: str) -> int:
+    """Length of the longest buffer suffix that is a proper prefix of a signal."""
+    for length in range(min(len(buffer), _MAX_SIGNAL_LEN - 1), 0, -1):
+        tail = buffer[-length:]
+        if any(signal.startswith(tail) for signal in TOOL_XML_SIGNALS):
+            return length
+    return 0
+
+
+class StreamToolCallHealer:
+    """Buffer-and-repair state machine for streamed passthrough content.
+
+    ``feed(text)`` / ``finalize()`` yield ``("text", str)`` events for content
+    to relay and ``("tool_call", dict)`` events carrying an OpenAI-shaped call
+    (string ``function.arguments``). Normal prose is forwarded immediately; only
+    a trailing partial-signal window (< max signal length) or a suspected tool
+    block is ever withheld, so streaming latency stays bounded. A false alarm
+    (the buffer can no longer become a parseable declared call) flushes the held
+    text verbatim.
+    """
+
+    def __init__(self, allowed_tools: set) -> None:
+        self._allowed = set(allowed_tools)
+        self._buffer = ""
+        self._holding = False
+        self._id_offset = 0
+        # Structured delta.tool_calls seen upstream: grammar mode already
+        # worked, so healing goes dormant and text relays verbatim.
+        self.dormant = False
+
+    @property
+    def healed(self) -> bool:
+        return self._id_offset > 0
+
+    def structured_tool_call_seen(self) -> list:
+        """Go dormant; flush anything held so no text is swallowed."""
+        self.dormant = True
+        held, self._buffer, self._holding = self._buffer, "", False
+        return [("text", held)] if held else []
+
+    def feed(self, text: str) -> list:
+        if self.dormant:
+            return [("text", text)] if text else []
+        self._buffer += text
+        return self._drain()
+
+    def _drain(self) -> list:
+        events: list = []
+        while True:
+            if not self._holding:
+                start = _earliest_signal(self._buffer)
+                if start >= 0:
+                    if start:
+                        events.append(("text", self._buffer[:start]))
+                    self._buffer = self._buffer[start:]
+                    self._holding = True
+                else:
+                    keep = _partial_signal_suffix(self._buffer)
+                    emit = self._buffer[: len(self._buffer) - keep]
+                    if emit:
+                        events.append(("text", emit))
+                    self._buffer = self._buffer[len(self._buffer) - keep :]
+                    return events
+            # HOLD: promote once at least one complete block parses.
+            parsed = parse_tool_calls_from_text(
+                self._buffer, id_offset = self._id_offset, allow_incomplete = False
+            )
+            if not parsed:
+                if len(self._buffer) > _MAX_HOLD_CHARS:
+                    events.append(("text", self._buffer))
+                    self._buffer = ""
+                    self._holding = False
+                    continue
+                return events
+            promoted = _promote(parsed, self._allowed, id_offset = self._id_offset)
+            if not promoted:
+                # Complete blocks, but none names a declared tool: false alarm.
+                # Flush the raw text so the client still sees what the model said.
+                events.append(("text", self._buffer))
+                self._buffer = ""
+                self._holding = False
+                continue
+            self._id_offset += len(promoted)
+            events.extend(("tool_call", call) for call in promoted)
+            # Drop the closed markup, keep surrounding text/partial blocks, and
+            # loop back to rescan the remainder (e.g. a second call following).
+            self._buffer = strip_tool_call_markup(self._buffer, final = False)
+            self._holding = False
+
+    def finalize(self) -> list:
+        """End of stream: last-chance heal of the residue, else flush it."""
+        if not self._buffer:
+            return []
+        residue, self._buffer = self._buffer, ""
+        holding, self._holding = self._holding, False
+        if self.dormant or not holding:
+            return [("text", residue)]
+        promoted = _promote(
+            parse_tool_calls_from_text(
+                residue, id_offset = self._id_offset, allow_incomplete = True
+            ),
+            self._allowed,
+            id_offset = self._id_offset,
+        )
+        if not promoted:
+            return [("text", residue)]
+        self._id_offset += len(promoted)
+        events = [("tool_call", call) for call in promoted]
+        remainder = strip_tool_call_markup(residue, final = True)
+        if remainder:
+            events.append(("text", remainder))
+        return events
+
+
+def _last_assistant_text(data: Any) -> str:
+    """First-choice assistant content of a non-streaming chat response, or ''."""
+    try:
+        message = data["choices"][0]["message"]
+        content = message.get("content")
+        return content if isinstance(content, str) else ""
+    except (KeyError, IndexError, TypeError):
+        return ""
+
+
+def nudge_should_retry(data: Any, allowed_tools: Optional[set]) -> bool:
+    """True when the first response tried to call a tool but nothing healed.
+
+    Trigger only on: healing enabled (allowed_tools set), zero structured
+    calls, a tool signal present in the text, and zero promotable calls -- the
+    exact failure a single re-ask can fix. Clean prose never retries.
+    """
+    if not allowed_tools:
+        return False
+    try:
+        message = data["choices"][0]["message"]
+    except (KeyError, IndexError, TypeError):
+        return False
+    if message.get("tool_calls"):
+        return False
+    text = message.get("content")
+    if not isinstance(text, str) or not has_tool_signal(text):
+        return False
+    return not _promote(
+        parse_tool_calls_from_text(text, allow_incomplete = True), allowed_tools
+    )
+
+
+def nudge_messages(data: Any, allowed_tools: set) -> list:
+    """The two-message suffix appended for the single nudge retry.
+
+    The retry body is the original body plus this suffix, so the prompt prefix
+    is byte-identical and llama-server's slot/prefix cache is reused (same
+    shape as the enable-tools loop's reprompt).
+    """
+    tool_hint = " or ".join(f"`{name}`" for name in sorted(allowed_tools)) or "an available tool"
+    return [
+        {"role": "assistant", "content": _last_assistant_text(data)},
+        {
+            "role": "user",
+            "content": (
+                "You have access to the declared tools. If a tool is needed to "
+                f"complete the action you described, call {tool_hint} now using the "
+                "native tool-call format with valid JSON arguments, not prose. If no "
+                "tool is needed, provide the final answer directly."
+            ),
+        },
+    ]

--- a/studio/backend/core/inference/passthrough_healing.py
+++ b/studio/backend/core/inference/passthrough_healing.py
@@ -14,7 +14,11 @@ RESPONSE side only: the upstream request body is never touched, no extra
 generation is issued, so llama-server slot/KV-cache reuse is byte-identical.
 
 Healing only ever fires when the request declared client tools, and only
-promotes calls whose function name exactly matches a declared tool. Responses
+promotes calls whose function name exactly matches a declared tool. Promotion
+is all-or-nothing per parse: if a response mixes a declared call with an
+undeclared (or unparseable-name) one, nothing is promoted and the text relays
+verbatim -- stripping the promoted markup would otherwise silently delete the
+undeclared call's text, which must reach the client as prose. Responses
 without a tool signal, requests without tools, and Studio's own enable-tools
 loop are untouched. Per-request opt-out: ``auto_heal_tool_calls: false``.
 Process kill-switch: ``UNSLOTH_DISABLE_TOOL_CALL_HEALING=1``.
@@ -118,7 +122,9 @@ def heal_openai_message(msg: dict, allowed_tools: set) -> bool:
 
     No-op (returns False) unless the message has NO structured ``tool_calls``
     (grammar mode already worked when it does) and its content carries a tool
-    signal that parses into at least one declared tool.
+    signal where EVERY parsed call names a declared tool. All-or-nothing:
+    ``strip_tool_call_markup`` removes every tool block, so promoting a subset
+    would silently delete the unpromoted calls' text.
     """
     if not isinstance(msg, dict) or msg.get("tool_calls"):
         return False
@@ -127,8 +133,9 @@ def heal_openai_message(msg: dict, allowed_tools: set) -> bool:
         return False
     # allow_incomplete: the response is final, so a trailing unclosed block is a
     # model failure worth repairing (same as the enable-tools loop at drain).
-    calls = _promote(parse_tool_calls_from_text(content, allow_incomplete = True), allowed_tools)
-    if not calls:
+    parsed = parse_tool_calls_from_text(content, allow_incomplete = True)
+    calls = _promote(parsed, allowed_tools)
+    if not calls or len(calls) != len(parsed):
         return False
     msg["tool_calls"] = calls
     # OpenAI requires content = null on a pure tool-call turn.
@@ -220,9 +227,12 @@ class StreamToolCallHealer:
                     continue
                 return events
             promoted = _promote(parsed, self._allowed, id_offset = self._id_offset)
-            if not promoted:
-                # Complete blocks, but none names a declared tool: false alarm.
-                # Flush the raw text so the client still sees what the model said.
+            if len(promoted) != len(parsed):
+                # At least one complete block names an undeclared tool (or has
+                # no usable name): false alarm for the WHOLE buffer. Stripping
+                # only the declared markup is impossible (the strip helper
+                # removes every block), so flush the raw text -- the client
+                # must still see what the model said.
                 events.append(("text", self._buffer))
                 self._buffer = ""
                 self._holding = False
@@ -242,12 +252,11 @@ class StreamToolCallHealer:
         holding, self._holding = self._holding, False
         if self.dormant or not holding:
             return [("text", residue)]
-        promoted = _promote(
-            parse_tool_calls_from_text(residue, id_offset = self._id_offset, allow_incomplete = True),
-            self._allowed,
-            id_offset = self._id_offset,
+        parsed = parse_tool_calls_from_text(
+            residue, id_offset = self._id_offset, allow_incomplete = True
         )
-        if not promoted:
+        promoted = _promote(parsed, self._allowed, id_offset = self._id_offset)
+        if not promoted or len(promoted) != len(parsed):
             return [("text", residue)]
         self._id_offset += len(promoted)
         events = [("tool_call", call) for call in promoted]
@@ -277,6 +286,13 @@ def _last_assistant_text(data: Any) -> str:
     return content if isinstance(content, str) else ""
 
 
+def _heal_would_promote(text: str, allowed_tools: set) -> bool:
+    """Whether ``heal_openai_message`` would promote this text (all-or-nothing)."""
+    parsed = parse_tool_calls_from_text(text, allow_incomplete = True)
+    promoted = _promote(parsed, allowed_tools)
+    return bool(promoted) and len(promoted) == len(parsed)
+
+
 def response_has_promotable_calls(data: Any, allowed_tools: set) -> bool:
     """True when a non-streaming chat response carries a usable tool call
     (structured, or text-form that healing would promote). Used to decide
@@ -289,7 +305,7 @@ def response_has_promotable_calls(data: Any, allowed_tools: set) -> bool:
     text = message.get("content")
     if not isinstance(text, str):
         return False
-    return bool(_promote(parse_tool_calls_from_text(text, allow_incomplete = True), allowed_tools))
+    return _heal_would_promote(text, allowed_tools)
 
 
 def nudge_should_retry(data: Any, allowed_tools: Optional[set]) -> bool:
@@ -307,7 +323,7 @@ def nudge_should_retry(data: Any, allowed_tools: Optional[set]) -> bool:
     text = message.get("content")
     if not isinstance(text, str) or not has_tool_signal(text):
         return False
-    return not _promote(parse_tool_calls_from_text(text, allow_incomplete = True), allowed_tools)
+    return not _heal_would_promote(text, allowed_tools)
 
 
 def nudge_messages(data: Any, allowed_tools: set) -> list:

--- a/studio/backend/core/inference/passthrough_healing.py
+++ b/studio/backend/core/inference/passthrough_healing.py
@@ -190,6 +190,41 @@ def _remove_spans(text: str, spans: list) -> str:
     return "".join(pieces)
 
 
+
+def heal_openai_message_events(
+    msg: dict,
+    allowed_tools: set,
+    tools: Optional[list] = None,
+) -> Optional[list]:
+    if not isinstance(msg, dict) or msg.get("tool_calls"):
+        return None
+    content = msg.get("content")
+    if not isinstance(content, str) or not has_tool_signal(content):
+        return None
+    parsed, spans = parse_tool_calls_from_text(content, allow_incomplete = True, with_spans = True)
+    tool_schemas = _tool_schemas_by_name(tools) if tools is not None else None
+    events: list = []
+    pos = 0
+    call_count = 0
+    for call, (start, end) in zip(parsed, spans):
+        promoted = _promote(
+            [call], allowed_tools, id_offset = call_count, tool_schemas = tool_schemas
+        )
+        if promoted:
+            if content[pos:start]:
+                events.append(("text", content[pos:start]))
+            events.append(("tool_call", promoted[0]))
+            call_count += 1
+        else:
+            events.append(("text", content[pos:end]))
+        pos = end
+    if not call_count:
+        return None
+    if content[pos:]:
+        events.append(("text", content[pos:]))
+    return events
+
+
 def heal_openai_message(
     msg: dict,
     allowed_tools: set,
@@ -203,28 +238,14 @@ def heal_openai_message(
     calls' markup spans are removed from the content; undeclared calls and
     anything the parser did not consume stay in the text byte-intact.
     """
-    if not isinstance(msg, dict) or msg.get("tool_calls"):
+    events = heal_openai_message_events(msg, allowed_tools, tools)
+    if not events:
         return False
-    content = msg.get("content")
-    if not isinstance(content, str) or not has_tool_signal(content):
-        return False
-    # allow_incomplete: the response is final, so a trailing unclosed block is a
-    # model failure worth repairing (same as the enable-tools loop at drain).
-    parsed, spans = parse_tool_calls_from_text(content, allow_incomplete = True, with_spans = True)
-    tool_schemas = _tool_schemas_by_name(tools) if tools is not None else None
-
-    calls = []
-    promoted_spans = []
-    for call, span in zip(parsed, spans):
-        promoted = _promote([call], allowed_tools, id_offset = len(calls), tool_schemas = tool_schemas)
-        if promoted:
-            calls.append(promoted[0])
-            promoted_spans.append(span)
-    if not calls:
-        return False
+    calls = [value for kind, value in events if kind == "tool_call"]
+    content = "".join(value for kind, value in events if kind == "text").strip()
     msg["tool_calls"] = calls
     # OpenAI requires content = null on a pure tool-call turn.
-    msg["content"] = _remove_spans(content, promoted_spans).strip() or None
+    msg["content"] = content or None
     return True
 
 
@@ -235,6 +256,23 @@ def _earliest_signal(buffer: str) -> int:
         if index >= 0 and (best < 0 or index < best):
             best = index
     return best
+
+
+
+def _closed_signal_span(buffer: str) -> Optional[tuple[int, int]]:
+    spans = []
+    for open_tag, close_tag in (
+        ("<tool_call>", "</tool_call>"),
+        ("<|tool_call>", "<tool_call|>"),
+        ("<function=", "</function>"),
+    ):
+        start = buffer.find(open_tag)
+        if start < 0:
+            continue
+        end = buffer.find(close_tag, start)
+        if end >= 0:
+            spans.append((start, end + len(close_tag)))
+    return min(spans, key = lambda span: span[0]) if spans else None
 
 
 def _partial_signal_suffix(buffer: str) -> int:
@@ -316,6 +354,13 @@ class StreamToolCallHealer:
                 with_spans = True,
             )
             if not parsed:
+                closed_span = _closed_signal_span(self._buffer)
+                if closed_span:
+                    _start, end = closed_span
+                    events.append(("text", self._buffer[:end]))
+                    self._buffer = self._buffer[end:]
+                    self._holding = False
+                    continue
                 if len(self._buffer) > _MAX_HOLD_CHARS:
                     events.append(("text", self._buffer))
                     self._buffer = ""

--- a/studio/backend/core/inference/passthrough_healing.py
+++ b/studio/backend/core/inference/passthrough_healing.py
@@ -26,6 +26,7 @@ own enable-tools loop are untouched. Per-request opt-out:
 
 import json
 import os
+from collections.abc import Mapping
 from typing import Any, Optional
 
 from core.inference.tool_call_parser import TOOL_XML_SIGNALS, has_tool_signal
@@ -86,16 +87,76 @@ def heal_gate(
     return names or None
 
 
+def _tool_schemas_by_name(tools: Optional[list]) -> dict[str, Any]:
+    schemas: dict[str, Any] = {}
+    for tool in tools or []:
+        if not isinstance(tool, dict):
+            continue
+        function = tool.get("function")
+        if not isinstance(function, dict):
+            continue
+        name = function.get("name")
+        if isinstance(name, str):
+            schemas[name] = function.get("parameters")
+    return schemas
+
+
+def _string_arg_key_from_schema(schema: Any) -> Optional[str]:
+    if not isinstance(schema, dict):
+        return None
+    properties = schema.get("properties")
+    required = schema.get("required")
+    if not isinstance(properties, dict) or not isinstance(required, list):
+        return None
+    required_names = [name for name in required if isinstance(name, str)]
+    if len(required_names) != 1:
+        return None
+    key = required_names[0]
+
+    if key not in properties:
+        return None
+    prop_schema = properties.get(key)
+    if isinstance(prop_schema, dict):
+        prop_type = prop_schema.get("type")
+        if isinstance(prop_type, list):
+            if "string" not in prop_type:
+                return None
+        elif prop_type is not None and prop_type != "string":
+            return None
+    return key
+
+
+def _coerce_promoted_arguments(
+    raw_args: Any,
+    tool_name: str,
+    tool_schemas: Optional[dict],
+) -> Optional[dict]:
+    if isinstance(raw_args, Mapping):
+        return dict(raw_args)
+    if isinstance(raw_args, str):
+        try:
+            parsed = json.loads(raw_args)
+            if isinstance(parsed, Mapping):
+                return dict(parsed)
+        except (json.JSONDecodeError, ValueError):
+            pass
+        if tool_schemas is not None:
+            key = _string_arg_key_from_schema(tool_schemas.get(tool_name))
+            return {key: raw_args} if key else None
+    coerced = coerce_tool_arguments(raw_args, heal = True, tool_name = tool_name)
+    return coerced.arguments
+
 def _promote(
     calls: list,
     allowed_tools: set,
     id_offset: int = 0,
+    tool_schemas: Optional[dict] = None,
 ) -> list:
     """Filter parsed calls to declared tools and normalize their arguments.
 
-    ``function.arguments`` leaves ``parse_tool_calls_from_text`` as whatever the
-    model wrote; OpenAI clients require a JSON-object string, so coerce through
-    the same canonical-key healing the enable-tools loop uses.
+    Bare string arguments on the client-tool passthrough use the declared
+    schema's single required string property. If the schema is ambiguous, the
+    call stays text instead of inventing a generic key.
     """
     promoted = []
     for call in calls:
@@ -103,14 +164,16 @@ def _promote(
         name = function.get("name") if isinstance(function, dict) else None
         if name not in allowed_tools:
             continue
-        coerced = coerce_tool_arguments(function.get("arguments"), heal = True, tool_name = name)
+        arguments = _coerce_promoted_arguments(function.get("arguments"), name, tool_schemas)
+        if arguments is None:
+            continue
         promoted.append(
             {
                 "id": f"call_{id_offset + len(promoted)}",
                 "type": "function",
                 "function": {
                     "name": name,
-                    "arguments": json.dumps(coerced.arguments, ensure_ascii = False),
+                    "arguments": json.dumps(arguments, ensure_ascii = False),
                 },
             }
         )
@@ -128,7 +191,11 @@ def _remove_spans(text: str, spans: list) -> str:
     return "".join(pieces)
 
 
-def heal_openai_message(msg: dict, allowed_tools: set) -> bool:
+def heal_openai_message(
+    msg: dict,
+    allowed_tools: set,
+    tools: Optional[list] = None,
+) -> bool:
     """Promote text-form tool calls in a non-streaming OpenAI message. In place.
 
     No-op (returns False) unless the message has NO structured ``tool_calls``
@@ -145,10 +212,14 @@ def heal_openai_message(msg: dict, allowed_tools: set) -> bool:
     # allow_incomplete: the response is final, so a trailing unclosed block is a
     # model failure worth repairing (same as the enable-tools loop at drain).
     parsed, spans = parse_tool_calls_from_text(content, allow_incomplete = True, with_spans = True)
+    tool_schemas = _tool_schemas_by_name(tools) if tools is not None else None
+
     calls = []
     promoted_spans = []
     for call, span in zip(parsed, spans):
-        promoted = _promote([call], allowed_tools, id_offset = len(calls))
+        promoted = _promote(
+            [call], allowed_tools, id_offset = len(calls), tool_schemas = tool_schemas
+        )
         if promoted:
             calls.append(promoted[0])
             promoted_spans.append(span)
@@ -190,8 +261,10 @@ class StreamToolCallHealer:
     text verbatim.
     """
 
-    def __init__(self, allowed_tools: set) -> None:
+    def __init__(self, allowed_tools: set, tools: Optional[list] = None) -> None:
         self._allowed = set(allowed_tools)
+
+        self._tool_schemas = _tool_schemas_by_name(tools) if tools is not None else None
         self._buffer = ""
         self._holding = False
         self._id_offset = 0
@@ -249,7 +322,12 @@ class StreamToolCallHealer:
                     continue
                 return events
             start, end = spans[0]
-            promoted = _promote([parsed[0]], self._allowed, id_offset = self._id_offset)
+            promoted = _promote(
+                [parsed[0]],
+                self._allowed,
+                id_offset = self._id_offset,
+                tool_schemas = self._tool_schemas,
+            )
             if promoted:
                 if start:
                     events.append(("text", self._buffer[:start]))
@@ -287,7 +365,12 @@ class StreamToolCallHealer:
         pos = 0
         any_promoted = False
         for call, (start, end) in zip(parsed, spans):
-            promoted = _promote([call], self._allowed, id_offset = self._id_offset)
+            promoted = _promote(
+                [call],
+                self._allowed,
+                id_offset = self._id_offset,
+                tool_schemas = self._tool_schemas,
+            )
             if promoted:
                 if residue[pos:start]:
                     events.append(("text", residue[pos:start]))
@@ -325,13 +408,22 @@ def _last_assistant_text(data: Any) -> str:
     return content if isinstance(content, str) else ""
 
 
-def _heal_would_promote(text: str, allowed_tools: set) -> bool:
+def _heal_would_promote(
+    text: str,
+    allowed_tools: set,
+    tools: Optional[list] = None,
+) -> bool:
     """Whether ``heal_openai_message`` would promote at least one call."""
     parsed = parse_tool_calls_from_text(text, allow_incomplete = True)
-    return bool(_promote(parsed, allowed_tools))
+    tool_schemas = _tool_schemas_by_name(tools) if tools is not None else None
+    return bool(_promote(parsed, allowed_tools, tool_schemas = tool_schemas))
 
 
-def response_has_promotable_calls(data: Any, allowed_tools: set) -> bool:
+def response_has_promotable_calls(
+    data: Any,
+    allowed_tools: set,
+    tools: Optional[list] = None,
+) -> bool:
     """True when a non-streaming chat response carries a usable tool call
     (structured naming a DECLARED tool, or text-form that healing would
     promote). Used to decide whether a nudge retry actually improved on the
@@ -354,10 +446,14 @@ def response_has_promotable_calls(data: Any, allowed_tools: set) -> bool:
     text = message.get("content")
     if not isinstance(text, str):
         return False
-    return _heal_would_promote(text, allowed_tools)
+    return _heal_would_promote(text, allowed_tools, tools)
 
 
-def nudge_should_retry(data: Any, allowed_tools: Optional[set]) -> bool:
+def nudge_should_retry(
+    data: Any,
+    allowed_tools: Optional[set],
+    tools: Optional[list] = None,
+) -> bool:
     """True when the first response tried to call a tool but nothing healed.
 
     Trigger only on: healing enabled (allowed_tools set), zero structured
@@ -372,7 +468,7 @@ def nudge_should_retry(data: Any, allowed_tools: Optional[set]) -> bool:
     text = message.get("content")
     if not isinstance(text, str) or not has_tool_signal(text):
         return False
-    return not _heal_would_promote(text, allowed_tools)
+    return not _heal_would_promote(text, allowed_tools, tools)
 
 
 def nudge_messages(data: Any, allowed_tools: set) -> list:

--- a/studio/backend/core/inference/passthrough_healing.py
+++ b/studio/backend/core/inference/passthrough_healing.py
@@ -30,6 +30,13 @@ from core.tool_healing import parse_tool_calls_from_text, strip_tool_call_markup
 
 # Read once at import (same convention as the other UNSLOTH_* switches).
 _HEALING_DISABLED = os.environ.get("UNSLOTH_DISABLE_TOOL_CALL_HEALING", "0") == "1"
+# Nudging is OPT-IN: per-request nudge_tool_calls=true, or flip the process
+# default with UNSLOTH_TOOL_CALL_NUDGE=1 (e.g. an `unsloth run` operator).
+_NUDGE_DEFAULT = os.environ.get("UNSLOTH_TOOL_CALL_NUDGE", "0") == "1"
+
+
+def nudge_enabled(request_flag: Optional[bool]) -> bool:
+    return _NUDGE_DEFAULT if request_flag is None else bool(request_flag)
 
 _MAX_SIGNAL_LEN = max(len(s) for s in TOOL_XML_SIGNALS)
 # A suspected-but-unclosed tool block larger than this is declared a false
@@ -96,8 +103,10 @@ def heal_openai_message(msg: dict, allowed_tools: set) -> bool:
     content = msg.get("content")
     if not isinstance(content, str) or not has_tool_signal(content):
         return False
+    # allow_incomplete: the response is final, so a trailing unclosed block is a
+    # model failure worth repairing (same as the enable-tools loop at drain).
     calls = _promote(
-        parse_tool_calls_from_text(content, allow_incomplete = False), allowed_tools
+        parse_tool_calls_from_text(content, allow_incomplete = True), allowed_tools
     )
     if not calls:
         return False
@@ -238,6 +247,24 @@ def _last_assistant_text(data: Any) -> str:
         return content if isinstance(content, str) else ""
     except (KeyError, IndexError, TypeError):
         return ""
+
+
+def response_has_promotable_calls(data: Any, allowed_tools: set) -> bool:
+    """True when a non-streaming chat response carries a usable tool call
+    (structured, or text-form that healing would promote). Used to decide
+    whether a nudge retry actually improved on the original response."""
+    try:
+        message = data["choices"][0]["message"]
+    except (KeyError, IndexError, TypeError):
+        return False
+    if message.get("tool_calls"):
+        return True
+    text = message.get("content")
+    if not isinstance(text, str):
+        return False
+    return bool(
+        _promote(parse_tool_calls_from_text(text, allow_incomplete = True), allowed_tools)
+    )
 
 
 def nudge_should_retry(data: Any, allowed_tools: Optional[set]) -> bool:

--- a/studio/backend/core/inference/passthrough_healing.py
+++ b/studio/backend/core/inference/passthrough_healing.py
@@ -144,9 +144,7 @@ def heal_openai_message(msg: dict, allowed_tools: set) -> bool:
         return False
     # allow_incomplete: the response is final, so a trailing unclosed block is a
     # model failure worth repairing (same as the enable-tools loop at drain).
-    parsed, spans = parse_tool_calls_from_text(
-        content, allow_incomplete = True, with_spans = True
-    )
+    parsed, spans = parse_tool_calls_from_text(content, allow_incomplete = True, with_spans = True)
     calls = []
     promoted_spans = []
     for call, span in zip(parsed, spans):

--- a/studio/backend/core/inference/passthrough_healing.py
+++ b/studio/backend/core/inference/passthrough_healing.py
@@ -127,9 +127,7 @@ def _string_arg_key_from_schema(schema: Any) -> Optional[str]:
 
 
 def _coerce_promoted_arguments(
-    raw_args: Any,
-    tool_name: str,
-    tool_schemas: Optional[dict],
+    raw_args: Any, tool_name: str, tool_schemas: Optional[dict]
 ) -> Optional[dict]:
     if isinstance(raw_args, Mapping):
         return dict(raw_args)
@@ -145,6 +143,7 @@ def _coerce_promoted_arguments(
             return {key: raw_args} if key else None
     coerced = coerce_tool_arguments(raw_args, heal = True, tool_name = tool_name)
     return coerced.arguments
+
 
 def _promote(
     calls: list,
@@ -217,9 +216,7 @@ def heal_openai_message(
     calls = []
     promoted_spans = []
     for call, span in zip(parsed, spans):
-        promoted = _promote(
-            [call], allowed_tools, id_offset = len(calls), tool_schemas = tool_schemas
-        )
+        promoted = _promote([call], allowed_tools, id_offset = len(calls), tool_schemas = tool_schemas)
         if promoted:
             calls.append(promoted[0])
             promoted_spans.append(span)
@@ -261,7 +258,11 @@ class StreamToolCallHealer:
     text verbatim.
     """
 
-    def __init__(self, allowed_tools: set, tools: Optional[list] = None) -> None:
+    def __init__(
+        self,
+        allowed_tools: set,
+        tools: Optional[list] = None,
+    ) -> None:
         self._allowed = set(allowed_tools)
 
         self._tool_schemas = _tool_schemas_by_name(tools) if tools is not None else None

--- a/studio/backend/core/inference/passthrough_healing.py
+++ b/studio/backend/core/inference/passthrough_healing.py
@@ -38,6 +38,7 @@ _NUDGE_DEFAULT = os.environ.get("UNSLOTH_TOOL_CALL_NUDGE", "0") == "1"
 def nudge_enabled(request_flag: Optional[bool]) -> bool:
     return _NUDGE_DEFAULT if request_flag is None else bool(request_flag)
 
+
 _MAX_SIGNAL_LEN = max(len(s) for s in TOOL_XML_SIGNALS)
 # A suspected-but-unclosed tool block larger than this is declared a false
 # alarm and flushed, bounding memory on a model rambling XML-lookalike text.
@@ -64,7 +65,11 @@ def heal_gate(auto_heal: Optional[bool], tools: Optional[list]) -> Optional[set]
     return names or None
 
 
-def _promote(calls: list, allowed_tools: set, id_offset: int = 0) -> list:
+def _promote(
+    calls: list,
+    allowed_tools: set,
+    id_offset: int = 0,
+) -> list:
     """Filter parsed calls to declared tools and normalize their arguments.
 
     ``function.arguments`` leaves ``parse_tool_calls_from_text`` as whatever the
@@ -105,9 +110,7 @@ def heal_openai_message(msg: dict, allowed_tools: set) -> bool:
         return False
     # allow_incomplete: the response is final, so a trailing unclosed block is a
     # model failure worth repairing (same as the enable-tools loop at drain).
-    calls = _promote(
-        parse_tool_calls_from_text(content, allow_incomplete = True), allowed_tools
-    )
+    calls = _promote(parse_tool_calls_from_text(content, allow_incomplete = True), allowed_tools)
     if not calls:
         return False
     msg["tool_calls"] = calls
@@ -223,9 +226,7 @@ class StreamToolCallHealer:
         if self.dormant or not holding:
             return [("text", residue)]
         promoted = _promote(
-            parse_tool_calls_from_text(
-                residue, id_offset = self._id_offset, allow_incomplete = True
-            ),
+            parse_tool_calls_from_text(residue, id_offset = self._id_offset, allow_incomplete = True),
             self._allowed,
             id_offset = self._id_offset,
         )
@@ -262,9 +263,7 @@ def response_has_promotable_calls(data: Any, allowed_tools: set) -> bool:
     text = message.get("content")
     if not isinstance(text, str):
         return False
-    return bool(
-        _promote(parse_tool_calls_from_text(text, allow_incomplete = True), allowed_tools)
-    )
+    return bool(_promote(parse_tool_calls_from_text(text, allow_incomplete = True), allowed_tools))
 
 
 def nudge_should_retry(data: Any, allowed_tools: Optional[set]) -> bool:
@@ -285,9 +284,7 @@ def nudge_should_retry(data: Any, allowed_tools: Optional[set]) -> bool:
     text = message.get("content")
     if not isinstance(text, str) or not has_tool_signal(text):
         return False
-    return not _promote(
-        parse_tool_calls_from_text(text, allow_incomplete = True), allowed_tools
-    )
+    return not _promote(parse_tool_calls_from_text(text, allow_incomplete = True), allowed_tools)
 
 
 def nudge_messages(data: Any, allowed_tools: set) -> list:

--- a/studio/backend/core/inference/passthrough_healing.py
+++ b/studio/backend/core/inference/passthrough_healing.py
@@ -15,13 +15,13 @@ generation is issued, so llama-server slot/KV-cache reuse is byte-identical.
 
 Healing only ever fires when the request declared client tools, and only
 promotes calls whose function name exactly matches a declared tool. Promotion
-is all-or-nothing per parse: if a response mixes a declared call with an
-undeclared (or unparseable-name) one, nothing is promoted and the text relays
-verbatim -- stripping the promoted markup would otherwise silently delete the
-undeclared call's text, which must reach the client as prose. Responses
-without a tool signal, requests without tools, and Studio's own enable-tools
-loop are untouched. Per-request opt-out: ``auto_heal_tool_calls: false``.
-Process kill-switch: ``UNSLOTH_DISABLE_TOOL_CALL_HEALING=1``.
+removes EXACTLY the promoted calls' markup spans (the parser reports them):
+undeclared calls, unparseable blocks, and suppressed alternate formats keep
+every byte and relay as text, so healing can never silently delete model
+output. Responses without a tool signal, requests without tools, and Studio's
+own enable-tools loop are untouched. Per-request opt-out:
+``auto_heal_tool_calls: false``. Process kill-switch:
+``UNSLOTH_DISABLE_TOOL_CALL_HEALING=1``.
 """
 
 import json
@@ -30,7 +30,7 @@ from typing import Any, Optional
 
 from core.inference.tool_call_parser import TOOL_XML_SIGNALS, has_tool_signal
 from core.inference.tool_loop_controller import coerce_tool_arguments
-from core.tool_healing import parse_tool_calls_from_text, strip_tool_call_markup
+from core.tool_healing import parse_tool_calls_from_text
 
 # Read once at import (same convention as the other UNSLOTH_* switches).
 _HEALING_DISABLED = os.environ.get("UNSLOTH_DISABLE_TOOL_CALL_HEALING", "0") == "1"
@@ -117,14 +117,25 @@ def _promote(
     return promoted
 
 
+def _remove_spans(text: str, spans: list) -> str:
+    """Text with the given non-overlapping, sorted (start, end) ranges removed."""
+    pieces = []
+    pos = 0
+    for start, end in spans:
+        pieces.append(text[pos:start])
+        pos = end
+    pieces.append(text[pos:])
+    return "".join(pieces)
+
+
 def heal_openai_message(msg: dict, allowed_tools: set) -> bool:
     """Promote text-form tool calls in a non-streaming OpenAI message. In place.
 
     No-op (returns False) unless the message has NO structured ``tool_calls``
     (grammar mode already worked when it does) and its content carries a tool
-    signal where EVERY parsed call names a declared tool. All-or-nothing:
-    ``strip_tool_call_markup`` removes every tool block, so promoting a subset
-    would silently delete the unpromoted calls' text.
+    signal that parses into at least one declared call. Only the promoted
+    calls' markup spans are removed from the content; undeclared calls and
+    anything the parser did not consume stay in the text byte-intact.
     """
     if not isinstance(msg, dict) or msg.get("tool_calls"):
         return False
@@ -133,13 +144,21 @@ def heal_openai_message(msg: dict, allowed_tools: set) -> bool:
         return False
     # allow_incomplete: the response is final, so a trailing unclosed block is a
     # model failure worth repairing (same as the enable-tools loop at drain).
-    parsed = parse_tool_calls_from_text(content, allow_incomplete = True)
-    calls = _promote(parsed, allowed_tools)
-    if not calls or len(calls) != len(parsed):
+    parsed, spans = parse_tool_calls_from_text(
+        content, allow_incomplete = True, with_spans = True
+    )
+    calls = []
+    promoted_spans = []
+    for call, span in zip(parsed, spans):
+        promoted = _promote([call], allowed_tools, id_offset = len(calls))
+        if promoted:
+            calls.append(promoted[0])
+            promoted_spans.append(span)
+    if not calls:
         return False
     msg["tool_calls"] = calls
     # OpenAI requires content = null on a pure tool-call turn.
-    msg["content"] = strip_tool_call_markup(content, final = True) or None
+    msg["content"] = _remove_spans(content, promoted_spans).strip() or None
     return True
 
 
@@ -215,9 +234,14 @@ class StreamToolCallHealer:
                         events.append(("text", emit))
                     self._buffer = self._buffer[len(self._buffer) - keep :]
                     return events
-            # HOLD: promote once at least one complete block parses.
-            parsed = parse_tool_calls_from_text(
-                self._buffer, id_offset = self._id_offset, allow_incomplete = False
+            # HOLD: handle the FIRST complete block per pass so events keep
+            # document order (a later declared call must not overtake an
+            # earlier undeclared one flushing as text).
+            parsed, spans = parse_tool_calls_from_text(
+                self._buffer,
+                id_offset = self._id_offset,
+                allow_incomplete = False,
+                with_spans = True,
             )
             if not parsed:
                 if len(self._buffer) > _MAX_HOLD_CHARS:
@@ -226,43 +250,60 @@ class StreamToolCallHealer:
                     self._holding = False
                     continue
                 return events
-            promoted = _promote(parsed, self._allowed, id_offset = self._id_offset)
-            if len(promoted) != len(parsed):
-                # At least one complete block names an undeclared tool (or has
-                # no usable name): false alarm for the WHOLE buffer. Stripping
-                # only the declared markup is impossible (the strip helper
-                # removes every block), so flush the raw text -- the client
-                # must still see what the model said.
-                events.append(("text", self._buffer))
-                self._buffer = ""
-                self._holding = False
-                continue
-            self._id_offset += len(promoted)
-            events.extend(("tool_call", call) for call in promoted)
-            # Drop the closed markup, keep surrounding text/partial blocks, and
-            # loop back to rescan the remainder (e.g. a second call following).
-            self._buffer = strip_tool_call_markup(self._buffer, final = False)
+            start, end = spans[0]
+            promoted = _promote([parsed[0]], self._allowed, id_offset = self._id_offset)
+            if promoted:
+                if start:
+                    events.append(("text", self._buffer[:start]))
+                events.append(("tool_call", promoted[0]))
+                self._id_offset += 1
+                # Drop exactly the promoted markup span; everything else
+                # (leading text, later blocks) stays and is rescanned.
+                self._buffer = self._buffer[end:]
+            else:
+                # Undeclared or unusable name: its markup is DATA, flush it
+                # (and anything before it) verbatim, then rescan the rest.
+                events.append(("text", self._buffer[:end]))
+                self._buffer = self._buffer[end:]
             self._holding = False
 
     def finalize(self) -> list:
-        """End of stream: last-chance heal of the residue, else flush it."""
+        """End of stream: last-chance heal of the residue, else flush it.
+
+        Events keep document order; only the promoted calls' markup spans are
+        dropped, every other residue byte flushes as text.
+        """
         if not self._buffer:
             return []
         residue, self._buffer = self._buffer, ""
         holding, self._holding = self._holding, False
         if self.dormant or not holding:
             return [("text", residue)]
-        parsed = parse_tool_calls_from_text(
-            residue, id_offset = self._id_offset, allow_incomplete = True
+        parsed, spans = parse_tool_calls_from_text(
+            residue,
+            id_offset = self._id_offset,
+            allow_incomplete = True,
+            with_spans = True,
         )
-        promoted = _promote(parsed, self._allowed, id_offset = self._id_offset)
-        if not promoted or len(promoted) != len(parsed):
+        events: list = []
+        pos = 0
+        any_promoted = False
+        for call, (start, end) in zip(parsed, spans):
+            promoted = _promote([call], self._allowed, id_offset = self._id_offset)
+            if promoted:
+                if residue[pos:start]:
+                    events.append(("text", residue[pos:start]))
+                events.append(("tool_call", promoted[0]))
+                self._id_offset += 1
+                any_promoted = True
+            else:
+                events.append(("text", residue[pos:end]))
+            pos = end
+        if not any_promoted:
             return [("text", residue)]
-        self._id_offset += len(promoted)
-        events = [("tool_call", call) for call in promoted]
-        remainder = strip_tool_call_markup(residue, final = True)
-        if remainder:
-            events.append(("text", remainder))
+        tail = residue[pos:].strip()
+        if tail:
+            events.append(("text", tail))
         return events
 
 
@@ -287,21 +328,27 @@ def _last_assistant_text(data: Any) -> str:
 
 
 def _heal_would_promote(text: str, allowed_tools: set) -> bool:
-    """Whether ``heal_openai_message`` would promote this text (all-or-nothing)."""
+    """Whether ``heal_openai_message`` would promote at least one call."""
     parsed = parse_tool_calls_from_text(text, allow_incomplete = True)
-    promoted = _promote(parsed, allowed_tools)
-    return bool(promoted) and len(promoted) == len(parsed)
+    return bool(_promote(parsed, allowed_tools))
 
 
 def response_has_promotable_calls(data: Any, allowed_tools: set) -> bool:
     """True when a non-streaming chat response carries a usable tool call
-    (structured, or text-form that healing would promote). Used to decide
-    whether a nudge retry actually improved on the original response."""
+    (structured naming a DECLARED tool, or text-form that healing would
+    promote). Used to decide whether a nudge retry actually improved on the
+    original response; a hallucinated undeclared call is not an improvement."""
     message = _first_choice_message(data)
     if not message:
         return False
-    if message.get("tool_calls"):
-        return True
+    tool_calls = message.get("tool_calls")
+    if tool_calls:
+        return any(
+            isinstance(tc, dict)
+            and isinstance(tc.get("function"), dict)
+            and tc["function"].get("name") in allowed_tools
+            for tc in tool_calls
+        )
     text = message.get("content")
     if not isinstance(text, str):
         return False

--- a/studio/backend/core/tool_healing.py
+++ b/studio/backend/core/tool_healing.py
@@ -403,13 +403,21 @@ def parse_tool_calls_from_text(
                 body_end = len(content)
             body_end = min(body_end, next_func)
             body = content[body_start:body_end]
-            if not allow_incomplete:
-                close_idx = body.rfind(_FUNC_CLOSE_TAG)
-                if close_idx < 0:
-                    continue
+            # Cut the body at the real </function> when present, in BOTH modes. The
+            # heal/finalize path (allow_incomplete=True) used to strip only an
+            # end-anchored </function>, so a closed call followed by trailing prose
+            # (<function=..>..</parameter></function> words) folded the close tags and
+            # the prose into the argument and deleted the prose from visible content.
+            close_idx = body.rfind(_FUNC_CLOSE_TAG)
+            if close_idx >= 0:
+                span_end = body_start + close_idx + len(_FUNC_CLOSE_TAG)
                 body = body[:close_idx]
+            elif not allow_incomplete:
+                continue
             else:
+                # Genuinely truncated (no </function> yet): keep what streamed so far.
                 body = _TC_FUNC_CLOSE_RE.sub("", body)
+                span_end = body_end
 
             arguments: dict = {}
             param_starts = list(_TC_PARAM_START_RE.finditer(body))
@@ -460,10 +468,8 @@ def parse_tool_calls_from_text(
             # enclosing <tool_call>...</tool_call> wrapper when present
             # (docstring format 3), so removal leaves no dangling wrapper tags.
             span_start = fm.start()
-            if not allow_incomplete:
-                span_end = body_start + close_idx + len(_FUNC_CLOSE_TAG)
-            else:
-                span_end = body_end
+            # span_end was set above at the real </function> (or body_end when the
+            # call is genuinely truncated).
             wrap_open = re.search(r"<tool_call>\s*$", content[:span_start])
             wrap_close = re.match(r"\s*</tool_call>", content[span_end:])
             if wrap_open and wrap_close:

--- a/studio/backend/core/tool_healing.py
+++ b/studio/backend/core/tool_healing.py
@@ -301,15 +301,22 @@ def parse_tool_calls_from_text(
     *,
     id_offset: int = 0,
     allow_incomplete: bool = True,
-) -> list[dict]:
+    with_spans: bool = False,
+):
     """Parse OpenAI-format tool calls from model text.
 
     Handles formats like:
       <tool_call>{"name":"web_search","arguments":{"query":"..."}}</tool_call>
       <|tool_call>call:web_search{query:"..."}<tool_call|>
       <tool_call><function=web_search><parameter=query>...</parameter></function></tool_call>
+
+    With ``with_spans=True`` returns ``(tool_calls, spans)`` where ``spans[i]``
+    is the half-open ``(start, end)`` byte range of ``tool_calls[i]``'s markup
+    in ``content`` (including its close tag when present), so a caller can
+    remove exactly the parsed markup and keep every other byte intact.
     """
     tool_calls: list[dict] = []
+    call_spans: list[tuple] = []
     # Collect JSON- and Gemma-format candidates with their byte spans, then
     # accept them in document order. Both order and spans matter:
     #   * tools execute in returned order, so a call appearing earlier in the
@@ -369,6 +376,15 @@ def parse_tool_calls_from_text(
                 "function": {"name": name, "arguments": arguments},
             }
         )
+        # Markup span: opening marker through the balanced brace, extended over
+        # the close tag when it follows (whitespace allowed in between).
+        span_end = end + 1
+        close_re = _TC_END_TAG_RE if kind == "json" else _TC_GEMMA_END_TAG_RE
+        ws = len(content[span_end:]) - len(content[span_end:].lstrip())
+        close_m = close_re.match(content, span_end + ws)
+        if close_m:
+            span_end = close_m.end()
+        call_spans.append((start, span_end))
 
     if not tool_calls:
         func_starts = [
@@ -440,6 +456,22 @@ def parse_tool_calls_from_text(
                 },
             }
             tool_calls.append(tc)
+            # Markup span: the <function=...> block plus an immediately
+            # enclosing <tool_call>...</tool_call> wrapper when present
+            # (docstring format 3), so removal leaves no dangling wrapper tags.
+            span_start = fm.start()
+            if not allow_incomplete:
+                span_end = body_start + close_idx + len(_FUNC_CLOSE_TAG)
+            else:
+                span_end = body_end
+            wrap_open = re.search(r"<tool_call>\s*$", content[:span_start])
+            wrap_close = re.match(r"\s*</tool_call>", content[span_end:])
+            if wrap_open and wrap_close:
+                span_start = wrap_open.start()
+                span_end += wrap_close.end()
+            call_spans.append((span_start, span_end))
+    if with_spans:
+        return tool_calls, call_spans
     return tool_calls
 
 

--- a/studio/backend/core/tool_healing.py
+++ b/studio/backend/core/tool_healing.py
@@ -317,19 +317,12 @@ def parse_tool_calls_from_text(
     """
     tool_calls: list[dict] = []
     call_spans: list[tuple] = []
-    # Collect JSON- and Gemma-format candidates with their byte spans, then
-    # accept them in document order. Both order and spans matter:
-    #   * tools execute in returned order, so a call appearing earlier in the
-    #     text must be emitted first even across the two formats;
-    #   * a tool-call marker INSIDE another call's argument string is data, not a
-    #     call, so a candidate starting within an already accepted span is
-    #     skipped (covers a JSON marker nested in a Gemma arg and a Gemma marker
-    #     nested in a JSON arg alike, regardless of which format is outer).
+    # Collect every supported call format with spans, then emit in document
+    # order. A marker inside another call's argument string is data, not a
+    # separate executable call.
+    parsed_items = []  # (start, span_end, name, arguments)
     candidates = []  # (start, brace_end, kind, match)
     for m in _TC_JSON_START_RE.finditer(content):
-        # A marker that begins inside an open <function=...><parameter=...> value
-        # is that parameter's data, not its own call; skip it (same guard the
-        # XML-style parser below applies to nested <function= markers).
         if _inside_open_parameter(content, m.start()):
             continue
         end = _balanced_brace_end(content, m.end() - 1)
@@ -343,14 +336,9 @@ def parse_tool_calls_from_text(
             candidates.append((m.start(), end, "gemma", m))
     candidates.sort(key = lambda c: c[0])
 
-    spans = [(s, e) for s, e, _kind, _m in candidates]
+    candidate_spans = [(s, e) for s, e, _kind, _m in candidates]
     for idx, (start, end, kind, m) in enumerate(candidates):
-        # Skip a candidate nested inside another candidate's brace span: it is
-        # the enclosing call's argument data, not its own call. Checked against
-        # every candidate span (not only the ones that parsed successfully), so a
-        # marker inside an outer call that later fails to normalize is still
-        # never promoted to its own executable tool call.
-        if any(s <= start and end <= e for j, (s, e) in enumerate(spans) if j != idx):
+        if any(s <= start and end <= e for j, (s, e) in enumerate(candidate_spans) if j != idx):
             continue
         if not allow_incomplete:
             tail = content[end + 1 :].lstrip()
@@ -369,6 +357,85 @@ def parse_tool_calls_from_text(
                 arguments = json.dumps(_gemma_arguments_to_json(content[m.end() : end]))
         except (json.JSONDecodeError, ValueError):
             continue
+        span_end = end + 1
+        close_re = _TC_END_TAG_RE if kind == "json" else _TC_GEMMA_END_TAG_RE
+        ws = len(content[span_end:]) - len(content[span_end:].lstrip())
+        close_m = close_re.match(content, span_end + ws)
+        if close_m:
+            span_end = close_m.end()
+        parsed_items.append((start, span_end, name, arguments))
+
+    func_starts = [
+        fm
+        for fm in _TC_FUNC_START_RE.finditer(content)
+        if not _inside_open_parameter(content, fm.start())
+        and not any(s <= fm.start() <= e for s, e in candidate_spans)
+    ]
+    for idx, fm in enumerate(func_starts):
+        func_name = fm.group(1)
+        body_start = fm.end()
+        next_func = func_starts[idx + 1].start() if idx + 1 < len(func_starts) else len(content)
+        end_tag = _TC_END_TAG_RE.search(content[body_start:])
+        if end_tag:
+            body_end = body_start + end_tag.start()
+        else:
+            body_end = len(content)
+        body_end = min(body_end, next_func)
+        body = content[body_start:body_end]
+        close_idx = body.rfind(_FUNC_CLOSE_TAG)
+        if close_idx >= 0:
+            span_end = body_start + close_idx + len(_FUNC_CLOSE_TAG)
+            body = body[:close_idx]
+        elif not allow_incomplete:
+            continue
+        else:
+            body = _TC_FUNC_CLOSE_RE.sub("", body)
+            span_end = body_end
+
+        arguments: dict = {}
+        param_starts = list(_TC_PARAM_START_RE.finditer(body))
+        if len(param_starts) == 1:
+            pm = param_starts[0]
+            val = body[pm.end() :]
+            if not allow_incomplete:
+                stripped_val = val.rstrip()
+                if not stripped_val.endswith(_PARAM_CLOSE_TAG):
+                    continue
+                val = stripped_val[: -len(_PARAM_CLOSE_TAG)]
+            else:
+                val = _TC_PARAM_CLOSE_RE.sub("", val)
+            arguments[pm.group(1)] = val.strip()
+        else:
+            valid_params = True
+            for pidx, pm in enumerate(param_starts):
+                param_name = pm.group(1)
+                val_start = pm.end()
+                next_param = (
+                    param_starts[pidx + 1].start() if pidx + 1 < len(param_starts) else len(body)
+                )
+                val = body[val_start:next_param]
+                if not allow_incomplete:
+                    stripped_val = val.rstrip()
+                    if not stripped_val.endswith(_PARAM_CLOSE_TAG):
+                        valid_params = False
+                        break
+                    val = stripped_val[: -len(_PARAM_CLOSE_TAG)]
+                else:
+                    val = _TC_PARAM_CLOSE_RE.sub("", val)
+                arguments[param_name] = val.strip()
+            if not valid_params:
+                continue
+
+        span_start = fm.start()
+        wrap_open = re.search(r"<tool_call>\s*$", content[:span_start])
+        wrap_close = re.match(r"\s*</tool_call>", content[span_end:])
+        if wrap_open and wrap_close:
+            span_start = wrap_open.start()
+            span_end += wrap_close.end()
+        parsed_items.append((span_start, span_end, func_name, json.dumps(arguments)))
+
+    parsed_items.sort(key = lambda item: item[0])
+    for start, span_end, name, arguments in parsed_items:
         tool_calls.append(
             {
                 "id": f"call_{id_offset + len(tool_calls)}",
@@ -376,106 +443,7 @@ def parse_tool_calls_from_text(
                 "function": {"name": name, "arguments": arguments},
             }
         )
-        # Markup span: opening marker through the balanced brace, extended over
-        # the close tag when it follows (whitespace allowed in between).
-        span_end = end + 1
-        close_re = _TC_END_TAG_RE if kind == "json" else _TC_GEMMA_END_TAG_RE
-        ws = len(content[span_end:]) - len(content[span_end:].lstrip())
-        close_m = close_re.match(content, span_end + ws)
-        if close_m:
-            span_end = close_m.end()
         call_spans.append((start, span_end))
-
-    if not tool_calls:
-        func_starts = [
-            fm
-            for fm in _TC_FUNC_START_RE.finditer(content)
-            if not _inside_open_parameter(content, fm.start())
-        ]
-        for idx, fm in enumerate(func_starts):
-            func_name = fm.group(1)
-            body_start = fm.end()
-            next_func = func_starts[idx + 1].start() if idx + 1 < len(func_starts) else len(content)
-            end_tag = _TC_END_TAG_RE.search(content[body_start:])
-            if end_tag:
-                body_end = body_start + end_tag.start()
-            else:
-                body_end = len(content)
-            body_end = min(body_end, next_func)
-            body = content[body_start:body_end]
-            # Cut the body at the real </function> when present, in BOTH modes. The
-            # heal/finalize path (allow_incomplete=True) used to strip only an
-            # end-anchored </function>, so a closed call followed by trailing prose
-            # (<function=..>..</parameter></function> words) folded the close tags and
-            # the prose into the argument and deleted the prose from visible content.
-            close_idx = body.rfind(_FUNC_CLOSE_TAG)
-            if close_idx >= 0:
-                span_end = body_start + close_idx + len(_FUNC_CLOSE_TAG)
-                body = body[:close_idx]
-            elif not allow_incomplete:
-                continue
-            else:
-                # Genuinely truncated (no </function> yet): keep what streamed so far.
-                body = _TC_FUNC_CLOSE_RE.sub("", body)
-                span_end = body_end
-
-            arguments: dict = {}
-            param_starts = list(_TC_PARAM_START_RE.finditer(body))
-            if len(param_starts) == 1:
-                pm = param_starts[0]
-                val = body[pm.end() :]
-                if not allow_incomplete:
-                    stripped_val = val.rstrip()
-                    if not stripped_val.endswith(_PARAM_CLOSE_TAG):
-                        continue
-                    val = stripped_val[: -len(_PARAM_CLOSE_TAG)]
-                else:
-                    val = _TC_PARAM_CLOSE_RE.sub("", val)
-                arguments[pm.group(1)] = val.strip()
-            else:
-                valid_params = True
-                for pidx, pm in enumerate(param_starts):
-                    param_name = pm.group(1)
-                    val_start = pm.end()
-                    next_param = (
-                        param_starts[pidx + 1].start()
-                        if pidx + 1 < len(param_starts)
-                        else len(body)
-                    )
-                    val = body[val_start:next_param]
-                    if not allow_incomplete:
-                        stripped_val = val.rstrip()
-                        if not stripped_val.endswith(_PARAM_CLOSE_TAG):
-                            valid_params = False
-                            break
-                        val = stripped_val[: -len(_PARAM_CLOSE_TAG)]
-                    else:
-                        val = _TC_PARAM_CLOSE_RE.sub("", val)
-                    arguments[param_name] = val.strip()
-                if not valid_params:
-                    continue
-
-            tc = {
-                "id": f"call_{id_offset + len(tool_calls)}",
-                "type": "function",
-                "function": {
-                    "name": func_name,
-                    "arguments": json.dumps(arguments),
-                },
-            }
-            tool_calls.append(tc)
-            # Markup span: the <function=...> block plus an immediately
-            # enclosing <tool_call>...</tool_call> wrapper when present
-            # (docstring format 3), so removal leaves no dangling wrapper tags.
-            span_start = fm.start()
-            # span_end was set above at the real </function> (or body_end when the
-            # call is genuinely truncated).
-            wrap_open = re.search(r"<tool_call>\s*$", content[:span_start])
-            wrap_close = re.match(r"\s*</tool_call>", content[span_end:])
-            if wrap_open and wrap_close:
-                span_start = wrap_open.start()
-                span_end += wrap_close.end()
-            call_spans.append((span_start, span_end))
     if with_spans:
         return tool_calls, call_spans
     return tool_calls

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -1612,6 +1612,10 @@ class AnthropicMessagesRequest(BaseModel):
         False,
         description = "[x-unsloth] Bypass Permissions: when true, disable the python/terminal execution sandbox (safety checks, command blocklist, resource limits) for server-side tool calls. Secret env vars are still stripped. Declared explicitly (not relied on via extra='allow') so omitted requests default to False instead of raising AttributeError.",
     )
+    auto_heal_tool_calls: Optional[bool] = Field(
+        True,
+        description = "[x-unsloth] Auto-detect and fix malformed tool calls from model output (mirrors the Chat Completions field; applies to the client-tool passthrough).",
+    )
     model_config = {"extra": "allow"}
 
     @model_validator(mode = "before")

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -780,6 +780,16 @@ class ChatCompletionRequest(BaseModel):
         True,
         description = "[x-unsloth] Auto-detect and fix malformed tool calls from model output.",
     )
+    nudge_tool_calls: Optional[bool] = Field(
+        None,
+        description = (
+            "[x-unsloth] Opt-in, non-streaming client-tool passthrough only: when the "
+            "model emitted a tool signal that healing could not repair, retry ONCE with "
+            "a short nudge appended (the retry shares the full prompt prefix, so the "
+            "server's KV cache is reused). Default off; UNSLOTH_TOOL_CALL_NUDGE=1 flips "
+            "the process default."
+        ),
+    )
     context_overflow: Optional[Literal["error", "truncate_middle"]] = Field(
         None,
         description = (
@@ -1615,6 +1625,10 @@ class AnthropicMessagesRequest(BaseModel):
     auto_heal_tool_calls: Optional[bool] = Field(
         True,
         description = "[x-unsloth] Auto-detect and fix malformed tool calls from model output (mirrors the Chat Completions field; applies to the client-tool passthrough).",
+    )
+    nudge_tool_calls: Optional[bool] = Field(
+        None,
+        description = "[x-unsloth] Opt-in, non-streaming only: retry once with a nudge when the model emitted a tool signal healing could not repair (mirrors the Chat Completions field).",
     )
     model_config = {"extra": "allow"}
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11011,9 +11011,7 @@ async def _openai_passthrough_stream(
                             # drop the native call here or the client gets two.
                             del delta["tool_calls"]
                             if delta or choice.get("finish_reason") or chunk_data.get("usage"):
-                                lines.append(
-                                    "data: " + json.dumps(chunk_data, ensure_ascii = False)
-                                )
+                                lines.append("data: " + json.dumps(chunk_data, ensure_ascii = False))
                             return lines
                         # A healed call already went out on index 0..n-1; OpenAI
                         # clients merge tool-call deltas by index, so shift the

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1119,6 +1119,8 @@ from core.inference.passthrough_healing import (
     StreamToolCallHealer,
     heal_gate,
     heal_openai_message,
+
+    heal_openai_message_events,
     nudge_enabled,
     nudge_messages,
     nudge_should_retry,
@@ -10451,45 +10453,64 @@ async def _anthropic_passthrough_non_streaming(
     message = choice.get("message") or {}
     finish_reason = choice.get("finish_reason")
 
-    # Promote text-form tool calls (declared client tools only) into structured
-    # tool_calls BEFORE block building, so the tool_use loop and the stop_reason
-    # line below treat them exactly like native calls.
     healing_active = bool(_allowed_tools)
-    if healing_active:
-        heal_openai_message(message, _allowed_tools, openai_tools)
+    healed_events = (
+        heal_openai_message_events(message, _allowed_tools, openai_tools) if healing_active else None
+    )
 
     content_blocks = []
-    text = message.get("content") or ""
-    if text:
-        # Healing span-trims only the promoted declared calls and leaves every
-        # unpromoted byte (undeclared or malformed text-form calls included) in
-        # place to relay as text -- the OpenAI passthrough relays those bytes
-        # verbatim too, and silently emptying the message recreates the dead
-        # turn this path exists to fix. The blanket legacy strip therefore only
-        # runs when healing is off (no declared tools, or opted out).
-        if not healing_active:
-            text = _TOOL_XML_RE.sub("", text)
-        text = text.strip()
-        if text:
-            content_blocks.append(AnthropicResponseTextBlock(text = text))
-
-    tool_calls = message.get("tool_calls") or []
-    # disable_parallel_tool_use: keep only the first tool_use block.
-    if disable_parallel_tool_use and len(tool_calls) > 1:
-        tool_calls = tool_calls[:1]
-    for tc in tool_calls:
-        fn = tc.get("function") or {}
-        try:
-            args = json.loads(fn.get("arguments", "{}"))
-        except json.JSONDecodeError:
-            args = {}
-        content_blocks.append(
-            AnthropicResponseToolUseBlock(
-                id = anthropic_tool_use_id(tc.get("id")),
-                name = fn.get("name", ""),
-                input = args,
+    tool_calls = []
+    if healed_events:
+        emitted_tool_uses = 0
+        for kind, value in healed_events:
+            if kind == "text":
+                text = str(value).strip()
+                if text:
+                    content_blocks.append(AnthropicResponseTextBlock(text = text))
+                continue
+            if disable_parallel_tool_use and emitted_tool_uses >= 1:
+                continue
+            fn = value.get("function") or {}
+            try:
+                args = json.loads(fn.get("arguments", "{}"))
+            except json.JSONDecodeError:
+                args = {}
+            tool_calls.append(value)
+            emitted_tool_uses += 1
+            content_blocks.append(
+                AnthropicResponseToolUseBlock(
+                    id = anthropic_tool_use_id(value.get("id")),
+                    name = fn.get("name", ""),
+                    input = args,
+                )
             )
-        )
+    else:
+        text = message.get("content") or ""
+        if text:
+            # Keep unpromoted bytes when healing is active; legacy stripping is
+            # only for opted-out or no-client-tool requests.
+            if not healing_active:
+                text = _TOOL_XML_RE.sub("", text)
+            text = text.strip()
+            if text:
+                content_blocks.append(AnthropicResponseTextBlock(text = text))
+
+        tool_calls = message.get("tool_calls") or []
+        if disable_parallel_tool_use and len(tool_calls) > 1:
+            tool_calls = tool_calls[:1]
+        for tc in tool_calls:
+            fn = tc.get("function") or {}
+            try:
+                args = json.loads(fn.get("arguments", "{}"))
+            except json.JSONDecodeError:
+                args = {}
+            content_blocks.append(
+                AnthropicResponseToolUseBlock(
+                    id = anthropic_tool_use_id(tc.get("id")),
+                    name = fn.get("name", ""),
+                    input = args,
+                )
+            )
 
     stop_reason = openai_finish_to_anthropic_stop(finish_reason, had_tool_calls = bool(tool_calls))
 
@@ -11052,10 +11073,12 @@ async def _openai_passthrough_stream(
                     # Nothing held or promoted: the healer passed the chunk
                     # through whole, so keep the verbatim upstream bytes.
                     return [raw_line]
-                lines = _healer_sse_lines(events)
-                # The healer re-emits (or withholds) the text, so drop it from the
-                # relayed chunk; keep the chunk only if it still carries anything.
                 del delta["content"]
+                prefix_lines = []
+                if delta:
+                    prefix_lines.append("data: " + json.dumps(chunk_data, ensure_ascii = False))
+                    delta.clear()
+                lines = prefix_lines + _healer_sse_lines(events)
                 if delta or finish or chunk_data.get("usage"):
                     if healer.healed and finish == "stop":
                         choice["finish_reason"] = "tool_calls"

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -10946,7 +10946,9 @@ async def _openai_passthrough_stream(
             last_chunk_id = completion_id
             last_chunk_model = model_name
             last_chunk_created = int(time.time())
-            healer = StreamToolCallHealer(_allowed_tools, body.get("tools")) if _allowed_tools else None
+            healer = (
+                StreamToolCallHealer(_allowed_tools, body.get("tools")) if _allowed_tools else None
+            )
             healed_call_index = 0
 
             def _synthetic_finish_line() -> str:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1119,8 +1119,10 @@ from core.inference.passthrough_healing import (
     StreamToolCallHealer,
     heal_gate,
     heal_openai_message,
+    nudge_enabled,
     nudge_messages,
     nudge_should_retry,
+    response_has_promotable_calls,
 )
 from core.inference.providers import get_base_url
 from core.inference.external_provider import ExternalProviderClient
@@ -8052,10 +8054,13 @@ def _build_chat_request(
         if isinstance(_tpl_kw, dict) and "enable_thinking" in _tpl_kw:
             chat_kwargs["enable_thinking"] = bool(_tpl_kw["enable_thinking"])
             explicit_enable_thinking = True
-        # auto_heal_tool_calls is not typed on ResponsesRequest; lift the opt-out
-        # from the extra-body so passthrough healing honors it on both paths.
+        # auto_heal_tool_calls / nudge_tool_calls are not typed on
+        # ResponsesRequest; lift them from the extra-body so passthrough
+        # healing (and the opt-in nudge) honor them on both paths.
         if isinstance(_extra.get("auto_heal_tool_calls"), bool):
             chat_kwargs["auto_heal_tool_calls"] = _extra["auto_heal_tool_calls"]
+        if isinstance(_extra.get("nudge_tool_calls"), bool):
+            chat_kwargs["nudge_tool_calls"] = _extra["nudge_tool_calls"]
 
     if isinstance(payload.reasoning, dict):
         effort = payload.reasoning.get("effort")
@@ -9508,6 +9513,7 @@ async def anthropic_messages(
                 tool_choice = openai_tool_choice,
                 disable_parallel_tool_use = _disable_parallel,
                 auto_heal_tool_calls = payload.auto_heal_tool_calls,
+                nudge_tool_calls = payload.nudge_tool_calls,
             )
         )
 
@@ -10259,6 +10265,7 @@ async def _anthropic_passthrough_non_streaming(
     tool_choice = "auto",
     disable_parallel_tool_use = False,
     auto_heal_tool_calls = None,
+    nudge_tool_calls = None,
 ):
     """Non-streaming client-side pass-through."""
     target_url = f"{llama_backend.base_url}/v1/chat/completions"
@@ -10291,6 +10298,33 @@ async def _anthropic_passthrough_non_streaming(
         )
 
     data = resp.json()
+    _allowed_tools = heal_gate(auto_heal_tool_calls, openai_tools)
+
+    # Opt-in single-retry nudge (mirrors the OpenAI passthrough): the model
+    # tried to call a tool but nothing usable came out; re-ask once with the
+    # prompt prefix intact so llama-server's KV cache is reused.
+    if (
+        _allowed_tools
+        and nudge_enabled(nudge_tool_calls)
+        and nudge_should_retry(data, _allowed_tools)
+    ):
+        retry_body = {
+            **body,
+            "messages": [*body.get("messages", []), *nudge_messages(data, _allowed_tools)],
+        }
+        try:
+            retry_resp = await nonstreaming_client().post(
+                target_url,
+                json = retry_body,
+                timeout = _llama_non_streaming_generation_timeout(),
+            )
+            if retry_resp.status_code == 200:
+                retry_data = retry_resp.json()
+                if response_has_promotable_calls(retry_data, _allowed_tools):
+                    data = retry_data
+        except (httpx.RequestError, ValueError) as exc:
+            logger.warning("tool-call nudge retry failed; keeping original: %s", exc)
+
     choice = (data.get("choices") or [{}])[0]
     message = choice.get("message") or {}
     finish_reason = choice.get("finish_reason")
@@ -10300,7 +10334,6 @@ async def _anthropic_passthrough_non_streaming(
     # line below treat them exactly like native calls. The legacy XML strip
     # still runs on whatever text remains, preserving today's cleanup when
     # nothing was promoted (or healing is opted out).
-    _allowed_tools = heal_gate(auto_heal_tool_calls, openai_tools)
     if _allowed_tools:
         heal_openai_message(message, _allowed_tools)
 
@@ -11166,6 +11199,33 @@ async def _openai_passthrough_non_streaming(
         )
         api_monitor.finish(monitor_id)
         return Response(content = resp.content, media_type = "application/json")
+
+    # Opt-in single-retry nudge: the model clearly tried to call a tool (signal
+    # present) but nothing parseable/declared came out, so re-ask once with the
+    # original prompt prefix intact (llama-server reuses the slot's KV cache)
+    # plus a two-message nudge suffix. The retry replaces the original response
+    # only when it actually yields a usable call.
+    if (
+        _allowed_tools
+        and nudge_enabled(payload.nudge_tool_calls)
+        and nudge_should_retry(data, _allowed_tools)
+    ):
+        retry_body = {
+            **body,
+            "messages": [*body.get("messages", []), *nudge_messages(data, _allowed_tools)],
+        }
+        try:
+            retry_resp = await nonstreaming_client().post(
+                target_url,
+                json = retry_body,
+                timeout = _llama_non_streaming_generation_timeout(),
+            )
+            if retry_resp.status_code == 200:
+                retry_data = retry_resp.json()
+                if response_has_promotable_calls(retry_data, _allowed_tools):
+                    resp, data = retry_resp, retry_data
+        except (httpx.RequestError, ValueError) as exc:
+            logger.warning("tool-call nudge retry failed; keeping original: %s", exc)
 
     changed = False
     for choice in data.get("choices", []):

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -9487,6 +9487,7 @@ async def anthropic_messages(
                     session_id = payload.session_id,
                     cancel_id = payload.cancel_id,
                     disable_parallel_tool_use = _disable_parallel,
+                    auto_heal_tool_calls = payload.auto_heal_tool_calls,
                 )
             )
         return await _monitored_anthropic(
@@ -9506,6 +9507,7 @@ async def anthropic_messages(
                 presence_penalty = presence_penalty,
                 tool_choice = openai_tool_choice,
                 disable_parallel_tool_use = _disable_parallel,
+                auto_heal_tool_calls = payload.auto_heal_tool_calls,
             )
         )
 
@@ -10076,6 +10078,7 @@ async def _anthropic_passthrough_stream(
     session_id = None,
     cancel_id = None,
     disable_parallel_tool_use = False,
+    auto_heal_tool_calls = None,
 ):
     """Streaming client-side pass-through: forward tools to llama-server and
     translate its stream to Anthropic SSE without executing anything."""
@@ -10112,6 +10115,13 @@ async def _anthropic_passthrough_stream(
 
     async def _stream():
         emitter = AnthropicPassthroughEmitter()
+        # Promote text-form tool calls (declared client tools only) into
+        # tool_use blocks; verbatim behavior when healing is off or no tools.
+        _allowed_tools = heal_gate(auto_heal_tool_calls, openai_tools)
+        if _allowed_tools:
+            emitter.enable_healing(
+                _allowed_tools, disable_parallel_tool_use = disable_parallel_tool_use
+            )
         for line in emitter.start(message_id, model_name, input_tokens = input_tokens):
             yield line
 
@@ -10248,6 +10258,7 @@ async def _anthropic_passthrough_non_streaming(
     presence_penalty = None,
     tool_choice = "auto",
     disable_parallel_tool_use = False,
+    auto_heal_tool_calls = None,
 ):
     """Non-streaming client-side pass-through."""
     target_url = f"{llama_backend.base_url}/v1/chat/completions"
@@ -10283,6 +10294,15 @@ async def _anthropic_passthrough_non_streaming(
     choice = (data.get("choices") or [{}])[0]
     message = choice.get("message") or {}
     finish_reason = choice.get("finish_reason")
+
+    # Promote text-form tool calls (declared client tools only) into structured
+    # tool_calls BEFORE block building, so the tool_use loop and the stop_reason
+    # line below treat them exactly like native calls. The legacy XML strip
+    # still runs on whatever text remains, preserving today's cleanup when
+    # nothing was promoted (or healing is opted out).
+    _allowed_tools = heal_gate(auto_heal_tool_calls, openai_tools)
+    if _allowed_tools:
+        heal_openai_message(message, _allowed_tools)
 
     content_blocks = []
     text = message.get("content") or ""

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1119,7 +1119,6 @@ from core.inference.passthrough_healing import (
     StreamToolCallHealer,
     heal_gate,
     heal_openai_message,
-
     heal_openai_message_events,
     nudge_enabled,
     nudge_messages,
@@ -10455,7 +10454,9 @@ async def _anthropic_passthrough_non_streaming(
 
     healing_active = bool(_allowed_tools)
     healed_events = (
-        heal_openai_message_events(message, _allowed_tools, openai_tools) if healing_active else None
+        heal_openai_message_events(message, _allowed_tools, openai_tools)
+        if healing_active
+        else None
     )
 
     content_blocks = []

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -10451,22 +10451,21 @@ async def _anthropic_passthrough_non_streaming(
 
     # Promote text-form tool calls (declared client tools only) into structured
     # tool_calls BEFORE block building, so the tool_use loop and the stop_reason
-    # line below treat them exactly like native calls. The legacy XML strip
-    # still runs on whatever text remains, preserving today's cleanup when
-    # nothing was promoted (or healing is opted out).
-    healed = False
-    if _allowed_tools:
-        healed = heal_openai_message(message, _allowed_tools)
+    # line below treat them exactly like native calls.
+    healing_active = bool(_allowed_tools)
+    if healing_active:
+        heal_openai_message(message, _allowed_tools)
 
     content_blocks = []
     text = message.get("content") or ""
     if text:
-        # Once healing promoted a call it span-trims only that declared call's
-        # markup and leaves every unpromoted byte (undeclared text-form calls
-        # included) in place to relay as text. Running the blanket legacy strip
-        # then would delete those bytes, so only apply it when nothing was
-        # promoted (or healing is opted out), matching the OpenAI passthrough.
-        if not healed:
+        # Healing span-trims only the promoted declared calls and leaves every
+        # unpromoted byte (undeclared or malformed text-form calls included) in
+        # place to relay as text -- the OpenAI passthrough relays those bytes
+        # verbatim too, and silently emptying the message recreates the dead
+        # turn this path exists to fix. The blanket legacy strip therefore only
+        # runs when healing is off (no declared tools, or opted out).
+        if not healing_active:
             text = _TOOL_XML_RE.sub("", text)
         text = text.strip()
         if text:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -10454,13 +10454,21 @@ async def _anthropic_passthrough_non_streaming(
     # line below treat them exactly like native calls. The legacy XML strip
     # still runs on whatever text remains, preserving today's cleanup when
     # nothing was promoted (or healing is opted out).
+    healed = False
     if _allowed_tools:
-        heal_openai_message(message, _allowed_tools)
+        healed = heal_openai_message(message, _allowed_tools)
 
     content_blocks = []
     text = message.get("content") or ""
     if text:
-        text = _TOOL_XML_RE.sub("", text).strip()
+        # Once healing promoted a call it span-trims only that declared call's
+        # markup and leaves every unpromoted byte (undeclared text-form calls
+        # included) in place to relay as text. Running the blanket legacy strip
+        # then would delete those bytes, so only apply it when nothing was
+        # promoted (or healing is opted out), matching the OpenAI passthrough.
+        if not healed:
+            text = _TOOL_XML_RE.sub("", text)
+        text = text.strip()
         if text:
             content_blocks.append(AnthropicResponseTextBlock(text = text))
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -8526,9 +8526,7 @@ async def _responses_stream(
                             "id": message_state["item_id"],
                             "status": "completed",
                             "role": "assistant",
-                            "content": [
-                                {"type": "output_text", "text": text, "annotations": []}
-                            ],
+                            "content": [{"type": "output_text", "text": text, "annotations": []}],
                         },
                     },
                 ),

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -8304,7 +8304,9 @@ async def _responses_stream(
         # Text-form tool calls promoted back to structured calls (declared
         # client tools only); dormant once grammar-mode structured deltas appear.
         _allowed_tools = heal_gate(
-            getattr(chat_req, "auto_heal_tool_calls", None), body.get("tools")
+            getattr(chat_req, "auto_heal_tool_calls", None),
+            body.get("tools"),
+            body.get("tool_choice"),
         )
         healer = StreamToolCallHealer(_allowed_tools) if _allowed_tools else None
         healed_tc_index = 0
@@ -8473,6 +8475,41 @@ async def _responses_stream(
                     },
                 ),
             ]
+
+        def _healed_event_sse(events) -> list[str]:
+            """Serialize healer events preserving their order.
+
+            Text around a healed call must keep its position relative to the
+            function_call item (output indexes are claimed in emission order),
+            so never split an event list into all-text-then-all-calls.
+            """
+            nonlocal full_text
+            out: list[str] = []
+            for kind, value in events:
+                if kind == "text":
+                    if not value:
+                        continue
+                    out.extend(_ensure_message_open())
+                    full_text += value
+                    api_monitor.append_reply(monitor_id, value)
+                    out.append(
+                        _sse(
+                            "response.output_text.delta",
+                            {
+                                "type": "response.output_text.delta",
+                                "item_id": message_state["item_id"],
+                                "output_index": message_state["output_index"],
+                                "content_index": 0,
+                                "delta": value,
+                            },
+                        )
+                    )
+                else:
+                    tc = _healed_tc(value)
+                    if tc is None:
+                        continue
+                    out.extend(_tool_call_delta_events(tc))
+            return out
 
         def _snapshot_output() -> list[dict]:
             """Snapshot of all completed output items for response.completed."""
@@ -8688,19 +8725,23 @@ async def _responses_stream(
                     )
                 # Heal text-form tool calls in the visible stream (never in
                 # reasoning text): promoted calls join the structured tc loop
-                # below through the same state machinery. Once a structured
-                # delta arrives, grammar mode worked and the healer goes dormant.
-                healed_calls: list = []
+                # below through the same state machinery, and healer events are
+                # emitted IN ORDER so text after a healed call never jumps ahead
+                # of the function_call item. Once a structured delta arrives,
+                # grammar mode worked and the healer goes dormant.
                 if healer is not None and not healer.dormant:
+                    healed_events = []
                     if delta.get("tool_calls"):
-                        held = healer.structured_tool_call_seen()
-                        visible_delta = (
-                            "".join(t for kind, t in held if kind == "text") + visible_delta
-                        )
+                        # Held text preceded the structured call; the call's own
+                        # deltas follow in the structured loop below.
+                        healed_events = healer.structured_tool_call_seen()
+                        if visible_delta:
+                            healed_events.append(("text", visible_delta))
                     elif visible_delta:
-                        events = healer.feed(visible_delta)
-                        visible_delta = "".join(t for kind, t in events if kind == "text")
-                        healed_calls = [v for kind, v in events if kind == "tool_call"]
+                        healed_events = healer.feed(visible_delta)
+                    visible_delta = ""
+                    for event in _healed_event_sse(healed_events):
+                        yield event
                 if visible_delta:
                     for event in _ensure_message_open():
                         yield event
@@ -8717,12 +8758,7 @@ async def _responses_stream(
                         },
                     )
 
-                for tc in [
-                    *(delta.get("tool_calls") or []),
-                    *(_healed_tc(call) for call in healed_calls),
-                ]:
-                    if tc is None:
-                        continue
+                for tc in delta.get("tool_calls") or []:
                     for event in _tool_call_delta_events(tc):
                         yield event
 
@@ -8781,12 +8817,13 @@ async def _responses_stream(
                 },
             )
         # Last-chance heal of any held residue (e.g. a tool block the model
-        # never closed) before the trailing visible text is flushed.
-        healed_final_calls: list = []
+        # never closed) before the trailing visible text is flushed; events
+        # keep healer order so trailing text stays behind a healed call.
         if healer is not None:
             events = (healer.feed(final_visible) if final_visible else []) + healer.finalize()
-            final_visible = "".join(t for kind, t in events if kind == "text")
-            healed_final_calls = [v for kind, v in events if kind == "tool_call"]
+            final_visible = ""
+            for event in _healed_event_sse(events):
+                yield event
         if final_visible:
             for event in _ensure_message_open():
                 yield event
@@ -8802,12 +8839,6 @@ async def _responses_stream(
                     "delta": final_visible,
                 },
             )
-        for call in healed_final_calls:
-            tc = _healed_tc(call)
-            if tc is None:
-                continue
-            for event in _tool_call_delta_events(tc):
-                yield event
 
         close_items: list[tuple[int, str, dict[str, Any]]] = []
         if reasoning_state["opened"]:
@@ -10123,7 +10154,8 @@ async def _anthropic_passthrough_stream(
         emitter = AnthropicPassthroughEmitter()
         # Promote text-form tool calls (declared client tools only) into
         # tool_use blocks; verbatim behavior when healing is off or no tools.
-        _allowed_tools = heal_gate(auto_heal_tool_calls, openai_tools)
+        # tool_choice arrives here already converted to the OpenAI shape.
+        _allowed_tools = heal_gate(auto_heal_tool_calls, openai_tools, tool_choice)
         if _allowed_tools:
             emitter.enable_healing(
                 _allowed_tools, disable_parallel_tool_use = disable_parallel_tool_use
@@ -10298,7 +10330,8 @@ async def _anthropic_passthrough_non_streaming(
         )
 
     data = resp.json()
-    _allowed_tools = heal_gate(auto_heal_tool_calls, openai_tools)
+    # tool_choice arrives here already converted to the OpenAI shape.
+    _allowed_tools = heal_gate(auto_heal_tool_calls, openai_tools, tool_choice)
 
     # Opt-in single-retry nudge (mirrors the OpenAI passthrough): the model
     # tried to call a tool but nothing usable came out; re-ask once with the
@@ -10710,8 +10743,11 @@ async def _openai_passthrough_stream(
     )
     # Text-form tool calls from small models get promoted to structured calls on
     # the way back (declared client tools only); requests without tools or with
-    # auto_heal_tool_calls=false keep the verbatim relay.
-    _allowed_tools = heal_gate(payload.auto_heal_tool_calls, body.get("tools"))
+    # auto_heal_tool_calls=false keep the verbatim relay. tool_choice constrains
+    # the allowlist ("none" disables, a forced function narrows to it).
+    _allowed_tools = heal_gate(
+        payload.auto_heal_tool_calls, body.get("tools"), body.get("tool_choice")
+    )
 
     _cancel_keys = (payload.cancel_id, payload.session_id, completion_id)
     _tracker = _TrackedCancel(cancel_event, *_cancel_keys)
@@ -11192,7 +11228,9 @@ async def _openai_passthrough_non_streaming(
     _guided_fence = bool((payload.model_extra or {}).get("_unsloth_guided_fence"))
     _do_fence = _guided_fence and _extract_response_format(payload) is not None
     _cap_parallel = payload.parallel_tool_calls is False
-    _allowed_tools = heal_gate(payload.auto_heal_tool_calls, body.get("tools"))
+    _allowed_tools = heal_gate(
+        payload.auto_heal_tool_calls, body.get("tools"), body.get("tool_choice")
+    )
 
     try:
         data = resp.json()
@@ -11242,8 +11280,13 @@ async def _openai_passthrough_non_streaming(
 
         # Small models emit tool calls as text instead of structured tool_calls;
         # promote them (declared client tools only) so the agent sees a real call.
+        # Truncation wins over the upgrade (same rule as the streaming and
+        # Anthropic paths): a call cut off at max_tokens keeps
+        # finish_reason="length" so the client knows the arguments may be
+        # incomplete, while the healed call itself stays attached.
         if _allowed_tools and heal_openai_message(msg, _allowed_tools):
-            choice["finish_reason"] = "tool_calls"
+            if choice.get("finish_reason") == "stop":
+                choice["finish_reason"] = "tool_calls"
             changed = True
 
         # OpenAI requires content=null on a pure tool-call turn; llama-server

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1115,6 +1115,13 @@ from core.inference.key_exchange import decrypt_api_key
 from core.inference.model_ids import public_model_id
 from core.inference.api_monitor import api_monitor
 from core.inference.llama_http import nonstreaming_client
+from core.inference.passthrough_healing import (
+    StreamToolCallHealer,
+    heal_gate,
+    heal_openai_message,
+    nudge_messages,
+    nudge_should_retry,
+)
 from core.inference.providers import get_base_url
 from core.inference.external_provider import ExternalProviderClient
 from core.inference.chat_templates import resolve_effective_chat_template_override
@@ -8045,6 +8052,10 @@ def _build_chat_request(
         if isinstance(_tpl_kw, dict) and "enable_thinking" in _tpl_kw:
             chat_kwargs["enable_thinking"] = bool(_tpl_kw["enable_thinking"])
             explicit_enable_thinking = True
+        # auto_heal_tool_calls is not typed on ResponsesRequest; lift the opt-out
+        # from the extra-body so passthrough healing honors it on both paths.
+        if isinstance(_extra.get("auto_heal_tool_calls"), bool):
+            chat_kwargs["auto_heal_tool_calls"] = _extra["auto_heal_tool_calls"]
 
     if isinstance(payload.reasoning, dict):
         effort = payload.reasoning.get("effort")
@@ -8285,9 +8296,94 @@ async def _responses_stream(
         #   {output_index, item_id, call_id, name, arguments, opened}
         tool_call_state: dict[int, dict] = {}
         next_output_index = 0
+        # Text-form tool calls promoted back to structured calls (declared
+        # client tools only); dormant once grammar-mode structured deltas appear.
+        _allowed_tools = heal_gate(
+            getattr(chat_req, "auto_heal_tool_calls", None), body.get("tools")
+        )
+        healer = StreamToolCallHealer(_allowed_tools) if _allowed_tools else None
+        healed_tc_index = 0
+
+        def _healed_tc(call: dict):
+            # Chat-delta shape for a healed call. Indexes live in a disjoint
+            # range so a healed call can never merge into a structured call's
+            # state slot; parallel_tool_calls=false caps healed calls too (the
+            # upstream cap ran before injection).
+            nonlocal healed_tc_index
+            if payload.parallel_tool_calls is False and healed_tc_index >= 1:
+                return None
+            tc = {
+                "index": 1_000_000 + healed_tc_index,
+                "id": call["id"],
+                "type": "function",
+                "function": call["function"],
+            }
+            healed_tc_index += 1
+            return tc
 
         def _sse(event_name: str, payload: dict) -> str:
             return f"event: {event_name}\ndata: {json.dumps(payload)}\n\n"
+
+        def _tool_call_delta_events(tc: dict) -> list:
+            # One Chat Completions tool_calls delta -> Responses SSE events,
+            # allocating/merging per-call state (shared by the structured loop
+            # and the healer's promoted calls).
+            events = []
+            idx = tc.get("index", 0)
+            st = tool_call_state.get(idx)
+            fn = tc.get("function") or {}
+            if st is None:
+                # First chunk for this tool call -- allocate an
+                # output_index and emit output_item.added.
+                st = {
+                    "output_index": _claim_output_index(),
+                    "item_id": f"fc_{uuid.uuid4().hex[:12]}",
+                    "call_id": tc.get("id") or "",
+                    "name": fn.get("name") or "",
+                    "arguments": "",
+                    "opened": False,
+                }
+                tool_call_state[idx] = st
+            else:
+                # Later chunks sometimes carry id/name only once; merge
+                # when present.
+                if tc.get("id") and not st["call_id"]:
+                    st["call_id"] = tc["id"]
+                if fn.get("name") and not st["name"]:
+                    st["name"] = fn["name"]
+
+            if not st["opened"] and st["call_id"] and st["name"]:
+                item_added = {
+                    "type": "response.output_item.added",
+                    "output_index": st["output_index"],
+                    "item": {
+                        "type": "function_call",
+                        "id": st["item_id"],
+                        "status": "in_progress",
+                        "call_id": st["call_id"],
+                        "name": st["name"],
+                        "arguments": "",
+                    },
+                }
+                events.append(_sse("response.output_item.added", item_added))
+                st["opened"] = True
+
+            arg_delta = fn.get("arguments") or ""
+            if arg_delta and st["opened"]:
+                st["arguments"] += arg_delta
+                args_delta_event = {
+                    "type": "response.function_call_arguments.delta",
+                    "item_id": st["item_id"],
+                    "output_index": st["output_index"],
+                    "delta": arg_delta,
+                }
+                events.append(_sse("response.function_call_arguments.delta", args_delta_event))
+            elif arg_delta:
+                # Buffer args until we can open the item (some models
+                # send id/name in the same chunk as the first arg delta;
+                # if not, stash).
+                st["arguments"] += arg_delta
+            return events
 
         def _claim_output_index() -> int:
             nonlocal next_output_index
@@ -8585,6 +8681,21 @@ async def _responses_stream(
                             "delta": reasoning_delta,
                         },
                     )
+                # Heal text-form tool calls in the visible stream (never in
+                # reasoning text): promoted calls join the structured tc loop
+                # below through the same state machinery. Once a structured
+                # delta arrives, grammar mode worked and the healer goes dormant.
+                healed_calls: list = []
+                if healer is not None and not healer.dormant:
+                    if delta.get("tool_calls"):
+                        held = healer.structured_tool_call_seen()
+                        visible_delta = (
+                            "".join(t for kind, t in held if kind == "text") + visible_delta
+                        )
+                    elif visible_delta:
+                        events = healer.feed(visible_delta)
+                        visible_delta = "".join(t for kind, t in events if kind == "text")
+                        healed_calls = [v for kind, v in events if kind == "tool_call"]
                 if visible_delta:
                     for event in _ensure_message_open():
                         yield event
@@ -8601,61 +8712,14 @@ async def _responses_stream(
                         },
                     )
 
-                for tc in delta.get("tool_calls") or []:
-                    idx = tc.get("index", 0)
-                    st = tool_call_state.get(idx)
-                    fn = tc.get("function") or {}
-                    if st is None:
-                        # First chunk for this tool call -- allocate an
-                        # output_index and emit output_item.added.
-                        st = {
-                            "output_index": _claim_output_index(),
-                            "item_id": f"fc_{uuid.uuid4().hex[:12]}",
-                            "call_id": tc.get("id") or "",
-                            "name": fn.get("name") or "",
-                            "arguments": "",
-                            "opened": False,
-                        }
-                        tool_call_state[idx] = st
-                    else:
-                        # Later chunks sometimes carry id/name only once; merge
-                        # when present.
-                        if tc.get("id") and not st["call_id"]:
-                            st["call_id"] = tc["id"]
-                        if fn.get("name") and not st["name"]:
-                            st["name"] = fn["name"]
-
-                    if not st["opened"] and st["call_id"] and st["name"]:
-                        item_added = {
-                            "type": "response.output_item.added",
-                            "output_index": st["output_index"],
-                            "item": {
-                                "type": "function_call",
-                                "id": st["item_id"],
-                                "status": "in_progress",
-                                "call_id": st["call_id"],
-                                "name": st["name"],
-                                "arguments": "",
-                            },
-                        }
-                        yield _sse("response.output_item.added", item_added)
-                        st["opened"] = True
-
-                    arg_delta = fn.get("arguments") or ""
-                    if arg_delta and st["opened"]:
-                        st["arguments"] += arg_delta
-                        args_delta_event = {
-                            "type": "response.function_call_arguments.delta",
-                            "item_id": st["item_id"],
-                            "output_index": st["output_index"],
-                            "delta": arg_delta,
-                        }
-                        yield _sse("response.function_call_arguments.delta", args_delta_event)
-                    elif arg_delta:
-                        # Buffer args until we can open the item (some models
-                        # send id/name in the same chunk as the first arg delta;
-                        # if not, stash).
-                        st["arguments"] += arg_delta
+                for tc in [
+                    *(delta.get("tool_calls") or []),
+                    *(_healed_tc(call) for call in healed_calls),
+                ]:
+                    if tc is None:
+                        continue
+                    for event in _tool_call_delta_events(tc):
+                        yield event
 
                 _apply_usage(chunk_data.get("usage"))
         except asyncio.CancelledError:
@@ -8711,6 +8775,13 @@ async def _responses_stream(
                     "delta": final_reasoning,
                 },
             )
+        # Last-chance heal of any held residue (e.g. a tool block the model
+        # never closed) before the trailing visible text is flushed.
+        healed_final_calls: list = []
+        if healer is not None:
+            events = (healer.feed(final_visible) if final_visible else []) + healer.finalize()
+            final_visible = "".join(t for kind, t in events if kind == "text")
+            healed_final_calls = [v for kind, v in events if kind == "tool_call"]
         if final_visible:
             for event in _ensure_message_open():
                 yield event
@@ -8726,6 +8797,12 @@ async def _responses_stream(
                     "delta": final_visible,
                 },
             )
+        for call in healed_final_calls:
+            tc = _healed_tc(call)
+            if tc is None:
+                continue
+            for event in _tool_call_delta_events(tc):
+                yield event
 
         close_items: list[tuple[int, str, dict[str, Any]]] = []
         if reasoning_state["opened"]:
@@ -10578,6 +10655,10 @@ async def _openai_passthrough_stream(
     body = _build_openai_passthrough_body(
         payload, backend_ctx = llama_backend.context_length, llama_backend = llama_backend
     )
+    # Text-form tool calls from small models get promoted to structured calls on
+    # the way back (declared client tools only); requests without tools or with
+    # auto_heal_tool_calls=false keep the verbatim relay.
+    _allowed_tools = heal_gate(payload.auto_heal_tool_calls, body.get("tools"))
 
     _cancel_keys = (payload.cancel_id, payload.session_id, completion_id)
     _tracker = _TrackedCancel(cancel_event, *_cancel_keys)
@@ -10680,9 +10761,12 @@ async def _openai_passthrough_stream(
             last_chunk_id = completion_id
             last_chunk_model = model_name
             last_chunk_created = int(time.time())
+            healer = StreamToolCallHealer(_allowed_tools) if _allowed_tools else None
+            healed_call_index = 0
 
             def _synthetic_finish_line() -> str:
-                finish_reason = "tool_calls" if saw_tool_call_delta else "stop"
+                healed = healer is not None and healer.healed
+                finish_reason = "tool_calls" if (saw_tool_call_delta or healed) else "stop"
                 chunk = ChatCompletionChunk(
                     id = last_chunk_id,
                     created = last_chunk_created,
@@ -10695,6 +10779,83 @@ async def _openai_passthrough_stream(
                     ],
                 )
                 return f"data: {chunk.model_dump_json(exclude_none = True)}"
+
+            def _healer_sse_lines(events) -> list:
+                # Serialize healer events as chunks matching the upstream stream's
+                # id/model/created so clients see one coherent completion.
+                nonlocal healed_call_index
+                lines = []
+                for kind, value in events:
+                    if kind == "text":
+                        if not value:
+                            continue
+                        delta = {"content": value}
+                    else:
+                        # parallel_tool_calls=false caps healed calls too (the SSE
+                        # line cap only sees structured upstream deltas).
+                        if payload.parallel_tool_calls is False and healed_call_index >= 1:
+                            continue
+                        delta = {
+                            "tool_calls": [
+                                {
+                                    "index": healed_call_index,
+                                    "id": value["id"],
+                                    "type": "function",
+                                    "function": value["function"],
+                                }
+                            ]
+                        }
+                        healed_call_index += 1
+                    chunk = {
+                        "id": last_chunk_id,
+                        "object": "chat.completion.chunk",
+                        "created": last_chunk_created,
+                        "model": last_chunk_model,
+                        "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
+                    }
+                    lines.append("data: " + json.dumps(chunk, ensure_ascii = False))
+                return lines
+
+            def _heal_transform(chunk_data: dict, raw_line: str) -> list:
+                """SSE lines to emit in place of one upstream line (healing on)."""
+                choices = chunk_data.get("choices")
+                if not (isinstance(choices, list) and choices and isinstance(choices[0], dict)):
+                    return [raw_line]
+                choice = choices[0]
+                delta = choice.get("delta")
+                delta = delta if isinstance(delta, dict) else {}
+                if delta.get("tool_calls"):
+                    # Structured call streamed: grammar mode worked. Flush any held
+                    # text (it preceded the call) and relay verbatim from here on.
+                    return _healer_sse_lines(healer.structured_tool_call_seen()) + [raw_line]
+                content = delta.get("content")
+                finish = choice.get("finish_reason")
+                if not isinstance(content, str) or not content:
+                    if not finish:
+                        return [raw_line]
+                    # Finish chunk: last-chance heal of the residue, and rewrite a
+                    # "stop" into "tool_calls" when text-form calls were promoted.
+                    lines = _healer_sse_lines(healer.finalize())
+                    if healer.healed and finish == "stop":
+                        choice["finish_reason"] = "tool_calls"
+                        return lines + ["data: " + json.dumps(chunk_data, ensure_ascii = False)]
+                    return lines + [raw_line]
+                events = healer.feed(content)
+                if finish:
+                    events += healer.finalize()
+                if not finish and events == [("text", content)]:
+                    # Nothing held or promoted: the healer passed the chunk
+                    # through whole, so keep the verbatim upstream bytes.
+                    return [raw_line]
+                lines = _healer_sse_lines(events)
+                # The healer re-emits (or withholds) the text, so drop it from the
+                # relayed chunk; keep the chunk only if it still carries anything.
+                del delta["content"]
+                if delta or finish or chunk_data.get("usage"):
+                    if healer.healed and finish == "stop":
+                        choice["finish_reason"] = "tool_calls"
+                    lines.append("data: " + json.dumps(chunk_data, ensure_ascii = False))
+                return lines
 
             try:
                 lines_iter = resp.aiter_lines()
@@ -10712,6 +10873,14 @@ async def _openai_passthrough_stream(
                     data_text = raw_line[6:].strip()
                     if data_text == "[DONE]":
                         saw_done = True
+                        # Upstream ended without a finish chunk: heal the residue
+                        # first so the synthetic finish sees healer.healed.
+                        if healer is not None and not saw_stream_error:
+                            for held_line in _healer_sse_lines(healer.finalize()):
+                                _monitor_openai_sse_line(
+                                    monitor_id, held_line, llama_backend.context_length
+                                )
+                                yield held_line + "\n\n"
                         if (
                             not saw_finish_reason
                             and not saw_stream_error
@@ -10767,13 +10936,13 @@ async def _openai_passthrough_stream(
                         # emit a successful finish_reason after a failed stream.
                         if _monitor_openai_error_message(chunk_data):
                             saw_stream_error = True
-                    monitor_event = _monitor_openai_sse_line(
-                        monitor_id,
-                        raw_line,
-                        llama_backend.context_length,
-                    )
-                    if monitor_event == "error":
-                        saw_stream_error = True
+                    # With healing active, a content-bearing line may be replaced by
+                    # held/promoted chunks; otherwise the single upstream line
+                    # relays verbatim (monitored exactly as emitted either way).
+                    if healer is not None and not healer.dormant and isinstance(chunk_data, dict) and not saw_stream_error:
+                        out_lines = _heal_transform(chunk_data, raw_line)
+                    else:
+                        out_lines = [raw_line]
                     # If a trailing usage-only chunk (include_usage) arrives before
                     # any finish chunk, emit the synthetic finish first so the order
                     # stays finish -> usage -> [DONE], matching the other streams.
@@ -10787,23 +10956,46 @@ async def _openai_passthrough_stream(
                         and not saw_stream_error
                         and not cancel_event.is_set()
                     ):
+                        if healer is not None:
+                            # Residue must precede the finish it may upgrade.
+                            held = _healer_sse_lines(healer.finalize())
+                            for held_line in held:
+                                _monitor_openai_sse_line(
+                                    monitor_id, held_line, llama_backend.context_length
+                                )
+                                yield held_line + "\n\n"
                         finish_line = _synthetic_finish_line()
                         _monitor_openai_sse_line(
                             monitor_id, finish_line, llama_backend.context_length
                         )
                         yield finish_line + "\n\n"
                         saw_finish_reason = True
-                    # Relay verbatim to preserve llama-server's native id,
-                    # finish_reason, delta.tool_calls, and usage chunks.
-                    yield raw_line + "\n\n"
-                    if monitor_event == "done":
-                        monitor_done = True
+                    for out_line in out_lines:
+                        monitor_event = _monitor_openai_sse_line(
+                            monitor_id,
+                            out_line,
+                            llama_backend.context_length,
+                        )
+                        if monitor_event == "error":
+                            saw_stream_error = True
+                        # Relay to preserve llama-server's native id,
+                        # finish_reason, delta.tool_calls, and usage chunks.
+                        yield out_line + "\n\n"
+                        if monitor_event == "done":
+                            monitor_done = True
+                    if monitor_done:
                         break
                 if not saw_done and not saw_stream_error and not cancel_event.is_set():
                     # Synthesize a finish chunk only if one was not already
                     # emitted (e.g. before a trailing usage-only chunk), but
                     # always close with [DONE] whenever the upstream omitted it,
                     # so the stream ends on the [DONE] sentinel either way.
+                    if healer is not None:
+                        for held_line in _healer_sse_lines(healer.finalize()):
+                            _monitor_openai_sse_line(
+                                monitor_id, held_line, llama_backend.context_length
+                            )
+                            yield held_line + "\n\n"
                     if not saw_finish_reason:
                         finish_line = _synthetic_finish_line()
                         _monitor_openai_sse_line(
@@ -10942,6 +11134,7 @@ async def _openai_passthrough_non_streaming(
     _guided_fence = bool((payload.model_extra or {}).get("_unsloth_guided_fence"))
     _do_fence = _guided_fence and _extract_response_format(payload) is not None
     _cap_parallel = payload.parallel_tool_calls is False
+    _allowed_tools = heal_gate(payload.auto_heal_tool_calls, body.get("tools"))
 
     try:
         data = resp.json()
@@ -10961,6 +11154,12 @@ async def _openai_passthrough_non_streaming(
         msg = choice.get("message")
         if not isinstance(msg, dict):
             continue
+
+        # Small models emit tool calls as text instead of structured tool_calls;
+        # promote them (declared client tools only) so the agent sees a real call.
+        if _allowed_tools and heal_openai_message(msg, _allowed_tools):
+            choice["finish_reason"] = "tool_calls"
+            changed = True
 
         # OpenAI requires content=null on a pure tool-call turn; llama-server
         # emits content="".

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -10992,7 +10992,12 @@ async def _openai_passthrough_stream(
                     # With healing active, a content-bearing line may be replaced by
                     # held/promoted chunks; otherwise the single upstream line
                     # relays verbatim (monitored exactly as emitted either way).
-                    if healer is not None and not healer.dormant and isinstance(chunk_data, dict) and not saw_stream_error:
+                    if (
+                        healer is not None
+                        and not healer.dormant
+                        and isinstance(chunk_data, dict)
+                        and not saw_stream_error
+                    ):
                         out_lines = _heal_transform(chunk_data, raw_line)
                     else:
                         out_lines = [raw_line]

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -8830,6 +8830,17 @@ async def _responses_stream(
                     )
 
                 for tc in delta.get("tool_calls") or []:
+                    if (
+                        payload.parallel_tool_calls is False
+                        and healed_tc_index >= 1
+                        and tc.get("index", 0) not in tool_call_state
+                    ):
+                        # A healed call already consumed the single allowed slot;
+                        # _drop_parallel_tool_call_deltas only sees native indexes,
+                        # so a native index-0 call would still open a second
+                        # function_call item. Skip it (and its later argument
+                        # deltas, which never allocate a state either).
+                        continue
                     for event in _tool_call_delta_events(tc):
                         yield event
 
@@ -10994,6 +11005,16 @@ async def _openai_passthrough_stream(
                     # text (it preceded the call) and relay verbatim from here on.
                     lines = _healer_sse_lines(healer.structured_tool_call_seen())
                     if healed_call_index:
+                        if payload.parallel_tool_calls is False:
+                            # A healed call already consumed the single allowed
+                            # slot; the upstream SSE cap keeps native index 0, so
+                            # drop the native call here or the client gets two.
+                            del delta["tool_calls"]
+                            if delta or choice.get("finish_reason") or chunk_data.get("usage"):
+                                lines.append(
+                                    "data: " + json.dumps(chunk_data, ensure_ascii = False)
+                                )
+                            return lines
                         # A healed call already went out on index 0..n-1; OpenAI
                         # clients merge tool-call deltas by index, so shift the
                         # native calls into the next indexes or they would merge

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11077,7 +11077,12 @@ async def _openai_passthrough_stream(
                 del delta["content"]
                 prefix_lines = []
                 if delta:
-                    prefix_lines.append("data: " + json.dumps(chunk_data, ensure_ascii = False))
+                    prefix_chunk = {k: v for k, v in chunk_data.items() if k != "usage"}
+                    prefix_choice = dict(choice)
+                    prefix_choice["delta"] = dict(delta)
+                    prefix_choice["finish_reason"] = None
+                    prefix_chunk["choices"] = [prefix_choice]
+                    prefix_lines.append("data: " + json.dumps(prefix_chunk, ensure_ascii = False))
                     delta.clear()
                 lines = prefix_lines + _healer_sse_lines(events)
                 if delta or finish or chunk_data.get("usage"):

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -8317,7 +8317,7 @@ async def _responses_stream(
             body.get("tools"),
             body.get("tool_choice"),
         )
-        healer = StreamToolCallHealer(_allowed_tools) if _allowed_tools else None
+        healer = StreamToolCallHealer(_allowed_tools, body.get("tools")) if _allowed_tools else None
         healed_tc_index = 0
 
         def _healed_tc(call: dict):
@@ -10245,7 +10245,9 @@ async def _anthropic_passthrough_stream(
         _allowed_tools = heal_gate(auto_heal_tool_calls, openai_tools, tool_choice)
         if _allowed_tools:
             emitter.enable_healing(
-                _allowed_tools, disable_parallel_tool_use = disable_parallel_tool_use
+                _allowed_tools,
+                openai_tools,
+                disable_parallel_tool_use = disable_parallel_tool_use,
             )
         for line in emitter.start(message_id, model_name, input_tokens = input_tokens):
             yield line
@@ -10426,7 +10428,7 @@ async def _anthropic_passthrough_non_streaming(
     if (
         _allowed_tools
         and nudge_enabled(nudge_tool_calls)
-        and nudge_should_retry(data, _allowed_tools)
+        and nudge_should_retry(data, _allowed_tools, openai_tools)
     ):
         retry_body = {
             **body,
@@ -10440,7 +10442,7 @@ async def _anthropic_passthrough_non_streaming(
             )
             if retry_resp.status_code == 200:
                 retry_data = retry_resp.json()
-                if response_has_promotable_calls(retry_data, _allowed_tools):
+                if response_has_promotable_calls(retry_data, _allowed_tools, openai_tools):
                     data = retry_data
         except (httpx.RequestError, ValueError) as exc:
             logger.warning("tool-call nudge retry failed; keeping original: %s", exc)
@@ -10454,7 +10456,7 @@ async def _anthropic_passthrough_non_streaming(
     # line below treat them exactly like native calls.
     healing_active = bool(_allowed_tools)
     if healing_active:
-        heal_openai_message(message, _allowed_tools)
+        heal_openai_message(message, _allowed_tools, openai_tools)
 
     content_blocks = []
     text = message.get("content") or ""
@@ -10944,7 +10946,7 @@ async def _openai_passthrough_stream(
             last_chunk_id = completion_id
             last_chunk_model = model_name
             last_chunk_created = int(time.time())
-            healer = StreamToolCallHealer(_allowed_tools) if _allowed_tools else None
+            healer = StreamToolCallHealer(_allowed_tools, body.get("tools")) if _allowed_tools else None
             healed_call_index = 0
 
             def _synthetic_finish_line() -> str:
@@ -11363,7 +11365,7 @@ async def _openai_passthrough_non_streaming(
     if (
         _allowed_tools
         and nudge_enabled(payload.nudge_tool_calls)
-        and nudge_should_retry(data, _allowed_tools)
+        and nudge_should_retry(data, _allowed_tools, body.get("tools"))
     ):
         retry_body = {
             **body,
@@ -11377,7 +11379,7 @@ async def _openai_passthrough_non_streaming(
             )
             if retry_resp.status_code == 200:
                 retry_data = retry_resp.json()
-                if response_has_promotable_calls(retry_data, _allowed_tools):
+                if response_has_promotable_calls(retry_data, _allowed_tools, body.get("tools")):
                     resp, data = retry_resp, retry_data
         except (httpx.RequestError, ValueError) as exc:
             logger.warning("tool-call nudge retry failed; keeping original: %s", exc)
@@ -11396,7 +11398,7 @@ async def _openai_passthrough_non_streaming(
         # Anthropic paths): a call cut off at max_tokens keeps
         # finish_reason="length" so the client knows the arguments may be
         # incomplete, while the healed call itself stays attached.
-        if _allowed_tools and heal_openai_message(msg, _allowed_tools):
+        if _allowed_tools and heal_openai_message(msg, _allowed_tools, body.get("tools")):
             if choice.get("finish_reason") == "stop":
                 choice["finish_reason"] = "tool_calls"
             changed = True

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -8295,7 +8295,16 @@ async def _responses_stream(
             parse_think_markers = _responses_should_parse_think_markers(chat_req, llama_backend)
         )
         reasoning_state: dict[str, Any] = {"output_index": None, "item_id": None, "opened": False}
-        message_state: dict[str, Any] = {"output_index": None, "item_id": None, "opened": False}
+        message_state: dict[str, Any] = {
+            "output_index": None,
+            "item_id": None,
+            "opened": False,
+            "text": "",
+        }
+        # Message items already closed mid-stream (a healed tool call splits
+        # the assistant text into separate message items, as native Responses
+        # streams do). Kept for the final response.completed snapshot.
+        closed_message_states: list[dict] = []
         # Per-tool-call state keyed by Chat Completions `tool_calls[].index`,
         # stable across chunks for the same call. Values:
         #   {output_index, item_id, call_id, name, arguments, opened}
@@ -8476,12 +8485,69 @@ async def _responses_stream(
                 ),
             ]
 
+        def _close_message_item() -> list[str]:
+            """Close the open message item so later text opens a fresh one.
+
+            Emits the same done-event triplet the end-of-stream close loop
+            would, records the item for the final snapshot, and resets the
+            state in place. No-op when no message item is open.
+            """
+            if not message_state["opened"]:
+                return []
+            text = message_state["text"]
+            events = [
+                _sse(
+                    "response.output_text.done",
+                    {
+                        "type": "response.output_text.done",
+                        "item_id": message_state["item_id"],
+                        "output_index": message_state["output_index"],
+                        "content_index": 0,
+                        "text": text,
+                    },
+                ),
+                _sse(
+                    "response.content_part.done",
+                    {
+                        "type": "response.content_part.done",
+                        "item_id": message_state["item_id"],
+                        "output_index": message_state["output_index"],
+                        "content_index": 0,
+                        "part": {"type": "output_text", "text": text, "annotations": []},
+                    },
+                ),
+                _sse(
+                    "response.output_item.done",
+                    {
+                        "type": "response.output_item.done",
+                        "output_index": message_state["output_index"],
+                        "item": {
+                            "type": "message",
+                            "id": message_state["item_id"],
+                            "status": "completed",
+                            "role": "assistant",
+                            "content": [
+                                {"type": "output_text", "text": text, "annotations": []}
+                            ],
+                        },
+                    },
+                ),
+            ]
+            closed_message_states.append(dict(message_state))
+            message_state.update(
+                {"output_index": None, "item_id": None, "opened": False, "text": ""}
+            )
+            return events
+
         def _healed_event_sse(events) -> list[str]:
             """Serialize healer events preserving their order.
 
             Text around a healed call must keep its position relative to the
             function_call item (output indexes are claimed in emission order),
-            so never split an event list into all-text-then-all-calls.
+            so never split an event list into all-text-then-all-calls. A healed
+            call also CLOSES any open message item, so trailing text opens a
+            fresh message with a later output index, exactly like a native
+            Responses stream that interleaves messages and calls.
             """
             nonlocal full_text
             out: list[str] = []
@@ -8491,6 +8557,7 @@ async def _responses_stream(
                         continue
                     out.extend(_ensure_message_open())
                     full_text += value
+                    message_state["text"] += value
                     api_monitor.append_reply(monitor_id, value)
                     out.append(
                         _sse(
@@ -8508,6 +8575,7 @@ async def _responses_stream(
                     tc = _healed_tc(value)
                     if tc is None:
                         continue
+                    out.extend(_close_message_item())
                     out.extend(_tool_call_delta_events(tc))
             return out
 
@@ -8527,19 +8595,23 @@ async def _responses_stream(
                         },
                     )
                 )
-            if message_state["opened"]:
+            # Closed copies keep opened=True (snapshotted before reset); the
+            # live state contributes only when a message is currently open.
+            for msg_st in [*closed_message_states, message_state]:
+                if not msg_st["opened"]:
+                    continue
                 indexed_items.append(
                     (
-                        message_state["output_index"],
+                        msg_st["output_index"],
                         {
                             "type": "message",
-                            "id": message_state["item_id"],
+                            "id": msg_st["item_id"],
                             "status": "completed",
                             "role": "assistant",
                             "content": [
                                 {
                                     "type": "output_text",
-                                    "text": full_text,
+                                    "text": msg_st["text"],
                                     "annotations": [],
                                 }
                             ],
@@ -8746,6 +8818,7 @@ async def _responses_stream(
                     for event in _ensure_message_open():
                         yield event
                     full_text += visible_delta
+                    message_state["text"] += visible_delta
                     api_monitor.append_reply(monitor_id, visible_delta)
                     yield _sse(
                         "response.output_text.delta",
@@ -8828,6 +8901,7 @@ async def _responses_stream(
             for event in _ensure_message_open():
                 yield event
             full_text += final_visible
+            message_state["text"] += final_visible
             api_monitor.append_reply(monitor_id, final_visible)
             yield _sse(
                 "response.output_text.delta",
@@ -8886,6 +8960,10 @@ async def _responses_stream(
                 continue
 
             if kind == "message":
+                # Per-item text: message items closed mid-stream (healed-call
+                # rotation) already emitted their done events, so this state
+                # carries only its own text, not the whole stream's.
+                _msg_text = st["text"]
                 yield _sse(
                     "response.output_text.done",
                     {
@@ -8893,7 +8971,7 @@ async def _responses_stream(
                         "item_id": st["item_id"],
                         "output_index": st["output_index"],
                         "content_index": 0,
-                        "text": full_text,
+                        "text": _msg_text,
                     },
                 )
                 yield _sse(
@@ -8903,7 +8981,7 @@ async def _responses_stream(
                         "item_id": st["item_id"],
                         "output_index": st["output_index"],
                         "content_index": 0,
-                        "part": {"type": "output_text", "text": full_text, "annotations": []},
+                        "part": {"type": "output_text", "text": _msg_text, "annotations": []},
                     },
                 )
                 yield _sse(
@@ -8917,7 +8995,7 @@ async def _responses_stream(
                             "status": "completed",
                             "role": "assistant",
                             "content": [
-                                {"type": "output_text", "text": full_text, "annotations": []}
+                                {"type": "output_text", "text": _msg_text, "annotations": []}
                             ],
                         },
                     },
@@ -10916,7 +10994,17 @@ async def _openai_passthrough_stream(
                 if delta.get("tool_calls"):
                     # Structured call streamed: grammar mode worked. Flush any held
                     # text (it preceded the call) and relay verbatim from here on.
-                    return _healer_sse_lines(healer.structured_tool_call_seen()) + [raw_line]
+                    lines = _healer_sse_lines(healer.structured_tool_call_seen())
+                    if healed_call_index:
+                        # A healed call already went out on index 0..n-1; OpenAI
+                        # clients merge tool-call deltas by index, so shift the
+                        # native calls into the next indexes or they would merge
+                        # into the healed call.
+                        for tc in delta["tool_calls"]:
+                            if isinstance(tc, dict) and isinstance(tc.get("index"), int):
+                                tc["index"] += healed_call_index
+                        return lines + ["data: " + json.dumps(chunk_data, ensure_ascii = False)]
+                    return lines + [raw_line]
                 content = delta.get("content")
                 finish = choice.get("finish_reason")
                 if not isinstance(content, str) or not content:

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -14,6 +14,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 _BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
 if _BACKEND_DIR not in sys.path:
     sys.path.insert(0, _BACKEND_DIR)
@@ -24,6 +26,7 @@ from core.inference.passthrough_healing import (  # noqa: E402
     heal_openai_message,
     nudge_messages,
     nudge_should_retry,
+    response_has_promotable_calls,
 )
 
 TOOLS = [
@@ -212,6 +215,28 @@ class TestNudgeHelpers:
         assert [m["role"] for m in suffix] == ["assistant", "user"]
         assert suffix[0]["content"] == "<tool_call>garbage"
         assert "`Bash` or `Read`" in suffix[1]["content"]
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            None,
+            "not a dict",
+            {},
+            {"choices": []},
+            {"choices": [{}]},
+            {"choices": [{"message": None}]},  # llama-server error bodies do this
+            {"choices": [{"message": "not a dict"}]},
+            {"choices": [{"message": {"content": None}}]},
+            {"error": {"message": "boom"}},
+        ],
+    )
+    def test_malformed_response_shapes_never_raise(self, data):
+        # A malformed upstream body must degrade to "nothing to heal/nudge",
+        # never crash the request with an AttributeError.
+        assert nudge_should_retry(data, {"Bash"}) is False
+        assert response_has_promotable_calls(data, {"Bash"}) is False
+        suffix = nudge_messages(data, {"Bash"})
+        assert suffix[0] == {"role": "assistant", "content": ""}
 
 
 # ── Route-level wiring (OpenAI passthrough) ─────────────────────────────

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -329,6 +329,17 @@ class TestNudgeHelpers:
         assert response_has_promotable_calls(self._resp("", undeclared), {"Bash"}) is False
         assert response_has_promotable_calls(self._resp("", declared), {"Bash"}) is True
 
+    def test_retry_with_mixed_structured_calls_is_not_an_improvement(self):
+        # ALL structured calls must be declared: the caller forwards the whole
+        # list (and a parallel cap could keep only the FIRST), so a mixed retry
+        # could still hand the client an undeclared tool.
+        mixed = [
+            {"id": "x", "type": "function", "function": {"name": "Nuke", "arguments": "{}"}},
+            {"id": "y", "type": "function", "function": {"name": "Bash", "arguments": "{}"}},
+        ]
+        assert response_has_promotable_calls(self._resp("", mixed), {"Bash"}) is False
+        assert response_has_promotable_calls(self._resp("", list(reversed(mixed))), {"Bash"}) is False
+
     @pytest.mark.parametrize(
         "data",
         [
@@ -1069,6 +1080,27 @@ class TestAnthropicNonStreamingRoute:
             _, data = await self._drive(monkeypatch, [_upstream_message(xml)])
             assert data["stop_reason"] == "end_turn"
             assert not any(b["type"] == "tool_use" for b in data["content"])
+            # Healing preserves what it does not promote: the undeclared call
+            # reaches the client as text instead of being silently stripped.
+            (text_block,) = [b for b in data["content"] if b["type"] == "text"]
+            assert text_block["text"] == xml
+
+        asyncio.run(_run())
+
+    def test_mixed_undeclared_text_preserved_after_heal(self, monkeypatch):
+        async def _run():
+            # Declared call promoted to tool_use; the undeclared call's markup
+            # stays in the text block (the legacy strip must not run after a
+            # span-exact heal), matching the OpenAI passthrough.
+            rogue = '<tool_call>{"name":"rogue","arguments":{}}</tool_call>'
+            _, data = await self._drive(
+                monkeypatch, [_upstream_message(f"{LOOKUP_XML} {rogue}")]
+            )
+            (tool_block,) = [b for b in data["content"] if b["type"] == "tool_use"]
+            assert tool_block["name"] == "lookup"
+            (text_block,) = [b for b in data["content"] if b["type"] == "text"]
+            assert rogue in text_block["text"]
+            assert data["stop_reason"] == "tool_use"
 
         asyncio.run(_run())
 

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -1115,9 +1115,7 @@ class TestOpenaiStreamingRoute:
                 'data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}',
                 "data: [DONE]",
             ]
-            chunks = await _drive_stream(
-                monkeypatch, _payload(parallel_tool_calls = False), lines
-            )
+            chunks = await _drive_stream(monkeypatch, _payload(parallel_tool_calls = False), lines)
             payloads = _stream_payloads(chunks)
             tool_deltas = [
                 tc

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Unit tests for core/inference/passthrough_healing.py: promoting text-form
+tool calls back into structured calls on the client-tool passthrough. The
+route-level wiring (OpenAI / Anthropic / Responses endpoints) is covered in
+their own endpoint test files; this file exercises the shared state machine
+and helpers directly.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from core.inference.passthrough_healing import (  # noqa: E402
+    StreamToolCallHealer,
+    heal_gate,
+    heal_openai_message,
+    nudge_messages,
+    nudge_should_retry,
+)
+
+TOOLS = [
+    {"type": "function", "function": {"name": "Bash", "parameters": {}}},
+    {"type": "function", "function": {"name": "Read", "parameters": {}}},
+]
+XML_BASH = '<tool_call>{"name":"Bash","arguments":{"cmd":"ls"}}</tool_call>'
+XML_UNDECLARED = '<tool_call>{"name":"Nuke","arguments":{}}</tool_call>'
+
+
+def _events_text(events):
+    return "".join(text for kind, text in events if kind == "text")
+
+
+def _events_calls(events):
+    return [call for kind, call in events if kind == "tool_call"]
+
+
+class TestHealGate:
+    def test_returns_declared_names(self):
+        assert heal_gate(None, TOOLS) == {"Bash", "Read"}
+        assert heal_gate(True, TOOLS) == {"Bash", "Read"}
+
+    def test_opt_out_and_no_tools(self):
+        assert heal_gate(False, TOOLS) is None
+        assert heal_gate(None, []) is None
+        assert heal_gate(None, None) is None
+
+    def test_malformed_tool_entries_ignored(self):
+        assert heal_gate(None, ["nonsense", {"function": "x"}, {}]) is None
+
+
+class TestHealOpenaiMessage:
+    def test_promotes_xml_and_strips_content(self):
+        msg = {"role": "assistant", "content": XML_BASH}
+        assert heal_openai_message(msg, {"Bash"}) is True
+        assert msg["content"] is None
+        (call,) = msg["tool_calls"]
+        assert call["function"]["name"] == "Bash"
+        assert json.loads(call["function"]["arguments"]) == {"cmd": "ls"}
+
+    def test_keeps_surrounding_prose(self):
+        msg = {"role": "assistant", "content": f"Let me check.\n{XML_BASH}"}
+        assert heal_openai_message(msg, {"Bash"}) is True
+        assert msg["content"] == "Let me check."
+
+    def test_undeclared_name_not_promoted(self):
+        msg = {"role": "assistant", "content": XML_UNDECLARED}
+        assert heal_openai_message(msg, {"Bash"}) is False
+        assert msg["content"] == XML_UNDECLARED
+        assert "tool_calls" not in msg
+
+    def test_structured_calls_untouched(self):
+        msg = {"role": "assistant", "content": XML_BASH, "tool_calls": [{"id": "x"}]}
+        assert heal_openai_message(msg, {"Bash"}) is False
+        assert msg["content"] == XML_BASH
+
+    def test_prose_only_untouched(self):
+        msg = {"role": "assistant", "content": "just an answer"}
+        assert heal_openai_message(msg, {"Bash"}) is False
+
+    def test_bad_json_arguments_coerced_under_canonical_key(self):
+        msg = {
+            "role": "assistant",
+            "content": '<tool_call>{"name":"Bash","arguments":"echo hi"}</tool_call>',
+        }
+        assert heal_openai_message(msg, {"Bash"}) is True
+        args = json.loads(msg["tool_calls"][0]["function"]["arguments"])
+        assert args == {"query": "echo hi"}
+
+
+class TestStreamHealer:
+    def test_plain_text_passes_through(self):
+        healer = StreamToolCallHealer({"Bash"})
+        events = healer.feed("hello ") + healer.feed("world") + healer.finalize()
+        assert _events_text(events) == "hello world"
+        assert not _events_calls(events)
+
+    def test_complete_call_in_one_chunk(self):
+        healer = StreamToolCallHealer({"Bash"})
+        events = healer.feed(f"On it. {XML_BASH}") + healer.finalize()
+        assert _events_text(events) == "On it. "
+        (call,) = _events_calls(events)
+        assert call["function"]["name"] == "Bash"
+        assert healer.healed
+
+    def test_signal_split_across_chunks(self):
+        healer = StreamToolCallHealer({"Bash"})
+        events = []
+        for piece in ["<tool", '_call>{"name":"Bash",', '"arguments":{}}</tool_call>']:
+            events += healer.feed(piece)
+        events += healer.finalize()
+        assert _events_text(events) == ""
+        assert len(_events_calls(events)) == 1
+
+    def test_false_alarm_html_flushes(self):
+        healer = StreamToolCallHealer({"Bash"})
+        events = healer.feed("use the <div> tag") + healer.finalize()
+        assert _events_text(events) == "use the <div> tag"
+        assert not _events_calls(events)
+
+    def test_partial_signal_tail_held_then_flushed_at_end(self):
+        healer = StreamToolCallHealer({"Bash"})
+        events = healer.feed("trailing <tool")
+        assert _events_text(events) == "trailing "  # tail held back
+        events += healer.finalize()
+        assert _events_text(events) == "trailing <tool"
+
+    def test_undeclared_tool_flushes_raw(self):
+        healer = StreamToolCallHealer({"Bash"})
+        events = healer.feed(XML_UNDECLARED) + healer.finalize()
+        assert _events_text(events) == XML_UNDECLARED
+        assert not _events_calls(events)
+
+    def test_two_calls_and_text_between(self):
+        healer = StreamToolCallHealer({"Bash", "Read"})
+        xml_read = '<tool_call>{"name":"Read","arguments":{"path":"f"}}</tool_call>'
+        events = healer.feed(f"{XML_BASH} then {xml_read}") + healer.finalize()
+        calls = _events_calls(events)
+        assert [c["function"]["name"] for c in calls] == ["Bash", "Read"]
+        assert [c["id"] for c in calls] == ["call_0", "call_1"]
+        assert _events_text(events).strip() == "then"
+
+    def test_incomplete_call_healed_at_finalize(self):
+        healer = StreamToolCallHealer({"Bash"})
+        events = healer.feed('<tool_call>{"name":"Bash","arguments":{"cmd":"ls"}}')
+        assert events == []  # held
+        events = healer.finalize()
+        (call,) = _events_calls(events)
+        assert call["function"]["name"] == "Bash"
+
+    def test_teaching_text_flushes_at_finalize(self):
+        healer = StreamToolCallHealer({"Bash"})
+        events = healer.feed("<tool_call> is the marker syntax") + healer.finalize()
+        assert _events_text(events) == "<tool_call> is the marker syntax"
+        assert not _events_calls(events)
+
+    def test_hold_bound_flushes(self):
+        healer = StreamToolCallHealer({"Bash"})
+        blob = "<tool_call>" + "x" * (64 * 1024 + 10)
+        events = healer.feed(blob) + healer.finalize()
+        assert _events_text(events) == blob
+        assert not _events_calls(events)
+
+    def test_dormant_after_structured_delta(self):
+        healer = StreamToolCallHealer({"Bash"})
+        held = healer.feed("prefix <tool")
+        flush = healer.structured_tool_call_seen()
+        after = healer.feed(XML_BASH) + healer.finalize()
+        assert _events_text(held + flush + after) == f"prefix <tool{XML_BASH}"
+        assert not _events_calls(after)
+
+
+class TestNudgeHelpers:
+    def _resp(self, content, tool_calls = None):
+        msg = {"role": "assistant", "content": content}
+        if tool_calls:
+            msg["tool_calls"] = tool_calls
+        return {"choices": [{"message": msg, "finish_reason": "stop"}]}
+
+    def test_retry_on_unparseable_signal(self):
+        # Signal present but the JSON never parses and no declared name matches.
+        data = self._resp("<tool_call>call Bash somehow???")
+        assert nudge_should_retry(data, {"Read"}) is True
+
+    def test_no_retry_on_clean_prose(self):
+        assert nudge_should_retry(self._resp("all done"), {"Bash"}) is False
+
+    def test_no_retry_when_heal_would_succeed(self):
+        assert nudge_should_retry(self._resp(XML_BASH), {"Bash"}) is False
+
+    def test_no_retry_with_structured_calls(self):
+        data = self._resp("", tool_calls = [{"id": "x"}])
+        assert nudge_should_retry(data, {"Bash"}) is False
+
+    def test_no_retry_when_healing_disabled(self):
+        assert nudge_should_retry(self._resp("<tool_call>???"), None) is False
+
+    def test_nudge_messages_shape(self):
+        data = self._resp("<tool_call>garbage")
+        suffix = nudge_messages(data, {"Bash", "Read"})
+        assert [m["role"] for m in suffix] == ["assistant", "user"]
+        assert suffix[0]["content"] == "<tool_call>garbage"
+        assert "`Bash` or `Read`" in suffix[1]["content"]

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -208,7 +208,6 @@ class TestStreamHealer:
         assert [call["function"]["name"] for call in _events_calls(events)] == ["Read", "Bash"]
         assert _events_text(events).strip() == "then"
 
-
     def test_false_alarm_html_flushes(self):
         healer = StreamToolCallHealer({"Bash"})
         events = healer.feed("use the <div> tag") + healer.finalize()
@@ -686,12 +685,13 @@ class TestOpenaiNonStreamingRoute:
             assert indexes.get(1) == "call_native"
 
         asyncio.run(_run())
+
     def test_role_delta_precedes_healed_stream_content(self, monkeypatch):
         async def _run():
             lines = [
                 'data: {"id":"c1","choices":[{"index":0,"delta":{"role":"assistant","content":'
                 + json.dumps(LOOKUP_XML)
-                + '}}]}',
+                + "}}]}",
                 'data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
                 "data: [DONE]",
             ]
@@ -702,8 +702,6 @@ class TestOpenaiNonStreamingRoute:
             assert "tool_calls" in payloads[1]["choices"][0]["delta"]
 
         asyncio.run(_run())
-
-
 
 
 GARBAGE_SIGNAL = "<tool_call>call lookup somehow???"
@@ -835,7 +833,6 @@ class TestNudgeRetryAnthropic:
             assert data["content"][1]["text"] == "done"
 
         asyncio.run(_run())
-
 
     def test_default_off(self, monkeypatch):
         async def _run():

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -338,7 +338,9 @@ class TestNudgeHelpers:
             {"id": "y", "type": "function", "function": {"name": "Bash", "arguments": "{}"}},
         ]
         assert response_has_promotable_calls(self._resp("", mixed), {"Bash"}) is False
-        assert response_has_promotable_calls(self._resp("", list(reversed(mixed))), {"Bash"}) is False
+        assert (
+            response_has_promotable_calls(self._resp("", list(reversed(mixed))), {"Bash"}) is False
+        )
 
     @pytest.mark.parametrize(
         "data",
@@ -1093,9 +1095,7 @@ class TestAnthropicNonStreamingRoute:
             # stays in the text block (the legacy strip must not run after a
             # span-exact heal), matching the OpenAI passthrough.
             rogue = '<tool_call>{"name":"rogue","arguments":{}}</tool_call>'
-            _, data = await self._drive(
-                monkeypatch, [_upstream_message(f"{LOOKUP_XML} {rogue}")]
-            )
+            _, data = await self._drive(monkeypatch, [_upstream_message(f"{LOOKUP_XML} {rogue}")])
             (tool_block,) = [b for b in data["content"] if b["type"] == "tool_use"]
             assert tool_block["name"] == "lookup"
             (text_block,) = [b for b in data["content"] if b["type"] == "text"]

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -396,6 +396,235 @@ class TestOpenaiNonStreamingRoute:
         asyncio.run(_run())
 
 
+class TestAnthropicEmitterHealing:
+    def _events(self, emitter, chunks, finish = True):
+        lines = []
+        for chunk in chunks:
+            lines += emitter.feed_chunk(chunk)
+        if finish:
+            lines += emitter.finish()
+        return [json.loads(ln.split("data: ", 1)[1]) for ln in lines if "data: " in ln]
+
+    def _emitter(self, allowed = ("lookup",), **kwargs):
+        from core.inference.anthropic_compat import AnthropicPassthroughEmitter
+
+        emitter = AnthropicPassthroughEmitter()
+        emitter.enable_healing(set(allowed), **kwargs)
+        return emitter
+
+    def _chunk(self, content = None, tool_calls = None, finish_reason = None):
+        delta = {}
+        if content is not None:
+            delta["content"] = content
+        if tool_calls is not None:
+            delta["tool_calls"] = tool_calls
+        return {"choices": [{"delta": delta, "finish_reason": finish_reason}]}
+
+    def test_xml_becomes_tool_use_block_and_stop_reason(self):
+        events = self._events(
+            self._emitter(),
+            [
+                self._chunk(content = LOOKUP_XML),
+                self._chunk(finish_reason = "stop"),
+            ],
+        )
+        starts = [e for e in events if e.get("type") == "content_block_start"]
+        (tool_start,) = [e for e in starts if e["content_block"]["type"] == "tool_use"]
+        assert tool_start["content_block"]["name"] == "lookup"
+        assert tool_start["content_block"]["id"].startswith("toolu_")
+        (args,) = [
+            e["delta"]["partial_json"]
+            for e in events
+            if e.get("type") == "content_block_delta" and e["delta"]["type"] == "input_json_delta"
+        ]
+        assert json.loads(args) == {"q": "x"}
+        (message_delta,) = [e for e in events if e.get("type") == "message_delta"]
+        assert message_delta["delta"]["stop_reason"] == "tool_use"
+
+    def test_mid_block_signal_closes_text_block_first(self):
+        events = self._events(
+            self._emitter(),
+            [
+                self._chunk(content = f"Let me check {LOOKUP_XML}"),
+                self._chunk(finish_reason = "stop"),
+            ],
+        )
+        kinds = [
+            (e["type"], (e.get("content_block") or e.get("delta") or {}).get("type"))
+            for e in events
+            if e["type"].startswith("content_block")
+        ]
+        # text opens, streams the safe prefix, closes; then the tool_use block.
+        assert kinds[0] == ("content_block_start", "text")
+        assert kinds[1] == ("content_block_delta", "text_delta")
+        assert kinds[2] == ("content_block_stop", None)
+        assert kinds[3] == ("content_block_start", "tool_use")
+        texts = [
+            e["delta"]["text"]
+            for e in events
+            if e.get("type") == "content_block_delta" and e["delta"]["type"] == "text_delta"
+        ]
+        assert "".join(texts) == "Let me check "
+
+    def test_false_alarm_streams_as_text(self):
+        events = self._events(
+            self._emitter(),
+            [self._chunk(content = "use the <div> tag"), self._chunk(finish_reason = "stop")],
+        )
+        texts = [
+            e["delta"]["text"]
+            for e in events
+            if e.get("type") == "content_block_delta" and e["delta"]["type"] == "text_delta"
+        ]
+        assert "".join(texts) == "use the <div> tag"
+        (message_delta,) = [e for e in events if e.get("type") == "message_delta"]
+        assert message_delta["delta"]["stop_reason"] == "end_turn"
+
+    def test_signal_split_across_chunks(self):
+        events = self._events(
+            self._emitter(),
+            [
+                self._chunk(content = "<tool"),
+                self._chunk(content = '_call>{"name":"lookup","arguments":{}}'),
+                self._chunk(finish_reason = "stop"),
+            ],
+        )
+        starts = [e for e in events if e.get("type") == "content_block_start"]
+        assert [e["content_block"]["type"] for e in starts] == ["tool_use"]
+        texts = [
+            e
+            for e in events
+            if e.get("type") == "content_block_delta" and e["delta"]["type"] == "text_delta"
+        ]
+        assert texts == []
+
+    def test_max_tokens_wins_over_healed_stop_reason(self):
+        events = self._events(
+            self._emitter(),
+            [self._chunk(content = LOOKUP_XML), self._chunk(finish_reason = "length")],
+        )
+        (message_delta,) = [e for e in events if e.get("type") == "message_delta"]
+        assert message_delta["delta"]["stop_reason"] == "max_tokens"
+
+    def test_structured_deltas_disable_healing_and_flush(self):
+        structured = [
+            {
+                "index": 0,
+                "id": "call_up",
+                "function": {"name": "lookup", "arguments": "{}"},
+            }
+        ]
+        events = self._events(
+            self._emitter(),
+            [
+                self._chunk(content = "held <tool"),
+                self._chunk(tool_calls = structured),
+                self._chunk(finish_reason = "tool_calls"),
+            ],
+        )
+        texts = [
+            e["delta"]["text"]
+            for e in events
+            if e.get("type") == "content_block_delta" and e["delta"]["type"] == "text_delta"
+        ]
+        assert "".join(texts) == "held <tool"  # nothing swallowed
+        starts = [e for e in events if e.get("type") == "content_block_start"]
+        assert [e["content_block"]["type"] for e in starts] == ["text", "tool_use"]
+
+    def test_disable_parallel_caps_healed_calls(self):
+        two = LOOKUP_XML + '<tool_call>{"name":"lookup","arguments":{"q":"y"}}</tool_call>'
+        events = self._events(
+            self._emitter(disable_parallel_tool_use = True),
+            [self._chunk(content = two), self._chunk(finish_reason = "stop")],
+        )
+        starts = [
+            e
+            for e in events
+            if e.get("type") == "content_block_start"
+            and e["content_block"]["type"] == "tool_use"
+        ]
+        assert len(starts) == 1
+
+    def test_no_healing_means_verbatim_text(self):
+        from core.inference.anthropic_compat import AnthropicPassthroughEmitter
+
+        emitter = AnthropicPassthroughEmitter()  # enable_healing never called
+        events = self._events(
+            emitter,
+            [self._chunk(content = LOOKUP_XML), self._chunk(finish_reason = "stop")],
+        )
+        texts = [
+            e["delta"]["text"]
+            for e in events
+            if e.get("type") == "content_block_delta" and e["delta"]["type"] == "text_delta"
+        ]
+        assert "".join(texts) == LOOKUP_XML
+
+
+class TestAnthropicNonStreamingRoute:
+    async def _drive(self, monkeypatch, bodies, auto_heal = None, tools = None):
+        import routes.inference as inf_mod
+        from routes.inference import _anthropic_passthrough_non_streaming
+
+        client = ScriptedClient(bodies)
+        monkeypatch.setattr(inf_mod, "nonstreaming_client", lambda: client)
+        response = await _anthropic_passthrough_non_streaming(
+            _llama_backend(),
+            [{"role": "user", "content": "hi"}],
+            tools if tools is not None else [LOOKUP_TOOL],
+            0.7,
+            0.95,
+            None,
+            256,
+            "msg_test",
+            "gguf",
+            auto_heal_tool_calls = auto_heal,
+        )
+        return client, json.loads(response.body)
+
+    def test_promotes_xml_to_tool_use(self, monkeypatch):
+        async def _run():
+            _, data = await self._drive(monkeypatch, [_upstream_message(LOOKUP_XML)])
+            (block,) = [b for b in data["content"] if b["type"] == "tool_use"]
+            assert block["name"] == "lookup"
+            assert block["input"] == {"q": "x"}
+            assert data["stop_reason"] == "tool_use"
+            assert not any(b["type"] == "text" for b in data["content"])
+
+        asyncio.run(_run())
+
+    def test_opt_out_keeps_legacy_strip(self, monkeypatch):
+        async def _run():
+            _, data = await self._drive(
+                monkeypatch, [_upstream_message(f"plan {LOOKUP_XML}")], auto_heal = False
+            )
+            assert data["stop_reason"] == "end_turn"
+            (block,) = data["content"]
+            assert block["type"] == "text"
+            assert block["text"] == "plan"  # XML stripped, nothing promoted
+
+        asyncio.run(_run())
+
+    def test_undeclared_tool_not_promoted(self, monkeypatch):
+        async def _run():
+            xml = '<tool_call>{"name":"rogue","arguments":{}}</tool_call>'
+            _, data = await self._drive(monkeypatch, [_upstream_message(xml)])
+            assert data["stop_reason"] == "end_turn"
+            assert not any(b["type"] == "tool_use" for b in data["content"])
+
+        asyncio.run(_run())
+
+    def test_length_beats_tool_use(self, monkeypatch):
+        async def _run():
+            _, data = await self._drive(
+                monkeypatch, [_upstream_message(LOOKUP_XML, finish_reason = "length")]
+            )
+            assert data["stop_reason"] == "max_tokens"
+            assert any(b["type"] == "tool_use" for b in data["content"])
+
+        asyncio.run(_run())
+
+
 class TestOpenaiStreamingRoute:
     def test_heals_streamed_xml(self, monkeypatch):
         async def _run():

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -530,7 +530,9 @@ class TestOpenaiNonStreamingRoute:
     def test_mixed_declared_and_undeclared_relays_verbatim(self, monkeypatch):
         async def _run():
             mixed = f'{LOOKUP_XML} also <tool_call>{{"name":"rogue","arguments":{{}}}}</tool_call>'
-            _, data = await _drive_non_streaming(monkeypatch, _payload(), [_upstream_message(mixed)])
+            _, data = await _drive_non_streaming(
+                monkeypatch, _payload(), [_upstream_message(mixed)]
+            )
             choice = data["choices"][0]
             assert choice["message"]["content"] == mixed
             assert "tool_calls" not in choice["message"]

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -153,17 +153,13 @@ class TestHealOpenaiMessage:
         assert heal_openai_message(msg, {"Bash"}) is True
         assert len(msg["tool_calls"]) == 2
 
-    def test_mixed_format_suppressed_function_block_not_deleted(self):
-        # parse_tool_calls_from_text only parses <function=...> blocks when no
-        # JSON/Gemma call parsed, so the Read call below is never promoted.
-        # Its markup must then SURVIVE in the content, not be stripped away.
+    def test_mixed_formats_promote_in_document_order(self):
         func_read = "<function=Read><parameter=path>a.txt</parameter></function>"
-        content = f"{XML_BASH} then {func_read}"
+        content = f"{func_read} then {XML_BASH}"
         msg = {"role": "assistant", "content": content}
         assert heal_openai_message(msg, {"Bash", "Read"}) is True
-        (call,) = msg["tool_calls"]
-        assert call["function"]["name"] == "Bash"
-        assert func_read in msg["content"]
+        assert [call["function"]["name"] for call in msg["tool_calls"]] == ["Read", "Bash"]
+        assert msg["content"] == "then"
 
     def test_unparseable_closed_block_not_deleted(self):
         # A closed <tool_call> block whose body never parses is model output,
@@ -198,6 +194,20 @@ class TestStreamHealer:
         events += healer.finalize()
         assert _events_text(events) == ""
         assert len(_events_calls(events)) == 1
+
+    def test_closed_malformed_tool_block_flushes_immediately(self):
+        healer = StreamToolCallHealer({"Bash"})
+        events = healer.feed("<tool_call>not json</tool_call> after")
+        assert _events_text(events) == "<tool_call>not json</tool_call> after"
+        assert not _events_calls(events)
+
+    def test_mixed_formats_stream_in_document_order(self):
+        healer = StreamToolCallHealer({"Bash", "Read"})
+        func_read = "<function=Read><parameter=path>a.txt</parameter></function>"
+        events = healer.feed(f"{func_read} then {XML_BASH}") + healer.finalize()
+        assert [call["function"]["name"] for call in _events_calls(events)] == ["Read", "Bash"]
+        assert _events_text(events).strip() == "then"
+
 
     def test_false_alarm_html_flushes(self):
         healer = StreamToolCallHealer({"Bash"})
@@ -676,6 +686,24 @@ class TestOpenaiNonStreamingRoute:
             assert indexes.get(1) == "call_native"
 
         asyncio.run(_run())
+    def test_role_delta_precedes_healed_stream_content(self, monkeypatch):
+        async def _run():
+            lines = [
+                'data: {"id":"c1","choices":[{"index":0,"delta":{"role":"assistant","content":'
+                + json.dumps(LOOKUP_XML)
+                + '}}]}',
+                'data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+                "data: [DONE]",
+            ]
+            chunks = await _drive_stream(monkeypatch, _payload(stream = True), lines)
+            payloads = _stream_payloads(chunks)
+            first_delta = payloads[0]["choices"][0]["delta"]
+            assert first_delta == {"role": "assistant"}
+            assert "tool_calls" in payloads[1]["choices"][0]["delta"]
+
+        asyncio.run(_run())
+
+
 
 
 GARBAGE_SIGNAL = "<tool_call>call lookup somehow???"
@@ -800,6 +828,15 @@ class TestNudgeRetryAnthropic:
 
         asyncio.run(_run())
 
+    def test_healed_tool_use_precedes_trailing_text(self, monkeypatch):
+        async def _run():
+            _, data = await self._drive(monkeypatch, [_upstream_message(f"{LOOKUP_XML} done")])
+            assert [block["type"] for block in data["content"]] == ["tool_use", "text"]
+            assert data["content"][1]["text"] == "done"
+
+        asyncio.run(_run())
+
+
     def test_default_off(self, monkeypatch):
         async def _run():
             client, _ = await self._drive(monkeypatch, [_upstream_message(GARBAGE_SIGNAL)])
@@ -842,13 +879,10 @@ class TestAnthropicPassthroughHealingText:
             # Declared lookup call is promoted into a structured tool_use block.
             (tool_use,) = [b for b in data["content"] if b["type"] == "tool_use"]
             assert tool_use["name"] == "lookup"
-            # Undeclared Nuke call was not promoted; its markup must survive in a
-            # text block instead of being deleted by the legacy XML strip.
-            (text_block,) = [b for b in data["content"] if b["type"] == "text"]
-            assert XML_UNDECLARED in text_block["text"]
-            assert "Running now." in text_block["text"] and "done." in text_block["text"]
-            # The promoted lookup markup is gone from the visible text.
-            assert LOOKUP_XML not in text_block["text"]
+            text = " ".join(b["text"] for b in data["content"] if b["type"] == "text")
+            assert XML_UNDECLARED in text
+            assert "Running now." in text and "done." in text
+            assert LOOKUP_XML not in text
 
         asyncio.run(_run())
 

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -115,6 +115,21 @@ class TestHealOpenaiMessage:
         args = json.loads(msg["tool_calls"][0]["function"]["arguments"])
         assert args == {"query": "echo hi"}
 
+    def test_mixed_declared_and_undeclared_relays_verbatim(self):
+        # All-or-nothing: promoting Bash would strip ALL markup, silently
+        # deleting the undeclared Nuke call's text. Decline the heal instead.
+        content = f"pre {XML_BASH} mid {XML_UNDECLARED} post"
+        msg = {"role": "assistant", "content": content}
+        assert heal_openai_message(msg, {"Bash"}) is False
+        assert msg["content"] == content
+        assert "tool_calls" not in msg
+
+    def test_multiple_declared_calls_all_promoted(self):
+        content = f"{XML_BASH} and {XML_BASH}"
+        msg = {"role": "assistant", "content": content}
+        assert heal_openai_message(msg, {"Bash"}) is True
+        assert len(msg["tool_calls"]) == 2
+
 
 class TestStreamHealer:
     def test_plain_text_passes_through(self):
@@ -152,6 +167,26 @@ class TestStreamHealer:
         assert _events_text(events) == "trailing "  # tail held back
         events += healer.finalize()
         assert _events_text(events) == "trailing <tool"
+
+    def test_mixed_calls_in_one_buffer_flush_raw(self):
+        # Declared + undeclared complete in the same hold window: all-or-nothing,
+        # the whole buffer flushes verbatim so no markup is silently deleted.
+        healer = StreamToolCallHealer({"Bash"})
+        text = f"{XML_BASH} then {XML_UNDECLARED}"
+        events = healer.feed(text) + healer.finalize()
+        assert _events_text(events) == text
+        assert not _events_calls(events)
+
+    def test_declared_promoted_then_late_undeclared_flushes_raw(self):
+        # Streaming causality: the declared call completed and was already
+        # emitted before the undeclared one arrived. The undeclared markup
+        # must still reach the client as raw text (no data loss).
+        healer = StreamToolCallHealer({"Bash"})
+        events = healer.feed(f"{XML_BASH} then ")
+        assert len(_events_calls(events)) == 1
+        events += healer.feed(XML_UNDECLARED) + healer.finalize()
+        assert XML_UNDECLARED in _events_text(events)
+        assert len(_events_calls(events)) == 1
 
     def test_undeclared_tool_flushes_raw(self):
         healer = StreamToolCallHealer({"Bash"})
@@ -489,6 +524,17 @@ class TestOpenaiNonStreamingRoute:
             message = data["choices"][0]["message"]
             assert message["content"] == LOOKUP_XML
             assert "tool_calls" not in message
+
+        asyncio.run(_run())
+
+    def test_mixed_declared_and_undeclared_relays_verbatim(self, monkeypatch):
+        async def _run():
+            mixed = f'{LOOKUP_XML} also <tool_call>{{"name":"rogue","arguments":{{}}}}</tool_call>'
+            _, data = await _drive_non_streaming(monkeypatch, _payload(), [_upstream_message(mixed)])
+            choice = data["choices"][0]
+            assert choice["message"]["content"] == mixed
+            assert "tool_calls" not in choice["message"]
+            assert choice["finish_reason"] == "stop"
 
         asyncio.run(_run())
 

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -115,20 +115,44 @@ class TestHealOpenaiMessage:
         args = json.loads(msg["tool_calls"][0]["function"]["arguments"])
         assert args == {"query": "echo hi"}
 
-    def test_mixed_declared_and_undeclared_relays_verbatim(self):
-        # All-or-nothing: promoting Bash would strip ALL markup, silently
-        # deleting the undeclared Nuke call's text. Decline the heal instead.
+    def test_mixed_declared_and_undeclared_promotes_declared_keeps_undeclared_text(self):
+        # Span-exact removal: only the promoted Bash markup is dropped; the
+        # undeclared Nuke call's text stays in the content byte-intact.
         content = f"pre {XML_BASH} mid {XML_UNDECLARED} post"
         msg = {"role": "assistant", "content": content}
-        assert heal_openai_message(msg, {"Bash"}) is False
-        assert msg["content"] == content
-        assert "tool_calls" not in msg
+        assert heal_openai_message(msg, {"Bash"}) is True
+        (call,) = msg["tool_calls"]
+        assert call["function"]["name"] == "Bash"
+        assert XML_UNDECLARED in msg["content"]
+        assert "pre" in msg["content"] and "post" in msg["content"]
+        assert XML_BASH not in msg["content"]
 
     def test_multiple_declared_calls_all_promoted(self):
         content = f"{XML_BASH} and {XML_BASH}"
         msg = {"role": "assistant", "content": content}
         assert heal_openai_message(msg, {"Bash"}) is True
         assert len(msg["tool_calls"]) == 2
+
+    def test_mixed_format_suppressed_function_block_not_deleted(self):
+        # parse_tool_calls_from_text only parses <function=...> blocks when no
+        # JSON/Gemma call parsed, so the Read call below is never promoted.
+        # Its markup must then SURVIVE in the content, not be stripped away.
+        func_read = "<function=Read><parameter=path>a.txt</parameter></function>"
+        content = f"{XML_BASH} then {func_read}"
+        msg = {"role": "assistant", "content": content}
+        assert heal_openai_message(msg, {"Bash", "Read"}) is True
+        (call,) = msg["tool_calls"]
+        assert call["function"]["name"] == "Bash"
+        assert func_read in msg["content"]
+
+    def test_unparseable_closed_block_not_deleted(self):
+        # A closed <tool_call> block whose body never parses is model output,
+        # not a promotable call; it must survive promotion of its neighbor.
+        garbage = "<tool_call>not json at all</tool_call>"
+        content = f"{XML_BASH} {garbage}"
+        msg = {"role": "assistant", "content": content}
+        assert heal_openai_message(msg, {"Bash"}) is True
+        assert garbage in msg["content"]
 
 
 class TestStreamHealer:
@@ -168,14 +192,38 @@ class TestStreamHealer:
         events += healer.finalize()
         assert _events_text(events) == "trailing <tool"
 
-    def test_mixed_calls_in_one_buffer_flush_raw(self):
-        # Declared + undeclared complete in the same hold window: all-or-nothing,
-        # the whole buffer flushes verbatim so no markup is silently deleted.
+    def test_mixed_calls_promote_declared_flush_undeclared_in_order(self):
+        # Declared + undeclared in the same buffer: the declared call is
+        # promoted, the undeclared markup flushes as text, and event order
+        # follows document order (call first here, since it came first).
         healer = StreamToolCallHealer({"Bash"})
-        text = f"{XML_BASH} then {XML_UNDECLARED}"
+        text = f"{XML_BASH} then {XML_UNDECLARED} post"
         events = healer.feed(text) + healer.finalize()
-        assert _events_text(events) == text
-        assert not _events_calls(events)
+        assert [k for k, _ in events if k == "tool_call"] == ["tool_call"]
+        assert events[0][0] == "tool_call"
+        joined = _events_text(events)
+        assert XML_UNDECLARED in joined
+        assert "then" in joined and "post" in joined
+
+    def test_text_between_two_healed_calls_keeps_document_order(self):
+        # call A, " middle ", call B in ONE buffer must stream as
+        # call A -> text -> call B, never both calls then the text.
+        healer = StreamToolCallHealer({"Bash"})
+        events = healer.feed(f"{XML_BASH} middle {XML_BASH}") + healer.finalize()
+        kinds = [k for k, _ in events]
+        assert kinds == ["tool_call", "text", "tool_call"]
+        assert events[1][1] == " middle "
+
+    def test_undeclared_then_declared_keeps_document_order(self):
+        # The undeclared block precedes the declared call; its raw text must
+        # be emitted BEFORE the promoted call event, never after.
+        healer = StreamToolCallHealer({"Bash"})
+        events = healer.feed(f"{XML_UNDECLARED} then {XML_BASH}") + healer.finalize()
+        kinds = [k for k, _ in events]
+        assert kinds.index("tool_call") == len(kinds) - 1
+        (call,) = _events_calls(events)
+        assert call["function"]["name"] == "Bash"
+        assert XML_UNDECLARED in _events_text(events)
 
     def test_declared_promoted_then_late_undeclared_flushes_raw(self):
         # Streaming causality: the declared call completed and was already
@@ -268,6 +316,18 @@ class TestNudgeHelpers:
         assert [m["role"] for m in suffix] == ["assistant", "user"]
         assert suffix[0]["content"] == "<tool_call>garbage"
         assert "`Bash` or `Read`" in suffix[1]["content"]
+
+    def test_retry_with_undeclared_structured_call_is_not_an_improvement(self):
+        # The retry replaces the original only when it carries a USABLE call:
+        # a structured call naming an undeclared tool must not count.
+        undeclared = [
+            {"id": "x", "type": "function", "function": {"name": "Nuke", "arguments": "{}"}}
+        ]
+        declared = [
+            {"id": "y", "type": "function", "function": {"name": "Bash", "arguments": "{}"}}
+        ]
+        assert response_has_promotable_calls(self._resp("", undeclared), {"Bash"}) is False
+        assert response_has_promotable_calls(self._resp("", declared), {"Bash"}) is True
 
     @pytest.mark.parametrize(
         "data",
@@ -527,16 +587,47 @@ class TestOpenaiNonStreamingRoute:
 
         asyncio.run(_run())
 
-    def test_mixed_declared_and_undeclared_relays_verbatim(self, monkeypatch):
+    def test_mixed_declared_and_undeclared_promotes_and_keeps_text(self, monkeypatch):
         async def _run():
-            mixed = f'{LOOKUP_XML} also <tool_call>{{"name":"rogue","arguments":{{}}}}</tool_call>'
+            rogue = '<tool_call>{"name":"rogue","arguments":{}}</tool_call>'
+            mixed = f"{LOOKUP_XML} also {rogue}"
             _, data = await _drive_non_streaming(
                 monkeypatch, _payload(), [_upstream_message(mixed)]
             )
             choice = data["choices"][0]
-            assert choice["message"]["content"] == mixed
-            assert "tool_calls" not in choice["message"]
-            assert choice["finish_reason"] == "stop"
+            (call,) = choice["message"]["tool_calls"]
+            assert call["function"]["name"] == "lookup"
+            assert rogue in choice["message"]["content"]
+            assert choice["finish_reason"] == "tool_calls"
+
+        asyncio.run(_run())
+
+    def test_healed_then_native_stream_indexes_disjoint(self, monkeypatch):
+        async def _run():
+            # A healed text-form call goes out first (index 0); a native
+            # structured delta follows. Clients merge deltas by index, so the
+            # native call must be shifted off index 0 or the two would merge.
+            native_line = (
+                'data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":'
+                '[{"index":0,"id":"call_native","type":"function","function":'
+                '{"name":"lookup","arguments":"{}"}}]}}]}'
+            )
+            lines = [
+                'data: {"id":"c1","choices":[{"index":0,"delta":{"content":'
+                + json.dumps(LOOKUP_XML)
+                + "}}]}",
+                native_line,
+                'data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}',
+                "data: [DONE]",
+            ]
+            chunks = await _drive_stream(monkeypatch, _payload(stream = True), lines)
+            indexes = {}
+            for payload_data in _stream_payloads(chunks):
+                for ch in payload_data.get("choices", []):
+                    for tc in (ch.get("delta") or {}).get("tool_calls") or []:
+                        indexes.setdefault(tc["index"], tc.get("id"))
+            assert indexes.get(0, "").startswith("call_") and indexes[0] != "call_native"
+            assert indexes.get(1) == "call_native"
 
         asyncio.run(_run())
 

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -704,6 +704,24 @@ class TestOpenaiNonStreamingRoute:
         asyncio.run(_run())
 
 
+    def test_same_chunk_role_content_finish_delays_finish_until_after_healed_tool(self, monkeypatch):
+        async def _run():
+            lines = [
+                'data: {"id":"c1","choices":[{"index":0,"delta":{"role":"assistant","content":'
+                + json.dumps(LOOKUP_XML)
+                + '},"finish_reason":"stop"}]}',
+                "data: [DONE]",
+            ]
+            chunks = await _drive_stream(monkeypatch, _payload(stream = True), lines)
+            payloads = _stream_payloads(chunks)
+            assert payloads[0]["choices"][0]["finish_reason"] is None
+            assert payloads[0]["choices"][0]["delta"] == {"role": "assistant"}
+            assert "tool_calls" in payloads[1]["choices"][0]["delta"]
+            assert payloads[-1]["choices"][0]["finish_reason"] == "tool_calls"
+
+        asyncio.run(_run())
+
+
 GARBAGE_SIGNAL = "<tool_call>call lookup somehow???"
 
 

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -527,7 +527,6 @@ class TestOpenaiNonStreamingRoute:
 
         asyncio.run(_run())
 
-
     def test_bare_string_uses_client_schema_key(self, monkeypatch):
         async def _run():
             content = '<tool_call>{"name":"Bash","arguments":"echo hi"}</tool_call>'

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -762,6 +762,51 @@ class TestNudgeRetryAnthropic:
         asyncio.run(_run())
 
 
+class TestAnthropicPassthroughHealingText:
+    """Non-streaming Anthropic passthrough must relay unpromoted (undeclared)
+    text-form calls as text, matching the OpenAI passthrough contract. Once
+    heal_openai_message promotes the declared call it span-trims only that
+    markup and deliberately leaves the undeclared bytes in the content; the
+    legacy blanket _TOOL_XML_RE strip must not delete them.
+    """
+
+    async def _drive(self, monkeypatch, upstream):
+        import routes.inference as inf_mod
+        from routes.inference import _anthropic_passthrough_non_streaming
+
+        client = ScriptedClient([upstream])
+        monkeypatch.setattr(inf_mod, "nonstreaming_client", lambda: client)
+        response = await _anthropic_passthrough_non_streaming(
+            _llama_backend(),
+            [{"role": "user", "content": "hi"}],
+            [LOOKUP_TOOL],
+            0.7,
+            0.95,
+            None,
+            256,
+            "msg_test",
+            "gguf",
+        )
+        return json.loads(response.body)
+
+    def test_mixed_declared_and_undeclared_relays_undeclared_as_text(self, monkeypatch):
+        async def _run():
+            content = f"Running now. {LOOKUP_XML} then {XML_UNDECLARED} done."
+            data = await self._drive(monkeypatch, _upstream_message(content))
+            # Declared lookup call is promoted into a structured tool_use block.
+            (tool_use,) = [b for b in data["content"] if b["type"] == "tool_use"]
+            assert tool_use["name"] == "lookup"
+            # Undeclared Nuke call was not promoted; its markup must survive in a
+            # text block instead of being deleted by the legacy XML strip.
+            (text_block,) = [b for b in data["content"] if b["type"] == "text"]
+            assert XML_UNDECLARED in text_block["text"]
+            assert "Running now." in text_block["text"] and "done." in text_block["text"]
+            # The promoted lookup markup is gone from the visible text.
+            assert LOOKUP_XML not in text_block["text"]
+
+        asyncio.run(_run())
+
+
 class TestAnthropicEmitterHealing:
     def _events(
         self,

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -33,6 +33,18 @@ TOOLS = [
     {"type": "function", "function": {"name": "Bash", "parameters": {}}},
     {"type": "function", "function": {"name": "Read", "parameters": {}}},
 ]
+
+BASH_COMMAND_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "Bash",
+        "parameters": {
+            "type": "object",
+            "properties": {"command": {"type": "string"}},
+            "required": ["command"],
+        },
+    },
+}
 XML_BASH = '<tool_call>{"name":"Bash","arguments":{"cmd":"ls"}}</tool_call>'
 XML_UNDECLARED = '<tool_call>{"name":"Nuke","arguments":{}}</tool_call>'
 
@@ -106,14 +118,22 @@ class TestHealOpenaiMessage:
         msg = {"role": "assistant", "content": "just an answer"}
         assert heal_openai_message(msg, {"Bash"}) is False
 
-    def test_bad_json_arguments_coerced_under_canonical_key(self):
+    def test_bare_string_arguments_use_schema_key(self):
         msg = {
             "role": "assistant",
             "content": '<tool_call>{"name":"Bash","arguments":"echo hi"}</tool_call>',
         }
-        assert heal_openai_message(msg, {"Bash"}) is True
+        assert heal_openai_message(msg, {"Bash"}, [BASH_COMMAND_TOOL]) is True
         args = json.loads(msg["tool_calls"][0]["function"]["arguments"])
-        assert args == {"query": "echo hi"}
+        assert args == {"command": "echo hi"}
+
+    def test_bare_string_arguments_decline_ambiguous_schema(self):
+        msg = {
+            "role": "assistant",
+            "content": '<tool_call>{"name":"Bash","arguments":"echo hi"}</tool_call>',
+        }
+        assert heal_openai_message(msg, {"Bash"}, TOOLS) is False
+        assert "tool_calls" not in msg
 
     def test_mixed_declared_and_undeclared_promotes_declared_keeps_undeclared_text(self):
         # Span-exact removal: only the promoted Bash markup is dropped; the
@@ -504,6 +524,20 @@ class TestOpenaiNonStreamingRoute:
             assert choice["message"]["content"] is None
             assert data["usage"]["total_tokens"] == 3  # usage preserved
             assert len(client.posts) == 1  # healing never re-requests
+
+        asyncio.run(_run())
+
+
+    def test_bare_string_uses_client_schema_key(self, monkeypatch):
+        async def _run():
+            content = '<tool_call>{"name":"Bash","arguments":"echo hi"}</tool_call>'
+            _, data = await _drive_non_streaming(
+                monkeypatch,
+                _payload(tools = [BASH_COMMAND_TOOL]),
+                [_upstream_message(content)],
+            )
+            (call,) = data["choices"][0]["message"]["tool_calls"]
+            assert json.loads(call["function"]["arguments"]) == {"command": "echo hi"}
 
         asyncio.run(_run())
 

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -396,6 +396,131 @@ class TestOpenaiNonStreamingRoute:
         asyncio.run(_run())
 
 
+GARBAGE_SIGNAL = "<tool_call>call lookup somehow???"
+
+
+class TestNudgeRetryOpenai:
+    def test_retry_recovers_call(self, monkeypatch):
+        async def _run():
+            client, data = await _drive_non_streaming(
+                monkeypatch,
+                _payload(nudge_tool_calls = True),
+                [_upstream_message(GARBAGE_SIGNAL), _upstream_message(LOOKUP_XML)],
+            )
+            assert len(client.posts) == 2  # exactly one retry
+            # Prefix byte-identical, nudge suffix appended (KV-cache reuse guard).
+            original, retry = client.posts
+            assert retry["messages"][: len(original["messages"])] == original["messages"]
+            suffix = retry["messages"][len(original["messages"]) :]
+            assert [m["role"] for m in suffix] == ["assistant", "user"]
+            assert suffix[0]["content"] == GARBAGE_SIGNAL
+            # The healed retry response is returned.
+            (call,) = data["choices"][0]["message"]["tool_calls"]
+            assert call["function"]["name"] == "lookup"
+            assert data["choices"][0]["finish_reason"] == "tool_calls"
+
+        asyncio.run(_run())
+
+    def test_retry_still_garbage_returns_original(self, monkeypatch):
+        async def _run():
+            client, data = await _drive_non_streaming(
+                monkeypatch,
+                _payload(nudge_tool_calls = True),
+                [_upstream_message(GARBAGE_SIGNAL), _upstream_message(GARBAGE_SIGNAL + "2")],
+            )
+            assert len(client.posts) == 2
+            assert data["choices"][0]["message"]["content"] == GARBAGE_SIGNAL
+            assert "tool_calls" not in data["choices"][0]["message"]
+
+        asyncio.run(_run())
+
+    def test_default_off_single_post(self, monkeypatch):
+        async def _run():
+            client, _ = await _drive_non_streaming(
+                monkeypatch, _payload(), [_upstream_message(GARBAGE_SIGNAL)]
+            )
+            assert len(client.posts) == 1
+
+        asyncio.run(_run())
+
+    def test_no_retry_on_clean_prose(self, monkeypatch):
+        async def _run():
+            client, _ = await _drive_non_streaming(
+                monkeypatch,
+                _payload(nudge_tool_calls = True),
+                [_upstream_message("all done")],
+            )
+            assert len(client.posts) == 1
+
+        asyncio.run(_run())
+
+    def test_no_retry_when_heal_succeeds(self, monkeypatch):
+        async def _run():
+            client, data = await _drive_non_streaming(
+                monkeypatch,
+                _payload(nudge_tool_calls = True),
+                [_upstream_message(LOOKUP_XML)],
+            )
+            assert len(client.posts) == 1
+            assert data["choices"][0]["message"]["tool_calls"]
+
+        asyncio.run(_run())
+
+    def test_heal_opt_out_disables_nudge_too(self, monkeypatch):
+        async def _run():
+            client, _ = await _drive_non_streaming(
+                monkeypatch,
+                _payload(auto_heal_tool_calls = False, nudge_tool_calls = True),
+                [_upstream_message(GARBAGE_SIGNAL)],
+            )
+            assert len(client.posts) == 1
+
+        asyncio.run(_run())
+
+
+class TestNudgeRetryAnthropic:
+    async def _drive(self, monkeypatch, bodies, nudge = None):
+        import routes.inference as inf_mod
+        from routes.inference import _anthropic_passthrough_non_streaming
+
+        client = ScriptedClient(bodies)
+        monkeypatch.setattr(inf_mod, "nonstreaming_client", lambda: client)
+        response = await _anthropic_passthrough_non_streaming(
+            _llama_backend(),
+            [{"role": "user", "content": "hi"}],
+            [LOOKUP_TOOL],
+            0.7,
+            0.95,
+            None,
+            256,
+            "msg_test",
+            "gguf",
+            nudge_tool_calls = nudge,
+        )
+        return client, json.loads(response.body)
+
+    def test_retry_recovers_tool_use(self, monkeypatch):
+        async def _run():
+            client, data = await self._drive(
+                monkeypatch,
+                [_upstream_message(GARBAGE_SIGNAL), _upstream_message(LOOKUP_XML)],
+                nudge = True,
+            )
+            assert len(client.posts) == 2
+            (block,) = [b for b in data["content"] if b["type"] == "tool_use"]
+            assert block["name"] == "lookup"
+            assert data["stop_reason"] == "tool_use"
+
+        asyncio.run(_run())
+
+    def test_default_off(self, monkeypatch):
+        async def _run():
+            client, _ = await self._drive(monkeypatch, [_upstream_message(GARBAGE_SIGNAL)])
+            assert len(client.posts) == 1
+
+        asyncio.run(_run())
+
+
 class TestAnthropicEmitterHealing:
     def _events(self, emitter, chunks, finish = True):
         lines = []

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -703,8 +703,9 @@ class TestOpenaiNonStreamingRoute:
 
         asyncio.run(_run())
 
-
-    def test_same_chunk_role_content_finish_delays_finish_until_after_healed_tool(self, monkeypatch):
+    def test_same_chunk_role_content_finish_delays_finish_until_after_healed_tool(
+        self, monkeypatch
+    ):
         async def _run():
             lines = [
                 'data: {"id":"c1","choices":[{"index":0,"delta":{"role":"assistant","content":'

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -58,6 +58,24 @@ class TestHealGate:
     def test_malformed_tool_entries_ignored(self):
         assert heal_gate(None, ["nonsense", {"function": "x"}, {}]) is None
 
+    def test_tool_choice_none_disables(self):
+        assert heal_gate(None, TOOLS, "none") is None
+
+    def test_tool_choice_forced_function_narrows_allowlist(self):
+        forced = {"type": "function", "function": {"name": "Bash"}}
+        assert heal_gate(None, TOOLS, forced) == {"Bash"}
+
+    def test_tool_choice_forced_undeclared_function_disables(self):
+        forced = {"type": "function", "function": {"name": "Nuke"}}
+        assert heal_gate(None, TOOLS, forced) is None
+
+    def test_tool_choice_auto_and_required_keep_full_set(self):
+        assert heal_gate(None, TOOLS, "auto") == {"Bash", "Read"}
+        assert heal_gate(None, TOOLS, "required") == {"Bash", "Read"}
+
+    def test_tool_choice_unrecognized_dict_keeps_full_set(self):
+        assert heal_gate(None, TOOLS, {"type": "function"}) == {"Bash", "Read"}
+
 
 class TestHealOpenaiMessage:
     def test_promotes_xml_and_strips_content(self):
@@ -431,6 +449,49 @@ class TestOpenaiNonStreamingRoute:
 
         asyncio.run(_run())
 
+    def test_length_finish_reason_preserved(self, monkeypatch):
+        async def _run():
+            # Truncated generation: the healed call stays attached but the
+            # client must still see the truncation, so length is never
+            # upgraded to tool_calls.
+            _, data = await _drive_non_streaming(
+                monkeypatch,
+                _payload(),
+                [_upstream_message(LOOKUP_XML, finish_reason = "length")],
+            )
+            choice = data["choices"][0]
+            assert choice["finish_reason"] == "length"
+            (call,) = choice["message"]["tool_calls"]
+            assert call["function"]["name"] == "lookup"
+
+        asyncio.run(_run())
+
+    def test_tool_choice_none_relays_verbatim(self, monkeypatch):
+        async def _run():
+            _, data = await _drive_non_streaming(
+                monkeypatch,
+                _payload(tool_choice = "none"),
+                [_upstream_message(LOOKUP_XML)],
+            )
+            message = data["choices"][0]["message"]
+            assert message["content"] == LOOKUP_XML
+            assert "tool_calls" not in message
+
+        asyncio.run(_run())
+
+    def test_tool_choice_forcing_other_function_not_promoted(self, monkeypatch):
+        async def _run():
+            _, data = await _drive_non_streaming(
+                monkeypatch,
+                _payload(tool_choice = {"type": "function", "function": {"name": "other"}}),
+                [_upstream_message(LOOKUP_XML)],
+            )
+            message = data["choices"][0]["message"]
+            assert message["content"] == LOOKUP_XML
+            assert "tool_calls" not in message
+
+        asyncio.run(_run())
+
 
 GARBAGE_SIGNAL = "<tool_call>call lookup somehow???"
 
@@ -747,6 +808,7 @@ class TestAnthropicNonStreamingRoute:
         bodies,
         auto_heal = None,
         tools = None,
+        tool_choice = "auto",
     ):
         import routes.inference as inf_mod
         from routes.inference import _anthropic_passthrough_non_streaming
@@ -763,6 +825,7 @@ class TestAnthropicNonStreamingRoute:
             256,
             "msg_test",
             "gguf",
+            tool_choice = tool_choice,
             auto_heal_tool_calls = auto_heal,
         )
         return client, json.loads(response.body)
@@ -806,6 +869,23 @@ class TestAnthropicNonStreamingRoute:
             )
             assert data["stop_reason"] == "max_tokens"
             assert any(b["type"] == "tool_use" for b in data["content"])
+
+        asyncio.run(_run())
+
+    def test_tool_choice_none_keeps_legacy_strip(self, monkeypatch):
+        async def _run():
+            # Anthropic {"type": "none"} arrives here converted to "none":
+            # the request forbade tool calls, so nothing is promoted and the
+            # legacy XML strip applies as before healing existed.
+            _, data = await self._drive(
+                monkeypatch,
+                [_upstream_message(f"plan {LOOKUP_XML}")],
+                tool_choice = "none",
+            )
+            assert data["stop_reason"] == "end_turn"
+            (block,) = data["content"]
+            assert block["type"] == "text"
+            assert block["text"] == "plan"
 
         asyncio.run(_run())
 

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -178,7 +178,11 @@ class TestStreamHealer:
 
 
 class TestNudgeHelpers:
-    def _resp(self, content, tool_calls = None):
+    def _resp(
+        self,
+        content,
+        tool_calls = None,
+    ):
         msg = {"role": "assistant", "content": content}
         if tool_calls:
             msg["tool_calls"] = tool_calls
@@ -251,7 +255,11 @@ def _llama_backend():
     )
 
 
-def _upstream_message(content, tool_calls = None, finish_reason = "stop"):
+def _upstream_message(
+    content,
+    tool_calls = None,
+    finish_reason = "stop",
+):
     message = {"role": "assistant", "content": content}
     if tool_calls is not None:
         message["tool_calls"] = tool_calls
@@ -272,7 +280,12 @@ class ScriptedClient:
         self.bodies = list(bodies)
         self.posts = []
 
-    async def post(self, _url, json = None, timeout = None):
+    async def post(
+        self,
+        _url,
+        json = None,
+        timeout = None,
+    ):
         self.posts.append(json)
         return httpx.Response(200, json = self.bodies[min(len(self.posts) - 1, len(self.bodies) - 1)])
 
@@ -369,9 +382,7 @@ class TestOpenaiNonStreamingRoute:
     def test_undeclared_tool_not_promoted(self, monkeypatch):
         async def _run():
             xml = '<tool_call>{"name":"rogue","arguments":{}}</tool_call>'
-            _, data = await _drive_non_streaming(
-                monkeypatch, _payload(), [_upstream_message(xml)]
-            )
+            _, data = await _drive_non_streaming(monkeypatch, _payload(), [_upstream_message(xml)])
             assert data["choices"][0]["message"]["content"] == xml
             assert "tool_calls" not in data["choices"][0]["message"]
 
@@ -479,7 +490,12 @@ class TestNudgeRetryOpenai:
 
 
 class TestNudgeRetryAnthropic:
-    async def _drive(self, monkeypatch, bodies, nudge = None):
+    async def _drive(
+        self,
+        monkeypatch,
+        bodies,
+        nudge = None,
+    ):
         import routes.inference as inf_mod
         from routes.inference import _anthropic_passthrough_non_streaming
 
@@ -522,7 +538,12 @@ class TestNudgeRetryAnthropic:
 
 
 class TestAnthropicEmitterHealing:
-    def _events(self, emitter, chunks, finish = True):
+    def _events(
+        self,
+        emitter,
+        chunks,
+        finish = True,
+    ):
         lines = []
         for chunk in chunks:
             lines += emitter.feed_chunk(chunk)
@@ -530,14 +551,23 @@ class TestAnthropicEmitterHealing:
             lines += emitter.finish()
         return [json.loads(ln.split("data: ", 1)[1]) for ln in lines if "data: " in ln]
 
-    def _emitter(self, allowed = ("lookup",), **kwargs):
+    def _emitter(
+        self,
+        allowed = ("lookup",),
+        **kwargs,
+    ):
         from core.inference.anthropic_compat import AnthropicPassthroughEmitter
 
         emitter = AnthropicPassthroughEmitter()
         emitter.enable_healing(set(allowed), **kwargs)
         return emitter
 
-    def _chunk(self, content = None, tool_calls = None, finish_reason = None):
+    def _chunk(
+        self,
+        content = None,
+        tool_calls = None,
+        finish_reason = None,
+    ):
         delta = {}
         if content is not None:
             delta["content"] = content
@@ -665,8 +695,7 @@ class TestAnthropicEmitterHealing:
         starts = [
             e
             for e in events
-            if e.get("type") == "content_block_start"
-            and e["content_block"]["type"] == "tool_use"
+            if e.get("type") == "content_block_start" and e["content_block"]["type"] == "tool_use"
         ]
         assert len(starts) == 1
 
@@ -687,7 +716,13 @@ class TestAnthropicEmitterHealing:
 
 
 class TestAnthropicNonStreamingRoute:
-    async def _drive(self, monkeypatch, bodies, auto_heal = None, tools = None):
+    async def _drive(
+        self,
+        monkeypatch,
+        bodies,
+        auto_heal = None,
+        tools = None,
+    ):
         import routes.inference as inf_mod
         from routes.inference import _anthropic_passthrough_non_streaming
 

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -208,3 +208,301 @@ class TestNudgeHelpers:
         assert [m["role"] for m in suffix] == ["assistant", "user"]
         assert suffix[0]["content"] == "<tool_call>garbage"
         assert "`Bash` or `Read`" in suffix[1]["content"]
+
+
+# ── Route-level wiring (OpenAI passthrough) ─────────────────────────────
+# Mirrors the fake-llama-server patterns in test_openai_tool_passthrough.py.
+
+import asyncio  # noqa: E402
+import threading  # noqa: E402
+from types import SimpleNamespace  # noqa: E402
+
+import httpx  # noqa: E402
+
+from core.inference.api_monitor import ApiMonitor  # noqa: E402
+from models.inference import ChatCompletionRequest, ChatMessage  # noqa: E402
+from routes.inference import (  # noqa: E402
+    _openai_passthrough_non_streaming,
+    _openai_passthrough_stream,
+)
+
+LOOKUP_TOOL = {
+    "type": "function",
+    "function": {"name": "lookup", "parameters": {"type": "object", "properties": {}}},
+}
+LOOKUP_XML = '<tool_call>{"name":"lookup","arguments":{"q":"x"}}</tool_call>'
+
+
+def _payload(**kwargs):
+    defaults = dict(
+        model = "default",
+        messages = [ChatMessage(role = "user", content = "hi")],
+        tools = [LOOKUP_TOOL],
+    )
+    defaults.update(kwargs)
+    return ChatCompletionRequest(**defaults)
+
+
+def _llama_backend():
+    return SimpleNamespace(
+        base_url = "http://llama.test",
+        context_length = 4096,
+        _request_reasoning_kwargs = lambda *_args, **_kwargs: None,
+    )
+
+
+def _upstream_message(content, tool_calls = None, finish_reason = "stop"):
+    message = {"role": "assistant", "content": content}
+    if tool_calls is not None:
+        message["tool_calls"] = tool_calls
+    return {
+        "id": "chatcmpl-up",
+        "object": "chat.completion",
+        "created": 1,
+        "model": "gguf",
+        "choices": [{"index": 0, "message": message, "finish_reason": finish_reason}],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+    }
+
+
+class ScriptedClient:
+    """Fake nonstreaming_client() returning scripted JSON bodies, counting POSTs."""
+
+    def __init__(self, bodies):
+        self.bodies = list(bodies)
+        self.posts = []
+
+    async def post(self, _url, json = None, timeout = None):
+        self.posts.append(json)
+        return httpx.Response(200, json = self.bodies[min(len(self.posts) - 1, len(self.bodies) - 1)])
+
+
+async def _drive_non_streaming(monkeypatch, payload, bodies):
+    import routes.inference as inf_mod
+
+    client = ScriptedClient(bodies)
+    monkeypatch.setattr(inf_mod, "nonstreaming_client", lambda: client)
+    response = await _openai_passthrough_non_streaming(
+        _llama_backend(), payload, "gguf", monitor_id = None
+    )
+    return client, json.loads(response.body)
+
+
+async def _drive_stream(monkeypatch, payload, lines):
+    import routes.inference as inf_mod
+
+    class Request:
+        async def is_disconnected(self):
+            return False
+
+    async def fake_send(*_args, **_kwargs):
+        return httpx.Response(200, content = b"")
+
+    async def fake_items(*_args, **_kwargs):
+        for line in lines:
+            yield line
+
+    monkeypatch.setattr(inf_mod, "_send_stream_with_preheader_cancel", fake_send)
+    monkeypatch.setattr(inf_mod, "_aiter_llama_stream_items", fake_items)
+    monkeypatch.setattr(inf_mod, "api_monitor", ApiMonitor(max_entries = 3))
+    response = await _openai_passthrough_stream(
+        Request(),
+        threading.Event(),
+        _llama_backend(),
+        payload,
+        "gguf",
+        "chatcmpl-test",
+        monitor_id = None,
+    )
+    return [chunk async for chunk in response.body_iterator]
+
+
+def _stream_payloads(chunks):
+    out = []
+    for chunk in chunks:
+        for line in chunk.splitlines():
+            if line.startswith("data: ") and line[6:] != "[DONE]":
+                out.append(json.loads(line[6:]))
+    return out
+
+
+class TestOpenaiNonStreamingRoute:
+    def test_heals_xml_to_tool_calls(self, monkeypatch):
+        async def _run():
+            client, data = await _drive_non_streaming(
+                monkeypatch, _payload(), [_upstream_message(LOOKUP_XML)]
+            )
+            choice = data["choices"][0]
+            assert choice["finish_reason"] == "tool_calls"
+            (call,) = choice["message"]["tool_calls"]
+            assert call["function"]["name"] == "lookup"
+            assert json.loads(call["function"]["arguments"]) == {"q": "x"}
+            assert choice["message"]["content"] is None
+            assert data["usage"]["total_tokens"] == 3  # usage preserved
+            assert len(client.posts) == 1  # healing never re-requests
+
+        asyncio.run(_run())
+
+    def test_opt_out_relays_verbatim(self, monkeypatch):
+        async def _run():
+            _, data = await _drive_non_streaming(
+                monkeypatch,
+                _payload(auto_heal_tool_calls = False),
+                [_upstream_message(LOOKUP_XML)],
+            )
+            choice = data["choices"][0]
+            assert choice["message"]["content"] == LOOKUP_XML
+            assert "tool_calls" not in choice["message"]
+            assert choice["finish_reason"] == "stop"
+
+        asyncio.run(_run())
+
+    def test_no_tools_untouched(self, monkeypatch):
+        async def _run():
+            _, data = await _drive_non_streaming(
+                monkeypatch, _payload(tools = None), [_upstream_message(LOOKUP_XML)]
+            )
+            assert data["choices"][0]["message"]["content"] == LOOKUP_XML
+
+        asyncio.run(_run())
+
+    def test_undeclared_tool_not_promoted(self, monkeypatch):
+        async def _run():
+            xml = '<tool_call>{"name":"rogue","arguments":{}}</tool_call>'
+            _, data = await _drive_non_streaming(
+                monkeypatch, _payload(), [_upstream_message(xml)]
+            )
+            assert data["choices"][0]["message"]["content"] == xml
+            assert "tool_calls" not in data["choices"][0]["message"]
+
+        asyncio.run(_run())
+
+    def test_structured_calls_untouched(self, monkeypatch):
+        async def _run():
+            native = [
+                {
+                    "id": "call_up",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{}"},
+                }
+            ]
+            _, data = await _drive_non_streaming(
+                monkeypatch,
+                _payload(),
+                [_upstream_message("", tool_calls = native, finish_reason = "tool_calls")],
+            )
+            assert data["choices"][0]["message"]["tool_calls"] == native
+
+        asyncio.run(_run())
+
+
+class TestOpenaiStreamingRoute:
+    def test_heals_streamed_xml(self, monkeypatch):
+        async def _run():
+            pieces = ["<tool_call>", '{"name":"lookup",', '"arguments":{"q":"x"}}', "</tool_call>"]
+            lines = [
+                'data: {"id":"c1","model":"gguf","created":1,"choices":[{"index":0,"delta":{"content":%s}}]}'
+                % json.dumps(p)
+                for p in pieces
+            ]
+            lines += [
+                'data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+                "data: [DONE]",
+            ]
+            chunks = await _drive_stream(monkeypatch, _payload(), lines)
+            payloads = _stream_payloads(chunks)
+            tool_deltas = [
+                tc
+                for p in payloads
+                for c in p.get("choices", [])
+                for tc in (c.get("delta") or {}).get("tool_calls") or []
+            ]
+            (call,) = tool_deltas
+            assert call["function"]["name"] == "lookup"
+            assert json.loads(call["function"]["arguments"]) == {"q": "x"}
+            finishes = [
+                c["finish_reason"]
+                for p in payloads
+                for c in p.get("choices", [])
+                if c.get("finish_reason")
+            ]
+            assert finishes == ["tool_calls"]
+            # None of the XML leaked as visible content.
+            text = "".join(
+                (c.get("delta") or {}).get("content") or ""
+                for p in payloads
+                for c in p.get("choices", [])
+            )
+            assert "<tool_call>" not in text
+            assert chunks[-1] == "data: [DONE]\n\n"
+
+        asyncio.run(_run())
+
+    def test_false_alarm_text_flushes(self, monkeypatch):
+        async def _run():
+            lines = [
+                'data: {"id":"c1","choices":[{"index":0,"delta":{"content":"use the <div> tag"}}]}',
+                'data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+                "data: [DONE]",
+            ]
+            chunks = await _drive_stream(monkeypatch, _payload(), lines)
+            payloads = _stream_payloads(chunks)
+            text = "".join(
+                (c.get("delta") or {}).get("content") or ""
+                for p in payloads
+                for c in p.get("choices", [])
+            )
+            assert text == "use the <div> tag"
+            finishes = [
+                c["finish_reason"]
+                for p in payloads
+                for c in p.get("choices", [])
+                if c.get("finish_reason")
+            ]
+            assert finishes == ["stop"]
+
+        asyncio.run(_run())
+
+    def test_incomplete_xml_healed_at_done(self, monkeypatch):
+        async def _run():
+            # No close tag and no finish chunk: healed at the [DONE] boundary,
+            # synthetic finish must say tool_calls.
+            lines = [
+                'data: {"id":"c1","choices":[{"index":0,"delta":{"content":"<tool_call>{\\"name\\":\\"lookup\\",\\"arguments\\":{}}"}}]}',
+                "data: [DONE]",
+            ]
+            chunks = await _drive_stream(monkeypatch, _payload(), lines)
+            payloads = _stream_payloads(chunks)
+            tool_deltas = [
+                tc
+                for p in payloads
+                for c in p.get("choices", [])
+                for tc in (c.get("delta") or {}).get("tool_calls") or []
+            ]
+            assert len(tool_deltas) == 1
+            finishes = [
+                c["finish_reason"]
+                for p in payloads
+                for c in p.get("choices", [])
+                if c.get("finish_reason")
+            ]
+            assert finishes == ["tool_calls"]
+
+        asyncio.run(_run())
+
+    def test_structured_upstream_calls_relay_verbatim(self, monkeypatch):
+        async def _run():
+            line = (
+                'data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":'
+                '[{"index":0,"id":"call_up","type":"function","function":'
+                '{"name":"lookup","arguments":"{}"}}]}}]}'
+            )
+            lines = [
+                line,
+                'data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}',
+                "data: [DONE]",
+            ]
+            chunks = await _drive_stream(monkeypatch, _payload(), lines)
+            assert chunks[0] == line + "\n\n"  # byte-for-byte relay
+
+        asyncio.run(_run())

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -924,6 +924,32 @@ class TestAnthropicEmitterHealing:
         ]
         assert len(starts) == 1
 
+    def test_disable_parallel_drops_native_after_healed(self):
+        # A healed call consumed the single allowed slot; a later native
+        # structured call (index 0, so it survives the caller's chunk-level
+        # cap) must not open a second tool_use block.
+        structured = [
+            {
+                "index": 0,
+                "id": "call_up",
+                "function": {"name": "lookup", "arguments": "{}"},
+            }
+        ]
+        events = self._events(
+            self._emitter(disable_parallel_tool_use = True),
+            [
+                self._chunk(content = LOOKUP_XML),
+                self._chunk(tool_calls = structured),
+                self._chunk(finish_reason = "tool_calls"),
+            ],
+        )
+        starts = [
+            e
+            for e in events
+            if e.get("type") == "content_block_start" and e["content_block"]["type"] == "tool_use"
+        ]
+        assert len(starts) == 1
+
     def test_no_healing_means_verbatim_text(self):
         from core.inference.anthropic_compat import AnthropicPassthroughEmitter
 
@@ -1068,6 +1094,39 @@ class TestOpenaiStreamingRoute:
             )
             assert "<tool_call>" not in text
             assert chunks[-1] == "data: [DONE]\n\n"
+
+        asyncio.run(_run())
+
+    def test_parallel_cap_drops_native_after_healed(self, monkeypatch):
+        async def _run():
+            # parallel_tool_calls=false: a healed call consumed the single
+            # allowed slot, and the upstream SSE cap keeps native index 0, so
+            # the route must drop the later native call itself.
+            xml = '<tool_call>{"name":"lookup","arguments":{"q":"x"}}</tool_call>'
+            native = (
+                'data: {"id":"c1","choices":[{"index":0,"delta":{"tool_calls":'
+                '[{"index":0,"id":"call_up","type":"function","function":'
+                '{"name":"lookup","arguments":"{}"}}]}}]}'
+            )
+            lines = [
+                'data: {"id":"c1","model":"gguf","created":1,"choices":'
+                '[{"index":0,"delta":{"content":%s}}]}' % json.dumps(xml),
+                native,
+                'data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}',
+                "data: [DONE]",
+            ]
+            chunks = await _drive_stream(
+                monkeypatch, _payload(parallel_tool_calls = False), lines
+            )
+            payloads = _stream_payloads(chunks)
+            tool_deltas = [
+                tc
+                for p in payloads
+                for c in p.get("choices", [])
+                for tc in (c.get("delta") or {}).get("tool_calls") or []
+            ]
+            (call,) = tool_deltas
+            assert call["id"] == "call_0"  # the healed call; native was dropped
 
         asyncio.run(_run())
 

--- a/studio/backend/tests/test_responses_tool_passthrough.py
+++ b/studio/backend/tests/test_responses_tool_passthrough.py
@@ -2156,8 +2156,7 @@ class TestResponsesStreamHealing:
         calls = [
             payload
             for name, payload in events
-            if name == "response.output_item.added"
-            and payload["item"]["type"] == "function_call"
+            if name == "response.output_item.added" and payload["item"]["type"] == "function_call"
         ]
         assert len(calls) == 1
         assert calls[0]["item"]["name"] == "lookup"

--- a/studio/backend/tests/test_responses_tool_passthrough.py
+++ b/studio/backend/tests/test_responses_tool_passthrough.py
@@ -1986,3 +1986,104 @@ class TestTranslatedMessagesValidate:
         msgs = _normalise_responses_input(payload)
         for m in msgs:
             ChatMessage(**m.model_dump(exclude_none = True))
+
+
+# =====================================================================
+# Streaming passthrough healing — text-form calls promoted in order
+# =====================================================================
+
+
+class TestResponsesStreamHealing:
+    """Route-level healing on the /v1/responses stream: text-form tool calls
+    are promoted through the same per-call item state machinery as structured
+    deltas, and healer events keep their order (text around a healed call must
+    not move relative to the function_call item)."""
+
+    _XML = '<tool_call>{"name":"lookup","arguments":{"q":"x"}}</tool_call>'
+    _TOOL = {"type": "function", "name": "lookup", "parameters": {"type": "object"}}
+
+    @staticmethod
+    def _ordered_events(lines):
+        events = []
+        for line in lines:
+            if not line.startswith("event: "):
+                continue
+            name, _, rest = line.partition("\n")
+            payload = json.loads(rest.split("data: ", 1)[1].strip())
+            events.append((name[len("event: ") :], payload))
+        return events
+
+    def _run_stream(self, monkeypatch, content, **payload_kwargs):
+        TestResponsesStreamAdapter._install_stream_mock(
+            monkeypatch, [{"choices": [{"delta": {"content": content}}]}]
+        )
+        payload = ResponsesRequest(
+            input = "hi", stream = True, tools = [self._TOOL], **payload_kwargs
+        )
+        messages = [ChatMessage(role = "user", content = "hi")]
+
+        async def run():
+            response = await _responses_stream(
+                payload, messages, TestResponsesStreamAdapter._Request()
+            )
+            return await TestResponsesStreamAdapter._collect(response)
+
+        return self._ordered_events(asyncio.run(run()))
+
+    def test_text_around_healed_call_keeps_order(self, monkeypatch):
+        events = self._run_stream(monkeypatch, f"before {self._XML} after.")
+        pos_before = pos_item = pos_after = None
+        for i, (name, payload) in enumerate(events):
+            if name == "response.output_text.delta":
+                if "before" in payload["delta"] and pos_before is None:
+                    pos_before = i
+                if "after" in payload["delta"]:
+                    pos_after = i
+            if (
+                name == "response.output_item.added"
+                and payload["item"]["type"] == "function_call"
+                and pos_item is None
+            ):
+                pos_item = i
+                assert payload["item"]["name"] == "lookup"
+        assert pos_before is not None and pos_item is not None and pos_after is not None
+        assert pos_before < pos_item < pos_after
+
+    def test_call_before_trailing_text_claims_lower_output_index(self, monkeypatch):
+        events = self._run_stream(monkeypatch, f"{self._XML} done.")
+        item_added = [
+            (name, payload)
+            for name, payload in events
+            if name == "response.output_item.added"
+        ]
+        # The call came first in the model output, so its item is added first
+        # and claims the lower output_index; the trailing text's message item
+        # follows.
+        assert [payload["item"]["type"] for _, payload in item_added] == [
+            "function_call",
+            "message",
+        ]
+        call_idx = item_added[0][1]["output_index"]
+        msg_idx = item_added[1][1]["output_index"]
+        assert call_idx < msg_idx
+        text = "".join(
+            payload["delta"]
+            for name, payload in events
+            if name == "response.output_text.delta"
+        )
+        assert "done." in text
+        assert "<tool_call>" not in text
+
+    def test_tool_choice_none_streams_raw_text(self, monkeypatch):
+        events = self._run_stream(monkeypatch, self._XML, tool_choice = "none")
+        assert not any(
+            payload["item"]["type"] == "function_call"
+            for name, payload in events
+            if name == "response.output_item.added"
+        )
+        text = "".join(
+            payload["delta"]
+            for name, payload in events
+            if name == "response.output_text.delta"
+        )
+        assert text == self._XML

--- a/studio/backend/tests/test_responses_tool_passthrough.py
+++ b/studio/backend/tests/test_responses_tool_passthrough.py
@@ -2017,7 +2017,9 @@ class TestResponsesStreamHealing:
         TestResponsesStreamAdapter._install_stream_mock(
             monkeypatch, [{"choices": [{"delta": {"content": content}}]}]
         )
-        payload = ResponsesRequest(input = "hi", stream = True, tools = [self._TOOL], **payload_kwargs)
+        payload = ResponsesRequest(
+            input = "hi", stream = True, tools = [self._TOOL], **payload_kwargs
+        )
         messages = [ChatMessage(role = "user", content = "hi")]
 
         async def run():
@@ -2050,7 +2052,9 @@ class TestResponsesStreamHealing:
     def test_call_before_trailing_text_claims_lower_output_index(self, monkeypatch):
         events = self._run_stream(monkeypatch, f"{self._XML} done.")
         item_added = [
-            (name, payload) for name, payload in events if name == "response.output_item.added"
+            (name, payload)
+            for name, payload in events
+            if name == "response.output_item.added"
         ]
         # The call came first in the model output, so its item is added first
         # and claims the lower output_index; the trailing text's message item
@@ -2063,7 +2067,9 @@ class TestResponsesStreamHealing:
         msg_idx = item_added[1][1]["output_index"]
         assert call_idx < msg_idx
         text = "".join(
-            payload["delta"] for name, payload in events if name == "response.output_text.delta"
+            payload["delta"]
+            for name, payload in events
+            if name == "response.output_text.delta"
         )
         assert "done." in text
         assert "<tool_call>" not in text
@@ -2076,6 +2082,8 @@ class TestResponsesStreamHealing:
             if name == "response.output_item.added"
         )
         text = "".join(
-            payload["delta"] for name, payload in events if name == "response.output_text.delta"
+            payload["delta"]
+            for name, payload in events
+            if name == "response.output_text.delta"
         )
         assert text == self._XML

--- a/studio/backend/tests/test_responses_tool_passthrough.py
+++ b/studio/backend/tests/test_responses_tool_passthrough.py
@@ -2017,9 +2017,7 @@ class TestResponsesStreamHealing:
         TestResponsesStreamAdapter._install_stream_mock(
             monkeypatch, [{"choices": [{"delta": {"content": content}}]}]
         )
-        payload = ResponsesRequest(
-            input = "hi", stream = True, tools = [self._TOOL], **payload_kwargs
-        )
+        payload = ResponsesRequest(input = "hi", stream = True, tools = [self._TOOL], **payload_kwargs)
         messages = [ChatMessage(role = "user", content = "hi")]
 
         async def run():
@@ -2052,9 +2050,7 @@ class TestResponsesStreamHealing:
     def test_call_before_trailing_text_claims_lower_output_index(self, monkeypatch):
         events = self._run_stream(monkeypatch, f"{self._XML} done.")
         item_added = [
-            (name, payload)
-            for name, payload in events
-            if name == "response.output_item.added"
+            (name, payload) for name, payload in events if name == "response.output_item.added"
         ]
         # The call came first in the model output, so its item is added first
         # and claims the lower output_index; the trailing text's message item
@@ -2067,9 +2063,7 @@ class TestResponsesStreamHealing:
         msg_idx = item_added[1][1]["output_index"]
         assert call_idx < msg_idx
         text = "".join(
-            payload["delta"]
-            for name, payload in events
-            if name == "response.output_text.delta"
+            payload["delta"] for name, payload in events if name == "response.output_text.delta"
         )
         assert "done." in text
         assert "<tool_call>" not in text
@@ -2082,8 +2076,6 @@ class TestResponsesStreamHealing:
             if name == "response.output_item.added"
         )
         text = "".join(
-            payload["delta"]
-            for name, payload in events
-            if name == "response.output_text.delta"
+            payload["delta"] for name, payload in events if name == "response.output_text.delta"
         )
         assert text == self._XML

--- a/studio/backend/tests/test_responses_tool_passthrough.py
+++ b/studio/backend/tests/test_responses_tool_passthrough.py
@@ -2111,3 +2111,53 @@ class TestResponsesStreamHealing:
         assert [item["type"] for item in output] == ["message", "function_call", "message"]
         assert output[0]["content"][0]["text"] == "before "
         assert output[2]["content"][0]["text"] == " after."
+
+    def test_parallel_cap_drops_native_after_healed(self, monkeypatch):
+        # parallel_tool_calls=false: a healed call consumed the single allowed
+        # slot; a later native structured call (index 0, so it survives
+        # _drop_parallel_tool_call_deltas) must not open a second
+        # function_call item.
+        TestResponsesStreamAdapter._install_stream_mock(
+            monkeypatch,
+            [
+                {"choices": [{"delta": {"content": self._XML}}]},
+                {
+                    "choices": [
+                        {
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "call_up",
+                                        "function": {"name": "lookup", "arguments": "{}"},
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+            ],
+        )
+        payload = ResponsesRequest(
+            input = "hi",
+            stream = True,
+            tools = [self._TOOL],
+            parallel_tool_calls = False,
+        )
+        messages = [ChatMessage(role = "user", content = "hi")]
+
+        async def run():
+            response = await _responses_stream(
+                payload, messages, TestResponsesStreamAdapter._Request()
+            )
+            return await TestResponsesStreamAdapter._collect(response)
+
+        events = self._ordered_events(asyncio.run(run()))
+        calls = [
+            payload
+            for name, payload in events
+            if name == "response.output_item.added"
+            and payload["item"]["type"] == "function_call"
+        ]
+        assert len(calls) == 1
+        assert calls[0]["item"]["name"] == "lookup"

--- a/studio/backend/tests/test_responses_tool_passthrough.py
+++ b/studio/backend/tests/test_responses_tool_passthrough.py
@@ -2079,3 +2079,35 @@ class TestResponsesStreamHealing:
             payload["delta"] for name, payload in events if name == "response.output_text.delta"
         )
         assert text == self._XML
+
+    def test_healed_call_splits_message_items(self, monkeypatch):
+        # Text on both sides of a healed call becomes TWO message items: the
+        # healed function_call closes the first, trailing text opens a fresh
+        # one with a later output index (native Responses stream shape).
+        events = self._run_stream(monkeypatch, f"before {self._XML} after.")
+        added = [
+            (payload["output_index"], payload["item"]["type"], payload["item"].get("id"))
+            for name, payload in events
+            if name == "response.output_item.added"
+        ]
+        assert [item_type for _, item_type, _ in added] == [
+            "message",
+            "function_call",
+            "message",
+        ]
+        assert [idx for idx, _, _ in added] == sorted(idx for idx, _, _ in added)
+        assert added[0][2] != added[2][2]  # distinct message item ids
+        # Text deltas attribute to their OWN message item.
+        deltas = [
+            (payload["item_id"], payload["delta"])
+            for name, payload in events
+            if name == "response.output_text.delta"
+        ]
+        assert [d for i, d in deltas if i == added[0][2]] == ["before "]
+        assert [d for i, d in deltas if i == added[2][2]] == [" after."]
+        # The completed snapshot lists all three items with per-item text.
+        completed = [payload for name, payload in events if name == "response.completed"]
+        output = completed[0]["response"]["output"]
+        assert [item["type"] for item in output] == ["message", "function_call", "message"]
+        assert output[0]["content"][0]["text"] == "before "
+        assert output[2]["content"][0]["text"] == " after."

--- a/studio/backend/tests/test_tool_call_parser_strict.py
+++ b/studio/backend/tests/test_tool_call_parser_strict.py
@@ -182,3 +182,18 @@ class TestHealingPathUnaffected:
         calls = parse_tool_calls_from_text(text, allow_incomplete = True)
         assert len(calls) == 1
         assert calls[0]["function"]["name"] == "web_search"
+
+    def test_closed_function_call_keeps_trailing_prose_out_of_arguments(self):
+        # allow_incomplete exists for truncated output; a call that DID close
+        # must parse identically to strict mode, leaving prose after
+        # </function> out of the last parameter and out of the removal span.
+        from core.tool_healing import parse_tool_calls_from_text as parse_with_spans
+
+        text = "<function=web_search><parameter=query>cats</parameter></function> trailing"
+        calls, spans = parse_with_spans(text, allow_incomplete = True, with_spans = True)
+        (call,) = calls
+        assert json.loads(call["function"]["arguments"]) == {"query": "cats"}
+        (span,) = spans
+        assert text[span[0] : span[1]] == (
+            "<function=web_search><parameter=query>cats</parameter></function>"
+        )

--- a/studio/backend/tests/test_tool_call_parser_strict.py
+++ b/studio/backend/tests/test_tool_call_parser_strict.py
@@ -71,6 +71,28 @@ class TestFunctionStyleTrailingText:
         call = _only(text)
         assert call == {"name": "python", "arguments": {"code": 'print("</function>")'}}
 
+    def test_closed_function_with_trailing_prose_heal_path(self):
+        # Regression: the heal / finalize path (allow_incomplete=True) used to fold
+        # </parameter></function> and the trailing prose into the argument and drop
+        # the prose from visible content. It must now match the strict path -- keep a
+        # clean argument and leave the trailing prose outside the call span.
+        text = "<function=web_search><parameter=query>cats</parameter></function> trailing words"
+        calls = parse_tool_calls_from_text(text, allow_incomplete = True)
+        assert len(calls) == 1
+        fn = calls[0]["function"]
+        assert fn["name"] == "web_search"
+        assert json.loads(fn["arguments"]) == {"query": "cats"}
+        # The trailing prose sits outside the removed span, so it stays visible.
+        from core.tool_healing import (
+            parse_tool_calls_from_text as _parse_with_spans,
+        )
+
+        _calls, spans = _parse_with_spans(text, allow_incomplete = True, with_spans = True)
+        out = text
+        for s, e in sorted(spans, reverse = True):
+            out = out[:s] + out[e:]
+        assert out == " trailing words"
+
     def test_incomplete_function_without_close_is_still_rejected(self):
         text = "<function=web_search><parameter=query>weather london"
         assert parse_tool_calls_from_text(text, allow_incomplete = False) == []


### PR DESCRIPTION
## Tool-call healing for the client-tool passthrough (unsloth run / unsloth API / coding agents)

Follow-up to #6613.

### Problem

Studio's own chat loop heals malformed tool calls that small GGUF models emit as text (`<tool_call>{...}</tool_call>`, Gemma `<|tool_call>...`, `<function=...>` XML) and nudges stalled models. But `unsloth run --disable-tools` (plain OpenAI-compatible API serving) and every coding agent attached via `unsloth start` use the client-tool passthrough: the agent's own tools go verbatim to llama-server and the response is relayed verbatim back. On that path a text-form tool call reaches the agent as prose and the turn dies. `--disable-tools` cannot be dropped, since the agent must use its own tools, not Studio's.

### What this does

Runs the existing healer over passthrough RESPONSES, default ON whenever the request declares client tools:

| Path | Non-streaming | Streaming |
| --- | --- | --- |
| `/v1/chat/completions` | text-form calls promoted to structured `tool_calls`, `finish_reason` becomes `tool_calls` | buffer-and-repair state machine: prose relays byte-for-byte, suspected tool XML is held, healed calls emit as synthetic `delta.tool_calls` chunks, false alarms flush verbatim |
| `/v1/responses` (Codex) | inherited via the chat path | healed calls feed the same per-call item state machinery as structured deltas |
| `/v1/messages` (Claude) | promoted into `tool_use` blocks, `stop_reason` becomes `tool_use` | the passthrough emitter routes text through the healer and emits synthetic `tool_use` blocks |

Design guarantees:

- Only calls naming a DECLARED client tool are promoted; healing can never invent a tool. Requests without tools relay verbatim, byte-for-byte.
- Once a structured (grammar-mode) tool call appears, the healer goes dormant after flushing anything held, so well-formed responses stay byte-identical.
- The upstream request body is never touched and healing issues no extra generation, so llama-server slot/KV-cache reuse is unchanged (verified live: a follow-up turn prefilled only the appended 21 tokens).
- Studio's own enable-tools loop never reaches this code; all its tool-loop suites pass unchanged.
- Arguments that are not valid JSON are coerced through the same canonical-key healing the tool loop uses. `parallel_tool_calls=false` and Anthropic `disable_parallel_tool_use` cap healed calls too.

### Nudging (opt-in)

When the model clearly tried to call a tool (a tool signal in the text) but healing produced nothing usable, an OPT-IN single retry re-asks with the original prompt prefix intact plus a two-message nudge naming the declared tools, so the server reuses the slot's KV cache. Non-streaming only (a stream has already emitted bytes). The retry replaces the original response only when it actually yields a usable call. Enable per request with `nudge_tool_calls: true`, or process-wide with `UNSLOTH_TOOL_CALL_NUDGE=1`.

### Controls

| Control | Effect |
| --- | --- |
| default | healing ON for passthrough requests that declare tools |
| `auto_heal_tool_calls: false` (per request, all three APIs) | disables healing and the nudge |
| `UNSLOTH_DISABLE_TOOL_CALL_HEALING=1` | process-wide kill switch |
| `nudge_tool_calls: true` / `UNSLOTH_TOOL_CALL_NUDGE=1` | opt-in nudge retry |

`unsloth run` and `unsloth start` need no new flags.

### Verification

- 55 new tests in `test_passthrough_healing.py` (healer state machine units, route-level OpenAI stream/non-stream, Anthropic emitter and non-stream, nudge retry with POST-count and prefix-identity assertions) plus the full regression battery: 486 tests across the passthrough, anthropic, responses, XML-strip, parser, and tool-loop suites, ruff clean.
- Live on an isolated Studio (Qwen3-1.7B GGUF): streamed prose with tools declared arrives intact with `finish_reason: stop`; a no-tools request relays raw text verbatim; native grammar-mode tool calls pass through untouched; Claude Code attached via the connector completed a real Write tool turn end to end; llama-server logs confirm slot prefix reuse across turns.

Note: current llama-server builds natively parse several text-form call shapes themselves, so this healer is the safety net for the combinations they miss (older builds, cross-template formats such as Gemma-style markers on non-Gemma models, and broken-JSON arguments).
