### PR TITLE
Fix ruff-format spacing drift in loader.py

### DIFF
--- a/unsloth/models/loader.py
+++ b/unsloth/models/loader.py
@@ -245,6 +245,7 @@ def _maybe_advise_fla_install(model_types):
         "transformers will use a slower pure PyTorch path."
     )
 
+
 def _fix_rope_inv_freq(model):
     """Fix inv_freq corruption caused by transformers v5 meta-device loading.
 


### PR DESCRIPTION
## Problem

`unsloth/models/loader.py` is missing the second blank line before the top-level `_fix_rope_inv_freq` function. ruff-format (run by the `ruff-format-with-kwargs` pre-commit hook) requires two blank lines before a top-level definition, so the hook reformats the file and the pre-commit run fails on main and on every PR that includes this file.

## Fix

Add the one blank line the formatter expects.

## Verification

Ran `scripts/run_ruff_format.py` across all tracked `.py` files (excluding the hook's own extend-exclude patterns): 1 file modified before this change (loader.py), 0 after. No other file drifts.