### PR TITLE
scan_packages: baseline sentencepiece dup2 finding after upstream reindent

### DIFF
--- a/scripts/scan_packages_baseline.json
+++ b/scripts/scan_packages_baseline.json
@@ -635,6 +635,14 @@
       "evidence_hash": "bba233b67f8ea4f0723b2fecaabf56528531bccd77ace836165bf38b47246bcc"
     },
     {
+      "package": "sentencepiece",
+      "file": "sentencepiece/__init__.py",
+      "check": "Reverse shell / bind shell pattern",
+      "severity": "CRITICAL",
+      "evidence": "L772:             os.dup2(self.ostream.fileno(), self.orig_stream_fileno) | L777:             os.dup2(self.orig_stream_dup, self.orig_stream_fileno)",
+      "evidence_hash": "65b5a11cce128fe09b3f238c01bed7c883d1740d7d46d659118f67940f6c17dc"
+    },
+    {
       "package": "setuptools",
       "file": "distutils-precedence.pth",
       "check": ".pth has advanced obfuscation (marshal/compile/zlib/__import__)",


### PR DESCRIPTION
### What

Add the current-indentation variant of the sentencepiece `os.dup2` finding to the `scan_packages.py` allowlist so the supply-chain scan stops blocking on it.

### Why it was failing

`pip scan-packages :: hf-stack` and `pip scan-packages :: studio` both fail on the "Scan declared + transitive Python deps" step with a single non-baselined CRITICAL:

```
[1] CRITICAL  Reverse shell / bind shell pattern
    Package:  sentencepiece
    File:     sentencepiece/__init__.py
    Evidence: L772: os.dup2(self.ostream.fileno(), self.orig_stream_fileno)
            | L777: os.dup2(self.orig_stream_dup, self.orig_stream_fileno)
```

This is a benign false positive: sentencepiece redirects stdout/stderr file descriptors to capture its C++ logs, and the heuristic flags `os.dup2` because reverse shells dup socket fds onto 0/1/2. No socket or networking is involved.

The finding is already allowlisted, but the baseline key is `(package, package-relative file, check, evidence_hash)`, where `evidence_hash` is over the matched code with the `L<NN>:` markers stripped and the code's own indentation preserved. A newer sentencepiece release reindented this block, moving it from L1221/L1226 to L772/L777 and changing its leading indentation. That changed the hash (`bba233..` to `65b5a11c..`), so the existing entry no longer matched and the finding resurfaced as a blocking CRITICAL. The scan gate only trips on non-baselined CRITICAL/HIGH, which is why the MEDIUM findings are unaffected.

### Fix

Add the new indentation variant to `scripts/scan_packages_baseline.json`. The old L1221 entry is kept so both sentencepiece versions stay covered.

Verified with the scanner's own `_load_baseline` / `_finding_key`: the L772/L777 finding key is now present in the baseline set, and the old L1221 variant is still covered.