### PR TITLE
Studio: startup loading banner and mute the benign bitsandbytes ROCm warning

### DIFF
--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -2584,7 +2584,6 @@ def run_training_process(*, event_queue: Any, stop_queue: Any, config: dict) -> 
             # warnings still show.
             if os.environ.get("BNB_ROCM_VERSION"):
                 import logging as _logging
-
                 _logging.getLogger("bitsandbytes.cextension").addFilter(
                     lambda _r: "environment variable detected" not in _r.getMessage()
                 )

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -2579,6 +2579,16 @@ def run_training_process(*, event_queue: Any, stop_queue: Any, config: dict) -> 
                         _bnb_rocm_ver,
                     )
 
+            # Setting BNB_ROCM_VERSION makes bitsandbytes log a benign override
+            # notice on import; drop only that record so real errors and mismatch
+            # warnings still show.
+            if os.environ.get("BNB_ROCM_VERSION"):
+                import logging as _logging
+
+                _logging.getLogger("bitsandbytes.cextension").addFilter(
+                    lambda _r: "environment variable detected" not in _r.getMessage()
+                )
+
             # Parse HIP version for the kernel-fix gate below, falling back to
             # the rocm version embedded in torch.__version__ when version.hip is
             # unset (AMD SDK / Radeon wheels).

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -163,7 +163,6 @@ if sys.platform == "win32":
     # import; drop only that record so real errors and mismatch warnings show.
     if os.environ.get("BNB_ROCM_VERSION"):
         import logging as _logging
-
         _logging.getLogger("bitsandbytes.cextension").addFilter(
             lambda _r: "environment variable detected" not in _r.getMessage()
         )

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -159,6 +159,15 @@ if sys.platform == "win32":
                 _bnb_rocm_ver_final,
             )
 
+    # Setting BNB_ROCM_VERSION makes bitsandbytes log a benign override notice on
+    # import; drop only that record so real errors and mismatch warnings show.
+    if os.environ.get("BNB_ROCM_VERSION"):
+        import logging as _logging
+
+        _logging.getLogger("bitsandbytes.cextension").addFilter(
+            lambda _r: "environment variable detected" not in _r.getMessage()
+        )
+
 # ── WSL AMD Strix Halo (gfx1151): enable ROCDXG before any torch import ──────
 # In WSL the AMD GPU is reached via the ROCDXG bridge (librocdxg.so over
 # /dev/dxg), which HSA loads only when HSA_ENABLE_DXG_DETECTION=1 is set BEFORE

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -1160,8 +1160,7 @@ def run_server(
     # silent), so print a flushed heads-up (piped stdout is block-buffered).
     if not silent:
         print(
-            "Loading Unsloth Studio, please wait... "
-            "(this can take a few minutes)",
+            "Loading Unsloth Studio, please wait... (this can take a few minutes)",
             flush = True,
         )
         print("  - loading PyTorch, Unsloth and Transformers...", flush = True)

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -1156,6 +1156,16 @@ def run_server(
     from threading import Thread, Event
     import uvicorn
 
+    # `from main import app` below loads torch/unsloth/transformers (~2 min cold,
+    # silent), so print a flushed heads-up (piped stdout is block-buffered).
+    if not silent:
+        print(
+            "Loading Unsloth Studio, please wait... "
+            "(first launch can take a few minutes while ML libraries load)",
+            flush = True,
+        )
+        print("  - loading PyTorch, Unsloth and Transformers...", flush = True)
+
     import_started = time.perf_counter()
 
     from main import app, setup_frontend, _IS_COLAB
@@ -1164,6 +1174,8 @@ def run_server(
         "Imported FastAPI app in %.1fms",
         (time.perf_counter() - import_started) * 1000,
     )
+    if not silent:
+        print("  - ML libraries loaded; starting server...", flush = True)
     from utils.paths import ensure_studio_directories
 
     # Allow local stdio MCP servers on a loopback bind (the user's own machine),

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -1161,7 +1161,7 @@ def run_server(
     if not silent:
         print(
             "Loading Unsloth Studio, please wait... "
-            "(first launch can take a few minutes while ML libraries load)",
+            "(this can take a few minutes)",
             flush = True,
         )
         print("  - loading PyTorch, Unsloth and Transformers...", flush = True)
@@ -1175,7 +1175,7 @@ def run_server(
         (time.perf_counter() - import_started) * 1000,
     )
     if not silent:
-        print("  - ML libraries loaded; starting server...", flush = True)
+        print("  - Starting server...", flush = True)
     from utils.paths import ensure_studio_directories
 
     # Allow local stdio MCP servers on a loopback bind (the user's own machine),


### PR DESCRIPTION
## Summary

Two small Studio startup UX fixes for Windows AMD ROCm hosts (and everyone else).

### 1. Loading banner on startup

`run_server` logs `run_server startup begin` and then blocks for up to ~2 minutes on `from main import app`, which transitively imports torch, unsloth, transformers and the bitsandbytes DLL. Nothing prints during that window, so the console looks frozen and people assume the launch hung.

This prints a flushed heads-up before the import, plus short progress lines around it:

```
Loading Unsloth Studio, please wait... (this can take a few minutes)
  - loading PyTorch, Unsloth and Transformers...
  - Starting server...
```

`flush=True` is required because a redirected or piped stdout is block buffered and we never leave the import to flush it. All output stays gated on the existing `silent` flag, and the single insertion in `run_server` covers every entry path (CLI, direct `run.py`, the Windows re-exec child, Colab).

### 2. Mute the benign bitsandbytes ROCm override notice

On Windows ROCm, `BNB_ROCM_VERSION` is set (by the installer sitecustomize seed, or by the redetection in `main.py` / `worker.py`), which makes bitsandbytes log this on every import:

```
WARNING: BNB_ROCM_VERSION=72 environment variable detected; loading libbitsandbytes_rocm72.dll. ...
```

The value is correct (it is the only ROCm DLL the wheel ships, and it matches bitsandbytes' own same-major fallback), so the message is pure noise. This attaches a message-scoped `logging.Filter` to the `bitsandbytes.cextension` logger that drops only records containing "environment variable detected", before bitsandbytes imports, in both the server (`main.py`) and the training worker (`worker.py`). Real load failures and the actionable "No prebuilt binary for ROCm x.y, loading z instead" mismatch warning are preserved, and the override itself is unchanged.

## Verification

Booted the server from this branch: the loading banner appears immediately before the slow import, and no bitsandbytes override notice appears in the log even though `BNB_ROCM_VERSION=72` is set and unsloth loads. A direct check confirms the filter drops the benign record and keeps the mismatch warning. `ruff check`, `py_compile` and `ast.parse` pass on all changed files.

Host: Windows 11, Strix Halo (gfx1151), torch 2.11.0+rocm7.13.0.
