### PR TITLE
Fix DeepSeek reasoning test shim

### DIFF
--- a/studio/backend/tests/test_deepseek_v4_thinking_effort.py
+++ b/studio/backend/tests/test_deepseek_v4_thinking_effort.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
@@ -128,15 +127,13 @@ def _kwargs_for(flags: dict, enable_thinking, reasoning_effort):
     """Drive the real backend method with a shim carrying the detected flags."""
     from core.inference.llama_cpp import LlamaCppBackend
 
-    shim = SimpleNamespace(
-        _supports_reasoning = flags["supports_reasoning"],
-        _reasoning_always_on = flags["reasoning_always_on"],
-        _reasoning_style = flags["reasoning_style"],
-        _reasoning_effort_levels = flags["reasoning_effort_levels"],
-        _supports_preserve_thinking = flags["supports_preserve_thinking"],
-    )
-    build = LlamaCppBackend._request_reasoning_kwargs.__get__(shim)
-    return build(enable_thinking, reasoning_effort, None) or {}
+    shim = object.__new__(LlamaCppBackend)
+    shim._supports_reasoning = flags["supports_reasoning"]
+    shim._reasoning_always_on = flags["reasoning_always_on"]
+    shim._reasoning_style = flags["reasoning_style"]
+    shim._reasoning_effort_levels = flags["reasoning_effort_levels"]
+    shim._supports_preserve_thinking = flags["supports_preserve_thinking"]
+    return shim._request_reasoning_kwargs(enable_thinking, reasoning_effort, None) or {}
 
 
 def _flags():


### PR DESCRIPTION
## Summary

- Replace the partial `SimpleNamespace` test shim with an uninitialized real `LlamaCppBackend` instance.
- Keep the test isolated from backend startup while retaining normal method lookup for helper methods.
- Restore the DeepSeek reasoning test coverage across the Backend CI Python matrix.

## Root cause

`_request_reasoning_kwargs` now delegates final normalization to `_coerce_reasoning_effort`. The test bound `_request_reasoning_kwargs` to a `SimpleNamespace`, so normal class method lookup was unavailable and four tests failed with `AttributeError`.

## Impact

This changes test setup only. Production backend behavior is unchanged. The test now exercises the same helper method resolution used by a real `LlamaCppBackend` instance, which makes it less likely to break when the production method delegates to another backend helper.

## Validation

- Reproduced the four failures on current `main`.
- Verified all eight DeepSeek reasoning tests on Python 3.10, 3.11, 3.12, and 3.13 in isolated `uv` environments.
- Ran `git diff --check`.
