### PR TITLE
Allow API key for Ollama connections

### DIFF
--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -276,8 +276,9 @@ PROVIDER_REGISTRY: dict[str, dict[str, Any]] = {
         "auth_header": "Authorization",
         "auth_prefix": "Bearer ",
         "notes": (
-            "Local Ollama server. OpenAI-compatible /v1/chat/completions; "
-            "no API key. Surfaced via CUSTOM_PROVIDER_PRESETS in the frontend."
+            "Ollama server (local or cloud). OpenAI-compatible "
+            "/v1/chat/completions; API key optional (required by Ollama "
+            "cloud). Surfaced via CUSTOM_PROVIDER_PRESETS in the frontend."
         ),
         "hidden": True,
     },

--- a/studio/frontend/src/features/chat/chat-providers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-providers-dialog.tsx
@@ -244,8 +244,8 @@ export function ChatProvidersSettings({
     (s) => s.setConnectionsEnabled,
   );
   const isCustomProvider = isCustomProviderType(providerType);
-  // Local presets (Ollama, llama.cpp) never use API keys — hide the field.
-  // vLLM may optionally use a bearer token on secured deployments.
+  // llama.cpp hides the key field. Ollama and vLLM show an optional key:
+  // Ollama cloud and secured vLLM need one; local servers leave it empty.
   const showApiKeyField = !customPresetSkipsApiKeyField(providerType);
   const showReasoningToggle = supportsProviderReasoningToggle(providerType);
 

--- a/studio/frontend/src/features/chat/external-providers.ts
+++ b/studio/frontend/src/features/chat/external-providers.ts
@@ -184,11 +184,12 @@ export function supportsRemoteModelCatalog(
   );
 }
 
-/** Presets that skip the API-key field (local servers with no auth by default). */
+/** Presets that hide the API-key field. Ollama is not skipped: Ollama cloud
+ * requires a key; local servers leave the optional field empty. */
 export function customPresetSkipsApiKeyField(
   providerType: string | null | undefined,
 ): boolean {
-  return providerType === "ollama" || providerType === "llama_cpp";
+  return providerType === "llama_cpp";
 }
 
 /** Catalog load plus optional manual model IDs. */


### PR DESCRIPTION
Fixes #7163

## Problem

The Connections form (Settings > Connections) hid the API key field for the Ollama preset. `customPresetSkipsApiKeyField` in `external-providers.ts` returned true for both `ollama` and `llama_cpp`, so there was no way to enter a key. Ollama cloud requires one, so cloud endpoints could only be used through a Custom connection workaround.

## Fix

Everything downstream was already key capable: the provider registry defines `Authorization: Bearer` auth for `ollama`, and model listing, connection tests, and chat requests all forward a stored key. The only blocker was the hidden input.

- `external-providers.ts`: remove `ollama` from `customPresetSkipsApiKeyField`, only `llama_cpp` still hides the field
- `chat-providers-dialog.tsx`: update the stale comment at the `showApiKeyField` computation
- `providers.py`: update the ollama registry note from "no API key" to "API key optional (required by Ollama cloud)"

Since Ollama is a custom provider type, the existing form logic already labels the field as optional, stores the key locally per connection, and removes a stored key when the field is saved empty.

## Behavior

- Ollama cloud: set Base URL to `https://ollama.com/v1` and paste a key, requests send `Authorization: Bearer <key>`
- Local Ollama: leave the field empty, no auth header is sent (avoids the httpx "Illegal header value" failure on an empty Bearer), so existing setups are unaffected

## Testing

- `tsc -b` passes
- Verified against the backend client: an ollama provider with a key produces `Authorization: Bearer <key>`; with an empty key no auth header is present
- Rebuilt the frontend and confirmed the Connections form shows "API key (optional)" for Ollama