### PR TITLE
DeepSeek-V4: eager attention and trainable FP8 grouped experts

### DIFF
--- a/unsloth/kernels/fp8.py
+++ b/unsloth/kernels/fp8.py
@@ -43,6 +43,11 @@ except:
     )
 
 try:
+    from transformers.integrations.finegrained_fp8 import FP8GroupedLinear
+except:
+    FP8GroupedLinear = None
+
+try:
     from transformers.integrations.fbgemm_fp8 import FbgemmFp8Linear
 except:
     FbgemmFp8Linear = None
@@ -688,3 +693,25 @@ if FbgemmFp8Linear is not None:
     FbgemmFp8Linear.forward = module_forward_patch(fbgemm_fp8_linear, "weight_scale")
 if FP8Linear is not None:
     FP8Linear.forward = module_forward_patch(fp8_block_quant_linear, "weight_scale_inv")
+
+# FP8GroupedLinear.forward calls a grouped matmul kernel with no autograd
+# formula, so backward fails while training. For training, dequantize the frozen
+# fp8 weight and run a differentiable grouped matmul; inference keeps the kernel.
+# torch._grouped_mm matches but has no backward here; _scaled_grouped_mm needs
+# fp8 activations, so bmm on the dequantized weight is exact and universal.
+if FP8GroupedLinear is not None:
+    _fp8_grouped_forward_orig = FP8GroupedLinear.forward
+
+    def _fp8_grouped_forward(self, x):
+        if self.weight.element_size() > 1 or not torch.is_grad_enabled():
+            return _fp8_grouped_forward_orig(self, x)
+        hidden_dim = x.shape[-1]
+        W = weight_dequant(self.weight, self.weight_scale_inv.float()).to(x.dtype)
+        w = W.view(self.n_groups, -1, hidden_dim).transpose(1, 2)
+        xg = x.reshape(-1, self.n_groups, hidden_dim).transpose(0, 1)
+        y = torch.bmm(xg, w).transpose(0, 1).reshape(*x.shape[:-2], self.n_groups, -1)
+        if self.has_bias:
+            y = y + self.bias.view(self.n_groups, -1)
+        return y
+
+    FP8GroupedLinear.forward = _fp8_grouped_forward

--- a/unsloth/kernels/fp8.py
+++ b/unsloth/kernels/fp8.py
@@ -735,7 +735,9 @@ if FP8GroupedLinear is not None:
         def backward(ctx, grad_y):
             weight, scale_inv = ctx.saved_tensors
             ng, out_per, hidden = ctx.n_groups, ctx.out_per, ctx.x_shape[-1]
-            W = _fp8_grouped_dequant(weight, scale_inv, ctx.block_size, ctx.dtype).view(ng, out_per, hidden)
+            W = _fp8_grouped_dequant(weight, scale_inv, ctx.block_size, ctx.dtype).view(
+                ng, out_per, hidden
+            )
             gy = grad_y.reshape(-1, ng, out_per).transpose(0, 1)
             grad_x = torch.bmm(gy, W).transpose(0, 1).reshape(ctx.x_shape)
             grad_bias = gy.sum(1).reshape(-1) if ctx.has_bias else None
@@ -746,8 +748,12 @@ if FP8GroupedLinear is not None:
             return _fp8_grouped_forward_orig(self, x)
         bias = self.bias if self.has_bias else None
         return _FP8GroupedMM.apply(
-            x, self.weight, self.weight_scale_inv, self.n_groups,
-            getattr(self, "block_size", None), bias,
+            x,
+            self.weight,
+            self.weight_scale_inv,
+            self.n_groups,
+            getattr(self, "block_size", None),
+            bias,
         )
 
     FP8GroupedLinear.forward = _fp8_grouped_forward

--- a/unsloth/kernels/fp8.py
+++ b/unsloth/kernels/fp8.py
@@ -694,24 +694,51 @@ if FbgemmFp8Linear is not None:
 if FP8Linear is not None:
     FP8Linear.forward = module_forward_patch(fp8_block_quant_linear, "weight_scale_inv")
 
-# FP8GroupedLinear.forward calls a grouped matmul kernel with no autograd
-# formula, so backward fails while training. For training, dequantize the frozen
-# fp8 weight and run a differentiable grouped matmul; inference keeps the kernel.
-# torch._grouped_mm matches but has no backward here; _scaled_grouped_mm needs
-# fp8 activations, so bmm on the dequantized weight is exact and universal.
+# FP8GroupedLinear.forward uses a grouped matmul kernel with no autograd formula,
+# so training backward fails. Train through a custom autograd Function that
+# dequantizes the frozen fp8 weight for a differentiable grouped bmm but saves
+# only the fp8 weight + scale (no bf16 copy retained per layer) and unwraps TP
+# shards; inference keeps the fused kernel. (torch._grouped_mm has no backward
+# here; _scaled_grouped_mm needs fp8 activations.)
 if FP8GroupedLinear is not None:
     _fp8_grouped_forward_orig = FP8GroupedLinear.forward
+
+    def _fp8_to_local(t):
+        dt = getattr(getattr(torch, "distributed", None), "tensor", None)
+        DTensor = getattr(dt, "DTensor", None) if dt is not None else None
+        return t.to_local() if DTensor is not None and isinstance(t, DTensor) else t
+
+    class _FP8GroupedMM(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, x, weight, scale_inv, n_groups, bias):
+            weight, scale_inv = _fp8_to_local(weight), _fp8_to_local(scale_inv)
+            hidden = x.shape[-1]
+            W = weight_dequant(weight, scale_inv.float()).to(x.dtype)
+            out_per = W.shape[0] // n_groups
+            xg = x.reshape(-1, n_groups, hidden).transpose(0, 1)
+            y = torch.bmm(xg, W.view(n_groups, out_per, hidden).transpose(1, 2))
+            y = y.transpose(0, 1).reshape(*x.shape[:-2], n_groups, out_per)
+            if bias is not None:
+                y = y + bias.view(n_groups, out_per)
+            ctx.save_for_backward(weight, scale_inv)
+            ctx.n_groups, ctx.out_per, ctx.x_shape = n_groups, out_per, x.shape
+            ctx.dtype, ctx.has_bias = x.dtype, bias is not None
+            return y
+
+        @staticmethod
+        def backward(ctx, grad_y):
+            weight, scale_inv = ctx.saved_tensors
+            ng, out_per, hidden = ctx.n_groups, ctx.out_per, ctx.x_shape[-1]
+            W = weight_dequant(weight, scale_inv.float()).to(ctx.dtype).view(ng, out_per, hidden)
+            gy = grad_y.reshape(-1, ng, out_per).transpose(0, 1)
+            grad_x = torch.bmm(gy, W).transpose(0, 1).reshape(ctx.x_shape)
+            grad_bias = gy.sum(1).reshape(-1) if ctx.has_bias else None
+            return grad_x, None, None, None, grad_bias
 
     def _fp8_grouped_forward(self, x):
         if self.weight.element_size() > 1 or not torch.is_grad_enabled():
             return _fp8_grouped_forward_orig(self, x)
-        hidden_dim = x.shape[-1]
-        W = weight_dequant(self.weight, self.weight_scale_inv.float()).to(x.dtype)
-        w = W.view(self.n_groups, -1, hidden_dim).transpose(1, 2)
-        xg = x.reshape(-1, self.n_groups, hidden_dim).transpose(0, 1)
-        y = torch.bmm(xg, w).transpose(0, 1).reshape(*x.shape[:-2], self.n_groups, -1)
-        if self.has_bias:
-            y = y + self.bias.view(self.n_groups, -1)
-        return y
+        bias = self.bias if self.has_bias else None
+        return _FP8GroupedMM.apply(x, self.weight, self.weight_scale_inv, self.n_groups, bias)
 
     FP8GroupedLinear.forward = _fp8_grouped_forward

--- a/unsloth/kernels/fp8.py
+++ b/unsloth/kernels/fp8.py
@@ -695,11 +695,11 @@ if FP8Linear is not None:
     FP8Linear.forward = module_forward_patch(fp8_block_quant_linear, "weight_scale_inv")
 
 # FP8GroupedLinear.forward uses a grouped matmul kernel with no autograd formula,
-# so training backward fails. Train through a custom autograd Function that
-# dequantizes the frozen fp8 weight for a differentiable grouped bmm but saves
-# only the fp8 weight + scale (no bf16 copy retained per layer) and unwraps TP
-# shards; inference keeps the fused kernel. (torch._grouped_mm has no backward
-# here; _scaled_grouped_mm needs fp8 activations.)
+# so training backward fails. In training mode run a custom autograd Function that
+# dequantizes the frozen fp8 weight for a differentiable grouped bmm but saves only
+# the fp8 weight + scale (no bf16 copy retained per layer) and unwraps TP shards;
+# eval keeps the fused kernel. Gate on self.training, not is_grad_enabled, so the
+# gradient-checkpointing no-grad forward and its recompute run the same math.
 if FP8GroupedLinear is not None:
     _fp8_grouped_forward_orig = FP8GroupedLinear.forward
 
@@ -708,12 +708,18 @@ if FP8GroupedLinear is not None:
         DTensor = getattr(dt, "DTensor", None) if dt is not None else None
         return t.to_local() if DTensor is not None and isinstance(t, DTensor) else t
 
+    def _fp8_grouped_dequant(weight, scale_inv, block_size, dtype):
+        # Honor the layer's block size; weight_dequant would assume 128 and mis-scale.
+        if block_size is not None and len(block_size) == 2:
+            return _blockwise_weight_dequant_any_shape(weight, scale_inv.float(), block_size, dtype)
+        return weight_dequant(weight, scale_inv.float()).to(dtype)
+
     class _FP8GroupedMM(torch.autograd.Function):
         @staticmethod
-        def forward(ctx, x, weight, scale_inv, n_groups, bias):
+        def forward(ctx, x, weight, scale_inv, n_groups, block_size, bias):
             weight, scale_inv = _fp8_to_local(weight), _fp8_to_local(scale_inv)
             hidden = x.shape[-1]
-            W = weight_dequant(weight, scale_inv.float()).to(x.dtype)
+            W = _fp8_grouped_dequant(weight, scale_inv, block_size, x.dtype)
             out_per = W.shape[0] // n_groups
             xg = x.reshape(-1, n_groups, hidden).transpose(0, 1)
             y = torch.bmm(xg, W.view(n_groups, out_per, hidden).transpose(1, 2))
@@ -722,23 +728,26 @@ if FP8GroupedLinear is not None:
                 y = y + bias.view(n_groups, out_per)
             ctx.save_for_backward(weight, scale_inv)
             ctx.n_groups, ctx.out_per, ctx.x_shape = n_groups, out_per, x.shape
-            ctx.dtype, ctx.has_bias = x.dtype, bias is not None
+            ctx.dtype, ctx.has_bias, ctx.block_size = x.dtype, bias is not None, block_size
             return y
 
         @staticmethod
         def backward(ctx, grad_y):
             weight, scale_inv = ctx.saved_tensors
             ng, out_per, hidden = ctx.n_groups, ctx.out_per, ctx.x_shape[-1]
-            W = weight_dequant(weight, scale_inv.float()).to(ctx.dtype).view(ng, out_per, hidden)
+            W = _fp8_grouped_dequant(weight, scale_inv, ctx.block_size, ctx.dtype).view(ng, out_per, hidden)
             gy = grad_y.reshape(-1, ng, out_per).transpose(0, 1)
             grad_x = torch.bmm(gy, W).transpose(0, 1).reshape(ctx.x_shape)
             grad_bias = gy.sum(1).reshape(-1) if ctx.has_bias else None
-            return grad_x, None, None, None, grad_bias
+            return grad_x, None, None, None, None, grad_bias
 
     def _fp8_grouped_forward(self, x):
-        if self.weight.element_size() > 1 or not torch.is_grad_enabled():
+        if self.weight.element_size() > 1 or not self.training:
             return _fp8_grouped_forward_orig(self, x)
         bias = self.bias if self.has_bias else None
-        return _FP8GroupedMM.apply(x, self.weight, self.weight_scale_inv, self.n_groups, bias)
+        return _FP8GroupedMM.apply(
+            x, self.weight, self.weight_scale_inv, self.n_groups,
+            getattr(self, "block_size", None), bias,
+        )
 
     FP8GroupedLinear.forward = _fp8_grouped_forward

--- a/unsloth/kernels/fp8.py
+++ b/unsloth/kernels/fp8.py
@@ -694,12 +694,11 @@ if FbgemmFp8Linear is not None:
 if FP8Linear is not None:
     FP8Linear.forward = module_forward_patch(fp8_block_quant_linear, "weight_scale_inv")
 
-# FP8GroupedLinear.forward uses a grouped matmul kernel with no autograd formula,
-# so training backward fails. In training mode run a custom autograd Function that
-# dequantizes the frozen fp8 weight for a differentiable grouped bmm but saves only
-# the fp8 weight + scale (no bf16 copy retained per layer) and unwraps TP shards;
-# eval keeps the fused kernel. Gate on self.training, not is_grad_enabled, so the
-# gradient-checkpointing no-grad forward and its recompute run the same math.
+# FP8GroupedLinear's fused grouped matmul has no autograd formula, so training
+# backward fails. In training, use a custom autograd Function: dequant the frozen
+# fp8 weight for a differentiable bmm, saving only the fp8 weight + scale and
+# unwrapping TP shards; eval keeps the fused kernel. Gate on self.training (not
+# is_grad_enabled) so the grad-checkpoint no-grad forward and its recompute match.
 if FP8GroupedLinear is not None:
     _fp8_grouped_forward_orig = FP8GroupedLinear.forward
 

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -438,8 +438,8 @@ DISABLE_SDPA_MODEL_NAMES = [
     "gpt_oss",
 ]
 _FLASH_EXCLUDED_MODELS = ("gpt_oss", "deepseek_v4")
-# deepseek_v4 ships sdpa/flash-incompatible custom attention; force eager and also
-# exclude it above so an explicit sdpa/flash request cannot re-enable the crash.
+# deepseek_v4's custom attention is sdpa/flash-incompatible; force eager, and
+# excluded above so an explicit sdpa/flash request cannot re-enable the crash.
 _EAGER_ONLY_PREFIXES = ("gemma3n", "deepseek_v4")
 _FLASH_ATTENTION_MAX_HEAD_DIM = 256
 _FLASH_ATTENTION_DISABLED_WARNED = set()

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -424,7 +424,7 @@ def apply_unsloth_gradient_checkpointing(use_gradient_checkpointing, max_seq_len
 # access on some GPU architectures (B200). Falls back to eager safely.
 _FLEX_EXCLUDED_MODELS = ("gpt_oss", "mllama", "nemotron_h", "modernbert")
 _FLEX_PREFERRED_MODELS = ("gemma3", "gemma3_text", "shieldgemma2")
-_SDPA_EXCLUDED_MODELS = ("gpt_oss",)
+_SDPA_EXCLUDED_MODELS = ("gpt_oss", "deepseek_v4")
 # The loader (loader.py) forces supports_sdpa=False for these because their bundled
 # SDPA modules are wrong. Kept here, not in loader.py, so _is_sdpa_excluded can honor
 # them without a loader -> _utils import cycle (loader.py already imports from _utils
@@ -437,8 +437,9 @@ DISABLE_SDPA_MODEL_NAMES = [
     "gemma3_text",  # Gemma3TextModel (EmbeddingGemma) - substring match, keep underscore
     "gpt_oss",
 ]
-_FLASH_EXCLUDED_MODELS = ("gpt_oss",)
-# deepseek_v4 ships sdpa/flash-incompatible custom attention; force eager.
+_FLASH_EXCLUDED_MODELS = ("gpt_oss", "deepseek_v4")
+# deepseek_v4 ships sdpa/flash-incompatible custom attention; force eager and also
+# exclude it above so an explicit sdpa/flash request cannot re-enable the crash.
 _EAGER_ONLY_PREFIXES = ("gemma3n", "deepseek_v4")
 _FLASH_ATTENTION_MAX_HEAD_DIM = 256
 _FLASH_ATTENTION_DISABLED_WARNED = set()

--- a/unsloth/models/_utils.py
+++ b/unsloth/models/_utils.py
@@ -438,7 +438,8 @@ DISABLE_SDPA_MODEL_NAMES = [
     "gpt_oss",
 ]
 _FLASH_EXCLUDED_MODELS = ("gpt_oss",)
-_EAGER_ONLY_PREFIXES = ("gemma3n",)
+# deepseek_v4 ships sdpa/flash-incompatible custom attention; force eager.
+_EAGER_ONLY_PREFIXES = ("gemma3n", "deepseek_v4")
 _FLASH_ATTENTION_MAX_HEAD_DIM = 256
 _FLASH_ATTENTION_DISABLED_WARNED = set()
 


### PR DESCRIPTION
## Summary

Finetuning DeepSeek-V4 (`deepseek_v4`) with `FastModel` currently fails in two places. This fixes both so the model loads and trains.

1. Loading raises an attention error. `deepseek_v4` ships a custom attention that is not compatible with the sdpa or flash paths, so it must run eager.
2. Once loaded, `loss.backward()` errors. Transformers stores the fused experts as `FP8GroupedLinear`, whose `forward` calls a grouped matmul kernel that has no autograd formula, so backward fails during finetuning.

## Changes

- `unsloth/models/_utils.py`: add `deepseek_v4` to `_EAGER_ONLY_PREFIXES` so it loads with eager attention.
- `unsloth/kernels/fp8.py`: patch `FP8GroupedLinear.forward` so that during training it dequantizes the frozen fp8 weight and runs a differentiable grouped matmul, while inference keeps the original fused fp8 kernel. Gated on `torch.is_grad_enabled()` and a fp8 weight, so the inference path is unchanged.

## Why bmm on the dequantized weight

- `torch._grouped_mm`: forward matches exactly, but its backward raises `Invalid strides/sizes` on the grouped-expert shapes, and backward is exactly what we need.
- `torch._scaled_grouped_mm`: needs a transposed operand and fp8-quantized activations, which adds quantization error and complexity.
- Dequantizing the frozen fp8 weight to bf16 and using `torch.bmm` is exact at fp8 precision, has a finite backward, and works on all shapes. Only the few grouped-linear modules materialize in bf16, so the overhead is negligible.

## Testing

On `trl-internal-testing/tiny-DeepseekV4ForCausalLM`:

- Loads in 4bit with eager attention.
- LoRA attaches to the experts and receives gradient.
- Forward and backward run with finite loss and finite gradients.
- `FP8GroupedLinear` parity: dequant + bmm matches the fused fp8 kernel to 2.7e-2 relative (fp8 rounding), with finite gradients.

Scope is loading and finetuning. Saving an fp8 checkpoint merged to 16bit is a separate path and is not changed here.
