### PR TITLE
Studio: preserve local GGUF reload identity

### DIFF
--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -120,6 +120,7 @@ import {
   hasLoadedGgufSource,
   hasUsableNativePathToken,
   isDownloadableHubRepo,
+  isLocalModelPath,
   isNativePathTokenExpired,
   loadOptionalBool,
   pendingSelectionMatches,
@@ -2701,7 +2702,9 @@ export function ChatPage({
           const checkpoint = state.params.checkpoint;
           if (checkpoint) {
             const isLoadedGguf = hasLoadedGgufSource(state);
-            const isDirectGguf = checkpoint.toLowerCase().endsWith(".gguf");
+            const isDirectGguf =
+              isLocalModelPath(checkpoint) &&
+              checkpoint.toLowerCase().endsWith(".gguf");
             const hasNativeToken = hasUsableNativePathToken({
               nativePathToken: state.activeNativePathToken,
               nativePathTokenExpiresAtMs: state.activeNativePathTokenExpiresAtMs,

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -2670,13 +2670,21 @@ export function ChatPage({
         loadingModel={loadingModel}
         onReloadModel={() => {
           const state = useChatRuntimeStore.getState();
-          if (state.params.checkpoint) {
+          const checkpoint = state.params.checkpoint;
+          if (checkpoint) {
+            const isLoadedGguf =
+              state.activeGgufVariant != null ||
+              state.activeNativePathToken != null ||
+              checkpoint.toLowerCase().endsWith(".gguf") ||
+              state.ggufContextLength != null;
             selectModel({
-              id: state.params.checkpoint,
+              id: checkpoint,
               ggufVariant: state.activeGgufVariant ?? undefined,
+              nativePathToken: state.activeNativePathToken ?? undefined,
               forceReload: true,
               isDownloaded: true,
-              loadingDescription: "Reloading with updated chat template.",
+              isGguf: isLoadedGguf,
+              loadingDescription: "Reloading with updated model settings.",
             });
           }
         }}

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -117,7 +117,10 @@ import {
   CHAT_TOOLS_ENABLED_KEY,
   CHAT_WEB_FETCH_TOOLS_ENABLED_KEY,
   hasGgufSource,
+  hasLoadedGgufSource,
+  hasUsableNativePathToken,
   isDownloadableHubRepo,
+  isNativePathTokenExpired,
   loadOptionalBool,
   pendingSelectionMatches,
   useChatRuntimeStore,
@@ -1760,6 +1763,7 @@ export function ChatPage({
         isDownloaded: selection.isDownloaded,
         expectedBytes: selection.expectedBytes,
         nativePathToken: selection.nativePathToken,
+        nativePathTokenExpiresAtMs: selection.nativePathTokenExpiresAtMs,
         isGguf: selection.isGguf,
         isHubRepo: wantManagerDownload || undefined,
         autoLoad: store.loadOnSelection,
@@ -1774,6 +1778,7 @@ export function ChatPage({
       await stageOrLoad({
         id: label,
         nativePathToken: intent.path.token,
+        nativePathTokenExpiresAtMs: intent.path.expiresAtMs,
         isDownloaded: true,
         loadingDescription,
         forceReload: true,
@@ -1946,6 +1951,7 @@ export function ChatPage({
           ggufMaxContextLength: null,
           ggufNativeContextLength: null,
           activeNativePathToken: null,
+          activeNativePathTokenExpiresAtMs: null,
           // Clear previous-model counters, else the relaxed external-provider
           // render gate shows stale stats until the next completion.
           contextUsage: null,
@@ -2155,6 +2161,28 @@ export function ChatPage({
   const lastOpenRouterChosenModel = useChatRuntimeStore(
     (s) => s.lastOpenRouterChosenModel,
   );
+  const activeNativePathTokenExpiresAtMs = useChatRuntimeStore(
+    (s) => s.activeNativePathTokenExpiresAtMs,
+  );
+  useEffect(() => {
+    if (activeNativePathTokenExpiresAtMs == null) return;
+    const clearExpiredActiveToken = () => {
+      const state = useChatRuntimeStore.getState();
+      if (
+        state.activeNativePathToken &&
+        isNativePathTokenExpired(state.activeNativePathTokenExpiresAtMs)
+      ) {
+        useChatRuntimeStore.setState({ activeNativePathToken: null });
+      }
+    };
+    const delay = activeNativePathTokenExpiresAtMs - Date.now();
+    if (delay <= 0) {
+      clearExpiredActiveToken();
+      return;
+    }
+    const timer = window.setTimeout(clearExpiredActiveToken, delay + 1);
+    return () => window.clearTimeout(timer);
+  }, [activeNativePathTokenExpiresAtMs]);
   const externalModels = useMemo<ExternalModelOption[]>(
     () =>
       [...externalProvidersForChat]
@@ -2672,15 +2700,36 @@ export function ChatPage({
           const state = useChatRuntimeStore.getState();
           const checkpoint = state.params.checkpoint;
           if (checkpoint) {
-            const isLoadedGguf =
-              state.activeGgufVariant != null ||
-              state.activeNativePathToken != null ||
-              checkpoint.toLowerCase().endsWith(".gguf") ||
-              state.ggufContextLength != null;
+            const isLoadedGguf = hasLoadedGgufSource(state);
+            const isDirectGguf = checkpoint.toLowerCase().endsWith(".gguf");
+            const hasNativeToken = hasUsableNativePathToken({
+              nativePathToken: state.activeNativePathToken,
+              nativePathTokenExpiresAtMs: state.activeNativePathTokenExpiresAtMs,
+            });
+            if (
+              isLoadedGguf &&
+              state.activeGgufVariant == null &&
+              !isDirectGguf &&
+              !hasNativeToken
+            ) {
+              useChatRuntimeStore.setState({ activeNativePathToken: null });
+              const message =
+                "Pick or drop the local .gguf file again before applying settings.";
+              useChatRuntimeStore.getState().setModelsError(message);
+              toast.error("Local model selection expired", {
+                description: message,
+              });
+              return;
+            }
             selectModel({
               id: checkpoint,
               ggufVariant: state.activeGgufVariant ?? undefined,
-              nativePathToken: state.activeNativePathToken ?? undefined,
+              nativePathToken: hasNativeToken
+                ? (state.activeNativePathToken ?? undefined)
+                : undefined,
+              nativePathTokenExpiresAtMs: hasNativeToken
+                ? state.activeNativePathTokenExpiresAtMs
+                : undefined,
               forceReload: true,
               isDownloaded: true,
               isGguf: isLoadedGguf,

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -547,8 +547,14 @@ export function ChatSettingsPanel({
     const base = slash >= 0 ? id.slice(slash + 1) : id;
     return base || id;
   })();
+  const activeGgufVariant = useChatRuntimeStore((s) => s.activeGgufVariant);
+  const activeNativePathToken = useChatRuntimeStore(
+    (s) => s.activeNativePathToken,
+  );
   const isLoadedGguf =
-    useChatRuntimeStore((s) => s.activeGgufVariant) != null;
+    activeGgufVariant != null ||
+    activeNativePathToken != null ||
+    params.checkpoint.toLowerCase().endsWith(".gguf");
   // While a pick is staged the sheet configures *that* model, so its GGUF-ness
   // (not the currently loaded model's) decides whether the GGUF-only controls
   // show. Otherwise a staged non-GGUF Hub repo would inherit the loaded GGUF's

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -106,6 +106,7 @@ import {
   providerSupportsFastMode,
 } from "./provider-capabilities";
 import {
+  hasLoadedGgufSource,
   isPendingGguf,
   pendingSelectionMatches,
   useChatRuntimeStore,
@@ -551,10 +552,17 @@ export function ChatSettingsPanel({
   const activeNativePathToken = useChatRuntimeStore(
     (s) => s.activeNativePathToken,
   );
-  const isLoadedGguf =
-    activeGgufVariant != null ||
-    activeNativePathToken != null ||
-    params.checkpoint.toLowerCase().endsWith(".gguf");
+  const activeNativePathTokenExpiresAtMs = useChatRuntimeStore(
+    (s) => s.activeNativePathTokenExpiresAtMs,
+  );
+  const ggufContextLength = useChatRuntimeStore((s) => s.ggufContextLength);
+  const isLoadedGguf = hasLoadedGgufSource({
+    activeGgufVariant,
+    activeNativePathToken,
+    activeNativePathTokenExpiresAtMs,
+    ggufContextLength,
+    params,
+  });
   // While a pick is staged the sheet configures *that* model, so its GGUF-ness
   // (not the currently loaded model's) decides whether the GGUF-only controls
   // show. Otherwise a staged non-GGUF Hub repo would inherit the loaded GGUF's
@@ -599,7 +607,6 @@ export function ChatSettingsPanel({
     (s) => s.loadedSpecDraftNMax,
   );
   const currentCheckpoint = params.checkpoint;
-  const ggufContextLength = useChatRuntimeStore((s) => s.ggufContextLength);
   const ggufMaxContextLength = useChatRuntimeStore(
     (s) => s.ggufMaxContextLength,
   );

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -577,6 +577,7 @@ export function useChatModelRuntime() {
             const validateMaxSeqLength = resolveLoadMaxSeqLength({
               modelId,
               ggufVariant,
+              isGguf,
               customContextLength: loadCustomContextLength,
               ggufContextLength: loadGgufContextLength,
               currentCheckpoint,

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -26,6 +26,7 @@ import {
 import { formatEta, formatRate } from "../utils/format-transfer";
 import {
   isLocalModelPath,
+  isNativePathTokenExpired,
   pendingSelectionMatches,
   readPersistedSpeculativeType,
   resolveToolsEnabledOnLoad,
@@ -68,6 +69,7 @@ export type SelectedModelInput = {
   expectedBytes?: number;
   forceReload?: boolean;
   nativePathToken?: string;
+  nativePathTokenExpiresAtMs?: number | null;
   /** Direct local .gguf file (no HF variant / native token) — still a GGUF
    *  source, so the staging flow treats it as one. */
   isGguf?: boolean;
@@ -408,6 +410,10 @@ export function useChatModelRuntime() {
         typeof selection === "string" ? false : selection.forceReload ?? false;
       const nativePathToken =
         typeof selection === "string" ? undefined : selection.nativePathToken;
+      const nativePathTokenExpiresAtMs =
+        typeof selection === "string"
+          ? undefined
+          : selection.nativePathTokenExpiresAtMs;
       const explicitIsGguf =
         typeof selection === "string" ? undefined : selection.isGguf;
       const throwOnError =
@@ -459,6 +465,28 @@ export function useChatModelRuntime() {
         toast.info("Another model is already loading", {
           description: "Wait for it to finish or cancel it first.",
         });
+        return;
+      }
+
+      if (
+        nativePathToken &&
+        isNativePathTokenExpired(nativePathTokenExpiresAtMs)
+      ) {
+        const message =
+          "Local model selection expired. Pick or drop the .gguf file again to apply these settings.";
+        setModelsError(message);
+        setLastModelLoadError(message);
+        const store = useChatRuntimeStore.getState();
+        if (store.activeNativePathToken === nativePathToken) {
+          useChatRuntimeStore.setState({
+            activeNativePathToken: null,
+            activeNativePathTokenExpiresAtMs: nativePathTokenExpiresAtMs ?? null,
+          });
+        }
+        toast.error("Local model selection expired", {
+          description: "Pick or drop the .gguf file again, then retry.",
+        });
+        if (throwOnError) throw new Error(message);
         return;
       }
 
@@ -549,6 +577,8 @@ export function useChatModelRuntime() {
             stateBeforeUnload.modelRequiresTrustRemoteCode;
           const previousActiveNativePathToken =
             stateBeforeUnload.activeNativePathToken;
+          const previousActiveNativePathTokenExpiresAtMs =
+            stateBeforeUnload.activeNativePathTokenExpiresAtMs;
           // Snapshot the load settings at click time, before the awaits below
           // (validation, the trust dialog, unload). For a staged Load these knobs
           // stay editable and a sheet-close revert (abandonStagedModel) can fire
@@ -783,6 +813,9 @@ export function useChatModelRuntime() {
               loadedIsMultimodal: isMultimodalResponse(loadResponse),
               loadedIsDiffusion: loadResponse.is_diffusion ?? false,
               activeNativePathToken: nativePathToken ?? null,
+              activeNativePathTokenExpiresAtMs: nativePathToken
+                ? (nativePathTokenExpiresAtMs ?? null)
+                : null,
             });
             // Unlock attach menus for capabilities the catalog entry lacked.
             syncModelCapabilities(modelId, loadResponse);
@@ -875,6 +908,10 @@ export function useChatModelRuntime() {
                 });
                 useChatRuntimeStore.setState({
                   activeNativePathToken: previousActiveNativePathToken ?? null,
+                  activeNativePathTokenExpiresAtMs:
+                    previousActiveNativePathToken
+                      ? (previousActiveNativePathTokenExpiresAtMs ?? null)
+                      : null,
                   loadedSpeculativeType: null,
                   loadedSpecDraftNMax: null,
                 });

--- a/studio/frontend/src/features/chat/hooks/use-staged-model-preparation.ts
+++ b/studio/frontend/src/features/chat/hooks/use-staged-model-preparation.ts
@@ -9,6 +9,7 @@ import { useLatestRef } from "@/features/hub/hooks/use-latest-ref";
 
 import { fetchGgufContextLength } from "../api/chat-api";
 import {
+  isNativePathTokenExpired,
   isPendingGguf,
   pendingSelectionMatches,
   useChatRuntimeStore,
@@ -67,7 +68,14 @@ export function useStagedModelPreparation(opts?: {
   const fetchContextMetadata = useCallback(async () => {
     const current = useChatRuntimeStore.getState().pendingSelection;
     if (!current?.id || !isPendingGguf(current)) return;
-    const { id, ggufVariant, nativePathToken } = current;
+    const { id, ggufVariant, nativePathToken, nativePathTokenExpiresAtMs } =
+      current;
+    if (
+      nativePathToken &&
+      isNativePathTokenExpired(nativePathTokenExpiresAtMs)
+    ) {
+      return;
+    }
     try {
       const contextLength = await fetchGgufContextLength({
         model_path: id,

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -516,7 +516,8 @@ export function hasLoadedGgufSource(x: {
       nativePathTokenExpiresAtMs: x.activeNativePathTokenExpiresAtMs,
     }) ||
     x.activeNativePathTokenExpiresAtMs != null ||
-    x.params.checkpoint.toLowerCase().endsWith(".gguf") ||
+    (isLocalModelPath(x.params.checkpoint) &&
+      x.params.checkpoint.toLowerCase().endsWith(".gguf")) ||
     x.ggufContextLength != null
   );
 }
@@ -526,6 +527,16 @@ export function hasLoadedGgufSource(x: {
  *  hub-repo predicate classify ids identically. */
 export function isLocalModelPath(id: string): boolean {
   return /^(\/|\.{1,2}[\\/]|~[\\/]|[A-Za-z]:[\\/]|\\\\)/.test(id);
+}
+
+function clearedLoadedGgufMetadata() {
+  return {
+    activeNativePathToken: null,
+    activeNativePathTokenExpiresAtMs: null,
+    ggufContextLength: null,
+    ggufMaxContextLength: null,
+    ggufNativeContextLength: null,
+  };
 }
 
 /** An uncached HF hub repo we can download as a full snapshot (non-GGUF
@@ -1237,11 +1248,13 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       }
       // Mirror setCheckpoint: the local load path can mutate params.checkpoint
       // via setParams() before setCheckpoint runs, leaving stale per-turn
-      // counters under the new checkpoint.
+      // counters or GGUF identity metadata under the new checkpoint.
       const checkpointChanged = state.params.checkpoint !== params.checkpoint;
       return {
         params,
-        ...(checkpointChanged ? { contextUsage: null } : {}),
+        ...(checkpointChanged
+          ? { contextUsage: null, ...clearedLoadedGgufMetadata() }
+          : {}),
       };
     }),
   setCustomPresets: (customPresets) =>
@@ -1309,6 +1322,9 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       // Clear stale per-turn usage on model change; the relaxed external-provider
       // render gate would otherwise show old counters until the next completion.
       const checkpointChanged = state.params.checkpoint !== modelId;
+      const nextGgufVariant = ggufVariant ?? null;
+      const loadedGgufSourceChanged =
+        checkpointChanged || state.activeGgufVariant !== nextGgufVariant;
       const pendingToClear =
         checkpointChanged && state.params.checkpoint
           ? state.pendingSelection
@@ -1341,8 +1357,9 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
           checkpoint: modelId,
           maxTokens: nextMaxTokens,
         },
-        activeGgufVariant: ggufVariant ?? null,
+        activeGgufVariant: nextGgufVariant,
         ...(checkpointChanged ? { contextUsage: null } : {}),
+        ...(loadedGgufSourceChanged ? clearedLoadedGgufMetadata() : {}),
         // Switching away from a loaded model (e.g. picking an external provider)
         // abandons any staged pick, so its Load button and edited knobs don't
         // linger over the newly active model. Same revert as abandonStagedModel.

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -1253,7 +1253,11 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       return {
         params,
         ...(checkpointChanged
-          ? { contextUsage: null, ...clearedLoadedGgufMetadata() }
+          ? {
+              contextUsage: null,
+              activeGgufVariant: null,
+              ...clearedLoadedGgufMetadata(),
+            }
           : {}),
       };
     }),

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -450,6 +450,9 @@ export type PendingModelSelection = {
   /** Native (drag-drop / picked-from-disk) GGUF: the path token used to read
    *  the header and to load. Absent for HF-repo models. */
   nativePathToken?: string;
+  /** Expiry for the native path token. Native tokens are short-lived grants,
+   *  not durable loaded-model identities. */
+  nativePathTokenExpiresAtMs?: number | null;
   /** Direct local .gguf file (custom folder / LM Studio): a GGUF source even
    *  though it carries neither an HF variant nor a native path token. */
   isGguf?: boolean;
@@ -474,6 +477,47 @@ export function hasGgufSource(x: {
 }): boolean {
   return (
     x.ggufVariant != null || x.nativePathToken != null || x.isGguf === true
+  );
+}
+
+export function isNativePathTokenExpired(
+  expiresAtMs?: number | null,
+  now = Date.now(),
+): boolean {
+  return (
+    typeof expiresAtMs === "number" &&
+    Number.isFinite(expiresAtMs) &&
+    expiresAtMs <= now
+  );
+}
+
+export function hasUsableNativePathToken(x: {
+  nativePathToken?: string | null;
+  nativePathTokenExpiresAtMs?: number | null;
+}): boolean {
+  return (
+    typeof x.nativePathToken === "string" &&
+    x.nativePathToken.length > 0 &&
+    !isNativePathTokenExpired(x.nativePathTokenExpiresAtMs)
+  );
+}
+
+export function hasLoadedGgufSource(x: {
+  activeGgufVariant?: string | null;
+  activeNativePathToken?: string | null;
+  activeNativePathTokenExpiresAtMs?: number | null;
+  ggufContextLength?: number | null;
+  params: { checkpoint: string };
+}): boolean {
+  return (
+    x.activeGgufVariant != null ||
+    hasUsableNativePathToken({
+      nativePathToken: x.activeNativePathToken,
+      nativePathTokenExpiresAtMs: x.activeNativePathTokenExpiresAtMs,
+    }) ||
+    x.activeNativePathTokenExpiresAtMs != null ||
+    x.params.checkpoint.toLowerCase().endsWith(".gguf") ||
+    x.ggufContextLength != null
   );
 }
 
@@ -716,6 +760,7 @@ type ChatRuntimeStore = {
   } | null;
   modelLoading: boolean;
   activeNativePathToken: string | null;
+  activeNativePathTokenExpiresAtMs: number | null;
   hydratePersistedSettings: () => Promise<void>;
   setModelLoading: (loading: boolean) => void;
   setModelRequiresTrustRemoteCode: (required: boolean) => void;
@@ -1141,6 +1186,7 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
   contextUsage: null,
   modelLoading: false,
   activeNativePathToken: null,
+  activeNativePathTokenExpiresAtMs: null,
   hydratePersistedSettings: async () => {
     if (get().settingsHydrated) {
       return;
@@ -1326,6 +1372,7 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
       },
       activeGgufVariant: null,
       activeNativePathToken: null,
+      activeNativePathTokenExpiresAtMs: null,
       pendingSelection: null,
       ggufContextLength: null,
       ggufMaxContextLength: null,

--- a/studio/frontend/src/features/native-intents/components/native-model-chip.tsx
+++ b/studio/frontend/src/features/native-intents/components/native-model-chip.tsx
@@ -11,6 +11,7 @@ interface NativeModelChipProps {
   onLoad: (selection: {
     id: string;
     nativePathToken: string;
+    nativePathTokenExpiresAtMs: number;
     isDownloaded: boolean;
     loadingDescription: string;
     forceReload: boolean;
@@ -43,6 +44,7 @@ export function NativeModelChip({
       await onLoad({
         id: label,
         nativePathToken: intent.path.token,
+        nativePathTokenExpiresAtMs: intent.path.expiresAtMs,
         isDownloaded: true,
         loadingDescription: "Loading selected local GGUF model.",
         forceReload: true,

--- a/tests/studio/test_chat_native_gguf_reload_contract.py
+++ b/tests/studio/test_chat_native_gguf_reload_contract.py
@@ -9,17 +9,10 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 CHAT_PAGE = REPO / "studio/frontend/src/features/chat/chat-page.tsx"
 SETTINGS_SHEET = REPO / "studio/frontend/src/features/chat/chat-settings-sheet.tsx"
-RUNTIME_HOOK = (
-    REPO / "studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts"
-)
-STAGED_PREP = (
-    REPO / "studio/frontend/src/features/chat/hooks/use-staged-model-preparation.ts"
-)
+RUNTIME_HOOK = REPO / "studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts"
+STAGED_PREP = REPO / "studio/frontend/src/features/chat/hooks/use-staged-model-preparation.ts"
 RUNTIME_STORE = REPO / "studio/frontend/src/features/chat/stores/chat-runtime-store.ts"
-NATIVE_CHIP = (
-    REPO
-    / "studio/frontend/src/features/native-intents/components/native-model-chip.tsx"
-)
+NATIVE_CHIP = REPO / "studio/frontend/src/features/native-intents/components/native-model-chip.tsx"
 
 
 def _src(path: Path) -> str:
@@ -38,9 +31,7 @@ _LOCAL_MODEL_PATH_RE = re.compile(r"^(\/|\.{1,2}[\\/]|~[\\/]|[A-Za-z]:[\\/]|\\\\
 
 
 def _is_direct_local_gguf(model_id: str) -> bool:
-    return bool(_LOCAL_MODEL_PATH_RE.match(model_id)) and model_id.lower().endswith(
-        ".gguf"
-    )
+    return bool(_LOCAL_MODEL_PATH_RE.match(model_id)) and model_id.lower().endswith(".gguf")
 
 
 def _between(src: str, start_marker: str, end_marker: str) -> str:
@@ -75,9 +66,7 @@ def test_native_gguf_reload_tracks_token_expiry_and_reselects_after_expiry():
 
     assert "nativePathTokenExpiresAtMs: intent.path.expiresAtMs" in page_src
     assert "hasUsableNativePathToken({" in page_src
-    assert (
-        "Pick or drop the local .gguf file again before applying settings." in page_src
-    )
+    assert "Pick or drop the local .gguf file again before applying settings." in page_src
     assert "activeNativePathToken: null" in page_src
 
     assert "isNativePathTokenExpired(nativePathTokenExpiresAtMs)" in hook_src
@@ -111,9 +100,7 @@ def test_native_token_expiry_flows_from_intent_through_staged_loads():
     chip_src = _src(NATIVE_CHIP)
     staged_src = _src(STAGED_PREP)
 
-    assert (
-        "nativePathTokenExpiresAtMs: selection.nativePathTokenExpiresAtMs" in page_src
-    )
+    assert "nativePathTokenExpiresAtMs: selection.nativePathTokenExpiresAtMs" in page_src
     assert "nativePathTokenExpiresAtMs: intent.path.expiresAtMs" in page_src
     assert "nativePathTokenExpiresAtMs: number;" in chip_src
     assert "nativePathTokenExpiresAtMs: intent.path.expiresAtMs" in chip_src
@@ -139,9 +126,8 @@ def test_native_display_basename_is_not_a_direct_gguf_path_on_reload():
 def test_direct_gguf_classifier_truth_table_matches_local_path_contract():
     store_src = _src(RUNTIME_STORE)
 
-    assert (
-        r"return/^(\/|\.{1,2}[\\/]|~[\\/]|[A-Za-z]:[\\/]|\\\\)/.test(id);"
-        in _minified(store_src)
+    assert r"return/^(\/|\.{1,2}[\\/]|~[\\/]|[A-Za-z]:[\\/]|\\\\)/.test(id);" in _minified(
+        store_src
     )
 
     for model_id in (

--- a/tests/studio/test_chat_native_gguf_reload_contract.py
+++ b/tests/studio/test_chat_native_gguf_reload_contract.py
@@ -45,7 +45,9 @@ def test_loaded_gguf_classifier_is_shared_by_reload_and_settings_sheet():
     sheet_src = _src(SETTINGS_SHEET)
 
     helper_start = store_src.index("export function hasLoadedGgufSource")
-    helper_body = store_src[helper_start : store_src.index("/** A local-disk model id", helper_start)]
+    helper_body = store_src[
+        helper_start : store_src.index("/** A local-disk model id", helper_start)
+    ]
     assert "x.activeGgufVariant != null" in helper_body
     assert "hasUsableNativePathToken" in helper_body
     assert "x.activeNativePathTokenExpiresAtMs != null" in helper_body

--- a/tests/studio/test_chat_native_gguf_reload_contract.py
+++ b/tests/studio/test_chat_native_gguf_reload_contract.py
@@ -1,0 +1,68 @@
+"""Static contracts for native GGUF settings reload identity."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+CHAT_PAGE = REPO / "studio/frontend/src/features/chat/chat-page.tsx"
+SETTINGS_SHEET = REPO / "studio/frontend/src/features/chat/chat-settings-sheet.tsx"
+RUNTIME_HOOK = REPO / "studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts"
+STAGED_PREP = REPO / "studio/frontend/src/features/chat/hooks/use-staged-model-preparation.ts"
+RUNTIME_STORE = REPO / "studio/frontend/src/features/chat/stores/chat-runtime-store.ts"
+NATIVE_CHIP = REPO / "studio/frontend/src/features/native-intents/components/native-model-chip.tsx"
+
+
+def _src(path: Path) -> str:
+    return path.read_text()
+
+
+def test_native_gguf_reload_tracks_token_expiry_and_reselects_after_expiry():
+    store_src = _src(RUNTIME_STORE)
+    page_src = _src(CHAT_PAGE)
+    hook_src = _src(RUNTIME_HOOK)
+
+    assert "activeNativePathTokenExpiresAtMs: number | null" in store_src
+    assert "nativePathTokenExpiresAtMs?: number | null" in store_src
+    assert "export function isNativePathTokenExpired" in store_src
+    assert "export function hasUsableNativePathToken" in store_src
+
+    assert "nativePathTokenExpiresAtMs: intent.path.expiresAtMs" in page_src
+    assert "hasUsableNativePathToken({" in page_src
+    assert "Pick or drop the local .gguf file again before applying settings." in page_src
+    assert "activeNativePathToken: null" in page_src
+
+    assert "isNativePathTokenExpired(nativePathTokenExpiresAtMs)" in hook_src
+    assert "Local model selection expired" in hook_src
+    assert "activeNativePathTokenExpiresAtMs: nativePathToken" in hook_src
+    assert "previousActiveNativePathTokenExpiresAtMs" in hook_src
+
+
+def test_loaded_gguf_classifier_is_shared_by_reload_and_settings_sheet():
+    store_src = _src(RUNTIME_STORE)
+    page_src = _src(CHAT_PAGE)
+    sheet_src = _src(SETTINGS_SHEET)
+
+    helper_start = store_src.index("export function hasLoadedGgufSource")
+    helper_body = store_src[helper_start : store_src.index("/** A local-disk model id", helper_start)]
+    assert "x.activeGgufVariant != null" in helper_body
+    assert "hasUsableNativePathToken" in helper_body
+    assert "x.activeNativePathTokenExpiresAtMs != null" in helper_body
+    assert 'x.params.checkpoint.toLowerCase().endsWith(".gguf")' in helper_body
+    assert "x.ggufContextLength != null" in helper_body
+
+    assert "const isLoadedGguf = hasLoadedGgufSource(state)" in page_src
+    assert "const isLoadedGguf = hasLoadedGgufSource({" in sheet_src
+
+
+def test_native_token_expiry_flows_from_intent_through_staged_loads():
+    page_src = _src(CHAT_PAGE)
+    chip_src = _src(NATIVE_CHIP)
+    staged_src = _src(STAGED_PREP)
+
+    assert "nativePathTokenExpiresAtMs: selection.nativePathTokenExpiresAtMs" in page_src
+    assert "nativePathTokenExpiresAtMs: intent.path.expiresAtMs" in page_src
+    assert "nativePathTokenExpiresAtMs: number;" in chip_src
+    assert "nativePathTokenExpiresAtMs: intent.path.expiresAtMs" in chip_src
+    assert "isNativePathTokenExpired(nativePathTokenExpiresAtMs)" in staged_src

--- a/tests/studio/test_chat_native_gguf_reload_contract.py
+++ b/tests/studio/test_chat_native_gguf_reload_contract.py
@@ -2,20 +2,65 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 
 REPO = Path(__file__).resolve().parents[2]
 CHAT_PAGE = REPO / "studio/frontend/src/features/chat/chat-page.tsx"
 SETTINGS_SHEET = REPO / "studio/frontend/src/features/chat/chat-settings-sheet.tsx"
-RUNTIME_HOOK = REPO / "studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts"
-STAGED_PREP = REPO / "studio/frontend/src/features/chat/hooks/use-staged-model-preparation.ts"
+RUNTIME_HOOK = (
+    REPO / "studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts"
+)
+STAGED_PREP = (
+    REPO / "studio/frontend/src/features/chat/hooks/use-staged-model-preparation.ts"
+)
 RUNTIME_STORE = REPO / "studio/frontend/src/features/chat/stores/chat-runtime-store.ts"
-NATIVE_CHIP = REPO / "studio/frontend/src/features/native-intents/components/native-model-chip.tsx"
+NATIVE_CHIP = (
+    REPO
+    / "studio/frontend/src/features/native-intents/components/native-model-chip.tsx"
+)
 
 
 def _src(path: Path) -> str:
     return path.read_text()
+
+
+def _minified(src: str) -> str:
+    return re.sub(r"\s+", "", src)
+
+
+def _contract(src: str) -> str:
+    return re.sub(r",(?=[})])", "", _minified(src))
+
+
+_LOCAL_MODEL_PATH_RE = re.compile(r"^(\/|\.{1,2}[\\/]|~[\\/]|[A-Za-z]:[\\/]|\\\\)")
+
+
+def _is_direct_local_gguf(model_id: str) -> bool:
+    return bool(_LOCAL_MODEL_PATH_RE.match(model_id)) and model_id.lower().endswith(
+        ".gguf"
+    )
+
+
+def _between(src: str, start_marker: str, end_marker: str) -> str:
+    start = src.index(start_marker)
+    return src[start : src.index(end_marker, start)]
+
+
+def _function_body(src: str, signature: str) -> str:
+    start = src.index(signature)
+    brace_start = src.index("{", src.index(")", start))
+    depth = 0
+    for idx in range(brace_start, len(src)):
+        char = src[idx]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : idx + 1]
+    raise AssertionError(f"Could not find end of {signature}")
 
 
 def test_native_gguf_reload_tracks_token_expiry_and_reselects_after_expiry():
@@ -30,7 +75,9 @@ def test_native_gguf_reload_tracks_token_expiry_and_reselects_after_expiry():
 
     assert "nativePathTokenExpiresAtMs: intent.path.expiresAtMs" in page_src
     assert "hasUsableNativePathToken({" in page_src
-    assert "Pick or drop the local .gguf file again before applying settings." in page_src
+    assert (
+        "Pick or drop the local .gguf file again before applying settings." in page_src
+    )
     assert "activeNativePathToken: null" in page_src
 
     assert "isNativePathTokenExpired(nativePathTokenExpiresAtMs)" in hook_src
@@ -44,15 +91,15 @@ def test_loaded_gguf_classifier_is_shared_by_reload_and_settings_sheet():
     page_src = _src(CHAT_PAGE)
     sheet_src = _src(SETTINGS_SHEET)
 
-    helper_start = store_src.index("export function hasLoadedGgufSource")
-    helper_body = store_src[
-        helper_start : store_src.index("/** A local-disk model id", helper_start)
-    ]
+    helper_body = _function_body(store_src, "export function hasLoadedGgufSource")
+    helper_contract = _contract(helper_body)
     assert "x.activeGgufVariant != null" in helper_body
     assert "hasUsableNativePathToken" in helper_body
     assert "x.activeNativePathTokenExpiresAtMs != null" in helper_body
-    assert "isLocalModelPath(x.params.checkpoint)" in helper_body
-    assert 'x.params.checkpoint.toLowerCase().endsWith(".gguf")' in helper_body
+    assert (
+        '(isLocalModelPath(x.params.checkpoint)&&x.params.checkpoint.toLowerCase().endsWith(".gguf"))'
+        in helper_contract
+    )
     assert "x.ggufContextLength != null" in helper_body
 
     assert "const isLoadedGguf = hasLoadedGgufSource(state)" in page_src
@@ -64,7 +111,9 @@ def test_native_token_expiry_flows_from_intent_through_staged_loads():
     chip_src = _src(NATIVE_CHIP)
     staged_src = _src(STAGED_PREP)
 
-    assert "nativePathTokenExpiresAtMs: selection.nativePathTokenExpiresAtMs" in page_src
+    assert (
+        "nativePathTokenExpiresAtMs: selection.nativePathTokenExpiresAtMs" in page_src
+    )
     assert "nativePathTokenExpiresAtMs: intent.path.expiresAtMs" in page_src
     assert "nativePathTokenExpiresAtMs: number;" in chip_src
     assert "nativePathTokenExpiresAtMs: intent.path.expiresAtMs" in chip_src
@@ -77,33 +126,74 @@ def test_native_display_basename_is_not_a_direct_gguf_path_on_reload():
 
     assert "isLocalModelPath," in page_src
     assert "const isDirectGguf =" in page_src
-    assert "isLocalModelPath(checkpoint)" in page_src
-    assert 'checkpoint.toLowerCase().endsWith(".gguf")' in page_src
-    assert "isLocalModelPath(x.params.checkpoint)" in store_src
+    assert (
+        'constisDirectGguf=isLocalModelPath(checkpoint)&&checkpoint.toLowerCase().endsWith(".gguf");'
+        in _minified(page_src)
+    )
+    assert (
+        '(isLocalModelPath(x.params.checkpoint)&&x.params.checkpoint.toLowerCase().endsWith(".gguf"))'
+        in _contract(_function_body(store_src, "export function hasLoadedGgufSource"))
+    )
+
+
+def test_direct_gguf_classifier_truth_table_matches_local_path_contract():
+    store_src = _src(RUNTIME_STORE)
+
+    assert (
+        r"return/^(\/|\.{1,2}[\\/]|~[\\/]|[A-Za-z]:[\\/]|\\\\)/.test(id);"
+        in _minified(store_src)
+    )
+
+    for model_id in (
+        "/models/model.gguf",
+        "./model.gguf",
+        "../models/model.gguf",
+        "~/model.GGUF",
+        r"C:\models\model.gguf",
+        r"\\server\share\model.gguf",
+    ):
+        assert _is_direct_local_gguf(model_id)
+
+    for model_id in (
+        "model.gguf",
+        "org/model.gguf",
+        "hf://org/model.gguf",
+        "/models/model.safetensors",
+        r"C:model.gguf",
+    ):
+        assert not _is_direct_local_gguf(model_id)
 
 
 def test_checkpoint_changes_clear_loaded_gguf_metadata():
     store_src = _src(RUNTIME_STORE)
 
     assert "function clearedLoadedGgufMetadata()" in store_src
-    clear_start = store_src.index("function clearedLoadedGgufMetadata()")
-    clear_body = store_src[clear_start : store_src.index("/** An uncached HF", clear_start)]
+    clear_body = _function_body(store_src, "function clearedLoadedGgufMetadata()")
     assert "activeNativePathToken: null" in clear_body
     assert "activeNativePathTokenExpiresAtMs: null" in clear_body
     assert "ggufContextLength: null" in clear_body
     assert "ggufMaxContextLength: null" in clear_body
     assert "ggufNativeContextLength: null" in clear_body
+    assert "activeGgufVariant" not in clear_body
 
-    set_params_start = store_src.index("setParams: (params)")
-    set_params_body = store_src[
-        set_params_start : store_src.index("setCustomPresets", set_params_start)
-    ]
+    set_params_body = _between(store_src, "setParams: (params)", "setCustomPresets")
+    set_params_contract = _contract(set_params_body)
     assert "checkpointChanged" in set_params_body
-    assert "...clearedLoadedGgufMetadata()" in set_params_body
+    assert (
+        "checkpointChanged?{contextUsage:null,activeGgufVariant:null,...clearedLoadedGgufMetadata()}:{}"
+        in set_params_contract
+    )
 
-    set_checkpoint_start = store_src.index("setCheckpoint: (modelId, ggufVariant)")
-    set_checkpoint_body = store_src[
-        set_checkpoint_start : store_src.index("setActiveThreadId", set_checkpoint_start)
-    ]
+    set_checkpoint_body = _between(
+        store_src, "setCheckpoint: (modelId, ggufVariant)", "setActiveThreadId"
+    )
+    set_checkpoint_contract = _contract(set_checkpoint_body)
     assert "loadedGgufSourceChanged" in set_checkpoint_body
-    assert "clearedLoadedGgufMetadata()" in set_checkpoint_body
+    assert (
+        "constloadedGgufSourceChanged=checkpointChanged||state.activeGgufVariant!==nextGgufVariant;"
+        in set_checkpoint_contract
+    )
+    assert (
+        "activeGgufVariant:nextGgufVariant,...(checkpointChanged?{contextUsage:null}:{}),...(loadedGgufSourceChanged?clearedLoadedGgufMetadata():{})"
+        in set_checkpoint_contract
+    )

--- a/tests/studio/test_chat_native_gguf_reload_contract.py
+++ b/tests/studio/test_chat_native_gguf_reload_contract.py
@@ -8,10 +8,17 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 CHAT_PAGE = REPO / "studio/frontend/src/features/chat/chat-page.tsx"
 SETTINGS_SHEET = REPO / "studio/frontend/src/features/chat/chat-settings-sheet.tsx"
-RUNTIME_HOOK = REPO / "studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts"
-STAGED_PREP = REPO / "studio/frontend/src/features/chat/hooks/use-staged-model-preparation.ts"
+RUNTIME_HOOK = (
+    REPO / "studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts"
+)
+STAGED_PREP = (
+    REPO / "studio/frontend/src/features/chat/hooks/use-staged-model-preparation.ts"
+)
 RUNTIME_STORE = REPO / "studio/frontend/src/features/chat/stores/chat-runtime-store.ts"
-NATIVE_CHIP = REPO / "studio/frontend/src/features/native-intents/components/native-model-chip.tsx"
+NATIVE_CHIP = (
+    REPO
+    / "studio/frontend/src/features/native-intents/components/native-model-chip.tsx"
+)
 
 
 def _src(path: Path) -> str:
@@ -30,7 +37,9 @@ def test_native_gguf_reload_tracks_token_expiry_and_reselects_after_expiry():
 
     assert "nativePathTokenExpiresAtMs: intent.path.expiresAtMs" in page_src
     assert "hasUsableNativePathToken({" in page_src
-    assert "Pick or drop the local .gguf file again before applying settings." in page_src
+    assert (
+        "Pick or drop the local .gguf file again before applying settings." in page_src
+    )
     assert "activeNativePathToken: null" in page_src
 
     assert "isNativePathTokenExpired(nativePathTokenExpiresAtMs)" in hook_src
@@ -51,6 +60,7 @@ def test_loaded_gguf_classifier_is_shared_by_reload_and_settings_sheet():
     assert "x.activeGgufVariant != null" in helper_body
     assert "hasUsableNativePathToken" in helper_body
     assert "x.activeNativePathTokenExpiresAtMs != null" in helper_body
+    assert "isLocalModelPath(x.params.checkpoint)" in helper_body
     assert 'x.params.checkpoint.toLowerCase().endsWith(".gguf")' in helper_body
     assert "x.ggufContextLength != null" in helper_body
 
@@ -63,7 +73,9 @@ def test_native_token_expiry_flows_from_intent_through_staged_loads():
     chip_src = _src(NATIVE_CHIP)
     staged_src = _src(STAGED_PREP)
 
-    assert "nativePathTokenExpiresAtMs: selection.nativePathTokenExpiresAtMs" in page_src
+    assert (
+        "nativePathTokenExpiresAtMs: selection.nativePathTokenExpiresAtMs" in page_src
+    )
     assert "nativePathTokenExpiresAtMs: intent.path.expiresAtMs" in page_src
     assert "nativePathTokenExpiresAtMs: number;" in chip_src
     assert "nativePathTokenExpiresAtMs: intent.path.expiresAtMs" in chip_src
@@ -72,8 +84,41 @@ def test_native_token_expiry_flows_from_intent_through_staged_loads():
 
 def test_native_display_basename_is_not_a_direct_gguf_path_on_reload():
     page_src = _src(CHAT_PAGE)
+    store_src = _src(RUNTIME_STORE)
 
     assert "isLocalModelPath," in page_src
     assert "const isDirectGguf =" in page_src
     assert "isLocalModelPath(checkpoint)" in page_src
     assert 'checkpoint.toLowerCase().endsWith(".gguf")' in page_src
+    assert "isLocalModelPath(x.params.checkpoint)" in store_src
+
+
+def test_checkpoint_changes_clear_loaded_gguf_metadata():
+    store_src = _src(RUNTIME_STORE)
+
+    assert "function clearedLoadedGgufMetadata()" in store_src
+    clear_start = store_src.index("function clearedLoadedGgufMetadata()")
+    clear_body = store_src[
+        clear_start : store_src.index("/** An uncached HF", clear_start)
+    ]
+    assert "activeNativePathToken: null" in clear_body
+    assert "activeNativePathTokenExpiresAtMs: null" in clear_body
+    assert "ggufContextLength: null" in clear_body
+    assert "ggufMaxContextLength: null" in clear_body
+    assert "ggufNativeContextLength: null" in clear_body
+
+    set_params_start = store_src.index("setParams: (params)")
+    set_params_body = store_src[
+        set_params_start : store_src.index("setCustomPresets", set_params_start)
+    ]
+    assert "checkpointChanged" in set_params_body
+    assert "...clearedLoadedGgufMetadata()" in set_params_body
+
+    set_checkpoint_start = store_src.index("setCheckpoint: (modelId, ggufVariant)")
+    set_checkpoint_body = store_src[
+        set_checkpoint_start : store_src.index(
+            "setActiveThreadId", set_checkpoint_start
+        )
+    ]
+    assert "loadedGgufSourceChanged" in set_checkpoint_body
+    assert "clearedLoadedGgufMetadata()" in set_checkpoint_body

--- a/tests/studio/test_chat_native_gguf_reload_contract.py
+++ b/tests/studio/test_chat_native_gguf_reload_contract.py
@@ -8,17 +8,10 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 CHAT_PAGE = REPO / "studio/frontend/src/features/chat/chat-page.tsx"
 SETTINGS_SHEET = REPO / "studio/frontend/src/features/chat/chat-settings-sheet.tsx"
-RUNTIME_HOOK = (
-    REPO / "studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts"
-)
-STAGED_PREP = (
-    REPO / "studio/frontend/src/features/chat/hooks/use-staged-model-preparation.ts"
-)
+RUNTIME_HOOK = REPO / "studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts"
+STAGED_PREP = REPO / "studio/frontend/src/features/chat/hooks/use-staged-model-preparation.ts"
 RUNTIME_STORE = REPO / "studio/frontend/src/features/chat/stores/chat-runtime-store.ts"
-NATIVE_CHIP = (
-    REPO
-    / "studio/frontend/src/features/native-intents/components/native-model-chip.tsx"
-)
+NATIVE_CHIP = REPO / "studio/frontend/src/features/native-intents/components/native-model-chip.tsx"
 
 
 def _src(path: Path) -> str:
@@ -37,9 +30,7 @@ def test_native_gguf_reload_tracks_token_expiry_and_reselects_after_expiry():
 
     assert "nativePathTokenExpiresAtMs: intent.path.expiresAtMs" in page_src
     assert "hasUsableNativePathToken({" in page_src
-    assert (
-        "Pick or drop the local .gguf file again before applying settings." in page_src
-    )
+    assert "Pick or drop the local .gguf file again before applying settings." in page_src
     assert "activeNativePathToken: null" in page_src
 
     assert "isNativePathTokenExpired(nativePathTokenExpiresAtMs)" in hook_src
@@ -73,9 +64,7 @@ def test_native_token_expiry_flows_from_intent_through_staged_loads():
     chip_src = _src(NATIVE_CHIP)
     staged_src = _src(STAGED_PREP)
 
-    assert (
-        "nativePathTokenExpiresAtMs: selection.nativePathTokenExpiresAtMs" in page_src
-    )
+    assert "nativePathTokenExpiresAtMs: selection.nativePathTokenExpiresAtMs" in page_src
     assert "nativePathTokenExpiresAtMs: intent.path.expiresAtMs" in page_src
     assert "nativePathTokenExpiresAtMs: number;" in chip_src
     assert "nativePathTokenExpiresAtMs: intent.path.expiresAtMs" in chip_src
@@ -98,9 +87,7 @@ def test_checkpoint_changes_clear_loaded_gguf_metadata():
 
     assert "function clearedLoadedGgufMetadata()" in store_src
     clear_start = store_src.index("function clearedLoadedGgufMetadata()")
-    clear_body = store_src[
-        clear_start : store_src.index("/** An uncached HF", clear_start)
-    ]
+    clear_body = store_src[clear_start : store_src.index("/** An uncached HF", clear_start)]
     assert "activeNativePathToken: null" in clear_body
     assert "activeNativePathTokenExpiresAtMs: null" in clear_body
     assert "ggufContextLength: null" in clear_body
@@ -116,9 +103,7 @@ def test_checkpoint_changes_clear_loaded_gguf_metadata():
 
     set_checkpoint_start = store_src.index("setCheckpoint: (modelId, ggufVariant)")
     set_checkpoint_body = store_src[
-        set_checkpoint_start : store_src.index(
-            "setActiveThreadId", set_checkpoint_start
-        )
+        set_checkpoint_start : store_src.index("setActiveThreadId", set_checkpoint_start)
     ]
     assert "loadedGgufSourceChanged" in set_checkpoint_body
     assert "clearedLoadedGgufMetadata()" in set_checkpoint_body

--- a/tests/studio/test_chat_native_gguf_reload_contract.py
+++ b/tests/studio/test_chat_native_gguf_reload_contract.py
@@ -68,3 +68,12 @@ def test_native_token_expiry_flows_from_intent_through_staged_loads():
     assert "nativePathTokenExpiresAtMs: number;" in chip_src
     assert "nativePathTokenExpiresAtMs: intent.path.expiresAtMs" in chip_src
     assert "isNativePathTokenExpired(nativePathTokenExpiresAtMs)" in staged_src
+
+
+def test_native_display_basename_is_not_a_direct_gguf_path_on_reload():
+    page_src = _src(CHAT_PAGE)
+
+    assert "isLocalModelPath," in page_src
+    assert "const isDirectGguf =" in page_src
+    assert "isLocalModelPath(checkpoint)" in page_src
+    assert 'checkpoint.toLowerCase().endsWith(".gguf")' in page_src


### PR DESCRIPTION
## Summary

Preserves local GGUF identity when Studio reloads model settings, especially after changing Context Length. Expired native path tokens now stop at the UI with a reselect prompt instead of being sent back through the reload path.

## Motivation

Local `.gguf` loads use short-lived native path tokens. The settings reload path treated those tokens like durable loaded-model identity, so Apply could try to reload with an expired token and lose the original GGUF source behavior.

Fixes #6855.

## Changes

- Adds `activeNativePathTokenExpiresAtMs` and shared GGUF/native-token helpers in `studio/frontend/src/features/chat/stores/chat-runtime-store.ts`.
- Carries native token expiry through staged selections, native model chips, and model load input.
- Blocks expired native-token loads in `use-chat-model-runtime.ts` and asks the user to pick or drop the `.gguf` again.
- Updates Apply in `chat-page.tsx` to use a shared loaded-GGUF classifier and only pass a native path token when it is still usable.
- Updates `chat-settings-sheet.tsx` to use the same loaded-GGUF classifier as the reload path.
- Skips staged GGUF metadata fetches when the staged native token is already expired.
- Adds `tests/studio/test_chat_native_gguf_reload_contract.py` to lock the reload/token-expiry contract.