### PR TITLE
Fix SyntheticDataKit.chunk_data emitting chunks over max_tokens

### DIFF
--- a/tests/test_synthetic_chunk_data.py
+++ b/tests/test_synthetic_chunk_data.py
@@ -129,6 +129,43 @@ def test_chunk_data_uninitialized_error_names_real_class():
         os.unlink(path)
 
 
+def test_chunk_data_chunks_do_not_exceed_max_tokens():
+    # Every chunk must fit within max_tokens (= max_seq_length - 2*max_generation_tokens - 128).
+    # The multi-chunk path fed n_chunks points into linspace, but pairing boundaries[:-1] with
+    # boundaries[1:] turns N points into N-1 ranges, so it emitted one fewer, oversized chunk:
+    # chunks exceeded max_tokens and a document just over the threshold came back unsplit.
+    kit = _make_kit(max_seq_length = 2048, max_generation_tokens = 760, overlap = 64)
+    max_tokens = 2048 - 760 * 2 - 128  # 400
+
+    for n_words in (500, 2000):
+        out, contents = _chunk("word " * n_words, kit = kit)
+        assert (
+            len(out) >= 2
+        ), f"a {n_words}-token doc (> max_tokens={max_tokens}) must be split, got {len(out)}"
+        for content in contents:
+            n_tokens = len(content.split())
+            assert (
+                n_tokens <= max_tokens
+            ), f"chunk has {n_tokens} tokens, exceeding max_tokens={max_tokens}"
+
+
+def test_chunk_data_does_not_over_split():
+    # n_chunks must be the *minimum* number of max_tokens-bounded chunks. Because
+    # consecutive chunks overlap, that count is ceil((length - overlap) / stride),
+    # not ceil(length / stride): the latter over-counts by one just past a stride
+    # multiple and emits an extra redundant chunk. With max_tokens=400 / overlap=64
+    # a 673-token doc fits in 2 chunks (~369 + ~368); the loose count gave 3 of ~267.
+    kit = _make_kit(max_seq_length = 2048, max_generation_tokens = 760, overlap = 64)
+    max_tokens = 2048 - 760 * 2 - 128  # 400
+    out, contents = _chunk("word " * 673, kit = kit)
+    assert len(out) == 2, f"673-token doc should yield the minimal 2 chunks, got {len(out)}"
+    for content in contents:
+        n_tokens = len(content.split())
+        assert (
+            n_tokens <= max_tokens
+        ), f"chunk has {n_tokens} tokens, exceeding max_tokens={max_tokens}"
+
+
 if __name__ == "__main__":
     test_chunk_data_keeps_single_chunk_document()
     test_chunk_data_still_splits_long_document()
@@ -136,4 +173,6 @@ if __name__ == "__main__":
     test_chunk_data_short_document_is_not_split_into_fragments()
     test_chunk_data_rejects_overlap_not_smaller_than_chunk()
     test_chunk_data_uninitialized_error_names_real_class()
+    test_chunk_data_chunks_do_not_exceed_max_tokens()
+    test_chunk_data_does_not_over_split()
     print("OK")

--- a/tests/test_synthetic_chunk_data.py
+++ b/tests/test_synthetic_chunk_data.py
@@ -130,10 +130,8 @@ def test_chunk_data_uninitialized_error_names_real_class():
 
 
 def test_chunk_data_chunks_do_not_exceed_max_tokens():
-    # Every chunk must fit within max_tokens (= max_seq_length - 2*max_generation_tokens - 128).
-    # The multi-chunk path fed n_chunks points into linspace, but pairing boundaries[:-1] with
-    # boundaries[1:] turns N points into N-1 ranges, so it emitted one fewer, oversized chunk:
-    # chunks exceeded max_tokens and a document just over the threshold came back unsplit.
+    # Every chunk must fit within max_tokens. The old multi-chunk path emitted one
+    # fewer, oversized chunk, and a doc just over the threshold came back unsplit.
     kit = _make_kit(max_seq_length = 2048, max_generation_tokens = 760, overlap = 64)
     max_tokens = 2048 - 760 * 2 - 128  # 400
 
@@ -150,11 +148,9 @@ def test_chunk_data_chunks_do_not_exceed_max_tokens():
 
 
 def test_chunk_data_does_not_over_split():
-    # n_chunks must be the *minimum* number of max_tokens-bounded chunks. Because
-    # consecutive chunks overlap, that count is ceil((length - overlap) / stride),
-    # not ceil(length / stride): the latter over-counts by one just past a stride
-    # multiple and emits an extra redundant chunk. With max_tokens=400 / overlap=64
-    # a 673-token doc fits in 2 chunks (~369 + ~368); the loose count gave 3 of ~267.
+    # n_chunks must be the minimum count: ceil((length - overlap) / stride), not
+    # ceil(length / stride) which over-splits just past a stride multiple. At 673
+    # tokens (max_tokens=400, overlap=64) the tight count gives 2 chunks (~369+368).
     kit = _make_kit(max_seq_length = 2048, max_generation_tokens = 760, overlap = 64)
     max_tokens = 2048 - 760 * 2 - 128  # 400
     out, contents = _chunk("word " * 673, kit = kit)

--- a/unsloth/dataprep/synthetic.py
+++ b/unsloth/dataprep/synthetic.py
@@ -425,8 +425,16 @@ class SyntheticDataKit:
         else:
             # length > max_tokens > overlap here, so length - overlap > 0 and the
             # linspace boundaries below are always non-negative.
-            n_chunks = int(np.ceil(length / (max_tokens - self.overlap)))
-            boundaries = np.ceil(np.linspace(0, length - self.overlap, n_chunks)).astype(int)
+            # Consecutive chunks overlap by `overlap`, so N chunks capped at max_tokens
+            # cover N * (max_tokens - overlap) + overlap tokens. Covering `length` needs
+            # ceil((length - overlap) / (max_tokens - overlap)) chunks; dividing plain
+            # length by the stride over-counts by one just past a stride multiple and
+            # emits an extra redundant (smaller) chunk.
+            n_chunks = int(np.ceil((length - self.overlap) / (max_tokens - self.overlap)))
+            # Emit n_chunks ranges: pairing boundaries[:-1] with boundaries[1:] turns
+            # N points into N-1 ranges, so linspace needs n_chunks + 1 points. Using
+            # n_chunks points produced one fewer, oversized chunk (exceeding max_tokens).
+            boundaries = np.ceil(np.linspace(0, length - self.overlap, n_chunks + 1)).astype(int)
             boundaries = np.stack((boundaries[:-1], (boundaries + self.overlap)[1:])).T
             boundaries = np.minimum(boundaries, length).tolist()
 

--- a/unsloth/dataprep/synthetic.py
+++ b/unsloth/dataprep/synthetic.py
@@ -425,15 +425,12 @@ class SyntheticDataKit:
         else:
             # length > max_tokens > overlap here, so length - overlap > 0 and the
             # linspace boundaries below are always non-negative.
-            # Consecutive chunks overlap by `overlap`, so N chunks capped at max_tokens
-            # cover N * (max_tokens - overlap) + overlap tokens. Covering `length` needs
-            # ceil((length - overlap) / (max_tokens - overlap)) chunks; dividing plain
-            # length by the stride over-counts by one just past a stride multiple and
-            # emits an extra redundant (smaller) chunk.
+            # Minimal count: overlapping chunks cover `length` in
+            # ceil((length - overlap) / stride) chunks, not ceil(length / stride)
+            # which over-splits just past a stride multiple.
             n_chunks = int(np.ceil((length - self.overlap) / (max_tokens - self.overlap)))
-            # Emit n_chunks ranges: pairing boundaries[:-1] with boundaries[1:] turns
-            # N points into N-1 ranges, so linspace needs n_chunks + 1 points. Using
-            # n_chunks points produced one fewer, oversized chunk (exceeding max_tokens).
+            # n_chunks + 1 points: [:-1]/[1:] pairing yields n_chunks ranges; using
+            # n_chunks points gave one fewer, oversized chunk (over max_tokens).
             boundaries = np.ceil(np.linspace(0, length - self.overlap, n_chunks + 1)).astype(int)
             boundaries = np.stack((boundaries[:-1], (boundaries + self.overlap)[1:])).T
             boundaries = np.minimum(boundaries, length).tolist()


### PR DESCRIPTION
## Summary

`SyntheticDataKit.chunk_data` splits a document into chunks bounded by `max_tokens` (`max_seq_length - 2*max_generation_tokens - 128`). The multi-chunk path builds boundaries with `np.linspace(0, length - overlap, n_chunks)` — but `n_chunks` is the desired **chunk count**, while `linspace` receives it as the number of **points**. Pairing `boundaries[:-1]` with `boundaries[1:]` turns N points into N-1 ranges, so the function emits one fewer, oversized chunk. Every chunk ends up larger than `max_tokens`, and a document just over the threshold is returned as a single unsplit chunk.

The single-chunk branch just above already documents this exact off-by-one — *"the linspace/stack pairing emits one fewer range than boundary points"* — it was only worked around for the `length <= max_tokens` case, leaving the multi-chunk path broken.

Example (`max_tokens=400`, `overlap=64`, 1 token per word):

| doc tokens | current | fixed |
|---|---|---|
| 500 | **1 chunk of 500** (unsplit) | 2 chunks of 282/282 |
| 1000 | 2 chunks of 532 | 3 chunks of 376 |
| 2000 | 5 chunks of ~451 | 6 chunks of ~387 |

Every multi-chunk case currently exceeds `max_tokens`.

## Fix

Use `n_chunks + 1` linspace points so the `[:-1]`/`[1:]` pairing yields exactly `n_chunks` ranges, each within `max_tokens`. Overlap is preserved (`n_chunks >= 2` in this branch, so `n_chunks + 1 >= 3` points is always valid for `np.stack`).

## Test

Extended `tests/test_synthetic_chunk_data.py` with `test_chunk_data_chunks_do_not_exceed_max_tokens`, asserting every produced chunk is `<= max_tokens` for 500- and 2000-token documents. It fails before the fix (chunks over budget / a doc returned unsplit) and passes after. The existing `test_chunk_data_still_splits_long_document` only checked `len(out) > 1`, so it missed this.

The chunk-boundary logic is pure `numpy`; I verified fail-before/pass-after by running the exact algorithm with the test's mock tokenizer standalone (importing the full module requires a GPU environment). `ruff check` is clean.

No linked issue — found by reading the code.


## Update (3e49790)

Also tightened the chunk **count** in the same path (raised in review): `n_chunks` was `ceil(length / stride)`, but because consecutive chunks overlap by `overlap`, covering `length` needs `ceil((length - overlap) / stride)` chunks. The looser count over-counted by one just past a stride multiple — e.g. a 673-token doc produced 3 chunks of ~267 where 2 of ~369 suffice — emitting an extra redundant generation input. Now uses the non-overlapped span; coverage and overlap are unchanged and every chunk still stays within `max_tokens`. Added `test_chunk_data_does_not_over_split` (fails before at 3 chunks, passes after at 2). The advertised 500/1000/2000 examples are unchanged.
