### PR TITLE
Studio: harden OpenAI-compatible GGUF streaming

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -100,6 +100,10 @@ class LlamaServerNotFoundError(RuntimeError):
     Subclasses RuntimeError so existing handlers still catch it."""
 
 
+class _LlamaStreamCancelled(Exception):
+    """Internal signal for an expected client/request cancellation."""
+
+
 # Shared so the from_identifier preflight and the load-time raise stay in sync.
 LLAMA_SERVER_NOT_FOUND_DETAIL = (
     "This is a GGUF model, but the llama.cpp runtime (llama-server) is not "
@@ -8369,7 +8373,7 @@ class LlamaCppBackend:
     ):
         """Open one streaming POST and let cancel interrupt prefill or reads."""
         if cancel_event is not None and cancel_event.is_set():
-            raise GeneratorExit
+            raise _LlamaStreamCancelled
 
         _cancel_closed = threading.Event()
         _response_ref: list = [None]
@@ -8414,13 +8418,13 @@ class LlamaCppBackend:
             ) as response:
                 _response_ref[0] = response
                 if cancel_event is not None and cancel_event.is_set():
-                    raise GeneratorExit
+                    raise _LlamaStreamCancelled
                 yield response
                 return
         except (httpx.RequestError, RuntimeError):
             # Response was closed by the cancel watcher
             if cancel_event is not None and cancel_event.is_set():
-                raise GeneratorExit
+                raise _LlamaStreamCancelled
             raise
         finally:
             _cancel_closed.set()
@@ -8623,6 +8627,8 @@ class LlamaCppBackend:
                         "finish_reason": _metadata_finish_reason,
                     }
 
+        except _LlamaStreamCancelled:
+            return
         except httpx.ConnectError as e:
             # Server already down. If this was an MTP+tensor crash, recover by
             # reloading without MTP (scheduled in the background) and fail this
@@ -9747,6 +9753,8 @@ class LlamaCppBackend:
                         break
                 continue
 
+            except _LlamaStreamCancelled:
+                return
             except httpx.ConnectError:
                 # Mark unresolved provisional cards as failed before raising.
                 for _pid, _pname in provisional_started_tool_calls.items():
@@ -9929,6 +9937,8 @@ class LlamaCppBackend:
                 if _meta is not None:
                     yield _meta
 
+        except _LlamaStreamCancelled:
+            return
         except httpx.ConnectError:
             raise RuntimeError("Lost connection to llama-server")
         except Exception as e:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -271,9 +271,6 @@ def _effective_max_tokens(payload):
 _OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV = "UNSLOTH_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS"
 _OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV = "UNSLOTH_OPENAI_COMPAT_MAX_TOKENS_CEILING"
 _OPENAI_COMPAT_STREAM_STALL_TIMEOUT_ENV = "UNSLOTH_OPENAI_COMPAT_STREAM_STALL_TIMEOUT"
-_OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT_ENV = (
-    "UNSLOTH_OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT"
-)
 
 
 def _positive_int_env(env_name: str, default):
@@ -812,103 +809,6 @@ def _openai_stream_usage_chunk(
     return f"data: {usage_chunk.model_dump_json(exclude_none = True)}\n\n"
 
 
-def _openai_non_stream_chat_response_sse_lines(
-    data: dict, payload, completion_id, model_name
-) -> list[str]:
-    """Convert a non-streaming chat completion JSON body into OpenAI SSE lines."""
-    if not isinstance(data, dict):
-        raise ValueError("non-streaming fallback response was not a JSON object")
-    created = data.get("created") or int(time.time())
-    chunk_id = data.get("id") or completion_id
-    chunk_model = data.get("model") or model_name
-
-    def _base_chunk() -> dict:
-        chunk = {
-            "id": chunk_id,
-            "object": "chat.completion.chunk",
-            "created": created,
-            "model": chunk_model,
-        }
-        fingerprint = data.get("system_fingerprint")
-        if fingerprint is not None:
-            chunk["system_fingerprint"] = fingerprint
-        return chunk
-
-    def _stream_tool_calls_with_indexes(tool_calls):
-        if not isinstance(tool_calls, list):
-            return tool_calls
-        indexed = []
-        for tool_index, tool_call in enumerate(tool_calls):
-            if isinstance(tool_call, dict) and tool_call.get("index") is None:
-                tool_call = {**tool_call, "index": tool_index}
-            indexed.append(tool_call)
-        return indexed
-
-    delta_choices = []
-    finish_choices = []
-    for fallback_choice in data.get("choices") or []:
-        if not isinstance(fallback_choice, dict):
-            continue
-        index = fallback_choice.get("index")
-        if index is None:
-            index = len(delta_choices)
-        message = fallback_choice.get("message") or {}
-        if not isinstance(message, dict):
-            message = {}
-        delta = {"role": message.get("role") or "assistant"}
-        for key in ("content", "reasoning_content", "tool_calls", "function_call"):
-            if key in message and message.get(key) is not None:
-                value = message.get(key)
-                if key == "tool_calls":
-                    value = _stream_tool_calls_with_indexes(value)
-                delta[key] = value
-        if "reasoning_content" in delta and "content" not in delta:
-            delta["content"] = ""
-        delta_choices.append(
-            {
-                "index": index,
-                "delta": delta,
-                "finish_reason": None,
-            }
-        )
-        finish_choices.append(
-            {
-                "index": index,
-                "delta": {},
-                "finish_reason": _clamp_finish_reason(fallback_choice.get("finish_reason")),
-            }
-        )
-
-    lines = []
-    if delta_choices:
-        chunk = _base_chunk()
-        chunk["choices"] = delta_choices
-        lines.append("data: " + json.dumps(chunk, separators = (",", ":"), ensure_ascii = False))
-    if finish_choices:
-        chunk = _base_chunk()
-        chunk["choices"] = finish_choices
-        lines.append("data: " + json.dumps(chunk, separators = (",", ":"), ensure_ascii = False))
-
-    usage = data.get("usage")
-    if _wants_stream_usage(payload) and isinstance(usage, dict):
-        chunk = _base_chunk()
-        chunk["choices"] = []
-        chunk["usage"] = {
-            "prompt_tokens": usage.get("prompt_tokens") or 0,
-            "completion_tokens": usage.get("completion_tokens") or 0,
-            "total_tokens": usage.get("total_tokens")
-            or ((usage.get("prompt_tokens") or 0) + (usage.get("completion_tokens") or 0)),
-            "prompt_tokens_details": _prompt_tokens_details(usage.get("prompt_tokens_details")),
-        }
-        timings = data.get("timings")
-        if timings is not None:
-            chunk["timings"] = timings
-        lines.append("data: " + json.dumps(chunk, separators = (",", ":"), ensure_ascii = False))
-
-    lines.append(_SSE_DONE_LINE)
-    return lines
-
-
 def _chat_chunk_sse(completion_id, created, model_name, *, delta, finish_reason) -> str:
     """One ``ChatCompletionChunk`` as an SSE ``data:`` line. The role / content /
     final chunks every in-process streamer emits differ only in their ``delta``
@@ -1203,7 +1103,6 @@ _STREAM_DISCONNECT_POLL_TIMEOUT_S = 0.25
 _OPENAI_PASSTHROUGH_PREHEADER_STATUS_WINDOW_S = 0.1
 _OPENAI_PASSTHROUGH_PENDING_RESPONSE_KEEPALIVE_S = 5.0
 _OPENAI_PASSTHROUGH_SSE_KEEPALIVE = ": keep-alive\n\n"
-_OPENAI_PASSTHROUGH_PREHEADER_FALLBACK_DEFAULT = None
 
 
 def _openai_compat_stream_stall_timeout():
@@ -1217,26 +1116,6 @@ def _openai_compat_stream_stall_timeout():
     return _positive_float_env(
         _OPENAI_COMPAT_STREAM_STALL_TIMEOUT_ENV,
         _DEFAULT_STREAM_STALL_TIMEOUT_S,
-    )
-
-
-def _openai_compat_stream_preheader_fallback_timeout():
-    """Optional retry deadline for a committed stream waiting for headers.
-
-    Studio always keeps the downstream SSE connection alive with comment
-    heartbeats while llama-server is still in prefill/header wait. Retrying via
-    the non-streaming path is intentionally opt-in: Studio cannot prove that
-    closing the HTTP request has released a single-slot backend, so starting a
-    second request too early can queue behind the first one and worsen latency
-    for agent clients.
-
-    Set ``UNSLOTH_OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT`` to a
-    positive number to opt into the retry; leave it unset or set it to 0 to keep
-    waiting on the original stream with heartbeats.
-    """
-    return _positive_float_env(
-        _OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT_ENV,
-        _OPENAI_PASSTHROUGH_PREHEADER_FALLBACK_DEFAULT,
     )
 
 
@@ -12222,7 +12101,6 @@ async def _openai_passthrough_stream(
     client = None
     resp = None
     send_task: Optional[asyncio.Task[Optional[httpx.Response]]] = None
-    preheader_fallback_deadline: Optional[float] = None
 
     async def _aclose_send_task(task: Optional[asyncio.Task[Optional[httpx.Response]]]) -> None:
         if task is None:
@@ -12238,10 +12116,6 @@ async def _openai_passthrough_stream(
                     pass
         except (asyncio.CancelledError, Exception):
             pass
-
-    def _new_preheader_fallback_deadline() -> Optional[float]:
-        timeout_s = _openai_compat_stream_preheader_fallback_timeout()
-        return None if timeout_s is None else time.monotonic() + timeout_s
 
     # Keep tracker cleanup paired if pre-header dispatch is cancelled.
     try:
@@ -12280,7 +12154,6 @@ async def _openai_passthrough_stream(
                         mark_cancel_on_cancel = False,
                     )
                 )
-                preheader_fallback_deadline = _new_preheader_fallback_deadline()
                 done, _ = await asyncio.wait(
                     {send_task},
                     timeout = _OPENAI_PASSTHROUGH_PREHEADER_STATUS_WINDOW_S,
@@ -12292,7 +12165,6 @@ async def _openai_passthrough_stream(
                 # Dispatch returned quickly enough to preserve pre-header status.
                 resp = await send_task
                 send_task = None
-                preheader_fallback_deadline = None
             except httpx.RequestError as e:
                 # llama-server subprocess crashed / starting / unreachable.
                 logger.error("openai passthrough stream: upstream unreachable: %s", e)
@@ -12367,7 +12239,7 @@ async def _openai_passthrough_stream(
             disconnect_watcher = None
 
             nonlocal resp, send_task, first_token_deadline, _truncate_budget
-            nonlocal client, preheader_fallback_deadline
+            nonlocal client
             monitor_done = False
             saw_finish_reason = False
             saw_done = False
@@ -12441,32 +12313,6 @@ async def _openai_passthrough_stream(
                 if terminal_seen:
                     return _OPENAI_PASSTHROUGH_TERMINAL_GRACE_S
                 return stall_timeout_s
-
-            async def _non_streaming_fallback_lines() -> list[str]:
-                nonlocal resp, send_task, client
-                await _aclose_send_task(send_task)
-                send_task = None
-                await _aclose_stream_resources(resp = resp, client = client)
-                resp = None
-                client = None
-                fallback_response = await _openai_passthrough_non_streaming(
-                    llama_backend,
-                    payload,
-                    model_name,
-                    monitor_id = monitor_id,
-                    request = request,
-                    cancel_event = cancel_event,
-                )
-                body_bytes = getattr(fallback_response, "body", b"")
-                if isinstance(body_bytes, str):
-                    body_bytes = body_bytes.encode("utf-8")
-                fallback_data = json.loads(body_bytes.decode("utf-8"))
-                return _openai_non_stream_chat_response_sse_lines(
-                    fallback_data,
-                    payload,
-                    completion_id,
-                    model_name,
-                )
 
             def _heal_transform(chunk_data: dict, raw_line: str) -> list:
                 """SSE lines to emit in place of one upstream line (healing on)."""
@@ -12546,16 +12392,6 @@ async def _openai_passthrough_stream(
                                 _STREAM_DISCONNECT_POLL_TIMEOUT_S,
                                 _OPENAI_PASSTHROUGH_PENDING_RESPONSE_KEEPALIVE_S,
                             )
-                            if preheader_fallback_deadline is not None:
-                                remaining_s = preheader_fallback_deadline - time.monotonic()
-                                if remaining_s <= 0:
-                                    logger.warning(
-                                        "openai passthrough stream: upstream headers delayed; falling back to non-streaming"
-                                    )
-                                    for fallback_line in await _non_streaming_fallback_lines():
-                                        yield fallback_line + "\n\n"
-                                    return
-                                wait_timeout = min(wait_timeout, max(remaining_s, 0.001))
                             done, _ = await asyncio.wait(
                                 {send_task},
                                 timeout = wait_timeout,
@@ -12587,7 +12423,6 @@ async def _openai_passthrough_stream(
                                 yield _openai_stream_error_sse(_openai_stream_error_chunk(e))
                                 return
                             send_task = None
-                            preheader_fallback_deadline = None
 
                     if resp is None:
                         api_monitor.finish(monitor_id, "cancelled")
@@ -12627,7 +12462,6 @@ async def _openai_passthrough_stream(
                                 mark_cancel_on_cancel = False,
                             )
                         )
-                        preheader_fallback_deadline = _new_preheader_fallback_deadline()
                         continue
 
                     upstream_error = _openai_passthrough_error(upstream_status, err_text)

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -9,7 +9,6 @@ import os
 import sys
 import time
 import uuid
-from urllib.parse import quote
 from pathlib import Path
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse, JSONResponse, Response
@@ -270,7 +269,6 @@ def _effective_max_tokens(payload):
 
 
 _OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV = "UNSLOTH_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS"
-_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_DEFAULT = 1024
 _OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV = "UNSLOTH_OPENAI_COMPAT_MAX_TOKENS_CEILING"
 _OPENAI_COMPAT_STREAM_STALL_TIMEOUT_ENV = "UNSLOTH_OPENAI_COMPAT_STREAM_STALL_TIMEOUT"
 _OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT_ENV = (
@@ -300,18 +298,15 @@ def _positive_float_env(env_name: str, default):
     return value if value > 0 else None
 
 
-def _openai_compat_implicit_max_tokens() -> int:
-    """Local serving default for OpenAI-compatible requests without a cap.
+def _openai_compat_implicit_max_tokens():
+    """Opt-in output cap for OpenAI-compatible requests that omit their own.
 
-    This is a latency/safety guard for local backends, not a strict OpenAI
-    behavior emulation. A future Studio setting can replace the environment
-    lookup without changing the callers: explicit request caps still win, and
-    this helper remains the single source for the omitted-cap policy.
+    OpenAI leaves an omitted ``max_tokens`` bounded only by the context window,
+    and Studio matches that by default (returns ``None``). Deployments that
+    want a local guard against runaway generations from cap-omitting clients
+    can set the env var; explicit request caps always win.
     """
-    return _positive_int_env(
-        _OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV,
-        _OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_DEFAULT,
-    )
+    return _positive_int_env(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, None)
 
 
 def _openai_compat_max_tokens_ceiling():
@@ -324,13 +319,13 @@ def _openai_compat_max_tokens_ceiling():
     return _positive_int_env(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, None)
 
 
-def _effective_openai_max_tokens_from_values(max_tokens, max_completion_tokens = None) -> int:
+def _effective_openai_max_tokens_from_values(max_tokens, max_completion_tokens = None):
     """Resolve the local OpenAI-compatible generation cap from raw request values.
 
-    OpenAI Chat Completions permits omitting ``max_tokens``. For local GGUF
-    serving, forwarding ``None`` lets lower layers expand the request to the
-    full context window, which can make small auxiliary client requests run for
-    minutes. Explicit client caps are preserved unless the deployment opts into
+    Returns ``None`` when the client omitted both fields and no local cap is
+    configured, so callers keep their context-window default (OpenAI treats an
+    omitted cap as bounded only by the context window). Explicit client caps
+    are preserved unless the deployment opts into
     ``UNSLOTH_OPENAI_COMPAT_MAX_TOKENS_CEILING``.
     """
 
@@ -365,11 +360,11 @@ def _effective_openai_max_tokens_from_values(max_tokens, max_completion_tokens =
     max_tokens = explicit if explicit is not None else _openai_compat_implicit_max_tokens()
     ceiling = _openai_compat_max_tokens_ceiling()
     if ceiling is not None:
-        max_tokens = min(max_tokens, ceiling)
+        max_tokens = ceiling if max_tokens is None else min(max_tokens, ceiling)
     return max_tokens
 
 
-def _effective_openai_max_tokens(payload) -> int:
+def _effective_openai_max_tokens(payload):
     return _effective_openai_max_tokens_from_values(
         getattr(payload, "max_tokens", None),
         getattr(payload, "max_completion_tokens", None),
@@ -955,12 +950,16 @@ def _chat_content_chunk(completion_id, created, model_name, text) -> str:
 
 
 def _chat_reasoning_chunk(completion_id, created, model_name, text) -> str:
-    """Like ``_chat_content_chunk`` but on ``reasoning_content`` (renders the UI thinking block)."""
+    """Like ``_chat_content_chunk`` but on ``reasoning_content`` (renders the UI thinking block).
+
+    Carries ``content: ""`` alongside, like the GGUF and passthrough paths, so
+    strict OpenAI adapters don't drop the reasoning-only delta.
+    """
     return _chat_chunk_sse(
         completion_id,
         created,
         model_name,
-        delta = ChoiceDelta(reasoning_content = text),
+        delta = ChoiceDelta(content = "", reasoning_content = text),
         finish_reason = None,
     )
 
@@ -1208,25 +1207,21 @@ def _set_stream_response_read_timeout(
 _STREAM_DISCONNECT_POLL_TIMEOUT_S = 0.25
 _OPENAI_PASSTHROUGH_PREHEADER_STATUS_WINDOW_S = 0.1
 _OPENAI_PASSTHROUGH_PENDING_RESPONSE_KEEPALIVE_S = 5.0
-_OPENAI_PASSTHROUGH_RESUMABLE_LOOKUP_INTERVAL_S = 0.5
-_OPENAI_PASSTHROUGH_RESUMABLE_LOOKUP_TIMEOUT_S = 0.25
 _OPENAI_PASSTHROUGH_SSE_KEEPALIVE = ": keep-alive\n\n"
-_OPENAI_PASSTHROUGH_STREAM_STALL_TIMEOUT_DEFAULT = 30.0
 _OPENAI_PASSTHROUGH_PREHEADER_FALLBACK_DEFAULT = None
 
 
 def _openai_compat_stream_stall_timeout():
     """Max silent gap after an OpenAI passthrough stream has produced data.
 
-    Local llama-server should continue emitting token chunks once generation has
-    started. If the socket goes silent after valid SSE data, keeping the client
-    open for the backend-wide stall timeout can look like a hung agent request.
-    The default is deliberately local-serving oriented and configurable; set the
-    env var to 0 to disable this shorter guard.
+    If the socket goes silent after valid SSE data, this bounds how long the
+    client is kept open. Defaults to the backend-wide stall timeout so this
+    path stalls out like every sibling stream; set the env var to tighten it
+    for local serving, or to 0 to disable the guard.
     """
     return _positive_float_env(
         _OPENAI_COMPAT_STREAM_STALL_TIMEOUT_ENV,
-        _OPENAI_PASSTHROUGH_STREAM_STALL_TIMEOUT_DEFAULT,
+        _DEFAULT_STREAM_STALL_TIMEOUT_S,
     )
 
 
@@ -1235,11 +1230,10 @@ def _openai_compat_stream_preheader_fallback_timeout():
 
     Studio always keeps the downstream SSE connection alive with comment
     heartbeats while llama-server is still in prefill/header wait. Retrying via
-    the non-streaming path is intentionally opt-in: before upstream headers are
-    returned, llama-server has not created a resumable stream session yet, so
-    Studio cannot prove that closing the HTTP request has released a
-    single-slot backend. Starting a second request too early can queue behind
-    the first one and worsen latency for agent clients.
+    the non-streaming path is intentionally opt-in: Studio cannot prove that
+    closing the HTTP request has released a single-slot backend, so starting a
+    second request too early can queue behind the first one and worsen latency
+    for agent clients.
 
     Set ``UNSLOTH_OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT`` to a
     positive number to opt into the retry; leave it unset or set it to 0 to keep
@@ -1251,104 +1245,13 @@ def _openai_compat_stream_preheader_fallback_timeout():
     )
 
 
-def _openai_passthrough_upstream_stream_id(completion_id: str) -> str:
-    return f"studio-{completion_id}-{uuid.uuid4().hex[:12]}"
-
-
-def _openai_passthrough_upstream_headers(
-    stream_id: Optional[str] = None, *, llama_backend = None
-) -> dict:
+def _openai_passthrough_upstream_headers(*, llama_backend = None) -> dict:
     headers = {}
     auth_headers = getattr(llama_backend, "_auth_headers", None)
     if isinstance(auth_headers, dict):
         headers.update(auth_headers)
     headers["Connection"] = "close"
-    if stream_id:
-        headers["X-Conversation-Id"] = stream_id
     return headers
-
-
-def _openai_resumable_session_has_replay_bytes(session) -> bool:
-    if not isinstance(session, dict):
-        return False
-    value = session.get("total_bytes")
-    return not isinstance(value, bool) and isinstance(value, (int, float)) and value > 0
-
-
-async def _openai_open_resumable_stream(
-    base_url: str,
-    stream_id: str,
-    headers: Optional[dict] = None,
-):
-    """Open llama-server's resumable SSE replay stream when available.
-
-    Newer llama-server builds attach a replay buffer when the original
-    streaming POST includes ``X-Conversation-Id``. This gives Studio a clean
-    recovery path for the Windows/httpx case where the original POST task does
-    not return headers even though llama-server has already started or finished
-    producing SSE chunks. Returns ``(client, response)`` or ``(None, None)`` so
-    callers can fall back to the original POST path on older servers.
-    """
-    client = httpx.AsyncClient(
-        timeout = httpx.Timeout(_OPENAI_PASSTHROUGH_RESUMABLE_LOOKUP_TIMEOUT_S),
-        limits = httpx.Limits(max_keepalive_connections = 0),
-        trust_env = False,
-    )
-    try:
-        lookup = await client.post(
-            f"{base_url}/v1/streams/lookup",
-            json = {"conversation_ids": [stream_id]},
-            headers = headers,
-        )
-        if lookup.status_code != 200:
-            return None, None
-        try:
-            sessions = lookup.json()
-        except Exception:
-            return None, None
-        if not isinstance(sessions, list) or not sessions:
-            return None, None
-        if not any(_openai_resumable_session_has_replay_bytes(s) for s in sessions):
-            return None, None
-        stream_url = f"{base_url}/v1/stream/{quote(stream_id, safe = '')}?from=0"
-        req = client.build_request("GET", stream_url, headers = headers)
-        resp = await client.send(req, stream = True)
-        if resp.status_code != 200:
-            try:
-                await resp.aclose()
-            except Exception:
-                pass
-            return None, None
-        return client, resp
-    except Exception as exc:
-        logger.debug("openai passthrough resumable stream unavailable: %s", exc)
-        return None, None
-    finally:
-        # Ownership transfers to the caller only when a response is returned.
-        if "resp" not in locals() or resp is None or getattr(resp, "status_code", None) != 200:
-            try:
-                await client.aclose()
-            except Exception:
-                pass
-
-
-async def _openai_delete_resumable_stream(
-    base_url: str,
-    stream_id: str,
-    headers: Optional[dict] = None,
-) -> None:
-    try:
-        async with httpx.AsyncClient(
-            timeout = httpx.Timeout(2.0),
-            limits = httpx.Limits(max_keepalive_connections = 0),
-            trust_env = False,
-        ) as client:
-            await client.delete(
-                f"{base_url}/v1/stream/{quote(stream_id, safe = '')}",
-                headers = headers,
-            )
-    except Exception:
-        pass
 
 
 class _CompatSameTaskTimeout:
@@ -8678,7 +8581,12 @@ async def openai_completions(request: Request, current_subject: str = Depends(ge
         if not isinstance(body, dict):
             raise HTTPException(status_code = 400, detail = "Request body must be a JSON object")
 
-    body["max_tokens"] = _effective_openai_max_tokens_from_values(body.get("max_tokens"))
+    _resolved_max_tokens = _effective_openai_max_tokens_from_values(body.get("max_tokens"))
+    body["max_tokens"] = (
+        _resolved_max_tokens
+        if _resolved_max_tokens is not None
+        else (llama_backend.context_length or _DEFAULT_MAX_TOKENS_FLOOR)
+    )
     target_url = f"{llama_backend.base_url}/v1/completions"
     is_stream = body.get("stream", False)
     prompt_text = _flatten_monitor_prompt(body.get("prompt", ""))
@@ -11541,7 +11449,7 @@ def _build_passthrough_payload(
     if stream and stream_options is not None:
         body["stream_options"] = stream_options
     body["max_tokens"] = (
-        max_tokens if max_tokens is not None else _openai_compat_implicit_max_tokens()
+        max_tokens if max_tokens is not None else (backend_ctx or _DEFAULT_MAX_TOKENS_FLOOR)
     )
     # Normalize stop the same way the non-passthrough path does (the passthrough
     # was previously the one path that forwarded an empty stop string verbatim).
@@ -12331,11 +12239,7 @@ async def _openai_passthrough_stream_upstream(
     tracker,
 ):
     target_url = f"{llama_backend.base_url}/v1/chat/completions"
-    upstream_stream_id = _openai_passthrough_upstream_stream_id(completion_id)
-    upstream_headers = _openai_passthrough_upstream_headers(
-        upstream_stream_id,
-        llama_backend = llama_backend,
-    )
+    upstream_headers = _openai_passthrough_upstream_headers(llama_backend = llama_backend)
 
     _tracker = tracker
     client = None
@@ -12361,20 +12265,6 @@ async def _openai_passthrough_stream_upstream(
     def _new_preheader_fallback_deadline() -> Optional[float]:
         timeout_s = _openai_compat_stream_preheader_fallback_timeout()
         return None if timeout_s is None else time.monotonic() + timeout_s
-
-    async def _delete_resumable_stream_for_cleanup() -> bool:
-        try:
-            await _openai_delete_resumable_stream(
-                llama_backend.base_url,
-                upstream_stream_id,
-                upstream_headers,
-            )
-            return False
-        except asyncio.CancelledError:
-            return True
-        except BaseException:
-            logger.debug("openai passthrough stream cleanup delete failed", exc_info = True)
-            return False
 
     async def _aclose_stream_resources_for_cleanup(**kwargs) -> bool:
         try:
@@ -12458,15 +12348,13 @@ async def _openai_passthrough_stream_upstream(
                 if cancel_event is not None:
                     cancel_event.set()
                 api_monitor.finish(monitor_id, "cancelled")
-                delete_cancelled = False
                 close_cancelled = False
                 try:
                     await _aclose_send_task(send_task)
                     close_cancelled = await _aclose_client_for_cleanup(client)
-                    delete_cancelled = await _delete_resumable_stream_for_cleanup()
                 finally:
                     _tracker.__exit__(None, None, None)
-                if close_cancelled or delete_cancelled:
+                if close_cancelled:
                     raise asyncio.CancelledError()
                 return _SameTaskStreamingResponse(
                     iter(()),
@@ -12604,8 +12492,6 @@ async def _openai_passthrough_stream_upstream(
                 await _aclose_stream_resources(resp = resp, client = client)
                 resp = None
                 client = None
-                if await _delete_resumable_stream_for_cleanup():
-                    raise asyncio.CancelledError()
                 fallback_response = await _openai_passthrough_non_streaming(
                     llama_backend,
                     payload,
@@ -12624,40 +12510,6 @@ async def _openai_passthrough_stream_upstream(
                     completion_id,
                     model_name,
                 )
-
-            async def _adopt_resumable_response() -> bool:
-                nonlocal resp, send_task, client, preheader_fallback_deadline
-                resume_client = None
-                resume_resp = None
-                try:
-                    resume_client, resume_resp = await _openai_open_resumable_stream(
-                        llama_backend.base_url,
-                        upstream_stream_id,
-                        upstream_headers,
-                    )
-                    if resume_resp is None:
-                        if resume_client is not None:
-                            await _aclose_stream_resources_for_cleanup(client = resume_client)
-                        return False
-                    logger.info(
-                        "openai passthrough stream: using llama-server resumable stream for delayed upstream response"
-                    )
-                    await _aclose_send_task(send_task)
-                    send_task = None
-                    await _aclose_stream_resources(resp = resp, client = client)
-                    resp = resume_resp
-                    client = resume_client
-                    resume_resp = None
-                    resume_client = None
-                    preheader_fallback_deadline = None
-                    return True
-                except BaseException:
-                    if resume_resp is not None or resume_client is not None:
-                        await _aclose_stream_resources_for_cleanup(
-                            resp = resume_resp,
-                            client = resume_client,
-                        )
-                    raise
 
             def _heal_transform(chunk_data: dict, raw_line: str) -> list:
                 """SSE lines to emit in place of one upstream line (healing on)."""
@@ -12730,8 +12582,11 @@ async def _openai_passthrough_stream_upstream(
                     if send_task is not None:
                         last_keepalive_at = time.monotonic()
                         while not send_task.done():
+                            # Wake often enough that _preheader_cancelled keeps
+                            # cancel/disconnect latency sub-second during prefill;
+                            # keepalives still pace off last_keepalive_at.
                             wait_timeout = min(
-                                _OPENAI_PASSTHROUGH_RESUMABLE_LOOKUP_INTERVAL_S,
+                                _STREAM_DISCONNECT_POLL_TIMEOUT_S,
                                 _OPENAI_PASSTHROUGH_PENDING_RESPONSE_KEEPALIVE_S,
                             )
                             if preheader_fallback_deadline is not None:
@@ -12751,8 +12606,6 @@ async def _openai_passthrough_stream_upstream(
                                 return_when = asyncio.FIRST_COMPLETED,
                             )
                             if send_task in done:
-                                break
-                            if await _adopt_resumable_response():
                                 break
                             if await _preheader_cancelled(cancel_event, request):
                                 api_monitor.finish(monitor_id, "cancelled")
@@ -13077,7 +12930,6 @@ async def _openai_passthrough_stream_upstream(
                 err = _openai_stream_error_chunk(e)
                 yield _openai_stream_error_sse(err)
             finally:
-                delete_cancelled = False
                 close_cancelled = False
                 try:
                     await _aclose_send_task(send_task)
@@ -13087,10 +12939,9 @@ async def _openai_passthrough_stream_upstream(
                         resp = resp,
                         client = client,
                     )
-                    delete_cancelled = await _delete_resumable_stream_for_cleanup()
                 finally:
                     _tracker.__exit__(None, None, None)
-                if close_cancelled or delete_cancelled:
+                if close_cancelled:
                     raise asyncio.CancelledError()
 
         async def _unstarted_cleanup() -> None:
@@ -13098,17 +12949,15 @@ async def _openai_passthrough_stream_upstream(
             # finally never ran. Release the eagerly-opened upstream resp/client
             # and the cancel-registry entry here; the watchers and line iterator
             # are created inside _stream(), so there is nothing else to close.
-            delete_cancelled = False
             close_cancelled = False
             try:
                 await _aclose_send_task(send_task)
                 close_cancelled = await _aclose_stream_resources_for_cleanup(
                     resp = resp, client = client
                 )
-                delete_cancelled = await _delete_resumable_stream_for_cleanup()
             finally:
                 _tracker.__exit__(None, None, None)
-            if close_cancelled or delete_cancelled:
+            if close_cancelled:
                 raise asyncio.CancelledError()
 
         return _SameTaskStreamingResponse(
@@ -13129,15 +12978,13 @@ async def _openai_passthrough_stream_upstream(
         else:
             detail = exc.detail if isinstance(exc, HTTPException) else _friendly_error(exc)
             api_monitor.fail(monitor_id, str(detail))
-        delete_cancelled = False
         close_cancelled = False
         try:
             await _aclose_send_task(send_task)
             close_cancelled = await _aclose_stream_resources_for_cleanup(resp = resp, client = client)
-            delete_cancelled = await _delete_resumable_stream_for_cleanup()
         finally:
             _tracker.__exit__(None, None, None)
-        if close_cancelled or delete_cancelled:
+        if close_cancelled:
             raise asyncio.CancelledError()
         raise
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -339,11 +339,14 @@ def _effective_openai_max_tokens_from_values(max_tokens, max_completion_tokens =
                     param = param,
                 ),
             )
-        if value <= 0:
+        # The legacy completions spec declares ``minimum: 0`` for max_tokens,
+        # so 0 is a valid (if degenerate) cap and only negatives are rejected.
+        # The chat fields never reach here with 0 (pydantic enforces ge=1).
+        if value < 0:
             raise HTTPException(
                 status_code = 400,
                 detail = openai_error_body(
-                    f"'{param}' must be greater than 0.",
+                    f"'{param}' must be at least 0.",
                     status = 400,
                     code = "invalid_value",
                     param = param,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -12216,33 +12216,9 @@ async def _openai_passthrough_stream(
     _cancel_keys = (payload.cancel_id, payload.session_id, completion_id)
     _tracker = _TrackedCancel(cancel_event, *_cancel_keys)
     _tracker.__enter__()
-    return await _openai_passthrough_stream_upstream(
-        request,
-        cancel_event,
-        llama_backend,
-        payload,
-        model_name,
-        completion_id,
-        monitor_id = monitor_id,
-        tracker = _tracker,
-    )
-
-
-async def _openai_passthrough_stream_upstream(
-    request,
-    cancel_event,
-    llama_backend,
-    payload,
-    model_name,
-    completion_id,
-    monitor_id: Optional[str] = None,
-    *,
-    tracker,
-):
     target_url = f"{llama_backend.base_url}/v1/chat/completions"
     upstream_headers = _openai_passthrough_upstream_headers(llama_backend = llama_backend)
 
-    _tracker = tracker
     client = None
     resp = None
     send_task: Optional[asyncio.Task[Optional[httpx.Response]]] = None

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -277,17 +277,14 @@ _OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT_ENV = (
 
 
 def _positive_int_env(env_name: str, default):
-    raw_value = os.environ.get(env_name)
-    if raw_value is None or not raw_value.strip():
-        return default
-    try:
-        value = int(raw_value.strip())
-    except ValueError:
-        return default
-    return value if value > 0 else default
+    value = _positive_int_or_none(os.environ.get(env_name))
+    return default if value is None else value
 
 
 def _positive_float_env(env_name: str, default):
+    """Unlike ``_positive_int_env``, a parseable non-positive value returns
+    ``None`` (0 disables the guarded feature); only unparseable or unset values
+    fall back to ``default``."""
     raw_value = os.environ.get(env_name)
     if raw_value is None or not raw_value.strip():
         return default
@@ -667,24 +664,6 @@ def _drop_parallel_tool_call_deltas(chunk) -> bool:
     return changed
 
 
-def _cap_parallel_tool_calls_sse_line(raw_line: str) -> str:
-    """Drop tool_call deltas whose index >= 1 from one streamed OpenAI SSE
-    ``data:`` line so only the first tool call survives (parallel_tool_calls=false,
-    best-effort). Non-tool / unparseable payloads are returned byte-for-byte."""
-    if not raw_line.startswith("data:"):
-        return raw_line
-    payload = raw_line[len("data:") :].lstrip()
-    if payload.strip() in ("", "[DONE]"):
-        return raw_line
-    try:
-        obj = json.loads(payload)
-    except Exception:
-        return raw_line
-    if not _drop_parallel_tool_call_deltas(obj):
-        return raw_line
-    return "data: " + json.dumps(obj, separators = (",", ":"))
-
-
 def _add_empty_content_to_reasoning_deltas(chunk: dict) -> bool:
     """Make reasoning-only deltas palatable to strict OpenAI adapters.
 
@@ -720,6 +699,12 @@ def _normalize_openai_passthrough_sse_line(
     """
     if not raw_line.startswith("data:"):
         return raw_line
+    # Both mutations key off JSON object keys, so a line without either quoted
+    # key can never change; skip the parse on the per-token common case.
+    if '"reasoning_content"' not in raw_line and not (
+        cap_parallel_tool_calls and '"tool_calls"' in raw_line
+    ):
+        return raw_line
     payload = raw_line[len("data:") :].lstrip()
     if payload.strip() in ("", "[DONE]"):
         return raw_line
@@ -752,6 +737,7 @@ def _wants_stream_usage(payload) -> bool:
 
 
 _OPENAI_PASSTHROUGH_TERMINAL_GRACE_S = 2.0
+_SSE_DONE_LINE = "data: [DONE]"
 
 
 def _openai_passthrough_sse_line_terminal_state(raw_line: str) -> Optional[str]:
@@ -771,6 +757,12 @@ def _openai_passthrough_sse_line_terminal_state(raw_line: str) -> Optional[str]:
         data = json.loads(data_str)
     except json.JSONDecodeError:
         return None
+    return _openai_passthrough_terminal_state_from_data(data)
+
+
+def _openai_passthrough_terminal_state_from_data(data) -> Optional[str]:
+    """Dict-level core of ``_openai_passthrough_sse_line_terminal_state`` for
+    callers that already parsed the chunk (avoids a re-parse per relayed line)."""
     if not isinstance(data, dict):
         return None
     if _monitor_openai_error_message(data):
@@ -910,7 +902,7 @@ def _openai_non_stream_chat_response_sse_lines(
             chunk["timings"] = timings
         lines.append("data: " + json.dumps(chunk, separators = (",", ":"), ensure_ascii = False))
 
-    lines.append("data: [DONE]")
+    lines.append(_SSE_DONE_LINE)
     return lines
 
 
@@ -2104,7 +2096,7 @@ async def _await_cancel_or_disconnect_then_close_client(
                 if cancel_event is not None:
                     cancel_event.set()
                 break
-            await asyncio.sleep(0.05)
+            await asyncio.sleep(0.1)
         try:
             await client.aclose()
         except Exception:
@@ -6937,7 +6929,6 @@ async def openai_chat_completions(
                     api_monitor.finish(
                         monitor_id, "cancelled" if cancel_event.is_set() else "completed"
                     )
-                    stream_completed = True
                     yield "data: [DONE]\n\n"
 
                 except asyncio.CancelledError:
@@ -7259,22 +7250,16 @@ async def openai_chat_completions(
                     finally:
                         _tracker.__exit__(None, None, None)
 
-            def _standard_stream_response():
-                async def _unstarted_cleanup() -> None:
-                    _tracker.__exit__(None, None, None)
-
-                return _SameTaskStreamingResponse(
-                    gguf_stream_chunks(),
-                    unstarted_cleanup = _unstarted_cleanup,
-                    media_type = "text/event-stream",
-                    headers = {
-                        "Cache-Control": "no-cache",
-                        "Connection": "close",
-                        "X-Accel-Buffering": "no",
-                    },
-                )
-
-            return _standard_stream_response()
+            return _SameTaskStreamingResponse(
+                gguf_stream_chunks(),
+                unstarted_cleanup = _tracked_cancel_unstarted_cleanup(_tracker),
+                media_type = "text/event-stream",
+                headers = {
+                    "Cache-Control": "no-cache",
+                    "Connection": "close",
+                    "X-Accel-Buffering": "no",
+                },
+            )
         else:
             try:
                 # ``n`` requests several independent completions; the single
@@ -12266,22 +12251,6 @@ async def _openai_passthrough_stream_upstream(
         timeout_s = _openai_compat_stream_preheader_fallback_timeout()
         return None if timeout_s is None else time.monotonic() + timeout_s
 
-    async def _aclose_stream_resources_for_cleanup(**kwargs) -> bool:
-        try:
-            await _aclose_stream_resources(**kwargs)
-            return False
-        except asyncio.CancelledError:
-            return True
-
-    async def _aclose_client_for_cleanup(close_client) -> bool:
-        try:
-            await close_client.aclose()
-            return False
-        except asyncio.CancelledError:
-            return True
-        except Exception:
-            return False
-
     # Keep tracker cleanup paired if pre-header dispatch is cancelled.
     try:
         body = _build_openai_passthrough_body(
@@ -12348,14 +12317,11 @@ async def _openai_passthrough_stream_upstream(
                 if cancel_event is not None:
                     cancel_event.set()
                 api_monitor.finish(monitor_id, "cancelled")
-                close_cancelled = False
                 try:
                     await _aclose_send_task(send_task)
-                    close_cancelled = await _aclose_client_for_cleanup(client)
+                    await _aclose_stream_resources(client = client)
                 finally:
                     _tracker.__exit__(None, None, None)
-                if close_cancelled:
-                    raise asyncio.CancelledError()
                 return _SameTaskStreamingResponse(
                     iter(()),
                     media_type = "text/event-stream",
@@ -12477,13 +12443,12 @@ async def _openai_passthrough_stream_upstream(
                     lines.append("data: " + json.dumps(chunk, ensure_ascii = False))
                 return lines
 
+            stall_timeout_s = _openai_compat_stream_stall_timeout()
+
             def _terminal_read_timeout_s() -> Optional[float]:
                 if terminal_seen:
                     return _OPENAI_PASSTHROUGH_TERMINAL_GRACE_S
-                return _openai_compat_stream_stall_timeout()
-
-            def _done_sse_line() -> str:
-                return "data: [DONE]"
+                return stall_timeout_s
 
             async def _non_streaming_fallback_lines() -> list[str]:
                 nonlocal resp, send_task, client
@@ -12597,7 +12562,6 @@ async def _openai_passthrough_stream_upstream(
                                     )
                                     for fallback_line in await _non_streaming_fallback_lines():
                                         yield fallback_line + "\n\n"
-                                    monitor_done = True
                                     return
                                 wait_timeout = min(wait_timeout, max(remaining_s, 0.001))
                             done, _ = await asyncio.wait(
@@ -12705,7 +12669,7 @@ async def _openai_passthrough_stream_upstream(
                     if not raw_line.startswith("data:"):
                         continue
                     saw_stream_item = True
-                    data_text = raw_line[5:].lstrip().strip()
+                    data_text = raw_line[5:].strip()
                     if data_text == "[DONE]":
                         saw_done = True
                         # Upstream ended without a finish chunk: heal the residue
@@ -12741,7 +12705,7 @@ async def _openai_passthrough_stream_upstream(
                         raw_line,
                         cap_parallel_tool_calls = payload.parallel_tool_calls is False,
                     )
-                    data_text = raw_line[5:].lstrip().strip()
+                    data_text = raw_line[5:].strip()
                     try:
                         chunk_data = json.loads(data_text)
                     except json.JSONDecodeError:
@@ -12820,11 +12784,15 @@ async def _openai_passthrough_stream_upstream(
                         if monitor_event == "done":
                             monitor_done = True
                             break
-                        terminal_state = _openai_passthrough_sse_line_terminal_state(out_line)
+                        terminal_state = (
+                            _openai_passthrough_terminal_state_from_data(chunk_data)
+                            if out_line is raw_line
+                            else _openai_passthrough_sse_line_terminal_state(out_line)
+                        )
                         if terminal_state == "usage" or (
                             terminal_state == "finish" and not _wants_stream_usage(payload)
                         ):
-                            done_line = _done_sse_line()
+                            done_line = _SSE_DONE_LINE
                             _monitor_openai_sse_line(
                                 monitor_id,
                                 done_line,
@@ -12857,7 +12825,7 @@ async def _openai_passthrough_stream_upstream(
                             llama_backend.context_length,
                         )
                         yield finish_line + "\n\n"
-                    done_line = "data: [DONE]"
+                    done_line = _SSE_DONE_LINE
                     _monitor_openai_sse_line(
                         monitor_id,
                         done_line,
@@ -12875,7 +12843,7 @@ async def _openai_passthrough_stream_upstream(
                 raise
             except httpx.ReadTimeout as e:
                 if terminal_seen and not saw_stream_error and not cancel_event.is_set():
-                    done_line = _done_sse_line()
+                    done_line = _SSE_DONE_LINE
                     _monitor_openai_sse_line(
                         monitor_id,
                         done_line,
@@ -12883,20 +12851,15 @@ async def _openai_passthrough_stream_upstream(
                     )
                     yield done_line + "\n\n"
                     api_monitor.finish(monitor_id)
-                    monitor_done = True
-                    return
-                if saw_stream_item and not saw_stream_error and not cancel_event.is_set():
-                    logger.error("openai passthrough stream stalled mid-response: %s", e)
-                    api_monitor.fail(monitor_id, _friendly_error(e))
-                    get_llama_cpp_backend()._maybe_recover_from_mtp_crash(e)
-                    err = _openai_stream_error_chunk(e)
-                    yield _openai_stream_error_sse(err)
-                    monitor_done = True
                     return
                 if cancel_event.is_set():
                     api_monitor.finish(monitor_id, "cancelled")
                     return
-                logger.error("openai passthrough stream timeout: %s", e)
+                logger.error(
+                    "openai passthrough stream %s: %s",
+                    "stalled mid-response" if saw_stream_item else "timeout",
+                    e,
+                )
                 api_monitor.fail(monitor_id, _friendly_error(e))
                 get_llama_cpp_backend()._maybe_recover_from_mtp_crash(e)
                 err = _openai_stream_error_chunk(e)
@@ -12930,10 +12893,11 @@ async def _openai_passthrough_stream_upstream(
                 err = _openai_stream_error_chunk(e)
                 yield _openai_stream_error_sse(err)
             finally:
-                close_cancelled = False
+                # _aclose_stream_resources re-raises a close-time CancelledError
+                # only after finishing teardown, and the tracker exits either way.
                 try:
                     await _aclose_send_task(send_task)
-                    close_cancelled = await _aclose_stream_resources_for_cleanup(
+                    await _aclose_stream_resources(
                         watchers = (cancel_watcher, disconnect_watcher),
                         iterator = lines_iter,
                         resp = resp,
@@ -12941,24 +12905,17 @@ async def _openai_passthrough_stream_upstream(
                     )
                 finally:
                     _tracker.__exit__(None, None, None)
-                if close_cancelled:
-                    raise asyncio.CancelledError()
 
         async def _unstarted_cleanup() -> None:
             # Client disconnected before the body stream started, so _stream()'s
             # finally never ran. Release the eagerly-opened upstream resp/client
             # and the cancel-registry entry here; the watchers and line iterator
             # are created inside _stream(), so there is nothing else to close.
-            close_cancelled = False
             try:
                 await _aclose_send_task(send_task)
-                close_cancelled = await _aclose_stream_resources_for_cleanup(
-                    resp = resp, client = client
-                )
+                await _aclose_stream_resources(resp = resp, client = client)
             finally:
                 _tracker.__exit__(None, None, None)
-            if close_cancelled:
-                raise asyncio.CancelledError()
 
         return _SameTaskStreamingResponse(
             _stream(),
@@ -12978,14 +12935,11 @@ async def _openai_passthrough_stream_upstream(
         else:
             detail = exc.detail if isinstance(exc, HTTPException) else _friendly_error(exc)
             api_monitor.fail(monitor_id, str(detail))
-        close_cancelled = False
         try:
             await _aclose_send_task(send_task)
-            close_cancelled = await _aclose_stream_resources_for_cleanup(resp = resp, client = client)
+            await _aclose_stream_resources(resp = resp, client = client)
         finally:
             _tracker.__exit__(None, None, None)
-        if close_cancelled:
-            raise asyncio.CancelledError()
         raise
 
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1371,7 +1371,8 @@ async def _aclose_stream_resources(
     """Tear down an httpx streaming generator's resources in the required order:
     cancel + await each watcher task, then aclose() the byte/line iterator, the
     response, and the client. Each step swallows its own exceptions so teardown
-    always completes. See _anthropic_passthrough_stream for the ordering rationale."""
+    always completes; a close-time CancelledError is re-raised only after every
+    step has run. See _anthropic_passthrough_stream for the ordering rationale."""
     for watcher in watchers:
         if watcher is not None:
             watcher.cancel()
@@ -1924,7 +1925,8 @@ def _explicit_studio_tool_loop_requested(payload) -> bool:
 
     Process-wide CLI policy can default Studio's tool loop on for ordinary chat,
     but it must not steal OpenAI-compatible client tools or response_format
-    requests from the llama-server passthrough path.
+    requests from the llama-server passthrough path. A policy of ``False``
+    (--disable-tools) vetoes even an explicit ``enable_tools: true`` ask.
     """
     from state.tool_policy import get_tool_policy
 
@@ -6511,7 +6513,12 @@ async def openai_chat_completions(
     _has_tool_catalog = bool(payload.tools and len(payload.tools) > 0)
     _has_active_tool_catalog = _has_tool_catalog and payload.tool_choice != "none"
     _has_client_tool_contract = _has_active_tool_catalog or _has_tool_messages
-    _studio_tool_loop_requested = _explicit_studio_tool_loop_requested(payload)
+    # The Studio tool loop needs a tool-capable backend, so a request that asks
+    # for it on a backend that can't run it (DiffusionGemma forces supports_tools
+    # off) must not steal client tools from the passthrough (#6851).
+    _studio_tool_loop_requested = (
+        _explicit_studio_tool_loop_requested(payload) and llama_backend.supports_tools
+    )
     _client_disabled_tool_calls = payload.tool_choice == "none" and not _studio_tool_loop_requested
     _supports_tool_passthrough = getattr(
         llama_backend, "supports_tool_passthrough", llama_backend.supports_tools
@@ -11635,13 +11642,17 @@ async def _anthropic_passthrough_stream(
                     yield event
                 return
         finally:
-            await _aclose_stream_resources(
-                watchers = (cancel_watcher, disconnect_watcher),
-                iterator = lines_iter,
-                resp = resp,
-                client = client,
-            )
-            _tracker.__exit__(None, None, None)
+            # Same shape as the OpenAI passthrough: a close-time CancelledError
+            # re-raised by _aclose_stream_resources must not skip the tracker exit.
+            try:
+                await _aclose_stream_resources(
+                    watchers = (cancel_watcher, disconnect_watcher),
+                    iterator = lines_iter,
+                    resp = resp,
+                    client = client,
+                )
+            finally:
+                _tracker.__exit__(None, None, None)
 
         for line in emitter.finish():
             yield line
@@ -12188,10 +12199,12 @@ async def _openai_passthrough_stream(
     """Streaming client-side pass-through for /v1/chat/completions.
 
     Forwards the client's OpenAI function-calling request to llama-server and
-    relays the SSE stream back verbatim, preserving llama-server's native
-    response ``id``, ``finish_reason`` (including ``"tool_calls"``),
-    ``delta.tool_calls``, and any client-requested trailing ``usage`` chunk so
-    the client sees a standard OpenAI response.
+    relays the SSE stream back with minimal normalization (reasoning-only
+    deltas gain ``content: ""``; errors and missing terminal markers get a
+    closing ``[DONE]``), preserving llama-server's native response ``id``,
+    ``finish_reason`` (including ``"tool_calls"``), ``delta.tool_calls``, and
+    any client-requested trailing ``usage`` chunk so the client sees a
+    standard OpenAI response.
 
     Reasoning/tool-call splitting is delegated to llama-server (``--jinja
     --reasoning-format auto``), so ``delta.content`` carries no raw markup and is
@@ -12258,7 +12271,7 @@ async def _openai_passthrough_stream_upstream(
         )
         # Text-form tool calls from small models get promoted to structured calls on
         # the way back (declared client tools only); requests without tools or with
-        # auto_heal_tool_calls=false keep the verbatim relay. tool_choice constrains
+        # auto_heal_tool_calls=false keep the unhealed relay. tool_choice constrains
         # the allowlist ("none" disables, a forced function narrows to it).
         _allowed_tools = heal_gate(
             payload.auto_heal_tool_calls, body.get("tools"), body.get("tool_choice")
@@ -12732,8 +12745,9 @@ async def _openai_passthrough_stream_upstream(
                         if _monitor_openai_error_message(chunk_data):
                             saw_stream_error = True
                     # With healing active, a content-bearing line may be replaced by
-                    # held/promoted chunks; otherwise the single upstream line
-                    # relays verbatim (monitored exactly as emitted either way).
+                    # held/promoted chunks; otherwise the single (already
+                    # normalized) line relays unchanged (monitored exactly as
+                    # emitted either way).
                     if (
                         healer is not None
                         and not healer.dormant

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -268,20 +268,13 @@ def _effective_max_tokens(payload):
     )
 
 
-_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV = "UNSLOTH_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS"
-_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV = "UNSLOTH_OPENAI_COMPAT_MAX_TOKENS_CEILING"
 _OPENAI_COMPAT_STREAM_STALL_TIMEOUT_ENV = "UNSLOTH_OPENAI_COMPAT_STREAM_STALL_TIMEOUT"
 
 
-def _positive_int_env(env_name: str, default):
-    value = _positive_int_or_none(os.environ.get(env_name))
-    return default if value is None else value
-
-
 def _positive_float_env(env_name: str, default):
-    """Unlike ``_positive_int_env``, a parseable non-positive value returns
-    ``None`` (0 disables the guarded feature); only unparseable or unset values
-    fall back to ``default``."""
+    """Parse a positive float from an env var. A parseable non-positive value
+    returns ``None`` (0 disables the guarded feature); only unparseable or unset
+    values fall back to ``default``."""
     raw_value = os.environ.get(env_name)
     if raw_value is None or not raw_value.strip():
         return default
@@ -292,35 +285,13 @@ def _positive_float_env(env_name: str, default):
     return value if value > 0 else None
 
 
-def _openai_compat_implicit_max_tokens():
-    """Opt-in output cap for OpenAI-compatible requests that omit their own.
-
-    OpenAI leaves an omitted ``max_tokens`` bounded only by the context window,
-    and Studio matches that by default (returns ``None``). Deployments that
-    want a local guard against runaway generations from cap-omitting clients
-    can set the env var; explicit request caps always win.
-    """
-    return _positive_int_env(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, None)
-
-
-def _openai_compat_max_tokens_ceiling():
-    """Optional service-level output cap for local OpenAI-compatible serving.
-
-    Unlike the implicit default above, this ceiling also applies to explicit
-    client caps when configured. It is disabled by default so strict clients keep
-    their requested value unless a local deployment opts into the guard.
-    """
-    return _positive_int_env(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, None)
-
-
 def _effective_openai_max_tokens_from_values(max_tokens, max_completion_tokens = None):
-    """Resolve the local OpenAI-compatible generation cap from raw request values.
+    """Resolve the OpenAI-compatible generation cap from raw request values.
 
-    Returns ``None`` when the client omitted both fields and no local cap is
-    configured, so callers keep their context-window default (OpenAI treats an
-    omitted cap as bounded only by the context window). Explicit client caps
-    are preserved unless the deployment opts into
-    ``UNSLOTH_OPENAI_COMPAT_MAX_TOKENS_CEILING``.
+    Prefers ``max_completion_tokens`` over the deprecated ``max_tokens``, and
+    returns ``None`` when both are omitted so callers keep their context-window
+    default (OpenAI treats an omitted cap as bounded only by the context
+    window). Explicit client caps pass through unchanged.
     """
 
     def _validate_explicit(value, param: str):
@@ -353,12 +324,7 @@ def _effective_openai_max_tokens_from_values(max_tokens, max_completion_tokens =
 
     max_tokens = _validate_explicit(max_tokens, "max_tokens")
     max_completion_tokens = _validate_explicit(max_completion_tokens, "max_completion_tokens")
-    explicit = max_completion_tokens if max_completion_tokens is not None else max_tokens
-    max_tokens = explicit if explicit is not None else _openai_compat_implicit_max_tokens()
-    ceiling = _openai_compat_max_tokens_ceiling()
-    if ceiling is not None:
-        max_tokens = ceiling if max_tokens is None else min(max_tokens, ceiling)
-    return max_tokens
+    return max_completion_tokens if max_completion_tokens is not None else max_tokens
 
 
 def _effective_openai_max_tokens(payload):

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1055,8 +1055,11 @@ def _llama_streaming_generation_timeout() -> httpx.Timeout:
 
 
 def _set_stream_response_read_timeout(
-    response: httpx.Response, read_timeout_s: float = _DEFAULT_STREAM_STALL_TIMEOUT_S
+    response: httpx.Response, read_timeout_s: Optional[float] = _DEFAULT_STREAM_STALL_TIMEOUT_S
 ) -> None:
+    # ``read_timeout_s = None`` clears httpx's read timeout (wait indefinitely),
+    # used when the stall guard is disabled so a stale first-token deadline
+    # can't keep timing out post-first-chunk gaps.
     try:
         timeout_ext = response.request.extensions.get("timeout")
         if isinstance(timeout_ext, dict):
@@ -1387,9 +1390,11 @@ async def _aiter_llama_stream_items(
                 continue
             raise httpx.ReadTimeout("The model stopped producing tokens mid-response.")
         if last_item_at is None and response is not None:
-            timeout_s = _post_first_timeout_s()
-            if timeout_s is not None:
-                _set_stream_response_read_timeout(response, timeout_s)
+            # The first-token read deadline no longer applies once a chunk has
+            # arrived: switch to the stall timeout, or clear the read timeout
+            # entirely when the stall guard is disabled (callable returns None)
+            # so a long gap can't trip the stale first-token deadline.
+            _set_stream_response_read_timeout(response, _post_first_timeout_s())
         last_item_at = time.monotonic()
         yield item
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -9,11 +9,12 @@ import os
 import sys
 import time
 import uuid
+from urllib.parse import quote
 from pathlib import Path
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse, JSONResponse, Response
 from starlette.requests import ClientDisconnect
-from typing import Any, List, Optional, Union
+from typing import Any, Callable, List, Optional, Union
 import json
 import httpx
 from loggers import get_logger
@@ -231,8 +232,126 @@ def _effective_max_tokens(payload):
     )
 
 
+_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV = "UNSLOTH_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS"
+_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_DEFAULT = 1024
+_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV = "UNSLOTH_OPENAI_COMPAT_MAX_TOKENS_CEILING"
+_OPENAI_COMPAT_STREAM_STALL_TIMEOUT_ENV = "UNSLOTH_OPENAI_COMPAT_STREAM_STALL_TIMEOUT"
+_OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT_ENV = (
+    "UNSLOTH_OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT"
+)
+
+
+def _positive_int_env(env_name: str, default):
+    raw_value = os.environ.get(env_name)
+    if raw_value is None or not raw_value.strip():
+        return default
+    try:
+        value = int(raw_value.strip())
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _positive_float_env(env_name: str, default):
+    raw_value = os.environ.get(env_name)
+    if raw_value is None or not raw_value.strip():
+        return default
+    try:
+        value = float(raw_value.strip())
+    except ValueError:
+        return default
+    return value if value > 0 else None
+
+
+def _openai_compat_implicit_max_tokens() -> int:
+    """Local serving default for OpenAI-compatible requests without a cap.
+
+    This is a latency/safety guard for local backends, not a strict OpenAI
+    behavior emulation. A future Studio setting can replace the environment
+    lookup without changing the callers: explicit request caps still win, and
+    this helper remains the single source for the omitted-cap policy.
+    """
+    return _positive_int_env(
+        _OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV,
+        _OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_DEFAULT,
+    )
+
+
+def _openai_compat_max_tokens_ceiling():
+    """Optional service-level output cap for local OpenAI-compatible serving.
+
+    Unlike the implicit default above, this ceiling also applies to explicit
+    client caps when configured. It is disabled by default so strict clients keep
+    their requested value unless a local deployment opts into the guard.
+    """
+    return _positive_int_env(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, None)
+
+
+def _effective_openai_max_tokens_from_values(max_tokens, max_completion_tokens = None) -> int:
+    """Resolve the local OpenAI-compatible generation cap from raw request values.
+
+    OpenAI Chat Completions permits omitting ``max_tokens``. For local GGUF
+    serving, forwarding ``None`` lets lower layers expand the request to the
+    full context window, which can make small auxiliary client requests run for
+    minutes. Explicit client caps are preserved unless the deployment opts into
+    ``UNSLOTH_OPENAI_COMPAT_MAX_TOKENS_CEILING``.
+    """
+
+    def _validate_explicit(value, param: str):
+        if value is None:
+            return None
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise HTTPException(
+                status_code = 400,
+                detail = openai_error_body(
+                    f"'{param}' must be an integer.",
+                    status = 400,
+                    code = "invalid_type",
+                    param = param,
+                ),
+            )
+        if value <= 0:
+            raise HTTPException(
+                status_code = 400,
+                detail = openai_error_body(
+                    f"'{param}' must be greater than 0.",
+                    status = 400,
+                    code = "invalid_value",
+                    param = param,
+                ),
+            )
+        return value
+
+    max_tokens = _validate_explicit(max_tokens, "max_tokens")
+    max_completion_tokens = _validate_explicit(max_completion_tokens, "max_completion_tokens")
+    explicit = max_completion_tokens if max_completion_tokens is not None else max_tokens
+    max_tokens = explicit if explicit is not None else _openai_compat_implicit_max_tokens()
+    ceiling = _openai_compat_max_tokens_ceiling()
+    if ceiling is not None:
+        max_tokens = min(max_tokens, ceiling)
+    return max_tokens
+
+
+def _effective_openai_max_tokens(payload) -> int:
+    return _effective_openai_max_tokens_from_values(
+        getattr(payload, "max_tokens", None),
+        getattr(payload, "max_completion_tokens", None),
+    )
+
+
 def _wants_multiple_choices(payload) -> bool:
     return (payload.n or 1) > 1
+
+
+def _has_openai_tool_history(messages) -> bool:
+    for message in messages or []:
+        if isinstance(message, dict):
+            if message.get("role") == "tool" or message.get("tool_calls"):
+                return True
+            continue
+        if getattr(message, "role", None) == "tool" or getattr(message, "tool_calls", None):
+            return True
+    return False
 
 
 def _raise_unsupported_openai_parameter(param: str, message: str) -> None:
@@ -292,6 +411,14 @@ def _openai_stream_error_chunk(exc) -> dict:
     if _cls is False:
         return openai_error_body(_friendly_error(exc), status = 400)
     return openai_error_body(_friendly_error(exc), status = 500)
+
+
+def _openai_stream_error_sse(error: dict) -> str:
+    return f"data: {json.dumps(error)}\n\ndata: [DONE]\n\n"
+
+
+def _openai_stream_error_sse_bytes(error: dict) -> bytes:
+    return _openai_stream_error_sse(error).encode("utf-8")
 
 
 def _openai_passthrough_error(status_code, text) -> "HTTPException":
@@ -512,7 +639,9 @@ def _cap_parallel_tool_calls_sse_line(raw_line: str) -> str:
     """Drop tool_call deltas whose index >= 1 from one streamed OpenAI SSE
     ``data:`` line so only the first tool call survives (parallel_tool_calls=false,
     best-effort). Non-tool / unparseable payloads are returned byte-for-byte."""
-    payload = raw_line[len("data: ") :]
+    if not raw_line.startswith("data:"):
+        return raw_line
+    payload = raw_line[len("data:") :].lstrip()
     if payload.strip() in ("", "[DONE]"):
         return raw_line
     try:
@@ -522,6 +651,58 @@ def _cap_parallel_tool_calls_sse_line(raw_line: str) -> str:
     if not _drop_parallel_tool_call_deltas(obj):
         return raw_line
     return "data: " + json.dumps(obj, separators = (",", ":"))
+
+
+def _add_empty_content_to_reasoning_deltas(chunk: dict) -> bool:
+    """Make reasoning-only deltas palatable to strict OpenAI adapters.
+
+    Some clients built on OpenAI-compatible streams ignore or reject chunks whose
+    delta only contains non-standard ``reasoning_content``. Preserve that field,
+    but add an empty standard ``content`` member so the chunk is still a valid
+    text-delta shape and downstream parsers keep the stream alive.
+    """
+    changed = False
+    choices = chunk.get("choices")
+    if not isinstance(choices, list):
+        return False
+    for choice in choices:
+        if not isinstance(choice, dict):
+            continue
+        delta = choice.get("delta")
+        if not isinstance(delta, dict):
+            continue
+        if "reasoning_content" in delta and "content" not in delta:
+            delta["content"] = ""
+            changed = True
+    return changed
+
+
+def _normalize_openai_passthrough_sse_line(
+    raw_line: str, *, cap_parallel_tool_calls: bool = False
+) -> str:
+    """Normalize one passthrough OpenAI SSE ``data:`` line before relaying.
+
+    The function is intentionally narrow: it leaves comments, blank events,
+    ``[DONE]``, and unparseable upstream bytes untouched; parsed chunks are
+    re-serialized only when a compatibility mutation is actually required.
+    """
+    if not raw_line.startswith("data:"):
+        return raw_line
+    payload = raw_line[len("data:") :].lstrip()
+    if payload.strip() in ("", "[DONE]"):
+        return raw_line
+    try:
+        obj = json.loads(payload)
+    except Exception:
+        return raw_line
+    if not isinstance(obj, dict):
+        return raw_line
+    changed = _add_empty_content_to_reasoning_deltas(obj)
+    if cap_parallel_tool_calls and _drop_parallel_tool_call_deltas(obj):
+        changed = True
+    if not changed:
+        return raw_line
+    return "data: " + json.dumps(obj, separators = (",", ":"), ensure_ascii = False)
 
 
 def _prompt_tokens_details(upstream):
@@ -536,6 +717,42 @@ def _prompt_tokens_details(upstream):
 
 def _wants_stream_usage(payload) -> bool:
     return bool((payload.stream_options or {}).get("include_usage"))
+
+
+_OPENAI_PASSTHROUGH_TERMINAL_GRACE_S = 2.0
+
+
+def _openai_passthrough_sse_line_terminal_state(raw_line: str) -> Optional[str]:
+    """Classify OpenAI-compatible chat stream terminal markers.
+
+    Some llama-server builds can emit the logical final chunk (``finish_reason``)
+    and optional usage chunk, then keep the HTTP stream open without sending the
+    OpenAI ``data: [DONE]`` sentinel. Classifying those chunks lets Studio close
+    the client stream promptly while preserving an optional trailing usage chunk.
+    """
+    if not raw_line.startswith("data:"):
+        return None
+    data_str = raw_line[5:].lstrip()
+    if data_str == "[DONE]":
+        return "done"
+    try:
+        data = json.loads(data_str)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    if _monitor_openai_error_message(data):
+        return "error"
+    choices = data.get("choices")
+    if isinstance(choices, list):
+        if not choices and isinstance(data.get("usage"), dict):
+            return "usage"
+        for choice in choices:
+            if isinstance(choice, dict) and choice.get("finish_reason") is not None:
+                return "finish"
+    elif isinstance(data.get("usage"), dict):
+        return "usage"
+    return None
 
 
 def _openai_stream_usage_chunk(
@@ -566,6 +783,103 @@ def _openai_stream_usage_chunk(
         timings = stream_timings,
     )
     return f"data: {usage_chunk.model_dump_json(exclude_none = True)}\n\n"
+
+
+def _openai_non_stream_chat_response_sse_lines(
+    data: dict, payload, completion_id, model_name
+) -> list[str]:
+    """Convert a non-streaming chat completion JSON body into OpenAI SSE lines."""
+    if not isinstance(data, dict):
+        raise ValueError("non-streaming fallback response was not a JSON object")
+    created = data.get("created") or int(time.time())
+    chunk_id = data.get("id") or completion_id
+    chunk_model = data.get("model") or model_name
+
+    def _base_chunk() -> dict:
+        chunk = {
+            "id": chunk_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": chunk_model,
+        }
+        fingerprint = data.get("system_fingerprint")
+        if fingerprint is not None:
+            chunk["system_fingerprint"] = fingerprint
+        return chunk
+
+    def _stream_tool_calls_with_indexes(tool_calls):
+        if not isinstance(tool_calls, list):
+            return tool_calls
+        indexed = []
+        for tool_index, tool_call in enumerate(tool_calls):
+            if isinstance(tool_call, dict) and tool_call.get("index") is None:
+                tool_call = {**tool_call, "index": tool_index}
+            indexed.append(tool_call)
+        return indexed
+
+    delta_choices = []
+    finish_choices = []
+    for fallback_choice in data.get("choices") or []:
+        if not isinstance(fallback_choice, dict):
+            continue
+        index = fallback_choice.get("index")
+        if index is None:
+            index = len(delta_choices)
+        message = fallback_choice.get("message") or {}
+        if not isinstance(message, dict):
+            message = {}
+        delta = {"role": message.get("role") or "assistant"}
+        for key in ("content", "reasoning_content", "tool_calls", "function_call"):
+            if key in message and message.get(key) is not None:
+                value = message.get(key)
+                if key == "tool_calls":
+                    value = _stream_tool_calls_with_indexes(value)
+                delta[key] = value
+        if "reasoning_content" in delta and "content" not in delta:
+            delta["content"] = ""
+        delta_choices.append(
+            {
+                "index": index,
+                "delta": delta,
+                "finish_reason": None,
+            }
+        )
+        finish_choices.append(
+            {
+                "index": index,
+                "delta": {},
+                "finish_reason": _clamp_finish_reason(fallback_choice.get("finish_reason")),
+            }
+        )
+
+    lines = []
+    if delta_choices:
+        chunk = _base_chunk()
+        chunk["choices"] = delta_choices
+        lines.append("data: " + json.dumps(chunk, separators = (",", ":"), ensure_ascii = False))
+    if finish_choices:
+        chunk = _base_chunk()
+        chunk["choices"] = finish_choices
+        lines.append("data: " + json.dumps(chunk, separators = (",", ":"), ensure_ascii = False))
+
+    usage = data.get("usage")
+    if _wants_stream_usage(payload) and isinstance(usage, dict):
+        chunk = _base_chunk()
+        chunk["choices"] = []
+        chunk["usage"] = {
+            "prompt_tokens": usage.get("prompt_tokens") or 0,
+            "completion_tokens": usage.get("completion_tokens") or 0,
+            "total_tokens": usage.get("total_tokens")
+            or ((usage.get("prompt_tokens") or 0) + (usage.get("completion_tokens") or 0)),
+            "prompt_tokens_details": _prompt_tokens_details(usage.get("prompt_tokens_details")),
+        }
+        timings = data.get("timings")
+        if timings is not None:
+            chunk["timings"] = timings
+        lines.append("data: " + json.dumps(chunk, separators = (",", ":"), ensure_ascii = False))
+
+    lines.append("data: [DONE]")
+    return lines
 
 
 def _chat_chunk_sse(completion_id, created, model_name, *, delta, finish_reason) -> str:
@@ -856,6 +1170,148 @@ def _set_stream_response_read_timeout(
 
 _STREAM_DISCONNECT_POLL_TIMEOUT_S = 0.25
 _OPENAI_PASSTHROUGH_PREHEADER_STATUS_WINDOW_S = 0.1
+_OPENAI_PASSTHROUGH_PENDING_RESPONSE_KEEPALIVE_S = 5.0
+_OPENAI_PASSTHROUGH_RESUMABLE_LOOKUP_INTERVAL_S = 0.5
+_OPENAI_PASSTHROUGH_RESUMABLE_LOOKUP_TIMEOUT_S = 0.25
+_OPENAI_PASSTHROUGH_SSE_KEEPALIVE = ": keep-alive\n\n"
+_OPENAI_PASSTHROUGH_STREAM_STALL_TIMEOUT_DEFAULT = 30.0
+_OPENAI_PASSTHROUGH_PREHEADER_FALLBACK_DEFAULT = None
+
+
+def _openai_compat_stream_stall_timeout():
+    """Max silent gap after an OpenAI passthrough stream has produced data.
+
+    Local llama-server should continue emitting token chunks once generation has
+    started. If the socket goes silent after valid SSE data, keeping the client
+    open for the backend-wide stall timeout can look like a hung agent request.
+    The default is deliberately local-serving oriented and configurable; set the
+    env var to 0 to disable this shorter guard.
+    """
+    return _positive_float_env(
+        _OPENAI_COMPAT_STREAM_STALL_TIMEOUT_ENV,
+        _OPENAI_PASSTHROUGH_STREAM_STALL_TIMEOUT_DEFAULT,
+    )
+
+
+def _openai_compat_stream_preheader_fallback_timeout():
+    """Optional retry deadline for a committed stream waiting for headers.
+
+    Studio always keeps the downstream SSE connection alive with comment
+    heartbeats while llama-server is still in prefill/header wait. Retrying via
+    the non-streaming path is intentionally opt-in: before upstream headers are
+    returned, llama-server has not created a resumable stream session yet, so
+    Studio cannot prove that closing the HTTP request has released a
+    single-slot backend. Starting a second request too early can queue behind
+    the first one and worsen latency for agent clients.
+
+    Set ``UNSLOTH_OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT`` to a
+    positive number to opt into the retry; leave it unset or set it to 0 to keep
+    waiting on the original stream with heartbeats.
+    """
+    return _positive_float_env(
+        _OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT_ENV,
+        _OPENAI_PASSTHROUGH_PREHEADER_FALLBACK_DEFAULT,
+    )
+
+
+def _openai_passthrough_upstream_stream_id(completion_id: str) -> str:
+    return f"studio-{completion_id}-{uuid.uuid4().hex[:12]}"
+
+
+def _openai_passthrough_upstream_headers(
+    stream_id: Optional[str] = None, *, llama_backend = None
+) -> dict:
+    headers = {}
+    auth_headers = getattr(llama_backend, "_auth_headers", None)
+    if isinstance(auth_headers, dict):
+        headers.update(auth_headers)
+    headers["Connection"] = "close"
+    if stream_id:
+        headers["X-Conversation-Id"] = stream_id
+    return headers
+
+
+def _openai_resumable_session_has_replay_bytes(session) -> bool:
+    if not isinstance(session, dict):
+        return False
+    value = session.get("total_bytes")
+    return not isinstance(value, bool) and isinstance(value, (int, float)) and value > 0
+
+
+async def _openai_open_resumable_stream(
+    base_url: str,
+    stream_id: str,
+    headers: Optional[dict] = None,
+):
+    """Open llama-server's resumable SSE replay stream when available.
+
+    Newer llama-server builds attach a replay buffer when the original
+    streaming POST includes ``X-Conversation-Id``. This gives Studio a clean
+    recovery path for the Windows/httpx case where the original POST task does
+    not return headers even though llama-server has already started or finished
+    producing SSE chunks. Returns ``(client, response)`` or ``(None, None)`` so
+    callers can fall back to the original POST path on older servers.
+    """
+    client = httpx.AsyncClient(
+        timeout = httpx.Timeout(_OPENAI_PASSTHROUGH_RESUMABLE_LOOKUP_TIMEOUT_S),
+        limits = httpx.Limits(max_keepalive_connections = 0),
+        trust_env = False,
+    )
+    try:
+        lookup = await client.post(
+            f"{base_url}/v1/streams/lookup",
+            json = {"conversation_ids": [stream_id]},
+            headers = headers,
+        )
+        if lookup.status_code != 200:
+            return None, None
+        try:
+            sessions = lookup.json()
+        except Exception:
+            return None, None
+        if not isinstance(sessions, list) or not sessions:
+            return None, None
+        if not any(_openai_resumable_session_has_replay_bytes(s) for s in sessions):
+            return None, None
+        stream_url = f"{base_url}/v1/stream/{quote(stream_id, safe = '')}?from=0"
+        req = client.build_request("GET", stream_url, headers = headers)
+        resp = await client.send(req, stream = True)
+        if resp.status_code != 200:
+            try:
+                await resp.aclose()
+            except Exception:
+                pass
+            return None, None
+        return client, resp
+    except Exception as exc:
+        logger.debug("openai passthrough resumable stream unavailable: %s", exc)
+        return None, None
+    finally:
+        # Ownership transfers to the caller only when a response is returned.
+        if "resp" not in locals() or resp is None or getattr(resp, "status_code", None) != 200:
+            try:
+                await client.aclose()
+            except Exception:
+                pass
+
+
+async def _openai_delete_resumable_stream(
+    base_url: str,
+    stream_id: str,
+    headers: Optional[dict] = None,
+) -> None:
+    try:
+        async with httpx.AsyncClient(
+            timeout = httpx.Timeout(2.0),
+            limits = httpx.Limits(max_keepalive_connections = 0),
+            trust_env = False,
+        ) as client:
+            await client.delete(
+                f"{base_url}/v1/stream/{quote(stream_id, safe = '')}",
+                headers = headers,
+            )
+    except Exception:
+        pass
 
 
 class _CompatSameTaskTimeout:
@@ -991,21 +1447,30 @@ async def _aclose_stream_resources(
                 await watcher
             except (asyncio.CancelledError, Exception):
                 pass
+    close_cancelled = False
     if iterator is not None:
         try:
             await iterator.aclose()
+        except asyncio.CancelledError:
+            close_cancelled = True
         except Exception:
             pass
     if resp is not None:
         try:
             await resp.aclose()
+        except asyncio.CancelledError:
+            close_cancelled = True
         except Exception:
             pass
     if client is not None:
         try:
             await client.aclose()
+        except asyncio.CancelledError:
+            close_cancelled = True
         except Exception:
             pass
+    if close_cancelled:
+        raise asyncio.CancelledError()
 
 
 async def _preheader_cancelled(cancel_event = None, request: Optional[Request] = None) -> bool:
@@ -1028,6 +1493,7 @@ async def _send_stream_with_preheader_cancel(
     req: httpx.Request,
     cancel_event = None,
     request: Optional[Request] = None,
+    mark_cancel_on_cancel: bool = True,
 ) -> Optional[httpx.Response]:
     if cancel_event is None and request is None:
         return await client.send(req, stream = True)
@@ -1059,7 +1525,7 @@ async def _send_stream_with_preheader_cancel(
         await _stop_send_task()
         return None
     except asyncio.CancelledError:
-        if cancel_event is not None:
+        if mark_cancel_on_cancel and cancel_event is not None:
             cancel_event.set()
         await _stop_send_task()
         raise
@@ -1078,11 +1544,19 @@ async def _aiter_llama_stream_items(
     request: Optional[Request] = None,
     first_token_deadline: Optional[float] = None,
     response: Optional[httpx.Response] = None,
-    post_first_item_read_timeout_s: Optional[float] = _DEFAULT_STREAM_STALL_TIMEOUT_S,
+    post_first_item_read_timeout_s: Optional[
+        Union[float, Callable[[], Optional[float]]]
+    ] = _DEFAULT_STREAM_STALL_TIMEOUT_S,
 ):
     if first_token_deadline is None:
         first_token_deadline = time.monotonic() + _DEFAULT_FIRST_TOKEN_TIMEOUT_S
     last_item_at: Optional[float] = None
+
+    def _post_first_timeout_s() -> Optional[float]:
+        if callable(post_first_item_read_timeout_s):
+            return post_first_item_read_timeout_s()
+        return post_first_item_read_timeout_s
+
     while True:
         if cancel_event is not None and cancel_event.is_set():
             return
@@ -1103,15 +1577,14 @@ async def _aiter_llama_stream_items(
                 async with _same_task_timeout(remaining_s):
                     item = await async_iter.__anext__()
             else:
+                timeout_s = _post_first_timeout_s()
                 if (
                     request is not None
                     and response is not None
-                    and post_first_item_read_timeout_s is not None
+                    and timeout_s is not None
                     and last_item_at is not None
                 ):
-                    stall_remaining_s = post_first_item_read_timeout_s - (
-                        time.monotonic() - last_item_at
-                    )
+                    stall_remaining_s = timeout_s - (time.monotonic() - last_item_at)
                     if stall_remaining_s <= 0:
                         raise httpx.ReadTimeout("The model stopped producing tokens mid-response.")
                     _set_stream_response_read_timeout(response, stall_remaining_s)
@@ -1128,19 +1601,14 @@ async def _aiter_llama_stream_items(
                 if now >= first_token_deadline:
                     raise
                 continue
-            if (
-                request is not None
-                and post_first_item_read_timeout_s is not None
-                and now - last_item_at < post_first_item_read_timeout_s
-            ):
+            timeout_s = _post_first_timeout_s()
+            if request is not None and timeout_s is not None and now - last_item_at < timeout_s:
                 continue
             raise httpx.ReadTimeout("The model stopped producing tokens mid-response.")
-        if (
-            last_item_at is None
-            and response is not None
-            and post_first_item_read_timeout_s is not None
-        ):
-            _set_stream_response_read_timeout(response, post_first_item_read_timeout_s)
+        if last_item_at is None and response is not None:
+            timeout_s = _post_first_timeout_s()
+            if timeout_s is not None:
+                _set_stream_response_read_timeout(response, timeout_s)
         last_item_at = time.monotonic()
         yield item
 
@@ -1519,6 +1987,19 @@ def _effective_enable_tools(payload) -> Optional[bool]:
     return policy if policy is not None else payload.enable_tools
 
 
+def _explicit_studio_tool_loop_requested(payload) -> bool:
+    """True when the request itself asks Studio to execute local tools.
+
+    Process-wide CLI policy can default Studio's tool loop on for ordinary chat,
+    but it must not steal OpenAI-compatible client tools or response_format
+    requests from the llama-server passthrough path.
+    """
+    from state.tool_policy import get_tool_policy
+
+    policy = get_tool_policy()
+    return policy is not False and (payload.enable_tools is True or bool(payload.mcp_enabled))
+
+
 # Cancel registry. Proxies (e.g. Colab) can swallow client fetch aborts so
 # is_disconnected() never fires. POST /inference/cancel looks up in-flight
 # cancel_events here by cancel_id (per-run) or session_id / completion_id
@@ -1655,6 +2136,39 @@ async def _await_disconnect_then_cancel(request, cancel_event) -> None:
         while not await request.is_disconnected():
             await asyncio.sleep(0.1)
         cancel_event.set()
+    except asyncio.CancelledError:
+        return
+
+
+def _cancelable_nonstreaming_client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        limits = httpx.Limits(max_connections = 1, max_keepalive_connections = 0),
+        trust_env = False,
+    )
+
+
+async def _await_cancel_or_disconnect_then_close_client(
+    *, cancel_event, request: Optional[Request], client: httpx.AsyncClient
+) -> None:
+    """Close a dedicated non-streaming upstream client on cancel/disconnect.
+
+    The shared ``nonstreaming_client()`` is pooled, so cancelable generation calls
+    use a per-request client. Closing it interrupts a blocked llama-server
+    request without affecting unrelated pooled non-streaming calls.
+    """
+    try:
+        while True:
+            if cancel_event is not None and cancel_event.is_set():
+                break
+            if request is not None and await request.is_disconnected():
+                if cancel_event is not None:
+                    cancel_event.set()
+                break
+            await asyncio.sleep(0.05)
+        try:
+            await client.aclose()
+        except Exception:
+            pass
     except asyncio.CancelledError:
         return
 
@@ -6040,11 +6554,11 @@ async def openai_chat_completions(
     # unaware of `role="tool"` messages and assistant messages that only
     # carry `tool_calls` (content=None) — both of which are valid in
     # multi-turn client-side tool loops.
-    effective_max_tokens = _effective_max_tokens(payload)
+    effective_max_tokens = _effective_openai_max_tokens(payload)
 
     normalized_stop = _normalize_stop_sequences(payload.stop)
 
-    _has_tool_messages = any(m.role == "tool" or m.tool_calls for m in payload.messages)
+    _has_tool_messages = _has_openai_tool_history(payload.messages)
     # Route guided-decoding requests through the verbatim passthrough so
     # ``response_format`` (JSON schema) reaches llama-server and the model's
     # GBNF-constrained output comes back unmodified. The non-passthrough GGUF
@@ -6053,13 +6567,38 @@ async def openai_chat_completions(
     # free-form sampling. Guided decoding does not require ``supports_tools`` --
     # the grammar machinery is independent of tool-call parsing.
     _has_response_format = _extract_response_format(payload) is not None
-    _tools_passthrough = getattr(
+    _has_tool_catalog = bool(payload.tools and len(payload.tools) > 0)
+    _has_active_tool_catalog = _has_tool_catalog and payload.tool_choice != "none"
+    _has_client_tool_contract = _has_active_tool_catalog or _has_tool_messages
+    _studio_tool_loop_requested = _explicit_studio_tool_loop_requested(payload)
+    _client_disabled_tool_calls = payload.tool_choice == "none" and not _studio_tool_loop_requested
+    _supports_tool_passthrough = getattr(
         llama_backend, "supports_tool_passthrough", llama_backend.supports_tools
-    ) and ((payload.tools and len(payload.tools) > 0) or _has_tool_messages)
-    # DiffusionGemma keeps supports_tools off, so the server-side tool loop can't
-    # claim the request; fall through to client passthrough, matching /v1/messages.
-    _server_tool_loop = _effective_enable_tools(payload) and llama_backend.supports_tools
-    if using_gguf and not _server_tool_loop and (_tools_passthrough or _has_response_format):
+    )
+    _tools_passthrough = _supports_tool_passthrough and _has_client_tool_contract
+    if (
+        using_gguf
+        and not _studio_tool_loop_requested
+        and _has_client_tool_contract
+        and not _supports_tool_passthrough
+    ):
+        raise _reject(
+            400,
+            openai_error_body(
+                (
+                    "Client-supplied tools or tool-call history require a GGUF chat template "
+                    "with tool-call support; the current model/template does not advertise tools."
+                ),
+                status = 400,
+                code = "unsupported_parameter",
+                param = "tools" if payload.tools else "messages",
+            ),
+        )
+    if (
+        using_gguf
+        and not _studio_tool_loop_requested
+        and (_tools_passthrough or _has_response_format)
+    ):
         if _wants_multiple_choices(payload):
             raise _reject_unsupported_n("GGUF tool or response_format passthrough")
         if payload.audio_base64:
@@ -6103,12 +6642,20 @@ async def openai_chat_completions(
                 completion_id,
                 monitor_id = monitor_id,
             )
-        return await _openai_passthrough_non_streaming(
-            llama_backend,
-            payload,
-            model_name,
-            monitor_id = monitor_id,
-        )
+        _cancel_keys = (payload.cancel_id, payload.session_id, completion_id)
+        _tracker = _TrackedCancel(cancel_event, *_cancel_keys)
+        _tracker.__enter__()
+        try:
+            return await _openai_passthrough_non_streaming(
+                llama_backend,
+                payload,
+                model_name,
+                monitor_id = monitor_id,
+                request = request,
+                cancel_event = cancel_event,
+            )
+        finally:
+            _tracker.__exit__(None, None, None)
 
     # ── Parse messages (handles multimodal content parts) ─────
     # Reuse the pre-hook parse when auto-switch did it, else parse now.
@@ -6168,6 +6715,8 @@ async def openai_chat_completions(
             )
 
         def _gguf_chat_delta_line(delta: ChoiceDelta, finish_reason = None) -> str:
+            if delta.reasoning_content is not None and delta.content is None:
+                delta = delta.model_copy(update = {"content": ""})
             chunk = ChatCompletionChunk(
                 id = completion_id,
                 created = created,
@@ -6191,8 +6740,12 @@ async def openai_chat_completions(
         from state.tool_policy import get_tool_policy as _get_tool_policy_g
 
         _cli_policy = _get_tool_policy_g()
-        _tools_on = _effective_enable_tools(payload)
-        _mcp_allowed = bool(payload.mcp_enabled) and _cli_policy is not False
+        _tools_on = False if _client_disabled_tool_calls else _effective_enable_tools(payload)
+        _mcp_allowed = (
+            not _client_disabled_tool_calls
+            and bool(payload.mcp_enabled)
+            and _cli_policy is not False
+        )
         use_tools = (_tools_on or _mcp_allowed) and llama_backend.supports_tools
 
         if use_tools:
@@ -6435,6 +6988,7 @@ async def openai_chat_completions(
                     api_monitor.finish(
                         monitor_id, "cancelled" if cancel_event.is_set() else "completed"
                     )
+                    stream_completed = True
                     yield "data: [DONE]\n\n"
 
                 except asyncio.CancelledError:
@@ -6447,7 +7001,7 @@ async def openai_chat_completions(
                     # Recover if an MTP+tensor crash killed the server mid-stream.
                     get_llama_cpp_backend()._maybe_recover_from_mtp_crash(e)
                     error_chunk = _openai_stream_error_chunk(e)
-                    yield f"data: {json.dumps(error_chunk)}\n\n"
+                    yield _openai_stream_error_sse(error_chunk)
                 finally:
                     await _stop_local_disconnect_cancel_watcher(disconnect_watcher)
                     if gen is not None:
@@ -6614,6 +7168,9 @@ async def openai_chat_completions(
                 disconnect_watcher = asyncio.create_task(
                     _await_disconnect_then_cancel(request, cancel_event)
                 )
+                gen = None
+                next_task = None
+                stream_completed = False
                 try:
                     yield _chat_role_chunk(completion_id, created, model_name)
 
@@ -6632,7 +7189,14 @@ async def openai_chat_completions(
                             cancel_event.set()
                             api_monitor.finish(monitor_id, "cancelled")
                             return
-                        cumulative = await asyncio.to_thread(next, gen, _gguf_sentinel)
+                        next_task = asyncio.create_task(
+                            asyncio.to_thread(next, gen, _gguf_sentinel)
+                        )
+                        try:
+                            cumulative = await asyncio.shield(next_task)
+                        finally:
+                            if next_task.done():
+                                next_task = None
                         if cumulative is _gguf_sentinel:
                             break
                         # Capture server metadata for the final usage chunk
@@ -6701,6 +7265,7 @@ async def openai_chat_completions(
                     api_monitor.finish(
                         monitor_id, "cancelled" if cancel_event.is_set() else "completed"
                     )
+                    stream_completed = True
                     yield "data: [DONE]\n\n"
 
                 except asyncio.CancelledError:
@@ -6711,73 +7276,145 @@ async def openai_chat_completions(
                     logger.error(f"Error during GGUF streaming: {e}", exc_info = True)
                     api_monitor.fail(monitor_id, _friendly_error(e))
                     error_chunk = _openai_stream_error_chunk(e)
-                    yield f"data: {json.dumps(error_chunk)}\n\n"
+                    yield _openai_stream_error_sse(error_chunk)
                 finally:
-                    await _stop_local_disconnect_cancel_watcher(disconnect_watcher)
+                    try:
+                        if not stream_completed:
+                            cancel_event.set()
+                        task_to_drain = next_task
+                        next_task = None
+                        while task_to_drain is not None and not task_to_drain.done():
+                            try:
+                                await asyncio.shield(task_to_drain)
+                            except asyncio.CancelledError:
+                                cancel_event.set()
+                                continue
+                            except Exception:
+                                break
+                        if task_to_drain is not None and task_to_drain.done():
+                            try:
+                                task_to_drain.exception()
+                            except (asyncio.CancelledError, Exception):
+                                pass
+                        if gen is not None and not stream_completed:
+                            try:
+                                await asyncio.to_thread(gen.close)
+                            except (RuntimeError, ValueError):
+                                pass
+                            except Exception:
+                                logger.debug(
+                                    "Error closing GGUF stream generator during cleanup",
+                                    exc_info = True,
+                                )
+                        await _stop_local_disconnect_cancel_watcher(disconnect_watcher)
+                    finally:
+                        _tracker.__exit__(None, None, None)
+
+            def _standard_stream_response():
+                async def _unstarted_cleanup() -> None:
                     _tracker.__exit__(None, None, None)
 
-            return _SameTaskStreamingResponse(
-                gguf_stream_chunks(),
-                unstarted_cleanup = _tracked_cancel_unstarted_cleanup(_tracker),
-                media_type = "text/event-stream",
-                headers = {
-                    "Cache-Control": "no-cache",
-                    "Connection": "close",
-                    "X-Accel-Buffering": "no",
-                },
-            )
+                return _SameTaskStreamingResponse(
+                    gguf_stream_chunks(),
+                    unstarted_cleanup = _unstarted_cleanup,
+                    media_type = "text/event-stream",
+                    headers = {
+                        "Cache-Control": "no-cache",
+                        "Connection": "close",
+                        "X-Accel-Buffering": "no",
+                    },
+                )
+
+            return _standard_stream_response()
         else:
             try:
                 # ``n`` requests several independent completions; the single
                 # decode slot yields one at a time, so loop sequentially.
-                _n = payload.n or 1
+                drain_task = None
 
-                _choices = []
-                _monitor_replies = []
-                _prompt_tokens = 0
-                _sum_completion = 0
-                _prompt_details = None
-                for _idx in range(_n):
-                    # Stop spawning the remaining choices once cancelled.
-                    if cancel_event.is_set():
-                        break
-                    full_text = ""
-                    completion_usage = None
-                    completion_finish = None
-                    for token in gguf_generate(_idx):
-                        if isinstance(token, dict):
-                            if token.get("type") == "metadata":
-                                completion_usage = token.get("usage")
-                                completion_finish = token.get("finish_reason")
+                async def _drain_cancelled_gguf_task():
+                    if drain_task is None:
+                        return
+                    while not drain_task.done():
+                        try:
+                            await asyncio.shield(drain_task)
+                        except asyncio.CancelledError:
+                            cancel_event.set()
                             continue
-                        full_text = token
+                        except Exception:
+                            break
+                    if drain_task.done():
+                        try:
+                            drain_task.exception()
+                        except (asyncio.CancelledError, Exception):
+                            pass
 
-                    reasoning_text, visible_text = _extract_responses_reasoning(
-                        full_text,
-                        parse_think_markers = _responses_should_parse_think_markers(
-                            payload,
-                            llama_backend,
-                        ),
-                    )
-                    message_kwargs = {"content": visible_text}
-                    if reasoning_text:
-                        message_kwargs["reasoning_content"] = reasoning_text
-                    _choices.append(
-                        CompletionChoice(
-                            index = _idx,
-                            message = CompletionMessage(**message_kwargs),
-                            finish_reason = _clamp_finish_reason(completion_finish),
+                def _drain_gguf_choices():
+                    _n = payload.n or 1
+                    _choices = []
+                    _monitor_replies = []
+                    _prompt_tokens = 0
+                    _sum_completion = 0
+                    _prompt_details = None
+                    for _idx in range(_n):
+                        # Stop spawning the remaining choices once cancelled.
+                        if cancel_event.is_set():
+                            break
+                        full_text = ""
+                        completion_usage = None
+                        completion_finish = None
+                        for token in gguf_generate(_idx):
+                            if isinstance(token, dict):
+                                if token.get("type") == "metadata":
+                                    completion_usage = token.get("usage")
+                                    completion_finish = token.get("finish_reason")
+                                continue
+                            full_text = token
+
+                        reasoning_text, visible_text = _extract_responses_reasoning(
+                            full_text,
+                            parse_think_markers = _responses_should_parse_think_markers(
+                                payload,
+                                llama_backend,
+                            ),
                         )
+                        message_kwargs = {"content": visible_text}
+                        if reasoning_text:
+                            message_kwargs["reasoning_content"] = reasoning_text
+                        _choices.append(
+                            CompletionChoice(
+                                index = _idx,
+                                message = CompletionMessage(**message_kwargs),
+                                finish_reason = _clamp_finish_reason(completion_finish),
+                            )
+                        )
+                        _monitor_replies.append(visible_text)
+                        if completion_usage:
+                            # The prompt is shared across all n choices, so count its
+                            # tokens ONCE (OpenAI bills only generated tokens for each
+                            # extra choice). Only completion_tokens accumulates.
+                            _prompt_tokens = completion_usage.get("prompt_tokens") or _prompt_tokens
+                            _sum_completion += completion_usage.get("completion_tokens") or 0
+                            if _prompt_details is None:
+                                _prompt_details = completion_usage.get("prompt_tokens_details")
+                    return (
+                        _n,
+                        _choices,
+                        _monitor_replies,
+                        _prompt_tokens,
+                        _sum_completion,
+                        _prompt_details,
                     )
-                    _monitor_replies.append(visible_text)
-                    if completion_usage:
-                        # The prompt is shared across all n choices, so count its
-                        # tokens ONCE (OpenAI bills only generated tokens for each
-                        # extra choice). Only completion_tokens accumulates.
-                        _prompt_tokens = completion_usage.get("prompt_tokens") or _prompt_tokens
-                        _sum_completion += completion_usage.get("completion_tokens") or 0
-                        if _prompt_details is None:
-                            _prompt_details = completion_usage.get("prompt_tokens_details")
+
+                drain_task = asyncio.create_task(asyncio.to_thread(_drain_gguf_choices))
+                (
+                    _n,
+                    _choices,
+                    _monitor_replies,
+                    _prompt_tokens,
+                    _sum_completion,
+                    _prompt_details,
+                ) = await asyncio.shield(drain_task)
 
                 response = ChatCompletion(
                     id = completion_id,
@@ -6809,6 +7446,11 @@ async def openai_chat_completions(
                 api_monitor.finish(monitor_id)
                 return _model_json_response(response)
 
+            except asyncio.CancelledError:
+                cancel_event.set()
+                await _drain_cancelled_gguf_task()
+                api_monitor.finish(monitor_id, "cancelled")
+                raise
             except Exception as e:
                 logger.error(f"Error during GGUF completion: {e}", exc_info = True)
                 api_monitor.fail(monitor_id, _friendly_error(e))
@@ -6828,7 +7470,6 @@ async def openai_chat_completions(
                         ),
                     )
                 raise HTTPException(status_code = 500, detail = safe_error_detail(e))
-
     # ── Standard Unsloth path ─────────────────────────────────
 
     # Decode image (from content parts OR legacy field)
@@ -7148,7 +7789,7 @@ async def openai_chat_completions(
                         "type": "server_error",
                     },
                 }
-                yield f"data: {json.dumps(error_chunk)}\n\n"
+                yield _openai_stream_error_sse(error_chunk)
             finally:
                 await _stop_local_disconnect_cancel_watcher(disconnect_watcher)
                 if gen is not None:
@@ -7493,7 +8134,7 @@ async def openai_chat_completions(
                         "type": "server_error",
                     },
                 }
-                yield f"data: {json.dumps(error_chunk)}\n\n"
+                yield _openai_stream_error_sse(error_chunk)
             finally:
                 await _stop_local_disconnect_cancel_watcher(disconnect_watcher)
                 _tracker.__exit__(None, None, None)
@@ -7991,8 +8632,7 @@ async def openai_completions(request: Request, current_subject: str = Depends(ge
         if not isinstance(body, dict):
             raise HTTPException(status_code = 400, detail = "Request body must be a JSON object")
 
-    if body.get("max_tokens") is None:
-        body["max_tokens"] = llama_backend.context_length or _DEFAULT_MAX_TOKENS_FLOOR
+    body["max_tokens"] = _effective_openai_max_tokens_from_values(body.get("max_tokens"))
     target_url = f"{llama_backend.base_url}/v1/completions"
     is_stream = body.get("stream", False)
     prompt_text = _flatten_monitor_prompt(body.get("prompt", ""))
@@ -8085,7 +8725,7 @@ async def openai_completions(request: Request, current_subject: str = Depends(ge
                     logger.error("openai_completions stream error: %s", e)
                     api_monitor.fail(monitor_id, _friendly_error(e))
                     error_chunk = _openai_stream_error_chunk(e)
-                    yield f"data: {json.dumps(error_chunk)}\n\n".encode("utf-8")
+                    yield _openai_stream_error_sse_bytes(error_chunk)
                     return
                 api_monitor.finish(monitor_id, "cancelled")
                 return
@@ -8100,7 +8740,7 @@ async def openai_completions(request: Request, current_subject: str = Depends(ge
                 logger.error("openai_completions stream error: %s", e)
                 api_monitor.fail(monitor_id, _friendly_error(e))
                 error_chunk = _openai_stream_error_chunk(e)
-                yield f"data: {json.dumps(error_chunk)}\n\n".encode("utf-8")
+                yield _openai_stream_error_sse_bytes(error_chunk)
                 return
             finally:
                 await _aclose_stream_resources(
@@ -10841,19 +11481,21 @@ def _build_passthrough_payload(
 ):
     body = {
         "messages": openai_messages,
-        "tools": openai_tools,
-        "tool_choice": tool_choice,
         "temperature": temperature,
         "top_p": top_p,
         "top_k": top_k,
         "stream": stream,
     }
+    if openai_tools:
+        body["tools"] = openai_tools
+        if tool_choice is not None:
+            body["tool_choice"] = tool_choice
     if seed is not None:
         body["seed"] = seed
     if stream and stream_options is not None:
         body["stream_options"] = stream_options
     body["max_tokens"] = (
-        max_tokens if max_tokens is not None else (backend_ctx or _DEFAULT_MAX_TOKENS_FLOOR)
+        max_tokens if max_tokens is not None else _openai_compat_implicit_max_tokens()
     )
     # Normalize stop the same way the non-passthrough path does (the passthrough
     # was previously the one path that forwarded an empty stop string verbatim).
@@ -11557,6 +12199,9 @@ def _build_openai_passthrough_body(
     system_prompt, _, _ = _extract_content_parts(payload.messages)
     messages = _set_or_prepend_system_message(messages, system_prompt)
     tool_choice = payload.tool_choice if payload.tool_choice is not None else "auto"
+    tools = payload.tools
+    if payload.tool_choice == "none" and not _has_openai_tool_history(payload.messages):
+        tools = None
     # Forward per-request reasoning fields (enable_thinking / reasoning_effort /
     # preserve_thinking) via chat_template_kwargs so the Jinja template renders
     # in the caller's mode, gated on the active template's capabilities exactly
@@ -11572,12 +12217,12 @@ def _build_openai_passthrough_body(
     )
     return _build_passthrough_payload(
         messages,
-        payload.tools,
+        tools,
         payload.temperature,
         payload.top_p,
         payload.top_k,
         # Honor max_completion_tokens on the tools/response_format passthrough too.
-        _effective_max_tokens(payload),
+        _effective_openai_max_tokens(payload),
         payload.stream,
         stop = payload.stop,
         min_p = payload.min_p,
@@ -11613,24 +12258,44 @@ async def _openai_passthrough_stream(
     --reasoning-format auto``), so ``delta.content`` carries no raw markup and is
     deliberately not re-parsed locally, unlike the ``/completion`` paths.
     """
-    target_url = f"{llama_backend.base_url}/v1/chat/completions"
-    body = _build_openai_passthrough_body(
-        payload, backend_ctx = llama_backend.context_length, llama_backend = llama_backend
-    )
-    # Text-form tool calls from small models get promoted to structured calls on
-    # the way back (declared client tools only); requests without tools or with
-    # auto_heal_tool_calls=false keep the verbatim relay. tool_choice constrains
-    # the allowlist ("none" disables, a forced function narrows to it).
-    _allowed_tools = heal_gate(
-        payload.auto_heal_tool_calls, body.get("tools"), body.get("tool_choice")
-    )
-
     _cancel_keys = (payload.cancel_id, payload.session_id, completion_id)
     _tracker = _TrackedCancel(cancel_event, *_cancel_keys)
     _tracker.__enter__()
+    return await _openai_passthrough_stream_upstream(
+        request,
+        cancel_event,
+        llama_backend,
+        payload,
+        model_name,
+        completion_id,
+        monitor_id = monitor_id,
+        tracker = _tracker,
+    )
+
+
+async def _openai_passthrough_stream_upstream(
+    request,
+    cancel_event,
+    llama_backend,
+    payload,
+    model_name,
+    completion_id,
+    monitor_id: Optional[str] = None,
+    *,
+    tracker,
+):
+    target_url = f"{llama_backend.base_url}/v1/chat/completions"
+    upstream_stream_id = _openai_passthrough_upstream_stream_id(completion_id)
+    upstream_headers = _openai_passthrough_upstream_headers(
+        upstream_stream_id,
+        llama_backend = llama_backend,
+    )
+
+    _tracker = tracker
     client = None
     resp = None
     send_task: Optional[asyncio.Task[Optional[httpx.Response]]] = None
+    preheader_fallback_deadline: Optional[float] = None
 
     async def _aclose_send_task(task: Optional[asyncio.Task[Optional[httpx.Response]]]) -> None:
         if task is None:
@@ -11647,8 +12312,53 @@ async def _openai_passthrough_stream(
         except (asyncio.CancelledError, Exception):
             pass
 
+    def _new_preheader_fallback_deadline() -> Optional[float]:
+        timeout_s = _openai_compat_stream_preheader_fallback_timeout()
+        return None if timeout_s is None else time.monotonic() + timeout_s
+
+    async def _delete_resumable_stream_for_cleanup() -> bool:
+        try:
+            await _openai_delete_resumable_stream(
+                llama_backend.base_url,
+                upstream_stream_id,
+                upstream_headers,
+            )
+            return False
+        except asyncio.CancelledError:
+            return True
+        except BaseException:
+            logger.debug("openai passthrough stream cleanup delete failed", exc_info = True)
+            return False
+
+    async def _aclose_stream_resources_for_cleanup(**kwargs) -> bool:
+        try:
+            await _aclose_stream_resources(**kwargs)
+            return False
+        except asyncio.CancelledError:
+            return True
+
+    async def _aclose_client_for_cleanup(close_client) -> bool:
+        try:
+            await close_client.aclose()
+            return False
+        except asyncio.CancelledError:
+            return True
+        except Exception:
+            return False
+
     # Keep tracker cleanup paired if pre-header dispatch is cancelled.
     try:
+        body = _build_openai_passthrough_body(
+            payload, backend_ctx = llama_backend.context_length, llama_backend = llama_backend
+        )
+        # Text-form tool calls from small models get promoted to structured calls on
+        # the way back (declared client tools only); requests without tools or with
+        # auto_heal_tool_calls=false keep the verbatim relay. tool_choice constrains
+        # the allowlist ("none" disables, a forced function narrows to it).
+        _allowed_tools = heal_gate(
+            payload.auto_heal_tool_calls, body.get("tools"), body.get("tool_choice")
+        )
+
         # Keep the pre-header window short so accepted SSE clients receive
         # immediate headers in the common timeout-reduced stall.
         client = httpx.AsyncClient(
@@ -11662,13 +12372,18 @@ async def _openai_passthrough_stream(
 
         while True:
             try:
-                req = client.build_request(
-                    "POST", target_url, json = body, headers = {"Connection": "close"}
-                )
+                req = client.build_request("POST", target_url, json = body, headers = upstream_headers)
                 first_token_deadline = time.monotonic() + _DEFAULT_FIRST_TOKEN_TIMEOUT_S
                 send_task = asyncio.create_task(
-                    _send_stream_with_preheader_cancel(client, req, cancel_event, request = request)
+                    _send_stream_with_preheader_cancel(
+                        client,
+                        req,
+                        cancel_event,
+                        request = request,
+                        mark_cancel_on_cancel = False,
+                    )
                 )
+                preheader_fallback_deadline = _new_preheader_fallback_deadline()
                 done, _ = await asyncio.wait(
                     {send_task},
                     timeout = _OPENAI_PASSTHROUGH_PREHEADER_STATUS_WINDOW_S,
@@ -11680,6 +12395,7 @@ async def _openai_passthrough_stream(
                 # Dispatch returned quickly enough to preserve pre-header status.
                 resp = await send_task
                 send_task = None
+                preheader_fallback_deadline = None
             except httpx.RequestError as e:
                 # llama-server subprocess crashed / starting / unreachable.
                 logger.error("openai passthrough stream: upstream unreachable: %s", e)
@@ -11693,13 +12409,19 @@ async def _openai_passthrough_stream(
             if resp is None and send_task is not None and not send_task.done():
                 break
             if resp is None:
+                if cancel_event is not None:
+                    cancel_event.set()
                 api_monitor.finish(monitor_id, "cancelled")
-                await _aclose_send_task(send_task)
+                delete_cancelled = False
+                close_cancelled = False
                 try:
-                    await client.aclose()
-                except Exception:
-                    pass
-                _tracker.__exit__(None, None, None)
+                    await _aclose_send_task(send_task)
+                    close_cancelled = await _aclose_client_for_cleanup(client)
+                    delete_cancelled = await _delete_resumable_stream_for_cleanup()
+                finally:
+                    _tracker.__exit__(None, None, None)
+                if close_cancelled or delete_cancelled:
+                    raise asyncio.CancelledError()
                 return _SameTaskStreamingResponse(
                     iter(()),
                     media_type = "text/event-stream",
@@ -11724,6 +12446,7 @@ async def _openai_passthrough_stream(
                 await resp.aclose()
             except Exception:
                 pass
+            resp = None
             # Opt-in overflow policy: shrink and retry instead of a fatal 400.
             if (
                 _truncate_budget > 0
@@ -11752,11 +12475,14 @@ async def _openai_passthrough_stream(
             disconnect_watcher = None
 
             nonlocal resp, send_task, first_token_deadline, _truncate_budget
+            nonlocal client, preheader_fallback_deadline
             monitor_done = False
             saw_finish_reason = False
             saw_done = False
             saw_stream_error = False
+            saw_stream_item = False
             saw_tool_call_delta = False
+            terminal_seen = False
             last_chunk_id = completion_id
             last_chunk_model = model_name
             last_chunk_created = int(time.time())
@@ -11816,6 +12542,76 @@ async def _openai_passthrough_stream(
                     }
                     lines.append("data: " + json.dumps(chunk, ensure_ascii = False))
                 return lines
+
+            def _terminal_read_timeout_s() -> Optional[float]:
+                if terminal_seen:
+                    return _OPENAI_PASSTHROUGH_TERMINAL_GRACE_S
+                return _openai_compat_stream_stall_timeout()
+
+            def _done_sse_line() -> str:
+                return "data: [DONE]"
+
+            async def _non_streaming_fallback_lines() -> list[str]:
+                nonlocal resp, send_task, client
+                await _aclose_send_task(send_task)
+                send_task = None
+                await _aclose_stream_resources(resp = resp, client = client)
+                resp = None
+                client = None
+                if await _delete_resumable_stream_for_cleanup():
+                    raise asyncio.CancelledError()
+                fallback_response = await _openai_passthrough_non_streaming(
+                    llama_backend,
+                    payload,
+                    model_name,
+                    monitor_id = monitor_id,
+                    request = request,
+                    cancel_event = cancel_event,
+                )
+                body_bytes = getattr(fallback_response, "body", b"")
+                if isinstance(body_bytes, str):
+                    body_bytes = body_bytes.encode("utf-8")
+                fallback_data = json.loads(body_bytes.decode("utf-8"))
+                return _openai_non_stream_chat_response_sse_lines(
+                    fallback_data,
+                    payload,
+                    completion_id,
+                    model_name,
+                )
+
+            async def _adopt_resumable_response() -> bool:
+                nonlocal resp, send_task, client, preheader_fallback_deadline
+                resume_client = None
+                resume_resp = None
+                try:
+                    resume_client, resume_resp = await _openai_open_resumable_stream(
+                        llama_backend.base_url,
+                        upstream_stream_id,
+                        upstream_headers,
+                    )
+                    if resume_resp is None:
+                        if resume_client is not None:
+                            await _aclose_stream_resources_for_cleanup(client = resume_client)
+                        return False
+                    logger.info(
+                        "openai passthrough stream: using llama-server resumable stream for delayed upstream response"
+                    )
+                    await _aclose_send_task(send_task)
+                    send_task = None
+                    await _aclose_stream_resources(resp = resp, client = client)
+                    resp = resume_resp
+                    client = resume_client
+                    resume_resp = None
+                    resume_client = None
+                    preheader_fallback_deadline = None
+                    return True
+                except BaseException:
+                    if resume_resp is not None or resume_client is not None:
+                        await _aclose_stream_resources_for_cleanup(
+                            resp = resume_resp,
+                            client = resume_client,
+                        )
+                    raise
 
             def _heal_transform(chunk_data: dict, raw_line: str) -> list:
                 """SSE lines to emit in place of one upstream line (healing on)."""
@@ -11885,24 +12681,58 @@ async def _openai_passthrough_stream(
 
             try:
                 while True:
-                    if send_task is not None and not send_task.done():
-                        try:
-                            resp = await send_task
-                        except httpx.RequestError as e:
-                            logger.error("openai passthrough stream: upstream unreachable: %s", e)
-                            api_monitor.fail(monitor_id, _friendly_error(e))
-                            yield f"data: {json.dumps(_openai_stream_error_chunk(e))}\n\n"
-                            return
-                        send_task = None
-                    elif send_task is not None:
-                        try:
-                            resp = send_task.result()
-                        except httpx.RequestError as e:
-                            logger.error("openai passthrough stream: upstream unreachable: %s", e)
-                            api_monitor.fail(monitor_id, _friendly_error(e))
-                            yield f"data: {json.dumps(_openai_stream_error_chunk(e))}\n\n"
-                            return
-                        send_task = None
+                    if send_task is not None:
+                        last_keepalive_at = time.monotonic()
+                        while not send_task.done():
+                            wait_timeout = min(
+                                _OPENAI_PASSTHROUGH_RESUMABLE_LOOKUP_INTERVAL_S,
+                                _OPENAI_PASSTHROUGH_PENDING_RESPONSE_KEEPALIVE_S,
+                            )
+                            if preheader_fallback_deadline is not None:
+                                remaining_s = preheader_fallback_deadline - time.monotonic()
+                                if remaining_s <= 0:
+                                    logger.warning(
+                                        "openai passthrough stream: upstream headers delayed; falling back to non-streaming"
+                                    )
+                                    for fallback_line in await _non_streaming_fallback_lines():
+                                        yield fallback_line + "\n\n"
+                                    monitor_done = True
+                                    return
+                                wait_timeout = min(wait_timeout, max(remaining_s, 0.001))
+                            done, _ = await asyncio.wait(
+                                {send_task},
+                                timeout = wait_timeout,
+                                return_when = asyncio.FIRST_COMPLETED,
+                            )
+                            if send_task in done:
+                                break
+                            if await _adopt_resumable_response():
+                                break
+                            if await _preheader_cancelled(cancel_event, request):
+                                api_monitor.finish(monitor_id, "cancelled")
+                                return
+                            # The downstream SSE response is already committed;
+                            # keep strict clients and proxies from treating a long
+                            # llama-server prefill/header wait as a dead stream.
+                            now = time.monotonic()
+                            if (
+                                now - last_keepalive_at
+                                >= _OPENAI_PASSTHROUGH_PENDING_RESPONSE_KEEPALIVE_S
+                            ):
+                                last_keepalive_at = now
+                                yield _OPENAI_PASSTHROUGH_SSE_KEEPALIVE
+                        if resp is None:
+                            try:
+                                resp = send_task.result()
+                            except httpx.RequestError as e:
+                                logger.error(
+                                    "openai passthrough stream: upstream unreachable: %s", e
+                                )
+                                api_monitor.fail(monitor_id, _friendly_error(e))
+                                yield _openai_stream_error_sse(_openai_stream_error_chunk(e))
+                                return
+                            send_task = None
+                            preheader_fallback_deadline = None
 
                     if resp is None:
                         api_monitor.finish(monitor_id, "cancelled")
@@ -11930,14 +12760,19 @@ async def _openai_passthrough_stream(
                     ):
                         _truncate_budget -= 1
                         req = client.build_request(
-                            "POST", target_url, json = body, headers = {"Connection": "close"}
+                            "POST", target_url, json = body, headers = upstream_headers
                         )
                         first_token_deadline = time.monotonic() + _DEFAULT_FIRST_TOKEN_TIMEOUT_S
                         send_task = asyncio.create_task(
                             _send_stream_with_preheader_cancel(
-                                client, req, cancel_event, request = request
+                                client,
+                                req,
+                                cancel_event,
+                                request = request,
+                                mark_cancel_on_cancel = False,
                             )
                         )
+                        preheader_fallback_deadline = _new_preheader_fallback_deadline()
                         continue
 
                     upstream_error = _openai_passthrough_error(upstream_status, err_text)
@@ -11950,7 +12785,7 @@ async def _openai_passthrough_stream(
                         )
                     )
                     api_monitor.fail(monitor_id, err_text[:500])
-                    yield f"data: {json.dumps(error_payload)}\n\n"
+                    yield _openai_stream_error_sse(error_payload)
                     return
 
                 cancel_watcher = asyncio.create_task(_await_cancel_then_close(cancel_event, resp))
@@ -11964,12 +12799,14 @@ async def _openai_passthrough_stream(
                     request = request,
                     first_token_deadline = first_token_deadline,
                     response = resp,
+                    post_first_item_read_timeout_s = _terminal_read_timeout_s,
                 ):
                     if not raw_line:
                         continue
-                    if not raw_line.startswith("data: "):
+                    if not raw_line.startswith("data:"):
                         continue
-                    data_text = raw_line[6:].strip()
+                    saw_stream_item = True
+                    data_text = raw_line[5:].lstrip().strip()
                     if data_text == "[DONE]":
                         saw_done = True
                         # Upstream ended without a finish chunk: heal the residue
@@ -12001,13 +12838,11 @@ async def _openai_passthrough_stream(
                         yield raw_line + "\n\n"
                         monitor_done = True
                         break
-                    # Honor parallel_tool_calls=false (best-effort): drop tool_call
-                    # deltas with index>=1 so only the first call streams. Only
-                    # lines carrying tool_calls are reparsed; everything else is
-                    # relayed byte-for-byte.
-                    if payload.parallel_tool_calls is False and '"tool_calls"' in raw_line:
-                        raw_line = _cap_parallel_tool_calls_sse_line(raw_line)
-                        data_text = raw_line[6:].strip()
+                    raw_line = _normalize_openai_passthrough_sse_line(
+                        raw_line,
+                        cap_parallel_tool_calls = payload.parallel_tool_calls is False,
+                    )
+                    data_text = raw_line[5:].lstrip().strip()
                     try:
                         chunk_data = json.loads(data_text)
                     except json.JSONDecodeError:
@@ -12085,6 +12920,23 @@ async def _openai_passthrough_stream(
                         yield out_line + "\n\n"
                         if monitor_event == "done":
                             monitor_done = True
+                            break
+                        terminal_state = _openai_passthrough_sse_line_terminal_state(out_line)
+                        if terminal_state == "usage" or (
+                            terminal_state == "finish" and not _wants_stream_usage(payload)
+                        ):
+                            done_line = _done_sse_line()
+                            _monitor_openai_sse_line(
+                                monitor_id,
+                                done_line,
+                                llama_backend.context_length,
+                            )
+                            yield done_line + "\n\n"
+                            saw_done = True
+                            monitor_done = True
+                            break
+                        if terminal_state == "finish":
+                            terminal_seen = True
                     if monitor_done:
                         break
                 if not saw_done and not saw_stream_error and not cancel_event.is_set():
@@ -12122,6 +12974,34 @@ async def _openai_passthrough_stream(
             except asyncio.CancelledError:
                 api_monitor.finish(monitor_id, "cancelled")
                 raise
+            except httpx.ReadTimeout as e:
+                if terminal_seen and not saw_stream_error and not cancel_event.is_set():
+                    done_line = _done_sse_line()
+                    _monitor_openai_sse_line(
+                        monitor_id,
+                        done_line,
+                        llama_backend.context_length,
+                    )
+                    yield done_line + "\n\n"
+                    api_monitor.finish(monitor_id)
+                    monitor_done = True
+                    return
+                if saw_stream_item and not saw_stream_error and not cancel_event.is_set():
+                    logger.error("openai passthrough stream stalled mid-response: %s", e)
+                    api_monitor.fail(monitor_id, _friendly_error(e))
+                    get_llama_cpp_backend()._maybe_recover_from_mtp_crash(e)
+                    err = _openai_stream_error_chunk(e)
+                    yield _openai_stream_error_sse(err)
+                    monitor_done = True
+                    return
+                if cancel_event.is_set():
+                    api_monitor.finish(monitor_id, "cancelled")
+                    return
+                logger.error("openai passthrough stream timeout: %s", e)
+                api_monitor.fail(monitor_id, _friendly_error(e))
+                get_llama_cpp_backend()._maybe_recover_from_mtp_crash(e)
+                err = _openai_stream_error_chunk(e)
+                yield _openai_stream_error_sse(err)
             except (httpx.RemoteProtocolError, httpx.ReadError, httpx.CloseError) as e:
                 # Watcher closed resp on cancel. Emit nothing extra; the client
                 # initiated the cancel or already disconnected.
@@ -12130,6 +13010,16 @@ async def _openai_passthrough_stream(
                     get_llama_cpp_backend()._maybe_recover_from_mtp_crash(e)
                     raise
                 api_monitor.finish(monitor_id, "cancelled")
+            except HTTPException as exc:
+                status_code = getattr(exc, "status_code", 500) or 500
+                detail = exc.detail
+                error_payload = (
+                    detail
+                    if isinstance(detail, dict) and "error" in detail
+                    else openai_error_body(str(detail), status = status_code)
+                )
+                api_monitor.fail(monitor_id, str(detail))
+                yield _openai_stream_error_sse(error_payload)
             except Exception as e:
                 if cancel_event.is_set():
                     api_monitor.finish(monitor_id, "cancelled")
@@ -12139,25 +13029,41 @@ async def _openai_passthrough_stream(
                 api_monitor.fail(monitor_id, _friendly_error(e))
                 get_llama_cpp_backend()._maybe_recover_from_mtp_crash(e)
                 err = _openai_stream_error_chunk(e)
-                yield f"data: {json.dumps(err)}\n\n"
+                yield _openai_stream_error_sse(err)
             finally:
-                await _aclose_send_task(send_task)
-                await _aclose_stream_resources(
-                    watchers = (cancel_watcher, disconnect_watcher),
-                    iterator = lines_iter,
-                    resp = resp,
-                    client = client,
-                )
-                _tracker.__exit__(None, None, None)
+                delete_cancelled = False
+                close_cancelled = False
+                try:
+                    await _aclose_send_task(send_task)
+                    close_cancelled = await _aclose_stream_resources_for_cleanup(
+                        watchers = (cancel_watcher, disconnect_watcher),
+                        iterator = lines_iter,
+                        resp = resp,
+                        client = client,
+                    )
+                    delete_cancelled = await _delete_resumable_stream_for_cleanup()
+                finally:
+                    _tracker.__exit__(None, None, None)
+                if close_cancelled or delete_cancelled:
+                    raise asyncio.CancelledError()
 
         async def _unstarted_cleanup() -> None:
             # Client disconnected before the body stream started, so _stream()'s
             # finally never ran. Release the eagerly-opened upstream resp/client
             # and the cancel-registry entry here; the watchers and line iterator
             # are created inside _stream(), so there is nothing else to close.
-            await _aclose_send_task(send_task)
-            await _aclose_stream_resources(resp = resp, client = client)
-            _tracker.__exit__(None, None, None)
+            delete_cancelled = False
+            close_cancelled = False
+            try:
+                await _aclose_send_task(send_task)
+                close_cancelled = await _aclose_stream_resources_for_cleanup(
+                    resp = resp, client = client
+                )
+                delete_cancelled = await _delete_resumable_stream_for_cleanup()
+            finally:
+                _tracker.__exit__(None, None, None)
+            if close_cancelled or delete_cancelled:
+                raise asyncio.CancelledError()
 
         return _SameTaskStreamingResponse(
             _stream(),
@@ -12169,10 +13075,24 @@ async def _openai_passthrough_stream(
             },
             unstarted_cleanup = _unstarted_cleanup,
         )
-    except BaseException:
-        await _aclose_send_task(send_task)
-        await _aclose_stream_resources(resp = resp, client = client)
-        _tracker.__exit__(None, None, None)
+    except BaseException as exc:
+        if isinstance(exc, asyncio.CancelledError):
+            if cancel_event is not None:
+                cancel_event.set()
+            api_monitor.finish(monitor_id, "cancelled")
+        else:
+            detail = exc.detail if isinstance(exc, HTTPException) else _friendly_error(exc)
+            api_monitor.fail(monitor_id, str(detail))
+        delete_cancelled = False
+        close_cancelled = False
+        try:
+            await _aclose_send_task(send_task)
+            close_cancelled = await _aclose_stream_resources_for_cleanup(resp = resp, client = client)
+            delete_cancelled = await _delete_resumable_stream_for_cleanup()
+        finally:
+            _tracker.__exit__(None, None, None)
+        if close_cancelled or delete_cancelled:
+            raise asyncio.CancelledError()
         raise
 
 
@@ -12181,6 +13101,9 @@ async def _openai_passthrough_non_streaming(
     payload,
     model_name,
     monitor_id: Optional[str] = None,
+    *,
+    request: Optional[Request] = None,
+    cancel_event = None,
 ):
     """Non-streaming client-side pass-through for /v1/chat/completions.
 
@@ -12189,20 +13112,67 @@ async def _openai_passthrough_non_streaming(
     ``tool_calls``, and accurate ``usage`` token counts.
     """
     target_url = f"{llama_backend.base_url}/v1/chat/completions"
+    upstream_headers = _openai_passthrough_upstream_headers(llama_backend = llama_backend)
     body = _build_openai_passthrough_body(
         payload, backend_ctx = llama_backend.context_length, llama_backend = llama_backend
     )
+    body["stream"] = False
+    body.pop("stream_options", None)
 
     _truncate_budget = (
         _OVERFLOW_TRUNCATE_MAX_RETRIES if _overflow_truncation_requested(payload) else 0
     )
-    while True:
-        try:
-            resp = await nonstreaming_client().post(
+
+    async def _post(body_to_send):
+        if cancel_event is None and request is None:
+            return await nonstreaming_client().post(
                 target_url,
-                json = body,
+                json = body_to_send,
+                headers = upstream_headers,
                 timeout = _llama_non_streaming_generation_timeout(),
             )
+
+        if cancel_event is None:
+            cancel = threading.Event()
+        else:
+            cancel = cancel_event
+        client = _cancelable_nonstreaming_client()
+        watcher = asyncio.create_task(
+            _await_cancel_or_disconnect_then_close_client(
+                cancel_event = cancel,
+                request = request,
+                client = client,
+            )
+        )
+        try:
+            try:
+                response = await client.post(
+                    target_url,
+                    json = body_to_send,
+                    headers = upstream_headers,
+                    timeout = _llama_non_streaming_generation_timeout(),
+                )
+            except httpx.RequestError:
+                if cancel.is_set():
+                    raise asyncio.CancelledError()
+                raise
+            if cancel.is_set():
+                raise asyncio.CancelledError()
+            return response
+        finally:
+            watcher.cancel()
+            try:
+                await watcher
+            except (asyncio.CancelledError, Exception):
+                pass
+            try:
+                await client.aclose()
+            except Exception:
+                pass
+
+    while True:
+        try:
+            resp = await _post(body)
         except asyncio.CancelledError:
             api_monitor.finish(monitor_id, "cancelled")
             raise
@@ -12270,15 +13240,14 @@ async def _openai_passthrough_non_streaming(
             "messages": [*body.get("messages", []), *nudge_messages(data, _allowed_tools)],
         }
         try:
-            retry_resp = await nonstreaming_client().post(
-                target_url,
-                json = retry_body,
-                timeout = _llama_non_streaming_generation_timeout(),
-            )
+            retry_resp = await _post(retry_body)
             if retry_resp.status_code == 200:
                 retry_data = retry_resp.json()
                 if response_has_promotable_calls(retry_data, _allowed_tools, body.get("tools")):
                     resp, data = retry_resp, retry_data
+        except asyncio.CancelledError:
+            api_monitor.finish(monitor_id, "cancelled")
+            raise
         except (httpx.RequestError, ValueError) as exc:
             logger.warning("tool-call nudge retry failed; keeping original: %s", exc)
 

--- a/studio/backend/tests/test_inference_dispatcher_resilience.py
+++ b/studio/backend/tests/test_inference_dispatcher_resilience.py
@@ -112,7 +112,7 @@ def test_route_llama_streaming_async_clients_disable_proxy_env():
             continue
         calls.append(node)
 
-    assert len(calls) == 4
+    assert len(calls) == 5
     for call in calls:
         assert any(
             kw.arg == "trust_env" and isinstance(kw.value, ast.Constant) and kw.value.value is False

--- a/studio/backend/tests/test_llama_cpp_stream_cancel.py
+++ b/studio/backend/tests/test_llama_cpp_stream_cancel.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+import contextlib
+import os
+import sys
+import threading
+
+import httpx
+import pytest
+
+_backend = os.path.join(os.path.dirname(__file__), "..")
+sys.path.insert(0, _backend)
+
+from core.inference.llama_cpp import LlamaCppBackend, _LlamaStreamCancelled
+
+
+def _backend_stub() -> LlamaCppBackend:
+    backend = LlamaCppBackend.__new__(LlamaCppBackend)
+    backend._process = object()
+    backend._healthy = True
+    backend._port = 48848
+    backend._effective_context_length = 4096
+    backend._supports_reasoning = False
+    backend._reasoning_always_on = False
+    backend._reasoning_style = "enable_thinking"
+    backend._supports_preserve_thinking = False
+    return backend
+
+
+def test_stream_cancel_uses_internal_exception_not_generator_exit():
+    class FakeResponse:
+        status_code = 200
+
+        def close(self):
+            pass
+
+    class FakeStream:
+        def __enter__(self):
+            return FakeResponse()
+
+        def __exit__(self, *_args):
+            return False
+
+    class FakeClient:
+        def stream(self, *_args, **_kwargs):
+            return FakeStream()
+
+    cancel_event = threading.Event()
+
+    with pytest.raises(Exception) as exc_info:
+        with LlamaCppBackend._stream_with_retry(
+            FakeClient(),
+            "http://llama.test/v1/chat/completions",
+            {},
+            cancel_event,
+        ):
+            cancel_event.set()
+            raise httpx.ReadError("client closed")
+
+    assert exc_info.type is _LlamaStreamCancelled
+    assert not issubclass(exc_info.type, GeneratorExit)
+
+
+def test_generate_chat_completion_swallows_internal_stream_cancel(monkeypatch):
+    backend = _backend_stub()
+
+    @contextlib.contextmanager
+    def fake_open_stream(*_args, **_kwargs):
+        raise _LlamaStreamCancelled
+
+    monkeypatch.setattr(backend, "_open_stream", fake_open_stream)
+
+    chunks = list(
+        backend.generate_chat_completion(
+            [{"role": "user", "content": "hi"}],
+            cancel_event = threading.Event(),
+        )
+    )
+
+    assert chunks == []

--- a/studio/backend/tests/test_llama_route_timeouts.py
+++ b/studio/backend/tests/test_llama_route_timeouts.py
@@ -203,3 +203,47 @@ def test_preheader_send_cleanup_on_disconnect_and_cancel():
 
     asyncio.run(_run(False))
     asyncio.run(_run(True))
+
+
+def test_stream_stall_timeout_callable_re_resolved_each_read():
+    # The OpenAI passthrough passes a callable so the stall bound can switch to
+    # the short post-terminal grace mid-stream; it must be re-resolved per read,
+    # not captured once at generator start.
+    async def _run():
+        response = SimpleNamespace(request = SimpleNamespace(extensions = {"timeout": {}}))
+        values = iter([100.0, 2.0])
+        seen = []
+
+        class _Request:
+            async def is_disconnected(self):
+                return False
+
+        class _Items:
+            def __init__(self):
+                self.count = 0
+
+            async def __anext__(self):
+                self.count += 1
+                if self.count > 3:
+                    raise StopAsyncIteration
+                return "data: {}"
+
+        async for _ in inf_mod._aiter_llama_stream_items(
+            _Items(),
+            cancel_event = threading.Event(),
+            request = _Request(),
+            response = response,
+            first_token_deadline = time.monotonic() + 1,
+            post_first_item_read_timeout_s = lambda: next(values, 5.0),
+        ):
+            seen.append(response.request.extensions["timeout"].get("read"))
+
+        assert len(seen) == 3
+        # The callable is resolved right after the first item (arming the
+        # post-first window) and again before each later read, consuming
+        # successive values.
+        assert seen[0] == 100.0
+        assert 1.0 <= seen[1] <= 2.0
+        assert 4.0 <= seen[2] <= 5.0
+
+    asyncio.run(_run())

--- a/studio/backend/tests/test_llama_route_timeouts.py
+++ b/studio/backend/tests/test_llama_route_timeouts.py
@@ -247,3 +247,43 @@ def test_stream_stall_timeout_callable_re_resolved_each_read():
         assert 4.0 <= seen[2] <= 5.0
 
     asyncio.run(_run())
+
+
+def test_stream_stall_timeout_disabled_clears_read_timeout():
+    # UNSLOTH_OPENAI_COMPAT_STREAM_STALL_TIMEOUT=0 disables the stall guard, so
+    # the callable returns None. Once a chunk has arrived the leftover
+    # first-token read timeout must be cleared, else a long post-first-chunk gap
+    # trips a stale deadline the operator asked to turn off.
+    async def _run():
+        response = SimpleNamespace(request = SimpleNamespace(extensions = {"timeout": {}}))
+        seen = []
+
+        class _Request:
+            async def is_disconnected(self):
+                return False
+
+        class _Items:
+            def __init__(self):
+                self.count = 0
+
+            async def __anext__(self):
+                self.count += 1
+                if self.count > 2:
+                    raise StopAsyncIteration
+                return "data: {}"
+
+        async for _ in inf_mod._aiter_llama_stream_items(
+            _Items(),
+            cancel_event = threading.Event(),
+            request = _Request(),
+            response = response,
+            first_token_deadline = time.monotonic() + 5,
+            post_first_item_read_timeout_s = lambda: None,
+        ):
+            seen.append(response.request.extensions["timeout"].get("read"))
+
+        # The first-token path armed a finite read timeout; after the first chunk
+        # with the guard disabled, it is cleared to None on every subsequent read.
+        assert seen == [None, None], seen
+
+    asyncio.run(_run())

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -41,6 +41,7 @@ from routes.inference import (
     _drop_empty_assistant_sentinels,
     _effective_max_tokens,
     _effective_openai_max_tokens,
+    _effective_openai_max_tokens_from_values,
     _extract_content_parts,
     _friendly_error,
     _friendly_upstream_error,
@@ -1333,6 +1334,18 @@ class TestOpenAICompatibilityHelpers:
         assert exc.value.status_code == 400
         assert exc.value.detail["error"]["param"] == param
         assert exc.value.detail["error"]["code"] == "invalid_type"
+
+    def test_openai_compat_max_tokens_zero_is_valid_and_negative_rejected(self):
+        # Legacy completions spec: max_tokens has minimum 0, so 0 must pass
+        # through; only negatives are invalid_value.
+        assert _effective_openai_max_tokens_from_values(0) == 0
+
+        with pytest.raises(HTTPException) as exc:
+            _effective_openai_max_tokens_from_values(-1)
+
+        assert exc.value.status_code == 400
+        assert exc.value.detail["error"]["code"] == "invalid_value"
+        assert exc.value.detail["error"]["param"] == "max_tokens"
 
     def test_chat_reasoning_chunk_carries_empty_content(self):
         from routes.inference import _chat_reasoning_chunk
@@ -4120,6 +4133,59 @@ class TestApiMonitorProviderAndCompletionStreams:
             await openai_completions(Request(), current_subject = "test")
 
             assert captured[0]["max_tokens"] == 4096
+            assert monitor.active_count() == 0
+
+        asyncio.run(_run())
+
+    def test_completions_forwards_spec_valid_zero_max_tokens(self, monkeypatch):
+        async def _run():
+            import routes.inference as inf_mod
+
+            class Request:
+                state = SimpleNamespace()
+                url = SimpleNamespace(path = "/v1/completions")
+                method = "POST"
+
+                async def json(self):
+                    return {"prompt": "hi", "stream": False, "max_tokens": 0}
+
+            captured = []
+
+            class CapturingClient:
+                async def post(self, _url, *, json, **_kwargs):
+                    captured.append(dict(json))
+                    return httpx.Response(
+                        200,
+                        json = {
+                            "id": "cmpl-test",
+                            "choices": [{"text": "", "finish_reason": "length"}],
+                            "usage": {
+                                "prompt_tokens": 1,
+                                "completion_tokens": 0,
+                                "total_tokens": 1,
+                            },
+                        },
+                    )
+
+            monitor = ApiMonitor(max_entries = 3)
+            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+            monkeypatch.delenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, raising = False)
+            monkeypatch.delenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, raising = False)
+            monkeypatch.setattr(inf_mod, "nonstreaming_client", lambda: CapturingClient())
+            monkeypatch.setattr(
+                inf_mod,
+                "get_llama_cpp_backend",
+                lambda: SimpleNamespace(
+                    is_loaded = True,
+                    base_url = "http://llama.test",
+                    context_length = 4096,
+                    model_identifier = "gguf",
+                ),
+            )
+
+            await openai_completions(Request(), current_subject = "test")
+
+            assert captured[0]["max_tokens"] == 0
             assert monitor.active_count() == 0
 
         asyncio.run(_run())

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -53,19 +53,16 @@ from routes.inference import (
     _openai_compat_stream_stall_timeout,
     _openai_messages_for_gguf_chat,
     _openai_non_stream_chat_response_sse_lines,
-    _openai_open_resumable_stream,
     _openai_passthrough_sse_line_terminal_state,
     _openai_passthrough_upstream_headers,
     _openai_passthrough_non_streaming,
     _openai_passthrough_stream,
-    _openai_resumable_session_has_replay_bytes,
     _openai_stream_error_sse,
     _openai_stream_usage_chunk,
     _openai_compat_implicit_max_tokens,
     _openai_compat_max_tokens_ceiling,
     _proxy_to_external_provider,
     _SameTaskStreamingResponse,
-    _OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_DEFAULT,
     _OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV,
     _OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV,
     _OPENAI_COMPAT_STREAM_STALL_TIMEOUT_ENV,
@@ -100,136 +97,6 @@ def test_aclose_stream_resources_attempts_remaining_closes_after_cancel():
         assert iterator.closed
         assert resp.closed
         assert client.closed
-
-    asyncio.run(_run())
-
-
-@pytest.mark.parametrize(
-    ("session", "expected"),
-    [
-        ({"id": "s", "total_bytes": 1}, True),
-        ({"id": "s", "total_bytes": 0}, False),
-        ({"id": "s", "total_bytes": True}, False),
-        ({"id": "s", "bytes": 2}, False),
-        ({"id": "s", "has_data": True}, False),
-        ({"id": "s"}, False),
-        ("s", False),
-    ],
-)
-def test_openai_resumable_session_has_replay_bytes(session, expected):
-    assert _openai_resumable_session_has_replay_bytes(session) is expected
-
-
-def test_openai_resumable_lookup_waits_for_buffered_bytes(monkeypatch):
-    async def _run():
-        import routes.inference as inf_mod
-
-        captured = {"closed": False, "sent": False}
-
-        class FakeAsyncClient:
-            def __init__(self, *, timeout, limits, trust_env):
-                captured["timeout"] = timeout
-                captured["limits"] = limits
-                captured["trust_env"] = trust_env
-
-            async def post(
-                self,
-                url,
-                *,
-                json = None,
-                headers = None,
-            ):
-                captured["post_url"] = url
-                captured["post_json"] = json
-                captured["post_headers"] = headers
-                return httpx.Response(200, json = [{"id": "stream-1", "total_bytes": 0}])
-
-            def build_request(self, *_args, **_kwargs):
-                raise AssertionError("replay GET must wait until lookup reports bytes")
-
-            async def send(self, *_args, **_kwargs):
-                captured["sent"] = True
-                raise AssertionError("replay GET must wait until lookup reports bytes")
-
-            async def aclose(self):
-                captured["closed"] = True
-
-        monkeypatch.setattr(inf_mod.httpx, "AsyncClient", FakeAsyncClient)
-
-        client, response = await _openai_open_resumable_stream(
-            "http://llama.test",
-            "stream-1",
-            headers = {"Authorization": "Bearer secret"},
-        )
-
-        assert client is None
-        assert response is None
-        assert captured["post_url"] == "http://llama.test/v1/streams/lookup"
-        assert captured["post_json"] == {"conversation_ids": ["stream-1"]}
-        assert captured["post_headers"] == {"Authorization": "Bearer secret"}
-        assert captured["timeout"].read == inf_mod._OPENAI_PASSTHROUGH_RESUMABLE_LOOKUP_TIMEOUT_S
-        assert captured["sent"] is False
-        assert captured["closed"] is True
-
-    asyncio.run(_run())
-
-
-def test_openai_resumable_lookup_opens_replay_after_buffered_bytes(monkeypatch):
-    async def _run():
-        import routes.inference as inf_mod
-
-        captured = {"closed": False, "sent": False}
-
-        class FakeAsyncClient:
-            def __init__(self, *, timeout, limits, trust_env):
-                captured["timeout"] = timeout
-
-            async def post(self, *_args, **_kwargs):
-                return httpx.Response(200, json = [{"id": "stream-1", "total_bytes": 12}])
-
-            def build_request(
-                self,
-                method,
-                url,
-                *,
-                headers = None,
-            ):
-                captured["method"] = method
-                captured["url"] = url
-                captured["headers"] = headers
-                return httpx.Request(method, url, headers = headers)
-
-            async def send(
-                self,
-                request,
-                *,
-                stream = False,
-            ):
-                captured["sent"] = True
-                captured["stream"] = stream
-                return httpx.Response(200, content = b"data: [DONE]\n\n", request = request)
-
-            async def aclose(self):
-                captured["closed"] = True
-
-        monkeypatch.setattr(inf_mod.httpx, "AsyncClient", FakeAsyncClient)
-
-        client, response = await _openai_open_resumable_stream(
-            "http://llama.test",
-            "stream-1",
-            headers = {"Authorization": "Bearer secret"},
-        )
-
-        assert client is not None
-        assert response is not None
-        assert response.status_code == 200
-        assert captured["method"] == "GET"
-        assert captured["url"] == "http://llama.test/v1/stream/stream-1?from=0"
-        assert captured["headers"] == {"Authorization": "Bearer secret"}
-        assert captured["stream"] is True
-        assert captured["sent"] is True
-        assert captured["closed"] is False
-        await client.aclose()
 
     asyncio.run(_run())
 
@@ -838,7 +705,7 @@ class TestChatCompletionRequestToolFields:
             context_length = 4096
 
             def generate_chat_completion(self, **kwargs):
-                assert kwargs["max_tokens"] == _OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_DEFAULT
+                assert kwargs["max_tokens"] is None
                 yield "plain response"
 
         monitor = ApiMonitor(max_entries = 3)
@@ -1133,14 +1000,13 @@ class TestBuildPassthroughPayloadToolChoice:
         assert body.get("repeat_penalty") == 1.1
         assert "repetition_penalty" not in body
 
-    def test_omitted_passthrough_max_tokens_uses_openai_compat_cap(self, monkeypatch):
-        monkeypatch.delenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, raising = False)
+    def test_omitted_passthrough_max_tokens_uses_backend_context(self):
         args = self._args()
         args["max_tokens"] = None
 
-        body = _build_passthrough_payload(**args)
+        body = _build_passthrough_payload(**args, backend_ctx = 4096)
 
-        assert body["max_tokens"] == _OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_DEFAULT
+        assert body["max_tokens"] == 4096
 
     def test_passthrough_body_merges_system_and_developer_messages(self):
         payload = ChatCompletionRequest(
@@ -1333,11 +1199,11 @@ class TestOpenAICompatibilityHelpers:
         payload = SimpleNamespace(max_tokens = 128, max_completion_tokens = 64)
         assert _effective_max_tokens(payload) == 64
 
-    def test_openai_compat_max_tokens_uses_implicit_cap_when_omitted(self, monkeypatch):
+    def test_openai_compat_max_tokens_returns_none_when_omitted(self, monkeypatch):
         monkeypatch.delenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, raising = False)
         monkeypatch.delenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, raising = False)
         payload = SimpleNamespace(max_tokens = None, max_completion_tokens = None)
-        assert _effective_openai_max_tokens(payload) == _OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_DEFAULT
+        assert _effective_openai_max_tokens(payload) is None
 
     def test_openai_compat_max_tokens_uses_env_override_when_omitted(self, monkeypatch):
         monkeypatch.setenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, "512")
@@ -1347,11 +1213,11 @@ class TestOpenAICompatibilityHelpers:
         assert _effective_openai_max_tokens(payload) == 512
 
     @pytest.mark.parametrize("raw_value", ["", "0", "-3", "not-an-int"])
-    def test_openai_compat_max_tokens_invalid_env_uses_default(self, monkeypatch, raw_value):
+    def test_openai_compat_max_tokens_invalid_env_keeps_no_cap(self, monkeypatch, raw_value):
         monkeypatch.setenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, raw_value)
         monkeypatch.delenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, raising = False)
         payload = SimpleNamespace(max_tokens = None, max_completion_tokens = None)
-        assert _effective_openai_max_tokens(payload) == _OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_DEFAULT
+        assert _effective_openai_max_tokens(payload) is None
 
     def test_openai_compat_max_tokens_preserves_explicit_value_without_ceiling(self, monkeypatch):
         monkeypatch.setenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, "512")
@@ -1387,15 +1253,23 @@ class TestOpenAICompatibilityHelpers:
         assert exc.value.detail["error"]["param"] == param
         assert exc.value.detail["error"]["code"] == "invalid_type"
 
-    def test_passthrough_upstream_headers_include_backend_auth_and_stream_id(self):
+    def test_chat_reasoning_chunk_carries_empty_content(self):
+        from routes.inference import _chat_reasoning_chunk
+
+        line = _chat_reasoning_chunk("chatcmpl-test", 123, "gguf", "thinking...")
+        chunk = json.loads(line[len("data: "):])
+        delta = chunk["choices"][0]["delta"]
+
+        assert delta["reasoning_content"] == "thinking..."
+        assert delta["content"] == ""
+
+    def test_passthrough_upstream_headers_include_backend_auth(self):
         headers = _openai_passthrough_upstream_headers(
-            "stream-123",
             llama_backend = SimpleNamespace(_auth_headers = {"Authorization": "Bearer secret"}),
         )
 
         assert headers["Authorization"] == "Bearer secret"
         assert headers["Connection"] == "close"
-        assert headers["X-Conversation-Id"] == "stream-123"
 
     @pytest.mark.parametrize("raw_value", ["", "0", "-3", "not-an-int"])
     def test_openai_compat_explicit_ceiling_invalid_env_disables_guard(
@@ -1421,7 +1295,7 @@ class TestOpenAICompatibilityHelpers:
         payload = SimpleNamespace(max_tokens = 512, max_completion_tokens = None)
         assert _effective_openai_max_tokens(payload) == 512
 
-    def test_openai_compat_explicit_ceiling_caps_implicit_default(self, monkeypatch):
+    def test_openai_compat_explicit_ceiling_applies_when_omitted(self, monkeypatch):
         monkeypatch.delenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, raising = False)
         monkeypatch.setenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, "256")
         payload = SimpleNamespace(max_tokens = None, max_completion_tokens = None)
@@ -1429,7 +1303,7 @@ class TestOpenAICompatibilityHelpers:
 
     def test_openai_compat_stream_stall_timeout_uses_default(self, monkeypatch):
         monkeypatch.delenv(_OPENAI_COMPAT_STREAM_STALL_TIMEOUT_ENV, raising = False)
-        assert _openai_compat_stream_stall_timeout() == 30.0
+        assert _openai_compat_stream_stall_timeout() == 120.0
 
     def test_openai_compat_stream_stall_timeout_uses_env_override(self, monkeypatch):
         monkeypatch.setenv(_OPENAI_COMPAT_STREAM_STALL_TIMEOUT_ENV, "4.5")
@@ -1440,7 +1314,7 @@ class TestOpenAICompatibilityHelpers:
         self, monkeypatch, raw_value
     ):
         monkeypatch.setenv(_OPENAI_COMPAT_STREAM_STALL_TIMEOUT_ENV, raw_value)
-        assert _openai_compat_stream_stall_timeout() == 30.0
+        assert _openai_compat_stream_stall_timeout() == 120.0
 
     @pytest.mark.parametrize("raw_value", ["0", "-1"])
     def test_openai_compat_stream_stall_timeout_non_positive_env_disables(
@@ -2384,7 +2258,7 @@ class TestGgufVisionToolRouting:
         ]
 
         def _plain(**kwargs):
-            assert kwargs["max_tokens"] == _OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_DEFAULT
+            assert kwargs["max_tokens"] is None
             yield "plain response"
 
         def _tools(**_kwargs):
@@ -3065,7 +2939,6 @@ class TestApiMonitorProviderAndCompletionStreams:
             assert "data: [DONE]\n\n" in "".join(chunks)
             assert captured_headers["authorization"] == "Bearer secret"
             assert captured_headers["connection"] == "close"
-            assert captured_headers["x-conversation-id"].startswith("studio-chatcmpl-test-")
 
         asyncio.run(_run())
 
@@ -3131,107 +3004,6 @@ class TestApiMonitorProviderAndCompletionStreams:
             ]
             body = "".join(chunks)
             assert "data: [DONE]\n\n" in body
-
-        asyncio.run(_run())
-
-    def test_passthrough_stream_uses_resumable_replay_when_headers_stall(self, monkeypatch):
-        async def _run():
-            import routes.inference as inf_mod
-
-            entered = asyncio.Event()
-            cancelled = asyncio.Event()
-            deleted = []
-            resumable_headers = {}
-
-            async def fake_send(*_args, **_kwargs):
-                entered.set()
-                try:
-                    await asyncio.Event().wait()
-                except asyncio.CancelledError:
-                    cancelled.set()
-                    raise
-
-            async def fake_resumable(
-                _base_url,
-                stream_id,
-                headers = None,
-            ):
-                resumable_headers["open"] = headers
-                body = (
-                    'data: {"id":"chatcmpl-test","created":1,"model":"gguf",'
-                    '"choices":[{"index":0,"delta":{"content":"OK"},"finish_reason":null}]}\n\n'
-                    'data: {"id":"chatcmpl-test","created":1,"model":"gguf",'
-                    '"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n'
-                    'data: {"id":"chatcmpl-test","created":1,"model":"gguf",'
-                    '"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}\n\n'
-                    "data: [DONE]\n\n"
-                )
-                return None, httpx.Response(200, content = body.encode("utf-8"))
-
-            async def fake_delete(
-                _base_url,
-                stream_id,
-                headers = None,
-            ):
-                resumable_headers["delete"] = headers
-                deleted.append(stream_id)
-
-            class Request:
-                async def is_disconnected(self):
-                    return False
-
-            monitor = ApiMonitor(max_entries = 3)
-            monitor_id = monitor.start(
-                endpoint = "/v1/chat/completions",
-                method = "POST",
-                model = "gguf",
-                prompt = "hi",
-            )
-            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
-            monkeypatch.setattr(inf_mod, "_send_stream_with_preheader_cancel", fake_send)
-            monkeypatch.setattr(inf_mod, "_openai_open_resumable_stream", fake_resumable)
-            monkeypatch.setattr(inf_mod, "_openai_delete_resumable_stream", fake_delete)
-            monkeypatch.setattr(inf_mod, "_OPENAI_PASSTHROUGH_RESUMABLE_LOOKUP_INTERVAL_S", 0.01)
-
-            payload = ChatCompletionRequest(
-                model = "default",
-                messages = [ChatMessage(role = "user", content = "hi")],
-                stream = True,
-            )
-
-            response = await asyncio.wait_for(
-                _openai_passthrough_stream(
-                    Request(),
-                    threading.Event(),
-                    SimpleNamespace(
-                        base_url = "http://llama.test",
-                        context_length = 4096,
-                        _auth_headers = {"Authorization": "Bearer secret"},
-                        _request_reasoning_kwargs = lambda *_args, **_kwargs: None,
-                    ),
-                    payload,
-                    "gguf",
-                    "chatcmpl-test",
-                    monitor_id = monitor_id,
-                ),
-                timeout = 0.2,
-            )
-            await asyncio.wait_for(entered.wait(), timeout = 0.2)
-            chunks = [
-                chunk.decode() if isinstance(chunk, bytes) else chunk
-                async for chunk in response.body_iterator
-            ]
-            body = "".join(chunks)
-
-            assert "OK" in body
-            assert body.endswith("data: [DONE]\n\n")
-            await asyncio.wait_for(cancelled.wait(), timeout = 0.2)
-            assert deleted
-            assert resumable_headers["open"]["Authorization"] == "Bearer secret"
-            assert resumable_headers["delete"]["Authorization"] == "Bearer secret"
-            [entry] = monitor.snapshot()
-            assert entry["status"] == "completed"
-            assert entry["reply"] == "OK"
 
         asyncio.run(_run())
 
@@ -4403,22 +4175,12 @@ class TestApiMonitorProviderAndCompletionStreams:
                 yield 'data: {"choices":[{"delta":{"content":"hello"}}]}'
                 await asyncio.sleep(3600)
 
-            deleted = []
             cancel_id = "passthrough-stream-delete-cancel"
-
-            async def fake_delete(
-                _base_url,
-                stream_id,
-                headers = None,
-            ):
-                deleted.append((stream_id, headers))
-                raise asyncio.CancelledError()
 
             monitor = ApiMonitor(max_entries = 3)
             monkeypatch.setattr(inf_mod, "api_monitor", monitor)
             monkeypatch.setattr(inf_mod, "_send_stream_with_preheader_cancel", fake_send)
             monkeypatch.setattr(inf_mod, "_aiter_llama_stream_items", fake_items)
-            monkeypatch.setattr(inf_mod, "_openai_delete_resumable_stream", fake_delete)
             monitor_id = monitor.start(
                 endpoint = "/v1/chat/completions",
                 method = "POST",
@@ -4471,9 +4233,6 @@ class TestApiMonitorProviderAndCompletionStreams:
             assert entry["status"] == "cancelled"
             assert entry["reply"] == "hello"
             assert monitor.active_count() == 0
-            assert deleted
-            assert deleted[0][0].startswith("studio-chatcmpl-test-")
-            assert deleted[0][1]["Authorization"] == "Bearer secret"
             assert cancel_id not in inf_mod._CANCEL_REGISTRY
 
         asyncio.run(_run())

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -692,6 +692,72 @@ class TestChatCompletionRequestToolFields:
         assert entry["status"] == "completed"
         assert monitor.active_count() == 0
 
+    def test_enable_tools_on_non_tool_backend_keeps_client_tools_on_passthrough(self, monkeypatch):
+        # DiffusionGemma forces supports_tools off while passthrough stays
+        # available (#6851): enable_tools=True must not steal client tools
+        # from the passthrough into a Studio tool loop that cannot run.
+        import routes.inference as inference_route
+
+        captured = {}
+
+        class _GGUFBackend:
+            is_loaded = True
+            model_identifier = "test-gguf"
+            supports_tools = False
+            supports_tool_passthrough = True
+            is_vision = False
+            _is_audio = False
+            context_length = 4096
+            base_url = "http://llama.passthrough-capability.test"
+            _request_reasoning_kwargs = lambda *_args, **_kwargs: None
+
+            def generate_chat_completion(self, **_kwargs):
+                raise AssertionError("client tools must use passthrough")
+
+            def generate_chat_completion_with_tools(self, **_kwargs):
+                raise AssertionError("Studio tool loop cannot run on a non-tool backend")
+
+        async def fake_passthrough(llama_backend, payload, model_name, **kwargs):
+            captured["body"] = inference_route._build_openai_passthrough_body(
+                payload,
+                backend_ctx = llama_backend.context_length,
+                llama_backend = llama_backend,
+            )
+            inference_route.api_monitor.finish(kwargs.get("monitor_id"))
+            return inference_route.JSONResponse({"ok": True, "model": model_name})
+
+        monitor = ApiMonitor(max_entries = 3)
+        monkeypatch.setattr(inference_route, "api_monitor", monitor)
+        monkeypatch.setattr(
+            inference_route,
+            "_openai_passthrough_non_streaming",
+            fake_passthrough,
+        )
+        client = self._v1_client(monkeypatch, _GGUFBackend())
+        resp = client.post(
+            "/v1/chat/completions",
+            json = {
+                "messages": [{"role": "user", "content": "use client tool"}],
+                "enable_tools": True,
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ],
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        assert captured["body"]["tools"][0]["function"]["name"] == "lookup"
+        [entry] = monitor.snapshot()
+        assert entry["status"] == "completed"
+        assert monitor.active_count() == 0
+
     def test_tool_choice_none_allows_tool_catalog_without_tool_template(self, monkeypatch):
         import routes.inference as inference_route
 
@@ -1059,6 +1125,22 @@ class TestOpenAIPassthroughSSETerminalState:
         assert data["choices"][0]["delta"]["tool_calls"] == [
             {"index": 0, "function": {"name": "a"}}
         ]
+
+    def test_plain_content_line_is_returned_identically(self):
+        # The relay dispatches terminal classification on `out_line is raw_line`,
+        # so the no-mutation path must return the identical string object.
+        line = 'data: {"choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}'
+        assert _normalize_openai_passthrough_sse_line(line) is line
+        assert _normalize_openai_passthrough_sse_line(line, cap_parallel_tool_calls = True) is line
+
+    def test_reasoning_key_inside_content_text_keeps_line_identical(self):
+        # Fast-path substring gate fires, but the parse finds nothing to change:
+        # the original object must come back so the relay stays byte-identical.
+        line = (
+            'data: {"choices":[{"index":0,"delta":{"content":'
+            '"mentions \\"reasoning_content\\" in text"},"finish_reason":null}]}'
+        )
+        assert _normalize_openai_passthrough_sse_line(line) is line
 
     def test_reasoning_only_delta_gets_empty_content(self):
         line = (
@@ -3987,6 +4069,61 @@ class TestApiMonitorProviderAndCompletionStreams:
 
         asyncio.run(_run())
 
+    def test_completions_omitted_max_tokens_falls_back_to_context(self, monkeypatch):
+        # With no env knobs set, an omitted max_tokens must forward the
+        # backend's context length, exactly as on main.
+        async def _run():
+            import routes.inference as inf_mod
+
+            class Request:
+                state = SimpleNamespace()
+                url = SimpleNamespace(path = "/v1/completions")
+                method = "POST"
+
+                async def json(self):
+                    return {"prompt": "hi", "stream": False}
+
+            captured = []
+
+            class CapturingClient:
+                async def post(self, _url, *, json, **_kwargs):
+                    captured.append(dict(json))
+                    return httpx.Response(
+                        200,
+                        json = {
+                            "id": "cmpl-test",
+                            "choices": [{"text": "ok"}],
+                            "usage": {
+                                "prompt_tokens": 1,
+                                "completion_tokens": 1,
+                                "total_tokens": 2,
+                            },
+                        },
+                    )
+
+            monitor = ApiMonitor(max_entries = 3)
+            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+            monkeypatch.delenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, raising = False)
+            monkeypatch.delenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, raising = False)
+            monkeypatch.setattr(inf_mod, "nonstreaming_client", lambda: CapturingClient())
+            monkeypatch.setattr(
+                inf_mod,
+                "get_llama_cpp_backend",
+                lambda: SimpleNamespace(
+                    is_loaded = True,
+                    base_url = "http://llama.test",
+                    context_length = 4096,
+                    model_identifier = "gguf",
+                ),
+            )
+
+            await openai_completions(Request(), current_subject = "test")
+
+            assert captured[0]["max_tokens"] == 4096
+            assert monitor.active_count() == 0
+
+        asyncio.run(_run())
+
     def test_completions_rejects_non_integer_max_tokens_before_ceiling(self, monkeypatch):
         async def _run():
             import routes.inference as inf_mod
@@ -4815,6 +4952,147 @@ class TestApiMonitorProviderAndCompletionStreams:
             assert entry["status"] == "completed"
             assert entry["reply"] == "hello"
             assert result.monitor.active_count() == 0
+
+        asyncio.run(_run())
+
+    def test_passthrough_finish_without_done_closes_stream_early(self, monkeypatch):
+        # Some llama-server builds emit the finish chunk and then hold the HTTP
+        # stream open without sending [DONE]; the terminal classifier must end
+        # the client stream promptly instead of hanging on the open socket.
+        async def _run():
+            import routes.inference as inf_mod
+
+            class Request:
+                async def is_disconnected(self):
+                    return False
+
+            async def fake_send(*_args, **_kwargs):
+                return httpx.Response(200, content = b"")
+
+            async def fake_items(*_args, **_kwargs):
+                yield 'data: {"choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}'
+                yield 'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}'
+                await asyncio.Event().wait()  # upstream never closes
+
+            monitor = ApiMonitor(max_entries = 3)
+            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+            monkeypatch.setattr(inf_mod, "_send_stream_with_preheader_cancel", fake_send)
+            monkeypatch.setattr(inf_mod, "_aiter_llama_stream_items", fake_items)
+            monitor_id = monitor.start(
+                endpoint = "/v1/chat/completions",
+                method = "POST",
+                model = "gguf",
+                prompt = "hi",
+            )
+            payload = ChatCompletionRequest(
+                model = "default",
+                messages = [ChatMessage(role = "user", content = "hi")],
+                stream = True,
+                tools = [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            )
+
+            response = await _openai_passthrough_stream(
+                Request(),
+                threading.Event(),
+                SimpleNamespace(
+                    base_url = "http://llama.test",
+                    context_length = 4096,
+                    _request_reasoning_kwargs = lambda *_args, **_kwargs: None,
+                ),
+                payload,
+                "gguf",
+                "chatcmpl-test",
+                monitor_id = monitor_id,
+            )
+
+            async def _consume():
+                return [chunk async for chunk in response.body_iterator]
+
+            chunks = await asyncio.wait_for(_consume(), timeout = 2)
+            body = "".join(chunks)
+
+            assert '"finish_reason":"stop"' in body.replace(" ", "")
+            assert body.endswith("data: [DONE]\n\n")
+            [entry] = monitor.snapshot()
+            assert entry["status"] == "completed"
+            assert monitor.active_count() == 0
+
+        asyncio.run(_run())
+
+    def test_passthrough_stall_after_finish_closes_cleanly(self, monkeypatch):
+        # include_usage keeps the stream open past the finish chunk waiting for
+        # the usage chunk; if that never arrives, the post-terminal grace path
+        # must close with a clean [DONE], not an in-band error.
+        async def _run():
+            import routes.inference as inf_mod
+
+            class Request:
+                async def is_disconnected(self):
+                    return False
+
+            async def fake_send(*_args, **_kwargs):
+                return httpx.Response(200, content = b"")
+
+            async def fake_items(*_args, **_kwargs):
+                yield 'data: {"choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}'
+                yield 'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}'
+                raise httpx.ReadTimeout("usage chunk never arrived")
+
+            monitor = ApiMonitor(max_entries = 3)
+            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+            monkeypatch.setattr(inf_mod, "_send_stream_with_preheader_cancel", fake_send)
+            monkeypatch.setattr(inf_mod, "_aiter_llama_stream_items", fake_items)
+            monitor_id = monitor.start(
+                endpoint = "/v1/chat/completions",
+                method = "POST",
+                model = "gguf",
+                prompt = "hi",
+            )
+            payload = ChatCompletionRequest(
+                model = "default",
+                messages = [ChatMessage(role = "user", content = "hi")],
+                stream = True,
+                stream_options = {"include_usage": True},
+                tools = [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            )
+
+            response = await _openai_passthrough_stream(
+                Request(),
+                threading.Event(),
+                SimpleNamespace(
+                    base_url = "http://llama.test",
+                    context_length = 4096,
+                    _request_reasoning_kwargs = lambda *_args, **_kwargs: None,
+                ),
+                payload,
+                "gguf",
+                "chatcmpl-test",
+                monitor_id = monitor_id,
+            )
+            chunks = [chunk async for chunk in response.body_iterator]
+            body = "".join(chunks)
+
+            assert '"type":"api_error"' not in body.replace(" ", "")
+            assert body.endswith("data: [DONE]\n\n")
+            [entry] = monitor.snapshot()
+            assert entry["status"] == "completed"
+            assert monitor.active_count() == 0
 
         asyncio.run(_run())
 

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -57,12 +57,8 @@ from routes.inference import (
     _openai_passthrough_stream,
     _openai_stream_error_sse,
     _openai_stream_usage_chunk,
-    _openai_compat_implicit_max_tokens,
-    _openai_compat_max_tokens_ceiling,
     _proxy_to_external_provider,
     _SameTaskStreamingResponse,
-    _OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV,
-    _OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV,
     _OPENAI_COMPAT_STREAM_STALL_TIMEOUT_ENV,
     _set_or_prepend_system_message,
     openai_completions,
@@ -1278,39 +1274,19 @@ class TestOpenAICompatibilityHelpers:
         payload = SimpleNamespace(max_tokens = 128, max_completion_tokens = 64)
         assert _effective_max_tokens(payload) == 64
 
-    def test_openai_compat_max_tokens_returns_none_when_omitted(self, monkeypatch):
-        monkeypatch.delenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, raising = False)
-        monkeypatch.delenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, raising = False)
+    def test_openai_compat_max_tokens_returns_none_when_omitted(self):
         payload = SimpleNamespace(max_tokens = None, max_completion_tokens = None)
         assert _effective_openai_max_tokens(payload) is None
 
-    def test_openai_compat_max_tokens_uses_env_override_when_omitted(self, monkeypatch):
-        monkeypatch.setenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, "512")
-        monkeypatch.delenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, raising = False)
-        payload = SimpleNamespace(max_tokens = None, max_completion_tokens = None)
-        assert _openai_compat_implicit_max_tokens() == 512
-        assert _effective_openai_max_tokens(payload) == 512
-
-    @pytest.mark.parametrize("raw_value", ["", "0", "-3", "not-an-int"])
-    def test_openai_compat_max_tokens_invalid_env_keeps_no_cap(self, monkeypatch, raw_value):
-        monkeypatch.setenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, raw_value)
-        monkeypatch.delenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, raising = False)
-        payload = SimpleNamespace(max_tokens = None, max_completion_tokens = None)
-        assert _effective_openai_max_tokens(payload) is None
-
-    def test_openai_compat_max_tokens_preserves_explicit_value_without_ceiling(self, monkeypatch):
-        monkeypatch.setenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, "512")
-        monkeypatch.delenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, raising = False)
-        payload = SimpleNamespace(max_tokens = 8192, max_completion_tokens = None)
-        assert _effective_openai_max_tokens(payload) == 8192
-
-    def test_openai_compat_max_completion_tokens_preserves_explicit_value_without_ceiling(
-        self, monkeypatch
-    ):
-        monkeypatch.setenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, "512")
-        monkeypatch.delenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, raising = False)
-        payload = SimpleNamespace(max_tokens = 8192, max_completion_tokens = 256)
-        assert _effective_openai_max_tokens(payload) == 256
+    @pytest.mark.parametrize(
+        ("payload", "expected"),
+        [
+            (SimpleNamespace(max_tokens = 8192, max_completion_tokens = None), 8192),
+            (SimpleNamespace(max_tokens = 8192, max_completion_tokens = 256), 256),
+        ],
+    )
+    def test_openai_compat_explicit_values_pass_through(self, payload, expected):
+        assert _effective_openai_max_tokens(payload) == expected
 
     @pytest.mark.parametrize(
         ("payload", "param"),
@@ -1361,36 +1337,6 @@ class TestOpenAICompatibilityHelpers:
 
         assert headers["Authorization"] == "Bearer secret"
         assert headers["Connection"] == "close"
-
-    @pytest.mark.parametrize("raw_value", ["", "0", "-3", "not-an-int"])
-    def test_openai_compat_explicit_ceiling_invalid_env_disables_guard(
-        self, monkeypatch, raw_value
-    ):
-        monkeypatch.setenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, raw_value)
-        payload = SimpleNamespace(max_tokens = 8192, max_completion_tokens = None)
-        assert _openai_compat_max_tokens_ceiling() is None
-        assert _effective_openai_max_tokens(payload) == 8192
-
-    def test_openai_compat_explicit_ceiling_caps_max_tokens(self, monkeypatch):
-        monkeypatch.setenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, "1024")
-        payload = SimpleNamespace(max_tokens = 32000, max_completion_tokens = None)
-        assert _effective_openai_max_tokens(payload) == 1024
-
-    def test_openai_compat_explicit_ceiling_caps_max_completion_tokens(self, monkeypatch):
-        monkeypatch.setenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, "1024")
-        payload = SimpleNamespace(max_tokens = 32000, max_completion_tokens = 4096)
-        assert _effective_openai_max_tokens(payload) == 1024
-
-    def test_openai_compat_explicit_ceiling_preserves_values_below_ceiling(self, monkeypatch):
-        monkeypatch.setenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, "1024")
-        payload = SimpleNamespace(max_tokens = 512, max_completion_tokens = None)
-        assert _effective_openai_max_tokens(payload) == 512
-
-    def test_openai_compat_explicit_ceiling_applies_when_omitted(self, monkeypatch):
-        monkeypatch.delenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, raising = False)
-        monkeypatch.setenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, "256")
-        payload = SimpleNamespace(max_tokens = None, max_completion_tokens = None)
-        assert _effective_openai_max_tokens(payload) == 256
 
     def test_openai_compat_stream_stall_timeout_uses_default(self, monkeypatch):
         monkeypatch.delenv(_OPENAI_COMPAT_STREAM_STALL_TIMEOUT_ENV, raising = False)
@@ -3788,69 +3734,6 @@ class TestApiMonitorProviderAndCompletionStreams:
 
         asyncio.run(_run())
 
-    def test_completions_applies_configured_max_tokens_ceiling(self, monkeypatch):
-        async def _run():
-            import routes.inference as inf_mod
-
-            class Request:
-                state = SimpleNamespace()
-                url = SimpleNamespace(path = "/v1/completions")
-                method = "POST"
-
-                def __init__(self, body):
-                    self._body = body
-
-                async def json(self):
-                    return dict(self._body)
-
-            captured = []
-
-            class CapturingClient:
-                async def post(self, _url, *, json, **_kwargs):
-                    captured.append(dict(json))
-                    return httpx.Response(
-                        200,
-                        json = {
-                            "id": "cmpl-test",
-                            "choices": [{"text": "ok"}],
-                            "usage": {
-                                "prompt_tokens": 1,
-                                "completion_tokens": 1,
-                                "total_tokens": 2,
-                            },
-                        },
-                    )
-
-            monitor = ApiMonitor(max_entries = 5)
-            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
-            monkeypatch.setenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, "256")
-            monkeypatch.setattr(inf_mod, "nonstreaming_client", lambda: CapturingClient())
-            monkeypatch.setattr(
-                inf_mod,
-                "get_llama_cpp_backend",
-                lambda: SimpleNamespace(
-                    is_loaded = True,
-                    base_url = "http://llama.test",
-                    context_length = 4096,
-                    model_identifier = "gguf",
-                ),
-            )
-
-            await openai_completions(
-                Request({"prompt": "hi", "stream": False}),
-                current_subject = "test",
-            )
-            await openai_completions(
-                Request({"prompt": "hi", "stream": False, "max_tokens": 9999}),
-                current_subject = "test",
-            )
-
-            assert captured[0]["max_tokens"] == 256
-            assert captured[1]["max_tokens"] == 256
-            assert monitor.active_count() == 0
-
-        asyncio.run(_run())
-
     def test_completions_omitted_max_tokens_falls_back_to_context(self, monkeypatch):
         # With no env knobs set, an omitted max_tokens must forward the
         # backend's context length, exactly as on main.
@@ -3885,8 +3768,6 @@ class TestApiMonitorProviderAndCompletionStreams:
 
             monitor = ApiMonitor(max_entries = 3)
             monkeypatch.setattr(inf_mod, "api_monitor", monitor)
-            monkeypatch.delenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, raising = False)
-            monkeypatch.delenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, raising = False)
             monkeypatch.setattr(inf_mod, "nonstreaming_client", lambda: CapturingClient())
             monkeypatch.setattr(
                 inf_mod,
@@ -3938,8 +3819,6 @@ class TestApiMonitorProviderAndCompletionStreams:
 
             monitor = ApiMonitor(max_entries = 3)
             monkeypatch.setattr(inf_mod, "api_monitor", monitor)
-            monkeypatch.delenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, raising = False)
-            monkeypatch.delenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, raising = False)
             monkeypatch.setattr(inf_mod, "nonstreaming_client", lambda: CapturingClient())
             monkeypatch.setattr(
                 inf_mod,
@@ -3959,7 +3838,7 @@ class TestApiMonitorProviderAndCompletionStreams:
 
         asyncio.run(_run())
 
-    def test_completions_rejects_non_integer_max_tokens_before_ceiling(self, monkeypatch):
+    def test_completions_rejects_non_integer_max_tokens_before_forwarding(self, monkeypatch):
         async def _run():
             import routes.inference as inf_mod
 
@@ -3977,7 +3856,6 @@ class TestApiMonitorProviderAndCompletionStreams:
 
             monitor = ApiMonitor(max_entries = 3)
             monkeypatch.setattr(inf_mod, "api_monitor", monitor)
-            monkeypatch.setenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, "256")
             monkeypatch.setattr(inf_mod, "nonstreaming_client", lambda: UnusedClient())
             monkeypatch.setattr(
                 inf_mod,

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -1351,7 +1351,7 @@ class TestOpenAICompatibilityHelpers:
         from routes.inference import _chat_reasoning_chunk
 
         line = _chat_reasoning_chunk("chatcmpl-test", 123, "gguf", "thinking...")
-        chunk = json.loads(line[len("data: "):])
+        chunk = json.loads(line[len("data: ") :])
         delta = chunk["choices"][0]["delta"]
 
         assert delta["reasoning_content"] == "thinking..."

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -49,10 +49,8 @@ from routes.inference import (
     _monitor_openai_chunk,
     _monitor_openai_sse_event,
     _normalize_openai_passthrough_sse_line,
-    _openai_compat_stream_preheader_fallback_timeout,
     _openai_compat_stream_stall_timeout,
     _openai_messages_for_gguf_chat,
-    _openai_non_stream_chat_response_sse_lines,
     _openai_passthrough_sse_line_terminal_state,
     _openai_passthrough_upstream_headers,
     _openai_passthrough_non_streaming,
@@ -66,7 +64,6 @@ from routes.inference import (
     _OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV,
     _OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV,
     _OPENAI_COMPAT_STREAM_STALL_TIMEOUT_ENV,
-    _OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT_ENV,
     _set_or_prepend_system_message,
     openai_completions,
     openai_embeddings,
@@ -1416,156 +1413,6 @@ class TestOpenAICompatibilityHelpers:
     ):
         monkeypatch.setenv(_OPENAI_COMPAT_STREAM_STALL_TIMEOUT_ENV, raw_value)
         assert _openai_compat_stream_stall_timeout() is None
-
-    def test_openai_compat_preheader_fallback_timeout_uses_default(self, monkeypatch):
-        monkeypatch.delenv(_OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT_ENV, raising = False)
-        assert _openai_compat_stream_preheader_fallback_timeout() is None
-
-    def test_openai_compat_preheader_fallback_timeout_uses_env_override(self, monkeypatch):
-        monkeypatch.setenv(_OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT_ENV, "2.5")
-        assert _openai_compat_stream_preheader_fallback_timeout() == 2.5
-
-    @pytest.mark.parametrize("raw_value", ["", "not-a-float"])
-    def test_openai_compat_preheader_fallback_timeout_invalid_env_disables(
-        self, monkeypatch, raw_value
-    ):
-        monkeypatch.setenv(_OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT_ENV, raw_value)
-        assert _openai_compat_stream_preheader_fallback_timeout() is None
-
-    @pytest.mark.parametrize("raw_value", ["0", "-1"])
-    def test_openai_compat_preheader_fallback_timeout_non_positive_env_disables(
-        self, monkeypatch, raw_value
-    ):
-        monkeypatch.setenv(_OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT_ENV, raw_value)
-        assert _openai_compat_stream_preheader_fallback_timeout() is None
-
-    def test_non_streaming_fallback_response_converts_to_openai_sse(self):
-        payload = SimpleNamespace(stream_options = {"include_usage": True})
-        lines = _openai_non_stream_chat_response_sse_lines(
-            {
-                "id": "chatcmpl-fallback",
-                "created": 123,
-                "model": "model-a",
-                "system_fingerprint": "fp-test",
-                "choices": [
-                    {
-                        "index": 0,
-                        "message": {
-                            "role": "assistant",
-                            "content": "OK",
-                            "reasoning_content": "short reasoning",
-                        },
-                        "finish_reason": "stop",
-                    }
-                ],
-                "usage": {
-                    "prompt_tokens": 7,
-                    "completion_tokens": 2,
-                    "total_tokens": 9,
-                },
-            },
-            payload,
-            "chatcmpl-original",
-            "model-b",
-        )
-
-        assert lines[-1] == "data: [DONE]"
-        delta = json.loads(lines[0][len("data: ") :])
-        assert delta["id"] == "chatcmpl-fallback"
-        assert delta["choices"][0]["delta"] == {
-            "role": "assistant",
-            "content": "OK",
-            "reasoning_content": "short reasoning",
-        }
-        finish = json.loads(lines[1][len("data: ") :])
-        assert finish["choices"][0]["finish_reason"] == "stop"
-        usage = json.loads(lines[2][len("data: ") :])
-        assert usage["choices"] == []
-        assert usage["usage"]["completion_tokens"] == 2
-
-    def test_non_streaming_fallback_response_omits_usage_without_opt_in(self):
-        payload = SimpleNamespace(stream_options = None)
-        lines = _openai_non_stream_chat_response_sse_lines(
-            {
-                "choices": [
-                    {
-                        "index": 0,
-                        "message": {"role": "assistant", "content": "OK"},
-                        "finish_reason": "stop",
-                    }
-                ],
-                "usage": {"prompt_tokens": 7, "completion_tokens": 2, "total_tokens": 9},
-            },
-            payload,
-            "chatcmpl-original",
-            "model-b",
-        )
-
-        assert len(lines) == 3
-        assert lines[-1] == "data: [DONE]"
-
-    def test_non_streaming_fallback_response_adds_empty_content_to_reasoning_only_delta(self):
-        payload = SimpleNamespace(stream_options = None)
-        lines = _openai_non_stream_chat_response_sse_lines(
-            {
-                "choices": [
-                    {
-                        "index": 0,
-                        "message": {
-                            "role": "assistant",
-                            "content": None,
-                            "reasoning_content": "plan",
-                        },
-                        "finish_reason": "stop",
-                    }
-                ],
-            },
-            payload,
-            "chatcmpl-original",
-            "model-b",
-        )
-
-        delta = json.loads(lines[0][len("data: ") :])["choices"][0]["delta"]
-        assert delta["reasoning_content"] == "plan"
-        assert delta["content"] == ""
-
-    def test_non_streaming_fallback_response_adds_tool_call_delta_indexes(self):
-        payload = SimpleNamespace(stream_options = None)
-        lines = _openai_non_stream_chat_response_sse_lines(
-            {
-                "choices": [
-                    {
-                        "index": 0,
-                        "message": {
-                            "role": "assistant",
-                            "content": None,
-                            "tool_calls": [
-                                {
-                                    "id": "call_1",
-                                    "type": "function",
-                                    "function": {"name": "lookup", "arguments": "{}"},
-                                },
-                                {
-                                    "index": 7,
-                                    "id": "call_2",
-                                    "type": "function",
-                                    "function": {"name": "search", "arguments": "{}"},
-                                },
-                            ],
-                        },
-                        "finish_reason": "tool_calls",
-                    }
-                ],
-            },
-            payload,
-            "chatcmpl-original",
-            "model-b",
-        )
-
-        delta = json.loads(lines[0][len("data: ") :])["choices"][0]["delta"]
-        assert [tool_call["index"] for tool_call in delta["tool_calls"]] == [0, 7]
-        finish = json.loads(lines[1][len("data: ") :])["choices"][0]
-        assert finish["finish_reason"] == "tool_calls"
 
     def test_openai_stream_error_sse_closes_with_done(self):
         error = {"error": {"message": "boom"}}
@@ -3625,84 +3472,6 @@ class TestApiMonitorProviderAndCompletionStreams:
                 await task
             await asyncio.wait_for(cancelled.wait(), timeout = 5.0)
             assert cancel_id not in inf_mod._CANCEL_REGISTRY
-
-        asyncio.run(_run())
-
-    def test_passthrough_stream_preheader_fallback_preserves_http_exception_detail(
-        self, monkeypatch
-    ):
-        async def _run():
-            import routes.inference as inf_mod
-
-            monkeypatch.setenv(_OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT_ENV, "0.01")
-            entered = asyncio.Event()
-
-            async def fake_send(*_args, **_kwargs):
-                entered.set()
-                await asyncio.Event().wait()
-
-            async def fake_non_streaming_upstream(*_args, **_kwargs):
-                raise HTTPException(
-                    status_code = 400,
-                    detail = {
-                        "error": {
-                            "message": "bad schema",
-                            "type": "invalid_request_error",
-                            "code": "invalid_request_error",
-                        }
-                    },
-                )
-
-            class Request:
-                async def is_disconnected(self):
-                    return False
-
-            monitor = ApiMonitor(max_entries = 3)
-            monitor_id = monitor.start(
-                endpoint = "/v1/chat/completions",
-                method = "POST",
-                model = "gguf",
-                prompt = "hi",
-            )
-            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
-            monkeypatch.setattr(inf_mod, "_send_stream_with_preheader_cancel", fake_send)
-            monkeypatch.setattr(
-                inf_mod,
-                "_openai_passthrough_non_streaming",
-                fake_non_streaming_upstream,
-            )
-
-            payload = ChatCompletionRequest(
-                model = "default",
-                messages = [ChatMessage(role = "user", content = "hi")],
-                stream = True,
-            )
-            response = await _openai_passthrough_stream(
-                Request(),
-                threading.Event(),
-                SimpleNamespace(
-                    base_url = "http://llama.test",
-                    context_length = 4096,
-                    _request_reasoning_kwargs = lambda *_args, **_kwargs: None,
-                ),
-                payload,
-                "gguf",
-                "chatcmpl-test",
-                monitor_id = monitor_id,
-            )
-            await asyncio.wait_for(entered.wait(), timeout = 0.2)
-            chunks = [
-                chunk.decode() if isinstance(chunk, bytes) else chunk
-                async for chunk in response.body_iterator
-            ]
-            body = "".join(chunks)
-
-            assert "bad schema" in body
-            assert "invalid_request_error" in body
-            assert "internal_error" not in body
-            assert body.endswith("data: [DONE]\n\n")
-            [entry] = monitor.snapshot()
-            assert entry["status"] == "error"
 
         asyncio.run(_run())
 

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -47,7 +47,6 @@ from routes.inference import (
     _merge_user_content,
     _monitor_openai_chunk,
     _monitor_openai_sse_event,
-    _cap_parallel_tool_calls_sse_line,
     _normalize_openai_passthrough_sse_line,
     _openai_compat_stream_preheader_fallback_timeout,
     _openai_compat_stream_stall_timeout,
@@ -1054,7 +1053,7 @@ class TestOpenAIPassthroughSSETerminalState:
             '{"index":1,"function":{"name":"b"}}]}}]}'
         )
 
-        capped = _cap_parallel_tool_calls_sse_line(line)
+        capped = _normalize_openai_passthrough_sse_line(line, cap_parallel_tool_calls = True)
 
         data = json.loads(capped[len("data:") :].lstrip())
         assert data["choices"][0]["delta"]["tool_calls"] == [

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -8,6 +8,7 @@ import sys
 import asyncio
 import json
 import threading
+import time
 from types import SimpleNamespace
 
 _backend = os.path.join(os.path.dirname(__file__), "..")
@@ -30,6 +31,7 @@ from core.inference.anthropic_compat import (
 )
 from core.inference.api_monitor import ApiMonitor
 from routes.inference import (
+    _aclose_stream_resources,
     _build_chat_request,
     _build_openai_passthrough_body,
     _build_passthrough_payload,
@@ -38,24 +40,198 @@ from routes.inference import (
     _coalesce_consecutive_user_turns,
     _drop_empty_assistant_sentinels,
     _effective_max_tokens,
+    _effective_openai_max_tokens,
     _extract_content_parts,
     _friendly_error,
     _friendly_upstream_error,
     _merge_user_content,
     _monitor_openai_chunk,
     _monitor_openai_sse_event,
+    _cap_parallel_tool_calls_sse_line,
+    _normalize_openai_passthrough_sse_line,
+    _openai_compat_stream_preheader_fallback_timeout,
+    _openai_compat_stream_stall_timeout,
     _openai_messages_for_gguf_chat,
+    _openai_non_stream_chat_response_sse_lines,
+    _openai_open_resumable_stream,
+    _openai_passthrough_sse_line_terminal_state,
+    _openai_passthrough_upstream_headers,
     _openai_passthrough_non_streaming,
     _openai_passthrough_stream,
+    _openai_resumable_session_has_replay_bytes,
+    _openai_stream_error_sse,
     _openai_stream_usage_chunk,
+    _openai_compat_implicit_max_tokens,
+    _openai_compat_max_tokens_ceiling,
     _proxy_to_external_provider,
     _SameTaskStreamingResponse,
+    _OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_DEFAULT,
+    _OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV,
+    _OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV,
+    _OPENAI_COMPAT_STREAM_STALL_TIMEOUT_ENV,
+    _OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT_ENV,
     _set_or_prepend_system_message,
     openai_completions,
     openai_embeddings,
     openai_chat_completions,
 )
-from state.tool_policy import reset_tool_policy
+from state.tool_policy import reset_tool_policy, set_tool_policy
+
+
+def test_aclose_stream_resources_attempts_remaining_closes_after_cancel():
+    class Closeable:
+        def __init__(self, *, cancel = False):
+            self.cancel = cancel
+            self.closed = False
+
+        async def aclose(self):
+            self.closed = True
+            if self.cancel:
+                raise asyncio.CancelledError()
+
+    async def _run():
+        iterator = Closeable(cancel = True)
+        resp = Closeable()
+        client = Closeable()
+
+        with pytest.raises(asyncio.CancelledError):
+            await _aclose_stream_resources(iterator = iterator, resp = resp, client = client)
+
+        assert iterator.closed
+        assert resp.closed
+        assert client.closed
+
+    asyncio.run(_run())
+
+
+@pytest.mark.parametrize(
+    ("session", "expected"),
+    [
+        ({"id": "s", "total_bytes": 1}, True),
+        ({"id": "s", "total_bytes": 0}, False),
+        ({"id": "s", "total_bytes": True}, False),
+        ({"id": "s", "bytes": 2}, False),
+        ({"id": "s", "has_data": True}, False),
+        ({"id": "s"}, False),
+        ("s", False),
+    ],
+)
+def test_openai_resumable_session_has_replay_bytes(session, expected):
+    assert _openai_resumable_session_has_replay_bytes(session) is expected
+
+
+def test_openai_resumable_lookup_waits_for_buffered_bytes(monkeypatch):
+    async def _run():
+        import routes.inference as inf_mod
+
+        captured = {"closed": False, "sent": False}
+
+        class FakeAsyncClient:
+            def __init__(self, *, timeout, limits, trust_env):
+                captured["timeout"] = timeout
+                captured["limits"] = limits
+                captured["trust_env"] = trust_env
+
+            async def post(
+                self,
+                url,
+                *,
+                json = None,
+                headers = None,
+            ):
+                captured["post_url"] = url
+                captured["post_json"] = json
+                captured["post_headers"] = headers
+                return httpx.Response(200, json = [{"id": "stream-1", "total_bytes": 0}])
+
+            def build_request(self, *_args, **_kwargs):
+                raise AssertionError("replay GET must wait until lookup reports bytes")
+
+            async def send(self, *_args, **_kwargs):
+                captured["sent"] = True
+                raise AssertionError("replay GET must wait until lookup reports bytes")
+
+            async def aclose(self):
+                captured["closed"] = True
+
+        monkeypatch.setattr(inf_mod.httpx, "AsyncClient", FakeAsyncClient)
+
+        client, response = await _openai_open_resumable_stream(
+            "http://llama.test",
+            "stream-1",
+            headers = {"Authorization": "Bearer secret"},
+        )
+
+        assert client is None
+        assert response is None
+        assert captured["post_url"] == "http://llama.test/v1/streams/lookup"
+        assert captured["post_json"] == {"conversation_ids": ["stream-1"]}
+        assert captured["post_headers"] == {"Authorization": "Bearer secret"}
+        assert captured["timeout"].read == inf_mod._OPENAI_PASSTHROUGH_RESUMABLE_LOOKUP_TIMEOUT_S
+        assert captured["sent"] is False
+        assert captured["closed"] is True
+
+    asyncio.run(_run())
+
+
+def test_openai_resumable_lookup_opens_replay_after_buffered_bytes(monkeypatch):
+    async def _run():
+        import routes.inference as inf_mod
+
+        captured = {"closed": False, "sent": False}
+
+        class FakeAsyncClient:
+            def __init__(self, *, timeout, limits, trust_env):
+                captured["timeout"] = timeout
+
+            async def post(self, *_args, **_kwargs):
+                return httpx.Response(200, json = [{"id": "stream-1", "total_bytes": 12}])
+
+            def build_request(
+                self,
+                method,
+                url,
+                *,
+                headers = None,
+            ):
+                captured["method"] = method
+                captured["url"] = url
+                captured["headers"] = headers
+                return httpx.Request(method, url, headers = headers)
+
+            async def send(
+                self,
+                request,
+                *,
+                stream = False,
+            ):
+                captured["sent"] = True
+                captured["stream"] = stream
+                return httpx.Response(200, content = b"data: [DONE]\n\n", request = request)
+
+            async def aclose(self):
+                captured["closed"] = True
+
+        monkeypatch.setattr(inf_mod.httpx, "AsyncClient", FakeAsyncClient)
+
+        client, response = await _openai_open_resumable_stream(
+            "http://llama.test",
+            "stream-1",
+            headers = {"Authorization": "Bearer secret"},
+        )
+
+        assert client is not None
+        assert response is not None
+        assert response.status_code == 200
+        assert captured["method"] == "GET"
+        assert captured["url"] == "http://llama.test/v1/stream/stream-1?from=0"
+        assert captured["headers"] == {"Authorization": "Bearer secret"}
+        assert captured["stream"] is True
+        assert captured["sent"] is True
+        assert captured["closed"] is False
+        await client.aclose()
+
+    asyncio.run(_run())
 
 
 class TestFriendlyUpstreamError:
@@ -548,6 +724,197 @@ class TestChatCompletionRequestToolFields:
         assert "n > 1 is not supported" in entry["error"]
         assert monitor.active_count() == 0
 
+    def test_client_tools_rejected_when_gguf_template_has_no_tool_support(self, monkeypatch):
+        import routes.inference as inference_route
+
+        class _GGUFBackend:
+            is_loaded = True
+            model_identifier = "test-gguf"
+            supports_tools = False
+            is_vision = False
+            _is_audio = False
+            context_length = 4096
+
+            def generate_chat_completion(self, **_kwargs):
+                raise AssertionError("client tools must not fall through to the standard GGUF path")
+
+        monitor = ApiMonitor(max_entries = 3)
+        monkeypatch.setattr(inference_route, "api_monitor", monitor)
+        client = self._v1_client(monkeypatch, _GGUFBackend())
+        resp = client.post(
+            "/v1/chat/completions",
+            json = {
+                "messages": [{"role": "user", "content": "hi"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ],
+            },
+        )
+
+        self._assert_unsupported_param(resp, "tools")
+        assert "does not advertise tools" in resp.json()["error"]["message"]
+        [entry] = monitor.snapshot()
+        assert entry["status"] == "error"
+        assert "does not advertise tools" in entry["error"]
+        assert monitor.active_count() == 0
+
+    def test_client_tools_use_passthrough_capability_when_tool_loop_is_disabled(self, monkeypatch):
+        import routes.inference as inference_route
+
+        captured = {}
+
+        class _GGUFBackend:
+            is_loaded = True
+            model_identifier = "test-gguf"
+            supports_tools = False
+            supports_tool_passthrough = True
+            is_vision = False
+            _is_audio = False
+            context_length = 4096
+            base_url = "http://llama.passthrough-capability.test"
+            _request_reasoning_kwargs = lambda *_args, **_kwargs: None
+
+            def generate_chat_completion(self, **_kwargs):
+                raise AssertionError("client tools must use passthrough")
+
+            def generate_chat_completion_with_tools(self, **_kwargs):
+                raise AssertionError("Studio tool loop must stay disabled")
+
+        async def fake_passthrough(llama_backend, payload, model_name, **kwargs):
+            captured["body"] = inference_route._build_openai_passthrough_body(
+                payload,
+                backend_ctx = llama_backend.context_length,
+                llama_backend = llama_backend,
+            )
+            inference_route.api_monitor.finish(kwargs.get("monitor_id"))
+            return inference_route.JSONResponse({"ok": True, "model": model_name})
+
+        monitor = ApiMonitor(max_entries = 3)
+        monkeypatch.setattr(inference_route, "api_monitor", monitor)
+        monkeypatch.setattr(
+            inference_route,
+            "_openai_passthrough_non_streaming",
+            fake_passthrough,
+        )
+        client = self._v1_client(monkeypatch, _GGUFBackend())
+        resp = client.post(
+            "/v1/chat/completions",
+            json = {
+                "messages": [{"role": "user", "content": "use client tool"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ],
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        assert captured["body"]["tools"][0]["function"]["name"] == "lookup"
+        [entry] = monitor.snapshot()
+        assert entry["status"] == "completed"
+        assert monitor.active_count() == 0
+
+    def test_tool_choice_none_allows_tool_catalog_without_tool_template(self, monkeypatch):
+        import routes.inference as inference_route
+
+        class _GGUFBackend:
+            is_loaded = True
+            model_identifier = "test-gguf"
+            supports_tools = False
+            is_vision = False
+            _is_audio = False
+            context_length = 4096
+
+            def generate_chat_completion(self, **kwargs):
+                assert kwargs["max_tokens"] == _OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_DEFAULT
+                yield "plain response"
+
+        monitor = ApiMonitor(max_entries = 3)
+        monkeypatch.setattr(inference_route, "api_monitor", monitor)
+        client = self._v1_client(monkeypatch, _GGUFBackend())
+        resp = client.post(
+            "/v1/chat/completions",
+            json = {
+                "messages": [{"role": "user", "content": "hi"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ],
+                "tool_choice": "none",
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["choices"][0]["message"]["content"] == "plain response"
+        [entry] = monitor.snapshot()
+        assert entry["status"] == "completed"
+        assert entry["reply"] == "plain response"
+        assert monitor.active_count() == 0
+
+    def test_tool_call_history_rejected_when_gguf_template_has_no_tool_support(self, monkeypatch):
+        import routes.inference as inference_route
+
+        class _GGUFBackend:
+            is_loaded = True
+            model_identifier = "test-gguf"
+            supports_tools = False
+            is_vision = False
+            _is_audio = False
+            context_length = 4096
+
+            def generate_chat_completion(self, **_kwargs):
+                raise AssertionError(
+                    "tool-call history must not fall through to the standard GGUF path"
+                )
+
+        monitor = ApiMonitor(max_entries = 3)
+        monkeypatch.setattr(inference_route, "api_monitor", monitor)
+        client = self._v1_client(monkeypatch, _GGUFBackend())
+        resp = client.post(
+            "/v1/chat/completions",
+            json = {
+                "messages": [
+                    {"role": "user", "content": "use a tool"},
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {"name": "lookup", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                    {"role": "tool", "tool_call_id": "call_1", "content": "{}"},
+                ],
+            },
+        )
+
+        self._assert_unsupported_param(resp, "messages")
+        assert "does not advertise tools" in resp.json()["error"]["message"]
+        [entry] = monitor.snapshot()
+        assert entry["status"] == "error"
+        assert "does not advertise tools" in entry["error"]
+        assert monitor.active_count() == 0
+
     def test_n_rejected_for_non_gguf_path(self, monkeypatch):
         class _NoGGUFBackend:
             is_loaded = False
@@ -748,10 +1115,32 @@ class TestBuildPassthroughPayloadToolChoice:
         )
         assert body.get("stream_options") == {"include_usage": False}
 
+    def test_response_format_without_tools_omits_tool_fields(self):
+        args = self._args()
+        args["openai_tools"] = None
+
+        body = _build_passthrough_payload(
+            **args,
+            response_format = {"type": "json_object"},
+        )
+
+        assert body["response_format"] == {"type": "json_object"}
+        assert "tools" not in body
+        assert "tool_choice" not in body
+
     def test_repetition_penalty_renamed(self):
         body = _build_passthrough_payload(**self._args(), repetition_penalty = 1.1)
         assert body.get("repeat_penalty") == 1.1
         assert "repetition_penalty" not in body
+
+    def test_omitted_passthrough_max_tokens_uses_openai_compat_cap(self, monkeypatch):
+        monkeypatch.delenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, raising = False)
+        args = self._args()
+        args["max_tokens"] = None
+
+        body = _build_passthrough_payload(**args)
+
+        assert body["max_tokens"] == _OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_DEFAULT
 
     def test_passthrough_body_merges_system_and_developer_messages(self):
         payload = ChatCompletionRequest(
@@ -770,6 +1159,58 @@ class TestBuildPassthroughPayloadToolChoice:
             {"role": "system", "content": "original system\n\ndeveloper rules"},
             {"role": "user", "content": "hi"},
         ]
+
+
+class TestOpenAIPassthroughSSETerminalState:
+    def test_done_sentinel(self):
+        assert _openai_passthrough_sse_line_terminal_state("data: [DONE]") == "done"
+
+    def test_finish_reason_with_space(self):
+        line = 'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}'
+        assert _openai_passthrough_sse_line_terminal_state(line) == "finish"
+
+    def test_finish_reason_without_space(self):
+        line = 'data:{"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}'
+        assert _openai_passthrough_sse_line_terminal_state(line) == "finish"
+
+    def test_usage_chunk(self):
+        line = 'data: {"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":2}}'
+        assert _openai_passthrough_sse_line_terminal_state(line) == "usage"
+
+    def test_error_chunk(self):
+        line = 'data: {"error":{"message":"boom"}}'
+        assert _openai_passthrough_sse_line_terminal_state(line) == "error"
+
+    def test_cap_parallel_tool_calls_accepts_no_space_after_data_colon(self):
+        line = (
+            'data:{"choices":[{"delta":{"tool_calls":['
+            '{"index":0,"function":{"name":"a"}},'
+            '{"index":1,"function":{"name":"b"}}]}}]}'
+        )
+
+        capped = _cap_parallel_tool_calls_sse_line(line)
+
+        data = json.loads(capped[len("data:") :].lstrip())
+        assert data["choices"][0]["delta"]["tool_calls"] == [
+            {"index": 0, "function": {"name": "a"}}
+        ]
+
+    def test_reasoning_only_delta_gets_empty_content(self):
+        line = (
+            'data: {"choices":[{"index":0,'
+            '"delta":{"reasoning_content":"thinking"},'
+            '"finish_reason":null}]}'
+        )
+
+        normalized = _normalize_openai_passthrough_sse_line(line)
+
+        data = json.loads(normalized[len("data:") :].lstrip())
+        delta = data["choices"][0]["delta"]
+        assert delta["reasoning_content"] == "thinking"
+        assert delta["content"] == ""
+
+    def test_reasoning_normalization_preserves_done_sentinel(self):
+        assert _normalize_openai_passthrough_sse_line("data: [DONE]") == "data: [DONE]"
 
 
 # =====================================================================
@@ -891,6 +1332,278 @@ class TestOpenAICompatibilityHelpers:
     def test_max_completion_tokens_wins_over_deprecated_max_tokens(self):
         payload = SimpleNamespace(max_tokens = 128, max_completion_tokens = 64)
         assert _effective_max_tokens(payload) == 64
+
+    def test_openai_compat_max_tokens_uses_implicit_cap_when_omitted(self, monkeypatch):
+        monkeypatch.delenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, raising = False)
+        monkeypatch.delenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, raising = False)
+        payload = SimpleNamespace(max_tokens = None, max_completion_tokens = None)
+        assert _effective_openai_max_tokens(payload) == _OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_DEFAULT
+
+    def test_openai_compat_max_tokens_uses_env_override_when_omitted(self, monkeypatch):
+        monkeypatch.setenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, "512")
+        monkeypatch.delenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, raising = False)
+        payload = SimpleNamespace(max_tokens = None, max_completion_tokens = None)
+        assert _openai_compat_implicit_max_tokens() == 512
+        assert _effective_openai_max_tokens(payload) == 512
+
+    @pytest.mark.parametrize("raw_value", ["", "0", "-3", "not-an-int"])
+    def test_openai_compat_max_tokens_invalid_env_uses_default(self, monkeypatch, raw_value):
+        monkeypatch.setenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, raw_value)
+        monkeypatch.delenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, raising = False)
+        payload = SimpleNamespace(max_tokens = None, max_completion_tokens = None)
+        assert _effective_openai_max_tokens(payload) == _OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_DEFAULT
+
+    def test_openai_compat_max_tokens_preserves_explicit_value_without_ceiling(self, monkeypatch):
+        monkeypatch.setenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, "512")
+        monkeypatch.delenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, raising = False)
+        payload = SimpleNamespace(max_tokens = 8192, max_completion_tokens = None)
+        assert _effective_openai_max_tokens(payload) == 8192
+
+    def test_openai_compat_max_completion_tokens_preserves_explicit_value_without_ceiling(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, "512")
+        monkeypatch.delenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, raising = False)
+        payload = SimpleNamespace(max_tokens = 8192, max_completion_tokens = 256)
+        assert _effective_openai_max_tokens(payload) == 256
+
+    @pytest.mark.parametrize(
+        ("payload", "param"),
+        [
+            (SimpleNamespace(max_tokens = "128", max_completion_tokens = None), "max_tokens"),
+            (SimpleNamespace(max_tokens = True, max_completion_tokens = None), "max_tokens"),
+            (SimpleNamespace(max_tokens = 12.5, max_completion_tokens = None), "max_tokens"),
+            (
+                SimpleNamespace(max_tokens = None, max_completion_tokens = "128"),
+                "max_completion_tokens",
+            ),
+        ],
+    )
+    def test_openai_compat_max_tokens_rejects_non_integer_explicit_values(self, payload, param):
+        with pytest.raises(HTTPException) as exc:
+            _effective_openai_max_tokens(payload)
+
+        assert exc.value.status_code == 400
+        assert exc.value.detail["error"]["param"] == param
+        assert exc.value.detail["error"]["code"] == "invalid_type"
+
+    def test_passthrough_upstream_headers_include_backend_auth_and_stream_id(self):
+        headers = _openai_passthrough_upstream_headers(
+            "stream-123",
+            llama_backend = SimpleNamespace(_auth_headers = {"Authorization": "Bearer secret"}),
+        )
+
+        assert headers["Authorization"] == "Bearer secret"
+        assert headers["Connection"] == "close"
+        assert headers["X-Conversation-Id"] == "stream-123"
+
+    @pytest.mark.parametrize("raw_value", ["", "0", "-3", "not-an-int"])
+    def test_openai_compat_explicit_ceiling_invalid_env_disables_guard(
+        self, monkeypatch, raw_value
+    ):
+        monkeypatch.setenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, raw_value)
+        payload = SimpleNamespace(max_tokens = 8192, max_completion_tokens = None)
+        assert _openai_compat_max_tokens_ceiling() is None
+        assert _effective_openai_max_tokens(payload) == 8192
+
+    def test_openai_compat_explicit_ceiling_caps_max_tokens(self, monkeypatch):
+        monkeypatch.setenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, "1024")
+        payload = SimpleNamespace(max_tokens = 32000, max_completion_tokens = None)
+        assert _effective_openai_max_tokens(payload) == 1024
+
+    def test_openai_compat_explicit_ceiling_caps_max_completion_tokens(self, monkeypatch):
+        monkeypatch.setenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, "1024")
+        payload = SimpleNamespace(max_tokens = 32000, max_completion_tokens = 4096)
+        assert _effective_openai_max_tokens(payload) == 1024
+
+    def test_openai_compat_explicit_ceiling_preserves_values_below_ceiling(self, monkeypatch):
+        monkeypatch.setenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, "1024")
+        payload = SimpleNamespace(max_tokens = 512, max_completion_tokens = None)
+        assert _effective_openai_max_tokens(payload) == 512
+
+    def test_openai_compat_explicit_ceiling_caps_implicit_default(self, monkeypatch):
+        monkeypatch.delenv(_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_ENV, raising = False)
+        monkeypatch.setenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, "256")
+        payload = SimpleNamespace(max_tokens = None, max_completion_tokens = None)
+        assert _effective_openai_max_tokens(payload) == 256
+
+    def test_openai_compat_stream_stall_timeout_uses_default(self, monkeypatch):
+        monkeypatch.delenv(_OPENAI_COMPAT_STREAM_STALL_TIMEOUT_ENV, raising = False)
+        assert _openai_compat_stream_stall_timeout() == 30.0
+
+    def test_openai_compat_stream_stall_timeout_uses_env_override(self, monkeypatch):
+        monkeypatch.setenv(_OPENAI_COMPAT_STREAM_STALL_TIMEOUT_ENV, "4.5")
+        assert _openai_compat_stream_stall_timeout() == 4.5
+
+    @pytest.mark.parametrize("raw_value", ["", "not-a-float"])
+    def test_openai_compat_stream_stall_timeout_invalid_env_uses_default(
+        self, monkeypatch, raw_value
+    ):
+        monkeypatch.setenv(_OPENAI_COMPAT_STREAM_STALL_TIMEOUT_ENV, raw_value)
+        assert _openai_compat_stream_stall_timeout() == 30.0
+
+    @pytest.mark.parametrize("raw_value", ["0", "-1"])
+    def test_openai_compat_stream_stall_timeout_non_positive_env_disables(
+        self, monkeypatch, raw_value
+    ):
+        monkeypatch.setenv(_OPENAI_COMPAT_STREAM_STALL_TIMEOUT_ENV, raw_value)
+        assert _openai_compat_stream_stall_timeout() is None
+
+    def test_openai_compat_preheader_fallback_timeout_uses_default(self, monkeypatch):
+        monkeypatch.delenv(_OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT_ENV, raising = False)
+        assert _openai_compat_stream_preheader_fallback_timeout() is None
+
+    def test_openai_compat_preheader_fallback_timeout_uses_env_override(self, monkeypatch):
+        monkeypatch.setenv(_OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT_ENV, "2.5")
+        assert _openai_compat_stream_preheader_fallback_timeout() == 2.5
+
+    @pytest.mark.parametrize("raw_value", ["", "not-a-float"])
+    def test_openai_compat_preheader_fallback_timeout_invalid_env_disables(
+        self, monkeypatch, raw_value
+    ):
+        monkeypatch.setenv(_OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT_ENV, raw_value)
+        assert _openai_compat_stream_preheader_fallback_timeout() is None
+
+    @pytest.mark.parametrize("raw_value", ["0", "-1"])
+    def test_openai_compat_preheader_fallback_timeout_non_positive_env_disables(
+        self, monkeypatch, raw_value
+    ):
+        monkeypatch.setenv(_OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT_ENV, raw_value)
+        assert _openai_compat_stream_preheader_fallback_timeout() is None
+
+    def test_non_streaming_fallback_response_converts_to_openai_sse(self):
+        payload = SimpleNamespace(stream_options = {"include_usage": True})
+        lines = _openai_non_stream_chat_response_sse_lines(
+            {
+                "id": "chatcmpl-fallback",
+                "created": 123,
+                "model": "model-a",
+                "system_fingerprint": "fp-test",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "OK",
+                            "reasoning_content": "short reasoning",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 7,
+                    "completion_tokens": 2,
+                    "total_tokens": 9,
+                },
+            },
+            payload,
+            "chatcmpl-original",
+            "model-b",
+        )
+
+        assert lines[-1] == "data: [DONE]"
+        delta = json.loads(lines[0][len("data: ") :])
+        assert delta["id"] == "chatcmpl-fallback"
+        assert delta["choices"][0]["delta"] == {
+            "role": "assistant",
+            "content": "OK",
+            "reasoning_content": "short reasoning",
+        }
+        finish = json.loads(lines[1][len("data: ") :])
+        assert finish["choices"][0]["finish_reason"] == "stop"
+        usage = json.loads(lines[2][len("data: ") :])
+        assert usage["choices"] == []
+        assert usage["usage"]["completion_tokens"] == 2
+
+    def test_non_streaming_fallback_response_omits_usage_without_opt_in(self):
+        payload = SimpleNamespace(stream_options = None)
+        lines = _openai_non_stream_chat_response_sse_lines(
+            {
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "OK"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 7, "completion_tokens": 2, "total_tokens": 9},
+            },
+            payload,
+            "chatcmpl-original",
+            "model-b",
+        )
+
+        assert len(lines) == 3
+        assert lines[-1] == "data: [DONE]"
+
+    def test_non_streaming_fallback_response_adds_empty_content_to_reasoning_only_delta(self):
+        payload = SimpleNamespace(stream_options = None)
+        lines = _openai_non_stream_chat_response_sse_lines(
+            {
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "reasoning_content": "plan",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+            },
+            payload,
+            "chatcmpl-original",
+            "model-b",
+        )
+
+        delta = json.loads(lines[0][len("data: ") :])["choices"][0]["delta"]
+        assert delta["reasoning_content"] == "plan"
+        assert delta["content"] == ""
+
+    def test_non_streaming_fallback_response_adds_tool_call_delta_indexes(self):
+        payload = SimpleNamespace(stream_options = None)
+        lines = _openai_non_stream_chat_response_sse_lines(
+            {
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": "call_1",
+                                    "type": "function",
+                                    "function": {"name": "lookup", "arguments": "{}"},
+                                },
+                                {
+                                    "index": 7,
+                                    "id": "call_2",
+                                    "type": "function",
+                                    "function": {"name": "search", "arguments": "{}"},
+                                },
+                            ],
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ],
+            },
+            payload,
+            "chatcmpl-original",
+            "model-b",
+        )
+
+        delta = json.loads(lines[0][len("data: ") :])["choices"][0]["delta"]
+        assert [tool_call["index"] for tool_call in delta["tool_calls"]] == [0, 7]
+        finish = json.loads(lines[1][len("data: ") :])["choices"][0]
+        assert finish["finish_reason"] == "tool_calls"
+
+    def test_openai_stream_error_sse_closes_with_done(self):
+        error = {"error": {"message": "boom"}}
+        assert _openai_stream_error_sse(error) == (
+            'data: {"error": {"message": "boom"}}\n\n' "data: [DONE]\n\n"
+        )
 
     @pytest.mark.parametrize(
         "finish_reason",
@@ -1515,8 +2228,329 @@ class TestGgufVisionToolRouting:
         assert "".join(d.get("reasoning_content", "") for d in deltas) == "plan"
         assert "".join(d.get("content", "") for d in deltas) == "visible"
         assert all("<think>" not in d.get("content", "") for d in deltas)
+        assert all("content" in d for d in deltas if "reasoning_content" in d)
         [entry] = result.monitor.snapshot()
         assert entry["reply"] == "visible"
+
+    def test_global_enable_tools_does_not_preempt_response_format_passthrough(self, monkeypatch):
+        import routes.inference as inf_mod
+
+        reset_tool_policy()
+        set_tool_policy(True)
+        captured = {}
+
+        def _plain(**_kwargs):
+            raise AssertionError("plain GGUF path should not be used")
+
+        def _tools(**_kwargs):
+            raise AssertionError("Studio tool loop should not steal response_format")
+
+        backend = SimpleNamespace(
+            is_loaded = True,
+            is_vision = False,
+            supports_tools = True,
+            _is_audio = False,
+            model_identifier = "test-gguf",
+            context_length = 4096,
+            base_url = "http://llama.policy.test",
+            _request_reasoning_kwargs = lambda *_args, **_kwargs: None,
+            generate_chat_completion = _plain,
+            generate_chat_completion_with_tools = _tools,
+        )
+
+        async def fake_passthrough(llama_backend, payload, model_name, **_kwargs):
+            captured["body"] = inf_mod._build_openai_passthrough_body(
+                payload,
+                backend_ctx = llama_backend.context_length,
+                llama_backend = llama_backend,
+            )
+            return inf_mod.JSONResponse({"ok": True, "model": model_name})
+
+        try:
+            monkeypatch.setattr(inf_mod, "get_llama_cpp_backend", lambda: backend)
+            monkeypatch.setattr(
+                inf_mod,
+                "_openai_passthrough_non_streaming",
+                fake_passthrough,
+            )
+            monitor = ApiMonitor(max_entries = 3)
+            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+
+            payload = ChatCompletionRequest(
+                model = "default",
+                messages = [{"role": "user", "content": "json"}],
+                response_format = {"type": "json_object"},
+            )
+            response = self._drive(
+                openai_chat_completions(
+                    payload,
+                    request = self._Request(),
+                    current_subject = "test",
+                )
+            )
+
+            assert json.loads(response.body)["ok"] is True
+            assert captured["body"]["response_format"] == {"type": "json_object"}
+            assert "tools" not in captured["body"]
+            assert "tool_choice" not in captured["body"]
+        finally:
+            reset_tool_policy()
+
+    def test_global_enable_tools_does_not_replace_client_tools_passthrough(self, monkeypatch):
+        import routes.inference as inf_mod
+
+        reset_tool_policy()
+        set_tool_policy(True)
+        captured = {}
+        client_tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "client_lookup",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+
+        def _plain(**_kwargs):
+            raise AssertionError("plain GGUF path should not be used")
+
+        def _tools(**_kwargs):
+            raise AssertionError("Studio tool loop should not replace client tools")
+
+        backend = SimpleNamespace(
+            is_loaded = True,
+            is_vision = False,
+            supports_tools = True,
+            _is_audio = False,
+            model_identifier = "test-gguf",
+            context_length = 4096,
+            base_url = "http://llama.policy.test",
+            _request_reasoning_kwargs = lambda *_args, **_kwargs: None,
+            generate_chat_completion = _plain,
+            generate_chat_completion_with_tools = _tools,
+        )
+
+        async def fake_passthrough(llama_backend, payload, model_name, **_kwargs):
+            captured["body"] = inf_mod._build_openai_passthrough_body(
+                payload,
+                backend_ctx = llama_backend.context_length,
+                llama_backend = llama_backend,
+            )
+            return inf_mod.JSONResponse({"ok": True, "model": model_name})
+
+        try:
+            monkeypatch.setattr(inf_mod, "get_llama_cpp_backend", lambda: backend)
+            monkeypatch.setattr(
+                inf_mod,
+                "_openai_passthrough_non_streaming",
+                fake_passthrough,
+            )
+            monitor = ApiMonitor(max_entries = 3)
+            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+
+            payload = ChatCompletionRequest(
+                model = "default",
+                messages = [{"role": "user", "content": "use client tool"}],
+                tools = client_tools,
+            )
+            response = self._drive(
+                openai_chat_completions(
+                    payload,
+                    request = self._Request(),
+                    current_subject = "test",
+                )
+            )
+
+            assert json.loads(response.body)["ok"] is True
+            assert captured["body"]["tools"] == client_tools
+            assert captured["body"]["tool_choice"] == "auto"
+        finally:
+            reset_tool_policy()
+
+    def test_global_enable_tools_honors_client_tool_choice_none(self, monkeypatch):
+        import routes.inference as inf_mod
+
+        reset_tool_policy()
+        set_tool_policy(True)
+        client_tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "client_lookup",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+
+        def _plain(**kwargs):
+            assert kwargs["max_tokens"] == _OPENAI_COMPAT_IMPLICIT_MAX_TOKENS_DEFAULT
+            yield "plain response"
+
+        def _tools(**_kwargs):
+            raise AssertionError("tool_choice='none' must not start Studio's tool loop")
+
+        backend = SimpleNamespace(
+            is_loaded = True,
+            is_vision = False,
+            supports_tools = True,
+            _is_audio = False,
+            model_identifier = "test-gguf",
+            context_length = 4096,
+            base_url = "http://llama.policy.test",
+            _request_reasoning_kwargs = lambda *_args, **_kwargs: None,
+            generate_chat_completion = _plain,
+            generate_chat_completion_with_tools = _tools,
+        )
+
+        try:
+            monkeypatch.setattr(inf_mod, "get_llama_cpp_backend", lambda: backend)
+            monitor = ApiMonitor(max_entries = 3)
+            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+
+            payload = ChatCompletionRequest(
+                model = "default",
+                messages = [{"role": "user", "content": "do not use tools"}],
+                tools = client_tools,
+                tool_choice = "none",
+            )
+            response = self._drive(
+                openai_chat_completions(
+                    payload,
+                    request = self._Request(),
+                    current_subject = "test",
+                )
+            )
+
+            assert json.loads(response.body)["choices"][0]["message"]["content"] == "plain response"
+            [entry] = monitor.snapshot()
+            assert entry["status"] == "completed"
+            assert entry["reply"] == "plain response"
+            assert monitor.active_count() == 0
+        finally:
+            reset_tool_policy()
+
+    def test_enabled_tools_without_enable_tools_keeps_response_format_passthrough(
+        self, monkeypatch
+    ):
+        import routes.inference as inf_mod
+
+        reset_tool_policy()
+        captured = {}
+
+        def _plain(**_kwargs):
+            raise AssertionError("plain GGUF path should not be used")
+
+        def _tools(**_kwargs):
+            raise AssertionError("enabled_tools alone must not start Studio's tool loop")
+
+        backend = SimpleNamespace(
+            is_loaded = True,
+            is_vision = False,
+            supports_tools = True,
+            _is_audio = False,
+            model_identifier = "test-gguf",
+            context_length = 4096,
+            base_url = "http://llama.enabled-tools.test",
+            _request_reasoning_kwargs = lambda *_args, **_kwargs: None,
+            generate_chat_completion = _plain,
+            generate_chat_completion_with_tools = _tools,
+        )
+
+        async def fake_passthrough(llama_backend, payload, model_name, **_kwargs):
+            captured["body"] = inf_mod._build_openai_passthrough_body(
+                payload,
+                backend_ctx = llama_backend.context_length,
+                llama_backend = llama_backend,
+            )
+            return inf_mod.JSONResponse({"ok": True, "model": model_name})
+
+        monkeypatch.setattr(inf_mod, "get_llama_cpp_backend", lambda: backend)
+        monkeypatch.setattr(inf_mod, "_openai_passthrough_non_streaming", fake_passthrough)
+        monitor = ApiMonitor(max_entries = 3)
+        monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+
+        payload = ChatCompletionRequest(
+            model = "default",
+            messages = [{"role": "user", "content": "json"}],
+            enabled_tools = ["web_search"],
+            response_format = {"type": "json_object"},
+        )
+        response = self._drive(
+            openai_chat_completions(
+                payload,
+                request = self._Request(),
+                current_subject = "test",
+            )
+        )
+
+        assert json.loads(response.body)["ok"] is True
+        assert captured["body"]["response_format"] == {"type": "json_object"}
+
+    def test_enabled_tools_without_enable_tools_keeps_client_tools_passthrough(self, monkeypatch):
+        import routes.inference as inf_mod
+
+        reset_tool_policy()
+        captured = {}
+        client_tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "client_lookup",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+
+        def _plain(**_kwargs):
+            raise AssertionError("plain GGUF path should not be used")
+
+        def _tools(**_kwargs):
+            raise AssertionError("enabled_tools alone must not start Studio's tool loop")
+
+        backend = SimpleNamespace(
+            is_loaded = True,
+            is_vision = False,
+            supports_tools = True,
+            _is_audio = False,
+            model_identifier = "test-gguf",
+            context_length = 4096,
+            base_url = "http://llama.enabled-tools.test",
+            _request_reasoning_kwargs = lambda *_args, **_kwargs: None,
+            generate_chat_completion = _plain,
+            generate_chat_completion_with_tools = _tools,
+        )
+
+        async def fake_passthrough(llama_backend, payload, model_name, **_kwargs):
+            captured["body"] = inf_mod._build_openai_passthrough_body(
+                payload,
+                backend_ctx = llama_backend.context_length,
+                llama_backend = llama_backend,
+            )
+            return inf_mod.JSONResponse({"ok": True, "model": model_name})
+
+        monkeypatch.setattr(inf_mod, "get_llama_cpp_backend", lambda: backend)
+        monkeypatch.setattr(inf_mod, "_openai_passthrough_non_streaming", fake_passthrough)
+        monitor = ApiMonitor(max_entries = 3)
+        monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+
+        payload = ChatCompletionRequest(
+            model = "default",
+            messages = [{"role": "user", "content": "use client tool"}],
+            enabled_tools = ["web_search"],
+            tools = client_tools,
+        )
+        response = self._drive(
+            openai_chat_completions(
+                payload,
+                request = self._Request(),
+                current_subject = "test",
+            )
+        )
+
+        assert json.loads(response.body)["ok"] is True
+        assert captured["body"]["tools"] == client_tools
+        assert captured["body"]["tool_choice"] == "auto"
 
     def test_reasoning_capable_gguf_stream_splits_reasoning_by_default(self, monkeypatch):
         def _generate(**_kwargs):
@@ -1691,6 +2725,58 @@ class TestGgufVisionToolRouting:
         assert entry["completion_tokens"] == 3
         assert monitor.active_count() == 0
 
+    def test_non_streaming_gguf_cancel_drains_worker(self, monkeypatch):
+        async def _run():
+            import routes.inference as inf_mod
+
+            started = threading.Event()
+            released = threading.Event()
+
+            def _generate(**kwargs):
+                cancel_event = kwargs["cancel_event"]
+                started.set()
+                while not cancel_event.is_set():
+                    time.sleep(0.005)
+                released.set()
+                yield from ()
+
+            backend = SimpleNamespace(
+                is_loaded = True,
+                is_vision = False,
+                supports_tools = False,
+                _is_audio = False,
+                model_identifier = "test-gguf",
+                context_length = 4096,
+                generate_chat_completion = _generate,
+            )
+            monitor = ApiMonitor(max_entries = 3)
+            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+            monkeypatch.setattr(inf_mod, "get_llama_cpp_backend", lambda: backend)
+
+            payload = ChatCompletionRequest(
+                model = "default",
+                messages = [{"role": "user", "content": "hi"}],
+            )
+            task = asyncio.create_task(
+                openai_chat_completions(
+                    payload,
+                    request = self._Request(),
+                    current_subject = "test",
+                )
+            )
+            assert await asyncio.to_thread(started.wait, 1.0)
+
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(task, timeout = 1.0)
+
+            assert released.is_set()
+            [entry] = monitor.snapshot()
+            assert entry["status"] == "cancelled"
+            assert monitor.active_count() == 0
+
+        asyncio.run(_run())
+
     def test_standard_gguf_merges_system_and_developer_messages(self, monkeypatch):
         import routes.inference as inf_mod
 
@@ -1801,7 +2887,12 @@ class TestApiMonitorProviderAndCompletionStreams:
         async def is_disconnected(self):
             return False
 
-    async def _run_passthrough_stream(self, monkeypatch, lines):
+    async def _run_passthrough_stream(
+        self,
+        monkeypatch,
+        lines,
+        stream_options = None,
+    ):
         import routes.inference as inf_mod
 
         class Request:
@@ -1829,6 +2920,7 @@ class TestApiMonitorProviderAndCompletionStreams:
             model = "default",
             messages = [ChatMessage(role = "user", content = "hi")],
             stream = True,
+            stream_options = stream_options,
             tools = [
                 {
                     "type": "function",
@@ -1910,6 +3002,236 @@ class TestApiMonitorProviderAndCompletionStreams:
                 async for chunk in response.body_iterator
             ]
             assert "data: [DONE]\n\n" in "".join(chunks)
+
+        asyncio.run(_run())
+
+    def test_passthrough_stream_forwards_backend_auth_headers(self, monkeypatch):
+        async def _run():
+            import routes.inference as inf_mod
+
+            captured_headers = {}
+
+            async def fake_send(_client, req, *_args, **_kwargs):
+                captured_headers.update(dict(req.headers))
+                return httpx.Response(200, content = b"")
+
+            class Request:
+                async def is_disconnected(self):
+                    return False
+
+            monitor = ApiMonitor(max_entries = 3)
+            monitor_id = monitor.start(
+                endpoint = "/v1/chat/completions",
+                method = "POST",
+                model = "gguf",
+                prompt = "hi",
+            )
+            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+            monkeypatch.setattr(inf_mod, "_send_stream_with_preheader_cancel", fake_send)
+
+            payload = ChatCompletionRequest(
+                model = "default",
+                messages = [ChatMessage(role = "user", content = "hi")],
+                stream = True,
+                tools = [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            )
+            response = await _openai_passthrough_stream(
+                Request(),
+                threading.Event(),
+                SimpleNamespace(
+                    base_url = "http://llama.test",
+                    context_length = 4096,
+                    _auth_headers = {"Authorization": "Bearer secret"},
+                    _request_reasoning_kwargs = lambda *_args, **_kwargs: None,
+                ),
+                payload,
+                "chatcmpl-test",
+                "chatcmpl-test",
+                monitor_id = monitor_id,
+            )
+            chunks = [
+                chunk.decode() if isinstance(chunk, bytes) else chunk
+                async for chunk in response.body_iterator
+            ]
+
+            assert "data: [DONE]\n\n" in "".join(chunks)
+            assert captured_headers["authorization"] == "Bearer secret"
+            assert captured_headers["connection"] == "close"
+            assert captured_headers["x-conversation-id"].startswith("studio-chatcmpl-test-")
+
+        asyncio.run(_run())
+
+    def test_passthrough_stream_keepalive_while_upstream_headers_are_pending(self, monkeypatch):
+        async def _run():
+            import routes.inference as inf_mod
+
+            gate = asyncio.Event()
+
+            async def fake_send(*_args, **_kwargs):
+                await gate.wait()
+                return httpx.Response(200, content = b"")
+
+            class Request:
+                async def is_disconnected(self):
+                    return False
+
+            monitor = ApiMonitor(max_entries = 3)
+            monitor_id = monitor.start(
+                endpoint = "/v1/chat/completions",
+                method = "POST",
+                model = "gguf",
+                prompt = "hi",
+            )
+            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+            monkeypatch.setattr(inf_mod, "_send_stream_with_preheader_cancel", fake_send)
+            monkeypatch.setattr(
+                inf_mod,
+                "_OPENAI_PASSTHROUGH_PENDING_RESPONSE_KEEPALIVE_S",
+                0.01,
+            )
+
+            payload = ChatCompletionRequest(
+                model = "default",
+                messages = [ChatMessage(role = "user", content = "hi")],
+                stream = True,
+            )
+
+            response = await asyncio.wait_for(
+                _openai_passthrough_stream(
+                    Request(),
+                    threading.Event(),
+                    SimpleNamespace(
+                        base_url = "http://llama.test",
+                        context_length = 4096,
+                        _request_reasoning_kwargs = lambda *_args, **_kwargs: None,
+                    ),
+                    payload,
+                    "chatcmpl-test",
+                    "chatcmpl-test",
+                    monitor_id = monitor_id,
+                ),
+                timeout = 0.2,
+            )
+
+            first = await asyncio.wait_for(response.body_iterator.__anext__(), timeout = 0.2)
+            assert first == ": keep-alive\n\n"
+
+            gate.set()
+            chunks = [
+                chunk.decode() if isinstance(chunk, bytes) else chunk
+                async for chunk in response.body_iterator
+            ]
+            body = "".join(chunks)
+            assert "data: [DONE]\n\n" in body
+
+        asyncio.run(_run())
+
+    def test_passthrough_stream_uses_resumable_replay_when_headers_stall(self, monkeypatch):
+        async def _run():
+            import routes.inference as inf_mod
+
+            entered = asyncio.Event()
+            cancelled = asyncio.Event()
+            deleted = []
+            resumable_headers = {}
+
+            async def fake_send(*_args, **_kwargs):
+                entered.set()
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    cancelled.set()
+                    raise
+
+            async def fake_resumable(
+                _base_url,
+                stream_id,
+                headers = None,
+            ):
+                resumable_headers["open"] = headers
+                body = (
+                    'data: {"id":"chatcmpl-test","created":1,"model":"gguf",'
+                    '"choices":[{"index":0,"delta":{"content":"OK"},"finish_reason":null}]}\n\n'
+                    'data: {"id":"chatcmpl-test","created":1,"model":"gguf",'
+                    '"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n'
+                    'data: {"id":"chatcmpl-test","created":1,"model":"gguf",'
+                    '"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}\n\n'
+                    "data: [DONE]\n\n"
+                )
+                return None, httpx.Response(200, content = body.encode("utf-8"))
+
+            async def fake_delete(
+                _base_url,
+                stream_id,
+                headers = None,
+            ):
+                resumable_headers["delete"] = headers
+                deleted.append(stream_id)
+
+            class Request:
+                async def is_disconnected(self):
+                    return False
+
+            monitor = ApiMonitor(max_entries = 3)
+            monitor_id = monitor.start(
+                endpoint = "/v1/chat/completions",
+                method = "POST",
+                model = "gguf",
+                prompt = "hi",
+            )
+            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+            monkeypatch.setattr(inf_mod, "_send_stream_with_preheader_cancel", fake_send)
+            monkeypatch.setattr(inf_mod, "_openai_open_resumable_stream", fake_resumable)
+            monkeypatch.setattr(inf_mod, "_openai_delete_resumable_stream", fake_delete)
+            monkeypatch.setattr(inf_mod, "_OPENAI_PASSTHROUGH_RESUMABLE_LOOKUP_INTERVAL_S", 0.01)
+
+            payload = ChatCompletionRequest(
+                model = "default",
+                messages = [ChatMessage(role = "user", content = "hi")],
+                stream = True,
+            )
+
+            response = await asyncio.wait_for(
+                _openai_passthrough_stream(
+                    Request(),
+                    threading.Event(),
+                    SimpleNamespace(
+                        base_url = "http://llama.test",
+                        context_length = 4096,
+                        _auth_headers = {"Authorization": "Bearer secret"},
+                        _request_reasoning_kwargs = lambda *_args, **_kwargs: None,
+                    ),
+                    payload,
+                    "gguf",
+                    "chatcmpl-test",
+                    monitor_id = monitor_id,
+                ),
+                timeout = 0.2,
+            )
+            await asyncio.wait_for(entered.wait(), timeout = 0.2)
+            chunks = [
+                chunk.decode() if isinstance(chunk, bytes) else chunk
+                async for chunk in response.body_iterator
+            ]
+            body = "".join(chunks)
+
+            assert "OK" in body
+            assert body.endswith("data: [DONE]\n\n")
+            await asyncio.wait_for(cancelled.wait(), timeout = 0.2)
+            assert deleted
+            assert resumable_headers["open"]["Authorization"] == "Bearer secret"
+            assert resumable_headers["delete"]["Authorization"] == "Bearer secret"
+            [entry] = monitor.snapshot()
+            assert entry["status"] == "completed"
+            assert entry["reply"] == "OK"
 
         asyncio.run(_run())
 
@@ -2055,6 +3377,7 @@ class TestApiMonitorProviderAndCompletionStreams:
             body = "".join(chunks)
             assert "data:" in body
             assert '"error"' in body
+            assert "data: [DONE]" in body
             [entry] = monitor.snapshot()
             assert entry["status"] == "error"
             assert "bad" in entry["error"]
@@ -2117,7 +3440,13 @@ class TestApiMonitorProviderAndCompletionStreams:
                 async for chunk in response.body_iterator
             ]
             body = "".join(chunks)
-            payload = json.loads(body.removeprefix("data: ").strip())
+            events = [
+                line.removeprefix("data: ")
+                for line in body.splitlines()
+                if line.startswith("data: ")
+            ]
+            assert events[-1] == "[DONE]"
+            payload = json.loads(events[0])
             assert payload["error"]["code"] == "context_length_exceeded"
             assert payload["error"]["param"] == "messages"
             assert isinstance(payload["error"], dict)
@@ -2200,6 +3529,105 @@ class TestApiMonitorProviderAndCompletionStreams:
                 async for chunk in response.body_iterator
             ]
             assert "data: [DONE]\n\n" in "".join(chunks)
+            assert len(calls) == 2
+            assert len(calls[1]["messages"]) < len(calls[0]["messages"])
+            [entry] = monitor.snapshot()
+            assert entry["status"] == "completed"
+
+        asyncio.run(_run())
+
+    def test_passthrough_stream_preheader_immediate_context_retry_adopts_delayed_response(
+        self, monkeypatch
+    ):
+        async def _run():
+            import routes.inference as inf_mod
+
+            gate = asyncio.Event()
+            calls = []
+            err_body = json.dumps(
+                {
+                    "error": {
+                        "message": "request (10000 tokens) exceeds the available context size (2048 tokens)",
+                        "n_prompt_tokens": 10000,
+                        "n_ctx": 2048,
+                    }
+                }
+            ).encode("utf-8")
+            ok_lines = [
+                'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,'
+                '"model":"gguf","choices":[{"index":0,"delta":{"content":"OK"},'
+                '"finish_reason":null}]}',
+                'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,'
+                '"model":"gguf","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+                "data: [DONE]",
+            ]
+
+            async def fake_send(_client, req, *_args, **_kwargs):
+                calls.append(json.loads(req.content.decode("utf-8")))
+                if len(calls) == 1:
+                    return httpx.Response(400, content = err_body)
+                await gate.wait()
+                return httpx.Response(200, content = b"")
+
+            async def fake_items(*_args, **_kwargs):
+                for line in ok_lines:
+                    yield line
+
+            class Request:
+                async def is_disconnected(self):
+                    return False
+
+            monitor = ApiMonitor(max_entries = 3)
+            monitor_id = monitor.start(
+                endpoint = "/v1/chat/completions",
+                method = "POST",
+                model = "gguf",
+                prompt = "hi",
+            )
+            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+            monkeypatch.setattr(inf_mod, "_send_stream_with_preheader_cancel", fake_send)
+            monkeypatch.setattr(inf_mod, "_aiter_llama_stream_items", fake_items)
+
+            messages = [
+                ChatMessage(role = "system", content = "system"),
+                *[
+                    ChatMessage(role = "user", content = f"turn {idx} " + ("x" * 1000))
+                    for idx in range(8)
+                ],
+            ]
+            payload = ChatCompletionRequest(
+                model = "default",
+                messages = messages,
+                stream = True,
+                context_overflow = "truncate_middle",
+            )
+            response = await asyncio.wait_for(
+                _openai_passthrough_stream(
+                    Request(),
+                    threading.Event(),
+                    SimpleNamespace(
+                        base_url = "http://llama.test",
+                        context_length = 2048,
+                        _request_reasoning_kwargs = lambda *_args, **_kwargs: None,
+                    ),
+                    payload,
+                    "chatcmpl-test",
+                    "chatcmpl-test",
+                    monitor_id = monitor_id,
+                ),
+                timeout = 0.2,
+            )
+            assert isinstance(response, _SameTaskStreamingResponse)
+
+            gate.set()
+            chunks = [
+                chunk.decode() if isinstance(chunk, bytes) else chunk
+                async for chunk in response.body_iterator
+            ]
+            body = "".join(chunks)
+
+            assert "OK" in body
+            assert "context_length_exceeded" not in body
             assert len(calls) == 2
             assert len(calls[1]["messages"]) < len(calls[0]["messages"])
             [entry] = monitor.snapshot()
@@ -2331,6 +3759,84 @@ class TestApiMonitorProviderAndCompletionStreams:
                 await task
             await asyncio.wait_for(cancelled.wait(), timeout = 5.0)
             assert cancel_id not in inf_mod._CANCEL_REGISTRY
+
+        asyncio.run(_run())
+
+    def test_passthrough_stream_preheader_fallback_preserves_http_exception_detail(
+        self, monkeypatch
+    ):
+        async def _run():
+            import routes.inference as inf_mod
+
+            monkeypatch.setenv(_OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT_ENV, "0.01")
+            entered = asyncio.Event()
+
+            async def fake_send(*_args, **_kwargs):
+                entered.set()
+                await asyncio.Event().wait()
+
+            async def fake_non_streaming_upstream(*_args, **_kwargs):
+                raise HTTPException(
+                    status_code = 400,
+                    detail = {
+                        "error": {
+                            "message": "bad schema",
+                            "type": "invalid_request_error",
+                            "code": "invalid_request_error",
+                        }
+                    },
+                )
+
+            class Request:
+                async def is_disconnected(self):
+                    return False
+
+            monitor = ApiMonitor(max_entries = 3)
+            monitor_id = monitor.start(
+                endpoint = "/v1/chat/completions",
+                method = "POST",
+                model = "gguf",
+                prompt = "hi",
+            )
+            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+            monkeypatch.setattr(inf_mod, "_send_stream_with_preheader_cancel", fake_send)
+            monkeypatch.setattr(
+                inf_mod,
+                "_openai_passthrough_non_streaming",
+                fake_non_streaming_upstream,
+            )
+
+            payload = ChatCompletionRequest(
+                model = "default",
+                messages = [ChatMessage(role = "user", content = "hi")],
+                stream = True,
+            )
+            response = await _openai_passthrough_stream(
+                Request(),
+                threading.Event(),
+                SimpleNamespace(
+                    base_url = "http://llama.test",
+                    context_length = 4096,
+                    _request_reasoning_kwargs = lambda *_args, **_kwargs: None,
+                ),
+                payload,
+                "gguf",
+                "chatcmpl-test",
+                monitor_id = monitor_id,
+            )
+            await asyncio.wait_for(entered.wait(), timeout = 0.2)
+            chunks = [
+                chunk.decode() if isinstance(chunk, bytes) else chunk
+                async for chunk in response.body_iterator
+            ]
+            body = "".join(chunks)
+
+            assert "bad schema" in body
+            assert "invalid_request_error" in body
+            assert "internal_error" not in body
+            assert body.endswith("data: [DONE]\n\n")
+            [entry] = monitor.snapshot()
+            assert entry["status"] == "error"
 
         asyncio.run(_run())
 
@@ -2647,6 +4153,110 @@ class TestApiMonitorProviderAndCompletionStreams:
 
         asyncio.run(_run())
 
+    def test_completions_applies_configured_max_tokens_ceiling(self, monkeypatch):
+        async def _run():
+            import routes.inference as inf_mod
+
+            class Request:
+                state = SimpleNamespace()
+                url = SimpleNamespace(path = "/v1/completions")
+                method = "POST"
+
+                def __init__(self, body):
+                    self._body = body
+
+                async def json(self):
+                    return dict(self._body)
+
+            captured = []
+
+            class CapturingClient:
+                async def post(self, _url, *, json, **_kwargs):
+                    captured.append(dict(json))
+                    return httpx.Response(
+                        200,
+                        json = {
+                            "id": "cmpl-test",
+                            "choices": [{"text": "ok"}],
+                            "usage": {
+                                "prompt_tokens": 1,
+                                "completion_tokens": 1,
+                                "total_tokens": 2,
+                            },
+                        },
+                    )
+
+            monitor = ApiMonitor(max_entries = 5)
+            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+            monkeypatch.setenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, "256")
+            monkeypatch.setattr(inf_mod, "nonstreaming_client", lambda: CapturingClient())
+            monkeypatch.setattr(
+                inf_mod,
+                "get_llama_cpp_backend",
+                lambda: SimpleNamespace(
+                    is_loaded = True,
+                    base_url = "http://llama.test",
+                    context_length = 4096,
+                    model_identifier = "gguf",
+                ),
+            )
+
+            await openai_completions(
+                Request({"prompt": "hi", "stream": False}),
+                current_subject = "test",
+            )
+            await openai_completions(
+                Request({"prompt": "hi", "stream": False, "max_tokens": 9999}),
+                current_subject = "test",
+            )
+
+            assert captured[0]["max_tokens"] == 256
+            assert captured[1]["max_tokens"] == 256
+            assert monitor.active_count() == 0
+
+        asyncio.run(_run())
+
+    def test_completions_rejects_non_integer_max_tokens_before_ceiling(self, monkeypatch):
+        async def _run():
+            import routes.inference as inf_mod
+
+            class Request:
+                state = SimpleNamespace()
+                url = SimpleNamespace(path = "/v1/completions")
+                method = "POST"
+
+                async def json(self):
+                    return {"prompt": "hi", "stream": False, "max_tokens": "128"}
+
+            class UnusedClient:
+                async def post(self, *_args, **_kwargs):
+                    raise AssertionError("invalid max_tokens must not reach llama-server")
+
+            monitor = ApiMonitor(max_entries = 3)
+            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+            monkeypatch.setenv(_OPENAI_COMPAT_MAX_TOKENS_CEILING_ENV, "256")
+            monkeypatch.setattr(inf_mod, "nonstreaming_client", lambda: UnusedClient())
+            monkeypatch.setattr(
+                inf_mod,
+                "get_llama_cpp_backend",
+                lambda: SimpleNamespace(
+                    is_loaded = True,
+                    base_url = "http://llama.test",
+                    context_length = 4096,
+                    model_identifier = "gguf",
+                ),
+            )
+
+            with pytest.raises(HTTPException) as exc:
+                await openai_completions(Request(), current_subject = "test")
+
+            assert exc.value.status_code == 400
+            assert exc.value.detail["error"]["param"] == "max_tokens"
+            assert exc.value.detail["error"]["code"] == "invalid_type"
+            assert monitor.active_count() == 0
+
+        asyncio.run(_run())
+
     def test_monitor_openai_chunk_records_all_choice_replies(self, monkeypatch):
         import routes.inference as inf_mod
 
@@ -2793,10 +4403,22 @@ class TestApiMonitorProviderAndCompletionStreams:
                 yield 'data: {"choices":[{"delta":{"content":"hello"}}]}'
                 await asyncio.sleep(3600)
 
+            deleted = []
+            cancel_id = "passthrough-stream-delete-cancel"
+
+            async def fake_delete(
+                _base_url,
+                stream_id,
+                headers = None,
+            ):
+                deleted.append((stream_id, headers))
+                raise asyncio.CancelledError()
+
             monitor = ApiMonitor(max_entries = 3)
             monkeypatch.setattr(inf_mod, "api_monitor", monitor)
             monkeypatch.setattr(inf_mod, "_send_stream_with_preheader_cancel", fake_send)
             monkeypatch.setattr(inf_mod, "_aiter_llama_stream_items", fake_items)
+            monkeypatch.setattr(inf_mod, "_openai_delete_resumable_stream", fake_delete)
             monitor_id = monitor.start(
                 endpoint = "/v1/chat/completions",
                 method = "POST",
@@ -2807,6 +4429,7 @@ class TestApiMonitorProviderAndCompletionStreams:
                 model = "default",
                 messages = [ChatMessage(role = "user", content = "hi")],
                 stream = True,
+                cancel_id = cancel_id,
                 tools = [
                     {
                         "type": "function",
@@ -2824,6 +4447,7 @@ class TestApiMonitorProviderAndCompletionStreams:
                 SimpleNamespace(
                     base_url = "http://llama.test",
                     context_length = 4096,
+                    _auth_headers = {"Authorization": "Bearer secret"},
                     _request_reasoning_kwargs = lambda *_args, **_kwargs: None,
                 ),
                 payload,
@@ -2835,6 +4459,7 @@ class TestApiMonitorProviderAndCompletionStreams:
             iterator = response.body_iterator
             first = await anext(iterator)
             assert "hello" in first
+            assert cancel_id in inf_mod._CANCEL_REGISTRY
 
             pending = asyncio.create_task(anext(iterator))
             await asyncio.sleep(0)
@@ -2846,6 +4471,10 @@ class TestApiMonitorProviderAndCompletionStreams:
             assert entry["status"] == "cancelled"
             assert entry["reply"] == "hello"
             assert monitor.active_count() == 0
+            assert deleted
+            assert deleted[0][0].startswith("studio-chatcmpl-test-")
+            assert deleted[0][1]["Authorization"] == "Bearer secret"
+            assert cancel_id not in inf_mod._CANCEL_REGISTRY
 
         asyncio.run(_run())
 
@@ -2931,6 +4560,27 @@ class TestApiMonitorProviderAndCompletionStreams:
 
         asyncio.run(_run())
 
+    def test_passthrough_usage_done_are_separate_sse_events(self, monkeypatch):
+        async def _run():
+            result = await self._run_passthrough_stream(
+                monkeypatch,
+                [
+                    'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
+                    'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+                    'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"m","choices":[],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}',
+                ],
+                stream_options = {"include_usage": True},
+            )
+
+            assert (
+                '"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2' in result.body
+            )
+            assert "data: [DONE]" in result.body
+            assert "}\n\ndata: [DONE]\n\n" in result.body
+            assert "}\ndata: [DONE]\n\n" not in result.body
+
+        asyncio.run(_run())
+
     def test_passthrough_non_streaming_cancel_finalizes_monitor(self, monkeypatch):
         async def _run():
             import routes.inference as inf_mod
@@ -2990,6 +4640,407 @@ class TestApiMonitorProviderAndCompletionStreams:
 
         asyncio.run(_run())
 
+    def test_passthrough_non_streaming_cancel_closes_blocked_upstream_post(self, monkeypatch):
+        async def _run():
+            import routes.inference as inf_mod
+
+            class HangingCancelableClient:
+                def __init__(self):
+                    self.started = asyncio.Event()
+                    self.closed = asyncio.Event()
+
+                async def post(self, *_args, **_kwargs):
+                    self.started.set()
+                    await self.closed.wait()
+                    raise httpx.ReadError("client closed")
+
+                async def aclose(self):
+                    self.closed.set()
+
+            class Request:
+                async def is_disconnected(self):
+                    return False
+
+            client = HangingCancelableClient()
+            monitor = ApiMonitor(max_entries = 3)
+            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+            monkeypatch.setattr(
+                inf_mod,
+                "_cancelable_nonstreaming_client",
+                lambda: client,
+            )
+            monitor_id = monitor.start(
+                endpoint = "/v1/chat/completions",
+                method = "POST",
+                model = "gguf",
+                prompt = "hi",
+            )
+            cancel_event = threading.Event()
+            payload = ChatCompletionRequest(
+                model = "default",
+                messages = [ChatMessage(role = "user", content = "hi")],
+                tools = [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            )
+
+            task = asyncio.create_task(
+                _openai_passthrough_non_streaming(
+                    SimpleNamespace(
+                        base_url = "http://llama.test",
+                        context_length = 4096,
+                        _request_reasoning_kwargs = lambda *_args, **_kwargs: None,
+                    ),
+                    payload,
+                    "gguf",
+                    monitor_id = monitor_id,
+                    request = Request(),
+                    cancel_event = cancel_event,
+                )
+            )
+            await asyncio.wait_for(client.started.wait(), 0.2)
+            cancel_event.set()
+
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(task, 0.5)
+
+            assert client.closed.is_set()
+            [entry] = monitor.snapshot()
+            assert entry["status"] == "cancelled"
+            assert monitor.active_count() == 0
+
+        asyncio.run(_run())
+
+    def test_passthrough_non_streaming_route_registers_cancel_id(self, monkeypatch):
+        async def _run():
+            import routes.inference as inf_mod
+
+            class HangingCancelableClient:
+                def __init__(self):
+                    self.started = asyncio.Event()
+                    self.closed = asyncio.Event()
+
+                async def post(self, *_args, **_kwargs):
+                    self.started.set()
+                    await self.closed.wait()
+                    raise httpx.ReadError("client closed")
+
+                async def aclose(self):
+                    self.closed.set()
+
+            class Request:
+                state = SimpleNamespace()
+                url = SimpleNamespace(path = "/v1/chat/completions")
+                method = "POST"
+
+                async def is_disconnected(self):
+                    return False
+
+            cancel_id = "passthrough-nonstream-cancel-id"
+            client = HangingCancelableClient()
+            monitor = ApiMonitor(max_entries = 3)
+            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+            monkeypatch.setattr(inf_mod, "_cancelable_nonstreaming_client", lambda: client)
+
+            def _plain(**_kwargs):
+                raise AssertionError("plain GGUF path should not be used")
+
+            monkeypatch.setattr(
+                inf_mod,
+                "get_llama_cpp_backend",
+                lambda: SimpleNamespace(
+                    is_loaded = True,
+                    is_vision = False,
+                    supports_tools = True,
+                    _is_audio = False,
+                    model_identifier = "test-gguf",
+                    context_length = 4096,
+                    base_url = "http://llama.test",
+                    _request_reasoning_kwargs = lambda *_args, **_kwargs: None,
+                    generate_chat_completion = _plain,
+                ),
+            )
+
+            payload = ChatCompletionRequest(
+                model = "default",
+                messages = [ChatMessage(role = "user", content = "hi")],
+                cancel_id = cancel_id,
+                tools = [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            )
+
+            task = asyncio.create_task(
+                openai_chat_completions(
+                    payload,
+                    request = Request(),
+                    current_subject = "test",
+                )
+            )
+            await asyncio.wait_for(client.started.wait(), 0.2)
+            assert cancel_id in inf_mod._CANCEL_REGISTRY
+            assert inf_mod._cancel_by_cancel_id_or_stash(cancel_id) == 1
+
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(task, 0.5)
+
+            assert client.closed.is_set()
+            assert cancel_id not in inf_mod._CANCEL_REGISTRY
+            [entry] = monitor.snapshot()
+            assert entry["status"] == "cancelled"
+            assert monitor.active_count() == 0
+
+        asyncio.run(_run())
+
+    def test_passthrough_non_streaming_disconnect_closes_blocked_upstream_post(self, monkeypatch):
+        async def _run():
+            import routes.inference as inf_mod
+
+            class HangingCancelableClient:
+                def __init__(self):
+                    self.started = asyncio.Event()
+                    self.closed = asyncio.Event()
+
+                async def post(self, *_args, **_kwargs):
+                    self.started.set()
+                    await self.closed.wait()
+                    raise httpx.ReadError("client closed")
+
+                async def aclose(self):
+                    self.closed.set()
+
+            class Request:
+                def __init__(self):
+                    self.disconnected = False
+
+                async def is_disconnected(self):
+                    return self.disconnected
+
+            client = HangingCancelableClient()
+            request = Request()
+            monitor = ApiMonitor(max_entries = 3)
+            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+            monkeypatch.setattr(
+                inf_mod,
+                "_cancelable_nonstreaming_client",
+                lambda: client,
+            )
+            monitor_id = monitor.start(
+                endpoint = "/v1/chat/completions",
+                method = "POST",
+                model = "gguf",
+                prompt = "hi",
+            )
+            cancel_event = threading.Event()
+            payload = ChatCompletionRequest(
+                model = "default",
+                messages = [ChatMessage(role = "user", content = "hi")],
+                tools = [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            )
+
+            task = asyncio.create_task(
+                _openai_passthrough_non_streaming(
+                    SimpleNamespace(
+                        base_url = "http://llama.test",
+                        context_length = 4096,
+                        _request_reasoning_kwargs = lambda *_args, **_kwargs: None,
+                    ),
+                    payload,
+                    "gguf",
+                    monitor_id = monitor_id,
+                    request = request,
+                    cancel_event = cancel_event,
+                )
+            )
+            await asyncio.wait_for(client.started.wait(), 0.2)
+            request.disconnected = True
+
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(task, 0.5)
+
+            assert client.closed.is_set()
+            assert cancel_event.is_set()
+            [entry] = monitor.snapshot()
+            assert entry["status"] == "cancelled"
+            assert monitor.active_count() == 0
+
+        asyncio.run(_run())
+
+    def test_passthrough_non_streaming_forwards_backend_auth_headers(self, monkeypatch):
+        async def _run():
+            import routes.inference as inf_mod
+
+            captured = {}
+
+            class FakeNonStreamingClient:
+                async def post(self, *_args, **kwargs):
+                    captured["headers"] = kwargs.get("headers")
+                    return httpx.Response(
+                        200,
+                        json = {
+                            "id": "chatcmpl-test",
+                            "object": "chat.completion",
+                            "created": 123,
+                            "model": "gguf",
+                            "choices": [
+                                {
+                                    "index": 0,
+                                    "message": {"role": "assistant", "content": "OK"},
+                                    "finish_reason": "stop",
+                                }
+                            ],
+                        },
+                    )
+
+            monitor = ApiMonitor(max_entries = 3)
+            monitor_id = monitor.start(
+                endpoint = "/v1/chat/completions",
+                method = "POST",
+                model = "gguf",
+                prompt = "hi",
+            )
+            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+            monkeypatch.setattr(
+                inf_mod,
+                "nonstreaming_client",
+                lambda: FakeNonStreamingClient(),
+            )
+            payload = ChatCompletionRequest(
+                model = "default",
+                messages = [ChatMessage(role = "user", content = "hi")],
+                tools = [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            )
+
+            response = await _openai_passthrough_non_streaming(
+                SimpleNamespace(
+                    base_url = "http://llama.test",
+                    context_length = 4096,
+                    _auth_headers = {"Authorization": "Bearer secret"},
+                    _request_reasoning_kwargs = lambda *_args, **_kwargs: None,
+                ),
+                payload,
+                "gguf",
+                monitor_id = monitor_id,
+            )
+
+            assert json.loads(response.body)["choices"][0]["message"]["content"] == "OK"
+            assert captured["headers"]["Authorization"] == "Bearer secret"
+            assert captured["headers"]["Connection"] == "close"
+
+        asyncio.run(_run())
+
+    def test_passthrough_non_streaming_forces_upstream_stream_false(self, monkeypatch):
+        async def _run():
+            import routes.inference as inf_mod
+
+            captured = {}
+
+            class FakeNonStreamingClient:
+                async def __aenter__(self):
+                    return self
+
+                async def __aexit__(self, *_args):
+                    return False
+
+                async def post(self, *_args, **kwargs):
+                    captured["json"] = kwargs.get("json")
+                    return httpx.Response(
+                        200,
+                        json = {
+                            "id": "chatcmpl-test",
+                            "object": "chat.completion",
+                            "created": 123,
+                            "model": "gguf",
+                            "choices": [
+                                {
+                                    "index": 0,
+                                    "message": {"role": "assistant", "content": "OK"},
+                                    "finish_reason": "stop",
+                                }
+                            ],
+                            "usage": {
+                                "prompt_tokens": 1,
+                                "completion_tokens": 1,
+                                "total_tokens": 2,
+                            },
+                        },
+                    )
+
+            monitor = ApiMonitor(max_entries = 3)
+            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+            monkeypatch.setattr(
+                inf_mod,
+                "nonstreaming_client",
+                lambda: FakeNonStreamingClient(),
+            )
+            monitor_id = monitor.start(
+                endpoint = "/v1/chat/completions",
+                method = "POST",
+                model = "gguf",
+                prompt = "hi",
+            )
+            payload = ChatCompletionRequest(
+                model = "default",
+                messages = [ChatMessage(role = "user", content = "hi")],
+                stream = True,
+                stream_options = {"include_usage": True},
+                tools = [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            )
+
+            await _openai_passthrough_non_streaming(
+                SimpleNamespace(
+                    base_url = "http://llama.test",
+                    context_length = 4096,
+                    _request_reasoning_kwargs = lambda *_args, **_kwargs: None,
+                ),
+                payload,
+                "gguf",
+                monitor_id = monitor_id,
+            )
+
+            assert captured["json"]["stream"] is False
+            assert "stream_options" not in captured["json"]
+            [entry] = monitor.snapshot()
+            assert entry["status"] == "completed"
+
+        asyncio.run(_run())
+
     def test_passthrough_clean_eof_finalizes_monitor(self, monkeypatch):
         async def _run():
             result = await self._run_passthrough_stream(
@@ -3006,6 +5057,75 @@ class TestApiMonitorProviderAndCompletionStreams:
             assert entry["status"] == "completed"
             assert entry["reply"] == "hello"
             assert result.monitor.active_count() == 0
+
+        asyncio.run(_run())
+
+    def test_passthrough_stream_stall_after_data_emits_error(self, monkeypatch):
+        async def _run():
+            import routes.inference as inf_mod
+
+            class Request:
+                async def is_disconnected(self):
+                    return False
+
+            async def fake_send(*_args, **_kwargs):
+                return httpx.Response(200, content = b"")
+
+            async def fake_items(*_args, **_kwargs):
+                yield 'data: {"choices":[{"delta":{"content":"hello"}}]}'
+                raise httpx.ReadTimeout("upstream went silent")
+
+            monitor = ApiMonitor(max_entries = 3)
+            monkeypatch.setattr(inf_mod, "api_monitor", monitor)
+            monkeypatch.setattr(inf_mod, "_send_stream_with_preheader_cancel", fake_send)
+            monkeypatch.setattr(inf_mod, "_aiter_llama_stream_items", fake_items)
+            monitor_id = monitor.start(
+                endpoint = "/v1/chat/completions",
+                method = "POST",
+                model = "gguf",
+                prompt = "hi",
+            )
+            payload = ChatCompletionRequest(
+                model = "default",
+                messages = [ChatMessage(role = "user", content = "hi")],
+                stream = True,
+                tools = [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            )
+
+            response = await _openai_passthrough_stream(
+                Request(),
+                threading.Event(),
+                SimpleNamespace(
+                    base_url = "http://llama.test",
+                    context_length = 4096,
+                    _request_reasoning_kwargs = lambda *_args, **_kwargs: None,
+                ),
+                payload,
+                "gguf",
+                "chatcmpl-test",
+                monitor_id = monitor_id,
+            )
+            chunks = [chunk async for chunk in response.body_iterator]
+            body = "".join(chunks)
+
+            assert 'data: {"choices":[{"delta":{"content":"hello"}}]}\n\n' in body
+            assert '"finish_reason"' not in body.replace(" ", "")
+            assert '"type":"api_error"' in body.replace(" ", "")
+            assert "still processing the prompt" in body
+            assert body.endswith("data: [DONE]\n\n")
+            [entry] = monitor.snapshot()
+            assert entry["status"] == "error"
+            assert "still processing the prompt" in entry["error"]
+            assert entry["reply"] == "hello"
+            assert monitor.active_count() == 0
 
         asyncio.run(_run())
 

--- a/studio/backend/tests/test_passthrough_healing.py
+++ b/studio/backend/tests/test_passthrough_healing.py
@@ -515,6 +515,7 @@ class ScriptedClient:
         _url,
         json = None,
         timeout = None,
+        headers = None,
     ):
         self.posts.append(json)
         return httpx.Response(200, json = self.bodies[min(len(self.posts) - 1, len(self.bodies) - 1)])


### PR DESCRIPTION
## Summary

This PR tightens Studio's OpenAI-compatible local GGUF chat serving path so streamed responses are easier for strict OpenAI-compatible clients to consume.

Main changes:

- preserve `reasoning_content` while also adding `content: ""` to reasoning-only stream deltas;
- normalize OpenAI passthrough SSE forwarding around `data:` payloads and `[DONE]`;
- close in-band stream errors with a separate `data: [DONE]` sentinel;
- convert terminal non-streaming fallback responses into OpenAI-style SSE chunks when needed;
- add a local implicit output-token cap only when clients omit both `max_tokens` and `max_completion_tokens`;
- preserve explicit client token limits unless the operator opts into a service-level ceiling.

## Motivation

Some OpenAI-compatible clients are strict about streamed chat delta shape and terminal SSE markers. Studio could forward chunks that were valid for llama.cpp but awkward for those clients, especially reasoning-only deltas and error/final chunks.

Local serving also needs a practical default when a client omits token limits. Without one, small auxiliary requests can unexpectedly become long generations. This PR keeps explicit client values intact and only applies a local default when no OpenAI token-limit field is present.

This does not disable reasoning and does not change model quality settings.

## Configuration

- `UNSLOTH_OPENAI_COMPAT_IMPLICIT_MAX_TOKENS`
  - default: `1024`
  - used only when the request omitted both `max_tokens` and `max_completion_tokens`.
- `UNSLOTH_OPENAI_COMPAT_MAX_TOKENS_CEILING`
  - disabled by default
  - optional service-level ceiling that can cap explicit client values.
- `UNSLOTH_OPENAI_COMPAT_STREAM_STALL_TIMEOUT`
  - default: `30`
  - caps post-first-chunk upstream silence.
- `UNSLOTH_OPENAI_COMPAT_STREAM_PREHEADER_FALLBACK_TIMEOUT`
  - disabled by default
  - positive values opt into non-streaming fallback for pre-header stalls.

These are backend-only environment hooks. They can be surfaced in Studio settings later without changing the API behavior added here.

## Validation

Automated:

```text
python -m py_compile studio/backend/routes/inference.py studio/backend/core/inference/llama_cpp.py studio/backend/tests/test_openai_tool_passthrough.py studio/backend/tests/test_llama_cpp_stream_cancel.py
python -m pytest studio/backend/tests/test_openai_tool_passthrough.py -q --tb=short
python -m pytest studio/backend/tests/test_llama_cpp_stream_cancel.py -q --tb=short
git diff --check
```

Targeted local result:

```text
224 passed, 1 warning
2 passed
```

Source-clone LAN API checks:

- server launched from `studio/backend/run.py`;
- URL: `http://192.168.20.80:8899`;
- command shape: `--host 0.0.0.0 --port 8899 --parallel 1 --api-only --no-cloudflare --disable-tools --silent`;
- model: `unsloth/Qwen3.6-27B-MTP-GGUF`;
- variant: `UD-Q4_K_XL`;
- loaded context: `129536`;
- standard non-stream small request: HTTP 200;
- standard stream small request: HTTP 200, one `[DONE]`, no malformed JSON chunks;
- tools passthrough stream: HTTP 200, one `[DONE]`, no malformed JSON chunks;
- reasoning remains enabled and `reasoning_content` is preserved.

Real external-client checks:

- OpenCode CLI `1.17.14` with an `@ai-sdk/openai-compatible` provider:
  - simple run: `RC=0`, expected marker received;
  - three consecutive continued turns: `RC=0`;
  - large attached-file prompt: `RC=0`, expected marker received;
  - short log excerpt:

    ```text
    RC=0
    JSON parsing failed: absent
    terminated: absent
    malformed SSE/JSON chunks: absent
    ```

- Codex CLI `0.142.5` with `wire_api = "responses"` and a local model catalog entry:
  - simple run: `RC=0`, expected marker received;
  - file/tool run: `RC=0`, expected marker received;
  - large prompt: `RC=0`, expected marker received;
  - short log excerpt:

    ```text
    RC=0
    JSON parsing failed: absent
    Unexpected non-whitespace: absent
    TypeValidationError: absent
    NoSuchModel: absent
    timeout: absent
    ```

## Compatibility Notes

- Explicit client `max_tokens` / `max_completion_tokens` values are preserved unless the optional local ceiling is configured.
- Queued/admission behavior is intentionally not part of this PR.
- No frontend settings are added in this PR.