### PR TITLE
Studio: keep the Bypass permissions pill label when composer pills collapse

### DIFF
--- a/studio/frontend/src/features/chat/permission-mode-select.tsx
+++ b/studio/frontend/src/features/chat/permission-mode-select.tsx
@@ -278,28 +278,23 @@ export function PermissionModeComposerPill({
           data-pill-label={active.label}
           data-active={fullAccess ? "true" : "false"}
           data-variant={fullAccess ? "danger" : undefined}
+          data-keep-label="true"
           aria-label="Permission level for tool calls"
           title={`${active.label}: ${active.description}`}
         >
           {/* The icon doubles as an off switch (mirrors the MCP pill): hover
               swaps it to an X; clicking it turns bypass permissions Off (no
-              prompts, sandbox on) without opening the menu. In compact
-              icon-only mode the glyph is the whole button, so clicks fall
-              through and open the menu instead. */}
+              prompts, sandbox on) without opening the menu. data-keep-label
+              exempts this pill from compact icon-only mode, so the off switch
+              stays clickable even while the other pills are collapsed. */}
           <span
             role="button"
             aria-label="Turn off bypass permissions"
             tabIndex={-1}
             onPointerDown={(e) => {
-              if (e.currentTarget.closest('[data-pill-compact="true"]')) {
-                return;
-              }
               e.stopPropagation();
             }}
             onClick={(e) => {
-              if (e.currentTarget.closest('[data-pill-compact="true"]')) {
-                return;
-              }
               e.stopPropagation();
               setPermissionMode("off");
             }}

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1467,7 +1467,9 @@ html[data-chat-font] .aui-root {
 	}
 
 	/* With more than 4 tools on, drop pill labels to icons only to cut clutter.
-	   Compare keeps its label via data-keep-label. */
+	   Compare and the bypass-permissions pill keep their labels via
+	   data-keep-label; the permission pill sits before the collapsed icons, so
+	   they line up to its right. */
 	[data-pill-compact="true"]
 		.composer-pill-btn:not([data-keep-label])
 		> span:not(.composer-pill-glyph) {


### PR DESCRIPTION
## What

When 5 or more options are active in the chat composer, every pill collapses into an icon-only button to cut clutter. That also shrank the Bypass permissions pill down to a small alert glyph, which is easy to miss for something that controls tool call approval.

This keeps the permission pill at full width with its label in compact mode. The pill already renders first among the toggles, right after the plus button, so the remaining collapsed icons line up to its right.

## How

- Added `data-keep-label` to `PermissionModeComposerPill`, the existing opt-out the Compare pill uses, so the compact CSS never strips its label
- Removed the compact-mode fallthrough in the glyph off switch handlers. It existed because the icon-only pill had nothing else to click for opening the menu. The pill is never icon-only now, so hovering the icon shows the X and clicking it turns bypass permissions off, same as expanded mode
- Updated the compact-mode comment in `index.css` to cover both keep-label pills

## Testing

- `npm run build` passes (tsc plus vite)
- Verified the built bundle carries the new attribute and the served page picks it up
- Applies to both the single chat composer and the compare composer, which share the pill component