### PR TITLE
diffusion: compute int8/fp8_dynamic text-encoder quant + video wiring

### DIFF
--- a/scripts/build_prequant_checkpoint.py
+++ b/scripts/build_prequant_checkpoint.py
@@ -58,6 +58,7 @@ def main(argv = None) -> int:
         FP8_GRANULARITY,
         TQ_FP8,
         TQ_SCHEMES,
+        _SCALED_MM_SCHEMES,
         _make_quant_config,
         _resolve_fast_accum,
         exclude_tokens_for_scheme,
@@ -87,13 +88,23 @@ def main(argv = None) -> int:
     # bakes them as int8 and crashes (torch._int_mm needs M>16) at the first denoise step on
     # Flux / Qwen. fp8 / fp4 / mx use scaled_mm (no M limit) -> exclude_tokens_for_scheme returns ().
     exclude_name_tokens = exclude_tokens_for_scheme(scheme)
+    # The scaled_mm schemes (fp8 / nvfp4 / mxfp8) assert a bf16 weight, so their filter must skip any
+    # non-bf16 Linear the transformer keeps: a mixed-precision DiT (Wan / Hunyuan) retains its
+    # _keep_in_fp32_modules in fp32 even under torch_dtype=bf16, so quantising one would raise inside
+    # quantize_ and abort the whole pass. Runtime quantize_transformer gates this on scheme membership;
+    # mirror it here so the offline checkpoint quantises the exact same layer set (offline == runtime).
+    require_bf16 = scheme in _SCALED_MM_SCHEMES
     # fp8 bakes the accumulate mode into the saved kernels; record the resolved choice so the
     # loader can refuse a checkpoint whose baked value contradicts an explicit runtime request.
     fast_accum = _resolve_fast_accum(None) if scheme == TQ_FP8 else None
     quantize_(
         transformer,
         _make_quant_config(scheme),
-        filter_fn = make_filter_fn(args.min_features, exclude_name_tokens = exclude_name_tokens),
+        filter_fn = make_filter_fn(
+            args.min_features,
+            exclude_name_tokens = exclude_name_tokens,
+            require_bf16 = require_bf16,
+        ),
     )
 
     # Move the state dict to CPU for a portable, GPU-free artifact.
@@ -107,9 +118,11 @@ def main(argv = None) -> int:
         "scheme": scheme,
         "min_features": args.min_features,
         # The layers skipped for this scheme (int8's M=1 modulation projections; () for
-        # the scaled_mm schemes) and, for fp8, the baked accumulate mode. Both let the
-        # loader reject a checkpoint that would not match the runtime path.
+        # the scaled_mm schemes), whether non-bf16 Linears were skipped (the scaled_mm
+        # bf16 gate), and, for fp8, the baked accumulate mode. All let the loader reject a
+        # checkpoint that would not match the runtime path.
         "exclude_name_tokens": list(exclude_name_tokens),
+        "require_bf16": require_bf16,
         "fast_accum": fast_accum,
         "torch_dtype": args.dtype,
         "quant_backend": "torchao",

--- a/scripts/build_prequant_checkpoint.py
+++ b/scripts/build_prequant_checkpoint.py
@@ -58,7 +58,7 @@ def main(argv = None) -> int:
         FP8_GRANULARITY,
         TQ_FP8,
         TQ_SCHEMES,
-        _SCALED_MM_SCHEMES,
+        _REQUIRE_BF16_SCHEMES,
         _make_quant_config,
         _resolve_fast_accum,
         exclude_tokens_for_scheme,
@@ -88,12 +88,13 @@ def main(argv = None) -> int:
     # bakes them as int8 and crashes (torch._int_mm needs M>16) at the first denoise step on
     # Flux / Qwen. fp8 / fp4 / mx use scaled_mm (no M limit) -> exclude_tokens_for_scheme returns ().
     exclude_name_tokens = exclude_tokens_for_scheme(scheme)
-    # The scaled_mm schemes (fp8 / nvfp4 / mxfp8) assert a bf16 weight, so their filter must skip any
-    # non-bf16 Linear the transformer keeps: a mixed-precision DiT (Wan / Hunyuan) retains its
-    # _keep_in_fp32_modules in fp32 even under torch_dtype=bf16, so quantising one would raise inside
-    # quantize_ and abort the whole pass. Runtime quantize_transformer gates this on scheme membership;
-    # mirror it here so the offline checkpoint quantises the exact same layer set (offline == runtime).
-    require_bf16 = scheme in _SCALED_MM_SCHEMES
+    # fp8 and mxfp8 assert a bf16 weight, so their filter must skip any non-bf16 Linear the
+    # transformer keeps: a mixed-precision DiT (Wan / Hunyuan) retains its _keep_in_fp32_modules in
+    # fp32 even under torch_dtype=bf16, so quantising one would raise inside quantize_ and abort the
+    # whole pass. nvfp4 quantises fp32 fine, so it is not gated. Runtime quantize_transformer gates
+    # this on scheme membership; mirror it here so the offline checkpoint quantises the exact same
+    # layer set (offline == runtime).
+    require_bf16 = scheme in _REQUIRE_BF16_SCHEMES
     # fp8 bakes the accumulate mode into the saved kernels; record the resolved choice so the
     # loader can refuse a checkpoint whose baked value contradicts an explicit runtime request.
     fast_accum = _resolve_fast_accum(None) if scheme == TQ_FP8 else None

--- a/studio/backend/core/inference/diffusion.py
+++ b/studio/backend/core/inference/diffusion.py
@@ -1451,12 +1451,14 @@ class DiffusionBackend:
                             "compiled; eager torchao quant is ~30x slower than GGUF here",
                             transformer_quant_engaged,
                         )
-                    # Quantise the dense companion text encoder(s) (opt-in fp8 / nvfp4),
-                    # also before placement so the offload hooks move the smaller weights.
+                    # Quantise the dense companion text encoder(s) (opt-in fp8 / fp8_dynamic /
+                    # int8 / nvfp4), also before placement so the offload hooks move the smaller
+                    # weights. int8 needs a per-family keep-bf16 schedule, so pass the family.
                     te_quant = quantize_text_encoders(
                         pipe,
                         target,
                         mode = text_encoder_quant,
+                        family = fam.name,
                         logger = logger,
                     )
 

--- a/studio/backend/core/inference/diffusion.py
+++ b/studio/backend/core/inference/diffusion.py
@@ -1459,6 +1459,7 @@ class DiffusionBackend:
                         target,
                         mode = text_encoder_quant,
                         family = fam.name,
+                        offload_active = plan.offload_policy != OFFLOAD_NONE,
                         logger = logger,
                     )
 

--- a/studio/backend/core/inference/diffusion_precision.py
+++ b/studio/backend/core/inference/diffusion_precision.py
@@ -126,6 +126,7 @@ def quantize_text_encoders(
         return None
     if mode == TE_QUANT_INT8:
         first, last = skip  # type: ignore[misc]
+
         def caster(enc: Any, tgt: Any) -> None:
             _cast_int8_selective(enc, tgt, first, last)
     elif mode == TE_QUANT_FP8_DYNAMIC:
@@ -199,7 +200,7 @@ def _cast_int8_selective(encoder: Any, target: Any, skip_first: int, skip_last: 
             return False
         return not any(fqn == k or fqn.startswith(k + ".") for k in keep)
 
-    quantize_(encoder, _make_quant_config(TQ_INT8), filter_fn=filter_fn)
+    quantize_(encoder, _make_quant_config(TQ_INT8), filter_fn = filter_fn)
 
 
 def _cast_fp8_dynamic(encoder: Any, target: Any) -> None:
@@ -216,7 +217,7 @@ def _cast_fp8_dynamic(encoder: Any, target: Any) -> None:
     )
 
     filter_fn = make_filter_fn(DEFAULT_MIN_LINEAR_FEATURES, _te_exclude_tokens(encoder))
-    quantize_(encoder, _make_quant_config(TQ_FP8), filter_fn=filter_fn)
+    quantize_(encoder, _make_quant_config(TQ_FP8), filter_fn = filter_fn)
 
 
 def _cast_fp8(encoder: Any, target: Any) -> None:

--- a/studio/backend/core/inference/diffusion_precision.py
+++ b/studio/backend/core/inference/diffusion_precision.py
@@ -107,12 +107,15 @@ def quantize_text_encoders(
     *,
     mode: Optional[str],
     family: Optional[str] = None,
+    offload_active: bool = False,
     logger: Any = None,
 ) -> Optional[str]:
     """Quantise each present text encoder in place with ``mode`` (fp8 / fp8_dynamic / int8 / nvfp4).
     Returns the mode actually applied, or None when disabled, unsupported, or no encoder was cast.
     ``int8`` needs a per-family keep-bf16 schedule (``_TE_INT8_SKIP``); a family without one falls
-    back to ``fp8``. Best-effort: any failure leaves the encoder dense."""
+    back to ``fp8``. When ``offload_active`` the torchao modes are skipped (their tensor subclasses
+    reject the ``Module.to()`` an offload hook uses); layerwise ``fp8`` still engages. Best-effort:
+    any failure leaves the encoder dense."""
     mode = normalize_te_quant(mode)
     if mode is None:
         return None
@@ -122,6 +125,17 @@ def quantize_text_encoders(
         if skip is None:
             _note(logger, f"int8 has no keep-bf16 schedule for family '{family}'; using fp8")
             mode = TE_QUANT_FP8
+    # The torchao modes (int8 with a schedule, fp8_dynamic, nvfp4) produce tensor subclasses that
+    # reject Module.to(); an offload placement moves the encoder that way and hard-crashes -- the
+    # DiT path skips torchao quant under offload for exactly this reason. Layerwise fp8 is not
+    # torchao and streams fine, so it still engages. Skip the torchao modes under offload.
+    if offload_active and mode in (TE_QUANT_INT8, TE_QUANT_FP8_DYNAMIC, TE_QUANT_NVFP4):
+        _note(
+            logger,
+            f"text-encoder '{mode}' skipped under offload (torchao tensors reject Module.to()); "
+            "pin a resident memory mode or use fp8",
+        )
+        return None
     if not te_quant_supported(target, mode):
         return None
     if mode == TE_QUANT_INT8:

--- a/studio/backend/core/inference/diffusion_precision.py
+++ b/studio/backend/core/inference/diffusion_precision.py
@@ -233,9 +233,9 @@ def _cast_fp8_dynamic(encoder: Any, target: Any) -> None:
     # require_bf16: scaled_mm asserts a bf16 weight, so skip any stray non-bf16 Linear the encoder
     # keeps (belt-and-suspenders over the named T5 wo exclusion) rather than aborting the pass.
     filter_fn = make_filter_fn(
-        DEFAULT_MIN_LINEAR_FEATURES, _te_exclude_tokens(encoder), require_bf16=True
+        DEFAULT_MIN_LINEAR_FEATURES, _te_exclude_tokens(encoder), require_bf16 = True
     )
-    quantize_(encoder, _make_quant_config(TQ_FP8), filter_fn=filter_fn)
+    quantize_(encoder, _make_quant_config(TQ_FP8), filter_fn = filter_fn)
 
 
 def _cast_fp8(encoder: Any, target: Any) -> None:

--- a/studio/backend/core/inference/diffusion_precision.py
+++ b/studio/backend/core/inference/diffusion_precision.py
@@ -230,8 +230,12 @@ def _cast_fp8_dynamic(encoder: Any, target: Any) -> None:
         make_filter_fn,
     )
 
-    filter_fn = make_filter_fn(DEFAULT_MIN_LINEAR_FEATURES, _te_exclude_tokens(encoder))
-    quantize_(encoder, _make_quant_config(TQ_FP8), filter_fn = filter_fn)
+    # require_bf16: scaled_mm asserts a bf16 weight, so skip any stray non-bf16 Linear the encoder
+    # keeps (belt-and-suspenders over the named T5 wo exclusion) rather than aborting the pass.
+    filter_fn = make_filter_fn(
+        DEFAULT_MIN_LINEAR_FEATURES, _te_exclude_tokens(encoder), require_bf16=True
+    )
+    quantize_(encoder, _make_quant_config(TQ_FP8), filter_fn=filter_fn)
 
 
 def _cast_fp8(encoder: Any, target: Any) -> None:

--- a/studio/backend/core/inference/diffusion_precision.py
+++ b/studio/backend/core/inference/diffusion_precision.py
@@ -5,21 +5,29 @@
 
 The transformer arrives quantised in the GGUF, but the companion text encoder loads
 dense (bf16) from the base repo and is often the largest resident component (a Qwen3
-/ T5-XXL / Mistral encoder runs to many GB). This shrinks it in place, with two
+/ T5-XXL / Mistral encoder runs to many GB). This shrinks it in place, with four
 backends:
 
-  fp8   - diffusers layerwise casting: 8-bit (e4m3) storage, upcast per layer to the
-          compute dtype. ~2x smaller. Works on any fp8-capable CUDA card (cc >= 8.9).
-  nvfp4 - torchao NVFP4 weight-only: 4-bit float with two-level microscaling, run on
-          Blackwell's (sm_100+) FP4 tensor cores. ~4x smaller and the lowest-VRAM
-          option, but a steeper quality cost than fp8.
+  fp8         - diffusers layerwise casting: 8-bit (e4m3) storage, upcast per layer to
+                the compute dtype. ~2x smaller. Works on any fp8-capable CUDA card (cc >= 8.9).
+  fp8_dynamic - torchao dynamic fp8 COMPUTE (per-row): keeps the matmul in fp8 on the
+                fp8 tensor cores (torch._scaled_mm) instead of upcasting each forward.
+                ~2x smaller plus a tensor-core speedup; needs fp8-GEMM silicon (cc >= 8.9).
+  int8        - torchao dynamic int8 COMPUTE (per-token act + per-channel weight ->
+                torch._int_mm), with per-layer keep-bf16 selection. int8 degrades on large
+                encoders unless the most quant-sensitive decoder blocks stay bf16, so it is
+                applied only for families with a measured keep-bf16 schedule (else it falls
+                back to fp8). ~2x smaller; needs int8 tensor cores (cc >= 8.0).
+  nvfp4       - torchao NVFP4 weight-only: 4-bit float with two-level microscaling, run on
+                Blackwell's (sm_100+) FP4 tensor cores. ~4x smaller and the lowest-VRAM
+                option, but a steeper quality cost than fp8.
 
-Both keep normalisations / embeddings full precision and are a memory-vs-quality
-tradeoff, not free, so both are off by default. They pair especially well with
-streamed (group) offload, where the text encoder stays resident -- this is where the
-companion footprint dominates. Quantify the quality cost per model with the quality
-harness (scripts/diffusion_quality.py). torch / diffusers / torchao are imported
-lazily so the module stays importable in a no-torch runtime.
+All keep normalisations / embeddings full precision and are a memory-vs-quality tradeoff,
+not free, so all are off by default. They pair especially well with streamed (group)
+offload, where the text encoder stays resident -- this is where the companion footprint
+dominates. Quantify the quality cost per model with the quality harness
+(scripts/diffusion_quality.py). torch / diffusers / torchao are imported lazily so the
+module stays importable in a no-torch runtime.
 """
 
 from __future__ import annotations
@@ -28,10 +36,26 @@ from typing import Any, Optional
 
 TE_QUANT_FP8 = "fp8"
 TE_QUANT_NVFP4 = "nvfp4"
-TE_QUANT_MODES = (TE_QUANT_FP8, TE_QUANT_NVFP4)
+TE_QUANT_INT8 = "int8"
+TE_QUANT_FP8_DYNAMIC = "fp8_dynamic"
+TE_QUANT_MODES = (TE_QUANT_FP8, TE_QUANT_NVFP4, TE_QUANT_INT8, TE_QUANT_FP8_DYNAMIC)
 
 # Pipeline attributes that hold a text encoder, in order.
 _TEXT_ENCODER_ATTRS = ("text_encoder", "text_encoder_2", "text_encoder_3")
+
+# int8 (torch._int_mm) degrades on large text encoders unless the most quant-sensitive decoder
+# blocks stay bf16. Per-family (skip_first, skip_last) decoder blocks to keep dense, from measured
+# hidden-state fidelity (mean per-token cosine vs the bf16 reference, at the layer each pipeline
+# consumes): keeping the first blocks stops early-layer error seeding, keeping the last blocks
+# protects the read layer. Families absent here have no int8 schedule that clears the bar, so an
+# int8 request for them falls back to fp8.
+#   qwen-image (Qwen2.5-VL-7B): first+last 6 -> ~0.997 cosine (both ends needed; outlier-bound).
+#   flux.2-dev (Mistral-Small-24B): first 3 -> ~0.98 cosine (pure early-layer seeding).
+_TE_INT8_SKIP: dict[str, tuple[int, int]] = {
+    "qwen-image": (6, 6),
+    "qwen-image-edit": (6, 6),
+    "flux.2-dev": (3, 0),
+}
 
 
 def normalize_te_quant(value: Optional[str]) -> Optional[str]:
@@ -51,8 +75,9 @@ def normalize_te_quant(value: Optional[str]) -> Optional[str]:
 
 
 def te_quant_supported(target: Any, mode: str) -> bool:
-    """Whether ``mode`` is usable for ``target``: a CUDA device with a bf16 compute
-    dtype, plus fp8 dtype support (fp8) or Blackwell sm_100+ tensor cores (nvfp4)."""
+    """Whether ``mode`` is usable for ``target``: a CUDA device with a bf16 compute dtype, plus
+    the tensor-core class each backend needs -- fp8 dtype (fp8 layerwise), fp8 GEMM sm_89+
+    (fp8_dynamic), int8 tensor cores sm_80+ (int8), or Blackwell sm_100+ (nvfp4)."""
     if getattr(target, "device", None) != "cuda":
         return False
     try:
@@ -62,6 +87,12 @@ def te_quant_supported(target: Any, mode: str) -> bool:
             return False
         if mode == TE_QUANT_FP8:
             return hasattr(torch, "float8_e4m3fn")
+        if mode == TE_QUANT_FP8_DYNAMIC:
+            # Compute fp8 (torch._scaled_mm) needs fp8-GEMM silicon: Ada sm_89+ / Hopper / Blackwell.
+            return hasattr(torch, "float8_e4m3fn") and torch.cuda.get_device_capability() >= (8, 9)
+        if mode == TE_QUANT_INT8:
+            # int8 tensor cores (torch._int_mm) need Ampere sm_80+.
+            return torch.cuda.get_device_capability()[0] >= 8
         if mode == TE_QUANT_NVFP4:
             # NVFP4 tensor cores need Blackwell (compute capability major >= 10).
             return torch.cuda.get_device_capability()[0] >= 10
@@ -75,15 +106,34 @@ def quantize_text_encoders(
     target: Any,
     *,
     mode: Optional[str],
+    family: Optional[str] = None,
     logger: Any = None,
 ) -> Optional[str]:
-    """Quantise each present text encoder in place with ``mode`` (fp8 / nvfp4).
-    Returns the mode actually applied, or None when disabled, unsupported, or no
-    encoder was cast. Best-effort: any failure leaves the encoder dense."""
+    """Quantise each present text encoder in place with ``mode`` (fp8 / fp8_dynamic / int8 / nvfp4).
+    Returns the mode actually applied, or None when disabled, unsupported, or no encoder was cast.
+    ``int8`` needs a per-family keep-bf16 schedule (``_TE_INT8_SKIP``); a family without one falls
+    back to ``fp8``. Best-effort: any failure leaves the encoder dense."""
     mode = normalize_te_quant(mode)
-    if mode is None or not te_quant_supported(target, mode):
+    if mode is None:
         return None
-    caster = _cast_fp8 if mode == TE_QUANT_FP8 else _cast_nvfp4
+    skip: Optional[tuple[int, int]] = None
+    if mode == TE_QUANT_INT8:
+        skip = _TE_INT8_SKIP.get((family or "").lower())
+        if skip is None:
+            _note(logger, f"int8 has no keep-bf16 schedule for family '{family}'; using fp8")
+            mode = TE_QUANT_FP8
+    if not te_quant_supported(target, mode):
+        return None
+    if mode == TE_QUANT_INT8:
+        first, last = skip  # type: ignore[misc]
+        def caster(enc: Any, tgt: Any) -> None:
+            _cast_int8_selective(enc, tgt, first, last)
+    elif mode == TE_QUANT_FP8_DYNAMIC:
+        caster = _cast_fp8_dynamic
+    elif mode == TE_QUANT_NVFP4:
+        caster = _cast_nvfp4
+    else:
+        caster = _cast_fp8
     cast: list[str] = []
     for attr in _TEXT_ENCODER_ATTRS:
         encoder = getattr(pipe, attr, None)
@@ -95,6 +145,78 @@ def quantize_text_encoders(
         except Exception as exc:  # noqa: BLE001 — leave this encoder dense
             _warn(logger, f"{mode}:{attr}", exc)
     return mode if cast else None
+
+
+def _te_exclude_tokens(encoder: Any) -> tuple[str, ...]:
+    """fqn tokens whose Linears stay bf16 in a torchao text-encoder quant: the VLM vision tower
+    and the unused lm_head (not used for prompt encoding), plus the encoder's own fp32-kept
+    modules (T5 ``wo``, which the gated feed-forward reads the dtype of and which explodes in
+    low precision)."""
+    tokens = ["visual", "vision_tower", "lm_head"]
+    tokens += [str(m).lower() for m in (getattr(encoder, "_keep_in_fp32_modules", None) or ())]
+    return tuple(dict.fromkeys(tokens))
+
+
+def _keep_bf16_block_fqns(encoder: Any, skip_first: int, skip_last: int) -> set[str]:
+    """FQNs of the decoder blocks to keep bf16: the first ``skip_first`` and last ``skip_last`` of
+    each top-level ``nn.ModuleList`` stack (a T5 ``encoder.block`` / a decoder ``...layers``).
+    Structural, so it needs no per-architecture table."""
+    import torch
+
+    keep: set[str] = set()
+    for name, module in encoder.named_modules():
+        if not isinstance(module, torch.nn.ModuleList):
+            continue
+        n = len(module)
+        if n <= skip_first + skip_last:
+            continue
+        for i in list(range(skip_first)) + list(range(n - skip_last, n)):
+            keep.add(f"{name}.{i}" if name else str(i))
+    return keep
+
+
+def _cast_int8_selective(encoder: Any, target: Any, skip_first: int, skip_last: int) -> None:
+    # torchao dynamic int8 (per-token act + per-channel weight -> torch._int_mm) on the FLOP-heavy
+    # Linears, but keeping the first/last decoder blocks (and the vision tower / lm_head / T5 wo)
+    # in bf16. Reuses the committed transformer-quant factory so the config never drifts.
+    from torchao.quantization import quantize_
+    from .diffusion_transformer_quant import (
+        TQ_INT8,
+        DEFAULT_MIN_LINEAR_FEATURES,
+        _make_quant_config,
+        make_filter_fn,
+        exclude_tokens_for_scheme,
+    )
+
+    base = make_filter_fn(
+        DEFAULT_MIN_LINEAR_FEATURES,
+        exclude_tokens_for_scheme(TQ_INT8) + _te_exclude_tokens(encoder),
+    )
+    keep = _keep_bf16_block_fqns(encoder, skip_first, skip_last)
+
+    def filter_fn(module: Any, fqn: str = "") -> bool:
+        if not base(module, fqn):
+            return False
+        return not any(fqn == k or fqn.startswith(k + ".") for k in keep)
+
+    quantize_(encoder, _make_quant_config(TQ_INT8), filter_fn=filter_fn)
+
+
+def _cast_fp8_dynamic(encoder: Any, target: Any) -> None:
+    # torchao dynamic fp8 COMPUTE, per-row (per-token activation + per-output-channel weight ->
+    # torch._scaled_mm on the fp8 tensor cores). Unlike the layerwise `fp8` backend this keeps the
+    # matmul in fp8 instead of upcasting each forward. fp8 is robust across encoder sizes, so no
+    # per-layer keep-bf16 is needed; only the vision tower / lm_head / T5 wo are excluded.
+    from torchao.quantization import quantize_
+    from .diffusion_transformer_quant import (
+        TQ_FP8,
+        DEFAULT_MIN_LINEAR_FEATURES,
+        _make_quant_config,
+        make_filter_fn,
+    )
+
+    filter_fn = make_filter_fn(DEFAULT_MIN_LINEAR_FEATURES, _te_exclude_tokens(encoder))
+    quantize_(encoder, _make_quant_config(TQ_FP8), filter_fn=filter_fn)
 
 
 def _cast_fp8(encoder: Any, target: Any) -> None:
@@ -155,3 +277,8 @@ def _cast_nvfp4(encoder: Any, target: Any) -> None:
 def _warn(logger: Any, what: str, exc: Exception) -> None:
     if logger is not None:
         logger.warning("diffusion.precision: text-encoder quant (%s) failed: %s", what, exc)
+
+
+def _note(logger: Any, msg: str) -> None:
+    if logger is not None:
+        logger.info("diffusion.precision: %s", msg)

--- a/studio/backend/core/inference/diffusion_prequant.py
+++ b/studio/backend/core/inference/diffusion_prequant.py
@@ -329,15 +329,16 @@ def _validate_checkpoint(
                 ),
             )
             return False
-    # require_bf16 (skip non-bf16 Linears) is the scaled_mm bf16 gate, derived from the scheme's
-    # use of scaled_mm. Like exclude_name_tokens it is pinned by the scheme today, but recording and
-    # verifying it guards against a future _SCALED_MM_SCHEMES change silently loading a checkpoint
-    # built under the old filter (it would carry a different quantised layer set). Absent (older
-    # artifact) is accepted since scheme already pins today's gate.
+    # require_bf16 (skip non-bf16 Linears) is the bf16-weight gate, pinned by the scheme (fp8 and
+    # mxfp8 assert a bf16 weight; nvfp4 / int8 quantise fp32 fine). Like exclude_name_tokens it is
+    # pinned by the scheme today, but recording and verifying it guards against a future
+    # _REQUIRE_BF16_SCHEMES change silently loading a checkpoint built under the old filter (it would
+    # carry a different quantised layer set). Absent (older artifact) is accepted since scheme already
+    # pins today's gate.
     ckpt_require_bf16 = meta.get("require_bf16")
     if ckpt_require_bf16 is not None:
-        from .diffusion_transformer_quant import _SCALED_MM_SCHEMES
-        expected_require_bf16 = scheme in _SCALED_MM_SCHEMES
+        from .diffusion_transformer_quant import _REQUIRE_BF16_SCHEMES
+        expected_require_bf16 = scheme in _REQUIRE_BF16_SCHEMES
         if bool(ckpt_require_bf16) != expected_require_bf16:
             _warn(
                 logger,

--- a/studio/backend/core/inference/diffusion_prequant.py
+++ b/studio/backend/core/inference/diffusion_prequant.py
@@ -329,6 +329,24 @@ def _validate_checkpoint(
                 ),
             )
             return False
+    # require_bf16 (skip non-bf16 Linears) is the scaled_mm bf16 gate, derived from the scheme's
+    # use of scaled_mm. Like exclude_name_tokens it is pinned by the scheme today, but recording and
+    # verifying it guards against a future _SCALED_MM_SCHEMES change silently loading a checkpoint
+    # built under the old filter (it would carry a different quantised layer set). Absent (older
+    # artifact) is accepted since scheme already pins today's gate.
+    ckpt_require_bf16 = meta.get("require_bf16")
+    if ckpt_require_bf16 is not None:
+        from .diffusion_transformer_quant import _SCALED_MM_SCHEMES
+        expected_require_bf16 = scheme in _SCALED_MM_SCHEMES
+        if bool(ckpt_require_bf16) != expected_require_bf16:
+            _warn(
+                logger,
+                scheme,
+                ValueError(
+                    f"checkpoint require_bf16 {bool(ckpt_require_bf16)!r} != {expected_require_bf16!r}"
+                ),
+            )
+            return False
     # fp8 fast-accum is baked into the saved kernels; only enforce when the caller forces it.
     if fast_accum is not None:
         ckpt_fa = meta.get("fast_accum")

--- a/studio/backend/core/inference/diffusion_transformer_quant.py
+++ b/studio/backend/core/inference/diffusion_transformer_quant.py
@@ -37,6 +37,11 @@ TQ_AUTO = "auto"
 TQ_SCHEMES = (TQ_INT8, TQ_FP8, TQ_NVFP4, TQ_MXFP8)
 TQ_MODES = (TQ_AUTO,) + TQ_SCHEMES
 
+# Schemes whose kernels (torch._scaled_mm / the fp4 / mx GEMMs) assert a bf16 input weight, so their
+# quantise filter must skip non-bf16 Linears (see make_filter_fn's require_bf16). int8 (torch._int_mm)
+# is not in this set: it quantises fp32/fp16 weights fine.
+_SCALED_MM_SCHEMES = (TQ_FP8, TQ_NVFP4, TQ_MXFP8)
+
 # The fp8 weight/activation granularity the runtime config uses (see _make_quant_config):
 # per-ROW is REQUIRED for correctness on outlier-heavy DiTs. Stamped into a pre-quantized
 # fp8 checkpoint's metadata at build time and required by the loader, so a stale checkpoint
@@ -391,11 +396,23 @@ def _make_quant_config(scheme: str, fast_accum: Optional[bool] = None) -> Any:
     raise ValueError(f"unknown transformer quant scheme '{scheme}'")
 
 
-def make_filter_fn(min_features: int, exclude_name_tokens: tuple[str, ...] = ()):
+def make_filter_fn(
+    min_features: int,
+    exclude_name_tokens: tuple[str, ...] = (),
+    *,
+    require_bf16: bool = False,
+):
     """A torchao ``quantize_`` filter keeping only the FLOP-heavy linears: nn.Linear with both
     in/out features >= ``min_features`` AND whose fully-qualified name contains none of
     ``exclude_name_tokens`` (used by int8 to skip the M=1 modulation / conditioning-embedder
-    projections that crash ``torch._int_mm``). Hides the (module, fqn) callback arity."""
+    projections that crash ``torch._int_mm``). Hides the (module, fqn) callback arity.
+
+    ``require_bf16`` additionally skips any Linear whose weight is not bfloat16. The scaled_mm
+    schemes (fp8 / mxfp8 / nvfp4) assert a bf16 input weight, so a single non-bf16 Linear -- e.g.
+    the fp32 layers Wan / Hunyuan video DiTs keep for numerical stability -- otherwise raises inside
+    ``quantize_`` and aborts the ENTIRE pass, leaving the module silently dense. Gating those layers
+    out lets the scheme engage on the bf16 linears and skip the fp32 ones. int8 (torch._int_mm)
+    tolerates non-bf16 weights, so it leaves this off and keeps quantising them."""
 
     def filter_fn(module: Any, fqn: str = "") -> bool:
         try:
@@ -413,6 +430,11 @@ def make_filter_fn(min_features: int, exclude_name_tokens: tuple[str, ...] = ())
         if exclude_name_tokens:
             name = fqn.lower() if fqn else ""
             if any(tok in name for tok in exclude_name_tokens):
+                return False
+        if require_bf16:
+            import torch
+            weight = getattr(module, "weight", None)
+            if weight is None or weight.dtype != torch.bfloat16:
                 return False
         return True
 
@@ -446,12 +468,18 @@ def quantize_transformer(
         from torchao.quantization import quantize_
 
         # int8 (torch._int_mm, M>16) additionally skips the M=1 modulation / conditioning-embedder
-        # projections; fp8 / fp4 / mx (scaled_mm) have no such limit and quantise everything.
+        # projections; fp8 / fp4 / mx (scaled_mm) have no such limit and quantise everything -- but
+        # they assert a bf16 weight, so on a mixed-precision DiT (Wan / Hunyuan keep some fp32
+        # linears) they must skip the non-bf16 ones or the whole pass raises and no-ops.
         exclude = exclude_tokens_for_scheme(scheme)
         quantize_(
             transformer,
             _make_quant_config(scheme, fast_accum = fast_accum),
-            filter_fn = make_filter_fn(min_features, exclude_name_tokens = exclude),
+            filter_fn = make_filter_fn(
+                min_features,
+                exclude_name_tokens = exclude,
+                require_bf16 = scheme in _SCALED_MM_SCHEMES,
+            ),
         )
         # Runtime-only marker (torchao tensors are not safetensors-serializable; this
         # backend is inference-only, so this is purely diagnostic).

--- a/studio/backend/core/inference/diffusion_transformer_quant.py
+++ b/studio/backend/core/inference/diffusion_transformer_quant.py
@@ -37,10 +37,15 @@ TQ_AUTO = "auto"
 TQ_SCHEMES = (TQ_INT8, TQ_FP8, TQ_NVFP4, TQ_MXFP8)
 TQ_MODES = (TQ_AUTO,) + TQ_SCHEMES
 
-# Schemes whose kernels (torch._scaled_mm / the fp4 / mx GEMMs) assert a bf16 input weight, so their
-# quantise filter must skip non-bf16 Linears (see make_filter_fn's require_bf16). int8 (torch._int_mm)
-# is not in this set: it quantises fp32/fp16 weights fine.
-_SCALED_MM_SCHEMES = (TQ_FP8, TQ_NVFP4, TQ_MXFP8)
+# Schemes whose torchao path asserts a bf16 weight, so their quantise filter must skip
+# non-bf16 Linears (see make_filter_fn's require_bf16) rather than aborting the whole pass on a
+# stray fp32 Linear (e.g. T5's fp32 `wo`). Verified on torchao 0.17 / B200: fp8 per-row asserts
+# "PerRow quantization only works for bfloat16 precision input weight" and mxfp8 asserts
+# "Only supporting bf16 out dtype", but NVFP4's high-precision conversion quantises an fp32
+# weight fine (forward included) -- so nvfp4 is deliberately NOT gated here, keeping those fp32
+# projections quantised instead of leaving them dense. int8 (torch._int_mm) also quantises
+# fp32/fp16 weights fine, so it is not gated either.
+_REQUIRE_BF16_SCHEMES = (TQ_FP8, TQ_MXFP8)
 
 # The fp8 weight/activation granularity the runtime config uses (see _make_quant_config):
 # per-ROW is REQUIRED for correctness on outlier-heavy DiTs. Stamped into a pre-quantized
@@ -469,8 +474,9 @@ def quantize_transformer(
 
         # int8 (torch._int_mm, M>16) additionally skips the M=1 modulation / conditioning-embedder
         # projections; fp8 / fp4 / mx (scaled_mm) have no such limit and quantise everything -- but
-        # they assert a bf16 weight, so on a mixed-precision DiT (Wan / Hunyuan keep some fp32
-        # linears) they must skip the non-bf16 ones or the whole pass raises and no-ops.
+        # fp8 and mxfp8 assert a bf16 weight, so on a mixed-precision DiT (Wan / Hunyuan keep some
+        # fp32 linears) they must skip the non-bf16 ones or the whole pass raises and no-ops. nvfp4
+        # quantises fp32 weights fine, so it is not gated (see _REQUIRE_BF16_SCHEMES).
         exclude = exclude_tokens_for_scheme(scheme)
         quantize_(
             transformer,
@@ -478,7 +484,7 @@ def quantize_transformer(
             filter_fn = make_filter_fn(
                 min_features,
                 exclude_name_tokens = exclude,
-                require_bf16 = scheme in _SCALED_MM_SCHEMES,
+                require_bf16 = scheme in _REQUIRE_BF16_SCHEMES,
             ),
         )
         # Runtime-only marker (torchao tensors are not safetensors-serializable; this

--- a/studio/backend/core/inference/video.py
+++ b/studio/backend/core/inference/video.py
@@ -78,6 +78,7 @@ from .diffusion_transformer_quant import (
     quantize_transformer,
     select_transformer_quant_scheme,
 )
+from .diffusion_precision import normalize_te_quant, quantize_text_encoders
 from .video_families import (
     VIDEO_CANCELLED_MSG,
     VIDEO_NOT_LOADED_MSG,
@@ -233,6 +234,10 @@ class _VideoLoadState:
     # load the dense DiT(s) can be torchao-quantised in place onto the low-precision
     # tensor cores; None means they run at their loaded (bf16) precision.
     transformer_quant: Optional[str] = None
+    # Text-encoder quant actually engaged ("fp8" | "fp8_dynamic" | "int8" | "nvfp4") or None.
+    # The companion text encoder (UMT5 / Gemma3 / Qwen2.5-VL) loads dense bf16 and is often the
+    # largest resident component; this shrinks it in place, mirroring the image backend.
+    text_encoder_quant: Optional[str] = None
     resolved: Optional[dict] = None
 
 
@@ -337,6 +342,7 @@ class VideoBackend:
         family_override: Optional[str] = None,
         model_kind: Optional[str] = None,
         transformer_quant: Optional[str] = None,
+        text_encoder_quant: Optional[str] = None,
     ) -> VideoFamily:
         """Cheap, network-free validation shared by the route and the load path."""
         kind = resolve_video_model_kind(gguf_filename, model_kind)
@@ -396,6 +402,9 @@ class VideoBackend:
         # only on pipeline-kind loads (the dense DiT from the base repo); an ignored value
         # on a gguf/single_file load is left to the loader, matching the image backend.
         normalize_transformer_quant(transformer_quant)
+        # Reject a malformed text_encoder_quant the same way (applies to any load kind: the dense
+        # text encoder is resident for pipeline / gguf / single_file alike).
+        normalize_te_quant(text_encoder_quant)
         _ensure_mp4_encoder_available()
         return fam
 
@@ -415,6 +424,7 @@ class VideoBackend:
         transformer_cache: Optional[str] = None,
         transformer_cache_threshold: Optional[float] = None,
         transformer_quant: Optional[str] = None,
+        text_encoder_quant: Optional[str] = None,
         model_kind: Optional[str] = None,
     ) -> dict[str, Any]:
         """Validate, then run the (slow) load on a daemon thread. Returns at once."""
@@ -426,6 +436,7 @@ class VideoBackend:
             family_override = family_override,
             model_kind = model_kind,
             transformer_quant = transformer_quant,
+            text_encoder_quant = text_encoder_quant,
         )
         with self._lock:
             if self._loading is not None and self._loading.error is None:
@@ -449,6 +460,7 @@ class VideoBackend:
                 transformer_cache = transformer_cache,
                 transformer_cache_threshold = transformer_cache_threshold,
                 transformer_quant = transformer_quant,
+                text_encoder_quant = text_encoder_quant,
                 model_kind = model_kind,
                 _load_token = token,
             ),
@@ -748,6 +760,7 @@ class VideoBackend:
         transformer_cache: Optional[str] = None,
         transformer_cache_threshold: Optional[float] = None,
         transformer_quant: Optional[str] = None,
+        text_encoder_quant: Optional[str] = None,
         model_kind: Optional[str] = None,
         _load_token: Optional[int] = None,
         _base_local_dir: Optional[str] = None,
@@ -762,6 +775,7 @@ class VideoBackend:
             family_override = family_override,
             model_kind = model_kind,
             transformer_quant = transformer_quant,
+            text_encoder_quant = text_encoder_quant,
         )
         kind = resolve_video_model_kind(gguf_filename, model_kind)
         base = repo_id if kind == "pipeline" else resolve_video_base_repo(fam, base_repo)
@@ -1022,6 +1036,21 @@ class VideoBackend:
         if quant_replanned and transformer_quant_engaged is None:
             plan = bf16_plan
 
+        # ── dense text-encoder quant (opt-in): the DiT arrives quantised in a GGUF, but the
+        # companion encoder (Gemma3 / UMT5 / Qwen2.5-VL) loads dense bf16 from the base repo and
+        # is often the largest resident component. Quantise it in place, mirroring the image
+        # backend (diffusion.py): applied for every kind (the encoder is dense regardless of how
+        # the DiT was sourced) and before placement so the offload hooks move the smaller weights.
+        # Best-effort: quantize_text_encoders leaves any encoder it can't cast dense. int8 needs a
+        # per-family keep-bf16 schedule, so the family name is passed.
+        text_encoder_quant_engaged = quantize_text_encoders(
+            pipe,
+            target,
+            mode = text_encoder_quant,
+            family = fam.name,
+            logger = logger,
+        )
+
         # ── optimisation layers, in the image backend's order: step cache FIRST
         # (compile keys its fullgraph decision off an active cache: FBCache hooks
         # graph-break, so compiling fullgraph before installing the cache crashes
@@ -1186,6 +1215,13 @@ class VideoBackend:
                         else "not engaged (dense bf16 DiT loaded)"
                     ),
                 ),
+                "text_encoder_quant": (
+                    text_encoder_quant,
+                    text_encoder_quant_engaged or "off",
+                    "dense text encoder quantised in place"
+                    if text_encoder_quant_engaged is not None
+                    else "not engaged (dense bf16 text encoder loaded)",
+                ),
             }
         )
 
@@ -1218,6 +1254,7 @@ class VideoBackend:
                 cache_quant_active = cache_quant_active,
                 cache_threshold = transformer_cache_threshold,
                 transformer_quant = transformer_quant_engaged,
+                text_encoder_quant = text_encoder_quant_engaged,
                 resolved = resolved,
             )
             # Ownership of the globals transferred to _state / _teardown_state.
@@ -1568,6 +1605,7 @@ class VideoBackend:
                 "attention_backend": None,
                 "transformer_cache": None,
                 "transformer_quant": None,
+                "text_encoder_quant": None,
                 "has_audio": False,
                 "defaults": None,
                 "resolved": None,
@@ -1592,6 +1630,7 @@ class VideoBackend:
             "attention_backend": state.attention_backend,
             "transformer_cache": state.transformer_cache,
             "transformer_quant": state.transformer_quant,
+            "text_encoder_quant": state.text_encoder_quant,
             "has_audio": fam.has_audio,
             "defaults": {
                 "steps": default_steps,

--- a/studio/backend/core/inference/video.py
+++ b/studio/backend/core/inference/video.py
@@ -1048,6 +1048,7 @@ class VideoBackend:
             target,
             mode = text_encoder_quant,
             family = fam.name,
+            offload_active = plan.offload_policy != "none",
             logger = logger,
         )
 

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -1743,12 +1743,13 @@ class DiffusionLoadRequest(BaseModel):
         "default (also regional torch.compile where eligible), "
         "max (also TF32 + fused QKV).",
     )
-    text_encoder_quant: Optional[Literal["fp8", "nvfp4"]] = Field(
+    text_encoder_quant: Optional[Literal["fp8", "fp8_dynamic", "int8", "nvfp4"]] = Field(
         None,
-        description = "Quantise the companion text encoder(s): fp8 (~2x smaller, "
-        "CUDA cc>=8.9) or nvfp4 (~4x smaller, Blackwell sm_100+). A "
-        "memory-vs-quality tradeoff (shifts fine detail), not free; "
-        "pairs well with balanced mode.",
+        description = "Quantise the companion text encoder(s): fp8 (layerwise cast, ~2x smaller, "
+        "CUDA cc>=8.9), fp8_dynamic (torchao compute fp8 on the tensor cores, ~2x + faster, "
+        "cc>=8.9), int8 (torchao compute int8 with per-family keep-bf16 layers; falls back to "
+        "fp8 where no schedule exists; cc>=8.0), or nvfp4 (~4x smaller, Blackwell sm_100+). A "
+        "memory-vs-quality tradeoff (shifts fine detail), not free; pairs well with balanced mode.",
     )
     transformer_quant: Optional[Literal["auto", "none", "off", "int8", "fp8", "nvfp4", "mxfp8"]] = (
         Field(
@@ -2341,6 +2342,16 @@ class VideoLoadRequest(BaseModel):
             "backend's transformer_quant field.",
         )
     )
+    text_encoder_quant: Optional[Literal["fp8", "fp8_dynamic", "int8", "nvfp4"]] = Field(
+        None,
+        description = "Quantise the dense companion text encoder (Gemma3 / UMT5 / Qwen2.5-VL), "
+        "which loads bf16 from the base repo regardless of how the DiT was sourced and is often "
+        "the largest resident component. fp8 = diffusers layerwise casting (memory only, cc >= "
+        "8.9); fp8_dynamic = torchao per-row fp8 COMPUTE on the tensor cores (cc >= 8.9); int8 = "
+        "torchao int8 COMPUTE with per-family keep-bf16 selection (cc >= 8.0; falls back to fp8 "
+        "for a family without a measured schedule); nvfp4 = torchao 4-bit weight-only (Blackwell "
+        "sm_100+). null keeps the encoder dense. Mirrors the image backend's field.",
+    )
 
     @field_validator("attention_backend", mode = "before")
     @classmethod
@@ -2505,6 +2516,12 @@ class VideoStatusResponse(BaseModel):
         description = "Dense transformer quant engaged on a pipeline load: int8 | fp8 | nvfp4 | "
         "mxfp8 | null (null = the DiT(s) run at their loaded bf16 precision). For a dual-expert "
         "MoE family both experts share the reported scheme.",
+    )
+    text_encoder_quant: Optional[str] = Field(
+        None,
+        description = "Text-encoder quant engaged: fp8 | fp8_dynamic | int8 | nvfp4 | null "
+        "(null = the dense bf16 encoder is loaded). An int8 request without a per-family "
+        "keep-bf16 schedule is reported as the fp8 it fell back to.",
     )
     has_audio: bool = Field(
         False, description = "Whether the loaded family produces a synchronized audio track"

--- a/studio/backend/routes/video.py
+++ b/studio/backend/routes/video.py
@@ -95,6 +95,7 @@ async def load_video_model(
             family_override = request.family_override,
             model_kind = request.model_kind,
             transformer_quant = request.transformer_quant,
+            text_encoder_quant = request.text_encoder_quant,
         )
         # Refuse while training is running: a multi-GB video pipeline would compete
         # with the training subprocess for VRAM. Mirrors the image-load guard.
@@ -123,6 +124,7 @@ async def load_video_model(
             transformer_cache = request.transformer_cache,
             transformer_cache_threshold = request.transformer_cache_threshold,
             transformer_quant = request.transformer_quant,
+            text_encoder_quant = request.text_encoder_quant,
             model_kind = request.model_kind,
         )
         return VideoStatusResponse(**status_dict)

--- a/studio/backend/tests/test_diffusion_precision.py
+++ b/studio/backend/tests/test_diffusion_precision.py
@@ -14,9 +14,14 @@ import types
 
 import pytest
 
+import core.inference.diffusion_precision as dp
 from core.inference.diffusion_precision import (
     TE_QUANT_FP8,
+    TE_QUANT_FP8_DYNAMIC,
+    TE_QUANT_INT8,
     TE_QUANT_NVFP4,
+    _cast_int8_selective,
+    _keep_bf16_block_fqns,
     normalize_te_quant,
     quantize_text_encoders,
     te_quant_supported,
@@ -44,8 +49,12 @@ def _stub_torch(
     if with_fp8:
         torch.float8_e4m3fn = "float8_e4m3fn"
     # _cast_fp8 skips nn.Embedding tables (skip_modules_classes) to keep prompt
-    # tokens full precision, so the stub torch must expose torch.nn.Embedding.
-    torch.nn = types.SimpleNamespace(Embedding = type("Embedding", (), {}))
+    # tokens full precision, and _keep_bf16_block_fqns walks for nn.ModuleList block
+    # stacks, so the stub torch must expose both.
+    torch.nn = types.SimpleNamespace(
+        Embedding = type("Embedding", (), {}),
+        ModuleList = type("ModuleList", (list,), {}),
+    )
     torch.cuda = types.SimpleNamespace(get_device_capability = lambda *a: cc)
     monkeypatch.setitem(sys.modules, "torch", torch)
     return torch
@@ -77,6 +86,9 @@ def test_normalize_te_quant():
     assert normalize_te_quant("none") is None
     assert normalize_te_quant("FP8") == TE_QUANT_FP8
     assert normalize_te_quant("NVFP4") == TE_QUANT_NVFP4
+    assert normalize_te_quant("int8") == TE_QUANT_INT8
+    # Hyphens fold to underscores so "fp8-dynamic" is accepted.
+    assert normalize_te_quant("FP8-Dynamic") == TE_QUANT_FP8_DYNAMIC
     with pytest.raises(ValueError):
         normalize_te_quant("int2")
 
@@ -97,6 +109,31 @@ def test_nvfp4_supported_requires_blackwell(monkeypatch):
     # Hopper (cc 9.0) has no NVFP4 tensor cores.
     _stub_torch(monkeypatch, cc = (9, 0))
     assert te_quant_supported(_target(), TE_QUANT_NVFP4) is False
+
+
+def test_int8_supported_requires_sm80(monkeypatch):
+    # int8 tensor cores (torch._int_mm) need Ampere sm_80+.
+    _stub_torch(monkeypatch, cc = (8, 0))
+    assert te_quant_supported(_target(), TE_QUANT_INT8) is True
+    _stub_torch(monkeypatch, cc = (7, 5))
+    assert te_quant_supported(_target(), TE_QUANT_INT8) is False
+    # Still needs CUDA + bf16 like every mode.
+    _stub_torch(monkeypatch, cc = (8, 0))
+    assert te_quant_supported(_target(device = "cpu"), TE_QUANT_INT8) is False
+
+
+def test_fp8_dynamic_supported_requires_sm89_and_fp8(monkeypatch):
+    # Compute fp8 (torch._scaled_mm) needs fp8-GEMM silicon: Ada sm_89+ / Hopper / Blackwell.
+    _stub_torch(monkeypatch, cc = (8, 9))
+    assert te_quant_supported(_target(), TE_QUANT_FP8_DYNAMIC) is True
+    _stub_torch(monkeypatch, cc = (9, 0))
+    assert te_quant_supported(_target(), TE_QUANT_FP8_DYNAMIC) is True
+    # Ampere (8.0) has int8 but not fp8 GEMM.
+    _stub_torch(monkeypatch, cc = (8, 0))
+    assert te_quant_supported(_target(), TE_QUANT_FP8_DYNAMIC) is False
+    # No fp8 dtype at all -> unsupported regardless of arch.
+    _stub_torch(monkeypatch, with_fp8 = False, cc = (9, 0))
+    assert te_quant_supported(_target(), TE_QUANT_FP8_DYNAMIC) is False
 
 
 # ── apply ─────────────────────────────────────────────────────────────────────
@@ -155,3 +192,131 @@ def test_quantize_tolerates_caster_failure(monkeypatch):
     pipe = types.SimpleNamespace(text_encoder = object())
     # The only encoder fails to cast -> nothing applied -> None.
     assert quantize_text_encoders(pipe, _target(), mode = "fp8") is None
+
+
+# ── int8 (selective) + fp8_dynamic routing ─────────────────────────────────────
+
+
+def test_quantize_int8_uses_family_keep_bf16_schedule(monkeypatch):
+    # int8 for a family with a measured schedule routes to the selective caster with
+    # that family's (skip_first, skip_last); qwen-image keeps first+last 6 blocks bf16.
+    _stub_torch(monkeypatch, cc = (10, 0))
+    calls: list = []
+    monkeypatch.setattr(
+        dp, "_cast_int8_selective", lambda enc, tgt, first, last: calls.append((enc, first, last))
+    )
+    te = object()
+    pipe = types.SimpleNamespace(text_encoder = te)
+    mode = quantize_text_encoders(pipe, _target(), mode = "int8", family = "qwen-image")
+    assert mode == TE_QUANT_INT8
+    assert calls == [(te, 6, 6)]
+
+
+def test_quantize_int8_unknown_family_falls_back_to_fp8(monkeypatch):
+    # A family without an int8 keep-bf16 schedule falls back to layerwise fp8 (logged),
+    # never silently running full int8 that would degrade the encoder.
+    _stub_torch(monkeypatch, cc = (10, 0))
+    int8_calls: list = []
+    fp8_calls: list = []
+    monkeypatch.setattr(dp, "_cast_int8_selective", lambda *a: int8_calls.append(a))
+    monkeypatch.setattr(dp, "_cast_fp8", lambda enc, tgt: fp8_calls.append(enc))
+    te = object()
+    pipe = types.SimpleNamespace(text_encoder = te)
+    mode = quantize_text_encoders(pipe, _target(), mode = "int8", family = "wan-umt5")
+    assert mode == TE_QUANT_FP8
+    assert int8_calls == [] and fp8_calls == [te]
+
+
+def test_quantize_fp8_dynamic_uses_compute_caster(monkeypatch):
+    # fp8_dynamic routes to the torchao per-row compute caster (not the layerwise one)
+    # and needs no per-family schedule.
+    _stub_torch(monkeypatch, cc = (9, 0))
+    calls: list = []
+    monkeypatch.setattr(dp, "_cast_fp8_dynamic", lambda enc, tgt: calls.append(enc))
+    te = object()
+    pipe = types.SimpleNamespace(text_encoder = te)
+    mode = quantize_text_encoders(pipe, _target(), mode = "fp8_dynamic")
+    assert mode == TE_QUANT_FP8_DYNAMIC
+    assert calls == [te]
+
+
+def test_quantize_int8_unsupported_hw_is_noop(monkeypatch):
+    # int8 on pre-Ampere silicon (no int8 tensor cores) applies nothing.
+    _stub_torch(monkeypatch, cc = (7, 5))
+    monkeypatch.setattr(dp, "_cast_int8_selective", lambda *a: pytest.fail("must not cast"))
+    pipe = types.SimpleNamespace(text_encoder = object())
+    assert quantize_text_encoders(pipe, _target(), mode = "int8", family = "qwen-image") is None
+
+
+# ── block selection + real int8 filter closure ─────────────────────────────────
+
+
+def test_keep_bf16_block_fqns_selects_first_and_last(monkeypatch):
+    torch = _stub_torch(monkeypatch)
+    module_list = torch.nn.ModuleList
+    layers = module_list([object() for _ in range(10)])
+    # A short stack (<= skip_first + skip_last) contributes nothing (keeping it all would
+    # leave no interior to quantise).
+    short = module_list([object() for _ in range(4)])
+    enc = types.SimpleNamespace()
+    enc.named_modules = lambda: [("", enc), ("model.layers", layers), ("aux.blocks", short)]
+    keep = _keep_bf16_block_fqns(enc, 3, 2)
+    assert keep == {
+        "model.layers.0",
+        "model.layers.1",
+        "model.layers.2",
+        "model.layers.8",
+        "model.layers.9",
+    }
+
+
+def _stub_transformer_quant(monkeypatch, captured):
+    # Reuse the committed factory's names but record what the int8 caster hands quantize_().
+    dtq = types.ModuleType("core.inference.diffusion_transformer_quant")
+    dtq.TQ_INT8 = "int8"
+    dtq.TQ_FP8 = "fp8"
+    dtq.DEFAULT_MIN_LINEAR_FEATURES = 512
+    dtq._make_quant_config = lambda scheme, *a, **k: f"cfg:{scheme}"
+    dtq.exclude_tokens_for_scheme = lambda scheme: ("modulation",)
+
+    def _make_filter_fn(min_features, exclude_name_tokens = ()):
+        def _f(module, fqn = ""):
+            return not any(tok in fqn for tok in exclude_name_tokens)
+
+        return _f
+
+    dtq.make_filter_fn = _make_filter_fn
+    monkeypatch.setitem(sys.modules, "core.inference.diffusion_transformer_quant", dtq)
+
+    tq = types.ModuleType("torchao.quantization")
+
+    def _quantize_(module, config, filter_fn = None):
+        captured["config"] = config
+        captured["filter_fn"] = filter_fn
+
+    tq.quantize_ = _quantize_
+    monkeypatch.setitem(sys.modules, "torchao.quantization", tq)
+
+
+def test_int8_filter_keeps_blocks_and_towers_dense(monkeypatch):
+    # The real selective closure: interior Linears quantise, but the kept first blocks,
+    # the vision tower, lm_head, and the encoder's fp32-kept modules (T5 "wo") stay bf16.
+    torch = _stub_torch(monkeypatch)
+    captured: dict = {}
+    _stub_transformer_quant(monkeypatch, captured)
+    layers = torch.nn.ModuleList([object() for _ in range(8)])
+    enc = types.SimpleNamespace(_keep_in_fp32_modules = ["wo"])
+    enc.named_modules = lambda: [("model.layers", layers)]
+
+    _cast_int8_selective(enc, _target(), 3, 0)
+    assert captured["config"] == "cfg:int8"
+    ff = captured["filter_fn"]
+    # Kept first-3 decoder blocks stay bf16.
+    assert ff(object(), "model.layers.0.self_attn.q_proj") is False
+    assert ff(object(), "model.layers.2.mlp.gate_proj") is False
+    # An interior block is quantised.
+    assert ff(object(), "model.layers.5.self_attn.q_proj") is True
+    # Vision tower / lm_head / T5 wo are excluded by the shared token filter.
+    assert ff(object(), "visual.blocks.0.attn.qkv") is False
+    assert ff(object(), "lm_head") is False
+    assert ff(object(), "model.decoder.wo") is False

--- a/studio/backend/tests/test_diffusion_precision.py
+++ b/studio/backend/tests/test_diffusion_precision.py
@@ -254,9 +254,13 @@ def test_quantize_te_skips_torchao_modes_under_offload(monkeypatch):
     # path skips torchao quant for the same reason). Hardware supports every mode here, so a None
     # result proves the offload skip, not a capability gate; the casters fail if wrongly invoked.
     _stub_torch(monkeypatch, cc = (10, 0))
-    monkeypatch.setattr(dp, "_cast_fp8_dynamic", lambda *a: pytest.fail("torchao caster must not run"))
+    monkeypatch.setattr(
+        dp, "_cast_fp8_dynamic", lambda *a: pytest.fail("torchao caster must not run")
+    )
     monkeypatch.setattr(dp, "_cast_nvfp4", lambda *a: pytest.fail("torchao caster must not run"))
-    monkeypatch.setattr(dp, "_cast_int8_selective", lambda *a: pytest.fail("torchao caster must not run"))
+    monkeypatch.setattr(
+        dp, "_cast_int8_selective", lambda *a: pytest.fail("torchao caster must not run")
+    )
     pipe = types.SimpleNamespace(text_encoder = object())
     assert quantize_text_encoders(pipe, _target(), mode = "fp8_dynamic", offload_active = True) is None
     assert quantize_text_encoders(pipe, _target(), mode = "nvfp4", offload_active = True) is None

--- a/studio/backend/tests/test_diffusion_precision.py
+++ b/studio/backend/tests/test_diffusion_precision.py
@@ -290,7 +290,11 @@ def _stub_transformer_quant(monkeypatch, captured):
 
     tq = types.ModuleType("torchao.quantization")
 
-    def _quantize_(module, config, filter_fn = None):
+    def _quantize_(
+        module,
+        config,
+        filter_fn = None,
+    ):
         captured["config"] = config
         captured["filter_fn"] = filter_fn
 

--- a/studio/backend/tests/test_diffusion_precision.py
+++ b/studio/backend/tests/test_diffusion_precision.py
@@ -248,6 +248,31 @@ def test_quantize_int8_unsupported_hw_is_noop(monkeypatch):
     assert quantize_text_encoders(pipe, _target(), mode = "int8", family = "qwen-image") is None
 
 
+def test_quantize_te_skips_torchao_modes_under_offload(monkeypatch):
+    # The torchao modes (int8-with-schedule / fp8_dynamic / nvfp4) produce tensor subclasses that
+    # reject Module.to(), which an offload hook uses, so they must be skipped under offload (the DiT
+    # path skips torchao quant for the same reason). Hardware supports every mode here, so a None
+    # result proves the offload skip, not a capability gate; the casters fail if wrongly invoked.
+    _stub_torch(monkeypatch, cc = (10, 0))
+    monkeypatch.setattr(dp, "_cast_fp8_dynamic", lambda *a: pytest.fail("torchao caster must not run"))
+    monkeypatch.setattr(dp, "_cast_nvfp4", lambda *a: pytest.fail("torchao caster must not run"))
+    monkeypatch.setattr(dp, "_cast_int8_selective", lambda *a: pytest.fail("torchao caster must not run"))
+    pipe = types.SimpleNamespace(text_encoder = object())
+    assert quantize_text_encoders(pipe, _target(), mode = "fp8_dynamic", offload_active = True) is None
+    assert quantize_text_encoders(pipe, _target(), mode = "nvfp4", offload_active = True) is None
+    assert (
+        quantize_text_encoders(
+            pipe, _target(), mode = "int8", family = "qwen-image", offload_active = True
+        )
+        is None
+    )
+    # Layerwise fp8 is not torchao and streams fine under offload, so it still engages.
+    fp8_calls: list = []
+    monkeypatch.setattr(dp, "_cast_fp8", lambda enc, tgt: fp8_calls.append(enc))
+    assert quantize_text_encoders(pipe, _target(), mode = "fp8", offload_active = True) == TE_QUANT_FP8
+    assert len(fp8_calls) == 1
+
+
 # ── block selection + real int8 filter closure ─────────────────────────────────
 
 

--- a/studio/backend/tests/test_diffusion_prequant.py
+++ b/studio/backend/tests/test_diffusion_prequant.py
@@ -286,6 +286,28 @@ def test_load_exclude_tokens_match_ok(monkeypatch, tmp_path):
     assert _load(monkeypatch, tmp_path, ckpt, scheme = "int8") is not None
 
 
+def test_load_require_bf16_mismatch_is_none(monkeypatch, tmp_path):
+    # An fp8 (scaled_mm) checkpoint built WITHOUT the bf16 gate quantised a different layer set
+    # than the runtime filter now produces, so it must be rejected rather than loaded.
+    ckpt = _good_ckpt(scheme = "fp8")
+    ckpt["metadata"]["require_bf16"] = False
+    assert _load(monkeypatch, tmp_path, ckpt, scheme = "fp8") is None
+
+
+def test_load_require_bf16_match_ok(monkeypatch, tmp_path):
+    ckpt = _good_ckpt(scheme = "fp8")
+    ckpt["metadata"]["require_bf16"] = True
+    assert _load(monkeypatch, tmp_path, ckpt, scheme = "fp8") is not None
+
+
+def test_load_require_bf16_int8_true_is_none(monkeypatch, tmp_path):
+    # int8 (torch._int_mm) tolerates non-bf16 weights, so it never sets the gate; a checkpoint
+    # claiming it did contradicts the runtime filter and must be rejected.
+    ckpt = _good_ckpt(scheme = "int8")
+    ckpt["metadata"]["require_bf16"] = True
+    assert _load(monkeypatch, tmp_path, ckpt, scheme = "int8") is None
+
+
 def test_resolve_checkpoint_path_expands_user(monkeypatch, tmp_path):
     # The allowlist gate expands ~, so the existence check must too, or a "~/..." checkpoint
     # that passed the gate is silently skipped.

--- a/studio/backend/tests/test_diffusion_prequant.py
+++ b/studio/backend/tests/test_diffusion_prequant.py
@@ -308,6 +308,22 @@ def test_load_require_bf16_int8_true_is_none(monkeypatch, tmp_path):
     assert _load(monkeypatch, tmp_path, ckpt, scheme = "int8") is None
 
 
+def test_load_require_bf16_nvfp4_false_ok(monkeypatch, tmp_path):
+    # nvfp4 quantises fp32 weights fine, so the runtime filter does NOT set the bf16 gate; a
+    # checkpoint built the same way (require_bf16=False) matches and loads.
+    ckpt = _good_ckpt(scheme = "nvfp4")
+    ckpt["metadata"]["require_bf16"] = False
+    assert _load(monkeypatch, tmp_path, ckpt, scheme = "nvfp4") is not None
+
+
+def test_load_require_bf16_nvfp4_true_is_none(monkeypatch, tmp_path):
+    # An nvfp4 checkpoint claiming the bf16 gate contradicts the runtime filter (nvfp4 is not gated),
+    # so it quantised a different layer set and must be rejected.
+    ckpt = _good_ckpt(scheme = "nvfp4")
+    ckpt["metadata"]["require_bf16"] = True
+    assert _load(monkeypatch, tmp_path, ckpt, scheme = "nvfp4") is None
+
+
 def test_resolve_checkpoint_path_expands_user(monkeypatch, tmp_path):
     # The allowlist gate expands ~, so the existence check must too, or a "~/..." checkpoint
     # that passed the gate is silently skipped.

--- a/studio/backend/tests/test_diffusion_transformer_quant.py
+++ b/studio/backend/tests/test_diffusion_transformer_quant.py
@@ -325,6 +325,29 @@ def test_make_filter_fn(monkeypatch):
     assert keep(types.SimpleNamespace(), "no_attrs") is False
 
 
+def test_make_filter_fn_require_bf16_skips_non_bf16(monkeypatch):
+    # The scaled_mm schemes (fp8 / mxfp8 / nvfp4) assert a bf16 weight, so require_bf16 must skip a
+    # fp32 Linear (which Wan / Hunyuan video DiTs keep) while keeping the bf16 ones -- otherwise a
+    # single fp32 layer raises inside quantize_ and no-ops the whole pass. int8 leaves it off.
+    torch = types.ModuleType("torch")
+    torch.bfloat16, torch.float32 = "bf16", "fp32"
+
+    class _Lin:
+        def __init__(self, i, o, dtype):
+            self.in_features, self.out_features = i, o
+            self.weight = types.SimpleNamespace(dtype = dtype)
+
+    torch.nn = types.SimpleNamespace(Linear = _Lin)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    gated = make_filter_fn(512, require_bf16 = True)
+    assert gated(_Lin(1024, 4096, torch.bfloat16), "blocks.0.attn.to_q") is True
+    assert gated(_Lin(1024, 4096, torch.float32), "blocks.0.attn.to_q") is False  # fp32 -> skip
+    assert gated(types.SimpleNamespace(in_features = 1024, out_features = 4096), "no_weight") is False
+    # int8 (require_bf16 off, the default) still quantises the fp32 linear.
+    assert make_filter_fn(512)(_Lin(1024, 4096, torch.float32), "blocks.0.attn.to_q") is True
+
+
 def test_make_filter_fn_int8_excludes_modulation_and_embedders(monkeypatch):
     # The int8 path skips the large M=1 AdaLN modulation / conditioning-embedder projections
     # (they crash torch._int_mm's M>16), while keeping the attention / FFN compute layers and

--- a/studio/backend/tests/test_diffusion_transformer_quant.py
+++ b/studio/backend/tests/test_diffusion_transformer_quant.py
@@ -325,10 +325,28 @@ def test_make_filter_fn(monkeypatch):
     assert keep(types.SimpleNamespace(), "no_attrs") is False
 
 
+def test_require_bf16_schemes_excludes_nvfp4():
+    # fp8 and mxfp8 assert a bf16 weight (torchao 0.17 / B200: "PerRow quantization only works for
+    # bfloat16 ..." and "Only supporting bf16 out dtype ..."), so they gate on it; nvfp4 quantises an
+    # fp32 weight fine, so it is NOT gated (leaving its large fp32 projections quantised, not dense).
+    from core.inference.diffusion_transformer_quant import (
+        _REQUIRE_BF16_SCHEMES,
+        TQ_FP8,
+        TQ_MXFP8,
+        TQ_NVFP4,
+        TQ_INT8,
+    )
+
+    assert TQ_FP8 in _REQUIRE_BF16_SCHEMES
+    assert TQ_MXFP8 in _REQUIRE_BF16_SCHEMES
+    assert TQ_NVFP4 not in _REQUIRE_BF16_SCHEMES
+    assert TQ_INT8 not in _REQUIRE_BF16_SCHEMES
+
+
 def test_make_filter_fn_require_bf16_skips_non_bf16(monkeypatch):
-    # The scaled_mm schemes (fp8 / mxfp8 / nvfp4) assert a bf16 weight, so require_bf16 must skip a
-    # fp32 Linear (which Wan / Hunyuan video DiTs keep) while keeping the bf16 ones -- otherwise a
-    # single fp32 layer raises inside quantize_ and no-ops the whole pass. int8 leaves it off.
+    # fp8 / mxfp8 assert a bf16 weight, so require_bf16 must skip a fp32 Linear (which Wan / Hunyuan
+    # video DiTs keep) while keeping the bf16 ones -- otherwise a single fp32 layer raises inside
+    # quantize_ and no-ops the whole pass. int8 and nvfp4 leave it off (they quantise fp32 fine).
     torch = types.ModuleType("torch")
     torch.bfloat16, torch.float32 = "bf16", "fp32"
 

--- a/studio/backend/tests/test_video_routes.py
+++ b/studio/backend/tests/test_video_routes.py
@@ -53,6 +53,7 @@ def _unloaded_status():
         "attention_backend": None,
         "transformer_cache": None,
         "transformer_quant": None,
+        "text_encoder_quant": None,
         "has_audio": False,
         "defaults": None,
         "resolved": None,
@@ -73,6 +74,7 @@ class _FakeBackend:
         family_override = None,
         model_kind = None,
         transformer_quant = None,
+        text_encoder_quant = None,
     ):
         # Mirror the real backend's cheap validation so the route's
         # validate-before-evict ordering is exercised.
@@ -284,6 +286,35 @@ def test_load_rejects_bad_transformer_quant_422(client):
             "model_path": "unsloth/LTX-2.3-GGUF",
             "gguf_filename": "q.gguf",
             "transformer_quant": "bogus",
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_load_threads_text_encoder_quant(client):
+    # The load-time text_encoder_quant field reaches the backend (the video path now
+    # quantises the dense companion encoder, not just the DiT).
+    resp = client.post(
+        "/api/inference/video/load",
+        json = {
+            "model_path": "unsloth/LTX-2.3-GGUF",
+            "gguf_filename": "q.gguf",
+            "text_encoder_quant": "fp8",
+        },
+    )
+    assert resp.status_code == 200
+    kwargs = video_module.get_video_backend().last_load_kwargs
+    assert kwargs.get("text_encoder_quant") == "fp8"
+
+
+def test_load_rejects_bad_text_encoder_quant_422(client):
+    # text_encoder_quant is a Literal, so an unknown scheme is a 422 at request validation.
+    resp = client.post(
+        "/api/inference/video/load",
+        json = {
+            "model_path": "unsloth/LTX-2.3-GGUF",
+            "gguf_filename": "q.gguf",
+            "text_encoder_quant": "bogus",
         },
     )
     assert resp.status_code == 422


### PR DESCRIPTION
## Summary

Adds two torchao **compute** text-encoder quant modes to the diffusion precision engine and wires text-encoder quant into the **video** backend (which previously loaded the companion encoder dense bf16 and only quantised the DiT).

New text-encoder modes, alongside the existing layerwise `fp8` and weight-only `nvfp4`:

- **`int8`** - per-token activation + per-channel weight (`torch._int_mm`), with per-layer keep-bf16 selection. int8 degrades on large encoders unless the most quant-sensitive decoder blocks stay bf16, so it engages only for families with a measured keep-bf16 schedule; a family without one falls back to `fp8` (logged).
- **`fp8_dynamic`** - per-row fp8 compute (`torch._scaled_mm`), keeping the matmul in fp8 on the tensor cores instead of upcasting each forward like the layerwise `fp8`.

## Why per-layer for int8

int8 has two failure modes on big encoders, both measured against the bf16 reference at the layer each pipeline reads:

- **Early-layer seeding** (Mistral-Small-24B / flux.2-dev): a few input blocks amplify error through depth. Keeping the first 3 blocks bf16 goes from about 0.80 to about 0.98 cosine.
- **Activation outliers** (Qwen2.5-VL / qwen-image): int8 only reaches fp8 fidelity by keeping both ends bf16 (first plus last 6, about 0.997).

fp8 (both variants) is robust across sizes because its exponent absorbs the outliers a linear int8 scale cannot, so it is the safe default; int8 is the option when you want the encoder torch.compiled (it lowers to `torch._int_mm` fullgraph).

Per-family keep-bf16 schedule (`_TE_INT8_SKIP`, as `(skip_first, skip_last)`):

| family | keep bf16 | int8 cosine |
|---|---|---|
| qwen-image / qwen-image-edit | first plus last 6 | about 0.997 |
| flux.2-dev | first 3 | about 0.98 |

## Self-contained

The selective int8 caster reuses the committed transformer-quant factory (`_make_quant_config` / `make_filter_fn` / `exclude_tokens_for_scheme`) plus a small structural first/last-N block skip (`_keep_bf16_block_fqns`), so it depends only on committed APIs. Embeddings, the VLM vision tower, `lm_head`, and T5 `wo` stay bf16.

## Video wiring

`text_encoder_quant` is plumbed through the video load request, validation, the load chain (`begin_load` to `_run_load` to `load_pipeline`), the resolved record, and status, mirroring the image backend. TE quant runs right after the DiT-quant step and before placement (so offload hooks move the smaller weights), and applies for every load kind since the encoder is dense regardless of how the DiT was sourced. Best-effort: any encoder that fails to cast is left dense.

## API

- Image and video load request `text_encoder_quant`: `fp8 | fp8_dynamic | int8 | nvfp4` (widened from `fp8 | nvfp4`).
- New `text_encoder_quant` field on the video status response.

## Tests

`pytest tests/test_diffusion_precision.py tests/test_video_routes.py` and the surrounding diffusion/video backend and route suites are green (230+ tests). New coverage: int8 family-schedule routing and fp8 fallback, fp8_dynamic routing, hardware gates (int8 sm_80+, fp8_dynamic sm_89+), the structural block selection, the real int8 filter closure (keeps first blocks plus vision tower / lm_head / T5 wo dense), and the video route threading and 422 validation.
