### PR TITLE
Give opencode real timeout headroom in Local Agent Guides CI

### DIFF
--- a/.github/scripts/agent-guides-drive.sh
+++ b/.github/scripts/agent-guides-drive.sh
@@ -36,6 +36,15 @@ AGENT="${2:?usage: agent-guides-drive.sh <mode> <agent>}"
 # Determinism (seed/temp) is applied at the server level by
 # serve-unsloth-run.sh --extra; agents inherit it through the API.
 TIMEOUT="${AGENT_INVOKE_TIMEOUT:-180}"
+# opencode is the slow outlier. Unlike the print-mode agents (claude -p, codex
+# exec) it runs a full turn AND a separate small_model call to name the session,
+# so one connection reply takes ~8 min on a CPU-served 4B -- right at the shared
+# 600s cap, so the cell flaked when a run drifted past a ~480s success. Give it
+# headroom (still well under the 40-min job budget); the fast agents keep the
+# tight cap that still catches a real headless-TTY hang.
+case "$AGENT" in
+  opencode) TIMEOUT=$(( TIMEOUT * 2 )) ;;
+esac
 
 # Claude refuses --dangerously-skip-permissions outside a sandbox; the CI runner
 # IS the sandbox, so declare it (mirrors unslothai/scripts launcher.sh). Harmless

--- a/.github/scripts/agent-guides-drive.sh
+++ b/.github/scripts/agent-guides-drive.sh
@@ -36,7 +36,6 @@ AGENT="${2:?usage: agent-guides-drive.sh <mode> <agent>}"
 # Determinism (seed/temp) is applied at the server level by
 # serve-unsloth-run.sh --extra; agents inherit it through the API.
 TIMEOUT="${AGENT_INVOKE_TIMEOUT:-180}"
-TIMEOUT="${TIMEOUT%s}"  # tolerate a trailing 's' (timeout(1) style) so the arithmetic and "${TIMEOUT}s" below stay valid
 # opencode is the slow outlier. Unlike the print-mode agents (claude -p, codex
 # exec) it runs a full turn AND a separate small_model call to name the session,
 # so one connection reply takes ~8 min on a CPU-served 4B -- right at the shared
@@ -44,7 +43,15 @@ TIMEOUT="${TIMEOUT%s}"  # tolerate a trailing 's' (timeout(1) style) so the arit
 # headroom (still well under the 40-min job budget); the fast agents keep the
 # tight cap that still catches a real headless-TTY hang.
 case "$AGENT" in
-  opencode) TIMEOUT=$(( TIMEOUT * 2 )) ;;
+  opencode)
+    # Double it, but only for a bare-integer seconds value. A GNU timeout(1)
+    # duration suffix (s/m/h/d, including floats like 0.5s) is left unchanged so
+    # the arithmetic never sees a non-number; timeout(1) parses it directly.
+    case "$TIMEOUT" in
+      *[!0-9]*) ;;
+      *) TIMEOUT=$(( TIMEOUT * 2 )) ;;
+    esac
+    ;;
 esac
 
 # Claude refuses --dangerously-skip-permissions outside a sandbox; the CI runner

--- a/.github/scripts/agent-guides-drive.sh
+++ b/.github/scripts/agent-guides-drive.sh
@@ -36,6 +36,7 @@ AGENT="${2:?usage: agent-guides-drive.sh <mode> <agent>}"
 # Determinism (seed/temp) is applied at the server level by
 # serve-unsloth-run.sh --extra; agents inherit it through the API.
 TIMEOUT="${AGENT_INVOKE_TIMEOUT:-180}"
+TIMEOUT="${TIMEOUT%s}"  # tolerate a trailing 's' (timeout(1) style) so the arithmetic and "${TIMEOUT}s" below stay valid
 # opencode is the slow outlier. Unlike the print-mode agents (claude -p, codex
 # exec) it runs a full turn AND a separate small_model call to name the session,
 # so one connection reply takes ~8 min on a CPU-served 4B -- right at the shared


### PR DESCRIPTION
## Problem

The `connection (opencode)` cell of Local Agent Guides CI flakes with a timeout, surfaced as guide drift:

```
[guide drift] agent=opencode: invoke timed out after 600s (headless-TTY hang -- the recipe likely needs a non-interactive/print flag)
```

It is not actually a hang. In a passing run the same `opencode run` finishes in about 482s (08:12:31 to 08:20:33), which sits right against the shared `AGENT_INVOKE_TIMEOUT` of 600s. Roughly one recent run in six drifts past the cap and fails, so this cell has been intermittently red on unrelated PRs.

## Why opencode is the slow one

The print-mode agents (`claude -p`, `codex exec`) run a single turn against the minimal system prompt the workflow injects. `opencode run` is different: it runs its own full turn with opencode's large system prompt, and on top of that it makes a separate `small_model` call to name the session (`start.py` pins `small_model` to the same 4B the server hosts). On a CPU-served gemma-4-E4B that is roughly 8 minutes of prefill and generation, so 600s leaves almost no margin and normal per-run variance tips it over.

## Fix

Give opencode double the per-invoke timeout in `agent-guides-drive.sh`, and keep the tight 600s cap for the fast agents so a genuine headless-TTY hang still fails quickly. 1200s stays well under the 40-minute job budget.

```sh
case "$AGENT" in
  opencode) TIMEOUT=$(( TIMEOUT * 2 )) ;;
esac
```

## Verification

- `bash -n` and `shellcheck -S warning` clean on `agent-guides-drive.sh`.
- The per-agent branch resolves opencode to 1200s and every other agent stays at 600s.
