### PR TITLE
fix(studio): use visible context length for VRAM method selection

### DIFF
--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -108,6 +108,9 @@ let _trainOnCompletionsManuallySet = false;
 // switching method auto-sets LR to 2e-4 (LoRA/QLoRA) or 2e-5 (full fine-tune).
 let _learningRateManuallySet = false;
 
+// Has the user manually chosen a training method since the last model load?
+let _trainingMethodManuallySet = false;
+
 // Stash the YAML learning rate so setTrainingMethod can restore it when
 // switching back from full to adapter.
 let _yamlLearningRate: number | undefined = undefined;
@@ -371,6 +374,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
 
             _trainOnCompletionsManuallySet = false;
             _learningRateManuallySet = false;
+            _trainingMethodManuallySet = false;
             _yamlLearningRate = undefined;
             const patch = mapBackendModelConfigToTrainingPatch(modelDetails.config);
             const contextLengthManuallySet = get().contextLengthManuallySet;
@@ -416,23 +420,6 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             const inferredModelType: ModelType = modelDetails.model_type
               ?? (isEmbedding ? "embeddings" : modelDetails.is_vision ? "vision" : modelDetails.is_audio ? "audio" : "text");
 
-            // Auto-select LoRA vs QLoRA by model size vs GPU memory (see
-            // autoSelectTrainingMethod). Skip if the user chose CPT.
-            const modelSizeBytes = modelDetails.model_size_bytes;
-            if (modelSizeBytes && modelSizeBytes > 0 && get().trainingMethod !== "cpt") {
-              void autoSelectTrainingMethod(modelSizeBytes, effectiveContextLength)
-                .then((method) => {
-                  if (get().selectedModel !== modelName) return;
-                  if (get().trainingMethod === "cpt") return;
-                  if (method) {
-                    const lrPatch = !_learningRateManuallySet && !modelConfigHasLR
-                      ? { learningRate: method === "full" ? LR_DEFAULT_FULL : LR_DEFAULT_LORA }
-                      : {};
-                    set({ trainingMethod: method, ...lrPatch });
-                  }
-                });
-            }
-
             // Preserve CPT hyperparams: YAML adapter defaults (r/alpha/targets/LR)
             // are tuned for standard LoRA and would clobber CPT settings.
             const cptOverrides =
@@ -453,6 +440,30 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
               modelDefaultsAppliedFor: modelName,
               maxPositionEmbeddings: modelDetails.max_position_embeddings ?? null,
             });
+
+            // Auto-select LoRA vs QLoRA by model size vs GPU memory (see
+            // autoSelectTrainingMethod). Skip if the user chose CPT or already
+            // chose a method manually.
+            const modelSizeBytes = modelDetails.model_size_bytes;
+            if (
+              modelSizeBytes &&
+              modelSizeBytes > 0 &&
+              !_trainingMethodManuallySet &&
+              get().trainingMethod !== "cpt"
+            ) {
+              void autoSelectTrainingMethod(modelSizeBytes, effectiveContextLength)
+                .then((method) => {
+                  if (get().selectedModel !== modelName) return;
+                  if (_trainingMethodManuallySet) return;
+                  if (get().trainingMethod === "cpt") return;
+                  if (method) {
+                    const lrPatch = !_learningRateManuallySet && !modelConfigHasLR
+                      ? { learningRate: method === "full" ? LR_DEFAULT_FULL : LR_DEFAULT_LORA }
+                      : {};
+                    set({ trainingMethod: method, ...lrPatch });
+                  }
+                });
+            }
           })
           .catch((error) => {
             if (controller.signal.aborted) return;
@@ -638,6 +649,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         },
         setProjectName: (projectName) => set({ projectName }),
         setTrainingMethod: (trainingMethod) => {
+          _trainingMethodManuallySet = true;
           const state = get();
           set(
             buildTrainingMethodPatch(
@@ -936,6 +948,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         reset: () => {
           _trainOnCompletionsManuallySet = false;
           _learningRateManuallySet = false;
+          _trainingMethodManuallySet = false;
           _yamlLearningRate = undefined;
           clearCptDatasetFormatTracking();
           set({ ...initialState, hfToken: getHfToken() });
@@ -943,6 +956,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         resetToModelDefaults: () => {
           const { selectedModel } = get();
           if (!selectedModel) return;
+          _trainingMethodManuallySet = false;
           set({
             contextLengthManuallySet: false,
             modelDefaultsAppliedFor: null,

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -989,6 +989,9 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             ...(patch.contextLength !== undefined
               ? { contextLengthManuallySet: true }
               : {}),
+            ...(patch.trainOnCompletions !== undefined
+              ? { trainOnCompletionsManuallySet: true }
+              : {}),
             ...(patch.learningRate !== undefined
               ? { learningRateManuallySet: false }
               : {}),

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -361,6 +361,10 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         _modelConfigController?.abort();
         const controller = new AbortController();
         _modelConfigController = controller;
+        _trainOnCompletionsManuallySet = false;
+        _learningRateManuallySet = false;
+        _trainingMethodManuallySet = false;
+        _yamlLearningRate = undefined;
         set({
           isLoadingModelDefaults: true,
           isCheckingVision: true,
@@ -372,10 +376,6 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             if (controller.signal.aborted) return;
             if (get().selectedModel !== modelName) return;
 
-            _trainOnCompletionsManuallySet = false;
-            _learningRateManuallySet = false;
-            _trainingMethodManuallySet = false;
-            _yamlLearningRate = undefined;
             const patch = mapBackendModelConfigToTrainingPatch(modelDetails.config);
             const contextLengthManuallySet = get().contextLengthManuallySet;
             const effectiveContextLength = contextLengthManuallySet

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -1043,9 +1043,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             useHfTokenStore.getState().setToken(legacyToken);
           }
           delete s.hfToken;
-          s.contextLengthManuallySet =
-            typeof s.contextLength === "number" &&
-            s.contextLength !== DEFAULT_HYPERPARAMS.contextLength;
+          s.contextLengthManuallySet = false;
         }
         return s as unknown as TrainingConfigStore;
       },

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -125,7 +125,6 @@ const NON_PERSISTED_STATE_KEYS: ReadonlySet<keyof TrainingConfigState> = new Set
   "isCheckingDataset",
   "isDatasetImage",
   "isDatasetAudio",
-  "trainOnCompletions",
   "maxPositionEmbeddings",
   "s3Config",
 ]);
@@ -254,10 +253,10 @@ function getCptTrainingPatch(): TrainingMethodStatePatch {
   };
 }
 
-function getCptModelDefaultsPatch(): TrainingMethodStatePatch {
+function getCptModelDefaultsPatch(learningRateManuallySet: boolean): TrainingMethodStatePatch {
   return {
     ...getCptTrainingPatch(),
-    learningRate: LR_DEFAULT_CPT,
+    ...(learningRateManuallySet ? {} : { learningRate: LR_DEFAULT_CPT }),
   };
 }
 
@@ -424,7 +423,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             // are tuned for standard LoRA and would clobber CPT settings.
             const cptOverrides =
               get().trainingMethod === "cpt"
-                ? getCptModelDefaultsPatch()
+                ? getCptModelDefaultsPatch(learningRateManuallySet)
                 : {};
 
             set({
@@ -584,6 +583,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             modelDefaultsError: null,
             modelDefaultsAppliedFor: null,
             trainOnCompletionsManuallySet: false,
+            contextLengthManuallySet: false,
             learningRateManuallySet: false,
             trainingMethodManuallySet: false,
           });
@@ -602,6 +602,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             isAudioModel?: boolean;
             isEmbeddingModel?: boolean;
             trainOnCompletionsManuallySet?: boolean;
+            contextLengthManuallySet?: boolean;
             learningRateManuallySet?: boolean;
             trainingMethodManuallySet?: boolean;
           } = {
@@ -621,6 +622,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             patch.isAudioModel = false;
             patch.isEmbeddingModel = false;
             patch.trainOnCompletionsManuallySet = false;
+            patch.contextLengthManuallySet = false;
             patch.learningRateManuallySet = false;
             patch.trainingMethodManuallySet = false;
           }
@@ -639,6 +641,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
               modelDefaultsError: null,
               modelDefaultsAppliedFor: null,
               trainOnCompletionsManuallySet: false,
+              contextLengthManuallySet: false,
               learningRateManuallySet: false,
               trainingMethodManuallySet: false,
             });
@@ -995,7 +998,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
     },
     {
       name: "unsloth_training_config_v1",
-      version: 13,
+      version: 14,
       migrate: (persisted, version) => {
         const s = persisted as Record<string, unknown>;
         if (version < 2 && s.datasetSubset == null && s.datasetConfig != null) {
@@ -1062,6 +1065,9 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
           s.trainOnCompletionsManuallySet = false;
           s.learningRateManuallySet = false;
           s.trainingMethodManuallySet = false;
+        }
+        if (version < 14) {
+          s.trainOnCompletionsManuallySet = false;
         }
         return s as unknown as TrainingConfigStore;
       },

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -417,12 +417,14 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             const inferredModelType: ModelType = modelDetails.model_type
               ?? (isEmbedding ? "embeddings" : modelDetails.is_vision ? "vision" : modelDetails.is_audio ? "audio" : "text");
 
-            // Preserve CPT hyperparams: YAML adapter defaults (r/alpha/targets/LR)
-            // are tuned for standard LoRA and would clobber CPT settings.
-            const cptOverrides =
-              get().trainingMethod === "cpt"
-                ? getCptModelDefaultsPatch(learningRateManuallySet)
-                : {};
+            // Preserve CPT hyperparams only when CPT is still the active
+            // manual choice; stale CPT state should not block model defaults.
+            const keepManualCpt =
+              get().trainingMethodManuallySet &&
+              get().trainingMethod === "cpt";
+            const cptOverrides = keepManualCpt
+              ? getCptModelDefaultsPatch(learningRateManuallySet)
+              : {};
 
             set({
               ...patch,
@@ -445,14 +447,12 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             if (
               modelSizeBytes &&
               modelSizeBytes > 0 &&
-              !get().trainingMethodManuallySet &&
-              get().trainingMethod !== "cpt"
+              !keepManualCpt
             ) {
               void autoSelectTrainingMethod(modelSizeBytes, effectiveContextLength)
                 .then((method) => {
                   if (get().selectedModel !== modelName) return;
-                  if (get().trainingMethodManuallySet) return;
-                  if (get().trainingMethod === "cpt") return;
+                  if (get().trainingMethodManuallySet && get().trainingMethod === "cpt") return;
                   if (method) {
                     const lrPatch = !get().learningRateManuallySet && !modelConfigHasLR
                       ? { learningRate: method === "full" ? LR_DEFAULT_FULL : LR_DEFAULT_LORA }

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -107,6 +107,11 @@ let _trainOnCompletionsManuallySet = false;
 // switching method auto-sets LR to 2e-4 (LoRA/QLoRA) or 2e-5 (full fine-tune).
 let _learningRateManuallySet = false;
 
+// Has the user explicitly set context length? When true, model-default patches
+// cannot overwrite the visible value. Unlike LR, this survives model loads so
+// a deliberate choice like 32768 keeps showing until the user resets defaults.
+let _contextLengthManuallySet = false;
+
 // Stash the YAML learning rate so setTrainingMethod can restore it when
 // switching back from full to adapter.
 let _yamlLearningRate: number | undefined = undefined;
@@ -372,6 +377,16 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             _learningRateManuallySet = false;
             _yamlLearningRate = undefined;
             const patch = mapBackendModelConfigToTrainingPatch(modelDetails.config);
+            const effectiveContextLength = _contextLengthManuallySet
+              ? get().contextLength
+              : patch.contextLength ?? get().contextLength;
+
+            // User explicitly set context length: discard the model default so
+            // the visible value is preserved. autoSelectTrainingMethod will
+            // receive the preserved visible value via the explicit fallback.
+            if (_contextLengthManuallySet) {
+              delete patch.contextLength;
+            }
 
             // Treat a model-config LR as authoritative so async auto-select
             // won't overwrite it.
@@ -408,7 +423,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             // autoSelectTrainingMethod). Skip if the user chose CPT.
             const modelSizeBytes = modelDetails.model_size_bytes;
             if (modelSizeBytes && modelSizeBytes > 0 && get().trainingMethod !== "cpt") {
-              void autoSelectTrainingMethod(modelSizeBytes, patch.contextLength ?? get().contextLength)
+              void autoSelectTrainingMethod(modelSizeBytes, effectiveContextLength)
                 .then((method) => {
                   if (get().selectedModel !== modelName) return;
                   if (get().trainingMethod === "cpt") return;
@@ -852,7 +867,10 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
           evalSteps: uploadedEvalFile ? 0.1 : 0,
         }),
         setEpochs: (epochs) => set({ epochs }),
-        setContextLength: (contextLength) => set({ contextLength }),
+        setContextLength: (contextLength) => {
+          _contextLengthManuallySet = true;
+          set({ contextLength });
+        },
         setVisionImageSize: (visionImageSize) => set({ visionImageSize }),
         setLearningRate: (learningRate) => {
           _learningRateManuallySet = true;
@@ -923,6 +941,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         reset: () => {
           _trainOnCompletionsManuallySet = false;
           _learningRateManuallySet = false;
+          _contextLengthManuallySet = false;
           _yamlLearningRate = undefined;
           clearCptDatasetFormatTracking();
           set({ ...initialState, hfToken: getHfToken() });
@@ -930,6 +949,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         resetToModelDefaults: () => {
           const { selectedModel } = get();
           if (!selectedModel) return;
+          _contextLengthManuallySet = false;
           set({
             modelDefaultsAppliedFor: null,
             visionImageSize: DEFAULT_HYPERPARAMS.visionImageSize,

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -91,6 +91,9 @@ const initialState: TrainingConfigState = {
   isDatasetAudio: false,
   maxPositionEmbeddings: null,
   contextLengthManuallySet: false,
+  trainOnCompletionsManuallySet: false,
+  learningRateManuallySet: false,
+  trainingMethodManuallySet: false,
   ...DEFAULT_HYPERPARAMS,
 };
 
@@ -99,17 +102,6 @@ let _datasetCheckController: AbortController | null = null;
 
 // AbortController for in-flight model default loads.
 let _modelConfigController: AbortController | null = null;
-
-// Has the user manually toggled trainOnCompletions since the last auto-set
-// (model load or dataset change)?
-let _trainOnCompletionsManuallySet = false;
-
-// Has the user manually edited the LR since the last model load? When false,
-// switching method auto-sets LR to 2e-4 (LoRA/QLoRA) or 2e-5 (full fine-tune).
-let _learningRateManuallySet = false;
-
-// Has the user manually chosen a training method since the last model load?
-let _trainingMethodManuallySet = false;
 
 // Stash the YAML learning rate so setTrainingMethod can restore it when
 // switching back from full to adapter.
@@ -306,8 +298,9 @@ function getRestoreDatasetFormatFromCptPatch(): TrainingMethodStatePatch {
 function resolveTrainingMethodLearningRate(
   prevMethod: TrainingMethod,
   nextMethod: TrainingMethod,
+  learningRateManuallySet: boolean,
 ): number | undefined {
-  if (_learningRateManuallySet) {
+  if (learningRateManuallySet) {
     return undefined;
   }
 
@@ -331,6 +324,7 @@ function buildTrainingMethodPatch(
   prevMethod: TrainingMethod,
   nextMethod: TrainingMethod,
   currentDatasetFormat: DatasetFormat,
+  learningRateManuallySet: boolean,
 ): TrainingMethodStatePatch {
   const patch: TrainingMethodStatePatch = { trainingMethod: nextMethod };
 
@@ -346,7 +340,7 @@ function buildTrainingMethodPatch(
     );
   }
 
-  const learningRate = resolveTrainingMethodLearningRate(prevMethod, nextMethod);
+  const learningRate = resolveTrainingMethodLearningRate(prevMethod, nextMethod, learningRateManuallySet);
   if (learningRate !== undefined) {
     patch.learningRate = learningRate;
   }
@@ -361,9 +355,6 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         _modelConfigController?.abort();
         const controller = new AbortController();
         _modelConfigController = controller;
-        _trainOnCompletionsManuallySet = false;
-        _learningRateManuallySet = false;
-        _trainingMethodManuallySet = false;
         _yamlLearningRate = undefined;
         set({
           isLoadingModelDefaults: true,
@@ -378,6 +369,8 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
 
             const patch = mapBackendModelConfigToTrainingPatch(modelDetails.config);
             const contextLengthManuallySet = get().contextLengthManuallySet;
+            const trainOnCompletionsManuallySet = get().trainOnCompletionsManuallySet;
+            const learningRateManuallySet = get().learningRateManuallySet;
             const effectiveContextLength = contextLengthManuallySet
               ? get().contextLength
               : patch.contextLength ?? get().contextLength;
@@ -388,6 +381,12 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             if (contextLengthManuallySet) {
               delete patch.contextLength;
             }
+            if (learningRateManuallySet) {
+              delete patch.learningRate;
+            }
+            if (trainOnCompletionsManuallySet) {
+              delete patch.trainOnCompletions;
+            }
 
             // Treat a model-config LR as authoritative so async auto-select
             // won't overwrite it.
@@ -396,23 +395,24 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
 
             // YAML LRs are tuned for adapters (LoRA/QLoRA); on full fine-tune,
             // use the full-finetune default instead of the YAML adapter LR.
-            if (modelConfigHasLR && !isAdapterMethod(get().trainingMethod)) {
+            if (!learningRateManuallySet && modelConfigHasLR && !isAdapterMethod(get().trainingMethod)) {
               patch.learningRate = LR_DEFAULT_FULL;
             }
 
-            // Vision model + known image dataset: force trainOnCompletions off.
-            if (modelDetails.is_vision && get().isDatasetImage === true) {
-              patch.trainOnCompletions = false;
-            }
-
             const isAudio = !!modelDetails.is_audio;
-            // Pure audio model -> always uncheck trainOnCompletions.
-            if (isAudio && !modelDetails.is_vision) {
-              patch.trainOnCompletions = false;
-            }
-            // Audio-capable vision model (e.g. gemma3n) + audio dataset -> uncheck.
-            if (isAudio && modelDetails.is_vision && get().isDatasetAudio) {
-              patch.trainOnCompletions = false;
+            if (!trainOnCompletionsManuallySet) {
+              // Vision model + known image dataset: force trainOnCompletions off.
+              if (modelDetails.is_vision && get().isDatasetImage === true) {
+                patch.trainOnCompletions = false;
+              }
+              // Pure audio model -> always uncheck trainOnCompletions.
+              if (isAudio && !modelDetails.is_vision) {
+                patch.trainOnCompletions = false;
+              }
+              // Audio-capable vision model (e.g. gemma3n) + audio dataset -> uncheck.
+              if (isAudio && modelDetails.is_vision && get().isDatasetAudio) {
+                patch.trainOnCompletions = false;
+              }
             }
 
             // Use backend model_type when available, else infer from flags.
@@ -448,16 +448,16 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             if (
               modelSizeBytes &&
               modelSizeBytes > 0 &&
-              !_trainingMethodManuallySet &&
+              !get().trainingMethodManuallySet &&
               get().trainingMethod !== "cpt"
             ) {
               void autoSelectTrainingMethod(modelSizeBytes, effectiveContextLength)
                 .then((method) => {
                   if (get().selectedModel !== modelName) return;
-                  if (_trainingMethodManuallySet) return;
+                  if (get().trainingMethodManuallySet) return;
                   if (get().trainingMethod === "cpt") return;
                   if (method) {
-                    const lrPatch = !_learningRateManuallySet && !modelConfigHasLR
+                    const lrPatch = !get().learningRateManuallySet && !modelConfigHasLR
                       ? { learningRate: method === "full" ? LR_DEFAULT_FULL : LR_DEFAULT_LORA }
                       : {};
                     set({ trainingMethod: method, ...lrPatch });
@@ -523,7 +523,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
               isDatasetAudio: isAudio,
               isCheckingDataset: false,
             };
-            if (!_trainOnCompletionsManuallySet) {
+            if (!get().trainOnCompletionsManuallySet) {
               const { isVisionModel, isAudioModel } = get();
               if (isVisionModel && isImage) {
                 updates.trainOnCompletions = false;
@@ -583,6 +583,9 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             isLoadingModelDefaults: false,
             modelDefaultsError: null,
             modelDefaultsAppliedFor: null,
+            trainOnCompletionsManuallySet: false,
+            learningRateManuallySet: false,
+            trainingMethodManuallySet: false,
           });
         },
         setSelectedModel: (selectedModel) => {
@@ -598,6 +601,9 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             isVisionModel?: boolean;
             isAudioModel?: boolean;
             isEmbeddingModel?: boolean;
+            trainOnCompletionsManuallySet?: boolean;
+            learningRateManuallySet?: boolean;
+            trainingMethodManuallySet?: boolean;
           } = {
             selectedModel,
             modelDefaultsError: null,
@@ -614,6 +620,9 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             patch.isVisionModel = false;
             patch.isAudioModel = false;
             patch.isEmbeddingModel = false;
+            patch.trainOnCompletionsManuallySet = false;
+            patch.learningRateManuallySet = false;
+            patch.trainingMethodManuallySet = false;
           }
           set(patch);
 
@@ -629,6 +638,9 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
               isLoadingModelDefaults: false,
               modelDefaultsError: null,
               modelDefaultsAppliedFor: null,
+              trainOnCompletionsManuallySet: false,
+              learningRateManuallySet: false,
+              trainingMethodManuallySet: false,
             });
             return;
           }
@@ -649,14 +661,17 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         },
         setProjectName: (projectName) => set({ projectName }),
         setTrainingMethod: (trainingMethod) => {
-          _trainingMethodManuallySet = true;
           const state = get();
           set(
-            buildTrainingMethodPatch(
-              state.trainingMethod,
-              trainingMethod,
-              state.datasetFormat,
-            ),
+            {
+              ...buildTrainingMethodPatch(
+                state.trainingMethod,
+                trainingMethod,
+                state.datasetFormat,
+                state.learningRateManuallySet,
+              ),
+              trainingMethodManuallySet: true,
+            },
           );
         },
         setHfToken: (hfToken) => useHfTokenStore.getState().setToken(hfToken),
@@ -664,10 +679,10 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         selectHfDataset: (dataset) => {
           _datasetCheckController?.abort();
           _datasetCheckController = null;
-          _trainOnCompletionsManuallySet = false;
           set({
             datasetSource: "huggingface",
             dataset,
+            trainOnCompletionsManuallySet: false,
             uploadedFile: null,
             ...resetDatasetState(),
           });
@@ -675,10 +690,10 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         selectLocalDataset: (uploadedFile) => {
           _datasetCheckController?.abort();
           _datasetCheckController = null;
-          _trainOnCompletionsManuallySet = false;
           set({
             datasetSource: "upload",
             dataset: null,
+            trainOnCompletionsManuallySet: false,
             uploadedFile,
             ...resetDatasetState(),
           });
@@ -689,10 +704,10 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         selectS3Source: () => {
           _datasetCheckController?.abort();
           _datasetCheckController = null;
-          _trainOnCompletionsManuallySet = false;
           set({
             datasetSource: "s3",
             dataset: null,
+            trainOnCompletionsManuallySet: false,
             uploadedFile: null,
             ...resetDatasetState(),
           });
@@ -720,9 +735,9 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         setDataset: (dataset) => {
           _datasetCheckController?.abort();
           _datasetCheckController = null;
-          _trainOnCompletionsManuallySet = false;
           set({
             dataset,
+            trainOnCompletionsManuallySet: false,
             datasetSubset: null,
             datasetSplit: null,
             datasetEvalSplit: null,
@@ -737,9 +752,9 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         setDatasetSubset: (datasetSubset) => {
           _datasetCheckController?.abort();
           _datasetCheckController = null;
-          _trainOnCompletionsManuallySet = false;
           set({
             datasetSubset,
+            trainOnCompletionsManuallySet: false,
             datasetSplit: null,
             datasetEvalSplit: null,
             datasetManualMapping: emptyManualMapping(),
@@ -856,9 +871,9 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         setUploadedFile: (uploadedFile) => {
           _datasetCheckController?.abort();
           _datasetCheckController = null;
-          _trainOnCompletionsManuallySet = false;
           set({
             uploadedFile,
+            trainOnCompletionsManuallySet: false,
             datasetSubset: null,
             datasetSplit: null,
             datasetEvalSplit: null,
@@ -880,8 +895,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
           set({ contextLength, contextLengthManuallySet: true }),
         setVisionImageSize: (visionImageSize) => set({ visionImageSize }),
         setLearningRate: (learningRate) => {
-          _learningRateManuallySet = true;
-          set({ learningRate });
+          set({ learningRate, learningRateManuallySet: true });
         },
         setEmbeddingLearningRate: (embeddingLearningRate) =>
           set({ embeddingLearningRate }),
@@ -919,9 +933,9 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         },
         setPacking: (packing) => set({ packing }),
         setTrainOnCompletions: (trainOnCompletions) => {
-          _trainOnCompletionsManuallySet = true;
           set({
             trainOnCompletions,
+            trainOnCompletionsManuallySet: true,
             ...(trainOnCompletions ? { datasetStreaming: false } : {}),
           });
         },
@@ -946,9 +960,6 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         setS3Config: (s3Config) => set({ s3Config }),
         canProceed: () => canProceedForStep(get()),
         reset: () => {
-          _trainOnCompletionsManuallySet = false;
-          _learningRateManuallySet = false;
-          _trainingMethodManuallySet = false;
           _yamlLearningRate = undefined;
           clearCptDatasetFormatTracking();
           set({ ...initialState, hfToken: getHfToken() });
@@ -956,9 +967,11 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         resetToModelDefaults: () => {
           const { selectedModel } = get();
           if (!selectedModel) return;
-          _trainingMethodManuallySet = false;
           set({
             contextLengthManuallySet: false,
+            trainOnCompletionsManuallySet: false,
+            learningRateManuallySet: false,
+            trainingMethodManuallySet: false,
             modelDefaultsAppliedFor: null,
             visionImageSize: DEFAULT_HYPERPARAMS.visionImageSize,
           });
@@ -968,13 +981,13 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
           const patch = mapBackendModelConfigToTrainingPatch(config);
           // Only clear the manual-edit flag when the config provides a LR,
           // so unrelated config patches don't silently disarm the guard.
-          if (patch.learningRate !== undefined) {
-            _learningRateManuallySet = false;
-          }
           set({
             ...patch,
             ...(patch.contextLength !== undefined
               ? { contextLengthManuallySet: true }
+              : {}),
+            ...(patch.learningRate !== undefined
+              ? { learningRateManuallySet: false }
               : {}),
           });
         },
@@ -982,7 +995,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
     },
     {
       name: "unsloth_training_config_v1",
-      version: 12,
+      version: 13,
       migrate: (persisted, version) => {
         const s = persisted as Record<string, unknown>;
         if (version < 2 && s.datasetSubset == null && s.datasetConfig != null) {
@@ -1044,6 +1057,11 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
           }
           delete s.hfToken;
           s.contextLengthManuallySet = false;
+        }
+        if (version < 13) {
+          s.trainOnCompletionsManuallySet = false;
+          s.learningRateManuallySet = false;
+          s.trainingMethodManuallySet = false;
         }
         return s as unknown as TrainingConfigStore;
       },

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -90,6 +90,7 @@ const initialState: TrainingConfigState = {
   isDatasetImage: null,
   isDatasetAudio: false,
   maxPositionEmbeddings: null,
+  contextLengthManuallySet: false,
   ...DEFAULT_HYPERPARAMS,
 };
 
@@ -106,11 +107,6 @@ let _trainOnCompletionsManuallySet = false;
 // Has the user manually edited the LR since the last model load? When false,
 // switching method auto-sets LR to 2e-4 (LoRA/QLoRA) or 2e-5 (full fine-tune).
 let _learningRateManuallySet = false;
-
-// Has the user explicitly set context length? When true, model-default patches
-// cannot overwrite the visible value. Unlike LR, this survives model loads so
-// a deliberate choice like 32768 keeps showing until the user resets defaults.
-let _contextLengthManuallySet = false;
 
 // Stash the YAML learning rate so setTrainingMethod can restore it when
 // switching back from full to adapter.
@@ -377,14 +373,15 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             _learningRateManuallySet = false;
             _yamlLearningRate = undefined;
             const patch = mapBackendModelConfigToTrainingPatch(modelDetails.config);
-            const effectiveContextLength = _contextLengthManuallySet
+            const contextLengthManuallySet = get().contextLengthManuallySet;
+            const effectiveContextLength = contextLengthManuallySet
               ? get().contextLength
               : patch.contextLength ?? get().contextLength;
 
             // User explicitly set context length: discard the model default so
             // the visible value is preserved. autoSelectTrainingMethod will
             // receive the preserved visible value via the explicit fallback.
-            if (_contextLengthManuallySet) {
+            if (contextLengthManuallySet) {
               delete patch.contextLength;
             }
 
@@ -867,10 +864,8 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
           evalSteps: uploadedEvalFile ? 0.1 : 0,
         }),
         setEpochs: (epochs) => set({ epochs }),
-        setContextLength: (contextLength) => {
-          _contextLengthManuallySet = true;
-          set({ contextLength });
-        },
+        setContextLength: (contextLength) =>
+          set({ contextLength, contextLengthManuallySet: true }),
         setVisionImageSize: (visionImageSize) => set({ visionImageSize }),
         setLearningRate: (learningRate) => {
           _learningRateManuallySet = true;
@@ -941,7 +936,6 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         reset: () => {
           _trainOnCompletionsManuallySet = false;
           _learningRateManuallySet = false;
-          _contextLengthManuallySet = false;
           _yamlLearningRate = undefined;
           clearCptDatasetFormatTracking();
           set({ ...initialState, hfToken: getHfToken() });
@@ -949,8 +943,8 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
         resetToModelDefaults: () => {
           const { selectedModel } = get();
           if (!selectedModel) return;
-          _contextLengthManuallySet = false;
           set({
+            contextLengthManuallySet: false,
             modelDefaultsAppliedFor: null,
             visionImageSize: DEFAULT_HYPERPARAMS.visionImageSize,
           });
@@ -963,7 +957,12 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
           if (patch.learningRate !== undefined) {
             _learningRateManuallySet = false;
           }
-          set(patch);
+          set({
+            ...patch,
+            ...(patch.contextLength !== undefined
+              ? { contextLengthManuallySet: true }
+              : {}),
+          });
         },
       };
     },
@@ -1030,6 +1029,9 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             useHfTokenStore.getState().setToken(legacyToken);
           }
           delete s.hfToken;
+          s.contextLengthManuallySet =
+            typeof s.contextLength === "number" &&
+            s.contextLength !== DEFAULT_HYPERPARAMS.contextLength;
         }
         return s as unknown as TrainingConfigStore;
       },

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -399,19 +399,17 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             }
 
             const isAudio = !!modelDetails.is_audio;
-            if (!trainOnCompletionsManuallySet) {
-              // Vision model + known image dataset: force trainOnCompletions off.
-              if (modelDetails.is_vision && get().isDatasetImage === true) {
-                patch.trainOnCompletions = false;
-              }
-              // Pure audio model -> always uncheck trainOnCompletions.
-              if (isAudio && !modelDetails.is_vision) {
-                patch.trainOnCompletions = false;
-              }
-              // Audio-capable vision model (e.g. gemma3n) + audio dataset -> uncheck.
-              if (isAudio && modelDetails.is_vision && get().isDatasetAudio) {
-                patch.trainOnCompletions = false;
-              }
+            // Vision model + known image dataset: force trainOnCompletions off.
+            if (modelDetails.is_vision && get().isDatasetImage === true) {
+              patch.trainOnCompletions = false;
+            }
+            // Pure audio model -> always uncheck trainOnCompletions.
+            if (isAudio && !modelDetails.is_vision) {
+              patch.trainOnCompletions = false;
+            }
+            // Audio-capable vision model (e.g. gemma3n) + audio dataset -> uncheck.
+            if (isAudio && modelDetails.is_vision && get().isDatasetAudio) {
+              patch.trainOnCompletions = false;
             }
 
             // Use backend model_type when available, else infer from flags.
@@ -522,19 +520,17 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
               isDatasetAudio: isAudio,
               isCheckingDataset: false,
             };
-            if (!get().trainOnCompletionsManuallySet) {
-              const { isVisionModel, isAudioModel } = get();
-              if (isVisionModel && isImage) {
-                updates.trainOnCompletions = false;
-              }
-              // Pure audio model → always uncheck regardless of dataset.
-              if (isAudioModel && !isVisionModel) {
-                updates.trainOnCompletions = false;
-              }
-              // Audio-capable vision model (e.g. gemma3n) + audio dataset → uncheck.
-              if (isAudioModel && isVisionModel && isAudio) {
-                updates.trainOnCompletions = false;
-              }
+            const { isVisionModel, isAudioModel } = get();
+            if (isVisionModel && isImage) {
+              updates.trainOnCompletions = false;
+            }
+            // Pure audio model → always uncheck regardless of dataset.
+            if (isAudioModel && !isVisionModel) {
+              updates.trainOnCompletions = false;
+            }
+            // Audio-capable vision model (e.g. gemma3n) + audio dataset → uncheck.
+            if (isAudioModel && isVisionModel && isAudio) {
+              updates.trainOnCompletions = false;
             }
             set(updates);
           })
@@ -993,7 +989,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
               ? { trainOnCompletionsManuallySet: true }
               : {}),
             ...(patch.learningRate !== undefined
-              ? { learningRateManuallySet: false }
+              ? { learningRateManuallySet: true }
               : {}),
           });
         },

--- a/studio/frontend/src/features/training/types/config.ts
+++ b/studio/frontend/src/features/training/types/config.ts
@@ -44,6 +44,9 @@ export interface TrainingConfigState {
   epochs: number;
   contextLength: number;
   contextLengthManuallySet: boolean;
+  trainOnCompletionsManuallySet: boolean;
+  learningRateManuallySet: boolean;
+  trainingMethodManuallySet: boolean;
   learningRate: number;
   embeddingLearningRate: number | null;
   optimizerType: string;

--- a/studio/frontend/src/features/training/types/config.ts
+++ b/studio/frontend/src/features/training/types/config.ts
@@ -43,6 +43,7 @@ export interface TrainingConfigState {
   uploadedEvalFile: string | null;
   epochs: number;
   contextLength: number;
+  contextLengthManuallySet: boolean;
   learningRate: number;
   embeddingLearningRate: number | null;
   optimizerType: string;

--- a/tests/studio/test_training_config_store_manual_flags.py
+++ b/tests/studio/test_training_config_store_manual_flags.py
@@ -12,3 +12,29 @@ def test_apply_config_patch_marks_completion_intent_manual():
 
     assert "patch.trainOnCompletions !== undefined" in block
     assert "{ trainOnCompletionsManuallySet: true }" in block
+
+
+def test_apply_config_patch_marks_learning_rate_intent_manual():
+    source = STORE.read_text(encoding = "utf-8")
+    block_start = source.index("applyConfigPatch: (config: BackendModelConfig) => {")
+    block_end = source.index("},", block_start)
+    block = source[block_start:block_end]
+
+    assert "patch.learningRate !== undefined" in block
+    assert "{ learningRateManuallySet: true }" in block
+
+
+def test_audio_and_vision_completion_guards_are_outside_manual_default_gate():
+    source = STORE.read_text(encoding = "utf-8")
+
+    model_block_start = source.index("const isAudio = !!modelDetails.is_audio;")
+    model_block_end = source.index("// Use backend model_type when available", model_block_start)
+    model_block = source[model_block_start:model_block_end]
+    assert "if (!trainOnCompletionsManuallySet)" not in model_block
+    assert "patch.trainOnCompletions = false;" in model_block
+
+    dataset_block_start = source.index("const updates: Record<string, unknown> = {")
+    dataset_block_end = source.index("set(updates);", dataset_block_start)
+    dataset_block = source[dataset_block_start:dataset_block_end]
+    assert "!get().trainOnCompletionsManuallySet" not in dataset_block
+    assert "updates.trainOnCompletions = false;" in dataset_block

--- a/tests/studio/test_training_config_store_manual_flags.py
+++ b/tests/studio/test_training_config_store_manual_flags.py
@@ -1,7 +1,16 @@
 from pathlib import Path
 
 
-STORE = Path(__file__).resolve().parents[2] / "studio" / "frontend" / "src" / "features" / "training" / "stores" / "training-config-store.ts"
+STORE = (
+    Path(__file__).resolve().parents[2]
+    / "studio"
+    / "frontend"
+    / "src"
+    / "features"
+    / "training"
+    / "stores"
+    / "training-config-store.ts"
+)
 
 
 def test_apply_config_patch_marks_completion_intent_manual():

--- a/tests/studio/test_training_config_store_manual_flags.py
+++ b/tests/studio/test_training_config_store_manual_flags.py
@@ -47,3 +47,17 @@ def test_audio_and_vision_completion_guards_are_outside_manual_default_gate():
     dataset_block = source[dataset_block_start:dataset_block_end]
     assert "!get().trainOnCompletionsManuallySet" not in dataset_block
     assert "updates.trainOnCompletions = false;" in dataset_block
+
+
+def test_stale_cpt_only_blocks_auto_defaults_while_manual_flag_is_set():
+    source = STORE.read_text(encoding = "utf-8")
+
+    model_block_start = source.index("// Preserve CPT hyperparams only when CPT is still the active")
+    model_block_end = source.index(".catch((error) => {", model_block_start)
+    model_block = source[model_block_start:model_block_end]
+
+    assert "const keepManualCpt =" in model_block
+    assert "get().trainingMethodManuallySet &&" in model_block
+    assert "get().trainingMethod === \"cpt\"" in model_block
+    assert "!keepManualCpt" in model_block
+    assert "if (get().trainingMethodManuallySet && get().trainingMethod === \"cpt\") return;" in model_block

--- a/tests/studio/test_training_config_store_manual_flags.py
+++ b/tests/studio/test_training_config_store_manual_flags.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+STORE = Path(__file__).resolve().parents[2] / "studio" / "frontend" / "src" / "features" / "training" / "stores" / "training-config-store.ts"
+
+
+def test_apply_config_patch_marks_completion_intent_manual():
+    source = STORE.read_text(encoding = "utf-8")
+    block_start = source.index("applyConfigPatch: (config: BackendModelConfig) => {")
+    block_end = source.index("},", block_start)
+    block = source[block_start:block_end]
+
+    assert "patch.trainOnCompletions !== undefined" in block
+    assert "{ trainOnCompletionsManuallySet: true }" in block

--- a/tests/studio/test_training_config_store_manual_flags.py
+++ b/tests/studio/test_training_config_store_manual_flags.py
@@ -52,12 +52,17 @@ def test_audio_and_vision_completion_guards_are_outside_manual_default_gate():
 def test_stale_cpt_only_blocks_auto_defaults_while_manual_flag_is_set():
     source = STORE.read_text(encoding = "utf-8")
 
-    model_block_start = source.index("// Preserve CPT hyperparams only when CPT is still the active")
+    model_block_start = source.index(
+        "// Preserve CPT hyperparams only when CPT is still the active"
+    )
     model_block_end = source.index(".catch((error) => {", model_block_start)
     model_block = source[model_block_start:model_block_end]
 
     assert "const keepManualCpt =" in model_block
     assert "get().trainingMethodManuallySet &&" in model_block
-    assert "get().trainingMethod === \"cpt\"" in model_block
+    assert 'get().trainingMethod === "cpt"' in model_block
     assert "!keepManualCpt" in model_block
-    assert "if (get().trainingMethodManuallySet && get().trainingMethod === \"cpt\") return;" in model_block
+    assert (
+        'if (get().trainingMethodManuallySet && get().trainingMethod === "cpt") return;'
+        in model_block
+    )


### PR DESCRIPTION
## Problem

Studio's training-method auto-selection can calculate VRAM fit from a model default context length instead of the context length the user sees in Run settings. That makes the method selection look like it ignored available VRAM or ignored the user's configuration.

## Fix

Use the effective visible context length when running VRAM-based training-method selection, and preserve explicit user-selected methods from asynchronous auto-selection. This is stacked on the context-length persistence fix so both paths use the same store authority, including the migration path that defaults older stores to untouched context intent instead of guessing from old values.

Manual intent for learning rate, train-on-completions, and training method is persisted, so same-model reloads do not reopen the overwrite path. Completion-only SFT settings also preserve a manual CPT learning rate instead of replacing it with model defaults.

Context-length manual intent is now scoped to the current model. Same-model reloads still preserve the visible context length, but switching to a different model clears the manual flag so the new model's YAML/default context length can apply before VRAM auto-selection runs.

Stacked on #6857.

## Testing

- `cd /d studio/frontend && npm run typecheck && npm run build`
- Focused store proof covering `32768` versus model default `4096`
- Boundary proof for `8192`, `16384`, and `32768`
- Reviewer rework proof for persisted manual completion mode and CPT learning-rate intent
- Reviewer rework proof for clearing stale manual context-length intent on true model switches

Result: frontend typecheck and build passed after reviewer rework.

Closes #6855
