### PR TITLE
Studio: install torch 2.11 on all modern CUDA (cu126/cu128/cu130)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2468,10 +2468,16 @@ case "$_torch_index_leaf" in
     *)          export UNSLOTH_TORCH_BACKEND="cuda" ;;
 esac
 
-# rocm7.2 ships torch 2.11.0 -- adjust the constraint to allow it.
-# All other ROCm tags and CUDA stay within <2.11.0.
+# rocm7.2 and the CUDA 12.6+/13 indexes (cu126/cu128/cu130) ship torch 2.11.0 --
+# allow it there: torchao 0.17's cpp kernels load on 2.11, and flash-attn /
+# causal-conv1d / mamba reuse their torch2.10 wheels on 2.11 (see wheel_utils
+# prebuilt_wheel_torch_mm). Older CUDA (cu124/cu118), other ROCm tags, CPU and
+# macOS stay within <2.11.0 -- torch 2.11 publishes no wheels for those.
 case "$TORCH_INDEX_URL" in
     */rocm7.2) TORCH_CONSTRAINT="torch>=2.11.0,<2.12.0" ;;
+    */cu130)   TORCH_CONSTRAINT="torch>=2.11.0,<2.12.0" ;;
+    */cu128)   TORCH_CONSTRAINT="torch>=2.11.0,<2.12.0" ;;
+    */cu126)   TORCH_CONSTRAINT="torch>=2.11.0,<2.12.0" ;;
 esac
 
 # Auto-detect GPU for AMD ROCm based

--- a/tests/sh/test_torch_constraint.sh
+++ b/tests/sh/test_torch_constraint.sh
@@ -108,6 +108,12 @@ assert_eq "\$TORCH_CONSTRAINT used in pip install" "yes" "$_has_var"
 _hardcoded=$(grep -c '"torch>=2.4,<2.11.0"' "$INSTALL_SH" || true)
 assert_eq "hardcoded torch>=2.4 appears exactly once" "1" "$_hardcoded"
 
+# The CUDA 12.6+/13 indexes (cu126/cu128/cu130) override the ceiling to torch 2.11.
+for _tag in cu126 cu128 cu130; do
+    _count=$(grep -cE "\*/${_tag}\).*torch>=2\.11\.0,<2\.12\.0" "$INSTALL_SH" || true)
+    assert_eq "${_tag} torch 2.11 override present" "1" "$_count"
+done
+
 echo ""
 echo "=== Structural: tokenizers in no-torch-runtime.txt ==="
 


### PR DESCRIPTION
## Summary

Install torch 2.11 on all modern CUDA indexes, not just Blackwell/cu130. This extends the existing `rocm7.2` `TORCH_CONSTRAINT` override in `install.sh` to the CUDA 12.6+/13 indexes (`cu126`, `cu128`, `cu130`), all of which publish torch 2.11.0 wheels. It generalizes #6982 (which did cu130 only) into one coherent change for the whole modern-CUDA stack.

```sh
case "$TORCH_INDEX_URL" in
    */rocm7.2) TORCH_CONSTRAINT="torch>=2.11.0,<2.12.0" ;;
    */cu130)   TORCH_CONSTRAINT="torch>=2.11.0,<2.12.0" ;;
    */cu128)   TORCH_CONSTRAINT="torch>=2.11.0,<2.12.0" ;;
    */cu126)   TORCH_CONSTRAINT="torch>=2.11.0,<2.12.0" ;;
esac
```

The default `torch>=2.4,<2.11.0` is intentionally left untouched, so older CUDA (`cu124`/`cu118`), other ROCm tags, CPU, and macOS stay on the 2.10 family. torch 2.11 publishes no wheels for those indexes, so bumping the default would make old-driver fresh installs resolve a nonexistent wheel and fail. Keeping the default also means the "hardcoded torch>=2.4 appears exactly once" test guard stays valid.

torch 2.11 is already supported end to end from #6970: torchao 0.17's cpp kernels load on 2.11, and flash-attn / causal-conv1d / mamba reuse their torch2.10 wheels via `wheel_utils.prebuilt_wheel_torch_mm`. GPU-arch support is unchanged: `cu126` 2.11 keeps Maxwell/Pascal/Volta/Turing+, and `cu128`/`cu130` are Turing (SM 7.5)+ exactly as their 2.10 counterparts were.

## Verification

Structural tests: `tests/sh/test_torch_constraint.sh` asserts each cu126/cu128/cu130 override is present (26 -> now covers all three) and passes 28/28; `tests/python/test_tokenizers_and_torch_constraint.py` and `studio/backend/tests/test_torchao_select.py` pass.

Stack smoke on a B200 (sm_100, compute cap 10.0) with a fresh torch 2.11.0+cu130 venv, the exact wheels the installer selects:

- torch 2.11.0+cu130 initializes, device reports B200 / (10, 0)
- flash-attn 2.8.1 (the torch2.10 cu13 wheel): FA2 forward matches SDPA, `max|err| = 8.1e-03` (bf16)
- torchao 0.17.0: int8-weight-only quantized `Linear` runs (cpp path loads, output finite)
- bitsandbytes 0.49.2: `Linear4bit` runs, output finite
- triton 3.6.0 and xformers 0.0.35 import

This complements the RTX 5090 (sm_120) run in #6982, so both Blackwell tiers are covered on torch 2.11.

## Scope / follow-ups

- Supersedes #6982 (cu130 only). Happy to close that in favor of this, keeping its 5090 verification noted here.
- cu126/cu128 target Ampere/Hopper/older; a spot-check LoRA run on one of those archs would round it out, though the accelerator reuse is a torch-version ABI property (proven on 2.11) independent of CUDA major.
- CPU, macOS arm64, and Windows CUDA (install.ps1) are separate follow-ups; each has torch 2.11 wheels but wants its own smoke pass. Old CUDA (cu124/cu118), non-7.2 ROCm, and macOS x86 stay on 2.10 (no 2.11 wheels).

Related: #6961, #6970, #6982.
