### PR TITLE
Clarify in README that -H 0.0.0.0 starts a public Cloudflare tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ By default `unsloth studio` binds to `127.0.0.1` (this machine only). To reach i
 ```bash
 unsloth studio --secure -p 8888
 ```
-- `-H 0.0.0.0`: bind the raw port on all network interfaces, reachable from anywhere on the network. Only use this on a trusted network. This also starts a public Cloudflare tunnel by default, exposing Studio to the internet at a `https://*.trycloudflare.com` URL that works even behind a firewall. Pass `--no-cloudflare` to drop the public link while keeping the network bind.
+- `-H 0.0.0.0`: bind the raw port on all network interfaces, reachable from anywhere on the network. This also starts a public Cloudflare quick tunnel by default, which publishes an internet-reachable `https://*.trycloudflare.com` URL even behind a firewall. Both the raw port and the tunnel expose Studio beyond this machine, so only use this on a network you trust; pass `--no-cloudflare` to drop the public link while keeping the network bind.
 ```bash
 unsloth studio -H 0.0.0.0 -p 8888
 ```

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ By default `unsloth studio` binds to `127.0.0.1` (this machine only). To reach i
 ```bash
 unsloth studio --secure -p 8888
 ```
-- `-H 0.0.0.0`: bind the raw port on all network interfaces, reachable from anywhere on the network. This also starts a public Cloudflare tunnel by default, exposing Studio to the internet at a `https://*.trycloudflare.com` URL that works even behind a firewall. Only use this on a network you trust; pass `--no-cloudflare` to drop the public link while keeping the network bind.
+- `-H 0.0.0.0`: bind the raw port on all network interfaces, reachable from anywhere on the network. This also starts a public Cloudflare tunnel by default, exposing Studio to the internet at a `https://*.trycloudflare.com` URL that works even behind a firewall. Pass `--no-cloudflare` to drop the public link while keeping the network bind.
 ```bash
 unsloth studio -H 0.0.0.0 -p 8888
 ```

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ By default `unsloth studio` binds to `127.0.0.1` (this machine only). To reach i
 ```bash
 unsloth studio --secure -p 8888
 ```
-- `-H 0.0.0.0`: bind the raw port on all network interfaces, reachable from anywhere on the network. This also starts a public Cloudflare tunnel by default, exposing Studio to the internet at a `https://*.trycloudflare.com` URL that works even behind a firewall. Pass `--no-cloudflare` to drop the public link while keeping the network bind.
+- `-H 0.0.0.0`: bind the raw port on all network interfaces, reachable from anywhere on the network. Only use this on a trusted network. This also starts a public Cloudflare tunnel by default, exposing Studio to the internet at a `https://*.trycloudflare.com` URL that works even behind a firewall. Pass `--no-cloudflare` to drop the public link while keeping the network bind.
 ```bash
 unsloth studio -H 0.0.0.0 -p 8888
 ```

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ By default `unsloth studio` binds to `127.0.0.1` (this machine only). To reach i
 ```bash
 unsloth studio --secure -p 8888
 ```
-- `-H 0.0.0.0`: bind the raw port on all network interfaces, reachable from anywhere on the network. This also starts a public Cloudflare quick-tunnel by default, which (when it comes up) publishes an internet-reachable `https://*.trycloudflare.com` URL that works even behind a firewall. Both the raw port and the tunnel expose Studio beyond this machine, so only use this on a network you trust; pass `--no-cloudflare` to drop the public link while keeping the network bind.
+- `-H 0.0.0.0`: bind the raw port on all network interfaces, reachable from anywhere on the network. This also starts a public Cloudflare tunnel by default, exposing Studio to the internet at a `https://*.trycloudflare.com` URL that works even behind a firewall. Only use this on a network you trust; pass `--no-cloudflare` to drop the public link while keeping the network bind.
 ```bash
 unsloth studio -H 0.0.0.0 -p 8888
 ```

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ By default `unsloth studio` binds to `127.0.0.1` (this machine only). To reach i
 ```bash
 unsloth studio --secure -p 8888
 ```
-- `-H 0.0.0.0`: bind the raw port on all network interfaces, reachable from anywhere on the network. This also starts a public Cloudflare quick-tunnel by default, publishing an internet-reachable `https://*.trycloudflare.com` URL (this works even behind a firewall). Pass `--no-cloudflare` to disable just the public link while keeping the network bind.
+- `-H 0.0.0.0`: bind the raw port on all network interfaces, reachable from anywhere on the network. This also starts a public Cloudflare quick-tunnel by default, which (when it comes up) publishes an internet-reachable `https://*.trycloudflare.com` URL that works even behind a firewall. Both the raw port and the tunnel expose Studio beyond this machine, so only use this on a network you trust; pass `--no-cloudflare` to drop the public link while keeping the network bind.
 ```bash
 unsloth studio -H 0.0.0.0 -p 8888
 ```

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ By default `unsloth studio` binds to `127.0.0.1` (this machine only). To reach i
 ```bash
 unsloth studio --secure -p 8888
 ```
-- `-H 0.0.0.0`: bind the raw port on all network interfaces, reachable from anywhere on the network. Only use this on a trusted network.
+- `-H 0.0.0.0`: bind the raw port on all network interfaces, reachable from anywhere on the network. This also starts a public Cloudflare quick-tunnel by default, publishing an internet-reachable `https://*.trycloudflare.com` URL (this works even behind a firewall). Pass `--no-cloudflare` to disable just the public link while keeping the network bind.
 ```bash
 unsloth studio -H 0.0.0.0 -p 8888
 ```


### PR DESCRIPTION
The README described `-H 0.0.0.0` as a LAN-only bind ("Only use this on a trusted network"), but a wildcard bind also starts a public Cloudflare tunnel by default and publishes an internet-reachable `https://*.trycloudflare.com` URL. A user was caught out by this on Discord: they launched for the local network and ended up exposed to the internet, with nothing in the docs about it.

Docs-only. The `-H 0.0.0.0` bullet now says it starts a public tunnel by default, that the URL works even behind a firewall, and that `--no-cloudflare` drops the public link while keeping the network bind. The startup warning banner for this already exists (#6515).
