### PR TITLE
MoE LoRA: auto-target per-expert Linear experts (gpt-oss 4bit) instead of leaving them frozen

### DIFF
--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -87,6 +87,7 @@ __all__ = [
     "is_moe_model",
     "get_moe_target_parameters",
     "get_moe_target_modules",
+    "warn_if_zoo_cannot_merge_moe_experts",
     "_select_moe_detection_targets",
     "make_fast_generate_wrapper",
     "_mark_unsloth_disable_data_parallel",
@@ -4125,22 +4126,65 @@ def get_moe_target_modules(model, target_modules = None) -> List[str]:
     if not hasattr(model, "named_modules"):
         return []
 
+    # Scope the returned suffixes to the requested projection leaves, matching
+    # get_moe_target_parameters: gate_proj/up_proj/gate_up_proj map to the fused
+    # gate_up ModuleList (e.g. gate_up_projs); down_proj maps to the down ModuleList
+    # (e.g. down_projs). A down-only (or gate/up-only) request must not pull in the
+    # other projection.
+    want_gate_up = bool(target_set & {"gate_proj", "up_proj", "gate_up_proj"})
+    want_down = "down_proj" in target_set
+
     targets = set()
     for name, module in model.named_modules():
         if not isinstance(module, torch.nn.ModuleList) or len(module) == 0:
             continue
         parent, _, leaf = name.rpartition(".")
         # ModuleList directly under an ``experts`` container, holding only Linear
-        # leaves (bnb Linear4bit / Linear8bitLt subclass nn.Linear).
+        # leaves (bnb Linear4bit / Linear8bitLt subclass nn.Linear). After PEFT has
+        # wrapped the experts the child is a LoRA layer whose ``base_layer`` is the
+        # Linear, so accept that too (keeps this idempotent across a re-wrapped model).
         if not parent.endswith("experts"):
             continue
-        if not all(isinstance(child, torch.nn.Linear) for child in module):
+        if not all(
+            isinstance(child, torch.nn.Linear)
+            or isinstance(getattr(child, "base_layer", None), torch.nn.Linear)
+            for child in module
+        ):
+            continue
+        # Honor the requested subset: classify the ModuleList by projection role.
+        leaf_lower = leaf.lower()
+        is_down = "down" in leaf_lower
+        is_gate_up = (not is_down) and ("gate" in leaf_lower or "up" in leaf_lower)
+        if is_down and not want_down:
+            continue
+        if is_gate_up and not want_gate_up:
             continue
         # One entry per expert index; ``leaf.<i>`` matches expert i in every layer.
         for expert_index in range(len(module)):
             targets.add(f"{leaf}.{expert_index}")
 
     return sorted(targets)
+
+
+def warn_if_zoo_cannot_merge_moe_experts():
+    """Warn once when the installed unsloth_zoo cannot fold per-expert Linear MoE LoRA
+    into a merged_16bit checkpoint. Older zoo releases keep the fused gate_up_proj /
+    down_proj tensors and drop the per-expert gate_up_projs.<i> / down_projs.<i> deltas,
+    so save_pretrained_merged("merged_16bit") would silently lose the expert training
+    (the LoRA adapter itself still saves and reloads correctly)."""
+    try:
+        from unsloth_zoo import saving_utils as _saving_utils
+        # _fold_perexpert_lora_into_fused is the helper that folds these experts.
+        if hasattr(_saving_utils, "_fold_perexpert_lora_into_fused"):
+            return
+    except Exception:
+        return  # cannot introspect zoo -> stay quiet rather than false-alarm
+    logger.warning_once(
+        "Unsloth: the installed unsloth_zoo will not fold these per-expert experts into "
+        "a merged_16bit checkpoint, so save_pretrained_merged('merged_16bit') would drop "
+        "the expert LoRA. Upgrade unsloth_zoo to merge them; saving the LoRA adapter is "
+        "unaffected."
+    )
 
 
 def _select_moe_detection_targets(

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -86,6 +86,7 @@ __all__ = [
     "maybe_prefetch_hf_snapshot",
     "is_moe_model",
     "get_moe_target_parameters",
+    "get_moe_target_modules",
     "_select_moe_detection_targets",
     "make_fast_generate_wrapper",
     "_mark_unsloth_disable_data_parallel",
@@ -4060,13 +4061,17 @@ def get_moe_target_parameters(model, target_modules = None) -> Optional[List[str
         alternate_name = "experts.down_proj",
     )
 
-    # gate_up_proj combines both gate_proj and up_proj in MoE
-    # Also match "gate_up_proj" directly since users may specify the fused name
+    # gate_up_proj combines gate_proj and up_proj; also match the fused name directly.
+    # Only target a fused expert Parameter that exists: per-expert Linear layouts
+    # (e.g. gpt-oss bnb-4bit) have no fused Parameter and are handled by
+    # get_moe_target_modules, so skip them rather than pass PEFT a dead path.
     if "gate_proj" in target_set or "up_proj" in target_set or "gate_up_proj" in target_set:
-        moe_params.append(gate_up_name)
+        if _moe_parameter_exists(model, gate_up_name):
+            moe_params.append(gate_up_name)
 
     if "down_proj" in target_set:
-        moe_params.append(down_name)
+        if _moe_parameter_exists(model, down_name):
+            moe_params.append(down_name)
 
     if moe_params:
         print(
@@ -4075,6 +4080,67 @@ def get_moe_target_parameters(model, target_modules = None) -> Optional[List[str
         return moe_params
 
     return None
+
+
+def _moe_parameter_exists(model, name: str) -> bool:
+    """True if ``name`` is an exact suffix of some parameter path on the model."""
+    if not hasattr(model, "named_parameters"):
+        return False
+    try:
+        for parameter_name, _ in model.named_parameters():
+            if parameter_name == name or parameter_name.endswith("." + name):
+                return True
+    except Exception:
+        return False
+    return False
+
+
+def get_moe_target_modules(model, target_modules = None) -> List[str]:
+    """Per-expert ``target_modules`` suffixes for MoE models whose experts are stored
+    as per-expert ``nn.Linear`` ModuleLists rather than fused nn.Parameters.
+
+    gpt-oss bnb-4bit is the canonical case (mlp.experts.gate_up_projs.<i> /
+    down_projs.<i> as Linear4bit): no fused Parameter, and the plain
+    gate/up/down_proj leaves do not match, so LoRA skips them. Returning the
+    per-expert suffixes makes PEFT attach via ordinary suffix matching (the
+    module-LoRA counterpart of get_moe_target_parameters). Returns [] for non-MoE,
+    fused-parameter MoEs, an absent per-expert layout, or a request that omits the
+    MLP experts (so an attention-only run does not train experts).
+    """
+    if not is_moe_model(model):
+        return []
+    if target_modules is None:
+        return []
+    if isinstance(target_modules, str):
+        target_set = _moe_target_set_from_string(target_modules)
+    else:
+        target_set = {
+            target
+            for target in target_modules or ()
+            if (isinstance(target, str) and "." not in target and target in _MOE_BROAD_MLP_TARGETS)
+        }
+    if not (target_set & _MOE_BROAD_MLP_TARGETS):
+        return []
+
+    if not hasattr(model, "named_modules"):
+        return []
+
+    targets = set()
+    for name, module in model.named_modules():
+        if not isinstance(module, torch.nn.ModuleList) or len(module) == 0:
+            continue
+        parent, _, leaf = name.rpartition(".")
+        # ModuleList directly under an ``experts`` container, holding only Linear
+        # leaves (bnb Linear4bit / Linear8bitLt subclass nn.Linear).
+        if not parent.endswith("experts"):
+            continue
+        if not all(isinstance(child, torch.nn.Linear) for child in module):
+            continue
+        # One entry per expert index; ``leaf.<i>`` matches expert i in every layer.
+        for expert_index in range(len(module)):
+            targets.add(f"{leaf}.{expert_index}")
+
+    return sorted(targets)
 
 
 def _select_moe_detection_targets(

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -4174,6 +4174,7 @@ def warn_if_zoo_cannot_merge_moe_experts():
     (the LoRA adapter itself still saves and reloads correctly)."""
     try:
         from unsloth_zoo import saving_utils as _saving_utils
+
         # _fold_perexpert_lora_into_fused is the helper that folds these experts.
         if hasattr(_saving_utils, "_fold_perexpert_lora_into_fused"):
             return

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -3331,6 +3331,18 @@ class FastLlamaModel:
         if target_parameters is None:
             target_parameters = get_moe_target_parameters(model, target_modules)
 
+        # Per-expert Linear expert layouts (e.g. gpt-oss bnb-4bit) are Linear modules,
+        # not fused Parameters, so target them via target_modules. No-op otherwise.
+        _moe_module_targets = get_moe_target_modules(model, target_modules)
+        if _moe_module_targets:
+            _added = [t for t in _moe_module_targets if t not in final_modules]
+            final_modules.extend(_added)
+            if _added:
+                print(
+                    f"Unsloth: Detected MoE model with per-expert Linear experts. "
+                    f"Enabling LoRA on {len(_added)} expert projection modules."
+                )
+
         if finetune_last_n_layers is not None and layers_to_transform is None:
             from .vision import _get_total_transformer_layers
             _total_layers = _get_total_transformer_layers(model)

--- a/unsloth/models/llama.py
+++ b/unsloth/models/llama.py
@@ -3105,6 +3105,11 @@ class FastLlamaModel:
             new_target_modules = list(target_modules) + list(
                 modules_to_save if modules_to_save is not None else []
             )
+            # Per-expert Linear MoE experts (e.g. gpt-oss bnb-4bit) were auto-added to the
+            # saved target_modules when the adapter was first created. Recompute them so a
+            # repeat get_peft_model call with the same args stays idempotent instead of
+            # tripping the mismatch below. No-op for non per-expert-Linear models.
+            new_target_modules += get_moe_target_modules(model, target_modules)
 
             # Now check!
             new_target_modules = set(new_target_modules)
@@ -3342,6 +3347,7 @@ class FastLlamaModel:
                     f"Unsloth: Detected MoE model with per-expert Linear experts. "
                     f"Enabling LoRA on {len(_added)} expert projection modules."
                 )
+                warn_if_zoo_cannot_merge_moe_experts()
 
         if finetune_last_n_layers is not None and layers_to_transform is None:
             from .vision import _get_total_transformer_layers

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1807,6 +1807,34 @@ class FastBaseModel:
             )
             target_parameters = get_moe_target_parameters(model, _moe_targets)
 
+        # Per-expert Linear expert layouts (e.g. gpt-oss bnb-4bit) target experts via
+        # target_modules, not fused Parameters. Extend either form PEFT accepts: a leaf
+        # list (explicit) or a regex string (auto / all-linear / scoped). No-op otherwise.
+        _moe_module_detect = _select_moe_detection_targets(
+            _moe_detect_target,
+            target_modules,
+            finetune_mlp_modules = finetune_mlp_modules,
+            finetune_language_layers = finetune_language_layers,
+        )
+        _moe_module_targets = get_moe_target_modules(model, _moe_module_detect)
+        if _moe_module_targets:
+            if isinstance(target_modules, (list, tuple)):
+                target_modules = list(target_modules) + [
+                    target for target in _moe_module_targets if target not in target_modules
+                ]
+            elif isinstance(target_modules, str):
+                _expert_leaves = sorted({t.rsplit(".", 1)[0] for t in _moe_module_targets})
+                _expert_alt = (
+                    r".*\.experts\.(?:"
+                    + "|".join(re.escape(leaf) for leaf in _expert_leaves)
+                    + r")\.\d+"
+                )
+                target_modules = f"(?:{target_modules})|(?:{_expert_alt})"
+            print(
+                f"Unsloth: Detected MoE model with per-expert Linear experts. "
+                f"Enabling LoRA on {len(_moe_module_targets)} expert projection modules."
+            )
+
         if finetune_last_n_layers is not None and layers_to_transform is None:
             _total_layers = _get_total_transformer_layers(model)
             if _total_layers is not None and _total_layers > 0:

--- a/unsloth/models/vision.py
+++ b/unsloth/models/vision.py
@@ -1834,6 +1834,7 @@ class FastBaseModel:
                 f"Unsloth: Detected MoE model with per-expert Linear experts. "
                 f"Enabling LoRA on {len(_moe_module_targets)} expert projection modules."
             )
+            warn_if_zoo_cannot_merge_moe_experts()
 
         if finetune_last_n_layers is not None and layers_to_transform is None:
             _total_layers = _get_total_transformer_layers(model)


### PR DESCRIPTION
## Summary

`get_moe_target_parameters` hands PEFT the fused expert `nn.Parameter`s (`mlp.experts.gate_up_proj` / `down_proj`) as `target_parameters`. Some quantized checkpoints have no fused expert Parameter at all: gpt-oss bnb-4bit stores its experts as a per-expert `Linear4bit` ModuleList (`mlp.experts.gate_up_projs.<i>` / `down_projs.<i>`). Those experts matched neither the fused `target_parameters` path nor the plain `gate_proj` / `up_proj` / `down_proj` leaf names, so LoRA attached to attention only and left every expert frozen, while still printing "Enabling LoRA on MoE parameters".

## Fix

Keep the honest gating and additionally attach the per-expert experts so they actually train:

- `_moe_parameter_exists(model, name)`: gate each fused expert name on a matching parameter actually existing, so we never hand PEFT a dead `target_parameters` path or print a misleading "Enabling LoRA on MoE parameters" line.
- `get_moe_target_modules(model, target_modules)`: the module-LoRA counterpart of `get_moe_target_parameters`. It detects per-expert `nn.Linear` ModuleLists under an `experts` container and returns their suffix `target_modules` (`gate_up_projs.<i>` / `down_projs.<i>`), so PEFT attaches LoRA to every expert Linear via ordinary suffix matching.
- `get_peft_model` (llama.py and vision.py) extends `target_modules` with these, handling both the explicit leaf-list form and the regex form (auto / all-linear / scoped). Gated on the same MLP-in-scope condition as the parameter path, so an attention-only request still skips the experts.

`get_moe_target_modules` returns an empty list for non-MoE models, fused-parameter MoEs (Qwen3 / Mixtral / LFM2 / BF16 gpt-oss, handled by `get_moe_target_parameters`), and absent per-expert layouts, so nothing else changes.

## Validation

gpt-oss-20b-unsloth-bnb-4bit (transformers 5.5.0): experts attach (3072 modules, trainable 1.65 percent). A memorize overfit trains and the LoRA adapter reloads exactly in a fresh process (teacher-forced CE 4e-6). No regression: fused-parameter MoEs (Qwen3-30B-A3B-4bit), non-MoE models, and attention-only requests are unaffected (`get_moe_target_modules` returns `[]`).

Folding these per-expert adapters into a `merged_16bit` checkpoint is handled by the companion PR unslothai/unsloth-zoo#885. With both, the LoRA adapter and the merged_16bit checkpoint reload the trained behaviour identically.

This replaces the honest-gating-only version this PR previously carried: the per-expert Linear4bit layout is now attached and trained rather than left frozen.
