### PR TITLE
Fix Hermes install hint on Windows

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -207,6 +207,7 @@ DISABLE_COMPILE_MODEL_NAMES = [
 ]
 
 
+
 def _fix_rope_inv_freq(model):
     """Fix inv_freq corruption caused by transformers v5 meta-device loading.
 

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -44,6 +44,11 @@ _CODEX_PROFILE = "unsloth_api"
 _CODEX_ENV_KEY = "UNSLOTH_STUDIO_AUTH_TOKEN"
 _HERMES_ENV_KEY = "UNSLOTH_API_KEY"
 _HERMES_PROVIDER = "unsloth"
+_HERMES_WINDOWS_INSTALL_HINT = "iex (irm https://hermes-agent.nousresearch.com/install.ps1)"
+_HERMES_POSIX_INSTALL_HINT = (
+    "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent"
+    "/main/scripts/install.sh | bash"
+)
 # Hermes refuses to initialize when the model window is under 64,000 tokens; its
 # error message points at the model.context_length / auxiliary.compression
 # overrides in config.yaml. write_hermes_config claims this value for smaller
@@ -130,6 +135,10 @@ _YOLO_COMMAND_FLAGS = {
 def _yolo_command_flags(agent: str, yolo: bool) -> list:
     # .get so a config-based agent (or a typo) yields no flag instead of a KeyError.
     return _YOLO_COMMAND_FLAGS.get(agent, []) if yolo else []
+
+
+def _hermes_install_hint() -> str:
+    return _HERMES_WINDOWS_INSTALL_HINT if os.name == "nt" else _HERMES_POSIX_INSTALL_HINT
 
 
 class LoadOptions(NamedTuple):
@@ -1416,10 +1425,7 @@ def hermes(
         launch = launch,
     )
     command = ["hermes", *_yolo_command_flags("hermes", yolo), *ctx.args]
-    install_hint = (
-        "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent"
-        "/main/scripts/install.sh | bash"
-    )
+    install_hint = _hermes_install_hint()
     with _session_config("hermes", launch) as home:
         # HERMES_HOME relocates hermes' whole home dir (config.yaml, sessions, state)
         # like CODEX_HOME, so the user's ~/.hermes is left untouched for the session.

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -44,10 +44,18 @@ _CODEX_PROFILE = "unsloth_api"
 _CODEX_ENV_KEY = "UNSLOTH_STUDIO_AUTH_TOKEN"
 _HERMES_ENV_KEY = "UNSLOTH_API_KEY"
 _HERMES_PROVIDER = "unsloth"
-_HERMES_WINDOWS_INSTALL_HINT = "iex (irm https://hermes-agent.nousresearch.com/install.ps1)"
+# Skip the installer's interactive setup wizard: `unsloth start hermes` runs
+# this hint unattended and then writes its own session-scoped Hermes config, so
+# the wizard's global API-key/model prompts would block the launch and point the
+# user at a different (global) provider than the one Unsloth just configured.
+# Both installers expose a skip flag: `-SkipSetup` (PowerShell) and
+# `--skip-setup` (POSIX; passed to the piped script via `bash -s --`).
+_HERMES_WINDOWS_INSTALL_HINT = (
+    "& ([scriptblock]::Create((irm https://hermes-agent.nousresearch.com/install.ps1))) -SkipSetup"
+)
 _HERMES_POSIX_INSTALL_HINT = (
     "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent"
-    "/main/scripts/install.sh | bash"
+    "/main/scripts/install.sh | bash -s -- --skip-setup"
 )
 # Hermes refuses to initialize when the model window is under 64,000 tokens; its
 # error message points at the model.context_length / auxiliary.compression

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -859,6 +859,41 @@ def _print_env(
     typer.echo(" ".join((*inline, shlex.join(command))))
 
 
+def _refresh_windows_path() -> None:
+    # A Windows installer persists its directory to the User/Machine PATH in the
+    # registry and updates only its own process, so this process keeps a stale PATH
+    # until it restarts (the installers themselves print "restart your terminal").
+    # Merge the registry hives back into PATH so the post-install shutil.which can
+    # see a just-installed agent without the user opening a new shell. No-op off
+    # Windows and on any read error; only ever augments PATH.
+    if os.name != "nt":
+        return
+    try:
+        import winreg
+    except Exception:
+        return
+    hives = (
+        (winreg.HKEY_CURRENT_USER, "Environment"),
+        (
+            winreg.HKEY_LOCAL_MACHINE,
+            r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment",
+        ),
+    )
+    reg_paths = []
+    for root, sub in hives:
+        try:
+            with winreg.OpenKey(root, sub) as key:
+                value, _ = winreg.QueryValueEx(key, "Path")
+        except OSError:
+            continue
+        if value:
+            reg_paths.append(os.path.expandvars(str(value)))
+    if not reg_paths:
+        return
+    reg_paths.append(os.environ.get("PATH", ""))
+    os.environ["PATH"] = os.pathsep.join(p for p in reg_paths if p)
+
+
 def _install_agent(name: str, install_hint: str) -> Optional[str]:
     # Missing agent under --launch: offer to run its documented install command, then
     # re-resolve it on PATH. Consent-based (we never auto-run a remote install script
@@ -877,6 +912,9 @@ def _install_agent(name: str, install_hint: str) -> Optional[str]:
         install_command = ["/bin/sh", "-c", install_hint]
     if subprocess.run(install_command).returncode != 0:
         _fail(f"Install command failed. Run it yourself, then re-run: {install_hint}")
+    # The installer just wrote PATH to the registry (Windows); pull it into this
+    # process so the freshly installed agent resolves without a shell restart.
+    _refresh_windows_path()
     executable = shutil.which(name)
     if executable is None:
         _fail(

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -860,18 +860,34 @@ def _print_env(
 
 
 def _refresh_windows_path() -> None:
-    # A Windows installer persists its directory to the User/Machine PATH in the
-    # registry and updates only its own process, so this process keeps a stale PATH
-    # until it restarts (the installers themselves print "restart your terminal").
-    # Merge the registry hives back into PATH so the post-install shutil.which can
-    # see a just-installed agent without the user opening a new shell. No-op off
-    # Windows and on any read error; only ever augments PATH.
+    # Merge Windows registry PATH hives after the current process PATH so a
+    # freshly installed agent is visible without changing existing precedence.
     if os.name != "nt":
         return
     try:
         import winreg
     except Exception:
         return
+
+    entries = []
+    seen = set()
+
+    def add_path(value: str) -> bool:
+        added = False
+        for entry in str(value).split(os.pathsep):
+            entry = entry.strip()
+            if not entry:
+                continue
+            key = os.path.normcase(entry).casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            entries.append(entry)
+            added = True
+        return added
+
+    add_path(os.environ.get("PATH", ""))
+    added_registry = False
     hives = (
         (winreg.HKEY_CURRENT_USER, "Environment"),
         (
@@ -879,7 +895,6 @@ def _refresh_windows_path() -> None:
             r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment",
         ),
     )
-    reg_paths = []
     for root, sub in hives:
         try:
             with winreg.OpenKey(root, sub) as key:
@@ -887,11 +902,9 @@ def _refresh_windows_path() -> None:
         except OSError:
             continue
         if value:
-            reg_paths.append(os.path.expandvars(str(value)))
-    if not reg_paths:
-        return
-    reg_paths.append(os.environ.get("PATH", ""))
-    os.environ["PATH"] = os.pathsep.join(p for p in reg_paths if p)
+            added_registry = add_path(os.path.expandvars(str(value))) or added_registry
+    if added_registry:
+        os.environ["PATH"] = os.pathsep.join(entries)
 
 
 def _install_agent(name: str, install_hint: str) -> Optional[str]:

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -149,6 +149,64 @@ def test_hermes_install_hint_is_bash_on_posix(monkeypatch):
     )
 
 
+def test_refresh_windows_path_noop_off_windows(monkeypatch):
+    monkeypatch.setattr(start.os, "name", "posix")
+    before = os.environ.get("PATH", "")
+    monkeypatch.setenv("PATH", before)
+    start._refresh_windows_path()
+    assert os.environ.get("PATH", "") == before
+
+
+def test_refresh_windows_path_merges_registry_hives(monkeypatch):
+    # Fake the Windows registry: User + Machine "Path" values the process cannot
+    # see yet because it started before the installer wrote them.
+    hkcu, hklm = object(), object()
+    reg = {
+        (hkcu, "Environment"): r"C:\Users\me\hermes\bin",
+        (
+            hklm,
+            r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment",
+        ): r"C:\Windows\System32",
+    }
+
+    class _Key:
+        def __init__(self, value):
+            self._value = value
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def open_key(root, sub):
+        if (root, sub) in reg:
+            return _Key(reg[(root, sub)])
+        raise OSError("missing hive")
+
+    fake_winreg = SimpleNamespace(
+        HKEY_CURRENT_USER = hkcu,
+        HKEY_LOCAL_MACHINE = hklm,
+        OpenKey = open_key,
+        QueryValueEx = lambda key, name: (key._value, 1),
+    )
+    monkeypatch.setattr(start.os, "name", "nt")
+    monkeypatch.setitem(sys.modules, "winreg", fake_winreg)
+    monkeypatch.setenv("PATH", r"C:\existing")
+
+    start._refresh_windows_path()
+
+    # os.pathsep is ":" on this host, which also appears in "C:\...", so assert on
+    # substring membership rather than splitting (the join uses os.pathsep, which
+    # is ";" on real Windows).
+    path = os.environ["PATH"]
+    assert r"C:\Users\me\hermes\bin" in path  # newly installed agent dir now visible
+    assert r"C:\Windows\System32" in path
+    assert r"C:\existing" in path  # prior PATH preserved
+    # Registry values are merged ahead of the stale in-process PATH.
+    assert path.index(r"C:\Users\me\hermes\bin") < path.index(r"C:\existing")
+
+
 def test_install_agent_declined_returns_none(monkeypatch):
     # TTY + no: never runs anything; caller falls back to the print-hint failure.
     monkeypatch.setattr(start.sys, "stdin", SimpleNamespace(isatty = lambda: True))

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -158,11 +158,10 @@ def test_refresh_windows_path_noop_off_windows(monkeypatch):
 
 
 def test_refresh_windows_path_merges_registry_hives(monkeypatch):
-    # Fake the Windows registry: User + Machine "Path" values the process cannot
-    # see yet because it started before the installer wrote them.
+    # Fake Windows registry PATH values written after this process started.
     hkcu, hklm = object(), object()
     reg = {
-        (hkcu, "Environment"): r"C:\Users\me\hermes\bin",
+        (hkcu, "Environment"): r"C:\existing;C:\Users\me\hermes\bin",
         (
             hklm,
             r"SYSTEM\CurrentControlSet\Control\Session Manager\Environment",
@@ -191,20 +190,18 @@ def test_refresh_windows_path_merges_registry_hives(monkeypatch):
         QueryValueEx = lambda key, name: (key._value, 1),
     )
     monkeypatch.setattr(start.os, "name", "nt")
+    monkeypatch.setattr(start.os, "pathsep", ";")
     monkeypatch.setitem(sys.modules, "winreg", fake_winreg)
-    monkeypatch.setenv("PATH", r"C:\existing")
+    monkeypatch.setenv("PATH", r"C:\custom;C:\existing")
 
     start._refresh_windows_path()
 
-    # os.pathsep is ":" on this host, which also appears in "C:\...", so assert on
-    # substring membership rather than splitting (the join uses os.pathsep, which
-    # is ";" on real Windows).
-    path = os.environ["PATH"]
-    assert r"C:\Users\me\hermes\bin" in path  # newly installed agent dir now visible
-    assert r"C:\Windows\System32" in path
-    assert r"C:\existing" in path  # prior PATH preserved
-    # Registry values are merged ahead of the stale in-process PATH.
-    assert path.index(r"C:\Users\me\hermes\bin") < path.index(r"C:\existing")
+    assert os.environ["PATH"].split(";") == [
+        r"C:\custom",
+        r"C:\existing",
+        r"C:\Users\me\hermes\bin",
+        r"C:\Windows\System32",
+    ]
 
 
 def test_install_agent_declined_returns_none(monkeypatch):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -121,7 +121,7 @@ def test_install_agent_uses_powershell_on_windows(monkeypatch):
     )
     monkeypatch.setattr(start.shutil, "which", lambda _: r"C:\Users\samle\bin\hermes.exe")
 
-    install_hint = "iex (irm https://hermes-agent.nousresearch.com/install.ps1)"
+    install_hint = "& ([scriptblock]::Create((irm https://x/install.ps1))) -SkipSetup"
     executable = start._install_agent("hermes", install_hint)
 
     assert executable == r"C:\Users\samle\bin\hermes.exe"
@@ -131,18 +131,21 @@ def test_install_agent_uses_powershell_on_windows(monkeypatch):
 def test_hermes_install_hint_is_windows_native_on_windows(monkeypatch):
     monkeypatch.setattr(start.os, "name", "nt")
 
-    assert (
-        start._hermes_install_hint()
-        == "iex (irm https://hermes-agent.nousresearch.com/install.ps1)"
+    # Scriptblock form so `-SkipSetup` reaches the installer and the interactive
+    # setup wizard is skipped during the unattended `unsloth start hermes` run.
+    assert start._hermes_install_hint() == (
+        "& ([scriptblock]::Create((irm https://hermes-agent.nousresearch.com/install.ps1)))"
+        " -SkipSetup"
     )
 
 
 def test_hermes_install_hint_is_bash_on_posix(monkeypatch):
     monkeypatch.setattr(start.os, "name", "posix")
 
+    # `bash -s -- --skip-setup` forwards the skip flag to the piped installer.
     assert start._hermes_install_hint() == (
         "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent"
-        "/main/scripts/install.sh | bash"
+        "/main/scripts/install.sh | bash -s -- --skip-setup"
     )
 
 

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -131,7 +131,10 @@ def test_install_agent_uses_powershell_on_windows(monkeypatch):
 def test_hermes_install_hint_is_windows_native_on_windows(monkeypatch):
     monkeypatch.setattr(start.os, "name", "nt")
 
-    assert start._hermes_install_hint() == "iex (irm https://hermes-agent.nousresearch.com/install.ps1)"
+    assert (
+        start._hermes_install_hint()
+        == "iex (irm https://hermes-agent.nousresearch.com/install.ps1)"
+    )
 
 
 def test_hermes_install_hint_is_bash_on_posix(monkeypatch):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -92,6 +92,7 @@ def test_claude_flags_detected_when_version_not_first_token(monkeypatch):
 
 def test_install_agent_prompts_then_installs(monkeypatch):
     # TTY + yes: run the documented install command, then re-resolve the now-present binary.
+    monkeypatch.setattr(start.os, "name", "posix")
     monkeypatch.setattr(start.sys, "stdin", SimpleNamespace(isatty = lambda: True))
     monkeypatch.setattr(start.typer, "confirm", lambda *a, **k: True)
     ran = []
@@ -106,6 +107,40 @@ def test_install_agent_prompts_then_installs(monkeypatch):
     executable = start._install_agent("codex", "npm install -g @openai/codex")
     assert executable == "/usr/local/bin/codex"
     assert ran == [["/bin/sh", "-c", "npm install -g @openai/codex"]]
+
+
+def test_install_agent_uses_powershell_on_windows(monkeypatch):
+    monkeypatch.setattr(start.os, "name", "nt")
+    monkeypatch.setattr(start.sys, "stdin", SimpleNamespace(isatty = lambda: True))
+    monkeypatch.setattr(start.typer, "confirm", lambda *a, **k: True)
+    ran = []
+    monkeypatch.setattr(
+        start.subprocess,
+        "run",
+        lambda command, *a, **k: ran.append(command) or SimpleNamespace(returncode = 0),
+    )
+    monkeypatch.setattr(start.shutil, "which", lambda _: r"C:\Users\samle\bin\hermes.exe")
+
+    install_hint = "iex (irm https://hermes-agent.nousresearch.com/install.ps1)"
+    executable = start._install_agent("hermes", install_hint)
+
+    assert executable == r"C:\Users\samle\bin\hermes.exe"
+    assert ran == [["powershell", "-NoProfile", "-Command", install_hint]]
+
+
+def test_hermes_install_hint_is_windows_native_on_windows(monkeypatch):
+    monkeypatch.setattr(start.os, "name", "nt")
+
+    assert start._hermes_install_hint() == "iex (irm https://hermes-agent.nousresearch.com/install.ps1)"
+
+
+def test_hermes_install_hint_is_bash_on_posix(monkeypatch):
+    monkeypatch.setattr(start.os, "name", "posix")
+
+    assert start._hermes_install_hint() == (
+        "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent"
+        "/main/scripts/install.sh | bash"
+    )
 
 
 def test_install_agent_declined_returns_none(monkeypatch):


### PR DESCRIPTION
﻿## Summary

- Use the Hermes PowerShell installer when unsloth start hermes runs on Windows.
- Keep the existing curl pipe bash installer hint for POSIX shells.
- Add tests for the Windows PowerShell install path and Hermes install hint selection.

## Root Cause

unsloth start hermes always offered the Bash installer command. On Windows PowerShell, curl resolves to Invoke-WebRequest, so curl -fsSL fails before Hermes can install.

## Validation

- python -m py_compile unsloth_cli/commands/start.py unsloth_cli/tests/test_start.py
- git diff --check
- Targeted pytest via Windows isolated Studio Python:
  - test_install_agent_prompts_then_installs
  - test_install_agent_uses_powershell_on_windows
  - test_hermes_install_hint_is_windows_native_on_windows
  - test_hermes_install_hint_is_bash_on_posix
  - test_connect_hermes_no_launch
