### PR TITLE
GRPO: default router_aux_loss_coef to 0 on TRL >= 1.7.0

### DIFF
--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -1370,6 +1370,9 @@ def _patch_trl_rl_trainers_impl(trainer_file = "grpo_trainer"):
             # [TODO] See https://fengyao.notion.site/off-policy-rl
             # https://github.com/huggingface/trl/pull/3867 (August 7th)
             "vllm_importance_sampling_correction": False,
+            # TRL >= 1.7.0 enables the MoE router aux loss by default (0.001); the optimized
+            # GRPO forward does not compute it, so default off. Opt in via router_aux_loss_coef > 0.
+            "router_aux_loss_coef": 0.0,
         }
         for k, v in replacements.items():
             x = f"{k}( = [^,\n]{{1,}})?,\n"


### PR DESCRIPTION
## Summary

Default `router_aux_loss_coef` to 0 for GRPO on TRL >= 1.7.0.

TRL 1.7.0 added the MoE router load-balancing auxiliary loss to GRPO and enables it by default: `router_aux_loss_coef` defaults to `0.001`, and the trainer sets `aux_loss_enabled = is_moe and router_aux_loss_coef != 0.0`, so it is on for any MoE model. Unsloth's optimized GRPO forward returns hidden states and does not compute the reduced `aux_loss`. Rather than add or log a placeholder value, this defaults the coefficient to 0 so the term is genuinely off, matching every pre-1.7.0 release. Users who want it can still opt in with `router_aux_loss_coef > 0`.

This reuses the existing GRPO config-default override block in `_patch_trl_rl_trainers_impl` (next to `beta`, `loss_type`, etc.), so it is scoped to `grpo_trainer` only and is a no-op on TRL < 1.7.0 where the argument does not exist.

## Testing

Verified on TRL 1.7.1 (tiny Qwen3-MoE) and TRL 0.25.1:

- GRPO default: `router_aux_loss_coef=0.0`, `aux_loss_enabled=False`, trains, no aux metric.
- GRPO opt-in (`router_aux_loss_coef=0.01`): `aux_loss_enabled=True`, trains without error.
- SFT and DPO train unchanged.
- No-op on TRL < 1.7.0.

Related to #6904 (GRPO support for TRL >= 1.7.0), which carries the accompanying crash fixes.
