### PR TITLE
Studio: scope the seeded bootstrap password auto-fill to loopback clients

### DIFF
--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1381,8 +1381,11 @@ def _is_loopback_ip(host: Optional[str]) -> bool:
 # cf-connecting-ip, reverse proxies set the rest (uvicorn only consumes
 # x-forwarded-for, so the others survive to here).
 _PROXIED_CLIENT_HEADERS = (
-    "cf-connecting-ip", "forwarded", "x-forwarded-for",
-    "x-forwarded-host", "x-real-ip",
+    "cf-connecting-ip",
+    "forwarded",
+    "x-forwarded-for",
+    "x-forwarded-host",
+    "x-real-ip",
 )
 
 
@@ -1395,9 +1398,9 @@ def _host_header_is_loopback(host_header: Optional[str]) -> bool:
     if not host_header:
         return False
     host = host_header.strip()
-    if host.startswith("["):        # [IPv6](:port)
+    if host.startswith("["):  # [IPv6](:port)
         host = host[1:].split("]", 1)[0]
-    elif host.count(":") == 1:      # host:port
+    elif host.count(":") == 1:  # host:port
         host = host.split(":", 1)[0]
     host = host.lower().rstrip(".")
     return host == "localhost" or _is_loopback_ip(host)

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1398,8 +1398,11 @@ def _host_header_is_loopback(host_header: Optional[str]) -> bool:
     if not host_header:
         return False
     host = host_header.strip()
-    if host.startswith("["):  # [IPv6](:port)
-        host = host[1:].split("]", 1)[0]
+    if host.startswith("["):  # [IPv6] or [IPv6]:port
+        end = host.find("]")
+        if end == -1 or (host[end + 1:] and not host[end + 1:].startswith(":")):
+            return False  # unclosed bracket or junk after ] (e.g. [::1]evil)
+        host = host[1:end]
     elif host.count(":") == 1:  # host:port
         host = host.split(":", 1)[0]
     host = host.lower().rstrip(".")

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1366,7 +1366,7 @@ def _canonical_origin(scheme: str, netloc: str) -> Optional[tuple[str, str, int]
 
 def _is_loopback_ip(host: Optional[str]) -> bool:
     """Return whether ``host`` is a loopback IP, including IPv4-mapped IPv6."""
-    if not host:
+    if not host or "%" in host:  # a scope id (::1%eth0) is never a plain loopback
         return False
     try:
         ip = ipaddress.ip_address(host)

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1376,20 +1376,41 @@ def _is_loopback_ip(host: Optional[str]) -> bool:
     return ip.is_loopback or (mapped is not None and mapped.is_loopback)
 
 
+# A loopback peer carrying any of these is a proxy/tunnel relaying a remote
+# client, so the peer is the proxy, not the caller: cloudflared sets
+# cf-connecting-ip, reverse proxies set the rest (uvicorn only consumes
+# x-forwarded-for, so the others survive to here).
+_PROXIED_CLIENT_HEADERS = (
+    "cf-connecting-ip", "forwarded", "x-forwarded-for",
+    "x-forwarded-host", "x-real-ip",
+)
+
+
+def _host_header_is_loopback(host_header: Optional[str]) -> bool:
+    """Loopback/localhost check on the raw Host header.
+
+    Reads the header directly so a malformed or absent Host cannot fall back to
+    ``request.url.hostname``'s (loopback) ASGI server address.
+    """
+    if not host_header:
+        return False
+    host = host_header.strip()
+    if host.startswith("["):        # [IPv6](:port)
+        host = host[1:].split("]", 1)[0]
+    elif host.count(":") == 1:      # host:port
+        host = host.split(":", 1)[0]
+    host = host.lower().rstrip(".")
+    return host == "localhost" or _is_loopback_ip(host)
+
+
 def _is_local_bootstrap_request(request: Request) -> bool:
     """Allow bootstrap injection only through a direct loopback authority."""
     client = request.client
     if client is None or not _is_loopback_ip(client.host):
         return False
-    # cloudflared connects over loopback, but marks requests at the edge.
-    if request.headers.get("cf-connecting-ip") is not None:
+    if any(request.headers.get(h) is not None for h in _PROXIED_CLIENT_HEADERS):
         return False
-    try:
-        request_host = request.url.hostname
-    except ValueError:
-        return False
-    request_host = (request_host or "").lower().rstrip(".")
-    return request_host == "localhost" or _is_loopback_ip(request_host)
+    return _host_header_is_loopback(request.headers.get("host"))
 
 
 def _is_same_origin_request(request: Request) -> bool:
@@ -1427,6 +1448,17 @@ def _is_same_origin_request(request: Request) -> bool:
     return origin_canon == self_canon
 
 
+def _should_inject_bootstrap(request: Request) -> bool:
+    """Whether to embed the seeded bootstrap password in index.html."""
+    if not _is_same_origin_request(request):
+        return False
+    if _IS_COLAB:
+        # Single-user notebook proxy: allow autofill, but never a public
+        # shareable tunnel (a Colab Cloudflare link sets cf-connecting-ip).
+        return request.headers.get("cf-connecting-ip") is None
+    return _is_local_bootstrap_request(request)
+
+
 def setup_frontend(app: FastAPI, build_path: Path):
     """Mount frontend static files (optional)"""
     if not build_path.exists():
@@ -1439,10 +1471,10 @@ def setup_frontend(app: FastAPI, build_path: Path):
     def _build_index_response(request: Request) -> Response:
         content = (build_path / "index.html").read_bytes()
         content = _strip_crossorigin(content)
-        # Bootstrap pw is same-origin only, and (outside Colab's single-user
-        # sandbox) only to a client on this machine: a wildcard bind must not
-        # serve it in-page to a LAN peer. Vary: Origin keeps caches honest.
-        if _is_same_origin_request(request) and (_IS_COLAB or _is_local_bootstrap_request(request)):
+        # Bootstrap pw goes only to a same-origin, direct-loopback client (or
+        # Colab's single-user notebook proxy): a wildcard bind must not serve it
+        # in-page to a LAN or proxied peer. Vary: Origin keeps caches honest.
+        if _should_inject_bootstrap(request):
             content, nonce = _inject_bootstrap(content, app)
         else:
             nonce = None

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1400,7 +1400,7 @@ def _host_header_is_loopback(host_header: Optional[str]) -> bool:
     host = host_header.strip()
     if host.startswith("["):  # [IPv6] or [IPv6]:port
         end = host.find("]")
-        if end == -1 or (host[end + 1:] and not host[end + 1:].startswith(":")):
+        if end == -1 or (host[end + 1 :] and not host[end + 1 :].startswith(":")):
             return False  # unclosed bracket or junk after ] (e.g. [::1]evil)
         host = host[1:end]
     elif host.count(":") == 1:  # host:port

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1364,23 +1364,32 @@ def _canonical_origin(scheme: str, netloc: str) -> Optional[tuple[str, str, int]
     return (scheme, host, port)
 
 
-def _is_loopback_client(request: Request) -> bool:
-    """Return whether the client connects directly from a loopback address.
-
-    Cloudflare tunnel requests also have a loopback socket peer, but carry
-    ``CF-Connecting-IP``. Missing or invalid peers and all tunnel requests fail
-    closed.
-    """
-    client = request.client
-    if client is None:
+def _is_loopback_ip(host: Optional[str]) -> bool:
+    """Return whether ``host`` is a loopback IP, including IPv4-mapped IPv6."""
+    if not host:
         return False
     try:
-        ip = ipaddress.ip_address(client.host)
-    except ValueError:
+        ip = ipaddress.ip_address(host)
+    except (TypeError, ValueError):
         return False
     mapped = getattr(ip, "ipv4_mapped", None)
-    is_loopback = ip.is_loopback or (mapped is not None and mapped.is_loopback)
-    return is_loopback and request.headers.get("cf-connecting-ip") is None
+    return ip.is_loopback or (mapped is not None and mapped.is_loopback)
+
+
+def _is_local_bootstrap_request(request: Request) -> bool:
+    """Allow bootstrap injection only through a direct loopback authority."""
+    client = request.client
+    if client is None or not _is_loopback_ip(client.host):
+        return False
+    # cloudflared connects over loopback, but marks requests at the edge.
+    if request.headers.get("cf-connecting-ip") is not None:
+        return False
+    try:
+        request_host = request.url.hostname
+    except ValueError:
+        return False
+    request_host = (request_host or "").lower().rstrip(".")
+    return request_host == "localhost" or _is_loopback_ip(request_host)
 
 
 def _is_same_origin_request(request: Request) -> bool:
@@ -1433,7 +1442,7 @@ def setup_frontend(app: FastAPI, build_path: Path):
         # Bootstrap pw is same-origin only, and (outside Colab's single-user
         # sandbox) only to a client on this machine: a wildcard bind must not
         # serve it in-page to a LAN peer. Vary: Origin keeps caches honest.
-        if _is_same_origin_request(request) and (_IS_COLAB or _is_loopback_client(request)):
+        if _is_same_origin_request(request) and (_IS_COLAB or _is_local_bootstrap_request(request)):
             content, nonce = _inject_bootstrap(content, app)
         else:
             nonce = None

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -234,6 +234,7 @@ if _STUDIO_ROOT_RESOLVED != _LEGACY_STUDIO_ROOT:
 os.environ.setdefault("UNSLOTH_IS_PRESENT", "1")
 
 import hashlib
+import ipaddress
 import mimetypes
 import re as _re
 import shutil
@@ -1363,6 +1364,28 @@ def _canonical_origin(scheme: str, netloc: str) -> Optional[tuple[str, str, int]
     return (scheme, host, port)
 
 
+def _is_loopback_client(request: Request) -> bool:
+    """True only when the HTTP client is on this machine (a loopback peer).
+
+    Gates the bootstrap-credential auto-fill so a wildcard bind (``-H 0.0.0.0``)
+    never serves the seeded admin password in-page to a LAN peer; a remote peer
+    must read it from the terminal instead. Fails safe: an absent, unparseable,
+    or non-loopback peer is treated as remote. Reads the real socket peer, which
+    is trustworthy in the default deployment: uvicorn only trusts forwarded
+    headers under Colab, and the caller exempts Colab. A user-run reverse proxy
+    that rewrites the peer to loopback is out of scope.
+    """
+    client = request.client
+    if client is None:
+        return False
+    try:
+        ip = ipaddress.ip_address(client.host)
+    except ValueError:
+        return False
+    mapped = getattr(ip, "ipv4_mapped", None)
+    return ip.is_loopback or (mapped is not None and mapped.is_loopback)
+
+
 def _is_same_origin_request(request: Request) -> bool:
     """True when Origin is missing or matches request's scheme://host:port.
 
@@ -1410,8 +1433,10 @@ def setup_frontend(app: FastAPI, build_path: Path):
     def _build_index_response(request: Request) -> Response:
         content = (build_path / "index.html").read_bytes()
         content = _strip_crossorigin(content)
-        # Bootstrap pw is same-origin only; Vary: Origin keeps caches honest.
-        if _is_same_origin_request(request):
+        # Bootstrap pw is same-origin only, and (outside Colab's single-user
+        # sandbox) only to a client on this machine: a wildcard bind must not
+        # serve it in-page to a LAN peer. Vary: Origin keeps caches honest.
+        if _is_same_origin_request(request) and (_IS_COLAB or _is_loopback_client(request)):
             content, nonce = _inject_bootstrap(content, app)
         else:
             nonce = None

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1365,15 +1365,11 @@ def _canonical_origin(scheme: str, netloc: str) -> Optional[tuple[str, str, int]
 
 
 def _is_loopback_client(request: Request) -> bool:
-    """True only when the HTTP client is on this machine (a loopback peer).
+    """Return whether the client connects directly from a loopback address.
 
-    Gates the bootstrap-credential auto-fill so a wildcard bind (``-H 0.0.0.0``)
-    never serves the seeded admin password in-page to a LAN peer; a remote peer
-    must read it from the terminal instead. Fails safe: an absent, unparseable,
-    or non-loopback peer is treated as remote. Reads the real socket peer, which
-    is trustworthy in the default deployment: uvicorn only trusts forwarded
-    headers under Colab, and the caller exempts Colab. A user-run reverse proxy
-    that rewrites the peer to loopback is out of scope.
+    Cloudflare tunnel requests also have a loopback socket peer, but carry
+    ``CF-Connecting-IP``. Missing or invalid peers and all tunnel requests fail
+    closed.
     """
     client = request.client
     if client is None:
@@ -1383,7 +1379,8 @@ def _is_loopback_client(request: Request) -> bool:
     except ValueError:
         return False
     mapped = getattr(ip, "ipv4_mapped", None)
-    return ip.is_loopback or (mapped is not None and mapped.is_loopback)
+    is_loopback = ip.is_loopback or (mapped is not None and mapped.is_loopback)
+    return is_loopback and request.headers.get("cf-connecting-ip") is None
 
 
 def _is_same_origin_request(request: Request) -> bool:

--- a/studio/backend/tests/test_index_bootstrap_loopback.py
+++ b/studio/backend/tests/test_index_bootstrap_loopback.py
@@ -90,6 +90,7 @@ def test_malformed_or_absent_host_is_remote():
 def test_colab_allows_notebook_proxy_but_not_shareable_tunnel(monkeypatch):
     """Colab autofills its single-user proxy, but not a public Cloudflare link."""
     import main
+
     monkeypatch.setattr(main, "_IS_COLAB", True)
     # In-notebook proxy: same-origin, no tunnel header, injects off-loopback too.
     assert main._should_inject_bootstrap(_request("10.0.0.2", "colab.proxy")) is True
@@ -101,6 +102,7 @@ def test_colab_allows_notebook_proxy_but_not_shareable_tunnel(monkeypatch):
 def test_non_colab_gate_requires_local_client(monkeypatch):
     """Outside Colab the gate injects only for a direct loopback client."""
     import main
+
     monkeypatch.setattr(main, "_IS_COLAB", False)
     assert main._should_inject_bootstrap(_request("127.0.0.1", "localhost")) is True
     assert main._should_inject_bootstrap(_request("192.168.1.10", "localhost")) is False

--- a/studio/backend/tests/test_index_bootstrap_loopback.py
+++ b/studio/backend/tests/test_index_bootstrap_loopback.py
@@ -11,10 +11,13 @@ def _request(
     request_host = "127.0.0.1",
     headers = None,
 ):
-    """Build a minimal request; ``None`` models an unresolved socket peer."""
+    """Build a minimal request; ``None`` models an unresolved peer / absent Host."""
     client = None if client_host is None else SimpleNamespace(host = client_host, port = 0)
-    url = SimpleNamespace(hostname = request_host)
-    return SimpleNamespace(client = client, headers = headers or {}, url = url)
+    hdrs = {}
+    if request_host is not None:
+        hdrs["host"] = request_host
+    hdrs.update(headers or {})
+    return SimpleNamespace(client = client, headers = hdrs, url = SimpleNamespace(hostname = request_host))
 
 
 def test_loopback_peers_are_local():
@@ -67,3 +70,37 @@ def test_unparseable_request_host_fails_safe():
         client = SimpleNamespace(host = "127.0.0.1", port = 0), headers = {}, url = _RaisingURL()
     )
     assert _is_local_bootstrap_request(request) is False
+
+
+def test_reverse_proxy_forwarded_headers_are_remote():
+    """A loopback proxy relaying a remote client (non-Cloudflare headers) is remote."""
+    from main import _is_local_bootstrap_request
+    for header in ("forwarded", "x-forwarded-for", "x-forwarded-host", "x-real-ip"):
+        request = _request("127.0.0.1", "localhost", headers = {header: "203.0.113.7"})
+        assert _is_local_bootstrap_request(request) is False, header
+
+
+def test_malformed_or_absent_host_is_remote():
+    """A malformed/absent Host must not fall back to the loopback server address."""
+    from main import _is_local_bootstrap_request
+    for host in ("e_vil", "[malformed", "", None):
+        assert _is_local_bootstrap_request(_request("127.0.0.1", host)) is False, host
+
+
+def test_colab_allows_notebook_proxy_but_not_shareable_tunnel(monkeypatch):
+    """Colab autofills its single-user proxy, but not a public Cloudflare link."""
+    import main
+    monkeypatch.setattr(main, "_IS_COLAB", True)
+    # In-notebook proxy: same-origin, no tunnel header, injects off-loopback too.
+    assert main._should_inject_bootstrap(_request("10.0.0.2", "colab.proxy")) is True
+    # Shareable Cloudflare link marks visitors with cf-connecting-ip; withhold.
+    tunnel = _request("127.0.0.1", "localhost", headers = {"cf-connecting-ip": "203.0.113.7"})
+    assert main._should_inject_bootstrap(tunnel) is False
+
+
+def test_non_colab_gate_requires_local_client(monkeypatch):
+    """Outside Colab the gate injects only for a direct loopback client."""
+    import main
+    monkeypatch.setattr(main, "_IS_COLAB", False)
+    assert main._should_inject_bootstrap(_request("127.0.0.1", "localhost")) is True
+    assert main._should_inject_bootstrap(_request("192.168.1.10", "localhost")) is False

--- a/studio/backend/tests/test_index_bootstrap_loopback.py
+++ b/studio/backend/tests/test_index_bootstrap_loopback.py
@@ -86,9 +86,19 @@ def test_reverse_proxy_forwarded_headers_are_remote():
 def test_malformed_or_absent_host_is_remote():
     """A malformed/absent/scope-id Host must not fall back to the loopback server address."""
     from main import _is_local_bootstrap_request
+
     # incl. bracket smuggling: [::1]evil / unclosed [::1 must not reduce to ::1
-    for host in ("e_vil", "[malformed", "", None, "[::1%25eth0]:8888",
-                 "[::1]attacker", "[::1]evil.com", "[::1", "[::1]x"):
+    for host in (
+        "e_vil",
+        "[malformed",
+        "",
+        None,
+        "[::1%25eth0]:8888",
+        "[::1]attacker",
+        "[::1]evil.com",
+        "[::1",
+        "[::1]x",
+    ):
         assert _is_local_bootstrap_request(_request("127.0.0.1", host)) is False, host
 
 

--- a/studio/backend/tests/test_index_bootstrap_loopback.py
+++ b/studio/backend/tests/test_index_bootstrap_loopback.py
@@ -1,42 +1,37 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Regression coverage for the bootstrap-pw LAN leak on a wildcard bind.
-
-``_is_loopback_client`` is the second half of the gate on ``_inject_bootstrap``
-(alongside ``_is_same_origin_request``): on ``-H 0.0.0.0`` the seeded admin
-password must not be auto-filled in-page for a non-loopback (LAN) peer.
-"""
+"""Regression coverage for bootstrap password exposure to remote clients."""
 
 from types import SimpleNamespace
 
 
-def _request(client_host):
-    """A minimal request whose ``.client`` mimics Starlette's (host, port) peer.
-
-    ``client_host is None`` models a peer uvicorn could not resolve (e.g. a
-    Unix-domain-socket bind), which must fail safe.
-    """
+def _request(client_host, headers = None):
+    """Build a minimal request; ``None`` models an unresolved socket peer."""
     client = None if client_host is None else SimpleNamespace(host = client_host, port = 0)
-    return SimpleNamespace(client = client)
+    return SimpleNamespace(client = client, headers = headers or {})
 
 
 def test_loopback_peers_are_local():
     from main import _is_loopback_client
-
-    # IPv4 loopback covers the whole 127.0.0.0/8 range, plus IPv6 ::1 and the
-    # IPv4-mapped-IPv6 form a dual-stack socket reports for an IPv4 connection.
-    for host in ("127.0.0.1", "127.0.0.5", "127.255.255.254", "::1", "::ffff:127.0.0.1"):
+    for host in ("127.0.0.1", "::1", "::ffff:127.0.0.1"):
         assert _is_loopback_client(_request(host)) is True, host
 
 
 def test_non_loopback_peers_are_remote():
     from main import _is_loopback_client
-    for host in ("192.168.1.10", "10.0.0.5", "169.254.1.1", "0.0.0.0", "::ffff:192.168.1.10"):
+    for host in ("192.168.1.10", "::ffff:192.168.1.10"):
         assert _is_loopback_client(_request(host)) is False, host
 
 
 def test_absent_or_unparseable_peer_fails_safe():
     from main import _is_loopback_client
-    for host in (None, "", "localhost", "not-an-ip", "fe80::1%eth0"):
+    for host in (None, "localhost"):
         assert _is_loopback_client(_request(host)) is False, host
+
+
+def test_cloudflare_tunnel_clients_are_remote_despite_loopback_peer():
+    from main import _is_loopback_client
+    for client_ip in ("203.0.113.7", ""):
+        request = _request("127.0.0.1", {"cf-connecting-ip": client_ip})
+        assert _is_loopback_client(request) is False, client_ip

--- a/studio/backend/tests/test_index_bootstrap_loopback.py
+++ b/studio/backend/tests/test_index_bootstrap_loopback.py
@@ -34,6 +34,7 @@ def test_loopback_peers_are_local():
 
 def test_non_loopback_peers_are_remote():
     from main import _is_local_bootstrap_request
+
     # ::1%eth0 is a scope-id'd address, which ipaddress treats as loopback on
     # 3.9+; it must not count as a direct local peer.
     for host in ("192.168.1.10", "::ffff:192.168.1.10", "::1%eth0"):

--- a/studio/backend/tests/test_index_bootstrap_loopback.py
+++ b/studio/backend/tests/test_index_bootstrap_loopback.py
@@ -6,32 +6,49 @@
 from types import SimpleNamespace
 
 
-def _request(client_host, headers = None):
+def _request(
+    client_host,
+    request_host = "127.0.0.1",
+    headers = None,
+):
     """Build a minimal request; ``None`` models an unresolved socket peer."""
     client = None if client_host is None else SimpleNamespace(host = client_host, port = 0)
-    return SimpleNamespace(client = client, headers = headers or {})
+    url = SimpleNamespace(hostname = request_host)
+    return SimpleNamespace(client = client, headers = headers or {}, url = url)
 
 
 def test_loopback_peers_are_local():
-    from main import _is_loopback_client
-    for host in ("127.0.0.1", "::1", "::ffff:127.0.0.1"):
-        assert _is_loopback_client(_request(host)) is True, host
+    from main import _is_local_bootstrap_request
+    cases = (
+        ("127.0.0.1", "127.0.0.1"),
+        ("::1", "::1"),
+        ("::ffff:127.0.0.1", "::ffff:127.0.0.1"),
+        ("127.0.0.1", "localhost"),
+    )
+    for peer, host in cases:
+        assert _is_local_bootstrap_request(_request(peer, host)) is True, (peer, host)
 
 
 def test_non_loopback_peers_are_remote():
-    from main import _is_loopback_client
+    from main import _is_local_bootstrap_request
     for host in ("192.168.1.10", "::ffff:192.168.1.10"):
-        assert _is_loopback_client(_request(host)) is False, host
+        assert _is_local_bootstrap_request(_request(host)) is False, host
 
 
 def test_absent_or_unparseable_peer_fails_safe():
-    from main import _is_loopback_client
+    from main import _is_local_bootstrap_request
     for host in (None, "localhost"):
-        assert _is_loopback_client(_request(host)) is False, host
+        assert _is_local_bootstrap_request(_request(host)) is False, host
 
 
 def test_cloudflare_tunnel_clients_are_remote_despite_loopback_peer():
-    from main import _is_loopback_client
+    from main import _is_local_bootstrap_request
     for client_ip in ("203.0.113.7", ""):
-        request = _request("127.0.0.1", {"cf-connecting-ip": client_ip})
-        assert _is_loopback_client(request) is False, client_ip
+        request = _request("127.0.0.1", headers = {"cf-connecting-ip": client_ip})
+        assert _is_local_bootstrap_request(request) is False, client_ip
+
+
+def test_dns_rebinding_host_is_remote_despite_loopback_peer():
+    from main import _is_local_bootstrap_request
+    for host in ("attacker.example", "192.168.1.10", None):
+        assert _is_local_bootstrap_request(_request("127.0.0.1", host)) is False, host

--- a/studio/backend/tests/test_index_bootstrap_loopback.py
+++ b/studio/backend/tests/test_index_bootstrap_loopback.py
@@ -34,7 +34,9 @@ def test_loopback_peers_are_local():
 
 def test_non_loopback_peers_are_remote():
     from main import _is_local_bootstrap_request
-    for host in ("192.168.1.10", "::ffff:192.168.1.10"):
+    # ::1%eth0 is a scope-id'd address, which ipaddress treats as loopback on
+    # 3.9+; it must not count as a direct local peer.
+    for host in ("192.168.1.10", "::ffff:192.168.1.10", "::1%eth0"):
         assert _is_local_bootstrap_request(_request(host)) is False, host
 
 
@@ -81,9 +83,9 @@ def test_reverse_proxy_forwarded_headers_are_remote():
 
 
 def test_malformed_or_absent_host_is_remote():
-    """A malformed/absent Host must not fall back to the loopback server address."""
+    """A malformed/absent/scope-id Host must not fall back to the loopback server address."""
     from main import _is_local_bootstrap_request
-    for host in ("e_vil", "[malformed", "", None):
+    for host in ("e_vil", "[malformed", "", None, "[::1%25eth0]:8888"):
         assert _is_local_bootstrap_request(_request("127.0.0.1", host)) is False, host
 
 

--- a/studio/backend/tests/test_index_bootstrap_loopback.py
+++ b/studio/backend/tests/test_index_bootstrap_loopback.py
@@ -52,3 +52,16 @@ def test_dns_rebinding_host_is_remote_despite_loopback_peer():
     from main import _is_local_bootstrap_request
     for host in ("attacker.example", "192.168.1.10", None):
         assert _is_local_bootstrap_request(_request("127.0.0.1", host)) is False, host
+
+
+def test_unparseable_request_host_fails_safe():
+    """A Host that makes ``request.url.hostname`` raise must fall to remote."""
+    from main import _is_local_bootstrap_request
+
+    class _RaisingURL:
+        @property
+        def hostname(self):
+            raise ValueError("malformed host")
+
+    request = SimpleNamespace(client = SimpleNamespace(host = "127.0.0.1", port = 0), headers = {}, url = _RaisingURL())
+    assert _is_local_bootstrap_request(request) is False

--- a/studio/backend/tests/test_index_bootstrap_loopback.py
+++ b/studio/backend/tests/test_index_bootstrap_loopback.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Regression coverage for the bootstrap-pw LAN leak on a wildcard bind.
+
+``_is_loopback_client`` is the second half of the gate on ``_inject_bootstrap``
+(alongside ``_is_same_origin_request``): on ``-H 0.0.0.0`` the seeded admin
+password must not be auto-filled in-page for a non-loopback (LAN) peer.
+"""
+
+from types import SimpleNamespace
+
+
+def _request(client_host):
+    """A minimal request whose ``.client`` mimics Starlette's (host, port) peer.
+
+    ``client_host is None`` models a peer uvicorn could not resolve (e.g. a
+    Unix-domain-socket bind), which must fail safe.
+    """
+    client = None if client_host is None else SimpleNamespace(host = client_host, port = 0)
+    return SimpleNamespace(client = client)
+
+
+def test_loopback_peers_are_local():
+    from main import _is_loopback_client
+    # IPv4 loopback covers the whole 127.0.0.0/8 range, plus IPv6 ::1 and the
+    # IPv4-mapped-IPv6 form a dual-stack socket reports for an IPv4 connection.
+    for host in ("127.0.0.1", "127.0.0.5", "127.255.255.254", "::1", "::ffff:127.0.0.1"):
+        assert _is_loopback_client(_request(host)) is True, host
+
+
+def test_non_loopback_peers_are_remote():
+    from main import _is_loopback_client
+    for host in ("192.168.1.10", "10.0.0.5", "169.254.1.1", "0.0.0.0", "::ffff:192.168.1.10"):
+        assert _is_loopback_client(_request(host)) is False, host
+
+
+def test_absent_or_unparseable_peer_fails_safe():
+    from main import _is_loopback_client
+    for host in (None, "", "localhost", "not-an-ip", "fe80::1%eth0"):
+        assert _is_loopback_client(_request(host)) is False, host

--- a/studio/backend/tests/test_index_bootstrap_loopback.py
+++ b/studio/backend/tests/test_index_bootstrap_loopback.py
@@ -23,6 +23,7 @@ def _request(client_host):
 
 def test_loopback_peers_are_local():
     from main import _is_loopback_client
+
     # IPv4 loopback covers the whole 127.0.0.0/8 range, plus IPv6 ::1 and the
     # IPv4-mapped-IPv6 form a dual-stack socket reports for an IPv4 connection.
     for host in ("127.0.0.1", "127.0.0.5", "127.255.255.254", "::1", "::ffff:127.0.0.1"):

--- a/studio/backend/tests/test_index_bootstrap_loopback.py
+++ b/studio/backend/tests/test_index_bootstrap_loopback.py
@@ -63,5 +63,7 @@ def test_unparseable_request_host_fails_safe():
         def hostname(self):
             raise ValueError("malformed host")
 
-    request = SimpleNamespace(client = SimpleNamespace(host = "127.0.0.1", port = 0), headers = {}, url = _RaisingURL())
+    request = SimpleNamespace(
+        client = SimpleNamespace(host = "127.0.0.1", port = 0), headers = {}, url = _RaisingURL()
+    )
     assert _is_local_bootstrap_request(request) is False

--- a/studio/backend/tests/test_index_bootstrap_loopback.py
+++ b/studio/backend/tests/test_index_bootstrap_loopback.py
@@ -86,7 +86,9 @@ def test_reverse_proxy_forwarded_headers_are_remote():
 def test_malformed_or_absent_host_is_remote():
     """A malformed/absent/scope-id Host must not fall back to the loopback server address."""
     from main import _is_local_bootstrap_request
-    for host in ("e_vil", "[malformed", "", None, "[::1%25eth0]:8888"):
+    # incl. bracket smuggling: [::1]evil / unclosed [::1 must not reduce to ::1
+    for host in ("e_vil", "[malformed", "", None, "[::1%25eth0]:8888",
+                 "[::1]attacker", "[::1]evil.com", "[::1", "[::1]x"):
         assert _is_local_bootstrap_request(_request("127.0.0.1", host)) is False, host
 
 


### PR DESCRIPTION
On a wildcard bind (`unsloth studio -H 0.0.0.0`), the served `index.html` auto-injects the seeded admin bootstrap password so the first-login form can pre-fill. The gate for that (PR #5739) only checks same-origin, not who is connecting, so a LAN peer that opens the host gets the default admin credential in-page. Studio's server-side Python and terminal tools are on by default, so that credential is a remote code-execution surface.

## Fix

Also require the client to be on this machine. The gate is now same-origin AND (Colab OR loopback client). A remote peer reads the password from the terminal instead (still printed at startup and saved to `.bootstrap_password`); login is unchanged. Colab is exempted because its trusted forwarded headers make every peer look remote and a notebook is a single-user sandbox.

## Verification

Ran a real `-H 0.0.0.0` server: a loopback request still auto-fills, a request from the machine's LAN IP does not. Added regression tests for the loopback classifier; the bootstrap-origin suite stays green (34 passed).
