### PR TITLE
Studio: render \[ \] and \( \) LaTeX delimiters in chat

### DIFF
--- a/studio/frontend/src/lib/latex.ts
+++ b/studio/frontend/src/lib/latex.ts
@@ -1,8 +1,13 @@
 // Adapted from LibreChat's latex.ts
 // https://github.com/danny-avila/LibreChat/blob/main/client/src/utils/latex.ts
 //
-// Escapes currency dollar signs so they are not misinterpreted as LaTeX math
-// delimiters when singleDollarTextMath is enabled.
+// Two jobs, in order:
+//   1. Convert LaTeX bracket delimiters (`\[...\]`, `\(...\)`) into the dollar
+//      forms remark-math understands (`$$...$$`, `$...$`). remark-math only
+//      tokenizes dollar delimiters, so models that emit `\[...\]` / `\(...\)`
+//      would otherwise render as literal text.
+//   2. Escape currency dollar signs so they are not misinterpreted as LaTeX
+//      math delimiters when singleDollarTextMath is enabled.
 
 /**
  * Matches a single $ followed by a number pattern (currency), e.g.:
@@ -51,9 +56,10 @@ function findCodeBlockRegions(content: string): Array<[number, number]> {
 }
 
 /**
- * Binary search to check if a position falls inside any code region.
+ * Binary search to check if a position falls inside any region. Regions must be
+ * sorted by start and non-overlapping.
  */
-function isInCodeBlock(
+function isInRegion(
   position: number,
   regions: Array<[number, number]>,
 ): boolean {
@@ -174,9 +180,105 @@ function hasInlineMathCloser(content: string, offset: number): boolean {
 }
 
 /**
- * Preprocess a markdown string to escape currency dollar signs so they are not
- * parsed as LaTeX math delimiters.
+ * Matches a `\[...\]` (display) or `\(...\)` (inline) LaTeX span. Non-greedy so
+ * the first closer wins; dotall so display spans can wrap lines. `(?<!\\)` on
+ * each opener leaves an escaped literal `\\[` (a real backslash then bracket)
+ * alone. The body is length-capped so an unclosed opener can't scan to
+ * end-of-input: without the cap, many unclosed `\(`/`\[` make matching O(n^2),
+ * and this runs per animation frame while streaming. Real spans are far shorter
+ * than the cap; a longer one just stays literal.
+ */
+const LATEX_DELIM_RE =
+  /(?<!\\)\\\[([\s\S]{0,4096}?)\\\]|(?<!\\)\\\(([\s\S]{0,4096}?)\\\)/g;
+
+/**
+ * Rewrite `\[...\]` -> block `$$...$$` and `\(...\)` -> inline `$...$` so
+ * remark-math can tokenize them. Bodies are trimmed: remark-math won't open an
+ * inline span on `$ ` (a `$` followed by whitespace), and display fences must
+ * sit on their own line to render as a centered block (not inline math), so
+ * `\[...\]` becomes `\n$$\n...\n$$\n`.
  *
+ * Spans inside code blocks/spans are left intact (a code sample showing `\(x\)`
+ * must not be rewritten).
+ *
+ * A space is inserted between a converted span and a following `$` so their
+ * delimiters can't fuse (`\(a\)\(b\)` -> `$a$$b$` would mis-tokenize into one
+ * broken span). A preceding currency (`$5\(x\)`) is instead broken later by the
+ * currency escape pass.
+ *
+ * Returns the rewritten text and the `[start, end)` ranges (in the rewritten
+ * string) of every span it produced, so the currency pass can skip them.
+ */
+function convertLatexDelimiters(content: string): {
+  text: string;
+  mathRegions: Array<[number, number]>;
+} {
+  if (!content.includes("\\[") && !content.includes("\\(")) {
+    return { text: content, mathRegions: [] };
+  }
+
+  const codeRegions = findCodeBlockRegions(content);
+  // Pushed in ascending, non-overlapping order (offset only grows), so this
+  // stays valid for isInRegion's binary search without a sort.
+  const mathRegions: Array<[number, number]> = [];
+  // Accumulate into an array, not a string: reading the last char off a growing
+  // `+=` accumulator flattens its rope every append (O(n^2) over many spans, on
+  // the per-frame streaming path), so track the tail char and length instead.
+  const parts: string[] = [];
+  let offset = 0;
+  let lastChar = "";
+  let last = 0;
+  // Append a chunk, separating a trailing `$` from a leading `$` so two spans
+  // can't fuse. Returns where the chunk landed (after any inserted space).
+  const append = (chunk: string): number => {
+    if (!chunk) return offset;
+    if (lastChar === "$" && chunk.startsWith("$")) {
+      parts.push(" ");
+      offset += 1;
+    }
+    const start = offset;
+    parts.push(chunk);
+    offset += chunk.length;
+    lastChar = chunk[chunk.length - 1];
+    return start;
+  };
+  let match: RegExpExecArray | null;
+  LATEX_DELIM_RE.lastIndex = 0;
+  while ((match = LATEX_DELIM_RE.exec(content)) !== null) {
+    const matchEnd = match.index + match[0].length;
+    // Skip if either delimiter is inside code: an opener outside a fence must
+    // not consume a closer inside one and rewrite across the boundary.
+    if (
+      isInRegion(match.index, codeRegions) ||
+      isInRegion(matchEnd - 1, codeRegions)
+    ) {
+      continue;
+    }
+    const isDisplay = match[1] !== undefined;
+    const body = (isDisplay ? match[1] : match[2]).trim();
+    // Leave an empty span (`\(\)`) literal; a bare `$$` would open a stray
+    // display block that swallows following text.
+    if (!body) {
+      continue;
+    }
+    append(content.slice(last, match.index));
+    const wrapped = isDisplay ? `\n$$\n${body}\n$$\n` : `$${body}$`;
+    const start = append(wrapped);
+    mathRegions.push([start, offset]);
+    last = matchEnd;
+  }
+  append(content.slice(last));
+  return { text: parts.join(""), mathRegions };
+}
+
+/**
+ * Preprocess a markdown string so LaTeX renders: convert bracket delimiters to
+ * dollar forms, then escape currency dollar signs so they are not parsed as
+ * math delimiters.
+ *
+ * - `\[E = mc^2\]` becomes a `$$` display block on its own lines (display math)
+ * - `\(\alpha\)` becomes `$\alpha$` (inline math)
+ * - `\(x\)` in a code span is untouched
  * - `$5` alone becomes `\$5` (currency, not math)
  * - `$\alpha$` is untouched (real LaTeX)
  * - `$30^\circ$` is untouched (LaTeX whose body starts with a digit)
@@ -185,15 +287,22 @@ function hasInlineMathCloser(content: string, offset: number): boolean {
  * - Currency inside code blocks/spans is untouched
  */
 export function preprocessLaTeX(content: string): string {
-  if (!content.includes("$")) return content;
+  const { text, mathRegions } = convertLatexDelimiters(content);
 
-  const codeRegions = findCodeBlockRegions(content);
+  if (!text.includes("$")) return text;
 
-  return content.replace(CURRENCY_REGEX, (match, offset) => {
-    if (isInCodeBlock(offset, codeRegions)) {
+  const codeRegions = findCodeBlockRegions(text);
+
+  return text.replace(CURRENCY_REGEX, (match, offset) => {
+    if (isInRegion(offset, codeRegions)) {
       return match;
     }
-    if (hasInlineMathCloser(content, offset)) {
+    // Skip the spans we just created from `\(...\)` so a numeric body like
+    // `$5$` isn't re-escaped back to literal `\$5$`.
+    if (isInRegion(offset, mathRegions)) {
+      return match;
+    }
+    if (hasInlineMathCloser(text, offset)) {
       return match;
     }
     return "\\" + match;

--- a/studio/frontend/src/lib/latex.ts
+++ b/studio/frontend/src/lib/latex.ts
@@ -20,14 +20,14 @@ const CURRENCY_REGEX =
   /(?<![\\$])\$(?!\$)(?=\d+(?:,\d{3})*(?:\.\d+)?[KMBkmb]?(?:\s|$|[^a-zA-Z\d]))/g;
 
 /**
- * Find code-block regions (``` ... ``` and ` ... `) to skip.
+ * Find code-block regions (``` ... ```, ~~~ ... ~~~, and ` ... `) to skip.
  * Returns a sorted array of [start, end] index pairs.
  */
 function findCodeBlockRegions(content: string): Array<[number, number]> {
   const regions: Array<[number, number]> = [];
 
-  // Fenced code blocks: ```...```
-  const fencedRe = /```[\s\S]*?```/g;
+  // Fenced code blocks: ```...``` and ~~~...~~~ (both are code in GFM)
+  const fencedRe = /```[\s\S]*?```|~~~[\s\S]*?~~~/g;
   let match: RegExpExecArray | null;
   while ((match = fencedRe.exec(content)) !== null) {
     regions.push([match.index, match.index + match[0].length]);
@@ -52,6 +52,34 @@ function findCodeBlockRegions(content: string): Array<[number, number]> {
 
   // Sort by start position for binary search.
   regions.sort((a, b) => a[0] - b[0]);
+  return regions;
+}
+
+/**
+ * Match an inline link/image `[text](DEST)`, capturing the destination as group 1
+ * with the `d` flag so its span is read straight from `match.indices` (the text
+ * can contain an escaped `\](`, so a string search for the separator is unsafe).
+ * The text disallows unescaped `]`; the destination allows escapes and one level
+ * of balanced parens.
+ */
+const LINK_DEST_RE =
+  /!?\[(?:\\.|[^\]\\])*?\]\(((?:\\.|[^()\\]|\([^()]*\))*)\)/gd;
+
+/**
+ * Find the destination spans of inline links/images, so a `\(...\)` written with
+ * escaped parens inside a URL isn't rewritten as math (which would break the
+ * link). Only the destination is returned, not the link text, so math in the
+ * visible text still converts. Sorted, non-overlapping (matches are disjoint).
+ */
+function findLinkDestinationRegions(content: string): Array<[number, number]> {
+  if (!content.includes("](")) return [];
+  const regions: Array<[number, number]> = [];
+  let match: RegExpExecArray | null;
+  LINK_DEST_RE.lastIndex = 0;
+  while ((match = LINK_DEST_RE.exec(content)) !== null) {
+    // `indices` is present (the `d` flag); group 1 spans the destination.
+    regions.push(match.indices![1]);
+  }
   return regions;
 }
 
@@ -218,6 +246,9 @@ function convertLatexDelimiters(content: string): {
   }
 
   const codeRegions = findCodeBlockRegions(content);
+  const linkRegions = findLinkDestinationRegions(content);
+  const inSkipZone = (pos: number) =>
+    isInRegion(pos, codeRegions) || isInRegion(pos, linkRegions);
   // Pushed in ascending, non-overlapping order (offset only grows), so this
   // stays valid for isInRegion's binary search without a sort.
   const mathRegions: Array<[number, number]> = [];
@@ -246,12 +277,13 @@ function convertLatexDelimiters(content: string): {
   LATEX_DELIM_RE.lastIndex = 0;
   while ((match = LATEX_DELIM_RE.exec(content)) !== null) {
     const matchEnd = match.index + match[0].length;
-    // Skip if either delimiter is inside code: an opener outside a fence must
-    // not consume a closer inside one and rewrite across the boundary.
-    if (
-      isInRegion(match.index, codeRegions) ||
-      isInRegion(matchEnd - 1, codeRegions)
-    ) {
+    // Skip if either delimiter is inside code or a link destination: an opener
+    // outside such a zone must not consume a closer inside one and rewrite
+    // across the boundary. Resume right after this opener (not past the whole
+    // match) so a valid span that this match spanned across (a stray code `\(`
+    // paired with a real closer) is still found on the next pass, not swallowed.
+    if (inSkipZone(match.index) || inSkipZone(matchEnd - 1)) {
+      LATEX_DELIM_RE.lastIndex = match.index + 1;
       continue;
     }
     const isDisplay = match[1] !== undefined;


### PR DESCRIPTION
Models often write math with `\[ ... \]` (display) and `\( ... \)` (inline) delimiters, but the chat renderer showed them as literal text instead of equations. For example, `\[ A = P e^{r t} \]` rendered as `[ A = P e^{r t} ]`.

The renderer uses remark-math, which only understands `$...$` and `$$...$$`. `preprocessLaTeX` already ran on every message (to escape currency `$`), but it didn't touch bracket delimiters.

## Reproduction

In Studio chat, tell the model to reply with the text below verbatim:

```
Compound interest has two standard forms: periodic compounding and the continuous limit.

**1. Periodic Compounding**
The balance after compounding \( n \) times per year is:

\[
A = P \left(1 + \frac{r}{n}\right)^{n t}
\]

*   \( P \) = principal
*   \( r \) = annual interest rate

**2. Continuous Compounding**
Taking the limit as \( n \to \infty \) gives:

\[
A = P e^{r t}
\]

*   \( e \) = Euler's number
*   \( t \) = time in years
```

On `main` the equations show as literal `[ ... ]` and `( ... )`. With this change they render as math.

## Fix

`preprocessLaTeX` now converts the bracket forms to dollar forms before the currency pass, so remark-math renders them:

- `\(...\)` becomes inline `$...$`
- `\[...\]` becomes a `$$` block on its own lines (so it renders as a centered block, not inline)

It skips anything inside code blocks/spans, leaves escaped `\\[` alone, and doesn't change existing `$`/`$$` math or currency handling.

## Verification

Reproduced with the text above (equations render after the change, literal before). Also ran ~85 cases through the real remark-math + rehype-katex pipeline covering the conversions, code blocks, currency, and malformed input. Lint and typecheck clean.
