### PR TITLE
Studio: guard project chat rename against IME composition keys

### DIFF
--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -1111,9 +1111,17 @@ function ProjectLanding({
                               setRenameDraft(event.target.value)
                             }
                             onKeyDown={(event) => {
+                              // Ignore keydowns fired mid-IME-composition (CJK)
+                              // so a candidate-confirming Enter or candidate-
+                              // cancelling Escape does not commit/cancel the
+                              // rename. Guard before the key branch so Escape is
+                              // covered too (isComposing on WebKit, 229 on Chromium).
+                              if (
+                                event.nativeEvent.isComposing ||
+                                event.keyCode === 229
+                              )
+                                return;
                               if (event.key === "Enter") {
-                                if (event.nativeEvent.isComposing || event.keyCode === 229)
-                                  return;
                                 event.preventDefault();
                                 skipRenameBlurRef.current = true;
                                 void commitRename(item);


### PR DESCRIPTION
## Problem

Follow-up to #7005. The project chat rename input guarded only the Enter that confirms an IME candidate, so on WebKit an Escape that cancels a candidate mid-composition also cancelled the rename. Composing a CJK title and pressing Escape to drop a candidate would lose the edit.

## Fix

Move the composition guard ahead of the key branch so both Enter and Escape are ignored while a candidate is being composed (`isComposing` on WebKit, keyCode 229 on Chromium). Non-IME input is unchanged: a real Enter still commits and a real Escape still cancels.

## Verification

Checked against the rename state machine: while composing, neither Enter nor Escape commits or cancels; outside composition both behave as before. Frontend only, scoped to the rename input.

## Compatibility

No behaviour change for non-IME input; only reorders where the existing composition check runs.
