### PR TITLE
Studio: route lfm2_moe (LFM2-8B-A1B) to transformers 5.3.0

### DIFF
--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -173,6 +173,7 @@ _TRANSFORMERS_530_ARCHITECTURES: set[str] = {
     "Qwen3MoeForCausalLM",
     "Qwen3NextForCausalLM",
     "Glm4MoeLiteForCausalLM",
+    "Lfm2MoeForCausalLM",
     "Lfm2VlForConditionalGeneration",
 }
 _TRANSFORMERS_530_MODEL_TYPES: set[str] = {
@@ -183,6 +184,7 @@ _TRANSFORMERS_530_MODEL_TYPES: set[str] = {
     "qwen3_moe",
     "qwen3_next",
     "glm4_moe_lite",
+    "lfm2_moe",
     "lfm2_vl",
 }
 


### PR DESCRIPTION
### Problem

Training or loading `LiquidAI/LFM2-8B-A1B` (or any `lfm2_moe` checkpoint) in Studio fails at model load with:

```
`LiquidAI/LFM2-8B-A1B` is not supported yet in `transformers==4.57.6`.
```

### Root cause

`studio/backend/utils/transformers_version.py` maps a model to the transformers sidecar it needs. The `lfm2_moe` model type and its `Lfm2MoeForCausalLM` architecture were not listed in any tier, so the resolver fell through to the default 4.57.x sidecar. The MoE variant was simply never added; only `lfm2_vl` was present. `lfm2_moe` is registered in transformers 5.3.0, which we already ship as the `.venv_t5_530` sidecar.

### Fix

Add `Lfm2MoeForCausalLM` to `_TRANSFORMERS_530_ARCHITECTURES` and `lfm2_moe` to `_TRANSFORMERS_530_MODEL_TYPES`, so LFM2 MoE checkpoints route to the 5.3.0 sidecar like the other MoE families already do.

### Verification

`get_transformers_tier` now returns `530` for the model:

```
Transformers tier 530 selected for LFM2-8B-A1B (local config.json check)
get_transformers_tier('LFM2-8B-A1B') -> '530'
```

With the 5.3.0 sidecar active, the full QLoRA path works end to end: 4-bit load with the experts quantized (about 4.5 GB resident), LoRA attaches to the MoE expert projections, a short train run produces a finite loss, and merge to 16-bit reloads in stock transformers and generates coherent text.

No behavior change for any other model: this only adds two entries to the 5.3.0 tier sets.
