### PR TITLE
Fix OpenClaw start default to local TUI

### DIFF
--- a/.github/scripts/agent-guides-drive.sh
+++ b/.github/scripts/agent-guides-drive.sh
@@ -376,7 +376,7 @@ case "$MODE" in
       hermes)   patch_hermes_tools none
                 invoke_via_connect "$OUT" -z "$PROMPT" ;;
       openclaw) patch_openclaw_agent notools
-                invoke_via_connect "$OUT" agent --local --agent ci \
+                CONNECT_CMD_OVERRIDE=openclaw invoke_via_connect "$OUT" agent --local --agent ci \
                   --model "unsloth/${UNSLOTH_MODEL_ID}" --message "$PROMPT" ;;
       *)        invoke_via_connect "$OUT" "$PROMPT" ;;
     esac
@@ -449,7 +449,7 @@ case "$MODE" in
           fi ;;
         opencode) invoke_via_connect "$out" run "$prompt" ;;
         hermes)   invoke_via_connect "$out" -z "$prompt" ;;
-        openclaw) invoke_via_connect "$out" agent --local --agent ci \
+        openclaw) CONNECT_CMD_OVERRIDE=openclaw invoke_via_connect "$out" agent --local --agent ci \
                     --model "unsloth/${UNSLOTH_MODEL_ID}" --message "$prompt" ;;
         *)        invoke_via_connect "$out" "$prompt" ;;
       esac

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1415,8 +1415,15 @@ def openclaw(
         launch = launch,
     )
     openclaw_args = list(ctx.args)
-    if not openclaw_args or openclaw_args[0].startswith("-"):
-        openclaw_args = ["tui", "--local", *openclaw_args]
+    # Default a bare `unsloth start openclaw` to the local TUI. Anything the caller
+    # passes through is forwarded verbatim so OpenClaw parses it under its own grammar
+    # (openclaw [global-flags] <command> [options]): an explicit subcommand, a global
+    # flag that must precede the command such as --profile/--dev, or a tui option. We
+    # cannot reinterpret those safely because a leading "--flag value" is ambiguous
+    # between a global (`--profile test`) and a tui option (`--message hi`); prepending
+    # `tui --local` would break the global form, so only the empty case is defaulted.
+    if not openclaw_args:
+        openclaw_args = ["tui", "--local"]
     command = ["openclaw", *openclaw_args]
     install_hint = (
         "iwr -useb https://openclaw.ai/install.ps1 | iex"

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1414,7 +1414,11 @@ def openclaw(
         serve = serve,
         launch = launch,
     )
-    command = ["openclaw", *ctx.args]
+    # Bare `openclaw` now opens Crestodian/setup on current OpenClaw builds.
+    # Launch the normal local TUI by default while still honoring explicit
+    # subcommands such as `crestodian`, `agent`, or a custom `tui ...`.
+    openclaw_args = list(ctx.args) or ["tui", "--local"]
+    command = ["openclaw", *openclaw_args]
     install_hint = (
         "iwr -useb https://openclaw.ai/install.ps1 | iex"
         if os.name == "nt"

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1414,10 +1414,9 @@ def openclaw(
         serve = serve,
         launch = launch,
     )
-    # Bare `openclaw` now opens Crestodian/setup on current OpenClaw builds.
-    # Launch the normal local TUI by default while still honoring explicit
-    # subcommands such as `crestodian`, `agent`, or a custom `tui ...`.
-    openclaw_args = list(ctx.args) or ["tui", "--local"]
+    openclaw_args = list(ctx.args)
+    if not openclaw_args or openclaw_args[0].startswith("-"):
+        openclaw_args = ["tui", "--local", *openclaw_args]
     command = ["openclaw", *openclaw_args]
     install_hint = (
         "iwr -useb https://openclaw.ai/install.ps1 | iex"

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1365,8 +1365,15 @@ def test_connect_openclaw_no_launch(fake_studio, tmp_path):
     config = json.loads(config_path.read_text())
     assert config["models"]["providers"]["unsloth"]["apiKey"] == "sk-unsloth-feedfacefeedface"
     assert config["agents"]["defaults"]["model"]["primary"] == f"unsloth/{MODEL['id']}"
+    assert _launch_command(result.output) == ["openclaw", "tui", "--local"]
     # OpenAI /v1/chat/completions works on either backend — no GGUF gate.
     assert not any(c[1].endswith("/api/inference/status") for c in fake_studio)
+
+
+def test_connect_openclaw_no_launch_keeps_explicit_subcommand(fake_studio):
+    result = CliRunner().invoke(start.start_app, ["openclaw", "--no-launch", "crestodian"])
+    assert result.exit_code == 0, result.output
+    assert _launch_command(result.output) == ["openclaw", "crestodian"]
 
 
 # ── OpenCode (OpenAI /v1/chat/completions) ───────────────────────────

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1376,10 +1376,13 @@ def test_connect_openclaw_no_launch_keeps_explicit_subcommand(fake_studio):
     assert _launch_command(result.output) == ["openclaw", "crestodian"]
 
 
-def test_connect_openclaw_no_launch_option_args_use_default_tui(fake_studio):
-    result = CliRunner().invoke(start.start_app, ["openclaw", "--no-launch", "--message", "hi"])
+def test_connect_openclaw_no_launch_passes_global_flags_through(fake_studio):
+    # OpenClaw globals (openclaw [--dev] [--profile <name>] <command>) precede the
+    # command, and tui does not accept them, so any passthrough args must be forwarded
+    # verbatim rather than rewritten into `openclaw tui --local <globals>`.
+    result = CliRunner().invoke(start.start_app, ["openclaw", "--no-launch", "--profile", "test"])
     assert result.exit_code == 0, result.output
-    assert _launch_command(result.output) == ["openclaw", "tui", "--local", "--message", "hi"]
+    assert _launch_command(result.output) == ["openclaw", "--profile", "test"]
 
 
 def test_connect_openclaw_no_launch_keeps_explicit_tui(fake_studio):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1376,6 +1376,18 @@ def test_connect_openclaw_no_launch_keeps_explicit_subcommand(fake_studio):
     assert _launch_command(result.output) == ["openclaw", "crestodian"]
 
 
+def test_connect_openclaw_no_launch_option_args_use_default_tui(fake_studio):
+    result = CliRunner().invoke(start.start_app, ["openclaw", "--no-launch", "--message", "hi"])
+    assert result.exit_code == 0, result.output
+    assert _launch_command(result.output) == ["openclaw", "tui", "--local", "--message", "hi"]
+
+
+def test_connect_openclaw_no_launch_keeps_explicit_tui(fake_studio):
+    result = CliRunner().invoke(start.start_app, ["openclaw", "--no-launch", "tui", "--message", "hi"])
+    assert result.exit_code == 0, result.output
+    assert _launch_command(result.output) == ["openclaw", "tui", "--message", "hi"]
+
+
 # ── OpenCode (OpenAI /v1/chat/completions) ───────────────────────────
 
 

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1383,7 +1383,9 @@ def test_connect_openclaw_no_launch_option_args_use_default_tui(fake_studio):
 
 
 def test_connect_openclaw_no_launch_keeps_explicit_tui(fake_studio):
-    result = CliRunner().invoke(start.start_app, ["openclaw", "--no-launch", "tui", "--message", "hi"])
+    result = CliRunner().invoke(
+        start.start_app, ["openclaw", "--no-launch", "tui", "--message", "hi"]
+    )
     assert result.exit_code == 0, result.output
     assert _launch_command(result.output) == ["openclaw", "tui", "--message", "hi"]
 


### PR DESCRIPTION
﻿## Summary

- Launch OpenClaw's normal local TUI by default from `unsloth start openclaw`.
- Preserve explicit OpenClaw subcommands passed by the user.
- Add no-launch regression coverage for the default and explicit-subcommand paths.

## Root Cause

Current OpenClaw builds can route bare `openclaw` to Crestodian/setup mode. `unsloth start openclaw` used the bare command, so a successful Unsloth model connection could still open Crestodian instead of the normal coding-agent TUI. Launching `openclaw tui --local` selects the expected main local agent directly.

## Validation

- User-confirmed manual WSL test: patched command opens `openclaw tui - local embedded - agent main` with the Unsloth model.
- `python -m py_compile unsloth_cli/commands/start.py unsloth_cli/tests/test_start.py`
- `git diff --check`
- Targeted OpenClaw pytest: 4 passed
