### PR TITLE
fix config cards clipping content at narrow window widths

### DIFF
--- a/studio/frontend/src/features/studio/sections/dataset-section.tsx
+++ b/studio/frontend/src/features/studio/sections/dataset-section.tsx
@@ -683,11 +683,7 @@ export function DatasetSection() {
         title={t("studio.dataset.title")}
         description={t("studio.dataset.description")}
         accent="indigo"
-        className={`dark:shadow-border ${
-          advancedOpen || (datasetSource === "upload" && uploadedFile)
-            ? "min-h-studio-config-column"
-            : "h-studio-config-column"
-        }`}
+        className="dark:shadow-border min-h-studio-config-column"
       >
         <div className="flex min-w-0 flex-col gap-4">
           {(() => {

--- a/studio/frontend/src/features/studio/sections/params-section.tsx
+++ b/studio/frontend/src/features/studio/sections/params-section.tsx
@@ -232,7 +232,7 @@ export function ParamsSection(): ReactElement {
         title={t("studio.params.title")}
         description={t("studio.params.description")}
         accent="orange"
-        className="min-h-studio-config-column duration-150"
+        className="min-h-studio-config-column"
       >
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-2">

--- a/studio/frontend/src/features/studio/sections/params-section.tsx
+++ b/studio/frontend/src/features/studio/sections/params-section.tsx
@@ -192,7 +192,6 @@ export function ParamsSection(): ReactElement {
   const showVisionImageSize = showVisionLora && !isDeepseekOcr;
   const [loraOpen, setLoraOpen] = useState(false);
   const [hyperOpen, setHyperOpen] = useState(false);
-  const needsExpandedHeight = isCpt || (isLora && loraOpen) || hyperOpen;
   const [ctxInput, setCtxInput] = useState(String(store.contextLength));
   const ctxAnchorRef = useRef<HTMLDivElement>(null);
   const ctxItems = CONTEXT_LENGTHS.map(String);
@@ -233,11 +232,7 @@ export function ParamsSection(): ReactElement {
         title={t("studio.params.title")}
         description={t("studio.params.description")}
         accent="orange"
-        className={`${
-          needsExpandedHeight
-            ? "min-h-studio-config-column"
-            : "h-studio-config-column"
-        } duration-150`}
+        className="min-h-studio-config-column duration-150"
       >
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-2">

--- a/studio/frontend/src/features/studio/sections/training-section.tsx
+++ b/studio/frontend/src/features/studio/sections/training-section.tsx
@@ -53,7 +53,6 @@ export function TrainingSection() {
     ((!store.isVisionModel && store.isDatasetImage === true) ||
       (!store.isAudioModel && store.isDatasetAudio === true));
   const configValidation = validateTrainingConfig(store);
-  const hasMessage = !!(startError || isIncompatible || (!configValidation.ok && configValidation.message));
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -125,7 +124,7 @@ export function TrainingSection() {
         title={t("studio.training.title")}
         description={t("studio.training.description")}
         accent="blue"
-        className={hasMessage ? "min-h-studio-config-column" : "h-studio-config-column"}
+        className="min-h-studio-config-column"
       >
         <div className="flex flex-col gap-4">
         {/* Loss chart */}

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2024,13 +2024,9 @@ html[data-chat-font] .aui-root {
 		}
 	}
 
-	/* Fine-tuning Studio: equal default height, expandable when needed (md+) */
+	/* Fine-tuning Studio: equal minimum card height, grows with content (md+) */
 	.min-h-studio-config-column {
 		@apply md:min-h-[520px];
-	}
-
-	.h-studio-config-column {
-		@apply md:h-[520px];
 	}
 
 	[data-streamdown="unordered-list"] {


### PR DESCRIPTION
The Studio configure cards had a fixed 520px height with clipped overflow, so at narrower windows the wrapped text pushed the bottom of the card out of view, the "Training Hyperparameters" section could become completely hidden and unclickable. Use min-height instead so cards keep the 520px baseline but grow with their content. Removes the unused h-studio-config-column class and leftover conditional state.

Before:
<img width="1524" height="572" alt="Screenshot 2026-07-15 at 8 02 54 PM" src="https://github.com/user-attachments/assets/7bd11280-8bc3-4193-a3ac-6caecd44031a" />

After:
<img width="1524" height="579" alt="Screenshot 2026-07-15 at 7 53 50 PM" src="https://github.com/user-attachments/assets/af863037-4198-4771-91c3-2a2ff61a4467" />
