### PR TITLE
fix: dispatch Qwen3-MoE LoRA in patch_peft_model

### DIFF
--- a/tests/test_qwen3_moe_lora_dispatch.py
+++ b/tests/test_qwen3_moe_lora_dispatch.py
@@ -1,0 +1,98 @@
+"""Regression test: FastLlamaModel.patch_peft_model must dispatch Qwen3-MoE.
+
+The activation dispatch in ``patch_peft_model`` reads ``model.config.model_type``
+and branches on string literals. The canonical HuggingFace ``model_type`` for
+Qwen3-MoE is ``"qwen3_moe"`` (with an underscore), used everywhere else in the
+repo (unsloth/models/_utils.py, the transformers.models.qwen3_moe imports,
+loader.py's comment). A missing underscore ("qwen3moe") makes that branch dead,
+so a Qwen3-MoE adapter falls through to
+``else: raise NotImplementedError("Unsloth: qwen3_moe is not yet implemented!")``
+and blocks ``get_peft_model`` on Qwen3-MoE.
+
+Pure AST/exec so it runs on every CI OS/Python without torch: it extracts the
+real dispatch chain from unsloth/models/llama.py, execs it with the
+``apply_lora_mlp_*`` names stubbed, and asserts ``"qwen3_moe"`` no longer raises.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+LLAMA_PATH = REPO_ROOT / "unsloth" / "models" / "llama.py"
+
+
+def _extract_activation_dispatch() -> ast.If:
+    """Return the ``if model_type == ...`` chain from FastLlamaModel.patch_peft_model."""
+    tree = ast.parse(LLAMA_PATH.read_text(encoding = "utf-8"))
+
+    method = None
+    for cls in (n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)):
+        if cls.name != "FastLlamaModel":
+            continue
+        for item in cls.body:
+            if isinstance(item, ast.FunctionDef) and item.name == "patch_peft_model":
+                method = item
+                break
+    assert method is not None, "FastLlamaModel.patch_peft_model not found"
+
+    # The dispatch is the first ``if`` whose test compares ``model_type`` to a str
+    # and whose orelse ultimately raises NotImplementedError.
+    for node in method.body:
+        if (
+            isinstance(node, ast.If)
+            and isinstance(node.test, ast.Compare)
+            and isinstance(node.test.left, ast.Name)
+            and node.test.left.id == "model_type"
+        ):
+            return node
+    raise AssertionError("activation dispatch (if model_type == ...) not found")
+
+
+def _run_dispatch(model_type: str) -> str:
+    """Exec the real dispatch chain for ``model_type``; return the bound apply fn name.
+
+    ``apply_lora_mlp_*`` are stubbed with sentinel strings so no torch/kernels are
+    imported; the ``else`` still raises NotImplementedError as in the real code.
+    """
+    dispatch = _extract_activation_dispatch()
+    module = ast.Module(body = [dispatch], type_ignores = [])
+    ast.fix_missing_locations(module)
+    code = compile(module, filename = str(LLAMA_PATH), mode = "exec")
+
+    namespace = {
+        "model_type": model_type,
+        "apply_lora_mlp_swiglu": "apply_lora_mlp_swiglu",
+        "apply_lora_mlp_geglu_approx": "apply_lora_mlp_geglu_approx",
+    }
+    exec(code, namespace)
+    return namespace["apply_lora_mlp"]
+
+
+class TestPatchPeftModelDispatchesQwen3Moe(unittest.TestCase):
+    def test_qwen3_moe_does_not_raise_not_implemented(self):
+        """The real HF model_type "qwen3_moe" is dispatched, not rejected."""
+        self.assertEqual(_run_dispatch("qwen3_moe"), "apply_lora_mlp_swiglu")
+
+    def test_misspelled_qwen3moe_branch_is_gone(self):
+        """The dead, underscore-less "qwen3moe" literal must not be in the dispatch."""
+        dispatch = _extract_activation_dispatch()
+        literals = {
+            n.value
+            for n in ast.walk(dispatch)
+            if isinstance(n, ast.Constant) and isinstance(n.value, str)
+        }
+        self.assertIn("qwen3_moe", literals)
+        self.assertNotIn("qwen3moe", literals)
+
+    def test_unknown_model_type_still_raises(self):
+        """Guard: an unrelated model_type still hits the NotImplementedError else-branch."""
+        with self.assertRaises(NotImplementedError):
+            _run_dispatch("definitely_not_a_real_model_type")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -3529,7 +3529,7 @@ class FastLlamaModel:
             apply_lora_mlp = apply_lora_mlp_swiglu
         elif model_type == "falcon_h1":
             apply_lora_mlp = apply_lora_mlp_swiglu
-        elif model_type == "qwen3moe":
+        elif model_type == "qwen3_moe":
             apply_lora_mlp = apply_lora_mlp_swiglu
         else:
             raise NotImplementedError(f"Unsloth: {model_type} is not yet implemented!")


### PR DESCRIPTION
### Summary

`FastLlamaModel.patch_peft_model` picks the LoRA MLP kernel by branching on
`model.config.model_type`. The Qwen3-MoE branch tested the literal `"qwen3moe"`
(no underscore), but the canonical HuggingFace `model_type` for Qwen3-MoE is
`"qwen3_moe"` (with an underscore). The misspelled branch is therefore dead, and
a Qwen3-MoE adapter falls through to:

```python
else:
    raise NotImplementedError(f"Unsloth: {model_type} is not yet implemented!")
```

so `get_peft_model` on a Qwen3-MoE model raises
`Unsloth: qwen3_moe is not yet implemented!`.

`"qwen3_moe"` is what the rest of the repo already uses: `unsloth/models/_utils.py`,
the `transformers.models.qwen3_moe` imports, and the comment in
`unsloth/models/loader.py`. It also matches transformers'
`Qwen3MoeConfig.model_type`.

### Fix

Correct the literal to `"qwen3_moe"` in the dispatch in `unsloth/models/llama.py`,
mirroring the existing `"qwen3"` / `"falcon_h1"` branches (all
`apply_lora_mlp_swiglu`, correct for Qwen3-MoE's SwiGLU MLP). One-character change.

### Repro (before this change)

```python
from unsloth import FastLanguageModel

model, tokenizer = FastLanguageModel.from_pretrained("unsloth/Qwen3-30B-A3B")
model = FastLanguageModel.get_peft_model(model, r = 16)
# NotImplementedError: Unsloth: qwen3_moe is not yet implemented!
```

### Test

Adds `tests/test_qwen3_moe_lora_dispatch.py`, a regression test that extracts the
real dispatch chain from `unsloth/models/llama.py` via `ast` and execs it (no
torch, so it runs on the CPU CI matrix). It asserts:

- `"qwen3_moe"` is dispatched (binds `apply_lora_mlp_swiglu`) instead of raising,
- the dead `"qwen3moe"` literal is gone from the dispatch,
- an unknown `model_type` still raises `NotImplementedError`.

Reintroducing the typo makes the test fail with the exact
`NotImplementedError: Unsloth: qwen3_moe is not yet implemented!`.

`ruff check` passes on both changed files.

### Note

The one-char dispatch fix and the regression test are verified on CPU. The full
end-to-end path (`FastLanguageModel.from_pretrained(<Qwen3-MoE>)` +
`get_peft_model` + a training step) needs a GPU and the Qwen3-MoE weights, so that
part is left to CI / maintainers.
