### PR TITLE
don't kill live llama-servers when a new Studio instance starts

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -8227,6 +8227,11 @@ class LlamaCppBackend:
                         if not is_ours:
                             continue
 
+                        # A live parent means a running Studio (or the user's
+                        # shell) still owns it -- not an orphan.
+                        if LlamaCppBackend._pid_parent_is_alive(proc.info["pid"]):
+                            continue
+
                         proc.kill()
                         killed += 1
                         logger.info(
@@ -8277,6 +8282,9 @@ class LlamaCppBackend:
                         binary.is_relative_to(root) for root in resolved_roots
                     )
                     if not owned:
+                        continue
+
+                    if LlamaCppBackend._pid_parent_is_alive(pid):
                         continue
 
                     try:

--- a/studio/backend/tests/test_llama_cpp_wait_for_vram_settle.py
+++ b/studio/backend/tests/test_llama_cpp_wait_for_vram_settle.py
@@ -373,6 +373,9 @@ def test_kill_orphaned_servers_returns_count():
     with (
         patch.dict(sys.modules, {"psutil": fake_psutil}),
         patch.dict(os.environ, {"LLAMA_SERVER_PATH": fake_path}),
+        patch.object(
+            LlamaCppBackend, "_pid_parent_is_alive", staticmethod(lambda pid: False)
+        ),
     ):
         n = LlamaCppBackend._kill_orphaned_servers()
     assert n == 1, "only the Studio-owned orphan should be counted"
@@ -384,9 +387,53 @@ def test_kill_orphaned_servers_returns_count():
     with (
         patch.dict(sys.modules, {"psutil": fake_psutil}),
         patch.dict(os.environ, {"LLAMA_SERVER_PATH": fake_path}),
+        patch.object(
+            LlamaCppBackend, "_pid_parent_is_alive", staticmethod(lambda pid: False)
+        ),
     ):
         assert LlamaCppBackend._kill_orphaned_servers() == 0
     assert killed == []
+
+
+def test_kill_orphaned_servers_spares_live_parent():
+    """A Studio-owned llama-server whose parent is still running is not an
+    orphan (a live Studio or the user's shell owns it) and must never be
+    killed; only the true orphan (parent gone) is reaped."""
+    import os
+
+    mypid = os.getpid()
+    fake_path = "/tmp/unsloth-test-llama/llama-server"
+    killed: list[int] = []
+
+    class _FakeProc:
+        def __init__(self, pid, name, exe):
+            self.info = {"pid": pid, "name": name, "exe": exe}
+
+        def kill(self):
+            killed.append(self.info["pid"])
+
+    live_parent = _FakeProc(mypid + 1, "llama-server", fake_path)
+    true_orphan = _FakeProc(mypid + 2, "llama-server", fake_path)
+
+    fake_psutil = _types.ModuleType("psutil")
+    fake_psutil.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
+    fake_psutil.AccessDenied = type("AccessDenied", (Exception,), {})
+    fake_psutil.ZombieProcess = type("ZombieProcess", (Exception,), {})
+    fake_psutil.process_iter = lambda attrs = None: [live_parent, true_orphan]
+
+    with (
+        patch.dict(sys.modules, {"psutil": fake_psutil}),
+        patch.dict(os.environ, {"LLAMA_SERVER_PATH": fake_path}),
+        patch.object(LlamaCppBackend, "_reap_recorded_pid", staticmethod(lambda: 0)),
+        patch.object(
+            LlamaCppBackend,
+            "_pid_parent_is_alive",
+            staticmethod(lambda pid: pid == mypid + 1),
+        ),
+    ):
+        n = LlamaCppBackend._kill_orphaned_servers()
+    assert n == 1, "only the true orphan should be reaped"
+    assert killed == [mypid + 2], "the live-parent server must be spared"
 
 
 def test_startup_reaper_arms_settle_timestamp():

--- a/studio/backend/tests/test_llama_cpp_wait_for_vram_settle.py
+++ b/studio/backend/tests/test_llama_cpp_wait_for_vram_settle.py
@@ -373,9 +373,7 @@ def test_kill_orphaned_servers_returns_count():
     with (
         patch.dict(sys.modules, {"psutil": fake_psutil}),
         patch.dict(os.environ, {"LLAMA_SERVER_PATH": fake_path}),
-        patch.object(
-            LlamaCppBackend, "_pid_parent_is_alive", staticmethod(lambda pid: False)
-        ),
+        patch.object(LlamaCppBackend, "_pid_parent_is_alive", staticmethod(lambda pid: False)),
     ):
         n = LlamaCppBackend._kill_orphaned_servers()
     assert n == 1, "only the Studio-owned orphan should be counted"
@@ -387,9 +385,7 @@ def test_kill_orphaned_servers_returns_count():
     with (
         patch.dict(sys.modules, {"psutil": fake_psutil}),
         patch.dict(os.environ, {"LLAMA_SERVER_PATH": fake_path}),
-        patch.object(
-            LlamaCppBackend, "_pid_parent_is_alive", staticmethod(lambda pid: False)
-        ),
+        patch.object(LlamaCppBackend, "_pid_parent_is_alive", staticmethod(lambda pid: False)),
     ):
         assert LlamaCppBackend._kill_orphaned_servers() == 0
     assert killed == []


### PR DESCRIPTION
Starting a second Studio instance killed the first instance's llama-server mid-generation chats died with "Lost connection to the model server".

The startup orphan reaper (_kill_orphaned_servers) killed every llama-server under a Studio install root without checking whether it was actually orphaned. It also killed user-launched llama-servers and its own instance's embed server (surfacing as a bogus "GPU start failed" CPU fallback).

Fix: skip processes whose parent is still alive, reusing _pid_parent_is_alive(the same guard the pidfile reaper already uses), in both the psutil path and the Linux pgrep fallback. True orphans (parent gone) are still reaped.

Repro: load a GGUF model, start a long generation, run `unsloth studio -p <port>` in another terminal — the stream died within ~3s. With the fix it completes, and a genuinely orphaned server is still cleaned up.