### PR TITLE
Fix offline training/export: avoid network calls in pre-flight checks and export

### DIFF
--- a/studio/backend/core/export/worker.py
+++ b/studio/backend/core/export/worker.py
@@ -632,7 +632,10 @@ def run_export_process(*, cmd_queue: Any, resp_queue: Any, config: dict) -> None
                     _handle_load(backend, cmd, resp_queue)
 
             elif cmd_type == "export":
-                _handle_export(backend, cmd, resp_queue)
+                # Offline window covers the export (save_pretrained_gguf etc. may
+                # trigger Hub calls via transformers tokenizer init -> model_info).
+                with _offline_window_if_unreachable(step = "exporting"):
+                    _handle_export(backend, cmd, resp_queue)
 
             elif cmd_type == "cleanup":
                 _handle_cleanup(backend, resp_queue)

--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -73,12 +73,28 @@ def _get(model_name: str | None = None):
             _install_torchao_stub_once()
             from sentence_transformers import SentenceTransformer
 
-            device = _device()
-            logger.info("loading embedding model %s on %s", name, device)
-            _model = SentenceTransformer(
-                name, device = device, model_kwargs = {"torch_dtype": "float16"}
+            import os as _os
+
+            _offline = (
+                _os.environ.get("HF_HUB_OFFLINE", "").strip().lower()
+                in {"1", "true", "yes", "on"}
+                or _os.environ.get("TRANSFORMERS_OFFLINE", "").strip().lower()
+                in {"1", "true", "yes", "on"}
             )
-            _name = name
+            if _offline:
+                _os.environ["HF_HUB_OFFLINE"] = "1"
+                _os.environ["TRANSFORMERS_OFFLINE"] = "1"
+            try:
+                device = _device()
+                logger.info("loading embedding model %s on %s", name, device)
+                _model = SentenceTransformer(
+                    name, device = device, model_kwargs = {"torch_dtype": "float16"}
+                )
+                _name = name
+            finally:
+                if _offline:
+                    _os.environ.pop("HF_HUB_OFFLINE", None)
+                    _os.environ.pop("TRANSFORMERS_OFFLINE", None)
         return _model
 
 

--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -75,12 +75,17 @@ def _get(model_name: str | None = None):
 
             import os as _os
 
-            _offline = (
-                _os.environ.get("HF_HUB_OFFLINE", "").strip().lower()
-                in {"1", "true", "yes", "on"}
-                or _os.environ.get("TRANSFORMERS_OFFLINE", "").strip().lower()
-                in {"1", "true", "yes", "on"}
-            )
+            _offline = _os.environ.get("HF_HUB_OFFLINE", "").strip().lower() in {
+                "1",
+                "true",
+                "yes",
+                "on",
+            } or _os.environ.get("TRANSFORMERS_OFFLINE", "").strip().lower() in {
+                "1",
+                "true",
+                "yes",
+                "on",
+            }
             if _offline:
                 _os.environ["HF_HUB_OFFLINE"] = "1"
                 _os.environ["TRANSFORMERS_OFFLINE"] = "1"

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -461,12 +461,17 @@ def _start_llama_cpp_probes_if_enabled(app: FastAPI) -> None:
 def _warm_rag_embedder() -> None:
     """Warm RAG embeddings without blocking backend readiness."""
     try:
-        _offline = (
-            os.environ.get("HF_HUB_OFFLINE", "").strip().lower()
-            in {"1", "true", "yes", "on"}
-            or os.environ.get("TRANSFORMERS_OFFLINE", "").strip().lower()
-            in {"1", "true", "yes", "on"}
-        )
+        _offline = os.environ.get("HF_HUB_OFFLINE", "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        } or os.environ.get("TRANSFORMERS_OFFLINE", "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
         if _offline:
             return
         from storage import rag_db

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -461,6 +461,14 @@ def _start_llama_cpp_probes_if_enabled(app: FastAPI) -> None:
 def _warm_rag_embedder() -> None:
     """Warm RAG embeddings without blocking backend readiness."""
     try:
+        _offline = (
+            os.environ.get("HF_HUB_OFFLINE", "").strip().lower()
+            in {"1", "true", "yes", "on"}
+            or os.environ.get("TRANSFORMERS_OFFLINE", "").strip().lower()
+            in {"1", "true", "yes", "on"}
+        )
+        if _offline:
+            return
         from storage import rag_db
 
         if not rag_db.RAG_AVAILABLE:

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -1668,12 +1668,12 @@ def _get_model_size_bytes(model_name: str, hf_token: Optional[str] = None) -> Op
     import os as _os
 
     # Offline: skip HF API call to avoid hanging on DNS/network errors
-    if (
-        _os.environ.get("HF_HUB_OFFLINE", "").strip().lower()
-        in {"1", "true", "yes", "on"}
-        or _os.environ.get("TRANSFORMERS_OFFLINE", "").strip().lower()
-        in {"1", "true", "yes", "on"}
-    ):
+    if _os.environ.get("HF_HUB_OFFLINE", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    } or _os.environ.get("TRANSFORMERS_OFFLINE", "").strip().lower() in {"1", "true", "yes", "on"}:
         return None
 
     try:

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -1665,6 +1665,17 @@ def _get_max_position_embeddings(config) -> Optional[int]:
 
 def _get_model_size_bytes(model_name: str, hf_token: Optional[str] = None) -> Optional[int]:
     """Total size of model weight files from HF Hub."""
+    import os as _os
+
+    # Offline: skip HF API call to avoid hanging on DNS/network errors
+    if (
+        _os.environ.get("HF_HUB_OFFLINE", "").strip().lower()
+        in {"1", "true", "yes", "on"}
+        or _os.environ.get("TRANSFORMERS_OFFLINE", "").strip().lower()
+        in {"1", "true", "yes", "on"}
+    ):
+        return None
+
     try:
         from huggingface_hub import HfApi
 

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -1904,6 +1904,14 @@ def detect_gguf_model_remote(repo_id: str, hf_token: Optional[str] = None) -> Op
             ):
                 logger.debug(f"Could not check GGUF files for '{repo_id}': {e}")
                 return None
+            # Connection / DNS / timeout errors are unlikely to self-heal
+            # on retry — fall back to local cache immediately
+            if isinstance(e, (ConnectionError, TimeoutError)) or err_name in (
+                "ConnectError",
+                "ConnectTimeout",
+                "ReadTimeout",
+            ):
+                break
             if attempt < 2:
                 time.sleep(2**attempt)
 
@@ -1965,6 +1973,12 @@ def is_embedding_model(model_name: str, hf_token: Optional[str] = None) -> bool:
         is_emb = os.path.isfile(os.path.join(local_dir, "modules.json"))
         _embedding_detection_cache[cache_key] = is_emb
         return is_emb
+
+    # Offline: cannot check remote metadata — assume not embedding to avoid blocking
+    if _env_offline():
+        logger.debug("Offline mode — skipping embedding model detection for %s", model_name)
+        _embedding_detection_cache[cache_key] = False
+        return False
 
     try:
         from huggingface_hub import model_info as hf_model_info


### PR DESCRIPTION
## Description

Fixes #6817

Unsloth Studio makes several network calls during training pre-flight checks, export, and startup that ignore `HF_HUB_OFFLINE` / `TRANSFORMERS_OFFLINE`, causing hangs and crashes when running without internet.

### What was broken

1. **Export (GGUF/merged/lora)** — the export handler had no offline protection. 
   `save_pretrained_gguf` triggers transformers' `_patch_mistral_regex` → `is_base_mistral()` → `model_info()` which makes a hidden network call and crashes with `RuntimeError: Unsloth: The tokenizer is weirdly not loaded?`

2. **RAG embedder warmup** — the daemon thread loaded `unsloth/bge-small-en-v1.5` via `SentenceTransformer` making HEAD requests even with `HF_HUB_OFFLINE=1`. Retried 5x per file causing massive startup delays.

3. **`is_embedding_model()`** — called `hf_model_info()` with no offline check, generating `Could not determine if X is embedding model` warnings.

4. **`_get_model_size_bytes()`** — called `HfApi.repo_info()` with no offline check, generating `Could not get model size for X` warnings.

5. **`detect_gguf_model_remote()`** — checked `_env_offline()` then fell back to cache (good), but when cache lookup returned None it fell into 3 network retries with 1s/2s/4s backoff instead of returning immediately.

### What was fixed

| File | Fix |
|------|-----|
| `core/export/worker.py` | Wrap export handler with `_offline_window_if_unreachable` (sets `HF_HUB_OFFLINE=1` + in-process flags + session reset) |
| `main.py` | Skip `_warm_rag_embedder()` when `HF_HUB_OFFLINE`/`TRANSFORMERS_OFFLINE` is set |
| `core/rag/embeddings.py` | Guard `SentenceTransformer` load with `HF_HUB_OFFLINE=1` / `TRANSFORMERS_OFFLINE=1` when offline env vars are set |
| `utils/models/model_config.py` | `is_embedding_model()`: check `_env_offline()` before `hf_model_info()` |
| `utils/models/model_config.py` | `detect_gguf_model_remote()`: catch connection/DNS/timeout errors and break retry loop immediately |
| `routes/models.py` | `_get_model_size_bytes()`: return `None` immediately when offline |

All fixes follow the pattern already established by `_env_offline()` checks in sibling functions (e.g. `detect_gguf_model_remote`, GGUF variant listing) — it was just never applied to these call sites.