### PR TITLE
unsloth start: add --persist to keep and reopen agent sessions

### DIFF
--- a/.github/scripts/agent-guides-drive.sh
+++ b/.github/scripts/agent-guides-drive.sh
@@ -588,7 +588,7 @@ case "$MODE" in
     }
 
     # Run one headless turn through the launch path. $1=outfile, $2="" or
-    # "--resume", rest = the agent subcommand. --yolo auto-approves so no tool
+    # "--persist", rest = the agent subcommand. --yolo auto-approves so no tool
     # prompt can hang; --api-key attaches to the already-served CI model.
     launch_turn() {
       local out="$1" rflag="$2"; shift 2
@@ -603,7 +603,7 @@ case "$MODE" in
     # One pass: fresh work dir, one planting turn, set RESULT to PERSISTED/WIPED
     # from the session-store delta. Runs in the main shell (not a command
     # substitution) so a hang's guide_fail actually fails the job and the
-    # progress lines reach the CI log. $1 = "" (baseline) or "--resume".
+    # progress lines reach the CI log. $1 = "" (baseline) or "--persist".
     RESULT=""
     run_pass() {
       local rflag="$1" label="baseline"
@@ -622,12 +622,18 @@ case "$MODE" in
       if [ "$after" -gt "$before" ]; then RESULT="PERSISTED"; else RESULT="WIPED"; fi
     }
 
-    run_pass "";         BASELINE="$RESULT"
-    run_pass "--resume"; RESUME="$RESULT"
+    run_pass ""; BASELINE="$RESULT"
+    # Only the temp-dir agents (codex/pi) need the --persist pass to prove the fix.
+    # opencode/claude persist either way, so the baseline already proves it and a
+    # second full CPU turn only risks a timeout; skip it for them.
+    case "$AGENT" in
+      codex|pi) run_pass "--persist"; RESUME="$RESULT" ;;
+      *)        RESUME="n/a (persists either way)" ;;
+    esac
 
     # Expected: codex/pi relocate their whole home to the temp dir, so a plain
-    # launch is WIPED and only --resume PERSISTS. opencode/claude keep their
-    # session data in a fixed user dir, so both passes PERSIST.
+    # launch is WIPED and only --persist PERSISTS. opencode/claude keep their
+    # session data in a fixed user dir, so the baseline already PERSISTS.
     case "$AGENT" in
       codex|pi)        EXPECT_BASELINE="WIPED" ;;
       opencode|claude) EXPECT_BASELINE="PERSISTED" ;;
@@ -635,23 +641,26 @@ case "$MODE" in
 
     echo "──────────────────────────────────────────────"
     echo "[$AGENT] RESUME EXPERIMENT"
-    echo "  baseline (unsloth start ${AGENT}):            ${BASELINE}  (expected ${EXPECT_BASELINE})"
-    echo "  with --resume (unsloth start ${AGENT} --resume): ${RESUME}  (expected PERSISTED)"
+    echo "  baseline (unsloth start ${AGENT}):                 ${BASELINE}  (expected ${EXPECT_BASELINE})"
+    echo "  with --persist (unsloth start ${AGENT} --persist): ${RESUME}"
     echo "──────────────────────────────────────────────"
 
     [ "$BASELINE" = "$EXPECT_BASELINE" ] \
       || guide_fail "baseline resume behavior for ${AGENT} was ${BASELINE}, expected ${EXPECT_BASELINE}"
-    [ "$RESUME" = "PERSISTED" ] \
-      || guide_fail "--resume did not persist ${AGENT}'s session (got ${RESUME}); the session dir is still not stable"
+    case "$AGENT" in
+      codex|pi)
+        [ "$RESUME" = "PERSISTED" ] \
+          || guide_fail "--persist did not persist ${AGENT}'s session (got ${RESUME}); the session dir is still not stable" ;;
+    esac
 
-    # Flagship behavioral proof (codex only, WARN-only): after a --resume plant,
+    # Flagship behavioral proof (codex only, WARN-only): after a --persist plant,
     # resume the session and check the model actually recalls the codeword. A
     # miss is not a failure (the CI model is small); the mechanism gate above is
     # the real assertion.
     if [ "$AGENT" = "codex" ]; then
       rm -rf "$WORK"; mkdir -p "$WORK"
-      ( cd "$WORK" && launch_turn "$LOGS_DIR/codex-resume-plant.txt" "--resume" exec "$T1" ) || true
-      ( cd "$WORK" && launch_turn "$LOGS_DIR/codex-resume-recall.txt" "--resume" exec resume --last "$T2" ) || true
+      ( cd "$WORK" && launch_turn "$LOGS_DIR/codex-resume-plant.txt" "--persist" exec "$T1" ) || true
+      ( cd "$WORK" && launch_turn "$LOGS_DIR/codex-resume-recall.txt" "--persist" exec resume --last "$T2" ) || true
       if grep -q "$CODEWORD" "$LOGS_DIR/codex-resume-recall.txt" 2>/dev/null; then
         echo "[codex] behavioral recall HIT: resumed session remembered ${CODEWORD}"
       else

--- a/.github/scripts/agent-guides-drive.sh
+++ b/.github/scripts/agent-guides-drive.sh
@@ -531,18 +531,18 @@ case "$MODE" in
   # Unlike the other modes, this drives the real LAUNCH path (`unsloth start
   # <agent> ...`, the interactive default), not the --no-launch recipe. That
   # path relocates each agent's home to a throwaway temp dir wiped on exit, so
-  # a session cannot be resumed -- unless --resume routes it to the stable
+  # a session cannot be resumed -- unless --persist routes it to the stable
   # Unsloth agents dir instead. We run one headless turn per pass and check
   # whether the turn left a session in a persistent store (deterministic, no
   # reliance on the model recalling anything), for a baseline pass and a
-  # --resume pass, and assert the expected split for this agent.
+  # --persist pass, and assert the expected split for this agent.
   resume)
     CODEWORD="PLATYPUS7"
     T1="Remember this codeword for later: ${CODEWORD}. Reply with just the word OK."
     T2="What codeword did I ask you to remember? Reply with just that word."
     WORK="$WORKDIR_BASE/${AGENT}-resume"
 
-    # STABLE_HOME: the stable dir that --no-launch (and --resume) relocate to.
+    # STABLE_HOME: the stable dir that --no-launch (and --persist) relocate to.
     # Read it from a --no-launch probe (which also writes the agent's config
     # there). codex/pi relocate their whole home/HOME here; opencode/claude keep
     # their session data in a fixed user dir, so STABLE_HOME stays empty for them.
@@ -618,7 +618,12 @@ case "$MODE" in
       popd >/dev/null || true
       after="$(count_session_files)"
       echo "[$AGENT] ${label}: session files ${before} -> ${after} (rc=${rc})"
-      [ "$rc" -eq 0 ] || { echo "[$AGENT] ${label} transcript (tail):"; tail -30 "$out" 2>/dev/null || true; }
+      # The turn must succeed for the delta to mean anything: an agent that writes a
+      # session file then errors would otherwise be misread as PERSISTED. Mirror the
+      # file-edit mode and fail the pass on a non-zero launch (the flagship codex recall
+      # below stays WARN-only, driven by its own launch_turn calls).
+      [ "$rc" -eq 0 ] || { echo "[$AGENT] ${label} transcript (tail):"; tail -30 "$out" 2>/dev/null || true; \
+        guide_fail "resume ${label} turn for ${AGENT} exited non-zero (rc=${rc})"; }
       if [ "$after" -gt "$before" ]; then RESULT="PERSISTED"; else RESULT="WIPED"; fi
     }
 

--- a/.github/scripts/agent-guides-drive.sh
+++ b/.github/scripts/agent-guides-drive.sh
@@ -527,6 +527,140 @@ case "$MODE" in
     echo "[claude] attribution A/B OK (suppressed HIT, header=1 MISS)"
     ;;
 
+  # ── resume: does a launched agent's session survive exit and resume? ────
+  # Unlike the other modes, this drives the real LAUNCH path (`unsloth start
+  # <agent> ...`, the interactive default), not the --no-launch recipe. That
+  # path relocates each agent's home to a throwaway temp dir wiped on exit, so
+  # a session cannot be resumed -- unless --resume routes it to the stable
+  # Unsloth agents dir instead. We run one headless turn per pass and check
+  # whether the turn left a session in a persistent store (deterministic, no
+  # reliance on the model recalling anything), for a baseline pass and a
+  # --resume pass, and assert the expected split for this agent.
+  resume)
+    CODEWORD="PLATYPUS7"
+    T1="Remember this codeword for later: ${CODEWORD}. Reply with just the word OK."
+    T2="What codeword did I ask you to remember? Reply with just that word."
+    WORK="$WORKDIR_BASE/${AGENT}-resume"
+
+    # STABLE_HOME: the stable dir that --no-launch (and --resume) relocate to.
+    # Read it from a --no-launch probe (which also writes the agent's config
+    # there). codex/pi relocate their whole home/HOME here; opencode/claude keep
+    # their session data in a fixed user dir, so STABLE_HOME stays empty for them.
+    parse_connect
+    case "$AGENT" in
+      codex)    STABLE_HOME="$(raw_env CODEX_HOME)" ;;
+      pi)       STABLE_HOME="$(raw_env HOME)" ;;
+      *)        STABLE_HOME="" ;;
+    esac
+
+    # The persistent stores a session would land in if it were NOT wiped. We
+    # count files here before/after each turn; a positive delta means the
+    # session persisted (is resumable), zero means it went to a wiped temp dir.
+    resume_tracked_dirs() {
+      case "$AGENT" in
+        codex)    printf '%s\n' "$HOME/.codex" ;;
+        opencode) printf '%s\n' "$HOME/.local/share/opencode" "$HOME/.config/opencode" ;;
+        claude)   printf '%s\n' "$HOME/.claude" ;;
+        pi)       printf '%s\n' "$HOME/.pi" ;;
+        *)        : ;;
+      esac
+      [ -n "$STABLE_HOME" ] && printf '%s\n' "$STABLE_HOME"
+    }
+    count_session_files() {
+      local total=0 d n
+      while IFS= read -r d; do
+        [ -n "$d" ] && [ -d "$d" ] || continue
+        n="$(find "$d" -type f 2>/dev/null | wc -l)"; total=$((total + n))
+      done < <(resume_tracked_dirs)
+      echo "$total"
+    }
+
+    # The headless first-turn subcommand per agent (mirrors file-edit's map),
+    # forwarded verbatim through the launch path as passthrough args.
+    set_t1_cmd() {
+      case "$AGENT" in
+        claude)   T1_CMD=("${CLAUDE_CONNECT_FLAGS[@]}" -p "$T1") ;;
+        codex)    T1_CMD=(exec "$T1") ;;
+        opencode) T1_CMD=(run "$T1") ;;
+        pi)       T1_CMD=(-p "$T1") ;;
+        *)        guide_fail "resume mode does not cover agent '$AGENT'" ;;
+      esac
+    }
+
+    # Run one headless turn through the launch path. $1=outfile, $2="" or
+    # "--resume", rest = the agent subcommand. --yolo auto-approves so no tool
+    # prompt can hang; --api-key attaches to the already-served CI model.
+    launch_turn() {
+      local out="$1" rflag="$2"; shift 2
+      local flag=(); [ -n "$rflag" ] && flag=("$rflag")
+      run_timed "$out" unsloth start "$AGENT" "${flag[@]}" --yolo \
+        --api-key "$UNSLOTH_API_KEY" "$@"
+      local rc=$?
+      redact "$out"
+      return "$rc"
+    }
+
+    # One pass: fresh work dir, one planting turn, set RESULT to PERSISTED/WIPED
+    # from the session-store delta. Runs in the main shell (not a command
+    # substitution) so a hang's guide_fail actually fails the job and the
+    # progress lines reach the CI log. $1 = "" (baseline) or "--resume".
+    RESULT=""
+    run_pass() {
+      local rflag="$1" label="baseline"
+      [ -n "$rflag" ] && label="resume"
+      rm -rf "$WORK"; mkdir -p "$WORK"
+      set_t1_cmd
+      local out="$LOGS_DIR/${AGENT}-resume-${label}.txt"
+      local before after rc
+      before="$(count_session_files)"
+      pushd "$WORK" >/dev/null || guide_fail "could not enter work dir $WORK"
+      launch_turn "$out" "$rflag" "${T1_CMD[@]}"; rc=$?
+      popd >/dev/null || true
+      after="$(count_session_files)"
+      echo "[$AGENT] ${label}: session files ${before} -> ${after} (rc=${rc})"
+      [ "$rc" -eq 0 ] || { echo "[$AGENT] ${label} transcript (tail):"; tail -30 "$out" 2>/dev/null || true; }
+      if [ "$after" -gt "$before" ]; then RESULT="PERSISTED"; else RESULT="WIPED"; fi
+    }
+
+    run_pass "";         BASELINE="$RESULT"
+    run_pass "--resume"; RESUME="$RESULT"
+
+    # Expected: codex/pi relocate their whole home to the temp dir, so a plain
+    # launch is WIPED and only --resume PERSISTS. opencode/claude keep their
+    # session data in a fixed user dir, so both passes PERSIST.
+    case "$AGENT" in
+      codex|pi)        EXPECT_BASELINE="WIPED" ;;
+      opencode|claude) EXPECT_BASELINE="PERSISTED" ;;
+    esac
+
+    echo "──────────────────────────────────────────────"
+    echo "[$AGENT] RESUME EXPERIMENT"
+    echo "  baseline (unsloth start ${AGENT}):            ${BASELINE}  (expected ${EXPECT_BASELINE})"
+    echo "  with --resume (unsloth start ${AGENT} --resume): ${RESUME}  (expected PERSISTED)"
+    echo "──────────────────────────────────────────────"
+
+    [ "$BASELINE" = "$EXPECT_BASELINE" ] \
+      || guide_fail "baseline resume behavior for ${AGENT} was ${BASELINE}, expected ${EXPECT_BASELINE}"
+    [ "$RESUME" = "PERSISTED" ] \
+      || guide_fail "--resume did not persist ${AGENT}'s session (got ${RESUME}); the session dir is still not stable"
+
+    # Flagship behavioral proof (codex only, WARN-only): after a --resume plant,
+    # resume the session and check the model actually recalls the codeword. A
+    # miss is not a failure (the CI model is small); the mechanism gate above is
+    # the real assertion.
+    if [ "$AGENT" = "codex" ]; then
+      rm -rf "$WORK"; mkdir -p "$WORK"
+      ( cd "$WORK" && launch_turn "$LOGS_DIR/codex-resume-plant.txt" "--resume" exec "$T1" ) || true
+      ( cd "$WORK" && launch_turn "$LOGS_DIR/codex-resume-recall.txt" "--resume" exec resume --last "$T2" ) || true
+      if grep -q "$CODEWORD" "$LOGS_DIR/codex-resume-recall.txt" 2>/dev/null; then
+        echo "[codex] behavioral recall HIT: resumed session remembered ${CODEWORD}"
+      else
+        echo "::warning::[codex] behavioral recall MISS (small CI model); mechanism gate still passed"
+      fi
+    fi
+    echo "[$AGENT] resume OK"
+    ;;
+
   *)
     echo "agent-guides-drive.sh: unknown mode '$MODE'" >&2
     exit 2

--- a/.github/workflows/local-agent-guides-ci.yml
+++ b/.github/workflows/local-agent-guides-ci.yml
@@ -472,6 +472,176 @@ jobs:
           retention-days: 7
 
   # ═════════════════════════════════════════════════════════════════════
+  # Job: resume
+  #   Does a conversation started with `unsloth start <agent>` survive exit
+  #   and resume? This drives the REAL launch path (not the --no-launch
+  #   recipe the other jobs use). A plain launch relocates the agent home to
+  #   a temp dir wiped on exit, so codex/pi cannot resume; --resume routes the
+  #   session to the stable Unsloth agents dir so it persists. opencode/claude
+  #   keep their session data in a fixed user dir, so they persist either way.
+  #   Dispatch-only: it is an end-to-end experiment, not a PR gate.
+  # ═════════════════════════════════════════════════════════════════════
+  resume:
+    name: resume (${{ matrix.agent }})
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        # codex/pi relocate their whole home (resume broken without --resume);
+        # opencode/claude keep session data in a fixed dir (resume already works).
+        # One agent from each class proves the split end to end; openclaw/hermes
+        # share codex's relocation mechanism and are covered by the unit tests.
+        agent: [codex, opencode, claude, pi]
+    env:
+      GGUF_REPO: unsloth/gemma-4-E4B-it-GGUF
+      GGUF_FILE: gemma-4-E4B-it-UD-Q4_K_XL.gguf
+      STUDIO_PORT: '18904'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Linux deps for llama.cpp prebuilt
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libcurl4-openssl-dev libssl-dev jq
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '22'
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Restore GGUF model file
+        id: cache-gguf
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        continue-on-error: true
+        with:
+          path: gguf-cache
+          key: ${{ runner.os }}-gguf-${{ env.GGUF_REPO }}-${{ env.GGUF_FILE }}-v1
+
+      - name: Download GGUF if cache miss
+        id: download-gguf
+        if: steps.cache-gguf.outputs.cache-hit != 'true' || steps.cache-gguf.outcome != 'success'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          python -m pip install --upgrade huggingface_hub
+          mkdir -p gguf-cache
+          bash .github/scripts/hf-download-with-retry.sh "$GGUF_REPO" "$GGUF_FILE" gguf-cache
+
+      - name: Save GGUF model file
+        if: always() && steps.download-gguf.outcome == 'success'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: gguf-cache
+          key: ${{ runner.os }}-gguf-${{ env.GGUF_REPO }}-${{ env.GGUF_FILE }}-v1
+
+      - name: Install Studio (--local, --no-torch)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          mkdir -p logs
+          set -o pipefail
+          bash install.sh --local --no-torch 2>&1 | tee logs/install.log
+
+      - name: Serve unsloth run --disable-tools (gemma-4-E4B)
+        run: |
+          unsloth studio reset-password
+          bash .github/scripts/serve-unsloth-run.sh \
+            --gguf-file "$GITHUB_WORKSPACE/gguf-cache/${GGUF_FILE}" \
+            --port "$STUDIO_PORT" --log-dir logs \
+            --extra "--seed $UNSLOTH_SEED --temp 0" \
+            --health-timeout 900
+
+      - name: Preflight the agent's API dialect (class-a isolation)
+        env:
+          AGENT: ${{ matrix.agent }}
+        run: |
+          set -uo pipefail
+          B="$UNSLOTH_BASE_URL"; K="$UNSLOTH_API_KEY"
+          preflight_fail() {
+            echo "::error::[server/API regression] agent=$AGENT: $* (preflight failed BEFORE install/connect). Endpoint contract lives in studio/backend/routes/**.";
+            exit 1
+          }
+          code=$(curl -s -o /tmp/pf.json -w '%{http_code}' "$B/v1/models" \
+            -H "Authorization: Bearer $K") || true
+          [ "$code" = "200" ] || preflight_fail "/v1/models returned HTTP $code"
+          case "$AGENT" in
+            claude)
+              code=$(curl -s -o /tmp/pf.json -w '%{http_code}' "$B/v1/messages" \
+                -H "Authorization: Bearer $K" -H 'content-type: application/json' \
+                --max-time 120 \
+                -d "{\"model\":\"$UNSLOTH_MODEL_ID\",\"max_tokens\":16,\"messages\":[{\"role\":\"user\",\"content\":\"Hi\"}]}") || true
+              [ "$code" = "200" ] || preflight_fail "/v1/messages returned HTTP $code"
+              ;;
+            codex)
+              code=$(curl -s -o /tmp/pf.json -w '%{http_code}' "$B/v1/responses" \
+                -H "Authorization: Bearer $K" -H 'content-type: application/json' \
+                --max-time 120 \
+                -d "{\"model\":\"$UNSLOTH_MODEL_ID\",\"input\":\"Hi\",\"max_output_tokens\":16,\"stream\":true}") || true
+              [ "$code" = "200" ] || preflight_fail "/v1/responses returned HTTP $code"
+              ;;
+            *)
+              code=$(curl -s -o /tmp/pf.json -w '%{http_code}' "$B/v1/chat/completions" \
+                -H "Authorization: Bearer $K" -H 'content-type: application/json' \
+                --max-time 120 \
+                -d "{\"model\":\"$UNSLOTH_MODEL_ID\",\"max_tokens\":16,\"messages\":[{\"role\":\"user\",\"content\":\"Hi\"}]}") || true
+              [ "$code" = "200" ] || preflight_fail "/v1/chat/completions returned HTTP $code"
+              ;;
+          esac
+          echo "preflight OK for $AGENT"
+
+      - name: Install agent CLI (class-b isolation)
+        env:
+          AGENT: ${{ matrix.agent }}
+        run: bash .github/scripts/agent-guides-install.sh "$AGENT"
+
+      - name: Resume experiment (launch path)
+        env:
+          AGENT: ${{ matrix.agent }}
+        run: bash .github/scripts/agent-guides-drive.sh resume "$AGENT"
+
+      - name: Collect server logs (debug)
+        if: always()
+        run: |
+          mkdir -p logs/studio-logs
+          cp -r "$HOME/.unsloth/studio/logs/." logs/studio-logs/ 2>/dev/null || true
+          if [ -n "${UNSLOTH_API_KEY:-}" ]; then
+            grep -rlF "$UNSLOTH_API_KEY" logs redacted-configs agent-workdir 2>/dev/null | while IFS= read -r f; do
+              sed -i "s#${UNSLOTH_API_KEY}#<REDACTED>#g" "$f" 2>/dev/null || true
+            done
+          fi
+
+      - name: Stop Studio
+        if: always()
+        run: |
+          if [ -n "${UNSLOTH_SERVER_PID:-}" ] && [ "${UNSLOTH_SERVER_PID}" != "0" ]; then
+            kill "${UNSLOTH_SERVER_PID}" 2>/dev/null || true
+          fi
+          sleep 2
+          ss -tln 2>/dev/null | grep ":${STUDIO_PORT}" || true
+
+      - name: Upload logs
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: resume-${{ matrix.agent }}-log
+          path: |
+            logs/
+            agent-workdir/
+            redacted-configs/
+          retention-days: 7
+
+  # ═════════════════════════════════════════════════════════════════════
   # Job 3: prompt-cache
   #   (a) curl 2-turn /v1/chat/completions: assert turn-2 cached_tokens > 0
   #       (server prompt-cache sanity).

--- a/.github/workflows/local-agent-guides-ci.yml
+++ b/.github/workflows/local-agent-guides-ci.yml
@@ -476,7 +476,7 @@ jobs:
   #   Does a conversation started with `unsloth start <agent>` survive exit
   #   and resume? This drives the REAL launch path (not the --no-launch
   #   recipe the other jobs use). A plain launch relocates the agent home to
-  #   a temp dir wiped on exit, so codex/pi cannot resume; --resume routes the
+  #   a temp dir wiped on exit, so codex/pi cannot resume; --persist routes the
   #   session to the stable Unsloth agents dir so it persists. opencode/claude
   #   keep their session data in a fixed user dir, so they persist either way.
   #   Dispatch-only: it is an end-to-end experiment, not a PR gate.
@@ -489,7 +489,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # codex/pi relocate their whole home (resume broken without --resume);
+        # codex/pi relocate their whole home (resume broken without --persist);
         # opencode/claude keep session data in a fixed dir (resume already works).
         # One agent from each class proves the split end to end; openclaw/hermes
         # share codex's relocation mechanism and are covered by the unit tests.

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -137,12 +137,15 @@ _PERSIST_OPTION = typer.Option(
     False,
     "--persist/--no-persist",
     help = (
-        "Keep this agent's session so you can resume it later. Without --persist a "
-        "launched agent's home is a throwaway temp dir wiped on exit (nothing "
-        "persists); with it, the session lives under the Unsloth agents dir (never "
-        "your own ~/.<agent>). A bare `--persist` also reopens the last conversation. "
-        "An agent's own resume flag (e.g. `claude --resume <id>`) still passes through "
-        "unchanged."
+        "Keep this agent's Unsloth-managed session dir so you can resume it later. "
+        "codex/openclaw/hermes/pi have their whole home relocated into an Unsloth dir "
+        "that is a throwaway temp dir (wiped on exit) by default; with --persist it "
+        "lives under the Unsloth agents dir and survives, so their own resume can reopen "
+        "it. claude and opencode keep sessions in your own stores (~/.claude, "
+        "~/.local/share/opencode), so they already resume regardless. To reopen a "
+        "session, pass the agent's own resume command through, e.g. "
+        "`unsloth start codex --persist resume` or `claude --resume <id>`; those flow to "
+        "the agent unchanged."
     ),
 )
 
@@ -161,33 +164,6 @@ _YOLO_COMMAND_FLAGS = {
 def _yolo_command_flags(agent: str, yolo: bool) -> list:
     # .get so a config-based agent (or a typo) yields no flag instead of a KeyError.
     return _YOLO_COMMAND_FLAGS.get(agent, []) if yolo else []
-
-
-# Native "reopen the previous session" tokens appended to a BARE `--persist` launch
-# (no passthrough args) so `unsloth start <agent> --persist` resumes the last chat
-# instead of opening a blank one. openclaw and hermes are omitted on purpose: their
-# resume is an in-app picker with no stable non-interactive selector, and --persist
-# already persists their session dir, so their own resume finds the prior sessions.
-_RESUME_LAUNCH_FLAGS = {
-    "claude": ["--continue"],
-    "codex": ["resume", "--last"],
-    "opencode": ["--continue"],
-    "pi": ["--continue"],
-}
-
-
-def _resume_launch_args(agent: str, persist: bool, launch: bool, passthrough) -> list:
-    """Tokens that make a bare `--persist` launch reopen the agent's last session.
-
-    Only a bare interactive launch (``--persist`` set, no passthrough args) gets them:
-    when the caller passes their own subcommand they drive resume themselves, and the
-    --no-launch printout is consumed by drivers that append their own subcommand, so a
-    resume token there would break it. An agent without a mapping returns nothing;
-    --persist still persists its session dir so its own resume works.
-    """
-    if persist and launch and not passthrough:
-        return list(_RESUME_LAUNCH_FLAGS.get(agent, []))
-    return []
 
 
 def _hermes_install_hint() -> str:
@@ -1526,7 +1502,8 @@ def claude(
     # IS_SANDBOX is left unset on purpose: Claude refuses bypass mode as root unless a
     # sandbox is detected, and we don't want to falsely claim one on the user's host.
     # claude keeps its history in ~/.claude/projects, which --settings/env never
-    # relocate, so a session already survives exit; --persist only needs to reopen it.
+    # relocate, so a session already survives exit; resume it with `claude --continue`
+    # or `--resume <id>` passed through.
     command = [
         "claude",
         "--model",
@@ -1534,7 +1511,6 @@ def claude(
         *_claude_flags(),
         *_yolo_command_flags("claude", yolo),
         *ctx.args,
-        *_resume_launch_args("claude", persist, launch, ctx.args),
     ]
     install_hint = (
         "irm https://claude.ai/install.ps1 | iex"
@@ -1589,7 +1565,6 @@ def codex(
         _CODEX_PROFILE,
         *_yolo_command_flags("codex", yolo),
         *ctx.args,
-        *_resume_launch_args("codex", persist, launch, ctx.args),
     ]
     with _session_config("codex", launch, persist = persist) as home:
         write_codex_config(base, entry, home)
@@ -1681,8 +1656,7 @@ def opencode(
     else:
         command = ["opencode"]
     # opencode keeps sessions in ~/.local/share/opencode (never relocated), so resume
-    # already survives exit; a bare --persist just reopens the last one with --continue.
-    command += _resume_launch_args("opencode", persist, launch, ctx.args)
+    # already survives exit; reopen the last one by passing `opencode --continue` through.
     with _session_config("opencode", launch, persist = persist) as cfg:
         config_path = cfg / "opencode.json"
         # OPENCODE_CONFIG is an overlay (loaded between the user's global and project
@@ -1788,7 +1762,6 @@ def pi(
         entry["id"],
         *_yolo_command_flags("pi", yolo),
         *ctx.args,
-        *_resume_launch_args("pi", persist, launch, ctx.args),
     ]
     # --ignore-scripts matches Pi's documented install recipe (its README notes Pi needs
     # no install scripts), so accepting the prompt skips dependency lifecycle scripts.

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -1153,7 +1153,11 @@ def _agents_config_root() -> Path:
 
 
 @contextlib.contextmanager
-def _session_config(agent: str, launch: bool, persist: bool = False):
+def _session_config(
+    agent: str,
+    launch: bool,
+    persist: bool = False,
+):
     """Yield a private directory for an agent's session config (never the user's own).
 
     launch (default): an ephemeral temp dir removed after the agent process exits, so

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -133,6 +133,16 @@ _YOLO_OPTION = typer.Option(
         "flag/config. Any of the three spellings works for any agent."
     ),
 )
+_RESUME_OPTION = typer.Option(
+    False,
+    "--resume/--no-resume",
+    help = (
+        "Keep this agent's session so you can resume it later. Without --resume a "
+        "launched agent's home is a throwaway temp dir wiped on exit (nothing "
+        "persists); with it, the session lives under the Unsloth agents dir (never "
+        "your own ~/.<agent>). A bare `--resume` also reopens the last conversation."
+    ),
+)
 
 # Per-agent CLI flag for "run tools without prompting". opencode and openclaw have no
 # such flag (config only) and are handled in their config writers, so they are absent.
@@ -149,6 +159,33 @@ _YOLO_COMMAND_FLAGS = {
 def _yolo_command_flags(agent: str, yolo: bool) -> list:
     # .get so a config-based agent (or a typo) yields no flag instead of a KeyError.
     return _YOLO_COMMAND_FLAGS.get(agent, []) if yolo else []
+
+
+# Native "reopen the previous session" tokens appended to a BARE `--resume` launch
+# (no passthrough args) so `unsloth start <agent> --resume` resumes the last chat
+# instead of opening a blank one. openclaw and hermes are omitted on purpose: their
+# resume is an in-app picker with no stable non-interactive selector, and --resume
+# already persists their session dir, so their own resume finds the prior sessions.
+_RESUME_LAUNCH_FLAGS = {
+    "claude": ["--continue"],
+    "codex": ["resume", "--last"],
+    "opencode": ["--continue"],
+    "pi": ["--continue"],
+}
+
+
+def _resume_launch_args(agent: str, resume: bool, launch: bool, passthrough) -> list:
+    """Tokens that make a bare `--resume` launch reopen the agent's last session.
+
+    Only a bare interactive launch (``--resume`` set, no passthrough args) gets them:
+    when the caller passes their own subcommand they drive resume themselves, and the
+    --no-launch printout is consumed by drivers that append their own subcommand, so a
+    resume token there would break it. An agent without a mapping returns nothing;
+    --resume still persists its session dir so its own resume works.
+    """
+    if resume and launch and not passthrough:
+        return list(_RESUME_LAUNCH_FLAGS.get(agent, []))
+    return []
 
 
 def _hermes_install_hint() -> str:
@@ -1116,15 +1153,16 @@ def _agents_config_root() -> Path:
 
 
 @contextlib.contextmanager
-def _session_config(agent: str, launch: bool):
+def _session_config(agent: str, launch: bool, persist: bool = False):
     """Yield a private directory for an agent's session config (never the user's own).
 
-    launch: an ephemeral temp dir removed after the agent process exits, so nothing
-    persists. no-launch: a stable Unsloth-owned dir (the printed recipe is run later
-    on this machine), reused across runs. Either way the user's real ~/.<agent>
-    config is left untouched.
+    launch (default): an ephemeral temp dir removed after the agent process exits, so
+    nothing persists. no-launch: a stable Unsloth-owned dir (the printed recipe is run
+    later on this machine), reused across runs. persist (from --resume): use that same
+    stable dir even for a launch, so the agent's session survives the exit and can be
+    resumed next time. Either way the user's real ~/.<agent> config is left untouched.
     """
-    if launch:
+    if launch and not persist:
         path = Path(tempfile.mkdtemp(prefix = f"unsloth-{agent}-"))
         try:
             yield path
@@ -1436,6 +1474,7 @@ def claude(
     tensor_parallel: bool = _TENSOR_PARALLEL_OPTION,
     serve: bool = _SERVE_OPTION,
     yolo: bool = _YOLO_OPTION,
+    resume: bool = _RESUME_OPTION,
 ):
     """Point Claude Code at the running Studio server and start it."""
     base, key, entry = _connect(
@@ -1480,6 +1519,8 @@ def claude(
     # --yolo (or its aliases) maps to Claude's own --dangerously-skip-permissions.
     # IS_SANDBOX is left unset on purpose: Claude refuses bypass mode as root unless a
     # sandbox is detected, and we don't want to falsely claim one on the user's host.
+    # claude keeps its history in ~/.claude/projects, which --settings/env never
+    # relocate, so a session already survives exit; --resume only needs to reopen it.
     command = [
         "claude",
         "--model",
@@ -1487,6 +1528,7 @@ def claude(
         *_claude_flags(),
         *_yolo_command_flags("claude", yolo),
         *ctx.args,
+        *_resume_launch_args("claude", resume, launch, ctx.args),
     ]
     install_hint = (
         "irm https://claude.ai/install.ps1 | iex"
@@ -1516,6 +1558,7 @@ def codex(
     tensor_parallel: bool = _TENSOR_PARALLEL_OPTION,
     serve: bool = _SERVE_OPTION,
     yolo: bool = _YOLO_OPTION,
+    resume: bool = _RESUME_OPTION,
 ):
     """Point OpenAI Codex at the running Studio server and start it."""
     base, key, entry = _connect(
@@ -1540,8 +1583,9 @@ def codex(
         _CODEX_PROFILE,
         *_yolo_command_flags("codex", yolo),
         *ctx.args,
+        *_resume_launch_args("codex", resume, launch, ctx.args),
     ]
-    with _session_config("codex", launch) as home:
+    with _session_config("codex", launch, persist = resume) as home:
         write_codex_config(base, entry, home)
         env = {_CODEX_ENV_KEY: key, "CODEX_HOME": str(home)}
         _run(base, entry, env, command, launch = launch, install_hint = "npm install -g @openai/codex")
@@ -1559,6 +1603,7 @@ def openclaw(
     tensor_parallel: bool = _TENSOR_PARALLEL_OPTION,
     serve: bool = _SERVE_OPTION,
     yolo: bool = _YOLO_OPTION,
+    resume: bool = _RESUME_OPTION,
 ):
     """Point OpenClaw at the running Studio server and start it."""
     base, key, entry = _connect(
@@ -1584,7 +1629,7 @@ def openclaw(
         if os.name == "nt"
         else "curl -fsSL https://openclaw.ai/install.sh | bash"
     )
-    with _session_config("openclaw", launch) as cfg:
+    with _session_config("openclaw", launch, persist = resume) as cfg:
         config_path = cfg / "openclaw.json"
         # key lives in the config, not the env; --yolo writes the exec policy here too.
         write_openclaw_config(base, key, entry, config_path, yolo = yolo)
@@ -1605,6 +1650,7 @@ def opencode(
     tensor_parallel: bool = _TENSOR_PARALLEL_OPTION,
     serve: bool = _SERVE_OPTION,
     yolo: bool = _YOLO_OPTION,
+    resume: bool = _RESUME_OPTION,
 ):
     """Point OpenCode at the running Studio server and start it."""
     base, key, entry = _connect(
@@ -1628,7 +1674,10 @@ def opencode(
         command = ["opencode", "--model", opencode_model]
     else:
         command = ["opencode"]
-    with _session_config("opencode", launch) as cfg:
+    # opencode keeps sessions in ~/.local/share/opencode (never relocated), so resume
+    # already survives exit; a bare --resume just reopens the last one with --continue.
+    command += _resume_launch_args("opencode", resume, launch, ctx.args)
+    with _session_config("opencode", launch, persist = resume) as cfg:
         config_path = cfg / "opencode.json"
         # OPENCODE_CONFIG is an overlay (loaded between the user's global and project
         # configs), so this adds the Unsloth provider/model for the session without
@@ -1680,6 +1729,7 @@ def hermes(
     tensor_parallel: bool = _TENSOR_PARALLEL_OPTION,
     serve: bool = _SERVE_OPTION,
     yolo: bool = _YOLO_OPTION,
+    resume: bool = _RESUME_OPTION,
 ):
     """Point Hermes (Nous Research) at the running Studio server and start it."""
     base, key, entry = _connect(
@@ -1691,7 +1741,7 @@ def hermes(
     )
     command = ["hermes", *_yolo_command_flags("hermes", yolo), *ctx.args]
     install_hint = _hermes_install_hint()
-    with _session_config("hermes", launch) as home:
+    with _session_config("hermes", launch, persist = resume) as home:
         # HERMES_HOME relocates hermes' whole home dir (config.yaml, sessions, state)
         # like CODEX_HOME, so the user's ~/.hermes is left untouched for the session.
         write_hermes_config(base, entry, home / "config.yaml")
@@ -1711,6 +1761,7 @@ def pi(
     tensor_parallel: bool = _TENSOR_PARALLEL_OPTION,
     serve: bool = _SERVE_OPTION,
     yolo: bool = _YOLO_OPTION,
+    resume: bool = _RESUME_OPTION,
 ):
     """Point Pi (coding agent) at the running Studio server and start it."""
     base, key, entry = _connect(
@@ -1731,11 +1782,12 @@ def pi(
         entry["id"],
         *_yolo_command_flags("pi", yolo),
         *ctx.args,
+        *_resume_launch_args("pi", resume, launch, ctx.args),
     ]
     # --ignore-scripts matches Pi's documented install recipe (its README notes Pi needs
     # no install scripts), so accepting the prompt skips dependency lifecycle scripts.
     install_hint = "npm install -g --ignore-scripts @earendil-works/pi-coding-agent"
-    with _session_config("pi", launch) as home:
+    with _session_config("pi", launch, persist = resume) as home:
         # Pi resolves its config dir from PI_CODING_AGENT_DIR first (getAgentDir() prefers
         # it over $HOME/.pi/agent), so pin it at the session dir: an inherited
         # PI_CODING_AGENT_DIR in the user's shell would otherwise send Pi to their real

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -133,14 +133,16 @@ _YOLO_OPTION = typer.Option(
         "flag/config. Any of the three spellings works for any agent."
     ),
 )
-_RESUME_OPTION = typer.Option(
+_PERSIST_OPTION = typer.Option(
     False,
-    "--resume/--no-resume",
+    "--persist/--no-persist",
     help = (
-        "Keep this agent's session so you can resume it later. Without --resume a "
+        "Keep this agent's session so you can resume it later. Without --persist a "
         "launched agent's home is a throwaway temp dir wiped on exit (nothing "
         "persists); with it, the session lives under the Unsloth agents dir (never "
-        "your own ~/.<agent>). A bare `--resume` also reopens the last conversation."
+        "your own ~/.<agent>). A bare `--persist` also reopens the last conversation. "
+        "An agent's own resume flag (e.g. `claude --resume <id>`) still passes through "
+        "unchanged."
     ),
 )
 
@@ -161,10 +163,10 @@ def _yolo_command_flags(agent: str, yolo: bool) -> list:
     return _YOLO_COMMAND_FLAGS.get(agent, []) if yolo else []
 
 
-# Native "reopen the previous session" tokens appended to a BARE `--resume` launch
-# (no passthrough args) so `unsloth start <agent> --resume` resumes the last chat
+# Native "reopen the previous session" tokens appended to a BARE `--persist` launch
+# (no passthrough args) so `unsloth start <agent> --persist` resumes the last chat
 # instead of opening a blank one. openclaw and hermes are omitted on purpose: their
-# resume is an in-app picker with no stable non-interactive selector, and --resume
+# resume is an in-app picker with no stable non-interactive selector, and --persist
 # already persists their session dir, so their own resume finds the prior sessions.
 _RESUME_LAUNCH_FLAGS = {
     "claude": ["--continue"],
@@ -174,16 +176,16 @@ _RESUME_LAUNCH_FLAGS = {
 }
 
 
-def _resume_launch_args(agent: str, resume: bool, launch: bool, passthrough) -> list:
-    """Tokens that make a bare `--resume` launch reopen the agent's last session.
+def _resume_launch_args(agent: str, persist: bool, launch: bool, passthrough) -> list:
+    """Tokens that make a bare `--persist` launch reopen the agent's last session.
 
-    Only a bare interactive launch (``--resume`` set, no passthrough args) gets them:
+    Only a bare interactive launch (``--persist`` set, no passthrough args) gets them:
     when the caller passes their own subcommand they drive resume themselves, and the
     --no-launch printout is consumed by drivers that append their own subcommand, so a
     resume token there would break it. An agent without a mapping returns nothing;
-    --resume still persists its session dir so its own resume works.
+    --persist still persists its session dir so its own resume works.
     """
-    if resume and launch and not passthrough:
+    if persist and launch and not passthrough:
         return list(_RESUME_LAUNCH_FLAGS.get(agent, []))
     return []
 
@@ -1162,7 +1164,7 @@ def _session_config(
 
     launch (default): an ephemeral temp dir removed after the agent process exits, so
     nothing persists. no-launch: a stable Unsloth-owned dir (the printed recipe is run
-    later on this machine), reused across runs. persist (from --resume): use that same
+    later on this machine), reused across runs. persist (from --persist): use that same
     stable dir even for a launch, so the agent's session survives the exit and can be
     resumed next time. Either way the user's real ~/.<agent> config is left untouched.
     """
@@ -1478,7 +1480,7 @@ def claude(
     tensor_parallel: bool = _TENSOR_PARALLEL_OPTION,
     serve: bool = _SERVE_OPTION,
     yolo: bool = _YOLO_OPTION,
-    resume: bool = _RESUME_OPTION,
+    persist: bool = _PERSIST_OPTION,
 ):
     """Point Claude Code at the running Studio server and start it."""
     base, key, entry = _connect(
@@ -1524,7 +1526,7 @@ def claude(
     # IS_SANDBOX is left unset on purpose: Claude refuses bypass mode as root unless a
     # sandbox is detected, and we don't want to falsely claim one on the user's host.
     # claude keeps its history in ~/.claude/projects, which --settings/env never
-    # relocate, so a session already survives exit; --resume only needs to reopen it.
+    # relocate, so a session already survives exit; --persist only needs to reopen it.
     command = [
         "claude",
         "--model",
@@ -1532,7 +1534,7 @@ def claude(
         *_claude_flags(),
         *_yolo_command_flags("claude", yolo),
         *ctx.args,
-        *_resume_launch_args("claude", resume, launch, ctx.args),
+        *_resume_launch_args("claude", persist, launch, ctx.args),
     ]
     install_hint = (
         "irm https://claude.ai/install.ps1 | iex"
@@ -1562,7 +1564,7 @@ def codex(
     tensor_parallel: bool = _TENSOR_PARALLEL_OPTION,
     serve: bool = _SERVE_OPTION,
     yolo: bool = _YOLO_OPTION,
-    resume: bool = _RESUME_OPTION,
+    persist: bool = _PERSIST_OPTION,
 ):
     """Point OpenAI Codex at the running Studio server and start it."""
     base, key, entry = _connect(
@@ -1587,9 +1589,9 @@ def codex(
         _CODEX_PROFILE,
         *_yolo_command_flags("codex", yolo),
         *ctx.args,
-        *_resume_launch_args("codex", resume, launch, ctx.args),
+        *_resume_launch_args("codex", persist, launch, ctx.args),
     ]
-    with _session_config("codex", launch, persist = resume) as home:
+    with _session_config("codex", launch, persist = persist) as home:
         write_codex_config(base, entry, home)
         env = {_CODEX_ENV_KEY: key, "CODEX_HOME": str(home)}
         _run(base, entry, env, command, launch = launch, install_hint = "npm install -g @openai/codex")
@@ -1607,7 +1609,7 @@ def openclaw(
     tensor_parallel: bool = _TENSOR_PARALLEL_OPTION,
     serve: bool = _SERVE_OPTION,
     yolo: bool = _YOLO_OPTION,
-    resume: bool = _RESUME_OPTION,
+    persist: bool = _PERSIST_OPTION,
 ):
     """Point OpenClaw at the running Studio server and start it."""
     base, key, entry = _connect(
@@ -1633,7 +1635,7 @@ def openclaw(
         if os.name == "nt"
         else "curl -fsSL https://openclaw.ai/install.sh | bash"
     )
-    with _session_config("openclaw", launch, persist = resume) as cfg:
+    with _session_config("openclaw", launch, persist = persist) as cfg:
         config_path = cfg / "openclaw.json"
         # key lives in the config, not the env; --yolo writes the exec policy here too.
         write_openclaw_config(base, key, entry, config_path, yolo = yolo)
@@ -1654,7 +1656,7 @@ def opencode(
     tensor_parallel: bool = _TENSOR_PARALLEL_OPTION,
     serve: bool = _SERVE_OPTION,
     yolo: bool = _YOLO_OPTION,
-    resume: bool = _RESUME_OPTION,
+    persist: bool = _PERSIST_OPTION,
 ):
     """Point OpenCode at the running Studio server and start it."""
     base, key, entry = _connect(
@@ -1679,9 +1681,9 @@ def opencode(
     else:
         command = ["opencode"]
     # opencode keeps sessions in ~/.local/share/opencode (never relocated), so resume
-    # already survives exit; a bare --resume just reopens the last one with --continue.
-    command += _resume_launch_args("opencode", resume, launch, ctx.args)
-    with _session_config("opencode", launch, persist = resume) as cfg:
+    # already survives exit; a bare --persist just reopens the last one with --continue.
+    command += _resume_launch_args("opencode", persist, launch, ctx.args)
+    with _session_config("opencode", launch, persist = persist) as cfg:
         config_path = cfg / "opencode.json"
         # OPENCODE_CONFIG is an overlay (loaded between the user's global and project
         # configs), so this adds the Unsloth provider/model for the session without
@@ -1733,7 +1735,7 @@ def hermes(
     tensor_parallel: bool = _TENSOR_PARALLEL_OPTION,
     serve: bool = _SERVE_OPTION,
     yolo: bool = _YOLO_OPTION,
-    resume: bool = _RESUME_OPTION,
+    persist: bool = _PERSIST_OPTION,
 ):
     """Point Hermes (Nous Research) at the running Studio server and start it."""
     base, key, entry = _connect(
@@ -1745,7 +1747,7 @@ def hermes(
     )
     command = ["hermes", *_yolo_command_flags("hermes", yolo), *ctx.args]
     install_hint = _hermes_install_hint()
-    with _session_config("hermes", launch, persist = resume) as home:
+    with _session_config("hermes", launch, persist = persist) as home:
         # HERMES_HOME relocates hermes' whole home dir (config.yaml, sessions, state)
         # like CODEX_HOME, so the user's ~/.hermes is left untouched for the session.
         write_hermes_config(base, entry, home / "config.yaml")
@@ -1765,7 +1767,7 @@ def pi(
     tensor_parallel: bool = _TENSOR_PARALLEL_OPTION,
     serve: bool = _SERVE_OPTION,
     yolo: bool = _YOLO_OPTION,
-    resume: bool = _RESUME_OPTION,
+    persist: bool = _PERSIST_OPTION,
 ):
     """Point Pi (coding agent) at the running Studio server and start it."""
     base, key, entry = _connect(
@@ -1786,12 +1788,12 @@ def pi(
         entry["id"],
         *_yolo_command_flags("pi", yolo),
         *ctx.args,
-        *_resume_launch_args("pi", resume, launch, ctx.args),
+        *_resume_launch_args("pi", persist, launch, ctx.args),
     ]
     # --ignore-scripts matches Pi's documented install recipe (its README notes Pi needs
     # no install scripts), so accepting the prompt skips dependency lifecycle scripts.
     install_hint = "npm install -g --ignore-scripts @earendil-works/pi-coding-agent"
-    with _session_config("pi", launch, persist = resume) as home:
+    with _session_config("pi", launch, persist = persist) as home:
         # Pi resolves its config dir from PI_CODING_AGENT_DIR first (getAgentDir() prefers
         # it over $HOME/.pi/agent), so pin it at the session dir: an inherited
         # PI_CODING_AGENT_DIR in the user's shell would otherwise send Pi to their real

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -2602,23 +2602,30 @@ def test_resume_opencode_config_in_stable_dir(fake_studio, tmp_path, monkeypatch
     assert stable.exists()
 
 
-def test_resume_bare_codex_launch_appends_native_resume(fake_studio, monkeypatch):
+def test_persist_bare_codex_launch_has_no_resume_token(fake_studio, monkeypatch):
+    # A bare `--persist` only persists the session dir; it must NOT auto-append a native
+    # resume token, or the very first launch (no session yet) would send codex down its
+    # no-session error path. The user resumes explicitly: `unsloth start codex --persist resume`.
     monkeypatch.setattr(start.shutil, "which", lambda _: "/usr/local/bin/codex")
     captured = _capture_launch(monkeypatch, ["codex", "--persist"])
-    assert captured["command"][-2:] == ["resume", "--last"]
+    assert "resume" not in captured["command"]
+    # command[0] is the resolved executable path; assert the argv after it.
+    assert captured["command"][1:] == ["--oss", "--profile", start._CODEX_PROFILE]
 
 
-def test_resume_bare_opencode_launch_appends_continue(fake_studio, monkeypatch):
+def test_persist_bare_opencode_launch_has_no_resume_token(fake_studio, monkeypatch):
     monkeypatch.setattr(start.shutil, "which", lambda _: "/usr/local/bin/opencode")
     captured = _capture_launch(monkeypatch, ["opencode", "--persist"])
-    assert captured["command"][-1] == "--continue"
+    assert "--continue" not in captured["command"]
+    assert captured["command"][1:] == ["--model", f"{start._OPENCODE_PROVIDER}/{MODEL['id']}"]
 
 
-def test_resume_bare_claude_launch_appends_continue(fake_studio, monkeypatch):
+def test_persist_bare_claude_launch_has_no_resume_token(fake_studio, monkeypatch):
     monkeypatch.setattr(start.shutil, "which", lambda _: "/usr/local/bin/claude")
     monkeypatch.setattr(start, "_claude_flags", lambda: [])
     captured = _capture_launch(monkeypatch, ["claude", "--persist"])
-    assert "--continue" in captured["command"]
+    assert "--continue" not in captured["command"]
+    assert captured["command"][1:] == ["--model", MODEL["id"]]
 
 
 def test_resume_with_passthrough_does_not_auto_append(fake_studio, monkeypatch):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -2558,7 +2558,11 @@ _RESUME_ENV_VAR = {
 def _capture_launch(monkeypatch, argv):
     captured = {}
 
-    def run(command, env = None, **kwargs):
+    def run(
+        command,
+        env = None,
+        **kwargs,
+    ):
         captured["command"] = command
         captured["env"] = env
         return SimpleNamespace(returncode = 0)

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -2524,9 +2524,9 @@ def test_session_config_no_launch_preserves_existing_state(fake_studio, tmp_path
         assert (home2 / "sessions" / "live.sqlite").read_text() == "state"
 
 
-# ── --resume: persist the agent session so it can be resumed ────────────────
+# ── --persist: persist the agent session so it can be resumed ────────────────
 def test_session_config_persist_uses_stable_dir_and_survives(monkeypatch, tmp_path):
-    # --resume routes a launch to the stable Unsloth agents dir (the one --no-launch
+    # --persist routes a launch to the stable Unsloth agents dir (the one --no-launch
     # already uses) instead of a throwaway temp dir, and never wipes it on exit.
     monkeypatch.setattr(start, "_agents_config_root", lambda: tmp_path / "agents")
     with start._session_config("codex", launch = True, persist = True) as home:
@@ -2537,14 +2537,14 @@ def test_session_config_persist_uses_stable_dir_and_survives(monkeypatch, tmp_pa
 
 
 def test_session_config_default_launch_is_ephemeral():
-    # Default launch (no --resume) still uses a throwaway temp dir wiped on exit.
+    # Default launch (no --persist) still uses a throwaway temp dir wiped on exit.
     with start._session_config("codex", launch = True) as home:
         assert home.exists()
         assert "unsloth-codex-" in home.name
     assert not home.exists()
 
 
-# The temp-dir agents: --resume points each one's home/state env at the stable dir;
+# The temp-dir agents: --persist points each one's home/state env at the stable dir;
 # without it, at an ephemeral temp path. opencode is handled separately (only its
 # config overlay is relocated; its session data was never in the temp dir).
 _RESUME_ENV_VAR = {
@@ -2576,7 +2576,7 @@ def _capture_launch(monkeypatch, argv):
 @pytest.mark.parametrize("agent", sorted(_RESUME_ENV_VAR))
 def test_resume_persists_agent_home_to_stable_dir(agent, fake_studio, tmp_path, monkeypatch):
     monkeypatch.setattr(start.shutil, "which", lambda _: f"/usr/local/bin/{agent}")
-    captured = _capture_launch(monkeypatch, [agent, "--resume"])
+    captured = _capture_launch(monkeypatch, [agent, "--persist"])
     stable = tmp_path / "agents" / agent
     assert captured["env"][_RESUME_ENV_VAR[agent]] == str(stable)
     # The stable dir survives the agent exit, so the session can be resumed.
@@ -2594,9 +2594,9 @@ def test_default_launch_home_is_ephemeral(agent, fake_studio, tmp_path, monkeypa
 
 def test_resume_opencode_config_in_stable_dir(fake_studio, tmp_path, monkeypatch):
     # opencode's session data lives in ~/.local/share/opencode (never relocated), so
-    # resume already survives exit; --resume also stabilizes its config overlay dir.
+    # resume already survives exit; --persist also stabilizes its config overlay dir.
     monkeypatch.setattr(start.shutil, "which", lambda _: "/usr/local/bin/opencode")
-    captured = _capture_launch(monkeypatch, ["opencode", "--resume"])
+    captured = _capture_launch(monkeypatch, ["opencode", "--persist"])
     stable = tmp_path / "agents" / "opencode"
     assert captured["env"]["OPENCODE_CONFIG"] == str(stable / "opencode.json")
     assert stable.exists()
@@ -2604,28 +2604,28 @@ def test_resume_opencode_config_in_stable_dir(fake_studio, tmp_path, monkeypatch
 
 def test_resume_bare_codex_launch_appends_native_resume(fake_studio, monkeypatch):
     monkeypatch.setattr(start.shutil, "which", lambda _: "/usr/local/bin/codex")
-    captured = _capture_launch(monkeypatch, ["codex", "--resume"])
+    captured = _capture_launch(monkeypatch, ["codex", "--persist"])
     assert captured["command"][-2:] == ["resume", "--last"]
 
 
 def test_resume_bare_opencode_launch_appends_continue(fake_studio, monkeypatch):
     monkeypatch.setattr(start.shutil, "which", lambda _: "/usr/local/bin/opencode")
-    captured = _capture_launch(monkeypatch, ["opencode", "--resume"])
+    captured = _capture_launch(monkeypatch, ["opencode", "--persist"])
     assert captured["command"][-1] == "--continue"
 
 
 def test_resume_bare_claude_launch_appends_continue(fake_studio, monkeypatch):
     monkeypatch.setattr(start.shutil, "which", lambda _: "/usr/local/bin/claude")
     monkeypatch.setattr(start, "_claude_flags", lambda: [])
-    captured = _capture_launch(monkeypatch, ["claude", "--resume"])
+    captured = _capture_launch(monkeypatch, ["claude", "--persist"])
     assert "--continue" in captured["command"]
 
 
 def test_resume_with_passthrough_does_not_auto_append(fake_studio, monkeypatch):
-    # When the caller drives their own subcommand, --resume only persists the dir; it
+    # When the caller drives their own subcommand, --persist only persists the dir; it
     # must not inject a resume token that would collide with the user's command.
     monkeypatch.setattr(start.shutil, "which", lambda _: "/usr/local/bin/codex")
-    captured = _capture_launch(monkeypatch, ["codex", "--resume", "exec", "hello"])
+    captured = _capture_launch(monkeypatch, ["codex", "--persist", "exec", "hello"])
     assert "resume" not in captured["command"]
     assert captured["command"][-2:] == ["exec", "hello"]
 
@@ -2638,9 +2638,22 @@ def test_default_launch_has_no_resume_token(fake_studio, monkeypatch):
 
 def test_resume_persist_only_agents_have_no_resume_token(fake_studio, monkeypatch):
     # openclaw/hermes persist their session dir but have no non-interactive resume
-    # selector, so --resume must not append a token; their own picker resumes.
+    # selector, so --persist must not append a token; their own picker resumes.
     for agent in ("openclaw", "hermes"):
         monkeypatch.setattr(start.shutil, "which", lambda _, a = agent: f"/usr/local/bin/{a}")
-        captured = _capture_launch(monkeypatch, [agent, "--resume"])
+        captured = _capture_launch(monkeypatch, [agent, "--persist"])
         assert "resume" not in captured["command"]
         assert "--continue" not in captured["command"]
+
+
+def test_native_resume_flag_passes_through_unchanged(fake_studio, monkeypatch):
+    # The persistence flag is --persist, NOT --resume, so an agent's own
+    # `--resume <id>` (e.g. `unsloth start claude --resume <guid>`) still flows
+    # through to the agent verbatim and is not swallowed as a Studio option.
+    monkeypatch.setattr(start.shutil, "which", lambda _: "/usr/local/bin/claude")
+    monkeypatch.setattr(start, "_claude_flags", lambda: [])
+    captured = _capture_launch(monkeypatch, ["claude", "--resume", "some-session-guid"])
+    assert captured["command"][-2:] == ["--resume", "some-session-guid"]
+    # Studio never auto-appends its own resume token when the user drives resume.
+    assert captured["command"].count("--resume") == 1
+    assert "--continue" not in captured["command"]

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -2522,3 +2522,121 @@ def test_session_config_no_launch_preserves_existing_state(fake_studio, tmp_path
     with start._session_config("codex", launch = False) as home2:
         assert home2 == home
         assert (home2 / "sessions" / "live.sqlite").read_text() == "state"
+
+
+# ── --resume: persist the agent session so it can be resumed ────────────────
+def test_session_config_persist_uses_stable_dir_and_survives(monkeypatch, tmp_path):
+    # --resume routes a launch to the stable Unsloth agents dir (the one --no-launch
+    # already uses) instead of a throwaway temp dir, and never wipes it on exit.
+    monkeypatch.setattr(start, "_agents_config_root", lambda: tmp_path / "agents")
+    with start._session_config("codex", launch = True, persist = True) as home:
+        assert home == tmp_path / "agents" / "codex"
+        (home / "marker").write_text("kept")
+    assert home.exists()
+    assert (home / "marker").read_text() == "kept"
+
+
+def test_session_config_default_launch_is_ephemeral():
+    # Default launch (no --resume) still uses a throwaway temp dir wiped on exit.
+    with start._session_config("codex", launch = True) as home:
+        assert home.exists()
+        assert "unsloth-codex-" in home.name
+    assert not home.exists()
+
+
+# The temp-dir agents: --resume points each one's home/state env at the stable dir;
+# without it, at an ephemeral temp path. opencode is handled separately (only its
+# config overlay is relocated; its session data was never in the temp dir).
+_RESUME_ENV_VAR = {
+    "codex": "CODEX_HOME",
+    "openclaw": "OPENCLAW_STATE_DIR",
+    "hermes": "HERMES_HOME",
+    "pi": "HOME",
+}
+
+
+def _capture_launch(monkeypatch, argv):
+    captured = {}
+
+    def run(command, env = None, **kwargs):
+        captured["command"] = command
+        captured["env"] = env
+        return SimpleNamespace(returncode = 0)
+
+    monkeypatch.setattr(start.subprocess, "run", run)
+    result = CliRunner().invoke(start.start_app, argv)
+    assert result.exit_code == 0, result.output
+    return captured
+
+
+@pytest.mark.parametrize("agent", sorted(_RESUME_ENV_VAR))
+def test_resume_persists_agent_home_to_stable_dir(agent, fake_studio, tmp_path, monkeypatch):
+    monkeypatch.setattr(start.shutil, "which", lambda _: f"/usr/local/bin/{agent}")
+    captured = _capture_launch(monkeypatch, [agent, "--resume"])
+    stable = tmp_path / "agents" / agent
+    assert captured["env"][_RESUME_ENV_VAR[agent]] == str(stable)
+    # The stable dir survives the agent exit, so the session can be resumed.
+    assert stable.exists()
+
+
+@pytest.mark.parametrize("agent", sorted(_RESUME_ENV_VAR))
+def test_default_launch_home_is_ephemeral(agent, fake_studio, tmp_path, monkeypatch):
+    monkeypatch.setattr(start.shutil, "which", lambda _: f"/usr/local/bin/{agent}")
+    captured = _capture_launch(monkeypatch, [agent])
+    home = captured["env"][_RESUME_ENV_VAR[agent]]
+    assert f"unsloth-{agent}-" in home
+    assert str(tmp_path / "agents") not in home
+
+
+def test_resume_opencode_config_in_stable_dir(fake_studio, tmp_path, monkeypatch):
+    # opencode's session data lives in ~/.local/share/opencode (never relocated), so
+    # resume already survives exit; --resume also stabilizes its config overlay dir.
+    monkeypatch.setattr(start.shutil, "which", lambda _: "/usr/local/bin/opencode")
+    captured = _capture_launch(monkeypatch, ["opencode", "--resume"])
+    stable = tmp_path / "agents" / "opencode"
+    assert captured["env"]["OPENCODE_CONFIG"] == str(stable / "opencode.json")
+    assert stable.exists()
+
+
+def test_resume_bare_codex_launch_appends_native_resume(fake_studio, monkeypatch):
+    monkeypatch.setattr(start.shutil, "which", lambda _: "/usr/local/bin/codex")
+    captured = _capture_launch(monkeypatch, ["codex", "--resume"])
+    assert captured["command"][-2:] == ["resume", "--last"]
+
+
+def test_resume_bare_opencode_launch_appends_continue(fake_studio, monkeypatch):
+    monkeypatch.setattr(start.shutil, "which", lambda _: "/usr/local/bin/opencode")
+    captured = _capture_launch(monkeypatch, ["opencode", "--resume"])
+    assert captured["command"][-1] == "--continue"
+
+
+def test_resume_bare_claude_launch_appends_continue(fake_studio, monkeypatch):
+    monkeypatch.setattr(start.shutil, "which", lambda _: "/usr/local/bin/claude")
+    monkeypatch.setattr(start, "_claude_flags", lambda: [])
+    captured = _capture_launch(monkeypatch, ["claude", "--resume"])
+    assert "--continue" in captured["command"]
+
+
+def test_resume_with_passthrough_does_not_auto_append(fake_studio, monkeypatch):
+    # When the caller drives their own subcommand, --resume only persists the dir; it
+    # must not inject a resume token that would collide with the user's command.
+    monkeypatch.setattr(start.shutil, "which", lambda _: "/usr/local/bin/codex")
+    captured = _capture_launch(monkeypatch, ["codex", "--resume", "exec", "hello"])
+    assert "resume" not in captured["command"]
+    assert captured["command"][-2:] == ["exec", "hello"]
+
+
+def test_default_launch_has_no_resume_token(fake_studio, monkeypatch):
+    monkeypatch.setattr(start.shutil, "which", lambda _: "/usr/local/bin/codex")
+    captured = _capture_launch(monkeypatch, ["codex"])
+    assert "resume" not in captured["command"]
+
+
+def test_resume_persist_only_agents_have_no_resume_token(fake_studio, monkeypatch):
+    # openclaw/hermes persist their session dir but have no non-interactive resume
+    # selector, so --resume must not append a token; their own picker resumes.
+    for agent in ("openclaw", "hermes"):
+        monkeypatch.setattr(start.shutil, "which", lambda _, a = agent: f"/usr/local/bin/{a}")
+        captured = _capture_launch(monkeypatch, [agent, "--resume"])
+        assert "resume" not in captured["command"]
+        assert "--continue" not in captured["command"]


### PR DESCRIPTION
## What

`unsloth start <agent>` launches a coding agent pointed at a served model. An interactive launch puts the agent's home in a throwaway temp dir that is deleted on exit, so nothing persists. Four of the agents relocate their WHOLE home there, which silently makes their conversations non-resumable:

| Agent | Launch-path session store | Resume today |
| --- | --- | --- |
| codex, openclaw, hermes, pi | whole home relocated to a temp dir wiped on exit | broken |
| opencode, claude | session data stays in a fixed user dir | works |

There was no `--resume` on `unsloth start`, and even passing the agent's own resume flag failed for the four temp-dir agents because their session store was already gone.

## Change

Add an opt-in `--resume/--no-resume` flag (default off):

- It routes the launch to the stable Unsloth agents dir (the same one `--no-launch` already uses) instead of a temp dir, so the session survives the exit. State lives under the Unsloth-owned agents dir, never the user's own `~/.<agent>`.
- A bare `--resume` (no passthrough subcommand) also reopens the last conversation via the agent's native selector: codex `resume --last`, opencode/claude/pi `--continue`. openclaw/hermes persist only, so their own in-app picker resumes.
- The default path is unchanged: a plain launch still uses a temp dir and persists nothing, so the current privacy behavior is preserved.

The core is a small addition to `_session_config` (a `persist` parameter that reuses the existing stable-dir branch) plus the per-command `--resume` option and the bare-launch native-resume mapping.

## Tests

`unsloth_cli/tests/test_start.py` gains unit coverage (runs on Linux, no agent installed):

- `_session_config(persist=True)` yields the stable dir and does not wipe it; the default yields a temp dir removed on exit.
- Each temp-dir agent's home env var points under the Unsloth agents dir with `--resume`, at a temp path without it.
- A bare `--resume` appends the native resume token; `--resume` with an explicit subcommand does not.

## CI

Adds a dispatch-only `resume` job to Local Agent Guides CI that drives the real launch path and asserts the split end to end: codex/pi are `WIPED` without `--resume` and `PERSISTED` with it, opencode/claude are `PERSISTED` either way. openclaw/hermes share codex's relocation mechanism and are covered by the unit tests.

## Usage

```
unsloth start codex --resume              # reopen your last codex session
unsloth start opencode --resume run ...   # persist the session, drive resume yourself
```