### PR TITLE
scan_packages: baseline transitive-dep drift in the supply-chain scan

### DIFF
--- a/scripts/scan_packages_baseline.json
+++ b/scripts/scan_packages_baseline.json
@@ -1489,6 +1489,62 @@
       "severity": "HIGH",
       "evidence": "sha256: 53c38430766be25dc672a30846ac3b9eba86aee35eb0746785ec012647c7d9a2",
       "evidence_hash": "2c6384e8115a6d5dacf1f84d8f724832d8dc59feb442bb98ffae0857c0ccb381"
+    },
+    {
+      "package": "fastapi",
+      "file": "fastapi/routing.py",
+      "check": "C2 polling/beaconing loop detected",
+      "severity": "CRITICAL",
+      "evidence": "L586:                                 while True: sha256:251135b5ebfdd1248916449f32262575e003ef64382501c65b7e4061d67bda45",
+      "evidence_hash": "365aef4449c8089753d9398417cd76ab762cef547d75db70d87bca9c0b550ab5"
+    },
+    {
+      "package": "fastmcp-slim",
+      "file": "fastmcp/cli/apps_dev.py",
+      "check": "Enumerates filesystem AND makes network calls",
+      "severity": "CRITICAL",
+      "evidence": "FS: L637:     history.replaceState(null, \"\", url); sha256:17068ba5bfed62c3a3007ec8bf3e0ea41ef6529b9e6112064d9afb3be9231436\nNetwork: L1304:     with httpx.Client(timeout=30.0) as client: | L1318:     with httpx.Client(timeout=30.0) as client: | L1348:     with httpx.Client(timeout=30.0) as client: | L1549:         client = httpx.AsyncClient(\nL1550:             timeout=httpx.Timeout(60.0, read=None), trust_env=False\nL1551:         ) | L1713:     async with httpx.AsyncClient(trust_env=False) as client: | L1781:                     with socket.socket(family, socket.SOCK_STREAM) as s:",
+      "evidence_hash": "e5325edfada6499540e6f0c24a0868979d275522e2b6a180aa9b5dd3280681b4"
+    },
+    {
+      "package": "huggingface-hub",
+      "file": "huggingface_hub/_sandbox.py",
+      "check": "C2 polling/beaconing loop detected",
+      "severity": "CRITICAL",
+      "evidence": "L1179:             while True: sha256:33ceddf9e42aae207e891e97808c518e92a0b27ab60e4326256717bfb25a3a38",
+      "evidence_hash": "802fd41d8bb17bf425e99d128c0351c820103a5efb74690a4086e542a71437b8"
+    },
+    {
+      "package": "huggingface-hub",
+      "file": "huggingface_hub/_sandbox.py",
+      "check": "Writes to /tmp and executes (staged dropper)",
+      "severity": "CRITICAL",
+      "evidence": "L83: d=/tmp/.sbx-server\nL84: if command -v wget >/dev/null 2>&1; then wget -q --header \"Authorization: Bearer $SBX_DL_TOKEN\" -O \"$d\" \"$SBX_SERVER_URL\"\nL85: elif command -v curl >/dev/null 2>&1; then curl -fsSL -H \"Authorization: Bearer $SBX_DL_TOKEN\" -o \"$d\" \"$SBX_SERVER_URL\"\nL86: else cp \"$SBX_SERVER_MOUNT/sbx-server\" \"$d\"; fi\nL87: chmod +x \"$d\"",
+      "evidence_hash": "6908a3fe328fa94ee22a119998d6ad07cfa1ba4efa2628acf240f4204fd76e22"
+    },
+    {
+      "package": "huggingface-hub",
+      "file": "huggingface_hub/hf_api.py",
+      "check": "C2 polling/beaconing loop detected",
+      "severity": "CRITICAL",
+      "evidence": "L4613:         while True: sha256:f764b6ca3118b23c7c0e670e77178c022a6905f825d7df6e528545fa10aae8f6",
+      "evidence_hash": "9c85d50c227285fa8dc69512999cbb082258cda4b299c7d0e0f69f5aff7accd4"
+    },
+    {
+      "package": "huggingface-hub",
+      "file": "huggingface_hub/utils/_http.py",
+      "check": "C2 polling/beaconing loop detected",
+      "severity": "CRITICAL",
+      "evidence": "L462:     while True: sha256:c75d1ee228cf7703a8c28551d649395a1f89f69a3aba69413f5bbcbd10c31958",
+      "evidence_hash": "d4d5f83fed39b87898cf776d5dad0bf1a6388a932f5fb7997d1070b50e46213e"
+    },
+    {
+      "package": "cffi",
+      "file": "cffi/_cffi_gen_src.py",
+      "check": "Advanced obfuscation (marshal/compile/zlib) + exec/eval",
+      "severity": "HIGH",
+      "evidence": "Obfusc: L52:     compiled = compile(source=pysrc, filename=filename, mode='exec')\nExec: L53:     exec(compiled, globs, globs)",
+      "evidence_hash": "c429e4c977a61db6b7c717b5a552fce74eda622213e49eb5467a3782fd746fb9"
     }
   ]
 }


### PR DESCRIPTION
## What

The `Security audit` workflow's `pip scan-packages` gate runs
`scripts/scan_packages.py --with-deps` with `SCAN_ENFORCE=1`, which
downloads the full transitive dependency closure and blocks on any
CRITICAL/HIGH pattern-scan finding that is not in
`scripts/scan_packages_baseline.json`.

Recent upstream releases of transitive dependencies added new files and
loops that the pattern scanner flags, so all three shards red-failed on
`main` on legitimate library code:

- `pip scan-packages :: extras` (4 CRITICAL, 1 HIGH)
- `pip scan-packages :: hf-stack` (4 CRITICAL)
- `pip scan-packages :: studio` (6 CRITICAL, 1 HIGH)

This is dependency-baseline drift, not a code change in this repo. The
biggest driver is `huggingface_hub` 1.22.0 (published 2026-07-03), pulled
in via `huggingface_hub>=0.34.0`; it ships a new `_sandbox.py` (HF Jobs
sandbox) plus new `while True` loops. The remaining ones come from
`fastapi`, `fastmcp-slim` and `cffi`.

## Fix

Add the 7 reviewed findings to the baseline. Each was confirmed to be
genuine upstream code from the official PyPI archive, not a typosquat or
injected payload:

| package | file | check | why it is benign |
| --- | --- | --- | --- |
| huggingface-hub | `huggingface_hub/_sandbox.py` | Writes to /tmp and executes | HF Jobs sandbox bootstrap script string (`_BOOTSTRAP_DOWNLOAD`) that fetches HF's own `sbx-server` |
| huggingface-hub | `huggingface_hub/_sandbox.py` | C2 polling loop | host-pool slot reservation `while True` loop |
| huggingface-hub | `huggingface_hub/hf_api.py` | C2 polling loop | standard status-polling loop |
| huggingface-hub | `huggingface_hub/utils/_http.py` | C2 polling loop | HTTP retry loop |
| fastapi | `fastapi/routing.py` | C2 polling loop | websocket receive loop |
| fastmcp-slim | `fastmcp/cli/apps_dev.py` | fs enum + network | FastMCP (PrefectHQ) dev CLI making httpx/socket calls |
| cffi | `cffi/_cffi_gen_src.py` | compile + exec | cffi compiling and running generated C-extension source (its core purpose) |

The change is **additive only**: no existing baseline entry is changed or
removed.

## Verification

Re-ran `scripts/scan_packages.py --with-deps` over the full closure of
all shard requirement files on Python 3.12.13 (the CI interpreter). The
`while True` span digests generated locally match the CI logs exactly
(e.g. `_sandbox.py` `sha256:33ceddf9...`, `hf_api.py` `sha256:f764b6ca...`,
`_http.py` `sha256:c75d1ee2...`), confirming identical resolved versions.
With the updated baseline the scan exits 0: all 140 CRITICAL + 72 HIGH
findings are suppressed and only MEDIUM (non-blocking) findings remain.

## Note on the other red check (`Core / HF=4.57.6 + TRL<1`)

Out of scope for this PR. Its failing step, `unsloth_zoo @ main - full
pytest (CPU)`, fails 6 tests in `unsloth_zoo`'s
`tests/test_moe_bnb4bit_per_expert_conversions.py` with
`AttributeError: 'WeightConverter' object has no attribute
'target_patterns'`. Root cause is an `unsloth_zoo`-side interaction, not
the studio merge: that test (added in unsloth_zoo #856) guards with
`pytest.importorskip("transformers.core_model_loading")`, but unsloth's
`import_fixes.py` intentionally injects a stub `core_model_loading`
module on transformers 4.x (to keep peft 0.19 LoRA reloads working), so
the guard does not skip and the test runs against the inert stub. The
identical 6 failures are present on the previous `main` commit
(`eb1ef442`), so it predates this PR's HEAD. The correct fix belongs in
`unsloth_zoo` (guard on the real v5 module, not mere importability), not
in unsloth.
