### PR TITLE
fix(dataprep): guard smart_chunk_text against stride >= chunk_size

### DIFF
--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -141,6 +141,26 @@ def test_raw_text_loader():
         except ValueError as e:
             assert "stride" in str(e) and "chunk_size" in str(e)
 
+        # smart_chunk_text validation: called directly, chunk_size/stride are its own
+        # arguments and bypass the constructor guard, so it must guard itself or an
+        # invalid stride makes `start_idx += chunk_size - stride` non-positive and the
+        # chunking loop never terminates (hangs).
+        long_text = "This is a test file for raw text training. " * 10
+        valid_chunks = loader.smart_chunk_text(long_text, chunk_size = 5, stride = 2)
+        assert len(valid_chunks) > 0, "Valid stride should produce chunks"
+
+        try:
+            loader.smart_chunk_text(long_text, chunk_size = 5, stride = 5)
+            assert False, "Should raise ValueError for stride == chunk_size"
+        except ValueError as e:
+            assert "stride" in str(e) and "chunk_size" in str(e)
+
+        try:
+            loader.smart_chunk_text(long_text, chunk_size = 5, stride = 10)
+            assert False, "Should raise ValueError for stride > chunk_size"
+        except ValueError as e:
+            assert "stride" in str(e) and "chunk_size" in str(e)
+
         # Preprocessor.
         preprocessor = TextPreprocessor()
         clean_text = preprocessor.clean_text("  messy   text  \n\n\n  ")

--- a/unsloth/dataprep/raw_text.py
+++ b/unsloth/dataprep/raw_text.py
@@ -132,6 +132,13 @@ class RawTextDataLoader:
         3. Maintains context with stride overlap
         4. Returns tokenized chunks directly (more efficient) or text chunks
         """
+        if chunk_size <= 0:
+            raise ValueError(f"chunk_size must be positive, got {chunk_size}")
+        if stride >= chunk_size:
+            raise ValueError(
+                f"stride ({stride}) must be smaller than chunk_size ({chunk_size}) to progress the chunking loop"
+            )
+
         # Tokenize the whole text once for accurate token counts
         tokenized = self.tokenizer(text, return_tensors = "pt", add_special_tokens = False)
         tokens = tokenized["input_ids"]


### PR DESCRIPTION

### What

`RawTextDataLoader.smart_chunk_text` (a public method on the exported
`RawTextDataLoader`) can hang forever when called directly with
`stride >= chunk_size`.

The method advances its window with `start_idx += chunk_size - stride` and only
exits the loop on `if end_idx == len(tokens): break`:

```python
# unsloth/dataprep/raw_text.py
while start_idx < len(tokens):
    end_idx = min(start_idx + chunk_size, len(tokens))
    ...
    if end_idx == len(tokens):
        break
    start_idx += chunk_size - stride   # <= 0 when stride >= chunk_size
```

When `stride == chunk_size` the increment is `0`; when `stride > chunk_size` it
is negative. For any text longer than one chunk, `start_idx` never advances past
the first window, `end_idx` never reaches `len(tokens)`, and the `while` loop
never terminates.

The constructor already validates this (`__init__` raises when
`stride >= chunk_size`), but `smart_chunk_text` takes `chunk_size` and `stride`
as its own explicit arguments, so a direct call bypasses the constructor guard:

```python
loader = RawTextDataLoader(tokenizer, chunk_size = 5, stride = 2)  # ok
loader.smart_chunk_text(long_text, chunk_size = 5, stride = 5)     # hangs
```

This guard used to live in `smart_chunk_text` itself and was later moved to the
constructor when parameter validation was centralized, which left the public
method unguarded for direct callers.

### Fix

Re-add the `chunk_size`/`stride` guard at the top of `smart_chunk_text` so direct
callers fail fast with a clear `ValueError` instead of hanging. The constructor
keeps its guard as well (defense in depth for the internal callers, which pass
the validated `self.chunk_size` / `self.stride`). No behavior changes for valid
inputs or for any existing internal call path.

### Test

Adds a regression test to `tests/test_raw_text.py` that calls `smart_chunk_text`
directly and asserts:

- a valid stride (`stride < chunk_size`) still produces chunks, and
- `stride == chunk_size` and `stride > chunk_size` raise `ValueError` (instead of
  hanging).

### Notes

- Single focused change.
- Lint: `ruff check` on both files passes.
- No linked issue exists; found while reading `dataprep`.
