### PR TITLE
CI: pin lockfile-audit actions to commit SHAs

### DIFF
--- a/.github/workflows/lockfile-audit.yml
+++ b/.github/workflows/lockfile-audit.yml
@@ -60,11 +60,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
## Problem

`.github/workflows/lockfile-audit.yml` is the only workflow still referencing
GitHub Actions by mutable tag:

```yaml
- uses: actions/checkout@v4
- uses: actions/setup-python@v5
```

Every other `uses:` across `.github/workflows/` is pinned to a full 40-char
commit SHA, and `security-audit.yml`'s "GitHub Actions pinning verifier" step
exists specifically to flag non-SHA-pinned references. A mutable tag can be
force-moved to an arbitrary commit (the class of attack behind the
tj-actions/changed-files compromise that the harden-runner comments already
cite), so these two lines are the one spot in the tree where that mitigation is
missing.

The blast radius is limited: this job only runs `python3 -c ast.parse` plus
`scripts/lockfile_supply_chain_audit.py` under `permissions: contents: read`,
so a hijacked action here could tamper with the audit result or read the
read-scoped token, but not write to the repo. It is still a real
self-consistency gap in the supply-chain hardening the project clearly cares
about.

## Fix

Pin both references to the commit SHAs behind the versions the rest of the tree
is already moving to, keeping the repo's `SHA  # vX.Y.Z` comment format:

- `actions/checkout@v4` -> `actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0`
- `actions/setup-python@v5` -> `actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0`

Both SHAs were verified against the upstream tag refs. After this change, no
`uses:` in `.github/workflows/` resolves to a mutable tag. Dependabot's
`github-actions` ecosystem keeps the SHAs current afterwards, exactly like every
other reference.

## Notes

An open Dependabot actions bump (#6893) advances every other `checkout` /
`setup-python` reference across the workflow tree to these same two SHAs
(v7.0.0 / v6.3.0), but for this file it only bumps the two lines above to the
mutable tags `@v7` / `@v6`. So it does not close this gap; if it merges as-is,
`lockfile-audit.yml` becomes the only file left with mutable-tag first-party
references. SHA-pinning here is still required for this workflow to match the
rest of the tree and satisfy the pinning verifier.
