### PR TITLE
studio: label RAM and VRAM readouts as GiB not GB

### DIFF
--- a/studio/frontend/src/components/floating-monitor.tsx
+++ b/studio/frontend/src/components/floating-monitor.tsx
@@ -27,9 +27,11 @@ function usageTextClass(percent: number): string {
   return "text-primary";
 }
 
-function formatGb(value: number): string {
+function formatGiB(value: number): string {
+  // RAM/VRAM come from the backend in binary units (bytes / 1024**3), matching
+  // nvidia-smi and PyTorch, so label the readout GiB rather than GB.
   const digits = value >= 10 ? 1 : 2;
-  return `${value.toFixed(digits)} GB`;
+  return `${value.toFixed(digits)} GiB`;
 }
 
 export function FloatingMonitor() {
@@ -116,7 +118,7 @@ export function FloatingMonitor() {
               </span>
             </div>
             <div className="text-xs text-muted-foreground font-mono tabular-nums">
-              {formatGb(ramUsed)} / {formatGb(ramTotal)}
+              {formatGiB(ramUsed)} / {formatGiB(ramTotal)}
             </div>
             <Progress
               value={ramPercent}
@@ -144,7 +146,7 @@ export function FloatingMonitor() {
                 </span>
               </div>
               <div className="text-xs text-muted-foreground font-mono tabular-nums">
-                {formatGb(vramUsed)} / {formatGb(vramTotal)}
+                {formatGiB(vramUsed)} / {formatGiB(vramTotal)}
               </div>
               <Progress
                 value={vramPercent}

--- a/studio/frontend/src/features/hub/hub-page.tsx
+++ b/studio/frontend/src/features/hub/hub-page.tsx
@@ -1085,11 +1085,11 @@ export function ModelsPage() {
   const { vramInfo, minMemory } = useHubModelVram(selectedModel, gpu);
 
   const gpuLabel = gpu.available
-    ? `${Math.round(gpu.memoryTotalGb)} GB`
+    ? `${Math.round(gpu.memoryTotalGb)} GiB`
     : "Unavailable";
   const ramLabel =
     gpu.systemRamTotalGb > 0
-      ? `${Math.round(gpu.systemRamTotalGb)} GB`
+      ? `${Math.round(gpu.systemRamTotalGb)} GiB`
       : "Unavailable";
   const coreLabel =
     gpu.cpuCore > 0 && gpu.cpuThread > 0

--- a/studio/frontend/src/features/onboarding/components/steps/summary-step.tsx
+++ b/studio/frontend/src/features/onboarding/components/steps/summary-step.tsx
@@ -125,7 +125,7 @@ export function SummaryStep() {
               <span className="text-xs text-muted-foreground">GPU</span>
               <div className="flex items-center gap-2">
                 <span className="text-sm font-medium">{hw.gpuName ?? "---"}</span>
-                <Badge variant="secondary">{hw.vramTotalGb != null ? `${hw.vramTotalGb} GB` : "---"}</Badge>
+                <Badge variant="secondary">{hw.vramTotalGb != null ? `${hw.vramTotalGb} GiB` : "---"}</Badge>
               </div>
             </div>
           </div>

--- a/studio/frontend/src/features/settings/tabs/about-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/about-tab.tsx
@@ -158,7 +158,7 @@ export function AboutTab() {
               <code className="font-mono text-xs text-muted-foreground">
                 {gpu.name ?? "—"}
                 {gpu.vramTotalGb != null
-                  ? ` · ${Math.round(gpu.vramTotalGb)} GB`
+                  ? ` · ${Math.round(gpu.vramTotalGb)} GiB`
                   : ""}
               </code>
             </SettingsRow>

--- a/studio/frontend/src/features/settings/tabs/resources-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/resources-tab.tsx
@@ -47,6 +47,15 @@ function formatGb(value: number | null | undefined): string {
   return `${safe.toFixed(digits)} GB`;
 }
 
+// RAM/VRAM come from the backend in binary units (bytes / 1024**3), matching
+// nvidia-smi and PyTorch, so label those readouts GiB. Disk stays on formatGb
+// because the backend reports disk in decimal GB (bytes / 1e9).
+function formatGiB(value: number | null | undefined): string {
+  const safe = isFiniteNumber(value) ? Math.max(0, value) : 0;
+  const digits = safe >= 10 ? 1 : 2;
+  return `${safe.toFixed(digits)} GiB`;
+}
+
 function formatMb(value: number | null | undefined): string {
   const safe = isFiniteNumber(value) ? Math.max(0, value) : 0;
   return `${Math.round(safe).toLocaleString()} MB`;
@@ -300,9 +309,9 @@ export function ResourcesTab() {
           />
           <MetricTile
             label={t("settings.resources.liveMonitor.ram")}
-            value={`${formatGb(metrics.ramUsed)} / ${formatGb(metrics.ramTotal)}`}
+            value={`${formatGiB(metrics.ramUsed)} / ${formatGiB(metrics.ramTotal)}`}
             detail={t("settings.resources.liveMonitor.free", {
-              value: formatGb(systemInfo.memory?.available_gb),
+              value: formatGiB(systemInfo.memory?.available_gb),
             })}
             percent={systemInfo.memory?.percent_used ?? 0}
           />
@@ -318,13 +327,13 @@ export function ResourcesTab() {
             label={t("settings.resources.liveMonitor.vram")}
             value={
               hasGpu
-                ? `${formatGb(metrics.vramUsed)} / ${formatGb(metrics.vramTotal)}`
+                ? `${formatGiB(metrics.vramUsed)} / ${formatGiB(metrics.vramTotal)}`
                 : t("settings.resources.liveMonitor.noGpu")
             }
             detail={
               hasGpu
                 ? t("settings.resources.liveMonitor.free", {
-                    value: formatGb(metrics.vramFree),
+                    value: formatGiB(metrics.vramFree),
                   })
                 : backendLabel
             }
@@ -373,17 +382,17 @@ export function ResourcesTab() {
                 <div className="grid gap-1 text-xs text-muted-foreground sm:grid-cols-3 sm:gap-2">
                   <span className="min-w-0 truncate font-mono tabular-nums">
                     {t("settings.resources.gpu.used", {
-                      value: formatGb(used),
+                      value: formatGiB(used),
                     })}
                   </span>
                   <span className="min-w-0 truncate font-mono tabular-nums sm:text-center">
                     {t("settings.resources.gpu.free", {
-                      value: formatGb(free),
+                      value: formatGiB(free),
                     })}
                   </span>
                   <span className="min-w-0 truncate font-mono tabular-nums sm:text-right">
                     {t("settings.resources.gpu.total", {
-                      value: formatGb(total),
+                      value: formatGiB(total),
                     })}
                   </span>
                 </div>

--- a/studio/frontend/src/features/studio/sections/progress-section.tsx
+++ b/studio/frontend/src/features/studio/sections/progress-section.tsx
@@ -411,7 +411,7 @@ function LiveGpuPanel({
                   value={index}
                   className="bg-popover text-popover-foreground dark:bg-zinc-900 dark:text-zinc-100"
                 >
-                  GPU {device.visible_ordinal ?? index} - {device.backend} ({device.vram_total_gb ? `${Math.round(device.vram_total_gb)}GB` : "N/A"})
+                  GPU {device.visible_ordinal ?? index} - {device.backend} ({device.vram_total_gb ? `${Math.round(device.vram_total_gb)}GiB` : "N/A"})
                 </option>
               ))}
             </select>
@@ -446,7 +446,7 @@ function LiveGpuPanel({
           icon={<HugeiconsIcon icon={RamMemoryIcon} className="size-3.5" />}
           value={
             currentGpu.vram_used_gb != null && currentGpu.vram_total_gb != null
-              ? `${currentGpu.vram_used_gb} / ${currentGpu.vram_total_gb} GB`
+              ? `${currentGpu.vram_used_gb} / ${currentGpu.vram_total_gb} GiB`
               : "--"
           }
           pct={currentGpu.vram_utilization_pct ?? 0}


### PR DESCRIPTION
## What

The Studio live resource monitor (and the other GPU/RAM readouts) derive memory from binary byte counts but label the values "GB":

- torch / psutil: `bytes / 1024**3`
- nvidia-smi path: `MiB / 1024`

Both are GiB. On a B200 the monitor showed `178.35 GB` while `nvidia-smi` reports `183359 MiB` (179 GiB), so it looked like about 14 GB of VRAM was missing.

## Why GiB, not decimal GB

Every GPU dev tool uses binary units, and the marketing "GB" is inconsistent per card:

| GPU | nvidia-smi | GiB (/1024^3) | decimal GB (/1e9) | Marketing |
| --- | --- | --- | --- | --- |
| B200 | 183,359 MiB | 179.1 GiB | 192.3 GB | "192 GB" (decimal) |
| A100 80GB | 81,920 MiB | 80.0 GiB | 85.9 GB | "80 GB" (binary) |
| H100 80GB | ~81,559 MiB | ~79.6 GiB | 85.5 GB | "80 GB" (binary) |

`nvidia-smi` reports MiB, and PyTorch's own OOM messages use GiB. Switching the divisor to `1e9` would make the meter disagree with `nvidia-smi` and over-report every A100/H100/4090, so the correct fix is the label, not the math.

## Change

Relabel the measured RAM/VRAM readouts from GB to GiB in:

- `components/floating-monitor.tsx`
- `features/settings/tabs/resources-tab.tsx` (RAM/VRAM only, via a new `formatGiB` helper; disk keeps `formatGb`)
- `features/studio/sections/progress-section.tsx`
- `features/hub/hub-page.tsx`
- `features/settings/tabs/about-tab.tsx`
- `features/onboarding/components/steps/summary-step.tsx`

The numeric values are unchanged, so the training GPU-selection and memory-fit logic that read the same `*_gb` fields are unaffected. No backend changes.

Left as GB on purpose:

- Disk usage (backend reports decimal GB, `bytes / 1e9`)
- Model file sizes and download progress (decimal GB to match Hugging Face)
- Heuristic model VRAM fit estimates ("~X GB")

## Testing

- `npm run typecheck` passes clean
- `eslint` on the changed files reports no new problems (the pre-existing hook/import warnings are unchanged from main)
