### PR TITLE
Studio: fix per-GPU VRAM reporting on Windows ROCm

### DIFF
--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1156,9 +1156,7 @@ def _get_cached_system_gpu_info(logger) -> dict[str, Any]:
             enriched_dev = dict(dev)
             enriched_dev["vram_used_gb"] = used_vram
             enriched_dev["vram_free_gb"] = (
-                round(total_vram - used_vram, 2)
-                if total_vram and used_vram is not None
-                else None
+                round(total_vram - used_vram, 2) if total_vram and used_vram is not None else None
             )
             enriched_dev["vram_utilization_pct"] = util.get("vram_utilization_pct")
             enriched_devices.append(enriched_dev)

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1148,8 +1148,8 @@ def _get_cached_system_gpu_info(logger) -> dict[str, Any]:
             util = util_devices.get(idx, {})
 
             total_vram = util.get("vram_total_gb") or dev.get("memory_total_gb") or 0
-            # None = usage unknown (e.g. Windows ROCm perf counter unavailable);
-            # keep None so the UI shows unknown, not a fabricated 0 used / full free.
+            # Keep None (usage unknown, e.g. Windows ROCm perf counter) so the UI
+            # shows unknown, not a fabricated 0 used / full free.
             used_vram = util.get("vram_used_gb")
 
             enriched_dev = dict(dev)

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1148,9 +1148,8 @@ def _get_cached_system_gpu_info(logger) -> dict[str, Any]:
             util = util_devices.get(idx, {})
 
             total_vram = util.get("vram_total_gb") or dev.get("memory_total_gb") or 0
-            # None means usage is unknown (e.g. Windows ROCm perf counter
-            # unavailable); keep it None so the UI shows unknown, not a fabricated
-            # 0 used / full free. ``or 0`` would re-hide the reported bug.
+            # None = usage unknown (e.g. Windows ROCm perf counter unavailable);
+            # keep None so the UI shows unknown, not a fabricated 0 used / full free.
             used_vram = util.get("vram_used_gb")
 
             enriched_dev = dict(dev)

--- a/studio/backend/main.py
+++ b/studio/backend/main.py
@@ -1148,11 +1148,18 @@ def _get_cached_system_gpu_info(logger) -> dict[str, Any]:
             util = util_devices.get(idx, {})
 
             total_vram = util.get("vram_total_gb") or dev.get("memory_total_gb") or 0
-            used_vram = util.get("vram_used_gb") or 0
+            # None means usage is unknown (e.g. Windows ROCm perf counter
+            # unavailable); keep it None so the UI shows unknown, not a fabricated
+            # 0 used / full free. ``or 0`` would re-hide the reported bug.
+            used_vram = util.get("vram_used_gb")
 
             enriched_dev = dict(dev)
             enriched_dev["vram_used_gb"] = used_vram
-            enriched_dev["vram_free_gb"] = round(total_vram - used_vram, 2) if total_vram else 0
+            enriched_dev["vram_free_gb"] = (
+                round(total_vram - used_vram, 2)
+                if total_vram and used_vram is not None
+                else None
+            )
             enriched_dev["vram_utilization_pct"] = util.get("vram_utilization_pct")
             enriched_devices.append(enriched_dev)
 

--- a/studio/backend/tests/test_rocm_windows_vram_7072.py
+++ b/studio/backend/tests/test_rocm_windows_vram_7072.py
@@ -354,3 +354,38 @@ def test_perf_counter_parser_and_sentinel(monkeypatch):
     assert parsed[0][0].startswith("luid_")
     monkeypatch.setattr(hw.subprocess, "run", _subprocess_run(adapter_output = "__NONE__\n"))
     assert hw._rocm_windows_perf_counter_vram_by_adapter() is None
+
+
+# ----------------------------------------------------------------------------- #
+# Unified-memory (Strix Halo APU) total reconciliation (Codex #7238)
+# ----------------------------------------------------------------------------- #
+def test_unified_memory_adopts_torch_total_even_when_used_unknown():
+    """On a Windows ROCm unified-memory APU, torch's used is None (the free==total
+    sentinel) while its total (the full GTT pool) stays authoritative. The
+    correction must still adopt that larger total instead of keeping amd-smi's
+    small dedicated carve-out, otherwise the card underreports its capacity;
+    only used stays at amd-smi's figure when torch's is unknown (Codex #7238)."""
+    metrics = {"vram_total_gb": 8.0, "vram_used_gb": 2.0, "vram_utilization_pct": 25.0}
+    hw._apply_unified_memory_correction(metrics, {"total_gb": 124.0, "used_gb": None, "index": 0})
+    assert metrics["vram_total_gb"] == 124.0  # full unified pool, not the 8 GB carve-out
+    assert metrics["vram_used_gb"] == 2.0  # amd-smi used preserved (torch's was None)
+    assert metrics["vram_utilization_pct"] == pytest.approx(round(2.0 / 124.0 * 100, 1))
+
+
+def test_unified_memory_overwrites_used_when_torch_used_known():
+    """When torch reports both a larger total and a known used, both are adopted
+    and utilization is recomputed against the corrected total (unchanged path)."""
+    metrics = {"vram_total_gb": 8.0, "vram_used_gb": 2.0, "vram_utilization_pct": 25.0}
+    hw._apply_unified_memory_correction(metrics, {"total_gb": 124.0, "used_gb": 40.0, "index": 0})
+    assert metrics["vram_total_gb"] == 124.0
+    assert metrics["vram_used_gb"] == 40.0
+    assert metrics["vram_utilization_pct"] == pytest.approx(round(40.0 / 124.0 * 100, 1))
+
+
+def test_unified_memory_no_op_when_torch_total_not_larger():
+    """A discrete GPU where torch total does not exceed amd-smi's is left untouched."""
+    metrics = {"vram_total_gb": 48.0, "vram_used_gb": 10.0, "vram_utilization_pct": 20.8}
+    hw._apply_unified_memory_correction(metrics, {"total_gb": 48.0, "used_gb": None, "index": 0})
+    assert metrics["vram_total_gb"] == 48.0
+    assert metrics["vram_used_gb"] == 10.0
+    assert metrics["vram_utilization_pct"] == 20.8

--- a/studio/backend/tests/test_rocm_windows_vram_7072.py
+++ b/studio/backend/tests/test_rocm_windows_vram_7072.py
@@ -135,9 +135,8 @@ def test_system_tab_shows_per_gpu_used(win_rocm, monkeypatch):
     assert by_idx[0]["vram_total_gb"] == 48.0
     assert by_idx[0]["vram_used_gb"] == pytest.approx(40.0, abs = 0.01)  # not 0
     assert by_idx[1]["vram_total_gb"] == 8.0  # own total
-    # The 3 MiB "Basic Render Driver" counter makes this a hidden-adapter case, so
-    # the idle card's 0.5 GiB is not capacity-forced (it also fits a hidden adapter).
-    # Only the 40 GiB is forced onto the 48 GiB card; the idle card reads Unknown.
+    # The 3 MiB Basic Render Driver counter makes this a hidden-adapter case: only
+    # the 40 GiB is forced onto the 48 GiB card; the idle card reads Unknown.
     assert by_idx[1]["vram_used_gb"] is None
     assert by_idx[1]["vram_utilization_pct"] is None
     assert all(
@@ -213,18 +212,16 @@ def test_match_adapter_reports_unknown_when_more_active_than_visible():
 
 
 def test_match_adapter_reports_unknown_when_hidden_high_use_adapter_survives_filter():
-    # Idle visible 8 GiB card (10 MiB, filtered as noise) beside a hidden 48 GiB
-    # card at 40 GiB. The 40 GiB survivor can't fit the 8 GiB device, so clamping
-    # it there would fabricate a fully-used reading. Report unknown.
+    # Idle 8 GiB card (10 MiB noise) beside a hidden 48 GiB card at 40 GiB: the
+    # 40 GiB can't fit the 8 GiB device, so clamping there would fabricate. Unknown.
     assert hw._match_adapter_used_to_devices([40 * GB, 10 * MiB], [8 * GB]) == [None]
     # Order of the counters must not matter.
     assert hw._match_adapter_used_to_devices([10 * MiB, 40 * GB], [8 * GB]) == [None]
 
 
 def test_match_adapter_reports_unknown_for_placeholder_fallback():
-    # Idle GPUs (every counter below the 64 MiB floor) plus a placeholder counter.
-    # No LUID-to-ordinal mapping distinguishes the placeholder from an idle GPU, so
-    # report unknown rather than fabricate.
+    # Every counter below the 64 MiB floor plus a placeholder: no LUID-to-ordinal
+    # mapping tells placeholder from idle GPU, so report unknown, not fabricate.
     # Single visible 8 GiB card idle (10 MiB) beside a 50 MiB placeholder counter.
     assert hw._match_adapter_used_to_devices([50 * MiB, 10 * MiB], [8 * GB]) == [None]
     # Order of the counters must not matter.
@@ -237,9 +234,8 @@ def test_match_adapter_reports_unknown_for_placeholder_fallback():
 
 
 def test_match_adapter_reports_unknown_when_usage_not_capacity_ordered():
-    # 8 GiB card near full (7 GiB) beside a lightly used 48 GiB card (5 GiB). The
-    # bigger usage still fits the smaller card, so both [8<-7, 48<-5] and
-    # [8<-5, 48<-7] are feasible; without a verified mapping, report unknown.
+    # 8 GiB card at 7 GiB beside a 48 GiB card at 5 GiB: the bigger usage still fits
+    # the smaller card, so both pairings are feasible -> unknown.
     assert hw._match_adapter_used_to_devices([7 * GB, 5 * GB], [8 * GB, 48 * GB]) == [None, None]
     # Device order must not matter (same physical situation, ordinals flipped).
     assert hw._match_adapter_used_to_devices([7 * GB, 5 * GB], [48 * GB, 8 * GB]) == [None, None]
@@ -253,10 +249,9 @@ def test_match_adapter_reports_unknown_when_usage_not_capacity_ordered():
 
 
 def test_match_adapter_reports_unknown_when_hidden_usage_fits_visible_card():
-    # With a hidden adapter present, a survivor that merely *fits* a visible card
-    # must NOT be pinned onto it. Two visible cards (48/8 GiB) at 40 GiB / 10 MiB
-    # beside a hidden 6 GiB adapter: the 6 GiB fits the idle 8 GiB card but isn't
-    # capacity-forced, so that card reads Unknown; only 40 GiB is forced.
+    # A survivor that merely *fits* a visible card must not be pinned onto it. Two
+    # cards (48/8 GiB) at 40 GiB / 10 MiB beside a hidden 6 GiB adapter: the 6 GiB
+    # fits the idle 8 GiB card but isn't forced -> Unknown; only 40 GiB is forced.
     assert hw._match_adapter_used_to_devices([40 * GB, 10 * MiB, 6 * GB], [48 * GB, 8 * GB]) == [
         40 * GB,
         None,

--- a/studio/backend/tests/test_rocm_windows_vram_7072.py
+++ b/studio/backend/tests/test_rocm_windows_vram_7072.py
@@ -135,12 +135,9 @@ def test_system_tab_shows_per_gpu_used(win_rocm, monkeypatch):
     assert by_idx[0]["vram_total_gb"] == 48.0
     assert by_idx[0]["vram_used_gb"] == pytest.approx(40.0, abs = 0.01)  # not 0
     assert by_idx[1]["vram_total_gb"] == 8.0  # own total
-    # The reporter's third counter (3 MiB "Basic Render Driver") makes this a
-    # hidden-adapter case: the noise filter could equally have dropped the visible
-    # 8 GiB card's real reading, so its 0.5 GiB survivor is not capacity-forced to
-    # that card (0.5 GiB fits it, but also fits a hidden adapter). Only the 40 GiB
-    # usage is forced -- it exceeds the 8 GiB card, so it can only be the 48 GiB
-    # card. The idle card reports Unknown rather than a possibly-fabricated 0.5 GiB.
+    # The 3 MiB "Basic Render Driver" counter makes this a hidden-adapter case, so
+    # the idle card's 0.5 GiB is not capacity-forced (it also fits a hidden adapter).
+    # Only the 40 GiB is forced onto the 48 GiB card; the idle card reads Unknown.
     assert by_idx[1]["vram_used_gb"] is None
     assert by_idx[1]["vram_utilization_pct"] is None
     assert all(
@@ -216,24 +213,18 @@ def test_match_adapter_reports_unknown_when_more_active_than_visible():
 
 
 def test_match_adapter_reports_unknown_when_hidden_high_use_adapter_survives_filter():
-    # HIP_VISIBLE_DEVICES exposes a single idle 8 GiB card (10 MiB used) on a host
-    # that also has a hidden 48 GiB card busy at 40 GiB. The visible card's real
-    # 10 MiB sits below the 64 MiB noise floor and is dropped, leaving the hidden
-    # card's 40 GiB as the only survivor. That 40 GiB cannot fit the 8 GiB visible
-    # device, so it must belong to the hidden card: clamping it onto the visible
-    # device would fabricate a "fully used" reading. Report unknown instead.
+    # Idle visible 8 GiB card (10 MiB, filtered as noise) beside a hidden 48 GiB
+    # card at 40 GiB. The 40 GiB survivor can't fit the 8 GiB device, so clamping
+    # it there would fabricate a fully-used reading. Report unknown.
     assert hw._match_adapter_used_to_devices([40 * GB, 10 * MiB], [8 * GB]) == [None]
     # Order of the counters must not matter.
     assert hw._match_adapter_used_to_devices([10 * MiB, 40 * GB], [8 * GB]) == [None]
 
 
 def test_match_adapter_reports_unknown_for_placeholder_fallback():
-    # Idle real GPUs (every counter below the 64 MiB noise floor) plus a Windows
-    # "Basic Render Driver" placeholder counter. non_trivial is empty, so the old
-    # `non_trivial or useds` fallback attributed a raw sub-threshold counter to a
-    # real GPU (and, with a single visible device, escaped the swap-ambiguity
-    # check). With no LUID-to-ordinal mapping the placeholder is indistinguishable
-    # from an idle GPU, so report unknown rather than fabricate.
+    # Idle GPUs (every counter below the 64 MiB floor) plus a placeholder counter.
+    # No LUID-to-ordinal mapping distinguishes the placeholder from an idle GPU, so
+    # report unknown rather than fabricate.
     # Single visible 8 GiB card idle (10 MiB) beside a 50 MiB placeholder counter.
     assert hw._match_adapter_used_to_devices([50 * MiB, 10 * MiB], [8 * GB]) == [None]
     # Order of the counters must not matter.
@@ -247,10 +238,8 @@ def test_match_adapter_reports_unknown_for_placeholder_fallback():
 
 def test_match_adapter_reports_unknown_when_usage_not_capacity_ordered():
     # 8 GiB card near full (7 GiB) beside a lightly used 48 GiB card (5 GiB). The
-    # bigger usage (7) still fits the smaller card, so ranking cannot tell which
-    # LUID is which torch ordinal: both [8<-7, 48<-5] and [8<-5, 48<-7] are
-    # feasible. Without a verified mapping, report unknown rather than swap the
-    # per-index values that routes/training_vram.py consumes.
+    # bigger usage still fits the smaller card, so both [8<-7, 48<-5] and
+    # [8<-5, 48<-7] are feasible; without a verified mapping, report unknown.
     assert hw._match_adapter_used_to_devices([7 * GB, 5 * GB], [8 * GB, 48 * GB]) == [None, None]
     # Device order must not matter (same physical situation, ordinals flipped).
     assert hw._match_adapter_used_to_devices([7 * GB, 5 * GB], [48 * GB, 8 * GB]) == [None, None]
@@ -264,13 +253,10 @@ def test_match_adapter_reports_unknown_when_usage_not_capacity_ordered():
 
 
 def test_match_adapter_reports_unknown_when_hidden_usage_fits_visible_card():
-    # Round-4 hole (Codex 3610843300): with a hidden adapter present, a survivor
-    # that merely *fits* a visible card must NOT be pinned onto it. Two visible
-    # cards at 48/8 GiB using 40 GiB / 10 MiB beside a hidden 6 GiB adapter: the
-    # 10 MiB drops below the noise floor and the hidden 6 GiB "fits" the idle 8 GiB
-    # card, so the old ranking fabricated [40, 6]. The 6 GiB is not capacity-forced
-    # onto the 8 GiB card (it also fits the hidden adapter), so that card must read
-    # Unknown. Only the 40 GiB usage is forced (it exceeds the 8 GiB card).
+    # With a hidden adapter present, a survivor that merely *fits* a visible card
+    # must NOT be pinned onto it. Two visible cards (48/8 GiB) at 40 GiB / 10 MiB
+    # beside a hidden 6 GiB adapter: the 6 GiB fits the idle 8 GiB card but isn't
+    # capacity-forced, so that card reads Unknown; only 40 GiB is forced.
     assert hw._match_adapter_used_to_devices([40 * GB, 10 * MiB, 6 * GB], [48 * GB, 8 * GB]) == [
         40 * GB,
         None,
@@ -280,30 +266,23 @@ def test_match_adapter_reports_unknown_when_hidden_usage_fits_visible_card():
         40 * GB,
         None,
     ]
-    # A single visible card with a hidden adapter can never be attributed: even a
-    # fitting survivor could be the hidden GPU's usage while the visible card is
-    # idle (its true reading filtered as noise).
+    # A single visible card with a hidden adapter is never attributable: a fitting
+    # survivor could be the hidden GPU's while the visible card is idle.
     assert hw._match_adapter_used_to_devices([6 * GB, 10 * MiB], [8 * GB]) == [None]
 
 
 def test_match_adapter_capacity_forced_matrix():
-    """Exhaustive hidden-adapter matrix: emit a value only when it is capacity-forced
-    AND the supra-threshold counters number exactly the visible devices.
+    """Exhaustive hidden-adapter matrix for the capacity-forced rule.
 
-    The invariant: in the hidden-adapter branch (more raw counters than visible
-    devices) concrete values are emitted only when the supra-threshold counters
-    equal the visible-device count (every visible card has one real reading, the
-    extras were sub-threshold placeholders), and then only for a device whose ranked
-    usage strictly exceeds every smaller visible card's capacity. If any visible
-    card is idle (fewer supra-threshold counters than devices) a survivor could be
-    the hidden GPU's usage, so every device reports unknown; the smallest card and
-    any merely-fitting usage stay unknown too.
+    A value is emitted only when the supra-threshold counters number exactly the
+    visible devices AND a device's ranked usage strictly exceeds every smaller
+    card's capacity. Otherwise (a visible card idle, a merely-fitting usage, or the
+    smallest card) every device reports unknown.
     """
     m = hw._match_adapter_used_to_devices
     # -- exactly-n supra-threshold counters, capacity-forced survivors are kept - #
-    # The reporter shape (40 GiB loaded, 0.5 GiB idle-but-supra survivor, tiny
-    # placeholder): both visible cards have a real reading, so the extra 3 MiB was a
-    # placeholder. 40 GiB forced onto the 48 GiB card, 0.5 GiB not forced -> None.
+    # Both visible cards have a real reading (the 3 MiB is a placeholder): 40 GiB
+    # forced onto the 48 GiB card, 0.5 GiB not forced -> None.
     assert m([40 * GB, 0.5 * GB, 3 * MiB], [48 * GB, 8 * GB]) == [40 * GB, None]
     # Three visible cards all active (supra-threshold) + placeholder: 40 > 24 and
     # 20 > 8, both forced; the 8 GiB card is not forced -> None.
@@ -313,9 +292,7 @@ def test_match_adapter_capacity_forced_matrix():
         None,
     ]
     # -- fewer supra-threshold counters than visible cards -> all unknown ------ #
-    # A visible card is idle, so a lone large survivor could be the hidden GPU's:
-    # (Codex 3610843300 hardened further -- even the "forced" 40 is not attributable
-    # when the other visible card is idle rather than merely fitting.)
+    # A visible card is idle, so even a "forced" 40 could be the hidden GPU's.
     assert m([40 * GB, 3 * MiB, 3 * MiB], [48 * GB, 8 * GB]) == [None, None]
     assert m([40 * GB, 10 * MiB, 10 * MiB], [48 * GB, 8 * GB]) == [None, None]
     assert m([40 * GB, 20 * GB, 3 * MiB, 3 * MiB], [48 * GB, 24 * GB, 8 * GB]) == [
@@ -360,11 +337,9 @@ def test_perf_counter_parser_and_sentinel(monkeypatch):
 # Unified-memory (Strix Halo APU) total reconciliation (Codex #7238)
 # ----------------------------------------------------------------------------- #
 def test_unified_memory_adopts_torch_total_even_when_used_unknown():
-    """On a Windows ROCm unified-memory APU, torch's used is None (the free==total
-    sentinel) while its total (the full GTT pool) stays authoritative. The
-    correction must still adopt that larger total instead of keeping amd-smi's
-    small dedicated carve-out, otherwise the card underreports its capacity;
-    only used stays at amd-smi's figure when torch's is unknown (Codex #7238)."""
+    """Windows ROCm unified-memory APU: torch's used is None but its total (the full
+    GTT pool) is authoritative. The correction must still adopt the larger total;
+    used stays at amd-smi's figure when torch's is unknown."""
     metrics = {"vram_total_gb": 8.0, "vram_used_gb": 2.0, "vram_utilization_pct": 25.0}
     hw._apply_unified_memory_correction(metrics, {"total_gb": 124.0, "used_gb": None, "index": 0})
     assert metrics["vram_total_gb"] == 124.0  # full unified pool, not the 8 GB carve-out

--- a/studio/backend/tests/test_rocm_windows_vram_7072.py
+++ b/studio/backend/tests/test_rocm_windows_vram_7072.py
@@ -206,6 +206,18 @@ def test_match_adapter_reports_unknown_when_more_active_than_visible():
     assert hw._match_adapter_used_to_devices([40 * GB, 0.5 * GB], [8 * GB]) == [None]
 
 
+def test_match_adapter_reports_unknown_when_hidden_high_use_adapter_survives_filter():
+    # HIP_VISIBLE_DEVICES exposes a single idle 8 GiB card (10 MiB used) on a host
+    # that also has a hidden 48 GiB card busy at 40 GiB. The visible card's real
+    # 10 MiB sits below the 64 MiB noise floor and is dropped, leaving the hidden
+    # card's 40 GiB as the only survivor. That 40 GiB cannot fit the 8 GiB visible
+    # device, so it must belong to the hidden card: clamping it onto the visible
+    # device would fabricate a "fully used" reading. Report unknown instead.
+    assert hw._match_adapter_used_to_devices([40 * GB, 10 * MiB], [8 * GB]) == [None]
+    # Order of the counters must not matter.
+    assert hw._match_adapter_used_to_devices([10 * MiB, 40 * GB], [8 * GB]) == [None]
+
+
 def test_match_adapter_reports_unknown_when_usage_not_capacity_ordered():
     # 8 GiB card near full (7 GiB) beside a lightly used 48 GiB card (5 GiB). The
     # bigger usage (7) still fits the smaller card, so ranking cannot tell which

--- a/studio/backend/tests/test_rocm_windows_vram_7072.py
+++ b/studio/backend/tests/test_rocm_windows_vram_7072.py
@@ -230,9 +230,10 @@ def test_match_adapter_reports_unknown_for_placeholder_fallback():
     # Order of the counters must not matter.
     assert hw._match_adapter_used_to_devices([10 * MiB, 50 * MiB], [8 * GB]) == [None]
     # Two idle visible GPUs plus a placeholder: all three counters below the floor.
-    assert hw._match_adapter_used_to_devices(
-        [50 * MiB, 10 * MiB, 5 * MiB], [48 * GB, 8 * GB]
-    ) == [None, None]
+    assert hw._match_adapter_used_to_devices([50 * MiB, 10 * MiB, 5 * MiB], [48 * GB, 8 * GB]) == [
+        None,
+        None,
+    ]
 
 
 def test_match_adapter_reports_unknown_when_usage_not_capacity_ordered():

--- a/studio/backend/tests/test_rocm_windows_vram_7072.py
+++ b/studio/backend/tests/test_rocm_windows_vram_7072.py
@@ -206,6 +206,24 @@ def test_match_adapter_reports_unknown_when_more_active_than_visible():
     assert hw._match_adapter_used_to_devices([40 * GB, 0.5 * GB], [8 * GB]) == [None]
 
 
+def test_match_adapter_reports_unknown_when_usage_not_capacity_ordered():
+    # 8 GiB card near full (7 GiB) beside a lightly used 48 GiB card (5 GiB). The
+    # bigger usage (7) still fits the smaller card, so ranking cannot tell which
+    # LUID is which torch ordinal: both [8<-7, 48<-5] and [8<-5, 48<-7] are
+    # feasible. Without a verified mapping, report unknown rather than swap the
+    # per-index values that routes/training_vram.py consumes.
+    assert hw._match_adapter_used_to_devices([7 * GB, 5 * GB], [8 * GB, 48 * GB]) == [None, None]
+    # Device order must not matter (same physical situation, ordinals flipped).
+    assert hw._match_adapter_used_to_devices([7 * GB, 5 * GB], [48 * GB, 8 * GB]) == [None, None]
+    # Same-capacity cards with unequal usage are equally unattributable.
+    assert hw._match_adapter_used_to_devices([12 * GB, 8 * GB], [24 * GB, 24 * GB]) == [None, None]
+    # A single usage that fits both cards can sit on either -> unknown.
+    assert hw._match_adapter_used_to_devices([5 * GB], [48 * GB, 8 * GB]) == [None, None]
+    # But a capacity-forced assignment (usage exceeds the smaller card) is kept:
+    # 40 GiB can only be the 48 GiB card, so it is not fabrication.
+    assert hw._match_adapter_used_to_devices([40 * GB], [48 * GB, 8 * GB]) == [40 * GB, None]
+
+
 def test_perf_counter_parser_and_sentinel(monkeypatch):
     monkeypatch.setattr(hw.platform, "system", lambda: "Windows")
     monkeypatch.setattr(

--- a/studio/backend/tests/test_rocm_windows_vram_7072.py
+++ b/studio/backend/tests/test_rocm_windows_vram_7072.py
@@ -200,6 +200,12 @@ def test_match_adapter_pairs_and_clamps():
     assert hw._match_adapter_used_to_devices([40 * GB], [48 * GB, 8 * GB]) == [40 * GB, None]
 
 
+def test_match_adapter_reports_unknown_when_more_active_than_visible():
+    # More adapters actively using VRAM than are visible (a GPU outside the mask):
+    # attribution would fabricate a value, so report unknown for every device.
+    assert hw._match_adapter_used_to_devices([40 * GB, 0.5 * GB], [8 * GB]) == [None]
+
+
 def test_perf_counter_parser_and_sentinel(monkeypatch):
     monkeypatch.setattr(hw.platform, "system", lambda: "Windows")
     monkeypatch.setattr(

--- a/studio/backend/tests/test_rocm_windows_vram_7072.py
+++ b/studio/backend/tests/test_rocm_windows_vram_7072.py
@@ -19,6 +19,7 @@ counter -- Task Manager's source -- for per-GPU used, takes per-GPU total from
 torch device properties, and guards the free==total mem_get_info quirk. CI has no
 AMD GPU/Windows, so torch, the performance counter, and platform are all mocked.
 """
+
 from __future__ import annotations
 
 import subprocess
@@ -29,14 +30,19 @@ import pytest
 
 from utils.hardware import hardware as hw
 
-GB = 1024 ** 3
-MiB = 1024 ** 2
+GB = 1024**3
+MiB = 1024**2
 
 
 # ----------------------------------------------------------------------------- #
 # Fakes
 # ----------------------------------------------------------------------------- #
-def _fake_torch(devices, *, free_equals_total=False, used_per_device=None):
+def _fake_torch(
+    devices,
+    *,
+    free_equals_total = False,
+    used_per_device = None,
+):
     """Build a fake `torch` module. devices: list of (name, total_bytes)."""
     dev = list(devices)
 
@@ -58,15 +64,15 @@ def _fake_torch(devices, *, free_equals_total=False, used_per_device=None):
 
     t = types.ModuleType("torch")
     t.__version__ = "2.11.0+rocm7.13"
-    t.version = types.SimpleNamespace(hip="7.13", cuda=None)
+    t.version = types.SimpleNamespace(hip = "7.13", cuda = None)
     t.cuda = types.SimpleNamespace(
-        is_available=lambda: len(dev) > 0,
-        device_count=lambda: len(dev),
-        current_device=lambda: 0,
-        get_device_properties=get_device_properties,
-        mem_get_info=mem_get_info,
-        memory_allocated=lambda i: 0,
-        memory_reserved=lambda i: 0,
+        is_available = lambda: len(dev) > 0,
+        device_count = lambda: len(dev),
+        current_device = lambda: 0,
+        get_device_properties = get_device_properties,
+        mem_get_info = mem_get_info,
+        memory_allocated = lambda i: 0,
+        memory_reserved = lambda i: 0,
     )
     return t
 
@@ -77,7 +83,7 @@ def _adapter_output(adapters):
     return "".join(f"{name}|{int(used)}\n" for name, used in adapters)
 
 
-def _subprocess_run(*, adapter_output="__NONE__\n", util_output="12.0\n"):
+def _subprocess_run(*, adapter_output = "__NONE__\n", util_output = "12.0\n"):
     def fake_run(cmd, *a, **k):
         joined = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
         if "GPU Adapter Memory" in joined and "InstanceName" in joined:
@@ -86,7 +92,8 @@ def _subprocess_run(*, adapter_output="__NONE__\n", util_output="12.0\n"):
             out = util_output
         else:
             out = "-1\n"
-        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=out, stderr="")
+        return subprocess.CompletedProcess(args = cmd, returncode = 0, stdout = out, stderr = "")
+
     return fake_run
 
 
@@ -100,15 +107,15 @@ def win_rocm(monkeypatch):
     monkeypatch.setattr(hw, "_smi_query", lambda *a, **k: None)  # amd-smi disabled
     # Visible set via HIP mask so we don't shell out to amd-smi for the count.
     monkeypatch.setenv("HIP_VISIBLE_DEVICES", "0,1")
-    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
-    monkeypatch.delenv("ROCR_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising = False)
+    monkeypatch.delenv("ROCR_VISIBLE_DEVICES", raising = False)
     return monkeypatch
 
 
 REPORTER_ADAPTERS = [
-    ("luid_0x00000000_0x0000d1e2_phys_0", 40.0 * GB),   # W7900, model loaded
-    ("luid_0x00000000_0x0000e34a_phys_0", 0.5 * GB),    # W7500, idle
-    ("luid_0x00000000_0x0000f001_phys_0", 3 * MiB),     # Basic Render Driver
+    ("luid_0x00000000_0x0000d1e2_phys_0", 40.0 * GB),  # W7900, model loaded
+    ("luid_0x00000000_0x0000e34a_phys_0", 0.5 * GB),  # W7500, idle
+    ("luid_0x00000000_0x0000f001_phys_0", 3 * MiB),  # Basic Render Driver
 ]
 DEVICES = [("AMD Radeon PRO W7900", 48 * GB), ("AMD Radeon PRO W7500", 8 * GB)]
 
@@ -117,24 +124,26 @@ DEVICES = [("AMD Radeon PRO W7900", 48 * GB), ("AMD Radeon PRO W7500", 8 * GB)]
 # System tab (get_visible_gpu_utilization) -- the reporter's screenshot
 # ----------------------------------------------------------------------------- #
 def test_system_tab_shows_per_gpu_used(win_rocm, monkeypatch):
-    monkeypatch.setitem(sys.modules, "torch", _fake_torch(DEVICES, free_equals_total=True))
-    monkeypatch.setattr(hw.subprocess, "run",
-                        _subprocess_run(adapter_output=_adapter_output(REPORTER_ADAPTERS)))
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(DEVICES, free_equals_total = True))
+    monkeypatch.setattr(
+        hw.subprocess, "run", _subprocess_run(adapter_output = _adapter_output(REPORTER_ADAPTERS))
+    )
 
     devices = hw.get_visible_gpu_utilization()["devices"]
     by_idx = {d["index"]: d for d in devices}
     assert len(devices) == 2
     assert by_idx[0]["vram_total_gb"] == 48.0
-    assert by_idx[0]["vram_used_gb"] == pytest.approx(40.0, abs=0.01)  # not 0
-    assert by_idx[1]["vram_total_gb"] == 8.0                          # own total
-    assert by_idx[1]["vram_used_gb"] == pytest.approx(0.5, abs=0.01)
+    assert by_idx[0]["vram_used_gb"] == pytest.approx(40.0, abs = 0.01)  # not 0
+    assert by_idx[1]["vram_total_gb"] == 8.0  # own total
+    assert by_idx[1]["vram_used_gb"] == pytest.approx(0.5, abs = 0.01)
     assert all(d["vram_used_gb"] <= d["vram_total_gb"] for d in devices)
 
 
 def test_gpu_utilization_does_not_collapse(win_rocm, monkeypatch):
-    monkeypatch.setitem(sys.modules, "torch", _fake_torch(DEVICES, free_equals_total=True))
-    monkeypatch.setattr(hw.subprocess, "run",
-                        _subprocess_run(adapter_output=_adapter_output(REPORTER_ADAPTERS)))
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(DEVICES, free_equals_total = True))
+    monkeypatch.setattr(
+        hw.subprocess, "run", _subprocess_run(adapter_output = _adapter_output(REPORTER_ADAPTERS))
+    )
 
     result = hw.get_gpu_utilization()
     devices = result["devices"]
@@ -144,8 +153,8 @@ def test_gpu_utilization_does_not_collapse(win_rocm, monkeypatch):
 
 
 def test_localized_counter_reports_unknown_not_zero(win_rocm, monkeypatch):
-    monkeypatch.setitem(sys.modules, "torch", _fake_torch(DEVICES, free_equals_total=True))
-    monkeypatch.setattr(hw.subprocess, "run", _subprocess_run(adapter_output="__NONE__\n"))
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(DEVICES, free_equals_total = True))
+    monkeypatch.setattr(hw.subprocess, "run", _subprocess_run(adapter_output = "__NONE__\n"))
 
     devices = hw.get_visible_gpu_utilization()["devices"]
     assert len(devices) == 2  # both still shown with correct totals
@@ -158,7 +167,7 @@ def test_localized_counter_reports_unknown_not_zero(win_rocm, monkeypatch):
 # mem_get_info free==total guard scoping
 # ----------------------------------------------------------------------------- #
 def test_mem_get_info_guard_scopes_to_windows_rocm(monkeypatch):
-    torch_mod = _fake_torch(DEVICES, free_equals_total=True)
+    torch_mod = _fake_torch(DEVICES, free_equals_total = True)
     monkeypatch.setattr(hw, "get_device", lambda: hw.DeviceType.CUDA)
     monkeypatch.setitem(sys.modules, "torch", torch_mod)
 
@@ -184,7 +193,8 @@ def test_mem_get_info_guard_scopes_to_windows_rocm(monkeypatch):
 # ----------------------------------------------------------------------------- #
 def test_match_adapter_pairs_and_clamps():
     assert hw._match_adapter_used_to_devices([40 * GB, 0.5 * GB], [48 * GB, 8 * GB]) == [
-        40 * GB, 0.5 * GB
+        40 * GB,
+        0.5 * GB,
     ]
     assert hw._match_adapter_used_to_devices([100 * GB], [48 * GB]) == [48 * GB]  # clamp
     assert hw._match_adapter_used_to_devices([40 * GB], [48 * GB, 8 * GB]) == [40 * GB, None]
@@ -192,10 +202,11 @@ def test_match_adapter_pairs_and_clamps():
 
 def test_perf_counter_parser_and_sentinel(monkeypatch):
     monkeypatch.setattr(hw.platform, "system", lambda: "Windows")
-    monkeypatch.setattr(hw.subprocess, "run",
-                        _subprocess_run(adapter_output=_adapter_output(REPORTER_ADAPTERS)))
+    monkeypatch.setattr(
+        hw.subprocess, "run", _subprocess_run(adapter_output = _adapter_output(REPORTER_ADAPTERS))
+    )
     parsed = hw._rocm_windows_perf_counter_vram_by_adapter()
     assert parsed is not None and len(parsed) == 3
     assert parsed[0][0].startswith("luid_")
-    monkeypatch.setattr(hw.subprocess, "run", _subprocess_run(adapter_output="__NONE__\n"))
+    monkeypatch.setattr(hw.subprocess, "run", _subprocess_run(adapter_output = "__NONE__\n"))
     assert hw._rocm_windows_perf_counter_vram_by_adapter() is None

--- a/studio/backend/tests/test_rocm_windows_vram_7072.py
+++ b/studio/backend/tests/test_rocm_windows_vram_7072.py
@@ -135,8 +135,19 @@ def test_system_tab_shows_per_gpu_used(win_rocm, monkeypatch):
     assert by_idx[0]["vram_total_gb"] == 48.0
     assert by_idx[0]["vram_used_gb"] == pytest.approx(40.0, abs = 0.01)  # not 0
     assert by_idx[1]["vram_total_gb"] == 8.0  # own total
-    assert by_idx[1]["vram_used_gb"] == pytest.approx(0.5, abs = 0.01)
-    assert all(d["vram_used_gb"] <= d["vram_total_gb"] for d in devices)
+    # The reporter's third counter (3 MiB "Basic Render Driver") makes this a
+    # hidden-adapter case: the noise filter could equally have dropped the visible
+    # 8 GiB card's real reading, so its 0.5 GiB survivor is not capacity-forced to
+    # that card (0.5 GiB fits it, but also fits a hidden adapter). Only the 40 GiB
+    # usage is forced -- it exceeds the 8 GiB card, so it can only be the 48 GiB
+    # card. The idle card reports Unknown rather than a possibly-fabricated 0.5 GiB.
+    assert by_idx[1]["vram_used_gb"] is None
+    assert by_idx[1]["vram_utilization_pct"] is None
+    assert all(
+        d["vram_used_gb"] <= d["vram_total_gb"]
+        for d in devices
+        if d["vram_used_gb"] is not None
+    )
 
 
 def test_gpu_utilization_does_not_collapse(win_rocm, monkeypatch):
@@ -252,6 +263,87 @@ def test_match_adapter_reports_unknown_when_usage_not_capacity_ordered():
     # But a capacity-forced assignment (usage exceeds the smaller card) is kept:
     # 40 GiB can only be the 48 GiB card, so it is not fabrication.
     assert hw._match_adapter_used_to_devices([40 * GB], [48 * GB, 8 * GB]) == [40 * GB, None]
+
+
+def test_match_adapter_reports_unknown_when_hidden_usage_fits_visible_card():
+    # Round-4 hole (Codex 3610843300): with a hidden adapter present, a survivor
+    # that merely *fits* a visible card must NOT be pinned onto it. Two visible
+    # cards at 48/8 GiB using 40 GiB / 10 MiB beside a hidden 6 GiB adapter: the
+    # 10 MiB drops below the noise floor and the hidden 6 GiB "fits" the idle 8 GiB
+    # card, so the old ranking fabricated [40, 6]. The 6 GiB is not capacity-forced
+    # onto the 8 GiB card (it also fits the hidden adapter), so that card must read
+    # Unknown. Only the 40 GiB usage is forced (it exceeds the 8 GiB card).
+    assert hw._match_adapter_used_to_devices([40 * GB, 10 * MiB, 6 * GB], [48 * GB, 8 * GB]) == [
+        40 * GB,
+        None,
+    ]
+    # Counter order must not matter.
+    assert hw._match_adapter_used_to_devices([6 * GB, 40 * GB, 10 * MiB], [48 * GB, 8 * GB]) == [
+        40 * GB,
+        None,
+    ]
+    # A single visible card with a hidden adapter can never be attributed: even a
+    # fitting survivor could be the hidden GPU's usage while the visible card is
+    # idle (its true reading filtered as noise).
+    assert hw._match_adapter_used_to_devices([6 * GB, 10 * MiB], [8 * GB]) == [None]
+
+
+def test_match_adapter_capacity_forced_matrix():
+    """Exhaustive hidden-adapter matrix: emit a value only when it is capacity-forced
+    AND the supra-threshold counters number exactly the visible devices.
+
+    The invariant: in the hidden-adapter branch (more raw counters than visible
+    devices) concrete values are emitted only when the supra-threshold counters
+    equal the visible-device count (every visible card has one real reading, the
+    extras were sub-threshold placeholders), and then only for a device whose ranked
+    usage strictly exceeds every smaller visible card's capacity. If any visible
+    card is idle (fewer supra-threshold counters than devices) a survivor could be
+    the hidden GPU's usage, so every device reports unknown; the smallest card and
+    any merely-fitting usage stay unknown too.
+    """
+    m = hw._match_adapter_used_to_devices
+    # -- exactly-n supra-threshold counters, capacity-forced survivors are kept - #
+    # The reporter shape (40 GiB loaded, 0.5 GiB idle-but-supra survivor, tiny
+    # placeholder): both visible cards have a real reading, so the extra 3 MiB was a
+    # placeholder. 40 GiB forced onto the 48 GiB card, 0.5 GiB not forced -> None.
+    assert m([40 * GB, 0.5 * GB, 3 * MiB], [48 * GB, 8 * GB]) == [40 * GB, None]
+    # Three visible cards all active (supra-threshold) + placeholder: 40 > 24 and
+    # 20 > 8, both forced; the 8 GiB card is not forced -> None.
+    assert m([40 * GB, 20 * GB, 5 * GB, 3 * MiB], [48 * GB, 24 * GB, 8 * GB]) == [
+        40 * GB,
+        20 * GB,
+        None,
+    ]
+    # -- fewer supra-threshold counters than visible cards -> all unknown ------ #
+    # A visible card is idle, so a lone large survivor could be the hidden GPU's:
+    # (Codex 3610843300 hardened further -- even the "forced" 40 is not attributable
+    # when the other visible card is idle rather than merely fitting.)
+    assert m([40 * GB, 3 * MiB, 3 * MiB], [48 * GB, 8 * GB]) == [None, None]
+    assert m([40 * GB, 10 * MiB, 10 * MiB], [48 * GB, 8 * GB]) == [None, None]
+    assert m([40 * GB, 20 * GB, 3 * MiB, 3 * MiB], [48 * GB, 24 * GB, 8 * GB]) == [
+        None,
+        None,
+        None,
+    ]
+    # Middle usage (6 GiB) fits both the 24 and 8 GiB cards, and only two cards are
+    # active for three visible -> not a bijection -> all unknown.
+    assert m([40 * GB, 6 * GB, 3 * MiB, 3 * MiB], [48 * GB, 24 * GB, 8 * GB]) == [
+        None,
+        None,
+        None,
+    ]
+    # -- hidden larger than every visible card -> all unknown ----------------- #
+    assert m([40 * GB, 10 * MiB], [8 * GB]) == [None]
+    assert m([48 * GB, 3 * MiB, 3 * MiB], [24 * GB, 8 * GB]) == [None, None]
+    # -- more active adapters than visible cards -> all unknown --------------- #
+    assert m([40 * GB, 7 * GB, 6 * GB, 3 * MiB], [48 * GB, 8 * GB]) == [None, None]
+    assert m([40 * GB, 7 * GB, 6 * GB, 3 * MiB, 3 * MiB], [48 * GB, 8 * GB]) == [None, None]
+    # -- every counter below the noise floor (placeholder fallback) -> unknown - #
+    assert m([50 * MiB, 10 * MiB], [8 * GB]) == [None]
+    assert m([50 * MiB, 10 * MiB, 5 * MiB], [48 * GB, 8 * GB]) == [None, None]
+    # -- equal-capacity cards with a hidden adapter: nothing is forced -------- #
+    assert m([40 * GB, 40 * GB, 3 * MiB], [48 * GB, 48 * GB]) == [None, None]
+    assert m([40 * GB, 30 * GB, 3 * MiB], [48 * GB, 48 * GB]) == [None, None]
 
 
 def test_perf_counter_parser_and_sentinel(monkeypatch):

--- a/studio/backend/tests/test_rocm_windows_vram_7072.py
+++ b/studio/backend/tests/test_rocm_windows_vram_7072.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Regression tests for issue #7072 -- "VRAM Usage in System Tab is wrong".
+
+Reporter: dual AMD (Radeon PRO W7900 ~48GB + W7500 8GB), Windows 10, ROCm 7.13,
+torch 2.11.0+rocm7.13. On Windows without a HIP SDK, amd-smi is permanently
+disabled (avoids a UAC/DiskPart prompt) and hipMemGetInfo returns free==total
+(used 0). Two symptoms followed:
+
+  * System tab (/api/system -> get_visible_gpu_utilization) showed ~0 VRAM used
+    on every GPU (torch mem_get_info free==total quirk; ROCm/ROCm#1909).
+  * get_gpu_utilization()'s Windows fallback SUMMED "GPU Adapter Memory\\Dedicated
+    Usage" across all adapters into ONE fake device with only GPU 0's total, so
+    the second GPU never appeared.
+
+The fix reads the per-adapter (LUID-instanced) Dedicated Usage performance
+counter -- Task Manager's source -- for per-GPU used, takes per-GPU total from
+torch device properties, and guards the free==total mem_get_info quirk. CI has no
+AMD GPU/Windows, so torch, the performance counter, and platform are all mocked.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import types
+
+import pytest
+
+from utils.hardware import hardware as hw
+
+GB = 1024 ** 3
+MiB = 1024 ** 2
+
+
+# ----------------------------------------------------------------------------- #
+# Fakes
+# ----------------------------------------------------------------------------- #
+def _fake_torch(devices, *, free_equals_total=False, used_per_device=None):
+    """Build a fake `torch` module. devices: list of (name, total_bytes)."""
+    dev = list(devices)
+
+    class _Props:
+        def __init__(self, name, total):
+            self.name = name
+            self.total_memory = total
+
+    def get_device_properties(i):
+        name, total = dev[i]
+        return _Props(name, total)
+
+    def mem_get_info(i):
+        _, total = dev[i]
+        if free_equals_total:
+            return (total, total)
+        used = used_per_device[i] if used_per_device is not None else 0
+        return (total - used, total)
+
+    t = types.ModuleType("torch")
+    t.__version__ = "2.11.0+rocm7.13"
+    t.version = types.SimpleNamespace(hip="7.13", cuda=None)
+    t.cuda = types.SimpleNamespace(
+        is_available=lambda: len(dev) > 0,
+        device_count=lambda: len(dev),
+        current_device=lambda: 0,
+        get_device_properties=get_device_properties,
+        mem_get_info=mem_get_info,
+        memory_allocated=lambda i: 0,
+        memory_reserved=lambda i: 0,
+    )
+    return t
+
+
+def _adapter_output(adapters):
+    if not adapters:
+        return "__NONE__\n"
+    return "".join(f"{name}|{int(used)}\n" for name, used in adapters)
+
+
+def _subprocess_run(*, adapter_output="__NONE__\n", util_output="12.0\n"):
+    def fake_run(cmd, *a, **k):
+        joined = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
+        if "GPU Adapter Memory" in joined and "InstanceName" in joined:
+            out = adapter_output
+        elif "engtype_3D" in joined or "GPU Engine" in joined:
+            out = util_output
+        else:
+            out = "-1\n"
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=out, stderr="")
+    return fake_run
+
+
+@pytest.fixture
+def win_rocm(monkeypatch):
+    """Configure the hardware module as a Windows ROCm host with 2 visible GPUs."""
+    monkeypatch.setattr(hw, "get_device", lambda: hw.DeviceType.CUDA)
+    monkeypatch.setattr(hw, "IS_ROCM", True)
+    monkeypatch.setattr(hw.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(hw.sys, "platform", "win32")
+    monkeypatch.setattr(hw, "_smi_query", lambda *a, **k: None)  # amd-smi disabled
+    # Visible set via HIP mask so we don't shell out to amd-smi for the count.
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "0,1")
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    monkeypatch.delenv("ROCR_VISIBLE_DEVICES", raising=False)
+    return monkeypatch
+
+
+REPORTER_ADAPTERS = [
+    ("luid_0x00000000_0x0000d1e2_phys_0", 40.0 * GB),   # W7900, model loaded
+    ("luid_0x00000000_0x0000e34a_phys_0", 0.5 * GB),    # W7500, idle
+    ("luid_0x00000000_0x0000f001_phys_0", 3 * MiB),     # Basic Render Driver
+]
+DEVICES = [("AMD Radeon PRO W7900", 48 * GB), ("AMD Radeon PRO W7500", 8 * GB)]
+
+
+# ----------------------------------------------------------------------------- #
+# System tab (get_visible_gpu_utilization) -- the reporter's screenshot
+# ----------------------------------------------------------------------------- #
+def test_system_tab_shows_per_gpu_used(win_rocm, monkeypatch):
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(DEVICES, free_equals_total=True))
+    monkeypatch.setattr(hw.subprocess, "run",
+                        _subprocess_run(adapter_output=_adapter_output(REPORTER_ADAPTERS)))
+
+    devices = hw.get_visible_gpu_utilization()["devices"]
+    by_idx = {d["index"]: d for d in devices}
+    assert len(devices) == 2
+    assert by_idx[0]["vram_total_gb"] == 48.0
+    assert by_idx[0]["vram_used_gb"] == pytest.approx(40.0, abs=0.01)  # not 0
+    assert by_idx[1]["vram_total_gb"] == 8.0                          # own total
+    assert by_idx[1]["vram_used_gb"] == pytest.approx(0.5, abs=0.01)
+    assert all(d["vram_used_gb"] <= d["vram_total_gb"] for d in devices)
+
+
+def test_gpu_utilization_does_not_collapse(win_rocm, monkeypatch):
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(DEVICES, free_equals_total=True))
+    monkeypatch.setattr(hw.subprocess, "run",
+                        _subprocess_run(adapter_output=_adapter_output(REPORTER_ADAPTERS)))
+
+    result = hw.get_gpu_utilization()
+    devices = result["devices"]
+    assert sorted(d["index"] for d in devices) == [0, 1]  # both GPUs, no collapse
+    assert {d["vram_total_gb"] for d in devices} == {48.0, 8.0}
+    assert result["vram_total_gb"] == 48.0  # legacy primary mirror preserved
+
+
+def test_localized_counter_reports_unknown_not_zero(win_rocm, monkeypatch):
+    monkeypatch.setitem(sys.modules, "torch", _fake_torch(DEVICES, free_equals_total=True))
+    monkeypatch.setattr(hw.subprocess, "run", _subprocess_run(adapter_output="__NONE__\n"))
+
+    devices = hw.get_visible_gpu_utilization()["devices"]
+    assert len(devices) == 2  # both still shown with correct totals
+    assert {d["vram_total_gb"] for d in devices} == {48.0, 8.0}
+    assert all(d["vram_used_gb"] is None for d in devices)  # unknown, not fake 0
+    assert all(d["vram_utilization_pct"] is None for d in devices)
+
+
+# ----------------------------------------------------------------------------- #
+# mem_get_info free==total guard scoping
+# ----------------------------------------------------------------------------- #
+def test_mem_get_info_guard_scopes_to_windows_rocm(monkeypatch):
+    torch_mod = _fake_torch(DEVICES, free_equals_total=True)
+    monkeypatch.setattr(hw, "get_device", lambda: hw.DeviceType.CUDA)
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+
+    # Windows ROCm -> used unknown (None), total kept.
+    monkeypatch.setattr(hw, "IS_ROCM", True)
+    monkeypatch.setattr(hw.sys, "platform", "win32")
+    win = hw._torch_get_per_device_info([0, 1])
+    assert [d["used_gb"] for d in win] == [None, None]
+    assert [d["total_gb"] for d in win] == [48.0, 8.0]
+
+    # Linux ROCm -> unchanged numeric used.
+    monkeypatch.setattr(hw.sys, "platform", "linux")
+    assert [d["used_gb"] for d in hw._torch_get_per_device_info([0, 1])] == [0.0, 0.0]
+
+    # Windows NVIDIA -> guard must not fire.
+    monkeypatch.setattr(hw, "IS_ROCM", False)
+    monkeypatch.setattr(hw.sys, "platform", "win32")
+    assert [d["used_gb"] for d in hw._torch_get_per_device_info([0, 1])] == [0.0, 0.0]
+
+
+# ----------------------------------------------------------------------------- #
+# Per-adapter attribution helpers (pure unit)
+# ----------------------------------------------------------------------------- #
+def test_match_adapter_pairs_and_clamps():
+    assert hw._match_adapter_used_to_devices([40 * GB, 0.5 * GB], [48 * GB, 8 * GB]) == [
+        40 * GB, 0.5 * GB
+    ]
+    assert hw._match_adapter_used_to_devices([100 * GB], [48 * GB]) == [48 * GB]  # clamp
+    assert hw._match_adapter_used_to_devices([40 * GB], [48 * GB, 8 * GB]) == [40 * GB, None]
+
+
+def test_perf_counter_parser_and_sentinel(monkeypatch):
+    monkeypatch.setattr(hw.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(hw.subprocess, "run",
+                        _subprocess_run(adapter_output=_adapter_output(REPORTER_ADAPTERS)))
+    parsed = hw._rocm_windows_perf_counter_vram_by_adapter()
+    assert parsed is not None and len(parsed) == 3
+    assert parsed[0][0].startswith("luid_")
+    monkeypatch.setattr(hw.subprocess, "run", _subprocess_run(adapter_output="__NONE__\n"))
+    assert hw._rocm_windows_perf_counter_vram_by_adapter() is None

--- a/studio/backend/tests/test_rocm_windows_vram_7072.py
+++ b/studio/backend/tests/test_rocm_windows_vram_7072.py
@@ -218,6 +218,23 @@ def test_match_adapter_reports_unknown_when_hidden_high_use_adapter_survives_fil
     assert hw._match_adapter_used_to_devices([10 * MiB, 40 * GB], [8 * GB]) == [None]
 
 
+def test_match_adapter_reports_unknown_for_placeholder_fallback():
+    # Idle real GPUs (every counter below the 64 MiB noise floor) plus a Windows
+    # "Basic Render Driver" placeholder counter. non_trivial is empty, so the old
+    # `non_trivial or useds` fallback attributed a raw sub-threshold counter to a
+    # real GPU (and, with a single visible device, escaped the swap-ambiguity
+    # check). With no LUID-to-ordinal mapping the placeholder is indistinguishable
+    # from an idle GPU, so report unknown rather than fabricate.
+    # Single visible 8 GiB card idle (10 MiB) beside a 50 MiB placeholder counter.
+    assert hw._match_adapter_used_to_devices([50 * MiB, 10 * MiB], [8 * GB]) == [None]
+    # Order of the counters must not matter.
+    assert hw._match_adapter_used_to_devices([10 * MiB, 50 * MiB], [8 * GB]) == [None]
+    # Two idle visible GPUs plus a placeholder: all three counters below the floor.
+    assert hw._match_adapter_used_to_devices(
+        [50 * MiB, 10 * MiB, 5 * MiB], [48 * GB, 8 * GB]
+    ) == [None, None]
+
+
 def test_match_adapter_reports_unknown_when_usage_not_capacity_ordered():
     # 8 GiB card near full (7 GiB) beside a lightly used 48 GiB card (5 GiB). The
     # bigger usage (7) still fits the smaller card, so ranking cannot tell which

--- a/studio/backend/tests/test_rocm_windows_vram_7072.py
+++ b/studio/backend/tests/test_rocm_windows_vram_7072.py
@@ -144,9 +144,7 @@ def test_system_tab_shows_per_gpu_used(win_rocm, monkeypatch):
     assert by_idx[1]["vram_used_gb"] is None
     assert by_idx[1]["vram_utilization_pct"] is None
     assert all(
-        d["vram_used_gb"] <= d["vram_total_gb"]
-        for d in devices
-        if d["vram_used_gb"] is not None
+        d["vram_used_gb"] <= d["vram_total_gb"] for d in devices if d["vram_used_gb"] is not None
     )
 
 

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -829,7 +829,17 @@ def _match_adapter_used_to_devices(
             # alone can't tell the visible set apart, so any pairing would
             # fabricate values; report unknown rather than mis-assign.
             return [None] * n
-        useds = (non_trivial or useds)[:n]
+        if not non_trivial:
+            # Every counter sits below the noise floor while an extra adapter is
+            # present (e.g. a "Basic Render Driver" placeholder alongside idle
+            # real GPUs). Falling back to the raw magnitude-sorted counters would
+            # attribute the placeholder's counter to a real GPU and drop a real
+            # card's reading, and with a single visible device the swap-ambiguity
+            # check below (which needs at least two ranks) cannot catch it. No
+            # LUID-to-ordinal mapping exists to tell the placeholder apart from a
+            # genuinely idle GPU, so report unknown rather than fabricate.
+            return [None] * n
+        useds = non_trivial[:n]
     ranked_positions = sorted(range(n), key = lambda i: -device_totals[i])
     # Usage per rank (largest usage to largest capacity), 0 for devices with no
     # adapter counter, plus the capacity at that rank.

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -800,62 +800,96 @@ def _match_adapter_used_to_devices(
 
     Windows shares no key between LUID counter instances and torch ordinals, so
     usage is paired with capacity: the largest usage goes to the largest device,
-    clamped to that total. That pairing is trustworthy only when it is the *only*
-    feasible one, i.e. capacity forces it (a usage larger than every smaller
-    device can sit on just one card). When a smaller-capacity device could
-    equally hold a strictly larger usage (e.g. an 8 GiB card near full beside a
-    lightly used 48 GiB card), the two values could be swapped without violating
-    any capacity, so the ranking is a guess. There is no verified LUID-to-torch
-    mapping to break the tie, and a wrong guess both mislabels the System tab and
-    feeds ``routes/training_vram.py`` a wrong per-index free value, so report
-    unknown (``None``) for every device rather than fabricate. Unmatched devices
-    get ``None``. Returns a list aligned to ``device_totals``.
+    clamped to that total. That pairing is trustworthy only when capacity *forces*
+    it (a usage larger than every smaller device can sit on just one card). When a
+    smaller-capacity device could equally hold a strictly larger usage (e.g. an
+    8 GiB card near full beside a lightly used 48 GiB card), the two values could
+    be swapped without violating any capacity, so the ranking is a guess. There is
+    no verified LUID-to-torch mapping to break the tie, and a wrong guess both
+    mislabels the System tab and feeds ``routes/training_vram.py`` a wrong
+    per-index free value, so report unknown (``None``) rather than fabricate.
+
+    When there are more raw counters than visible devices at least one adapter
+    belongs to a hidden GPU (outside the visibility mask) or a non-GPU display
+    adapter, and the sub-threshold noise filter may itself have dropped a
+    *visible* card's real reading. A surviving counter that merely *fits* a visible
+    card can actually be the hidden GPU's usage pinned onto an idle visible card
+    whose true (filtered) reading was tiny -- e.g. two visible cards at 48/8 GiB
+    using 40 GiB / 10 MiB beside a hidden 6 GiB adapter: the 10 MiB drops out and
+    the 6 GiB "fits" the 8 GiB card even though that card is idle. Worse, if BOTH
+    visible readings fall below the noise floor a lone large survivor could belong
+    to the hidden GPU entirely while both visible cards are idle. So in the
+    hidden-adapter case concrete values are emitted only when the supra-threshold
+    counters number EXACTLY the visible devices: then every visible card has one
+    real reading and the extras were sub-threshold placeholders, making a
+    capacity-ranked bijection plausible. When the supra-threshold counters are
+    fewer than the visible devices (a visible card is idle, so a survivor could be
+    the hidden device's) or more (a masked GPU is actively using VRAM), no counter
+    can be attributed, so every device reports unknown. Even in the exactly-n case a
+    value is emitted for a device ONLY when capacity forces it: the ranked usage
+    must exceed every smaller visible card's capacity, so no smaller visible card
+    could account for it (best-effort -- a contrived hidden-busy while a visible
+    card is idle can still mislead, but the common loaded-card case is correct). The
+    smallest visible card and any usage that merely fits report unknown. Unmatched
+    devices get ``None``. Returns a list aligned to ``device_totals``.
     """
     n = len(device_totals)
     if n == 0:
         return []
     useds = sorted(adapter_useds, reverse = True)
+    ranked_positions = sorted(range(n), key = lambda i: -device_totals[i])
+    ranked_totals = [device_totals[pos] for pos in ranked_positions]
+    assigned: list[Optional[float]]
     # More raw counters than visible devices means at least one adapter belongs to
     # a GPU outside the visibility mask (or a non-GPU display adapter). Measured on
     # the raw count *before* the noise filter, because a genuinely idle visible card
     # can itself sit below the sub-threshold noise floor.
-    extra_adapters = len(useds) > n
-    # Drop placeholder adapters only if they'd outnumber real devices.
-    if extra_adapters:
+    if len(useds) > n:
         non_trivial = [u for u in useds if u >= _ROCM_WIN_ADAPTER_MIN_BYTES]
-        if len(non_trivial) > n:
-            # More adapters are actively using VRAM than are visible here (a GPU
-            # outside the visibility mask, or an extra discrete adapter). Usage
-            # alone can't tell the visible set apart, so any pairing would
-            # fabricate values; report unknown rather than mis-assign.
+        if len(non_trivial) != n:
+            # Not a clean visible-set bijection, so no counter can be attributed to
+            # a specific visible card. With MORE supra-threshold counters than
+            # visible cards a GPU outside the visibility mask is actively using VRAM;
+            # with FEWER, at least one visible card is idle (its reading below the
+            # noise floor) and a surviving counter could be that hidden device's
+            # usage rather than the idle card's -- e.g. two visible 48/8 GiB cards
+            # both idle beside a hidden GPU using 40 GiB looks identical to the
+            # 48 GiB card loaded to 40 GiB, so pinning 40 onto a visible card would
+            # fabricate a reading. (This also subsumes the placeholder-only case
+            # where every counter is sub-threshold.) No LUID-to-ordinal mapping
+            # exists to break the tie, so report unknown rather than fabricate.
             return [None] * n
-        if not non_trivial:
-            # Every counter sits below the noise floor while an extra adapter is
-            # present (e.g. a "Basic Render Driver" placeholder alongside idle
-            # real GPUs). Falling back to the raw magnitude-sorted counters would
-            # attribute the placeholder's counter to a real GPU and drop a real
-            # card's reading, and with a single visible device the swap-ambiguity
-            # check below (which needs at least two ranks) cannot catch it. No
-            # LUID-to-ordinal mapping exists to tell the placeholder apart from a
-            # genuinely idle GPU, so report unknown rather than fabricate.
-            return [None] * n
-        useds = non_trivial[:n]
-    ranked_positions = sorted(range(n), key = lambda i: -device_totals[i])
-    # Usage per rank (largest usage to largest capacity), 0 for devices with no
-    # adapter counter, plus the capacity at that rank.
-    ranked_useds = [useds[rank] if rank < len(useds) else 0.0 for rank in range(n)]
-    ranked_totals = [device_totals[pos] for pos in ranked_positions]
-    # With hidden adapters present, a kept usage that exceeds its ranked visible
-    # capacity cannot belong to any visible card: it is a hidden, larger GPU whose
-    # counter survived the noise filter while a visible card's real (sub-threshold)
-    # usage was dropped as noise. Clamping it onto the smaller visible device would
-    # fabricate a "fully used" reading (e.g. a hidden 48 GiB card at 40 GiB shown as
-    # a visible 8 GiB card fully used while its true 10 MiB usage was filtered out),
-    # so report unknown rather than mis-assign the hidden card's usage.
-    if extra_adapters:
+        # Exactly n supra-threshold counters: the extra raw adapters were all
+        # sub-threshold placeholders and every visible card has one supra-threshold
+        # reading, so a capacity-ranked bijection is plausible. Emit a value only
+        # where capacity forces it (best-effort: a contrived hidden-busy while a
+        # visible card is idle can still mislead, but the common loaded-card case,
+        # which is what #7072 reports, is attributed correctly).
+        useds = non_trivial
+        ranked_useds = [useds[rank] for rank in range(n)]
+        # A kept usage that exceeds its own ranked visible capacity is a hidden,
+        # larger GPU whose counter outlived a visible card's filtered reading;
+        # clamping it onto the smaller visible card would fabricate a fully-used
+        # reading (a hidden 48 GiB card at 40 GiB shown as a visible 8 GiB card
+        # fully used), so report unknown for every device.
         for rank in range(n):
             if ranked_useds[rank] > ranked_totals[rank]:
                 return [None] * n
+        # Emit a value only where capacity forces the mapping: the ranked usage
+        # must strictly exceed the next-smaller (and thus every smaller) visible
+        # capacity, so it cannot be a smaller visible card's reading or a dropped
+        # sub-threshold one. The smallest card (no smaller capacity to exceed) and
+        # any usage that merely fits stay unknown. This keeps the classic single
+        # dominant-usage case (40 GiB across 48/8 GiB -> [40, None]) while refusing
+        # to pin a hidden adapter's fitting usage onto an idle visible card.
+        assigned = [None] * n
+        for rank, pos in enumerate(ranked_positions):
+            if rank + 1 < n and ranked_useds[rank] > ranked_totals[rank + 1]:
+                assigned[pos] = min(ranked_useds[rank], device_totals[pos])
+        return assigned
+    # No hidden adapters: every counter belongs to a visible card, so the capacity
+    # ranking has to be a permutation of the visible set.
+    ranked_useds = [useds[rank] if rank < len(useds) else 0.0 for rank in range(n)]
     # Ambiguous whenever a strictly larger usage would also fit the next
     # smaller-capacity device: those two values could be swapped without breaking
     # any capacity, so ranking cannot know which card actually holds which. No
@@ -864,7 +898,7 @@ def _match_adapter_used_to_devices(
         upper, lower = ranked_useds[rank], ranked_useds[rank + 1]
         if upper > lower and upper <= ranked_totals[rank + 1]:
             return [None] * n
-    assigned: list[Optional[float]] = [None] * n
+    assigned = [None] * n
     for rank, pos in enumerate(ranked_positions):
         if rank < len(useds):
             assigned[pos] = min(useds[rank], device_totals[pos])

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -815,8 +815,13 @@ def _match_adapter_used_to_devices(
     if n == 0:
         return []
     useds = sorted(adapter_useds, reverse = True)
+    # More raw counters than visible devices means at least one adapter belongs to
+    # a GPU outside the visibility mask (or a non-GPU display adapter). Measured on
+    # the raw count *before* the noise filter, because a genuinely idle visible card
+    # can itself sit below the sub-threshold noise floor.
+    extra_adapters = len(useds) > n
     # Drop placeholder adapters only if they'd outnumber real devices.
-    if len(useds) > n:
+    if extra_adapters:
         non_trivial = [u for u in useds if u >= _ROCM_WIN_ADAPTER_MIN_BYTES]
         if len(non_trivial) > n:
             # More adapters are actively using VRAM than are visible here (a GPU
@@ -830,6 +835,17 @@ def _match_adapter_used_to_devices(
     # adapter counter, plus the capacity at that rank.
     ranked_useds = [useds[rank] if rank < len(useds) else 0.0 for rank in range(n)]
     ranked_totals = [device_totals[pos] for pos in ranked_positions]
+    # With hidden adapters present, a kept usage that exceeds its ranked visible
+    # capacity cannot belong to any visible card: it is a hidden, larger GPU whose
+    # counter survived the noise filter while a visible card's real (sub-threshold)
+    # usage was dropped as noise. Clamping it onto the smaller visible device would
+    # fabricate a "fully used" reading (e.g. a hidden 48 GiB card at 40 GiB shown as
+    # a visible 8 GiB card fully used while its true 10 MiB usage was filtered out),
+    # so report unknown rather than mis-assign the hidden card's usage.
+    if extra_adapters:
+        for rank in range(n):
+            if ranked_useds[rank] > ranked_totals[rank]:
+                return [None] * n
     # Ambiguous whenever a strictly larger usage would also fit the next
     # smaller-capacity device: those two values could be swapped without breaking
     # any capacity, so ranking cannot know which card actually holds which. No

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -1221,19 +1221,28 @@ def _apply_unified_memory_correction(
     torch_total_gb = torch_info["total_gb"]
     torch_used_gb = torch_info.get("used_gb")
     smi_total_gb = device_metrics.get("vram_total_gb") or 0.0
-    # Skip when used is unknown (Windows-ROCm guard) so a None can't overwrite a
-    # good amd-smi figure.
-    if torch_used_gb is not None and torch_total_gb > smi_total_gb:
+    # torch sees the full unified (GTT) pool; amd-smi reports only the dedicated
+    # carve-out. Adopt torch's larger total independently of used: on Windows ROCm
+    # torch_used is None (the free==total sentinel) while its total stays
+    # authoritative, so gating the total on used would keep the small amd-smi
+    # carve-out and underreport the card's real capacity. Overwrite used only when
+    # torch's is known (else keep amd-smi's dedicated-usage figure) and recompute
+    # utilization against whatever used remains.
+    if torch_total_gb > smi_total_gb:
         device_metrics["vram_total_gb"] = torch_total_gb
-        device_metrics["vram_used_gb"] = torch_used_gb
+        if torch_used_gb is not None:
+            device_metrics["vram_used_gb"] = torch_used_gb
+        _used_for_pct = device_metrics.get("vram_used_gb")
         device_metrics["vram_utilization_pct"] = (
-            round((torch_used_gb / torch_total_gb) * 100, 1) if torch_total_gb > 0 else None
+            round((_used_for_pct / torch_total_gb) * 100, 1)
+            if torch_total_gb > 0 and _used_for_pct is not None
+            else None
         )
         logger.debug(
-            "ROCm unified memory: replaced amd-smi VRAM (%.2f GB) with "
-            "torch mem_get_info total (%.2f GB) for device %s",
-            smi_total_gb,
+            "ROCm unified memory: adopted torch mem_get_info total (%.2f GB) over "
+            "amd-smi (%.2f GB) for device %s",
             torch_total_gb,
+            smi_total_gb,
             torch_info.get("index"),
         )
 

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -573,9 +573,7 @@ def _torch_get_per_device_info(device_indices: list[int]) -> list[Dict[str, Any]
                     "visible_ordinal": ordinal,
                     "name": props.name,
                     "total_gb": round(total_bytes / (1024**3), 2),
-                    "used_gb": round(used_bytes / (1024**3), 2)
-                    if used_bytes is not None
-                    else None,
+                    "used_gb": round(used_bytes / (1024**3), 2) if used_bytes is not None else None,
                 }
             )
         except Exception as e:
@@ -978,9 +976,7 @@ def get_gpu_utilization() -> Dict[str, Any]:
                 # A single visible GPU can own the aggregate 3D-engine utilization;
                 # across several GPUs the sum isn't per-device, so leave it unset.
                 _win_util = (
-                    _rocm_windows_perf_counter_gpu_util_pct()
-                    if len(_win_devices) == 1
-                    else None
+                    _rocm_windows_perf_counter_gpu_util_pct() if len(_win_devices) == 1 else None
                 )
                 return _gpu_utilization_payload(
                     device,

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -796,12 +796,20 @@ def _rocm_windows_perf_counter_vram_by_adapter() -> Optional[list[tuple[str, flo
 def _match_adapter_used_to_devices(
     adapter_useds: list[float], device_totals: list[float]
 ) -> list[Optional[float]]:
-    """Attribute per-adapter used bytes to torch devices (by index position).
+    """Attribute per-adapter used bytes to torch devices (by capacity ranking).
 
     Windows shares no key between LUID counter instances and torch ordinals, so
-    the largest usage pairs with the largest-capacity device (single-model /
-    size-proportional-shard case), clamped to that total. Unmatched devices get
-    ``None``. Returns a list aligned to ``device_totals``.
+    usage is paired with capacity: the largest usage goes to the largest device,
+    clamped to that total. That pairing is trustworthy only when it is the *only*
+    feasible one, i.e. capacity forces it (a usage larger than every smaller
+    device can sit on just one card). When a smaller-capacity device could
+    equally hold a strictly larger usage (e.g. an 8 GiB card near full beside a
+    lightly used 48 GiB card), the two values could be swapped without violating
+    any capacity, so the ranking is a guess. There is no verified LUID-to-torch
+    mapping to break the tie, and a wrong guess both mislabels the System tab and
+    feeds ``routes/training_vram.py`` a wrong per-index free value, so report
+    unknown (``None``) for every device rather than fabricate. Unmatched devices
+    get ``None``. Returns a list aligned to ``device_totals``.
     """
     n = len(device_totals)
     if n == 0:
@@ -818,6 +826,18 @@ def _match_adapter_used_to_devices(
             return [None] * n
         useds = (non_trivial or useds)[:n]
     ranked_positions = sorted(range(n), key = lambda i: -device_totals[i])
+    # Usage per rank (largest usage to largest capacity), 0 for devices with no
+    # adapter counter, plus the capacity at that rank.
+    ranked_useds = [useds[rank] if rank < len(useds) else 0.0 for rank in range(n)]
+    ranked_totals = [device_totals[pos] for pos in ranked_positions]
+    # Ambiguous whenever a strictly larger usage would also fit the next
+    # smaller-capacity device: those two values could be swapped without breaking
+    # any capacity, so ranking cannot know which card actually holds which. No
+    # verified LUID->ordinal mapping exists to resolve it -> report unknown.
+    for rank in range(n - 1):
+        upper, lower = ranked_useds[rank], ranked_useds[rank + 1]
+        if upper > lower and upper <= ranked_totals[rank + 1]:
+            return [None] * n
     assigned: list[Optional[float]] = [None] * n
     for rank, pos in enumerate(ranked_positions):
         if rank < len(useds):

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -736,12 +736,10 @@ def _rocm_linux_sysfs_vram_gb() -> tuple[Optional[float], Optional[float]]:
 
 # ── Windows AMD/ROCm per-adapter VRAM (issue #7072) ──────────────────────────
 # amd-smi is disabled and hipMemGetInfo reports free==total, so read used from the
-# per-LUID "GPU Adapter Memory" perf counters (Task Manager's source) and take each
-# total from torch properties. Shows every GPU instead of summing all adapters into
-# one fake device with GPU 0's total.
-
-# Placeholder adapters (Basic Render Driver / idle iGPU) are dropped only when they
-# would outnumber the real torch devices.
+# per-LUID "GPU Adapter Memory" perf counters and take each total from torch, so
+# every GPU shows instead of one fake device with GPU 0's total.
+# Placeholder adapters (Basic Render Driver / idle iGPU) drop only when they would
+# outnumber the real torch devices.
 _ROCM_WIN_ADAPTER_MIN_BYTES = 64 * 1024 * 1024  # 64 MiB
 
 
@@ -792,24 +790,16 @@ def _match_adapter_used_to_devices(
 ) -> list[Optional[float]]:
     """Attribute per-adapter used bytes to torch devices by capacity ranking.
 
-    Windows shares no key between LUID counter instances and torch ordinals, so
-    the largest usage is paired with the largest device and clamped to its total.
-    That pairing is trusted only when capacity *forces* it (a usage exceeding every
-    smaller device fits only one card). If a smaller device could equally hold a
-    strictly larger usage, the two could be swapped without violating capacity, so
-    without a verified LUID-to-torch mapping the ranking is a guess; a wrong guess
-    mislabels the System tab and feeds ``routes/training_vram.py`` a wrong per-index
-    free, so report unknown (``None``) rather than fabricate.
+    Windows shares no key between LUID counters and torch ordinals, so usages are
+    ranked against device totals and each is trusted only when capacity *forces* it
+    (it exceeds every smaller device); an ambiguous ranking reports unknown
+    (``None``) rather than fabricate a per-index free.
 
-    More raw counters than visible devices means a hidden GPU (outside the mask) or
-    a display adapter is present, and the noise filter may have dropped a visible
-    card's real reading, so a survivor that merely *fits* a visible card could be
-    the hidden GPU's usage pinned onto an idle card. Values are therefore emitted
-    only when the supra-threshold counters number EXACTLY the visible devices (every
-    card has one real reading, the extras were placeholders) AND capacity forces the
-    mapping; otherwise every device reports unknown. Best-effort: a hidden-busy card
-    beside an idle visible one can still mislead, but the common loaded-card case
-    (#7072) is correct. Returns a list aligned to ``device_totals``.
+    Extra counters mean a hidden/display adapter, and the noise filter may have
+    dropped a real reading, so values are emitted only when the supra-threshold
+    counters number EXACTLY the visible devices AND capacity forces the mapping;
+    otherwise every device is unknown. Best-effort but correct for the common
+    loaded-card case (#7072). Returns a list aligned to ``device_totals``.
     """
     n = len(device_totals)
     if n == 0:
@@ -818,28 +808,25 @@ def _match_adapter_used_to_devices(
     ranked_positions = sorted(range(n), key = lambda i: -device_totals[i])
     ranked_totals = [device_totals[pos] for pos in ranked_positions]
     assigned: list[Optional[float]]
-    # More raw counters than visible devices -> a hidden/display adapter is present.
-    # Measured before the noise filter, since an idle visible card can sit below it.
+    # More counters than devices -> a hidden/display adapter (check before noise filter).
     if len(useds) > n:
         non_trivial = [u for u in useds if u >= _ROCM_WIN_ADAPTER_MIN_BYTES]
         if len(non_trivial) != n:
-            # Not a clean visible-set bijection: more supra-threshold counters than
-            # cards means a masked GPU is busy; fewer means a visible card is idle
-            # and a survivor could be the hidden device's. Either way no counter can
-            # be attributed to a specific card, so report unknown.
+            # Not a clean bijection (a masked GPU is busy or a visible card idle):
+            # no counter maps to a specific card, so report unknown.
             return [None] * n
-        # Exactly n supra-threshold counters: the extras were placeholders and every
-        # card has one reading, so a capacity-ranked bijection is plausible.
+        # Exactly n supra-threshold counters: extras were placeholders, so a
+        # capacity-ranked bijection is plausible.
         useds = non_trivial
         ranked_useds = [useds[rank] for rank in range(n)]
-        # A usage exceeding its own ranked capacity is a hidden larger GPU; clamping
-        # it onto the smaller visible card would fabricate a fully-used reading.
+        # A usage above its ranked capacity is a hidden larger GPU; clamping onto the
+        # smaller card would fabricate a fully-used reading.
         for rank in range(n):
             if ranked_useds[rank] > ranked_totals[rank]:
                 return [None] * n
-        # Capacity forces the mapping only when the ranked usage exceeds the
-        # next-smaller (thus every smaller) capacity. The smallest card and any
-        # merely-fitting usage stay unknown. Keeps 40 GiB over 48/8 GiB -> [40, None].
+        # Capacity forces the mapping only when the usage exceeds the next-smaller
+        # capacity; the smallest card and merely-fitting usages stay unknown.
+        # Keeps 40 GiB over 48/8 GiB -> [40, None].
         assigned = [None] * n
         for rank, pos in enumerate(ranked_positions):
             if rank + 1 < n and ranked_useds[rank] > ranked_totals[rank + 1]:

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -538,21 +538,33 @@ def _torch_get_physical_gpu_count() -> Optional[int]:
 
 
 def _torch_get_per_device_info(device_indices: list[int]) -> list[Dict[str, Any]]:
-    """Query torch for per-GPU name, total VRAM, and used VRAM."""
+    """Query torch for per-GPU name, total VRAM, and used VRAM.
+
+    ``used_gb`` is ``None`` when untrustworthy: Windows ROCm ``hipMemGetInfo``
+    reports ``free == total`` even with a model resident (ROCm/ROCm#1909), so a 0
+    there means "unknown", not "empty". ``total_gb`` stays authoritative.
+    """
     mod, _ = _torch_get_device_module()
     if mod is None:
         return []
 
+    # free==total is a Windows-ROCm-only quirk; other backends keep used = total - free.
+    _win_rocm = sys.platform == "win32" and IS_ROCM
     devices = []
     for ordinal, phys_idx in enumerate(device_indices):
         try:
             # torch ordinals are 0-based relative to CUDA_VISIBLE_DEVICES.
             props = mod.get_device_properties(ordinal)
             total_bytes = props.total_memory
+            used_bytes: Optional[int]
             # Prefer mem_get_info (system-wide) so auto-select sees other consumers.
             if hasattr(mod, "mem_get_info"):
                 free_bytes, total_bytes = mod.mem_get_info(ordinal)
                 used_bytes = total_bytes - free_bytes
+                # Windows ROCm free==total is the broken-API sentinel, not a proven
+                # idle GPU; mark used unknown so callers never show a bogus 0.
+                if _win_rocm and free_bytes == total_bytes:
+                    used_bytes = None
             else:
                 used_bytes = mod.memory_allocated(ordinal)
             devices.append(
@@ -561,7 +573,9 @@ def _torch_get_per_device_info(device_indices: list[int]) -> list[Dict[str, Any]
                     "visible_ordinal": ordinal,
                     "name": props.name,
                     "total_gb": round(total_bytes / (1024**3), 2),
-                    "used_gb": round(used_bytes / (1024**3), 2),
+                    "used_gb": round(used_bytes / (1024**3), 2)
+                    if used_bytes is not None
+                    else None,
                 }
             )
         except Exception as e:
@@ -724,20 +738,36 @@ def _rocm_linux_sysfs_vram_gb() -> tuple[Optional[float], Optional[float]]:
         return None, None
 
 
-def _rocm_windows_perf_counter_vram_gb() -> tuple[Optional[float], Optional[float]]:
-    """Query system-wide dedicated GPU VRAM via Windows Performance Counters.
+# ── Windows AMD/ROCm per-adapter VRAM (issue #7072) ──────────────────────────
+# amd-smi is disabled here and hipMemGetInfo reports free==total, so read used
+# from the "GPU Adapter Memory" perf counters (Task Manager's source), instanced
+# per adapter by LUID, and take each total from torch properties (the counter set
+# has no per-adapter total). This shows every GPU instead of summing all adapters
+# into one fake device with only GPU 0's total.
 
-    Same data source as Task Manager, so cross-process usage is accurate.
-    Works for any GPU vendor without amd-smi or nvidia-smi.
-    Returns (used_gb, total_gb) or (None, None) on failure.
+# Placeholder adapters (Basic Render Driver / idle iGPU) are dropped only when
+# they would outnumber the real torch devices.
+_ROCM_WIN_ADAPTER_MIN_BYTES = 64 * 1024 * 1024  # 64 MiB
+
+
+def _rocm_windows_perf_counter_vram_by_adapter() -> Optional[list[tuple[str, float]]]:
+    """Per-adapter dedicated VRAM usage on Windows via Performance Counters.
+
+    Enumerates each ``\\GPU Adapter Memory(<instance>)\\Dedicated Usage`` instance
+    (one per adapter, named by LUID) rather than summing them. Returns
+    ``[(instance_name, used_bytes)]``, or ``None`` when the counter is unavailable,
+    localized, or empty so callers fall back instead of reporting a wrong 0.
     """
     if platform.system() != "Windows":
-        return None, None
+        return None
     try:
+        # Emit "<InstanceName>|<CookedValue>" per sample, or a sentinel when the
+        # counter set is absent/localized so we return None (not a 0 sum).
         ps = (
             "$s=(Get-Counter '\\GPU Adapter Memory(*)\\Dedicated Usage'"
             " -ErrorAction SilentlyContinue).CounterSamples;"
-            "if($s){($s|Measure-Object CookedValue -Sum).Sum}else{-1}"
+            "if($s){$s|ForEach-Object{'{0}|{1}' -f $_.InstanceName,[int64]$_.CookedValue}}"
+            "else{'__NONE__'}"
         )
         r = subprocess.run(
             ["powershell", "-NoProfile", "-NonInteractive", "-Command", ps],
@@ -746,16 +776,132 @@ def _rocm_windows_perf_counter_vram_gb() -> tuple[Optional[float], Optional[floa
             timeout = 5,
         )
         if r.returncode != 0 or not r.stdout.strip():
-            return None, None
-        used_bytes = float(r.stdout.strip())
-        if used_bytes < 0:
-            return None, None
-        import torch as _torch
-
-        total_bytes = _torch.cuda.get_device_properties(0).total_memory
-        return round(used_bytes / (1024**3), 2), round(total_bytes / (1024**3), 2)
+            return None
+        adapters: list[tuple[str, float]] = []
+        for line in r.stdout.splitlines():
+            line = line.strip()
+            if not line or line == "__NONE__" or "|" not in line:
+                continue
+            instance, _, raw = line.rpartition("|")
+            try:
+                used = float(raw.strip())
+            except (ValueError, TypeError):
+                continue
+            if used < 0:
+                continue
+            adapters.append((instance.strip(), used))
+        return adapters or None
     except Exception:
-        return None, None
+        return None
+
+
+def _match_adapter_used_to_devices(
+    adapter_useds: list[float], device_totals: list[float]
+) -> list[Optional[float]]:
+    """Attribute per-adapter used bytes to torch devices (by index position).
+
+    Windows shares no key between LUID counter instances and torch ordinals, so
+    the largest usage pairs with the largest-capacity device (single-model /
+    size-proportional-shard case), clamped to that total. Unmatched devices get
+    ``None``. Returns a list aligned to ``device_totals``.
+    """
+    n = len(device_totals)
+    if n == 0:
+        return []
+    useds = sorted(adapter_useds, reverse = True)
+    # Drop placeholder adapters only if they'd outnumber real devices.
+    if len(useds) > n:
+        non_trivial = [u for u in useds if u >= _ROCM_WIN_ADAPTER_MIN_BYTES]
+        useds = (non_trivial or useds)[:n]
+    ranked_positions = sorted(range(n), key = lambda i: -device_totals[i])
+    assigned: list[Optional[float]] = [None] * n
+    for rank, pos in enumerate(ranked_positions):
+        if rank < len(useds):
+            assigned[pos] = min(useds[rank], device_totals[pos])
+    return assigned
+
+
+def _rocm_windows_per_device_vram(device_indices: list[int]) -> list[Dict[str, Any]]:
+    """Per-GPU VRAM on Windows AMD/ROCm: total from torch properties (reliable),
+    used from the per-adapter Dedicated Usage counter.
+
+    Returns ``{index, visible_ordinal, name, used_gb, total_gb}`` per visible GPU
+    (``used_gb`` may be ``None`` when the counter is unavailable), or ``[]`` when
+    torch can't enumerate devices so callers fall through to the torch last resort.
+    """
+    if platform.system() != "Windows":
+        return []
+    mod, _ = _torch_get_device_module()
+    if mod is None:
+        return []
+    # Totals/names from torch properties, not mem_get_info (its free==total quirk
+    # would zero used); totals stay correct regardless.
+    dev_meta: list[Dict[str, Any]] = []
+    for ordinal, phys_idx in enumerate(device_indices):
+        try:
+            props = mod.get_device_properties(ordinal)
+            dev_meta.append(
+                {
+                    "index": phys_idx,
+                    "visible_ordinal": ordinal,
+                    "name": props.name,
+                    "total_bytes": int(props.total_memory),
+                }
+            )
+        except Exception as e:
+            logger.debug("torch property probe failed for ordinal %d: %s", ordinal, e)
+    if not dev_meta:
+        return []
+
+    adapters = _rocm_windows_perf_counter_vram_by_adapter()
+    if adapters:
+        assigned = _match_adapter_used_to_devices(
+            [used for _, used in adapters],
+            [d["total_bytes"] for d in dev_meta],
+        )
+    else:
+        # Counter unavailable: show every GPU with a correct total, used unknown.
+        assigned = [None] * len(dev_meta)
+
+    devices: list[Dict[str, Any]] = []
+    for meta, used_bytes in zip(dev_meta, assigned):
+        total_gb = round(meta["total_bytes"] / (1024**3), 2)
+        used_gb = round(used_bytes / (1024**3), 2) if used_bytes is not None else None
+        devices.append(
+            {
+                "index": meta["index"],
+                "visible_ordinal": meta["visible_ordinal"],
+                "name": meta["name"],
+                "used_gb": used_gb,
+                "total_gb": total_gb,
+            }
+        )
+    return devices
+
+
+def _rocm_windows_device_payload_entry(
+    device: DeviceType, dev: Dict[str, Any], gpu_util_pct: Optional[float]
+) -> Dict[str, Any]:
+    """Build a ``get_gpu_utilization`` device entry from a per-device VRAM dict."""
+    total_gb = dev["total_gb"]
+    used_gb = dev["used_gb"]
+    return {
+        "available": True,
+        "backend": _backend_label(device),
+        "index": dev["index"],
+        "visible_ordinal": dev["visible_ordinal"],
+        "name": dev.get("name", "Unknown"),
+        "gpu_utilization_pct": gpu_util_pct,
+        "temperature_c": None,
+        "vram_used_gb": used_gb,
+        "vram_total_gb": total_gb,
+        "vram_utilization_pct": round((used_gb / total_gb) * 100, 1)
+        if total_gb and total_gb > 0 and used_gb is not None
+        else None,
+        "power_draw_w": None,
+        "power_limit_w": None,
+        "power_utilization_pct": None,
+    }
 
 
 def _gpu_utilization_payload(
@@ -821,30 +967,26 @@ def get_gpu_utilization() -> Dict[str, Any]:
                 index_kind = result.get("index_kind"),
             )
 
-        # Fallback Windows ROCm
+        # Fallback Windows ROCm: per-adapter VRAM attribution (issue #7072), so
+        # every visible GPU is shown instead of a sum collapsed onto one device.
         if IS_ROCM and platform.system() == "Windows":
-            _win_used, _win_total = _rocm_windows_perf_counter_vram_gb()
-            if _win_used is not None and _win_total is not None:
-                _win_util = _rocm_windows_perf_counter_gpu_util_pct()
+            _win_ids = _get_parent_visible_gpu_spec().get("numeric_ids")
+            if not _win_ids:
+                _win_ids = list(range(_torch_get_physical_gpu_count() or 0))
+            _win_devices = _rocm_windows_per_device_vram(_win_ids)
+            if _win_devices:
+                # A single visible GPU can own the aggregate 3D-engine utilization;
+                # across several GPUs the sum isn't per-device, so leave it unset.
+                _win_util = (
+                    _rocm_windows_perf_counter_gpu_util_pct()
+                    if len(_win_devices) == 1
+                    else None
+                )
                 return _gpu_utilization_payload(
                     device,
                     [
-                        {
-                            "available": True,
-                            "backend": _backend_label(device),
-                            "index": 0,
-                            "visible_ordinal": 0,
-                            "gpu_utilization_pct": _win_util,
-                            "temperature_c": None,
-                            "vram_used_gb": _win_used,
-                            "vram_total_gb": _win_total,
-                            "vram_utilization_pct": round((_win_used / _win_total) * 100, 1)
-                            if _win_total > 0
-                            else None,
-                            "power_draw_w": None,
-                            "power_limit_w": None,
-                            "power_utilization_pct": None,
-                        }
+                        _rocm_windows_device_payload_entry(device, _wd, _win_util)
+                        for _wd in _win_devices
                     ],
                 )
 
@@ -901,7 +1043,7 @@ def get_gpu_utilization() -> Dict[str, Any]:
                         "vram_used_gb": _used,
                         "vram_total_gb": _total,
                         "vram_utilization_pct": round((_used / _total) * 100, 1)
-                        if _total > 0
+                        if _total > 0 and _used is not None
                         else None,
                         "power_draw_w": None,
                         "power_limit_w": None,
@@ -995,9 +1137,11 @@ def _apply_unified_memory_correction(
     endpoints stay in sync on AMD iGPUs with unified memory.
     """
     torch_total_gb = torch_info["total_gb"]
+    torch_used_gb = torch_info.get("used_gb")
     smi_total_gb = device_metrics.get("vram_total_gb") or 0.0
-    if torch_total_gb > smi_total_gb:
-        torch_used_gb = torch_info["used_gb"]
+    # Skip when used is unknown (Windows-ROCm guard) so a None can't overwrite a
+    # good amd-smi figure.
+    if torch_used_gb is not None and torch_total_gb > smi_total_gb:
         device_metrics["vram_total_gb"] = torch_total_gb
         device_metrics["vram_used_gb"] = torch_used_gb
         device_metrics["vram_utilization_pct"] = (
@@ -1067,6 +1211,49 @@ def get_visible_gpu_utilization() -> Dict[str, Any]:
                 _reconcile_rocm_unified_memory(result, numeric_ids)
             return result
 
+        # Windows AMD/ROCm (issue #7072): the System tab's VRAM source. Without
+        # this branch the torch fallback below reports used==0 (free==total), so
+        # read per-adapter Dedicated Usage instead; total from torch properties.
+        if IS_ROCM and platform.system() == "Windows":
+            win_numeric_ids = parent_visible_spec.get("numeric_ids")
+            if win_numeric_ids:
+                win_ids = win_numeric_ids
+                win_index_kind = "physical"
+            else:
+                win_ids = list(range(_torch_get_physical_gpu_count() or 0))
+                win_index_kind = "relative"
+            win_devices = _rocm_windows_per_device_vram(win_ids)
+            if win_devices:
+                devices = []
+                for wd in win_devices:
+                    total = wd["total_gb"]
+                    used = wd["used_gb"]
+                    devices.append(
+                        {
+                            "index": wd["index"],
+                            "index_kind": win_index_kind,
+                            "visible_ordinal": wd["visible_ordinal"],
+                            "name": wd.get("name"),
+                            "gpu_utilization_pct": None,
+                            "temperature_c": None,
+                            "vram_used_gb": used,
+                            "vram_total_gb": total,
+                            "vram_utilization_pct": round((used / total) * 100, 1)
+                            if total and total > 0 and used is not None
+                            else None,
+                            "power_draw_w": None,
+                            "power_limit_w": None,
+                            "power_utilization_pct": None,
+                        }
+                    )
+                return {
+                    "available": True,
+                    "backend": _backend_label(device),
+                    "parent_visible_gpu_ids": win_numeric_ids or [],
+                    "devices": devices,
+                    "index_kind": win_index_kind,
+                }
+
     # Torch-based fallback for CUDA (nvidia-smi unavailable, AMD ROCm) and XPU (Intel)
     if device in (DeviceType.CUDA, DeviceType.XPU):
         parent_ids = get_parent_visible_gpu_ids()
@@ -1094,7 +1281,7 @@ def get_visible_gpu_utilization() -> Dict[str, Any]:
                         "vram_used_gb": used,
                         "vram_total_gb": total,
                         "vram_utilization_pct": round((used / total) * 100, 1)
-                        if total > 0
+                        if total > 0 and used is not None
                         else None,
                         "power_draw_w": None,
                         "power_limit_w": None,

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -810,6 +810,12 @@ def _match_adapter_used_to_devices(
     # Drop placeholder adapters only if they'd outnumber real devices.
     if len(useds) > n:
         non_trivial = [u for u in useds if u >= _ROCM_WIN_ADAPTER_MIN_BYTES]
+        if len(non_trivial) > n:
+            # More adapters are actively using VRAM than are visible here (a GPU
+            # outside the visibility mask, or an extra discrete adapter). Usage
+            # alone can't tell the visible set apart, so any pairing would
+            # fabricate values; report unknown rather than mis-assign.
+            return [None] * n
         useds = (non_trivial or useds)[:n]
     ranked_positions = sorted(range(n), key = lambda i: -device_totals[i])
     assigned: list[Optional[float]] = [None] * n

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -540,15 +540,14 @@ def _torch_get_physical_gpu_count() -> Optional[int]:
 def _torch_get_per_device_info(device_indices: list[int]) -> list[Dict[str, Any]]:
     """Query torch for per-GPU name, total VRAM, and used VRAM.
 
-    ``used_gb`` is ``None`` when untrustworthy: Windows ROCm ``hipMemGetInfo``
-    reports ``free == total`` even with a model resident (ROCm/ROCm#1909), so a 0
-    there means "unknown", not "empty". ``total_gb`` stays authoritative.
+    ``used_gb`` is ``None`` on Windows ROCm when ``hipMemGetInfo`` reports
+    ``free == total`` (ROCm/ROCm#1909): that 0 means unknown, not empty.
     """
     mod, _ = _torch_get_device_module()
     if mod is None:
         return []
 
-    # free==total is a Windows-ROCm-only quirk; other backends keep used = total - free.
+    # free==total is a Windows-ROCm-only quirk.
     _win_rocm = sys.platform == "win32" and IS_ROCM
     devices = []
     for ordinal, phys_idx in enumerate(device_indices):
@@ -561,8 +560,7 @@ def _torch_get_per_device_info(device_indices: list[int]) -> list[Dict[str, Any]
             if hasattr(mod, "mem_get_info"):
                 free_bytes, total_bytes = mod.mem_get_info(ordinal)
                 used_bytes = total_bytes - free_bytes
-                # Windows ROCm free==total is the broken-API sentinel, not a proven
-                # idle GPU; mark used unknown so callers never show a bogus 0.
+                # free==total is the broken-API sentinel, not an idle GPU.
                 if _win_rocm and free_bytes == total_bytes:
                     used_bytes = None
             else:
@@ -737,30 +735,26 @@ def _rocm_linux_sysfs_vram_gb() -> tuple[Optional[float], Optional[float]]:
 
 
 # ── Windows AMD/ROCm per-adapter VRAM (issue #7072) ──────────────────────────
-# amd-smi is disabled here and hipMemGetInfo reports free==total, so read used
-# from the "GPU Adapter Memory" perf counters (Task Manager's source), instanced
-# per adapter by LUID, and take each total from torch properties (the counter set
-# has no per-adapter total). This shows every GPU instead of summing all adapters
-# into one fake device with only GPU 0's total.
+# amd-smi is disabled and hipMemGetInfo reports free==total, so read used from the
+# per-LUID "GPU Adapter Memory" perf counters (Task Manager's source) and take each
+# total from torch properties. Shows every GPU instead of summing all adapters into
+# one fake device with GPU 0's total.
 
-# Placeholder adapters (Basic Render Driver / idle iGPU) are dropped only when
-# they would outnumber the real torch devices.
+# Placeholder adapters (Basic Render Driver / idle iGPU) are dropped only when they
+# would outnumber the real torch devices.
 _ROCM_WIN_ADAPTER_MIN_BYTES = 64 * 1024 * 1024  # 64 MiB
 
 
 def _rocm_windows_perf_counter_vram_by_adapter() -> Optional[list[tuple[str, float]]]:
     """Per-adapter dedicated VRAM usage on Windows via Performance Counters.
 
-    Enumerates each ``\\GPU Adapter Memory(<instance>)\\Dedicated Usage`` instance
-    (one per adapter, named by LUID) rather than summing them. Returns
-    ``[(instance_name, used_bytes)]``, or ``None`` when the counter is unavailable,
-    localized, or empty so callers fall back instead of reporting a wrong 0.
+    Returns ``[(instance_name, used_bytes)]`` (one per LUID-named adapter), or
+    ``None`` when the counter is unavailable/localized/empty so callers fall back.
     """
     if platform.system() != "Windows":
         return None
     try:
-        # Emit "<InstanceName>|<CookedValue>" per sample, or a sentinel when the
-        # counter set is absent/localized so we return None (not a 0 sum).
+        # Emit "<InstanceName>|<CookedValue>" per sample, or a __NONE__ sentinel.
         ps = (
             "$s=(Get-Counter '\\GPU Adapter Memory(*)\\Dedicated Usage'"
             " -ErrorAction SilentlyContinue).CounterSamples;"
@@ -796,42 +790,26 @@ def _rocm_windows_perf_counter_vram_by_adapter() -> Optional[list[tuple[str, flo
 def _match_adapter_used_to_devices(
     adapter_useds: list[float], device_totals: list[float]
 ) -> list[Optional[float]]:
-    """Attribute per-adapter used bytes to torch devices (by capacity ranking).
+    """Attribute per-adapter used bytes to torch devices by capacity ranking.
 
     Windows shares no key between LUID counter instances and torch ordinals, so
-    usage is paired with capacity: the largest usage goes to the largest device,
-    clamped to that total. That pairing is trustworthy only when capacity *forces*
-    it (a usage larger than every smaller device can sit on just one card). When a
-    smaller-capacity device could equally hold a strictly larger usage (e.g. an
-    8 GiB card near full beside a lightly used 48 GiB card), the two values could
-    be swapped without violating any capacity, so the ranking is a guess. There is
-    no verified LUID-to-torch mapping to break the tie, and a wrong guess both
-    mislabels the System tab and feeds ``routes/training_vram.py`` a wrong
-    per-index free value, so report unknown (``None``) rather than fabricate.
+    the largest usage is paired with the largest device and clamped to its total.
+    That pairing is trusted only when capacity *forces* it (a usage exceeding every
+    smaller device fits only one card). If a smaller device could equally hold a
+    strictly larger usage, the two could be swapped without violating capacity, so
+    without a verified LUID-to-torch mapping the ranking is a guess; a wrong guess
+    mislabels the System tab and feeds ``routes/training_vram.py`` a wrong per-index
+    free, so report unknown (``None``) rather than fabricate.
 
-    When there are more raw counters than visible devices at least one adapter
-    belongs to a hidden GPU (outside the visibility mask) or a non-GPU display
-    adapter, and the sub-threshold noise filter may itself have dropped a
-    *visible* card's real reading. A surviving counter that merely *fits* a visible
-    card can actually be the hidden GPU's usage pinned onto an idle visible card
-    whose true (filtered) reading was tiny -- e.g. two visible cards at 48/8 GiB
-    using 40 GiB / 10 MiB beside a hidden 6 GiB adapter: the 10 MiB drops out and
-    the 6 GiB "fits" the 8 GiB card even though that card is idle. Worse, if BOTH
-    visible readings fall below the noise floor a lone large survivor could belong
-    to the hidden GPU entirely while both visible cards are idle. So in the
-    hidden-adapter case concrete values are emitted only when the supra-threshold
-    counters number EXACTLY the visible devices: then every visible card has one
-    real reading and the extras were sub-threshold placeholders, making a
-    capacity-ranked bijection plausible. When the supra-threshold counters are
-    fewer than the visible devices (a visible card is idle, so a survivor could be
-    the hidden device's) or more (a masked GPU is actively using VRAM), no counter
-    can be attributed, so every device reports unknown. Even in the exactly-n case a
-    value is emitted for a device ONLY when capacity forces it: the ranked usage
-    must exceed every smaller visible card's capacity, so no smaller visible card
-    could account for it (best-effort -- a contrived hidden-busy while a visible
-    card is idle can still mislead, but the common loaded-card case is correct). The
-    smallest visible card and any usage that merely fits report unknown. Unmatched
-    devices get ``None``. Returns a list aligned to ``device_totals``.
+    More raw counters than visible devices means a hidden GPU (outside the mask) or
+    a display adapter is present, and the noise filter may have dropped a visible
+    card's real reading, so a survivor that merely *fits* a visible card could be
+    the hidden GPU's usage pinned onto an idle card. Values are therefore emitted
+    only when the supra-threshold counters number EXACTLY the visible devices (every
+    card has one real reading, the extras were placeholders) AND capacity forces the
+    mapping; otherwise every device reports unknown. Best-effort: a hidden-busy card
+    beside an idle visible one can still mislead, but the common loaded-card case
+    (#7072) is correct. Returns a list aligned to ``device_totals``.
     """
     n = len(device_totals)
     if n == 0:
@@ -840,60 +818,37 @@ def _match_adapter_used_to_devices(
     ranked_positions = sorted(range(n), key = lambda i: -device_totals[i])
     ranked_totals = [device_totals[pos] for pos in ranked_positions]
     assigned: list[Optional[float]]
-    # More raw counters than visible devices means at least one adapter belongs to
-    # a GPU outside the visibility mask (or a non-GPU display adapter). Measured on
-    # the raw count *before* the noise filter, because a genuinely idle visible card
-    # can itself sit below the sub-threshold noise floor.
+    # More raw counters than visible devices -> a hidden/display adapter is present.
+    # Measured before the noise filter, since an idle visible card can sit below it.
     if len(useds) > n:
         non_trivial = [u for u in useds if u >= _ROCM_WIN_ADAPTER_MIN_BYTES]
         if len(non_trivial) != n:
-            # Not a clean visible-set bijection, so no counter can be attributed to
-            # a specific visible card. With MORE supra-threshold counters than
-            # visible cards a GPU outside the visibility mask is actively using VRAM;
-            # with FEWER, at least one visible card is idle (its reading below the
-            # noise floor) and a surviving counter could be that hidden device's
-            # usage rather than the idle card's -- e.g. two visible 48/8 GiB cards
-            # both idle beside a hidden GPU using 40 GiB looks identical to the
-            # 48 GiB card loaded to 40 GiB, so pinning 40 onto a visible card would
-            # fabricate a reading. (This also subsumes the placeholder-only case
-            # where every counter is sub-threshold.) No LUID-to-ordinal mapping
-            # exists to break the tie, so report unknown rather than fabricate.
+            # Not a clean visible-set bijection: more supra-threshold counters than
+            # cards means a masked GPU is busy; fewer means a visible card is idle
+            # and a survivor could be the hidden device's. Either way no counter can
+            # be attributed to a specific card, so report unknown.
             return [None] * n
-        # Exactly n supra-threshold counters: the extra raw adapters were all
-        # sub-threshold placeholders and every visible card has one supra-threshold
-        # reading, so a capacity-ranked bijection is plausible. Emit a value only
-        # where capacity forces it (best-effort: a contrived hidden-busy while a
-        # visible card is idle can still mislead, but the common loaded-card case,
-        # which is what #7072 reports, is attributed correctly).
+        # Exactly n supra-threshold counters: the extras were placeholders and every
+        # card has one reading, so a capacity-ranked bijection is plausible.
         useds = non_trivial
         ranked_useds = [useds[rank] for rank in range(n)]
-        # A kept usage that exceeds its own ranked visible capacity is a hidden,
-        # larger GPU whose counter outlived a visible card's filtered reading;
-        # clamping it onto the smaller visible card would fabricate a fully-used
-        # reading (a hidden 48 GiB card at 40 GiB shown as a visible 8 GiB card
-        # fully used), so report unknown for every device.
+        # A usage exceeding its own ranked capacity is a hidden larger GPU; clamping
+        # it onto the smaller visible card would fabricate a fully-used reading.
         for rank in range(n):
             if ranked_useds[rank] > ranked_totals[rank]:
                 return [None] * n
-        # Emit a value only where capacity forces the mapping: the ranked usage
-        # must strictly exceed the next-smaller (and thus every smaller) visible
-        # capacity, so it cannot be a smaller visible card's reading or a dropped
-        # sub-threshold one. The smallest card (no smaller capacity to exceed) and
-        # any usage that merely fits stay unknown. This keeps the classic single
-        # dominant-usage case (40 GiB across 48/8 GiB -> [40, None]) while refusing
-        # to pin a hidden adapter's fitting usage onto an idle visible card.
+        # Capacity forces the mapping only when the ranked usage exceeds the
+        # next-smaller (thus every smaller) capacity. The smallest card and any
+        # merely-fitting usage stay unknown. Keeps 40 GiB over 48/8 GiB -> [40, None].
         assigned = [None] * n
         for rank, pos in enumerate(ranked_positions):
             if rank + 1 < n and ranked_useds[rank] > ranked_totals[rank + 1]:
                 assigned[pos] = min(ranked_useds[rank], device_totals[pos])
         return assigned
-    # No hidden adapters: every counter belongs to a visible card, so the capacity
-    # ranking has to be a permutation of the visible set.
+    # No hidden adapters: every counter is a visible card, so ranking is a permutation.
     ranked_useds = [useds[rank] if rank < len(useds) else 0.0 for rank in range(n)]
-    # Ambiguous whenever a strictly larger usage would also fit the next
-    # smaller-capacity device: those two values could be swapped without breaking
-    # any capacity, so ranking cannot know which card actually holds which. No
-    # verified LUID->ordinal mapping exists to resolve it -> report unknown.
+    # Ambiguous if a strictly larger usage also fits the next smaller card: the two
+    # could be swapped without breaking capacity, so ranking can't tell them apart.
     for rank in range(n - 1):
         upper, lower = ranked_useds[rank], ranked_useds[rank + 1]
         if upper > lower and upper <= ranked_totals[rank + 1]:
@@ -918,8 +873,7 @@ def _rocm_windows_per_device_vram(device_indices: list[int]) -> list[Dict[str, A
     mod, _ = _torch_get_device_module()
     if mod is None:
         return []
-    # Totals/names from torch properties, not mem_get_info (its free==total quirk
-    # would zero used); totals stay correct regardless.
+    # Totals/names from torch properties (mem_get_info's free==total quirk zeroes used).
     dev_meta: list[Dict[str, Any]] = []
     for ordinal, phys_idx in enumerate(device_indices):
         try:
@@ -1221,13 +1175,10 @@ def _apply_unified_memory_correction(
     torch_total_gb = torch_info["total_gb"]
     torch_used_gb = torch_info.get("used_gb")
     smi_total_gb = device_metrics.get("vram_total_gb") or 0.0
-    # torch sees the full unified (GTT) pool; amd-smi reports only the dedicated
-    # carve-out. Adopt torch's larger total independently of used: on Windows ROCm
-    # torch_used is None (the free==total sentinel) while its total stays
-    # authoritative, so gating the total on used would keep the small amd-smi
-    # carve-out and underreport the card's real capacity. Overwrite used only when
-    # torch's is known (else keep amd-smi's dedicated-usage figure) and recompute
-    # utilization against whatever used remains.
+    # torch sees the full unified (GTT) pool; amd-smi only the dedicated carve-out.
+    # Adopt torch's larger total regardless of used: on Windows ROCm torch_used is
+    # None (free==total sentinel) but its total stays authoritative. Overwrite used
+    # only when torch's is known, then recompute utilization against whatever remains.
     if torch_total_gb > smi_total_gb:
         device_metrics["vram_total_gb"] = torch_total_gb
         if torch_used_gb is not None:
@@ -1302,9 +1253,9 @@ def get_visible_gpu_utilization() -> Dict[str, Any]:
                 _reconcile_rocm_unified_memory(result, numeric_ids)
             return result
 
-        # Windows AMD/ROCm (issue #7072): the System tab's VRAM source. Without
-        # this branch the torch fallback below reports used==0 (free==total), so
-        # read per-adapter Dedicated Usage instead; total from torch properties.
+        # Windows AMD/ROCm (issue #7072): the System tab's VRAM source. The torch
+        # fallback below would report used==0 (free==total), so read per-adapter
+        # Dedicated Usage instead; total from torch properties.
         if IS_ROCM and platform.system() == "Windows":
             win_numeric_ids = parent_visible_spec.get("numeric_ids")
             if win_numeric_ids:

--- a/studio/frontend/src/components/floating-monitor.tsx
+++ b/studio/frontend/src/components/floating-monitor.tsx
@@ -70,9 +70,8 @@ export function FloatingMonitor() {
     (sum, device) => sum + (device.memory_total_gb ?? 0),
     0,
   );
-  // null usage = unknown (e.g. Windows ROCm perf counter unavailable); treating
-  // it as 0 fabricates a 0-used/full-free readout, so mark the aggregate unknown
-  // when any device is unknown.
+  // null usage = unknown (e.g. Windows ROCm perf counter): treating it as 0
+  // fabricates a 0-used readout, so the aggregate is unknown if any device is.
   const vramUsageKnown =
     devices.length > 0 &&
     devices.every((device) => Number.isFinite(device.vram_used_gb));

--- a/studio/frontend/src/components/floating-monitor.tsx
+++ b/studio/frontend/src/components/floating-monitor.tsx
@@ -70,13 +70,19 @@ export function FloatingMonitor() {
     (sum, device) => sum + (device.memory_total_gb ?? 0),
     0,
   );
-  const vramUsed = devices.reduce(
-    (sum, device) => sum + (device.vram_used_gb ?? 0),
-    0,
-  );
+  // A device reports null usage when it is unknown (e.g. Windows ROCm perf
+  // counter unavailable). Treating null as 0 would fabricate a 0-used/full-free
+  // readout, so surface the aggregate as unknown when any device is unknown.
+  const vramUsageKnown =
+    devices.length > 0 &&
+    devices.every((device) => Number.isFinite(device.vram_used_gb));
+  const vramUsed = vramUsageKnown
+    ? devices.reduce((sum, device) => sum + (device.vram_used_gb ?? 0), 0)
+    : 0;
   const vramPercent = clampPercent(
-    vramTotal > 0 ? (vramUsed / vramTotal) * 100 : 0,
+    vramUsageKnown && vramTotal > 0 ? (vramUsed / vramTotal) * 100 : 0,
   );
+  const unknownLabel = t("settings.resources.environment.unknown");
 
   const hasGpu = (systemInfo.gpu?.available ?? false) && devices.length > 0;
 
@@ -164,17 +170,20 @@ export function FloatingMonitor() {
                     <span
                       className={cn(
                         "shrink-0 tabular-nums",
-                        usageTextClass(vramPercent),
+                        vramUsageKnown
+                          ? usageTextClass(vramPercent)
+                          : "text-muted-foreground",
                       )}
                     >
-                      {Math.round(vramPercent)}%
+                      {vramUsageKnown ? `${Math.round(vramPercent)}%` : "--"}
                     </span>
                   </div>
                   <div className="text-xs text-muted-foreground font-mono tabular-nums">
-                    {formatGiB(vramUsed)} / {formatGiB(vramTotal)}
+                    {vramUsageKnown ? formatGiB(vramUsed) : unknownLabel} /{" "}
+                    {formatGiB(vramTotal)}
                   </div>
                   <Progress
-                    value={vramPercent}
+                    value={vramUsageKnown ? vramPercent : 0}
                     className="mt-1 h-1.5 rounded-full bg-muted"
                     indicatorClassName={usageIndicatorClass(vramPercent)}
                   />

--- a/studio/frontend/src/components/floating-monitor.tsx
+++ b/studio/frontend/src/components/floating-monitor.tsx
@@ -70,9 +70,9 @@ export function FloatingMonitor() {
     (sum, device) => sum + (device.memory_total_gb ?? 0),
     0,
   );
-  // A device reports null usage when it is unknown (e.g. Windows ROCm perf
-  // counter unavailable). Treating null as 0 would fabricate a 0-used/full-free
-  // readout, so surface the aggregate as unknown when any device is unknown.
+  // null usage = unknown (e.g. Windows ROCm perf counter unavailable); treating
+  // it as 0 fabricates a 0-used/full-free readout, so mark the aggregate unknown
+  // when any device is unknown.
   const vramUsageKnown =
     devices.length > 0 &&
     devices.every((device) => Number.isFinite(device.vram_used_gb));

--- a/studio/frontend/src/features/settings/tabs/resources-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/resources-tab.tsx
@@ -197,9 +197,9 @@ export function ResourcesTab() {
       (sum, device) => sum + (device.memory_total_gb ?? 0),
       0,
     );
-    // A device reports null usage when it is unknown (e.g. Windows ROCm perf
-    // counter unavailable). Treating null as 0 would fabricate a 0-used/full-free
-    // total, so surface the aggregate as unknown when any device is unknown.
+    // null usage = unknown (e.g. Windows ROCm perf counter unavailable); treating
+    // it as 0 fabricates a 0-used/full-free total, so mark the aggregate unknown
+    // when any device is unknown.
     const vramUsageKnown =
       devices.length > 0 &&
       devices.every((device) => isFiniteNumber(device.vram_used_gb));
@@ -368,9 +368,8 @@ export function ResourcesTab() {
         {hasGpu ? (
           metrics.devices.map((device, index) => {
             const ordinal = deviceOrdinal(device);
-            // Preserve null (unknown, e.g. Windows ROCm perf counter
-            // unavailable): coercing to 0 would render a fabricated 0 used /
-            // full free instead of unknown.
+            // Preserve null (unknown, e.g. Windows ROCm perf counter unavailable);
+            // coercing to 0 would render a fabricated 0 used / full free.
             const total = device.memory_total_gb ?? null;
             const used = device.vram_used_gb ?? null;
             const free =

--- a/studio/frontend/src/features/settings/tabs/resources-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/resources-tab.tsx
@@ -90,8 +90,8 @@ function MetricTile({
   label: string;
   value: string;
   detail: string;
-  // null means usage is unknown (e.g. Windows ROCm perf counter unavailable);
-  // show a dash and an empty bar rather than a fabricated 0%.
+  // null = usage unknown (e.g. Windows ROCm perf counter): show a dash and
+  // empty bar rather than a fabricated 0%.
   percent: number | null;
 }) {
   const percentKnown = isFiniteNumber(percent);
@@ -197,9 +197,8 @@ export function ResourcesTab() {
       (sum, device) => sum + (device.memory_total_gb ?? 0),
       0,
     );
-    // null usage = unknown (e.g. Windows ROCm perf counter unavailable); treating
-    // it as 0 fabricates a 0-used/full-free total, so mark the aggregate unknown
-    // when any device is unknown.
+    // null usage = unknown (e.g. Windows ROCm perf counter): treating it as 0
+    // fabricates a 0-used total, so the aggregate is unknown if any device is.
     const vramUsageKnown =
       devices.length > 0 &&
       devices.every((device) => isFiniteNumber(device.vram_used_gb));
@@ -368,8 +367,8 @@ export function ResourcesTab() {
         {hasGpu ? (
           metrics.devices.map((device, index) => {
             const ordinal = deviceOrdinal(device);
-            // Preserve null (unknown, e.g. Windows ROCm perf counter unavailable);
-            // coercing to 0 would render a fabricated 0 used / full free.
+            // Preserve null (unknown, e.g. Windows ROCm perf counter); coercing
+            // to 0 would render a fabricated 0 used / full free.
             const total = device.memory_total_gb ?? null;
             const used = device.vram_used_gb ?? null;
             const free =

--- a/studio/frontend/src/features/settings/tabs/resources-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/resources-tab.tsx
@@ -194,18 +194,31 @@ export function ResourcesTab() {
       (sum, device) => sum + (device.memory_total_gb ?? 0),
       0,
     );
-    const vramUsed = devices.reduce(
-      (sum, device) => sum + (device.vram_used_gb ?? 0),
-      0,
-    );
-    const vramFree = devices.reduce(
-      (sum, device) =>
-        sum +
-        (device.vram_free_gb ??
-          Math.max(0, (device.memory_total_gb ?? 0) - (device.vram_used_gb ?? 0))),
-      0,
-    );
-    const vramPercent = vramTotal > 0 ? (vramUsed / vramTotal) * 100 : 0;
+    // A device reports null usage when it is unknown (e.g. Windows ROCm perf
+    // counter unavailable). Treating null as 0 would fabricate a 0-used/full-free
+    // total, so surface the aggregate as unknown when any device is unknown.
+    const vramUsageKnown =
+      devices.length > 0 &&
+      devices.every((device) => isFiniteNumber(device.vram_used_gb));
+    const vramUsed = vramUsageKnown
+      ? devices.reduce((sum, device) => sum + (device.vram_used_gb ?? 0), 0)
+      : null;
+    const vramFree = vramUsageKnown
+      ? devices.reduce(
+          (sum, device) =>
+            sum +
+            (device.vram_free_gb ??
+              Math.max(
+                0,
+                (device.memory_total_gb ?? 0) - (device.vram_used_gb ?? 0),
+              )),
+          0,
+        )
+      : null;
+    const vramPercent =
+      vramUsageKnown && isFiniteNumber(vramUsed) && vramTotal > 0
+        ? (vramUsed / vramTotal) * 100
+        : 0;
 
     return {
       devices,
@@ -218,6 +231,7 @@ export function ResourcesTab() {
       vramUsed,
       vramFree,
       vramPercent,
+      vramUsageKnown,
     };
   }, [systemInfo]);
 
@@ -259,6 +273,7 @@ export function ResourcesTab() {
     : modelsFolderLoaded
       ? t("settings.resources.environment.unknown")
       : t("common.loading");
+  const unknownLabel = t("settings.resources.environment.unknown");
 
   return (
     <div className="flex flex-col gap-6">
@@ -327,14 +342,18 @@ export function ResourcesTab() {
             label={t("settings.resources.liveMonitor.vram")}
             value={
               hasGpu
-                ? `${formatGiB(metrics.vramUsed)} / ${formatGiB(metrics.vramTotal)}`
+                ? metrics.vramUsageKnown
+                  ? `${formatGiB(metrics.vramUsed)} / ${formatGiB(metrics.vramTotal)}`
+                  : `${unknownLabel} / ${formatGiB(metrics.vramTotal)}`
                 : t("settings.resources.liveMonitor.noGpu")
             }
             detail={
               hasGpu
-                ? t("settings.resources.liveMonitor.free", {
-                    value: formatGiB(metrics.vramFree),
-                  })
+                ? metrics.vramUsageKnown
+                  ? t("settings.resources.liveMonitor.free", {
+                      value: formatGiB(metrics.vramFree),
+                    })
+                  : unknownLabel
                 : backendLabel
             }
             percent={metrics.vramPercent}
@@ -346,13 +365,34 @@ export function ResourcesTab() {
         {hasGpu ? (
           metrics.devices.map((device, index) => {
             const ordinal = deviceOrdinal(device);
-            const total = device.memory_total_gb ?? 0;
-            const used = device.vram_used_gb ?? 0;
-            const free = device.vram_free_gb ?? Math.max(0, total - used);
+            // Preserve null (unknown, e.g. Windows ROCm perf counter
+            // unavailable): coercing to 0 would render a fabricated 0 used /
+            // full free instead of unknown.
+            const total = device.memory_total_gb ?? null;
+            const used = device.vram_used_gb ?? null;
+            const free =
+              device.vram_free_gb ??
+              (isFiniteNumber(total) && isFiniteNumber(used)
+                ? Math.max(0, total - used)
+                : null);
             const percent =
               device.vram_utilization_pct ??
-              (total > 0 ? (used / total) * 100 : null);
+              (isFiniteNumber(total) && total > 0 && isFiniteNumber(used)
+                ? (used / total) * 100
+                : null);
             const safePercent = clampPercent(percent);
+            const usedText = isFiniteNumber(used)
+              ? formatGiB(used)
+              : unknownLabel;
+            const freeText = isFiniteNumber(free)
+              ? formatGiB(free)
+              : unknownLabel;
+            const totalText = isFiniteNumber(total)
+              ? formatGiB(total)
+              : unknownLabel;
+            const percentText = isFiniteNumber(percent)
+              ? formatPercent(safePercent)
+              : unknownLabel;
             return (
               <div
                 key={`${device.index ?? index}-${device.name ?? "gpu"}`}
@@ -374,7 +414,7 @@ export function ResourcesTab() {
                   </div>
                   <div className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
                     <span>
-                      {formatPercent(safePercent)}{" "}
+                      {percentText}{" "}
                       {t("settings.resources.gpu.vramUtilization")}
                     </span>
                   </div>
@@ -382,17 +422,17 @@ export function ResourcesTab() {
                 <div className="grid gap-1 text-xs text-muted-foreground sm:grid-cols-3 sm:gap-2">
                   <span className="min-w-0 truncate font-mono tabular-nums">
                     {t("settings.resources.gpu.used", {
-                      value: formatGiB(used),
+                      value: usedText,
                     })}
                   </span>
                   <span className="min-w-0 truncate font-mono tabular-nums sm:text-center">
                     {t("settings.resources.gpu.free", {
-                      value: formatGiB(free),
+                      value: freeText,
                     })}
                   </span>
                   <span className="min-w-0 truncate font-mono tabular-nums sm:text-right">
                     {t("settings.resources.gpu.total", {
-                      value: formatGiB(total),
+                      value: totalText,
                     })}
                   </span>
                 </div>

--- a/studio/frontend/src/features/settings/tabs/resources-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/resources-tab.tsx
@@ -90,8 +90,11 @@ function MetricTile({
   label: string;
   value: string;
   detail: string;
-  percent: number;
+  // null means usage is unknown (e.g. Windows ROCm perf counter unavailable);
+  // show a dash and an empty bar rather than a fabricated 0%.
+  percent: number | null;
 }) {
+  const percentKnown = isFiniteNumber(percent);
   const safePercent = clampPercent(percent);
   return (
     <div className="flex min-w-0 flex-col gap-2 rounded-md border border-border/60 bg-muted/20 p-3">
@@ -102,10 +105,10 @@ function MetricTile({
         <span
           className={cn(
             "shrink-0 font-mono text-xs tabular-nums",
-            usageTextClass(safePercent),
+            percentKnown ? usageTextClass(safePercent) : "text-muted-foreground",
           )}
         >
-          {formatPercent(safePercent)}
+          {percentKnown ? formatPercent(safePercent) : "--"}
         </span>
       </div>
       <div className="min-w-0">
@@ -117,7 +120,7 @@ function MetricTile({
         </div>
       </div>
       <Progress
-        value={safePercent}
+        value={percentKnown ? safePercent : 0}
         aria-label={label}
         className="h-1.5 rounded-full bg-muted"
         indicatorClassName={usageIndicatorClass(safePercent)}
@@ -356,7 +359,7 @@ export function ResourcesTab() {
                   : unknownLabel
                 : backendLabel
             }
-            percent={metrics.vramPercent}
+            percent={metrics.vramUsageKnown ? metrics.vramPercent : null}
           />
         </div>
       </SettingsSection>


### PR DESCRIPTION
## Problem

On a Windows ROCm host the System tab showed close to zero VRAM in use even with a model fully loaded, and on a multi-GPU box it did not report each GPU correctly. Two causes:

- The System tab reads `get_visible_gpu_utilization()`. On Windows without a HIP SDK amd-smi is disabled (to avoid a UAC prompt), and that function fell straight through to `torch.cuda.mem_get_info`, which on Windows ROCm returns `free == total`. So used VRAM computed to 0.
- The other Windows fallback summed `\GPU Adapter Memory(*)\Dedicated Usage` across every adapter into a single device and used only GPU 0's total, so a second GPU never appeared and the total was wrong.

## Fix

- Read the Windows performance counter per adapter (per-LUID instances) and attribute usage to each torch device, reporting every GPU with its own total. Largest usage maps to the largest-capacity device, clamped so used never exceeds total, and placeholder adapters (basic render / idle iGPU) are dropped.
- Take each GPU's total and name from `torch.get_device_properties`, which is reliable, and the used value from the counter.
- Wire this into both `get_gpu_utilization()` and `get_visible_gpu_utilization()` (the latter never had the Windows fallback at all).
- Guard the `torch.cuda.mem_get_info` last resort: on Windows ROCm, if it reports `free == total`, treat used as unknown rather than reporting 0.

## Verification

New `studio/backend/tests/test_rocm_windows_vram_7072.py` (6 tests, mocked PowerShell output and torch) reproduces the reporter's dual-GPU case and the free==total case, and passes on the fix while failing on current code. The wider hardware suites (`test_windows_gpu_detection_mock`, `test_amd_apu_unified_memory`, gpu-selection and training-vram suites) stay green.

## Compatibility

Every new branch is gated on Windows plus ROCm; the free==total guard is gated on Windows plus ROCm. NVIDIA (nvidia-smi), Linux ROCm (sysfs), Apple/MLX, CPU and single-GPU AMD paths are unchanged, and the return shape is preserved (`used_gb` of `None` is already handled downstream). Final confirmation of the exact per-adapter numbers needs a real Windows AMD box, since CI Windows runners have no AMD GPU; the counter and hipMemGetInfo behaviour here is grounded in the ROCm issue tracker and the Windows performance-counter docs.

Fixes #7072
