### PR TITLE
Stabilize floating monitor drag

### DIFF
--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -1374,12 +1374,14 @@ jobs:
 
       - name: Assert Visual Studio + CMake are genuinely undetectable
         shell: pwsh
-        env:
-          ProgramFiles: ${{ env.NO_BUILD_TOOLS_PROGRAMFILES }}
-          ProgramFiles(x86): ${{ env.NO_BUILD_TOOLS_PROGRAMFILES_X86 }}
-          Path: ${{ env.NO_BUILD_TOOLS_PATH }}
         run: |
           $ErrorActionPreference = 'Stop'
+          # Set in-script: the runner does not apply step-level env keys with
+          # parentheses (`ProgramFiles(x86)`), so vswhere still found VS.
+          if (-not $env:NO_BUILD_TOOLS_PROGRAMFILES) { Write-Error "NO_BUILD_TOOLS_* env missing (Prepare step did not run?)"; exit 1 }
+          $env:ProgramFiles = $env:NO_BUILD_TOOLS_PROGRAMFILES
+          ${env:ProgramFiles(x86)} = $env:NO_BUILD_TOOLS_PROGRAMFILES_X86
+          $env:Path = $env:NO_BUILD_TOOLS_PATH
           . (Join-Path $env:GITHUB_WORKSPACE 'tests/studio_setup_ps1/Get-FunctionSource.ps1')
           $setup = Join-Path $env:GITHUB_WORKSPACE 'studio/setup.ps1'
           foreach ($fn in @('Resolve-VsGeneratorFromLabel', 'Find-VsBuildTools')) {
@@ -1403,10 +1405,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
-          ProgramFiles: ${{ env.NO_BUILD_TOOLS_PROGRAMFILES }}
-          ProgramFiles(x86): ${{ env.NO_BUILD_TOOLS_PROGRAMFILES_X86 }}
-          Path: ${{ env.NO_BUILD_TOOLS_PATH }}
         run: |
+          # Set in-script (see the assert step); child processes inherit these.
+          $env:ProgramFiles = $env:NO_BUILD_TOOLS_PROGRAMFILES
+          ${env:ProgramFiles(x86)} = $env:NO_BUILD_TOOLS_PROGRAMFILES_X86
+          $env:Path = $env:NO_BUILD_TOOLS_PATH
           New-Item -ItemType Directory -Force -Path logs | Out-Null
           $ProgressPreference = 'SilentlyContinue'
           & ./install.ps1 --local --no-torch *>&1 | Tee-Object -FilePath logs/install.log
@@ -1595,19 +1598,28 @@ jobs:
           echo "Windows CUDA and ROCm prebuilts are available -- GPU users get them without compiling."
 
       - name: The prebuilt resolver runs without Visual Studio
+        shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ProgramFiles: ${{ env.NO_BUILD_TOOLS_PROGRAMFILES }}
-          ProgramFiles(x86): ${{ env.NO_BUILD_TOOLS_PROGRAMFILES_X86 }}
-          Path: ${{ env.NO_BUILD_TOOLS_PATH }}
         run: |
+          $ErrorActionPreference = 'Stop'
+          # pwsh: bash cannot export `ProgramFiles(x86)`; set in-script so the
+          # python child inherits the overrides.
+          $env:ProgramFiles = $env:NO_BUILD_TOOLS_PROGRAMFILES
+          ${env:ProgramFiles(x86)} = $env:NO_BUILD_TOOLS_PROGRAMFILES_X86
+          $env:Path = $env:NO_BUILD_TOOLS_PATH
           # Resolver-only (no GPU on hosted runners, so the host resolves to the
           # CPU bundle). The point is that resolution needs no compiler/VS.
           python -m pip install --upgrade huggingface_hub
-          python studio/install_llama_prebuilt.py --resolve-prebuilt latest --output-format json > /tmp/resolve.json || {
-            echo "::error::resolver exited non-zero"; cat /tmp/resolve.json || true; exit 1; }
-          cat /tmp/resolve.json
-          echo "Prebuilt resolver ran with no Visual Studio present."
+          if ($LASTEXITCODE -ne 0) { Write-Host "::error::pip install huggingface_hub failed"; exit 1 }
+          python studio/install_llama_prebuilt.py --resolve-prebuilt latest --output-format json > resolve.json
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::resolver exited non-zero"
+            if (Test-Path resolve.json) { Get-Content resolve.json }
+            exit 1
+          }
+          Get-Content resolve.json
+          Write-Host "Prebuilt resolver ran with no Visual Studio present."
 
       - name: Clean no-build-tools simulation
         if: always()

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -1334,40 +1334,50 @@ jobs:
             try { Add-MpPreference -ExclusionPath $p -ErrorAction Stop } catch { }
           }
 
-      - name: Hide Visual Studio + CMake (simulate a host with no build tools)
+      - name: Prepare no-build-tools simulation
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          # A Program Files dir can hold a transient handle (Defender / MSBuild node)
-          # so Rename-Item intermittently fails with "Access is denied"; retry to ride it out.
-          function Rename-WithRetry($Path, $NewName) {
-            for ($i = 1; $i -le 6; $i++) {
-              try { Rename-Item -LiteralPath $Path -NewName $NewName -ErrorAction Stop; return }
-              catch { if ($i -eq 6) { throw }; Start-Sleep -Seconds 3 }
+          $root = Join-Path $env:GITHUB_WORKSPACE 'no-build-tools'
+          $pf = Join-Path $root 'ProgramFiles'
+          $pfx86 = Join-Path $root 'ProgramFilesx86'
+          New-Item -ItemType Directory -Force -Path $pf, $pfx86 | Out-Null
+
+          $blocked = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+          foreach ($tool in @('cmake', 'cl.exe')) {
+            foreach ($cmd in (Get-Command $tool -All -ErrorAction SilentlyContinue)) {
+              if ($cmd.Source) {
+                $dir = Split-Path -Parent $cmd.Source
+                if ($dir) { [void] $blocked.Add($dir) }
+              }
             }
           }
-          # Rename the Visual Studio install roots (incl. the Installer that holds
-          # vswhere.exe) so Find-VsBuildTools' vswhere + filesystem scan both miss.
-          foreach ($d in @("$env:ProgramFiles\Microsoft Visual Studio", "${env:ProgramFiles(x86)}\Microsoft Visual Studio")) {
-            if (Test-Path -LiteralPath $d) {
-              Rename-WithRetry $d ((Split-Path $d -Leaf) + '.vsoff')
-              Write-Host "Hid VS: $d"
-            }
+
+          $pathParts = $env:Path -split [IO.Path]::PathSeparator |
+            Where-Object { $_ -and -not $blocked.Contains($_) }
+          $noBuildToolsPath = $pathParts -join [IO.Path]::PathSeparator
+
+          "NO_BUILD_TOOLS_PROGRAMFILES=$pf" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "NO_BUILD_TOOLS_PROGRAMFILES_X86=$pfx86" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "NO_BUILD_TOOLS_PATH<<NO_BUILD_TOOLS_PATH_EOF" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          $noBuildToolsPath | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "NO_BUILD_TOOLS_PATH_EOF" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+          Write-Host "ProgramFiles simulation root: $pf"
+          Write-Host "ProgramFiles(x86) simulation root: $pfx86"
+          if ($blocked.Count -gt 0) {
+            Write-Host "Removed build-tool PATH dirs:"
+            $blocked | Sort-Object | ForEach-Object { Write-Host "  $_" }
+          } else {
+            Write-Host "No cmake or cl.exe PATH dirs found to remove."
           }
-          # Surgically rename each cmake executable on PATH (not its parent dir --
-          # cmake can share a dir with other shims) so Get-Command cmake fails.
-          $hidden = @()
-          foreach ($c in (Get-Command cmake -All -ErrorAction SilentlyContinue)) {
-            if ($c.Source -and (Test-Path -LiteralPath $c.Source)) {
-              Rename-WithRetry $c.Source ((Split-Path $c.Source -Leaf) + '.off')
-              $hidden += $c.Source
-              Write-Host "Hid cmake: $($c.Source)"
-            }
-          }
-          ("HIDDEN_CMAKE=" + ($hidden -join '|')) | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
       - name: Assert Visual Studio + CMake are genuinely undetectable
         shell: pwsh
+        env:
+          ProgramFiles: ${{ env.NO_BUILD_TOOLS_PROGRAMFILES }}
+          ProgramFiles(x86): ${{ env.NO_BUILD_TOOLS_PROGRAMFILES_X86 }}
+          Path: ${{ env.NO_BUILD_TOOLS_PATH }}
         run: |
           $ErrorActionPreference = 'Stop'
           . (Join-Path $env:GITHUB_WORKSPACE 'tests/studio_setup_ps1/Get-FunctionSource.ps1')
@@ -1393,6 +1403,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Withheld on PR: this step runs checked-out PR code; public GGUF still downloads.
           HF_TOKEN: ${{ github.event_name != 'pull_request' && secrets.HF_TOKEN || '' }}
+          ProgramFiles: ${{ env.NO_BUILD_TOOLS_PROGRAMFILES }}
+          ProgramFiles(x86): ${{ env.NO_BUILD_TOOLS_PROGRAMFILES_X86 }}
+          Path: ${{ env.NO_BUILD_TOOLS_PATH }}
         run: |
           New-Item -ItemType Directory -Force -Path logs | Out-Null
           $ProgressPreference = 'SilentlyContinue'
@@ -1480,19 +1493,11 @@ jobs:
           [ -n "$CONTENT" ] && [ "$CONTENT" != "null" ] || { echo "::error::empty completion"; exit 1; }
           echo "Inference OK without Visual Studio: $CONTENT"
 
-      - name: Restore Visual Studio + CMake
+      - name: Clean no-build-tools simulation
         if: always()
         shell: pwsh
         run: |
-          foreach ($d in @("$env:ProgramFiles\Microsoft Visual Studio", "${env:ProgramFiles(x86)}\Microsoft Visual Studio")) {
-            $off = "$d.vsoff"
-            if (Test-Path -LiteralPath $off) { Rename-Item -LiteralPath $off -NewName (Split-Path $d -Leaf); Write-Host "Restored $d" }
-          }
-          if ($env:HIDDEN_CMAKE) {
-            foreach ($src in ($env:HIDDEN_CMAKE -split '\|')) {
-              if ($src -and (Test-Path -LiteralPath "$src.off")) { Rename-Item -LiteralPath "$src.off" -NewName (Split-Path $src -Leaf) }
-            }
-          }
+          Remove-Item -LiteralPath (Join-Path $env:GITHUB_WORKSPACE 'no-build-tools') -Recurse -Force -ErrorAction SilentlyContinue
 
       - name: Stop Studio
         if: always()
@@ -1540,21 +1545,34 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Hide Visual Studio
+      - name: Prepare no-build-tools simulation
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          # Retry the rename: a Program Files dir can hold a transient handle that
-          # makes Rename-Item intermittently fail with "Access is denied".
-          function Rename-WithRetry($Path, $NewName) {
-            for ($i = 1; $i -le 6; $i++) {
-              try { Rename-Item -LiteralPath $Path -NewName $NewName -ErrorAction Stop; return }
-              catch { if ($i -eq 6) { throw }; Start-Sleep -Seconds 3 }
+          $root = Join-Path $env:GITHUB_WORKSPACE 'no-build-tools'
+          $pf = Join-Path $root 'ProgramFiles'
+          $pfx86 = Join-Path $root 'ProgramFilesx86'
+          New-Item -ItemType Directory -Force -Path $pf, $pfx86 | Out-Null
+
+          $blocked = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+          foreach ($tool in @('cmake', 'cl.exe')) {
+            foreach ($cmd in (Get-Command $tool -All -ErrorAction SilentlyContinue)) {
+              if ($cmd.Source) {
+                $dir = Split-Path -Parent $cmd.Source
+                if ($dir) { [void] $blocked.Add($dir) }
+              }
             }
           }
-          foreach ($d in @("$env:ProgramFiles\Microsoft Visual Studio", "${env:ProgramFiles(x86)}\Microsoft Visual Studio")) {
-            if (Test-Path -LiteralPath $d) { Rename-WithRetry $d ((Split-Path $d -Leaf) + '.vsoff'); Write-Host "Hid VS: $d" }
-          }
+
+          $pathParts = $env:Path -split [IO.Path]::PathSeparator |
+            Where-Object { $_ -and -not $blocked.Contains($_) }
+          $noBuildToolsPath = $pathParts -join [IO.Path]::PathSeparator
+
+          "NO_BUILD_TOOLS_PROGRAMFILES=$pf" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "NO_BUILD_TOOLS_PROGRAMFILES_X86=$pfx86" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "NO_BUILD_TOOLS_PATH<<NO_BUILD_TOOLS_PATH_EOF" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          $noBuildToolsPath | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "NO_BUILD_TOOLS_PATH_EOF" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
       - name: Windows CUDA and ROCm prebuilts exist in unslothai/llama.cpp (what GPU users download, no VS)
         env:
@@ -1579,6 +1597,9 @@ jobs:
       - name: The prebuilt resolver runs without Visual Studio
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ProgramFiles: ${{ env.NO_BUILD_TOOLS_PROGRAMFILES }}
+          ProgramFiles(x86): ${{ env.NO_BUILD_TOOLS_PROGRAMFILES_X86 }}
+          Path: ${{ env.NO_BUILD_TOOLS_PATH }}
         run: |
           # Resolver-only (no GPU on hosted runners, so the host resolves to the
           # CPU bundle). The point is that resolution needs no compiler/VS.
@@ -1588,14 +1609,11 @@ jobs:
           cat /tmp/resolve.json
           echo "Prebuilt resolver ran with no Visual Studio present."
 
-      - name: Restore Visual Studio
+      - name: Clean no-build-tools simulation
         if: always()
         shell: pwsh
         run: |
-          foreach ($d in @("$env:ProgramFiles\Microsoft Visual Studio", "${env:ProgramFiles(x86)}\Microsoft Visual Studio")) {
-            $off = "$d.vsoff"
-            if (Test-Path -LiteralPath $off) { Rename-Item -LiteralPath $off -NewName (Split-Path $d -Leaf); Write-Host "Restored $d" }
-          }
+          Remove-Item -LiteralPath (Join-Path $env:GITHUB_WORKSPACE 'no-build-tools') -Recurse -Force -ErrorAction SilentlyContinue
 
   # ── folded from studio-setup-ps1-vs2026.yml: setup.ps1 unit tests + real-VS detection + vcredist ──
   pester:

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -1348,14 +1348,35 @@ jobs:
             foreach ($cmd in (Get-Command $tool -All -ErrorAction SilentlyContinue)) {
               if ($cmd.Source) {
                 $dir = Split-Path -Parent $cmd.Source
-                if ($dir) { [void] $blocked.Add($dir) }
+                if ($dir) {
+                  [void] $blocked.Add(
+                    [Environment]::ExpandEnvironmentVariables($dir).Trim().Trim('"').TrimEnd('\'))
+                }
               }
             }
           }
+          # Normalized comparison so registry spellings (trailing slash,
+          # unexpanded %VAR%) still match.
+          function Test-Blocked([string]$p) {
+            $n = [Environment]::ExpandEnvironmentVariables($p).Trim().Trim('"').TrimEnd('\')
+            return $blocked.Contains($n)
+          }
 
           $pathParts = $env:Path -split [IO.Path]::PathSeparator |
-            Where-Object { $_ -and -not $blocked.Contains($_) }
+            Where-Object { $_ -and -not (Test-Blocked $_) }
           $noBuildToolsPath = $pathParts -join [IO.Path]::PathSeparator
+
+          # install.ps1's Refresh-SessionPath and setup.ps1's Refresh-Environment
+          # rebuild the session Path from these scopes mid-install, so filter
+          # them too. Originals are saved for the cleanup step.
+          foreach ($scope in @('Machine', 'User')) {
+            $orig = [Environment]::GetEnvironmentVariable('Path', $scope)
+            if (-not $orig) { continue }
+            Set-Content -LiteralPath (Join-Path $root "orig-path-$scope.txt") -Value $orig -NoNewline
+            $kept = ($orig -split ';' | Where-Object { $_ -and -not (Test-Blocked $_) }) -join ';'
+            [Environment]::SetEnvironmentVariable('Path', $kept, $scope)
+            Write-Host "Filtered $scope Path scope."
+          }
 
           "NO_BUILD_TOOLS_PROGRAMFILES=$pf" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           "NO_BUILD_TOOLS_PROGRAMFILES_X86=$pfx86" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
@@ -1500,7 +1521,15 @@ jobs:
         if: always()
         shell: pwsh
         run: |
-          Remove-Item -LiteralPath (Join-Path $env:GITHUB_WORKSPACE 'no-build-tools') -Recurse -Force -ErrorAction SilentlyContinue
+          $root = Join-Path $env:GITHUB_WORKSPACE 'no-build-tools'
+          foreach ($scope in @('Machine', 'User')) {
+            $saved = Join-Path $root "orig-path-$scope.txt"
+            if (Test-Path -LiteralPath $saved) {
+              [Environment]::SetEnvironmentVariable('Path', (Get-Content -LiteralPath $saved -Raw), $scope)
+              Write-Host "Restored $scope Path scope."
+            }
+          }
+          Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
 
       - name: Stop Studio
         if: always()

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -81,7 +81,6 @@ import {
   TestTube01Icon,
   ZapIcon,
 } from "@hugeicons/core-free-icons";
-import { listStoredChatThreads } from "@/features/chat/utils/chat-history-storage";
 import {
   Tooltip,
   TooltipContent,
@@ -97,6 +96,7 @@ import {
   createChatProject,
   deleteChatProject,
   deleteChatItem,
+  listStoredChatThreads,
   moveChatItemToProject,
   renameChatItem,
   renameChatProject,
@@ -582,7 +582,14 @@ export function AppSidebar() {
   useEffect(() => {
     if (!pendingRename) return;
     const match = allChatItems.find((i) => i.id === pendingRename.id);
-    if (match && match.title === pendingRename.title) setPendingRename(null);
+    if (!match || match.title !== pendingRename.title) return;
+    queueMicrotask(() => {
+      setPendingRename((current) =>
+        current?.id === pendingRename.id && current.title === pendingRename.title
+          ? null
+          : current,
+      );
+    });
   }, [allChatItems, pendingRename]);
   const [creatingProject, setCreatingProject] = useState(false);
   const [projectNameDraft, setProjectNameDraft] = useState("");
@@ -679,12 +686,6 @@ export function AppSidebar() {
   const [confirmingDelete, setConfirmingDelete] =
     useState<DeleteTarget | null>(null);
   const [deleteProjectFiles, setDeleteProjectFiles] = useState(false);
-
-  useEffect(() => {
-    if (confirmingDelete?.kind !== "project") {
-      setDeleteProjectFiles(false);
-    }
-  }, [confirmingDelete]);
 
   async function commitDelete() {
     const target = confirmingDelete;
@@ -1572,9 +1573,6 @@ export function AppSidebar() {
                   >
                     <HugeiconsIcon icon={Globe02Icon} strokeWidth={1.75} className="size-[18px]" />
                     <span>{t("shell.navigation.api")}</span>
-                    <span className="ml-auto rounded-full bg-emerald-500/10 px-2 py-1 text-[10px] leading-none font-semibold text-emerald-700 dark:text-emerald-300">
-                      {t("common.new")}
-                    </span>
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     ref={anchorRef as React.Ref<HTMLDivElement>}

--- a/studio/frontend/src/components/floating-monitor.tsx
+++ b/studio/frontend/src/components/floating-monitor.tsx
@@ -8,8 +8,8 @@ import { useSystemInfo } from "@/hooks/use-system";
 import { useT } from "@/i18n";
 import { cn } from "@/lib/utils";
 import { CpuIcon, GripVerticalIcon, XIcon } from "lucide-react";
-import { motion, useDragControls } from "motion/react";
-import { useRef, type PointerEvent } from "react";
+import { AnimatePresence, motion, useDragControls } from "motion/react";
+import { useMemo, useState, type PointerEvent } from "react";
 
 function clampPercent(value: number): number {
   return Math.max(0, Math.min(100, value));
@@ -39,15 +39,18 @@ export function FloatingMonitor() {
   const { isOpen, setIsOpen } = useMonitorOverlayStore();
   const systemInfo = useSystemInfo({ enabled: isOpen, pollMs: 5000 });
 
-  const constraintsRef = useRef<HTMLDivElement>(null);
+  const [constraintsElement, setConstraintsElement] =
+    useState<HTMLDivElement | null>(null);
+  const constraintsRef = useMemo(
+    () => ({ current: constraintsElement }),
+    [constraintsElement],
+  );
   const dragControls = useDragControls();
 
   function startDrag(event: PointerEvent<HTMLDivElement>) {
     event.preventDefault();
     dragControls.start(event);
   }
-
-  if (!isOpen) return null;
 
   const ramTotal = systemInfo.memory?.total_gb ?? 0;
   const ramAvailable = systemInfo.memory?.available_gb ?? 0;
@@ -70,103 +73,107 @@ export function FloatingMonitor() {
   const hasGpu = (systemInfo.gpu?.available ?? false) && devices.length > 0;
 
   return (
-    <div
-      ref={constraintsRef}
-      className="fixed inset-0 z-50 pointer-events-none"
-    >
-      <motion.div
-        drag={true}
-        dragControls={dragControls}
-        dragListener={false}
-        dragConstraints={constraintsRef}
-        dragElastic={0}
-        dragMomentum={false}
-        initial={{ opacity: 0, scale: 0.9 }}
-        animate={{ opacity: 1, scale: 1 }}
-        exit={{ opacity: 0, scale: 0.9 }}
-        className="settings-surface fixed bottom-4 right-4 w-64 max-w-[calc(100vw-2rem)] resize overflow-hidden rounded-xl border border-border/70 p-3 shadow-border ring-0 backdrop-blur-sm pointer-events-auto cursor-default select-none"
-      >
-        <div className="mb-2 flex items-center justify-between gap-2 border-b border-border/60 pb-2">
-          <div className="flex min-w-0 flex-1 items-center gap-1.5 truncate text-xs font-semibold text-foreground">
-            <CpuIcon className="size-3.5 shrink-0 text-primary" />
-            <span className="truncate">
-              {t("settings.resources.liveMonitor.title")}
-            </span>
-          </div>
-          <div className="flex items-center gap-1 shrink-0">
-            <div
-              onPointerDown={startDrag}
-              className="touch-none cursor-grab rounded-md px-1 text-muted-foreground/60 transition-colors hover:bg-muted/60 hover:text-muted-foreground active:cursor-grabbing"
-            >
-              <GripVerticalIcon className="size-3.5" />
-            </div>
-
-            <Button
-              size="icon-xs"
-              variant="ghost"
-              className="text-muted-foreground hover:text-foreground"
-              onClick={() => setIsOpen(false)}
-              title={t("common.close")}
-              aria-label={t("common.close")}
-            >
-              <XIcon className="size-3" />
-            </Button>
-          </div>
-        </div>
-
-        <motion.div
-          initial={{ opacity: 0, height: 0 }}
-          animate={{ opacity: 1, height: "auto" }}
-          exit={{ opacity: 0, height: 0 }}
-          className="space-y-3 overflow-hidden"
+    <AnimatePresence>
+      {isOpen && (
+        <div
+          ref={setConstraintsElement}
+          className="fixed inset-0 z-50 pointer-events-none"
         >
-          <div className="space-y-1">
-            <div className="flex justify-between text-[11px] font-medium font-mono">
-              <span>{t("settings.resources.liveMonitor.ram")}</span>
-              <span className={cn("tabular-nums", usageTextClass(ramPercent))}>
-                {Math.round(ramPercent)}%
-              </span>
-            </div>
-            <div className="text-xs text-muted-foreground font-mono tabular-nums">
-              {formatGiB(ramUsed)} / {formatGiB(ramTotal)}
-            </div>
-            <Progress
-              value={ramPercent}
-              className="mt-1 h-1.5 rounded-full bg-muted"
-              indicatorClassName={usageIndicatorClass(ramPercent)}
-            />
-          </div>
-
-          {hasGpu && (
-            <div className="space-y-1">
-              <div className="flex justify-between text-[11px] font-medium font-mono">
-                <span className="truncate flex-1 pr-2">
-                  {t("settings.resources.liveMonitor.vram")}{" "}
-                  {devices.length > 1
-                    ? `(${devices.length} GPUs)`
-                    : `(${devices[0].name ?? "GPU"})`}
+          <motion.div
+            drag={true}
+            dragControls={dragControls}
+            dragListener={false}
+            dragConstraints={constraintsRef}
+            dragElastic={0}
+            dragMomentum={false}
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.9 }}
+            className="settings-surface fixed bottom-4 right-4 w-64 max-w-[calc(100vw-2rem)] resize overflow-hidden rounded-xl border border-border/70 p-3 shadow-border ring-0 backdrop-blur-sm pointer-events-auto cursor-default select-none"
+          >
+            <div className="mb-2 flex items-center justify-between gap-2 border-b border-border/60 pb-2">
+              <div className="flex min-w-0 flex-1 items-center gap-1.5 truncate text-xs font-semibold text-foreground">
+                <CpuIcon className="size-3.5 shrink-0 text-primary" />
+                <span className="truncate">
+                  {t("settings.resources.liveMonitor.title")}
                 </span>
-                <span
-                  className={cn(
-                    "shrink-0 tabular-nums",
-                    usageTextClass(vramPercent),
-                  )}
+              </div>
+              <div className="flex items-center gap-1 shrink-0">
+                <div
+                  onPointerDown={startDrag}
+                  className="touch-none cursor-grab rounded-md px-1 text-muted-foreground/60 transition-colors hover:bg-muted/60 hover:text-muted-foreground active:cursor-grabbing"
                 >
-                  {Math.round(vramPercent)}%
-                </span>
+                  <GripVerticalIcon className="size-3.5" />
+                </div>
+
+                <Button
+                  size="icon-xs"
+                  variant="ghost"
+                  className="text-muted-foreground hover:text-foreground"
+                  onClick={() => setIsOpen(false)}
+                  title={t("common.close")}
+                  aria-label={t("common.close")}
+                >
+                  <XIcon className="size-3" />
+                </Button>
               </div>
-              <div className="text-xs text-muted-foreground font-mono tabular-nums">
-                {formatGiB(vramUsed)} / {formatGiB(vramTotal)}
-              </div>
-              <Progress
-                value={vramPercent}
-                className="mt-1 h-1.5 rounded-full bg-muted"
-                indicatorClassName={usageIndicatorClass(vramPercent)}
-              />
             </div>
-          )}
-        </motion.div>
-      </motion.div>
-    </div>
+
+            <motion.div
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: "auto" }}
+              exit={{ opacity: 0, height: 0 }}
+              className="space-y-3 overflow-hidden"
+            >
+              <div className="space-y-1">
+                <div className="flex justify-between text-[11px] font-medium font-mono">
+                  <span>{t("settings.resources.liveMonitor.ram")}</span>
+                  <span className={cn("tabular-nums", usageTextClass(ramPercent))}>
+                    {Math.round(ramPercent)}%
+                  </span>
+                </div>
+                <div className="text-xs text-muted-foreground font-mono tabular-nums">
+                  {formatGiB(ramUsed)} / {formatGiB(ramTotal)}
+                </div>
+                <Progress
+                  value={ramPercent}
+                  className="mt-1 h-1.5 rounded-full bg-muted"
+                  indicatorClassName={usageIndicatorClass(ramPercent)}
+                />
+              </div>
+
+              {hasGpu && (
+                <div className="space-y-1">
+                  <div className="flex justify-between text-[11px] font-medium font-mono">
+                    <span className="truncate flex-1 pr-2">
+                      {t("settings.resources.liveMonitor.vram")}{" "}
+                      {devices.length > 1
+                        ? `(${devices.length} GPUs)`
+                        : `(${devices[0].name ?? "GPU"})`}
+                    </span>
+                    <span
+                      className={cn(
+                        "shrink-0 tabular-nums",
+                        usageTextClass(vramPercent),
+                      )}
+                    >
+                      {Math.round(vramPercent)}%
+                    </span>
+                  </div>
+                  <div className="text-xs text-muted-foreground font-mono tabular-nums">
+                    {formatGiB(vramUsed)} / {formatGiB(vramTotal)}
+                  </div>
+                  <Progress
+                    value={vramPercent}
+                    className="mt-1 h-1.5 rounded-full bg-muted"
+                    indicatorClassName={usageIndicatorClass(vramPercent)}
+                  />
+                </div>
+              )}
+            </motion.div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
   );
 }

--- a/studio/frontend/src/components/floating-monitor.tsx
+++ b/studio/frontend/src/components/floating-monitor.tsx
@@ -9,21 +9,29 @@ import { useT } from "@/i18n";
 import { cn } from "@/lib/utils";
 import { CpuIcon, GripVerticalIcon, XIcon } from "lucide-react";
 import { AnimatePresence, motion, useDragControls } from "motion/react";
-import { useMemo, useState, type PointerEvent } from "react";
+import { type PointerEvent, useMemo, useState } from "react";
 
 function clampPercent(value: number): number {
   return Math.max(0, Math.min(100, value));
 }
 
 function usageIndicatorClass(percent: number): string {
-  if (percent >= 90) return "bg-destructive";
-  if (percent >= 70) return "bg-amber-500";
+  if (percent >= 90) {
+    return "bg-destructive";
+  }
+  if (percent >= 70) {
+    return "bg-amber-500";
+  }
   return "bg-primary";
 }
 
 function usageTextClass(percent: number): string {
-  if (percent >= 90) return "text-destructive";
-  if (percent >= 70) return "text-amber-600 dark:text-amber-400";
+  if (percent >= 90) {
+    return "text-destructive";
+  }
+  if (percent >= 70) {
+    return "text-amber-600 dark:text-amber-400";
+  }
   return "text-primary";
 }
 
@@ -128,7 +136,9 @@ export function FloatingMonitor() {
               <div className="space-y-1">
                 <div className="flex justify-between text-[11px] font-medium font-mono">
                   <span>{t("settings.resources.liveMonitor.ram")}</span>
-                  <span className={cn("tabular-nums", usageTextClass(ramPercent))}>
+                  <span
+                    className={cn("tabular-nums", usageTextClass(ramPercent))}
+                  >
                     {Math.round(ramPercent)}%
                   </span>
                 </div>

--- a/studio/frontend/src/components/floating-monitor.tsx
+++ b/studio/frontend/src/components/floating-monitor.tsx
@@ -3,13 +3,13 @@
 
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
-import { useMonitorOverlayStore } from "@/features/settings/stores/monitor-overlay-store";
+import { useMonitorOverlayStore } from "@/features/settings";
 import { useSystemInfo } from "@/hooks/use-system";
 import { useT } from "@/i18n";
 import { cn } from "@/lib/utils";
 import { CpuIcon, GripVerticalIcon, XIcon } from "lucide-react";
-import { motion } from "motion/react";
-import { useRef } from "react";
+import { motion, useDragControls } from "motion/react";
+import { useRef, type PointerEvent } from "react";
 
 function clampPercent(value: number): number {
   return Math.max(0, Math.min(100, value));
@@ -40,6 +40,12 @@ export function FloatingMonitor() {
   const systemInfo = useSystemInfo({ enabled: isOpen, pollMs: 5000 });
 
   const constraintsRef = useRef<HTMLDivElement>(null);
+  const dragControls = useDragControls();
+
+  function startDrag(event: PointerEvent<HTMLDivElement>) {
+    event.preventDefault();
+    dragControls.start(event);
+  }
 
   if (!isOpen) return null;
 
@@ -69,10 +75,11 @@ export function FloatingMonitor() {
       className="fixed inset-0 z-50 pointer-events-none"
     >
       <motion.div
-        layout={true}
         drag={true}
+        dragControls={dragControls}
+        dragListener={false}
         dragConstraints={constraintsRef}
-        dragElastic={0.1}
+        dragElastic={0}
         dragMomentum={false}
         initial={{ opacity: 0, scale: 0.9 }}
         animate={{ opacity: 1, scale: 1 }}
@@ -87,7 +94,10 @@ export function FloatingMonitor() {
             </span>
           </div>
           <div className="flex items-center gap-1 shrink-0">
-            <div className="cursor-grab rounded-md px-1 text-muted-foreground/60 transition-colors hover:bg-muted/60 hover:text-muted-foreground active:cursor-grabbing">
+            <div
+              onPointerDown={startDrag}
+              className="touch-none cursor-grab rounded-md px-1 text-muted-foreground/60 transition-colors hover:bg-muted/60 hover:text-muted-foreground active:cursor-grabbing"
+            >
               <GripVerticalIcon className="size-3.5" />
             </div>
 

--- a/studio/frontend/src/features/chat/index.ts
+++ b/studio/frontend/src/features/chat/index.ts
@@ -36,6 +36,7 @@ export { ChatSearchDialog } from "./components/chat-search-dialog";
 export { setTrainingCompareHandoff } from "./lib/training-compare-handoff";
 export type { ProjectRecord } from "./types";
 export { clearAllChats, countAllChats } from "./utils/clear-all-chats";
+export { listStoredChatThreads } from "./utils/chat-history-storage";
 export { ArtifactCard } from "./artifacts/artifact-card";
 export {
   useChatArtifactsStore,

--- a/studio/frontend/src/features/settings/index.ts
+++ b/studio/frontend/src/features/settings/index.ts
@@ -7,6 +7,7 @@ export {
   savePersonalization,
 } from "./api/personalization";
 export { setTheme, useTheme } from "./stores/theme-store";
+export { useMonitorOverlayStore } from "./stores/monitor-overlay-store";
 export type {
   Personalization,
   PersonalizationAppearance,

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -409,7 +409,6 @@ export const en = {
       description: "Access Unsloth via the OpenAI-compatible API.",
       readDocs: "Read the API docs",
       noAccess: "No API access yet.",
-      newBadge: "New",
       accessTokens: "Access tokens",
       loadError: "Couldn't load API access.",
       createError: "Couldn't create access token.",

--- a/studio/frontend/src/i18n/locales/ja.ts
+++ b/studio/frontend/src/i18n/locales/ja.ts
@@ -296,7 +296,6 @@ export const ja = {
       description: "OpenAI互換 API を介して Unsloth にアクセスします。",
       readDocs: "API ドキュメントを読む",
       noAccess: "まだ API アクセス権がありません。",
-      newBadge: "新規",
       accessTokens: "アクセストークン",
       loadError: "API アクセス権を読み込めませんでした。",
       createError: "アクセストークンを作成できませんでした。",

--- a/studio/frontend/src/i18n/locales/pt-br.ts
+++ b/studio/frontend/src/i18n/locales/pt-br.ts
@@ -363,7 +363,6 @@ export const ptBR = {
         "Acesse o Unsloth por meio da API compatível com OpenAI.",
       readDocs: "Leia a documentação da API",
       noAccess: "Nenhum acesso à API ainda.",
-      newBadge: "Novo",
       accessTokens: "Tokens de acesso",
       loadError: "Não foi possível carregar o acesso à API.",
       createError: "Não foi possível criar o token de acesso.",

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -267,7 +267,6 @@ export const zhCN = {
       description: "通过兼容 OpenAI 的 API 以编程方式访问 Unsloth。",
       readDocs: "阅读 API 文档",
       noAccess: "还没有 API 访问权限。",
-      newBadge: "新",
       accessTokens: "访问 token",
       loadError: "无法加载 API 访问权限。",
       createError: "无法创建访问 token。",

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1265,23 +1265,23 @@ with sync_playwright() as p:
     # ─────────────────────────────────────────────────────
     step("Shutdown via account menu")
     # Start fresh after the CLI rotation invalidates this browser session.
+    # Stay in the SAME context: macOS Chromium runs --single-process, where
+    # closing the last context kills the browser and a second context cannot
+    # be created. Clear cookies to drop the stale token and open the new page
+    # before closing the old one; the context init script covers the new page.
+    try:
+        ctx.clear_cookies()
+    except Exception as exc:
+        info(f"WARN clearing stale session cookies failed: {exc!r}")
+    _fresh_page = ctx.new_page()
+    _fresh_page.set_default_timeout(60_000)
+    _fresh_page.on("pageerror", lambda e: page_errors.append(str(e)))
+    _fresh_page.on("console", _on_console)
     try:
         page.close()
     except Exception:
         pass
-    try:
-        ctx.close()
-    except Exception as exc:
-        info(f"WARN closing stale browser context failed: {exc!r}")
-    ctx = browser.new_context(
-        viewport = {"width": 1280, "height": 900},
-        reduced_motion = "reduce",
-    )
-    install_view_transition_killer(ctx)
-    page = ctx.new_page()
-    page.set_default_timeout(60_000)
-    page.on("pageerror", lambda e: page_errors.append(str(e)))
-    page.on("console", _on_console)
+    page = _fresh_page
 
     # Re-login with NEW2 for a valid /api/shutdown token. Route changes can
     # still abort or interrupt this navigation, so the field wait below is the

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1267,12 +1267,21 @@ with sync_playwright() as p:
     # Start fresh after the CLI rotation invalidates this browser session.
     # Stay in the SAME context: macOS Chromium runs --single-process, where
     # closing the last context kills the browser and a second context cannot
-    # be created. Clear cookies to drop the stale token and open the new page
-    # before closing the old one; the context init script covers the new page.
+    # be created. Open the new page before closing the old one; the context
+    # init script covers the new page.
     try:
         ctx.clear_cookies()
     except Exception as exc:
         info(f"WARN clearing stale session cookies failed: {exc!r}")
+    # Auth tokens live in localStorage, and /login's guest guard redirects on
+    # their mere presence, so drop them before navigating.
+    try:
+        page.evaluate(
+            "['unsloth_auth_token', 'unsloth_auth_refresh_token']"
+            ".forEach((key) => localStorage.removeItem(key))"
+        )
+    except Exception as exc:
+        info(f"WARN clearing stale auth tokens failed: {exc!r}")
     _fresh_page = ctx.new_page()
     _fresh_page.set_default_timeout(60_000)
     _fresh_page.on("pageerror", lambda e: page_errors.append(str(e)))

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1264,11 +1264,28 @@ with sync_playwright() as p:
     # placeholder, and /api/health goes unreachable shortly after.
     # ─────────────────────────────────────────────────────
     step("Shutdown via account menu")
-    # Re-login with NEW2 for a valid /api/shutdown token (CLI rotation
-    # invalidated the old one). The stale token can make the SPA auth guard
-    # abort this goto with ERR_ABORTED, or redirect to the same /login URL
-    # ("interrupted by another navigation"); resolve on domcontentloaded and
-    # tolerate either -- the pw-field wait below confirms we are on /login.
+    # Start fresh after the CLI rotation invalidates this browser session.
+    try:
+        page.close()
+    except Exception:
+        pass
+    try:
+        ctx.close()
+    except Exception as exc:
+        info(f"WARN closing stale browser context failed: {exc!r}")
+    ctx = browser.new_context(
+        viewport = {"width": 1280, "height": 900},
+        reduced_motion = "reduce",
+    )
+    install_view_transition_killer(ctx)
+    page = ctx.new_page()
+    page.set_default_timeout(60_000)
+    page.on("pageerror", lambda e: page_errors.append(str(e)))
+    page.on("console", _on_console)
+
+    # Re-login with NEW2 for a valid /api/shutdown token. Route changes can
+    # still abort or interrupt this navigation, so the field wait below is the
+    # final confirmation that we reached /login.
     _tolerated_nav = ("ERR_ABORTED", "interrupted by another navigation")
     try:
         page.goto(f"{BASE}/login", wait_until = "domcontentloaded", timeout = 60_000)


### PR DESCRIPTION
## Summary

- Stop the live monitor from layout-animating its fixed floating panel.
- Start dragging only from the grip handle instead of the whole panel.
- Preserve the close exit animation with `AnimatePresence` and callback-backed drag constraints.
- Keep the API item in the settings menu free of the old `New` badge.
- Export shared stores and helpers through feature indexes.
- Harden Windows Studio smoke checks that were failing from CI environment issues.

## Why

The floating monitor mixed layout animation, full-panel drag listening, and native resize on the same fixed element. Metric refreshes and resize changes could re-project the panel and make it jump even when nothing was being dragged.

The API badge removal was already merged separately, but this branch was still carrying the old badge markup. This keeps the active PR from reintroducing it.

The CI hardening keeps Windows no-build-tools checks sandboxed with temporary discovery roots and a filtered `Path`, instead of renaming protected `Program Files` directories. The overrides are set in-script because the runner does not apply step-level env keys containing parentheses. It also resets the Playwright browser session in place before the shutdown re-login after password rotation, since macOS Chromium runs `--single-process` and cannot host a second context.

## Testing

- `node temp/pr-simulations/pr-invariants.mjs temp/unsloth-full`
- Chrome headless local browser simulation: `PASS`
- Firefox headless screenshot local browser simulation: `PASS`
- `npx eslint src/components/floating-monitor.tsx src/components/app-sidebar.tsx src/features/settings/index.ts src/features/chat/index.ts src/i18n/locales/en.ts src/i18n/locales/ja.ts src/i18n/locales/zh-CN.ts src/i18n/locales/pt-br.ts`
- `npx biome check src/components/floating-monitor.tsx src/features/settings/index.ts src/features/chat/index.ts`
- `npm run i18n:check`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- `python -m py_compile tests/studio/playwright_chat_ui.py` inside a `uv venv`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/studio-windows-inference-smoke.yml")'`
- PowerShell run of the extracted `Find-VsBuildTools` against a fake VS 2026 tree: detected with real discovery roots, undetectable after the in-script overrides
- Reproduced the macOS `TargetClosedError` under `--single-process` Chromium with the same launch args; the same-context reset passed 11 consecutive runs
