### PR TITLE
Clear stale yolo approval state on no-launch reruns

### DIFF
--- a/.github/scripts/agent-guides-drive.sh
+++ b/.github/scripts/agent-guides-drive.sh
@@ -154,7 +154,12 @@ raw_env() {  # $1 = var name -> value (one shlex-quote layer stripped)
 # writers as a side effect (it writes each agent's relocated session config).
 parse_connect() {
   local raw="$LOGS_DIR/connect-${AGENT}.txt"
-  if ! unsloth start "$AGENT" --no-launch --api-key "$UNSLOTH_API_KEY" > "$raw" 2>&1; then
+  # CONNECT_YOLO=1 adds --yolo. opencode/openclaw gate tool approval through their
+  # config (which now prompts by default), so the file-edit test opts into auto-approval
+  # here, the same intent as claude/codex's per-call bypass flags.
+  local yolo=()
+  [ -n "${CONNECT_YOLO:-}" ] && yolo=(--yolo)
+  if ! unsloth start "$AGENT" --no-launch "${yolo[@]}" --api-key "$UNSLOTH_API_KEY" > "$raw" 2>&1; then
     cat_redacted "$raw"
     guide_fail "'unsloth start ${AGENT} --no-launch' exited non-zero"
   fi
@@ -394,7 +399,10 @@ case "$MODE" in
     T2='Run hello.py with python and show me the exact output.'
 
     # The start.py recipe writers + crosscheck must see the repo; run them
-    # from the repo root BEFORE cd-ing into the scratch work dir.
+    # from the repo root BEFORE cd-ing into the scratch work dir. opencode/openclaw
+    # gate tool approval through their config (prompting by default), so file-edit
+    # opts them into auto-approval to run edits/commands headlessly.
+    case "$AGENT" in opencode|openclaw) CONNECT_YOLO=1 ;; esac
     parse_connect
     crosscheck_contract
     # File-edit needs real tools, so we cannot zero them as in connection.

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1165,9 +1165,7 @@ def write_opencode_config(
             # A string permission ("deny"/"ask"/"allow") is a global user rule left in the
             # config file as-is; carry the same prompting guarantee inline (never weaker
             # than that rule) so a permissive project config still prompts.
-            session_permission = {
-                t: "deny" if permission == "deny" else "ask" for t in tools
-            }
+            session_permission = {t: "deny" if permission == "deny" else "ask" for t in tools}
         else:
             permission = permission if isinstance(permission, dict) else {}
             # An absent tool inherits the "*" catch-all when present, else OpenCode's

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -5,7 +5,6 @@
 
 import atexit
 import contextlib
-import copy
 import json
 import os
 import re
@@ -1082,26 +1081,26 @@ def write_openclaw_config(
             state = _read_json_object(approvals)
             if state is not None:
                 defaults = state.get("defaults")
-                changed = False
-                if isinstance(defaults, dict):
-                    for field, yolo_value in (
-                        ("security", "full"),
-                        ("ask", "off"),
-                        ("askFallback", "full"),
-                    ):
-                        if defaults.get(field) == yolo_value:
-                            del defaults[field]
-                            changed = True
+                # Strip the defaults only when they are exactly the yolo fingerprint; a
+                # user-managed mixed policy that merely shares a field (e.g. askFallback=full,
+                # whose omitted default is deny) must be kept intact.
+                yolo_defaults = (("security", "full"), ("ask", "off"), ("askFallback", "full"))
+                is_yolo = isinstance(defaults, dict) and all(
+                    defaults.get(k) == v for k, v in yolo_defaults
+                )
+                if is_yolo:
+                    for k, _ in yolo_defaults:
+                        del defaults[k]
                     if not defaults:
                         del state["defaults"]
-                if changed and set(state) <= {"version"}:
-                    # Nothing left but our own yolo payload: remove it.
-                    approvals.unlink()
-                    typer.echo(f"Removed {approvals}")
-                elif changed:
-                    # Keep approvals OpenClaw itself recorded; only the yolo defaults go.
-                    _write_private_json(approvals, state)
-                    typer.echo(f"Updated {approvals}")
+                    if set(state) <= {"version"}:
+                        # Nothing left but our own yolo payload: remove it.
+                        approvals.unlink()
+                        typer.echo(f"Removed {approvals}")
+                    else:
+                        # Keep approvals OpenClaw itself recorded; only the yolo defaults go.
+                        _write_private_json(approvals, state)
+                        typer.echo(f"Updated {approvals}")
     if json.dumps(config, sort_keys = True) != before:
         _write_private_json(path, config)
         typer.echo(f"Updated {path}")
@@ -1149,60 +1148,24 @@ def write_opencode_config(
     tools = ("edit", "bash", "webfetch")
     if yolo:
         # OpenCode has no --yolo flag; auto-approve is the config `permission` block
-        # (singular). Allow the prompting tools so tool calls don't block on the TUI.
+        # (singular). Allow the prompting tools so tool calls don't block on the TUI. This
+        # rides inline (OPENCODE_CONFIG_CONTENT) so --yolo works even over a project config.
         session_permission = {t: "allow" for t in tools}
         config["permission"] = dict(session_permission)
     else:
-        # OpenCode defaults an unset permission to "allow" (runs without asking) and
-        # OPENCODE_CONFIG loads BELOW project opencode.json, so a non-yolo run must carry a
-        # non-permissive policy INLINE (OPENCODE_CONFIG_CONTENT outranks project config) or
-        # a permissive project config still auto-approves the tools --yolo opened. The
-        # inline value per tool is the stricter of "ask" and the tool's effective value in
-        # our own config: a plain "allow" (or an absent tool defaulting to allow) becomes
-        # "ask" (a prompt, never a silent auto-approve); a "deny", "ask", or granular
-        # object value a user set is carried through VERBATIM so it is never weakened.
-        # (We cannot read the project config, so a project-only "deny" is softened to a
-        # prompt; that keeps the no-silent-approve contract without hard-blocking.)
+        # Undo only what --yolo wrote: our yolo sets an explicit per-tool "allow" for these
+        # three tools, so flip exactly those explicit allows back to "ask". A "deny"/"ask",
+        # a granular object, a string, or a "*" catch-all is the user's own rule and is left
+        # untouched. We do NOT carry a permission inline for a non-yolo session: since
+        # OPENCODE_CONFIG_CONTENT outranks the project opencode.json we cannot read, any
+        # value forced there would override the user's project rules (weakening a project
+        # deny, or auto-approving through a granular object's permissive default). Clearing
+        # our own persisted yolo state is the fix; the project's own permissions are honored.
+        session_permission: dict = {}
         permission = config.get("permission")
-        if isinstance(permission, str):
-            # A string permission ("deny"/"ask"/"allow") is a global user rule left in the
-            # config file as-is; "deny" rides inline verbatim, anything looser floors to
-            # "ask".
-            session_permission = {t: permission if permission == "deny" else "ask" for t in tools}
-        else:
-            permission = permission if isinstance(permission, dict) else {}
-            # An absent tool inherits the "*" catch-all when present, else OpenCode's
-            # "allow" default. The catch-all itself is never rewritten, so other tools keep
-            # inheriting it.
-            default = permission.get("*", "allow")
-
-            def _has_allow(value):
-                # A granular object maps glob -> "allow"/"ask"/"deny"; it is permissive if
-                # any pattern (at any depth) resolves to "allow".
-                if isinstance(value, dict):
-                    return any(_has_allow(v) for v in value.values())
-                return value == "allow"
-
-            def _inline(value):
-                # Carry a "deny" string or a granular object that grants nothing
-                # ("ask"/"deny" only) inline VERBATIM so a per-tool user rule is not
-                # collapsed to a blanket "ask". An object that grants "allow" anywhere is
-                # permissive: floor it to the string "ask", which fully replaces (not
-                # deep-merges) a project object, so no inline "allow" pattern can leak
-                # through. A plain "allow" or an absent tool also floors to "ask".
-                if isinstance(value, dict):
-                    # Copy so the returned inline dict never aliases config["permission"].
-                    return copy.deepcopy(value) if not _has_allow(value) else "ask"
-                return "deny" if value == "deny" else "ask"
-
-            session_permission = {t: _inline(permission.get(t, default)) for t in tools}
-            # Tighten a tool whose EFFECTIVE value is "allow" (set explicitly or inherited
-            # from an "allow" catch-all) to "ask" in the file too; a deny/object/ask value
-            # (per-tool or via a deny catch-all) is a stricter user rule and stays put.
-            to_ask = [t for t in tools if permission.get(t, default) == "allow"]
-            if to_ask:
-                permission = _subdict(config, "permission")
-                for tool in to_ask:
+        if isinstance(permission, dict):
+            for tool in tools:
+                if permission.get(tool) == "allow":
                     permission[tool] = "ask"
     if json.dumps(config, sort_keys = True) != before:
         _write_private_json(path, config)
@@ -1495,10 +1458,10 @@ def opencode(
         # changing the user's default model. Key lives in the config, not the env.
         session_permission = write_opencode_config(base, key, entry, config_path, yolo = yolo)
         # A project's own opencode.json outranks OPENCODE_CONFIG, so the session model pin
-        # AND the permission policy (yolo's allow, or non-yolo's ask) would silently lose
-        # to a repo config allowing edit/bash/webfetch. Carry both in OPENCODE_CONFIG_CONTENT,
-        # which outranks project config, so a non-yolo session prompts even over a permissive
-        # project config; the API key stays in the private file, never in the printed env.
+        # would silently lose to a repo config. Carry it in OPENCODE_CONFIG_CONTENT, which
+        # outranks project config; the API key stays in the private file, never the env.
+        # Only --yolo carries a permission here (its allow must win over a project config);
+        # a non-yolo session returns no permission, so the project's own rules are honored.
         inline_config: dict = {"model": f"unsloth/{entry['id']}"}
         if session_permission:
             inline_config["permission"] = session_permission

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -5,6 +5,7 @@
 
 import atexit
 import contextlib
+import copy
 import json
 import os
 import re
@@ -1054,20 +1055,19 @@ def write_openclaw_config(
         tools = config.get("tools")
         exec_policy = tools.get("exec") if isinstance(tools, dict) else None
         exec_policy = exec_policy if isinstance(exec_policy, dict) else {}
-        # tools.exec.mode is OpenClaw's normalized policy knob and cannot be combined with
-        # explicit security/ask (the config is rejected outright), so a mode-based policy
-        # governs approval on its own; leave it alone. host=sandbox defaults to
-        # security=deny, and host=node routes to a paired node; both are user-set (--yolo
-        # only ever writes host=gateway), so leave a non-gateway host untouched rather than
-        # broadening its routing. Only rewrite a gateway-routed policy whose effective
-        # security+ask is the permissive yolo default (an omitted host defaults to the
-        # gateway when no sandbox runs).
-        host = exec_policy.get("host")
+        # Match ONLY the exact fingerprint --yolo writes (host=gateway, security=full,
+        # ask=off, all explicit, no mode); anything else is left untouched. host=auto or an
+        # omitted host resolves to security=deny under an active sandbox, so treating those
+        # as the permissive gateway default would broaden a fresh sandboxed config from
+        # deny to allowlist. host=node and host=sandbox are user-set (--yolo only writes
+        # gateway). tools.exec.mode is OpenClaw's normalized knob (it cannot be combined
+        # with security/ask, and OpenClaw never rewrites our security/ask write into it),
+        # so a mode is always a deliberate user policy; never clobber it.
         permissive = (
             "mode" not in exec_policy
-            and host in (None, "gateway", "auto")
-            and exec_policy.get("security", "full") == "full"
-            and exec_policy.get("ask", "off") == "off"
+            and exec_policy.get("host") == "gateway"
+            and exec_policy.get("security") == "full"
+            and exec_policy.get("ask") == "off"
         )
         if permissive:
             exec_policy = _subdict(_subdict(config, "tools"), "exec")
@@ -1153,29 +1153,52 @@ def write_opencode_config(
         session_permission = {t: "allow" for t in tools}
         config["permission"] = dict(session_permission)
     else:
-        # OpenCode defaults an unset permission to "allow" (runs without asking), so a
-        # non-yolo run must WRITE an "ask" policy for the tools --yolo opened, not just
-        # drop the allow entries (which would fall back to that permissive default). A
-        # stricter value (deny/ask) the user set is kept. A string ("deny") or "*"
-        # catch-all is a global user rule: leave it in place, and only flip a tool that is
-        # EXPLICITLY "allow" (do not default an absent tool to allow when a catch-all,
-        # which the tool inherits, governs it).
+        # OpenCode defaults an unset permission to "allow" (runs without asking) and
+        # OPENCODE_CONFIG loads BELOW project opencode.json, so a non-yolo run must carry a
+        # non-permissive policy INLINE (OPENCODE_CONFIG_CONTENT outranks project config) or
+        # a permissive project config still auto-approves the tools --yolo opened. The
+        # inline value per tool is the stricter of "ask" and the tool's effective value in
+        # our own config: a plain "allow" (or an absent tool defaulting to allow) becomes
+        # "ask" (a prompt, never a silent auto-approve); a "deny", "ask", or granular
+        # object value a user set is carried through VERBATIM so it is never weakened.
+        # (We cannot read the project config, so a project-only "deny" is softened to a
+        # prompt; that keeps the no-silent-approve contract without hard-blocking.)
         permission = config.get("permission")
         if isinstance(permission, str):
             # A string permission ("deny"/"ask"/"allow") is a global user rule left in the
-            # config file as-is; carry the same prompting guarantee inline (never weaker
-            # than that rule) so a permissive project config still prompts.
-            session_permission = {t: "deny" if permission == "deny" else "ask" for t in tools}
+            # config file as-is; "deny" rides inline verbatim, anything looser floors to
+            # "ask".
+            session_permission = {t: permission if permission == "deny" else "ask" for t in tools}
         else:
             permission = permission if isinstance(permission, dict) else {}
             # An absent tool inherits the "*" catch-all when present, else OpenCode's
-            # "allow" default. Only an EFFECTIVE "allow" is tightened to "ask"; a "deny"
-            # (per-tool or via a deny catch-all) is a stricter user rule and stays. The
-            # catch-all itself is never rewritten, so other tools keep inheriting it.
+            # "allow" default. The catch-all itself is never rewritten, so other tools keep
+            # inheriting it.
             default = permission.get("*", "allow")
-            session_permission = {
-                t: "deny" if permission.get(t, default) == "deny" else "ask" for t in tools
-            }
+
+            def _has_allow(value):
+                # A granular object maps glob -> "allow"/"ask"/"deny"; it is permissive if
+                # any pattern (at any depth) resolves to "allow".
+                if isinstance(value, dict):
+                    return any(_has_allow(v) for v in value.values())
+                return value == "allow"
+
+            def _inline(value):
+                # Carry a "deny" string or a granular object that grants nothing
+                # ("ask"/"deny" only) inline VERBATIM so a per-tool user rule is not
+                # collapsed to a blanket "ask". An object that grants "allow" anywhere is
+                # permissive: floor it to the string "ask", which fully replaces (not
+                # deep-merges) a project object, so no inline "allow" pattern can leak
+                # through. A plain "allow" or an absent tool also floors to "ask".
+                if isinstance(value, dict):
+                    # Copy so the returned inline dict never aliases config["permission"].
+                    return copy.deepcopy(value) if not _has_allow(value) else "ask"
+                return "deny" if value == "deny" else "ask"
+
+            session_permission = {t: _inline(permission.get(t, default)) for t in tools}
+            # Tighten a tool whose EFFECTIVE value is "allow" (set explicitly or inherited
+            # from an "allow" catch-all) to "ask" in the file too; a deny/object/ask value
+            # (per-tool or via a deny catch-all) is a stricter user rule and stays put.
             to_ask = [t for t in tools if permission.get(t, default) == "allow"]
             if to_ask:
                 permission = _subdict(config, "permission")

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1051,9 +1051,25 @@ def write_openclaw_config(
         # security=full, ask=off on the gateway host, so deleting the keys would keep
         # auto-approval on: a non-yolo run must WRITE a prompting policy. Only a
         # permissive/yolo policy is replaced; a stricter one set by hand survives.
-        exec_policy = (config.get("tools") or {}).get("exec")
+        tools = config.get("tools")
+        exec_policy = tools.get("exec") if isinstance(tools, dict) else None
         exec_policy = exec_policy if isinstance(exec_policy, dict) else {}
-        if exec_policy.get("security", "full") == "full" and exec_policy.get("ask", "off") == "off":
+        # tools.exec.mode is OpenClaw's normalized policy knob and cannot be combined with
+        # explicit security/ask (the config is rejected outright), so a mode-based policy
+        # governs approval on its own; leave it alone. host=sandbox defaults to
+        # security=deny, and host=node routes to a paired node; both are user-set (--yolo
+        # only ever writes host=gateway), so leave a non-gateway host untouched rather than
+        # broadening its routing. Only rewrite a gateway-routed policy whose effective
+        # security+ask is the permissive yolo default (an omitted host defaults to the
+        # gateway when no sandbox runs).
+        host = exec_policy.get("host")
+        permissive = (
+            "mode" not in exec_policy
+            and host in (None, "gateway", "auto")
+            and exec_policy.get("security", "full") == "full"
+            and exec_policy.get("ask", "off") == "off"
+        )
+        if permissive:
             exec_policy = _subdict(_subdict(config, "tools"), "exec")
             exec_policy.pop("host", None)  # routing only; defaults to the gateway host
             exec_policy["security"] = "allowlist"  # only allowlisted commands skip approval
@@ -1097,7 +1113,7 @@ def write_opencode_config(
     model: dict,
     path: Path,
     yolo: bool = False,
-) -> None:
+) -> dict:
     config = _read_json_object(path)
     if config is None:
         typer.echo(
@@ -1105,7 +1121,7 @@ def write_opencode_config(
             "yourself, or move the file aside and re-run.",
             err = True,
         )
-        return
+        return {}
     before = json.dumps(config, sort_keys = True)
     config.setdefault("$schema", "https://opencode.ai/config.json")
     model_entry = {"name": model["id"]}
@@ -1130,25 +1146,47 @@ def write_opencode_config(
         compaction = _subdict(config, "compaction")
         compaction["auto"] = True
         compaction["reserved"] = max(1, window // 10)
+    tools = ("edit", "bash", "webfetch")
     if yolo:
         # OpenCode has no --yolo flag; auto-approve is the config `permission` block
         # (singular). Allow the prompting tools so tool calls don't block on the TUI.
-        config["permission"] = {"edit": "allow", "bash": "allow", "webfetch": "allow"}
+        session_permission = {t: "allow" for t in tools}
+        config["permission"] = dict(session_permission)
     else:
         # OpenCode defaults an unset permission to "allow" (runs without asking), so a
         # non-yolo run must WRITE an "ask" policy for the tools --yolo opened, not just
         # drop the allow entries (which would fall back to that permissive default). A
-        # stricter value (deny/ask) the user set is kept.
+        # stricter value (deny/ask) the user set is kept. A string ("deny") or "*"
+        # catch-all is a global user rule: leave it in place, and only flip a tool that is
+        # EXPLICITLY "allow" (do not default an absent tool to allow when a catch-all,
+        # which the tool inherits, governs it).
         permission = config.get("permission")
-        permission = permission if isinstance(permission, dict) else {}
-        to_ask = [t for t in ("edit", "bash", "webfetch") if permission.get(t, "allow") == "allow"]
-        if to_ask:
-            permission = _subdict(config, "permission")
-            for tool in to_ask:
-                permission[tool] = "ask"
+        if isinstance(permission, str):
+            # A string permission ("deny"/"ask"/"allow") is a global user rule left in the
+            # config file as-is; carry the same prompting guarantee inline (never weaker
+            # than that rule) so a permissive project config still prompts.
+            session_permission = {
+                t: "deny" if permission == "deny" else "ask" for t in tools
+            }
+        else:
+            permission = permission if isinstance(permission, dict) else {}
+            # An absent tool inherits the "*" catch-all when present, else OpenCode's
+            # "allow" default. Only an EFFECTIVE "allow" is tightened to "ask"; a "deny"
+            # (per-tool or via a deny catch-all) is a stricter user rule and stays. The
+            # catch-all itself is never rewritten, so other tools keep inheriting it.
+            default = permission.get("*", "allow")
+            session_permission = {
+                t: "deny" if permission.get(t, default) == "deny" else "ask" for t in tools
+            }
+            to_ask = [t for t in tools if permission.get(t, default) == "allow"]
+            if to_ask:
+                permission = _subdict(config, "permission")
+                for tool in to_ask:
+                    permission[tool] = "ask"
     if json.dumps(config, sort_keys = True) != before:
         _write_private_json(path, config)
         typer.echo(f"Updated {path}")
+    return session_permission
 
 
 def write_hermes_config(base: str, model: dict, path: Path) -> None:
@@ -1434,14 +1472,15 @@ def opencode(
         # OPENCODE_CONFIG is an overlay (loaded between the user's global and project
         # configs), so this adds the Unsloth provider/model for the session without
         # changing the user's default model. Key lives in the config, not the env.
-        write_opencode_config(base, key, entry, config_path, yolo = yolo)
-        # A project's own opencode.json outranks OPENCODE_CONFIG, so the session model
-        # pin (and --yolo permissions) would silently lose to a repo config. Carry the
-        # settings that must win in OPENCODE_CONFIG_CONTENT, which outranks project
-        # config; the API key stays in the private file, never in the printed env.
+        session_permission = write_opencode_config(base, key, entry, config_path, yolo = yolo)
+        # A project's own opencode.json outranks OPENCODE_CONFIG, so the session model pin
+        # AND the permission policy (yolo's allow, or non-yolo's ask) would silently lose
+        # to a repo config allowing edit/bash/webfetch. Carry both in OPENCODE_CONFIG_CONTENT,
+        # which outranks project config, so a non-yolo session prompts even over a permissive
+        # project config; the API key stays in the private file, never in the printed env.
         inline_config: dict = {"model": f"unsloth/{entry['id']}"}
-        if yolo:
-            inline_config["permission"] = {"edit": "allow", "bash": "allow", "webfetch": "allow"}
+        if session_permission:
+            inline_config["permission"] = session_permission
         env = {
             "OPENCODE_CONFIG": str(config_path),
             "OPENCODE_CONFIG_CONTENT": json.dumps(inline_config),

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1047,25 +1047,20 @@ def write_openclaw_config(
         typer.echo(f"Updated {approvals}")
     else:
         # The no-launch config dir is reused across runs, so a previous --yolo run may
-        # have left auto-approval state behind. A run without --yolo must restore
-        # prompting: strip the exec policy and the approvals defaults. Only the exact
-        # values the yolo branch writes are removed, so a stricter policy someone set
-        # by hand (or OpenClaw recorded) survives.
-        tools = config.get("tools")
-        if isinstance(tools, dict):
-            exec_policy = tools.get("exec")
-            if isinstance(exec_policy, dict):
-                for field, yolo_value in (
-                    ("host", "gateway"),
-                    ("security", "full"),
-                    ("ask", "off"),
-                ):
-                    if exec_policy.get(field) == yolo_value:
-                        del exec_policy[field]
-                if not exec_policy:
-                    del tools["exec"]
-            if not tools:
-                del config["tools"]
+        # have left auto-approval state behind. OpenClaw treats an omitted exec policy as
+        # security=full, ask=off on the gateway host, so deleting the keys would keep
+        # auto-approval on: a non-yolo run must WRITE a prompting policy. Only a
+        # permissive/yolo policy is replaced; a stricter one set by hand survives.
+        exec_policy = (config.get("tools") or {}).get("exec")
+        exec_policy = exec_policy if isinstance(exec_policy, dict) else {}
+        if exec_policy.get("security", "full") == "full" and exec_policy.get("ask", "off") == "off":
+            exec_policy = _subdict(_subdict(config, "tools"), "exec")
+            exec_policy.pop("host", None)  # routing only; defaults to the gateway host
+            exec_policy["security"] = "allowlist"  # only allowlisted commands skip approval
+            exec_policy["ask"] = "on-miss"  # prompt on every non-allowlisted command
+        # Drop the yolo defaults from the host approvals file (a stricter default set by
+        # the user or OpenClaw is kept). With a prompting tools.exec the stricter of the
+        # two layers wins, so an omitted approvals default still prompts.
         approvals = path.parent / "exec-approvals.json"
         if approvals.exists():
             state = _read_json_object(approvals)
@@ -1140,16 +1135,17 @@ def write_opencode_config(
         # (singular). Allow the prompting tools so tool calls don't block on the TUI.
         config["permission"] = {"edit": "allow", "bash": "allow", "webfetch": "allow"}
     else:
-        # The no-launch config is reused across runs; drop the auto-allow entries a
-        # previous --yolo run wrote so this session prompts again. Anything else in
-        # the permission block (ask/deny policies, other tools) is kept.
+        # OpenCode defaults an unset permission to "allow" (runs without asking), so a
+        # non-yolo run must WRITE an "ask" policy for the tools --yolo opened, not just
+        # drop the allow entries (which would fall back to that permissive default). A
+        # stricter value (deny/ask) the user set is kept.
         permission = config.get("permission")
-        if isinstance(permission, dict):
-            for tool in ("edit", "bash", "webfetch"):
-                if permission.get(tool) == "allow":
-                    del permission[tool]
-            if not permission:
-                del config["permission"]
+        permission = permission if isinstance(permission, dict) else {}
+        to_ask = [t for t in ("edit", "bash", "webfetch") if permission.get(t, "allow") == "allow"]
+        if to_ask:
+            permission = _subdict(config, "permission")
+            for tool in to_ask:
+                permission[tool] = "ask"
     if json.dumps(config, sort_keys = True) != before:
         _write_private_json(path, config)
         typer.echo(f"Updated {path}")

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1055,7 +1055,11 @@ def write_openclaw_config(
         if isinstance(tools, dict):
             exec_policy = tools.get("exec")
             if isinstance(exec_policy, dict):
-                for field, yolo_value in (("host", "gateway"), ("security", "full"), ("ask", "off")):
+                for field, yolo_value in (
+                    ("host", "gateway"),
+                    ("security", "full"),
+                    ("ask", "off"),
+                ):
                     if exec_policy.get(field) == yolo_value:
                         del exec_policy[field]
                 if not exec_policy:
@@ -1070,7 +1074,9 @@ def write_openclaw_config(
                 changed = False
                 if isinstance(defaults, dict):
                     for field, yolo_value in (
-                        ("security", "full"), ("ask", "off"), ("askFallback", "full"),
+                        ("security", "full"),
+                        ("ask", "off"),
+                        ("askFallback", "full"),
                     ):
                         if defaults.get(field) == yolo_value:
                             del defaults[field]

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -983,7 +983,9 @@ def _session_config(agent: str, launch: bool):
     else:
         # Never wipe this dir: a previously printed recipe may still be running
         # an agent whose sessions/state live here, and every config writer
-        # merges idempotently into an existing home anyway.
+        # merges idempotently into an existing home anyway. Writers must also
+        # reset any state a previous run's flags left behind (--yolo especially),
+        # since files here outlive the invocation that wrote them.
         path = _agents_config_root() / agent
         path.mkdir(parents = True, exist_ok = True, mode = 0o700)
         yield path
@@ -1043,6 +1045,32 @@ def write_openclaw_config(
             {"version": 1, "defaults": {"security": "full", "ask": "off", "askFallback": "full"}},
         )
         typer.echo(f"Updated {approvals}")
+    else:
+        # The no-launch config dir is reused across runs, so a previous --yolo run may
+        # have left auto-approval state behind. A run without --yolo must restore
+        # prompting: strip both the exec policy and the approvals defaults.
+        tools = config.get("tools")
+        if isinstance(tools, dict):
+            exec_policy = tools.get("exec")
+            if isinstance(exec_policy, dict):
+                for field in ("host", "security", "ask"):
+                    exec_policy.pop(field, None)
+                if not exec_policy:
+                    del tools["exec"]
+            if not tools:
+                del config["tools"]
+        approvals = path.parent / "exec-approvals.json"
+        if approvals.exists():
+            state = _read_json_object(approvals) or {}
+            had_defaults = state.pop("defaults", None) is not None
+            if set(state) <= {"version"}:
+                # Nothing left but our own yolo payload (or unreadable): remove it.
+                approvals.unlink()
+                typer.echo(f"Removed {approvals}")
+            elif had_defaults:
+                # Keep approvals OpenClaw itself recorded; only the yolo defaults go.
+                _write_private_json(approvals, state)
+                typer.echo(f"Updated {approvals}")
     if json.dumps(config, sort_keys = True) != before:
         _write_private_json(path, config)
         typer.echo(f"Updated {path}")
@@ -1091,6 +1119,10 @@ def write_opencode_config(
         # OpenCode has no --yolo flag; auto-approve is the config `permission` block
         # (singular). Allow the prompting tools so tool calls don't block on the TUI.
         config["permission"] = {"edit": "allow", "bash": "allow", "webfetch": "allow"}
+    else:
+        # The no-launch config is reused across runs; drop a permission block left by
+        # a previous --yolo run so this session prompts again.
+        config.pop("permission", None)
     if json.dumps(config, sort_keys = True) != before:
         _write_private_json(path, config)
         typer.echo(f"Updated {path}")

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1048,29 +1048,43 @@ def write_openclaw_config(
     else:
         # The no-launch config dir is reused across runs, so a previous --yolo run may
         # have left auto-approval state behind. A run without --yolo must restore
-        # prompting: strip both the exec policy and the approvals defaults.
+        # prompting: strip the exec policy and the approvals defaults. Only the exact
+        # values the yolo branch writes are removed, so a stricter policy someone set
+        # by hand (or OpenClaw recorded) survives.
         tools = config.get("tools")
         if isinstance(tools, dict):
             exec_policy = tools.get("exec")
             if isinstance(exec_policy, dict):
-                for field in ("host", "security", "ask"):
-                    exec_policy.pop(field, None)
+                for field, yolo_value in (("host", "gateway"), ("security", "full"), ("ask", "off")):
+                    if exec_policy.get(field) == yolo_value:
+                        del exec_policy[field]
                 if not exec_policy:
                     del tools["exec"]
             if not tools:
                 del config["tools"]
         approvals = path.parent / "exec-approvals.json"
         if approvals.exists():
-            state = _read_json_object(approvals) or {}
-            had_defaults = state.pop("defaults", None) is not None
-            if set(state) <= {"version"}:
-                # Nothing left but our own yolo payload (or unreadable): remove it.
-                approvals.unlink()
-                typer.echo(f"Removed {approvals}")
-            elif had_defaults:
-                # Keep approvals OpenClaw itself recorded; only the yolo defaults go.
-                _write_private_json(approvals, state)
-                typer.echo(f"Updated {approvals}")
+            state = _read_json_object(approvals)
+            if state is not None:
+                defaults = state.get("defaults")
+                changed = False
+                if isinstance(defaults, dict):
+                    for field, yolo_value in (
+                        ("security", "full"), ("ask", "off"), ("askFallback", "full"),
+                    ):
+                        if defaults.get(field) == yolo_value:
+                            del defaults[field]
+                            changed = True
+                    if not defaults:
+                        del state["defaults"]
+                if changed and set(state) <= {"version"}:
+                    # Nothing left but our own yolo payload: remove it.
+                    approvals.unlink()
+                    typer.echo(f"Removed {approvals}")
+                elif changed:
+                    # Keep approvals OpenClaw itself recorded; only the yolo defaults go.
+                    _write_private_json(approvals, state)
+                    typer.echo(f"Updated {approvals}")
     if json.dumps(config, sort_keys = True) != before:
         _write_private_json(path, config)
         typer.echo(f"Updated {path}")
@@ -1120,9 +1134,16 @@ def write_opencode_config(
         # (singular). Allow the prompting tools so tool calls don't block on the TUI.
         config["permission"] = {"edit": "allow", "bash": "allow", "webfetch": "allow"}
     else:
-        # The no-launch config is reused across runs; drop a permission block left by
-        # a previous --yolo run so this session prompts again.
-        config.pop("permission", None)
+        # The no-launch config is reused across runs; drop the auto-allow entries a
+        # previous --yolo run wrote so this session prompts again. Anything else in
+        # the permission block (ask/deny policies, other tools) is kept.
+        permission = config.get("permission")
+        if isinstance(permission, dict):
+            for tool in ("edit", "bash", "webfetch"):
+                if permission.get(tool) == "allow":
+                    del permission[tool]
+            if not permission:
+                del config["permission"]
     if json.dumps(config, sort_keys = True) != before:
         _write_private_json(path, config)
         typer.echo(f"Updated {path}")

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1806,7 +1806,9 @@ def test_openclaw_non_yolo_preserves_stricter_approval_defaults(tmp_path):
     # settings from the user or the OpenClaw UI) are kept, and the file stays.
     path = tmp_path / "openclaw.json"
     approvals = path.parent / "exec-approvals.json"
-    approvals.write_text(json.dumps({"version": 1, "defaults": {"security": "allowlist", "ask": "on"}}))
+    approvals.write_text(
+        json.dumps({"version": 1, "defaults": {"security": "allowlist", "ask": "on"}})
+    )
     start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
     state = json.loads(approvals.read_text())
     assert state["defaults"] == {"security": "allowlist", "ask": "on"}

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1719,6 +1719,78 @@ def test_write_openclaw_config_yolo_unit(tmp_path):
     }
 
 
+def test_no_launch_rerun_clears_stale_opencode_yolo_permissions(fake_studio, tmp_path):
+    # The no-launch config dir is reused across runs, so a --yolo run persists its
+    # auto-approve settings; a later run without --yolo must strip them, not leave
+    # tool execution silently pre-approved.
+    yolo = CliRunner().invoke(start.start_app, ["opencode", "--yolo", "--no-launch"])
+    assert yolo.exit_code == 0, yolo.output
+    config_path = tmp_path / "agents" / "opencode" / "opencode.json"
+    assert "permission" in json.loads(config_path.read_text())
+    plain = CliRunner().invoke(start.start_app, ["opencode", "--no-launch"])
+    assert plain.exit_code == 0, plain.output
+    config = json.loads(config_path.read_text())
+    assert "permission" not in config
+    # The session provider survives the cleanup.
+    assert "unsloth" in config["provider"]
+
+
+def test_no_launch_rerun_clears_stale_openclaw_yolo_state(fake_studio, tmp_path):
+    yolo = CliRunner().invoke(start.start_app, ["openclaw", "--yolo", "--no-launch"])
+    assert yolo.exit_code == 0, yolo.output
+    state = tmp_path / "agents" / "openclaw"
+    assert (state / "exec-approvals.json").exists()
+    plain = CliRunner().invoke(start.start_app, ["openclaw", "--no-launch"])
+    assert plain.exit_code == 0, plain.output
+    config = json.loads((state / "openclaw.json").read_text())
+    assert "exec" not in config.get("tools", {})
+    assert not (state / "exec-approvals.json").exists()
+    # The session provider survives the cleanup.
+    assert "unsloth" in config["models"]["providers"]
+
+
+def test_write_openclaw_config_yolo_then_plain_unit(tmp_path):
+    path = tmp_path / "openclaw.json"
+    start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = True)
+    start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+    config = json.loads(path.read_text())
+    assert "tools" not in config
+    assert not (path.parent / "exec-approvals.json").exists()
+
+
+def test_write_opencode_config_yolo_then_plain_unit(tmp_path):
+    path = tmp_path / "opencode.json"
+    start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = True)
+    start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+    config = json.loads(path.read_text())
+    assert "permission" not in config
+
+
+def test_openclaw_non_yolo_keeps_runtime_approvals(tmp_path):
+    # OpenClaw records its own entries in exec-approvals.json (OPENCLAW_STATE_DIR is
+    # this dir); the non-yolo reset drops only the yolo defaults, not those.
+    path = tmp_path / "openclaw.json"
+    start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = True)
+    approvals = path.parent / "exec-approvals.json"
+    state = json.loads(approvals.read_text())
+    state["agents"] = {"main": {"allowlist": ["git status"]}}
+    approvals.write_text(json.dumps(state))
+    start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+    remaining = json.loads(approvals.read_text())
+    assert "defaults" not in remaining
+    assert remaining["agents"] == {"main": {"allowlist": ["git status"]}}
+
+
+def test_openclaw_non_yolo_preserves_foreign_exec_keys(tmp_path):
+    # Only the keys the yolo path writes are reset; anything else under tools.exec
+    # is left alone.
+    path = tmp_path / "openclaw.json"
+    path.write_text(json.dumps({"tools": {"exec": {"timeout": 30, "ask": "off"}}}))
+    start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+    config = json.loads(path.read_text())
+    assert config["tools"]["exec"] == {"timeout": 30}
+
+
 def test_yolo_command_flags_unmapped_agent_is_empty():
     # Config-based agents (and any typo) must yield no flag, not a KeyError.
     assert start._yolo_command_flags("opencode", True) == []

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -446,10 +446,10 @@ def test_opencode_inline_config_beats_project_config(fake_studio):
     assert "sk-unsloth" not in content_line  # key stays in the private file
 
 
-def test_opencode_inline_config_carries_ask_policy_without_yolo(fake_studio):
-    # OPENCODE_CONFIG loads BELOW project opencode.json, so the ask policy must also ride
-    # in OPENCODE_CONFIG_CONTENT (which outranks project config) or a project config
-    # allowing edit/bash/webfetch would still auto-approve a non-yolo session.
+def test_opencode_inline_config_omits_permission_without_yolo(fake_studio):
+    # A non-yolo session carries no permission inline. OPENCODE_CONFIG_CONTENT outranks the
+    # project opencode.json we cannot read, so forcing any value there would override the
+    # user's project rules; clearing our own config is the fix, and the inline pins the model.
     result = CliRunner().invoke(start.start_app, ["opencode", "--no-launch"])
     assert result.exit_code == 0, result.output
     content_line = next(
@@ -459,7 +459,7 @@ def test_opencode_inline_config_carries_ask_policy_without_yolo(fake_studio):
         shlex.split(content_line.removeprefix("export OPENCODE_CONFIG_CONTENT="))[0]
     )
     assert inline["model"] == f"unsloth/{MODEL['id']}"
-    assert inline["permission"] == {"edit": "ask", "bash": "ask", "webfetch": "ask"}
+    assert "permission" not in inline
 
 
 def test_https_loopback_never_auto_serves(fake_studio, monkeypatch):
@@ -1676,13 +1676,29 @@ def test_yolo_opencode_writes_permission_block(fake_studio, tmp_path):
     assert config["permission"] == {"edit": "allow", "bash": "allow", "webfetch": "allow"}
 
 
-def test_no_yolo_opencode_writes_ask_policy(fake_studio, tmp_path):
+def test_no_yolo_opencode_has_no_permission_block(fake_studio, tmp_path):
     result = CliRunner().invoke(start.start_app, ["opencode", "--no-launch"])
     assert result.exit_code == 0, result.output
     config = json.loads((tmp_path / "agents" / "opencode" / "opencode.json").read_text())
-    # OpenCode's default for an unset permission is "allow", so a non-yolo run must
-    # write an explicit "ask" policy rather than leave it unset.
-    assert config["permission"] == {"edit": "ask", "bash": "ask", "webfetch": "ask"}
+    # A non-yolo run on a fresh config writes no permission block; it only flips a prior
+    # --yolo run's explicit allow back to ask (see the yolo-then-plain test below).
+    assert "permission" not in config
+
+
+def test_no_yolo_opencode_flips_prior_yolo_allow_to_ask(fake_studio, tmp_path):
+    # The core reset: a --yolo run wrote explicit per-tool allow; a later non-yolo run
+    # must flip exactly those back to ask so nothing stays auto-approved.
+    yolo = CliRunner().invoke(start.start_app, ["opencode", "--yolo", "--no-launch"])
+    assert yolo.exit_code == 0, yolo.output
+    config_path = tmp_path / "agents" / "opencode" / "opencode.json"
+    assert json.loads(config_path.read_text())["permission"] == {
+        "edit": "allow", "bash": "allow", "webfetch": "allow"
+    }
+    plain = CliRunner().invoke(start.start_app, ["opencode", "--no-launch"])
+    assert plain.exit_code == 0, plain.output
+    assert json.loads(config_path.read_text())["permission"] == {
+        "edit": "ask", "bash": "ask", "webfetch": "ask"
+    }
 
 
 def test_yolo_openclaw_writes_exec_policy(fake_studio, tmp_path):
@@ -1799,6 +1815,18 @@ def test_openclaw_non_yolo_keeps_runtime_approvals(tmp_path):
     assert remaining["agents"] == {"main": {"allowlist": ["git status"]}}
 
 
+def test_openclaw_non_yolo_keeps_mixed_approval_defaults(tmp_path):
+    # A mixed user-managed defaults block that only shares a field with the yolo payload
+    # (here askFallback=full, whose omitted default is deny) is not stale yolo state, so a
+    # non-yolo run leaves it intact rather than stripping the shared field.
+    path = tmp_path / "openclaw.json"
+    approvals = path.parent / "exec-approvals.json"
+    mixed = {"version": 1, "defaults": {"security": "allowlist", "ask": "on-miss", "askFallback": "full"}}
+    approvals.write_text(json.dumps(mixed))
+    start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+    assert json.loads(approvals.read_text()) == mixed
+
+
 def test_openclaw_non_yolo_leaves_partial_policy_untouched(tmp_path):
     # A policy that lacks the full yolo fingerprint (here no host and no security) is not
     # our --yolo write, so a non-yolo run leaves it as-is rather than assuming ask=off
@@ -1856,118 +1884,47 @@ def test_openclaw_non_yolo_leaves_unparseable_approvals(tmp_path):
     assert approvals.read_text() == "{not json"
 
 
-def test_opencode_non_yolo_preserves_custom_permissions(tmp_path):
-    # An "allow" tool is tightened to "ask" and an omitted one (allow by default) gains
-    # an explicit "ask"; deny/ask policies and other tools' entries are kept.
+def test_opencode_non_yolo_flips_only_explicit_allow(tmp_path):
+    # Only a tool explicitly set to "allow" (what --yolo writes) is flipped to "ask". A
+    # deny/ask a user set is kept, and an absent tool is not added.
     path = tmp_path / "opencode.json"
     path.write_text(json.dumps({"permission": {"edit": "allow", "bash": "deny", "read": "ask"}}))
-    start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+    session = start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
     config = json.loads(path.read_text())
-    assert config["permission"] == {"edit": "ask", "bash": "deny", "read": "ask", "webfetch": "ask"}
+    assert config["permission"] == {"edit": "ask", "bash": "deny", "read": "ask"}
+    assert session == {}  # a non-yolo session carries no permission inline
 
 
-def test_opencode_non_yolo_preserves_string_permission(tmp_path):
-    # A global string rule ("deny") is a user-managed catch-all; it must be left in the
-    # config file untouched, not replaced by a per-tool "ask" block that weakens it.
+def test_opencode_non_yolo_leaves_string_permission(tmp_path):
+    # A global string rule ("deny") is a user-managed catch-all; leave it untouched and
+    # carry no inline override.
     path = tmp_path / "opencode.json"
     path.write_text(json.dumps({"permission": "deny"}))
     session = start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
-    config = json.loads(path.read_text())
-    assert config["permission"] == "deny"
-    # The inline session policy carried over project config never weakens the "deny".
-    assert session == {"edit": "deny", "bash": "deny", "webfetch": "deny"}
+    assert json.loads(path.read_text())["permission"] == "deny"
+    assert session == {}
 
 
-def test_opencode_non_yolo_preserves_catch_all_deny(tmp_path):
-    # A "*" deny catch-all governs absent tools; do not override it with per-tool "ask",
-    # but do tighten a tool explicitly set to "allow".
+def test_opencode_non_yolo_leaves_catch_all_and_flips_explicit_allow(tmp_path):
+    # A "*" catch-all is the user's own rule, never something --yolo writes (yolo sets
+    # explicit per-tool allow), so it is left intact; an explicit per-tool "allow" is still
+    # flipped to "ask", but an absent tool inheriting the catch-all is not touched.
     path = tmp_path / "opencode.json"
-    path.write_text(json.dumps({"permission": {"*": "deny", "bash": "allow"}}))
+    path.write_text(json.dumps({"permission": {"*": "allow", "bash": "allow"}}))
     session = start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
-    config = json.loads(path.read_text())
-    assert config["permission"] == {"*": "deny", "bash": "ask"}
-    assert session == {"edit": "deny", "bash": "ask", "webfetch": "deny"}
+    assert json.loads(path.read_text())["permission"] == {"*": "allow", "bash": "ask"}
+    assert session == {}
 
 
-def test_opencode_non_yolo_tightens_catch_all_allow(tmp_path):
-    # A "*" allow catch-all still auto-approves the yolo tools, so a non-yolo run pins the
-    # three tools to "ask" (keeping the catch-all for other tools).
+def test_opencode_non_yolo_leaves_granular_object(tmp_path):
+    # A granular object value is a user rule (yolo only ever writes a plain "allow" string),
+    # so it is left in the file verbatim and never carried inline.
     path = tmp_path / "opencode.json"
-    path.write_text(json.dumps({"permission": {"*": "allow"}}))
+    obj = {"read *": "deny", "git *": "ask"}
+    path.write_text(json.dumps({"permission": {"bash": dict(obj)}}))
     session = start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
-    config = json.loads(path.read_text())
-    assert config["permission"] == {"*": "allow", "edit": "ask", "bash": "ask", "webfetch": "ask"}
-    assert session == {"edit": "ask", "bash": "ask", "webfetch": "ask"}
-
-
-def test_opencode_non_yolo_ask_policy_wins_over_project_config(fake_studio):
-    # OPENCODE_CONFIG loads below project opencode.json, so the ask policy must also ride
-    # in OPENCODE_CONFIG_CONTENT to prompt even when a project config allows the tools.
-    result = CliRunner().invoke(start.start_app, ["opencode", "--no-launch"])
-    assert result.exit_code == 0, result.output
-    content_line = next(
-        ln for ln in result.output.splitlines() if ln.startswith("export OPENCODE_CONFIG_CONTENT=")
-    )
-    inline = json.loads(
-        shlex.split(content_line.removeprefix("export OPENCODE_CONFIG_CONTENT="))[0]
-    )
-    assert inline["permission"] == {"edit": "ask", "bash": "ask", "webfetch": "ask"}
-
-
-def test_opencode_non_yolo_preserves_granular_object_deny(tmp_path):
-    # OpenCode allows granular object values, e.g. permission = {"bash": {"*": "deny"}}.
-    # Since OPENCODE_CONFIG_CONTENT outranks project config, collapsing that dict to a
-    # plain "ask" inline would weaken the deny; carry the object through verbatim instead.
-    path = tmp_path / "opencode.json"
-    path.write_text(json.dumps({"permission": {"bash": {"read *": "deny", "git *": "ask"}}}))
-    session = start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
-    config = json.loads(path.read_text())
-    # The granular deny/ask object is kept in the file (only an explicit "allow" is
-    # tightened) and rides inline unchanged; the two other tools floor to "ask".
-    assert config["permission"]["bash"] == {"read *": "deny", "git *": "ask"}
-    assert session == {"edit": "ask", "bash": {"read *": "deny", "git *": "ask"}, "webfetch": "ask"}
-    # The inline object must not alias the file's, so a later edit of one cannot corrupt the
-    # other.
-    assert session["bash"] is not config["permission"]["bash"]
-
-
-def test_opencode_non_yolo_floors_permissive_object_to_ask(tmp_path):
-    # A granular object that grants "allow" anywhere is permissive. OpenCode deep-merges an
-    # inline object into the project object (so an inline "allow" pattern would leak
-    # through), and evaluates globs last-match-wins, so carrying it verbatim would silently
-    # auto-approve. Floor it to the string "ask", which fully REPLACES a project object.
-    path = tmp_path / "opencode.json"
-    path.write_text(json.dumps({"permission": {"bash": {"*": "allow", "git push *": "deny"}}}))
-    session = start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
-    assert session == {"edit": "ask", "bash": "ask", "webfetch": "ask"}
-
-
-def test_opencode_non_yolo_floors_permissive_object_catch_all(tmp_path):
-    # A permissive granular "*" catch-all inherited by absent tools must also floor to
-    # "ask", not propagate an "allow"-bearing object to every tool.
-    path = tmp_path / "opencode.json"
-    path.write_text(json.dumps({"permission": {"*": {"*": "allow"}}}))
-    session = start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
-    assert session == {"edit": "ask", "bash": "ask", "webfetch": "ask"}
-
-
-def test_opencode_non_yolo_carries_own_deny_inline_over_project(fake_studio, tmp_path):
-    # A deny the user left in our own session config (reused no-launch dir) must not be
-    # softened. It rides inline verbatim so a permissive project config cannot re-open it,
-    # while the tools it does not name floor to "ask".
-    config_path = tmp_path / "agents" / "opencode" / "opencode.json"
-    config_path.parent.mkdir(parents = True, exist_ok = True)
-    config_path.write_text(json.dumps({"permission": {"bash": "deny"}}))
-    result = CliRunner().invoke(start.start_app, ["opencode", "--no-launch"])
-    assert result.exit_code == 0, result.output
-    content_line = next(
-        ln for ln in result.output.splitlines() if ln.startswith("export OPENCODE_CONFIG_CONTENT=")
-    )
-    inline = json.loads(
-        shlex.split(content_line.removeprefix("export OPENCODE_CONFIG_CONTENT="))[0]
-    )
-    # bash stays denied inline (never weakened to ask); edit/webfetch floor to ask.
-    assert inline["permission"] == {"edit": "ask", "bash": "deny", "webfetch": "ask"}
+    assert json.loads(path.read_text())["permission"]["bash"] == obj
+    assert session == {}
 
 
 def test_openclaw_non_yolo_leaves_mode_policy(tmp_path):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -446,7 +446,10 @@ def test_opencode_inline_config_beats_project_config(fake_studio):
     assert "sk-unsloth" not in content_line  # key stays in the private file
 
 
-def test_opencode_inline_config_omits_permissions_without_yolo(fake_studio):
+def test_opencode_inline_config_carries_ask_policy_without_yolo(fake_studio):
+    # OPENCODE_CONFIG loads BELOW project opencode.json, so the ask policy must also ride
+    # in OPENCODE_CONFIG_CONTENT (which outranks project config) or a project config
+    # allowing edit/bash/webfetch would still auto-approve a non-yolo session.
     result = CliRunner().invoke(start.start_app, ["opencode", "--no-launch"])
     assert result.exit_code == 0, result.output
     content_line = next(
@@ -455,7 +458,8 @@ def test_opencode_inline_config_omits_permissions_without_yolo(fake_studio):
     inline = json.loads(
         shlex.split(content_line.removeprefix("export OPENCODE_CONFIG_CONTENT="))[0]
     )
-    assert inline == {"model": f"unsloth/{MODEL['id']}"}
+    assert inline["model"] == f"unsloth/{MODEL['id']}"
+    assert inline["permission"] == {"edit": "ask", "bash": "ask", "webfetch": "ask"}
 
 
 def test_https_loopback_never_auto_serves(fake_studio, monkeypatch):
@@ -1856,6 +1860,85 @@ def test_opencode_non_yolo_preserves_custom_permissions(tmp_path):
     start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
     config = json.loads(path.read_text())
     assert config["permission"] == {"edit": "ask", "bash": "deny", "read": "ask", "webfetch": "ask"}
+
+
+def test_opencode_non_yolo_preserves_string_permission(tmp_path):
+    # A global string rule ("deny") is a user-managed catch-all; it must be left in the
+    # config file untouched, not replaced by a per-tool "ask" block that weakens it.
+    path = tmp_path / "opencode.json"
+    path.write_text(json.dumps({"permission": "deny"}))
+    session = start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+    config = json.loads(path.read_text())
+    assert config["permission"] == "deny"
+    # The inline session policy carried over project config never weakens the "deny".
+    assert session == {"edit": "deny", "bash": "deny", "webfetch": "deny"}
+
+
+def test_opencode_non_yolo_preserves_catch_all_deny(tmp_path):
+    # A "*" deny catch-all governs absent tools; do not override it with per-tool "ask",
+    # but do tighten a tool explicitly set to "allow".
+    path = tmp_path / "opencode.json"
+    path.write_text(json.dumps({"permission": {"*": "deny", "bash": "allow"}}))
+    session = start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+    config = json.loads(path.read_text())
+    assert config["permission"] == {"*": "deny", "bash": "ask"}
+    assert session == {"edit": "deny", "bash": "ask", "webfetch": "deny"}
+
+
+def test_opencode_non_yolo_tightens_catch_all_allow(tmp_path):
+    # A "*" allow catch-all still auto-approves the yolo tools, so a non-yolo run pins the
+    # three tools to "ask" (keeping the catch-all for other tools).
+    path = tmp_path / "opencode.json"
+    path.write_text(json.dumps({"permission": {"*": "allow"}}))
+    session = start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+    config = json.loads(path.read_text())
+    assert config["permission"] == {"*": "allow", "edit": "ask", "bash": "ask", "webfetch": "ask"}
+    assert session == {"edit": "ask", "bash": "ask", "webfetch": "ask"}
+
+
+def test_opencode_non_yolo_ask_policy_wins_over_project_config(fake_studio):
+    # OPENCODE_CONFIG loads below project opencode.json, so the ask policy must also ride
+    # in OPENCODE_CONFIG_CONTENT to prompt even when a project config allows the tools.
+    result = CliRunner().invoke(start.start_app, ["opencode", "--no-launch"])
+    assert result.exit_code == 0, result.output
+    content_line = next(
+        ln for ln in result.output.splitlines() if ln.startswith("export OPENCODE_CONFIG_CONTENT=")
+    )
+    inline = json.loads(
+        shlex.split(content_line.removeprefix("export OPENCODE_CONFIG_CONTENT="))[0]
+    )
+    assert inline["permission"] == {"edit": "ask", "bash": "ask", "webfetch": "ask"}
+
+
+def test_openclaw_non_yolo_leaves_mode_policy(tmp_path):
+    # tools.exec.mode is OpenClaw's normalized knob and cannot be combined with explicit
+    # security/ask (the config is rejected), so a mode-based policy must be left as-is.
+    path = tmp_path / "openclaw.json"
+    path.write_text(json.dumps({"tools": {"exec": {"mode": "deny"}}}))
+    start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+    config = json.loads(path.read_text())
+    assert config["tools"]["exec"] == {"mode": "deny"}
+
+
+def test_openclaw_non_yolo_preserves_sandbox_host(tmp_path):
+    # host=sandbox defaults to security=deny (stricter than the gateway "full" default),
+    # so a non-yolo run must not treat the missing security as permissive nor pop host
+    # (which would broaden routing to the gateway).
+    path = tmp_path / "openclaw.json"
+    path.write_text(json.dumps({"tools": {"exec": {"host": "sandbox"}}}))
+    start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+    config = json.loads(path.read_text())
+    assert config["tools"]["exec"] == {"host": "sandbox"}
+
+
+def test_openclaw_non_yolo_preserves_node_host(tmp_path):
+    # host=node routes to a paired node and is only ever set by the user (--yolo writes
+    # host=gateway), so a non-yolo run must not pop it and reroute to the gateway.
+    path = tmp_path / "openclaw.json"
+    path.write_text(json.dumps({"tools": {"exec": {"host": "node"}}}))
+    start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+    config = json.loads(path.read_text())
+    assert config["tools"]["exec"] == {"host": "node"}
 
 
 def test_yolo_command_flags_unmapped_agent_is_empty():

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1672,11 +1672,13 @@ def test_yolo_opencode_writes_permission_block(fake_studio, tmp_path):
     assert config["permission"] == {"edit": "allow", "bash": "allow", "webfetch": "allow"}
 
 
-def test_no_yolo_opencode_has_no_permission_block(fake_studio, tmp_path):
+def test_no_yolo_opencode_writes_ask_policy(fake_studio, tmp_path):
     result = CliRunner().invoke(start.start_app, ["opencode", "--no-launch"])
     assert result.exit_code == 0, result.output
     config = json.loads((tmp_path / "agents" / "opencode" / "opencode.json").read_text())
-    assert "permission" not in config
+    # OpenCode's default for an unset permission is "allow", so a non-yolo run must
+    # write an explicit "ask" policy rather than leave it unset.
+    assert config["permission"] == {"edit": "ask", "bash": "ask", "webfetch": "ask"}
 
 
 def test_yolo_openclaw_writes_exec_policy(fake_studio, tmp_path):
@@ -1691,12 +1693,14 @@ def test_yolo_openclaw_writes_exec_policy(fake_studio, tmp_path):
     assert approvals["defaults"] == {"security": "full", "ask": "off", "askFallback": "full"}
 
 
-def test_no_yolo_openclaw_has_no_exec_policy(fake_studio, tmp_path):
+def test_no_yolo_openclaw_writes_prompting_policy(fake_studio, tmp_path):
     result = CliRunner().invoke(start.start_app, ["openclaw", "--no-launch"])
     assert result.exit_code == 0, result.output
     state = tmp_path / "agents" / "openclaw"
     config = json.loads((state / "openclaw.json").read_text())
-    assert "exec" not in config.get("tools", {})  # no auto-approve policy without --yolo
+    # OpenClaw's default for an omitted policy is permissive, so a non-yolo run must
+    # write an explicit prompting policy, not leave exec unset.
+    assert config["tools"]["exec"] == {"security": "allowlist", "ask": "on-miss"}
     assert not (state / "exec-approvals.json").exists()
 
 
@@ -1730,7 +1734,9 @@ def test_no_launch_rerun_clears_stale_opencode_yolo_permissions(fake_studio, tmp
     plain = CliRunner().invoke(start.start_app, ["opencode", "--no-launch"])
     assert plain.exit_code == 0, plain.output
     config = json.loads(config_path.read_text())
-    assert "permission" not in config
+    # The yolo allow policy is replaced by a prompting one, not deleted (which would
+    # revert to OpenCode's permissive "allow" default).
+    assert config["permission"] == {"edit": "ask", "bash": "ask", "webfetch": "ask"}
     # The session provider survives the cleanup.
     assert "unsloth" in config["provider"]
 
@@ -1743,7 +1749,9 @@ def test_no_launch_rerun_clears_stale_openclaw_yolo_state(fake_studio, tmp_path)
     plain = CliRunner().invoke(start.start_app, ["openclaw", "--no-launch"])
     assert plain.exit_code == 0, plain.output
     config = json.loads((state / "openclaw.json").read_text())
-    assert "exec" not in config.get("tools", {})
+    # The yolo policy is replaced by a prompting one, not deleted (which would revert
+    # to OpenClaw's permissive default), and the yolo approvals file is gone.
+    assert config["tools"]["exec"] == {"security": "allowlist", "ask": "on-miss"}
     assert not (state / "exec-approvals.json").exists()
     # The session provider survives the cleanup.
     assert "unsloth" in config["models"]["providers"]
@@ -1754,7 +1762,9 @@ def test_write_openclaw_config_yolo_then_plain_unit(tmp_path):
     start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = True)
     start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
     config = json.loads(path.read_text())
-    assert "tools" not in config
+    # A plain rerun replaces the yolo policy with a prompting one (deleting it would
+    # fall back to OpenClaw's permissive default) and removes the yolo approvals file.
+    assert config["tools"]["exec"] == {"security": "allowlist", "ask": "on-miss"}
     assert not (path.parent / "exec-approvals.json").exists()
 
 
@@ -1763,7 +1773,8 @@ def test_write_opencode_config_yolo_then_plain_unit(tmp_path):
     start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = True)
     start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
     config = json.loads(path.read_text())
-    assert "permission" not in config
+    # A plain rerun replaces the yolo allow policy with a prompting one.
+    assert config["permission"] == {"edit": "ask", "bash": "ask", "webfetch": "ask"}
 
 
 def test_openclaw_non_yolo_keeps_runtime_approvals(tmp_path):
@@ -1782,13 +1793,26 @@ def test_openclaw_non_yolo_keeps_runtime_approvals(tmp_path):
 
 
 def test_openclaw_non_yolo_preserves_foreign_exec_keys(tmp_path):
-    # Only the keys the yolo path writes are reset; anything else under tools.exec
-    # is left alone.
+    # A permissive policy (no security, ask=off) is tightened to prompting, but foreign
+    # keys like timeout are left untouched.
     path = tmp_path / "openclaw.json"
     path.write_text(json.dumps({"tools": {"exec": {"timeout": 30, "ask": "off"}}}))
     start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
     config = json.loads(path.read_text())
-    assert config["tools"]["exec"] == {"timeout": 30}
+    assert config["tools"]["exec"] == {"timeout": 30, "security": "allowlist", "ask": "on-miss"}
+
+
+def test_openclaw_non_yolo_leaves_no_permissive_values(tmp_path):
+    # The whole point of the reset: after a yolo run, a plain run must leave neither the
+    # config nor the approvals file at OpenClaw's permissive (security=full, ask=off)
+    # default, or exec still auto-approves.
+    path = tmp_path / "openclaw.json"
+    start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = True)
+    start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+    exec_policy = json.loads(path.read_text())["tools"]["exec"]
+    assert exec_policy.get("security") != "full"
+    assert exec_policy.get("ask") != "off"
+    assert not (path.parent / "exec-approvals.json").exists()
 
 
 def test_openclaw_non_yolo_preserves_stricter_exec_policy(tmp_path):
@@ -1825,13 +1849,13 @@ def test_openclaw_non_yolo_leaves_unparseable_approvals(tmp_path):
 
 
 def test_opencode_non_yolo_preserves_custom_permissions(tmp_path):
-    # Only the auto-allow values the yolo path writes are dropped; deny/ask policies
-    # and other tools' entries survive a plain rerun.
+    # An "allow" tool is tightened to "ask" and an omitted one (allow by default) gains
+    # an explicit "ask"; deny/ask policies and other tools' entries are kept.
     path = tmp_path / "opencode.json"
     path.write_text(json.dumps({"permission": {"edit": "allow", "bash": "deny", "read": "ask"}}))
     start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
     config = json.loads(path.read_text())
-    assert config["permission"] == {"bash": "deny", "read": "ask"}
+    assert config["permission"] == {"edit": "ask", "bash": "deny", "read": "ask", "webfetch": "ask"}
 
 
 def test_yolo_command_flags_unmapped_agent_is_empty():

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1692,12 +1692,16 @@ def test_no_yolo_opencode_flips_prior_yolo_allow_to_ask(fake_studio, tmp_path):
     assert yolo.exit_code == 0, yolo.output
     config_path = tmp_path / "agents" / "opencode" / "opencode.json"
     assert json.loads(config_path.read_text())["permission"] == {
-        "edit": "allow", "bash": "allow", "webfetch": "allow"
+        "edit": "allow",
+        "bash": "allow",
+        "webfetch": "allow",
     }
     plain = CliRunner().invoke(start.start_app, ["opencode", "--no-launch"])
     assert plain.exit_code == 0, plain.output
     assert json.loads(config_path.read_text())["permission"] == {
-        "edit": "ask", "bash": "ask", "webfetch": "ask"
+        "edit": "ask",
+        "bash": "ask",
+        "webfetch": "ask",
     }
 
 
@@ -1821,7 +1825,10 @@ def test_openclaw_non_yolo_keeps_mixed_approval_defaults(tmp_path):
     # non-yolo run leaves it intact rather than stripping the shared field.
     path = tmp_path / "openclaw.json"
     approvals = path.parent / "exec-approvals.json"
-    mixed = {"version": 1, "defaults": {"security": "allowlist", "ask": "on-miss", "askFallback": "full"}}
+    mixed = {
+        "version": 1,
+        "defaults": {"security": "allowlist", "ask": "on-miss", "askFallback": "full"},
+    }
     approvals.write_text(json.dumps(mixed))
     start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
     assert json.loads(approvals.read_text()) == mixed

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1697,14 +1697,17 @@ def test_yolo_openclaw_writes_exec_policy(fake_studio, tmp_path):
     assert approvals["defaults"] == {"security": "full", "ask": "off", "askFallback": "full"}
 
 
-def test_no_yolo_openclaw_writes_prompting_policy(fake_studio, tmp_path):
+def test_no_yolo_openclaw_leaves_fresh_config_untouched(fake_studio, tmp_path):
+    # A fresh non-yolo run only undoes state a prior --yolo wrote; with no yolo
+    # fingerprint present it must not synthesize an exec policy. An omitted policy can
+    # resolve to a sandbox default of security=deny, so writing allowlist here would
+    # BROADEN it. The reset is scoped to the exact yolo write, verified by the
+    # yolo-then-plain round trip below.
     result = CliRunner().invoke(start.start_app, ["openclaw", "--no-launch"])
     assert result.exit_code == 0, result.output
     state = tmp_path / "agents" / "openclaw"
     config = json.loads((state / "openclaw.json").read_text())
-    # OpenClaw's default for an omitted policy is permissive, so a non-yolo run must
-    # write an explicit prompting policy, not leave exec unset.
-    assert config["tools"]["exec"] == {"security": "allowlist", "ask": "on-miss"}
+    assert "exec" not in config.get("tools", {})
     assert not (state / "exec-approvals.json").exists()
 
 
@@ -1796,14 +1799,15 @@ def test_openclaw_non_yolo_keeps_runtime_approvals(tmp_path):
     assert remaining["agents"] == {"main": {"allowlist": ["git status"]}}
 
 
-def test_openclaw_non_yolo_preserves_foreign_exec_keys(tmp_path):
-    # A permissive policy (no security, ask=off) is tightened to prompting, but foreign
-    # keys like timeout are left untouched.
+def test_openclaw_non_yolo_leaves_partial_policy_untouched(tmp_path):
+    # A policy that lacks the full yolo fingerprint (here no host and no security) is not
+    # our --yolo write, so a non-yolo run leaves it as-is rather than assuming ask=off
+    # means permissive: an omitted host/security can resolve to a sandbox deny default.
     path = tmp_path / "openclaw.json"
     path.write_text(json.dumps({"tools": {"exec": {"timeout": 30, "ask": "off"}}}))
     start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
     config = json.loads(path.read_text())
-    assert config["tools"]["exec"] == {"timeout": 30, "security": "allowlist", "ask": "on-miss"}
+    assert config["tools"]["exec"] == {"timeout": 30, "ask": "off"}
 
 
 def test_openclaw_non_yolo_leaves_no_permissive_values(tmp_path):
@@ -1910,6 +1914,62 @@ def test_opencode_non_yolo_ask_policy_wins_over_project_config(fake_studio):
     assert inline["permission"] == {"edit": "ask", "bash": "ask", "webfetch": "ask"}
 
 
+def test_opencode_non_yolo_preserves_granular_object_deny(tmp_path):
+    # OpenCode allows granular object values, e.g. permission = {"bash": {"*": "deny"}}.
+    # Since OPENCODE_CONFIG_CONTENT outranks project config, collapsing that dict to a
+    # plain "ask" inline would weaken the deny; carry the object through verbatim instead.
+    path = tmp_path / "opencode.json"
+    path.write_text(json.dumps({"permission": {"bash": {"read *": "deny", "git *": "ask"}}}))
+    session = start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+    config = json.loads(path.read_text())
+    # The granular deny/ask object is kept in the file (only an explicit "allow" is
+    # tightened) and rides inline unchanged; the two other tools floor to "ask".
+    assert config["permission"]["bash"] == {"read *": "deny", "git *": "ask"}
+    assert session == {"edit": "ask", "bash": {"read *": "deny", "git *": "ask"}, "webfetch": "ask"}
+    # The inline object must not alias the file's, so a later edit of one cannot corrupt the
+    # other.
+    assert session["bash"] is not config["permission"]["bash"]
+
+
+def test_opencode_non_yolo_floors_permissive_object_to_ask(tmp_path):
+    # A granular object that grants "allow" anywhere is permissive. OpenCode deep-merges an
+    # inline object into the project object (so an inline "allow" pattern would leak
+    # through), and evaluates globs last-match-wins, so carrying it verbatim would silently
+    # auto-approve. Floor it to the string "ask", which fully REPLACES a project object.
+    path = tmp_path / "opencode.json"
+    path.write_text(json.dumps({"permission": {"bash": {"*": "allow", "git push *": "deny"}}}))
+    session = start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+    assert session == {"edit": "ask", "bash": "ask", "webfetch": "ask"}
+
+
+def test_opencode_non_yolo_floors_permissive_object_catch_all(tmp_path):
+    # A permissive granular "*" catch-all inherited by absent tools must also floor to
+    # "ask", not propagate an "allow"-bearing object to every tool.
+    path = tmp_path / "opencode.json"
+    path.write_text(json.dumps({"permission": {"*": {"*": "allow"}}}))
+    session = start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+    assert session == {"edit": "ask", "bash": "ask", "webfetch": "ask"}
+
+
+def test_opencode_non_yolo_carries_own_deny_inline_over_project(fake_studio, tmp_path):
+    # A deny the user left in our own session config (reused no-launch dir) must not be
+    # softened. It rides inline verbatim so a permissive project config cannot re-open it,
+    # while the tools it does not name floor to "ask".
+    config_path = tmp_path / "agents" / "opencode" / "opencode.json"
+    config_path.parent.mkdir(parents = True, exist_ok = True)
+    config_path.write_text(json.dumps({"permission": {"bash": "deny"}}))
+    result = CliRunner().invoke(start.start_app, ["opencode", "--no-launch"])
+    assert result.exit_code == 0, result.output
+    content_line = next(
+        ln for ln in result.output.splitlines() if ln.startswith("export OPENCODE_CONFIG_CONTENT=")
+    )
+    inline = json.loads(
+        shlex.split(content_line.removeprefix("export OPENCODE_CONFIG_CONTENT="))[0]
+    )
+    # bash stays denied inline (never weakened to ask); edit/webfetch floor to ask.
+    assert inline["permission"] == {"edit": "ask", "bash": "deny", "webfetch": "ask"}
+
+
 def test_openclaw_non_yolo_leaves_mode_policy(tmp_path):
     # tools.exec.mode is OpenClaw's normalized knob and cannot be combined with explicit
     # security/ask (the config is rejected), so a mode-based policy must be left as-is.
@@ -1939,6 +1999,45 @@ def test_openclaw_non_yolo_preserves_node_host(tmp_path):
     start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
     config = json.loads(path.read_text())
     assert config["tools"]["exec"] == {"host": "node"}
+
+
+def test_openclaw_non_yolo_preserves_auto_host_permissive(tmp_path):
+    # host=auto (or omitted) with security=full/ask=off is NOT the --yolo write: under an
+    # active sandbox, auto resolves to security=deny. --yolo only ever writes host=gateway,
+    # so the reset must not treat auto/None as the permissive gateway default and broaden a
+    # sandboxed deny to allowlist.
+    for exec_policy in (
+        {"host": "auto", "security": "full", "ask": "off"},
+        {"security": "full", "ask": "off"},
+    ):
+        path = tmp_path / "openclaw.json"
+        path.write_text(json.dumps({"tools": {"exec": dict(exec_policy)}}))
+        start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+        config = json.loads(path.read_text())
+        assert config["tools"]["exec"] == exec_policy
+
+
+def test_openclaw_non_yolo_resets_only_gateway_yolo_fingerprint(tmp_path):
+    # The reset fires on exactly the host=gateway + security=full + ask=off write --yolo
+    # makes, and nothing else.
+    path = tmp_path / "openclaw.json"
+    path.write_text(
+        json.dumps({"tools": {"exec": {"host": "gateway", "security": "full", "ask": "off"}}})
+    )
+    start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+    config = json.loads(path.read_text())
+    assert config["tools"]["exec"] == {"security": "allowlist", "ask": "on-miss"}
+
+
+def test_openclaw_non_yolo_preserves_full_mode(tmp_path):
+    # OpenClaw never normalizes our security=full/ask=off yolo write into mode:"full"
+    # (verified against the binary: doctor --fix and config get leave security/ask as-is),
+    # so a mode:"full" is always a deliberate user policy, not stale yolo state; leave it.
+    path = tmp_path / "openclaw.json"
+    path.write_text(json.dumps({"tools": {"exec": {"mode": "full"}}}))
+    start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+    config = json.loads(path.read_text())
+    assert config["tools"]["exec"] == {"mode": "full"}
 
 
 def test_yolo_command_flags_unmapped_agent_is_empty():

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1791,6 +1791,47 @@ def test_openclaw_non_yolo_preserves_foreign_exec_keys(tmp_path):
     assert config["tools"]["exec"] == {"timeout": 30}
 
 
+def test_openclaw_non_yolo_preserves_stricter_exec_policy(tmp_path):
+    # A policy that doesn't carry the yolo values (for example stricter security or
+    # prompting turned on) was not written by --yolo and must survive a plain run.
+    path = tmp_path / "openclaw.json"
+    path.write_text(json.dumps({"tools": {"exec": {"security": "deny", "ask": "on"}}}))
+    start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+    config = json.loads(path.read_text())
+    assert config["tools"]["exec"] == {"security": "deny", "ask": "on"}
+
+
+def test_openclaw_non_yolo_preserves_stricter_approval_defaults(tmp_path):
+    # exec-approvals.json defaults that don't match the yolo payload (stricter
+    # settings from the user or the OpenClaw UI) are kept, and the file stays.
+    path = tmp_path / "openclaw.json"
+    approvals = path.parent / "exec-approvals.json"
+    approvals.write_text(json.dumps({"version": 1, "defaults": {"security": "allowlist", "ask": "on"}}))
+    start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+    state = json.loads(approvals.read_text())
+    assert state["defaults"] == {"security": "allowlist", "ask": "on"}
+
+
+def test_openclaw_non_yolo_leaves_unparseable_approvals(tmp_path):
+    # An unreadable approvals file is left in place rather than deleted, matching
+    # how an unparseable config is handled.
+    path = tmp_path / "openclaw.json"
+    approvals = path.parent / "exec-approvals.json"
+    approvals.write_text("{not json")
+    start.write_openclaw_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+    assert approvals.read_text() == "{not json"
+
+
+def test_opencode_non_yolo_preserves_custom_permissions(tmp_path):
+    # Only the auto-allow values the yolo path writes are dropped; deny/ask policies
+    # and other tools' entries survive a plain rerun.
+    path = tmp_path / "opencode.json"
+    path.write_text(json.dumps({"permission": {"edit": "allow", "bash": "deny", "read": "ask"}}))
+    start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path, yolo = False)
+    config = json.loads(path.read_text())
+    assert config["permission"] == {"bash": "deny", "read": "ask"}
+
+
 def test_yolo_command_flags_unmapped_agent_is_empty():
     # Config-based agents (and any typo) must yield no flag, not a KeyError.
     assert start._yolo_command_flags("opencode", True) == []


### PR DESCRIPTION
### Problem

`unsloth start <agent> --no-launch` reuses a stable Unsloth-owned config directory across runs (by design, since a previously printed recipe may still be running an agent whose sessions live there). The `--yolo` path writes auto-approval settings into those persistent files, but runs without `--yolo` never removed them:

- OpenClaw: `tools.exec = {host: gateway, security: full, ask: off}` in `openclaw.json`, plus `exec-approvals.json` with `security=full/ask=off` defaults.
- OpenCode: `permission = {edit: allow, bash: allow, webfetch: allow}` in `opencode.json`.

So after a single `--yolo --no-launch` run, every later `--no-launch` run of the same agent without `--yolo` still had tool execution silently pre-approved. That defeats the confirmation gate the non-yolo mode is supposed to provide: any prompt-injected or otherwise malicious instruction the agent follows can run commands or edit files without the user ever being asked.

Repro on main:

```
unsloth start opencode --no-launch --yolo   # writes permission allow block
unsloth start opencode --no-launch          # block is still there
```

The other agents (claude, codex, hermes, pi) are unaffected: their yolo form is a command line flag, nothing is persisted. Launch mode is unaffected: it uses an ephemeral temp dir that is deleted when the agent exits.

### Fix

Runs without `--yolo` now reset the persisted state instead of leaving it behind:

- OpenClaw: the `host`/`security`/`ask` keys the yolo path writes are stripped from `tools.exec` (empty parents removed), and the yolo `defaults` are stripped from `exec-approvals.json`. Approvals OpenClaw itself recorded in that file are preserved; the file is deleted when only the yolo payload is left. The CLI echoes `Removed .../exec-approvals.json` so the reset is visible.
- OpenCode: the `permission` block is dropped.

Any other user or runtime state in the session dir is left alone, so the never-wipe contract of the no-launch dir still holds.

### Validation

- Regression tests added for both agents at the CLI level (`--yolo --no-launch` then `--no-launch` on the same dir leaves no auto-approval state, session provider intact) and at the writer level, including one that checks OpenClaw runtime-recorded approvals survive the reset and one for foreign `tools.exec` keys. Full suite: 138 passed.
- Live check against a running Studio: `unsloth start openclaw/opencode --no-launch --yolo` followed by the same command without `--yolo` on a fresh Studio home. Before the fix the exec policy, approvals file, and permission block all persist; after the fix the rerun removes all three and the printed recipe still works.