### PR TITLE
Fix Settings layout overflow

### DIFF
--- a/studio/frontend/src/features/settings/components/api-monitor-console.tsx
+++ b/studio/frontend/src/features/settings/components/api-monitor-console.tsx
@@ -111,7 +111,7 @@ function MonitorEntry({
   const reply = replyText || (entry.status === "running" ? "Waiting..." : "No reply");
 
   return (
-    <article className="rounded-lg border border-border/70 bg-background">
+    <article className="min-w-0 rounded-lg border border-border/70 bg-background">
       <button
         type="button"
         onClick={onToggle}

--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -253,7 +253,8 @@ export function SettingsDialog() {
           <DialogDescription className="sr-only">
             {t("settings.dialog.description")}
           </DialogDescription>
-          <div className="flex h-full min-h-0 max-sm:flex-col">
+          {/* Keep tab content from expanding the dialog grid. */}
+          <div className="flex h-full min-h-0 min-w-0 w-full max-sm:flex-col">
             <aside className="font-heading flex w-[248px] shrink-0 flex-col border-r border-sidebar-border bg-muted/20 p-2 dark:border-r-0 max-sm:w-full max-sm:border-r-0 max-sm:border-b max-sm:border-sidebar-border">
               <div className="relative mx-1 mt-3 mb-2 max-sm:hidden">
                 <HugeiconsIcon

--- a/studio/frontend/src/features/settings/tabs/general-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/general-tab.tsx
@@ -654,9 +654,10 @@ export function GeneralTab() {
           description={t("settings.general.rag.embeddingModelDescription", {
             defaultModel: embeddingModel?.defaultEmbeddingModel ?? "",
           })}
+          className="max-[360px]:flex-col max-[360px]:items-stretch max-[360px]:gap-3"
         >
-          <div className="flex flex-col items-end gap-1">
-            <div className="flex items-center gap-2">
+          <div className="flex flex-col items-end gap-1 max-[360px]:w-full">
+            <div className="flex items-center gap-2 max-[360px]:w-full">
               <EmbeddingModelCombobox
                 value={draftEmbeddingModel}
                 onChange={(next) => {
@@ -668,7 +669,7 @@ export function GeneralTab() {
                 disabled={!embeddingModel}
                 placeholder={embeddingModel?.defaultEmbeddingModel ?? ""}
                 ariaLabel={t("settings.general.rag.embeddingModel")}
-                className="w-[220px]"
+                className="w-[220px] max-[360px]:min-w-0 max-[360px]:flex-1"
               />
               <Button
                 variant="outline"

--- a/tests/studio/test_settings_compact_overflow_contract.py
+++ b/tests/studio/test_settings_compact_overflow_contract.py
@@ -1,0 +1,42 @@
+"""Responsive overflow contracts for the settings dialog."""
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+SETTINGS_DIALOG = REPO / "studio/frontend/src/features/settings/settings-dialog.tsx"
+API_MONITOR = (
+    REPO
+    / "studio/frontend/src/features/settings/components/api-monitor-console.tsx"
+)
+GENERAL_TAB = REPO / "studio/frontend/src/features/settings/tabs/general-tab.tsx"
+
+
+def test_dialog_content_can_shrink_inside_the_dialog_grid():
+    source = SETTINGS_DIALOG.read_text(encoding = "utf-8")
+    assert "flex h-full min-h-0 min-w-0 w-full max-sm:flex-col" in source
+    assert "relative flex min-h-0 min-w-0 flex-1 flex-col" in source
+
+
+def test_api_monitor_entries_and_expanded_text_can_shrink():
+    source = API_MONITOR.read_text(encoding = "utf-8")
+    assert (
+        '<article className="min-w-0 rounded-lg border border-border/70 bg-background">'
+        in source
+    )
+    assert (
+        '<section className="flex min-w-0 flex-col rounded-lg border border-border/70 bg-background">'
+        in source
+    )
+    assert source.count(
+        'className="max-h-44 overflow-auto whitespace-pre-wrap break-words'
+    ) == 2
+
+
+def test_embedding_model_controls_stack_on_the_narrowest_viewports():
+    source = GENERAL_TAB.read_text(encoding = "utf-8")
+    assert (
+        'className="max-[360px]:flex-col max-[360px]:items-stretch '
+        'max-[360px]:gap-3"'
+    ) in source
+    assert 'className="w-[220px] max-[360px]:min-w-0 max-[360px]:flex-1"' in source

--- a/tests/studio/test_settings_compact_overflow_contract.py
+++ b/tests/studio/test_settings_compact_overflow_contract.py
@@ -5,10 +5,7 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 SETTINGS_DIALOG = REPO / "studio/frontend/src/features/settings/settings-dialog.tsx"
-API_MONITOR = (
-    REPO
-    / "studio/frontend/src/features/settings/components/api-monitor-console.tsx"
-)
+API_MONITOR = REPO / "studio/frontend/src/features/settings/components/api-monitor-console.tsx"
 GENERAL_TAB = REPO / "studio/frontend/src/features/settings/tabs/general-tab.tsx"
 
 
@@ -21,22 +18,18 @@ def test_dialog_content_can_shrink_inside_the_dialog_grid():
 def test_api_monitor_entries_and_expanded_text_can_shrink():
     source = API_MONITOR.read_text(encoding = "utf-8")
     assert (
-        '<article className="min-w-0 rounded-lg border border-border/70 bg-background">'
-        in source
+        '<article className="min-w-0 rounded-lg border border-border/70 bg-background">' in source
     )
     assert (
         '<section className="flex min-w-0 flex-col rounded-lg border border-border/70 bg-background">'
         in source
     )
-    assert source.count(
-        'className="max-h-44 overflow-auto whitespace-pre-wrap break-words'
-    ) == 2
+    assert source.count('className="max-h-44 overflow-auto whitespace-pre-wrap break-words') == 2
 
 
 def test_embedding_model_controls_stack_on_the_narrowest_viewports():
     source = GENERAL_TAB.read_text(encoding = "utf-8")
     assert (
-        'className="max-[360px]:flex-col max-[360px]:items-stretch '
-        'max-[360px]:gap-3"'
+        'className="max-[360px]:flex-col max-[360px]:items-stretch max-[360px]:gap-3"'
     ) in source
     assert 'className="w-[220px] max-[360px]:min-w-0 max-[360px]:flex-1"' in source


### PR DESCRIPTION
## Summary

- Allow the Settings dialog content wrapper to shrink within the dialog grid.
- Allow API monitor entries to shrink instead of expanding their grid column.
- Stack the embedding model control at phone widths so the combobox and Save button remain visible.
- Add regression contracts for the dialog, API monitor, and compact embedding controls.

## Root cause

`DialogContent` uses a grid layout. Its direct flex child kept its min-content width, so wide API content expanded the grid track beyond the dialog boundary and clipped the right side. Two compact controls also retained fixed min-content widths inside narrower Settings panels.

## Impact

Settings tabs remain within the viewport, API monitor rows no longer create internal horizontal overflow, and the embedding model controls remain usable on narrow phones. Desktop sizing and existing tab behavior are unchanged.

## Validation

- Reproduced the issue at 1051 x 666 before the change.
- Verified all nine Settings tabs at 1051, 800, and 600 pixel widths.
- Verified API monitor entries at 375 and 320 pixels with long unbroken model paths and tool-call payloads.
- Verified the embedding model row at 320 pixels.
- Ran 38 related UI contract tests.
- Ran the new regression contracts on Python 3.10, 3.11, 3.12, and 3.13 in isolated `uv` environments.
- Ran frontend typecheck and production builds on Node 20, 22, and 24.
- Recorded 1,206 passing Studio tests in the expanded sandbox, then reran 23 load and timing tests and 23 hardware dispatch tests independently with all passing.
- Ran `npm run typecheck`.
- Ran `npm run build`.
- Ran `npm run i18n:check`.
- Ran the lockfile, dependency-removal, and script-pin audits.
- Ran `git diff --check`.

## Notes

The API key prefix remains intentionally shortened after creation because the backend does not return the full secret again. This PR fixes unintended layout clipping, not intentional secret redaction or text previews.

The failing Backend CI Python jobs reproduce on current `main` and are unrelated to this frontend change. PR #7169 fixes the incomplete DeepSeek reasoning test shim that causes those failures.

Five ROCm installer test failures reproduced unchanged on the baseline branch and are unrelated to this frontend-only change.

Closes #7161
