### PR TITLE
Studio: self-heal a pre-#6483-fix anyio>=4.14 stuck in existing installs

### DIFF
--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -190,7 +190,6 @@ _ANYIO_BAD_FLOOR = (4, 14)
 def _installed_anyio_version() -> tuple[int, int] | None:
     try:
         from importlib.metadata import version as _pkg_version
-
         raw = _pkg_version("anyio")
     except Exception:
         return None

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -181,6 +181,42 @@ def _probe_installed_torch_version() -> str | None:
     return lines[-1] if lines else None
 
 
+# constraints.txt caps new anyio resolutions at <4.14 (#6483), but an install
+# from before the cap existed can already be stuck at 4.14+, which later
+# constrained installs won't touch since it already satisfies mcp/fastmcp.
+_ANYIO_BAD_FLOOR = (4, 14)
+
+
+def _installed_anyio_version() -> tuple[int, int] | None:
+    try:
+        from importlib.metadata import version as _pkg_version
+
+        raw = _pkg_version("anyio")
+    except Exception:
+        return None
+    parts = raw.split(".")
+    try:
+        major = int(parts[0])
+        minor = int(re.sub(r"[^0-9].*", "", parts[1])) if len(parts) > 1 else 0
+    except (IndexError, ValueError):
+        return None
+    return (major, minor)
+
+
+def _repair_bad_anyio() -> None:
+    installed = _installed_anyio_version()
+    if installed is None or installed < _ANYIO_BAD_FLOOR:
+        return
+    _safe_print(_dim(f"   anyio {installed[0]}.{installed[1]} found -- reinstalling anyio<4.14..."))
+    pip_install(
+        "Repairing anyio version",
+        "--no-cache-dir",
+        "--force-reinstall",
+        "anyio<4.14.0",
+        constrain = False,
+    )
+
+
 # AMD Windows ROCm wheels (repo.amd.com/rocm/whl/{arch_family}/).
 # Override with UNSLOTH_ROCM_WINDOWS_MIRROR for air-gapped/mirror installs.
 _ROCM_WINDOWS_INDEX_BASE = (
@@ -1970,7 +2006,7 @@ def install_python_stack() -> int:
     package_name = os.environ.get("STUDIO_PACKAGE_NAME", "unsloth")
     # --local overlays a local repo checkout after updating deps.
     local_repo = os.environ.get("STUDIO_LOCAL_REPO", "")
-    base_total = 10 if IS_WINDOWS else 11
+    base_total = 11 if IS_WINDOWS else 12  # +1 for the anyio repair check (step 8b)
     if IS_MACOS:
         base_total -= 1  # triton step is skipped on macOS
     if not IS_MACOS and not NO_TORCH:
@@ -2283,6 +2319,10 @@ def install_python_stack() -> int:
         "--no-cache-dir",
         req = REQ_ROOT / "studio.txt",
     )
+
+    # 8b. anyio repair (#6483)
+    _progress("anyio check")
+    _repair_bad_anyio()
 
     # 9. Data-designer dependencies
     _progress("data designer deps")

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -2645,6 +2645,28 @@ if ($env:SKIP_STUDIO_BASE -ne "1" -and $env:STUDIO_LOCAL_INSTALL -ne "1") {
     if ($InstalledVer -and $LatestVer -and ($InstalledVer -eq $LatestVer)) {
         step "python" "$_PkgName $InstalledVer is up to date"
         $SkipPythonDeps = $true
+        # A pre-#6483-fix install can be stuck on anyio>=4.14 even though
+        # $_PkgName itself is current; the fast path above would otherwise
+        # never reach install_python_stack's anyio repair (#6797).
+        $_anyioBad = $false
+        try {
+            & python -c "
+import re, sys
+from importlib.metadata import version, PackageNotFoundError
+try:
+    parts = version('anyio').split('.')
+    major = int(parts[0])
+    minor = int(re.sub(r'[^0-9].*', '', parts[1])) if len(parts) > 1 else 0
+except (PackageNotFoundError, ValueError, IndexError):
+    sys.exit(1)
+sys.exit(0 if (major, minor) >= (4, 14) else 1)
+" 2>$null
+            if ($LASTEXITCODE -eq 0) { $_anyioBad = $true }
+        } catch {}
+        if ($_anyioBad) {
+            substep "anyio >=4.14 found (#6483) -- forcing dependency pass to repair..." "Cyan"
+            $SkipPythonDeps = $false
+        }
         # ...but not if an AMD GPU is present and installed PyTorch is CPU-only
         # (host predates ROCm-wheel support, or GPU added later): the fast "up to
         # date" path would leave the user on CPU torch with Train/Export disabled.

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -947,6 +947,23 @@ print(version(sys.argv[1]))
     if [ -n "$INSTALLED_VER" ] && [ -n "$LATEST_VER" ] && [ "$INSTALLED_VER" = "$LATEST_VER" ]; then
         step "python" "$_PKG_NAME $INSTALLED_VER is up to date"
         _SKIP_PYTHON_DEPS=true
+        # A pre-#6483-fix install can be stuck on anyio>=4.14 even though
+        # $_PKG_NAME itself is current; the fast path above would otherwise
+        # never reach install_python_stack's anyio repair (#6797).
+        if "$VENV_DIR/bin/python" -c "
+import re, sys
+from importlib.metadata import version, PackageNotFoundError
+try:
+    parts = version('anyio').split('.')
+    major = int(parts[0])
+    minor = int(re.sub(r'[^0-9].*', '', parts[1])) if len(parts) > 1 else 0
+except (PackageNotFoundError, ValueError, IndexError):
+    sys.exit(1)
+sys.exit(0 if (major, minor) >= (4, 14) else 1)
+" 2>/dev/null; then
+            substep "anyio >=4.14 found (#6483) -- forcing dependency pass to repair..."
+            _SKIP_PYTHON_DEPS=false
+        fi
     elif [ -n "$INSTALLED_VER" ] && [ -n "$LATEST_VER" ]; then
         substep "$_PKG_NAME $INSTALLED_VER -> $LATEST_VER available, updating..."
     elif [ -z "$LATEST_VER" ]; then


### PR DESCRIPTION
## Summary

- Fixes #6797, a recurrence of the anyio 4.14 + Python 3.13 cancel-scope crash tracked in #6483 (`RuntimeError: Attempted to exit a cancel scope that isn't the current tasks's current cancel scope`), which breaks effectively every Studio API request.
- `constraints.txt` / `no-torch-runtime.txt` already cap `anyio<4.14.0` (#6546, #6579, #6581), but that cap only constrains *new* resolutions. An install made before the cap existed can already have anyio stuck at 4.14+, and since it already satisfies mcp/fastmcp's `anyio>=4.5` floor, every later constrained install (`-c constraints.txt`) sees it as already-satisfied and never touches it — so those installs never self-heal, even after running `unsloth studio update`.
- Adds a repair step to `studio/install_python_stack.py` (shared by the Windows and Linux/macOS installers) that checks the installed anyio version after the studio-deps step and force-reinstalls `anyio<4.14.0` if it finds a stuck 4.14+, unconstrained so the downgrade actually happens instead of being skipped as already-satisfied.

## Test plan

- [x] `python3 -m py_compile studio/install_python_stack.py`
- [x] Verified the version-parsing helper against `4.13.0`, `4.14.0`, `4.15.2`, `3.7.1`, and a pre-release string (`4.14rc1.0`)
- [x] Traced that the repair step runs unconditionally on every install/update path (not skipped by `SKIP_STUDIO_BASE`), and that on macOS-arm the existing `UV_OVERRIDE` mechanism (already fighting mlx-vlm/mlx-lm's anyio>=4.14 pull) also governs this new call, so no new conflict is introduced there
- [ ] Manual end-to-end run of `unsloth studio update` against an environment with anyio pinned at 4.14+ (not run in this sandbox — no live Studio install available)
