### PR TITLE
Studio: honor the 'none' gradient checkpointing option in training

### DIFF
--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -931,7 +931,7 @@ class UnslothTrainer:
                     use_gradient_checkpointing = "unsloth"
                 elif use_gradient_checkpointing in ("true", "1", "yes"):
                     use_gradient_checkpointing = True
-                elif use_gradient_checkpointing in ("false", "0", "no"):
+                elif use_gradient_checkpointing in ("false", "0", "no", "none", "off"):
                     use_gradient_checkpointing = False
                 else:
                     # Invalid value -> "unsloth"


### PR DESCRIPTION
Selecting **None** in the training "Gradient checkpointing" dropdown did nothing on the main LoRA/QLoRA path. Studio silently kept Unsloth's checkpointing on and logged a bogus "Invalid value" warning, so a user who wanted it off couldn't turn it off.

## Fix

The trainer only recognized `true`/`false`-style values and dropped `none` to its default. Add `none` (and `off`) to the disable case, so the dropdown choice is honored. The MLX and embedding training paths already did this, so this just brings the LoRA path in line.

No other option changes: Unsloth, Standard, and the default behave exactly as before.

## Verification

Confirmed the `none` value reaches the trainer unchanged from the dropdown, that it now disables checkpointing (instead of being reset to Unsloth), and that the sibling paths already behaved this way. No existing test relied on the old behavior.

Surfaced by an AMD (gfx1201) user who reported Unsloth "forcing smart memory despite selecting none": https://www.reddit.com/r/unsloth/comments/1uunobi/any_roadmap_for_when_gfx1201_will_become/. Their training also crashes, which is a separate issue.
