### PR TITLE
Show iconless models in Hub feed above likes threshold

### DIFF
--- a/studio/frontend/src/features/hub/hub-page.tsx
+++ b/studio/frontend/src/features/hub/hub-page.tsx
@@ -111,6 +111,10 @@ const ALL_MODELS_VIEW_STORAGE_KEY = "unsloth.hub.allModelsView";
 const INVENTORY_SORT_STORAGE_KEY = "unsloth.hub.inventorySort";
 const OWNER_SCOPE_STORAGE_KEY = "unsloth.hub.ownerScope";
 
+// Iconless models (repo name matches no provider logo, e.g. Ornith, Inkling)
+// still show in the feed once they clear this many Hugging Face likes.
+const MIN_ICONLESS_MODEL_LIKES = 30;
+
 /** Discover browsing scope: the whole Hub (default) or only the unsloth org. */
 export type OwnerScope = "unsloth" | "all";
 
@@ -739,9 +743,10 @@ export function ModelsPage() {
       (row) =>
         !isHiddenModelId(row.id) &&
         !isConfiguredHiddenModelId(hiddenEmbeddingModelIds, row.id) &&
-        // The default feed only shows models with a provider logo.
+        // Feed shows logo'd models, plus iconless ones above the likes threshold.
         (!isFeedMode ||
-          resolveOwnerProviderLogo(row.owner, row.repo) !== null) &&
+          resolveOwnerProviderLogo(row.owner, row.repo) !== null ||
+          (row.result.likes ?? 0) >= MIN_ICONLESS_MODEL_LIKES) &&
         matchesFormat(
           detectResultFormat(row.result),
           effectiveDiscoverFormat,


### PR DESCRIPTION
## What

The Hub Discover feed only surfaces models whose repo name maps to a known provider logo. Some models we upload are iconless (their repo name matches no provider logo, e.g. Ornith and Inkling), so they never appear in the feed even when they are popular.

This lets an iconless model through the feed filter once it clears a Hugging Face likes threshold, so well-liked models are no longer hidden purely for lacking an icon.

## How

- Added a `MIN_ICONLESS_MODEL_LIKES` constant (30).
- Relaxed the feed filter in `hub-page.tsx` so a row passes when it has a provider logo OR its likes are at or above the threshold.

## Notes

- Only affects the feed view. Search and sort-browse are unchanged.
- The format dropdown still applies as before, so the feed default keeps hiding non-GGUF results.
- Threshold lives in one constant and is easy to tune later.
