### PR TITLE
Fix Hermes resumed one-shot approval handling

### DIFF
--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -197,12 +197,7 @@ def _hermes_resume_oneshot_args(args: list[str]) -> list[str]:
             raise typer.BadParameter(
                 "Hermes cannot resume a one-shot session with --usage-file; remove that option."
             )
-        prefix = ["chat", "-Q"]
-        if "--yolo" not in rewritten:
-            prefix.append("--yolo")
-        if "--accept-hooks" not in rewritten:
-            prefix.append("--accept-hooks")
-        rewritten = prefix + rewritten
+        rewritten = ["chat", "-Q", *rewritten]
         return rewritten
     return args
 

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -2897,14 +2897,7 @@ def test_hermes_resume_oneshot_uses_session_aware_chat(fake_studio, monkeypatch)
         monkeypatch,
         ["hermes", "--persist", "--resume", "session-id", "-z", "follow up"],
     )
-    assert captured["command"][1:] == [
-        "chat",
-        "-Q",
-        "--resume",
-        "session-id",
-        "-q",
-        "follow up",
-    ]
+    assert captured["command"][1:] == ["chat", "-Q", "--resume", "session-id", "-q", "follow up"]
 
 
 def test_hermes_resume_oneshot_forwards_only_explicit_approvals(fake_studio, monkeypatch):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -2813,8 +2813,6 @@ def test_resume_persist_only_agents_have_no_resume_token(fake_studio, monkeypatc
             [
                 "chat",
                 "-Q",
-                "--yolo",
-                "--accept-hooks",
                 "--resume",
                 "session-id",
                 "-q",
@@ -2823,19 +2821,17 @@ def test_resume_persist_only_agents_have_no_resume_token(fake_studio, monkeypatc
         ),
         (
             ["-rsession-id", "-zfollow up"],
-            ["chat", "-Q", "--yolo", "--accept-hooks", "-rsession-id", "-qfollow up"],
+            ["chat", "-Q", "-rsession-id", "-qfollow up"],
         ),
         (
             ["-c=project", "-z=follow up"],
-            ["chat", "-Q", "--yolo", "--accept-hooks", "-c=project", "-q=follow up"],
+            ["chat", "-Q", "-c=project", "-q=follow up"],
         ),
         (
             ["-r", "session-id", "--oneshot=follow up"],
             [
                 "chat",
                 "-Q",
-                "--yolo",
-                "--accept-hooks",
                 "-r",
                 "session-id",
                 "--query=follow up",
@@ -2846,8 +2842,6 @@ def test_resume_persist_only_agents_have_no_resume_token(fake_studio, monkeypatc
             [
                 "chat",
                 "-Q",
-                "--yolo",
-                "--accept-hooks",
                 "--continue",
                 "project",
                 "-q",
@@ -2859,7 +2853,6 @@ def test_resume_persist_only_agents_have_no_resume_token(fake_studio, monkeypatc
             [
                 "chat",
                 "-Q",
-                "--accept-hooks",
                 "--yolo",
                 "--resume",
                 "session-id",
@@ -2872,7 +2865,6 @@ def test_resume_persist_only_agents_have_no_resume_token(fake_studio, monkeypatc
             [
                 "chat",
                 "-Q",
-                "--yolo",
                 "--accept-hooks",
                 "--resume",
                 "session-id",
@@ -2885,8 +2877,6 @@ def test_resume_persist_only_agents_have_no_resume_token(fake_studio, monkeypatc
             [
                 "chat",
                 "-Q",
-                "--yolo",
-                "--accept-hooks",
                 "--resume",
                 "chat",
                 "-q",
@@ -2910,13 +2900,37 @@ def test_hermes_resume_oneshot_uses_session_aware_chat(fake_studio, monkeypatch)
     assert captured["command"][1:] == [
         "chat",
         "-Q",
-        "--yolo",
-        "--accept-hooks",
         "--resume",
         "session-id",
         "-q",
         "follow up",
     ]
+
+
+def test_hermes_resume_oneshot_forwards_only_explicit_approvals(fake_studio, monkeypatch):
+    monkeypatch.setattr(start.shutil, "which", lambda _: "/usr/local/bin/hermes")
+
+    yolo = _capture_launch(
+        monkeypatch,
+        ["hermes", "--persist", "--yolo", "--resume", "session-id", "-z", "follow up"],
+    )
+    assert "--yolo" in yolo["command"]
+    assert "--accept-hooks" not in yolo["command"]
+
+    accept_hooks = _capture_launch(
+        monkeypatch,
+        [
+            "hermes",
+            "--persist",
+            "--resume",
+            "session-id",
+            "-z",
+            "follow up",
+            "--accept-hooks",
+        ],
+    )
+    assert "--yolo" not in accept_hooks["command"]
+    assert "--accept-hooks" in accept_hooks["command"]
 
 
 @pytest.mark.parametrize("usage_arg", ["--usage-file", "--usage-file=usage.json"])


### PR DESCRIPTION
## Summary

- preserve the `hermes chat -Q` rewrite needed for resumed one-shot prompts
- stop silently adding Hermes `--yolo` and `--accept-hooks`
- preserve either approval flag only when the user explicitly supplies it
- add helper-level and command-construction regression coverage

## Security impact

Previously, `unsloth start hermes --persist --resume <id> -z <prompt>` injected both approval-bypass flags even when Unsloth's explicit `--yolo` option was false. This could auto-approve dangerous tool actions and unseen shell hooks in resumed sessions.

After this change, a plain resumed one-shot carries neither approval flag. Unsloth `--yolo` forwards only Hermes `--yolo`, while native `--accept-hooks` remains available as an explicit pass-through argument.

## Validation

- pre-fix regression run: 10 expected failures proving both flags were injected
- post-fix focused Hermes suite: 14 passed
- full `unsloth_cli/tests/test_start.py`: 210 passed, 3 skipped
- `python -m py_compile` passed for the modified files
- `ruff check` and `git diff --check` passed
