### PR TITLE
diffusion: skip non-bf16 linears for scaled_mm quant schemes

### DIFF
--- a/scripts/build_prequant_checkpoint.py
+++ b/scripts/build_prequant_checkpoint.py
@@ -58,6 +58,7 @@ def main(argv = None) -> int:
         FP8_GRANULARITY,
         TQ_FP8,
         TQ_SCHEMES,
+        _SCALED_MM_SCHEMES,
         _make_quant_config,
         _resolve_fast_accum,
         exclude_tokens_for_scheme,
@@ -87,13 +88,23 @@ def main(argv = None) -> int:
     # bakes them as int8 and crashes (torch._int_mm needs M>16) at the first denoise step on
     # Flux / Qwen. fp8 / fp4 / mx use scaled_mm (no M limit) -> exclude_tokens_for_scheme returns ().
     exclude_name_tokens = exclude_tokens_for_scheme(scheme)
+    # The scaled_mm schemes (fp8 / nvfp4 / mxfp8) assert a bf16 weight, so their filter must skip any
+    # non-bf16 Linear the transformer keeps: a mixed-precision DiT (Wan / Hunyuan) retains its
+    # _keep_in_fp32_modules in fp32 even under torch_dtype=bf16, so quantising one would raise inside
+    # quantize_ and abort the whole pass. Runtime quantize_transformer gates this on scheme membership;
+    # mirror it here so the offline checkpoint quantises the exact same layer set (offline == runtime).
+    require_bf16 = scheme in _SCALED_MM_SCHEMES
     # fp8 bakes the accumulate mode into the saved kernels; record the resolved choice so the
     # loader can refuse a checkpoint whose baked value contradicts an explicit runtime request.
     fast_accum = _resolve_fast_accum(None) if scheme == TQ_FP8 else None
     quantize_(
         transformer,
         _make_quant_config(scheme),
-        filter_fn = make_filter_fn(args.min_features, exclude_name_tokens = exclude_name_tokens),
+        filter_fn = make_filter_fn(
+            args.min_features,
+            exclude_name_tokens = exclude_name_tokens,
+            require_bf16 = require_bf16,
+        ),
     )
 
     # Move the state dict to CPU for a portable, GPU-free artifact.
@@ -107,9 +118,11 @@ def main(argv = None) -> int:
         "scheme": scheme,
         "min_features": args.min_features,
         # The layers skipped for this scheme (int8's M=1 modulation projections; () for
-        # the scaled_mm schemes) and, for fp8, the baked accumulate mode. Both let the
-        # loader reject a checkpoint that would not match the runtime path.
+        # the scaled_mm schemes), whether non-bf16 Linears were skipped (the scaled_mm
+        # bf16 gate), and, for fp8, the baked accumulate mode. All let the loader reject a
+        # checkpoint that would not match the runtime path.
         "exclude_name_tokens": list(exclude_name_tokens),
+        "require_bf16": require_bf16,
         "fast_accum": fast_accum,
         "torch_dtype": args.dtype,
         "quant_backend": "torchao",

--- a/scripts/build_prequant_checkpoint.py
+++ b/scripts/build_prequant_checkpoint.py
@@ -58,7 +58,7 @@ def main(argv = None) -> int:
         FP8_GRANULARITY,
         TQ_FP8,
         TQ_SCHEMES,
-        _SCALED_MM_SCHEMES,
+        _REQUIRE_BF16_SCHEMES,
         _make_quant_config,
         _resolve_fast_accum,
         exclude_tokens_for_scheme,
@@ -88,12 +88,13 @@ def main(argv = None) -> int:
     # bakes them as int8 and crashes (torch._int_mm needs M>16) at the first denoise step on
     # Flux / Qwen. fp8 / fp4 / mx use scaled_mm (no M limit) -> exclude_tokens_for_scheme returns ().
     exclude_name_tokens = exclude_tokens_for_scheme(scheme)
-    # The scaled_mm schemes (fp8 / nvfp4 / mxfp8) assert a bf16 weight, so their filter must skip any
-    # non-bf16 Linear the transformer keeps: a mixed-precision DiT (Wan / Hunyuan) retains its
-    # _keep_in_fp32_modules in fp32 even under torch_dtype=bf16, so quantising one would raise inside
-    # quantize_ and abort the whole pass. Runtime quantize_transformer gates this on scheme membership;
-    # mirror it here so the offline checkpoint quantises the exact same layer set (offline == runtime).
-    require_bf16 = scheme in _SCALED_MM_SCHEMES
+    # fp8 and mxfp8 assert a bf16 weight, so their filter must skip any non-bf16 Linear the
+    # transformer keeps: a mixed-precision DiT (Wan / Hunyuan) retains its _keep_in_fp32_modules in
+    # fp32 even under torch_dtype=bf16, so quantising one would raise inside quantize_ and abort the
+    # whole pass. nvfp4 quantises fp32 fine, so it is not gated. Runtime quantize_transformer gates
+    # this on scheme membership; mirror it here so the offline checkpoint quantises the exact same
+    # layer set (offline == runtime).
+    require_bf16 = scheme in _REQUIRE_BF16_SCHEMES
     # fp8 bakes the accumulate mode into the saved kernels; record the resolved choice so the
     # loader can refuse a checkpoint whose baked value contradicts an explicit runtime request.
     fast_accum = _resolve_fast_accum(None) if scheme == TQ_FP8 else None

--- a/studio/backend/core/inference/diffusion_precision.py
+++ b/studio/backend/core/inference/diffusion_precision.py
@@ -233,9 +233,9 @@ def _cast_fp8_dynamic(encoder: Any, target: Any) -> None:
     # require_bf16: scaled_mm asserts a bf16 weight, so skip any stray non-bf16 Linear the encoder
     # keeps (belt-and-suspenders over the named T5 wo exclusion) rather than aborting the pass.
     filter_fn = make_filter_fn(
-        DEFAULT_MIN_LINEAR_FEATURES, _te_exclude_tokens(encoder), require_bf16=True
+        DEFAULT_MIN_LINEAR_FEATURES, _te_exclude_tokens(encoder), require_bf16 = True
     )
-    quantize_(encoder, _make_quant_config(TQ_FP8), filter_fn=filter_fn)
+    quantize_(encoder, _make_quant_config(TQ_FP8), filter_fn = filter_fn)
 
 
 def _cast_fp8(encoder: Any, target: Any) -> None:

--- a/studio/backend/core/inference/diffusion_precision.py
+++ b/studio/backend/core/inference/diffusion_precision.py
@@ -230,8 +230,12 @@ def _cast_fp8_dynamic(encoder: Any, target: Any) -> None:
         make_filter_fn,
     )
 
-    filter_fn = make_filter_fn(DEFAULT_MIN_LINEAR_FEATURES, _te_exclude_tokens(encoder))
-    quantize_(encoder, _make_quant_config(TQ_FP8), filter_fn = filter_fn)
+    # require_bf16: scaled_mm asserts a bf16 weight, so skip any stray non-bf16 Linear the encoder
+    # keeps (belt-and-suspenders over the named T5 wo exclusion) rather than aborting the pass.
+    filter_fn = make_filter_fn(
+        DEFAULT_MIN_LINEAR_FEATURES, _te_exclude_tokens(encoder), require_bf16=True
+    )
+    quantize_(encoder, _make_quant_config(TQ_FP8), filter_fn=filter_fn)
 
 
 def _cast_fp8(encoder: Any, target: Any) -> None:

--- a/studio/backend/core/inference/diffusion_prequant.py
+++ b/studio/backend/core/inference/diffusion_prequant.py
@@ -329,15 +329,16 @@ def _validate_checkpoint(
                 ),
             )
             return False
-    # require_bf16 (skip non-bf16 Linears) is the scaled_mm bf16 gate, derived from the scheme's
-    # use of scaled_mm. Like exclude_name_tokens it is pinned by the scheme today, but recording and
-    # verifying it guards against a future _SCALED_MM_SCHEMES change silently loading a checkpoint
-    # built under the old filter (it would carry a different quantised layer set). Absent (older
-    # artifact) is accepted since scheme already pins today's gate.
+    # require_bf16 (skip non-bf16 Linears) is the bf16-weight gate, pinned by the scheme (fp8 and
+    # mxfp8 assert a bf16 weight; nvfp4 / int8 quantise fp32 fine). Like exclude_name_tokens it is
+    # pinned by the scheme today, but recording and verifying it guards against a future
+    # _REQUIRE_BF16_SCHEMES change silently loading a checkpoint built under the old filter (it would
+    # carry a different quantised layer set). Absent (older artifact) is accepted since scheme already
+    # pins today's gate.
     ckpt_require_bf16 = meta.get("require_bf16")
     if ckpt_require_bf16 is not None:
-        from .diffusion_transformer_quant import _SCALED_MM_SCHEMES
-        expected_require_bf16 = scheme in _SCALED_MM_SCHEMES
+        from .diffusion_transformer_quant import _REQUIRE_BF16_SCHEMES
+        expected_require_bf16 = scheme in _REQUIRE_BF16_SCHEMES
         if bool(ckpt_require_bf16) != expected_require_bf16:
             _warn(
                 logger,

--- a/studio/backend/core/inference/diffusion_prequant.py
+++ b/studio/backend/core/inference/diffusion_prequant.py
@@ -329,6 +329,24 @@ def _validate_checkpoint(
                 ),
             )
             return False
+    # require_bf16 (skip non-bf16 Linears) is the scaled_mm bf16 gate, derived from the scheme's
+    # use of scaled_mm. Like exclude_name_tokens it is pinned by the scheme today, but recording and
+    # verifying it guards against a future _SCALED_MM_SCHEMES change silently loading a checkpoint
+    # built under the old filter (it would carry a different quantised layer set). Absent (older
+    # artifact) is accepted since scheme already pins today's gate.
+    ckpt_require_bf16 = meta.get("require_bf16")
+    if ckpt_require_bf16 is not None:
+        from .diffusion_transformer_quant import _SCALED_MM_SCHEMES
+        expected_require_bf16 = scheme in _SCALED_MM_SCHEMES
+        if bool(ckpt_require_bf16) != expected_require_bf16:
+            _warn(
+                logger,
+                scheme,
+                ValueError(
+                    f"checkpoint require_bf16 {bool(ckpt_require_bf16)!r} != {expected_require_bf16!r}"
+                ),
+            )
+            return False
     # fp8 fast-accum is baked into the saved kernels; only enforce when the caller forces it.
     if fast_accum is not None:
         ckpt_fa = meta.get("fast_accum")

--- a/studio/backend/core/inference/diffusion_transformer_quant.py
+++ b/studio/backend/core/inference/diffusion_transformer_quant.py
@@ -37,6 +37,11 @@ TQ_AUTO = "auto"
 TQ_SCHEMES = (TQ_INT8, TQ_FP8, TQ_NVFP4, TQ_MXFP8)
 TQ_MODES = (TQ_AUTO,) + TQ_SCHEMES
 
+# Schemes whose kernels (torch._scaled_mm / the fp4 / mx GEMMs) assert a bf16 input weight, so their
+# quantise filter must skip non-bf16 Linears (see make_filter_fn's require_bf16). int8 (torch._int_mm)
+# is not in this set: it quantises fp32/fp16 weights fine.
+_SCALED_MM_SCHEMES = (TQ_FP8, TQ_NVFP4, TQ_MXFP8)
+
 # The fp8 weight/activation granularity the runtime config uses (see _make_quant_config):
 # per-ROW is REQUIRED for correctness on outlier-heavy DiTs. Stamped into a pre-quantized
 # fp8 checkpoint's metadata at build time and required by the loader, so a stale checkpoint
@@ -391,11 +396,23 @@ def _make_quant_config(scheme: str, fast_accum: Optional[bool] = None) -> Any:
     raise ValueError(f"unknown transformer quant scheme '{scheme}'")
 
 
-def make_filter_fn(min_features: int, exclude_name_tokens: tuple[str, ...] = ()):
+def make_filter_fn(
+    min_features: int,
+    exclude_name_tokens: tuple[str, ...] = (),
+    *,
+    require_bf16: bool = False,
+):
     """A torchao ``quantize_`` filter keeping only the FLOP-heavy linears: nn.Linear with both
     in/out features >= ``min_features`` AND whose fully-qualified name contains none of
     ``exclude_name_tokens`` (used by int8 to skip the M=1 modulation / conditioning-embedder
-    projections that crash ``torch._int_mm``). Hides the (module, fqn) callback arity."""
+    projections that crash ``torch._int_mm``). Hides the (module, fqn) callback arity.
+
+    ``require_bf16`` additionally skips any Linear whose weight is not bfloat16. The scaled_mm
+    schemes (fp8 / mxfp8 / nvfp4) assert a bf16 input weight, so a single non-bf16 Linear -- e.g.
+    the fp32 layers Wan / Hunyuan video DiTs keep for numerical stability -- otherwise raises inside
+    ``quantize_`` and aborts the ENTIRE pass, leaving the module silently dense. Gating those layers
+    out lets the scheme engage on the bf16 linears and skip the fp32 ones. int8 (torch._int_mm)
+    tolerates non-bf16 weights, so it leaves this off and keeps quantising them."""
 
     def filter_fn(module: Any, fqn: str = "") -> bool:
         try:
@@ -413,6 +430,11 @@ def make_filter_fn(min_features: int, exclude_name_tokens: tuple[str, ...] = ())
         if exclude_name_tokens:
             name = fqn.lower() if fqn else ""
             if any(tok in name for tok in exclude_name_tokens):
+                return False
+        if require_bf16:
+            import torch
+            weight = getattr(module, "weight", None)
+            if weight is None or weight.dtype != torch.bfloat16:
                 return False
         return True
 
@@ -446,12 +468,18 @@ def quantize_transformer(
         from torchao.quantization import quantize_
 
         # int8 (torch._int_mm, M>16) additionally skips the M=1 modulation / conditioning-embedder
-        # projections; fp8 / fp4 / mx (scaled_mm) have no such limit and quantise everything.
+        # projections; fp8 / fp4 / mx (scaled_mm) have no such limit and quantise everything -- but
+        # they assert a bf16 weight, so on a mixed-precision DiT (Wan / Hunyuan keep some fp32
+        # linears) they must skip the non-bf16 ones or the whole pass raises and no-ops.
         exclude = exclude_tokens_for_scheme(scheme)
         quantize_(
             transformer,
             _make_quant_config(scheme, fast_accum = fast_accum),
-            filter_fn = make_filter_fn(min_features, exclude_name_tokens = exclude),
+            filter_fn = make_filter_fn(
+                min_features,
+                exclude_name_tokens = exclude,
+                require_bf16 = scheme in _SCALED_MM_SCHEMES,
+            ),
         )
         # Runtime-only marker (torchao tensors are not safetensors-serializable; this
         # backend is inference-only, so this is purely diagnostic).

--- a/studio/backend/core/inference/diffusion_transformer_quant.py
+++ b/studio/backend/core/inference/diffusion_transformer_quant.py
@@ -37,10 +37,15 @@ TQ_AUTO = "auto"
 TQ_SCHEMES = (TQ_INT8, TQ_FP8, TQ_NVFP4, TQ_MXFP8)
 TQ_MODES = (TQ_AUTO,) + TQ_SCHEMES
 
-# Schemes whose kernels (torch._scaled_mm / the fp4 / mx GEMMs) assert a bf16 input weight, so their
-# quantise filter must skip non-bf16 Linears (see make_filter_fn's require_bf16). int8 (torch._int_mm)
-# is not in this set: it quantises fp32/fp16 weights fine.
-_SCALED_MM_SCHEMES = (TQ_FP8, TQ_NVFP4, TQ_MXFP8)
+# Schemes whose torchao path asserts a bf16 weight, so their quantise filter must skip
+# non-bf16 Linears (see make_filter_fn's require_bf16) rather than aborting the whole pass on a
+# stray fp32 Linear (e.g. T5's fp32 `wo`). Verified on torchao 0.17 / B200: fp8 per-row asserts
+# "PerRow quantization only works for bfloat16 precision input weight" and mxfp8 asserts
+# "Only supporting bf16 out dtype", but NVFP4's high-precision conversion quantises an fp32
+# weight fine (forward included) -- so nvfp4 is deliberately NOT gated here, keeping those fp32
+# projections quantised instead of leaving them dense. int8 (torch._int_mm) also quantises
+# fp32/fp16 weights fine, so it is not gated either.
+_REQUIRE_BF16_SCHEMES = (TQ_FP8, TQ_MXFP8)
 
 # The fp8 weight/activation granularity the runtime config uses (see _make_quant_config):
 # per-ROW is REQUIRED for correctness on outlier-heavy DiTs. Stamped into a pre-quantized
@@ -469,8 +474,9 @@ def quantize_transformer(
 
         # int8 (torch._int_mm, M>16) additionally skips the M=1 modulation / conditioning-embedder
         # projections; fp8 / fp4 / mx (scaled_mm) have no such limit and quantise everything -- but
-        # they assert a bf16 weight, so on a mixed-precision DiT (Wan / Hunyuan keep some fp32
-        # linears) they must skip the non-bf16 ones or the whole pass raises and no-ops.
+        # fp8 and mxfp8 assert a bf16 weight, so on a mixed-precision DiT (Wan / Hunyuan keep some
+        # fp32 linears) they must skip the non-bf16 ones or the whole pass raises and no-ops. nvfp4
+        # quantises fp32 weights fine, so it is not gated (see _REQUIRE_BF16_SCHEMES).
         exclude = exclude_tokens_for_scheme(scheme)
         quantize_(
             transformer,
@@ -478,7 +484,7 @@ def quantize_transformer(
             filter_fn = make_filter_fn(
                 min_features,
                 exclude_name_tokens = exclude,
-                require_bf16 = scheme in _SCALED_MM_SCHEMES,
+                require_bf16 = scheme in _REQUIRE_BF16_SCHEMES,
             ),
         )
         # Runtime-only marker (torchao tensors are not safetensors-serializable; this

--- a/studio/backend/tests/test_diffusion_prequant.py
+++ b/studio/backend/tests/test_diffusion_prequant.py
@@ -286,6 +286,28 @@ def test_load_exclude_tokens_match_ok(monkeypatch, tmp_path):
     assert _load(monkeypatch, tmp_path, ckpt, scheme = "int8") is not None
 
 
+def test_load_require_bf16_mismatch_is_none(monkeypatch, tmp_path):
+    # An fp8 (scaled_mm) checkpoint built WITHOUT the bf16 gate quantised a different layer set
+    # than the runtime filter now produces, so it must be rejected rather than loaded.
+    ckpt = _good_ckpt(scheme = "fp8")
+    ckpt["metadata"]["require_bf16"] = False
+    assert _load(monkeypatch, tmp_path, ckpt, scheme = "fp8") is None
+
+
+def test_load_require_bf16_match_ok(monkeypatch, tmp_path):
+    ckpt = _good_ckpt(scheme = "fp8")
+    ckpt["metadata"]["require_bf16"] = True
+    assert _load(monkeypatch, tmp_path, ckpt, scheme = "fp8") is not None
+
+
+def test_load_require_bf16_int8_true_is_none(monkeypatch, tmp_path):
+    # int8 (torch._int_mm) tolerates non-bf16 weights, so it never sets the gate; a checkpoint
+    # claiming it did contradicts the runtime filter and must be rejected.
+    ckpt = _good_ckpt(scheme = "int8")
+    ckpt["metadata"]["require_bf16"] = True
+    assert _load(monkeypatch, tmp_path, ckpt, scheme = "int8") is None
+
+
 def test_resolve_checkpoint_path_expands_user(monkeypatch, tmp_path):
     # The allowlist gate expands ~, so the existence check must too, or a "~/..." checkpoint
     # that passed the gate is silently skipped.

--- a/studio/backend/tests/test_diffusion_prequant.py
+++ b/studio/backend/tests/test_diffusion_prequant.py
@@ -308,6 +308,22 @@ def test_load_require_bf16_int8_true_is_none(monkeypatch, tmp_path):
     assert _load(monkeypatch, tmp_path, ckpt, scheme = "int8") is None
 
 
+def test_load_require_bf16_nvfp4_false_ok(monkeypatch, tmp_path):
+    # nvfp4 quantises fp32 weights fine, so the runtime filter does NOT set the bf16 gate; a
+    # checkpoint built the same way (require_bf16=False) matches and loads.
+    ckpt = _good_ckpt(scheme = "nvfp4")
+    ckpt["metadata"]["require_bf16"] = False
+    assert _load(monkeypatch, tmp_path, ckpt, scheme = "nvfp4") is not None
+
+
+def test_load_require_bf16_nvfp4_true_is_none(monkeypatch, tmp_path):
+    # An nvfp4 checkpoint claiming the bf16 gate contradicts the runtime filter (nvfp4 is not gated),
+    # so it quantised a different layer set and must be rejected.
+    ckpt = _good_ckpt(scheme = "nvfp4")
+    ckpt["metadata"]["require_bf16"] = True
+    assert _load(monkeypatch, tmp_path, ckpt, scheme = "nvfp4") is None
+
+
 def test_resolve_checkpoint_path_expands_user(monkeypatch, tmp_path):
     # The allowlist gate expands ~, so the existence check must too, or a "~/..." checkpoint
     # that passed the gate is silently skipped.

--- a/studio/backend/tests/test_diffusion_transformer_quant.py
+++ b/studio/backend/tests/test_diffusion_transformer_quant.py
@@ -325,6 +325,29 @@ def test_make_filter_fn(monkeypatch):
     assert keep(types.SimpleNamespace(), "no_attrs") is False
 
 
+def test_make_filter_fn_require_bf16_skips_non_bf16(monkeypatch):
+    # The scaled_mm schemes (fp8 / mxfp8 / nvfp4) assert a bf16 weight, so require_bf16 must skip a
+    # fp32 Linear (which Wan / Hunyuan video DiTs keep) while keeping the bf16 ones -- otherwise a
+    # single fp32 layer raises inside quantize_ and no-ops the whole pass. int8 leaves it off.
+    torch = types.ModuleType("torch")
+    torch.bfloat16, torch.float32 = "bf16", "fp32"
+
+    class _Lin:
+        def __init__(self, i, o, dtype):
+            self.in_features, self.out_features = i, o
+            self.weight = types.SimpleNamespace(dtype = dtype)
+
+    torch.nn = types.SimpleNamespace(Linear = _Lin)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    gated = make_filter_fn(512, require_bf16 = True)
+    assert gated(_Lin(1024, 4096, torch.bfloat16), "blocks.0.attn.to_q") is True
+    assert gated(_Lin(1024, 4096, torch.float32), "blocks.0.attn.to_q") is False  # fp32 -> skip
+    assert gated(types.SimpleNamespace(in_features = 1024, out_features = 4096), "no_weight") is False
+    # int8 (require_bf16 off, the default) still quantises the fp32 linear.
+    assert make_filter_fn(512)(_Lin(1024, 4096, torch.float32), "blocks.0.attn.to_q") is True
+
+
 def test_make_filter_fn_int8_excludes_modulation_and_embedders(monkeypatch):
     # The int8 path skips the large M=1 AdaLN modulation / conditioning-embedder projections
     # (they crash torch._int_mm's M>16), while keeping the attention / FFN compute layers and

--- a/studio/backend/tests/test_diffusion_transformer_quant.py
+++ b/studio/backend/tests/test_diffusion_transformer_quant.py
@@ -325,10 +325,28 @@ def test_make_filter_fn(monkeypatch):
     assert keep(types.SimpleNamespace(), "no_attrs") is False
 
 
+def test_require_bf16_schemes_excludes_nvfp4():
+    # fp8 and mxfp8 assert a bf16 weight (torchao 0.17 / B200: "PerRow quantization only works for
+    # bfloat16 ..." and "Only supporting bf16 out dtype ..."), so they gate on it; nvfp4 quantises an
+    # fp32 weight fine, so it is NOT gated (leaving its large fp32 projections quantised, not dense).
+    from core.inference.diffusion_transformer_quant import (
+        _REQUIRE_BF16_SCHEMES,
+        TQ_FP8,
+        TQ_MXFP8,
+        TQ_NVFP4,
+        TQ_INT8,
+    )
+
+    assert TQ_FP8 in _REQUIRE_BF16_SCHEMES
+    assert TQ_MXFP8 in _REQUIRE_BF16_SCHEMES
+    assert TQ_NVFP4 not in _REQUIRE_BF16_SCHEMES
+    assert TQ_INT8 not in _REQUIRE_BF16_SCHEMES
+
+
 def test_make_filter_fn_require_bf16_skips_non_bf16(monkeypatch):
-    # The scaled_mm schemes (fp8 / mxfp8 / nvfp4) assert a bf16 weight, so require_bf16 must skip a
-    # fp32 Linear (which Wan / Hunyuan video DiTs keep) while keeping the bf16 ones -- otherwise a
-    # single fp32 layer raises inside quantize_ and no-ops the whole pass. int8 leaves it off.
+    # fp8 / mxfp8 assert a bf16 weight, so require_bf16 must skip a fp32 Linear (which Wan / Hunyuan
+    # video DiTs keep) while keeping the bf16 ones -- otherwise a single fp32 layer raises inside
+    # quantize_ and no-ops the whole pass. int8 and nvfp4 leave it off (they quantise fp32 fine).
     torch = types.ModuleType("torch")
     torch.bfloat16, torch.float32 = "bf16", "fp32"
 


### PR DESCRIPTION
## Problem

fp8 / mxfp8 / nvfp4 run on `torch._scaled_mm` and the fp4 / mx GEMMs, which assert a bfloat16 input weight. On a mixed-precision DiT that keeps some linears in fp32 for numerical stability, `quantize_` hits the first fp32 linear, raises, and `quantize_transformer`'s best-effort wrapper swallows the exception to `None`. The transformer then stays fully dense with no error surfaced and no speedup or memory saving.

This bites the video DiTs in particular. Wan2.2 (TI2V-5B and T2V-A14B) and HunyuanVideo-1.5 ship transformers with a mix of bf16 and fp32 linears, so fp8 and mxfp8 silently no-op on them today, while int8 (which uses `torch._int_mm`) works.

## Fix

Add a `require_bf16` gate to `make_filter_fn` and pass it for the scaled_mm schemes in `quantize_transformer` (and the `fp8_dynamic` text-encoder caster). The gate skips non-bf16 linears so the scheme engages on the bf16 ones and leaves the fp32 layers dense. int8 leaves the gate off and keeps quantizing fp32/fp16 weights as before, so its coverage is unchanged.

## Verification

- New unit test `test_make_filter_fn_require_bf16_skips_non_bf16`: with the gate on, a fp32 linear is skipped and a bf16 linear is kept; with it off (int8) the fp32 linear is still quantized.
- On Wan2.2-TI2V-5B, fp8 and mxfp8 now quantize 303 linears through the committed `quantize_transformer` path where they previously engaged 0 (int8 unchanged at 303).
- Full `test_diffusion_transformer_quant.py` + `test_diffusion_precision.py` green (61 passed).

Stacked on #6894 (te-encoder-int8); the text-encoder caster hunk depends on that branch's `_cast_fp8_dynamic`.