### PR TITLE
fix(studio): recover MLX VLM image prompts

### DIFF
--- a/studio/backend/core/inference/mlx_inference.py
+++ b/studio/backend/core/inference/mlx_inference.py
@@ -8,10 +8,94 @@ instead of torch/transformers for model loading and generation.
 import os
 import threading
 from typing import Optional, Generator
+from core.inference.message_content import content_to_text
 from core.inference.runtime_context import runtime_context_length
 from loggers import get_logger
 
 logger = get_logger(__name__)
+
+
+def _mlx_vlm_model_config(model):
+    """Return the loaded MLX model config and its model type."""
+    config = getattr(model, "config", None)
+    if config is None:
+        config = getattr(model, "_config", None)
+    model_type = None
+    if config is not None:
+        model_type = (
+            config.get("model_type")
+            if isinstance(config, dict)
+            else getattr(config, "model_type", None)
+        )
+    return config, model_type
+
+
+def _render_registered_vlm_prompt(processor, model, messages, num_images):
+    """Render through mlx-vlm when it declares a formatter for this model."""
+    from mlx_vlm import prompt_utils
+
+    config, model_type = _mlx_vlm_model_config(model)
+    if config is None:
+        return None
+    if model_type not in getattr(prompt_utils, "MODEL_CONFIG", {}):
+        return None
+
+    rendered = prompt_utils.apply_chat_template(
+        processor,
+        config,
+        messages,
+        add_generation_prompt = True,
+        num_images = num_images,
+    )
+    if isinstance(rendered, str) and rendered.strip():
+        return rendered
+    raise RuntimeError("mlx-vlm's registered renderer returned an empty prompt.")
+
+
+def _count_vlm_images(content):
+    if isinstance(content, list):
+        return sum(_count_vlm_images(item) for item in content)
+    if not isinstance(content, dict):
+        return 0
+    if str(content.get("type", "")).lower() in ("image", "image_url", "input_image"):
+        return 1
+    return _count_vlm_images(content.get("content"))
+
+
+def _prompt_serializes_vlm_media(prompt, messages):
+    """Detect templates that embed the exact structured media object repr."""
+    media_reprs = {
+        str(message.get("content"))
+        for message in messages
+        if isinstance(message, dict) and _count_vlm_images(message.get("content"))
+    }
+    text_content = [
+        content_to_text(message.get("content")) for message in messages if isinstance(message, dict)
+    ]
+    return any(
+        prompt.count(media_repr) > sum(content.count(media_repr) for content in text_content)
+        for media_repr in media_reprs
+    )
+
+
+def _vlm_prompt_issue(prompt, messages):
+    if not isinstance(prompt, str) or not prompt.strip():
+        return "an empty prompt"
+    if _prompt_serializes_vlm_media(prompt, messages):
+        return "serialized structured image content"
+    return None
+
+
+def _vlm_messages_have_tool_history(messages):
+    return any(
+        isinstance(message, dict)
+        and (
+            message.get("role") == "tool"
+            or message.get("tool_calls")
+            or message.get("tool_call_id")
+        )
+        for message in messages
+    )
 
 
 def _build_generation_stats(prompt_n, prompt_tps, gen_n, gen_tps):
@@ -422,9 +506,7 @@ class MLXInferenceBackend:
                             {"type": "text", "text": content},
                         ]
                     elif isinstance(content, list):
-                        has_image = any(
-                            p.get("type") == "image" for p in content if isinstance(p, dict)
-                        )
+                        has_image = _count_vlm_images(content) > 0
                         if not has_image:
                             content.insert(0, {"type": "image"})
                     break
@@ -632,17 +714,87 @@ class MLXInferenceBackend:
         ):
             chat_target = getattr(self._processor, "tokenizer", self._processor)
 
-        prompt = apply_chat_template_for_generation(
-            chat_target,
-            messages,
-            tools = tools,
-            enable_thinking = enable_thinking,
-            reasoning_effort = reasoning_effort,
-            preserve_thinking = preserve_thinking,
-        )
-
         # mlx_vlm's stream_generate handles pixel_values (None for text-only)
         images = [image] if image is not None else None
+        attached_images = 0 if images is None else len(images)
+        structured_images = sum(
+            _count_vlm_images(message.get("content"))
+            for message in messages
+            if isinstance(message, dict)
+        )
+        if structured_images != attached_images:
+            raise RuntimeError(
+                f"VLM conversation contains {structured_images} structured image "
+                f"item(s) for {attached_images} attached image(s)."
+            )
+        prompt = None
+        has_tool_history = _vlm_messages_have_tool_history(messages)
+        prompt_error = None
+        try:
+            prompt = apply_chat_template_for_generation(
+                chat_target,
+                messages,
+                tools = tools,
+                enable_thinking = enable_thinking,
+                reasoning_effort = reasoning_effort,
+                preserve_thinking = preserve_thinking,
+            )
+        except Exception as exc:
+            if images is None or has_tool_history:
+                raise
+            prompt_error = exc
+        prompt_issue = (
+            _vlm_prompt_issue(prompt, messages) if prompt_error is None else "a rendering error"
+        )
+        if prompt_issue and has_tool_history:
+            raise RuntimeError(
+                f"VLM chat template returned {prompt_issue} and cannot be recovered "
+                "without dropping tool-call history."
+            ) from prompt_error
+
+        if images is not None and prompt_issue:
+            if tools or any(
+                value is not None
+                for value in (enable_thinking, reasoning_effort, preserve_thinking)
+            ):
+                if prompt_error is not None:
+                    raise prompt_error
+                raise RuntimeError(
+                    f"VLM chat template returned {prompt_issue} and cannot be recovered "
+                    "without dropping requested tools or reasoning controls."
+                )
+            try:
+                recovered_prompt = _render_registered_vlm_prompt(
+                    self._processor,
+                    self._model,
+                    messages,
+                    len(images),
+                )
+            except Exception as recovery_error:
+                if prompt_error is not None:
+                    raise prompt_error
+                raise RuntimeError(
+                    f"VLM chat template returned {prompt_issue}; model-aware "
+                    f"recovery failed: {recovery_error}"
+                ) from recovery_error
+            if recovered_prompt is None:
+                if prompt_error is not None:
+                    raise prompt_error
+                raise RuntimeError(
+                    f"VLM chat template returned {prompt_issue}, and no registered "
+                    "MLX VLM renderer was available for this model."
+                )
+            recovered_issue = _vlm_prompt_issue(recovered_prompt, messages)
+            if recovered_issue:
+                if prompt_error is not None:
+                    raise prompt_error
+                raise RuntimeError(
+                    f"Model-aware VLM rendering returned {recovered_issue} for "
+                    f"{attached_images} attached image(s)."
+                )
+            prompt = recovered_prompt
+        elif prompt_issue:
+            raise RuntimeError(f"VLM chat template returned {prompt_issue}.") from prompt_error
 
         from core.inference.chat_template_helpers import detect_think_prefill
 

--- a/studio/backend/core/inference/mlx_inference.py
+++ b/studio/backend/core/inference/mlx_inference.py
@@ -5,6 +5,7 @@ Drop-in replacement for InferenceBackend — same interface, uses mlx-lm/mlx-vlm
 instead of torch/transformers for model loading and generation.
 """
 
+import json
 import os
 import threading
 from typing import Optional, Generator
@@ -62,13 +63,29 @@ def _count_vlm_images(content):
     return _count_vlm_images(content.get("content"))
 
 
+def _vlm_media_reprs(content):
+    if isinstance(content, list):
+        values = (
+            {str(content), json.dumps(content, ensure_ascii = False)}
+            if _count_vlm_images(content)
+            else set()
+        )
+        for item in content:
+            values.update(_vlm_media_reprs(item))
+        return values
+    if not isinstance(content, dict):
+        return set()
+    if str(content.get("type", "")).lower() in ("image", "image_url", "input_image"):
+        return {str(content), json.dumps(content, ensure_ascii = False)}
+    return _vlm_media_reprs(content.get("content"))
+
+
 def _prompt_serializes_vlm_media(prompt, messages):
     """Detect templates that embed the exact structured media object repr."""
-    media_reprs = {
-        str(message.get("content"))
-        for message in messages
-        if isinstance(message, dict) and _count_vlm_images(message.get("content"))
-    }
+    media_reprs = set()
+    for message in messages:
+        if isinstance(message, dict):
+            media_reprs.update(_vlm_media_reprs(message.get("content")))
     text_content = [
         content_to_text(message.get("content")) for message in messages if isinstance(message, dict)
     ]

--- a/studio/backend/core/inference/mlx_inference.py
+++ b/studio/backend/core/inference/mlx_inference.py
@@ -19,11 +19,13 @@ logger = get_logger(__name__)
 def _mlx_vlm_model_config(model):
     """Return the loaded MLX model config and its type, preferring whichever of
     config / _config actually carries a model_type."""
+
     def _model_type(cfg):
         return cfg.get("model_type") if isinstance(cfg, dict) else getattr(cfg, "model_type", None)
 
     configs = [
-        cfg for cfg in (getattr(model, "config", None), getattr(model, "_config", None))
+        cfg
+        for cfg in (getattr(model, "config", None), getattr(model, "_config", None))
         if cfg is not None
     ]
     for cfg in configs:

--- a/studio/backend/core/inference/mlx_inference.py
+++ b/studio/backend/core/inference/mlx_inference.py
@@ -17,18 +17,20 @@ logger = get_logger(__name__)
 
 
 def _mlx_vlm_model_config(model):
-    """Return the loaded MLX model config and its model type."""
-    config = getattr(model, "config", None)
-    if config is None:
-        config = getattr(model, "_config", None)
-    model_type = None
-    if config is not None:
-        model_type = (
-            config.get("model_type")
-            if isinstance(config, dict)
-            else getattr(config, "model_type", None)
-        )
-    return config, model_type
+    """Return the loaded MLX model config and its type, preferring whichever of
+    config / _config actually carries a model_type."""
+    def _model_type(cfg):
+        return cfg.get("model_type") if isinstance(cfg, dict) else getattr(cfg, "model_type", None)
+
+    configs = [
+        cfg for cfg in (getattr(model, "config", None), getattr(model, "_config", None))
+        if cfg is not None
+    ]
+    for cfg in configs:
+        model_type = _model_type(cfg)
+        if model_type is not None:
+            return cfg, model_type
+    return (configs[0] if configs else None), None
 
 
 def _render_registered_vlm_prompt(processor, model, messages, num_images):

--- a/studio/backend/tests/test_mlx_inference_backend.py
+++ b/studio/backend/tests/test_mlx_inference_backend.py
@@ -440,7 +440,8 @@ def test_mlx_vlm_model_config_prefers_config_with_model_type():
     assert _mlx_vlm_model_config(m)[1] == "qwen2_vl"
     # a config that already carries a model_type is preferred and returned unchanged
     assert _mlx_vlm_model_config(SimpleNamespace(config = {"model_type": "gemma3"})) == (
-        {"model_type": "gemma3"}, "gemma3"
+        {"model_type": "gemma3"},
+        "gemma3",
     )
 
 

--- a/studio/backend/tests/test_mlx_inference_backend.py
+++ b/studio/backend/tests/test_mlx_inference_backend.py
@@ -429,6 +429,21 @@ def test_mlx_vlm_image_injection_reuses_media_aliases(monkeypatch):
     assert captured[0][0]["content"] == [{"type": "image_url"}]
 
 
+def test_mlx_vlm_model_config_prefers_config_with_model_type():
+    from core.inference.mlx_inference import _mlx_vlm_model_config
+
+    # config present but missing model_type must fall back to _config
+    m = SimpleNamespace(config = {}, _config = {"model_type": "deepseek_vl_v2"})
+    assert _mlx_vlm_model_config(m) == ({"model_type": "deepseek_vl_v2"}, "deepseek_vl_v2")
+    # an object config whose model_type is None also falls back
+    m = SimpleNamespace(config = SimpleNamespace(model_type = None), _config = {"model_type": "qwen2_vl"})
+    assert _mlx_vlm_model_config(m)[1] == "qwen2_vl"
+    # a config that already carries a model_type is preferred and returned unchanged
+    assert _mlx_vlm_model_config(SimpleNamespace(config = {"model_type": "gemma3"})) == (
+        {"model_type": "gemma3"}, "gemma3"
+    )
+
+
 def test_mlx_generate_text_forwards_kwargs_into_template_helper(monkeypatch):
     """Mac text path must route through apply_chat_template_for_generation so
     reasoning / tool kwargs reach the tokenizer."""

--- a/studio/backend/tests/test_mlx_inference_backend.py
+++ b/studio/backend/tests/test_mlx_inference_backend.py
@@ -404,10 +404,18 @@ def test_mlx_vlm_image_injection_reuses_media_aliases(monkeypatch):
 
     media = [{"type": "image"}]
     quoted = [{"role": "user", "content": media}, {"role": "user", "content": f"Explain {media}"}]
+    assert _prompt_serializes_vlm_media(f"<image>\n{media[0]}", quoted[:1])
     assert not _prompt_serializes_vlm_media(f"<image>\nExplain {media}", quoted)
     assert _prompt_serializes_vlm_media(f"User: {media}\nExplain {media}", quoted)
     quoted[1]["content"] = [{"type": "text", "text": f'Explain "this" {media}'}]
     assert not _prompt_serializes_vlm_media(f'<image>\nExplain "this" {media}', quoted)
+    json_media = [{"type": "image_url"}]
+    json_repr = '{"type": "image_url"}'
+    assert _prompt_serializes_vlm_media(f"<image>\n{json_repr}", [{"content": json_media}])
+    assert not _prompt_serializes_vlm_media(
+        f"<image>\nExplain {json_repr}",
+        [{"content": json_media}, {"content": f"Explain {json_repr}"}],
+    )
 
     backend = MLXInferenceBackend()
     backend._model = object()

--- a/studio/backend/tests/test_mlx_inference_backend.py
+++ b/studio/backend/tests/test_mlx_inference_backend.py
@@ -333,6 +333,94 @@ def test_mlx_generate_chat_response_accepts_template_kwargs():
         ), f"{name!r} must default to None so existing callers stay valid"
 
 
+def test_mlx_vlm_generation_selects_renderer_by_capability(monkeypatch):
+    from core.inference.mlx_inference import MLXInferenceBackend
+
+    calls = {"generic": [], "model": [], "stream": []}
+    state = {"generic": "serialized", "model": "<image> model-aware"}
+    prompt_utils = SimpleNamespace(
+        MODEL_CONFIG = {"deepseek_vl_v2": object()},
+        apply_chat_template = lambda *_args, **kwargs: (
+            calls["model"].append(kwargs) or state["model"]
+        ),
+    )
+    mlx_vlm = types.ModuleType("mlx_vlm")
+    mlx_vlm.prompt_utils = prompt_utils
+    mlx_vlm.stream_generate = lambda *_args, **kwargs: (
+        calls["stream"].append((_args, kwargs))
+        or iter([SimpleNamespace(text = "ok", prompt_tokens = 3, generation_tokens = 1)])
+    )
+    monkeypatch.setitem(sys.modules, "mlx_vlm", mlx_vlm)
+
+    def generic(_target, _messages, **kwargs):
+        calls["generic"].append(kwargs)
+        if isinstance(state["generic"], Exception):
+            raise state["generic"]
+        if state["generic"] == "serialized":
+            return f"User: {_messages[0]['content']}"
+        return state["generic"]
+
+    monkeypatch.setattr(
+        "core.inference.chat_template_helpers.apply_chat_template_for_generation",
+        generic,
+    )
+    backend = MLXInferenceBackend()
+    backend._model = SimpleNamespace(config = {"model_type": "deepseek_vl_v2"})
+    backend._processor = SimpleNamespace(tokenizer = SimpleNamespace())
+    args = ([{"role": "user", "content": [{"type": "image"}]}], object(), 0, 1, 0, 0, 1, 1, None)
+    tools = [{"function": {"name": "search"}}]
+    assert list(backend._generate_vlm(*args)) == ["ok"]
+    assert calls["model"][0]["num_images"] == 1
+    assert calls["stream"][0][0][2] == "<image> model-aware"
+    with pytest.raises(RuntimeError, match = "dropping requested tools"):
+        list(backend._generate_vlm(*args, tools = tools))
+    with pytest.raises(RuntimeError, match = "dropping requested tools or reasoning"):
+        list(backend._generate_vlm(*args, enable_thinking = False))
+    backend._processor = SimpleNamespace(chat_template = "template")
+    state["generic"] = "<image> healthy generic"
+    assert list(backend._generate_vlm(*args, tools = tools, enable_thinking = False)) == ["ok"]
+    assert calls["generic"][-1]["enable_thinking"] is False
+    assert calls["stream"][-1][0][2] == "<image> healthy generic"
+    state["generic"] = "generic prompt"
+    text_messages = [{"role": "user", "content": "hello"}]
+    assert list(backend._generate_vlm(*((text_messages, None) + args[2:]), tools = tools)) == ["ok"]
+    assert calls["generic"][-1]["tools"] == tools
+    assert calls["stream"][-1][0][2] == "generic prompt"
+    two_images = [{"role": "user", "content": [{"type": "image"}, {"type": "image"}]}]
+    with pytest.raises(RuntimeError, match = "2 structured image item"):
+        list(backend._generate_vlm(*((two_images,) + args[1:]), tools = tools))
+    state["generic"] = "serialized"
+    tool_history = args[0] + [{"role": "assistant", "tool_calls": [{"id": "call-1"}]}]
+    with pytest.raises(RuntimeError, match = "tool-call history"):
+        list(backend._generate_vlm(*((tool_history,) + args[1:]), tools = tools))
+    state["generic"] = ValueError("generic rendering failed")
+    state["model"] = f"User: {args[0][0]['content']}"
+    with pytest.raises(ValueError, match = "generic rendering failed"):
+        list(backend._generate_vlm(*args))
+
+
+def test_mlx_vlm_image_injection_reuses_media_aliases(monkeypatch):
+    from core.inference.mlx_inference import MLXInferenceBackend, _prompt_serializes_vlm_media
+
+    media = [{"type": "image"}]
+    quoted = [{"role": "user", "content": media}, {"role": "user", "content": f"Explain {media}"}]
+    assert not _prompt_serializes_vlm_media(f"<image>\nExplain {media}", quoted)
+    assert _prompt_serializes_vlm_media(f"User: {media}\nExplain {media}", quoted)
+    quoted[1]["content"] = [{"type": "text", "text": f'Explain "this" {media}'}]
+    assert not _prompt_serializes_vlm_media(f'<image>\nExplain "this" {media}', quoted)
+
+    backend = MLXInferenceBackend()
+    backend._model = object()
+    backend._is_vlm = True
+    captured = []
+    backend._generate_vlm = lambda messages, *_args, **_kwargs: (
+        captured.append(messages) or iter(())
+    )
+    messages = [{"role": "user", "content": [{"type": "image_url"}]}]
+    list(backend.generate_chat_response(messages, image = object()))
+    assert captured[0][0]["content"] == [{"type": "image_url"}]
+
+
 def test_mlx_generate_text_forwards_kwargs_into_template_helper(monkeypatch):
     """Mac text path must route through apply_chat_template_for_generation so
     reasoning / tool kwargs reach the tokenizer."""


### PR DESCRIPTION
## Summary

Restore model-aware prompt rendering for MLX vision-language chat when Studio's generic chat-template path serializes structured image content instead of emitting the model's media marker.

This keeps the existing generic renderer as the primary path for healthy processors, including text-only VLM turns, tools, and reasoning controls. Recovery is activated only for malformed or failed image prompt rendering and only when mlx-vlm registers a formatter for the loaded model type.

## Root Cause

Studio normally formats MLX chat requests through the shared chat-template helper. Some VLM processors, including DeepSeek-VL2, expect a text-oriented conversation shape and can render an OpenAI-style structured image list as literal Python-like content. The image still reaches mlx-vlm, but the prompt no longer contains the model-specific media token, so preprocessing or generation fails downstream.

Using mlx-vlm's renderer unconditionally would create a different regression: release renderers do not consistently preserve Studio's tool history, tool declarations, or reasoning controls. The fix therefore detects the malformed generic result and performs a capability-gated recovery rather than replacing the normal path.

## What Changed

- Detect empty prompts and extra serialized full content lists or individual image items in Python-repr or Transformers-JSON form, while discounting exact representations quoted in user text.
- Count `image`, `image_url`, and `input_image` aliases recursively and require the structured media count to match the attached images.
- Resolve the loaded MLX model type from either `config` or `_config`.
- Recover through `mlx_vlm.prompt_utils.apply_chat_template()` only when that model type is present in mlx-vlm's `MODEL_CONFIG` registry.
- Preserve the healthy generic prompt byte-for-byte when no issue is detected.
- Preserve text-only VLM behavior and continue forwarding tools and reasoning controls through Studio's shared helper.
- Refuse lossy recovery when tool-call history, requested tools, or explicit reasoning controls would be dropped.
- Raise precise prompt-contract errors when no safe registered recovery exists.
- Reuse existing structured media aliases during Studio image injection instead of inserting a duplicate placeholder.

## User Impact

Image chat for affected MLX VLMs now reaches generation with the model's expected image marker. Healthy Qwen, Gemma, Phi, and text-only prompt paths retain their existing rendering behavior. Unsupported combinations fail before model execution with an actionable prompt error instead of a later processor assertion.

## Validation

```bash
python -m pytest studio/backend/tests/test_mlx_inference_backend.py -q
# 12 passed

python -m py_compile \
  studio/backend/core/inference/mlx_inference.py \
  studio/backend/tests/test_mlx_inference_backend.py

ruff check --select E9,F63,F7,F82 \
  studio/backend/core/inference/mlx_inference.py \
  studio/backend/tests/test_mlx_inference_backend.py

git diff --check origin/main...HEAD
```

The branch was rebased onto current `main` before validation. No dependency or lockfile changes are included.

Real-model validation performed during implementation confirmed:

- DeepSeek-VL2 tiny preprocessing produced model-ready image tensors and completed Studio-shaped generation.
- Phi retained its model-specific image token dialect.
- Healthy Qwen and Gemma prompt paths remained on their existing renderer.

## Risk

The change is scoped to Studio's MLX VLM path. Recovery requires all of the following: an attached image, an invalid generic prompt, no lossy tool/reasoning state, a loaded model config, and a renderer registered by mlx-vlm for that exact model type. Requests outside that boundary retain existing behavior.
