### PR TITLE
Studio: fix currency and indentation edge cases in LaTeX rendering

### DIFF
--- a/studio/frontend/src/lib/latex.ts
+++ b/studio/frontend/src/lib/latex.ts
@@ -334,7 +334,8 @@ function convertLatexDelimiters(content: string): {
       // Keep the opener's leading indentation so a `$$` block inside a list item
       // stays in the container instead of breaking out at column 0. Only when the
       // opener is whitespace-prefixed, so inline `text \[x\]` keeps column 0.
-      const lineStart = content.lastIndexOf("\n", match.index - 1) + 1;
+      const lineStart =
+        match.index > 0 ? content.lastIndexOf("\n", match.index - 1) + 1 : 0;
       const prefix = content.slice(lineStart, match.index);
       const indent = /^\s*$/.test(prefix) ? prefix : "";
       wrapped = `\n${indent}$$\n${indent}${body}\n${indent}$$\n`;

--- a/studio/frontend/src/lib/latex.ts
+++ b/studio/frontend/src/lib/latex.ts
@@ -67,11 +67,12 @@ const LINK_DEST_RE =
 
 /**
  * Reference-link definition `[label]: DEST` (group 1 = angle `<...>`, group 2 =
- * bare run). `d` flag for indices, `m` to anchor at line start. Its URL, like an
- * inline destination, must not be rewritten as math.
+ * bare run). `d` flag for indices, `m` to anchor at line start. `(?!\^)` skips
+ * GFM footnotes (`[^id]: text`), whose body is prose, not a URL. Its URL, like
+ * an inline destination, must not be rewritten as math.
  */
 const REF_DEF_DEST_RE =
-  /^ {0,3}\[(?:\\.|[^\]\n\\])+\]:[^\S\n]*(?:<([^>\n]*)>|([^\s<][^\s]*))/gmd;
+  /^ {0,3}\[(?!\^)(?:\\.|[^\]\n\\])+\]:[^\S\n]*(?:<([^>\n]*)>|([^\s<][^\s]*))/gmd;
 
 /**
  * Destination spans of inline links/images and reference-link definitions, so a

--- a/studio/frontend/src/lib/latex.ts
+++ b/studio/frontend/src/lib/latex.ts
@@ -66,20 +66,39 @@ const LINK_DEST_RE =
   /!?\[(?:\\.|[^\]\\])*?\]\(((?:\\.|[^()\\]|\([^()]*\))*)\)/gd;
 
 /**
- * Find the destination spans of inline links/images, so a `\(...\)` written with
- * escaped parens inside a URL isn't rewritten as math (which would break the
- * link). Only the destination is returned, not the link text, so math in the
- * visible text still converts. Sorted, non-overlapping (matches are disjoint).
+ * Reference-link definition `[label]: DEST` (group 1 = angle `<...>`, group 2 =
+ * bare run). `d` flag for indices, `m` to anchor at line start. Its URL, like an
+ * inline destination, must not be rewritten as math.
+ */
+const REF_DEF_DEST_RE =
+  /^ {0,3}\[(?:\\.|[^\]\n\\])+\]:[^\S\n]*(?:<([^>\n]*)>|([^\s<][^\s]*))/gmd;
+
+/**
+ * Destination spans of inline links/images and reference-link definitions, so a
+ * `\(...\)` inside a URL isn't rewritten as math. Link text is not returned, so
+ * math in the visible text still converts.
  */
 function findLinkDestinationRegions(content: string): Array<[number, number]> {
-  if (!content.includes("](")) return [];
+  const hasInline = content.includes("](");
+  const hasRefDef = content.includes("]:");
+  if (!hasInline && !hasRefDef) return [];
   const regions: Array<[number, number]> = [];
   let match: RegExpExecArray | null;
-  LINK_DEST_RE.lastIndex = 0;
-  while ((match = LINK_DEST_RE.exec(content)) !== null) {
-    // `indices` is present (the `d` flag); group 1 spans the destination.
-    regions.push(match.indices![1]);
+  if (hasInline) {
+    LINK_DEST_RE.lastIndex = 0;
+    while ((match = LINK_DEST_RE.exec(content)) !== null) {
+      regions.push(match.indices![1]); // `d` flag: group 1 is the destination.
+    }
   }
+  if (hasRefDef) {
+    REF_DEF_DEST_RE.lastIndex = 0;
+    while ((match = REF_DEF_DEST_RE.exec(content)) !== null) {
+      const span = match.indices![1] ?? match.indices![2];
+      if (span) regions.push(span);
+    }
+  }
+  // Inline and ref-def spans can interleave (never overlap), so sort.
+  regions.sort((a, b) => a[0] - b[0]);
   return regions;
 }
 
@@ -173,7 +192,11 @@ function looksLikeMathBody(body: string): boolean {
  * (`**$X$**`, `__$X$__`) are always math: LLMs use that for "bold math"
  * and the heuristic would otherwise reject prose-shaped bodies like "90 - x".
  */
-function hasInlineMathCloser(content: string, offset: number): boolean {
+function hasInlineMathCloser(
+  content: string,
+  offset: number,
+  mathRegions: Array<[number, number]>,
+): boolean {
   const MAX_SPAN = 200;
   const limit = Math.min(content.length, offset + 1 + MAX_SPAN);
   for (let i = offset + 1; i < limit; i++) {
@@ -181,6 +204,9 @@ function hasInlineMathCloser(content: string, offset: number): boolean {
     if (c === "\n") return false;
     if (c !== "$") continue;
     if (content[i - 1] === "\\") continue;
+    // A `$` opening a generated span (from `\(...\)`) is not a currency closer;
+    // pairing with it would swallow the price into math (`$5 + x \(y\)`).
+    if (isInRegion(i, mathRegions)) return false;
     if (content[i + 1] === "$") {
       i++;
       continue;
@@ -294,7 +320,18 @@ function convertLatexDelimiters(content: string): {
       continue;
     }
     append(content.slice(last, match.index));
-    const wrapped = isDisplay ? `\n$$\n${body}\n$$\n` : `$${body}$`;
+    let wrapped: string;
+    if (isDisplay) {
+      // Keep the opener's leading indentation so a `$$` block inside a list item
+      // stays in the container instead of breaking out at column 0. Only when the
+      // opener is whitespace-prefixed, so inline `text \[x\]` keeps column 0.
+      const lineStart = content.lastIndexOf("\n", match.index - 1) + 1;
+      const prefix = content.slice(lineStart, match.index);
+      const indent = /^\s*$/.test(prefix) ? prefix : "";
+      wrapped = `\n${indent}$$\n${indent}${body}\n${indent}$$\n`;
+    } else {
+      wrapped = `$${body}$`;
+    }
     const start = append(wrapped);
     mathRegions.push([start, offset]);
     last = matchEnd;
@@ -334,7 +371,7 @@ export function preprocessLaTeX(content: string): string {
     if (isInRegion(offset, mathRegions)) {
       return match;
     }
-    if (hasInlineMathCloser(text, offset)) {
+    if (hasInlineMathCloser(text, offset, mathRegions)) {
       return match;
     }
     return "\\" + match;

--- a/studio/frontend/src/lib/latex.ts
+++ b/studio/frontend/src/lib/latex.ts
@@ -98,9 +98,17 @@ function findLinkDestinationRegions(content: string): Array<[number, number]> {
       if (span) regions.push(span);
     }
   }
-  // Inline and ref-def spans can interleave (never overlap), so sort.
+  // Sort, then merge overlaps: a reference-def token can nest inline-link spans
+  // (`[1]: http://h/[a](b)/foo\(x\)`), and isInRegion's binary search needs
+  // disjoint spans.
   regions.sort((a, b) => a[0] - b[0]);
-  return regions;
+  const merged: Array<[number, number]> = [];
+  for (const span of regions) {
+    const last = merged[merged.length - 1];
+    if (last && span[0] <= last[1]) last[1] = Math.max(last[1], span[1]);
+    else merged.push(span);
+  }
+  return merged;
 }
 
 /**

--- a/studio/frontend/src/lib/latex.ts
+++ b/studio/frontend/src/lib/latex.ts
@@ -66,49 +66,21 @@ const LINK_DEST_RE =
   /!?\[(?:\\.|[^\]\\])*?\]\(((?:\\.|[^()\\]|\([^()]*\))*)\)/gd;
 
 /**
- * Reference-link definition `[label]: DEST` (group 1 = angle `<...>`, group 2 =
- * bare run). `d` flag for indices, `m` to anchor at line start. `(?!\^)` skips
- * GFM footnotes (`[^id]: text`), whose body is prose, not a URL. Its URL, like
- * an inline destination, must not be rewritten as math.
- */
-const REF_DEF_DEST_RE =
-  /^ {0,3}\[(?!\^)(?:\\.|[^\]\n\\])+\]:[^\S\n]*(?:<([^>\n]*)>|([^\s<][^\s]*))/gmd;
-
-/**
- * Destination spans of inline links/images and reference-link definitions, so a
- * `\(...\)` inside a URL isn't rewritten as math. Link text is not returned, so
- * math in the visible text still converts.
+ * Find the destination spans of inline links/images, so a `\(...\)` written with
+ * escaped parens inside a URL isn't rewritten as math (which would break the
+ * link). Only the destination is returned, not the link text, so math in the
+ * visible text still converts. Sorted, non-overlapping (matches are disjoint).
  */
 function findLinkDestinationRegions(content: string): Array<[number, number]> {
-  const hasInline = content.includes("](");
-  const hasRefDef = content.includes("]:");
-  if (!hasInline && !hasRefDef) return [];
+  if (!content.includes("](")) return [];
   const regions: Array<[number, number]> = [];
   let match: RegExpExecArray | null;
-  if (hasInline) {
-    LINK_DEST_RE.lastIndex = 0;
-    while ((match = LINK_DEST_RE.exec(content)) !== null) {
-      regions.push(match.indices![1]); // `d` flag: group 1 is the destination.
-    }
+  LINK_DEST_RE.lastIndex = 0;
+  while ((match = LINK_DEST_RE.exec(content)) !== null) {
+    // `indices` is present (the `d` flag); group 1 spans the destination.
+    regions.push(match.indices![1]);
   }
-  if (hasRefDef) {
-    REF_DEF_DEST_RE.lastIndex = 0;
-    while ((match = REF_DEF_DEST_RE.exec(content)) !== null) {
-      const span = match.indices![1] ?? match.indices![2];
-      if (span) regions.push(span);
-    }
-  }
-  // Sort, then merge overlaps: a reference-def token can nest inline-link spans
-  // (`[1]: http://h/[a](b)/foo\(x\)`), and isInRegion's binary search needs
-  // disjoint spans.
-  regions.sort((a, b) => a[0] - b[0]);
-  const merged: Array<[number, number]> = [];
-  for (const span of regions) {
-    const last = merged[merged.length - 1];
-    if (last && span[0] <= last[1]) last[1] = Math.max(last[1], span[1]);
-    else merged.push(span);
-  }
-  return merged;
+  return regions;
 }
 
 /**
@@ -338,7 +310,10 @@ function convertLatexDelimiters(content: string): {
         match.index > 0 ? content.lastIndexOf("\n", match.index - 1) + 1 : 0;
       const prefix = content.slice(lineStart, match.index);
       const indent = /^\s*$/.test(prefix) ? prefix : "";
-      wrapped = `\n${indent}$$\n${indent}${body}\n${indent}$$\n`;
+      // Indent every body line, not just the first, so multi-line display math
+      // (`\[a\nb\]`) stays wholly inside the container.
+      const inner = indent ? body.replace(/\n/g, `\n${indent}`) : body;
+      wrapped = `\n${indent}$$\n${indent}${inner}\n${indent}$$\n`;
     } else {
       wrapped = `$${body}$`;
     }


### PR DESCRIPTION
Follow-up to #6914, which made Studio chat render `\[ \]` and `\( \)` LaTeX delimiters. This fixes two edge cases in `studio/frontend/src/lib/latex.ts` where the conversion mis-handled well-formed input.

## Fixes

1. Display math indentation. A `\[...\]` inside a list item emitted the `$$` fence at column 0, so the block broke out of the list (for example `- step:` followed by an indented `\[x\]` rendered the equation outside the list). The opener line's indentation is now preserved and applied to every line of a multi-line body, guarded so inline and column-0 uses stay unchanged.

2. Currency swallowed into math. A currency amount before a converted span on the same line could use the generated span's opening `$` as its closer, so `Cost is $5 + x \(y\)` rendered `5 + x` as math and dropped the `$5`. `hasInlineMathCloser` now skips a `$` that opens a generated math region.

An earlier revision also protected reference-style link URLs, but that guarded a case models effectively never emit (escaped parens in a `[id]: url` definition) and needed open-ended special-casing of CommonMark reference definitions, so it was dropped to keep this change focused. Inline link handling is unchanged from #6914.

## Verification

- 32 exact-output transform cases and 27 cases through the real remark-math + rehype-katex pipeline pass.
- `tsc` (5.9.3, project config) is clean, and behavior for input without bracket delimiters is byte-identical to before.
