### PR TITLE
Silence torch._check_is_size FutureWarning and shim it if torch removes it

### DIFF
--- a/unsloth/_gpu_init.py
+++ b/unsloth/_gpu_init.py
@@ -26,6 +26,7 @@ already_imported = [mod for mod in critical_modules if mod in sys.modules]
 # Fix some issues before importing other packages
 from .import_fixes import (
     fix_message_factory_issue,
+    fix_torch_check_is_size,
     check_fbgemm_gpu_version,
     disable_broken_causal_conv1d,
     disable_broken_vllm,
@@ -72,6 +73,7 @@ fix_bitsandbytes_rocm_arch_detection()
 disable_broken_causal_conv1d()
 disable_broken_vllm()
 fix_message_factory_issue()
+fix_torch_check_is_size()
 check_fbgemm_gpu_version()
 torchvision_compatibility_check()
 fix_diffusers_warnings()
@@ -81,6 +83,7 @@ del fix_bitsandbytes_rocm_arch_detection
 del disable_broken_causal_conv1d
 del disable_broken_vllm
 del fix_message_factory_issue
+del fix_torch_check_is_size
 del check_fbgemm_gpu_version
 del torchvision_compatibility_check
 del fix_diffusers_warnings

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -173,7 +173,9 @@ if not UNSLOTH_ENABLE_LOGGING:
     warnings.filterwarnings("ignore", message = "`int4_weight_only` is deprecated")
     warnings.filterwarnings("ignore", message = "`int8_weight_only` is deprecated")
     # torch._check_is_size FutureWarning (called by bitsandbytes 4-bit dequant)
-    warnings.filterwarnings("ignore", message = r"_check_is_size will be removed", category = FutureWarning)
+    warnings.filterwarnings(
+        "ignore", message = r"_check_is_size will be removed", category = FutureWarning
+    )
 
     # TorchAO deprecated import paths (https://github.com/pytorch/ao/issues/2752)
     warnings.filterwarnings(
@@ -261,12 +263,20 @@ def fix_torch_check_is_size():
     keeps working. The FutureWarning itself is silenced in suppress_cuda_printf."""
     try:
         import torch
+
         if hasattr(torch, "_check_is_size"):
             return
-        def _check_is_size(i, message = None, *, max = None):
+
+        def _check_is_size(
+            i,
+            message = None,
+            *,
+            max = None,
+        ):
             torch._check(i >= 0, message)
             if max is not None:
                 torch._check(i <= max, message)
+
         torch._check_is_size = _check_is_size
     except Exception:
         return

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -172,6 +172,8 @@ if not UNSLOTH_ENABLE_LOGGING:
     # Deprecation warnings from torchao
     warnings.filterwarnings("ignore", message = "`int4_weight_only` is deprecated")
     warnings.filterwarnings("ignore", message = "`int8_weight_only` is deprecated")
+    # torch._check_is_size FutureWarning (called by bitsandbytes 4-bit dequant)
+    warnings.filterwarnings("ignore", message = r"_check_is_size will be removed", category = FutureWarning)
 
     # TorchAO deprecated import paths (https://github.com/pytorch/ao/issues/2752)
     warnings.filterwarnings(
@@ -251,6 +253,23 @@ if not UNSLOTH_ENABLE_LOGGING:
         category = UserWarning,
         module = r"^apex\.transformer\.functional\.fused_rope$",
     )
+
+
+def fix_torch_check_is_size():
+    """torch deprecated torch._check_is_size (bitsandbytes 4-bit dequant calls
+    it); if a future torch removes it, shim it to _check(i >= 0) so bitsandbytes
+    keeps working. The FutureWarning itself is silenced in suppress_cuda_printf."""
+    try:
+        import torch
+        if hasattr(torch, "_check_is_size"):
+            return
+        def _check_is_size(i, message = None, *, max = None):
+            torch._check(i >= 0, message)
+            if max is not None:
+                torch._check(i <= max, message)
+        torch._check_is_size = _check_is_size
+    except Exception:
+        return
 
 
 # Fix up AttributeError: 'MessageFactory' object has no attribute 'GetPrototype'

--- a/unsloth/import_fixes.py
+++ b/unsloth/import_fixes.py
@@ -258,9 +258,8 @@ if not UNSLOTH_ENABLE_LOGGING:
 
 
 def fix_torch_check_is_size():
-    """torch deprecated torch._check_is_size (bitsandbytes 4-bit dequant calls
-    it); if a future torch removes it, shim it to _check(i >= 0) so bitsandbytes
-    keeps working. The FutureWarning itself is silenced in suppress_cuda_printf."""
+    """Shim torch._check_is_size if a future torch removes it (bitsandbytes 4-bit
+    dequant calls it). The FutureWarning is silenced in suppress_cuda_printf."""
     try:
         import torch
 


### PR DESCRIPTION
### Summary

bitsandbytes 4-bit dequant calls `torch._check_is_size(blocksize)` (many sites across `bitsandbytes/_ops.py` and the CUDA/Triton backends). torch deprecated that function, so every gpt-oss and any bnb-4bit load prints:

```
FutureWarning: _check_is_size will be removed in a future PyTorch release along with guard_size_oblivious. Use _check(i >= 0) instead.
```

### Change

- Silence that specific FutureWarning in `suppress_cuda_printf`, next to the other torch and torchao deprecation filters.
- Add `fix_torch_check_is_size()`: if a future torch removes `torch._check_is_size`, shim it to `torch._check(i >= 0)` (honoring the optional `max` bound) so bitsandbytes keeps working. It is a no-op while torch still provides the function.

Wired into `_gpu_init.py`. Only bitsandbytes calls `_check_is_size`; no unsloth or unsloth_zoo code does.

### Tested

On torch 2.11.0 and 2.12.1: the warning no longer prints after `import unsloth`, and with `_check_is_size` deleted the shim recreates it, accepts a valid size, rejects a negative size, and honors `max`.
