### PR TITLE
fix(mlx): relax Metal context-store timeout by default

### DIFF
--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -49,6 +49,11 @@ logger = get_logger(__name__)
 # and spawn workers copy os.environ. setdefault so an explicit user override wins.
 os.environ.setdefault("CUDA_DEVICE_ORDER", "PCI_BUS_ID")
 
+# Studio workers can import MLX without importing unsloth first, so mirror the
+# package bootstrap here. Keep an explicit user value authoritative.
+if platform.system() == "Darwin" and platform.machine() == "arm64":
+    os.environ.setdefault("AGX_RELAX_CDM_CTXSTORE_TIMEOUT", "1")
+
 
 # ========== Device Enum ==========
 

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -16,6 +16,11 @@ import os, importlib.util, platform
 
 os.environ["UNSLOTH_IS_PRESENT"] = "1"
 
+# Relax Metal's context-store timeout before MLX modules can initialize Metal.
+# Keep an explicit user value authoritative.
+if platform.system() == "Darwin" and platform.machine() == "arm64":
+    os.environ.setdefault("AGX_RELAX_CDM_CTXSTORE_TIMEOUT", "1")
+
 # ── Windows console UTF-8 safety ─────────────────────────────────────────────
 # Legacy Windows consoles (cp1252) can't encode Unsloth's emoji/box-drawing
 # glyphs and crash with UnicodeEncodeError. Force stdout/stderr to UTF-8 only on


### PR DESCRIPTION
## Summary

- Default `AGX_RELAX_CDM_CTXSTORE_TIMEOUT` to `1` on Apple Silicon before MLX modules can initialize through the normal Python API or Studio workers.
- Preserve every explicit user value, including `0` and an empty string, with `os.environ.setdefault`.

## Why

Sustained MLX workloads can hit Metal's context-store/interactivity watchdog while a display is active, as reported in [ml-explore/mlx#3267](https://github.com/ml-explore/mlx/issues/3267). The driver setting helped the reported M2 case, but it is private and does not guarantee protection on every chip or workload.

The setting must exist before MLX or Metal initializes. The `unsloth` package bootstrap covers normal Python API and export imports, while Studio's hardware bootstrap mirrors the default for training and inference workers that import MLX directly without first importing `unsloth`.

## Behavior and risk

This is an Apple-Silicon-only, process-scoped default. It does not modify shell profiles or system configuration, and an explicitly supplied environment value always remains authoritative.

Because the variable is undocumented and has not protected every reported system, this PR treats it as a best-effort mitigation rather than a universal watchdog fix.

## Validation

```text
python -m ruff check unsloth/__init__.py studio/backend/utils/hardware/hardware.py
All checks passed
```

Direct `import unsloth` subprocess probes confirmed:

```text
unset -> 1
explicit 0 -> 0
explicit empty string -> empty string
```
