### PR TITLE
Studio: don't let a malformed HF token empty the model picker's Recommended list

### DIFF
--- a/studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx
+++ b/studio/frontend/src/components/assistant-ui/model-selector/pickers.tsx
@@ -47,7 +47,7 @@ import {
 import { useOnlineStatus } from "@/features/hub/hooks/use-online-status";
 import { isHiddenModelId } from "@/features/hub/lib/hidden-models";
 import { classifyUnslothSupport } from "@/features/hub/lib/unsloth-support";
-import { useHfTokenStore } from "@/features/hub/stores/hf-token-store";
+import { hfApiToken, useHfTokenStore } from "@/features/hub/stores/hf-token-store";
 import {
   downloadManager,
   jobKeyOf,
@@ -1411,7 +1411,8 @@ export function HubModelPicker({
   // Shared Hub search stack (the same hooks the Hub page uses) so the picker
   // and Hub run one implementation. Scoped to unsloth like the old listing.
   const online = useOnlineStatus();
-  const accessToken = hfToken || undefined;
+  // Sanitize to anonymous on a malformed token, matching the Hub page.
+  const accessToken = hfApiToken(hfToken);
   // Recommended section: a live unsloth listing sorted by the dropdown. The
   // same sort drives the search results so the dropdown works while searching.
   const [recommendedSort, setRecommendedSort] =


### PR DESCRIPTION
The "Select model" picker's Recommended list calls Hugging Face's `listModels` from the browser with the saved token. A malformed token (anything not starting with `hf_`) makes `@huggingface/hub` throw before it even sends a request, and the picker renders that failure as "No models found". The Hub page already runs the token through `hfApiToken()` first, so it stays populated; the picker passed the raw token, so only the picker broke.

## Fix

Route the picker's `accessToken` through `hfApiToken()` too, matching the Hub page. A malformed token now falls back to anonymous browsing, so the public Unsloth listing still shows.

The gap dates to #6364/#6605, when the picker adopted the shared search stack but the `hfApiToken()` sanitizer was wired only into the Hub page. Not a regression from #7261.

## Verification

`tsc -b` and eslint on the changed file pass. A valid or even expired `hf_` token was never affected, since HF serves the public listing anonymously either way; only a non-`hf_` token hit this.
