### PR TITLE
Studio: do not show Run for embedding-only non-GGUF models in the Model Hub

### DIFF
--- a/studio/frontend/src/features/hub/catalog/model-inspector.tsx
+++ b/studio/frontend/src/features/hub/catalog/model-inspector.tsx
@@ -531,11 +531,26 @@ export const ModelInspector = memo(function ModelInspector({
     ? formatCompact(model.totalParams)
     : "N/A";
   const unslothSupported = unslothSupport.status !== "unsupported";
+  // Embedding-only non-GGUF repos classify as supported but have no generative
+  // head, so a chat load dead-ends. Keep them out of the non-GGUF Run gate.
+  const isEmbeddingOnly =
+    !model.isGguf &&
+    model.capabilities.some((c) => c.key === "embedding") &&
+    !model.capabilities.some(
+      (c) =>
+        c.key === "conversational" ||
+        c.key === "tools" ||
+        c.key === "reasoning" ||
+        c.key === "code" ||
+        c.key === "vision" ||
+        c.key === "audio",
+    );
   // Chat-only hosts (no supported GPU / usable MLX) run inference only through
   // llama.cpp, so only GGUF is loadable.
   const canRunModel =
     !isDataset &&
     (model.runtimeCapabilities?.canChat ?? true) &&
+    !isEmbeddingOnly &&
     (model.isGguf || (!chatOnly && unslothSupported));
   const canTrainModel =
     !isDataset &&

--- a/studio/frontend/src/features/hub/catalog/model-inspector.tsx
+++ b/studio/frontend/src/features/hub/catalog/model-inspector.tsx
@@ -59,6 +59,16 @@ import { ModelReadme } from "./model-readme";
 import { OwnerAvatar } from "./owner-avatar";
 import { AccessChip, CapabilityPill } from "./shared";
 
+// HF pipeline_tag values that denote an embedding / feature-extraction repo with
+// no generative head. Authoritative for the Run gate: topical capability labels
+// (code / vision / audio / reasoning) attach to embedding repos from their name
+// or tags (e.g. jina-embeddings-v2-base-code gets "code" from its -code suffix),
+// so they cannot be trusted to exempt a model from the gate.
+const EMBEDDING_PIPELINE_TAGS: ReadonlySet<string> = new Set([
+  "feature-extraction",
+  "sentence-similarity",
+]);
+
 function ViewRepositoryButton({
   repoId,
   isDataset,
@@ -532,19 +542,23 @@ export const ModelInspector = memo(function ModelInspector({
     : "N/A";
   const unslothSupported = unslothSupport.status !== "unsupported";
   // Embedding-only non-GGUF repos classify as supported but have no generative
-  // head, so a chat load dead-ends. Keep them out of the non-GGUF Run gate.
+  // head, so a chat load dead-ends. Keep them out of the non-GGUF Run gate. An
+  // embedding pipeline tag is authoritative (no generative head even when the
+  // repo name/tags also imply code/vision/audio/reasoning); otherwise fall back
+  // to the capability heuristic.
   const isEmbeddingOnly =
     !model.isGguf &&
     model.capabilities.some((c) => c.key === "embedding") &&
-    !model.capabilities.some(
-      (c) =>
-        c.key === "conversational" ||
-        c.key === "tools" ||
-        c.key === "reasoning" ||
-        c.key === "code" ||
-        c.key === "vision" ||
-        c.key === "audio",
-    );
+    (EMBEDDING_PIPELINE_TAGS.has(model.pipelineTag?.toLowerCase() ?? "") ||
+      !model.capabilities.some(
+        (c) =>
+          c.key === "conversational" ||
+          c.key === "tools" ||
+          c.key === "reasoning" ||
+          c.key === "code" ||
+          c.key === "vision" ||
+          c.key === "audio",
+      ));
   // Chat-only hosts (no supported GPU / usable MLX) run inference only through
   // llama.cpp, so only GGUF is loadable.
   const canRunModel =

--- a/studio/frontend/src/features/hub/catalog/model-inspector.tsx
+++ b/studio/frontend/src/features/hub/catalog/model-inspector.tsx
@@ -59,9 +59,8 @@ import { ModelReadme } from "./model-readme";
 import { OwnerAvatar } from "./owner-avatar";
 import { AccessChip, CapabilityPill } from "./shared";
 
-// HF pipeline_tag values for embedding/feature-extraction repos with no
-// generative head. Authoritative for the Run gate: capability labels like
-// code/vision/audio can leak onto embedding repos from their name or tags.
+// HF pipeline_tag values authoritative for embedding-only repos; capability
+// labels (code/vision/audio) can leak onto them via name or tags.
 const EMBEDDING_PIPELINE_TAGS: ReadonlySet<string> = new Set([
   "feature-extraction",
   "sentence-similarity",
@@ -539,9 +538,8 @@ export const ModelInspector = memo(function ModelInspector({
     ? formatCompact(model.totalParams)
     : "N/A";
   const unslothSupported = unslothSupport.status !== "unsupported";
-  // Embedding-only non-GGUF repos classify as supported but have no generative
-  // head, so a chat load dead-ends. Keep them out of the Run gate: an embedding
-  // pipeline tag is authoritative, else fall back to the capability heuristic.
+  // Embedding-only non-GGUF repos have no generative head, so keep them out of
+  // the Run gate. Prefer the pipeline tag, else the capability heuristic.
   const isEmbeddingOnly =
     !model.isGguf &&
     model.capabilities.some((c) => c.key === "embedding") &&

--- a/studio/frontend/src/features/hub/catalog/model-inspector.tsx
+++ b/studio/frontend/src/features/hub/catalog/model-inspector.tsx
@@ -59,11 +59,9 @@ import { ModelReadme } from "./model-readme";
 import { OwnerAvatar } from "./owner-avatar";
 import { AccessChip, CapabilityPill } from "./shared";
 
-// HF pipeline_tag values that denote an embedding / feature-extraction repo with
-// no generative head. Authoritative for the Run gate: topical capability labels
-// (code / vision / audio / reasoning) attach to embedding repos from their name
-// or tags (e.g. jina-embeddings-v2-base-code gets "code" from its -code suffix),
-// so they cannot be trusted to exempt a model from the gate.
+// HF pipeline_tag values for embedding/feature-extraction repos with no
+// generative head. Authoritative for the Run gate: capability labels like
+// code/vision/audio can leak onto embedding repos from their name or tags.
 const EMBEDDING_PIPELINE_TAGS: ReadonlySet<string> = new Set([
   "feature-extraction",
   "sentence-similarity",
@@ -542,10 +540,8 @@ export const ModelInspector = memo(function ModelInspector({
     : "N/A";
   const unslothSupported = unslothSupport.status !== "unsupported";
   // Embedding-only non-GGUF repos classify as supported but have no generative
-  // head, so a chat load dead-ends. Keep them out of the non-GGUF Run gate. An
-  // embedding pipeline tag is authoritative (no generative head even when the
-  // repo name/tags also imply code/vision/audio/reasoning); otherwise fall back
-  // to the capability heuristic.
+  // head, so a chat load dead-ends. Keep them out of the Run gate: an embedding
+  // pipeline tag is authoritative, else fall back to the capability heuristic.
   const isEmbeddingOnly =
     !model.isGguf &&
     model.capabilities.some((c) => c.key === "embedding") &&


### PR DESCRIPTION
## Problem

Follow-up to #7001. That change gated the non-GGUF Run button on host capability and format support, which is correct for generative models. But a downloaded embedding-only repo (for example a sentence-transformers or feature-extraction model) reports `canChat` by safetensors format and classifies as supported, so the Model Hub still shows an enabled Run button that dead-ends when the loader tries to start a chat on a model with no generative head.

## Fix

Treat an embedding-only non-GGUF model (has an embedding capability and none of conversational, tools, reasoning, code, vision or audio) as not runnable, and keep it out of the Run gate. GGUF is unaffected, since llama.cpp resolves embed vs generate at load time. This only touches the Run affordance; the model stays trainable, so the shared train gate is untouched.

## Verification

The gating predicate was checked against embedding-only, chat, hybrid, GGUF and CPU-only cases; the enabled-Run set now matches what actually loads, and the previously dead-ending embedding-only case is disabled. Frontend only, scoped to the Model Hub card.

## Compatibility

Additive guard on the existing predicate; no change to GGUF, chat or hybrid models, and the train gate is unaffected.
