### PR TITLE
Studio: make Stop and stall deadlines interrupt a wedged stream portably

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -8998,6 +8998,55 @@ class LlamaCppBackend:
             logger.debug("Could not close httpx client", exc_info = True)
 
     @staticmethod
+    def _install_cancel_aware_read(
+        client: "httpx.Client",
+        cancel_event: threading.Event,
+        poll_s: float = 0.2,
+    ) -> None:
+        """Make the reader thread interrupt its own blocked recv() on cancel.
+
+        The watcher's cross-thread socket shutdown unblocks a parked recv() on
+        POSIX but is unreliable on Windows (Winsock does not dependably wake a
+        recv() in progress on another thread). Instead, wrap the httpcore
+        network stream so each read loops in short slices and polls cancel_event
+        between them: the reader interrupts itself, so cancel is portable and
+        works for plain and TLS streams. Slice timeouts are swallowed, so a
+        slow-but-alive stream is never torn down."""
+        import httpcore
+        try:
+            pool = getattr(getattr(client, "_transport", None), "_pool", None)
+            for connection in list(getattr(pool, "_connections", []) or []):
+                inner = getattr(connection, "_connection", None)
+                stream = getattr(inner, "_network_stream", None)
+                if stream is None or getattr(stream, "_unsloth_cancel_wrapped", False):
+                    continue
+                orig_read = stream.read
+
+                def read(max_bytes, timeout = None, _orig = orig_read):
+                    deadline = None if timeout is None else time.monotonic() + timeout
+                    while True:
+                        if cancel_event.is_set():
+                            raise httpcore.ReadError("stream cancelled by user")
+                        if deadline is None:
+                            step = poll_s
+                        else:
+                            remaining = deadline - time.monotonic()
+                            if remaining <= 0:
+                                raise httpcore.ReadTimeout("read operation timed out")
+                            step = min(poll_s, remaining)
+                        try:
+                            return _orig(max_bytes, timeout = step)
+                        except httpcore.ReadTimeout:
+                            if deadline is not None and time.monotonic() >= deadline:
+                                raise
+                            continue  # slice timed out on silence, keep the stream alive
+
+                stream.read = read
+                stream._unsloth_cancel_wrapped = True
+        except Exception:
+            logger.debug("Could not install cancel-aware read", exc_info = True)
+
+    @staticmethod
     @contextlib.contextmanager
     def _stream_with_retry(
         client: "httpx.Client",
@@ -9054,6 +9103,11 @@ class LlamaCppBackend:
                 headers = headers,
             ) as response:
                 _response_ref[0] = response
+                if cancel_event is not None:
+                    # Portable mid-stream cancel: the reader polls cancel itself,
+                    # so Stop interrupts a stalled read even where the watcher's
+                    # cross-thread socket shutdown does not (Windows).
+                    LlamaCppBackend._install_cancel_aware_read(client, cancel_event)
                 if cancel_event is not None and cancel_event.is_set():
                     raise _LlamaStreamCancelled
                 yield response

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -9051,9 +9051,7 @@ class LlamaCppBackend:
                 ):
                     live = _live_read_timeout()
                     effective = live if live is not None else timeout
-                    deadline = (
-                        None if effective is None else time.monotonic() + effective
-                    )
+                    deadline = None if effective is None else time.monotonic() + effective
                     while True:
                         if cancel_event.is_set():
                             raise httpcore.ReadError("stream cancelled by user")
@@ -9139,9 +9137,7 @@ class LlamaCppBackend:
                     # cross-thread socket shutdown does not (Windows). Pass the
                     # response so the wrapper honors the live (post-first-token
                     # stall) read timeout, which httpcore otherwise snapshots.
-                    LlamaCppBackend._install_cancel_aware_read(
-                        client, cancel_event, response
-                    )
+                    LlamaCppBackend._install_cancel_aware_read(client, cancel_event, response)
                 if cancel_event is not None and cancel_event.is_set():
                     raise _LlamaStreamCancelled
                 yield response

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -9022,7 +9022,11 @@ class LlamaCppBackend:
                     continue
                 orig_read = stream.read
 
-                def read(max_bytes, timeout = None, _orig = orig_read):
+                def read(
+                    max_bytes,
+                    timeout = None,
+                    _orig = orig_read,
+                ):
                     deadline = None if timeout is None else time.monotonic() + timeout
                     while True:
                         if cancel_event.is_set():

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -9006,20 +9006,17 @@ class LlamaCppBackend:
     ) -> None:
         """Make the reader thread interrupt its own blocked recv() on cancel.
 
-        The watcher's cross-thread socket shutdown unblocks a parked recv() on
-        POSIX but is unreliable on Windows (Winsock does not dependably wake a
-        recv() in progress on another thread). Instead, wrap the httpcore
-        network stream so each read loops in short slices and polls cancel_event
-        between them: the reader interrupts itself, so cancel is portable and
-        works for plain and TLS streams. Slice timeouts are swallowed, so a
-        slow-but-alive stream is never torn down.
+        The watcher's cross-thread socket shutdown wakes a parked recv() on POSIX
+        but not reliably on Windows (Winsock). So wrap the httpcore network stream
+        to read in short slices and poll cancel_event between them: the reader
+        interrupts itself, portably and for plain or TLS streams. Slice timeouts
+        are swallowed so a slow-but-alive stream is never torn down.
 
-        httpcore's _receive_response_body snapshots request.extensions["timeout"]
-        ["read"] once when the body starts, so lowering it to the stall timeout
-        after the first token never reaches the socket read. When ``response`` is
-        given we re-read that live value per call and bound each read by it, so
-        the post-first-token stall timeout is honored instead of the long prefill
-        timeout."""
+        httpcore snapshots request.extensions["timeout"]["read"] once at body
+        start, so lowering it to the stall timeout after the first token never
+        reaches the socket. Given ``response`` we re-read that live value per call
+        and bound each read by it, honoring the post-first-token stall timeout
+        instead of the long prefill timeout."""
         import httpcore
 
         def _live_read_timeout() -> Optional[float]:
@@ -9067,7 +9064,7 @@ class LlamaCppBackend:
                         except httpcore.ReadTimeout:
                             if deadline is not None and time.monotonic() >= deadline:
                                 raise
-                            continue  # slice timed out on silence, keep the stream alive
+                            continue  # silence, not death: keep the stream alive
 
                 stream.read = read
                 stream._unsloth_cancel_wrapped = True
@@ -9133,10 +9130,9 @@ class LlamaCppBackend:
                 _response_ref[0] = response
                 if cancel_event is not None:
                     # Portable mid-stream cancel: the reader polls cancel itself,
-                    # so Stop interrupts a stalled read even where the watcher's
-                    # cross-thread socket shutdown does not (Windows). Pass the
-                    # response so the wrapper honors the live (post-first-token
-                    # stall) read timeout, which httpcore otherwise snapshots.
+                    # so Stop interrupts a stalled read where the watcher's socket
+                    # shutdown does not (Windows). Pass response so the wrapper
+                    # honors the live post-first-token stall timeout.
                     LlamaCppBackend._install_cancel_aware_read(client, cancel_event, response)
                 if cancel_event is not None and cancel_event.is_set():
                     raise _LlamaStreamCancelled

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -9001,6 +9001,7 @@ class LlamaCppBackend:
     def _install_cancel_aware_read(
         client: "httpx.Client",
         cancel_event: threading.Event,
+        response: Optional["httpx.Response"] = None,
         poll_s: float = 0.2,
     ) -> None:
         """Make the reader thread interrupt its own blocked recv() on cancel.
@@ -9011,8 +9012,29 @@ class LlamaCppBackend:
         network stream so each read loops in short slices and polls cancel_event
         between them: the reader interrupts itself, so cancel is portable and
         works for plain and TLS streams. Slice timeouts are swallowed, so a
-        slow-but-alive stream is never torn down."""
+        slow-but-alive stream is never torn down.
+
+        httpcore's _receive_response_body snapshots request.extensions["timeout"]
+        ["read"] once when the body starts, so lowering it to the stall timeout
+        after the first token never reaches the socket read. When ``response`` is
+        given we re-read that live value per call and bound each read by it, so
+        the post-first-token stall timeout is honored instead of the long prefill
+        timeout."""
         import httpcore
+
+        def _live_read_timeout() -> Optional[float]:
+            if response is None:
+                return None
+            try:
+                ext = response.request.extensions.get("timeout")
+                if isinstance(ext, dict):
+                    value = ext.get("read")
+                    if isinstance(value, (int, float)):
+                        return float(value)
+            except Exception:
+                pass
+            return None
+
         try:
             pool = getattr(getattr(client, "_transport", None), "_pool", None)
             for connection in list(getattr(pool, "_connections", []) or []):
@@ -9027,7 +9049,11 @@ class LlamaCppBackend:
                     timeout = None,
                     _orig = orig_read,
                 ):
-                    deadline = None if timeout is None else time.monotonic() + timeout
+                    live = _live_read_timeout()
+                    effective = live if live is not None else timeout
+                    deadline = (
+                        None if effective is None else time.monotonic() + effective
+                    )
                     while True:
                         if cancel_event.is_set():
                             raise httpcore.ReadError("stream cancelled by user")
@@ -9110,8 +9136,12 @@ class LlamaCppBackend:
                 if cancel_event is not None:
                     # Portable mid-stream cancel: the reader polls cancel itself,
                     # so Stop interrupts a stalled read even where the watcher's
-                    # cross-thread socket shutdown does not (Windows).
-                    LlamaCppBackend._install_cancel_aware_read(client, cancel_event)
+                    # cross-thread socket shutdown does not (Windows). Pass the
+                    # response so the wrapper honors the live (post-first-token
+                    # stall) read timeout, which httpcore otherwise snapshots.
+                    LlamaCppBackend._install_cancel_aware_read(
+                        client, cancel_event, response
+                    )
                 if cancel_event is not None and cancel_event.is_set():
                     raise _LlamaStreamCancelled
                 yield response

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -9004,19 +9004,14 @@ class LlamaCppBackend:
         response: Optional["httpx.Response"] = None,
         poll_s: float = 0.2,
     ) -> None:
-        """Make the reader thread interrupt its own blocked recv() on cancel.
+        """Wrap the httpcore stream so the reader interrupts its own blocked recv() on cancel.
 
-        The watcher's cross-thread socket shutdown wakes a parked recv() on POSIX
-        but not reliably on Windows (Winsock). So wrap the httpcore network stream
-        to read in short slices and poll cancel_event between them: the reader
-        interrupts itself, portably and for plain or TLS streams. Slice timeouts
-        are swallowed so a slow-but-alive stream is never torn down.
-
-        httpcore snapshots request.extensions["timeout"]["read"] once at body
-        start, so lowering it to the stall timeout after the first token never
-        reaches the socket. Given ``response`` we re-read that live value per call
-        and bound each read by it, honoring the post-first-token stall timeout
-        instead of the long prefill timeout."""
+        A cross-thread socket shutdown wakes a parked recv() on POSIX but not on
+        Windows (Winsock), so read in short slices and poll cancel_event between them
+        (plain or TLS); slice timeouts are swallowed so a slow-but-alive stream survives.
+        httpcore snapshots request.extensions["timeout"]["read"] once at body start, so
+        given ``response`` we re-read the live value per call to honor the post-first-token
+        stall timeout instead of the long prefill timeout."""
         import httpcore
 
         def _live_read_timeout() -> Optional[float]:
@@ -9064,7 +9059,7 @@ class LlamaCppBackend:
                         except httpcore.ReadTimeout:
                             if deadline is not None and time.monotonic() >= deadline:
                                 raise
-                            continue  # silence, not death: keep the stream alive
+                            continue  # slow but alive: keep reading
 
                 stream.read = read
                 stream._unsloth_cancel_wrapped = True
@@ -9129,10 +9124,9 @@ class LlamaCppBackend:
             ) as response:
                 _response_ref[0] = response
                 if cancel_event is not None:
-                    # Portable mid-stream cancel: the reader polls cancel itself,
-                    # so Stop interrupts a stalled read where the watcher's socket
-                    # shutdown does not (Windows). Pass response so the wrapper
-                    # honors the live post-first-token stall timeout.
+                    # Portable mid-stream cancel: the reader polls cancel itself, so
+                    # Stop interrupts a stalled read where the watcher's Windows socket
+                    # shutdown does not. Pass response to honor the live stall timeout.
                     LlamaCppBackend._install_cancel_aware_read(client, cancel_event, response)
                 if cancel_event is not None and cancel_event.is_set():
                     raise _LlamaStreamCancelled

--- a/studio/backend/tests/test_llama_cpp_stall_timeout.py
+++ b/studio/backend/tests/test_llama_cpp_stall_timeout.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Regression test for the post-first-token stall timeout in the cancel-aware read.
+
+httpcore's ``HTTP11Connection._receive_response_body`` reads
+``request.extensions["timeout"]["read"]`` once when the body starts and reuses
+that value for every socket read. So when ``_iter_text_cancellable`` lowers the
+read timeout to the stall timeout after the first token, httpcore keeps the long
+prefill timeout and a one-token-then-silent server hangs for the full prefill
+window instead of raising after the stall timeout.
+
+The fix makes the cancel-aware read wrapper re-read the live extensions timeout
+per call. This exercises the wrapper's deadline logic with a fake clock and a
+fake always-silent stream (no live socket): the read must give up after the live
+stall timeout, not the stale prefill timeout passed in by httpcore.
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+import threading
+import types as _types
+from pathlib import Path
+
+import pytest
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+# Mirror sibling tests' stubbing so the module imports without fastapi.
+_loggers_stub = _types.ModuleType("loggers")
+_loggers_stub.get_logger = lambda name: __import__("logging").getLogger(name)
+sys.modules.setdefault("loggers", _loggers_stub)
+sys.modules.setdefault("structlog", _types.ModuleType("structlog"))
+
+import httpcore  # noqa: E402
+
+from core.inference import llama_cpp as llama_cpp_mod  # noqa: E402
+from core.inference.llama_cpp import LlamaCppBackend  # noqa: E402
+
+_PREFILL_TIMEOUT = 1200.0  # what httpcore snapshots from the prefill timeout
+_STALL_TIMEOUT = 120.0  # the post-first-token stall timeout the wrapper must honor
+
+
+class _Obj:
+    pass
+
+
+def _install(response, clock, silent_stream):
+    """Wire fake client/pool objects so _install_cancel_aware_read finds the
+    stream, patch the module clock, then return the wrapped stream.read."""
+    inner = _Obj()
+    inner._network_stream = silent_stream
+    connection = _Obj()
+    connection._connection = inner
+    pool = _Obj()
+    pool._connections = [connection]
+    transport = _Obj()
+    transport._pool = pool
+    client = _Obj()
+    client._transport = transport
+
+    cancel_event = threading.Event()  # never set: we test the stall path, not cancel
+    sig = inspect.signature(LlamaCppBackend._install_cancel_aware_read)
+    if "response" in sig.parameters:
+        # Fixed signature: the wrapper reads the live extensions timeout.
+        LlamaCppBackend._install_cancel_aware_read(client, cancel_event, response)
+    else:
+        # Pre-fix signature: no response, so the wrapper trusts httpcore's stale
+        # prefill timeout and the stall assertion below fails (proving the bug).
+        LlamaCppBackend._install_cancel_aware_read(client, cancel_event)
+    return silent_stream.read
+
+
+def test_stall_timeout_honored_after_first_token(monkeypatch):
+    clock = {"t": 0.0}
+    monkeypatch.setattr(llama_cpp_mod.time, "monotonic", lambda: clock["t"])
+
+    # A server that emits one token then goes silent: every body read times out.
+    # Each slice "waits" its full timeout of fake time before timing out.
+    def silent_read(max_bytes, timeout=None):
+        clock["t"] += timeout if timeout is not None else 0.0
+        raise httpcore.ReadTimeout("slice timed out on silence")
+
+    stream = _Obj()
+    stream.read = silent_read
+
+    # First token already seen: _iter_text_cancellable lowered the live read
+    # timeout to the stall timeout via response.request.extensions.
+    request = _Obj()
+    request.extensions = {"timeout": {"read": _STALL_TIMEOUT}}
+    response = _Obj()
+    response.request = request
+
+    wrapped_read = _install(response, clock, stream)
+
+    # httpcore still passes the stale prefill timeout it snapshotted at body start.
+    with pytest.raises(httpcore.ReadTimeout):
+        wrapped_read(65536, timeout=_PREFILL_TIMEOUT)
+
+    # The wrapper must give up ~stall timeout after the last token, not after the
+    # 20-minute prefill window. Allow slack for the final partial slice.
+    assert clock["t"] <= _STALL_TIMEOUT * 1.5, (
+        f"stall timeout not honored: waited {clock['t']}s "
+        f"(expected ~{_STALL_TIMEOUT}s, not {_PREFILL_TIMEOUT}s)"
+    )
+    assert clock["t"] >= _STALL_TIMEOUT * 0.5
+
+
+def test_prefill_timeout_used_when_no_live_override(monkeypatch):
+    """Without a lowered live timeout, the wrapper still honors the passed
+    (prefill) timeout, so the normal first-token wait is unchanged."""
+    clock = {"t": 0.0}
+    monkeypatch.setattr(llama_cpp_mod.time, "monotonic", lambda: clock["t"])
+
+    def silent_read(max_bytes, timeout=None):
+        clock["t"] += timeout if timeout is not None else 0.0
+        raise httpcore.ReadTimeout("slice timed out on silence")
+
+    stream = _Obj()
+    stream.read = silent_read
+
+    # No timeout extension set: wrapper falls back to httpcore's passed timeout.
+    request = _Obj()
+    request.extensions = {}
+    response = _Obj()
+    response.request = request
+
+    wrapped_read = _install(response, clock, stream)
+
+    with pytest.raises(httpcore.ReadTimeout):
+        wrapped_read(65536, timeout=_PREFILL_TIMEOUT)
+
+    assert clock["t"] >= _PREFILL_TIMEOUT * 0.9

--- a/studio/backend/tests/test_llama_cpp_stall_timeout.py
+++ b/studio/backend/tests/test_llama_cpp_stall_timeout.py
@@ -81,7 +81,7 @@ def test_stall_timeout_honored_after_first_token(monkeypatch):
 
     # A server that emits one token then goes silent: every body read times out.
     # Each slice "waits" its full timeout of fake time before timing out.
-    def silent_read(max_bytes, timeout=None):
+    def silent_read(max_bytes, timeout = None):
         clock["t"] += timeout if timeout is not None else 0.0
         raise httpcore.ReadTimeout("slice timed out on silence")
 
@@ -99,7 +99,7 @@ def test_stall_timeout_honored_after_first_token(monkeypatch):
 
     # httpcore still passes the stale prefill timeout it snapshotted at body start.
     with pytest.raises(httpcore.ReadTimeout):
-        wrapped_read(65536, timeout=_PREFILL_TIMEOUT)
+        wrapped_read(65536, timeout = _PREFILL_TIMEOUT)
 
     # The wrapper must give up ~stall timeout after the last token, not after the
     # 20-minute prefill window. Allow slack for the final partial slice.
@@ -116,7 +116,7 @@ def test_prefill_timeout_used_when_no_live_override(monkeypatch):
     clock = {"t": 0.0}
     monkeypatch.setattr(llama_cpp_mod.time, "monotonic", lambda: clock["t"])
 
-    def silent_read(max_bytes, timeout=None):
+    def silent_read(max_bytes, timeout = None):
         clock["t"] += timeout if timeout is not None else 0.0
         raise httpcore.ReadTimeout("slice timed out on silence")
 
@@ -132,6 +132,6 @@ def test_prefill_timeout_used_when_no_live_override(monkeypatch):
     wrapped_read = _install(response, clock, stream)
 
     with pytest.raises(httpcore.ReadTimeout):
-        wrapped_read(65536, timeout=_PREFILL_TIMEOUT)
+        wrapped_read(65536, timeout = _PREFILL_TIMEOUT)
 
     assert clock["t"] >= _PREFILL_TIMEOUT * 0.9

--- a/studio/backend/tests/test_llama_cpp_stall_timeout.py
+++ b/studio/backend/tests/test_llama_cpp_stall_timeout.py
@@ -3,12 +3,11 @@
 
 """Regression test for the post-first-token stall timeout in the cancel-aware read.
 
-httpcore snapshots ``request.extensions["timeout"]["read"]`` once at body start,
-so when ``_iter_text_cancellable`` lowers the read timeout to the stall timeout
-after the first token, a one-token-then-silent server hangs for the full prefill
-window. The fix makes the wrapper re-read the live extensions timeout per call.
-Exercised with a fake clock and always-silent stream: the read must give up after
-the live stall timeout, not the stale prefill timeout passed in by httpcore.
+httpcore snapshots ``request.extensions["timeout"]["read"]`` once at body start, so
+when ``_iter_text_cancellable`` lowers it after the first token, a one-token-then-silent
+server hangs for the full prefill window. The fix re-reads the live extensions timeout
+per call; a fake clock and always-silent stream check the read gives up after the live
+stall timeout, not the stale prefill one.
 """
 
 from __future__ import annotations
@@ -45,8 +44,7 @@ class _Obj:
 
 
 def _install(response, clock, silent_stream):
-    """Wire fake client/pool objects so _install_cancel_aware_read finds the
-    stream, then return the wrapped stream.read."""
+    """Wire fake client/pool so _install_cancel_aware_read finds the stream; return the wrapped stream.read."""
     inner = _Obj()
     inner._network_stream = silent_stream
     connection = _Obj()
@@ -102,8 +100,7 @@ def test_stall_timeout_honored_after_first_token(monkeypatch):
 
 
 def test_prefill_timeout_used_when_no_live_override(monkeypatch):
-    """Without a lowered live timeout, the wrapper honors the passed prefill
-    timeout, so the normal first-token wait is unchanged."""
+    """Without a lowered live timeout, the wrapper honors the passed prefill timeout, so the normal first-token wait is unchanged."""
     clock = {"t": 0.0}
     monkeypatch.setattr(llama_cpp_mod.time, "monotonic", lambda: clock["t"])
 

--- a/studio/backend/tests/test_llama_cpp_stall_timeout.py
+++ b/studio/backend/tests/test_llama_cpp_stall_timeout.py
@@ -3,17 +3,12 @@
 
 """Regression test for the post-first-token stall timeout in the cancel-aware read.
 
-httpcore's ``HTTP11Connection._receive_response_body`` reads
-``request.extensions["timeout"]["read"]`` once when the body starts and reuses
-that value for every socket read. So when ``_iter_text_cancellable`` lowers the
-read timeout to the stall timeout after the first token, httpcore keeps the long
-prefill timeout and a one-token-then-silent server hangs for the full prefill
-window instead of raising after the stall timeout.
-
-The fix makes the cancel-aware read wrapper re-read the live extensions timeout
-per call. This exercises the wrapper's deadline logic with a fake clock and a
-fake always-silent stream (no live socket): the read must give up after the live
-stall timeout, not the stale prefill timeout passed in by httpcore.
+httpcore snapshots ``request.extensions["timeout"]["read"]`` once at body start,
+so when ``_iter_text_cancellable`` lowers the read timeout to the stall timeout
+after the first token, a one-token-then-silent server hangs for the full prefill
+window. The fix makes the wrapper re-read the live extensions timeout per call.
+Exercised with a fake clock and always-silent stream: the read must give up after
+the live stall timeout, not the stale prefill timeout passed in by httpcore.
 """
 
 from __future__ import annotations
@@ -51,7 +46,7 @@ class _Obj:
 
 def _install(response, clock, silent_stream):
     """Wire fake client/pool objects so _install_cancel_aware_read finds the
-    stream, patch the module clock, then return the wrapped stream.read."""
+    stream, then return the wrapped stream.read."""
     inner = _Obj()
     inner._network_stream = silent_stream
     connection = _Obj()
@@ -66,11 +61,10 @@ def _install(response, clock, silent_stream):
     cancel_event = threading.Event()  # never set: we test the stall path, not cancel
     sig = inspect.signature(LlamaCppBackend._install_cancel_aware_read)
     if "response" in sig.parameters:
-        # Fixed signature: the wrapper reads the live extensions timeout.
+        # Fixed signature: wrapper reads the live extensions timeout.
         LlamaCppBackend._install_cancel_aware_read(client, cancel_event, response)
     else:
-        # Pre-fix signature: no response, so the wrapper trusts httpcore's stale
-        # prefill timeout and the stall assertion below fails (proving the bug).
+        # Pre-fix signature: no response, so the stall assertion fails (proves the bug).
         LlamaCppBackend._install_cancel_aware_read(client, cancel_event)
     return silent_stream.read
 
@@ -79,8 +73,7 @@ def test_stall_timeout_honored_after_first_token(monkeypatch):
     clock = {"t": 0.0}
     monkeypatch.setattr(llama_cpp_mod.time, "monotonic", lambda: clock["t"])
 
-    # A server that emits one token then goes silent: every body read times out.
-    # Each slice "waits" its full timeout of fake time before timing out.
+    # One token then silence: every read times out, advancing fake time by its timeout.
     def silent_read(max_bytes, timeout = None):
         clock["t"] += timeout if timeout is not None else 0.0
         raise httpcore.ReadTimeout("slice timed out on silence")
@@ -88,8 +81,7 @@ def test_stall_timeout_honored_after_first_token(monkeypatch):
     stream = _Obj()
     stream.read = silent_read
 
-    # First token already seen: _iter_text_cancellable lowered the live read
-    # timeout to the stall timeout via response.request.extensions.
+    # First token seen: the live read timeout is lowered to the stall timeout.
     request = _Obj()
     request.extensions = {"timeout": {"read": _STALL_TIMEOUT}}
     response = _Obj()
@@ -101,8 +93,7 @@ def test_stall_timeout_honored_after_first_token(monkeypatch):
     with pytest.raises(httpcore.ReadTimeout):
         wrapped_read(65536, timeout = _PREFILL_TIMEOUT)
 
-    # The wrapper must give up ~stall timeout after the last token, not after the
-    # 20-minute prefill window. Allow slack for the final partial slice.
+    # Must give up ~stall timeout after the last token, not the prefill window.
     assert clock["t"] <= _STALL_TIMEOUT * 1.5, (
         f"stall timeout not honored: waited {clock['t']}s "
         f"(expected ~{_STALL_TIMEOUT}s, not {_PREFILL_TIMEOUT}s)"
@@ -111,8 +102,8 @@ def test_stall_timeout_honored_after_first_token(monkeypatch):
 
 
 def test_prefill_timeout_used_when_no_live_override(monkeypatch):
-    """Without a lowered live timeout, the wrapper still honors the passed
-    (prefill) timeout, so the normal first-token wait is unchanged."""
+    """Without a lowered live timeout, the wrapper honors the passed prefill
+    timeout, so the normal first-token wait is unchanged."""
     clock = {"t": 0.0}
     monkeypatch.setattr(llama_cpp_mod.time, "monotonic", lambda: clock["t"])
 
@@ -123,7 +114,7 @@ def test_prefill_timeout_used_when_no_live_override(monkeypatch):
     stream = _Obj()
     stream.read = silent_read
 
-    # No timeout extension set: wrapper falls back to httpcore's passed timeout.
+    # No timeout extension: wrapper falls back to httpcore's passed timeout.
     request = _Obj()
     request.extensions = {}
     response = _Obj()


### PR DESCRIPTION
## Problem

When a llama.cpp generation stalls mid-stream (for example when the context fills), the Stop button and the stall deadlines could fail to interrupt it, so the stream hung for the full first-token budget (around 20 minutes). The cancel watcher unblocks a stalled read by shutting the socket down from another thread. That works on Linux and macOS, but not reliably on native Windows: Winsock does not dependably wake a `recv()` that is already in progress on another thread, and closing a socket another thread is using is a documented race. So on Windows the person watching a wedged generation had no working way to stop it.

## Fix

Make the reader thread interrupt itself instead of relying on a cross-thread socket teardown. Right after the stream response opens, we wrap the connection's httpcore network stream so each body read loops the underlying read in short slices and polls the cancel event between slices, raising once cancelled.

- Cancellation no longer depends on Winsock behaviour, so Stop and the stall deadlines interrupt a wedged read on Windows, macOS, Linux and WSL alike.
- It wraps `.read` rather than poking the raw socket, so it also works for TLS streams (a remote llama.cpp over HTTPS).
- The slice timeouts are swallowed below h11, so a slow but still-alive stream (a large MoE model with minutes between tokens) is never torn down.
- The existing POSIX socket-shutdown path is left in place as a fast path.

## Verification

`studio/backend/tests/test_llama_cpp_stream_cancel.py` passes. Reproduced separately against a raw stalling HTTP server driven through the real httpx/httpcore stack: with the socket-shutdown path disabled (to model Winsock) the unpatched code hangs to the deadline, while the wrapped reader cancels in well under a second and a slow-but-alive stream still completes with every token.

## Compatibility

Additive and off the happy path. No API change. Verified against httpx 0.27/0.28 and httpcore 1.0.9.
