### PR TITLE
fix(studio): return /load immediately and load models in the background (#5206)

### DIFF
--- a/studio/backend/core/inference/llama_keepwarm.py
+++ b/studio/backend/core/inference/llama_keepwarm.py
@@ -161,6 +161,15 @@ def inference_lifecycle_gate():
     return _unload_gate()
 
 
+def acquire_inference_lifecycle_gate_nowait() -> bool:
+    """Try to claim the model-swap gate without waiting behind an active request."""
+    return _lifecycle_lock.acquire(blocking = False)
+
+
+def release_inference_lifecycle_gate() -> None:
+    _lifecycle_lock.release()
+
+
 def note_model_loaded() -> None:
     """Record a successful GGUF load: stamp activity and drop any reload stash so
     a manual load clears it synchronously, not only on the next idle poll."""

--- a/studio/backend/core/inference/llama_keepwarm.py
+++ b/studio/backend/core/inference/llama_keepwarm.py
@@ -175,6 +175,16 @@ def inference_lifecycle_gate():
     return _unload_gate()
 
 
+def acquire_inference_lifecycle_gate_nowait() -> bool:
+    """Claim the process-wide lifecycle gate without queueing a load."""
+    return _lifecycle_lock.acquire(blocking = False)
+
+
+def release_inference_lifecycle_gate() -> None:
+    """Release a gate claim made by acquire_inference_lifecycle_gate_nowait."""
+    _lifecycle_lock.release()
+
+
 def note_model_loaded(backend = None) -> None:
     """Stamp activity and synchronously drop any reload stash."""
     _note_activity()

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -109,6 +109,14 @@ class LoadRequest(BaseModel):
             "auth, UI/server mode) are rejected. Ignored for non-GGUF models."
         ),
     )
+    async_load: bool = Field(
+        False,
+        description = (
+            "When true, return immediately with a 'loading' acknowledgement instead "
+            "of blocking on the full load; poll GET /status (loading/loaded/load_error) "
+            "for completion."
+        ),
+    )
 
 
 class UnloadRequest(BaseModel):
@@ -335,6 +343,17 @@ class LoadResponse(BaseModel):
     )
 
 
+class LoadAcceptedResponse(BaseModel):
+    """Immediate acknowledgement for an async ("fire and forget") /load request.
+
+    The actual load continues in the background; poll GET /status for
+    ``loading`` / ``loaded`` / ``load_error`` to observe completion.
+    """
+
+    status: str = Field("loading", description = "Always 'loading' for an accepted async load")
+    model: str = Field(..., description = "Model identifier being loaded")
+
+
 class UnloadResponse(BaseModel):
     """Response after unloading a model"""
 
@@ -498,6 +517,12 @@ class InferenceStatusResponse(BaseModel):
     llama_cpp_latest_tag: Optional[str] = Field(
         None,
         description = "Latest published llama.cpp tag, or None if GitHub unreachable.",
+    )
+    load_error: Optional[str] = Field(
+        None,
+        description = "Error message from the most recent async (async_load=true) "
+        "/load call that failed in the background, or None if the last async load "
+        "succeeded (or none has run yet). Cleared at the start of the next async load.",
     )
 
 

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -283,6 +283,13 @@ class LoadRequest(BaseModel):
             "replaces the llama-server every open conversation decodes on."
         ),
     )
+    async_load: bool = Field(
+        False,
+        description = (
+            "Return immediately and continue loading in the background; poll /status "
+            "for loading, loaded, or load_error."
+        ),
+    )
 
 
 class UnloadRequest(BaseModel):
@@ -923,6 +930,13 @@ class LoadResponse(_InferenceRuntimeFields):
     )
 
 
+class LoadAcceptedResponse(BaseModel):
+    """Acknowledgement returned after an asynchronous load is admitted."""
+
+    status: str = Field("loading", description = "Always loading for an accepted load")
+    model: str = Field(..., description = "Model identifier being loaded")
+
+
 class UnloadResponse(BaseModel):
     """Response after unloading a model"""
 
@@ -1039,6 +1053,7 @@ class InferenceStatusResponse(_InferenceRuntimeFields):
     )
     gguf_variant: Optional[str] = Field(None, description = "GGUF quantization variant (e.g. Q4_K_M)")
     loading: List[str] = Field(default_factory = list, description = "Models currently being loaded")
+    load_error: Optional[str] = Field(None, description = "Redacted error from the latest async load")
     loaded: List[str] = Field(default_factory = list, description = "Models currently loaded")
     inference: Optional[Dict[str, Any]] = Field(
         None, description = "Recommended inference parameters for the active model"

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -4028,6 +4028,7 @@ async def load_model(
                     if sidecar_swap_in_progress():
                         raise _swap_409
                     await _load_model_impl(request, fastapi_request, current_subject)
+                _last_async_load_error = None
             except Exception as exc:
                 detail = exc.detail if isinstance(exc, HTTPException) else str(exc)
                 logger.warning("inference.async_load_failed: %s", detail)

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1694,6 +1694,7 @@ from models.inference import (
     UnloadRequest,
     GenerateRequest,
     LoadResponse,
+    LoadAcceptedResponse,
     LoadProgressResponse,
     UnloadResponse,
     InferenceStatusResponse,
@@ -3975,12 +3976,18 @@ def _maybe_unsupported_message(msg: str) -> str:
     return msg
 
 
-@router.post("/load", response_model = LoadResponse)
+# Set at the start of each async (async_load=true) /load call and updated if the
+# background load fails; surfaced on GET /status so pollers can see why a
+# fire-and-forget load never reached `loaded`. Process-wide like the backend slot.
+_last_async_load_error: Optional[str] = None
+
+
+@router.post("/load")
 async def load_model(
     request: LoadRequest,
     fastapi_request: Request,
     current_subject: str = Depends(get_current_subject),
-):
+) -> Union[LoadResponse, LoadAcceptedResponse]:
     """
     Load a model for inference.
 
@@ -3989,6 +3996,10 @@ async def load_model(
     back to default.yaml for missing values.
 
     GGUF models load via llama-server (llama.cpp) instead of Unsloth.
+
+    When ``async_load=true``, returns immediately with a ``LoadAcceptedResponse``
+    and continues the load in the background; poll GET /status for completion
+    (``loading`` / ``loaded`` / ``load_error``).
     """
     # A sidecar install that has reserved the swap must not lose to a load that
     # then gets unloaded by the pre-swap teardown. Rechecked under the gate: an
@@ -4006,6 +4017,24 @@ async def load_model(
     # Hold the lifecycle gate across the load so idle auto-unload can't unload the
     # model mid-load. Auto-switch calls _load_model_impl directly since it already
     # holds this gate.
+    if request.async_load:
+        global _last_async_load_error
+        _last_async_load_error = None
+
+        async def _background_load() -> None:
+            global _last_async_load_error
+            try:
+                async with inference_lifecycle_gate():
+                    if sidecar_swap_in_progress():
+                        raise _swap_409
+                    await _load_model_impl(request, fastapi_request, current_subject)
+            except Exception as exc:
+                detail = exc.detail if isinstance(exc, HTTPException) else str(exc)
+                logger.warning("inference.async_load_failed: %s", detail)
+                _last_async_load_error = str(detail)
+
+        asyncio.create_task(_background_load())
+        return LoadAcceptedResponse(model = request.model_path)
     async with inference_lifecycle_gate():
         if sidecar_swap_in_progress():
             raise _swap_409
@@ -5598,6 +5627,7 @@ async def get_status(current_subject: str = Depends(get_current_subject)):
                 llama_cpp_prebuilt_stale = _stale,
                 llama_cpp_installed_tag = _installed_tag,
                 llama_cpp_latest_tag = _latest_tag,
+                load_error = _last_async_load_error,
             )
 
         # Otherwise, report Unsloth backend status
@@ -5651,6 +5681,7 @@ async def get_status(current_subject: str = Depends(get_current_subject)):
             llama_cpp_prebuilt_stale = _stale,
             llama_cpp_installed_tag = _installed_tag,
             llama_cpp_latest_tag = _latest_tag,
+            load_error = _last_async_load_error,
         )
 
     except Exception as e:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3980,6 +3980,7 @@ def _maybe_unsupported_message(msg: str) -> str:
 # background load fails; surfaced on GET /status so pollers can see why a
 # fire-and-forget load never reached `loaded`. Process-wide like the backend slot.
 _last_async_load_error: Optional[str] = None
+_background_tasks: set = set()
 
 
 @router.post("/load")
@@ -4034,7 +4035,9 @@ async def load_model(
                 logger.warning("inference.async_load_failed: %s", detail)
                 _last_async_load_error = str(detail)
 
-        asyncio.create_task(_background_load())
+        task = asyncio.create_task(_background_load())
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
         return LoadAcceptedResponse(model = request.model_path)
     async with inference_lifecycle_gate():
         if sidecar_swap_in_progress():

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -4068,7 +4068,9 @@ async def load_model(
         task = asyncio.create_task(_background_load())
         _active_async_load_task = task
         _background_tasks.add(task)
-        task.add_done_callback(lambda done_task: _clear_async_load_if_current(done_task, generation))
+        task.add_done_callback(
+            lambda done_task: _clear_async_load_if_current(done_task, generation)
+        )
         return LoadAcceptedResponse(model = request.model_path)
     async with inference_lifecycle_gate():
         if sidecar_swap_in_progress():

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -4036,19 +4036,20 @@ async def load_model(
     # Hold the lifecycle gate across the load so idle auto-unload can't unload the
     # model mid-load. Auto-switch calls _load_model_impl directly since it already
     # holds this gate.
-    if request.async_load:
-        global _active_async_load_task, _accepted_async_load_model, _async_load_generation
-        global _last_async_load_error
-        if _active_async_load_task is not None and not _active_async_load_task.done():
-            raise HTTPException(
-                status_code = status.HTTP_409_CONFLICT,
-                detail = f"Model load already in progress: {_accepted_async_load_model}",
-            )
+    global _active_async_load_task, _accepted_async_load_model, _async_load_generation
+    global _last_async_load_error
+    if _active_async_load_task is not None and not _active_async_load_task.done():
+        raise HTTPException(
+            status_code = status.HTTP_409_CONFLICT,
+            detail = f"Model load already in progress: {_accepted_async_load_model}",
+        )
 
+    if request.async_load:
         _async_load_generation += 1
         generation = _async_load_generation
         _accepted_async_load_model = request.model_path
         _last_async_load_error = None
+        gate_acquired = asyncio.get_running_loop().create_future()
 
         async def _background_load() -> None:
             global _last_async_load_error
@@ -4056,12 +4057,16 @@ async def load_model(
                 async with inference_lifecycle_gate():
                     if sidecar_swap_in_progress():
                         raise _swap_409
+                    if not gate_acquired.done():
+                        gate_acquired.set_result(None)
                     await _load_model_impl(request, fastapi_request, current_subject)
                 if generation == _async_load_generation:
                     _last_async_load_error = None
             except Exception as exc:
                 detail = exc.detail if isinstance(exc, HTTPException) else str(exc)
                 logger.warning("inference.async_load_failed: %s", detail)
+                if not gate_acquired.done():
+                    gate_acquired.set_exception(exc)
                 if generation == _async_load_generation:
                     _last_async_load_error = str(detail)
 
@@ -4071,11 +4076,14 @@ async def load_model(
         task.add_done_callback(
             lambda done_task: _clear_async_load_if_current(done_task, generation)
         )
+        await gate_acquired
         return LoadAcceptedResponse(model = request.model_path)
     async with inference_lifecycle_gate():
         if sidecar_swap_in_progress():
             raise _swap_409
-        return await _load_model_impl(request, fastapi_request, current_subject)
+        response = await _load_model_impl(request, fastapi_request, current_subject)
+    _last_async_load_error = None
+    return response
 
 
 async def _load_model_impl(request: LoadRequest, fastapi_request: Request, current_subject: str):

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3984,6 +3984,7 @@ _background_tasks: set = set()
 _async_load_generation = 0
 _accepted_async_load_model: Optional[str] = None
 _active_async_load_task: Optional[asyncio.Task] = None
+_async_load_admission_lock = threading.Lock()
 
 
 def _async_loading_models(backend_loading: Iterable[str] = ()) -> List[str]:
@@ -4036,48 +4037,69 @@ async def load_model(
     # Hold the lifecycle gate across the load so idle auto-unload can't unload the
     # model mid-load. Auto-switch calls _load_model_impl directly since it already
     # holds this gate.
+    from core.inference.llama_keepwarm import (
+        acquire_inference_lifecycle_gate_nowait,
+        inference_lifecycle_gate,
+        release_inference_lifecycle_gate,
+    )
     global _active_async_load_task, _accepted_async_load_model, _async_load_generation
     global _last_async_load_error
+
+    if request.async_load:
+        with _async_load_admission_lock:
+            if _active_async_load_task is not None and not _active_async_load_task.done():
+                raise HTTPException(
+                    status_code = status.HTTP_409_CONFLICT,
+                    detail = f"Model load already in progress: {_accepted_async_load_model}",
+                )
+            if not acquire_inference_lifecycle_gate_nowait():
+                raise HTTPException(
+                    status_code = status.HTTP_409_CONFLICT,
+                    detail = "Another model operation is already in progress.",
+                )
+            if sidecar_swap_in_progress():
+                release_inference_lifecycle_gate()
+                raise _swap_409
+            _async_load_generation += 1
+            generation = _async_load_generation
+            _accepted_async_load_model = request.model_path
+            _last_async_load_error = None
+
+            async def _background_load() -> None:
+                global _last_async_load_error
+                try:
+                    await asyncio.sleep(0)
+                    await _load_model_impl(request, fastapi_request, current_subject)
+                    if generation == _async_load_generation:
+                        _last_async_load_error = None
+                except Exception as exc:
+                    detail = exc.detail if isinstance(exc, HTTPException) else str(exc)
+                    logger.warning("inference.async_load_failed: %s", detail)
+                    if generation == _async_load_generation:
+                        _last_async_load_error = str(detail)
+
+            def _finish_async_load(done_task: asyncio.Task) -> None:
+                try:
+                    release_inference_lifecycle_gate()
+                finally:
+                    _clear_async_load_if_current(done_task, generation)
+
+            try:
+                task = asyncio.create_task(_background_load())
+            except Exception:
+                _accepted_async_load_model = None
+                release_inference_lifecycle_gate()
+                raise
+            _active_async_load_task = task
+            _background_tasks.add(task)
+            task.add_done_callback(_finish_async_load)
+        return LoadAcceptedResponse(model = request.model_path)
+
     if _active_async_load_task is not None and not _active_async_load_task.done():
         raise HTTPException(
             status_code = status.HTTP_409_CONFLICT,
             detail = f"Model load already in progress: {_accepted_async_load_model}",
         )
-
-    if request.async_load:
-        _async_load_generation += 1
-        generation = _async_load_generation
-        _accepted_async_load_model = request.model_path
-        _last_async_load_error = None
-        gate_acquired = asyncio.get_running_loop().create_future()
-
-        async def _background_load() -> None:
-            global _last_async_load_error
-            try:
-                async with inference_lifecycle_gate():
-                    if sidecar_swap_in_progress():
-                        raise _swap_409
-                    if not gate_acquired.done():
-                        gate_acquired.set_result(None)
-                    await _load_model_impl(request, fastapi_request, current_subject)
-                if generation == _async_load_generation:
-                    _last_async_load_error = None
-            except Exception as exc:
-                detail = exc.detail if isinstance(exc, HTTPException) else str(exc)
-                logger.warning("inference.async_load_failed: %s", detail)
-                if not gate_acquired.done():
-                    gate_acquired.set_exception(exc)
-                if generation == _async_load_generation:
-                    _last_async_load_error = str(detail)
-
-        task = asyncio.create_task(_background_load())
-        _active_async_load_task = task
-        _background_tasks.add(task)
-        task.add_done_callback(
-            lambda done_task: _clear_async_load_if_current(done_task, generation)
-        )
-        await gate_acquired
-        return LoadAcceptedResponse(model = request.model_path)
     async with inference_lifecycle_gate():
         if sidecar_swap_in_progress():
             raise _swap_409

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3976,9 +3976,9 @@ def _maybe_unsupported_message(msg: str) -> str:
     return msg
 
 
-# Set at the start of each async (async_load=true) /load call and updated if the
-# background load fails; surfaced on GET /status so pollers can see why a
-# fire-and-forget load never reached `loaded`. Process-wide like the backend slot.
+# Set at the start of each async (async_load=true) /load call and updated by the
+# matching background load; surfaced on GET /status so pollers can observe the
+# pending model immediately and see why a load never reached `loaded`.
 _last_async_load_error: Optional[str] = None
 _background_tasks: set = set()
 _async_load_generation = 0
@@ -4041,8 +4041,8 @@ async def load_model(
         global _last_async_load_error
         if _active_async_load_task is not None and not _active_async_load_task.done():
             raise HTTPException(
-                status_code = 409,
-                detail = "Another async model load is already in progress.",
+                status_code = status.HTTP_409_CONFLICT,
+                detail = f"Model load already in progress: {_accepted_async_load_model}",
             )
 
         _async_load_generation += 1

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse, JSONResponse, Response
 from starlette.requests import ClientDisconnect
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Callable, Iterable, List, Optional, Union
 import json
 import httpx
 from loggers import get_logger
@@ -3981,6 +3981,24 @@ def _maybe_unsupported_message(msg: str) -> str:
 # fire-and-forget load never reached `loaded`. Process-wide like the backend slot.
 _last_async_load_error: Optional[str] = None
 _background_tasks: set = set()
+_async_load_generation = 0
+_accepted_async_load_model: Optional[str] = None
+_active_async_load_task: Optional[asyncio.Task] = None
+
+
+def _async_loading_models(backend_loading: Iterable[str] = ()) -> List[str]:
+    loading = list(backend_loading)
+    if _accepted_async_load_model and _accepted_async_load_model not in loading:
+        loading.append(_accepted_async_load_model)
+    return loading
+
+
+def _clear_async_load_if_current(task: asyncio.Task, generation: int) -> None:
+    global _accepted_async_load_model, _active_async_load_task
+    _background_tasks.discard(task)
+    if generation == _async_load_generation and _active_async_load_task is task:
+        _active_async_load_task = None
+        _accepted_async_load_model = None
 
 
 @router.post("/load")
@@ -4019,7 +4037,17 @@ async def load_model(
     # model mid-load. Auto-switch calls _load_model_impl directly since it already
     # holds this gate.
     if request.async_load:
+        global _active_async_load_task, _accepted_async_load_model, _async_load_generation
         global _last_async_load_error
+        if _active_async_load_task is not None and not _active_async_load_task.done():
+            raise HTTPException(
+                status_code = 409,
+                detail = "Another async model load is already in progress.",
+            )
+
+        _async_load_generation += 1
+        generation = _async_load_generation
+        _accepted_async_load_model = request.model_path
         _last_async_load_error = None
 
         async def _background_load() -> None:
@@ -4029,15 +4057,18 @@ async def load_model(
                     if sidecar_swap_in_progress():
                         raise _swap_409
                     await _load_model_impl(request, fastapi_request, current_subject)
-                _last_async_load_error = None
+                if generation == _async_load_generation:
+                    _last_async_load_error = None
             except Exception as exc:
                 detail = exc.detail if isinstance(exc, HTTPException) else str(exc)
                 logger.warning("inference.async_load_failed: %s", detail)
-                _last_async_load_error = str(detail)
+                if generation == _async_load_generation:
+                    _last_async_load_error = str(detail)
 
         task = asyncio.create_task(_background_load())
+        _active_async_load_task = task
         _background_tasks.add(task)
-        task.add_done_callback(_background_tasks.discard)
+        task.add_done_callback(lambda done_task: _clear_async_load_if_current(done_task, generation))
         return LoadAcceptedResponse(model = request.model_path)
     async with inference_lifecycle_gate():
         if sidecar_swap_in_progress():
@@ -5606,7 +5637,7 @@ async def get_status(current_subject: str = Depends(get_current_subject)):
                 is_audio = getattr(llama_backend, "_is_audio", False),
                 audio_type = _audio_type,
                 has_audio_input = getattr(llama_backend, "_has_audio_input", False),
-                loading = [],
+                loading = _async_loading_models(),
                 loaded = [_display_model_id] if _display_model_id else [],
                 inference = _inference_cfg,
                 # GGUF status: auto_map never executes, so inert (matches validate_model).
@@ -5667,7 +5698,7 @@ async def get_status(current_subject: str = Depends(get_current_subject)):
             is_audio = is_audio,
             audio_type = audio_type,
             has_audio_input = has_audio_input,
-            loading = list(getattr(backend, "loading_models", set())),
+            loading = _async_loading_models(getattr(backend, "loading_models", set())),
             loaded = list(backend.models.keys()),
             inference = inference_config,
             requires_trust_remote_code = _resolve_loaded_trust_remote_code(

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -4050,6 +4050,7 @@ async def load_model(
         inference_lifecycle_gate,
         release_inference_lifecycle_gate,
     )
+
     global _active_async_load_task, _accepted_async_load_model, _async_load_generation
     global _last_async_load_error, _sync_load_admission_count
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3985,6 +3985,7 @@ _async_load_generation = 0
 _accepted_async_load_model: Optional[str] = None
 _active_async_load_task: Optional[asyncio.Task] = None
 _async_load_admission_lock = threading.Lock()
+_sync_load_admission_count = 0
 
 
 def _async_loading_models(backend_loading: Iterable[str] = ()) -> List[str]:
@@ -3992,6 +3993,13 @@ def _async_loading_models(backend_loading: Iterable[str] = ()) -> List[str]:
     if _accepted_async_load_model and _accepted_async_load_model not in loading:
         loading.append(_accepted_async_load_model)
     return loading
+
+
+def get_pending_async_load_model() -> Optional[str]:
+    with _async_load_admission_lock:
+        if _active_async_load_task is not None and not _active_async_load_task.done():
+            return _accepted_async_load_model
+    return None
 
 
 def _clear_async_load_if_current(task: asyncio.Task, generation: int) -> None:
@@ -4043,7 +4051,7 @@ async def load_model(
         release_inference_lifecycle_gate,
     )
     global _active_async_load_task, _accepted_async_load_model, _async_load_generation
-    global _last_async_load_error
+    global _last_async_load_error, _sync_load_admission_count
 
     if request.async_load:
         with _async_load_admission_lock:
@@ -4051,6 +4059,11 @@ async def load_model(
                 raise HTTPException(
                     status_code = status.HTTP_409_CONFLICT,
                     detail = f"Model load already in progress: {_accepted_async_load_model}",
+                )
+            if _sync_load_admission_count:
+                raise HTTPException(
+                    status_code = status.HTTP_409_CONFLICT,
+                    detail = "Another model operation is already in progress.",
                 )
             if not acquire_inference_lifecycle_gate_nowait():
                 raise HTTPException(
@@ -4095,15 +4108,21 @@ async def load_model(
             task.add_done_callback(_finish_async_load)
         return LoadAcceptedResponse(model = request.model_path)
 
-    if _active_async_load_task is not None and not _active_async_load_task.done():
-        raise HTTPException(
-            status_code = status.HTTP_409_CONFLICT,
-            detail = f"Model load already in progress: {_accepted_async_load_model}",
-        )
-    async with inference_lifecycle_gate():
-        if sidecar_swap_in_progress():
-            raise _swap_409
-        response = await _load_model_impl(request, fastapi_request, current_subject)
+    with _async_load_admission_lock:
+        if _active_async_load_task is not None and not _active_async_load_task.done():
+            raise HTTPException(
+                status_code = status.HTTP_409_CONFLICT,
+                detail = f"Model load already in progress: {_accepted_async_load_model}",
+            )
+        _sync_load_admission_count += 1
+    try:
+        async with inference_lifecycle_gate():
+            if sidecar_swap_in_progress():
+                raise _swap_409
+            response = await _load_model_impl(request, fastapi_request, current_subject)
+    finally:
+        with _async_load_admission_lock:
+            _sync_load_admission_count -= 1
     _last_async_load_error = None
     return response
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -8590,6 +8590,25 @@ def get_pending_async_load_deletion_path() -> Optional[str]:
     return None
 
 
+def _cancel_pending_async_load(model_path: str, current_subject: str) -> Optional[_LoadAdmission]:
+    with _load_admissions_lock:
+        operation = _pending_async_load
+        if (
+            operation is None
+            or operation.subject != current_subject
+            or operation.task is None
+            or operation.task.done()
+            or model_path.strip().casefold()
+            not in {
+                operation.model_path.strip().casefold(),
+                operation.deletion_model_path.strip().casefold(),
+            }
+        ):
+            return None
+        operation.attempt.cancel_event.set()
+        return operation
+
+
 def _status_loading(backend_loading = ()) -> List[str]:
     loading = list(backend_loading)
     pending = _pending_async_model()
@@ -8742,6 +8761,8 @@ async def load_model(
             load_model_gated(request, fastapi_request, current_subject, user_initiated = True, attempt = attempt),
             label = "Model load",
         )
+        with _load_admissions_lock:
+            _last_async_load_error = None
         return response
     finally:
         _finish_load_admission(operation)
@@ -9348,6 +9369,8 @@ async def _load_model_impl(
             )
 
             if not success:
+                if load_cancel_event is not None and load_cancel_event.is_set():
+                    raise HTTPException(status_code = 409, detail = "Model load cancelled")
                 raise HTTPException(
                     status_code = 500,
                     detail = f"Failed to load GGUF model: {model_log_label if native_grant_backed else config.display_name}",
@@ -9472,6 +9495,8 @@ async def _load_model_impl(
         )
 
         if not success:
+            if load_cancel_event is not None and load_cancel_event.is_set():
+                raise HTTPException(status_code = 409, detail = "Model load cancelled")
             # Check if YAML says this model needs trust_remote_code.
             if not request.trust_remote_code:
                 model_defaults = load_model_defaults(config.identifier)
@@ -10658,6 +10683,11 @@ async def _unload_model_impl(request: UnloadRequest, current_subject: str):
                 return UnloadResponse(status = "unloaded", model = request.model_path)
             finally:
                 attempt.cancel_complete.set()
+
+        pending_async = _cancel_pending_async_load(request.model_path, current_subject)
+        if pending_async is not None:
+            logger.info("Cancelled pending async load: %s", request.model_path)
+            return UnloadResponse(status = "unloaded", model = request.model_path)
 
         # "Stop loading" (frontend cancelLoading -> /unload) must abort a still-loading
         # model promptly, and /load holds the lifecycle gate for the whole load. cancel_load only

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -2232,6 +2232,7 @@ from models.inference import (
     AudioGalleryItem,
     AudioGalleryListResponse,
     LoadResponse,
+    LoadAcceptedResponse,
     LoadProgressResponse,
     UnloadResponse,
     InferenceStatusResponse,
@@ -8533,7 +8534,65 @@ async def _run_tracked_load_model_impl(
             _finish_load_attempt(attempt)
 
 
-@router.post("/load", response_model = LoadResponse)
+class _LoadAdmission(NamedTuple):
+    token: str
+    kind: str
+    model_path: str
+    subject: str
+    attempt: _ScopedLoadAttempt
+    lease_claimed: bool = False
+    task: Optional[asyncio.Task] = None
+
+
+_load_admissions_lock = threading.Lock()
+_load_admissions: dict[str, _LoadAdmission] = {}
+_pending_async_load: Optional[_LoadAdmission] = None
+_last_async_load_error: Optional[str] = None
+
+
+def _pending_async_model() -> Optional[str]:
+    with _load_admissions_lock:
+        operation = _pending_async_load
+        if operation is not None and operation.task is not None and not operation.task.done():
+            return operation.model_path
+    return None
+
+
+def get_pending_async_load_model() -> Optional[str]:
+    return _pending_async_model()
+
+
+def _status_loading(backend_loading = ()) -> List[str]:
+    loading = list(backend_loading)
+    pending = _pending_async_model()
+    if pending and pending not in loading:
+        loading.append(pending)
+    return loading
+
+
+def _redact_async_load_error(exc: BaseException) -> str:
+    if isinstance(exc, asyncio.CancelledError):
+        return ""
+    if isinstance(exc, HTTPException):
+        detail = exc.detail
+    else:
+        detail = "Model load failed"
+    text = str(detail)
+    if not text or "cancel" in text.casefold():
+        return ""
+    return "Model load failed"
+
+
+def _finish_load_admission(operation: _LoadAdmission) -> None:
+    global _pending_async_load
+    with _load_admissions_lock:
+        _load_admissions.pop(operation.token, None)
+        if _pending_async_load is operation:
+            _pending_async_load = None
+    _finish_load_attempt(operation.attempt)
+
+
+@router.post("/load", response_model = Union[LoadResponse, LoadAcceptedResponse])
 async def load_model(
     request: LoadRequest,
     fastapi_request: Request,
@@ -8548,10 +8607,89 @@ async def load_model(
 
     GGUF models load via llama-server (llama.cpp) instead of Unsloth.
     """
-    return await _tunnel_safe_json(
-        load_model_gated(request, fastapi_request, current_subject, user_initiated = True),
-        label = "Model load",
+    global _pending_async_load, _last_async_load_error
+    from core.inference.llama_keepwarm import (
+        acquire_inference_lifecycle_gate_nowait,
+        inference_lifecycle_gate,
+        release_inference_lifecycle_gate,
     )
+
+    if request.async_load:
+        if not request.load_request_id:
+            raise HTTPException(status_code = 422, detail = "async_load requires load_request_id")
+        with _load_admissions_lock:
+            if _pending_async_load is not None:
+                raise HTTPException(status_code = 409, detail = "Another model operation is already in progress.")
+            if any(item.kind == "sync" for item in _load_admissions.values()):
+                raise HTTPException(status_code = 409, detail = "Another model operation is already in progress.")
+            if not acquire_inference_lifecycle_gate_nowait():
+                raise HTTPException(status_code = 409, detail = "Another model operation is already in progress.")
+            try:
+                attempt = _begin_load_attempt(request, current_subject)
+            except BaseException:
+                release_inference_lifecycle_gate()
+                raise
+            operation = _LoadAdmission(uuid.uuid4().hex, "async", request.model_path, current_subject, attempt, True)
+            _load_admissions[operation.token] = operation
+            _pending_async_load = operation
+            _last_async_load_error = None
+
+            async def _background_load() -> None:
+                global _last_async_load_error
+                try:
+                    await asyncio.sleep(0)
+                    await _run_tracked_load_model_impl(
+                        request, fastapi_request, current_subject, attempt = attempt
+                    )
+                    with _load_admissions_lock:
+                        if _pending_async_load is operation:
+                            _last_async_load_error = None
+                except asyncio.CancelledError:
+                    raise
+                except BaseException as exc:
+                    detail = _redact_async_load_error(exc)
+                    if detail:
+                        logger.warning("inference.async_load_failed: %s", detail)
+                    with _load_admissions_lock:
+                        if _pending_async_load is operation and detail:
+                            _last_async_load_error = detail
+
+            try:
+                task = asyncio.create_task(_background_load())
+            except BaseException:
+                _load_admissions.pop(operation.token, None)
+                _pending_async_load = None
+                _finish_load_attempt(attempt)
+                release_inference_lifecycle_gate()
+                raise
+            operation = operation._replace(task = task)
+            _load_admissions[operation.token] = operation
+            _pending_async_load = operation
+
+            def _finish(done_task: asyncio.Task) -> None:
+                try:
+                    release_inference_lifecycle_gate()
+                finally:
+                    _finish_load_admission(operation)
+
+            task.add_done_callback(_finish)
+        return LoadAcceptedResponse(status = "loading", model = request.model_path)
+
+    with _load_admissions_lock:
+        if _pending_async_load is not None or _load_admissions:
+            raise HTTPException(status_code = 409, detail = "Another model operation is already in progress.")
+        attempt = _begin_load_attempt(request, current_subject)
+        operation = _LoadAdmission(uuid.uuid4().hex, "sync", request.model_path, current_subject, attempt)
+        _load_admissions[operation.token] = operation
+    try:
+        response = await _tunnel_safe_json(
+            load_model_gated(request, fastapi_request, current_subject, user_initiated = True, attempt = attempt),
+            label = "Model load",
+        )
+        _last_async_load_error = None
+        return response
+    finally:
+        _finish_load_admission(operation)
 
 
 async def load_model_gated(
@@ -8560,6 +8698,7 @@ async def load_model_gated(
     current_subject: str,
     *,
     user_initiated: bool = False,
+    attempt: Optional[_ScopedLoadAttempt] = None,
 ):
     """Everything ``POST /load`` does except the tunnel-safe padding.
 
@@ -8574,7 +8713,8 @@ async def load_model_gated(
     # check alone is only a fast path.
     from core.inference.llama_keepwarm import inference_lifecycle_gate
 
-    attempt = _begin_load_attempt(request, current_subject)
+    owns_attempt = attempt is None
+    attempt = attempt or _begin_load_attempt(request, current_subject)
     try:
         _raise_if_sidecar_swap_in_progress()
         # Hold the lifecycle gate across the load so idle auto-unload can't unload the
@@ -8603,7 +8743,8 @@ async def load_model_gated(
         get_llama_cpp_backend()._loaded_by_user_action = user_initiated
         return response
     finally:
-        _finish_load_attempt(attempt)
+        if owns_attempt:
+            _finish_load_attempt(attempt)
 
 
 async def _load_model_impl(
@@ -11054,7 +11195,7 @@ async def get_status(current_subject: str = Depends(get_current_subject)):
                     llama_backend, _native_grant_backed, _model_id
                 ),
                 gguf_variant = llama_backend.hf_variant,
-                loading = [],
+                loading = _status_loading(),
                 # Plus anything the Unsloth registry still holds: the GGUF load
                 # only unloaded the ACTIVE one, so a model cached behind it is
                 # still in VRAM and was invisible to every client reading this.
@@ -11079,6 +11220,7 @@ async def get_status(current_subject: str = Depends(get_current_subject)):
                 llama_cpp_prebuilt_stale = _stale,
                 llama_cpp_installed_tag = _installed_tag,
                 llama_cpp_latest_tag = _latest_tag,
+                load_error = _last_async_load_error,
             )
 
         # Otherwise report Unsloth backend status. Peek rather than build: no singleton means
@@ -11086,6 +11228,7 @@ async def get_status(current_subject: str = Depends(get_current_subject)):
         backend = _peek_inference_backend()
         if backend is None:
             return InferenceStatusResponse(
+                loading = _status_loading(),
                 llama_cpp_supports_mtp = _supports_mtp,
                 llama_cpp_prebuilt_stale = _stale,
                 llama_cpp_installed_tag = _installed_tag,
@@ -11133,7 +11276,7 @@ async def get_status(current_subject: str = Depends(get_current_subject)):
             mlx_kv_quant_note = model_info.get("mlx_kv_quant_note"),
             chat_template_override = model_info.get("chat_template_override_requested"),
             chat_template_override_reason = model_info.get("chat_template_override_reason"),
-            loading = list(getattr(backend, "loading_models", set())),
+            loading = _status_loading(getattr(backend, "loading_models", set())),
             loaded = list(backend.models.keys()),
             inference = inference_config,
             requires_trust_remote_code = _resolve_loaded_trust_remote_code(
@@ -11152,6 +11295,7 @@ async def get_status(current_subject: str = Depends(get_current_subject)):
             llama_cpp_prebuilt_stale = _stale,
             llama_cpp_installed_tag = _installed_tag,
             llama_cpp_latest_tag = _latest_tag,
+            load_error = _last_async_load_error,
         )
 
     except Exception as e:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -5068,7 +5068,10 @@ def _verify_native_path_lease_for_request(
 
 
 def _resolve_model_identifier_for_request(
-    request: LoadRequest | ValidateModelRequest, *, operation: str, native_grant = None
+    request: LoadRequest | ValidateModelRequest,
+    *,
+    operation: str,
+    native_grant = None,
 ) -> tuple[str, str, bool]:
     if native_grant is None and not request.native_path_lease:
         return request.model_path, request.model_path, False
@@ -8709,11 +8712,17 @@ async def load_model(
         pending_model_label = _lifecycle_model_label(request.model_path, request.gguf_variant)
         with _load_admissions_lock:
             if _pending_async_load is not None:
-                raise HTTPException(status_code = 409, detail = "Another model operation is already in progress.")
+                raise HTTPException(
+                    status_code = 409, detail = "Another model operation is already in progress."
+                )
             if any(item.kind == "sync" for item in _load_admissions.values()):
-                raise HTTPException(status_code = 409, detail = "Another model operation is already in progress.")
+                raise HTTPException(
+                    status_code = 409, detail = "Another model operation is already in progress."
+                )
             if not acquire_inference_lifecycle_gate_nowait():
-                raise HTTPException(status_code = 409, detail = "Another model operation is already in progress.")
+                raise HTTPException(
+                    status_code = 409, detail = "Another model operation is already in progress."
+                )
             try:
                 attempt = _begin_load_attempt(request, current_subject)
             except BaseException:
@@ -8787,7 +8796,9 @@ async def load_model(
         if _pending_async_load is not None or any(
             item.kind == "async" for item in _load_admissions.values()
         ):
-            raise HTTPException(status_code = 409, detail = "Another model operation is already in progress.")
+            raise HTTPException(
+                status_code = 409, detail = "Another model operation is already in progress."
+            )
         attempt = _begin_load_attempt(request, current_subject)
         operation = _LoadAdmission(
             uuid.uuid4().hex,
@@ -8801,7 +8812,9 @@ async def load_model(
     deferred = False
     try:
         response = await _tunnel_safe_json(
-            load_model_gated(request, fastapi_request, current_subject, user_initiated = True, attempt = attempt),
+            load_model_gated(
+                request, fastapi_request, current_subject, user_initiated = True, attempt = attempt
+            ),
             label = "Model load",
         )
         task = getattr(response, "_same_task", None)

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -8509,14 +8509,33 @@ async def _run_tracked_load_model_impl(
     try:
         if attempt.cancel_event.is_set():
             raise HTTPException(status_code = 409, detail = "Model load cancelled")
-        return await _load_model_impl(
-            request,
-            fastapi_request,
-            current_subject,
-            current_request_counted = current_request_counted,
-            on_reload_confirmed = on_reload_confirmed,
-            load_cancel_event = attempt.cancel_event,
+        load_task = asyncio.create_task(
+            _load_model_impl(
+                request,
+                fastapi_request,
+                current_subject,
+                current_request_counted = current_request_counted,
+                on_reload_confirmed = on_reload_confirmed,
+                load_cancel_event = attempt.cancel_event,
+            )
         )
+        try:
+            return await asyncio.shield(load_task)
+        except asyncio.CancelledError:
+            # Cancelling this waiter must not abandon a to_thread worker that can still mutate
+            # the backend. Keep the lease until the shielded load has reached its own cleanup.
+            current_task = asyncio.current_task()
+            while not load_task.done():
+                try:
+                    await asyncio.shield(load_task)
+                except asyncio.CancelledError:
+                    if current_task is not None:
+                        current_task.uncancel()
+            try:
+                load_task.result()
+            except BaseException:
+                pass
+            raise
     finally:
         if attempt.cancel_event.is_set() and not attempt.cancel_complete.is_set():
             if not await asyncio.to_thread(
@@ -8538,6 +8557,7 @@ class _LoadAdmission(NamedTuple):
     token: str
     kind: str
     model_path: str
+    deletion_model_path: str
     subject: str
     attempt: _ScopedLoadAttempt
     lease_claimed: bool = False
@@ -8560,6 +8580,14 @@ def _pending_async_model() -> Optional[str]:
 
 def get_pending_async_load_model() -> Optional[str]:
     return _pending_async_model()
+
+
+def get_pending_async_load_deletion_path() -> Optional[str]:
+    with _load_admissions_lock:
+        operation = _pending_async_load
+        if operation is not None and operation.task is not None and not operation.task.done():
+            return operation.deletion_model_path
+    return None
 
 
 def _status_loading(backend_loading = ()) -> List[str]:
@@ -8617,6 +8645,10 @@ async def load_model(
     if request.async_load:
         if not request.load_request_id:
             raise HTTPException(status_code = 422, detail = "async_load requires load_request_id")
+        deletion_model_path, _, _ = _resolve_model_identifier_for_request(
+            request, operation = "load-model"
+        )
+        pending_model_label = _lifecycle_model_label(request.model_path, request.gguf_variant)
         with _load_admissions_lock:
             if _pending_async_load is not None:
                 raise HTTPException(status_code = 409, detail = "Another model operation is already in progress.")
@@ -8629,7 +8661,15 @@ async def load_model(
             except BaseException:
                 release_inference_lifecycle_gate()
                 raise
-            operation = _LoadAdmission(uuid.uuid4().hex, "async", request.model_path, current_subject, attempt, True)
+            operation = _LoadAdmission(
+                uuid.uuid4().hex,
+                "async",
+                pending_model_label,
+                deletion_model_path,
+                current_subject,
+                attempt,
+                True,
+            )
             _load_admissions[operation.token] = operation
             _pending_async_load = operation
             _last_async_load_error = None
@@ -8639,8 +8679,17 @@ async def load_model(
                 try:
                     await asyncio.sleep(0)
                     await _run_tracked_load_model_impl(
-                        request, fastapi_request, current_subject, attempt = attempt
+                        request,
+                        fastapi_request,
+                        current_subject,
+                        attempt = attempt,
+                        on_reload_confirmed = lambda *, cancel: _raise_or_cancel_active_generations(
+                            force = request.force_cancel_active,
+                            action = "Loading a model",
+                            cancel = cancel,
+                        ),
                     )
+                    get_llama_cpp_backend()._loaded_by_user_action = True
                     with _load_admissions_lock:
                         if _pending_async_load is operation:
                             _last_async_load_error = None
@@ -8673,20 +8722,26 @@ async def load_model(
                     _finish_load_admission(operation)
 
             task.add_done_callback(_finish)
-        return LoadAcceptedResponse(status = "loading", model = request.model_path)
+        return LoadAcceptedResponse(status = "loading", model = pending_model_label)
 
     with _load_admissions_lock:
         if _pending_async_load is not None or _load_admissions:
             raise HTTPException(status_code = 409, detail = "Another model operation is already in progress.")
         attempt = _begin_load_attempt(request, current_subject)
-        operation = _LoadAdmission(uuid.uuid4().hex, "sync", request.model_path, current_subject, attempt)
+        operation = _LoadAdmission(
+            uuid.uuid4().hex,
+            "sync",
+            _lifecycle_model_label(request.model_path, request.gguf_variant),
+            request.model_path,
+            current_subject,
+            attempt,
+        )
         _load_admissions[operation.token] = operation
     try:
         response = await _tunnel_safe_json(
             load_model_gated(request, fastapi_request, current_subject, user_initiated = True, attempt = attempt),
             label = "Model load",
         )
-        _last_async_load_error = None
         return response
     finally:
         _finish_load_admission(operation)
@@ -11233,6 +11288,7 @@ async def get_status(current_subject: str = Depends(get_current_subject)):
                 llama_cpp_prebuilt_stale = _stale,
                 llama_cpp_installed_tag = _installed_tag,
                 llama_cpp_latest_tag = _latest_tag,
+                load_error = _last_async_load_error,
             )
 
         is_vision = False

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1944,11 +1944,13 @@ async def _tunnel_safe_json(coro, *, label: str):
                 yield json.dumps(jsonable_encoder(payload)).encode()
             return
 
-    return _SameTaskStreamingResponse(
+    response = _SameTaskStreamingResponse(
         _body(),
         media_type = "application/json",
         headers = {"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )
+    response._same_task = task
+    return response
 
 
 async def _aclose_stream_resources(
@@ -5041,11 +5043,11 @@ def _active_gguf_intent(
     )
 
 
-def _resolve_model_identifier_for_request(
+def _verify_native_path_lease_for_request(
     request: LoadRequest | ValidateModelRequest, *, operation: str
-) -> tuple[str, str, bool]:
+):
     if not request.native_path_lease:
-        return request.model_path, request.model_path, False
+        return None
     try:
         grant = verify_native_path_lease(
             request.native_path_lease,
@@ -5062,6 +5064,15 @@ def _resolve_model_identifier_for_request(
             status_code = 400,
             detail = redact_native_paths(str(exc)),
         ) from exc
+    return grant
+
+
+def _resolve_model_identifier_for_request(
+    request: LoadRequest | ValidateModelRequest, *, operation: str, native_grant = None
+) -> tuple[str, str, bool]:
+    if native_grant is None and not request.native_path_lease:
+        return request.model_path, request.model_path, False
+    grant = native_grant or _verify_native_path_lease_for_request(request, operation = operation)
     display_label = grant.display_label or Path(request.model_path).name or "Native model"
     return str(grant.canonical_path), display_label, True
 
@@ -8499,6 +8510,7 @@ async def _run_tracked_load_model_impl(
     attempt: Optional[_ScopedLoadAttempt] = None,
     current_request_counted: bool = False,
     on_reload_confirmed = None,
+    native_grant = None,
 ):
     global _running_load_attempt
 
@@ -8517,6 +8529,7 @@ async def _run_tracked_load_model_impl(
                 current_request_counted = current_request_counted,
                 on_reload_confirmed = on_reload_confirmed,
                 load_cancel_event = attempt.cancel_event,
+                native_grant = native_grant,
             )
         )
         try:
@@ -8531,6 +8544,10 @@ async def _run_tracked_load_model_impl(
                 except asyncio.CancelledError:
                     if current_task is not None:
                         current_task.uncancel()
+                except BaseException:
+                    if not load_task.done():
+                        raise
+                    break
             try:
                 load_task.result()
             except BaseException:
@@ -8639,6 +8656,27 @@ def _finish_load_admission(operation: _LoadAdmission) -> None:
     _finish_load_attempt(operation.attempt)
 
 
+def _defer_sync_load_admission(operation: _LoadAdmission, task: asyncio.Task) -> None:
+    global _last_async_load_error
+    operation = operation._replace(task = task)
+    with _load_admissions_lock:
+        if _load_admissions.get(operation.token) is not None:
+            _load_admissions[operation.token] = operation
+
+    def _finish(done_task: asyncio.Task) -> None:
+        global _last_async_load_error
+        try:
+            done_task.result()
+        except BaseException:
+            pass
+        else:
+            with _load_admissions_lock:
+                _last_async_load_error = None
+        _finish_load_admission(operation)
+
+    task.add_done_callback(_finish)
+
+
 @router.post("/load", response_model = Union[LoadResponse, LoadAcceptedResponse])
 async def load_model(
     request: LoadRequest,
@@ -8664,8 +8702,9 @@ async def load_model(
     if request.async_load:
         if not request.load_request_id:
             raise HTTPException(status_code = 422, detail = "async_load requires load_request_id")
-        deletion_model_path, _, _ = _resolve_model_identifier_for_request(
-            request, operation = "load-model"
+        native_grant = _verify_native_path_lease_for_request(request, operation = "load-model")
+        deletion_model_path = (
+            str(native_grant.canonical_path) if native_grant is not None else request.model_path
         )
         pending_model_label = _lifecycle_model_label(request.model_path, request.gguf_variant)
         with _load_admissions_lock:
@@ -8707,6 +8746,7 @@ async def load_model(
                             action = "Loading a model",
                             cancel = cancel,
                         ),
+                        native_grant = native_grant,
                     )
                     get_llama_cpp_backend()._loaded_by_user_action = True
                     with _load_admissions_lock:
@@ -8744,7 +8784,9 @@ async def load_model(
         return LoadAcceptedResponse(status = "loading", model = pending_model_label)
 
     with _load_admissions_lock:
-        if _pending_async_load is not None or _load_admissions:
+        if _pending_async_load is not None or any(
+            item.kind == "async" for item in _load_admissions.values()
+        ):
             raise HTTPException(status_code = 409, detail = "Another model operation is already in progress.")
         attempt = _begin_load_attempt(request, current_subject)
         operation = _LoadAdmission(
@@ -8756,16 +8798,23 @@ async def load_model(
             attempt,
         )
         _load_admissions[operation.token] = operation
+    deferred = False
     try:
         response = await _tunnel_safe_json(
             load_model_gated(request, fastapi_request, current_subject, user_initiated = True, attempt = attempt),
             label = "Model load",
         )
-        with _load_admissions_lock:
-            _last_async_load_error = None
+        task = getattr(response, "_same_task", None)
+        if task is not None:
+            _defer_sync_load_admission(operation, task)
+            deferred = True
+        else:
+            with _load_admissions_lock:
+                _last_async_load_error = None
         return response
     finally:
-        _finish_load_admission(operation)
+        if not deferred:
+            _finish_load_admission(operation)
 
 
 async def load_model_gated(
@@ -8831,6 +8880,7 @@ async def _load_model_impl(
     current_request_counted: bool = False,
     on_reload_confirmed = None,
     load_cancel_event: Optional[threading.Event] = None,
+    native_grant = None,
 ):
     from core.inference.llama_cpp import LlamaServerNotFoundError
 
@@ -8908,9 +8958,16 @@ async def _load_model_impl(
         # request's managed offload flags against the stripped launch state.
         request = request.model_copy(update = {"llama_extra_args": extra_llama_args})
 
-        model_identifier, model_log_label, native_grant_backed = (
-            _resolve_model_identifier_for_request(request, operation = "load-model")
-        )
+        if native_grant is None:
+            model_identifier, model_log_label, native_grant_backed = (
+                _resolve_model_identifier_for_request(request, operation = "load-model")
+            )
+        else:
+            model_identifier, model_log_label, native_grant_backed = (
+                _resolve_model_identifier_for_request(
+                    request, operation = "load-model", native_grant = native_grant
+                )
+            )
         # Version switching is handled by the subprocess-based inference
         # backend -- no ensure_transformers_version() needed here.
 

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -850,7 +850,7 @@ def collect_local_models(models_root: Path) -> List[LocalModelInfo]:
 
     models = sorted(
         deduped.values(),
-        key = lambda item: (item.updated_at or 0),
+        key = lambda item: item.updated_at or 0,
         reverse = True,
     )
     return [m for m in models if not _is_hidden_model(m.id, m.path)]
@@ -2340,8 +2340,16 @@ async def delete_finetuned_model(
             ) from e
 
     try:
-        from routes.inference import get_llama_cpp_backend
+        from routes.inference import get_llama_cpp_backend, get_pending_async_load_model
 
+        pending_async_load = get_pending_async_load_model()
+        if pending_async_load and _loading_model_matches_deleted_path(
+            pending_async_load, target_path
+        ):
+            raise HTTPException(
+                status_code = 409,
+                detail = "Cannot delete a model while it is loading",
+            )
         llama_backend = get_llama_cpp_backend()
         if (
             llama_backend.is_active

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -3049,7 +3049,16 @@ async def delete_finetuned_model(
             ) from e
 
     try:
-        from routes.inference import get_llama_cpp_backend
+        from routes.inference import get_llama_cpp_backend, get_pending_async_load_model
+
+        pending_async_load = get_pending_async_load_model()
+        if pending_async_load and _loading_model_matches_deleted_path(
+            pending_async_load, target_path
+        ):
+            raise HTTPException(
+                status_code = 409,
+                detail = "Cannot delete a model while it is loading",
+            )
 
         llama_backend = get_llama_cpp_backend()
         if (

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -3049,9 +3049,12 @@ async def delete_finetuned_model(
             ) from e
 
     try:
-        from routes.inference import get_llama_cpp_backend, get_pending_async_load_model
+        from routes.inference import (
+            get_llama_cpp_backend,
+            get_pending_async_load_deletion_path,
+        )
 
-        pending_async_load = get_pending_async_load_model()
+        pending_async_load = get_pending_async_load_deletion_path()
         if pending_async_load and _loading_model_matches_deleted_path(
             pending_async_load, target_path
         ):

--- a/studio/backend/tests/test_inference_load_async.py
+++ b/studio/backend/tests/test_inference_load_async.py
@@ -109,6 +109,41 @@ def test_async_load_clears_previous_error_before_scheduling(monkeypatch):
     assert inference_route._last_async_load_error is None
 
 
+def test_overlapping_loads_success_clears_stale_error(monkeypatch):
+    """Race condition: load A fails (sets error), then load B succeeds.
+    The success path must clear the error so /status doesn't return stale
+    failure info from load A."""
+
+    call_count = 0
+
+    async def _alternating_load(request, fastapi_request, current_subject):
+        nonlocal call_count
+        call_count += 1
+        seq = call_count
+        if seq == 1:
+            await asyncio.sleep(0.02)
+            raise HTTPException(status_code = 400, detail = "A failed")
+        await asyncio.sleep(0.02)
+        return LoadResponse(status = "loaded", model = request.model_path, display_name = "B", inference = {})
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", _alternating_load)
+    monkeypatch.setattr(inference_route, "_last_async_load_error", None)
+
+    async def _scenario():
+        # Fire load A (will fail)
+        await inference_route.load_model(_request(), object(), "tester")
+        await asyncio.sleep(0.1)
+        assert inference_route._last_async_load_error == "A failed"
+
+        # Fire load B (will succeed) -- acceptance clears the error, but the
+        # important part is that the *background success* also clears it.
+        await inference_route.load_model(_request(), object(), "tester")
+        await asyncio.sleep(0.1)
+
+    _run(_scenario())
+    assert inference_route._last_async_load_error is None
+
+
 def test_sync_load_unaffected_returns_load_response_directly(monkeypatch):
     """async_load=false (the default) must keep behaving synchronously: no
     background task, and the caller gets the real LoadResponse directly."""

--- a/studio/backend/tests/test_inference_load_async.py
+++ b/studio/backend/tests/test_inference_load_async.py
@@ -38,16 +38,14 @@ def _run(coro):
 
 
 def test_async_load_returns_immediately(monkeypatch):
-    """The route must not block on the slow load: it returns as soon as the
-    background task is scheduled, well before the mocked load finishes."""
+    """The route must return as soon as the background task is scheduled."""
 
     async def _slow_load(request, fastapi_request, current_subject):
         await asyncio.sleep(0.2)
-        return LoadResponse(
-            status = "loaded", model = request.model_path, display_name = "A", inference = {}
-        )
+        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _slow_load)
+
     async def _scenario():
         start = asyncio.get_event_loop().time()
         result = await inference_route.load_model(_request(), object(), "tester")
@@ -62,15 +60,12 @@ def test_async_load_returns_immediately(monkeypatch):
 
 
 def test_async_load_success_leaves_error_none(monkeypatch):
-    """A background load that succeeds must not populate load_error."""
-
     async def _quick_load(request, fastapi_request, current_subject):
         await asyncio.sleep(0.02)
-        return LoadResponse(
-            status = "loaded", model = request.model_path, display_name = "A", inference = {}
-        )
+        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _quick_load)
+
     async def _scenario():
         await inference_route.load_model(_request(), object(), "tester")
         await asyncio.sleep(0.1)
@@ -80,14 +75,12 @@ def test_async_load_success_leaves_error_none(monkeypatch):
 
 
 def test_async_load_failure_surfaces_via_last_async_load_error(monkeypatch):
-    """A background load that raises must record its message so GET /status can
-    surface it via load_error."""
-
     async def _failing_load(request, fastapi_request, current_subject):
         await asyncio.sleep(0.02)
         raise HTTPException(status_code = 400, detail = "boom: unsupported model")
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _failing_load)
+
     async def _scenario():
         await inference_route.load_model(_request(), object(), "tester")
         await asyncio.sleep(0.1)
@@ -97,117 +90,149 @@ def test_async_load_failure_surfaces_via_last_async_load_error(monkeypatch):
 
 
 def test_async_load_clears_previous_error_before_scheduling(monkeypatch):
-    """Starting a new async load must clear a stale error synchronously, before
-    the background task even runs -- otherwise a poller could read a load_error
-    left over from an unrelated, earlier failed load."""
-
     async def _quick_load(request, fastapi_request, current_subject):
         await asyncio.sleep(0.2)
-        return LoadResponse(
-            status = "loaded", model = request.model_path, display_name = "A", inference = {}
-        )
+        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _quick_load)
     monkeypatch.setattr(inference_route, "_last_async_load_error", "stale error from a prior load")
 
     async def _scenario():
-        result = await inference_route.load_model(_request(), object(), "tester")
-        # Checked immediately after the route returns, before the background
-        # task (sleeping 0.2s) has had a chance to run.
-        return result
+        return await inference_route.load_model(_request(), object(), "tester")
 
     _run(_scenario())
     assert inference_route._last_async_load_error is None
 
 
-def test_async_load_status_tracks_accepted_model_before_backend_loading(monkeypatch):
-    """The accepted model should appear as loading immediately, before the
-    backend-specific loading set is populated."""
-
-    entered_load = asyncio.Event()
-    release_load = asyncio.Event()
+def test_async_load_rejects_second_load_while_pending(monkeypatch):
+    release = asyncio.Event()
+    calls = []
 
     async def _slow_load(request, fastapi_request, current_subject):
-        entered_load.set()
-        await release_load.wait()
-        return LoadResponse(
-            status = "loaded", model = request.model_path, display_name = "A", inference = {}
-        )
-
-    monkeypatch.setattr(inference_route, "_load_model_impl", _slow_load)
-
-    async def _scenario():
-        result = await inference_route.load_model(_request("unsloth/Pending-GGUF"), object(), "tester")
-        assert isinstance(result, LoadAcceptedResponse)
-        assert "unsloth/Pending-GGUF" in inference_route._async_loading_models()
-        release_load.set()
-        await asyncio.wait_for(entered_load.wait(), timeout = 1)
-        await asyncio.sleep(0.05)
-
-    _run(_scenario())
-
-
-def test_async_load_rejects_second_accepted_load_while_one_is_active(monkeypatch):
-    """Only one async load is accepted at a time, so double-clicks/retries do
-    not build an unbounded queue behind the lifecycle gate."""
-
-    entered_load = asyncio.Event()
-    release_load = asyncio.Event()
-
-    async def _slow_load(request, fastapi_request, current_subject):
-        entered_load.set()
-        await release_load.wait()
-        return LoadResponse(
-            status = "loaded", model = request.model_path, display_name = "A", inference = {}
-        )
+        calls.append(request.model_path)
+        await release.wait()
+        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _slow_load)
 
     async def _scenario():
         first = await inference_route.load_model(_request("unsloth/A-GGUF"), object(), "tester")
-        assert isinstance(first, LoadAcceptedResponse)
-        await asyncio.wait_for(entered_load.wait(), timeout = 1)
-        with pytest.raises(HTTPException) as exc:
+        with pytest.raises(HTTPException) as exc_info:
             await inference_route.load_model(_request("unsloth/B-GGUF"), object(), "tester")
-        assert exc.value.status_code == 409
-        assert len(inference_route._background_tasks) == 1
-        release_load.set()
-        await asyncio.sleep(0.05)
+        release.set()
+        await inference_route._active_async_load_task
+        return first, exc_info.value
 
-    _run(_scenario())
+    first, exc = _run(_scenario())
+    assert isinstance(first, LoadAcceptedResponse)
+    assert exc.status_code == 409
+    assert "unsloth/A-GGUF" in exc.detail
+    assert calls == ["unsloth/A-GGUF"]
 
 
-def test_older_async_failure_cannot_overwrite_newer_accepted_load(monkeypatch):
-    """A newer async load cannot be accepted while an older one is active, so
-    the older task cannot later write a failure against that newer accepted load."""
+def test_async_load_status_reports_pending_model_immediately(monkeypatch):
+    release = asyncio.Event()
 
-    entered_load = asyncio.Event()
+    class _LlamaBackend:
+        is_loaded = False
 
-    async def _failing_load(request, fastapi_request, current_subject):
-        entered_load.set()
-        await asyncio.sleep(0.05)
-        raise HTTPException(status_code = 400, detail = "A failed after B attempted")
+        @staticmethod
+        def _find_llama_server_binary():
+            raise RuntimeError("no llama-server in test")
 
-    monkeypatch.setattr(inference_route, "_load_model_impl", _failing_load)
+    class _Backend:
+        active_model_name = None
+        models = {}
+        loading_models = set()
+
+    async def _slow_load(request, fastapi_request, current_subject):
+        await release.wait()
+        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", _slow_load)
+    monkeypatch.setattr(inference_route, "get_llama_cpp_backend", lambda: _LlamaBackend())
+    monkeypatch.setattr(inference_route, "get_inference_backend", lambda: _Backend())
+    monkeypatch.setattr(
+        inference_route,
+        "_detect_safetensors_features",
+        lambda backend, chat_template: {
+            "supports_reasoning": False,
+            "reasoning_style": "enable_thinking",
+            "reasoning_effort_levels": [],
+            "reasoning_always_on": False,
+            "supports_preserve_thinking": False,
+            "supports_tools": False,
+        },
+    )
+    monkeypatch.setattr(inference_route, "_resolve_loaded_trust_remote_code", lambda *args: False)
 
     async def _scenario():
-        first = await inference_route.load_model(_request("unsloth/A-GGUF"), object(), "tester")
-        assert isinstance(first, LoadAcceptedResponse)
-        await asyncio.wait_for(entered_load.wait(), timeout = 1)
-        with pytest.raises(HTTPException) as exc:
-            await inference_route.load_model(_request("unsloth/B-GGUF"), object(), "tester")
-        assert exc.value.status_code == 409
-        await asyncio.sleep(0.1)
+        accepted = await inference_route.load_model(_request("unsloth/A-GGUF"), object(), "tester")
+        status = await inference_route.get_status("tester")
+        release.set()
+        await inference_route._active_async_load_task
+        return accepted, status
 
-    _run(_scenario())
-    assert inference_route._last_async_load_error == "A failed after B attempted"
+    accepted, status = _run(_scenario())
+    assert isinstance(accepted, LoadAcceptedResponse)
+    assert status.loading == ["unsloth/A-GGUF"]
+    assert status.load_error is None
+
+
+def test_async_load_status_keeps_previous_gguf_loaded_while_pending(monkeypatch):
+    release = asyncio.Event()
+
+    class _LlamaBackend:
+        is_loaded = True
+        model_identifier = "unsloth/Previous-GGUF"
+        is_vision = False
+        is_diffusion = False
+        hf_variant = None
+        supports_reasoning = False
+        reasoning_style = "enable_thinking"
+        reasoning_effort_levels = []
+        reasoning_always_on = False
+        supports_preserve_thinking = False
+        supports_tools = False
+        chat_template = None
+        context_length = None
+        max_context_length = None
+        native_context_length = None
+        cache_type_kv = None
+        chat_template_override = None
+        requested_spec_mode = None
+        spec_draft_n_max = None
+        tensor_parallel = False
+        spec_fallback_reason = None
+
+        @staticmethod
+        def _find_llama_server_binary():
+            raise RuntimeError("no llama-server in test")
+
+    async def _slow_load(request, fastapi_request, current_subject):
+        await release.wait()
+        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", _slow_load)
+    monkeypatch.setattr(inference_route, "get_llama_cpp_backend", lambda: _LlamaBackend())
+    monkeypatch.setattr(inference_route, "display_label_for_native_path", lambda model_id: model_id)
+    monkeypatch.setattr(inference_route, "load_inference_config", lambda model_id: None)
+    monkeypatch.setattr(inference_route, "resolve_effective_chat_template_override", lambda **kwargs: None)
+
+    async def _scenario():
+        accepted = await inference_route.load_model(_request("unsloth/Next-GGUF"), object(), "tester")
+        status = await inference_route.get_status("tester")
+        release.set()
+        await inference_route._active_async_load_task
+        return accepted, status
+
+    accepted, status = _run(_scenario())
+    assert isinstance(accepted, LoadAcceptedResponse)
+    assert status.loaded == ["unsloth/Previous-GGUF"]
+    assert status.loading == ["unsloth/Next-GGUF"]
 
 
 def test_overlapping_loads_success_clears_stale_error(monkeypatch):
-    """Race condition: load A fails (sets error), then load B succeeds.
-    The success path must clear the error so /status doesn't return stale
-    failure info from load A."""
-
     call_count = 0
 
     async def _alternating_load(request, fastapi_request, current_subject):
@@ -218,21 +243,15 @@ def test_overlapping_loads_success_clears_stale_error(monkeypatch):
             await asyncio.sleep(0.02)
             raise HTTPException(status_code = 400, detail = "A failed")
         await asyncio.sleep(0.02)
-        return LoadResponse(
-            status = "loaded", model = request.model_path, display_name = "B", inference = {}
-        )
+        return LoadResponse(status = "loaded", model = request.model_path, display_name = "B", inference = {})
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _alternating_load)
-    monkeypatch.setattr(inference_route, "_last_async_load_error", None)
 
     async def _scenario():
-        # Fire load A (will fail)
         await inference_route.load_model(_request(), object(), "tester")
         await asyncio.sleep(0.1)
         assert inference_route._last_async_load_error == "A failed"
 
-        # Fire load B (will succeed) -- acceptance clears the error, but the
-        # important part is that the *background success* also clears it.
         await inference_route.load_model(_request(), object(), "tester")
         await asyncio.sleep(0.1)
 
@@ -241,16 +260,11 @@ def test_overlapping_loads_success_clears_stale_error(monkeypatch):
 
 
 def test_sync_load_unaffected_returns_load_response_directly(monkeypatch):
-    """async_load=false (the default) must keep behaving synchronously: no
-    background task, and the caller gets the real LoadResponse directly."""
-
     calls = []
 
     async def _load(request, fastapi_request, current_subject):
         calls.append(request)
-        return LoadResponse(
-            status = "loaded", model = request.model_path, display_name = "A", inference = {}
-        )
+        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _load)
 

--- a/studio/backend/tests/test_inference_load_async.py
+++ b/studio/backend/tests/test_inference_load_async.py
@@ -155,14 +155,18 @@ def test_sync_load_rejected_while_async_load_pending(monkeypatch):
 
     async def _slow_load(request, fastapi_request, current_subject):
         await release.wait()
-        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
+        return LoadResponse(
+            status = "loaded", model = request.model_path, display_name = "A", inference = {}
+        )
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _slow_load)
 
     async def _scenario():
         await inference_route.load_model(_request("unsloth/A-GGUF"), object(), "tester")
         with pytest.raises(HTTPException) as exc_info:
-            await inference_route.load_model(_request("unsloth/B-GGUF", async_load = False), object(), "tester")
+            await inference_route.load_model(
+                _request("unsloth/B-GGUF", async_load = False), object(), "tester"
+            )
         release.set()
         await inference_route._active_async_load_task
         return exc_info.value
@@ -313,7 +317,9 @@ def test_overlapping_loads_success_clears_stale_error(monkeypatch):
 
 def test_sync_load_success_clears_stale_async_error(monkeypatch):
     async def _load(request, fastapi_request, current_subject):
-        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
+        return LoadResponse(
+            status = "loaded", model = request.model_path, display_name = "A", inference = {}
+        )
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _load)
     monkeypatch.setattr(inference_route, "_last_async_load_error", "stale async failure")

--- a/studio/backend/tests/test_inference_load_async.py
+++ b/studio/backend/tests/test_inference_load_async.py
@@ -17,6 +17,7 @@ from fastapi import HTTPException
 
 import core.inference.llama_keepwarm as keepwarm
 import routes.inference as inference_route
+import routes.models as models_route
 from models.inference import LoadAcceptedResponse, LoadRequest, LoadResponse
 
 
@@ -26,6 +27,7 @@ def _reset_async_load_state(monkeypatch):
     monkeypatch.setattr(inference_route, "_async_load_generation", 0)
     monkeypatch.setattr(inference_route, "_accepted_async_load_model", None)
     monkeypatch.setattr(inference_route, "_active_async_load_task", None)
+    monkeypatch.setattr(inference_route, "_sync_load_admission_count", 0)
     inference_route._background_tasks.clear()
     yield
     inference_route._background_tasks.clear()
@@ -174,6 +176,47 @@ def test_sync_load_rejected_while_async_load_pending(monkeypatch):
     assert "unsloth/A-GGUF" in exc.detail
 
 
+def test_async_load_rejected_while_sync_load_admitted(monkeypatch):
+    release = asyncio.Event()
+    sync_admitted = asyncio.Event()
+    calls = []
+
+    class _Gate:
+        async def __aenter__(self):
+            sync_admitted.set()
+            await release.wait()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+    async def _load(request, fastapi_request, current_subject):
+        calls.append(request.model_path)
+        return LoadResponse(
+            status = "loaded", model = request.model_path, display_name = "A", inference = {}
+        )
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", _load)
+    monkeypatch.setattr(keepwarm, "inference_lifecycle_gate", lambda: _Gate())
+
+    async def _scenario():
+        sync_task = asyncio.create_task(
+            inference_route.load_model(
+                _request("unsloth/Sync-GGUF", async_load = False), object(), "tester"
+            )
+        )
+        await sync_admitted.wait()
+        with pytest.raises(HTTPException) as exc_info:
+            await inference_route.load_model(_request("unsloth/Async-GGUF"), object(), "tester")
+        release.set()
+        response = await sync_task
+        return exc_info.value, response
+
+    exc, response = _run(_scenario())
+    assert exc.status_code == 409
+    assert response.model == "unsloth/Sync-GGUF"
+    assert calls == ["unsloth/Sync-GGUF"]
+
+
 def test_async_load_rejects_when_lifecycle_gate_is_busy(monkeypatch):
     calls = []
 
@@ -228,6 +271,50 @@ def test_async_load_releases_lifecycle_gate_when_cancelled_before_start(monkeypa
     assert releases == ["released"]
     assert inference_route._active_async_load_task is None
     assert inference_route._accepted_async_load_model is None
+
+
+def test_delete_rejects_pending_async_load_before_backend_marker(monkeypatch, tmp_path):
+    export_root = tmp_path / "exports"
+    target = export_root / "model"
+    target.mkdir(parents = True)
+    release = asyncio.Event()
+
+    class _LlamaBackend:
+        is_active = False
+        is_loaded = False
+        model_identifier = None
+        hf_variant = None
+
+    class _InferenceBackend:
+        loading_models = set()
+        active_model_name = None
+
+    async def _load(request, fastapi_request, current_subject):
+        await release.wait()
+        return LoadResponse(
+            status = "loaded", model = request.model_path, display_name = "A", inference = {}
+        )
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", _load)
+    monkeypatch.setattr(models_route, "exports_root", lambda: export_root)
+    monkeypatch.setattr(models_route, "get_inference_backend", lambda: _InferenceBackend())
+    monkeypatch.setattr(inference_route, "get_llama_cpp_backend", lambda: _LlamaBackend())
+
+    async def _scenario():
+        await inference_route.load_model(_request(str(target)), object(), "tester")
+        with pytest.raises(HTTPException) as exc_info:
+            await models_route.delete_finetuned_model(
+                model_path = str(target),
+                source = "exported",
+                current_subject = "tester",
+            )
+        release.set()
+        await inference_route._active_async_load_task
+        return exc_info.value
+
+    exc = _run(_scenario())
+    assert exc.status_code == 409
+    assert target.exists()
 
 
 def test_async_load_status_reports_pending_model_immediately(monkeypatch):

--- a/studio/backend/tests/test_inference_load_async.py
+++ b/studio/backend/tests/test_inference_load_async.py
@@ -32,7 +32,9 @@ def test_async_load_returns_immediately(monkeypatch):
 
     async def _slow_load(request, fastapi_request, current_subject):
         await asyncio.sleep(0.2)
-        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
+        return LoadResponse(
+            status = "loaded", model = request.model_path, display_name = "A", inference = {}
+        )
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _slow_load)
     monkeypatch.setattr(inference_route, "_last_async_load_error", None)
@@ -55,7 +57,9 @@ def test_async_load_success_leaves_error_none(monkeypatch):
 
     async def _quick_load(request, fastapi_request, current_subject):
         await asyncio.sleep(0.02)
-        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
+        return LoadResponse(
+            status = "loaded", model = request.model_path, display_name = "A", inference = {}
+        )
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _quick_load)
     monkeypatch.setattr(inference_route, "_last_async_load_error", None)
@@ -94,7 +98,9 @@ def test_async_load_clears_previous_error_before_scheduling(monkeypatch):
 
     async def _quick_load(request, fastapi_request, current_subject):
         await asyncio.sleep(0.2)
-        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
+        return LoadResponse(
+            status = "loaded", model = request.model_path, display_name = "A", inference = {}
+        )
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _quick_load)
     monkeypatch.setattr(inference_route, "_last_async_load_error", "stale error from a prior load")
@@ -124,7 +130,9 @@ def test_overlapping_loads_success_clears_stale_error(monkeypatch):
             await asyncio.sleep(0.02)
             raise HTTPException(status_code = 400, detail = "A failed")
         await asyncio.sleep(0.02)
-        return LoadResponse(status = "loaded", model = request.model_path, display_name = "B", inference = {})
+        return LoadResponse(
+            status = "loaded", model = request.model_path, display_name = "B", inference = {}
+        )
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _alternating_load)
     monkeypatch.setattr(inference_route, "_last_async_load_error", None)
@@ -152,7 +160,9 @@ def test_sync_load_unaffected_returns_load_response_directly(monkeypatch):
 
     async def _load(request, fastapi_request, current_subject):
         calls.append(request)
-        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
+        return LoadResponse(
+            status = "loaded", model = request.model_path, display_name = "A", inference = {}
+        )
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _load)
 

--- a/studio/backend/tests/test_inference_load_async.py
+++ b/studio/backend/tests/test_inference_load_async.py
@@ -14,6 +14,7 @@ import asyncio
 import pytest
 from fastapi import HTTPException
 
+import core.inference.llama_keepwarm as keepwarm
 import routes.inference as inference_route
 from models.inference import LoadAcceptedResponse, LoadRequest, LoadResponse
 
@@ -40,6 +41,15 @@ def _run(coro):
 def test_async_load_returns_immediately(monkeypatch):
     """The route must return as soon as the background task is scheduled."""
 
+    gate_entered = asyncio.Event()
+
+    class _Gate:
+        async def __aenter__(self):
+            gate_entered.set()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
     async def _slow_load(request, fastapi_request, current_subject):
         await asyncio.sleep(0.2)
         return LoadResponse(
@@ -47,6 +57,7 @@ def test_async_load_returns_immediately(monkeypatch):
         )
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _slow_load)
+    monkeypatch.setattr(keepwarm, "inference_lifecycle_gate", lambda: _Gate())
 
     async def _scenario():
         start = asyncio.get_event_loop().time()
@@ -58,6 +69,7 @@ def test_async_load_returns_immediately(monkeypatch):
     assert isinstance(result, LoadAcceptedResponse)
     assert result.status == "loading"
     assert result.model == "unsloth/A-GGUF"
+    assert gate_entered.is_set()
     assert elapsed < 0.1
 
 
@@ -136,6 +148,28 @@ def test_async_load_rejects_second_load_while_pending(monkeypatch):
     assert exc.status_code == 409
     assert "unsloth/A-GGUF" in exc.detail
     assert calls == ["unsloth/A-GGUF"]
+
+
+def test_sync_load_rejected_while_async_load_pending(monkeypatch):
+    release = asyncio.Event()
+
+    async def _slow_load(request, fastapi_request, current_subject):
+        await release.wait()
+        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", _slow_load)
+
+    async def _scenario():
+        await inference_route.load_model(_request("unsloth/A-GGUF"), object(), "tester")
+        with pytest.raises(HTTPException) as exc_info:
+            await inference_route.load_model(_request("unsloth/B-GGUF", async_load = False), object(), "tester")
+        release.set()
+        await inference_route._active_async_load_task
+        return exc_info.value
+
+    exc = _run(_scenario())
+    assert exc.status_code == 409
+    assert "unsloth/A-GGUF" in exc.detail
 
 
 def test_async_load_status_reports_pending_model_immediately(monkeypatch):
@@ -274,6 +308,18 @@ def test_overlapping_loads_success_clears_stale_error(monkeypatch):
         await asyncio.sleep(0.1)
 
     _run(_scenario())
+    assert inference_route._last_async_load_error is None
+
+
+def test_sync_load_success_clears_stale_async_error(monkeypatch):
+    async def _load(request, fastapi_request, current_subject):
+        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", _load)
+    monkeypatch.setattr(inference_route, "_last_async_load_error", "stale async failure")
+
+    result = _run(inference_route.load_model(_request(async_load = False), object(), "tester"))
+    assert isinstance(result, LoadResponse)
     assert inference_route._last_async_load_error is None
 
 

--- a/studio/backend/tests/test_inference_load_async.py
+++ b/studio/backend/tests/test_inference_load_async.py
@@ -42,7 +42,9 @@ def test_async_load_returns_immediately(monkeypatch):
 
     async def _slow_load(request, fastapi_request, current_subject):
         await asyncio.sleep(0.2)
-        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
+        return LoadResponse(
+            status = "loaded", model = request.model_path, display_name = "A", inference = {}
+        )
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _slow_load)
 
@@ -62,7 +64,9 @@ def test_async_load_returns_immediately(monkeypatch):
 def test_async_load_success_leaves_error_none(monkeypatch):
     async def _quick_load(request, fastapi_request, current_subject):
         await asyncio.sleep(0.02)
-        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
+        return LoadResponse(
+            status = "loaded", model = request.model_path, display_name = "A", inference = {}
+        )
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _quick_load)
 
@@ -92,7 +96,9 @@ def test_async_load_failure_surfaces_via_last_async_load_error(monkeypatch):
 def test_async_load_clears_previous_error_before_scheduling(monkeypatch):
     async def _quick_load(request, fastapi_request, current_subject):
         await asyncio.sleep(0.2)
-        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
+        return LoadResponse(
+            status = "loaded", model = request.model_path, display_name = "A", inference = {}
+        )
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _quick_load)
     monkeypatch.setattr(inference_route, "_last_async_load_error", "stale error from a prior load")
@@ -111,7 +117,9 @@ def test_async_load_rejects_second_load_while_pending(monkeypatch):
     async def _slow_load(request, fastapi_request, current_subject):
         calls.append(request.model_path)
         await release.wait()
-        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
+        return LoadResponse(
+            status = "loaded", model = request.model_path, display_name = "A", inference = {}
+        )
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _slow_load)
 
@@ -147,7 +155,9 @@ def test_async_load_status_reports_pending_model_immediately(monkeypatch):
 
     async def _slow_load(request, fastapi_request, current_subject):
         await release.wait()
-        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
+        return LoadResponse(
+            status = "loaded", model = request.model_path, display_name = "A", inference = {}
+        )
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _slow_load)
     monkeypatch.setattr(inference_route, "get_llama_cpp_backend", lambda: _LlamaBackend())
@@ -211,16 +221,22 @@ def test_async_load_status_keeps_previous_gguf_loaded_while_pending(monkeypatch)
 
     async def _slow_load(request, fastapi_request, current_subject):
         await release.wait()
-        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
+        return LoadResponse(
+            status = "loaded", model = request.model_path, display_name = "A", inference = {}
+        )
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _slow_load)
     monkeypatch.setattr(inference_route, "get_llama_cpp_backend", lambda: _LlamaBackend())
     monkeypatch.setattr(inference_route, "display_label_for_native_path", lambda model_id: model_id)
     monkeypatch.setattr(inference_route, "load_inference_config", lambda model_id: None)
-    monkeypatch.setattr(inference_route, "resolve_effective_chat_template_override", lambda **kwargs: None)
+    monkeypatch.setattr(
+        inference_route, "resolve_effective_chat_template_override", lambda **kwargs: None
+    )
 
     async def _scenario():
-        accepted = await inference_route.load_model(_request("unsloth/Next-GGUF"), object(), "tester")
+        accepted = await inference_route.load_model(
+            _request("unsloth/Next-GGUF"), object(), "tester"
+        )
         status = await inference_route.get_status("tester")
         release.set()
         await inference_route._active_async_load_task
@@ -243,7 +259,9 @@ def test_overlapping_loads_success_clears_stale_error(monkeypatch):
             await asyncio.sleep(0.02)
             raise HTTPException(status_code = 400, detail = "A failed")
         await asyncio.sleep(0.02)
-        return LoadResponse(status = "loaded", model = request.model_path, display_name = "B", inference = {})
+        return LoadResponse(
+            status = "loaded", model = request.model_path, display_name = "B", inference = {}
+        )
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _alternating_load)
 
@@ -264,7 +282,9 @@ def test_sync_load_unaffected_returns_load_response_directly(monkeypatch):
 
     async def _load(request, fastapi_request, current_subject):
         calls.append(request)
-        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
+        return LoadResponse(
+            status = "loaded", model = request.model_path, display_name = "A", inference = {}
+        )
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _load)
 

--- a/studio/backend/tests/test_inference_load_async.py
+++ b/studio/backend/tests/test_inference_load_async.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Async model load: POST /load with async_load=true returns immediately and
+finishes the real load in a background task, surfacing failures via
+GET /status's load_error field.
+
+No GPU or llama-server: _load_model_impl is mocked to a bare asyncio.sleep,
+mirroring tests/test_openai_auto_switch.py.
+"""
+
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+
+import routes.inference as inference_route
+from models.inference import LoadAcceptedResponse, LoadRequest, LoadResponse
+
+
+def _request(model_path = "unsloth/A-GGUF", async_load = True) -> LoadRequest:
+    return LoadRequest(model_path = model_path, async_load = async_load)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_async_load_returns_immediately(monkeypatch):
+    """The route must not block on the slow load: it returns as soon as the
+    background task is scheduled, well before the mocked load finishes."""
+
+    async def _slow_load(request, fastapi_request, current_subject):
+        await asyncio.sleep(0.2)
+        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", _slow_load)
+    monkeypatch.setattr(inference_route, "_last_async_load_error", None)
+
+    async def _scenario():
+        start = asyncio.get_event_loop().time()
+        result = await inference_route.load_model(_request(), object(), "tester")
+        elapsed = asyncio.get_event_loop().time() - start
+        return result, elapsed
+
+    result, elapsed = _run(_scenario())
+    assert isinstance(result, LoadAcceptedResponse)
+    assert result.status == "loading"
+    assert result.model == "unsloth/A-GGUF"
+    assert elapsed < 0.1
+
+
+def test_async_load_success_leaves_error_none(monkeypatch):
+    """A background load that succeeds must not populate load_error."""
+
+    async def _quick_load(request, fastapi_request, current_subject):
+        await asyncio.sleep(0.02)
+        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", _quick_load)
+    monkeypatch.setattr(inference_route, "_last_async_load_error", None)
+
+    async def _scenario():
+        await inference_route.load_model(_request(), object(), "tester")
+        await asyncio.sleep(0.1)
+
+    _run(_scenario())
+    assert inference_route._last_async_load_error is None
+
+
+def test_async_load_failure_surfaces_via_last_async_load_error(monkeypatch):
+    """A background load that raises must record its message so GET /status can
+    surface it via load_error."""
+
+    async def _failing_load(request, fastapi_request, current_subject):
+        await asyncio.sleep(0.02)
+        raise HTTPException(status_code = 400, detail = "boom: unsupported model")
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", _failing_load)
+    monkeypatch.setattr(inference_route, "_last_async_load_error", None)
+
+    async def _scenario():
+        await inference_route.load_model(_request(), object(), "tester")
+        await asyncio.sleep(0.1)
+
+    _run(_scenario())
+    assert inference_route._last_async_load_error == "boom: unsupported model"
+
+
+def test_async_load_clears_previous_error_before_scheduling(monkeypatch):
+    """Starting a new async load must clear a stale error synchronously, before
+    the background task even runs -- otherwise a poller could read a load_error
+    left over from an unrelated, earlier failed load."""
+
+    async def _quick_load(request, fastapi_request, current_subject):
+        await asyncio.sleep(0.2)
+        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", _quick_load)
+    monkeypatch.setattr(inference_route, "_last_async_load_error", "stale error from a prior load")
+
+    async def _scenario():
+        result = await inference_route.load_model(_request(), object(), "tester")
+        # Checked immediately after the route returns, before the background
+        # task (sleeping 0.2s) has had a chance to run.
+        return result
+
+    _run(_scenario())
+    assert inference_route._last_async_load_error is None
+
+
+def test_sync_load_unaffected_returns_load_response_directly(monkeypatch):
+    """async_load=false (the default) must keep behaving synchronously: no
+    background task, and the caller gets the real LoadResponse directly."""
+
+    calls = []
+
+    async def _load(request, fastapi_request, current_subject):
+        calls.append(request)
+        return LoadResponse(status = "loaded", model = request.model_path, display_name = "A", inference = {})
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", _load)
+
+    result = _run(inference_route.load_model(_request(async_load = False), object(), "tester"))
+    assert isinstance(result, LoadResponse)
+    assert result.model == "unsloth/A-GGUF"
+    assert len(calls) == 1

--- a/studio/backend/tests/test_inference_load_async.py
+++ b/studio/backend/tests/test_inference_load_async.py
@@ -18,6 +18,17 @@ import routes.inference as inference_route
 from models.inference import LoadAcceptedResponse, LoadRequest, LoadResponse
 
 
+@pytest.fixture(autouse = True)
+def _reset_async_load_state(monkeypatch):
+    monkeypatch.setattr(inference_route, "_last_async_load_error", None)
+    monkeypatch.setattr(inference_route, "_async_load_generation", 0)
+    monkeypatch.setattr(inference_route, "_accepted_async_load_model", None)
+    monkeypatch.setattr(inference_route, "_active_async_load_task", None)
+    inference_route._background_tasks.clear()
+    yield
+    inference_route._background_tasks.clear()
+
+
 def _request(model_path = "unsloth/A-GGUF", async_load = True) -> LoadRequest:
     return LoadRequest(model_path = model_path, async_load = async_load)
 
@@ -37,8 +48,6 @@ def test_async_load_returns_immediately(monkeypatch):
         )
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _slow_load)
-    monkeypatch.setattr(inference_route, "_last_async_load_error", None)
-
     async def _scenario():
         start = asyncio.get_event_loop().time()
         result = await inference_route.load_model(_request(), object(), "tester")
@@ -62,8 +71,6 @@ def test_async_load_success_leaves_error_none(monkeypatch):
         )
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _quick_load)
-    monkeypatch.setattr(inference_route, "_last_async_load_error", None)
-
     async def _scenario():
         await inference_route.load_model(_request(), object(), "tester")
         await asyncio.sleep(0.1)
@@ -81,8 +88,6 @@ def test_async_load_failure_surfaces_via_last_async_load_error(monkeypatch):
         raise HTTPException(status_code = 400, detail = "boom: unsupported model")
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _failing_load)
-    monkeypatch.setattr(inference_route, "_last_async_load_error", None)
-
     async def _scenario():
         await inference_route.load_model(_request(), object(), "tester")
         await asyncio.sleep(0.1)
@@ -113,6 +118,89 @@ def test_async_load_clears_previous_error_before_scheduling(monkeypatch):
 
     _run(_scenario())
     assert inference_route._last_async_load_error is None
+
+
+def test_async_load_status_tracks_accepted_model_before_backend_loading(monkeypatch):
+    """The accepted model should appear as loading immediately, before the
+    backend-specific loading set is populated."""
+
+    entered_load = asyncio.Event()
+    release_load = asyncio.Event()
+
+    async def _slow_load(request, fastapi_request, current_subject):
+        entered_load.set()
+        await release_load.wait()
+        return LoadResponse(
+            status = "loaded", model = request.model_path, display_name = "A", inference = {}
+        )
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", _slow_load)
+
+    async def _scenario():
+        result = await inference_route.load_model(_request("unsloth/Pending-GGUF"), object(), "tester")
+        assert isinstance(result, LoadAcceptedResponse)
+        assert "unsloth/Pending-GGUF" in inference_route._async_loading_models()
+        release_load.set()
+        await asyncio.wait_for(entered_load.wait(), timeout = 1)
+        await asyncio.sleep(0.05)
+
+    _run(_scenario())
+
+
+def test_async_load_rejects_second_accepted_load_while_one_is_active(monkeypatch):
+    """Only one async load is accepted at a time, so double-clicks/retries do
+    not build an unbounded queue behind the lifecycle gate."""
+
+    entered_load = asyncio.Event()
+    release_load = asyncio.Event()
+
+    async def _slow_load(request, fastapi_request, current_subject):
+        entered_load.set()
+        await release_load.wait()
+        return LoadResponse(
+            status = "loaded", model = request.model_path, display_name = "A", inference = {}
+        )
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", _slow_load)
+
+    async def _scenario():
+        first = await inference_route.load_model(_request("unsloth/A-GGUF"), object(), "tester")
+        assert isinstance(first, LoadAcceptedResponse)
+        await asyncio.wait_for(entered_load.wait(), timeout = 1)
+        with pytest.raises(HTTPException) as exc:
+            await inference_route.load_model(_request("unsloth/B-GGUF"), object(), "tester")
+        assert exc.value.status_code == 409
+        assert len(inference_route._background_tasks) == 1
+        release_load.set()
+        await asyncio.sleep(0.05)
+
+    _run(_scenario())
+
+
+def test_older_async_failure_cannot_overwrite_newer_accepted_load(monkeypatch):
+    """A newer async load cannot be accepted while an older one is active, so
+    the older task cannot later write a failure against that newer accepted load."""
+
+    entered_load = asyncio.Event()
+
+    async def _failing_load(request, fastapi_request, current_subject):
+        entered_load.set()
+        await asyncio.sleep(0.05)
+        raise HTTPException(status_code = 400, detail = "A failed after B attempted")
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", _failing_load)
+
+    async def _scenario():
+        first = await inference_route.load_model(_request("unsloth/A-GGUF"), object(), "tester")
+        assert isinstance(first, LoadAcceptedResponse)
+        await asyncio.wait_for(entered_load.wait(), timeout = 1)
+        with pytest.raises(HTTPException) as exc:
+            await inference_route.load_model(_request("unsloth/B-GGUF"), object(), "tester")
+        assert exc.value.status_code == 409
+        await asyncio.sleep(0.1)
+
+    _run(_scenario())
+    assert inference_route._last_async_load_error == "A failed after B attempted"
 
 
 def test_overlapping_loads_success_clears_stale_error(monkeypatch):

--- a/studio/backend/tests/test_inference_load_async.py
+++ b/studio/backend/tests/test_inference_load_async.py
@@ -10,6 +10,7 @@ mirroring tests/test_openai_auto_switch.py.
 """
 
 import asyncio
+import time
 
 import pytest
 from fastapi import HTTPException
@@ -43,21 +44,18 @@ def test_async_load_returns_immediately(monkeypatch):
 
     gate_entered = asyncio.Event()
 
-    class _Gate:
-        async def __aenter__(self):
-            gate_entered.set()
-
-        async def __aexit__(self, exc_type, exc, tb):
-            pass
-
     async def _slow_load(request, fastapi_request, current_subject):
+        time.sleep(0.2)
         await asyncio.sleep(0.2)
         return LoadResponse(
             status = "loaded", model = request.model_path, display_name = "A", inference = {}
         )
 
     monkeypatch.setattr(inference_route, "_load_model_impl", _slow_load)
-    monkeypatch.setattr(keepwarm, "inference_lifecycle_gate", lambda: _Gate())
+    monkeypatch.setattr(
+        keepwarm, "acquire_inference_lifecycle_gate_nowait", lambda: gate_entered.set() or True
+    )
+    monkeypatch.setattr(keepwarm, "release_inference_lifecycle_gate", lambda: None)
 
     async def _scenario():
         start = asyncio.get_event_loop().time()
@@ -174,6 +172,62 @@ def test_sync_load_rejected_while_async_load_pending(monkeypatch):
     exc = _run(_scenario())
     assert exc.status_code == 409
     assert "unsloth/A-GGUF" in exc.detail
+
+
+def test_async_load_rejects_when_lifecycle_gate_is_busy(monkeypatch):
+    calls = []
+
+    async def _load(request, fastapi_request, current_subject):
+        calls.append(request.model_path)
+        return LoadResponse(
+            status = "loaded", model = request.model_path, display_name = "A", inference = {}
+        )
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", _load)
+    monkeypatch.setattr(keepwarm, "acquire_inference_lifecycle_gate_nowait", lambda: False)
+
+    async def _scenario():
+        with pytest.raises(HTTPException) as exc_info:
+            await inference_route.load_model(_request("unsloth/A-GGUF"), object(), "tester")
+        return exc_info.value
+
+    exc = _run(_scenario())
+    assert exc.status_code == 409
+    assert calls == []
+    assert inference_route._accepted_async_load_model is None
+
+
+def test_async_load_releases_lifecycle_gate_when_cancelled_before_start(monkeypatch):
+    calls = []
+    releases = []
+
+    async def _load(request, fastapi_request, current_subject):
+        calls.append(request.model_path)
+        return LoadResponse(
+            status = "loaded", model = request.model_path, display_name = "A", inference = {}
+        )
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", _load)
+    monkeypatch.setattr(keepwarm, "acquire_inference_lifecycle_gate_nowait", lambda: True)
+    monkeypatch.setattr(
+        keepwarm, "release_inference_lifecycle_gate", lambda: releases.append("released")
+    )
+
+    async def _scenario():
+        await inference_route.load_model(_request("unsloth/A-GGUF"), object(), "tester")
+        task = inference_route._active_async_load_task
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        await asyncio.sleep(0)
+
+    _run(_scenario())
+    assert calls == []
+    assert releases == ["released"]
+    assert inference_route._active_async_load_task is None
+    assert inference_route._accepted_async_load_model is None
 
 
 def test_async_load_status_reports_pending_model_immediately(monkeypatch):

--- a/studio/backend/tests/test_inference_load_async.py
+++ b/studio/backend/tests/test_inference_load_async.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import sys
 import types
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -198,6 +199,38 @@ def test_manual_unload_cancels_pending_async_admission(monkeypatch):
         await operation.task
 
     run(scenario())
+
+
+def test_async_native_lease_is_verified_once_and_reused(monkeypatch):
+    captured = []
+    grant = SimpleNamespace(
+        canonical_path = Path("C:/models/model.gguf"),
+        display_label = "model.gguf",
+    )
+
+    async def load(req, fastapi_request, subject, **kwargs):
+        captured.append(kwargs["native_grant"])
+        return response(req.model_path)
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", load)
+    monkeypatch.setattr(
+        inference_route,
+        "_verify_native_path_lease_for_request",
+        lambda req, operation: grant,
+    )
+    monkeypatch.setattr(keepwarm, "acquire_inference_lifecycle_gate_nowait", lambda: True)
+    monkeypatch.setattr(keepwarm, "release_inference_lifecycle_gate", lambda: None)
+
+    async def scenario():
+        native_request = request(async_load = True).model_copy(
+            update = {"native_path_lease": "signed-lease"}
+        )
+        accepted = await inference_route.load_model(native_request, object(), "subject")
+        assert accepted.model == "unsloth/test"
+        await inference_route._pending_async_load.task
+
+    run(scenario())
+    assert captured == [grant]
 
 
 def test_async_load_preserves_active_generation_callback(monkeypatch):

--- a/studio/backend/tests/test_inference_load_async.py
+++ b/studio/backend/tests/test_inference_load_async.py
@@ -1,7 +1,21 @@
 import asyncio
+import logging
+import sys
+import types
+from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
+
+# Keep this lifecycle-focused module independent of the optional structured logging dependency.
+_loggers = types.ModuleType("loggers")
+_loggers.get_logger = lambda name: logging.getLogger(name)
+sys.modules.setdefault("loggers", _loggers)
+_structlog = types.ModuleType("structlog")
+_structlog.get_logger = lambda *args, **kwargs: logging.getLogger(
+    args[0] if args else "structlog"
+)
+sys.modules.setdefault("structlog", _structlog)
 
 import core.inference.llama_keepwarm as keepwarm
 import routes.inference as inference_route
@@ -107,11 +121,110 @@ def test_busy_gate_does_not_admit(monkeypatch):
     assert not inference_route._load_admissions
 
 
-def test_status_pending_is_published_in_idle_branch(monkeypatch):
+def test_status_pending_error_is_published_in_idle_branch(monkeypatch):
+    monkeypatch.setattr(
+        inference_route,
+        "get_llama_cpp_backend",
+        lambda: SimpleNamespace(is_loaded = False),
+    )
+    monkeypatch.setattr(
+        inference_route,
+        "_probe_llama_cpp_status",
+        lambda _backend: (False, {}),
+    )
     monkeypatch.setattr(inference_route, "_peek_inference_backend", lambda: None)
-    inference_route._pending_async_load = object()
-    inference_route._pending_async_load = None
-    assert inference_route._status_loading() == []
+    inference_route._last_async_load_error = "Model load failed"
+    status = run(inference_route.get_status("subject"))
+    assert status.loading == []
+    assert status.load_error == "Model load failed"
+
+
+def test_pending_admission_keeps_public_label_separate_from_delete_identity(monkeypatch):
+    release = asyncio.Event()
+
+    async def load(req, fastapi_request, subject, **kwargs):
+        await release.wait()
+        return response(req.model_path)
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", load)
+    monkeypatch.setattr(keepwarm, "acquire_inference_lifecycle_gate_nowait", lambda: True)
+    monkeypatch.setattr(keepwarm, "release_inference_lifecycle_gate", lambda: None)
+
+    async def scenario():
+        accepted = await inference_route.load_model(
+            request("org/test", async_load = True), object(), "subject"
+        )
+        assert accepted.model == "org/test"
+        assert inference_route.get_pending_async_load_model() == "org/test"
+        assert inference_route.get_pending_async_load_deletion_path() == "org/test"
+        release.set()
+        await inference_route._pending_async_load.task
+
+    run(scenario())
+
+
+def test_async_load_preserves_active_generation_callback(monkeypatch):
+    release = asyncio.Event()
+    callbacks = []
+
+    async def load(req, fastapi_request, subject, **kwargs):
+        kwargs["on_reload_confirmed"](cancel = False)
+        await release.wait()
+        return response(req.model_path)
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", load)
+    monkeypatch.setattr(keepwarm, "acquire_inference_lifecycle_gate_nowait", lambda: True)
+    monkeypatch.setattr(keepwarm, "release_inference_lifecycle_gate", lambda: None)
+    monkeypatch.setattr(
+        inference_route,
+        "_raise_or_cancel_active_generations",
+        lambda **kwargs: callbacks.append(kwargs),
+    )
+
+    async def scenario():
+        await inference_route.load_model(
+            request(async_load = True), object(), "subject"
+        )
+        await asyncio.sleep(0)
+        release.set()
+        await inference_route._pending_async_load.task
+
+    run(scenario())
+    assert callbacks == [{"force": False, "action": "Loading a model", "cancel": False}]
+
+
+def test_cancelling_async_waiter_keeps_lease_until_load_finishes(monkeypatch):
+    started = asyncio.Event()
+    release = asyncio.Event()
+    released = []
+
+    async def load(req, fastapi_request, subject, **kwargs):
+        started.set()
+        await release.wait()
+        return response(req.model_path)
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", load)
+    monkeypatch.setattr(keepwarm, "acquire_inference_lifecycle_gate_nowait", lambda: True)
+    monkeypatch.setattr(
+        keepwarm,
+        "release_inference_lifecycle_gate",
+        lambda: released.append(True),
+    )
+
+    async def scenario():
+        await inference_route.load_model(request(async_load = True), object(), "subject")
+        task = inference_route._pending_async_load.task
+        await started.wait()
+        task.cancel()
+        await asyncio.sleep(0)
+        assert released == []
+        assert inference_route.get_pending_async_load_model() == "unsloth/test"
+        release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    run(scenario())
+    assert released == [True]
 
 
 def test_cancellation_does_not_publish_error(monkeypatch):

--- a/studio/backend/tests/test_inference_load_async.py
+++ b/studio/backend/tests/test_inference_load_async.py
@@ -60,6 +60,16 @@ def test_defaults_to_sync_and_preserves_response(monkeypatch):
     assert calls == [False]
 
 
+def test_successful_sync_load_clears_stale_async_error(monkeypatch):
+    async def load(req, fastapi_request, subject, **kwargs):
+        return response(req.model_path)
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", load)
+    inference_route._last_async_load_error = "Model load failed"
+    assert isinstance(run(inference_route.load_model(request(), object(), "subject")), LoadResponse)
+    assert inference_route._last_async_load_error is None
+
+
 def test_async_requires_non_empty_request_id():
     with pytest.raises(Exception):
         LoadRequest(model_path = "m", async_load = True, load_request_id = "")
@@ -159,6 +169,33 @@ def test_pending_admission_keeps_public_label_separate_from_delete_identity(monk
         assert inference_route.get_pending_async_load_deletion_path() == "org/test"
         release.set()
         await inference_route._pending_async_load.task
+
+    run(scenario())
+
+
+def test_manual_unload_cancels_pending_async_admission(monkeypatch):
+    release = asyncio.Event()
+
+    async def load(req, fastapi_request, subject, **kwargs):
+        await release.wait()
+        return response(req.model_path)
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", load)
+    monkeypatch.setattr(keepwarm, "acquire_inference_lifecycle_gate_nowait", lambda: True)
+    monkeypatch.setattr(keepwarm, "release_inference_lifecycle_gate", lambda: None)
+
+    async def scenario():
+        await inference_route.load_model(request(async_load = True), object(), "subject")
+        operation = inference_route._pending_async_load
+        assert operation is not None
+        assert not operation.attempt.cancel_event.is_set()
+        assert (
+            inference_route._cancel_pending_async_load("unsloth/test", "subject")
+            is operation
+        )
+        assert operation.attempt.cancel_event.is_set()
+        release.set()
+        await operation.task
 
     run(scenario())
 

--- a/studio/backend/tests/test_inference_load_async.py
+++ b/studio/backend/tests/test_inference_load_async.py
@@ -1,0 +1,131 @@
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+
+import core.inference.llama_keepwarm as keepwarm
+import routes.inference as inference_route
+from models.inference import LoadAcceptedResponse, LoadRequest, LoadResponse
+
+
+@pytest.fixture(autouse = True)
+def reset_state():
+    inference_route._load_admissions.clear()
+    inference_route._pending_async_load = None
+    inference_route._last_async_load_error = None
+    yield
+    for operation in list(inference_route._load_admissions.values()):
+        if operation.task is not None and not operation.task.done():
+            operation.task.cancel()
+    inference_route._load_admissions.clear()
+    inference_route._pending_async_load = None
+
+
+def request(model = "unsloth/test", *, async_load = False, request_id = "load-1"):
+    return LoadRequest(model_path = model, async_load = async_load, load_request_id = request_id)
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def response(model):
+    return LoadResponse(status = "loaded", model = model, display_name = "test", inference = {})
+
+
+def test_defaults_to_sync_and_preserves_response(monkeypatch):
+    calls = []
+
+    async def load(req, fastapi_request, subject, **kwargs):
+        calls.append(req.async_load)
+        return response(req.model_path)
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", load)
+    result = run(inference_route.load_model(request(), object(), "subject"))
+    assert isinstance(result, LoadResponse)
+    assert calls == [False]
+
+
+def test_async_requires_non_empty_request_id():
+    with pytest.raises(Exception):
+        LoadRequest(model_path = "m", async_load = True, load_request_id = "")
+
+
+def test_async_returns_before_background_work(monkeypatch):
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def load(req, fastapi_request, subject, **kwargs):
+        started.set()
+        await release.wait()
+        return response(req.model_path)
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", load)
+    monkeypatch.setattr(keepwarm, "acquire_inference_lifecycle_gate_nowait", lambda: True)
+    monkeypatch.setattr(keepwarm, "release_inference_lifecycle_gate", lambda: None)
+
+    async def scenario():
+        accepted = await inference_route.load_model(request(async_load = True), object(), "subject")
+        assert isinstance(accepted, LoadAcceptedResponse)
+        assert inference_route.get_pending_async_load_model() == "unsloth/test"
+        release.set()
+        await inference_route._pending_async_load.task
+
+    run(scenario())
+
+
+def test_duplicate_subject_and_id_are_rejected(monkeypatch):
+    release = asyncio.Event()
+
+    async def load(req, fastapi_request, subject, **kwargs):
+        await release.wait()
+        return response(req.model_path)
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", load)
+    monkeypatch.setattr(keepwarm, "acquire_inference_lifecycle_gate_nowait", lambda: True)
+    monkeypatch.setattr(keepwarm, "release_inference_lifecycle_gate", lambda: None)
+
+    async def scenario():
+        await inference_route.load_model(request(async_load = True), object(), "a")
+        with pytest.raises(HTTPException) as duplicate:
+            await inference_route.load_model(request("other", async_load = True), object(), "a")
+        with pytest.raises(HTTPException) as isolated:
+            await inference_route.load_model(request("other", async_load = True), object(), "b")
+        release.set()
+        await inference_route._pending_async_load.task
+        return duplicate.value, isolated.value
+
+    duplicate, isolated = run(scenario())
+    assert duplicate.status_code == isolated.status_code == 409
+
+
+def test_busy_gate_does_not_admit(monkeypatch):
+    monkeypatch.setattr(keepwarm, "acquire_inference_lifecycle_gate_nowait", lambda: False)
+    with pytest.raises(HTTPException) as exc:
+        run(inference_route.load_model(request(async_load = True), object(), "subject"))
+    assert exc.value.status_code == 409
+    assert not inference_route._load_admissions
+
+
+def test_status_pending_is_published_in_idle_branch(monkeypatch):
+    monkeypatch.setattr(inference_route, "_peek_inference_backend", lambda: None)
+    inference_route._pending_async_load = object()
+    inference_route._pending_async_load = None
+    assert inference_route._status_loading() == []
+
+
+def test_cancellation_does_not_publish_error(monkeypatch):
+    async def load(req, fastapi_request, subject, **kwargs):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(inference_route, "_load_model_impl", load)
+    monkeypatch.setattr(keepwarm, "acquire_inference_lifecycle_gate_nowait", lambda: True)
+    monkeypatch.setattr(keepwarm, "release_inference_lifecycle_gate", lambda: None)
+
+    async def scenario():
+        await inference_route.load_model(request(async_load = True), object(), "subject")
+        with pytest.raises(asyncio.CancelledError):
+            await inference_route._pending_async_load.task
+
+    run(scenario())
+    assert inference_route._last_async_load_error is None

--- a/studio/backend/tests/test_inference_load_async.py
+++ b/studio/backend/tests/test_inference_load_async.py
@@ -13,9 +13,7 @@ _loggers = types.ModuleType("loggers")
 _loggers.get_logger = lambda name: logging.getLogger(name)
 sys.modules.setdefault("loggers", _loggers)
 _structlog = types.ModuleType("structlog")
-_structlog.get_logger = lambda *args, **kwargs: logging.getLogger(
-    args[0] if args else "structlog"
-)
+_structlog.get_logger = lambda *args, **kwargs: logging.getLogger(args[0] if args else "structlog")
 sys.modules.setdefault("structlog", _structlog)
 
 import core.inference.llama_keepwarm as keepwarm
@@ -36,7 +34,12 @@ def reset_state():
     inference_route._pending_async_load = None
 
 
-def request(model = "unsloth/test", *, async_load = False, request_id = "load-1"):
+def request(
+    model = "unsloth/test",
+    *,
+    async_load = False,
+    request_id = "load-1",
+):
     return LoadRequest(model_path = model, async_load = async_load, load_request_id = request_id)
 
 
@@ -190,10 +193,7 @@ def test_manual_unload_cancels_pending_async_admission(monkeypatch):
         operation = inference_route._pending_async_load
         assert operation is not None
         assert not operation.attempt.cancel_event.is_set()
-        assert (
-            inference_route._cancel_pending_async_load("unsloth/test", "subject")
-            is operation
-        )
+        assert inference_route._cancel_pending_async_load("unsloth/test", "subject") is operation
         assert operation.attempt.cancel_event.is_set()
         release.set()
         await operation.task
@@ -252,9 +252,7 @@ def test_async_load_preserves_active_generation_callback(monkeypatch):
     )
 
     async def scenario():
-        await inference_route.load_model(
-            request(async_load = True), object(), "subject"
-        )
+        await inference_route.load_model(request(async_load = True), object(), "subject")
         await asyncio.sleep(0)
         release.set()
         await inference_route._pending_async_load.task


### PR DESCRIPTION
## Problem

Large model loads can exceed proxy response-header timeouts before `POST /api/inference/load` sends a response.

## Fix

- Add an opt-in `async_load` request field that returns an accepted response before slow loading work starts.
- Keep one process-wide admission owner for async and synchronous model loads, with the existing request-id cancellation handshake and lifecycle gate.
- Expose the pending model immediately through `/status`, preserve redacted public labels, and prevent matching local model deletion until the operation settles.
- Publish only the current operation's terminal error, preserve active-generation checks and explicit user-load provenance, and keep the synchronous response path unchanged.

`async_load` remains opt-in, so existing clients continue using the synchronous contract.

## Testing

Focused async-load tests: 13 passed. Tunnel-safe load and unload-cancel regressions: 86 passed. Python compilation and diff checks passed.
