### PR TITLE
Studio: show Hugging Face address on hover for Hub and online model rows (#6382)

### DIFF
--- a/studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx
+++ b/studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx
@@ -393,6 +393,7 @@ function ModelRow({
   vramEst,
   gpuGb,
   tooltipText,
+  hubUrl,
   optionProps,
   onArrowDownIntoChildren,
   capabilities,
@@ -409,6 +410,10 @@ function ModelRow({
   vramEst?: number;
   gpuGb?: number;
   tooltipText?: ReactNode;
+  /** Hugging Face address (e.g. "huggingface.co/owner/name") for online/Hub
+   * rows; surfaced on hover so their repo id / URL is discoverable the same
+   * way local rows show an on-disk path. Omit to show no address line. */
+  hubUrl?: string;
   optionProps?: ModelRowOptionProps;
   onArrowDownIntoChildren?: () => boolean;
   /** Capability override (HF rows have tags); falls back to name detection. */
@@ -546,22 +551,30 @@ function ModelRow({
     </button>
   );
 
-  if (vramTooltipText) {
-    return (
-      <Tooltip>
-        <TooltipTrigger asChild={true}>{content}</TooltipTrigger>
-        <TooltipContent
-          side="left"
-          className="tooltip-compact max-w-xs break-all"
-        >
-          {label}
-          <span className="block text-[10px] mt-1">{vramTooltipText}</span>
-        </TooltipContent>
-      </Tooltip>
-    );
-  }
+  // Optional Hugging Face address line for online/Hub rows, rendered under
+  // whichever tooltip shows so the repo id / URL is always visible on hover.
+  const hubUrlLine = hubUrl ? (
+    <span className="block mt-1 text-[10px] text-muted-foreground break-all">
+      {hubUrl}
+    </span>
+  ) : null;
 
-  if (tooltipText) {
+  const tooltipBody = vramTooltipText ? (
+    <>
+      {label}
+      <span className="block text-[10px] mt-1">{vramTooltipText}</span>
+      {hubUrlLine}
+    </>
+  ) : tooltipText ? (
+    tooltipText
+  ) : hubUrl ? (
+    <>
+      <span className="block break-words">{label}</span>
+      {hubUrlLine}
+    </>
+  ) : null;
+
+  if (tooltipBody) {
     return (
       <Tooltip>
         <TooltipTrigger asChild={true}>{content}</TooltipTrigger>
@@ -569,7 +582,7 @@ function ModelRow({
           side="left"
           className="tooltip-compact max-w-xs break-all"
         >
-          {tooltipText}
+          {tooltipBody}
         </TooltipContent>
       </Tooltip>
     );
@@ -1191,6 +1204,13 @@ function localPathTooltip(name: string, path: string): ReactNode {
       </span>
     </>
   );
+}
+
+/** Hugging Face address for an online/Hub row, or undefined when the repo id is
+ * missing so the row shows no (empty) address line on hover. */
+function hubRepoUrl(id: string | null | undefined): string | undefined {
+  const trimmed = id?.trim();
+  return trimmed ? `huggingface.co/${trimmed}` : undefined;
 }
 
 /** Whether a local model is an MLX build (name hint). MLX runs on Mac only, so
@@ -2462,6 +2482,7 @@ export function HubModelPicker({
           <div className="min-w-0 flex-1">
             <ModelRow
               label={c.repo_id}
+              hubUrl={hubRepoUrl(c.repo_id)}
               meta="GGUF"
               showVision={c.has_vision ?? visionByRepo[c.repo_id]}
               selected={isSelected}
@@ -2518,6 +2539,7 @@ export function HubModelPicker({
         <div className="min-w-0 flex-1">
           <ModelRow
             label={c.repo_id}
+            hubUrl={hubRepoUrl(c.repo_id)}
             meta={`${isMlxId(c.repo_id) ? "MLX" : "Safetensors"} · ${formatBytes(
               c.size_bytes,
             )}`}
@@ -3378,6 +3400,7 @@ export function HubModelPicker({
                         <div key={id}>
                           <ModelRow
                             label={id}
+                            hubUrl={hubRepoUrl(id)}
                             hideOwner={true}
                             downloaded={downloadedSet.has(id.toLowerCase())}
                             capabilities={capsById.get(id)}
@@ -3463,6 +3486,7 @@ export function HubModelPicker({
                       <div key={id}>
                         <ModelRow
                           label={id}
+                          hubUrl={hubRepoUrl(id)}
                           capabilities={capsById.get(id)}
                           meta={
                             isKnownGgufRepo(id)
@@ -3545,6 +3569,7 @@ export function HubModelPicker({
                         <div key={id}>
                           <ModelRow
                             label={id}
+                            hubUrl={hubRepoUrl(id)}
                             capabilities={capsById.get(id)}
                             meta={
                               isSearchGguf

--- a/studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx
+++ b/studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx
@@ -566,7 +566,10 @@ function ModelRow({
       {hubUrlLine}
     </>
   ) : tooltipText ? (
-    tooltipText
+    <>
+      {tooltipText}
+      {hubUrlLine}
+    </>
   ) : hubUrl ? (
     <>
       <span className="block break-words">{label}</span>
@@ -2482,7 +2485,7 @@ export function HubModelPicker({
           <div className="min-w-0 flex-1">
             <ModelRow
               label={c.repo_id}
-              hubUrl={hubRepoUrl(c.repo_id)}
+              tooltipText={localPathTooltip(c.repo_id, c.cache_path)}
               meta="GGUF"
               showVision={c.has_vision ?? visionByRepo[c.repo_id]}
               selected={isSelected}

--- a/studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx
+++ b/studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx
@@ -576,7 +576,7 @@ function ModelRow({
 
   if (tooltipBody) {
     return (
-      <Tooltip>
+      <Tooltip delayDuration={700}>
         <TooltipTrigger asChild={true}>{content}</TooltipTrigger>
         <TooltipContent
           side="left"


### PR DESCRIPTION
## Summary
Follow-up to the earlier local-path tooltip so #6382 is fully addressed. Hub and online model rows in the model selector now show their Hugging Face address on hover, the same way local rows already show their on-disk path.

## What changed
`studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx`:
- New optional `hubUrl` prop on `ModelRow` and a `hubRepoUrl(id)` helper returning `huggingface.co/<id>` (or undefined for an empty id, so no empty address line renders).
- Consolidated the two tooltip branches into a single `tooltipBody`. Precedence is unchanged: VRAM estimate > local path > Hub address, and the VRAM tooltip now also appends the address line.
- Wired `hubUrl={hubRepoUrl(...)}` on the five Hub and online call sites: Discover/recommended, search-recommended, search-hf, downloaded GGUF, and downloaded model rows.

Local rows keep their existing on-disk path tooltip (they never pass `hubUrl`), so there is no regression.

## Testing
`npm run typecheck` (tsc -b) passes clean.

Closes #6382
