### PR TITLE
Fix Studio toast close-button positioning

### DIFF
--- a/studio/frontend/src/components/ui/sonner.tsx
+++ b/studio/frontend/src/components/ui/sonner.tsx
@@ -90,7 +90,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
             // Pin the close button inside the toast's top-right corner.
             // Sonner defaults to the left/outside edge, so keep the horizontal
             // override here and the top offset in index.css.
-            "--toast-close-button-start": "unset",
+            "--toast-close-button-start": "auto",
             "--toast-close-button-end": "8px",
             "--toast-close-button-transform": "none",
           } as React.CSSProperties

--- a/studio/frontend/src/features/settings/components/language-select.tsx
+++ b/studio/frontend/src/features/settings/components/language-select.tsx
@@ -35,7 +35,11 @@ export function LanguageSelect() {
       >
         <SelectValue />
       </SelectTrigger>
-      <SelectContent>
+      <SelectContent
+        style={{
+          maxHeight: "min(18rem, var(--radix-select-content-available-height))",
+        }}
+      >
         <SelectItem value={AUTO_LOCALE}>
           {t("settings.appearance.language.autoDetect")}
         </SelectItem>

--- a/studio/frontend/src/i18n/locale-store.ts
+++ b/studio/frontend/src/i18n/locale-store.ts
@@ -98,7 +98,6 @@ function writeStoredPreference(preference: LocalePreference): void {
 function syncDocumentLang(locale: Locale): void {
   if (typeof document === "undefined") return;
   document.documentElement.lang = locale;
-  document.documentElement.dir = LOCALES[locale].dir;
 }
 
 function notifySubscribers(): void {

--- a/studio/frontend/src/i18n/messages.ts
+++ b/studio/frontend/src/i18n/messages.ts
@@ -15,19 +15,18 @@ import { de } from "./locales/de";
 import { ko } from "./locales/ko";
 import type { InterpolationValues, MessageKey } from "./types";
 
-// dir sets documentElement.dir; Arabic stays ltr (CSS still physical-direction) but renders rtl via bidi.
 export const LOCALES = {
-  en: { label: "English", nativeLabel: "English", dir: "ltr" },
-  "zh-CN": { label: "Chinese (Simplified)", nativeLabel: "简体中文", dir: "ltr" },
-  ja: { label: "Japanese", nativeLabel: "日本語", dir: "ltr" },
-  ko: { label: "Korean", nativeLabel: "한국어", dir: "ltr" },
-  es: { label: "Spanish", nativeLabel: "Español", dir: "ltr" },
-  "pt-BR": { label: "Portuguese (Brazil)", nativeLabel: "Português (Brasil)", dir: "ltr" },
-  fr: { label: "French", nativeLabel: "Français", dir: "ltr" },
-  de: { label: "German", nativeLabel: "Deutsch", dir: "ltr" },
-  ru: { label: "Russian", nativeLabel: "Русский", dir: "ltr" },
-  hi: { label: "Hindi", nativeLabel: "हिन्दी", dir: "ltr" },
-  ar: { label: "Arabic", nativeLabel: "العربية", dir: "ltr" },
+  en: { label: "English", nativeLabel: "English" },
+  "zh-CN": { label: "Chinese (Simplified)", nativeLabel: "简体中文" },
+  ja: { label: "Japanese", nativeLabel: "日本語" },
+  ko: { label: "Korean", nativeLabel: "한국어" },
+  es: { label: "Spanish", nativeLabel: "Español" },
+  "pt-BR": { label: "Portuguese (Brazil)", nativeLabel: "Português (Brasil)" },
+  fr: { label: "French", nativeLabel: "Français" },
+  de: { label: "German", nativeLabel: "Deutsch" },
+  ru: { label: "Russian", nativeLabel: "Русский" },
+  hi: { label: "Hindi", nativeLabel: "हिन्दी" },
+  ar: { label: "Arabic", nativeLabel: "العربية" },
 } as const;
 
 export type Locale = keyof typeof LOCALES;

--- a/tests/studio/test_locale_root_direction_contract.py
+++ b/tests/studio/test_locale_root_direction_contract.py
@@ -6,6 +6,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 LOCALE_STORE = REPO / "studio/frontend/src/i18n/locale-store.ts"
 MESSAGES = REPO / "studio/frontend/src/i18n/messages.ts"
+SONNER = REPO / "studio/frontend/src/components/ui/sonner.tsx"
 
 
 def test_locale_changes_do_not_force_document_direction():
@@ -21,3 +22,9 @@ def test_locale_metadata_does_not_advertise_unused_layout_direction():
     src = MESSAGES.read_text(encoding = "utf-8")
     locales_block = src[src.index("export const LOCALES") : src.index("export type Locale")]
     assert "dir:" not in locales_block
+
+
+def test_toast_close_position_does_not_inherit_root_direction():
+    src = SONNER.read_text(encoding = "utf-8")
+    assert '"--toast-close-button-start": "auto"' in src
+    assert '"--toast-close-button-start": "unset"' not in src

--- a/tests/studio/test_locale_root_direction_contract.py
+++ b/tests/studio/test_locale_root_direction_contract.py
@@ -9,7 +9,7 @@ MESSAGES = REPO / "studio/frontend/src/i18n/messages.ts"
 
 
 def test_locale_changes_do_not_force_document_direction():
-    src = LOCALE_STORE.read_text(encoding="utf-8")
+    src = LOCALE_STORE.read_text(encoding = "utf-8")
     assert "document.documentElement.lang = locale" in src
     assert "document.documentElement.dir" not in src, (
         "locale changes must not force the root direction; html[dir] changes "
@@ -18,6 +18,6 @@ def test_locale_changes_do_not_force_document_direction():
 
 
 def test_locale_metadata_does_not_advertise_unused_layout_direction():
-    src = MESSAGES.read_text(encoding="utf-8")
+    src = MESSAGES.read_text(encoding = "utf-8")
     locales_block = src[src.index("export const LOCALES") : src.index("export type Locale")]
     assert "dir:" not in locales_block

--- a/tests/studio/test_locale_root_direction_contract.py
+++ b/tests/studio/test_locale_root_direction_contract.py
@@ -1,0 +1,23 @@
+"""Regression guard for locale changes affecting the entire Studio layout."""
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+LOCALE_STORE = REPO / "studio/frontend/src/i18n/locale-store.ts"
+MESSAGES = REPO / "studio/frontend/src/i18n/messages.ts"
+
+
+def test_locale_changes_do_not_force_document_direction():
+    src = LOCALE_STORE.read_text()
+    assert "document.documentElement.lang = locale" in src
+    assert "document.documentElement.dir" not in src, (
+        "locale changes must not force the root direction; html[dir] changes "
+        "third-party component layout, including Sonner close-button positioning"
+    )
+
+
+def test_locale_metadata_does_not_advertise_unused_layout_direction():
+    src = MESSAGES.read_text()
+    locales_block = src[src.index("export const LOCALES") : src.index("export type Locale")]
+    assert "dir:" not in locales_block

--- a/tests/studio/test_locale_root_direction_contract.py
+++ b/tests/studio/test_locale_root_direction_contract.py
@@ -9,7 +9,7 @@ MESSAGES = REPO / "studio/frontend/src/i18n/messages.ts"
 
 
 def test_locale_changes_do_not_force_document_direction():
-    src = LOCALE_STORE.read_text()
+    src = LOCALE_STORE.read_text(encoding="utf-8")
     assert "document.documentElement.lang = locale" in src
     assert "document.documentElement.dir" not in src, (
         "locale changes must not force the root direction; html[dir] changes "
@@ -18,6 +18,6 @@ def test_locale_changes_do_not_force_document_direction():
 
 
 def test_locale_metadata_does_not_advertise_unused_layout_direction():
-    src = MESSAGES.read_text()
+    src = MESSAGES.read_text(encoding="utf-8")
     locales_block = src[src.index("export const LOCALES") : src.index("export type Locale")]
     assert "dir:" not in locales_block


### PR DESCRIPTION
## Summary

- Stop locale changes from setting the global document direction.
- Remove unused locale direction metadata while preserving all language catalogs, detection, persistence, selection, and synchronization behavior.
- Pin the toast close button to the right edge even if another caller sets a document direction.
- Limit the language dropdown to 18rem so additional options require scrolling instead of extending down the page.
- Add regression coverage for locale direction and toast positioning contracts.

## Root cause

PR #7076 added document direction synchronization for an RTL Arabic layout. Arabic was later kept on an LTR layout because Studio still uses physical-direction CSS, but the root `dir="ltr"` assignment remained for every locale.

Sonner defines close-button variables under `html[dir="ltr"]`, including a start position of zero. The Studio override used `unset`, which inherits for custom properties, so Sonner's root value won and placed the close button over the status icon.

This change removes the unused global direction mutation and uses `auto` for the close button's start position. The close button therefore remains pinned eight pixels from the right edge even if `dir="ltr"` or `dir="rtl"` is set later.

## Before and after

Before this PR:

- Every locale set a root direction.
- Sonner inherited a left-edge close-button position.
- Status icons and close buttons overlapped.
- An external or future root direction could reproduce the overlap.
- The language dropdown grew to about 440px and displayed all 12 choices at once.

After this PR:

- Locale changes update `lang` without mutating global layout direction.
- All 12 choices, including automatic detection and 11 supported locales, remain available.
- The close button stays inside the top-right corner under no direction, LTR, RTL, and live direction changes.
- Toast content, actions, and status icons do not overlap the close button.
- The language dropdown is capped at 18rem, about 288px, and scrolls to reveal the remaining choices.

## Scope and compatibility

This PR changes no backend, model, hardware, operating-system, packaging, or inference path. Existing supported paths are untouched. The language selector, automatic detection, persisted preferences, personalization synchronization, locale overlays, and per-element bidirectional text behavior remain intact. The dropdown cap is local to the language selector and does not affect shared dropdown components.

## Testing

- 568 toast assertions against real before and after builds
  - macOS: Chromium, installed Chrome, Firefox, WebKit 26.5, and isolated official Edge 150
  - Linux ARM64 container: Chromium, Firefox, and WebKit
  - Mobile, tablet, and desktop viewports
  - Eleven locales, light and dark themes, eight toast variants
  - Long text, Arabic, Hindi, CJK, mixed-direction text, and emoji
  - Stacking, dismissal, live resize, LTR, RTL, live direction changes, high DPI, forced colors, and normal motion
- 50 language dropdown assertions across Chromium, installed Chrome, Firefox, WebKit, and isolated official Edge
  - Tall baseline reproduction and 18rem cap verification
  - Required overflow, wheel scrolling, scrolled selection, keyboard traversal, and touch selection
  - Viewports from 320px through 1440px wide, including a 320px short-height case
- Linux Node 24 clean install, locale parity, typecheck, and production build
- macOS production builds before and after
- `npm run i18n:check`
- `npm run typecheck`
- `npm run build`
- `pytest -q tests/studio/test_locale_root_direction_contract.py` on Python 3.10, 3.11, 3.12, and 3.13, with 3 passing tests on each version
- Relevant pre-commit hooks, ESLint, formatting, and whitespace checks
- Windows legacy-codec simulation confirming that explicit UTF-8 reads avoid the multilingual catalog failure mode

Native Safari automation requires the local Safari remote-automation permission, and native Windows validation remains covered by the repository's Windows CI runners.