### PR TITLE
Studio /v1/messages: accept thinking and unknown content blocks

### DIFF
--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -1533,12 +1533,42 @@ class AnthropicToolResultBlock(BaseModel):
     tool_use_id: str
     content: Union[str, list] = ""
 
+    @field_validator("content", mode = "before")
+    @classmethod
+    def _coerce_null_content(cls, v):
+        # Some clients emit a null content for an empty tool result; the str|list
+        # union would 400 on it, so treat null as the empty string.
+        return "" if v is None else v
+
+
+# Block types Studio translates explicitly. Anything else -- Claude's `thinking`
+# / `redacted_thinking`, a provider-specific block a resumed session replays, or a
+# future block type -- is accepted verbatim as an unknown block and dropped by the
+# converter (anthropic_messages_to_openai ignores types it doesn't translate),
+# instead of the whole request 400-ing on strict validation.
+_KNOWN_ANTHROPIC_BLOCK_TYPES = frozenset({"text", "image", "tool_use", "tool_result"})
+
+
+class AnthropicUnknownBlock(BaseModel):
+    type: str
+    model_config = {"extra": "allow"}
+
+    @field_validator("type")
+    @classmethod
+    def _only_unknown_types(cls, v):
+        # A known type must parse as its typed model above (so a malformed known
+        # block still fails cleanly); this fallback only catches the rest.
+        if v in _KNOWN_ANTHROPIC_BLOCK_TYPES:
+            raise ValueError("known block type handled by its typed model")
+        return v
+
 
 AnthropicContentBlock = Union[
     AnthropicTextBlock,
     AnthropicImageBlock,
     AnthropicToolUseBlock,
     AnthropicToolResultBlock,
+    AnthropicUnknownBlock,
 ]
 
 
@@ -1582,6 +1612,14 @@ def _merge_anthropic_system(system: Any, additions: list[str]) -> Any:
 class AnthropicMessage(BaseModel):
     role: Literal["user", "assistant"]
     content: Union[str, list[AnthropicContentBlock]]
+
+    @field_validator("content", mode = "before")
+    @classmethod
+    def _coerce_null_content(cls, v):
+        # An assistant tool-only turn a resumed session replays can carry null
+        # content; the str|list union would 400 on it. An empty string is the
+        # neutral equivalent and keeps the converter's `for block in content` safe.
+        return "" if v is None else v
 
 
 class AnthropicTool(BaseModel):

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -1632,13 +1632,21 @@ class AnthropicMessage(BaseModel):
             return data
         content = data.get("content")
         if data.get("role") == "assistant":
-            return {**data, "content": ""} if content is None else data
+            # Coerce only an explicit null (a resumed tool-only turn serializes
+            # its content as null). A missing content key stays malformed so the
+            # required-field check still 400s instead of silently becoming "".
+            if "content" in data and content is None:
+                return {**data, "content": ""}
+            return data
         if isinstance(content, list):
             for block in content:
                 btype = (
                     block.get("type") if isinstance(block, dict) else getattr(block, "type", None)
                 )
-                if btype not in _KNOWN_ANTHROPIC_BLOCK_TYPES:
+                # Compare as a plain value: a non-string type (list / dict) is
+                # unsupported too, and a membership test on an unhashable value
+                # would raise TypeError and escape as a 500 instead of a clean 400.
+                if not isinstance(btype, str) or btype not in _KNOWN_ANTHROPIC_BLOCK_TYPES:
                     raise ValueError(f"unsupported content block type {btype!r} in a user message")
         return data
 

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -1635,11 +1635,11 @@ class AnthropicMessage(BaseModel):
             return {**data, "content": ""} if content is None else data
         if isinstance(content, list):
             for block in content:
-                btype = block.get("type") if isinstance(block, dict) else getattr(block, "type", None)
+                btype = (
+                    block.get("type") if isinstance(block, dict) else getattr(block, "type", None)
+                )
                 if btype not in _KNOWN_ANTHROPIC_BLOCK_TYPES:
-                    raise ValueError(
-                        f"unsupported content block type {btype!r} in a user message"
-                    )
+                    raise ValueError(f"unsupported content block type {btype!r} in a user message")
         return data
 
 

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -1536,16 +1536,15 @@ class AnthropicToolResultBlock(BaseModel):
     @field_validator("content", mode = "before")
     @classmethod
     def _coerce_null_content(cls, v):
-        # Some clients emit a null content for an empty tool result; the str|list
-        # union would 400 on it, so treat null as the empty string.
+        # Some clients send null content for an empty tool result; the str|list
+        # union would 400 on it, so treat null as "".
         return "" if v is None else v
 
 
-# Block types Studio translates explicitly. Anything else -- Claude's `thinking`
-# / `redacted_thinking`, a provider-specific block a resumed session replays, or a
-# future block type -- is accepted verbatim as an unknown block and dropped by the
-# converter (anthropic_messages_to_openai ignores types it doesn't translate),
-# instead of the whole request 400-ing on strict validation.
+# Block types the converter translates explicitly. Anything else (thinking /
+# redacted_thinking, a provider block a resumed session replays, or a future type)
+# is accepted as an unknown block and dropped by the converter, rather than 400-ing
+# the whole request on strict validation.
 _KNOWN_ANTHROPIC_BLOCK_TYPES = frozenset({"text", "image", "tool_use", "tool_result"})
 
 
@@ -1556,8 +1555,8 @@ class AnthropicUnknownBlock(BaseModel):
     @field_validator("type")
     @classmethod
     def _only_unknown_types(cls, v):
-        # A known type must parse as its typed model above (so a malformed known
-        # block still fails cleanly); this fallback only catches the rest.
+        # Known types parse as their typed models above (so a malformed known block
+        # still fails cleanly); this fallback only catches the rest.
         if v in _KNOWN_ANTHROPIC_BLOCK_TYPES:
             raise ValueError("known block type handled by its typed model")
         return v
@@ -1616,25 +1615,22 @@ class AnthropicMessage(BaseModel):
     @model_validator(mode = "before")
     @classmethod
     def _normalize_content(cls, data):
-        # Leniency is role-aware so it never silently drops real user input:
-        #  - assistant: a resumed tool-only turn can carry null content -> "" (the
-        #    str|list union would 400 on null; "" is the neutral equivalent and
-        #    keeps the converter's `for block in content` safe). Unknown blocks
-        #    (thinking / redacted_thinking / future types) validate via
+        # Role-aware leniency that never silently drops real user input:
+        #  - assistant: a resumed tool-only turn's null content -> "" (str|list would
+        #    400 on null; "" keeps the converter's `for block in content` safe).
+        #    Unknown blocks (thinking / future types) validate via
         #    AnthropicUnknownBlock and are dropped by the converter.
-        #  - user: keep the boundary strict. A null user content is malformed, so
-        #    leave it None for the str|list field to reject (400) instead of
-        #    forwarding an empty prompt; and reject any block type the converter
-        #    cannot translate. anthropic_messages_to_openai silently skips unknown
-        #    user blocks, so a user turn made only of them would otherwise validate
-        #    yet send the model no user content at all (silent data loss).
+        #  - user: keep strict. Null user content stays None so str|list rejects it
+        #    (400) rather than forwarding an empty prompt; and reject block types the
+        #    converter cannot translate, since it silently skips unknown user blocks
+        #    -- a user turn made only of them would validate yet send no content
+        #    (silent data loss).
         if not isinstance(data, dict):
             return data
         content = data.get("content")
         if data.get("role") == "assistant":
-            # Coerce only an explicit null (a resumed tool-only turn serializes
-            # its content as null). A missing content key stays malformed so the
-            # required-field check still 400s instead of silently becoming "".
+            # Coerce only an explicit null (resumed tool-only turn). A missing
+            # content key stays malformed so the required-field check still 400s.
             if "content" in data and content is None:
                 return {**data, "content": ""}
             return data
@@ -1643,9 +1639,9 @@ class AnthropicMessage(BaseModel):
                 btype = (
                     block.get("type") if isinstance(block, dict) else getattr(block, "type", None)
                 )
-                # Compare as a plain value: a non-string type (list / dict) is
-                # unsupported too, and a membership test on an unhashable value
-                # would raise TypeError and escape as a 500 instead of a clean 400.
+                # Guard the value: a non-string type is unsupported too, and a
+                # membership test on an unhashable value would raise TypeError
+                # (escaping as a 500 instead of a clean 400).
                 if not isinstance(btype, str) or btype not in _KNOWN_ANTHROPIC_BLOCK_TYPES:
                     raise ValueError(f"unsupported content block type {btype!r} in a user message")
         return data

--- a/studio/backend/models/inference.py
+++ b/studio/backend/models/inference.py
@@ -1613,13 +1613,34 @@ class AnthropicMessage(BaseModel):
     role: Literal["user", "assistant"]
     content: Union[str, list[AnthropicContentBlock]]
 
-    @field_validator("content", mode = "before")
+    @model_validator(mode = "before")
     @classmethod
-    def _coerce_null_content(cls, v):
-        # An assistant tool-only turn a resumed session replays can carry null
-        # content; the str|list union would 400 on it. An empty string is the
-        # neutral equivalent and keeps the converter's `for block in content` safe.
-        return "" if v is None else v
+    def _normalize_content(cls, data):
+        # Leniency is role-aware so it never silently drops real user input:
+        #  - assistant: a resumed tool-only turn can carry null content -> "" (the
+        #    str|list union would 400 on null; "" is the neutral equivalent and
+        #    keeps the converter's `for block in content` safe). Unknown blocks
+        #    (thinking / redacted_thinking / future types) validate via
+        #    AnthropicUnknownBlock and are dropped by the converter.
+        #  - user: keep the boundary strict. A null user content is malformed, so
+        #    leave it None for the str|list field to reject (400) instead of
+        #    forwarding an empty prompt; and reject any block type the converter
+        #    cannot translate. anthropic_messages_to_openai silently skips unknown
+        #    user blocks, so a user turn made only of them would otherwise validate
+        #    yet send the model no user content at all (silent data loss).
+        if not isinstance(data, dict):
+            return data
+        content = data.get("content")
+        if data.get("role") == "assistant":
+            return {**data, "content": ""} if content is None else data
+        if isinstance(content, list):
+            for block in content:
+                btype = block.get("type") if isinstance(block, dict) else getattr(block, "type", None)
+                if btype not in _KNOWN_ANTHROPIC_BLOCK_TYPES:
+                    raise ValueError(
+                        f"unsupported content block type {btype!r} in a user message"
+                    )
+        return data
 
 
 class AnthropicTool(BaseModel):

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -10088,10 +10088,9 @@ async def anthropic_count_tokens(
     # Apply the same sanitization /messages does before generation, so the count
     # matches the prompt the real request would build (otherwise empty-assistant
     # sentinels / synthetic tool history inflate the count or hit the fallback).
-    # Coalesce the adjacent user turns that dropping an empty / null assistant
-    # turn can leave behind, so a strict GGUF chat template does not 400 on
-    # non-alternating roles (mirrors the GGUF chat path); a no-op for histories
-    # that are already alternating.
+    # Coalesce adjacent user turns left behind by dropping an empty / null assistant
+    # turn, so a strict GGUF chat template does not 400 on non-alternating roles
+    # (mirrors the GGUF chat path); a no-op for already-alternating histories.
     openai_messages = _coalesce_consecutive_user_turns(
         _strip_provider_synthetic_tool_history(_drop_empty_assistant_sentinels(openai_messages))
     )
@@ -10221,10 +10220,9 @@ async def anthropic_messages(
     # builders apply the same strip; without it an Anthropic /v1/messages caller
     # replaying a prior provider-side tool_use forwards fake builtin tool
     # history to a backend with no matching function declarations.
-    # Coalesce the adjacent user turns that dropping an empty / null assistant
-    # turn can leave behind, so a strict GGUF chat template does not 400 on
-    # non-alternating roles (mirrors the GGUF chat path); a no-op for histories
-    # that are already alternating.
+    # Coalesce adjacent user turns left behind by dropping an empty / null assistant
+    # turn, so a strict GGUF chat template does not 400 on non-alternating roles
+    # (mirrors the GGUF chat path); a no-op for already-alternating histories.
     openai_messages = _coalesce_consecutive_user_turns(
         _strip_provider_synthetic_tool_history(_drop_empty_assistant_sentinels(openai_messages))
     )

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -10093,9 +10093,7 @@ async def anthropic_count_tokens(
     # non-alternating roles (mirrors the GGUF chat path); a no-op for histories
     # that are already alternating.
     openai_messages = _coalesce_consecutive_user_turns(
-        _strip_provider_synthetic_tool_history(
-            _drop_empty_assistant_sentinels(openai_messages)
-        )
+        _strip_provider_synthetic_tool_history(_drop_empty_assistant_sentinels(openai_messages))
     )
     openai_tools = anthropic_tools_to_openai(payload.tools or []) or None
 
@@ -10228,9 +10226,7 @@ async def anthropic_messages(
     # non-alternating roles (mirrors the GGUF chat path); a no-op for histories
     # that are already alternating.
     openai_messages = _coalesce_consecutive_user_turns(
-        _strip_provider_synthetic_tool_history(
-            _drop_empty_assistant_sentinels(openai_messages)
-        )
+        _strip_provider_synthetic_tool_history(_drop_empty_assistant_sentinels(openai_messages))
     )
 
     # Enforce vision guard + re-encode embedded images to PNG so the Anthropic

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -10088,8 +10088,14 @@ async def anthropic_count_tokens(
     # Apply the same sanitization /messages does before generation, so the count
     # matches the prompt the real request would build (otherwise empty-assistant
     # sentinels / synthetic tool history inflate the count or hit the fallback).
-    openai_messages = _strip_provider_synthetic_tool_history(
-        _drop_empty_assistant_sentinels(openai_messages)
+    # Coalesce the adjacent user turns that dropping an empty / null assistant
+    # turn can leave behind, so a strict GGUF chat template does not 400 on
+    # non-alternating roles (mirrors the GGUF chat path); a no-op for histories
+    # that are already alternating.
+    openai_messages = _coalesce_consecutive_user_turns(
+        _strip_provider_synthetic_tool_history(
+            _drop_empty_assistant_sentinels(openai_messages)
+        )
     )
     openai_tools = anthropic_tools_to_openai(payload.tools or []) or None
 
@@ -10217,8 +10223,14 @@ async def anthropic_messages(
     # builders apply the same strip; without it an Anthropic /v1/messages caller
     # replaying a prior provider-side tool_use forwards fake builtin tool
     # history to a backend with no matching function declarations.
-    openai_messages = _strip_provider_synthetic_tool_history(
-        _drop_empty_assistant_sentinels(openai_messages)
+    # Coalesce the adjacent user turns that dropping an empty / null assistant
+    # turn can leave behind, so a strict GGUF chat template does not 400 on
+    # non-alternating roles (mirrors the GGUF chat path); a no-op for histories
+    # that are already alternating.
+    openai_messages = _coalesce_consecutive_user_turns(
+        _strip_provider_synthetic_tool_history(
+            _drop_empty_assistant_sentinels(openai_messages)
+        )
     )
 
     # Enforce vision guard + re-encode embedded images to PNG so the Anthropic

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -1907,6 +1907,7 @@ def test_assistant_missing_content_key_still_rejected():
     # turn). An assistant message that omits content entirely stays malformed and
     # must still fail required-field validation, not be silently coerced to "".
     from pydantic import ValidationError
+
     with pytest.raises(ValidationError):
         AnthropicMessagesRequest(
             model = "x",

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -1886,3 +1886,77 @@ def test_user_malformed_known_block_still_rejected():
                 {"role": "user", "content": [{"type": "tool_result", "content": "x"}]},
             ],
         )
+
+
+def test_user_content_block_non_string_type_rejected_cleanly():
+    # A malformed user block whose `type` is a non-string (unhashable list / dict,
+    # or a stray int) must fail as a clean validation error -> 400, not raise
+    # TypeError from the frozenset membership test and escape as a 500.
+    from pydantic import ValidationError
+    for bad_type in ([], {}, 5):
+        with pytest.raises(ValidationError):
+            AnthropicMessagesRequest(
+                model = "x",
+                max_tokens = 16,
+                messages = [{"role": "user", "content": [{"type": bad_type}]}],
+            )
+
+
+def test_assistant_missing_content_key_still_rejected():
+    # The null -> "" leniency is only for an EXPLICIT null (a resumed tool-only
+    # turn). An assistant message that omits content entirely stays malformed and
+    # must still fail required-field validation, not be silently coerced to "".
+    from pydantic import ValidationError
+    with pytest.raises(ValidationError):
+        AnthropicMessagesRequest(
+            model = "x",
+            max_tokens = 16,
+            messages = [{"role": "assistant"}],
+        )
+    # An explicit null is still accepted and coerced (regression guard).
+    req = AnthropicMessagesRequest(
+        model = "x",
+        max_tokens = 16,
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": None},
+        ],
+    )
+    assert req.messages[1].content == ""
+
+
+def test_resumed_null_assistant_between_users_coalesced_on_messages_route(monkeypatch):
+    # user -> assistant(content: null) -> user is now accepted: the null assistant
+    # turn coerces to "" and is dropped. The /v1/messages route must then coalesce
+    # the two remaining user turns so a strict GGUF chat template does not 400 on
+    # non-alternating roles.
+    backend = _mock_backend(monkeypatch, context_length = 2048)
+
+    class _Req:
+        state = SimpleNamespace()
+        url = SimpleNamespace(path = "/v1/messages")
+        method = "POST"
+
+        async def is_disconnected(self):
+            return False
+
+    payload = AnthropicMessagesRequest(
+        model = "x",
+        max_tokens = 16,
+        messages = [
+            {"role": "user", "content": "first question"},
+            {"role": "assistant", "content": None},
+            {"role": "user", "content": "please continue"},
+        ],
+    )
+
+    response = _drive(anthropic_messages(payload, request = _Req(), current_subject = "t"))
+    assert response.status_code == 200
+
+    [(_path, kwargs)] = backend.calls
+    user_turns = [m for m in kwargs["messages"] if m.get("role") == "user"]
+    assert len(user_turns) == 1  # the two user turns were merged, not left adjacent
+    merged = user_turns[0]["content"]
+    if isinstance(merged, list):
+        merged = " ".join(p.get("text", "") for p in merged if isinstance(p, dict))
+    assert "first question" in merged and "please continue" in merged

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -1773,9 +1773,8 @@ class TestAnthropicMessagesToolRouting:
 
 
 def test_resumed_session_thinking_and_null_content_do_not_400():
-    # A resumed Claude session replays assistant turns containing `thinking`
-    # (and sometimes null) content. Those must be accepted (and the thinking
-    # dropped by the converter), not rejected with a 400 on messages[n].content.
+    # A resumed session replays assistant turns with `thinking` (and sometimes null)
+    # content. Those must be accepted (thinking dropped by the converter), not 400ed.
     from pydantic import ValidationError
 
     req = AnthropicMessagesRequest(
@@ -1814,9 +1813,8 @@ def test_resumed_session_thinking_and_null_content_do_not_400():
 
 
 def test_user_null_content_rejected():
-    # The null->"" leniency is assistant-only. A malformed user turn with null
-    # content must be rejected at the boundary, not coerced into an empty prompt
-    # and forwarded to the model.
+    # The null->"" leniency is assistant-only; a null user content must be rejected
+    # at the boundary, not coerced into an empty prompt and forwarded to the model.
     from pydantic import ValidationError
     with pytest.raises(ValidationError):
         AnthropicMessagesRequest(
@@ -1827,10 +1825,9 @@ def test_user_null_content_rejected():
 
 
 def test_user_unknown_block_rejected_not_silently_dropped():
-    # anthropic_messages_to_openai skips user blocks it cannot translate, so a
-    # user turn whose only block is unknown/future would validate yet forward no
-    # user content at all. Reject it at the boundary instead of that silent
-    # data loss (the assistant fallback is unaffected).
+    # The converter skips user blocks it cannot translate, so a user turn whose only
+    # block is unknown would validate yet forward no content. Reject at the boundary
+    # to avoid that silent data loss (the assistant fallback is unaffected).
     from pydantic import ValidationError
     with pytest.raises(ValidationError):
         AnthropicMessagesRequest(
@@ -1843,9 +1840,8 @@ def test_user_unknown_block_rejected_not_silently_dropped():
 
 
 def test_user_translatable_blocks_still_accepted():
-    # text / image / tool_result are the block types the converter translates for
-    # a user turn, so a real user message built from them must still pass; the
-    # unknown-block guard only trips on other types.
+    # text / image / tool_result are translatable, so a real user message built from
+    # them must still pass; the unknown-block guard only trips on other types.
     req = AnthropicMessagesRequest(
         model = "x",
         max_tokens = 16,
@@ -1874,9 +1870,8 @@ def test_user_translatable_blocks_still_accepted():
 
 
 def test_user_malformed_known_block_still_rejected():
-    # The role-aware guard only allow-lists a user block's *type*; the union
-    # still validates its shape, so a known-but-malformed user block (tool_result
-    # without tool_use_id) still fails strict validation.
+    # The guard only allow-lists a user block's *type*; the union still validates its
+    # shape, so a known-but-malformed block (tool_result without tool_use_id) fails.
     from pydantic import ValidationError
     with pytest.raises(ValidationError):
         AnthropicMessagesRequest(
@@ -1889,9 +1884,9 @@ def test_user_malformed_known_block_still_rejected():
 
 
 def test_user_content_block_non_string_type_rejected_cleanly():
-    # A malformed user block whose `type` is a non-string (unhashable list / dict,
-    # or a stray int) must fail as a clean validation error -> 400, not raise
-    # TypeError from the frozenset membership test and escape as a 500.
+    # A user block whose `type` is a non-string (unhashable list / dict, or a stray
+    # int) must fail as a clean validation error, not raise TypeError from the
+    # frozenset membership test and escape as a 500.
     from pydantic import ValidationError
     for bad_type in ([], {}, 5):
         with pytest.raises(ValidationError):
@@ -1903,9 +1898,8 @@ def test_user_content_block_non_string_type_rejected_cleanly():
 
 
 def test_assistant_missing_content_key_still_rejected():
-    # The null -> "" leniency is only for an EXPLICIT null (a resumed tool-only
-    # turn). An assistant message that omits content entirely stays malformed and
-    # must still fail required-field validation, not be silently coerced to "".
+    # The null -> "" leniency is only for an EXPLICIT null. An assistant message that
+    # omits content entirely stays malformed and must fail required-field validation.
     from pydantic import ValidationError
 
     with pytest.raises(ValidationError):
@@ -1927,10 +1921,9 @@ def test_assistant_missing_content_key_still_rejected():
 
 
 def test_resumed_null_assistant_between_users_coalesced_on_messages_route(monkeypatch):
-    # user -> assistant(content: null) -> user is now accepted: the null assistant
-    # turn coerces to "" and is dropped. The /v1/messages route must then coalesce
-    # the two remaining user turns so a strict GGUF chat template does not 400 on
-    # non-alternating roles.
+    # user -> assistant(null) -> user is now accepted: the null assistant turn coerces
+    # to "" and is dropped. The route must then coalesce the two remaining user turns
+    # so a strict GGUF chat template does not 400 on non-alternating roles.
     backend = _mock_backend(monkeypatch, context_length = 2048)
 
     class _Req:

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -1770,3 +1770,44 @@ class TestAnthropicMessagesToolRouting:
 
         _drive(anthropic_messages(payload, request = None, current_subject = "t"))
         assert backend.calls[0][0] == "plain"
+
+
+def test_resumed_session_thinking_and_null_content_do_not_400():
+    # A resumed Claude session replays assistant turns containing `thinking`
+    # (and sometimes null) content. Those must be accepted (and the thinking
+    # dropped by the converter), not rejected with a 400 on messages[n].content.
+    from pydantic import ValidationError
+
+    req = AnthropicMessagesRequest(
+        model = "x",
+        max_tokens = 16,
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "secret reasoning", "signature": "s"},
+                    {"type": "text", "text": "the answer"},
+                    {"type": "tool_use", "id": "t1", "name": "f", "input": {}},
+                ],
+            },
+            {"role": "assistant", "content": None},  # tool-only turn serialized as null
+        ],
+    )
+    # Known blocks still parse as their typed models; only the unknown one is loose.
+    assert type(req.messages[1].content[0]).__name__ == "AnthropicUnknownBlock"
+    assert type(req.messages[1].content[1]).__name__ == "AnthropicTextBlock"
+    assert req.messages[2].content == ""  # null coerced
+
+    openai = anthropic_messages_to_openai([m.model_dump() for m in req.messages])
+    assistant = next(m for m in openai if m["role"] == "assistant" and m.get("content"))
+    assert assistant["content"] == "the answer"
+    assert "secret reasoning" not in json.dumps(openai)  # thinking never forwarded
+
+    # A malformed KNOWN block still fails cleanly instead of being swallowed.
+    with pytest.raises(ValidationError):
+        AnthropicMessagesRequest(
+            model = "x",
+            max_tokens = 16,
+            messages = [{"role": "assistant", "content": [{"type": "tool_use", "name": "f"}]}],
+        )

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -1818,7 +1818,6 @@ def test_user_null_content_rejected():
     # content must be rejected at the boundary, not coerced into an empty prompt
     # and forwarded to the model.
     from pydantic import ValidationError
-
     with pytest.raises(ValidationError):
         AnthropicMessagesRequest(
             model = "x",
@@ -1833,7 +1832,6 @@ def test_user_unknown_block_rejected_not_silently_dropped():
     # user content at all. Reject it at the boundary instead of that silent
     # data loss (the assistant fallback is unaffected).
     from pydantic import ValidationError
-
     with pytest.raises(ValidationError):
         AnthropicMessagesRequest(
             model = "x",
@@ -1880,7 +1878,6 @@ def test_user_malformed_known_block_still_rejected():
     # still validates its shape, so a known-but-malformed user block (tool_result
     # without tool_use_id) still fails strict validation.
     from pydantic import ValidationError
-
     with pytest.raises(ValidationError):
         AnthropicMessagesRequest(
             model = "x",

--- a/studio/backend/tests/test_anthropic_messages.py
+++ b/studio/backend/tests/test_anthropic_messages.py
@@ -1811,3 +1811,81 @@ def test_resumed_session_thinking_and_null_content_do_not_400():
             max_tokens = 16,
             messages = [{"role": "assistant", "content": [{"type": "tool_use", "name": "f"}]}],
         )
+
+
+def test_user_null_content_rejected():
+    # The null->"" leniency is assistant-only. A malformed user turn with null
+    # content must be rejected at the boundary, not coerced into an empty prompt
+    # and forwarded to the model.
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        AnthropicMessagesRequest(
+            model = "x",
+            max_tokens = 16,
+            messages = [{"role": "user", "content": None}],
+        )
+
+
+def test_user_unknown_block_rejected_not_silently_dropped():
+    # anthropic_messages_to_openai skips user blocks it cannot translate, so a
+    # user turn whose only block is unknown/future would validate yet forward no
+    # user content at all. Reject it at the boundary instead of that silent
+    # data loss (the assistant fallback is unaffected).
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        AnthropicMessagesRequest(
+            model = "x",
+            max_tokens = 16,
+            messages = [
+                {"role": "user", "content": [{"type": "document", "source": {}}]},
+            ],
+        )
+
+
+def test_user_translatable_blocks_still_accepted():
+    # text / image / tool_result are the block types the converter translates for
+    # a user turn, so a real user message built from them must still pass; the
+    # unknown-block guard only trips on other types.
+    req = AnthropicMessagesRequest(
+        model = "x",
+        max_tokens = 16,
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What is this?"},
+                    {
+                        "type": "image",
+                        "source": {"type": "base64", "media_type": "image/png", "data": "AA"},
+                    },
+                    {"type": "tool_result", "tool_use_id": "t1", "content": "ok"},
+                ],
+            }
+        ],
+    )
+    assert [type(b).__name__ for b in req.messages[0].content] == [
+        "AnthropicTextBlock",
+        "AnthropicImageBlock",
+        "AnthropicToolResultBlock",
+    ]
+
+    openai = anthropic_messages_to_openai([m.model_dump() for m in req.messages])
+    assert any(m["role"] == "tool" and m["tool_call_id"] == "t1" for m in openai)
+
+
+def test_user_malformed_known_block_still_rejected():
+    # The role-aware guard only allow-lists a user block's *type*; the union
+    # still validates its shape, so a known-but-malformed user block (tool_result
+    # without tool_use_id) still fails strict validation.
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        AnthropicMessagesRequest(
+            model = "x",
+            max_tokens = 16,
+            messages = [
+                {"role": "user", "content": [{"type": "tool_result", "content": "x"}]},
+            ],
+        )


### PR DESCRIPTION
## Problem

Resuming a Claude Code session against Studio fails with:

```
API Error: 400 messages.1.content.str: Input should be a valid string
```

The Anthropic-compatible `/v1/messages` endpoint models a message's `content` as `Union[str, list[{text | image | tool_use | tool_result}]]` (`studio/backend/models/inference.py`). Any other block type makes Pydantic reject the whole request. A resumed session almost always replays assistant turns that carry **`thinking`** (extended thinking) blocks, and sometimes a **`null`** content for a tool-only turn; both trip this and return a 400. The `...content.str` in the message is just the first half of the union error. Reproduced against the model: a `thinking` block, `null`, and a bare block dict each produce that exact error, while a plain text list passes.

## Fix

- Add a permissive `AnthropicUnknownBlock` fallback to the content-block union: any block whose `type` is not one of the four known ones (`text`/`image`/`tool_use`/`tool_result`) is accepted verbatim. A `type` validator rejects the known types in the fallback, so a known block still parses as its typed model and a malformed known block (e.g. a `tool_use` missing `id`) still 400s cleanly instead of being swallowed.
- Coerce a `null` message content (and `tool_result` content) to `""`, so the converter's `for block in content` stays safe.

`anthropic_messages_to_openai` already ignores block types it does not translate, so a `thinking` block is dropped rather than forwarded to the model (verified it does not leak into the converted history).

## Tests

`studio/backend/tests/test_anthropic_messages.py`:

- A resumed-session payload with `thinking` + `text` + `tool_use` and a following `null`-content turn validates; the thinking block is dropped, the answer text and tool call are preserved, and the thinking text never reaches the converted messages.
- Known blocks still parse as their typed models; a malformed `tool_use` (missing `id`) still raises.

Existing `test_anthropic_messages.py` (100), thinking-translation, message-content, tool-empty-content, and compaction suites pass unchanged.