### PR TITLE
fix(fp8): guard Triton kernel launches with the tensor's CUDA device …

### DIFF
--- a/unsloth/kernels/fp8.py
+++ b/unsloth/kernels/fp8.py
@@ -95,7 +95,11 @@ def weight_dequant_block(
         triton.cdiv(M, meta["BLOCK_SIZE"]),
         triton.cdiv(N, meta["BLOCK_SIZE"]),
     )
-    weight_dequant_kernel[grid](x, s, y, M, N, BLOCK_SIZE = block_size)
+    # Launch on the tensor's device: with multi-GPU device_map the current CUDA
+    # device may differ from x.device, and a mismatched Triton launch reads/writes
+    # through cross-device pointers (silent corruption / NaNs, or IMA).
+    with torch.cuda.device(x.device):
+        weight_dequant_kernel[grid](x, s, y, M, N, BLOCK_SIZE = block_size)
     return y
 
 
@@ -149,7 +153,8 @@ def act_quant(x: torch.Tensor, block_size: int = 128) -> tuple[torch.Tensor, tor
     def grid(meta):
         return (triton.cdiv(x.numel(), meta["BLOCK_SIZE"]),)
 
-    act_quant_kernel[grid](x, y, s, BLOCK_SIZE = block_size)
+    with torch.cuda.device(x.device):
+        act_quant_kernel[grid](x, y, s, BLOCK_SIZE = block_size)
     return y, s
 
 
@@ -274,32 +279,33 @@ def w8a8_block_fp8_matmul_triton(
     def grid(META):
         return (triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),)
 
-    _w8a8_block_fp8_matmul[grid](
-        A,
-        B,
-        C,
-        As,
-        Bs,
-        M,
-        N,
-        K,
-        block_n,
-        block_k,
-        A.stride(-2),
-        A.stride(-1),
-        B.stride(1),
-        B.stride(0),
-        C.stride(-2),
-        C.stride(-1),
-        As.stride(-2),
-        As.stride(-1),
-        Bs.stride(1),
-        Bs.stride(0),
-        BLOCK_SIZE_M = BLOCK_SIZE_M,
-        BLOCK_SIZE_N = BLOCK_SIZE_N,
-        BLOCK_SIZE_K = BLOCK_SIZE_K,
-        GROUP_SIZE_M = 8,
-    )
+    with torch.cuda.device(A.device):
+        _w8a8_block_fp8_matmul[grid](
+            A,
+            B,
+            C,
+            As,
+            Bs,
+            M,
+            N,
+            K,
+            block_n,
+            block_k,
+            A.stride(-2),
+            A.stride(-1),
+            B.stride(1),
+            B.stride(0),
+            C.stride(-2),
+            C.stride(-1),
+            As.stride(-2),
+            As.stride(-1),
+            Bs.stride(1),
+            Bs.stride(0),
+            BLOCK_SIZE_M = BLOCK_SIZE_M,
+            BLOCK_SIZE_N = BLOCK_SIZE_N,
+            BLOCK_SIZE_K = BLOCK_SIZE_K,
+            GROUP_SIZE_M = 8,
+        )
     return C
 
 


### PR DESCRIPTION
### What

Triton kernel launches in `unsloth/kernels/fp8.py` run on whatever CUDA device is
*current*, not the device the tensors live on. This PR wraps the three launch sites
(`weight_dequant_kernel`, `act_quant_kernel`, `_w8a8_block_fp8_matmul`) in
`with torch.cuda.device(<tensor>.device):`.

### Why

On a multi-GPU `device_map` model, layer weights/activations live on `cuda:1`..`cuda:N`
while the current CUDA device typically stays `cuda:0`. When Triton launches a kernel
under the wrong current device, the kernel accesses pointers belonging to another GPU.
Depending on timing/topology this either:

- crashes hard: `ValueError: Pointer argument (at 0) cannot be accessed from Triton`, or
- **corrupts silently**: the dequantized weights come back as garbage/NaN with no error,
  which surfaces as nondeterministic `loss=nan` or unstable loss during training.

The silent case is the dangerous one — training appears to run but the FP8 dequant path
is producing wrong weights for every layer not on `cuda:0`.

### Repro / evidence (from #6831)

GLM-5.2 FP8 (block-quantized MoE), 8x H200, explicit `device_map` spreading 78 layers
across GPUs, attention-only LoRA:

- Per-layer dequant probe: layer 3 (on `cuda:0`) always clean; layer 40 (on `cuda:4`)
  crashed with the Triton pointer error or returned corrupted values.
- Same-batch full-model forward: loss wobbled nondeterministically (0.157→0.198 across
  repeated forwards with zero dropout) and intermittently went NaN.
- After wrapping the launch in `torch.cuda.device(x.device)`: layer 40 output became
  bit-identical to the layer-3 reference path, and the same batch produced a stable
  loss of 0.077 (down from a corrupted 0.15–0.30/NaN) across runs.

### Notes

- The guard is a no-op when the current device already matches the tensor's device, so
  single-GPU behavior and performance are unchanged.
- `act_quant` and `w8a8_block_fp8_matmul` are the same launch pattern; they get the same
  guard preventively so the FP8 path is consistent.
- Companion bug to the int64 offset overflow fixed in #6884 — both were hit on the same
  multi-GPU FP8 MoE workload (#6830 / #6831).

Fixes #6831
