### PR TITLE
CI: opt tool-calling smoke tests out of the chat tool approval gate

### DIFF
--- a/.github/workflows/studio-inference-smoke.yml
+++ b/.github/workflows/studio-inference-smoke.yml
@@ -729,6 +729,7 @@ jobs:
                       content, events = post_sse("/v1/chat/completions", {
                           "messages":      [{"role": "user", "content": prompt}],
                           "enable_tools":  True,
+                          "permission_mode": "full",
                           "enabled_tools": enabled,
                           "session_id":    f"{session}-att{attempt_i}",
                           "temperature":   TOOL_PROBE_TEMP,
@@ -818,6 +819,7 @@ jobs:
               content, events = post_sse("/v1/chat/completions", {
                   "messages":      [{"role": "user", "content": "Search the web for 'unsloth ai github' and summarise."}],
                   "enable_tools":  True,
+                  "permission_mode": "full",
                   "enabled_tools": ["web_search"],
                   "session_id":    "ci-tool-calling-web",
                   "temperature":   0.0,

--- a/.github/workflows/studio-mac-inference-smoke.yml
+++ b/.github/workflows/studio-mac-inference-smoke.yml
@@ -612,6 +612,7 @@ jobs:
           content = post_sse("/v1/chat/completions", {
               "messages":      [{"role": "user", "content": "What is 123 * 456? Use the python tool to compute it and tell me the number."}],
               "enable_tools":  True,
+              "permission_mode": "full",
               "enabled_tools": ["python"],
               "session_id":    "ci-tool-calling-py",
               "temperature":   TEMP,
@@ -647,6 +648,7 @@ jobs:
               content = post_sse("/v1/chat/completions", {
                   "messages":      [{"role": "user", "content": "Search the web for 'unsloth ai github' and summarise."}],
                   "enable_tools":  True,
+                  "permission_mode": "full",
                   "enabled_tools": ["web_search"],
                   "session_id":    "ci-tool-calling-web",
                   "temperature":   TEMP,

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -791,6 +791,7 @@ jobs:
           content = post_sse("/v1/chat/completions", {
               "messages":      [{"role": "user", "content": "What is 123 * 456? Use the python tool to compute it and tell me the number."}],
               "enable_tools":  True,
+              "permission_mode": "full",
               "enabled_tools": ["python"],
               "session_id":    "ci-tool-calling-py",
               "temperature":   TEMP,
@@ -816,6 +817,7 @@ jobs:
           content = post_sse("/v1/chat/completions", {
               "messages":      [{"role": "user", "content": "Use the terminal tool to run `echo hello-bash-tool` and tell me the exact output."}],
               "enable_tools":  True,
+              "permission_mode": "full",
               "enabled_tools": ["terminal"],
               "session_id":    "ci-tool-calling-bash",
               "temperature":   TEMP,
@@ -840,6 +842,7 @@ jobs:
               content = post_sse("/v1/chat/completions", {
                   "messages":      [{"role": "user", "content": "Search the web for 'unsloth ai github' and summarise."}],
                   "enable_tools":  True,
+                  "permission_mode": "full",
                   "enabled_tools": ["web_search"],
                   "session_id":    "ci-tool-calling-web",
                   "temperature":   TEMP,


### PR DESCRIPTION
Since the permission-levels feature (#7079), an unset permission_mode on a streaming request with tools enabled defaults to the ask gate. The headless smoke probes never approve, so every Tool calling Tests job across all branches hangs at the approval wait (3600s decision timeout) until the job timeout kills it - reproduced locally and bisected to the gate default in _permission_mode_confirm.

This declares permission_mode full in the seven tool-probe request bodies across the linux, mac, and windows inference smoke workflows. Gate behavior itself stays covered by the tool-policy unit tests.

Verified locally against a live Studio: with the gate engaged the stream stalls at tool_start (awaiting_confirmation) as CI sees; with permission_mode full the same probe completes.