### PR TITLE
Propagate fp8 block_size before the early return in get_lora_parameters_bias

### DIFF
--- a/tests/python/test_get_lora_parameters_bias_fp8_block_size.py
+++ b/tests/python/test_get_lora_parameters_bias_fp8_block_size.py
@@ -9,9 +9,7 @@ def _load_function(name):
     source = Path(__file__).parents[2] / "unsloth" / "kernels" / "utils.py"
     tree = ast.parse(source.read_text(encoding = "utf-8"))
     funcs = [
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, ast.FunctionDef) and node.name == name
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == name
     ]
     assert len(funcs) == 1, (name, funcs)
     namespace = {"getattr": getattr, "_FP8_WEIGHT_DTYPES": ()}

--- a/tests/python/test_get_lora_parameters_bias_fp8_block_size.py
+++ b/tests/python/test_get_lora_parameters_bias_fp8_block_size.py
@@ -1,0 +1,54 @@
+import ast
+from pathlib import Path
+
+
+def _load_function(name):
+    # Extract a function from kernels/utils.py without importing unsloth (which
+    # needs a GPU / torch / bitsandbytes). The functions exercised here only use
+    # getattr and the _FP8_WEIGHT_DTYPES name on the paths under test.
+    source = Path(__file__).parents[2] / "unsloth" / "kernels" / "utils.py"
+    tree = ast.parse(source.read_text(encoding = "utf-8"))
+    funcs = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    ]
+    assert len(funcs) == 1, (name, funcs)
+    namespace = {"getattr": getattr, "_FP8_WEIGHT_DTYPES": ()}
+    module = ast.Module(body = funcs, type_ignores = [])
+    ast.fix_missing_locations(module)
+    exec(compile(module, str(source), "exec"), namespace)
+    return namespace[name]
+
+
+class _Obj:
+    pass
+
+
+def _make_disabled_block_fp8_proj(block_size):
+    # A merged/disabled projection whose base layer is a block-fp8 weight that
+    # ships a non-default block size on its checkpoint.
+    weight = _Obj()
+    weight.quant_state = _Obj()
+    base_layer = _Obj()
+    base_layer.weight = weight
+    base_layer.quant_method = "fp8"
+    base_layer.block_size = block_size
+    base_layer.bias = None
+    proj = _Obj()
+    proj.base_layer = base_layer
+    proj.merged = True
+    proj.disable_adapters = True
+    return proj, weight.quant_state
+
+
+def test_bias_variant_propagates_fp8_block_size_on_disabled_path():
+    # Downstream fp8 kernels read getattr(weight_scale, "block_size", [128, 128]),
+    # so the checkpoint's real block size must survive the merged/disabled path,
+    # exactly as it does for the non-bias sibling get_lora_parameters.
+    get_lora_parameters_bias = _load_function("get_lora_parameters_bias")
+
+    proj, weight_scale = _make_disabled_block_fp8_proj([64, 128])
+    get_lora_parameters_bias(proj)
+
+    assert getattr(weight_scale, "block_size", [128, 128]) == [64, 128]

--- a/tests/python/test_get_lora_parameters_bias_fp8_block_size.py
+++ b/tests/python/test_get_lora_parameters_bias_fp8_block_size.py
@@ -50,3 +50,33 @@ def test_bias_variant_propagates_fp8_block_size_on_disabled_path():
     get_lora_parameters_bias(proj)
 
     assert getattr(weight_scale, "block_size", [128, 128]) == [64, 128]
+
+
+def _make_decompressed_merged_proj():
+    # A merged compressed-tensors layer that was decompressed back to bf16. It keeps
+    # quant_method == "fp8" from the checkpoint metadata, but the live weight is bf16
+    # so there is no quant state to attach a block size to.
+    weight = _Obj()
+    weight.dtype = "bfloat16"
+    base_layer = _Obj()
+    base_layer.weight = weight
+    base_layer.quant_method = "fp8"
+    base_layer.block_size = [128, 128]
+    base_layer.bias = None
+    proj = _Obj()
+    proj.base_layer = base_layer
+    proj.merged = True
+    proj.disable_adapters = True
+    return proj
+
+
+def test_bias_variant_keeps_none_quant_state_for_decompressed_layer():
+    # Such a layer has no quant state, and fast_linear_forward relies on getting
+    # W_quant None back so it can fall back to a plain matmul, so setting the block
+    # size must not assume a quant state is present.
+    get_lora_parameters_bias = _load_function("get_lora_parameters_bias")
+
+    W, W_quant = get_lora_parameters_bias(_make_decompressed_merged_proj())[:2]
+
+    assert W_quant is None
+    assert getattr(W, "block_size", None) == [128, 128]

--- a/tests/python/test_get_lora_parameters_fp8_block_size.py
+++ b/tests/python/test_get_lora_parameters_fp8_block_size.py
@@ -1,0 +1,81 @@
+import ast
+from pathlib import Path
+
+
+def _load_function(name):
+    # Extract a function from kernels/utils.py without importing unsloth (which
+    # needs a GPU / torch / bitsandbytes). get_lora_parameters only uses getattr,
+    # hasattr and the _FP8_WEIGHT_DTYPES name on the paths under test.
+    source = Path(__file__).parents[2] / "unsloth" / "kernels" / "utils.py"
+    tree = ast.parse(source.read_text(encoding = "utf-8"))
+    funcs = [
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == name
+    ]
+    assert len(funcs) == 1, (name, funcs)
+    namespace = {"getattr": getattr, "hasattr": hasattr, "_FP8_WEIGHT_DTYPES": ()}
+    module = ast.Module(body = funcs, type_ignores = [])
+    ast.fix_missing_locations(module)
+    exec(compile(module, str(source), "exec"), namespace)
+    return namespace[name]
+
+
+class _Obj:
+    pass
+
+
+def _make_disabled_block_fp8_proj(block_size):
+    # A merged/disabled projection whose base layer is a block-fp8 weight that
+    # ships a non-default block size on its checkpoint.
+    weight = _Obj()
+    weight.quant_state = _Obj()
+    base_layer = _Obj()
+    base_layer.weight = weight
+    base_layer.quant_method = "fp8"
+    base_layer.block_size = block_size
+    proj = _Obj()
+    proj.base_layer = base_layer
+    proj.merged = True
+    proj.disable_adapters = True
+    return proj, weight.quant_state
+
+
+def test_propagates_fp8_block_size_on_disabled_path():
+    # get_lora_parameters already sets block_size before its early return; downstream
+    # fp8 kernels read getattr(weight_scale, "block_size", [128, 128]), so the
+    # checkpoint's real block size must survive the merged/disabled path.
+    get_lora_parameters = _load_function("get_lora_parameters")
+
+    proj, weight_scale = _make_disabled_block_fp8_proj([64, 128])
+    get_lora_parameters(proj)
+
+    assert getattr(weight_scale, "block_size", [128, 128]) == [64, 128]
+
+
+def _make_decompressed_merged_proj():
+    # A merged compressed-tensors layer that was decompressed back to bf16. It keeps
+    # quant_method == "fp8" from the checkpoint metadata, but the live weight is bf16
+    # so there is no quant state to attach a block size to.
+    weight = _Obj()
+    weight.dtype = "bfloat16"
+    base_layer = _Obj()
+    base_layer.weight = weight
+    base_layer.quant_method = "fp8"
+    base_layer.block_size = [128, 128]
+    proj = _Obj()
+    proj.base_layer = base_layer
+    proj.merged = True
+    proj.disable_adapters = True
+    return proj
+
+
+def test_keeps_none_quant_state_for_decompressed_layer():
+    # Mirrors the get_lora_parameters_bias guard: with no quant state, assigning
+    # W_quant.block_size must not assume one is present, or it raises AttributeError
+    # on None. fast_lora relies on getting W_quant None back to fall back to a plain
+    # matmul, so this path must stay crash-free.
+    get_lora_parameters = _load_function("get_lora_parameters")
+
+    W, W_quant = get_lora_parameters(_make_decompressed_merged_proj())[:2]
+
+    assert W_quant is None
+    assert getattr(W, "block_size", None) == [128, 128]

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -325,7 +325,10 @@ def get_lora_parameters(proj):
     if getattr(base_layer, "quant_method", None) == "fp8":
         # we need to somehow store and pass this information :)
         W.block_size = getattr(base_layer, "block_size", [128, 128])
-        W_quant.block_size = W.block_size
+        # A decompressed compressed-tensors layer keeps quant_method == "fp8" while its
+        # weight is back to bf16, so it has no quant state to carry the block size.
+        if W_quant is not None:
+            W_quant.block_size = W.block_size
 
     # if not hasattr(proj, "disable_adapters") or proj.disable_adapters or proj.merged:
     if getattr(proj, "disable_adapters", True) or proj.merged:

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -378,7 +378,10 @@ def get_lora_parameters_bias(proj):
     if getattr(base_layer, "quant_method", None) == "fp8":
         # we need to somehow store and pass this information :)
         W.block_size = getattr(base_layer, "block_size", [128, 128])
-        W_quant.block_size = W.block_size
+        # A decompressed compressed-tensors layer keeps quant_method == "fp8" while its
+        # weight is back to bf16, so it has no quant state to carry the block size.
+        if W_quant is not None:
+            W_quant.block_size = W.block_size
 
     # if not hasattr(proj, "disable_adapters") or proj.disable_adapters or proj.merged:
     if getattr(proj, "disable_adapters", True) or proj.merged:

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -375,14 +375,14 @@ def get_lora_parameters_bias(proj):
         if W_quant is None:
             W_quant = getattr(base_layer, "weight_scale", None)
 
-    # if not hasattr(proj, "disable_adapters") or proj.disable_adapters or proj.merged:
-    if getattr(proj, "disable_adapters", True) or proj.merged:
-        return W, W_quant, None, None, None, base_layer.bias
-
     if getattr(base_layer, "quant_method", None) == "fp8":
         # we need to somehow store and pass this information :)
         W.block_size = getattr(base_layer, "block_size", [128, 128])
         W_quant.block_size = W.block_size
+
+    # if not hasattr(proj, "disable_adapters") or proj.disable_adapters or proj.merged:
+    if getattr(proj, "disable_adapters", True) or proj.merged:
+        return W, W_quant, None, None, None, base_layer.bias
 
     adapter = getattr(proj, "active_adapters", None)
     if adapter is None:


### PR DESCRIPTION
## Summary

`get_lora_parameters_bias` in `unsloth/kernels/utils.py` propagates the fp8 `block_size` onto `W` / `W_quant` only *after* its `disable_adapters` / `merged` early return:

```python
    if getattr(proj, "disable_adapters", True) or proj.merged:
        return W, W_quant, None, None, None, base_layer.bias

    if getattr(base_layer, "quant_method", None) == "fp8":
        W.block_size = getattr(base_layer, "block_size", [128, 128])
        W_quant.block_size = W.block_size
```

So on the merged / disabled path (merged inference, DPO reference model) the block is dead code: a block-fp8 weight never gets its real `block_size` attached, and the downstream fp8 kernels (`fp8.py`, which read `getattr(weight_scale, "block_size", [128, 128])`) silently fall back to `[128, 128]`. A block-fp8 checkpoint whose real block size is not `[128, 128]` is then dequantized with the wrong block size.

The non-bias sibling `get_lora_parameters` already sets `block_size` *before* its early return, so the two helpers disagree for the same layer.

## Fix

Move the fp8 `block_size` block ahead of the early return, so `get_lora_parameters_bias` matches the long-standing ordering of `get_lora_parameters`. Common `[128, 128]` fp8 models are unaffected; the change only restores the correct block size for non-`[128, 128]` block-fp8 checkpoints on the bias/merged path.

## Test

Added `tests/python/test_get_lora_parameters_bias_fp8_block_size.py`, a CPU-only test (auto-discovered by `pytest tests/`, no GPU). It AST-extracts `get_lora_parameters_bias` (unsloth needs a GPU to import) and, for a merged/disabled block-fp8 projection shipping `block_size = [64, 128]`, asserts that value survives onto the returned weight scale. It fails before this change (the block size drops to `[128, 128]`) and passes after.
