### PR TITLE
Studio: hint at Model auto-switch in the OpenAI "No model loaded" 400

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -8993,19 +8993,14 @@ async def _responses_stream(
         # double-layer asyncgen close pattern that produces "Attempted to exit
         # cancel scope in a different task" on Python 3.13. Surface a typed 400
         # so the client sees a useful error instead of a dangling stream.
-        detail = (
-            "Streaming /v1/responses requires a GGUF model loaded via "
-            "llama-server. Use non-streaming /v1/responses, "
-            "/v1/chat/completions, or load a GGUF model."
+        raise HTTPException(
+            status_code = 400,
+            detail = _no_model_loaded_detail(
+                "Streaming /v1/responses requires a GGUF model loaded via "
+                "llama-server. Use non-streaming /v1/responses, "
+                "/v1/chat/completions, or load a GGUF model."
+            ),
         )
-        # Only when nothing is loaded at all does this become the reported
-        # "named a listed model, got a bare error" case that auto-switch fixes.
-        # A live non-GGUF (Transformers) model also trips this GGUF-only guard,
-        # and auto-switch won't evict it to load a GGUF, so the hint would
-        # mislead; skip it then. The helper still no-ops when the toggle is on.
-        if not get_inference_backend().active_model_name:
-            detail = _no_model_loaded_detail(detail)
-        raise HTTPException(status_code = 400, detail = detail)
 
     # Direct pass-through bypasses the openai_chat_completions image gate.
     if not llama_backend.is_vision and any(

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2806,6 +2806,22 @@ def _automatic_model_load_may_run() -> bool:
     return get_openai_auto_switch_enabled() or get_auto_unload_idle_seconds() > 0
 
 
+def _no_model_loaded_detail(base: str) -> str:
+    """Append a pointer to the opt-in auto-switch toggle to a "no model loaded"
+    error, but only when it's off. Auto-switch (default off) cold-loads a
+    requested downloaded GGUF, so an off toggle is the usual reason a request
+    naming a listed model still 400/503s; surface the fix. With it on the name
+    simply didn't resolve to a local GGUF, so the hint would mislead and is omitted."""
+    from utils.openai_auto_switch_settings import get_openai_auto_switch_enabled
+
+    if get_openai_auto_switch_enabled():
+        return base
+    return base + (
+        " Or enable Model auto-switch (Settings > API) to load a requested"
+        " model automatically."
+    )
+
+
 async def _maybe_auto_switch_model(
     requested_model: Optional[str],
     fastapi_request: Request,
@@ -5909,7 +5925,9 @@ async def openai_chat_completions(
         if not backend.active_model_name:
             raise HTTPException(
                 status_code = 400,
-                detail = "No model loaded. Call POST /inference/load first.",
+                detail = _no_model_loaded_detail(
+                    "No model loaded. Call POST /inference/load first."
+                ),
             )
         # Clean public id so the response never echoes a local path; the audio
         # branch below receives this sanitized label too.
@@ -8028,7 +8046,9 @@ async def openai_completions(request: Request, current_subject: str = Depends(ge
     if not llama_backend.is_loaded:
         raise HTTPException(
             status_code = 503,
-            detail = "No GGUF model loaded. Load a GGUF model first.",
+            detail = _no_model_loaded_detail(
+                "No GGUF model loaded. Load a GGUF model first."
+            ),
         )
     if not isinstance(body, dict):
         # Re-read to re-raise a malformed-body error (post-503, pre-feature behavior);
@@ -8240,7 +8260,9 @@ async def openai_embeddings(request: Request, current_subject: str = Depends(get
     if not llama_backend.is_loaded:
         raise HTTPException(
             status_code = 503,
-            detail = "No GGUF model loaded. Load a GGUF model first.",
+            detail = _no_model_loaded_detail(
+                "No GGUF model loaded. Load a GGUF model first."
+            ),
         )
     if not isinstance(body, dict):
         # Re-read to re-raise a malformed-body error (post-503, pre-feature behavior);
@@ -8978,14 +9000,19 @@ async def _responses_stream(
         # double-layer asyncgen close pattern that produces "Attempted to exit
         # cancel scope in a different task" on Python 3.13. Surface a typed 400
         # so the client sees a useful error instead of a dangling stream.
-        raise HTTPException(
-            status_code = 400,
-            detail = (
-                "Streaming /v1/responses requires a GGUF model loaded via "
-                "llama-server. Use non-streaming /v1/responses, "
-                "/v1/chat/completions, or load a GGUF model."
-            ),
+        detail = (
+            "Streaming /v1/responses requires a GGUF model loaded via "
+            "llama-server. Use non-streaming /v1/responses, "
+            "/v1/chat/completions, or load a GGUF model."
         )
+        # Only when nothing is loaded at all does this become the reported
+        # "named a listed model, got a bare error" case that auto-switch fixes.
+        # A live non-GGUF (Transformers) model also trips this GGUF-only guard,
+        # and auto-switch won't evict it to load a GGUF, so the hint would
+        # mislead; skip it then. The helper still no-ops when the toggle is on.
+        if not get_inference_backend().active_model_name:
+            detail = _no_model_loaded_detail(detail)
+        raise HTTPException(status_code = 400, detail = detail)
 
     # Direct pass-through bypasses the openai_chat_completions image gate.
     if not llama_backend.is_vision and any(
@@ -10076,7 +10103,9 @@ async def anthropic_count_tokens(
     if not llama_backend.is_loaded:
         raise HTTPException(
             status_code = 503,
-            detail = "No GGUF model loaded. Load a GGUF model first.",
+            detail = _no_model_loaded_detail(
+                "No GGUF model loaded. Load a GGUF model first."
+            ),
         )
 
     # Same Anthropic → OpenAI translation as anthropic_messages: system is
@@ -10146,7 +10175,9 @@ async def anthropic_messages(
     if not llama_backend.is_loaded and not _automatic_model_load_may_run():
         raise HTTPException(
             status_code = 503,
-            detail = "No GGUF model loaded. Load a GGUF model first.",
+            detail = _no_model_loaded_detail(
+                "No GGUF model loaded. Load a GGUF model first."
+            ),
         )
 
     # max_tokens is a required field on the Anthropic Messages API; real Anthropic
@@ -10197,7 +10228,9 @@ async def anthropic_messages(
     if not llama_backend.is_loaded:
         raise HTTPException(
             status_code = 503,
-            detail = "No GGUF model loaded. Load a GGUF model first.",
+            detail = _no_model_loaded_detail(
+                "No GGUF model loaded. Load a GGUF model first."
+            ),
         )
 
     # Advertised repo id after an auto-switch load, else a clean public id, never

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2817,8 +2817,7 @@ def _no_model_loaded_detail(base: str) -> str:
     if get_openai_auto_switch_enabled():
         return base
     return base + (
-        " Or enable Model auto-switch (Settings > API) to load a requested"
-        " model automatically."
+        " Or enable Model auto-switch (Settings > API) to load a requested model automatically."
     )
 
 
@@ -5925,9 +5924,7 @@ async def openai_chat_completions(
         if not backend.active_model_name:
             raise HTTPException(
                 status_code = 400,
-                detail = _no_model_loaded_detail(
-                    "No model loaded. Call POST /inference/load first."
-                ),
+                detail = _no_model_loaded_detail("No model loaded. Call POST /inference/load first."),
             )
         # Clean public id so the response never echoes a local path; the audio
         # branch below receives this sanitized label too.
@@ -8046,9 +8043,7 @@ async def openai_completions(request: Request, current_subject: str = Depends(ge
     if not llama_backend.is_loaded:
         raise HTTPException(
             status_code = 503,
-            detail = _no_model_loaded_detail(
-                "No GGUF model loaded. Load a GGUF model first."
-            ),
+            detail = _no_model_loaded_detail("No GGUF model loaded. Load a GGUF model first."),
         )
     if not isinstance(body, dict):
         # Re-read to re-raise a malformed-body error (post-503, pre-feature behavior);
@@ -8260,9 +8255,7 @@ async def openai_embeddings(request: Request, current_subject: str = Depends(get
     if not llama_backend.is_loaded:
         raise HTTPException(
             status_code = 503,
-            detail = _no_model_loaded_detail(
-                "No GGUF model loaded. Load a GGUF model first."
-            ),
+            detail = _no_model_loaded_detail("No GGUF model loaded. Load a GGUF model first."),
         )
     if not isinstance(body, dict):
         # Re-read to re-raise a malformed-body error (post-503, pre-feature behavior);
@@ -10103,9 +10096,7 @@ async def anthropic_count_tokens(
     if not llama_backend.is_loaded:
         raise HTTPException(
             status_code = 503,
-            detail = _no_model_loaded_detail(
-                "No GGUF model loaded. Load a GGUF model first."
-            ),
+            detail = _no_model_loaded_detail("No GGUF model loaded. Load a GGUF model first."),
         )
 
     # Same Anthropic → OpenAI translation as anthropic_messages: system is
@@ -10175,9 +10166,7 @@ async def anthropic_messages(
     if not llama_backend.is_loaded and not _automatic_model_load_may_run():
         raise HTTPException(
             status_code = 503,
-            detail = _no_model_loaded_detail(
-                "No GGUF model loaded. Load a GGUF model first."
-            ),
+            detail = _no_model_loaded_detail("No GGUF model loaded. Load a GGUF model first."),
         )
 
     # max_tokens is a required field on the Anthropic Messages API; real Anthropic
@@ -10228,9 +10217,7 @@ async def anthropic_messages(
     if not llama_backend.is_loaded:
         raise HTTPException(
             status_code = 503,
-            detail = _no_model_loaded_detail(
-                "No GGUF model loaded. Load a GGUF model first."
-            ),
+            detail = _no_model_loaded_detail("No GGUF model loaded. Load a GGUF model first."),
         )
 
     # Advertised repo id after an auto-switch load, else a clean public id, never

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -3037,3 +3037,62 @@ def test_acquire_swap_gate_is_cancellation_safe():
         inference_route._auto_switch_process_lock.release()
 
     asyncio.run(asyncio.wait_for(main(), timeout = 5))
+
+
+def test_no_model_loaded_detail_appends_hint_only_when_off(monkeypatch):
+    # The "no model loaded" errors point at the opt-in auto-switch toggle so a
+    # request naming a listed-but-unloaded model is self-explanatory -- but only
+    # when it's off. With it on the name simply didn't resolve, so no hint.
+    base = "No GGUF model loaded. Load a GGUF model first."
+
+    monkeypatch.setattr(settings, "get_openai_auto_switch_enabled", lambda: False)
+    off = inference_route._no_model_loaded_detail(base)
+    assert off.startswith(base)
+    assert "Model auto-switch" in off and "Settings > API" in off
+
+    monkeypatch.setattr(settings, "get_openai_auto_switch_enabled", lambda: True)
+    assert inference_route._no_model_loaded_detail(base) == base
+
+
+def _run_responses_stream_no_model(monkeypatch, *, enabled, active_model_name):
+    # Drive _responses_stream's GGUF-not-loaded guard: llama backend unloaded,
+    # inference backend maybe holding a non-GGUF model. Returns the 400 detail.
+    from fastapi import HTTPException
+    from models.inference import ResponsesRequest, ChatMessage
+
+    monkeypatch.setattr(settings, "get_openai_auto_switch_enabled", lambda: enabled)
+    monkeypatch.setattr(
+        inference_route, "get_llama_cpp_backend", lambda: _FakeBackend(loaded_id = None)
+    )
+    monkeypatch.setattr(
+        inference_route,
+        "get_inference_backend",
+        lambda: type("_B", (), {"active_model_name": active_model_name})(),
+    )
+    payload = ResponsesRequest(model = "unsloth/Qwen3.5-4B-GGUF", stream = True)
+    messages = [ChatMessage(role = "user", content = "hi")]
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(inference_route._responses_stream(payload, messages, None))
+    assert exc.value.status_code == 400
+    return exc.value.detail
+
+
+def test_responses_stream_hint_only_when_nothing_loaded_and_off(monkeypatch):
+    # Streaming /v1/responses shares a GGUF-only 400 with the non-GGUF-loaded
+    # state, so the auto-switch hint attaches only when nothing is loaded at all
+    # (the reported bug class) and the toggle is off. A live non-GGUF model, or
+    # the toggle already on, must not draw the hint.
+    hinted = _run_responses_stream_no_model(
+        monkeypatch, enabled = False, active_model_name = None
+    )
+    assert "Model auto-switch" in hinted
+
+    on = _run_responses_stream_no_model(
+        monkeypatch, enabled = True, active_model_name = None
+    )
+    assert "Model auto-switch" not in on
+
+    non_gguf_loaded = _run_responses_stream_no_model(
+        monkeypatch, enabled = False, active_model_name = "unsloth/Llama-3.2-1B-Instruct"
+    )
+    assert "Model auto-switch" not in non_gguf_loaded

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -3077,11 +3077,13 @@ def _run_responses_stream_no_model(monkeypatch, *, enabled, active_model_name):
     return exc.value.detail
 
 
-def test_responses_stream_hint_only_when_nothing_loaded_and_off(monkeypatch):
-    # Streaming /v1/responses shares a GGUF-only 400 with the non-GGUF-loaded
-    # state, so the auto-switch hint attaches only when nothing is loaded at all
-    # (the reported bug class) and the toggle is off. A live non-GGUF model, or
-    # the toggle already on, must not draw the hint.
+def test_responses_stream_hint_matches_toggle_regardless_of_active_model(monkeypatch):
+    # Streaming /v1/responses shares the GGUF-only 400 with the other "no model
+    # loaded" sites, so the auto-switch hint attaches whenever the toggle is
+    # off -- including while a non-GGUF model is active, since auto-switch
+    # evicts it to load a resolved GGUF (_maybe_auto_switch_model's resolver
+    # branch has no active-model guard, unlike its reload-stash branch). Only
+    # the toggle being on suppresses it.
     hinted = _run_responses_stream_no_model(monkeypatch, enabled = False, active_model_name = None)
     assert "Model auto-switch" in hinted
 
@@ -3091,4 +3093,4 @@ def test_responses_stream_hint_only_when_nothing_loaded_and_off(monkeypatch):
     non_gguf_loaded = _run_responses_stream_no_model(
         monkeypatch, enabled = False, active_model_name = "unsloth/Llama-3.2-1B-Instruct"
     )
-    assert "Model auto-switch" not in non_gguf_loaded
+    assert "Model auto-switch" in non_gguf_loaded

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -3082,14 +3082,10 @@ def test_responses_stream_hint_only_when_nothing_loaded_and_off(monkeypatch):
     # state, so the auto-switch hint attaches only when nothing is loaded at all
     # (the reported bug class) and the toggle is off. A live non-GGUF model, or
     # the toggle already on, must not draw the hint.
-    hinted = _run_responses_stream_no_model(
-        monkeypatch, enabled = False, active_model_name = None
-    )
+    hinted = _run_responses_stream_no_model(monkeypatch, enabled = False, active_model_name = None)
     assert "Model auto-switch" in hinted
 
-    on = _run_responses_stream_no_model(
-        monkeypatch, enabled = True, active_model_name = None
-    )
+    on = _run_responses_stream_no_model(monkeypatch, enabled = True, active_model_name = None)
     assert "Model auto-switch" not in on
 
     non_gguf_loaded = _run_responses_stream_no_model(


### PR DESCRIPTION
Studio can already auto-load a requested model over the API before serving it, but it's opt-in and off by default (Model auto-switch, shipped in #6392/#6430). With it off, calling `/v1/chat/completions` with a model that `/v1/models` lists returns a bare `400 No model loaded. Call POST /inference/load first.`, and nothing tells you the toggle that fixes it exists. Users keep hitting this and reporting it (Discord).

## Fix

When auto-switch is off, the "no model loaded" error now adds a pointer to the toggle:

> No model loaded. Call POST /inference/load first. Or enable Model auto-switch (Settings > API) to load a requested model automatically.

Turn the toggle on and the same request loads the model and serves it. The hint only shows when it would actually help. With auto-switch already on, hitting the error means the requested name just didn't match a downloaded model, so the pointer would be misleading and is left off.

The same hint now covers the other endpoints where auto-switch applies too, not just chat: `/v1/completions`, `/v1/embeddings`, and the Anthropic `/v1/messages` and `/v1/messages/count_tokens`. Streaming `/v1/responses` gets it only when nothing is loaded at all, since that error also fires when a non-GGUF model is already up (where enabling auto-switch wouldn't change anything). The in-app UI routes are unchanged.

## Verification

Ran Studio and hit each endpoint live. With auto-switch off the hint shows up; with it on and an unrecognized model name it stays off. Added regression tests for both cases, including the streaming `/v1/responses` behavior. `test_openai_auto_switch.py` passes (150).
