### PR TITLE
Fix FastSentenceTransformer Qwen embedding preprocessing

### DIFF
--- a/tests/python/test_fast_sentence_transformer_embedding_parity.py
+++ b/tests/python/test_fast_sentence_transformer_embedding_parity.py
@@ -79,23 +79,27 @@ def test_fast_sentence_transformer_matches_stock_st():
 
     # Control FIRST, before importing unsloth, so its global import patches never
     # touch the stock reference (mirrors the issue's "restart runtime" repro).
-    ctrl = SentenceTransformer(model_id, device=device, model_kwargs={"torch_dtype": dtype})
+    ctrl = SentenceTransformer(model_id, device = device, model_kwargs = {"torch_dtype": dtype})
     ctrl.max_seq_length = max_seq_length
     ctrl_ids = ctrl.tokenize([texts[0]])["input_ids"][0].tolist()
-    ctrl_emb = np.asarray(ctrl.encode(texts, normalize_embeddings=True, batch_size=8), dtype=np.float32)
+    ctrl_emb = np.asarray(
+        ctrl.encode(texts, normalize_embeddings = True, batch_size = 8), dtype = np.float32
+    )
 
     import unsloth  # noqa: F401
     from unsloth import FastSentenceTransformer
 
     fast = FastSentenceTransformer.from_pretrained(
         model_id,
-        max_seq_length=max_seq_length,
-        dtype=dtype,
-        load_in_4bit=False,
-        load_in_16bit=use_cuda,
+        max_seq_length = max_seq_length,
+        dtype = dtype,
+        load_in_4bit = False,
+        load_in_16bit = use_cuda,
     )
     fast_ids = fast.tokenize([texts[0]])["input_ids"][0].tolist()
-    fast_emb = np.asarray(fast.encode(texts, normalize_embeddings=True, batch_size=8), dtype=np.float32)
+    fast_emb = np.asarray(
+        fast.encode(texts, normalize_embeddings = True, batch_size = 8), dtype = np.float32
+    )
 
     # Identical tokenization = no chat-template wrapping slipped in (the #6881 defect).
     assert fast_ids == ctrl_ids, (
@@ -104,7 +108,7 @@ def test_fast_sentence_transformer_matches_stock_st():
     )
 
     cos = (ctrl_emb * fast_emb).sum(1) / (
-        np.linalg.norm(ctrl_emb, axis=1) * np.linalg.norm(fast_emb, axis=1)
+        np.linalg.norm(ctrl_emb, axis = 1) * np.linalg.norm(fast_emb, axis = 1)
     )
     assert float(cos.min()) > 0.99, (
         f"embedding parity regressed: min cosine {float(cos.min()):.5f} <= 0.99 "

--- a/tests/python/test_fast_sentence_transformer_embedding_parity.py
+++ b/tests/python/test_fast_sentence_transformer_embedding_parity.py
@@ -25,8 +25,10 @@ import pytest
 
 
 def test_transformer_load_signature_supports_unsloth_kwargs():
-    """Forwards-compat tripwire on the installed ST: Transformer.load must stay a
-    callable that accepts the hub kwargs the fix passes (or grow **kwargs)."""
+    """Forwards-compat tripwire: when the installed Transformer.load is the modern
+    Hub-capable variant, it must accept the kwargs the #6881 fix passes. Legacy ST
+    3.x/4.x expose load(input_path); the production path treats that as non-Hub-capable
+    and falls back to Transformer(...), so mirror that gate and skip there."""
     models = pytest.importorskip("sentence_transformers.models")
     load = getattr(models.Transformer, "load", None)
     assert callable(load), (
@@ -35,6 +37,12 @@ def test_transformer_load_signature_supports_unsloth_kwargs():
     )
     params = inspect.signature(load).parameters
     accepts_var_kw = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+    # Mirror _create_transformer_module's hub_capable gate.
+    hub_capable = accepts_var_kw or any(k in params for k in ("token", "cache_folder", "revision"))
+    if not hub_capable:
+        pytest.skip(
+            "legacy Transformer.load(input_path); production path falls back to Transformer(...)"
+        )
     unsupported = [
         k
         for k in ("token", "cache_folder", "revision", "trust_remote_code")

--- a/tests/python/test_fast_sentence_transformer_embedding_parity.py
+++ b/tests/python/test_fast_sentence_transformer_embedding_parity.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team.
+"""Regression guard for issue #6881: FastSentenceTransformer must preprocess text
+exactly like a stock SentenceTransformer for decoder embedding models.
+
+sentence-transformers 5.x infers a "message" modality for models whose tokenizer
+has a chat template (e.g. Qwen/Qwen3-Embedding), so building the module through
+`Transformer(model_name, ...)` chat-wraps plain inputs and silently degrades
+embeddings. `_create_transformer_module` builds through `Transformer.load(...)`
+instead, matching stock ST.
+
+Two layers:
+  * test_transformer_load_signature_supports_unsloth_kwargs - fast, runs wherever
+    sentence_transformers is importable; fails if ST drops the kwargs the fix passes.
+  * test_fast_sentence_transformer_matches_stock_st - end-to-end parity; opt-in via
+    UNSLOTH_EMBEDDING_PARITY_MODEL (a HF id or local path), so default CI is unaffected.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+
+import pytest
+
+
+def test_transformer_load_signature_supports_unsloth_kwargs():
+    """Forwards-compat tripwire on the installed ST: Transformer.load must stay a
+    callable that accepts the hub kwargs the fix passes (or grow **kwargs)."""
+    models = pytest.importorskip("sentence_transformers.models")
+    load = getattr(models.Transformer, "load", None)
+    assert callable(load), (
+        "sentence_transformers Transformer.load is missing; the #6881 fix in "
+        "unsloth.models.sentence_transformer._create_transformer_module depends on it."
+    )
+    params = inspect.signature(load).parameters
+    accepts_var_kw = any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+    unsupported = [
+        k
+        for k in ("token", "cache_folder", "revision", "trust_remote_code")
+        if not (accepts_var_kw or k in params)
+    ]
+    assert not unsupported, (
+        f"installed sentence_transformers Transformer.load no longer accepts {unsupported} "
+        f"and has no **kwargs; update _create_transformer_module (#6881) before it silently "
+        f"falls back to Transformer(...)."
+    )
+
+
+def _probe_texts():
+    return [
+        "roasted chickpeas in 20 kg bags",
+        "The capital of France is Paris.",
+        "A fast brown fox jumps over the lazy dog.",
+        "recette de tarte aux pommes traditionnelle",
+    ]
+
+
+def test_fast_sentence_transformer_matches_stock_st():
+    """End-to-end: FastSentenceTransformer embeddings and tokenization must match a
+    stock SentenceTransformer load of the same checkpoint. Opt-in (needs a model)."""
+    model_id = os.environ.get("UNSLOTH_EMBEDDING_PARITY_MODEL")
+    if not model_id:
+        pytest.skip(
+            "set UNSLOTH_EMBEDDING_PARITY_MODEL to a chat-template embedding model "
+            "(HF id or local path) to run the #6881 parity test"
+        )
+
+    torch = pytest.importorskip("torch")
+    np = pytest.importorskip("numpy")
+    pytest.importorskip("sentence_transformers")
+    from sentence_transformers import SentenceTransformer
+
+    use_cuda = torch.cuda.is_available()
+    device = "cuda" if use_cuda else "cpu"
+    dtype = torch.float16 if use_cuda else torch.float32
+    texts = _probe_texts()
+    max_seq_length = 256
+
+    # Control FIRST, before importing unsloth, so its global import patches never
+    # touch the stock reference (mirrors the issue's "restart runtime" repro).
+    ctrl = SentenceTransformer(model_id, device=device, model_kwargs={"torch_dtype": dtype})
+    ctrl.max_seq_length = max_seq_length
+    ctrl_ids = ctrl.tokenize([texts[0]])["input_ids"][0].tolist()
+    ctrl_emb = np.asarray(ctrl.encode(texts, normalize_embeddings=True, batch_size=8), dtype=np.float32)
+
+    import unsloth  # noqa: F401
+    from unsloth import FastSentenceTransformer
+
+    fast = FastSentenceTransformer.from_pretrained(
+        model_id,
+        max_seq_length=max_seq_length,
+        dtype=dtype,
+        load_in_4bit=False,
+        load_in_16bit=use_cuda,
+    )
+    fast_ids = fast.tokenize([texts[0]])["input_ids"][0].tolist()
+    fast_emb = np.asarray(fast.encode(texts, normalize_embeddings=True, batch_size=8), dtype=np.float32)
+
+    # Identical tokenization = no chat-template wrapping slipped in (the #6881 defect).
+    assert fast_ids == ctrl_ids, (
+        f"tokenization diverged (chat-template wrapping regressed?):\n"
+        f"  stock: {ctrl_ids}\n  fast:  {fast_ids}"
+    )
+
+    cos = (ctrl_emb * fast_emb).sum(1) / (
+        np.linalg.norm(ctrl_emb, axis=1) * np.linalg.norm(fast_emb, axis=1)
+    )
+    assert float(cos.min()) > 0.99, (
+        f"embedding parity regressed: min cosine {float(cos.min()):.5f} <= 0.99 "
+        f"(per-text {[round(float(c), 5) for c in cos]})"
+    )

--- a/tests/python/test_fast_sentence_transformer_embedding_parity.py
+++ b/tests/python/test_fast_sentence_transformer_embedding_parity.py
@@ -77,7 +77,9 @@ def test_fast_sentence_transformer_matches_stock_st():
     from sentence_transformers import SentenceTransformer
 
     device = "cuda"
-    dtype = torch.float16
+    # Prefer bf16 when the GPU supports it: fp16 overflows to NaN on bf16-native
+    # embedders such as EmbeddingGemma (Gemma3), which would mask real parity.
+    dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
     texts = _probe_texts()
     max_seq_length = 256
 

--- a/tests/python/test_fast_sentence_transformer_embedding_parity.py
+++ b/tests/python/test_fast_sentence_transformer_embedding_parity.py
@@ -60,7 +60,8 @@ def _probe_texts():
 
 def test_fast_sentence_transformer_matches_stock_st():
     """End-to-end: FastSentenceTransformer embeddings and tokenization must match a
-    stock SentenceTransformer load of the same checkpoint. Opt-in (needs a model)."""
+    stock SentenceTransformer load of the same checkpoint. Opt-in (needs a model) and
+    GPU-only (FastSentenceTransformer requires CUDA), so it skips on CPU-only runners."""
     model_id = os.environ.get("UNSLOTH_EMBEDDING_PARITY_MODEL")
     if not model_id:
         pytest.skip(
@@ -69,13 +70,14 @@ def test_fast_sentence_transformer_matches_stock_st():
         )
 
     torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("FastSentenceTransformer requires CUDA; skipping on CPU-only runner")
     np = pytest.importorskip("numpy")
     pytest.importorskip("sentence_transformers")
     from sentence_transformers import SentenceTransformer
 
-    use_cuda = torch.cuda.is_available()
-    device = "cuda" if use_cuda else "cpu"
-    dtype = torch.float16 if use_cuda else torch.float32
+    device = "cuda"
+    dtype = torch.float16
     texts = _probe_texts()
     max_seq_length = 256
 
@@ -96,7 +98,7 @@ def test_fast_sentence_transformer_matches_stock_st():
         max_seq_length = max_seq_length,
         dtype = dtype,
         load_in_4bit = False,
-        load_in_16bit = use_cuda,
+        load_in_16bit = True,
     )
     fast_ids = fast.tokenize([texts[0]])["input_ids"][0].tolist()
     fast_emb = np.asarray(

--- a/tests/python/test_fast_sentence_transformer_embedding_parity.py
+++ b/tests/python/test_fast_sentence_transformer_embedding_parity.py
@@ -1,19 +1,14 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team.
 """Regression guard for issue #6881: FastSentenceTransformer must preprocess text
-exactly like a stock SentenceTransformer for decoder embedding models.
+like a stock SentenceTransformer for decoder embedding models. ST 5.x infers a
+"message" modality for chat-template models (e.g. Qwen/Qwen3-Embedding), so building
+via `Transformer(model_name, ...)` chat-wraps inputs and degrades embeddings;
+`_create_transformer_module` uses `Transformer.load(...)` instead.
 
-sentence-transformers 5.x infers a "message" modality for models whose tokenizer
-has a chat template (e.g. Qwen/Qwen3-Embedding), so building the module through
-`Transformer(model_name, ...)` chat-wraps plain inputs and silently degrades
-embeddings. `_create_transformer_module` builds through `Transformer.load(...)`
-instead, matching stock ST.
-
-Two layers:
-  * test_transformer_load_signature_supports_unsloth_kwargs - fast, runs wherever
-    sentence_transformers is importable; fails if ST drops the kwargs the fix passes.
-  * test_fast_sentence_transformer_matches_stock_st - end-to-end parity; opt-in via
-    UNSLOTH_EMBEDDING_PARITY_MODEL (a HF id or local path), so default CI is unaffected.
+Layers: test_transformer_load_signature_supports_unsloth_kwargs (fast, runs when ST
+is importable) and test_fast_sentence_transformer_matches_stock_st (end-to-end parity,
+opt-in via UNSLOTH_EMBEDDING_PARITY_MODEL so default CI is unaffected).
 """
 
 from __future__ import annotations
@@ -25,10 +20,9 @@ import pytest
 
 
 def test_transformer_load_signature_supports_unsloth_kwargs():
-    """Forwards-compat tripwire: when the installed Transformer.load is the modern
-    Hub-capable variant, it must accept the kwargs the #6881 fix passes. Legacy ST
-    3.x/4.x expose load(input_path); the production path treats that as non-Hub-capable
-    and falls back to Transformer(...), so mirror that gate and skip there."""
+    """Forwards-compat tripwire: a Hub-capable Transformer.load must accept the kwargs
+    the #6881 fix passes. Legacy ST 3.x/4.x expose load(input_path); the code falls back
+    to Transformer(...) there, so mirror that gate and skip."""
     models = pytest.importorskip("sentence_transformers.models")
     load = getattr(models.Transformer, "load", None)
     assert callable(load), (

--- a/tests/version_compat/test_sentence_transformers_pinned_symbols.py
+++ b/tests/version_compat/test_sentence_transformers_pinned_symbols.py
@@ -125,13 +125,10 @@ def test_st_transformer_base_class_either_path(tag: str):
 # Transformer.load classmethod: unsloth builds saved-ST modules through it (#6881).
 @pytest.mark.parametrize("tag", ST_TAGS)
 def test_st_transformer_load_accepts_unsloth_kwargs(tag: str):
-    """`_create_transformer_module` builds saved ST models via Transformer.load(...)
-    so the saved module config (incl. ST 5.x modality_config) is honored; otherwise
-    ST 5.x infers a 'message' modality for chat-template embedders (e.g.
-    Qwen3-Embedding) and silently chat-wraps inputs (#6881). If .load stops accepting
-    the hub kwargs unsloth passes (and grows no **kwargs), the fix must be updated
-    before it silently regresses. Not locating .load here is a SKIP (it may be
-    inherited); the live signature test guards the installed version."""
+    """unsloth builds saved ST models via Transformer.load(...) so the saved
+    modality_config is honored (#6881). If .load stops accepting the hub kwargs it
+    passes (and has no **kwargs), update the fix before it silently regresses. Not
+    locating .load is a SKIP (may be inherited); the live test guards the install."""
     candidates = [
         "sentence_transformers/models/Transformer.py",
         "sentence_transformers/models/transformer.py",

--- a/tests/version_compat/test_sentence_transformers_pinned_symbols.py
+++ b/tests/version_compat/test_sentence_transformers_pinned_symbols.py
@@ -19,6 +19,8 @@ ST_TAGS = [
     "v5.2.3",
     "v5.3.0",
     "v5.4.1",
+    "v5.5.1",
+    "v5.6.0",
     "master",
 ]
 
@@ -118,6 +120,45 @@ def test_st_transformer_base_class_either_path(tag: str):
         f"unsloth's three-path probe in sentence_transformer.py:1169-1171 "
         f"will ImportError on every fallback"
     )
+
+
+# Transformer.load classmethod: unsloth builds saved-ST modules through it (#6881).
+@pytest.mark.parametrize("tag", ST_TAGS)
+def test_st_transformer_load_accepts_unsloth_kwargs(tag: str):
+    """`_create_transformer_module` builds saved ST models via Transformer.load(...)
+    so the saved module config (incl. ST 5.x modality_config) is honored; otherwise
+    ST 5.x infers a 'message' modality for chat-template embedders (e.g.
+    Qwen3-Embedding) and silently chat-wraps inputs (#6881). If .load stops accepting
+    the hub kwargs unsloth passes (and grows no **kwargs), the fix must be updated
+    before it silently regresses. Not locating .load here is a SKIP (it may be
+    inherited); the live signature test guards the installed version."""
+    candidates = [
+        "sentence_transformers/models/Transformer.py",
+        "sentence_transformers/models/transformer.py",
+        "sentence_transformers/base/modules/transformer.py",
+        "sentence_transformers/base/modules/module.py",
+    ]
+    for p in candidates:
+        src = fetch_text("UKPLab/sentence-transformers", tag, p)
+        if src is None or not has_def(src, "load", "func"):
+            continue
+        m = re.search(r"def\s+load\s*\((.*?)\)\s*(?:->[^:]*)?:", src, re.S)
+        if m is None:
+            continue
+        sig = m.group(1)
+        accepts_var_kw = "**" in sig
+        missing = [
+            kw
+            for kw in ("token", "cache_folder", "revision", "trust_remote_code")
+            if not (accepts_var_kw or re.search(rf"\b{re.escape(kw)}\b", sig))
+        ]
+        assert not missing, (
+            f"{tag}: Transformer.load in {p} no longer accepts {missing} and has no "
+            f"**kwargs; update unsloth.models.sentence_transformer._create_transformer_module "
+            f"(#6881) before it silently falls back to Transformer(...)."
+        )
+        return
+    pytest.skip(f"{tag}: Transformer.load not locatable in {candidates} (may be inherited)")
 
 
 # sentence_transformers.util: import_from_string + load_dir_path helpers unsloth calls.

--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -1095,9 +1095,12 @@ class FastSentenceTransformer(FastModel):
                 # still loads. max_seq_length is (re)applied below regardless.
                 transformer_module = None
                 transformer_load = getattr(Transformer, "load", None)
-                has_modules_json = FastSentenceTransformer._module_path(
-                    model_name, token, cache_dir = cache_dir, revision = revision
-                ) is not None
+                has_modules_json = (
+                    FastSentenceTransformer._module_path(
+                        model_name, token, cache_dir = cache_dir, revision = revision
+                    )
+                    is not None
+                )
                 if callable(transformer_load) and has_modules_json:
                     load_params = inspect.signature(transformer_load).parameters
                     accepts_var_kw = any(

--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -1086,15 +1086,12 @@ class FastSentenceTransformer(FastModel):
                 elif "tokenizer_args" in transformer_init_params:
                     transformer_kwargs["tokenizer_args"] = trust_remote_code_kwargs.copy()
 
-                # Saved ST models: build via Transformer.load so the saved module config
-                # (incl. ST 5.x modality_config) is honored; plain Transformer(...) lets ST
-                # 5.x add a "message" modality for chat-template models (e.g. Qwen3-Embedding)
-                # that chat-wraps inputs and silently degrades embeddings (#6881). Use .load
-                # only when it can resolve a Hub id: modern ST accepts these kwargs or has
-                # **kwargs; legacy ST 3.x/4.x is Transformer.load(input_path) (local-only, no
-                # modality bug), so fall back to the constructor there instead of crashing.
-                # Pass only kwargs its signature accepts so a renamed kwarg can't disable the
-                # fix. max_seq_length is (re)applied below regardless.
+                # Build via Transformer.load so the saved modality_config is honored: plain
+                # Transformer(...) makes ST 5.x infer a "message" modality for chat-template
+                # models (e.g. Qwen3-Embedding), chat-wrapping inputs and degrading embeddings
+                # (#6881). Only use .load when it resolves a Hub id (accepts the kwargs or
+                # **kwargs); legacy ST 3.x/4.x load(input_path) is local-only with no modality
+                # bug, so fall back to the constructor.
                 transformer_module = None
                 transformer_load = getattr(Transformer, "load", None)
                 has_modules_json = (

--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -990,7 +990,16 @@ class FastSentenceTransformer(FastModel):
             return None
 
     @staticmethod
-    def _create_transformer_module(model_name, model, tokenizer, max_seq_length, trust_remote_code):
+    def _create_transformer_module(
+        model_name,
+        model,
+        tokenizer,
+        max_seq_length,
+        trust_remote_code,
+        token = None,
+        cache_dir = None,
+        revision = None,
+    ):
         """Helper to create and configure a Transformer module."""
         from sentence_transformers.models import Transformer
 
@@ -1077,7 +1086,28 @@ class FastSentenceTransformer(FastModel):
                 elif "tokenizer_args" in transformer_init_params:
                     transformer_kwargs["tokenizer_args"] = trust_remote_code_kwargs.copy()
 
-                transformer_module = Transformer(model_name, **transformer_kwargs)
+                transformer_load_params = inspect.signature(Transformer.load).parameters
+                can_load_from_hub = all(
+                    key in transformer_load_params
+                    for key in ("token", "cache_folder", "revision", "trust_remote_code")
+                )
+                if (
+                    can_load_from_hub and
+                    FastSentenceTransformer._module_path(
+                        model_name, token, cache_dir = cache_dir, revision = revision
+                    )
+                    is not None
+                ):
+                    transformer_module = Transformer.load(
+                        model_name,
+                        token = token,
+                        cache_folder = cache_dir,
+                        revision = revision,
+                        trust_remote_code = trust_remote_code,
+                        **transformer_kwargs,
+                    )
+                else:
+                    transformer_module = Transformer(model_name, **transformer_kwargs)
             finally:
                 # Restore original Auto* loading immediately
                 AutoModel.from_pretrained = original_model_from_pretrained
@@ -1191,6 +1221,9 @@ class FastSentenceTransformer(FastModel):
                         tokenizer,
                         max_seq_length,
                         trust_remote_code,
+                        token,
+                        cache_dir,
+                        revision,
                     )
                     modules[name] = transformer_module
                 else:
@@ -1226,7 +1259,14 @@ class FastSentenceTransformer(FastModel):
         )
 
         transformer_module = FastSentenceTransformer._create_transformer_module(
-            model_name, model, tokenizer, max_seq_length, trust_remote_code
+            model_name,
+            model,
+            tokenizer,
+            max_seq_length,
+            trust_remote_code,
+            token,
+            cache_dir,
+            revision,
         )
         modules["0"] = transformer_module
 

--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -1089,10 +1089,12 @@ class FastSentenceTransformer(FastModel):
                 # Saved ST models: build via Transformer.load so the saved module config
                 # (incl. ST 5.x modality_config) is honored; plain Transformer(...) lets ST
                 # 5.x add a "message" modality for chat-template models (e.g. Qwen3-Embedding)
-                # that chat-wraps inputs and silently degrades embeddings (#6881). Prefer
-                # .load whenever present, passing only kwargs its signature accepts, so a
-                # renamed kwarg can't silently disable the fix and older ST without .load
-                # still loads. max_seq_length is (re)applied below regardless.
+                # that chat-wraps inputs and silently degrades embeddings (#6881). Use .load
+                # only when it can resolve a Hub id: modern ST accepts these kwargs or has
+                # **kwargs; legacy ST 3.x/4.x is Transformer.load(input_path) (local-only, no
+                # modality bug), so fall back to the constructor there instead of crashing.
+                # Pass only kwargs its signature accepts so a renamed kwarg can't disable the
+                # fix. max_seq_length is (re)applied below regardless.
                 transformer_module = None
                 transformer_load = getattr(Transformer, "load", None)
                 has_modules_json = (
@@ -1106,16 +1108,20 @@ class FastSentenceTransformer(FastModel):
                     accepts_var_kw = any(
                         p.kind is inspect.Parameter.VAR_KEYWORD for p in load_params.values()
                     )
-                    load_kwargs = {
-                        "token": token,
-                        "cache_folder": cache_dir,
-                        "revision": revision,
-                        "trust_remote_code": trust_remote_code,
-                        **transformer_kwargs,
-                    }
-                    if not accepts_var_kw:
-                        load_kwargs = {k: v for k, v in load_kwargs.items() if k in load_params}
-                    transformer_module = Transformer.load(model_name, **load_kwargs)
+                    hub_capable = accepts_var_kw or any(
+                        key in load_params for key in ("token", "cache_folder", "revision")
+                    )
+                    if hub_capable:
+                        load_kwargs = {
+                            "token": token,
+                            "cache_folder": cache_dir,
+                            "revision": revision,
+                            "trust_remote_code": trust_remote_code,
+                            **transformer_kwargs,
+                        }
+                        if not accepts_var_kw:
+                            load_kwargs = {k: v for k, v in load_kwargs.items() if k in load_params}
+                        transformer_module = Transformer.load(model_name, **load_kwargs)
                 if transformer_module is None:
                     transformer_module = Transformer(model_name, **transformer_kwargs)
             finally:

--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -1086,6 +1086,10 @@ class FastSentenceTransformer(FastModel):
                 elif "tokenizer_args" in transformer_init_params:
                     transformer_kwargs["tokenizer_args"] = trust_remote_code_kwargs.copy()
 
+                # Saved ST models: load via Transformer.load to keep the saved module
+                # config. Plain Transformer(...) lets ST 5.x add a "message" modality for
+                # chat-template models (e.g. Qwen3-Embedding), wrapping inputs in the chat
+                # template and silently degrading embeddings (#6881).
                 transformer_load_params = inspect.signature(Transformer.load).parameters
                 can_load_from_hub = all(
                     key in transformer_load_params

--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -1092,8 +1092,8 @@ class FastSentenceTransformer(FastModel):
                     for key in ("token", "cache_folder", "revision", "trust_remote_code")
                 )
                 if (
-                    can_load_from_hub and
-                    FastSentenceTransformer._module_path(
+                    can_load_from_hub
+                    and FastSentenceTransformer._module_path(
                         model_name, token, cache_dir = cache_dir, revision = revision
                     )
                     is not None

--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -999,6 +999,7 @@ class FastSentenceTransformer(FastModel):
         token = None,
         cache_dir = None,
         revision = None,
+        module_subfolder = "",
     ):
         """Helper to create and configure a Transformer module."""
         from sentence_transformers.models import Transformer
@@ -1116,6 +1117,10 @@ class FastSentenceTransformer(FastModel):
                             "trust_remote_code": trust_remote_code,
                             **transformer_kwargs,
                         }
+                        # Resolve config/tokenizer from the module's saved subfolder
+                        # (modules.json "path"), like stock ST; "" (root) is a no-op.
+                        if module_subfolder:
+                            load_kwargs["subfolder"] = module_subfolder
                         if not accepts_var_kw:
                             load_kwargs = {k: v for k, v in load_kwargs.items() if k in load_params}
                         transformer_module = Transformer.load(model_name, **load_kwargs)
@@ -1237,6 +1242,7 @@ class FastSentenceTransformer(FastModel):
                         token,
                         cache_dir,
                         revision,
+                        module_subfolder = module_config.get("path") or "",
                     )
                     modules[name] = transformer_module
                 else:

--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -1086,31 +1086,34 @@ class FastSentenceTransformer(FastModel):
                 elif "tokenizer_args" in transformer_init_params:
                     transformer_kwargs["tokenizer_args"] = trust_remote_code_kwargs.copy()
 
-                # Saved ST models: load via Transformer.load to keep the saved module
-                # config. Plain Transformer(...) lets ST 5.x add a "message" modality for
-                # chat-template models (e.g. Qwen3-Embedding), wrapping inputs in the chat
-                # template and silently degrading embeddings (#6881).
-                transformer_load_params = inspect.signature(Transformer.load).parameters
-                can_load_from_hub = all(
-                    key in transformer_load_params
-                    for key in ("token", "cache_folder", "revision", "trust_remote_code")
-                )
-                if (
-                    can_load_from_hub
-                    and FastSentenceTransformer._module_path(
-                        model_name, token, cache_dir = cache_dir, revision = revision
+                # Saved ST models: build via Transformer.load so the saved module config
+                # (incl. ST 5.x modality_config) is honored; plain Transformer(...) lets ST
+                # 5.x add a "message" modality for chat-template models (e.g. Qwen3-Embedding)
+                # that chat-wraps inputs and silently degrades embeddings (#6881). Prefer
+                # .load whenever present, passing only kwargs its signature accepts, so a
+                # renamed kwarg can't silently disable the fix and older ST without .load
+                # still loads. max_seq_length is (re)applied below regardless.
+                transformer_module = None
+                transformer_load = getattr(Transformer, "load", None)
+                has_modules_json = FastSentenceTransformer._module_path(
+                    model_name, token, cache_dir = cache_dir, revision = revision
+                ) is not None
+                if callable(transformer_load) and has_modules_json:
+                    load_params = inspect.signature(transformer_load).parameters
+                    accepts_var_kw = any(
+                        p.kind is inspect.Parameter.VAR_KEYWORD for p in load_params.values()
                     )
-                    is not None
-                ):
-                    transformer_module = Transformer.load(
-                        model_name,
-                        token = token,
-                        cache_folder = cache_dir,
-                        revision = revision,
-                        trust_remote_code = trust_remote_code,
+                    load_kwargs = {
+                        "token": token,
+                        "cache_folder": cache_dir,
+                        "revision": revision,
+                        "trust_remote_code": trust_remote_code,
                         **transformer_kwargs,
-                    )
-                else:
+                    }
+                    if not accepts_var_kw:
+                        load_kwargs = {k: v for k, v in load_kwargs.items() if k in load_params}
+                    transformer_module = Transformer.load(model_name, **load_kwargs)
+                if transformer_module is None:
                     transformer_module = Transformer(model_name, **transformer_kwargs)
             finally:
                 # Restore original Auto* loading immediately


### PR DESCRIPTION
  ## Summary

  Fixes `FastSentenceTransformer` module construction for saved SentenceTransformers models such as `Qwen/Qwen3-Embedding-0.6B`. The loader now preserves the saved text-only Transformer module config instead of
  letting SentenceTransformers infer Qwen chat/message preprocessing.

  ## Motivation

  `FastSentenceTransformer.from_pretrained("Qwen/Qwen3-Embedding-0.6B")` was producing embeddings that diverged from a plain `SentenceTransformer` load. With SentenceTransformers 5.x, constructing the module
  through `Transformer(...)` can infer Qwen's chat template path, so plain embedding strings get encoded as chat messages.

  Fixes #6881.

  ## Changes

  - In `unsloth/models/sentence_transformer.py`, use `Transformer.load(...)` when the model has `modules.json`.
  - Pass `token`, `cache_dir`, and `revision` into `_create_transformer_module()` so the module loader uses the same Hub/cache context as `_load_modules()`.
  - Keep the direct `Transformer(...)` fallback for non-SentenceTransformers models that do not have `modules.json`.

  ## How to test

  Run a parity check for Qwen3 embeddings:

  ```python
  import numpy as np
  import torch
  from sentence_transformers import SentenceTransformer
  from unsloth import FastSentenceTransformer

  texts = [
      "The capital of France is Paris.",
      "A fast brown fox jumps over the lazy dog.",
      "Qwen embedding models use last token pooling.",
  ]

  plain = SentenceTransformer(
      "Qwen/Qwen3-Embedding-0.6B",
      device="cuda",
      model_kwargs={"torch_dtype": torch.float16},
  )
  fast = FastSentenceTransformer.from_pretrained(
      "Qwen/Qwen3-Embedding-0.6B",
      dtype=torch.float16,
      load_in_4bit=False,
      load_in_16bit=True,
  )

  a = plain.encode(texts, normalize_embeddings=True)
  b = fast.encode(texts, normalize_embeddings=True)

  cos = (a * b).sum(axis=1) / (np.linalg.norm(a, axis=1) * np.linalg.norm(b, axis=1))
  print(cos)
```
  Expected result: cosine values should be near 1.0. In the Colab check for this fix, mean_cos was 0.99999699 and max_abs_diff was 0.000305.