### PR TITLE
Fix opencode Unsloth provider selection

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -245,6 +245,7 @@ def _maybe_advise_fla_install(model_types):
         "transformers will use a slower pure PyTorch path."
     )
 
+
 def _fix_rope_inv_freq(model):
     """Fix inv_freq corruption caused by transformers v5 meta-device loading.
 

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -50,6 +50,12 @@ _HERMES_PROVIDER = "unsloth"
 # windows and scales the compaction threshold back down to the real window.
 _HERMES_MIN_CONTEXT = 65536
 _PI_PROVIDER = "unsloth"
+# OpenCode selects a model by "<providerID>/<modelID>" and honors a user
+# disabled_providers list. Register the session provider under a dedicated id a
+# user's disable list would never target, so the model is always selectable
+# without the wrapper having to reconstruct (and override) OpenCode's full,
+# multi-layer disabled_providers resolution.
+_OPENCODE_PROVIDER = "unsloth-studio"
 _PROVIDER_HEADER = f"[model_providers.{_CODEX_PROFILE}]"
 _PASSTHROUGH = {"allow_extra_args": True, "ignore_unknown_options": True}
 _CLAUDE_ENV_UNSET = ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN")
@@ -1106,113 +1112,6 @@ def write_openclaw_config(
         typer.echo(f"Updated {path}")
 
 
-def _strip_jsonc(text: str) -> str:
-    # Best-effort JSONC -> JSON: drop // line and /* */ block comments (outside
-    # strings) and trailing commas, so opencode's .jsonc configs parse. Imperfect
-    # inputs fall back to no data at the call site rather than raising.
-    out = []
-    i, n = 0, len(text)
-    in_str = False
-    quote = ""
-    while i < n:
-        ch = text[i]
-        if in_str:
-            out.append(ch)
-            if ch == "\\" and i + 1 < n:
-                out.append(text[i + 1])
-                i += 2
-                continue
-            if ch == quote:
-                in_str = False
-            i += 1
-            continue
-        if ch in ('"', "'"):
-            in_str = True
-            quote = ch
-            out.append(ch)
-            i += 1
-            continue
-        if ch == "/" and i + 1 < n and text[i + 1] == "/":
-            i += 2
-            while i < n and text[i] not in "\r\n":
-                i += 1
-            continue
-        if ch == "/" and i + 1 < n and text[i + 1] == "*":
-            i += 2
-            while i + 1 < n and not (text[i] == "*" and text[i + 1] == "/"):
-                i += 1
-            i += 2
-            continue
-        out.append(ch)
-        i += 1
-    stripped = "".join(out)
-    stripped = re.sub(r",(\s*[}\]])", r"\1", stripped)
-    return stripped
-
-
-def _load_opencode_config(path: Path) -> Optional[dict]:
-    # Read an opencode config file, tolerating JSONC. None on any failure.
-    try:
-        text = path.read_text(encoding = "utf-8")
-    except OSError:
-        return None
-    for candidate in (text, _strip_jsonc(text)):
-        try:
-            data = json.loads(candidate)
-        except Exception:
-            continue
-        return data if isinstance(data, dict) else None
-    return None
-
-
-def _opencode_dir_disabled_providers(directory: Path) -> Optional[list]:
-    # opencode's loader reads config.json, then opencode.json, then opencode.jsonc
-    # from a config dir; the last file that sets disabled_providers wins (arrays
-    # replace). Return that list, or None if no file in this dir sets it.
-    result: Optional[list] = None
-    for name in ("config.json", "opencode.json", "opencode.jsonc"):
-        data = _load_opencode_config(directory / name)
-        if data is not None and isinstance(data.get("disabled_providers"), list):
-            result = data["disabled_providers"]
-    return result
-
-
-def _opencode_effective_disabled_providers() -> list:
-    # The disabled_providers opencode effectively applies, which the session's
-    # highest-priority (inline) layer must override to re-enable unsloth. Under
-    # array-replace semantics that is the project config's list if the current
-    # repo sets one, otherwise the user's global config. Best-effort: unreadable
-    # or absent configs contribute nothing.
-    # opencode discovers the project config by walking up from the cwd, so use the
-    # nearest ancestor that sets disabled_providers, not just the cwd itself.
-    project = None
-    try:
-        cwd = Path.cwd()
-    except OSError:
-        cwd = None
-    if cwd is not None:
-        for directory in (cwd, *cwd.parents):
-            project = _opencode_dir_disabled_providers(directory)
-            if project is not None:
-                break
-    if project is not None:
-        return project
-    dirs: list[Path] = []
-    xdg = os.environ.get("XDG_CONFIG_HOME")
-    if xdg:
-        dirs.append(Path(xdg) / "opencode")
-    dirs.append(Path.home() / ".config" / "opencode")
-    if os.name == "nt":
-        appdata = os.environ.get("APPDATA")
-        if appdata:
-            dirs.append(Path(appdata) / "opencode")
-    for directory in dirs:
-        found = _opencode_dir_disabled_providers(directory)
-        if found is not None:
-            return found
-    return []
-
-
 def write_opencode_config(
     base: str,
     key: str,
@@ -1223,16 +1122,17 @@ def write_opencode_config(
     config = _read_json_object(path)
     if config is None:
         typer.echo(
-            f"Warning: couldn't parse {path} — add an 'unsloth' provider there "
-            "yourself, or move the file aside and re-run.",
+            f"Warning: couldn't parse {path} — add an '{_OPENCODE_PROVIDER}' provider "
+            "there yourself, or move the file aside and re-run.",
             err = True,
         )
         return {}
     before = json.dumps(config, sort_keys = True)
     config.setdefault("$schema", "https://opencode.ai/config.json")
-    # Re-enabling a disabled "unsloth" provider is handled by the caller in the
-    # inline OPENCODE_CONFIG_CONTENT layer, which outranks the project config that
-    # could otherwise re-disable it; this overlay only adds the provider and model.
+    # The session provider is registered under a dedicated id (_OPENCODE_PROVIDER)
+    # that a user's disabled_providers list would never target, so it is always
+    # selectable without this overlay having to reconstruct or override OpenCode's
+    # disabled_providers resolution.
     model_entry = {"name": model["id"]}
     window = model.get("context_length") or model.get("max_context_length")
     if window:
@@ -1241,14 +1141,14 @@ def write_opencode_config(
         # disables OpenCode's auto-compaction; declare the real window (and a sane
         # output cap) so it compacts instead of overflowing the server.
         model_entry["limit"] = {"context": window, "output": min(window // 4, 8192)}
-    _subdict(config, "provider")["unsloth"] = {
+    _subdict(config, "provider")[_OPENCODE_PROVIDER] = {
         "npm": "@ai-sdk/openai-compatible",
         "name": "Unsloth Studio",
         "options": {"baseURL": f"{base}/v1", "apiKey": key},
         "models": {model["id"]: model_entry},
     }
     # OpenCode selects a model by "<providerID>/<modelID>".
-    config["model"] = f"unsloth/{model['id']}"
+    config["model"] = f"{_OPENCODE_PROVIDER}/{model['id']}"
     if window:
         # Compact with ~10% headroom (near 90% full). The fixed 20k-token default
         # buffer over-compacts, or never settles, on a small local context.
@@ -1560,7 +1460,7 @@ def opencode(
         serve = serve,
         launch = launch,
     )
-    opencode_model = f"unsloth/{entry['id']}"
+    opencode_model = f"{_OPENCODE_PROVIDER}/{entry['id']}"
     # Only add --model on a bare launch. Any passthrough (a subcommand like serve/run,
     # or top-level flags like --dir/--print-logs that may precede a subcommand) is left
     # untouched: inserting --model before a subcommand can be misparsed, and it is not
@@ -1578,17 +1478,13 @@ def opencode(
         # outranks project config; the API key stays in the private file, never the env.
         # Only --yolo carries a permission here (its allow must win over a project config);
         # a non-yolo session returns no permission, so the project's own rules are honored.
+        # The session model is served by the dedicated _OPENCODE_PROVIDER id, which a
+        # user's disabled_providers list would never target, so this overlay does not
+        # touch disabled_providers at all: the user's own disables (in any config
+        # layer) are left exactly as they are and the session model still loads.
         inline_config: dict = {"model": opencode_model}
         if session_permission:
             inline_config["permission"] = session_permission
-        # Re-enable the unsloth provider when the user disabled it. The inline layer
-        # outranks the global and project configs (and is recomputed every run, so
-        # --no-launch reruns never reuse a stale list), so set disabled_providers to
-        # the effective list minus unsloth -- only when unsloth is actually disabled,
-        # to avoid clobbering the user's other disables when it is not.
-        effective_disabled = _opencode_effective_disabled_providers()
-        if "unsloth" in effective_disabled:
-            inline_config["disabled_providers"] = [p for p in effective_disabled if p != "unsloth"]
         env = {
             "OPENCODE_CONFIG": str(config_path),
             "OPENCODE_CONFIG_CONTENT": json.dumps(inline_config),

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1495,8 +1495,13 @@ def opencode(
         # or denylist for the launch. It is session-only: it lives in OPENCODE_CONFIG_CONTENT
         # for this invocation and never touches the user's config files, so their normal
         # `opencode` is unchanged; only this session is limited to the Studio provider.
+        # small_model is opencode's separate model for lightweight tasks; pin it to the
+        # session model too, or a user/project small_model on another (now filtered)
+        # provider would resolve a not-found error mid-session. The session serves one
+        # model, so the session model is the only valid target here anyway.
         inline_config: dict = {
             "model": opencode_model,
+            "small_model": opencode_model,
             "enabled_providers": [_OPENCODE_PROVIDER],
             "disabled_providers": [],
         }

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1461,12 +1461,19 @@ def opencode(
         launch = launch,
     )
     opencode_model = f"{_OPENCODE_PROVIDER}/{entry['id']}"
-    # Only add --model on a bare launch. Any passthrough (a subcommand like serve/run,
-    # or top-level flags like --dir/--print-logs that may precede a subcommand) is left
-    # untouched: inserting --model before a subcommand can be misparsed, and it is not
-    # needed anyway because the inline OPENCODE_CONFIG_CONTENT below pins the model in
-    # the highest-priority layer, so the session model is forced without the flag.
-    command = ["opencode", *ctx.args] if ctx.args else ["opencode", "--model", opencode_model]
+    # The inline OPENCODE_CONFIG_CONTENT below pins the model in the highest-priority
+    # layer, so the session model is forced without a --model flag. Only add --model for
+    # an interactive bare launch (a convenience so the TUI opens on our model). It is
+    # omitted for passthrough (inserting it before a subcommand can be misparsed) and for
+    # --no-launch, where the printed command is consumed by drivers that append a
+    # subcommand such as `run <prompt>`; a leading --model would land before that
+    # subcommand and break it. Those paths rely on the inline pin instead.
+    if ctx.args:
+        command = ["opencode", *ctx.args]
+    elif launch:
+        command = ["opencode", "--model", opencode_model]
+    else:
+        command = ["opencode"]
     with _session_config("opencode", launch) as cfg:
         config_path = cfg / "opencode.json"
         # OPENCODE_CONFIG is an overlay (loaded between the user's global and project
@@ -1478,11 +1485,21 @@ def opencode(
         # outranks project config; the API key stays in the private file, never the env.
         # Only --yolo carries a permission here (its allow must win over a project config);
         # a non-yolo session returns no permission, so the project's own rules are honored.
-        # The session model is served by the dedicated _OPENCODE_PROVIDER id, which a
-        # user's disabled_providers list would never target, so this overlay does not
-        # touch disabled_providers at all: the user's own disables (in any config
-        # layer) are left exactly as they are and the session model still loads.
-        inline_config: dict = {"model": opencode_model}
+        # opencode filters every provider (a config-defined custom one included) through
+        # its enabled_providers allowlist and disabled_providers denylist, and a model pin
+        # does not bypass that gate -- a filtered provider resolves to ModelNotFoundError.
+        # To guarantee the session model loads without reading or modifying the user's real
+        # config, scope THIS session to our provider alone: allowlist _OPENCODE_PROVIDER and
+        # clear the denylist. These arrays are replaced (not merged) by higher layers, so
+        # setting them in the highest-priority inline overlay neutralizes any user allowlist
+        # or denylist for the launch. It is session-only: it lives in OPENCODE_CONFIG_CONTENT
+        # for this invocation and never touches the user's config files, so their normal
+        # `opencode` is unchanged; only this session is limited to the Studio provider.
+        inline_config: dict = {
+            "model": opencode_model,
+            "enabled_providers": [_OPENCODE_PROVIDER],
+            "disabled_providers": [],
+        }
         if session_permission:
             inline_config["permission"] = session_permission
         env = {

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1065,12 +1065,13 @@ def write_opencode_config(
         return
     before = json.dumps(config, sort_keys = True)
     config.setdefault("$schema", "https://opencode.ai/config.json")
+    # Only clear "unsloth" from an existing disable list so the session provider can
+    # load. Never introduce disabled_providers here: this file is an OPENCODE_CONFIG
+    # overlay, and writing an empty list would re-enable providers the user disabled
+    # in their own global/project config.
     disabled_providers = config.get("disabled_providers")
-    config["disabled_providers"] = (
-        [provider for provider in disabled_providers if provider != "unsloth"]
-        if isinstance(disabled_providers, list)
-        else []
-    )
+    if isinstance(disabled_providers, list) and "unsloth" in disabled_providers:
+        config["disabled_providers"] = [p for p in disabled_providers if p != "unsloth"]
     model_entry = {"name": model["id"]}
     window = model.get("context_length") or model.get("max_context_length")
     if window:
@@ -1380,7 +1381,10 @@ def opencode(
         launch = launch,
     )
     opencode_model = f"unsloth/{entry['id']}"
-    command = ["opencode", "--model", opencode_model, *ctx.args]
+    # Force the model only on a bare launch. --model is a global flag for the TUI, but
+    # a passthrough subcommand (serve/run/...) takes the model from the pinned config,
+    # so --model must not be inserted before it.
+    command = ["opencode", *ctx.args] if ctx.args else ["opencode", "--model", opencode_model]
     with _session_config("opencode", launch) as cfg:
         config_path = cfg / "opencode.json"
         # OPENCODE_CONFIG is an overlay (loaded between the user's global and project
@@ -1391,7 +1395,7 @@ def opencode(
         # pin (and --yolo permissions) would silently lose to a repo config. Carry the
         # settings that must win in OPENCODE_CONFIG_CONTENT, which outranks project
         # config; the API key stays in the private file, never in the printed env.
-        inline_config: dict = {"model": opencode_model, "disabled_providers": []}
+        inline_config: dict = {"model": opencode_model}
         if yolo:
             inline_config["permission"] = {"edit": "allow", "bash": "allow", "webfetch": "allow"}
         env = {

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1065,6 +1065,12 @@ def write_opencode_config(
         return
     before = json.dumps(config, sort_keys = True)
     config.setdefault("$schema", "https://opencode.ai/config.json")
+    disabled_providers = config.get("disabled_providers")
+    config["disabled_providers"] = (
+        [provider for provider in disabled_providers if provider != "unsloth"]
+        if isinstance(disabled_providers, list)
+        else []
+    )
     model_entry = {"name": model["id"]}
     window = model.get("context_length") or model.get("max_context_length")
     if window:
@@ -1373,7 +1379,8 @@ def opencode(
         serve = serve,
         launch = launch,
     )
-    command = ["opencode", *ctx.args]
+    opencode_model = f"unsloth/{entry['id']}"
+    command = ["opencode", "--model", opencode_model, *ctx.args]
     with _session_config("opencode", launch) as cfg:
         config_path = cfg / "opencode.json"
         # OPENCODE_CONFIG is an overlay (loaded between the user's global and project
@@ -1384,7 +1391,7 @@ def opencode(
         # pin (and --yolo permissions) would silently lose to a repo config. Carry the
         # settings that must win in OPENCODE_CONFIG_CONTENT, which outranks project
         # config; the API key stays in the private file, never in the printed env.
-        inline_config: dict = {"model": f"unsloth/{entry['id']}"}
+        inline_config: dict = {"model": opencode_model, "disabled_providers": []}
         if yolo:
             inline_config["permission"] = {"edit": "allow", "bash": "allow", "webfetch": "allow"}
         env = {

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1106,12 +1106,89 @@ def write_openclaw_config(
         typer.echo(f"Updated {path}")
 
 
-def _opencode_global_disabled_providers() -> list:
-    # opencode reads its global config from $XDG_CONFIG_HOME/opencode (or
-    # ~/.config/opencode), and %APPDATA%/opencode on Windows. Return that
-    # config's disabled_providers list so the session overlay can re-enable
-    # "unsloth" without dropping the user's other disables. Best-effort: any
-    # missing/unreadable/unparseable config yields an empty list.
+def _strip_jsonc(text: str) -> str:
+    # Best-effort JSONC -> JSON: drop // line and /* */ block comments (outside
+    # strings) and trailing commas, so opencode's .jsonc configs parse. Imperfect
+    # inputs fall back to no data at the call site rather than raising.
+    out = []
+    i, n = 0, len(text)
+    in_str = False
+    quote = ""
+    while i < n:
+        ch = text[i]
+        if in_str:
+            out.append(ch)
+            if ch == "\\" and i + 1 < n:
+                out.append(text[i + 1])
+                i += 2
+                continue
+            if ch == quote:
+                in_str = False
+            i += 1
+            continue
+        if ch in ('"', "'"):
+            in_str = True
+            quote = ch
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "/" and i + 1 < n and text[i + 1] == "/":
+            i += 2
+            while i < n and text[i] not in "\r\n":
+                i += 1
+            continue
+        if ch == "/" and i + 1 < n and text[i + 1] == "*":
+            i += 2
+            while i + 1 < n and not (text[i] == "*" and text[i + 1] == "/"):
+                i += 1
+            i += 2
+            continue
+        out.append(ch)
+        i += 1
+    stripped = "".join(out)
+    stripped = re.sub(r",(\s*[}\]])", r"\1", stripped)
+    return stripped
+
+
+def _load_opencode_config(path: Path) -> Optional[dict]:
+    # Read an opencode config file, tolerating JSONC. None on any failure.
+    try:
+        text = path.read_text(encoding = "utf-8")
+    except OSError:
+        return None
+    for candidate in (text, _strip_jsonc(text)):
+        try:
+            data = json.loads(candidate)
+        except Exception:
+            continue
+        return data if isinstance(data, dict) else None
+    return None
+
+
+def _opencode_dir_disabled_providers(directory: Path) -> Optional[list]:
+    # opencode's loader reads config.json, then opencode.json, then opencode.jsonc
+    # from a config dir; the last file that sets disabled_providers wins (arrays
+    # replace). Return that list, or None if no file in this dir sets it.
+    result: Optional[list] = None
+    for name in ("config.json", "opencode.json", "opencode.jsonc"):
+        data = _load_opencode_config(directory / name)
+        if data is not None and isinstance(data.get("disabled_providers"), list):
+            result = data["disabled_providers"]
+    return result
+
+
+def _opencode_effective_disabled_providers() -> list:
+    # The disabled_providers opencode effectively applies, which the session's
+    # highest-priority (inline) layer must override to re-enable unsloth. Under
+    # array-replace semantics that is the project config's list if the current
+    # repo sets one, otherwise the user's global config. Best-effort: unreadable
+    # or absent configs contribute nothing.
+    try:
+        project = _opencode_dir_disabled_providers(Path.cwd())
+    except OSError:
+        project = None
+    if project is not None:
+        return project
     dirs: list[Path] = []
     xdg = os.environ.get("XDG_CONFIG_HOME")
     if xdg:
@@ -1122,16 +1199,9 @@ def _opencode_global_disabled_providers() -> list:
         if appdata:
             dirs.append(Path(appdata) / "opencode")
     for directory in dirs:
-        for name in ("opencode.json", "opencode.jsonc"):
-            candidate = directory / name
-            try:
-                if not candidate.is_file():
-                    continue
-                data = json.loads(candidate.read_text(encoding = "utf-8"))
-            except Exception:
-                continue
-            if isinstance(data, dict) and isinstance(data.get("disabled_providers"), list):
-                return data["disabled_providers"]
+        found = _opencode_dir_disabled_providers(directory)
+        if found is not None:
+            return found
     return []
 
 
@@ -1152,18 +1222,9 @@ def write_opencode_config(
         return {}
     before = json.dumps(config, sort_keys = True)
     config.setdefault("$schema", "https://opencode.ai/config.json")
-    # Re-enable the "unsloth" provider for this session when the user disabled it.
-    # opencode replaces disabled_providers across config layers only when a higher
-    # layer sets the key, so a global ["unsloth", ...] survives unless the overlay
-    # overrides it -- a fresh overlay omitting the key leaves the provider disabled.
-    # Take the effective disable list (this overlay's own if present, else the
-    # user's global config) and, only when it lists "unsloth", write it back minus
-    # "unsloth" so the provider loads while the user's other disables are preserved.
-    disabled_providers = config.get("disabled_providers")
-    if not isinstance(disabled_providers, list):
-        disabled_providers = _opencode_global_disabled_providers()
-    if isinstance(disabled_providers, list) and "unsloth" in disabled_providers:
-        config["disabled_providers"] = [p for p in disabled_providers if p != "unsloth"]
+    # Re-enabling a disabled "unsloth" provider is handled by the caller in the
+    # inline OPENCODE_CONFIG_CONTENT layer, which outranks the project config that
+    # could otherwise re-disable it; this overlay only adds the provider and model.
     model_entry = {"name": model["id"]}
     window = model.get("context_length") or model.get("max_context_length")
     if window:
@@ -1492,10 +1553,14 @@ def opencode(
         launch = launch,
     )
     opencode_model = f"unsloth/{entry['id']}"
-    # Force the model only on a bare launch. --model is a global flag for the TUI, but
-    # a passthrough subcommand (serve/run/...) takes the model from the pinned config,
-    # so --model must not be inserted before it.
-    command = ["opencode", *ctx.args] if ctx.args else ["opencode", "--model", opencode_model]
+    # Force the model for the TUI (bare launch, with or without top-level flags like
+    # --dir/--continue). A passthrough that starts with a subcommand (serve/run/...)
+    # takes the model from the pinned config, so --model must not be inserted before
+    # it. A leading "-" means TUI flags, not a subcommand, so --model still applies.
+    if ctx.args and not ctx.args[0].startswith("-"):
+        command = ["opencode", *ctx.args]
+    else:
+        command = ["opencode", "--model", opencode_model, *ctx.args]
     with _session_config("opencode", launch) as cfg:
         config_path = cfg / "opencode.json"
         # OPENCODE_CONFIG is an overlay (loaded between the user's global and project
@@ -1510,6 +1575,14 @@ def opencode(
         inline_config: dict = {"model": opencode_model}
         if session_permission:
             inline_config["permission"] = session_permission
+        # Re-enable the unsloth provider when the user disabled it. The inline layer
+        # outranks the global and project configs (and is recomputed every run, so
+        # --no-launch reruns never reuse a stale list), so set disabled_providers to
+        # the effective list minus unsloth -- only when unsloth is actually disabled,
+        # to avoid clobbering the user's other disables when it is not.
+        effective_disabled = _opencode_effective_disabled_providers()
+        if "unsloth" in effective_disabled:
+            inline_config["disabled_providers"] = [p for p in effective_disabled if p != "unsloth"]
         env = {
             "OPENCODE_CONFIG": str(config_path),
             "OPENCODE_CONFIG_CONTENT": json.dumps(inline_config),

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1561,14 +1561,12 @@ def opencode(
         launch = launch,
     )
     opencode_model = f"unsloth/{entry['id']}"
-    # Force the model for the TUI (bare launch, with or without top-level flags like
-    # --dir/--continue). A passthrough that starts with a subcommand (serve/run/...)
-    # takes the model from the pinned config, so --model must not be inserted before
-    # it. A leading "-" means TUI flags, not a subcommand, so --model still applies.
-    if ctx.args and not ctx.args[0].startswith("-"):
-        command = ["opencode", *ctx.args]
-    else:
-        command = ["opencode", "--model", opencode_model, *ctx.args]
+    # Only add --model on a bare launch. Any passthrough (a subcommand like serve/run,
+    # or top-level flags like --dir/--print-logs that may precede a subcommand) is left
+    # untouched: inserting --model before a subcommand can be misparsed, and it is not
+    # needed anyway because the inline OPENCODE_CONFIG_CONTENT below pins the model in
+    # the highest-priority layer, so the session model is forced without the flag.
+    command = ["opencode", *ctx.args] if ctx.args else ["opencode", "--model", opencode_model]
     with _session_config("opencode", launch) as cfg:
         config_path = cfg / "opencode.json"
         # OPENCODE_CONFIG is an overlay (loaded between the user's global and project

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1106,6 +1106,35 @@ def write_openclaw_config(
         typer.echo(f"Updated {path}")
 
 
+def _opencode_global_disabled_providers() -> list:
+    # opencode reads its global config from $XDG_CONFIG_HOME/opencode (or
+    # ~/.config/opencode), and %APPDATA%/opencode on Windows. Return that
+    # config's disabled_providers list so the session overlay can re-enable
+    # "unsloth" without dropping the user's other disables. Best-effort: any
+    # missing/unreadable/unparseable config yields an empty list.
+    dirs: list[Path] = []
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    if xdg:
+        dirs.append(Path(xdg) / "opencode")
+    dirs.append(Path.home() / ".config" / "opencode")
+    if os.name == "nt":
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            dirs.append(Path(appdata) / "opencode")
+    for directory in dirs:
+        for name in ("opencode.json", "opencode.jsonc"):
+            candidate = directory / name
+            try:
+                if not candidate.is_file():
+                    continue
+                data = json.loads(candidate.read_text(encoding = "utf-8"))
+            except Exception:
+                continue
+            if isinstance(data, dict) and isinstance(data.get("disabled_providers"), list):
+                return data["disabled_providers"]
+    return []
+
+
 def write_opencode_config(
     base: str,
     key: str,
@@ -1123,11 +1152,16 @@ def write_opencode_config(
         return {}
     before = json.dumps(config, sort_keys = True)
     config.setdefault("$schema", "https://opencode.ai/config.json")
-    # Only clear "unsloth" from an existing disable list so the session provider can
-    # load. Never introduce disabled_providers here: this file is an OPENCODE_CONFIG
-    # overlay, and writing an empty list would re-enable providers the user disabled
-    # in their own global/project config.
+    # Re-enable the "unsloth" provider for this session when the user disabled it.
+    # opencode replaces disabled_providers across config layers only when a higher
+    # layer sets the key, so a global ["unsloth", ...] survives unless the overlay
+    # overrides it -- a fresh overlay omitting the key leaves the provider disabled.
+    # Take the effective disable list (this overlay's own if present, else the
+    # user's global config) and, only when it lists "unsloth", write it back minus
+    # "unsloth" so the provider loads while the user's other disables are preserved.
     disabled_providers = config.get("disabled_providers")
+    if not isinstance(disabled_providers, list):
+        disabled_providers = _opencode_global_disabled_providers()
     if isinstance(disabled_providers, list) and "unsloth" in disabled_providers:
         config["disabled_providers"] = [p for p in disabled_providers if p != "unsloth"]
     model_entry = {"name": model["id"]}

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1183,10 +1183,18 @@ def _opencode_effective_disabled_providers() -> list:
     # array-replace semantics that is the project config's list if the current
     # repo sets one, otherwise the user's global config. Best-effort: unreadable
     # or absent configs contribute nothing.
+    # opencode discovers the project config by walking up from the cwd, so use the
+    # nearest ancestor that sets disabled_providers, not just the cwd itself.
+    project = None
     try:
-        project = _opencode_dir_disabled_providers(Path.cwd())
+        cwd = Path.cwd()
     except OSError:
-        project = None
+        cwd = None
+    if cwd is not None:
+        for directory in (cwd, *cwd.parents):
+            project = _opencode_dir_disabled_providers(directory)
+            if project is not None:
+                break
     if project is not None:
         return project
     dirs: list[Path] = []

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -29,10 +29,10 @@ MODEL = {"id": "unsloth/gemma-4-26B-A4B-it-GGUF", "context_length": 131072}
 
 @pytest.fixture(autouse = True)
 def _no_global_opencode_config(monkeypatch):
-    # Isolate the opencode config tests from any real ~/.config/opencode on the
-    # host, so the overlay's disabled_providers handling is deterministic. Tests
-    # that exercise the global-disable path override this with their own value.
-    monkeypatch.setattr(start, "_opencode_global_disabled_providers", lambda: [])
+    # Isolate the opencode config tests from any real opencode config on the host,
+    # so the inline disabled_providers override is deterministic. Tests that
+    # exercise the disable path override this with their own value.
+    monkeypatch.setattr(start, "_opencode_effective_disabled_providers", lambda: [])
 
 
 # --no-launch prints shell setup as POSIX (export/unset) on Unix/WSL and
@@ -1413,7 +1413,9 @@ def test_write_opencode_config_preserves_and_idempotent(tmp_path):
     start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path)
     config = json.loads(path.read_text())
     assert config["theme"] == "tokyonight"
-    assert config["disabled_providers"] == ["ollama"]
+    # The overlay no longer edits disabled_providers; re-enabling unsloth is done in
+    # the inline layer, so an existing list here is preserved untouched.
+    assert config["disabled_providers"] == ["ollama", "unsloth"]
     assert config["provider"]["anthropic"]["name"] == "Anthropic"
     assert config["provider"]["unsloth"]["options"]["baseURL"] == f"{BASE}/v1"
     before = path.read_text()
@@ -1432,43 +1434,95 @@ def test_write_opencode_config_keeps_foreign_disabled_providers(tmp_path):
     assert config["disabled_providers"] == ["openai", "gemini"]
 
 
-def test_write_opencode_config_reenables_unsloth_from_global_disable(tmp_path, monkeypatch):
-    # A fresh overlay omits disabled_providers, so a global ["unsloth", ...] would
-    # otherwise survive the merge and keep the session provider disabled. The overlay
-    # must override it, re-enabling unsloth while preserving the user's other disables.
-    monkeypatch.setattr(start, "_opencode_global_disabled_providers", lambda: ["ollama", "unsloth"])
-    path = tmp_path / "opencode.json"
-    start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path)
-    config = json.loads(path.read_text())
-    assert config["disabled_providers"] == ["ollama"]
+def _opencode_inline_config(output: str) -> dict:
+    line = next(
+        ln for ln in output.splitlines() if ln.startswith("export OPENCODE_CONFIG_CONTENT=")
+    )
+    return json.loads(shlex.split(line.removeprefix("export OPENCODE_CONFIG_CONTENT="))[0])
 
 
-def test_write_opencode_config_no_override_when_global_allows_unsloth(tmp_path, monkeypatch):
-    # If the global config disables other providers but not unsloth, the overlay must
-    # not touch disabled_providers (unsloth already loads; a rewrite would clobber).
-    monkeypatch.setattr(start, "_opencode_global_disabled_providers", lambda: ["ollama", "openai"])
-    path = tmp_path / "opencode.json"
-    start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path)
-    config = json.loads(path.read_text())
-    assert "disabled_providers" not in config
+def test_opencode_inline_reenables_unsloth_from_disable(fake_studio, monkeypatch):
+    # The disabled_providers override rides in the inline OPENCODE_CONFIG_CONTENT
+    # (highest layer, beats a project config), minus unsloth, so the provider loads
+    # while the user's other disables are preserved.
+    monkeypatch.setattr(
+        start, "_opencode_effective_disabled_providers", lambda: ["ollama", "unsloth"]
+    )
+    result = CliRunner().invoke(start.start_app, ["opencode", "--no-launch"])
+    assert result.exit_code == 0, result.output
+    inline = _opencode_inline_config(result.output)
+    assert inline["disabled_providers"] == ["ollama"]
+    assert inline["model"] == f"unsloth/{MODEL['id']}"
 
 
-def test_opencode_global_disabled_providers_reads_xdg_config(tmp_path, monkeypatch):
-    monkeypatch.undo()  # drop the autouse stub; exercise the real implementation
-    cfg_dir = tmp_path / "opencode"
-    cfg_dir.mkdir()
-    (cfg_dir / "opencode.json").write_text(
+def test_opencode_inline_no_disable_when_unsloth_allowed(fake_studio, monkeypatch):
+    # When unsloth is not disabled, no override is written, or it would clobber the
+    # user's other disables.
+    monkeypatch.setattr(
+        start, "_opencode_effective_disabled_providers", lambda: ["ollama", "openai"]
+    )
+    result = CliRunner().invoke(start.start_app, ["opencode", "--no-launch"])
+    assert result.exit_code == 0, result.output
+    assert "disabled_providers" not in _opencode_inline_config(result.output)
+
+
+def test_opencode_tui_flags_keep_model_flag(fake_studio):
+    # Top-level TUI flags (not a subcommand) must still pin --model; only a real
+    # subcommand like `serve` takes the model from config.
+    result = CliRunner().invoke(start.start_app, ["opencode", "--no-launch", "--dir", "repo"])
+    assert result.exit_code == 0, result.output
+    command = _launch_command(result.output)
+    assert command[:3] == ["opencode", "--model", f"unsloth/{MODEL['id']}"]
+    assert command[3:] == ["--dir", "repo"]
+
+
+def test_opencode_effective_disabled_project_overrides_global(tmp_path, monkeypatch):
+    monkeypatch.undo()  # exercise the real implementation
+    (tmp_path / "xdg" / "opencode").mkdir(parents = True)
+    (tmp_path / "xdg" / "opencode" / "opencode.json").write_text(
+        json.dumps({"disabled_providers": ["ollama"]})
+    )
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / "opencode.json").write_text(json.dumps({"disabled_providers": ["unsloth", "gemini"]}))
+    monkeypatch.chdir(proj)
+    assert start._opencode_effective_disabled_providers() == ["unsloth", "gemini"]
+
+
+def test_opencode_effective_disabled_reads_global_when_no_project(tmp_path, monkeypatch):
+    monkeypatch.undo()
+    (tmp_path / "xdg" / "opencode").mkdir(parents = True)
+    (tmp_path / "xdg" / "opencode" / "opencode.json").write_text(
         json.dumps({"disabled_providers": ["unsloth", "openai"]})
     )
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-    assert start._opencode_global_disabled_providers() == ["unsloth", "openai"]
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setenv("HOME", str(tmp_path / "nohome"))
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.chdir(empty)
+    assert start._opencode_effective_disabled_providers() == ["unsloth", "openai"]
 
 
-def test_opencode_global_disabled_providers_missing_returns_empty(tmp_path, monkeypatch):
-    monkeypatch.undo()  # drop the autouse stub; exercise the real implementation
+def test_opencode_dir_disabled_parses_jsonc_and_config_json(tmp_path):
+    (tmp_path / "jsonc").mkdir()
+    (tmp_path / "jsonc" / "opencode.jsonc").write_text(
+        '{\n  // disable the studio provider\n  "disabled_providers": ["unsloth",],\n}'
+    )
+    assert start._opencode_dir_disabled_providers(tmp_path / "jsonc") == ["unsloth"]
+    (tmp_path / "legacy").mkdir()
+    (tmp_path / "legacy" / "config.json").write_text(
+        json.dumps({"disabled_providers": ["unsloth", "openai"]})
+    )
+    assert start._opencode_dir_disabled_providers(tmp_path / "legacy") == ["unsloth", "openai"]
+
+
+def test_opencode_effective_disabled_missing_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.undo()
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
     monkeypatch.setenv("HOME", str(tmp_path / "nohome"))
-    assert start._opencode_global_disabled_providers() == []
+    monkeypatch.chdir(tmp_path)
+    assert start._opencode_effective_disabled_providers() == []
 
 
 def test_opencode_passthrough_subcommand_omits_model_flag(fake_studio):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1445,6 +1445,9 @@ def test_opencode_inline_scopes_session_to_studio_provider(fake_studio):
     assert inline["enabled_providers"] == [start._OPENCODE_PROVIDER]
     assert inline["disabled_providers"] == []
     assert inline["model"] == f"{start._OPENCODE_PROVIDER}/{MODEL['id']}"
+    # small_model stays on the enabled provider too, so lightweight tasks do not resolve a
+    # filtered provider mid-session.
+    assert inline["small_model"] == f"{start._OPENCODE_PROVIDER}/{MODEL['id']}"
 
 
 def test_opencode_passthrough_flags_omit_model_flag(fake_studio):
@@ -1491,6 +1494,7 @@ def test_connect_opencode_no_launch(fake_studio, tmp_path):
     assert "enabled_providers" not in config
     assert inline_config == {
         "model": f"{start._OPENCODE_PROVIDER}/{MODEL['id']}",
+        "small_model": f"{start._OPENCODE_PROVIDER}/{MODEL['id']}",
         "enabled_providers": [start._OPENCODE_PROVIDER],
         "disabled_providers": [],
     }

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1504,6 +1504,21 @@ def test_opencode_effective_disabled_reads_global_when_no_project(tmp_path, monk
     assert start._opencode_effective_disabled_providers() == ["unsloth", "openai"]
 
 
+def test_opencode_effective_disabled_walks_up_to_project_config(tmp_path, monkeypatch):
+    # Running from a subdir must still find the project config in an ancestor, the
+    # way opencode discovers it.
+    monkeypatch.undo()
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+    monkeypatch.setenv("HOME", str(tmp_path / "nohome"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "opencode.json").write_text(json.dumps({"disabled_providers": ["unsloth", "gemini"]}))
+    deep = repo / "src" / "deep"
+    deep.mkdir(parents = True)
+    monkeypatch.chdir(deep)
+    assert start._opencode_effective_disabled_providers() == ["unsloth", "gemini"]
+
+
 def test_opencode_dir_disabled_parses_jsonc_and_config_json(tmp_path):
     (tmp_path / "jsonc").mkdir()
     (tmp_path / "jsonc" / "opencode.jsonc").write_text(

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1380,6 +1380,7 @@ def test_write_opencode_config_fresh(tmp_path):
         MODEL["id"]: {"name": MODEL["id"], "limit": {"context": 131072, "output": 8192}}
     }
     assert config["model"] == f"unsloth/{MODEL['id']}"
+    assert config["disabled_providers"] == []
     # Compaction buffer scaled to ~10% of the window (compact near 90%).
     assert config["compaction"] == {"auto": True, "reserved": 131072 // 10}
 
@@ -1387,11 +1388,18 @@ def test_write_opencode_config_fresh(tmp_path):
 def test_write_opencode_config_preserves_and_idempotent(tmp_path):
     path = tmp_path / "opencode.json"
     path.write_text(
-        json.dumps({"theme": "tokyonight", "provider": {"anthropic": {"name": "Anthropic"}}})
+        json.dumps(
+            {
+                "theme": "tokyonight",
+                "disabled_providers": ["ollama", "unsloth"],
+                "provider": {"anthropic": {"name": "Anthropic"}},
+            }
+        )
     )
     start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path)
     config = json.loads(path.read_text())
     assert config["theme"] == "tokyonight"
+    assert config["disabled_providers"] == ["ollama"]
     assert config["provider"]["anthropic"]["name"] == "Anthropic"
     assert config["provider"]["unsloth"]["options"]["baseURL"] == f"{BASE}/v1"
     before = path.read_text()
@@ -1406,9 +1414,26 @@ def test_connect_opencode_no_launch(fake_studio, tmp_path):
     config_path = tmp_path / "agents" / "opencode" / "opencode.json"
     # OPENCODE_CONFIG overlay points at the session file, not the user's global config.
     _assert_env_set(result.output, "OPENCODE_CONFIG", str(config_path))
+    inline_config_text = (
+        result.output.split("OPENCODE_CONFIG_CONTENT", 1)[1]
+        .splitlines()[0]
+        .split("=", 1)[1]
+        .strip()
+        .strip('"')
+        .replace("`", "")
+    )
+    inline_config = json.loads(inline_config_text)
     config = json.loads(config_path.read_text())
     assert config["provider"]["unsloth"]["options"]["apiKey"] == "sk-unsloth-feedfacefeedface"
     assert config["model"] == f"unsloth/{MODEL['id']}"
+    assert config["disabled_providers"] == []
+    assert inline_config["model"] == f"unsloth/{MODEL['id']}"
+    assert inline_config["disabled_providers"] == []
+    assert _launch_command(result.output)[:3] == [
+        "opencode",
+        "--model",
+        f"unsloth/{MODEL['id']}",
+    ]
     assert not any(c[1].endswith("/api/inference/status") for c in fake_studio)
 
 

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -27,14 +27,6 @@ BASE = "http://127.0.0.1:8888"
 MODEL = {"id": "unsloth/gemma-4-26B-A4B-it-GGUF", "context_length": 131072}
 
 
-@pytest.fixture(autouse = True)
-def _no_global_opencode_config(monkeypatch):
-    # Isolate the opencode config tests from any real opencode config on the host,
-    # so the inline disabled_providers override is deterministic. Tests that
-    # exercise the disable path override this with their own value.
-    monkeypatch.setattr(start, "_opencode_effective_disabled_providers", lambda: [])
-
-
 # --no-launch prints shell setup as POSIX (export/unset) on Unix/WSL and
 # PowerShell ($env:/Remove-Item) on native Windows; assert the host's form.
 def _assert_env_set(output: str, name: str, value: str) -> None:
@@ -449,7 +441,7 @@ def test_opencode_inline_config_beats_project_config(fake_studio):
     inline = json.loads(
         shlex.split(content_line.removeprefix("export OPENCODE_CONFIG_CONTENT="))[0]
     )
-    assert inline["model"] == f"unsloth/{MODEL['id']}"
+    assert inline["model"] == f"{start._OPENCODE_PROVIDER}/{MODEL['id']}"
     assert inline["permission"] == {"edit": "allow", "bash": "allow", "webfetch": "allow"}
     assert "sk-unsloth" not in content_line  # key stays in the private file
 
@@ -466,7 +458,7 @@ def test_opencode_inline_config_omits_permission_without_yolo(fake_studio):
     inline = json.loads(
         shlex.split(content_line.removeprefix("export OPENCODE_CONFIG_CONTENT="))[0]
     )
-    assert inline["model"] == f"unsloth/{MODEL['id']}"
+    assert inline["model"] == f"{start._OPENCODE_PROVIDER}/{MODEL['id']}"
     assert "permission" not in inline
 
 
@@ -1384,16 +1376,16 @@ def test_write_opencode_config_fresh(tmp_path):
     path = tmp_path / "opencode.json"
     start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path)
     config = json.loads(path.read_text())
-    provider = config["provider"]["unsloth"]
+    provider = config["provider"][start._OPENCODE_PROVIDER]
     assert provider["npm"] == "@ai-sdk/openai-compatible"
     assert provider["options"] == {"baseURL": f"{BASE}/v1", "apiKey": "sk-unsloth-abc"}
     # Context limit must be declared, or OpenCode treats it as 0 and disables compaction.
     assert provider["models"] == {
         MODEL["id"]: {"name": MODEL["id"], "limit": {"context": 131072, "output": 8192}}
     }
-    assert config["model"] == f"unsloth/{MODEL['id']}"
-    # A fresh config gains no disabled_providers key, so the overlay can't re-enable a
-    # provider the user disabled elsewhere.
+    assert config["model"] == f"{start._OPENCODE_PROVIDER}/{MODEL['id']}"
+    # The overlay never writes disabled_providers; the dedicated provider id is one a
+    # user's disable list would not target, so nothing needs re-enabling.
     assert "disabled_providers" not in config
     # Compaction buffer scaled to ~10% of the window (compact near 90%).
     assert config["compaction"] == {"auto": True, "reserved": 131072 // 10}
@@ -1417,7 +1409,7 @@ def test_write_opencode_config_preserves_and_idempotent(tmp_path):
     # the inline layer, so an existing list here is preserved untouched.
     assert config["disabled_providers"] == ["ollama", "unsloth"]
     assert config["provider"]["anthropic"]["name"] == "Anthropic"
-    assert config["provider"]["unsloth"]["options"]["baseURL"] == f"{BASE}/v1"
+    assert config["provider"][start._OPENCODE_PROVIDER]["options"]["baseURL"] == f"{BASE}/v1"
     before = path.read_text()
     start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path)
     assert path.read_text() == before
@@ -1441,31 +1433,6 @@ def _opencode_inline_config(output: str) -> dict:
     return json.loads(shlex.split(line.removeprefix("export OPENCODE_CONFIG_CONTENT="))[0])
 
 
-def test_opencode_inline_reenables_unsloth_from_disable(fake_studio, monkeypatch):
-    # The disabled_providers override rides in the inline OPENCODE_CONFIG_CONTENT
-    # (highest layer, beats a project config), minus unsloth, so the provider loads
-    # while the user's other disables are preserved.
-    monkeypatch.setattr(
-        start, "_opencode_effective_disabled_providers", lambda: ["ollama", "unsloth"]
-    )
-    result = CliRunner().invoke(start.start_app, ["opencode", "--no-launch"])
-    assert result.exit_code == 0, result.output
-    inline = _opencode_inline_config(result.output)
-    assert inline["disabled_providers"] == ["ollama"]
-    assert inline["model"] == f"unsloth/{MODEL['id']}"
-
-
-def test_opencode_inline_no_disable_when_unsloth_allowed(fake_studio, monkeypatch):
-    # When unsloth is not disabled, no override is written, or it would clobber the
-    # user's other disables.
-    monkeypatch.setattr(
-        start, "_opencode_effective_disabled_providers", lambda: ["ollama", "openai"]
-    )
-    result = CliRunner().invoke(start.start_app, ["opencode", "--no-launch"])
-    assert result.exit_code == 0, result.output
-    assert "disabled_providers" not in _opencode_inline_config(result.output)
-
-
 def test_opencode_passthrough_flags_omit_model_flag(fake_studio):
     # Any passthrough (top-level flags that may precede a subcommand, or a subcommand)
     # is left untouched; --model is not injected. The model is pinned by the inline
@@ -1475,71 +1442,10 @@ def test_opencode_passthrough_flags_omit_model_flag(fake_studio):
     command = _launch_command(result.output)
     assert command == ["opencode", "--dir", "repo"]
     assert "--model" not in command
-    assert _opencode_inline_config(result.output)["model"] == f"unsloth/{MODEL['id']}"
-
-
-def test_opencode_effective_disabled_project_overrides_global(tmp_path, monkeypatch):
-    monkeypatch.undo()  # exercise the real implementation
-    (tmp_path / "xdg" / "opencode").mkdir(parents = True)
-    (tmp_path / "xdg" / "opencode" / "opencode.json").write_text(
-        json.dumps({"disabled_providers": ["ollama"]})
+    assert (
+        _opencode_inline_config(result.output)["model"]
+        == f"{start._OPENCODE_PROVIDER}/{MODEL['id']}"
     )
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
-    proj = tmp_path / "proj"
-    proj.mkdir()
-    (proj / "opencode.json").write_text(json.dumps({"disabled_providers": ["unsloth", "gemini"]}))
-    monkeypatch.chdir(proj)
-    assert start._opencode_effective_disabled_providers() == ["unsloth", "gemini"]
-
-
-def test_opencode_effective_disabled_reads_global_when_no_project(tmp_path, monkeypatch):
-    monkeypatch.undo()
-    (tmp_path / "xdg" / "opencode").mkdir(parents = True)
-    (tmp_path / "xdg" / "opencode" / "opencode.json").write_text(
-        json.dumps({"disabled_providers": ["unsloth", "openai"]})
-    )
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
-    monkeypatch.setenv("HOME", str(tmp_path / "nohome"))
-    empty = tmp_path / "empty"
-    empty.mkdir()
-    monkeypatch.chdir(empty)
-    assert start._opencode_effective_disabled_providers() == ["unsloth", "openai"]
-
-
-def test_opencode_effective_disabled_walks_up_to_project_config(tmp_path, monkeypatch):
-    # Running from a subdir must still find the project config in an ancestor, the
-    # way opencode discovers it.
-    monkeypatch.undo()
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
-    monkeypatch.setenv("HOME", str(tmp_path / "nohome"))
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    (repo / "opencode.json").write_text(json.dumps({"disabled_providers": ["unsloth", "gemini"]}))
-    deep = repo / "src" / "deep"
-    deep.mkdir(parents = True)
-    monkeypatch.chdir(deep)
-    assert start._opencode_effective_disabled_providers() == ["unsloth", "gemini"]
-
-
-def test_opencode_dir_disabled_parses_jsonc_and_config_json(tmp_path):
-    (tmp_path / "jsonc").mkdir()
-    (tmp_path / "jsonc" / "opencode.jsonc").write_text(
-        '{\n  // disable the studio provider\n  "disabled_providers": ["unsloth",],\n}'
-    )
-    assert start._opencode_dir_disabled_providers(tmp_path / "jsonc") == ["unsloth"]
-    (tmp_path / "legacy").mkdir()
-    (tmp_path / "legacy" / "config.json").write_text(
-        json.dumps({"disabled_providers": ["unsloth", "openai"]})
-    )
-    assert start._opencode_dir_disabled_providers(tmp_path / "legacy") == ["unsloth", "openai"]
-
-
-def test_opencode_effective_disabled_missing_returns_empty(tmp_path, monkeypatch):
-    monkeypatch.undo()
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
-    monkeypatch.setenv("HOME", str(tmp_path / "nohome"))
-    monkeypatch.chdir(tmp_path)
-    assert start._opencode_effective_disabled_providers() == []
 
 
 def test_opencode_passthrough_subcommand_omits_model_flag(fake_studio):
@@ -1567,14 +1473,15 @@ def test_connect_opencode_no_launch(fake_studio, tmp_path):
         shlex.split(content_line.removeprefix("export OPENCODE_CONFIG_CONTENT="))[0]
     )
     config = json.loads(config_path.read_text())
-    assert config["provider"]["unsloth"]["options"]["apiKey"] == "sk-unsloth-feedfacefeedface"
-    assert config["model"] == f"unsloth/{MODEL['id']}"
+    provider = config["provider"][start._OPENCODE_PROVIDER]
+    assert provider["options"]["apiKey"] == "sk-unsloth-feedfacefeedface"
+    assert config["model"] == f"{start._OPENCODE_PROVIDER}/{MODEL['id']}"
     assert "disabled_providers" not in config
-    assert inline_config == {"model": f"unsloth/{MODEL['id']}"}
+    assert inline_config == {"model": f"{start._OPENCODE_PROVIDER}/{MODEL['id']}"}
     assert _launch_command(result.output)[:3] == [
         "opencode",
         "--model",
-        f"unsloth/{MODEL['id']}",
+        f"{start._OPENCODE_PROVIDER}/{MODEL['id']}",
     ]
     assert not any(c[1].endswith("/api/inference/status") for c in fake_studio)
 
@@ -1928,7 +1835,7 @@ def test_no_launch_rerun_clears_stale_opencode_yolo_permissions(fake_studio, tmp
     # revert to OpenCode's permissive "allow" default).
     assert config["permission"] == {"edit": "ask", "bash": "ask", "webfetch": "ask"}
     # The session provider survives the cleanup.
-    assert "unsloth" in config["provider"]
+    assert start._OPENCODE_PROVIDER in config["provider"]
 
 
 def test_no_launch_rerun_clears_stale_openclaw_yolo_state(fake_studio, tmp_path):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1380,7 +1380,9 @@ def test_write_opencode_config_fresh(tmp_path):
         MODEL["id"]: {"name": MODEL["id"], "limit": {"context": 131072, "output": 8192}}
     }
     assert config["model"] == f"unsloth/{MODEL['id']}"
-    assert config["disabled_providers"] == []
+    # A fresh config gains no disabled_providers key, so the overlay can't re-enable a
+    # provider the user disabled elsewhere.
+    assert "disabled_providers" not in config
     # Compaction buffer scaled to ~10% of the window (compact near 90%).
     assert config["compaction"] == {"auto": True, "reserved": 131072 // 10}
 
@@ -1407,6 +1409,28 @@ def test_write_opencode_config_preserves_and_idempotent(tmp_path):
     assert path.read_text() == before
 
 
+def test_write_opencode_config_keeps_foreign_disabled_providers(tmp_path):
+    # A user who disabled other providers (but not unsloth) must keep them disabled:
+    # the overlay must not rewrite disabled_providers, or those providers get silently
+    # re-enabled for the session.
+    path = tmp_path / "opencode.json"
+    path.write_text(json.dumps({"disabled_providers": ["openai", "gemini"]}))
+    start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path)
+    config = json.loads(path.read_text())
+    assert config["disabled_providers"] == ["openai", "gemini"]
+
+
+def test_opencode_passthrough_subcommand_omits_model_flag(fake_studio):
+    # A passthrough subcommand (e.g. `serve`) takes the model from the pinned config;
+    # inserting --model before it would break opencode's arg parsing.
+    result = CliRunner().invoke(start.start_app, ["opencode", "--no-launch", "serve"])
+    assert result.exit_code == 0, result.output
+    command = _launch_command(result.output)
+    assert command[0] == "opencode"
+    assert command[1] == "serve"
+    assert "--model" not in command
+
+
 def test_connect_opencode_no_launch(fake_studio, tmp_path):
     result = CliRunner().invoke(start.start_app, ["opencode", "--no-launch"])
     assert result.exit_code == 0, result.output
@@ -1414,21 +1438,17 @@ def test_connect_opencode_no_launch(fake_studio, tmp_path):
     config_path = tmp_path / "agents" / "opencode" / "opencode.json"
     # OPENCODE_CONFIG overlay points at the session file, not the user's global config.
     _assert_env_set(result.output, "OPENCODE_CONFIG", str(config_path))
-    inline_config_text = (
-        result.output.split("OPENCODE_CONFIG_CONTENT", 1)[1]
-        .splitlines()[0]
-        .split("=", 1)[1]
-        .strip()
-        .strip('"')
-        .replace("`", "")
+    content_line = next(
+        ln for ln in result.output.splitlines() if ln.startswith("export OPENCODE_CONFIG_CONTENT=")
     )
-    inline_config = json.loads(inline_config_text)
+    inline_config = json.loads(
+        shlex.split(content_line.removeprefix("export OPENCODE_CONFIG_CONTENT="))[0]
+    )
     config = json.loads(config_path.read_text())
     assert config["provider"]["unsloth"]["options"]["apiKey"] == "sk-unsloth-feedfacefeedface"
     assert config["model"] == f"unsloth/{MODEL['id']}"
-    assert config["disabled_providers"] == []
-    assert inline_config["model"] == f"unsloth/{MODEL['id']}"
-    assert inline_config["disabled_providers"] == []
+    assert "disabled_providers" not in config
+    assert inline_config == {"model": f"unsloth/{MODEL['id']}"}
     assert _launch_command(result.output)[:3] == [
         "opencode",
         "--model",

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1466,14 +1466,16 @@ def test_opencode_inline_no_disable_when_unsloth_allowed(fake_studio, monkeypatc
     assert "disabled_providers" not in _opencode_inline_config(result.output)
 
 
-def test_opencode_tui_flags_keep_model_flag(fake_studio):
-    # Top-level TUI flags (not a subcommand) must still pin --model; only a real
-    # subcommand like `serve` takes the model from config.
+def test_opencode_passthrough_flags_omit_model_flag(fake_studio):
+    # Any passthrough (top-level flags that may precede a subcommand, or a subcommand)
+    # is left untouched; --model is not injected. The model is pinned by the inline
+    # OPENCODE_CONFIG_CONTENT (highest layer) instead, so it is still forced.
     result = CliRunner().invoke(start.start_app, ["opencode", "--no-launch", "--dir", "repo"])
     assert result.exit_code == 0, result.output
     command = _launch_command(result.output)
-    assert command[:3] == ["opencode", "--model", f"unsloth/{MODEL['id']}"]
-    assert command[3:] == ["--dir", "repo"]
+    assert command == ["opencode", "--dir", "repo"]
+    assert "--model" not in command
+    assert _opencode_inline_config(result.output)["model"] == f"unsloth/{MODEL['id']}"
 
 
 def test_opencode_effective_disabled_project_overrides_global(tmp_path, monkeypatch):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -435,15 +435,10 @@ def test_opencode_inline_config_beats_project_config(fake_studio):
     # permissions) ride in OPENCODE_CONFIG_CONTENT, which outranks project config.
     result = CliRunner().invoke(start.start_app, ["opencode", "--no-launch", "--yolo"])
     assert result.exit_code == 0, result.output
-    content_line = next(
-        ln for ln in result.output.splitlines() if ln.startswith("export OPENCODE_CONFIG_CONTENT=")
-    )
-    inline = json.loads(
-        shlex.split(content_line.removeprefix("export OPENCODE_CONFIG_CONTENT="))[0]
-    )
+    inline = _opencode_inline_config(result.output)
     assert inline["model"] == f"{start._OPENCODE_PROVIDER}/{MODEL['id']}"
     assert inline["permission"] == {"edit": "allow", "bash": "allow", "webfetch": "allow"}
-    assert "sk-unsloth" not in content_line  # key stays in the private file
+    assert "sk-unsloth" not in result.output  # key stays in the private file, not the env
 
 
 def test_opencode_inline_config_omits_permission_without_yolo(fake_studio):
@@ -452,12 +447,7 @@ def test_opencode_inline_config_omits_permission_without_yolo(fake_studio):
     # user's project rules; clearing our own config is the fix, and the inline pins the model.
     result = CliRunner().invoke(start.start_app, ["opencode", "--no-launch"])
     assert result.exit_code == 0, result.output
-    content_line = next(
-        ln for ln in result.output.splitlines() if ln.startswith("export OPENCODE_CONFIG_CONTENT=")
-    )
-    inline = json.loads(
-        shlex.split(content_line.removeprefix("export OPENCODE_CONFIG_CONTENT="))[0]
-    )
+    inline = _opencode_inline_config(result.output)
     assert inline["model"] == f"{start._OPENCODE_PROVIDER}/{MODEL['id']}"
     assert "permission" not in inline
 
@@ -1427,10 +1417,34 @@ def test_write_opencode_config_keeps_foreign_disabled_providers(tmp_path):
 
 
 def _opencode_inline_config(output: str) -> dict:
-    line = next(
-        ln for ln in output.splitlines() if ln.startswith("export OPENCODE_CONFIG_CONTENT=")
-    )
-    return json.loads(shlex.split(line.removeprefix("export OPENCODE_CONFIG_CONTENT="))[0])
+    # --no-launch prints OPENCODE_CONFIG_CONTENT as a POSIX `export NAME=<shell-quoted>`
+    # line on Unix/WSL and a PowerShell `$env:NAME = "<escaped>"` line on native Windows;
+    # parse whichever the host emitted so the opencode tests are shell-agnostic.
+    name = "OPENCODE_CONFIG_CONTENT"
+    for raw in output.splitlines():
+        line = raw.strip()
+        if line.startswith(f"export {name}="):
+            return json.loads(shlex.split(line.removeprefix(f"export {name}="))[0])
+        prefix = f'$env:{name} = "'
+        if line.startswith(prefix) and line.endswith('"'):
+            escaped = line[len(prefix) : -1]
+            # Reverse _print_env's PowerShell escaping (backtick is the escape char).
+            value = escaped.replace("`$", "$").replace('`"', '"').replace("``", "`")
+            return json.loads(value)
+    raise AssertionError(f"{name} not found in:\n{output}")
+
+
+def test_opencode_inline_scopes_session_to_studio_provider(fake_studio):
+    # opencode filters even config-defined providers through enabled/disabled_providers,
+    # and a model pin does not bypass that gate. The inline overlay (session-only, highest
+    # layer, arrays replace) allowlists our provider and clears the denylist so the Studio
+    # model always loads regardless of the user's config, without reading or editing it.
+    result = CliRunner().invoke(start.start_app, ["opencode", "--no-launch"])
+    assert result.exit_code == 0, result.output
+    inline = _opencode_inline_config(result.output)
+    assert inline["enabled_providers"] == [start._OPENCODE_PROVIDER]
+    assert inline["disabled_providers"] == []
+    assert inline["model"] == f"{start._OPENCODE_PROVIDER}/{MODEL['id']}"
 
 
 def test_opencode_passthrough_flags_omit_model_flag(fake_studio):
@@ -1466,23 +1480,23 @@ def test_connect_opencode_no_launch(fake_studio, tmp_path):
     config_path = tmp_path / "agents" / "opencode" / "opencode.json"
     # OPENCODE_CONFIG overlay points at the session file, not the user's global config.
     _assert_env_set(result.output, "OPENCODE_CONFIG", str(config_path))
-    content_line = next(
-        ln for ln in result.output.splitlines() if ln.startswith("export OPENCODE_CONFIG_CONTENT=")
-    )
-    inline_config = json.loads(
-        shlex.split(content_line.removeprefix("export OPENCODE_CONFIG_CONTENT="))[0]
-    )
+    inline_config = _opencode_inline_config(result.output)
     config = json.loads(config_path.read_text())
     provider = config["provider"][start._OPENCODE_PROVIDER]
     assert provider["options"]["apiKey"] == "sk-unsloth-feedfacefeedface"
     assert config["model"] == f"{start._OPENCODE_PROVIDER}/{MODEL['id']}"
+    # The session config file (a throwaway overlay, not the user's real config) does not
+    # carry provider filters; the session scoping rides in the inline env layer only.
     assert "disabled_providers" not in config
-    assert inline_config == {"model": f"{start._OPENCODE_PROVIDER}/{MODEL['id']}"}
-    assert _launch_command(result.output)[:3] == [
-        "opencode",
-        "--model",
-        f"{start._OPENCODE_PROVIDER}/{MODEL['id']}",
-    ]
+    assert "enabled_providers" not in config
+    assert inline_config == {
+        "model": f"{start._OPENCODE_PROVIDER}/{MODEL['id']}",
+        "enabled_providers": [start._OPENCODE_PROVIDER],
+        "disabled_providers": [],
+    }
+    # --no-launch prints an append-safe base command (no --model before a subcommand a
+    # driver may append); the model is forced by the inline pin above.
+    assert _launch_command(result.output) == ["opencode"]
     assert not any(c[1].endswith("/api/inference/status") for c in fake_studio)
 
 

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -27,6 +27,14 @@ BASE = "http://127.0.0.1:8888"
 MODEL = {"id": "unsloth/gemma-4-26B-A4B-it-GGUF", "context_length": 131072}
 
 
+@pytest.fixture(autouse = True)
+def _no_global_opencode_config(monkeypatch):
+    # Isolate the opencode config tests from any real ~/.config/opencode on the
+    # host, so the overlay's disabled_providers handling is deterministic. Tests
+    # that exercise the global-disable path override this with their own value.
+    monkeypatch.setattr(start, "_opencode_global_disabled_providers", lambda: [])
+
+
 # --no-launch prints shell setup as POSIX (export/unset) on Unix/WSL and
 # PowerShell ($env:/Remove-Item) on native Windows; assert the host's form.
 def _assert_env_set(output: str, name: str, value: str) -> None:
@@ -1422,6 +1430,45 @@ def test_write_opencode_config_keeps_foreign_disabled_providers(tmp_path):
     start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path)
     config = json.loads(path.read_text())
     assert config["disabled_providers"] == ["openai", "gemini"]
+
+
+def test_write_opencode_config_reenables_unsloth_from_global_disable(tmp_path, monkeypatch):
+    # A fresh overlay omits disabled_providers, so a global ["unsloth", ...] would
+    # otherwise survive the merge and keep the session provider disabled. The overlay
+    # must override it, re-enabling unsloth while preserving the user's other disables.
+    monkeypatch.setattr(start, "_opencode_global_disabled_providers", lambda: ["ollama", "unsloth"])
+    path = tmp_path / "opencode.json"
+    start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path)
+    config = json.loads(path.read_text())
+    assert config["disabled_providers"] == ["ollama"]
+
+
+def test_write_opencode_config_no_override_when_global_allows_unsloth(tmp_path, monkeypatch):
+    # If the global config disables other providers but not unsloth, the overlay must
+    # not touch disabled_providers (unsloth already loads; a rewrite would clobber).
+    monkeypatch.setattr(start, "_opencode_global_disabled_providers", lambda: ["ollama", "openai"])
+    path = tmp_path / "opencode.json"
+    start.write_opencode_config(BASE, "sk-unsloth-abc", MODEL, path)
+    config = json.loads(path.read_text())
+    assert "disabled_providers" not in config
+
+
+def test_opencode_global_disabled_providers_reads_xdg_config(tmp_path, monkeypatch):
+    monkeypatch.undo()  # drop the autouse stub; exercise the real implementation
+    cfg_dir = tmp_path / "opencode"
+    cfg_dir.mkdir()
+    (cfg_dir / "opencode.json").write_text(
+        json.dumps({"disabled_providers": ["unsloth", "openai"]})
+    )
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    assert start._opencode_global_disabled_providers() == ["unsloth", "openai"]
+
+
+def test_opencode_global_disabled_providers_missing_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.undo()  # drop the autouse stub; exercise the real implementation
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+    monkeypatch.setenv("HOME", str(tmp_path / "nohome"))
+    assert start._opencode_global_disabled_providers() == []
 
 
 def test_opencode_passthrough_subcommand_omits_model_flag(fake_studio):


### PR DESCRIPTION
﻿## Summary

- Ensure the session Unsloth provider is not disabled in opencode config.
- Launch opencode with an explicit `--model unsloth/<model>` argument.
- Add regressions for user config that disables `unsloth` and for the no-launch command/env output.

## Root Cause

`unsloth start opencode` writes a session provider named `unsloth`, but opencode merges user config first. If the user-level config contains `disabled_providers = ["unsloth"]`, the session provider exists but remains disabled, so the TUI can fall back to another configured provider/model such as Ollama Cloud.

## Validation

- `python -m py_compile unsloth_cli/commands/start.py unsloth_cli/tests/test_start.py`
- `git diff --check`
- Targeted Windows pytest: `test_write_opencode_config_fresh`, `test_write_opencode_config_preserves_and_idempotent`, `test_connect_opencode_no_launch`
- Manual resolved-config check with installed opencode confirmed `disabled_providers: []` enables the `unsloth` provider.
