### PR TITLE
fix: correct DeepScaleR-1.5B 16bit mapping to its own repo

### DIFF
--- a/tests/test_get_model_name.py
+++ b/tests/test_get_model_name.py
@@ -102,6 +102,19 @@ class TestGetModelName(unittest.TestCase):
             ),
             ("unsloth/Kimi-K2-Instruct", True, "unsloth/Kimi-K2-Instruct-BF16", True),
             ("unsloth/Kimi-K2-Instruct", False, "unsloth/Kimi-K2-Instruct", False),
+            # DeepScaleR-1.5B must resolve to its own 16bit repo, not another model
+            (
+                "agentica-org/DeepScaleR-1.5B-Preview",
+                False,
+                "unsloth/DeepScaleR-1.5B-Preview",
+                True,
+            ),
+            (
+                "agentica-org/DeepScaleR-1.5B-Preview",
+                True,
+                "unsloth/DeepScaleR-1.5B-Preview-unsloth-bnb-4bit",
+                True,
+            ),
             # Fallback-to-original behavior
             "nonexistent-user/nonexistent-model-123",
             "google/gemma-3-random-prototype-123",
@@ -157,6 +170,10 @@ class TestGetModelName(unittest.TestCase):
             with self.subTest(src = src):
                 self.assertEqual(FLOAT_TO_INT_MAPPER[src], expected)
         self.assertEqual(MAP_TO_UNSLOTH_16bit["qwen/qwen3-8b-fp8"], "unsloth/Qwen3-8B-FP8")
+        self.assertEqual(
+            MAP_TO_UNSLOTH_16bit["agentica-org/deepscaler-1.5b-preview"],
+            "unsloth/DeepScaleR-1.5B-Preview",
+        )
 
 
 if __name__ == "__main__":

--- a/unsloth/models/mapper.py
+++ b/unsloth/models/mapper.py
@@ -701,7 +701,7 @@ __INT_TO_FLOAT_MAPPER = \
         "unsloth/Qwen2.5-VL-72B-Instruct-bnb-4bit",
     ),
     "unsloth/DeepScaleR-1.5B-Preview-unsloth-bnb-4bit" : (
-        "unsloth/DeepHermes-3-Llama-3-8B-Preview",
+        "unsloth/DeepScaleR-1.5B-Preview",
         "agentica-org/DeepScaleR-1.5B-Preview",
         "unsloth/DeepScaleR-1.5B-Preview-bnb-4bit",
     ),


### PR DESCRIPTION

### What

In `unsloth/models/mapper.py`, the `__INT_TO_FLOAT_MAPPER` entry keyed by
`unsloth/DeepScaleR-1.5B-Preview-unsloth-bnb-4bit` has its first tuple element
(the 16bit repo) set to an unrelated model:

```python
"unsloth/DeepScaleR-1.5B-Preview-unsloth-bnb-4bit" : (
    "unsloth/DeepHermes-3-Llama-3-8B-Preview",   # <- wrong: unrelated 8B model
    "agentica-org/DeepScaleR-1.5B-Preview",
    "unsloth/DeepScaleR-1.5B-Preview-bnb-4bit",
),
```

The key and the other two elements are all DeepScaleR-1.5B, but the first element
is `unsloth/DeepHermes-3-Llama-3-8B-Preview`, a different NousResearch reasoning
model (Llama-3, 8B) that shares nothing with DeepScaleR-1.5B (Qwen2, ~1.8B). It
looks like a copy-paste from a neighboring entry; `DeepHermes` appears nowhere
else in the file.

For every other entry, that first element is the `unsloth/<name>` 16bit repo that
corresponds to the key. It is what the mapper build loop feeds into
`INT_TO_FLOAT_MAPPER[key]`, and (because it starts with `unsloth`) into the
`MAP_TO_UNSLOTH_16bit` entries for both `agentica-org/DeepScaleR-1.5B-Preview` and
`unsloth/DeepScaleR-1.5B-Preview-bnb-4bit`. So `get_model_name()` silently resolves
DeepScaleR-1.5B (loaded non-4bit, or via the unsloth 16bit remap) to the DeepHermes
8B model, a different architecture roughly 5x the size.

### Fix

Point that first element at `unsloth/DeepScaleR-1.5B-Preview` (which exists on the
Hub and is the 16bit repo of the key), matching the convention of every other
entry. One-line change; no signatures or control flow touched.

### Test

Adds regression coverage to the existing `tests/test_get_model_name.py`:

- Two end-to-end `get_model_name` cases for `agentica-org/DeepScaleR-1.5B-Preview`
  in `test_resolution_matrix` (the 16bit resolution and the 4bit resolution).
- A direct `MAP_TO_UNSLOTH_16bit["agentica-org/deepscaler-1.5b-preview"]` assertion
  in `test_static_mapper_contract`.

The 16bit end-to-end case and the static-contract assertion both fail before the
fix (they resolve to DeepHermes) and pass after.

### Notes

- Single focused change.
- Lint: `ruff check` on both files passes.
- No linked issue exists; found while reading the model mapper.
