### PR TITLE
feat(studio): add UNSLOTH_LLAMA_CPP_BACKEND env var to force CPU fallback #7213

### DIFF
--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -445,6 +445,39 @@ def test_route_to_vulkan_prebuilt_cpu_fallback_wins():
     assert routed is host
 
 
+def test_resolve_prebuilt_cpu_fallback_overrides_intel_vulkan(monkeypatch, capsys):
+    """--cpu-fallback via CLI must suppress Vulkan even on an Intel GPU host."""
+    monkeypatch.setattr(
+        ilp,
+        "detect_host",
+        lambda: _host(is_linux = True, is_x86_64 = True, has_intel_gpu = True),
+    )
+    seen = {}
+
+    def _resolver(tag, host, repo, published_release_tag):
+        seen["host"] = host
+        seen["repo"] = repo
+        raise ilp.PrebuiltFallback("no asset")
+
+    monkeypatch.setattr(ilp, "resolve_simple_install_release_plans", _resolver)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "install_llama_prebuilt.py",
+            "--resolve-prebuilt",
+            "latest",
+            "--cpu-fallback",
+            "--output-format",
+            "json",
+        ],
+    )
+    assert ilp.main() == ilp.EXIT_SUCCESS
+    # --cpu-fallback must suppress Intel GPU, route to fork (not upstream Vulkan)
+    assert seen["host"].has_intel_gpu is False
+    assert seen["repo"] == FORK
+
+
 def test_route_to_vulkan_prebuilt_hidden_nvidia_not_rerouted():
     # A mixed NVIDIA+Intel host that hid NVIDIA (CUDA_VISIBLE_DEVICES=""/-1):
     # physical NVIDIA present but not usable. Must NOT auto-route to Vulkan, or

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -445,8 +445,10 @@ def test_route_to_vulkan_prebuilt_cpu_fallback_wins():
     assert routed is host
 
 
-def test_resolve_prebuilt_cpu_fallback_overrides_intel_vulkan(monkeypatch, capsys):
-    """--cpu-fallback via CLI must suppress Vulkan even on an Intel GPU host."""
+@pytest.mark.parametrize("cpu_flag", ["--cpu-fallback", "--force-cpu"])
+def test_resolve_prebuilt_cpu_fallback_overrides_intel_vulkan(monkeypatch, capsys, cpu_flag):
+    """Either CPU flag via CLI must suppress Vulkan even on an Intel GPU host: both
+    drop GPU detection (--force-cpu additionally persists, on the install path)."""
     monkeypatch.setattr(
         ilp,
         "detect_host",
@@ -467,15 +469,43 @@ def test_resolve_prebuilt_cpu_fallback_overrides_intel_vulkan(monkeypatch, capsy
             "install_llama_prebuilt.py",
             "--resolve-prebuilt",
             "latest",
-            "--cpu-fallback",
+            cpu_flag,
             "--output-format",
             "json",
         ],
     )
     assert ilp.main() == ilp.EXIT_SUCCESS
-    # --cpu-fallback must suppress Intel GPU, route to fork (not upstream Vulkan)
+    # The CPU flag must suppress Intel GPU, route to fork (not upstream Vulkan)
     assert seen["host"].has_intel_gpu is False
     assert seen["repo"] == FORK
+
+
+@pytest.mark.parametrize(
+    "flags, expect_force, expect_persist",
+    [
+        ([], False, False),
+        # Automatic/transient last resort (arm64 GPU-build recovery): drops GPU but
+        # does NOT persist, so a later update heals to a GPU bundle (#6097).
+        (["--cpu-fallback"], True, False),
+        # Deliberate CPU-only (UNSLOTH_LLAMA_CPP_BACKEND=cpu): drops GPU AND persists so
+        # the updater re-asserts it and never revives the Intel iGPU crash (#7213).
+        (["--force-cpu"], True, True),
+        (["--cpu-fallback", "--force-cpu"], True, True),
+    ],
+)
+def test_cli_cpu_flags_thread_force_and_persist(
+    monkeypatch, tmp_path, flags, expect_force, expect_persist
+):
+    captured = {}
+    monkeypatch.setattr(ilp, "install_prebuilt", lambda **kw: captured.update(kw))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["install_llama_prebuilt.py", "--install-dir", str(tmp_path / "llama.cpp"), *flags],
+    )
+    assert ilp.main() == ilp.EXIT_SUCCESS
+    assert captured["force_cpu"] is expect_force
+    assert captured["persist_force_cpu"] is expect_persist
 
 
 def test_route_to_vulkan_prebuilt_hidden_nvidia_not_rerouted():

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -508,6 +508,38 @@ def test_cli_cpu_flags_thread_force_and_persist(
     assert captured["persist_force_cpu"] is expect_persist
 
 
+@pytest.mark.parametrize(
+    "existing, requested, expected",
+    [
+        # A deliberate --force-cpu on top of a naturally-installed CPU bundle (same
+        # asset, install skipped) must still flip the marker to true (#7213).
+        (False, True, True),
+        (None, True, True),
+        # No spurious writes when already in sync, and a released force syncs down.
+        (True, True, True),
+        (False, False, False),
+        (True, False, False),
+    ],
+)
+def test_sync_marker_force_cpu(tmp_path, existing, requested, expected):
+    marker = {"tag": "b9585", "asset": "llama-b9585-bin-ubuntu-x64.tar.gz"}
+    if existing is not None:
+        marker["force_cpu"] = existing
+    marker_path = tmp_path / "UNSLOTH_PREBUILT_INFO.json"
+    marker_path.write_text(json.dumps(marker))
+    ilp.sync_marker_force_cpu(tmp_path, requested)
+    written = json.loads(marker_path.read_text())
+    assert written["force_cpu"] is expected
+    # Unrelated fields are preserved.
+    assert written["asset"] == "llama-b9585-bin-ubuntu-x64.tar.gz"
+
+
+def test_sync_marker_force_cpu_missing_marker_is_noop(tmp_path):
+    # No marker (or unreadable) must not crash the reuse path.
+    ilp.sync_marker_force_cpu(tmp_path, True)
+    assert not (tmp_path / "UNSLOTH_PREBUILT_INFO.json").exists()
+
+
 def test_route_to_vulkan_prebuilt_hidden_nvidia_not_rerouted():
     # A mixed NVIDIA+Intel host that hid NVIDIA (CUDA_VISIBLE_DEVICES=""/-1):
     # physical NVIDIA present but not usable. Must NOT auto-route to Vulkan, or

--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -499,10 +499,11 @@ def test_start_update_preserves_vulkan_via_env(monkeypatch, tmp_path):
 @pytest.mark.parametrize(
     "force_cpu, expect_flag",
     [
-        # Explicitly forced CPU (--cpu-fallback) re-asserts the flag on update so
-        # detect_host on a GPU host cannot re-route and revive the crash (#7213).
+        # A deliberate CPU install (marker force_cpu=True) re-asserts --force-cpu on
+        # update so detect_host on a GPU host cannot re-route and revive the crash
+        # (#7213); --force-cpu also re-persists the flag for the next update.
         (True, True),
-        # A natural CPU fallback (or a legacy marker without the flag) stays free to
+        # A transient fallback (or a legacy marker without the flag) stays free to
         # heal to a GPU bundle (#6097).
         (False, False),
         (None, False),
@@ -532,7 +533,8 @@ def test_start_update_cpu_fallback_preserved_by_flag(monkeypatch, tmp_path, forc
             break
         time.sleep(0.05)
     assert job["state"] == "success", job
-    assert ("--cpu-fallback" in captured["cmd"]) is expect_flag
+    assert ("--force-cpu" in captured["cmd"]) is expect_flag
+    assert "--cpu-fallback" not in captured["cmd"]
 
 
 def test_start_update_reports_full_release_tag(monkeypatch, tmp_path):
@@ -718,7 +720,7 @@ def test_install_cmd_rocm_marker_forwards_gfx(monkeypatch, tmp_path):
     assert "--rocm-gfx" in cmd
     assert cmd[cmd.index("--rocm-gfx") + 1] == "gfx110x"
     assert "--has-rocm" not in cmd
-    assert "--cpu-fallback" not in cmd
+    assert "--force-cpu" not in cmd
     assert "--simple-policy" not in cmd
     assert "--published-repo" in cmd and "unslothai/llama.cpp" in cmd
 
@@ -732,17 +734,17 @@ def test_install_cmd_fork_rocm_marker_forwards_has_rocm(monkeypatch, tmp_path):
 
 
 def test_install_cmd_ggml_cpu_marker_has_no_cpu_fallback(monkeypatch, tmp_path):
-    # Legacy CPU installs recorded a ggml-org marker (new installs use the fork).
-    # Re-running into the same install-dir/repo reproduces the same CPU bundle;
-    # --cpu-fallback (which force-drops GPU detection) is reserved for setup.sh's
-    # arm64 rescue and must not appear here.
+    # Legacy CPU installs recorded a ggml-org marker (new installs use the fork) with
+    # no force_cpu field. Re-running into the same install-dir/repo reproduces the same
+    # CPU bundle; --force-cpu (the persisted-CPU re-assert) must not appear for a marker
+    # that never recorded a deliberate CPU choice, so it can still heal to GPU (#6097).
     cmd = _capture_install_cmd(
         monkeypatch,
         tmp_path,
         repo = "ggml-org/llama.cpp",
         asset = "llama-b9334-bin-ubuntu-x64.tar.gz",
     )
-    assert "--cpu-fallback" not in cmd
+    assert "--force-cpu" not in cmd
     assert "--rocm-gfx" not in cmd
     assert "--has-rocm" not in cmd
     assert "--simple-policy" not in cmd
@@ -756,7 +758,7 @@ def test_install_cmd_cuda_marker_minimal_and_backward_compatible(monkeypatch, tm
     assert "--simple-policy" not in cmd
     assert "--rocm-gfx" not in cmd
     assert "--has-rocm" not in cmd
-    assert "--cpu-fallback" not in cmd
+    assert "--force-cpu" not in cmd
 
 
 def test_install_cmd_pins_offered_release_tag(monkeypatch, tmp_path):

--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -83,6 +83,7 @@ def _write_install(
     repo: str = "unslothai/llama.cpp",
     asset: str | None = None,
     release_tag: str | None = None,
+    install_kind: str | None = None,
 ) -> str:
     """Create a fake prebuilt install and return the llama-server path."""
     bin_dir = dir_ / "build" / "bin"
@@ -99,6 +100,8 @@ def _write_install(
     }
     if asset is not None:
         marker["asset"] = asset
+    if install_kind is not None:
+        marker["install_kind"] = install_kind
     (dir_ / MARKER).write_text(json.dumps(marker))
     return str(binary)
 
@@ -491,6 +494,46 @@ def test_start_update_preserves_vulkan_via_env(monkeypatch, tmp_path):
         time.sleep(0.05)
     assert job["state"] == "success", job
     assert popen_kwargs["env"]["UNSLOTH_FORCE_VULKAN"] == "1"
+
+
+def test_start_update_preserves_cpu_via_flag(monkeypatch, tmp_path):
+    # A forced-CPU install (UNSLOTH_LLAMA_CPP_BACKEND=cpu) must re-assert
+    # --cpu-fallback on update, or detect_host on an Intel iGPU box re-routes to
+    # the Vulkan bundle and reintroduces the crash (#7213). Keyed off install_kind
+    # since the Linux CPU asset name carries no "cpu" marker.
+    install_dir = tmp_path / "llama.cpp"
+    binary = _write_install(
+        install_dir,
+        "b9493",
+        asset = "llama-b9493-bin-ubuntu-x64.tar.gz",
+        install_kind = "linux-cpu",
+    )
+    monkeypatch.setattr(upd, "_find_binary", lambda: binary)
+    monkeypatch.setattr(upd, "_installer_script", lambda: tmp_path / "install_llama_prebuilt.py")
+    monkeypatch.setattr(freshness, "_fetch_latest_release_tag", lambda repo, timeout = 5.0: "b9518")
+
+    captured: dict = {}
+
+    def _on_start(cmd):
+        captured["cmd"] = cmd
+        _write_install(
+            install_dir,
+            "b9518",
+            asset = "llama-b9518-bin-ubuntu-x64.tar.gz",
+            install_kind = "linux-cpu",
+        )
+
+    _patch_installer_popen(monkeypatch, lines = ["installed\n"], on_start = _on_start)
+
+    assert upd.start_update()["started"] is True
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        job = upd.get_update_status()["job"]
+        if job["state"] in ("success", "error"):
+            break
+        time.sleep(0.05)
+    assert job["state"] == "success", job
+    assert "--cpu-fallback" in captured["cmd"]
 
 
 def test_start_update_reports_full_release_tag(monkeypatch, tmp_path):

--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -513,10 +513,9 @@ def test_start_update_preserves_vulkan_via_env(monkeypatch, tmp_path):
 def test_start_update_cpu_fallback_preserved_by_kind(
     monkeypatch, tmp_path, install_kind, asset, expect_flag
 ):
-    # A CPU install (x86_64 *-cpu or arm64 *-arm64) must re-assert --cpu-fallback on
-    # update, or detect_host on a GPU host re-routes to a GPU/source build and
-    # reintroduces the crash (#7213). Keyed off install_kind; legacy markers with no
-    # install_kind deliberately do not force CPU (#6097 heal-to-GPU).
+    # A CPU install (*-cpu or *-arm64) must re-assert --cpu-fallback on update, else
+    # detect_host on a GPU host re-routes and revives the crash (#7213). Keyed off
+    # install_kind; legacy markers without it stay heal-to-GPU (#6097).
     install_dir = tmp_path / "llama.cpp"
     binary = _write_install(install_dir, "b9493", asset = asset, install_kind = install_kind)
     monkeypatch.setattr(upd, "_find_binary", lambda: binary)

--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -505,6 +505,9 @@ def test_start_update_preserves_vulkan_via_env(monkeypatch, tmp_path):
         ("windows-arm64", "llama-b9493-bin-win-cpu-arm64.zip", True),
         ("linux-vulkan", "llama-b9493-bin-ubuntu-vulkan-x64.tar.gz", False),
         ("linux-cuda", "llama-b9493-bin-ubuntu-cuda-x64.tar.gz", False),
+        # Legacy markers without install_kind keep the pre-#6097 heal-to-GPU behaviour
+        # (no forced --cpu-fallback); see test_install_cmd_ggml_cpu_marker_has_no_cpu_fallback.
+        (None, "llama-b9493-bin-ubuntu-x64.tar.gz", False),
     ],
 )
 def test_start_update_cpu_fallback_preserved_by_kind(
@@ -512,7 +515,8 @@ def test_start_update_cpu_fallback_preserved_by_kind(
 ):
     # A CPU install (x86_64 *-cpu or arm64 *-arm64) must re-assert --cpu-fallback on
     # update, or detect_host on a GPU host re-routes to a GPU/source build and
-    # reintroduces the crash (#7213). Keyed off install_kind, not the asset name.
+    # reintroduces the crash (#7213). Keyed off install_kind; legacy markers with no
+    # install_kind deliberately do not force CPU (#6097 heal-to-GPU).
     install_dir = tmp_path / "llama.cpp"
     binary = _write_install(install_dir, "b9493", asset = asset, install_kind = install_kind)
     monkeypatch.setattr(upd, "_find_binary", lambda: binary)

--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -496,18 +496,25 @@ def test_start_update_preserves_vulkan_via_env(monkeypatch, tmp_path):
     assert popen_kwargs["env"]["UNSLOTH_FORCE_VULKAN"] == "1"
 
 
-def test_start_update_preserves_cpu_via_flag(monkeypatch, tmp_path):
-    # A forced-CPU install (UNSLOTH_LLAMA_CPP_BACKEND=cpu) must re-assert
-    # --cpu-fallback on update, or detect_host on an Intel iGPU box re-routes to
-    # the Vulkan bundle and reintroduces the crash (#7213). Keyed off install_kind
-    # since the Linux CPU asset name carries no "cpu" marker.
+@pytest.mark.parametrize(
+    "install_kind, asset, expect_flag",
+    [
+        ("linux-cpu", "llama-b9493-bin-ubuntu-x64.tar.gz", True),
+        ("windows-cpu", "llama-b9493-bin-win-cpu-x64.zip", True),
+        ("linux-arm64", "llama-b9493-bin-ubuntu-arm64.tar.gz", True),
+        ("windows-arm64", "llama-b9493-bin-win-cpu-arm64.zip", True),
+        ("linux-vulkan", "llama-b9493-bin-ubuntu-vulkan-x64.tar.gz", False),
+        ("linux-cuda", "llama-b9493-bin-ubuntu-cuda-x64.tar.gz", False),
+    ],
+)
+def test_start_update_cpu_fallback_preserved_by_kind(
+    monkeypatch, tmp_path, install_kind, asset, expect_flag
+):
+    # A CPU install (x86_64 *-cpu or arm64 *-arm64) must re-assert --cpu-fallback on
+    # update, or detect_host on a GPU host re-routes to a GPU/source build and
+    # reintroduces the crash (#7213). Keyed off install_kind, not the asset name.
     install_dir = tmp_path / "llama.cpp"
-    binary = _write_install(
-        install_dir,
-        "b9493",
-        asset = "llama-b9493-bin-ubuntu-x64.tar.gz",
-        install_kind = "linux-cpu",
-    )
+    binary = _write_install(install_dir, "b9493", asset = asset, install_kind = install_kind)
     monkeypatch.setattr(upd, "_find_binary", lambda: binary)
     monkeypatch.setattr(upd, "_installer_script", lambda: tmp_path / "install_llama_prebuilt.py")
     monkeypatch.setattr(freshness, "_fetch_latest_release_tag", lambda repo, timeout = 5.0: "b9518")
@@ -516,12 +523,7 @@ def test_start_update_preserves_cpu_via_flag(monkeypatch, tmp_path):
 
     def _on_start(cmd):
         captured["cmd"] = cmd
-        _write_install(
-            install_dir,
-            "b9518",
-            asset = "llama-b9518-bin-ubuntu-x64.tar.gz",
-            install_kind = "linux-cpu",
-        )
+        _write_install(install_dir, "b9518", asset = asset, install_kind = install_kind)
 
     _patch_installer_popen(monkeypatch, lines = ["installed\n"], on_start = _on_start)
 
@@ -533,7 +535,7 @@ def test_start_update_preserves_cpu_via_flag(monkeypatch, tmp_path):
             break
         time.sleep(0.05)
     assert job["state"] == "success", job
-    assert "--cpu-fallback" in captured["cmd"]
+    assert ("--cpu-fallback" in captured["cmd"]) is expect_flag
 
 
 def test_start_update_reports_full_release_tag(monkeypatch, tmp_path):

--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -83,7 +83,7 @@ def _write_install(
     repo: str = "unslothai/llama.cpp",
     asset: str | None = None,
     release_tag: str | None = None,
-    install_kind: str | None = None,
+    force_cpu: bool | None = None,
 ) -> str:
     """Create a fake prebuilt install and return the llama-server path."""
     bin_dir = dir_ / "build" / "bin"
@@ -100,8 +100,8 @@ def _write_install(
     }
     if asset is not None:
         marker["asset"] = asset
-    if install_kind is not None:
-        marker["install_kind"] = install_kind
+    if force_cpu is not None:
+        marker["force_cpu"] = force_cpu
     (dir_ / MARKER).write_text(json.dumps(marker))
     return str(binary)
 
@@ -497,27 +497,21 @@ def test_start_update_preserves_vulkan_via_env(monkeypatch, tmp_path):
 
 
 @pytest.mark.parametrize(
-    "install_kind, asset, expect_flag",
+    "force_cpu, expect_flag",
     [
-        ("linux-cpu", "llama-b9493-bin-ubuntu-x64.tar.gz", True),
-        ("windows-cpu", "llama-b9493-bin-win-cpu-x64.zip", True),
-        ("linux-arm64", "llama-b9493-bin-ubuntu-arm64.tar.gz", True),
-        ("windows-arm64", "llama-b9493-bin-win-cpu-arm64.zip", True),
-        ("linux-vulkan", "llama-b9493-bin-ubuntu-vulkan-x64.tar.gz", False),
-        ("linux-cuda", "llama-b9493-bin-ubuntu-cuda-x64.tar.gz", False),
-        # Legacy markers without install_kind keep the pre-#6097 heal-to-GPU behaviour
-        # (no forced --cpu-fallback); see test_install_cmd_ggml_cpu_marker_has_no_cpu_fallback.
-        (None, "llama-b9493-bin-ubuntu-x64.tar.gz", False),
+        # Explicitly forced CPU (--cpu-fallback) re-asserts the flag on update so
+        # detect_host on a GPU host cannot re-route and revive the crash (#7213).
+        (True, True),
+        # A natural CPU fallback (or a legacy marker without the flag) stays free to
+        # heal to a GPU bundle (#6097).
+        (False, False),
+        (None, False),
     ],
 )
-def test_start_update_cpu_fallback_preserved_by_kind(
-    monkeypatch, tmp_path, install_kind, asset, expect_flag
-):
-    # A CPU install (*-cpu or *-arm64) must re-assert --cpu-fallback on update, else
-    # detect_host on a GPU host re-routes and revives the crash (#7213). Keyed off
-    # install_kind; legacy markers without it stay heal-to-GPU (#6097).
+def test_start_update_cpu_fallback_preserved_by_flag(monkeypatch, tmp_path, force_cpu, expect_flag):
+    asset = "llama-b9493-bin-ubuntu-x64.tar.gz"
     install_dir = tmp_path / "llama.cpp"
-    binary = _write_install(install_dir, "b9493", asset = asset, install_kind = install_kind)
+    binary = _write_install(install_dir, "b9493", asset = asset, force_cpu = force_cpu)
     monkeypatch.setattr(upd, "_find_binary", lambda: binary)
     monkeypatch.setattr(upd, "_installer_script", lambda: tmp_path / "install_llama_prebuilt.py")
     monkeypatch.setattr(freshness, "_fetch_latest_release_tag", lambda repo, timeout = 5.0: "b9518")
@@ -526,7 +520,7 @@ def test_start_update_cpu_fallback_preserved_by_kind(
 
     def _on_start(cmd):
         captured["cmd"] = cmd
-        _write_install(install_dir, "b9518", asset = asset, install_kind = install_kind)
+        _write_install(install_dir, "b9518", asset = asset, force_cpu = force_cpu)
 
     _patch_installer_popen(monkeypatch, lines = ["installed\n"], on_start = _on_start)
 

--- a/studio/backend/tests/test_setup_llama_cpp_backend.py
+++ b/studio/backend/tests/test_setup_llama_cpp_backend.py
@@ -72,24 +72,48 @@ def test_backend_unknown_warns_and_no_flag(value):
     assert "Ignoring" in stderr
 
 
-def _ps1_block() -> str:
-    text = _SETUP_PS1.read_text(encoding = "utf-8")
-    m = re.search(r"\$llamaBackend =.*?Write-Host.*?\n\s*\}", text, re.DOTALL)
-    assert m, "UNSLOTH_LLAMA_CPP_BACKEND block not found in setup.ps1"
+def _ps1_search(pattern: str, flags = 0) -> str:
+    m = re.search(pattern, _SETUP_PS1.read_text(encoding = "utf-8"), flags)
+    assert m, f"setup.ps1 block not found: {pattern}"
     return m.group(0)
 
 
 def _run_ps1(value: str | None) -> str:
+    # The override is normalized (assign + warn) at the top of the prebuilt block and
+    # applied to $prebuiltArgs lower down; compose both real snippets.
+    normalize = _ps1_search(
+        r'\$llamaBackend = "\$\(\$env:UNSLOTH_LLAMA_CPP_BACKEND\)".*?Write-Host.*?\n\s*\}',
+        re.DOTALL,
+    )
+    apply_flag = _ps1_search(
+        r'if \(\$llamaBackend -eq "cpu"\) \{\s*\$prebuiltArgs \+= "--cpu-fallback"\s*\}'
+    )
     env = {k: v for k, v in os.environ.items() if k != "UNSLOTH_LLAMA_CPP_BACKEND"}
     if value is not None:
         env["UNSLOTH_LLAMA_CPP_BACKEND"] = value
-    harness = f'$prebuiltArgs = @()\n{_ps1_block()}\n"ARGS:" + ($prebuiltArgs -join ",")'
+    harness = f'$prebuiltArgs = @()\n{normalize}\n{apply_flag}\n"ARGS:" + ($prebuiltArgs -join ",")'
     out = subprocess.run(
         ["pwsh", "-NoProfile", "-Command", harness],
         capture_output = True,
         text = True,
         env = env,
         check = True,
+    )
+    return out.stdout
+
+
+def _run_ps1_expected_kinds(backend: str, has_nvidia: bool) -> str:
+    # The mismatch-prune must treat a forced-CPU install as expected on a GPU host, or
+    # persisting install_kind deletes a valid windows-cpu bundle every rerun (#7228).
+    kinds = _ps1_search(
+        r"\$expectedKinds = if .*?else \{ @\(\"windows-cpu\", \"windows-arm64\"\) \}"
+    )
+    harness = (
+        f"$HasNvidiaSmi=${str(has_nvidia).lower()}; $HasROCm=$false; $script:ROCmGfxArch=$null\n"
+        f'$llamaBackend="{backend}"\n{kinds}\n"KINDS:" + ($expectedKinds -join ",")'
+    )
+    out = subprocess.run(
+        ["pwsh", "-NoProfile", "-Command", harness], capture_output = True, text = True, check = True
     )
     return out.stdout
 
@@ -116,3 +140,18 @@ def test_ps1_backend_unknown_warns_and_no_flag(value):
     out = _run_ps1(value)
     assert "--cpu-fallback" not in out
     assert "Ignoring" in out
+
+
+@_SKIP_NO_PWSH
+def test_ps1_cpu_override_keeps_cpu_expected_on_gpu_host():
+    # Forced CPU on an NVIDIA host: windows-cpu must stay expected so the mismatch
+    # prune does not delete a deliberate CPU install (#7228).
+    assert "windows-cpu" in _run_ps1_expected_kinds("cpu", has_nvidia = True)
+
+
+@_SKIP_NO_PWSH
+def test_ps1_auto_prunes_cpu_on_nvidia_host():
+    # Without the override an NVIDIA host still expects only windows-cuda.
+    out = _run_ps1_expected_kinds("auto", has_nvidia = True)
+    assert "windows-cuda" in out
+    assert "windows-cpu" not in out

--- a/studio/backend/tests/test_setup_llama_cpp_backend.py
+++ b/studio/backend/tests/test_setup_llama_cpp_backend.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""setup.sh must map UNSLOTH_LLAMA_CPP_BACKEND=cpu to install_llama_prebuilt.py's
+--cpu-fallback so users can force the CPU-only prebuilt on GPU hosts (#7213). The
+match is case-insensitive, matching setup.ps1's PowerShell -eq. Runs the real
+block extracted from setup.sh so the test tracks the shipped logic.
+"""
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SETUP_SH = Path(__file__).resolve().parents[2] / "setup.sh"
+
+
+def _backend_case_block() -> str:
+    text = _SETUP_SH.read_text(encoding = "utf-8")
+    m = re.search(r'case "\$\{UNSLOTH_LLAMA_CPP_BACKEND.*?esac', text, re.DOTALL)
+    assert m, "UNSLOTH_LLAMA_CPP_BACKEND case block not found in setup.sh"
+    return m.group(0)
+
+
+def _run(value: str | None) -> list[str]:
+    assign = "" if value is None else f"export UNSLOTH_LLAMA_CPP_BACKEND={value}\n"
+    script = f'_PREBUILT_CMD=()\n{assign}{_backend_case_block()}\nprintf "%s\\n" "${{_PREBUILT_CMD[@]}}"'
+    out = subprocess.run(["bash", "-c", script], capture_output = True, text = True, check = True)
+    return out.stdout.split()
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason = "bash unavailable")
+@pytest.mark.parametrize("value", ["cpu", "CPU", "Cpu"])
+def test_backend_cpu_appends_flag(value):
+    assert "--cpu-fallback" in _run(value)
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason = "bash unavailable")
+@pytest.mark.parametrize("value", [None, "auto", "vulkan"])
+def test_backend_non_cpu_no_flag(value):
+    assert "--cpu-fallback" not in _run(value)

--- a/studio/backend/tests/test_setup_llama_cpp_backend.py
+++ b/studio/backend/tests/test_setup_llama_cpp_backend.py
@@ -2,11 +2,11 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 """setup.sh and setup.ps1 must map UNSLOTH_LLAMA_CPP_BACKEND=cpu to
-install_llama_prebuilt.py's --cpu-fallback so users can force the CPU-only
-prebuilt on GPU hosts (#7213). The match is case-insensitive and
-whitespace-trimmed, and an unrecognized value warns instead of silently falling
-back. Runs the real block extracted from each script so the tests track the
-shipped logic.
+install_llama_prebuilt.py's --force-cpu so users can force the CPU-only prebuilt
+on GPU hosts (#7213). The match is case-insensitive and whitespace-trimmed, an
+unrecognized value warns instead of silently falling back, and macOS warns (no
+CPU-only bundle). Runs the real block extracted from each script so the tests
+track the shipped logic.
 """
 
 import os
@@ -31,14 +31,16 @@ def _backend_block() -> str:
     return m.group(0)
 
 
-def _run(value: str | None) -> tuple[list[str], str]:
+def _run(value: str | None, system: str = "Linux") -> tuple[list[str], str]:
     # Pass the value through env (not the script text) so whitespace survives, and
-    # stub the setup.sh logging helpers the unknown-value branch calls.
+    # stub the setup.sh logging helpers the unknown-value branch calls. system sets
+    # _HOST_SYSTEM so the macOS (Darwin) no-op branch can be exercised.
     env = {k: v for k, v in os.environ.items() if k != "UNSLOTH_LLAMA_CPP_BACKEND"}
     if value is not None:
         env["UNSLOTH_LLAMA_CPP_BACKEND"] = value
     harness = (
-        '_PREBUILT_CMD=()\nC_WARN=""\nstep() { printf "STEP: %s\\n" "$*" >&2; }\n'
+        f'_PREBUILT_CMD=()\nC_WARN=""\n_HOST_SYSTEM="{system}"\n'
+        'step() { printf "STEP: %s\\n" "$*" >&2; }\n'
         f"{_backend_block()}\n"
         'printf "%s\\n" "${_PREBUILT_CMD[@]}"'
     )
@@ -51,16 +53,30 @@ def _run(value: str | None) -> tuple[list[str], str]:
 @_SKIP_NO_BASH
 @pytest.mark.parametrize("value", ["cpu", "CPU", "Cpu", " cpu ", "CPU\t"])
 def test_backend_cpu_appends_flag(value):
+    # A deliberate CPU choice persists, so it uses --force-cpu (not the transient
+    # --cpu-fallback the arm64 GPU-build recovery uses).
     args, stderr = _run(value)
-    assert "--cpu-fallback" in args
+    assert "--force-cpu" in args
+    assert "--cpu-fallback" not in args
     assert "Ignoring" not in stderr
+
+
+@_SKIP_NO_BASH
+@pytest.mark.parametrize("value", ["cpu", "CPU", " cpu "])
+def test_backend_cpu_macos_warns_no_flag(value):
+    # macOS has no CPU-only bundle (the universal build already runs on CPU), so the
+    # override warns instead of writing a misleading forced-CPU marker.
+    args, stderr = _run(value, system = "Darwin")
+    assert "--force-cpu" not in args
+    assert "--cpu-fallback" not in args
+    assert "macOS" in stderr
 
 
 @_SKIP_NO_BASH
 @pytest.mark.parametrize("value", [None, "", "auto", "AUTO", "  "])
 def test_backend_auto_no_flag_no_warn(value):
     args, stderr = _run(value)
-    assert "--cpu-fallback" not in args
+    assert "--force-cpu" not in args
     assert "Ignoring" not in stderr
 
 
@@ -68,8 +84,20 @@ def test_backend_auto_no_flag_no_warn(value):
 @pytest.mark.parametrize("value", ["vulkan", "gpu", "cuda"])
 def test_backend_unknown_warns_and_no_flag(value):
     args, stderr = _run(value)
-    assert "--cpu-fallback" not in args
+    assert "--force-cpu" not in args
     assert "Ignoring" in stderr
+
+
+@_SKIP_NO_BASH
+def test_arm64_recovery_uses_transient_cpu_fallback():
+    # The arm64 Linux GPU-build recovery must stay transient (--cpu-fallback), never
+    # the persisted --force-cpu, so a later update can still heal to a GPU bundle (#6097).
+    text = _SETUP_SH.read_text(encoding = "utf-8")
+    m = re.search(r"_ARM64_CPU_CMD=\((.*?)\)", text, re.DOTALL)
+    assert m, "arm64 CPU recovery command not found in setup.sh"
+    block = m.group(1)
+    assert "--cpu-fallback" in block
+    assert "--force-cpu" not in block
 
 
 def _ps1_search(pattern: str, flags = 0) -> str:
@@ -86,7 +114,7 @@ def _run_ps1(value: str | None) -> str:
         re.DOTALL,
     )
     apply_flag = _ps1_search(
-        r'if \(\$llamaBackend -eq "cpu"\) \{\s*\$prebuiltArgs \+= "--cpu-fallback"\s*\}'
+        r'if \(\$llamaBackend -eq "cpu"\) \{\s*\$prebuiltArgs \+= "--force-cpu"\s*\}'
     )
     env = {k: v for k, v in os.environ.items() if k != "UNSLOTH_LLAMA_CPP_BACKEND"}
     if value is not None:
@@ -106,7 +134,7 @@ def _run_ps1(value: str | None) -> str:
 @pytest.mark.parametrize("value", ["cpu", "CPU", "Cpu", " cpu ", "CPU\t"])
 def test_ps1_backend_cpu_appends_flag(value):
     out = _run_ps1(value)
-    assert "--cpu-fallback" in out
+    assert "--force-cpu" in out
     assert "Ignoring" not in out
 
 
@@ -114,7 +142,7 @@ def test_ps1_backend_cpu_appends_flag(value):
 @pytest.mark.parametrize("value", [None, "", "auto", "AUTO", "  "])
 def test_ps1_backend_auto_no_flag_no_warn(value):
     out = _run_ps1(value)
-    assert "--cpu-fallback" not in out
+    assert "--force-cpu" not in out
     assert "Ignoring" not in out
 
 
@@ -122,5 +150,5 @@ def test_ps1_backend_auto_no_flag_no_warn(value):
 @pytest.mark.parametrize("value", ["vulkan", "gpu", "cuda"])
 def test_ps1_backend_unknown_warns_and_no_flag(value):
     out = _run_ps1(value)
-    assert "--cpu-fallback" not in out
+    assert "--force-cpu" not in out
     assert "Ignoring" in out

--- a/studio/backend/tests/test_setup_llama_cpp_backend.py
+++ b/studio/backend/tests/test_setup_llama_cpp_backend.py
@@ -102,24 +102,6 @@ def _run_ps1(value: str | None) -> str:
     return out.stdout
 
 
-def _ps1_prune_decision(backend: str, nvidia: bool, rocm: bool, existing_kind: str) -> str:
-    # Run the real setup.ps1 expectedKinds + prune check for one host/install combo.
-    # Persisting install_kind activates this prune, so it must keep every valid
-    # current-host install and only drop a bundle the host cannot run (#7228).
-    kinds = _ps1_search(
-        r'\$expectedKinds = if .*?else \{ @\("windows-vulkan", "windows-cpu", "windows-arm64"\) \}'
-    )
-    harness = (
-        f"$HasNvidiaSmi=${str(nvidia).lower()}; $HasROCm=${str(rocm).lower()}; $script:ROCmGfxArch=$null\n"
-        f'$llamaBackend="{backend}"; $existingKind="{existing_kind}"\n{kinds}\n'
-        'if ($existingKind -and ($existingKind -notin $expectedKinds)) { "PRUNE" } else { "KEEP" }'
-    )
-    out = subprocess.run(
-        ["pwsh", "-NoProfile", "-Command", harness], capture_output = True, text = True, check = True
-    )
-    return out.stdout.strip()
-
-
 @_SKIP_NO_PWSH
 @pytest.mark.parametrize("value", ["cpu", "CPU", "Cpu", " cpu ", "CPU\t"])
 def test_ps1_backend_cpu_appends_flag(value):
@@ -142,30 +124,3 @@ def test_ps1_backend_unknown_warns_and_no_flag(value):
     out = _run_ps1(value)
     assert "--cpu-fallback" not in out
     assert "Ignoring" in out
-
-
-@_SKIP_NO_PWSH
-@pytest.mark.parametrize(
-    "backend, nvidia, rocm, existing, expected",
-    [
-        # Every valid current-host install is kept: the auto Intel->vulkan route and
-        # the per-vendor CPU/arm64 fallbacks used when a GPU prebuilt is missing.
-        ("", False, False, "windows-vulkan", "KEEP"),
-        ("", False, False, "windows-cpu", "KEEP"),
-        ("", False, False, "windows-arm64", "KEEP"),
-        ("", True, False, "windows-cuda", "KEEP"),
-        ("", True, False, "windows-cpu", "KEEP"),
-        ("", False, True, "windows-rocm", "KEEP"),
-        ("", False, True, "windows-hip", "KEEP"),
-        ("", False, True, "windows-cpu", "KEEP"),
-        # Only a bundle this host cannot run is pruned.
-        ("", False, False, "windows-cuda", "PRUNE"),
-        ("", True, False, "windows-rocm", "PRUNE"),
-        ("", False, True, "windows-cuda", "PRUNE"),
-        # Forced CPU replaces a GPU install but keeps a CPU one.
-        ("cpu", False, False, "windows-vulkan", "PRUNE"),
-        ("cpu", True, False, "windows-cpu", "KEEP"),
-    ],
-)
-def test_ps1_prune_keeps_valid_installs(backend, nvidia, rocm, existing, expected):
-    assert _ps1_prune_decision(backend, nvidia, rocm, existing) == expected

--- a/studio/backend/tests/test_setup_llama_cpp_backend.py
+++ b/studio/backend/tests/test_setup_llama_cpp_backend.py
@@ -1,12 +1,15 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""setup.sh must map UNSLOTH_LLAMA_CPP_BACKEND=cpu to install_llama_prebuilt.py's
---cpu-fallback so users can force the CPU-only prebuilt on GPU hosts (#7213). The
-match is case-insensitive, matching setup.ps1's PowerShell -eq. Runs the real
-block extracted from setup.sh so the test tracks the shipped logic.
+"""setup.sh and setup.ps1 must map UNSLOTH_LLAMA_CPP_BACKEND=cpu to
+install_llama_prebuilt.py's --cpu-fallback so users can force the CPU-only
+prebuilt on GPU hosts (#7213). The match is case-insensitive and
+whitespace-trimmed, and an unrecognized value warns instead of silently falling
+back. Runs the real block extracted from each script so the tests track the
+shipped logic.
 """
 
+import os
 import re
 import shutil
 import subprocess
@@ -14,32 +17,102 @@ from pathlib import Path
 
 import pytest
 
-_SETUP_SH = Path(__file__).resolve().parents[2] / "setup.sh"
+_STUDIO = Path(__file__).resolve().parents[2]
+_SETUP_SH = _STUDIO / "setup.sh"
+_SETUP_PS1 = _STUDIO / "setup.ps1"
+_SKIP_NO_BASH = pytest.mark.skipif(shutil.which("bash") is None, reason = "bash unavailable")
+_SKIP_NO_PWSH = pytest.mark.skipif(shutil.which("pwsh") is None, reason = "pwsh unavailable")
 
 
-def _backend_case_block() -> str:
+def _backend_block() -> str:
     text = _SETUP_SH.read_text(encoding = "utf-8")
-    m = re.search(r'case "\$\{UNSLOTH_LLAMA_CPP_BACKEND.*?esac', text, re.DOTALL)
-    assert m, "UNSLOTH_LLAMA_CPP_BACKEND case block not found in setup.sh"
+    m = re.search(r"_llama_backend=.*?esac", text, re.DOTALL)
+    assert m, "UNSLOTH_LLAMA_CPP_BACKEND block not found in setup.sh"
     return m.group(0)
 
 
-def _run(value: str | None) -> list[str]:
-    assign = "" if value is None else f"export UNSLOTH_LLAMA_CPP_BACKEND={value}\n"
-    script = (
-        f'_PREBUILT_CMD=()\n{assign}{_backend_case_block()}\nprintf "%s\\n" "${{_PREBUILT_CMD[@]}}"'
+def _run(value: str | None) -> tuple[list[str], str]:
+    # Pass the value through env (not the script text) so whitespace survives, and
+    # stub the setup.sh logging helpers the unknown-value branch calls.
+    env = {k: v for k, v in os.environ.items() if k != "UNSLOTH_LLAMA_CPP_BACKEND"}
+    if value is not None:
+        env["UNSLOTH_LLAMA_CPP_BACKEND"] = value
+    harness = (
+        '_PREBUILT_CMD=()\nC_WARN=""\nstep() { printf "STEP: %s\\n" "$*" >&2; }\n'
+        f"{_backend_block()}\n"
+        'printf "%s\\n" "${_PREBUILT_CMD[@]}"'
     )
-    out = subprocess.run(["bash", "-c", script], capture_output = True, text = True, check = True)
-    return out.stdout.split()
+    out = subprocess.run(
+        ["bash", "-c", harness], capture_output = True, text = True, env = env, check = True
+    )
+    return out.stdout.split(), out.stderr
 
 
-@pytest.mark.skipif(shutil.which("bash") is None, reason = "bash unavailable")
-@pytest.mark.parametrize("value", ["cpu", "CPU", "Cpu"])
+@_SKIP_NO_BASH
+@pytest.mark.parametrize("value", ["cpu", "CPU", "Cpu", " cpu ", "CPU\t"])
 def test_backend_cpu_appends_flag(value):
-    assert "--cpu-fallback" in _run(value)
+    args, stderr = _run(value)
+    assert "--cpu-fallback" in args
+    assert "Ignoring" not in stderr
 
 
-@pytest.mark.skipif(shutil.which("bash") is None, reason = "bash unavailable")
-@pytest.mark.parametrize("value", [None, "auto", "vulkan"])
-def test_backend_non_cpu_no_flag(value):
-    assert "--cpu-fallback" not in _run(value)
+@_SKIP_NO_BASH
+@pytest.mark.parametrize("value", [None, "", "auto", "AUTO", "  "])
+def test_backend_auto_no_flag_no_warn(value):
+    args, stderr = _run(value)
+    assert "--cpu-fallback" not in args
+    assert "Ignoring" not in stderr
+
+
+@_SKIP_NO_BASH
+@pytest.mark.parametrize("value", ["vulkan", "gpu", "cuda"])
+def test_backend_unknown_warns_and_no_flag(value):
+    args, stderr = _run(value)
+    assert "--cpu-fallback" not in args
+    assert "Ignoring" in stderr
+
+
+def _ps1_block() -> str:
+    text = _SETUP_PS1.read_text(encoding = "utf-8")
+    m = re.search(r"\$llamaBackend =.*?Write-Host.*?\n\s*\}", text, re.DOTALL)
+    assert m, "UNSLOTH_LLAMA_CPP_BACKEND block not found in setup.ps1"
+    return m.group(0)
+
+
+def _run_ps1(value: str | None) -> str:
+    env = {k: v for k, v in os.environ.items() if k != "UNSLOTH_LLAMA_CPP_BACKEND"}
+    if value is not None:
+        env["UNSLOTH_LLAMA_CPP_BACKEND"] = value
+    harness = f'$prebuiltArgs = @()\n{_ps1_block()}\n"ARGS:" + ($prebuiltArgs -join ",")'
+    out = subprocess.run(
+        ["pwsh", "-NoProfile", "-Command", harness],
+        capture_output = True,
+        text = True,
+        env = env,
+        check = True,
+    )
+    return out.stdout
+
+
+@_SKIP_NO_PWSH
+@pytest.mark.parametrize("value", ["cpu", "CPU", "Cpu", " cpu ", "CPU\t"])
+def test_ps1_backend_cpu_appends_flag(value):
+    out = _run_ps1(value)
+    assert "--cpu-fallback" in out
+    assert "Ignoring" not in out
+
+
+@_SKIP_NO_PWSH
+@pytest.mark.parametrize("value", [None, "", "auto", "AUTO", "  "])
+def test_ps1_backend_auto_no_flag_no_warn(value):
+    out = _run_ps1(value)
+    assert "--cpu-fallback" not in out
+    assert "Ignoring" not in out
+
+
+@_SKIP_NO_PWSH
+@pytest.mark.parametrize("value", ["vulkan", "gpu", "cuda"])
+def test_ps1_backend_unknown_warns_and_no_flag(value):
+    out = _run_ps1(value)
+    assert "--cpu-fallback" not in out
+    assert "Ignoring" in out

--- a/studio/backend/tests/test_setup_llama_cpp_backend.py
+++ b/studio/backend/tests/test_setup_llama_cpp_backend.py
@@ -102,20 +102,22 @@ def _run_ps1(value: str | None) -> str:
     return out.stdout
 
 
-def _run_ps1_expected_kinds(backend: str, has_nvidia: bool) -> str:
-    # The mismatch-prune must treat a forced-CPU install as expected on a GPU host, or
-    # persisting install_kind deletes a valid windows-cpu bundle every rerun (#7228).
+def _ps1_prune_decision(backend: str, nvidia: bool, rocm: bool, existing_kind: str) -> str:
+    # Run the real setup.ps1 expectedKinds + prune check for one host/install combo.
+    # Persisting install_kind activates this prune, so it must keep every valid
+    # current-host install and only drop a bundle the host cannot run (#7228).
     kinds = _ps1_search(
-        r"\$expectedKinds = if .*?else \{ @\(\"windows-cpu\", \"windows-arm64\"\) \}"
+        r'\$expectedKinds = if .*?else \{ @\("windows-vulkan", "windows-cpu", "windows-arm64"\) \}'
     )
     harness = (
-        f"$HasNvidiaSmi=${str(has_nvidia).lower()}; $HasROCm=$false; $script:ROCmGfxArch=$null\n"
-        f'$llamaBackend="{backend}"\n{kinds}\n"KINDS:" + ($expectedKinds -join ",")'
+        f"$HasNvidiaSmi=${str(nvidia).lower()}; $HasROCm=${str(rocm).lower()}; $script:ROCmGfxArch=$null\n"
+        f'$llamaBackend="{backend}"; $existingKind="{existing_kind}"\n{kinds}\n'
+        'if ($existingKind -and ($existingKind -notin $expectedKinds)) { "PRUNE" } else { "KEEP" }'
     )
     out = subprocess.run(
         ["pwsh", "-NoProfile", "-Command", harness], capture_output = True, text = True, check = True
     )
-    return out.stdout
+    return out.stdout.strip()
 
 
 @_SKIP_NO_PWSH
@@ -143,15 +145,27 @@ def test_ps1_backend_unknown_warns_and_no_flag(value):
 
 
 @_SKIP_NO_PWSH
-def test_ps1_cpu_override_keeps_cpu_expected_on_gpu_host():
-    # Forced CPU on an NVIDIA host: windows-cpu must stay expected so the mismatch
-    # prune does not delete a deliberate CPU install (#7228).
-    assert "windows-cpu" in _run_ps1_expected_kinds("cpu", has_nvidia = True)
-
-
-@_SKIP_NO_PWSH
-def test_ps1_auto_prunes_cpu_on_nvidia_host():
-    # Without the override an NVIDIA host still expects only windows-cuda.
-    out = _run_ps1_expected_kinds("auto", has_nvidia = True)
-    assert "windows-cuda" in out
-    assert "windows-cpu" not in out
+@pytest.mark.parametrize(
+    "backend, nvidia, rocm, existing, expected",
+    [
+        # Every valid current-host install is kept: the auto Intel->vulkan route and
+        # the per-vendor CPU/arm64 fallbacks used when a GPU prebuilt is missing.
+        ("", False, False, "windows-vulkan", "KEEP"),
+        ("", False, False, "windows-cpu", "KEEP"),
+        ("", False, False, "windows-arm64", "KEEP"),
+        ("", True, False, "windows-cuda", "KEEP"),
+        ("", True, False, "windows-cpu", "KEEP"),
+        ("", False, True, "windows-rocm", "KEEP"),
+        ("", False, True, "windows-hip", "KEEP"),
+        ("", False, True, "windows-cpu", "KEEP"),
+        # Only a bundle this host cannot run is pruned.
+        ("", False, False, "windows-cuda", "PRUNE"),
+        ("", True, False, "windows-rocm", "PRUNE"),
+        ("", False, True, "windows-cuda", "PRUNE"),
+        # Forced CPU replaces a GPU install but keeps a CPU one.
+        ("cpu", False, False, "windows-vulkan", "PRUNE"),
+        ("cpu", True, False, "windows-cpu", "KEEP"),
+    ],
+)
+def test_ps1_prune_keeps_valid_installs(backend, nvidia, rocm, existing, expected):
+    assert _ps1_prune_decision(backend, nvidia, rocm, existing) == expected

--- a/studio/backend/tests/test_setup_llama_cpp_backend.py
+++ b/studio/backend/tests/test_setup_llama_cpp_backend.py
@@ -26,7 +26,9 @@ def _backend_case_block() -> str:
 
 def _run(value: str | None) -> list[str]:
     assign = "" if value is None else f"export UNSLOTH_LLAMA_CPP_BACKEND={value}\n"
-    script = f'_PREBUILT_CMD=()\n{assign}{_backend_case_block()}\nprintf "%s\\n" "${{_PREBUILT_CMD[@]}}"'
+    script = (
+        f'_PREBUILT_CMD=()\n{assign}{_backend_case_block()}\nprintf "%s\\n" "${{_PREBUILT_CMD[@]}}"'
+    )
     out = subprocess.run(["bash", "-c", script], capture_output = True, text = True, check = True)
     return out.stdout.split()
 

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -523,12 +523,12 @@ def _run_update(
         if pin_release_tag:
             cmd.extend(["--published-release-tag", pin_release_tag])
         cmd.extend(_rocm_install_args(asset))
-        # Re-assert an explicitly forced CPU install (--cpu-fallback) so detect_host on a
-        # GPU host does not re-route to a GPU/Vulkan bundle and revive the crash (#7213).
-        # Only an explicit force is preserved: a natural CPU fallback (or a legacy marker
-        # without the flag) stays free to heal to a GPU bundle (#6097).
+        # Re-assert a deliberate CPU install (--force-cpu) so detect_host on a GPU host
+        # does not re-route to a GPU/Vulkan bundle and revive the crash (#7213). --force-cpu
+        # (not --cpu-fallback) also re-persists force_cpu, keeping the choice across future
+        # updates. A natural fallback (or a legacy marker without the flag) heals to GPU (#6097).
         if force_cpu:
-            cmd.append("--cpu-fallback")
+            cmd.append("--force-cpu")
         logger.info("llama update: installing", cmd = " ".join(cmd))
         # Stream progress lines into job["progress"].
         env = dict(os.environ, UNSLOTH_PROGRESS_PERCENT_STEP = "5")

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -479,6 +479,7 @@ def _run_update(
     asset: Optional[str],
     script: Path,
     pin_release_tag: Optional[str] = None,
+    install_kind: Optional[str] = None,
 ) -> None:
     """Worker: put the backend into a maintenance state, run the installer for
     the latest prebuilt, then refresh caches so the next load uses the new build.
@@ -522,6 +523,12 @@ def _run_update(
         if pin_release_tag:
             cmd.extend(["--published-release-tag", pin_release_tag])
         cmd.extend(_rocm_install_args(asset))
+        # Preserve a forced-CPU install across updates: on an Intel iGPU box
+        # detect_host would otherwise re-route to the Vulkan bundle and bring
+        # back the crash the override avoids (#7213). install_kind is *-cpu for
+        # every CPU bundle; the asset name has no "cpu" marker on Linux.
+        if install_kind and install_kind.endswith("-cpu"):
+            cmd.append("--cpu-fallback")
         logger.info("llama update: installing", cmd = " ".join(cmd))
         # Stream progress lines into job["progress"].
         env = dict(os.environ, UNSLOTH_PROGRESS_PERCENT_STEP = "5")
@@ -671,6 +678,7 @@ def start_update() -> dict:
         repo = marker.get("published_repo") or DEFAULT_PUBLISHED_REPO
         from_tag = marker.get("tag") or marker.get("release_tag")
         asset = marker.get("asset")
+        install_kind = marker.get("install_kind")
         # Install exactly the release the banner offered: the installer's own
         # "latest" is commit-date ordered and can lag the published_at pick
         # above, reinstalling the current build in a loop (the #6219 class).
@@ -705,6 +713,7 @@ def start_update() -> dict:
         repo = (res or {}).get("repo") or DEFAULT_PUBLISHED_REPO
         from_tag = None
         asset = (res or {}).get("asset")
+        install_kind = (res or {}).get("install_kind")
         # No pin: source-build detection resolves via --resolve-prebuilt latest,
         # the same resolver the unpinned apply uses, so the two already agree.
         pin_release_tag = None
@@ -735,7 +744,7 @@ def start_update() -> dict:
 
     thread = threading.Thread(
         target = _run_update,
-        args = (install_dir, repo, asset, script, pin_release_tag),
+        args = (install_dir, repo, asset, script, pin_release_tag, install_kind),
         name = "llama-cpp-update",
         daemon = True,
     )

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -473,6 +473,12 @@ def _rocm_install_args(asset: Optional[str]) -> list[str]:
     return ["--has-rocm"]
 
 
+# CPU-only prebuilt kinds that detect_host would re-route to a GPU/source build on a
+# GPU host if --cpu-fallback is dropped: the x86_64 (*-cpu) and arm64 (*-arm64) bundles
+# on Linux and Windows. macOS bundles ignore --cpu-fallback, so are omitted.
+_CPU_INSTALL_KINDS = ("linux-cpu", "windows-cpu", "linux-arm64", "windows-arm64")
+
+
 def _run_update(
     install_dir: Path,
     repo: str,
@@ -523,11 +529,12 @@ def _run_update(
         if pin_release_tag:
             cmd.extend(["--published-release-tag", pin_release_tag])
         cmd.extend(_rocm_install_args(asset))
-        # Preserve a forced-CPU install across updates: on an Intel iGPU box
-        # detect_host would otherwise re-route to the Vulkan bundle and bring
-        # back the crash the override avoids (#7213). install_kind is *-cpu for
-        # every CPU bundle; the asset name has no "cpu" marker on Linux.
-        if install_kind and install_kind.endswith("-cpu"):
+        # Preserve a CPU install across updates: on a GPU host detect_host would
+        # otherwise re-route to a GPU/Vulkan bundle (or source build) and bring back
+        # the crash the override avoids (#7213). The marker's install_kind is
+        # authoritative -- the asset name has no reliable "cpu" marker (Linux x64 CPU
+        # is bin-ubuntu-x64, and arm64 CPU kinds are *-arm64, not *-cpu).
+        if install_kind in _CPU_INSTALL_KINDS:
             cmd.append("--cpu-fallback")
         logger.info("llama update: installing", cmd = " ".join(cmd))
         # Stream progress lines into job["progress"].

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -533,7 +533,8 @@ def _run_update(
         # otherwise re-route to a GPU/Vulkan bundle (or source build) and bring back
         # the crash the override avoids (#7213). The marker's install_kind is
         # authoritative -- the asset name has no reliable "cpu" marker (Linux x64 CPU
-        # is bin-ubuntu-x64, and arm64 CPU kinds are *-arm64, not *-cpu).
+        # is bin-ubuntu-x64, and arm64 CPU kinds are *-arm64, not *-cpu). Legacy
+        # markers without install_kind keep the pre-#6097 heal-to-GPU behaviour.
         if install_kind in _CPU_INSTALL_KINDS:
             cmd.append("--cpu-fallback")
         logger.info("llama update: installing", cmd = " ".join(cmd))

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -473,18 +473,13 @@ def _rocm_install_args(asset: Optional[str]) -> list[str]:
     return ["--has-rocm"]
 
 
-# CPU-only prebuilt kinds to re-assert with --cpu-fallback on update: the x86_64
-# (*-cpu) and arm64 (*-arm64) Linux/Windows bundles. macOS ignores it, so is omitted.
-_CPU_INSTALL_KINDS = ("linux-cpu", "windows-cpu", "linux-arm64", "windows-arm64")
-
-
 def _run_update(
     install_dir: Path,
     repo: str,
     asset: Optional[str],
     script: Path,
     pin_release_tag: Optional[str] = None,
-    install_kind: Optional[str] = None,
+    force_cpu: bool = False,
 ) -> None:
     """Worker: put the backend into a maintenance state, run the installer for
     the latest prebuilt, then refresh caches so the next load uses the new build.
@@ -528,11 +523,11 @@ def _run_update(
         if pin_release_tag:
             cmd.extend(["--published-release-tag", pin_release_tag])
         cmd.extend(_rocm_install_args(asset))
-        # Preserve a CPU install across updates, else detect_host on a GPU host
-        # re-routes to a GPU/Vulkan bundle and revives the crash (#7213). Keyed off
-        # install_kind, not the asset (Linux x64 CPU is bin-ubuntu-x64, arm64 is
-        # *-arm64); legacy markers without it keep #6097 heal-to-GPU.
-        if install_kind in _CPU_INSTALL_KINDS:
+        # Re-assert an explicitly forced CPU install (--cpu-fallback) so detect_host on a
+        # GPU host does not re-route to a GPU/Vulkan bundle and revive the crash (#7213).
+        # Only an explicit force is preserved: a natural CPU fallback (or a legacy marker
+        # without the flag) stays free to heal to a GPU bundle (#6097).
+        if force_cpu:
             cmd.append("--cpu-fallback")
         logger.info("llama update: installing", cmd = " ".join(cmd))
         # Stream progress lines into job["progress"].
@@ -683,7 +678,7 @@ def start_update() -> dict:
         repo = marker.get("published_repo") or DEFAULT_PUBLISHED_REPO
         from_tag = marker.get("tag") or marker.get("release_tag")
         asset = marker.get("asset")
-        install_kind = marker.get("install_kind")
+        force_cpu = bool(marker.get("force_cpu"))
         # Install exactly the release the banner offered: the installer's own
         # "latest" is commit-date ordered and can lag the published_at pick
         # above, reinstalling the current build in a loop (the #6219 class).
@@ -718,7 +713,8 @@ def start_update() -> dict:
         repo = (res or {}).get("repo") or DEFAULT_PUBLISHED_REPO
         from_tag = None
         asset = (res or {}).get("asset")
-        install_kind = (res or {}).get("install_kind")
+        # Source builds carry no forced-CPU marker, so nothing to preserve here.
+        force_cpu = False
         # No pin: source-build detection resolves via --resolve-prebuilt latest,
         # the same resolver the unpinned apply uses, so the two already agree.
         pin_release_tag = None
@@ -749,7 +745,7 @@ def start_update() -> dict:
 
     thread = threading.Thread(
         target = _run_update,
-        args = (install_dir, repo, asset, script, pin_release_tag, install_kind),
+        args = (install_dir, repo, asset, script, pin_release_tag, force_cpu),
         name = "llama-cpp-update",
         daemon = True,
     )

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -473,9 +473,8 @@ def _rocm_install_args(asset: Optional[str]) -> list[str]:
     return ["--has-rocm"]
 
 
-# CPU-only prebuilt kinds that detect_host would re-route to a GPU/source build on a
-# GPU host if --cpu-fallback is dropped: the x86_64 (*-cpu) and arm64 (*-arm64) bundles
-# on Linux and Windows. macOS bundles ignore --cpu-fallback, so are omitted.
+# CPU-only prebuilt kinds to re-assert with --cpu-fallback on update: the x86_64
+# (*-cpu) and arm64 (*-arm64) Linux/Windows bundles. macOS ignores it, so is omitted.
 _CPU_INSTALL_KINDS = ("linux-cpu", "windows-cpu", "linux-arm64", "windows-arm64")
 
 
@@ -529,12 +528,10 @@ def _run_update(
         if pin_release_tag:
             cmd.extend(["--published-release-tag", pin_release_tag])
         cmd.extend(_rocm_install_args(asset))
-        # Preserve a CPU install across updates: on a GPU host detect_host would
-        # otherwise re-route to a GPU/Vulkan bundle (or source build) and bring back
-        # the crash the override avoids (#7213). The marker's install_kind is
-        # authoritative -- the asset name has no reliable "cpu" marker (Linux x64 CPU
-        # is bin-ubuntu-x64, and arm64 CPU kinds are *-arm64, not *-cpu). Legacy
-        # markers without install_kind keep the pre-#6097 heal-to-GPU behaviour.
+        # Preserve a CPU install across updates, else detect_host on a GPU host
+        # re-routes to a GPU/Vulkan bundle and revives the crash (#7213). Keyed off
+        # install_kind, not the asset (Linux x64 CPU is bin-ubuntu-x64, arm64 is
+        # *-arm64); legacy markers without it keep #6097 heal-to-GPU.
         if install_kind in _CPU_INSTALL_KINDS:
             cmd.append("--cpu-fallback")
         logger.info("llama update: installing", cmd = " ".join(cmd))

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -6474,6 +6474,9 @@ def write_prebuilt_metadata(
         "release_tag": release_tag,
         "published_repo": approved_checksums.repo,
         "asset": choice.name,
+        # Canonical backend of this install (e.g. linux-cpu/linux-vulkan); lets
+        # the in-app updater re-assert a forced-CPU build across updates (#7213).
+        "install_kind": choice.install_kind,
         "asset_sha256": choice.expected_sha256,
         "source": choice.source_label,
         # Binary-side repo/tag for non-fork sources (e.g. the ggml-org upstream

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -6474,8 +6474,8 @@ def write_prebuilt_metadata(
         "release_tag": release_tag,
         "published_repo": approved_checksums.repo,
         "asset": choice.name,
-        # Canonical backend of this install (e.g. linux-cpu/linux-vulkan); lets
-        # the in-app updater re-assert a forced-CPU build across updates (#7213).
+        # Canonical backend (e.g. linux-cpu); lets the updater re-assert a forced-CPU
+        # build across updates (#7213).
         "install_kind": choice.install_kind,
         "asset_sha256": choice.expected_sha256,
         "source": choice.source_label,

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -6506,6 +6506,24 @@ def write_prebuilt_metadata(
     (install_dir / "UNSLOTH_PREBUILT_INFO.json").write_text(json.dumps(metadata, indent = 2) + "\n")
 
 
+def sync_marker_force_cpu(install_dir: Path, persist_force_cpu: bool) -> None:
+    """Sync only the force_cpu flag of an existing marker when the resolved bundle is
+    unchanged, so the install is skipped without a full metadata rewrite. A deliberate
+    --force-cpu on top of a naturally installed CPU bundle (same asset) must still be
+    recorded, else the updater will not re-assert it and can re-route the install to a
+    GPU/Vulkan bundle that revives the crash (#7213)."""
+    marker_path = install_dir / "UNSLOTH_PREBUILT_INFO.json"
+    try:
+        marker = json.loads(marker_path.read_text())
+    except (OSError, ValueError):
+        return
+    if not isinstance(marker, dict) or bool(marker.get("force_cpu")) == persist_force_cpu:
+        return
+    marker["force_cpu"] = persist_force_cpu
+    marker_path.write_text(json.dumps(marker, indent = 2) + "\n")
+    log(f"existing install reused; recorded force_cpu={persist_force_cpu} from this run")
+
+
 def expected_install_fingerprint(
     *,
     llama_tag: str,
@@ -7084,6 +7102,9 @@ def install_prebuilt(
                         "existing llama.cpp install already matches selected release "
                         f"{current.release_tag} upstream_tag={current.llama_tag}; skipping download and install"
                     )
+                    # Reused bundle is unchanged, but a fresh --force-cpu still must be
+                    # recorded so the updater re-asserts it (#7213).
+                    sync_marker_force_cpu(install_dir, persist_force_cpu)
                     return
             with tempfile.TemporaryDirectory(prefix = "unsloth-llama-prebuilt-") as tmp:
                 work_dir = Path(tmp)
@@ -7104,6 +7125,7 @@ def install_prebuilt(
                                 "existing llama.cpp install already matches fallback release "
                                 f"{plan.release_tag} upstream_tag={plan.llama_tag}; skipping reinstall"
                             )
+                            sync_marker_force_cpu(install_dir, persist_force_cpu)
                             return
                     log(
                         "selected "

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -6450,6 +6450,7 @@ def write_prebuilt_metadata(
     choice: AssetChoice,
     approved_checksums: ApprovedReleaseChecksums,
     prebuilt_fallback_used: bool,
+    force_cpu: bool = False,
 ) -> None:
     source_asset_name, source_sha256 = selected_source_archive_metadata(
         approved_checksums,
@@ -6474,9 +6475,10 @@ def write_prebuilt_metadata(
         "release_tag": release_tag,
         "published_repo": approved_checksums.repo,
         "asset": choice.name,
-        # Canonical backend (e.g. linux-cpu); lets the updater re-assert a forced-CPU
-        # build across updates (#7213).
-        "install_kind": choice.install_kind,
+        # Whether CPU was explicitly forced (--cpu-fallback). The updater re-asserts it
+        # so a deliberate CPU install is not re-routed to a GPU bundle (#7213); a natural
+        # CPU fallback stays False so it can still heal to GPU.
+        "force_cpu": force_cpu,
         "asset_sha256": choice.expected_sha256,
         "source": choice.source_label,
         # Binary-side repo/tag for non-fork sources (e.g. the ggml-org upstream
@@ -6749,6 +6751,7 @@ def validate_prebuilt_choice(
     approved_checksums: ApprovedReleaseChecksums,
     prebuilt_fallback_used: bool,
     quantized_path: Path,
+    force_cpu: bool = False,
 ) -> tuple[Path, Path]:
     source_repo, source_ref, source_archive, exact_source = preferred_source_archive(
         approved_checksums, llama_tag
@@ -6789,6 +6792,7 @@ def validate_prebuilt_choice(
         choice = choice,
         approved_checksums = approved_checksums,
         prebuilt_fallback_used = prebuilt_fallback_used,
+        force_cpu = force_cpu,
     )
     # Hashless external prebuilts are not in the approved-sha256
     # manifest and rely on the functional smoke test as their only integrity gate,
@@ -6831,6 +6835,7 @@ def validate_prebuilt_attempts(
     approved_checksums: ApprovedReleaseChecksums,
     initial_fallback_used: bool = False,
     existing_install_dir: Path | None = None,
+    force_cpu: bool = False,
 ) -> tuple[AssetChoice, Path, bool]:
     attempt_list = list(attempts)
     if not attempt_list:
@@ -6883,6 +6888,7 @@ def validate_prebuilt_attempts(
                 approved_checksums = approved_checksums,
                 prebuilt_fallback_used = tried_fallback,
                 quantized_path = quantized_path,
+                force_cpu = force_cpu,
             )
         except Exception as exc:
             remove_tree(staging_dir)
@@ -7115,6 +7121,7 @@ def install_prebuilt(
                             initial_fallback_used = release_index > 0,
                             # Skip is gated per-attempt inside, so pass the dir always.
                             existing_install_dir = install_dir,
+                            force_cpu = force_cpu,
                         )
                     except ExistingInstallSatisfied:
                         return

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -6475,9 +6475,9 @@ def write_prebuilt_metadata(
         "release_tag": release_tag,
         "published_repo": approved_checksums.repo,
         "asset": choice.name,
-        # Whether CPU was explicitly forced (--cpu-fallback). The updater re-asserts it
-        # so a deliberate CPU install is not re-routed to a GPU bundle (#7213); a natural
-        # CPU fallback stays False so it can still heal to GPU.
+        # True only for a deliberate CPU choice (--force-cpu). The updater re-asserts it
+        # so a forced CPU install is not re-routed to a GPU bundle (#7213). An automatic
+        # --cpu-fallback (e.g. arm64 GPU-build recovery) stays False so it can heal to GPU.
         "force_cpu": force_cpu,
         "asset_sha256": choice.expected_sha256,
         "source": choice.source_label,
@@ -6948,8 +6948,8 @@ def _route_to_vulkan_prebuilt(
     """Point a Vulkan-capable host at the upstream ggml-org Vulkan prebuilt.
 
     The unsloth published repo ships only CUDA/ROCm/CPU assets, so Vulkan comes
-    from UPSTREAM_REPO. Two triggers route here, both suppressed under
-    --cpu-fallback (the explicit "give me CPU" last resort wins):
+    from UPSTREAM_REPO. Two triggers route here, both suppressed when a CPU flag
+    (--cpu-fallback or --force-cpu, folded into force_cpu) wins:
       * UNSLOTH_FORCE_VULKAN forces Vulkan over the detected CUDA/ROCm backend;
       * an auto-detected Intel GPU with NO physical NVIDIA/ROCm -- the purpose
         of the has_intel_gpu probe, since the fork manifest ships no Vulkan asset.
@@ -7029,8 +7029,11 @@ def install_prebuilt(
     override_has_rocm: bool = False,
     override_rocm_gfx: str | None = None,
     force_cpu: bool = False,
+    persist_force_cpu: bool = False,
     instruction_cleanup_root: Path | None = None,
 ) -> None:
+    # force_cpu drops GPU detection (mechanism, both --cpu-fallback and --force-cpu);
+    # persist_force_cpu records the deliberate choice so the updater re-asserts it.
     host = detect_host()
     host = _apply_host_overrides(
         host,
@@ -7121,7 +7124,8 @@ def install_prebuilt(
                             initial_fallback_used = release_index > 0,
                             # Skip is gated per-attempt inside, so pass the dir always.
                             existing_install_dir = install_dir,
-                            force_cpu = force_cpu,
+                            # Persist only the deliberate choice, not a transient fallback.
+                            force_cpu = persist_force_cpu,
                         )
                     except ExistingInstallSatisfied:
                         return
@@ -7219,8 +7223,21 @@ def parse_args() -> argparse.Namespace:
         default = False,
         help = (
             "Select the CPU prebuilt for this OS/arch even when a GPU is present. "
-            "setup.sh uses this as a last resort for arm64 Linux GPU hosts whose "
-            "source build failed (no arm64 CUDA prebuilt exists anywhere)."
+            "Automatic/transient: setup.sh uses this as a last resort for arm64 Linux "
+            "GPU hosts whose source build failed. Does NOT persist, so a later update "
+            "heals back to a GPU bundle once one is available (#6097). Use --force-cpu "
+            "for a deliberate CPU-only choice that survives updates."
+        ),
+    )
+    parser.add_argument(
+        "--force-cpu",
+        action = "store_true",
+        default = False,
+        help = (
+            "Deliberate CPU-only install (UNSLOTH_LLAMA_CPP_BACKEND=cpu). Drops GPU "
+            "detection like --cpu-fallback but also records force_cpu in the marker, so "
+            "the in-app updater re-asserts CPU and never re-routes to a GPU/Vulkan "
+            "bundle that would revive the Intel iGPU crash (#7213)."
         ),
     )
     resolve_group = parser.add_mutually_exclusive_group()
@@ -7343,16 +7360,19 @@ def main() -> int:
         # Host-aware "is a prebuilt available" probe, no download. Every host now
         # plans against the fork (args.published_repo defaults to it); an explicit
         # --published-repo overrides. PrebuiltFallback == source build.
+        # Both flags drop GPU detection; --force-cpu additionally persists (install
+        # path only). The probe only needs the mechanism, so OR them.
+        _cpu_mechanism = args.cpu_fallback or args.force_cpu
         host = _apply_host_overrides(
             detect_host(),
             override_has_rocm = args.has_rocm,
             override_rocm_gfx = args.rocm_gfx,
-            force_cpu = args.cpu_fallback,
+            force_cpu = _cpu_mechanism,
         )
         # Same Vulkan routing the install path applies, so the probe's answer
         # matches what would install (an Intel/forced-Vulkan host -> upstream).
         host, repo, release_tag = _route_to_vulkan_prebuilt(
-            host, args.published_repo, args.published_release_tag or "", force_cpu = args.cpu_fallback
+            host, args.published_repo, args.published_release_tag or "", force_cpu = _cpu_mechanism
         )
         try:
             _requested, plans = resolve_simple_install_release_plans(
@@ -7390,7 +7410,10 @@ def main() -> int:
         published_release_tag = args.published_release_tag or "",
         override_has_rocm = args.has_rocm,
         override_rocm_gfx = args.rocm_gfx,
-        force_cpu = args.cpu_fallback,
+        # Both drop GPU detection; only --force-cpu (deliberate) is recorded so the
+        # updater re-asserts it. --cpu-fallback stays transient and heals to GPU.
+        force_cpu = args.cpu_fallback or args.force_cpu,
+        persist_force_cpu = args.force_cpu,
         instruction_cleanup_root = install_arg.absolute(),
     )
     return EXIT_SUCCESS

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -3371,11 +3371,14 @@ if ($LocalLlamaCppLinked) {
         if ($env:UNSLOTH_LLAMA_RELEASE_TAG) {
             $prebuiltArgs += @("--published-release-tag", $env:UNSLOTH_LLAMA_RELEASE_TAG)
         }
-        # UNSLOTH_LLAMA_CPP_BACKEND: "auto" (default) or "cpu" -- forces the CPU-only
-        # prebuilt, bypassing Vulkan/CUDA/ROCm selection. Fixes Intel iGPU Vulkan
-        # crashes (#7213).
-        if ($env:UNSLOTH_LLAMA_CPP_BACKEND -eq "cpu") {
+        # UNSLOTH_LLAMA_CPP_BACKEND=cpu forces the CPU-only prebuilt (case-insensitive
+        # and whitespace-trimmed), bypassing Vulkan/CUDA/ROCm. Fixes Intel iGPU Vulkan
+        # crashes (#7213). Maps to install_llama_prebuilt.py --cpu-fallback.
+        $llamaBackend = "$($env:UNSLOTH_LLAMA_CPP_BACKEND)".Trim().ToLowerInvariant()
+        if ($llamaBackend -eq "cpu") {
             $prebuiltArgs += "--cpu-fallback"
+        } elseif ($llamaBackend -and $llamaBackend -ne "auto") {
+            Write-Host "[WARN] Ignoring UNSLOTH_LLAMA_CPP_BACKEND='$($env:UNSLOTH_LLAMA_CPP_BACKEND)' (expected 'auto' or 'cpu')" -ForegroundColor Yellow
         }
         $prevEAPPrebuilt = $ErrorActionPreference
         $ErrorActionPreference = "Continue"

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -3375,9 +3375,8 @@ if ($LocalLlamaCppLinked) {
         if ($env:UNSLOTH_LLAMA_RELEASE_TAG) {
             $prebuiltArgs += @("--published-release-tag", $env:UNSLOTH_LLAMA_RELEASE_TAG)
         }
-        # UNSLOTH_LLAMA_CPP_BACKEND=cpu forces the CPU-only prebuilt ($llamaBackend
-        # normalized above), bypassing Vulkan/CUDA/ROCm. Fixes Intel iGPU Vulkan
-        # crashes (#7213). Maps to install_llama_prebuilt.py --cpu-fallback.
+        # UNSLOTH_LLAMA_CPP_BACKEND=cpu ($llamaBackend, normalized above) forces the
+        # CPU-only prebuilt via --cpu-fallback. Fixes Intel iGPU Vulkan crash (#7213).
         if ($llamaBackend -eq "cpu") {
             $prebuiltArgs += "--cpu-fallback"
         }

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -3313,6 +3313,12 @@ if ($LocalLlamaCppLinked) {
     substep "Skipping prebuilt install -- falling back to source build" "Yellow"
 } else {
     Write-Host ""
+    # Normalize the CPU-backend override once (case-insensitive, whitespace-trimmed) so
+    # both the mismatch-prune and the prebuilt args honor UNSLOTH_LLAMA_CPP_BACKEND=cpu.
+    $llamaBackend = "$($env:UNSLOTH_LLAMA_CPP_BACKEND)".Trim().ToLowerInvariant()
+    if ($llamaBackend -and $llamaBackend -notin @("auto", "cpu")) {
+        Write-Host "[WARN] Ignoring UNSLOTH_LLAMA_CPP_BACKEND='$($env:UNSLOTH_LLAMA_CPP_BACKEND)' (expected 'auto' or 'cpu')" -ForegroundColor Yellow
+    }
     if (Test-Path -LiteralPath $LlamaCppDir) {
         substep "Existing llama.cpp install detected -- validating staged prebuilt update before replacement"
         # If the existing install is the wrong kind (e.g. windows-cpu on a ROCm
@@ -3330,11 +3336,9 @@ if ($LocalLlamaCppLinked) {
                 # ROCm-capable -- the ROCm prebuilt bundles its own runtime,
                 # mirroring the --rocm-gfx forward below. The CPU branch covers both
                 # the x64 windows-cpu and arm64 windows-arm64 bundles (Windows arm64
-                # has no GPU prebuilt). NOTE: this block is currently inert --
-                # write_prebuilt_metadata does not persist an install_kind key, so
-                # $existingKind is always null; keep $expectedKinds in sync with the
-                # kinds install_llama_prebuilt.py installs before relying on it.
-                $expectedKinds = if ($HasROCm -or $script:ROCmGfxArch) { @("windows-rocm", "windows-hip") } elseif ($HasNvidiaSmi) { @("windows-cuda") } else { @("windows-cpu", "windows-arm64") }
+                # has no GPU prebuilt), and UNSLOTH_LLAMA_CPP_BACKEND=cpu makes CPU
+                # expected so a deliberate CPU install is not pruned on a GPU host.
+                $expectedKinds = if ($llamaBackend -eq "cpu") { @("windows-cpu", "windows-arm64") } elseif ($HasROCm -or $script:ROCmGfxArch) { @("windows-rocm", "windows-hip") } elseif ($HasNvidiaSmi) { @("windows-cuda") } else { @("windows-cpu", "windows-arm64") }
                 if ($existingKind -and ($existingKind -notin $expectedKinds)) {
                     substep "Removing mismatched llama.cpp install (found '$existingKind', need one of: $($expectedKinds -join ', '))..."
                     Remove-Item -Recurse -Force -LiteralPath $LlamaCppDir -ErrorAction SilentlyContinue
@@ -3371,14 +3375,11 @@ if ($LocalLlamaCppLinked) {
         if ($env:UNSLOTH_LLAMA_RELEASE_TAG) {
             $prebuiltArgs += @("--published-release-tag", $env:UNSLOTH_LLAMA_RELEASE_TAG)
         }
-        # UNSLOTH_LLAMA_CPP_BACKEND=cpu forces the CPU-only prebuilt (case-insensitive
-        # and whitespace-trimmed), bypassing Vulkan/CUDA/ROCm. Fixes Intel iGPU Vulkan
+        # UNSLOTH_LLAMA_CPP_BACKEND=cpu forces the CPU-only prebuilt ($llamaBackend
+        # normalized above), bypassing Vulkan/CUDA/ROCm. Fixes Intel iGPU Vulkan
         # crashes (#7213). Maps to install_llama_prebuilt.py --cpu-fallback.
-        $llamaBackend = "$($env:UNSLOTH_LLAMA_CPP_BACKEND)".Trim().ToLowerInvariant()
         if ($llamaBackend -eq "cpu") {
             $prebuiltArgs += "--cpu-fallback"
-        } elseif ($llamaBackend -and $llamaBackend -ne "auto") {
-            Write-Host "[WARN] Ignoring UNSLOTH_LLAMA_CPP_BACKEND='$($env:UNSLOTH_LLAMA_CPP_BACKEND)' (expected 'auto' or 'cpu')" -ForegroundColor Yellow
         }
         $prevEAPPrebuilt = $ErrorActionPreference
         $ErrorActionPreference = "Continue"

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -3372,10 +3372,11 @@ if ($LocalLlamaCppLinked) {
             $prebuiltArgs += @("--published-release-tag", $env:UNSLOTH_LLAMA_RELEASE_TAG)
         }
         # UNSLOTH_LLAMA_CPP_BACKEND=cpu (case-insensitive, whitespace-trimmed) forces the
-        # CPU-only prebuilt via --cpu-fallback. Fixes Intel iGPU Vulkan crash (#7213).
+        # CPU-only prebuilt via --force-cpu (persisted so updates keep it). Fixes Intel
+        # iGPU Vulkan crash (#7213).
         $llamaBackend = "$($env:UNSLOTH_LLAMA_CPP_BACKEND)".Trim().ToLowerInvariant()
         if ($llamaBackend -eq "cpu") {
-            $prebuiltArgs += "--cpu-fallback"
+            $prebuiltArgs += "--force-cpu"
         } elseif ($llamaBackend -and $llamaBackend -ne "auto") {
             Write-Host "[WARN] Ignoring UNSLOTH_LLAMA_CPP_BACKEND='$($env:UNSLOTH_LLAMA_CPP_BACKEND)' (expected 'auto' or 'cpu')" -ForegroundColor Yellow
         }

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -3313,30 +3313,28 @@ if ($LocalLlamaCppLinked) {
     substep "Skipping prebuilt install -- falling back to source build" "Yellow"
 } else {
     Write-Host ""
-    # Normalize the CPU-backend override once (case-insensitive, whitespace-trimmed) so
-    # both the mismatch-prune and the prebuilt args honor UNSLOTH_LLAMA_CPP_BACKEND=cpu.
-    $llamaBackend = "$($env:UNSLOTH_LLAMA_CPP_BACKEND)".Trim().ToLowerInvariant()
-    if ($llamaBackend -and $llamaBackend -notin @("auto", "cpu")) {
-        Write-Host "[WARN] Ignoring UNSLOTH_LLAMA_CPP_BACKEND='$($env:UNSLOTH_LLAMA_CPP_BACKEND)' (expected 'auto' or 'cpu')" -ForegroundColor Yellow
-    }
     if (Test-Path -LiteralPath $LlamaCppDir) {
         substep "Existing llama.cpp install detected -- validating staged prebuilt update before replacement"
-        # If the existing install is a bundle this host cannot run, remove it so the
-        # installer downloads the right variant rather than skipping on a tag match.
+        # If the existing install is the wrong kind (e.g. windows-cpu on a ROCm
+        # machine that should have windows-rocm), remove it so the installer is
+        # forced to download the correct variant rather than skipping on tag match.
         $existingMetaPath = Join-Path $LlamaCppDir "UNSLOTH_PREBUILT_INFO.json"
         if (Test-Path $existingMetaPath) {
             try {
                 $existingMeta = Get-Content $existingMetaPath -Raw | ConvertFrom-Json
                 $existingKind = $existingMeta.install_kind
-                # expectedKinds lists every kind the installer may produce for this
-                # host, so a valid current-host install is never pruned: the GPU kind
-                # PLUS the windows-cpu/windows-arm64 fallback used when the GPU prebuilt
-                # is missing (ROCm also accepts the upstream windows-hip; a name-inferred
-                # gfx still counts as ROCm-capable), and the non-NVIDIA/non-AMD branch
-                # adds windows-vulkan (the Intel auto-route). Only a bundle this host
-                # cannot run (e.g. windows-cuda with no NVIDIA) is pruned;
-                # UNSLOTH_LLAMA_CPP_BACKEND=cpu narrows expected to CPU to replace a GPU one.
-                $expectedKinds = if ($llamaBackend -eq "cpu") { @("windows-cpu", "windows-arm64") } elseif ($HasROCm -or $script:ROCmGfxArch) { @("windows-rocm", "windows-hip", "windows-cpu", "windows-arm64") } elseif ($HasNvidiaSmi) { @("windows-cuda", "windows-cpu", "windows-arm64") } else { @("windows-vulkan", "windows-cpu", "windows-arm64") }
+                # A ROCm host may legitimately carry the fork's windows-rocm bundle
+                # or the upstream windows-hip fallback, so accept either and never
+                # treat a valid ROCm install as mismatched. A name-inferred gfx
+                # arch (Adrenalin-only, no confirmed runtime) still counts as
+                # ROCm-capable -- the ROCm prebuilt bundles its own runtime,
+                # mirroring the --rocm-gfx forward below. The CPU branch covers both
+                # the x64 windows-cpu and arm64 windows-arm64 bundles (Windows arm64
+                # has no GPU prebuilt). NOTE: this block is currently inert --
+                # write_prebuilt_metadata does not persist an install_kind key, so
+                # $existingKind is always null; keep $expectedKinds in sync with the
+                # kinds install_llama_prebuilt.py installs before relying on it.
+                $expectedKinds = if ($HasROCm -or $script:ROCmGfxArch) { @("windows-rocm", "windows-hip") } elseif ($HasNvidiaSmi) { @("windows-cuda") } else { @("windows-cpu", "windows-arm64") }
                 if ($existingKind -and ($existingKind -notin $expectedKinds)) {
                     substep "Removing mismatched llama.cpp install (found '$existingKind', need one of: $($expectedKinds -join ', '))..."
                     Remove-Item -Recurse -Force -LiteralPath $LlamaCppDir -ErrorAction SilentlyContinue
@@ -3373,10 +3371,13 @@ if ($LocalLlamaCppLinked) {
         if ($env:UNSLOTH_LLAMA_RELEASE_TAG) {
             $prebuiltArgs += @("--published-release-tag", $env:UNSLOTH_LLAMA_RELEASE_TAG)
         }
-        # UNSLOTH_LLAMA_CPP_BACKEND=cpu ($llamaBackend, normalized above) forces the
+        # UNSLOTH_LLAMA_CPP_BACKEND=cpu (case-insensitive, whitespace-trimmed) forces the
         # CPU-only prebuilt via --cpu-fallback. Fixes Intel iGPU Vulkan crash (#7213).
+        $llamaBackend = "$($env:UNSLOTH_LLAMA_CPP_BACKEND)".Trim().ToLowerInvariant()
         if ($llamaBackend -eq "cpu") {
             $prebuiltArgs += "--cpu-fallback"
+        } elseif ($llamaBackend -and $llamaBackend -ne "auto") {
+            Write-Host "[WARN] Ignoring UNSLOTH_LLAMA_CPP_BACKEND='$($env:UNSLOTH_LLAMA_CPP_BACKEND)' (expected 'auto' or 'cpu')" -ForegroundColor Yellow
         }
         $prevEAPPrebuilt = $ErrorActionPreference
         $ErrorActionPreference = "Continue"

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -32,6 +32,10 @@ $PackageDir = Split-Path -Parent $ScriptDir
 # (no matching GitHub release), forces a source build, and causes HTTP 422
 # errors. Only use "master" temporarily when the latest release is missing
 # support for a new model architecture.
+#
+# UNSLOTH_LLAMA_CPP_BACKEND : "auto" (default) or "cpu". When "cpu", forces
+# the CPU-only prebuilt bundle on GPU hosts. Fixes Intel iGPU Vulkan
+# crashes (#7213).
 $DefaultLlamaPrForce = ""
 $DefaultLlamaSource = "https://github.com/ggml-org/llama.cpp"
 $DefaultLlamaTag = "latest"
@@ -3366,6 +3370,12 @@ if ($LocalLlamaCppLinked) {
         }
         if ($env:UNSLOTH_LLAMA_RELEASE_TAG) {
             $prebuiltArgs += @("--published-release-tag", $env:UNSLOTH_LLAMA_RELEASE_TAG)
+        }
+        # UNSLOTH_LLAMA_CPP_BACKEND: "auto" (default) or "cpu" -- forces the CPU-only
+        # prebuilt, bypassing Vulkan/CUDA/ROCm selection. Fixes Intel iGPU Vulkan
+        # crashes (#7213).
+        if ($env:UNSLOTH_LLAMA_CPP_BACKEND -eq "cpu") {
+            $prebuiltArgs += "--cpu-fallback"
         }
         $prevEAPPrebuilt = $ErrorActionPreference
         $ErrorActionPreference = "Continue"

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -3321,24 +3321,22 @@ if ($LocalLlamaCppLinked) {
     }
     if (Test-Path -LiteralPath $LlamaCppDir) {
         substep "Existing llama.cpp install detected -- validating staged prebuilt update before replacement"
-        # If the existing install is the wrong kind (e.g. windows-cpu on a ROCm
-        # machine that should have windows-rocm), remove it so the installer is
-        # forced to download the correct variant rather than skipping on tag match.
+        # If the existing install is a bundle this host cannot run, remove it so the
+        # installer downloads the right variant rather than skipping on a tag match.
         $existingMetaPath = Join-Path $LlamaCppDir "UNSLOTH_PREBUILT_INFO.json"
         if (Test-Path $existingMetaPath) {
             try {
                 $existingMeta = Get-Content $existingMetaPath -Raw | ConvertFrom-Json
                 $existingKind = $existingMeta.install_kind
-                # A ROCm host may legitimately carry the fork's windows-rocm bundle
-                # or the upstream windows-hip fallback, so accept either and never
-                # treat a valid ROCm install as mismatched. A name-inferred gfx
-                # arch (Adrenalin-only, no confirmed runtime) still counts as
-                # ROCm-capable -- the ROCm prebuilt bundles its own runtime,
-                # mirroring the --rocm-gfx forward below. The CPU branch covers both
-                # the x64 windows-cpu and arm64 windows-arm64 bundles (Windows arm64
-                # has no GPU prebuilt), and UNSLOTH_LLAMA_CPP_BACKEND=cpu makes CPU
-                # expected so a deliberate CPU install is not pruned on a GPU host.
-                $expectedKinds = if ($llamaBackend -eq "cpu") { @("windows-cpu", "windows-arm64") } elseif ($HasROCm -or $script:ROCmGfxArch) { @("windows-rocm", "windows-hip") } elseif ($HasNvidiaSmi) { @("windows-cuda") } else { @("windows-cpu", "windows-arm64") }
+                # expectedKinds lists every kind the installer may produce for this
+                # host, so a valid current-host install is never pruned: the GPU kind
+                # PLUS the windows-cpu/windows-arm64 fallback used when the GPU prebuilt
+                # is missing (ROCm also accepts the upstream windows-hip; a name-inferred
+                # gfx still counts as ROCm-capable), and the non-NVIDIA/non-AMD branch
+                # adds windows-vulkan (the Intel auto-route). Only a bundle this host
+                # cannot run (e.g. windows-cuda with no NVIDIA) is pruned;
+                # UNSLOTH_LLAMA_CPP_BACKEND=cpu narrows expected to CPU to replace a GPU one.
+                $expectedKinds = if ($llamaBackend -eq "cpu") { @("windows-cpu", "windows-arm64") } elseif ($HasROCm -or $script:ROCmGfxArch) { @("windows-rocm", "windows-hip", "windows-cpu", "windows-arm64") } elseif ($HasNvidiaSmi) { @("windows-cuda", "windows-cpu", "windows-arm64") } else { @("windows-vulkan", "windows-cpu", "windows-arm64") }
                 if ($existingKind -and ($existingKind -notin $expectedKinds)) {
                     substep "Removing mismatched llama.cpp install (found '$existingKind', need one of: $($expectedKinds -join ', '))..."
                     Remove-Item -Recurse -Force -LiteralPath $LlamaCppDir -ErrorAction SilentlyContinue

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -1363,9 +1363,8 @@ else
         # present so it can still attempt a prebuilt. Mirrors setup.ps1 behaviour.
         _PREBUILT_CMD+=(--has-rocm)
     fi
-    # UNSLOTH_LLAMA_CPP_BACKEND=cpu forces the CPU-only prebuilt (case-insensitive
-    # and whitespace-trimmed, matching setup.ps1), bypassing Vulkan/CUDA/ROCm. Fixes
-    # Intel iGPU Vulkan crashes (#7213). Maps to install_llama_prebuilt.py --cpu-fallback.
+    # UNSLOTH_LLAMA_CPP_BACKEND=cpu (case-insensitive, trimmed) forces the CPU-only
+    # prebuilt via --cpu-fallback, bypassing Vulkan/CUDA/ROCm. Fixes Intel iGPU crash (#7213).
     _llama_backend="$(printf '%s' "${UNSLOTH_LLAMA_CPP_BACKEND:-auto}" | awk '{$1=$1; print tolower($0)}')"
     case "$_llama_backend" in
         cpu)     _PREBUILT_CMD+=(--cpu-fallback) ;;

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -1363,11 +1363,14 @@ else
         # present so it can still attempt a prebuilt. Mirrors setup.ps1 behaviour.
         _PREBUILT_CMD+=(--has-rocm)
     fi
-    # UNSLOTH_LLAMA_CPP_BACKEND=cpu forces the CPU-only prebuilt (case-insensitive,
-    # matching setup.ps1), bypassing Vulkan/CUDA/ROCm. Fixes Intel iGPU Vulkan
-    # crashes (#7213). Maps to install_llama_prebuilt.py --cpu-fallback.
-    case "${UNSLOTH_LLAMA_CPP_BACKEND:-auto}" in
-        [cC][pP][uU]) _PREBUILT_CMD+=(--cpu-fallback) ;;
+    # UNSLOTH_LLAMA_CPP_BACKEND=cpu forces the CPU-only prebuilt (case-insensitive
+    # and whitespace-trimmed, matching setup.ps1), bypassing Vulkan/CUDA/ROCm. Fixes
+    # Intel iGPU Vulkan crashes (#7213). Maps to install_llama_prebuilt.py --cpu-fallback.
+    _llama_backend="$(printf '%s' "${UNSLOTH_LLAMA_CPP_BACKEND:-auto}" | awk '{$1=$1; print tolower($0)}')"
+    case "$_llama_backend" in
+        cpu)     _PREBUILT_CMD+=(--cpu-fallback) ;;
+        ""|auto) ;;
+        *) step "llama.cpp" "Ignoring UNSLOTH_LLAMA_CPP_BACKEND='$UNSLOTH_LLAMA_CPP_BACKEND' (expected 'auto' or 'cpu')" "$C_WARN" >&2 ;;
     esac
     _PREBUILT_LOG="$(mktemp)"
     set +e

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -1364,10 +1364,18 @@ else
         _PREBUILT_CMD+=(--has-rocm)
     fi
     # UNSLOTH_LLAMA_CPP_BACKEND=cpu (case-insensitive, trimmed) forces the CPU-only
-    # prebuilt via --cpu-fallback, bypassing Vulkan/CUDA/ROCm. Fixes Intel iGPU crash (#7213).
+    # prebuilt via --force-cpu, bypassing Vulkan/CUDA/ROCm. Fixes Intel iGPU crash (#7213).
+    # No effect on macOS: the universal bundle already runs on CPU (Metal is a runtime
+    # -ngl choice), so warn instead of writing a misleading forced-CPU marker.
     _llama_backend="$(printf '%s' "${UNSLOTH_LLAMA_CPP_BACKEND:-auto}" | awk '{$1=$1; print tolower($0)}')"
     case "$_llama_backend" in
-        cpu)     _PREBUILT_CMD+=(--cpu-fallback) ;;
+        cpu)
+            if [ "$_HOST_SYSTEM" = "Darwin" ]; then
+                step "llama.cpp" "UNSLOTH_LLAMA_CPP_BACKEND=cpu has no effect on macOS (universal build; use -ngl 0 at runtime for CPU-only)" "$C_WARN" >&2
+            else
+                _PREBUILT_CMD+=(--force-cpu)
+            fi
+            ;;
         ""|auto) ;;
         *) step "llama.cpp" "Ignoring UNSLOTH_LLAMA_CPP_BACKEND='$UNSLOTH_LLAMA_CPP_BACKEND' (expected 'auto' or 'cpu')" "$C_WARN" >&2 ;;
     esac

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -1363,12 +1363,12 @@ else
         # present so it can still attempt a prebuilt. Mirrors setup.ps1 behaviour.
         _PREBUILT_CMD+=(--has-rocm)
     fi
-    # UNSLOTH_LLAMA_CPP_BACKEND: "auto" (default) or "cpu" -- forces the CPU-only
-    # prebuilt, bypassing Vulkan/CUDA/ROCm selection. Fixes Intel iGPU Vulkan
-    # crashes (#7213). Matches install_llama_prebuilt.py --cpu-fallback.
-    if [ "${UNSLOTH_LLAMA_CPP_BACKEND:-auto}" = "cpu" ]; then
-        _PREBUILT_CMD+=(--cpu-fallback)
-    fi
+    # UNSLOTH_LLAMA_CPP_BACKEND=cpu forces the CPU-only prebuilt (case-insensitive,
+    # matching setup.ps1), bypassing Vulkan/CUDA/ROCm. Fixes Intel iGPU Vulkan
+    # crashes (#7213). Maps to install_llama_prebuilt.py --cpu-fallback.
+    case "${UNSLOTH_LLAMA_CPP_BACKEND:-auto}" in
+        [cC][pP][uU]) _PREBUILT_CMD+=(--cpu-fallback) ;;
+    esac
     _PREBUILT_LOG="$(mktemp)"
     set +e
     if _is_verbose; then

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -36,6 +36,10 @@ fi
 #                             forces a source build, and causes HTTP 422 errors.
 #                             Only use "master" temporarily when the latest release
 #                             is missing support for a new model architecture.
+#
+#   UNSLOTH_LLAMA_CPP_BACKEND : "auto" (default) or "cpu". When "cpu", forces
+#                               the CPU-only prebuilt bundle on GPU hosts.
+#                               Fixes Intel iGPU Vulkan crashes (#7213).
 # ──────────────────────────────────────────────────────────────────────────
 _DEFAULT_LLAMA_PR_FORCE=""
 _DEFAULT_LLAMA_SOURCE="https://github.com/ggml-org/llama.cpp"
@@ -1358,6 +1362,12 @@ else
         # AMD was detected but gfx resolution failed; tell the installer ROCm is
         # present so it can still attempt a prebuilt. Mirrors setup.ps1 behaviour.
         _PREBUILT_CMD+=(--has-rocm)
+    fi
+    # UNSLOTH_LLAMA_CPP_BACKEND: "auto" (default) or "cpu" -- forces the CPU-only
+    # prebuilt, bypassing Vulkan/CUDA/ROCm selection. Fixes Intel iGPU Vulkan
+    # crashes (#7213). Matches install_llama_prebuilt.py --cpu-fallback.
+    if [ "${UNSLOTH_LLAMA_CPP_BACKEND:-auto}" = "cpu" ]; then
+        _PREBUILT_CMD+=(--cpu-fallback)
     fi
     _PREBUILT_LOG="$(mktemp)"
     set +e

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -1348,6 +1348,7 @@ def test_install_prebuilt_falls_back_to_older_release_plan(
         approved_checksums,
         initial_fallback_used = False,
         existing_install_dir = None,
+        force_cpu = False,
     ):
         call_log.append((llama_tag, initial_fallback_used))
         if llama_tag == "b9002":
@@ -2551,6 +2552,7 @@ def test_install_prebuilt_skips_when_older_release_fallback_matches_existing_ins
         approved_checksums,
         initial_fallback_used = False,
         existing_install_dir = None,
+        force_cpu = False,
     ):
         call_log.append(llama_tag)
         raise PrebuiltFallback("validation failed for latest release")
@@ -2698,6 +2700,7 @@ def test_install_prebuilt_skips_same_release_fallback_attempt_when_installed(
         approved_checksums,
         prebuilt_fallback_used,
         quantized_path,
+        force_cpu = False,
     ):
         attempted_names.append(choice.name)
         if choice.name == first_choice.name:
@@ -2824,6 +2827,7 @@ def test_install_prebuilt_same_tag_upstream_failure_uses_older_unsloth_release_p
         approved_checksums,
         initial_fallback_used = False,
         existing_install_dir = None,
+        force_cpu = False,
     ):
         attempted.append((llama_tag, release_tag, attempts[0].source_label))
         if llama_tag == "b9002":


### PR DESCRIPTION
This PR introduces a new user-facing environment variable `UNSLOTH_LLAMA_CPP_BACKEND` to allow users to force the CPU-only llama.cpp prebuilt on GPU hosts.
 
## Background
Currently, `install_llama_prebuilt.py` automatically routes Intel (and other non-NVIDIA/non-AMD) GPUs to the Vulkan prebuilt because it generally offers better performance than the CPU backend. However, on some specific hardware setups (e.g., Intel UHD 630 on Linux), the Vulkan backend crashes with `vk::Queue::submit: ErrorDeviceLost`.
 
Before this PR, users facing this driver/hardware compatibility issue had no way to bypass the Vulkan auto-routing and force a CPU fallback.
 
## Changes Made
This fix is pure plumbing—it does not alter the existing hardware auto-detection logic, but exposes the internal `--cpu-fallback` mechanism as a user override.
 
- **`setup.sh` / `setup.ps1`**: Added support for `UNSLOTH_LLAMA_CPP_BACKEND=cpu`. When this is set, the installer scripts append `--cpu-fallback` to the `install_llama_prebuilt.py` command, bypassing the Vulkan/CUDA/ROCm selection. Follows the same env-var-override convention already used for `UNSLOTH_LLAMA_RELEASE_TAG` / `UNSLOTH_LLAMA_FORCE_COMPILE` / `UNSLOTH_ROCM_GFX_ARCH`.
## Testing
- [x] Existing coverage in `test_install_resolve_prebuilt.py` (`test_route_to_vulkan_prebuilt_cpu_fallback_wins`, `test_force_cpu_clears_all_gpu_attributes_including_intel`) already confirms `--cpu-fallback` correctly suppresses Vulkan routing — unchanged by this PR since the routing logic itself isn't touched, only its trigger surface.
- [x] Added a new test asserting `setup.sh` appends `--cpu-fallback` to the installer command array when `UNSLOTH_LLAMA_CPP_BACKEND=cpu` is set — this is the actual new behavior this PR introduces.
- [ ] Equivalent coverage for `setup.ps1`'s `$prebuiltArgs` forwarding — in progress / open for review.
- [x] Manually confirmed the environment variable correctly forwards the flag and selects the CPU bundle on both Windows and Linux paths.
## Follow-ups (intentionally not in this PR)
1. The Vulkan `ErrorDeviceLost` crash itself is a separate hardware/driver-compat problem worth its own investigation — e.g. a startup health-check that auto-retries with `--cpu-fallback` if the GPU backend crashes immediately on launch, so users don't have to self-diagnose this the way the original reporter did.
2. A Studio Settings UI toggle for this, once the env var path is proven out in the wild.