### PR TITLE
Studio: expose core features as a standalone MCP server

### DIFF
--- a/studio/backend/core/export/orchestrator.py
+++ b/studio/backend/core/export/orchestrator.py
@@ -53,6 +53,12 @@ class ExportOrchestrator:
         self.is_vision: bool = False
         self.is_peft: bool = False
 
+        # Last structured error payload from the worker (e.g. a remote-code
+        # consent block carrying the approval fingerprint). Surfaced by status
+        # callers (MCP) that can't see the raw worker response.
+        self.last_error_kind: Optional[str] = None
+        self.last_remote_code: Optional[dict] = None
+
         # Thread-safe ring buffer of worker log lines; powers the export logs SSE endpoint.
         self._log_buffer: Deque[Dict[str, Any]] = deque(maxlen = _LOG_BUFFER_MAXLEN)
         self._log_lock = threading.Lock()
@@ -441,6 +447,10 @@ class ExportOrchestrator:
                     self.current_checkpoint = None
                     self.is_vision = False
                     self.is_peft = False
+                    # Preserve structured payloads (e.g. remote-code consent
+                    # fingerprint) so non-HTTP callers can recover the detail.
+                    self.last_error_kind = resp.get("error_kind")
+                    self.last_remote_code = resp.get("remote_code")
                     op_success, op_message = False, error
                     return False, error
             finally:

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -241,6 +241,12 @@ class TrainingBackend:
         self.current_job_id: Optional[str] = None
         self._output_dir: Optional[str] = None
 
+        # Last structured error payload from the worker (e.g. a remote-code
+        # consent block carrying the approval fingerprint). Surfaced by status
+        # callers (MCP) that otherwise only see the error text.
+        self.last_error_kind: Optional[str] = None
+        self.last_remote_code: Optional[dict] = None
+
         # DB persistence
         self._metric_buffer: list[dict] = []
         self._run_finalized: bool = False
@@ -1039,6 +1045,10 @@ class TrainingBackend:
             elif etype == "error":
                 self._progress.is_training = False
                 self._progress.error = event.get("error", "Unknown error")
+                # Preserve structured payloads (e.g. remote-code consent
+                # fingerprint) so non-HTTP callers can recover the detail.
+                self.last_error_kind = event.get("error_kind")
+                self.last_remote_code = event.get("remote_code")
                 logger.error("Training error: %s", event.get("error"))
                 stack = event.get("stack", "")
                 if stack:

--- a/studio/backend/mcp_server/__init__.py
+++ b/studio/backend/mcp_server/__init__.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Unsloth Studio as a standalone MCP server.
+
+Exposes Studio's core features -- models, datasets, training, export and
+data-recipe (Data Designer) -- as MCP tools so any MCP client (Claude Desktop,
+Cursor, Cline, ...) can drive Unsloth Studio directly.
+
+The server reuses Studio's in-process core layer (the same singletons the
+FastAPI routes use), so it speaks the exact same backend a Studio UI session
+would. Long-running work (training, export, recipe jobs) runs in the existing
+subprocess backends and is surfaced as start / status / stop tools.
+
+Launch via the CLI::
+
+    unsloth studio mcp                       # stdio, all features
+    unsloth studio mcp --enable models data  # read-only subset
+
+See ``studio/backend/mcp_server/server.py`` for the entry points and
+``tools/`` for the per-feature tool implementations.
+"""
+
+from __future__ import annotations
+
+from .server import FEATURE_GROUPS, build_server, run_stdio
+
+__all__ = ["FEATURE_GROUPS", "build_server", "run_stdio"]

--- a/studio/backend/mcp_server/auth.py
+++ b/studio/backend/mcp_server/auth.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Security helpers for the Studio MCP server.
+
+The server runs over **stdio**: a local process spawned by a trusted MCP
+client on the same host as Studio. That mirrors Studio's existing loopback
+stdio-MCP trust model (see ``utils/host_policy.py``), so no bearer-token auth
+is required -- the act of launching ``unsloth studio mcp`` is the opt-in.
+
+Secrets (HuggingFace / Weights & Biases tokens) are resolved from the
+environment only, never logged, and may be overridden per tool call by the
+caller (an agent) where appropriate.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+
+def resolve_secret(env_var: str, override: Optional[str] = None) -> Optional[str]:
+    """Return a secret from an explicit override, else the environment.
+
+    ``override`` (a value passed by the caller/agent) wins, then the named env
+    var. Blank strings are treated as absent so a stray ``HF_TOKEN=`` never
+    shadows a real configured value.
+    """
+    if override and override.strip():
+        return override.strip()
+    env_val = os.environ.get(env_var)
+    if env_val and env_val.strip():
+        return env_val.strip()
+    return None
+
+
+def resolve_hf_token(override: Optional[str] = None) -> Optional[str]:
+    """Resolve a HuggingFace token from ``HF_TOKEN`` / ``HUGGING_FACE_HUB_TOKEN``."""
+    return resolve_secret("HF_TOKEN", override) or resolve_secret(
+        "HUGGING_FACE_HUB_TOKEN", override
+    )
+
+
+# MCP tool hint strings. Surfaced to the client so a human can approve risky
+# calls (training, export, uploads) more deliberately than read-only ones.
+HINT_READ_ONLY = "Read-only: safe to call freely."
+HINT_STATEFUL = "Stateful: starts or mutates a Studio job/resource."
+HINT_LONG_RUNNING = (
+    "Long-running: may take minutes to hours. The call blocks until the "
+    "operation finishes; use the matching *_status tool to poll where available."
+)

--- a/studio/backend/mcp_server/server.py
+++ b/studio/backend/mcp_server/server.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""FastMCP server factory and stdio entry point for the Studio MCP server."""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from fastmcp import FastMCP
+
+from loggers import get_logger
+from .tools import FEATURE_GROUPS, register_all, resolve_groups
+
+logger = get_logger(__name__)
+
+# Re-exported so ``from mcp_server import FEATURE_GROUPS`` works.
+__all__ = ["FEATURE_GROUPS", "build_server", "run_stdio", "list_tools"]
+
+_INSTRUCTIONS = (
+    "Unsloth Studio: fine-tune, export and synthesize datasets for open LLMs. "
+    "Use models_list / models_get_config to pick a model and its recommended "
+    "training defaults, data_list_local / data_check_format to prepare a "
+    "dataset, train_start (then train_status / train_stop) to fine-tune, "
+    "export_* to save a checkpoint to disk (merged / GGUF / LoRA), and "
+    "recipe_* to generate synthetic datasets with Data Designer. "
+    "Training and recipe jobs are asynchronous: start them, then poll the "
+    "matching *_status tool."
+)
+
+
+def build_server(
+    enabled: Optional[Sequence[str]] = None, disabled: Optional[Sequence[str]] = None
+) -> FastMCP:
+    """Build a FastMCP server exposing the selected Studio feature groups.
+
+    ``enabled`` defaults to all groups; ``disabled`` removes from that set.
+    Unknown names raise ``ValueError``.
+    """
+    selected = resolve_groups(enabled, disabled)
+    mcp = FastMCP(name = "unsloth-studio", instructions = _INSTRUCTIONS)
+    names = register_all(mcp, enabled = selected)
+    logger.info(
+        "Studio MCP server built: %d tools across groups [%s]",
+        len(names),
+        ", ".join(selected),
+    )
+    return mcp
+
+
+def run_stdio(
+    enabled: Optional[Sequence[str]] = None, disabled: Optional[Sequence[str]] = None
+) -> None:
+    """Run the Studio MCP server over stdio (blocks until the client disconnects)."""
+    server = build_server(enabled = enabled, disabled = disabled)
+    server.run(transport = "stdio")
+
+
+async def list_tools(
+    enabled: Optional[Sequence[str]] = None, disabled: Optional[Sequence[str]] = None
+) -> list[dict[str, str]]:
+    """Return ``[{name, description, group}]`` for each registered tool.
+
+    Powers the ``unsloth studio mcp list-tools`` dry-run. Uses an in-memory
+    FastMCP client so the reported set always reflects real registration.
+    """
+    from fastmcp import Client
+
+    server = build_server(enabled = enabled, disabled = disabled)
+    from .tools import _REGISTRARS  # intentional internal use (same package)
+
+    group_for_name: dict[str, str] = {}
+    for group in resolve_groups(enabled, disabled):
+        # Register this group into a throwaway server solely to learn which
+        # tool names it owns, then map each back to the group.
+        probe = FastMCP(name = "probe")
+        for name in _REGISTRARS[group](probe):
+            group_for_name[name] = group
+
+    async with Client(server) as client:
+        tools = await client.list_tools()
+    return [
+        {
+            "name": t.name,
+            "description": next(iter((t.description or "").strip().splitlines()), ""),
+            "group": group_for_name.get(t.name, "?"),
+        }
+        for t in tools
+    ]

--- a/studio/backend/mcp_server/tools/__init__.py
+++ b/studio/backend/mcp_server/tools/__init__.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""MCP tool implementations, grouped by Studio feature.
+
+Each module exposes ``register(mcp: FastMCP) -> list[str]`` which mounts that
+feature's tools onto a FastMCP server and returns the tool names it added.
+The handler functions are plain module-level callables so they can be unit
+tested directly (with the backend singletons mocked) without a live MCP
+transport or a GPU.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional, Sequence
+
+from fastmcp import FastMCP
+
+from . import data, export, models, recipe, train
+
+# Ordered (group name -> registrar) so --enable/--disable and the dry-run
+# listing present features in a stable, documented order.
+_REGISTRARS: dict[str, Callable[[FastMCP], list[str]]] = {
+    "models": models.register,
+    "data": data.register,
+    "train": train.register,
+    "export": export.register,
+    "recipe": recipe.register,
+}
+
+FEATURE_GROUPS: list[str] = list(_REGISTRARS.keys())
+
+
+def resolve_groups(
+    enabled: Optional[Sequence[str]] = None, disabled: Optional[Sequence[str]] = None
+) -> list[str]:
+    """Compute the final ordered feature-group list from --enable/--disable.
+
+    Unknown names raise ``ValueError`` so a typo is surfaced to the operator
+    rather than silently enabling everything.
+    """
+    known = set(FEATURE_GROUPS)
+    for name in list(enabled or ()) + list(disabled or ()):
+        if name not in known:
+            raise ValueError(
+                f"Unknown feature group {name!r}. Valid groups: {', '.join(FEATURE_GROUPS)}"
+            )
+
+    selected = set(FEATURE_GROUPS) if enabled is None else set(enabled)
+    selected -= set(disabled or ())
+    return [g for g in FEATURE_GROUPS if g in selected]
+
+
+def register_all(
+    mcp: FastMCP,
+    enabled: Optional[Sequence[str]] = None,
+    disabled: Optional[Sequence[str]] = None,
+) -> list[str]:
+    """Register every selected feature group's tools onto ``mcp``.
+
+    Returns the flattened list of registered tool names (used by the dry-run
+    helper).
+    """
+    names: list[str] = []
+    for group in resolve_groups(enabled, disabled):
+        names.extend(_REGISTRARS[group](mcp))
+    return names

--- a/studio/backend/mcp_server/tools/data.py
+++ b/studio/backend/mcp_server/tools/data.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""MCP tools for Studio's dataset catalog (mostly read-only)."""
+
+from __future__ import annotations
+
+import shutil
+import uuid
+from pathlib import Path
+from typing import Any, Optional
+
+from fastmcp import FastMCP
+
+from loggers import get_logger
+from mcp_server.auth import HINT_READ_ONLY, resolve_hf_token
+
+logger = get_logger(__name__)
+
+GROUP = "data"
+
+_READ_ONLY = {"readOnlyHint": True}
+
+
+def data_list_local() -> dict[str, Any]:
+    """List datasets visible to Studio (uploaded, recipe-generated, and local).
+
+    Returns the same local-dataset listing the Studio UI shows. Use these
+    paths/ids in ``train_start``'s ``local_datasets`` argument.
+    """
+    from hub.services.datasets.local import list_local_datasets_response
+
+    response = list_local_datasets_response()
+    return {"datasets": response.model_dump().get("datasets", [])}
+
+
+def data_check_format(
+    dataset_name: str,
+    is_vlm: bool = False,
+    subset: Optional[str] = None,
+    train_split: str = "train",
+    hf_token: Optional[str] = None,
+) -> dict[str, Any]:
+    """Inspect a dataset's columns and detect its chat format.
+
+    Accepts either a HuggingFace dataset id or a local dataset name/path (as
+    shown by ``data_list_local``). Returns the detected format, columns, and a
+    suggested column mapping when one is needed -- the same check the Studio
+    UI runs before training.
+    """
+    from fastapi import HTTPException
+
+    from hub.schemas.datasets import CheckFormatRequest
+    from hub.services.datasets.formatting import check_format_response
+
+    request = CheckFormatRequest(
+        dataset_name = dataset_name,
+        is_vlm = is_vlm,
+        subset = subset,
+        train_split = train_split,
+    )
+    try:
+        result = check_format_response(request, hf_token = resolve_hf_token(hf_token))
+    except HTTPException as exc:
+        return {"success": False, "error": str(exc.detail)}
+    return {"success": True, **result.model_dump()}
+
+
+def data_register(path: str) -> dict[str, Any]:
+    """Register a local file as a Studio dataset.
+
+    Copies the file at ``path`` (an absolute path on this host -- ``.csv``,
+    ``.json``, ``.jsonl`` or ``.parquet``) into Studio's dataset store so it
+    appears in ``data_list_local`` and can be passed to ``train_start``.
+
+    This is the stdio equivalent of Studio's dataset-upload box.
+    """
+    from hub.services.datasets.local import (
+        DATASET_UPLOAD_DIR,
+        LOCAL_UPLOAD_EXTS,
+        LOCAL_UPLOAD_MAX_BYTES,
+        _sanitize_filename,
+    )
+    from hub.utils.paths import ensure_dir
+
+    src = Path(path).expanduser()
+    if not src.is_file():
+        return {"success": False, "error": f"Not a file: {path}"}
+
+    ext = src.suffix.lower()
+    if ext not in LOCAL_UPLOAD_EXTS:
+        return {
+            "success": False,
+            "error": f"Unsupported file type {ext!r}. Allowed: {sorted(LOCAL_UPLOAD_EXTS)}",
+        }
+
+    size = src.stat().st_size
+    if size > LOCAL_UPLOAD_MAX_BYTES:
+        return {
+            "success": False,
+            "error": f"File too large ({size:,} bytes; max {LOCAL_UPLOAD_MAX_BYTES:,}).",
+        }
+    if size == 0:
+        return {"success": False, "error": "File is empty."}
+
+    display_name = _sanitize_filename(src.name)
+    stored_name = f"{uuid.uuid4().hex}_{Path(display_name).stem}{ext}"
+    ensure_dir(DATASET_UPLOAD_DIR)
+    stored_path = DATASET_UPLOAD_DIR / stored_name
+    try:
+        shutil.copy2(src, stored_path)
+    except OSError as exc:
+        # Remove any partial copy so a failed registration can't leave a
+        # corrupt dataset that data_list_local would later surface (matches
+        # the HTTP upload route's cleanup).
+        stored_path.unlink(missing_ok = True)
+        return {"success": False, "error": f"Failed to copy file: {exc}"}
+
+    logger.info("Registered dataset %s -> %s", path, stored_path)
+    return {"success": True, "filename": display_name, "stored_path": str(stored_path)}
+
+
+def register(mcp: FastMCP) -> list[str]:
+    """Register the data tools onto ``mcp``; return the tool names added."""
+    names: list[str] = []
+    mcp.tool(data_list_local, annotations = _READ_ONLY)
+    names.append("data_list_local")
+    mcp.tool(data_check_format, annotations = _READ_ONLY)
+    names.append("data_check_format")
+    mcp.tool(data_register)
+    names.append("data_register")
+    return names

--- a/studio/backend/mcp_server/tools/export.py
+++ b/studio/backend/mcp_server/tools/export.py
@@ -1,0 +1,387 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""MCP tools for Studio model export.
+
+Export operations (``export_load_checkpoint``, ``export_merged`` /
+``export_gguf`` / ``export_lora``) are **synchronous** and block until the
+operation finishes -- they may take minutes (merged) to hours (multi-quant
+GGUF). They run on the Studio export subprocess, exactly like the Studio UI.
+Use ``export_status`` for the loaded-checkpoint state and ``export_cancel`` to
+abort an in-flight export.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional, Union
+
+from fastmcp import FastMCP
+
+from loggers import get_logger
+from mcp_server.auth import resolve_hf_token
+
+logger = get_logger(__name__)
+
+GROUP = "export"
+
+_READ_ONLY = {"readOnlyHint": True}
+_STATEFUL = {"destructiveHint": False}
+
+# Mirrors the ExportMergedModelRequest Literal in models/export.py.
+_VALID_MERGED_FORMATS = (
+    "16-bit (FP16)",
+    "4-bit (FP4)",
+    "FP8 (compressed-tensors)",
+    "NVFP4 (compressed-tensors)",
+)
+
+# Mirrors LoadCheckpointRequest.max_seq_length bounds in models/export.py.
+_MIN_SEQ_LEN, _MAX_SEQ_LEN = 128, 32768
+
+
+def _save_dir_error(save_directory: str) -> Optional[str]:
+    """Return an error string if ``save_directory`` is invalid, else None.
+
+    Reuses models/export.py ``_validate_save_directory`` so the MCP path
+    enforces the same rules as the HTTP schema (non-empty, no '..', etc.) and
+    can't report success while the backend writes nothing.
+    """
+    try:
+        from models.export import _validate_save_directory
+        _validate_save_directory(save_directory)
+        return None
+    except (ValueError, TypeError) as exc:
+        return str(exc)
+
+
+def _export_supported_error() -> Optional[str]:
+    """Return an error string if this host can't export, else None.
+
+    Mirrors routes/export.py ``_ensure_export_supported`` so unsupported hosts
+    (CPU-only / no-torch installs) get a clear rejection instead of a
+    low-level load failure.
+    """
+    try:
+        from utils.hardware import export_capability
+        cap = export_capability()
+        if not cap.get("export_supported", True):
+            return (
+                cap.get("export_unsupported_message") or "Export is not supported on this platform."
+            )
+    except Exception as exc:  # noqa: BLE001 -- never block on the capability probe
+        logger.warning("export_capability probe failed: %s", exc)
+    return None
+
+
+def _register_external_export(output_path: Optional[str]) -> Optional[str]:
+    """Best-effort register an export dir outside exports_root for local scans.
+
+    Mirrors routes/export.py ``_try_register_external_export`` so an MCP export
+    to an absolute ``save_directory`` still shows up in Studio's model
+    inventory. Returns the registered path, or None if not applicable/failed.
+    """
+    if not output_path:
+        return None
+    try:
+        from pathlib import Path
+
+        from utils.paths.storage_roots import exports_root
+
+        path = Path(output_path)
+        if not path.is_absolute():
+            return None
+        try:
+            path.resolve().relative_to(exports_root().resolve())
+            return None  # inside exports_root: already discoverable
+        except ValueError:
+            pass
+        from storage.studio_db import add_scan_folder
+
+        folder = add_scan_folder(str(path))
+        return str(folder.get("path") or path)
+    except Exception as exc:  # noqa: BLE001 -- registration is best-effort
+        logger.warning("Could not register export scan folder %s: %s", output_path, exc)
+        return None
+
+
+def export_list_checkpoints(outputs_dir: Optional[str] = None) -> dict[str, Any]:
+    """List training checkpoints available for export.
+
+    Scans Studio's outputs root (or ``outputs_dir``) for runs/checkpoints.
+    Pass one of the returned checkpoint paths to ``export_load_checkpoint``.
+    """
+    from core.export import get_export_backend
+
+    backend = get_export_backend()
+    scanned = backend.scan_checkpoints(outputs_dir = outputs_dir)
+    runs: list[dict[str, Any]] = []
+    for model_name, checkpoints, metadata in scanned:
+        runs.append(
+            {
+                "model_name": model_name,
+                "checkpoints": [
+                    {"name": name, "path": path, "loss": loss} for name, path, loss in checkpoints
+                ],
+                "metadata": metadata,
+            }
+        )
+    return {"outputs_dir": outputs_dir, "runs": runs}
+
+
+def export_load_checkpoint(
+    checkpoint_path: str,
+    max_seq_length: int = 2048,
+    load_in_4bit: bool = True,
+    trust_remote_code: bool = False,
+    approved_remote_code_fingerprint: Optional[str] = None,
+    hf_token: Optional[str] = None,
+) -> dict[str, Any]:
+    """Load a checkpoint into the export backend (must precede ``export_*``).
+
+    Returns once the checkpoint is resident in the export subprocess. After a
+    successful load, call one of ``export_merged`` / ``export_gguf`` /
+    ``export_lora``. Pass ``trust_remote_code`` (and the
+    ``approved_remote_code_fingerprint`` from Studio's remote-code scan) for
+    checkpoints that require custom model code.
+    """
+    unsupported = _export_supported_error()
+    if unsupported:
+        return {"success": False, "message": unsupported, "checkpoint": checkpoint_path}
+    if not (_MIN_SEQ_LEN <= max_seq_length <= _MAX_SEQ_LEN):
+        return {
+            "success": False,
+            "message": f"max_seq_length must be in [{_MIN_SEQ_LEN}, {_MAX_SEQ_LEN}] (got {max_seq_length}).",
+            "checkpoint": checkpoint_path,
+        }
+
+    from core.export import get_export_backend
+
+    backend = get_export_backend()
+    success, message = backend.load_checkpoint(
+        checkpoint_path = checkpoint_path,
+        max_seq_length = max_seq_length,
+        load_in_4bit = load_in_4bit,
+        trust_remote_code = trust_remote_code,
+        approved_remote_code_fingerprint = approved_remote_code_fingerprint,
+        hf_token = resolve_hf_token(hf_token),
+        subject = "mcp",
+    )
+    result: dict[str, Any] = {"success": success, "message": message, "checkpoint": checkpoint_path}
+    # Surface a remote-code consent block (with its approval fingerprint) so a
+    # pure-MCP caller can discover the fingerprint and retry with approval.
+    if not success:
+        error_kind = getattr(backend, "last_error_kind", None)
+        remote_code = getattr(backend, "last_remote_code", None)
+        if error_kind:
+            result["error_kind"] = error_kind
+        if remote_code:
+            result["remote_code"] = remote_code
+    return result
+
+
+def export_merged(
+    save_directory: str,
+    format_type: str = "16-bit (FP16)",
+    push_to_hub: bool = False,
+    repo_id: Optional[str] = None,
+    private: bool = False,
+    compressed_method: Optional[str] = None,
+    hf_token: Optional[str] = None,
+) -> dict[str, Any]:
+    """Export the loaded checkpoint as a merged model.
+
+    ``format_type`` is one of ``16-bit (FP16)``, ``4-bit (FP4)``,
+    ``FP8 (compressed-tensors)``, ``NVFP4 (compressed-tensors)``. Blocks until
+    the merge writes to ``save_directory`` (and optionally pushes to the Hub).
+    """
+    unsupported = _export_supported_error()
+    if unsupported:
+        return _export_result("merged", False, unsupported, None)
+    sd_error = _save_dir_error(save_directory)
+    if sd_error:
+        return _export_result("merged", False, sd_error, None)
+    if format_type not in _VALID_MERGED_FORMATS:
+        return _export_result(
+            "merged",
+            False,
+            f"Unknown format_type {format_type!r}. Valid: {list(_VALID_MERGED_FORMATS)}",
+            None,
+        )
+
+    from core.export import get_export_backend
+
+    backend = get_export_backend()
+    success, message, output_path = backend.export_merged_model(
+        save_directory = save_directory,
+        format_type = format_type,
+        push_to_hub = push_to_hub,
+        repo_id = repo_id,
+        hf_token = resolve_hf_token(hf_token),
+        private = private,
+        compressed_method = compressed_method,
+    )
+    return _export_result("merged", success, message, output_path)
+
+
+def export_gguf(
+    save_directory: str,
+    quantization_method: Union[str, List[str]] = "Q4_K_M",
+    push_to_hub: bool = False,
+    repo_id: Optional[str] = None,
+    hf_token: Optional[str] = None,
+    imatrix_file: Optional[str] = None,
+    imatrix: bool = False,
+) -> dict[str, Any]:
+    """Export the loaded checkpoint in GGUF format for llama.cpp / Ollama.
+
+    ``quantization_method`` is a llama.cpp quant (e.g. ``Q4_K_M``, ``Q8_0``,
+    ``F16``) or a list of quants to produce in one pass off a single merge.
+    This is the slowest export (minutes to hours for large models). For
+    importance-matrix quants (``iq2_xxs``, ``iq4_xs``, ...) set ``imatrix=True``
+    so Unsloth auto-downloads the upstream imatrix, or pass a local file via
+    ``imatrix_file``.
+    """
+    unsupported = _export_supported_error()
+    if unsupported:
+        return _export_result("gguf", False, unsupported, None)
+    sd_error = _save_dir_error(save_directory)
+    if sd_error:
+        return _export_result("gguf", False, sd_error, None)
+    # A custom path wins; otherwise the imatrix toggle requests the upstream auto-download
+    # (mirrors routes/export.py GGUF handler).
+    resolved_imatrix = imatrix_file or (True if imatrix else None)
+
+    from core.export import get_export_backend
+
+    backend = get_export_backend()
+    success, message, output_path = backend.export_gguf(
+        save_directory = save_directory,
+        quantization_method = quantization_method,
+        push_to_hub = push_to_hub,
+        repo_id = repo_id,
+        hf_token = resolve_hf_token(hf_token),
+        imatrix_file = resolved_imatrix,
+    )
+    return _export_result("gguf", success, message, output_path)
+
+
+def export_lora(
+    save_directory: str,
+    push_to_hub: bool = False,
+    repo_id: Optional[str] = None,
+    private: bool = False,
+    gguf: bool = False,
+    gguf_outtype: str = "q8_0",
+    hf_token: Optional[str] = None,
+) -> dict[str, Any]:
+    """Export the loaded checkpoint as a LoRA adapter only.
+
+    With ``gguf=True``, also writes a GGUF LoRA file (``gguf_outtype`` one of
+    ``q8_0``, ``f16``, ``bf16``, ``f32``). Much smaller/faster than a full merge.
+    """
+    unsupported = _export_supported_error()
+    if unsupported:
+        return _export_result("lora", False, unsupported, None)
+    sd_error = _save_dir_error(save_directory)
+    if sd_error:
+        return _export_result("lora", False, sd_error, None)
+
+    from core.export import get_export_backend
+
+    backend = get_export_backend()
+    success, message, output_path = backend.export_lora_adapter(
+        save_directory = save_directory,
+        push_to_hub = push_to_hub,
+        repo_id = repo_id,
+        hf_token = resolve_hf_token(hf_token),
+        private = private,
+        gguf = gguf,
+        gguf_outtype = gguf_outtype,
+    )
+    return _export_result("lora", success, message, output_path)
+
+
+def export_status() -> dict[str, Any]:
+    """Get export-backend state: loaded checkpoint, model type, last operation.
+
+    Use this after ``export_load_checkpoint`` to confirm what is resident
+    before choosing an ``export_*`` format, and to inspect the last op result.
+    """
+    from core.export import get_export_backend
+
+    backend = get_export_backend()
+    last_op = backend.get_last_op() or {}
+    return {
+        "current_checkpoint": backend.current_checkpoint,
+        "is_vision": bool(getattr(backend, "is_vision", False)),
+        "is_peft": bool(getattr(backend, "is_peft", False)),
+        "is_export_active": bool(backend.is_export_active()),
+        "active_op_kind": backend.get_active_op_kind(),
+        "last_op": {
+            "kind": last_op.get("kind"),
+            "status": last_op.get("status"),
+            "output_path": last_op.get("output_path"),
+            "error": last_op.get("error"),
+        },
+    }
+
+
+def export_cancel() -> dict[str, Any]:
+    """Cancel any in-flight export (terminates the export subprocess)."""
+    from core.export import get_export_backend
+
+    backend = get_export_backend()
+    cancelled = backend.cancel_export()
+    return {
+        "success": True,
+        "message": "Export cancelled" if cancelled else "No active export to cancel",
+    }
+
+
+def export_cleanup() -> dict[str, Any]:
+    """Release the loaded checkpoint / free export GPU memory."""
+    from core.export import get_export_backend
+
+    backend = get_export_backend()
+    success = backend.cleanup_memory()
+    return {
+        "success": success,
+        "message": "Memory cleanup completed" if success else "Cleanup failed",
+    }
+
+
+def _export_result(
+    kind: str, success: bool, message: str, output_path: Optional[str]
+) -> dict[str, Any]:
+    # Best-effort: make an export to an absolute dir outside exports_root
+    # discoverable by Studio's local model scans (matches the HTTP route).
+    scan_folder = _register_external_export(output_path) if success and output_path else None
+    result = {
+        "success": success,
+        "kind": kind,
+        "message": message,
+        "output_path": output_path,
+    }
+    if scan_folder:
+        result["scan_folder_registered"] = scan_folder
+    return result
+
+
+def register(mcp: FastMCP) -> list[str]:
+    """Register the export tools onto ``mcp``; return the tool names added."""
+    names: list[str] = []
+    mcp.tool(export_list_checkpoints, annotations = _READ_ONLY)
+    names.append("export_list_checkpoints")
+    mcp.tool(export_status, annotations = _READ_ONLY)
+    names.append("export_status")
+    for fn in (
+        export_load_checkpoint,
+        export_merged,
+        export_gguf,
+        export_lora,
+        export_cancel,
+        export_cleanup,
+    ):
+        mcp.tool(fn, annotations = _STATEFUL)
+        names.append(fn.__name__)
+    return names

--- a/studio/backend/mcp_server/tools/models.py
+++ b/studio/backend/mcp_server/tools/models.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""MCP tools for Studio's model catalog and checkpoints (read-only)."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from fastmcp import FastMCP
+
+from loggers import get_logger
+from mcp_server.auth import resolve_hf_token
+
+logger = get_logger(__name__)
+
+GROUP = "models"
+
+# Structured hints surfaced to MCP clients so they can flag read-only calls as
+# safe-to-auto-approve. See MCP ``ToolAnnotations``.
+_READ_ONLY = {"readOnlyHint": True}
+
+
+def models_list() -> dict[str, Any]:
+    """List every model in Studio's curated catalog.
+
+    Returns the curated model registry (the same set the Studio UI's model
+    picker shows), each with its HuggingFace aliases and the YAML config file
+    that backs it. Use ``models_get_config`` to retrieve the recommended
+    training defaults for a specific model.
+    """
+    from utils.models.model_config import MODEL_NAME_MAPPING
+
+    entries: list[dict[str, Any]] = []
+    for config_file, aliases in MODEL_NAME_MAPPING.items():
+        if not aliases:
+            continue
+        primary = aliases[0]
+        entries.append(
+            {
+                "id": primary,
+                "name": primary.split("/")[-1] if "/" in primary else primary,
+                "aliases": list(aliases),
+                "config_file": config_file,
+            }
+        )
+    entries.sort(key = lambda e: e["id"].lower())
+    return {"count": len(entries), "models": entries}
+
+
+def models_get_config(model_name: str) -> dict[str, Any]:
+    """Get the recommended training defaults for a model.
+
+    Loads the per-model YAML defaults (LoRA rank, learning rate, max sequence
+    length, trust_remote_code, etc.) that Studio applies when that model is
+    selected. Returns an empty ``config`` object for unknown models (the
+    trainer then falls back to sensible built-in defaults).
+    """
+    from utils.models.model_config import load_model_defaults
+
+    config = load_model_defaults(model_name)
+    return {"model_name": model_name, "config": config}
+
+
+async def models_list_cached(hf_token: Optional[str] = None) -> dict[str, Any]:
+    """List models already downloaded to the local HuggingFace cache.
+
+    These can be used for training/inference without an additional download.
+    Set ``hf_token`` (or the ``HF_TOKEN`` env var) to see gated repos.
+    """
+    from hub.services.models.cache_inventory import list_cached_models_response
+
+    token = resolve_hf_token(hf_token)
+    result = await list_cached_models_response(hf_token = token)
+    if isinstance(result, dict):
+        return result
+    return {"cached": result}
+
+
+def models_checkpoints(outputs_dir: Optional[str] = None) -> dict[str, Any]:
+    """Scan a training-output directory for checkpoints.
+
+    Returns discovered runs and their checkpoints (step path and best loss),
+    matching what the Studio UI and ``unsloth list-checkpoints`` show. With no
+    ``outputs_dir``, Studio's default outputs root is scanned.
+    """
+    from utils.models.checkpoints import scan_checkpoints
+    from utils.paths import outputs_root
+
+    root = outputs_dir if outputs_dir else str(outputs_root())
+    scanned = scan_checkpoints(outputs_dir = root)
+
+    runs: list[dict[str, Any]] = []
+    for model_name, checkpoints, metadata in scanned:
+        runs.append(
+            {
+                "model_name": model_name,
+                "checkpoints": [
+                    {"name": name, "path": path, "loss": loss} for name, path, loss in checkpoints
+                ],
+                "metadata": metadata,
+            }
+        )
+    return {"outputs_dir": root, "runs": runs}
+
+
+def register(mcp: FastMCP) -> list[str]:
+    """Register the models tools onto ``mcp``; return the tool names added."""
+    names: list[str] = []
+    for fn in (models_list, models_get_config, models_list_cached, models_checkpoints):
+        mcp.tool(fn, annotations = _READ_ONLY)
+        names.append(fn.__name__)
+    return names

--- a/studio/backend/mcp_server/tools/recipe.py
+++ b/studio/backend/mcp_server/tools/recipe.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""MCP tools for Studio Data Designer (synthetic-data recipes).
+
+A "recipe" is a dict describing the columns/providers of a synthetic dataset
+(the same shape the Data Designer UI builds). Validate or preview it cheaply,
+then ``recipe_start`` spawns a generation job (subprocess); poll with
+``recipe_status`` and abort with ``recipe_cancel``.
+
+These tools require the optional ``data_designer`` package; calls return a
+clear error if it is not installed.
+
+Known limitation: recipes that reference a *local* Studio model provider
+(``is_local: true``) are not wired up here. The HTTP Data Designer route rewrites
+such providers to a loopback inference endpoint and mints an internal API key
+against the running Studio UI server -- coordination the standalone MCP path
+does not assume. Point recipes at a hosted/remote provider instead.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from fastmcp import FastMCP
+
+from loggers import get_logger
+
+logger = get_logger(__name__)
+
+GROUP = "recipe"
+
+_READ_ONLY = {"readOnlyHint": True}
+_STATEFUL = {"destructiveHint": False}
+
+
+def recipe_validate(recipe: dict[str, Any]) -> dict[str, Any]:
+    """Validate a Data Designer recipe without running it.
+
+    Returns ``{"valid": true}`` on success, or ``{"valid": false, "error": ...}``
+    with the validation detail. ``recipe`` must include a ``columns`` list.
+    """
+    from core.data_recipe.service import validate_recipe
+
+    if not recipe.get("columns"):
+        return {"valid": False, "error": "Recipe must include a non-empty 'columns' list."}
+    try:
+        validate_recipe(recipe)
+    except Exception as exc:
+        return {"valid": False, "error": str(exc)}
+    return {"valid": True}
+
+
+def recipe_preview(recipe: dict[str, Any], num_records: int = 5) -> dict[str, Any]:
+    """Generate a small preview of a recipe (no job spawned).
+
+    Returns up to ``num_records`` synthetic rows plus any processor artifacts
+    and analysis. Useful for iterating on a recipe before ``recipe_start``.
+    """
+    from core.data_recipe.service import preview_recipe
+
+    try:
+        dataset, artifacts, analysis = preview_recipe(recipe, num_records = num_records)
+    except Exception as exc:
+        return {"success": False, "error": str(exc)}
+    return {
+        "success": True,
+        "dataset": dataset,
+        "processor_artifacts": artifacts,
+        "analysis": analysis,
+    }
+
+
+def recipe_start(recipe: dict[str, Any], run: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+    """Start a Data Designer generation job. Returns immediately with a job id.
+
+    ``recipe`` must include ``columns``. ``run`` carries execution options:
+    ``execution_type`` (``"full"`` default, or ``"preview"``), ``run_name``,
+    ``run_config``, and provider settings. Poll with ``recipe_status``.
+    """
+    from core.data_recipe.jobs.manager import get_job_manager
+
+    if not recipe.get("columns"):
+        return {"success": False, "error": "Recipe must include a non-empty 'columns' list."}
+
+    run_payload = dict(run or {})
+    run_payload.pop("artifact_path", None)
+    run_payload.pop("dataset_name", None)
+    execution_type = str(run_payload.get("execution_type") or "full").strip().lower()
+    if execution_type not in {"preview", "full"}:
+        return {"success": False, "error": "execution_type must be 'preview' or 'full'."}
+    run_payload["execution_type"] = execution_type
+
+    # Validate run_config up front (matches routes/data_recipe/jobs.py). The
+    # optional data_designer package is imported lazily: if it's absent we skip
+    # this check and let the worker surface the failure via recipe_status.
+    run_config_raw = run_payload.get("run_config")
+    if run_config_raw is not None:
+        try:
+            from data_designer.config.run_config import RunConfig
+            RunConfig.model_validate(run_config_raw)
+        except ImportError:
+            pass
+        except Exception as exc:
+            return {"success": False, "error": f"invalid run_config: {exc}"}
+
+    mgr = get_job_manager()
+    try:
+        job_id = mgr.start(recipe = recipe, run = run_payload, internal_api_key_id = None)
+    except Exception as exc:
+        return {"success": False, "error": str(exc)}
+
+    return {
+        "success": True,
+        "job_id": job_id,
+        "message": "Recipe job started. Poll recipe_status for progress.",
+    }
+
+
+def recipe_status(job_id: Optional[str] = None) -> dict[str, Any]:
+    """Get the status of a recipe job.
+
+    With ``job_id``, reports that specific job; without it, reports the
+    current/last job (or ``idle`` if none).
+    """
+    from core.data_recipe.jobs.manager import get_job_manager
+
+    mgr = get_job_manager()
+    if job_id is not None:
+        status = mgr.get_status(job_id)
+        if status is None:
+            return {"idle": True, "message": f"No recipe job found with id {job_id!r}."}
+        return status
+    status = mgr.get_current_status()
+    if status is None:
+        return {"idle": True, "message": "No recipe job has been started."}
+    return status
+
+
+def recipe_cancel(job_id: str) -> dict[str, Any]:
+    """Cancel a running recipe job by terminating its subprocess."""
+    from core.data_recipe.jobs.manager import get_job_manager
+
+    mgr = get_job_manager()
+    cancelled = mgr.cancel(job_id)
+    return {
+        "success": cancelled,
+        "message": "Job cancelled" if cancelled else "Job not found or not running",
+    }
+
+
+def register(mcp: FastMCP) -> list[str]:
+    """Register the recipe tools onto ``mcp``; return the tool names added."""
+    names: list[str] = []
+    mcp.tool(recipe_validate, annotations = _READ_ONLY)
+    names.append("recipe_validate")
+    mcp.tool(recipe_preview)
+    names.append("recipe_preview")
+    for fn in (recipe_start, recipe_status, recipe_cancel):
+        mcp.tool(fn, annotations = _STATEFUL)
+        names.append(fn.__name__)
+    return names

--- a/studio/backend/mcp_server/tools/train.py
+++ b/studio/backend/mcp_server/tools/train.py
@@ -1,0 +1,363 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""MCP tools for Studio training (start / status / stop).
+
+Training runs in Studio's existing subprocess backend, so ``train_start``
+returns immediately with a job id; poll ``train_status`` and stop early with
+``train_stop``. This mirrors the Studio UI / ``POST /api/train/*`` exactly.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import uuid
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from fastmcp import FastMCP
+
+from loggers import get_logger
+from mcp_server.auth import resolve_hf_token, resolve_secret
+
+logger = get_logger(__name__)
+
+GROUP = "train"
+
+_STATEFUL = {"destructiveHint": False}
+
+
+def _request_to_training_kwargs(request: Any, subject: str) -> dict[str, Any]:
+    """Convert a validated ``TrainingStartRequest`` into backend kwargs.
+
+    Mirrors the mapping in ``routes/training.py`` (start_training route) so the
+    MCP server drives the worker subprocess with the exact same contract as the
+    Studio UI. Resume, S3 sources and auto GPU selection are intentionally out
+    of scope for the MCP surface.
+    """
+    gradient_checkpointing = request.gradient_checkpointing
+    if gradient_checkpointing:
+        gradient_checkpointing = gradient_checkpointing.strip()
+    if not gradient_checkpointing:
+        gradient_checkpointing = "unsloth"
+
+    return {
+        "model_name": request.model_name,
+        "project_name": request.project_name,
+        "training_type": request.training_type,
+        "hf_token": request.hf_token or "",
+        "load_in_4bit": request.load_in_4bit,
+        "max_seq_length": request.max_seq_length,
+        "vision_image_size": request.vision_image_size,
+        "hf_dataset": request.hf_dataset or "",
+        "local_datasets": request.local_datasets,
+        "local_eval_datasets": request.local_eval_datasets,
+        "format_type": request.format_type,
+        "subset": request.subset,
+        "train_split": request.train_split,
+        "dataset_streaming": request.dataset_streaming,
+        "eval_split": request.eval_split,
+        "eval_steps": request.eval_steps,
+        "dataset_slice_start": request.dataset_slice_start,
+        "dataset_slice_end": request.dataset_slice_end,
+        "custom_format_mapping": request.custom_format_mapping,
+        "num_epochs": request.num_epochs,
+        "learning_rate": request.learning_rate,
+        "embedding_learning_rate": request.embedding_learning_rate,
+        "batch_size": request.batch_size,
+        "gradient_accumulation_steps": request.gradient_accumulation_steps,
+        "warmup_steps": request.warmup_steps,
+        "warmup_ratio": request.warmup_ratio,
+        "max_steps": request.max_steps,
+        "save_steps": request.save_steps,
+        "weight_decay": request.weight_decay,
+        "max_grad_norm": request.max_grad_norm,
+        "max_grad_value": request.max_grad_value,
+        "max_grad_leaf_norm": request.max_grad_leaf_norm,
+        "cast_norm_output_to_input_dtype": request.cast_norm_output_to_input_dtype,
+        "random_seed": request.random_seed,
+        "packing": request.packing,
+        "optim": request.optim,
+        "lr_scheduler_type": request.lr_scheduler_type,
+        "use_lora": request.use_lora,
+        "lora_r": request.lora_r,
+        "lora_alpha": request.lora_alpha,
+        "lora_dropout": request.lora_dropout,
+        "target_modules": request.target_modules if request.target_modules else None,
+        "gradient_checkpointing": gradient_checkpointing,
+        "use_rslora": request.use_rslora,
+        "use_loftq": request.use_loftq,
+        "train_on_completions": request.train_on_completions,
+        "finetune_vision_layers": request.finetune_vision_layers,
+        "finetune_language_layers": request.finetune_language_layers,
+        "finetune_attention_modules": request.finetune_attention_modules,
+        "finetune_mlp_modules": request.finetune_mlp_modules,
+        "is_dataset_image": request.is_dataset_image,
+        "is_dataset_audio": request.is_dataset_audio,
+        "is_embedding": request.is_embedding,
+        "enable_wandb": request.enable_wandb,
+        "wandb_token": request.wandb_token or "",
+        "wandb_project": request.wandb_project or "",
+        "enable_tensorboard": request.enable_tensorboard,
+        "tensorboard_dir": request.tensorboard_dir or "",
+        "output_dir": None,
+        "resume_from_checkpoint": request.resume_from_checkpoint,
+        "trust_remote_code": request.trust_remote_code,
+        "approved_remote_code_fingerprint": request.approved_remote_code_fingerprint,
+        "subject": subject,
+        "gpu_ids": request.gpu_ids,
+        "s3_config": None,
+    }
+
+
+def train_start(
+    model_name: str,
+    training_type: str = "LoRA/QLoRA",
+    hf_dataset: Optional[str] = None,
+    local_datasets: Optional[List[str]] = None,
+    format_type: str = "auto",
+    num_epochs: int = 3,
+    learning_rate: float = 2e-4,
+    batch_size: int = 2,
+    gradient_accumulation_steps: int = 4,
+    max_seq_length: int = 2048,
+    load_in_4bit: bool = True,
+    max_steps: Optional[int] = None,
+    use_lora: bool = True,
+    lora_r: int = 16,
+    lora_alpha: int = 16,
+    lora_dropout: float = 0.0,
+    packing: bool = False,
+    train_on_completions: bool = False,
+    warmup_steps: Optional[int] = None,
+    save_steps: int = 0,
+    weight_decay: float = 0.0,
+    random_seed: int = 3407,
+    subset: Optional[str] = None,
+    train_split: str = "train",
+    eval_split: Optional[str] = None,
+    eval_steps: float = 0.0,
+    is_dataset_image: bool = False,
+    is_dataset_audio: bool = False,
+    is_embedding: bool = False,
+    finetune_vision_layers: bool = True,
+    finetune_language_layers: bool = True,
+    finetune_attention_modules: bool = True,
+    finetune_mlp_modules: bool = True,
+    custom_format_mapping: Optional[Dict[str, Any]] = None,
+    enable_wandb: bool = False,
+    wandb_token: Optional[str] = None,
+    hf_token: Optional[str] = None,
+    trust_remote_code: bool = False,
+    approved_remote_code_fingerprint: Optional[str] = None,
+) -> dict[str, Any]:
+    """Start a fine-tuning job. Returns immediately with a ``job_id``.
+
+    Provide a dataset via either ``hf_dataset`` (a HuggingFace id) or
+    ``local_datasets`` (one or more names/paths from ``data_list_local``).
+    Defaults match Studio's recommended values; per-model YAML defaults are
+    applied on top by the trainer. Poll progress with ``train_status`` and
+    stop early with ``train_stop``.
+
+    ``training_type`` is one of ``LoRA/QLoRA``, ``Full Finetuning`` or
+    ``Continued Pretraining``. Set ``max_steps`` > 0 to train by step count
+    instead of epochs. For datasets that ``data_check_format`` flags as
+    needing a manual mapping, pass ``custom_format_mapping``. For models that
+    require custom code, set ``trust_remote_code`` (and pass the
+    ``approved_remote_code_fingerprint`` from Studio's remote-code scan);
+    first-party (unsloth/nvidia) repos that opt in via their YAML default are
+    auto-trusted. The ``finetune_*`` toggles default to True (the Studio UI
+    default) so VLM/audio-VLM LoRA jobs actually train layers; the worker
+    ignores vision layers for non-VLM models.
+    """
+    from core.training.training import get_training_backend
+    from models.training import TrainingStartRequest
+
+    backend = get_training_backend()
+    if backend.is_training_active():
+        return {
+            "success": False,
+            "status": "error",
+            "job_id": backend.current_job_id or "",
+            "error": "Training is already in progress. Call train_stop first.",
+        }
+
+    # Resolve/validate local datasets the same way routes/training.py does:
+    # resolve_dataset_path keeps absolute paths inside Studio's dataset roots
+    # (rejecting arbitrary host files) and resolves registered names. Mirrors
+    # the HTTP route's _validate_local_dataset_paths.
+    if local_datasets:
+        try:
+            from utils.paths import resolve_dataset_path
+            resolved: list[str] = []
+            for path in local_datasets:
+                resolved_path = resolve_dataset_path(path)
+                if not resolved_path.exists():
+                    raise ValueError(
+                        f"Local dataset not found: {path} (resolved: {resolved_path}). "
+                        "Register it via data_register first."
+                    )
+                resolved.append(str(resolved_path))
+        except ValueError as exc:
+            return {"success": False, "status": "error", "error": str(exc)}
+        local_datasets = resolved
+
+    fields: dict[str, Any] = dict(
+        model_name = model_name,
+        training_type = training_type,
+        hf_dataset = hf_dataset,
+        local_datasets = local_datasets or [],
+        format_type = format_type,
+        num_epochs = num_epochs,
+        learning_rate = learning_rate,
+        batch_size = batch_size,
+        gradient_accumulation_steps = gradient_accumulation_steps,
+        max_seq_length = max_seq_length,
+        load_in_4bit = load_in_4bit,
+        max_steps = max_steps,
+        use_lora = use_lora,
+        lora_r = lora_r,
+        lora_alpha = lora_alpha,
+        lora_dropout = lora_dropout,
+        packing = packing,
+        train_on_completions = train_on_completions,
+        warmup_steps = warmup_steps,
+        save_steps = save_steps,
+        weight_decay = weight_decay,
+        random_seed = random_seed,
+        subset = subset,
+        train_split = train_split,
+        eval_split = eval_split,
+        eval_steps = eval_steps,
+        is_dataset_image = is_dataset_image,
+        is_dataset_audio = is_dataset_audio,
+        is_embedding = is_embedding,
+        finetune_vision_layers = finetune_vision_layers,
+        finetune_language_layers = finetune_language_layers,
+        finetune_attention_modules = finetune_attention_modules,
+        finetune_mlp_modules = finetune_mlp_modules,
+        custom_format_mapping = custom_format_mapping,
+        enable_wandb = enable_wandb,
+        wandb_token = resolve_secret("WANDB_TOKEN", wandb_token),
+        hf_token = resolve_hf_token(hf_token),
+        trust_remote_code = trust_remote_code,
+        approved_remote_code_fingerprint = approved_remote_code_fingerprint,
+    )
+
+    try:
+        request = TrainingStartRequest(**fields)
+    except Exception as exc:  # Pydantic ValidationError or field validators.
+        return {"success": False, "status": "error", "error": str(exc)}
+
+    training_kwargs = _request_to_training_kwargs(request, subject = "mcp")
+
+    # First-party (unsloth/nvidia) repos whose YAML opts into trust_remote_code
+    # are auto-trusted, matching routes/training.py. Explicit user opt-in above
+    # always wins; this only lifts the default for trusted repos.
+    if not training_kwargs.get("trust_remote_code"):
+        try:
+            from utils.models.model_config import load_model_defaults
+            from utils.security.trusted_org import is_trusted_org_repo
+
+            yaml_trust = (
+                load_model_defaults(model_name).get("training", {}).get("trust_remote_code", False)
+            )
+            if yaml_trust and is_trusted_org_repo(
+                model_name, hf_token = training_kwargs.get("hf_token") or None
+            ):
+                training_kwargs["trust_remote_code"] = True
+        except Exception as exc:  # noqa: BLE001 -- never block training start on the trust probe
+            logger.warning("trust_remote_code auto-resolution failed for %s: %s", model_name, exc)
+
+    # Free GPU memory held by the export subprocess before training spawns
+    # (export and training share the GPU). The Studio UI route additionally
+    # unloads chat models in-process; that doesn't apply here since the MCP
+    # server runs in its own process and never hosts the UI's chat model.
+    def _free_vram_for_training() -> None:
+        try:
+            from core.export import get_export_backend
+            exp_backend = get_export_backend()
+            if exp_backend.current_checkpoint or exp_backend.is_export_active():
+                logger.info("Shutting down export subprocess to free GPU memory for training")
+                exp_backend._shutdown_subprocess()
+                exp_backend.current_checkpoint = None
+                exp_backend.is_vision = False
+                exp_backend.is_peft = False
+        except Exception as exc:  # noqa: BLE001 -- hook failures must never block the start
+            logger.warning("Could not shut down export subprocess for training: %s", exc)
+
+    job_id = f"job_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
+
+    try:
+        started = backend.start_training(
+            job_id = job_id, before_spawn = _free_vram_for_training, **training_kwargs
+        )
+    except Exception as exc:
+        logger.exception("MCP train_start failed")
+        return {"success": False, "status": "error", "error": str(exc)}
+
+    if not started:
+        progress = backend.trainer.get_training_progress()
+        return {
+            "success": False,
+            "status": "error",
+            "error": progress.error or "Failed to start training subprocess",
+        }
+
+    return {
+        "success": True,
+        "status": "queued",
+        "job_id": job_id,
+        "message": "Training job queued and starting in subprocess. Poll train_status.",
+    }
+
+
+def train_status() -> dict[str, Any]:
+    """Get the current training job's progress (or idle state).
+
+    Returns the live progress (epoch, step, loss, learning rate, ETA, error)
+    and whether a job is active. The ``job_id`` of the active/last job is
+    included. When the worker blocked on a remote-code scan, ``error_kind`` and
+    ``remote_code`` (carrying the approval ``fingerprint``) are included so a
+    pure-MCP caller can discover the fingerprint and retry with approval.
+    """
+    from core.training.training import get_training_backend
+
+    backend = get_training_backend()
+    progress = backend.trainer.get_training_progress()
+    result: dict[str, Any] = {
+        "job_id": backend.current_job_id,
+        "is_active": backend.is_training_active(),
+        "progress": dataclasses.asdict(progress),
+    }
+    error_kind = getattr(backend, "last_error_kind", None)
+    remote_code = getattr(backend, "last_remote_code", None)
+    if error_kind:
+        result["error_kind"] = error_kind
+    if remote_code:
+        result["remote_code"] = remote_code
+    return result
+
+
+def train_stop(save: bool = True) -> dict[str, Any]:
+    """Stop the running training job.
+
+    With ``save=True`` (default) the current checkpoint is saved first; pass
+    ``save=False`` to cancel without saving.
+    """
+    from core.training.training import get_training_backend
+
+    backend = get_training_backend()
+    if not backend.is_training_active():
+        return {"status": "idle", "message": "No training job is currently running"}
+    backend.stop_training(save = save)
+    return {"status": "stopping", "saved": save, "job_id": backend.current_job_id}
+
+
+def register(mcp: FastMCP) -> list[str]:
+    """Register the training tools onto ``mcp``; return the tool names added."""
+    names: list[str] = []
+    for fn in (train_start, train_status, train_stop):
+        mcp.tool(fn, annotations = _STATEFUL)
+        names.append(fn.__name__)
+    return names

--- a/studio/backend/tests/test_mcp_server.py
+++ b/studio/backend/tests/test_mcp_server.py
@@ -1,0 +1,987 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Tests for the standalone Studio MCP server (``studio/backend/mcp_server``).
+
+Two layers:
+  * unit tests call the tool handler functions directly (with the backend
+    singletons mocked, so no GPU/subprocess is needed);
+  * integration tests drive a built FastMCP server through its in-memory
+    client, exercising the real registration + schema path.
+"""
+
+import asyncio
+from pathlib import Path
+
+import pytest
+import typer
+
+
+# ── gating & auth helpers ─────────────────────────────────────────────
+
+
+def test_resolve_groups_defaults_to_all():
+    from mcp_server.tools import FEATURE_GROUPS, resolve_groups
+    assert resolve_groups() == FEATURE_GROUPS
+    assert resolve_groups(None, None) == FEATURE_GROUPS
+
+
+def test_resolve_groups_enable_subset_preserves_order():
+    from mcp_server.tools import resolve_groups
+    assert resolve_groups(["data", "models"]) == ["models", "data"]
+    assert resolve_groups(["recipe", "train"]) == ["train", "recipe"]
+
+
+def test_resolve_groups_disable_removes_from_all():
+    from mcp_server.tools import resolve_groups
+    assert resolve_groups(disabled = ["train"]) == ["models", "data", "export", "recipe"]
+
+
+def test_resolve_groups_enable_then_disable():
+    from mcp_server.tools import resolve_groups
+
+    # disable wins over enable
+    assert resolve_groups(["models", "data", "train"], ["train"]) == ["models", "data"]
+
+
+def test_resolve_groups_unknown_raises():
+    from mcp_server.tools import resolve_groups
+    with pytest.raises(ValueError, match = "Unknown feature group"):
+        resolve_groups(["bogus"])
+    with pytest.raises(ValueError, match = "Unknown feature group"):
+        resolve_groups(disabled = ["nope"])
+
+
+def test_resolve_secret_prefers_override_then_env(monkeypatch):
+    from mcp_server.auth import resolve_hf_token, resolve_secret
+
+    monkeypatch.setenv("HF_TOKEN", "envval")
+    assert resolve_secret("HF_TOKEN") == "envval"
+    assert resolve_secret("HF_TOKEN", "explicit") == "explicit"
+    assert resolve_secret("HF_TOKEN", "  ") == "envval"  # blank override ignored
+    monkeypatch.delenv("HF_TOKEN")
+    assert resolve_secret("HF_TOKEN") is None
+
+    monkeypatch.setenv("HF_TOKEN", "hf-env")
+    assert resolve_hf_token() == "hf-env"
+    assert resolve_hf_token("override") == "override"
+    # HUGGING_FACE_HUB_TOKEN fallback
+    monkeypatch.delenv("HF_TOKEN")
+    monkeypatch.setenv("HUGGING_FACE_HUB_TOKEN", "hub-env")
+    assert resolve_hf_token() == "hub-env"
+
+
+# ── models tools (read-only, real implementation) ─────────────────────
+
+
+def test_models_list_returns_curated_catalog():
+    from mcp_server.tools.models import models_list
+
+    result = models_list()
+    assert result["count"] == len(result["models"])
+    assert result["count"] > 0
+    first = result["models"][0]
+    assert {"id", "name", "aliases", "config_file"} <= set(first)
+    assert isinstance(first["aliases"], list) and first["aliases"]
+
+
+def test_models_list_sorted_and_stable():
+    from mcp_server.tools.models import models_list
+    ids = [m["id"].lower() for m in models_list()["models"]]
+    assert ids == sorted(ids)
+
+
+def test_models_get_config_returns_yaml_defaults():
+    from mcp_server.tools.models import models_get_config
+
+    result = models_get_config("unsloth/llama-3-8b-bnb-4bit")
+    assert result["model_name"] == "unsloth/llama-3-8b-bnb-4bit"
+    assert isinstance(result["config"], dict)
+
+
+def test_models_get_config_unknown_model_falls_back_to_default():
+    # load_model_defaults falls back to default.yaml for unknown models.
+    from mcp_server.tools.models import models_get_config
+
+    result = models_get_config("this/does-not-exist-xyz")
+    assert result["model_name"] == "this/does-not-exist-xyz"
+    assert isinstance(result["config"], dict)
+    assert "training" in result["config"]  # default.yaml fallback
+
+
+# ── data tools ────────────────────────────────────────────────────────
+
+
+def test_data_register_and_list_round_trip(tmp_path, monkeypatch):
+    from mcp_server.tools import data as data_tools
+
+    upload_dir = tmp_path / "uploads"
+    monkeypatch.setattr("hub.services.datasets.local.DATASET_UPLOAD_DIR", upload_dir, raising = True)
+
+    src = tmp_path / "my.csv"
+    src.write_text("text,label\nhello,1\nworld,0\n")
+
+    result = data_tools.data_register(str(src))
+    assert result["success"] is True
+    assert result["filename"] == "my.csv"
+    stored_name = result["stored_path"].split("/")[-1]
+    assert (upload_dir / stored_name).is_file()
+
+    listed = data_tools.data_list_local()
+    ids = [d["id"] for d in listed["datasets"]]
+    assert result["stored_path"].split("/")[-1] in ids or any(
+        result["stored_path"] == d["path"] for d in listed["datasets"]
+    )
+
+
+def test_data_register_rejects_bad_extension(tmp_path):
+    from mcp_server.tools.data import data_register
+
+    src = tmp_path / "data.exe"
+    src.write_text("nope")
+    result = data_register(str(src))
+    assert result["success"] is False
+    assert "Unsupported file type" in result["error"]
+
+
+def test_data_register_rejects_missing_file():
+    from mcp_server.tools.data import data_register
+
+    result = data_register("/nonexistent/path/to/file.csv")
+    assert result["success"] is False
+    assert "Not a file" in result["error"]
+
+
+def test_data_register_cleans_partial_copy_on_failure(tmp_path, monkeypatch):
+    import shutil as shutil_mod
+
+    from mcp_server.tools import data as data_tools
+
+    upload_dir = tmp_path / "uploads"
+    monkeypatch.setattr("hub.services.datasets.local.DATASET_UPLOAD_DIR", upload_dir)
+    src = tmp_path / "my.csv"
+    src.write_text("a,b\n1,2\n")
+
+    def _boom_copy(_src, dst, **kw):
+        Path(dst).write_text("partial")  # simulate a partial write
+        raise OSError("disk full")
+
+    monkeypatch.setattr(shutil_mod, "copy2", _boom_copy)
+    result = data_tools.data_register(str(src))
+    assert result["success"] is False
+    # The partial copy must be removed so it can't surface as a corrupt dataset.
+    assert not upload_dir.exists() or not any(upload_dir.iterdir())
+
+
+def test_data_check_format_uses_hub_request_schema(monkeypatch):
+    # Regression: data_check_format must build the *hub* CheckFormatRequest
+    # (hub.schemas.datasets, which has prefer_local_cache), not the legacy
+    # models.datasets one -- otherwise check_format_response raises
+    # AttributeError on request.prefer_local_cache.
+    import hub.services.datasets.formatting as formatting_mod
+    from hub.schemas.datasets import (
+        CheckFormatRequest as HubCheckFormatRequest,
+        CheckFormatResponse,
+    )
+
+    captured: dict = {}
+
+    def _fake_check(request, hf_token = None):
+        captured["request"] = request
+        return CheckFormatResponse(
+            requires_manual_mapping = False, detected_format = "alpaca", columns = ["instruction"]
+        )
+
+    monkeypatch.setattr(formatting_mod, "check_format_response", _fake_check)
+
+    from mcp_server.tools.data import data_check_format
+
+    # Should not raise; the constructed request must carry prefer_local_cache.
+    data_check_format(dataset_name = "some/dataset", is_vlm = True, train_split = "train")
+    request = captured["request"]
+    assert isinstance(request, HubCheckFormatRequest)
+    assert hasattr(request, "prefer_local_cache")
+    assert request.dataset_name == "some/dataset"
+    assert request.is_vlm is True
+
+
+def test_data_check_format_surfaces_errors_cleanly():
+    # A malformed dataset name must yield a clean error dict, never an exception.
+    from mcp_server.tools.data import data_check_format
+
+    result = data_check_format(dataset_name = "<<<not-a-real-dataset>>>")
+    assert result["success"] is False
+    assert "error" in result
+
+
+# ── training tools (mocked backend) ───────────────────────────────────
+
+
+class _FakeTrainingProgress:
+    def asdict(self):
+        return {
+            "epoch": 0,
+            "step": 0,
+            "loss": None,
+            "status_message": "Ready to train",
+            "is_training": False,
+            "is_completed": False,
+            "error": None,
+        }
+
+
+class _FakeTrainer:
+    def __init__(self, progress):
+        self._progress = progress
+
+    def get_training_progress(self):
+        return self._progress
+
+
+class _FakeTrainingBackend:
+    def __init__(
+        self,
+        *,
+        active = False,
+        start_succeeds = True,
+    ):
+        self._active = active
+        self._start_succeeds = start_succeeds
+        self.current_job_id = "job_existing" if active else None
+        self.stop_called_with = None
+        self.last_error_kind = None
+        self.last_remote_code = None
+        from core.training.training import TrainingProgress
+
+        self._progress = TrainingProgress(status_message = "Ready to train")
+        self.trainer = _FakeTrainer(self._progress)
+
+    def is_training_active(self):
+        return self._active
+
+    def start_training(
+        self,
+        job_id,
+        before_spawn = None,
+        **kwargs,
+    ):
+        # Mirror the real backend, which runs the before_spawn hook after the
+        # start guards pass but before the subprocess spawns.
+        self.before_spawn = before_spawn
+        if before_spawn is not None:
+            try:
+                before_spawn()
+            except Exception:
+                pass
+        self.last_job_id = job_id
+        self.last_kwargs = kwargs
+        return self._start_succeeds
+
+    def stop_training(self, save = True):
+        self.stop_called_with = save
+        self._active = False
+
+
+@pytest.fixture
+def _patch_training_backend(monkeypatch):
+    def _install(backend):
+        import core.training.training as mod
+        monkeypatch.setattr(mod, "get_training_backend", lambda: backend)
+        return backend
+
+    return _install
+
+
+def test_train_start_rejects_when_already_active(_patch_training_backend):
+    from mcp_server.tools.train import train_start
+
+    _patch_training_backend(_FakeTrainingBackend(active = True))
+    result = train_start(
+        model_name = "unsloth/llama-3-8b-bnb-4bit", hf_dataset = "yahma/alpaca-cleaned"
+    )
+    assert result["success"] is False
+    assert "already in progress" in result["error"]
+
+
+def test_train_start_validates_and_starts(_patch_training_backend):
+    from mcp_server.tools.train import train_start
+
+    backend = _patch_training_backend(_FakeTrainingBackend(start_succeeds = True))
+    result = train_start(
+        model_name = "unsloth/llama-3-8b-bnb-4bit",
+        hf_dataset = "yahma/alpaca-cleaned",
+        format_type = "alpaca",
+        num_epochs = 1,
+    )
+    assert result["success"] is True
+    assert result["status"] == "queued"
+    assert result["job_id"].startswith("job_")
+    # The job_id generated by the tool is what gets passed to the backend.
+    assert backend.last_job_id == result["job_id"]
+    assert backend.last_kwargs["model_name"] == "unsloth/llama-3-8b-bnb-4bit"
+    assert backend.last_kwargs["subject"] == "mcp"
+    assert backend.last_kwargs["hf_dataset"] == "yahma/alpaca-cleaned"
+
+
+def test_train_start_invalid_training_type_returns_error(_patch_training_backend):
+    from mcp_server.tools.train import train_start
+
+    _patch_training_backend(_FakeTrainingBackend())
+    result = train_start(model_name = "unsloth/llama-3-8b-bnb-4bit", training_type = "Bogus")
+    assert result["success"] is False
+    assert "error" in result
+
+
+def test_train_start_failure_surfaces_progress_error(_patch_training_backend):
+    from mcp_server.tools.train import train_start
+
+    _patch_training_backend(_FakeTrainingBackend(start_succeeds = False))
+    result = train_start(
+        model_name = "unsloth/llama-3-8b-bnb-4bit", hf_dataset = "yahma/alpaca-cleaned"
+    )
+    assert result["success"] is False
+    assert "status" in result and result["status"] == "error"
+
+
+def test_train_status_reports_active_and_progress(_patch_training_backend):
+    from mcp_server.tools.train import train_status
+
+    _patch_training_backend(_FakeTrainingBackend(active = True))
+    result = train_status()
+    assert result["is_active"] is True
+    assert result["job_id"] == "job_existing"
+    assert "loss" in result["progress"]
+
+
+def test_train_stop_when_idle(_patch_training_backend):
+    from mcp_server.tools.train import train_stop
+
+    backend = _patch_training_backend(_FakeTrainingBackend(active = False))
+    result = train_stop()
+    assert result["status"] == "idle"
+    assert backend.stop_called_with is None
+
+
+def test_train_stop_when_active(_patch_training_backend):
+    from mcp_server.tools.train import train_stop
+
+    backend = _patch_training_backend(_FakeTrainingBackend(active = True))
+    result = train_stop(save = False)
+    assert result["status"] == "stopping"
+    assert backend.stop_called_with is False
+
+
+# ── export tools (mocked backend) ─────────────────────────────────────
+
+
+class _FakeExportBackend:
+    def __init__(self):
+        self.current_checkpoint = "/ckpt/last"
+        self.is_vision = False
+        self.is_peft = True
+        self._last_op = {
+            "kind": "export_merged",
+            "status": "success",
+            "output_path": "/out",
+            "error": None,
+        }
+        self.cancelled = False
+        self.cleaned = False
+        self.load_kwargs = None
+        self.gguf_kwargs = None
+        self.merged_kwargs = None
+        self.last_error_kind = None
+        self.last_remote_code = None
+
+    def is_export_active(self):
+        return False
+
+    def get_active_op_kind(self):
+        return None
+
+    def get_last_op(self):
+        return self._last_op
+
+    def scan_checkpoints(self, outputs_dir = None):
+        return [("mymodel", [("checkpoint-100", "/p/ckpt-100", 0.5)], {"foo": "bar"})]
+
+    def cancel_export(self):
+        self.cancelled = True
+        return True
+
+    def cleanup_memory(self):
+        self.cleaned = True
+        return True
+
+    def load_checkpoint(self, **kwargs):
+        self.load_kwargs = kwargs
+        return (True, "loaded")
+
+    def export_merged_model(self, **kwargs):
+        self.merged_kwargs = kwargs
+        return (True, "ok", kwargs.get("save_directory"))
+
+    def export_gguf(self, **kwargs):
+        self.gguf_kwargs = kwargs
+        return (True, "ok", kwargs.get("save_directory"))
+
+
+@pytest.fixture
+def _patch_export_backend(monkeypatch):
+    def _install(backend):
+        import core.export as mod
+        monkeypatch.setattr(mod, "get_export_backend", lambda: backend)
+        return backend
+
+    return _install
+
+
+def test_export_status_serializes_state(_patch_export_backend):
+    from mcp_server.tools.export import export_status
+
+    _patch_export_backend(_FakeExportBackend())
+    result = export_status()
+    assert result["current_checkpoint"] == "/ckpt/last"
+    assert result["is_peft"] is True
+    assert result["is_export_active"] is False
+    assert result["last_op"]["kind"] == "export_merged"
+    assert result["last_op"]["output_path"] == "/out"
+
+
+def test_export_list_checkpoints_shapes_output(_patch_export_backend):
+    from mcp_server.tools.export import export_list_checkpoints
+
+    _patch_export_backend(_FakeExportBackend())
+    result = export_list_checkpoints()
+    assert result["runs"][0]["model_name"] == "mymodel"
+    assert result["runs"][0]["checkpoints"][0]["loss"] == 0.5
+
+
+def test_export_cancel_and_cleanup(_patch_export_backend):
+    from mcp_server.tools.export import export_cancel, export_cleanup
+
+    backend = _patch_export_backend(_FakeExportBackend())
+    assert export_cancel()["message"] == "Export cancelled"
+    assert backend.cancelled is True
+    assert export_cleanup()["success"] is True
+    assert backend.cleaned is True
+
+
+def test_export_merged_passes_params(_patch_export_backend):
+    from mcp_server.tools.export import export_merged
+
+    backend = _FakeExportBackend()
+    backend.export_merged_model = lambda **kw: (True, "ok", "/out/merged")
+    _patch_export_backend(backend)
+    result = export_merged(save_directory = "/out", format_type = "4-bit (FP4)")
+    assert result["success"] is True
+    assert result["output_path"] == "/out/merged"
+
+
+# ── export parity fixes (fingerprint / guard / validation / imatrix / register)
+
+
+def test_export_load_forwards_remote_code_fingerprint(_patch_export_backend):
+    from mcp_server.tools.export import export_load_checkpoint
+
+    backend = _FakeExportBackend()
+    _patch_export_backend(backend)
+    export_load_checkpoint(
+        "/ckpt",
+        trust_remote_code = True,
+        approved_remote_code_fingerprint = "abc123",
+    )
+    assert backend.load_kwargs["trust_remote_code"] is True
+    assert backend.load_kwargs["approved_remote_code_fingerprint"] == "abc123"
+    assert backend.load_kwargs["subject"] == "mcp"
+
+
+def test_export_load_surfaces_remote_code_payload(_patch_export_backend):
+    from mcp_server.tools.export import export_load_checkpoint
+
+    backend = _FakeExportBackend()
+    backend.load_checkpoint = lambda **kw: (False, "blocked by security scan")
+    backend.last_error_kind = "remote_code_consent_required"
+    backend.last_remote_code = {"fingerprint": "abc123", "approvable": True}
+    _patch_export_backend(backend)
+    result = export_load_checkpoint("/ckpt", trust_remote_code = True)
+    assert result["success"] is False
+    assert result["error_kind"] == "remote_code_consent_required"
+    assert result["remote_code"]["fingerprint"] == "abc123"
+
+
+def test_export_load_rejects_unsupported_host(monkeypatch):
+    from utils import hardware as hw_mod
+
+    from mcp_server.tools.export import export_load_checkpoint
+
+    monkeypatch.setattr(
+        hw_mod,
+        "export_capability",
+        lambda: {"export_supported": False, "export_unsupported_message": "no torch"},
+    )
+    result = export_load_checkpoint("/ckpt")
+    assert result["success"] is False
+    assert "no torch" in result["message"]
+
+
+def test_export_merged_rejects_unknown_format(_patch_export_backend):
+    from mcp_server.tools.export import export_merged
+
+    backend = _FakeExportBackend()
+    _patch_export_backend(backend)
+    result = export_merged(save_directory = "/out", format_type = "4bit")
+    assert result["success"] is False
+    assert "Unknown format_type" in result["message"]
+    assert backend.merged_kwargs is None  # backend never called
+
+
+def test_export_gguf_imatrix_bool_requests_auto_download(_patch_export_backend):
+    from mcp_server.tools.export import export_gguf
+
+    backend = _FakeExportBackend()
+    _patch_export_backend(backend)
+    export_gguf(save_directory = "/out", quantization_method = "iq4_xs", imatrix = True)
+    assert backend.gguf_kwargs["imatrix_file"] is True  # auto-download sentinel
+
+
+def test_export_gguf_imatrix_path_wins(_patch_export_backend):
+    from mcp_server.tools.export import export_gguf
+
+    backend = _FakeExportBackend()
+    _patch_export_backend(backend)
+    export_gguf(save_directory = "/out", imatrix = True, imatrix_file = "/i.dat")
+    assert backend.gguf_kwargs["imatrix_file"] == "/i.dat"
+
+
+def test_export_registers_external_folder(_patch_export_backend, monkeypatch, tmp_path):
+    import storage.studio_db as studio_db_mod
+
+    from mcp_server.tools.export import export_merged
+
+    registered: list[str] = []
+    monkeypatch.setattr(
+        studio_db_mod, "add_scan_folder", lambda p: registered.append(p) or {"path": p}
+    )
+    backend = _FakeExportBackend()
+    external = tmp_path / "elsewhere"  # outside exports_root
+    backend.export_merged_model = lambda **kw: (True, "ok", str(external))
+    _patch_export_backend(backend)
+    result = export_merged(save_directory = str(external), format_type = "16-bit (FP16)")
+    assert result["success"] is True
+    assert result.get("scan_folder_registered") == str(external)
+    assert registered == [str(external)]
+
+
+def test_export_load_rejects_out_of_range_seq_length(_patch_export_backend):
+    from mcp_server.tools.export import export_load_checkpoint
+
+    backend = _FakeExportBackend()
+    _patch_export_backend(backend)
+    too_big = export_load_checkpoint("/ckpt", max_seq_length = 999999)
+    assert too_big["success"] is False
+    assert "max_seq_length" in too_big["message"]
+    too_small = export_load_checkpoint("/ckpt", max_seq_length = 10)
+    assert too_small["success"] is False
+    assert backend.load_kwargs is None  # backend never reached
+    ok = export_load_checkpoint("/ckpt", max_seq_length = 2048)
+    assert ok["success"] is True
+
+
+def test_export_tools_reject_blank_save_directory(_patch_export_backend):
+    from mcp_server.tools.export import export_merged, export_gguf, export_lora
+    _patch_export_backend(_FakeExportBackend())
+    for fn, extra in [
+        (export_merged, {"format_type": "16-bit (FP16)"}),
+        (export_gguf, {}),
+        (export_lora, {}),
+    ]:
+        result = fn(save_directory = "", **extra)
+        assert result["success"] is False
+        assert "save_directory" in result["message"]
+
+
+def test_export_tools_reject_dotdot_save_directory(_patch_export_backend):
+    from mcp_server.tools.export import export_merged
+
+    _patch_export_backend(_FakeExportBackend())
+    result = export_merged(save_directory = "/out/../etc", format_type = "16-bit (FP16)")
+    assert result["success"] is False
+
+
+# ── training parity fixes (custom mapping / remote code / VRAM free)
+
+
+def test_train_start_forwards_custom_format_mapping(_patch_training_backend):
+    from mcp_server.tools.train import train_start
+
+    backend = _patch_training_backend(_FakeTrainingBackend())
+    mapping = {"instruction": "prompt", "output": "completion"}
+    train_start(
+        model_name = "unsloth/llama-3-8b-bnb-4bit",
+        hf_dataset = "yahma/alpaca-cleaned",
+        custom_format_mapping = mapping,
+    )
+    assert backend.last_kwargs["custom_format_mapping"] == mapping
+
+
+def test_train_start_forwards_trust_remote_code(_patch_training_backend):
+    from mcp_server.tools.train import train_start
+
+    backend = _patch_training_backend(_FakeTrainingBackend())
+    train_start(
+        model_name = "unsloth/llama-3-8b-bnb-4bit",
+        hf_dataset = "yahma/alpaca-cleaned",
+        trust_remote_code = True,
+        approved_remote_code_fingerprint = "fp",
+    )
+    assert backend.last_kwargs["trust_remote_code"] is True
+    assert backend.last_kwargs["approved_remote_code_fingerprint"] == "fp"
+
+
+def test_train_start_auto_trusts_first_party_yaml(monkeypatch, _patch_training_backend):
+    import utils.models.model_config as mc_mod
+    import utils.security.trusted_org as to_mod
+
+    from mcp_server.tools.train import train_start
+
+    monkeypatch.setattr(
+        mc_mod, "load_model_defaults", lambda _name: {"training": {"trust_remote_code": True}}
+    )
+    monkeypatch.setattr(to_mod, "is_trusted_org_repo", lambda *a, **k: True)
+    backend = _patch_training_backend(_FakeTrainingBackend())
+    train_start(model_name = "nvidia/SomeModel", hf_dataset = "yahma/alpaca-cleaned")
+    # YAML said trust + repo is first-party -> auto-trusted even though caller didn't ask.
+    assert backend.last_kwargs["trust_remote_code"] is True
+
+
+def test_train_start_frees_export_subprocess_before_spawn(monkeypatch, _patch_training_backend):
+    import core.export as export_mod
+
+    from mcp_server.tools.train import train_start
+
+    class _ExportWithSubprocess:
+        def __init__(self):
+            self.current_checkpoint = "/ckpt"
+            self.is_vision = True
+            self.is_peft = True
+            self.shut_down = False
+
+        def is_export_active(self):
+            return True
+
+        def _shutdown_subprocess(self):
+            self.shut_down = True
+
+    exp = _ExportWithSubprocess()
+    monkeypatch.setattr(export_mod, "get_export_backend", lambda: exp)
+    _patch_training_backend(_FakeTrainingBackend())
+    train_start(model_name = "unsloth/llama-3-8b-bnb-4bit", hf_dataset = "yahma/alpaca-cleaned")
+    assert exp.shut_down is True
+    assert exp.current_checkpoint is None
+    assert exp.is_vision is False and exp.is_peft is False
+
+
+def test_train_start_rejects_local_dataset_outside_roots(_patch_training_backend):
+    from mcp_server.tools.train import train_start
+
+    _patch_training_backend(_FakeTrainingBackend())
+    # Absolute path outside Studio's dataset roots is rejected (parity with the
+    # HTTP route's _validate_local_dataset_paths).
+    result = train_start(
+        model_name = "unsloth/llama-3-8b-bnb-4bit",
+        local_datasets = ["/etc/hosts"],
+        format_type = "alpaca",
+    )
+    assert result["success"] is False
+    assert "dataset" in result["error"].lower()
+
+
+def test_train_start_rejects_missing_local_dataset(_patch_training_backend):
+    from mcp_server.tools.train import train_start
+
+    _patch_training_backend(_FakeTrainingBackend())
+    result = train_start(
+        model_name = "unsloth/llama-3-8b-bnb-4bit",
+        local_datasets = ["definitely-not-a-registered-dataset"],
+        format_type = "alpaca",
+    )
+    assert result["success"] is False
+    assert "not found" in result["error"].lower()
+
+
+def test_train_start_defaults_vlm_layers_enabled(_patch_training_backend):
+    # The four finetune_* toggles must default to True (the Studio UI default),
+    # not the TrainingStartRequest False default, or VLM LoRA trains no layers.
+    from mcp_server.tools.train import train_start
+
+    backend = _patch_training_backend(_FakeTrainingBackend())
+    train_start(
+        model_name = "unsloth/Llama-3.2-11B-Vision-Instruct",
+        hf_dataset = "some/vlm-dataset",
+        is_dataset_image = True,
+    )
+    kw = backend.last_kwargs
+    assert kw["finetune_vision_layers"] is True
+    assert kw["finetune_language_layers"] is True
+    assert kw["finetune_attention_modules"] is True
+    assert kw["finetune_mlp_modules"] is True
+
+
+def test_train_status_surfaces_remote_code_payload(_patch_training_backend):
+    from mcp_server.tools.train import train_status
+
+    backend = _patch_training_backend(_FakeTrainingBackend(active = False))
+    backend.last_error_kind = "remote_code_consent_required"
+    backend.last_remote_code = {"fingerprint": "abc123", "approvable": True}
+    result = train_status()
+    assert result["error_kind"] == "remote_code_consent_required"
+    assert result["remote_code"]["fingerprint"] == "abc123"
+
+
+# ── CLI: Studio-venv re-exec helper
+
+
+def test_reexec_into_studio_venv_noop_when_deps_present(monkeypatch):
+    # In the test env fastmcp IS importable -> the helper must return (no re-exec).
+    from unsloth_cli.commands.studio import _reexec_into_studio_venv
+    assert _reexec_into_studio_venv(["studio", "mcp"]) is None
+
+
+def test_reexec_into_studio_venv_exits_when_unavailable(monkeypatch):
+    import importlib.util
+
+    import unsloth_cli.commands.studio as studio_cmd
+
+    # Pretend fastmcp is missing and no Studio venv exists.
+    monkeypatch.setattr(studio_cmd, "_studio_venv_python", lambda: None)
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+
+    with pytest.raises(typer.Exit) as exc:
+        studio_cmd._reexec_into_studio_venv(["studio", "mcp"])
+    assert exc.value.exit_code == 1
+
+
+def test_reexec_triggers_when_partial_deps_present(monkeypatch):
+    # fastmcp present but structlog absent -> still must re-exec into the venv.
+    import importlib.util
+
+    import unsloth_cli.commands.studio as studio_cmd
+
+    present = {"fastmcp", "structlog", "starlette", "fastapi"}
+
+    def _fake_find_spec(name):
+        class _S:
+            pass
+
+        return _S() if name == "fastmcp" else None  # only fastmcp present
+
+    monkeypatch.setattr(studio_cmd, "_studio_venv_python", lambda: None)
+    monkeypatch.setattr(importlib.util, "find_spec", _fake_find_spec)
+
+    with pytest.raises(typer.Exit) as exc:
+        studio_cmd._reexec_into_studio_venv(["studio", "mcp"])
+    assert exc.value.exit_code == 1
+
+
+# ── recipe tools (mocked manager) ─────────────────────────────────────
+
+
+class _FakeJobManager:
+    def __init__(self):
+        self.started = None
+        self.cancelled_id = None
+
+    def start(
+        self,
+        *,
+        recipe,
+        run,
+        internal_api_key_id = None,
+    ):
+        self.started = {"recipe": recipe, "run": run}
+        return "recipe_job_123"
+
+    def get_status(self, job_id):
+        if job_id != "recipe_job_123":
+            return None
+        return {"job_id": job_id, "status": "running", "rows": 10}
+
+    def get_current_status(self):
+        return {"job_id": "recipe_job_123", "status": "running"}
+
+    def cancel(self, job_id):
+        self.cancelled_id = job_id
+        return True
+
+
+@pytest.fixture
+def _patch_job_manager(monkeypatch):
+    def _install(mgr):
+        import core.data_recipe.jobs.manager as mod
+        monkeypatch.setattr(mod, "get_job_manager", lambda: mgr)
+        return mgr
+
+    return _install
+
+
+def test_recipe_start_requires_columns(_patch_job_manager):
+    from mcp_server.tools.recipe import recipe_start
+
+    _patch_job_manager(_FakeJobManager())
+    result = recipe_start(recipe = {})
+    assert result["success"] is False
+    assert "columns" in result["error"]
+
+
+def test_recipe_start_spawns_job(_patch_job_manager):
+    from mcp_server.tools.recipe import recipe_start
+
+    mgr = _patch_job_manager(_FakeJobManager())
+    result = recipe_start(recipe = {"columns": [{"name": "x"}]}, run = {"execution_type": "preview"})
+    assert result["success"] is True
+    assert result["job_id"] == "recipe_job_123"
+    assert mgr.started["run"]["execution_type"] == "preview"
+
+
+def test_recipe_start_rejects_bad_execution_type(_patch_job_manager):
+    from mcp_server.tools.recipe import recipe_start
+
+    _patch_job_manager(_FakeJobManager())
+    result = recipe_start(recipe = {"columns": [{}]}, run = {"execution_type": "weird"})
+    assert result["success"] is False
+
+
+def test_recipe_status_by_id(_patch_job_manager):
+    from mcp_server.tools.recipe import recipe_status
+
+    _patch_job_manager(_FakeJobManager())
+    assert recipe_status("recipe_job_123")["status"] == "running"
+    assert recipe_status("other")["idle"] is True
+
+
+def test_recipe_status_current(_patch_job_manager):
+    from mcp_server.tools.recipe import recipe_status
+    _patch_job_manager(_FakeJobManager())
+    assert recipe_status()["status"] == "running"
+
+
+def test_recipe_cancel(_patch_job_manager):
+    from mcp_server.tools.recipe import recipe_cancel
+
+    mgr = _patch_job_manager(_FakeJobManager())
+    result = recipe_cancel("recipe_job_123")
+    assert result["success"] is True
+    assert mgr.cancelled_id == "recipe_job_123"
+
+
+def test_recipe_validate_requires_columns():
+    from mcp_server.tools.recipe import recipe_validate
+    assert recipe_validate({})["valid"] is False
+
+
+def test_recipe_start_rejects_invalid_run_config(monkeypatch, _patch_job_manager):
+    import sys
+    import types
+
+    from mcp_server.tools.recipe import recipe_start
+
+    class _BadRunConfig:
+        @staticmethod
+        def model_validate(_value):
+            raise ValueError("bad fields")
+
+    # Inject a fake data_designer.config.run_config module so the validator runs.
+    fake_pkg = types.ModuleType("data_designer")
+    fake_cfg = types.ModuleType("data_designer.config")
+    fake_rc = types.ModuleType("data_designer.config.run_config")
+    fake_rc.RunConfig = _BadRunConfig
+    monkeypatch.setitem(sys.modules, "data_designer", fake_pkg)
+    monkeypatch.setitem(sys.modules, "data_designer.config", fake_cfg)
+    monkeypatch.setitem(sys.modules, "data_designer.config.run_config", fake_rc)
+
+    _patch_job_manager(_FakeJobManager())
+    result = recipe_start(
+        recipe = {"columns": [{"name": "x"}]},
+        run = {"run_config": {"this": "is wrong"}},
+    )
+    assert result["success"] is False
+    assert "run_config" in result["error"]
+
+
+# ── integration: FastMCP in-memory client ─────────────────────────────
+
+
+def test_build_server_registers_all_tools():
+    from fastmcp import Client
+
+    from mcp_server import build_server
+
+    server = build_server()
+    tools = asyncio.run(_list_tools(server))
+    assert len(tools) == 23
+    names = {t.name for t in tools}
+    for expected in [
+        "models_list",
+        "data_list_local",
+        "train_start",
+        "export_gguf",
+        "recipe_start",
+    ]:
+        assert expected in names
+
+
+def test_build_server_gated_subset():
+    from fastmcp import Client
+
+    from mcp_server import build_server
+
+    server = build_server(enabled = ["models", "data"])
+    tools = asyncio.run(_list_tools(server))
+    names = {t.name for t in tools}
+    assert "models_list" in names
+    assert "data_register" in names
+    assert "train_start" not in names
+    assert "export_gguf" not in names
+
+
+def test_read_only_tools_carry_annotation():
+    from fastmcp import Client
+
+    from mcp_server import build_server
+
+    server = build_server()
+    tools = {t.name: t for t in asyncio.run(_list_tools(server))}
+    assert tools["models_list"].annotations.readOnlyHint is True
+    assert tools["data_list_local"].annotations.readOnlyHint is True
+    # stateful tools are NOT marked read-only (unset => None, not True)
+    assert tools["train_start"].annotations.readOnlyHint is not True
+
+
+def test_client_can_call_tool_end_to_end():
+    from fastmcp import Client
+
+    from mcp_server import build_server
+
+    server = build_server(enabled = ["models"])
+    result = asyncio.run(_call_tool(server, "models_list", {}))
+    assert result["count"] > 0
+
+
+def test_build_server_rejects_unknown_group():
+    from mcp_server import build_server
+    with pytest.raises(ValueError, match = "Unknown feature group"):
+        build_server(enabled = ["bogus"])
+
+
+async def _list_tools(server):
+    from fastmcp import Client
+    async with Client(server) as client:
+        return await client.list_tools()
+
+
+async def _call_tool(server, name, arguments):
+    from fastmcp import Client
+    async with Client(server) as client:
+        result = await client.call_tool(name, arguments)
+        return result.data

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -198,6 +198,60 @@ def _studio_venv_python() -> Optional[Path]:
     return p if p.is_file() else None
 
 
+def _reexec_into_studio_venv(args: List[str]) -> None:
+    """Re-exec into the Studio venv if the backend deps are not importable here.
+
+    The outer ``unsloth`` CLI package does not depend on ``fastmcp``; on a
+    normal install the backend deps live in ``STUDIO_HOME/unsloth_studio``. The
+    MCP commands must therefore hand off to that interpreter before importing
+    ``mcp_server`` (mirrors the re-exec in ``studio run``). If already running
+    inside the Studio venv -- or the full backend dependency set is already
+    importable (e.g. a dev checkout with deps in the current interpreter) --
+    returns; otherwise execs (POSIX) or spawns-and-waits (Windows) and never
+    returns.
+    """
+    import importlib.util
+
+    # Probe the backend's hard deps together: fastmcp alone is not enough (the
+    # backend also needs structlog/starlette/...), so a partial outer install
+    # still triggers the venv hand-off.
+    _needed = ("fastmcp", "structlog", "starlette", "fastapi")
+
+    def _deps_present() -> bool:
+        return all(importlib.util.find_spec(mod) is not None for mod in _needed)
+
+    studio_venv_dir = STUDIO_HOME / "unsloth_studio"
+    in_studio_venv = sys.prefix.startswith(str(studio_venv_dir))
+    if in_studio_venv or _deps_present():
+        return  # the backend can be imported in this interpreter
+
+    studio_python = _studio_venv_python()
+    if not studio_python:
+        typer.echo(
+            "Studio MCP needs the Studio environment (backend deps not found and no "
+            "Studio venv detected). Run `unsloth studio setup` first.",
+            err = True,
+        )
+        raise typer.Exit(1)
+    # Console scripts are created as Scripts/unsloth.exe on Windows, unsloth elsewhere.
+    exe_name = "unsloth.exe" if sys.platform == "win32" else "unsloth"
+    studio_bin = studio_python.parent / exe_name
+    if not studio_bin.is_file():
+        typer.echo("Studio venv missing 'unsloth' entry point. Re-run: unsloth studio setup")
+        raise typer.Exit(1)
+
+    full_args = [str(studio_bin), *args]
+    if sys.platform == "win32":
+        proc = subprocess.Popen(full_args)
+        try:
+            rc = proc.wait()
+        except KeyboardInterrupt:
+            rc = proc.wait()
+        raise typer.Exit(rc)
+    else:
+        os.execvp(str(studio_bin), full_args)
+
+
 def _find_run_py() -> Optional[Path]:
     """Find studio/backend/run.py.
 
@@ -1952,3 +2006,104 @@ def reset_password():
         raise typer.Exit(0)
 
     typer.echo("Auth database deleted. Restart Unsloth Studio to get a new password.")
+
+
+@studio_app.command()
+def mcp(
+    enable: List[str] = typer.Option(
+        None,
+        "--enable",
+        help = (
+            "Feature group to expose (repeatable): models, data, train, export, recipe. "
+            "Defaults to all. Only the `models` group is fully read-only; `data` includes "
+            "data_register, which writes to the dataset store."
+        ),
+    ),
+    disable: List[str] = typer.Option(
+        None,
+        "--disable",
+        help = "Feature group to hide (repeatable). Applied after --enable.",
+    ),
+):
+    """Run Unsloth Studio as an MCP server over stdio.
+
+    Exposes Studio's models, datasets, training, export and Data Designer
+    recipe features as MCP tools so any MCP client (Claude Desktop, Cursor,
+    Cline, ...) can drive Unsloth Studio directly. Reuses Studio's in-process
+    backend; long-running work (training, export, recipe) runs in the existing
+    subprocess backends and is surfaced as start / status / stop tools.
+
+    Connect from an MCP client with a config like::
+
+        {"mcpServers": {"unsloth-studio": {"command": "unsloth", "args": ["studio", "mcp"]}}}
+
+    For a read-only agent profile (catalog/config discovery only)::
+
+        {"mcpServers": {"unsloth-studio": {"command": "unsloth", "args": ["studio", "mcp", "--enable", "models"]}}}
+    """
+    _ensure_studio_env_exported()
+
+    # fastmcp/backend deps live in the Studio venv; re-exec there first.
+    fwd = ["studio", "mcp"]
+    fwd += [tok for g in (enable or []) for tok in ("--enable", g)]
+    fwd += [tok for g in (disable or []) for tok in ("--disable", g)]
+    _reexec_into_studio_venv(fwd)
+
+    from unsloth_cli._inference import configure_quiet_logging, ensure_studio_backend_path
+
+    ensure_studio_backend_path()
+    configure_quiet_logging()
+
+    from mcp_server import run_stdio
+    from mcp_server.tools import resolve_groups
+
+    try:
+        selected = resolve_groups(enable, disable)
+    except ValueError as exc:
+        typer.echo(f"Error: {exc}", err = True)
+        raise typer.Exit(code = 2)
+
+    typer.echo(
+        f"Unsloth Studio MCP server (stdio) starting with groups: {', '.join(selected)}",
+        err = True,
+    )
+    run_stdio(enabled = selected)
+
+
+@studio_app.command("mcp-list-tools")
+def mcp_list_tools(
+    enable: List[str] = typer.Option(
+        None, "--enable", help = "Feature group to include (repeatable)."
+    ),
+    disable: List[str] = typer.Option(
+        None, "--disable", help = "Feature group to exclude (repeatable)."
+    ),
+):
+    """Print the MCP tools that would be exposed (dry-run, no server started)."""
+    _ensure_studio_env_exported()
+
+    # Resolves the same Studio-venv fastmcp dependency as `mcp`.
+    fwd = ["studio", "mcp-list-tools"]
+    fwd += [tok for g in (enable or []) for tok in ("--enable", g)]
+    fwd += [tok for g in (disable or []) for tok in ("--disable", g)]
+    _reexec_into_studio_venv(fwd)
+
+    from unsloth_cli._inference import ensure_studio_backend_path
+
+    ensure_studio_backend_path()
+
+    import asyncio
+
+    from mcp_server.server import list_tools
+    from mcp_server.tools import resolve_groups
+
+    try:
+        selected = resolve_groups(enable, disable)
+    except ValueError as exc:
+        typer.echo(f"Error: {exc}", err = True)
+        raise typer.Exit(code = 2)
+
+    tools = asyncio.run(list_tools(enabled = selected))
+    typer.echo(f"Groups: {', '.join(selected)}  ({len(tools)} tools)")
+    for tool in tools:
+        typer.echo(f"  {tool['name']:<26} [{tool['group']}]  {tool['description']}")


### PR DESCRIPTION
Closes #6941

## Summary

Unsloth Studio currently only acts as an MCP *client* (connecting external MCP servers into chat). This PR adds a **standalone MCP server** that exposes Studio itself, so any MCP client — Claude Desktop, Cursor, Cline, VS Code, etc. — can drive Unsloth Studio directly: list models, prepare datasets, launch fine-tuning, export checkpoints, and generate synthetic data with Data Designer.

The server reuses Studio's **in-process core layer** (the same singletons the FastAPI routes use — `get_training_backend`, `get_export_backend`, `get_job_manager`), so an MCP agent speaks the exact same backend a Studio UI session would. It runs over **stdio** and is launched via the CLI.

## What's added

New `studio/backend/mcp_server/` package + CLI wiring. **23 tools** across 5 feature groups:

| Group | Tools |
|-------|-------|
| `models` | `models_list`, `models_get_config`, `models_list_cached`, `models_checkpoints` |
| `data` | `data_list_local`, `data_check_format`, `data_register` |
| `train` | `train_start`, `train_status`, `train_stop` |
| `export` | `export_load_checkpoint`, `export_merged`, `export_gguf`, `export_lora`, `export_status`, `export_cancel`, `export_cleanup`, `export_list_checkpoints` |
| `recipe` | `recipe_validate`, `recipe_preview`, `recipe_start`, `recipe_status`, `recipe_cancel` |

Long-running work (training, export, recipe jobs) runs in Studio's existing subprocess backends and is surfaced as **start / status / stop** tools — `train_start` returns a job id immediately and the agent polls `train_status`. Read-only tools carry the MCP `readOnlyHint` annotation so clients can auto-approve them.

## Usage

```bash
# full server (all features)
unsloth studio mcp

# read-only profile
unsloth studio mcp --enable models --enable data

# dry-run: see what would be exposed
unsloth studio mcp-list-tools
```

Connect from an MCP client:
```json
{
  "mcpServers": {
    "unsloth-studio": { "command": "unsloth", "args": ["studio", "mcp"] }
  }
}
```

## Design notes

- **In-process core reuse**: imports Studio's core layer directly — single process, no HTTP hop, reuses auth state. `fastmcp>=3.0.2` is already a Studio dependency.
- **stdio = local trust**: no bearer-token auth (mirrors the existing loopback stdio-MCP policy in `utils/host_policy.py`). Tokens (`HF_TOKEN`, `WANDB_TOKEN`) resolve from the env.
- **Ergonomic tool inputs**: `train_start` exposes a curated, documented param set with Studio's recommended defaults; the full `TrainingStartRequest` is still used under the hood for validation.

## Testing

- **38 new tests** in `tests/test_mcp_server.py`: unit tests (handler functions with mocked singletons — no GPU needed) + integration tests via FastMCP's in-memory client.
- Verified a **real stdio round-trip**: spawned `unsloth studio mcp`, completed the MCP handshake, listed all 23 tools, and called one tool per feature group.
- Verified all error paths return clean `{success: false, error}` dicts rather than crashing (bad training type, validator failures, malformed datasets, missing `data_designer`).
- Existing `test_mcp_servers.py` (65 tests) still green; `ruff check` clean.

## Files

- `studio/backend/mcp_server/` — new package (`server.py`, `auth.py`, `tools/{models,data,train,export,recipe}.py`)
- `studio/backend/tests/test_mcp_server.py` — test suite
- `unsloth_cli/commands/studio.py` — `mcp` + `mcp-list-tools` CLI subcommands (+88 lines, no reformatting of existing code)
