### PR TITLE
Studio: allow CPU-only DiffusionGemma by granting the diffusion runner the CPU device

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -3995,8 +3995,7 @@ class LlamaCppBackend:
         # get_device_type() ("needs a GPU"), even though the shim only drives the
         # CPU visual-server binary and does no torch GPU work. Allow the CPU device
         # so the runner starts; the visual server still runs on the CPU llama.cpp build.
-        cpu_only = self._effective_gpu_count() == 0
-        if cpu_only:
+        if self._effective_gpu_count() == 0:
             env.setdefault("UNSLOTH_ALLOW_CPU", "1")
         env["DG_VISUAL_BIN"] = visual_bin
         env["DG_GPU"] = gpu
@@ -4044,9 +4043,7 @@ class LlamaCppBackend:
         self._is_audio = False  # clear any prior TTS/audio model's routing flag
         self._model_identifier = model_identifier
         self._cache_type_kv = None
-        # CPU-only diffusion holds no VRAM, so training_vram.py must not treat it
-        # as a GPU-resident model (matches the llama-server path's _classify_gpu_offload).
-        self._gpu_offload_active = not cpu_only
+        self._gpu_offload_active = True
         if hf_variant:
             self._hf_variant = hf_variant
         elif gguf_path:
@@ -4064,7 +4061,7 @@ class LlamaCppBackend:
         healthy = self._wait_for_health(timeout = 600.0)
         if healthy:
             self._healthy = True
-            self._gpu_offload_active = not cpu_only
+            self._gpu_offload_active = True
             if extra_args is not None:
                 self._extra_args = list(extra_args)
                 self._extra_args_source = (model_identifier, hf_variant)

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -3991,6 +3991,12 @@ class LlamaCppBackend:
         # refuses to load unless UNSLOTH_IS_PRESENT is set (normally by `import
         # unsloth`). The shim never imports unsloth, so set it here as unsloth does.
         env["UNSLOTH_IS_PRESENT"] = "1"
+        # On a GPU-less host the shim's `import unsloth_zoo` aborts in
+        # get_device_type() ("needs a GPU"), even though the shim only drives the
+        # CPU visual-server binary and does no torch GPU work. Allow the CPU device
+        # so the runner starts; the visual server still runs on the CPU llama.cpp build.
+        if self._effective_gpu_count() == 0:
+            env.setdefault("UNSLOTH_ALLOW_CPU", "1")
         env["DG_VISUAL_BIN"] = visual_bin
         env["DG_GPU"] = gpu
         # The file-override shim imports its sibling visual_engine; put its dir on PYTHONPATH.

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -3995,7 +3995,8 @@ class LlamaCppBackend:
         # get_device_type() ("needs a GPU"), even though the shim only drives the
         # CPU visual-server binary and does no torch GPU work. Allow the CPU device
         # so the runner starts; the visual server still runs on the CPU llama.cpp build.
-        if self._effective_gpu_count() == 0:
+        cpu_only = self._effective_gpu_count() == 0
+        if cpu_only:
             env.setdefault("UNSLOTH_ALLOW_CPU", "1")
         env["DG_VISUAL_BIN"] = visual_bin
         env["DG_GPU"] = gpu
@@ -4043,7 +4044,9 @@ class LlamaCppBackend:
         self._is_audio = False  # clear any prior TTS/audio model's routing flag
         self._model_identifier = model_identifier
         self._cache_type_kv = None
-        self._gpu_offload_active = True
+        # CPU-only diffusion holds no VRAM, so training_vram.py must not treat it
+        # as a GPU-resident model (matches the llama-server path's _classify_gpu_offload).
+        self._gpu_offload_active = not cpu_only
         if hf_variant:
             self._hf_variant = hf_variant
         elif gguf_path:
@@ -4061,7 +4064,7 @@ class LlamaCppBackend:
         healthy = self._wait_for_health(timeout = 600.0)
         if healthy:
             self._healthy = True
-            self._gpu_offload_active = True
+            self._gpu_offload_active = not cpu_only
             if extra_args is not None:
                 self._extra_args = list(extra_args)
                 self._extra_args_source = (model_identifier, hf_variant)

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -3971,7 +3971,11 @@ class LlamaCppBackend:
         # Auto-size (0): the visual server probes the largest context that fits this GPU's VRAM
         # (capped at the training context). An explicit in-range n_ctx overrides it.
         maxtok = n_ctx if (n_ctx and 0 < n_ctx <= 65536) else 0
-        gpu = os.environ.get("DG_GPU", "0")
+        # No visible CUDA GPU: a genuine CPU host, or a GPU host masked with
+        # CUDA_VISIBLE_DEVICES="" to force CPU serving. Keep the visual-server child
+        # CPU-masked (empty --gpu) so the shim does not re-expose GPU 0 via its default.
+        cpu_only = self._effective_gpu_count() == 0
+        gpu = "" if cpu_only else os.environ.get("DG_GPU", "0")
 
         cmd = list(shim_cmd) + [
             "--gguf",
@@ -3991,11 +3995,11 @@ class LlamaCppBackend:
         # refuses to load unless UNSLOTH_IS_PRESENT is set (normally by `import
         # unsloth`). The shim never imports unsloth, so set it here as unsloth does.
         env["UNSLOTH_IS_PRESENT"] = "1"
-        # On a GPU-less host the shim's `import unsloth_zoo` aborts in
-        # get_device_type() ("needs a GPU"), even though the shim only drives the
-        # CPU visual-server binary and does no torch GPU work. Allow the CPU device
-        # so the runner starts; the visual server still runs on the CPU llama.cpp build.
-        if self._effective_gpu_count() == 0:
+        # The shim's `import unsloth_zoo` aborts in get_device_type() ("needs a GPU")
+        # when no accelerator is visible, even though it only drives the CPU
+        # visual-server binary and does no torch GPU work. Allow the CPU device so the
+        # runner starts; the visual server still runs on the CPU llama.cpp build.
+        if cpu_only:
             env.setdefault("UNSLOTH_ALLOW_CPU", "1")
         env["DG_VISUAL_BIN"] = visual_bin
         env["DG_GPU"] = gpu


### PR DESCRIPTION
Lets DiffusionGemma GGUFs run in Studio on CPU-only hosts. Complements #6311 (which routes CPU hosts to the fork's CPU bundle that ships the DiffusionGemma binaries) by removing the last blocker on that path.

## Problem

On a GPU-less host, loading a DiffusionGemma GGUF fails at load time:

```
Failed to load GGUF model: ... llama-server exited with code 1
  File ".../unsloth_zoo/__init__.py", line 333, in <module>
  File ".../unsloth_zoo/device_type.py", line 235, in get_device_type
NotImplementedError: Unsloth cannot find any torch accelerator? You need a GPU.
```

The diffusion runner is launched as `python -m unsloth_zoo.diffusion_studio.shim`. Importing `unsloth_zoo` runs `device_type.get_device_type()` at module import, which aborts when no accelerator is visible. This happens even though the shim only drives the `llama-diffusion-gemma-visual-server` subprocess and does no torch GPU work itself, and even though the visual-server binary and the model run fine on CPU.

## Fix

In `_start_diffusion_server`, when the host has no usable GPU, set `UNSLOTH_ALLOW_CPU=1` in the runner's child env (via `setdefault`, so an explicit user value still wins). This is the same env-priming pattern already used one line above for `UNSLOTH_IS_PRESENT`. On GPU hosts nothing changes.

```python
if self._effective_gpu_count() == 0:
    env.setdefault("UNSLOTH_ALLOW_CPU", "1")
```

## Verification

Tested end-to-end CPU-only (GPUs hidden via `CUDA_VISIBLE_DEVICES=""`) with the fork's CPU prebuilt (`b9909-mix-53618c5`, `linux-x64-cpu`):

- Before: load fails with the `get_device_type()` error above.
- After: `unsloth/diffusiongemma-26B-A4B-it-GGUF` (Q4_K_M) loads on CPU (~20s), and an OpenAI-compat request with tools returns a structured `tool_calls` array (`finish_reason: tool_calls`, `get_weather(location="San Francisco")`).
- The visual-server log confirms pure CPU: `loaded CPU backend from .../libggml-cpu-sapphirerapids.so`, every `layer N assigned to device CPU`, no CUDA.

Plain (non-diffusion) GGUF and GPU DiffusionGemma paths are unchanged.
