### PR TITLE
Fix S3 tab flashing on reload

### DIFF
--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -115,11 +115,12 @@ let _yamlLearningRate: number | undefined = undefined;
 let _datasetFormatBeforeCpt: DatasetFormat | null = null;
 let _datasetFormatAutoForcedByCpt = false;
 
+// isVisionModel / isAudioModel persist so multimodal-only UI paints right on
+// reload; the model-config fetch still re-derives them afterwards.
 const NON_PERSISTED_STATE_KEYS: ReadonlySet<keyof TrainingConfigState> = new Set([
   "modelType",
   "isCheckingVision",
   "isEmbeddingModel",
-  "isAudioModel",
   "isLoadingModelDefaults",
   "modelDefaultsError",
   "modelDefaultsAppliedFor",
@@ -128,7 +129,6 @@ const NON_PERSISTED_STATE_KEYS: ReadonlySet<keyof TrainingConfigState> = new Set
   "isDatasetAudio",
   "trainOnCompletions",
   "maxPositionEmbeddings",
-  "isVisionModel",
   "s3Config",
 ]);
 

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -115,10 +115,9 @@ let _yamlLearningRate: number | undefined = undefined;
 let _datasetFormatBeforeCpt: DatasetFormat | null = null;
 let _datasetFormatAutoForcedByCpt = false;
 
-// isVisionModel / isAudioModel persist so multimodal-only UI paints right on
-// reload; the model-config fetch still re-derives them afterwards.
+// modelType / isVisionModel / isAudioModel persist so multimodal-only UI
+// paints right on reload; the model-config fetch still re-derives them.
 const NON_PERSISTED_STATE_KEYS: ReadonlySet<keyof TrainingConfigState> = new Set([
-  "modelType",
   "isCheckingVision",
   "isEmbeddingModel",
   "isLoadingModelDefaults",
@@ -570,6 +569,9 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             visionImageSize?: number | null;
             trustRemoteCode?: boolean;
             approvedRemoteCodeFingerprint?: string | null;
+            isVisionModel?: boolean;
+            isAudioModel?: boolean;
+            isEmbeddingModel?: boolean;
           } = {
             selectedModel,
             modelDefaultsError: null,
@@ -581,6 +583,11 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             // re-applied below, and a custom-code model re-opens the dialog before start.
             patch.trustRemoteCode = false;
             patch.approvedRemoteCodeFingerprint = null;
+            // Reset capability flags so a mid-fetch reload can't persist the
+            // previous model's vision/audio flags against the new model.
+            patch.isVisionModel = false;
+            patch.isAudioModel = false;
+            patch.isEmbeddingModel = false;
           }
           set(patch);
 


### PR DESCRIPTION
isVisionModel and isAudioModel weren't persisted, so the S3 tab would flash on reload until the model-config fetch re-derived them. Persist both flags to fix it.