### PR TITLE
CI: retry transient HTTP timeouts in Studio smoke probes

### DIFF
--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -444,6 +444,8 @@ jobs:
           python - <<'PY'
           import json
           import os
+          import time
+          import urllib.error
           import urllib.request
 
           BASE = os.environ["BASE_URL"]
@@ -464,8 +466,19 @@ jobs:
                       "Content-Type": "application/json",
                   },
               )
-              with urllib.request.urlopen(req, timeout = timeout) as resp:
-                  return resp.status, json.loads(resp.read().decode())
+              # Shared CI runners stall sporadically, so retry transport-level
+              # failures only; HTTP status errors surface immediately.
+              for attempt in range(3):
+                  try:
+                      with urllib.request.urlopen(req, timeout = timeout) as resp:
+                          return resp.status, json.loads(resp.read().decode())
+                  except urllib.error.HTTPError:
+                      raise
+                  except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
+                      if attempt == 2:
+                          raise
+                      print(f"[retry] {path}: {exc!r}", flush = True)
+                      time.sleep(15)
 
           def post_sse(path, body, *, timeout = 600):
               """POST a streaming request and accumulate the assistant
@@ -938,6 +951,8 @@ jobs:
           import base64
           import json
           import os
+          import time
+          import urllib.error
           import urllib.request
           from openai import OpenAI
           from anthropic import Anthropic
@@ -956,8 +971,19 @@ jobs:
                       "Content-Type":  "application/json",
                   },
               )
-              with urllib.request.urlopen(req, timeout = timeout) as resp:
-                  return resp.status, json.loads(resp.read().decode())
+              # Shared CI runners stall sporadically, so retry transport-level
+              # failures only; HTTP status errors surface immediately.
+              for attempt in range(3):
+                  try:
+                      with urllib.request.urlopen(req, timeout = timeout) as resp:
+                          return resp.status, json.loads(resp.read().decode())
+                  except urllib.error.HTTPError:
+                      raise
+                  except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
+                      if attempt == 2:
+                          raise
+                      print(f"[retry] {path}: {exc!r}", flush = True)
+                      time.sleep(15)
 
           # ── 1. response_format = json_object (JSON mode) ─────────────
           # llama.cpp's HTTP server supports OpenAI-compatible JSON

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -467,13 +467,15 @@ jobs:
                   },
               )
               # Shared CI runners stall sporadically, so retry transport-level
-              # failures only; HTTP status errors surface immediately. Long
-              # probes (timeout > 300s) get a single attempt so the worst
-              # case stays inside the job's timeout-minutes budget.
-              attempts = 3 if timeout <= 300 else 1
+              # failures only; HTTP status errors surface immediately. Bounded
+              # to fit the job's timeout-minutes: short probes get 3 full
+              # attempts, long probes one retry capped at 300s (a healthy
+              # server answers a retry quickly; a stalled one never does).
+              attempts = 3 if timeout <= 300 else 2
               for attempt in range(attempts):
                   try:
-                      with urllib.request.urlopen(req, timeout = timeout) as resp:
+                      t = timeout if attempt == 0 else min(timeout, 300)
+                      with urllib.request.urlopen(req, timeout = t) as resp:
                           return resp.status, json.loads(resp.read().decode())
                   except urllib.error.HTTPError:
                       raise
@@ -975,13 +977,15 @@ jobs:
                   },
               )
               # Shared CI runners stall sporadically, so retry transport-level
-              # failures only; HTTP status errors surface immediately. Long
-              # probes (timeout > 300s) get a single attempt so the worst
-              # case stays inside the job's timeout-minutes budget.
-              attempts = 3 if timeout <= 300 else 1
+              # failures only; HTTP status errors surface immediately. Bounded
+              # to fit the job's timeout-minutes: short probes get 3 full
+              # attempts, long probes one retry capped at 300s (a healthy
+              # server answers a retry quickly; a stalled one never does).
+              attempts = 3 if timeout <= 300 else 2
               for attempt in range(attempts):
                   try:
-                      with urllib.request.urlopen(req, timeout = timeout) as resp:
+                      t = timeout if attempt == 0 else min(timeout, 300)
+                      with urllib.request.urlopen(req, timeout = t) as resp:
                           return resp.status, json.loads(resp.read().decode())
                   except urllib.error.HTTPError:
                       raise

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -467,15 +467,18 @@ jobs:
                   },
               )
               # Shared CI runners stall sporadically, so retry transport-level
-              # failures only; HTTP status errors surface immediately.
-              for attempt in range(3):
+              # failures only; HTTP status errors surface immediately. Long
+              # probes (timeout > 300s) get a single attempt so the worst
+              # case stays inside the job's timeout-minutes budget.
+              attempts = 3 if timeout <= 300 else 1
+              for attempt in range(attempts):
                   try:
                       with urllib.request.urlopen(req, timeout = timeout) as resp:
                           return resp.status, json.loads(resp.read().decode())
                   except urllib.error.HTTPError:
                       raise
                   except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
-                      if attempt == 2:
+                      if attempt == attempts - 1:
                           raise
                       print(f"[retry] {path}: {exc!r}", flush = True)
                       time.sleep(15)
@@ -972,15 +975,18 @@ jobs:
                   },
               )
               # Shared CI runners stall sporadically, so retry transport-level
-              # failures only; HTTP status errors surface immediately.
-              for attempt in range(3):
+              # failures only; HTTP status errors surface immediately. Long
+              # probes (timeout > 300s) get a single attempt so the worst
+              # case stays inside the job's timeout-minutes budget.
+              attempts = 3 if timeout <= 300 else 1
+              for attempt in range(attempts):
                   try:
                       with urllib.request.urlopen(req, timeout = timeout) as resp:
                           return resp.status, json.loads(resp.read().decode())
                   except urllib.error.HTTPError:
                       raise
                   except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
-                      if attempt == 2:
+                      if attempt == attempts - 1:
                           raise
                       print(f"[retry] {path}: {exc!r}", flush = True)
                       time.sleep(15)

--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -453,13 +453,15 @@ jobs:
                   },
               )
               # Shared CI runners stall sporadically, so retry transport-level
-              # failures only; HTTP status errors surface immediately. Long
-              # probes (timeout > 300s) get a single attempt so the worst
-              # case stays inside the job's timeout-minutes budget.
-              attempts = 3 if timeout <= 300 else 1
+              # failures only; HTTP status errors surface immediately. Bounded
+              # to fit the job's timeout-minutes: short probes get 3 full
+              # attempts, long probes one retry capped at 300s (a healthy
+              # server answers a retry quickly; a stalled one never does).
+              attempts = 3 if timeout <= 300 else 2
               for attempt in range(attempts):
                   try:
-                      with urllib.request.urlopen(req, timeout = timeout) as resp:
+                      t = timeout if attempt == 0 else min(timeout, 300)
+                      with urllib.request.urlopen(req, timeout = t) as resp:
                           return resp.status, json.loads(resp.read().decode())
                   except urllib.error.HTTPError:
                       raise
@@ -867,13 +869,15 @@ jobs:
                   },
               )
               # Shared CI runners stall sporadically, so retry transport-level
-              # failures only; HTTP status errors surface immediately. Long
-              # probes (timeout > 300s) get a single attempt so the worst
-              # case stays inside the job's timeout-minutes budget.
-              attempts = 3 if timeout <= 300 else 1
+              # failures only; HTTP status errors surface immediately. Bounded
+              # to fit the job's timeout-minutes: short probes get 3 full
+              # attempts, long probes one retry capped at 300s (a healthy
+              # server answers a retry quickly; a stalled one never does).
+              attempts = 3 if timeout <= 300 else 2
               for attempt in range(attempts):
                   try:
-                      with urllib.request.urlopen(req, timeout = timeout) as resp:
+                      t = timeout if attempt == 0 else min(timeout, 300)
+                      with urllib.request.urlopen(req, timeout = t) as resp:
                           return resp.status, json.loads(resp.read().decode())
                   except urllib.error.HTTPError:
                       raise

--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -453,15 +453,18 @@ jobs:
                   },
               )
               # Shared CI runners stall sporadically, so retry transport-level
-              # failures only; HTTP status errors surface immediately.
-              for attempt in range(3):
+              # failures only; HTTP status errors surface immediately. Long
+              # probes (timeout > 300s) get a single attempt so the worst
+              # case stays inside the job's timeout-minutes budget.
+              attempts = 3 if timeout <= 300 else 1
+              for attempt in range(attempts):
                   try:
                       with urllib.request.urlopen(req, timeout = timeout) as resp:
                           return resp.status, json.loads(resp.read().decode())
                   except urllib.error.HTTPError:
                       raise
                   except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
-                      if attempt == 2:
+                      if attempt == attempts - 1:
                           raise
                       print(f"[retry] {path}: {exc!r}", flush = True)
                       time.sleep(15)
@@ -864,15 +867,18 @@ jobs:
                   },
               )
               # Shared CI runners stall sporadically, so retry transport-level
-              # failures only; HTTP status errors surface immediately.
-              for attempt in range(3):
+              # failures only; HTTP status errors surface immediately. Long
+              # probes (timeout > 300s) get a single attempt so the worst
+              # case stays inside the job's timeout-minutes budget.
+              attempts = 3 if timeout <= 300 else 1
+              for attempt in range(attempts):
                   try:
                       with urllib.request.urlopen(req, timeout = timeout) as resp:
                           return resp.status, json.loads(resp.read().decode())
                   except urllib.error.HTTPError:
                       raise
                   except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
-                      if attempt == 2:
+                      if attempt == attempts - 1:
                           raise
                       print(f"[retry] {path}: {exc!r}", flush = True)
                       time.sleep(15)

--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -430,6 +430,8 @@ jobs:
           python - <<'PY'
           import json
           import os
+          import time
+          import urllib.error
           import urllib.request
 
           BASE = os.environ["BASE_URL"]
@@ -450,8 +452,19 @@ jobs:
                       "Content-Type": "application/json",
                   },
               )
-              with urllib.request.urlopen(req, timeout = timeout) as resp:
-                  return resp.status, json.loads(resp.read().decode())
+              # Shared CI runners stall sporadically, so retry transport-level
+              # failures only; HTTP status errors surface immediately.
+              for attempt in range(3):
+                  try:
+                      with urllib.request.urlopen(req, timeout = timeout) as resp:
+                          return resp.status, json.loads(resp.read().decode())
+                  except urllib.error.HTTPError:
+                      raise
+                  except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
+                      if attempt == 2:
+                          raise
+                      print(f"[retry] {path}: {exc!r}", flush = True)
+                      time.sleep(15)
 
           def post_sse(path, body, *, timeout = 600):
               """POST a streaming request and accumulate the assistant
@@ -825,6 +838,8 @@ jobs:
           import base64
           import json
           import os
+          import time
+          import urllib.error
           import urllib.request
           from openai import OpenAI
           from anthropic import Anthropic
@@ -848,8 +863,19 @@ jobs:
                       "Content-Type":  "application/json",
                   },
               )
-              with urllib.request.urlopen(req, timeout = timeout) as resp:
-                  return resp.status, json.loads(resp.read().decode())
+              # Shared CI runners stall sporadically, so retry transport-level
+              # failures only; HTTP status errors surface immediately.
+              for attempt in range(3):
+                  try:
+                      with urllib.request.urlopen(req, timeout = timeout) as resp:
+                          return resp.status, json.loads(resp.read().decode())
+                  except urllib.error.HTTPError:
+                      raise
+                  except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
+                      if attempt == 2:
+                          raise
+                      print(f"[retry] {path}: {exc!r}", flush = True)
+                      time.sleep(15)
 
           # ── 1. response_format = json_object (JSON mode) ─────────────
           # llama.cpp's HTTP server supports OpenAI-compatible JSON

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -659,13 +659,15 @@ jobs:
                   },
               )
               # Shared CI runners stall sporadically, so retry transport-level
-              # failures only; HTTP status errors surface immediately. Long
-              # probes (timeout > 300s) get a single attempt so the worst
-              # case stays inside the job's timeout-minutes budget.
-              attempts = 3 if timeout <= 300 else 1
+              # failures only; HTTP status errors surface immediately. Bounded
+              # to fit the job's timeout-minutes: short probes get 3 full
+              # attempts, long probes one retry capped at 300s (a healthy
+              # server answers a retry quickly; a stalled one never does).
+              attempts = 3 if timeout <= 300 else 2
               for attempt in range(attempts):
                   try:
-                      with urllib.request.urlopen(req, timeout = timeout) as resp:
+                      t = timeout if attempt == 0 else min(timeout, 300)
+                      with urllib.request.urlopen(req, timeout = t) as resp:
                           return resp.status, json.loads(resp.read().decode())
                   except urllib.error.HTTPError:
                       raise
@@ -1101,13 +1103,15 @@ jobs:
                   },
               )
               # Shared CI runners stall sporadically, so retry transport-level
-              # failures only; HTTP status errors surface immediately. Long
-              # probes (timeout > 300s) get a single attempt so the worst
-              # case stays inside the job's timeout-minutes budget.
-              attempts = 3 if timeout <= 300 else 1
+              # failures only; HTTP status errors surface immediately. Bounded
+              # to fit the job's timeout-minutes: short probes get 3 full
+              # attempts, long probes one retry capped at 300s (a healthy
+              # server answers a retry quickly; a stalled one never does).
+              attempts = 3 if timeout <= 300 else 2
               for attempt in range(attempts):
                   try:
-                      with urllib.request.urlopen(req, timeout = timeout) as resp:
+                      t = timeout if attempt == 0 else min(timeout, 300)
+                      with urllib.request.urlopen(req, timeout = t) as resp:
                           return resp.status, json.loads(resp.read().decode())
                   except urllib.error.HTTPError:
                       raise

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -659,15 +659,18 @@ jobs:
                   },
               )
               # Shared CI runners stall sporadically, so retry transport-level
-              # failures only; HTTP status errors surface immediately.
-              for attempt in range(3):
+              # failures only; HTTP status errors surface immediately. Long
+              # probes (timeout > 300s) get a single attempt so the worst
+              # case stays inside the job's timeout-minutes budget.
+              attempts = 3 if timeout <= 300 else 1
+              for attempt in range(attempts):
                   try:
                       with urllib.request.urlopen(req, timeout = timeout) as resp:
                           return resp.status, json.loads(resp.read().decode())
                   except urllib.error.HTTPError:
                       raise
                   except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
-                      if attempt == 2:
+                      if attempt == attempts - 1:
                           raise
                       print(f"[retry] {path}: {exc!r}", flush = True)
                       time.sleep(15)
@@ -1098,15 +1101,18 @@ jobs:
                   },
               )
               # Shared CI runners stall sporadically, so retry transport-level
-              # failures only; HTTP status errors surface immediately.
-              for attempt in range(3):
+              # failures only; HTTP status errors surface immediately. Long
+              # probes (timeout > 300s) get a single attempt so the worst
+              # case stays inside the job's timeout-minutes budget.
+              attempts = 3 if timeout <= 300 else 1
+              for attempt in range(attempts):
                   try:
                       with urllib.request.urlopen(req, timeout = timeout) as resp:
                           return resp.status, json.loads(resp.read().decode())
                   except urllib.error.HTTPError:
                       raise
                   except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
-                      if attempt == 2:
+                      if attempt == attempts - 1:
                           raise
                       print(f"[retry] {path}: {exc!r}", flush = True)
                       time.sleep(15)

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -634,6 +634,8 @@ jobs:
           python - <<'PY'
           import json
           import os
+          import time
+          import urllib.error
           import urllib.request
 
           BASE = os.environ["BASE_URL"]
@@ -656,8 +658,19 @@ jobs:
                       "Content-Type": "application/json",
                   },
               )
-              with urllib.request.urlopen(req, timeout = timeout) as resp:
-                  return resp.status, json.loads(resp.read().decode())
+              # Shared CI runners stall sporadically, so retry transport-level
+              # failures only; HTTP status errors surface immediately.
+              for attempt in range(3):
+                  try:
+                      with urllib.request.urlopen(req, timeout = timeout) as resp:
+                          return resp.status, json.loads(resp.read().decode())
+                  except urllib.error.HTTPError:
+                      raise
+                  except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
+                      if attempt == 2:
+                          raise
+                      print(f"[retry] {path}: {exc!r}", flush = True)
+                      time.sleep(15)
 
           def post_sse(path, body, *, timeout = 600):
               body = {**body, "stream": True}
@@ -1063,6 +1076,8 @@ jobs:
           import base64
           import json
           import os
+          import time
+          import urllib.error
           import urllib.request
           from openai import OpenAI
           from anthropic import Anthropic
@@ -1082,8 +1097,19 @@ jobs:
                       "Content-Type":  "application/json",
                   },
               )
-              with urllib.request.urlopen(req, timeout = timeout) as resp:
-                  return resp.status, json.loads(resp.read().decode())
+              # Shared CI runners stall sporadically, so retry transport-level
+              # failures only; HTTP status errors surface immediately.
+              for attempt in range(3):
+                  try:
+                      with urllib.request.urlopen(req, timeout = timeout) as resp:
+                          return resp.status, json.loads(resp.read().decode())
+                  except urllib.error.HTTPError:
+                      raise
+                  except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
+                      if attempt == 2:
+                          raise
+                      print(f"[retry] {path}: {exc!r}", flush = True)
+                      time.sleep(15)
 
           # ── 1. response_format = json_object (JSON mode) ─────────────
           status, data = post("/v1/chat/completions", {


### PR DESCRIPTION
## Summary

The Studio inference smoke workflows (`studio-inference-smoke.yml`, `studio-mac-inference-smoke.yml`, `studio-windows-inference-smoke.yml`) probe the local Studio server with a `post()` helper that does a single `urllib.request.urlopen` with a 240s timeout. On shared runners this sporadically raises `TimeoutError: timed out` while the server is stalled, failing the whole 25 minute job for one transport hiccup.

This is a recurring flake, not a code signal: the same timeout hit the "JSON, images" job on #7042 and #7043 and the "Tool calling Tests" step on a Windows staging run, on unrelated diffs, and every occurrence passed on plain re-run.

## Change

Retry the probe in `post()` up to 3 times, 15s apart, on transport-level failures only: `TimeoutError`, `ConnectionError`, and non-HTTP `URLError`.

- `HTTPError` re-raises immediately, so any response the server actually produced (4xx/5xx) still fails on the first attempt and genuine regressions surface unchanged.
- `post_sse()` is deliberately untouched: it has a 600s budget and has not flaked.
- Worst case adds about 8.5 minutes, inside the 25/30 minute job budgets.
- Same change applied to all 6 `post()` definitions (2 per OS workflow), plus the `time` / `urllib.error` imports.

These probes hit a seeded local test server, so re-sending a request is safe.

## Validation

- YAML parse plus `ast.parse` of every inline python block in the three workflows.
- Unit-checked the retry semantics: timeout-twice-then-ok succeeds on attempt 3; HTTP 500 surfaces immediately with no retry; a permanent timeout re-raises after 3 attempts.
- Ran the three edited workflows end to end on a staging repo before opening this PR (each workflow self-triggers on edits to its own file): all runs green on ubuntu, macos, and windows, 40/40 including the full Studio suites.
