### PR TITLE
Fix duplicate gemma-2b-bnb-4bit key routing the base model to the instruct model

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -365,6 +365,7 @@ jobs:
             tests/utils/test_trunc_normal_patch.py \
             tests/python/test_fast_language_model_text_only.py \
             tests/test_prefetch_snapshot_scope.py \
+            tests/test_gemma_2b_mapper_key.py \
             --deselect 'tests/utils/test_attention_masks.py::test_run_attention_flash_varlen_receives_window_and_softcap'
           # The deselected test monkeypatches flash_attn_varlen_func, which is
           # only bound on the module when `flash_attn` is importable. flash_attn

--- a/tests/test_gemma_2b_mapper_key.py
+++ b/tests/test_gemma_2b_mapper_key.py
@@ -1,0 +1,46 @@
+"""Regression test for the duplicate ``unsloth/gemma-2b-bnb-4bit`` key in
+``unsloth/models/mapper.py``.
+
+The 4bit instruction-tuned Gemma 2B entry was accidentally keyed with the base
+model's repo name, so ``__INT_TO_FLOAT_MAPPER`` held two identical
+``unsloth/gemma-2b-bnb-4bit`` keys. Python keeps only the last value for a
+duplicate literal key, so the base 4bit repo resolved to the *instruct* model,
+the base model lost its reverse (4x-faster) mapping, and
+``unsloth/gemma-2b-it-bnb-4bit`` was never registered at all.
+
+``mapper.py`` has no imports, so we exec it directly and inspect the built
+mappers without importing ``unsloth`` (which requires a GPU).
+"""
+
+import os
+
+MAPPER_PATH = os.path.join(os.path.dirname(__file__), os.pardir, "unsloth", "models", "mapper.py")
+
+
+def _load_mappers():
+    with open(MAPPER_PATH) as f:
+        source = f.read()
+    namespace = {}
+    exec(compile(source, MAPPER_PATH, "exec"), namespace)
+    return namespace
+
+
+def test_gemma_2b_base_and_instruct_4bit_are_distinct():
+    namespace = _load_mappers()
+    int_to_float = namespace["INT_TO_FLOAT_MAPPER"]
+    float_to_int = namespace["FLOAT_TO_INT_MAPPER"]
+
+    # The base 4bit repo must resolve to the base model, not the instruct one.
+    assert int_to_float["unsloth/gemma-2b-bnb-4bit"] == "unsloth/gemma-2b"
+
+    # The instruct 4bit repo must be registered and resolve to the instruct model.
+    assert "unsloth/gemma-2b-it-bnb-4bit" in int_to_float
+    assert int_to_float["unsloth/gemma-2b-it-bnb-4bit"] == "unsloth/gemma-2b-it"
+
+    # The base model must reverse-map back to the base 4bit repo.
+    assert float_to_int["unsloth/gemma-2b"] == "unsloth/gemma-2b-bnb-4bit"
+    assert float_to_int["google/gemma-2b"] == "unsloth/gemma-2b-bnb-4bit"
+
+    # The instruct model must reverse-map to the instruct 4bit repo.
+    assert float_to_int["unsloth/gemma-2b-it"] == "unsloth/gemma-2b-it-bnb-4bit"
+    assert float_to_int["google/gemma-2b-it"] == "unsloth/gemma-2b-it-bnb-4bit"

--- a/unsloth/models/mapper.py
+++ b/unsloth/models/mapper.py
@@ -134,7 +134,7 @@ __INT_TO_FLOAT_MAPPER = \
         "unsloth/gemma-7b-it",
         "google/gemma-7b-it",
     ),
-    "unsloth/gemma-2b-bnb-4bit" : (
+    "unsloth/gemma-2b-it-bnb-4bit" : (
         "unsloth/gemma-2b-it",
         "google/gemma-2b-it",
     ),


### PR DESCRIPTION
### Summary

`__INT_TO_FLOAT_MAPPER` in `unsloth/models/mapper.py` has two entries keyed with the exact same string `"unsloth/gemma-2b-bnb-4bit"`:

```python
"unsloth/gemma-2b-bnb-4bit" : (          # line 129 (base)
    "unsloth/gemma-2b",
    "google/gemma-2b",
),
...
"unsloth/gemma-2b-bnb-4bit" : (          # line 137 (meant to be the instruct model)
    "unsloth/gemma-2b-it",
    "google/gemma-2b-it",
),
```

The line-137 entry was clearly meant to register the 4bit instruction-tuned model, but its key is missing the `-it` suffix (compare the adjacent `gemma-7b` pair, which correctly uses `unsloth/gemma-7b-bnb-4bit` and `unsloth/gemma-7b-it-bnb-4bit`). Because a Python dict literal keeps only the last value for a duplicate key, the base-model mapping is silently discarded.

### Impact

After the module builds `INT_TO_FLOAT_MAPPER` / `FLOAT_TO_INT_MAPPER` / `MAP_TO_UNSLOTH_16bit`:

- `INT_TO_FLOAT_MAPPER["unsloth/gemma-2b-bnb-4bit"]` resolves to `"unsloth/gemma-2b-it"`, so loading the base 4bit repo with `load_in_4bit=False` returns the **instruct** model instead of the base model.
- The base model loses its reverse mapping: `FLOAT_TO_INT_MAPPER` has no entry for `"unsloth/gemma-2b"` or `"google/gemma-2b"`, so the base model does not get routed to its 4x-faster 4bit repo.
- `"google/gemma-2b-it"` reverse-maps to the base 4bit repo.
- `"unsloth/gemma-2b-it-bnb-4bit"` is never registered at all.

### Fix

Give the instruct entry its correct key `"unsloth/gemma-2b-it-bnb-4bit"`, mirroring the `gemma-7b` base/it pattern. This is a one-line change; the value tuple is unchanged. The Hugging Face repo `unsloth/gemma-2b-it-bnb-4bit` exists (the mapping now points at a real model), and the new key does not collide with any existing entry.

Out of scope: there is also a duplicate `"unsloth/llama-2-7b-chat-bnb-4bit"` key, but both of its entries have identical values, so it is harmless redundancy and left untouched.

### Test

`mapper.py` has no imports, so the new `tests/test_gemma_2b_mapper_key.py` execs the module directly and asserts the base and instruct 4bit repos map to distinct models in both directions. It fails on the current code (the base repo resolves to the instruct model) and passes with this fix. It runs on CPU with no GPU, so it is wired into the Bucket-A CPU step in `consolidated-tests-ci.yml`.
