### PR TITLE
Fix Studio auto-titles for reasoning models

### DIFF
--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -77,6 +77,7 @@ const pendingRunStartReadyByMessageId = new Map<string, Promise<void>>();
 
 type TitleResponse = {
   choices?: Array<{
+    finish_reason?: string | null;
     message?: {
       content?: string;
     };
@@ -474,6 +475,8 @@ async function generateTitleWithModel(payload: {
       max_tokens: 24,
       top_k: 20,
       repetition_penalty: 1.0,
+      enable_thinking: false,
+      reasoning_effort: "none",
       messages: [
         {
           role: "system",
@@ -489,8 +492,10 @@ async function generateTitleWithModel(payload: {
     .json()
     .catch(() => null)) as TitleResponse | null;
   if (!response.ok) return null;
-  const raw: string | undefined = body?.choices?.[0]?.message?.content;
-  if (!raw) return null;
+  const choice = body?.choices?.[0];
+  if (choice?.finish_reason === "length") return null;
+  const raw: string | undefined = choice?.message?.content;
+  if (!raw || /<\/?think>/i.test(raw)) return null;
   return normalizeTitle(raw);
 }
 

--- a/tests/studio/test_chat_title_generation.py
+++ b/tests/studio/test_chat_title_generation.py
@@ -65,6 +65,8 @@ def test_title_model_payload_includes_optional_assistant_reply():
     assert "if (assistant)" in block
     assert "parts.push(`Assistant: ${assistant}`);" in block
     assert 'parts.join("\\n")' in block
+    assert "enable_thinking: false" in block
+    assert 'reasoning_effort: "none"' in block
 
 
 def test_generate_title_passes_first_assistant_reply_after_first_user():
@@ -81,6 +83,25 @@ def test_generate_title_passes_first_assistant_reply_after_first_user():
     assert "assistantText," in block
 
 
+def test_tool_call_only_first_assistant_still_uses_first_user_message():
+    source = RUNTIME_TSX.read_text()
+    extract_block = " ".join(_balanced_block(source, "function extractTextParts").split())
+    generate_block = " ".join(_balanced_block(source, "async generateTitle(remoteId").split())
+
+    assert (
+        '.filter((p): p is Extract<typeof p, { type: "text" }> => p.type === "text")'
+        in extract_block
+    )
+    assert (
+        "const userText = extractTextParts(firstUser) || defaultTitle; const assistantText = extractTextParts(firstAssistant);"
+        in generate_block
+    )
+    assert (
+        "(await generateTitleWithModel({ userText, assistantText, })) || fallbackTitleFromUserText(userText);"
+        in generate_block
+    )
+
+
 def test_auto_title_disabled_uses_deterministic_user_text_fallback():
     block = _balanced_block(
         RUNTIME_TSX.read_text(),
@@ -93,12 +114,18 @@ def test_auto_title_disabled_uses_deterministic_user_text_fallback():
 
 
 def test_model_failure_still_falls_back_to_user_text():
-    block = _balanced_block(
-        RUNTIME_TSX.read_text(),
-        "async generateTitle(remoteId",
+    source = RUNTIME_TSX.read_text()
+    model_block = _source_until(
+        source,
+        "async function generateTitleWithModel",
+        "\nconst inflightTitleByKey",
     )
+    generate_block = _balanced_block(source, "async generateTitle(remoteId")
 
-    assert "})) || fallbackTitleFromUserText(userText);" in block
+    assert "finish_reason?: string | null;" in source
+    assert 'if (choice?.finish_reason === "length") return null;' in model_block
+    assert r"if (!raw || /<\/?think>/i.test(raw)) return null;" in model_block
+    assert "})) || fallbackTitleFromUserText(userText);" in generate_block
 
 
 def test_title_normalizer_still_enforces_output_constraints():
@@ -113,3 +140,4 @@ def test_title_normalizer_still_enforces_output_constraints():
     assert 'replace(/[.!?:;,]+/g, " ")' in block
     assert 'title.split(" ").filter(Boolean).slice(0, 6)' in block
     assert "joined.length > 60" in block
+    assert "return normalizeTitle(raw);" in block


### PR DESCRIPTION
## Summary

- Disable reasoning explicitly for automatic chat-title requests with both `enable_thinking: false` and `reasoning_effort: "none"`.
- Reject truncated title completions and output containing think markers so the deterministic first-user-message fallback is used.
- Preserve tool-call-only first turns by keeping assistant context optional.
- Extend the focused Studio title-generation regression coverage.

## Root cause

Automatic title generation reused the active chat model with a 24-token output limit but did not disable reasoning. Reasoning models could spend the complete budget on reasoning before producing a title. On the GGUF path, reasoning-only output may be promoted to visible content to protect normal chat responses from becoming blank, allowing that text to pass title normalization and become the permanent chat title.

This change keeps the global GGUF behavior intact and hardens only the title-generation request and response handling. It does not special-case any observed title phrase.

Fixes #7071

## Validation

```text
python -m pytest tests/studio/test_chat_title_generation.py -q
7 passed

npm run typecheck
passed

ruff check tests/studio/test_chat_title_generation.py
passed

ruff format --check tests/studio/test_chat_title_generation.py
passed

git diff --check
passed
```

Targeted ESLint reports the same pre-existing ref-during-render error and Fast Refresh warnings as the unchanged base branch; this patch introduces no new lint finding.

## Risk

The patch is limited to title generation. If a backend rejects the reasoning controls, the existing failed-request path uses the deterministic title fallback. If a backend ignores them, truncated and think-tagged responses are also rejected. An always-reasoning backend that silently ignores both controls and returns short, untagged reasoning with a non-truncation finish reason remains outside what the response shape can distinguish from a valid title.