### PR TITLE
Fix stale sidebar account-block regression test after markup change

### DIFF
--- a/tests/studio/test_studio_text_descender_clipping.py
+++ b/tests/studio/test_studio_text_descender_clipping.py
@@ -34,10 +34,11 @@ def test_model_selector_trigger_label_uses_leading_tight():
 
 def test_sidebar_account_block_uses_leading_tight():
     src = _read(APP_SIDEBAR)
-    # Match the account-block parent div regardless of its gap utility; this
-    # guard is about the leading-* class, not the spacing.
+    # Match the account-block parent div regardless of its other layout
+    # utilities (min-w-0 / flex-1 / gap-*); this guard is about the leading-*
+    # class, not the surrounding spacing/sizing classes.
     pattern = re.compile(
-        r'<div\s+className="flex\s+flex-col\s+gap-\S+\s+(\S+)\s+group-data-\[collapsible=icon\]:hidden">',
+        r'<div\s+className="flex\b[^"]*\bflex-col\b[^"]*\s(\S+)\s+group-data-\[collapsible=icon\]:hidden">',
     )
     matches = pattern.findall(src)
     assert matches, "could not find sidebar account-block parent div"

--- a/tests/studio/test_studio_text_descender_clipping.py
+++ b/tests/studio/test_studio_text_descender_clipping.py
@@ -34,18 +34,18 @@ def test_model_selector_trigger_label_uses_leading_tight():
 
 def test_sidebar_account_block_uses_leading_tight():
     src = _read(APP_SIDEBAR)
-    # Match the account-block parent div regardless of its other layout
-    # utilities (min-w-0 / flex-1 / gap-*); this guard is about the leading-*
-    # class, not the surrounding spacing/sizing classes.
-    pattern = re.compile(
-        r'<div\s+className="flex\b[^"]*\bflex-col\b[^"]*\s(\S+)\s+group-data-\[collapsible=icon\]:hidden">',
-    )
-    matches = pattern.findall(src)
-    assert matches, "could not find sidebar account-block parent div"
-    leading_classes = [m for m in matches if m.startswith("leading-")]
-    assert leading_classes, f"no leading-* class on sidebar account-block parent: {matches}"
-    for cls in leading_classes:
-        assert cls == "leading-tight", f"sidebar account-block must use leading-tight, got: {cls}"
+    # Identify each account-block parent div by its class SET (order-independent),
+    # not a positional regex: a flex-col column hidden when the sidebar collapses
+    # to icons. EVERY such block must carry leading-tight and never leading-none,
+    # checked per block -- a filter-then-"any" check would let one block drop the
+    # class and hide behind another, defeating the per-block descender guard.
+    div_classes = re.findall(r'<div\s+[^>]*className="([^"]*)"', src)
+    markers = {"flex", "flex-col", "group-data-[collapsible=icon]:hidden"}
+    blocks = [c.split() for c in div_classes if markers <= set(c.split())]
+    assert blocks, "could not find sidebar account-block parent div"
+    for classes in blocks:
+        assert "leading-tight" in classes, f"sidebar account-block must use leading-tight, got: {classes}"
+        assert "leading-none" not in classes, f"leading-none must not coexist with truncate here: {classes}"
 
 
 def test_no_truncate_plus_leading_none_in_changed_files():


### PR DESCRIPTION
## What

`tests/studio/test_studio_text_descender_clipping.py::test_sidebar_account_block_uses_leading_tight` is failing on main (Repo tests CPU), which blocks CI for every open PR.

## Why

The test regex hardcoded `flex flex-col` adjacency:

```
flex\s+flex-col\s+gap-\S+\s+(\S+)\s+group-data-\[collapsible=icon\]:hidden
```

But the account-block divs in `app-sidebar.tsx` now read `flex min-w-0 flex-col ...` and `flex min-w-0 flex-1 flex-col ...` after the sidebar truncation work in #7171. The `leading-tight` class the guard exists for is still present, so this is a stale test, not a UI regression.

## Fix

Loosen the regex to allow the extra layout utilities (`min-w-0` / `flex-1`) between `flex` and `flex-col` while still capturing and asserting the `leading-*` class. The regex now captures `leading-tight` for both account-block divs.

## Tests

```
python -m pytest tests/studio/test_studio_text_descender_clipping.py -q
3 passed
```

Test-only change.