### PR TITLE
Harden Windows Pester install against missing PSGallery

### DIFF
--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -1610,6 +1610,13 @@ jobs:
       - name: Install Pester v5
         shell: pwsh
         run: |
+          # PSGallery is intermittently absent from the repository list on GitHub's Windows
+          # runners, which makes `Set-PSRepository PSGallery` fail with "No repository with the
+          # name 'PSGallery' was found." Re-register the default gallery first so the policy
+          # change and module install below always have a repository to target.
+          if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+            Register-PSRepository -Default -ErrorAction SilentlyContinue
+          }
           Set-PSRepository PSGallery -InstallationPolicy Trusted
           Install-Module Pester -MinimumVersion 5.5.0 -Force -SkipPublisherCheck -Scope CurrentUser
           Import-Module Pester -MinimumVersion 5.5.0


### PR DESCRIPTION
### Problem

The `setup.ps1 unit tests (VS 2026 / CMake guard)` job in this workflow intermittently fails on the `windows-latest` runner at the `Install Pester v5` step:

```
Set-PSRepository PSGallery -InstallationPolicy Trusted
  | No repository with the name 'PSGallery' was found.
##[error]Process completed with exit code 1.
```

The default PowerShell Gallery is occasionally not registered on GitHub's hosted Windows runners. `Set-PSRepository` only modifies an already-registered repository, so it throws before Pester can be installed and the whole job fails, even though nothing in the change under test is at fault.

### Fix

Re-register the default gallery when it is missing, before setting its policy and installing Pester:

```powershell
if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
  Register-PSRepository -Default -ErrorAction SilentlyContinue
}
Set-PSRepository PSGallery -InstallationPolicy Trusted
```

`Register-PSRepository -Default` recreates the built-in PSGallery entry, so the subsequent `Set-PSRepository` and `Install-Module` always have a repository to target. When PSGallery is already present (the common case) the guard is a no-op, so behavior is unchanged on healthy runners. This is the standard remedy for the "No repository with the name 'PSGallery' was found" error on hosted runners.

Only the `Install Pester v5` step is touched; the smoke jobs and Pester suite are unchanged.
