### PR TITLE
Studio: fix permission composer layout and Hub feed icons

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1433,7 +1433,6 @@ const Composer: FC<{
   const mcpEnabledForChat = useChatRuntimeStore((s) => s.mcpEnabledForChat);
   const ragEnabled = useChatRuntimeStore((s) => s.ragEnabled);
   const permissionMode = useChatRuntimeStore((s) => s.permissionMode);
-  const bypassPermissions = useChatRuntimeStore((s) => s.bypassPermissions);
   // More than 4 pills: collapse to icons only. Search and Code always show; the
   // permission pill shows in every mode except "off" (it renders null there);
   // Images, RAG, Canvas and MCP are conditional.
@@ -1557,8 +1556,7 @@ const Composer: FC<{
   }, [composerText, draftKey]);
   // Two-row layout shows once the input wraps or a tool is on. Tools can
   // pre-select before a model loads, so an active toggle expands it either way.
-  // Bypass permissions counts too: turning it on should drop the composer into
-  // the two-row layout immediately, same as Search/Code.
+  // Keep the composer expanded whenever the permission pill is visible.
   const composerExpanded =
     isMultiline ||
     hasAttachments ||
@@ -1569,7 +1567,7 @@ const Composer: FC<{
     ragEnabled ||
     artifactsEnabled ||
     mcpEnabledForChat ||
-    bypassPermissions;
+    permissionMode !== "off";
   // react-textarea-autosize re-measures only on value change or window resize,
   // not on the width swap from expanding, so it keeps the taller height and
   // leaves a stray blank row. Nudge a resize whenever input width changes.

--- a/studio/frontend/src/features/hub/hub-page.tsx
+++ b/studio/frontend/src/features/hub/hub-page.tsx
@@ -75,6 +75,7 @@ import {
 } from "./lib/channels";
 import { isHiddenModelId } from "./lib/hidden-models";
 import { inventoryRowMatches, tokenizeQuery } from "./lib/inventory-search";
+import { resolveOwnerProviderLogo } from "./lib/provider-logos";
 import {
   buildDiscoverRows,
   detectResultFormat,
@@ -699,6 +700,9 @@ export function ModelsPage() {
     return discoverRows.filter(
       (row) =>
         !isHiddenModelId(row.id) &&
+        // The default feed only shows models with a provider logo.
+        (!isFeedMode ||
+          resolveOwnerProviderLogo(row.owner, row.repo) !== null) &&
         matchesFormat(detectResultFormat(row.result), effectiveDiscoverFormat) &&
         matchesCapability(row.capabilities, deferredCapabilityFilter) &&
         (!activeChannel?.finetunableOnly || isUnslothFinetunable(row.result)) &&
@@ -711,6 +715,7 @@ export function ModelsPage() {
   }, [
     discoverRows,
     isDatasetMode,
+    isFeedMode,
     effectiveDiscoverFormat,
     deferredCapabilityFilter,
     activeChannel,


### PR DESCRIPTION
## Summary

- Keep the Studio chat composer expanded whenever the permission mode pill is visible.
- Match the Search and Code layout for Ask for approval, Approve for me, and Full access.
- Filter the default Latest Unsloth Models feed to models with registered provider logos.
- Leave Hub search, channel, and downloaded views unchanged.

## Root causes

The composer layout checked `bypassPermissions`, which is true only for Full access. The permission pill is also visible for Ask for approval and Approve for me, so those modes incorrectly stayed in the single-row layout.

The default Hub feed accepted every latest Unsloth model even when the avatar renderer had no matching provider logo. Those rows fell back to an initial tile instead of a set profile icon.

## Impact

The permission selector now consistently uses the two-row composer layout whenever it appears. The default newest Hub list also avoids fallback-icon entries such as LFM while retaining models with registered provider branding.

## Validation

- `npm run build`
- `git diff origin/main...HEAD --check`
- Focused provider-logo registry assertion for LFM and visible providers