### PR TITLE
Fix the sidebar descender test regex broken by the truncation restyle

### DIFF
--- a/tests/studio/test_studio_text_descender_clipping.py
+++ b/tests/studio/test_studio_text_descender_clipping.py
@@ -37,8 +37,12 @@ def test_sidebar_account_block_uses_leading_tight():
     # Match the account-block parent div regardless of its gap utility or any
     # sizing classes between flex and flex-col (min-w-0 flex-1 arrived with the
     # long-name truncation work); this guard is about the leading-* class only.
+    # [^"\s] keeps the wildcard inside the className attribute, and the trailing
+    # displayTitle anchor pins the match to the account block itself so a
+    # lookalike wrapper (the update card) can never satisfy the guard.
     pattern = re.compile(
-        r'<div\s+className="flex\s+(?:\S+\s+)*?flex-col\s+gap-\S+\s+(\S+)\s+group-data-\[collapsible=icon\]:hidden">',
+        r'<div\s+className="flex\s+(?:[^"\s]+\s+)*?flex-col\s+gap-[^"\s]+\s+([^"\s]+)\s+'
+        r'group-data-\[collapsible=icon\]:hidden">(?:(?!</div>)[\s\S]){0,400}?\{displayTitle\}',
     )
     matches = pattern.findall(src)
     assert matches, "could not find sidebar account-block parent div"

--- a/tests/studio/test_studio_text_descender_clipping.py
+++ b/tests/studio/test_studio_text_descender_clipping.py
@@ -34,10 +34,11 @@ def test_model_selector_trigger_label_uses_leading_tight():
 
 def test_sidebar_account_block_uses_leading_tight():
     src = _read(APP_SIDEBAR)
-    # Match the account-block parent div regardless of its gap utility; this
-    # guard is about the leading-* class, not the spacing.
+    # Match the account-block parent div regardless of its gap utility or any
+    # sizing classes between flex and flex-col (min-w-0 flex-1 arrived with the
+    # long-name truncation work); this guard is about the leading-* class only.
     pattern = re.compile(
-        r'<div\s+className="flex\s+flex-col\s+gap-\S+\s+(\S+)\s+group-data-\[collapsible=icon\]:hidden">',
+        r'<div\s+className="flex\s+(?:\S+\s+)*?flex-col\s+gap-\S+\s+(\S+)\s+group-data-\[collapsible=icon\]:hidden">',
     )
     matches = pattern.findall(src)
     assert matches, "could not find sidebar account-block parent div"


### PR DESCRIPTION
## Summary

Backend CI's "Repo tests (CPU)" job has been failing on `main` and on every open PR branch since July 16 with:

```
FAILED tests/studio/test_studio_text_descender_clipping.py::test_sidebar_account_block_uses_leading_tight
AssertionError: could not find sidebar account-block parent div
```

The test is a source-scanning guard that greps `app-sidebar.tsx` for the sidebar account-block div and asserts it keeps `leading-tight` (descender-clipping regression protection). Its regex required `flex` and `flex-col` to be adjacent:

```
<div\s+className="flex\s+flex-col\s+gap-\S+\s+...
```

#7171 (sidebar settings cog + long name truncation) changed the div from

```
flex flex-col gap-px leading-tight group-data-[collapsible=icon]:hidden
```

to

```
flex min-w-0 flex-1 flex-col gap-px leading-tight group-data-[collapsible=icon]:hidden
```

The inserted `min-w-0 flex-1` breaks the adjacency, so the pattern finds zero matches and the assert trips. The invariant the test protects was never violated: the new markup still uses `leading-tight` and never pairs `truncate` with `leading-none`. Only the pattern was stale.

## Fix

Allow utility classes between `flex` and `flex-col` (`flex\s+(?:\S+\s+)*?flex-col`), keeping the `leading-*` capture group and all assertions unchanged. One regex, no test semantics changed.

## Verification

All three tests in the file pass against the current sources; before the fix the sidebar test fails with the exact CI error. Reproduced the CI failure locally by running the old regex against `origin/main`'s `app-sidebar.tsx` (zero matches).
