### PR TITLE
Studio: heal DiffusionGemma tool calls into structured tool_calls

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1687,6 +1687,15 @@ class LlamaCppBackend:
         return self._supports_tools
 
     @property
+    def supports_tool_passthrough(self) -> bool:
+        # Client-side tool loops (the caller declares tools, executes them, and
+        # sends results back) only need the response healer to promote the model's
+        # text-form <|tool_call> blocks into structured tool_calls -- they never run
+        # the agentic loop, so DiffusionGemma's per-step canvas frames survive.
+        # So this stays on for diffusion even though supports_tools (agentic) is off.
+        return self._supports_tools
+
+    @property
     def cache_type_kv(self) -> Optional[str]:
         return self._cache_type_kv
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -67,7 +67,6 @@ from core.tool_healing import (
     _strip_bracket_tag_calls,
     apply_tool_strip_patterns,
     strip_outside_think,
-    strip_tool_call_markup,
 )
 from utils.native_path_leases import child_env_without_native_path_secret
 from utils.hf_xet_fallback import hf_hub_download_with_xet_fallback

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1688,11 +1688,9 @@ class LlamaCppBackend:
 
     @property
     def supports_tool_passthrough(self) -> bool:
-        # Client-side tool loops (the caller declares tools, executes them, and
-        # sends results back) only need the response healer to promote the model's
-        # text-form <|tool_call> blocks into structured tool_calls -- they never run
-        # the agentic loop, so DiffusionGemma's per-step canvas frames survive.
-        # So this stays on for diffusion even though supports_tools (agentic) is off.
+        # supports_tools is forced off for DiffusionGemma (its agentic loop drops the
+        # per-step canvas frames); client tool loops skip that loop, so the passthrough
+        # follows the real _supports_tools instead of the forced-off value.
         return self._supports_tools
 
     @property

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1783,8 +1783,8 @@ class LlamaCppBackend:
     @property
     def supports_tool_passthrough(self) -> bool:
         # supports_tools is forced off for DiffusionGemma (its agentic loop drops the
-        # per-step canvas frames); client tool loops skip that loop, so the passthrough
-        # follows the real _supports_tools instead of the forced-off value.
+        # per-step canvas frames), but client passthrough skips that loop, so it uses
+        # the real _supports_tools.
         return self._supports_tools
 
     @property

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -5705,7 +5705,7 @@ async def openai_chat_completions(
     # free-form sampling. Guided decoding does not require ``supports_tools`` --
     # the grammar machinery is independent of tool-call parsing.
     _has_response_format = _extract_response_format(payload) is not None
-    _tools_passthrough = llama_backend.supports_tools and (
+    _tools_passthrough = llama_backend.supports_tool_passthrough and (
         (payload.tools and len(payload.tools) > 0) or _has_tool_messages
     )
     if (
@@ -9564,7 +9564,9 @@ async def anthropic_messages(
         and not _has_image
     )
     client_tools = (
-        not server_tools and len(openai_client_tools) > 0 and llama_backend.supports_tools
+        not server_tools
+        and len(openai_client_tools) > 0
+        and llama_backend.supports_tool_passthrough
     )
 
     # Anthropic tool_choice.disable_parallel_tool_use caps the response to a

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -5708,9 +5708,12 @@ async def openai_chat_completions(
     _tools_passthrough = getattr(
         llama_backend, "supports_tool_passthrough", llama_backend.supports_tools
     ) and ((payload.tools and len(payload.tools) > 0) or _has_tool_messages)
+    # DiffusionGemma keeps supports_tools off, so the server-side tool loop can't
+    # claim the request; fall through to client passthrough, matching /v1/messages.
+    _server_tool_loop = _effective_enable_tools(payload) and llama_backend.supports_tools
     if (
         using_gguf
-        and not _effective_enable_tools(payload)
+        and not _server_tool_loop
         and (_tools_passthrough or _has_response_format)
     ):
         if _wants_multiple_choices(payload):

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -5711,11 +5711,7 @@ async def openai_chat_completions(
     # DiffusionGemma keeps supports_tools off, so the server-side tool loop can't
     # claim the request; fall through to client passthrough, matching /v1/messages.
     _server_tool_loop = _effective_enable_tools(payload) and llama_backend.supports_tools
-    if (
-        using_gguf
-        and not _server_tool_loop
-        and (_tools_passthrough or _has_response_format)
-    ):
+    if using_gguf and not _server_tool_loop and (_tools_passthrough or _has_response_format):
         if _wants_multiple_choices(payload):
             raise _reject_unsupported_n("GGUF tool or response_format passthrough")
         if payload.audio_base64:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -5705,9 +5705,9 @@ async def openai_chat_completions(
     # free-form sampling. Guided decoding does not require ``supports_tools`` --
     # the grammar machinery is independent of tool-call parsing.
     _has_response_format = _extract_response_format(payload) is not None
-    _tools_passthrough = llama_backend.supports_tool_passthrough and (
-        (payload.tools and len(payload.tools) > 0) or _has_tool_messages
-    )
+    _tools_passthrough = getattr(
+        llama_backend, "supports_tool_passthrough", llama_backend.supports_tools
+    ) and ((payload.tools and len(payload.tools) > 0) or _has_tool_messages)
     if (
         using_gguf
         and not _effective_enable_tools(payload)
@@ -9566,7 +9566,7 @@ async def anthropic_messages(
     client_tools = (
         not server_tools
         and len(openai_client_tools) > 0
-        and llama_backend.supports_tool_passthrough
+        and getattr(llama_backend, "supports_tool_passthrough", llama_backend.supports_tools)
     )
 
     # Anthropic tool_choice.disable_parallel_tool_use caps the response to a


### PR DESCRIPTION
DiffusionGemma tool calls come back as raw text instead of a structured `tool_calls` array. A client that declares a tool gets `<|tool_call>call:get_weather{...}<tool_call|>` in the message content with `finish_reason: stop`, so OpenAI-v1 clients like pi can't see the call.

Closes #6732

(Thinking already works; only tool calls were affected.)

## Problem

`supports_tools` is off for diffusion, which keeps the agentic tool loop from running (it would drop the canvas frames that drive the visualization). But that same flag also switched off the client-tool passthrough, the path that turns the model's text tool call into a structured `tool_calls`.

So the tool call reached the client as raw text. The parser already understands DiffusionGemma's `<|tool_call>` format (from #6801); it just wasn't being reached.

## Fix

Split the flag in two: `supports_tools` still gates the agentic loop (stays off for diffusion), and a new `supports_tool_passthrough` gates only the client-tool passthrough (on for diffusion).

Non-diffusion models are unaffected, since both flags return the same value there.

## Verification

Live on `unsloth/diffusiongemma-26B-A4B-it-GGUF` with a declared tool: OpenAI (streaming and non-streaming) and Anthropic `/v1/messages` now return proper `tool_calls` / `tool_use`, and the diffusion visualization still streams. The existing passthrough and route suites pass unchanged.

## Note

This is the Studio half. The model only emits schema-correct arguments once the shim (unslothai/unsloth-zoo#864) and the visual server (llama.cpp #24423) forward the tool definitions too, so it's a no-op until a client sends tools.
