### PR TITLE
scripts: refresh scan_packages allowlist baseline

### DIFF
--- a/scripts/scan_packages_baseline.json
+++ b/scripts/scan_packages_baseline.json
@@ -159,8 +159,8 @@
       "file": "huggingface_hub/hf_api.py",
       "check": "C2 polling/beaconing loop detected",
       "severity": "CRITICAL",
-      "evidence": "L4613:         while True: sha256:f764b6ca3118b23c7c0e670e77178c022a6905f825d7df6e528545fa10aae8f6",
-      "evidence_hash": "9c85d50c227285fa8dc69512999cbb082258cda4b299c7d0e0f69f5aff7accd4"
+      "evidence": "L4677:         while True: sha256:04afb38843e4125d1476f3f04bdad0edf1f63f8d75ad49a713b13e4bc68612fb",
+      "evidence_hash": "18877a2502c862b46a5d7e33fa7c39ab4ef32da7e1b07f596fd455f4376770c6"
     },
     {
       "package": "huggingface-hub",
@@ -340,11 +340,19 @@
     },
     {
       "package": "openai",
+      "file": "openai/resources/beta/responses/responses.py",
+      "check": "C2 polling/beaconing loop detected",
+      "severity": "CRITICAL",
+      "evidence": "L3999:         while True: sha256:df298b6eaf3416589b79f4ef283f8fb76e54d505bfda8840673f8e6419117e2e",
+      "evidence_hash": "10ce5cb5a7097fcff4042ddcfb4802edda60aa4b7b113c8b926a52ddb76f78c2"
+    },
+    {
+      "package": "openai",
       "file": "openai/resources/beta/threads/runs/runs.py",
       "check": "C2 polling/beaconing loop detected",
       "severity": "CRITICAL",
-      "evidence": "L1074:         while True: sha256:ef6d59a4a10b73a5af491f10af2885b7a309fda9468eb0f9572d19558d3ceb9f",
-      "evidence_hash": "43c03b55fedcbc980e5e6649c3c4493729128d280cc868349ab9590908ea5f99"
+      "evidence": "L1053:         while True: sha256:973bb1aeca2e17e022872dc343a1bf5d8fe33bfa59fe01e2f8fe875522db5bce",
+      "evidence_hash": "24626e4aa53047a515ead563b42c07c43f73a2c5b82978fa59f58ffc2859e19b"
     },
     {
       "package": "openai",
@@ -359,7 +367,7 @@
       "file": "openai/resources/responses/responses.py",
       "check": "C2 polling/beaconing loop detected",
       "severity": "CRITICAL",
-      "evidence": "L3803:         while True: sha256:1ce0b5a388c747945cdfda1a71b77afdfd03ae840d7aa9fa62f02eb00aa5e29f",
+      "evidence": "L3950:         while True: sha256:1ce0b5a388c747945cdfda1a71b77afdfd03ae840d7aa9fa62f02eb00aa5e29f",
       "evidence_hash": "6de300ebb5e6e17cb51c89cbcdf08515a44655182f0776f0908a9d1043ebbcd7"
     },
     {


### PR DESCRIPTION
## Why

All three blocking `pip scan-packages` CI shards (studio, hf-stack, extras) fail org-wide, including on main (e.g. run 29152277211). New releases of huggingface-hub (1.23.0) and openai (2.45.0) shifted or added polling loops that the scanner's "C2 polling/beaconing loop" check flags:

- studio: 1 new CRITICAL
- hf-stack: 1 new CRITICAL
- extras: 3 new CRITICAL

## What

Regenerated `scripts/scan_packages_baseline.json` with `scan_packages.py --write-baseline`, run once per CI shard with the exact same requirements groupings and `--with-deps` as `security-audit.yml`, then merged with the same ordering convention as the previous refresh (#7032). Net diff: 1 entry added, 2 evidence hashes refreshed, 1 evidence line number refreshed, 191 -> 192 entries.

## Triage of every new suppression

Each finding was reviewed at the resolved version by reading the cited code:

| Package | File | Finding | Why it is a false positive |
|---|---|---|---|
| huggingface-hub 1.23.0 | `huggingface_hub/hf_api.py` L4677 | C2 polling/beaconing loop | `create_repo` retry loop: POSTs to the canonical Hub endpoint and retries only on a specific 409 "conflicting operation in progress" error, otherwise breaks. Hash refresh of the existing entry (loop body changed upstream). |
| openai 2.45.0 | `openai/resources/beta/threads/runs/runs.py` L1053 | C2 polling/beaconing loop | Documented `create_and_poll` run-status helper polling api.openai.com until a terminal state, honoring the server's `openai-poll-after-ms` header. Hash refresh of the existing entry (Assistants deprecation refactor). |
| openai 2.45.0 | `openai/resources/beta/responses/responses.py` L3999 | C2 polling/beaconing loop | New beta websocket client: `__aiter__` yields server events until the connection closes, with bounded reconnect handling. Standard event-stream iterator. New entry. |
| openai 2.45.0 | `openai/resources/responses/responses.py` | (line shift only) | Evidence line number refreshed from L3803 to L3950; evidence hash unchanged, so this entry never reopened. Review-metadata update only. |

Nothing suspicious was found: no unknown or typosquatted packages, no secret exfiltration to non-canonical hosts, no obfuscation. All flagged code is upstream first-party client behavior in mainstream libraries.

## Dropped entries

Two entries were dropped because they no longer occur at the resolved versions; they are the pre-refactor evidence hashes of the same two loops refreshed above (huggingface-hub `hf_api.py` L4613, openai `beta/threads/runs/runs.py` L1074). All other 189 existing suppressions are retained and still fire.

## Verification

All three shards replicated locally on Python 3.12 with the same input transform as CI (pyproject extraction + git+ stripping, `--with-deps`). The known descript-audio-codec bulk-resolve conflict fell back to per-spec resolution as in CI. With the new baseline every shard exits 0 with 0 unsuppressed CRITICAL/HIGH:

- hf-stack: exit 0, 120 suppressed (82 CRITICAL, 38 HIGH)
- studio: exit 0, 151 suppressed (97 CRITICAL, 54 HIGH)
- extras: exit 0, 99 suppressed (64 CRITICAL, 35 HIGH)