### PR TITLE
Studio: show HF token tick only after validation

### DIFF
--- a/studio/frontend/src/features/settings/tabs/general-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/general-tab.tsx
@@ -223,12 +223,13 @@ export function GeneralTab() {
     setHfToken("");
   };
 
-  // Show an "accepted" tick once a non-empty token has been committed to the
-  // store and the field still matches it (i.e. not mid-edit). Gives the user
-  // feedback that a pasted token was saved.
-  const tokenSaved =
+  // Only show the success tick for the currently displayed token after the
+  // authenticated validation endpoint has confirmed it. A saved token alone
+  // may still be malformed, expired, or revoked.
+  const tokenIsCurrent =
     draftToken.trim().length > 0 && draftToken.trim() === (hfToken ?? "");
   const tokenValidation = useHfTokenValidation(hfToken ?? "");
+  const tokenValidated = tokenIsCurrent && tokenValidation.isValid === true;
 
   useEffect(() => {
     let cancelled = false;
@@ -520,16 +521,16 @@ export function GeneralTab() {
                   onBlur={commitToken}
                   className={cn(
                     "h-8 w-full font-mono text-xs",
-                    tokenSaved ? "pr-14" : "pr-8",
+                    tokenValidated ? "pr-14" : "pr-8",
                   )}
                 />
-                {tokenSaved ? (
+                {tokenValidated ? (
                   // Decorative: pointer-events-none lets clicks reach the input
                   // underneath so the field still focuses anywhere.
                   <span
                     className="pointer-events-none absolute right-7 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center text-emerald-600 duration-150 animate-in fade-in zoom-in dark:text-emerald-500"
                     role="img"
-                    aria-label={t("settings.general.tokenSaved")}
+                    aria-label={t("settings.general.tokenValidated")}
                   >
                     <Check className="size-4" strokeWidth={2.5} />
                   </span>

--- a/studio/frontend/src/hooks/use-hf-token-validation.ts
+++ b/studio/frontend/src/hooks/use-hf-token-validation.ts
@@ -36,10 +36,8 @@ const COMPLETE_HF_TOKEN = /^hf_[A-Za-z0-9]{34}$/;
  * requests while typing. isValid is null until checked.
  */
 export function useHfTokenValidation(token: string): HfTokenValidationState {
-  const debouncedToken = useDebouncedValue(
-    token.trim().replace(/^["']+|["']+$/g, ""),
-    500,
-  );
+  const normalizedToken = token.trim().replace(/^["']+|["']+$/g, "");
+  const debouncedToken = useDebouncedValue(normalizedToken, 500);
   const [completed, setCompleted] = useState<CompletedValidation>(
     NO_COMPLETED_VALIDATION,
   );
@@ -83,7 +81,8 @@ export function useHfTokenValidation(token: string): HfTokenValidationState {
           setCompleted({
             token: debouncedToken,
             isValid: null,
-            error: "Could not verify the token. Check your connection and try again.",
+            error:
+              "Could not verify the token. Check your connection and try again.",
             isChecking: false,
           });
         }
@@ -93,15 +92,16 @@ export function useHfTokenValidation(token: string): HfTokenValidationState {
         setCompleted({
           token: debouncedToken,
           isValid: null,
-          error: "Could not verify the token. Check your connection and try again.",
+          error:
+            "Could not verify the token. Check your connection and try again.",
           isChecking: false,
         });
       },
     );
   }, [debouncedToken, shouldValidate]);
 
-  if (!shouldValidate) return INITIAL;
-  if (completed.token !== debouncedToken) {
+  if (!COMPLETE_HF_TOKEN.test(normalizedToken)) return INITIAL;
+  if (completed.token !== normalizedToken) {
     return { isValid: null, error: null, isChecking: true };
   }
   return {

--- a/studio/frontend/src/i18n/locales/ar.ts
+++ b/studio/frontend/src/i18n/locales/ar.ts
@@ -111,7 +111,7 @@ export const ar = {
         "يُستخدم لتحميل النماذج المقيّدة ورفع المخرجات.",
       hideToken: "إخفاء التوكن",
       showToken: "إظهار التوكن",
-      tokenSaved: "تم حفظ التوكن",
+      tokenValidated: "تم التحقق من الرمز",
       password: "كلمة المرور",
       passwordDescription: "تغيير كلمة المرور لحساب Unsloth هذا.",
       passwordDialog: {

--- a/studio/frontend/src/i18n/locales/de.ts
+++ b/studio/frontend/src/i18n/locales/de.ts
@@ -112,7 +112,7 @@ export const de = {
         "Wird verwendet, um gated Modelle zu laden und Artefakte zu pushen.",
       hideToken: "Token verbergen",
       showToken: "Token anzeigen",
-      tokenSaved: "Token gespeichert",
+      tokenValidated: "Token validiert",
       password: "Passwort",
       passwordDescription:
         "Ändern Sie das Passwort für dieses Unsloth-Konto.",

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -182,7 +182,7 @@ export const en = {
         "Used to load gated models and push artifacts.",
       hideToken: "Hide token",
       showToken: "Show token",
-      tokenSaved: "Token saved",
+      tokenValidated: "Token validated",
       password: "Password",
       passwordDescription: "Change the password for this Unsloth account.",
       passwordDialog: {

--- a/studio/frontend/src/i18n/locales/es.ts
+++ b/studio/frontend/src/i18n/locales/es.ts
@@ -112,7 +112,7 @@ export const es = {
         "Se usa para cargar modelos restringidos y subir artefactos.",
       hideToken: "Ocultar token",
       showToken: "Mostrar token",
-      tokenSaved: "Token guardado",
+      tokenValidated: "Token validado",
       password: "Contraseña",
       passwordDescription:
         "Cambia la contraseña de esta cuenta de Unsloth.",

--- a/studio/frontend/src/i18n/locales/fr.ts
+++ b/studio/frontend/src/i18n/locales/fr.ts
@@ -112,7 +112,7 @@ export const fr = {
         "Utilisé pour charger des modèles restreints et publier des artefacts.",
       hideToken: "Masquer le token",
       showToken: "Afficher le token",
-      tokenSaved: "Token enregistré",
+      tokenValidated: "Jeton validé",
       password: "Mot de passe",
       passwordDescription:
         "Changez le mot de passe de ce compte Unsloth.",

--- a/studio/frontend/src/i18n/locales/hi.ts
+++ b/studio/frontend/src/i18n/locales/hi.ts
@@ -111,7 +111,7 @@ export const hi = {
         "गेटेड मॉडल लोड करने और आर्टिफैक्ट पुश करने के लिए उपयोग किया जाता है।",
       hideToken: "token छिपाएं",
       showToken: "token दिखाएं",
-      tokenSaved: "Token सहेजा गया",
+      tokenValidated: "Token सत्यापित",
       password: "पासवर्ड",
       passwordDescription: "इस Unsloth खाते के लिए पासवर्ड बदलें।",
       passwordDialog: {

--- a/studio/frontend/src/i18n/locales/ja.ts
+++ b/studio/frontend/src/i18n/locales/ja.ts
@@ -114,7 +114,7 @@ export const ja = {
       huggingFaceTokenDescription: "ゲート付きモデルの読み込みや、アーティファクトのプッシュに使用されます。",
       hideToken: "トークンを非表示",
       showToken: "トークンを表示",
-      tokenSaved: "トークンを保存しました",
+      tokenValidated: "トークンは検証済みです",
       password: "パスワード",
       passwordDescription: "この Unsloth アカウントのパスワードを変更します。",
       passwordDialog: {

--- a/studio/frontend/src/i18n/locales/ko.ts
+++ b/studio/frontend/src/i18n/locales/ko.ts
@@ -111,7 +111,7 @@ export const ko = {
         "게이트된 모델을 불러오고 아티팩트를 푸시하는 데 사용됩니다.",
       hideToken: "토큰 숨기기",
       showToken: "토큰 표시",
-      tokenSaved: "토큰이 저장되었습니다",
+      tokenValidated: "토큰이 확인되었습니다",
       password: "비밀번호",
       passwordDescription: "이 Unsloth 계정의 비밀번호를 변경합니다.",
       passwordDialog: {

--- a/studio/frontend/src/i18n/locales/pt-br.ts
+++ b/studio/frontend/src/i18n/locales/pt-br.ts
@@ -112,7 +112,7 @@ export const ptBR = {
       huggingFaceToken: "Token do Hugging Face",
       huggingFaceTokenDescription:
         "Usado para carregar modelos restritos e enviar artefatos.",
-      tokenSaved: "Token salvo",
+      tokenValidated: "Token validado",
       hideToken: "Ocultar token",
       showToken: "Mostrar token",
       password: "Senha",

--- a/studio/frontend/src/i18n/locales/ru.ts
+++ b/studio/frontend/src/i18n/locales/ru.ts
@@ -111,7 +111,7 @@ export const ru = {
         "Используется для загрузки закрытых моделей и публикации артефактов.",
       hideToken: "Скрыть токен",
       showToken: "Показать токен",
-      tokenSaved: "Токен сохранён",
+      tokenValidated: "Токен проверен",
       password: "Пароль",
       passwordDescription: "Изменить пароль для этого аккаунта Unsloth.",
       passwordDialog: {

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -113,7 +113,7 @@ export const zhCN = {
       huggingFaceTokenDescription: "用于加载受限模型和推送产物。",
       hideToken: "隐藏 token",
       showToken: "显示 token",
-      tokenSaved: "Token 已保存",
+      tokenValidated: "Token 已验证",
       password: "密码",
       passwordDescription: "更改此 Unsloth 账号的密码。",
       passwordDialog: {

--- a/tests/studio/test_hf_token_validation_tick_contract.py
+++ b/tests/studio/test_hf_token_validation_tick_contract.py
@@ -1,0 +1,17 @@
+"""Contracts for the Hugging Face token validation indicator."""
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+GENERAL_TAB = REPO / "studio/frontend/src/features/settings/tabs/general-tab.tsx"
+
+
+def test_success_tick_requires_the_current_token_to_be_validated():
+    source = GENERAL_TAB.read_text(encoding = "utf-8")
+
+    assert "tokenIsCurrent && tokenValidation.isValid === true" in source
+    assert 'tokenValidated ? "pr-14" : "pr-8"' in source
+    assert "{tokenValidated ? (" in source
+    assert 'aria-label={t("settings.general.tokenValidated")}' in source
+    assert 'aria-label={t("settings.general.tokenSaved")}' not in source

--- a/tests/studio/test_hf_token_validation_tick_contract.py
+++ b/tests/studio/test_hf_token_validation_tick_contract.py
@@ -5,13 +5,24 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 GENERAL_TAB = REPO / "studio/frontend/src/features/settings/tabs/general-tab.tsx"
+VALIDATION_HOOK = REPO / "studio/frontend/src/hooks/use-hf-token-validation.ts"
 
 
 def test_success_tick_requires_the_current_token_to_be_validated():
-    source = GENERAL_TAB.read_text(encoding = "utf-8")
+    source = GENERAL_TAB.read_text(encoding="utf-8")
 
     assert "tokenIsCurrent && tokenValidation.isValid === true" in source
     assert 'tokenValidated ? "pr-14" : "pr-8"' in source
     assert "{tokenValidated ? (" in source
     assert 'aria-label={t("settings.general.tokenValidated")}' in source
     assert 'aria-label={t("settings.general.tokenSaved")}' not in source
+
+
+def test_validation_result_must_belong_to_the_current_normalized_token():
+    source = VALIDATION_HOOK.read_text(encoding="utf-8")
+
+    assert "const normalizedToken = token.trim()" in source
+    assert "useDebouncedValue(normalizedToken, 500)" in source
+    assert "if (!COMPLETE_HF_TOKEN.test(normalizedToken)) return INITIAL" in source
+    assert "if (completed.token !== normalizedToken)" in source
+    assert "if (completed.token !== debouncedToken)" not in source

--- a/tests/studio/test_hf_token_validation_tick_contract.py
+++ b/tests/studio/test_hf_token_validation_tick_contract.py
@@ -9,7 +9,7 @@ VALIDATION_HOOK = REPO / "studio/frontend/src/hooks/use-hf-token-validation.ts"
 
 
 def test_success_tick_requires_the_current_token_to_be_validated():
-    source = GENERAL_TAB.read_text(encoding="utf-8")
+    source = GENERAL_TAB.read_text(encoding = "utf-8")
 
     assert "tokenIsCurrent && tokenValidation.isValid === true" in source
     assert 'tokenValidated ? "pr-14" : "pr-8"' in source
@@ -19,7 +19,7 @@ def test_success_tick_requires_the_current_token_to_be_validated():
 
 
 def test_validation_result_must_belong_to_the_current_normalized_token():
-    source = VALIDATION_HOOK.read_text(encoding="utf-8")
+    source = VALIDATION_HOOK.read_text(encoding = "utf-8")
 
     assert "const normalizedToken = token.trim()" in source
     assert "useDebouncedValue(normalizedToken, 500)" in source


### PR DESCRIPTION
## Summary

- show the green Hugging Face token indicator only after backend validation succeeds
- hide the indicator while validation is pending, after validation failure, or while the field differs from the saved token
- update the localized accessible label from "saved" to "validated"

## Root cause

The indicator was driven only by whether the input matched the persisted token. That made malformed, expired, or revoked tokens look accepted even when token validation reported an error.

## User impact

The success indicator now communicates confirmed validity instead of storage state.

## Validation

- `npm run build`
- `npm run typecheck`
- `npm run i18n:check`
- `npx eslint src/features/settings/tabs/general-tab.tsx src/i18n/locales/*.ts`
- `uvx --from pytest pytest -q tests/studio/test_hf_token_validation_tick_contract.py tests/studio/test_settings_compact_overflow_contract.py` (4 passed)
- `git diff --check`
- manually verified in Studio
