### PR TITLE
Refresh the fastapi C2-loop scan baseline entry for the current release

### DIFF
--- a/scripts/scan_packages_baseline.json
+++ b/scripts/scan_packages_baseline.json
@@ -95,8 +95,8 @@
       "file": "fastapi/routing.py",
       "check": "C2 polling/beaconing loop detected",
       "severity": "CRITICAL",
-      "evidence": "L586:                                 while True: sha256:251135b5ebfdd1248916449f32262575e003ef64382501c65b7e4061d67bda45",
-      "evidence_hash": "365aef4449c8089753d9398417cd76ab762cef547d75db70d87bca9c0b550ab5"
+      "evidence": "L587:                                 while True: sha256:06c2c7f15d73bf192e5e3272c5ff5fcaeff7f6774fef5f4eca6ef473ae50e2b3",
+      "evidence_hash": "57acd497f404c203e4450d0580ad85aa8a33406e8d64ad06fbac6cf47d97b24d"
     },
     {
       "package": "fastmcp-slim",


### PR DESCRIPTION
## What

Refreshes the one stale entry in `scripts/scan_packages_baseline.json` that is failing the `pip scan-packages :: studio` shard on main and on every open PR.

## Why

The baseline suppresses a reviewed, benign finding: the SSE keepalive `while True:` loop in `fastapi/routing.py`, which the scanner's C2-loop heuristic flags. The entry pins the evidence at L586 together with the span digest of the fastapi release that was current when it was baselined. The latest fastapi release shifts the loop to L587 and changes the span digest, so the stored `evidence_hash` no longer matches and the scanner reports the finding as a new unsuppressed CRITICAL, turning the shard red (see the Security-audit runs on main, e.g. 29631733699 and 29621709961, both `studio-scan=failure` on an untouched baseline).

## Re-review of the flagged code

Before refreshing the suppression I re-read the flagged code in the current release: L587 of `fastapi/routing.py` is the same keepalive-comment loop inside the streaming response machinery as before (receive with `anyio.fail_after`, forward, emit a keepalive comment on timeout). It is not a polling beacon.

## Verification

- `python scripts/scan_packages.py fastapi --no-baseline` reproduces the exact evidence string CI prints, including the L587 marker and span digest.
- With the updated baseline, the same scan exits 0: `1 finding(s) suppressed by baseline (1 CRITICAL, 0 HIGH, 0 MEDIUM)`.
- The diff touches only the one entry's `evidence` and `evidence_hash` fields (2 lines).
