### PR TITLE
fix(studio): use writable recipe artifact path

### DIFF
--- a/studio/backend/core/data_recipe/service.py
+++ b/studio/backend/core/data_recipe/service.py
@@ -280,6 +280,8 @@ def create_data_designer(recipe: dict[str, Any], *, artifact_path: str | None = 
     from data_designer.interface.data_designer import DataDesigner  # pyright: ignore[reportMissingImports]
 
     if artifact_path is None:
+        # DataDesigner defaults to cwd/artifacts; packaged Studio can run with
+        # cwd=/, so keep default callers on Studio's writable recipe artifact root.
         artifact_path = str(recipe_datasets_root())
 
     recipe = _strip_frontend_model_config_metadata(recipe)

--- a/studio/backend/core/data_recipe/service.py
+++ b/studio/backend/core/data_recipe/service.py
@@ -9,6 +9,8 @@ import os
 from pathlib import Path
 from typing import Any
 
+from utils.paths import recipe_datasets_root
+
 from .jsonable import to_jsonable
 from .local_callable_validators import (
     register_oxc_local_callable_validators,
@@ -276,6 +278,9 @@ def build_config_builder(recipe: dict[str, Any]):
 def create_data_designer(recipe: dict[str, Any], *, artifact_path: str | None = None):
     _apply_data_designer_image_context_patch()
     from data_designer.interface.data_designer import DataDesigner  # pyright: ignore[reportMissingImports]
+
+    if artifact_path is None:
+        artifact_path = str(recipe_datasets_root())
 
     recipe = _strip_frontend_model_config_metadata(recipe)
     model_providers = build_model_providers(recipe)


### PR DESCRIPTION
## Summary
- Default Studio Data Designer artifact storage to the recipe datasets root when callers omit `artifact_path`.
- Keep explicit `artifact_path` callers, including the background recipe worker, unchanged.

## Root Cause
Validation paths constructed `DataDesigner` without `artifact_path`. Data Designer then fell back to `Path.cwd() / "artifacts"`, which can become `/artifacts` in packaged Studio when cwd is `/`.

Fixes #7038

## Validation
```bash
python -m pytest studio/backend/tests/test_data_recipe_github_progress.py studio/backend/tests/test_data_recipe_pump_resilience.py studio/backend/tests/test_data_recipe_seed.py -q
```