### PR TITLE
fix: correct class name in SyntheticDataKit.chunk_data guard message

### DIFF
--- a/tests/test_synthetic_chunk_data.py
+++ b/tests/test_synthetic_chunk_data.py
@@ -119,12 +119,12 @@ def test_chunk_data_uninitialized_error_names_real_class():
             raise AssertionError("expected RuntimeError when max_seq_length is unset")
         except RuntimeError as e:
             msg = str(e)
-            assert "SyntheticDataKit.from_pretrained" in msg, (
-                f"error must name SyntheticDataKit.from_pretrained, got: {msg}"
-            )
-            assert "SynthetidDataKit" not in msg, (
-                f"error must not misspell the class name, got: {msg}"
-            )
+            assert (
+                "SyntheticDataKit.from_pretrained" in msg
+            ), f"error must name SyntheticDataKit.from_pretrained, got: {msg}"
+            assert (
+                "SynthetidDataKit" not in msg
+            ), f"error must not misspell the class name, got: {msg}"
     finally:
         os.unlink(path)
 

--- a/tests/test_synthetic_chunk_data.py
+++ b/tests/test_synthetic_chunk_data.py
@@ -104,10 +104,36 @@ def test_chunk_data_rejects_overlap_not_smaller_than_chunk():
         os.unlink(path)
 
 
+def test_chunk_data_uninitialized_error_names_real_class():
+    # Without max_seq_length the guard tells the user which method to call first.
+    # The message must name the real class (SyntheticDataKit) so copying it works;
+    # a misspelling would raise NameError when the user follows it verbatim.
+    kit = SyntheticDataKit.__new__(SyntheticDataKit)
+    kit.tokenizer = _MockTokenizer()  # max_seq_length intentionally unset
+    with tempfile.NamedTemporaryFile("w", suffix = ".txt", delete = False) as f:
+        f.write("word " * 50)
+        path = f.name
+    try:
+        try:
+            kit.chunk_data(filename = path)
+            raise AssertionError("expected RuntimeError when max_seq_length is unset")
+        except RuntimeError as e:
+            msg = str(e)
+            assert "SyntheticDataKit.from_pretrained" in msg, (
+                f"error must name SyntheticDataKit.from_pretrained, got: {msg}"
+            )
+            assert "SynthetidDataKit" not in msg, (
+                f"error must not misspell the class name, got: {msg}"
+            )
+    finally:
+        os.unlink(path)
+
+
 if __name__ == "__main__":
     test_chunk_data_keeps_single_chunk_document()
     test_chunk_data_still_splits_long_document()
     test_chunk_data_empty_document_yields_no_chunks()
     test_chunk_data_short_document_is_not_split_into_fragments()
     test_chunk_data_rejects_overlap_not_smaller_than_chunk()
+    test_chunk_data_uninitialized_error_names_real_class()
     print("OK")

--- a/unsloth/dataprep/synthetic.py
+++ b/unsloth/dataprep/synthetic.py
@@ -391,7 +391,7 @@ class SyntheticDataKit:
         assert os.path.exists(filename)
         assert hasattr(self, "tokenizer")
         if not hasattr(self, "max_seq_length"):
-            raise RuntimeError("Please use SynthetidDataKit.from_pretrained(...) first!")
+            raise RuntimeError("Please use SyntheticDataKit.from_pretrained(...) first!")
         if not hasattr(self, "overlap") or not hasattr(self, "max_generation_tokens"):
             raise RuntimeError("Please use prepare_qa_generation first!")
 


### PR DESCRIPTION

### What

`SyntheticDataKit.chunk_data` raises a guard error when it is called before the
kit is initialized (`max_seq_length` unset), telling the user which method to
call first. The class name in that message is misspelled:

```python
# unsloth/dataprep/synthetic.py
raise RuntimeError("Please use SynthetidDataKit.from_pretrained(...) first!")
#                               ^^^^^^^^^ "Synthetid" (transposed), not "Synthetic"
```

The class is `SyntheticDataKit` (defined in the same file, exported in
`__all__`, constructed via the `from_pretrained` classmethod). A user who copies
the instruction verbatim hits a second, confusing error:

```
NameError: name 'SynthetidDataKit' is not defined
```

### Fix

Correct the single misspelled token in the message
(`Synthetid` -> `Synthetic`) so the guidance is actionable. This is
user-facing error text only; there is no behavior change.

### Test

Adds one regression test to `tests/test_synthetic_chunk_data.py` that builds a
kit without `max_seq_length`, calls `chunk_data`, and asserts the raised message
names `SyntheticDataKit.from_pretrained` and does not contain the old
misspelling.

### Notes

- Single focused change per CONTRIBUTING.
- Lint: `ruff check` on both files passes.
- No linked issue exists; found while reading `dataprep`.
