### PR TITLE
Polish assistant message actions menu

### DIFF
--- a/studio/frontend/src/components/assistant-ui/message-response-details-sheet.tsx
+++ b/studio/frontend/src/components/assistant-ui/message-response-details-sheet.tsx
@@ -18,7 +18,7 @@ import {
   useExternalProvidersStore,
 } from "@/features/chat";
 import { cn } from "@/lib/utils";
-import { FileDatabaseIcon } from "@hugeicons/core-free-icons";
+import { HelpCircleIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useMessage, useMessageTiming } from "@assistant-ui/react";
 import type { FC, ReactNode } from "react";
@@ -341,7 +341,7 @@ export const MessageResponseDetailsSheet: FC<{
         <SheetHeader className="border-b p-4">
           <SheetTitle className="flex items-center gap-2 pr-10 font-heading text-base">
             <HugeiconsIcon
-              icon={FileDatabaseIcon}
+              icon={HelpCircleIcon}
               strokeWidth={1.75}
               className="size-icon text-chat-icon-fg"
             />

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -127,6 +127,7 @@ import {
   FileDatabaseIcon,
   Folder01Icon,
   FolderAddIcon,
+  HelpCircleIcon,
   Image03Icon,
   McpServerIcon,
   PencilRulerIcon,
@@ -3952,7 +3953,7 @@ const AssistantActionBar: FC = () => {
                   strokeWidth={1.75}
                   className="size-icon"
                 />
-                Export as Markdown
+                Export as markdown
               </ActionBarMorePrimitive.Item>
             </ActionBarPrimitive.ExportMarkdown>
             <ActionBarMorePrimitive.Item
@@ -3960,7 +3961,7 @@ const AssistantActionBar: FC = () => {
               className="aui-action-bar-more-item flex cursor-pointer select-none items-center gap-2 rounded-[12px] px-3 py-2 text-sm outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
             >
               <HugeiconsIcon
-                icon={FileDatabaseIcon}
+                icon={HelpCircleIcon}
                 strokeWidth={1.75}
                 className="size-icon"
               />


### PR DESCRIPTION
Small polish to the assistant message actions menu in Studio chat.

### Changes
- Swap the "See response details" icon from the file-database icon to the circle question mark (`HelpCircleIcon`), which reads better as a "details / more info" affordance.
- Lowercase the "Export as markdown" label for consistent casing.

Text and icon swap only, no behaviour change. Frontend typechecks and builds clean.