### PR TITLE
fix(studio): equal padding in the dataset source segmented control

### DIFF
--- a/studio/frontend/src/features/studio/sections/dataset-section.tsx
+++ b/studio/frontend/src/features/studio/sections/dataset-section.tsx
@@ -70,6 +70,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useNavigate } from "@tanstack/react-router";
+import { motion, useReducedMotion } from "motion/react";
 import {
   type ChangeEvent,
   type DragEvent,
@@ -153,6 +154,7 @@ function normalizeSliceInput(value: string): string | null {
 export function DatasetSection() {
   const t = useT();
   const navigate = useNavigate();
+  const reducedMotion = useReducedMotion();
   const {
     dataset,
     datasetSource,
@@ -686,6 +688,9 @@ export function DatasetSection() {
           {(() => {
             // Hub-style sliding-pill segmented control, matching the Hub tabs
             // via the shared .hub-tab-toggle / .hub-tab-toggle-pill classes.
+            // flex-auto buttons share leftover space equally so padding stays
+            // equal for all labels; the pill sits inside the active button so
+            // it always matches its bounds.
             const sourceTabs: {
               value: "huggingface" | "upload" | "s3";
               label: string;
@@ -696,24 +701,12 @@ export function DatasetSection() {
                 ? []
                 : [{ value: "s3" as const, label: "Amazon S3" }]),
             ];
-            const activeIndex = Math.max(
-              0,
-              sourceTabs.findIndex((item) => item.value === datasetSource),
-            );
             return (
               <div
                 role="radiogroup"
                 aria-label="Dataset source"
-                className="hub-tab-toggle relative inline-flex h-9 w-full items-center rounded-full"
+                className="hub-tab-toggle relative flex h-9 w-full items-center rounded-full"
               >
-                <span
-                  aria-hidden="true"
-                  className="hub-tab-toggle-pill pointer-events-none absolute inset-y-0 left-0 rounded-full transition-transform duration-200 ease-out"
-                  style={{
-                    width: `${100 / sourceTabs.length}%`,
-                    transform: `translateX(${activeIndex * 100}%)`,
-                  }}
-                />
                 {sourceTabs.map((item) => (
                   <button
                     key={item.value}
@@ -732,13 +725,30 @@ export function DatasetSection() {
                       }
                     }}
                     className={cn(
-                      "relative z-10 inline-flex h-9 flex-1 cursor-pointer items-center justify-center rounded-full px-3 text-[12.5px] font-medium transition-colors",
+                      "relative inline-flex h-9 flex-auto cursor-pointer items-center justify-center rounded-full px-3 text-[12.5px] font-medium transition-colors",
                       datasetSource === item.value
                         ? "text-foreground"
                         : "text-muted-foreground hover:text-foreground",
                     )}
                   >
-                    {item.label}
+                    {datasetSource === item.value && (
+                      <motion.span
+                        aria-hidden="true"
+                        layoutId="dataset-source-pill"
+                        className="hub-tab-toggle-pill absolute inset-0 rounded-full"
+                        transition={
+                          reducedMotion
+                            ? { duration: 0 }
+                            : {
+                                type: "spring",
+                                stiffness: 500,
+                                damping: 35,
+                                mass: 0.5,
+                              }
+                        }
+                      />
+                    )}
+                    <span className="relative z-10">{item.label}</span>
                   </button>
                 ))}
               </div>

--- a/studio/frontend/src/features/studio/sections/dataset-section.tsx
+++ b/studio/frontend/src/features/studio/sections/dataset-section.tsx
@@ -76,6 +76,7 @@ import {
   type DragEvent,
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -155,6 +156,8 @@ export function DatasetSection() {
   const t = useT();
   const navigate = useNavigate();
   const reducedMotion = useReducedMotion();
+  // Scopes the pill layoutId so multiple instances never share one.
+  const sourcePillLayoutId = useId();
   const {
     dataset,
     datasetSource,
@@ -734,7 +737,7 @@ export function DatasetSection() {
                     {datasetSource === item.value && (
                       <motion.span
                         aria-hidden="true"
-                        layoutId="dataset-source-pill"
+                        layoutId={sourcePillLayoutId}
                         className="hub-tab-toggle-pill absolute inset-0 rounded-full"
                         transition={
                           reducedMotion


### PR DESCRIPTION
## Problem

On the Studio train page, the Dataset section has a Hugging Face / Local / Amazon S3 segmented control. Each button was forced to exactly one third of the track width with `flex-1`, and the sliding pill was hard coded to 33.3% width.

Since the three labels have very different lengths, the whitespace came out uneven: "Hugging Face" almost filled its pill while "Local" sat in a large empty segment, and the gaps between neighboring labels differed as well.

## Fix

- Buttons now use `flex-auto` instead of `flex-1`. Each button takes its label's natural width plus an equal share of the leftover track space, so the control still spans the full card width but the padding around every label and the spacing between buttons is now identical.
- Since segments are no longer uniform width, the fixed 33% pill is replaced with a `motion` `layoutId` pill rendered inside the active button. The pill always matches the active button's true bounds and still animates smoothly between tabs.

This matches the pattern already used by `ThemeSegmented` in settings (same spring transition and reduced motion support), so the Studio control is now consistent with the rest of the app.

## Testing

- `npm run typecheck` passes
- `npm run build` succeeds
- Verified in a local Studio install that the pill hugs each tab and the spacing around all three labels is equal, including the two tab case for multimodal models where the S3 tab is hidden