### PR TITLE
Restore the inheritance-before-guard ordering assertion in the gguf order test

### DIFF
--- a/studio/backend/tests/test_gguf_load_cache_reuse.py
+++ b/studio/backend/tests/test_gguf_load_cache_reuse.py
@@ -730,9 +730,12 @@ class TestLoadHubDownloadExclusion:
 
         # The gguf_load_in_flight marker must be entered before the hub-download
         # guard and the unload so a concurrent load can't race the download
-        # manager. The llama_extra_args inheritance that used to sit between the
-        # marker and the guard now runs in _guard_chat_load_against_training, ahead
-        # of the GGUF branch, so it is no longer a landmark inside this slice.
+        # manager. The llama_extra_args inheritance moved out of the branch into
+        # _resolve_inherited_extra_args, which must still run BEFORE it: the
+        # inherited value (e.g. a carried --no-mmproj) shapes the guard's
+        # require_mmproj. Anchor on the call form so the assertion pins the
+        # endpoint's call site, not the function definition.
+        assert source.index("= _resolve_inherited_extra_args(") < source.index("if config.is_gguf:")
         assert (
             gguf_branch.index("enter_context(gguf_load_in_flight")
             < gguf_branch.index("_hub_download_blocks_gguf_load")


### PR DESCRIPTION
## What

Restores the ordering assertion that the gguf order fix on main dropped: `_resolve_inherited_extra_args` must run before the GGUF branch, because the inherited `llama_extra_args` (a carried `--no-mmproj`) shapes the hub guard's `require_mmproj`. Without it a future reorder could reject a load over an mmproj download the inherited arguments would disable.

## How

- Anchored on the call form `= _resolve_inherited_extra_args(` so the assertion pins the endpoint's call site; the bare name would match the function definition, which always precedes the endpoint, making the check vacuous.
- Corrected the comment that misattributed the inheritance site to `_guard_chat_load_against_training`.

Full file passes: 32 tests. This PR was rebased onto current main; it now contains only this restoration.