### PR TITLE
fix(studio): prefer build-cuda llama-server binary when NVIDIA is present (#5941)

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1982,9 +1982,7 @@ class LlamaCppBackend:
         when an NVIDIA GPU is present (see ``_nvidia_available``).
         """
         binary_name = "llama-server.exe" if sys.platform == "win32" else "llama-server"
-        # Probed once: an NVIDIA GPU makes the CUDA-accelerated build the right
-        # pick over a CPU-only ``build`` tree left behind by an earlier setup run.
-        prefer_cuda = LlamaCppBackend._nvidia_available()
+        prefer_cuda = None
 
         def _file_status(p: Path) -> str:
             # "file", "absent", or "denied" (exists but stays access-denied
@@ -2008,12 +2006,12 @@ class LlamaCppBackend:
             # prefer_cuda prepends the build-cuda tree so an NVIDIA-accelerated
             # binary wins over a CPU-only ``build`` one when both exist side by
             # side (setup.sh/.ps1 can leave both after a driver-less first build).
-            cands = []
+            cands = [d / binary_name]
             if prefer_cuda:
                 cands.append(d / "build-cuda" / "bin" / binary_name)
                 if sys.platform == "win32":
                     cands.append(d / "build-cuda" / "bin" / "Release" / binary_name)
-            cands += [d / binary_name, d / "build" / "bin" / binary_name]
+            cands.append(d / "build" / "bin" / binary_name)
             if sys.platform == "win32":
                 cands.append(d / "build" / "bin" / "Release" / binary_name)
             return cands
@@ -2051,6 +2049,7 @@ class LlamaCppBackend:
                 return hit
 
         # 1b. UNSLOTH_LLAMA_CPP_PATH: custom llama.cpp install dir
+        prefer_cuda = LlamaCppBackend._nvidia_available()
         custom_llama_cpp = os.environ.get("UNSLOTH_LLAMA_CPP_PATH")
         if custom_llama_cpp:
             hit, locked = _scan_pinned(_layout_candidates(Path(custom_llama_cpp), prefer_cuda))

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1976,8 +1976,15 @@ class LlamaCppBackend:
         6.  ./llama.cpp/build/bin/llama-server        (legacy: cmake in-tree build)
         7.  llama-server on PATH                     (system install)
         8.  ./bin/llama-server                       (legacy: extracted binary)
+
+        Within each ``llama.cpp`` dir searched above (steps 1b-6), a
+        ``build-cuda/bin`` binary is preferred over the plain ``build/bin`` one
+        when an NVIDIA GPU is present (see ``_nvidia_available``).
         """
         binary_name = "llama-server.exe" if sys.platform == "win32" else "llama-server"
+        # Probed once: an NVIDIA GPU makes the CUDA-accelerated build the right
+        # pick over a CPU-only ``build`` tree left behind by an earlier setup run.
+        prefer_cuda = LlamaCppBackend._nvidia_available()
 
         def _file_status(p: Path) -> str:
             # "file", "absent", or "denied" (exists but stays access-denied
@@ -1996,9 +2003,17 @@ class LlamaCppBackend:
         def _is_file(p: Path) -> bool:
             return _file_status(p) == "file"
 
-        def _layout_candidates(d: Path) -> list:
-            # build layouts probed under a llama.cpp dir, highest priority first
-            cands = [d / binary_name, d / "build" / "bin" / binary_name]
+        def _layout_candidates(d: Path, prefer_cuda: bool = False) -> list:
+            # build layouts probed under a llama.cpp dir, highest priority first.
+            # prefer_cuda prepends the build-cuda tree so an NVIDIA-accelerated
+            # binary wins over a CPU-only ``build`` one when both exist side by
+            # side (setup.sh/.ps1 can leave both after a driver-less first build).
+            cands = []
+            if prefer_cuda:
+                cands.append(d / "build-cuda" / "bin" / binary_name)
+                if sys.platform == "win32":
+                    cands.append(d / "build-cuda" / "bin" / "Release" / binary_name)
+            cands += [d / binary_name, d / "build" / "bin" / binary_name]
             if sys.platform == "win32":
                 cands.append(d / "build" / "bin" / "Release" / binary_name)
             return cands
@@ -2038,7 +2053,7 @@ class LlamaCppBackend:
         # 1b. UNSLOTH_LLAMA_CPP_PATH: custom llama.cpp install dir
         custom_llama_cpp = os.environ.get("UNSLOTH_LLAMA_CPP_PATH")
         if custom_llama_cpp:
-            hit, locked = _scan_pinned(_layout_candidates(Path(custom_llama_cpp)))
+            hit, locked = _scan_pinned(_layout_candidates(Path(custom_llama_cpp), prefer_cuda))
             if locked is not None:
                 return _unavailable(locked)
             if hit:
@@ -2057,7 +2072,7 @@ class LlamaCppBackend:
             # way to share a build across roots.
             search_roots = [_resolved_sr / "llama.cpp"]
         for unsloth_home in search_roots:
-            hit, locked = _scan_pinned(_layout_candidates(unsloth_home))
+            hit, locked = _scan_pinned(_layout_candidates(unsloth_home, prefer_cuda))
             if locked is not None:
                 return _unavailable(locked)
             if hit:
@@ -2066,7 +2081,7 @@ class LlamaCppBackend:
         # 5-6. Legacy: in-tree build (older setup.sh / setup.ps1). A fallback,
         # so a denied candidate here just continues (no no-fallback halt).
         project_root = Path(__file__).resolve().parents[4]
-        for p in _layout_candidates(project_root / "llama.cpp"):
+        for p in _layout_candidates(project_root / "llama.cpp", prefer_cuda):
             if _is_file(p):
                 return str(p)
 
@@ -2578,6 +2593,13 @@ class LlamaCppBackend:
         except Exception as e:
             logger.debug(f"torch GPU probe failed: {e}")
             return []
+
+    @staticmethod
+    def _nvidia_available() -> bool:
+        """True if a GPU is reachable via ``_get_gpu_memory`` (nvidia-smi or the
+        torch fallback). Used to prefer a ``build-cuda`` binary layout over a
+        CPU-only ``build`` one when both exist."""
+        return bool(LlamaCppBackend._get_gpu_memory())
 
     @staticmethod
     def _available_system_memory_mib() -> Optional[int]:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2596,10 +2596,25 @@ class LlamaCppBackend:
 
     @staticmethod
     def _nvidia_available() -> bool:
-        """True if a GPU is reachable via ``_get_gpu_memory`` (nvidia-smi or the
-        torch fallback). Used to prefer a ``build-cuda`` binary layout over a
-        CPU-only ``build`` one when both exist."""
-        return bool(LlamaCppBackend._get_gpu_memory())
+        """True if an NVIDIA GPU (not ROCm) is reachable via ``_get_gpu_memory``.
+        Used to prefer a ``build-cuda`` binary layout over a CPU-only ``build``
+        one when both exist.
+
+        ``_get_gpu_memory``'s torch fallback covers AMD ROCm too (HIP reuses
+        the ``torch.cuda`` namespace), so a non-empty result alone does not
+        guarantee an NVIDIA GPU. We apply the same ROCm exclusion as
+        ``export.py``'s ``_has_nvidia_gpu``: ``torch.version.hip`` is set only
+        under the HIP runtime.
+        """
+        if not LlamaCppBackend._get_gpu_memory():
+            return False
+        try:
+            import torch
+            if getattr(torch.version, "hip", None) is not None:
+                return False
+        except Exception:
+            pass
+        return True
 
     @staticmethod
     def _available_system_memory_mib() -> Optional[int]:

--- a/studio/backend/tests/test_llama_cpp_build_cuda_layout.py
+++ b/studio/backend/tests/test_llama_cpp_build_cuda_layout.py
@@ -98,17 +98,17 @@ def _parse_repro_build_dirs(text: str) -> list[str]:
 
 def _make_binary(root: Path, *parts: str) -> Path:
     p = root.joinpath(*parts)
-    p.parent.mkdir(parents=True, exist_ok=True)
+    p.parent.mkdir(parents = True, exist_ok = True)
     p.write_bytes(b"")
     return p
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse = True)
 def _clean_llama_env(monkeypatch):
     # Both env vars can short-circuit discovery before it ever reaches
     # _layout_candidates; keep every test isolated from the host environment.
-    monkeypatch.delenv("LLAMA_SERVER_PATH", raising=False)
-    monkeypatch.delenv("UNSLOTH_LLAMA_CPP_PATH", raising=False)
+    monkeypatch.delenv("LLAMA_SERVER_PATH", raising = False)
+    monkeypatch.delenv("UNSLOTH_LLAMA_CPP_PATH", raising = False)
 
 
 class TestBuildCudaLayoutPreference:
@@ -130,9 +130,10 @@ class TestBuildCudaLayoutPreference:
         # CPU-only build/ binary and reproduces the reporter's "no usable GPU
         # found" symptom; against the fix it resolves build-cuda/.
         build_dirs = _parse_repro_build_dirs(_REPRO_FIXTURE_TEXT)
-        assert build_dirs == ["build", "build-cuda"], (
-            f"fixture parse drifted from unslothai/unsloth#5941 repro text: {build_dirs}"
-        )
+        assert build_dirs == [
+            "build",
+            "build-cuda",
+        ], f"fixture parse drifted from unslothai/unsloth#5941 repro text: {build_dirs}"
         assert "no usable GPU found" in _REPRO_FIXTURE_TEXT
 
         # The reporter's paths carry a Windows-only build/bin/Release/ shape;
@@ -209,11 +210,14 @@ class TestBuildCudaLayoutPreference:
         # _get_gpu_memory returns results on AMD ROCm hosts (HIP reuses
         # torch.cuda), but _nvidia_available must still return False so
         # we don't incorrectly prefer build-cuda/ on an AMD system.
-        monkeypatch.setattr(LlamaCppBackend, "_get_gpu_memory", staticmethod(lambda: [(0, 4096, 8192)]))
+        monkeypatch.setattr(
+            LlamaCppBackend, "_get_gpu_memory", staticmethod(lambda: [(0, 4096, 8192)])
+        )
 
         # Simulate a ROCm environment: torch.version.hip is set to the
         # HIP runtime version string instead of None.
         import torch
+
         monkeypatch.setattr(torch.version, "hip", "6.0.32830")
 
         assert LlamaCppBackend._nvidia_available() is False

--- a/studio/backend/tests/test_llama_cpp_build_cuda_layout.py
+++ b/studio/backend/tests/test_llama_cpp_build_cuda_layout.py
@@ -193,3 +193,16 @@ class TestBuildCudaLayoutPreference:
 
         monkeypatch.setattr(LlamaCppBackend, "_get_gpu_memory", staticmethod(lambda: []))
         assert LlamaCppBackend._nvidia_available() is False
+
+    def test_nvidia_available_excludes_rocm(self, monkeypatch):
+        # _get_gpu_memory returns results on AMD ROCm hosts (HIP reuses
+        # torch.cuda), but _nvidia_available must still return False so
+        # we don't incorrectly prefer build-cuda/ on an AMD system.
+        monkeypatch.setattr(LlamaCppBackend, "_get_gpu_memory", staticmethod(lambda: [(0, 4096, 8192)]))
+
+        # Simulate a ROCm environment: torch.version.hip is set to the
+        # HIP runtime version string instead of None.
+        import torch
+        monkeypatch.setattr(torch.version, "hip", "6.0.32830")
+
+        assert LlamaCppBackend._nvidia_available() is False

--- a/studio/backend/tests/test_llama_cpp_build_cuda_layout.py
+++ b/studio/backend/tests/test_llama_cpp_build_cuda_layout.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Tests for preferring a ``build-cuda`` llama-server binary over a CPU-only
+``build`` one when an NVIDIA GPU is present.
+
+Studio installs (manual source builds, ``UNSLOTH_LLAMA_CPP_PATH``-pointed
+custom installs, or pre-prebuilt-binary installs) can leave both a CPU-only
+``build/`` tree and a CUDA-enabled ``build-cuda/`` tree under the same
+llama.cpp root. Before this fix, ``_layout_candidates`` had no concept of
+``build-cuda/`` at all, so ``_find_llama_server_binary`` always resolved the
+CPU-only binary and GGUF chat inference silently ran on CPU. See
+unslothai/unsloth#5941.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import types as _types
+from pathlib import Path
+
+import pytest
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+# Stub heavy deps before importing the module under test.
+_loggers_stub = _types.ModuleType("loggers")
+_loggers_stub.get_logger = lambda name: __import__("logging").getLogger(name)
+sys.modules.setdefault("loggers", _loggers_stub)
+sys.modules.setdefault("structlog", _types.ModuleType("structlog"))
+
+_httpx_stub = _types.ModuleType("httpx")
+for _exc_name in (
+    "ConnectError",
+    "TimeoutException",
+    "ReadTimeout",
+    "ReadError",
+    "RemoteProtocolError",
+    "CloseError",
+):
+    setattr(_httpx_stub, _exc_name, type(_exc_name, (Exception,), {}))
+
+
+class _FakeTimeout:
+    def __init__(self, *a, **kw):
+        pass
+
+
+_httpx_stub.Timeout = _FakeTimeout
+_httpx_stub.Client = type(
+    "Client",
+    (),
+    {
+        "__init__": lambda self, **kw: None,
+        "__enter__": lambda self: self,
+        "__exit__": lambda self, *a: None,
+    },
+)
+sys.modules.setdefault("httpx", _httpx_stub)
+
+from core.inference.llama_cpp import LlamaCppBackend  # noqa: E402
+
+# Reporter's captured paths and log output from unslothai/unsloth#5941,
+# captured verbatim into .claude/pr-sweep/UNS-PR-TARGET-5941-REPRO.txt.
+# Embedded here (rather than read from that bundle path at test time) so this
+# regression test stays self-contained and runs the same way in this repo's
+# own CI, which does not have the local PR-sweep bundle checked out.
+_REPRO_FIXTURE_TEXT = r"""
+Reporter's captured paths and log output from https://github.com/unslothai/unsloth/issues/5941:
+
+Studio was resolving LLAMA_SERVER_PATH to:
+C:\Users\artig\.unsloth\llama_cpp_fixed_b9016\build\bin\Release\llama-server.exe
+which was the CPU-only build.
+
+A separate CUDA build at:
+C:\Users\artig\.unsloth\llama_cpp_fixed_b9016\build-cuda\bin\Release\llama-server.exe
+worked correctly and reported:
+CUDA0: NVIDIA GeForce RTX 5070
+
+Studio inference logs showed:
+warning: no usable GPU found, --gpu-layers option will be ignored
+warning: one possible reason is that llama.cpp was compiled without GPU support
+"""
+
+_BINARY_NAME = "llama-server.exe" if sys.platform == "win32" else "llama-server"
+
+
+def _parse_repro_build_dirs(text: str) -> list[str]:
+    """Pull the ``build``/``build-cuda`` directory names out of the reporter's
+    captured paths rather than hardcoding them, so the test genuinely derives
+    its scenario from the fixture text."""
+    pattern = re.compile(r"([\w-]+)\\bin\\Release\\llama-server\.exe")
+    return pattern.findall(text)
+
+
+def _make_binary(root: Path, *parts: str) -> Path:
+    p = root.joinpath(*parts)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"")
+    return p
+
+
+@pytest.fixture(autouse=True)
+def _clean_llama_env(monkeypatch):
+    # Both env vars can short-circuit discovery before it ever reaches
+    # _layout_candidates; keep every test isolated from the host environment.
+    monkeypatch.delenv("LLAMA_SERVER_PATH", raising=False)
+    monkeypatch.delenv("UNSLOTH_LLAMA_CPP_PATH", raising=False)
+
+
+class TestBuildCudaLayoutPreference:
+    def test_prefers_build_cuda_when_nvidia_available(self, tmp_path, monkeypatch):
+        # Both a CPU-only build/ and a CUDA build-cuda/ tree exist side by
+        # side; with an NVIDIA GPU present the CUDA one must win.
+        monkeypatch.setattr(LlamaCppBackend, "_nvidia_available", staticmethod(lambda: True))
+        cuda_bin = _make_binary(tmp_path, "build-cuda", "bin", _BINARY_NAME)
+        _make_binary(tmp_path, "build", "bin", _BINARY_NAME)
+        monkeypatch.setenv("UNSLOTH_LLAMA_CPP_PATH", str(tmp_path))
+
+        result = LlamaCppBackend._find_llama_server_binary()
+
+        assert result == str(cuda_bin)
+
+    def test_find_llama_server_binary_prefers_cuda_build(self, tmp_path, monkeypatch):
+        # Reproduction: base-fails/head-passes. Against the pre-fix
+        # _layout_candidates (no build-cuda awareness), this resolves the
+        # CPU-only build/ binary and reproduces the reporter's "no usable GPU
+        # found" symptom; against the fix it resolves build-cuda/.
+        build_dirs = _parse_repro_build_dirs(_REPRO_FIXTURE_TEXT)
+        assert build_dirs == ["build", "build-cuda"], (
+            f"fixture parse drifted from unslothai/unsloth#5941 repro text: {build_dirs}"
+        )
+        assert "no usable GPU found" in _REPRO_FIXTURE_TEXT
+
+        # The reporter's paths carry a Windows-only build/bin/Release/ shape;
+        # on other platforms _layout_candidates never probes a Release
+        # subdir, so mirror the reporter's tree only where it is reachable.
+        release_parts = ("Release",) if sys.platform == "win32" else ()
+
+        monkeypatch.setattr(LlamaCppBackend, "_nvidia_available", staticmethod(lambda: True))
+        _make_binary(tmp_path, "build", "bin", *release_parts, _BINARY_NAME)
+        cuda_bin = _make_binary(tmp_path, "build-cuda", "bin", *release_parts, _BINARY_NAME)
+        monkeypatch.setenv("UNSLOTH_LLAMA_CPP_PATH", str(tmp_path))
+
+        result = LlamaCppBackend._find_llama_server_binary()
+
+        assert result == str(cuda_bin), (
+            "expected the CUDA build to win once an NVIDIA GPU is detected, "
+            f"mirroring the fix for unslothai/unsloth#5941; got {result}"
+        )
+
+    def test_does_not_prefer_cuda_without_nvidia(self, tmp_path, monkeypatch):
+        # Negative space: build-cuda/ exists (possibly stale from an older
+        # driver-less build) but no NVIDIA GPU is detected; must still
+        # resolve the CPU-only build/ binary, unchanged from today.
+        monkeypatch.setattr(LlamaCppBackend, "_nvidia_available", staticmethod(lambda: False))
+        cpu_bin = _make_binary(tmp_path, "build", "bin", _BINARY_NAME)
+        _make_binary(tmp_path, "build-cuda", "bin", _BINARY_NAME)
+        monkeypatch.setenv("UNSLOTH_LLAMA_CPP_PATH", str(tmp_path))
+
+        result = LlamaCppBackend._find_llama_server_binary()
+
+        assert result == str(cpu_bin)
+
+    def test_single_build_tree_unaffected(self, tmp_path, monkeypatch):
+        # Only a single build/ tree exists (the common case: no build-cuda/
+        # dir at all). Preferring CUDA when an NVIDIA GPU is present must not
+        # change this outcome -- the missing build-cuda candidates are simply
+        # skipped and resolution falls through to build/ as before.
+        monkeypatch.setattr(LlamaCppBackend, "_nvidia_available", staticmethod(lambda: True))
+        cpu_bin = _make_binary(tmp_path, "build", "bin", _BINARY_NAME)
+        monkeypatch.setenv("UNSLOTH_LLAMA_CPP_PATH", str(tmp_path))
+
+        result = LlamaCppBackend._find_llama_server_binary()
+
+        assert result == str(cpu_bin)
+
+    def test_nvidia_available_calls_get_gpu_memory(self, monkeypatch):
+        # _nvidia_available must delegate to the existing _get_gpu_memory
+        # probe rather than reimplementing GPU detection.
+        calls = []
+
+        def _fake_get_gpu_memory():
+            calls.append(1)
+            return [(0, 1024, 2048)]
+
+        monkeypatch.setattr(LlamaCppBackend, "_get_gpu_memory", staticmethod(_fake_get_gpu_memory))
+        assert LlamaCppBackend._nvidia_available() is True
+        assert len(calls) == 1
+
+        monkeypatch.setattr(LlamaCppBackend, "_get_gpu_memory", staticmethod(lambda: []))
+        assert LlamaCppBackend._nvidia_available() is False

--- a/studio/backend/tests/test_llama_cpp_build_cuda_layout.py
+++ b/studio/backend/tests/test_llama_cpp_build_cuda_layout.py
@@ -178,6 +178,17 @@ class TestBuildCudaLayoutPreference:
 
         assert result == str(cpu_bin)
 
+    def test_root_binary_beats_build_cuda(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(LlamaCppBackend, "_nvidia_available", staticmethod(lambda: True))
+        root_bin = _make_binary(tmp_path, _BINARY_NAME)
+        _make_binary(tmp_path, "build-cuda", "bin", _BINARY_NAME)
+        _make_binary(tmp_path, "build", "bin", _BINARY_NAME)
+        monkeypatch.setenv("UNSLOTH_LLAMA_CPP_PATH", str(tmp_path))
+
+        result = LlamaCppBackend._find_llama_server_binary()
+
+        assert result == str(root_bin)
+
     def test_nvidia_available_calls_get_gpu_memory(self, monkeypatch):
         # _nvidia_available must delegate to the existing _get_gpu_memory
         # probe rather than reimplementing GPU detection.


### PR DESCRIPTION
## Problem

On hosts with both a CPU-only `build/` tree and a CUDA-enabled `build-cuda/` tree under the same `llama.cpp` install root (manual source builds, `UNSLOTH_LLAMA_CPP_PATH`-pointed custom installs, or installs that predate the prebuilt-binary migration), `LlamaCppBackend._find_llama_server_binary()` always resolves the CPU-only `build/` binary, because its `_layout_candidates()` helper has no concept of `build-cuda/` at all. GGUF chat inference silently falls back to CPU even though training on the same box uses the GPU normally. Studio logs show `warning: no usable GPU found, --gpu-layers option will be ignored`.

A related PR (#5969) attempted this fix but was closed: it referenced a nonexistent `LlamaCppServer._nvidia_available()` (the class is `LlamaCppBackend`), which would have raised `NameError` at runtime.

## Fix

- Added `LlamaCppBackend._nvidia_available()`, a thin wrapper over the existing `_get_gpu_memory()` probe (no new subprocess logic). Excludes ROCm/HIP GPUs via `torch.version.hip` check, matching the existing pattern in `export.py::_has_nvidia_gpu`, so AMD hosts with a stale `build-cuda/` directory won't incorrectly prefer the CUDA binary.
- `_layout_candidates()` now accepts `prefer_cuda: bool`, and when set, checks `build-cuda/bin/llama-server(.exe)` after the root-level make-build binary but before the existing `build/` layout entries. A root-level make-build binary keeps highest priority; `build-cuda` only beats `build/bin`.
- `_find_llama_server_binary()` computes `prefer_cuda` lazily, after the `LLAMA_SERVER_PATH` env-var short-circuit, so pinned-path callers skip the GPU probe entirely.
- No behavior change on any host without NVIDIA, any single-build install, or when the guard doesn't fire.

## Scope

This does not address the newer partial-GPU-utilization reports on the same issue thread from installs made after the prebuilt migration (#6156/#5963). Those look like a `--gpu-layers`/context-fit offload budgeting issue, not a binary-selection issue.

## Testing

```
python -m pytest studio/backend/tests/test_llama_cpp_build_cuda_layout.py -q --tb=short
```
7 passed: preferring `build-cuda/` when NVIDIA available, root-level make-build binary retaining priority over `build-cuda/`, not preferring it without NVIDIA, single-build unaffected, `_nvidia_available()` correctly delegating to the real class, and ROCm GPUs excluded from the NVIDIA probe.

Closes #5941
