### PR TITLE
fix(studio): warn when a KV-cache type lacks GPU flash-attention support (#6272)

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1040,6 +1040,29 @@ def _kv_bytes_per_elem(cache_type: Optional[str]) -> float:
     }.get((cache_type or "f16").strip().lower(), 2.0)
 
 
+# K-quant KV cache types without a CUDA dequant kernel in mainline llama.cpp;
+# a GPU-offloaded run silently falls back to the CPU reference path for KV
+# ops, which can dominate decode latency. q8_0/q4_0/iq4_nl are GPU-accelerated.
+_GPU_UNACCELERATED_CACHE_TYPES = frozenset({"q4_1", "q5_0", "q5_1"})
+
+
+def _kv_cache_gpu_fallback_warning(
+    cache_type_kv: Optional[str], gpu_present: bool
+) -> Optional[str]:
+    """Hedged warning when a GPU launch requests a KV cache type that may lack
+    a CUDA kernel and fall back to CPU, or None when no warning applies."""
+    if not gpu_present:
+        return None
+    normalized = (cache_type_kv or "").strip().lower()
+    if normalized not in _GPU_UNACCELERATED_CACHE_TYPES:
+        return None
+    return (
+        f"KV cache type {normalized} may lack GPU acceleration on this "
+        "llama.cpp build and fall back to CPU, causing high CPU load. "
+        "q8_0 is a safer quantized option."
+    )
+
+
 def _env_main_cache_type_for_budget(env: Optional[Mapping[str, str]] = None) -> Optional[str]:
     """Heavier of the inherited LLAMA_ARG_CACHE_TYPE_K/_V env types when it
     exceeds the f16 default, else None. Studio emits --cache-type only for the
@@ -6344,6 +6367,11 @@ class LlamaCppBackend:
                     )
                     self._cache_type_kv = cache_type_kv
                     logger.info(f"KV cache type: {cache_type_kv}")
+                    gpu_fallback_warning = _kv_cache_gpu_fallback_warning(
+                        cache_type_kv, bool(gpus)
+                    )
+                    if gpu_fallback_warning:
+                        logger.warning(gpu_fallback_warning)
                 else:
                     # An env-only type is left inherited (untouched) so an
                     # asymmetric K/V env reaches the child as set.

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -6367,9 +6367,7 @@ class LlamaCppBackend:
                     )
                     self._cache_type_kv = cache_type_kv
                     logger.info(f"KV cache type: {cache_type_kv}")
-                    gpu_fallback_warning = _kv_cache_gpu_fallback_warning(
-                        cache_type_kv, bool(gpus)
-                    )
+                    gpu_fallback_warning = _kv_cache_gpu_fallback_warning(cache_type_kv, bool(gpus))
                     if gpu_fallback_warning:
                         logger.warning(gpu_fallback_warning)
                 else:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2857,8 +2857,7 @@ def _kv_cache_gpu_fallback_warning(
         return None
     if gpu_memory_mode not in {"auto", "manual"}:
         return None
-    if gpu_memory_mode == "manual" and gpu_layers < 0:
-        pass  # Manual Auto still delegates placement to llama.cpp's GPU fitter.
+    # Manual Auto still delegates placement to llama.cpp's GPU fitter.
     normalized = (cache_type_kv or "").strip().lower()
     if normalized not in _GPU_UNACCELERATED_CACHE_TYPES:
         return None
@@ -17399,8 +17398,17 @@ class LlamaCppBackend:
                     )
                     if intent.cpu_fallback:
                         inference_backend = None
+                    advisory_cache_type = (
+                        intent.cache_type_kv
+                        if (
+                            _extras_cache is None
+                            and not _cache_type_from_env
+                            and cache_type_kv == intent.cache_type_kv
+                        )
+                        else None
+                    )
                     gpu_fallback_warning = _kv_cache_gpu_fallback_warning(
-                        intent.cache_type_kv,
+                        advisory_cache_type,
                         gpu_memory_mode,
                         gpu_layers,
                         inference_backend,

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -17400,7 +17400,7 @@ class LlamaCppBackend:
                     if intent.cpu_fallback:
                         inference_backend = None
                     gpu_fallback_warning = _kv_cache_gpu_fallback_warning(
-                        cache_type_kv,
+                        intent.cache_type_kv,
                         gpu_memory_mode,
                         gpu_layers,
                         inference_backend,

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2839,6 +2839,36 @@ def _kv_bytes_per_elem(cache_type: Optional[str]) -> float:
     }.get((cache_type or "f16").strip().lower(), 2.0)
 
 
+# These scalar cache types use the CPU reference path for KV operations on the
+# affected CUDA/HIP llama.cpp builds.
+_GPU_UNACCELERATED_CACHE_TYPES = frozenset({"q4_1", "q5_0", "q5_1", "iq4_nl"})
+
+
+def _kv_cache_gpu_fallback_warning(
+    cache_type_kv: Optional[str],
+    gpu_memory_mode: str,
+    gpu_layers: int,
+    inference_backend: Optional[str],
+) -> Optional[str]:
+    """Warn for an affected scalar cache on a GPU-backed inference launch."""
+    if inference_backend not in {"cuda", "hip"}:
+        return None
+    if gpu_memory_mode == "manual" and gpu_layers == 0:
+        return None
+    if gpu_memory_mode not in {"auto", "manual"}:
+        return None
+    if gpu_memory_mode == "manual" and gpu_layers < 0:
+        pass  # Manual Auto still delegates placement to llama.cpp's GPU fitter.
+    normalized = (cache_type_kv or "").strip().lower()
+    if normalized not in _GPU_UNACCELERATED_CACHE_TYPES:
+        return None
+    return (
+        f"KV cache type {normalized} may lack GPU acceleration on this "
+        "CUDA/HIP llama.cpp build and fall back to CPU, causing high CPU load. "
+        "q8_0 is a safer quantized option."
+    )
+
+
 def _pad_kv_cells(cells: int) -> int:
     return ((cells + 255) // 256) * 256
 
@@ -17359,6 +17389,24 @@ class LlamaCppBackend:
                     )
                     self._cache_type_kv = cache_type_kv
                     logger.info(f"KV cache type: {cache_type_kv}")
+                    inference_backend = next(
+                        (
+                            name
+                            for name in ("cuda", "hip")
+                            if name in self._installed_ggml_backends(binary)
+                        ),
+                        None,
+                    )
+                    if intent.cpu_fallback:
+                        inference_backend = None
+                    gpu_fallback_warning = _kv_cache_gpu_fallback_warning(
+                        cache_type_kv,
+                        gpu_memory_mode,
+                        gpu_layers,
+                        inference_backend,
+                    )
+                    if gpu_fallback_warning:
+                        logger.warning(gpu_fallback_warning)
                 else:
                     # An env-only type is left inherited (untouched) so an
                     # asymmetric K/V env reaches the child as set.

--- a/studio/backend/tests/test_llama_cpp_kv_cache_gpu_warning.py
+++ b/studio/backend/tests/test_llama_cpp_kv_cache_gpu_warning.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Tests for the KV-cache GPU-compat warning (#6272).
+
+q4_1/q5_0/q5_1 KV cache types have no CUDA dequant kernel in mainline
+llama.cpp, so a GPU-offloaded launch requesting one silently falls back to
+the CPU reference path for KV ops, which can dominate decode latency.
+``_kv_cache_gpu_fallback_warning`` hedges that with a warning at launch
+time, using the ``gpus`` list already probed by ``load_model`` (no new
+GPU probe). Pins: warns only for the risky types, only when a GPU is
+present, and composes correctly against the real ``gpus``-shaped value
+used at the call site.
+"""
+
+from __future__ import annotations
+
+import sys
+import types as _types
+from pathlib import Path
+
+import pytest
+
+# Stub heavy / unavailable deps before importing the module under test.
+# Same pattern as test_llama_cpp_max_context_threshold.py.
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+# loggers
+_loggers_stub = _types.ModuleType("loggers")
+_loggers_stub.get_logger = lambda name: __import__("logging").getLogger(name)
+sys.modules.setdefault("loggers", _loggers_stub)
+
+# structlog
+_structlog_stub = _types.ModuleType("structlog")
+sys.modules.setdefault("structlog", _structlog_stub)
+
+# httpx
+_httpx_stub = _types.ModuleType("httpx")
+for _exc_name in (
+    "ConnectError",
+    "TimeoutException",
+    "ReadTimeout",
+    "ReadError",
+    "RemoteProtocolError",
+    "CloseError",
+):
+    setattr(_httpx_stub, _exc_name, type(_exc_name, (Exception,), {}))
+
+
+class _FakeTimeout:
+    def __init__(self, *a, **kw):
+        pass
+
+
+_httpx_stub.Timeout = _FakeTimeout
+_httpx_stub.Client = type(
+    "Client",
+    (),
+    {
+        "__init__": lambda self, **kw: None,
+        "__enter__": lambda self: self,
+        "__exit__": lambda self, *a: None,
+    },
+)
+sys.modules.setdefault("httpx", _httpx_stub)
+
+from core.inference.llama_cpp import (
+    _GPU_UNACCELERATED_CACHE_TYPES,
+    _kv_cache_gpu_fallback_warning,
+)
+
+
+class TestWarnsForRiskyTypeWithGpu:
+    """Every GPU-unaccelerated cache type should warn when a GPU is present."""
+
+    @pytest.mark.parametrize("cache_type", sorted(_GPU_UNACCELERATED_CACHE_TYPES))
+    def test_warns(self, cache_type):
+        msg = _kv_cache_gpu_fallback_warning(cache_type, True)
+        assert msg is not None
+        assert cache_type in msg
+        assert "q8_0" in msg
+
+    def test_case_insensitive(self):
+        assert _kv_cache_gpu_fallback_warning("Q5_1", True) is not None
+
+
+class TestSilentForSafeTypeWithGpu:
+    """GPU-accelerated cache types must never warn, even with a GPU present."""
+
+    @pytest.mark.parametrize("cache_type", ["f16", "bf16", "f32", "q8_0", "q4_0", "iq4_nl"])
+    def test_silent(self, cache_type):
+        assert _kv_cache_gpu_fallback_warning(cache_type, True) is None
+
+    def test_silent_for_none(self):
+        assert _kv_cache_gpu_fallback_warning(None, True) is None
+
+
+class TestSilentForRiskyTypeWithoutGpu:
+    """A CPU-only launch is on the CPU path regardless of cache type, so no
+    GPU-fallback warning applies."""
+
+    @pytest.mark.parametrize("cache_type", sorted(_GPU_UNACCELERATED_CACHE_TYPES))
+    def test_silent(self, cache_type):
+        assert _kv_cache_gpu_fallback_warning(cache_type, False) is None
+
+
+class TestLogsViaExistingGpusVar:
+    """The launch call site passes ``bool(gpus)`` where ``gpus`` is the list
+    of ``(gpu_index, free_mib, total_mib)`` / ``(gpu_index, free_mib)``
+    tuples already probed by ``load_model`` -- no new GPU probe. Exercise
+    that exact conversion against realistic shapes."""
+
+    def test_nonempty_gpus_list_warns(self):
+        gpus = [(0, 24_000, 24_000)]
+        assert _kv_cache_gpu_fallback_warning("q5_0", bool(gpus)) is not None
+
+    def test_empty_gpus_list_is_silent(self):
+        gpus: list[tuple[int, int, int]] = []
+        assert _kv_cache_gpu_fallback_warning("q5_0", bool(gpus)) is None
+
+    def test_multi_gpu_list_warns(self):
+        gpus = [(0, 24_000), (1, 24_000)]
+        assert _kv_cache_gpu_fallback_warning("q4_1", bool(gpus)) is not None

--- a/studio/backend/tests/test_llama_cpp_kv_cache_gpu_warning.py
+++ b/studio/backend/tests/test_llama_cpp_kv_cache_gpu_warning.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Production-path contract tests for the GGUF KV-cache advisory."""
+
+from __future__ import annotations
+
+import inspect
+import sys
+import types
+
+import pytest
+
+# Keep this focused module importable in the lightweight backend test runner.
+_loggers = types.ModuleType("loggers")
+_loggers.get_logger = lambda name: __import__("logging").getLogger(name)
+sys.modules.setdefault("loggers", _loggers)
+_structlog = types.ModuleType("structlog")
+_structlog.get_logger = lambda *args, **kwargs: __import__("logging").getLogger("stub")
+sys.modules.setdefault("structlog", _structlog)
+
+from core.inference import llama_cpp
+
+
+RISKY = ("q4_1", "q5_0", "q5_1", "iq4_nl")
+SAFE = ("f16", "bf16", "q8_0", "q4_0", "f32", None)
+BACKENDS = ("cuda", "hip")
+
+
+@pytest.mark.parametrize("cache_type", RISKY)
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize(
+    "mode,layers",
+    [("auto", -1), ("manual", -1), ("manual", 1)],
+)
+def test_production_warning_path_warns(cache_type, backend, mode, layers):
+    assert (
+        llama_cpp._kv_cache_gpu_fallback_warning(cache_type, mode, layers, backend)
+        is not None
+    )
+
+
+@pytest.mark.parametrize("cache_type", SAFE)
+@pytest.mark.parametrize("backend", ("cuda", "hip", "vulkan", "metal", "cpu", "unknown", None))
+@pytest.mark.parametrize(
+    "mode,layers",
+    [("auto", -1), ("manual", -1), ("manual", 0), ("manual", 1)],
+)
+def test_safe_types_and_non_cuda_hip_backends_are_silent(cache_type, backend, mode, layers):
+    assert llama_cpp._kv_cache_gpu_fallback_warning(cache_type, mode, layers, backend) is None
+
+
+@pytest.mark.parametrize("backend", ("cuda", "hip"))
+def test_manual_zero_and_cpu_fallback_are_silent(backend):
+    assert llama_cpp._kv_cache_gpu_fallback_warning("q4_1", "manual", 0, backend) is None
+    assert llama_cpp._kv_cache_gpu_fallback_warning("q4_1", "manual", 0, None) is None
+
+
+def test_load_model_uses_scalar_intent_and_preserves_command_path():
+    source = inspect.getsource(llama_cpp.LlamaCppBackend.load_model)
+    assert "_kv_cache_gpu_fallback_warning(" in source
+    assert "cache_type_kv" in source
+    assert "intent.gpu_memory_mode" in source
+    assert "intent.gpu_layers" in source
+    assert "intent.gpu_ids" not in source[source.find("_kv_cache_gpu_fallback_warning") :]
+    assert '"--cache-type-k"' in source
+    assert '"--cache-type-v"' in source
+
+
+def test_warning_does_not_read_per_axis_extra_arguments_or_environment():
+    source = inspect.getsource(llama_cpp._kv_cache_gpu_fallback_warning)
+    assert "extra_args" not in source
+    assert "environ" not in source

--- a/studio/backend/tests/test_llama_cpp_kv_cache_gpu_warning.py
+++ b/studio/backend/tests/test_llama_cpp_kv_cache_gpu_warning.py
@@ -4,8 +4,12 @@
 from __future__ import annotations
 
 import inspect
+import struct
+import subprocess
 import sys
 import types
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -74,3 +78,87 @@ def test_warning_does_not_read_per_axis_extra_arguments_or_environment():
     source = inspect.getsource(llama_cpp._kv_cache_gpu_fallback_warning)
     assert "extra_args" not in source
     assert "environ" not in source
+
+
+def _write_minimal_gguf(path: Path) -> str:
+    key = b"general.architecture"
+    value = b"llama"
+    metadata = struct.pack("<Q", len(key)) + key
+    metadata += struct.pack("<I", 8) + struct.pack("<Q", len(value)) + value
+    path.write_bytes(struct.pack("<IIQQ", 0x46554747, 3, 0, 1) + metadata)
+    return str(path)
+
+
+@pytest.mark.parametrize(
+    "extra_args,env_cache,expected_warning",
+    [
+        (None, None, ("q4_1", "auto", -1, "cuda")),
+        (["--cache-type-k", "q8_0"], None, (None, "auto", -1, "cuda")),
+        (None, "f32", None),
+    ],
+)
+def test_production_load_path_applies_advisory_authority(
+    monkeypatch, tmp_path, extra_args, env_cache, expected_warning
+):
+    backend = llama_cpp.LlamaCppBackend()
+    gguf = _write_minimal_gguf(tmp_path / "model.gguf")
+    backend._get_gpu_memory = lambda _binary = None, **_kw: [(0, 10_000, 16_000)]
+    backend._get_gpu_free_memory = lambda _binary = None, **_kw: [(0, 10_000)]
+    backend._read_gguf_metadata = lambda _path: None
+    backend._can_estimate_kv = lambda: False
+    backend._get_gguf_size_bytes = lambda _path: 1024
+    backend._mmproj_vram_bytes = lambda _path: 0
+    backend._resolve_launch_mmproj_path = lambda **_kwargs: None
+    backend._apu_ram_shortfall_message = lambda *args, **kwargs: None
+    backend._launch_host_shortfall_message = lambda *args, **kwargs: None
+    backend._amd_apu_wants_unified_memory = lambda *args, **kwargs: False
+    backend._find_llama_server_binary = lambda **_kwargs: "/fake/llama-server"
+    backend._is_vulkan_backend = lambda _binary = None: False
+    backend._installed_ggml_backends = lambda _binary = None: frozenset({"cuda"})
+    backend._wait_for_health = lambda timeout: True
+    backend._detect_audio_type_strict = lambda: None
+    backend._apply_detected_audio = lambda _detected: True
+    if env_cache is None:
+        monkeypatch.delenv("LLAMA_ARG_CACHE_TYPE_K", raising = False)
+    else:
+        monkeypatch.setenv("LLAMA_ARG_CACHE_TYPE_K", env_cache)
+
+    warnings = []
+    monkeypatch.setattr(
+        llama_cpp,
+        "_kv_cache_gpu_fallback_warning",
+        lambda *args: warnings.append(args) or None,
+    )
+
+    real_popen = subprocess.Popen
+
+    def fake_popen(cmd, **kwargs):
+        if not cmd or str(cmd[0]) != "/fake/llama-server":
+            return real_popen(cmd, **kwargs)
+        return type(
+            "Process",
+            (),
+            {
+                "pid": 123,
+                "stdout": (),
+                "poll": lambda self: None,
+                "terminate": lambda self: None,
+                "wait": lambda self, timeout = None: 0,
+                "kill": lambda self: None,
+            },
+        )()
+
+    with patch.object(subprocess, "Popen", side_effect = fake_popen):
+        assert backend.load_model(
+            llama_cpp.GgufLoadIntent(
+                gguf_path = gguf,
+                model_identifier = "test",
+                cache_type_kv = None if env_cache is not None else "q4_1",
+                extra_args = extra_args,
+            )
+        ) is True
+
+    if expected_warning is None:
+        assert warnings == []
+    else:
+        assert warnings == [expected_warning]

--- a/studio/backend/tests/test_llama_cpp_kv_cache_gpu_warning.py
+++ b/studio/backend/tests/test_llama_cpp_kv_cache_gpu_warning.py
@@ -57,7 +57,10 @@ def test_manual_zero_and_cpu_fallback_are_silent(backend):
 def test_load_model_uses_scalar_intent_and_preserves_command_path():
     source = inspect.getsource(llama_cpp.LlamaCppBackend.load_model)
     assert "_kv_cache_gpu_fallback_warning(" in source
-    assert "cache_type_kv" in source
+    warning_start = source.index("gpu_fallback_warning = _kv_cache_gpu_fallback_warning(")
+    warning_block = source[warning_start : warning_start + 260]
+    assert "intent.cache_type_kv" in warning_block
+    assert "\n                    cache_type_kv," not in warning_block
     assert "intent.gpu_memory_mode" in source
     assert "intent.gpu_layers" in source
     assert "intent.gpu_ids" not in source[source.find("_kv_cache_gpu_fallback_warning") :]

--- a/studio/backend/tests/test_llama_cpp_kv_cache_gpu_warning.py
+++ b/studio/backend/tests/test_llama_cpp_kv_cache_gpu_warning.py
@@ -36,10 +36,7 @@ BACKENDS = ("cuda", "hip")
     [("auto", -1), ("manual", -1), ("manual", 1)],
 )
 def test_production_warning_path_warns(cache_type, backend, mode, layers):
-    assert (
-        llama_cpp._kv_cache_gpu_fallback_warning(cache_type, mode, layers, backend)
-        is not None
-    )
+    assert llama_cpp._kv_cache_gpu_fallback_warning(cache_type, mode, layers, backend) is not None
 
 
 @pytest.mark.parametrize("cache_type", SAFE)
@@ -149,14 +146,17 @@ def test_production_load_path_applies_advisory_authority(
         )()
 
     with patch.object(subprocess, "Popen", side_effect = fake_popen):
-        assert backend.load_model(
-            llama_cpp.GgufLoadIntent(
-                gguf_path = gguf,
-                model_identifier = "test",
-                cache_type_kv = None if env_cache is not None else "q4_1",
-                extra_args = extra_args,
+        assert (
+            backend.load_model(
+                llama_cpp.GgufLoadIntent(
+                    gguf_path = gguf,
+                    model_identifier = "test",
+                    cache_type_kv = None if env_cache is not None else "q4_1",
+                    extra_args = extra_args,
+                )
             )
-        ) is True
+            is True
+        )
 
     if expected_warning is None:
         assert warnings == []

--- a/studio/backend/tests/test_llama_cpp_kv_cache_gpu_warning.py
+++ b/studio/backend/tests/test_llama_cpp_kv_cache_gpu_warning.py
@@ -58,8 +58,10 @@ def test_load_model_uses_scalar_intent_and_preserves_command_path():
     source = inspect.getsource(llama_cpp.LlamaCppBackend.load_model)
     assert "_kv_cache_gpu_fallback_warning(" in source
     warning_start = source.index("gpu_fallback_warning = _kv_cache_gpu_fallback_warning(")
-    warning_block = source[warning_start : warning_start + 260]
-    assert "intent.cache_type_kv" in warning_block
+    warning_block = source[warning_start : warning_start + 650]
+    assert "advisory_cache_type" in warning_block
+    assert "_extras_cache is None" in source
+    assert "not _cache_type_from_env" in source
     assert "\n                    cache_type_kv," not in warning_block
     assert "intent.gpu_memory_mode" in source
     assert "intent.gpu_layers" in source

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1078,7 +1078,7 @@ export function ChatSettingsPanel({
                     </Select>
                   </div>
                 </div>
-                {(kvCacheDtype === "q4_1" || kvCacheDtype === "q5_1") && (
+                {(kvCacheDtype === "q4_1" || kvCacheDtype === "q5_0" || kvCacheDtype === "q5_1") && (
                   <p className="text-[11px] text-amber-500">
                     May lack GPU acceleration on this build and fall back to
                     CPU, causing high CPU load. q8_0 is a safer quantized

--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -1078,6 +1078,13 @@ export function ChatSettingsPanel({
                     </Select>
                   </div>
                 </div>
+                {(kvCacheDtype === "q4_1" || kvCacheDtype === "q5_1") && (
+                  <p className="text-[11px] text-amber-500">
+                    May lack GPU acceleration on this build and fall back to
+                    CPU, causing high CPU load. q8_0 is a safer quantized
+                    option.
+                  </p>
+                )}
                 {isGguf && (
                   <>
                 <div className="flex items-center justify-between gap-3">

--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -41,6 +41,7 @@ import {
   cachedPinnableGpuContext,
   pinnableGpuContext,
   reconcileGpuSelection,
+  useInferenceGpuInfo,
   useGpuDevices,
 } from "@/hooks/use-gpu-info";
 import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
@@ -957,6 +958,20 @@ function GgufAdvancedSettings({
       : N_BATCH_LLAMA_DEFAULT;
   const ubatchExceedsBatch =
     config.nUbatch != null && config.nUbatch > effectiveBatch;
+  const inferenceGpu = useInferenceGpuInfo();
+  const affectedKvCache = ["q4_1", "q5_0", "q5_1", "iq4_nl"].includes(
+    config.kvCacheDtype ?? KV_CACHE_DTYPE_DEFAULT,
+  );
+  const gpuPlacementWarns =
+    (config.gpuMemoryMode ?? "auto") === "auto" ||
+    ((config.gpuMemoryMode ?? "auto") === "manual" &&
+      (config.gpuLayers == null || config.gpuLayers < 0 || config.gpuLayers > 0));
+  const kvCacheGpuWarning =
+    (inferenceGpu.backend === "cuda" ||
+      inferenceGpu.backend === "rocm" ||
+      inferenceGpu.backend === "hip") &&
+    gpuPlacementWarns &&
+    affectedKvCache;
   return (
     <>
       <div className={ROW_CLASS}>
@@ -994,6 +1009,12 @@ function GgufAdvancedSettings({
           </SelectContent>
         </Select>
       </div>
+      {kvCacheGpuWarning ? (
+        <p className="text-ui-11 leading-snug text-amber-500">
+          This cache type may fall back to CPU on CUDA/HIP, causing high CPU
+          load. q8_0 is a safer quantized option.
+        </p>
+      ) : null}
 
       <div className={ROW_CLASS}>
         <div className="flex min-w-0 items-center gap-1.5">

--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -967,6 +967,7 @@ function GgufAdvancedSettings({
     ((config.gpuMemoryMode ?? "auto") === "manual" &&
       (config.gpuLayers == null || config.gpuLayers < 0 || config.gpuLayers > 0));
   const kvCacheGpuWarning =
+    !isDiffusion &&
     (inferenceGpu.backend === "cuda" ||
       inferenceGpu.backend === "rocm" ||
       inferenceGpu.backend === "hip") &&

--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -41,9 +41,10 @@ import {
   cachedPinnableGpuContext,
   pinnableGpuContext,
   reconcileGpuSelection,
-  useInferenceGpuInfo,
   useGpuDevices,
 } from "@/hooks/use-gpu-info";
+import { useLlamaCppBackend } from "@/hooks/use-llama-backend";
+import { shouldWarnKvCacheGpuFallback } from "@/features/model-picker/model-config/kv-cache-gpu-warning";
 import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
 import { toast } from "@/lib/toast";
 import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
@@ -958,21 +959,15 @@ function GgufAdvancedSettings({
       : N_BATCH_LLAMA_DEFAULT;
   const ubatchExceedsBatch =
     config.nUbatch != null && config.nUbatch > effectiveBatch;
-  const inferenceGpu = useInferenceGpuInfo();
-  const affectedKvCache = ["q4_1", "q5_0", "q5_1", "iq4_nl"].includes(
-    config.kvCacheDtype ?? KV_CACHE_DTYPE_DEFAULT,
-  );
-  const gpuPlacementWarns =
-    (config.gpuMemoryMode ?? "auto") === "auto" ||
-    ((config.gpuMemoryMode ?? "auto") === "manual" &&
-      (config.gpuLayers == null || config.gpuLayers < 0 || config.gpuLayers > 0));
-  const kvCacheGpuWarning =
-    !isDiffusion &&
-    (inferenceGpu.backend === "cuda" ||
-      inferenceGpu.backend === "rocm" ||
-      inferenceGpu.backend === "hip") &&
-    gpuPlacementWarns &&
-    affectedKvCache;
+  const llamaBackend = useLlamaCppBackend();
+  const kvCacheWarningId = useId();
+  const kvCacheGpuWarning = shouldWarnKvCacheGpuFallback({
+    backend: llamaBackend,
+    cacheType: config.kvCacheDtype ?? KV_CACHE_DTYPE_DEFAULT,
+    gpuMemoryMode: config.gpuMemoryMode ?? "auto",
+    gpuLayers: config.gpuLayers,
+    isDiffusion,
+  });
   return (
     <>
       <div className={ROW_CLASS}>
@@ -995,6 +990,7 @@ function GgufAdvancedSettings({
             icon={ChevronDownStandardIcon}
             iconClassName="size-3.5"
             className={`w-[92px] ${SELECT_TRIGGER_CLASS}`}
+            aria-describedby={kvCacheGpuWarning ? kvCacheWarningId : undefined}
           >
             <SelectValue />
           </SelectTrigger>
@@ -1011,7 +1007,10 @@ function GgufAdvancedSettings({
         </Select>
       </div>
       {kvCacheGpuWarning ? (
-        <p className="text-ui-11 leading-snug text-amber-500">
+        <p
+          id={kvCacheWarningId}
+          className="text-ui-11 leading-snug text-amber-500"
+        >
           This cache type may fall back to CPU on CUDA/HIP, causing high CPU
           load. q8_0 is a safer quantized option.
         </p>

--- a/studio/frontend/src/features/model-picker/model-config/kv-cache-gpu-warning.ts
+++ b/studio/frontend/src/features/model-picker/model-config/kv-cache-gpu-warning.ts
@@ -1,0 +1,26 @@
+const GPU_FALLBACK_CACHE_TYPES = new Set(["q4_1", "q5_0", "q5_1", "iq4_nl"]);
+
+export function shouldWarnKvCacheGpuFallback({
+  backend,
+  cacheType,
+  gpuMemoryMode,
+  gpuLayers,
+  isDiffusion,
+}: {
+  backend: string | null;
+  cacheType: string;
+  gpuMemoryMode: "auto" | "manual";
+  gpuLayers: number | null | undefined;
+  isDiffusion: boolean;
+}): boolean {
+  const placementWarns =
+    gpuMemoryMode === "auto" ||
+    (gpuMemoryMode === "manual" &&
+      (gpuLayers == null || gpuLayers < 0 || gpuLayers > 0));
+  return (
+    !isDiffusion &&
+    (backend === "cuda" || backend === "rocm") &&
+    placementWarns &&
+    GPU_FALLBACK_CACHE_TYPES.has(cacheType.trim().toLowerCase())
+  );
+}

--- a/studio/frontend/src/hooks/gpu-backend.ts
+++ b/studio/frontend/src/hooks/gpu-backend.ts
@@ -1,0 +1,10 @@
+type InferenceSystemSnapshot = {
+  device_backend?: string;
+  inference_gpu?: { backend?: string };
+};
+
+export function inferenceBackendFromSystem(
+  data: InferenceSystemSnapshot | null,
+): string {
+  return data?.inference_gpu?.backend ?? data?.device_backend ?? "";
+}

--- a/studio/frontend/src/hooks/llama-backend-warning.ts
+++ b/studio/frontend/src/hooks/llama-backend-warning.ts
@@ -1,0 +1,9 @@
+export function resolveLlamaBackendForWarning({
+  backend,
+  envBackend,
+}: {
+  backend: string | null;
+  envBackend: string | null;
+}): string | null {
+  return envBackend && envBackend !== "auto" ? envBackend : backend;
+}

--- a/studio/frontend/src/hooks/use-gpu-info.ts
+++ b/studio/frontend/src/hooks/use-gpu-info.ts
@@ -19,6 +19,9 @@ import {
   getCachedSystemInfo,
   subscribeSystemInfo,
 } from "./use-system";
+import { inferenceBackendFromSystem } from "./gpu-backend";
+
+export { inferenceBackendFromSystem } from "./gpu-backend";
 
 export {
   pinnableGpuContext,
@@ -69,7 +72,10 @@ function toGpuInfo(
   // CPU/RAM exist even on GPU-less hosts (e.g. Mac), so populate them on every
   // path: unified-memory math still needs a RAM budget to work with.
   const base = {
-    backend: data?.device_backend ?? "",
+    backend:
+      source === "inference_gpu"
+        ? inferenceBackendFromSystem(data)
+        : (data?.device_backend ?? ""),
     cpuCore: data?.cpu?.physical_count ?? 0,
     cpuThread: data?.cpu?.logical_count ?? 0,
     systemRamAvailableGb: data?.memory?.available_gb ?? 0,

--- a/studio/frontend/src/hooks/use-llama-backend.ts
+++ b/studio/frontend/src/hooks/use-llama-backend.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 
 import { loadLlamaBackendStatus } from "@/features/settings/api/llama-backend";
+import { resolveLlamaBackendForWarning } from "./llama-backend-warning";
 
 export function useLlamaCppBackend(): string | null {
   const [backend, setBackend] = useState<string | null>(null);
@@ -9,7 +10,7 @@ export function useLlamaCppBackend(): string | null {
     let cancelled = false;
     loadLlamaBackendStatus()
       .then((status) => {
-        if (!cancelled) setBackend(status.backend);
+        if (!cancelled) setBackend(resolveLlamaBackendForWarning(status));
       })
       .catch(() => {
         if (!cancelled) setBackend(null);

--- a/studio/frontend/src/hooks/use-llama-backend.ts
+++ b/studio/frontend/src/hooks/use-llama-backend.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+import { loadLlamaBackendStatus } from "@/features/settings/api/llama-backend";
+
+export function useLlamaCppBackend(): string | null {
+  const [backend, setBackend] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadLlamaBackendStatus()
+      .then((status) => {
+        if (!cancelled) setBackend(status.backend);
+      })
+      .catch(() => {
+        if (!cancelled) setBackend(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return backend;
+}

--- a/studio/frontend/tests/inference-gpu-info.test.ts
+++ b/studio/frontend/tests/inference-gpu-info.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { registerBundlerResolver } from "./helpers/kit.ts";
+
+registerBundlerResolver();
+
+const { inferenceBackendFromSystem } = await import(
+  "../src/hooks/gpu-backend.ts",
+);
+
+test("inference GPU info uses the llama.cpp backend when it differs from torch", () => {
+  assert.equal(
+    inferenceBackendFromSystem({
+      device_backend: "cuda",
+      inference_gpu: { backend: "vulkan", available: true, devices: [] },
+    } as never),
+    "vulkan",
+  );
+  assert.equal(
+    inferenceBackendFromSystem({ device_backend: "rocm" } as never),
+    "rocm",
+  );
+});

--- a/studio/frontend/tests/kv-cache-gpu-warning.test.ts
+++ b/studio/frontend/tests/kv-cache-gpu-warning.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shouldWarnKvCacheGpuFallback } from "../src/features/model-picker/model-config/kv-cache-gpu-warning.ts";
+
+const base = {
+  cacheType: "q4_1",
+  gpuLayers: -1,
+  isDiffusion: false,
+} as const;
+
+test("KV cache advisory covers affected CUDA/HIP placement modes", () => {
+  for (const backend of ["cuda", "rocm"]) {
+    for (const gpuMemoryMode of ["auto", "manual"] as const) {
+      for (const gpuLayers of gpuMemoryMode === "auto" ? [-1] : [-1, 1]) {
+        assert.equal(
+          shouldWarnKvCacheGpuFallback({
+            ...base,
+            backend,
+            gpuMemoryMode,
+            gpuLayers,
+          }),
+          true,
+        );
+      }
+    }
+  }
+});
+
+test("KV cache advisory preserves silent negative space", () => {
+  for (const backend of ["vulkan", "metal", "cpu", "unknown", null]) {
+    assert.equal(
+      shouldWarnKvCacheGpuFallback({ ...base, backend, gpuMemoryMode: "auto" }),
+      false,
+    );
+  }
+  assert.equal(
+    shouldWarnKvCacheGpuFallback({
+      ...base,
+      backend: "cuda",
+      gpuMemoryMode: "manual",
+      gpuLayers: 0,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldWarnKvCacheGpuFallback({
+      ...base,
+      backend: "cuda",
+      cacheType: "q8_0",
+      gpuMemoryMode: "auto",
+    }),
+    false,
+  );
+  assert.equal(
+    shouldWarnKvCacheGpuFallback({
+      ...base,
+      backend: "cuda",
+      isDiffusion: true,
+      gpuMemoryMode: "auto",
+    }),
+    false,
+  );
+});

--- a/studio/frontend/tests/llama-backend-warning-source.test.ts
+++ b/studio/frontend/tests/llama-backend-warning-source.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveLlamaBackendForWarning } from "../src/hooks/llama-backend-warning.ts";
+
+test("environment backend override is authoritative for the warning", () => {
+  assert.equal(
+    resolveLlamaBackendForWarning({ backend: "cuda", envBackend: "vulkan" }),
+    "vulkan",
+  );
+  assert.equal(
+    resolveLlamaBackendForWarning({ backend: "cuda", envBackend: "auto" }),
+    "cuda",
+  );
+  assert.equal(
+    resolveLlamaBackendForWarning({ backend: "rocm", envBackend: null }),
+    "rocm",
+  );
+});


### PR DESCRIPTION
## Problem

Some quantized KV-cache types can fall back to CPU work on CUDA/HIP llama.cpp launches without a visible diagnostic.

## Fix

- Warn for `q4_1`, `q5_0`, `q5_1`, and `iq4_nl` when the authoritative scalar cache intent targets CUDA/HIP GPU placement.
- Keep Default, Manual Auto, and positive Manual placement covered, while Manual zero and non-CUDA/HIP backends remain silent.
- Leave extra-argument and environment cache settings outside this advisory, and preserve the existing cache command flags and placement behavior.
- Show the advisory beside the shared KV-cache selector, excluding diffusion GGUF hosts. The UI reads the resolved llama.cpp backend, so a Vulkan llama.cpp runtime is not confused with the torch backend.

## Testing

Backend production-path matrix tests: 199 passed. Frontend predicate, backend-authority, and environment-override tests: 4 passed. Frontend typecheck and build passed.

CUDA/HIP runtime and live Studio DOM verification remain outside this change's available evidence.

Closes #6272
