### PR TITLE
Studio: clickable sidebar settings cog, long name truncation, Canvas menu opt-in

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1590,7 +1590,7 @@ export function AppSidebar() {
                         useSettingsDialogStore.getState().openDialog();
                       }
                     }}
-                    className="ml-auto flex size-[32px] shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-black/10 hover:text-foreground dark:hover:bg-white/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-data-[collapsible=icon]:hidden"
+                    className="-ml-1 flex size-[32px] shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-black/10 hover:text-foreground dark:hover:bg-white/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-data-[collapsible=icon]:hidden"
                   >
                     <HugeiconsIcon
                       icon={Settings02Icon}

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1561,7 +1561,8 @@ export function AppSidebar() {
                       className="!size-[32px] group-data-[collapsible=icon]:!rounded-full"
                     />
                   </div>
-                  <div className="flex flex-col gap-px leading-tight group-data-[collapsible=icon]:hidden">
+                  {/* min-w-0 so long names truncate instead of pushing the cog out */}
+                  <div className="flex min-w-0 flex-1 flex-col gap-px leading-tight group-data-[collapsible=icon]:hidden">
                     <span className="truncate font-heading text-[13.5px] tracking-[0.025em] dark:tracking-[0.04em] font-semibold text-nav-fg">{displayTitle}</span>
                     <span className="truncate text-[11.5px] tracking-nav text-muted-foreground">Unsloth</span>
                   </div>

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1551,7 +1551,7 @@ export function AppSidebar() {
                 <SidebarMenuButton
                   size="lg"
                   aria-label={t("shell.accountMenu", { name: displayTitle })}
-                  className="sidebar-nav-btn !h-[44px] -my-[3px] gap-[9px] px-2 py-[3px] rounded-[14px] group-data-[collapsible=icon]:!size-[34px] group-data-[collapsible=icon]:!rounded-full group-data-[collapsible=icon]:!p-0 group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:justify-center"
+                  className="sidebar-nav-btn !h-[44px] -my-[3px] gap-[9px] pl-2 pr-[45px] py-[3px] rounded-[14px] group-data-[collapsible=icon]:!size-[34px] group-data-[collapsible=icon]:!rounded-full group-data-[collapsible=icon]:!p-0 group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:justify-center"
                 >
                   <div className="flex shrink-0 items-center">
                     <UserAvatar
@@ -1561,43 +1561,12 @@ export function AppSidebar() {
                       className="!size-[32px] group-data-[collapsible=icon]:!rounded-full"
                     />
                   </div>
-                  {/* min-w-0 so long names truncate instead of pushing the cog out */}
+                  {/* min-w-0 so long names truncate instead of overflowing;
+                      pr on the button reserves room for the settings cog */}
                   <div className="flex min-w-0 flex-1 flex-col gap-px leading-tight group-data-[collapsible=icon]:hidden">
                     <span className="truncate font-heading text-[13.5px] tracking-[0.025em] dark:tracking-[0.04em] font-semibold text-nav-fg">{displayTitle}</span>
                     <span className="truncate text-[11.5px] tracking-nav text-muted-foreground">Unsloth</span>
                   </div>
-                  {/* settings cog; opens the settings dialog directly.
-                      span, not button: nesting a button inside the trigger
-                      button is invalid HTML. */}
-                  <span
-                    role="button"
-                    tabIndex={0}
-                    aria-label={t("shell.navigation.settings")}
-                    onPointerDown={(e) => {
-                      // Radix opens the dropdown on pointerdown; block it.
-                      e.stopPropagation();
-                      e.preventDefault();
-                    }}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      e.preventDefault();
-                      useSettingsDialogStore.getState().openDialog();
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.stopPropagation();
-                        e.preventDefault();
-                        useSettingsDialogStore.getState().openDialog();
-                      }
-                    }}
-                    className="-ml-1 flex size-[32px] shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-black/10 hover:text-foreground dark:hover:bg-white/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-data-[collapsible=icon]:hidden"
-                  >
-                    <HugeiconsIcon
-                      icon={Settings02Icon}
-                      strokeWidth={1.5}
-                      className="!size-[18px]"
-                    />
-                  </span>
                 </SidebarMenuButton>
               </DropdownMenuTrigger>
               <DropdownMenuContent
@@ -1712,6 +1681,20 @@ export function AppSidebar() {
                 )}
               </DropdownMenuContent>
             </DropdownMenu>
+            {/* settings cog; sibling of the trigger (buttons cannot nest),
+                overlaid on the row's right edge, opens settings directly */}
+            <button
+              type="button"
+              aria-label={t("shell.navigation.settings")}
+              onClick={() => useSettingsDialogStore.getState().openDialog()}
+              className="absolute right-2 top-1/2 flex size-[32px] -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-black/10 hover:text-foreground dark:hover:bg-white/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-data-[collapsible=icon]:hidden"
+            >
+              <HugeiconsIcon
+                icon={Settings02Icon}
+                strokeWidth={1.5}
+                className="!size-[18px]"
+              />
+            </button>
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarFooter>

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1565,10 +1565,31 @@ export function AppSidebar() {
                     <span className="truncate font-heading text-[13.5px] tracking-[0.025em] dark:tracking-[0.04em] font-semibold text-nav-fg">{displayTitle}</span>
                     <span className="truncate text-[11.5px] tracking-nav text-muted-foreground">Unsloth</span>
                   </div>
-                  {/* settings cog (replaces the up/down chevron) */}
+                  {/* settings cog; opens the settings dialog directly.
+                      span, not button: nesting a button inside the trigger
+                      button is invalid HTML. */}
                   <span
-                    aria-hidden="true"
-                    className="ml-auto flex size-[32px] shrink-0 items-center justify-center text-muted-foreground group-data-[collapsible=icon]:hidden"
+                    role="button"
+                    tabIndex={0}
+                    aria-label={t("shell.navigation.settings")}
+                    onPointerDown={(e) => {
+                      // Radix opens the dropdown on pointerdown; block it.
+                      e.stopPropagation();
+                      e.preventDefault();
+                    }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                      useSettingsDialogStore.getState().openDialog();
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.stopPropagation();
+                        e.preventDefault();
+                        useSettingsDialogStore.getState().openDialog();
+                      }
+                    }}
+                    className="ml-auto flex size-[32px] shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-black/10 hover:text-foreground dark:hover:bg-white/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-data-[collapsible=icon]:hidden"
                   >
                     <HugeiconsIcon
                       icon={Settings02Icon}

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1326,7 +1326,9 @@ const ThreadWelcome: FC<{
 
   useEffect(() => {
     // Prefer the nickname; otherwise first name only. Blank falls back to none.
-    const name = nickname.trim() || (displayName.trim().split(/\s+/)[0] ?? "");
+    const raw = nickname.trim() || (displayName.trim().split(/\s+/)[0] ?? "");
+    // Cap very long names so the greeting stays on one line.
+    const name = raw.length > 20 ? `${raw.slice(0, 20)}…` : raw;
     setWelcome(buildWelcome(new Date().getHours(), name));
   }, [displayName, nickname]);
 

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -2709,6 +2709,7 @@ const ComposerToolsMenu: FC<{ side?: "top" | "bottom" }> = ({
   const setCodeToolsEnabled = useChatRuntimeStore((s) => s.setCodeToolsEnabled);
   const artifactsEnabled = useChatRuntimeStore((s) => s.artifactsEnabled);
   const setArtifactsEnabled = useChatRuntimeStore((s) => s.setArtifactsEnabled);
+  const showCanvasMenuItem = useChatRuntimeStore((s) => s.showCanvasMenuItem);
   const mcpEnabledForChat = useChatRuntimeStore((s) => s.mcpEnabledForChat);
   const setMcpEnabledForChat = useChatRuntimeStore(
     (s) => s.setMcpEnabledForChat,
@@ -2959,7 +2960,8 @@ const ComposerToolsMenu: FC<{ side?: "top" | "bottom" }> = ({
         </DropdownMenuSubContent>
       </DropdownMenuSub>
     ),
-    canvas: (
+    // Hidden by default; enabled from Settings > Chat > Canvas.
+    canvas: showCanvasMenuItem ? (
       <DropdownMenuItem
         className={artifactsEnabled ? "text-primary font-medium" : undefined}
         onSelect={() => setArtifactsEnabled(!artifactsEnabled)}
@@ -2970,7 +2972,7 @@ const ComposerToolsMenu: FC<{ side?: "top" | "bottom" }> = ({
           <HugeiconsIcon icon={Tick02Icon} strokeWidth={2} className="ml-auto" />
         ) : null}
       </DropdownMenuItem>
-    ),
+    ) : null,
     bypassPermissions: <BypassPermissionsMenuItem />,
     projects: (
       <DropdownMenuSub>

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -613,6 +613,7 @@ export function SharedComposer({
   );
   const artifactsEnabled = useChatRuntimeStore((s) => s.artifactsEnabled);
   const setArtifactsEnabled = useChatRuntimeStore((s) => s.setArtifactsEnabled);
+  const showCanvasMenuItem = useChatRuntimeStore((s) => s.showCanvasMenuItem);
   const permissionMode = useChatRuntimeStore((s) => s.permissionMode);
   const mcpEnabledForChat = useChatRuntimeStore((s) => s.mcpEnabledForChat);
   const setMcpEnabledForChat = useChatRuntimeStore(
@@ -1411,7 +1412,8 @@ export function SharedComposer({
         </DropdownMenuSubContent>
       </DropdownMenuSub>
     ),
-    canvas: (
+    // Hidden by default; enabled from Settings > Chat > Canvas.
+    canvas: showCanvasMenuItem ? (
       <DropdownMenuItem
         className={artifactsEnabled ? "text-primary font-medium" : undefined}
         onSelect={() => setArtifactsEnabled(!artifactsEnabled)}
@@ -1422,7 +1424,7 @@ export function SharedComposer({
           <HugeiconsIcon icon={Tick02Icon} strokeWidth={2} className="ml-auto" />
         ) : null}
       </DropdownMenuItem>
-    ),
+    ) : null,
     bypassPermissions: <BypassPermissionsMenuItem />,
     projects: (
       <DropdownMenuSub>

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -23,6 +23,7 @@ import {
   savePersistedChatSettingsPatch,
 } from "../utils/chat-settings-storage";
 import { useExternalProvidersStore } from "./external-providers-store";
+import { PLUS_MENU_PINS_STORAGE_KEY } from "./plus-menu-prefs-store";
 
 const HF_TOKEN_KEY = "unsloth_hf_token";
 const HF_TOKEN_CHANGED_EVENT = "unsloth:hf-token-changed";
@@ -356,6 +357,24 @@ function saveBool(key: string, value: boolean): void {
     localStorage.setItem(key, value ? "true" : "false");
   } catch {
     // ignore
+  }
+}
+
+// The visibility flag shipped after the menu pins, so when it is absent,
+// profiles that had explicitly pinned Canvas keep it visible.
+function loadShowCanvasMenuItem(): boolean {
+  const stored = loadOptionalBool(CHAT_SHOW_CANVAS_MENU_ITEM_KEY);
+  if (stored !== null) return stored;
+  if (!canUseStorage()) return false;
+  try {
+    const raw = localStorage.getItem(PLUS_MENU_PINS_STORAGE_KEY);
+    if (raw === null) return false;
+    const parsed = JSON.parse(raw) as {
+      state?: { pins?: { canvas?: boolean } };
+    };
+    return parsed.state?.pins?.canvas === true;
+  } catch {
+    return false;
   }
 }
 
@@ -1152,7 +1171,7 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
   codeToolsEnabled: loadBool(CHAT_CODE_TOOLS_ENABLED_KEY, false),
   imageToolsEnabled: loadBool(CHAT_IMAGE_TOOLS_ENABLED_KEY, false),
   artifactsEnabled: loadBool(CHAT_ARTIFACTS_ENABLED_KEY, false),
-  showCanvasMenuItem: loadBool(CHAT_SHOW_CANVAS_MENU_ITEM_KEY, false),
+  showCanvasMenuItem: loadShowCanvasMenuItem(),
   collapseHtmlArtifacts: loadBool(CHAT_COLLAPSE_HTML_ARTIFACTS_KEY, false),
   allowArtifactNetworkAccess: loadBool(
     CHAT_ALLOW_ARTIFACT_NETWORK_ACCESS_KEY,

--- a/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
+++ b/studio/frontend/src/features/chat/stores/chat-runtime-store.ts
@@ -31,6 +31,8 @@ export const CHAT_TOOLS_ENABLED_KEY = "unsloth_chat_tools_enabled";
 export const CHAT_CODE_TOOLS_ENABLED_KEY = "unsloth_chat_code_tools_enabled";
 export const CHAT_IMAGE_TOOLS_ENABLED_KEY = "unsloth_chat_image_tools_enabled";
 export const CHAT_ARTIFACTS_ENABLED_KEY = "unsloth_chat_artifacts_enabled";
+export const CHAT_SHOW_CANVAS_MENU_ITEM_KEY =
+  "unsloth_chat_show_canvas_menu_item";
 export const CHAT_COLLAPSE_HTML_ARTIFACTS_KEY =
   "unsloth_chat_collapse_html_artifacts";
 export const CHAT_ALLOW_ARTIFACT_NETWORK_ACCESS_KEY =
@@ -642,6 +644,8 @@ type ChatRuntimeStore = {
   codeToolsEnabled: boolean;
   imageToolsEnabled: boolean;
   artifactsEnabled: boolean;
+  // Whether the Canvas toggle is offered in the composer + menu (hidden by default).
+  showCanvasMenuItem: boolean;
   collapseHtmlArtifacts: boolean;
   allowArtifactNetworkAccess: boolean;
   mcpEnabledForChat: boolean;
@@ -818,6 +822,7 @@ type ChatRuntimeStore = {
     enabled: boolean,
     options?: { persist?: boolean },
   ) => void;
+  setShowCanvasMenuItem: (enabled: boolean) => void;
   setCollapseHtmlArtifacts: (enabled: boolean) => void;
   setAllowArtifactNetworkAccess: (enabled: boolean) => void;
   setMcpEnabledForChat: (enabled: boolean) => void;
@@ -1147,6 +1152,7 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
   codeToolsEnabled: loadBool(CHAT_CODE_TOOLS_ENABLED_KEY, false),
   imageToolsEnabled: loadBool(CHAT_IMAGE_TOOLS_ENABLED_KEY, false),
   artifactsEnabled: loadBool(CHAT_ARTIFACTS_ENABLED_KEY, false),
+  showCanvasMenuItem: loadBool(CHAT_SHOW_CANVAS_MENU_ITEM_KEY, false),
   collapseHtmlArtifacts: loadBool(CHAT_COLLAPSE_HTML_ARTIFACTS_KEY, false),
   allowArtifactNetworkAccess: loadBool(
     CHAT_ALLOW_ARTIFACT_NETWORK_ACCESS_KEY,
@@ -1503,6 +1509,11 @@ export const useChatRuntimeStore = create<ChatRuntimeStore>((set, get) => ({
         saveBool(CHAT_ARTIFACTS_ENABLED_KEY, artifactsEnabled);
       }
       return { artifactsEnabled };
+    }),
+  setShowCanvasMenuItem: (showCanvasMenuItem) =>
+    set(() => {
+      saveBool(CHAT_SHOW_CANVAS_MENU_ITEM_KEY, showCanvasMenuItem);
+      return { showCanvasMenuItem };
     }),
   setCollapseHtmlArtifacts: (collapseHtmlArtifacts) =>
     set((state) => {

--- a/studio/frontend/src/features/chat/stores/plus-menu-prefs-store.ts
+++ b/studio/frontend/src/features/chat/stores/plus-menu-prefs-store.ts
@@ -44,6 +44,8 @@ const DEFAULT_PINS: Record<PlusMenuItemId, boolean> = {
   bypassPermissions: false,
 };
 
+export const PLUS_MENU_PINS_STORAGE_KEY = "unsloth_plus_menu_pins";
+
 export interface PlusMenuPrefsState {
   pins: Record<PlusMenuItemId, boolean>;
   setPin: (id: PlusMenuItemId, value: boolean) => void;
@@ -72,7 +74,7 @@ export const usePlusMenuPrefsStore = create<PlusMenuPrefsState>()(
         })),
     }),
     {
-      name: "unsloth_plus_menu_pins",
+      name: PLUS_MENU_PINS_STORAGE_KEY,
       // Backfill any ids added in a later release so persisted state from an
       // older version still resolves every menu item.
       merge: (persisted, current) => {

--- a/studio/frontend/src/features/settings/tabs/chat-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/chat-tab.tsx
@@ -413,19 +413,8 @@ export function ChatTab() {
         }
       >
         {PLUS_MENU_SETTINGS.map((item) => (
-          <SettingsRow
-            key={item.id}
-            label={item.label}
-            icon={item.icon}
-            description={
-              // Canvas toggles visibility, not placement: off removes it
-              // from the menu entirely (the default) instead of moving it
-              // into "More".
-              item.id === "canvas"
-                ? "Off hides Canvas from the menu entirely."
-                : undefined
-            }
-          >
+          <SettingsRow key={item.id} label={item.label} icon={item.icon}>
+            {/* Canvas toggles menu visibility; the rest toggle pin placement. */}
             <Switch
               checked={
                 item.id === "canvas" ? showCanvasMenuItem : plusPins[item.id]

--- a/studio/frontend/src/features/settings/tabs/chat-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/chat-tab.tsx
@@ -412,14 +412,29 @@ export function ChatTab() {
           </>
         }
       >
-        {PLUS_MENU_SETTINGS.filter(
-          // Canvas only appears in the menu when opted in under Canvas below.
-          (item) => item.id !== "canvas" || showCanvasMenuItem,
-        ).map((item) => (
-          <SettingsRow key={item.id} label={item.label} icon={item.icon}>
+        {PLUS_MENU_SETTINGS.map((item) => (
+          <SettingsRow
+            key={item.id}
+            label={item.label}
+            icon={item.icon}
+            description={
+              // Canvas toggles visibility, not placement: off removes it
+              // from the menu entirely (the default) instead of moving it
+              // into "More".
+              item.id === "canvas"
+                ? "Off hides Canvas from the menu entirely."
+                : undefined
+            }
+          >
             <Switch
-              checked={plusPins[item.id]}
-              onCheckedChange={() => togglePlusPin(item.id)}
+              checked={
+                item.id === "canvas" ? showCanvasMenuItem : plusPins[item.id]
+              }
+              onCheckedChange={
+                item.id === "canvas"
+                  ? setShowCanvasMenuItem
+                  : () => togglePlusPin(item.id)
+              }
             />
           </SettingsRow>
         ))}
@@ -454,15 +469,6 @@ export function ChatTab() {
       </SettingsSection>
 
       <SettingsSection title={t("settings.chat.artifacts.title")}>
-        <SettingsRow
-          label="Canvas in chat menu"
-          description="Offer the Canvas toggle in chat's + side menu. HTML canvases still render either way."
-        >
-          <Switch
-            checked={showCanvasMenuItem}
-            onCheckedChange={setShowCanvasMenuItem}
-          />
-        </SettingsRow>
         <SettingsRow
           label={t("settings.chat.artifacts.collapseHtmlBlocks")}
           description={t(

--- a/studio/frontend/src/features/settings/tabs/chat-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/chat-tab.tsx
@@ -175,6 +175,12 @@ export function ChatTab() {
   const [clearing, setClearing] = useState(false);
   const autoTitle = useChatRuntimeStore((state) => state.autoTitle);
   const setAutoTitle = useChatRuntimeStore((state) => state.setAutoTitle);
+  const showCanvasMenuItem = useChatRuntimeStore(
+    (state) => state.showCanvasMenuItem,
+  );
+  const setShowCanvasMenuItem = useChatRuntimeStore(
+    (state) => state.setShowCanvasMenuItem,
+  );
   const collapseHtmlArtifacts = useChatRuntimeStore(
     (state) => state.collapseHtmlArtifacts,
   );
@@ -406,7 +412,10 @@ export function ChatTab() {
           </>
         }
       >
-        {PLUS_MENU_SETTINGS.map((item) => (
+        {PLUS_MENU_SETTINGS.filter(
+          // Canvas only appears in the menu when opted in under Canvas below.
+          (item) => item.id !== "canvas" || showCanvasMenuItem,
+        ).map((item) => (
           <SettingsRow key={item.id} label={item.label} icon={item.icon}>
             <Switch
               checked={plusPins[item.id]}
@@ -445,6 +454,15 @@ export function ChatTab() {
       </SettingsSection>
 
       <SettingsSection title={t("settings.chat.artifacts.title")}>
+        <SettingsRow
+          label="Canvas in chat menu"
+          description="Offer the Canvas toggle in chat's + side menu. HTML canvases still render either way."
+        >
+          <Switch
+            checked={showCanvasMenuItem}
+            onCheckedChange={setShowCanvasMenuItem}
+          />
+        </SettingsRow>
         <SettingsRow
           label={t("settings.chat.artifacts.collapseHtmlBlocks")}
           description={t(


### PR DESCRIPTION
### What

Started as a sidebar polish and grew into a set of small chat shell fixes: the account row settings cog is now a real control that opens settings directly, long profile names truncate instead of breaking layouts, and the Canvas chat menu item is hidden by default behind a settings opt-in.

### Changes

**Sidebar account row**
- The settings cog was a decorative `aria-hidden` span inside the account dropdown trigger. It is now a real `<button>` rendered as a sibling of the trigger (nested buttons are invalid HTML), absolutely positioned over the right edge of the row, following the same pattern as `SidebarMenuAction`. Clicking it opens the settings dialog directly via `useSettingsDialogStore.getState().openDialog()`; clicking the rest of the row still opens the account menu.
- Circular hover treatment per existing icon button conventions (`rounded-full`, `hover:bg-black/10`, `dark:hover:bg-white/10`) plus a focus-visible ring and `aria-label`. As a native button it gains focus normally, so the dialog's `captureOpener()` focus restoration works.
- The name column now has `min-w-0 flex-1` and the trigger reserves right padding, so very long profile names truncate with an ellipsis instead of pushing the cog out of the row.

**Welcome greeting**
- Names over 20 characters are capped with an ellipsis before being interpolated into the greeting line, so an unbroken long name no longer wraps the headline.

**Canvas chat menu item**
- HTML canvases render regardless of the + menu Canvas toggle (the fenced-HTML path is unconditional), so the menu item mostly confused people. It is now hidden by default. The Canvas row stays in the Settings > Chat > Chat menu list, but its switch controls visibility instead of placement: off (the default) removes Canvas from the + menu entirely, on brings it back (persisted in localStorage as `unsloth_chat_show_canvas_menu_item`).
- The `artifactsEnabled` behavior itself is unchanged: the render_html tool exposure, canvas instruction, in-place code collapsing, and the composer pill all work as before for users who have it on.

### Testing

- `npm run build` (tsc + vite) passes.
- Built and served the changes from a local Studio instance and confirmed the running server picks up the new bundle. Sidebar collapsed state keeps hiding the cog as before.
- Review feedback on the earlier nested-control approach was verified against the code and addressed by the sibling-button restructure.

