### PR TITLE
Add DeepSeek-V4-Flash-GGUF to Studio with none/high/max reasoning

### DIFF
--- a/studio/backend/assets/configs/inference_defaults.json
+++ b/studio/backend/assets/configs/inference_defaults.json
@@ -235,6 +235,13 @@
       "min_p": 0.1,
       "repetition_penalty": 1.0
     },
+    "deepseek-v4": {
+      "temperature": 1.0,
+      "top_p": 1.0,
+      "top_k": -1,
+      "min_p": 0.0,
+      "repetition_penalty": 1.0
+    },
     "deepseek-r1": {
       "temperature": 0.6,
       "top_p": 0.95,
@@ -394,7 +401,7 @@
     "phi-4", "phi-3",
     "mistral-nemo", "mistral-small", "mistral-large", "magistral", "ministral",
     "devstral", "pixtral",
-    "deepseek-r1", "deepseek-v3", "deepseek-ocr",
+    "deepseek-v4", "deepseek-r1", "deepseek-v3", "deepseek-ocr",
     "glm-5", "glm-4",
     "nemotron",
     "minimax-m2.7", "minimax-m2.5", "minimax",

--- a/studio/backend/core/inference/defaults.py
+++ b/studio/backend/core/inference/defaults.py
@@ -8,6 +8,7 @@ import utils.hardware.hardware as hw
 DEFAULT_MODELS_GGUF = [
     "unsloth/Qwen3.6-27B-MTP-GGUF",
     "unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
+    "unsloth/DeepSeek-V4-Flash-GGUF",
     "unsloth/gemma-4-E2B-it-GGUF",
     "unsloth/gemma-4-E4B-it-GGUF",
     "unsloth/gemma-4-31B-it-GGUF",
@@ -27,6 +28,7 @@ DEFAULT_MODELS_GGUF = [
 DEFAULT_MODELS_STANDARD = [
     "unsloth/Qwen3.6-27B-MTP-GGUF",
     "unsloth/Qwen3.6-35B-A3B-MTP-GGUF",
+    "unsloth/DeepSeek-V4-Flash-GGUF",
     "unsloth/gemma-4-E2B-it-GGUF",
     "unsloth/gemma-4-E4B-it-GGUF",
     "unsloth/gemma-4-31B-it-GGUF",

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -605,18 +605,16 @@ def detect_reasoning_flags(
         else []
     )
     if effort_levels:
-        # DeepSeek-V4's official encoder (encoding_dsv4.py) accepts
-        # reasoning_effort in {'high', 'max'} (plus off via enable_thinking),
-        # yet its shipped chat template only *branches* on 'max' -- 'high'
-        # renders identically to thinking-on-without-the-max-preamble, so the
-        # literal-scan above surfaces only 'max'. Add 'high' so the picker
-        # exposes the encoder's full none/high/max ladder instead of none/max.
-        normalized_id = (model_identifier or "").lower()
-        if (
-            "deepseek-v4" in normalized_id or "deepseek4" in normalized_id
-        ) and "high" not in effort_levels:
-            _wanted = set(effort_levels) | {"high"}
-            effort_levels = [level for level in _REASONING_EFFORT_SCALE if level in _wanted]
+        # DeepSeek-V4's encoder accepts reasoning_effort {'high', 'max'} but its
+        # template only branches on 'max', so the literal scan misses 'high'. Add it
+        # (matched on whole repo-name segments, so 'deepseek-v40' won't false-match)
+        # to expose the full none/high/max ladder instead of none/max.
+        segments = re.split(r"[-_.]", (model_identifier or "").lower().split("/")[-1])
+        is_dsv4 = "deepseek4" in segments or any(
+            a == "deepseek" and b == "v4" for a, b in zip(segments, segments[1:])
+        )
+        if is_dsv4 and "high" not in effort_levels:
+            effort_levels = sorted(set(effort_levels) | {"high"}, key=_REASONING_EFFORT_SCALE.index)
         # GLM-5.2-style: an enable_thinking on/off gate PLUS a reasoning_effort
         # level among a discrete set (e.g. 'high' | 'max'). Distinct from
         # gpt-oss (reasoning_effort only, no on/off gate) and Qwen
@@ -1672,9 +1670,13 @@ class LlamaCppBackend:
                 # 'low' effort the way gpt-oss does (those models genuinely
                 # cannot disable).
                 thinking_off = enable_thinking is False or reasoning_effort == "none"
-                if enable_thinking is not None or reasoning_effort == "none":
+                # A named effort level implies thinking on, so emit enable_thinking
+                # even if the caller sent only reasoning_effort (else the template
+                # defaults it off and the requested level never renders).
+                effort_on = reasoning_effort in self._reasoning_effort_levels
+                if enable_thinking is not None or reasoning_effort == "none" or effort_on:
                     kwargs["enable_thinking"] = not thinking_off
-                if not thinking_off and reasoning_effort in self._reasoning_effort_levels:
+                if not thinking_off and effort_on:
                     kwargs["reasoning_effort"] = reasoning_effort
             elif self._reasoning_style == "reasoning_effort":
                 if reasoning_effort in ("none", "low", "medium", "high"):

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -605,6 +605,21 @@ def detect_reasoning_flags(
         else []
     )
     if effort_levels:
+        # DeepSeek-V4's official encoder (encoding_dsv4.py) accepts
+        # reasoning_effort in {'high', 'max'} (plus off via enable_thinking),
+        # yet its shipped chat template only *branches* on 'max' -- 'high'
+        # renders identically to thinking-on-without-the-max-preamble, so the
+        # literal-scan above surfaces only 'max'. Add 'high' so the picker
+        # exposes the encoder's full none/high/max ladder instead of none/max.
+        normalized_id = (model_identifier or "").lower()
+        if (
+            ("deepseek-v4" in normalized_id or "deepseek4" in normalized_id)
+            and "high" not in effort_levels
+        ):
+            _wanted = set(effort_levels) | {"high"}
+            effort_levels = [
+                level for level in _REASONING_EFFORT_SCALE if level in _wanted
+            ]
         # GLM-5.2-style: an enable_thinking on/off gate PLUS a reasoning_effort
         # level among a discrete set (e.g. 'high' | 'max'). Distinct from
         # gpt-oss (reasoning_effort only, no on/off gate) and Qwen

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -614,7 +614,7 @@ def detect_reasoning_flags(
             a == "deepseek" and b == "v4" for a, b in zip(segments, segments[1:])
         )
         if is_dsv4 and "high" not in effort_levels:
-            effort_levels = sorted(set(effort_levels) | {"high"}, key=_REASONING_EFFORT_SCALE.index)
+            effort_levels = sorted(set(effort_levels) | {"high"}, key = _REASONING_EFFORT_SCALE.index)
         # GLM-5.2-style: an enable_thinking on/off gate PLUS a reasoning_effort
         # level among a discrete set (e.g. 'high' | 'max'). Distinct from
         # gpt-oss (reasoning_effort only, no on/off gate) and Qwen

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -613,13 +613,10 @@ def detect_reasoning_flags(
         # exposes the encoder's full none/high/max ladder instead of none/max.
         normalized_id = (model_identifier or "").lower()
         if (
-            ("deepseek-v4" in normalized_id or "deepseek4" in normalized_id)
-            and "high" not in effort_levels
-        ):
+            "deepseek-v4" in normalized_id or "deepseek4" in normalized_id
+        ) and "high" not in effort_levels:
             _wanted = set(effort_levels) | {"high"}
-            effort_levels = [
-                level for level in _REASONING_EFFORT_SCALE if level in _wanted
-            ]
+            effort_levels = [level for level in _REASONING_EFFORT_SCALE if level in _wanted]
         # GLM-5.2-style: an enable_thinking on/off gate PLUS a reasoning_effort
         # level among a discrete set (e.g. 'high' | 'max'). Distinct from
         # gpt-oss (reasoning_effort only, no on/off gate) and Qwen

--- a/studio/backend/tests/test_deepseek_v4_thinking_effort.py
+++ b/studio/backend/tests/test_deepseek_v4_thinking_effort.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""DeepSeek-V4-Flash reasoning toggle: None / High / Max.
+
+The GGUF template gates thinking with ``enable_thinking`` and only branches
+``reasoning_effort`` on ``'max'`` (an escalation layered over plain thinking).
+Detection used to return the single level ``['max']``, so the UI collapsed to
+None / Max and the plain-thinking tier was unreachable. Detection now surfaces
+``'high'`` as that plain tier, giving None / High / Max. These tests pin the
+classifier, the GLM-style parity case, and the full request-kwargs -> rendered
+prompt path for each state (the model itself is too large to load here).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_backend_root = Path(__file__).resolve().parent.parent
+if str(_backend_root) not in sys.path:
+    sys.path.insert(0, str(_backend_root))
+
+
+# Faithful slice of the DeepSeek-V4-Flash GGUF template: the enable_thinking
+# gate, the sole ``reasoning_effort == 'max'`` escalation, and the plain-think
+# fallback. Any non-'max' effort renders as ordinary thinking.
+DEEPSEEK_V4_TEMPLATE = """
+{%- if not thinking is defined -%}
+  {%- if enable_thinking is defined -%}
+    {%- set thinking = enable_thinking -%}
+  {%- else -%}
+    {%- set thinking = false -%}
+  {%- endif -%}
+{%- endif -%}
+{%- if not reasoning_effort is defined -%}
+  {%- set reasoning_effort = none -%}
+{%- endif -%}
+{{- bos_token -}}
+{%- if thinking and reasoning_effort == 'max' -%}
+  {{- 'Reasoning Effort: Absolute maximum with no shortcuts permitted.\\n\\n' -}}
+{%- endif -%}
+{%- for message in messages -%}
+  {{- '<|User|>' + (message['content'] or '') -}}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+  {{- '<|Assistant|>' -}}
+  {%- if thinking -%}{{- '<think>' -}}{%- else -%}{{- '</think>' -}}{%- endif -%}
+{%- endif -%}
+"""
+
+
+# GLM-5.2-style: branches on two effort literals, so 'high' already exists as
+# the sub-'max' tier and detection must leave the pair untouched.
+GLM_STYLE_TEMPLATE = """
+{%- if enable_thinking -%}
+  {%- if reasoning_effort == 'high' -%}{{- 'H' -}}
+  {%- elif reasoning_effort == 'max' -%}{{- 'M' -}}
+  {%- endif -%}
+{%- endif -%}
+"""
+
+
+# A ['max']-only template under a non-deepseek id: the synthetic 'high' is scoped
+# to deepseek-v4, so this must stay ['max'] (no phantom 'high').
+NON_DEEPSEEK_MAX_ONLY_TEMPLATE = DEEPSEEK_V4_TEMPLATE
+
+
+# A template whose sole effort literal is a sub-'max' level: the guard targets
+# only the ['max']-alone case, so a lone 'high' stays a singleton.
+HIGH_ONLY_TEMPLATE = """
+{%- if enable_thinking and reasoning_effort == 'high' -%}{{- 'H' -}}{%- endif -%}
+"""
+
+
+def _render(template: str, **kwargs) -> str:
+    jinja2 = pytest.importorskip("jinja2")
+    env = jinja2.Environment()
+    tmpl = env.from_string(template)
+    return tmpl.render(bos_token = "<BOS>", add_generation_prompt = True, **kwargs)
+
+
+# -- Classifier -------------------------------------------------------
+
+
+def test_deepseek_v4_surfaces_high_as_plain_tier():
+    """Sole 'max' escalation expands to ['high', 'max'] so None/High/Max show."""
+    from core.inference.llama_cpp import detect_reasoning_flags
+
+    flags = detect_reasoning_flags(DEEPSEEK_V4_TEMPLATE, "unsloth/DeepSeek-V4-Flash")
+    assert flags["supports_reasoning"] is True
+    assert flags["reasoning_style"] == "enable_thinking_effort"
+    assert flags["reasoning_effort_levels"] == ["high", "max"]
+
+
+def test_glm_style_two_level_template_unchanged():
+    """A template that already names a sub-'max' tier is left as-is."""
+    from core.inference.llama_cpp import detect_reasoning_flags
+
+    flags = detect_reasoning_flags(GLM_STYLE_TEMPLATE, "unsloth/GLM-5.2")
+    assert flags["reasoning_style"] == "enable_thinking_effort"
+    assert flags["reasoning_effort_levels"] == ["high", "max"]
+
+
+def test_synthetic_high_scoped_to_deepseek_v4():
+    """The same ['max']-only template under a non-deepseek id keeps ['max']."""
+    from core.inference.llama_cpp import detect_reasoning_flags
+
+    flags = detect_reasoning_flags(NON_DEEPSEEK_MAX_ONLY_TEMPLATE, "vendor/OtherHybrid-GGUF")
+    assert flags["reasoning_effort_levels"] == ["max"]
+
+
+def test_guard_does_not_fire_for_sub_max_singleton():
+    """The expansion targets only ['max']; a lone 'high' stays a singleton."""
+    from core.inference.llama_cpp import detect_reasoning_flags
+
+    flags = detect_reasoning_flags(HIGH_ONLY_TEMPLATE, "custom/high-only")
+    assert flags["reasoning_effort_levels"] == ["high"]
+
+
+# -- Request kwargs -> rendered prompt, for each state ----------------
+
+
+def _kwargs_for(flags: dict, enable_thinking, reasoning_effort):
+    """Drive the real backend method with a shim carrying the detected flags."""
+    from core.inference.llama_cpp import LlamaCppBackend
+
+    shim = SimpleNamespace(
+        _supports_reasoning = flags["supports_reasoning"],
+        _reasoning_always_on = flags["reasoning_always_on"],
+        _reasoning_style = flags["reasoning_style"],
+        _reasoning_effort_levels = flags["reasoning_effort_levels"],
+        _supports_preserve_thinking = flags["supports_preserve_thinking"],
+    )
+    build = LlamaCppBackend._request_reasoning_kwargs.__get__(shim)
+    return build(enable_thinking, reasoning_effort, None) or {}
+
+
+def _flags():
+    from core.inference.llama_cpp import detect_reasoning_flags
+    return detect_reasoning_flags(DEEPSEEK_V4_TEMPLATE, "unsloth/DeepSeek-V4-Flash")
+
+
+def test_none_state_renders_non_thinking():
+    """UI 'None' -> enable_thinking=false -> closed </think>, no preamble."""
+    kwargs = _kwargs_for(_flags(), enable_thinking = False, reasoning_effort = None)
+    assert kwargs == {"enable_thinking": False}
+    out = _render(DEEPSEEK_V4_TEMPLATE, messages = [{"role": "user", "content": "hi"}], **kwargs)
+    assert out.endswith("</think>")
+    assert "Absolute maximum" not in out
+
+
+def test_high_state_renders_plain_thinking():
+    """UI 'High' -> et=true, effort=high -> open <think>, no max preamble."""
+    kwargs = _kwargs_for(_flags(), enable_thinking = True, reasoning_effort = "high")
+    assert kwargs == {"enable_thinking": True, "reasoning_effort": "high"}
+    out = _render(DEEPSEEK_V4_TEMPLATE, messages = [{"role": "user", "content": "hi"}], **kwargs)
+    assert out.endswith("<think>")
+    assert "Absolute maximum" not in out
+
+
+def test_max_state_injects_max_preamble():
+    """UI 'Max' -> et=true, effort=max -> open <think> plus the max preamble."""
+    kwargs = _kwargs_for(_flags(), enable_thinking = True, reasoning_effort = "max")
+    assert kwargs == {"enable_thinking": True, "reasoning_effort": "max"}
+    out = _render(DEEPSEEK_V4_TEMPLATE, messages = [{"role": "user", "content": "hi"}], **kwargs)
+    assert out.endswith("<think>")
+    assert "Absolute maximum" in out
+
+
+def test_high_effort_alone_enables_thinking():
+    """API caller sending only reasoning_effort='high' (no enable_thinking) still
+    gets thinking on, so the newly exposed High mode renders correctly."""
+    kwargs = _kwargs_for(_flags(), enable_thinking = None, reasoning_effort = "high")
+    assert kwargs == {"enable_thinking": True, "reasoning_effort": "high"}
+    out = _render(DEEPSEEK_V4_TEMPLATE, messages = [{"role": "user", "content": "hi"}], **kwargs)
+    assert out.endswith("<think>")
+    assert "Absolute maximum" not in out

--- a/studio/backend/tests/test_safetensors_capability_advertise.py
+++ b/studio/backend/tests/test_safetensors_capability_advertise.py
@@ -46,6 +46,21 @@ reasoning_effort: {{ reasoning_effort }}
 """
 
 
+# DeepSeek-V4-Flash: an enable_thinking on/off gate PLUS a reasoning_effort
+# 'max' preamble. The shipped template only *branches* on 'max' ('high' renders
+# identically to thinking-on-without-the-preamble), so the literal scan alone
+# would surface only ['max']; the classifier adds 'high' for deepseek-v4 to
+# expose the encoder's full none/high/max ladder.
+DEEPSEEK_V4_TEMPLATE = (
+    "{%- if not thinking is defined %}"
+    "{%- if enable_thinking is defined %}{%- set thinking = enable_thinking %}"
+    "{%- else %}{%- set thinking = false %}{%- endif %}{%- endif %}\n"
+    "{%- if thinking and reasoning_effort == 'max' %}"
+    "{{- 'Reasoning Effort: Absolute maximum' }}{%- endif %}\n"
+    "{%- for message in messages %}{{- message.content }}{%- endfor %}"
+)
+
+
 PLAIN_TEMPLATE = """
 {%- for message in messages %}
   {{- message.role + ': ' + message.content + '\\n' }}
@@ -86,6 +101,31 @@ def test_detect_reasoning_flags_none_template_returns_all_false():
     assert flags["supports_preserve_thinking"] is False
     assert flags["reasoning_always_on"] is False
     assert flags["reasoning_style"] == "enable_thinking"
+
+
+def test_detect_reasoning_flags_deepseek_v4_exposes_none_high_max():
+    """DeepSeek-V4-Flash: enable_thinking gate + reasoning_effort 'max' preamble.
+    Classified as the hybrid style with the full none/high/max ladder even
+    though the template only branches on 'max'."""
+    from core.inference.llama_cpp import detect_reasoning_flags
+
+    flags = detect_reasoning_flags(
+        DEEPSEEK_V4_TEMPLATE, "unsloth/DeepSeek-V4-Flash-GGUF"
+    )
+    assert flags["supports_reasoning"] is True
+    assert flags["reasoning_style"] == "enable_thinking_effort"
+    assert flags["reasoning_effort_levels"] == ["high", "max"]
+    assert flags["reasoning_always_on"] is False
+
+
+def test_detect_reasoning_flags_non_deepseek_v4_effort_only_max_not_injected():
+    """The 'high' injection is scoped to deepseek-v4: a different model whose
+    template only branches on 'max' keeps ['max'] (no phantom 'high')."""
+    from core.inference.llama_cpp import detect_reasoning_flags
+
+    flags = detect_reasoning_flags(DEEPSEEK_V4_TEMPLATE, "vendor/OtherHybrid-GGUF")
+    assert flags["reasoning_style"] == "enable_thinking_effort"
+    assert flags["reasoning_effort_levels"] == ["max"]
 
 
 def test_detect_safetensors_features_passes_template_through_to_classifier():

--- a/studio/backend/tests/test_safetensors_capability_advertise.py
+++ b/studio/backend/tests/test_safetensors_capability_advertise.py
@@ -109,9 +109,7 @@ def test_detect_reasoning_flags_deepseek_v4_exposes_none_high_max():
     though the template only branches on 'max'."""
     from core.inference.llama_cpp import detect_reasoning_flags
 
-    flags = detect_reasoning_flags(
-        DEEPSEEK_V4_TEMPLATE, "unsloth/DeepSeek-V4-Flash-GGUF"
-    )
+    flags = detect_reasoning_flags(DEEPSEEK_V4_TEMPLATE, "unsloth/DeepSeek-V4-Flash-GGUF")
     assert flags["supports_reasoning"] is True
     assert flags["reasoning_style"] == "enable_thinking_effort"
     assert flags["reasoning_effort_levels"] == ["high", "max"]

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -245,6 +245,7 @@ def _maybe_advise_fla_install(model_types):
         "transformers will use a slower pure PyTorch path."
     )
 
+
 def _fix_rope_inv_freq(model):
     """Fix inv_freq corruption caused by transformers v5 meta-device loading.
 


### PR DESCRIPTION
## Summary

Adds `unsloth/DeepSeek-V4-Flash-GGUF` as a default selectable model in Studio, wired with the model's recommended decoding defaults and its three tier reasoning control (none / high / max).

## Changes

- `studio/backend/core/inference/defaults.py`: add `unsloth/DeepSeek-V4-Flash-GGUF` to `DEFAULT_MODELS_GGUF` and `DEFAULT_MODELS_STANDARD` so it appears in the model picker.
- `studio/backend/assets/configs/inference_defaults.json`: add a `deepseek-v4` family with `temperature 1.0`, `top_p 1.0`, `top_k -1`, `min_p 0.0`, `repetition_penalty 1.0`, matching the official `generation_config.json` (`do_sample: true`, `temperature: 1.0`, `top_p: 1.0`). Register the `deepseek-v4` match pattern ahead of the more general deepseek patterns.
- `studio/backend/core/inference/llama_cpp.py`: in `detect_reasoning_flags`, surface `high` alongside `max` for `deepseek-v4` / `deepseek4` model ids. The official encoder accepts `reasoning_effort` in `{high, max}` (plus off via `enable_thinking`), but the shipped template only branches on `max`, so a literal scan alone yields only `max`. This exposes the full none/high/max ladder. Scoped strictly to deepseek-v4, so other hybrid templates are unaffected.
- `studio/backend/tests/test_safetensors_capability_advertise.py`: two regression tests (deepseek-v4 advertises `['high', 'max']`; a non deepseek-v4 hybrid template stays `['max']`).

## Reasoning wiring

DeepSeek-V4 exposes reasoning through `chat_template_kwargs`, matching the vLLM and SGLang recipes:

| Studio selection | chat_template_kwargs | Rendered |
| --- | --- | --- |
| None | `{enable_thinking: false}` | no reasoning, no preamble |
| High | `{enable_thinking: true, reasoning_effort: "high"}` | reasoning on, no preamble |
| Max | `{enable_thinking: true, reasoning_effort: "max"}` | reasoning on plus the maximum effort preamble |

This reuses the existing `enable_thinking_effort` reasoning style end to end (`detect_reasoning_flags` -> `reasoning_effort_levels` -> `_request_reasoning_kwargs`), so no frontend changes are needed.

## Testing

`pytest studio/backend/tests/test_safetensors_capability_advertise.py` passes 19/19, including the two new tests.
