### PR TITLE
Studio: opt-in recursive scanning for custom model folders

### DIFF
--- a/studio/backend/core/inference/local_model_resolver.py
+++ b/studio/backend/core/inference/local_model_resolver.py
@@ -191,6 +191,16 @@ def _build_index() -> dict[str, _LocalGgufEntry]:
                 found += (
                     _scan_models_dir(fp, limit = 200) + _scan_hf_once(fp) + _scan_lmstudio_dir(fp)
                 )
+                if folder.get("recursive"):
+                    from hub.services.models.local_inventory import iter_recursive_scan_dirs
+                    from hub.utils.paths import path_is_same_or_child
+
+                    for subdir in iter_recursive_scan_dirs(fp):
+                        found += [
+                            m
+                            for m in _scan_models_dir(subdir, limit = 200)
+                            if path_is_same_or_child(Path(m.path), fp)
+                        ]
             except Exception as exc:
                 logger.debug("auto-switch: scan folder %r failed: %s", folder, exc)
     except Exception as exc:

--- a/studio/backend/core/inference/local_model_resolver.py
+++ b/studio/backend/core/inference/local_model_resolver.py
@@ -200,17 +200,20 @@ def _build_index() -> dict[str, _LocalGgufEntry]:
                         scan_result_within_folder,
                     )
                     from routes.models import _dir_has_loadable_weights
+
                     seen = {
-                        (m.path, getattr(m, "model_format", None), getattr(m, "format_variant", None))
+                        (
+                            m.path,
+                            getattr(m, "model_format", None),
+                            getattr(m, "format_variant", None),
+                        )
                         for m in found
                     }
                     recursive_budget = max(0, 200 - (len(found) - before))
                     for subdir in iter_recursive_scan_dirs(fp):
                         if recursive_budget <= 0:
                             break
-                        for m in _scan_models_dir(
-                            subdir, limit = recursive_budget, entry_limit = 2000
-                        ):
+                        for m in _scan_models_dir(subdir, limit = recursive_budget, entry_limit = 2000):
                             key = (
                                 m.path,
                                 getattr(m, "model_format", None),

--- a/studio/backend/core/inference/local_model_resolver.py
+++ b/studio/backend/core/inference/local_model_resolver.py
@@ -192,13 +192,16 @@ def _build_index() -> dict[str, _LocalGgufEntry]:
                     _scan_models_dir(fp, limit = 200) + _scan_hf_once(fp) + _scan_lmstudio_dir(fp)
                 )
                 if folder.get("recursive"):
-                    from hub.services.models.local_inventory import iter_recursive_scan_dirs
-                    from hub.utils.paths import path_is_same_or_child
+                    from hub.services.models.local_inventory import (
+                        iter_recursive_scan_dirs,
+                        scan_result_within_folder,
+                    )
+
                     for subdir in iter_recursive_scan_dirs(fp):
                         found += [
                             m
                             for m in _scan_models_dir(subdir, limit = 200)
-                            if path_is_same_or_child(Path(m.path), fp)
+                            if scan_result_within_folder(m.path, fp)
                         ]
             except Exception as exc:
                 logger.debug("auto-switch: scan folder %r failed: %s", folder, exc)

--- a/studio/backend/core/inference/local_model_resolver.py
+++ b/studio/backend/core/inference/local_model_resolver.py
@@ -196,7 +196,6 @@ def _build_index() -> dict[str, _LocalGgufEntry]:
                         iter_recursive_scan_dirs,
                         scan_result_within_folder,
                     )
-
                     for subdir in iter_recursive_scan_dirs(fp):
                         found += [
                             m

--- a/studio/backend/core/inference/local_model_resolver.py
+++ b/studio/backend/core/inference/local_model_resolver.py
@@ -194,7 +194,6 @@ def _build_index() -> dict[str, _LocalGgufEntry]:
                 if folder.get("recursive"):
                     from hub.services.models.local_inventory import iter_recursive_scan_dirs
                     from hub.utils.paths import path_is_same_or_child
-
                     for subdir in iter_recursive_scan_dirs(fp):
                         found += [
                             m

--- a/studio/backend/core/inference/local_model_resolver.py
+++ b/studio/backend/core/inference/local_model_resolver.py
@@ -188,21 +188,45 @@ def _build_index() -> dict[str, _LocalGgufEntry]:
         for folder in list_scan_folders():
             try:
                 fp = Path(folder["path"])
+                before = len(found)
                 found += (
-                    _scan_models_dir(fp, limit = 200) + _scan_hf_once(fp) + _scan_lmstudio_dir(fp)
+                    _scan_models_dir(fp, limit = 200, entry_limit = 2000)
+                    + _scan_hf_once(fp)
+                    + _scan_lmstudio_dir(fp)
                 )
                 if folder.get("recursive"):
                     from hub.services.models.local_inventory import (
                         iter_recursive_scan_dirs,
                         scan_result_within_folder,
                     )
-                    recursive_budget = 200
+                    from routes.models import _dir_has_loadable_weights
+                    seen = {
+                        (m.path, getattr(m, "model_format", None), getattr(m, "format_variant", None))
+                        for m in found
+                    }
+                    recursive_budget = max(0, 200 - (len(found) - before))
                     for subdir in iter_recursive_scan_dirs(fp):
                         if recursive_budget <= 0:
                             break
-                        for m in _scan_models_dir(subdir, limit = recursive_budget):
-                            if not scan_result_within_folder(m.path, fp):
+                        for m in _scan_models_dir(
+                            subdir, limit = recursive_budget, entry_limit = 2000
+                        ):
+                            key = (
+                                m.path,
+                                getattr(m, "model_format", None),
+                                getattr(m, "format_variant", None),
+                            )
+                            if (
+                                key in seen
+                                or not scan_result_within_folder(m.path, fp)
+                                or not _dir_has_loadable_weights(Path(m.path))
+                                or any(
+                                    seg in (".studio_links", "ollama_links")
+                                    for seg in Path(m.path).parts
+                                )
+                            ):
                                 continue
+                            seen.add(key)
                             found.append(m)
                             recursive_budget -= 1
                             if recursive_budget <= 0:

--- a/studio/backend/core/inference/local_model_resolver.py
+++ b/studio/backend/core/inference/local_model_resolver.py
@@ -196,12 +196,17 @@ def _build_index() -> dict[str, _LocalGgufEntry]:
                         iter_recursive_scan_dirs,
                         scan_result_within_folder,
                     )
+                    recursive_budget = 200
                     for subdir in iter_recursive_scan_dirs(fp):
-                        found += [
-                            m
-                            for m in _scan_models_dir(subdir, limit = 200)
-                            if scan_result_within_folder(m.path, fp)
-                        ]
+                        if recursive_budget <= 0:
+                            break
+                        for m in _scan_models_dir(subdir, limit = recursive_budget):
+                            if not scan_result_within_folder(m.path, fp):
+                                continue
+                            found.append(m)
+                            recursive_budget -= 1
+                            if recursive_budget <= 0:
+                                break
             except Exception as exc:
                 logger.debug("auto-switch: scan folder %r failed: %s", folder, exc)
     except Exception as exc:

--- a/studio/backend/hub/routes/inventory.py
+++ b/studio/backend/hub/routes/inventory.py
@@ -68,7 +68,7 @@ def get_scan_folders(current_subject: str = Depends(get_current_subject)):
 def add_scan_folder_endpoint(
     body: AddScanFolderRequest, current_subject: str = Depends(get_current_subject)
 ):
-    return local_inventory.add_scan_folder_response(body.path)
+    return local_inventory.add_scan_folder_response(body.path, body.recursive)
 
 
 @router.delete("/scan-folders/{folder_id}", response_model = RemoveScanFolderResponse)

--- a/studio/backend/hub/schemas/inventory.py
+++ b/studio/backend/hub/schemas/inventory.py
@@ -196,8 +196,8 @@ class AddScanFolderRequest(BaseModel):
         ...,
         description = "Absolute or relative folder path, or a model weight file path",
     )
-    recursive: bool = Field(
-        False,
+    recursive: Optional[bool] = Field(
+        None,
         description = "Also scan sub-folders (bounded depth) for models",
     )
 

--- a/studio/backend/hub/schemas/inventory.py
+++ b/studio/backend/hub/schemas/inventory.py
@@ -196,6 +196,10 @@ class AddScanFolderRequest(BaseModel):
         ...,
         description = "Absolute or relative folder path, or a model weight file path",
     )
+    recursive: bool = Field(
+        False,
+        description = "Also scan sub-folders (bounded depth) for models",
+    )
 
 
 class ScanFolderInfo(BaseModel):
@@ -204,6 +208,7 @@ class ScanFolderInfo(BaseModel):
     id: int = Field(..., description = "Database row ID")
     path: str = Field(..., description = "Normalized absolute path")
     created_at: str = Field(..., description = "ISO 8601 creation timestamp")
+    recursive: int = Field(0, description = "1 when sub-folders are also scanned")
 
 
 class ScanFoldersResponse(BaseModel):

--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -108,7 +108,11 @@ def _is_model_directory_for_scan(path: Path, *, entry_limit: int | None) -> bool
 def _is_scan_leaf_dir(path: Path, *, entry_limit: int | None) -> bool:
     if _is_model_directory_for_scan(path, entry_limit = entry_limit):
         return True
-    probe = entry_limit if entry_limit is not None else _MODEL_SIGNAL_PROBE_LIMIT
+    # Probe the same window the parent scan uses to emit a model directory
+    # (_has_immediate_model_signal), so a directory the parent would not emit is
+    # never pruned here. A wider window could prune a directory that is never
+    # emitted, dropping the model from every scan.
+    probe = _MODEL_SIGNAL_PROBE_LIMIT
     try:
         for index, entry in enumerate(path.iterdir(), start = 1):
             if index > probe:
@@ -600,34 +604,48 @@ def iter_recursive_scan_dirs(
 
     Directories the parent scan already classifies as models (config plus weights,
     or a main GGUF file) are not yielded and are never descended into.
-    Symlinks are never followed; depth and visited-entry caps bound the walk."""
+    Symlinks are never followed; depth and visited-entry caps bound the walk.
+
+    Uses ``os.scandir`` and stops reading a directory once the entry cap is hit,
+    so a flat folder with a very large number of files never materializes the
+    whole listing before the cap applies."""
     base_depth = len(folder_path.parts)
     visited = 0
-    for dirpath, dirnames, _filenames in os.walk(folder_path, topdown = True, followlinks = False):
-        current = Path(dirpath)
-        depth = len(current.parts) - base_depth
-        if entry_limit is not None:
-            visited += len(_filenames)
-        if depth >= max_depth or (entry_limit is not None and visited > entry_limit):
-            dirnames[:] = []
+    stack: list[Path] = [folder_path]
+    while stack:
+        current = stack.pop()
+        if len(current.parts) - base_depth >= max_depth:
             continue
-        keep: list[str] = []
-        for name in sorted(dirnames):
-            visited += 1
-            if entry_limit is not None and visited > entry_limit:
-                break
-            if name.startswith(".") or name == "ollama_links":
-                continue
-            child = current / name
-            try:
-                if child.is_symlink() or _is_scan_leaf_dir(child, entry_limit = entry_limit):
+        try:
+            scanner = os.scandir(current)
+        except OSError:
+            continue
+        children: list[Path] = []
+        with scanner:
+            for entry in scanner:
+                if entry_limit is not None:
+                    visited += 1
+                    if visited > entry_limit:
+                        break
+                name = entry.name
+                if name.startswith(".") or name == "ollama_links":
                     continue
-            except OSError:
-                continue
-            keep.append(name)
-        dirnames[:] = keep
-        for name in keep:
-            yield current / name
+                try:
+                    # Never follow symlinks: an is_dir that does not follow them
+                    # treats a symlinked directory as a non-directory and skips it.
+                    if not entry.is_dir(follow_symlinks = False):
+                        continue
+                    child = Path(entry.path)
+                    if _is_scan_leaf_dir(child, entry_limit = entry_limit):
+                        continue
+                except OSError:
+                    continue
+                children.append(child)
+        # Yield each directory's children in a stable order (only the kept
+        # sub-directories are sorted, never the full listing).
+        for child in sorted(children):
+            yield child
+            stack.append(child)
 
 
 def _scan_custom_folder(folder_path: Path, recursive: bool = False) -> List[LocalModelInfo]:

--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -108,9 +108,10 @@ def _is_model_directory_for_scan(path: Path, *, entry_limit: int | None) -> bool
 def _is_scan_leaf_dir(path: Path, *, entry_limit: int | None) -> bool:
     if _is_model_directory_for_scan(path, entry_limit = entry_limit):
         return True
+    probe = entry_limit if entry_limit is not None else _MODEL_SIGNAL_PROBE_LIMIT
     try:
         for index, entry in enumerate(path.iterdir(), start = 1):
-            if index > _MODEL_SIGNAL_PROBE_LIMIT:
+            if index > probe:
                 break
             try:
                 if (
@@ -133,19 +134,32 @@ def scan_result_within_folder(path: str, folder_path: Path) -> bool:
     try:
         if not candidate.is_dir():
             return True
-        # Validate every immediate weight file, not just the first probe window:
-        # the loader reads all of them, so a single symlink escaping the folder
-        # is enough to reject the row. This runs only on classified model dirs.
+        # Loaders may read any file in a model directory (weights, companion
+        # GGUFs such as mmproj, configs, tokenizers), so reject the row if any
+        # immediate entry is a symlink resolving outside the registered folder.
+        # Non-symlink entries are physically inside and need no check. This
+        # runs only on classified model directories, so it stays cheap.
         for entry in candidate.iterdir():
             try:
-                if entry.is_file() and _is_immediate_model_weight_file(entry):
-                    if not path_is_same_or_child(entry, folder_path):
-                        return False
+                if entry.is_symlink() and not path_is_same_or_child(entry, folder_path):
+                    return False
             except OSError:
                 continue
     except OSError:
         return False
     return True
+
+
+def _dir_has_loadable_weights(path: Path) -> bool:
+    try:
+        if path.is_file():
+            suffix = path.suffix.lower()
+            if suffix == ".gguf":
+                return _is_main_gguf_filename(path.name)
+            return suffix in (".safetensors", ".bin")
+        return _has_immediate_model_weight(path, probe_limit = _MAX_CUSTOM_FOLDER_ENTRIES)
+    except OSError:
+        return False
 
 
 def _resolve_hf_cache_dir() -> Path:
@@ -649,7 +663,11 @@ def _scan_custom_folder(folder_path: Path, recursive: bool = False) -> List[Loca
                 )
             ):
                 key = (m.path, m.model_format, m.format_variant)
-                if key in seen or not scan_result_within_folder(m.path, folder_path):
+                if (
+                    key in seen
+                    or not scan_result_within_folder(m.path, folder_path)
+                    or not _dir_has_loadable_weights(Path(m.path))
+                ):
                     continue
                 seen.add(key)
                 generic.append(m)

--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -546,9 +546,7 @@ def iter_recursive_scan_dirs(
     Symlinks are never followed; depth and visited-entry caps bound the walk."""
     base_depth = len(folder_path.parts)
     visited = 0
-    for dirpath, dirnames, _filenames in os.walk(
-        folder_path, topdown = True, followlinks = False
-    ):
+    for dirpath, dirnames, _filenames in os.walk(folder_path, topdown = True, followlinks = False):
         current = Path(dirpath)
         depth = len(current.parts) - base_depth
         if depth >= max_depth or (entry_limit is not None and visited > entry_limit):

--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -133,9 +133,10 @@ def scan_result_within_folder(path: str, folder_path: Path) -> bool:
     try:
         if not candidate.is_dir():
             return True
-        for index, entry in enumerate(candidate.iterdir(), start = 1):
-            if index > _MODEL_SIGNAL_PROBE_LIMIT:
-                break
+        # Validate every immediate weight file, not just the first probe window:
+        # the loader reads all of them, so a single symlink escaping the folder
+        # is enough to reject the row. This runs only on classified model dirs.
+        for entry in candidate.iterdir():
             try:
                 if entry.is_file() and _is_immediate_model_weight_file(entry):
                     if not path_is_same_or_child(entry, folder_path):

--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -41,6 +41,7 @@ logger = get_logger(__name__)
 _MAX_MODELS_PER_CUSTOM_FOLDER = 200
 _MAX_CUSTOM_FOLDER_ENTRIES = 2000
 _MODEL_SIGNAL_PROBE_LIMIT = 200
+_MAX_RECURSIVE_SCAN_DEPTH = 8
 
 # Local aliases keep the extracted code close to the original implementation.
 _is_model_directory = model_common._is_model_directory
@@ -532,22 +533,83 @@ async def _collect_models_from_default_sources(
     return local_models
 
 
-def _scan_custom_folder(folder_path: Path) -> List[LocalModelInfo]:
+def iter_recursive_scan_dirs(
+    folder_path: Path,
+    *,
+    max_depth: int = _MAX_RECURSIVE_SCAN_DEPTH,
+    entry_limit: int | None = _MAX_CUSTOM_FOLDER_ENTRIES,
+):
+    """Yield sub-directories of *folder_path* that should themselves be scanned.
+
+    Directories with an immediate model signal are not yielded (they are picked
+    up as children of their parent's scan) and are never descended into.
+    Symlinks are never followed; depth and visited-entry caps bound the walk."""
+    base_depth = len(folder_path.parts)
+    visited = 0
+    for dirpath, dirnames, _filenames in os.walk(
+        folder_path, topdown = True, followlinks = False
+    ):
+        current = Path(dirpath)
+        depth = len(current.parts) - base_depth
+        if depth >= max_depth or (entry_limit is not None and visited > entry_limit):
+            dirnames[:] = []
+            continue
+        keep: list[str] = []
+        for name in sorted(dirnames):
+            visited += 1
+            if entry_limit is not None and visited > entry_limit:
+                break
+            if name.startswith(".") or name == "ollama_links":
+                continue
+            child = current / name
+            try:
+                if child.is_symlink() or _has_immediate_model_signal(child):
+                    continue
+            except OSError:
+                continue
+            keep.append(name)
+        dirnames[:] = keep
+        for name in keep:
+            yield current / name
+
+
+def _scan_custom_folder(folder_path: Path, recursive: bool = False) -> List[LocalModelInfo]:
     supported_formats: set[ModelFormat] = {"gguf", "safetensors", "adapter"}
-    generic = [
-        m
-        for m in (
-            _scan_models_dir(
-                folder_path,
-                limit = _MAX_MODELS_PER_CUSTOM_FOLDER,
-                entry_limit = _MAX_CUSTOM_FOLDER_ENTRIES,
-            )
-            + _scan_hf_cache(folder_path, entry_limit = _MAX_CUSTOM_FOLDER_ENTRIES)
-            + _scan_lmstudio_dir(folder_path, entry_limit = _MAX_CUSTOM_FOLDER_ENTRIES)
+
+    def _filtered(models: List[LocalModelInfo]) -> List[LocalModelInfo]:
+        return [
+            m
+            for m in models
+            if m.model_format in supported_formats
+            if not any(p in (".studio_links", "ollama_links") for p in Path(m.path).parts)
+        ]
+
+    generic = _filtered(
+        _scan_models_dir(
+            folder_path,
+            limit = _MAX_MODELS_PER_CUSTOM_FOLDER,
+            entry_limit = _MAX_CUSTOM_FOLDER_ENTRIES,
         )
-        if m.model_format in supported_formats
-        if not any(p in (".studio_links", "ollama_links") for p in Path(m.path).parts)
-    ]
+        + _scan_hf_cache(folder_path, entry_limit = _MAX_CUSTOM_FOLDER_ENTRIES)
+        + _scan_lmstudio_dir(folder_path, entry_limit = _MAX_CUSTOM_FOLDER_ENTRIES)
+    )
+    if recursive:
+        seen = {(m.path, m.model_format, m.format_variant) for m in generic}
+        for subdir in iter_recursive_scan_dirs(folder_path):
+            if len(generic) >= _MAX_MODELS_PER_CUSTOM_FOLDER:
+                break
+            for m in _filtered(
+                _scan_models_dir(
+                    subdir,
+                    limit = _MAX_MODELS_PER_CUSTOM_FOLDER - len(generic),
+                    entry_limit = _MAX_CUSTOM_FOLDER_ENTRIES,
+                )
+            ):
+                key = (m.path, m.model_format, m.format_variant)
+                if key in seen:
+                    continue
+                seen.add(key)
+                generic.append(m)
     return generic[:_MAX_MODELS_PER_CUSTOM_FOLDER]
 
 
@@ -585,7 +647,11 @@ async def _collect_models_from_custom_folders() -> List[LocalModelInfo]:
     for folder in custom_folders:
         folder_path = Path(normalize_path(folder["path"])).expanduser()
         try:
-            custom_models = await asyncio.to_thread(_scan_custom_folder, folder_path)
+            custom_models = await asyncio.to_thread(
+                _scan_custom_folder,
+                folder_path,
+                bool(folder.get("recursive")),
+            )
         except Exception as e:
             logger.warning("Skipping unreadable scan folder %s: %s", folder_path, e)
             continue
@@ -699,9 +765,9 @@ def get_scan_folders_response() -> dict:
     return {"folders": list_scan_folders()}
 
 
-def add_scan_folder_response(path: str) -> dict:
+def add_scan_folder_response(path: str, recursive: bool = False) -> dict:
     try:
-        folder = add_scan_folder(_coerce_scan_folder_path(path))
+        folder = add_scan_folder(_coerce_scan_folder_path(path), recursive)
     except ValueError as e:
         logger.warning("Scan folder rejected: %s (path=%s)", e, path)
         raise HTTPException(status_code = 400, detail = str(e))

--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -105,6 +105,48 @@ def _is_model_directory_for_scan(path: Path, *, entry_limit: int | None) -> bool
     return has_config and _has_immediate_model_weight(path)
 
 
+def _is_scan_leaf_dir(path: Path, *, entry_limit: int | None) -> bool:
+    if _is_model_directory_for_scan(path, entry_limit = entry_limit):
+        return True
+    try:
+        for index, entry in enumerate(path.iterdir(), start = 1):
+            if index > _MODEL_SIGNAL_PROBE_LIMIT:
+                break
+            try:
+                if (
+                    entry.is_file()
+                    and entry.suffix.lower() == ".gguf"
+                    and _is_main_gguf_filename(entry.name)
+                ):
+                    return True
+            except OSError:
+                continue
+    except OSError:
+        return True
+    return False
+
+
+def scan_result_within_folder(path: str, folder_path: Path) -> bool:
+    candidate = Path(path)
+    if not path_is_same_or_child(candidate, folder_path):
+        return False
+    try:
+        if not candidate.is_dir():
+            return True
+        for index, entry in enumerate(candidate.iterdir(), start = 1):
+            if index > _MODEL_SIGNAL_PROBE_LIMIT:
+                break
+            try:
+                if entry.is_file() and _is_immediate_model_weight_file(entry):
+                    if not path_is_same_or_child(entry, folder_path):
+                        return False
+            except OSError:
+                continue
+    except OSError:
+        return False
+    return True
+
+
 def _resolve_hf_cache_dir() -> Path:
     try:
         from huggingface_hub.constants import HF_HUB_CACHE
@@ -541,14 +583,16 @@ def iter_recursive_scan_dirs(
 ):
     """Yield sub-directories of *folder_path* that should themselves be scanned.
 
-    Directories holding immediate model weights are not yielded (they are picked
-    up as children of their parent's scan) and are never descended into.
+    Directories the parent scan already classifies as models (config plus weights,
+    or a main GGUF file) are not yielded and are never descended into.
     Symlinks are never followed; depth and visited-entry caps bound the walk."""
     base_depth = len(folder_path.parts)
     visited = 0
     for dirpath, dirnames, _filenames in os.walk(folder_path, topdown = True, followlinks = False):
         current = Path(dirpath)
         depth = len(current.parts) - base_depth
+        if entry_limit is not None:
+            visited += len(_filenames)
         if depth >= max_depth or (entry_limit is not None and visited > entry_limit):
             dirnames[:] = []
             continue
@@ -561,7 +605,7 @@ def iter_recursive_scan_dirs(
                 continue
             child = current / name
             try:
-                if child.is_symlink() or _has_immediate_model_weight(child):
+                if child.is_symlink() or _is_scan_leaf_dir(child, entry_limit = entry_limit):
                     continue
             except OSError:
                 continue
@@ -604,7 +648,7 @@ def _scan_custom_folder(folder_path: Path, recursive: bool = False) -> List[Loca
                 )
             ):
                 key = (m.path, m.model_format, m.format_variant)
-                if key in seen or not path_is_same_or_child(Path(m.path), folder_path):
+                if key in seen or not scan_result_within_folder(m.path, folder_path):
                     continue
                 seen.add(key)
                 generic.append(m)
@@ -763,7 +807,7 @@ def get_scan_folders_response() -> dict:
     return {"folders": list_scan_folders()}
 
 
-def add_scan_folder_response(path: str, recursive: bool = False) -> dict:
+def add_scan_folder_response(path: str, recursive: bool | None = None) -> dict:
     try:
         folder = add_scan_folder(_coerce_scan_folder_path(path), recursive)
     except ValueError as e:

--- a/studio/backend/hub/services/models/local_inventory.py
+++ b/studio/backend/hub/services/models/local_inventory.py
@@ -541,7 +541,7 @@ def iter_recursive_scan_dirs(
 ):
     """Yield sub-directories of *folder_path* that should themselves be scanned.
 
-    Directories with an immediate model signal are not yielded (they are picked
+    Directories holding immediate model weights are not yielded (they are picked
     up as children of their parent's scan) and are never descended into.
     Symlinks are never followed; depth and visited-entry caps bound the walk."""
     base_depth = len(folder_path.parts)
@@ -561,7 +561,7 @@ def iter_recursive_scan_dirs(
                 continue
             child = current / name
             try:
-                if child.is_symlink() or _has_immediate_model_signal(child):
+                if child.is_symlink() or _has_immediate_model_weight(child):
                     continue
             except OSError:
                 continue
@@ -604,7 +604,7 @@ def _scan_custom_folder(folder_path: Path, recursive: bool = False) -> List[Loca
                 )
             ):
                 key = (m.path, m.model_format, m.format_variant)
-                if key in seen:
+                if key in seen or not path_is_same_or_child(Path(m.path), folder_path):
                     continue
                 seen.add(key)
                 generic.append(m)

--- a/studio/backend/hub/storage/scan_folders.py
+++ b/studio/backend/hub/storage/scan_folders.py
@@ -85,9 +85,7 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
             row[1] for row in conn.execute("PRAGMA table_info(scan_folders)").fetchall()
         }
         if "recursive" not in existing_cols:
-            conn.execute(
-                "ALTER TABLE scan_folders ADD COLUMN recursive INTEGER NOT NULL DEFAULT 0"
-            )
+            conn.execute("ALTER TABLE scan_folders ADD COLUMN recursive INTEGER NOT NULL DEFAULT 0")
         conn.commit()
         _schema_ready = True
 

--- a/studio/backend/hub/storage/scan_folders.py
+++ b/studio/backend/hub/storage/scan_folders.py
@@ -102,7 +102,7 @@ def list_scan_folders() -> list[dict]:
         conn.close()
 
 
-def add_scan_folder(path: str, recursive: bool = False) -> dict:
+def add_scan_folder(path: str, recursive: bool | None = None) -> dict:
     """Add a readable directory for the local OS user; not a multi-user sandbox."""
     if not path or not path.strip():
         raise ValueError("Path cannot be empty")
@@ -143,7 +143,7 @@ def add_scan_folder(path: str, recursive: bool = False) -> dict:
                 (normalized,),
             ).fetchone()
         if existing is not None:
-            if bool(existing["recursive"]) != recursive:
+            if recursive is not None and bool(existing["recursive"]) != bool(recursive):
                 conn.execute(
                     "UPDATE scan_folders SET recursive = ? WHERE id = ?",
                     (1 if recursive else 0, existing["id"]),

--- a/studio/backend/hub/storage/scan_folders.py
+++ b/studio/backend/hub/storage/scan_folders.py
@@ -76,10 +76,18 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
             CREATE TABLE IF NOT EXISTS scan_folders (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 path TEXT NOT NULL UNIQUE {collation},
-                created_at TEXT NOT NULL
+                created_at TEXT NOT NULL,
+                recursive INTEGER NOT NULL DEFAULT 0
             )
             """
         )
+        existing_cols = {
+            row[1] for row in conn.execute("PRAGMA table_info(scan_folders)").fetchall()
+        }
+        if "recursive" not in existing_cols:
+            conn.execute(
+                "ALTER TABLE scan_folders ADD COLUMN recursive INTEGER NOT NULL DEFAULT 0"
+            )
         conn.commit()
         _schema_ready = True
 
@@ -89,14 +97,14 @@ def list_scan_folders() -> list[dict]:
     try:
         _ensure_schema(conn)
         rows = conn.execute(
-            "SELECT id, path, created_at FROM scan_folders ORDER BY created_at"
+            "SELECT id, path, created_at, recursive FROM scan_folders ORDER BY created_at"
         ).fetchall()
         return [dict(row) for row in rows]
     finally:
         conn.close()
 
 
-def add_scan_folder(path: str) -> dict:
+def add_scan_folder(path: str, recursive: bool = False) -> dict:
     """Add a readable directory for the local OS user; not a multi-user sandbox."""
     if not path or not path.strip():
         raise ValueError("Path cannot be empty")
@@ -128,28 +136,35 @@ def add_scan_folder(path: str) -> dict:
         now = datetime.now(timezone.utc).isoformat()
         if is_win:
             existing = conn.execute(
-                "SELECT id, path, created_at FROM scan_folders WHERE path = ? COLLATE NOCASE",
+                "SELECT id, path, created_at, recursive FROM scan_folders WHERE path = ? COLLATE NOCASE",
                 (normalized,),
             ).fetchone()
         else:
             existing = conn.execute(
-                "SELECT id, path, created_at FROM scan_folders WHERE path = ?",
+                "SELECT id, path, created_at, recursive FROM scan_folders WHERE path = ?",
                 (normalized,),
             ).fetchone()
         if existing is not None:
+            if bool(existing["recursive"]) != recursive:
+                conn.execute(
+                    "UPDATE scan_folders SET recursive = ? WHERE id = ?",
+                    (1 if recursive else 0, existing["id"]),
+                )
+                conn.commit()
+                return {**dict(existing), "recursive": 1 if recursive else 0}
             return dict(existing)
         try:
             conn.execute(
-                "INSERT INTO scan_folders (path, created_at) VALUES (?, ?)",
-                (normalized, now),
+                "INSERT INTO scan_folders (path, created_at, recursive) VALUES (?, ?, ?)",
+                (normalized, now, 1 if recursive else 0),
             )
             conn.commit()
         except sqlite3.IntegrityError:
             pass
         fallback_sql = (
-            "SELECT id, path, created_at FROM scan_folders WHERE path = ? COLLATE NOCASE"
+            "SELECT id, path, created_at, recursive FROM scan_folders WHERE path = ? COLLATE NOCASE"
             if is_win
-            else "SELECT id, path, created_at FROM scan_folders WHERE path = ?"
+            else "SELECT id, path, created_at, recursive FROM scan_folders WHERE path = ?"
         )
         row = conn.execute(fallback_sql, (normalized,)).fetchone()
         if row is None:

--- a/studio/backend/hub/tests/test_recursive_scan_folders.py
+++ b/studio/backend/hub/tests/test_recursive_scan_folders.py
@@ -330,3 +330,18 @@ def test_schema_migrates_existing_table(tmp_path, monkeypatch):
     monkeypatch.setattr(scan_folders, "_schema_ready", False)
     listed_again = scan_folders.list_scan_folders()
     assert listed_again[0]["recursive"] == 0
+
+
+def test_recursive_scan_descends_through_file_heavy_dirs(tmp_path):
+    # A directory padded with many files must still be descended into to reach a
+    # nested model. Guards the scandir walker (which counts files toward the cap)
+    # against regressing the file-heavy case.
+    padded = tmp_path / "padded"
+    padded.mkdir()
+    for i in range(50):
+        (padded / f"note{i:03d}.txt").write_text("x")
+    _make_model_dir(padded / "nested" / "model-z")
+
+    recursive = local_inventory._scan_custom_folder(tmp_path, recursive = True)
+
+    assert "model-z" in {m.display_name for m in recursive}

--- a/studio/backend/hub/tests/test_recursive_scan_folders.py
+++ b/studio/backend/hub/tests/test_recursive_scan_folders.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import os
+import sqlite3
+
+from hub.services.models import local_inventory
+from hub.storage import scan_folders
+
+
+def _make_model_dir(path):
+    path.mkdir(parents = True)
+    (path / "config.json").write_text("{}")
+    (path / "model.safetensors").write_bytes(b"\0" * 8)
+
+
+def test_walker_yields_nested_dirs_and_prunes_model_dirs(tmp_path):
+    _make_model_dir(tmp_path / "a" / "b" / "model-x")
+    (tmp_path / "plain" / "deeper").mkdir(parents = True)
+
+    yielded = list(local_inventory.iter_recursive_scan_dirs(tmp_path))
+
+    assert tmp_path / "a" in yielded
+    assert tmp_path / "a" / "b" in yielded
+    assert tmp_path / "plain" in yielded
+    assert tmp_path / "plain" / "deeper" in yielded
+    assert tmp_path / "a" / "b" / "model-x" not in yielded
+
+
+def test_walker_skips_hidden_and_link_dirs(tmp_path):
+    (tmp_path / ".studio_links" / "x").mkdir(parents = True)
+    (tmp_path / "ollama_links" / "y").mkdir(parents = True)
+    (tmp_path / "kept").mkdir()
+
+    yielded = list(local_inventory.iter_recursive_scan_dirs(tmp_path))
+
+    assert yielded == [tmp_path / "kept"]
+
+
+def test_walker_respects_depth_cap(tmp_path):
+    deep = tmp_path
+    for i in range(12):
+        deep = deep / f"d{i}"
+    deep.mkdir(parents = True)
+
+    yielded = list(local_inventory.iter_recursive_scan_dirs(tmp_path, max_depth = 3))
+
+    assert tmp_path / "d0" / "d1" / "d2" in yielded
+    assert all(len(p.parts) - len(tmp_path.parts) <= 3 for p in yielded)
+
+
+def test_walker_respects_entry_limit(tmp_path):
+    for i in range(30):
+        (tmp_path / f"dir{i:02d}").mkdir()
+
+    yielded = list(local_inventory.iter_recursive_scan_dirs(tmp_path, entry_limit = 10))
+
+    assert len(yielded) <= 10
+
+
+def test_walker_does_not_follow_symlinks(tmp_path):
+    (tmp_path / "real").mkdir()
+    os.symlink(tmp_path, tmp_path / "real" / "loop")
+
+    yielded = list(local_inventory.iter_recursive_scan_dirs(tmp_path))
+
+    assert tmp_path / "real" in yielded
+    assert tmp_path / "real" / "loop" not in yielded
+
+
+def test_scan_custom_folder_finds_nested_models_only_when_recursive(tmp_path):
+    _make_model_dir(tmp_path / "vendor" / "family" / "model-deep")
+    _make_model_dir(tmp_path / "model-shallow")
+
+    flat = local_inventory._scan_custom_folder(tmp_path)
+    flat_paths = {m.path for m in flat}
+    assert any("model-shallow" in p for p in flat_paths)
+    assert not any("model-deep" in p for p in flat_paths)
+
+    recursive = local_inventory._scan_custom_folder(tmp_path, recursive = True)
+    recursive_paths = {m.path for m in recursive}
+    assert any("model-shallow" in p for p in recursive_paths)
+    assert any("model-deep" in p for p in recursive_paths)
+
+
+def test_scan_custom_folder_recursive_does_not_duplicate(tmp_path):
+    _make_model_dir(tmp_path / "sub" / "model-a")
+
+    recursive = local_inventory._scan_custom_folder(tmp_path, recursive = True)
+
+    matches = [m for m in recursive if "model-a" in m.path]
+    assert len(matches) == 1
+
+
+def _tmp_connection_factory(db_path):
+    def _connect():
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    return _connect
+
+
+def test_add_scan_folder_round_trips_recursive(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        scan_folders, "get_connection", _tmp_connection_factory(tmp_path / "studio.db")
+    )
+    monkeypatch.setattr(scan_folders, "_schema_ready", False)
+    monkeypatch.setattr(scan_folders, "_denied_path_prefixes", lambda: [])
+    target = tmp_path / "models"
+    target.mkdir()
+
+    folder = scan_folders.add_scan_folder(str(target), recursive = True)
+    assert folder["recursive"] == 1
+
+    listed = scan_folders.list_scan_folders()
+    assert [f["recursive"] for f in listed] == [1]
+
+    updated = scan_folders.add_scan_folder(str(target), recursive = False)
+    assert updated["recursive"] == 0
+    assert [f["recursive"] for f in scan_folders.list_scan_folders()] == [0]
+
+
+def test_schema_migrates_existing_table(tmp_path, monkeypatch):
+    db_path = tmp_path / "studio.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        CREATE TABLE scan_folders (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            path TEXT NOT NULL UNIQUE,
+            created_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO scan_folders (path, created_at) VALUES (?, ?)",
+        ("/somewhere", "2026-01-01T00:00:00+00:00"),
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(scan_folders, "get_connection", _tmp_connection_factory(db_path))
+    monkeypatch.setattr(scan_folders, "_schema_ready", False)
+
+    listed = scan_folders.list_scan_folders()
+    assert listed[0]["recursive"] == 0
+
+    monkeypatch.setattr(scan_folders, "_schema_ready", False)
+    listed_again = scan_folders.list_scan_folders()
+    assert listed_again[0]["recursive"] == 0

--- a/studio/backend/hub/tests/test_recursive_scan_folders.py
+++ b/studio/backend/hub/tests/test_recursive_scan_folders.py
@@ -142,9 +142,7 @@ def test_recursive_scan_rejects_symlinked_weight_files(tmp_path):
     outside = tmp_path / "outside"
     outside.mkdir()
     (outside / "real.safetensors").write_bytes(b"\0" * 8)
-    os.symlink(
-        outside / "real.safetensors", root / "x" / "a" / "model-s" / "model.safetensors"
-    )
+    os.symlink(outside / "real.safetensors", root / "x" / "a" / "model-s" / "model.safetensors")
 
     recursive = local_inventory._scan_custom_folder(root, recursive = True)
 

--- a/studio/backend/hub/tests/test_recursive_scan_folders.py
+++ b/studio/backend/hub/tests/test_recursive_scan_folders.py
@@ -186,6 +186,80 @@ def test_recursive_scan_does_not_surface_config_only_intermediate(tmp_path):
     assert str(tmp_path / "family") not in paths
 
 
+def test_scan_result_within_folder_rejects_symlinked_companion_gguf(tmp_path):
+    root = tmp_path / "root"
+    model = root / "model"
+    model.mkdir(parents = True)
+    (model / "model.gguf").write_bytes(b"\0" * 8)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "mmproj-model.gguf").write_bytes(b"\0" * 8)
+    os.symlink(outside / "mmproj-model.gguf", model / "mmproj-model.gguf")
+
+    assert local_inventory.scan_result_within_folder(str(model), root) is False
+
+
+def test_scan_result_within_folder_rejects_any_symlinked_entry_outside(tmp_path):
+    root = tmp_path / "root"
+    model = root / "model"
+    model.mkdir(parents = True)
+    (model / "model.safetensors").write_bytes(b"\0" * 8)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "config.json").write_text("{}")
+    os.symlink(outside / "config.json", model / "config.json")
+
+    assert local_inventory.scan_result_within_folder(str(model), root) is False
+
+
+def test_scan_result_within_folder_allows_symlinks_inside_folder(tmp_path):
+    root = tmp_path / "root"
+    model = root / "model"
+    model.mkdir(parents = True)
+    (root / "shared.safetensors").write_bytes(b"\0" * 8)
+    os.symlink(root / "shared.safetensors", model / "model.safetensors")
+
+    assert local_inventory.scan_result_within_folder(str(model), root) is True
+
+
+def test_dir_has_loadable_weights_rejects_config_and_companion_only(tmp_path):
+    config_only = tmp_path / "config_only"
+    config_only.mkdir()
+    (config_only / "config.json").write_text("{}")
+    assert local_inventory._dir_has_loadable_weights(config_only) is False
+
+    companion_only = tmp_path / "companion"
+    companion_only.mkdir()
+    (companion_only / "mmproj-model.gguf").write_bytes(b"\0" * 8)
+    assert local_inventory._dir_has_loadable_weights(companion_only) is False
+
+    real = tmp_path / "real"
+    real.mkdir()
+    (real / "model.safetensors").write_bytes(b"\0" * 8)
+    assert local_inventory._dir_has_loadable_weights(real) is True
+
+    main_gguf = tmp_path / "gg"
+    main_gguf.mkdir()
+    (main_gguf / "model.gguf").write_bytes(b"\0" * 8)
+    assert local_inventory._dir_has_loadable_weights(main_gguf) is True
+
+
+def test_leaf_probe_prunes_gguf_dir_past_default_window(tmp_path):
+    model = tmp_path / "model"
+    model.mkdir()
+    for i in range(250):
+        (model / f"note{i:03d}.txt").write_text("x")
+    (model / "model.gguf").write_bytes(b"\0" * 8)
+    (tmp_path / "plain").mkdir()
+
+    yielded = list(local_inventory.iter_recursive_scan_dirs(tmp_path))
+
+    # The main GGUF sorts after 200 entries; with the probe raised to the entry
+    # limit the dir is still classified as a model leaf and pruned from descent.
+    assert model not in yielded
+    assert tmp_path / "plain" in yielded
+
+
 def test_scan_custom_folder_recursive_does_not_duplicate(tmp_path):
     _make_model_dir(tmp_path / "sub" / "model-a")
 

--- a/studio/backend/hub/tests/test_recursive_scan_folders.py
+++ b/studio/backend/hub/tests/test_recursive_scan_folders.py
@@ -104,6 +104,53 @@ def test_recursive_scan_ignores_symlinked_models_outside_folder(tmp_path):
     assert not any("model-o" in m.path or "link" in m.path for m in recursive)
 
 
+def test_recursive_scan_descends_through_weight_only_dirs(tmp_path):
+    (tmp_path / "family").mkdir()
+    (tmp_path / "family" / "orphan.safetensors").write_bytes(b"\0" * 8)
+    _make_model_dir(tmp_path / "family" / "variant" / "model-y")
+
+    recursive = local_inventory._scan_custom_folder(tmp_path, recursive = True)
+
+    assert any("model-y" in m.path for m in recursive)
+
+
+def test_walker_prunes_gguf_leaf_dirs(tmp_path):
+    (tmp_path / "gguf-model").mkdir()
+    (tmp_path / "gguf-model" / "model.gguf").write_bytes(b"\0" * 8)
+    (tmp_path / "plain").mkdir()
+
+    yielded = list(local_inventory.iter_recursive_scan_dirs(tmp_path))
+
+    assert tmp_path / "plain" in yielded
+    assert tmp_path / "gguf-model" not in yielded
+
+
+def test_walker_counts_files_toward_entry_limit(tmp_path):
+    for i in range(60):
+        (tmp_path / f"file{i:02d}.txt").write_text("x")
+    (tmp_path / "sub").mkdir()
+
+    yielded = list(local_inventory.iter_recursive_scan_dirs(tmp_path, entry_limit = 10))
+
+    assert yielded == []
+
+
+def test_recursive_scan_rejects_symlinked_weight_files(tmp_path):
+    root = tmp_path / "root"
+    (root / "x" / "a" / "model-s").mkdir(parents = True)
+    (root / "x" / "a" / "model-s" / "config.json").write_text("{}")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "real.safetensors").write_bytes(b"\0" * 8)
+    os.symlink(
+        outside / "real.safetensors", root / "x" / "a" / "model-s" / "model.safetensors"
+    )
+
+    recursive = local_inventory._scan_custom_folder(root, recursive = True)
+
+    assert not any("model-s" in m.path for m in recursive)
+
+
 def test_scan_custom_folder_recursive_does_not_duplicate(tmp_path):
     _make_model_dir(tmp_path / "sub" / "model-a")
 
@@ -136,6 +183,10 @@ def test_add_scan_folder_round_trips_recursive(tmp_path, monkeypatch):
 
     listed = scan_folders.list_scan_folders()
     assert [f["recursive"] for f in listed] == [1]
+
+    unchanged = scan_folders.add_scan_folder(str(target))
+    assert unchanged["recursive"] == 1
+    assert [f["recursive"] for f in scan_folders.list_scan_folders()] == [1]
 
     updated = scan_folders.add_scan_folder(str(target), recursive = False)
     assert updated["recursive"] == 0

--- a/studio/backend/hub/tests/test_recursive_scan_folders.py
+++ b/studio/backend/hub/tests/test_recursive_scan_folders.py
@@ -149,6 +149,43 @@ def test_recursive_scan_rejects_symlinked_weight_files(tmp_path):
     assert not any("model-s" in m.path for m in recursive)
 
 
+def test_scan_result_within_folder_checks_weights_past_probe_window(tmp_path):
+    root = tmp_path / "root"
+    model = root / "model"
+    model.mkdir(parents = True)
+    (model / "config.json").write_text("{}")
+    # Many non-weight files so the escaping weight sits well past the old probe cap.
+    for i in range(250):
+        (model / f"note{i:03d}.txt").write_text("x")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "real.safetensors").write_bytes(b"\0" * 8)
+    os.symlink(outside / "real.safetensors", model / "model.safetensors")
+
+    assert local_inventory.scan_result_within_folder(str(model), root) is False
+
+
+def test_scan_result_within_folder_accepts_contained_weights(tmp_path):
+    root = tmp_path / "root"
+    model = root / "model"
+    model.mkdir(parents = True)
+    (model / "model.safetensors").write_bytes(b"\0" * 8)
+
+    assert local_inventory.scan_result_within_folder(str(model), root) is True
+
+
+def test_recursive_scan_does_not_surface_config_only_intermediate(tmp_path):
+    (tmp_path / "family").mkdir()
+    (tmp_path / "family" / "config.json").write_text("{}")
+    _make_model_dir(tmp_path / "family" / "variant" / "model-real")
+
+    recursive = local_inventory._scan_custom_folder(tmp_path, recursive = True)
+    paths = {m.path for m in recursive}
+
+    assert any("model-real" in p for p in paths)
+    assert str(tmp_path / "family") not in paths
+
+
 def test_scan_custom_folder_recursive_does_not_duplicate(tmp_path):
     _make_model_dir(tmp_path / "sub" / "model-a")
 

--- a/studio/backend/hub/tests/test_recursive_scan_folders.py
+++ b/studio/backend/hub/tests/test_recursive_scan_folders.py
@@ -83,6 +83,27 @@ def test_scan_custom_folder_finds_nested_models_only_when_recursive(tmp_path):
     assert any("model-deep" in p for p in recursive_paths)
 
 
+def test_recursive_scan_descends_through_config_only_dirs(tmp_path):
+    (tmp_path / "family").mkdir()
+    (tmp_path / "family" / "config.json").write_text("{}")
+    _make_model_dir(tmp_path / "family" / "variant" / "model-nested")
+
+    recursive = local_inventory._scan_custom_folder(tmp_path, recursive = True)
+
+    assert any("model-nested" in m.path for m in recursive)
+
+
+def test_recursive_scan_ignores_symlinked_models_outside_folder(tmp_path):
+    root = tmp_path / "root"
+    (root / "a" / "b").mkdir(parents = True)
+    _make_model_dir(tmp_path / "outside" / "model-o")
+    os.symlink(tmp_path / "outside" / "model-o", root / "a" / "b" / "link")
+
+    recursive = local_inventory._scan_custom_folder(root, recursive = True)
+
+    assert not any("model-o" in m.path or "link" in m.path for m in recursive)
+
+
 def test_scan_custom_folder_recursive_does_not_duplicate(tmp_path):
     _make_model_dir(tmp_path / "sub" / "model-a")
 

--- a/studio/backend/models/models.py
+++ b/studio/backend/models/models.py
@@ -211,7 +211,9 @@ class AddScanFolderRequest(BaseModel):
     """Request body for adding a custom scan folder."""
 
     path: str = Field(..., description = "Absolute or relative directory path to scan for models")
-    recursive: bool = Field(False, description = "Also scan sub-folders (bounded depth) for models")
+    recursive: Optional[bool] = Field(
+        None, description = "Also scan sub-folders (bounded depth) for models"
+    )
 
 
 class ScanFolderInfo(BaseModel):

--- a/studio/backend/models/models.py
+++ b/studio/backend/models/models.py
@@ -211,6 +211,7 @@ class AddScanFolderRequest(BaseModel):
     """Request body for adding a custom scan folder."""
 
     path: str = Field(..., description = "Absolute or relative directory path to scan for models")
+    recursive: bool = Field(False, description = "Also scan sub-folders (bounded depth) for models")
 
 
 class ScanFolderInfo(BaseModel):
@@ -218,6 +219,7 @@ class ScanFolderInfo(BaseModel):
 
     id: int = Field(..., description = "Database row ID")
     path: str = Field(..., description = "Normalized absolute path")
+    recursive: int = Field(0, description = "1 when sub-folders are also scanned")
     created_at: str = Field(..., description = "ISO 8601 creation timestamp")
 
 

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -335,6 +335,9 @@ def _scan_models_dir(
             ),
         ]
 
+    # Directories and standalone .gguf files are handled in a single pass so each
+    # entry is counted against entry_limit exactly once; a separate glob pass would
+    # count a top-level .gguf again and could drop it once the cap is reached.
     found: List[LocalModelInfo] = []
     visited = 0
     for child in models_dir.iterdir():
@@ -344,23 +347,41 @@ def _scan_models_dir(
         if entry_limit is not None and visited > entry_limit:
             break
         try:
-            if not child.is_dir():
+            is_dir = child.is_dir()
+            is_gguf_file = (
+                not is_dir
+                and child.suffix.lower() == ".gguf"
+                and child.is_file()
+            )
+            if not is_dir and not is_gguf_file:
                 continue
-            has_gguf = any(child.glob("*.gguf"))
-            has_non_gguf_weights = _has_non_gguf_weights(child)
-            has_config = (child / "config.json").exists() or (
-                child / "adapter_config.json"
-            ).exists()
-            has_model_files = has_gguf or has_non_gguf_weights or has_config
+            if is_dir:
+                has_gguf = any(child.glob("*.gguf"))
+                has_non_gguf_weights = _has_non_gguf_weights(child)
+                has_config = (child / "config.json").exists() or (
+                    child / "adapter_config.json"
+                ).exists()
+                if not (has_gguf or has_non_gguf_weights or has_config):
+                    continue
         except OSError:
             # Skip unreadable children rather than failing the scan.
-            continue
-        if not has_model_files:
             continue
         try:
             updated_at = child.stat().st_mtime
         except OSError:
             updated_at = None
+        if is_gguf_file:
+            found.append(
+                LocalModelInfo(
+                    id = str(child),
+                    display_name = child.stem,
+                    path = str(child),
+                    source = "models_dir",
+                    model_format = "gguf",
+                    updated_at = updated_at,
+                ),
+            )
+            continue
         # A folder whose only weights are .gguf is GGUF-format even when it also
         # ships a config.json (common for HF GGUF repos); such folders often lack
         # a -GGUF suffix, so surface the format for the UI's GGUF classification.
@@ -375,29 +396,6 @@ def _scan_models_dir(
                 updated_at = updated_at,
             ),
         )
-    # Also scan standalone .gguf files in the models directory.
-    if limit is None or len(found) < limit:
-        for gguf_file in models_dir.glob("*.gguf"):
-            if limit is not None and len(found) >= limit:
-                break
-            visited += 1
-            if entry_limit is not None and visited > entry_limit:
-                break
-            if gguf_file.is_file():
-                try:
-                    updated_at = gguf_file.stat().st_mtime
-                except OSError:
-                    updated_at = None
-                found.append(
-                    LocalModelInfo(
-                        id = str(gguf_file),
-                        display_name = gguf_file.stem,
-                        path = str(gguf_file),
-                        source = "models_dir",
-                        model_format = "gguf",
-                        updated_at = updated_at,
-                    ),
-                )
 
     return found
 

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -832,6 +832,7 @@ def collect_local_models(models_root: Path) -> List[LocalModelInfo]:
             if folder.get("recursive"):
                 from hub.services.models.local_inventory import iter_recursive_scan_dirs
                 from hub.utils.paths import path_is_same_or_child
+
                 seen = {
                     (m.path, m.model_format, getattr(m, "format_variant", None))
                     for m in custom_models
@@ -848,8 +849,7 @@ def collect_local_models(models_root: Path) -> List[LocalModelInfo]:
                             key in seen
                             or not path_is_same_or_child(Path(m.path), folder_path)
                             or any(
-                                p in (".studio_links", "ollama_links")
-                                for p in Path(m.path).parts
+                                p in (".studio_links", "ollama_links") for p in Path(m.path).parts
                             )
                         ):
                             continue

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -831,7 +831,11 @@ def collect_local_models(models_root: Path) -> List[LocalModelInfo]:
             custom_models = _generic
             if folder.get("recursive"):
                 from hub.services.models.local_inventory import iter_recursive_scan_dirs
-                seen = {(m.path, m.model_format, m.format_variant) for m in custom_models}
+                from hub.utils.paths import path_is_same_or_child
+                seen = {
+                    (m.path, m.model_format, getattr(m, "format_variant", None))
+                    for m in custom_models
+                }
                 for subdir in iter_recursive_scan_dirs(folder_path):
                     if len(custom_models) >= _MAX_MODELS_PER_FOLDER:
                         break
@@ -839,9 +843,14 @@ def collect_local_models(models_root: Path) -> List[LocalModelInfo]:
                         subdir,
                         limit = _MAX_MODELS_PER_FOLDER - len(custom_models),
                     ):
-                        key = (m.path, m.model_format, m.format_variant)
-                        if key in seen or any(
-                            p in (".studio_links", "ollama_links") for p in Path(m.path).parts
+                        key = (m.path, m.model_format, getattr(m, "format_variant", None))
+                        if (
+                            key in seen
+                            or not path_is_same_or_child(Path(m.path), folder_path)
+                            or any(
+                                p in (".studio_links", "ollama_links")
+                                for p in Path(m.path).parts
+                            )
                         ):
                             continue
                         seen.add(key)

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -831,7 +831,6 @@ def collect_local_models(models_root: Path) -> List[LocalModelInfo]:
             custom_models = _generic
             if folder.get("recursive"):
                 from hub.services.models.local_inventory import iter_recursive_scan_dirs
-
                 seen = {(m.path, m.model_format, m.format_variant) for m in custom_models}
                 for subdir in iter_recursive_scan_dirs(folder_path):
                     if len(custom_models) >= _MAX_MODELS_PER_FOLDER:

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -295,15 +295,23 @@ def _has_non_gguf_weights(path: Path) -> bool:
 
 
 def _dir_has_loadable_weights(path: Path) -> bool:
+    from hub.services.models.common import _is_main_gguf_filename
+
     try:
         if path.is_file():
+            if path.suffix.lower() == ".gguf":
+                return _is_main_gguf_filename(path.name)
             return True
-        return any(path.glob("*.gguf")) or _has_non_gguf_weights(path)
+        if any(_is_main_gguf_filename(f.name) for f in path.glob("*.gguf")):
+            return True
+        return _has_non_gguf_weights(path)
     except OSError:
         return False
 
 
-def _scan_models_dir(models_dir: Path, *, limit: int | None = None) -> List[LocalModelInfo]:
+def _scan_models_dir(
+    models_dir: Path, *, limit: int | None = None, entry_limit: int | None = None
+) -> List[LocalModelInfo]:
     if not models_dir.exists() or not models_dir.is_dir():
         return []
 
@@ -326,8 +334,12 @@ def _scan_models_dir(models_dir: Path, *, limit: int | None = None) -> List[Loca
         ]
 
     found: List[LocalModelInfo] = []
+    visited = 0
     for child in models_dir.iterdir():
         if limit is not None and len(found) >= limit:
+            break
+        visited += 1
+        if entry_limit is not None and visited > entry_limit:
             break
         try:
             if not child.is_dir():
@@ -365,6 +377,9 @@ def _scan_models_dir(models_dir: Path, *, limit: int | None = None) -> List[Loca
     if limit is None or len(found) < limit:
         for gguf_file in models_dir.glob("*.gguf"):
             if limit is not None and len(found) >= limit:
+                break
+            visited += 1
+            if entry_limit is not None and visited > entry_limit:
                 break
             if gguf_file.is_file():
                 try:
@@ -831,7 +846,9 @@ def collect_local_models(models_root: Path) -> List[LocalModelInfo]:
             _generic = [
                 m
                 for m in (
-                    _scan_models_dir(folder_path, limit = _MAX_MODELS_PER_FOLDER)
+                    _scan_models_dir(
+                        folder_path, limit = _MAX_MODELS_PER_FOLDER, entry_limit = 2000
+                    )
                     + _scan_hf_cache(folder_path)
                     + _scan_lmstudio_dir(folder_path)
                 )
@@ -853,6 +870,7 @@ def collect_local_models(models_root: Path) -> List[LocalModelInfo]:
                     for m in _scan_models_dir(
                         subdir,
                         limit = _MAX_MODELS_PER_FOLDER - len(custom_models),
+                        entry_limit = 2000,
                     ):
                         key = (m.path, m.model_format, getattr(m, "format_variant", None))
                         if (

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -830,9 +830,10 @@ def collect_local_models(models_root: Path) -> List[LocalModelInfo]:
             ]
             custom_models = _generic
             if folder.get("recursive"):
-                from hub.services.models.local_inventory import iter_recursive_scan_dirs
-                from hub.utils.paths import path_is_same_or_child
-
+                from hub.services.models.local_inventory import (
+                    iter_recursive_scan_dirs,
+                    scan_result_within_folder,
+                )
                 seen = {
                     (m.path, m.model_format, getattr(m, "format_variant", None))
                     for m in custom_models
@@ -847,7 +848,7 @@ def collect_local_models(models_root: Path) -> List[LocalModelInfo]:
                         key = (m.path, m.model_format, getattr(m, "format_variant", None))
                         if (
                             key in seen
-                            or not path_is_same_or_child(Path(m.path), folder_path)
+                            or not scan_result_within_folder(m.path, folder_path)
                             or any(
                                 p in (".studio_links", "ollama_links") for p in Path(m.path).parts
                             )

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -294,6 +294,15 @@ def _has_non_gguf_weights(path: Path) -> bool:
         return False
 
 
+def _dir_has_loadable_weights(path: Path) -> bool:
+    try:
+        if path.is_file():
+            return True
+        return any(path.glob("*.gguf")) or _has_non_gguf_weights(path)
+    except OSError:
+        return False
+
+
 def _scan_models_dir(models_dir: Path, *, limit: int | None = None) -> List[LocalModelInfo]:
     if not models_dir.exists() or not models_dir.is_dir():
         return []
@@ -849,6 +858,7 @@ def collect_local_models(models_root: Path) -> List[LocalModelInfo]:
                         if (
                             key in seen
                             or not scan_result_within_folder(m.path, folder_path)
+                            or not _dir_has_loadable_weights(Path(m.path))
                             or any(
                                 p in (".studio_links", "ollama_links") for p in Path(m.path).parts
                             )

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -829,6 +829,24 @@ def collect_local_models(models_root: Path) -> List[LocalModelInfo]:
                 if not any(p in (".studio_links", "ollama_links") for p in Path(m.path).parts)
             ]
             custom_models = _generic
+            if folder.get("recursive"):
+                from hub.services.models.local_inventory import iter_recursive_scan_dirs
+
+                seen = {(m.path, m.model_format, m.format_variant) for m in custom_models}
+                for subdir in iter_recursive_scan_dirs(folder_path):
+                    if len(custom_models) >= _MAX_MODELS_PER_FOLDER:
+                        break
+                    for m in _scan_models_dir(
+                        subdir,
+                        limit = _MAX_MODELS_PER_FOLDER - len(custom_models),
+                    ):
+                        key = (m.path, m.model_format, m.format_variant)
+                        if key in seen or any(
+                            p in (".studio_links", "ollama_links") for p in Path(m.path).parts
+                        ):
+                            continue
+                        seen.add(key)
+                        custom_models.append(m)
             if len(custom_models) < _MAX_MODELS_PER_FOLDER:
                 custom_models += _scan_ollama_dir(
                     folder_path,
@@ -937,7 +955,7 @@ async def add_scan_folder_endpoint(
     from storage.studio_db import add_scan_folder
 
     try:
-        folder = add_scan_folder(body.path)
+        folder = add_scan_folder(body.path, body.recursive)
     except ValueError as e:
         logger.warning("Scan folder rejected: %s (path=%s)", e, body.path)
         # Forward the curated, path-free validation message.

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -296,7 +296,6 @@ def _has_non_gguf_weights(path: Path) -> bool:
 
 def _dir_has_loadable_weights(path: Path) -> bool:
     from hub.services.models.common import _is_main_gguf_filename
-
     try:
         if path.is_file():
             if path.suffix.lower() == ".gguf":
@@ -310,7 +309,10 @@ def _dir_has_loadable_weights(path: Path) -> bool:
 
 
 def _scan_models_dir(
-    models_dir: Path, *, limit: int | None = None, entry_limit: int | None = None
+    models_dir: Path,
+    *,
+    limit: int | None = None,
+    entry_limit: int | None = None,
 ) -> List[LocalModelInfo]:
     if not models_dir.exists() or not models_dir.is_dir():
         return []
@@ -846,9 +848,7 @@ def collect_local_models(models_root: Path) -> List[LocalModelInfo]:
             _generic = [
                 m
                 for m in (
-                    _scan_models_dir(
-                        folder_path, limit = _MAX_MODELS_PER_FOLDER, entry_limit = 2000
-                    )
+                    _scan_models_dir(folder_path, limit = _MAX_MODELS_PER_FOLDER, entry_limit = 2000)
                     + _scan_hf_cache(folder_path)
                     + _scan_lmstudio_dir(folder_path)
                 )

--- a/studio/backend/storage/studio_db.py
+++ b/studio/backend/storage/studio_db.py
@@ -204,10 +204,16 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         CREATE TABLE IF NOT EXISTS scan_folders (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             path TEXT NOT NULL UNIQUE {collation},
-            created_at TEXT NOT NULL
+            created_at TEXT NOT NULL,
+            recursive INTEGER NOT NULL DEFAULT 0
         )
         """
     )
+    existing_scan_cols = {
+        row[1] for row in conn.execute("PRAGMA table_info(scan_folders)").fetchall()
+    }
+    if "recursive" not in existing_scan_cols:
+        conn.execute("ALTER TABLE scan_folders ADD COLUMN recursive INTEGER NOT NULL DEFAULT 0")
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS chat_projects (
@@ -911,14 +917,14 @@ def list_scan_folders() -> list[dict]:
     conn = get_connection()
     try:
         rows = conn.execute(
-            "SELECT id, path, created_at FROM scan_folders ORDER BY created_at"
+            "SELECT id, path, created_at, recursive FROM scan_folders ORDER BY created_at"
         ).fetchall()
         return [dict(row) for row in rows]
     finally:
         conn.close()
 
 
-def add_scan_folder(path: str) -> dict:
+def add_scan_folder(path: str, recursive: bool = False) -> dict:
     """Add a directory to the custom scan folder list. Returns the row."""
     if not path or not path.strip():
         raise ValueError("Path cannot be empty")
@@ -950,29 +956,36 @@ def add_scan_folder(path: str) -> dict:
         # Windows: case-insensitive lookup so C:\Models and c:\models dedup.
         if is_win:
             existing = conn.execute(
-                "SELECT id, path, created_at FROM scan_folders WHERE path = ? COLLATE NOCASE",
+                "SELECT id, path, created_at, recursive FROM scan_folders WHERE path = ? COLLATE NOCASE",
                 (normalized,),
             ).fetchone()
         else:
             existing = conn.execute(
-                "SELECT id, path, created_at FROM scan_folders WHERE path = ?",
+                "SELECT id, path, created_at, recursive FROM scan_folders WHERE path = ?",
                 (normalized,),
             ).fetchone()
         if existing is not None:
+            if bool(existing["recursive"]) != recursive:
+                conn.execute(
+                    "UPDATE scan_folders SET recursive = ? WHERE id = ?",
+                    (1 if recursive else 0, existing["id"]),
+                )
+                conn.commit()
+                return {**dict(existing), "recursive": 1 if recursive else 0}
             return dict(existing)
         try:
             conn.execute(
-                "INSERT INTO scan_folders (path, created_at) VALUES (?, ?)",
-                (normalized, now),
+                "INSERT INTO scan_folders (path, created_at, recursive) VALUES (?, ?, ?)",
+                (normalized, now, 1 if recursive else 0),
             )
             conn.commit()
         except sqlite3.IntegrityError:
             pass  # duplicate; fall through to SELECT
         # Same collation as the pre-check to catch concurrent writes (Windows).
         fallback_sql = (
-            "SELECT id, path, created_at FROM scan_folders WHERE path = ? COLLATE NOCASE"
+            "SELECT id, path, created_at, recursive FROM scan_folders WHERE path = ? COLLATE NOCASE"
             if is_win
-            else "SELECT id, path, created_at FROM scan_folders WHERE path = ?"
+            else "SELECT id, path, created_at, recursive FROM scan_folders WHERE path = ?"
         )
         row = conn.execute(fallback_sql, (normalized,)).fetchone()
         if row is None:

--- a/studio/backend/storage/studio_db.py
+++ b/studio/backend/storage/studio_db.py
@@ -924,7 +924,7 @@ def list_scan_folders() -> list[dict]:
         conn.close()
 
 
-def add_scan_folder(path: str, recursive: bool = False) -> dict:
+def add_scan_folder(path: str, recursive: bool | None = None) -> dict:
     """Add a directory to the custom scan folder list. Returns the row."""
     if not path or not path.strip():
         raise ValueError("Path cannot be empty")
@@ -937,6 +937,8 @@ def add_scan_folder(path: str, recursive: bool = False) -> dict:
         raise ValueError("Path must be a directory, not a file")
     if not os.access(normalized, os.R_OK | os.X_OK):
         raise ValueError("Path is not readable")
+    if os.path.dirname(normalized) == normalized:
+        raise ValueError("The filesystem root cannot be registered")
     if _contains_sensitive_path_component(normalized):
         raise ValueError("Credential or configuration directories are not allowed")
 
@@ -965,7 +967,7 @@ def add_scan_folder(path: str, recursive: bool = False) -> dict:
                 (normalized,),
             ).fetchone()
         if existing is not None:
-            if bool(existing["recursive"]) != recursive:
+            if recursive is not None and bool(existing["recursive"]) != bool(recursive):
                 conn.execute(
                     "UPDATE scan_folders SET recursive = ? WHERE id = ?",
                     (1 if recursive else 0, existing["id"]),

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -372,12 +372,14 @@ export async function listScanFolders(): Promise<ScanFolderInfo[]> {
 
 export async function addScanFolder(
   path: string,
-  recursive = false,
+  recursive?: boolean,
 ): Promise<ScanFolderInfo> {
   const response = await authFetch("/api/models/scan-folders", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ path, recursive }),
+    body: JSON.stringify(
+      recursive === undefined ? { path } : { path, recursive },
+    ),
   });
   return parseJsonOrThrow<ScanFolderInfo>(response);
 }

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -361,6 +361,7 @@ export interface ScanFolderInfo {
   id: number;
   path: string;
   created_at: string;
+  recursive?: number;
 }
 
 export async function listScanFolders(): Promise<ScanFolderInfo[]> {
@@ -369,11 +370,14 @@ export async function listScanFolders(): Promise<ScanFolderInfo[]> {
   return data.folders;
 }
 
-export async function addScanFolder(path: string): Promise<ScanFolderInfo> {
+export async function addScanFolder(
+  path: string,
+  recursive = false,
+): Promise<ScanFolderInfo> {
   const response = await authFetch("/api/models/scan-folders", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ path }),
+    body: JSON.stringify({ path, recursive }),
   });
   return parseJsonOrThrow<ScanFolderInfo>(response);
 }

--- a/studio/frontend/src/features/hub/catalog/on-device-folders-dialog.tsx
+++ b/studio/frontend/src/features/hub/catalog/on-device-folders-dialog.tsx
@@ -3,6 +3,7 @@
 
 import { FolderBrowser } from "@/components/assistant-ui/model-selector/folder-browser";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -60,6 +61,7 @@ export function OnDeviceFoldersDialog({
 }) {
   const [folders, setFolders] = useState<ScanFolderInfo[]>([]);
   const [path, setPath] = useState("");
+  const [recursive, setRecursive] = useState(false);
   const [browserOpen, setBrowserOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -119,8 +121,9 @@ export function OnDeviceFoldersDialog({
       setPending("add");
       setError(null);
       try {
-        const folder = await addScanFolder(nextPath);
+        const folder = await addScanFolder(nextPath, recursive);
         setPath("");
+        setRecursive(false);
         mutationVersionRef.current += 1;
         setFolders((current) => {
           const withoutDuplicate = current.filter((row) => row.id !== folder.id);
@@ -138,7 +141,7 @@ export function OnDeviceFoldersDialog({
         setPending(null);
       }
     },
-    [handleInventoryChanged, pending],
+    [handleInventoryChanged, pending, recursive],
   );
 
   // Scan folders are arbitrary paths that may be moved or deleted after they
@@ -262,6 +265,20 @@ export function OnDeviceFoldersDialog({
                     Add
                   </Button>
                 </div>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="scan-subfolders"
+                  checked={recursive}
+                  onCheckedChange={(v) => setRecursive(!!v)}
+                />
+                <label
+                  htmlFor="scan-subfolders"
+                  className="text-[12px] text-muted-foreground"
+                >
+                  Also scan sub-folders
+                </label>
               </div>
             </div>
 

--- a/studio/frontend/src/features/hub/inventory/api.ts
+++ b/studio/frontend/src/features/hub/inventory/api.ts
@@ -139,6 +139,7 @@ export interface ScanFolderInfo {
   id: number;
   path: string;
   created_at: string;
+  recursive?: number;
 }
 
 export interface BrowseEntry {
@@ -294,11 +295,14 @@ export async function listScanFolders(): Promise<ScanFolderInfo[]> {
   return data.folders;
 }
 
-export async function addScanFolder(path: string): Promise<ScanFolderInfo> {
+export async function addScanFolder(
+  path: string,
+  recursive = false,
+): Promise<ScanFolderInfo> {
   const response = await authFetch("/api/hub/scan-folders", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ path }),
+    body: JSON.stringify({ path, recursive }),
   });
   const folder = await parseJsonOrThrow<ScanFolderInfo>(response);
   bumpInventoryVersion();

--- a/studio/frontend/src/features/hub/inventory/api.ts
+++ b/studio/frontend/src/features/hub/inventory/api.ts
@@ -297,12 +297,14 @@ export async function listScanFolders(): Promise<ScanFolderInfo[]> {
 
 export async function addScanFolder(
   path: string,
-  recursive = false,
+  recursive?: boolean,
 ): Promise<ScanFolderInfo> {
   const response = await authFetch("/api/hub/scan-folders", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ path, recursive }),
+    body: JSON.stringify(
+      recursive === undefined ? { path } : { path, recursive },
+    ),
   });
   const folder = await parseJsonOrThrow<ScanFolderInfo>(response);
   bumpInventoryVersion();


### PR DESCRIPTION
## Summary

Closes #6371 (option 1)

Registered custom scan folders only surface models that sit directly inside them, so a library organized as nested trees (`vendor/family/model`) never shows up in the Hub. This adds an opt-in **Also scan sub-folders** checkbox when registering a location. Folders added without it keep byte-identical behavior, and option 2 from the issue (whole disk indexing) is intentionally out of scope.

## How it works

- `scan_folders` gains a nullable `recursive` column (default 0), added idempotently via the same `PRAGMA table_info` + `ALTER TABLE` pattern the schema init already uses for other tables. Both bootstrap sites are kept in sync (`hub/storage/scan_folders.py` and the legacy `storage/studio_db.py`, which share the table). Re-registering an existing folder updates its flag.
- `iter_recursive_scan_dirs` in `hub/services/models/local_inventory.py` is a bounded walker: `os.walk` with `followlinks=False`, a depth cap of 8, the existing `_MAX_CUSTOM_FOLDER_ENTRIES` visited cap, hidden and `ollama_links` directories skipped, and directories with an immediate model signal never descended into (they are classified as children of their parent's scan, exactly like today's depth-1 behavior).
- Both scan paths honor the flag: `_scan_custom_folder` (Hub inventory) and the legacy `collect_local_models` loop in `routes/models.py`. A seen-set keyed on `(path, model_format, format_variant)` prevents double-reporting models the base scanners already find (for example the LM Studio scanner already catches exactly-depth-2 `publisher/repo` layouts), and the existing `_MAX_MODELS_PER_CUSTOM_FOLDER` cap applies across the whole folder.
- API: `recursive` on `AddScanFolderRequest` / `ScanFolderInfo`, threaded through both POST endpoints (`/api/hub/scan-folders` and `/api/models/scan-folders`).
- Frontend: checkbox in the add-location dialog, threaded through both `addScanFolder` clients.

Security posture is unchanged: registration-time path validation (denied prefixes, sensitive-path denylist) is inherited, symlinks are never followed, and the walk is hard-capped by depth and entry count.

## Tests

`studio/backend/hub/tests/test_recursive_scan_folders.py` (CPU-only, runs with the existing hub test stubs):

- walker yields nested dirs, prunes model dirs, skips hidden/`ollama_links`, respects the depth cap and entry limit, and does not follow symlink cycles
- `_scan_custom_folder` finds a depth-3 model only when the flag is on, keeps the flat behavior otherwise, and does not double-report a model the LM Studio scanner already found
- storage round-trips the flag (including updating it on re-add) and migrates an existing `scan_folders` table without the column, idempotently

All 136 hub backend tests pass locally (127 existing + 9 new).
