### PR TITLE
Retry the Studio UI shutdown re-login on transient goto timeout

### DIFF
--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1296,16 +1296,73 @@ with sync_playwright() as p:
     # still abort or interrupt this navigation, so the field wait below is the
     # final confirmation that we reached /login.
     _tolerated_nav = ("ERR_ABORTED", "interrupted by another navigation")
-    try:
-        page.goto(f"{BASE}/login", wait_until = "domcontentloaded", timeout = 60_000)
-    except Exception as exc:
-        if not any(t in str(exc) for t in _tolerated_nav):
-            raise
-        info(f"goto /login interrupted ({exc!r}); password-field wait will confirm /login")
-    pw_field = page.locator("#password")
-    pw_field.wait_for(state = "visible", timeout = 60_000)
-    pw_field.fill(NEW2)
-    page.locator('button[type="submit"]').click()
+    # A slow CI runner can make this re-login navigation time out even with the
+    # server healthy, so retry the whole goto/wait/fill/submit sequence (mirrors
+    # the change-password retry above). wait_for_health is a diagnostic pre-gate.
+    wait_for_health(BASE, timeout = 30.0, info = info)
+    relogin_err: Exception | None = None
+    for _relogin_attempt in range(3):
+        try:
+            try:
+                page.goto(f"{BASE}/login", wait_until = "domcontentloaded", timeout = 60_000)
+            except Exception as exc:
+                if not any(t in str(exc) for t in _tolerated_nav):
+                    raise
+                info(f"goto /login interrupted ({exc!r}); password-field wait will confirm /login")
+            pw_field = page.locator("#password")
+            pw_field.wait_for(state = "visible", timeout = 60_000)
+            pw_field.fill(NEW2)
+            page.locator('button[type="submit"]').click()
+            relogin_err = None
+            break
+        except Exception as e:
+            relogin_err = e
+            try:
+                cur_url = page.url
+            except Exception:
+                cur_url = "<page closed>"
+            print(
+                f"[ui]   re-login attempt {_relogin_attempt + 1} failed: "
+                f"{type(e).__name__}: {str(e)[:200]}; page.url={cur_url}; "
+                f"page_errors={len(page_errors)} console_errors={len(console_errors)}",
+                flush = True,
+            )
+            if console_errors:
+                print(
+                    f"[ui]   first console.error: {console_errors[0][:200]!r}",
+                    flush = True,
+                )
+            if page_errors:
+                print(f"[ui]   first pageerror:    {page_errors[0][:200]!r}", flush = True)
+            try:
+                shoot(f"18-relogin-attempt-{_relogin_attempt + 1}-fail")
+            except Exception:
+                pass
+            if _relogin_attempt < 2:
+                # ERR_NO_BUFFER_SPACE needs the OS to recover socket
+                # buffers; back off 5s then 15s before retrying.
+                if "ERR_NO_BUFFER_SPACE" in str(e):
+                    backoff_s = 5 if _relogin_attempt == 0 else 15
+                    print(
+                        f"[ui]   ENOBUFS detected; sleeping {backoff_s}s "
+                        f"before retry to let OS recover socket buffers...",
+                        flush = True,
+                    )
+                    time.sleep(backoff_s)
+                # Replace the page if it died; otherwise next iteration's
+                # page.goto() handles the reload.
+                page = recover_or_replace_page(
+                    page,
+                    ctx,
+                    default_timeout_ms = 60_000,
+                    info = lambda m: print(f"[ui]   recovery: {m}", flush = True),
+                )
+    if relogin_err is not None:
+        raise relogin_err
+    # Composer mount confirms the rotated session is authenticated. Kept OUTSIDE the
+    # retry: the loop breaks right after submit, so we never re-goto /login once login
+    # has set tokens -- that would hit the guest guard, redirect to /chat, and make a
+    # merely-slow composer look like a broken login.
     composer = page.locator('textarea[aria-label="Message input"]')
     composer.wait_for(state = "visible", timeout = 60_000)
     shoot("18-relogin-with-NEW2")

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1312,7 +1312,20 @@ with sync_playwright() as p:
             pw_field = page.locator("#password")
             pw_field.wait_for(state = "visible", timeout = 60_000)
             pw_field.fill(NEW2)
-            page.locator('button[type="submit"]').click()
+            # Wait on the login POST so a transient 4xx/5xx is caught and retried
+            # here, not swallowed until the out-of-loop composer wait.
+            status, _ = click_and_wait_for_response(
+                page,
+                url_substr = "/api/auth/login",
+                method = "POST",
+                do_click = lambda: page.locator('button[type="submit"]').click(),
+                timeout_ms = 30_000,
+                info = lambda m: print(f"[ui]   {m}", flush = True),
+            )
+            if status is not None and status >= 400:
+                raise AssertionError(
+                    f"login POST returned {status}; see console_errors={console_errors[:1]!r}"
+                )
             relogin_err = None
             break
         except Exception as e:
@@ -1351,12 +1364,18 @@ with sync_playwright() as p:
                     time.sleep(backoff_s)
                 # Replace the page if it died; otherwise next iteration's
                 # page.goto() handles the reload.
+                old_page = page
                 page = recover_or_replace_page(
                     page,
                     ctx,
                     default_timeout_ms = 60_000,
                     info = lambda m: print(f"[ui]   recovery: {m}", flush = True),
                 )
+                # A freshly created replacement page loses the pageerror/console
+                # listeners; re-attach so error tracking survives recovery.
+                if page is not old_page:
+                    page.on("pageerror", lambda e: page_errors.append(str(e)))
+                    page.on("console", _on_console)
     if relogin_err is not None:
         raise relogin_err
     # Composer mount confirms the rotated session is authenticated. Kept OUTSIDE the


### PR DESCRIPTION
## Problem

The Studio UI CI ("Chat UI Tests", `studio-ui-smoke.yml`) intermittently fails at the pre-shutdown re-login in `tests/studio/playwright_chat_ui.py`. In the "Shutdown via account menu" step, after the CLI password rotation and full session teardown, the test re-logs-in to obtain a valid `/api/shutdown` token:

```python
page.goto(f"{BASE}/login", wait_until = "domcontentloaded", timeout = 60_000)
```

On a slow runner this can raise `playwright TimeoutError: Page.goto: Timeout 60000ms exceeded` even though the server is healthy. The surrounding `except` only tolerated `ERR_ABORTED` / "interrupted by another navigation", so a plain timeout re-raised and hard-failed the whole job (the `#password` / composer waits below never got a chance to recover).

## Fix

Wrap the re-login goto/wait/fill/submit in the same 3-attempt retry the change-password step already uses:

- `recover_or_replace_page(...)` between attempts and per-attempt fail screenshots, matching the existing loop.
- A `wait_for_health(BASE)` diagnostic pre-gate before the loop (never raises) so a briefly-unready backend is waited out instead of sinking a full 60s navigation.
- The inner `try/except` keeps the existing tolerated-navigation handling; a plain `TimeoutError` now retries instead of failing.
- The composer wait stays outside the loop: the loop breaks right after submit, so a retry never re-navigates once login has set tokens (which would hit the guest guard and redirect to `/chat`). The composer wait remains the authoritative confirmation, so a genuinely broken login still fails loudly, and an exhausted retry re-raises.

Single file, single hunk; no app / CI / auth behavior changes.

## Scope

Surgical fix for the one navigation that flaked. The other single navigations (`goto('/chat')`, `goto('/data-recipes')`, and the `reload()` session-survival calls) run mid-test against a warm, authenticated shell and have not flaked, so they are left as-is; they can be wrapped the same way if they ever do.

## Notes

Independent of the embedding fix in #6939 (that PR only touched `unsloth/models/sentence_transformer.py` and two Python tests; it tripped this workflow only because the workflow triggers on `unsloth/**`).

## Verification

- `python -m py_compile tests/studio/playwright_chat_ui.py` passes.
- The retry mirrors the proven change-password loop line-for-line.
- End-to-end coverage is the Studio UI CI job itself (real Studio server + Chromium + GGUF); the flake is timing-dependent, so the signal is a green job plus, if any attempt ever times out, a `re-login attempt N failed` log line and `18-relogin-attempt-N-fail` artifact showing recovery rather than a hard failure.
