### PR TITLE
Studio CI: make tool-calling SSE probes resilient to transport stalls

### DIFF
--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -505,11 +505,12 @@ jobs:
               A shared CI runner can stall the stream transport (the
               connection opening, or a mid-stream read) even when Studio
               is healthy, so retry a stall once with a fresh request
-              capped at 300s, and return whatever events already streamed
-              before a stall rather than discarding them. HTTP status
-              errors surface immediately; a stall that yields nothing
-              across all attempts re-raises so the caller can rotate to
-              the next seed.
+              capped at 300s. A stall means the stream did NOT complete,
+              so partial events are never returned as a result (an early
+              tool_start with no tool_end is not proof the tool loop
+              finished). HTTP status errors surface immediately; a stall
+              that yields nothing across all attempts re-raises so the
+              caller can rotate to the next seed.
               """
               body = {**body, "stream": True}
               data = json.dumps(body).encode()
@@ -548,11 +549,11 @@ jobs:
                   except urllib.error.HTTPError:
                       raise
                   except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
-                      # Events already streamed are valid signal -- keep
-                      # them rather than re-running a heavy generation.
-                      if events:
-                          print(f"[retry-sse] {path}: {exc!r}; keeping {len(events)} partial events", flush = True)
-                          return "".join(parts), events
+                      # A stalled stream is incomplete: returning its partial
+                      # events would let a hung tool loop (an early tool_start
+                      # with no tool_end) pass _tool_invoked and WARN-pass the
+                      # job. Retry once, then raise so _run_tool_probe rotates
+                      # to the next seed instead of accepting a broken stream.
                       if attempt == retries:
                           raise
                       print(f"[retry-sse] {path}: {exc!r}", flush = True)
@@ -693,9 +694,21 @@ jobs:
               """
               attempts_log = []
               best = None
+              # Cap the wall-clock spent rotating through stalled seeds so a
+              # persistent no-data wedge fails fast (clean assertion) instead
+              # of being killed by the job's timeout-minutes. A healthy or
+              # merely degenerate round answers in seconds, so all seeds still
+              # run in the normal case; only stalls consume the budget.
+              probe_deadline = time.monotonic() + 300
               for attempt_i in range(max_attempts):
+                  if attempt_i and time.monotonic() > probe_deadline:
+                      print(f"[tools] {label}: seed-rotation budget spent after {attempt_i} attempts", flush = True)
+                      break
                   attempt_seed = SEED + attempt_i
                   try:
+                      # Bounded per-attempt timeout, no inner retry -- the seed
+                      # loop IS the retry, so a stall raises at 180s and rotates
+                      # rather than spending post_sse's full 600+300s.
                       content, events = post_sse("/v1/chat/completions", {
                           "messages":      [{"role": "user", "content": prompt}],
                           "enable_tools":  True,
@@ -704,7 +717,7 @@ jobs:
                           "temperature":   TOOL_PROBE_TEMP,
                           "seed":          attempt_seed,
                           "max_tokens":    600,
-                      })
+                      }, timeout = 180, retries = 0)
                   except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
                       # A transport stall that outlived post_sse's own retry:
                       # log it as a failed attempt and rotate to the next seed
@@ -775,6 +788,9 @@ jobs:
           # enough that requiring a tool_call marker would create
           # red-herring failures from infra rather than from Studio.
           try:
+              # Best-effort and bounded: a single 180s attempt keeps a stall
+              # from eating the job's timeout-minutes (it already WARNs, so a
+              # retry buys nothing).
               content, events = post_sse("/v1/chat/completions", {
                   "messages":      [{"role": "user", "content": "Search the web for 'unsloth ai github' and summarise."}],
                   "enable_tools":  True,
@@ -783,7 +799,7 @@ jobs:
                   "temperature":   0.0,
                   "seed":          SEED,
                   "max_tokens":    400,
-              })
+              }, timeout = 180, retries = 0)
               print(
                   f"[tools] PASS web_search stream ({len(content)} chars in content, "
                   f"{len(events)} raw events)"

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -718,6 +718,12 @@ jobs:
                           "seed":          attempt_seed,
                           "max_tokens":    600,
                       }, timeout = 180, retries = 0)
+                  except urllib.error.HTTPError:
+                      # HTTPError subclasses URLError, so re-raise a real 4xx/5xx
+                      # here instead of letting the transport-stall handler below
+                      # swallow it and rotate seeds -- an endpoint status failure
+                      # must surface, not be masked as missing tool evidence.
+                      raise
                   except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
                       # A transport stall that outlived post_sse's own retry:
                       # log it as a failed attempt and rotate to the next seed

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -485,7 +485,7 @@ jobs:
                       print(f"[retry] {path}: {exc!r}", flush = True)
                       time.sleep(15)
 
-          def post_sse(path, body, *, timeout = 600):
+          def post_sse(path, body, *, timeout = 600, retries = 1):
               """POST a streaming request and accumulate the assistant
               text deltas. The server-side agentic loop ALWAYS returns
               SSE regardless of the request's `stream` field, so any
@@ -501,6 +501,15 @@ jobs:
                                  invocation markers / tool output, since
                                  `delta.content` alone is not evidence
                                  that the tool path executed.
+
+              A shared CI runner can stall the stream transport (the
+              connection opening, or a mid-stream read) even when Studio
+              is healthy, so retry a stall once with a fresh request
+              capped at 300s, and return whatever events already streamed
+              before a stall rather than discarding them. HTTP status
+              errors surface immediately; a stall that yields nothing
+              across all attempts re-raises so the caller can rotate to
+              the next seed.
               """
               body = {**body, "stream": True}
               data = json.dumps(body).encode()
@@ -513,26 +522,41 @@ jobs:
                       "Content-Type": "application/json",
                   },
               )
-              parts = []
-              events = []
-              with urllib.request.urlopen(req, timeout = timeout) as resp:
-                  for raw in resp:
-                      line = raw.decode().strip()
-                      if not line.startswith("data: "):
-                          continue
-                      payload = line[6:]
-                      if payload == "[DONE]":
-                          break
-                      events.append(payload)
-                      try:
-                          chunk = json.loads(payload)
-                      except json.JSONDecodeError:
-                          continue
-                      for choice in chunk.get("choices", []):
-                          delta = choice.get("delta", {}) or {}
-                          if delta.get("content"):
-                              parts.append(delta["content"])
-              return "".join(parts), events
+              for attempt in range(retries + 1):
+                  parts = []
+                  events = []
+                  t = timeout if attempt == 0 else min(timeout, 300)
+                  try:
+                      with urllib.request.urlopen(req, timeout = t) as resp:
+                          for raw in resp:
+                              line = raw.decode().strip()
+                              if not line.startswith("data: "):
+                                  continue
+                              payload = line[6:]
+                              if payload == "[DONE]":
+                                  break
+                              events.append(payload)
+                              try:
+                                  chunk = json.loads(payload)
+                              except json.JSONDecodeError:
+                                  continue
+                              for choice in chunk.get("choices", []):
+                                  delta = choice.get("delta", {}) or {}
+                                  if delta.get("content"):
+                                      parts.append(delta["content"])
+                      return "".join(parts), events
+                  except urllib.error.HTTPError:
+                      raise
+                  except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
+                      # Events already streamed are valid signal -- keep
+                      # them rather than re-running a heavy generation.
+                      if events:
+                          print(f"[retry-sse] {path}: {exc!r}; keeping {len(events)} partial events", flush = True)
+                          return "".join(parts), events
+                      if attempt == retries:
+                          raise
+                      print(f"[retry-sse] {path}: {exc!r}", flush = True)
+                      time.sleep(15)
 
           _STUDIO_TOOL_TYPES = {
               "tool_start", "tool_end", "tool_use", "tool_result",
@@ -671,15 +695,26 @@ jobs:
               best = None
               for attempt_i in range(max_attempts):
                   attempt_seed = SEED + attempt_i
-                  content, events = post_sse("/v1/chat/completions", {
-                      "messages":      [{"role": "user", "content": prompt}],
-                      "enable_tools":  True,
-                      "enabled_tools": enabled,
-                      "session_id":    f"{session}-att{attempt_i}",
-                      "temperature":   TOOL_PROBE_TEMP,
-                      "seed":          attempt_seed,
-                      "max_tokens":    600,
-                  })
+                  try:
+                      content, events = post_sse("/v1/chat/completions", {
+                          "messages":      [{"role": "user", "content": prompt}],
+                          "enable_tools":  True,
+                          "enabled_tools": enabled,
+                          "session_id":    f"{session}-att{attempt_i}",
+                          "temperature":   TOOL_PROBE_TEMP,
+                          "seed":          attempt_seed,
+                          "max_tokens":    600,
+                      })
+                  except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
+                      # A transport stall that outlived post_sse's own retry:
+                      # log it as a failed attempt and rotate to the next seed
+                      # rather than sinking the whole probe on one bad stream.
+                      attempts_log.append({
+                          "attempt": attempt_i, "seed": attempt_seed,
+                          "transport_error": repr(exc),
+                      })
+                      print(f"[tools] retry {label} attempt {attempt_i}: transport {exc!r}", flush = True)
+                      continue
                   invoked  = _tool_invoked(events)
                   produced = _tool_output_contains(events, *needles)
                   attempts_log.append({

--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -485,7 +485,7 @@ jobs:
                       print(f"[retry] {path}: {exc!r}", flush = True)
                       time.sleep(15)
 
-          def post_sse(path, body, *, timeout = 600, retries = 1):
+          def post_sse(path, body, *, timeout = 600, retries = 1, complete_on = None):
               """POST a streaming request and accumulate the assistant
               text deltas. The server-side agentic loop ALWAYS returns
               SSE regardless of the request's `stream` field, so any
@@ -506,11 +506,17 @@ jobs:
               connection opening, or a mid-stream read) even when Studio
               is healthy, so retry a stall once with a fresh request
               capped at 300s. A stall means the stream did NOT complete,
-              so partial events are never returned as a result (an early
+              so partial events are normally NOT returned (an early
               tool_start with no tool_end is not proof the tool loop
-              finished). HTTP status errors surface immediately; a stall
-              that yields nothing across all attempts re-raises so the
-              caller can rotate to the next seed.
+              finished). The one exception is `complete_on`: an optional
+              predicate over the events collected so far -- when a stall
+              happens after it is already satisfied (the tool ran and
+              produced its result before the trailing read timed out),
+              those events are returned rather than discarded, so the
+              stall-after-answer case still counts. HTTP status errors
+              surface immediately; a stall that yields no completed result
+              across all attempts re-raises so the caller can rotate to
+              the next seed.
               """
               body = {**body, "stream": True}
               data = json.dumps(body).encode()
@@ -549,11 +555,15 @@ jobs:
                   except urllib.error.HTTPError:
                       raise
                   except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
-                      # A stalled stream is incomplete: returning its partial
-                      # events would let a hung tool loop (an early tool_start
-                      # with no tool_end) pass _tool_invoked and WARN-pass the
-                      # job. Retry once, then raise so _run_tool_probe rotates
-                      # to the next seed instead of accepting a broken stream.
+                      # A stall after the tool already produced its result is
+                      # the case this probe exists to tolerate: keep those
+                      # events. But a stall with only an early tool_start (no
+                      # completed output) is not proof the tool loop finished,
+                      # so it must not pass -- retry once, then raise so
+                      # _run_tool_probe rotates to the next seed.
+                      if complete_on is not None and complete_on(events):
+                          print(f"[retry-sse] {path}: {exc!r}; keeping {len(events)} completed events", flush = True)
+                          return "".join(parts), events
                       if attempt == retries:
                           raise
                       print(f"[retry-sse] {path}: {exc!r}", flush = True)
@@ -701,14 +711,21 @@ jobs:
               # run in the normal case; only stalls consume the budget.
               probe_deadline = time.monotonic() + 300
               for attempt_i in range(max_attempts):
-                  if attempt_i and time.monotonic() > probe_deadline:
+                  # Cap each read by the budget still remaining (not just a flat
+                  # 180s) and skip an attempt too small to finish, so the whole
+                  # rotation stays within ~300s -- two probes then fit the job's
+                  # timeout-minutes even if every seed stalls.
+                  remaining = int(probe_deadline - time.monotonic())
+                  if attempt_i and remaining < 30:
                       print(f"[tools] {label}: seed-rotation budget spent after {attempt_i} attempts", flush = True)
                       break
                   attempt_seed = SEED + attempt_i
                   try:
                       # Bounded per-attempt timeout, no inner retry -- the seed
-                      # loop IS the retry, so a stall raises at 180s and rotates
-                      # rather than spending post_sse's full 600+300s.
+                      # loop IS the retry, so a stall raises quickly and rotates
+                      # rather than spending post_sse's full 600+300s. complete_on
+                      # keeps a stall that already produced the tool result (only
+                      # the trailing read timed out) instead of discarding it.
                       content, events = post_sse("/v1/chat/completions", {
                           "messages":      [{"role": "user", "content": prompt}],
                           "enable_tools":  True,
@@ -717,7 +734,8 @@ jobs:
                           "temperature":   TOOL_PROBE_TEMP,
                           "seed":          attempt_seed,
                           "max_tokens":    600,
-                      }, timeout = 180, retries = 0)
+                      }, timeout = min(180, remaining), retries = 0,
+                         complete_on = lambda ev: _tool_invoked(ev) and _tool_output_contains(ev, *needles))
                   except urllib.error.HTTPError:
                       # HTTPError subclasses URLError, so re-raise a real 4xx/5xx
                       # here instead of letting the transport-stall handler below

--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -471,11 +471,22 @@ jobs:
                       print(f"[retry] {path}: {exc!r}", flush = True)
                       time.sleep(15)
 
-          def post_sse(path, body, *, timeout = 600):
+          def post_sse(path, body, *, timeout = 600, retries = 1, soft = False):
               """POST a streaming request and accumulate the assistant
               text deltas. The server-side agentic loop ALWAYS returns
               SSE regardless of the request's `stream` field, so any
-              call with enable_tools=true must use this helper."""
+              call with enable_tools=true must use this helper.
+
+              A shared CI runner can stall the stream transport (the
+              connection opening, or a mid-stream read) even when Studio
+              is healthy, so harden the read three ways: retry a stall
+              once with a fresh request capped at 300s; return any text
+              already streamed before a stall (a stall on the trailing
+              tokens, after the answer arrived, still counts); and when
+              every attempt yields nothing, a hard call re-raises while a
+              soft call (the best-effort server-side tool probes) returns
+              None so the caller can WARN instead of sinking the whole
+              job. HTTP status errors always surface immediately."""
               body = {**body, "stream": True}
               data = json.dumps(body).encode()
               req = urllib.request.Request(
@@ -487,24 +498,43 @@ jobs:
                       "Content-Type": "application/json",
                   },
               )
-              parts = []
-              with urllib.request.urlopen(req, timeout = timeout) as resp:
-                  for raw in resp:
-                      line = raw.decode().strip()
-                      if not line.startswith("data: "):
-                          continue
-                      payload = line[6:]
-                      if payload == "[DONE]":
-                          break
-                      try:
-                          chunk = json.loads(payload)
-                      except json.JSONDecodeError:
-                          continue
-                      for choice in chunk.get("choices", []):
-                          delta = choice.get("delta", {}) or {}
-                          if delta.get("content"):
-                              parts.append(delta["content"])
-              return "".join(parts)
+              for attempt in range(retries + 1):
+                  parts = []
+                  t = timeout if attempt == 0 else min(timeout, 300)
+                  try:
+                      with urllib.request.urlopen(req, timeout = t) as resp:
+                          for raw in resp:
+                              line = raw.decode().strip()
+                              if not line.startswith("data: "):
+                                  continue
+                              payload = line[6:]
+                              if payload == "[DONE]":
+                                  break
+                              try:
+                                  chunk = json.loads(payload)
+                              except json.JSONDecodeError:
+                                  continue
+                              for choice in chunk.get("choices", []):
+                                  delta = choice.get("delta", {}) or {}
+                                  if delta.get("content"):
+                                      parts.append(delta["content"])
+                      return "".join(parts)
+                  except urllib.error.HTTPError:
+                      raise
+                  except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
+                      # Text already streamed is a valid signal -- keep it
+                      # rather than re-running a heavy generation.
+                      if parts:
+                          joined = "".join(parts)
+                          print(f"[retry-sse] {path}: {exc!r}; keeping {len(joined)} partial chars", flush = True)
+                          return joined
+                      if attempt == retries:
+                          if soft:
+                              print(f"[tools] WARN {path}: SSE transport stalled with no data ({exc!r}) -- non-blocking", flush = True)
+                              return None
+                          raise
+                      print(f"[retry-sse] {path}: {exc!r}", flush = True)
+                      time.sleep(15)
 
           # ── 1. Standard OpenAI function calling ──────────────────────
           weather_tool = {
@@ -583,8 +613,10 @@ jobs:
               "temperature":   TEMP,
               "seed":          SEED,
               "max_tokens":    128,
-          }, timeout = 180)
-          if "56088" in content or "56,088" in content:
+          }, timeout = 180, soft = True)
+          if content is None:
+              print("[tools] WARN python tool: SSE transport stalled after retries -- non-blocking")
+          elif "56088" in content or "56,088" in content:
               print(f"[tools] PASS python tool ({len(content)} chars, found 56088)")
           else:
               # Empty stream is a known Mac-quant degeneracy too; log

--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -605,6 +605,10 @@ jobs:
           # macos-14 free runner is ~10 tok/s on Qwen3.5-2B Q4_K_XL;
           # cap max_tokens tightly so each SSE round stays under ~30s
           # even when the model stalls in a degenerate output state.
+          # retries=0 on the best-effort probes: this job's 25-minute cap
+          # allows a 10-minute model load, so a no-data stall must be a
+          # single 180s attempt (not 180+15+180s) to leave room for the
+          # thinking checks. A soft/best-effort probe only WARNs anyway.
           content = post_sse("/v1/chat/completions", {
               "messages":      [{"role": "user", "content": "What is 123 * 456? Use the python tool to compute it and tell me the number."}],
               "enable_tools":  True,
@@ -613,7 +617,7 @@ jobs:
               "temperature":   TEMP,
               "seed":          SEED,
               "max_tokens":    128,
-          }, timeout = 180, soft = True)
+          }, timeout = 180, retries = 0, soft = True)
           if content is None:
               print("[tools] WARN python tool: SSE transport stalled after retries -- non-blocking")
           elif "56088" in content or "56,088" in content:
@@ -648,7 +652,7 @@ jobs:
                   "temperature":   TEMP,
                   "seed":          SEED,
                   "max_tokens":    96,
-              }, timeout = 180)
+              }, timeout = 180, retries = 0)
               print(f"[tools] PASS web_search stream ({len(content)} chars)")
           except Exception as exc:
               print(f"[tools] WARN web_search probe failed (non-blocking): {exc}")

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -783,6 +783,11 @@ jobs:
               )
 
           # ── 2. Server-side python tool ───────────────────────────────
+          # Bound each soft probe to a single 180s attempt (timeout=180,
+          # retries=0): this job runs two of them back-to-back under a
+          # 30-minute cap, so the default 600+15+300s per stall could hit
+          # the workflow timeout before the thinking checks run. A soft
+          # probe only WARNs anyway, so a retry buys nothing.
           content = post_sse("/v1/chat/completions", {
               "messages":      [{"role": "user", "content": "What is 123 * 456? Use the python tool to compute it and tell me the number."}],
               "enable_tools":  True,
@@ -791,7 +796,7 @@ jobs:
               "temperature":   TEMP,
               "seed":          SEED,
               "max_tokens":    600,
-          }, soft = True)
+          }, timeout = 180, retries = 0, soft = True)
           if content is None:
               print("[tools] WARN python tool: SSE transport stalled after retries -- non-blocking")
           elif "56088" in content or "56,088" in content:
@@ -816,7 +821,7 @@ jobs:
               "temperature":   TEMP,
               "seed":          SEED,
               "max_tokens":    600,
-          }, soft = True)
+          }, timeout = 180, retries = 0, soft = True)
           if content is None:
               print("[tools] WARN terminal tool: SSE transport stalled after retries -- non-blocking")
           elif "hello-bash-tool" in content:
@@ -840,7 +845,7 @@ jobs:
                   "temperature":   TEMP,
                   "seed":          SEED,
                   "max_tokens":    400,
-              })
+              }, timeout = 180, retries = 0)
               print(f"[tools] PASS web_search stream ({len(content)} chars)")
           except Exception as exc:
               print(f"[tools] WARN web_search probe failed (non-blocking): {exc}")

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -677,7 +677,22 @@ jobs:
                       print(f"[retry] {path}: {exc!r}", flush = True)
                       time.sleep(15)
 
-          def post_sse(path, body, *, timeout = 600):
+          def post_sse(path, body, *, timeout = 600, retries = 1, soft = False):
+              # The server-side agentic loop always answers over SSE. A
+              # shared CI runner can stall the stream transport (the
+              # connection opening, or a mid-stream read) even when Studio
+              # is healthy, so harden the read three ways:
+              #   * retry a transport stall once with a fresh request,
+              #     capped at 300s (a healthy server answers a retry
+              #     quickly, a wedged one never does);
+              #   * return any text already streamed before a stall, so a
+              #     stall on the trailing tokens -- after the answer
+              #     arrived -- still counts;
+              #   * when every attempt yields nothing, a hard call
+              #     re-raises while a soft call (the best-effort
+              #     server-side tool probes) returns None so the caller
+              #     can WARN instead of sinking the whole job.
+              # HTTP status errors always surface immediately.
               body = {**body, "stream": True}
               data = json.dumps(body).encode()
               req = urllib.request.Request(
@@ -689,24 +704,43 @@ jobs:
                       "Content-Type": "application/json",
                   },
               )
-              parts = []
-              with urllib.request.urlopen(req, timeout = timeout) as resp:
-                  for raw in resp:
-                      line = raw.decode().strip()
-                      if not line.startswith("data: "):
-                          continue
-                      payload = line[6:]
-                      if payload == "[DONE]":
-                          break
-                      try:
-                          chunk = json.loads(payload)
-                      except json.JSONDecodeError:
-                          continue
-                      for choice in chunk.get("choices", []):
-                          delta = choice.get("delta", {}) or {}
-                          if delta.get("content"):
-                              parts.append(delta["content"])
-              return "".join(parts)
+              for attempt in range(retries + 1):
+                  parts = []
+                  t = timeout if attempt == 0 else min(timeout, 300)
+                  try:
+                      with urllib.request.urlopen(req, timeout = t) as resp:
+                          for raw in resp:
+                              line = raw.decode().strip()
+                              if not line.startswith("data: "):
+                                  continue
+                              payload = line[6:]
+                              if payload == "[DONE]":
+                                  break
+                              try:
+                                  chunk = json.loads(payload)
+                              except json.JSONDecodeError:
+                                  continue
+                              for choice in chunk.get("choices", []):
+                                  delta = choice.get("delta", {}) or {}
+                                  if delta.get("content"):
+                                      parts.append(delta["content"])
+                      return "".join(parts)
+                  except urllib.error.HTTPError:
+                      raise
+                  except (TimeoutError, ConnectionError, urllib.error.URLError) as exc:
+                      # Text already streamed is a valid signal -- keep it
+                      # rather than re-running a heavy generation.
+                      if parts:
+                          joined = "".join(parts)
+                          print(f"[retry-sse] {path}: {exc!r}; keeping {len(joined)} partial chars", flush = True)
+                          return joined
+                      if attempt == retries:
+                          if soft:
+                              print(f"[tools] WARN {path}: SSE transport stalled with no data ({exc!r}) -- non-blocking", flush = True)
+                              return None
+                          raise
+                      print(f"[retry-sse] {path}: {exc!r}", flush = True)
+                      time.sleep(15)
 
           # ── 1. Standard OpenAI function calling ──────────────────────
           weather_tool = {
@@ -757,8 +791,10 @@ jobs:
               "temperature":   TEMP,
               "seed":          SEED,
               "max_tokens":    600,
-          })
-          if "56088" in content or "56,088" in content:
+          }, soft = True)
+          if content is None:
+              print("[tools] WARN python tool: SSE transport stalled after retries -- non-blocking")
+          elif "56088" in content or "56,088" in content:
               print(f"[tools] PASS python tool ({len(content)} chars, found 56088)")
           else:
               assert content, "python tool: SSE stream empty"
@@ -780,8 +816,10 @@ jobs:
               "temperature":   TEMP,
               "seed":          SEED,
               "max_tokens":    600,
-          })
-          if "hello-bash-tool" in content:
+          }, soft = True)
+          if content is None:
+              print("[tools] WARN terminal tool: SSE transport stalled after retries -- non-blocking")
+          elif "hello-bash-tool" in content:
               print(f"[tools] PASS terminal tool ({len(content)} chars)")
           else:
               assert content, "terminal tool: SSE stream empty"


### PR DESCRIPTION
## Problem

The "Tool calling Tests" job in the Studio inference-smoke workflows boots a real Studio server on a shared CI runner and drives the server-side tool loop over SSE (`/v1/chat/completions` with `enable_tools`). On the free Windows and macOS runners, CPU inference of the Qwen3.5-2B GGUF is slow, and the SSE stream can stall at the transport level (the connection opening, or a mid-stream read) even when Studio is healthy.

When that happens, `post_sse` raises `TimeoutError: timed out` from `socket.recv_into` and the whole job fails, even though the meaningful tool-call contract (the non-streaming function-calling probe, and the thinking on/off probe) already passed. A recent example failed exactly this way: the `get_weather` function-calling probe passed, then the python-tool SSE probe stalled with no tokens and the job exited 1.

## Change

Harden the SSE read in all three inference-smoke workflows without weakening the real assertions:

- `post_sse` now retries a transport stall once with a fresh request capped at 300s (mirroring the existing `post` helper), and returns any text already streamed before a stall, so a stall on the trailing tokens after the answer arrived still counts.
- The best-effort server-side tool probes (python, terminal) mark the call `soft`: a total transport stall that yields nothing becomes a non-blocking WARN instead of failing the job, the same philosophy already applied to the `web_search` probe.
- The hard correctness assertions are unchanged: the non-streaming function-calling probe and the thinking on/off probe still fail the job on a real regression, so a genuinely broken tool loop is still caught.
- In `studio-inference-smoke.yml` the multi-seed `_run_tool_probe` now also catches a transport stall and rotates to the next seed rather than propagating it, and its `post_sse` gains the same retry plus partial-return.

## Files

- `.github/workflows/studio-windows-inference-smoke.yml`
- `.github/workflows/studio-mac-inference-smoke.yml`
- `.github/workflows/studio-inference-smoke.yml`

## Validation

Extracted the real `post_sse` text from each workflow and exercised it against a mocked stream: a clean stream returns full content; a mid-stream stall returns the partial content already received; a total stall returns `None` under `soft` (or re-raises for seed rotation in the generic file) after using both attempts; and an HTTP status error surfaces immediately without retry. All three embedded Python heredocs compile and the YAML parses.