### PR TITLE
Show concise NVFP4 inference errors

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -4546,8 +4546,17 @@ async def _load_model_impl(request: LoadRequest, fastapi_request: Request, curre
     except HTTPException:
         raise
     except ValueError as e:
+        redacted_msg = redact_native_paths(str(e))
+        if _is_unsupported_nvfp4_inference_error(redacted_msg):
+            logger.warning(
+                "NVFP4 inference is not supported yet while loading '%s'",
+                model_log_label,
+            )
+            raise HTTPException(
+                status_code = 500,
+                detail = _NVFP4_INFERENCE_UNSUPPORTED_MESSAGE,
+            )
         if native_grant_backed:
-            redacted_msg = redact_native_paths(str(e))
             logger.warning(
                 "Rejected inference selection for native model %s: %s",
                 model_log_label,
@@ -4556,7 +4565,7 @@ async def _load_model_impl(request: LoadRequest, fastapi_request: Request, curre
             raise HTTPException(status_code = 400, detail = redacted_msg)
         logger.warning("Rejected inference GPU selection: %s", e)
         # User-facing validation (e.g. "Invalid gpu_ids [99]"): redact paths, keep detail.
-        raise HTTPException(status_code = 400, detail = redact_native_paths(str(e)))
+        raise HTTPException(status_code = 400, detail = redacted_msg)
     except LlamaServerNotFoundError as e:
         # Missing GGUF runtime: 400 with the install message, not a generic 500.
         logger.warning("GGUF runtime missing while loading '%s': %s", model_log_label, e)

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -3867,6 +3867,17 @@ _NOT_SUPPORTED_HINTS = (
     "does not support",
 )
 
+_NVFP4_INFERENCE_UNSUPPORTED_MESSAGE = (
+    "We are working on supporting NVFP4 inference. For now it is not supported"
+)
+
+
+def _is_unsupported_nvfp4_inference_error(msg: str) -> bool:
+    """Whether ``msg`` is the verbose MLX per-module metadata error emitted
+    while loading an NVFP4 checkpoint."""
+    lower_msg = msg.lower()
+    return "nvfp4" in lower_msg and "per-module mlx quantization metadata" in lower_msg
+
 
 def _maybe_unsupported_message(msg: str) -> str:
     """Rewrite a load/validate error into the friendly "not supported yet"
@@ -4557,8 +4568,17 @@ async def _load_model_impl(request: LoadRequest, fastapi_request: Request, curre
             # Lost the spawn-time race to a sidecar install/repair: retryable 409.
             raise HTTPException(status_code = 409, detail = str(e))
         # Friendlier message for models Unsloth cannot load.
+        redacted_msg = redact_native_paths(str(e))
+        if _is_unsupported_nvfp4_inference_error(redacted_msg):
+            logger.warning(
+                "NVFP4 inference is not supported yet while loading '%s'",
+                model_log_label,
+            )
+            raise HTTPException(
+                status_code = 500,
+                detail = _NVFP4_INFERENCE_UNSUPPORTED_MESSAGE,
+            )
         if native_grant_backed:
-            redacted_msg = redact_native_paths(str(e))
             logger.error(
                 "Error loading native model %s: %s",
                 model_log_label,
@@ -4570,7 +4590,7 @@ async def _load_model_impl(request: LoadRequest, fastapi_request: Request, curre
                 detail = f"Failed to load native model {model_log_label}: {msg}",
             )
         logger.error(f"Error loading model: {e}", exc_info = True)
-        msg = _maybe_unsupported_message(redact_native_paths(str(e)))
+        msg = _maybe_unsupported_message(redacted_msg)
         raise HTTPException(status_code = 500, detail = f"Failed to load model: {msg}")
 
 

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -4845,8 +4845,17 @@ async def validate_model(
         logger.warning("GGUF runtime missing while validating '%s': %s", request.model_path, e)
         raise HTTPException(status_code = 400, detail = str(e))
     except Exception as e:
+        redacted_msg = redact_native_paths(str(e))
+        if _is_unsupported_nvfp4_inference_error(redacted_msg):
+            logger.warning(
+                "NVFP4 inference is not supported yet while validating '%s'",
+                model_log_label,
+            )
+            raise HTTPException(
+                status_code = 400,
+                detail = _NVFP4_INFERENCE_UNSUPPORTED_MESSAGE,
+            )
         if native_grant_backed:
-            redacted_msg = redact_native_paths(str(e))
             logger.error(
                 "Error validating native model %s: %s",
                 model_log_label,
@@ -4867,7 +4876,7 @@ async def validate_model(
         # Path-redact for safety and keep any other exception type generic so an
         # unexpected internal error never leaks its details to the client.
         if isinstance(e, (RuntimeError, ValueError)):
-            msg = redact_native_paths(str(e)).strip()
+            msg = redacted_msg.strip()
             if msg:
                 msg = _maybe_unsupported_message(msg)
                 raise HTTPException(

--- a/studio/backend/tests/test_nvfp4_load_error_message.py
+++ b/studio/backend/tests/test_nvfp4_load_error_message.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""NVFP4 load failures should not expose verbose MLX quantization metadata."""
+
+import asyncio
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from models.inference import LoadRequest
+
+_BACKEND_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_route_module():
+    spec = importlib.util.spec_from_file_location(
+        "inference_route_nvfp4_error",
+        _BACKEND_ROOT / "routes/inference.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_failure(message: str) -> HTTPException:
+    inference_route = _load_route_module()
+    model_path = "unsloth/Qwen3.6-35B-A3B-NVFP4-Fast"
+    request = LoadRequest(model_path = model_path)
+    backend = MagicMock(active_model_name = None)
+    with (
+        patch.object(
+            inference_route,
+            "_resolve_model_identifier_for_request",
+            return_value = (model_path, model_path, False),
+        ),
+        patch.object(
+            inference_route,
+            "resolve_effective_chat_template_override",
+            return_value = None,
+        ),
+        patch.object(inference_route, "get_inference_backend", return_value = backend),
+        patch.object(inference_route, "get_llama_cpp_backend", return_value = MagicMock()),
+        patch.object(
+            inference_route.ModelConfig, "from_identifier", side_effect = RuntimeError(message)
+        ),
+        pytest.raises(HTTPException) as exc,
+    ):
+        asyncio.run(inference_route.load_model(request, MagicMock(), current_subject = "test-user"))
+    return exc.value
+
+
+def test_nvfp4_mlx_metadata_error_is_replaced_with_short_message():
+    error = _load_failure(
+        "Unsloth: 'unsloth/Qwen3.6-35B-A3B-NVFP4-Fast' has per-module MLX "
+        "quantization metadata {'config_groups': {'group_0': {'format': "
+        "'float-quantized'}, 'group_1': {'format': 'nvfp4-pack-quantized'}}}"
+    )
+
+    assert error.status_code == 500
+    assert error.detail == (
+        "We are working on supporting NVFP4 inference. For now it is not supported"
+    )
+    assert "quantization metadata" not in error.detail
+
+
+def test_unrelated_load_error_keeps_existing_message():
+    error = _load_failure("Network connection timed out")
+
+    assert error.status_code == 500
+    assert error.detail == "Failed to load model: Network connection timed out"

--- a/studio/backend/tests/test_nvfp4_load_error_message.py
+++ b/studio/backend/tests/test_nvfp4_load_error_message.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
-from models.inference import LoadRequest
+from models.inference import LoadRequest, ValidateModelRequest
 
 _BACKEND_ROOT = Path(__file__).resolve().parent.parent
 
@@ -60,6 +60,32 @@ def _load_failure(
     return exc.value
 
 
+def _validation_failure(
+    message: str,
+    exception_type: type[Exception] = RuntimeError,
+    native: bool = False,
+) -> HTTPException:
+    inference_route = _load_route_module()
+    model_path = "unsloth/Qwen3.6-35B-A3B-NVFP4-Fast"
+    model_label = "Qwen3.6-35B-A3B-NVFP4-Fast" if native else model_path
+    request = ValidateModelRequest(model_path = model_path)
+    with (
+        patch.object(
+            inference_route,
+            "_resolve_model_identifier_for_request",
+            return_value = (model_path, model_label, native),
+        ),
+        patch.object(
+            inference_route.ModelConfig,
+            "from_identifier",
+            side_effect = exception_type(message),
+        ),
+        pytest.raises(HTTPException) as exc,
+    ):
+        asyncio.run(inference_route.validate_model(request, current_subject = "test-user"))
+    return exc.value
+
+
 @pytest.mark.parametrize("exception_type", [Exception, RuntimeError, ValueError])
 @pytest.mark.parametrize("native", [False, True])
 def test_nvfp4_mlx_metadata_error_is_replaced_with_short_message(exception_type, native):
@@ -91,3 +117,38 @@ def test_unrelated_value_error_keeps_existing_message(native):
 
     assert error.status_code == 400
     assert error.detail == "Invalid gpu_ids [99]"
+
+
+@pytest.mark.parametrize("exception_type", [Exception, RuntimeError, ValueError])
+@pytest.mark.parametrize("native", [False, True])
+def test_nvfp4_validation_error_is_replaced_with_short_message(exception_type, native):
+    error = _validation_failure(
+        "Unsloth: 'unsloth/Qwen3.6-35B-A3B-NVFP4-Fast' has per-module MLX "
+        "quantization metadata {'config_groups': {'group_0': {'format': "
+        "'float-quantized'}, 'group_1': {'format': 'nvfp4-pack-quantized'}}}",
+        exception_type = exception_type,
+        native = native,
+    )
+
+    assert error.status_code == 400
+    assert error.detail == (
+        "We are working on supporting NVFP4 inference. For now it is not supported"
+    )
+    assert "quantization metadata" not in error.detail
+
+
+@pytest.mark.parametrize(
+    ("native", "expected_detail"),
+    [
+        (False, "Network connection timed out"),
+        (
+            True,
+            "Invalid native model Qwen3.6-35B-A3B-NVFP4-Fast: Network connection timed out",
+        ),
+    ],
+)
+def test_unrelated_validation_error_keeps_existing_message(native, expected_detail):
+    error = _validation_failure("Network connection timed out", native = native)
+
+    assert error.status_code == 400
+    assert error.detail == expected_detail

--- a/studio/backend/tests/test_nvfp4_load_error_message.py
+++ b/studio/backend/tests/test_nvfp4_load_error_message.py
@@ -26,16 +26,21 @@ def _load_route_module():
     return module
 
 
-def _load_failure(message: str) -> HTTPException:
+def _load_failure(
+    message: str,
+    exception_type: type[Exception] = RuntimeError,
+    native: bool = False,
+) -> HTTPException:
     inference_route = _load_route_module()
     model_path = "unsloth/Qwen3.6-35B-A3B-NVFP4-Fast"
+    model_label = "Qwen3.6-35B-A3B-NVFP4-Fast" if native else model_path
     request = LoadRequest(model_path = model_path)
     backend = MagicMock(active_model_name = None)
     with (
         patch.object(
             inference_route,
             "_resolve_model_identifier_for_request",
-            return_value = (model_path, model_path, False),
+            return_value = (model_path, model_label, native),
         ),
         patch.object(
             inference_route,
@@ -45,7 +50,9 @@ def _load_failure(message: str) -> HTTPException:
         patch.object(inference_route, "get_inference_backend", return_value = backend),
         patch.object(inference_route, "get_llama_cpp_backend", return_value = MagicMock()),
         patch.object(
-            inference_route.ModelConfig, "from_identifier", side_effect = RuntimeError(message)
+            inference_route.ModelConfig,
+            "from_identifier",
+            side_effect = exception_type(message),
         ),
         pytest.raises(HTTPException) as exc,
     ):
@@ -53,11 +60,15 @@ def _load_failure(message: str) -> HTTPException:
     return exc.value
 
 
-def test_nvfp4_mlx_metadata_error_is_replaced_with_short_message():
+@pytest.mark.parametrize("exception_type", [Exception, RuntimeError, ValueError])
+@pytest.mark.parametrize("native", [False, True])
+def test_nvfp4_mlx_metadata_error_is_replaced_with_short_message(exception_type, native):
     error = _load_failure(
         "Unsloth: 'unsloth/Qwen3.6-35B-A3B-NVFP4-Fast' has per-module MLX "
         "quantization metadata {'config_groups': {'group_0': {'format': "
-        "'float-quantized'}, 'group_1': {'format': 'nvfp4-pack-quantized'}}}"
+        "'float-quantized'}, 'group_1': {'format': 'nvfp4-pack-quantized'}}}",
+        exception_type = exception_type,
+        native = native,
     )
 
     assert error.status_code == 500
@@ -72,3 +83,11 @@ def test_unrelated_load_error_keeps_existing_message():
 
     assert error.status_code == 500
     assert error.detail == "Failed to load model: Network connection timed out"
+
+
+@pytest.mark.parametrize("native", [False, True])
+def test_unrelated_value_error_keeps_existing_message(native):
+    error = _load_failure("Invalid gpu_ids [99]", exception_type = ValueError, native = native)
+
+    assert error.status_code == 400
+    assert error.detail == "Invalid gpu_ids [99]"


### PR DESCRIPTION
## Summary

- Replace verbose per-module MLX quantization metadata errors for NVFP4 validation and loading with a concise unsupported inference message.
- Handle validation before the main chat flow reaches the load endpoint.
- Handle both serialized backend exceptions and direct `ValueError` paths.
- Preserve existing behavior for unrelated validation, load, and GPU-selection failures.
- Add route-level regression coverage for Hub and native model flows.

## Why

NVFP4 checkpoints can reach an unsupported MLX per-module quantization path that returns the full metadata blob to Studio. The chat flow validates a model before loading it, so both endpoints must replace this signature. The metadata is not actionable and overwhelms the error notification.

## Before

Studio could display the complete per-module quantization metadata during validation or loading.

## After

Failed NVFP4 validation and load requests with this signature show:

> We are working on supporting NVFP4 inference. For now it is not supported

Other errors retain their existing status codes and details.

## Safety

The replacement requires both `nvfp4` and `per-module MLX quantization metadata` in the error, using case-insensitive matching. Network, authentication, download, disk, GPU-selection, GGUF, and other model errors remain on their existing paths.

## Testing

- Validation and load regression tests on Python 3.10, 3.11, 3.12, 3.13, and 3.14: 22 passed per version
- Isolated `uv` matrix on Python 3.10 through 3.14: 40 passed per version
- Fresh Linux ARM64 container: 40 passed
- Fresh Linux AMD64 container: 40 passed
- Existing validation error module: 12 passed
- Existing chat-load module: 36 passed
- Full existing GPU-selection module: 58 passed, plus 4 subtests
- Frontend response contract, type checking, and production build passed
- Ruff 0.15.12 and Python compilation checks passed

The simulation matrix covers validation and loading, generic exceptions, runtime errors, direct value errors, native and Hub models, mixed casing, long metadata, Windows and POSIX paths, unrelated failure signatures, HTTP response shape, and concurrent matching.