### PR TITLE
Fix BAD_MAPPINGS not redirecting the -unsloth-bnb-4bit dynamic quants

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -364,6 +364,7 @@ jobs:
             tests/utils/test_attention_masks.py \
             tests/utils/test_trunc_normal_patch.py \
             tests/python/test_fast_language_model_text_only.py \
+            tests/test_bad_mappings_redirect.py \
             tests/test_prefetch_snapshot_scope.py \
             --deselect 'tests/utils/test_attention_masks.py::test_run_attention_flash_varlen_receives_window_and_softcap'
           # The deselected test monkeypatches flash_attn_varlen_func, which is

--- a/tests/test_bad_mappings_redirect.py
+++ b/tests/test_bad_mappings_redirect.py
@@ -1,9 +1,10 @@
 """Regression test for BAD_MAPPINGS redirecting oversized dynamic quants.
 
 get_model_name previously applied BAD_MAPPINGS only to the resolver's output,
-but the `-unsloth-bnb-4bit` names are keys of the mappers (the resolver returns
-None for them), so their BAD_MAPPINGS entries were dead and the oversized model
-loaded. The mapper table and the resolver have no heavy imports of their own,
+but several listed names (the `-unsloth-bnb-4bit` dynamic quants, plus any name
+the resolver doesn't map) come back as None, so their BAD_MAPPINGS entries were
+dead and the oversized model loaded. Asserting over every entry catches all of
+them. The mapper table and the resolver have no heavy imports of their own,
 so we exec the import-free mapper module and ast-extract the resolver functions
 rather than importing unsloth (which needs a GPU).
 """
@@ -16,10 +17,10 @@ _MODELS = os.path.join(os.path.dirname(__file__), os.pardir, "unsloth", "models"
 
 def _load_get_model_name():
     mapper_ns = {}
-    with open(os.path.join(_MODELS, "mapper.py")) as f:
+    with open(os.path.join(_MODELS, "mapper.py"), encoding = "utf-8") as f:
         exec(compile(f.read(), "mapper.py", "exec"), mapper_ns)
 
-    with open(os.path.join(_MODELS, "loader_utils.py")) as f:
+    with open(os.path.join(_MODELS, "loader_utils.py"), encoding = "utf-8") as f:
         tree = ast.parse(f.read())
 
     namespace = dict(mapper_ns)

--- a/tests/test_bad_mappings_redirect.py
+++ b/tests/test_bad_mappings_redirect.py
@@ -1,0 +1,46 @@
+"""Regression test for BAD_MAPPINGS redirecting oversized dynamic quants.
+
+get_model_name previously applied BAD_MAPPINGS only to the resolver's output,
+but the `-unsloth-bnb-4bit` names are keys of the mappers (the resolver returns
+None for them), so their BAD_MAPPINGS entries were dead and the oversized model
+loaded. The mapper table and the resolver have no heavy imports of their own,
+so we exec the import-free mapper module and ast-extract the resolver functions
+rather than importing unsloth (which needs a GPU).
+"""
+
+import ast
+import os
+
+_MODELS = os.path.join(os.path.dirname(__file__), os.pardir, "unsloth", "models")
+
+
+def _load_get_model_name():
+    mapper_ns = {}
+    with open(os.path.join(_MODELS, "mapper.py")) as f:
+        exec(compile(f.read(), "mapper.py", "exec"), mapper_ns)
+
+    with open(os.path.join(_MODELS, "loader_utils.py")) as f:
+        tree = ast.parse(f.read())
+
+    namespace = dict(mapper_ns)
+    namespace["SUPPORTS_FOURBIT"] = True
+    namespace["_env_says_offline"] = lambda: True
+    namespace["_get_new_mapper"] = lambda: ({}, {}, {})
+
+    wanted = {"__get_model_name", "_resolve_with_mappers", "get_model_name"}
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            getattr(target, "id", None) == "BAD_MAPPINGS" for target in node.targets
+        ):
+            exec(compile(ast.Module([node], []), "<bad_mappings>", "exec"), namespace)
+        elif isinstance(node, ast.FunctionDef) and node.name in wanted:
+            exec(compile(ast.Module([node], []), node.name, "exec"), namespace)
+
+    return namespace["get_model_name"], namespace["BAD_MAPPINGS"]
+
+
+def test_bad_mappings_redirect_every_listed_name():
+    get_model_name, bad_mappings = _load_get_model_name()
+    assert bad_mappings, "BAD_MAPPINGS should not be empty"
+    for name, expected in bad_mappings.items():
+        assert get_model_name(name, load_in_4bit=True) == expected, name

--- a/tests/test_bad_mappings_redirect.py
+++ b/tests/test_bad_mappings_redirect.py
@@ -43,4 +43,4 @@ def test_bad_mappings_redirect_every_listed_name():
     get_model_name, bad_mappings = _load_get_model_name()
     assert bad_mappings, "BAD_MAPPINGS should not be empty"
     for name, expected in bad_mappings.items():
-        assert get_model_name(name, load_in_4bit=True) == expected, name
+        assert get_model_name(name, load_in_4bit = True) == expected, name

--- a/unsloth/models/loader_utils.py
+++ b/unsloth/models/loader_utils.py
@@ -239,6 +239,11 @@ def get_model_name(
         and new_model_name.lower() in BAD_MAPPINGS
     ):
         new_model_name = BAD_MAPPINGS[new_model_name.lower()]
+    elif new_model_name is None and model_name.lower() in BAD_MAPPINGS:
+        # Some bad names (e.g. the `-unsloth-bnb-4bit` dynamic quants) are keys
+        # of the mappers, not values, so the resolver returns None for them and
+        # the remap above is skipped; remap the input name directly instead.
+        new_model_name = BAD_MAPPINGS[model_name.lower()]
 
     if (
         new_model_name is None


### PR DESCRIPTION
### Summary

`BAD_MAPPINGS` redirects a few oversized dynamic quants to smaller models, e.g.:

```python
BAD_MAPPINGS = {
    "unsloth/Qwen3-32B-unsloth-bnb-4bit".lower(): "unsloth/Qwen3-32B-bnb-4bit".lower(),  # 32B dynamic quant is way too big
    "unsloth/Qwen3-30B-A3B-unsloth-bnb-4bit".lower(): "unsloth/Qwen3-30B-A3B".lower(),   # HF loads MoEs too slowly
    ...
}
```

But the `-unsloth-bnb-4bit` entries never fire. `get_model_name` applies `BAD_MAPPINGS` only to the resolver's output:

```python
new_model_name = _resolve_with_mappers(...)
if (new_model_name is not None and ... and new_model_name.lower() in BAD_MAPPINGS):
    new_model_name = BAD_MAPPINGS[new_model_name.lower()]
```

The `-unsloth-bnb-4bit` names are **keys** of `INT_TO_FLOAT_MAPPER`, not values of `FLOAT_TO_INT_MAPPER`, so with `load_in_4bit=True` `_resolve_with_mappers` returns `None` for them. The remap is guarded by `new_model_name is not None`, so it is skipped, and `get_model_name` falls through to `new_model_name = model_name`, returning the oversized name unchanged. So `FastLanguageModel.from_pretrained("unsloth/Qwen3-32B-unsloth-bnb-4bit")` loads the large dynamic quant (much higher VRAM / OOM) instead of `unsloth/Qwen3-32B-bnb-4bit`, which is exactly what `BAD_MAPPINGS` is meant to prevent. The `-bnb-4bit` entries work because the resolver does resolve those, so the existing block catches them.

### Fix

When the resolver returns `None`, also remap the **input** name through `BAD_MAPPINGS`:

```python
    elif new_model_name is None and model_name.lower() in BAD_MAPPINGS:
        new_model_name = BAD_MAPPINGS[model_name.lower()]
```

This activates the `-unsloth-bnb-4bit` entries. Names the resolver does resolve (including the working `-bnb-4bit` entries) and all other names are unchanged, since this branch only runs when the resolver returned `None`.

### Test

`tests/test_bad_mappings_redirect.py` asserts that `get_model_name(name, load_in_4bit=True) == BAD_MAPPINGS[name.lower()]` for **every** `BAD_MAPPINGS` entry. It fails on the current code (the three `-unsloth-bnb-4bit` names come back unchanged) and passes with this fix. The mapper table and resolver have no heavy imports, so the test execs the import-free `mapper.py` and ast-extracts the resolver functions (no GPU, no `import unsloth`); it is wired into the Bucket-A CPU CI step.
