### PR TITLE
Local Agent Guides CI: run the resume job on the weekly schedule

### DIFF
--- a/.github/workflows/local-agent-guides-ci.yml
+++ b/.github/workflows/local-agent-guides-ci.yml
@@ -479,11 +479,12 @@ jobs:
   #   a temp dir wiped on exit, so codex/pi cannot resume; --persist routes the
   #   session to the stable Unsloth agents dir so it persists. opencode/claude
   #   keep their session data in a fixed user dir, so they persist either way.
-  #   Dispatch-only: it is an end-to-end experiment, not a PR gate.
+  #   Weekly + dispatch only (like file-edit) -- it drives the launch path end
+  #   to end on a 4B model, too slow and model-heavy to gate PRs.
   # ═════════════════════════════════════════════════════════════════════
   resume:
     name: resume (${{ matrix.agent }})
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:


### PR DESCRIPTION
## What

The Local Agent Guides CI already has a `resume` job (added alongside `unsloth start --persist` in #7014) that drives the real launch path and checks that a session started with `unsloth start <agent>` survives exit and reopens. It was gated to `workflow_dispatch` only, so it never ran unless someone triggered it by hand.

This promotes it to the same trigger as its sibling `file-edit` job:

```yaml
if: github.event_name != 'pull_request'
```

so it runs on the weekly schedule (`37 7 * * 1`) and on manual dispatch, and the `--persist` path is exercised automatically instead of only when remembered.

## Why not on pull_request

Same reason `file-edit` skips PRs: the job serves a 4B GGUF on a CPU runner and drives each agent through a two-turn launch-path conversation, which is too slow and heavy to gate PRs on.

Per-PR coverage is unchanged:

- The `connection` job still runs on every PR for all six agents (endpoint dialect preflight, install, recipe execution).
- `unsloth_cli/tests/test_start.py` still asserts the `--persist` argv/env construction (stable agents dir vs wiped temp dir) on every PR, with no server or GPU needed.

## Scope

- One-line trigger change plus the job comment. The job steps are unchanged.
- Matrix unchanged: `[codex, opencode, claude, pi]`. That is one agent per persistence class; the driver's `resume` mode only covers these four, and openclaw/hermes share codex's home-relocation mechanism and are already covered by the unit tests.
