### PR TITLE
fix: guard remove_special_tokens against tokenizers without a BOS token

### DIFF
--- a/tests/python/test_remove_special_tokens_no_bos.py
+++ b/tests/python/test_remove_special_tokens_no_bos.py
@@ -1,0 +1,45 @@
+import ast
+from pathlib import Path
+
+
+def _load_remove_special_tokens():
+    # Extract remove_special_tokens without importing unsloth (importing unsloth
+    # needs unsloth_zoo / a GPU). The function is pure Python and uses no imports,
+    # so it execs cleanly in an empty namespace.
+    source = Path(__file__).parents[2] / "unsloth" / "chat_templates.py"
+    tree = ast.parse(source.read_text(encoding = "utf-8"))
+    funcs = [
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "remove_special_tokens"
+    ]
+    namespace = {}
+    module = ast.Module(body = funcs, type_ignores = [])
+    ast.fix_missing_locations(module)
+    exec(compile(module, str(source), "exec"), namespace)
+    return namespace["remove_special_tokens"]
+
+
+class _StubTokenizer:
+    def __init__(self, bos_token):
+        self.bos_token = bos_token
+
+
+def test_no_bos_tokenizer_does_not_crash():
+    # Tokenizers such as Qwen2 / Qwen2.5, GPT-2, Falcon and GPT-NeoX have no BOS
+    # token, so tokenizer.bos_token is None. remove_special_tokens must leave the
+    # prompt untouched instead of raising
+    # "TypeError: startswith first arg must be str or a tuple of str, not NoneType".
+    remove_special_tokens = _load_remove_special_tokens()
+    assert remove_special_tokens(_StubTokenizer(None), "Hello world") == "Hello world"
+
+
+def test_double_bos_is_stripped():
+    # A tokenizer with a BOS token still has a single leading BOS removed.
+    remove_special_tokens = _load_remove_special_tokens()
+    assert remove_special_tokens(_StubTokenizer("<s>"), "<s>Hello world") == "Hello world"
+
+
+def test_prompt_without_leading_bos_unchanged():
+    # A BOS-bearing tokenizer leaves a prompt that does not start with BOS alone.
+    remove_special_tokens = _load_remove_special_tokens()
+    assert remove_special_tokens(_StubTokenizer("<s>"), "Hello world") == "Hello world"

--- a/tests/python/test_remove_special_tokens_no_bos.py
+++ b/tests/python/test_remove_special_tokens_no_bos.py
@@ -9,7 +9,8 @@ def _load_remove_special_tokens():
     source = Path(__file__).parents[2] / "unsloth" / "chat_templates.py"
     tree = ast.parse(source.read_text(encoding = "utf-8"))
     funcs = [
-        node for node in tree.body
+        node
+        for node in tree.body
         if isinstance(node, ast.FunctionDef) and node.name == "remove_special_tokens"
     ]
     namespace = {}

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -2103,8 +2103,9 @@ def get_chat_template(
 
 def remove_special_tokens(tokenizer, prompt):
     # Removes double BOS token
-    if prompt.startswith(tokenizer.bos_token):
-        prompt = prompt[len(tokenizer.bos_token):]
+    bos_token = getattr(tokenizer, "bos_token", None)
+    if bos_token is not None and prompt.startswith(bos_token):
+        prompt = prompt[len(bos_token):]
     return prompt
 
 


### PR DESCRIPTION
### Summary

`remove_special_tokens` strips a leading BOS token but calls `prompt.startswith(tokenizer.bos_token)` without checking that the tokenizer actually has a BOS token. Many popular tokenizers, including Qwen2 / Qwen2.5, GPT-2, Falcon and GPT-NeoX, define no BOS token, so `tokenizer.bos_token` is `None` and the call raises:

```
TypeError: startswith first arg must be str or a tuple of str, not NoneType
```

`remove_special_tokens` is the final step of `test_hf_gguf_equivalence`, so running the HF vs GGUF equivalence check on any of those models crashes.

### Fix

Guard `bos_token` with `getattr(tokenizer, "bos_token", None)` before the comparison, mirroring the `None` checks already used elsewhere in this same file (`get_ollama_eos_tokens` and `_change_system_message`). When the tokenizer has no BOS token the prompt is returned unchanged; the existing single-BOS-stripping behaviour is preserved for tokenizers that do have one.

### Test

`tests/python/test_remove_special_tokens_no_bos.py` loads the function via `ast` (no GPU, no `import unsloth`) and covers:

- a no-BOS tokenizer (`bos_token=None`) returns the prompt unchanged (this raises the `TypeError` before the fix),
- a BOS-bearing tokenizer still strips one leading BOS token,
- a prompt without a leading BOS is left untouched.