### PR TITLE
Note bundled flash-linear-attention kernels for gated-deltanet models

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -209,7 +209,7 @@ DISABLE_COMPILE_MODEL_NAMES = [
 # Architectures with gated-deltanet (linear attention) layers. Unsloth bundles the
 # flash-linear-attention Triton kernels (unsloth_zoo/_vendored/fla), so no install is
 # needed; transformers uses the much slower pure PyTorch path only when they can't be enabled.
-FLA_MODEL_TYPE_PREFIXES = ("qwen3_next", "qwen3_5", "kimi_linear")
+FLA_MODEL_TYPE_PREFIXES = ("qwen3_next", "qwen3_5", "kimi_linear", "olmo_hybrid")
 _fla_advised = False
 
 

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -207,10 +207,8 @@ DISABLE_COMPILE_MODEL_NAMES = [
 ]
 
 # Architectures with gated-deltanet (linear attention) layers. Unsloth bundles the
-# flash-linear-attention (fla) Triton kernels (unsloth_zoo/_vendored/fla) and injects
-# them automatically, so no `pip install flash-linear-attention` is needed. Transformers
-# only falls back to the several-times-slower pure PyTorch path when those bundled kernels
-# cannot be enabled on the current setup.
+# flash-linear-attention Triton kernels (unsloth_zoo/_vendored/fla), so no install is
+# needed; transformers uses the much slower pure PyTorch path only when they can't be enabled.
 FLA_MODEL_TYPE_PREFIXES = ("qwen3_next", "qwen3_5", "kimi_linear")
 _fla_advised = False
 

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -206,6 +206,42 @@ DISABLE_COMPILE_MODEL_NAMES = [
     "granite,llava_next",  # Granite-vision 3
 ]
 
+# Architectures with gated-deltanet (linear attention) layers. Unsloth bundles the
+# flash-linear-attention (fla) Triton kernels (unsloth_zoo/_vendored/fla) and injects
+# them automatically, so no `pip install flash-linear-attention` is needed. Transformers
+# only falls back to the several-times-slower pure PyTorch path when those bundled kernels
+# cannot be enabled on the current setup.
+FLA_MODEL_TYPE_PREFIXES = ("qwen3_next", "qwen3_5", "kimi_linear")
+_fla_advised = False
+
+
+def _maybe_advise_fla_install(model_types):
+    """One-time note when a gated-deltanet model loads without the fast kernels.
+
+    The kernels ship with Unsloth (no install needed); this fires only when they
+    could not be enabled on this platform (e.g. no CUDA, torch < 2.7 or
+    triton < 3.3), i.e. exactly when transformers uses the slow pure PyTorch path.
+    """
+    global _fla_advised
+    if _fla_advised:
+        return
+    try:
+        if not any(
+            isinstance(t, str) and t.startswith(FLA_MODEL_TYPE_PREFIXES) for t in model_types
+        ):
+            return
+        from transformers.utils.import_utils import is_flash_linear_attention_available
+        if is_flash_linear_attention_available():
+            return  # bundled (or user-installed) fast kernels are active
+    except Exception:
+        return
+    _fla_advised = True
+    print(
+        "Unsloth: This model uses gated-deltanet linear attention layers. Unsloth\n"
+        "bundles the flash-linear-attention kernels, but they could not be enabled\n"
+        "on this setup (they need CUDA with torch >= 2.7 and triton >= 3.3), so\n"
+        "transformers will use a slower pure PyTorch path."
+    )
 
 def _fix_rope_inv_freq(model):
     """Fix inv_freq corruption caused by transformers v5 meta-device loading.
@@ -1304,6 +1340,7 @@ class FastModel(FastBaseModel):
             trust_remote_code = trust_remote_code,
         )
         model_types_all = ",".join(model_types) + ","
+        _maybe_advise_fla_install(model_types)
 
         # ---- Text-diffusion models (e.g. DiffusionGemma) take a transformers-only slow path. ----
         # These use a custom block-diffusion `generate` and a novel backbone, so we skip Unsloth's

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -223,6 +223,10 @@ def _maybe_advise_fla_install(model_types):
     global _fla_advised
     if _fla_advised:
         return
+    if model_types is None:
+        return
+    if isinstance(model_types, str):
+        model_types = [model_types]  # a lone string would otherwise iterate chars
     try:
         if not any(
             isinstance(t, str) and t.startswith(FLA_MODEL_TYPE_PREFIXES) for t in model_types


### PR DESCRIPTION
## Summary

Gated-deltanet models (Qwen3.5, Qwen3.6, Qwen3-Next, kimi-linear) run their linear-attention layers on flash-linear-attention (fla) Triton kernels when available, and otherwise fall back to a several-times-slower pure PyTorch recurrence (measured 978 to 5573 tok/s on Qwen3.6-35B-A3B 4-bit at 4k, a 5.7x gap).

unsloth-zoo now bundles those kernels (see unslothai/unsloth-zoo#865) and injects them automatically, so no `pip install flash-linear-attention` is required. This updates the loader note accordingly.

## Behavior

`_maybe_advise_fla_install` now keys on `is_flash_linear_attention_available()` (which the bundled injection sets true) rather than the mere presence of an `fla` install. As a result it stays silent whenever the fast kernels are active, and prints a one-time note only when a gated-deltanet model is loaded and the bundled kernels could not be enabled on the current setup (no CUDA, or torch < 2.7 / triton < 3.3), which is exactly when transformers uses the slow pure PyTorch path. The message no longer tells users to install anything, since the kernels ship with Unsloth.

## Notes

Requires an unsloth-zoo build that includes the bundled kernels (unslothai/unsloth-zoo#865); on older unsloth-zoo without them, `is_flash_linear_attention_available()` is false unless the user installed fla, so the note still fires correctly.
