### PR TITLE
fix(grpo): forward spatial_shapes/num_tiles/image_position_ids in VLM per-token logps chunking (#6960)

### DIFF
--- a/tests/test_multi_image_grpo_chunking.py
+++ b/tests/test_multi_image_grpo_chunking.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import math
 import os
 import re
+import textwrap
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 SOURCE_PATH = os.path.join(REPO_ROOT, "unsloth", "models", "rl_replacements.py")
@@ -183,3 +184,187 @@ def test_guard_introspection_failure_does_not_silent_no_op():
     assert re.search(
         r"_zoo_src\s*=\s*['\"]{2}", src
     ), "introspection failure path must default _zoo_src to empty string"
+
+
+# Tiled VLM kwargs forwarding (spatial_shapes/num_tiles/image_position_ids, T6960)
+
+
+def _extract_extra_vision_kwargs_block():
+    src = _read_source()
+    mid = src.find("_extra_vision_kwargs = {}")
+    assert mid != -1
+    # rewind to the start of the line so the block's own leading whitespace
+    # is included; otherwise textwrap.dedent can't compute a common margin
+    start = src.rfind(chr(10), 0, mid) + 1
+    end = src.find('with torch.amp.autocast(device_type = "cuda"', mid)
+    assert end != -1 and end > start
+    return textwrap.dedent(src[start:end])
+
+
+def _build_extra_vision_kwargs(
+    token_type_ids_chunk = None,
+    mm_token_type_ids_chunk = None,
+    spatial_shapes_chunk = None,
+    num_tiles_chunk = None,
+    image_position_ids_chunk = None,
+):
+    namespace = {
+        "token_type_ids_chunk": token_type_ids_chunk,
+        "mm_token_type_ids_chunk": mm_token_type_ids_chunk,
+        "spatial_shapes_chunk": spatial_shapes_chunk,
+        "num_tiles_chunk": num_tiles_chunk,
+        "image_position_ids_chunk": image_position_ids_chunk,
+    }
+    exec(_extract_extra_vision_kwargs_block(), namespace)
+    return namespace["_extra_vision_kwargs"]
+
+
+def test_spatial_shapes_num_tiles_image_position_ids_extracted():
+    """Reproduction: on base, these three kwargs are dropped before the chunk
+    forward() call is built; on head, extraction (kwargs.get) and forwarding
+    (_extra_vision_kwargs[...] = ...) are both present and wired together."""
+    src = _read_source()
+    assert 'kwargs.get("spatial_shapes", None)' in src
+    assert 'kwargs.get("num_tiles", None)' in src
+    assert 'kwargs.get("image_position_ids", None)' in src
+
+    # Behavioral: execute the real _extra_vision_kwargs construction block
+    # (extracted verbatim from source) and confirm the three kwargs actually
+    # reach the dict that is **-unpacked into the model forward() call.
+    extra = _build_extra_vision_kwargs(
+        spatial_shapes_chunk = "SHAPES",
+        num_tiles_chunk = "TILES",
+        image_position_ids_chunk = "POS_IDS",
+    )
+    assert extra.get("spatial_shapes") == "SHAPES"
+    assert extra.get("num_tiles") == "TILES"
+    assert extra.get("image_position_ids") == "POS_IDS"
+
+
+def test_cum_tiles_cumsum_present_and_cpu_materialized():
+    src = _read_source()
+    idx = src.find("cum_tiles = [0]")
+    assert idx != -1, "cum_tiles cumulative-sum construction must exist"
+    window = src[idx : idx + 150]
+    assert "for _n_tiles in num_tiles:" in window
+    assert "cum_tiles.append(cum_tiles[-1] + int(_n_tiles))" in window
+    assert "else:\n                cum_tiles = None" in src
+    # gated the same way as cum_rows/cum_imgs
+    gate_idx = src.rfind("if (", 0, idx)
+    gate_window = src[gate_idx:idx]
+    assert "num_tiles is not None" in gate_window
+    assert "image_grid_thw is not None" in gate_window
+    assert "pixel_values is not None" in gate_window
+    assert "num_images is not None" in gate_window
+    # plain python list -> no GPU tensor / device kwarg, unlike cum_rows
+    assert "torch.tensor" not in window and "device" not in window
+
+
+def test_three_new_chunk_lists_initialized():
+    src = _read_source()
+    idx = src.find("mm_token_type_ids_chunks = []")
+    assert idx != -1
+    window = src[idx : idx + 200]
+    assert "spatial_shapes_chunks = []" in window
+    assert "num_tiles_chunks = []" in window
+    assert "image_position_ids_chunks = []" in window
+
+
+def _simulate_tile_boundaries(num_images, num_tiles_per_image, B):
+    """Mirror of the real cum_imgs/cum_tiles per-chunk slicing math using
+    plain Python, independent of torch."""
+    total_samples = len(num_images)
+    batch_size = max(1, math.ceil(total_samples / B))
+    cum_imgs = [0]
+    for n in num_images:
+        cum_imgs.append(cum_imgs[-1] + n)
+    cum_tiles = [0]
+    for n in num_tiles_per_image:
+        cum_tiles.append(cum_tiles[-1] + n)
+    chunks = []
+    for start in range(0, total_samples, batch_size):
+        end = min(start + batch_size, total_samples)
+        img_start, img_end = cum_imgs[start], cum_imgs[end]
+        tile_start, tile_end = cum_tiles[img_start], cum_tiles[img_end]
+        chunks.append((img_start, img_end, tile_start, tile_end))
+    return chunks
+
+
+def test_simulate_tile_boundary_slicing_matches_num_tiles_cumsum():
+    # 4 samples, images per sample = [2, 1, 1, 2] (image axis, sum = 6 images)
+    num_images = [2, 1, 1, 2]
+    # per-image tile counts, aligned to the image axis (6 entries)
+    num_tiles_per_image = [3, 1, 2, 4, 1, 2]
+    chunks = _simulate_tile_boundaries(num_images, num_tiles_per_image, B = 2)
+    # sample chunk 0 covers samples [0,2) -> images [0,3) -> tiles [0,6)
+    # sample chunk 1 covers samples [2,4) -> images [3,6) -> tiles [6,13)
+    assert chunks == [(0, 3, 0, 6), (3, 6, 6, 13)]
+    total_tiles = sum(num_tiles_per_image)
+    assert chunks[-1][-1] == total_tiles
+
+
+def test_all_three_new_chunk_lists_appended_in_every_branch():
+    src = _read_source()
+    for name in ("num_tiles_chunks", "image_position_ids_chunks", "spatial_shapes_chunks"):
+        appends = len(re.findall(re.escape(name) + r"\.append\(", src))
+        assert appends >= 3, (
+            f"{name} must be appended in the tile-capable branch (slice + None fallback) "
+            f"and in the no-vision else branch to stay aligned with the other chunk lists "
+            f"for zip(); found {appends} append call(s)"
+        )
+    # explicit None fallback inside the image_grid_thw/pixel_values branch
+    assert "if num_tiles is None or img_start is None:" in src
+    assert "if image_position_ids is None or img_start is None:" in src
+    assert "if spatial_shapes is None or cum_tiles is None or img_start is None:" in src
+    # explicit None fallback in the outer else (no vision at all) keeps all
+    # chunk lists the same length so zip() cannot silently misalign
+    else_marker = (
+        "image_sizes_chunks.append(slice_sample_axis(image_sizes, start, end))\n"
+        "                    num_tiles_chunks.append(None)"
+    )
+    assert else_marker in src, "outer else branch must append None for all three new lists"
+
+
+def test_extra_vision_kwargs_forwards_tile_kwargs():
+    src = _read_source()
+    assert '_extra_vision_kwargs["spatial_shapes"] = spatial_shapes_chunk' in src
+    assert '_extra_vision_kwargs["num_tiles"] = num_tiles_chunk' in src
+    assert '_extra_vision_kwargs["image_position_ids"] = image_position_ids_chunk' in src
+    # the for-loop unpack tuple must include the 3 new chunk vars
+    assert (
+        "mm_token_type_ids_chunk,\n"
+        "                    spatial_shapes_chunk,\n"
+        "                    num_tiles_chunk,\n"
+        "                    image_position_ids_chunk,\n"
+        "                ) in zipped_inputs:"
+    ) in src
+    # zipped_inputs must zip() the 3 new chunk lists
+    assert (
+        "mm_token_type_ids_chunks,\n"
+        "                spatial_shapes_chunks,\n"
+        "                num_tiles_chunks,\n"
+        "                image_position_ids_chunks,\n"
+        "            )"
+    ) in src
+
+    # Behavioral: verify actual forwarding through the extracted block
+    extra = _build_extra_vision_kwargs(spatial_shapes_chunk = [1, 2])
+    assert extra == {"spatial_shapes": [1, 2]}
+
+
+def test_text_only_grpo_unaffected():
+    """Negative space: a text-only GRPO batch has no vision kwargs at all, so
+    kwargs.get(...) returns None for spatial_shapes/num_tiles/image_position_ids,
+    and the None-gated forwarding must append None (not forward anything)."""
+    extra = _build_extra_vision_kwargs()
+    assert extra == {}, "text-only batches must not forward any tile kwargs"
+
+    src = _read_source()
+    # the outer (no image_grid_thw/pixel_values) branch is unaffected: it
+    # still appends None for the 3 new lists exactly like the pre-existing ones
+    idx = src.find("else:\n                    pixel_values_chunks.append(None)")
+    assert idx != -1
+    window = src[idx : idx + 500]
+    assert "num_tiles_chunks.append(None)" in window
+    assert "image_position_ids_chunks.append(None)" in window
+    assert "spatial_shapes_chunks.append(None)" in window

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -2138,8 +2138,8 @@ def grpo_trainer_compute_loss(function_name, function):
             inputs.get("image_sizes", None),
         )
         num_images = inputs.get("num_images", None)
-        spatial_shapes     = inputs.get("spatial_shapes",     None)
-        num_tiles          = inputs.get("num_tiles",          None)
+        spatial_shapes = inputs.get("spatial_shapes", None)
+        num_tiles = inputs.get("num_tiles", None)
         image_position_ids = inputs.get("image_position_ids", None)
         # Transformers 5.x needs token_type_ids/mm_token_type_ids for some vision models
         token_type_ids = inputs.get("token_type_ids", None)

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -1214,6 +1214,10 @@ def grpo_trainer__get_per_token_logps_and_entropies(function_name, function):
                 kwargs.get("image_sizes", None),
             )
             num_images = kwargs.get("num_images", None)
+            # TRL >= 1.7 tiled/dynamic-resolution VLM kwargs (e.g. LightOnOCR, InternVL tiling)
+            spatial_shapes = kwargs.get("spatial_shapes", None)
+            num_tiles = kwargs.get("num_tiles", None)
+            image_position_ids = kwargs.get("image_position_ids", None)
             # Transformers 5.x needs token_type_ids/mm_token_type_ids for some vision models
             token_type_ids = kwargs.get("token_type_ids", None)
             mm_token_type_ids = kwargs.get("mm_token_type_ids", None)
@@ -1273,6 +1277,8 @@ def grpo_trainer__get_per_token_logps_and_entropies(function_name, function):
             batch_size = math.ceil(total_samples / B)
             if isinstance(num_images, torch.Tensor):
                 num_images = num_images.detach().cpu().reshape(-1).tolist()
+            if isinstance(num_tiles, torch.Tensor):
+                num_tiles = num_tiles.detach().cpu().reshape(-1).tolist()
             if image_grid_thw is not None and pixel_values is not None and num_images is not None:
                 rows_per_image = image_grid_thw.prod(dim = -1)
                 rows_per_sample = torch.split(rows_per_image, num_images)
@@ -1289,6 +1295,20 @@ def grpo_trainer__get_per_token_logps_and_entropies(function_name, function):
             else:
                 cum_rows = None
                 cum_imgs = None
+
+            if (
+                num_tiles is not None
+                and image_grid_thw is not None
+                and pixel_values is not None
+                and num_images is not None
+            ):
+                # why: cum_tiles is indexed via list indexing inside the per-chunk loop;
+                # a plain Python list (built once here) avoids per-iteration GPU->CPU sync.
+                cum_tiles = [0]
+                for _n_tiles in num_tiles:
+                    cum_tiles.append(cum_tiles[-1] + int(_n_tiles))
+            else:
+                cum_tiles = None
 
             def _first_dim_len(value):
                 if value is None:
@@ -1311,6 +1331,9 @@ def grpo_trainer__get_per_token_logps_and_entropies(function_name, function):
             image_sizes_chunks = []
             token_type_ids_chunks = []
             mm_token_type_ids_chunks = []
+            spatial_shapes_chunks = []
+            num_tiles_chunks = []
+            image_position_ids_chunks = []
 
             current_pixel_idx = 0
             # TRL 0.23.0 batching logic
@@ -1369,11 +1392,31 @@ def grpo_trainer__get_per_token_logps_and_entropies(function_name, function):
                     else:
                         pixel_attention_mask_chunks.append(pixel_attention_mask[start:end])
 
+                    if num_tiles is None or img_start is None:
+                        num_tiles_chunks.append(None)
+                    else:
+                        num_tiles_chunks.append(num_tiles[img_start:img_end])
+
+                    if image_position_ids is None or img_start is None:
+                        image_position_ids_chunks.append(None)
+                    else:
+                        image_position_ids_chunks.append(image_position_ids[img_start:img_end])
+
+                    if spatial_shapes is None or cum_tiles is None or img_start is None:
+                        spatial_shapes_chunks.append(None)
+                    else:
+                        tile_start = cum_tiles[img_start]
+                        tile_end = cum_tiles[img_end]
+                        spatial_shapes_chunks.append(spatial_shapes[tile_start:tile_end])
+
                 else:
                     pixel_values_chunks.append(None)
                     image_grid_thw_chunks.append(None)
                     pixel_attention_mask_chunks.append(None)
                     image_sizes_chunks.append(slice_sample_axis(image_sizes, start, end))
+                    num_tiles_chunks.append(None)
+                    image_position_ids_chunks.append(None)
+                    spatial_shapes_chunks.append(None)
 
             temperature = self.temperature
             model_config = _unsloth_get_model_config(model)
@@ -1394,6 +1437,9 @@ def grpo_trainer__get_per_token_logps_and_entropies(function_name, function):
                 image_sizes_chunks,
                 token_type_ids_chunks,
                 mm_token_type_ids_chunks,
+                spatial_shapes_chunks,
+                num_tiles_chunks,
+                image_position_ids_chunks,
             )
             os.environ["UNSLOTH_RETURN_HIDDEN_STATES"] = "1"
 
@@ -1840,12 +1886,21 @@ def grpo_trainer__get_per_token_logps_and_entropies(function_name, function):
                     image_sizes_chunk,
                     token_type_ids_chunk,
                     mm_token_type_ids_chunk,
+                    spatial_shapes_chunk,
+                    num_tiles_chunk,
+                    image_position_ids_chunk,
                 ) in zipped_inputs:
                     _extra_vision_kwargs = {}
                     if token_type_ids_chunk is not None:
                         _extra_vision_kwargs["token_type_ids"] = token_type_ids_chunk
                     if mm_token_type_ids_chunk is not None:
                         _extra_vision_kwargs["mm_token_type_ids"] = mm_token_type_ids_chunk
+                    if spatial_shapes_chunk is not None:
+                        _extra_vision_kwargs["spatial_shapes"] = spatial_shapes_chunk
+                    if num_tiles_chunk is not None:
+                        _extra_vision_kwargs["num_tiles"] = num_tiles_chunk
+                    if image_position_ids_chunk is not None:
+                        _extra_vision_kwargs["image_position_ids"] = image_position_ids_chunk
                     with torch.amp.autocast(device_type = "cuda", dtype = self._autocast_dtype):
                         if pixel_values is None:
                             outputs = unwrapped_model(

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -2138,6 +2138,9 @@ def grpo_trainer_compute_loss(function_name, function):
             inputs.get("image_sizes", None),
         )
         num_images = inputs.get("num_images", None)
+        spatial_shapes     = inputs.get("spatial_shapes",     None)
+        num_tiles          = inputs.get("num_tiles",          None)
+        image_position_ids = inputs.get("image_position_ids", None)
         # Transformers 5.x needs token_type_ids/mm_token_type_ids for some vision models
         token_type_ids = inputs.get("token_type_ids", None)
         mm_token_type_ids = inputs.get("mm_token_type_ids", None)
@@ -2337,6 +2340,9 @@ def grpo_trainer_compute_loss(function_name, function):
                     pixel_attention_mask = pixel_attention_mask,
                     image_sizes = image_sizes,
                     num_images = num_images,
+                    spatial_shapes = spatial_shapes,
+                    num_tiles = num_tiles,
+                    image_position_ids = image_position_ids,
                     logits_to_keep = logits_to_keep,
                     completion_mask = completion_mask,
                     advantages = advantages,
@@ -2373,6 +2379,9 @@ def grpo_trainer_compute_loss(function_name, function):
                     pixel_attention_mask = pixel_attention_mask,
                     image_sizes = image_sizes,
                     num_images = num_images,
+                    spatial_shapes = spatial_shapes,
+                    num_tiles = num_tiles,
+                    image_position_ids = image_position_ids,
                     logits_to_keep = logits_to_keep,
                     completion_mask = completion_mask,
                     advantages = advantages,


### PR DESCRIPTION
## Problem

TRL's `GRPOTrainer` (>= 1.7) calls `_get_per_token_logps_and_entropies` with extra forward kwargs for tiled/dynamic-resolution VLMs: `spatial_shapes`, `num_tiles`, `image_position_ids`. Unsloth's GRPO replacement for this method only extracts and forwards `pixel_values`/`image_grid_thw`/`pixel_attention_mask`/`image_sizes`/`num_images`/`token_type_ids`/`mm_token_type_ids`. The three tiling kwargs are silently dropped before the per-chunk model forward calls, which either crashes with a missing-argument error on tiled VLMs that require them, or produces logprobs computed without the correct spatial/tile layout, corrupting GRPO's advantage estimation.

## Fix

Forward `spatial_shapes`, `num_tiles`, and `image_position_ids` through both GRPO code paths:

**Chunking path** (`_get_per_token_logps_and_entropies`):
- Extract the three kwargs alongside existing VLM kwargs.
- Compute a `cum_tiles` cumsum from `num_tiles` (per-image, mirroring the existing `cum_imgs`/`cum_rows` pattern) so `spatial_shapes` can be sliced consistently with `pixel_values` chunk boundaries.
- Slice `num_tiles` and `image_position_ids` per chunk using the existing `img_start:img_end` per-image cursor.
- Forward all three through `_extra_vision_kwargs`, which both model-forward call sites already spread into the `unwrapped_model(...)` call.

**Accumulated loss path** (`compute_loss`):
- Extract the three kwargs from `inputs` alongside existing vision kwargs.
- Pass them through to `grpo_accumulated_loss` (which accepts `**kwargs`).

No behavior change for non-tiled VLMs or text-only GRPO: all three new extractions default to `None`, and every new chunk-list append path has a `None` fallback so chunk lengths stay consistent with existing lists.

## Testing

```
python -m pytest tests/test_multi_image_grpo_chunking.py -q --tb=short
```
20 passed (10 pre-existing + 10 new covering kwarg extraction, tile-boundary cumsum, per-chunk slicing simulation, zip expansion shapes, `_extra_vision_kwargs` forwarding, and text-only negative space). Full logprob-parity validation against stock TRL GRPO on a tiled VLM checkpoint requires a GPU environment not available for this change; flagged for maintainer follow-up per acceptance criterion 3.

Closes #6960