### PR TITLE
Add MiCA as init_lora_weights option

### DIFF
--- a/tests/version_compat/test_peft_pinned_symbols.py
+++ b/tests/version_compat/test_peft_pinned_symbols.py
@@ -337,3 +337,22 @@ def test_peft_version_parseable(tag: str):
     assert (
         has_literal or has_subimport or has_metadata
     ), f"{tag}: peft.__version__ not exported via any known mechanism"
+
+
+# 11. peft.tuners.lora.variants.MiCALinearVariant
+
+@pytest.mark.parametrize("tag", PEFT_TAGS)
+def test_peft_mica_variant_and_init(tag: str):
+    variants_src = fetch_text(
+        "huggingface/peft", tag, "src/peft/tuners/lora/variants.py"
+    )
+    if variants_src is None or not has_def(variants_src, "MiCALinearVariant", "class"):
+        pytest.skip(f"{tag}: MiCA not present in this PEFT version")
+
+    layer_src = fetch_text("huggingface/peft", tag, "src/peft/tuners/lora/layer.py")
+    assert layer_src is not None, f"{tag}: layer.py missing"
+    assert has_def(layer_src, "mica_init", "func"), (
+        f"{tag}: MiCALinearVariant present but LoraLayer.mica_init missing — "
+        f'unsloth\'s `init_lora_weights="mica"` gate imports the class but PEFT '
+        f"needs the init hook to actually initialize the adapter"
+    )

--- a/tests/version_compat/test_peft_pinned_symbols.py
+++ b/tests/version_compat/test_peft_pinned_symbols.py
@@ -341,11 +341,10 @@ def test_peft_version_parseable(tag: str):
 
 # 11. peft.tuners.lora.variants.MiCALinearVariant
 
+
 @pytest.mark.parametrize("tag", PEFT_TAGS)
 def test_peft_mica_variant_and_init(tag: str):
-    variants_src = fetch_text(
-        "huggingface/peft", tag, "src/peft/tuners/lora/variants.py"
-    )
+    variants_src = fetch_text("huggingface/peft", tag, "src/peft/tuners/lora/variants.py")
     if variants_src is None or not has_def(variants_src, "MiCALinearVariant", "class"):
         pytest.skip(f"{tag}: MiCA not present in this PEFT version")
 

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -3004,9 +3004,9 @@ def validate_loftq_config(loftq_config, lora_dropout, bias, init_lora_weights, m
         except ImportError:
             import peft
             raise RuntimeError(
-                   f"Unsloth: Your PEFT version of {peft.__version__} does not support MiCA init.\n"
-                    "MiCA is not yet in a released version. Install from source:\n"
-                    "`pip install git+https://github.com/huggingface/peft.git`"
+                f"Unsloth: Your PEFT version of {peft.__version__} does not support MiCA init.\n"
+                "MiCA is not yet in a released version. Install from source:\n"
+                "`pip install git+https://github.com/huggingface/peft.git`"
             )
         if hasattr(model.config, "quantization_config"):
             raise ValueError(
@@ -3014,7 +3014,6 @@ def validate_loftq_config(loftq_config, lora_dropout, bias, init_lora_weights, m
                 "MiCA runs SVD on the base weights and requires fp32/fp16/bf16 — PEFT will refuse quantized weights.\n"
                 "Reload your model without quantization by setting `load_in_4bit = False` and `load_in_8bit = False`."
             )
-
 
     return loftq_config
 

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -2970,9 +2970,10 @@ def validate_loftq_config(loftq_config, lora_dropout, bias, init_lora_weights, m
         or init_lora_weights == "gaussian"
         or init_lora_weights == "loftq"
         or init_lora_weights == "corda"
+        or init_lora_weights == "mica"
     ):
         raise ValueError(
-            'Unsloth: `init_lora_weights` must be either [True, False, "gaussian", "loftq", "corda"].'
+            'Unsloth: `init_lora_weights` must be either [True, False, "gaussian", "loftq", "corda" , "mica"].'
         )
 
     if init_lora_weights == "loftq":
@@ -2997,6 +2998,23 @@ def validate_loftq_config(loftq_config, lora_dropout, bias, init_lora_weights, m
                 "Unsloth: You are using `loftq` init, yet `load_in_4bit = True` was set.\n"
                 "Reload your model without any quantization by setting `load_in_4bit = False`."
             )
+    if init_lora_weights == "mica":
+        try:
+            from peft.tuners.lora.variants import MiCALinearVariant
+        except ImportError:
+            import peft
+            raise RuntimeError(
+                   f"Unsloth: Your PEFT version of {peft.__version__} does not support MiCA init.\n"
+                    "MiCA is not yet in a released version. Install from source:\n"
+                    "`pip install git+https://github.com/huggingface/peft.git`"
+            )
+        if hasattr(model.config, "quantization_config"):
+            raise ValueError(
+                "Unsloth: You are using `mica` init, yet your model is quantized (e.g. `load_in_4bit = True`).\n"
+                "MiCA runs SVD on the base weights and requires fp32/fp16/bf16 — PEFT will refuse quantized weights.\n"
+                "Reload your model without quantization by setting `load_in_4bit = False` and `load_in_8bit = False`."
+            )
+
 
     return loftq_config
 

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -3008,7 +3008,7 @@ def validate_loftq_config(loftq_config, lora_dropout, bias, init_lora_weights, m
                 "MiCA is not yet in a released version. Install from source:\n"
                 "`pip install git+https://github.com/huggingface/peft.git`"
             )
-        if hasattr(model.config, "quantization_config"):
+        if getattr(model.config, "quantization_config", None) is not None:
             raise ValueError(
                 "Unsloth: You are using `mica` init, yet your model is quantized (e.g. `load_in_4bit = True`).\n"
                 "MiCA runs SVD on the base weights and requires fp32/fp16/bf16 — PEFT will refuse quantized weights.\n"

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -3078,9 +3078,10 @@ class FastLlamaModel:
             or init_lora_weights == "gaussian"
             or init_lora_weights == "loftq"
             or init_lora_weights == "corda"
+            or init_lora_weights == "mica"
         ):
             raise ValueError(
-                'Unsloth: `init_lora_weights` must be either [True, False, "gaussian", "loftq", "corda"].'
+                'Unsloth: `init_lora_weights` must be either [True, False, "gaussian", "loftq", "corda", "mica"].'
             )
 
         if init_lora_weights == "loftq":
@@ -3105,6 +3106,24 @@ class FastLlamaModel:
                     "Unsloth: You are using `loftq` init, yet `load_in_4bit = True` was set.\n"
                     "Reload your model without any quantization by setting `load_in_4bit = False`."
                 )
+        
+        if init_lora_weights == "mica":
+            try:
+                from peft.tuners.lora.variants import MiCALinearVariant
+            except ImportError:
+                import peft
+                raise RuntimeError(
+                   f"Unsloth: Your PEFT version of {peft.__version__} does not support MiCA init.\n"
+                    "MiCA is not yet in a released version. Install from source:\n"
+                    "`pip install git+https://github.com/huggingface/peft.git`"
+                )
+            if hasattr(model.config, "quantization_config"):
+                raise ValueError(
+                    "Unsloth: You are using `mica` init, yet your model is quantized (e.g. `load_in_4bit = True`).\n"
+                    "MiCA runs SVD on the base weights and requires fp32/fp16/bf16 — PEFT will refuse quantized weights.\n"
+                    "Reload your model without quantization by setting `load_in_4bit = False` and `load_in_8bit = False`."
+                )
+
 
         assert type(use_rslora) is bool
         if use_rslora:

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -3106,14 +3106,14 @@ class FastLlamaModel:
                     "Unsloth: You are using `loftq` init, yet `load_in_4bit = True` was set.\n"
                     "Reload your model without any quantization by setting `load_in_4bit = False`."
                 )
-        
+
         if init_lora_weights == "mica":
             try:
                 from peft.tuners.lora.variants import MiCALinearVariant
             except ImportError:
                 import peft
                 raise RuntimeError(
-                   f"Unsloth: Your PEFT version of {peft.__version__} does not support MiCA init.\n"
+                    f"Unsloth: Your PEFT version of {peft.__version__} does not support MiCA init.\n"
                     "MiCA is not yet in a released version. Install from source:\n"
                     "`pip install git+https://github.com/huggingface/peft.git`"
                 )
@@ -3123,7 +3123,6 @@ class FastLlamaModel:
                     "MiCA runs SVD on the base weights and requires fp32/fp16/bf16 — PEFT will refuse quantized weights.\n"
                     "Reload your model without quantization by setting `load_in_4bit = False` and `load_in_8bit = False`."
                 )
-
 
         assert type(use_rslora) is bool
         if use_rslora:

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -3117,7 +3117,7 @@ class FastLlamaModel:
                     "MiCA is not yet in a released version. Install from source:\n"
                     "`pip install git+https://github.com/huggingface/peft.git`"
                 )
-            if hasattr(model.config, "quantization_config"):
+            if getattr(model.config, "quantization_config", None) is not None:
                 raise ValueError(
                     "Unsloth: You are using `mica` init, yet your model is quantized (e.g. `load_in_4bit = True`).\n"
                     "MiCA runs SVD on the base weights and requires fp32/fp16/bf16 — PEFT will refuse quantized weights.\n"


### PR DESCRIPTION
Closes #6730

Adds "mica" as a supported init_lora_weights value, wiring PEFT's MiCA init (huggingface/peft#3260) through Unsloth's LoRA config gate.

Guards in both call paths (llama.py and _utils.py): RuntimeError if PEFT is missing MiCALinearVariant, ValueError if the base is quantized (PEFT's MiCA refuses quantized weights). Pinned-symbol test in test_peft_pinned_symbols.py skips on pre-#3260 tags, asserts on main.

PEFT version: MiCA is not in a released PEFT yet (latest v0.19.1 is pre-merge). Guard directs users to `pip install --upgrade git+https://github.com/huggingface/peft.git`; message can pin a specific version once PEFT ships MiCA.

Follow-up planned: 4-bit / QLoRA path via on-the-fly dequantization on target modules.

Verified locally: pytest -k mica in test_peft_pinned_symbols.py passes (4 skipped on pre-MiCA tags, 1 on main). Manual runs on Qwen/Qwen3.5-0.8B confirmed fp16 MiCA produces lora_A == 0 with nonzero lora_B, 4-bit path raises the new ValueError (not PEFT's TypeError), and simulated pre-#3260 PEFT raises the new RuntimeError with git-install hint.
