### PR TITLE
Studio: fix mid-stream stall watchdog so a stalled generation times out in ~2 min not ~20 min

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -240,10 +240,9 @@ _DEFAULT_FIRST_TOKEN_TIMEOUT_S = 1200.0  # 20 min
 # is exempt because it needs immediate artifact feedback.
 _PROVISIONAL_ARGS_MIN_CHARS = 256
 _DEFAULT_STREAM_STALL_TIMEOUT_S = 120.0  # 2 min
-# httpcore binds the socket read timeout once when body iteration starts, so a
-# mid-stream stall can't be caught by lowering the read timeout. A watchdog
-# thread polls the elapsed-since-last-chunk deadline at this cadence instead and
-# closes the response when the first-token or stall window elapses.
+# Watchdog poll cadence. httpcore binds the read timeout once when body
+# iteration starts, so a mid-stream stall can't be caught by lowering it; a
+# thread polls the deadline at this cadence and closes the response instead.
 _STREAM_WATCHDOG_POLL_S = 0.5
 # Cap tool calls from a single TEXTUAL-fallback turn (mirrors the safetensors
 # loop). Structured delta.tool_calls are grammar-bounded by llama-server; text
@@ -8319,10 +8318,9 @@ class LlamaCppBackend:
 
         # Shared with the watchdog thread; the GIL makes these single dict
         # reads/writes atomic enough for a monotonic deadline check (no lock).
-        # ``reading_since`` is the monotonic time the current ``next()`` began
-        # blocking on the socket, or None while suspended at ``yield`` — so the
-        # window measures upstream silence only, never a slow/backpressured
-        # consumer between chunks.
+        # ``reading_since`` is when the current ``next()`` began blocking on the
+        # socket, or None while suspended at ``yield``, so the window measures
+        # upstream silence only, never a slow consumer between chunks.
         watch_state = {"reading_since": None, "got_first_chunk": False, "timed_out": False}
         watchdog_stop = threading.Event()
 
@@ -8360,10 +8358,10 @@ class LlamaCppBackend:
                 except StopIteration:
                     return
                 except (httpx.RequestError, httpx.StreamError) as exc:
-                    # The watchdog (or a cancel) closes the response to abort a
+                    # The watchdog or a cancel closes the response to abort a
                     # blocked read: a watchdog close is the stall/first-token
-                    # timeout, a cancel close is a clean stop, and anything else
-                    # is a genuine upstream error that must propagate.
+                    # timeout, a cancel is a clean stop, anything else is a
+                    # genuine upstream error that must propagate.
                     if watch_state["timed_out"]:
                         if watch_state["got_first_chunk"]:
                             raise httpx.ReadTimeout(

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -240,6 +240,11 @@ _DEFAULT_FIRST_TOKEN_TIMEOUT_S = 1200.0  # 20 min
 # is exempt because it needs immediate artifact feedback.
 _PROVISIONAL_ARGS_MIN_CHARS = 256
 _DEFAULT_STREAM_STALL_TIMEOUT_S = 120.0  # 2 min
+# httpcore binds the socket read timeout once when body iteration starts, so a
+# mid-stream stall can't be caught by lowering the read timeout. A watchdog
+# thread polls the elapsed-since-last-chunk deadline at this cadence instead and
+# closes the response when the first-token or stall window elapses.
+_STREAM_WATCHDOG_POLL_S = 0.5
 # Cap tool calls from a single TEXTUAL-fallback turn (mirrors the safetensors
 # loop). Structured delta.tool_calls are grammar-bounded by llama-server; text
 # parsed from content is not, so one runaway turn could fan out unbounded.
@@ -8261,10 +8266,11 @@ class LlamaCppBackend:
     @contextlib.contextmanager
     def _open_stream(self, url: str, payload: dict, cancel_event):
         """Open a streaming POST to llama-server, retrying through prefill, and
-        yield ``(response, first_token_deadline)`` once a 200 lands. Owns the
-        httpx.Client + auth headers for the stream's lifetime; raises
+        yield ``(response, first_token_deadline, client)`` once a 200 lands. Owns
+        the httpx.Client + auth headers for the stream's lifetime; raises
         RuntimeError on a non-200. Shared scaffold for the streaming consumers,
-        which differ only in how they parse the SSE body."""
+        which differ only in how they parse the SSE body. The client is exposed
+        so the stall watchdog can shut its socket down to abort a blocked read."""
         stream_timeout = httpx.Timeout(connect = 10, read = 0.5, write = 10, pool = 10)
         with httpx.Client(
             timeout = stream_timeout,
@@ -8285,7 +8291,7 @@ class LlamaCppBackend:
                     raise RuntimeError(
                         f"llama-server returned {response.status_code}: {error_body}"
                     )
-                yield response, first_token_deadline
+                yield response, first_token_deadline, client
 
     @staticmethod
     def _iter_text_cancellable(
@@ -8293,52 +8299,89 @@ class LlamaCppBackend:
         cancel_event: Optional[threading.Event] = None,
         stall_timeout_s: float = _DEFAULT_STREAM_STALL_TIMEOUT_S,
         first_token_deadline: Optional[float] = None,
-        post_first_chunk_read_timeout_s: Optional[float] = _DEFAULT_STREAM_STALL_TIMEOUT_S,
+        client: Optional["httpx.Client"] = None,
     ) -> Generator[str, None, None]:
-        """Iterate a stream while polling cancel and stall timeouts."""
+        """Iterate a stream while enforcing cancel, first-token, and stall windows.
+
+        httpcore binds the socket read timeout once when body iteration starts
+        (``_receive_response_body`` in httpcore 1.0.9), so lowering the request's
+        read timeout mid-stream is a no-op and a genuine no-byte stall would hang
+        for the whole first-token deadline. Enforce the windows from Python
+        instead: a watchdog thread shuts the socket down once the active deadline
+        elapses (the long first-token deadline before any content, then the short
+        stall window after the last chunk), which unblocks the reader with a
+        stream error we surface as a ``ReadTimeout``. ``response.close()`` alone
+        does not interrupt a blocked read, so we mirror the cancel watcher in
+        ``_stream_with_retry`` and shut the socket down."""
         text_iter = response.iter_text()
         if first_token_deadline is None:
             first_token_deadline = time.monotonic() + _DEFAULT_FIRST_TOKEN_TIMEOUT_S
-        last_chunk_at: Optional[float] = None
-        while True:
-            if cancel_event is not None and cancel_event.is_set():
-                response.close()
-                return
-            try:
-                if last_chunk_at is None:
-                    remaining_s = first_token_deadline - time.monotonic()
-                    if remaining_s <= 0:
-                        raise httpx.ReadTimeout("The model did not produce a first token in time.")
-                    LlamaCppBackend._set_stream_read_timeout(response, remaining_s)
-                chunk = next(text_iter)
-                if chunk:
-                    if last_chunk_at is None and post_first_chunk_read_timeout_s is not None:
-                        LlamaCppBackend._set_stream_read_timeout(
-                            response,
-                            post_first_chunk_read_timeout_s,
-                        )
-                    last_chunk_at = time.monotonic()
-                yield chunk
-            except StopIteration:
-                return
-            except httpx.ReadTimeout:
-                now = time.monotonic()
-                if last_chunk_at is None:
-                    if now >= first_token_deadline:
-                        raise
-                elif now - last_chunk_at >= stall_timeout_s:
-                    raise httpx.ReadTimeout("The model stopped producing tokens mid-response.")
-                continue
 
-    @staticmethod
-    def _set_stream_read_timeout(response: "httpx.Response", read_timeout_s: float) -> None:
-        """Lower only post-header stream reads; keep prefill timeout long."""
+        # Shared with the watchdog thread; the GIL makes these single dict
+        # reads/writes atomic enough for a monotonic deadline check (no lock).
+        # ``reading_since`` is the monotonic time the current ``next()`` began
+        # blocking on the socket, or None while suspended at ``yield`` — so the
+        # window measures upstream silence only, never a slow/backpressured
+        # consumer between chunks.
+        watch_state = {"reading_since": None, "got_first_chunk": False, "timed_out": False}
+        watchdog_stop = threading.Event()
+
+        def _stall_watchdog() -> None:
+            while not watchdog_stop.wait(timeout = _STREAM_WATCHDOG_POLL_S):
+                reading_since = watch_state["reading_since"]
+                if reading_since is None:
+                    continue
+                if watch_state["got_first_chunk"]:
+                    deadline = reading_since + stall_timeout_s
+                else:
+                    deadline = first_token_deadline
+                if time.monotonic() >= deadline:
+                    watch_state["timed_out"] = True
+                    try:
+                        if client is not None:
+                            LlamaCppBackend._shutdown_active_httpx_sockets(client)
+                        response.close()
+                    except Exception:
+                        logger.debug("Stall watchdog could not close response", exc_info = True)
+                    return
+
+        watchdog = threading.Thread(
+            target = _stall_watchdog, daemon = True, name = "stream-stall-watchdog"
+        )
+        watchdog.start()
         try:
-            timeout_ext = response.request.extensions.get("timeout")
-            if isinstance(timeout_ext, dict):
-                timeout_ext["read"] = read_timeout_s
-        except Exception:
-            logger.debug("Could not lower response read timeout", exc_info = True)
+            while True:
+                if cancel_event is not None and cancel_event.is_set():
+                    response.close()
+                    return
+                watch_state["reading_since"] = time.monotonic()
+                try:
+                    chunk = next(text_iter)
+                except StopIteration:
+                    return
+                except (httpx.RequestError, httpx.StreamError) as exc:
+                    # The watchdog (or a cancel) closes the response to abort a
+                    # blocked read: a watchdog close is the stall/first-token
+                    # timeout, a cancel close is a clean stop, and anything else
+                    # is a genuine upstream error that must propagate.
+                    if watch_state["timed_out"]:
+                        if watch_state["got_first_chunk"]:
+                            raise httpx.ReadTimeout(
+                                "The model stopped producing tokens mid-response."
+                            ) from exc
+                        raise httpx.ReadTimeout(
+                            "The model did not produce a first token in time."
+                        ) from exc
+                    if cancel_event is not None and cancel_event.is_set():
+                        return
+                    raise
+                # Stop the read clock before yielding so consumer time is excluded.
+                watch_state["reading_since"] = None
+                if chunk:
+                    watch_state["got_first_chunk"] = True
+                yield chunk
+        finally:
+            watchdog_stop.set()
 
     @staticmethod
     def _shutdown_active_httpx_sockets(client: "httpx.Client") -> None:
@@ -8539,6 +8582,7 @@ class LlamaCppBackend:
             with self._open_stream(url, payload, cancel_event) as (
                 response,
                 first_token_deadline,
+                stream_client,
             ):
                 buffer = ""
                 has_content_tokens = False
@@ -8547,6 +8591,7 @@ class LlamaCppBackend:
                     response,
                     cancel_event,
                     first_token_deadline = first_token_deadline,
+                    client = stream_client,
                 ):
                     buffer += raw_chunk
                     while "\n" in buffer:
@@ -8976,12 +9021,14 @@ class LlamaCppBackend:
                 with self._open_stream(url, payload, cancel_event) as (
                     response,
                     first_token_deadline,
+                    stream_client,
                 ):
                     raw_buf = ""
                     for raw_chunk in self._iter_text_cancellable(
                         response,
                         cancel_event,
                         first_token_deadline = first_token_deadline,
+                        client = stream_client,
                     ):
                         raw_buf += raw_chunk
                         while "\n" in raw_buf:
@@ -9848,12 +9895,14 @@ class LlamaCppBackend:
             with self._open_stream(url, stream_payload, cancel_event) as (
                 response,
                 first_token_deadline,
+                stream_client,
             ):
                 buffer = ""
                 for raw_chunk in self._iter_text_cancellable(
                     response,
                     cancel_event,
                     first_token_deadline = first_token_deadline,
+                    client = stream_client,
                 ):
                     buffer += raw_chunk
                     while "\n" in buffer:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1140,23 +1140,21 @@ async def _aiter_llama_stream_items(
                 async with _same_task_timeout(remaining_s):
                     item = await async_iter.__anext__()
             else:
-                if (
-                    request is not None
-                    and response is not None
-                    and post_first_item_read_timeout_s is not None
-                    and last_item_at is not None
-                ):
-                    stall_remaining_s = post_first_item_read_timeout_s - (
-                        time.monotonic() - last_item_at
-                    )
-                    if stall_remaining_s <= 0:
-                        raise httpx.ReadTimeout("The model stopped producing tokens mid-response.")
-                    _set_stream_response_read_timeout(response, stall_remaining_s)
-                item = await async_iter.__anext__()
+                if post_first_item_read_timeout_s is not None:
+                    # httpcore binds the per-read timeout once when body
+                    # iteration starts, so lowering it mid-stream is a no-op;
+                    # enforce the stall window in-task with the same cancel-scope
+                    # helper as the first-token wait above. The wrap covers only
+                    # __anext__ (the upstream read), so a slow/backpressured
+                    # consumer between yields can't shrink the window.
+                    async with _same_task_timeout(post_first_item_read_timeout_s):
+                        item = await async_iter.__anext__()
+                else:
+                    item = await async_iter.__anext__()
         except asyncio.TimeoutError as exc:
             if waiting_first_item:
                 raise httpx.ReadTimeout("The model did not produce a first token in time.") from exc
-            raise
+            raise httpx.ReadTimeout("The model stopped producing tokens mid-response.") from exc
         except StopAsyncIteration:
             return
         except httpx.ReadTimeout:
@@ -1166,18 +1164,11 @@ async def _aiter_llama_stream_items(
                     raise
                 continue
             if (
-                request is not None
-                and post_first_item_read_timeout_s is not None
+                post_first_item_read_timeout_s is not None
                 and now - last_item_at < post_first_item_read_timeout_s
             ):
                 continue
             raise httpx.ReadTimeout("The model stopped producing tokens mid-response.")
-        if (
-            last_item_at is None
-            and response is not None
-            and post_first_item_read_timeout_s is not None
-        ):
-            _set_stream_response_read_timeout(response, post_first_item_read_timeout_s)
         last_item_at = time.monotonic()
         yield item
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1143,10 +1143,10 @@ async def _aiter_llama_stream_items(
                 if post_first_item_read_timeout_s is not None:
                     # httpcore binds the per-read timeout once when body
                     # iteration starts, so lowering it mid-stream is a no-op;
-                    # enforce the stall window in-task with the same cancel-scope
-                    # helper as the first-token wait above. The wrap covers only
-                    # __anext__ (the upstream read), so a slow/backpressured
-                    # consumer between yields can't shrink the window.
+                    # enforce the stall window in-task with the same
+                    # _same_task_timeout helper as the first-token wait above.
+                    # The wrap covers only __anext__ (the upstream read), so a
+                    # slow consumer between yields can't shrink the window.
                     async with _same_task_timeout(post_first_item_read_timeout_s):
                         item = await async_iter.__anext__()
                 else:

--- a/studio/backend/tests/test_gguf_route_cursor_reset.py
+++ b/studio/backend/tests/test_gguf_route_cursor_reset.py
@@ -68,6 +68,7 @@ def _make_backend(monkeypatch, streams: list[list[str]], payloads: list[dict]):
         response,
         _cancel_event,
         first_token_deadline = None,
+        client = None,
     ):
         yield from response.chunks
 

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -65,6 +65,7 @@ def _make_backend(monkeypatch, streams: list[list[str]], payloads: list[dict]):
         response,
         _cancel_event,
         first_token_deadline = None,
+        client = None,
     ):
         yield from response.chunks
 

--- a/studio/backend/tests/test_llama_route_timeouts.py
+++ b/studio/backend/tests/test_llama_route_timeouts.py
@@ -205,14 +205,22 @@ def test_preheader_send_cleanup_on_disconnect_and_cancel():
     asyncio.run(_run(True))
 
 
-def test_stream_stall_timeout_callable_re_resolved_each_read():
+def test_stream_stall_timeout_callable_re_resolved_each_read(monkeypatch):
     # The OpenAI passthrough passes a callable so the stall bound can switch to
     # the short post-terminal grace mid-stream; it must be re-resolved per read,
-    # not captured once at generator start.
+    # not captured once at generator start. Enforcement is the in-task
+    # _same_task_timeout wrap around each read, so capture the bound it arms.
+    armed = []
+    real_timeout = inf_mod._same_task_timeout
+
+    def _record(timeout_s):
+        armed.append(timeout_s)
+        return real_timeout(timeout_s)
+
+    monkeypatch.setattr(inf_mod, "_same_task_timeout", _record)
+
     async def _run():
-        response = SimpleNamespace(request = SimpleNamespace(extensions = {"timeout": {}}))
         values = iter([100.0, 2.0])
-        seen = []
 
         class _Request:
             async def is_disconnected(self):
@@ -228,36 +236,42 @@ def test_stream_stall_timeout_callable_re_resolved_each_read():
                     raise StopAsyncIteration
                 return "data: {}"
 
-        async for _ in inf_mod._aiter_llama_stream_items(
+        out = []
+        async for item in inf_mod._aiter_llama_stream_items(
             _Items(),
             cancel_event = threading.Event(),
             request = _Request(),
-            response = response,
             first_token_deadline = time.monotonic() + 1,
             post_first_item_read_timeout_s = lambda: next(values, 5.0),
         ):
-            seen.append(response.request.extensions["timeout"].get("read"))
+            out.append(item)
 
-        assert len(seen) == 3
-        # The callable is resolved right after the first item (arming the
-        # post-first window) and again before each later read, consuming
-        # successive values.
-        assert seen[0] == 100.0
-        assert 1.0 <= seen[1] <= 2.0
-        assert 4.0 <= seen[2] <= 5.0
+        assert out == ["data: {}"] * 3
 
     asyncio.run(_run())
 
+    # First read is the first-token wait (~1s remaining). Each of the three
+    # post-first reads re-resolves the callable, consuming 100.0, 2.0, then the
+    # 5.0 default; a once-captured bound would repeat a single value.
+    assert len(armed) == 4
+    assert armed[0] <= 1.0
+    assert armed[1:] == [100.0, 2.0, 5.0]
 
-def test_stream_stall_timeout_disabled_clears_read_timeout():
+
+def test_stream_stall_timeout_disabled_skips_post_first_wrap(monkeypatch):
     # UNSLOTH_OPENAI_COMPAT_STREAM_STALL_TIMEOUT=0 disables the stall guard, so
-    # the callable returns None. Once a chunk has arrived the leftover
-    # first-token read timeout must be cleared, else a long post-first-chunk gap
-    # trips a stale deadline the operator asked to turn off.
-    async def _run():
-        response = SimpleNamespace(request = SimpleNamespace(extensions = {"timeout": {}}))
-        seen = []
+    # the callable returns None and post-first reads run unwrapped: only the
+    # first-token wait is bounded, no stall deadline the operator turned off.
+    armed = []
+    real_timeout = inf_mod._same_task_timeout
 
+    def _record(timeout_s):
+        armed.append(timeout_s)
+        return real_timeout(timeout_s)
+
+    monkeypatch.setattr(inf_mod, "_same_task_timeout", _record)
+
+    async def _run():
         class _Request:
             async def is_disconnected(self):
                 return False
@@ -272,18 +286,21 @@ def test_stream_stall_timeout_disabled_clears_read_timeout():
                     raise StopAsyncIteration
                 return "data: {}"
 
-        async for _ in inf_mod._aiter_llama_stream_items(
+        out = []
+        async for item in inf_mod._aiter_llama_stream_items(
             _Items(),
             cancel_event = threading.Event(),
             request = _Request(),
-            response = response,
             first_token_deadline = time.monotonic() + 5,
             post_first_item_read_timeout_s = lambda: None,
         ):
-            seen.append(response.request.extensions["timeout"].get("read"))
+            out.append(item)
 
-        # The first-token path armed a finite read timeout; after the first chunk
-        # with the guard disabled, it is cleared to None on every subsequent read.
-        assert seen == [None, None], seen
+        assert out == ["data: {}"] * 2
 
     asyncio.run(_run())
+
+    # Only the first-token read is wrapped; the disabled guard leaves every
+    # post-first read unwrapped, so exactly one timeout is armed.
+    assert len(armed) == 1
+    assert armed[0] <= 5.0

--- a/studio/backend/tests/test_secure_tools_execute.py
+++ b/studio/backend/tests/test_secure_tools_execute.py
@@ -90,6 +90,7 @@ def _make_backend(monkeypatch, streams: list[list[str]]):
         response,
         _cancel_event,
         first_token_deadline = None,
+        client = None,
     ):
         yield from response.chunks
 

--- a/studio/backend/tests/test_stream_stall_watchdog.py
+++ b/studio/backend/tests/test_stream_stall_watchdog.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Regression tests for the mid-stream stall watchdog.
+
+httpcore binds the socket read timeout once when body iteration starts, so the
+old "lower the read timeout after the first chunk" trick was a no-op and a real
+no-byte stall hung for the whole ~20 min first-token deadline. These tests drive
+a genuine ``httpx``/``httpcore`` stream through a raw socket that emits one chunk
+then goes silent, and assert the consumer raises within the short stall window,
+NOT the far-off first-token deadline. No model, subprocess, or GPU needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import sys
+import threading
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from core.inference.llama_cpp import LlamaCppBackend  # noqa: E402
+import routes.inference as inf_mod  # noqa: E402
+
+
+_ONE_CHUNK = b"data: hello\n\n"
+
+
+class _StubUpstream:
+    """A raw HTTP/1.1 server that streams headers + one chunked SSE body chunk,
+    then behaves per ``mode``:
+
+    - ``"stall"``: hold the socket open forever, sending nothing more.
+    - ``"no_first_token"``: send only headers, never any body chunk.
+    - ``"complete"``: send the chunk then the terminating 0-length chunk.
+    - ``"two_chunks"``: send the chunk, a short healthy gap, a second chunk,
+      then the terminator (upstream is never silent for long).
+    """
+
+    def __init__(self, mode: str):
+        self.mode = mode
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind(("127.0.0.1", 0))
+        self._sock.listen(1)
+        self.port = self._sock.getsockname()[1]
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target = self._serve, daemon = True)
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.port}/stream"
+
+    def __enter__(self):
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc):
+        self._stop.set()
+        try:
+            self._sock.close()
+        except OSError:
+            pass
+        self._thread.join(timeout = 5)
+
+    def _serve(self) -> None:
+        try:
+            conn, _ = self._sock.accept()
+        except OSError:
+            return
+        with conn:
+            # Drain the whole request (head + body) so a clean close can't RST
+            # the client on its unread request bytes.
+            conn.settimeout(5)
+            try:
+                buf = b""
+                while b"\r\n\r\n" not in buf:
+                    data = conn.recv(4096)
+                    if not data:
+                        return
+                    buf += data
+                head, _, body = buf.partition(b"\r\n\r\n")
+                content_length = 0
+                for line in head.split(b"\r\n"):
+                    if line.lower().startswith(b"content-length:"):
+                        content_length = int(line.split(b":", 1)[1].strip())
+                        break
+                while len(body) < content_length:
+                    data = conn.recv(4096)
+                    if not data:
+                        break
+                    body += data
+            except OSError:
+                return
+            conn.sendall(
+                b"HTTP/1.1 200 OK\r\n"
+                b"Content-Type: text/event-stream\r\n"
+                b"Transfer-Encoding: chunked\r\n"
+                b"\r\n"
+            )
+            if self.mode != "no_first_token":
+                chunk = _ONE_CHUNK
+                conn.sendall(b"%x\r\n%s\r\n" % (len(chunk), chunk))
+            if self.mode == "complete":
+                conn.sendall(b"0\r\n\r\n")
+                return
+            if self.mode == "two_chunks":
+                self._stop.wait(timeout = 0.2)
+                conn.sendall(b"%x\r\n%s\r\n" % (len(_ONE_CHUNK), _ONE_CHUNK))
+                conn.sendall(b"0\r\n\r\n")
+                return
+            # stall / no_first_token: hold the connection open and silent until
+            # the client tears it down (the watchdog closes its side).
+            while not self._stop.wait(timeout = 0.05):
+                try:
+                    conn.settimeout(0.05)
+                    if conn.recv(1) == b"":
+                        return
+                except socket.timeout:
+                    continue
+                except OSError:
+                    return
+
+
+def test_sync_stall_raises_at_stall_window_not_first_token_deadline():
+    # Bound read timeout is large (proxy for the real ~1200s) and the
+    # first-token deadline is far away; only the 0.5s stall watchdog should fire.
+    with _StubUpstream("stall") as server:
+        with httpx.Client(timeout = httpx.Timeout(connect = 5, read = 100, write = 5, pool = 5)) as client:
+            with client.stream("POST", server.url, json = {}) as response:
+                started = time.monotonic()
+                chunks = []
+                with pytest.raises(httpx.ReadTimeout) as excinfo:
+                    for chunk in LlamaCppBackend._iter_text_cancellable(
+                        response,
+                        stall_timeout_s = 0.5,
+                        first_token_deadline = started + 100,
+                        client = client,
+                    ):
+                        chunks.append(chunk)
+                elapsed = time.monotonic() - started
+    assert "".join(chunks) == _ONE_CHUNK.decode()
+    assert "mid-response" in str(excinfo.value)
+    # Fires on the 0.5s stall window, not the 100s first-token deadline.
+    assert elapsed < 30, elapsed
+
+
+def test_sync_first_token_deadline_fires_when_no_chunk_arrives():
+    with _StubUpstream("no_first_token") as server:
+        with httpx.Client(timeout = httpx.Timeout(connect = 5, read = 100, write = 5, pool = 5)) as client:
+            with client.stream("POST", server.url, json = {}) as response:
+                started = time.monotonic()
+                with pytest.raises(httpx.ReadTimeout) as excinfo:
+                    for _ in LlamaCppBackend._iter_text_cancellable(
+                        response,
+                        stall_timeout_s = 100,
+                        first_token_deadline = started + 0.5,
+                        client = client,
+                    ):
+                        pass
+                elapsed = time.monotonic() - started
+    assert "first token" in str(excinfo.value)
+    assert elapsed < 30, elapsed
+
+
+def test_sync_slow_consumer_does_not_trip_stall():
+    # A consumer that sleeps longer than the stall window between chunks must
+    # NOT trip the watchdog: the window measures upstream silence, not consumer
+    # latency (client backpressure). Pre-fix, the watchdog counted this sleep and
+    # shut the live socket down with a spurious "mid-response".
+    with _StubUpstream("two_chunks") as server:
+        with httpx.Client(timeout = httpx.Timeout(connect = 5, read = 100, write = 5, pool = 5)) as client:
+            with client.stream("POST", server.url, json = {}) as response:
+                started = time.monotonic()
+                chunks = []
+                for chunk in LlamaCppBackend._iter_text_cancellable(
+                    response,
+                    stall_timeout_s = 0.5,
+                    first_token_deadline = started + 100,
+                    client = client,
+                ):
+                    chunks.append(chunk)
+                    if len(chunks) == 1:
+                        time.sleep(1.2)  # > stall window, while upstream is healthy
+    assert "".join(chunks) == (_ONE_CHUNK * 2).decode()
+
+
+def test_async_slow_consumer_does_not_trip_stall():
+    async def _run():
+        with _StubUpstream("two_chunks") as server:
+            async with httpx.AsyncClient(
+                timeout = httpx.Timeout(connect = 5, read = 100, write = 5, pool = 5)
+            ) as client:
+                async with client.stream("POST", server.url, json = {}) as response:
+                    started = time.monotonic()
+                    chunks = []
+                    async for chunk in inf_mod._aiter_llama_stream_items(
+                        response.aiter_text(),
+                        response = response,
+                        first_token_deadline = started + 100,
+                        post_first_item_read_timeout_s = 0.5,
+                    ):
+                        chunks.append(chunk)
+                        if len(chunks) == 1:
+                            await asyncio.sleep(1.2)
+        assert "".join(chunks) == (_ONE_CHUNK * 2).decode()
+
+    asyncio.run(_run())
+
+
+def test_sync_complete_stream_yields_and_ends_cleanly():
+    with _StubUpstream("complete") as server:
+        with httpx.Client(timeout = httpx.Timeout(connect = 5, read = 100, write = 5, pool = 5)) as client:
+            with client.stream("POST", server.url, json = {}) as response:
+                started = time.monotonic()
+                chunks = list(
+                    LlamaCppBackend._iter_text_cancellable(
+                        response,
+                        stall_timeout_s = 5,
+                        first_token_deadline = started + 100,
+                        client = client,
+                    )
+                )
+    assert "".join(chunks) == _ONE_CHUNK.decode()
+
+
+def test_async_stall_raises_at_stall_window_not_first_token_deadline():
+    async def _run():
+        with _StubUpstream("stall") as server:
+            async with httpx.AsyncClient(
+                timeout = httpx.Timeout(connect = 5, read = 100, write = 5, pool = 5)
+            ) as client:
+                async with client.stream("POST", server.url, json = {}) as response:
+                    started = time.monotonic()
+                    chunks = []
+                    with pytest.raises(httpx.ReadTimeout) as excinfo:
+                        async for chunk in inf_mod._aiter_llama_stream_items(
+                            response.aiter_text(),
+                            response = response,
+                            first_token_deadline = started + 100,
+                            post_first_item_read_timeout_s = 0.5,
+                        ):
+                            chunks.append(chunk)
+                    elapsed = time.monotonic() - started
+        assert "".join(chunks) == _ONE_CHUNK.decode()
+        assert "mid-response" in str(excinfo.value)
+        assert elapsed < 30, elapsed
+
+    asyncio.run(_run())

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -827,6 +827,31 @@ function parseSseEvent(rawEvent: string): string[] {
   return dataLines;
 }
 
+// Client-side backstop so the UI leaves "running" if the backend goes silent
+// without ever terminating the stream (wedged event loop, a dropped connection
+// that never resets). The backend's own first-token (~20 min) and stall (~2 min)
+// windows normally surface an SSE error first; this sits just past the backend's
+// longest legitimate silence (a slow prefill) so it never preempts a real run.
+const STREAM_INACTIVITY_TIMEOUT_MS = 21 * 60 * 1000;
+
+async function readWithInactivityTimeout(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  timeoutMs: number,
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error("The model stopped responding.")),
+      timeoutMs,
+    );
+  });
+  try {
+    return await Promise.race([reader.read(), timeout]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
 export async function* streamChatCompletions(
   payload: OpenAIChatCompletionsRequest,
   signal: AbortSignal,
@@ -854,7 +879,10 @@ export async function* streamChatCompletions(
 
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      const { done, value } = await readWithInactivityTimeout(
+        reader,
+        STREAM_INACTIVITY_TIMEOUT_MS,
+      );
       if (done) {
         completed = true;
         break;


### PR DESCRIPTION
When a GGUF generation goes quiet mid-response (for example the context window fills up), the chat stays stuck on "running" for about 20 minutes before anything happens, and Stop does nothing in the meantime. Reported on Discord: a reply stopped mid-sentence and the button sat running for 30 minutes.

There is supposed to be a safeguard here: if a stream produces nothing for 2 minutes, give up and show an error. It never actually fired, so any mid-stream stall hung for the full ~20 minute first-token budget instead.

## Fix

- A stalled generation now ends after ~2 minutes with a clear error, and the UI leaves "running" instead of hanging.
- Applies to both the local chat UI and the OpenAI/Anthropic compatible API streams.
- A slow prefill still gets the full ~20 minutes to produce its first token, so nothing legitimate is cut short.
- A slow or backgrounded client no longer counts against the 2 minute window, so a laggy tab can't falsely kill a healthy generation.
- The browser has its own backstop too, so the UI can recover even if the backend never sends a final event.

## Verification

Added regression tests that run a real stream which sends one token then goes silent, and confirm the generation now stops at the 2 minute mark instead of 20. Added tests that a client pausing longer than the stall window does not trip it. Confirmed these fail on the old code and pass now. Existing streaming and passthrough suites stay green, and the frontend typecheck is clean.
