### PR TITLE
fix(rocm): prepend system ROCm libs on native Linux to avoid bundled HIP crash

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -247,6 +247,53 @@ def _wsl_system_rocm_lib_dirs() -> "list[str]":
     return out
 
 
+def _bundled_hip_present(binary_dir: str) -> bool:
+    """True when a prebuilt bundle ships its own HIP libraries."""
+    if not binary_dir:
+        return False
+    try:
+        return os.path.exists(os.path.join(str(binary_dir), "libggml-hip.so")) or os.path.exists(
+            os.path.join(str(binary_dir), "libggml-hip.so.0")
+        )
+    except OSError:
+        return False
+
+
+def _native_linux_system_rocm_lib_dirs(binary_dir: str = "") -> "list[str]":
+    """System ROCm lib dir(s) to load before a prebuilt's bundled HIP, on native Linux.
+
+    The bundled bare-metal HIP runtime can be incompatible with the host's
+    kernel driver (amdkfd) and crash inside hsa_init(); prepending the system
+    ROCm libs loads the matching libhsa-runtime64 / libamdhip64 while the
+    bundle still supplies libggml-hip / librocblas with GPU kernels.
+    No-op on WSL (handled by _wsl_system_rocm_lib_dirs) or non-Linux.
+    """
+    if sys.platform != "linux" or os.path.exists("/dev/dxg"):
+        return []
+    if not os.path.exists("/dev/kfd"):
+        return []
+    if not _bundled_hip_present(binary_dir):
+        return []
+    candidates = ["/opt/rocm"]
+    for var in ("HIP_PATH", "HIP_PATH_57", "ROCM_PATH"):
+        val = os.environ.get(var)
+        if val:
+            candidates.append(val)
+    out: "list[str]" = []
+    seen: "set[str]" = set()
+    for base in candidates:
+        for lib_sub in ("lib", "lib64"):
+            d = os.path.join(base, lib_sub)
+            if d in seen:
+                continue
+            seen.add(d)
+            if os.path.exists(os.path.join(d, "libhsa-runtime64.so")) or os.path.exists(
+                os.path.join(d, "libhsa-runtime64.so.1")
+            ):
+                out.append(d)
+    return out
+
+
 # Plan-without-action re-prompt state now lives in tool_call_parser (imported above).
 
 # Default max_tokens to the effective context when known. The floor is high
@@ -3592,6 +3639,9 @@ class LlamaCppBackend:
             lib_dirs.extend(_wsl_system_rocm_lib_dirs())
             if lib_dirs:
                 env.setdefault("HSA_ENABLE_DXG_DETECTION", "1")
+            # Native Linux AMD: system ROCm libs before the bundle's bundled HIP
+            # runtime, which can be incompatible with the host amdkfd driver.
+            lib_dirs.extend(_native_linux_system_rocm_lib_dirs(binary_dir))
             lib_dirs.append(binary_dir)
             _arch = platform.machine()  # x86_64, aarch64, etc.
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -260,18 +260,14 @@ def _bundled_hip_present(binary_dir: str) -> bool:
 
 
 def _native_linux_system_rocm_lib_dirs(binary_dir: str = "") -> "list[str]":
-    """System ROCm lib dir(s) to load before a prebuilt's bundled HIP, on native Linux.
+    """System ROCm lib dir(s) to prepend before a prebuilt's bundled HIP, on native Linux.
 
-    The bundled bare-metal HIP runtime can be incompatible with the host kernel
-    driver (amdkfd) and crash inside hsa_init(); prepending the system ROCm lib
-    dir loads a version-consistent, driver-matched stack (libhsa-runtime64 /
-    libamdhip64 / librocblas) ahead of the bundle, while the bundle still
-    supplies libggml-hip. The whole dir is used deliberately: keeping the
-    bundle's per-gfx rocBLAS while loading a different-version system HIP/ROCR
-    risks missing-symbol failures, so the consistent system stack wins when the
-    host ROCm supports this GPU (it must, for the ROCm torch build to run).
-    UNSLOTH_LLAMA_NO_SYSTEM_ROCM=1 keeps the pure bundle for a host whose system
-    ROCm lacks this arch's compute kernels. No-op on WSL / non-Linux.
+    The bundled bare-metal HIP runtime can mismatch the host amdkfd driver and crash
+    in hsa_init(); prepending the whole system ROCm lib dir loads a driver-matched,
+    version-consistent stack (libhsa-runtime64 / libamdhip64 / librocblas) ahead of it.
+    The whole dir is deliberate: mixing the bundle's rocBLAS with a different-version
+    system HIP/ROCR risks missing symbols. UNSLOTH_LLAMA_NO_SYSTEM_ROCM=1 keeps the pure
+    bundle (for a host whose system ROCm lacks this arch); no-op on WSL / non-Linux.
     """
     if os.environ.get("UNSLOTH_LLAMA_NO_SYSTEM_ROCM") == "1":
         return []
@@ -3649,8 +3645,8 @@ class LlamaCppBackend:
             lib_dirs.extend(_wsl_system_rocm_lib_dirs())
             if lib_dirs:
                 env.setdefault("HSA_ENABLE_DXG_DETECTION", "1")
-            # Native Linux AMD: system ROCm libs before the bundle's bundled HIP
-            # runtime, which can be incompatible with the host amdkfd driver.
+            # Native Linux AMD: system ROCm libs before the bundle's HIP runtime,
+            # which can be incompatible with the host amdkfd driver.
             lib_dirs.extend(_native_linux_system_rocm_lib_dirs(binary_dir))
             lib_dirs.append(binary_dir)
             _arch = platform.machine()  # x86_64, aarch64, etc.

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -248,13 +248,13 @@ def _wsl_system_rocm_lib_dirs() -> "list[str]":
 
 
 def _bundled_hip_present(binary_dir: str) -> bool:
-    """True when a prebuilt bundle ships its own HIP libraries."""
+    """True when a prebuilt bundle ships its own HIP backend library."""
     if not binary_dir:
         return False
     try:
-        return os.path.exists(os.path.join(str(binary_dir), "libggml-hip.so")) or os.path.exists(
-            os.path.join(str(binary_dir), "libggml-hip.so.0")
-        )
+        # Glob the version suffix (libggml-hip.so, .so.0, .so.0.11.1) the same
+        # way the installer's runtime health check matches libggml-hip.so*.
+        return any(Path(str(binary_dir)).glob("libggml-hip.so*"))
     except OSError:
         return False
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -262,12 +262,16 @@ def _bundled_hip_present(binary_dir: str) -> bool:
 def _native_linux_system_rocm_lib_dirs(binary_dir: str = "") -> "list[str]":
     """System ROCm lib dir(s) to load before a prebuilt's bundled HIP, on native Linux.
 
-    The bundled bare-metal HIP runtime can be incompatible with the host's
-    kernel driver (amdkfd) and crash inside hsa_init(); prepending the system
-    ROCm libs loads the matching libhsa-runtime64 / libamdhip64 while the
-    bundle still supplies libggml-hip / librocblas with GPU kernels.
-    No-op on WSL (handled by _wsl_system_rocm_lib_dirs), non-Linux, or via
-    UNSLOTH_LLAMA_NO_SYSTEM_ROCM=1 (keep the bundled runtime).
+    The bundled bare-metal HIP runtime can be incompatible with the host kernel
+    driver (amdkfd) and crash inside hsa_init(); prepending the system ROCm lib
+    dir loads a version-consistent, driver-matched stack (libhsa-runtime64 /
+    libamdhip64 / librocblas) ahead of the bundle, while the bundle still
+    supplies libggml-hip. The whole dir is used deliberately: keeping the
+    bundle's per-gfx rocBLAS while loading a different-version system HIP/ROCR
+    risks missing-symbol failures, so the consistent system stack wins when the
+    host ROCm supports this GPU (it must, for the ROCm torch build to run).
+    UNSLOTH_LLAMA_NO_SYSTEM_ROCM=1 keeps the pure bundle for a host whose system
+    ROCm lacks this arch's compute kernels. No-op on WSL / non-Linux.
     """
     if os.environ.get("UNSLOTH_LLAMA_NO_SYSTEM_ROCM") == "1":
         return []

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -277,11 +277,14 @@ def _native_linux_system_rocm_lib_dirs(binary_dir: str = "") -> "list[str]":
         return []
     if not _bundled_hip_present(binary_dir):
         return []
-    candidates = ["/opt/rocm"]
+    # Env-configured ROCm root first; /opt/rocm only as a fallback so a stale
+    # /opt/rocm doesn't shadow the driver-matching install these vars point at.
+    candidates = []
     for var in ("HIP_PATH", "HIP_PATH_57", "ROCM_PATH"):
         val = os.environ.get(var)
         if val:
             candidates.append(val)
+    candidates.append("/opt/rocm")
     out: "list[str]" = []
     seen: "set[str]" = set()
     for base in candidates:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -266,8 +266,11 @@ def _native_linux_system_rocm_lib_dirs(binary_dir: str = "") -> "list[str]":
     kernel driver (amdkfd) and crash inside hsa_init(); prepending the system
     ROCm libs loads the matching libhsa-runtime64 / libamdhip64 while the
     bundle still supplies libggml-hip / librocblas with GPU kernels.
-    No-op on WSL (handled by _wsl_system_rocm_lib_dirs) or non-Linux.
+    No-op on WSL (handled by _wsl_system_rocm_lib_dirs), non-Linux, or via
+    UNSLOTH_LLAMA_NO_SYSTEM_ROCM=1 (keep the bundled runtime).
     """
+    if os.environ.get("UNSLOTH_LLAMA_NO_SYSTEM_ROCM") == "1":
+        return []
     if sys.platform != "linux" or os.path.exists("/dev/dxg"):
         return []
     if not os.path.exists("/dev/kfd"):

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5721,9 +5721,9 @@ def _bundled_hip_present(binary_dir: str) -> bool:
     if not binary_dir:
         return False
     try:
-        return os.path.exists(os.path.join(str(binary_dir), "libggml-hip.so")) or os.path.exists(
-            os.path.join(str(binary_dir), "libggml-hip.so.0")
-        )
+        # Glob the version suffix (libggml-hip.so, .so.0, .so.0.11.1) the same
+        # way the installer's runtime health check matches libggml-hip.so*.
+        return any(Path(str(binary_dir)).glob("libggml-hip.so*"))
     except OSError:
         return False
 

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5738,11 +5738,14 @@ def _native_linux_system_rocm_lib_dirs(binary_dir: str = "") -> list[str]:
         return []
     if not _bundled_hip_present(binary_dir):
         return []
-    candidates = ["/opt/rocm"]
+    # Env-configured ROCm root first; /opt/rocm only as a fallback so a stale
+    # /opt/rocm doesn't shadow the driver-matching install these vars point at.
+    candidates = []
     for var in ("HIP_PATH", "HIP_PATH_57", "ROCM_PATH"):
         val = os.environ.get(var)
         if val:
             candidates.append(val)
+    candidates.append("/opt/rocm")
     out: list[str] = []
     seen: set[str] = set()
     for base in candidates:

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5717,6 +5717,44 @@ def _wsl_system_rocm_lib_dirs() -> list[str]:
     return out
 
 
+def _bundled_hip_present(binary_dir: str) -> bool:
+    if not binary_dir:
+        return False
+    try:
+        return os.path.exists(os.path.join(str(binary_dir), "libggml-hip.so")) or os.path.exists(
+            os.path.join(str(binary_dir), "libggml-hip.so.0")
+        )
+    except OSError:
+        return False
+
+
+def _native_linux_system_rocm_lib_dirs(binary_dir: str = "") -> list[str]:
+    if sys.platform != "linux" or os.path.exists("/dev/dxg"):
+        return []
+    if not os.path.exists("/dev/kfd"):
+        return []
+    if not _bundled_hip_present(binary_dir):
+        return []
+    candidates = ["/opt/rocm"]
+    for var in ("HIP_PATH", "HIP_PATH_57", "ROCM_PATH"):
+        val = os.environ.get(var)
+        if val:
+            candidates.append(val)
+    out: list[str] = []
+    seen: set[str] = set()
+    for base in candidates:
+        for lib_sub in ("lib", "lib64"):
+            d = os.path.join(base, lib_sub)
+            if d in seen:
+                continue
+            seen.add(d)
+            if os.path.exists(os.path.join(d, "libhsa-runtime64.so")) or os.path.exists(
+                os.path.join(d, "libhsa-runtime64.so.1")
+            ):
+                out.append(d)
+    return out
+
+
 # Secrets a downloaded llama.cpp binary never needs; keep them out of binary_env().
 # The installer's own API calls read os.environ directly, so auth is unaffected.
 _SECRET_ENV_EXACT_NAMES = frozenset(
@@ -5877,6 +5915,11 @@ def binary_env(
         if _wsl_rocm:
             ld_dirs = [*_wsl_rocm, *ld_dirs]
             env.setdefault("HSA_ENABLE_DXG_DETECTION", "1")
+        # Native Linux AMD: system ROCm libs before the bundle's bundled HIP
+        # runtime, which can be incompatible with the host amdkfd driver.
+        _native_rocm = _native_linux_system_rocm_lib_dirs(str(binary_path.parent))
+        if _native_rocm:
+            ld_dirs = [*_native_rocm, *ld_dirs]
         existing = [part for part in env.get("LD_LIBRARY_PATH", "").split(os.pathsep) if part]
         env["LD_LIBRARY_PATH"] = os.pathsep.join(dedupe_existing_dirs([*ld_dirs, *existing]))
     elif host.is_macos:

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5729,6 +5729,9 @@ def _bundled_hip_present(binary_dir: str) -> bool:
 
 
 def _native_linux_system_rocm_lib_dirs(binary_dir: str = "") -> list[str]:
+    # UNSLOTH_LLAMA_NO_SYSTEM_ROCM=1 keeps the bundled runtime (opt-out).
+    if os.environ.get("UNSLOTH_LLAMA_NO_SYSTEM_ROCM") == "1":
+        return []
     if sys.platform != "linux" or os.path.exists("/dev/dxg"):
         return []
     if not os.path.exists("/dev/kfd"):


### PR DESCRIPTION
## Summary

Two fixes:

1. **ROCm native Linux GPU fallback**: On native Linux AMD hosts, prebuilt llama-server bundles ship bundled ROCR/HIP runtimes incompatible with the host's amdkfd kernel driver, causing silent CPU fallback. The existing workaround was gated to WSL only. This PR adds `_native_linux_system_rocm_lib_dirs()` that dynamically resolves the ROCm path from `HIP_PATH`, `HIP_PATH_57`, `ROCM_PATH` env vars (with `/opt/rocm` fallback) and prepends system libs to `LD_LIBRARY_PATH`.

2. **CI: opencode agent guide timeout**: `opencode run` hangs in headless CI. Added `--format json` which makes it output structured JSON events non-interactively instead of blocking on TTY.

## Root Cause

1. `_wsl_system_rocm_lib_dirs()` at `llama_cpp.py:210` and `install_llama_prebuilt.py:5693` gates on `/dev/dxg`, so native Linux never gets the system-ROCm library prepend. Bundled HIP runtime crashes in `hsa_init()` -> silent CPU fallback.

2. `opencode run` without `--format json` hangs in TTY-less CI environments waiting for interactive output.

## Changes

- `studio/backend/core/inference/llama_cpp.py`: Added `_bundled_hip_present()` and `_native_linux_system_rocm_lib_dirs()` helpers; integrated into `_llama_server_env_for_binary()`
- `studio/install_llama_prebuilt.py`: Same helpers mirrored; integrated into `binary_env()`
- `.github/scripts/agent-guides-drive.sh`: Added `--format json` to opencode `run` invocations for both connection and file-edit modes

Fixes #7208
