### PR TITLE
Fix Backend CI: add has_blackwell_gpu to the mlx worker test stub

### DIFF
--- a/studio/backend/tests/test_mlx_training_worker_config.py
+++ b/studio/backend/tests/test_mlx_training_worker_config.py
@@ -37,6 +37,7 @@ def _load_worker_module():
         for name in (
             "direct_wheel_url",
             "flash_attn_wheel_url",
+            "has_blackwell_gpu",
             "install_wheel",
             "probe_torch_wheel_env",
             "url_exists",


### PR DESCRIPTION
## Summary

#6970 restored `has_blackwell_gpu` in `studio/backend/utils/wheel_utils.py` and re-added its import in `studio/backend/core/training/worker.py`, but the mlx worker test's `_load_worker_module` stubs `utils.wheel_utils` with a fixed name tuple that did not include `has_blackwell_gpu`. Loading the worker against that stub raised `ImportError: cannot import name 'has_blackwell_gpu' from 'utils.wheel_utils' (unknown location)`, so Backend CI could not collect `studio/backend/tests/test_mlx_training_worker_config.py` on any of Python 3.10 to 3.13.

This adds `has_blackwell_gpu` to the stub tuple so it matches `worker.py`'s imports, restoring the consistent state the file had before the name was dropped.

## Verification

- Reproduced the exact collection error locally: `cannot import name 'has_blackwell_gpu' from 'utils.wheel_utils' (unknown location)`.
- With the fix, `test_mlx_training_worker_config.py` collects and its tests pass (the one unrelated failure I saw locally is a bitsandbytes/CUDA setup issue on a GPU box; it does not occur under the CPU torch the Backend CI installs).
- One line, test-only change; matches the other importers (`worker.py`, `install_python_stack.py`) that already list `has_blackwell_gpu`.
