### PR TITLE
Studio: strip orphaned tool-call markup and byte-fallback characters from MTP output

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -52,10 +52,12 @@ from core.inference.tool_call_parser import (
     _strip_gemma_wrapperless_calls,
     _strip_glm_calls,
     _strip_mistral_closed_calls,
+    _strip_trailing_orphan_close_run,
     TOOL_XML_SIGNALS as _SHARED_TOOL_XML_SIGNALS,
     RAG_MAX_SEARCHES_PER_TURN,
     RAG_SEARCH_CAP_NUDGE,
     parse_tool_calls_from_text as _shared_parse_tool_calls_from_text,
+    sanitize_control_chars as _sanitize_control_chars,
     strip_leading_bare_json_call,
     strip_llama3_leading_sentinels,
     strip_tool_markup as _shared_strip_tool_markup,
@@ -9428,6 +9430,9 @@ class LlamaCppBackend:
             )
 
         def _strip_tool_markup_streaming(text: str, *, force: bool = False) -> str:
+            # Scrub U+FFFD / control chars first, so a mangled opener cannot leave its close
+            # unmatched and byte-fallback garbage never leaks; mirrors strip_tool_markup.
+            text = _sanitize_control_chars(text)
             if not (auto_heal_tool_calls or force):
                 return text
 
@@ -9448,6 +9453,9 @@ class LlamaCppBackend:
                 for pat in pats:
                     seg = pat.sub("", seg)
                 if is_last:
+                    # Trailing orphan closes (drained/U+FFFD-mangled opener); orphan-strip before
+                    # rehearsal-tail to match strip_tool_markup(final=True).
+                    seg = _strip_trailing_orphan_close_run(seg)
                     seg = apply_tool_strip_patterns(
                         seg, [_REHEARSAL_TAIL_STRIP_RE], enabled_tool_names = _enabled_names_gate
                     )

--- a/studio/backend/core/inference/safetensors_agentic.py
+++ b/studio/backend/core/inference/safetensors_agentic.py
@@ -33,6 +33,7 @@ from core.inference.tool_call_parser import (
     _strip_glm_calls,
     _strip_mistral_closed_calls,
     _strip_mistral_reasoning,
+    _strip_trailing_orphan_close_run,
     BUDGET_EXHAUSTED_NUDGE,
     MAX_ACT_REPROMPTS,
     RAG_MAX_SEARCHES_PER_TURN,
@@ -41,6 +42,7 @@ from core.inference.tool_call_parser import (
     is_short_intent_without_action,
     parse_tool_calls_from_text,
     reprompt_to_act_message,
+    sanitize_control_chars,
     strip_leading_bare_json_call,
     strip_llama3_leading_sentinels,
     strip_tool_markup,
@@ -255,6 +257,9 @@ def strip_tool_markup_streaming(
     not be deleted, else the cumulative text shrinks then regrows). ``enabled_tool_names``
     keeps an inactive-name ``foo[ARGS]{..}`` / ``call:NAME{..}`` example visible (it is prose,
     not a call), matching the parse / detection active-tool gate."""
+    # Scrub U+FFFD / control chars first, so a mangled opener cannot leave its close unmatched
+    # and byte-fallback garbage never leaks into streamed display; mirrors strip_tool_markup.
+    text = sanitize_control_chars(text)
     if not (auto_heal_tool_calls or tool_protocol_active):
         return text
 
@@ -278,6 +283,9 @@ def strip_tool_markup_streaming(
         for pat in pats:
             seg = pat.sub("", seg)
         if is_last:
+            # Trailing orphan closes (drained/U+FFFD-mangled opener); orphan-strip before
+            # rehearsal-tail to match strip_tool_markup(final=True).
+            seg = _strip_trailing_orphan_close_run(seg)
             seg = apply_tool_strip_patterns(
                 seg, [_REHEARSAL_TAIL_STRIP_RE], enabled_tool_names = enabled_tool_names
             )

--- a/studio/backend/core/inference/tool_call_parser.py
+++ b/studio/backend/core/inference/tool_call_parser.py
@@ -33,6 +33,19 @@ from typing import Any, Optional
 from core import tool_healing as _tool_healing
 
 
+# C0 (keep tab/newline/return/ESC), C1, and U+FFFD: never valid in chat/tool output. MTP/
+# speculative GGUF byte-fallback surfaces as U+FFFD (ggml-org/llama.cpp#25618). Same class as
+# tools._BINARY_CHAR_RE.
+_DISPLAY_CONTROL_CHAR_RE = re.compile("[\x00-\x08\x0b\x0c\x0e-\x1a\x1c-\x1f\x7f-\x9f�]")
+
+
+def sanitize_control_chars(text: str) -> str:
+    """Drop control chars and U+FFFD from ``text``, keeping ``\\t`` ``\\n`` ``\\r`` and ESC."""
+    if not text:
+        return text
+    return _DISPLAY_CONTROL_CHAR_RE.sub("", text)
+
+
 # Flip the streaming buffer STREAMING->DRAINING so partial markup never leaks.
 TOOL_XML_SIGNALS = (
     "<tool_call>",
@@ -118,7 +131,34 @@ _TOOL_ALL_PATS = _TOOL_CLOSED_PATS + [
         re.DOTALL,
     ),
     # Gemma wrapper-less ``call:NAME{...}`` is handled by ``_strip_gemma_wrapperless_calls`` (enabled-name gate).
+    # Trailing orphan-close runs are handled by _strip_trailing_orphan_close_run.
 ]
+
+_ORPHAN_CLOSE_TOKENS = ("</tool_call>", "</parameter>", "</function>", "</param>", "<tool_call|>")
+_ORPHAN_SENTINELS = ("</tool_call>", "<tool_call|>")
+
+
+def _strip_trailing_orphan_close_run(text: str) -> str:
+    """Strip a trailing whitespace-separated run of tool close tags, but only when it
+    carries a </tool_call> or <tool_call|> sentinel (a drained/U+FFFD-mangled opener leaves
+    the close to leak); a lone </function> or </parameter> is kept as likely code/XML.
+    Linear scan, so no regex backtracking."""
+    i = len(text)
+    while i > 0 and text[i - 1].isspace():
+        i -= 1
+    run_start = i
+    has_sentinel = False
+    while True:
+        matched = next((t for t in _ORPHAN_CLOSE_TOKENS if text.endswith(t, 0, i)), None)
+        if matched is None:
+            break
+        if matched in _ORPHAN_SENTINELS:
+            has_sentinel = True
+        i -= len(matched)
+        run_start = i
+        while i > 0 and text[i - 1].isspace():
+            i -= 1
+    return text[:run_start] if has_sentinel else text
 
 
 TOOL_ERROR_PREFIXES = (
@@ -281,6 +321,23 @@ _KIMI_CALL_BEGIN = "<|tool_call_begin|>"
 _KIMI_ARG_BEGIN = "<|tool_call_argument_begin|>"
 _KIMI_CALL_END = "<|tool_call_end|>"
 _KIMI_ID_RE = re.compile(r"^(?:functions\.)?([\w\.\-]+)(?::(\d+))?$")
+
+# Kimi and DeepSeek end-of-turn closers are back-to-back special tokens; a drained/U+FFFD-
+# mangled opener leaves them to leak as a trailing orphan. Never legit prose, so they join the
+# ``<tool_call|>``-style sentinel set. Extended here (not the tuple defs above) since these
+# consts are defined later.
+_ORPHAN_CLOSE_TOKENS = _ORPHAN_CLOSE_TOKENS + (
+    _KIMI_CALL_END,
+    _KIMI_SECTION_END,
+    _DEEPSEEK_CALL_END,
+    _DEEPSEEK_END,
+)
+_ORPHAN_SENTINELS = _ORPHAN_SENTINELS + (
+    _KIMI_CALL_END,
+    _KIMI_SECTION_END,
+    _DEEPSEEK_CALL_END,
+    _DEEPSEEK_END,
+)
 
 # Gemma 4: ``<|tool_call>call:NAME{...}<tool_call|>``, ``<|"|>`` wraps strings.
 _GEMMA_TC_RE = re.compile(r"<\|tool_call>\s*call\s*:\s*([\w\.\-]+)\s*\{")
@@ -618,6 +675,8 @@ def strip_tool_markup(
     prose is kept (mirrors the parser gate): the bare reasoning-rehearsal ``name[ARGS]{...}``
     and the markerless Gemma ``call:NAME{...}`` strip. ``None`` strips every closed call.
     """
+    # Scrub U+FFFD / control chars first, so a mangled opener cannot leave its close unmatched.
+    text = sanitize_control_chars(text)
     if final:
         # Drop a leading Magistral ``[THINK]...[/THINK]`` at end-of-turn; its bracket
         # form is not the ``<think>`` the reasoning channel renders.
@@ -643,6 +702,8 @@ def strip_tool_markup(
         for pat in pats:
             seg = pat.sub("", seg)
         if seg_final:
+            # Trailing orphan closes whose opener was drained or U+FFFD-mangled upstream.
+            seg = _strip_trailing_orphan_close_run(seg)
             # Drop a trailing partial bare rehearsal (``name[ARGS]`` with a truncated or absent
             # body) the balanced scan cannot close; gated so prose ``foo[ARGS] ...`` survives.
             seg = _tool_healing.apply_tool_strip_patterns(

--- a/studio/backend/core/inference/tool_loop_controller.py
+++ b/studio/backend/core/inference/tool_loop_controller.py
@@ -17,7 +17,11 @@ from dataclasses import dataclass, field
 from typing import Any, Literal, Mapping, Sequence
 from urllib.parse import urlparse
 
-from core.inference.tool_call_parser import TOOL_ERROR_NUDGE, TOOL_ERROR_PREFIXES
+from core.inference.tool_call_parser import (
+    TOOL_ERROR_NUDGE,
+    TOOL_ERROR_PREFIXES,
+    sanitize_control_chars,
+)
 
 
 _CANONICAL_HEAL_ARG = {
@@ -403,6 +407,9 @@ class ToolLoopController:
     def record_result(self, decision: ToolCallDecision, result: Any) -> ToolCallCompletion:
         """Record a real tool execution and return model/frontend payload helpers."""
         result_text = result if isinstance(result, str) else str(result)
+        # Scrub garbage a fetch/subprocess can leave, so it neither shows on the tool card
+        # nor poisons the model's next prompt.
+        result_text = sanitize_control_chars(result_text)
         failed = is_tool_error(result_text)
         self._history.append(
             _ToolCallRecord(

--- a/studio/backend/tests/test_mtp_tool_markup_leak.py
+++ b/studio/backend/tests/test_mtp_tool_markup_leak.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Regression tests for the MTP GGUF tool-call garbage bug (issue #7084).
+
+On an MTP GGUF model, speculative decoding on a quantized target
+(ggml-org/llama.cpp#25618) emits byte-fallback garbage that llama-server forwards as
+U+FFFD plus an orphaned ``</tool_call>`` whose opener was drained/``�``-mangled;
+``strip_tool_markup`` had no arm for a bare orphan close, so the reporter saw
+``8��� </binary data> </tool_call>`` in chat.
+
+The scrub is centralized at the tool-call chokepoints, so these tests pin only those:
+
+  1. ``strip_tool_markup`` (finalized answer): scrubs U+FFFD / control chars and removes a
+     trailing orphan-close run, while keeping well-formed stripping and mid-prose literals.
+  2. ``strip_tool_markup_streaming`` (streaming display): the same scrub at the streaming
+     entry, so the live display agrees with the finalized answer.
+  3. ``sanitize_control_chars``: drops garbage but keeps ``\t \n \r`` / ESC.
+  4. ``ToolLoopController.record_result``: scrubs a tool result before the model/card.
+"""
+
+import pytest
+
+from core.inference.safetensors_agentic import strip_tool_markup_streaming
+from core.inference.tool_call_parser import sanitize_control_chars, strip_tool_markup
+from core.inference.tool_loop_controller import ToolCallDecision, ToolLoopController
+
+
+# -- sanitize_control_chars ------------------------------------------
+
+
+def test_sanitize_drops_replacement_and_control_chars():
+    assert sanitize_control_chars("8��� ok") == "8 ok"
+    assert sanitize_control_chars("a\x00b\x7fc\x9fd") == "abcd"
+
+
+def test_sanitize_keeps_tab_newline_cr_and_esc():
+    # ESC (\x1b) is preserved so terminal ANSI in a tool result survives.
+    assert sanitize_control_chars("a\tb\nc\r\n\x1b[0m") == "a\tb\nc\r\n\x1b[0m"
+
+
+def test_sanitize_noop_on_clean_text():
+    s = "Perfectly normal answer with a supplementary-plane char \U00020000 and kanji 美味しい."
+    assert sanitize_control_chars(s) == s
+
+
+# -- strip_tool_markup (finalized answer): the reporter's exact garbage --
+
+
+def test_reporter_garbage_is_cleaned():
+    # Exact string from issue #7084; before the fix both the U+FFFD and the orphan
+    # </tool_call> leaked.
+    out = strip_tool_markup("8��� </binary data> </tool_call>", final = True)
+    assert "�" not in out
+    assert "</tool_call>" not in out
+    # </binary data> is model-hallucinated prose, not a Studio token, so it is left as-is.
+    assert out == "8 </binary data>"
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("Here is the answer.</tool_call>", "Here is the answer."),
+        ("x<tool_call|>", "x"),
+        ("answer</function>\n</tool_call>", "answer"),  # nested leak run ending in </tool_call>
+        ("Here is the answer.</tool_call>\n", "Here is the answer."),  # trailing newline
+        ("8��� </tool_call>\n", "8"),  # reporter's garbage + trailing newline
+    ],
+)
+def test_trailing_orphan_closes_are_stripped_at_final(text, expected):
+    assert strip_tool_markup(text, final = True) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Done.</function>",  # lone close, no </tool_call> sentinel
+        "value</parameter>",
+        "The XML closing tag is </function>",  # a code/XML answer ending on a literal
+        "In XML you write <parameter>x</parameter> inside a tag.",  # mid-prose literal
+    ],
+)
+def test_trailing_literal_close_without_tool_call_survives(text):
+    # A trailing </function> / </parameter> with no </tool_call> sentinel reads as a
+    # code/XML literal, not a leak, so it survives (a real leak carries </tool_call>).
+    assert strip_tool_markup(text, final = True) == text
+
+
+def test_wellformed_call_still_stripped():
+    text = (
+        "Prefix <tool_call>\n<function=web_search>\n<parameter=query>\nx\n"
+        "</parameter>\n</function>\n</tool_call> suffix"
+    )
+    out = strip_tool_markup(text, final = True)
+    assert "<tool_call>" not in out and "</tool_call>" not in out
+    assert out == "Prefix  suffix"
+
+
+def test_streaming_pass_final_false_buffers_orphan_but_scrubs():
+    # final=False keeps in-progress markup buffered (orphan-run arm is end-of-turn only)
+    # but still scrubs U+FFFD.
+    assert strip_tool_markup("Here is the answer.</tool_call>", final = False) == (
+        "Here is the answer.</tool_call>"
+    )
+    assert "�" not in strip_tool_markup("hi � there", final = False)
+
+
+# -- strip_tool_markup_streaming (streaming display) chokepoint -------
+
+
+def test_streaming_strips_trailing_orphan_close():
+    # The MTP byte-fallback U+FFFD is scrubbed at the streaming entry, so the display strip
+    # sees a bare orphan close and removes it, matching strip_tool_markup(final=True).
+    assert strip_tool_markup_streaming("answer�</tool_call>") == "answer"
+    # A genuine complete call is still fully stripped (no under-strip regression).
+    assert strip_tool_markup_streaming('<tool_call>{"name":"x","arguments":{}}</tool_call>') == ""
+    # A lone </function> without a sentinel is kept (likely code/XML), not over-stripped.
+    assert strip_tool_markup_streaming("see </function> here") == "see </function> here"
+
+
+def test_streaming_entry_scrubs_control_chars_even_when_disabled():
+    # The entry scrub runs before the auto-heal gate, so byte-fallback garbage is dropped
+    # from streamed display even with stripping disabled.
+    out = strip_tool_markup_streaming(
+        "hi �\x00 there", auto_heal_tool_calls = False, tool_protocol_active = False
+    )
+    assert "�" not in out and "\x00" not in out
+
+
+def test_gguf_streaming_closure_wires_scrub_and_orphan_strip():
+    # The GGUF streaming stripper is a nested closure, so pin the fix by source: its entry must
+    # scrub control chars and its final-segment block must drop trailing orphan closes, matching
+    # the safetensors path and strip_tool_markup(final=True).
+    import inspect
+
+    from core.inference.llama_cpp import LlamaCppBackend
+
+    src = inspect.getsource(LlamaCppBackend.generate_chat_completion_with_tools)
+    assert "_sanitize_control_chars(text)" in src
+    assert "_strip_trailing_orphan_close_run(seg)" in src
+
+
+# -- record_result scrubs the tool result on both boundaries ---------
+
+
+def _decision(name = "web_search"):
+    return ToolCallDecision(
+        action = "execute",
+        tool_name = name,
+        arguments = {"query": "x"},
+        tool_call_id = "call_0",
+        key = f"{name}:{{}}",
+    )
+
+
+def test_record_result_scrubs_tool_result_for_model_and_display():
+    ctrl = ToolLoopController(tools = [{"function": {"name": "web_search"}}])
+    dirty = "Title: Page�� body\x00 text�"
+    completion = ctrl.record_result(_decision(), dirty)
+    # Fed back to the model:
+    assert "�" not in completion.model_message()["content"]
+    assert "\x00" not in completion.model_message()["content"]
+    # Shown in the tool card:
+    assert "�" not in completion.tool_end_payload()["result"]
+    assert completion.result == "Title: Page body text"
+
+
+def test_record_result_keeps_clean_result_intact():
+    ctrl = ToolLoopController(tools = [{"function": {"name": "web_search"}}])
+    clean = "Title: Florida ACA 2026\nSilver premium: $1,900/mo"
+    completion = ctrl.record_result(_decision(), clean)
+    assert completion.result == clean
+
+
+# -- Kimi + DeepSeek end-of-turn closers belong to the orphan-close set --
+#
+# ``_ORPHAN_CLOSE_TOKENS`` / ``_ORPHAN_SENTINELS`` also list the Kimi
+# ``<|tool_call_end|><|tool_calls_section_end|>`` and DeepSeek
+# ``<tool_call_end><tool_calls_end>`` closers: back-to-back special tokens, never legit
+# prose, so a run whose opener was drained/U+FFFD-mangled is scrubbed like ``</tool_call>``.
+
+
+def _kimi_deepseek_tokens():
+    from core.inference.tool_call_parser import (
+        _DEEPSEEK_CALL_END,
+        _DEEPSEEK_END,
+        _KIMI_CALL_END,
+        _KIMI_SECTION_END,
+    )
+    return _KIMI_CALL_END, _KIMI_SECTION_END, _DEEPSEEK_CALL_END, _DEEPSEEK_END
+
+
+def test_kimi_and_deepseek_trailing_closers_stripped_at_final():
+    kimi_end, kimi_section_end, ds_call_end, ds_end = _kimi_deepseek_tokens()
+    assert strip_tool_markup("answer " + kimi_end + kimi_section_end, final = True) == "answer"
+    assert strip_tool_markup("answer " + ds_call_end + ds_end, final = True) == "answer"
+
+
+def test_kimi_and_deepseek_closers_stripped_in_streaming():
+    kimi_end, kimi_section_end, ds_call_end, ds_end = _kimi_deepseek_tokens()
+    assert strip_tool_markup_streaming("answer" + kimi_end + kimi_section_end) == "answer"
+    assert strip_tool_markup_streaming("answer" + ds_call_end + ds_end) == "answer"
+
+
+def test_kimi_closer_in_mid_prose_survives():
+    # Only TRAILING orphans are stripped: a token embedded in prose (with real text after) is
+    # not a trailing run, so a plain answer is never over-stripped.
+    kimi_end, *_ = _kimi_deepseek_tokens()
+    text = "the token " + kimi_end + " appears mid sentence"
+    assert strip_tool_markup(text, final = True) == text


### PR DESCRIPTION
## Problem

On an MTP GGUF model with tools or thinking enabled, the chat could show garbage: a stray closing tag like `</tool_call>` or `</binary data>` leaking into the message, and a replacement character where a token failed to decode. MTP speculative decoding on a quantized target intermittently emits byte-fallback tokens that render as U+FFFD, and one of those can mangle a `<tool_call>` opener while its intact closing tag still lands on the content channel, so the close leaks. The stray character also fed back into the next prompt and pushed the model further off track.

## Fix

- Add a trailing orphan-close strip arm to `strip_tool_markup` that removes a run of closing tool-call tags whose opener never arrived. It is anchored to the end of the turn so a literal `</function>` in prose survives, mirroring the route-level regex.
- Sanitize U+FFFD and control characters on display (content and the reasoning channel, which bypasses the markup strip) and in tool results before they are fed back to the model. Tab, newline, return and ESC are kept, so terminal output in a tool result is untouched.

## Verification

New `studio/backend/tests/test_mtp_tool_markup_leak.py` (15 tests) covers the reporter's exact string, orphan-close runs, the conservative contract (a literal close in prose is kept), and result scrubbing on both boundaries. Reproduced live on an MTP GGUF: the plain and search flows now return clean output. The wider backend suites stay green.

## Compatibility

The strip only adds removal of end-of-turn orphan closes and U+FFFD/control characters; well-formed tool calls and mid-prose literals are untouched, and non-MTP models, non-tool chat and other model families are unaffected.

## Note

This addresses the visible garbage. The separate case where a search agent returns an empty answer and must be re-prompted is dominated by upstream MTP quantized-target degradation plus tool-result context budgeting, and is not part of this change.
