### PR TITLE
fix(registry): don't register deepseek models at import time

### DIFF
--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,5 +1,6 @@
 """Register each model set and check the registered ids exist on the HF Hub."""
 
+import os
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -85,22 +86,39 @@ def test_importing_registry_does_not_register_models():
     """Importing the registry must not populate MODEL_REGISTRY on its own.
 
     ``_deepseek`` used to call ``register_deepseek_models(...)`` at module
-    scope, so merely importing ``unsloth.registry`` registered models (and hit
-    the hub) as an import side effect, unlike every other family which only
-    registers on demand. Run in a subprocess so the check is independent of any
+    scope, so merely importing ``unsloth.registry`` registered models as an
+    import side effect, unlike every other family which only registers on
+    demand. Run in a subprocess so the check is independent of any
     ``register_models()`` calls other tests make on the shared registry.
+
+    The child first imports this directory's ``conftest`` so it inherits the
+    same GPU-free harness the pytest session uses (device_type stubs plus
+    torch.cuda probe patches). Without it, ``import unsloth.registry`` raises
+    ``NotImplementedError`` from ``unsloth_zoo.device_type`` on no-accelerator
+    CI runners, so the child would exit non-zero and the test would fail even
+    though the registry fix itself is correct.
     """
+    tests_dir = os.path.dirname(os.path.abspath(__file__))
     result = subprocess.run(
         [
             sys.executable,
             "-c",
+            f"import sys; sys.path.insert(0, {tests_dir!r})\n"
+            "try:\n"
+            "    import conftest  # noqa: F401  GPU-free harness on no-accelerator runners\n"
+            "except Exception:\n"
+            "    pass\n"
             "import unsloth.registry\n"
             "from unsloth.registry.registry import MODEL_REGISTRY\n"
             "print('REGISTRY_SIZE', len(MODEL_REGISTRY))",
         ],
         capture_output = True,
         text = True,
-        check = True,
+        check = False,
+    )
+    assert result.returncode == 0, (
+        f"registry import subprocess exited {result.returncode}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     )
     size_lines = [line for line in result.stdout.splitlines() if line.startswith("REGISTRY_SIZE")]
-    assert size_lines == ["REGISTRY_SIZE 0"], result.stdout
+    assert size_lines == ["REGISTRY_SIZE 0"], result.stdout + result.stderr

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -102,7 +102,5 @@ def test_importing_registry_does_not_register_models():
         text = True,
         check = True,
     )
-    size_lines = [
-        line for line in result.stdout.splitlines() if line.startswith("REGISTRY_SIZE")
-    ]
+    size_lines = [line for line in result.stdout.splitlines() if line.startswith("REGISTRY_SIZE")]
     assert size_lines == ["REGISTRY_SIZE 0"], result.stdout

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,5 +1,7 @@
 """Register each model set and check the registered ids exist on the HF Hub."""
 
+import subprocess
+import sys
 from dataclasses import dataclass
 
 import pytest
@@ -77,3 +79,30 @@ def test_quant_type():
     assert all(m.quant_type == QuantType.UNSLOTH for m in dynamic_quant_models)
     quant_tag = QUANT_TAG_MAP[QuantType.UNSLOTH]
     assert all(quant_tag in m.model_path for m in dynamic_quant_models)
+
+
+def test_importing_registry_does_not_register_models():
+    """Importing the registry must not populate MODEL_REGISTRY on its own.
+
+    ``_deepseek`` used to call ``register_deepseek_models(...)`` at module
+    scope, so merely importing ``unsloth.registry`` registered models (and hit
+    the hub) as an import side effect, unlike every other family which only
+    registers on demand. Run in a subprocess so the check is independent of any
+    ``register_models()`` calls other tests make on the shared registry.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import unsloth.registry\n"
+            "from unsloth.registry.registry import MODEL_REGISTRY\n"
+            "print('REGISTRY_SIZE', len(MODEL_REGISTRY))",
+        ],
+        capture_output = True,
+        text = True,
+        check = True,
+    )
+    size_lines = [
+        line for line in result.stdout.splitlines() if line.startswith("REGISTRY_SIZE")
+    ]
+    assert size_lines == ["REGISTRY_SIZE 0"], result.stdout

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -82,39 +82,44 @@ def test_quant_type():
     assert all(quant_tag in m.model_path for m in dynamic_quant_models)
 
 
+def _run_registry_child(body: str) -> subprocess.CompletedProcess:
+    """Run ``body`` in a fresh interpreter that first imports this directory's
+    ``conftest`` so it inherits the same GPU-free harness the pytest session
+    uses (device_type stubs plus torch.cuda probe patches). Without it,
+    ``import unsloth.registry`` raises ``NotImplementedError`` from
+    ``unsloth_zoo.device_type`` on no-accelerator CI runners, so the child
+    would exit non-zero and the test would fail even though the registry code
+    is correct. A fresh process also keeps each check independent of any
+    ``register_models()`` calls other tests make on the shared registry.
+    """
+    tests_dir = os.path.dirname(os.path.abspath(__file__))
+    prelude = (
+        f"import sys; sys.path.insert(0, {tests_dir!r})\n"
+        "try:\n"
+        "    import conftest  # noqa: F401  GPU-free harness on no-accelerator runners\n"
+        "except Exception:\n"
+        "    pass\n"
+    )
+    return subprocess.run(
+        [sys.executable, "-c", prelude + body],
+        capture_output = True,
+        text = True,
+        check = False,
+    )
+
+
 def test_importing_registry_does_not_register_models():
     """Importing the registry must not populate MODEL_REGISTRY on its own.
 
     ``_deepseek`` used to call ``register_deepseek_models(...)`` at module
     scope, so merely importing ``unsloth.registry`` registered models as an
     import side effect, unlike every other family which only registers on
-    demand. Run in a subprocess so the check is independent of any
-    ``register_models()`` calls other tests make on the shared registry.
-
-    The child first imports this directory's ``conftest`` so it inherits the
-    same GPU-free harness the pytest session uses (device_type stubs plus
-    torch.cuda probe patches). Without it, ``import unsloth.registry`` raises
-    ``NotImplementedError`` from ``unsloth_zoo.device_type`` on no-accelerator
-    CI runners, so the child would exit non-zero and the test would fail even
-    though the registry fix itself is correct.
+    demand.
     """
-    tests_dir = os.path.dirname(os.path.abspath(__file__))
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            f"import sys; sys.path.insert(0, {tests_dir!r})\n"
-            "try:\n"
-            "    import conftest  # noqa: F401  GPU-free harness on no-accelerator runners\n"
-            "except Exception:\n"
-            "    pass\n"
-            "import unsloth.registry\n"
-            "from unsloth.registry.registry import MODEL_REGISTRY\n"
-            "print('REGISTRY_SIZE', len(MODEL_REGISTRY))",
-        ],
-        capture_output = True,
-        text = True,
-        check = False,
+    result = _run_registry_child(
+        "import unsloth.registry\n"
+        "from unsloth.registry.registry import MODEL_REGISTRY\n"
+        "print('REGISTRY_SIZE', len(MODEL_REGISTRY))"
     )
     assert result.returncode == 0, (
         f"registry import subprocess exited {result.returncode}\n"
@@ -122,3 +127,38 @@ def test_importing_registry_does_not_register_models():
     )
     size_lines = [line for line in result.stdout.splitlines() if line.startswith("REGISTRY_SIZE")]
     assert size_lines == ["REGISTRY_SIZE 0"], result.stdout + result.stderr
+
+
+def test_register_models_registers_no_upstream_originals():
+    """``register_models()`` must register each family's ``unsloth``-org models
+    and must NOT leak upstream vendor "original" models.
+
+    Before the fix, ``_deepseek``'s import-time
+    ``register_deepseek_models(include_original_model = True)`` set the
+    ``_IS_DEEPSEEK_*_REGISTERED`` guards, so the later default
+    ``register_models()`` early-returned for deepseek and its 10 ``deepseek-ai``
+    originals leaked permanently (129 -> 139). This asserts the whole registry
+    is ``unsloth``-org after ``register_models()`` while deepseek is still
+    registered via the normal path. Runs in a fresh interpreter so it is
+    independent of other tests' registry mutations.
+    """
+    result = _run_registry_child(
+        "import unsloth.registry\n"
+        "from unsloth.registry import register_models\n"
+        "from unsloth.registry.registry import MODEL_REGISTRY\n"
+        "register_models()\n"
+        "orgs = sorted({m.org for m in MODEL_REGISTRY.values()})\n"
+        "deepseek = [k for k in MODEL_REGISTRY if 'deepseek' in k.lower()]\n"
+        "print('ORGS', orgs)\n"
+        "print('NUM_DEEPSEEK', len(deepseek))"
+    )
+    assert result.returncode == 0, (
+        f"register_models subprocess exited {result.returncode}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    out = result.stdout
+    # Every registered model is unsloth-org: no upstream "original" leaked.
+    assert "ORGS ['unsloth']" in out, out + result.stderr
+    # Deepseek is still registered via the normal path, just without originals.
+    deepseek_lines = [line for line in out.splitlines() if line.startswith("NUM_DEEPSEEK")]
+    assert deepseek_lines and int(deepseek_lines[0].split()[1]) > 0, out + result.stderr

--- a/unsloth/registry/_deepseek.py
+++ b/unsloth/registry/_deepseek.py
@@ -171,8 +171,6 @@ def _list_deepseek_r1_distill_models():
     return distill_models
 
 
-register_deepseek_models(include_original_model = True)
-
 if __name__ == "__main__":
     from unsloth.registry.registry import MODEL_REGISTRY, _check_model_info
 


### PR DESCRIPTION
### Problem

`unsloth/registry/_deepseek.py` calls `register_deepseek_models(include_original_model=True)` at module scope (line 174). None of the other five families (`_gemma`/`_llama`/`_mistral`/`_phi`/`_qwen`) have a module-level register call — they register only when `register_models()` asks them to.

That one stray line has two effects:

1. **Importing `unsloth.registry` has side effects.** Merely `import unsloth.registry` populates `MODEL_REGISTRY` (32 entries, including 10 `deepseek-ai` original models that no other family leaks) before any explicit `register_models()` call.
2. **`register_models()` can't register deepseek the normal way.** The import-time call sets the `_IS_DEEPSEEK_*_REGISTERED` guards with `include_original_model=True`, so the later `register_models()` call — which uses the default `include_original_model=False` — early-returns. The import-time result wins permanently, and `test_model_registration[deepseek]` passes vacuously (guard already set → registers nothing → empty set trivially "not missing").

### Fix

Remove the stray module-level call. The `if __name__ == "__main__"` block below already registers with `include_original_model=True` for standalone script use, so that path is unaffected.

Before / after, `import unsloth.registry` with no explicit call:

```
before:  MODEL_REGISTRY size 32   (deepseek-ai: 10)
after:   MODEL_REGISTRY size 0
```

After the fix, `register_models()` still registers all 129 `unsloth`-org models and no longer leaks the `deepseek-ai` originals — deepseek is now consistent with the other families.

### Test

Two subprocess tests, each run in a fresh interpreter so it is independent of other tests' `register_models()` calls on the shared registry (both are network-free):

- `test_importing_registry_does_not_register_models` asserts that importing `unsloth.registry` leaves `MODEL_REGISTRY` empty. It fails on the current code (`REGISTRY_SIZE 32`) and passes with the fix.
- `test_register_models_registers_no_upstream_originals` asserts that after `register_models()` every registered model is `unsloth`-org, with deepseek still registered via the normal path and none of the `deepseek-ai` originals leaked. It fails on the current code (`deepseek-ai` present, 129 -> 139) and passes with the fix.

The child imports the tests directory's `conftest` first so it inherits the GPU-free harness on no-accelerator CI runners.

---
Disclosure: this change is fully AI-authored and autonomous (Claude Code, on this account). An AI found the bug, ran the before/after repro, wrote the fix and the test, and wrote this description; the human account holder reviews every change and is accountable for it. The before/after numbers and the red/green of the new test are real and re-runnable from the diff — just done by the AI, not a person. If this isn't the kind of contribution you want, say so and I'll close it.
