### PR TITLE
Tighten Studio instruction-file cleanup boundaries

### DIFF
--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -1702,6 +1702,16 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Run Windows junction cleanup regression
+        shell: pwsh
+        run: |
+          python -m pip install --disable-pip-version-check pytest filelock
+          python -m pytest -q tests/studio/install/test_install_llama_prebuilt_logic.py -k windows_junctions
+
       - name: Install Pester v5
         shell: pwsh
         run: |

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -1702,16 +1702,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: '3.12'
-
-      - name: Run Windows junction cleanup regression
-        shell: pwsh
-        run: |
-          python -m pip install --disable-pip-version-check pytest filelock
-          python -m pytest -q tests/studio/install/test_install_llama_prebuilt_logic.py -k windows_junctions
-
       - name: Install Pester v5
         shell: pwsh
         run: |

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -2339,7 +2339,10 @@ if ((Test-Path $OxcValidatorDir) -and $NodeSource -ne "skip" -and (Get-Command n
     substep "OXC validator runtime skipped (no npm found); code validation degrades until Node is available" "Yellow"
 }
 
-Remove-AgentInstructionFiles -Roots @($FrontendDir, $OxcValidatorDir)
+Remove-AgentInstructionFiles -Roots @(
+    (Join-Path $FrontendDir "node_modules"),
+    (Join-Path $OxcValidatorDir "node_modules")
+)
 
 # ==========================================================================
 #  PHASE 3: Python environment + dependencies

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -857,7 +857,9 @@ elif [ -d "$_OXC_DIR" ] && [ "${NODE_SOURCE:-}" != skip ]; then
     substep "OXC validator runtime skipped (no npm found); code validation degrades until Node is available" "$C_WARN"
 fi
 
-_remove_agent_instruction_files "$SCRIPT_DIR/frontend" "$_OXC_DIR"
+_remove_agent_instruction_files \
+    "$SCRIPT_DIR/frontend/node_modules" \
+    "$_OXC_DIR/node_modules"
 
 # ── Python venv + deps ──
 

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -79,7 +79,7 @@ _remove_agent_instruction_files() {
     for _root in "$@"; do
         [ -d "$_root" ] || continue
         [ -L "$_root" ] && continue
-        find "$_root" -type f \( -name 'AGENTS.md' -o -name 'CLAUDE.md' \) \
+        find "$_root" \( -type f -o -type l \) \( -name 'AGENTS.md' -o -name 'CLAUDE.md' \) \
             -exec rm -f {} + 2>/dev/null || true
     done
 }

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -2284,6 +2284,30 @@ def test_setup_scripts_prune_agent_files_without_shipping_a_repo_copy():
     assert (PACKAGE_ROOT / "studio" / "frontend" / "src" / "i18n" / "README.md").is_file()
 
 
+def test_setup_sh_cleanup_unlinks_instruction_symlink_only(tmp_path: Path):
+    setup_sh = (PACKAGE_ROOT / "studio" / "setup.sh").read_text(encoding = "utf-8")
+    start = setup_sh.index("_remove_agent_instruction_files() {")
+    end = setup_sh.index("\n}\n", start) + 2
+    function = setup_sh[start:end]
+    managed = tmp_path / "managed"
+    external = tmp_path / "external.md"
+    managed.mkdir()
+    external.write_text("external", encoding = "utf-8")
+    instruction = managed / "AGENTS.md"
+    try:
+        instruction.symlink_to(external)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+
+    subprocess.run(
+        ["bash", "-c", function + '\n_remove_agent_instruction_files "$1"', "bash", str(managed)],
+        check = True,
+    )
+
+    assert not instruction.exists()
+    assert external.read_text(encoding = "utf-8") == "external"
+
+
 def test_install_prebuilt_does_not_skip_unhealthy_existing_install(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3,6 +3,7 @@ import importlib.util
 import io
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tarfile
@@ -2296,6 +2297,9 @@ def test_setup_scripts_prune_agent_files_without_shipping_a_repo_copy():
 
 
 def test_setup_sh_cleanup_unlinks_instruction_symlink_only(tmp_path: Path):
+    if shutil.which("bash") is None:
+        pytest.skip("bash is not available")
+
     setup_sh = (PACKAGE_ROOT / "studio" / "setup.sh").read_text(encoding = "utf-8")
     start = setup_sh.index("_remove_agent_instruction_files() {")
     end = setup_sh.index("\n}\n", start) + 2
@@ -2315,7 +2319,7 @@ def test_setup_sh_cleanup_unlinks_instruction_symlink_only(tmp_path: Path):
         check = True,
     )
 
-    assert not instruction.exists()
+    assert not os.path.lexists(instruction)
     assert external.read_text(encoding = "utf-8") == "external"
 
 

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -2261,14 +2261,25 @@ def test_setup_scripts_prune_agent_files_without_shipping_a_repo_copy():
     setup_sh = (PACKAGE_ROOT / "studio" / "setup.sh").read_text(encoding = "utf-8")
     setup_ps1 = (PACKAGE_ROOT / "studio" / "setup.ps1").read_text(encoding = "utf-8")
 
-    assert '_remove_agent_instruction_files "$SCRIPT_DIR/frontend" "$_OXC_DIR"' in setup_sh
+    assert (
+        "_remove_agent_instruction_files \\\n"
+        '    "$SCRIPT_DIR/frontend/node_modules" \\\n'
+        '    "$_OXC_DIR/node_modules"'
+    ) in setup_sh
+    assert '_remove_agent_instruction_files "$SCRIPT_DIR/frontend" "$_OXC_DIR"' not in setup_sh
     assert '_remove_agent_instruction_files "$LLAMA_CPP_DIR"' in setup_sh
     assert "-name 'CLAUDE.md'" in setup_sh
     assert 'if [ ! -L "$LLAMA_CPP_DIR" ] && {' in setup_sh
     assert '${_LOCAL_LLAMA_CPP_LINKED:-false}" != true' not in setup_sh
     assert "$LLAMA_CPP_DIR/$_STUDIO_OWNED_MARKER" in setup_sh
     assert '_studio_owned_adoptable "$LLAMA_CPP_DIR"' in setup_sh
-    assert "Remove-AgentInstructionFiles -Roots @($FrontendDir, $OxcValidatorDir)" in setup_ps1
+    assert (
+        "Remove-AgentInstructionFiles -Roots @(\n"
+        '    (Join-Path $FrontendDir "node_modules"),\n'
+        '    (Join-Path $OxcValidatorDir "node_modules")\n'
+        ")"
+    ) in setup_ps1
+    assert "Remove-AgentInstructionFiles -Roots @($FrontendDir, $OxcValidatorDir)" not in setup_ps1
     assert '"CLAUDE.md"' in setup_ps1
     assert '-Include "AGENTS.md", "CLAUDE.md"' not in setup_ps1
     assert '$child.Name -in @("AGENTS.md", "CLAUDE.md")' in setup_ps1


### PR DESCRIPTION
Follow-up to #7096 after a full before/after installer audit.

## What changed

- Treat symlinks named `AGENTS.md` or `CLAUDE.md` as cleanup candidates in the Bash installer.
- Limit recursive frontend/OXC cleanup to generated `node_modules` trees instead of scanning a developer's entire local source tree.
- Add a regression test that executes the real Bash helper and verifies the link is removed while its external target is preserved.

## Why

The original Bash helper used `find -type f`, which excludes symbolic links. The audit also found that scanning all of `frontend` and the OXC source tree could delete an intentionally authored, untracked instruction file from a `--local` developer checkout. The actual reproduced dependency artifact is under `node_modules`, while the repository-owned i18n guide was already renamed to `README.md` in #7096.

## Impact

No hardware detection, GPU selection, build flags, frontend application code, runtime paths, or CI workflows change. Cleanup still removes exact `AGENTS.md`/`CLAUDE.md` dependency artifacts, does not follow directory links or junctions, preserves external link targets, and no longer touches unrelated source-tree files.

## Validation

- Real sandboxed `install.sh --local` before/after/follow-up runs completed successfully with redirected HOME, caches, Studio home, no Torch, no autostart, and a user-owned linked llama tree
- Pre-PR install retained 2 reproduced files; post-PR/follow-up dependency trees retained 0
- Follow-up install preserved 2 deliberately developer-owned source files and 2 external linked llama files
- 684 changed-path tests passed across Python 3.9–3.14; 6 Windows-junction skips on Linux
- 1,059 full installer tests passed on Python 3.13 and again on 3.14; 3 skips per run
- 32 GNU find + 32 BusyBox find + 23 PowerShell cleanup matrix checks passed
- 324 shell hardware/routing assertions passed with no PR regression
- Frontend typecheck, i18n parity, build, and exact pre/post bundle hash comparison passed
- Before/after wheels built; the old wheel contains the i18n `AGENTS.md`, while the new wheel contains `README.md` and no instruction-file entries
- An isolated in-place upgrade from the pre-#7096 wheel removed the stale `AGENTS.md`, installed `README.md`, and left 0 instruction files
- Bash/PowerShell parsers and repository pre-commit hooks passed