### PR TITLE
fix(dataprep): smart_chunk_text single-chunk path leaks internal tensor type when eos_token_id is None

### DIFF
--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -241,6 +241,52 @@ def test_raw_text_loader():
         os.unlink(test_file)
 
 
+def test_smart_chunk_text_single_chunk_no_eos_returns_plain_list():
+    """smart_chunk_text's single-chunk branch must return a plain list for
+    input_ids even when the tokenizer has no eos_token_id, matching the
+    multi-chunk branch's unconditional tolist()/list() conversion."""
+
+    class MockTensor:
+        def __init__(self, data):
+            self.data = data
+
+        def __getitem__(self, idx):
+            return self.data
+
+        def __len__(self):
+            return len(self.data)
+
+        def tolist(self):
+            return self.data
+
+    class MockTokenizerNoEos:
+        def __init__(self):
+            self.eos_token = None
+            self.eos_token_id = None
+
+        def __call__(self, text, return_tensors = None, add_special_tokens = False,):
+            token_ids = list(range(len(text.split())))
+            if return_tensors == "pt":
+                return {"input_ids": [MockTensor(token_ids)]}
+            return {"input_ids": token_ids}
+
+        def decode(self, token_ids, skip_special_tokens = False,):
+            return " ".join(f"word_{i}" for i in token_ids)
+
+    loader = RawTextDataLoader(MockTokenizerNoEos(), chunk_size = 2048, stride = 512)
+    result = loader.smart_chunk_text(
+        "hello world short text", chunk_size = 2048, stride = 512, return_tokenized = True
+    )
+    input_ids = result[0]["input_ids"]
+    assert isinstance(input_ids, list), (
+        f"input_ids should be a plain list even without an eos_token_id, got {type(input_ids)}"
+    )
+    assert input_ids == [0, 1, 2, 3], f"unexpected input_ids: {input_ids}"
+    print("✅ test_smart_chunk_text_single_chunk_no_eos_returns_plain_list passed!")
+    return True
+
+
 if __name__ == "__main__":
     success = test_raw_text_loader()
+    success = test_smart_chunk_text_single_chunk_no_eos_returns_plain_list() and success
     sys.exit(0 if success else 1)

--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -264,13 +264,22 @@ def test_smart_chunk_text_single_chunk_no_eos_returns_plain_list():
             self.eos_token = None
             self.eos_token_id = None
 
-        def __call__(self, text, return_tensors = None, add_special_tokens = False,):
+        def __call__(
+            self,
+            text,
+            return_tensors = None,
+            add_special_tokens = False,
+        ):
             token_ids = list(range(len(text.split())))
             if return_tensors == "pt":
                 return {"input_ids": [MockTensor(token_ids)]}
             return {"input_ids": token_ids}
 
-        def decode(self, token_ids, skip_special_tokens = False,):
+        def decode(
+            self,
+            token_ids,
+            skip_special_tokens = False,
+        ):
             return " ".join(f"word_{i}" for i in token_ids)
 
     loader = RawTextDataLoader(MockTokenizerNoEos(), chunk_size = 2048, stride = 512)
@@ -278,9 +287,9 @@ def test_smart_chunk_text_single_chunk_no_eos_returns_plain_list():
         "hello world short text", chunk_size = 2048, stride = 512, return_tokenized = True
     )
     input_ids = result[0]["input_ids"]
-    assert isinstance(input_ids, list), (
-        f"input_ids should be a plain list even without an eos_token_id, got {type(input_ids)}"
-    )
+    assert isinstance(
+        input_ids, list
+    ), f"input_ids should be a plain list even without an eos_token_id, got {type(input_ids)}"
     assert input_ids == [0, 1, 2, 3], f"unexpected input_ids: {input_ids}"
     print("✅ test_smart_chunk_text_single_chunk_no_eos_returns_plain_list passed!")
     return True

--- a/unsloth/dataprep/raw_text.py
+++ b/unsloth/dataprep/raw_text.py
@@ -154,9 +154,9 @@ class RawTextDataLoader:
         if len(tokens) <= chunk_size:
             # Fits in a single chunk
             if return_tokenized:
+                tokens = tokens.tolist() if hasattr(tokens, "tolist") else list(tokens)
                 eos_token_id = getattr(self.tokenizer, "eos_token_id", None)
                 if eos_token_id is not None:
-                    tokens = tokens.tolist() if hasattr(tokens, "tolist") else list(tokens)
                     tokens.append(eos_token_id)
 
                 attention_mask = [1] * len(tokens)


### PR DESCRIPTION
### Problem

`RawTextDataLoader.smart_chunk_text()` (`unsloth/dataprep/raw_text.py`) has
two branches for building the `input_ids` output, and they disagree on
output type:

**Single-chunk branch (when the whole text fits in `chunk_size`):**
```python
if return_tokenized:
    eos_token_id = getattr(self.tokenizer, "eos_token_id", None)
    if eos_token_id is not None:
        tokens = tokens.tolist() if hasattr(tokens, "tolist") else list(tokens)
        tokens.append(eos_token_id)

    attention_mask = [1] * len(tokens)
    return [{"input_ids": tokens, "attention_mask": attention_mask}]
```
The `tolist()`/`list()` conversion only happens *inside* the
`if eos_token_id is not None:` guard. When the tokenizer has no EOS token
configured, that branch never runs, and `tokens` — whatever
tensor-like object came out of the tokenizer normalization step a few
lines up — is returned as `input_ids` verbatim.

**Multi-chunk branch (a few lines below), for comparison:**
```python
chunk_tokens_list = (
    chunk_tokens.tolist() if hasattr(chunk_tokens, "tolist") else list(chunk_tokens)
)
if end_idx == len(tokens) or len(chunk_tokens_list) == chunk_size:
    eos_token_id = getattr(self.tokenizer, "eos_token_id", None)
    if eos_token_id is not None:
        chunk_tokens_list.append(eos_token_id)
```
Here the conversion runs *unconditionally, before* checking
`eos_token_id` — the correct pattern.

### Impact

`create_causal_dataset()` does `labels = [list(ids) for ids in input_ids]`.
`list()`-ing a tensor produces a list of 0-d tensor elements rather than
plain Python ints, inconsistent with every multi-chunk sample and liable to
break type inference in `Dataset.from_dict()` / downstream
tokenization/collation code that expects plain ints.

### Repro (bare, before fix — via a minimal mock tokenizer, no torch/GPU needed)

```python
loader = RawTextDataLoader(MockTokenizerWithNoEos(), chunk_size=2048, stride=512)
result = loader.smart_chunk_text("hello world short text", chunk_size=2048, stride=512, return_tokenized=True)
type(result[0]["input_ids"])   # MockTensor (or torch.Tensor in practice), not list
```

### Fix

Move the list conversion out of the `eos_token_id` guard, matching the
multi-chunk branch's existing pattern (2-line diff, single-chunk branch
only).

### Testing

Added `test_smart_chunk_text_single_chunk_no_eos_returns_plain_list` to
`tests/test_raw_text.py` (reusing the file's existing `MockTensor`/mock-
tokenizer pattern, no heavy deps). Confirmed:
- red against unfixed code (assertion failure: `input_ids` was the mock
  tensor type, not a list)
- green after the fix
- full `tests/test_raw_text.py` (both test functions) passes:
  `python3 tests/test_raw_text.py` → `✅ All tests passed!` /
  `✅ test_smart_chunk_text_single_chunk_no_eos_returns_plain_list passed!`

`ruff check` and the repo's `scripts/run_ruff_format.py` (kwarg-spacing
formatter): clean.

Note: `tests/test_raw_text.py` doesn't appear to be wired into any
`.github/workflows/*.yml` job as far as I could find — a pre-existing repo
characteristic, not something this PR changes. Verified locally instead.

### Duplicate-work check

Searched merged/closed PRs and issues for `smart_chunk_text` /
`raw_text.py` — found #7126 ("guard smart_chunk_text against stride >=
chunk_size", merged), a different bug in the same function (stride
validation, not the EOS-branch type leak this PR fixes). No open PR
touches this file.

---

*Disclosure: I used AI assistance (Claude) to find this bug and draft the
fix and test. I independently traced both branches, reproduced the type
mismatch against unfixed code with a bare mock-tokenizer repro, verified
the fix red→green, and ran the full local test file + ruff before
submitting.*