### PR TITLE
Guard RoPE scaling against the transformers v5 buffer blank; honor extended RoPE factor

### DIFF
--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -1900,7 +1900,7 @@ class TestApiMonitorProviderAndCompletionStreams:
                     "chatcmpl-test",
                     monitor_id = monitor_id,
                 ),
-                timeout = 0.2,
+                timeout = 5.0,
             )
             assert isinstance(response, _SameTaskStreamingResponse)
 
@@ -2044,7 +2044,7 @@ class TestApiMonitorProviderAndCompletionStreams:
                     "chatcmpl-test",
                     monitor_id = monitor_id,
                 ),
-                timeout = 0.2,
+                timeout = 5.0,
             )
             assert isinstance(response, _SameTaskStreamingResponse)
             gate.set()
@@ -2107,7 +2107,7 @@ class TestApiMonitorProviderAndCompletionStreams:
                     "chatcmpl-test",
                     monitor_id = monitor_id,
                 ),
-                timeout = 0.2,
+                timeout = 5.0,
             )
             assert isinstance(response, _SameTaskStreamingResponse)
 
@@ -2190,7 +2190,7 @@ class TestApiMonitorProviderAndCompletionStreams:
                     "chatcmpl-test",
                     monitor_id = monitor_id,
                 ),
-                timeout = 0.2,
+                timeout = 5.0,
             )
             assert isinstance(response, _SameTaskStreamingResponse)
 
@@ -2252,7 +2252,7 @@ class TestApiMonitorProviderAndCompletionStreams:
                     "chatcmpl-test",
                     monitor_id = monitor_id,
                 ),
-                timeout = 0.2,
+                timeout = 5.0,
             )
             assert isinstance(response, _SameTaskStreamingResponse)
             assert cancel_id in inf_mod._CANCEL_REGISTRY
@@ -2323,13 +2323,13 @@ class TestApiMonitorProviderAndCompletionStreams:
                     monitor_id = monitor_id,
                 )
             )
-            await asyncio.wait_for(entered.wait(), timeout = 0.2)
+            await asyncio.wait_for(entered.wait(), timeout = 5.0)
             assert cancel_id in inf_mod._CANCEL_REGISTRY
 
             task.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await task
-            await asyncio.wait_for(cancelled.wait(), timeout = 0.2)
+            await asyncio.wait_for(cancelled.wait(), timeout = 5.0)
             assert cancel_id not in inf_mod._CANCEL_REGISTRY
 
         asyncio.run(_run())
@@ -2389,13 +2389,13 @@ class TestApiMonitorProviderAndCompletionStreams:
                     "chatcmpl-test",
                     monitor_id = monitor_id,
                 ),
-                timeout = 0.2,
+                timeout = 5.0,
             )
             assert isinstance(response, _SameTaskStreamingResponse)
             assert cancel_id in inf_mod._CANCEL_REGISTRY
 
             gate.set()
-            await asyncio.wait_for(returned.wait(), timeout = 0.2)
+            await asyncio.wait_for(returned.wait(), timeout = 5.0)
             await asyncio.sleep(0)
             await response._unstarted_cleanup()
             assert upstream_response.is_closed

--- a/tests/utils/test_rope_scaling_drift.py
+++ b/tests/utils/test_rope_scaling_drift.py
@@ -285,6 +285,35 @@ def test_extended_rotary_reads_config_factor():
     )
 
 
+def test_extended_rotary_reads_rope_parameters_v5():
+    # transformers v5 stores scaling under rope_parameters (rope_scaling is a
+    # back-compat shim that may be removed); the factor must still be read.
+    from types import SimpleNamespace
+
+    from unsloth.models.llama import LlamaExtendedRotaryEmbedding
+
+    rot = object.__new__(LlamaExtendedRotaryEmbedding)
+    rot.base = ROPE_THETA
+    rot.dim = HEAD_DIM
+    rot._unsloth_rope_config = SimpleNamespace(
+        rope_scaling = None,
+        rope_parameters = {
+            "rope_type": "llama3",
+            "factor": 32.0,
+            "low_freq_factor": 1.0,
+            "high_freq_factor": 4.0,
+            "original_max_position_embeddings": 8192,
+        },
+    )
+    vanilla = _vanilla_inv_freq()
+    scaled = rot._apply_inv_freq_scaling(vanilla).reshape(-1)
+    ratio = float(vanilla[-1]) / float(scaled[-1])
+    assert abs(ratio - 32.0) < 1e-3, (
+        f"Extended rotary ignored rope_parameters factor 32 (ratio {ratio}); v5 "
+        "keeps the factor under rope_parameters, not rope_scaling."
+    )
+
+
 def _cos_at_position(rot, position):
     """cos row at one position, built like _set_cos_sin_cache but CPU-only."""
     inv_freq = rot.inv_freq.float().cpu()

--- a/tests/utils/test_rope_scaling_drift.py
+++ b/tests/utils/test_rope_scaling_drift.py
@@ -365,7 +365,6 @@ def _blank_nonpersistent_buffers(module):
 
 def _build_llama3_rotary():
     from unsloth.models import llama as llama_mod
-
     config = _make_config(LLAMA3_ROPE_SCALING)
     return llama_mod.LlamaRotaryEmbedding(config = config), config
 

--- a/tests/utils/test_rope_scaling_drift.py
+++ b/tests/utils/test_rope_scaling_drift.py
@@ -405,6 +405,11 @@ def test_v5_blank_repair_roundtrip(build):
     # keeps scaling in a buffer (issue #2405 / PR #6907).
     from unsloth.models import loader
 
+    # The repair only runs on transformers v5 (it is what blanks the buffers);
+    # on v4 _fix_rope_inv_freq is a no-op, so the round-trip cannot restore.
+    if not loader._NEEDS_ROPE_FIX:
+        pytest.skip("transformers < 5 does not blank rope buffers; repair is a no-op")
+
     rot, config = build()
     snapshot = {name: buf.detach().clone() for name, buf in rot.named_buffers()}
     assert snapshot, "rotary registers no buffers; nothing to guard"

--- a/tests/utils/test_rope_scaling_drift.py
+++ b/tests/utils/test_rope_scaling_drift.py
@@ -257,6 +257,34 @@ def test_recompute_helper_scales_on_cpu():
     ), "_unsloth_recompute_inv_freq must return vanilla inv_freq when unscaled."
 
 
+def test_extended_rotary_reads_config_factor():
+    # LlamaExtendedRotaryEmbedding must honor the config factor, not hardcode 8
+    # (Llama-3.2 uses 32); otherwise the subclass path re-drops scaling (#2405).
+    from types import SimpleNamespace
+
+    from unsloth.models.llama import LlamaExtendedRotaryEmbedding
+
+    rot = object.__new__(LlamaExtendedRotaryEmbedding)
+    rot.base = ROPE_THETA
+    rot.dim = HEAD_DIM
+    rot._unsloth_rope_config = SimpleNamespace(
+        rope_scaling = {
+            "rope_type": "llama3",
+            "factor": 32.0,
+            "low_freq_factor": 1.0,
+            "high_freq_factor": 4.0,
+            "original_max_position_embeddings": 8192,
+        }
+    )
+    vanilla = _vanilla_inv_freq()
+    scaled = rot._apply_inv_freq_scaling(vanilla).reshape(-1)
+    ratio = float(vanilla[-1]) / float(scaled[-1])
+    assert abs(ratio - 32.0) < 1e-3, (
+        f"LlamaExtendedRotaryEmbedding ignored config factor 32 (ratio {ratio}); the "
+        "low-frequency band must be divided by the config factor (issue #2405)."
+    )
+
+
 def _cos_at_position(rot, position):
     """cos row at one position, built like _set_cos_sin_cache but CPU-only."""
     inv_freq = rot.inv_freq.float().cpu()
@@ -322,6 +350,83 @@ def test_extended_cache_keeps_scaling_after_growth():
         "scaling of inv_freq; long-context decode loses scaling otherwise "
         "(issue #2405)."
     )
+
+
+def _blank_nonpersistent_buffers(module):
+    """Mimic transformers v5 meta-load: overwrite non-persistent buffers with garbage."""
+    for name, buf in list(module.named_buffers()):
+        leaf = module
+        *parents, attr = name.split(".")
+        for part in parents:
+            leaf = getattr(leaf, part)
+        if attr in getattr(leaf, "_non_persistent_buffers_set", set()):
+            setattr(leaf, attr, torch.rand_like(buf))
+
+
+def _build_llama3_rotary():
+    from unsloth.models import llama as llama_mod
+
+    config = _make_config(LLAMA3_ROPE_SCALING)
+    return llama_mod.LlamaRotaryEmbedding(config = config), config
+
+
+def _build_longrope_rotary():
+    from types import SimpleNamespace
+
+    from unsloth.models import llama as llama_mod
+
+    short_factor, long_factor = [1.05] * 48, [1.3] * 48
+    rot = llama_mod.LongRopeRotaryEmbedding(
+        dim = 96,
+        max_position_embeddings = 131072,
+        original_max_position_embeddings = 4096,
+        base = ROPE_THETA,
+        short_factor = short_factor,
+        long_factor = long_factor,
+    )
+    config = SimpleNamespace(
+        rope_scaling = {
+            "rope_type": "longrope",
+            "short_factor": short_factor,
+            "long_factor": long_factor,
+            "original_max_position_embeddings": 4096,
+        }
+    )
+    return rot, config
+
+
+@requires_cuda
+@pytest.mark.parametrize(
+    "build", [_build_llama3_rotary, _build_longrope_rotary], ids = ["llama3", "longrope"]
+)
+def test_v5_blank_repair_roundtrip(build):
+    # Build scaled -> blank non-persistent buffers (what transformers v5 does on
+    # load) -> run the repair -> every buffer must return to its scaled value.
+    # Family-agnostic: encodes no scaling math, so it guards any rotary that
+    # keeps scaling in a buffer (issue #2405 / PR #6907).
+    from unsloth.models import loader
+
+    rot, config = build()
+    snapshot = {name: buf.detach().clone() for name, buf in rot.named_buffers()}
+    assert snapshot, "rotary registers no buffers; nothing to guard"
+
+    _blank_nonpersistent_buffers(rot)
+    assert any(
+        not torch.equal(rot.get_buffer(name), snapshot[name]) for name in snapshot
+    ), "blanking changed no buffer; the round-trip would be vacuous"
+
+    wrapper = torch.nn.Module()
+    wrapper.add_module("rotary_emb", rot)
+    wrapper.config = config
+    loader._fix_rope_inv_freq(wrapper)
+
+    for name in snapshot:
+        assert torch.allclose(
+            rot.get_buffer(name).cpu(), snapshot[name].cpu(), rtol = 1e-4, atol = 1e-6
+        ), (
+            f"{name} was not restored to its scaled value by loader._fix_rope_inv_freq "
+            "after the transformers v5 buffer blank (issue #2405 / PR #6907)."
+        )
 
 
 def test_object_style_rope_scaling_does_not_crash():

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -2834,6 +2834,7 @@ def patch_llama_rope_scaling(
                 dim = self.head_dim,
                 max_position_embeddings=self.max_position_embeddings,
                 base=self.rope_theta,
+                config=self.config,
             )
         elif scaling_type == "longrope":
             self.rotary_emb = {longrope_rope_function}(

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1936,9 +1936,7 @@ class LlamaExtendedRotaryEmbedding(LlamaRotaryEmbedding):
         # survives even if the rope_scaling back-compat shim is dropped.
         config = getattr(self, "_unsloth_rope_config", None)
         rope_scaling = _rope_scaling_as_dict(
-            getattr(config, "rope_scaling", None)
-            or getattr(config, "rope_parameters", None)
-            or {}
+            getattr(config, "rope_scaling", None) or getattr(config, "rope_parameters", None) or {}
         )
         scale_factor = rope_scaling.get("factor", 8)
         low_freq_factor = rope_scaling.get("low_freq_factor", 1)

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1930,11 +1930,15 @@ class LlamaExtendedRotaryEmbedding(LlamaRotaryEmbedding):
 
     # From https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/api/model.py#L41
     def _apply_inv_freq_scaling(self, freqs: torch.Tensor):
-        # Values obtained from grid search
-        scale_factor = 8
-        low_freq_factor = 1
-        high_freq_factor = 4
-        old_context_len = 8192  # original llama3 length
+        # llama3 factors from config; Llama-3.1 defaults when built without one
+        # (legacy codegen path). Hardcoding 8 is wrong for e.g. Llama-3.2 (32).
+        rope_scaling = _rope_scaling_as_dict(
+            getattr(getattr(self, "_unsloth_rope_config", None), "rope_scaling", None) or {}
+        )
+        scale_factor = rope_scaling.get("factor", 8)
+        low_freq_factor = rope_scaling.get("low_freq_factor", 1)
+        high_freq_factor = rope_scaling.get("high_freq_factor", 4)
+        old_context_len = rope_scaling.get("original_max_position_embeddings", 8192)
 
         low_freq_wavelen = old_context_len / low_freq_factor
         high_freq_wavelen = old_context_len / high_freq_factor

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -1932,8 +1932,13 @@ class LlamaExtendedRotaryEmbedding(LlamaRotaryEmbedding):
     def _apply_inv_freq_scaling(self, freqs: torch.Tensor):
         # llama3 factors from config; Llama-3.1 defaults when built without one
         # (legacy codegen path). Hardcoding 8 is wrong for e.g. Llama-3.2 (32).
+        # v5 renames rope_scaling -> rope_parameters; read either so the factor
+        # survives even if the rope_scaling back-compat shim is dropped.
+        config = getattr(self, "_unsloth_rope_config", None)
         rope_scaling = _rope_scaling_as_dict(
-            getattr(getattr(self, "_unsloth_rope_config", None), "rope_scaling", None) or {}
+            getattr(config, "rope_scaling", None)
+            or getattr(config, "rope_parameters", None)
+            or {}
         )
         scale_factor = rope_scaling.get("factor", 8)
         low_freq_factor = rope_scaling.get("low_freq_factor", 1)


### PR DESCRIPTION
## Summary

Follow-up to #6907. Adds a generic guard for the whole "RoPE scaling dropped when transformers v5 blanks buffers on load" bug class, and fixes a related hardcoded factor in the extended rotary.

## Detection: a v5-blank round-trip guard

#6907 fixed the llama3 case and added a guard that the repair routes through the shared helper, but that only checks wiring at one call site. This adds a behavioral guard that generalizes:

build each rotary from a scaled config, snapshot its non-persistent buffers, blank them (exactly what transformers v5 meta-load does), run `loader._fix_rope_inv_freq`, then assert every buffer is restored to its scaled value.

It encodes no scaling math, so it guards any rotary that keeps scaling in a buffer. Parametrized over the two families that do: llama3 (`LlamaRotaryEmbedding`, `inv_freq`) and longrope (`LongRopeRotaryEmbedding`, `short_inv_freq` / `long_inv_freq`). Validated to fail on the pre-fix repair and pass on the fix.

I audited the other rotaries while here: Gemma / Gemma2 write cos/sin caches directly and register no `inv_freq` buffer, so they are immune; native transformers rotaries (Gemma3, etc.) carry `original_inv_freq` and are restored by transformers' own `_init_weights`.

## Fix: extended rotary honors the config factor

`LlamaExtendedRotaryEmbedding._apply_inv_freq_scaling` hardcoded factor 8 / low 1 / high 4 / original_max 8192, which is wrong for a model with a different factor (Llama-3.2 uses 32). It now reads these from the config (stashed on the module in #6907), falling back to the Llama-3.1 defaults when built without a config (the legacy per-layer codegen path), so there is no behavior change on that path.

## Tests

`tests/utils/test_rope_scaling_drift.py`:
- `test_v5_blank_repair_roundtrip[llama3, longrope]` (CUDA): the round-trip above.
- `test_extended_rotary_reads_config_factor` (CPU): the extended rotary divides by the config factor (32), not 8.

Full suite: 13 passed, 1 skipped. Both new guards were confirmed to fail on their pre-fix code.

## Also: de-flake the passthrough stream tests

Unrelated to RoPE but folded in to unblock this PR's own CI. `studio/backend/tests/test_openai_tool_passthrough.py` guarded async setup and cross-task event signaling with `asyncio.wait_for(..., timeout = 0.2)`. Those guards catch a genuine hang, but 0.2s is a latency assertion in disguise: it times out under CI scheduling load (this PR's Backend CI failed only on the 3.11 matrix leg while 3.10 / 3.12 / 3.13 passed the same commit). Raised the 9 guards to 5.0s, matching the timeout used elsewhere in the suite. No test relies on the guard expiring, and forcing a tiny timeout reproduces the exact CI failure locally, confirming the value (not the logic) was the fragile part.
