### PR TITLE
Studio: fix stale GGUF load-marker ordering test after llama_extra_args relocation

### DIFF
--- a/studio/backend/tests/test_gguf_load_cache_reuse.py
+++ b/studio/backend/tests/test_gguf_load_cache_reuse.py
@@ -728,9 +728,13 @@ class TestLoadHubDownloadExclusion:
         source = (Path(__file__).resolve().parent.parent / "routes" / "inference.py").read_text()
         gguf_branch = source[source.index("if config.is_gguf:") :]
 
+        # The gguf_load_in_flight marker must be entered before the hub-download
+        # guard and the unload so a concurrent load can't race the download
+        # manager. The llama_extra_args inheritance that used to sit between the
+        # marker and the guard now runs in _guard_chat_load_against_training, ahead
+        # of the GGUF branch, so it is no longer a landmark inside this slice.
         assert (
             gguf_branch.index("enter_context(gguf_load_in_flight")
-            < gguf_branch.index("if request.llama_extra_args is None")
             < gguf_branch.index("_hub_download_blocks_gguf_load")
             < gguf_branch.index("unsloth_backend.unload_model")
         )


### PR DESCRIPTION
#6414 relocated the llama_extra_args inheritance block out of the GGUF branch in `_load_model_impl` and into `_guard_chat_load_against_training`, which runs before the branch. `test_load_marker_precedes_hub_guard_and_unload` slices `routes/inference.py` from `if config.is_gguf:` to the end and asserts an ordering that still lists `if request.llama_extra_args is None` as a landmark, which now sits ahead of that slice, so `str.index` raises `ValueError: substring not found`.

The Backend tests job only runs on pull_request, not on push to main, so main went red on this test without surfacing on the default branch. It fails the (Python 3.10) Backend tests job on every open PR whose merge picks up the relocation.

The guarantee the test protects is intact: the `gguf_load_in_flight` marker is entered before the hub-download guard and the unload. This drops the relocated landmark from the ordering so the assertion matches the current structure, and adds a short comment noting where the inheritance now runs.

Verified locally: `test_gguf_load_cache_reuse.py::TestLoadHubDownloadExclusion` -> 10 passed.