### PR TITLE
studio: fix 'Standard' gradient checkpointing leaving the smart offloader active

### DIFF
--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -1607,9 +1607,19 @@ def _run_mlx_training(event_queue, stop_queue, config):
     # get_peft_model and MLXTrainer both accept and handle strings.
     gc_setting = config.get("gradient_checkpointing", "mlx")
     if isinstance(gc_setting, str):
-        use_grad_checkpoint = (
-            gc_setting if gc_setting.lower() not in ("false", "none", "") else False
-        )
+        _gc = gc_setting.lower()
+        if _gc in ("false", "none", ""):
+            use_grad_checkpoint = False
+        elif _gc in ("true", "1", "yes"):
+            # HF-standard GC (UI "Standard"): pass a real bool so unsloth
+            # unpatches the smart offloader. Leaving it the string "true" hits
+            # neither the "unsloth" nor the (True, False) branch in
+            # _configure_gradient_checkpointing, so the offloader stays patched
+            # and active against the user's choice (memory crash on
+            # constrained/unified GPUs).
+            use_grad_checkpoint = True
+        else:
+            use_grad_checkpoint = gc_setting  # "unsloth" / "mlx" stay strings
     else:
         use_grad_checkpoint = gc_setting
 


### PR DESCRIPTION
### What

Selecting **Standard** gradient checkpointing in the training UI left Unsloth's smart memory offloader active anyway, OOM-crashing on memory-constrained and unified-memory GPUs even though the user opted out of offloading. Reported for gfx1201 (R9700) on Linux; the same path hits Strix Halo and any tight-VRAM setup.

### Root cause

The UI "Standard" option sends the string `"true"`. In `studio/backend/core/training/worker.py` the normalizer mapped `"false"/"none"/""` to `False` but passed `"true"` through **as a string**. unsloth's `_configure_gradient_checkpointing` (`unsloth/models/_utils.py:401-413`) only unpatches the smart offloader on the `(True, False)` boolean branch:

```python
if use_gradient_checkpointing == "unsloth":
    ... patch smart offloader ...
elif use_gradient_checkpointing in (True, False):
    unpatch_unsloth_smart_gradient_checkpointing()   # <- only booleans reach this
    return use_gradient_checkpointing
return use_gradient_checkpointing                     # <- string "true" lands here, no unpatch
```

The string `"true"` matches neither `"unsloth"` nor `(True, False)`, so it returns without unpatching. The global `torch.utils.checkpoint` monkeypatch from any prior "unsloth" state stays installed and the offloader keeps running.

### Fix

Normalize `"true"/"1"/"yes"` to the boolean `True` in the worker so unsloth reaches the unpatch branch. This matches the normalization `trainer.py:929-949` already does. `"unsloth"` and `"mlx"` remain strings (Mac MLX path unaffected); booleans pass through unchanged.

Verified: `ast.parse` clean; normalization table `true->True`, `none/false/""->False`, `unsloth/mlx` preserved, `True/False` unchanged.

### Scope

Not AMD-specific (the "Standard" option was broken everywhere), but the crash only bites memory-constrained / unified-memory GPUs, which is where AMD APUs and RDNA4 land. No NVIDIA/Mac regression: this only converts a string that should have been a bool.
