### PR TITLE
Studio: install torchao Windows ROCm stub in the inference worker

### DIFF
--- a/studio/backend/core/inference/worker.py
+++ b/studio/backend/core/inference/worker.py
@@ -1003,6 +1003,13 @@ def run_inference_process(
 
         ensure_real_packages("unsloth_zoo", "unsloth")
 
+        # Stub torchao on Windows ROCm before importing transformers / unsloth
+        # (RCCL absent). No-op off Windows ROCm. Must run before the import below,
+        # which pulls in transformers transitively via InferenceBackend.
+        from core._torchao_stub import install_torchao_windows_rocm_stub
+
+        install_torchao_windows_rocm_stub()
+
         from core.inference.inference import InferenceBackend
 
         import transformers

--- a/studio/backend/core/inference/worker.py
+++ b/studio/backend/core/inference/worker.py
@@ -906,6 +906,21 @@ def run_inference_process(
                 )
         return
 
+    # ── Windows: check Triton availability (must precede import torch) ──
+    # Must run before the torchao stub below, which imports torch itself to detect ROCm --
+    # otherwise this check runs against an already-imported torch and TORCHDYNAMO_DISABLE
+    # would race the training/export workers' ordering (see their "1c" Triton gate).
+    if sys.platform == "win32":
+        try:
+            import triton  # noqa: F401
+            logger.info("Triton available — torch.compile enabled")
+        except ImportError:
+            os.environ["TORCHDYNAMO_DISABLE"] = "1"
+            logger.warning(
+                "Triton not found on Windows — torch.compile disabled. "
+                'Install for better performance: pip install "triton-windows<3.7"'
+            )
+
     # ── Stub torchao on Windows ROCm before ANY transformers import ──
     # Must precede every path that pulls transformers, not just the ML imports in section 2:
     # a local LoRA adapter with no recorded base reaches transformers here via
@@ -952,19 +967,7 @@ def run_inference_process(
         )
         return
 
-    # ── 1b. Windows: check Triton availability (must precede import torch) ──
-    if sys.platform == "win32":
-        try:
-            import triton  # noqa: F401
-            logger.info("Triton available — torch.compile enabled")
-        except ImportError:
-            os.environ["TORCHDYNAMO_DISABLE"] = "1"
-            logger.warning(
-                "Triton not found on Windows — torch.compile disabled. "
-                'Install for better performance: pip install "triton-windows<3.7"'
-            )
-
-    # ── 1c. Security gates, then SSM/Mamba kernels, BEFORE importing transformers ──
+    # ── 1b. Security gates, then SSM/Mamba kernels, BEFORE importing transformers ──
     # transformers snapshots its optional-backend gates at import, so a hybrid model's kernels
     # must be installed before the import below ("mamba-ssm is required" otherwise). The gates
     # are metadata-only, so run them first and refuse a blocked model before any native build.

--- a/studio/backend/core/inference/worker.py
+++ b/studio/backend/core/inference/worker.py
@@ -906,6 +906,14 @@ def run_inference_process(
                 )
         return
 
+    # ── Stub torchao on Windows ROCm before ANY transformers import ──
+    # Must precede every path that pulls transformers, not just the ML imports in section 2:
+    # a local LoRA adapter with no recorded base reaches transformers here via
+    # _resolve_base_model -> utils.models. See core/_torchao_stub.py; no-op off Windows ROCm.
+    from core._torchao_stub import install_torchao_windows_rocm_stub
+
+    install_torchao_windows_rocm_stub()
+
     # ── Resolve the effective base once, before activation/gates/install (no ML import) ──
     # A remote LoRA's base is in its Hub adapter_config.json (else surfaced only by ModelConfig
     # after import). _lora_base is set only for a genuine adapter, never a full fine-tune's base.
@@ -1002,13 +1010,6 @@ def run_inference_process(
         from core.import_guards import ensure_real_packages
 
         ensure_real_packages("unsloth_zoo", "unsloth")
-
-        # Stub torchao on Windows ROCm before importing transformers / unsloth
-        # (RCCL absent). No-op off Windows ROCm. Must run before the import below,
-        # which pulls in transformers transitively via InferenceBackend.
-        from core._torchao_stub import install_torchao_windows_rocm_stub
-
-        install_torchao_windows_rocm_stub()
 
         from core.inference.inference import InferenceBackend
 

--- a/studio/backend/core/inference/worker.py
+++ b/studio/backend/core/inference/worker.py
@@ -906,10 +906,9 @@ def run_inference_process(
                 )
         return
 
-    # ── Windows: check Triton availability (must precede import torch) ──
-    # Must run before the torchao stub below, which imports torch itself to detect ROCm --
-    # otherwise this check runs against an already-imported torch and TORCHDYNAMO_DISABLE
-    # would race the training/export workers' ordering (see their "1c" Triton gate).
+    # ── Windows: check Triton availability ──
+    # Placed ahead of the torchao stub below (which imports torch on win32 to detect ROCm),
+    # matching the training and export workers' gate-then-stub ordering.
     if sys.platform == "win32":
         try:
             import triton  # noqa: F401
@@ -929,7 +928,9 @@ def run_inference_process(
 
     install_torchao_windows_rocm_stub()
 
-    # ── Resolve the effective base once, before activation/gates/install (no ML import) ──
+    # ── Resolve the effective base once, before activation/gates/install ──
+    # No ML import on the common path; a local adapter with no recorded base pulls
+    # transformers via utils.models, which is why the stub above precedes this.
     # A remote LoRA's base is in its Hub adapter_config.json (else surfaced only by ModelConfig
     # after import). _lora_base is set only for a genuine adapter, never a full fine-tune's base.
     import json as _json

--- a/studio/backend/tests/test_torchao_stub_worker_parity.py
+++ b/studio/backend/tests/test_torchao_stub_worker_parity.py
@@ -1,23 +1,16 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Invariant: every subprocess entrypoint that imports transformers / sentence-transformers must first
-install the torchao Windows-ROCm stub.
+"""Invariant: the inference subprocess must install the torchao Windows-ROCm stub before it imports
+transformers.
 
-``core/_torchao_stub.py:install_torchao_windows_rocm_stub`` stubs torchao so ``transformers.modeling_utils``
-can expose ``PreTrainedModel`` without importing an absent c10d/RCCL backend on Windows ROCm (it is a no-op
-on every other runtime). If transformers is imported before the stub is in place, a legacy Windows-ROCm venv
-that still carries a real torchao crashes on import (issue #6833) instead of merely warning.
-
+``core/_torchao_stub.py:install_torchao_windows_rocm_stub`` stubs torchao so transformers can import
+without an absent RCCL backend on Windows ROCm (no-op on every other runtime). If transformers imports
+first, a legacy Windows-ROCm venv that still carries a real torchao crashes on import (issue #6833).
 Three workers already guard this (training, export, rag); the inference worker -- the most-used path --
-regressed by omitting it. These tests lock parity so it cannot silently drift again:
+regressed by omitting it.
 
-* ``test_all_entrypoints_call_stub`` -- each of the four entrypoints actually *calls* the stub.
-* ``test_inference_worker_stubs_before_transformers`` -- in the inference worker the stub call runs BEFORE
-  the transformers-importing statements (both the direct ``import transformers`` and the transitive import
-  via ``from core.inference.inference import InferenceBackend``, whose module imports transformers at load).
-
-CPU-only, no torch/transformers/GPU/weights needed: parses source with ``ast``.
+CPU-only: parses source with ``ast``, no torch/transformers/GPU/weights needed.
 """
 
 from __future__ import annotations
@@ -25,8 +18,9 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-_BACKEND_DIR = Path(__file__).resolve().parent.parent  # studio/backend
-_CORE = _BACKEND_DIR / "core"
+_BACKEND = Path(__file__).resolve().parent.parent  # studio/backend
+_CORE = _BACKEND / "core"
+_STUB = "install_torchao_windows_rocm_stub"
 
 _ENTRYPOINTS = [
     _CORE / "training" / "worker.py",
@@ -35,61 +29,77 @@ _ENTRYPOINTS = [
     _CORE / "inference" / "worker.py",
 ]
 
-_STUB_FUNC = "install_torchao_windows_rocm_stub"
 
-
-def _parse(path: Path) -> ast.Module:
-    return ast.parse(path.read_text(encoding = "utf-8"), filename = str(path))
-
-
-def _stub_call_linenos(tree: ast.AST) -> list[int]:
-    """Line numbers of every ``install_torchao_windows_rocm_stub()`` call in the tree."""
+def _stub_call_linenos(node) -> list[int]:
+    """Line numbers of every ``install_torchao_windows_rocm_stub()`` call under ``node``."""
     return [
-        node.lineno
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Name)
-        and node.func.id == _STUB_FUNC
+        c.lineno
+        for c in ast.walk(node)
+        if isinstance(c, ast.Call) and isinstance(c.func, ast.Name) and c.func.id == _STUB
     ]
 
 
+def _func(tree, name):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    return None
+
+
 def test_all_entrypoints_call_stub():
-    """Each subprocess/embedder entrypoint that imports transformers must call the stub."""
+    """Every entrypoint that imports transformers must call the stub at all -- this is the exact
+    regression that shipped (the inference worker dropped the call). This is a presence check (the call
+    exists in the file); ordering is asserted only for the inference worker below, the path this fix
+    hardened. The other three import transformers at structurally different sites."""
     for path in _ENTRYPOINTS:
-        assert path.exists(), f"missing entrypoint: {path}"
-        calls = _stub_call_linenos(_parse(path))
-        assert calls, (
-            f"{path.relative_to(_BACKEND_DIR)} never calls {_STUB_FUNC}() -- transformers would import "
+        assert _stub_call_linenos(ast.parse(path.read_text())), (
+            f"{path.relative_to(_BACKEND)} never calls {_STUB}() -- transformers would import "
             "unguarded and crash on a legacy Windows-ROCm venv (issue #6833)."
         )
 
 
+def _imports_transformers(node) -> bool:
+    """A statement that imports transformers directly (``import transformers[.x]`` /
+    ``from transformers[.x] import ...``) or transitively at load (via ``core.inference.inference``,
+    whose module imports transformers)."""
+    if isinstance(node, ast.Import):
+        return any(a.name.split(".")[0] == "transformers" for a in node.names)
+    if isinstance(node, ast.ImportFrom) and node.module:
+        return node.module.split(".")[0] == "transformers" or node.module == "core.inference.inference"
+    return False
+
+
 def test_inference_worker_stubs_before_transformers():
-    """In the inference worker the stub call precedes every statement that imports transformers,
-    directly (``import transformers``) or transitively (``from core.inference.inference import ...``)."""
-    path = _CORE / "inference" / "worker.py"
-    tree = _parse(path)
+    """In ``run_inference_process`` the stub must precede every path that reaches transformers: the
+    section-2 imports (direct ``import transformers`` and the transitive ``core.inference.inference``
+    import), and -- the reason it sits at the top of the function -- the ``_resolve_base_model`` call,
+    which pulls transformers via ``utils.models`` for a local LoRA adapter with no recorded base.
+    Scoped to the function (mirrors ``test_ssm_runtime``) so a stub call elsewhere in the module can't
+    mask a drop from the function that actually runs the import. The ``_activate_transformers_version``
+    call inside the MLX branch is not an anchor: MLX is never Windows ROCm, so it needs no stub."""
+    tree = ast.parse((_CORE / "inference" / "worker.py").read_text())
+    fn = _func(tree, "run_inference_process")
+    assert fn is not None, "run_inference_process not found in inference/worker.py -- renamed? update this test."
 
-    stub_linenos = _stub_call_linenos(tree)
-    assert stub_linenos, f"{path.name}: stub never called"
-    first_stub = min(stub_linenos)
+    stub = _stub_call_linenos(fn)
+    assert stub, f"run_inference_process must call {_STUB}()"
 
-    transformers_import_linenos = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            if any(alias.name == "transformers" or alias.name.startswith("transformers.") for alias in node.names):
-                transformers_import_linenos.append(node.lineno)
-        elif isinstance(node, ast.ImportFrom):
-            # Transitive: core.inference.inference imports transformers at module load.
-            if node.module == "core.inference.inference":
-                transformers_import_linenos.append(node.lineno)
-
-    assert transformers_import_linenos, (
-        f"{path.name}: expected an `import transformers` / `from core.inference.inference import ...` "
-        "statement; the test's anchor is stale -- update it to the new import site."
+    dangers = []
+    for node in ast.walk(fn):
+        if _imports_transformers(node):
+            dangers.append(node.lineno)
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_resolve_base_model"
+        ):
+            dangers.append(node.lineno)
+    assert dangers, (
+        "no transformers-reaching site found in run_inference_process -- the anchors are stale, update "
+        "them to the new import/resolution sites."
     )
-    earliest_import = min(transformers_import_linenos)
-    assert first_stub < earliest_import, (
-        f"{path.name}: {_STUB_FUNC}() at line {first_stub} must run BEFORE the transformers import at "
-        f"line {earliest_import}; otherwise torchao imports unguarded on Windows ROCm (issue #6833)."
+
+    assert min(stub) < min(dangers), (
+        f"{_STUB}() at line {min(stub)} must run before the first transformers-reaching site at line "
+        f"{min(dangers)}; otherwise torchao imports unguarded on Windows ROCm (issue #6833)."
     )

--- a/studio/backend/tests/test_torchao_stub_worker_parity.py
+++ b/studio/backend/tests/test_torchao_stub_worker_parity.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Invariant: every subprocess entrypoint that imports transformers / sentence-transformers must first
+install the torchao Windows-ROCm stub.
+
+``core/_torchao_stub.py:install_torchao_windows_rocm_stub`` stubs torchao so ``transformers.modeling_utils``
+can expose ``PreTrainedModel`` without importing an absent c10d/RCCL backend on Windows ROCm (it is a no-op
+on every other runtime). If transformers is imported before the stub is in place, a legacy Windows-ROCm venv
+that still carries a real torchao crashes on import (issue #6833) instead of merely warning.
+
+Three workers already guard this (training, export, rag); the inference worker -- the most-used path --
+regressed by omitting it. These tests lock parity so it cannot silently drift again:
+
+* ``test_all_entrypoints_call_stub`` -- each of the four entrypoints actually *calls* the stub.
+* ``test_inference_worker_stubs_before_transformers`` -- in the inference worker the stub call runs BEFORE
+  the transformers-importing statements (both the direct ``import transformers`` and the transitive import
+  via ``from core.inference.inference import InferenceBackend``, whose module imports transformers at load).
+
+CPU-only, no torch/transformers/GPU/weights needed: parses source with ``ast``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_BACKEND_DIR = Path(__file__).resolve().parent.parent  # studio/backend
+_CORE = _BACKEND_DIR / "core"
+
+_ENTRYPOINTS = [
+    _CORE / "training" / "worker.py",
+    _CORE / "export" / "worker.py",
+    _CORE / "rag" / "embeddings.py",
+    _CORE / "inference" / "worker.py",
+]
+
+_STUB_FUNC = "install_torchao_windows_rocm_stub"
+
+
+def _parse(path: Path) -> ast.Module:
+    return ast.parse(path.read_text(encoding = "utf-8"), filename = str(path))
+
+
+def _stub_call_linenos(tree: ast.AST) -> list[int]:
+    """Line numbers of every ``install_torchao_windows_rocm_stub()`` call in the tree."""
+    return [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == _STUB_FUNC
+    ]
+
+
+def test_all_entrypoints_call_stub():
+    """Each subprocess/embedder entrypoint that imports transformers must call the stub."""
+    for path in _ENTRYPOINTS:
+        assert path.exists(), f"missing entrypoint: {path}"
+        calls = _stub_call_linenos(_parse(path))
+        assert calls, (
+            f"{path.relative_to(_BACKEND_DIR)} never calls {_STUB_FUNC}() -- transformers would import "
+            "unguarded and crash on a legacy Windows-ROCm venv (issue #6833)."
+        )
+
+
+def test_inference_worker_stubs_before_transformers():
+    """In the inference worker the stub call precedes every statement that imports transformers,
+    directly (``import transformers``) or transitively (``from core.inference.inference import ...``)."""
+    path = _CORE / "inference" / "worker.py"
+    tree = _parse(path)
+
+    stub_linenos = _stub_call_linenos(tree)
+    assert stub_linenos, f"{path.name}: stub never called"
+    first_stub = min(stub_linenos)
+
+    transformers_import_linenos = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(alias.name == "transformers" or alias.name.startswith("transformers.") for alias in node.names):
+                transformers_import_linenos.append(node.lineno)
+        elif isinstance(node, ast.ImportFrom):
+            # Transitive: core.inference.inference imports transformers at module load.
+            if node.module == "core.inference.inference":
+                transformers_import_linenos.append(node.lineno)
+
+    assert transformers_import_linenos, (
+        f"{path.name}: expected an `import transformers` / `from core.inference.inference import ...` "
+        "statement; the test's anchor is stale -- update it to the new import site."
+    )
+    earliest_import = min(transformers_import_linenos)
+    assert first_stub < earliest_import, (
+        f"{path.name}: {_STUB_FUNC}() at line {first_stub} must run BEFORE the transformers import at "
+        f"line {earliest_import}; otherwise torchao imports unguarded on Windows ROCm (issue #6833)."
+    )

--- a/studio/backend/tests/test_torchao_stub_worker_parity.py
+++ b/studio/backend/tests/test_torchao_stub_worker_parity.py
@@ -65,7 +65,9 @@ def _imports_transformers(node) -> bool:
     if isinstance(node, ast.Import):
         return any(a.name.split(".")[0] == "transformers" for a in node.names)
     if isinstance(node, ast.ImportFrom) and node.module:
-        return node.module.split(".")[0] == "transformers" or node.module == "core.inference.inference"
+        return (
+            node.module.split(".")[0] == "transformers" or node.module == "core.inference.inference"
+        )
     return False
 
 
@@ -79,7 +81,9 @@ def test_inference_worker_stubs_before_transformers():
     call inside the MLX branch is not an anchor: MLX is never Windows ROCm, so it needs no stub."""
     tree = ast.parse((_CORE / "inference" / "worker.py").read_text())
     fn = _func(tree, "run_inference_process")
-    assert fn is not None, "run_inference_process not found in inference/worker.py -- renamed? update this test."
+    assert (
+        fn is not None
+    ), "run_inference_process not found in inference/worker.py -- renamed? update this test."
 
     stub = _stub_call_linenos(fn)
     assert stub, f"run_inference_process must call {_STUB}()"

--- a/studio/backend/tests/test_torchao_stub_worker_parity.py
+++ b/studio/backend/tests/test_torchao_stub_worker_parity.py
@@ -7,8 +7,8 @@ transformers.
 ``core/_torchao_stub.py:install_torchao_windows_rocm_stub`` stubs torchao so transformers can import
 without an absent RCCL backend on Windows ROCm (no-op on every other runtime). If transformers imports
 first, a legacy Windows-ROCm venv that still carries a real torchao crashes on import (issue #6833).
-Three workers already guard this (training, export, rag); the inference worker -- the most-used path --
-regressed by omitting it.
+Three entrypoints already guard this (the training and export workers, and the main-process rag
+embedder); the inference worker -- the most-used path -- never had the call.
 
 CPU-only: parses source with ``ast``, no torch/transformers/GPU/weights needed.
 """
@@ -18,9 +18,11 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+from core._torchao_stub import install_torchao_windows_rocm_stub
+
 _BACKEND = Path(__file__).resolve().parent.parent  # studio/backend
 _CORE = _BACKEND / "core"
-_STUB = "install_torchao_windows_rocm_stub"
+_STUB = install_torchao_windows_rocm_stub.__name__  # a rename breaks the import loudly
 
 _ENTRYPOINTS = [
     _CORE / "training" / "worker.py",
@@ -48,7 +50,7 @@ def _func(tree, name):
 
 def test_all_entrypoints_call_stub():
     """Every entrypoint that imports transformers must call the stub at all -- this is the exact
-    regression that shipped (the inference worker dropped the call). This is a presence check (the call
+    gap that shipped (the inference worker never gained the call). This is a presence check (the call
     exists in the file); ordering is asserted only for the inference worker below, the path this fix
     hardened. The other three import transformers at structurally different sites."""
     for path in _ENTRYPOINTS:
@@ -58,15 +60,34 @@ def test_all_entrypoints_call_stub():
         )
 
 
+_INFERENCE_MOD = "core.inference.inference"
+
+
 def _imports_transformers(node) -> bool:
     """A statement that imports transformers directly (``import transformers[.x]`` /
-    ``from transformers[.x] import ...``) or transitively at load (via ``core.inference.inference``,
-    whose module imports transformers)."""
+    ``from transformers[.x] import ...``) or transitively at load: any absolute or relative import
+    form resolving to ``core.inference.inference`` (whose module imports transformers), so a style
+    refactor of the section-2 import can't slip past the anchor."""
     if isinstance(node, ast.Import):
-        return any(a.name.split(".")[0] == "transformers" for a in node.names)
-    if isinstance(node, ast.ImportFrom) and node.module:
-        return (
-            node.module.split(".")[0] == "transformers" or node.module == "core.inference.inference"
+        return any(
+            a.name.split(".")[0] == "transformers"
+            or a.name == _INFERENCE_MOD
+            or a.name.startswith(_INFERENCE_MOD + ".")
+            for a in node.names
+        )
+    if isinstance(node, ast.ImportFrom):
+        module = node.module or ""
+        if node.level == 0:
+            return (
+                module.split(".")[0] == "transformers"
+                or module == _INFERENCE_MOD
+                or module.startswith(_INFERENCE_MOD + ".")
+                or (module == "core.inference" and any(a.name == "inference" for a in node.names))
+            )
+        # Relative forms inside core/inference/worker.py: ``from .inference import X`` and
+        # ``from . import inference`` both resolve to core.inference.inference.
+        return module == "inference" or (
+            not module and any(a.name == "inference" for a in node.names)
         )
     return False
 

--- a/studio/backend/tests/test_torchao_stub_worker_parity.py
+++ b/studio/backend/tests/test_torchao_stub_worker_parity.py
@@ -52,7 +52,7 @@ def test_all_entrypoints_call_stub():
     exists in the file); ordering is asserted only for the inference worker below, the path this fix
     hardened. The other three import transformers at structurally different sites."""
     for path in _ENTRYPOINTS:
-        assert _stub_call_linenos(ast.parse(path.read_text())), (
+        assert _stub_call_linenos(ast.parse(path.read_text(encoding = "utf-8"))), (
             f"{path.relative_to(_BACKEND)} never calls {_STUB}() -- transformers would import "
             "unguarded and crash on a legacy Windows-ROCm venv (issue #6833)."
         )
@@ -79,7 +79,7 @@ def test_inference_worker_stubs_before_transformers():
     Scoped to the function (mirrors ``test_ssm_runtime``) so a stub call elsewhere in the module can't
     mask a drop from the function that actually runs the import. The ``_activate_transformers_version``
     call inside the MLX branch is not an anchor: MLX is never Windows ROCm, so it needs no stub."""
-    tree = ast.parse((_CORE / "inference" / "worker.py").read_text())
+    tree = ast.parse((_CORE / "inference" / "worker.py").read_text(encoding = "utf-8"))
     fn = _func(tree, "run_inference_process")
     assert (
         fn is not None


### PR DESCRIPTION
On a Windows ROCm venv that still carries a real torchao (a legacy or manual install, not a fresh post-#6837 one), loading a safetensors model through the inference worker crashes: it imports transformers before torchao is stubbed, so torchao aborts on import with an AttributeError (the crash in #6833), not just the cosmetic warning. Training, export, and rag already install the stub; the inference worker, the most-used path, did not.

## Fix

Install `install_torchao_windows_rocm_stub()` in `run_inference_process` before it touches transformers. It is a no-op off Windows ROCm, so nothing changes on any other setup.

It goes at the top of the non-MLX path, not just before `import transformers`, because the worker can reach transformers earlier: loading a local LoRA adapter with no recorded base resolves the base through `_resolve_base_model` -> `utils.models`, which imports transformers. The MLX path returns before this and never needs the stub.

## Tests

`test_torchao_stub_worker_parity.py` (CPU-only, no torch/GPU): all four workers install the stub, and in the inference worker it runs before every path that reaches transformers. Passes with `test_ssm_runtime.py` (49).

No live repro here: that needs a Windows AMD ROCm box with a real torchao and a safetensors load. The guarantee is the no-op-off-ROCm behavior plus matching what the three other workers already do.

Related to #6833. The warning is already suppressed on main (#6506, #6712) and the installer skips torchao on Windows ROCm (#6837); this covers venvs the installer never touched. The training and export workers share the same local-adapter gap; fixing them is a separate change.
