### PR TITLE
Studio: don't apply nest_asyncio on plain CLI starts (breaks asyncio on Python 3.14+)

### DIFF
--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -1356,14 +1356,12 @@ def run_server(
 
     import asyncio
 
-    # nest_asyncio exists for Colab/IPython, where the main thread already runs an
-    # event loop that the blocking waits below would otherwise collide with. Apply
-    # it only when a loop is actually running (a plain CLI start has nothing to
-    # nest) AND only on Python <= 3.13. On 3.14+ asyncio moved task tracking into C
-    # and nest_asyncio's Task patch leaves asyncio.current_task() returning None;
-    # apply() patches globally, so it also breaks the background uvicorn loop below
-    # and every request 500s, for notebook/embedded starts too, not just the CLI.
-    # nest_asyncio is archived upstream, so no 3.14 fix is coming; skip it there.
+    # nest_asyncio is for Colab/IPython, where the main thread already runs a loop
+    # the blocking waits below would collide with. Apply it only with a loop running
+    # (a plain CLI start has nothing to nest) and only on Python <= 3.13: on 3.14+
+    # its global Task patch leaves asyncio.current_task() None (tracking moved into
+    # C), which also breaks the background uvicorn loop and 500s every request. It
+    # is archived upstream, so no 3.14 fix is coming; skip it there.
     if sys.version_info < (3, 14):
         try:
             asyncio.get_running_loop()

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -1356,18 +1356,22 @@ def run_server(
 
     import asyncio
 
-    # nest_asyncio exists for Colab/IPython, where the main thread already runs
-    # an event loop that blocking waits below would otherwise collide with. Its
-    # Task patches break asyncio.current_task() on Python 3.14+ (task tracking
-    # moved into C), so only apply it when a loop is actually running — a plain
-    # CLI start has nothing to nest and must stay unpatched.
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        pass
-    else:
-        import nest_asyncio
-        nest_asyncio.apply()
+    # nest_asyncio exists for Colab/IPython, where the main thread already runs an
+    # event loop that the blocking waits below would otherwise collide with. Apply
+    # it only when a loop is actually running (a plain CLI start has nothing to
+    # nest) AND only on Python <= 3.13. On 3.14+ asyncio moved task tracking into C
+    # and nest_asyncio's Task patch leaves asyncio.current_task() returning None;
+    # apply() patches globally, so it also breaks the background uvicorn loop below
+    # and every request 500s, for notebook/embedded starts too, not just the CLI.
+    # nest_asyncio is archived upstream, so no 3.14 fix is coming; skip it there.
+    if sys.version_info < (3, 14):
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+        else:
+            import nest_asyncio
+            nest_asyncio.apply()
 
     from threading import Thread, Event
     import uvicorn

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -1367,7 +1367,6 @@ def run_server(
         pass
     else:
         import nest_asyncio
-
         nest_asyncio.apply()
 
     from threading import Thread, Event

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -1354,11 +1354,22 @@ def run_server(
     if secure:
         os.environ["UNSLOTH_SECURE"] = "1"
 
-    import nest_asyncio
-
-    nest_asyncio.apply()
-
     import asyncio
+
+    # nest_asyncio exists for Colab/IPython, where the main thread already runs
+    # an event loop that blocking waits below would otherwise collide with. Its
+    # Task patches break asyncio.current_task() on Python 3.14+ (task tracking
+    # moved into C), so only apply it when a loop is actually running — a plain
+    # CLI start has nothing to nest and must stay unpatched.
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    else:
+        import nest_asyncio
+
+        nest_asyncio.apply()
+
     from threading import Thread, Event
     import uvicorn
 


### PR DESCRIPTION
## Problem

`run.py` calls `nest_asyncio.apply()` unconditionally at startup. On Python 3.14, asyncio's task tracking moved into C (`asyncio.current_task()` reads C-level state that nest_asyncio's patched task step never sets), so with the patch applied `current_task()` returns `None` inside every request coroutine. anyio then fails on any thread-pool hop — including StaticFiles serving every frontend asset:

```
File ".../anyio/_backends/_asyncio.py", line 422, in __enter__
    task_state = _task_states[host_task]
File ".../weakref.py", line 326, in __getitem__
    return self.data[ref(key)]
TypeError: cannot create weak reference to 'NoneType' object
```

Every request 500s; Studio is unusable on 3.14. Minimal repro (Python 3.14.6, anyio 4.13):

```python
import nest_asyncio, asyncio, anyio
nest_asyncio.apply()
async def main():
    print(asyncio.current_task())          # None
    await anyio.to_thread.run_sync(lambda: 1)  # TypeError
asyncio.run(main())
```

nest_asyncio is archived upstream, so no fix is coming on its side.

## Change

Only apply nest_asyncio when the current thread already has a running event loop — the Colab/IPython case it exists for. A plain CLI start has nothing to nest and stays unpatched, which is exactly the environment where Python 3.14 users hit the crash. Notebook behavior on <= 3.13 is unchanged.

## Tested

On Python 3.14.6: backend starts, `/` and `/assets/*.js` (the previously-crashing StaticFiles thread-pool path) return 200, API routes respond normally. Repro script above confirms the failure mode and that skipping the patch avoids it.