### PR TITLE
 Studio: fix duplicate response model labels and hover

### DIFF
--- a/studio/frontend/src/components/assistant-ui/message-response-details-sheet.tsx
+++ b/studio/frontend/src/components/assistant-ui/message-response-details-sheet.tsx
@@ -288,7 +288,7 @@ export const MessageResponseModelBadge: FC<{ className?: string }> = ({
   return (
     <span
       className={cn(
-        "aui-response-model-badge inline-flex min-h-5 max-w-full items-center text-muted-foreground/80 text-xs font-medium leading-5 opacity-0 transition-opacity duration-150 group-hover/assistant-message:opacity-100 group-focus-within/assistant-message:opacity-100",
+        "aui-response-model-badge pointer-events-auto relative inline-flex min-h-5 max-w-full cursor-text select-text items-center text-muted-foreground/80 text-xs font-medium leading-5 opacity-0 transition-opacity duration-150 after:absolute after:inset-x-0 after:top-full after:h-1 after:content-[''] hover:opacity-100 group-hover/assistant-message:opacity-100 group-focus-within/assistant-message:opacity-100",
         className,
       )}
       title={providerLabel ? `${modelLabel} - ${providerLabel}` : modelLabel}

--- a/studio/frontend/src/components/assistant-ui/message-response-details-sheet.tsx
+++ b/studio/frontend/src/components/assistant-ui/message-response-details-sheet.tsx
@@ -288,7 +288,7 @@ export const MessageResponseModelBadge: FC<{ className?: string }> = ({
   return (
     <span
       className={cn(
-        "aui-response-model-badge pointer-events-auto relative inline-flex min-h-5 max-w-full cursor-text select-text items-center text-muted-foreground/80 text-xs font-medium leading-5 opacity-0 transition-opacity duration-150 after:absolute after:inset-x-0 after:top-full after:h-1 after:content-[''] hover:opacity-100 group-hover/assistant-message:opacity-100 group-focus-within/assistant-message:opacity-100",
+        "aui-response-model-badge pointer-events-none relative inline-flex min-h-5 max-w-full cursor-text select-text items-center text-muted-foreground/80 text-xs font-medium leading-5 opacity-0 transition-opacity duration-150 after:absolute after:inset-x-0 after:top-full after:h-1 after:content-[''] hover:opacity-100 group-hover/assistant-message:pointer-events-auto group-hover/assistant-message:opacity-100 group-focus-within/assistant-message:pointer-events-auto group-focus-within/assistant-message:opacity-100",
         className,
       )}
       title={providerLabel ? `${modelLabel} - ${providerLabel}` : modelLabel}

--- a/studio/frontend/src/components/assistant-ui/reasoning.tsx
+++ b/studio/frontend/src/components/assistant-ui/reasoning.tsx
@@ -6,7 +6,6 @@
 /* eslint-disable react-refresh/only-export-components */
 
 import { MarkdownText } from "@/components/assistant-ui/markdown-text";
-import { MessageResponseModelBadge } from "@/components/assistant-ui/message-response-details-sheet";
 import {
   Collapsible,
   CollapsibleContent,
@@ -393,15 +392,12 @@ const ReasoningGroupImpl: ReasoningGroupComponent = ({
     >
       <div className="flex min-w-0 items-center gap-2">
         <ReasoningTrigger
-          className="min-w-0 flex-none"
+          className="min-w-0 flex-1"
           active={isReasoningStreaming}
           // Prefer server timing when available.
           duration={persistedDuration || duration}
         />
-        <span className="hidden min-w-0 max-w-[12rem] group-hover/assistant-message:inline-flex group-focus-within/assistant-message:inline-flex sm:max-w-[16rem]">
-          <MessageResponseModelBadge className="min-w-0" />
-        </span>
-        <div className="ml-auto flex w-16 shrink-0 justify-end">
+        <div className="flex w-16 shrink-0 justify-end">
           {isOpen && !isReasoningStreaming && (
             <ReasoningCopyButton startIndex={startIndex} endIndex={endIndex} />
           )}

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -3569,9 +3569,6 @@ const AssistantMessage: FC = () => {
   const aui = useAui();
   const messageId = useAuiState(({ message }) => message.id);
   const messageContent = useAuiState(({ message }) => message.content);
-  const hasReasoningParts = useAuiState(({ message }) =>
-    message.parts.some((part) => part.type === "reasoning"),
-  );
   const incognito = useChatRuntimeStore((s) => s.incognito);
 
   // Use global store for editing state to ensure a single source of truth
@@ -3657,11 +3654,9 @@ const AssistantMessage: FC = () => {
           </div>
         ) : (
           <>
-            {!hasReasoningParts ? (
-              <div className="pointer-events-none relative h-0 min-w-0">
-                <MessageResponseModelBadge className="absolute -top-6 left-0 max-w-[min(22rem,100%)]" />
-              </div>
-            ) : null}
+            <div className="pointer-events-none relative h-0 min-w-0">
+              <MessageResponseModelBadge className="absolute -top-6 left-0 max-w-[min(22rem,100%)]" />
+            </div>
             <GeneratingIndicator />
             <CancelledIndicator />
             <DiffusionCanvas />

--- a/tests/studio/test_chat_response_details_ui_contract.py
+++ b/tests/studio/test_chat_response_details_ui_contract.py
@@ -56,7 +56,9 @@ def test_response_model_badge_is_user_configurable_and_rendered_once_per_message
     assert "Show response model" in chat_tab_src
     assert "setShowResponseModel" in chat_tab_src
     details_src = DETAILS_TSX.read_text()
-    assert "aui-response-model-badge pointer-events-auto relative inline-flex min-h-5" in details_src
+    assert (
+        "aui-response-model-badge pointer-events-auto relative inline-flex min-h-5" in details_src
+    )
     assert "cursor-text select-text" in details_src
     assert "leading-5" in details_src
     assert "after:top-full after:h-1" in details_src

--- a/tests/studio/test_chat_response_details_ui_contract.py
+++ b/tests/studio/test_chat_response_details_ui_contract.py
@@ -57,13 +57,16 @@ def test_response_model_badge_is_user_configurable_and_rendered_once_per_message
     assert "setShowResponseModel" in chat_tab_src
     details_src = DETAILS_TSX.read_text()
     assert (
-        "aui-response-model-badge pointer-events-auto relative inline-flex min-h-5" in details_src
+        "aui-response-model-badge pointer-events-none relative inline-flex min-h-5" in details_src
     )
     assert "cursor-text select-text" in details_src
     assert "leading-5" in details_src
     assert "after:top-full after:h-1" in details_src
     assert "hover:opacity-100" in details_src
     assert "group-hover/assistant-message:opacity-100" in details_src
+    # Pointer events gated behind hover/focus so the hidden badge stays inert when idle.
+    assert "group-hover/assistant-message:pointer-events-auto" in details_src
+    assert "group-focus-within/assistant-message:pointer-events-auto" in details_src
     assert thread_src.count("<MessageResponseModelBadge") == 1
     assert "hasReasoningParts" not in thread_src
     assert "group/assistant-message aui-assistant-message-root" in thread_src

--- a/tests/studio/test_chat_response_details_ui_contract.py
+++ b/tests/studio/test_chat_response_details_ui_contract.py
@@ -44,7 +44,7 @@ def test_response_details_sheet_uses_unsloth_sheet_and_key_sections():
         assert f'label="{field}"' in src
 
 
-def test_response_model_chip_is_user_configurable_and_rendered_in_metadata_rows():
+def test_response_model_badge_is_user_configurable_and_rendered_once_per_message():
     prefs_src = CHAT_PREFS_TS.read_text()
     chat_tab_src = CHAT_TAB_TSX.read_text()
     thread_src = THREAD_TSX.read_text()
@@ -55,17 +55,19 @@ def test_response_model_chip_is_user_configurable_and_rendered_in_metadata_rows(
     assert "showResponseModel: saved?.showResponseModel ?? false" in prefs_src
     assert "Show response model" in chat_tab_src
     assert "setShowResponseModel" in chat_tab_src
-    assert "aui-response-model-badge inline-flex min-h-5" in DETAILS_TSX.read_text()
-    assert "leading-5" in DETAILS_TSX.read_text()
-    assert "group-hover/assistant-message:opacity-100" in DETAILS_TSX.read_text()
-    assert "MessageResponseModelBadge" in thread_src
-    assert "hasReasoningParts" in thread_src
+    details_src = DETAILS_TSX.read_text()
+    assert "aui-response-model-badge pointer-events-auto relative inline-flex min-h-5" in details_src
+    assert "cursor-text select-text" in details_src
+    assert "leading-5" in details_src
+    assert "after:top-full after:h-1" in details_src
+    assert "hover:opacity-100" in details_src
+    assert "group-hover/assistant-message:opacity-100" in details_src
+    assert thread_src.count("<MessageResponseModelBadge") == 1
+    assert "hasReasoningParts" not in thread_src
     assert "group/assistant-message aui-assistant-message-root" in thread_src
     assert "pointer-events-none relative h-0" in thread_src
-    assert "MessageResponseModelBadge" in reasoning_src
-    assert 'className="min-w-0 flex-none"' in reasoning_src
-    assert "hidden min-w-0 max-w-[12rem]" in reasoning_src
-    assert "group-hover/assistant-message:inline-flex" in reasoning_src
+    assert "MessageResponseModelBadge" not in reasoning_src
+    assert 'className="min-w-0 flex-1"' in reasoning_src
 
 
 def test_response_details_metadata_is_persisted_without_backend_schema_change():


### PR DESCRIPTION
 ## Summary

  Show the response model once at the assistant-message level, including replies with multiple thinking and tool phases. Keep the revealed model label visible and selectable while the pointer moves onto it.

  ## Motivation

  Thinking and tool calls can split a reply into multiple reasoning groups. Rendering the model badge inside each group repeated the same model name, sometimes three times.

  The badge also ignored pointer events, so it disappeared before users could select and copy the name.

  ## Changes

  - Move `MessageResponseModelBadge` to the shared assistant-message header so each response renders one label (`studio/frontend/src/components/assistant-ui/thread.tsx:3655`).
  - Remove the badge from `ReasoningGroup` and restore the reasoning trigger's flex layout (`studio/frontend/src/components/assistant-ui/reasoning.tsx:388`).
  - Make the label pointer-active and selectable. Add a 4 px invisible hover bridge between the label and message (`studio/frontend/src/components/assistant-ui/message-response-details-sheet.tsx:276`).
  - Update the static UI contract to require one message-level badge and the hover/select behavior (`tests/studio/test_chat_response_details_ui_contract.py:47`).