### PR TITLE
Do not reinstall llm-compressor when it is already installed

### DIFF
--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -1383,6 +1383,23 @@ def install_llm_compressor():
     except Exception:
         pass
 
+    # Already installed but not importable in THIS process? Do not reinstall. The in-process import
+    # can fail under Unsloth's transformers patches (the compressed export quantizes in an isolated
+    # subprocess that re-imports cleanly), and reinstalling the version-capped, torch/transformers-
+    # pinned spec makes pip re-resolve and backtrack destructively (it drags in numpy<2 built from
+    # source and the export fails). Only fall through to a pip install when it is genuinely absent.
+    try:
+        from importlib.metadata import version as _iv, PackageNotFoundError as _PNF
+        try:
+            _iv("llmcompressor")
+            # Present; the compressed-export subprocess performs the real import. The caller only
+            # uses this to trigger the install and fail fast, so returning None here is safe.
+            return None, None
+        except _PNF:
+            pass
+    except Exception:
+        pass
+
     # Opt-out for locked-down / air-gapped setups: forbid the auto-install, require a manual one.
     if os.environ.get("UNSLOTH_DISABLE_LLM_COMPRESSOR_AUTOINSTALL", "0").lower() not in (
         "0",


### PR DESCRIPTION
Follow-up to #6778 (found while testing FP8 export in Studio).

The FP8/FP4 compressed export calls `install_llm_compressor()` in the export worker to ensure the dependency is present. That in-process import can fail even when llm-compressor is installed, because Unsloth's transformers patches interfere in this process (the actual quantization runs in a separate clean subprocess that re-imports it fine). On that spurious failure the code fell through to a pip install of the version-capped, torch/transformers-pinned spec, which made pip re-resolve the whole graph and backtrack over every llm-compressor release, eventually trying to build `numpy<2` from source and failing the export with a confusing pip error:

```
Export failed: Unsloth: Failed to install llm-compressor ...
Collecting numpy<2.0,>=1.17.0 ... Using cached numpy-1.26.4.tar.gz ... Preparing metadata (pyproject.toml): started
```

Fix: guard the install on `importlib.metadata`. When a llm-compressor distribution is already present, return instead of reinstalling. Reinstalling cannot fix an in-process import error, and the isolated quantization subprocess imports it cleanly. A genuinely absent install still triggers the auto-install as before.

Verified: forcing the in-process import to fail no longer invokes pip when the package is installed (returns cleanly, no backtrack); `py_compile` clean.