### PR TITLE
Studio: force-terminate a stuck training stop after a grace period

### DIFF
--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -39,6 +39,22 @@ from utils.paths import outputs_root
 
 logger = get_logger(__name__)
 
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        raw = (os.environ.get(name) or "").strip()
+        return int(raw) if raw else default
+    except ValueError:
+        return default
+
+
+# Stop-watchdog escalation timeouts. After a Stop is requested, force-terminate the
+# worker if it does not exit on its own: a short grace once "complete" (save done)
+# is seen, plus an absolute cap covering a hang during save. Guards against a wedged
+# post-save GPU/driver teardown that never exits.
+_STOP_GRACE_S = _env_int("UNSLOTH_STUDIO_TRAINING_STOP_GRACE_S", 15)
+_STOP_TIMEOUT_S = _env_int("UNSLOTH_STUDIO_TRAINING_STOP_TIMEOUT_S", 120)
+
 _pyplot = None
 _pyplot_failed = False
 
@@ -741,6 +757,11 @@ class TrainingBackend:
         self._pump_running: bool = False
         self._lock = threading.Lock()
 
+        # Stop watchdog: after a stop is requested, escalates to force_terminate()
+        # if the worker does not exit on its own within a bounded time.
+        self._stop_watchdog: Optional[threading.Thread] = None
+        self._complete_seen = threading.Event()
+
         # Progress state (updated by pump thread from subprocess events)
         self._progress = TrainingProgress()
         self._should_stop = False
@@ -896,6 +917,7 @@ class TrainingBackend:
         self.current_job_id = job_id
         self._should_stop = False
         self._cancel_requested = False
+        self._complete_seen.clear()
         self._progress = TrainingProgress(
             is_training = True, status_message = "Initializing training..."
         )
@@ -953,7 +975,72 @@ class TrainingBackend:
             self._progress.status_message = (
                 "Stopping training and saving checkpoint..." if save else "Cancelling training..."
             )
+        # Guarantee the run finalizes even if the worker wedges after saving.
+        self._start_stop_watchdog()
         return True
+
+    def _start_stop_watchdog(self) -> None:
+        """Start a daemon that force-terminates the worker if a requested stop does
+        not exit on its own. No-op if one is already running or no worker is alive.
+        """
+        with self._lock:
+            if self._stop_watchdog is not None and self._stop_watchdog.is_alive():
+                return
+            proc = self._proc
+            if proc is None or not proc.is_alive():
+                return
+            watchdog = threading.Thread(
+                target = self._stop_watchdog_loop, args = (proc,), daemon = True
+            )
+            self._stop_watchdog = watchdog
+            watchdog.start()
+
+    def _stop_watchdog_loop(self, target_proc: "mp.Process") -> None:
+        """Escalate a stuck stop to force_terminate().
+
+        A worker normally exits shortly after saving; this only fires when it does
+        not. Two triggers: a short grace after the worker's "complete" (save done),
+        and an absolute cap covering a hang during save. No-ops on a clean exit;
+        exits silently if a new run replaces the worker it was watching.
+        """
+        started = time.monotonic()
+        complete_at: Optional[float] = None
+        reason = ""
+        while True:
+            with self._lock:
+                superseded = self._proc is not target_proc
+            if superseded or not target_proc.is_alive():
+                return
+            now = time.monotonic()
+            if complete_at is None and self._complete_seen.is_set():
+                complete_at = now
+            if complete_at is not None and now - complete_at >= _STOP_GRACE_S:
+                reason = "worker still alive after save"
+                break
+            if now - started >= _STOP_TIMEOUT_S:
+                reason = "worker did not stop within timeout"
+                break
+            time.sleep(0.5)
+
+        with self._lock:
+            superseded = self._proc is not target_proc
+        if superseded or not target_proc.is_alive():
+            return
+        logger.warning("Stop watchdog force-terminating stuck training worker: %s", reason)
+        self.force_terminate()
+        self._finalize_stopped_after_escalation()
+
+    def _finalize_stopped_after_escalation(self) -> None:
+        """Finalize parent state after a watchdog force-terminate so the UI leaves
+        "Stopping..." even if the worker is wedged in driver teardown and unreaped.
+        Dropping the handle is safe: the worker is a daemon bound to parent lifetime.
+        """
+        with self._lock:
+            self._progress.is_training = False
+            self._progress.status_message = "Training stopped."
+            self._proc = None
+        self._ensure_db_run_created()
+        self._finalize_run_in_db(status = "stopped")
 
     def force_terminate(self) -> None:
         """Force-kill the training subprocess so state can be reset immediately."""
@@ -1468,6 +1555,8 @@ class TrainingBackend:
                     "training cancelled",
                     "training stopped",
                 }
+                # Save is done by now; let the stop watchdog start its grace timer.
+                self._complete_seen.set()
                 self._progress.is_training = False
                 self._progress.is_completed = not stopped
                 self._output_dir = event.get("output_dir")

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -49,11 +49,13 @@ def _env_int(name: str, default: int) -> int:
 
 
 # Stop-watchdog escalation timeouts. After a Stop is requested, force-terminate the
-# worker if it does not exit on its own: a short grace once "complete" (save done)
-# is seen, plus an absolute cap covering a hang during save. Guards against a wedged
-# post-save GPU/driver teardown that never exits.
+# worker if it does not exit on its own. Primary trigger is a short grace once
+# "complete" (save done) is seen. The absolute cap is a last-resort backstop only:
+# for a save=True stop it is long so a slow save is never killed mid-write; for a
+# cancel (save=False) there is nothing to save, so the backstop is shorter.
 _STOP_GRACE_S = _env_int("UNSLOTH_STUDIO_TRAINING_STOP_GRACE_S", 15)
-_STOP_TIMEOUT_S = _env_int("UNSLOTH_STUDIO_TRAINING_STOP_TIMEOUT_S", 120)
+_STOP_TIMEOUT_S = _env_int("UNSLOTH_STUDIO_TRAINING_STOP_TIMEOUT_S", 600)
+_CANCEL_TIMEOUT_S = _env_int("UNSLOTH_STUDIO_TRAINING_CANCEL_TIMEOUT_S", 120)
 
 _pyplot = None
 _pyplot_failed = False
@@ -758,8 +760,10 @@ class TrainingBackend:
         self._lock = threading.Lock()
 
         # Stop watchdog: after a stop is requested, escalates to force_terminate()
-        # if the worker does not exit on its own within a bounded time.
+        # if the worker does not exit on its own within a bounded time. The watched
+        # proc is tracked so a new run always gets its own watcher.
         self._stop_watchdog: Optional[threading.Thread] = None
+        self._stop_watchdog_proc: Optional[mp.Process] = None
         self._complete_seen = threading.Event()
 
         # Progress state (updated by pump thread from subprocess events)
@@ -976,32 +980,46 @@ class TrainingBackend:
                 "Stopping training and saving checkpoint..." if save else "Cancelling training..."
             )
         # Guarantee the run finalizes even if the worker wedges after saving.
-        self._start_stop_watchdog()
+        self._start_stop_watchdog(cancel = not save)
         return True
 
-    def _start_stop_watchdog(self) -> None:
+    def _start_stop_watchdog(self, cancel: bool) -> None:
         """Start a daemon that force-terminates the worker if a requested stop does
-        not exit on its own. No-op if one is already running or no worker is alive.
+        not exit on its own. No-op if no worker is alive or an existing watchdog is
+        already watching the current worker; a stale watchdog on an old proc does
+        not stop a new run from getting its own watcher.
         """
         with self._lock:
-            if self._stop_watchdog is not None and self._stop_watchdog.is_alive():
-                return
             proc = self._proc
             if proc is None or not proc.is_alive():
                 return
-            watchdog = threading.Thread(target = self._stop_watchdog_loop, args = (proc,), daemon = True)
+            if (
+                self._stop_watchdog is not None
+                and self._stop_watchdog.is_alive()
+                and self._stop_watchdog_proc is proc
+            ):
+                return
+            watchdog = threading.Thread(
+                target = self._stop_watchdog_loop,
+                args = (proc, cancel),
+                name = f"stop-watchdog-{self.current_job_id or 'unknown'}",
+                daemon = True,
+            )
             self._stop_watchdog = watchdog
+            self._stop_watchdog_proc = proc
             watchdog.start()
 
-    def _stop_watchdog_loop(self, target_proc: "mp.Process") -> None:
+    def _stop_watchdog_loop(self, target_proc: "mp.Process", cancel: bool) -> None:
         """Escalate a stuck stop to force_terminate().
 
         A worker normally exits shortly after saving; this only fires when it does
-        not. Two triggers: a short grace after the worker's "complete" (save done),
-        and an absolute cap covering a hang during save. No-ops on a clean exit;
-        exits silently if a new run replaces the worker it was watching.
+        not. Primary trigger is a short grace after "complete" (save done). The
+        absolute cap is a last-resort backstop: long for save=True so a slow save is
+        never killed mid-write, shorter for a cancel that has nothing to save.
+        No-ops on a clean exit; exits silently if a new run replaces the worker.
         """
         started = time.monotonic()
+        abs_timeout = _CANCEL_TIMEOUT_S if cancel else _STOP_TIMEOUT_S
         complete_at: Optional[float] = None
         reason = ""
         while True:
@@ -1015,8 +1033,8 @@ class TrainingBackend:
             if complete_at is not None and now - complete_at >= _STOP_GRACE_S:
                 reason = "worker still alive after save"
                 break
-            if now - started >= _STOP_TIMEOUT_S:
-                reason = "worker did not stop within timeout"
+            if now - started >= abs_timeout:
+                reason = "worker did not exit within the absolute timeout"
                 break
             time.sleep(0.5)
 
@@ -1024,29 +1042,52 @@ class TrainingBackend:
             superseded = self._proc is not target_proc
         if superseded or not target_proc.is_alive():
             return
-        logger.warning("Stop watchdog force-terminating stuck training worker: %s", reason)
-        self.force_terminate()
-        self._finalize_stopped_after_escalation()
+        if complete_at is None:
+            # Backstop fired before completion: warn loudly since a save may still
+            # have been in progress (only reachable past the long save=True cap).
+            logger.warning(
+                "Stop watchdog: absolute timeout with no completion signal; "
+                "force-terminating a possibly-mid-save worker: %s",
+                reason,
+            )
+        else:
+            logger.warning("Stop watchdog force-terminating stuck training worker: %s", reason)
+        # force_terminate can raise on a wedged child (re-issued kill); finalize
+        # regardless so the run never stays stuck in "Stopping...".
+        try:
+            self.force_terminate(target_proc = target_proc)
+        except Exception:
+            logger.exception("Stop watchdog: force_terminate failed; finalizing anyway")
+        finally:
+            self._finalize_stopped_after_escalation()
 
     def _finalize_stopped_after_escalation(self) -> None:
         """Finalize parent state after a watchdog force-terminate so the UI leaves
         "Stopping..." even if the worker is wedged in driver teardown and unreaped.
         Dropping the handle is safe: the worker is a daemon bound to parent lifetime.
+        Preserve output_dir so a saved checkpoint is still recorded in run history.
         """
         with self._lock:
             self._progress.is_training = False
             self._progress.status_message = "Training stopped."
+            output_dir = self._output_dir
             self._proc = None
         self._ensure_db_run_created()
-        self._finalize_run_in_db(status = "stopped")
+        self._finalize_run_in_db(status = "stopped", output_dir = output_dir)
 
-    def force_terminate(self) -> None:
-        """Force-kill the training subprocess so state can be reset immediately."""
+    def force_terminate(self, target_proc: "Optional[mp.Process]" = None) -> None:
+        """Force-kill the training subprocess so state can be reset immediately.
+
+        When ``target_proc`` is given, terminate only that handle and no-op if a new
+        run has since replaced it, so the watchdog can never kill a fresh worker.
+        """
         with self._lock:
-            if self._proc is not None and self._proc.is_alive():
-                logger.info("Force-terminating training subprocess (pid=%s)", self._proc.pid)
-                self._proc.terminate()
             proc = self._proc
+            if target_proc is not None and proc is not target_proc:
+                return  # superseded by a new run; do not touch the new worker
+            if proc is not None and proc.is_alive():
+                logger.info("Force-terminating training subprocess (pid=%s)", proc.pid)
+                proc.terminate()
             cancelled = self._cancel_requested
             output_dir = self._output_dir
 

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -788,6 +788,7 @@ class TrainingBackend:
         self._metric_buffer: list[dict] = []
         self._run_finalized: bool = False
         self._db_run_created: bool = False
+        self._db_create_in_progress: bool = False
         self._db_total_steps_set: bool = False
         self._db_config: Optional[dict] = None
         self._db_started_at: Optional[str] = None
@@ -997,7 +998,7 @@ class TrainingBackend:
                 return
             watchdog = threading.Thread(
                 target = self._stop_watchdog_loop,
-                args = (proc, cancel),
+                args = (proc, cancel, self.current_job_id),
                 name = f"stop-watchdog-{self.current_job_id or 'unknown'}",
                 daemon = True,
             )
@@ -1005,7 +1006,12 @@ class TrainingBackend:
             self._stop_watchdog_proc = proc
             watchdog.start()
 
-    def _stop_watchdog_loop(self, target_proc: "mp.Process", cancel: bool) -> None:
+    def _stop_watchdog_loop(
+        self,
+        target_proc: "mp.Process",
+        cancel: bool,
+        watched_job_id: Optional[str] = None,
+    ) -> None:
         """Escalate a stuck stop to force_terminate(): grace after "complete", else the
         absolute backstop (see the module timeouts). No-ops on a clean exit; exits
         silently if a new run replaces the worker."""
@@ -1051,25 +1057,37 @@ class TrainingBackend:
         except Exception:
             logger.exception("Stop watchdog: force_terminate failed; finalizing anyway")
         finally:
-            self._finalize_stopped_after_escalation(target_proc = target_proc)
+            self._finalize_stopped_after_escalation(
+                target_proc = target_proc, watched_job_id = watched_job_id
+            )
 
     def _finalize_stopped_after_escalation(
-        self, target_proc: "Optional[mp.Process]" = None
+        self,
+        target_proc: "Optional[mp.Process]" = None,
+        watched_job_id: Optional[str] = None,
     ) -> None:
         """Finalize parent state after a force-terminate so the UI leaves "Stopping..."
         even if the worker is wedged in driver teardown. No-ops if a new run has already
         replaced the worker we watched, so a stale watchdog never marks a fresh run
-        stopped or drops its handle. Preserves output_dir so a saved checkpoint is kept."""
+        stopped or drops its handle. Preserves output_dir so a saved checkpoint is kept.
+
+        Supersession is checked on both the watched proc and the watched job id:
+        start_training updates current_job_id before it installs the new _proc, so a
+        stale watchdog entering during that startup window still sees the old (dead)
+        handle and is caught by the job-id guard."""
         with self._lock:
-            if target_proc is not None and self._proc is not None and self._proc is not target_proc:
+            if target_proc is not None and self._proc is not target_proc:
                 return  # a new run replaced the worker; never touch its state
-            job_id = self.current_job_id
+            if watched_job_id is not None and self.current_job_id != watched_job_id:
+                return  # a new run is already starting up; leave its state alone
             self._progress.is_training = False
             self._progress.status_message = "Training stopped."
             output_dir = self._output_dir
             self._proc = None
         self._ensure_db_run_created()
-        self._finalize_run_in_db(status = "stopped", output_dir = output_dir, expected_job_id = job_id)
+        self._finalize_run_in_db(
+            status = "stopped", output_dir = output_dir, expected_job_id = watched_job_id
+        )
 
     def force_terminate(self, target_proc: "Optional[mp.Process]" = None) -> None:
         """Force-kill the training subprocess so state can be reset immediately. With
@@ -1654,18 +1672,28 @@ class TrainingBackend:
             self._finalize_run_in_db(**db_action_kwargs)
 
     def _ensure_db_run_created(self) -> None:
-        """Create the DB row if it doesn't exist yet. Claims creation under the lock so
-        the pump and watchdog can't both create the same run; unclaims on failure."""
+        """Create the DB row if it doesn't exist yet. A dedicated in-progress flag lets
+        only one caller create at a time, and ``_db_run_created`` is published only after
+        ``create_run`` commits, so a concurrent finalize never runs ``finish_run`` against
+        a not-yet-inserted row (an UPDATE that would touch zero rows and leave the run
+        stuck as running)."""
         with self._lock:
-            if self._db_run_created or not self.current_job_id or not self._db_config:
+            if (
+                self._db_run_created
+                or self._db_create_in_progress
+                or not self.current_job_id
+                or not self._db_config
+            ):
                 return
-            self._db_run_created = True  # claim so only one caller creates
+            self._db_create_in_progress = True  # only one caller creates
             job_id = self.current_job_id
             db_config = self._db_config
             started_at = self._db_started_at or datetime.now(timezone.utc).isoformat()
             total_steps = self._progress.total_steps or None
+        created = False
         try:
             from storage.studio_db import create_run
+
             dataset_name = (
                 db_config.get("hf_dataset")
                 or next(iter(db_config.get("local_datasets") or []), None)
@@ -1680,10 +1708,14 @@ class TrainingBackend:
                 started_at = started_at,
                 total_steps = total_steps,
             )
+            created = True
         except Exception:
-            with self._lock:
-                self._db_run_created = False  # unclaim so a later caller can retry
             logger.warning("Failed to create DB run record for early failure", exc_info = True)
+        finally:
+            with self._lock:
+                if created:
+                    self._db_run_created = True  # publish only after the insert commits
+                self._db_create_in_progress = False
 
     def _finalize_run_in_db(
         self,
@@ -1694,28 +1726,36 @@ class TrainingBackend:
     ) -> None:
         """Flush remaining metrics and mark a run as finished in the DB. Claims the
         finalize under the lock so the watchdog and pump can't double-finalize, and
-        no-ops when ``expected_job_id`` no longer matches (a new run took over)."""
+        no-ops when ``expected_job_id`` no longer matches (a new run took over). The run
+        id and the final-progress fields are snapshotted under the lock and threaded
+        through the flush/finish calls, so a racing new run started between this claim and
+        the DB writes can't be flushed or marked stopped under the old run's finalize."""
         with self._lock:
             if expected_job_id is not None and self.current_job_id != expected_job_id:
                 return
             if not self.current_job_id or not self._db_run_created or self._run_finalized:
                 return
             self._run_finalized = True  # claim so only one caller finalizes
-        self._flush_metrics_to_db()
+            run_id = self.current_job_id
+            final_step = self._progress.step
+            final_loss = self._progress.loss
+            if final_loss is not None and not math.isfinite(final_loss):
+                final_loss = None
+            duration = self._progress.elapsed_seconds
+            loss_history = list(self.loss_history)
+        self._flush_metrics_to_db(run_id = run_id)
         try:
             from storage.studio_db import finish_run
             from utils.downsample import downsample
 
-            sparkline = downsample(self.loss_history, 50)
+            sparkline = downsample(loss_history, 50)
             finish_run(
-                id = self.current_job_id,
+                id = run_id,
                 status = status,
                 ended_at = datetime.now(timezone.utc).isoformat(),
-                final_step = self._progress.step,
-                final_loss = self._progress.loss
-                if (self._progress.loss is not None and math.isfinite(self._progress.loss))
-                else None,
-                duration_seconds = self._progress.elapsed_seconds,
+                final_step = final_step,
+                final_loss = final_loss,
+                duration_seconds = duration,
                 loss_sparkline = _json.dumps(sparkline),
                 output_dir = output_dir,
                 error_message = error_message,
@@ -1725,12 +1765,15 @@ class TrainingBackend:
                 self._run_finalized = False  # unclaim so a later flush can retry
             logger.warning("Failed to finalize run in DB (status=%s)", status, exc_info = True)
 
-    def _flush_metrics_to_db(self) -> None:
-        """Flush buffered metrics to the database and update live progress. The buffer
-        is snapshotted and claimed under the lock so a concurrent flush (pump vs
-        watchdog finalize) can't double-remove or drop metrics."""
+    def _flush_metrics_to_db(self, run_id: Optional[str] = None) -> None:
+        """Flush buffered metrics to the database and update live progress. The target run
+        id, the metric batch, and the progress snapshot are all taken under the lock, so a
+        concurrent flush can't double-remove metrics and a racing new run can't redirect
+        the write to a different job. A finalizer passes ``run_id`` to pin the target to
+        the run it captured."""
         with self._lock:
-            if not self._metric_buffer or not self.current_job_id or not self._db_run_created:
+            target = run_id if run_id is not None else self.current_job_id
+            if not self._metric_buffer or not target or not self._db_run_created:
                 return
             # Cap buffer to bound memory growth.
             if len(self._metric_buffer) > 500:
@@ -1742,17 +1785,15 @@ class TrainingBackend:
             # Claim the batch under the lock so a concurrent flush can't re-remove it.
             batch = list(self._metric_buffer)
             del self._metric_buffer[: len(batch)]
+            step = self._progress.step
+            loss = self._progress.loss
+            if loss is not None and not math.isfinite(loss):
+                loss = None
+            duration = self._progress.elapsed_seconds
         try:
             from storage.studio_db import insert_metrics_batch, update_run_progress
-            insert_metrics_batch(self.current_job_id, batch)
-            update_run_progress(
-                id = self.current_job_id,
-                step = self._progress.step,
-                loss = self._progress.loss
-                if (self._progress.loss is not None and math.isfinite(self._progress.loss))
-                else None,
-                duration_seconds = self._progress.elapsed_seconds,
-            )
+            insert_metrics_batch(target, batch)
+            update_run_progress(id = target, step = step, loss = loss, duration_seconds = duration)
         except Exception:
             # Re-queue the claimed batch at the front so it retries on the next flush.
             with self._lock:

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -48,11 +48,9 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
-# Stop-watchdog escalation timeouts. After a Stop is requested, force-terminate the
-# worker if it does not exit on its own. Primary trigger is a short grace once
-# "complete" (save done) is seen. The absolute cap is a last-resort backstop only:
-# for a save=True stop it is long so a slow save is never killed mid-write; for a
-# cancel (save=False) there is nothing to save, so the backstop is shorter.
+# Stop-watchdog escalation timeouts. Primary trigger is a short grace once "complete"
+# (save done) is seen. The absolute cap is a backstop: long for save=True so a slow
+# save is never killed mid-write, shorter for a cancel that has nothing to save.
 _STOP_GRACE_S = _env_int("UNSLOTH_STUDIO_TRAINING_STOP_GRACE_S", 15)
 _STOP_TIMEOUT_S = _env_int("UNSLOTH_STUDIO_TRAINING_STOP_TIMEOUT_S", 600)
 _CANCEL_TIMEOUT_S = _env_int("UNSLOTH_STUDIO_TRAINING_CANCEL_TIMEOUT_S", 120)
@@ -984,11 +982,9 @@ class TrainingBackend:
         return True
 
     def _start_stop_watchdog(self, cancel: bool) -> None:
-        """Start a daemon that force-terminates the worker if a requested stop does
-        not exit on its own. No-op if no worker is alive or an existing watchdog is
-        already watching the current worker; a stale watchdog on an old proc does
-        not stop a new run from getting its own watcher.
-        """
+        """Start a daemon that force-terminates the worker if a requested stop does not
+        exit on its own. No-op if no worker is alive or a live watchdog already watches
+        this proc (a stale watchdog on an old proc never blocks a new run's watcher)."""
         with self._lock:
             proc = self._proc
             if proc is None or not proc.is_alive():
@@ -1010,14 +1006,9 @@ class TrainingBackend:
             watchdog.start()
 
     def _stop_watchdog_loop(self, target_proc: "mp.Process", cancel: bool) -> None:
-        """Escalate a stuck stop to force_terminate().
-
-        A worker normally exits shortly after saving; this only fires when it does
-        not. Primary trigger is a short grace after "complete" (save done). The
-        absolute cap is a last-resort backstop: long for save=True so a slow save is
-        never killed mid-write, shorter for a cancel that has nothing to save.
-        No-ops on a clean exit; exits silently if a new run replaces the worker.
-        """
+        """Escalate a stuck stop to force_terminate(): grace after "complete", else the
+        absolute backstop (see the module timeouts). No-ops on a clean exit; exits
+        silently if a new run replaces the worker."""
         started = time.monotonic()
         abs_timeout = _CANCEL_TIMEOUT_S if cancel else _STOP_TIMEOUT_S
         complete_at: Optional[float] = None
@@ -1043,8 +1034,7 @@ class TrainingBackend:
         if superseded or not target_proc.is_alive():
             return
         if complete_at is None:
-            # Backstop fired before completion: warn loudly since a save may still
-            # have been in progress (only reachable past the long save=True cap).
+            # Backstop fired pre-completion: a save may still be in progress.
             logger.warning(
                 "Stop watchdog: absolute timeout with no completion signal; "
                 "force-terminating a possibly-mid-save worker: %s",
@@ -1052,8 +1042,7 @@ class TrainingBackend:
             )
         else:
             logger.warning("Stop watchdog force-terminating stuck training worker: %s", reason)
-        # force_terminate can raise on a wedged child (re-issued kill); finalize
-        # regardless so the run never stays stuck in "Stopping...".
+        # force_terminate can raise on a wedged child; finalize regardless.
         try:
             self.force_terminate(target_proc = target_proc)
         except Exception:
@@ -1062,11 +1051,9 @@ class TrainingBackend:
             self._finalize_stopped_after_escalation()
 
     def _finalize_stopped_after_escalation(self) -> None:
-        """Finalize parent state after a watchdog force-terminate so the UI leaves
-        "Stopping..." even if the worker is wedged in driver teardown and unreaped.
-        Dropping the handle is safe: the worker is a daemon bound to parent lifetime.
-        Preserve output_dir so a saved checkpoint is still recorded in run history.
-        """
+        """Finalize parent state after a force-terminate so the UI leaves "Stopping..."
+        even if the worker is wedged in driver teardown. Dropping the handle is safe
+        (daemon bound to parent). Preserves output_dir so a saved checkpoint is kept."""
         with self._lock:
             self._progress.is_training = False
             self._progress.status_message = "Training stopped."
@@ -1076,11 +1063,9 @@ class TrainingBackend:
         self._finalize_run_in_db(status = "stopped", output_dir = output_dir)
 
     def force_terminate(self, target_proc: "Optional[mp.Process]" = None) -> None:
-        """Force-kill the training subprocess so state can be reset immediately.
-
-        When ``target_proc`` is given, terminate only that handle and no-op if a new
-        run has since replaced it, so the watchdog can never kill a fresh worker.
-        """
+        """Force-kill the training subprocess so state can be reset immediately. With
+        ``target_proc``, terminate only that handle and no-op if a new run has replaced
+        it, so the watchdog can never kill a fresh worker."""
         with self._lock:
             proc = self._proc
             if target_proc is not None and proc is not target_proc:

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -1010,15 +1010,18 @@ class TrainingBackend:
         absolute backstop (see the module timeouts). No-ops on a clean exit; exits
         silently if a new run replaces the worker."""
         started = time.monotonic()
-        abs_timeout = _CANCEL_TIMEOUT_S if cancel else _STOP_TIMEOUT_S
         complete_at: Optional[float] = None
         reason = ""
         while True:
             with self._lock:
                 superseded = self._proc is not target_proc
+                # A cancel has nothing to save, so honor a later cancel (save=False)
+                # by tightening an in-flight save watchdog to the shorter cancel cap.
+                cancelling = cancel or self._cancel_requested
             if superseded or not target_proc.is_alive():
                 return
             now = time.monotonic()
+            abs_timeout = _CANCEL_TIMEOUT_S if cancelling else _STOP_TIMEOUT_S
             if complete_at is None and self._complete_seen.is_set():
                 complete_at = now
             if complete_at is not None and now - complete_at >= _STOP_GRACE_S:
@@ -1048,19 +1051,25 @@ class TrainingBackend:
         except Exception:
             logger.exception("Stop watchdog: force_terminate failed; finalizing anyway")
         finally:
-            self._finalize_stopped_after_escalation()
+            self._finalize_stopped_after_escalation(target_proc = target_proc)
 
-    def _finalize_stopped_after_escalation(self) -> None:
+    def _finalize_stopped_after_escalation(
+        self, target_proc: "Optional[mp.Process]" = None
+    ) -> None:
         """Finalize parent state after a force-terminate so the UI leaves "Stopping..."
-        even if the worker is wedged in driver teardown. Dropping the handle is safe
-        (daemon bound to parent). Preserves output_dir so a saved checkpoint is kept."""
+        even if the worker is wedged in driver teardown. No-ops if a new run has already
+        replaced the worker we watched, so a stale watchdog never marks a fresh run
+        stopped or drops its handle. Preserves output_dir so a saved checkpoint is kept."""
         with self._lock:
+            if target_proc is not None and self._proc is not None and self._proc is not target_proc:
+                return  # a new run replaced the worker; never touch its state
+            job_id = self.current_job_id
             self._progress.is_training = False
             self._progress.status_message = "Training stopped."
             output_dir = self._output_dir
             self._proc = None
         self._ensure_db_run_created()
-        self._finalize_run_in_db(status = "stopped", output_dir = output_dir)
+        self._finalize_run_in_db(status = "stopped", output_dir = output_dir, expected_job_id = job_id)
 
     def force_terminate(self, target_proc: "Optional[mp.Process]" = None) -> None:
         """Force-kill the training subprocess so state can be reset immediately. With
@@ -1645,28 +1654,35 @@ class TrainingBackend:
             self._finalize_run_in_db(**db_action_kwargs)
 
     def _ensure_db_run_created(self) -> None:
-        """Create the DB row if it doesn't exist yet. Called outside the lock."""
-        if self._db_run_created or not self.current_job_id or not self._db_config:
-            return
+        """Create the DB row if it doesn't exist yet. Claims creation under the lock so
+        the pump and watchdog can't both create the same run; unclaims on failure."""
+        with self._lock:
+            if self._db_run_created or not self.current_job_id or not self._db_config:
+                return
+            self._db_run_created = True  # claim so only one caller creates
+            job_id = self.current_job_id
+            db_config = self._db_config
+            started_at = self._db_started_at or datetime.now(timezone.utc).isoformat()
+            total_steps = self._progress.total_steps or None
         try:
             from storage.studio_db import create_run
-
             dataset_name = (
-                self._db_config.get("hf_dataset")
-                or next(iter(self._db_config.get("local_datasets") or []), None)
-                or _s3_dataset_name(self._db_config.get("s3_dataset"))
+                db_config.get("hf_dataset")
+                or next(iter(db_config.get("local_datasets") or []), None)
+                or _s3_dataset_name(db_config.get("s3_dataset"))
                 or "unknown"
             )
             create_run(
-                id = self.current_job_id,
-                model_name = self._db_config["model_name"],
+                id = job_id,
+                model_name = db_config["model_name"],
                 dataset_name = dataset_name,
-                config_json = _json.dumps(self._db_config),
-                started_at = self._db_started_at or datetime.now(timezone.utc).isoformat(),
-                total_steps = self._progress.total_steps or None,
+                config_json = _json.dumps(db_config),
+                started_at = started_at,
+                total_steps = total_steps,
             )
-            self._db_run_created = True
         except Exception:
+            with self._lock:
+                self._db_run_created = False  # unclaim so a later caller can retry
             logger.warning("Failed to create DB run record for early failure", exc_info = True)
 
     def _finalize_run_in_db(
@@ -1674,10 +1690,17 @@ class TrainingBackend:
         status: str,
         error_message: Optional[str] = None,
         output_dir: Optional[str] = None,
+        expected_job_id: Optional[str] = None,
     ) -> None:
-        """Flush remaining metrics and mark a run as finished in the DB."""
-        if not self.current_job_id or not self._db_run_created or self._run_finalized:
-            return
+        """Flush remaining metrics and mark a run as finished in the DB. Claims the
+        finalize under the lock so the watchdog and pump can't double-finalize, and
+        no-ops when ``expected_job_id`` no longer matches (a new run took over)."""
+        with self._lock:
+            if expected_job_id is not None and self.current_job_id != expected_job_id:
+                return
+            if not self.current_job_id or not self._db_run_created or self._run_finalized:
+                return
+            self._run_finalized = True  # claim so only one caller finalizes
         self._flush_metrics_to_db()
         try:
             from storage.studio_db import finish_run
@@ -1697,28 +1720,31 @@ class TrainingBackend:
                 output_dir = output_dir,
                 error_message = error_message,
             )
-            self._run_finalized = True
         except Exception:
+            with self._lock:
+                self._run_finalized = False  # unclaim so a later flush can retry
             logger.warning("Failed to finalize run in DB (status=%s)", status, exc_info = True)
 
     def _flush_metrics_to_db(self) -> None:
-        """Flush buffered metrics to the database and update live progress."""
-        if not self._metric_buffer or not self.current_job_id or not self._db_run_created:
-            return
-        # Cap buffer to bound memory growth.
-        if len(self._metric_buffer) > 500:
-            logger.warning(
-                "Metric buffer exceeded 500 entries (%d) — trimming oldest",
-                len(self._metric_buffer),
-            )
-            self._metric_buffer = self._metric_buffer[-500:]
-        # Snapshot before insert so metrics arriving during the write survive.
-        batch = list(self._metric_buffer)
+        """Flush buffered metrics to the database and update live progress. The buffer
+        is snapshotted and claimed under the lock so a concurrent flush (pump vs
+        watchdog finalize) can't double-remove or drop metrics."""
+        with self._lock:
+            if not self._metric_buffer or not self.current_job_id or not self._db_run_created:
+                return
+            # Cap buffer to bound memory growth.
+            if len(self._metric_buffer) > 500:
+                logger.warning(
+                    "Metric buffer exceeded 500 entries (%d) — trimming oldest",
+                    len(self._metric_buffer),
+                )
+                del self._metric_buffer[:-500]
+            # Claim the batch under the lock so a concurrent flush can't re-remove it.
+            batch = list(self._metric_buffer)
+            del self._metric_buffer[: len(batch)]
         try:
             from storage.studio_db import insert_metrics_batch, update_run_progress
-
             insert_metrics_batch(self.current_job_id, batch)
-            del self._metric_buffer[: len(batch)]
             update_run_progress(
                 id = self.current_job_id,
                 step = self._progress.step,
@@ -1728,7 +1754,9 @@ class TrainingBackend:
                 duration_seconds = self._progress.elapsed_seconds,
             )
         except Exception:
-            # Leave buffer intact for retry on next flush
+            # Re-queue the claimed batch at the front so it retries on the next flush.
+            with self._lock:
+                self._metric_buffer[:0] = batch
             logger.warning("Failed to flush metrics to DB", exc_info = True)
 
     @staticmethod

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -989,9 +989,7 @@ class TrainingBackend:
             proc = self._proc
             if proc is None or not proc.is_alive():
                 return
-            watchdog = threading.Thread(
-                target = self._stop_watchdog_loop, args = (proc,), daemon = True
-            )
+            watchdog = threading.Thread(target = self._stop_watchdog_loop, args = (proc,), daemon = True)
             self._stop_watchdog = watchdog
             watchdog.start()
 

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -1087,12 +1087,15 @@ class TrainingBackend:
             if watched_job_id is not None and self.current_job_id != watched_job_id:
                 return  # a new run is already starting up; leave its state alone
             run_id = self.current_job_id  # == watched_job_id; capture before exposing idle
-            db_created = self._db_run_created
-            already_final = self._run_finalized
+            # Only claim the finalize when the row already exists. If creation is still in
+            # progress (an early create failed and the pump is retrying it), claiming here
+            # would make the pump's later finalize no-op and strand the row as running, so
+            # leave the finalize to that create-then-finalize path.
+            do_finalize = bool(run_id) and self._db_run_created and not self._run_finalized
             batch: list = []
             final_step = final_loss = duration = None
             loss_history: list = []
-            if not already_final:
+            if do_finalize:
                 self._run_finalized = True  # claim this run's finalize
                 batch = list(self._metric_buffer)
                 del self._metric_buffer[: len(batch)]
@@ -1106,7 +1109,7 @@ class TrainingBackend:
             self._progress.status_message = "Training stopped."
             output_dir = self._output_dir
             self._proc = None
-        if run_id and db_created and not already_final:
+        if do_finalize:
             self._finish_stopped_run(
                 run_id, output_dir, batch, final_step, final_loss, duration, loss_history
             )
@@ -1126,7 +1129,9 @@ class TrainingBackend:
         longer current (a new run started in the gap after the backend went idle) is still
         finalized. insert_metrics_batch upserts and finish_run is an idempotent UPDATE, so
         a concurrent pump finalize of the same run is harmless and a different current run
-        is never touched."""
+        is never touched. On a DB error (e.g. a transient SQLite lock), the finalize is
+        unclaimed and the metrics re-queued when the run is still current, so the pump or a
+        later retry can still record it stopped instead of stranding the row as running."""
         try:
             from storage.studio_db import finish_run, insert_metrics_batch
             from utils.downsample import downsample
@@ -1147,6 +1152,12 @@ class TrainingBackend:
             )
         except Exception:
             logger.warning("Failed to finalize stopped run %s in DB", run_id, exc_info = True)
+            with self._lock:
+                # Only if this run is still current; a new run's state must never be touched.
+                if self.current_job_id == run_id:
+                    self._run_finalized = False  # unclaim so the pump/a later retry finalizes
+                    if batch:
+                        self._metric_buffer[:0] = batch  # requeue drained metrics for retry
 
     def force_terminate(self, target_proc: "Optional[mp.Process]" = None) -> None:
         """Force-kill the training subprocess so state can be reset immediately. With

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -1074,20 +1074,79 @@ class TrainingBackend:
         Supersession is checked on both the watched proc and the watched job id:
         start_training updates current_job_id before it installs the new _proc, so a
         stale watchdog entering during that startup window still sees the old (dead)
-        handle and is caught by the job-id guard."""
+        handle and is caught by the job-id guard.
+
+        Once the guards pass, current_job_id is guaranteed to be the watched run, so the
+        run is finalized by that captured id (not the mutable current_job_id). Clearing
+        _proc exposes the backend as idle; a new run starting in that gap gets its own
+        fresh state and is never finalized here, and the old run is still recorded stopped
+        because finish_run targets the captured id."""
         with self._lock:
             if target_proc is not None and self._proc is not target_proc:
                 return  # a new run replaced the worker; never touch its state
             if watched_job_id is not None and self.current_job_id != watched_job_id:
                 return  # a new run is already starting up; leave its state alone
+            run_id = self.current_job_id  # == watched_job_id; capture before exposing idle
+            db_created = self._db_run_created
+            already_final = self._run_finalized
+            batch: list = []
+            final_step = final_loss = duration = None
+            loss_history: list = []
+            if not already_final:
+                self._run_finalized = True  # claim this run's finalize
+                batch = list(self._metric_buffer)
+                del self._metric_buffer[: len(batch)]
+                final_step = self._progress.step
+                final_loss = self._progress.loss
+                if final_loss is not None and not math.isfinite(final_loss):
+                    final_loss = None
+                duration = self._progress.elapsed_seconds
+                loss_history = list(self.loss_history)
             self._progress.is_training = False
             self._progress.status_message = "Training stopped."
             output_dir = self._output_dir
             self._proc = None
-        self._ensure_db_run_created()
-        self._finalize_run_in_db(
-            status = "stopped", output_dir = output_dir, expected_job_id = watched_job_id
-        )
+        if run_id and db_created and not already_final:
+            self._finish_stopped_run(
+                run_id, output_dir, batch, final_step, final_loss, duration, loss_history
+            )
+
+    def _finish_stopped_run(
+        self,
+        run_id: str,
+        output_dir: Optional[str],
+        batch: list,
+        final_step: Optional[int],
+        final_loss: Optional[float],
+        duration: Optional[float],
+        loss_history: list,
+    ) -> None:
+        """Record a force-stopped run as finished by its captured id, using state
+        snapshotted under the lock. The stop watchdog uses this so a run whose id is no
+        longer current (a new run started in the gap after the backend went idle) is still
+        finalized. insert_metrics_batch upserts and finish_run is an idempotent UPDATE, so
+        a concurrent pump finalize of the same run is harmless and a different current run
+        is never touched."""
+        try:
+            from storage.studio_db import finish_run, insert_metrics_batch
+            from utils.downsample import downsample
+
+            if batch:
+                insert_metrics_batch(run_id, batch)
+            sparkline = downsample(loss_history, 50)
+            finish_run(
+                id = run_id,
+                status = "stopped",
+                ended_at = datetime.now(timezone.utc).isoformat(),
+                final_step = final_step,
+                final_loss = final_loss,
+                duration_seconds = duration,
+                loss_sparkline = _json.dumps(sparkline),
+                output_dir = output_dir,
+                error_message = None,
+            )
+        except Exception:
+            logger.warning("Failed to finalize stopped run %s in DB", run_id, exc_info = True)
 
     def force_terminate(self, target_proc: "Optional[mp.Process]" = None) -> None:
         """Force-kill the training subprocess so state can be reset immediately. With

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -941,6 +941,7 @@ class TrainingBackend:
         self._metric_buffer.clear()
         self._run_finalized = False
         self._db_run_created = False
+        self._db_create_in_progress = False  # a stale watchdog create can't block this run
         self._db_total_steps_set = False
         self._db_config = _sanitize_db_config(config)
         self._db_started_at = datetime.now(timezone.utc).isoformat()
@@ -1801,9 +1802,14 @@ class TrainingBackend:
             logger.warning("Failed to create DB run record for early failure", exc_info = True)
         finally:
             with self._lock:
-                if created:
-                    self._db_run_created = True  # publish only after the insert commits
-                self._db_create_in_progress = False
+                # Publish the flags only if this is still the current run. A killed worker
+                # lets a new /start proceed mid-create, and these flags are backend-wide, so
+                # a stale create for the captured job must not satisfy the new run's DB state
+                # (the row was still created by id; the new run owns/creates its own row).
+                if self.current_job_id == job_id:
+                    if created:
+                        self._db_run_created = True  # publish only after the insert commits
+                    self._db_create_in_progress = False
 
     def _finalize_run_in_db(
         self,

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -55,6 +55,11 @@ _STOP_GRACE_S = _env_int("UNSLOTH_STUDIO_TRAINING_STOP_GRACE_S", 15)
 _STOP_TIMEOUT_S = _env_int("UNSLOTH_STUDIO_TRAINING_STOP_TIMEOUT_S", 600)
 _CANCEL_TIMEOUT_S = _env_int("UNSLOTH_STUDIO_TRAINING_CANCEL_TIMEOUT_S", 120)
 
+# Watchdog DB finalize: a few short retries so a transient SQLite lock doesn't lose the
+# terminal state, since the watchdog is the sole finalizer once _proc is dropped.
+_DB_FINALIZE_RETRIES = 3
+_DB_FINALIZE_RETRY_S = 0.5
+
 _pyplot = None
 _pyplot_failed = False
 
@@ -1074,23 +1079,36 @@ class TrainingBackend:
         Supersession is checked on both the watched proc and job id: start_training sets
         current_job_id before it installs the new _proc, so a stale watchdog entering that
         startup window still sees the old (dead) handle and is caught by the job-id guard.
-        Past the guards current_job_id is the watched run, so it is finalized by that
-        captured id; clearing _proc exposes idle, and a new run starting in that gap gets
-        fresh state (never finalized here) while the old run is still recorded stopped."""
+
+        The run's terminal DB state is recorded (create-if-needed + finish by captured id)
+        BEFORE _proc is dropped: a wedged worker still reports alive, so the pump never
+        reaches its own finalize and would bail on its _proc-is-None guard once the handle
+        is gone. While the handle is held is_training_active() stays true, so no new run can
+        start and current_job_id stays the watched run for the write. _proc is dropped last,
+        re-guarded on target_proc so a run that did replace the worker keeps its handle."""
         with self._lock:
             if target_proc is not None and self._proc is not target_proc:
                 return  # a new run replaced the worker; never touch its state
             if watched_job_id is not None and self.current_job_id != watched_job_id:
                 return  # a new run is already starting up; leave its state alone
-            run_id = self.current_job_id  # == watched_job_id; capture before exposing idle
-            # Only claim the finalize once the row exists. If creation is still retrying
-            # (an early create failed), claiming here would no-op the pump's later finalize
-            # and strand the row as running, so leave it to that create-then-finalize path.
-            do_finalize = bool(run_id) and self._db_run_created and not self._run_finalized
+            run_id = self.current_job_id  # == watched_job_id
+            self._progress.is_training = False
+            self._progress.status_message = "Training stopped."
+        # Create the row if a start-time create failed (no-op otherwise; skips when the pump
+        # is mid-create, in which case its create-then-finalize records the run instead).
+        self._ensure_db_run_created()
+        with self._lock:
+            claim = (
+                bool(run_id)
+                and self.current_job_id == run_id
+                and self._db_run_created
+                and not self._run_finalized
+            )
             batch: list = []
             final_step = final_loss = duration = None
             loss_history: list = []
-            if do_finalize:
+            output_dir = self._output_dir
+            if claim:
                 self._run_finalized = True  # claim this run's finalize
                 batch = list(self._metric_buffer)
                 del self._metric_buffer[: len(batch)]
@@ -1100,14 +1118,13 @@ class TrainingBackend:
                     final_loss = None
                 duration = self._progress.elapsed_seconds
                 loss_history = list(self.loss_history)
-            self._progress.is_training = False
-            self._progress.status_message = "Training stopped."
-            output_dir = self._output_dir
-            self._proc = None
-        if do_finalize:
+        if claim:
             self._finish_stopped_run(
                 run_id, output_dir, batch, final_step, final_loss, duration, loss_history
             )
+        with self._lock:
+            if target_proc is None or self._proc is target_proc:
+                self._proc = None  # drop only our handle, never a run that replaced it
 
     def _finish_stopped_run(
         self,
@@ -1119,39 +1136,47 @@ class TrainingBackend:
         duration: Optional[float],
         loss_history: list,
     ) -> None:
-        """Record a force-stopped run as finished by its captured id, from state snapshotted
-        under the lock, so a run whose id is no longer current (a new run started in the gap
-        after the backend went idle) is still finalized. insert_metrics_batch upserts and
-        finish_run is an idempotent UPDATE, so a concurrent pump finalize of the same run is
-        harmless and a different current run is never touched. On a DB error, the finalize is
-        unclaimed and metrics re-queued only when the run is still current, so the pump or a
-        later retry can still record it stopped instead of stranding the row as running."""
-        try:
-            from storage.studio_db import finish_run, insert_metrics_batch
-            from utils.downsample import downsample
+        """Record a force-stopped run finished by its captured id, from state snapshotted
+        under the lock. insert_metrics_batch upserts and finish_run is an idempotent UPDATE,
+        so a concurrent pump finalize of the same run is harmless and a different current run
+        is never touched. The watchdog is the sole finalizer once _proc is dropped, so a
+        transient DB error (e.g. a SQLite lock) is retried a few times; on final failure the
+        finalize is unclaimed (only if the run is still current) so the row is not left
+        claimed-but-unfinalized."""
+        for attempt in range(_DB_FINALIZE_RETRIES):
+            try:
+                from storage.studio_db import finish_run, insert_metrics_batch
+                from utils.downsample import downsample
 
-            if batch:
-                insert_metrics_batch(run_id, batch)
-            sparkline = downsample(loss_history, 50)
-            finish_run(
-                id = run_id,
-                status = "stopped",
-                ended_at = datetime.now(timezone.utc).isoformat(),
-                final_step = final_step,
-                final_loss = final_loss,
-                duration_seconds = duration,
-                loss_sparkline = _json.dumps(sparkline),
-                output_dir = output_dir,
-                error_message = None,
-            )
-        except Exception:
-            logger.warning("Failed to finalize stopped run %s in DB", run_id, exc_info = True)
-            with self._lock:
-                # Only if this run is still current; a new run's state must never be touched.
-                if self.current_job_id == run_id:
-                    self._run_finalized = False  # unclaim so the pump/a later retry finalizes
-                    if batch:
-                        self._metric_buffer[:0] = batch  # requeue drained metrics for retry
+                if batch:
+                    insert_metrics_batch(run_id, batch)
+                sparkline = downsample(loss_history, 50)
+                finish_run(
+                    id = run_id,
+                    status = "stopped",
+                    ended_at = datetime.now(timezone.utc).isoformat(),
+                    final_step = final_step,
+                    final_loss = final_loss,
+                    duration_seconds = duration,
+                    loss_sparkline = _json.dumps(sparkline),
+                    output_dir = output_dir,
+                    error_message = None,
+                )
+                return
+            except Exception:
+                if attempt + 1 < _DB_FINALIZE_RETRIES:
+                    time.sleep(_DB_FINALIZE_RETRY_S)
+                    continue
+                logger.warning(
+                    "Failed to finalize stopped run %s in DB after %d attempts",
+                    run_id,
+                    _DB_FINALIZE_RETRIES,
+                    exc_info = True,
+                )
+                with self._lock:
+                    # Only if still current; a new run's finalize state is never touched.
+                    if self.current_job_id == run_id:
+                        self._run_finalized = False
 
     def force_terminate(self, target_proc: "Optional[mp.Process]" = None) -> None:
         """Force-kill the training subprocess so state can be reset immediately. With

--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -48,9 +48,9 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
-# Stop-watchdog escalation timeouts. Primary trigger is a short grace once "complete"
-# (save done) is seen. The absolute cap is a backstop: long for save=True so a slow
-# save is never killed mid-write, shorter for a cancel that has nothing to save.
+# Stop-watchdog escalation timeouts. Primary trigger: a short grace once "complete"
+# (save done). Absolute cap is a backstop: long for save=True so a slow save is never
+# killed mid-write, shorter for a cancel that has nothing to save.
 _STOP_GRACE_S = _env_int("UNSLOTH_STUDIO_TRAINING_STOP_GRACE_S", 15)
 _STOP_TIMEOUT_S = _env_int("UNSLOTH_STUDIO_TRAINING_STOP_TIMEOUT_S", 600)
 _CANCEL_TIMEOUT_S = _env_int("UNSLOTH_STUDIO_TRAINING_CANCEL_TIMEOUT_S", 120)
@@ -1021,8 +1021,8 @@ class TrainingBackend:
         while True:
             with self._lock:
                 superseded = self._proc is not target_proc
-                # A cancel has nothing to save, so honor a later cancel (save=False)
-                # by tightening an in-flight save watchdog to the shorter cancel cap.
+                # A later cancel has nothing to save, so tighten an in-flight save
+                # watchdog to the shorter cancel cap.
                 cancelling = cancel or self._cancel_requested
             if superseded or not target_proc.is_alive():
                 return
@@ -1067,30 +1067,25 @@ class TrainingBackend:
         watched_job_id: Optional[str] = None,
     ) -> None:
         """Finalize parent state after a force-terminate so the UI leaves "Stopping..."
-        even if the worker is wedged in driver teardown. No-ops if a new run has already
-        replaced the worker we watched, so a stale watchdog never marks a fresh run
-        stopped or drops its handle. Preserves output_dir so a saved checkpoint is kept.
+        even if the worker is wedged in driver teardown; preserves output_dir so a saved
+        checkpoint is kept. No-ops if a new run already replaced the watched worker, so a
+        stale watchdog never marks a fresh run stopped or drops its handle.
 
-        Supersession is checked on both the watched proc and the watched job id:
-        start_training updates current_job_id before it installs the new _proc, so a
-        stale watchdog entering during that startup window still sees the old (dead)
-        handle and is caught by the job-id guard.
-
-        Once the guards pass, current_job_id is guaranteed to be the watched run, so the
-        run is finalized by that captured id (not the mutable current_job_id). Clearing
-        _proc exposes the backend as idle; a new run starting in that gap gets its own
-        fresh state and is never finalized here, and the old run is still recorded stopped
-        because finish_run targets the captured id."""
+        Supersession is checked on both the watched proc and job id: start_training sets
+        current_job_id before it installs the new _proc, so a stale watchdog entering that
+        startup window still sees the old (dead) handle and is caught by the job-id guard.
+        Past the guards current_job_id is the watched run, so it is finalized by that
+        captured id; clearing _proc exposes idle, and a new run starting in that gap gets
+        fresh state (never finalized here) while the old run is still recorded stopped."""
         with self._lock:
             if target_proc is not None and self._proc is not target_proc:
                 return  # a new run replaced the worker; never touch its state
             if watched_job_id is not None and self.current_job_id != watched_job_id:
                 return  # a new run is already starting up; leave its state alone
             run_id = self.current_job_id  # == watched_job_id; capture before exposing idle
-            # Only claim the finalize when the row already exists. If creation is still in
-            # progress (an early create failed and the pump is retrying it), claiming here
-            # would make the pump's later finalize no-op and strand the row as running, so
-            # leave the finalize to that create-then-finalize path.
+            # Only claim the finalize once the row exists. If creation is still retrying
+            # (an early create failed), claiming here would no-op the pump's later finalize
+            # and strand the row as running, so leave it to that create-then-finalize path.
             do_finalize = bool(run_id) and self._db_run_created and not self._run_finalized
             batch: list = []
             final_step = final_loss = duration = None
@@ -1124,13 +1119,12 @@ class TrainingBackend:
         duration: Optional[float],
         loss_history: list,
     ) -> None:
-        """Record a force-stopped run as finished by its captured id, using state
-        snapshotted under the lock. The stop watchdog uses this so a run whose id is no
-        longer current (a new run started in the gap after the backend went idle) is still
-        finalized. insert_metrics_batch upserts and finish_run is an idempotent UPDATE, so
-        a concurrent pump finalize of the same run is harmless and a different current run
-        is never touched. On a DB error (e.g. a transient SQLite lock), the finalize is
-        unclaimed and the metrics re-queued when the run is still current, so the pump or a
+        """Record a force-stopped run as finished by its captured id, from state snapshotted
+        under the lock, so a run whose id is no longer current (a new run started in the gap
+        after the backend went idle) is still finalized. insert_metrics_batch upserts and
+        finish_run is an idempotent UPDATE, so a concurrent pump finalize of the same run is
+        harmless and a different current run is never touched. On a DB error, the finalize is
+        unclaimed and metrics re-queued only when the run is still current, so the pump or a
         later retry can still record it stopped instead of stranding the row as running."""
         try:
             from storage.studio_db import finish_run, insert_metrics_batch
@@ -1742,11 +1736,10 @@ class TrainingBackend:
             self._finalize_run_in_db(**db_action_kwargs)
 
     def _ensure_db_run_created(self) -> None:
-        """Create the DB row if it doesn't exist yet. A dedicated in-progress flag lets
-        only one caller create at a time, and ``_db_run_created`` is published only after
-        ``create_run`` commits, so a concurrent finalize never runs ``finish_run`` against
-        a not-yet-inserted row (an UPDATE that would touch zero rows and leave the run
-        stuck as running)."""
+        """Create the DB row if it doesn't exist yet. An in-progress flag lets only one
+        caller create at a time, and ``_db_run_created`` is published only after
+        ``create_run`` commits, so a concurrent finalize never runs ``finish_run`` against a
+        not-yet-inserted row (a zero-row UPDATE that would leave the run stuck as running)."""
         with self._lock:
             if (
                 self._db_run_created
@@ -1794,18 +1787,18 @@ class TrainingBackend:
         output_dir: Optional[str] = None,
         expected_job_id: Optional[str] = None,
     ) -> None:
-        """Flush remaining metrics and mark a run as finished in the DB. Claims the
-        finalize under the lock so the watchdog and pump can't double-finalize, and
-        no-ops when ``expected_job_id`` no longer matches (a new run took over). The run
-        id and the final-progress fields are snapshotted under the lock and threaded
-        through the flush/finish calls, so a racing new run started between this claim and
-        the DB writes can't be flushed or marked stopped under the old run's finalize."""
+        """Flush remaining metrics and mark a run finished in the DB. Claims the finalize
+        under the lock so the watchdog and pump can't double-finalize, and no-ops when
+        ``expected_job_id`` no longer matches (a new run took over). The run id and final
+        progress are snapshotted under the lock and threaded through the flush/finish calls,
+        so a new run racing between this claim and the DB writes can't be flushed or marked
+        stopped under the old run's finalize."""
         with self._lock:
             if expected_job_id is not None and self.current_job_id != expected_job_id:
                 return
             if not self.current_job_id or not self._db_run_created or self._run_finalized:
                 return
-            self._run_finalized = True  # claim so only one caller finalizes
+            self._run_finalized = True
             run_id = self.current_job_id
             final_step = self._progress.step
             final_loss = self._progress.loss
@@ -1836,11 +1829,10 @@ class TrainingBackend:
             logger.warning("Failed to finalize run in DB (status=%s)", status, exc_info = True)
 
     def _flush_metrics_to_db(self, run_id: Optional[str] = None) -> None:
-        """Flush buffered metrics to the database and update live progress. The target run
-        id, the metric batch, and the progress snapshot are all taken under the lock, so a
-        concurrent flush can't double-remove metrics and a racing new run can't redirect
-        the write to a different job. A finalizer passes ``run_id`` to pin the target to
-        the run it captured."""
+        """Flush buffered metrics to the DB and update live progress. The target run id,
+        metric batch, and progress snapshot are all taken under the lock, so a concurrent
+        flush can't double-remove metrics and a racing new run can't redirect the write to
+        a different job. A finalizer passes ``run_id`` to pin the target to its captured run."""
         with self._lock:
             target = run_id if run_id is not None else self.current_job_id
             if not self._metric_buffer or not target or not self._db_run_created:

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -691,10 +691,10 @@ def test_escalation_finalizes_watched_run_by_id_end_to_end(monkeypatch):
     assert b._metric_buffer == [], "the captured batch must be drained"
 
 
-def test_escalation_does_not_claim_finalize_before_row_exists(monkeypatch):
-    # If the DB row is not created yet (an early create failed and the pump is retrying),
-    # the escalation must not claim _run_finalized or call _finish_stopped_run, so the
-    # pump's later create-then-finalize still records the run.
+def test_escalation_defers_when_row_cannot_be_created_here(monkeypatch):
+    # If the row does not exist and cannot be created here (no db_config, or the pump is
+    # mid-create), the escalation must not claim _run_finalized or call _finish_stopped_run,
+    # so the pump's create-then-finalize records the run. Parent state still clears.
     b = TrainingBackend()
     called: list = []
     monkeypatch.setattr(b, "_finish_stopped_run", lambda *a: called.append(a))
@@ -702,47 +702,95 @@ def test_escalation_does_not_claim_finalize_before_row_exists(monkeypatch):
     b._proc = _FakeProc(alive = False)
     b.current_job_id = "job_q"
     b._db_run_created = False  # row not created yet
+    b._db_config = None  # ... and cannot be created here
     b._run_finalized = False
     b._progress.is_training = True
 
     b._finalize_stopped_after_escalation(target_proc = b._proc, watched_job_id = "job_q")
 
-    assert called == [], "must not finalize before the row exists"
+    assert called == [], "must not finalize when the row can't be established here"
     assert b._run_finalized is False, "must not claim the finalize the pump still owes"
     assert b._progress.is_training is False, "parent state must still clear so the UI unsticks"
     assert b._proc is None
 
 
-def test_finish_stopped_run_requeues_on_db_error(monkeypatch):
-    # A transient DB error must unclaim the finalize and requeue the drained metrics
-    # (when the run is still current) so a later retry can record it stopped.
+def test_escalation_creates_row_then_finalizes_when_start_create_failed(monkeypatch):
+    # A wedged worker's pump can never finalize and would bail once _proc is dropped, so if
+    # the row was never created (start-time create failed) the escalation creates it and
+    # finalizes by id itself, recording the terminal state before dropping the handle.
+    recs = _install_fake_db(monkeypatch)
+    b = TrainingBackend()
+    b.current_job_id = "job_s"
+    b._db_config = {"model_name": "m"}  # so _ensure_db_run_created can create the row
+    b._db_run_created = False  # start-time create failed
+    b._proc = _FakeProc(alive = True)  # wedged: still reports alive
+    b._should_stop = True
+    b._progress.is_training = True
+
+    b._finalize_stopped_after_escalation(target_proc = b._proc, watched_job_id = "job_s")
+
+    assert [c["id"] for c in recs["created"]] == ["job_s"], "must create the missing row"
+    assert [f["id"] for f in recs["finished"]] == ["job_s"], "must finish the created row by id"
+    assert b._proc is None, "handle dropped only after the terminal state is recorded"
+    assert b._db_run_created is True
+
+
+def test_escalation_does_not_drop_a_new_runs_handle(monkeypatch):
+    # If a run replaces the worker while the finalize DB write is in flight, the final _proc
+    # drop must leave the new run's handle intact (re-guarded on target_proc).
+    b = TrainingBackend()
+    b.current_job_id = "job_old"
+    b._db_run_created = True
+    old_proc = _FakeProc(alive = False)
+    new_proc = _FakeProc(alive = True)
+    b._proc = old_proc
+
+    def hijack(*a):
+        b._proc = new_proc  # a new run takes over during the finalize
+
+    monkeypatch.setattr(b, "_finish_stopped_run", hijack)
+
+    b._finalize_stopped_after_escalation(target_proc = old_proc, watched_job_id = "job_old")
+
+    assert b._proc is new_proc, "must not drop the handle a new run installed during finalize"
+
+
+def _make_finish_raise(monkeypatch, calls):
+    fn = sys.modules["storage.studio_db"]
+
+    def _boom(**kw):
+        calls.append(kw)
+        raise RuntimeError("database is locked")
+
+    fn.finish_run = _boom
+
+
+def test_finish_stopped_run_retries_then_unclaims_on_db_error(monkeypatch):
+    # The watchdog is the sole finalizer once _proc is dropped, so a transient DB error is
+    # retried a few times; on final failure the finalize is unclaimed (run still current).
+    monkeypatch.setitem(_G, "_DB_FINALIZE_RETRY_S", 0.0)
     _install_fake_db(monkeypatch)
-    sys.modules["storage.studio_db"].finish_run = lambda **kw: (_ for _ in ()).throw(
-        RuntimeError("database is locked")
-    )
+    tries: list = []
+    _make_finish_raise(monkeypatch, tries)
     b = TrainingBackend()
     b.current_job_id = "job_r"
     b._run_finalized = True  # the caller (escalation) already claimed
-    b._metric_buffer[:] = []  # the caller already drained the batch
 
     b._finish_stopped_run("job_r", None, [{"step": 1}], 1, None, None, [])
 
-    assert b._run_finalized is False, "a DB error must unclaim so the pump can retry"
-    assert b._metric_buffer == [{"step": 1}], "the drained batch must be requeued for retry"
+    assert len(tries) == 3, "a transient DB error must be retried before giving up"
+    assert b._run_finalized is False, "a persistent DB error must unclaim the finalize"
 
 
 def test_finish_stopped_run_error_leaves_new_run_untouched(monkeypatch):
-    # If the watched run was superseded, a DB error must not unclaim/requeue onto the new run.
+    # If the watched run was superseded, a DB error must not unclaim the new run's finalize.
+    monkeypatch.setitem(_G, "_DB_FINALIZE_RETRY_S", 0.0)
     _install_fake_db(monkeypatch)
-    sys.modules["storage.studio_db"].finish_run = lambda **kw: (_ for _ in ()).throw(
-        RuntimeError("database is locked")
-    )
+    _make_finish_raise(monkeypatch, [])
     b = TrainingBackend()
     b.current_job_id = "job_new"  # a new run is live
     b._run_finalized = True  # the new run's flag
-    b._metric_buffer[:] = [{"step": 99}]  # the new run's buffer
 
     b._finish_stopped_run("job_old", None, [{"step": 1}], 1, None, None, [])
 
     assert b._run_finalized is True, "must not unclaim the new run's finalize"
-    assert b._metric_buffer == [{"step": 99}], "must not corrupt the new run's buffer"

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -665,6 +665,34 @@ def test_ensure_db_run_created_stays_unpublished_on_failure(monkeypatch):
     assert b._db_create_in_progress is False, "the in-progress flag must be cleared on failure"
 
 
+def test_ensure_db_run_created_does_not_publish_for_a_new_run(monkeypatch):
+    # A killed worker lets a new /start proceed while the watchdog is still creating the old
+    # run's row. The stale create must not publish the backend-wide flags against the new
+    # current_job_id, or the new run would skip inserting its own row.
+    b = TrainingBackend()
+    b.current_job_id = "job_old"
+    b._db_config = {"model_name": "m"}
+    b._db_run_created = False
+    b._db_create_in_progress = False
+
+    fake_storage = _types.ModuleType("storage")
+    fake_db = _types.ModuleType("storage.studio_db")
+
+    def _create(**kw):
+        b.current_job_id = "job_new"  # a new run takes over during the slow create
+
+    fake_db.create_run = _create
+    fake_storage.studio_db = fake_db
+    monkeypatch.setitem(sys.modules, "storage", fake_storage)
+    monkeypatch.setitem(sys.modules, "storage.studio_db", fake_db)
+
+    b._ensure_db_run_created()
+
+    assert b._db_run_created is False, "must not publish the created flag against the new run"
+    # The stale claim is left for start_training to reset, not satisfied for the new run.
+    assert b._db_create_in_progress is True, "must not clear the claim once the run is not current"
+
+
 # ----------------------------------------------------------------------------
 # (h) The escalation finalizes the watched run by id (so it is never left running).
 # ----------------------------------------------------------------------------

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -124,7 +124,9 @@ def _record_force_terminate(monkeypatch, b):
     """Replace force_terminate + escalation finalize with recorders (no DB/OS)."""
     calls: list = []
     monkeypatch.setattr(b, "force_terminate", lambda target_proc = None: calls.append("force"))
-    monkeypatch.setattr(b, "_finalize_stopped_after_escalation", lambda: calls.append("final"))
+    monkeypatch.setattr(
+        b, "_finalize_stopped_after_escalation", lambda target_proc = None: calls.append("final")
+    )
     return calls
 
 
@@ -317,7 +319,9 @@ def test_finalize_runs_even_if_force_terminate_raises(monkeypatch):
 
     finalized: list = []
     monkeypatch.setattr(b, "force_terminate", _boom)
-    monkeypatch.setattr(b, "_finalize_stopped_after_escalation", lambda: finalized.append(True))
+    monkeypatch.setattr(
+        b, "_finalize_stopped_after_escalation", lambda target_proc = None: finalized.append(True)
+    )
 
     b._proc = _FakeProc(alive = True)
     b._complete_seen.set()
@@ -374,3 +378,166 @@ def test_stop_training_starts_watchdog_only_when_worker_alive(monkeypatch):
     b._proc = None
     assert b.stop_training(save = True) is True
     assert b._stop_watchdog is None
+
+
+# ----------------------------------------------------------------------------
+# (d) A stale watchdog must never clobber a run that replaced its worker.
+# ----------------------------------------------------------------------------
+
+
+def test_finalize_after_escalation_no_ops_when_superseded(monkeypatch):
+    # A /start can slip in while the watchdog is force-terminating the old worker
+    # (is_training_active() is False once _should_stop is set and the old proc is
+    # dead). The escalation finalize must then leave the NEW run untouched instead
+    # of dropping its handle and marking it stopped.
+    b = TrainingBackend()
+    finalized: list = []
+    monkeypatch.setattr(b, "_ensure_db_run_created", lambda: None)
+    monkeypatch.setattr(b, "_finalize_run_in_db", lambda **kw: finalized.append(kw))
+
+    old_proc = _FakeProc(alive = False)  # force-terminated worker we were watching
+    new_proc = _FakeProc(alive = True)  # a new run already took over
+    b._proc = new_proc
+    b.current_job_id = "job_new"
+    b._progress.is_training = True
+
+    b._finalize_stopped_after_escalation(target_proc = old_proc)
+
+    assert b._proc is new_proc, "must not drop the new run's handle"
+    assert b._progress.is_training is True, "must not mark the new run stopped"
+    assert finalized == [], "must not finalize the new run in the DB"
+
+
+def test_finalize_after_escalation_runs_for_its_own_worker(monkeypatch):
+    # The common case: the worker we watched is still current, so finalize proceeds.
+    b = TrainingBackend()
+    finalized: list = []
+    monkeypatch.setattr(b, "_ensure_db_run_created", lambda: None)
+    monkeypatch.setattr(b, "_finalize_run_in_db", lambda **kw: finalized.append(kw))
+
+    proc = _FakeProc(alive = False)
+    b._proc = proc
+    b.current_job_id = "job_a"
+    b._progress.is_training = True
+
+    b._finalize_stopped_after_escalation(target_proc = proc)
+
+    assert b._proc is None
+    assert b._progress.is_training is False
+    assert finalized and finalized[0].get("status") == "stopped"
+    assert finalized[0].get("expected_job_id") == "job_a"
+
+
+# ----------------------------------------------------------------------------
+# (e) A later cancel (save=False) tightens an in-flight save watchdog.
+# ----------------------------------------------------------------------------
+
+
+def test_later_cancel_tightens_watchdog_timeout(monkeypatch):
+    monkeypatch.setitem(_G, "_STOP_GRACE_S", 100.0)  # never trips (no complete)
+    monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)  # save cap would not fire
+    monkeypatch.setitem(_G, "_CANCEL_TIMEOUT_S", 0.05)
+    b = TrainingBackend()
+    calls = _record_force_terminate(monkeypatch, b)
+
+    b._proc = _FakeProc(alive = True)
+    b._start_stop_watchdog(cancel = False)  # started as a save-stop with the long cap
+    time.sleep(0.15)
+    assert calls == [], "a save-stop must not escalate on the short cancel cap yet"
+
+    # The user now cancels the in-flight stop: the watchdog must tighten its cap.
+    b._cancel_requested = True
+    assert _wait_until(
+        lambda: calls == ["force", "final"]
+    ), "a later cancel must tighten the watchdog to the shorter cancel cap"
+    b._stop_watchdog.join(timeout = 5)
+
+
+# ----------------------------------------------------------------------------
+# (f) DB finalize/flush are safe when the watchdog and pump race (see Item 4).
+# ----------------------------------------------------------------------------
+
+
+def _install_fake_db(monkeypatch):
+    """Stub storage.studio_db + utils.downsample so the real DB helpers run without
+    SQLite. Returns the recorder dict."""
+    recs = {"created": [], "finished": [], "inserted": []}
+    fake_storage = _types.ModuleType("storage")
+    fake_db = _types.ModuleType("storage.studio_db")
+    fake_db.create_run = lambda **kw: recs["created"].append(kw)
+    fake_db.finish_run = lambda **kw: recs["finished"].append(kw)
+    fake_db.insert_metrics_batch = lambda job_id, batch: recs["inserted"].extend(batch)
+    fake_db.update_run_progress = lambda **kw: None
+    fake_storage.studio_db = fake_db
+    monkeypatch.setitem(sys.modules, "storage", fake_storage)
+    monkeypatch.setitem(sys.modules, "storage.studio_db", fake_db)
+    fake_ds = _types.ModuleType("utils.downsample")
+    fake_ds.downsample = lambda seq, n: list(seq)[:n]
+    monkeypatch.setitem(sys.modules, "utils.downsample", fake_ds)
+    return recs
+
+
+def test_finalize_run_in_db_single_winner_under_concurrency(monkeypatch):
+    # The watchdog and pump can both finalize; only one call may reach finish_run.
+    recs = _install_fake_db(monkeypatch)
+    b = TrainingBackend()
+    b.current_job_id = "job_x"
+    b._db_run_created = True
+    b._run_finalized = False
+
+    start = threading.Barrier(8)
+
+    def worker():
+        start.wait()
+        b._finalize_run_in_db(status = "stopped")
+
+    threads = [threading.Thread(target = worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout = 5)
+
+    assert len(recs["finished"]) == 1, f"finalize must run once, got {len(recs['finished'])}"
+    assert b._run_finalized is True
+
+
+def test_finalize_run_in_db_no_ops_on_job_mismatch(monkeypatch):
+    # A finalize captured for an old job must not finalize the run that replaced it.
+    recs = _install_fake_db(monkeypatch)
+    b = TrainingBackend()
+    b.current_job_id = "job_new"
+    b._db_run_created = True
+    b._run_finalized = False
+
+    b._finalize_run_in_db(status = "stopped", expected_job_id = "job_old")
+
+    assert recs["finished"] == [], "a superseded job id must not finalize the current run"
+    assert b._run_finalized is False
+
+
+def test_concurrent_flush_claims_each_metric_once(monkeypatch):
+    # Concurrent flushes (pump periodic flush vs watchdog finalize flush) must not
+    # double-remove or drop buffered metrics.
+    recs = _install_fake_db(monkeypatch)
+    b = TrainingBackend()
+    b.current_job_id = "job_y"
+    b._db_run_created = True
+    b._metric_buffer[:] = [{"step": i} for i in range(200)]
+
+    start = threading.Barrier(6)
+
+    def worker():
+        start.wait()
+        for _ in range(50):
+            b._flush_metrics_to_db()
+
+    threads = [threading.Thread(target = worker) for _ in range(6)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout = 5)
+    b._flush_metrics_to_db()  # drain any remainder
+
+    steps = sorted(m["step"] for m in recs["inserted"])
+    assert steps == list(range(200)), "each metric must be inserted exactly once"
+    assert b._metric_buffer == [], "the buffer must be fully drained"

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -123,7 +123,7 @@ def _wait_until(predicate, timeout = 5.0):
 def _record_force_terminate(monkeypatch, b):
     """Replace force_terminate + escalation finalize with recorders (no DB/OS)."""
     calls: list = []
-    monkeypatch.setattr(b, "force_terminate", lambda: calls.append("force"))
+    monkeypatch.setattr(b, "force_terminate", lambda target_proc = None: calls.append("force"))
     monkeypatch.setattr(b, "_finalize_stopped_after_escalation", lambda: calls.append("final"))
     return calls
 
@@ -143,7 +143,7 @@ def test_watchdog_escalates_after_grace_once_complete_seen(monkeypatch):
     b._proc = proc
     b._complete_seen.set()  # worker reported "complete" -> save is done
 
-    b._start_stop_watchdog()
+    b._start_stop_watchdog(cancel = False)
     assert _wait_until(
         lambda: calls == ["force", "final"]
     ), "watchdog must force_terminate a worker still alive after the post-save grace"
@@ -151,24 +151,59 @@ def test_watchdog_escalates_after_grace_once_complete_seen(monkeypatch):
 
 
 # ----------------------------------------------------------------------------
-# (b) Escalate after the absolute timeout when no "complete" ever arrives.
+# (b) The absolute cap is a last-resort backstop, not a save killer.
 # ----------------------------------------------------------------------------
 
 
-def test_watchdog_escalates_after_absolute_timeout(monkeypatch):
-    monkeypatch.setitem(_G, "_STOP_GRACE_S", 100.0)  # never trips (no complete anyway)
-    monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 0.05)
+def test_watchdog_does_not_kill_save_still_saving_within_window(monkeypatch):
+    # save=True, no "complete" yet: a large/slow save is in progress. It must not be
+    # force-killed while inside the (long) absolute window.
+    monkeypatch.setitem(_G, "_STOP_GRACE_S", 100.0)
+    monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)
     b = TrainingBackend()
     calls = _record_force_terminate(monkeypatch, b)
 
     proc = _FakeProc(alive = True)
     b._proc = proc
-    # No _complete_seen: simulates a hang during save, no "complete" ever sent.
+    b._start_stop_watchdog(cancel = False)
 
-    b._start_stop_watchdog()
+    time.sleep(0.3)
+    assert calls == [], "an in-progress save must not be killed within the absolute window"
+    assert b._stop_watchdog.is_alive()
+
+    proc._alive = False
+    b._stop_watchdog.join(timeout = 5)
+
+
+def test_watchdog_backstop_fires_for_save_after_absolute_timeout(monkeypatch):
+    # Past the long save=True cap with no completion: force-terminate as last resort.
+    monkeypatch.setitem(_G, "_STOP_GRACE_S", 100.0)  # never trips (no complete)
+    monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 0.05)
+    b = TrainingBackend()
+    calls = _record_force_terminate(monkeypatch, b)
+
+    b._proc = _FakeProc(alive = True)
+    b._start_stop_watchdog(cancel = False)
     assert _wait_until(
         lambda: calls == ["force", "final"]
-    ), "watchdog must force_terminate a worker that never exits within the timeout"
+    ), "the absolute backstop must force_terminate a save that never completes"
+    b._stop_watchdog.join(timeout = 5)
+
+
+def test_cancel_uses_shorter_absolute_timeout(monkeypatch):
+    # A cancel has nothing to save, so it escalates on the shorter cancel cap even
+    # when the long save cap has not elapsed.
+    monkeypatch.setitem(_G, "_STOP_GRACE_S", 100.0)
+    monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)  # save cap would not fire
+    monkeypatch.setitem(_G, "_CANCEL_TIMEOUT_S", 0.05)
+    b = TrainingBackend()
+    calls = _record_force_terminate(monkeypatch, b)
+
+    b._proc = _FakeProc(alive = True)
+    b._start_stop_watchdog(cancel = True)
+    assert _wait_until(
+        lambda: calls == ["force", "final"]
+    ), "a cancel must escalate on the shorter cancel timeout"
     b._stop_watchdog.join(timeout = 5)
 
 
@@ -187,7 +222,7 @@ def test_watchdog_no_op_on_clean_quick_exit(monkeypatch):
     b._proc = proc
     b._complete_seen.set()  # save done; worker is about to exit on its own
 
-    b._start_stop_watchdog()
+    b._start_stop_watchdog(cancel = False)
     # Worker exits promptly, well before the grace period elapses.
     time.sleep(0.1)
     proc._alive = False
@@ -208,7 +243,7 @@ def test_watchdog_no_op_when_worker_superseded(monkeypatch):
     old_proc = _FakeProc(alive = True)
     b._proc = old_proc
     b._complete_seen.set()
-    b._start_stop_watchdog()
+    b._start_stop_watchdog(cancel = False)
 
     # A new run takes over the handle before the grace elapses.
     b._proc = _FakeProc(alive = True)
@@ -217,9 +252,81 @@ def test_watchdog_no_op_when_worker_superseded(monkeypatch):
     assert calls == [], "watchdog must not force_terminate a superseded worker"
 
 
+def test_new_run_gets_its_own_watchdog(monkeypatch):
+    # A stale watchdog still sleeping on an old proc must not stop a new run's stop
+    # from creating its own watcher.
+    monkeypatch.setitem(_G, "_STOP_GRACE_S", 100.0)
+    monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)
+    b = TrainingBackend()
+    _record_force_terminate(monkeypatch, b)
+
+    old_proc = _FakeProc(alive = True)
+    b._proc = old_proc
+    b._start_stop_watchdog(cancel = False)
+    first_wd = b._stop_watchdog
+
+    # New run: fresh worker replaces the handle; its stop must get a new watcher
+    # even though the old (superseded) watchdog is still alive.
+    new_proc = _FakeProc(alive = True)
+    b._proc = new_proc
+    b._start_stop_watchdog(cancel = False)
+    second_wd = b._stop_watchdog
+
+    try:
+        assert first_wd.is_alive()
+        assert second_wd is not first_wd, "a new run must get its own watchdog"
+        assert b._stop_watchdog_proc is new_proc
+    finally:
+        old_proc._alive = False
+        new_proc._alive = False
+        first_wd.join(timeout = 5)
+        second_wd.join(timeout = 5)
+
+
+def test_force_terminate_targets_only_captured_proc():
+    # Superseded: force_terminate(target) must not touch a different current worker.
+    b = TrainingBackend()
+    old_proc = _FakeProc(alive = True)
+    new_proc = _FakeProc(alive = True)
+    b._proc = new_proc
+    b.force_terminate(target_proc = old_proc)
+    assert new_proc.terminated is False, "must not terminate the new run's worker"
+    assert old_proc.terminated is False, "must not terminate a handle that is not current"
+
+    # Matching: the captured handle is the current worker, so it is terminated.
+    p = _FakeProc(alive = True)
+    b._proc = p
+    b.force_terminate(target_proc = p)
+    assert p.terminated is True
+
+
 # ----------------------------------------------------------------------------
 # Post-escalation finalize leaves the parent ready for a new run.
 # ----------------------------------------------------------------------------
+
+
+def test_finalize_runs_even_if_force_terminate_raises(monkeypatch):
+    # A wedged child can make force_terminate() raise; finalize must still run so the
+    # run does not stay stuck in "Stopping...".
+    monkeypatch.setitem(_G, "_STOP_GRACE_S", 0.05)
+    monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)
+    b = TrainingBackend()
+
+    def _boom(target_proc = None):
+        raise RuntimeError("kill() failed on wedged child")
+
+    finalized: list = []
+    monkeypatch.setattr(b, "force_terminate", _boom)
+    monkeypatch.setattr(b, "_finalize_stopped_after_escalation", lambda: finalized.append(True))
+
+    b._proc = _FakeProc(alive = True)
+    b._complete_seen.set()
+    b._start_stop_watchdog(cancel = False)
+
+    assert _wait_until(
+        lambda: finalized == [True]
+    ), "finalize must run even when force_terminate raises"
+    b._stop_watchdog.join(timeout = 5)
 
 
 def test_finalize_after_escalation_clears_state(monkeypatch):
@@ -241,6 +348,24 @@ def test_finalize_after_escalation_clears_state(monkeypatch):
     assert b._progress.status_message == "Training stopped."
     assert finalized.get("status") == "stopped"
     assert b.is_training_active() is False
+
+
+def test_finalize_after_escalation_preserves_output_dir(monkeypatch):
+    # A save-stop that already emitted "complete" has the checkpoint dir; run history
+    # must record it even if the watchdog wins the finalize race against the pump.
+    b = TrainingBackend()
+    finalized: dict = {}
+    monkeypatch.setattr(b, "_ensure_db_run_created", lambda: None)
+    monkeypatch.setattr(b, "_finalize_run_in_db", lambda **kw: finalized.update(kw))
+
+    b._proc = _FakeProc(alive = True)
+    b._should_stop = True
+    b._output_dir = "/tmp/outputs/run-123"
+
+    b._finalize_stopped_after_escalation()
+
+    assert finalized.get("status") == "stopped"
+    assert finalized.get("output_dir") == "/tmp/outputs/run-123"
 
 
 def test_stop_training_starts_watchdog_only_when_worker_alive(monkeypatch):

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -341,20 +341,21 @@ def test_finalize_after_escalation_clears_state(monkeypatch):
     # Even if the OS never reaps the wedged worker, the parent must report the run
     # stopped so the UI leaves "Stopping..." and a new run can start.
     b = TrainingBackend()
-    finalized: dict = {}
-    monkeypatch.setattr(b, "_ensure_db_run_created", lambda: None)
-    monkeypatch.setattr(b, "_finalize_run_in_db", lambda **kw: finalized.update(kw))
+    finstop: list = []
+    monkeypatch.setattr(b, "_finish_stopped_run", lambda *a: finstop.append(a))
 
     b._proc = _FakeProc(alive = True)  # wedged: still reports alive
     b._should_stop = True
+    b.current_job_id = "job_c"
+    b._db_run_created = True
     b._progress.is_training = True
 
-    b._finalize_stopped_after_escalation()
+    b._finalize_stopped_after_escalation(watched_job_id = "job_c")
 
     assert b._proc is None, "the wedged handle must be dropped so is_training_active clears"
     assert b._progress.is_training is False
     assert b._progress.status_message == "Training stopped."
-    assert finalized.get("status") == "stopped"
+    assert finstop and finstop[0][0] == "job_c", "the captured run must be finalized by id"
     assert b.is_training_active() is False
 
 
@@ -362,18 +363,20 @@ def test_finalize_after_escalation_preserves_output_dir(monkeypatch):
     # A save-stop that already emitted "complete" has the checkpoint dir; run history
     # must record it even if the watchdog wins the finalize race against the pump.
     b = TrainingBackend()
-    finalized: dict = {}
-    monkeypatch.setattr(b, "_ensure_db_run_created", lambda: None)
-    monkeypatch.setattr(b, "_finalize_run_in_db", lambda **kw: finalized.update(kw))
+    finstop: list = []
+    monkeypatch.setattr(b, "_finish_stopped_run", lambda *a: finstop.append(a))
 
     b._proc = _FakeProc(alive = True)
     b._should_stop = True
+    b.current_job_id = "job_c"
+    b._db_run_created = True
     b._output_dir = "/tmp/outputs/run-123"
 
-    b._finalize_stopped_after_escalation()
+    b._finalize_stopped_after_escalation(watched_job_id = "job_c")
 
-    assert finalized.get("status") == "stopped"
-    assert finalized.get("output_dir") == "/tmp/outputs/run-123"
+    # _finish_stopped_run(run_id, output_dir, batch, final_step, final_loss, duration, loss_history)
+    assert finstop and finstop[0][0] == "job_c"
+    assert finstop[0][1] == "/tmp/outputs/run-123"
 
 
 def test_stop_training_starts_watchdog_only_when_worker_alive(monkeypatch):
@@ -395,42 +398,41 @@ def test_finalize_after_escalation_no_ops_when_superseded(monkeypatch):
     # dead). The escalation finalize must then leave the NEW run untouched instead
     # of dropping its handle and marking it stopped.
     b = TrainingBackend()
-    finalized: list = []
-    monkeypatch.setattr(b, "_ensure_db_run_created", lambda: None)
-    monkeypatch.setattr(b, "_finalize_run_in_db", lambda **kw: finalized.append(kw))
+    finstop: list = []
+    monkeypatch.setattr(b, "_finish_stopped_run", lambda *a: finstop.append(a))
 
     old_proc = _FakeProc(alive = False)  # force-terminated worker we were watching
     new_proc = _FakeProc(alive = True)  # a new run already took over
     b._proc = new_proc
     b.current_job_id = "job_new"
+    b._db_run_created = True
     b._progress.is_training = True
 
     b._finalize_stopped_after_escalation(target_proc = old_proc)
 
     assert b._proc is new_proc, "must not drop the new run's handle"
     assert b._progress.is_training is True, "must not mark the new run stopped"
-    assert finalized == [], "must not finalize the new run in the DB"
+    assert finstop == [], "must not finalize the new run in the DB"
 
 
 def test_finalize_after_escalation_runs_for_its_own_worker(monkeypatch):
     # The common case: the worker we watched is still current, so finalize proceeds
-    # and threads the watched job id through as expected_job_id.
+    # and finalizes the captured run by id.
     b = TrainingBackend()
-    finalized: list = []
-    monkeypatch.setattr(b, "_ensure_db_run_created", lambda: None)
-    monkeypatch.setattr(b, "_finalize_run_in_db", lambda **kw: finalized.append(kw))
+    finstop: list = []
+    monkeypatch.setattr(b, "_finish_stopped_run", lambda *a: finstop.append(a))
 
     proc = _FakeProc(alive = False)
     b._proc = proc
     b.current_job_id = "job_a"
+    b._db_run_created = True
     b._progress.is_training = True
 
     b._finalize_stopped_after_escalation(target_proc = proc, watched_job_id = "job_a")
 
     assert b._proc is None
     assert b._progress.is_training is False
-    assert finalized and finalized[0].get("status") == "stopped"
-    assert finalized[0].get("expected_job_id") == "job_a"
+    assert finstop and finstop[0][0] == "job_a", "must finalize the captured run by id"
 
 
 def test_finalize_after_escalation_no_ops_on_job_change_during_startup(monkeypatch):
@@ -438,20 +440,20 @@ def test_finalize_after_escalation_no_ops_on_job_change_during_startup(monkeypat
     # watchdog can enter while _proc is still the old (dead) handle. The job-id guard must
     # catch this even though the proc-only guard would not.
     b = TrainingBackend()
-    finalized: list = []
-    monkeypatch.setattr(b, "_ensure_db_run_created", lambda: None)
-    monkeypatch.setattr(b, "_finalize_run_in_db", lambda **kw: finalized.append(kw))
+    finstop: list = []
+    monkeypatch.setattr(b, "_finish_stopped_run", lambda *a: finstop.append(a))
 
     old_proc = _FakeProc(alive = False)  # old worker, dead; new _proc not installed yet
     b._proc = old_proc  # still the old handle (== target), so proc guard would pass
     b.current_job_id = "job_new"  # but the new run already claimed the job id
+    b._db_run_created = True
     b._progress.is_training = True
 
     b._finalize_stopped_after_escalation(target_proc = old_proc, watched_job_id = "job_old")
 
     assert b._proc is old_proc, "must not drop the handle during a new run's startup"
     assert b._progress.is_training is True, "must not mark the starting run stopped"
-    assert finalized == [], "must not finalize while a new run is starting up"
+    assert finstop == [], "must not finalize while a new run is starting up"
 
 
 # ----------------------------------------------------------------------------
@@ -663,3 +665,29 @@ def test_ensure_db_run_created_stays_unpublished_on_failure(monkeypatch):
 
     assert b._db_run_created is False, "a failed insert must not publish the row as created"
     assert b._db_create_in_progress is False, "the in-progress flag must be cleared on failure"
+
+
+# ----------------------------------------------------------------------------
+# (h) The escalation finalizes the watched run by id (so it is never left running).
+# ----------------------------------------------------------------------------
+
+
+def test_escalation_finalizes_watched_run_by_id_end_to_end(monkeypatch):
+    # Item A: exercise the real _finish_stopped_run against a fake DB. The watched run is
+    # finalized by its captured id with its buffered metrics, so a new run that starts in
+    # the gap after the backend goes idle can never leave the stopped run recorded running.
+    recs = _install_fake_db(monkeypatch)
+    b = TrainingBackend()
+    b.current_job_id = "job_old"
+    b._db_run_created = True
+    b._proc = _FakeProc(alive = False)
+    b._progress.is_training = True
+    b._progress.step = 42
+    b._metric_buffer[:] = [{"step": 41}, {"step": 42}]
+
+    b._finalize_stopped_after_escalation(target_proc = b._proc, watched_job_id = "job_old")
+
+    assert [f["id"] for f in recs["finished"]] == ["job_old"], "must finish the captured run by id"
+    assert recs["finished"][0]["status"] == "stopped"
+    assert recs["insert_ids"] == ["job_old"], "buffered metrics must land on the captured run"
+    assert b._metric_buffer == [], "the captured batch must be drained"

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Stop-watchdog escalation for a stuck training stop.
+
+A save-stop only signals the worker and waits for it to save and exit. On some
+platforms the worker saves successfully but then wedges in post-save GPU/driver
+teardown and never exits, leaving the run stuck in "Stopping..." forever. These
+tests pin the bounded recovery: the watchdog escalates to force_terminate() a
+short grace after "complete" (save done) or after an absolute timeout (hang during
+save), and never force-kills a worker that exits cleanly on its own. Fakes only;
+no GPU, network, or subprocess.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import queue
+import sys
+import threading
+import time
+import types as _types
+from pathlib import Path
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+# Stub the heavy module-level imports of core/training/training.py so it imports
+# under CPU-only/no-network, then restore them (see the restore loop below).
+_SAVED: dict = {}
+
+
+def _stub(name, mod):
+    _SAVED[name] = sys.modules.get(name)
+    sys.modules[name] = mod
+
+
+_lg = _types.ModuleType("loggers")
+_lg.get_logger = lambda name: logging.getLogger(name)
+_stub("loggers", _lg)
+_stub("structlog", _types.ModuleType("structlog"))
+_mpl = _types.ModuleType("matplotlib")
+_plt = _types.ModuleType("matplotlib.pyplot")
+_plt.Figure = type("Figure", (), {})  # referenced in a class-def annotation
+_mpl.pyplot = _plt
+_stub("matplotlib", _mpl)
+_stub("matplotlib.pyplot", _plt)
+_hw = _types.ModuleType("utils.hardware")
+_hw.prepare_gpu_selection = lambda *a, **k: (None, None)
+_stub("utils.hardware", _hw)
+_npl = _types.ModuleType("utils.native_path_leases")
+_npl.native_path_secret_removed_for_child_start = lambda: contextlib.nullcontext()
+_npl.run_without_native_path_secret = lambda fn: fn
+_stub("utils.native_path_leases", _npl)
+_pth = _types.ModuleType("utils.paths")
+_pth.outputs_root = lambda *a, **k: "/tmp/outputs"
+_stub("utils.paths", _pth)
+
+# Whether core.training.training was already imported before this file ran; only
+# evict it below if we were the one to create the (stub-bound) module instance.
+_TRAINING_PRE_IMPORTED = "core.training.training" in sys.modules
+
+from core.training.training import TrainingBackend
+
+# Restore every stubbed module so this file never pollutes the shared session.
+for _name in (
+    "loggers",
+    "structlog",
+    "matplotlib",
+    "matplotlib.pyplot",
+    "utils.hardware",
+    "utils.native_path_leases",
+    "utils.paths",
+):
+    _prev = _SAVED.get(_name)
+    if _prev is None:
+        sys.modules.pop(_name, None)
+    else:
+        sys.modules[_name] = _prev
+
+if not _TRAINING_PRE_IMPORTED:
+    sys.modules.pop("core.training.training", None)
+    sys.modules.pop("core.training", None)
+
+# The module globals hold the escalation timeouts and are the watchdog's own
+# namespace; patch them here so tests run in well under a second.
+_G = TrainingBackend._stop_watchdog_loop.__globals__
+
+
+class _FakeProc:
+    """A subprocess handle whose liveness and kill calls the test observes."""
+
+    def __init__(self, alive: bool = True):
+        self._alive = alive
+        self.pid = 4321
+        self.terminated = False
+        self.killed = False
+
+    def is_alive(self):
+        return self._alive
+
+    def terminate(self):
+        self.terminated = True
+
+    def kill(self):
+        self.killed = True
+
+    def join(self, timeout = None):
+        pass
+
+
+def _wait_until(predicate, timeout = 5.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
+
+
+def _record_force_terminate(monkeypatch, b):
+    """Replace force_terminate + escalation finalize with recorders (no DB/OS)."""
+    calls: list = []
+    monkeypatch.setattr(b, "force_terminate", lambda: calls.append("force"))
+    monkeypatch.setattr(b, "_finalize_stopped_after_escalation", lambda: calls.append("final"))
+    return calls
+
+
+# ----------------------------------------------------------------------------
+# (a) Escalate a short grace after "complete" (save done) if still alive.
+# ----------------------------------------------------------------------------
+
+
+def test_watchdog_escalates_after_grace_once_complete_seen(monkeypatch):
+    monkeypatch.setitem(_G, "_STOP_GRACE_S", 0.05)
+    monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)  # ensure grace, not timeout, fires
+    b = TrainingBackend()
+    calls = _record_force_terminate(monkeypatch, b)
+
+    proc = _FakeProc(alive = True)
+    b._proc = proc
+    b._complete_seen.set()  # worker reported "complete" -> save is done
+
+    b._start_stop_watchdog()
+    assert _wait_until(lambda: calls == ["force", "final"]), (
+        "watchdog must force_terminate a worker still alive after the post-save grace"
+    )
+    b._stop_watchdog.join(timeout = 5)
+
+
+# ----------------------------------------------------------------------------
+# (b) Escalate after the absolute timeout when no "complete" ever arrives.
+# ----------------------------------------------------------------------------
+
+
+def test_watchdog_escalates_after_absolute_timeout(monkeypatch):
+    monkeypatch.setitem(_G, "_STOP_GRACE_S", 100.0)  # never trips (no complete anyway)
+    monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 0.05)
+    b = TrainingBackend()
+    calls = _record_force_terminate(monkeypatch, b)
+
+    proc = _FakeProc(alive = True)
+    b._proc = proc
+    # No _complete_seen: simulates a hang during save, no "complete" ever sent.
+
+    b._start_stop_watchdog()
+    assert _wait_until(lambda: calls == ["force", "final"]), (
+        "watchdog must force_terminate a worker that never exits within the timeout"
+    )
+    b._stop_watchdog.join(timeout = 5)
+
+
+# ----------------------------------------------------------------------------
+# (c) No force-kill when the worker exits cleanly and promptly.
+# ----------------------------------------------------------------------------
+
+
+def test_watchdog_no_op_on_clean_quick_exit(monkeypatch):
+    monkeypatch.setitem(_G, "_STOP_GRACE_S", 5.0)
+    monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 10.0)
+    b = TrainingBackend()
+    calls = _record_force_terminate(monkeypatch, b)
+
+    proc = _FakeProc(alive = True)
+    b._proc = proc
+    b._complete_seen.set()  # save done; worker is about to exit on its own
+
+    b._start_stop_watchdog()
+    # Worker exits promptly, well before the grace period elapses.
+    time.sleep(0.1)
+    proc._alive = False
+
+    b._stop_watchdog.join(timeout = 5)
+    assert not b._stop_watchdog.is_alive()
+    assert calls == [], "a clean quick exit must not trigger force_terminate"
+
+
+def test_watchdog_no_op_when_worker_superseded(monkeypatch):
+    # A stale watchdog from a prior run must never kill the worker of a new run:
+    # once self._proc is replaced, it exits silently.
+    monkeypatch.setitem(_G, "_STOP_GRACE_S", 0.05)
+    monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 0.05)
+    b = TrainingBackend()
+    calls = _record_force_terminate(monkeypatch, b)
+
+    old_proc = _FakeProc(alive = True)
+    b._proc = old_proc
+    b._complete_seen.set()
+    b._start_stop_watchdog()
+
+    # A new run takes over the handle before the grace elapses.
+    b._proc = _FakeProc(alive = True)
+
+    b._stop_watchdog.join(timeout = 5)
+    assert calls == [], "watchdog must not force_terminate a superseded worker"
+
+
+# ----------------------------------------------------------------------------
+# Post-escalation finalize leaves the parent ready for a new run.
+# ----------------------------------------------------------------------------
+
+
+def test_finalize_after_escalation_clears_state(monkeypatch):
+    # Even if the OS never reaps the wedged worker, the parent must report the run
+    # stopped so the UI leaves "Stopping..." and a new run can start.
+    b = TrainingBackend()
+    finalized: dict = {}
+    monkeypatch.setattr(b, "_ensure_db_run_created", lambda: None)
+    monkeypatch.setattr(b, "_finalize_run_in_db", lambda **kw: finalized.update(kw))
+
+    b._proc = _FakeProc(alive = True)  # wedged: still reports alive
+    b._should_stop = True
+    b._progress.is_training = True
+
+    b._finalize_stopped_after_escalation()
+
+    assert b._proc is None, "the wedged handle must be dropped so is_training_active clears"
+    assert b._progress.is_training is False
+    assert b._progress.status_message == "Training stopped."
+    assert finalized.get("status") == "stopped"
+    assert b.is_training_active() is False
+
+
+def test_stop_training_starts_watchdog_only_when_worker_alive(monkeypatch):
+    # No worker -> nothing to escalate; the watchdog must not spawn.
+    b = TrainingBackend()
+    b._proc = None
+    assert b.stop_training(save = True) is True
+    assert b._stop_watchdog is None

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -125,7 +125,9 @@ def _record_force_terminate(monkeypatch, b):
     calls: list = []
     monkeypatch.setattr(b, "force_terminate", lambda target_proc = None: calls.append("force"))
     monkeypatch.setattr(
-        b, "_finalize_stopped_after_escalation", lambda target_proc = None: calls.append("final")
+        b,
+        "_finalize_stopped_after_escalation",
+        lambda target_proc = None, watched_job_id = None: calls.append("final"),
     )
     return calls
 
@@ -320,7 +322,9 @@ def test_finalize_runs_even_if_force_terminate_raises(monkeypatch):
     finalized: list = []
     monkeypatch.setattr(b, "force_terminate", _boom)
     monkeypatch.setattr(
-        b, "_finalize_stopped_after_escalation", lambda target_proc = None: finalized.append(True)
+        b,
+        "_finalize_stopped_after_escalation",
+        lambda target_proc = None, watched_job_id = None: finalized.append(True),
     )
 
     b._proc = _FakeProc(alive = True)
@@ -409,7 +413,8 @@ def test_finalize_after_escalation_no_ops_when_superseded(monkeypatch):
 
 
 def test_finalize_after_escalation_runs_for_its_own_worker(monkeypatch):
-    # The common case: the worker we watched is still current, so finalize proceeds.
+    # The common case: the worker we watched is still current, so finalize proceeds
+    # and threads the watched job id through as expected_job_id.
     b = TrainingBackend()
     finalized: list = []
     monkeypatch.setattr(b, "_ensure_db_run_created", lambda: None)
@@ -420,12 +425,33 @@ def test_finalize_after_escalation_runs_for_its_own_worker(monkeypatch):
     b.current_job_id = "job_a"
     b._progress.is_training = True
 
-    b._finalize_stopped_after_escalation(target_proc = proc)
+    b._finalize_stopped_after_escalation(target_proc = proc, watched_job_id = "job_a")
 
     assert b._proc is None
     assert b._progress.is_training is False
     assert finalized and finalized[0].get("status") == "stopped"
     assert finalized[0].get("expected_job_id") == "job_a"
+
+
+def test_finalize_after_escalation_no_ops_on_job_change_during_startup(monkeypatch):
+    # start_training updates current_job_id BEFORE it installs the new _proc, so a stale
+    # watchdog can enter while _proc is still the old (dead) handle. The job-id guard must
+    # catch this even though the proc-only guard would not.
+    b = TrainingBackend()
+    finalized: list = []
+    monkeypatch.setattr(b, "_ensure_db_run_created", lambda: None)
+    monkeypatch.setattr(b, "_finalize_run_in_db", lambda **kw: finalized.append(kw))
+
+    old_proc = _FakeProc(alive = False)  # old worker, dead; new _proc not installed yet
+    b._proc = old_proc  # still the old handle (== target), so proc guard would pass
+    b.current_job_id = "job_new"  # but the new run already claimed the job id
+    b._progress.is_training = True
+
+    b._finalize_stopped_after_escalation(target_proc = old_proc, watched_job_id = "job_old")
+
+    assert b._proc is old_proc, "must not drop the handle during a new run's startup"
+    assert b._progress.is_training is True, "must not mark the starting run stopped"
+    assert finalized == [], "must not finalize while a new run is starting up"
 
 
 # ----------------------------------------------------------------------------
@@ -461,13 +487,16 @@ def test_later_cancel_tightens_watchdog_timeout(monkeypatch):
 def _install_fake_db(monkeypatch):
     """Stub storage.studio_db + utils.downsample so the real DB helpers run without
     SQLite. Returns the recorder dict."""
-    recs = {"created": [], "finished": [], "inserted": []}
+    recs = {"created": [], "finished": [], "inserted": [], "insert_ids": [], "progress_ids": []}
     fake_storage = _types.ModuleType("storage")
     fake_db = _types.ModuleType("storage.studio_db")
     fake_db.create_run = lambda **kw: recs["created"].append(kw)
     fake_db.finish_run = lambda **kw: recs["finished"].append(kw)
-    fake_db.insert_metrics_batch = lambda job_id, batch: recs["inserted"].extend(batch)
-    fake_db.update_run_progress = lambda **kw: None
+    fake_db.insert_metrics_batch = lambda job_id, batch: (
+        recs["inserted"].extend(batch),
+        recs["insert_ids"].append(job_id),
+    )
+    fake_db.update_run_progress = lambda **kw: recs["progress_ids"].append(kw.get("id"))
     fake_storage.studio_db = fake_db
     monkeypatch.setitem(sys.modules, "storage", fake_storage)
     monkeypatch.setitem(sys.modules, "storage.studio_db", fake_db)
@@ -541,3 +570,96 @@ def test_concurrent_flush_claims_each_metric_once(monkeypatch):
     steps = sorted(m["step"] for m in recs["inserted"])
     assert steps == list(range(200)), "each metric must be inserted exactly once"
     assert b._metric_buffer == [], "the buffer must be fully drained"
+
+
+def test_flush_pins_to_passed_run_id(monkeypatch):
+    # A finalizer flushes to the run it captured, even if a new /start has already
+    # changed current_job_id.
+    recs = _install_fake_db(monkeypatch)
+    b = TrainingBackend()
+    b.current_job_id = "job_new"  # a new run is already live
+    b._db_run_created = True
+    b._metric_buffer[:] = [{"step": 1}, {"step": 2}]
+
+    b._flush_metrics_to_db(run_id = "job_old")
+
+    assert recs["insert_ids"] == ["job_old"], "metrics must go to the captured run, not the new one"
+    assert recs["progress_ids"] == ["job_old"]
+
+
+def test_finalize_uses_snapshot_run_id_across_new_run(monkeypatch):
+    # If a new /start changes current_job_id after the finalize claim but before the DB
+    # writes, finish_run must still target the run captured under the lock.
+    recs = _install_fake_db(monkeypatch)
+    b = TrainingBackend()
+    b.current_job_id = "job_x"
+    b._db_run_created = True
+    b._run_finalized = False
+
+    def hijack(run_id = None):
+        # Simulate a new run taking over during the flush (after the finalize claim).
+        b.current_job_id = "job_y"
+
+    monkeypatch.setattr(b, "_flush_metrics_to_db", hijack)
+
+    b._finalize_run_in_db(status = "stopped", expected_job_id = "job_x")
+
+    assert [f["id"] for f in recs["finished"]] == [
+        "job_x"
+    ], "finish_run must target the captured run, not the run that replaced it"
+
+
+# ----------------------------------------------------------------------------
+# (g) DB row creation must not be published before the insert commits.
+# ----------------------------------------------------------------------------
+
+
+def test_ensure_db_run_created_publishes_only_after_insert(monkeypatch):
+    # _db_run_created must stay False while create_run is in flight, so a concurrent
+    # finalize can't run finish_run (an UPDATE) against a not-yet-inserted row.
+    b = TrainingBackend()
+    b.current_job_id = "job_z"
+    b._db_config = {"model_name": "m"}
+    observed: dict = {}
+
+    fake_storage = _types.ModuleType("storage")
+    fake_db = _types.ModuleType("storage.studio_db")
+
+    def _create(**kw):
+        observed["flag_during_create"] = b._db_run_created
+        observed["in_progress_during_create"] = b._db_create_in_progress
+
+    fake_db.create_run = _create
+    fake_storage.studio_db = fake_db
+    monkeypatch.setitem(sys.modules, "storage", fake_storage)
+    monkeypatch.setitem(sys.modules, "storage.studio_db", fake_db)
+
+    b._ensure_db_run_created()
+
+    assert observed["flag_during_create"] is False, "flag must not be published before insert"
+    assert observed["in_progress_during_create"] is True
+    assert b._db_run_created is True, "flag must be published after a successful insert"
+    assert b._db_create_in_progress is False
+
+
+def test_ensure_db_run_created_stays_unpublished_on_failure(monkeypatch):
+    # If create_run raises, neither flag stays set, so a later caller can retry.
+    b = TrainingBackend()
+    b.current_job_id = "job_z"
+    b._db_config = {"model_name": "m"}
+
+    fake_storage = _types.ModuleType("storage")
+    fake_db = _types.ModuleType("storage.studio_db")
+
+    def _boom_create(**kw):
+        raise RuntimeError("insert failed")
+
+    fake_db.create_run = _boom_create
+    fake_storage.studio_db = fake_db
+    monkeypatch.setitem(sys.modules, "storage", fake_storage)
+    monkeypatch.setitem(sys.modules, "storage.studio_db", fake_db)
+
+    b._ensure_db_run_created()
+
+    assert b._db_run_created is False, "a failed insert must not publish the row as created"
+    assert b._db_create_in_progress is False, "the in-progress flag must be cleared on failure"

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -691,3 +691,60 @@ def test_escalation_finalizes_watched_run_by_id_end_to_end(monkeypatch):
     assert recs["finished"][0]["status"] == "stopped"
     assert recs["insert_ids"] == ["job_old"], "buffered metrics must land on the captured run"
     assert b._metric_buffer == [], "the captured batch must be drained"
+
+
+def test_escalation_does_not_claim_finalize_before_row_exists(monkeypatch):
+    # Item A (round 4): if the DB row is not created yet (an early create failed and the
+    # pump is retrying it), the escalation must not claim _run_finalized or call
+    # _finish_stopped_run, so the pump's later create-then-finalize still records the run.
+    b = TrainingBackend()
+    called: list = []
+    monkeypatch.setattr(b, "_finish_stopped_run", lambda *a: called.append(a))
+
+    b._proc = _FakeProc(alive = False)
+    b.current_job_id = "job_q"
+    b._db_run_created = False  # row not created yet
+    b._run_finalized = False
+    b._progress.is_training = True
+
+    b._finalize_stopped_after_escalation(target_proc = b._proc, watched_job_id = "job_q")
+
+    assert called == [], "must not finalize before the row exists"
+    assert b._run_finalized is False, "must not claim the finalize the pump still owes"
+    assert b._progress.is_training is False, "parent state must still clear so the UI unsticks"
+    assert b._proc is None
+
+
+def test_finish_stopped_run_requeues_on_db_error(monkeypatch):
+    # Item B (round 4): a transient DB error must unclaim the finalize and requeue the
+    # drained metrics (when the run is still current) so a later retry can record it stopped.
+    _install_fake_db(monkeypatch)
+    sys.modules["storage.studio_db"].finish_run = lambda **kw: (_ for _ in ()).throw(
+        RuntimeError("database is locked")
+    )
+    b = TrainingBackend()
+    b.current_job_id = "job_r"
+    b._run_finalized = True  # the caller (escalation) already claimed
+    b._metric_buffer[:] = []  # the caller already drained the batch
+
+    b._finish_stopped_run("job_r", None, [{"step": 1}], 1, None, None, [])
+
+    assert b._run_finalized is False, "a DB error must unclaim so the pump can retry"
+    assert b._metric_buffer == [{"step": 1}], "the drained batch must be requeued for retry"
+
+
+def test_finish_stopped_run_error_leaves_new_run_untouched(monkeypatch):
+    # If the watched run was superseded, a DB error must not unclaim/requeue onto the new run.
+    _install_fake_db(monkeypatch)
+    sys.modules["storage.studio_db"].finish_run = lambda **kw: (_ for _ in ()).throw(
+        RuntimeError("database is locked")
+    )
+    b = TrainingBackend()
+    b.current_job_id = "job_new"  # a new run is live
+    b._run_finalized = True  # the new run's flag
+    b._metric_buffer[:] = [{"step": 99}]  # the new run's buffer
+
+    b._finish_stopped_run("job_old", None, [{"step": 1}], 1, None, None, [])
+
+    assert b._run_finalized is True, "must not unclaim the new run's finalize"
+    assert b._metric_buffer == [{"step": 99}], "must not corrupt the new run's buffer"

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -3,13 +3,12 @@
 
 """Stop-watchdog escalation for a stuck training stop.
 
-A save-stop only signals the worker and waits for it to save and exit. On some
-platforms the worker saves successfully but then wedges in post-save GPU/driver
-teardown and never exits, leaving the run stuck in "Stopping..." forever. These
-tests pin the bounded recovery: the watchdog escalates to force_terminate() a
-short grace after "complete" (save done) or after an absolute timeout (hang during
-save), and never force-kills a worker that exits cleanly on its own. Fakes only;
-no GPU, network, or subprocess.
+A save-stop signals the worker and waits for it to save and exit. On some platforms the
+worker saves but then wedges in post-save GPU/driver teardown and never exits, leaving the
+run stuck in "Stopping..." forever. These tests pin the bounded recovery: the watchdog
+escalates to force_terminate() a short grace after "complete" (save done) or after an
+absolute timeout (hang during save), and never force-kills a worker that exits cleanly.
+Fakes only; no GPU, network, or subprocess.
 """
 
 from __future__ import annotations
@@ -160,8 +159,8 @@ def test_watchdog_escalates_after_grace_once_complete_seen(monkeypatch):
 
 
 def test_watchdog_does_not_kill_save_still_saving_within_window(monkeypatch):
-    # save=True, no "complete" yet: a large/slow save is in progress. It must not be
-    # force-killed while inside the (long) absolute window.
+    # save=True, no "complete" yet: a slow save in progress must not be force-killed
+    # inside the (long) absolute window.
     monkeypatch.setitem(_G, "_STOP_GRACE_S", 100.0)
     monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)
     b = TrainingBackend()
@@ -195,8 +194,8 @@ def test_watchdog_backstop_fires_for_save_after_absolute_timeout(monkeypatch):
 
 
 def test_cancel_uses_shorter_absolute_timeout(monkeypatch):
-    # A cancel has nothing to save, so it escalates on the shorter cancel cap even
-    # when the long save cap has not elapsed.
+    # A cancel has nothing to save, so it escalates on the shorter cancel cap even before
+    # the long save cap elapses.
     monkeypatch.setitem(_G, "_STOP_GRACE_S", 100.0)
     monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)  # save cap would not fire
     monkeypatch.setitem(_G, "_CANCEL_TIMEOUT_S", 0.05)
@@ -237,8 +236,8 @@ def test_watchdog_no_op_on_clean_quick_exit(monkeypatch):
 
 
 def test_watchdog_no_op_when_worker_superseded(monkeypatch):
-    # A stale watchdog from a prior run must never kill the worker of a new run:
-    # once self._proc is replaced, it exits silently.
+    # A stale watchdog from a prior run must never kill a new run's worker: once
+    # self._proc is replaced, it exits silently.
     monkeypatch.setitem(_G, "_STOP_GRACE_S", 0.05)
     monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 0.05)
     b = TrainingBackend()
@@ -257,8 +256,8 @@ def test_watchdog_no_op_when_worker_superseded(monkeypatch):
 
 
 def test_new_run_gets_its_own_watchdog(monkeypatch):
-    # A stale watchdog still sleeping on an old proc must not stop a new run's stop
-    # from creating its own watcher.
+    # A stale watchdog sleeping on an old proc must not stop a new run's stop from
+    # creating its own watcher.
     monkeypatch.setitem(_G, "_STOP_GRACE_S", 100.0)
     monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)
     b = TrainingBackend()
@@ -393,10 +392,9 @@ def test_stop_training_starts_watchdog_only_when_worker_alive(monkeypatch):
 
 
 def test_finalize_after_escalation_no_ops_when_superseded(monkeypatch):
-    # A /start can slip in while the watchdog is force-terminating the old worker
-    # (is_training_active() is False once _should_stop is set and the old proc is
-    # dead). The escalation finalize must then leave the NEW run untouched instead
-    # of dropping its handle and marking it stopped.
+    # A /start can slip in while the watchdog force-terminates the old worker
+    # (is_training_active() is False once _should_stop is set and the old proc is dead).
+    # The escalation finalize must then leave the NEW run untouched, not drop its handle.
     b = TrainingBackend()
     finstop: list = []
     monkeypatch.setattr(b, "_finish_stopped_run", lambda *a: finstop.append(a))
@@ -416,8 +414,8 @@ def test_finalize_after_escalation_no_ops_when_superseded(monkeypatch):
 
 
 def test_finalize_after_escalation_runs_for_its_own_worker(monkeypatch):
-    # The common case: the worker we watched is still current, so finalize proceeds
-    # and finalizes the captured run by id.
+    # Common case: the watched worker is still current, so finalize proceeds and
+    # finalizes the captured run by id.
     b = TrainingBackend()
     finstop: list = []
     monkeypatch.setattr(b, "_finish_stopped_run", lambda *a: finstop.append(a))
@@ -673,9 +671,9 @@ def test_ensure_db_run_created_stays_unpublished_on_failure(monkeypatch):
 
 
 def test_escalation_finalizes_watched_run_by_id_end_to_end(monkeypatch):
-    # Item A: exercise the real _finish_stopped_run against a fake DB. The watched run is
-    # finalized by its captured id with its buffered metrics, so a new run that starts in
-    # the gap after the backend goes idle can never leave the stopped run recorded running.
+    # Exercise the real _finish_stopped_run against a fake DB. The watched run is finalized
+    # by its captured id with its buffered metrics, so a new run that starts in the gap
+    # after the backend goes idle can never leave the stopped run recorded running.
     recs = _install_fake_db(monkeypatch)
     b = TrainingBackend()
     b.current_job_id = "job_old"
@@ -694,9 +692,9 @@ def test_escalation_finalizes_watched_run_by_id_end_to_end(monkeypatch):
 
 
 def test_escalation_does_not_claim_finalize_before_row_exists(monkeypatch):
-    # Item A (round 4): if the DB row is not created yet (an early create failed and the
-    # pump is retrying it), the escalation must not claim _run_finalized or call
-    # _finish_stopped_run, so the pump's later create-then-finalize still records the run.
+    # If the DB row is not created yet (an early create failed and the pump is retrying),
+    # the escalation must not claim _run_finalized or call _finish_stopped_run, so the
+    # pump's later create-then-finalize still records the run.
     b = TrainingBackend()
     called: list = []
     monkeypatch.setattr(b, "_finish_stopped_run", lambda *a: called.append(a))
@@ -716,8 +714,8 @@ def test_escalation_does_not_claim_finalize_before_row_exists(monkeypatch):
 
 
 def test_finish_stopped_run_requeues_on_db_error(monkeypatch):
-    # Item B (round 4): a transient DB error must unclaim the finalize and requeue the
-    # drained metrics (when the run is still current) so a later retry can record it stopped.
+    # A transient DB error must unclaim the finalize and requeue the drained metrics
+    # (when the run is still current) so a later retry can record it stopped.
     _install_fake_db(monkeypatch)
     sys.modules["storage.studio_db"].finish_run = lambda **kw: (_ for _ in ()).throw(
         RuntimeError("database is locked")

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -144,9 +144,9 @@ def test_watchdog_escalates_after_grace_once_complete_seen(monkeypatch):
     b._complete_seen.set()  # worker reported "complete" -> save is done
 
     b._start_stop_watchdog()
-    assert _wait_until(lambda: calls == ["force", "final"]), (
-        "watchdog must force_terminate a worker still alive after the post-save grace"
-    )
+    assert _wait_until(
+        lambda: calls == ["force", "final"]
+    ), "watchdog must force_terminate a worker still alive after the post-save grace"
     b._stop_watchdog.join(timeout = 5)
 
 
@@ -166,9 +166,9 @@ def test_watchdog_escalates_after_absolute_timeout(monkeypatch):
     # No _complete_seen: simulates a hang during save, no "complete" ever sent.
 
     b._start_stop_watchdog()
-    assert _wait_until(lambda: calls == ["force", "final"]), (
-        "watchdog must force_terminate a worker that never exits within the timeout"
-    )
+    assert _wait_until(
+        lambda: calls == ["force", "final"]
+    ), "watchdog must force_terminate a worker that never exits within the timeout"
     b._stop_watchdog.join(timeout = 5)
 
 


### PR DESCRIPTION
## Summary

Stopping a training run with save could hang forever. A Stop-with-save only sends
a stop signal to the training subprocess and then waits for the subprocess to save
the model and exit on its own. The only force-kill path, `force_terminate()`, was
reachable exclusively from `/reset` and only when the user chose Cancel (save=False,
`_cancel_requested=True`). A normal Stop-with-save therefore had no force-kill
fallback.

On Windows + AMD ROCm this surfaces as a stuck run: the subprocess saves the
adapter files successfully but then wedges during post-save GPU/HIP context
teardown in the driver and never exits (unkillable even by `taskkill /F` until the
driver times out). The run is stuck in "Stopping..." indefinitely, `is_training`
stays true, and the user cannot recover because `/reset` returns HTTP 409 for a
non-cancel active run.

## Changes

- Add a stop watchdog (daemon thread) started when a stop is requested. It
  guarantees the run finalizes in bounded time by escalating to `force_terminate()`
  if the subprocess does not exit on its own, without ever killing a legitimate
  in-progress save prematurely.
  - Primary trigger: once the worker sends `complete` (which happens after
    `trainer.save_model` finishes), the save is done, so the watchdog
    force-terminates after a short grace period if the subprocess is still alive.
  - Absolute cap is a last-resort backstop only. For a save=True stop it is long,
    so a slow save (large model, network disk) is never killed mid-write; a
    not-yet-`complete` save is not treated as a hang before that long window. For a
    cancel (save=False) there is nothing to save, so the backstop is shorter. When
    the backstop fires with no completion signal it logs a clear warning.
- After escalation the parent state is finalized regardless of whether the OS
  actually reaped the wedged process: `is_training=False` and status
  "Training stopped.", so the UI leaves "Stopping..." and the user can start a new
  run. Finalization runs even if `force_terminate()` raises on a wedged child
  (try/except/finally), and the saved `output_dir` is preserved so run history still
  records the checkpoint path. The wedged handle is dropped; it is a daemon bound to
  the parent lifetime.
- The watchdog tracks the worker it watches: a new run always gets its own watcher,
  termination targets only the captured handle, and a superseded worker is never
  touched, so a stale watchdog can never kill a fresh run.
- Configurable timeouts, read in the existing `_env_int` style:
  - `UNSLOTH_STUDIO_TRAINING_STOP_GRACE_S` (default 15)
  - `UNSLOTH_STUDIO_TRAINING_STOP_TIMEOUT_S` (default 600, save backstop)
  - `UNSLOTH_STUDIO_TRAINING_CANCEL_TIMEOUT_S` (default 120, cancel backstop)
- Unit tests (fakes only, no GPU/subprocess) covering: escalation after the grace
  period once `complete` is seen; a save still saving (no `complete`) is not killed
  within the long window and the backstop only fires past it; cancel uses the
  shorter cap; no force-kill on a clean quick exit; finalize runs even when
  `force_terminate` raises; `output_dir` is preserved on finalize; a new run gets
  its own watcher; and termination targets only the captured process.

## Notes

- Platform-agnostic: a worker that exits cleanly and promptly is a no-op (no
  force-kill, no log), so Linux and macOS behavior is unchanged. The watchdog only
  fires when a requested stop fails to exit on its own.
- The deeper layer-2 issue (the ROCm/HIP post-save teardown hang itself) is a
  separate problem and is out of scope here; this change bounds the recovery so the
  run always finalizes and the UI never gets stuck in "Stopping...".
