### PR TITLE
fix(install): return failure exit codes

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -91,6 +91,7 @@ function Install-UnslothStudio {
         if ($TauriMode) {
             exit $Code
         }
+        throw $Message
     }
 
     # ── Parse flags ──

--- a/tests/test_installer_skip_autostart.py
+++ b/tests/test_installer_skip_autostart.py
@@ -1,4 +1,4 @@
-"""Regression tests for the installers' post-install autostart opt-out."""
+"""Regression tests for installer controls and process exits."""
 
 from __future__ import annotations
 
@@ -118,6 +118,27 @@ def test_windows_skip_autostart_bypasses_only_the_interactive_prompt():
     assert source.index("Start Unsloth Studio now? [Y/n]") < source.index(
         'step "launch" "manual commands:"'
     )
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
+def test_windows_installer_invalid_package_fails():
+    result = subprocess.run(
+        [
+            "pwsh",
+            "-NoProfile",
+            "-NonInteractive",
+            "-File",
+            str(INSTALL_PS1),
+            "--package",
+            "bad!",
+        ],
+        capture_output = True,
+        text = True,
+        timeout = 30,
+    )
+
+    assert result.returncode != 0
+    assert "package name contains invalid characters" in result.stdout + result.stderr
 
 
 def test_skip_autostart_is_documented_for_all_installers():


### PR DESCRIPTION
## Summary

- make non-Tauri Windows installer failures terminate after rollback instead of returning success
- retain the existing Tauri exit-code behavior
- add a process regression test for invalid `--package` input

## Verification

- parsed `install.ps1` under Windows PowerShell 5.1
- verified invalid `--package` returns exit code 1 in standard and Tauri modes
- ran `python -m py_compile tests/test_installer_skip_autostart.py`