### PR TITLE
Studio: pin llama.cpp update apply to the release the banner offered

### DIFF
--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -393,6 +393,9 @@ def test_start_update_source_build_installs_prebuilt(monkeypatch, tmp_path):
     assert "--llama-tag" in cmd and "latest" in cmd
     assert cmd[cmd.index("--rocm-gfx") + 1] == "gfx110x"
     assert "--simple-policy" not in cmd and "--cpu-fallback" not in cmd
+    # No pin: source-build detection and the unpinned apply share the same
+    # "latest" resolver, so they already agree.
+    assert "--published-release-tag" not in cmd
 
 
 def test_start_update_happy_path(monkeypatch, tmp_path):
@@ -661,6 +664,26 @@ def test_install_cmd_cuda_marker_minimal_and_backward_compatible(monkeypatch, tm
     assert "--rocm-gfx" not in cmd
     assert "--has-rocm" not in cmd
     assert "--cpu-fallback" not in cmd
+
+
+def test_install_cmd_pins_offered_release_tag(monkeypatch, tmp_path):
+    # Apply must install exactly the release the banner offered. The installer's
+    # own "latest" comes from commit-date-ordered sources, which can lag the
+    # published_at-newest tag detection picked; unpinned, that lag makes Update
+    # reinstall the current build while the banner never clears.
+    monkeypatch.setattr(sys, "platform", "linux")
+    cmd = _capture_install_cmd(monkeypatch, tmp_path, latest = "b9601-mix-a0e2906")
+    # The full release identity is pinned, not the bare upstream base.
+    assert cmd[cmd.index("--published-release-tag") + 1] == "b9601-mix-a0e2906"
+
+
+def test_install_cmd_does_not_pin_on_macos(monkeypatch, tmp_path):
+    # A pinned tag disables the installer's older-release walk-back, which macOS
+    # needs to skip prebuilts built for a newer macOS than the host.
+    monkeypatch.setattr(sys, "platform", "darwin")
+    cmd = _capture_install_cmd(monkeypatch, tmp_path)
+    assert "--published-release-tag" not in cmd
+    assert "--llama-tag" in cmd and "latest" in cmd
 
 
 # --- refusal + maintenance-state coordination ---

--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -522,6 +522,53 @@ def test_start_update_reports_full_release_tag(monkeypatch, tmp_path):
     assert "Updated llama.cpp to b9596-mix-e6f2453." in job["message"]
 
 
+def _run_start_update_to_completion():
+    res = upd.start_update()
+    assert res["started"] is True
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        job = upd.get_update_status()["job"]
+        if job["state"] in ("success", "error"):
+            return job
+        time.sleep(0.05)
+    return upd.get_update_status()["job"]
+
+
+def test_start_update_pinned_tag_mismatch_fails(monkeypatch, tmp_path):
+    # Installer stays on the pinned repo but produces a different tag -> it
+    # ignored the pin (the silent mismatch this pin exists to prevent). Fail loud.
+    monkeypatch.setattr(sys, "platform", "linux")
+    install_dir = tmp_path / "llama.cpp"
+    binary = _write_install(install_dir, "b9595")
+    monkeypatch.setattr(upd, "_find_binary", lambda: binary)
+    monkeypatch.setattr(upd, "_installer_script", lambda: tmp_path / "install_llama_prebuilt.py")
+    monkeypatch.setattr(freshness, "_fetch_latest_release_tag", lambda repo, timeout = 5.0: "b9601-mix-a0e2906")
+    _patch_installer_popen(
+        monkeypatch,
+        on_start = lambda cmd: _write_install(install_dir, "b9500", release_tag = "b9500-mix-deadbee"),
+    )
+    job = _run_start_update_to_completion()
+    assert job["state"] == "error", job
+    assert "b9601-mix-a0e2906" in (job["error"] or "")
+
+
+def test_start_update_pinned_reroute_to_other_repo_ok(monkeypatch, tmp_path):
+    # A Vulkan/Intel host reroutes fork->upstream and drops the pin, installing a
+    # different-repo tag. Legitimate: the pin check must not flag the repo switch.
+    monkeypatch.setattr(sys, "platform", "linux")
+    install_dir = tmp_path / "llama.cpp"
+    binary = _write_install(install_dir, "b9595", repo = "unslothai/llama.cpp")
+    monkeypatch.setattr(upd, "_find_binary", lambda: binary)
+    monkeypatch.setattr(upd, "_installer_script", lambda: tmp_path / "install_llama_prebuilt.py")
+    monkeypatch.setattr(freshness, "_fetch_latest_release_tag", lambda repo, timeout = 5.0: "b9601-mix-a0e2906")
+    _patch_installer_popen(
+        monkeypatch,
+        on_start = lambda cmd: _write_install(install_dir, "b9601", repo = "ggml-org/llama.cpp"),
+    )
+    job = _run_start_update_to_completion()
+    assert job["state"] == "success", job
+
+
 def test_start_update_installer_failure_reports_error(monkeypatch, tmp_path):
     install_dir = tmp_path / "llama.cpp"
     binary = _write_install(install_dir, "b9493")

--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -542,7 +542,9 @@ def test_start_update_pinned_tag_mismatch_fails(monkeypatch, tmp_path):
     binary = _write_install(install_dir, "b9595")
     monkeypatch.setattr(upd, "_find_binary", lambda: binary)
     monkeypatch.setattr(upd, "_installer_script", lambda: tmp_path / "install_llama_prebuilt.py")
-    monkeypatch.setattr(freshness, "_fetch_latest_release_tag", lambda repo, timeout = 5.0: "b9601-mix-a0e2906")
+    monkeypatch.setattr(
+        freshness, "_fetch_latest_release_tag", lambda repo, timeout = 5.0: "b9601-mix-a0e2906"
+    )
     _patch_installer_popen(
         monkeypatch,
         on_start = lambda cmd: _write_install(install_dir, "b9500", release_tag = "b9500-mix-deadbee"),
@@ -560,7 +562,9 @@ def test_start_update_pinned_reroute_to_other_repo_ok(monkeypatch, tmp_path):
     binary = _write_install(install_dir, "b9595", repo = "unslothai/llama.cpp")
     monkeypatch.setattr(upd, "_find_binary", lambda: binary)
     monkeypatch.setattr(upd, "_installer_script", lambda: tmp_path / "install_llama_prebuilt.py")
-    monkeypatch.setattr(freshness, "_fetch_latest_release_tag", lambda repo, timeout = 5.0: "b9601-mix-a0e2906")
+    monkeypatch.setattr(
+        freshness, "_fetch_latest_release_tag", lambda repo, timeout = 5.0: "b9601-mix-a0e2906"
+    )
     _patch_installer_popen(
         monkeypatch,
         on_start = lambda cmd: _write_install(install_dir, "b9601", repo = "ggml-org/llama.cpp"),

--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -677,6 +677,13 @@ def test_install_cmd_pins_offered_release_tag(monkeypatch, tmp_path):
     assert cmd[cmd.index("--published-release-tag") + 1] == "b9601-mix-a0e2906"
 
 
+def test_install_cmd_pins_on_windows(monkeypatch, tmp_path):
+    # The darwin exemption must not leak to other platforms.
+    monkeypatch.setattr(sys, "platform", "win32")
+    cmd = _capture_install_cmd(monkeypatch, tmp_path)
+    assert cmd[cmd.index("--published-release-tag") + 1] == "b9518"
+
+
 def test_install_cmd_does_not_pin_on_macos(monkeypatch, tmp_path):
     # A pinned tag disables the installer's older-release walk-back, which macOS
     # needs to skip prebuilts built for a newer macOS than the host.

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -483,11 +483,8 @@ def _run_update(
     """Worker: put the backend into a maintenance state, run the installer for
     the latest prebuilt, then refresh caches so the next load uses the new build.
 
-    pin_release_tag pins the installer to that exact published release. Without
-    it the installer re-resolves "latest" itself (via GitHub's /releases/latest
-    pointer or list order, both commit-date based), which can lag the
-    published_at-newest release the update banner offered; the apply then
-    reinstalls the current build and the banner never clears (see #6219)."""
+    pin_release_tag pins the installer to that exact published release instead
+    of letting it re-resolve "latest" itself (see start_update for why)."""
     backend = None
     model_was_active = False
     try:
@@ -664,14 +661,12 @@ def start_update() -> dict:
         repo = marker.get("published_repo") or DEFAULT_PUBLISHED_REPO
         from_tag = marker.get("tag") or marker.get("release_tag")
         asset = marker.get("asset")
-        # Install exactly the release the banner offered, not whatever the
-        # installer's own "latest" resolves to at apply time (commit-date
-        # ordered, can lag the published_at pick above -- reinstalling the
-        # current build in a loop). Not on macOS: a pinned tag disables the
-        # older-release walk-back that skips prebuilts built for a newer macOS.
-        # Elsewhere losing the walk-back is accepted: a latest release that is
-        # unusable for this host fails the job loudly (retryable) rather than
-        # silently installing a release other than the one offered.
+        # Install exactly the release the banner offered: the installer's own
+        # "latest" is commit-date ordered and can lag the published_at pick
+        # above, reinstalling the current build in a loop (the #6219 class).
+        # Not on macOS, which needs the older-release walk-back a pin disables
+        # (skipping too-new prebuilts); elsewhere an unusable latest now fails
+        # the job loudly (retryable) instead of walking back.
         pin_release_tag = None if sys.platform == "darwin" else status.get("latest_tag")
     else:
         # Source build / custom path: only proceed when the same detection logic

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -580,6 +580,16 @@ def _run_update(
         new_marker = read_install_marker(_find_binary())
         new_tag = (new_marker or {}).get("release_tag") or (new_marker or {}).get("tag")
 
+        # Pinned install must land on that exact release; a same-repo mismatch
+        # means the pin was ignored (Vulkan/Intel reroute to another repo is fine).
+        if (
+            pin_release_tag
+            and new_tag
+            and (new_marker or {}).get("published_repo") == repo
+            and new_tag != pin_release_tag
+        ):
+            raise RuntimeError(f"pinned release {pin_release_tag} but installer produced {new_tag}")
+
         with _job_lock:
             _job.update(
                 state = _JOB_SUCCESS,

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -669,6 +669,9 @@ def start_update() -> dict:
         # ordered, can lag the published_at pick above -- reinstalling the
         # current build in a loop). Not on macOS: a pinned tag disables the
         # older-release walk-back that skips prebuilts built for a newer macOS.
+        # Elsewhere losing the walk-back is accepted: a latest release that is
+        # unusable for this host fails the job loudly (retryable) rather than
+        # silently installing a release other than the one offered.
         pin_release_tag = None if sys.platform == "darwin" else status.get("latest_tag")
     else:
         # Source build / custom path: only proceed when the same detection logic

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -473,9 +473,21 @@ def _rocm_install_args(asset: Optional[str]) -> list[str]:
     return ["--has-rocm"]
 
 
-def _run_update(install_dir: Path, repo: str, asset: Optional[str], script: Path) -> None:
+def _run_update(
+    install_dir: Path,
+    repo: str,
+    asset: Optional[str],
+    script: Path,
+    pin_release_tag: Optional[str] = None,
+) -> None:
     """Worker: put the backend into a maintenance state, run the installer for
-    the latest prebuilt, then refresh caches so the next load uses the new build."""
+    the latest prebuilt, then refresh caches so the next load uses the new build.
+
+    pin_release_tag pins the installer to that exact published release. Without
+    it the installer re-resolves "latest" itself (via GitHub's /releases/latest
+    pointer or list order, both commit-date based), which can lag the
+    published_at-newest release the update banner offered; the apply then
+    reinstalls the current build and the banner never clears (see #6219)."""
     backend = None
     model_was_active = False
     try:
@@ -510,6 +522,8 @@ def _run_update(install_dir: Path, repo: str, asset: Optional[str], script: Path
             "--published-repo",
             repo,
         ]
+        if pin_release_tag:
+            cmd.extend(["--published-release-tag", pin_release_tag])
         cmd.extend(_rocm_install_args(asset))
         logger.info("llama update: installing", cmd = " ".join(cmd))
         # Stream progress lines into job["progress"].
@@ -650,6 +664,12 @@ def start_update() -> dict:
         repo = marker.get("published_repo") or DEFAULT_PUBLISHED_REPO
         from_tag = marker.get("tag") or marker.get("release_tag")
         asset = marker.get("asset")
+        # Install exactly the release the banner offered, not whatever the
+        # installer's own "latest" resolves to at apply time (commit-date
+        # ordered, can lag the published_at pick above -- reinstalling the
+        # current build in a loop). Not on macOS: a pinned tag disables the
+        # older-release walk-back that skips prebuilts built for a newer macOS.
+        pin_release_tag = None if sys.platform == "darwin" else status.get("latest_tag")
     else:
         # Source build / custom path: only proceed when the same detection logic
         # would offer the update (prebuilt exists, install is behind, root is
@@ -677,6 +697,9 @@ def start_update() -> dict:
         repo = (res or {}).get("repo") or DEFAULT_PUBLISHED_REPO
         from_tag = None
         asset = (res or {}).get("asset")
+        # No pin: source-build detection resolves via --resolve-prebuilt latest,
+        # the same resolver the unpinned apply uses, so the two already agree.
+        pin_release_tag = None
 
     if install_dir is None:
         return {
@@ -704,7 +727,7 @@ def start_update() -> dict:
 
     thread = threading.Thread(
         target = _run_update,
-        args = (install_dir, repo, asset, script),
+        args = (install_dir, repo, asset, script, pin_release_tag),
         name = "llama-cpp-update",
         daemon = True,
     )


### PR DESCRIPTION
The update banner and the Update button resolve "latest" differently. Detection picks the newest release by `published_at` (#6219). The Update button runs the installer with `--llama-tag latest`, and the installer re-resolves that word on its own, in commit-date order. When the two orderings disagree (the incident class behind #6219), Update re-downloads and reinstalls the build the user already has, reports success, and the banner never clears. No error is surfaced, so the updater just looks broken.

## Fix

The apply step now passes detection's resolved tag to the installer via its existing `--published-release-tag` flag, so it installs exactly the release the update check offered. The pin comes from the same force-refreshed status check that gates `update_available`.

Scope:

- Not on macOS: a pinned tag disables the older-release walk-back that macOS needs to skip prebuilts built for a newer macOS than the host.
- Not for source builds: their detection and apply already share the installer's resolver.

Trade-off: when the offered release is unusable (assets still uploading), a pinned apply fails with a visible, retryable error instead of silently walking back to an older release. A failed pin cannot fall through to a source build. In practice the window is small: the last 8 fork releases all ship the identical 35 host variants.

## Verification

- `test_llama_cpp_update.py`, `test_llama_route.py`, `test_local_llama_cpp_link.py`: 58 pass. New tests cover the pinned tag (full `b9601-mix-a0e2906` identity), win32, and the macOS and source-build exemptions.
- Live run: `--resolve-prebuilt latest --published-release-tag b9975-mix-53618c5` selects the correct host asset for exactly that tag; a bogus pin fails fast with a clean 404 and no substitution.
