### PR TITLE
Studio: Show Run button for downloaded non-GGUF models in the Model Hub

### DIFF
--- a/studio/frontend/src/features/hub/catalog/local-on-device-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/local-on-device-card.tsx
@@ -4,6 +4,7 @@
 import { TrainIcon } from "../components/train-icon";
 import {
   HUB_GGUF_RUN_ACTIONS_VISIBLE,
+  HUB_NON_GGUF_RUN_ACTIONS_VISIBLE,
   HUB_POST_DOWNLOAD_ACTIONS_VISIBLE,
 } from "../lib/hub-feature-flags";
 import {
@@ -410,7 +411,7 @@ export function LocalOnDeviceCard({
   const showOldCacheHint = source === "hf_cache" && !!unsupportedReason;
   const runActionsVisible = isGguf
     ? HUB_GGUF_RUN_ACTIONS_VISIBLE
-    : HUB_POST_DOWNLOAD_ACTIONS_VISIBLE;
+    : HUB_NON_GGUF_RUN_ACTIONS_VISIBLE;
 
   return (
     <div className="flex w-full flex-col gap-2">

--- a/studio/frontend/src/features/hub/catalog/model-inspector.tsx
+++ b/studio/frontend/src/features/hub/catalog/model-inspector.tsx
@@ -504,17 +504,17 @@ export const ModelInspector = memo(function ModelInspector({
   const paramsLabel = model.totalParams
     ? formatCompact(model.totalParams)
     : "N/A";
-  const trainingSupported = unslothSupport.status !== "unsupported";
+  const unslothSupported = unslothSupport.status !== "unsupported";
   const canRunModel =
     !isDataset &&
     (model.runtimeCapabilities?.canChat ?? true) &&
-    (model.isGguf || unslothSupport.status !== "unsupported");
+    (model.isGguf || unslothSupported);
   const canTrainModel =
     !isDataset &&
     (model.runtimeCapabilities?.canTrain ?? false) &&
     model.modelFormat !== "gguf" &&
     model.modelFormat !== "adapter" &&
-    trainingSupported;
+    unslothSupported;
 
   const languages = parseLanguageTags(model.tags);
   const datasetSizeBytes =

--- a/studio/frontend/src/features/hub/catalog/model-inspector.tsx
+++ b/studio/frontend/src/features/hub/catalog/model-inspector.tsx
@@ -263,17 +263,22 @@ type VramInfo = { est: number; status: "fits" | "tight" | "exceeds" } | null;
 function ModelStatusChips({
   isDataset,
   isGguf,
+  chatOnly,
   unslothSupport,
   vramInfo,
 }: {
   isDataset: boolean;
   isGguf: boolean;
+  chatOnly: boolean;
   unslothSupport: UnslothSupport;
   vramInfo: VramInfo;
 }) {
   const showUnsupported = !isDataset && unslothSupport.status === "unsupported";
+  // The format-unsupported chip already explains itself; this one covers the
+  // supported-format model a chat-only host still can't run.
+  const showChatOnly = !isDataset && !isGguf && chatOnly && !showUnsupported;
   const showVram = !isDataset && vramInfo && !isGguf;
-  if (!showUnsupported && !showVram) return null;
+  if (!showUnsupported && !showChatOnly && !showVram) return null;
 
   const vramTone = vramInfo
     ? vramInfo.status === "exceeds"
@@ -317,6 +322,26 @@ function ModelStatusChips({
                 {unslothSupport.reason}
               </span>
             )}
+            <span className="mt-1 block text-[10.5px] font-normal text-white/75">
+              Still downloadable to your Hugging Face cache.
+            </span>
+          </TooltipContent>
+        </Tooltip>
+      )}
+      {showChatOnly && (
+        <Tooltip>
+          <TooltipTrigger asChild={true}>
+            <span tabIndex={0} className="inline-flex outline-none">
+              <StatusChip tone="warning" label="GGUF-only device" />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent
+            side="bottom"
+            sideOffset={6}
+            className="tooltip-compact max-w-xs"
+          >
+            This device has no supported GPU or usable MLX, so only GGUF models
+            can run here.
             <span className="mt-1 block text-[10.5px] font-normal text-white/75">
               Still downloadable to your Hugging Face cache.
             </span>
@@ -770,6 +795,7 @@ export const ModelInspector = memo(function ModelInspector({
         <ModelStatusChips
           isDataset={isDataset}
           isGguf={model.isGguf}
+          chatOnly={chatOnly}
           unslothSupport={unslothSupport}
           vramInfo={vramInfo}
         />

--- a/studio/frontend/src/features/hub/catalog/model-inspector.tsx
+++ b/studio/frontend/src/features/hub/catalog/model-inspector.tsx
@@ -506,7 +506,9 @@ export const ModelInspector = memo(function ModelInspector({
     : "N/A";
   const trainingSupported = unslothSupport.status !== "unsupported";
   const canRunModel =
-    !isDataset && (model.runtimeCapabilities?.canChat ?? true);
+    !isDataset &&
+    (model.runtimeCapabilities?.canChat ?? true) &&
+    (model.isGguf || unslothSupport.status !== "unsupported");
   const canTrainModel =
     !isDataset &&
     (model.runtimeCapabilities?.canTrain ?? false) &&

--- a/studio/frontend/src/features/hub/catalog/model-inspector.tsx
+++ b/studio/frontend/src/features/hub/catalog/model-inspector.tsx
@@ -406,6 +406,7 @@ export const ModelInspector = memo(function ModelInspector({
     onSearchHub,
   } = actions;
   const deviceType = usePlatformStore((s) => s.deviceType);
+  const chatOnly = usePlatformStore((s) => s.isChatOnly());
   const hfToken = useHfTokenStore((s) => s.token);
   const datasetRepoId = isDataset && model?.hubRepoId ? model.hubRepoId : null;
   const datasetSize = useDatasetSize(datasetRepoId, {
@@ -505,10 +506,12 @@ export const ModelInspector = memo(function ModelInspector({
     ? formatCompact(model.totalParams)
     : "N/A";
   const unslothSupported = unslothSupport.status !== "unsupported";
+  // Chat-only hosts (no supported GPU / usable MLX) run inference only through
+  // llama.cpp, so only GGUF is loadable.
   const canRunModel =
     !isDataset &&
     (model.runtimeCapabilities?.canChat ?? true) &&
-    (model.isGguf || unslothSupported);
+    (model.isGguf || (!chatOnly && unslothSupported));
   const canTrainModel =
     !isDataset &&
     (model.runtimeCapabilities?.canTrain ?? false) &&

--- a/studio/frontend/src/features/hub/catalog/safetensors-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/safetensors-download-card.tsx
@@ -242,7 +242,8 @@ export function SafetensorsDownloadCard({
             )}
           </div>
         </div>
-        {/* Info/actions hairline; omitted before a lone Run button, matching the GGUF and on-device cards. */}
+        {/* Info/actions hairline; dropped for the run action row (no divider before
+            Run, as in the GGUF card's Run CTA), restored when the Train pair ships. */}
         {(!showActionPair || trainActionVisible) && <CardDivider />}
         {showActionPair ? (
           <div

--- a/studio/frontend/src/features/hub/catalog/safetensors-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/safetensors-download-card.tsx
@@ -161,7 +161,7 @@ export function SafetensorsDownloadCard({
   const showActionPair = isDownloaded && !downloading && (canRun || !!onTrain);
   const showUnavailableAction =
     isDownloaded && !downloading && !canRun && !onTrain;
-  const runActionsVisible = HUB_NON_GGUF_RUN_ACTIONS_VISIBLE;
+  const trainActionVisible = !!onTrain && HUB_POST_DOWNLOAD_ACTIONS_VISIBLE;
   const canDelete =
     (isDownloaded || isPartial) &&
     !downloading &&
@@ -243,15 +243,15 @@ export function SafetensorsDownloadCard({
           </div>
         </div>
         {/* Info/actions hairline; omitted before a lone Run button, matching the GGUF and on-device cards. */}
-        {(!showActionPair || (HUB_POST_DOWNLOAD_ACTIONS_VISIBLE && !!onTrain)) && <CardDivider />}
+        {(!showActionPair || trainActionVisible) && <CardDivider />}
         {showActionPair ? (
           <div
             className={cn(
               "group/pair flex h-9 shrink-0 items-stretch gap-1.5",
-              !runActionsVisible && "hidden",
+              !HUB_NON_GGUF_RUN_ACTIONS_VISIBLE && "hidden",
             )}
           >
-            {onTrain && HUB_POST_DOWNLOAD_ACTIONS_VISIBLE && (
+            {trainActionVisible && (
               <button
                 type="button"
                 onClick={onTrain}

--- a/studio/frontend/src/features/hub/catalog/safetensors-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/safetensors-download-card.tsx
@@ -161,7 +161,6 @@ export function SafetensorsDownloadCard({
   const showActionPair = isDownloaded && !downloading && (canRun || !!onTrain);
   const showUnavailableAction =
     isDownloaded && !downloading && !canRun && !onTrain;
-  // Run ships for non-GGUF now; Train stays behind HUB_POST_DOWNLOAD_ACTIONS_VISIBLE.
   const runActionsVisible = HUB_NON_GGUF_RUN_ACTIONS_VISIBLE;
   const canDelete =
     (isDownloaded || isPartial) &&
@@ -243,13 +242,12 @@ export function SafetensorsDownloadCard({
             )}
           </div>
         </div>
-        {/* Divider sits above the Download CTA; in the action-pair state it hides with the pair. */}
+        {/* Divider sits above the bottom CTA row; it drops only when the action pair is gated off. */}
         {(!showActionPair || runActionsVisible) && <CardDivider />}
         {showActionPair ? (
           <div
             className={cn(
               "group/pair flex h-9 shrink-0 items-stretch gap-1.5",
-              // Pair hidden only when the Run action is gated off too.
               !runActionsVisible && "hidden",
             )}
           >

--- a/studio/frontend/src/features/hub/catalog/safetensors-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/safetensors-download-card.tsx
@@ -242,8 +242,8 @@ export function SafetensorsDownloadCard({
             )}
           </div>
         </div>
-        {/* Divider sits above the bottom CTA row; it drops only when the action pair is gated off. */}
-        {(!showActionPair || runActionsVisible) && <CardDivider />}
+        {/* Info/actions hairline; omitted before a lone Run button, matching the GGUF and on-device cards. */}
+        {(!showActionPair || (HUB_POST_DOWNLOAD_ACTIONS_VISIBLE && !!onTrain)) && <CardDivider />}
         {showActionPair ? (
           <div
             className={cn(

--- a/studio/frontend/src/features/hub/catalog/safetensors-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/safetensors-download-card.tsx
@@ -16,7 +16,10 @@ import {
   PlayIcon,
 } from "@hugeicons/core-free-icons";
 import { TrainIcon } from "../components/train-icon";
-import { HUB_POST_DOWNLOAD_ACTIONS_VISIBLE } from "../lib/hub-feature-flags";
+import {
+  HUB_NON_GGUF_RUN_ACTIONS_VISIBLE,
+  HUB_POST_DOWNLOAD_ACTIONS_VISIBLE,
+} from "../lib/hub-feature-flags";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useEffect, useState } from "react";
 import { useHfTokenStore } from "../stores/hf-token-store";
@@ -158,6 +161,8 @@ export function SafetensorsDownloadCard({
   const showActionPair = isDownloaded && !downloading && (canRun || !!onTrain);
   const showUnavailableAction =
     isDownloaded && !downloading && !canRun && !onTrain;
+  // Run ships for non-GGUF now; Train stays behind HUB_POST_DOWNLOAD_ACTIONS_VISIBLE.
+  const runActionsVisible = HUB_NON_GGUF_RUN_ACTIONS_VISIBLE;
   const canDelete =
     (isDownloaded || isPartial) &&
     !downloading &&
@@ -239,16 +244,16 @@ export function SafetensorsDownloadCard({
           </div>
         </div>
         {/* Divider sits above the Download CTA; in the action-pair state it hides with the pair. */}
-        {(!showActionPair || HUB_POST_DOWNLOAD_ACTIONS_VISIBLE) && <CardDivider />}
+        {(!showActionPair || runActionsVisible) && <CardDivider />}
         {showActionPair ? (
           <div
             className={cn(
               "group/pair flex h-9 shrink-0 items-stretch gap-1.5",
-              // Run+Train pair hidden until Hub→chat / Hub→train pickers ship.
-              !HUB_POST_DOWNLOAD_ACTIONS_VISIBLE && "hidden",
+              // Pair hidden only when the Run action is gated off too.
+              !runActionsVisible && "hidden",
             )}
           >
-            {onTrain && (
+            {onTrain && HUB_POST_DOWNLOAD_ACTIONS_VISIBLE && (
               <button
                 type="button"
                 onClick={onTrain}

--- a/studio/frontend/src/features/hub/lib/hub-feature-flags.ts
+++ b/studio/frontend/src/features/hub/lib/hub-feature-flags.ts
@@ -4,8 +4,8 @@
 // Hub feature flags for staged rollout. JSX/wiring stay in place so flipping
 // a flag here is the only edit needed to re-enable.
 
-// Post-download Run / New Chat / Use in chat / Train CTAs; hidden until the
-// Hub-aware chat and train pickers ship.
+// Post-download New Chat / Use in chat / Train CTAs; hidden until the
+// Hub-aware chat and train pickers ship. Run CTAs are gated separately below.
 export const HUB_POST_DOWNLOAD_ACTIONS_VISIBLE = false;
 
 export const HUB_GGUF_RUN_ACTIONS_VISIBLE = true;

--- a/studio/frontend/src/features/hub/lib/hub-feature-flags.ts
+++ b/studio/frontend/src/features/hub/lib/hub-feature-flags.ts
@@ -10,8 +10,9 @@ export const HUB_POST_DOWNLOAD_ACTIONS_VISIBLE = false;
 
 export const HUB_GGUF_RUN_ACTIONS_VISIBLE = true;
 
-// Post-download Run CTA for non-GGUF (safetensors / MLX) models. The Run action
-// has no dependency on the Hub-aware chat/train pickers (GGUF already ships it),
-// so it enables independently of HUB_POST_DOWNLOAD_ACTIONS_VISIBLE, which still
-// gates the New Chat / Train pickers.
+// Post-download Run CTA for non-GGUF models (safetensors, checkpoints, adapters;
+// MLX repos classify as safetensors). The Run action has no dependency on the
+// Hub-aware chat/train pickers (GGUF already ships it), so it enables
+// independently of HUB_POST_DOWNLOAD_ACTIONS_VISIBLE, which still gates the
+// New Chat / Train pickers.
 export const HUB_NON_GGUF_RUN_ACTIONS_VISIBLE = true;

--- a/studio/frontend/src/features/hub/lib/hub-feature-flags.ts
+++ b/studio/frontend/src/features/hub/lib/hub-feature-flags.ts
@@ -9,3 +9,9 @@
 export const HUB_POST_DOWNLOAD_ACTIONS_VISIBLE = false;
 
 export const HUB_GGUF_RUN_ACTIONS_VISIBLE = true;
+
+// Post-download Run CTA for non-GGUF (safetensors / MLX) models. The Run action
+// has no dependency on the Hub-aware chat/train pickers (GGUF already ships it),
+// so it enables independently of HUB_POST_DOWNLOAD_ACTIONS_VISIBLE, which still
+// gates the New Chat / Train pickers.
+export const HUB_NON_GGUF_RUN_ACTIONS_VISIBLE = true;

--- a/studio/frontend/src/features/hub/lib/hub-feature-flags.ts
+++ b/studio/frontend/src/features/hub/lib/hub-feature-flags.ts
@@ -10,9 +10,7 @@ export const HUB_POST_DOWNLOAD_ACTIONS_VISIBLE = false;
 
 export const HUB_GGUF_RUN_ACTIONS_VISIBLE = true;
 
-// Post-download Run CTA for non-GGUF models (safetensors, checkpoints, adapters;
-// MLX repos classify as safetensors). The Run action has no dependency on the
-// Hub-aware chat/train pickers (GGUF already ships it), so it enables
-// independently of HUB_POST_DOWNLOAD_ACTIONS_VISIBLE, which still gates the
-// New Chat / Train pickers.
+// Post-download Run CTA for non-GGUF models (MLX repos classify as safetensors).
+// Run has no dependency on the Hub-aware chat/train pickers, so it enables
+// independently of HUB_POST_DOWNLOAD_ACTIONS_VISIBLE, which still gates those.
 export const HUB_NON_GGUF_RUN_ACTIONS_VISIBLE = true;

--- a/studio/frontend/src/features/hub/lib/unsloth-support.ts
+++ b/studio/frontend/src/features/hub/lib/unsloth-support.ts
@@ -157,6 +157,9 @@ function detectFormatKey(
     if (alias) return alias;
   }
   if (modelId) {
+    // Owner implies format even when local metadata lacks tags; mirrors the
+    // backend's _looks_like_mlx_repo heuristic.
+    if (modelId.trim().toLowerCase().startsWith("mlx-community/")) return "mlx";
     const name = repoLeaf(modelId);
     for (const { key, pattern } of FORMAT_NAME_PATTERNS) {
       if (pattern.test(name)) return key;


### PR DESCRIPTION
Downloaded non-GGUF models (safetensors, MLX, adapters, checkpoints) got no Run button in the Model Hub. Reported on Discord for MLX on Mac, but it affects every non-GGUF format on every OS. The model still loads from the main chat dropdown, so this was purely a Hub-UI gap, not a loader gap.

## Problem

#6152 turned the post-download Run button on for GGUF, but non-GGUF cards stayed behind `HUB_POST_DOWNLOAD_ACTIONS_VISIBLE`, which is still `false` because it also gates the not-yet-shipped New Chat / Train pickers. So a downloaded non-GGUF card showed no Run button while GGUF showed one.

## Fix

Give non-GGUF Run its own flag (`HUB_NON_GGUF_RUN_ACTIONS_VISIBLE = true`), like the GGUF one, keeping New Chat / Train hidden until those pickers ship. Run wires to the existing load handlers; no backend change.

What changes in the UI:

- A downloaded safetensors model, adapter, or checkpoint shows a Run button in the Hub. Clicking it loads the model into chat, same as the dropdown.
- Models the machine can't actually run don't get a live button: unsupported formats (e.g. MLX on a non-Mac, including untagged `mlx-community` repos) and any non-GGUF model on a host with no GPU or usable MLX show a disabled state instead, with a "GGUF-only device" chip explaining the host case.
- GGUF cards are unchanged.

## Verification

Ran main and the PR side by side. A downloaded safetensors model shows no Run on main and a working Run on the PR: it loads and chat works. GGUF cards are identical on both. `mlx-community` repos show the "May not be supported" chip on a CUDA host. Typecheck green.
