### PR TITLE
Make patch_unsloth_gguf_save actually protect the save directory

### DIFF
--- a/tests/python/test_gguf_save_rmtree_guard.py
+++ b/tests/python/test_gguf_save_rmtree_guard.py
@@ -40,7 +40,7 @@ def test_patch_unsloth_gguf_save_protects_only_the_save_directory(tmp_path):
     (unrelated / "scratch.bin").write_text("temp")
 
     original_rmtree = shutil.rmtree
-    with patch_unsloth_gguf_save(str(save_dir)):
+    with patch_unsloth_gguf_save(str(save_dir), str(unrelated)):
         shutil.rmtree(str(save_dir))  # protected: no-op
         shutil.rmtree(str(subdir))  # inside the protected tree: no-op
         shutil.rmtree(str(unrelated))  # unrelated temp dir: still deleted
@@ -50,3 +50,25 @@ def test_patch_unsloth_gguf_save_protects_only_the_save_directory(tmp_path):
         assert not unrelated.exists(), "unrelated temp directories must still be cleaned up"
 
     assert shutil.rmtree is original_rmtree, "shutil.rmtree must be restored on exit"
+
+
+def test_patch_unsloth_gguf_save_still_cleans_a_temporary_dir_inside_the_save_directory(tmp_path):
+    # temporary_location defaults to the relative "_unsloth_temporary_saved_buffers",
+    # so it resolves inside the save directory whenever the model is saved to the
+    # current directory. Those scratch buffers must still be cleaned up, otherwise
+    # they are left behind in the saved model and uploaded by the push_to_hub path.
+    patch_unsloth_gguf_save = _load_patch_unsloth_gguf_save()
+
+    save_dir = tmp_path / "saved_model"
+    save_dir.mkdir()
+    (save_dir / "model.safetensors").write_text("weights")
+    nested_temp = save_dir / "_unsloth_temporary_saved_buffers"
+    nested_temp.mkdir()
+    (nested_temp / "scratch.bin").write_text("temp")
+
+    with patch_unsloth_gguf_save(str(save_dir), str(nested_temp)):
+        shutil.rmtree(str(nested_temp))  # configured temp location: still deleted
+        shutil.rmtree(str(save_dir))  # protected: no-op
+
+        assert not nested_temp.exists(), "the configured temporary location must be cleaned up"
+        assert save_dir.exists(), "the save directory itself must still survive"

--- a/tests/python/test_gguf_save_rmtree_guard.py
+++ b/tests/python/test_gguf_save_rmtree_guard.py
@@ -1,0 +1,52 @@
+import ast
+import contextlib
+import os
+import shutil
+from pathlib import Path
+
+
+def _load_patch_unsloth_gguf_save():
+    # Extract the nested patch_unsloth_gguf_save context manager without importing
+    # unsloth (which needs unsloth_zoo / a GPU). It only relies on contextlib, os
+    # and shutil, so it can be exec'd in isolation.
+    source = Path(__file__).parents[2] / "unsloth" / "models" / "sentence_transformer.py"
+    tree = ast.parse(source.read_text(encoding = "utf-8"))
+    funcs = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "patch_unsloth_gguf_save"
+    ]
+    assert len(funcs) == 1, funcs
+    namespace = {"contextlib": contextlib, "os": os, "shutil": shutil}
+    module = ast.Module(body = funcs, type_ignores = [])
+    ast.fix_missing_locations(module)
+    exec(compile(module, str(source), "exec"), namespace)
+    return namespace["patch_unsloth_gguf_save"]
+
+
+def test_patch_unsloth_gguf_save_protects_only_the_save_directory(tmp_path):
+    # The guard must suppress deletion of the save directory (and its subtree) while
+    # still letting unrelated temporary directories be cleaned up, and it must restore
+    # shutil.rmtree on exit.
+    patch_unsloth_gguf_save = _load_patch_unsloth_gguf_save()
+
+    save_dir = tmp_path / "saved_model"
+    save_dir.mkdir()
+    (save_dir / "model.safetensors").write_text("weights")
+    subdir = save_dir / "0_Transformer"
+    subdir.mkdir()
+    unrelated = tmp_path / "_unsloth_temporary_saved_buffers"
+    unrelated.mkdir()
+    (unrelated / "scratch.bin").write_text("temp")
+
+    original_rmtree = shutil.rmtree
+    with patch_unsloth_gguf_save(str(save_dir)):
+        shutil.rmtree(str(save_dir))   # protected: no-op
+        shutil.rmtree(str(subdir))     # inside the protected tree: no-op
+        shutil.rmtree(str(unrelated))  # unrelated temp dir: still deleted
+
+        assert save_dir.exists(), "save directory must survive the guard"
+        assert subdir.exists(), "a subdirectory of the save directory must survive"
+        assert not unrelated.exists(), "unrelated temp directories must still be cleaned up"
+
+    assert shutil.rmtree is original_rmtree, "shutil.rmtree must be restored on exit"

--- a/tests/python/test_gguf_save_rmtree_guard.py
+++ b/tests/python/test_gguf_save_rmtree_guard.py
@@ -41,8 +41,8 @@ def test_patch_unsloth_gguf_save_protects_only_the_save_directory(tmp_path):
 
     original_rmtree = shutil.rmtree
     with patch_unsloth_gguf_save(str(save_dir)):
-        shutil.rmtree(str(save_dir))   # protected: no-op
-        shutil.rmtree(str(subdir))     # inside the protected tree: no-op
+        shutil.rmtree(str(save_dir))  # protected: no-op
+        shutil.rmtree(str(subdir))  # inside the protected tree: no-op
         shutil.rmtree(str(unrelated))  # unrelated temp dir: still deleted
 
         assert save_dir.exists(), "save directory must survive the guard"

--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -188,17 +188,33 @@ def _save_pretrained_gguf(
 
     # 4. Patch environment so Unsloth treats this embedding model correctly
     @contextlib.contextmanager
-    def patch_unsloth_gguf_save(protected_directory):
+    def patch_unsloth_gguf_save(protected_directory, temporary_location = None):
         # Prevent deletion of the directory self.save_pretrained just created (and
-        # anything inside it), while still allowing unrelated temporary directories to
-        # be cleaned up. The previous version saved and restored shutil.rmtree without
-        # ever replacing it, so the guard never actually protected anything.
-        protected = os.path.abspath(protected_directory)
+        # anything inside it), while still allowing temporary directories to be cleaned
+        # up. The previous version saved and restored shutil.rmtree without ever
+        # replacing it, so the guard never actually protected anything.
+        def normalize(path):
+            # normcase so the comparison holds on case-insensitive filesystems.
+            return os.path.normcase(os.path.abspath(os.fspath(path)))
+
+        def is_within(target, directory):
+            return target == directory or target.startswith(directory + os.sep)
+
+        protected = normalize(protected_directory)
+        # temporary_location defaults to a relative path, so it can resolve to a
+        # directory inside the protected tree (for example when saving to "."). Its
+        # cleanup must still run, otherwise scratch buffers are left in the saved
+        # model and get uploaded by the push_to_hub path.
+        temporary = normalize(temporary_location) if temporary_location is not None else None
         original_rmtree = shutil.rmtree
 
         def guarded_rmtree(path, *args, **kwargs):
-            target = os.path.abspath(os.fspath(path))
-            if target == protected or target.startswith(protected + os.sep):
+            target = normalize(path)
+            if target == protected:
+                return
+            if temporary is not None and is_within(target, temporary):
+                return original_rmtree(path, *args, **kwargs)
+            if is_within(target, protected):
                 return
             return original_rmtree(path, *args, **kwargs)
 
@@ -209,7 +225,7 @@ def _save_pretrained_gguf(
             shutil.rmtree = original_rmtree
 
     # 5. Call Unsloth's GGUF saver on the inner model targeting the transformer subdirectory
-    with patch_unsloth_gguf_save(save_directory):
+    with patch_unsloth_gguf_save(save_directory, temporary_location):
         result = unsloth_save_pretrained_gguf(
             inner_model,
             save_directory = transformer_dir,

--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -188,16 +188,28 @@ def _save_pretrained_gguf(
 
     # 4. Patch environment so Unsloth treats this embedding model correctly
     @contextlib.contextmanager
-    def patch_unsloth_gguf_save():
-        # Prevent deletion of the directory self.save_pretrained just created
+    def patch_unsloth_gguf_save(protected_directory):
+        # Prevent deletion of the directory self.save_pretrained just created (and
+        # anything inside it), while still allowing unrelated temporary directories to
+        # be cleaned up. The previous version saved and restored shutil.rmtree without
+        # ever replacing it, so the guard never actually protected anything.
+        protected = os.path.abspath(protected_directory)
         original_rmtree = shutil.rmtree
+
+        def guarded_rmtree(path, *args, **kwargs):
+            target = os.path.abspath(os.fspath(path))
+            if target == protected or target.startswith(protected + os.sep):
+                return
+            return original_rmtree(path, *args, **kwargs)
+
+        shutil.rmtree = guarded_rmtree
         try:
             yield
         finally:
             shutil.rmtree = original_rmtree
 
     # 5. Call Unsloth's GGUF saver on the inner model targeting the transformer subdirectory
-    with patch_unsloth_gguf_save():
+    with patch_unsloth_gguf_save(save_directory):
         result = unsloth_save_pretrained_gguf(
             inner_model,
             save_directory = transformer_dir,


### PR DESCRIPTION
## Summary

`patch_unsloth_gguf_save` in `unsloth/models/sentence_transformer.py` is documented to "Prevent deletion of the directory `self.save_pretrained` just created", but it is a no-op:

```python
@contextlib.contextmanager
def patch_unsloth_gguf_save():
    # Prevent deletion of the directory self.save_pretrained just created
    original_rmtree = shutil.rmtree
    try:
        yield
    finally:
        shutil.rmtree = original_rmtree
```

It saves and restores `shutil.rmtree` but never replaces it, so nothing is guarded. The sibling `patch_unsloth_save` in the same file does patch `shutil.rmtree`, and the adjacent code already computes an absolute path "for later commonpath comparison", so the guard was clearly meant to be there and was left unfinished.

## Fix

Replace `shutil.rmtree` for the duration of the GGUF save with a wrapper that skips deletion of the protected save directory (and its subtree) and delegates every other path to the original `shutil.rmtree`. This makes the documented guard actually work without suppressing the legitimate temporary-directory cleanups (`temporary_location`, the `llama.cpp` build dir) that also run inside the wrapped call. The context manager now takes the directory to protect, and the call site passes `save_directory`.

## Test

Added `tests/python/test_gguf_save_rmtree_guard.py`, a CPU-only test (auto-discovered by the repo's `pytest tests/`, no GPU) that AST-extracts the context manager (unsloth can't be imported without a GPU) and asserts that, inside the guard, deleting the save directory or a subdirectory is a no-op while an unrelated temp directory is still removed, and that `shutil.rmtree` is restored on exit. It fails against the previous no-op version (the save directory gets deleted) and passes with this change.
