### PR TITLE
Studio: lock the last enabled GPU switch instead of silently ignoring it

### DIFF
--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -723,11 +723,11 @@ export function ChatSettingsPanel({
   const autoLayers = isManual && gpuLayers < 0;
   // GPUs actually in use: the picked subset, or all visible when none picked.
   const gpusInUse = selectedGpuIds ?? gpuDevices.map((d) => d.index);
-  // TP is off with fewer than 2 GPUs in use (single GPU, or the picker narrowed
-  // to one): tensor split is a no-op there and aborts on some archs. Mirrors the
-  // multi-GPU gate on the GPU picker / Split ratio. (Under Auto layers the whole
-  // TP control is hidden -- llama.cpp's --fit aborts under --split-mode tensor.)
-  const tpDisabled = gpusInUse.length <= 1;
+  // The picker must keep one GPU selected.
+  const singleGpuInUse = gpusInUse.length <= 1;
+  // TP needs at least two GPUs because tensor split is a no-op on one and may
+  // abort. Auto layers hides TP because --fit aborts under --split-mode tensor.
+  const tpDisabled = singleGpuInUse;
   // Manual gpu-layers ceiling = model layer count + 1 (else a safe fallback):
   // llama.cpp counts the output layer as one more offloadable layer past the
   // repeating blocks ("offloaded 33/33" needs -ngl 33 on a 32-block model), so
@@ -1537,7 +1537,7 @@ export function ChatSettingsPanel({
                         Which GPUs this model may use. Unchecked GPUs are hidden
                         from llama.cpp (CUDA_VISIBLE_DEVICES, or
                         HIP_VISIBLE_DEVICES on ROCm). Leave all checked to use
-                        every GPU.
+                        every GPU. At least one GPU must stay selected.
                       </InfoHint>
                     </div>
                     <div className="flex flex-col gap-2">
@@ -1557,7 +1557,10 @@ export function ChatSettingsPanel({
                             checked={isGpuChecked(d.index)}
                             onCheckedChange={() => toggleGpu(d.index)}
                             data-test-id={`gpu-pick-${d.index}`}
-                            disabled={modelControlsDisabled}
+                            disabled={
+                              modelControlsDisabled ||
+                              (isGpuChecked(d.index) && singleGpuInUse)
+                            }
                           />
                         </div>
                       ))}


### PR DESCRIPTION
Closes #7254

On a multi-GPU host, the GGUF GPU picker in Chat settings lets you uncheck GPUs to narrow which devices llama.cpp uses. `toggleGpu` keeps at least one GPU selected (`if (next.length === 0) return;`), but the last-enabled switch was still rendered fully interactive. Clicking it did nothing and gave no feedback, so the switch read as broken.

## Fix

Disable the switch of the last-remaining selected GPU so the constraint is visible instead of silent. This mirrors the sibling Tensor Parallelism switch, which already greys out when only one GPU is in use. The `next.length === 0` guard stays as the correctness backstop. This change is purely the missing visual affordance.

The single-GPU-in-use predicate shared by both controls is extracted to `singleGpuInUse` (previously inline in `tpDisabled`), so the picker and TP gate can't drift apart.

The InfoHint gains one sentence: "At least one GPU must stay selected."

## Behavior boundaries

- All GPUs checked (default): every switch stays enabled, so any one can be unchecked.
- Narrowed to one GPU: only that GPU's switch locks on. The unchecked ones stay enabled, so you can re-add a device or swap which one is active.
- CPU-only offload is unchanged and remains its own control (GPU Memory = Manual, GPU Layers = 0). The picker never claimed to do it.

## Verification

`tsc -b` and eslint on the changed file pass with no new findings. The file's pre-existing lint warnings are untouched.
