### PR TITLE
Studio: keep the nudge wiring test collectable without the unsloth stack

### DIFF
--- a/studio/backend/tests/test_nudge_tool_calls_wiring.py
+++ b/studio/backend/tests/test_nudge_tool_calls_wiring.py
@@ -23,10 +23,19 @@ Mechanism (verified here without loading a model):
 
 import inspect
 
-from core.inference.inference import InferenceBackend
 from core.inference.llama_cpp import LlamaCppBackend
 from core.inference.orchestrator import InferenceOrchestrator
 from core.inference.safetensors_agentic import run_safetensors_tool_loop
+
+try:
+    # core.inference.inference imports unsloth at module scope, which requires
+    # unsloth_zoo. The dependency-light backend CI matrix job does not install
+    # it, so the safetensors InferenceBackend is folded into the checks below
+    # only when the unsloth stack is importable (local runs / full CI); the
+    # other entry points are always checked.
+    from core.inference.inference import InferenceBackend
+except ImportError:
+    InferenceBackend = None
 
 
 def _params(fn):
@@ -37,12 +46,14 @@ def test_shared_loop_accepts_nudge_flag():
     assert "nudge_tool_calls" in _params(run_safetensors_tool_loop)
 
 
-def test_all_three_backends_accept_the_flag():
-    for method in (
-        InferenceBackend.generate_chat_completion_with_tools,
+def test_backends_accept_the_flag():
+    methods = [
         InferenceOrchestrator.generate_chat_completion_with_tools,
         LlamaCppBackend.generate_chat_completion_with_tools,
-    ):
+    ]
+    if InferenceBackend is not None:  # safetensors path; needs the unsloth stack
+        methods.append(InferenceBackend.generate_chat_completion_with_tools)
+    for method in methods:
         assert "nudge_tool_calls" in _params(method), method.__qualname__
 
 
@@ -50,10 +61,10 @@ def test_delegating_backends_forward_the_flag_to_the_shared_loop():
     # safetensors (in-process transformers) and MLX (parent-process orchestrator)
     # both delegate to run_safetensors_tool_loop; GGUF runs its own in-file loop
     # and consumes the flag directly (asserted separately by the gate test).
-    for method in (
-        InferenceBackend.generate_chat_completion_with_tools,
-        InferenceOrchestrator.generate_chat_completion_with_tools,
-    ):
+    methods = [InferenceOrchestrator.generate_chat_completion_with_tools]
+    if InferenceBackend is not None:  # safetensors path; needs the unsloth stack
+        methods.append(InferenceBackend.generate_chat_completion_with_tools)
+    for method in methods:
         src = inspect.getsource(method)
         assert "nudge_tool_calls = nudge_tool_calls" in src, method.__qualname__
 


### PR DESCRIPTION
## What

`test_nudge_tool_calls_wiring.py` (added in #6883) imports `InferenceBackend`
from `core.inference.inference` at module scope. That module does
`from unsloth import FastLanguageModel, FastVisionModel`, which requires
`unsloth_zoo`. The Backend CI matrix job (`(Python 3.10/3.11/3.12/3.13)`) is
deliberately dependency-light and does not install `unsloth_zoo`, so the import
raised `PackageNotFoundError` at collection time and pytest aborted the whole
job before running anything:

```
ERROR collecting studio/backend/tests/test_nudge_tool_calls_wiring.py
importlib.metadata.PackageNotFoundError: No package metadata was found for unsloth_zoo
ImportError: Unsloth: Please install unsloth_zoo via `pip install unsloth_zoo` then retry!
Interrupted: 1 error during collection
```

This turned Backend CI red on `main` (all ~831 backend tests skipped by the
collection abort).

## Fix

Guard the one offending import and fold the safetensors `InferenceBackend`
checks in only when the unsloth stack is importable. The other entry points
(`InferenceOrchestrator`, `LlamaCppBackend`, `run_safetensors_tool_loop`) never
needed unsloth and are still asserted unconditionally, so the wiring guard keeps
working in the light job; local runs and any full-stack job still exercise the
`InferenceBackend` path.

## Verified

- Collection no longer aborts; the light suite runs.
- Full stack (unsloth present): 6 passed, InferenceBackend folded in.
- Simulated light job (unsloth import blocked): `InferenceBackend is None`, all
  tests pass, no collection error.
- ruff clean.
