### PR TITLE
studio: re-emit prefilled <think> opener on the safetensors stream (fixes #6815)

### DIFF
--- a/studio/backend/core/inference/inference.py
+++ b/studio/backend/core/inference/inference.py
@@ -982,6 +982,18 @@ class InferenceBackend:
             formatted_prompt = self.format_chat_prompt(messages, system_prompt)
 
         # Step 3: generate
+
+        # Newer hybrid-thinking templates (Qwen3.5 / Qwen3.6 style) *prefill* the reasoning
+        # opener in the generation prompt (`...<|im_start|>assistant\n<think>\n`), so the
+        # model's own output stream is `reasoning...</think>answer` with no opening tag.
+        # The shared stream protocol marks reasoning with literal <think>...</think> tags
+        # (the harmony parser above emits them for gpt-oss, and llama-server handles the
+        # prefilled-opener convention natively on the GGUF path). Without re-emitting the
+        # opener here, everything the model thinks renders as answer text on the
+        # safetensors path (#6815). enable_thinking=False prompts end with an *empty*
+        # `<think>\n\n</think>` block, not the bare opener, so they are unaffected.
+        if formatted_prompt.rstrip().endswith("<think>"):
+            yield "<think>"
         yield from self.generate_stream(
             formatted_prompt,
             temperature,

--- a/studio/backend/core/inference/inference.py
+++ b/studio/backend/core/inference/inference.py
@@ -992,9 +992,13 @@ class InferenceBackend:
         # opener here, everything the model thinks renders as answer text on the
         # safetensors path (#6815). enable_thinking=False prompts end with an *empty*
         # `<think>\n\n</think>` block, not the bare opener, so they are unaffected.
-        if formatted_prompt.rstrip().endswith("<think>"):
-            yield "<think>"
-        yield from self.generate_stream(
+        # This generator yields *cumulative* snapshots (consumers diff each value
+        # against the previous one), so the synthetic opener must remain part of
+        # every subsequent snapshot rather than be emitted once on its own.
+        think_prefix = "<think>" if formatted_prompt.rstrip().endswith("<think>") else ""
+        if think_prefix:
+            yield think_prefix
+        for cumulative in self.generate_stream(
             formatted_prompt,
             temperature,
             top_p,
@@ -1004,7 +1008,8 @@ class InferenceBackend:
             repetition_penalty,
             cancel_event = cancel_event,
             _adapter_state = _adapter_state,
-        )
+        ):
+            yield think_prefix + cumulative
 
     def _generate_vision_response(
         self,


### PR DESCRIPTION

Fixes #6815 (Qwen3.6-A3B "thinking broken" on the safetensors path).

## Root cause

Qwen3.6-style hybrid-thinking templates **prefill** the reasoning opener in the generation prompt —
the rendered prompt ends `<|im_start|>assistant\n<think>\n` (verified on the real
`Qwen/Qwen3.6-35B-A3B` template). The model's own output stream is therefore
`reasoning…</think>answer` with **no opening tag**, so Studio's tag-based stream splitting renders
all reasoning as answer text. The GGUF path is unaffected because llama-server handles the
prefilled-opener convention natively — which is why the issue only reproduces on safetensors.

## Fix

In `_generate_chat_response_inner`: when the rendered prompt `rstrip().endswith("<think>")`, the
opener is carried as a prefix on every cumulative snapshot from `generate_stream` (the stream
protocol is cumulative -- consumers diff against the previous value; per the Codex review
finding, a one-shot yield would drop characters from the diff). This is consistent with the existing stream protocol (the
harmony parser already emits literal tags for gpt-oss).

Predicate verified on real templates:

| template | prompt tail | predicate |
|---|---|---|
| Qwen3.6-35B-A3B, default | `…assistant\n<think>\n` | **True** (opener re-emitted) |
| Qwen3.6-35B-A3B, `enable_thinking=False` | `…<think>\n\n</think>\n\n` | False (closed empty block — untouched) |
| Qwen3-0.6B (older, no prefill) | `…assistant\n` | False (unchanged behavior) |

## Note

`mlx_inference.py` likely needs the same guard on its stream path — happy to extend this PR or
follow up separately, maintainer preference.

