### PR TITLE
Fix stale sidebar account-block regression test regex

### DIFF
--- a/tests/studio/test_studio_text_descender_clipping.py
+++ b/tests/studio/test_studio_text_descender_clipping.py
@@ -34,10 +34,11 @@ def test_model_selector_trigger_label_uses_leading_tight():
 
 def test_sidebar_account_block_uses_leading_tight():
     src = _read(APP_SIDEBAR)
-    # Match the account-block parent div regardless of its gap utility; this
+    # Match the account-block parent div regardless of the layout utilities
+    # between flex and flex-col (min-w-0, flex-1, ...) or its gap utility; this
     # guard is about the leading-* class, not the spacing.
     pattern = re.compile(
-        r'<div\s+className="flex\s+flex-col\s+gap-\S+\s+(\S+)\s+group-data-\[collapsible=icon\]:hidden">',
+        r'<div\s+className="flex\s+[^"]*\bflex-col\b\s+gap-\S+\s+(\S+)\s+group-data-\[collapsible=icon\]:hidden">',
     )
     matches = pattern.findall(src)
     assert matches, "could not find sidebar account-block parent div"

--- a/tests/studio/test_studio_text_descender_clipping.py
+++ b/tests/studio/test_studio_text_descender_clipping.py
@@ -34,18 +34,20 @@ def test_model_selector_trigger_label_uses_leading_tight():
 
 def test_sidebar_account_block_uses_leading_tight():
     src = _read(APP_SIDEBAR)
-    # Match the account-block parent div regardless of the layout utilities
-    # between flex and flex-col (min-w-0, flex-1, ...) or its gap utility; this
-    # guard is about the leading-* class, not the spacing.
+    # Match every account-block parent div by structure (flex + flex-col + gap +
+    # the collapsible-hidden marker), tolerant of any layout utilities between
+    # them, and capture the full className so we can require leading-tight on
+    # each matched block instead of letting one good block mask a broken one.
     pattern = re.compile(
-        r'<div\s+className="flex\s+[^"]*\bflex-col\b\s+gap-\S+\s+(\S+)\s+group-data-\[collapsible=icon\]:hidden">',
+        r'<div\s+className="(flex\s+[^"]*\bflex-col\b[^"]*\bgap-\S+[^"]*group-data-\[collapsible=icon\]:hidden)">',
     )
     matches = pattern.findall(src)
     assert matches, "could not find sidebar account-block parent div"
-    leading_classes = [m for m in matches if m.startswith("leading-")]
-    assert leading_classes, f"no leading-* class on sidebar account-block parent: {matches}"
-    for cls in leading_classes:
-        assert cls == "leading-tight", f"sidebar account-block must use leading-tight, got: {cls}"
+    for cls in matches:
+        assert "leading-tight" in cls, f"sidebar account-block must use leading-tight, got: {cls}"
+        assert "leading-none" not in cls, (
+            f"leading-none must not coexist with leading-tight here: {cls}"
+        )
 
 
 def test_no_truncate_plus_leading_none_in_changed_files():

--- a/tests/studio/test_studio_text_descender_clipping.py
+++ b/tests/studio/test_studio_text_descender_clipping.py
@@ -45,9 +45,9 @@ def test_sidebar_account_block_uses_leading_tight():
     assert matches, "could not find sidebar account-block parent div"
     for cls in matches:
         assert "leading-tight" in cls, f"sidebar account-block must use leading-tight, got: {cls}"
-        assert "leading-none" not in cls, (
-            f"leading-none must not coexist with leading-tight here: {cls}"
-        )
+        assert (
+            "leading-none" not in cls
+        ), f"leading-none must not coexist with leading-tight here: {cls}"
 
 
 def test_no_truncate_plus_leading_none_in_changed_files():


### PR DESCRIPTION
## Problem

`tests/studio/test_studio_text_descender_clipping.py::test_sidebar_account_block_uses_leading_tight` fails on `main` right now, and therefore on the "Repo tests (CPU)" job of every open Studio PR.

The guard matches the sidebar account-block div with a rigid `flex\s+flex-col` adjacency:

```
r'<div\s+className="flex\s+flex-col\s+gap-\S+\s+(\S+)\s+group-data-\[collapsible=icon\]:hidden">'
```

A later sidebar change inserted layout utilities between `flex` and `flex-col`, so the current markup is:

```
<div className="flex min-w-0 flex-col gap-px leading-tight group-data-[collapsible=icon]:hidden">
<div className="flex min-w-0 flex-1 flex-col gap-px leading-tight group-data-[collapsible=icon]:hidden">
```

The regex no longer matches, so `matches` is empty and the test asserts out with "could not find sidebar account-block parent div". The styling it protects (`leading-tight`) is still correct; only the guard's pattern is stale.

## Fix

Relax the pattern to allow any layout utilities between `flex` and `flex-col`, while still capturing the token before `group-data-...` and asserting it is `leading-tight`:

```
r'<div\s+className="flex\s+[^"]*\bflex-col\b\s+gap-\S+\s+(\S+)\s+group-data-\[collapsible=icon\]:hidden">'
```

## Tests

```
python -m pytest tests/studio/test_studio_text_descender_clipping.py -q
3 passed
```

Confirmed failing (1 failed, 2 passed) on `main` before the change and passing (3 passed) after. No production code touched; guard behavior is unchanged for correct markup.