### PR TITLE
Stabilize Studio regression tests

### DIFF
--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -258,15 +258,29 @@ def test_watchdog_no_op_when_worker_superseded(monkeypatch):
 def test_new_run_gets_its_own_watchdog(monkeypatch):
     # A stale watchdog sleeping on an old proc must not stop a new run's stop from
     # creating its own watcher.
-    monkeypatch.setitem(_G, "_STOP_GRACE_S", 100.0)
-    monkeypatch.setitem(_G, "_STOP_TIMEOUT_S", 100.0)
     b = TrainingBackend()
-    _record_force_terminate(monkeypatch, b)
+    started = []
+    release = threading.Event()
+
+    def _blocked_watchdog(
+        target_proc,
+        cancel,
+        watched_job_id = None,
+    ):
+        started.append(target_proc)
+        # Block until the test's finally releases us (always reached), so a superseded
+        # watchdog stays alive regardless of scheduler load: no timeout can expire mid
+        # assertion and fail the test. The thread is a daemon, so even a release missed
+        # on a pre-cleanup abort never blocks process exit.
+        release.wait()
+
+    monkeypatch.setattr(b, "_stop_watchdog_loop", _blocked_watchdog)
 
     old_proc = _FakeProc(alive = True)
     b._proc = old_proc
     b._start_stop_watchdog(cancel = False)
     first_wd = b._stop_watchdog
+    assert _wait_until(lambda: started == [old_proc])
 
     # New run: fresh worker replaces the handle; its stop must get a new watcher
     # even though the old (superseded) watchdog is still alive.
@@ -276,12 +290,12 @@ def test_new_run_gets_its_own_watchdog(monkeypatch):
     second_wd = b._stop_watchdog
 
     try:
+        assert _wait_until(lambda: started == [old_proc, new_proc])
         assert first_wd.is_alive()
         assert second_wd is not first_wd, "a new run must get its own watchdog"
         assert b._stop_watchdog_proc is new_proc
     finally:
-        old_proc._alive = False
-        new_proc._alive = False
+        release.set()
         first_wd.join(timeout = 5)
         second_wd.join(timeout = 5)
 

--- a/studio/backend/tests/test_training_stop_watchdog.py
+++ b/studio/backend/tests/test_training_stop_watchdog.py
@@ -268,10 +268,8 @@ def test_new_run_gets_its_own_watchdog(monkeypatch):
         watched_job_id = None,
     ):
         started.append(target_proc)
-        # Block until the test's finally releases us (always reached), so a superseded
-        # watchdog stays alive regardless of scheduler load: no timeout can expire mid
-        # assertion and fail the test. The thread is a daemon, so even a release missed
-        # on a pre-cleanup abort never blocks process exit.
+        # No timeout: the finally always releases this, so a superseded watchdog stays
+        # alive through the assertions regardless of load; as a daemon it can't hang exit.
         release.wait()
 
     monkeypatch.setattr(b, "_stop_watchdog_loop", _blocked_watchdog)

--- a/tests/studio/test_studio_text_descender_clipping.py
+++ b/tests/studio/test_studio_text_descender_clipping.py
@@ -34,17 +34,22 @@ def test_model_selector_trigger_label_uses_leading_tight():
 
 def test_sidebar_account_block_uses_leading_tight():
     src = _read(APP_SIDEBAR)
-    # Match the account-block parent div regardless of its gap utility; this
-    # guard is about the leading-* class, not the spacing.
-    pattern = re.compile(
-        r'<div\s+className="flex\s+flex-col\s+gap-\S+\s+(\S+)\s+group-data-\[collapsible=icon\]:hidden">',
-    )
-    matches = pattern.findall(src)
+    class_names = re.findall(r'<div\s+className="([^"]+)"', src)
+    required = {
+        "flex",
+        "flex-1",
+        "flex-col",
+        "group-data-[collapsible=icon]:hidden",
+    }
+    matches = [classes for classes in class_names if required <= set(classes.split())]
     assert matches, "could not find sidebar account-block parent div"
-    leading_classes = [m for m in matches if m.startswith("leading-")]
-    assert leading_classes, f"no leading-* class on sidebar account-block parent: {matches}"
-    for cls in leading_classes:
-        assert cls == "leading-tight", f"sidebar account-block must use leading-tight, got: {cls}"
+    for classes in matches:
+        leading_classes = [cls for cls in classes.split() if cls.startswith("leading-")]
+        assert leading_classes, f"no leading-* class on sidebar account-block parent: {classes}"
+        for cls in leading_classes:
+            assert (
+                cls == "leading-tight"
+            ), f"sidebar account-block must use leading-tight, got: {cls}"
 
 
 def test_no_truncate_plus_leading_none_in_changed_files():


### PR DESCRIPTION
## Summary

- Match the sidebar account block by stable class membership instead of utility order.
- Hold the old watchdog thread with an event while verifying that a replacement process gets a new watchdog.

## Root cause

The sidebar test encoded an obsolete class order. The component still uses `leading-tight`, but additional layout utilities made the ordered regular expression miss the account block.

The watchdog test replaced the watched process and then asserted that the old thread was still alive. The old thread is expected to exit after that replacement, so the assertion raced with correct production behavior.

## Impact

This is test-only. Production behavior is unchanged. The regression guards still fail when the account block loses `leading-tight` or when a replacement process does not receive its own watchdog.

## Validation

- Full watchdog module: 30 passed on Python 3.10, 3.11, 3.12, and 3.13.
- Formerly flaky watchdog case: 100 consecutive iterations passed on each Python version.
- Text descender regression module: 3 passed.
- Sidebar matcher mutation checks covered reordered utilities, wrong leading, missing leading, and missing account identity.
- Pre-commit hooks passed for both changed files.
