### PR TITLE
fix(save): unsloth_push_to_hub_gguf(save_method="lora") raises NameError

### DIFF
--- a/tests/saving/test_export_dispatch.py
+++ b/tests/saving/test_export_dispatch.py
@@ -8,6 +8,8 @@ regressions that pure AST checks cannot (e.g. wrong scheme/suffix/outtype passed
 
 from __future__ import annotations
 
+import inspect
+
 import pytest
 
 import unsloth.save as save_mod
@@ -164,6 +166,40 @@ def test_push_to_hub_gguf_lora_skips_non_main_process(monkeypatch):
     )
     assert result is None
     assert calls == []
+
+
+def test_push_to_hub_gguf_skips_non_main_process_before_merged_conversion(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        save_mod,
+        "unsloth_save_pretrained_gguf",
+        lambda **kw: calls.append(kw),
+    )
+    result = save_mod.unsloth_push_to_hub_gguf(
+        _FakeModel(),
+        "repo/id",
+        tokenizer = object(),
+        is_main_process = False,
+    )
+    assert result is None
+    assert calls == []
+
+
+def test_push_to_hub_gguf_preserves_positional_max_shard_size():
+    bound = inspect.signature(save_mod.unsloth_push_to_hub_gguf).bind(
+        _FakeModel(),
+        "repo/id",
+        object(),
+        "q4_k_m",
+        None,
+        None,
+        None,
+        None,
+        "token",
+        "50GB",
+    )
+    assert bound.arguments["max_shard_size"] == "50GB"
+    assert "is_main_process" not in bound.arguments
 
 
 # -- torchao PTQ / QAT dispatch ------------------------------------------------------------

--- a/tests/saving/test_export_dispatch.py
+++ b/tests/saving/test_export_dispatch.py
@@ -126,6 +126,46 @@ def test_gguf_lora_push_to_hub_is_rejected(tmp_path):
         )
 
 
+# The above rejection points users at push_to_hub_gguf(save_method='lora'), so that path
+# has to work; it is only ever exercised here.
+
+
+def test_push_to_hub_gguf_lora_dispatches(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        save_mod,
+        "_unsloth_save_lora_gguf",
+        lambda model, tok, sd, **kw: seen.update(kw),
+    )
+    save_mod.unsloth_push_to_hub_gguf(
+        _FakeModel(),
+        "repo/id",
+        tokenizer = object(),
+        save_method = "lora",
+        quantization_method = "q8_0",
+    )
+    assert seen.get("outtype") == "q8_0"
+    assert seen.get("push_to_hub") is True
+
+
+def test_push_to_hub_gguf_lora_skips_non_main_process(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        save_mod,
+        "_unsloth_save_lora_gguf",
+        lambda *a, **kw: calls.append(kw),
+    )
+    result = save_mod.unsloth_push_to_hub_gguf(
+        _FakeModel(),
+        "repo/id",
+        tokenizer = object(),
+        save_method = "lora",
+        is_main_process = False,
+    )
+    assert result is None
+    assert calls == []
+
+
 # -- torchao PTQ / QAT dispatch ------------------------------------------------------------
 
 

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -3132,6 +3132,7 @@ def unsloth_push_to_hub_gguf(
     commit_message: Optional[str] = "Trained with Unsloth",
     private: Optional[bool] = None,
     token: Union[bool, str, None] = None,
+    is_main_process: bool = True,
     max_shard_size: Union[int, str, None] = "5GB",
     create_pr: bool = False,
     safe_serialization: bool = True,
@@ -3233,6 +3234,7 @@ def unsloth_push_to_hub_gguf(
             first_conversion = first_conversion,
             push_to_hub = False,  # Never push from here
             token = token,  # forwarded so imatrix_file=True can read a gated/private upstream
+            is_main_process = is_main_process,
             max_shard_size = max_shard_size,
             safe_serialization = safe_serialization,
             temporary_location = temporary_location,

--- a/unsloth/save.py
+++ b/unsloth/save.py
@@ -3132,7 +3132,6 @@ def unsloth_push_to_hub_gguf(
     commit_message: Optional[str] = "Trained with Unsloth",
     private: Optional[bool] = None,
     token: Union[bool, str, None] = None,
-    is_main_process: bool = True,
     max_shard_size: Union[int, str, None] = "5GB",
     create_pr: bool = False,
     safe_serialization: bool = True,
@@ -3144,6 +3143,7 @@ def unsloth_push_to_hub_gguf(
     datasets: Optional[List[str]] = None,
     save_method: str = None,
     imatrix_file = None,
+    is_main_process: bool = True,
 ):
     """
     Same as .push_to_hub(...) except 4bit weights are auto
@@ -3176,11 +3176,11 @@ def unsloth_push_to_hub_gguf(
     """
     if tokenizer is None:
         raise ValueError("Unsloth: Saving to GGUF must have a tokenizer.")
+    if not is_main_process:
+        return None
 
     # save_method="lora" exports the adapter itself as a GGUF LoRA (not a merged model).
     if save_method is not None and str(save_method).lower() == "lora":
-        if not is_main_process:
-            return None  # only the main rank converts and uploads, like the local lora branch
         _qm = quantization_method
         if isinstance(_qm, (list, tuple)) and len(_qm) == 1:
             _qm = _qm[0]  # the gguf API allows a list; unwrap a single outtype


### PR DESCRIPTION
`unsloth_push_to_hub_gguf` reads `is_main_process` at `save.py:3181` but never declares it:

```python
if save_method is not None and str(save_method).lower() == "lora":
    if not is_main_process:        # <-- NameError, always
```

Its twin `unsloth_save_pretrained_gguf` declares it (`:2783`) and uses it identically (`:2839`). The LoRA branch was copied between the twins; the parameter it depends on wasn't. There's no module-level `is_main_process`, so the name resolves as a global load and the branch raises `NameError` every time.

The path is the one the codebase actively points users at — `save.py:2842`:

```python
raise ValueError(
    "Unsloth: Please use .push_to_hub_gguf(save_method='lora') instead of "
    ".save_pretrained_gguf(save_method='lora', push_to_hub=True)."
)
```

so the documented escape hatch is the broken call. It's bound as `model.push_to_hub_gguf` at `:5359` (text) and `:5374` (vision). No distributed setup needed — it fires on the default path.

## The fix

Add `is_main_process: bool = True` to the signature, positioned as in the twin. I also forwarded it to `unsloth_save_pretrained_gguf` on the merged path (`:3237`) — otherwise the new parameter would be honored on the LoRA branch and silently ignored on the other one. Default stays `True`, so nothing changes for existing callers.

Happy to drop the forwarding line if you'd rather keep this to the crash fix alone.

## Verification

Static — the two twins resolve the name in different scopes (`symtable` on each function):

```
unsloth_save_pretrained_gguf   is_main_process: local=True  global=False param=True
unsloth_push_to_hub_gguf       is_main_process: local=False global=True  param=False   <-- before
unsloth_push_to_hub_gguf       is_main_process: local=True  global=False param=True    <-- after
```

Dynamic — before: `NameError: name 'is_main_process' is not defined`. After: dispatches to `_unsloth_save_lora_gguf` with `outtype='f16'`, `push_to_hub=True`; `is_main_process=False` returns `None` without converting. As a control, `save_method=None` gets past the branch and dies on an unrelated stub, so the fault is branch-specific.

Two regression tests added to `tests/saving/test_export_dispatch.py`, matching the file's existing CPU-only monkeypatch style. Verified red before the fix (both fail with the `NameError` at `save.py:3181`), green after.

- `tests/saving/test_export_dispatch.py`: 11 passed (9 existing + 2 new)
- `tests/saving/test_export_api_surface.py`, `test_imatrix_export.py`, `test_quant_method_none_normalization.py`: 25 passed
- `test_fix_sentencepiece_gguf_robustness.py` errors at collection with `TypeError: Descriptors cannot be created directly` — a protobuf-version issue in my env, identical on a pristine tree.
- `ruff check unsloth unsloth_cli tests cli.py` clean.

## Why nothing caught this

`tests/saving/test_export_dispatch.py` exercises `save_method="lora"` three times, but only against `unsloth_save_pretrained_gguf` — the twin that has the parameter. `test_export_api_surface.py::test_gguf_savers_have_lora_branch` does name `unsloth_push_to_hub_gguf`, but it's a static AST check that never executes the body. One test covers the function statically, another covers the branch dynamically; the combination didn't exist until now.

`ruff` would have flagged it — `F821 Undefined name 'is_main_process'` — but `pyproject.toml:1326` lists `F821` in `lint.ignore`, so the rule is off repo-wide (understandable alongside the `F403`/`F405` ignores). I haven't touched that; just noting why the linter is silent here. FWIW the same run also flags `unsloth_push_to_hub` as undefined, which may be worth a separate look.

---

*Disclosure — correcting my original wording, which implied a human did the checking: this contribution is fully AI-authored and autonomous (Claude Code, acting on this account). An AI found the bug, ran the repro, wrote the tests, and wrote this description; the human operator of this account did not hand-review the diff or run the tests. The verification above is real and re-runnable from the diff — it was just done by the AI, not a person. Please review it as unsupervised AI output, and tell me if that is not something you want here.*

