### PR TITLE
Fix stale transformers sidecar imports

### DIFF
--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import pytest
+import importlib
 from pathlib import Path
 from unittest.mock import patch
 
@@ -1588,6 +1589,50 @@ class TestActivateLoggingClarity:
         assert (
             "sys.path" in text or "path only" in text
         ), f"early activation log does not clarify it is path-prepend only: {text!r}"
+
+    def test_activate_530_purges_stale_transformers_before_sidecar_import(self, tmp_path):
+        sidecar = tmp_path / "t5_530"
+        package = sidecar / "transformers"
+        package.mkdir(parents = True)
+        (package / "__init__.py").write_text('__version__ = "5.3.0"\n')
+
+        stale = _types.ModuleType("transformers")
+        stale.__version__ = "4.57.6"
+        snap = self._snapshot_env()
+        saved_modules = {
+            name: sys.modules.get(name)
+            for name in ("transformers", "transformers.models", "huggingface_hub")
+        }
+        sys.modules["transformers"] = stale
+        sys.modules["transformers.models"] = _types.ModuleType("transformers.models")
+        try:
+            with (
+                patch(
+                    "utils.transformers_version._resolve_base_model",
+                    side_effect = lambda m: m,
+                ),
+                patch(
+                    "utils.transformers_version.get_transformers_tier",
+                    return_value = "530",
+                ),
+                patch(
+                    "utils.transformers_version._ensure_venv_t5_530_exists",
+                    return_value = True,
+                ),
+                patch("utils.transformers_version._VENV_T5_530_DIR", str(sidecar)),
+            ):
+                activate_transformers_for_subprocess("Qwen/Qwen3.5-9B")
+                imported = importlib.import_module("transformers")
+        finally:
+            self._restore_env(snap)
+            for name, module in saved_modules.items():
+                if module is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = module
+
+        assert imported.__version__ == "5.3.0"
+        assert imported is not stale
 
     def test_activate_prefers_local_checkpoint_tier_over_resolved_base(self, caplog, tmp_path):
         # Base resolves to an offline/private id (default tier); the local config.json wins.

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -61,6 +61,9 @@ from utils.transformers_version import (
     activate_transformers_for_subprocess,
     _venv_dir_is_valid,
     _ensure_venv_dir,
+    _VENV_T5_530_PACKAGES,
+    _VENV_T5_550_PACKAGES,
+    _VENV_T5_510_PACKAGES,
     hf_endpoint_unreachable,
 )
 
@@ -1633,6 +1636,11 @@ class TestActivateLoggingClarity:
 
         assert imported.__version__ == "5.3.0"
         assert imported is not stale
+
+    def test_5x_sidecars_include_soxr_for_transformers_audio_imports(self):
+        # transformers 5.x imports audio_utils while resolving BLOOM via PEFT/TRL.
+        for packages in (_VENV_T5_530_PACKAGES, _VENV_T5_550_PACKAGES, _VENV_T5_510_PACKAGES):
+            assert "soxr" in packages
 
     def test_activate_prefers_local_checkpoint_tier_over_resolved_base(self, caplog, tmp_path):
         # Base resolves to an offline/private id (default tier); the local config.json wins.

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -64,6 +64,7 @@ from utils.transformers_version import (
     _VENV_T5_530_PACKAGES,
     _VENV_T5_550_PACKAGES,
     _VENV_T5_510_PACKAGES,
+    _purge_modules,
     hf_endpoint_unreachable,
 )
 
@@ -1641,6 +1642,41 @@ class TestActivateLoggingClarity:
         # transformers 5.x imports audio_utils while resolving BLOOM via PEFT/TRL.
         for packages in (_VENV_T5_530_PACKAGES, _VENV_T5_550_PACKAGES, _VENV_T5_510_PACKAGES):
             assert "soxr" in packages
+
+    def test_purge_removes_stale_unsloth_zoo_import_hooks(self):
+        class StaleZooFinder:
+            pass
+
+        class OtherFinder:
+            pass
+
+        StaleZooFinder.__module__ = "unsloth_zoo.fused_losses.forward_install"
+        stale_finder = StaleZooFinder()
+        other_finder = OtherFinder()
+        saved_meta_path = list(sys.meta_path)
+        saved_modules = {
+            name: sys.modules.get(name)
+            for name in ("transformers", "unsloth_zoo", "unsloth_zoo.fused_losses")
+        }
+        try:
+            sys.meta_path[:] = [stale_finder, other_finder, *saved_meta_path]
+            sys.modules["transformers"] = _types.ModuleType("transformers")
+            sys.modules["unsloth_zoo"] = _types.ModuleType("unsloth_zoo")
+            sys.modules["unsloth_zoo.fused_losses"] = _types.ModuleType("unsloth_zoo.fused_losses")
+
+            _purge_modules()
+
+            assert stale_finder not in sys.meta_path
+            assert other_finder in sys.meta_path
+            assert "unsloth_zoo" not in sys.modules
+            assert "unsloth_zoo.fused_losses" not in sys.modules
+        finally:
+            sys.meta_path[:] = saved_meta_path
+            for name, module in saved_modules.items():
+                if module is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = module
 
     def test_activate_prefers_local_checkpoint_tier_over_resolved_base(self, caplog, tmp_path):
         # Base resolves to an offline/private id (default tier); the local config.json wins.

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -1354,6 +1354,14 @@ def _purge_modules() -> int:
     Returns the number of modules purged.
     """
     importlib.invalidate_caches()
+    sys.meta_path[:] = [
+        finder
+        for finder in sys.meta_path
+        if not any(
+            type(finder).__module__ == p or type(finder).__module__.startswith(p + ".")
+            for p in _PURGE_PREFIXES
+        )
+    ]
     to_remove = [
         k
         for k in list(sys.modules.keys())

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -1369,6 +1369,7 @@ _VENV_T5_530_PACKAGES = (
     "huggingface_hub==1.8.0",
     "hf_xet==1.4.2",
     "tiktoken",
+    "soxr",
 )
 
 _VENV_T5_510_PACKAGES = (
@@ -1376,6 +1377,7 @@ _VENV_T5_510_PACKAGES = (
     "huggingface_hub==1.8.0",
     "hf_xet==1.4.2",
     "tiktoken",
+    "soxr",
 )
 
 _VENV_T5_550_PACKAGES = (
@@ -1383,6 +1385,7 @@ _VENV_T5_550_PACKAGES = (
     "huggingface_hub==1.8.0",
     "hf_xet==1.4.2",
     "tiktoken",
+    "soxr",
 )
 
 # Backwards-compat alias

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -263,6 +263,8 @@ def activate_transformers_for_subprocess(model_name: str, hf_token: str | None =
         # surface, but path names alone must not upgrade a plain adapter.
         tier = _higher_tier(tier, get_transformers_tier(model_name, hf_token))
 
+    stale_transformers = _get_in_memory_version()
+
     if tier == "510":
         if not _ensure_venv_t5_510_exists():
             raise RuntimeError(
@@ -316,6 +318,16 @@ def activate_transformers_for_subprocess(model_name: str, hf_token: str | None =
         os.environ["PYTHONPATH"] = _VENV_T5_530_DIR + (os.pathsep + _pp if _pp else "")
     else:
         logger.info("Using default transformers (4.57.x) for %s", model_name)
+        return
+
+    if stale_transformers is not None:
+        count = _purge_modules()
+        logger.warning(
+            "Purged %d stale module(s) after subprocess transformers sidecar activation "
+            "(previous transformers=%s)",
+            count,
+            stale_transformers,
+        )
 
 
 def _has_adapter_weights(path: Path) -> bool:


### PR DESCRIPTION
## What

Fix Studio sidecar activation when the default 	ransformers package has already been imported before a 5.x sidecar is selected.

When a Qwen3.5 run selects the 5.3.0 sidecar, ctivate_transformers_for_subprocess() previously only prepended .venv_t5_530 to sys.path. If 	ransformers==4.57.6 was already cached in sys.modules, later imports kept using the stale default package and Qwen3.5 failed with the unsupported-transformers error.

This change records whether 	ransformers was already loaded, activates the chosen sidecar path as before, then purges stale 	ransformers and dependent modules so the next import resolves from the sidecar.

## Validation

- PYTHONPATH=studio/backend ~/.unsloth/studio/unsloth_studio/bin/python -m pytest studio/backend/tests/test_transformers_version.py::TestActivateLoggingClarity -q
- Direct A/B smoke test with real Studio venv and real .venv_t5_530:
  - no purge: preloaded 4.57.6, after activation still 4.57.6 from unsloth_studio/lib/python3.13/site-packages
  - with fix: preloaded 4.57.6, purged 65 stale modules, after activation 5.3.0 from /home/samle/.unsloth/studio/.venv_t5_530/transformers/__init__.py

## Notes

This is intentionally limited to the subprocess sidecar activation path. Default-tier models still return without purging.
