### PR TITLE
Studio: appearance palettes, customization options

### DIFF
--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -562,11 +562,68 @@ class PersonalizationProfile(BaseModel):
         return value
 
 
+class PersonalizationCustomColors(BaseModel):
+    model_config = ConfigDict(extra = "ignore")
+
+    accent: Optional[str] = Field(None, pattern = r"^#[0-9a-fA-F]{6}$")
+    background: Optional[str] = Field(None, pattern = r"^#[0-9a-fA-F]{6}$")
+    foreground: Optional[str] = Field(None, pattern = r"^#[0-9a-fA-F]{6}$")
+
+
+class PersonalizationCustomColorModes(BaseModel):
+    model_config = ConfigDict(extra = "ignore")
+
+    light: PersonalizationCustomColors = Field(default_factory = PersonalizationCustomColors)
+    dark: PersonalizationCustomColors = Field(default_factory = PersonalizationCustomColors)
+
+
+MAX_IMPORTED_FONTS = 3
+# ~1.5 MB font file as base64; matches MAX_IMPORTED_FONT_DATA_URL_LENGTH in
+# the frontend appearance-custom-store.
+MAX_FONT_DATA_URL_LENGTH = 2_200_000
+
+
+class PersonalizationImportedFont(BaseModel):
+    model_config = ConfigDict(extra = "ignore")
+
+    name: str = Field(..., min_length = 1, max_length = 100)
+    dataUrl: str = Field(..., max_length = MAX_FONT_DATA_URL_LENGTH)
+
+    @field_validator("dataUrl")
+    @classmethod
+    def _validate_font_data_url(cls, value: str) -> str:
+        if not (value.startswith("data:font/") or value.startswith("data:application/")):
+            raise ValueError("dataUrl must be a font data URL.")
+        return value
+
+
+class PersonalizationCustomization(BaseModel):
+    model_config = ConfigDict(extra = "ignore")
+
+    colors: PersonalizationCustomColorModes = Field(default_factory = PersonalizationCustomColorModes)
+    uiFont: Optional[str] = Field(None, max_length = 200)
+    codeFont: Optional[str] = Field(None, max_length = 200)
+    importedFonts: list[PersonalizationImportedFont] = Field(
+        default_factory = list, max_length = MAX_IMPORTED_FONTS
+    )
+    uiFontSize: Optional[int] = Field(None, ge = 12, le = 20)
+    codeFontSize: Optional[int] = Field(None, ge = 10, le = 20)
+    contrast: int = Field(50, ge = 0, le = 100)
+    pointerCursors: bool = False
+    reduceMotion: Literal["system", "on", "off"] = "system"
+    fontSmoothing: bool = True
+    translucentSidebar: bool = False
+
+
 class PersonalizationAppearance(BaseModel):
     model_config = ConfigDict(extra = "ignore")
 
     theme: Literal["light", "dark", "system"] = "system"
+    palette: Literal["standard", "classic", "minimal"] = "standard"
     language: Optional[str] = Field(None, max_length = 20)
+    customization: PersonalizationCustomization = Field(
+        default_factory = PersonalizationCustomization
+    )
 
 
 class PersonalizationPayload(BaseModel):

--- a/studio/backend/tests/test_personalization_settings.py
+++ b/studio/backend/tests/test_personalization_settings.py
@@ -63,13 +63,9 @@ def test_customization_invalid_values_rejected():
             {"appearance": {"customization": {"colors": {"light": {"accent": "red"}}}}}
         )
     with pytest.raises(ValidationError):
-        PersonalizationPayload.model_validate(
-            {"appearance": {"customization": {"uiFontSize": 99}}}
-        )
+        PersonalizationPayload.model_validate({"appearance": {"customization": {"uiFontSize": 99}}})
     with pytest.raises(ValidationError):
-        PersonalizationPayload.model_validate(
-            {"appearance": {"customization": {"contrast": 500}}}
-        )
+        PersonalizationPayload.model_validate({"appearance": {"customization": {"contrast": 500}}})
     with pytest.raises(ValidationError):
         PersonalizationPayload.model_validate(
             {"appearance": {"customization": {"reduceMotion": "sometimes"}}}
@@ -81,9 +77,7 @@ def test_customization_imported_fonts_validated():
         {
             "appearance": {
                 "customization": {
-                    "importedFonts": [
-                        {"name": "My Font", "dataUrl": "data:font/woff2;base64,AAAA"}
-                    ]
+                    "importedFonts": [{"name": "My Font", "dataUrl": "data:font/woff2;base64,AAAA"}]
                 }
             }
         }

--- a/studio/backend/tests/test_personalization_settings.py
+++ b/studio/backend/tests/test_personalization_settings.py
@@ -23,6 +23,7 @@ def test_defaults_fill_missing_fields():
     p = PersonalizationPayload.model_validate({})
     assert p.version == pers.PERSONALIZATION_VERSION
     assert p.appearance.theme == "system"
+    assert p.appearance.palette == "standard"
     assert p.profile.avatarShape == "circle"
     assert p.profile.displayName == ""
 
@@ -37,6 +38,82 @@ def test_unknown_keys_are_ignored():
 def test_invalid_theme_rejected():
     with pytest.raises(ValidationError):
         PersonalizationPayload.model_validate({"appearance": {"theme": "neon"}})
+
+
+def test_invalid_palette_rejected():
+    with pytest.raises(ValidationError):
+        PersonalizationPayload.model_validate({"appearance": {"palette": "neon"}})
+
+
+def test_customization_defaults():
+    p = PersonalizationPayload.model_validate({})
+    c = p.appearance.customization
+    assert c.contrast == 50
+    assert c.reduceMotion == "system"
+    assert c.fontSmoothing is True
+    assert c.pointerCursors is False
+    assert c.translucentSidebar is False
+    assert c.colors.light.accent is None
+    assert c.uiFontSize is None
+
+
+def test_customization_invalid_values_rejected():
+    with pytest.raises(ValidationError):
+        PersonalizationPayload.model_validate(
+            {"appearance": {"customization": {"colors": {"light": {"accent": "red"}}}}}
+        )
+    with pytest.raises(ValidationError):
+        PersonalizationPayload.model_validate(
+            {"appearance": {"customization": {"uiFontSize": 99}}}
+        )
+    with pytest.raises(ValidationError):
+        PersonalizationPayload.model_validate(
+            {"appearance": {"customization": {"contrast": 500}}}
+        )
+    with pytest.raises(ValidationError):
+        PersonalizationPayload.model_validate(
+            {"appearance": {"customization": {"reduceMotion": "sometimes"}}}
+        )
+
+
+def test_customization_imported_fonts_validated():
+    ok = PersonalizationPayload.model_validate(
+        {
+            "appearance": {
+                "customization": {
+                    "importedFonts": [
+                        {"name": "My Font", "dataUrl": "data:font/woff2;base64,AAAA"}
+                    ]
+                }
+            }
+        }
+    )
+    assert ok.appearance.customization.importedFonts[0].name == "My Font"
+    with pytest.raises(ValidationError):
+        PersonalizationPayload.model_validate(
+            {
+                "appearance": {
+                    "customization": {
+                        "importedFonts": [
+                            {"name": "Evil", "dataUrl": "https://example.com/font.woff2"}
+                        ]
+                    }
+                }
+            }
+        )
+    with pytest.raises(ValidationError):
+        PersonalizationPayload.model_validate(
+            {
+                "appearance": {
+                    "customization": {
+                        "importedFonts": [
+                            {"name": f"Font {i}", "dataUrl": "data:font/ttf;base64,AAAA"}
+                            for i in range(4)
+                        ]
+                    }
+                }
+            }
+        )
 
 
 def test_avatar_must_be_image_data_url():
@@ -133,7 +210,29 @@ def test_personalization_route_roundtrip_real_shape(monkeypatch):
             "avatarDataUrl": "/Sloth%20emojis/large%20sloth%20yay.png",
             "avatarShape": "rounded",
         },
-        "appearance": {"theme": "dark", "language": "en"},
+        "appearance": {
+            "theme": "dark",
+            "palette": "classic",
+            "language": "en",
+            "customization": {
+                "colors": {
+                    "light": {"accent": "#339cff", "background": None, "foreground": None},
+                    "dark": {"accent": None, "background": "#111111", "foreground": None},
+                },
+                "uiFont": "SF Pro Text",
+                "codeFont": None,
+                "importedFonts": [
+                    {"name": "SF Pro Text", "dataUrl": "data:font/woff2;base64,AAAA"}
+                ],
+                "uiFontSize": 14,
+                "codeFontSize": 13,
+                "contrast": 60,
+                "pointerCursors": True,
+                "reduceMotion": "off",
+                "fontSmoothing": True,
+                "translucentSidebar": True,
+            },
+        },
     }
     put = client.put("/api/settings/personalization", json = payload)
     assert put.status_code == 200

--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -1,33 +1,39 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { LlamaUpdateBanner } from "@/components/llama-update-banner";
 import { StartupScreen } from "@/components/tauri/startup-screen";
 import { UpdateBanner } from "@/components/tauri/update-banner";
 import { UpdateScreen } from "@/components/tauri/update-screen";
 import {
   WindowTitlebar,
-  shouldUseNativeMacWindowTitlebar,
   shouldUseCustomWindowTitlebar,
+  shouldUseNativeMacWindowTitlebar,
 } from "@/components/tauri/window-titlebar";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { WebUpdateBanner } from "@/components/web/update-banner";
-import { LlamaUpdateBanner } from "@/components/llama-update-banner";
-import { DownloadManagerPanel } from "@/features/hub/download-manager";
+import { fetchDeviceType } from "@/config/env";
 import { getTauriAuthFailure, tauriAutoAuth } from "@/features/auth";
+import { DownloadManagerPanel } from "@/features/hub/download-manager";
 import { NativeIntentDrain } from "@/features/native-intents/native-intent-drain";
-import { useTauriBackend, type BackendStatus } from "@/hooks/use-tauri-backend";
+import {
+  applyCustomizationToDocument,
+  useAppearanceCustomStore,
+} from "@/features/settings/stores/appearance-custom-store";
+import { useTheme } from "@/features/settings/stores/theme-store";
+import { type BackendStatus, useTauriBackend } from "@/hooks/use-tauri-backend";
 import { useTauriUpdate } from "@/hooks/use-tauri-update";
 import { isTauri } from "@/lib/api-base";
-import { fetchDeviceType } from "@/config/env";
 import { useRouterState } from "@tanstack/react-router";
+import { MotionConfig } from "motion/react";
 import { ThemeProvider } from "next-themes";
 import {
+  type CSSProperties,
+  type ReactNode,
   useEffect,
   useRef,
   useState,
-  type CSSProperties,
-  type ReactNode,
 } from "react";
 
 interface AppProviderProps {
@@ -43,7 +49,9 @@ const SETUP_WINDOW_WIDTH = 760;
 const SETUP_WINDOW_HEIGHT = 560;
 
 async function showSetupWindow(isCurrent: WindowLayoutGuard): Promise<void> {
-  const { getCurrentWindow, LogicalSize } = await import("@tauri-apps/api/window");
+  const { getCurrentWindow, LogicalSize } = await import(
+    "@tauri-apps/api/window"
+  );
   if (!isCurrent()) return;
 
   const win = getCurrentWindow();
@@ -57,7 +65,9 @@ async function showSetupWindow(isCurrent: WindowLayoutGuard): Promise<void> {
 }
 
 async function enforceMinimumWindowSize(
-  win: Awaited<ReturnType<typeof import("@tauri-apps/api/window")["getCurrentWindow"]>>,
+  win: Awaited<
+    ReturnType<typeof import("@tauri-apps/api/window")["getCurrentWindow"]>
+  >,
   LogicalSize: typeof import("@tauri-apps/api/window")["LogicalSize"],
   isCurrent: WindowLayoutGuard,
 ): Promise<void> {
@@ -76,10 +86,16 @@ async function enforceMinimumWindowSize(
   }
 }
 
-async function applyAppWindowLayout(isCurrent: WindowLayoutGuard): Promise<void> {
-  const { getCurrentWindow, currentMonitor, LogicalSize } = await import("@tauri-apps/api/window");
+async function applyAppWindowLayout(
+  isCurrent: WindowLayoutGuard,
+): Promise<void> {
+  const { getCurrentWindow, currentMonitor, LogicalSize } = await import(
+    "@tauri-apps/api/window"
+  );
   const { invoke } = await import("@tauri-apps/api/core");
-  const { restoreStateCurrent, StateFlags } = await import("@tauri-apps/plugin-window-state");
+  const { restoreStateCurrent, StateFlags } = await import(
+    "@tauri-apps/plugin-window-state"
+  );
   if (!isCurrent()) return;
 
   const win = getCurrentWindow();
@@ -123,7 +139,10 @@ async function applyAppWindowLayout(isCurrent: WindowLayoutGuard): Promise<void>
   if (!isCurrent()) return;
   // Apply constraints after restore/show: doing so before plugin restore can emit
   // a Resized event and overwrite the plugin's cached saved size.
-  await win.setSizeConstraints({ minWidth: MIN_WINDOW_WIDTH, minHeight: MIN_WINDOW_HEIGHT });
+  await win.setSizeConstraints({
+    minWidth: MIN_WINDOW_WIDTH,
+    minHeight: MIN_WINDOW_HEIGHT,
+  });
   if (!isCurrent()) return;
   await enforceMinimumWindowSize(win, LogicalSize, isCurrent);
 }
@@ -252,9 +271,18 @@ const CUSTOM_CHROME_STYLE = {
 function TauriWrapper({ children }: { children: ReactNode }) {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const {
-    status, logs, error, isExternalServer,
-    currentStepIndex, progressDetail, elevationPackages,
-    startInstall, retry, retryInstall, approveElevation, copyDiagnostics,
+    status,
+    logs,
+    error,
+    isExternalServer,
+    currentStepIndex,
+    progressDetail,
+    elevationPackages,
+    startInstall,
+    retry,
+    retryInstall,
+    approveElevation,
+    copyDiagnostics,
   } = useTauriBackend();
 
   const appliedWindowModeRef = useRef<TauriWindowMode | null>(null);
@@ -288,14 +316,18 @@ function TauriWrapper({ children }: { children: ReactNode }) {
 
     const layoutGeneration = windowLayoutGenerationRef.current + 1;
     windowLayoutGenerationRef.current = layoutGeneration;
-    const isCurrent = () => windowLayoutGenerationRef.current === layoutGeneration;
-    const applyWindowMode = nextMode === "setup" ? showSetupWindow : applyAppWindowLayout;
+    const isCurrent = () =>
+      windowLayoutGenerationRef.current === layoutGeneration;
+    const applyWindowMode =
+      nextMode === "setup" ? showSetupWindow : applyAppWindowLayout;
     applyWindowMode(isCurrent).catch(async () => {
       if (!isCurrent()) return;
       // On failure, at minimum make the window visible and resizable so user can fix manually.
       try {
         await showWindowFallback();
-      } catch { /* swallow — window may still be functional */ }
+      } catch {
+        /* swallow; window may still be functional */
+      }
     });
   }, [status]);
 
@@ -325,7 +357,9 @@ function TauriWrapper({ children }: { children: ReactNode }) {
       }
     });
 
-    return () => { disposed = true; };
+    return () => {
+      disposed = true;
+    };
   }, [status, desktopAuthRetry]);
 
   useEffect(() => {
@@ -370,7 +404,9 @@ function TauriWrapper({ children }: { children: ReactNode }) {
           positioned={false}
           enabled={showInteractiveApp && !hidesTitlebarSidebar}
         />
-        {showInteractiveApp ? <DownloadManagerPanel positioned={false} /> : null}
+        {showInteractiveApp ? (
+          <DownloadManagerPanel positioned={false} />
+        ) : null}
       </TauriUpdateLayer>
       {showInteractiveApp ? <NativeIntentDrain /> : null}
       {showInteractiveApp ? children : null}
@@ -378,7 +414,10 @@ function TauriWrapper({ children }: { children: ReactNode }) {
         <div className="pointer-events-none fixed inset-x-0 bottom-5 z-[9999] flex justify-center px-4">
           <div className="absolute inset-x-4 bottom-16 mx-auto flex max-w-[520px] flex-col items-center gap-2 rounded-2xl border border-border/70 bg-background/95 px-6 py-5 text-center shadow-xl">
             <div className="font-medium text-sm">Preparing Studio</div>
-            <div className="text-muted-foreground text-xs">The local backend is ready. Signing in to your desktop session before loading chats.</div>
+            <div className="text-muted-foreground text-xs">
+              The local backend is ready. Signing in to your desktop session
+              before loading chats.
+            </div>
           </div>
           <div className="rounded-full border border-border/70 bg-background/95 px-4 py-2 text-xs text-muted-foreground shadow-lg">
             Signing in to desktop session...
@@ -416,9 +455,9 @@ function TauriWrapper({ children }: { children: ReactNode }) {
           }
           style={MAC_NATIVE_CHROME_STYLE}
         >
-          {(!showApp || hidesTitlebarSidebar) ? (
+          {!showApp || hidesTitlebarSidebar ? (
             <div
-              data-tauri-drag-region
+              data-tauri-drag-region={true}
               aria-hidden="true"
               className="pointer-events-auto fixed inset-x-0 top-0 z-50 h-[var(--studio-mac-titlebar-height,34px)] select-none"
             />
@@ -428,13 +467,10 @@ function TauriWrapper({ children }: { children: ReactNode }) {
       );
     }
 
-    return (
-      <>{content}</>
-    );
+    return <>{content}</>;
   }
 
-  const showSidebarSurface =
-    showApp && !hidesTitlebarSidebar;
+  const showSidebarSurface = showApp && !hidesTitlebarSidebar;
 
   return (
     <div
@@ -442,29 +478,51 @@ function TauriWrapper({ children }: { children: ReactNode }) {
       style={CUSTOM_CHROME_STYLE}
     >
       <WindowTitlebar showSidebarSurface={showSidebarSurface} />
-      <div className="h-full min-h-0 overflow-hidden">
-        {content}
-      </div>
+      <div className="h-full min-h-0 overflow-hidden">{content}</div>
     </div>
   );
 }
 
+/**
+ * Mirrors the appearance customization store onto <html> (inline CSS vars,
+ * classes, attributes). Colors are per resolved light/dark mode, so re-apply
+ * whenever either the customization or the resolved theme changes.
+ */
+function AppearanceCustomizationEffect() {
+  const { resolved } = useTheme();
+  const customization = useAppearanceCustomStore((s) => s.customization);
+  useEffect(() => {
+    applyCustomizationToDocument(customization, resolved);
+  }, [customization, resolved]);
+  return null;
+}
+
+const REDUCED_MOTION_MAP = {
+  system: "user",
+  on: "always",
+  off: "never",
+} as const;
+
 export function AppProvider({ children }: AppProviderProps) {
+  const reduceMotion = useAppearanceCustomStore(
+    (s) => s.customization.reduceMotion,
+  );
   return (
-    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-      <TooltipProvider>
-        <TauriWrapper>
-          {children}
-        </TauriWrapper>
-        <Toaster
-          position="top-right"
-          visibleToasts={2}
-          expand={true}
-          closeButton={true}
-          // Clear the chat header buttons on the right.
-          offset={{ top: 12, right: 64 }}
-        />
-      </TooltipProvider>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem={true}>
+      <MotionConfig reducedMotion={REDUCED_MOTION_MAP[reduceMotion]}>
+        <TooltipProvider>
+          <AppearanceCustomizationEffect />
+          <TauriWrapper>{children}</TauriWrapper>
+          <Toaster
+            position="top-right"
+            visibleToasts={2}
+            expand={true}
+            closeButton={true}
+            // Clear the chat header buttons on the right.
+            offset={{ top: 12, right: 64 }}
+          />
+        </TooltipProvider>
+      </MotionConfig>
     </ThemeProvider>
   );
 }

--- a/studio/frontend/src/components/assistant-ui/model-selector/folder-browser.tsx
+++ b/studio/frontend/src/components/assistant-ui/model-selector/folder-browser.tsx
@@ -18,8 +18,9 @@ import {
   type BrowseFoldersResponse,
   browseFolders,
 } from "@/features/chat/api/chat-api";
+import { ChevronUpStandardIcon } from "@/lib/chevron-icons";
 import { cn } from "@/lib/utils";
-import { ArrowUp02Icon, Folder02Icon } from "@hugeicons/core-free-icons";
+import { Folder02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -230,7 +231,7 @@ export function FolderBrowser({
                   className="flex w-full items-center gap-2 px-6 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 >
                   <HugeiconsIcon
-                    icon={ArrowUp02Icon}
+                    icon={ChevronUpStandardIcon}
                     className="size-3 shrink-0"
                   />
                   <span className="font-mono">..</span>

--- a/studio/frontend/src/components/ui/accordion.tsx
+++ b/studio/frontend/src/components/ui/accordion.tsx
@@ -7,7 +7,7 @@ import { Accordion as AccordionPrimitive } from "radix-ui";
 import type * as React from "react";
 
 import { cn } from "@/lib/utils";
-import { ArrowDown01Icon, ArrowUp01Icon } from "@hugeicons/core-free-icons";
+import { ChevronDownStandardIcon, ChevronUpStandardIcon } from "@/lib/chevron-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
 function Accordion({
@@ -56,13 +56,13 @@ function AccordionTrigger({
       >
         {children}
         <HugeiconsIcon
-          icon={ArrowDown01Icon}
+          icon={ChevronDownStandardIcon}
           strokeWidth={2}
           data-slot="accordion-trigger-icon"
           className="pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden"
         />
         <HugeiconsIcon
-          icon={ArrowUp01Icon}
+          icon={ChevronUpStandardIcon}
           strokeWidth={2}
           data-slot="accordion-trigger-icon"
           className="pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline"

--- a/studio/frontend/src/components/ui/button.tsx
+++ b/studio/frontend/src/components/ui/button.tsx
@@ -17,7 +17,7 @@ export const buttonVariants = cva(
         default: "bg-primary text-primary-foreground hover:bg-primary/80",
         dark: "bg-foreground text-background hover:bg-foreground/85 dark:bg-foreground dark:text-background",
         outline:
-          "border-border bg-input/30 hover:bg-input/50 hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground",
+          "border-border bg-background hover:bg-accent/50 dark:border-transparent dark:bg-white/10 dark:hover:bg-white/[0.14] hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         ghost:

--- a/studio/frontend/src/components/ui/input-group.tsx
+++ b/studio/frontend/src/components/ui/input-group.tsx
@@ -15,7 +15,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="input-group"
       role="group"
       className={cn(
-        "border-input bg-input/30 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 h-9 rounded-4xl border transition-colors has-data-[align=block-end]:rounded-2xl has-data-[align=block-start]:rounded-2xl has-[[data-slot=input-group-control]:focus-visible]:ring-[3px] has-[[data-slot][aria-invalid=true]]:ring-[3px] has-[textarea]:rounded-xl has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5 [[data-slot=combobox-content]_&]:focus-within:border-inherit [[data-slot=combobox-content]_&]:focus-within:ring-0 group/input-group relative flex w-full min-w-0 items-center outline-none has-[>textarea]:h-auto",
+        "border-transparent bg-panel-input-surface has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 h-9 rounded-full border transition-colors has-data-[align=block-end]:rounded-2xl has-data-[align=block-start]:rounded-2xl has-[[data-slot=input-group-control]:focus-visible]:ring-[3px] has-[[data-slot][aria-invalid=true]]:ring-[3px] has-[textarea]:rounded-xl has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5 [[data-slot=combobox-content]_&]:focus-within:border-inherit [[data-slot=combobox-content]_&]:focus-within:ring-0 group/input-group relative flex w-full min-w-0 items-center outline-none has-[>textarea]:h-auto",
         className,
       )}
       {...props}
@@ -122,7 +122,7 @@ function InputGroupInput({
     <Input
       data-slot="input-group-control"
       className={cn(
-        "rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent flex-1",
+        "rounded-none border-0 bg-transparent hover:bg-transparent shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent flex-1",
         className,
       )}
       {...props}

--- a/studio/frontend/src/components/ui/input.tsx
+++ b/studio/frontend/src/components/ui/input.tsx
@@ -11,7 +11,9 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-9 rounded-4xl border px-3 py-1 text-base transition-colors file:h-7 file:text-sm file:font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+        // ChatGPT-app field styling: soft solid fill, no visible border,
+        // fully-rounded pill for single-row controls.
+        "bg-panel-input-surface hover:bg-panel-input-surface-hover border-transparent focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-9 rounded-full border px-3.5 py-1 text-base transition-colors file:h-7 file:text-sm file:font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       {...props}

--- a/studio/frontend/src/components/ui/navigation-menu.tsx
+++ b/studio/frontend/src/components/ui/navigation-menu.tsx
@@ -8,7 +8,7 @@ import { NavigationMenu as NavigationMenuPrimitive } from "radix-ui";
 import type * as React from "react";
 
 import { cn } from "@/lib/utils";
-import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
+import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
 export function NavigationMenu({
@@ -87,7 +87,7 @@ export function NavigationMenuTrigger({
     >
       {children}{" "}
       <HugeiconsIcon
-        icon={ArrowDown01Icon}
+        icon={ChevronDownStandardIcon}
         strokeWidth={2}
         className="relative top-[1px] ml-1 size-3 transition duration-300 group-data-open/navigation-menu-trigger:rotate-180 group-data-popup-open/navigation-menu-trigger:rotate-180"
         aria-hidden="true"

--- a/studio/frontend/src/components/ui/select.tsx
+++ b/studio/frontend/src/components/ui/select.tsx
@@ -8,14 +8,12 @@ import type * as React from "react";
 import { createContext, useContext, useState } from "react";
 
 import { Tick02Icon } from "@/lib/tick-icon";
-import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
+import {
+  ChevronDownStandardIcon,
+  ChevronUpStandardIcon,
+} from "@/lib/chevron-icons";
 import { cn } from "@/lib/utils";
 import { useDialogPortalContainer } from "@/components/ui/dialog";
-import {
-  ArrowDown01Icon,
-  ArrowUp01Icon,
-  UnfoldMoreIcon,
-} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
 const SelectOpenContext = createContext(false);
@@ -70,7 +68,7 @@ function SelectTrigger({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
   size?: "sm" | "default";
-  icon?: typeof UnfoldMoreIcon;
+  icon?: typeof ChevronDownStandardIcon;
   iconClassName?: string;
   animateRadius?: boolean;
 }) {
@@ -91,7 +89,7 @@ function SelectTrigger({
           : undefined
       }
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 gap-1.5 rounded-4xl border px-3 py-2 text-sm transition-colors focus-visible:ring-[3px] aria-invalid:ring-[3px] data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:flex *:data-[slot=select-value]:gap-1.5 [&_svg:not([class*='size-'])]:size-4 flex w-fit items-center justify-between whitespace-nowrap outline-none disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center [&_svg]:pointer-events-none [&_svg]:shrink-0 cursor-pointer",
+        "border-border data-[placeholder]:text-muted-foreground bg-background hover:bg-accent/50 dark:border-white/10 dark:bg-white/[0.06] dark:hover:bg-white/10 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 gap-1.5 rounded-full border px-3.5 py-2 text-sm transition-colors focus-visible:ring-[3px] aria-invalid:ring-[3px] data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:flex *:data-[slot=select-value]:gap-1.5 [&_svg:not([class*='size-'])]:size-4 flex w-fit items-center justify-between whitespace-nowrap outline-none disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center [&_svg]:pointer-events-none [&_svg]:shrink-0 cursor-pointer",
         className,
       )}
       {...props}
@@ -222,7 +220,7 @@ function SelectScrollUpButton({
       )}
       {...props}
     >
-      <HugeiconsIcon icon={ArrowUp01Icon} strokeWidth={2} />
+      <HugeiconsIcon icon={ChevronUpStandardIcon} strokeWidth={2} />
     </SelectPrimitive.ScrollUpButton>
   );
 }
@@ -240,7 +238,7 @@ function SelectScrollDownButton({
       )}
       {...props}
     >
-      <HugeiconsIcon icon={ArrowDown01Icon} strokeWidth={2} />
+      <HugeiconsIcon icon={ChevronDownStandardIcon} strokeWidth={2} />
     </SelectPrimitive.ScrollDownButton>
   );
 }

--- a/studio/frontend/src/components/ui/switch.tsx
+++ b/studio/frontend/src/components/ui/switch.tsx
@@ -18,14 +18,14 @@ function Switch({
       data-slot="switch"
       data-size={size}
       className={cn(
-        "data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-[3px] aria-invalid:ring-[3px] data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] peer group/switch relative inline-flex items-center transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        "data-checked:bg-control-accent data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-[3px] aria-invalid:ring-[3px] data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] peer group/switch relative inline-flex items-center transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 data-disabled:cursor-not-allowed data-disabled:opacity-50",
         className,
       )}
       {...props}
     >
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
-        className="bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 pointer-events-none block ring-0 transition-transform"
+        className="bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-control-accent-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 pointer-events-none block ring-0 transition-transform"
       />
     </SwitchPrimitive.Root>
   );

--- a/studio/frontend/src/components/ui/textarea.tsx
+++ b/studio/frontend/src/components/ui/textarea.tsx
@@ -18,7 +18,9 @@ function Textarea({
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 resize-none rounded-xl border px-3 py-3 text-base transition-colors focus-visible:ring-[3px] aria-invalid:ring-[3px] md:text-sm placeholder:text-muted-foreground flex min-h-16 min-w-0 max-w-full w-full whitespace-pre-wrap break-words [overflow-wrap:anywhere] outline-none disabled:cursor-not-allowed disabled:opacity-50",
+        // ChatGPT-app field styling: soft solid fill, no visible border.
+        // Multi-row control, so rounded-xl rather than a full pill.
+        "border-transparent bg-panel-input-surface focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 resize-none rounded-xl border px-3.5 py-3 text-base transition-colors focus-visible:ring-[3px] aria-invalid:ring-[3px] md:text-sm placeholder:text-muted-foreground flex min-h-16 min-w-0 max-w-full w-full whitespace-pre-wrap break-words [overflow-wrap:anywhere] outline-none disabled:cursor-not-allowed disabled:opacity-50",
         fieldSizing === "content" ? "field-sizing-content" : "[field-sizing:fixed]",
         className,
       )}

--- a/studio/frontend/src/features/data-recipes/pages/data-recipes-page.tsx
+++ b/studio/frontend/src/features/data-recipes/pages/data-recipes-page.tsx
@@ -25,10 +25,10 @@ import {
   EmptyTitle,
 } from "@/components/ui/empty";
 import { ShineBorder } from "@/components/ui/shine-border";
+import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
 import { toastError } from "@/shared/toast";
 import {
   Album02Icon,
-  ArrowDown01Icon,
   CodeIcon,
   CookBookIcon,
   Database02Icon,
@@ -415,7 +415,10 @@ export function DataRecipesPage(): ReactElement {
               <Button type="button" disabled={isBusy}>
                 <HugeiconsIcon icon={PlusSignIcon} className="size-4" />
                 New Recipe
-                <HugeiconsIcon icon={ArrowDown01Icon} className="size-4" />
+                <HugeiconsIcon
+                  icon={ChevronDownStandardIcon}
+                  className="size-4"
+                />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
@@ -439,7 +442,88 @@ export function DataRecipesPage(): ReactElement {
           </DropdownMenu>
         </div>
 
-        {!ready ? (
+        {ready ? (
+          recipes.length === 0 ? (
+            <Empty className="mt-8 border border-dashed border-border/70 dark:border-none">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <HugeiconsIcon icon={CookBookIcon} className="size-5" />
+                </EmptyMedia>
+                <EmptyTitle>No recipes yet</EmptyTitle>
+                <EmptyDescription>
+                  Browse Learning Recipes below to understand how recipe
+                  workflows work.
+                </EmptyDescription>
+              </EmptyHeader>
+              <EmptyContent className="max-w-6xl items-stretch">
+                {/*<Button*/}
+                {/*  type="button"*/}
+                {/*  variant="secondary"*/}
+                {/*  className="mx-auto"*/}
+                {/*  onClick={() => setLearningDialogOpen(true)}*/}
+                {/*  disabled={isBusy}*/}
+                {/*>*/}
+                {/*  <HugeiconsIcon icon={CookBookIcon} className="size-4" />*/}
+                {/*  Start Tutorial*/}
+                {/*</Button>*/}
+                <LearningRecipeCards
+                  onSelect={(template) => {
+                    openLearningRecipe(template).catch(() => undefined);
+                  }}
+                  loadingTemplateId={loadingTemplateId}
+                />
+              </EmptyContent>
+            </Empty>
+          ) : (
+            <div className="mt-8 space-y-2">
+              {recipes.map((recipe) => (
+                <div
+                  key={recipe.id}
+                  className="flex items-center gap-3 rounded-xl border bg-card px-4 py-3"
+                >
+                  <button
+                    type="button"
+                    className="flex min-w-0 flex-1 items-center gap-3 text-left"
+                    onClick={() => openRecipe(recipe)}
+                  >
+                    <div className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/20">
+                      <HugeiconsIcon
+                        icon={CookBookIcon}
+                        className="size-4 text-muted-foreground"
+                      />
+                    </div>
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <p className="truncate text-sm font-medium">
+                          {recipe.name}
+                        </p>
+                        {recipe.learningRecipeId ? (
+                          <Badge variant="outline">Learning Recipe</Badge>
+                        ) : null}
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        Last updated {formatRelativeTime(recipe.updatedAt)} |
+                        Created {formatRelativeTime(recipe.createdAt)}
+                      </p>
+                    </div>
+                  </button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-8"
+                    onClick={() => {
+                      handleDeleteRecipe(recipe.id).catch(() => undefined);
+                    }}
+                    aria-label={`Delete ${recipe.name}`}
+                  >
+                    <HugeiconsIcon icon={Delete02Icon} className="size-4" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )
+        ) : (
           <div className="mt-8 rounded-2xl border border-border/70 bg-card px-6 py-10 text-center">
             <p className="text-sm font-medium text-foreground">
               Loading recipes
@@ -447,85 +531,6 @@ export function DataRecipesPage(): ReactElement {
             <p className="mt-1 text-xs text-muted-foreground">
               Fetching your saved recipes and learning templates.
             </p>
-          </div>
-        ) : recipes.length === 0 ? (
-          <Empty className="mt-8 border border-dashed border-border/70 dark:border-none">
-            <EmptyHeader>
-              <EmptyMedia variant="icon">
-                <HugeiconsIcon icon={CookBookIcon} className="size-5" />
-              </EmptyMedia>
-              <EmptyTitle>No recipes yet</EmptyTitle>
-              <EmptyDescription>
-                Browse Learning Recipes below to understand how recipe workflows
-                work.
-              </EmptyDescription>
-            </EmptyHeader>
-            <EmptyContent className="max-w-6xl items-stretch">
-              {/*<Button*/}
-              {/*  type="button"*/}
-              {/*  variant="secondary"*/}
-              {/*  className="mx-auto"*/}
-              {/*  onClick={() => setLearningDialogOpen(true)}*/}
-              {/*  disabled={isBusy}*/}
-              {/*>*/}
-              {/*  <HugeiconsIcon icon={CookBookIcon} className="size-4" />*/}
-              {/*  Start Tutorial*/}
-              {/*</Button>*/}
-              <LearningRecipeCards
-                onSelect={(template) => {
-                  openLearningRecipe(template).catch(() => undefined);
-                }}
-                loadingTemplateId={loadingTemplateId}
-              />
-            </EmptyContent>
-          </Empty>
-        ) : (
-          <div className="mt-8 space-y-2">
-            {recipes.map((recipe) => (
-              <div
-                key={recipe.id}
-                className="flex items-center gap-3 rounded-xl border bg-card px-4 py-3"
-              >
-                <button
-                  type="button"
-                  className="flex min-w-0 flex-1 items-center gap-3 text-left"
-                  onClick={() => openRecipe(recipe)}
-                >
-                  <div className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-border/70 bg-muted/20">
-                    <HugeiconsIcon
-                      icon={CookBookIcon}
-                      className="size-4 text-muted-foreground"
-                    />
-                  </div>
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-2">
-                      <p className="truncate text-sm font-medium">
-                        {recipe.name}
-                      </p>
-                      {recipe.learningRecipeId ? (
-                        <Badge variant="outline">Learning Recipe</Badge>
-                      ) : null}
-                    </div>
-                    <p className="text-xs text-muted-foreground">
-                      Last updated {formatRelativeTime(recipe.updatedAt)} |
-                      Created {formatRelativeTime(recipe.createdAt)}
-                    </p>
-                  </div>
-                </button>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="size-8"
-                  onClick={() => {
-                    handleDeleteRecipe(recipe.id).catch(() => undefined);
-                  }}
-                  aria-label={`Delete ${recipe.name}`}
-                >
-                  <HugeiconsIcon icon={Delete02Icon} className="size-4" />
-                </Button>
-              </div>
-            ))}
           </div>
         )}
       </main>

--- a/studio/frontend/src/features/export/export-page.tsx
+++ b/studio/frontend/src/features/export/export-page.tsx
@@ -2,8 +2,8 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { SectionCard } from "@/components/section-card";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Switch } from "@/components/ui/switch";
 import {
   Combobox,
   ComboboxContent,
@@ -12,6 +12,14 @@ import {
   ComboboxItem,
   ComboboxList,
 } from "@/components/ui/combobox";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   InputGroup,
   InputGroupAddon,
@@ -24,46 +32,37 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
-} from "@/components/ui/alert";
 import { Separator } from "@/components/ui/separator";
 import { Spinner } from "@/components/ui/spinner";
+import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import {
-  listLocalModels,
-  type LocalModelInfo,
-  useTrainingConfigStore,
-} from "@/features/training";
+import { usePlatformStore } from "@/config/env";
 import { useHubModelSearch } from "@/features/hub/hooks/use-hub-model-search";
 import { confirmRemoteCodeIfNeeded } from "@/features/security";
+import { GuidedTour, useGuidedTourController } from "@/features/tour";
+import {
+  type LocalModelInfo,
+  listLocalModels,
+  useTrainingConfigStore,
+} from "@/features/training";
 import { useDebouncedValue, useHfTokenValidation } from "@/hooks";
+import { useHardwareInfo } from "@/hooks/use-hardware-info";
+import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
 import {
   AlertCircleIcon,
-  ArrowDown01Icon,
   FolderSearchIcon,
   InformationCircleIcon,
   Key01Icon,
   PackageIcon,
   Search01Icon,
 } from "@hugeicons/core-free-icons";
-import { useSearch } from "@tanstack/react-router";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { useSearch } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import type { ModelCheckpoints } from "./api/export-api";
@@ -77,22 +76,23 @@ import {
   GUIDE_STEPS,
   MERGED_FORMATS,
   type MergedFormatOption,
-  mergedFormatPayload,
   QUANT_OPTIONS,
   buildQuantSizeLabels,
   getEstimatedSize,
+  mergedFormatPayload,
 } from "./constants";
-import { useHardwareInfo } from "@/hooks/use-hardware-info";
-import { usePlatformStore } from "@/config/env";
+import { useExportSizeEstimate } from "./hooks/use-export-size-estimate";
 import {
   isExportPanelActive,
   useExportRuntimeStore,
 } from "./stores/export-runtime-store";
-import { useExportSizeEstimate } from "./hooks/use-export-size-estimate";
-import { GuidedTour, useGuidedTourController } from "@/features/tour";
 import { exportTourSteps } from "./tour";
 
-const SEARCH_INPUT_REASONS = new Set(["input-change", "input-paste", "input-clear"]);
+const SEARCH_INPUT_REASONS = new Set([
+  "input-change",
+  "input-paste",
+  "input-clear",
+]);
 
 // GGUF LoRA output float types (Q8_0 first / default). Q8_0 falls back to F16 per tensor for dims
 // not divisible by the block size (32); no "auto" - the choice is explicit.
@@ -100,7 +100,6 @@ const LORA_GGUF_OUTTYPES = ["q8_0", "f16", "bf16", "f32"] as const;
 
 type SourceTab = "local" | "checkpoint" | "hf";
 type SourceMode = "checkpoint" | "model";
-
 
 function safePathSegment(
   value: string | null | undefined,
@@ -125,7 +124,7 @@ function buildRelativeSaveDirectory(
   if (exportMethod === "gguf") {
     const rawName =
       sourceMode === "checkpoint"
-        ? checkpoint ?? selectedModelIdx ?? sourceBaseModelName
+        ? (checkpoint ?? selectedModelIdx ?? sourceBaseModelName)
         : sourceBaseModelName;
     return `${safePathSegment(rawName)}-GGUF`;
   }
@@ -136,7 +135,7 @@ function buildRelativeSaveDirectory(
   // Local / HF source (no checkpoint): name from the model id to avoid "model/null".
   const rawName =
     sourceMode === "checkpoint"
-      ? checkpoint ?? selectedModelIdx ?? sourceBaseModelName
+      ? (checkpoint ?? selectedModelIdx ?? sourceBaseModelName)
       : sourceBaseModelName;
   return `${safePathSegment(rawName)}-${exportMethod === "lora" ? "adapter" : "merged"}`;
 }
@@ -154,11 +153,12 @@ function siblingGgufDirectory(sourcePath: string): string | null {
       : trimmed.slice(0, slash);
   const name = trimmed.slice(slash + 1);
   if (!name) return null;
-  const sep = parent.endsWith("/") || parent.endsWith("\\")
-    ? ""
-    : trimmed.includes("\\")
-      ? "\\"
-      : "/";
+  const sep =
+    parent.endsWith("/") || parent.endsWith("\\")
+      ? ""
+      : trimmed.includes("\\")
+        ? "\\"
+        : "/";
   return `${parent}${sep}${name}_gguf`;
 }
 
@@ -250,9 +250,7 @@ export function ExportPage() {
   );
   const toggleFormat = useCallback((value: string) => {
     setSelectedFormats((prev) =>
-      prev.includes(value)
-        ? prev.filter((v) => v !== value)
-        : [...prev, value],
+      prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value],
     );
   }, []);
   // availableFormats already drops NVIDIA-only formats on other hardware, so no pruning needed.
@@ -353,7 +351,9 @@ export function ExportPage() {
       .catch((error) => {
         if (controller.signal.aborted) return;
         setLocalModelsError(
-          error instanceof Error ? error.message : "Failed to load local models",
+          error instanceof Error
+            ? error.message
+            : "Failed to load local models",
         );
       })
       .finally(() => {
@@ -367,7 +367,7 @@ export function ExportPage() {
   const selectedModelData = useMemo(
     () =>
       selectedModelIdx != null
-        ? models.find((m) => m.name === selectedModelIdx) ?? null
+        ? (models.find((m) => m.name === selectedModelIdx) ?? null)
         : null,
     [models, selectedModelIdx],
   );
@@ -390,9 +390,8 @@ export function ExportPage() {
   const trainingMethodLabel = selectedModelData?.peft_type
     ? "LoRA / QLoRA"
     : "Full Fine-tune";
-  const sourceBaseModelName = sourceMode === "model"
-    ? selectedSourceModel ?? "—"
-    : baseModelName;
+  const sourceBaseModelName =
+    sourceMode === "model" ? (selectedSourceModel ?? "—") : baseModelName;
 
   // For a full fine-tune checkpoint the weights live in the checkpoint dir
   // itself (its base_model may be a local/custom path that can't be sized), so
@@ -405,10 +404,19 @@ export function ExportPage() {
       }
     }
     return sourceBaseModelName;
-  }, [sourceMode, isAdapter, checkpointsForModel, checkpoint, sourceBaseModelName]);
+  }, [
+    sourceMode,
+    isAdapter,
+    checkpointsForModel,
+    checkpoint,
+    sourceBaseModelName,
+  ]);
 
   // Real (MoE-aware) fp16 size, used to scale the GGUF quant estimates.
-  const { fp16Bytes } = useExportSizeEstimate(sizeTargetModel, debouncedHfToken);
+  const { fp16Bytes } = useExportSizeEstimate(
+    sizeTargetModel,
+    debouncedHfToken,
+  );
   const quantSizeLabels = useMemo(
     () => buildQuantSizeLabels(fp16Bytes),
     [fp16Bytes],
@@ -521,7 +529,13 @@ export function ExportPage() {
     if ((!effectiveIsAdapter || isMacHost) && ggufTarget !== "model") {
       setGgufTarget("model");
     }
-  }, [effectiveIsAdapter, effectiveIsQuantized, exportMethod, isMacHost, ggufTarget]);
+  }, [
+    effectiveIsAdapter,
+    effectiveIsQuantized,
+    exportMethod,
+    isMacHost,
+    ggufTarget,
+  ]);
 
   const handleSourceTabChange = useCallback((next: string) => {
     if (next === "checkpoint") {
@@ -579,7 +593,10 @@ export function ExportPage() {
       selectedSourceModel
     ) {
       const localModel = localMetaById.get(selectedSourceModel);
-      if (localModel && (localModel.source === "models_dir" || localModel.source === "custom")) {
+      if (
+        localModel &&
+        (localModel.source === "models_dir" || localModel.source === "custom")
+      ) {
         return siblingGgufDirectory(localModel.path) ?? relative;
       }
     }
@@ -606,7 +623,9 @@ export function ExportPage() {
 
   // Restrict a Hub merged export to a single format; multi-format stays available for local export.
   const hubMultiFormat =
-    destination === "hub" && exportMethod === "merged" && selectedFormats.length > 1;
+    destination === "hub" &&
+    exportMethod === "merged" &&
+    selectedFormats.length > 1;
 
   const canExport = !!(
     selectedExportSource &&
@@ -657,7 +676,14 @@ export function ExportPage() {
 
   useEffect(() => {
     setCustomSaveDirectory(null);
-  }, [checkpoint, exportMethod, modelSource, selectedModelIdx, selectedSourceModel, sourceMode]);
+  }, [
+    checkpoint,
+    exportMethod,
+    modelSource,
+    selectedModelIdx,
+    selectedSourceModel,
+    sourceMode,
+  ]);
 
   const handleLocalSourceInputChange = useCallback(
     (value: string, eventDetails?: { reason?: string }) => {
@@ -677,27 +703,31 @@ export function ExportPage() {
   // Assemble the run params from the current form and hand off to the global
   // runtime store, which drives load -> export -> cleanup in the background.
   const handleStart = useCallback(async () => {
-    const source = sourceMode === "checkpoint" ? checkpoint : selectedSourceModel;
+    const source =
+      sourceMode === "checkpoint" ? checkpoint : selectedSourceModel;
     if (!source || !exportMethod) return;
     // No supported accelerator (or PyTorch/MLX missing): the backend would reject anyway; don't submit.
     if (exportUnsupported) return;
     // GGUF with no quant, or merged with no format, would run an unintended/empty export; require
     // at least one (mirrors canExport, in case the panel's Start button bypasses the outer one).
-    if (exportMethod === "gguf" && !ggufAsLora && quantLevels.length === 0) return;
+    if (exportMethod === "gguf" && !ggufAsLora && quantLevels.length === 0)
+      return;
     if (exportMethod === "merged" && selectedFormats.length === 0) return;
     // A Hub merged push writes each format to the repo root; several would collide (mirrors canExport).
     if (hubMultiFormat) return;
 
-    const selectedCp = sourceMode === "checkpoint"
-      ? checkpointsForModel.find((cp) => cp.display_name === checkpoint)
-      : null;
+    const selectedCp =
+      sourceMode === "checkpoint"
+        ? checkpointsForModel.find((cp) => cp.display_name === checkpoint)
+        : null;
     if (sourceMode === "checkpoint" && !selectedCp) return;
     const checkpointPath = selectedCp?.path ?? null;
 
     const pushToHub = destination === "hub";
-    const repoId = pushToHub && hfUsername && modelName
-      ? `${hfUsername}/${modelName}`
-      : undefined;
+    const repoId =
+      pushToHub && hfUsername && modelName
+        ? `${hfUsername}/${modelName}`
+        : undefined;
     const token = pushToHub && hfToken ? hfToken : undefined;
     // The GGUF method with the LoRA target reuses the LoRA-adapter export path.
     const effectiveMethod: ExportMethod = ggufAsLora ? "lora" : exportMethod;
@@ -705,7 +735,8 @@ export function ExportPage() {
       ggufAsLora || (effectiveMethod === "lora" && loraAsGguf && !isMacHost);
     const methodLabel = ggufAsLora
       ? "GGUF LoRA adapter"
-      : (EXPORT_METHODS.find((m) => m.value === exportMethod)?.title ?? exportMethod);
+      : (EXPORT_METHODS.find((m) => m.value === exportMethod)?.title ??
+        exportMethod);
     const adapterExport = sourceMode === "checkpoint" && isAdapter;
 
     // Consent gate for an HF source's custom (auto_map) code, run before we hand
@@ -936,7 +967,10 @@ export function ExportPage() {
 
                   {sourceMode === "checkpoint" ? (
                     <div className="flex flex-col gap-2 overflow-visible">
-                      <div data-tour="export-training-run" className="flex flex-col gap-2">
+                      <div
+                        data-tour="export-training-run"
+                        className="flex flex-col gap-2"
+                      >
                         <label className="text-xs font-medium text-muted-foreground">
                           Training Run
                         </label>
@@ -960,13 +994,12 @@ export function ExportPage() {
                                 ? m.name.slice(0, tsMatch.index)
                                 : m.name;
                               const timeStr = tsMatch
-                                ? new Date(Number(tsMatch[1]) * 1000).toLocaleString(
-                                    undefined,
-                                    {
-                                      dateStyle: "medium",
-                                      timeStyle: "short",
-                                    },
-                                  )
+                                ? new Date(
+                                    Number(tsMatch[1]) * 1000,
+                                  ).toLocaleString(undefined, {
+                                    dateStyle: "medium",
+                                    timeStyle: "short",
+                                  })
                                 : null;
                               return (
                                 <SelectItem key={m.name} value={m.name}>
@@ -989,7 +1022,10 @@ export function ExportPage() {
                         </Select>
                       </div>
 
-                      <div data-tour="export-checkpoint" className="flex flex-col gap-2">
+                      <div
+                        data-tour="export-checkpoint"
+                        className="flex flex-col gap-2"
+                      >
                         <label className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
                           Checkpoint
                           <Tooltip>
@@ -1026,11 +1062,11 @@ export function ExportPage() {
                           <SelectTrigger className="w-full">
                             <SelectValue
                               placeholder={
-                                !selectedModelIdx
-                                  ? "Select a training run first"
-                                  : checkpointsForModel.length === 0
+                                selectedModelIdx
+                                  ? checkpointsForModel.length === 0
                                     ? "No checkpoints found"
                                     : "Select a checkpoint…"
+                                  : "Select a training run first"
                               }
                             />
                           </SelectTrigger>
@@ -1064,7 +1100,9 @@ export function ExportPage() {
                                 items={hfResultIds}
                                 filteredItems={hfResultIds}
                                 filter={null}
-                                value={modelInput || selectedSourceModel || null}
+                                value={
+                                  modelInput || selectedSourceModel || null
+                                }
                                 onValueChange={handleHfSourceModelSelect}
                                 onInputValueChange={handleHfSourceInputChange}
                                 itemToStringValue={(id) => id}
@@ -1083,7 +1121,10 @@ export function ExportPage() {
                                   }}
                                 >
                                   <InputGroupAddon>
-                                    <HugeiconsIcon icon={Search01Icon} className="size-4" />
+                                    <HugeiconsIcon
+                                      icon={Search01Icon}
+                                      className="size-4"
+                                    />
                                   </InputGroupAddon>
                                 </ComboboxInput>
                                 <ComboboxContent anchor={hfComboboxAnchorRef}>
@@ -1092,11 +1133,17 @@ export function ExportPage() {
                                       <Spinner className="size-4" /> Searching…
                                     </div>
                                   ) : (
-                                    <ComboboxEmpty>No models found</ComboboxEmpty>
+                                    <ComboboxEmpty>
+                                      No models found
+                                    </ComboboxEmpty>
                                   )}
                                   <ComboboxList className="p-1 !max-h-none !overflow-visible">
                                     {(id: string) => (
-                                      <ComboboxItem key={id} value={id} className="gap-2">
+                                      <ComboboxItem
+                                        key={id}
+                                        value={id}
+                                        className="gap-2"
+                                      >
                                         <span className="block min-w-0 flex-1 truncate">
                                           {id}
                                         </span>
@@ -1120,7 +1167,10 @@ export function ExportPage() {
                             </label>
                             <InputGroup>
                               <InputGroupAddon>
-                                <HugeiconsIcon icon={Key01Icon} className="size-4" />
+                                <HugeiconsIcon
+                                  icon={Key01Icon}
+                                  className="size-4"
+                                />
                               </InputGroupAddon>
                               <InputGroupInput
                                 type="password"
@@ -1132,7 +1182,9 @@ export function ExportPage() {
                               />
                             </InputGroup>
                             {isCheckingToken && (
-                              <p className="text-xs text-muted-foreground">Checking token…</p>
+                              <p className="text-xs text-muted-foreground">
+                                Checking token…
+                              </p>
                             )}
                           </div>
                         </>
@@ -1164,15 +1216,24 @@ export function ExportPage() {
                                     : "./models/my-model"
                                 }
                                 className="w-full"
-                                onBlur={() => applyLocalSourceModel(localModelInputRef.current)}
+                                onBlur={() =>
+                                  applyLocalSourceModel(
+                                    localModelInputRef.current,
+                                  )
+                                }
                                 onKeyDown={(event) => {
                                   if (event.key !== "Enter") return;
                                   event.preventDefault();
-                                  applyLocalSourceModel(localModelInputRef.current);
+                                  applyLocalSourceModel(
+                                    localModelInputRef.current,
+                                  );
                                 }}
                               >
                                 <InputGroupAddon>
-                                  <HugeiconsIcon icon={FolderSearchIcon} className="size-4" />
+                                  <HugeiconsIcon
+                                    icon={FolderSearchIcon}
+                                    className="size-4"
+                                  />
                                 </InputGroupAddon>
                               </ComboboxInput>
                               <ComboboxContent anchor={localComboboxAnchorRef}>
@@ -1185,7 +1246,9 @@ export function ExportPage() {
                                     {localModelsError}
                                   </div>
                                 ) : (
-                                  <ComboboxEmpty>No local models found</ComboboxEmpty>
+                                  <ComboboxEmpty>
+                                    No local models found
+                                  </ComboboxEmpty>
                                 )}
                                 <ComboboxList className="p-1 !max-h-none !overflow-visible">
                                   {(id: string) => {
@@ -1197,7 +1260,11 @@ export function ExportPage() {
                                           ? "Custom Folders"
                                           : "Local dir";
                                     return (
-                                      <ComboboxItem key={id} value={id} className="gap-2">
+                                      <ComboboxItem
+                                        key={id}
+                                        value={id}
+                                        className="gap-2"
+                                      >
                                         <span className="block min-w-0 flex-1 truncate">
                                           {model?.display_name ?? id}
                                         </span>
@@ -1216,7 +1283,9 @@ export function ExportPage() {
                               Scanning local models...
                             </p>
                           ) : localModelsError ? (
-                            <p className="text-[10px] text-red-500">{localModelsError}</p>
+                            <p className="text-[10px] text-red-500">
+                              {localModelsError}
+                            </p>
                           ) : (
                             <p className="text-[10px] text-muted-foreground">
                               {exportableLocalModels.length > 0
@@ -1242,7 +1311,9 @@ export function ExportPage() {
                       </span>
                       <div className="grid grid-cols-1 gap-x-6 gap-y-1.5 text-xs sm:grid-cols-2">
                         <div className="flex justify-between">
-                          <span className="text-muted-foreground">Base Model</span>
+                          <span className="text-muted-foreground">
+                            Base Model
+                          </span>
                           <span className="font-medium">{baseModelName}</span>
                         </div>
                         <div className="flex justify-between">
@@ -1252,14 +1323,18 @@ export function ExportPage() {
                           </span>
                         </div>
                         <div className="flex justify-between">
-                          <span className="text-muted-foreground">Checkpoints</span>
+                          <span className="text-muted-foreground">
+                            Checkpoints
+                          </span>
                           <span className="font-medium">
                             {checkpointsForModel.length}
                           </span>
                         </div>
                         {isAdapter && (
                           <div className="flex justify-between">
-                            <span className="text-muted-foreground">LoRA Rank</span>
+                            <span className="text-muted-foreground">
+                              LoRA Rank
+                            </span>
                             <span className="font-medium">{loraRank}</span>
                           </div>
                         )}
@@ -1292,7 +1367,9 @@ export function ExportPage() {
                 <Alert variant="destructive">
                   <HugeiconsIcon icon={AlertCircleIcon} className="size-4" />
                   <AlertTitle>Export unavailable</AlertTitle>
-                  <AlertDescription>{exportUnsupportedMessage}</AlertDescription>
+                  <AlertDescription>
+                    {exportUnsupportedMessage}
+                  </AlertDescription>
                 </Alert>
               )}
 
@@ -1304,18 +1381,18 @@ export function ExportPage() {
                     ? ["merged", "lora", "gguf"]
                     : !effectiveIsAdapter && effectiveIsQuantized
                       ? ["merged", "lora", "gguf"]
-                      : !effectiveIsAdapter
-                        ? ["lora"]
-                        : []
+                      : effectiveIsAdapter
+                        ? []
+                        : ["lora"]
                 }
                 disabledReason={
                   exportUnsupported
                     ? exportUnsupportedMessage
                     : !effectiveIsAdapter && effectiveIsQuantized
                       ? "Pre-quantized (BNB 4-bit) models cannot be exported without LoRA adapters"
-                      : !effectiveIsAdapter
-                        ? "LoRA-only export needs a LoRA adapter checkpoint"
-                        : undefined
+                      : effectiveIsAdapter
+                        ? undefined
+                        : "LoRA-only export needs a LoRA adapter checkpoint"
                 }
               />
 
@@ -1445,66 +1522,68 @@ export function ExportPage() {
                 </div>
               )}
 
-              {exportMethod === "lora" && effectiveIsAdapter && !exportUnsupported && (
-                <div className="space-y-3">
-                  <div className="space-y-2">
-                    <div className="text-sm font-medium">Adapter format</div>
-                    <div className="flex flex-wrap gap-2">
-                      <Button
-                        type="button"
-                        variant={!loraAsGguf ? "default" : "outline"}
-                        size="sm"
-                        onClick={() => setLoraAsGguf(false)}
-                        title="Standard PEFT adapter (adapter_model.safetensors)."
-                      >
-                        Adapter (safetensors)
-                      </Button>
-                      <Button
-                        type="button"
-                        variant={loraAsGguf ? "default" : "outline"}
-                        size="sm"
-                        disabled={isMacHost}
-                        onClick={() => setLoraAsGguf(true)}
-                        title={
-                          isMacHost
-                            ? "GGUF LoRA export is not available on macOS/MLX. Use the safetensors adapter."
-                            : "llama.cpp GGUF LoRA, loadable with `llama-cli --lora`."
-                        }
-                      >
-                        GGUF adapter
-                      </Button>
+              {exportMethod === "lora" &&
+                effectiveIsAdapter &&
+                !exportUnsupported && (
+                  <div className="space-y-3">
+                    <div className="space-y-2">
+                      <div className="text-sm font-medium">Adapter format</div>
+                      <div className="flex flex-wrap gap-2">
+                        <Button
+                          type="button"
+                          variant={loraAsGguf ? "outline" : "default"}
+                          size="sm"
+                          onClick={() => setLoraAsGguf(false)}
+                          title="Standard PEFT adapter (adapter_model.safetensors)."
+                        >
+                          Adapter (safetensors)
+                        </Button>
+                        <Button
+                          type="button"
+                          variant={loraAsGguf ? "default" : "outline"}
+                          size="sm"
+                          disabled={isMacHost}
+                          onClick={() => setLoraAsGguf(true)}
+                          title={
+                            isMacHost
+                              ? "GGUF LoRA export is not available on macOS/MLX. Use the safetensors adapter."
+                              : "llama.cpp GGUF LoRA, loadable with `llama-cli --lora`."
+                          }
+                        >
+                          GGUF adapter
+                        </Button>
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {isMacHost
+                          ? "GGUF LoRA is not available on macOS/MLX; exporting the safetensors adapter."
+                          : loraAsGguf
+                            ? "Converts the adapter to a GGUF LoRA (llama.cpp `--lora`). The base model stays separate."
+                            : "Standard PEFT adapter files. Pair with the base model at inference."}
+                      </div>
                     </div>
-                    <div className="text-xs text-muted-foreground">
-                      {isMacHost
-                        ? "GGUF LoRA is not available on macOS/MLX; exporting the safetensors adapter."
-                        : loraAsGguf
-                          ? "Converts the adapter to a GGUF LoRA (llama.cpp `--lora`). The base model stays separate."
-                          : "Standard PEFT adapter files. Pair with the base model at inference."}
-                    </div>
-                  </div>
 
-                  {loraAsGguf && (
-                    <div className="space-y-1.5">
-                      <div className="text-sm font-medium">Output type</div>
-                      <Select
-                        value={loraGgufOuttype}
-                        onValueChange={(v) => setLoraGgufOuttype(v)}
-                      >
-                        <SelectTrigger className="w-full sm:w-56">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {LORA_GGUF_OUTTYPES.map((t) => (
-                            <SelectItem key={t} value={t}>
-                              {t.toUpperCase()}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  )}
-                </div>
-              )}
+                    {loraAsGguf && (
+                      <div className="space-y-1.5">
+                        <div className="text-sm font-medium">Output type</div>
+                        <Select
+                          value={loraGgufOuttype}
+                          onValueChange={(v) => setLoraGgufOuttype(v)}
+                        >
+                          <SelectTrigger className="w-full sm:w-56">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {LORA_GGUF_OUTTYPES.map((t) => (
+                              <SelectItem key={t} value={t}>
+                                {t.toUpperCase()}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    )}
+                  </div>
+                )}
 
               {exportMethod === "gguf" && !exportUnsupported && (
                 <div className="space-y-3">
@@ -1514,7 +1593,9 @@ export function ExportPage() {
                       <div className="flex flex-wrap gap-2">
                         <Button
                           type="button"
-                          variant={ggufTarget === "model" ? "default" : "outline"}
+                          variant={
+                            ggufTarget === "model" ? "default" : "outline"
+                          }
                           size="sm"
                           onClick={() => setGgufTarget("model")}
                           title="Merge the adapter into the base model, then quantize the full model to GGUF."
@@ -1523,7 +1604,9 @@ export function ExportPage() {
                         </Button>
                         <Button
                           type="button"
-                          variant={ggufTarget === "lora" ? "default" : "outline"}
+                          variant={
+                            ggufTarget === "lora" ? "default" : "outline"
+                          }
                           size="sm"
                           onClick={() => setGgufTarget("lora")}
                           title="Export just the adapter as a GGUF LoRA (llama.cpp `--lora`); the base model stays separate."
@@ -1598,32 +1681,36 @@ export function ExportPage() {
 
               <Separator />
               {showPanel && (
-                    <ExportRunPanel
-                      exportMethod={exportMethod}
-                      quantLevels={quantLevels}
-                      checkpoint={selectedExportSource}
-                      baseModelName={sourceBaseModelName}
-                      isAdapter={sourceMode === "checkpoint" && isAdapter}
-                      destination={destination}
-                      onDestinationChange={setDestination}
-                      saveDirectory={saveDirectory}
-                      defaultSaveDirectory={defaultSaveDirectory}
-                      saveDirectoryOverridden={!!customSaveDirectory}
-                      onSaveDirectoryChange={setCustomSaveDirectory}
-                      hfUsername={hfUsername}
-                      onHfUsernameChange={setHfUsername}
-                      modelName={modelName}
-                      onModelNameChange={setModelName}
-                      hfToken={hfToken}
-                      onHfTokenChange={setHfToken}
-                      privateRepo={privateRepo}
-                      onPrivateRepoChange={setPrivateRepo}
-                      onStart={handleStart}
-                      onClose={handleClosePanel}
-                    />
-                )}
+                <ExportRunPanel
+                  exportMethod={exportMethod}
+                  quantLevels={quantLevels}
+                  checkpoint={selectedExportSource}
+                  baseModelName={sourceBaseModelName}
+                  isAdapter={sourceMode === "checkpoint" && isAdapter}
+                  destination={destination}
+                  onDestinationChange={setDestination}
+                  saveDirectory={saveDirectory}
+                  defaultSaveDirectory={defaultSaveDirectory}
+                  saveDirectoryOverridden={!!customSaveDirectory}
+                  onSaveDirectoryChange={setCustomSaveDirectory}
+                  hfUsername={hfUsername}
+                  onHfUsernameChange={setHfUsername}
+                  modelName={modelName}
+                  onModelNameChange={setModelName}
+                  hfToken={hfToken}
+                  onHfTokenChange={setHfToken}
+                  privateRepo={privateRepo}
+                  onPrivateRepoChange={setPrivateRepo}
+                  onStart={handleStart}
+                  onClose={handleClosePanel}
+                />
+              )}
               {showPanel && (
-                <div ref={panelEndRef} aria-hidden="true" className="h-px w-full" />
+                <div
+                  ref={panelEndRef}
+                  aria-hidden="true"
+                  className="h-px w-full"
+                />
               )}
               {showPanel && !panelEndVisible && (
                 <button
@@ -1637,7 +1724,10 @@ export function ExportPage() {
                   aria-label="Scroll to export output"
                   className="fixed bottom-6 right-6 z-30 flex size-10 items-center justify-center rounded-full border border-border/60 bg-background/90 text-foreground shadow-md backdrop-blur transition-colors hover:bg-muted"
                 >
-                  <HugeiconsIcon icon={ArrowDown01Icon} className="size-5" />
+                  <HugeiconsIcon
+                    icon={ChevronDownStandardIcon}
+                    className="size-5"
+                  />
                 </button>
               )}
               {!showPanel && (

--- a/studio/frontend/src/features/hub/download-manager/download-manager-panel.tsx
+++ b/studio/frontend/src/features/hub/download-manager/download-manager-panel.tsx
@@ -8,10 +8,10 @@ import {
 } from "@/components/ui/tooltip";
 import { hasAuthToken, mustChangePassword } from "@/features/auth/session";
 import { isTauri } from "@/lib/api-base";
+import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
 import { cn } from "@/lib/utils";
 import {
   Alert02Icon,
-  ArrowDown01Icon,
   Cancel01Icon,
   CheckmarkCircle02Icon,
   Download01Icon,
@@ -19,13 +19,13 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useRouterState } from "@tanstack/react-router";
 import { useEffect, useMemo, useState } from "react";
-import { DownloadProgressBar } from "./download-progress-bar";
 import {
   type ManagedDownload,
   downloadManager,
   hydrateDownloadManager,
   useDownloadManagerStore,
 } from "./download-manager-controller";
+import { DownloadProgressBar } from "./download-progress-bar";
 
 function createOrderedJobKeysSelector(): (state: {
   jobs: Record<string, ManagedDownload>;
@@ -241,7 +241,7 @@ export function DownloadManagerPanel({
               className="inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground dark:hover:bg-white/[0.06]"
             >
               <HugeiconsIcon
-                icon={ArrowDown01Icon}
+                icon={ChevronDownStandardIcon}
                 strokeWidth={1.75}
                 className="size-3.5"
               />

--- a/studio/frontend/src/features/profile/hooks/use-personalization-sync.ts
+++ b/studio/frontend/src/features/profile/hooks/use-personalization-sync.ts
@@ -2,19 +2,27 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import {
-  loadPersonalization,
-  savePersonalization,
-  setTheme,
-  useTheme,
+  type AppearanceCustomization,
+  type Palette,
   type Theme,
+  isDefaultCustomization,
+  isPalette,
+  loadPersonalization,
+  sanitizeCustomization,
+  savePersonalization,
+  setPalette,
+  setTheme,
+  useAppearanceCustomStore,
+  usePalette,
+  useTheme,
 } from "@/features/settings";
 import {
   DEFAULT_LOCALE,
+  type Locale,
   getLocale,
   isSupportedLocale,
   setLocale,
   useLocale,
-  type Locale,
 } from "@/i18n";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
@@ -110,12 +118,14 @@ function profileSnapshot(): ProfileSnapshot {
 function payload(
   profile: ProfileSnapshot,
   theme: Theme,
+  palette: Palette,
+  customization: AppearanceCustomization,
   language: Locale | null,
 ): PersonalizationWrite {
   return {
     version: 1,
     profile: normalizeProfile(profile),
-    appearance: { theme, language },
+    appearance: { theme, palette, language, customization },
   };
 }
 
@@ -126,6 +136,8 @@ function serialized(data: PersonalizationWrite): string {
 function hasLocalSettings(
   profile: ProfileSnapshot,
   theme: Theme,
+  palette: Palette,
+  customization: AppearanceCustomization,
   language: Locale,
 ): boolean {
   return Boolean(
@@ -134,6 +146,8 @@ function hasLocalSettings(
       profile.avatarDataUrl ||
       profile.avatarShape !== "circle" ||
       theme !== "system" ||
+      palette !== "standard" ||
+      !isDefaultCustomization(customization) ||
       language !== DEFAULT_LOCALE,
   );
 }
@@ -144,10 +158,14 @@ export function usePersonalizationSync(enabled: boolean): void {
   const avatarDataUrl = useUserProfileStore((s) => s.avatarDataUrl);
   const avatarShape = useUserProfileStore((s) => s.avatarShape);
   const { theme } = useTheme();
+  const { palette } = usePalette();
+  const customization = useAppearanceCustomStore((s) => s.customization);
   const language = useLocale();
   const [hydratedGeneration, setHydratedGeneration] = useState(0);
   const authGenerationRef = useRef(0);
   const latestThemeRef = useRef(theme);
+  const latestPaletteRef = useRef(palette);
+  const latestCustomizationRef = useRef(customization);
   const latestLanguageRef = useRef(language);
   const lastSavedRef = useRef("");
   const saveInFlightRef = useRef(false);
@@ -165,6 +183,14 @@ export function usePersonalizationSync(enabled: boolean): void {
   useEffect(() => {
     latestThemeRef.current = theme;
   }, [theme]);
+
+  useEffect(() => {
+    latestPaletteRef.current = palette;
+  }, [palette]);
+
+  useEffect(() => {
+    latestCustomizationRef.current = customization;
+  }, [customization]);
 
   useEffect(() => {
     latestLanguageRef.current = language;
@@ -188,17 +214,38 @@ export function usePersonalizationSync(enabled: boolean): void {
             displayName: remote.profile.displayName ?? "",
             nickname: remote.profile.nickname ?? "",
             avatarDataUrl: remote.profile.avatarDataUrl ?? null,
-            avatarShape: remote.profile.avatarShape === "rounded" ? "rounded" : "circle",
+            avatarShape:
+              remote.profile.avatarShape === "rounded" ? "rounded" : "circle",
           };
           const nextTheme = remote.appearance.theme;
+          const nextPalette = isPalette(remote.appearance.palette)
+            ? remote.appearance.palette
+            : latestPaletteRef.current;
+          const nextCustomization = sanitizeCustomization(
+            remote.appearance.customization,
+          );
           const nextLanguage = isSupportedLocale(remote.appearance.language)
             ? remote.appearance.language
             : latestLanguageRef.current;
           useUserProfileStore.setState(nextProfile);
           if (nextTheme !== latestThemeRef.current) setTheme(nextTheme);
-          if (nextLanguage !== latestLanguageRef.current) setLocale(nextLanguage);
+          if (nextPalette !== latestPaletteRef.current) setPalette(nextPalette);
+          if (
+            JSON.stringify(nextCustomization) !==
+            JSON.stringify(latestCustomizationRef.current)
+          ) {
+            useAppearanceCustomStore.getState().replaceAll(nextCustomization);
+          }
+          if (nextLanguage !== latestLanguageRef.current)
+            setLocale(nextLanguage);
           lastSavedRef.current = serialized(
-            payload(nextProfile, nextTheme, nextLanguage),
+            payload(
+              nextProfile,
+              nextTheme,
+              nextPalette,
+              nextCustomization,
+              nextLanguage,
+            ),
           );
         } else {
           const rawProfile = profileSnapshot();
@@ -207,10 +254,26 @@ export function usePersonalizationSync(enabled: boolean): void {
             useUserProfileStore.setState(nextProfile);
           }
           const nextTheme = latestThemeRef.current;
+          const nextPalette = latestPaletteRef.current;
+          const nextCustomization = latestCustomizationRef.current;
           const nextLanguage = getLocale();
-          const nextPayload = payload(nextProfile, nextTheme, nextLanguage);
+          const nextPayload = payload(
+            nextProfile,
+            nextTheme,
+            nextPalette,
+            nextCustomization,
+            nextLanguage,
+          );
           const nextSerialized = serialized(nextPayload);
-          if (hasLocalSettings(nextProfile, nextTheme, nextLanguage)) {
+          if (
+            hasLocalSettings(
+              nextProfile,
+              nextTheme,
+              nextPalette,
+              nextCustomization,
+              nextLanguage,
+            )
+          ) {
             try {
               await savePersonalization(nextPayload);
               lastSavedRef.current = nextSerialized;
@@ -240,6 +303,8 @@ export function usePersonalizationSync(enabled: boolean): void {
     const current = payload(
       { displayName, nickname, avatarDataUrl, avatarShape },
       theme,
+      palette,
+      customization,
       language,
     );
     const currentSerialized = serialized(current);
@@ -261,6 +326,8 @@ export function usePersonalizationSync(enabled: boolean): void {
     avatarDataUrl,
     avatarShape,
     theme,
+    palette,
+    customization,
     language,
     drainSaveQueue,
   ]);

--- a/studio/frontend/src/features/recipe-studio/components/runtime/execution-progress-island.tsx
+++ b/studio/frontend/src/features/recipe-studio/components/runtime/execution-progress-island.tsx
@@ -1,18 +1,17 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import {
-  ArrowDown01Icon,
-  ArrowUp01Icon,
-  CheckmarkCircle02Icon,
-  Flag02Icon,
-} from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
-import type { ReactElement } from "react";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { Spinner } from "@/components/ui/spinner";
+import {
+  ChevronDownStandardIcon,
+  ChevronUpStandardIcon,
+} from "@/lib/chevron-icons";
 import { cn } from "@/lib/utils";
+import { CheckmarkCircle02Icon, Flag02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import type { ReactElement } from "react";
 import type { RecipeExecutionRecord } from "../../execution-types";
 import { isExecutionInProgress } from "../../executions/execution-helpers";
 import {
@@ -112,8 +111,11 @@ export function ExecutionProgressIsland({
         execution.source_progress?.status === "rate_limited" ||
         execution.source_progress?.status === "retrying"),
   );
-  const sourcePercent = showSourceProgress ? execution.source_progress?.percent : null;
-  const progressPercent = sourcePercent ?? execution.progress?.percent ?? (complete ? 100 : 0);
+  const sourcePercent = showSourceProgress
+    ? execution.source_progress?.percent
+    : null;
+  const progressPercent =
+    sourcePercent ?? execution.progress?.percent ?? (complete ? 100 : 0);
   const hasProgressSignal = Boolean(
     (execution.progress &&
       (typeof execution.progress.done === "number" ||
@@ -165,7 +167,7 @@ export function ExecutionProgressIsland({
             title={minimized ? "Expand" : "Minimize"}
           >
             <HugeiconsIcon
-              icon={minimized ? ArrowDown01Icon : ArrowUp01Icon}
+              icon={minimized ? ChevronDownStandardIcon : ChevronUpStandardIcon}
               className="size-3.5"
             />
           </button>
@@ -179,16 +181,28 @@ export function ExecutionProgressIsland({
       {!minimized && (
         <>
           <div className="grid grid-cols-2 gap-2 px-3 pt-2 text-[11px] text-muted-foreground sm:grid-cols-4">
-            <p className="truncate" title={`Done: ${formatMetricValue(execution.progress?.done)}`}>
+            <p
+              className="truncate"
+              title={`Done: ${formatMetricValue(execution.progress?.done)}`}
+            >
               Done: {formatMetricValue(execution.progress?.done)}
             </p>
-            <p className="truncate" title={`Total: ${formatMetricValue(execution.progress?.total)}`}>
+            <p
+              className="truncate"
+              title={`Total: ${formatMetricValue(execution.progress?.total)}`}
+            >
               Total: {formatMetricValue(execution.progress?.total)}
             </p>
-            <p className="truncate" title={`Rate: ${formatMetricValue(execution.progress?.rate)}`}>
+            <p
+              className="truncate"
+              title={`Rate: ${formatMetricValue(execution.progress?.rate)}`}
+            >
               Rate: {formatMetricValue(execution.progress?.rate)}
             </p>
-            <p className="truncate" title={`ETA: ${formatEta(execution.progress?.eta_sec)}`}>
+            <p
+              className="truncate"
+              title={`ETA: ${formatEta(execution.progress?.eta_sec)}`}
+            >
               ETA: {formatEta(execution.progress?.eta_sec)}
             </p>
           </div>
@@ -208,10 +222,7 @@ export function ExecutionProgressIsland({
                 icon={currentColumnIcon}
                 className="size-3.5 shrink-0"
               />
-              <p
-                className="truncate"
-                title={execution.current_column ?? "--"}
-              >
+              <p className="truncate" title={execution.current_column ?? "--"}>
                 Column: {execution.current_column ?? "--"}
               </p>
             </div>
@@ -221,7 +232,8 @@ export function ExecutionProgressIsland({
               className="mt-1 truncate px-3 text-[11px] text-muted-foreground"
               title={`Batch: ${execution.batch?.idx ?? "--"}/${execution.batch?.total ?? "--"}`}
             >
-              Batch: {execution.batch?.idx ?? "--"}/{execution.batch?.total ?? "--"}
+              Batch: {execution.batch?.idx ?? "--"}/
+              {execution.batch?.total ?? "--"}
             </div>
           )}
           <div className="px-3 pb-2 pt-2">

--- a/studio/frontend/src/features/recipe-studio/dialogs/preview-dialog.tsx
+++ b/studio/frontend/src/features/recipe-studio/dialogs/preview-dialog.tsx
@@ -17,10 +17,10 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
 import { cn } from "@/lib/utils";
 import {
   AlertCircleIcon,
-  ArrowDown01Icon,
   CheckmarkCircle02Icon,
   CookBookIcon,
   TestTube01Icon,
@@ -413,7 +413,7 @@ function RunDialogBody({
             className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground hover:text-foreground"
           >
             <HugeiconsIcon
-              icon={ArrowDown01Icon}
+              icon={ChevronDownStandardIcon}
               className={cn(
                 "size-3.5 transition-transform",
                 advancedOpen && "rotate-180",
@@ -615,7 +615,9 @@ function RunDialogBody({
                     0,
                     MAX_RETRY_STEPS,
                     (value) =>
-                      onSettingsChange({ maxConversationCorrectionSteps: value }),
+                      onSettingsChange({
+                        maxConversationCorrectionSteps: value,
+                      }),
                     setCorrectionsDraft,
                   )
                 }
@@ -624,7 +626,8 @@ function RunDialogBody({
                 <div className="space-y-0.5">
                   <p className="font-medium">Keep running through failures</p>
                   <p className="text-xs text-muted-foreground">
-                    Useful for longer runs when you want as many rows as possible.
+                    Useful for longer runs when you want as many rows as
+                    possible.
                   </p>
                 </div>
                 <Switch

--- a/studio/frontend/src/features/recipe-studio/dialogs/shared/available-variables.tsx
+++ b/studio/frontend/src/features/recipe-studio/dialogs/shared/available-variables.tsx
@@ -2,12 +2,12 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { Badge } from "@/components/ui/badge";
-import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
+import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { type ReactElement, useMemo, useState } from "react";
 import { useRecipeStudioStore } from "../../stores/recipe-studio";
-import { getAvailableVariableEntries } from "../../utils/variables";
 import { RECIPE_STUDIO_REFERENCE_BADGE_TONES } from "../../utils/ui-tones";
+import { getAvailableVariableEntries } from "../../utils/variables";
 
 type AvailableVariablesProps = {
   configId: string;
@@ -27,7 +27,10 @@ export function AvailableVariables({
   const [showUserFields, setShowUserFields] = useState(false);
   const configs = useRecipeStudioStore((state) => state.configs);
   const vars = getAvailableVariableEntries(configs, configId);
-  const variableNames = useMemo(() => new Set(vars.map((entry) => entry.name)), [vars]);
+  const variableNames = useMemo(
+    () => new Set(vars.map((entry) => entry.name)),
+    [vars],
+  );
   const hasUserRoot = variableNames.has("user");
   const userFieldEntries = useMemo(
     () =>
@@ -71,19 +74,22 @@ export function AvailableVariables({
               onClick={() => setShowUserFields((prev) => !prev)}
               className="cursor-pointer"
               aria-expanded={showUserFields}
-              aria-label={showUserFields ? "Hide user fields" : "Show user fields"}
+              aria-label={
+                showUserFields ? "Hide user fields" : "Show user fields"
+              }
             >
               <Badge variant="secondary" className={className}>
                 <span>{`{{ ${v.name} }}`}</span>
                 <HugeiconsIcon
-                  icon={ArrowDown01Icon}
+                  icon={ChevronDownStandardIcon}
                   className={`size-3 transition-transform ${showUserFields ? "rotate-180" : ""}`}
                 />
               </Badge>
             </button>
           );
         })}
-        {hasUserRoot && showUserFields &&
+        {hasUserRoot &&
+          showUserFields &&
           userFieldEntries.map((entry) => (
             <Badge
               key={`user-expanded:${entry.name}`}

--- a/studio/frontend/src/features/recipe-studio/dialogs/shared/collapsible-section-trigger.tsx
+++ b/studio/frontend/src/features/recipe-studio/dialogs/shared/collapsible-section-trigger.tsx
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
 import { cn } from "@/lib/utils";
-import { ArrowDown01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import {
-  forwardRef,
   type ButtonHTMLAttributes,
   type ReactElement,
+  forwardRef,
 } from "react";
 
 type CollapsibleSectionTriggerProps = {
@@ -42,7 +42,7 @@ export const CollapsibleSectionTriggerButton = forwardRef<
     >
       <span className="flex min-w-0 items-center gap-2">
         <HugeiconsIcon
-          icon={ArrowDown01Icon}
+          icon={ChevronDownStandardIcon}
           className={cn(
             "size-3.5 shrink-0 transition-transform",
             open && "rotate-180",

--- a/studio/frontend/src/features/settings/api/personalization.ts
+++ b/studio/frontend/src/features/settings/api/personalization.ts
@@ -3,6 +3,7 @@
 
 import { authFetch } from "@/features/auth";
 import { readFastApiError } from "@/lib/format-fastapi-error";
+import type { AppearanceCustomization } from "../stores/appearance-custom-store";
 
 export type PersonalizationProfile = {
   displayName: string;
@@ -13,7 +14,9 @@ export type PersonalizationProfile = {
 
 export type PersonalizationAppearance = {
   theme: "light" | "dark" | "system";
+  palette: "standard" | "classic" | "minimal";
   language: string | null;
+  customization: AppearanceCustomization;
 };
 
 export type Personalization = {
@@ -27,7 +30,9 @@ export type Personalization = {
 export async function loadPersonalization(): Promise<Personalization> {
   const res = await authFetch("/api/settings/personalization");
   if (!res.ok) {
-    throw new Error(await readFastApiError(res, "Failed to load personalization"));
+    throw new Error(
+      await readFastApiError(res, "Failed to load personalization"),
+    );
   }
   return (await res.json()) as Personalization;
 }
@@ -41,6 +46,8 @@ export async function savePersonalization(
     body: JSON.stringify(data),
   });
   if (!res.ok) {
-    throw new Error(await readFastApiError(res, "Failed to save personalization"));
+    throw new Error(
+      await readFastApiError(res, "Failed to save personalization"),
+    );
   }
 }

--- a/studio/frontend/src/features/settings/components/appearance-custom-controls.tsx
+++ b/studio/frontend/src/features/settings/components/appearance-custom-controls.tsx
@@ -1,0 +1,741 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Slider } from "@/components/ui/slider";
+import { Switch } from "@/components/ui/switch";
+import { type TranslationKey, useT } from "@/i18n";
+import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
+import { toast } from "@/lib/toast";
+import { cn } from "@/lib/utils";
+import { Cancel01Icon, Tick02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { motion, useReducedMotion } from "motion/react";
+import { useEffect, useRef, useState } from "react";
+import {
+  CODE_FONT_SIZE_RANGE,
+  type CustomModeColors,
+  DEFAULT_CUSTOMIZATION,
+  MAX_IMPORTED_FONTS,
+  type ReduceMotionSetting,
+  UI_FONT_SIZE_RANGE,
+  isDefaultCustomization,
+  useAppearanceCustomStore,
+} from "../stores/appearance-custom-store";
+import {
+  type Palette,
+  type ResolvedTheme,
+  usePalette,
+  useTheme,
+} from "../stores/theme-store";
+import { ColorPickerSwatch } from "./color-picker";
+
+/* ------------------------------- Colors -------------------------------- */
+
+// Seed values shown in the pickers while no override is set. Mirrors the
+// palette token values in index.css (foregrounds converted from oklch).
+type DefaultModeColors = { [K in keyof CustomModeColors]: string };
+const PALETTE_DEFAULT_COLORS: Record<
+  Palette,
+  Record<ResolvedTheme, DefaultModeColors>
+> = {
+  standard: {
+    light: { accent: "#17b88b", background: "#fefefd", foreground: "#262626" },
+    dark: { accent: "#17b88b", background: "#181818", foreground: "#ececec" },
+  },
+  classic: {
+    light: { accent: "#339cff", background: "#ffffff", foreground: "#1a1c1f" },
+    dark: { accent: "#4dabff", background: "#181818", foreground: "#ececec" },
+  },
+  minimal: {
+    light: { accent: "#171717", background: "#ffffff", foreground: "#171717" },
+    dark: { accent: "#ededed", background: "#181818", foreground: "#ededed" },
+  },
+};
+
+/**
+ * Color override control for the CURRENTLY ACTIVE resolved mode. Only the
+ * active mode is editable; the other mode's overrides stay stored and take
+ * effect when the color scheme flips (ChatGPT-app style).
+ */
+export function ActiveColorControl({
+  colorKey,
+  label,
+}: {
+  colorKey: keyof CustomModeColors;
+  label: string;
+}) {
+  const t = useT();
+  const { resolved } = useTheme();
+  const { palette } = usePalette();
+  const override = useAppearanceCustomStore(
+    (s) => s.customization.colors[resolved][colorKey],
+  );
+  const setColor = useAppearanceCustomStore((s) => s.setColor);
+  const fallback = PALETTE_DEFAULT_COLORS[palette][resolved][colorKey];
+  const value = override ?? fallback;
+  return (
+    <div className="flex items-center gap-2">
+      {override !== null && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2 text-xs text-muted-foreground"
+          onClick={() => setColor(resolved, colorKey, null)}
+        >
+          {t("settings.appearance.custom.reset")}
+        </Button>
+      )}
+      <span className="font-mono text-xs text-muted-foreground uppercase">
+        {value}
+      </span>
+      <ColorPickerSwatch
+        value={value}
+        onChange={(hex) => setColor(resolved, colorKey, hex)}
+        label={label}
+        highlighted={override !== null}
+      />
+    </div>
+  );
+}
+
+/* ------------------------------ Typography ------------------------------ */
+
+/** Fonts Unsloth Studio already ships (bundled @font-face / fontsource). */
+const BUNDLED_FONTS = [
+  "Inter Variable",
+  "Hellix",
+  "Space Grotesk Variable",
+  "Figtree Variable",
+  "JetBrains Mono",
+  "Fira Code",
+] as const;
+
+/* ----------------------------- Device fonts ------------------------------ */
+
+// Fallback candidates probed by canvas measurement when the Local Font
+// Access API (Chromium-only) is unavailable or denied.
+const CANDIDATE_DEVICE_FONTS = [
+  "American Typewriter",
+  "Andale Mono",
+  "Arial",
+  "Avenir",
+  "Avenir Next",
+  "Baskerville",
+  "Calibri",
+  "Cambria",
+  "Candara",
+  "Cantarell",
+  "Charter",
+  "Comic Sans MS",
+  "Consolas",
+  "Constantia",
+  "Corbel",
+  "Courier",
+  "Courier New",
+  "DejaVu Sans",
+  "DejaVu Sans Mono",
+  "DejaVu Serif",
+  "Didot",
+  "Fira Sans",
+  "Franklin Gothic Medium",
+  "Futura",
+  "Geneva",
+  "Georgia",
+  "Gill Sans",
+  "Helvetica",
+  "Helvetica Neue",
+  "Hoefler Text",
+  "IBM Plex Mono",
+  "IBM Plex Sans",
+  "Impact",
+  "Inconsolata",
+  "Iosevka",
+  "Lato",
+  "Liberation Mono",
+  "Liberation Sans",
+  "Liberation Serif",
+  "Lucida Grande",
+  "Menlo",
+  "Monaco",
+  "Montserrat",
+  "Noto Sans",
+  "Noto Serif",
+  "Nunito",
+  "Open Sans",
+  "Optima",
+  "Palatino",
+  "Roboto",
+  "Rockwell",
+  "Segoe UI",
+  "Seravek",
+  "Source Sans Pro",
+  "Tahoma",
+  "Times",
+  "Times New Roman",
+  "Trebuchet MS",
+  "Ubuntu",
+  "Verdana",
+];
+
+function detectFontsByMeasurement(candidates: string[]): string[] {
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return [];
+  const sample = "mmmmmmmmmwwwwwwwlli";
+  const baselines = ["monospace", "sans-serif", "serif"].map((base) => {
+    ctx.font = `72px ${base}`;
+    return { base, width: ctx.measureText(sample).width };
+  });
+  return candidates.filter((family) =>
+    baselines.some(({ base, width }) => {
+      ctx.font = `72px "${family}", ${base}`;
+      return ctx.measureText(sample).width !== width;
+    }),
+  );
+}
+
+let deviceFontsCache: string[] | null = null;
+
+async function loadDeviceFonts(): Promise<string[]> {
+  if (deviceFontsCache) return deviceFontsCache;
+  let families: string[] = [];
+  const query = (
+    globalThis as {
+      queryLocalFonts?: () => Promise<{ family: string }[]>;
+    }
+  ).queryLocalFonts;
+  if (typeof query === "function") {
+    try {
+      const fonts = await query();
+      families = [...new Set(fonts.map((f) => f.family))];
+    } catch {
+      // permission denied; fall back to measurement probing
+    }
+  }
+  if (families.length === 0) {
+    families = detectFontsByMeasurement(CANDIDATE_DEVICE_FONTS);
+  }
+  deviceFontsCache = families.sort((a, b) => a.localeCompare(b));
+  return deviceFontsCache;
+}
+
+function FontSelect({
+  value,
+  onCommit,
+  ariaLabel,
+}: {
+  value: string | null;
+  onCommit: (next: string | null) => void;
+  ariaLabel: string;
+}) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+  const [deviceFonts, setDeviceFonts] = useState<string[] | null>(
+    deviceFontsCache,
+  );
+  const importedFonts = useAppearanceCustomStore(
+    (s) => s.customization.importedFonts,
+  );
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    // Kick off inside the click gesture: queryLocalFonts may need transient
+    // user activation for its permission prompt.
+    if (next && deviceFonts === null) {
+      void loadDeviceFonts().then(setDeviceFonts);
+    }
+  };
+
+  const select = (next: string | null) => {
+    onCommit(next);
+    setOpen(false);
+  };
+
+  const knownNames = new Set<string>([
+    ...BUNDLED_FONTS,
+    ...importedFonts.map((f) => f.name),
+  ]);
+  const deviceOnlyFonts = (deviceFonts ?? []).filter((f) => !knownNames.has(f));
+
+  const renderItem = (font: string) => (
+    <CommandItem
+      key={font}
+      value={font}
+      onSelect={() => select(font)}
+      style={{ fontFamily: `"${font}"` }}
+    >
+      <span className="min-w-0 truncate">{font}</span>
+      {value === font && (
+        <HugeiconsIcon icon={Tick02Icon} className="ml-auto size-3.5" />
+      )}
+    </CommandItem>
+  );
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild={true}>
+        <button
+          type="button"
+          aria-label={ariaLabel}
+          aria-expanded={open}
+          className="flex h-8 w-56 cursor-pointer items-center justify-between gap-1.5 rounded-full border border-border bg-background px-3.5 text-xs outline-none transition-colors hover:bg-accent/50 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 dark:border-white/10 dark:bg-white/[0.06] dark:hover:bg-white/10"
+        >
+          <span className="min-w-0 truncate">
+            {value ?? t("settings.appearance.custom.fontDefault")}
+          </span>
+          <HugeiconsIcon
+            icon={ChevronDownStandardIcon}
+            strokeWidth={2}
+            className="size-4 shrink-0 text-muted-foreground"
+          />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-64 p-1">
+        <Command>
+          <CommandInput
+            placeholder={t("settings.appearance.custom.fontSearch")}
+          />
+          <CommandList className="max-h-64">
+            <CommandEmpty>
+              {t("settings.appearance.custom.fontNoResults")}
+            </CommandEmpty>
+            <CommandItem
+              value={t("settings.appearance.custom.fontDefault")}
+              onSelect={() => select(null)}
+            >
+              <span>{t("settings.appearance.custom.fontDefault")}</span>
+              {value === null && (
+                <HugeiconsIcon icon={Tick02Icon} className="ml-auto size-3.5" />
+              )}
+            </CommandItem>
+            <CommandGroup
+              heading={t("settings.appearance.custom.fontBundledGroup")}
+            >
+              {BUNDLED_FONTS.map(renderItem)}
+            </CommandGroup>
+            {importedFonts.length > 0 && (
+              <CommandGroup
+                heading={t("settings.appearance.custom.fontImportedGroup")}
+              >
+                {importedFonts.map((font) => renderItem(font.name))}
+              </CommandGroup>
+            )}
+            <CommandGroup
+              heading={t("settings.appearance.custom.fontDeviceGroup")}
+            >
+              {deviceFonts === null ? (
+                <div className="px-2 py-1.5 text-xs text-muted-foreground">
+                  {t("settings.appearance.custom.fontDeviceLoading")}
+                </div>
+              ) : (
+                deviceOnlyFonts.map(renderItem)
+              )}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export function UiFontRow() {
+  const t = useT();
+  const uiFont = useAppearanceCustomStore((s) => s.customization.uiFont);
+  const patch = useAppearanceCustomStore((s) => s.patch);
+  return (
+    <FontSelect
+      value={uiFont}
+      onCommit={(next) => patch({ uiFont: next })}
+      ariaLabel={t("settings.appearance.custom.uiFont.label")}
+    />
+  );
+}
+
+export function CodeFontRow() {
+  const t = useT();
+  const codeFont = useAppearanceCustomStore((s) => s.customization.codeFont);
+  const patch = useAppearanceCustomStore((s) => s.patch);
+  return (
+    <FontSelect
+      value={codeFont}
+      onCommit={(next) => patch({ codeFont: next })}
+      ariaLabel={t("settings.appearance.custom.codeFont.label")}
+    />
+  );
+}
+
+/* ---------------------------- Imported fonts ---------------------------- */
+
+const FONT_MIME_BY_EXTENSION: Record<string, string> = {
+  woff2: "font/woff2",
+  woff: "font/woff",
+  ttf: "font/ttf",
+  otf: "font/otf",
+};
+
+const MAX_FONT_FILE_BYTES = Math.floor(1.5 * 1024 * 1024);
+
+function fontNameFromFile(fileName: string, taken: Set<string>): string {
+  const base =
+    fileName
+      .replace(/\.[^.]+$/, "")
+      .replace(/[;{}()<>"']/g, "")
+      .replace(/[_-]+/g, " ")
+      .trim()
+      .slice(0, 60) || "Imported font";
+  let candidate = base;
+  let suffix = 2;
+  while (taken.has(candidate)) {
+    candidate = `${base} ${suffix}`;
+    suffix += 1;
+  }
+  return candidate;
+}
+
+export function ImportFontControls() {
+  const t = useT();
+  const importedFonts = useAppearanceCustomStore(
+    (s) => s.customization.importedFonts,
+  );
+  const addImportedFont = useAppearanceCustomStore((s) => s.addImportedFont);
+  const removeImportedFont = useAppearanceCustomStore(
+    (s) => s.removeImportedFont,
+  );
+  const inputRef = useRef<HTMLInputElement>(null);
+  const atLimit = importedFonts.length >= MAX_IMPORTED_FONTS;
+
+  const importFile = (file: File) => {
+    const extension = file.name.split(".").pop()?.toLowerCase() ?? "";
+    const mime = FONT_MIME_BY_EXTENSION[extension];
+    if (!mime) {
+      toast.error(t("settings.appearance.custom.importFont.errorInvalidType"));
+      return;
+    }
+    if (file.size > MAX_FONT_FILE_BYTES) {
+      toast.error(t("settings.appearance.custom.importFont.errorTooLarge"));
+      return;
+    }
+    const reader = new FileReader();
+    reader.onerror = () => {
+      toast.error(t("settings.appearance.custom.importFont.errorFailed"));
+    };
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== "string") {
+        toast.error(t("settings.appearance.custom.importFont.errorFailed"));
+        return;
+      }
+      // Rewrite whatever MIME the browser guessed to the extension's font
+      // type so the stored data URL passes frontend and backend validation.
+      const base64 = result.slice(result.indexOf(",") + 1);
+      const dataUrl = `data:${mime};base64,${base64}`;
+      const taken = new Set<string>([
+        ...BUNDLED_FONTS,
+        ...importedFonts.map((f) => f.name),
+      ]);
+      const name = fontNameFromFile(file.name, taken);
+      // Prove the file is a loadable font before persisting it.
+      const face = new FontFace(name, `url(${dataUrl})`);
+      face
+        .load()
+        .then(() => {
+          addImportedFont({ name, dataUrl });
+        })
+        .catch(() => {
+          toast.error(t("settings.appearance.custom.importFont.errorFailed"));
+        });
+    };
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <div className="flex flex-col items-end gap-2">
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".woff2,.woff,.ttf,.otf"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) importFile(file);
+          e.target.value = "";
+        }}
+      />
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => {
+          if (atLimit) {
+            toast.error(t("settings.appearance.custom.importFont.errorLimit"));
+            return;
+          }
+          inputRef.current?.click();
+        }}
+      >
+        {t("settings.appearance.custom.importFont.button")}
+      </Button>
+      {importedFonts.length > 0 && (
+        <div className="flex max-w-72 flex-wrap justify-end gap-1.5">
+          {importedFonts.map((font) => (
+            <span
+              key={font.name}
+              className="inline-flex items-center gap-1 rounded-full border border-border px-2 py-1 text-xs text-foreground"
+              style={{ fontFamily: `"${font.name}"` }}
+            >
+              {font.name}
+              <button
+                type="button"
+                onClick={() => removeImportedFont(font.name)}
+                aria-label={`${t("settings.appearance.custom.importFont.remove")}: ${font.name}`}
+                className="text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <HugeiconsIcon icon={Cancel01Icon} className="size-3" />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FontSizeInput({
+  value,
+  range,
+  onCommit,
+  ariaLabel,
+}: {
+  value: number | null;
+  range: { min: number; max: number; default: number };
+  onCommit: (next: number | null) => void;
+  ariaLabel: string;
+}) {
+  const [draft, setDraft] = useState(value === null ? "" : String(value));
+  useEffect(() => {
+    setDraft(value === null ? "" : String(value));
+  }, [value]);
+  const commit = () => {
+    const trimmed = draft.trim();
+    if (trimmed === "") {
+      onCommit(null);
+      return;
+    }
+    const parsed = Number.parseInt(trimmed, 10);
+    if (Number.isNaN(parsed)) {
+      setDraft(value === null ? "" : String(value));
+      return;
+    }
+    onCommit(Math.min(range.max, Math.max(range.min, parsed)));
+  };
+  return (
+    <div className="flex items-center gap-1.5">
+      <Input
+        type="number"
+        inputMode="numeric"
+        min={range.min}
+        max={range.max}
+        value={draft}
+        placeholder={String(range.default)}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            commit();
+            e.currentTarget.blur();
+          }
+        }}
+        aria-label={ariaLabel}
+        className="h-8 w-16 text-xs"
+      />
+      <span className="text-xs text-muted-foreground">px</span>
+    </div>
+  );
+}
+
+export function UiFontSizeRow() {
+  const t = useT();
+  const uiFontSize = useAppearanceCustomStore(
+    (s) => s.customization.uiFontSize,
+  );
+  const patch = useAppearanceCustomStore((s) => s.patch);
+  return (
+    <FontSizeInput
+      value={uiFontSize}
+      range={UI_FONT_SIZE_RANGE}
+      onCommit={(next) => patch({ uiFontSize: next })}
+      ariaLabel={t("settings.appearance.custom.uiFontSize.label")}
+    />
+  );
+}
+
+export function CodeFontSizeRow() {
+  const t = useT();
+  const codeFontSize = useAppearanceCustomStore(
+    (s) => s.customization.codeFontSize,
+  );
+  const patch = useAppearanceCustomStore((s) => s.patch);
+  return (
+    <FontSizeInput
+      value={codeFontSize}
+      range={CODE_FONT_SIZE_RANGE}
+      onCommit={(next) => patch({ codeFontSize: next })}
+      ariaLabel={t("settings.appearance.custom.codeFontSize.label")}
+    />
+  );
+}
+
+export function FontSmoothingSwitch() {
+  const fontSmoothing = useAppearanceCustomStore(
+    (s) => s.customization.fontSmoothing,
+  );
+  const patch = useAppearanceCustomStore((s) => s.patch);
+  return (
+    <Switch
+      checked={fontSmoothing}
+      onCheckedChange={(checked) => patch({ fontSmoothing: checked })}
+    />
+  );
+}
+
+/* ------------------------------ Interface ------------------------------- */
+
+export function ContrastSliderRow() {
+  const t = useT();
+  const contrast = useAppearanceCustomStore((s) => s.customization.contrast);
+  const patch = useAppearanceCustomStore((s) => s.patch);
+  return (
+    <div className="flex w-48 items-center gap-3">
+      <Slider
+        value={[contrast]}
+        min={0}
+        max={100}
+        step={5}
+        onValueChange={(values: number[]) => patch({ contrast: values[0] })}
+        aria-label={t("settings.appearance.custom.contrast.label")}
+      />
+      <span className="w-8 text-right text-xs tabular-nums text-muted-foreground">
+        {contrast}
+      </span>
+    </div>
+  );
+}
+
+export function PointerCursorsSwitch() {
+  const pointerCursors = useAppearanceCustomStore(
+    (s) => s.customization.pointerCursors,
+  );
+  const patch = useAppearanceCustomStore((s) => s.patch);
+  return (
+    <Switch
+      checked={pointerCursors}
+      onCheckedChange={(checked) => patch({ pointerCursors: checked })}
+    />
+  );
+}
+
+export function TranslucentSidebarSwitch() {
+  const translucentSidebar = useAppearanceCustomStore(
+    (s) => s.customization.translucentSidebar,
+  );
+  const patch = useAppearanceCustomStore((s) => s.patch);
+  return (
+    <Switch
+      checked={translucentSidebar}
+      onCheckedChange={(checked) => patch({ translucentSidebar: checked })}
+    />
+  );
+}
+
+const REDUCE_MOTION_OPTIONS: {
+  value: ReduceMotionSetting;
+  labelKey: TranslationKey;
+}[] = [
+  {
+    value: "system",
+    labelKey: "settings.appearance.custom.reduceMotion.system",
+  },
+  { value: "on", labelKey: "settings.appearance.custom.reduceMotion.on" },
+  { value: "off", labelKey: "settings.appearance.custom.reduceMotion.off" },
+];
+
+export function ReduceMotionSegmented() {
+  const t = useT();
+  const reduceMotion = useAppearanceCustomStore(
+    (s) => s.customization.reduceMotion,
+  );
+  const patch = useAppearanceCustomStore((s) => s.patch);
+  const reduced = useReducedMotion();
+  return (
+    <div className="hub-tab-toggle inline-flex h-8 items-center rounded-full">
+      {REDUCE_MOTION_OPTIONS.map((opt) => {
+        const active = reduceMotion === opt.value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => patch({ reduceMotion: opt.value })}
+            aria-pressed={active}
+            className={cn(
+              "relative flex h-8 items-center rounded-full px-3 text-xs font-medium transition-colors",
+              active
+                ? "text-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {active && (
+              <motion.span
+                layoutId="reduce-motion-pill"
+                className="hub-tab-toggle-pill absolute inset-0 rounded-full"
+                transition={
+                  reduced
+                    ? { duration: 0 }
+                    : { type: "spring", stiffness: 500, damping: 35, mass: 0.5 }
+                }
+              />
+            )}
+            <span className="relative z-10">{t(opt.labelKey)}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/* ------------------------------- Reset all ------------------------------ */
+
+export function ResetCustomizationButton() {
+  const t = useT();
+  const customization = useAppearanceCustomStore((s) => s.customization);
+  const resetAll = useAppearanceCustomStore((s) => s.resetAll);
+  const pristine = isDefaultCustomization(customization);
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      disabled={pristine}
+      onClick={resetAll}
+    >
+      {t("settings.appearance.custom.resetAll")}
+    </Button>
+  );
+}
+
+export { DEFAULT_CUSTOMIZATION };

--- a/studio/frontend/src/features/settings/components/color-picker.tsx
+++ b/studio/frontend/src/features/settings/components/color-picker.tsx
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { useT } from "@/i18n";
+import { cn } from "@/lib/utils";
+import { ColorPickerIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useEffect, useRef, useState } from "react";
+
+/* ------------------------- HSV ↔ hex conversions ------------------------- */
+
+type Hsv = { h: number; s: number; v: number };
+
+function hexToHsv(hex: string): Hsv {
+  const r = Number.parseInt(hex.slice(1, 3), 16) / 255;
+  const g = Number.parseInt(hex.slice(3, 5), 16) / 255;
+  const b = Number.parseInt(hex.slice(5, 7), 16) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const d = max - min;
+  let h = 0;
+  if (d !== 0) {
+    if (max === r) h = ((g - b) / d) % 6;
+    else if (max === g) h = (b - r) / d + 2;
+    else h = (r - g) / d + 4;
+    h *= 60;
+    if (h < 0) h += 360;
+  }
+  return { h, s: max === 0 ? 0 : d / max, v: max };
+}
+
+function hsvToHex({ h, s, v }: Hsv): string {
+  const c = v * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = v - c;
+  let rgb: [number, number, number];
+  if (h < 60) rgb = [c, x, 0];
+  else if (h < 120) rgb = [x, c, 0];
+  else if (h < 180) rgb = [0, c, x];
+  else if (h < 240) rgb = [0, x, c];
+  else if (h < 300) rgb = [x, 0, c];
+  else rgb = [c, 0, x];
+  const channel = (value: number) =>
+    Math.round((value + m) * 255)
+      .toString(16)
+      .padStart(2, "0");
+  return `#${channel(rgb[0])}${channel(rgb[1])}${channel(rgb[2])}`;
+}
+
+const HEX_PATTERN = /^#?([0-9a-fA-F]{6})$/;
+
+/* ------------------------------- Component ------------------------------- */
+
+type EyeDropperResult = { sRGBHex: string };
+type EyeDropperConstructor = new () => {
+  open: () => Promise<EyeDropperResult>;
+};
+
+/**
+ * In-app color picker in a Popover: saturation/value area, hue slider, hex
+ * field, and (where supported) a screen eyedropper. Replaces the native
+ * <input type="color"> so no OS-level color panel is left dangling when the
+ * user clicks away; the popover dismisses like any other popup.
+ */
+export function ColorPickerSwatch({
+  value,
+  onChange,
+  label,
+  highlighted,
+}: {
+  value: string;
+  onChange: (hex: string) => void;
+  label: string;
+  highlighted?: boolean;
+}) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+  const [hsv, setHsv] = useState<Hsv>(() => hexToHsv(value));
+  const [hexDraft, setHexDraft] = useState(value);
+  const areaRef = useRef<HTMLDivElement>(null);
+
+  // Re-seed the picker from the outside value each time it opens (the value
+  // may have changed via reset, palette switch, or remote sync).
+  useEffect(() => {
+    if (open) {
+      setHsv(hexToHsv(value));
+      setHexDraft(value);
+    }
+  }, [open, value]);
+
+  const emit = (next: Hsv) => {
+    setHsv(next);
+    const hex = hsvToHex(next);
+    setHexDraft(hex);
+    onChange(hex);
+  };
+
+  const moveFromPointer = (e: React.PointerEvent) => {
+    const area = areaRef.current;
+    if (!area) return;
+    const rect = area.getBoundingClientRect();
+    const s = Math.min(1, Math.max(0, (e.clientX - rect.left) / rect.width));
+    const v =
+      1 - Math.min(1, Math.max(0, (e.clientY - rect.top) / rect.height));
+    emit({ ...hsv, s, v });
+  };
+
+  const commitHex = () => {
+    const match = HEX_PATTERN.exec(hexDraft.trim());
+    if (!match) {
+      setHexDraft(hsvToHex(hsv));
+      return;
+    }
+    const hex = `#${match[1].toLowerCase()}`;
+    setHsv(hexToHsv(hex));
+    setHexDraft(hex);
+    onChange(hex);
+  };
+
+  const eyeDropperCtor = (
+    globalThis as { EyeDropper?: EyeDropperConstructor }
+  ).EyeDropper;
+
+  const pickFromScreen = async () => {
+    if (!eyeDropperCtor) return;
+    try {
+      const result = await new eyeDropperCtor().open();
+      const hex = result.sRGBHex.toLowerCase();
+      if (HEX_PATTERN.test(hex)) {
+        setHsv(hexToHsv(hex));
+        setHexDraft(hex);
+        onChange(hex);
+      }
+    } catch {
+      // user dismissed the eyedropper
+    }
+  };
+
+  const hueColor = hsvToHex({ h: hsv.h, s: 1, v: 1 });
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={label}
+          className={cn(
+            "h-7 w-10 cursor-pointer rounded-md border transition-shadow",
+            highlighted ? "border-ring" : "border-border",
+          )}
+          style={{ backgroundColor: value }}
+        />
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-60 rounded-xl p-3">
+        <div className="flex flex-col gap-3">
+          <div
+            ref={areaRef}
+            role="slider"
+            aria-label={label}
+            aria-valuetext={hexDraft}
+            aria-valuenow={Math.round(hsv.v * 100)}
+            tabIndex={0}
+            className="relative h-36 w-full cursor-crosshair touch-none rounded-lg"
+            style={{
+              background: `linear-gradient(to top, #000, transparent), linear-gradient(to right, #fff, ${hueColor})`,
+            }}
+            onPointerDown={(e) => {
+              e.currentTarget.setPointerCapture(e.pointerId);
+              moveFromPointer(e);
+            }}
+            onPointerMove={(e) => {
+              if (e.buttons === 1) moveFromPointer(e);
+            }}
+          >
+            <span
+              className="pointer-events-none absolute size-3.5 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white shadow-[0_0_0_1px_rgba(0,0,0,0.35)]"
+              style={{
+                left: `${hsv.s * 100}%`,
+                top: `${(1 - hsv.v) * 100}%`,
+                backgroundColor: hsvToHex(hsv),
+              }}
+            />
+          </div>
+          <input
+            type="range"
+            min={0}
+            max={360}
+            step={1}
+            value={Math.round(hsv.h)}
+            aria-label={t("settings.appearance.custom.colorPicker.hue")}
+            onChange={(e) => emit({ ...hsv, h: Number(e.target.value) })}
+            className="h-3 w-full cursor-pointer appearance-none rounded-full outline-none [&::-moz-range-thumb]:size-3.5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-white [&::-moz-range-thumb]:bg-transparent [&::-webkit-slider-thumb]:size-3.5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-white [&::-webkit-slider-thumb]:shadow-[0_0_0_1px_rgba(0,0,0,0.35)]"
+            style={{
+              background:
+                "linear-gradient(to right, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00)",
+            }}
+          />
+          <div className="flex items-center gap-2">
+            <input
+              value={hexDraft.toUpperCase()}
+              onChange={(e) => setHexDraft(e.target.value)}
+              onBlur={commitHex}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  commitHex();
+                  e.currentTarget.blur();
+                }
+              }}
+              aria-label={t("settings.appearance.custom.colorPicker.hex")}
+              spellCheck={false}
+              className="h-8 w-full min-w-0 rounded-full bg-panel-input-surface px-3 font-mono text-xs text-foreground uppercase outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+            />
+            {eyeDropperCtor && (
+              <button
+                type="button"
+                onClick={() => void pickFromScreen()}
+                aria-label={t(
+                  "settings.appearance.custom.colorPicker.eyedropper",
+                )}
+                title={t("settings.appearance.custom.colorPicker.eyedropper")}
+                className="flex size-8 shrink-0 items-center justify-center rounded-full border border-border text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <HugeiconsIcon icon={ColorPickerIcon} className="size-4" />
+              </button>
+            )}
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/studio/frontend/src/features/settings/components/palette-cards.tsx
+++ b/studio/frontend/src/features/settings/components/palette-cards.tsx
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { type TranslationKey, useT } from "@/i18n";
+import { cn } from "@/lib/utils";
+import { Tick02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  type Palette,
+  type ResolvedTheme,
+  usePalette,
+  useTheme,
+} from "../stores/theme-store";
+
+type PreviewColors = {
+  bg: string;
+  sidebar: string;
+  accent: string;
+  text: string;
+  border: string;
+};
+
+// Representative swatches per palette × resolved mode. Hardcoded (rather than
+// reading the live CSS variables) so every card previews its own palette while
+// only one palette is active on <html>. Sidebar tones are slightly exaggerated
+// so the two surfaces stay distinguishable at thumbnail size.
+const PREVIEWS: Record<Palette, Record<ResolvedTheme, PreviewColors>> = {
+  standard: {
+    light: {
+      bg: "#fefefd",
+      sidebar: "#f1f1ef",
+      accent: "#17b88b",
+      text: "#444444",
+      border: "#e4e4e0",
+    },
+    dark: {
+      bg: "#181818",
+      sidebar: "#262626",
+      accent: "#17b88b",
+      text: "#b5b5b5",
+      border: "#303030",
+    },
+  },
+  classic: {
+    light: {
+      bg: "#ffffff",
+      sidebar: "#ededed",
+      accent: "#339cff",
+      text: "#4b4d50",
+      border: "#e6e6e6",
+    },
+    dark: {
+      bg: "#181818",
+      sidebar: "#262626",
+      accent: "#4dabff",
+      text: "#b5b5b5",
+      border: "#303030",
+    },
+  },
+  minimal: {
+    light: {
+      bg: "#ffffff",
+      sidebar: "#f2f2f2",
+      accent: "#171717",
+      text: "#555555",
+      border: "#e2e2e2",
+    },
+    dark: {
+      bg: "#181818",
+      sidebar: "#262626",
+      accent: "#ededed",
+      text: "#a8a8a8",
+      border: "#303030",
+    },
+  },
+};
+
+const OPTIONS: {
+  value: Palette;
+  labelKey: TranslationKey;
+}[] = [
+  { value: "standard", labelKey: "settings.appearance.palette.standard" },
+  { value: "classic", labelKey: "settings.appearance.palette.classic" },
+  { value: "minimal", labelKey: "settings.appearance.palette.minimal" },
+];
+
+function PalettePreview({ colors }: { colors: PreviewColors }) {
+  return (
+    <div
+      className="h-16 w-full overflow-hidden rounded-lg border"
+      style={{ backgroundColor: colors.bg, borderColor: colors.border }}
+      aria-hidden="true"
+    >
+      <div className="flex h-full">
+        <div
+          className="h-full w-1/4"
+          style={{ backgroundColor: colors.sidebar }}
+        />
+        <div className="flex flex-1 flex-col justify-center gap-1.5 px-2.5">
+          <span
+            className="h-1.5 w-3/4 rounded-full"
+            style={{ backgroundColor: colors.text }}
+          />
+          <span
+            className="h-1.5 w-1/2 rounded-full opacity-60"
+            style={{ backgroundColor: colors.text }}
+          />
+          <span
+            className="h-2.5 w-8 rounded-full"
+            style={{ backgroundColor: colors.accent }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function PaletteCards() {
+  const t = useT();
+  const { resolved } = useTheme();
+  const { palette, setPalette } = usePalette();
+  return (
+    <div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-3">
+      {OPTIONS.map((opt) => {
+        const active = palette === opt.value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => setPalette(opt.value)}
+            aria-pressed={active}
+            className={cn(
+              "flex flex-col gap-2 rounded-xl border p-2.5 text-left transition-colors",
+              active
+                ? "border-ring ring-1 ring-ring"
+                : "border-border hover:border-ring/40",
+            )}
+          >
+            <PalettePreview colors={PREVIEWS[opt.value][resolved]} />
+            <div className="flex items-center justify-between gap-2 px-0.5">
+              <span className="text-sm font-medium text-foreground">
+                {t(opt.labelKey)}
+              </span>
+              {active && (
+                <span className="flex size-4 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground">
+                  <HugeiconsIcon icon={Tick02Icon} className="size-3" />
+                </span>
+              )}
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/studio/frontend/src/features/settings/index.ts
+++ b/studio/frontend/src/features/settings/index.ts
@@ -6,7 +6,25 @@ export {
   loadPersonalization,
   savePersonalization,
 } from "./api/personalization";
-export { setTheme, useTheme } from "./stores/theme-store";
+export {
+  isPalette,
+  setPalette,
+  setTheme,
+  usePalette,
+  useTheme,
+} from "./stores/theme-store";
+export {
+  DEFAULT_CUSTOMIZATION,
+  applyCustomizationToDocument,
+  isDefaultCustomization,
+  sanitizeCustomization,
+  useAppearanceCustomStore,
+} from "./stores/appearance-custom-store";
+export type {
+  AppearanceCustomization,
+  CustomModeColors,
+  ReduceMotionSetting,
+} from "./stores/appearance-custom-store";
 export { useMonitorOverlayStore } from "./stores/monitor-overlay-store";
 export type {
   Personalization,
@@ -15,4 +33,4 @@ export type {
 } from "./api/personalization";
 export { useSettingsDialogStore } from "./stores/settings-dialog-store";
 export type { SettingsTab } from "./stores/settings-dialog-store";
-export type { ResolvedTheme, Theme } from "./stores/theme-store";
+export type { Palette, ResolvedTheme, Theme } from "./stores/theme-store";

--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -206,7 +206,7 @@ export function SettingsDialog() {
                         {t(tab.labelKey)}
                       </span>
                       {tab.badgeKey ? (
-                        <span className="relative z-10 ml-auto rounded-full bg-emerald-500/10 px-2 py-1 text-[10px] leading-none font-semibold text-emerald-700 dark:text-emerald-300">
+                        <span className="relative z-10 ml-auto rounded-full bg-control-accent/10 px-2 py-1 text-[10px] leading-none font-semibold text-control-accent">
                           {t(tab.badgeKey)}
                         </span>
                       ) : null}

--- a/studio/frontend/src/features/settings/stores/appearance-custom-store.ts
+++ b/studio/frontend/src/features/settings/stores/appearance-custom-store.ts
@@ -1,0 +1,405 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { ResolvedTheme } from "./theme-store";
+
+export type ReduceMotionSetting = "system" | "on" | "off";
+
+export type CustomModeColors = {
+  accent: string | null;
+  background: string | null;
+  foreground: string | null;
+};
+
+export type ImportedFont = {
+  /** Font-family name the FontFace is registered under. */
+  name: string;
+  /** data: URL of the uploaded font file. */
+  dataUrl: string;
+};
+
+export const MAX_IMPORTED_FONTS = 3;
+/** ~1.5 MB file → ~2 MB base64; must stay in sync with the backend cap. */
+export const MAX_IMPORTED_FONT_DATA_URL_LENGTH = 2_200_000;
+
+export type AppearanceCustomization = {
+  colors: { light: CustomModeColors; dark: CustomModeColors };
+  uiFont: string | null;
+  codeFont: string | null;
+  importedFonts: ImportedFont[];
+  /** Root font size in px (rem base). null = browser default (16). */
+  uiFontSize: number | null;
+  /** Code/pre font size in px. null = inherit each element's own size. */
+  codeFontSize: number | null;
+  /** 0–100; 50 is neutral (no adjustment). */
+  contrast: number;
+  pointerCursors: boolean;
+  reduceMotion: ReduceMotionSetting;
+  /** true = the app default (antialiased). */
+  fontSmoothing: boolean;
+  translucentSidebar: boolean;
+};
+
+const EMPTY_MODE_COLORS: CustomModeColors = {
+  accent: null,
+  background: null,
+  foreground: null,
+};
+
+export const DEFAULT_CUSTOMIZATION: AppearanceCustomization = {
+  colors: { light: { ...EMPTY_MODE_COLORS }, dark: { ...EMPTY_MODE_COLORS } },
+  uiFont: null,
+  codeFont: null,
+  importedFonts: [],
+  uiFontSize: null,
+  codeFontSize: null,
+  contrast: 50,
+  pointerCursors: false,
+  reduceMotion: "system",
+  fontSmoothing: true,
+  translucentSidebar: false,
+};
+
+export const UI_FONT_SIZE_RANGE = { min: 12, max: 20, default: 16 } as const;
+export const CODE_FONT_SIZE_RANGE = { min: 10, max: 20, default: 13 } as const;
+
+const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+
+export function isHexColor(value: unknown): value is string {
+  return typeof value === "string" && HEX_COLOR_PATTERN.test(value);
+}
+
+function sanitizeColor(value: unknown): string | null {
+  return isHexColor(value) ? value.toLowerCase() : null;
+}
+
+function sanitizeFont(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  // Strip characters that could terminate the declaration or smuggle extra
+  // CSS through the inline style (the value lands in style.setProperty).
+  const cleaned = value
+    .replace(/[;{}()<>"']/g, "")
+    .trim()
+    .slice(0, 200);
+  return cleaned.length > 0 ? cleaned : null;
+}
+
+function sanitizeSize(
+  value: unknown,
+  range: { min: number; max: number },
+): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  const rounded = Math.round(value);
+  if (rounded < range.min || rounded > range.max) {
+    return Math.min(range.max, Math.max(range.min, rounded));
+  }
+  return rounded;
+}
+
+function sanitizeModeColors(value: unknown): CustomModeColors {
+  const source = (value ?? {}) as Partial<CustomModeColors>;
+  return {
+    accent: sanitizeColor(source.accent),
+    background: sanitizeColor(source.background),
+    foreground: sanitizeColor(source.foreground),
+  };
+}
+
+const FONT_DATA_URL_PATTERN =
+  /^data:(?:font\/(?:woff2?|ttf|otf|sfnt)|application\/(?:octet-stream|x-font-\w+|font-\w+));base64,[A-Za-z0-9+/=]+$/;
+
+function sanitizeImportedFonts(value: unknown): ImportedFont[] {
+  if (!Array.isArray(value)) return [];
+  const fonts: ImportedFont[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (fonts.length >= MAX_IMPORTED_FONTS) break;
+    const source = (entry ?? {}) as Partial<ImportedFont>;
+    const name = sanitizeFont(source.name);
+    if (!name || seen.has(name)) continue;
+    const dataUrl = source.dataUrl;
+    if (
+      typeof dataUrl !== "string" ||
+      dataUrl.length > MAX_IMPORTED_FONT_DATA_URL_LENGTH ||
+      !FONT_DATA_URL_PATTERN.test(dataUrl)
+    ) {
+      continue;
+    }
+    seen.add(name);
+    fonts.push({ name, dataUrl });
+  }
+  return fonts;
+}
+
+/**
+ * Coerce arbitrary (persisted/remote) data into a valid customization object.
+ * Anything malformed falls back to the default for that field, so a bad
+ * payload can never wedge the UI.
+ */
+export function sanitizeCustomization(value: unknown): AppearanceCustomization {
+  const source = (value ?? {}) as Partial<AppearanceCustomization> & {
+    colors?: { light?: unknown; dark?: unknown };
+  };
+  const contrast =
+    typeof source.contrast === "number" && Number.isFinite(source.contrast)
+      ? Math.min(100, Math.max(0, Math.round(source.contrast)))
+      : DEFAULT_CUSTOMIZATION.contrast;
+  return {
+    colors: {
+      light: sanitizeModeColors(source.colors?.light),
+      dark: sanitizeModeColors(source.colors?.dark),
+    },
+    uiFont: sanitizeFont(source.uiFont),
+    codeFont: sanitizeFont(source.codeFont),
+    importedFonts: sanitizeImportedFonts(source.importedFonts),
+    uiFontSize: sanitizeSize(source.uiFontSize, UI_FONT_SIZE_RANGE),
+    codeFontSize: sanitizeSize(source.codeFontSize, CODE_FONT_SIZE_RANGE),
+    contrast,
+    pointerCursors: source.pointerCursors === true,
+    reduceMotion:
+      source.reduceMotion === "on" || source.reduceMotion === "off"
+        ? source.reduceMotion
+        : "system",
+    fontSmoothing: source.fontSmoothing !== false,
+    translucentSidebar: source.translucentSidebar === true,
+  };
+}
+
+export function isDefaultCustomization(c: AppearanceCustomization): boolean {
+  return JSON.stringify(c) === JSON.stringify(DEFAULT_CUSTOMIZATION);
+}
+
+interface AppearanceCustomState {
+  customization: AppearanceCustomization;
+  setColor: (
+    mode: ResolvedTheme,
+    key: keyof CustomModeColors,
+    value: string | null,
+  ) => void;
+  patch: (partial: Partial<AppearanceCustomization>) => void;
+  addImportedFont: (font: ImportedFont) => void;
+  removeImportedFont: (name: string) => void;
+  replaceAll: (next: AppearanceCustomization) => void;
+  resetAll: () => void;
+}
+
+export const useAppearanceCustomStore = create<AppearanceCustomState>()(
+  persist(
+    (set) => ({
+      customization: DEFAULT_CUSTOMIZATION,
+      setColor: (mode, key, value) =>
+        set((state) => ({
+          customization: {
+            ...state.customization,
+            colors: {
+              ...state.customization.colors,
+              [mode]: {
+                ...state.customization.colors[mode],
+                [key]: sanitizeColor(value),
+              },
+            },
+          },
+        })),
+      patch: (partial) =>
+        set((state) => ({
+          customization: sanitizeCustomization({
+            ...state.customization,
+            ...partial,
+          }),
+        })),
+      addImportedFont: (font) =>
+        set((state) => ({
+          customization: sanitizeCustomization({
+            ...state.customization,
+            importedFonts: [
+              ...state.customization.importedFonts.filter(
+                (f) => f.name !== font.name,
+              ),
+              font,
+            ],
+          }),
+        })),
+      removeImportedFont: (name) =>
+        set((state) => {
+          const c = state.customization;
+          return {
+            customization: sanitizeCustomization({
+              ...c,
+              importedFonts: c.importedFonts.filter((f) => f.name !== name),
+              // Fall back to the default font wherever the removed one was in use.
+              uiFont: c.uiFont === name ? null : c.uiFont,
+              codeFont: c.codeFont === name ? null : c.codeFont,
+            }),
+          };
+        }),
+      replaceAll: (next) => set({ customization: sanitizeCustomization(next) }),
+      resetAll: () => set({ customization: DEFAULT_CUSTOMIZATION }),
+    }),
+    {
+      name: "unsloth_appearance_customization",
+      version: 2,
+      migrate: (persisted) => {
+        const state = (persisted ?? {}) as Partial<AppearanceCustomState>;
+        return {
+          customization: sanitizeCustomization(state.customization),
+        } as AppearanceCustomState;
+      },
+      // Sanitize on EVERY rehydrate, not just version bumps: a same-version
+      // payload written by an older bundle (e.g. before importedFonts existed)
+      // would otherwise reach the app with missing fields and crash .map calls.
+      merge: (persisted, current) => ({
+        ...current,
+        customization: sanitizeCustomization(
+          (persisted as Partial<AppearanceCustomState> | undefined)
+            ?.customization,
+        ),
+      }),
+    },
+  ),
+);
+
+/* ------------------------------ DOM applier ------------------------------ */
+
+const DEFAULT_SANS_STACK =
+  '"Inter Variable", ui-sans-serif, sans-serif, system-ui';
+const DEFAULT_MONO_STACK = "JetBrains Mono, monospace";
+
+/** WCAG-ish relative luminance from a #rrggbb hex. */
+function hexLuminance(hex: string): number {
+  const channel = (i: number) => {
+    const c = Number.parseInt(hex.slice(i, i + 2), 16) / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(1) + 0.7152 * channel(3) + 0.0722 * channel(5);
+}
+
+function readableForeground(hex: string): string {
+  return hexLuminance(hex) > 0.45 ? "#111417" : "#ffffff";
+}
+
+/**
+ * FontFaces registered for imported fonts, keyed by family name. Kept so a
+ * removed import can be unregistered from document.fonts.
+ */
+const registeredFontFaces = new Map<string, FontFace>();
+
+function syncImportedFonts(fonts: ImportedFont[]): void {
+  if (typeof document === "undefined" || !("fonts" in document)) return;
+  // Never trust the shape at this boundary: a stale
+  // persisted payload without importedFonts must not crash the applier.
+  const wanted = new Map(
+    (Array.isArray(fonts) ? fonts : []).map((f) => [f.name, f.dataUrl]),
+  );
+  for (const [name, face] of registeredFontFaces) {
+    if (!wanted.has(name)) {
+      document.fonts.delete(face);
+      registeredFontFaces.delete(name);
+    }
+  }
+  for (const [name, dataUrl] of wanted) {
+    if (registeredFontFaces.has(name)) continue;
+    try {
+      const face = new FontFace(name, `url(${dataUrl})`);
+      registeredFontFaces.set(name, face);
+      document.fonts.add(face);
+      face.load().catch(() => {
+        document.fonts.delete(face);
+        registeredFontFaces.delete(name);
+      });
+    } catch {
+      registeredFontFaces.delete(name);
+    }
+  }
+}
+
+/**
+ * The custom "Accent" recolors the accent family (toggles, badges, focus
+ * rings, chart-1) Codex-style. Palette-defined button colors (--primary)
+ * are deliberately left alone, so Classic's neutral buttons stay neutral.
+ */
+const ACCENT_VARS = [
+  "--control-accent",
+  "--ring",
+  "--sidebar-ring",
+  "--chart-1",
+] as const;
+const ACCENT_FG_VARS = ["--control-accent-foreground"] as const;
+
+/**
+ * Push the customization onto <html> as inline CSS variables, attributes, and
+ * classes. Everything is keyed off explicit hooks (inline vars beat every
+ * palette block; the classes/attributes gate rules in index.css), so the
+ * default customization leaves the document byte-identical to stock.
+ */
+export function applyCustomizationToDocument(
+  c: AppearanceCustomization,
+  resolved: ResolvedTheme,
+): void {
+  if (typeof document === "undefined") return;
+  const el = document.documentElement;
+  const style = el.style;
+
+  const setVar = (name: string, value: string | null) => {
+    if (value === null) style.removeProperty(name);
+    else style.setProperty(name, value);
+  };
+
+  const colors = c.colors[resolved];
+
+  for (const name of ACCENT_VARS) setVar(name, colors.accent);
+  for (const name of ACCENT_FG_VARS) {
+    setVar(name, colors.accent ? readableForeground(colors.accent) : null);
+  }
+  setVar("--background", colors.background);
+  setVar("--foreground", colors.foreground);
+
+  syncImportedFonts(c.importedFonts);
+
+  // Family names are single identifiers picked from the dropdown (sanitizeFont
+  // strips quote characters), so quoting here is always safe.
+  setVar(
+    "--font-sans",
+    c.uiFont ? `"${c.uiFont}", ${DEFAULT_SANS_STACK}` : null,
+  );
+  setVar(
+    "--font-mono",
+    c.codeFont ? `"${c.codeFont}", ${DEFAULT_MONO_STACK}` : null,
+  );
+
+  if (c.uiFontSize !== null && c.uiFontSize !== UI_FONT_SIZE_RANGE.default) {
+    style.fontSize = `${c.uiFontSize}px`;
+  } else {
+    style.removeProperty("font-size");
+  }
+
+  if (c.codeFontSize !== null) {
+    el.setAttribute("data-code-font-size", "");
+    setVar("--custom-code-font-size", `${c.codeFontSize}px`);
+  } else {
+    el.removeAttribute("data-code-font-size");
+    setVar("--custom-code-font-size", null);
+  }
+
+  if (c.contrast !== 50) {
+    // Map |contrast - 50| ∈ (0, 50] onto a 0–40% color-mix toward the
+    // foreground (higher contrast) or background (lower contrast).
+    const mix = Math.round(Math.abs(c.contrast - 50) * 0.8);
+    el.setAttribute("data-contrast-adjust", "");
+    setVar("--contrast-mix", `${mix}%`);
+    setVar(
+      "--contrast-target",
+      c.contrast > 50 ? "var(--foreground)" : "var(--background)",
+    );
+  } else {
+    el.removeAttribute("data-contrast-adjust");
+    setVar("--contrast-mix", null);
+    setVar("--contrast-target", null);
+  }
+
+  el.classList.toggle("pointer-cursors", c.pointerCursors);
+  el.classList.toggle("force-reduced-motion", c.reduceMotion === "on");
+  el.classList.toggle("no-font-smoothing", !c.fontSmoothing);
+  el.classList.toggle("translucent-sidebar", c.translucentSidebar);
+}

--- a/studio/frontend/src/features/settings/stores/theme-store.ts
+++ b/studio/frontend/src/features/settings/stores/theme-store.ts
@@ -5,8 +5,16 @@ import { useSyncExternalStore } from "react";
 
 export type Theme = "light" | "dark" | "system";
 export type ResolvedTheme = "light" | "dark";
+export type Palette = "standard" | "classic" | "minimal";
 
 const STORAGE_KEY = "theme";
+const PALETTE_STORAGE_KEY = "palette";
+
+export const PALETTES: readonly Palette[] = ["standard", "classic", "minimal"];
+
+export function isPalette(value: unknown): value is Palette {
+  return value === "standard" || value === "classic" || value === "minimal";
+}
 
 function readStoredTheme(): Theme {
   if (typeof window === "undefined") return "system";
@@ -16,8 +24,20 @@ function readStoredTheme(): Theme {
   } catch {
     return "system";
   }
-  if (stored === "light" || stored === "dark" || stored === "system") return stored;
+  if (stored === "light" || stored === "dark" || stored === "system")
+    return stored;
   return "system";
+}
+
+function readStoredPalette(): Palette {
+  if (typeof window === "undefined") return "standard";
+  let stored: string | null = null;
+  try {
+    stored = window.localStorage.getItem(PALETTE_STORAGE_KEY);
+  } catch {
+    return "standard";
+  }
+  return isPalette(stored) ? stored : "standard";
 }
 
 function systemPrefersDark(): boolean {
@@ -39,6 +59,18 @@ function applyToDocument(resolved: ResolvedTheme) {
   cl.toggle("light", resolved === "light");
 }
 
+function applyPaletteToDocument(palette: Palette) {
+  if (typeof document === "undefined") return;
+  const el = document.documentElement;
+  // Standard is the base :root/.dark palette; no attribute keeps the DOM
+  // (and CSS selectors) simple for the default look.
+  if (palette === "standard") {
+    el.removeAttribute("data-palette");
+  } else {
+    el.setAttribute("data-palette", palette);
+  }
+}
+
 const listeners = new Set<() => void>();
 function subscribe(cb: () => void) {
   listeners.add(cb);
@@ -48,6 +80,7 @@ function subscribe(cb: () => void) {
   const mq = window.matchMedia("(prefers-color-scheme: dark)");
   const syncTheme = () => {
     applyToDocument(resolveTheme(readStoredTheme()));
+    applyPaletteToDocument(readStoredPalette());
     cb();
   };
   // Apply on mount so this store is the single source of truth for the DOM
@@ -56,8 +89,14 @@ function subscribe(cb: () => void) {
   // localStorage) falls back to its own default and shows light while the
   // control still reads "system".
   applyToDocument(resolveTheme(readStoredTheme()));
+  applyPaletteToDocument(readStoredPalette());
   const onStorage = (e: StorageEvent) => {
-    if (e.key === STORAGE_KEY || e.key === null) syncTheme();
+    if (
+      e.key === STORAGE_KEY ||
+      e.key === PALETTE_STORAGE_KEY ||
+      e.key === null
+    )
+      syncTheme();
   };
   mq.addEventListener("change", syncTheme);
   window.addEventListener("storage", onStorage);
@@ -102,4 +141,40 @@ export function useTheme(): {
   const theme = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
   const resolved = resolveTheme(theme);
   return { theme, resolved, setTheme };
+}
+
+function getPaletteSnapshot(): Palette {
+  return readStoredPalette();
+}
+
+function getPaletteServerSnapshot(): Palette {
+  return "standard";
+}
+
+/**
+ * Single source of truth for setting the color palette; mirrors setTheme so
+ * the data-palette attribute, localStorage, and React subscribers stay in
+ * sync.
+ */
+export function setPalette(next: Palette): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(PALETTE_STORAGE_KEY, next);
+  } catch {
+    // ignore storage failures
+  }
+  applyPaletteToDocument(next);
+  listeners.forEach((cb) => cb());
+}
+
+export function usePalette(): {
+  palette: Palette;
+  setPalette: (next: Palette) => void;
+} {
+  const palette = useSyncExternalStore(
+    subscribe,
+    getPaletteSnapshot,
+    getPaletteServerSnapshot,
+  );
+  return { palette, setPalette };
 }

--- a/studio/frontend/src/features/settings/tabs/appearance-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/appearance-tab.tsx
@@ -4,13 +4,30 @@
 import { Switch } from "@/components/ui/switch";
 import { useSidebarPin } from "@/hooks/use-sidebar-pin";
 import { useT } from "@/i18n";
+import {
+  ActiveColorControl,
+  CodeFontRow,
+  CodeFontSizeRow,
+  ContrastSliderRow,
+  FontSmoothingSwitch,
+  ImportFontControls,
+  PointerCursorsSwitch,
+  ReduceMotionSegmented,
+  ResetCustomizationButton,
+  TranslucentSidebarSwitch,
+  UiFontRow,
+  UiFontSizeRow,
+} from "../components/appearance-custom-controls";
 import { LanguageSelect } from "../components/language-select";
+import { PaletteCards } from "../components/palette-cards";
 import { SettingsRow } from "../components/settings-row";
 import { SettingsSection } from "../components/settings-section";
 import { ThemeSegmented } from "../components/theme-segmented";
+import { useTheme } from "../stores/theme-store";
 
 export function AppearanceTab() {
   const t = useT();
+  const { resolved } = useTheme();
   const { pinned, setPinned } = useSidebarPin();
   return (
     <div className="flex flex-col gap-6">
@@ -30,6 +47,118 @@ export function AppearanceTab() {
         >
           <ThemeSegmented />
         </SettingsRow>
+        <SettingsRow
+          label={t("settings.appearance.palette.label")}
+          description={t("settings.appearance.palette.description")}
+          className="flex-col items-stretch gap-3"
+        >
+          <PaletteCards />
+        </SettingsRow>
+      </SettingsSection>
+
+      <SettingsSection
+        title={t(
+          resolved === "light"
+            ? "settings.appearance.custom.colors.lightGroup"
+            : "settings.appearance.custom.colors.darkGroup",
+        )}
+        description={t("settings.appearance.custom.colors.description")}
+      >
+        <SettingsRow label={t("settings.appearance.custom.colors.accent")}>
+          <ActiveColorControl
+            colorKey="accent"
+            label={t("settings.appearance.custom.colors.accent")}
+          />
+        </SettingsRow>
+        <SettingsRow label={t("settings.appearance.custom.colors.background")}>
+          <ActiveColorControl
+            colorKey="background"
+            label={t("settings.appearance.custom.colors.background")}
+          />
+        </SettingsRow>
+        <SettingsRow label={t("settings.appearance.custom.colors.foreground")}>
+          <ActiveColorControl
+            colorKey="foreground"
+            label={t("settings.appearance.custom.colors.foreground")}
+          />
+        </SettingsRow>
+        <SettingsRow
+          label={t("settings.appearance.custom.uiFont.label")}
+          description={t("settings.appearance.custom.uiFont.description")}
+        >
+          <UiFontRow />
+        </SettingsRow>
+        <SettingsRow
+          label={t("settings.appearance.custom.codeFont.label")}
+          description={t("settings.appearance.custom.codeFont.description")}
+        >
+          <CodeFontRow />
+        </SettingsRow>
+        <SettingsRow
+          label={t("settings.appearance.custom.importFont.label")}
+          description={t("settings.appearance.custom.importFont.description")}
+        >
+          <ImportFontControls />
+        </SettingsRow>
+        <SettingsRow
+          label={t("settings.appearance.custom.translucentSidebar.label")}
+          description={t(
+            "settings.appearance.custom.translucentSidebar.description",
+          )}
+        >
+          <TranslucentSidebarSwitch />
+        </SettingsRow>
+        <SettingsRow
+          label={t("settings.appearance.custom.contrast.label")}
+          description={t("settings.appearance.custom.contrast.description")}
+        >
+          <ContrastSliderRow />
+        </SettingsRow>
+      </SettingsSection>
+
+      <SettingsSection title={t("settings.appearance.custom.preferencesTitle")}>
+        <SettingsRow
+          label={t("settings.appearance.custom.pointerCursors.label")}
+          description={t(
+            "settings.appearance.custom.pointerCursors.description",
+          )}
+        >
+          <PointerCursorsSwitch />
+        </SettingsRow>
+        <SettingsRow
+          label={t("settings.appearance.custom.reduceMotion.label")}
+          description={t("settings.appearance.custom.reduceMotion.description")}
+        >
+          <ReduceMotionSegmented />
+        </SettingsRow>
+        <SettingsRow
+          label={t("settings.appearance.custom.uiFontSize.label")}
+          description={t("settings.appearance.custom.uiFontSize.description")}
+        >
+          <UiFontSizeRow />
+        </SettingsRow>
+        <SettingsRow
+          label={t("settings.appearance.custom.codeFontSize.label")}
+          description={t("settings.appearance.custom.codeFontSize.description")}
+        >
+          <CodeFontSizeRow />
+        </SettingsRow>
+        <SettingsRow
+          label={t("settings.appearance.custom.fontSmoothing.label")}
+          description={t(
+            "settings.appearance.custom.fontSmoothing.description",
+          )}
+        >
+          <FontSmoothingSwitch />
+        </SettingsRow>
+        <SettingsRow
+          label={t("settings.appearance.layout.compactSidebar")}
+          description={t(
+            "settings.appearance.layout.compactSidebarDescription",
+          )}
+        >
+          <Switch checked={pinned} onCheckedChange={setPinned} />
+        </SettingsRow>
       </SettingsSection>
 
       <SettingsSection title={t("settings.appearance.language.title")}>
@@ -41,14 +170,9 @@ export function AppearanceTab() {
         </SettingsRow>
       </SettingsSection>
 
-      <SettingsSection title={t("settings.appearance.layout.title")}>
-        <SettingsRow
-          label={t("settings.appearance.layout.compactSidebar")}
-          description={t("settings.appearance.layout.compactSidebarDescription")}
-        >
-          <Switch checked={pinned} onCheckedChange={setPinned} />
-        </SettingsRow>
-      </SettingsSection>
+      <div className="flex justify-end border-t border-border/60 pt-4">
+        <ResetCustomizationButton />
+      </div>
     </div>
   );
 }

--- a/studio/frontend/src/features/studio/sections/dataset-section.tsx
+++ b/studio/frontend/src/features/studio/sections/dataset-section.tsx
@@ -28,29 +28,38 @@ import {
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { cn } from "@/lib/utils";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { useDebouncedValue, useHfTokenValidation } from "@/hooks";
+import { usePlatformStore } from "@/config/env";
 import { useHubDatasetSearch } from "@/features/hub/hooks/use-hub-dataset-search";
 import { useHubInfiniteScroll } from "@/features/hub/hooks/use-hub-infinite-scroll";
 import {
+  formatUploadSize,
+  getCachedUploadLimitBytes,
+  getCachedUploadLimitLabel,
+  loadUploadLimitSettings,
+  subscribeUploadLimitSettings,
+} from "@/features/settings/api/upload-limit";
+import {
   HfDatasetSubsetSplitSelectors,
+  type LocalDatasetInfo,
   listLocalDatasets,
   uploadTrainingDataset,
   useDatasetPreviewDialogStore,
   useTrainingConfigStore,
-  type LocalDatasetInfo,
 } from "@/features/training";
 // Imported directly from the store module rather than the "@/features/training"
 // barrel to avoid an import cycle (the barrel re-exports this section's siblings).
 import { hasSeparateStreamingEvalSplit } from "@/features/training/stores/training-config-store";
-import { useNavigate } from "@tanstack/react-router";
+import { useDebouncedValue, useHfTokenValidation } from "@/hooks";
+import { translate, useT } from "@/i18n";
+import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
+import { toast } from "@/lib/toast";
+import { cn } from "@/lib/utils";
 import {
-  ArrowDown01Icon,
   Cancel01Icon,
   CloudUploadIcon,
   Database02Icon,
@@ -60,6 +69,7 @@ import {
   ViewIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
+import { useNavigate } from "@tanstack/react-router";
 import {
   type ChangeEvent,
   type DragEvent,
@@ -69,19 +79,9 @@ import {
   useRef,
   useState,
 } from "react";
-import { toast } from "@/lib/toast";
-import {
-  formatUploadSize,
-  getCachedUploadLimitBytes,
-  getCachedUploadLimitLabel,
-  loadUploadLimitSettings,
-  subscribeUploadLimitSettings,
-} from "@/features/settings/api/upload-limit";
 import { useShallow } from "zustand/react/shallow";
 import { DocumentUploadRedirectDialog } from "./document-upload-redirect-dialog";
-import { translate, useT } from "@/i18n";
 import { S3ConfigForm } from "./s3-config-form";
-import { usePlatformStore } from "@/config/env";
 
 const TRAINING_UPLOAD_EXTENSIONS = [
   ".csv",
@@ -242,7 +242,13 @@ export function DatasetSection() {
     );
   if (trainOnCompletions)
     streamingBlockers.push('Turn off "Assistant completions only".');
-  if (!hasSeparateStreamingEvalSplit({ evalSteps, datasetSplit, datasetEvalSplit }))
+  if (
+    !hasSeparateStreamingEvalSplit({
+      evalSteps,
+      datasetSplit,
+      datasetEvalSplit,
+    })
+  )
     streamingBlockers.push(
       "Pick a separate eval split — evaluation is on but no distinct eval split is set.",
     );
@@ -255,9 +261,13 @@ export function DatasetSection() {
       "Embedding models don't support streaming (training needs the full dataset).",
     );
   if (isDatasetImage)
-    streamingBlockers.push("This dataset looks like images, which can't stream.");
+    streamingBlockers.push(
+      "This dataset looks like images, which can't stream.",
+    );
   if (isDatasetAudio)
-    streamingBlockers.push("This dataset looks like audio, which can't stream.");
+    streamingBlockers.push(
+      "This dataset looks like audio, which can't stream.",
+    );
   if (platformDeviceType === "mac")
     streamingBlockers.push(
       "Streaming isn't supported on Apple Silicon (MLX) yet.",
@@ -491,12 +501,16 @@ export function DatasetSection() {
   const comboboxAnchorRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const evalFileInputRef = useRef<HTMLInputElement>(null);
-  const { scrollRef, sentinelRef } = useHubInfiniteScroll(fetchMore, scannedCount, {
-    enabled: pickerTab === "huggingface",
-    isFetching: isLoading || isLoadingMore,
-    resultCount: hfResults.length,
-    resetKey: debouncedQuery,
-  });
+  const { scrollRef, sentinelRef } = useHubInfiniteScroll(
+    fetchMore,
+    scannedCount,
+    {
+      enabled: pickerTab === "huggingface",
+      isFetching: isLoading || isLoadingMore,
+      resultCount: hfResults.length,
+      resetKey: debouncedQuery,
+    },
+  );
 
   const [isUploading, setIsUploading] = useState(false);
   const [isDatasetDragOver, setIsDatasetDragOver] = useState(false);
@@ -519,9 +533,11 @@ export function DatasetSection() {
       setUploadLimitLabel(settings.maxUploadSizeLabel);
     };
     const unsubscribe = subscribeUploadLimitSettings(applyLimit);
-    void loadUploadLimitSettings().then((settings) => {
-      if (!cancelled) applyLimit(settings);
-    }).catch(() => {});
+    void loadUploadLimitSettings()
+      .then((settings) => {
+        if (!cancelled) applyLimit(settings);
+      })
+      .catch(() => {});
     return () => {
       cancelled = true;
       unsubscribe();
@@ -568,7 +584,10 @@ export function DatasetSection() {
       toast.success(successMessage, { description: uploaded.filename });
     } catch (error) {
       toast.error(t("studio.dataset.uploadFailed"), {
-        description: error instanceof Error ? error.message : t("studio.dataset.unknownError"),
+        description:
+          error instanceof Error
+            ? error.message
+            : t("studio.dataset.unknownError"),
       });
     } finally {
       setIsUploading(false);
@@ -592,7 +611,11 @@ export function DatasetSection() {
       return;
     }
 
-    await handleFileUpload(file, selectLocalDataset, t("studio.dataset.datasetUploaded"));
+    await handleFileUpload(
+      file,
+      selectLocalDataset,
+      t("studio.dataset.datasetUploaded"),
+    );
   };
 
   const handleDatasetFileChange = async (
@@ -640,7 +663,11 @@ export function DatasetSection() {
     event.target.value = "";
     if (!file) return;
 
-    await handleFileUpload(file, setUploadedEvalFile, t("studio.dataset.evalDatasetUploaded"));
+    await handleFileUpload(
+      file,
+      setUploadedEvalFile,
+      t("studio.dataset.evalDatasetUploaded"),
+    );
   };
 
   const handleOpenLearningRecipes = useCallback(() => {
@@ -672,9 +699,9 @@ export function DatasetSection() {
             }[] = [
               { value: "huggingface", label: "Hugging Face" },
               { value: "upload", label: t("studio.dataset.localTab") },
-              ...(!isMultimodalModel
-                ? [{ value: "s3" as const, label: "Amazon S3" }]
-                : []),
+              ...(isMultimodalModel
+                ? []
+                : [{ value: "s3" as const, label: "Amazon S3" }]),
             ];
             const activeIndex = Math.max(
               0,
@@ -728,355 +755,375 @@ export function DatasetSection() {
           {datasetSource === "s3" && <S3ConfigForm />}
 
           {datasetSource !== "s3" && (
-          <div className="flex min-w-0 flex-col gap-2">
-            <span className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
-              {t("studio.dataset.chooseDataset")}
-              <span className="rounded-full border border-border/70 bg-muted/40 px-2 py-0.5 text-[10px] font-medium text-foreground/80">
-                {datasetSource === "upload" ? t("studio.dataset.localTab") : "Hugging Face"}
+            <div className="flex min-w-0 flex-col gap-2">
+              <span className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                {t("studio.dataset.chooseDataset")}
+                <span className="rounded-full border border-border/70 bg-muted/40 px-2 py-0.5 text-[10px] font-medium text-foreground/80">
+                  {datasetSource === "upload"
+                    ? t("studio.dataset.localTab")
+                    : "Hugging Face"}
+                </span>
+                <Tooltip>
+                  <TooltipTrigger asChild={true}>
+                    <button
+                      type="button"
+                      className="text-foreground/70 hover:text-foreground"
+                    >
+                      <HugeiconsIcon
+                        icon={InformationCircleIcon}
+                        className="size-3"
+                      />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {t("studio.dataset.chooseDatasetTooltip")}{" "}
+                    <a
+                      href="https://unsloth.ai/docs/get-started/fine-tuning-llms-guide/datasets-guide"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary underline"
+                    >
+                      {t("studio.params.readMore")}
+                    </a>
+                  </TooltipContent>
+                </Tooltip>
               </span>
-              <Tooltip>
-                <TooltipTrigger asChild={true}>
-                  <button
-                    type="button"
-                    className="text-foreground/70 hover:text-foreground"
+              <div
+                ref={comboboxAnchorRef}
+                className="min-w-0"
+                onKeyDown={(event) => {
+                  if (event.key !== "Enter") return;
+                  if (!(event.target instanceof HTMLInputElement)) return;
+                  event.preventDefault();
+                  if (pickerTab === "huggingface") {
+                    if (hfResults.length > 0) {
+                      handleDatasetSelect(hfResults[0].id);
+                    } else {
+                      const text = event.target.value.trim();
+                      if (text) handleDatasetSelect(text);
+                    }
+                    return;
+                  }
+
+                  if (localResultIds.length > 0) {
+                    const selectedId = localResultIds[0];
+                    const path = localPathById.get(selectedId);
+                    if (path) {
+                      handleLocalDatasetSelect(path);
+                    }
+                  }
+                }}
+              >
+                <Combobox
+                  items={comboboxItems}
+                  filteredItems={comboboxItems}
+                  filter={null}
+                  value={comboboxValue}
+                  onOpenChange={(open) => {
+                    setSearchQuery("");
+                    if (
+                      open &&
+                      (pickerTab === "local" || activeSourceTab === "local")
+                    ) {
+                      void refreshLocalDatasets();
+                    }
+                    if (!open) {
+                      setPickerTab(
+                        pendingSourceTabRef.current ?? activeSourceTab,
+                      );
+                      pendingSourceTabRef.current = null;
+                    }
+                  }}
+                  onValueChange={(value) => {
+                    if (!value) {
+                      clearSelectionForTab(pickerTab);
+                      return;
+                    }
+                    if (pickerTab === "huggingface") {
+                      handleDatasetSelect(value);
+                      return;
+                    }
+                    const path = localPathById.get(value);
+                    if (path) {
+                      handleLocalDatasetSelect(path);
+                    }
+                  }}
+                  onInputValueChange={(value, eventDetails) =>
+                    handleInputChange(value, eventDetails)
+                  }
+                  itemToStringValue={(id) =>
+                    pickerTab === "local" ? (localLabelById.get(id) ?? id) : id
+                  }
+                  autoHighlight={true}
+                >
+                  <ComboboxInput
+                    placeholder={
+                      pickerTab === "huggingface"
+                        ? t("studio.dataset.searchHuggingFaceDatasets")
+                        : t("studio.dataset.searchLocalDatasets")
+                    }
+                    className="w-full min-w-0 overflow-hidden leading-5"
+                    showClear={true}
                   >
-                    <HugeiconsIcon
-                      icon={InformationCircleIcon}
-                      className="size-3"
-                    />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {t("studio.dataset.chooseDatasetTooltip")}{" "}
+                    <InputGroupAddon>
+                      <HugeiconsIcon icon={Search01Icon} className="size-4" />
+                    </InputGroupAddon>
+                  </ComboboxInput>
+                  <ComboboxContent anchor={comboboxAnchorRef}>
+                    <div className="px-2 pt-2 pb-2">
+                      <Tabs
+                        value={pickerTab}
+                        onValueChange={(value) => {
+                          setPickerTab(value as "huggingface" | "local");
+                          setSearchQuery("");
+                        }}
+                        className="w-full"
+                      >
+                        <TabsList className=" w-full">
+                          <TabsTrigger value="huggingface">
+                            Hugging Face
+                          </TabsTrigger>
+                          <TabsTrigger value="local">
+                            {t("studio.dataset.localTab")}
+                          </TabsTrigger>
+                        </TabsList>
+
+                        <TabsContent value="huggingface" className="m-0">
+                          {isLoading ? (
+                            <div className="flex items-center justify-center py-4 gap-2 text-xs text-muted-foreground">
+                              <Spinner className="size-4" />{" "}
+                              {t("studio.dataset.searching")}
+                            </div>
+                          ) : (
+                            <ComboboxEmpty>
+                              {t("studio.dataset.noDatasetsFound")}
+                            </ComboboxEmpty>
+                          )}
+                          <div
+                            ref={scrollRef}
+                            className="max-h-64 overflow-y-auto overscroll-contain [scrollbar-width:thin]"
+                          >
+                            <ComboboxList className="p-1 !max-h-none !overflow-visible">
+                              {(id: string) => {
+                                return (
+                                  <ComboboxItem
+                                    key={id}
+                                    value={id}
+                                    className="gap-2"
+                                  >
+                                    <Tooltip>
+                                      <TooltipTrigger asChild={true}>
+                                        <span className="block min-w-0 flex-1 truncate">
+                                          {id}
+                                        </span>
+                                      </TooltipTrigger>
+                                      <TooltipContent
+                                        side="left"
+                                        className="max-w-xs break-all"
+                                      >
+                                        {id}
+                                      </TooltipContent>
+                                    </Tooltip>
+                                  </ComboboxItem>
+                                );
+                              }}
+                            </ComboboxList>
+                            <div ref={sentinelRef} className="h-px" />
+                            {isLoadingMore && (
+                              <div className="flex items-center justify-center py-2">
+                                <Spinner className="size-3.5 text-muted-foreground" />
+                              </div>
+                            )}
+                          </div>
+                        </TabsContent>
+
+                        <TabsContent value="local" className="m-0">
+                          {localLoading ? (
+                            <div className="flex items-center justify-center py-4 gap-2 text-xs text-muted-foreground">
+                              <Spinner className="size-4" />{" "}
+                              {t("studio.dataset.loadingLocalDatasets")}
+                            </div>
+                          ) : (
+                            <>
+                              {localError ? (
+                                <p className="px-2 py-2 text-xs text-destructive">
+                                  {localError}
+                                </p>
+                              ) : (
+                                <ComboboxEmpty className="px-2 py-3">
+                                  <div className="flex w-full flex-col items-center gap-2 text-center">
+                                    <p className="text-xs text-muted-foreground">
+                                      {localDatasets.length === 0
+                                        ? t("studio.dataset.noLocalDatasetsYet")
+                                        : t(
+                                            "studio.dataset.noLocalDatasetsMatchSearch",
+                                          )}
+                                    </p>
+                                    {localDatasets.length === 0 ? (
+                                      <Button
+                                        asChild={true}
+                                        size="sm"
+                                        variant="outline"
+                                      >
+                                        <a href="/data-recipes">
+                                          {t("studio.dataset.openDataRecipes")}
+                                        </a>
+                                      </Button>
+                                    ) : null}
+                                  </div>
+                                </ComboboxEmpty>
+                              )}
+                              <div className="max-h-64 overflow-y-auto overscroll-contain [scrollbar-width:thin]">
+                                <ComboboxList className="p-1 !max-h-none !overflow-visible">
+                                  {(id: string) => {
+                                    const label = localLabelById.get(id) ?? id;
+                                    return (
+                                      <ComboboxItem
+                                        key={id}
+                                        value={id}
+                                        className="gap-2"
+                                      >
+                                        <Tooltip>
+                                          <TooltipTrigger asChild={true}>
+                                            <span className="block min-w-0 flex-1 truncate">
+                                              {label}
+                                            </span>
+                                          </TooltipTrigger>
+                                          <TooltipContent
+                                            side="left"
+                                            className="max-w-xs break-all"
+                                          >
+                                            {label}
+                                          </TooltipContent>
+                                        </Tooltip>
+                                      </ComboboxItem>
+                                    );
+                                  }}
+                                </ComboboxList>
+                              </div>
+                            </>
+                          )}
+                        </TabsContent>
+                      </Tabs>
+                    </div>
+                  </ComboboxContent>
+                </Combobox>
+              </div>
+              {(tokenValidationError ?? hfSearchError) && (
+                <p className="text-xs text-destructive">
+                  {tokenValidationError ?? hfSearchError}
+                  {" — "}
                   <a
-                    href="https://unsloth.ai/docs/get-started/fine-tuning-llms-guide/datasets-guide"
+                    href="https://huggingface.co/settings/tokens"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-primary underline"
+                    className="underline"
                   >
-                    {t("studio.params.readMore")}
+                    {t("studio.dataset.getOrUpdateToken")}
                   </a>
-                </TooltipContent>
-              </Tooltip>
-            </span>
-            <div
-              ref={comboboxAnchorRef}
-              className="min-w-0"
-              onKeyDown={(event) => {
-                if (event.key !== "Enter") return;
-                if (!(event.target instanceof HTMLInputElement)) return;
-                event.preventDefault();
-                if (pickerTab === "huggingface") {
-                  if (hfResults.length > 0) {
-                    handleDatasetSelect(hfResults[0].id);
-                  } else {
-                    const text = event.target.value.trim();
-                    if (text) handleDatasetSelect(text);
-                  }
-                  return;
-                }
-
-                if (localResultIds.length > 0) {
-                  const selectedId = localResultIds[0];
-                  const path = localPathById.get(selectedId);
-                  if (path) {
-                    handleLocalDatasetSelect(path);
-                  }
-                }
-              }}
-            >
-              <Combobox
-                items={comboboxItems}
-                filteredItems={comboboxItems}
-                filter={null}
-                value={comboboxValue}
-                onOpenChange={(open) => {
-                  setSearchQuery("");
-                  if (
-                    open &&
-                    (pickerTab === "local" || activeSourceTab === "local")
-                  ) {
-                    void refreshLocalDatasets();
-                  }
-                  if (!open) {
-                    setPickerTab(
-                      pendingSourceTabRef.current ?? activeSourceTab,
-                    );
-                    pendingSourceTabRef.current = null;
-                  }
-                }}
-                onValueChange={(value) => {
-                  if (!value) {
-                    clearSelectionForTab(pickerTab);
-                    return;
-                  }
-                  if (pickerTab === "huggingface") {
-                    handleDatasetSelect(value);
-                    return;
-                  }
-                  const path = localPathById.get(value);
-                  if (path) {
-                    handleLocalDatasetSelect(path);
-                  }
-                }}
-                onInputValueChange={(value, eventDetails) =>
-                  handleInputChange(value, eventDetails)
-                }
-                itemToStringValue={(id) =>
-                  pickerTab === "local" ? (localLabelById.get(id) ?? id) : id
-                }
-                autoHighlight={true}
-              >
-                <ComboboxInput
-                  placeholder={
-                    pickerTab === "huggingface"
-                      ? t("studio.dataset.searchHuggingFaceDatasets")
-                      : t("studio.dataset.searchLocalDatasets")
-                  }
-                  className="w-full min-w-0 overflow-hidden leading-5"
-                  showClear={true}
-                >
-                  <InputGroupAddon>
-                    <HugeiconsIcon icon={Search01Icon} className="size-4" />
-                  </InputGroupAddon>
-                </ComboboxInput>
-                <ComboboxContent anchor={comboboxAnchorRef}>
-                  <div className="px-2 pt-2 pb-2">
-                    <Tabs
-                      value={pickerTab}
-                      onValueChange={(value) => {
-                        setPickerTab(value as "huggingface" | "local");
-                        setSearchQuery("");
-                      }}
-                      className="w-full"
-                    >
-                      <TabsList className=" w-full">
-                        <TabsTrigger value="huggingface">Hugging Face</TabsTrigger>
-                        <TabsTrigger value="local">{t("studio.dataset.localTab")}</TabsTrigger>
-                      </TabsList>
-
-                      <TabsContent value="huggingface" className="m-0">
-                        {isLoading ? (
-                          <div className="flex items-center justify-center py-4 gap-2 text-xs text-muted-foreground">
-                            <Spinner className="size-4" /> {t("studio.dataset.searching")}
-                          </div>
-                        ) : (
-                          <ComboboxEmpty>{t("studio.dataset.noDatasetsFound")}</ComboboxEmpty>
-                        )}
-                        <div
-                          ref={scrollRef}
-                          className="max-h-64 overflow-y-auto overscroll-contain [scrollbar-width:thin]"
-                        >
-                          <ComboboxList className="p-1 !max-h-none !overflow-visible">
-                            {(id: string) => {
-                              return (
-                                <ComboboxItem
-                                  key={id}
-                                  value={id}
-                                  className="gap-2"
-                                >
-                                  <Tooltip>
-                                    <TooltipTrigger asChild={true}>
-                                      <span className="block min-w-0 flex-1 truncate">
-                                        {id}
-                                      </span>
-                                    </TooltipTrigger>
-                                    <TooltipContent
-                                      side="left"
-                                      className="max-w-xs break-all"
-                                    >
-                                      {id}
-                                    </TooltipContent>
-                                  </Tooltip>
-                                </ComboboxItem>
-                              );
-                            }}
-                          </ComboboxList>
-                          <div ref={sentinelRef} className="h-px" />
-                          {isLoadingMore && (
-                            <div className="flex items-center justify-center py-2">
-                              <Spinner className="size-3.5 text-muted-foreground" />
-                            </div>
-                          )}
-                        </div>
-                      </TabsContent>
-
-                      <TabsContent value="local" className="m-0">
-                        {localLoading ? (
-                          <div className="flex items-center justify-center py-4 gap-2 text-xs text-muted-foreground">
-                            <Spinner className="size-4" /> {t("studio.dataset.loadingLocalDatasets")}
-                          </div>
-                        ) : (
-                          <>
-                            {localError ? (
-                              <p className="px-2 py-2 text-xs text-destructive">
-                                {localError}
-                              </p>
-                            ) : (
-                              <ComboboxEmpty className="px-2 py-3">
-                                <div className="flex w-full flex-col items-center gap-2 text-center">
-                                  <p className="text-xs text-muted-foreground">
-                                    {localDatasets.length === 0
-                                      ? t("studio.dataset.noLocalDatasetsYet")
-                                      : t("studio.dataset.noLocalDatasetsMatchSearch")}
-                                  </p>
-                                  {localDatasets.length === 0 ? (
-                                    <Button asChild={true} size="sm" variant="outline">
-                                      <a href="/data-recipes">{t("studio.dataset.openDataRecipes")}</a>
-                                    </Button>
-                                  ) : null}
-                                </div>
-                              </ComboboxEmpty>
-                            )}
-                            <div className="max-h-64 overflow-y-auto overscroll-contain [scrollbar-width:thin]">
-                              <ComboboxList className="p-1 !max-h-none !overflow-visible">
-                                {(id: string) => {
-                                  const label = localLabelById.get(id) ?? id;
-                                  return (
-                                    <ComboboxItem
-                                      key={id}
-                                      value={id}
-                                      className="gap-2"
-                                    >
-                                      <Tooltip>
-                                        <TooltipTrigger asChild={true}>
-                                          <span className="block min-w-0 flex-1 truncate">
-                                            {label}
-                                          </span>
-                                        </TooltipTrigger>
-                                        <TooltipContent
-                                          side="left"
-                                          className="max-w-xs break-all"
-                                        >
-                                          {label}
-                                        </TooltipContent>
-                                      </Tooltip>
-                                    </ComboboxItem>
-                                  );
-                                }}
-                              </ComboboxList>
-                            </div>
-                          </>
-                        )}
-                      </TabsContent>
-                    </Tabs>
-                  </div>
-                </ComboboxContent>
-              </Combobox>
+                </p>
+              )}
+              {isCheckingToken && (
+                <p className="text-xs text-muted-foreground">
+                  {t("studio.dataset.checkingToken")}
+                </p>
+              )}
+              {pickerTab !== activeSourceTab && (
+                <p className="text-[11px] text-muted-foreground">
+                  {t("studio.dataset.browsingSource", {
+                    browsing:
+                      pickerTab === "local"
+                        ? t("studio.dataset.localDatasets")
+                        : "Hugging Face",
+                    current:
+                      datasetSource === "upload"
+                        ? t("studio.dataset.localTab")
+                        : "Hugging Face",
+                  })}
+                </p>
+              )}
             </div>
-            {(tokenValidationError ?? hfSearchError) && (
-              <p className="text-xs text-destructive">
-                {tokenValidationError ?? hfSearchError}
-                {" — "}
-                <a
-                  href="https://huggingface.co/settings/tokens"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline"
-                >
-                  {t("studio.dataset.getOrUpdateToken")}
-                </a>
-              </p>
-            )}
-            {isCheckingToken && (
-              <p className="text-xs text-muted-foreground">
-                {t("studio.dataset.checkingToken")}
-              </p>
-            )}
-            {pickerTab !== activeSourceTab && (
-              <p className="text-[11px] text-muted-foreground">
-                {t("studio.dataset.browsingSource", {
-                  browsing:
-                    pickerTab === "local"
-                      ? t("studio.dataset.localDatasets")
-                      : "Hugging Face",
-                  current:
-                    datasetSource === "upload"
-                      ? t("studio.dataset.localTab")
-                      : "Hugging Face",
-                })}
-              </p>
-            )}
-          </div>
           )}
 
           {datasetSource !== "s3" &&
             (isHfDatasetSelected ? (
-            <HfDatasetSubsetSplitSelectors
-              variant="studio"
-              enabled={true}
-              datasetName={dataset}
-              accessToken={hfToken || undefined}
-              datasetSubset={datasetSubset}
-              setDatasetSubset={setDatasetSubset}
-              datasetSplit={datasetSplit}
-              setDatasetSplit={setDatasetSplit}
-              datasetEvalSplit={datasetEvalSplit}
-              setDatasetEvalSplit={setDatasetEvalSplit}
-            />
-          ) : !selectedDatasetName ? (
-            <HfDatasetSubsetSplitSelectors
-              variant="studio"
-              enabled={false}
-              datasetName={null}
-              accessToken={hfToken || undefined}
-              datasetSubset={datasetSubset}
-              setDatasetSubset={setDatasetSubset}
-              datasetSplit={datasetSplit}
-              setDatasetSplit={setDatasetSplit}
-              datasetEvalSplit={datasetEvalSplit}
-              setDatasetEvalSplit={setDatasetEvalSplit}
-            />
-          ) : datasetSource === "upload" && selectedLocalDataset ? (
-            <div className="rounded-lg border bg-muted/20 px-3.5 py-3">
-              <div className="mb-3 flex items-center justify-between gap-3">
-                <div>
-                  <p className="text-xs font-medium text-muted-foreground">
-                    {t("studio.dataset.localDatasetMetadata")}
-                  </p>
-                  <p className="text-[10px] text-muted-foreground/80">
-                    {t("studio.dataset.dataRecipeOutput")}
-                  </p>
-                </div>
-              </div>
+              <HfDatasetSubsetSplitSelectors
+                variant="studio"
+                enabled={true}
+                datasetName={dataset}
+                accessToken={hfToken || undefined}
+                datasetSubset={datasetSubset}
+                setDatasetSubset={setDatasetSubset}
+                datasetSplit={datasetSplit}
+                setDatasetSplit={setDatasetSplit}
+                datasetEvalSplit={datasetEvalSplit}
+                setDatasetEvalSplit={setDatasetEvalSplit}
+              />
+            ) : selectedDatasetName ? (
+              datasetSource === "upload" && selectedLocalDataset ? (
+                <div className="rounded-lg border bg-muted/20 px-3.5 py-3">
+                  <div className="mb-3 flex items-center justify-between gap-3">
+                    <div>
+                      <p className="text-xs font-medium text-muted-foreground">
+                        {t("studio.dataset.localDatasetMetadata")}
+                      </p>
+                      <p className="text-[10px] text-muted-foreground/80">
+                        {t("studio.dataset.dataRecipeOutput")}
+                      </p>
+                    </div>
+                  </div>
 
-              <div className="flex flex-col gap-3">
-                <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
-                  <MetadataRow
-                    label={t("studio.dataset.rows")}
-                    value={
-                      typeof selectedLocalRows === "number"
-                        ? selectedLocalRows.toLocaleString()
-                        : "--"
-                    }
-                  />
-                  <MetadataRow
-                    label={t("studio.dataset.columns")}
-                    value={
-                      selectedLocalColumns.length > 0
-                        ? String(selectedLocalColumns.length)
-                        : "--"
-                    }
-                  />
-                  <MetadataRow
-                    label={t("studio.dataset.batches")}
-                    value={
-                      typeof selectedLocalMetadata?.num_completed_batches ===
-                        "number" &&
-                      typeof selectedLocalMetadata?.total_num_batches ===
-                        "number"
-                        ? `${selectedLocalMetadata.num_completed_batches}/${selectedLocalMetadata.total_num_batches}`
-                        : "--"
-                    }
-                  />
-                  <MetadataRow
-                    label={t("studio.dataset.updated")}
-                    value={formatUpdatedDate(selectedLocalUpdatedAt)}
-                  />
+                  <div className="flex flex-col gap-3">
+                    <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
+                      <MetadataRow
+                        label={t("studio.dataset.rows")}
+                        value={
+                          typeof selectedLocalRows === "number"
+                            ? selectedLocalRows.toLocaleString()
+                            : "--"
+                        }
+                      />
+                      <MetadataRow
+                        label={t("studio.dataset.columns")}
+                        value={
+                          selectedLocalColumns.length > 0
+                            ? String(selectedLocalColumns.length)
+                            : "--"
+                        }
+                      />
+                      <MetadataRow
+                        label={t("studio.dataset.batches")}
+                        value={
+                          typeof selectedLocalMetadata?.num_completed_batches ===
+                            "number" &&
+                          typeof selectedLocalMetadata?.total_num_batches ===
+                            "number"
+                            ? `${selectedLocalMetadata.num_completed_batches}/${selectedLocalMetadata.total_num_batches}`
+                            : "--"
+                        }
+                      />
+                      <MetadataRow
+                        label={t("studio.dataset.updated")}
+                        value={formatUpdatedDate(selectedLocalUpdatedAt)}
+                      />
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </div>
-          ) : null)}
+              ) : null
+            ) : (
+              <HfDatasetSubsetSplitSelectors
+                variant="studio"
+                enabled={false}
+                datasetName={null}
+                accessToken={hfToken || undefined}
+                datasetSubset={datasetSubset}
+                setDatasetSubset={setDatasetSubset}
+                datasetSplit={datasetSplit}
+                setDatasetSplit={setDatasetSplit}
+                datasetEvalSplit={datasetEvalSplit}
+                setDatasetEvalSplit={setDatasetEvalSplit}
+              />
+            ))}
 
           {datasetSource === "upload" && uploadedFile && (
             <div className="rounded-lg border bg-muted/20 px-3.5 py-3">
@@ -1135,7 +1182,7 @@ export function DatasetSection() {
           <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
             <CollapsibleTrigger className="flex w-full cursor-pointer items-center gap-1.5 text-xs text-muted-foreground">
               <HugeiconsIcon
-                icon={ArrowDown01Icon}
+                icon={ChevronDownStandardIcon}
                 className={`size-3.5 transition-transform ${advancedOpen ? "rotate-180" : ""}`}
               />
               {t("studio.dataset.advanced")}
@@ -1180,11 +1227,15 @@ export function DatasetSection() {
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="auto">{t("studio.dataset.auto")}</SelectItem>
+                      <SelectItem value="auto">
+                        {t("studio.dataset.auto")}
+                      </SelectItem>
                       <SelectItem value="alpaca">Alpaca</SelectItem>
                       <SelectItem value="chatml">ChatML</SelectItem>
                       <SelectItem value="sharegpt">ShareGPT</SelectItem>
-                      <SelectItem value="raw">{t("studio.dataset.rawText")}</SelectItem>
+                      <SelectItem value="raw">
+                        {t("studio.dataset.rawText")}
+                      </SelectItem>
                     </SelectContent>
                   </Select>
                 </div>
@@ -1382,8 +1433,8 @@ export function DatasetSection() {
                       {t("studio.dataset.dropFileOrClick")}
                     </span>
                     <span className="mt-0.5 block truncate text-[10px] text-muted-foreground">
-                      {TRAINING_DATASET_UPLOAD_LABEL} · up to{" "}
-                      {uploadLimitLabel}; {DOCUMENT_REDIRECT_LABEL}
+                      {TRAINING_DATASET_UPLOAD_LABEL} · up to {uploadLimitLabel}
+                      ; {DOCUMENT_REDIRECT_LABEL}
                     </span>
                   </span>
                 </button>
@@ -1400,7 +1451,10 @@ export function DatasetSection() {
                   {isUploading ? (
                     <Spinner className="size-3.5" />
                   ) : (
-                    <HugeiconsIcon icon={CloudUploadIcon} className="size-3.5" />
+                    <HugeiconsIcon
+                      icon={CloudUploadIcon}
+                      className="size-3.5"
+                    />
                   )}
                   {isUploading
                     ? t("studio.dataset.uploading")

--- a/studio/frontend/src/features/studio/sections/params-section.tsx
+++ b/studio/frontend/src/features/studio/sections/params-section.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { usePlatformStore } from "@/config/env";
 import { SectionCard } from "@/components/section-card";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -9,7 +8,6 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { Input } from "@/components/ui/input";
 import {
   Combobox,
   ComboboxContent,
@@ -18,6 +16,7 @@ import {
   ComboboxItem,
   ComboboxList,
 } from "@/components/ui/combobox";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -32,6 +31,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { usePlatformStore } from "@/config/env";
 import {
   CONTEXT_LENGTHS,
   CPT_TARGET_MODULES,
@@ -39,18 +39,27 @@ import {
   OPTIMIZER_OPTIONS,
   TARGET_MODULES,
 } from "@/config/training";
-import { useMaxStepsEpochsToggle, useTrainingConfigStore } from "@/features/training";
+import {
+  useMaxStepsEpochsToggle,
+  useTrainingConfigStore,
+} from "@/features/training";
 import { isRawTextDatasetFormat } from "@/features/training/lib/training-methods";
+import { useT } from "@/i18n";
+import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
 import { isAdapterMethod } from "@/types/training";
 import type { GradientCheckpointing } from "@/types/training";
 import {
-  ArrowDown01Icon,
   InformationCircleIcon,
   Settings04Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { type ReactElement, type ReactNode, useEffect, useRef, useState } from "react";
-import { useT } from "@/i18n";
+import {
+  type ReactElement,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 type StudioT = ReturnType<typeof useT>;
 
@@ -224,9 +233,11 @@ export function ParamsSection(): ReactElement {
         title={t("studio.params.title")}
         description={t("studio.params.description")}
         accent="orange"
-        className={`${needsExpandedHeight
-          ? "min-h-studio-config-column"
-          : "h-studio-config-column"} duration-150`}
+        className={`${
+          needsExpandedHeight
+            ? "min-h-studio-config-column"
+            : "h-studio-config-column"
+        } duration-150`}
       >
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-2">
@@ -255,7 +266,9 @@ export function ParamsSection(): ReactElement {
             >
               <div className="flex items-center justify-between">
                 <span className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
-                  {useEpochs ? t("studio.params.epochs") : t("studio.params.maxSteps")}
+                  {useEpochs
+                    ? t("studio.params.epochs")
+                    : t("studio.params.maxSteps")}
                   <Tooltip>
                     <TooltipTrigger asChild={true}>
                       <button
@@ -289,7 +302,9 @@ export function ParamsSection(): ReactElement {
                     onClick={toggleUseEpochs}
                     className="text-xs text-primary underline cursor-pointer"
                   >
-                    {useEpochs ? t("studio.params.useMaxSteps") : t("studio.params.useEpochs")}
+                    {useEpochs
+                      ? t("studio.params.useMaxSteps")
+                      : t("studio.params.useEpochs")}
                   </button>
                   <input
                     type="number"
@@ -387,9 +402,13 @@ export function ParamsSection(): ReactElement {
                     setCtxInput(String(store.contextLength));
                   }}
                   onKeyDown={(e) => {
-                    if (e.key !== "Enter") { return; }
+                    if (e.key !== "Enter") {
+                      return;
+                    }
                     const n = trySetContextLength(ctxInput);
-                    if (n === null) { return; }
+                    if (n === null) {
+                      return;
+                    }
                     if (!ctxItems.includes(ctxInput.trim())) {
                       e.stopPropagation();
                       e.preventDefault();
@@ -398,7 +417,9 @@ export function ParamsSection(): ReactElement {
                   }}
                 />
                 <ComboboxContent anchor={ctxAnchorRef}>
-                  <ComboboxEmpty>{t("studio.params.customContextLength")}</ComboboxEmpty>
+                  <ComboboxEmpty>
+                    {t("studio.params.customContextLength")}
+                  </ComboboxEmpty>
                   <ComboboxList className="p-1">
                     {(id: string) => (
                       <ComboboxItem key={id} value={id} className="font-mono">
@@ -506,194 +527,204 @@ export function ParamsSection(): ReactElement {
             <Collapsible open={loraOpen} onOpenChange={setLoraOpen}>
               <CollapsibleTrigger className="flex w-full cursor-pointer items-center gap-1.5 text-xs text-muted-foreground">
                 <HugeiconsIcon
-                  icon={ArrowDown01Icon}
+                  icon={ChevronDownStandardIcon}
                   className={`size-3.5 transition-transform ${loraOpen ? "rotate-180" : ""}`}
                 />
                 {t("studio.params.loraSettings")}
               </CollapsibleTrigger>
               <CollapsibleContent className="mt-3 data-[state=open]:overflow-visible">
                 <div className="pt-1.5 flex flex-col gap-4">
-                <SliderRow
-                  label={t("studio.params.rank")}
-                  tooltip={
-                    <>
-                      {t("studio.params.rankTooltip")}{" "}
-                      <a
-                        href="https://unsloth.ai/docs/get-started/fine-tuning-llms-guide/lora-hyperparameters-guide"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-primary underline"
-                      >
-                        {t("studio.params.readMore")}
-                      </a>
-                    </>
-                  }
-                  value={store.loraRank}
-                  onChange={store.setLoraRank}
-                  min={4}
-                  max={128}
-                  step={4}
-                />
-                <SliderRow
-                  label={t("studio.params.alpha")}
-                  tooltip={
-                    <>
-                      {t("studio.params.alphaTooltip")}{" "}
-                      <a
-                        href="https://unsloth.ai/docs/get-started/fine-tuning-llms-guide/lora-hyperparameters-guide"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-primary underline"
-                      >
-                        {t("studio.params.readMore")}
-                      </a>
-                    </>
-                  }
-                  value={store.loraAlpha}
-                  onChange={store.setLoraAlpha}
-                  min={4}
-                  max={256}
-                  step={4}
-                />
-                <SliderRow
-                  label={t("studio.params.dropout")}
-                  tooltip={
-                    <>
-                      {t("studio.params.dropoutTooltip")}{" "}
-                      <a
-                        href="https://unsloth.ai/docs/get-started/fine-tuning-llms-guide/lora-hyperparameters-guide"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-primary underline"
-                      >
-                        {t("studio.params.readMore")}
-                      </a>
-                    </>
-                  }
-                  value={store.loraDropout}
-                  onChange={store.setLoraDropout}
-                  min={0}
-                  max={0.5}
-                  step={0.01}
-                  format={(v) => v.toFixed(2)}
-                />
+                  <SliderRow
+                    label={t("studio.params.rank")}
+                    tooltip={
+                      <>
+                        {t("studio.params.rankTooltip")}{" "}
+                        <a
+                          href="https://unsloth.ai/docs/get-started/fine-tuning-llms-guide/lora-hyperparameters-guide"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-primary underline"
+                        >
+                          {t("studio.params.readMore")}
+                        </a>
+                      </>
+                    }
+                    value={store.loraRank}
+                    onChange={store.setLoraRank}
+                    min={4}
+                    max={128}
+                    step={4}
+                  />
+                  <SliderRow
+                    label={t("studio.params.alpha")}
+                    tooltip={
+                      <>
+                        {t("studio.params.alphaTooltip")}{" "}
+                        <a
+                          href="https://unsloth.ai/docs/get-started/fine-tuning-llms-guide/lora-hyperparameters-guide"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-primary underline"
+                        >
+                          {t("studio.params.readMore")}
+                        </a>
+                      </>
+                    }
+                    value={store.loraAlpha}
+                    onChange={store.setLoraAlpha}
+                    min={4}
+                    max={256}
+                    step={4}
+                  />
+                  <SliderRow
+                    label={t("studio.params.dropout")}
+                    tooltip={
+                      <>
+                        {t("studio.params.dropoutTooltip")}{" "}
+                        <a
+                          href="https://unsloth.ai/docs/get-started/fine-tuning-llms-guide/lora-hyperparameters-guide"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-primary underline"
+                        >
+                          {t("studio.params.readMore")}
+                        </a>
+                      </>
+                    }
+                    value={store.loraDropout}
+                    onChange={store.setLoraDropout}
+                    min={0}
+                    max={0.5}
+                    step={0.01}
+                    format={(v) => v.toFixed(2)}
+                  />
 
-                {/* Vision checkboxes */}
-                {showVisionLora && (
-                  <div className="flex flex-col gap-2 pt-1">
+                  {/* Vision checkboxes */}
+                  {showVisionLora && (
+                    <div className="flex flex-col gap-2 pt-1">
+                      {(
+                        [
+                          [
+                            "finetuneVisionLayers",
+                            t("studio.params.visionLayers"),
+                            store.finetuneVisionLayers,
+                            store.setFinetuneVisionLayers,
+                          ],
+                          [
+                            "finetuneLanguageLayers",
+                            t("studio.params.languageLayers"),
+                            store.finetuneLanguageLayers,
+                            store.setFinetuneLanguageLayers,
+                          ],
+                          [
+                            "finetuneAttentionModules",
+                            t("studio.params.attentionModules"),
+                            store.finetuneAttentionModules,
+                            store.setFinetuneAttentionModules,
+                          ],
+                          [
+                            "finetuneMLPModules",
+                            t("studio.params.mlpModules"),
+                            store.finetuneMLPModules,
+                            store.setFinetuneMLPModules,
+                          ],
+                        ] as const
+                      ).map(([key, label, value, setter]) => (
+                        <div key={key} className="flex items-center gap-2">
+                          <Checkbox
+                            id={key}
+                            checked={value as boolean}
+                            onCheckedChange={(v) =>
+                              (setter as (v: boolean) => void)(!!v)
+                            }
+                          />
+                          <label
+                            htmlFor={key}
+                            className="text-xs cursor-pointer text-muted-foreground"
+                          >
+                            {label}
+                          </label>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
+                  {/* Text target modules */}
+                  {!showVisionLora && (
+                    <div className="flex flex-col gap-2 pt-1">
+                      <span className="text-xs font-medium text-muted-foreground">
+                        {t("studio.params.targetModules")}
+                      </span>
+                      <div className="flex flex-wrap gap-1.5">
+                        {(isCpt ? CPT_TARGET_MODULES : TARGET_MODULES).map(
+                          (mod) => {
+                            const active = store.targetModules.includes(mod);
+                            return (
+                              <button
+                                key={mod}
+                                type="button"
+                                onClick={() => {
+                                  store.setTargetModules(
+                                    active
+                                      ? store.targetModules.filter(
+                                          (m) => m !== mod,
+                                        )
+                                      : [...store.targetModules, mod],
+                                  );
+                                }}
+                                className={`cursor-pointer rounded-full border px-2.5 py-0.5 text-[11px] font-mono transition-colors ${
+                                  active
+                                    ? "border-orange-300 bg-orange-50 text-orange-700 dark:border-orange-700 dark:bg-orange-950 dark:text-orange-300"
+                                    : "text-muted-foreground hover:bg-muted/50"
+                                }`}
+                              >
+                                {mod}
+                              </button>
+                            );
+                          },
+                        )}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* LoRA variant */}
+                  <div className="flex gap-2">
                     {(
                       [
-                        [
-                          "finetuneVisionLayers",
-                          t("studio.params.visionLayers"),
-                          store.finetuneVisionLayers,
-                          store.setFinetuneVisionLayers,
-                        ],
-                        [
-                          "finetuneLanguageLayers",
-                          t("studio.params.languageLayers"),
-                          store.finetuneLanguageLayers,
-                          store.setFinetuneLanguageLayers,
-                        ],
-                        [
-                          "finetuneAttentionModules",
-                          t("studio.params.attentionModules"),
-                          store.finetuneAttentionModules,
-                          store.setFinetuneAttentionModules,
-                        ],
-                        [
-                          "finetuneMLPModules",
-                          t("studio.params.mlpModules"),
-                          store.finetuneMLPModules,
-                          store.setFinetuneMLPModules,
-                        ],
+                        {
+                          value: "lora",
+                          label: t("studio.params.enableLora"),
+                          desc: t("studio.params.trainWithLora"),
+                        },
+                        {
+                          value: "rslora",
+                          label: "RS-LoRA",
+                          desc: t("studio.params.stableRank"),
+                        },
+                        {
+                          value: "loftq",
+                          label: "LoftQ",
+                          desc: t("studio.params.memoryEfficient"),
+                        },
                       ] as const
-                    ).map(([key, label, value, setter]) => (
-                      <div key={key} className="flex items-center gap-2">
-                        <Checkbox
-                          id={key}
-                          checked={value as boolean}
-                          onCheckedChange={(v) =>
-                            (setter as (v: boolean) => void)(!!v)
-                          }
-                        />
-                        <label
-                          htmlFor={key}
-                          className="text-xs cursor-pointer text-muted-foreground"
-                        >
-                          {label}
-                        </label>
-                      </div>
+                    ).map((opt) => (
+                      <button
+                        key={opt.value}
+                        type="button"
+                        onClick={() => store.setLoraVariant(opt.value)}
+                        className={`flex-1 corner-squircle rounded-xl border px-3 py-2 text-left transition-colors cursor-pointer ${
+                          store.loraVariant === opt.value
+                            ? "border-primary/50 bg-primary/5 ring-1 ring-primary/20"
+                            : "border-border hover:border-foreground/20"
+                        }`}
+                      >
+                        <p className="text-xs font-medium">{opt.label}</p>
+                        <p className="text-[10px] text-muted-foreground">
+                          {opt.desc}
+                        </p>
+                      </button>
                     ))}
                   </div>
-                )}
-
-                {/* Text target modules */}
-                {!showVisionLora && (
-                  <div className="flex flex-col gap-2 pt-1">
-                    <span className="text-xs font-medium text-muted-foreground">
-                      {t("studio.params.targetModules")}
-                    </span>
-                    <div className="flex flex-wrap gap-1.5">
-                      {(isCpt ? CPT_TARGET_MODULES : TARGET_MODULES).map((mod) => {
-                        const active = store.targetModules.includes(mod);
-                        return (
-                          <button
-                            key={mod}
-                            type="button"
-                            onClick={() => {
-                              store.setTargetModules(
-                                active
-                                  ? store.targetModules.filter((m) => m !== mod)
-                                  : [...store.targetModules, mod],
-                              );
-                            }}
-                            className={`cursor-pointer rounded-full border px-2.5 py-0.5 text-[11px] font-mono transition-colors ${active
-                                ? "border-orange-300 bg-orange-50 text-orange-700 dark:border-orange-700 dark:bg-orange-950 dark:text-orange-300"
-                                : "text-muted-foreground hover:bg-muted/50"
-                              }`}
-                          >
-                            {mod}
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </div>
-                )}
-
-                {/* LoRA variant */}
-                <div className="flex gap-2">
-                  {(
-                    [
-                      {
-                        value: "lora",
-                        label: t("studio.params.enableLora"),
-                        desc: t("studio.params.trainWithLora"),
-                      },
-                      { value: "rslora", label: "RS-LoRA", desc: t("studio.params.stableRank") },
-                      {
-                        value: "loftq",
-                        label: "LoftQ",
-                        desc: t("studio.params.memoryEfficient"),
-                      },
-                    ] as const
-                  ).map((opt) => (
-                    <button
-                      key={opt.value}
-                      type="button"
-                      onClick={() => store.setLoraVariant(opt.value)}
-                      className={`flex-1 corner-squircle rounded-xl border px-3 py-2 text-left transition-colors cursor-pointer ${store.loraVariant === opt.value
-                          ? "border-primary/50 bg-primary/5 ring-1 ring-primary/20"
-                          : "border-border hover:border-foreground/20"
-                        }`}
-                    >
-                      <p className="text-xs font-medium">{opt.label}</p>
-                      <p className="text-[10px] text-muted-foreground">
-                        {opt.desc}
-                      </p>
-                    </button>
-                  ))}
-                </div>
                 </div>
               </CollapsibleContent>
             </Collapsible>
@@ -703,7 +734,7 @@ export function ParamsSection(): ReactElement {
           <Collapsible open={hyperOpen} onOpenChange={setHyperOpen}>
             <CollapsibleTrigger className="flex w-full cursor-pointer items-center gap-1.5 text-xs text-muted-foreground">
               <HugeiconsIcon
-                icon={ArrowDown01Icon}
+                icon={ChevronDownStandardIcon}
                 className={`size-3.5 transition-transform ${hyperOpen ? "rotate-180" : ""}`}
               />
               {t("studio.params.trainingHyperparameters")}
@@ -760,10 +791,7 @@ export function ParamsSection(): ReactElement {
                       </SelectTrigger>
                       <SelectContent>
                         {OPTIMIZER_OPTIONS.map((opt) => (
-                          <SelectItem
-                            key={opt.value}
-                            value={opt.value}
-                          >
+                          <SelectItem key={opt.value} value={opt.value}>
                             {formatOptimizerLabel(opt.value, opt.label, t)}
                           </SelectItem>
                         ))}
@@ -795,10 +823,7 @@ export function ParamsSection(): ReactElement {
                       </SelectTrigger>
                       <SelectContent>
                         {LR_SCHEDULER_OPTIONS.map((opt) => (
-                          <SelectItem
-                            key={opt.value}
-                            value={opt.value}
-                          >
+                          <SelectItem key={opt.value} value={opt.value}>
                             {formatSchedulerLabel(opt.value, opt.label, t)}
                           </SelectItem>
                         ))}
@@ -942,7 +967,9 @@ export function ParamsSection(): ReactElement {
                     <Input
                       type="number"
                       value={store.saveSteps}
-                      onChange={(e) => store.setSaveSteps(Number(e.target.value))}
+                      onChange={(e) =>
+                        store.setSaveSteps(Number(e.target.value))
+                      }
                       className="w-28 font-mono"
                     />
                   </Row>
@@ -956,11 +983,16 @@ export function ParamsSection(): ReactElement {
                       min="0.0"
                       max="1.0"
                       value={store.evalSteps}
-                      onChange={(e) => store.setEvalSteps(Number(e.target.value))}
+                      onChange={(e) =>
+                        store.setEvalSteps(Number(e.target.value))
+                      }
                       className="w-28 font-mono"
                     />
                   </Row>
-                  <Row label={t("studio.params.seed")} tooltip={t("studio.params.seedTooltip")}>
+                  <Row
+                    label={t("studio.params.seed")}
+                    tooltip={t("studio.params.seedTooltip")}
+                  >
                     <Input
                       type="number"
                       value={store.randomSeed}
@@ -972,14 +1004,18 @@ export function ParamsSection(): ReactElement {
                   </Row>
                 </TabsContent>
 
-                <TabsContent value="memory" className="mt-3 flex flex-col gap-3">
+                <TabsContent
+                  value="memory"
+                  className="mt-3 flex flex-col gap-3"
+                >
                   {showVisionImageSize && (
                     <Row
                       label="Image Size"
                       tooltip={
                         <>
                           Resize images by maximum side length. Default uses the
-                          model image size. Larger images use up more context. Does not upscale or change aspect ratio.{" "}
+                          model image size. Larger images use up more context.
+                          Does not upscale or change aspect ratio.{" "}
                           <a
                             href="https://unsloth.ai/docs/basics/vision-fine-tuning"
                             target="_blank"
@@ -1014,9 +1050,7 @@ export function ParamsSection(): ReactElement {
                             !visionImageSizePresets.includes(
                               store.visionImageSize,
                             ) && (
-                              <SelectItem
-                                value={String(store.visionImageSize)}
-                              >
+                              <SelectItem value={String(store.visionImageSize)}>
                                 {store.visionImageSize}
                               </SelectItem>
                             )}
@@ -1048,15 +1082,21 @@ export function ParamsSection(): ReactElement {
                     <Select
                       value={store.gradientCheckpointing}
                       onValueChange={(v) =>
-                        store.setGradientCheckpointing(v as GradientCheckpointing)
+                        store.setGradientCheckpointing(
+                          v as GradientCheckpointing,
+                        )
                       }
                     >
                       <SelectTrigger className="w-32">
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="none">{t("studio.params.none")}</SelectItem>
-                        <SelectItem value="true">{t("studio.params.standard")}</SelectItem>
+                        <SelectItem value="none">
+                          {t("studio.params.none")}
+                        </SelectItem>
+                        <SelectItem value="true">
+                          {t("studio.params.standard")}
+                        </SelectItem>
                         {platformDeviceType === "mac" ? (
                           <SelectItem value="mlx">MLX</SelectItem>
                         ) : (
@@ -1086,7 +1126,9 @@ export function ParamsSection(): ReactElement {
                         id="trainOnCompletions"
                         checked={store.trainOnCompletions}
                         disabled={store.datasetStreaming}
-                        onCheckedChange={(v) => store.setTrainOnCompletions(!!v)}
+                        onCheckedChange={(v) =>
+                          store.setTrainOnCompletions(!!v)
+                        }
                       />
                       <label
                         htmlFor="trainOnCompletions"

--- a/studio/frontend/src/features/studio/sections/training-section.tsx
+++ b/studio/frontend/src/features/studio/sections/training-section.tsx
@@ -175,7 +175,7 @@ export function TrainingSection() {
         {/* Start/Stop */}
         <Button
           data-tour="studio-start"
-          className="w-full cursor-pointer bg-gradient-to-r from-emerald-500 to-teal-500 text-white hover:from-emerald-600 hover:to-teal-600"
+          className="w-full cursor-pointer bg-primary text-primary-foreground hover:bg-primary/90"
           onClick={() => void startTrainingRun()}
           disabled={isStarting || isIncompatible || store.isCheckingDataset || isLoadingModel || !configValidation.ok}
         >

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -265,6 +265,90 @@ export const en = {
         light: "Light",
         dark: "Dark",
       },
+      palette: {
+        label: "Color palette",
+        description: "Colors used across Studio, in light and dark mode.",
+        standard: "Standard",
+        classic: "Classic",
+        minimal: "Minimal",
+      },
+      custom: {
+        reset: "Reset",
+        resetAll: "Reset customization",
+        preferencesTitle: "Preferences",
+        colors: {
+          description:
+            "Applies to the mode you're using now. Switch the color scheme to edit the other.",
+          lightGroup: "Light theme",
+          darkGroup: "Dark theme",
+          accent: "Accent",
+          background: "Background",
+          foreground: "Foreground",
+        },
+        fontDefault: "Default",
+        fontBundledGroup: "Built-in",
+        fontImportedGroup: "Imported",
+        fontDeviceGroup: "On this device",
+        fontDeviceLoading: "Looking for device fonts…",
+        fontSearch: "Search fonts…",
+        fontNoResults: "No fonts found.",
+        colorPicker: {
+          hue: "Hue",
+          hex: "Hex color",
+          eyedropper: "Pick a color from the screen",
+        },
+        uiFont: {
+          label: "UI font",
+          description: "Font used across the interface.",
+        },
+        codeFont: {
+          label: "Code font",
+          description: "Font used for code and diffs.",
+        },
+        importFont: {
+          label: "Import font",
+          description: "Add a font file from your device (max 1.5 MB).",
+          button: "Import font…",
+          remove: "Remove",
+          errorInvalidType:
+            "Unsupported file type. Use .woff2, .woff, .ttf, or .otf.",
+          errorTooLarge: "Font file is too large (max 1.5 MB).",
+          errorLimit: "You can import up to 3 fonts.",
+          errorFailed: "Could not load this font file.",
+        },
+        uiFontSize: {
+          label: "UI font size",
+          description: "Adjust the base size used for the Studio UI.",
+        },
+        codeFontSize: {
+          label: "Code font size",
+          description: "Adjust the base size used for code.",
+        },
+        fontSmoothing: {
+          label: "Font smoothing",
+          description: "Use smoothed font anti-aliasing.",
+        },
+        contrast: {
+          label: "Contrast",
+          description: "Strength of borders and secondary text.",
+        },
+        reduceMotion: {
+          label: "Reduce motion",
+          description: "Reduce animations or match your system.",
+          system: "System",
+          on: "On",
+          off: "Off",
+        },
+        pointerCursors: {
+          label: "Use pointer cursors",
+          description:
+            "Change the cursor to a pointer when hovering over interactive elements.",
+        },
+        translucentSidebar: {
+          label: "Translucent sidebar",
+          description: "Let content show through the sidebar.",
+        },
+      },
       language: {
         title: "Language",
         label: "Display language",

--- a/studio/frontend/src/i18n/locales/ja.ts
+++ b/studio/frontend/src/i18n/locales/ja.ts
@@ -218,6 +218,90 @@ export const ja = {
         light: "ライト",
         dark: "ダーク",
       },
+      palette: {
+        label: "カラーパレット",
+        description: "Studio 全体で使用される配色。ライト・ダーク両対応。",
+        standard: "スタンダード",
+        classic: "クラシック",
+        minimal: "ミニマル",
+      },
+      custom: {
+        reset: "リセット",
+        resetAll: "カスタマイズをリセット",
+        preferencesTitle: "環境設定",
+        colors: {
+          description:
+            "現在のモードに適用されます。もう一方はカラー構成を切り替えて編集します。",
+          lightGroup: "ライトテーマ",
+          darkGroup: "ダークテーマ",
+          accent: "アクセント",
+          background: "背景",
+          foreground: "文字色",
+        },
+        fontDefault: "デフォルト",
+        fontBundledGroup: "内蔵",
+        fontImportedGroup: "インポート済み",
+        fontDeviceGroup: "このデバイス",
+        fontDeviceLoading: "デバイスのフォントを検索中…",
+        fontSearch: "フォントを検索…",
+        fontNoResults: "フォントが見つかりません。",
+        colorPicker: {
+          hue: "色相",
+          hex: "16進カラー",
+          eyedropper: "画面から色を選択",
+        },
+        uiFont: {
+          label: "UI フォント",
+          description: "インターフェイスで使用するフォント。",
+        },
+        codeFont: {
+          label: "コードフォント",
+          description: "コードと差分で使用するフォント。",
+        },
+        importFont: {
+          label: "フォントをインポート",
+          description: "デバイスからフォントファイルを追加（最大 1.5 MB）。",
+          button: "フォントをインポート…",
+          remove: "削除",
+          errorInvalidType:
+            "サポートされていないファイル形式です。.woff2、.woff、.ttf、.otf を使用してください。",
+          errorTooLarge: "フォントファイルが大きすぎます（最大 1.5 MB）。",
+          errorLimit: "インポートできるフォントは最大 3 つです。",
+          errorFailed: "このフォントファイルを読み込めませんでした。",
+        },
+        uiFontSize: {
+          label: "UI フォントサイズ",
+          description: "Studio UI の基本サイズを調整します。",
+        },
+        codeFontSize: {
+          label: "コードフォントサイズ",
+          description: "コードの基本サイズを調整します。",
+        },
+        fontSmoothing: {
+          label: "フォントスムージング",
+          description: "滑らかなアンチエイリアスを使用します。",
+        },
+        contrast: {
+          label: "コントラスト",
+          description: "枠線と補助テキストの強さ。",
+        },
+        reduceMotion: {
+          label: "モーションを減らす",
+          description: "アニメーションを減らすか、システム設定に従います。",
+          system: "システム",
+          on: "オン",
+          off: "オフ",
+        },
+        pointerCursors: {
+          label: "ポインターカーソルを使用",
+          description:
+            "操作可能な要素にカーソルを合わせたときにポインターに変更します。",
+        },
+        translucentSidebar: {
+          label: "半透明サイドバー",
+          description: "サイドバー越しにコンテンツを透かします。",
+        },
+      },
       language: {
         title: "言語",
         label: "表示言語",

--- a/studio/frontend/src/i18n/locales/pt-br.ts
+++ b/studio/frontend/src/i18n/locales/pt-br.ts
@@ -217,6 +217,91 @@ export const ptBR = {
         light: "Claro",
         dark: "Escuro",
       },
+      palette: {
+        label: "Paleta de cores",
+        description: "Cores usadas no Studio, nos modos claro e escuro.",
+        standard: "Padrão",
+        classic: "Clássico",
+        minimal: "Minimalista",
+      },
+      custom: {
+        reset: "Redefinir",
+        resetAll: "Redefinir personalização",
+        preferencesTitle: "Preferências",
+        colors: {
+          description:
+            "Aplica-se ao modo em uso. Troque o esquema de cores para editar o outro.",
+          lightGroup: "Tema claro",
+          darkGroup: "Tema escuro",
+          accent: "Destaque",
+          background: "Fundo",
+          foreground: "Texto",
+        },
+        fontDefault: "Padrão",
+        fontBundledGroup: "Integradas",
+        fontImportedGroup: "Importadas",
+        fontDeviceGroup: "Neste dispositivo",
+        fontDeviceLoading: "Procurando fontes do dispositivo…",
+        fontSearch: "Buscar fontes…",
+        fontNoResults: "Nenhuma fonte encontrada.",
+        colorPicker: {
+          hue: "Matiz",
+          hex: "Cor hexadecimal",
+          eyedropper: "Escolher uma cor da tela",
+        },
+        uiFont: {
+          label: "Fonte da interface",
+          description: "Fonte usada na interface.",
+        },
+        codeFont: {
+          label: "Fonte de código",
+          description: "Fonte usada em código e diffs.",
+        },
+        importFont: {
+          label: "Importar fonte",
+          description:
+            "Adicione um arquivo de fonte do seu dispositivo (máx. 1,5 MB).",
+          button: "Importar fonte…",
+          remove: "Remover",
+          errorInvalidType:
+            "Tipo de arquivo não suportado. Use .woff2, .woff, .ttf ou .otf.",
+          errorTooLarge: "O arquivo de fonte é muito grande (máx. 1,5 MB).",
+          errorLimit: "Você pode importar até 3 fontes.",
+          errorFailed: "Não foi possível carregar este arquivo de fonte.",
+        },
+        uiFontSize: {
+          label: "Tamanho da fonte da interface",
+          description: "Ajuste o tamanho base da interface do Studio.",
+        },
+        codeFontSize: {
+          label: "Tamanho da fonte de código",
+          description: "Ajuste o tamanho base do código.",
+        },
+        fontSmoothing: {
+          label: "Suavização de fonte",
+          description: "Usar anti-aliasing suavizado nas fontes.",
+        },
+        contrast: {
+          label: "Contraste",
+          description: "Intensidade das bordas e do texto secundário.",
+        },
+        reduceMotion: {
+          label: "Reduzir movimento",
+          description: "Reduza as animações ou siga o sistema.",
+          system: "Sistema",
+          on: "Ativado",
+          off: "Desativado",
+        },
+        pointerCursors: {
+          label: "Usar cursor de ponteiro",
+          description:
+            "Muda o cursor para ponteiro ao passar sobre elementos interativos.",
+        },
+        translucentSidebar: {
+          label: "Barra lateral translúcida",
+          description: "Deixa o conteúdo transparecer pela barra lateral.",
+        },
+      },
       language: {
         title: "Idioma",
         label: "Idioma de exibição",

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -195,6 +195,88 @@ export const zhCN = {
         light: "浅色",
         dark: "深色",
       },
+      palette: {
+        label: "调色板",
+        description: "Studio 全局使用的配色，支持浅色和深色模式。",
+        standard: "标准",
+        classic: "经典",
+        minimal: "极简",
+      },
+      custom: {
+        reset: "重置",
+        resetAll: "重置自定义",
+        preferencesTitle: "偏好设置",
+        colors: {
+          description: "应用于当前模式。切换颜色主题可编辑另一种模式。",
+          lightGroup: "浅色主题",
+          darkGroup: "深色主题",
+          accent: "强调色",
+          background: "背景",
+          foreground: "前景",
+        },
+        fontDefault: "默认",
+        fontBundledGroup: "内置",
+        fontImportedGroup: "已导入",
+        fontDeviceGroup: "此设备",
+        fontDeviceLoading: "正在查找设备字体…",
+        fontSearch: "搜索字体…",
+        fontNoResults: "未找到字体。",
+        colorPicker: {
+          hue: "色相",
+          hex: "十六进制颜色",
+          eyedropper: "从屏幕取色",
+        },
+        uiFont: {
+          label: "界面字体",
+          description: "界面使用的字体。",
+        },
+        codeFont: {
+          label: "代码字体",
+          description: "代码和差异视图使用的字体。",
+        },
+        importFont: {
+          label: "导入字体",
+          description: "从设备添加字体文件（最大 1.5 MB）。",
+          button: "导入字体…",
+          remove: "移除",
+          errorInvalidType:
+            "不支持的文件类型。请使用 .woff2、.woff、.ttf 或 .otf。",
+          errorTooLarge: "字体文件过大（最大 1.5 MB）。",
+          errorLimit: "最多可导入 3 个字体。",
+          errorFailed: "无法加载此字体文件。",
+        },
+        uiFontSize: {
+          label: "界面字号",
+          description: "调整 Studio 界面的基准字号。",
+        },
+        codeFontSize: {
+          label: "代码字号",
+          description: "调整代码的基准字号。",
+        },
+        fontSmoothing: {
+          label: "字体平滑",
+          description: "使用平滑的字体抗锯齿。",
+        },
+        contrast: {
+          label: "对比度",
+          description: "边框和次要文本的强度。",
+        },
+        reduceMotion: {
+          label: "减少动态效果",
+          description: "减少动画，或跟随系统设置。",
+          system: "跟随系统",
+          on: "开",
+          off: "关",
+        },
+        pointerCursors: {
+          label: "使用指针光标",
+          description: "悬停在可交互元素上时将光标变为指针。",
+        },
+        translucentSidebar: {
+          label: "半透明侧边栏",
+          description: "让内容透过侧边栏显示。",
+        },
+      },
       layout: {
         title: "布局",
         compactSidebar: "默认固定侧边栏",

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -258,6 +258,13 @@
 	--chat-icon-fg-hover: var(--foreground);
 	--chat-icon-bg-hover: #ededec;
 
+	/* Control accent: switches, "New" badges, notification-style chips.
+	   Follows the brand accent by default; palettes that keep their primary
+	   neutral (Classic) override this so small controls still get a hue.
+	   References resolve at use, so .dark's --primary flows through. */
+	--control-accent: var(--primary);
+	--control-accent-foreground: var(--primary-foreground);
+
 	/* Standard interactive-icon size for nav, menus, action bars, and
 	   in-message code-block actions. Sized one step above body text so
 	   icons read as minimally larger than adjacent labels (~14px text).
@@ -271,47 +278,47 @@
 }
 
 .dark {
-	/* Exact palette from apps/studio/index_chat.html mockup. Using hex so the
-	   rendered surface matches the mockup pixel-for-pixel — OKLCH conversion
-	   drifted ~3% darker and shifted the neutral hue. */
-	/* Slightly darker than --sidebar so the sidebar reads as its own surface. */
-	--background: #1a1b1e;
-	--foreground: #ececee;
-	--card: #2d2e32;
-	--card-foreground: #ececee;
-	--popover: #2d2e32;
-	--popover-foreground: #ececee;
+	/* Codex/ChatGPT-app dark surfaces, shared by ALL palettes: #181818 page,
+	   elevated #1f1f1f sidebar, #212121 cards. Palette dark blocks override
+	   only accent tokens so dark mode stays consistent across themes. */
+	--background: #181818;
+	--foreground: #ececec;
+	--card: #212121;
+	--card-foreground: #ececec;
+	--popover: #212121;
+	--popover-foreground: #ececec;
 	--primary: #17b88b;
 	--primary-foreground: oklch(1 0 0);
-	--secondary: #2e3035;
-	--secondary-foreground: #ececee;
-	--muted: #2e3035;
-	--muted-foreground: #999999;
+	--secondary: #242424;
+	--secondary-foreground: #ececec;
+	--muted: #242424;
+	--muted-foreground: #9b9b9b;
 	/* One step lighter than --popover so menu item hover reads clearly. */
-	--accent: #3a3d43;
-	--accent-foreground: #ececee;
+	--accent: #2e2e2e;
+	--accent-foreground: #ececec;
 	--destructive: oklch(0.6368 0.2078 25.3313);
 	/* Bypass permissions accent: bright, saturated neon yellow on dark. */
 	--bypass: #ffd60a;
 	/* --border / --input one step lighter than --muted so outlines and form
 	   borders stay visible on muted surfaces (right config panel, export
 	   tiles, quant chips) and keep subtle contrast on card. */
-	--border: #3a3d42;
-	--input: #3a3d42;
+	--border: #303030;
+	--input: #303030;
 	--ring: #17b88b;
 	--chart-1: oklch(0.7511 0.1407 166.2284);
 	--chart-2: oklch(0.75 0.14 136.5572);
 	--chart-3: oklch(0.7554 0.1285 197.339);
 	--chart-4: oklch(0.7503 0.1199 346.7805);
 	--chart-5: oklch(0.799 0.1196 84.6633);
-	/* A step lighter than --background; the tone difference is the separator. */
-	--sidebar: #1f2023;
-	--sidebar-foreground: #ececee;
+	/* Elevated (a step lighter than --background), Codex-style; the tone
+	   difference is the separator. */
+	--sidebar: #1f1f1f;
+	--sidebar-foreground: #ececec;
 	--sidebar-primary: #17b88b;
 	--sidebar-primary-foreground: oklch(1 0 0);
-	--sidebar-accent: #2e3035;
-	--sidebar-accent-foreground: #ececee;
-	--sidebar-border: #2d2e32;
+	--sidebar-accent: #2a2a2a;
+	--sidebar-accent-foreground: #ececec;
+	--sidebar-border: #2a2a2a;
 	--sidebar-ring: #17b88b;
 	--destructive-foreground: oklch(1 0 0);
 	/* Match light's radius so every rounded-* element is the same in both themes. */
@@ -336,21 +343,23 @@
 	--shadow-xl: 0px 0px 0px 0px hsl(0 0% 0% / 0), 0px 8px 10px 0px hsl(0 0% 0% / 0);
 	--shadow-2xl: 0px 0px 0px 0px hsl(0 0% 0% / 0);
 
-	--nav-fg: #c7c7c4;
-	--nav-fg-muted: #96979b;
-	--nav-surface-hover: #2e3035;
+	--nav-fg: #c9c9c9;
+	--nav-fg-muted: #969696;
+	--nav-surface-hover: #2a2a2a;
 	--nav-icon-idle: #5c5c5c;
-	--nav-beta-border: #3a3c3f;
-	--panel-surface-hover: #3a3c42;
+	--nav-beta-border: #333333;
+	--panel-surface-hover: #333333;
 	/* Right-side chat-parameters panel: matches the chat content
 	   surface in both themes — distinction from the left sidebar
-	   (#18181a, the deepest surface) is handled by the left border
-	   alone. Tracks `--background` so any future tweaks to the chat
-	   surface flow through automatically. */
+	   is handled by the left border alone. Tracks `--background` so
+	   any future tweaks to the chat surface flow through
+	   automatically. */
 	--panel-surface: var(--background);
 	--panel-surface-fg: var(--foreground);
-	--panel-input-surface: #2a2b2e;
-	--panel-input-surface-hover: #34373c;
+	/* Translucent white like the ChatGPT app's dark fields, so the same fill
+	   reads correctly on the #181818 page AND on #212121 cards/dialogs. */
+	--panel-input-surface: rgba(255, 255, 255, 0.07);
+	--panel-input-surface-hover: rgba(255, 255, 255, 0.11);
 	/* Soft neutral gray for muted text and sliders. Pure-ish #ababab
 	   reads as quiet on the dark panel without going colored. */
 	--panel-surface-fg-muted: #ababab;
@@ -362,7 +371,242 @@
 	   hover restores full --foreground for affordance. */
 	--chat-icon-fg: #d8d8d8;
 	--chat-icon-fg-hover: var(--foreground);
-	--chat-icon-bg-hover: #2d2e32;
+	--chat-icon-bg-hover: #2a2a2a;
+}
+
+/* ---------------------------------------------------------------------------
+   Color palettes.
+
+   The palette is a second theming dimension, orthogonal to light/dark. It is
+   carried on <html> as `data-palette` (managed by theme-store.ts alongside the
+   light/dark class):
+
+     (no attribute)            → Standard: the signature Unsloth green.
+     data-palette="classic"    → Classic: neutral grays with a calm steel-blue
+                                 accent; enterprise-safe, in the spirit of
+                                 Claude Code / Codex.
+     data-palette="minimal"    → Minimal: strictly black, white, and gray.
+
+   Each palette overrides only color tokens; typography, radii, spacing, and
+   shadows are inherited from the base :root/.dark blocks so layout is
+   identical across palettes. Light blocks are scoped with :not(.dark) so the
+   base .dark block always wins the mode dimension. */
+
+/* -------------------------------- Classic --------------------------------
+   Codex / ChatGPT-app clone: white content + #f9f9f9 sidebar in light,
+   #212121 content + #171717 sidebar in dark, neutral gray hovers, and the
+   Codex blue (#339cff) as the accent. */
+:root[data-palette="classic"]:not(.dark) {
+	--background: #ffffff;
+	--foreground: #1a1c1f;
+	--card: #ffffff;
+	--card-foreground: #1a1c1f;
+	--popover: #ffffff;
+	--popover-foreground: #1a1c1f;
+	/* Neutral primary like ChatGPT's black buttons; blue is reserved for
+	   small controls via --control-accent (toggles, badges, focus rings). */
+	--primary: #0d0d0d;
+	--primary-foreground: #ffffff;
+	--control-accent: #339cff;
+	--control-accent-foreground: #ffffff;
+	--secondary: #f5f5f5;
+	--secondary-foreground: #1a1c1f;
+	--muted: #f7f7f7;
+	--muted-foreground: #8f8f8f;
+	--accent: #ececec;
+	--accent-foreground: #1a1c1f;
+	--bypass: #9a7b1e;
+	--border: #e6e6e6;
+	--input: #e6e6e6;
+	--ring: #339cff;
+	--chart-1: #339cff;
+	--chart-2: #8fa3b8;
+	--chart-3: #0f6fd6;
+	--chart-4: #b8c4d0;
+	--chart-5: #5b7189;
+	--sidebar: #f9f9f9;
+	--sidebar-foreground: #1a1c1f;
+	--sidebar-primary: #0d0d0d;
+	--sidebar-primary-foreground: #ffffff;
+	--sidebar-accent: #ececec;
+	--sidebar-accent-foreground: #1a1c1f;
+	--sidebar-border: #ececec;
+	--sidebar-ring: #339cff;
+
+	--nav-fg: #2d2f31;
+	--nav-fg-muted: #8f8f8f;
+	--nav-surface-hover: #ececec;
+	--nav-icon-idle: #8f8f8f;
+	--nav-beta-border: #e0e0e0;
+	--panel-surface-hover: #ececec;
+	--panel-input-surface: #f4f4f4;
+	--panel-input-surface-hover: #ededed;
+	--panel-surface-fg-muted: #7a7c7e;
+	--panel-slider-fg: #9b9d9f;
+	--chat-icon-fg: #5d5f61;
+	--chat-icon-bg-hover: #ececec;
+}
+
+/* Dark surfaces come from the shared base .dark block; Classic only swaps
+   the accents: neutral (white) buttons like ChatGPT dark, Codex blue on
+   small controls via --control-accent. */
+:root[data-palette="classic"].dark {
+	--primary: #ececec;
+	--primary-foreground: #0d0d0d;
+	--control-accent: #4dabff;
+	--control-accent-foreground: #ffffff;
+	--bypass: #d9b40b;
+	--ring: #4dabff;
+	--chart-1: #4dabff;
+	--chart-2: #8ab6de;
+	--chart-3: #1f7fe8;
+	--chart-4: #b3d4f5;
+	--chart-5: #6d87a3;
+	--sidebar-primary: #ececec;
+	--sidebar-primary-foreground: #0d0d0d;
+	--sidebar-ring: #4dabff;
+}
+
+/* -------------------------------- Minimal -------------------------------- */
+:root[data-palette="minimal"]:not(.dark) {
+	--background: #ffffff;
+	--foreground: #171717;
+	--card: #ffffff;
+	--card-foreground: #171717;
+	--popover: #ffffff;
+	--popover-foreground: #171717;
+	--primary: #171717;
+	--primary-foreground: #ffffff;
+	--secondary: #f5f5f5;
+	--secondary-foreground: #262626;
+	--muted: #f5f5f5;
+	--muted-foreground: #6f6f6f;
+	--accent: #ebebeb;
+	--accent-foreground: #171717;
+	--bypass: #6f6f6f;
+	--border: #e2e2e2;
+	--input: #e2e2e2;
+	--ring: #171717;
+	--chart-1: #171717;
+	--chart-2: #4d4d4d;
+	--chart-3: #7a7a7a;
+	--chart-4: #a6a6a6;
+	--chart-5: #d1d1d1;
+	/* White sidebar on white content; the border alone is the separator. */
+	--sidebar: #ffffff;
+	--sidebar-foreground: #171717;
+	--sidebar-primary: #171717;
+	--sidebar-primary-foreground: #ffffff;
+	--sidebar-accent: #ebebeb;
+	--sidebar-accent-foreground: #171717;
+	--sidebar-border: #e8e8e8;
+	--sidebar-ring: #171717;
+
+	--nav-fg: #333333;
+	--nav-fg-muted: #8a8a8a;
+	--nav-surface-hover: #efefef;
+	--nav-icon-idle: #8f8f8f;
+	--nav-beta-border: #dddddd;
+	--panel-surface-hover: #ececec;
+	--panel-input-surface: #f4f4f4;
+	--panel-input-surface-hover: #ededed;
+	--panel-surface-fg-muted: #757575;
+	--panel-slider-fg: #9b9b9b;
+	--chat-icon-fg: #555555;
+	--chat-icon-bg-hover: #ececec;
+}
+
+/* Dark surfaces come from the shared base .dark block; Minimal only swaps
+   the accents to pure monochrome (white buttons, gray chart ramp). */
+:root[data-palette="minimal"].dark {
+	--primary: #ededed;
+	--primary-foreground: #111111;
+	--bypass: #9c9c9c;
+	--ring: #ededed;
+	--chart-1: #ededed;
+	--chart-2: #bdbdbd;
+	--chart-3: #8f8f8f;
+	--chart-4: #616161;
+	--chart-5: #3d3d3d;
+	--sidebar-primary: #ededed;
+	--sidebar-primary-foreground: #111111;
+	--sidebar-ring: #ededed;
+}
+
+/* ---------------------------------------------------------------------------
+   Appearance customization hooks (Settings → Appearance).
+
+   Every rule below is gated on a class or data attribute that
+   appearance-custom-store.ts toggles on <html>. With no customization active,
+   none of these selectors match and the stylesheet behaves exactly as stock.
+   Custom colors/fonts are applied as inline CSS variables on <html> (inline
+   wins over every :root/.dark/palette block), so they need no rules here. */
+
+/* Contrast slider: remap border and muted-text tokens by mixing their base
+   values toward the foreground (higher contrast) or background (lower).
+   --input mirrors --border in every palette, so it serves as the untouched
+   base for --border; --panel-surface-fg-muted is the closest stable base for
+   --muted-foreground. --contrast-mix / --contrast-target are set inline. */
+html[data-contrast-adjust] {
+	--border: color-mix(in oklab, var(--input), var(--contrast-target) var(--contrast-mix));
+	--sidebar-border: color-mix(in oklab, var(--input), var(--contrast-target) var(--contrast-mix));
+	--muted-foreground: color-mix(
+		in oklab,
+		var(--panel-surface-fg-muted),
+		var(--contrast-target) var(--contrast-mix)
+	);
+}
+
+/* Code font size: only overrides when the user sets an explicit size, so the
+   per-element Tailwind sizes stay authoritative by default. */
+html[data-code-font-size] :is(pre, code, kbd, samp) {
+	font-size: var(--custom-code-font-size) !important;
+}
+
+/* Pointer cursors: Codex-style hand cursor over interactive elements. */
+html.pointer-cursors
+	:is(
+		button:not(:disabled),
+		[role="button"],
+		a[href],
+		select,
+		summary,
+		[role="tab"],
+		[role="menuitem"],
+		[role="option"],
+		[role="switch"],
+		[role="checkbox"],
+		input[type="checkbox"],
+		input[type="radio"],
+		input[type="range"],
+		label[for]
+	) {
+	cursor: pointer;
+}
+
+/* Force reduced motion: collapses CSS animations/transitions app-wide.
+   JS-driven springs are handled separately via MotionConfig in the provider. */
+html.force-reduced-motion *,
+html.force-reduced-motion *::before,
+html.force-reduced-motion *::after {
+	animation-duration: 0.01ms !important;
+	animation-iteration-count: 1 !important;
+	transition-duration: 0.01ms !important;
+	scroll-behavior: auto !important;
+}
+
+/* Font smoothing toggle: back to the browser's subpixel default. */
+html.no-font-smoothing body {
+	-webkit-font-smoothing: auto;
+	-moz-osx-font-smoothing: auto;
+}
+
+/* Translucent sidebar: most visible in the floating/overlay sidebar, where
+   content actually sits behind the panel. */
+html.translucent-sidebar [data-slot="sidebar-inner"] {
+	background-color: color-mix(in srgb, var(--sidebar) 72%, transparent);
+	backdrop-filter: blur(18px) saturate(1.4);
+	-webkit-backdrop-filter: blur(18px) saturate(1.4);
 }
 
 @theme inline {
@@ -395,6 +639,8 @@
 	--color-secondary: var(--secondary);
 	--color-primary-foreground: var(--primary-foreground);
 	--color-primary: var(--primary);
+	--color-control-accent: var(--control-accent);
+	--color-control-accent-foreground: var(--control-accent-foreground);
 	--color-popover-foreground: var(--popover-foreground);
 	--color-popover: var(--popover);
 	--color-card-foreground: var(--card-foreground);
@@ -444,6 +690,8 @@
 	--color-panel-surface: var(--panel-surface);
 	--color-panel-surface-fg: var(--panel-surface-fg);
 	--color-panel-surface-fg-muted: var(--panel-surface-fg-muted);
+	--color-panel-input-surface: var(--panel-input-surface);
+	--color-panel-input-surface-hover: var(--panel-input-surface-hover);
 	--color-chat-icon-fg: var(--chat-icon-fg);
 	--color-chat-icon-fg-hover: var(--chat-icon-fg-hover);
 	--color-chat-icon-bg-hover: var(--chat-icon-bg-hover);

--- a/studio/frontend/src/lib/chevron-icons.ts
+++ b/studio/frontend/src/lib/chevron-icons.ts
@@ -19,6 +19,20 @@ export const ChevronDownStandardIcon: IconSvgElement = [
   ],
 ];
 
+export const ChevronUpStandardIcon: IconSvgElement = [
+  [
+    "path",
+    {
+      d: "M5.99977 15L11.9998 9.00005L17.9998 15",
+      stroke: "currentColor",
+      strokeLinecap: "round",
+      strokeLinejoin: "round",
+      strokeWidth: "1.5",
+      key: "0",
+    },
+  ],
+];
+
 export const ChevronRightStandardIcon: IconSvgElement = [
   [
     "path",


### PR DESCRIPTION
## What this adds

Appearance settings in Studio previously only offered light/dark. This PR adds color palettes, a full set of appearance customization options, and restyles the core controls (dropdowns, buttons, inputs) for a cleaner, more neutral look in both modes.

### Color palettes

Three palettes in Settings > Appearance, each with its own light and dark scheme:

- **Standard**: the current Unsloth green look.
- **Classic**: a neutral enterprise scheme (greys, blacks, white) with a blue accent used sparingly on toggles, "New" badges, and focus rings. Buttons stay neutral.
- **Minimal**: strictly black, grey, and white, including monochrome badges and a white sidebar in light mode.

Dark mode surfaces (page, sidebar, cards, popovers, borders) are shared by all three palettes so the app stays consistent; palettes only swap accents. The palette is stored as a `data-palette` attribute on `<html>`, orthogonal to the existing dark/light class, so the default look is untouched.

### Customization options

All options apply to the currently active mode only (the other mode keeps its own values), persist through the personalization API, and sync across devices:

- Accent, background, and foreground colors with an in-app color picker (saturation/value area, hue slider, hex field, eyedropper where supported)
- UI font and code font with a searchable dropdown covering bundled fonts, fonts detected on the device, and imported fonts
- Font file import (woff2/woff/ttf/otf, validated and size capped, max 3)
- UI font size, code font size, contrast slider, pointer cursors, reduce motion, font smoothing, translucent sidebar
- Reset control at the bottom of the tab

The customization applier writes inline CSS variables and gated classes on `<html>`, so a default customization leaves the document byte-identical to stock. Persisted payloads are sanitized on every rehydrate so stale local storage can never break the UI.

### Control restyle

- Dropdown triggers, outline buttons, inputs, and textareas follow a flat pill style: solid or translucent fills, subtle borders, no drop shadows
- Single-row controls are fully rounded; multi-row controls keep rounded rectangles
- All rounded dropdown arrows (`ArrowDown01Icon`, `ArrowUp01Icon`, `ArrowUp02Icon`, `UnfoldMoreIcon`) are replaced by simple straight-line chevrons across the app (selects, accordions, navigation, collapsibles, export, data recipes, download manager, folder browser)

### Backend

`PersonalizationAppearance` gains `palette` and `customization` with strict validation (hex color patterns, font name length, size and contrast ranges, imported font data URL checks).

## Testing

- `npm run typecheck`, `npm run build`, and `npm run i18n:check` pass (en, ja, zh-CN, pt-br strings added)
- 16 backend tests in `test_personalization_settings.py` cover palette and customization validation, defaults, imported font limits, and full round-trips
- Verified in the browser across all three palettes in light and dark: settings dialog, sidebar, popovers, training, export, data recipes, chat
