### PR TITLE
feat: detect installed coding agent CLIs in Studio settings

### DIFF
--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -32,6 +32,7 @@ from utils.helper_precache_settings import (
     helper_model_disabled_by_env,
     set_helper_precache_enabled,
 )
+from utils.coding_agents import CODING_AGENTS, detect_installed_coding_agents
 from utils.openai_auto_switch_settings import (
     DEFAULT_AUTO_UNLOAD_IDLE_SECONDS,
     DEFAULT_OPENAI_AUTO_SWITCH_ENABLED,
@@ -172,6 +173,21 @@ def update_helper_precache(
             log = logger,
         ) from exc
     return _helper_precache_response(enabled)
+
+
+class CodingAgentsResponse(BaseModel):
+    # All agents `unsloth start` supports, in the CLI's declared order.
+    agents: list[str] = list(CODING_AGENTS)
+    # Subset of `agents` whose CLI binary was found on PATH; the frontend uses
+    # this to default the API-keys panel to a command the user can run as-is.
+    detected: list[str]
+
+
+@router.get("/coding-agents", response_model = CodingAgentsResponse)
+def get_coding_agents(
+    current_subject: str = Depends(get_current_subject),
+) -> CodingAgentsResponse:
+    return CodingAgentsResponse(detected = detect_installed_coding_agents())
 
 
 @router.get("/openai-auto-switch", response_model = OpenAIAutoSwitchResponse)

--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -184,9 +184,7 @@ class CodingAgentsResponse(BaseModel):
 
 
 @router.get("/coding-agents", response_model = CodingAgentsResponse)
-def get_coding_agents(
-    current_subject: str = Depends(get_current_subject),
-) -> CodingAgentsResponse:
+def get_coding_agents(current_subject: str = Depends(get_current_subject)) -> CodingAgentsResponse:
     return CodingAgentsResponse(detected = detect_installed_coding_agents())
 
 

--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -177,7 +177,7 @@ def update_helper_precache(
 
 class CodingAgentsResponse(BaseModel):
     # All agents `unsloth start` supports, in the CLI's declared order.
-    agents: list[str] = list(CODING_AGENTS)
+    agents: tuple[str, ...] = CODING_AGENTS
     # Subset of `agents` whose CLI binary was found on PATH; the frontend uses
     # this to default the API-keys panel to a command the user can run as-is.
     detected: list[str]

--- a/studio/backend/tests/test_coding_agents.py
+++ b/studio/backend/tests/test_coding_agents.py
@@ -35,3 +35,16 @@ def test_preserves_declared_order_regardless_of_path_lookup_order():
         side_effect = lambda name: name if name in ("pi", "claude", "hermes") else None,
     ):
         assert detect_installed_coding_agents() == ["claude", "hermes", "pi"]
+
+
+def test_treats_a_path_lookup_error_as_not_installed():
+    # An advisory check: shutil.which raising for one entry (e.g. a permission
+    # error walking a PATH directory) should not take down the whole endpoint,
+    # and should not stop the remaining agents from being checked.
+    def flaky_which(name: str):
+        if name == "codex":
+            raise OSError("permission denied")
+        return name if name == "claude" else None
+
+    with patch("utils.coding_agents.shutil.which", side_effect = flaky_which):
+        assert detect_installed_coding_agents() == ["claude"]

--- a/studio/backend/tests/test_coding_agents.py
+++ b/studio/backend/tests/test_coding_agents.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Tests for coding-agent CLI detection used by the API-keys settings panel."""
+
+from unittest.mock import patch
+
+from utils.coding_agents import CODING_AGENTS, detect_installed_coding_agents
+
+
+def test_matches_unsloth_start_subcommands():
+    # Each entry must be an actual `unsloth start <agent>` subcommand name
+    # (unsloth_cli/commands/start.py). Spelled out here rather than imported
+    # from that module, which pulls in the CLI's heavier dependencies.
+    assert CODING_AGENTS == ("claude", "codex", "openclaw", "opencode", "hermes", "pi")
+
+
+def test_detects_only_agents_present_on_path():
+    installed = {"claude", "opencode"}
+    with patch(
+        "utils.coding_agents.shutil.which",
+        side_effect = lambda name: f"/usr/bin/{name}" if name in installed else None,
+    ):
+        assert detect_installed_coding_agents() == ["claude", "opencode"]
+
+
+def test_returns_empty_list_when_nothing_is_installed():
+    with patch("utils.coding_agents.shutil.which", return_value = None):
+        assert detect_installed_coding_agents() == []
+
+
+def test_preserves_declared_order_regardless_of_path_lookup_order():
+    with patch(
+        "utils.coding_agents.shutil.which",
+        side_effect = lambda name: name if name in ("pi", "claude", "hermes") else None,
+    ):
+        assert detect_installed_coding_agents() == ["claude", "hermes", "pi"]

--- a/studio/backend/utils/coding_agents.py
+++ b/studio/backend/utils/coding_agents.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Detect which `unsloth start <agent>` coding-agent CLIs are on PATH.
+
+The web UI only ever shows the user the "claude" flavor of the `unsloth start`
+command (see agent-command.ts), leaving anyone using Codex, OpenCode, and the
+other supported agents to manually edit the copied command. This module gives
+the frontend a way to ask which of those CLIs are actually installed so it can
+default to one the user can run immediately.
+"""
+
+import shutil
+
+# Keep in sync with the `unsloth start <agent>` subcommands defined in
+# unsloth_cli/commands/start.py. Each entry is the exact executable name that
+# subcommand launches, so a hit here means `unsloth start <agent>` can find the
+# binary on PATH without the user installing anything first.
+CODING_AGENTS: tuple[str, ...] = ("claude", "codex", "openclaw", "opencode", "hermes", "pi")
+
+
+def detect_installed_coding_agents() -> list[str]:
+    """Return the subset of CODING_AGENTS whose CLI binary is on PATH.
+
+    Order follows CODING_AGENTS, not discovery order, so callers can treat the
+    first entry as the preferred default among the installed agents.
+    """
+    return [agent for agent in CODING_AGENTS if shutil.which(agent)]

--- a/studio/backend/utils/coding_agents.py
+++ b/studio/backend/utils/coding_agents.py
@@ -19,10 +19,21 @@ import shutil
 CODING_AGENTS: tuple[str, ...] = ("claude", "codex", "openclaw", "opencode", "hermes", "pi")
 
 
+def _is_on_path(agent: str) -> bool:
+    # shutil.which is documented to return None on a miss, but PATH lookups can
+    # still raise (e.g. a permission error while probing a directory entry);
+    # this is an advisory check, so a lookup failure should read as "not
+    # installed" instead of breaking the settings endpoint.
+    try:
+        return shutil.which(agent) is not None
+    except OSError:
+        return False
+
+
 def detect_installed_coding_agents() -> list[str]:
     """Return the subset of CODING_AGENTS whose CLI binary is on PATH.
 
     Order follows CODING_AGENTS, not discovery order, so callers can treat the
     first entry as the preferred default among the installed agents.
     """
-    return [agent for agent in CODING_AGENTS if shutil.which(agent)]
+    return [agent for agent in CODING_AGENTS if _is_on_path(agent)]

--- a/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
+++ b/studio/frontend/src/features/chat/lib/apply-inference-status-to-store.ts
@@ -3,16 +3,19 @@
 
 import { getInferenceStatus } from "../api/chat-api";
 import { mergeBackendRecommendedInference } from "../presets/preset-policy";
+import { clampReasoningEffortToLevels } from "../provider-capabilities";
 import {
   CHAT_REASONING_ENABLED_KEY,
-  loadOptionalBool,
   type ReasoningEffort,
   type ReasoningStyle,
+  loadOptionalBool,
   resolveToolsEnabledOnLoad,
   useChatRuntimeStore,
 } from "../stores/chat-runtime-store";
-import { isMultimodalResponse, type InferenceStatusResponse } from "../types/api";
-import { clampReasoningEffortToLevels } from "../provider-capabilities";
+import {
+  type InferenceStatusResponse,
+  isMultimodalResponse,
+} from "../types/api";
 import type { ChatModelSummary } from "../types/runtime";
 
 type LocalReasoningEffort = Extract<ReasoningEffort, "low" | "medium" | "high">;
@@ -31,7 +34,10 @@ export function normalizeSpeculativeType(
     return "ngram";
   }
   if (s === "mtp+ngram") return "mtp+ngram";
-  const parts = s.split(",").map((p) => p.trim()).filter(Boolean);
+  const parts = s
+    .split(",")
+    .map((p) => p.trim())
+    .filter(Boolean);
   const hasMtp = parts.some((p) => p === "mtp" || p === "draft-mtp");
   const hasNgram = parts.some(
     (p) => p === "ngram" || p === "ngram-mod" || p === "ngram-simple",
@@ -197,6 +203,12 @@ export function applyActiveModelStatusToStore(
     ggufContextLength: currentGgufContextLength,
     ggufMaxContextLength,
     ggufNativeContextLength,
+    // A non-GGUF status must also drop a stale native-path token: without this the
+    // isGguf OR (activeGgufVariant || activeNativePathToken || ggufContextLength)
+    // stays true after switching from a native GGUF to a transformers model, so a
+    // Codex-only detection would auto-select for a model its preflight rejects. A real
+    // GGUF load reports is_gguf: true, so its token is preserved (the load path owns it).
+    ...(status.is_gguf ? {} : { activeNativePathToken: null }),
     modelRequiresTrustRemoteCode: status.requires_trust_remote_code ?? false,
     defaultChatTemplate: nextDefaultChatTemplate,
     loadedIsMultimodal: isMultimodalResponse(status),
@@ -245,7 +257,7 @@ export function applyActiveModelStatusToStore(
     const mid = checkpointId.toLowerCase();
     if (mid.includes("qwen3.5") || mid.includes("qwen3.6")) {
       const sizeMatch = mid.match(/(\d+\.?\d*)\s*b/);
-      if (sizeMatch && parseFloat(sizeMatch[1]) < 9) {
+      if (sizeMatch && Number.parseFloat(sizeMatch[1]) < 9) {
         reasoningDefault = false;
       }
     }
@@ -281,8 +293,7 @@ export async function tryAdoptServerActiveModel(): Promise<boolean> {
   }
 
   // Re-check after the await: keep a checkpoint the user picked meanwhile.
-  const previousCheckpoint =
-    useChatRuntimeStore.getState().params.checkpoint;
+  const previousCheckpoint = useChatRuntimeStore.getState().params.checkpoint;
   if (previousCheckpoint) {
     return true;
   }

--- a/studio/frontend/src/features/settings/api/coding-agents.ts
+++ b/studio/frontend/src/features/settings/api/coding-agents.ts
@@ -16,7 +16,11 @@ type ApiCodingAgentsInfo = {
   detected: string[];
 };
 
-let cachedInfo: CodingAgentsInfo | null = null;
+// Which CLIs are on PATH is environment state, not a persisted setting -- it
+// can change any time the user installs something new, so this only
+// de-duplicates concurrent in-flight calls (e.g. React strict-mode's double
+// mount) rather than caching the result across the module's lifetime. Every
+// fresh call (each time a settings panel mounts) re-checks PATH for real.
 let inFlightInfo: Promise<CodingAgentsInfo> | null = null;
 
 function fromApi(info: ApiCodingAgentsInfo): CodingAgentsInfo {
@@ -34,16 +38,8 @@ async function fetchCodingAgents(): Promise<CodingAgentsInfo> {
 }
 
 export async function loadCodingAgents(): Promise<CodingAgentsInfo> {
-  if (cachedInfo) {
-    return cachedInfo;
-  }
-  inFlightInfo ??= fetchCodingAgents()
-    .then((info) => {
-      cachedInfo = info;
-      return info;
-    })
-    .finally(() => {
-      inFlightInfo = null;
-    });
+  inFlightInfo ??= fetchCodingAgents().finally(() => {
+    inFlightInfo = null;
+  });
   return inFlightInfo;
 }

--- a/studio/frontend/src/features/settings/api/coding-agents.ts
+++ b/studio/frontend/src/features/settings/api/coding-agents.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { authFetch } from "@/features/auth";
+import { readFastApiError } from "@/lib/format-fastapi-error";
+
+export type CodingAgentsInfo = {
+  // Every agent `unsloth start` supports, in the CLI's declared order.
+  agents: string[];
+  // Subset of `agents` whose CLI binary was found on PATH by the backend.
+  detected: string[];
+};
+
+type ApiCodingAgentsInfo = {
+  agents: string[];
+  detected: string[];
+};
+
+let cachedInfo: CodingAgentsInfo | null = null;
+let inFlightInfo: Promise<CodingAgentsInfo> | null = null;
+
+function fromApi(info: ApiCodingAgentsInfo): CodingAgentsInfo {
+  return { agents: info.agents, detected: info.detected };
+}
+
+async function fetchCodingAgents(): Promise<CodingAgentsInfo> {
+  const res = await authFetch("/api/settings/coding-agents");
+  if (!res.ok) {
+    throw new Error(
+      await readFastApiError(res, "Failed to load installed coding agents"),
+    );
+  }
+  return fromApi(await res.json());
+}
+
+export async function loadCodingAgents(): Promise<CodingAgentsInfo> {
+  if (cachedInfo) {
+    return cachedInfo;
+  }
+  inFlightInfo ??= fetchCodingAgents()
+    .then((info) => {
+      cachedInfo = info;
+      return info;
+    })
+    .finally(() => {
+      inFlightInfo = null;
+    });
+  return inFlightInfo;
+}

--- a/studio/frontend/src/features/settings/components/agent-command.ts
+++ b/studio/frontend/src/features/settings/components/agent-command.ts
@@ -12,7 +12,7 @@ const DEFAULT_AGENT = "claude";
 
 // URL.hostname brackets IPv6 literals (`new URL("http://[::1]:8888").hostname` is
 // "[::1]"), so strip the brackets before matching the bare "::1" loopback rules below.
-function normalizeHost(host: string): string {
+export function normalizeHost(host: string): string {
   const lower = host.toLowerCase();
   return lower.startsWith("[") && lower.endsWith("]") ? lower.slice(1, -1) : lower;
 }
@@ -26,7 +26,7 @@ function isDefaultLocalHost(host: string): boolean {
 }
 
 // Match the CLI auto-mint rule (is_loopback_url): localhost, ::1, and all of 127.0.0.0/8.
-function isLoopbackHost(host: string): boolean {
+export function isLoopbackHost(host: string): boolean {
   if (host === "localhost" || host === "::1") return true;
   const octets = host.split(".");
   return (

--- a/studio/frontend/src/features/settings/components/usage-examples.tsx
+++ b/studio/frontend/src/features/settings/components/usage-examples.tsx
@@ -501,19 +501,24 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
   }, []);
 
   useEffect(() => {
+    // shutil.which runs on the Studio backend, so "detected" only means
+    // something for the browser's own machine when the base this panel
+    // targets is loopback; for a LAN/tunnel/remote base the server's
+    // installed CLIs describe a different machine. Skip the request
+    // entirely and clear out any stale result from a previous loopback
+    // base (e.g. the Cloudflare URL arriving after mount, or the user
+    // flipping Secure HTTPS/tunnel) instead of leaving old agents marked
+    // "detected" for a command that now targets somewhere else.
+    if (!isLoopbackBase) {
+      setDetectedAgents([]);
+      return;
+    }
+
     let cancelled = false;
     void loadCodingAgents()
       .then((info) => {
         if (cancelled) return;
         setAvailableAgents(info.agents);
-
-        // shutil.which runs on the Studio backend, so "detected" only means
-        // something for the browser's own machine when the base this panel
-        // targets is loopback; for a LAN/tunnel/remote base the server's
-        // installed CLIs describe a different machine, so don't mark
-        // anything as detected or let it drive the default.
-        if (!isLoopbackBase) return;
-
         setDetectedAgents(info.detected);
         // Prefer an agent that's actually installed over the hardcoded
         // "claude" starting point, but never override a choice the user
@@ -537,6 +542,20 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
       cancelled = true;
     };
   }, [isLoopbackBase]);
+
+  // The effect above only re-evaluates codex's GGUF requirement at the
+  // moment detection resolves; if the user swaps to a non-GGUF model while
+  // this panel stays mounted, steer the auto-pick away from codex instead of
+  // leaving a command that unsloth_cli's _require_gguf_for_codex will now
+  // reject. No network call here -- it only re-derives from state already in
+  // hand, and it never overrides a choice the user made by hand.
+  const activeGgufVariant = useChatRuntimeStore((s) => s.activeGgufVariant);
+  useEffect(() => {
+    if (agentPickedByUserRef.current) return;
+    if (agent !== "codex" || activeGgufVariant) return;
+    const fallback = detectedAgents.find((id) => id !== "codex");
+    if (fallback) setAgent(fallback);
+  }, [agent, activeGgufVariant, detectedAgents]);
 
   useEffect(() => {
     let cancelled = false;

--- a/studio/frontend/src/features/settings/components/usage-examples.tsx
+++ b/studio/frontend/src/features/settings/components/usage-examples.tsx
@@ -33,7 +33,7 @@ import {
   loadOpenAIAutoSwitchSettings,
   updateOpenAIAutoSwitchSettings,
 } from "../api/openai-auto-switch";
-import { buildAgentCommand } from "./agent-command";
+import { buildAgentCommand, isLoopbackHost, normalizeHost } from "./agent-command";
 
 type ExampleType =
   | "curl"
@@ -420,17 +420,18 @@ function useLoadedModelName(): string {
   }, [checkpoint, ggufVariant]);
 }
 
-// `codex` only runs against a GGUF model served by llama-server (see
-// unsloth_cli's `_require_gguf_for_codex`); anything else makes the copied
-// `unsloth start codex` command fail immediately. This tells the agent
-// picker below whether the currently loaded model actually qualifies.
-function useActiveModelIsGguf(): boolean {
-  const checkpoint = useChatRuntimeStore((s) => s.params.checkpoint);
-  const models = useChatRuntimeStore((s) => s.models);
-  return useMemo(
-    () => models.find((m) => m.id === checkpoint)?.isGguf ?? false,
-    [models, checkpoint],
-  );
+// Best-effort loopback check on the base the panel is currently pointing at.
+// Detection (`/api/settings/coding-agents`) runs `shutil.which` on the Studio
+// backend, which only describes the browser's own machine when that base
+// resolves to loopback; for a LAN or tunnel/remote base it describes a
+// different machine entirely, so it must not drive what gets marked
+// "detected" or picked as the default agent.
+function resolveIsLoopbackBase(base: string): boolean {
+  try {
+    return isLoopbackHost(normalizeHost(new URL(base).hostname));
+  } catch {
+    return false;
+  }
 }
 
 const SHIKI_THEMES = [unslothLightTheme, unslothDarkTheme] as [
@@ -484,8 +485,11 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
   // True once the user has picked an agent themselves; guards the detection
   // effect below from clobbering that choice if it resolves afterward.
   const agentPickedByUserRef = useRef(false);
-  const activeModelIsGguf = useActiveModelIsGguf();
   const [useTunnel, setUseTunnel] = useState<boolean>(readUseTunnelPref);
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  const base =
+    useTunnel && cloudflareUrl ? cloudflareUrl : (serverUrl ?? origin);
+  const isLoopbackBase = resolveIsLoopbackBase(base);
   // null while loading; the same setting the General tab exposes (shared cache).
   const [autoSwitch, setAutoSwitch] = useState<OpenAIAutoSwitchSettings | null>(
     null,
@@ -502,13 +506,28 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
       .then((info) => {
         if (cancelled) return;
         setAvailableAgents(info.agents);
+
+        // shutil.which runs on the Studio backend, so "detected" only means
+        // something for the browser's own machine when the base this panel
+        // targets is loopback; for a LAN/tunnel/remote base the server's
+        // installed CLIs describe a different machine, so don't mark
+        // anything as detected or let it drive the default.
+        if (!isLoopbackBase) return;
+
         setDetectedAgents(info.detected);
         // Prefer an agent that's actually installed over the hardcoded
         // "claude" starting point, but never override a choice the user
         // already made -- including one made while this request was in
         // flight, which a value comparison against "claude" alone would miss.
+        // `codex` additionally refuses to launch against a non-GGUF model
+        // (unsloth_cli's _require_gguf_for_codex exits for transformers-backed
+        // models), so skip it unless the loaded model actually qualifies.
         if (!agentPickedByUserRef.current && info.detected.length > 0) {
-          setAgent(info.detected[0]);
+          const isGguf = Boolean(
+            useChatRuntimeStore.getState().activeGgufVariant,
+          );
+          const preferred = info.detected.find((a) => a !== "codex" || isGguf);
+          if (preferred) setAgent(preferred);
         }
       })
       .catch(() => {
@@ -517,19 +536,7 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
     return () => {
       cancelled = true;
     };
-  }, []);
-
-  // Steers away from an auto-picked "codex" once we know the loaded model
-  // isn't GGUF (codex would otherwise be handed to the user as a ready-to-run
-  // command that's guaranteed to fail against a transformers-backed model).
-  // Runs on its own so it also re-corrects if the model changes after the
-  // initial detection resolved; never touches a choice the user made by hand.
-  useEffect(() => {
-    if (agentPickedByUserRef.current) return;
-    if (agent !== "codex" || activeModelIsGguf) return;
-    const fallback = detectedAgents.find((id) => id !== "codex");
-    if (fallback) setAgent(fallback);
-  }, [agent, activeModelIsGguf, detectedAgents]);
+  }, [isLoopbackBase]);
 
   useEffect(() => {
     let cancelled = false;
@@ -547,9 +554,6 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
 
   const model = useLoadedModelName();
   const key = apiKey || KEY_PLACEHOLDER;
-  const origin = typeof window !== "undefined" ? window.location.origin : "";
-  const base =
-    useTunnel && cloudflareUrl ? cloudflareUrl : (serverUrl ?? origin);
 
   const autoSwitchOn = autoSwitch?.enabled ?? false;
   const snippets = useMemo(
@@ -802,11 +806,7 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
                   aria-pressed={active}
                   title={
                     installed
-                      ? t(
-                          useTunnel
-                            ? "settings.apiKeys.codingAgentDetectedRemote"
-                            : "settings.apiKeys.codingAgentDetected",
-                        )
+                      ? t("settings.apiKeys.codingAgentDetected")
                       : undefined
                   }
                   className={cn(
@@ -845,16 +845,11 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
           </div>
           <span className="text-[11px] leading-snug text-muted-foreground">
             {detectedAgents.length > 0
-              ? t(
-                  useTunnel
-                    ? "settings.apiKeys.codingAgentsDetectedHintRemote"
-                    : "settings.apiKeys.codingAgentsDetectedHint",
-                  {
-                    agents: detectedAgents
-                      .map((id) => AGENT_LABELS[id] ?? id)
-                      .join(", "),
-                  },
-                )
+              ? t("settings.apiKeys.codingAgentsDetectedHint", {
+                  agents: detectedAgents
+                    .map((id) => AGENT_LABELS[id] ?? id)
+                    .join(", "),
+                })
               : t("settings.apiKeys.codingAgentsSwap")}
           </span>
         </div>

--- a/studio/frontend/src/features/settings/components/usage-examples.tsx
+++ b/studio/frontend/src/features/settings/components/usage-examples.tsx
@@ -420,6 +420,19 @@ function useLoadedModelName(): string {
   }, [checkpoint, ggufVariant]);
 }
 
+// `codex` only runs against a GGUF model served by llama-server (see
+// unsloth_cli's `_require_gguf_for_codex`); anything else makes the copied
+// `unsloth start codex` command fail immediately. This tells the agent
+// picker below whether the currently loaded model actually qualifies.
+function useActiveModelIsGguf(): boolean {
+  const checkpoint = useChatRuntimeStore((s) => s.params.checkpoint);
+  const models = useChatRuntimeStore((s) => s.models);
+  return useMemo(
+    () => models.find((m) => m.id === checkpoint)?.isGguf ?? false,
+    [models, checkpoint],
+  );
+}
+
 const SHIKI_THEMES = [unslothLightTheme, unslothDarkTheme] as [
   typeof unslothLightTheme,
   typeof unslothDarkTheme,
@@ -471,6 +484,7 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
   // True once the user has picked an agent themselves; guards the detection
   // effect below from clobbering that choice if it resolves afterward.
   const agentPickedByUserRef = useRef(false);
+  const activeModelIsGguf = useActiveModelIsGguf();
   const [useTunnel, setUseTunnel] = useState<boolean>(readUseTunnelPref);
   // null while loading; the same setting the General tab exposes (shared cache).
   const [autoSwitch, setAutoSwitch] = useState<OpenAIAutoSwitchSettings | null>(
@@ -504,6 +518,18 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
       cancelled = true;
     };
   }, []);
+
+  // Steers away from an auto-picked "codex" once we know the loaded model
+  // isn't GGUF (codex would otherwise be handed to the user as a ready-to-run
+  // command that's guaranteed to fail against a transformers-backed model).
+  // Runs on its own so it also re-corrects if the model changes after the
+  // initial detection resolved; never touches a choice the user made by hand.
+  useEffect(() => {
+    if (agentPickedByUserRef.current) return;
+    if (agent !== "codex" || activeModelIsGguf) return;
+    const fallback = detectedAgents.find((id) => id !== "codex");
+    if (fallback) setAgent(fallback);
+  }, [agent, activeModelIsGguf, detectedAgents]);
 
   useEffect(() => {
     let cancelled = false;
@@ -776,7 +802,11 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
                   aria-pressed={active}
                   title={
                     installed
-                      ? t("settings.apiKeys.codingAgentDetected")
+                      ? t(
+                          useTunnel
+                            ? "settings.apiKeys.codingAgentDetectedRemote"
+                            : "settings.apiKeys.codingAgentDetected",
+                        )
                       : undefined
                   }
                   className={cn(
@@ -815,11 +845,16 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
           </div>
           <span className="text-[11px] leading-snug text-muted-foreground">
             {detectedAgents.length > 0
-              ? t("settings.apiKeys.codingAgentsDetectedHint", {
-                  agents: detectedAgents
-                    .map((id) => AGENT_LABELS[id] ?? id)
-                    .join(", "),
-                })
+              ? t(
+                  useTunnel
+                    ? "settings.apiKeys.codingAgentsDetectedHintRemote"
+                    : "settings.apiKeys.codingAgentsDetectedHint",
+                  {
+                    agents: detectedAgents
+                      .map((id) => AGENT_LABELS[id] ?? id)
+                      .join(", "),
+                  },
+                )
               : t("settings.apiKeys.codingAgentsSwap")}
           </span>
         </div>

--- a/studio/frontend/src/features/settings/components/usage-examples.tsx
+++ b/studio/frontend/src/features/settings/components/usage-examples.tsx
@@ -16,6 +16,7 @@ import { fetchDeviceType, usePlatformStore } from "@/config/env";
 import { useChatRuntimeStore } from "@/features/chat";
 import { useT } from "@/i18n";
 import type { TranslationKey } from "@/i18n";
+import { isTauri } from "@/lib/api-base";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
 import { Tick02Icon } from "@/lib/tick-icon";
 import { cn } from "@/lib/utils";
@@ -424,13 +425,10 @@ function useLoadedModelName(): string {
   }, [checkpoint, ggufVariant]);
 }
 
-// Best-effort loopback check on the base the panel is currently pointing at.
-// Detection (`/api/settings/coding-agents`) runs `shutil.which` on the Studio
-// backend, which only describes the browser's own machine when that base
-// resolves to loopback; for a LAN or tunnel/remote base it describes a
-// different machine entirely, so it must not drive what gets marked
-// "detected" or picked as the default agent.
-function resolveIsLoopbackBase(base: string): boolean {
+// Backend PATH detection is only safe in the desktop app, where the UI owns
+// the local backend. A browser loopback URL may be an SSH/local port forward.
+function canUseLocalAgentDetection(base: string): boolean {
+  if (!isTauri) return false;
   try {
     return isLoopbackHost(normalizeHost(new URL(base).hostname));
   } catch {
@@ -493,7 +491,7 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
   const origin = typeof window !== "undefined" ? window.location.origin : "";
   const base =
     useTunnel && cloudflareUrl ? cloudflareUrl : (serverUrl ?? origin);
-  const isLoopbackBase = resolveIsLoopbackBase(base);
+  const localAgentDetection = canUseLocalAgentDetection(base);
   // null while loading; the same setting the General tab exposes (shared cache).
   const [autoSwitch, setAutoSwitch] = useState<OpenAIAutoSwitchSettings | null>(
     null,
@@ -509,15 +507,9 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
   // list is derived separately below, so it can react to the loaded model
   // changing too, not just a fresh fetch.
   useEffect(() => {
-    // shutil.which runs on the Studio backend, so "detected" only means
-    // something for the browser's own machine when the base this panel
-    // targets is loopback; for a LAN/tunnel/remote base the server's
-    // installed CLIs describe a different machine. Skip the request
-    // entirely and clear out any stale result from a previous loopback
-    // base (e.g. the Cloudflare URL arriving after mount, or the user
-    // flipping Secure HTTPS/tunnel) instead of leaving old agents marked
-    // "detected" for a command that now targets somewhere else.
-    if (!isLoopbackBase) {
+    // Browser loopback URLs can be SSH/local forwards, so only the desktop app
+    // may use backend PATH checks to mark or auto-pick local agents.
+    if (!localAgentDetection) {
       setDetectedAgents([]);
       // A previously auto-picked agent was only ever verified against the
       // Studio backend's PATH, which is meaningless now that this panel no
@@ -542,7 +534,7 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
     return () => {
       cancelled = true;
     };
-  }, [isLoopbackBase]);
+  }, [localAgentDetection]);
 
   // Single source of truth for the auto-picked agent, re-derived whenever
   // the detected list or the loaded model's GGUF-ness changes -- in either

--- a/studio/frontend/src/features/settings/components/usage-examples.tsx
+++ b/studio/frontend/src/features/settings/components/usage-examples.tsx
@@ -27,6 +27,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useEffect, useMemo, useState } from "react";
 import { Streamdown } from "streamdown";
+import { loadCodingAgents } from "../api/coding-agents";
 import {
   type OpenAIAutoSwitchSettings,
   loadOpenAIAutoSwitchSettings,
@@ -113,6 +114,26 @@ const DOC_LINKS = [
   { label: "OpenCode", href: "https://unsloth.ai/docs/integrations/opencode" },
   { label: "Hermes Agent", href: "https://unsloth.ai/docs/integrations/hermes-agent" },
 ];
+
+// Falls back to this list until the backend's installed-CLI check resolves;
+// kept in sync with the `unsloth start <agent>` subcommands and with
+// CODING_AGENTS in studio/backend/utils/coding_agents.py.
+const DEFAULT_AGENTS = [
+  "claude",
+  "codex",
+  "openclaw",
+  "opencode",
+  "hermes",
+  "pi",
+];
+const AGENT_LABELS: Record<string, string> = {
+  claude: "Claude Code",
+  codex: "Codex",
+  openclaw: "OpenClaw",
+  opencode: "OpenCode",
+  hermes: "Hermes",
+  pi: "Pi",
+};
 
 const j = (s: string): string => JSON.stringify(s);
 const shSingle = (s: string): string => s.replace(/'/g, "'\\''");
@@ -443,6 +464,10 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
   const [copied, setCopied] = useState(false);
   const [copiedUrl, setCopiedUrl] = useState(false);
   const [copiedAgent, setCopiedAgent] = useState(false);
+  const [agent, setAgent] = useState<string>("claude");
+  const [availableAgents, setAvailableAgents] =
+    useState<string[]>(DEFAULT_AGENTS);
+  const [detectedAgents, setDetectedAgents] = useState<string[]>([]);
   const [useTunnel, setUseTunnel] = useState<boolean>(readUseTunnelPref);
   // null while loading; the same setting the General tab exposes (shared cache).
   const [autoSwitch, setAutoSwitch] = useState<OpenAIAutoSwitchSettings | null>(
@@ -452,6 +477,30 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
 
   useEffect(() => {
     void fetchDeviceType({ force: true });
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadCodingAgents()
+      .then((info) => {
+        if (cancelled) return;
+        setAvailableAgents(info.agents);
+        setDetectedAgents(info.detected);
+        // Only steer the default once: prefer an agent that's actually
+        // installed over the hardcoded "claude" starting point, but never
+        // override a choice the user has already made in this session.
+        setAgent((current) =>
+          info.detected.length > 0 && !info.detected.includes(current)
+            ? info.detected[0]
+            : current,
+        );
+      })
+      .catch(() => {
+        // Best-effort: keep the default agent list and let the user pick manually.
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
@@ -481,8 +530,8 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
   );
   // Agent command must target the server the panel shows, not the :8888 default.
   const agentCommand = useMemo(
-    () => buildAgentCommand(base, key, os),
-    [base, key, os],
+    () => buildAgentCommand(base, key, os, agent),
+    [base, key, os, agent],
   );
 
   const osAware = OS_AWARE[lang];
@@ -710,6 +759,39 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
           <span className="text-[11px] leading-snug text-muted-foreground">
             {t("settings.apiKeys.codingAgentsHint")}
           </span>
+          <div className="flex min-w-0 flex-wrap items-center gap-1">
+            {availableAgents.map((id) => {
+              const installed = detectedAgents.includes(id);
+              const active = agent === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setAgent(id)}
+                  aria-pressed={active}
+                  title={
+                    installed
+                      ? t("settings.apiKeys.codingAgentDetected")
+                      : undefined
+                  }
+                  className={cn(
+                    "flex items-center gap-1 rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                    active
+                      ? "hub-tab-toggle-pill text-foreground"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  {AGENT_LABELS[id] ?? id}
+                  {installed ? (
+                    <span
+                      aria-hidden="true"
+                      className="size-1.5 rounded-full bg-emerald-500"
+                    />
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
           <div className="relative mt-0.5 min-w-0">
             <code className="block min-w-0 overflow-x-auto rounded border border-border bg-muted/30 px-2 py-1.5 pr-14 font-mono text-[11px] text-foreground">
               {agentCommand}
@@ -727,7 +809,13 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
             </button>
           </div>
           <span className="text-[11px] leading-snug text-muted-foreground">
-            {t("settings.apiKeys.codingAgentsSwap")}
+            {detectedAgents.length > 0
+              ? t("settings.apiKeys.codingAgentsDetectedHint", {
+                  agents: detectedAgents
+                    .map((id) => AGENT_LABELS[id] ?? id)
+                    .join(", "),
+                })
+              : t("settings.apiKeys.codingAgentsSwap")}
           </span>
         </div>
         <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-t border-border px-3 py-2 text-[11px] text-muted-foreground">

--- a/studio/frontend/src/features/settings/components/usage-examples.tsx
+++ b/studio/frontend/src/features/settings/components/usage-examples.tsx
@@ -25,7 +25,7 @@ import {
   InformationCircleIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Streamdown } from "streamdown";
 import { loadCodingAgents } from "../api/coding-agents";
 import {
@@ -468,6 +468,9 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
   const [availableAgents, setAvailableAgents] =
     useState<string[]>(DEFAULT_AGENTS);
   const [detectedAgents, setDetectedAgents] = useState<string[]>([]);
+  // True once the user has picked an agent themselves; guards the detection
+  // effect below from clobbering that choice if it resolves afterward.
+  const agentPickedByUserRef = useRef(false);
   const [useTunnel, setUseTunnel] = useState<boolean>(readUseTunnelPref);
   // null while loading; the same setting the General tab exposes (shared cache).
   const [autoSwitch, setAutoSwitch] = useState<OpenAIAutoSwitchSettings | null>(
@@ -486,14 +489,13 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
         if (cancelled) return;
         setAvailableAgents(info.agents);
         setDetectedAgents(info.detected);
-        // Only steer the default once: prefer an agent that's actually
-        // installed over the hardcoded "claude" starting point, but never
-        // override a choice the user has already made in this session.
-        setAgent((current) =>
-          info.detected.length > 0 && !info.detected.includes(current)
-            ? info.detected[0]
-            : current,
-        );
+        // Prefer an agent that's actually installed over the hardcoded
+        // "claude" starting point, but never override a choice the user
+        // already made -- including one made while this request was in
+        // flight, which a value comparison against "claude" alone would miss.
+        if (!agentPickedByUserRef.current && info.detected.length > 0) {
+          setAgent(info.detected[0]);
+        }
       })
       .catch(() => {
         // Best-effort: keep the default agent list and let the user pick manually.
@@ -767,7 +769,10 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
                 <button
                   key={id}
                   type="button"
-                  onClick={() => setAgent(id)}
+                  onClick={() => {
+                    agentPickedByUserRef.current = true;
+                    setAgent(id);
+                  }}
                   aria-pressed={active}
                   title={
                     installed

--- a/studio/frontend/src/features/settings/components/usage-examples.tsx
+++ b/studio/frontend/src/features/settings/components/usage-examples.tsx
@@ -126,6 +126,10 @@ const DEFAULT_AGENTS = [
   "hermes",
   "pi",
 ];
+// The agent selection resets to this whenever an auto-pick is no longer
+// trustworthy (leaving loopback, or the only compatible detected agent
+// stops being compatible) rather than lingering on a stale choice.
+const DEFAULT_AGENT = "claude";
 const AGENT_LABELS: Record<string, string> = {
   claude: "Claude Code",
   codex: "Codex",
@@ -478,7 +482,7 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
   const [copied, setCopied] = useState(false);
   const [copiedUrl, setCopiedUrl] = useState(false);
   const [copiedAgent, setCopiedAgent] = useState(false);
-  const [agent, setAgent] = useState<string>("claude");
+  const [agent, setAgent] = useState<string>(DEFAULT_AGENT);
   const [availableAgents, setAvailableAgents] =
     useState<string[]>(DEFAULT_AGENTS);
   const [detectedAgents, setDetectedAgents] = useState<string[]>([]);
@@ -515,6 +519,13 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
     // "detected" for a command that now targets somewhere else.
     if (!isLoopbackBase) {
       setDetectedAgents([]);
+      // A previously auto-picked agent was only ever verified against the
+      // Studio backend's PATH, which is meaningless now that this panel no
+      // longer targets a loopback base -- don't leave it selected, but
+      // never touch a choice the user made by hand.
+      if (!agentPickedByUserRef.current) {
+        setAgent(DEFAULT_AGENT);
+      }
       return;
     }
 
@@ -547,8 +558,16 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
     if (detectedAgents.length === 0) return;
     const isGguf = Boolean(activeGgufVariant);
     const preferred = detectedAgents.find((a) => a !== "codex" || isGguf);
-    if (preferred) setAgent(preferred);
-  }, [detectedAgents, activeGgufVariant]);
+    if (preferred) {
+      setAgent(preferred);
+    } else if (agent === "codex" && !isGguf) {
+      // codex was auto-picked while a GGUF model was active and it's the
+      // only detected agent; now that the model isn't GGUF anymore, nothing
+      // detected is actually runnable, so fall back to the default instead
+      // of leaving a codex command unsloth_cli will reject.
+      setAgent(DEFAULT_AGENT);
+    }
+  }, [agent, detectedAgents, activeGgufVariant]);
 
   useEffect(() => {
     let cancelled = false;

--- a/studio/frontend/src/features/settings/components/usage-examples.tsx
+++ b/studio/frontend/src/features/settings/components/usage-examples.tsx
@@ -552,11 +552,24 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
   // non-GGUF-gated fallback picked something else re-steers back to codex
   // just as loading a non-GGUF model steers away from it. Never overrides a
   // choice the user made by hand.
+  // activeGgufVariant alone only covers an HF-repo GGUF pick (a specific
+  // quant variant string) -- a direct local .gguf file (custom folder /
+  // LM Studio / drag-drop) is just as much a GGUF the codex preflight would
+  // accept, but never has a "variant" to report, and would otherwise read as
+  // non-GGUF here. activeNativePathToken covers the drag-drop/picked-file
+  // case; ggufContextLength is only ever populated when the backend's
+  // /api/inference/status last reported is_gguf: true for the active model
+  // (see applyActiveModelStatusToStore), so together these three cover every
+  // path a model can be GGUF through, matching the same is_gguf-or-equivalent
+  // check hasGgufSource applies to a staged pick.
   const activeGgufVariant = useChatRuntimeStore((s) => s.activeGgufVariant);
+  const activeNativePathToken = useChatRuntimeStore((s) => s.activeNativePathToken);
+  const ggufContextLength = useChatRuntimeStore((s) => s.ggufContextLength);
   useEffect(() => {
     if (agentPickedByUserRef.current) return;
     if (detectedAgents.length === 0) return;
-    const isGguf = Boolean(activeGgufVariant);
+    const isGguf =
+      activeGgufVariant != null || activeNativePathToken != null || ggufContextLength != null;
     const preferred = detectedAgents.find((a) => a !== "codex" || isGguf);
     if (preferred) {
       setAgent(preferred);
@@ -567,7 +580,7 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
       // of leaving a codex command unsloth_cli will reject.
       setAgent(DEFAULT_AGENT);
     }
-  }, [agent, detectedAgents, activeGgufVariant]);
+  }, [agent, detectedAgents, activeGgufVariant, activeNativePathToken, ggufContextLength]);
 
   useEffect(() => {
     let cancelled = false;

--- a/studio/frontend/src/features/settings/components/usage-examples.tsx
+++ b/studio/frontend/src/features/settings/components/usage-examples.tsx
@@ -500,6 +500,10 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
     void fetchDeviceType({ force: true });
   }, []);
 
+  // Fetching is the only job of this effect: populate availableAgents/
+  // detectedAgents (or clear them). Which agent gets auto-picked from that
+  // list is derived separately below, so it can react to the loaded model
+  // changing too, not just a fresh fetch.
   useEffect(() => {
     // shutil.which runs on the Studio backend, so "detected" only means
     // something for the browser's own machine when the base this panel
@@ -520,20 +524,6 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
         if (cancelled) return;
         setAvailableAgents(info.agents);
         setDetectedAgents(info.detected);
-        // Prefer an agent that's actually installed over the hardcoded
-        // "claude" starting point, but never override a choice the user
-        // already made -- including one made while this request was in
-        // flight, which a value comparison against "claude" alone would miss.
-        // `codex` additionally refuses to launch against a non-GGUF model
-        // (unsloth_cli's _require_gguf_for_codex exits for transformers-backed
-        // models), so skip it unless the loaded model actually qualifies.
-        if (!agentPickedByUserRef.current && info.detected.length > 0) {
-          const isGguf = Boolean(
-            useChatRuntimeStore.getState().activeGgufVariant,
-          );
-          const preferred = info.detected.find((a) => a !== "codex" || isGguf);
-          if (preferred) setAgent(preferred);
-        }
       })
       .catch(() => {
         // Best-effort: keep the default agent list and let the user pick manually.
@@ -543,19 +533,22 @@ export function UsageExamples({ apiKey }: { apiKey?: string | null }) {
     };
   }, [isLoopbackBase]);
 
-  // The effect above only re-evaluates codex's GGUF requirement at the
-  // moment detection resolves; if the user swaps to a non-GGUF model while
-  // this panel stays mounted, steer the auto-pick away from codex instead of
-  // leaving a command that unsloth_cli's _require_gguf_for_codex will now
-  // reject. No network call here -- it only re-derives from state already in
-  // hand, and it never overrides a choice the user made by hand.
+  // Single source of truth for the auto-picked agent, re-derived whenever
+  // the detected list or the loaded model's GGUF-ness changes -- in either
+  // direction. `codex` needs a GGUF model (unsloth_cli's
+  // _require_gguf_for_codex exits otherwise), so it's only preferred once
+  // the loaded model actually qualifies; loading a GGUF model *after* a
+  // non-GGUF-gated fallback picked something else re-steers back to codex
+  // just as loading a non-GGUF model steers away from it. Never overrides a
+  // choice the user made by hand.
   const activeGgufVariant = useChatRuntimeStore((s) => s.activeGgufVariant);
   useEffect(() => {
     if (agentPickedByUserRef.current) return;
-    if (agent !== "codex" || activeGgufVariant) return;
-    const fallback = detectedAgents.find((id) => id !== "codex");
-    if (fallback) setAgent(fallback);
-  }, [agent, activeGgufVariant, detectedAgents]);
+    if (detectedAgents.length === 0) return;
+    const isGguf = Boolean(activeGgufVariant);
+    const preferred = detectedAgents.find((a) => a !== "codex" || isGguf);
+    if (preferred) setAgent(preferred);
+  }, [detectedAgents, activeGgufVariant]);
 
   useEffect(() => {
     let cancelled = false;

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -445,12 +445,7 @@ export const en = {
         "Launch a coding agent against this server. It uses the loaded model; a local server mints an API key automatically, a remote one includes it in the command.",
       codingAgentsSwap: "Swap claude for codex, openclaw, opencode, hermes, or pi.",
       codingAgentDetected: "Installed on this machine",
-      // Shown instead of codingAgentDetected when the tunnel URL is in use:
-      // detection runs on the Studio server, not the device viewing this panel.
-      codingAgentDetectedRemote: "Installed on the Studio server",
       codingAgentsDetectedHint: "Detected on this machine: {agents}.",
-      codingAgentsDetectedHintRemote:
-        "Detected on the Studio server, which may not match this device when connecting via tunnel: {agents}.",
       relativeNever: "never",
       relativeJustNow: "just now",
       relativeHoursAgo: "{count}h ago",

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -444,6 +444,8 @@ export const en = {
       codingAgentsHint:
         "Launch a coding agent against this server. It uses the loaded model; a local server mints an API key automatically, a remote one includes it in the command.",
       codingAgentsSwap: "Swap claude for codex, openclaw, opencode, hermes, or pi.",
+      codingAgentDetected: "Installed on this machine",
+      codingAgentsDetectedHint: "Detected on this machine: {agents}.",
       relativeNever: "never",
       relativeJustNow: "just now",
       relativeHoursAgo: "{count}h ago",

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -445,7 +445,12 @@ export const en = {
         "Launch a coding agent against this server. It uses the loaded model; a local server mints an API key automatically, a remote one includes it in the command.",
       codingAgentsSwap: "Swap claude for codex, openclaw, opencode, hermes, or pi.",
       codingAgentDetected: "Installed on this machine",
+      // Shown instead of codingAgentDetected when the tunnel URL is in use:
+      // detection runs on the Studio server, not the device viewing this panel.
+      codingAgentDetectedRemote: "Installed on the Studio server",
       codingAgentsDetectedHint: "Detected on this machine: {agents}.",
+      codingAgentsDetectedHintRemote:
+        "Detected on the Studio server, which may not match this device when connecting via tunnel: {agents}.",
       relativeNever: "never",
       relativeJustNow: "just now",
       relativeHoursAgo: "{count}h ago",

--- a/tests/studio/test_chat_response_details_ui_contract.py
+++ b/tests/studio/test_chat_response_details_ui_contract.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
 """Static contract for the chat response-details action and metadata."""
 
 from __future__ import annotations

--- a/tests/studio/test_usage_examples_agent_detection_contract.py
+++ b/tests/studio/test_usage_examples_agent_detection_contract.py
@@ -10,12 +10,10 @@ USAGE_EXAMPLES_TSX = REPO / "studio/frontend/src/features/settings/components/us
 
 
 def test_agent_detection_requires_desktop_scope():
-    src = USAGE_EXAMPLES_TSX.read_text(encoding="utf-8")
+    src = USAGE_EXAMPLES_TSX.read_text(encoding = "utf-8")
     assert 'import { isTauri } from "@/lib/api-base"' in src
     assert "function canUseLocalAgentDetection(base: string): boolean" in src
-    helper = src[
-        src.find("function canUseLocalAgentDetection") : src.find("const SHIKI_THEMES")
-    ]
+    helper = src[src.find("function canUseLocalAgentDetection") : src.find("const SHIKI_THEMES")]
     assert "if (!isTauri) return false" in helper
     assert "isLoopbackHost(normalizeHost(new URL(base).hostname))" in helper
     assert "const localAgentDetection = canUseLocalAgentDetection(base)" in src

--- a/tests/studio/test_usage_examples_agent_detection_contract.py
+++ b/tests/studio/test_usage_examples_agent_detection_contract.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Static contract for API usage-example agent detection scope."""
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+USAGE_EXAMPLES_TSX = REPO / "studio/frontend/src/features/settings/components/usage-examples.tsx"
+
+
+def test_agent_detection_requires_desktop_scope():
+    src = USAGE_EXAMPLES_TSX.read_text(encoding="utf-8")
+    assert 'import { isTauri } from "@/lib/api-base"' in src
+    assert "function canUseLocalAgentDetection(base: string): boolean" in src
+    helper = src[
+        src.find("function canUseLocalAgentDetection") : src.find("const SHIKI_THEMES")
+    ]
+    assert "if (!isTauri) return false" in helper
+    assert "isLoopbackHost(normalizeHost(new URL(base).hostname))" in helper
+    assert "const localAgentDetection = canUseLocalAgentDetection(base)" in src
+    assert "if (!localAgentDetection)" in src
+    assert "}, [localAgentDetection]);" in src

--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -245,6 +245,7 @@ def _maybe_advise_fla_install(model_types):
         "transformers will use a slower pure PyTorch path."
     )
 
+
 def _fix_rope_inv_freq(model):
     """Fix inv_freq corruption caused by transformers v5 meta-device loading.
 


### PR DESCRIPTION
The API-keys panel only ever showed the "claude" flavor of the `unsloth start` command, so anyone using Codex, OpenCode, OpenClaw, Hermes, or Pi had to manually rewrite the copied command by hand.

Add a backend check that looks for each agent's CLI binary on PATH (shutil.which, mirroring the pattern already used elsewhere in studio/backend/utils) and expose it as GET /api/settings/coding-agents. The API-keys panel now renders a picker for all six supported agents, marks the ones it finds installed, and defaults to one of those instead of always falling back to claude.

Includes unit tests for the detection helper.