### PR TITLE
Fix Studio user-message overflow for long unbroken text

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -4006,7 +4006,7 @@ const UserMessage: FC = () => {
       <UserMessageAudio />
 
       <div className="aui-user-message-content-wrapper flex max-w-[80%] min-w-0 flex-col items-end">
-        <div className="aui-user-message-content wrap-break-word w-fit rounded-[24px] bg-[#f5f5f5] px-4 py-2.5 text-[#0d0d0d] dark:text-foreground dark:bg-card">
+        <div className="aui-user-message-content wrap-break-word w-fit max-w-full rounded-[24px] bg-[#f5f5f5] px-4 py-2.5 text-[#0d0d0d] dark:text-foreground dark:bg-card">
           <MessagePrimitive.Parts />
         </div>
         <div className="mt-1 -mr-[var(--icon-btn-inset)] flex min-h-8 items-center">


### PR DESCRIPTION
## Summary

- Cap the Studio user-message bubble at the width of its existing `max-w-[80%]` wrapper.
- Preserve intrinsic `w-fit` sizing for short messages and the existing wrapping behavior for normal prose.
- Keep assistant Markdown, code-block scrolling, viewport overflow, character limits, and context-window validation unchanged.

This may address one contributing cause of #7068; the broader issue should remain open for further investigation.

## Root cause

The user bubble combined `w-fit` with `overflow-wrap: break-word` but had no maximum width. `break-word` does not constrain intrinsic width, so a long unbroken path, URL, hash, or console value could make the right-aligned bubble thousands of pixels wider than its wrapper. Adding `max-w-full` supplies the missing hard cap while allowing the existing wrapping rule to break the text inside that finite width.

## Scope and risk

The change adds one Tailwind class to the user-message content element. Short messages remain content-sized, while long messages cannot exceed the existing wrapper. No assistant-message or thread-viewport classes are touched.

## Validation

- Reproduced the untouched behavior in the real Studio chat path: 5,000 consecutive characters produced a 55,558.97px bubble inside a 595.19px wrapper, while similarly sized spaced prose remained contained.
- Verified the fixed layout at 1280×900 and 390×844 with short text, multiline prose, 5,000 consecutive characters, long paths and URLs, hashes, and 9,629 characters of multiline console output.
- Confirmed the bubble and document scroll widths remain contained on desktop and narrow layouts.
- Completed two independent review passes with no findings.

```text
npm run typecheck
npm run build
python -m pytest tests/studio/test_chat_response_details_ui_contract.py tests/studio/test_composer_rtl_bidi_attribute.py -q
git diff --check origin/main...HEAD
```

All commands above pass; the focused test run reports 18 passed. `npm run lint` was also run and reports 449 pre-existing repository diagnostics unrelated to the changed line.