### PR TITLE
Installer: enable ROCm torch on RDNA2 (gfx1030-1036) on Windows

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -2128,6 +2128,10 @@ exit 0
             "gfx1151" = "gfx1151";     "gfx1150" = "gfx1150"       # RDNA 3.5 (Strix Halo/Point)
             "gfx1103" = "gfx110X-all"; "gfx1102" = "gfx110X-all"   # RDNA 3
             "gfx1101" = "gfx110X-all"; "gfx1100" = "gfx110X-all"
+            "gfx1036" = "gfx103X-all"; "gfx1035" = "gfx103X-all"   # RDNA 2 (RX 6000)
+            "gfx1034" = "gfx103X-all"; "gfx1033" = "gfx103X-all"
+            "gfx1032" = "gfx103X-all"; "gfx1031" = "gfx103X-all"
+            "gfx1030" = "gfx103X-all"
             "gfx90a"  = "gfx90a";      "gfx908"  = "gfx908"        # MI200/MI100
         }
         # gfx120X (RDNA 4) and gfx1151/gfx1150 (Strix) have a null-pointer bug in

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -352,6 +352,13 @@ _GFX_TO_AMD_INDEX_ARCH: dict[str, str] = {
     "gfx1102": "gfx110X-all",  # RDNA 3
     "gfx1101": "gfx110X-all",
     "gfx1100": "gfx110X-all",
+    "gfx1036": "gfx103X-all",
+    "gfx1035": "gfx103X-all",  # RDNA 2 (RX 6000)
+    "gfx1034": "gfx103X-all",
+    "gfx1033": "gfx103X-all",
+    "gfx1032": "gfx103X-all",
+    "gfx1031": "gfx103X-all",
+    "gfx1030": "gfx103X-all",
     "gfx90a": "gfx90a",
     "gfx908": "gfx908",  # MI200/MI100
 }

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -2774,6 +2774,7 @@ if ((Test-Path -LiteralPath $VenvDir -PathType Container) -and -not $NoTorchMode
                 "gfx1201", "gfx1200",           # RDNA 4
                 "gfx1151", "gfx1150",           # RDNA 3.5 (Strix Halo/Point)
                 "gfx1103", "gfx1102", "gfx1101", "gfx1100",  # RDNA 3
+                "gfx1036", "gfx1035", "gfx1034", "gfx1033", "gfx1032", "gfx1031", "gfx1030",  # RDNA 2 (RX 6000)
                 "gfx90a", "gfx908"              # MI200 / MI100
             )
             if ($script:ROCmGfxArch -and ($_rocmWheelArches -contains $script:ROCmGfxArch)) {
@@ -3064,6 +3065,10 @@ if (-not $TorchIndexPinned -and ($HasROCm -or $ROCmGfxArch) -and $CuTag -eq "cpu
         "gfx1151" = "gfx1151";     "gfx1150" = "gfx1150"      # RDNA 3.5 (Strix Halo/Point)
         "gfx1103" = "gfx110X-all"; "gfx1102" = "gfx110X-all"  # RDNA 3
         "gfx1101" = "gfx110X-all"; "gfx1100" = "gfx110X-all"
+        "gfx1036" = "gfx103X-all"; "gfx1035" = "gfx103X-all"  # RDNA 2 (RX 6000)
+        "gfx1034" = "gfx103X-all"; "gfx1033" = "gfx103X-all"
+        "gfx1032" = "gfx103X-all"; "gfx1031" = "gfx103X-all"
+        "gfx1030" = "gfx103X-all"
         "gfx90a"  = "gfx90a";      "gfx908"  = "gfx908"       # MI200/MI100
     }
     # gfx120X and Strix have a null _grouped_mm kernel on torch <2.11.0.
@@ -3098,7 +3103,7 @@ if (-not $TorchIndexPinned -and ($HasROCm -or $ROCmGfxArch) -and $CuTag -eq "cpu
         # GPU arch detected but not in the supported wheel map — warn explicitly
         # so the user knows why they are getting CPU PyTorch instead of ROCm.
         substep "[WARN] AMD GPU ($ROCmGfxArch) not in supported arch list -- falling back to CPU-only PyTorch" "Yellow"
-        substep "       Supported: gfx1200/1201 (RDNA 4), gfx1150/1151 (RDNA 3.5), gfx1100-1103 (RDNA 3), gfx90a, gfx908" "Yellow"
+        substep "       Supported: gfx1200/1201 (RDNA 4), gfx1150/1151 (RDNA 3.5), gfx1100-1103 (RDNA 3), gfx1030-1036 (RDNA 2), gfx90a, gfx908" "Yellow"
     } else {
         # HIP SDK present ($HasROCm=true via amd-smi) but gcnArchName was not
         # readable — warn rather than silently falling back to CPU PyTorch.


### PR DESCRIPTION
## Summary

On Windows, AMD RDNA2 cards (RX 6000 series: gfx1030/1031/1032, etc.) fall back to CPU-only PyTorch even though AMD publishes working ROCm wheels for them. `repo.amd.com/rocm/whl/gfx103X-all/` serves `win_amd64` torch 2.9.1/2.10.0/2.11.0+rocm7.13.0 (cp310-313), but both Windows arch allowlists omitted the gfx103X family, so the installer routed RDNA2 to CPU.

Reported by RX 6800 / RX 6900 XT (gfx1030) and RX 6600 XT (gfx1032) users.

## Fix

Map gfx1030-1036 to the `gfx103X-all` family in the two Windows allowlists:
- `install.ps1` `$archFamilyMap`
- `studio/install_python_stack.py` `_GFX_TO_AMD_INDEX_ARCH`

No torch floor is added: RDNA2 mirrors `gfx110X-all` (installs the newest wheel). The `torch._grouped_mm` null-pointer bug that forces a floor on gfx120X/Strix does not affect RDNA2, which has no MoE grouped-mm path. The unlisted-arch default at `install_python_stack.py:1586-1588` installs a bare `torch/torchvision/torchaudio` trio from the arch index, and the ROCm install is non-fatal on failure (keeps the existing build).

## Verified

- `repo.amd.com/rocm/whl/gfx103X-all/torch/` serves `win_amd64` wheels for cp310-313 (torch 2.9.1/2.10.0/2.11.0+rocm7.13.0).
- Arch-spoof (`UNSLOTH_ROCM_GFX_ARCH`) through the real selection code:
  - `gfx1030/1031/1032/1036` -> `https://repo.amd.com/rocm/whl/gfx103X-all/`
  - `gfx1103` -> `gfx110X-all`, `gfx1151` -> `gfx1151`, `gfx1201` -> `gfx120X-all` (all unchanged)
  - `gfx906/gfx900` -> CPU (unchanged; AMD publishes no wheel family for these)
- `install.ps1` parses cleanly (PowerShell AST, 0 errors).

## Scope

AMD-only, additive keys. NVIDIA, Mac, Intel, CPU, and Linux paths are untouched (these maps are Windows ROCm-only). gfx906 (MI50) stays on CPU because `repo.amd.com` publishes no gfx906 wheel family (HTTP 403); it already works on Linux via the pytorch.org rocm index.

## Note

RDNA2 is excluded from aotriton, so flash-attention stays off on these cards (already handled by `is_rdna`); QLoRA relies on bitsandbytes-ROCm. This PR fixes wheel selection so RDNA2 gets a GPU torch build instead of CPU; runtime fine-tuning stability on RDNA2 (bitsandbytes kernels) is a separate follow-up.
