### PR TITLE
Studio (Windows): keep prompt caching on full GPU offload

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -7563,8 +7563,9 @@ class LlamaCppBackend:
                 else:
                     self._api_key = None
 
-                # Windows + full offload: disable KV checkpoints (WDDM/PCI-E
-                # overhead). CPU/partial offload keeps prompt caching. #5692.
+                # Windows + full offload: drop the host-RAM KV checkpoints that cause
+                # WDDM/PCI-E overhead, but keep prompt caching (in-VRAM prefix reuse) so
+                # a repeated prompt is not re-prefilled on every request. #5692.
                 if sys.platform == "win32" and full_offload_tuning_active:
                     unsupported_cache_flags: list[str] = []
                     if server_caps.get("supports_cache_ram"):
@@ -7575,11 +7576,6 @@ class LlamaCppBackend:
                         cmd.extend(["--ctx-checkpoints", "0"])
                     else:
                         unsupported_cache_flags.append("--ctx-checkpoints")
-                    if server_caps.get("supports_no_cache_prompt"):
-                        cmd.append("--no-cache-prompt")
-                        self._prompt_cache_disabled = True
-                    else:
-                        unsupported_cache_flags.append("--no-cache-prompt")
                     if unsupported_cache_flags:
                         logger.info(
                             "Skipping unsupported Windows cache flags for llama-server: %s",

--- a/studio/backend/tests/test_llama_cpp_mtp_detection.py
+++ b/studio/backend/tests/test_llama_cpp_mtp_detection.py
@@ -362,15 +362,14 @@ _LIST_MUTATORS = frozenset({"append", "extend", "insert"})
 
 def _has_flag_literal(node: ast.AST) -> bool:
     return any(
-        isinstance(n, ast.Constant) and n.value == _NO_CACHE_PROMPT_FLAG
-        for n in ast.walk(node)
+        isinstance(n, ast.Constant) and n.value == _NO_CACHE_PROMPT_FLAG for n in ast.walk(node)
     )
 
 
 def _no_cache_prompt_injections(source: str, filename: str) -> list[tuple[str, int]]:
     """(file, lineno) for each spot adding --no-cache-prompt to a list."""
     hits: list[tuple[str, int]] = []
-    for node in ast.walk(ast.parse(source, filename=filename)):
+    for node in ast.walk(ast.parse(source, filename = filename)):
         # cmd.append/extend/insert(... flag ...) or cmd += [... flag ...]
         if (
             isinstance(node, ast.Call)
@@ -392,9 +391,7 @@ def test_unsloth_never_injects_no_cache_prompt_into_any_command():
     violations: list[tuple[str, int]] = []
     for path in files:
         try:
-            violations += _no_cache_prompt_injections(
-                path.read_text(encoding="utf-8"), str(path)
-            )
+            violations += _no_cache_prompt_injections(path.read_text(encoding = "utf-8"), str(path))
         except (OSError, UnicodeDecodeError, SyntaxError):
             continue
     assert files, "no backend source files were scanned"

--- a/studio/backend/tests/test_llama_cpp_mtp_detection.py
+++ b/studio/backend/tests/test_llama_cpp_mtp_detection.py
@@ -345,7 +345,9 @@ def test_windows_full_offload_flags_use_current_llama_server_args():
     stale_checkpoint_flag = "--checkpoint-" + "every-n-tokens"
     assert '"--cache-ram"' in src
     assert '"--ctx-checkpoints"' in src
-    assert '"--no-cache-prompt"' in src
+    # Prompt caching stays on (in-VRAM prefix reuse); #5692 only needed the host-RAM
+    # checkpoints (--cache-ram / --ctx-checkpoints) disabled, not prompt reuse.
+    assert '"--no-cache-prompt"' not in src
     assert stale_checkpoint_flag not in src
 
 

--- a/studio/backend/tests/test_llama_cpp_mtp_detection.py
+++ b/studio/backend/tests/test_llama_cpp_mtp_detection.py
@@ -9,6 +9,7 @@ the _already_in_target_state mirror that prevents needless reloads.
 
 from __future__ import annotations
 
+import ast
 import inspect
 import os
 import struct
@@ -349,6 +350,59 @@ def test_windows_full_offload_flags_use_current_llama_server_args():
     # checkpoints (--cache-ram / --ctx-checkpoints) disabled, not prompt reuse.
     assert '"--no-cache-prompt"' not in src
     assert stale_checkpoint_flag not in src
+
+
+# Backend-wide guard: Unsloth must never inject --no-cache-prompt into a llama-server
+# command. It disables in-VRAM prompt-prefix reuse, re-prefilling every repeated prompt
+# (#5692 only needed --cache-ram / --ctx-checkpoints off; #7260 dropped the stray flag).
+# Detecting it (_is_real) or honouring a user-supplied one (_prompt_cache_off) is fine.
+_NO_CACHE_PROMPT_FLAG = "--no-cache-prompt"
+_LIST_MUTATORS = frozenset({"append", "extend", "insert"})
+
+
+def _has_flag_literal(node: ast.AST) -> bool:
+    return any(
+        isinstance(n, ast.Constant) and n.value == _NO_CACHE_PROMPT_FLAG
+        for n in ast.walk(node)
+    )
+
+
+def _no_cache_prompt_injections(source: str, filename: str) -> list[tuple[str, int]]:
+    """(file, lineno) for each spot adding --no-cache-prompt to a list."""
+    hits: list[tuple[str, int]] = []
+    for node in ast.walk(ast.parse(source, filename=filename)):
+        # cmd.append/extend/insert(... flag ...) or cmd += [... flag ...]
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in _LIST_MUTATORS
+            and any(_has_flag_literal(a) for a in node.args)
+        ) or (
+            isinstance(node, ast.AugAssign)
+            and isinstance(node.op, ast.Add)
+            and _has_flag_literal(node.value)
+        ):
+            hits.append((filename, node.lineno))
+    return hits
+
+
+def test_unsloth_never_injects_no_cache_prompt_into_any_command():
+    root = Path(_BACKEND_DIR)
+    files = [p for p in root.rglob("*.py") if "tests" not in p.relative_to(root).parts]
+    violations: list[tuple[str, int]] = []
+    for path in files:
+        try:
+            violations += _no_cache_prompt_injections(
+                path.read_text(encoding="utf-8"), str(path)
+            )
+        except (OSError, UnicodeDecodeError, SyntaxError):
+            continue
+    assert files, "no backend source files were scanned"
+    assert violations == [], (
+        "Unsloth must never add --no-cache-prompt to a llama-server command "
+        "(it disables prompt-prefix reuse); detecting or honouring a user-supplied "
+        f"one is fine. Offending sites: {violations}"
+    )
 
 
 def test_load_model_sets_threads_once():


### PR DESCRIPTION
## Summary

The Windows full-offload tuning from #5692 disables host-RAM KV checkpoints (`--cache-ram 0`, `--ctx-checkpoints 0`) to avoid WDDM/PCI-E overhead, which is correct. It also adds `--no-cache-prompt`, and that one is an overreach: it turns off in-VRAM prompt-prefix reuse, a different feature. For a fully offloaded model the KV cache lives in VRAM, so reusing a common prefix does not copy anything to system RAM and does not cause the PCI-E overhead #5692 was about.

The side effect is that llama-server re-prefills the entire prompt on every request. It is barely noticeable for short single-turn chats, but severe for a large, stable system prompt reused across many calls (coding agents via `unsloth start`, long multi-turn chats). In testing, one short turn re-prefilled about 79k prompt tokens.

This affects all Windows full-offload GGUF inference (Studio UI chat, `unsloth start` agents, direct API), so it is not agent-specific.

## Change

Drop `--no-cache-prompt` from the `win32 and full_offload_tuning_active` branch in `studio/backend/core/inference/llama_cpp.py`. Keep `--cache-ram 0` and `--ctx-checkpoints 0` (the flags that actually address #5692) and the OMP / thread tuning. `_prompt_cache_disabled` therefore stays `False` (its default), so slot save/restore continues to work.

## Verification

Fully offloaded gemma GGUF, the same prompt sent twice with prompt caching on, then once with it off:

| request | cache_prompt | prompt tokens prefilled |
| --- | --- | --- |
| 1 (cold) | on | 2220 |
| 2 (repeat) | on | 1 |
| 3 (repeat) | off | 2220 |

A repeated prompt is reused (2220 to 1) instead of fully re-prefilled. Backend tests pass (`studio/backend/tests`: 404 passed, 13 skipped), including the updated `test_windows_full_offload_flags_use_current_llama_server_args`, which now asserts `--no-cache-prompt` is not added.
