### PR TITLE
Fix repeated base model downloads across checkpoint exports

### DIFF
--- a/tests/saving/test_prewarm_base_model_hub_cache.py
+++ b/tests/saving/test_prewarm_base_model_hub_cache.py
@@ -116,8 +116,11 @@ def _build_env(
     )
     zoo_module = types.SimpleNamespace(determine_base_model_source = determine_base_model_source)
     # Stub the live-env cache resolver the pre-warm uses (matches what the merge reads).
-    _live = (hub_cache if hub_cache is not None else str(cache_dir)) \
-        if live_hub_cache == "__same__" else live_hub_cache
+    _live = (
+        (hub_cache if hub_cache is not None else str(cache_dir))
+        if live_hub_cache == "__same__"
+        else live_hub_cache
+    )
     hf_cache_module = types.SimpleNamespace(_active_caches = lambda: (None, _live, None))
     monkeypatch.setitem(__import__("sys").modules, "huggingface_hub", hf_module)
     monkeypatch.setitem(__import__("sys").modules, "unsloth_zoo.saving_utils", zoo_module)
@@ -327,8 +330,10 @@ def test_prewarm_survives_runtime_cache_redirect(monkeypatch, tmp_path):
     # Frozen constants (stale dir) vs the merge's runtime-redirected dir: the pre-warm
     # must follow the redirect, else the cache-copy fast path misses and #6890 is unfixed.
     fn, stubs = _build_env(
-        monkeypatch, tmp_path,
-        hub_cache = "/read-only/original/hub", live_hub_cache = "/writable/redirect/hub",
+        monkeypatch,
+        tmp_path,
+        hub_cache = "/read-only/original/hub",
+        live_hub_cache = "/writable/redirect/hub",
     )
     fn(_FakePeftModel(), save_method = "merged_16bit")
     assert stubs.snapshot_download.calls[0][1]["cache_dir"] == "/writable/redirect/hub"
@@ -336,7 +341,11 @@ def test_prewarm_survives_runtime_cache_redirect(monkeypatch, tmp_path):
 
 def test_cached_probe_uses_live_env_cache(monkeypatch, tmp_path):
     # The already-cached fast path must probe the live-env cache dir too.
-    fn, stubs = _build_env(monkeypatch, tmp_path, cached = True, live_hub_cache = "/mnt/persistent/hf/hub")
+    fn, stubs = _build_env(
+        monkeypatch, tmp_path, cached = True, live_hub_cache = "/mnt/persistent/hf/hub"
+    )
     fn(_FakePeftModel(), save_method = "merged_16bit")
     assert stubs.hf_hub_download.calls, "cached probe did not run"
-    assert all(kw.get("cache_dir") == "/mnt/persistent/hf/hub" for _, kw in stubs.hf_hub_download.calls)
+    assert all(
+        kw.get("cache_dir") == "/mnt/persistent/hf/hub" for _, kw in stubs.hf_hub_download.calls
+    )

--- a/tests/saving/test_prewarm_base_model_hub_cache.py
+++ b/tests/saving/test_prewarm_base_model_hub_cache.py
@@ -68,6 +68,7 @@ def _build_env(
     base_source = None,
     kaggle = False,
     colab = False,
+    hub_cache = None,
 ):
     """Exec the extracted helper with stubbed collaborators; returns (fn, stubs)."""
     shards = (
@@ -108,7 +109,9 @@ def _build_env(
         HfFileSystem = _FS,
         hf_hub_download = hf_hub_download,
         snapshot_download = snapshot_download,
-        constants = types.SimpleNamespace(HF_HUB_CACHE = str(cache_dir)),
+        constants = types.SimpleNamespace(
+            HF_HUB_CACHE = hub_cache if hub_cache is not None else str(cache_dir)
+        ),
     )
     zoo_module = types.SimpleNamespace(determine_base_model_source = determine_base_model_source)
     monkeypatch.setitem(__import__("sys").modules, "huggingface_hub", hf_module)
@@ -118,6 +121,7 @@ def _build_env(
         disk_usage = lambda path: types.SimpleNamespace(free = free_bytes)
     )
 
+    prints = []
     namespace = {
         "os": os,
         "shutil": fake_shutil,
@@ -125,7 +129,7 @@ def _build_env(
         "get_model_name": lambda name, load_in_4bit: name.removesuffix("-bnb-4bit"),
         "IS_KAGGLE_ENVIRONMENT": kaggle,
         "IS_COLAB_ENVIRONMENT": colab,
-        "print": lambda *a, **k: None,
+        "print": lambda *a, **k: prints.append(" ".join(str(x) for x in a)),
     }
     exec(
         compile(_extract_function("_prewarm_base_model_hub_cache"), str(_SAVE_PY), "exec"),
@@ -135,6 +139,7 @@ def _build_env(
         snapshot_download = snapshot_download,
         hf_hub_download = hf_hub_download,
         determine_base_model_source = determine_base_model_source,
+        prints = prints,
     )
     return namespace["_prewarm_base_model_hub_cache"], stubs
 
@@ -263,6 +268,30 @@ def test_gpt_oss_bf16_mxfp4_swap_skips(monkeypatch, tmp_path):
         save_method = "mxfp4",
     )
     assert stubs.snapshot_download.calls == []
+
+
+def test_missing_config_skips_cleanly(monkeypatch, tmp_path):
+    # A model whose config is None must skip silently, not fall into the outer
+    # exception handler that prints a misleading "Could not pre-cache" warning.
+    fn, stubs = _build_env(monkeypatch, tmp_path)
+    model = _FakePeftModel()  # a PeftModel instance so the isinstance guard passes
+    model.config = None
+    fn(model, save_method = "merged_16bit")
+    assert stubs.determine_base_model_source.calls == []
+    assert stubs.snapshot_download.calls == []
+    assert not any("Could not pre-cache" in p for p in stubs.prints), (
+        "missing config took the error path instead of a clean skip"
+    )
+
+
+def test_relative_hub_cache_does_not_falsely_skip(monkeypatch, tmp_path):
+    # A relative HF_HUB_CACHE whose leaf does not exist yet must still resolve to a
+    # real root for the disk-space probe; without abspath the walk-up hits "" and
+    # the pre-warm is wrongly skipped. Run from a real dir so abspath has a base.
+    monkeypatch.chdir(tmp_path)
+    fn, stubs = _build_env(monkeypatch, tmp_path, hub_cache = "relcache/hub")
+    fn(_FakePeftModel(), save_method = "merged_16bit")
+    assert len(stubs.snapshot_download.calls) == 1, "relative cache path falsely skipped pre-warm"
 
 
 def test_generic_save_calls_prewarm_before_merge():

--- a/tests/saving/test_prewarm_base_model_hub_cache.py
+++ b/tests/saving/test_prewarm_base_model_hub_cache.py
@@ -69,6 +69,7 @@ def _build_env(
     kaggle = False,
     colab = False,
     hub_cache = None,
+    live_hub_cache = "__same__",
 ):
     """Exec the extracted helper with stubbed collaborators; returns (fn, stubs)."""
     shards = (
@@ -114,8 +115,13 @@ def _build_env(
         ),
     )
     zoo_module = types.SimpleNamespace(determine_base_model_source = determine_base_model_source)
+    # Stub the live-env cache resolver the pre-warm uses (matches what the merge reads).
+    _live = (hub_cache if hub_cache is not None else str(cache_dir)) \
+        if live_hub_cache == "__same__" else live_hub_cache
+    hf_cache_module = types.SimpleNamespace(_active_caches = lambda: (None, _live, None))
     monkeypatch.setitem(__import__("sys").modules, "huggingface_hub", hf_module)
     monkeypatch.setitem(__import__("sys").modules, "unsloth_zoo.saving_utils", zoo_module)
+    monkeypatch.setitem(__import__("sys").modules, "unsloth_zoo.hf_cache", hf_cache_module)
 
     fake_shutil = types.SimpleNamespace(
         disk_usage = lambda path: types.SimpleNamespace(free = free_bytes)
@@ -308,3 +314,29 @@ def test_generic_save_calls_prewarm_before_merge():
     assert prewarm_pos != -1, "unsloth_generic_save no longer pre-warms the hub cache"
     assert merge_pos != -1
     assert prewarm_pos < merge_pos, "pre-warm must run before the merge downloads shards"
+
+
+def test_prewarm_downloads_into_live_env_cache(monkeypatch, tmp_path):
+    # Download must target the live-env cache (what the merge reads), via cache_dir.
+    fn, stubs = _build_env(monkeypatch, tmp_path, live_hub_cache = "/mnt/persistent/hf/hub")
+    fn(_FakePeftModel(), save_method = "merged_16bit")
+    assert stubs.snapshot_download.calls[0][1]["cache_dir"] == "/mnt/persistent/hf/hub"
+
+
+def test_prewarm_survives_runtime_cache_redirect(monkeypatch, tmp_path):
+    # Frozen constants (stale dir) vs the merge's runtime-redirected dir: the pre-warm
+    # must follow the redirect, else the cache-copy fast path misses and #6890 is unfixed.
+    fn, stubs = _build_env(
+        monkeypatch, tmp_path,
+        hub_cache = "/read-only/original/hub", live_hub_cache = "/writable/redirect/hub",
+    )
+    fn(_FakePeftModel(), save_method = "merged_16bit")
+    assert stubs.snapshot_download.calls[0][1]["cache_dir"] == "/writable/redirect/hub"
+
+
+def test_cached_probe_uses_live_env_cache(monkeypatch, tmp_path):
+    # The already-cached fast path must probe the live-env cache dir too.
+    fn, stubs = _build_env(monkeypatch, tmp_path, cached = True, live_hub_cache = "/mnt/persistent/hf/hub")
+    fn(_FakePeftModel(), save_method = "merged_16bit")
+    assert stubs.hf_hub_download.calls, "cached probe did not run"
+    assert all(kw.get("cache_dir") == "/mnt/persistent/hf/hub" for _, kw in stubs.hf_hub_download.calls)

--- a/tests/saving/test_prewarm_base_model_hub_cache.py
+++ b/tests/saving/test_prewarm_base_model_hub_cache.py
@@ -43,7 +43,11 @@ class _FakePeftModel:
 class _Recorder:
     """Callable that records calls and returns/raises per configuration."""
 
-    def __init__(self, result = None, exc = None):
+    def __init__(
+        self,
+        result = None,
+        exc = None,
+    ):
         self.calls = []
         self.result = result
         self.exc = exc
@@ -66,10 +70,14 @@ def _build_env(
     colab = False,
 ):
     """Exec the extracted helper with stubbed collaborators; returns (fn, stubs)."""
-    shards = shards if shards is not None else [
-        ("model-00001-of-00002.safetensors", 30 * 1024**3),
-        ("model-00002-of-00002.safetensors", 29 * 1024**3),
-    ]
+    shards = (
+        shards
+        if shards is not None
+        else [
+            ("model-00001-of-00002.safetensors", 30 * 1024**3),
+            ("model-00002-of-00002.safetensors", 29 * 1024**3),
+        ]
+    )
     if base_source is None:
         base_source = ("unsloth/gemma-4-31b-it", False, None, False, None)
 
@@ -77,7 +85,11 @@ def _build_env(
         def __init__(self, token = None):
             pass
 
-        def ls(self, repo, detail = True):
+        def ls(
+            self,
+            repo,
+            detail = True,
+        ):
             return [{"name": f"{repo}/{n}", "size": s} for n, s in shards]
 
     class _LocalMiss(Exception):
@@ -98,15 +110,9 @@ def _build_env(
         snapshot_download = snapshot_download,
         constants = types.SimpleNamespace(HF_HUB_CACHE = str(cache_dir)),
     )
-    zoo_module = types.SimpleNamespace(
-        determine_base_model_source = determine_base_model_source
-    )
-    monkeypatch.setitem(
-        __import__("sys").modules, "huggingface_hub", hf_module
-    )
-    monkeypatch.setitem(
-        __import__("sys").modules, "unsloth_zoo.saving_utils", zoo_module
-    )
+    zoo_module = types.SimpleNamespace(determine_base_model_source = determine_base_model_source)
+    monkeypatch.setitem(__import__("sys").modules, "huggingface_hub", hf_module)
+    monkeypatch.setitem(__import__("sys").modules, "unsloth_zoo.saving_utils", zoo_module)
 
     fake_shutil = types.SimpleNamespace(
         disk_usage = lambda path: types.SimpleNamespace(free = free_bytes)
@@ -121,7 +127,10 @@ def _build_env(
         "IS_COLAB_ENVIRONMENT": colab,
         "print": lambda *a, **k: None,
     }
-    exec(compile(_extract_function("_prewarm_base_model_hub_cache"), str(_SAVE_PY), "exec"), namespace)
+    exec(
+        compile(_extract_function("_prewarm_base_model_hub_cache"), str(_SAVE_PY), "exec"),
+        namespace,
+    )
     stubs = types.SimpleNamespace(
         snapshot_download = snapshot_download,
         hf_hub_download = hf_hub_download,
@@ -150,9 +159,7 @@ def test_skips_download_when_already_cached(monkeypatch, tmp_path):
     fn(_FakePeftModel(), save_method = "merged_16bit")
     assert stubs.snapshot_download.calls == []
     # The cached check must not hit the network.
-    assert all(
-        kwargs.get("local_files_only") for _, kwargs in stubs.hf_hub_download.calls
-    )
+    assert all(kwargs.get("local_files_only") for _, kwargs in stubs.hf_hub_download.calls)
 
 
 def test_skips_when_disk_too_small_for_cache_copy(monkeypatch, tmp_path):

--- a/tests/saving/test_prewarm_base_model_hub_cache.py
+++ b/tests/saving/test_prewarm_base_model_hub_cache.py
@@ -16,6 +16,7 @@ source via ast and exec it against fakes, mirroring the other GPU-free tests.
 from __future__ import annotations
 
 import ast
+import json
 import os
 import types
 from pathlib import Path
@@ -76,6 +77,7 @@ def _build_env(
     live_hub_cache = "__same__",
     fp8_sibling = None,
     sibling_source = None,
+    index_weight_map = None,
 ):
     """Exec the extracted helper with stubbed collaborators; returns (fn, stubs)."""
     shards = (
@@ -106,6 +108,23 @@ def _build_env(
     hf_hub_download = _Recorder(result = str(tmp_path / "cached"))
     if not cached:
         hf_hub_download.exc = _LocalMiss("not cached")
+    # Serve model.safetensors.index.json (the merge's shard filter) while shard cache
+    # probes still miss, so the index-filter path can be exercised without a network.
+    if index_weight_map is not None:
+        _idx_path = tmp_path / "model.safetensors.index.json"
+        _idx_path.write_text(json.dumps({"weight_map": index_weight_map}))
+
+        def _hub_dl(
+            repo_id = None,
+            filename = None,
+            **kw,
+        ):
+            if filename == "model.safetensors.index.json":
+                return str(_idx_path)
+            raise _LocalMiss("not cached")
+
+        hf_hub_download.exc = None
+        hf_hub_download.results_fn = _hub_dl
     snapshot_download = _Recorder()
     determine_base_model_source = _Recorder(result = base_source)
     # For the FP8 -> 16bit sibling swap: return the sibling's (16bit) source when the
@@ -395,3 +414,47 @@ def test_fp8_base_without_sibling_still_prewarms_fp8_repo(monkeypatch, tmp_path)
     fn(_FakePeftModel(name_or_path = "unsloth/Model-FP8"), save_method = "merged_16bit")
     assert len(stubs.snapshot_download.calls) == 1
     assert stubs.snapshot_download.calls[0][1]["repo_id"] == "unsloth/Model-FP8"
+
+
+def test_prewarm_filters_shards_through_index(monkeypatch, tmp_path):
+    # A repo with a leftover shard not referenced by the index: the merge keeps only the
+    # indexed shards, so the pre-warm must too (else the disk gate over-counts and
+    # snapshot_download fetches the unused leftover).
+    fn, stubs = _build_env(
+        monkeypatch,
+        tmp_path,
+        shards = [
+            ("model-00001-of-00002.safetensors", 10 * 1024**3),
+            ("model-00002-of-00002.safetensors", 10 * 1024**3),
+            ("leftover-00001-of-00001.safetensors", 10 * 1024**3),
+        ],
+        index_weight_map = {
+            "a.weight": "model-00001-of-00002.safetensors",
+            "b.weight": "model-00002-of-00002.safetensors",
+        },
+    )
+    fn(_FakePeftModel(), save_method = "merged_16bit")
+    allow = stubs.snapshot_download.calls[0][1]["allow_patterns"]
+    assert "leftover-00001-of-00001.safetensors" not in allow
+    assert "model-00001-of-00002.safetensors" in allow
+    assert "model-00002-of-00002.safetensors" in allow
+
+
+def test_prewarm_keeps_all_shards_when_index_matches(monkeypatch, tmp_path):
+    # No leftover: every listed shard is indexed, so none are dropped.
+    fn, stubs = _build_env(
+        monkeypatch,
+        tmp_path,
+        shards = [
+            ("model-00001-of-00002.safetensors", 10 * 1024**3),
+            ("model-00002-of-00002.safetensors", 10 * 1024**3),
+        ],
+        index_weight_map = {
+            "a.weight": "model-00001-of-00002.safetensors",
+            "b.weight": "model-00002-of-00002.safetensors",
+        },
+    )
+    fn(_FakePeftModel(), save_method = "merged_16bit")
+    allow = stubs.snapshot_download.calls[0][1]["allow_patterns"]
+    assert "model-00001-of-00002.safetensors" in allow
+    assert "model-00002-of-00002.safetensors" in allow

--- a/tests/saving/test_prewarm_base_model_hub_cache.py
+++ b/tests/saving/test_prewarm_base_model_hub_cache.py
@@ -1,0 +1,274 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Regression tests for #6890: repeated base-model downloads across checkpoint exports.
+
+merge_and_overwrite_lora downloads missing 16-bit shards with hf_hub_download(local_dir),
+which never populates the persistent HF hub cache; a temporary merge directory (Studio
+GGUF exports delete it) means every checkpoint export re-downloads the full base model.
+_prewarm_base_model_hub_cache snapshot-downloads the base into the hub cache first so
+the zoo's cache-copy fast path is hit on later exports.
+
+unsloth.save cannot be imported on GPU-less hosts, so these tests extract the helper's
+source via ast and exec it against fakes, mirroring the other GPU-free tests.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import types
+from pathlib import Path
+
+import pytest
+
+
+_SAVE_PY = Path(__file__).resolve().parent.parent.parent / "unsloth" / "save.py"
+_SOURCE = _SAVE_PY.read_text(encoding = "utf-8")
+
+
+def _extract_function(name: str) -> str:
+    tree = ast.parse(_SOURCE)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return ast.get_source_segment(_SOURCE, node)
+    raise AssertionError(f"{name} not found in unsloth/save.py")
+
+
+class _FakePeftModel:
+    def __init__(self, name_or_path = "unsloth/gemma-4-31b-it-bnb-4bit"):
+        self.config = types.SimpleNamespace(_name_or_path = name_or_path)
+
+
+class _Recorder:
+    """Callable that records calls and returns/raises per configuration."""
+
+    def __init__(self, result = None, exc = None):
+        self.calls = []
+        self.result = result
+        self.exc = exc
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        if self.exc is not None:
+            raise self.exc
+        return self.result
+
+
+def _build_env(
+    monkeypatch,
+    tmp_path,
+    shards = None,
+    cached = False,
+    free_bytes = 10**15,
+    base_source = None,
+    kaggle = False,
+    colab = False,
+):
+    """Exec the extracted helper with stubbed collaborators; returns (fn, stubs)."""
+    shards = shards if shards is not None else [
+        ("model-00001-of-00002.safetensors", 30 * 1024**3),
+        ("model-00002-of-00002.safetensors", 29 * 1024**3),
+    ]
+    if base_source is None:
+        base_source = ("unsloth/gemma-4-31b-it", False, None, False, None)
+
+    class _FS:
+        def __init__(self, token = None):
+            pass
+
+        def ls(self, repo, detail = True):
+            return [{"name": f"{repo}/{n}", "size": s} for n, s in shards]
+
+    class _LocalMiss(Exception):
+        pass
+
+    hf_hub_download = _Recorder(result = str(tmp_path / "cached"))
+    if not cached:
+        hf_hub_download.exc = _LocalMiss("not cached")
+    snapshot_download = _Recorder()
+    determine_base_model_source = _Recorder(result = base_source)
+
+    cache_dir = tmp_path / "hub_cache"
+    cache_dir.mkdir(exist_ok = True)
+
+    hf_module = types.SimpleNamespace(
+        HfFileSystem = _FS,
+        hf_hub_download = hf_hub_download,
+        snapshot_download = snapshot_download,
+        constants = types.SimpleNamespace(HF_HUB_CACHE = str(cache_dir)),
+    )
+    zoo_module = types.SimpleNamespace(
+        determine_base_model_source = determine_base_model_source
+    )
+    monkeypatch.setitem(
+        __import__("sys").modules, "huggingface_hub", hf_module
+    )
+    monkeypatch.setitem(
+        __import__("sys").modules, "unsloth_zoo.saving_utils", zoo_module
+    )
+
+    fake_shutil = types.SimpleNamespace(
+        disk_usage = lambda path: types.SimpleNamespace(free = free_bytes)
+    )
+
+    namespace = {
+        "os": os,
+        "shutil": fake_shutil,
+        "PeftModel": _FakePeftModel,
+        "get_model_name": lambda name, load_in_4bit: name.removesuffix("-bnb-4bit"),
+        "IS_KAGGLE_ENVIRONMENT": kaggle,
+        "IS_COLAB_ENVIRONMENT": colab,
+        "print": lambda *a, **k: None,
+    }
+    exec(compile(_extract_function("_prewarm_base_model_hub_cache"), str(_SAVE_PY), "exec"), namespace)
+    stubs = types.SimpleNamespace(
+        snapshot_download = snapshot_download,
+        hf_hub_download = hf_hub_download,
+        determine_base_model_source = determine_base_model_source,
+    )
+    return namespace["_prewarm_base_model_hub_cache"], stubs
+
+
+def test_downloads_base_into_hub_cache(monkeypatch, tmp_path):
+    monkeypatch.delenv("UNSLOTH_PREWARM_HUB_CACHE", raising = False)
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+    monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising = False)
+    fn, stubs = _build_env(monkeypatch, tmp_path)
+    fn(_FakePeftModel(), save_method = "merged_16bit", token = "tok")
+    assert len(stubs.snapshot_download.calls) == 1
+    _, kwargs = stubs.snapshot_download.calls[0]
+    assert kwargs["repo_id"] == "unsloth/gemma-4-31b-it"
+    # No local_dir: the whole point is populating the persistent cache.
+    assert "local_dir" not in kwargs
+    assert "model-00001-of-00002.safetensors" in kwargs["allow_patterns"]
+    assert "model.safetensors.index.json" in kwargs["allow_patterns"]
+
+
+def test_skips_download_when_already_cached(monkeypatch, tmp_path):
+    fn, stubs = _build_env(monkeypatch, tmp_path, cached = True)
+    fn(_FakePeftModel(), save_method = "merged_16bit")
+    assert stubs.snapshot_download.calls == []
+    # The cached check must not hit the network.
+    assert all(
+        kwargs.get("local_files_only") for _, kwargs in stubs.hf_hub_download.calls
+    )
+
+
+def test_skips_when_disk_too_small_for_cache_copy(monkeypatch, tmp_path):
+    fn, stubs = _build_env(monkeypatch, tmp_path, free_bytes = 60 * 1024**3)
+    fn(_FakePeftModel(), save_method = "merged_16bit")
+    assert stubs.snapshot_download.calls == []
+
+
+@pytest.mark.parametrize("env_value", ["0", "false", "NO", "off"])
+def test_env_opt_out(monkeypatch, tmp_path, env_value):
+    monkeypatch.setenv("UNSLOTH_PREWARM_HUB_CACHE", env_value)
+    fn, stubs = _build_env(monkeypatch, tmp_path)
+    fn(_FakePeftModel(), save_method = "merged_16bit")
+    assert stubs.snapshot_download.calls == []
+
+
+@pytest.mark.parametrize("var", ["HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE"])
+def test_offline_skips(monkeypatch, tmp_path, var):
+    monkeypatch.setenv(var, "1")
+    fn, stubs = _build_env(monkeypatch, tmp_path)
+    fn(_FakePeftModel(), save_method = "merged_16bit")
+    assert stubs.snapshot_download.calls == []
+
+
+def test_kaggle_and_colab_skip(monkeypatch, tmp_path):
+    for flag in ("kaggle", "colab"):
+        fn, stubs = _build_env(monkeypatch, tmp_path, **{flag: True})
+        fn(_FakePeftModel(), save_method = "merged_16bit")
+        assert stubs.snapshot_download.calls == [], f"{flag} must skip pre-warm"
+
+
+@pytest.mark.parametrize("save_method", ["merged_4bit", "forced_merged_4bit", "lora"])
+def test_non_downloading_save_methods_skip(monkeypatch, tmp_path, save_method):
+    fn, stubs = _build_env(monkeypatch, tmp_path)
+    fn(_FakePeftModel(), save_method = save_method)
+    assert stubs.snapshot_download.calls == []
+
+
+def test_local_base_model_skips(monkeypatch, tmp_path):
+    local_dir = tmp_path / "local_base"
+    local_dir.mkdir()
+    fn, stubs = _build_env(monkeypatch, tmp_path)
+    fn(_FakePeftModel(name_or_path = str(local_dir)), save_method = "merged_16bit")
+    assert stubs.snapshot_download.calls == []
+
+
+def test_quantized_base_skips(monkeypatch, tmp_path):
+    fn, stubs = _build_env(
+        monkeypatch,
+        tmp_path,
+        base_source = ("unsloth/gemma-4-31b-it-bnb-4bit", False, None, True, "nf4"),
+    )
+    fn(_FakePeftModel(), save_method = "merged_16bit")
+    assert stubs.snapshot_download.calls == []
+
+
+def test_non_peft_model_skips(monkeypatch, tmp_path):
+    fn, stubs = _build_env(monkeypatch, tmp_path)
+    fn(object(), save_method = "merged_16bit")
+    assert stubs.determine_base_model_source.calls == []
+    assert stubs.snapshot_download.calls == []
+
+
+def test_consolidated_shard_excluded_when_proper_shards_exist(monkeypatch, tmp_path):
+    fn, stubs = _build_env(
+        monkeypatch,
+        tmp_path,
+        shards = [
+            ("consolidated.safetensors", 14 * 1024**3),
+            ("model-00001-of-00001.safetensors", 14 * 1024**3),
+        ],
+    )
+    fn(_FakePeftModel(), save_method = "merged_16bit")
+    _, kwargs = stubs.snapshot_download.calls[0]
+    assert "consolidated.safetensors" not in kwargs["allow_patterns"]
+    assert "model-00001-of-00001.safetensors" in kwargs["allow_patterns"]
+
+
+def test_consolidated_only_repo_is_kept(monkeypatch, tmp_path):
+    fn, stubs = _build_env(
+        monkeypatch,
+        tmp_path,
+        shards = [("consolidated.safetensors", 14 * 1024**3)],
+    )
+    fn(_FakePeftModel(), save_method = "merged_16bit")
+    _, kwargs = stubs.snapshot_download.calls[0]
+    assert "consolidated.safetensors" in kwargs["allow_patterns"]
+
+
+def test_listing_failure_is_swallowed(monkeypatch, tmp_path):
+    fn, stubs = _build_env(monkeypatch, tmp_path)
+    stubs.determine_base_model_source.exc = RuntimeError("HF is down")
+    fn(_FakePeftModel(), save_method = "merged_16bit")  # must not raise
+    assert stubs.snapshot_download.calls == []
+
+
+def test_gpt_oss_bf16_mxfp4_swap_skips(monkeypatch, tmp_path):
+    fn, stubs = _build_env(monkeypatch, tmp_path)
+    fn(
+        _FakePeftModel(name_or_path = "unsloth/gpt-oss-20b-BF16"),
+        save_method = "mxfp4",
+    )
+    assert stubs.snapshot_download.calls == []
+
+
+def test_generic_save_calls_prewarm_before_merge():
+    """unsloth_generic_save must pre-warm the cache before merge_and_overwrite_lora."""
+    tree = ast.parse(_SOURCE)
+    fn = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "unsloth_generic_save"
+    )
+    body_src = ast.get_source_segment(_SOURCE, fn)
+    prewarm_pos = body_src.find("_prewarm_base_model_hub_cache(")
+    merge_pos = body_src.find("merge_and_overwrite_lora(")
+    assert prewarm_pos != -1, "unsloth_generic_save no longer pre-warms the hub cache"
+    assert merge_pos != -1
+    assert prewarm_pos < merge_pos, "pre-warm must run before the merge downloads shards"

--- a/tests/saving/test_prewarm_base_model_hub_cache.py
+++ b/tests/saving/test_prewarm_base_model_hub_cache.py
@@ -279,9 +279,9 @@ def test_missing_config_skips_cleanly(monkeypatch, tmp_path):
     fn(model, save_method = "merged_16bit")
     assert stubs.determine_base_model_source.calls == []
     assert stubs.snapshot_download.calls == []
-    assert not any("Could not pre-cache" in p for p in stubs.prints), (
-        "missing config took the error path instead of a clean skip"
-    )
+    assert not any(
+        "Could not pre-cache" in p for p in stubs.prints
+    ), "missing config took the error path instead of a clean skip"
 
 
 def test_relative_hub_cache_does_not_falsely_skip(monkeypatch, tmp_path):

--- a/tests/saving/test_prewarm_base_model_hub_cache.py
+++ b/tests/saving/test_prewarm_base_model_hub_cache.py
@@ -331,9 +331,8 @@ def test_missing_config_skips_cleanly(monkeypatch, tmp_path):
 
 
 def test_relative_hub_cache_does_not_falsely_skip(monkeypatch, tmp_path):
-    # A relative HF_HUB_CACHE whose leaf does not exist yet must still resolve to a
-    # real root for the disk-space probe; without abspath the walk-up hits "" and
-    # the pre-warm is wrongly skipped. Run from a real dir so abspath has a base.
+    # A relative HF_HUB_CACHE whose leaf does not exist yet must still resolve to a real
+    # root for the disk probe; without abspath the walk-up hits "" and pre-warm is skipped.
     monkeypatch.chdir(tmp_path)
     fn, stubs = _build_env(monkeypatch, tmp_path, hub_cache = "relcache/hub")
     fn(_FakePeftModel(), save_method = "merged_16bit")

--- a/tests/saving/test_prewarm_base_model_hub_cache.py
+++ b/tests/saving/test_prewarm_base_model_hub_cache.py
@@ -47,15 +47,19 @@ class _Recorder:
         self,
         result = None,
         exc = None,
+        results_fn = None,
     ):
         self.calls = []
         self.result = result
         self.exc = exc
+        self.results_fn = results_fn
 
     def __call__(self, *args, **kwargs):
         self.calls.append((args, kwargs))
         if self.exc is not None:
             raise self.exc
+        if self.results_fn is not None:
+            return self.results_fn(*args, **kwargs)
         return self.result
 
 
@@ -70,6 +74,8 @@ def _build_env(
     colab = False,
     hub_cache = None,
     live_hub_cache = "__same__",
+    fp8_sibling = None,
+    sibling_source = None,
 ):
     """Exec the extracted helper with stubbed collaborators; returns (fn, stubs)."""
     shards = (
@@ -102,6 +108,14 @@ def _build_env(
         hf_hub_download.exc = _LocalMiss("not cached")
     snapshot_download = _Recorder()
     determine_base_model_source = _Recorder(result = base_source)
+    # For the FP8 -> 16bit sibling swap: return the sibling's (16bit) source when the
+    # helper re-resolves the sibling, else the original base source.
+    if fp8_sibling is not None:
+        _sib_src = sibling_source or (fp8_sibling, False, None, False, None)
+        determine_base_model_source.results_fn = (
+            lambda name, token = None: _sib_src if name == fp8_sibling else base_source
+        )
+    resolve_fp8_16bit_sibling = _Recorder(result = fp8_sibling)
 
     cache_dir = tmp_path / "hub_cache"
     cache_dir.mkdir(exist_ok = True)
@@ -114,7 +128,10 @@ def _build_env(
             HF_HUB_CACHE = hub_cache if hub_cache is not None else str(cache_dir)
         ),
     )
-    zoo_module = types.SimpleNamespace(determine_base_model_source = determine_base_model_source)
+    zoo_module = types.SimpleNamespace(
+        determine_base_model_source = determine_base_model_source,
+        _resolve_fp8_16bit_sibling = resolve_fp8_16bit_sibling,
+    )
     # Stub the live-env cache resolver the pre-warm uses (matches what the merge reads).
     _live = (
         (hub_cache if hub_cache is not None else str(cache_dir))
@@ -148,6 +165,7 @@ def _build_env(
         snapshot_download = snapshot_download,
         hf_hub_download = hf_hub_download,
         determine_base_model_source = determine_base_model_source,
+        resolve_fp8_16bit_sibling = resolve_fp8_16bit_sibling,
         prints = prints,
     )
     return namespace["_prewarm_base_model_hub_cache"], stubs
@@ -349,3 +367,31 @@ def test_cached_probe_uses_live_env_cache(monkeypatch, tmp_path):
     assert all(
         kw.get("cache_dir") == "/mnt/persistent/hf/hub" for _, kw in stubs.hf_hub_download.calls
     )
+
+
+def test_fp8_base_prewarms_16bit_sibling_not_fp8_repo(monkeypatch, tmp_path):
+    # A merged_16bit export of an FP8 base with a 16bit sibling merges onto the sibling,
+    # so the pre-warm must cache the sibling (what the merge downloads), not the FP8 repo.
+    fn, stubs = _build_env(
+        monkeypatch,
+        tmp_path,
+        base_source = ("unsloth/Model-FP8", False, None, True, "fp8"),
+        fp8_sibling = "unsloth/Model",
+    )
+    fn(_FakePeftModel(name_or_path = "unsloth/Model-FP8"), save_method = "merged_16bit")
+    assert stubs.resolve_fp8_16bit_sibling.calls, "sibling resolver was not consulted"
+    assert len(stubs.snapshot_download.calls) == 1
+    assert stubs.snapshot_download.calls[0][1]["repo_id"] == "unsloth/Model"
+
+
+def test_fp8_base_without_sibling_still_prewarms_fp8_repo(monkeypatch, tmp_path):
+    # No sibling: the merge dequants the FP8 base in place, so caching the FP8 repo helps.
+    fn, stubs = _build_env(
+        monkeypatch,
+        tmp_path,
+        base_source = ("unsloth/Model-FP8", False, None, True, "fp8"),
+        fp8_sibling = None,
+    )
+    fn(_FakePeftModel(name_or_path = "unsloth/Model-FP8"), save_method = "merged_16bit")
+    assert len(stubs.snapshot_download.calls) == 1
+    assert stubs.snapshot_download.calls[0][1]["repo_id"] == "unsloth/Model-FP8"

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -245,6 +245,7 @@ def _maybe_advise_fla_install(model_types):
         "transformers will use a slower pure PyTorch path."
     )
 
+
 def _fix_rope_inv_freq(model):
     """Fix inv_freq corruption caused by transformers v5 meta-device loading.
 

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -3692,7 +3692,11 @@ from unsloth_zoo.llama_cpp import (
 )
 
 
-def _prewarm_base_model_hub_cache(model, save_method = "merged_16bit", token = None):
+def _prewarm_base_model_hub_cache(
+    model,
+    save_method = "merged_16bit",
+    token = None,
+):
     """Download the 16-bit base weights into the persistent HF hub cache before the merge.
 
     merge_and_overwrite_lora fetches missing shards with hf_hub_download(local_dir = ...),
@@ -3732,8 +3736,9 @@ def _prewarm_base_model_hub_cache(model, save_method = "merged_16bit", token = N
             return
 
         from unsloth_zoo.saving_utils import determine_base_model_source
-        model_name, is_local_path, _, base_is_quantized, quant_type = (
-            determine_base_model_source(model_name, token)
+
+        model_name, is_local_path, _, base_is_quantized, quant_type = determine_base_model_source(
+            model_name, token
         )
         if not model_name or is_local_path:
             return
@@ -3769,6 +3774,7 @@ def _prewarm_base_model_hub_cache(model, save_method = "merged_16bit", token = N
 
         # The cache copy is extra disk on top of the merge working copy; need room for both.
         from huggingface_hub import constants as _hf_constants
+
         cache_probe = os.path.expanduser(str(_hf_constants.HF_HUB_CACHE))
         while cache_probe and not os.path.exists(cache_probe):
             parent = os.path.dirname(cache_probe)

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -3791,9 +3791,13 @@ def _prewarm_base_model_hub_cache(
             )
             return
 
+        if total_size_in_bytes >= 0.1 * 1024**3:
+            size_str = f"{round(total_size_in_bytes / 1024**3, 1)}GB"
+        else:
+            size_str = f"{max(1, round(total_size_in_bytes / 1024**2))}MB"
         print(
             f"Unsloth: Downloading `{model_name}` into the Hugging Face cache so future "
-            f"exports skip the {round(total_size_in_bytes / 1024**3, 1)}GB download..."
+            f"exports skip the {size_str} download..."
         )
         snapshot_download(
             repo_id = model_name,

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -3692,6 +3692,116 @@ from unsloth_zoo.llama_cpp import (
 )
 
 
+def _prewarm_base_model_hub_cache(model, save_method = "merged_16bit", token = None):
+    """Download the 16-bit base weights into the persistent HF hub cache before the merge.
+
+    merge_and_overwrite_lora fetches missing shards with hf_hub_download(local_dir = ...),
+    which never populates the hub cache. When the merge directory is temporary (GGUF
+    checkpoint exports delete it after conversion), every export re-downloads the full
+    base model (#6890). Pre-warming the cache makes the first export download once and
+    later exports copy from the cache. Best-effort: any failure or skip falls back to
+    the streaming download. Disable with UNSLOTH_PREWARM_HUB_CACHE=0.
+    """
+    _false = ("0", "false", "no", "off")
+    if os.environ.get("UNSLOTH_PREWARM_HUB_CACHE", "1").strip().lower() in _false:
+        return
+    if IS_KAGGLE_ENVIRONMENT or IS_COLAB_ENVIRONMENT:
+        return
+    _true = ("1", "true", "yes", "on")
+    if (
+        os.environ.get("HF_HUB_OFFLINE", "").strip().lower() in _true
+        or os.environ.get("TRANSFORMERS_OFFLINE", "").strip().lower() in _true
+    ):
+        return
+    # Only the 16bit / mxfp4 merges download the base model; merged_4bit and lora do not.
+    if save_method not in ("merged_16bit", "mxfp4"):
+        return
+    if not isinstance(model, PeftModel):
+        return
+
+    try:
+        try:
+            model_name = get_model_name(model.config._name_or_path, load_in_4bit = False)
+        except Exception:
+            model_name = model.config._name_or_path
+        if not model_name or os.path.isdir(model_name):
+            return  # local checkpoints are copied, never downloaded
+
+        # The merge may swap a gpt-oss "-BF16" repo for its MXFP4 variant, so skip it.
+        if save_method == "mxfp4" and model_name.endswith("-BF16"):
+            return
+
+        from unsloth_zoo.saving_utils import determine_base_model_source
+        model_name, is_local_path, _, base_is_quantized, quant_type = (
+            determine_base_model_source(model_name, token)
+        )
+        if not model_name or is_local_path:
+            return
+        if base_is_quantized and quant_type in ("nf4", "fp4"):
+            return  # the 16bit merge refuses these bases; nothing worth caching
+
+        from huggingface_hub import HfFileSystem, hf_hub_download, snapshot_download
+
+        # Mirror the zoo's shard listing (drop consolidated.safetensors when proper
+        # shards coexist) so the cached set is a superset of what the merge looks up.
+        shard_names = []
+        total_size_in_bytes = 0
+        for x in HfFileSystem(token = token).ls(model_name, detail = True):
+            if x["name"].endswith(".safetensors"):
+                shard_names.append((os.path.split(x["name"])[-1], int(x.get("size") or 0)))
+        if any(name != "consolidated.safetensors" for name, _ in shard_names):
+            shard_names = [x for x in shard_names if x[0] != "consolidated.safetensors"]
+        if not shard_names:
+            return
+        total_size_in_bytes = sum(size for _, size in shard_names)
+
+        try:
+            for filename, _ in shard_names:
+                hf_hub_download(
+                    repo_id = model_name,
+                    filename = filename,
+                    local_files_only = True,
+                    token = token,
+                )
+            return  # already fully cached
+        except Exception:
+            pass
+
+        # The cache copy is extra disk on top of the merge working copy; need room for both.
+        from huggingface_hub import constants as _hf_constants
+        cache_probe = os.path.expanduser(str(_hf_constants.HF_HUB_CACHE))
+        while cache_probe and not os.path.exists(cache_probe):
+            parent = os.path.dirname(cache_probe)
+            if parent == cache_probe:
+                break
+            cache_probe = parent
+        free_space = shutil.disk_usage(cache_probe).free if os.path.exists(cache_probe) else 0
+        if free_space < 2 * total_size_in_bytes:
+            print(
+                f"Unsloth: Not enough free disk to keep `{model_name}` in the Hugging Face "
+                f"cache (need ~{round(2 * total_size_in_bytes / 1024**3, 1)}GB free, have "
+                f"{round(free_space / 1024**3, 1)}GB). Downloading straight to the merge "
+                f"directory instead; the next export will re-download it."
+            )
+            return
+
+        print(
+            f"Unsloth: Downloading `{model_name}` into the Hugging Face cache so future "
+            f"exports skip the {round(total_size_in_bytes / 1024**3, 1)}GB download..."
+        )
+        snapshot_download(
+            repo_id = model_name,
+            allow_patterns = [name for name, _ in shard_names]
+            + ["model.safetensors.index.json", "tokenizer.model"],
+            token = token,
+        )
+    except Exception as e:
+        print(
+            f"Unsloth: Could not pre-cache the base model weights ({e}). "
+            f"Falling back to downloading into the merge directory."
+        )
+
+
 @torch.inference_mode
 def save_to_gguf_generic(
     model,
@@ -3886,6 +3996,7 @@ def unsloth_generic_save(
 
         print(f"Unsloth: Model saved successfully to '{save_directory}'")
     else:
+        _prewarm_base_model_hub_cache(model, save_method = save_method, token = token)
         merge_and_overwrite_lora(
             get_model_name,
             model = model,

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -3747,6 +3747,21 @@ def _prewarm_base_model_hub_cache(
         )
         if not model_name or is_local_path:
             return
+        # Mirror the merge: an FP8 base with a 16bit sibling merges onto the sibling, so
+        # pre-warm the sibling (what the merge downloads), not the FP8 repo, else the
+        # cache-copy fast path misses and #6890 stays unfixed for FP8 bases.
+        if base_is_quantized and quant_type == "fp8" and save_method == "merged_16bit":
+            try:
+                from unsloth_zoo.saving_utils import _resolve_fp8_16bit_sibling
+                sibling = _resolve_fp8_16bit_sibling(model_name, token)
+            except Exception:
+                sibling = None
+            if sibling:
+                model_name, is_local_path, _, base_is_quantized, quant_type = (
+                    determine_base_model_source(sibling, token)
+                )
+                if not model_name or is_local_path:
+                    return
         if base_is_quantized and quant_type in ("nf4", "fp4"):
             return  # the 16bit merge refuses these bases; nothing worth caching
 

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -3724,10 +3724,14 @@ def _prewarm_base_model_hub_cache(
         return
 
     try:
+        # getattr so a model without a config / _name_or_path skips instead of raising.
+        name_or_path = getattr(getattr(model, "config", None), "_name_or_path", None)
+        if not name_or_path:
+            return
         try:
-            model_name = get_model_name(model.config._name_or_path, load_in_4bit = False)
+            model_name = get_model_name(name_or_path, load_in_4bit = False)
         except Exception:
-            model_name = model.config._name_or_path
+            model_name = name_or_path
         if not model_name or os.path.isdir(model_name):
             return  # local checkpoints are copied, never downloaded
 
@@ -3775,7 +3779,8 @@ def _prewarm_base_model_hub_cache(
         # The cache copy is extra disk on top of the merge working copy; need room for both.
         from huggingface_hub import constants as _hf_constants
 
-        cache_probe = os.path.expanduser(str(_hf_constants.HF_HUB_CACHE))
+        # abspath so a relative HF_HUB_CACHE walks up to an existing root, not "".
+        cache_probe = os.path.abspath(os.path.expanduser(str(_hf_constants.HF_HUB_CACHE)))
         while cache_probe and not os.path.exists(cache_probe):
             parent = os.path.dirname(cache_probe)
             if parent == cache_probe:

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -3788,7 +3788,6 @@ def _prewarm_base_model_hub_cache(
             shard_names = [x for x in shard_names if x[0] != "consolidated.safetensors"]
         if not shard_names:
             return
-        total_size_in_bytes = sum(size for _, size in shard_names)
 
         try:
             for filename, _ in shard_names:
@@ -3802,6 +3801,32 @@ def _prewarm_base_model_hub_cache(
             return  # already fully cached
         except Exception:
             pass
+
+        # Mirror the merge's index filter (only needed on the download path): some repos ship
+        # a leftover shard set the index does not reference; the merge keeps only indexed
+        # shards, so cache only those, else the disk gate over-counts (can skip) and
+        # snapshot_download fetches unused shards.
+        if len(shard_names) > 1:
+            try:
+                import json as _json
+
+                _idx = hf_hub_download(
+                    repo_id = model_name,
+                    filename = "model.safetensors.index.json",
+                    cache_dir = hub_cache_dir,
+                    token = token,
+                )
+                with open(_idx, encoding = "utf-8") as _f:
+                    _indexed = {
+                        os.path.split(v)[-1] for v in _json.load(_f).get("weight_map", {}).values()
+                    }
+                if _indexed and not {n for n, _ in shard_names}.issubset(_indexed):
+                    _kept = [x for x in shard_names if x[0] in _indexed]
+                    if _kept:
+                        shard_names = _kept
+            except Exception:
+                pass
+        total_size_in_bytes = sum(size for _, size in shard_names)
 
         # The cache copy is extra disk on top of the merge working copy; need room for both.
         from huggingface_hub import constants as _hf_constants

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -3751,6 +3751,16 @@ def _prewarm_base_model_hub_cache(
 
         from huggingface_hub import HfFileSystem, hf_hub_download, snapshot_download
 
+        # Resolve the cache from the live env (as the merge does), not huggingface_hub's
+        # import-time-frozen constants: a runtime HF cache redirect (read-only default
+        # cache, Studio) would otherwise pre-warm the wrong dir and miss on merge (#6890).
+        try:
+            from unsloth_zoo.hf_cache import _active_caches
+            _hub_cache = _active_caches()[1]
+            hub_cache_dir = str(_hub_cache) if _hub_cache is not None else None
+        except Exception:
+            hub_cache_dir = None
+
         # Mirror the zoo's shard listing (drop consolidated.safetensors when proper
         # shards coexist) so the cached set is a superset of what the merge looks up.
         shard_names = []
@@ -3769,6 +3779,7 @@ def _prewarm_base_model_hub_cache(
                 hf_hub_download(
                     repo_id = model_name,
                     filename = filename,
+                    cache_dir = hub_cache_dir,
                     local_files_only = True,
                     token = token,
                 )
@@ -3780,7 +3791,7 @@ def _prewarm_base_model_hub_cache(
         from huggingface_hub import constants as _hf_constants
 
         # abspath so a relative HF_HUB_CACHE walks up to an existing root, not "".
-        cache_probe = os.path.abspath(os.path.expanduser(str(_hf_constants.HF_HUB_CACHE)))
+        cache_probe = os.path.abspath(os.path.expanduser(str(hub_cache_dir or _hf_constants.HF_HUB_CACHE)))
         while cache_probe and not os.path.exists(cache_probe):
             parent = os.path.dirname(cache_probe)
             if parent == cache_probe:
@@ -3808,6 +3819,7 @@ def _prewarm_base_model_hub_cache(
             repo_id = model_name,
             allow_patterns = [name for name, _ in shard_names]
             + ["model.safetensors.index.json", "tokenizer.model"],
+            cache_dir = hub_cache_dir,
             token = token,
         )
     except Exception as e:

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -3791,7 +3791,9 @@ def _prewarm_base_model_hub_cache(
         from huggingface_hub import constants as _hf_constants
 
         # abspath so a relative HF_HUB_CACHE walks up to an existing root, not "".
-        cache_probe = os.path.abspath(os.path.expanduser(str(hub_cache_dir or _hf_constants.HF_HUB_CACHE)))
+        cache_probe = os.path.abspath(
+            os.path.expanduser(str(hub_cache_dir or _hf_constants.HF_HUB_CACHE))
+        )
         while cache_probe and not os.path.exists(cache_probe):
             parent = os.path.dirname(cache_probe)
             if parent == cache_probe:

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -3748,8 +3748,7 @@ def _prewarm_base_model_hub_cache(
         if not model_name or is_local_path:
             return
         # Mirror the merge: an FP8 base with a 16bit sibling merges onto the sibling, so
-        # pre-warm the sibling (what the merge downloads), not the FP8 repo, else the
-        # cache-copy fast path misses and #6890 stays unfixed for FP8 bases.
+        # pre-warm the sibling (what the merge downloads), not the FP8 repo (#6890).
         if base_is_quantized and quant_type == "fp8" and save_method == "merged_16bit":
             try:
                 from unsloth_zoo.saving_utils import _resolve_fp8_16bit_sibling
@@ -3767,9 +3766,8 @@ def _prewarm_base_model_hub_cache(
 
         from huggingface_hub import HfFileSystem, hf_hub_download, snapshot_download
 
-        # Resolve the cache from the live env (as the merge does), not huggingface_hub's
-        # import-time-frozen constants: a runtime HF cache redirect (read-only default
-        # cache, Studio) would otherwise pre-warm the wrong dir and miss on merge (#6890).
+        # Resolve the cache from the live env like the merge, not huggingface_hub's frozen
+        # constants: a runtime cache redirect (read-only default, Studio) would else miss (#6890).
         try:
             from unsloth_zoo.hf_cache import _active_caches
             _hub_cache = _active_caches()[1]
@@ -3802,10 +3800,9 @@ def _prewarm_base_model_hub_cache(
         except Exception:
             pass
 
-        # Mirror the merge's index filter (only needed on the download path): some repos ship
-        # a leftover shard set the index does not reference; the merge keeps only indexed
-        # shards, so cache only those, else the disk gate over-counts (can skip) and
-        # snapshot_download fetches unused shards.
+        # Mirror the merge's index filter (download path only): some repos ship leftover shards
+        # the index omits; keep only indexed ones, else the disk gate over-counts and we fetch
+        # unused shards.
         if len(shard_names) > 1:
             try:
                 import json as _json


### PR DESCRIPTION
Fixes #6890

## Problem

Exporting multiple checkpoints of a model that trains on a pre-quantized 4bit base (for example gemma-4-31b-it) re-downloads the full fp16 base model on every single export. For a 59GB base this can take longer than the training run itself.

Root cause: `merge_and_overwrite_lora` fetches the 16bit shards with `hf_hub_download(local_dir = save_directory)`. With `local_dir` set, huggingface_hub writes the files straight into the merge working directory and never populates the persistent hub cache (the `.cache/huggingface` folder reported in the issue is hub's local-dir metadata, not a redirected `HF_HOME`). Studio GGUF exports run the merge in a throwaway `_tmp_model_<uuid>` directory that is deleted after conversion, so the download is lost every time.

This affects more than GGUF export. Everything that funnels through `unsloth_generic_save` hits the same path: 16bit merged export, FP8/NVFP4 compressed-tensors and torchao exports (they merge to 16bit first), and `push_to_hub_merged` / `push_to_hub_gguf` (worst with `use_temp_file`, where shards land in a deleted temp dir). Training, inference and LoRA adapter export are not affected since they use normal `from_pretrained` caching.

## Fix

The zoo already has a cache fast path (`_try_copy_all_from_cache`) that copies shards from the hub cache instead of downloading. It just never gets a hit because nothing puts the fp16 base there. This PR adds `_prewarm_base_model_hub_cache()` in `unsloth/save.py`, called from `unsloth_generic_save` right before `merge_and_overwrite_lora`, so one site covers every export format. It runs `snapshot_download` for the fp16 base into the persistent hub cache, mirroring the zoo's shard listing (drops a redundant `consolidated.safetensors` when proper shards coexist) so the cached set is always a superset of what the merge looks up.

Result: the first export downloads the base once, every later export copies from the cache. This also means a base that was manually pre-downloaded into the standard HF cache is now picked up automatically, which was the workaround the issue author tried and could not get working.

The helper is strictly best-effort and skips itself when:

- the shards are already fully cached
- `UNSLOTH_PREWARM_HUB_CACHE=0` (opt out)
- offline (`HF_HUB_OFFLINE` / `TRANSFORMERS_OFFLINE`)
- running on Kaggle/Colab, where the hub cache is deliberately purged to save disk
- the base model is a local directory
- the save method does not download the base (`merged_4bit`, `forced_merged_4bit`, `lora`)
- the base is nf4/fp4 quantized (the 16bit merge refuses those anyway)
- the gpt-oss `-BF16` to MXFP4 repo swap case, where pre-warming could cache the wrong repo
- free disk on the cache filesystem cannot hold the cache copy on top of the merge working copy

Any exception inside the helper is swallowed and the export falls back to the previous streaming download behaviour.

## Tests

`tests/saving/test_prewarm_base_model_hub_cache.py` adds 21 GPU-free tests using the ast-extraction pattern already used elsewhere in the repo (since `unsloth.save` cannot be imported on hosts without an accelerator). They cover the download path and its arguments, the cache-hit skip, the disk gate, every skip condition above, the consolidated shard filter, exception swallowing, and that `unsloth_generic_save` calls the pre-warm before the merge.

All 21 pass locally, `py_compile` is clean and `scripts/enforce_kwargs_spacing.py` makes no changes.
