### PR TITLE
Studio: remove AGENTS.md and CLAUDE.md from install artifacts

### DIFF
--- a/studio/frontend/src/i18n/README.md
+++ b/studio/frontend/src/i18n/README.md
@@ -1,4 +1,4 @@
-# i18n Contribution Instructions
+# i18n Contribution Guide
 
 - `locales/en.ts` is the complete baseline message file.
 - Non-English locale files may be partial. Missing keys must fall back to English at runtime.

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -6861,7 +6861,9 @@ def install_prebuilt(
             if (install_dir / "UNSLOTH_PREBUILT_INFO.json").is_file():
                 removed = remove_agent_instruction_files(install_dir)
                 if removed:
-                    log(f"removed {removed} contributor-only agent instruction file(s) from install")
+                    log(
+                        f"removed {removed} contributor-only agent instruction file(s) from install"
+                    )
             if install_dir.exists():
                 log(
                     f"existing llama.cpp install detected at {install_dir}; validating staged prebuilt update before replacement"

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4392,8 +4392,6 @@ def _is_link_or_junction(path: Path) -> bool:
         if path.is_symlink():
             return True
     except OSError:
-        # Cleanup is optional. If link ownership cannot be established, preserve
-        # the path rather than risk deleting files outside the managed tree.
         return True
 
     is_junction = getattr(path, "is_junction", None)
@@ -4404,8 +4402,7 @@ def _is_link_or_junction(path: Path) -> bool:
         except OSError:
             return True
 
-    # Path.is_junction was added in Python 3.12, while Studio also supports
-    # Python 3.10 and 3.11. Detect Windows reparse points on those versions.
+    # Path.is_junction is unavailable on Python 3.10 and 3.11.
     if os.name == "nt":
         try:
             attributes = getattr(path.lstat(), "st_file_attributes", 0)
@@ -4423,9 +4420,7 @@ def remove_agent_instruction_files(root: Path) -> int:
     removed = 0
     for current_dir, dirnames, filenames in os.walk(root, topdown = True, followlinks = False):
         current_path = Path(current_dir)
-        # os.walk(followlinks=False) excludes symbolic links but follows Windows
-        # directory junctions. Prune every redirect explicitly, and re-check a
-        # yielded directory to limit link-swap races between iterations.
+        # followlinks=False still follows Windows junctions.
         if current_path != root and _is_link_or_junction(current_path):
             dirnames.clear()
             continue
@@ -4437,7 +4432,6 @@ def remove_agent_instruction_files(root: Path) -> int:
             try:
                 candidate.unlink()
             except FileNotFoundError:
-                # Another cleanup may have won the race.
                 continue
             except OSError as exc:
                 log(f"could not remove contributor-only instruction {candidate}: {exc}")
@@ -6902,9 +6896,6 @@ def install_prebuilt(
     choice: AssetChoice | None = None
     try:
         with install_lock(install_lock_path(install_dir)):
-            # Upgrade an existing managed prebuilt in place as well as fresh
-            # staging trees, so installs made before this cleanup do not retain
-            # upstream contributor instructions on a tag-match fast path.
             if (install_dir / "UNSLOTH_PREBUILT_INFO.json").is_file():
                 removed = remove_agent_instruction_files(install_dir)
                 if removed:
@@ -7242,9 +7233,7 @@ def main() -> int:
     global _LOG_TO_STDOUT
     _LOG_TO_STDOUT = True
     install_prebuilt(
-        # Keep the lexical install path so link/junction ownership checks remain
-        # effective. Path.resolve() would collapse a user-owned linked root before
-        # remove_agent_instruction_files() can identify and preserve it.
+        # Preserve link identity for cleanup ownership checks.
         install_dir = Path(args.install_dir).expanduser().absolute(),
         llama_tag = args.llama_tag,
         published_repo = args.published_repo,

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -20,6 +20,7 @@ import re
 import shutil
 import site
 import socket
+import stat
 import struct
 import subprocess
 import sys
@@ -4385,17 +4386,63 @@ def copy_directory_contents(source_dir: Path, destination: Path) -> None:
             shutil.copy2(item, target)
 
 
+def _is_link_or_junction(path: Path) -> bool:
+    """Return whether ``path`` redirects to another filesystem location."""
+    try:
+        if path.is_symlink():
+            return True
+    except OSError:
+        # Cleanup is optional. If link ownership cannot be established, preserve
+        # the path rather than risk deleting files outside the managed tree.
+        return True
+
+    is_junction = getattr(path, "is_junction", None)
+    if is_junction is not None:
+        try:
+            if is_junction():
+                return True
+        except OSError:
+            return True
+
+    # Path.is_junction was added in Python 3.12, while Studio also supports
+    # Python 3.10 and 3.11. Detect Windows reparse points on those versions.
+    if os.name == "nt":
+        try:
+            attributes = getattr(path.lstat(), "st_file_attributes", 0)
+        except OSError:
+            return True
+        return bool(attributes & stat.FILE_ATTRIBUTE_REPARSE_POINT)
+    return False
+
+
 def remove_agent_instruction_files(root: Path) -> int:
-    """Remove contributor-only agent instructions without following linked roots."""
-    if root.is_symlink() or not root.is_dir():
+    """Best-effort removal inside a managed tree without following links."""
+    if _is_link_or_junction(root) or not root.is_dir():
         return 0
 
     removed = 0
-    for current_dir, _, filenames in os.walk(root, followlinks = False):
+    for current_dir, dirnames, filenames in os.walk(root, topdown = True, followlinks = False):
+        current_path = Path(current_dir)
+        # os.walk(followlinks=False) excludes symbolic links but follows Windows
+        # directory junctions. Prune every redirect explicitly, and re-check a
+        # yielded directory to limit link-swap races between iterations.
+        if current_path != root and _is_link_or_junction(current_path):
+            dirnames.clear()
+            continue
+        dirnames[:] = [
+            dirname for dirname in dirnames if not _is_link_or_junction(current_path / dirname)
+        ]
         for filename in sorted({"AGENTS.md", "CLAUDE.md"}.intersection(filenames)):
-            candidate = Path(current_dir) / filename
-            candidate.unlink()
-            removed += 1
+            candidate = current_path / filename
+            try:
+                candidate.unlink()
+            except FileNotFoundError:
+                # Another cleanup may have won the race.
+                continue
+            except OSError as exc:
+                log(f"could not remove contributor-only instruction {candidate}: {exc}")
+            else:
+                removed += 1
     return removed
 
 
@@ -7195,7 +7242,10 @@ def main() -> int:
     global _LOG_TO_STDOUT
     _LOG_TO_STDOUT = True
     install_prebuilt(
-        install_dir = Path(args.install_dir).expanduser().resolve(),
+        # Keep the lexical install path so link/junction ownership checks remain
+        # effective. Path.resolve() would collapse a user-owned linked root before
+        # remove_agent_instruction_files() can identify and preserve it.
+        install_dir = Path(args.install_dir).expanduser().absolute(),
         llama_tag = args.llama_tag,
         published_repo = args.published_repo,
         published_release_tag = args.published_release_tag or "",

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4386,17 +4386,16 @@ def copy_directory_contents(source_dir: Path, destination: Path) -> None:
 
 
 def remove_agent_instruction_files(root: Path) -> int:
-    """Remove contributor-only AGENTS.md files without following linked roots."""
+    """Remove contributor-only agent instructions without following linked roots."""
     if root.is_symlink() or not root.is_dir():
         return 0
 
     removed = 0
     for current_dir, _, filenames in os.walk(root, followlinks = False):
-        if "AGENTS.md" not in filenames:
-            continue
-        candidate = Path(current_dir) / "AGENTS.md"
-        candidate.unlink()
-        removed += 1
+        for filename in sorted({"AGENTS.md", "CLAUDE.md"}.intersection(filenames)):
+            candidate = Path(current_dir) / filename
+            candidate.unlink()
+            removed += 1
     return removed
 
 
@@ -4464,7 +4463,7 @@ def hydrate_source_tree(
         copy_directory_contents(source_root, install_dir)
         removed = remove_agent_instruction_files(install_dir)
         if removed:
-            log(f"removed {removed} contributor-only AGENTS.md file(s) from staged source")
+            log(f"removed {removed} contributor-only agent instruction file(s) from staged source")
     except PrebuiltFallback:
         raise
     except Exception as exc:
@@ -6862,7 +6861,7 @@ def install_prebuilt(
             if (install_dir / "UNSLOTH_PREBUILT_INFO.json").is_file():
                 removed = remove_agent_instruction_files(install_dir)
                 if removed:
-                    log(f"removed {removed} contributor-only AGENTS.md file(s) from install")
+                    log(f"removed {removed} contributor-only agent instruction file(s) from install")
             if install_dir.exists():
                 log(
                     f"existing llama.cpp install detected at {install_dir}; validating staged prebuilt update before replacement"

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4385,6 +4385,21 @@ def copy_directory_contents(source_dir: Path, destination: Path) -> None:
             shutil.copy2(item, target)
 
 
+def remove_agent_instruction_files(root: Path) -> int:
+    """Remove contributor-only AGENTS.md files without following linked roots."""
+    if root.is_symlink() or not root.is_dir():
+        return 0
+
+    removed = 0
+    for current_dir, _, filenames in os.walk(root, followlinks = False):
+        if "AGENTS.md" not in filenames:
+            continue
+        candidate = Path(current_dir) / "AGENTS.md"
+        candidate.unlink()
+        removed += 1
+    return removed
+
+
 def hydrate_source_tree(
     source_ref: str,
     install_dir: Path,
@@ -4447,6 +4462,9 @@ def hydrate_source_tree(
                 "upstream source archive was missing required repo files: " + ", ".join(missing)
             )
         copy_directory_contents(source_root, install_dir)
+        removed = remove_agent_instruction_files(install_dir)
+        if removed:
+            log(f"removed {removed} contributor-only AGENTS.md file(s) from staged source")
     except PrebuiltFallback:
         raise
     except Exception as exc:
@@ -6838,6 +6856,13 @@ def install_prebuilt(
     choice: AssetChoice | None = None
     try:
         with install_lock(install_lock_path(install_dir)):
+            # Upgrade an existing managed prebuilt in place as well as fresh
+            # staging trees, so installs made before this cleanup do not retain
+            # upstream contributor instructions on a tag-match fast path.
+            if (install_dir / "UNSLOTH_PREBUILT_INFO.json").is_file():
+                removed = remove_agent_instruction_files(install_dir)
+                if removed:
+                    log(f"removed {removed} contributor-only AGENTS.md file(s) from install")
             if install_dir.exists():
                 log(
                     f"existing llama.cpp install detected at {install_dir}; validating staged prebuilt update before replacement"

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -6882,6 +6882,7 @@ def install_prebuilt(
     override_has_rocm: bool = False,
     override_rocm_gfx: str | None = None,
     force_cpu: bool = False,
+    instruction_cleanup_root: Path | None = None,
 ) -> None:
     host = detect_host()
     host = _apply_host_overrides(
@@ -6894,10 +6895,11 @@ def install_prebuilt(
         host, published_repo, published_release_tag, force_cpu = force_cpu
     )
     choice: AssetChoice | None = None
+    cleanup_root = install_dir if instruction_cleanup_root is None else instruction_cleanup_root
     try:
         with install_lock(install_lock_path(install_dir)):
             if (install_dir / "UNSLOTH_PREBUILT_INFO.json").is_file():
-                removed = remove_agent_instruction_files(install_dir)
+                removed = remove_agent_instruction_files(cleanup_root)
                 if removed:
                     log(
                         f"removed {removed} contributor-only agent instruction file(s) from install"
@@ -7232,15 +7234,16 @@ def main() -> int:
     # Install path only: route status logs to stdout (see _LOG_TO_STDOUT note).
     global _LOG_TO_STDOUT
     _LOG_TO_STDOUT = True
+    install_arg = Path(args.install_dir).expanduser()
     install_prebuilt(
-        # Preserve link identity for cleanup ownership checks.
-        install_dir = Path(args.install_dir).expanduser().absolute(),
+        install_dir = install_arg.resolve(),
         llama_tag = args.llama_tag,
         published_repo = args.published_repo,
         published_release_tag = args.published_release_tag or "",
         override_has_rocm = args.has_rocm,
         override_rocm_gfx = args.rocm_gfx,
         force_cpu = args.cpu_fallback,
+        instruction_cleanup_root = install_arg.absolute(),
     )
     return EXIT_SUCCESS
 

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4388,28 +4388,16 @@ def copy_directory_contents(source_dir: Path, destination: Path) -> None:
 
 def _is_link_or_junction(path: Path) -> bool:
     """Return whether ``path`` redirects to another filesystem location."""
-    try:
-        if path.is_symlink():
-            return True
-    except OSError:
-        return True
-
-    is_junction = getattr(path, "is_junction", None)
-    if is_junction is not None:
-        try:
-            if is_junction():
-                return True
-        except OSError:
-            return True
-
-    # Path.is_junction is unavailable on Python 3.10 and 3.11.
     if os.name == "nt":
         try:
             attributes = getattr(path.lstat(), "st_file_attributes", 0)
         except OSError:
             return True
         return bool(attributes & stat.FILE_ATTRIBUTE_REPARSE_POINT)
-    return False
+    try:
+        return path.is_symlink()
+    except OSError:
+        return True
 
 
 def remove_agent_instruction_files(root: Path) -> int:

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -211,9 +211,20 @@ function Remove-AgentInstructionFiles {
         $item = Get-Item -LiteralPath $root -Force -ErrorAction SilentlyContinue
         if (-not $item -or -not $item.PSIsContainer) { continue }
         if ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) { continue }
-        Get-ChildItem -LiteralPath $root -Include "AGENTS.md", "CLAUDE.md" -File -Recurse -Force `
-            -ErrorAction SilentlyContinue |
-            Remove-Item -Force -ErrorAction SilentlyContinue
+        $pending = New-Object System.Collections.Stack
+        $pending.Push($item)
+        while ($pending.Count -gt 0) {
+            $current = $pending.Pop()
+            foreach ($child in @(Get-ChildItem -LiteralPath $current.FullName -Force -ErrorAction SilentlyContinue)) {
+                if ($child.PSIsContainer) {
+                    if (-not ($child.Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {
+                        $pending.Push($child)
+                    }
+                } elseif ($child.Name -in @("AGENTS.md", "CLAUDE.md")) {
+                    Remove-Item -LiteralPath $child.FullName -Force -ErrorAction SilentlyContinue
+                }
+            }
+        }
     }
 }
 

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -203,6 +203,23 @@ function New-UnslothTemporaryFile {
     return Get-Item -LiteralPath $tempPath
 }
 
+# AGENTS.md files are contributor/agent instructions, not Studio runtime data.
+# Do not traverse a linked root because --with-llama-cpp-dir points at a
+# user-owned checkout.
+function Remove-AgentInstructionFiles {
+    param([string[]]$Roots)
+
+    foreach ($root in $Roots) {
+        if (-not $root) { continue }
+        $item = Get-Item -LiteralPath $root -Force -ErrorAction SilentlyContinue
+        if (-not $item -or -not $item.PSIsContainer) { continue }
+        if ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) { continue }
+        Get-ChildItem -LiteralPath $root -Filter "AGENTS.md" -File -Recurse -Force `
+            -ErrorAction SilentlyContinue |
+            Remove-Item -Force -ErrorAction SilentlyContinue
+    }
+}
+
 function Get-InstalledLlamaPrebuiltRelease {
     param([string]$InstallDir)
 
@@ -2314,6 +2331,8 @@ if ((Test-Path $OxcValidatorDir) -and $NodeSource -ne "skip" -and (Get-Command n
     substep "OXC validator runtime skipped (no npm found); code validation degrades until Node is available" "Yellow"
 }
 
+Remove-AgentInstructionFiles -Roots @($FrontendDir, $OxcValidatorDir)
+
 # ==========================================================================
 #  PHASE 3: Python environment + dependencies
 # ==========================================================================
@@ -4022,6 +4041,12 @@ if ($LocalLlamaCppLinked) {
             $script:LlamaCppDegraded = $true
         }
     }
+}
+
+# A managed source build clones the complete llama.cpp repository. Prune its
+# contributor-only instructions, but never mutate a user-provided linked tree.
+if (-not $LocalLlamaCppLinked) {
+    Remove-AgentInstructionFiles -Roots @($LlamaCppDir)
 }
 
 # ─────────────────────────────────────────────

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -4052,7 +4052,13 @@ if ($LocalLlamaCppLinked) {
     }
 }
 
-if (-not $LocalLlamaCppLinked) {
+$llamaCppItem = Get-Item -LiteralPath $LlamaCppDir -Force -ErrorAction SilentlyContinue
+$llamaCppIsLink = $llamaCppItem -and ($llamaCppItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint)
+if (-not $llamaCppIsLink -and (
+        -not $StudioHomeIsCustom -or
+        (Test-Path -LiteralPath (Join-Path $LlamaCppDir $StudioOwnedMarker) -PathType Leaf) -or
+        (Test-StudioOwnedAdoptable $LlamaCppDir)
+    )) {
     Remove-AgentInstructionFiles -Roots @($LlamaCppDir)
 }
 

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -203,9 +203,6 @@ function New-UnslothTemporaryFile {
     return Get-Item -LiteralPath $tempPath
 }
 
-# AGENTS.md and CLAUDE.md are contributor/agent instructions, not Studio runtime
-# data. Do not traverse a linked root because --with-llama-cpp-dir points at a
-# user-owned checkout.
 function Remove-AgentInstructionFiles {
     param([string[]]$Roots)
 
@@ -3278,8 +3275,6 @@ if ($LocalLlamaCppSrc) {
         if ($LASTEXITCODE -ne 0) {
             substep "Could not create directory junction; copying instead..." "Yellow"
             Copy-Item -Recurse -LiteralPath $ResolvedLocal -Destination $LlamaCppDir
-            # The fallback is a Studio-owned copy, not a link into the user's
-            # checkout, so it is safe and necessary to prune the copied files.
             Remove-AgentInstructionFiles -Roots @($LlamaCppDir)
         }
         Write-Host ""
@@ -4046,8 +4041,6 @@ if ($LocalLlamaCppLinked) {
     }
 }
 
-# A managed source build clones the complete llama.cpp repository. Prune its
-# contributor-only instructions, but never mutate a user-provided linked tree.
 if (-not $LocalLlamaCppLinked) {
     Remove-AgentInstructionFiles -Roots @($LlamaCppDir)
 }

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -203,8 +203,8 @@ function New-UnslothTemporaryFile {
     return Get-Item -LiteralPath $tempPath
 }
 
-# AGENTS.md files are contributor/agent instructions, not Studio runtime data.
-# Do not traverse a linked root because --with-llama-cpp-dir points at a
+# AGENTS.md and CLAUDE.md are contributor/agent instructions, not Studio runtime
+# data. Do not traverse a linked root because --with-llama-cpp-dir points at a
 # user-owned checkout.
 function Remove-AgentInstructionFiles {
     param([string[]]$Roots)
@@ -214,7 +214,7 @@ function Remove-AgentInstructionFiles {
         $item = Get-Item -LiteralPath $root -Force -ErrorAction SilentlyContinue
         if (-not $item -or -not $item.PSIsContainer) { continue }
         if ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) { continue }
-        Get-ChildItem -LiteralPath $root -Filter "AGENTS.md" -File -Recurse -Force `
+        Get-ChildItem -LiteralPath $root -Include "AGENTS.md", "CLAUDE.md" -File -Recurse -Force `
             -ErrorAction SilentlyContinue |
             Remove-Item -Force -ErrorAction SilentlyContinue
     }

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -3278,6 +3278,9 @@ if ($LocalLlamaCppSrc) {
         if ($LASTEXITCODE -ne 0) {
             substep "Could not create directory junction; copying instead..." "Yellow"
             Copy-Item -Recurse -LiteralPath $ResolvedLocal -Destination $LlamaCppDir
+            # The fallback is a Studio-owned copy, not a link into the user's
+            # checkout, so it is safe and necessary to prune the copied files.
+            Remove-AgentInstructionFiles -Roots @($LlamaCppDir)
         }
         Write-Host ""
         step "llama.cpp" "linked local directory: $ResolvedLocal"

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -74,10 +74,6 @@ verbose_substep() {
     return 0
 }
 
-# AGENTS.md and CLAUDE.md are contributor/agent instructions, not Studio runtime
-# data. Upstream npm packages may publish them, so remove them from dependency
-# trees after installation. Never follow a linked root: --with-llama-cpp-dir
-# points at a user-owned checkout and must remain under the user's control.
 _remove_agent_instruction_files() {
     local _root
     for _root in "$@"; do
@@ -1935,9 +1931,6 @@ if [ "$_LLAMA_CPP_DEGRADED" = true ] \
     fi
 fi
 
-# The managed source-build path clones a complete llama.cpp repository. Keep
-# contributor-only agent instructions out of the installed runtime, while
-# leaving a user-supplied --with-llama-cpp-dir tree untouched.
 if [ "${_LOCAL_LLAMA_CPP_LINKED:-false}" != true ]; then
     _remove_agent_instruction_files "$LLAMA_CPP_DIR"
 fi

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -74,6 +74,19 @@ verbose_substep() {
     return 0
 }
 
+# AGENTS.md files are contributor/agent instructions, not Studio runtime data.
+# Upstream npm packages may publish them, so remove them from dependency trees
+# after installation. Never follow a linked root: --with-llama-cpp-dir points at
+# a user-owned checkout and must remain byte-for-byte under the user's control.
+_remove_agent_instruction_files() {
+    local _root
+    for _root in "$@"; do
+        [ -d "$_root" ] || continue
+        [ -L "$_root" ] && continue
+        find "$_root" -type f -name 'AGENTS.md' -exec rm -f {} + 2>/dev/null || true
+    done
+}
+
 # ── Corporate-mirror / proxy escape hatch for the frontend npm/bun install (#6491) ──
 # studio/frontend/.npmrc pins registry=https://registry.npmjs.org/ as a supply-chain
 # lock. A project-level pin overrides a corporate user's ~/.npmrc proxy, so the install
@@ -846,6 +859,8 @@ elif [ -d "$_OXC_DIR" ] && [ "${NODE_SOURCE:-}" != skip ]; then
     # the validator gracefully. Mirrors setup.ps1's elseif on this block.
     substep "OXC validator runtime skipped (no npm found); code validation degrades until Node is available" "$C_WARN"
 fi
+
+_remove_agent_instruction_files "$SCRIPT_DIR/frontend" "$_OXC_DIR"
 
 # ── Python venv + deps ──
 
@@ -1917,6 +1932,13 @@ if [ "$_LLAMA_CPP_DEGRADED" = true ] \
         _LLAMA_CPP_DEGRADED=false
         print_installed_llama_prebuilt_release "$LLAMA_CPP_DIR"
     fi
+fi
+
+# The managed source-build path clones a complete llama.cpp repository. Keep
+# contributor-only AGENTS.md files out of the installed runtime, while leaving a
+# user-supplied --with-llama-cpp-dir tree untouched.
+if [ "${_LOCAL_LLAMA_CPP_LINKED:-false}" != true ]; then
+    _remove_agent_instruction_files "$LLAMA_CPP_DIR"
 fi
 
 # ── Footer ──

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -74,16 +74,17 @@ verbose_substep() {
     return 0
 }
 
-# AGENTS.md files are contributor/agent instructions, not Studio runtime data.
-# Upstream npm packages may publish them, so remove them from dependency trees
-# after installation. Never follow a linked root: --with-llama-cpp-dir points at
-# a user-owned checkout and must remain byte-for-byte under the user's control.
+# AGENTS.md and CLAUDE.md are contributor/agent instructions, not Studio runtime
+# data. Upstream npm packages may publish them, so remove them from dependency
+# trees after installation. Never follow a linked root: --with-llama-cpp-dir
+# points at a user-owned checkout and must remain under the user's control.
 _remove_agent_instruction_files() {
     local _root
     for _root in "$@"; do
         [ -d "$_root" ] || continue
         [ -L "$_root" ] && continue
-        find "$_root" -type f -name 'AGENTS.md' -exec rm -f {} + 2>/dev/null || true
+        find "$_root" -type f \( -name 'AGENTS.md' -o -name 'CLAUDE.md' \) \
+            -exec rm -f {} + 2>/dev/null || true
     done
 }
 
@@ -1935,8 +1936,8 @@ if [ "$_LLAMA_CPP_DEGRADED" = true ] \
 fi
 
 # The managed source-build path clones a complete llama.cpp repository. Keep
-# contributor-only AGENTS.md files out of the installed runtime, while leaving a
-# user-supplied --with-llama-cpp-dir tree untouched.
+# contributor-only agent instructions out of the installed runtime, while
+# leaving a user-supplied --with-llama-cpp-dir tree untouched.
 if [ "${_LOCAL_LLAMA_CPP_LINKED:-false}" != true ]; then
     _remove_agent_instruction_files "$LLAMA_CPP_DIR"
 fi

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -1931,7 +1931,11 @@ if [ "$_LLAMA_CPP_DEGRADED" = true ] \
     fi
 fi
 
-if [ "${_LOCAL_LLAMA_CPP_LINKED:-false}" != true ]; then
+if [ ! -L "$LLAMA_CPP_DIR" ] && {
+    [ "$_STUDIO_HOME_IS_CUSTOM" != true ] ||
+        [ -f "$LLAMA_CPP_DIR/$_STUDIO_OWNED_MARKER" ] ||
+        _studio_owned_adoptable "$LLAMA_CPP_DIR"
+}; then
     _remove_agent_instruction_files "$LLAMA_CPP_DIR"
 fi
 

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -212,7 +212,10 @@ def test_remove_agent_instruction_files_does_not_follow_links(tmp_path: Path):
     external.mkdir()
     (managed / "AGENTS.md").write_text("managed root", encoding = "utf-8")
     (nested / "AGENTS.md").write_text("managed nested", encoding = "utf-8")
+    (managed / "CLAUDE.md").write_text("managed Claude root", encoding = "utf-8")
+    (nested / "CLAUDE.md").write_text("managed Claude nested", encoding = "utf-8")
     (external / "AGENTS.md").write_text("user owned", encoding = "utf-8")
+    (external / "CLAUDE.md").write_text("user-owned Claude", encoding = "utf-8")
     try:
         (managed / "external-link").symlink_to(external, target_is_directory = True)
         linked_root = tmp_path / "linked-root"
@@ -220,12 +223,15 @@ def test_remove_agent_instruction_files_does_not_follow_links(tmp_path: Path):
     except OSError as exc:
         pytest.skip(f"directory symlinks unavailable: {exc}")
 
-    assert remove_agent_instruction_files(managed) == 2
+    assert remove_agent_instruction_files(managed) == 4
     assert not list(managed.rglob("AGENTS.md"))
+    assert not list(managed.rglob("CLAUDE.md"))
     assert (external / "AGENTS.md").read_text(encoding = "utf-8") == "user owned"
+    assert (external / "CLAUDE.md").read_text(encoding = "utf-8") == "user-owned Claude"
 
     assert remove_agent_instruction_files(linked_root) == 0
     assert (external / "AGENTS.md").exists()
+    assert (external / "CLAUDE.md").exists()
 
 
 def test_hydrate_source_tree_extracts_upstream_archive_contents(
@@ -259,6 +265,16 @@ def test_hydrate_source_tree_extracts_upstream_archive_contents(
             f"llama.cpp-{upstream_tag}/examples/AGENTS.md",
             b"nested contributor instructions\n",
         )
+        add_bytes_to_tar(
+            archive,
+            f"llama.cpp-{upstream_tag}/CLAUDE.md",
+            b"Claude contributor instructions\n",
+        )
+        add_bytes_to_tar(
+            archive,
+            f"llama.cpp-{upstream_tag}/examples/CLAUDE.md",
+            b"nested Claude contributor instructions\n",
+        )
 
     source_urls = set(INSTALL_LLAMA_PREBUILT.upstream_source_archive_urls(upstream_tag))
 
@@ -280,6 +296,7 @@ def test_hydrate_source_tree_extracts_upstream_archive_contents(
     assert (install_dir / "gguf-py" / "gguf" / "__init__.py").exists()
     assert not (install_dir / f"llama.cpp-{upstream_tag}").exists()
     assert not list(install_dir.rglob("AGENTS.md"))
+    assert not list(install_dir.rglob("CLAUDE.md"))
 
 
 def test_release_asset_download_url():
@@ -2047,6 +2064,10 @@ def test_install_prebuilt_skips_download_when_existing_install_matches(
     nested_agents = install_dir / "examples" / "AGENTS.md"
     nested_agents.parent.mkdir()
     nested_agents.write_text("old nested instructions", encoding = "utf-8")
+    (install_dir / "CLAUDE.md").write_text("old Claude instructions", encoding = "utf-8")
+    (nested_agents.parent / "CLAUDE.md").write_text(
+        "old nested Claude instructions", encoding = "utf-8"
+    )
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "detect_host", lambda: host)
     monkeypatch.setattr(
@@ -2067,6 +2088,7 @@ def test_install_prebuilt_skips_download_when_existing_install_matches(
 
     install_prebuilt(install_dir, "latest", "unslothai/llama.cpp", "")
     assert not list(install_dir.rglob("AGENTS.md"))
+    assert not list(install_dir.rglob("CLAUDE.md"))
 
 
 def test_setup_scripts_prune_agent_files_without_shipping_a_repo_copy():
@@ -2075,8 +2097,10 @@ def test_setup_scripts_prune_agent_files_without_shipping_a_repo_copy():
 
     assert '_remove_agent_instruction_files "$SCRIPT_DIR/frontend" "$_OXC_DIR"' in setup_sh
     assert '_remove_agent_instruction_files "$LLAMA_CPP_DIR"' in setup_sh
+    assert "-name 'CLAUDE.md'" in setup_sh
     assert 'if [ "${_LOCAL_LLAMA_CPP_LINKED:-false}" != true ]; then' in setup_sh
     assert "Remove-AgentInstructionFiles -Roots @($FrontendDir, $OxcValidatorDir)" in setup_ps1
+    assert '"CLAUDE.md"' in setup_ps1
     assert "if (-not $LocalLlamaCppLinked)" in setup_ps1
     assert not (PACKAGE_ROOT / "studio" / "frontend" / "src" / "i18n" / "AGENTS.md").exists()
     assert (PACKAGE_ROOT / "studio" / "frontend" / "src" / "i18n" / "README.md").is_file()

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -310,7 +310,7 @@ def test_remove_agent_instruction_files_continues_after_unlink_error(
     assert "could not remove contributor-only instruction" in captured.out + captured.err
 
 
-def test_main_preserves_linked_install_path_for_ownership_checks(
+def test_main_resolves_linked_install_path_and_preserves_cleanup_root(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
     target = tmp_path / "target"
@@ -335,8 +335,46 @@ def test_main_preserves_linked_install_path_for_ownership_checks(
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_LOG_TO_STDOUT", False)
 
     assert INSTALL_LLAMA_PREBUILT.main() == 0
-    assert received["install_dir"] == linked_root.absolute()
-    assert received["install_dir"].is_symlink()
+    assert received["install_dir"] == target.resolve()
+    assert received["instruction_cleanup_root"] == linked_root.absolute()
+    assert received["instruction_cleanup_root"].is_symlink()
+
+
+def test_install_prebuilt_uses_explicit_instruction_cleanup_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    install_dir = tmp_path / "target"
+    linked_root = tmp_path / "linked-root"
+    install_dir.mkdir()
+    (install_dir / "UNSLOTH_PREBUILT_INFO.json").write_text("{}", encoding = "utf-8")
+    try:
+        linked_root.symlink_to(install_dir, target_is_directory = True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks unavailable: {exc}")
+
+    cleanup_roots = []
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "detect_host", linux_host)
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "remove_agent_instruction_files",
+        lambda root: cleanup_roots.append(root) or 0,
+    )
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "resolve_simple_install_release_plans",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("stop after cleanup")),
+    )
+
+    with pytest.raises(RuntimeError, match = "stop after cleanup"):
+        install_prebuilt(
+            install_dir.resolve(),
+            "latest",
+            "unslothai/llama.cpp",
+            "",
+            instruction_cleanup_root = linked_root.absolute(),
+        )
+
+    assert cleanup_roots == [linked_root.absolute()]
 
 
 def test_hydrate_source_tree_extracts_upstream_archive_contents(
@@ -800,6 +838,29 @@ def test_activate_install_tree_restores_existing_install_after_activation_failur
     output = captured.out + captured.err
     assert "moving existing install to rollback path" in output
     assert "restored previous install from rollback path" in output
+
+
+def test_activate_install_tree_preserves_symlink_to_resolved_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    install_dir = tmp_path / "target"
+    linked_root = tmp_path / "linked-root"
+    staging_dir = tmp_path / "staging"
+    install_dir.mkdir()
+    staging_dir.mkdir()
+    (install_dir / "old.txt").write_text("old", encoding = "utf-8")
+    (staging_dir / "new.txt").write_text("new", encoding = "utf-8")
+    try:
+        linked_root.symlink_to(install_dir, target_is_directory = True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks unavailable: {exc}")
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "confirm_install_tree", lambda *_args: None)
+
+    activate_install_tree(staging_dir, linked_root.resolve(), linux_host())
+
+    assert linked_root.is_symlink()
+    assert (linked_root / "new.txt").read_text(encoding = "utf-8") == "new"
+    assert not (linked_root / "old.txt").exists()
 
 
 def test_activate_install_tree_cleans_all_paths_when_rollback_restore_fails(
@@ -2203,12 +2264,18 @@ def test_setup_scripts_prune_agent_files_without_shipping_a_repo_copy():
     assert '_remove_agent_instruction_files "$SCRIPT_DIR/frontend" "$_OXC_DIR"' in setup_sh
     assert '_remove_agent_instruction_files "$LLAMA_CPP_DIR"' in setup_sh
     assert "-name 'CLAUDE.md'" in setup_sh
-    assert 'if [ "${_LOCAL_LLAMA_CPP_LINKED:-false}" != true ]; then' in setup_sh
+    assert 'if [ ! -L "$LLAMA_CPP_DIR" ] && {' in setup_sh
+    assert '${_LOCAL_LLAMA_CPP_LINKED:-false}" != true' not in setup_sh
+    assert "$LLAMA_CPP_DIR/$_STUDIO_OWNED_MARKER" in setup_sh
+    assert '_studio_owned_adoptable "$LLAMA_CPP_DIR"' in setup_sh
     assert "Remove-AgentInstructionFiles -Roots @($FrontendDir, $OxcValidatorDir)" in setup_ps1
     assert '"CLAUDE.md"' in setup_ps1
     assert '-Include "AGENTS.md", "CLAUDE.md"' not in setup_ps1
     assert '$child.Name -in @("AGENTS.md", "CLAUDE.md")' in setup_ps1
-    assert "if (-not $LocalLlamaCppLinked)" in setup_ps1
+    assert "$llamaCppIsLink" in setup_ps1
+    assert "if (-not $LocalLlamaCppLinked)" not in setup_ps1
+    assert "Join-Path $LlamaCppDir $StudioOwnedMarker" in setup_ps1
+    assert "Test-StudioOwnedAdoptable $LlamaCppDir" in setup_ps1
     assert (
         "Copy-Item -Recurse -LiteralPath $ResolvedLocal -Destination $LlamaCppDir\n"
         "            Remove-AgentInstructionFiles -Roots @($LlamaCppDir)"

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -30,6 +30,7 @@ AssetChoice = INSTALL_LLAMA_PREBUILT.AssetChoice
 ApprovedArtifactHash = INSTALL_LLAMA_PREBUILT.ApprovedArtifactHash
 ApprovedReleaseChecksums = INSTALL_LLAMA_PREBUILT.ApprovedReleaseChecksums
 hydrate_source_tree = INSTALL_LLAMA_PREBUILT.hydrate_source_tree
+remove_agent_instruction_files = INSTALL_LLAMA_PREBUILT.remove_agent_instruction_files
 validate_prebuilt_choice = INSTALL_LLAMA_PREBUILT.validate_prebuilt_choice
 activate_install_tree = INSTALL_LLAMA_PREBUILT.activate_install_tree
 activate_staged_dir = INSTALL_LLAMA_PREBUILT.activate_staged_dir
@@ -203,6 +204,30 @@ def test_extract_archive_rejects_zip_symlink_entry(tmp_path: Path):
         extract_archive(archive_path, tmp_path / "extract")
 
 
+def test_remove_agent_instruction_files_does_not_follow_links(tmp_path: Path):
+    managed = tmp_path / "managed"
+    nested = managed / "nested"
+    external = tmp_path / "external"
+    nested.mkdir(parents = True)
+    external.mkdir()
+    (managed / "AGENTS.md").write_text("managed root", encoding = "utf-8")
+    (nested / "AGENTS.md").write_text("managed nested", encoding = "utf-8")
+    (external / "AGENTS.md").write_text("user owned", encoding = "utf-8")
+    try:
+        (managed / "external-link").symlink_to(external, target_is_directory = True)
+        linked_root = tmp_path / "linked-root"
+        linked_root.symlink_to(external, target_is_directory = True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks unavailable: {exc}")
+
+    assert remove_agent_instruction_files(managed) == 2
+    assert not list(managed.rglob("AGENTS.md"))
+    assert (external / "AGENTS.md").read_text(encoding = "utf-8") == "user owned"
+
+    assert remove_agent_instruction_files(linked_root) == 0
+    assert (external / "AGENTS.md").exists()
+
+
 def test_hydrate_source_tree_extracts_upstream_archive_contents(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
@@ -224,6 +249,16 @@ def test_hydrate_source_tree_extracts_upstream_archive_contents(
             f"llama.cpp-{upstream_tag}/gguf-py/gguf/__init__.py",
             b"__all__ = []\n",
         )
+        add_bytes_to_tar(
+            archive,
+            f"llama.cpp-{upstream_tag}/AGENTS.md",
+            b"upstream contributor instructions\n",
+        )
+        add_bytes_to_tar(
+            archive,
+            f"llama.cpp-{upstream_tag}/examples/AGENTS.md",
+            b"nested contributor instructions\n",
+        )
 
     source_urls = set(INSTALL_LLAMA_PREBUILT.upstream_source_archive_urls(upstream_tag))
 
@@ -244,6 +279,7 @@ def test_hydrate_source_tree_extracts_upstream_archive_contents(
     assert (install_dir / "convert_hf_to_gguf.py").exists()
     assert (install_dir / "gguf-py" / "gguf" / "__init__.py").exists()
     assert not (install_dir / f"llama.cpp-{upstream_tag}").exists()
+    assert not list(install_dir.rglob("AGENTS.md"))
 
 
 def test_release_asset_download_url():
@@ -2007,6 +2043,10 @@ def test_install_prebuilt_skips_download_when_existing_install_matches(
         approved_checksums = checksums,
         prebuilt_fallback_used = False,
     )
+    (install_dir / "AGENTS.md").write_text("old root instructions", encoding = "utf-8")
+    nested_agents = install_dir / "examples" / "AGENTS.md"
+    nested_agents.parent.mkdir()
+    nested_agents.write_text("old nested instructions", encoding = "utf-8")
 
     monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "detect_host", lambda: host)
     monkeypatch.setattr(
@@ -2026,6 +2066,20 @@ def test_install_prebuilt_skips_download_when_existing_install_matches(
     )
 
     install_prebuilt(install_dir, "latest", "unslothai/llama.cpp", "")
+    assert not list(install_dir.rglob("AGENTS.md"))
+
+
+def test_setup_scripts_prune_agent_files_without_shipping_a_repo_copy():
+    setup_sh = (PACKAGE_ROOT / "studio" / "setup.sh").read_text(encoding = "utf-8")
+    setup_ps1 = (PACKAGE_ROOT / "studio" / "setup.ps1").read_text(encoding = "utf-8")
+
+    assert '_remove_agent_instruction_files "$SCRIPT_DIR/frontend" "$_OXC_DIR"' in setup_sh
+    assert '_remove_agent_instruction_files "$LLAMA_CPP_DIR"' in setup_sh
+    assert 'if [ "${_LOCAL_LLAMA_CPP_LINKED:-false}" != true ]; then' in setup_sh
+    assert "Remove-AgentInstructionFiles -Roots @($FrontendDir, $OxcValidatorDir)" in setup_ps1
+    assert "if (-not $LocalLlamaCppLinked)" in setup_ps1
+    assert not (PACKAGE_ROOT / "studio" / "frontend" / "src" / "i18n" / "AGENTS.md").exists()
+    assert (PACKAGE_ROOT / "studio" / "frontend" / "src" / "i18n" / "README.md").is_file()
 
 
 def test_install_prebuilt_does_not_skip_unhealthy_existing_install(

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -2206,6 +2206,8 @@ def test_setup_scripts_prune_agent_files_without_shipping_a_repo_copy():
     assert 'if [ "${_LOCAL_LLAMA_CPP_LINKED:-false}" != true ]; then' in setup_sh
     assert "Remove-AgentInstructionFiles -Roots @($FrontendDir, $OxcValidatorDir)" in setup_ps1
     assert '"CLAUDE.md"' in setup_ps1
+    assert '-Include "AGENTS.md", "CLAUDE.md"' not in setup_ps1
+    assert '$child.Name -in @("AGENTS.md", "CLAUDE.md")' in setup_ps1
     assert "if (-not $LocalLlamaCppLinked)" in setup_ps1
     assert (
         "Copy-Item -Recurse -LiteralPath $ResolvedLocal -Destination $LlamaCppDir\n"

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3,6 +3,7 @@ import importlib.util
 import io
 import json
 import os
+import subprocess
 import sys
 import tarfile
 import zipfile
@@ -232,6 +233,110 @@ def test_remove_agent_instruction_files_does_not_follow_links(tmp_path: Path):
     assert remove_agent_instruction_files(linked_root) == 0
     assert (external / "AGENTS.md").exists()
     assert (external / "CLAUDE.md").exists()
+
+
+@pytest.mark.skipif(os.name != "nt", reason = "Windows junction behavior")
+def test_remove_agent_instruction_files_does_not_follow_windows_junctions(tmp_path: Path):
+    managed = tmp_path / "managed"
+    external = tmp_path / "external"
+    managed.mkdir()
+    external.mkdir()
+    (external / "AGENTS.md").write_text("user owned", encoding = "utf-8")
+    (external / "CLAUDE.md").write_text("user-owned Claude", encoding = "utf-8")
+
+    nested_junction = managed / "external-junction"
+    root_junction = tmp_path / "linked-root"
+    for junction in (nested_junction, root_junction):
+        result = subprocess.run(
+            ["cmd", "/d", "/c", "mklink", "/J", str(junction), str(external)],
+            capture_output = True,
+            text = True,
+            check = False,
+        )
+        if result.returncode != 0:
+            pytest.skip(f"directory junctions unavailable: {result.stderr or result.stdout}")
+
+    assert remove_agent_instruction_files(managed) == 0
+    assert remove_agent_instruction_files(root_junction) == 0
+    assert (external / "AGENTS.md").read_text(encoding = "utf-8") == "user owned"
+    assert (external / "CLAUDE.md").read_text(encoding = "utf-8") == "user-owned Claude"
+
+
+def test_remove_agent_instruction_files_prunes_linklike_directories(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    managed = tmp_path / "managed"
+    simulated_junction = managed / "simulated-junction"
+    simulated_junction.mkdir(parents = True)
+    agents = simulated_junction / "AGENTS.md"
+    claude = simulated_junction / "CLAUDE.md"
+    agents.write_text("external instructions", encoding = "utf-8")
+    claude.write_text("external Claude instructions", encoding = "utf-8")
+    real_is_link_or_junction = INSTALL_LLAMA_PREBUILT._is_link_or_junction
+
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "_is_link_or_junction",
+        lambda path: path == simulated_junction or real_is_link_or_junction(path),
+    )
+
+    assert remove_agent_instruction_files(managed) == 0
+    assert agents.exists()
+    assert claude.exists()
+
+
+def test_remove_agent_instruction_files_continues_after_unlink_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    blocked = managed / "AGENTS.md"
+    removable = managed / "CLAUDE.md"
+    blocked.write_text("blocked", encoding = "utf-8")
+    removable.write_text("remove me", encoding = "utf-8")
+    real_unlink = Path.unlink
+
+    def selective_unlink(path: Path, *args, **kwargs):
+        if path == blocked:
+            raise PermissionError(errno.EACCES, "Access is denied", str(path))
+        return real_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", selective_unlink)
+
+    assert remove_agent_instruction_files(managed) == 1
+    assert blocked.exists()
+    assert not removable.exists()
+    captured = capsys.readouterr()
+    assert "could not remove contributor-only instruction" in captured.out + captured.err
+
+
+def test_main_preserves_linked_install_path_for_ownership_checks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    target = tmp_path / "target"
+    linked_root = tmp_path / "linked-root"
+    target.mkdir()
+    try:
+        linked_root.symlink_to(target, target_is_directory = True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks unavailable: {exc}")
+
+    received = {}
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["install_llama_prebuilt.py", "--install-dir", str(linked_root)],
+    )
+    monkeypatch.setattr(
+        INSTALL_LLAMA_PREBUILT,
+        "install_prebuilt",
+        lambda **kwargs: received.update(kwargs),
+    )
+    monkeypatch.setattr(INSTALL_LLAMA_PREBUILT, "_LOG_TO_STDOUT", False)
+
+    assert INSTALL_LLAMA_PREBUILT.main() == 0
+    assert received["install_dir"] == linked_root.absolute()
+    assert received["install_dir"].is_symlink()
 
 
 def test_hydrate_source_tree_extracts_upstream_archive_contents(
@@ -2102,6 +2207,12 @@ def test_setup_scripts_prune_agent_files_without_shipping_a_repo_copy():
     assert "Remove-AgentInstructionFiles -Roots @($FrontendDir, $OxcValidatorDir)" in setup_ps1
     assert '"CLAUDE.md"' in setup_ps1
     assert "if (-not $LocalLlamaCppLinked)" in setup_ps1
+    assert (
+        "Copy-Item -Recurse -LiteralPath $ResolvedLocal -Destination $LlamaCppDir\n"
+        "            # The fallback is a Studio-owned copy, not a link into the user's\n"
+        "            # checkout, so it is safe and necessary to prune the copied files.\n"
+        "            Remove-AgentInstructionFiles -Roots @($LlamaCppDir)"
+    ) in setup_ps1
     assert not (PACKAGE_ROOT / "studio" / "frontend" / "src" / "i18n" / "AGENTS.md").exists()
     assert (PACKAGE_ROOT / "studio" / "frontend" / "src" / "i18n" / "README.md").is_file()
 

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -2209,8 +2209,6 @@ def test_setup_scripts_prune_agent_files_without_shipping_a_repo_copy():
     assert "if (-not $LocalLlamaCppLinked)" in setup_ps1
     assert (
         "Copy-Item -Recurse -LiteralPath $ResolvedLocal -Destination $LlamaCppDir\n"
-        "            # The fallback is a Studio-owned copy, not a link into the user's\n"
-        "            # checkout, so it is safe and necessary to prune the copied files.\n"
         "            Remove-AgentInstructionFiles -Roots @($LlamaCppDir)"
     ) in setup_ps1
     assert not (PACKAGE_ROOT / "studio" / "frontend" / "src" / "i18n" / "AGENTS.md").exists()


### PR DESCRIPTION
## Summary

- rename the repository-owned i18n `AGENTS.md` guide to `README.md`
- prune `AGENTS.md` and `CLAUDE.md` files published by frontend and OXC npm dependencies after setup
- prune both instruction files from fresh and existing Studio-managed llama.cpp trees, including tag-match fast paths
- preserve user-owned llama.cpp directories supplied through `--with-llama-cpp-dir`

Both `ggml-org/llama.cpp` and `unslothai/llama.cpp` currently ship root-level `AGENTS.md` and `CLAUDE.md`, so the prebuilt source hydration path covers both.

## Testing

- `uv tool run --from pytest pytest tests/studio/install/test_install_llama_prebuilt_logic.py -q` (52 passed)
- `bash tests/sh/test_with_llama_cpp_dir_link_behavior.sh`
- `sh tests/sh/test_with_llama_cpp_dir_flag.sh` (24 checks passed)
- behavioral Unix and PowerShell cleanup checks for both filenames
- `ruff check` on the modified Python files
- Bash syntax and PowerShell parser checks