### PR TITLE
unsloth start: warn before running an agent's remote installer

### DIFF
--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -989,6 +989,12 @@ def _refresh_windows_path() -> None:
         os.environ["PATH"] = os.pathsep.join(entries)
 
 
+def _install_source(install_hint: str) -> Optional[str]:
+    """The first http(s) URL an install hint fetches, or None (e.g. an npm install)."""
+    match = re.search(r"https?://[^\s'\")]+", install_hint)
+    return match.group(0) if match else None
+
+
 def _install_agent(name: str, install_hint: str) -> Optional[str]:
     # Missing agent under --launch: offer to run its documented install command, then
     # re-resolve it on PATH. Consent-based (we never auto-run a remote install script
@@ -997,7 +1003,18 @@ def _install_agent(name: str, install_hint: str) -> Optional[str]:
     if not sys.stdin.isatty():
         return None
     typer.echo(f"`{name}` is not installed.")
-    if not typer.confirm(f"Install it now with `{install_hint}`?", default = False):
+    # Make the supply-chain risk explicit before the prompt: these are the vendors'
+    # own installers (curl | bash, irm | iex, npm), run with the user's privileges,
+    # and nothing checks a signature or hash on the fetched content. Naming the source
+    # turns a blind "yes" into informed consent.
+    source = _install_source(install_hint)
+    warning = (
+        f"This will download and RUN a script from {source} with your privileges"
+        if source
+        else f"This will RUN `{install_hint}` with your privileges"
+    )
+    typer.secho(f"{warning}; there is no signature or hash check.", fg = "yellow", err = True)
+    if not typer.confirm(f"Install `{name}` now with `{install_hint}`?", default = False):
         return None
     # Run each hint through the shell it is written for: PowerShell (irm | iex, or npm)
     # on Windows, /bin/sh (curl | bash, or npm) everywhere else.

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -128,6 +128,32 @@ def test_install_agent_uses_powershell_on_windows(monkeypatch):
     assert ran == [["powershell", "-NoProfile", "-Command", install_hint]]
 
 
+def test_install_agent_warns_and_names_remote_source(monkeypatch, capsys):
+    # Before the confirm, a remote installer must name the URL it fetches so the
+    # user consents to a specific source rather than blindly accepting.
+    monkeypatch.setattr(start.os, "name", "nt")
+    monkeypatch.setattr(start.sys, "stdin", SimpleNamespace(isatty = lambda: True))
+    monkeypatch.setattr(start.typer, "confirm", lambda *a, **k: False)  # decline: nothing runs
+    hint = "& ([scriptblock]::Create((irm https://hermes-agent.nousresearch.com/install.ps1))) -SkipSetup"
+    assert start._install_agent("hermes", hint) is None
+    err = capsys.readouterr().err
+    assert "https://hermes-agent.nousresearch.com/install.ps1" in err
+    assert "download and RUN" in err
+    assert "signature or hash" in err
+
+
+def test_install_agent_warns_for_package_installer(monkeypatch, capsys):
+    # An npm-style installer has no URL to fetch, but still runs with the user's
+    # privileges, so the warning names the command instead.
+    monkeypatch.setattr(start.os, "name", "posix")
+    monkeypatch.setattr(start.sys, "stdin", SimpleNamespace(isatty = lambda: True))
+    monkeypatch.setattr(start.typer, "confirm", lambda *a, **k: False)
+    assert start._install_agent("codex", "npm install -g @openai/codex") is None
+    err = capsys.readouterr().err
+    assert "npm install -g @openai/codex" in err
+    assert "with your privileges" in err
+
+
 def test_hermes_install_hint_is_windows_native_on_windows(monkeypatch):
     monkeypatch.setattr(start.os, "name", "nt")
 


### PR DESCRIPTION
## Context

A security review flagged that `unsloth start hermes` on Windows, after an interactive confirm, runs the vendor installer `irm https://hermes-agent.nousresearch.com/install.ps1 | <scriptblock>` with no signature or hash check. The same pattern applies to every agent whose vendor ships a shell installer rather than a package: `claude` (`irm .../install.ps1 | iex`), `openclaw` (`iwr -useb .../install.ps1 | iex`), and the POSIX `curl | bash` variants. The npm-based agents (`codex`, `opencode`, `pi`) get registry integrity instead.

We cannot pin a hash or signature for a third-party remote installer we do not control (the content changes on every upstream release, so a pinned hash would break installs and give false assurance). The realistic hardening is to make the existing consent step fully informed, uniformly across all agents.

## Change

`_install_agent` keeps the confirm-then-run behavior, but before the prompt it now prints an explicit warning that names the exact source:

- Remote installer: `This will download and RUN a script from <url> with your privileges; there is no signature or hash check.`
- Package installer (npm): `This will RUN \`<command>\` with your privileges; there is no signature or hash check.`

Everything else is unchanged: non-interactive stdin still never executes anything, the confirm still defaults to no, and the command that runs is identical.

## Tests

`unsloth_cli/tests/test_start.py`:
- A remote installer warning names the fetched URL and states there is no signature or hash check.
- A package installer warning names the command.
- The existing tests that assert the executed command (`powershell -NoProfile -Command ...`, `/bin/sh -c ...`) still pass unchanged.