### PR TITLE
Fix ShareGPT/CSV import losing thinking and tool-call formatting

### DIFF
--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -150,6 +150,27 @@ function exportCollectionJsonl(prompts: PromptEntry[], lists: PromptListEntry[])
   downloadBlob(lines, "prompt-collection.jsonl", "application/x-ndjson");
 }
 
+// A tool-call part's `args` is coerced to an object for the UI (a
+// key/value display can't render a bare string/null), but chat-adapter's
+// serializeAssistantToolCallPart already treats `argsText` as the
+// authoritative raw value for replay when present -- re-export should use
+// the same precedent, or a decoded null/string args value (e.g. from
+// imported OpenAI JSONL where function.arguments was null or already a raw
+// JSON string) would silently turn into "{}" here even though the decoder
+// preserved the original faithfully in argsText.
+function toolCallExportArgs(p: Record<string, unknown>): unknown {
+  const argsText = p.argsText;
+  if (typeof argsText !== "string") return p.args;
+  try {
+    return JSON.parse(argsText);
+  } catch {
+    // Not valid JSON on its own -- argsText is itself the raw arguments
+    // string (the non-string-args branch below always produces valid
+    // JSON), so that string *is* the original value.
+    return argsText;
+  }
+}
+
 function contentBlocksToText(content: unknown): string {
   if (typeof content === "string") return content;
   if (!Array.isArray(content)) return JSON.stringify(content);
@@ -173,7 +194,7 @@ function contentBlocksToText(content: unknown): string {
         parts.push(
           JSON.stringify({
             tool_call: p.toolName,
-            args: p.args,
+            args: toolCallExportArgs(p),
             result: p.result,
           }),
         );
@@ -892,73 +913,78 @@ function textToContentParts(value: string, role: string): Record<string, unknown
     flushText();
   };
 
+  // A reasoning block's own content can legitimately contain the literal
+  // text "[thinking]"/"[/thinking]" as part of a blank-line-delimited
+  // example (e.g. a model explaining the format it was trained on), and
+  // separately, ordinary *visible* text right after a real close can just
+  // as legitimately mention "[/thinking]" on its own. Neither "always take
+  // the first close" nor "always take the last close before the next open"
+  // handles both: the first swallows an embedded fake close into visible
+  // text, the second swallows visible text (that merely mentions the tag)
+  // into reasoning.
+  //
+  // What actually distinguishes them is nesting: a complete embedded
+  // example doesn't change how many opens are still waiting on a close; a
+  // real close is the one that brings that count back to zero. For each
+  // open, count depth forward from that open's own position (an open bumps
+  // depth up, a close brings it down, the close that returns depth to 0 is
+  // this open's real end) -- a single shared left-to-right pass can't do
+  // this correctly, because an open with no close ever after it (e.g. a
+  // training file of many literal, never-closed "[thinking]" markers) has
+  // no way to "give up" its claim on depth, so it silently absorbs every
+  // close that belongs to a real block appearing later in the value. A
+  // per-open scan avoids that: each open's depth count is independent, so
+  // unrelated unclosed siblings can't blot out a real block after them.
+  //
+  // The tradeoff is that a per-open scan is quadratic in the number of
+  // literal, never-closed markers, since each one independently rescans
+  // the rest of the value looking for a close that isn't there. The short
+  // circuit below covers exactly that reported case cheaply: if the value
+  // contains no "[/thinking]"-shaped close at all, no open anywhere can
+  // possibly resolve, so skip scanning entirely and fall through to plain
+  // text. A lone embedded close with no paired open is the one residual
+  // case none of this can resolve syntactically, same as before either of
+  // the nesting fixes existed.
   let lastIndex = 0;
   let hadMatch = false;
-  let openMatch: RegExpExecArray | null;
-  while ((openMatch = openThinkingRegex.exec(value)) !== null) {
-    const contentStart = openMatch.index + openMatch[0].length;
-
-    // A reasoning block's own content can legitimately contain the literal
-    // text "[thinking]"/"[/thinking]" as part of a blank-line-delimited
-    // example (e.g. a model explaining the format it was trained on), and
-    // separately, ordinary *visible* text right after the real close can
-    // just as legitimately mention "[/thinking]" on its own. Neither
-    // "always take the first close" nor "always take the last close in the
-    // window up to the next open" handles both: the first rule swallows an
-    // embedded fake close into visible text, the second rule swallows
-    // visible text (that merely mentions the tag) into reasoning.
-    //
-    // What actually distinguishes them is nesting: an embedded example is
-    // a *complete open+close pair* inside the content, so it doesn't
-    // change how many opens are still waiting on a close; a real close is
-    // the one that brings that count back to zero. Track it like balanced
-    // brackets -- start at depth 1 for this wrapper's own open, treat every
-    // further open as needing its own close before this one can, and take
-    // the first close that brings the depth back to 0. A lone embedded
-    // close with no paired open (no way to tell it apart from the real one
-    // syntactically at all) is the one residual case this can't resolve,
-    // same as it was before either of these fixes existed.
-    const nestedOpenProbe = new RegExp(openThinkingRegex.source, "g");
-    const nestedCloseProbe = new RegExp(closeThinkingRegex.source, "g");
-    nestedOpenProbe.lastIndex = contentStart;
-    nestedCloseProbe.lastIndex = contentStart;
-
-    let depth = 1;
-    let pendingOpen: RegExpExecArray | null = nestedOpenProbe.exec(value);
-    let pendingClose: RegExpExecArray | null = nestedCloseProbe.exec(value);
-    let realClose: RegExpExecArray | null = null;
-    while (pendingClose !== null) {
-      if (pendingOpen !== null && pendingOpen.index < pendingClose.index) {
-        depth += 1;
-        nestedOpenProbe.lastIndex = pendingOpen.index + pendingOpen[0].length;
-        pendingOpen = nestedOpenProbe.exec(value);
+  if (closeThinkingRegex.test(value)) {
+    closeThinkingRegex.lastIndex = 0;
+    let openMatch: RegExpExecArray | null;
+    while ((openMatch = openThinkingRegex.exec(value)) !== null) {
+      const contentStart = openMatch.index + openMatch[0].length;
+      const nestedOpenProbe = new RegExp(openThinkingRegex.source, "g");
+      const nestedCloseProbe = new RegExp(closeThinkingRegex.source, "g");
+      nestedOpenProbe.lastIndex = contentStart;
+      nestedCloseProbe.lastIndex = contentStart;
+      let depth = 1;
+      let pendingOpen = nestedOpenProbe.exec(value);
+      let pendingClose = nestedCloseProbe.exec(value);
+      let realClose: RegExpExecArray | null = null;
+      while (pendingClose !== null) {
+        if (pendingOpen !== null && pendingOpen.index < pendingClose.index) {
+          depth += 1;
+          nestedOpenProbe.lastIndex = pendingOpen.index + pendingOpen[0].length;
+          pendingOpen = nestedOpenProbe.exec(value);
+          continue;
+        }
+        depth -= 1;
+        if (depth === 0) {
+          realClose = pendingClose;
+          break;
+        }
+        nestedCloseProbe.lastIndex = pendingClose.index + 1;
+        pendingClose = nestedCloseProbe.exec(value);
+      }
+      if (!realClose) {
+        openThinkingRegex.lastIndex = openMatch.index + 1;
         continue;
       }
-      depth -= 1;
-      if (depth === 0) {
-        realClose = pendingClose;
-        break;
-      }
-      nestedCloseProbe.lastIndex = pendingClose.index + 1;
-      pendingClose = nestedCloseProbe.exec(value);
+      pushChunk(value.slice(lastIndex, openMatch.index), hadMatch);
+      parts.push({ type: "reasoning", text: value.slice(contentStart, realClose.index) });
+      lastIndex = realClose.index + realClose[0].length;
+      hadMatch = true;
+      openThinkingRegex.lastIndex = lastIndex;
     }
-
-    if (!realClose) {
-      // Depth never returned to 0 before running out of closes -- this
-      // "[thinking]" was never actually closed (malformed/truncated
-      // export), so it isn't a genuine wrapper. Leave it as literal text:
-      // resume scanning right after this open match instead of consuming
-      // it, without touching `lastIndex`/pushing anything, so it stays
-      // embedded in whatever chunk eventually gets flushed as plain text.
-      openThinkingRegex.lastIndex = openMatch.index + 1;
-      continue;
-    }
-
-    pushChunk(value.slice(lastIndex, openMatch.index), hadMatch);
-    parts.push({ type: "reasoning", text: value.slice(contentStart, realClose.index) });
-    lastIndex = realClose.index + realClose[0].length;
-    hadMatch = true;
-    openThinkingRegex.lastIndex = lastIndex;
   }
   pushChunk(value.slice(lastIndex), hadMatch);
 

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -647,6 +647,13 @@ function parseToolCallSegment(segment: string): Record<string, unknown> | null {
     return null;
   }
   if (typeof parsed.tool_call !== "string") return null;
+  // `contentBlocksToText` omits `result` entirely for a pending/cancelled
+  // tool call, and chat-adapter's replay (canReplayToolCallWithoutRoleTool)
+  // drops a non-builtin tool-call part with no result -- decoding one here
+  // would make the imported thread silently lose that content on the next
+  // send, so leave it as the literal JSON blob instead (parseToolCallSegment
+  // returning null falls through to plain text in the caller).
+  if (parsed.result === undefined) return null;
   const args = parsed.args !== null && typeof parsed.args === "object" ? parsed.args : {};
   return {
     type: "tool-call",
@@ -654,7 +661,7 @@ function parseToolCallSegment(segment: string): Record<string, unknown> | null {
     toolName: parsed.tool_call,
     args,
     argsText: JSON.stringify(args),
-    ...(parsed.result !== undefined ? { result: parsed.result } : {}),
+    result: parsed.result,
   };
 }
 
@@ -670,21 +677,34 @@ function textToContentParts(value: string, role: string): Record<string, unknown
   }
 
   const parts: Record<string, unknown>[] = [];
-  const thinkingRegex = /\[thinking\]\r?\n([\s\S]*?)\r?\n\[\/thinking\]/g;
+  // The leading boundary is consumed into the match itself (not a
+  // lookbehind) so `match.index` lands on the separator, not after it --
+  // that's what lets the gap chunk *before* a match exclude the join
+  // separator while still keeping any of the previous block's own genuine
+  // trailing blank lines (see pushChunk's `afterMatch` handling for the
+  // mirror case on the trailing side, where the separator isn't consumable
+  // this way because whatever follows isn't necessarily another match).
+  const thinkingRegex =
+    /(?:^|\r?\n\r?\n)\[thinking\]\r?\n([\s\S]*?)\r?\n\[\/thinking\](?=\r?\n\r?\n|$)/g;
 
   // Segments between (or around) thinking blocks may still contain a
   // tool-call blob alongside plain text, both joined with blank lines. Keep
   // consecutive plain-text segments merged into one part and only split off
   // the ones that parse as a tool call, so an ordinary multi-paragraph
   // message doesn't get fragmented into several text parts.
-  const pushChunk = (chunk: string) => {
-    const segments = chunk.split(/\r?\n\r?\n/);
-    // Cosmetic leading/trailing blank segments (e.g. a chunk that starts or
-    // ends exactly at a thinking-block boundary) are dropped, but interior
-    // blank paragraphs are kept so text with multiple blank lines still
-    // round-trips exactly.
-    while (segments.length > 0 && segments[0].trim() === "") segments.shift();
-    while (segments.length > 0 && segments[segments.length - 1].trim() === "") segments.pop();
+  //
+  // `afterMatch` is true whenever this chunk immediately follows a
+  // "[/thinking]" -- in that position, exactly one leading "\n\n" is the
+  // encoder's join separator, not part of this chunk's own content, and is
+  // stripped once. It's false for the very first chunk (nothing precedes it
+  // but the start of the value), so a message with no thinking blocks at
+  // all -- or genuine leading blank lines before the first block -- is
+  // never touched.
+  const pushChunk = (chunk: string, afterMatch: boolean) => {
+    const withoutJoin = afterMatch ? chunk.replace(/^\r?\n\r?\n/, "") : chunk;
+    if (withoutJoin === "") return;
+    const segments = withoutJoin.split(/\r?\n\r?\n/);
+    if (segments.every((s) => s.trim() === "")) return;
 
     let textBuffer: string[] = [];
     const flushText = () => {
@@ -709,13 +729,15 @@ function textToContentParts(value: string, role: string): Record<string, unknown
   };
 
   let lastIndex = 0;
+  let hadMatch = false;
   let match: RegExpExecArray | null;
   while ((match = thinkingRegex.exec(value)) !== null) {
-    pushChunk(value.slice(lastIndex, match.index));
+    pushChunk(value.slice(lastIndex, match.index), hadMatch);
     parts.push({ type: "reasoning", text: match[1] });
     lastIndex = thinkingRegex.lastIndex;
+    hadMatch = true;
   }
-  pushChunk(value.slice(lastIndex));
+  pushChunk(value.slice(lastIndex), hadMatch);
 
   return parts;
 }

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -749,7 +749,7 @@ function csvToRecords(csvText: string, threadId: string, baseTs: number): Messag
       threadId,
       parentId: prevId,
       role: validRole as MessageRecord["role"],
-      content: [{ type: "text", text: content }] as MessageRecord["content"],
+      content: textToContentParts(content) as MessageRecord["content"],
       createdAt: baseTs + idx,
     });
     prevId = id;

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -671,6 +671,19 @@ function parseToolCallSegment(segment: string): Record<string, unknown> | null {
     args,
     argsText: JSON.stringify(args),
     result: parsed.result,
+    // chat-adapter's shouldFlushCompletedLocalToolPair (see
+    // studio/frontend/src/features/chat/api/chat-adapter.ts) only keeps
+    // consecutive tool calls in strict call/result/call/result order when
+    // each part's provenance.source is "local" -- the same marker the
+    // backend's tool_event_provenance() stamps on a live local-tool
+    // execution (studio/backend/core/inference/tool_loop_controller.py).
+    // A decoded call has already completed locally by definition (it has
+    // a real `result` and isn't a server-side builtin, both checked
+    // above), so without this marker two consecutive imported tool calls
+    // get batched into one assistant turn instead of being replayed as
+    // separate steps, which corrupts the order when a later call's
+    // arguments depended on an earlier call's result.
+    provenance: { source: "local" },
   };
 }
 
@@ -710,24 +723,56 @@ function textToContentParts(value: string, role: string): Record<string, unknown
   // all -- or genuine leading blank lines before the first block -- is
   // never touched.
   const pushChunk = (chunk: string, afterMatch: boolean) => {
-    const withoutJoin = afterMatch ? chunk.replace(/^\r?\n\r?\n/, "") : chunk;
+    // The join contentBlocksToText inserts between blocks is always the
+    // literal two-byte sequence "\n\n" -- plain Array.prototype.join,
+    // never adapted for CRLF -- so the leading strip below only ever needs
+    // to match that exact sequence.
+    const withoutJoin = afterMatch ? chunk.replace(/^\n\n/, "") : chunk;
     if (withoutJoin === "") return;
-    // Capture the separators (odd indices) instead of discarding them, so a
-    // run of segments that all end up merged into one text part can be
-    // reassembled with their exact original bytes -- CRLF included -- and
-    // not a hardcoded "\n\n" that would otherwise normalize CSV/ShareGPT
-    // rows with Windows-style paragraph breaks and no thinking/tool markers.
-    const pieces = withoutJoin.split(/(\r?\n\r?\n)/);
-    const isContent = (i: number) => i % 2 === 0;
-    if (pieces.every((piece, i) => !isContent(i) || piece.trim() === "")) return;
 
-    const classified = pieces
-      .map((piece, i) => ({ i, piece }))
-      .filter(({ i }) => isContent(i))
-      .map(({ i, piece }) => {
-        const trimmed = piece.trim();
-        return { i, piece, toolCall: trimmed ? parseToolCallSegment(trimmed) : null };
-      });
+    // Split into "islands" at genuine encoder block boundaries only, not
+    // at every run of newline-ish characters. A run between two islands is
+    // a real boundary if and only if it *contains* the literal "\n\n"
+    // join somewhere in it; a run that never contains a bare LF pair at
+    // all (e.g. "\r\n\r\n" in the middle of a pasted CRLF paragraph,
+    // which is entirely CRLF units with no two adjacent bare LFs) isn't a
+    // boundary candidate in the first place and is left untouched inside
+    // whichever island contains it -- splitting there would risk
+    // misreading one half of an ordinary paragraph as a stray tool-call
+    // blob.
+    //
+    // Only a "text" block can contribute its own extra whitespace right
+    // at a boundary (reasoning/tool-call/image/audio all serialize to a
+    // fixed shape with no incidental leading/trailing characters), so once
+    // a run does qualify, exactly one side can own anything beyond the
+    // plain "\n\n": whichever neighbor resolves to a tool call
+    // contributes nothing of its own, so any extra bytes in the run must
+    // belong to the *other* side. That's determined by which neighbor is
+    // the tool call, not by inspecting the run's own leading/trailing
+    // characters -- which is what lets this handle CRLF on either side of
+    // a tool-call blob with the same rule.
+    type Island = { content: string; runBefore: string };
+    const islands: Island[] = [];
+    {
+      const runRegex = /[\r\n]+/g;
+      let curStart = 0;
+      let pendingRun = "";
+      let boundary: RegExpExecArray | null;
+      while ((boundary = runRegex.exec(withoutJoin)) !== null) {
+        const run = boundary[0];
+        if (run.includes("\n\n")) {
+          islands.push({ content: withoutJoin.slice(curStart, boundary.index), runBefore: pendingRun });
+          pendingRun = run;
+          curStart = boundary.index + run.length;
+        }
+      }
+      islands.push({ content: withoutJoin.slice(curStart), runBefore: pendingRun });
+    }
+
+    const classified = islands.map((island) => {
+      const trimmed = island.content.trim();
+      return { ...island, toolCall: trimmed ? parseToolCallSegment(trimmed) : null };
+    });
 
     let textBuffer = "";
     let havePendingText = false;
@@ -739,45 +784,49 @@ function textToContentParts(value: string, role: string): Record<string, unknown
       }
     };
     for (let k = 0; k < classified.length; k += 1) {
-      const { i, piece, toolCall } = classified[k];
-      if (toolCall) {
-        // A tool-call segment is only ever the bare JSON blob -- it never
-        // carries whitespace of its own -- so any leading/trailing
-        // whitespace still attached to `piece` here is a stray newline the
-        // "\r?\n\r?\n" split above couldn't absorb (e.g. a text block
-        // that ends with its own trailing "\n" right before this blob,
-        // making three newlines in a row instead of the encoder's usual
-        // two). Fold it back into the neighboring text instead of
-        // dropping it, so re-exporting reproduces the exact original byte
-        // count.
-        const leadWs = piece.slice(0, piece.length - piece.trimStart().length);
-        if (leadWs) {
-          textBuffer += leadWs;
+      const { content, runBefore, toolCall } = classified[k];
+      const prevToolCall = k > 0 ? classified[k - 1].toolCall : null;
+      if (runBefore) {
+        if (!prevToolCall && !toolCall) {
+          // Neither neighbor is a tool call -- keep the run's exact
+          // original bytes. Whether it was "really" the encoder's join or
+          // a block's own internal blank line makes no difference once
+          // both sides land in the same merged text part anyway.
+          textBuffer += runBefore;
           havePendingText = true;
+        } else if (prevToolCall && !toolCall) {
+          // The preceding block contributed nothing, so the run is
+          // exactly "\n\n" followed by whatever this (text) island's own
+          // leading whitespace is.
+          const leftover = runBefore.slice(2);
+          if (leftover) {
+            textBuffer += leftover;
+            havePendingText = true;
+          }
+        } else if (!prevToolCall && toolCall) {
+          // The upcoming block contributes nothing, so the run is
+          // whatever the preceding (text) island's own trailing
+          // whitespace is, followed by exactly "\n\n".
+          const leftover = runBefore.slice(0, runBefore.length - 2);
+          if (leftover) {
+            textBuffer += leftover;
+            havePendingText = true;
+          }
         }
+        // Both neighbors resolving to tool calls means neither side can
+        // have contributed anything beyond the plain "\n\n" join, so
+        // there's nothing left to fold in here.
+      }
+      if (toolCall) {
         flushText();
         parts.push(toolCall);
-        const trailWs = piece.slice(piece.trimEnd().length);
-        if (trailWs) {
-          textBuffer += trailWs;
-          havePendingText = true;
-        }
-        continue;
-      }
-      // Keep the segment's own whitespace intact (don't trim) so ordinary
-      // text isn't mutated just for having passed through this parser.
-      textBuffer += piece;
-      havePendingText = true;
-      // Only fold the separator that follows this segment into the buffer
-      // when the *next* segment is also staying as plain text -- i.e. the
-      // two will land in the same merged text part. A separator right
-      // before a tool call belongs to the boundary between two different
-      // parts, which contentBlocksToText's own re-export already rejoins
-      // with its own "\n\n"; keeping it here too would double it up.
-      const next = classified[k + 1];
-      if (next && !next.toolCall) {
-        const separator = pieces[i + 1];
-        if (separator) textBuffer += separator;
+      } else {
+        // Keep the island's own whitespace intact (don't trim) so ordinary
+        // text -- including a whitespace-only island, e.g. a genuine blank
+        // paragraph exported right before a [thinking] block -- isn't
+        // mutated or silently dropped just for having passed through here.
+        textBuffer += content;
+        havePendingText = true;
       }
     }
     flushText();

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -647,14 +647,23 @@ function parseToolCallSegment(segment: string): Record<string, unknown> | null {
     return null;
   }
   if (typeof parsed.tool_call !== "string") return null;
-  // `contentBlocksToText` omits `result` entirely for a pending/cancelled
-  // tool call, and chat-adapter's replay (canReplayToolCallWithoutRoleTool)
-  // drops a non-builtin tool-call part with no result -- decoding one here
-  // would make the imported thread silently lose that content on the next
-  // send, so leave it as the literal JSON blob instead (parseToolCallSegment
-  // returning null falls through to plain text in the caller).
-  if (parsed.result === undefined) return null;
+  // `contentBlocksToText` omits `result` for a pending/cancelled tool call,
+  // but also legitimately serializes a completed one whose result is a
+  // JSON `null`. chat-adapter's serializeToolResultPart (see
+  // studio/frontend/src/features/chat/api/chat-adapter.ts) treats both the
+  // same way -- undefined or null, no role="tool" message is produced --
+  // and a non-builtin tool-call part without one is dropped entirely on
+  // replay. Leave either case as the literal JSON blob instead of decoding
+  // it into something that will silently disappear on the next send.
+  if (parsed.result === undefined || parsed.result === null) return null;
   const args = parsed.args !== null && typeof parsed.args === "object" ? parsed.args : {};
+  // `args._server_tool` is the backend's marker for a provider-side builtin
+  // call (web_search, web_fetch, code_execution, image_generation -- see
+  // SERVER_SIDE_BUILTIN_TOOL_NAMES in chat-adapter.ts). Those only replay
+  // through native provider parts the live call produced; a decoded part
+  // rebuilt from plain-text history has no such native part, so
+  // serializeAssistantToolCallPart drops it entirely. Leave it as text too.
+  if ((args as Record<string, unknown>)._server_tool === true) return null;
   return {
     type: "tool-call",
     toolCallId: crypto.randomUUID(),
@@ -703,26 +712,53 @@ function textToContentParts(value: string, role: string): Record<string, unknown
   const pushChunk = (chunk: string, afterMatch: boolean) => {
     const withoutJoin = afterMatch ? chunk.replace(/^\r?\n\r?\n/, "") : chunk;
     if (withoutJoin === "") return;
-    const segments = withoutJoin.split(/\r?\n\r?\n/);
-    if (segments.every((s) => s.trim() === "")) return;
+    // Capture the separators (odd indices) instead of discarding them, so a
+    // run of segments that all end up merged into one text part can be
+    // reassembled with their exact original bytes -- CRLF included -- and
+    // not a hardcoded "\n\n" that would otherwise normalize CSV/ShareGPT
+    // rows with Windows-style paragraph breaks and no thinking/tool markers.
+    const pieces = withoutJoin.split(/(\r?\n\r?\n)/);
+    const isContent = (i: number) => i % 2 === 0;
+    if (pieces.every((piece, i) => !isContent(i) || piece.trim() === "")) return;
 
-    let textBuffer: string[] = [];
+    const classified = pieces
+      .map((piece, i) => ({ i, piece }))
+      .filter(({ i }) => isContent(i))
+      .map(({ i, piece }) => {
+        const trimmed = piece.trim();
+        return { i, piece, toolCall: trimmed ? parseToolCallSegment(trimmed) : null };
+      });
+
+    let textBuffer = "";
+    let havePendingText = false;
     const flushText = () => {
-      if (textBuffer.length > 0) {
-        parts.push({ type: "text", text: textBuffer.join("\n\n") });
-        textBuffer = [];
+      if (havePendingText) {
+        parts.push({ type: "text", text: textBuffer });
+        textBuffer = "";
+        havePendingText = false;
       }
     };
-    for (const segment of segments) {
-      const trimmed = segment.trim();
-      const toolCall = trimmed ? parseToolCallSegment(trimmed) : null;
+    for (let k = 0; k < classified.length; k += 1) {
+      const { i, piece, toolCall } = classified[k];
       if (toolCall) {
         flushText();
         parts.push(toolCall);
-      } else {
-        // Keep the segment's own whitespace intact (don't trim) so ordinary
-        // text isn't mutated just for having passed through this parser.
-        textBuffer.push(segment);
+        continue;
+      }
+      // Keep the segment's own whitespace intact (don't trim) so ordinary
+      // text isn't mutated just for having passed through this parser.
+      textBuffer += piece;
+      havePendingText = true;
+      // Only fold the separator that follows this segment into the buffer
+      // when the *next* segment is also staying as plain text -- i.e. the
+      // two will land in the same merged text part. A separator right
+      // before a tool call belongs to the boundary between two different
+      // parts, which contentBlocksToText's own re-export already rejoins
+      // with its own "\n\n"; keeping it here too would double it up.
+      const next = classified[k + 1];
+      if (next && !next.toolCall) {
+        const separator = pieces[i + 1];
+        if (separator) textBuffer += separator;
       }
     }
     flushText();

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -730,8 +730,8 @@ function textToContentParts(value: string, role: string): Record<string, unknown
   // trailing blank lines (see pushChunk's `afterMatch` handling for the
   // mirror case on the trailing side, where the separator isn't consumable
   // this way because whatever follows isn't necessarily another match).
-  const thinkingRegex =
-    /(?:^|\r?\n\r?\n)\[thinking\]\r?\n([\s\S]*?)\r?\n\[\/thinking\](?=\r?\n\r?\n|$)/g;
+  const openThinkingRegex = /(?:^|\r?\n\r?\n)\[thinking\]\r?\n/g;
+  const closeThinkingRegex = /\r?\n\[\/thinking\](?=\r?\n\r?\n|$)/g;
 
   // Segments between (or around) thinking blocks may still contain a
   // tool-call blob alongside plain text, both joined with blank lines. Keep
@@ -870,12 +870,49 @@ function textToContentParts(value: string, role: string): Record<string, unknown
 
   let lastIndex = 0;
   let hadMatch = false;
-  let match: RegExpExecArray | null;
-  while ((match = thinkingRegex.exec(value)) !== null) {
-    pushChunk(value.slice(lastIndex, match.index), hadMatch);
-    parts.push({ type: "reasoning", text: match[1] });
-    lastIndex = thinkingRegex.lastIndex;
+  let openMatch: RegExpExecArray | null;
+  while ((openMatch = openThinkingRegex.exec(value)) !== null) {
+    const contentStart = openMatch.index + openMatch[0].length;
+
+    // A reasoning block's own content can legitimately contain the literal
+    // text "[/thinking]" followed by a blank line -- e.g. a model
+    // explaining the format it was trained on -- which a naive lazy match
+    // would mistake for the wrapper's real close, truncating the
+    // reasoning early and leaking the remainder as plain (visible) text.
+    // The real close can never be past the *next* genuine "[thinking]"
+    // open boundary (or the end of the value), so search only within that
+    // window, and take the LAST valid close in it rather than the first --
+    // an embedded false close is never the actual wrapper boundary.
+    const nextOpenProbe = new RegExp(openThinkingRegex.source, "g");
+    nextOpenProbe.lastIndex = contentStart;
+    const nextOpenMatch = nextOpenProbe.exec(value);
+    const windowEnd = nextOpenMatch ? nextOpenMatch.index : value.length;
+
+    closeThinkingRegex.lastIndex = contentStart;
+    let lastClose: RegExpExecArray | null = null;
+    let closeMatch: RegExpExecArray | null;
+    while ((closeMatch = closeThinkingRegex.exec(value)) !== null) {
+      if (closeMatch.index >= windowEnd) break;
+      lastClose = closeMatch;
+      closeThinkingRegex.lastIndex = closeMatch.index + 1;
+    }
+
+    if (!lastClose) {
+      // No real close before the next block (or end of value) -- this
+      // "[thinking]" was never actually closed (malformed/truncated
+      // export), so it isn't a genuine wrapper. Leave it as literal text:
+      // resume scanning right after this open match instead of consuming
+      // it, without touching `lastIndex`/pushing anything, so it stays
+      // embedded in whatever chunk eventually gets flushed as plain text.
+      openThinkingRegex.lastIndex = openMatch.index + 1;
+      continue;
+    }
+
+    pushChunk(value.slice(lastIndex, openMatch.index), hadMatch);
+    parts.push({ type: "reasoning", text: value.slice(contentStart, lastClose.index) });
+    lastIndex = lastClose.index + lastClose[0].length;
     hadMatch = true;
+    openThinkingRegex.lastIndex = lastIndex;
   }
   pushChunk(value.slice(lastIndex), hadMatch);
 

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -741,8 +741,27 @@ function textToContentParts(value: string, role: string): Record<string, unknown
     for (let k = 0; k < classified.length; k += 1) {
       const { i, piece, toolCall } = classified[k];
       if (toolCall) {
+        // A tool-call segment is only ever the bare JSON blob -- it never
+        // carries whitespace of its own -- so any leading/trailing
+        // whitespace still attached to `piece` here is a stray newline the
+        // "\r?\n\r?\n" split above couldn't absorb (e.g. a text block
+        // that ends with its own trailing "\n" right before this blob,
+        // making three newlines in a row instead of the encoder's usual
+        // two). Fold it back into the neighboring text instead of
+        // dropping it, so re-exporting reproduces the exact original byte
+        // count.
+        const leadWs = piece.slice(0, piece.length - piece.trimStart().length);
+        if (leadWs) {
+          textBuffer += leadWs;
+          havePendingText = true;
+        }
         flushText();
         parts.push(toolCall);
+        const trailWs = piece.slice(piece.trimEnd().length);
+        if (trailWs) {
+          textBuffer += trailWs;
+          havePendingText = true;
+        }
         continue;
       }
       // Keep the segment's own whitespace intact (don't trim) so ordinary

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -668,6 +668,21 @@ function parseToolCallSegment(segment: string): Record<string, unknown> | null {
   // it into something that will silently disappear on the next send.
   if (parsed.result === undefined || parsed.result === null) return null;
   const args = parsed.args !== null && typeof parsed.args === "object" ? parsed.args : {};
+  // A real exported tool call can have non-object args -- e.g. imported
+  // OpenAI JSONL where function.arguments was null or already a raw JSON
+  // string -- since contentBlocksToText just serializes whatever `p.args`
+  // was, verbatim. `args` above is coerced to {} only for safely rendering
+  // a key/value UI; `argsText` is what chat-adapter's
+  // serializeAssistantToolCallPart actually sends on replay
+  // (falling back to JSON.stringify(args) only if argsText is missing), so
+  // it must reflect the original value, not the coerced display object, or
+  // replay/re-export would send different arguments than the source data.
+  const argsText =
+    typeof parsed.args === "string"
+      ? parsed.args
+      : parsed.args === undefined
+        ? "{}"
+        : JSON.stringify(parsed.args);
   // `args._server_tool` only makes a call server-side-builtin (see
   // isServerSideBuiltinToolPart) once the tool *name* is also one of
   // SERVER_SIDE_BUILTIN_TOOL_NAMES -- a non-builtin tool (e.g. a user's
@@ -693,7 +708,7 @@ function parseToolCallSegment(segment: string): Record<string, unknown> | null {
     toolCallId: crypto.randomUUID(),
     toolName: parsed.tool_call,
     args,
-    argsText: JSON.stringify(args),
+    argsText,
     result: parsed.result,
     // chat-adapter's shouldFlushCompletedLocalToolPair (see
     // studio/frontend/src/features/chat/api/chat-adapter.ts) only keeps
@@ -794,8 +809,17 @@ function textToContentParts(value: string, role: string): Record<string, unknown
     }
 
     const classified = islands.map((island) => {
-      const trimmed = island.content.trim();
-      return { ...island, toolCall: trimmed ? parseToolCallSegment(trimmed) : null };
+      // contentBlocksToText emits a tool-call as a bare JSON.stringify with
+      // no surrounding characters at all, so a genuine one is never
+      // indented or padded -- only trimming *newline runs* off via the
+      // island split above ever legitimately isolates one. An island whose
+      // content still has its own leading/trailing whitespace (spaces,
+      // tabs -- anything .trim() would remove) can only be literal
+      // assistant text that happens to look tool-call-shaped, e.g. an
+      // indented JSON example; checking the raw content instead of a
+      // trimmed copy keeps that as text instead of silently promoting it.
+      const toolCall = island.content ? parseToolCallSegment(island.content) : null;
+      return { ...island, toolCall };
     });
 
     let textBuffer = "";

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -771,6 +771,26 @@ function parseToolCallSegment(segment: string): Record<string, unknown> | null {
 // or system message that happens to *contain* one of these markers literally
 // (e.g. a prompt showing example output) would be silently reinterpreted and
 // dropped from the context on the next send.
+// Splits a run of pure "[\r\n]+" characters into its constituent newline
+// units, treating "\r\n" as one unit and a bare "\n" as one unit, so
+// slicing "the join" (always exactly two units) off either end of a run
+// works the same whether the source file is bare-LF, fully
+// CRLF-normalized, or (in principle) a mix of both.
+function newlineRunUnits(run: string): string[] {
+  const units: string[] = [];
+  let i = 0;
+  while (i < run.length) {
+    if (run[i] === "\r" && run[i + 1] === "\n") {
+      units.push("\r\n");
+      i += 2;
+    } else {
+      units.push(run[i]);
+      i += 1;
+    }
+  }
+  return units;
+}
+
 function textToContentParts(value: string, role: string): Record<string, unknown>[] {
   if (role !== "assistant") {
     return value.trim() ? [{ type: "text", text: value }] : [];
@@ -844,7 +864,19 @@ function textToContentParts(value: string, role: string): Record<string, unknown
       let boundary: RegExpExecArray | null;
       while ((boundary = runRegex.exec(withoutJoin)) !== null) {
         const run = boundary[0];
-        if (run.includes("\n\n")) {
+        // A run counts as a genuine encoder boundary if it contains a
+        // blank-line-shaped break at all, in either the encoder's own LF
+        // ("\n\n") form or a CRLF-normalized ("\r\n\r\n") form -- the
+        // latter happens when a whole exported file gets re-saved with
+        // Windows line endings, turning the join into 4 bytes instead of
+        // 2, same as pushChunk's own join-strip and both thinking-block
+        // regexes already tolerate. A run that's pure CRLF with no bare
+        // "\n\n" can still legitimately be an incidental blank line
+        // pasted inside an ordinary CRLF paragraph, but over-splitting
+        // there is harmless: when neither resulting side is a tool call,
+        // the run is added straight back into the text buffer unchanged
+        // below, reconstructing the original bytes either way.
+        if (/\r?\n\r?\n/.test(run)) {
           islands.push({ content: withoutJoin.slice(curStart, boundary.index), runBefore: pendingRun });
           pendingRun = run;
           curStart = boundary.index + run.length;
@@ -889,9 +921,10 @@ function textToContentParts(value: string, role: string): Record<string, unknown
           havePendingText = true;
         } else if (prevToolCall && !toolCall) {
           // The preceding block contributed nothing, so the run is
-          // exactly "\n\n" followed by whatever this (text) island's own
-          // leading whitespace is.
-          const leftover = runBefore.slice(2);
+          // exactly one join (two newline units -- "\n\n", or
+          // "\r\n\r\n" if this file was CRLF-normalized) followed by
+          // whatever this (text) island's own leading whitespace is.
+          const leftover = newlineRunUnits(runBefore).slice(2).join("");
           if (leftover) {
             textBuffer += leftover;
             havePendingText = true;
@@ -899,8 +932,9 @@ function textToContentParts(value: string, role: string): Record<string, unknown
         } else if (!prevToolCall && toolCall) {
           // The upcoming block contributes nothing, so the run is
           // whatever the preceding (text) island's own trailing
-          // whitespace is, followed by exactly "\n\n".
-          const leftover = runBefore.slice(0, runBefore.length - 2);
+          // whitespace is, followed by exactly one join.
+          const units = newlineRunUnits(runBefore);
+          const leftover = units.slice(0, units.length - 2).join("");
           if (leftover) {
             textBuffer += leftover;
             havePendingText = true;
@@ -911,11 +945,11 @@ function textToContentParts(value: string, role: string): Record<string, unknown
           // still sit between them as its own island (e.g. tool1, a text
           // part whose content is "\n\n", tool2), contributing a join on
           // each side plus its own content in between. Strip exactly one
-          // join's worth (2 bytes) off each end and keep whatever's left
-          // as its own text part; a run that's only the two joins with
-          // nothing between them (length 2 or 4, no middle block at all,
-          // or an empty-string middle block) correctly yields nothing.
-          const middle = runBefore.length > 4 ? runBefore.slice(2, runBefore.length - 2) : "";
+          // join's worth (two newline units) off each end and keep
+          // whatever's left as its own text part; a run that's only the
+          // two joins with nothing between them correctly yields nothing.
+          const units = newlineRunUnits(runBefore);
+          const middle = units.slice(2, units.length - 2).join("");
           if (middle) {
             textBuffer += middle;
             havePendingText = true;

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -647,7 +647,7 @@ function parseToolCallSegment(segment: string): Record<string, unknown> | null {
     return null;
   }
   if (typeof parsed.tool_call !== "string") return null;
-  const args = parsed.args ?? {};
+  const args = parsed.args !== null && typeof parsed.args === "object" ? parsed.args : {};
   return {
     type: "tool-call",
     toolCallId: crypto.randomUUID(),
@@ -658,9 +658,19 @@ function parseToolCallSegment(segment: string): Record<string, unknown> | null {
   };
 }
 
-function textToContentParts(value: string): Record<string, unknown>[] {
+// `contentBlocksToText` only ever emits `[thinking]`/tool-call markers for
+// assistant turns, and non-assistant replay only re-serializes text/image
+// parts, so decoding is limited to `role === "assistant"`. Otherwise a user
+// or system message that happens to *contain* one of these markers literally
+// (e.g. a prompt showing example output) would be silently reinterpreted and
+// dropped from the context on the next send.
+function textToContentParts(value: string, role: string): Record<string, unknown>[] {
+  if (role !== "assistant") {
+    return value.trim() ? [{ type: "text", text: value }] : [];
+  }
+
   const parts: Record<string, unknown>[] = [];
-  const thinkingRegex = /\[thinking\]\n([\s\S]*?)\n\[\/thinking\]/g;
+  const thinkingRegex = /\[thinking\]\r?\n([\s\S]*?)\r?\n\[\/thinking\]/g;
 
   // Segments between (or around) thinking blocks may still contain a
   // tool-call blob alongside plain text, both joined with blank lines. Keep
@@ -668,6 +678,14 @@ function textToContentParts(value: string): Record<string, unknown>[] {
   // the ones that parse as a tool call, so an ordinary multi-paragraph
   // message doesn't get fragmented into several text parts.
   const pushChunk = (chunk: string) => {
+    const segments = chunk.split(/\r?\n\r?\n/);
+    // Cosmetic leading/trailing blank segments (e.g. a chunk that starts or
+    // ends exactly at a thinking-block boundary) are dropped, but interior
+    // blank paragraphs are kept so text with multiple blank lines still
+    // round-trips exactly.
+    while (segments.length > 0 && segments[0].trim() === "") segments.shift();
+    while (segments.length > 0 && segments[segments.length - 1].trim() === "") segments.pop();
+
     let textBuffer: string[] = [];
     const flushText = () => {
       if (textBuffer.length > 0) {
@@ -675,15 +693,16 @@ function textToContentParts(value: string): Record<string, unknown>[] {
         textBuffer = [];
       }
     };
-    for (const segment of chunk.split("\n\n")) {
+    for (const segment of segments) {
       const trimmed = segment.trim();
-      if (!trimmed) continue;
-      const toolCall = parseToolCallSegment(trimmed);
+      const toolCall = trimmed ? parseToolCallSegment(trimmed) : null;
       if (toolCall) {
         flushText();
         parts.push(toolCall);
       } else {
-        textBuffer.push(trimmed);
+        // Keep the segment's own whitespace intact (don't trim) so ordinary
+        // text isn't mutated just for having passed through this parser.
+        textBuffer.push(segment);
       }
     }
     flushText();
@@ -721,7 +740,7 @@ function sharegptToRecords(
       threadId,
       parentId: prevId,
       role,
-      content: textToContentParts(value) as MessageRecord["content"],
+      content: textToContentParts(value, role) as MessageRecord["content"],
       createdAt: baseTs + idx,
     });
     prevId = id;
@@ -749,7 +768,7 @@ function csvToRecords(csvText: string, threadId: string, baseTs: number): Messag
       threadId,
       parentId: prevId,
       role: validRole as MessageRecord["role"],
-      content: textToContentParts(content) as MessageRecord["content"],
+      content: textToContentParts(content, validRole) as MessageRecord["content"],
       createdAt: baseTs + idx,
     });
     prevId = id;

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -629,6 +629,78 @@ function oaiMessagesToRecords(
   return records;
 }
 
+// Reverses the ad-hoc plain-text encoding `contentBlocksToText` produces for
+// ShareGPT/CSV export: `[thinking]...[/thinking]` wrappers for reasoning
+// blocks (joined into the surrounding text with blank lines) and a bespoke
+// `{tool_call, args, result}` JSON blob for tool calls. Without this, a
+// re-imported thread stores everything as a single `{type: "text"}` part and
+// the reasoning/tool-call UI never gets the typed content it needs to render
+// (see #6179). `toolCallId` isn't part of the exported format, so it's
+// synthesized on the way back in, same as the OpenAI JSONL importer does for
+// tool calls that arrive without one.
+function parseToolCallSegment(segment: string): Record<string, unknown> | null {
+  if (!segment.startsWith("{") || !segment.endsWith("}")) return null;
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(segment) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  if (typeof parsed.tool_call !== "string") return null;
+  const args = parsed.args ?? {};
+  return {
+    type: "tool-call",
+    toolCallId: crypto.randomUUID(),
+    toolName: parsed.tool_call,
+    args,
+    argsText: JSON.stringify(args),
+    ...(parsed.result !== undefined ? { result: parsed.result } : {}),
+  };
+}
+
+function textToContentParts(value: string): Record<string, unknown>[] {
+  const parts: Record<string, unknown>[] = [];
+  const thinkingRegex = /\[thinking\]\n([\s\S]*?)\n\[\/thinking\]/g;
+
+  // Segments between (or around) thinking blocks may still contain a
+  // tool-call blob alongside plain text, both joined with blank lines. Keep
+  // consecutive plain-text segments merged into one part and only split off
+  // the ones that parse as a tool call, so an ordinary multi-paragraph
+  // message doesn't get fragmented into several text parts.
+  const pushChunk = (chunk: string) => {
+    let textBuffer: string[] = [];
+    const flushText = () => {
+      if (textBuffer.length > 0) {
+        parts.push({ type: "text", text: textBuffer.join("\n\n") });
+        textBuffer = [];
+      }
+    };
+    for (const segment of chunk.split("\n\n")) {
+      const trimmed = segment.trim();
+      if (!trimmed) continue;
+      const toolCall = parseToolCallSegment(trimmed);
+      if (toolCall) {
+        flushText();
+        parts.push(toolCall);
+      } else {
+        textBuffer.push(trimmed);
+      }
+    }
+    flushText();
+  };
+
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = thinkingRegex.exec(value)) !== null) {
+    pushChunk(value.slice(lastIndex, match.index));
+    parts.push({ type: "reasoning", text: match[1] });
+    lastIndex = thinkingRegex.lastIndex;
+  }
+  pushChunk(value.slice(lastIndex));
+
+  return parts;
+}
+
 function sharegptToRecords(
   conversations: unknown[],
   threadId: string,

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -638,6 +638,17 @@ function oaiMessagesToRecords(
 // (see #6179). `toolCallId` isn't part of the exported format, so it's
 // synthesized on the way back in, same as the OpenAI JSONL importer does for
 // tool calls that arrive without one.
+// Mirrors chat-adapter.ts's SERVER_SIDE_BUILTIN_TOOL_NAMES -- only these
+// tool names can ever be provider-side builtins there; args._server_tool on
+// any other tool name is just a user-controlled argument that happens to
+// share that key, not a builtin marker (see isServerSideBuiltinToolPart).
+const SERVER_SIDE_BUILTIN_TOOL_NAMES = new Set<string>([
+  "web_search",
+  "web_fetch",
+  "code_execution",
+  "image_generation",
+]);
+
 function parseToolCallSegment(segment: string): Record<string, unknown> | null {
   if (!segment.startsWith("{") || !segment.endsWith("}")) return null;
   let parsed: Record<string, unknown>;
@@ -657,13 +668,26 @@ function parseToolCallSegment(segment: string): Record<string, unknown> | null {
   // it into something that will silently disappear on the next send.
   if (parsed.result === undefined || parsed.result === null) return null;
   const args = parsed.args !== null && typeof parsed.args === "object" ? parsed.args : {};
-  // `args._server_tool` is the backend's marker for a provider-side builtin
-  // call (web_search, web_fetch, code_execution, image_generation -- see
-  // SERVER_SIDE_BUILTIN_TOOL_NAMES in chat-adapter.ts). Those only replay
-  // through native provider parts the live call produced; a decoded part
-  // rebuilt from plain-text history has no such native part, so
-  // serializeAssistantToolCallPart drops it entirely. Leave it as text too.
-  if ((args as Record<string, unknown>)._server_tool === true) return null;
+  // `args._server_tool` only makes a call server-side-builtin (see
+  // isServerSideBuiltinToolPart) once the tool *name* is also one of
+  // SERVER_SIDE_BUILTIN_TOOL_NAMES -- a non-builtin tool (e.g. a user's
+  // "submit_form") that merely has an argument literally named
+  // "_server_tool" is unaffected there and replays normally, so gating
+  // only on the marker without the name check was leaving those
+  // perfectly-replayable calls undecoded.
+  const isBuiltinName = SERVER_SIDE_BUILTIN_TOOL_NAMES.has(parsed.tool_call.toLowerCase());
+  if (isBuiltinName && (args as Record<string, unknown>)._server_tool === true) return null;
+  // `contentBlocksToText` always emits this exact compact shape --
+  // `JSON.stringify({tool_call, args, result})`, fixed key order, no
+  // formatting. A JSON object with the same fields but different key
+  // order or added whitespace could never have come from that encoder, so
+  // it's literal assistant text that merely looks tool-call-shaped (e.g. a
+  // training example demonstrating the format); decoding it anyway would
+  // silently change what gets replayed/exported for that turn. Round-trip
+  // through the exact same serialization the encoder uses and only accept
+  // an exact byte match.
+  const canonical = JSON.stringify({ tool_call: parsed.tool_call, args: parsed.args, result: parsed.result });
+  if (canonical !== segment) return null;
   return {
     type: "tool-call",
     toolCallId: crypto.randomUUID(),
@@ -812,10 +836,22 @@ function textToContentParts(value: string, role: string): Record<string, unknown
             textBuffer += leftover;
             havePendingText = true;
           }
+        } else if (prevToolCall && toolCall) {
+          // Both neighbors are tool calls, which contribute nothing of
+          // their own -- but a genuine whitespace-only *text* block can
+          // still sit between them as its own island (e.g. tool1, a text
+          // part whose content is "\n\n", tool2), contributing a join on
+          // each side plus its own content in between. Strip exactly one
+          // join's worth (2 bytes) off each end and keep whatever's left
+          // as its own text part; a run that's only the two joins with
+          // nothing between them (length 2 or 4, no middle block at all,
+          // or an empty-string middle block) correctly yields nothing.
+          const middle = runBefore.length > 4 ? runBefore.slice(2, runBefore.length - 2) : "";
+          if (middle) {
+            textBuffer += middle;
+            havePendingText = true;
+          }
         }
-        // Both neighbors resolving to tool calls means neither side can
-        // have contributed anything beyond the plain "\n\n" join, so
-        // there's nothing left to fold in here.
       }
       if (toolCall) {
         flushText();

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -899,30 +899,52 @@ function textToContentParts(value: string, role: string): Record<string, unknown
     const contentStart = openMatch.index + openMatch[0].length;
 
     // A reasoning block's own content can legitimately contain the literal
-    // text "[/thinking]" followed by a blank line -- e.g. a model
-    // explaining the format it was trained on -- which a naive lazy match
-    // would mistake for the wrapper's real close, truncating the
-    // reasoning early and leaking the remainder as plain (visible) text.
-    // The real close can never be past the *next* genuine "[thinking]"
-    // open boundary (or the end of the value), so search only within that
-    // window, and take the LAST valid close in it rather than the first --
-    // an embedded false close is never the actual wrapper boundary.
-    const nextOpenProbe = new RegExp(openThinkingRegex.source, "g");
-    nextOpenProbe.lastIndex = contentStart;
-    const nextOpenMatch = nextOpenProbe.exec(value);
-    const windowEnd = nextOpenMatch ? nextOpenMatch.index : value.length;
+    // text "[thinking]"/"[/thinking]" as part of a blank-line-delimited
+    // example (e.g. a model explaining the format it was trained on), and
+    // separately, ordinary *visible* text right after the real close can
+    // just as legitimately mention "[/thinking]" on its own. Neither
+    // "always take the first close" nor "always take the last close in the
+    // window up to the next open" handles both: the first rule swallows an
+    // embedded fake close into visible text, the second rule swallows
+    // visible text (that merely mentions the tag) into reasoning.
+    //
+    // What actually distinguishes them is nesting: an embedded example is
+    // a *complete open+close pair* inside the content, so it doesn't
+    // change how many opens are still waiting on a close; a real close is
+    // the one that brings that count back to zero. Track it like balanced
+    // brackets -- start at depth 1 for this wrapper's own open, treat every
+    // further open as needing its own close before this one can, and take
+    // the first close that brings the depth back to 0. A lone embedded
+    // close with no paired open (no way to tell it apart from the real one
+    // syntactically at all) is the one residual case this can't resolve,
+    // same as it was before either of these fixes existed.
+    const nestedOpenProbe = new RegExp(openThinkingRegex.source, "g");
+    const nestedCloseProbe = new RegExp(closeThinkingRegex.source, "g");
+    nestedOpenProbe.lastIndex = contentStart;
+    nestedCloseProbe.lastIndex = contentStart;
 
-    closeThinkingRegex.lastIndex = contentStart;
-    let lastClose: RegExpExecArray | null = null;
-    let closeMatch: RegExpExecArray | null;
-    while ((closeMatch = closeThinkingRegex.exec(value)) !== null) {
-      if (closeMatch.index >= windowEnd) break;
-      lastClose = closeMatch;
-      closeThinkingRegex.lastIndex = closeMatch.index + 1;
+    let depth = 1;
+    let pendingOpen: RegExpExecArray | null = nestedOpenProbe.exec(value);
+    let pendingClose: RegExpExecArray | null = nestedCloseProbe.exec(value);
+    let realClose: RegExpExecArray | null = null;
+    while (pendingClose !== null) {
+      if (pendingOpen !== null && pendingOpen.index < pendingClose.index) {
+        depth += 1;
+        nestedOpenProbe.lastIndex = pendingOpen.index + pendingOpen[0].length;
+        pendingOpen = nestedOpenProbe.exec(value);
+        continue;
+      }
+      depth -= 1;
+      if (depth === 0) {
+        realClose = pendingClose;
+        break;
+      }
+      nestedCloseProbe.lastIndex = pendingClose.index + 1;
+      pendingClose = nestedCloseProbe.exec(value);
     }
 
-    if (!lastClose) {
-      // No real close before the next block (or end of value) -- this
+    if (!realClose) {
+      // Depth never returned to 0 before running out of closes -- this
       // "[thinking]" was never actually closed (malformed/truncated
       // export), so it isn't a genuine wrapper. Leave it as literal text:
       // resume scanning right after this open match instead of consuming
@@ -933,8 +955,8 @@ function textToContentParts(value: string, role: string): Record<string, unknown
     }
 
     pushChunk(value.slice(lastIndex, openMatch.index), hadMatch);
-    parts.push({ type: "reasoning", text: value.slice(contentStart, lastClose.index) });
-    lastIndex = lastClose.index + lastClose[0].length;
+    parts.push({ type: "reasoning", text: value.slice(contentStart, realClose.index) });
+    lastIndex = realClose.index + realClose[0].length;
     hadMatch = true;
     openThinkingRegex.lastIndex = lastIndex;
   }

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -721,7 +721,7 @@ function sharegptToRecords(
       threadId,
       parentId: prevId,
       role,
-      content: [{ type: "text", text: value }] as MessageRecord["content"],
+      content: textToContentParts(value) as MessageRecord["content"],
       createdAt: baseTs + idx,
     });
     prevId = id;

--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -160,7 +160,14 @@ function exportCollectionJsonl(prompts: PromptEntry[], lists: PromptListEntry[])
 // preserved the original faithfully in argsText.
 function toolCallExportArgs(p: Record<string, unknown>): unknown {
   const argsText = p.argsText;
-  if (typeof argsText !== "string") return p.args;
+  // chat-adapter's serializeAssistantToolCallPart treats an empty string
+  // the same as a missing argsText -- falling back to
+  // JSON.stringify(args ?? {}) -- because the streaming path can produce
+  // a no-argument tool call with argsText === "" and args === {}. Mirror
+  // that same fallback here, or a streamed no-args call would re-export
+  // as the literal string "" instead of the "{}" that replay actually
+  // sends and that export produced before this helper existed.
+  if (typeof argsText !== "string" || argsText.length === 0) return p.args;
   try {
     return JSON.parse(argsText);
   } catch {
@@ -317,7 +324,18 @@ function messageToOpenAI(msg: { role: unknown; content: unknown; attachments?: u
       } else if (p.type === "tool-call") {
         const id = typeof p.toolCallId === "string" ? p.toolCallId : `call_${toolCalls.length}`;
         const name = typeof p.toolName === "string" ? p.toolName : "unknown";
-        const argsStr = p.args != null ? JSON.stringify(p.args) : (typeof p.argsText === "string" ? p.argsText : "{}");
+        // Mirror serializeAssistantToolCallPart / toolCallExportArgs:
+        // argsText (when present and non-empty) is the authoritative raw
+        // value for replay, since `p.args` is coerced to {} for any
+        // non-object decoded value (null, a raw JSON string) just to
+        // safely render a key/value UI. Preferring p.args here (as long
+        // as it's non-null, which the coerced {} always is) meant Raw
+        // JSONL export silently turned a real null/string tool-call args
+        // value into "{}" on every import -> Raw JSONL export.
+        const argsStr =
+          typeof p.argsText === "string" && p.argsText.length > 0
+            ? p.argsText
+            : JSON.stringify(p.args ?? {});
         toolCalls.push({ id, type: "function", function: { name, arguments: argsStr } });
         if (p.result !== undefined && p.result !== null) {
           const resultStr = typeof p.result === "string" ? p.result : JSON.stringify(p.result);
@@ -783,11 +801,17 @@ function textToContentParts(value: string, role: string): Record<string, unknown
   // all -- or genuine leading blank lines before the first block -- is
   // never touched.
   const pushChunk = (chunk: string, afterMatch: boolean) => {
-    // The join contentBlocksToText inserts between blocks is always the
-    // literal two-byte sequence "\n\n" -- plain Array.prototype.join,
-    // never adapted for CRLF -- so the leading strip below only ever needs
-    // to match that exact sequence.
-    const withoutJoin = afterMatch ? chunk.replace(/^\n\n/, "") : chunk;
+    // contentBlocksToText's own join is always the literal two-byte
+    // sequence "\n\n" -- plain Array.prototype.join, never adapted for
+    // CRLF -- but a file that's been wholesale LF->CRLF normalized after
+    // export (e.g. re-saved on Windows) turns every "\n" into "\r\n",
+    // including this join separator, into "\r\n\r\n". Both
+    // openThinkingRegex and closeThinkingRegex already accept that
+    // CRLF-normalized form for the boundary itself (via "\r?\n\r?\n"),
+    // so the strip here has to accept it too, or the join survives as a
+    // spurious leading blank paragraph on whatever text follows a
+    // reasoning block's close.
+    const withoutJoin = afterMatch ? chunk.replace(/^\r?\n\r?\n/, "") : chunk;
     if (withoutJoin === "") return;
 
     // Split into "islands" at genuine encoder block boundaries only, not
@@ -913,77 +937,104 @@ function textToContentParts(value: string, role: string): Record<string, unknown
     flushText();
   };
 
-  // A reasoning block's own content can legitimately contain the literal
+  // A [thinking] block's own content can legitimately contain the literal
   // text "[thinking]"/"[/thinking]" as part of a blank-line-delimited
-  // example (e.g. a model explaining the format it was trained on), and
-  // separately, ordinary *visible* text right after a real close can just
-  // as legitimately mention "[/thinking]" on its own. Neither "always take
-  // the first close" nor "always take the last close before the next open"
-  // handles both: the first swallows an embedded fake close into visible
-  // text, the second swallows visible text (that merely mentions the tag)
-  // into reasoning.
+  // example (a model explaining the format it was trained on), or an
+  // ordinary, never-properly-closed mention of the tag name (the model
+  // just talking about the format without actually invoking a new one).
+  // Distinguishing a genuine nested pair from an incidental unclosed
+  // mention -- so a real outer wrapper still resolves via its own real
+  // close either way -- needs two passes plus a domain-specific tie-break,
+  // not a single depth counter (which can't "give back" a count once an
+  // open turns out to never close) and not generic bracket-repair (whose
+  // usual convention discards the *earliest* dangling open, the opposite
+  // of what's wanted here: the outermost, earliest wrapper is what the
+  // API actually emitted around real hidden reasoning, so it should be
+  // the one presumed genuine whenever there's a shortage of closes).
   //
-  // What actually distinguishes them is nesting: a complete embedded
-  // example doesn't change how many opens are still waiting on a close; a
-  // real close is the one that brings that count back to zero. For each
-  // open, count depth forward from that open's own position (an open bumps
-  // depth up, a close brings it down, the close that returns depth to 0 is
-  // this open's real end) -- a single shared left-to-right pass can't do
-  // this correctly, because an open with no close ever after it (e.g. a
-  // training file of many literal, never-closed "[thinking]" markers) has
-  // no way to "give up" its claim on depth, so it silently absorbs every
-  // close that belongs to a real block appearing later in the value. A
-  // per-open scan avoids that: each open's depth count is independent, so
-  // unrelated unclosed siblings can't blot out a real block after them.
-  //
-  // The tradeoff is that a per-open scan is quadratic in the number of
-  // literal, never-closed markers, since each one independently rescans
-  // the rest of the value looking for a close that isn't there. The short
-  // circuit below covers exactly that reported case cheaply: if the value
-  // contains no "[/thinking]"-shaped close at all, no open anywhere can
-  // possibly resolve, so skip scanning entirely and fall through to plain
-  // text. A lone embedded close with no paired open is the one residual
-  // case none of this can resolve syntactically, same as before either of
-  // the nesting fixes existed.
+  // Pass 1 (forward): a close with no still-open marker before it has
+  // nothing to pair with at all -- mark it invalid (stray/literal).
+  // Tie-break: with N opens and only M (< N) valid closes, treat the
+  // *earliest* M opens as the real ones and the *latest* (N - M) as
+  // incidental literal mentions -- consistent with a model being most
+  // likely to genuinely close the outermost wrapper it started, and only
+  // ever accidentally leave a deeper, later mention hanging.
+  // Pass 2 (forward): the kept opens and valid closes are now guaranteed
+  // to pair up completely (equal counts, and pass 1 already ensured every
+  // valid close has enough preceding opens), so an ordinary shared depth
+  // counter -- attributing to whichever open is currently outermost -- is
+  // unambiguous. No per-open rescanning, no recursion, no off-by-one
+  // resync: every pass is one linear walk over the precomputed matches.
+  const opens: RegExpExecArray[] = [];
+  {
+    const probe = new RegExp(openThinkingRegex.source, "g");
+    let m: RegExpExecArray | null;
+    while ((m = probe.exec(value)) !== null) opens.push(m);
+  }
+  const closes: RegExpExecArray[] = [];
+  {
+    const probe = new RegExp(closeThinkingRegex.source, "g");
+    let m: RegExpExecArray | null;
+    while ((m = probe.exec(value)) !== null) closes.push(m);
+  }
+
+  const validCloses: RegExpExecArray[] = [];
+  {
+    let oi = 0;
+    let ci = 0;
+    let unmatchedOpens = 0;
+    while (oi < opens.length || ci < closes.length) {
+      const nextOpen = oi < opens.length ? opens[oi] : null;
+      const nextClose = ci < closes.length ? closes[ci] : null;
+      if (nextOpen && (!nextClose || nextOpen.index < nextClose.index)) {
+        unmatchedOpens += 1;
+        oi += 1;
+      } else if (nextClose) {
+        if (unmatchedOpens > 0) {
+          unmatchedOpens -= 1;
+          validCloses.push(nextClose);
+        }
+        ci += 1;
+      } else {
+        break;
+      }
+    }
+  }
+
+  // validCloses.length can never exceed opens.length -- each valid close
+  // consumed exactly one unit of credit from a preceding open above --
+  // so keeping the first validCloses.length opens (by position, since
+  // `opens` is already in left-to-right match order) and dropping the
+  // rest is always in range.
+  const keptOpens = opens.slice(0, validCloses.length);
+
   let lastIndex = 0;
   let hadMatch = false;
-  if (closeThinkingRegex.test(value)) {
-    closeThinkingRegex.lastIndex = 0;
-    let openMatch: RegExpExecArray | null;
-    while ((openMatch = openThinkingRegex.exec(value)) !== null) {
-      const contentStart = openMatch.index + openMatch[0].length;
-      const nestedOpenProbe = new RegExp(openThinkingRegex.source, "g");
-      const nestedCloseProbe = new RegExp(closeThinkingRegex.source, "g");
-      nestedOpenProbe.lastIndex = contentStart;
-      nestedCloseProbe.lastIndex = contentStart;
-      let depth = 1;
-      let pendingOpen = nestedOpenProbe.exec(value);
-      let pendingClose = nestedCloseProbe.exec(value);
-      let realClose: RegExpExecArray | null = null;
-      while (pendingClose !== null) {
-        if (pendingOpen !== null && pendingOpen.index < pendingClose.index) {
-          depth += 1;
-          nestedOpenProbe.lastIndex = pendingOpen.index + pendingOpen[0].length;
-          pendingOpen = nestedOpenProbe.exec(value);
-          continue;
-        }
-        depth -= 1;
-        if (depth === 0) {
-          realClose = pendingClose;
-          break;
-        }
-        nestedCloseProbe.lastIndex = pendingClose.index + 1;
-        pendingClose = nestedCloseProbe.exec(value);
-      }
-      if (!realClose) {
-        openThinkingRegex.lastIndex = openMatch.index + 1;
+  {
+    let oi = 0;
+    let ci = 0;
+    let depth = 0;
+    let outermostOpen: RegExpExecArray | null = null;
+    while (oi < keptOpens.length || ci < validCloses.length) {
+      const nextOpen = oi < keptOpens.length ? keptOpens[oi] : null;
+      const nextClose = ci < validCloses.length ? validCloses[ci] : null;
+      if (nextOpen && (!nextClose || nextOpen.index < nextClose.index)) {
+        if (depth === 0) outermostOpen = nextOpen;
+        depth += 1;
+        oi += 1;
         continue;
       }
-      pushChunk(value.slice(lastIndex, openMatch.index), hadMatch);
-      parts.push({ type: "reasoning", text: value.slice(contentStart, realClose.index) });
-      lastIndex = realClose.index + realClose[0].length;
-      hadMatch = true;
-      openThinkingRegex.lastIndex = lastIndex;
+      if (!nextClose) break;
+      depth -= 1;
+      if (depth === 0 && outermostOpen) {
+        const contentStart = outermostOpen.index + outermostOpen[0].length;
+        pushChunk(value.slice(lastIndex, outermostOpen.index), hadMatch);
+        parts.push({ type: "reasoning", text: value.slice(contentStart, nextClose.index) });
+        lastIndex = nextClose.index + nextClose[0].length;
+        hadMatch = true;
+        outermostOpen = null;
+      }
+      ci += 1;
     }
   }
   pushChunk(value.slice(lastIndex), hadMatch);


### PR DESCRIPTION
Fixes #6179

`contentBlocksToText()` (the ShareGPT/CSV export path) serializes reasoning blocks to a `[thinking]...[/thinking]` wrapper and tool calls to a bespoke `{tool_call, args, result}` JSON blob, both joined into the message text with blank lines. Nothing on the import side parsed that back out: `sharegptToRecords()` and `csvToRecords()` stored the whole thing as a single `{type: "text"}` part, so a re-imported thread rendered reasoning and tool-call messages as raw text instead of their styled UI components.

- Added `textToContentParts()` / `parseToolCallSegment()` to reverse that encoding: `[thinking]` blocks become `{type: "reasoning"}` parts, the JSON tool-call blobs become `{type: "tool-call"}` parts (with a freshly synthesized `toolCallId`, since the export format doesn't carry one — same fallback the OpenAI JSONL importer already uses), and everything else stays merged into `{type: "text"}` parts so ordinary multi-paragraph messages aren't fragmented.

- Wired `sharegptToRecords()` and `csvToRecords()` to use it.

Verified the shapes produced match the real `@assistant-ui/core` `ReasoningMessagePart`/`ToolCallMessagePart` types (checked with `tsc --strict` against the actual published type declarations), and round-tripped `contentBlocksToText()` output back through the new parser for plain text, reasoning, tool calls, a mixed turn, a reasoning block containing its own blank line, and a plain-text segment that merely looks like JSON — all reconstruct correctly.