### PR TITLE
Recognize Radeon 8065S (Gorgon Halo / Ryzen AI Max 400) as gfx1151

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1844,7 +1844,7 @@ exit 0
                 $nameArchTable = @(
                     @{ P = "9070 XT|9080";                                        A = "gfx1201" }  # RDNA 4 (RX 9070 XT / 9080)
                     @{ P = "9070|9060";                                           A = "gfx1200" }  # RDNA 4 (RX 9070 / 9060)
-                    @{ P = "8060S|8050S|8040S|Strix Halo|Ryzen AI Max|AI Max"; A = "gfx1151" }  # RDNA 3.5 (Strix Halo: Radeon 8060S/8050S/8040S iGPU, Ryzen AI Max+)
+                    @{ P = "8065S|8060S|8050S|8040S|Strix Halo|Ryzen AI Max|AI Max"; A = "gfx1151" }  # RDNA 3.5 (Strix Halo + Gorgon Halo: Radeon 8065S/8060S/8050S/8040S iGPU, Ryzen AI Max / Max+)
                     @{ P = "890M|880M|860M|840M|Strix Point|Krackan|HX 37[05]|AI 9 HX|AI 9 36[05]|AI 7 35[05]|AI 5 34[05]|AI 7 PRO 35|AI 5 33"; A = "gfx1150" }  # RDNA 3.5 (Strix/Krackan Point: Radeon 890M/880M iGPU, Ryzen AI 9 HX 370/375)
                     @{ P = "RX 7900|RX 7800|RX 7700(?!S)|PRO W7900|PRO W7800|PRO W7700"; A = "gfx1100" }  # RDNA 3 desktop/workstation (Navi 31)
                     @{ P = "RX 7600|RX 7700S|RX 7650|PRO W7600|PRO W7500|PRO V710"; A = "gfx1102" }  # RDNA 3 (Navi 33)

--- a/install.sh
+++ b/install.sh
@@ -1636,7 +1636,7 @@ _maybe_reroute_strixhalo_to_2404() {
     # CUDA_VISIBLE_DEVICES=""/-1 and the /proc/driver/nvidia fallback for PATH/timeout gaps.
     if _has_usable_nvidia_gpu; then return 0; fi
     # Strix APUs show in /proc/cpuinfo; discrete cards don't, so also try WMI. Either reroutes.
-    if ! grep -qiE 'Ryzen AI Max|Radeon 80[0-9]0S|Strix Halo' /proc/cpuinfo 2>/dev/null \
+    if ! grep -qiE 'Ryzen AI Max|Radeon 80[0-9][05]S|Strix Halo' /proc/cpuinfo 2>/dev/null \
        && ! _wsl_amd_gpu_name >/dev/null 2>&1; then
         return 0
     fi
@@ -2649,7 +2649,7 @@ _maybe_bootstrap_rocm_wsl() {
     [ -e /dev/dxg ] || return 0
     # Strix APUs show in /proc/cpuinfo (the CPU model); discrete cards don't, so also
     # ask the Windows host. Either signal suffices; the bootstrap detects arch from rocminfo.
-    if ! grep -qiE 'Ryzen AI Max|Radeon 80[0-9]0S|Strix Halo' /proc/cpuinfo 2>/dev/null \
+    if ! grep -qiE 'Ryzen AI Max|Radeon 80[0-9][05]S|Strix Halo' /proc/cpuinfo 2>/dev/null \
        && ! _wsl_amd_gpu_name >/dev/null 2>&1; then
         return 0
     fi
@@ -2960,7 +2960,7 @@ elif case "$TORCH_INDEX_URL" in */rocm*|*/gfx*) true ;; *) false ;; esac; then
         case "$_gpu_disp_mkt" in
             *"9070 XT"*|*9080*)                                                                            _gpu_disp_gfx="gfx1201" ;;  # RDNA 4
             *9070*|*9060*)                                                                                 _gpu_disp_gfx="gfx1200" ;;  # RDNA 4
-            *"8060S"*|*"8050S"*|*"8040S"*|*"Strix Halo"*|*"Ryzen AI Max"*|*"AI Max"*) _gpu_disp_gfx="gfx1151" ;;  # RDNA 3.5 (Strix Halo: Radeon 8060S/8050S/8040S iGPU, Ryzen AI Max+)
+            *"8065S"*|*"8060S"*|*"8050S"*|*"8040S"*|*"Strix Halo"*|*"Ryzen AI Max"*|*"AI Max"*) _gpu_disp_gfx="gfx1151" ;;  # RDNA 3.5 (Strix Halo + Gorgon Halo: Radeon 8065S/8060S/8050S/8040S iGPU, Ryzen AI Max / Max+)
             *"890M"*|*"880M"*|*"860M"*|*"840M"*|*"Strix Point"*|*"Krackan"*|*"HX 37"*|*"AI 9 HX"*|*"AI 9 36"*|*"AI 7 35"*|*"AI 5 34"*|*"AI 7 PRO 35"*|*"AI 5 33"*) _gpu_disp_gfx="gfx1150" ;;  # RDNA 3.5 (Strix/Krackan Point: Radeon 890M/880M iGPU, Ryzen AI 9 HX 370/375)
             *"RX 7600"*|*"RX 7700S"*|*"RX 7650"*|*"PRO W7600"*|*"PRO W7500"*|*"PRO V710"*)                  _gpu_disp_gfx="gfx1102" ;;  # RDNA 3 (Navi 33)
             *"RX 7900"*|*"RX 7800"*|*"RX 7700"*|*"PRO W7900"*|*"PRO W7800"*|*"PRO W7700"*)                  _gpu_disp_gfx="gfx1100" ;;  # RDNA 3 desktop / workstation (Navi 31)

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -729,7 +729,11 @@ def _rocm_classify_unified_memory(props: Any) -> tuple[str, bool]:
     # Arch attrs absent — fall back to device-name matching.
     dev_lower = (getattr(props, "name", "") or "").lower()
     is_unified = (
-        "890m" in dev_lower or "880m" in dev_lower or "8065s" in dev_lower or "8060s" in dev_lower or "8050s" in dev_lower
+        "890m" in dev_lower
+        or "880m" in dev_lower
+        or "8065s" in dev_lower
+        or "8060s" in dev_lower
+        or "8050s" in dev_lower
     )
     return gcn_arch, is_unified
 

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -702,8 +702,9 @@ def _rocm_classify_unified_memory(props: Any) -> tuple[str, bool]:
     3. Device-name substring match (last resort when all arch attrs absent;
        AMD SDK / Radeon wheels may not populate them):
          - gfx1150 Strix Point: ``Radeon 890M``, ``Radeon 880M``
-         - gfx1151 Strix Halo:  ``Radeon 8060S`` (Ryzen AI MAX+ 395),
-                                ``Radeon 8050S`` (cut-down SKU)
+         - gfx1151 Strix Halo / Gorgon Halo:  ``Radeon 8065S`` (Ryzen AI
+                                Max+ 495), ``Radeon 8060S`` (Ryzen AI MAX+
+                                395), ``Radeon 8050S`` (cut-down SKU)
     """
     gcn_arch = ""
     for _attr in ("gcnArchName", "gcn_arch_name", "arch_name", "gfx_arch_name"):
@@ -728,7 +729,7 @@ def _rocm_classify_unified_memory(props: Any) -> tuple[str, bool]:
     # Arch attrs absent — fall back to device-name matching.
     dev_lower = (getattr(props, "name", "") or "").lower()
     is_unified = (
-        "890m" in dev_lower or "880m" in dev_lower or "8060s" in dev_lower or "8050s" in dev_lower
+        "890m" in dev_lower or "880m" in dev_lower or "8065s" in dev_lower or "8060s" in dev_lower or "8050s" in dev_lower
     )
     return gcn_arch, is_unified
 

--- a/studio/backend/tests/test_rocm_oom_guard.py
+++ b/studio/backend/tests/test_rocm_oom_guard.py
@@ -163,6 +163,9 @@ class TestDeviceNameFallback:
             "AMD Radeon 8060S",
             "Radeon 8050S Graphics",  # cut-down Strix Halo SKU
             "AMD Radeon 8050S",
+            # gfx1151 Gorgon Halo (Ryzen AI Max 400 refresh)
+            "Radeon 8065S Graphics",  # Ryzen AI Max+ 495
+            "AMD Radeon 8065S",
             # case variants
             "RADEON 8060S GRAPHICS",
             "radeon 8050s",

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -719,8 +719,8 @@ def _detect_windows_gfx_arch() -> str | None:
 _WIN_GPU_NAME_ARCH_TABLE: "list[tuple[str, str]]" = [
     (r"9070 XT|9080", "gfx1201"),  # RDNA 4 (Radeon RX 9070 XT / 9080)
     (r"9070|9060", "gfx1200"),  # RDNA 4 (Radeon RX 9070 / 9060)
-    # RDNA 3.5 (Strix Halo: Radeon 8060S/8050S/8040S iGPU, Ryzen AI Max+)
-    (r"8060S|8050S|8040S|Strix Halo|Ryzen AI Max|AI Max", "gfx1151"),
+    # RDNA 3.5 (Strix Halo + Gorgon Halo: Radeon 8065S/8060S/8050S/8040S iGPU, Ryzen AI Max / Max+)
+    (r"8065S|8060S|8050S|8040S|Strix Halo|Ryzen AI Max|AI Max", "gfx1151"),
     # RDNA 3.5 (Strix/Krackan Point: Radeon 890M/880M iGPU, Ryzen AI 9 HX 370/375)
     (
         r"890M|880M|860M|840M|Strix Point|Krackan|HX 37[05]|AI 9 HX|AI 9 36[05]"

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1498,7 +1498,7 @@ if (-not $HasNvidiaSmi) {
             $nameArchTable = @(
                 @{ P = "9070 XT|9080";                                        A = "gfx1201" }  # RDNA 4 (Radeon RX 9070 XT / 9080)
                 @{ P = "9070|9060";                                           A = "gfx1200" }  # RDNA 4 (Radeon RX 9070 / 9060)
-                @{ P = "8060S|8050S|8040S|Strix Halo|Ryzen AI Max|AI Max"; A = "gfx1151" }  # RDNA 3.5 (Strix Halo: Radeon 8060S/8050S/8040S iGPU, Ryzen AI Max+)
+                @{ P = "8065S|8060S|8050S|8040S|Strix Halo|Ryzen AI Max|AI Max"; A = "gfx1151" }  # RDNA 3.5 (Strix Halo + Gorgon Halo: Radeon 8065S/8060S/8050S/8040S iGPU, Ryzen AI Max / Max+)
                 @{ P = "890M|880M|860M|840M|Strix Point|Krackan|HX 37[05]|AI 9 HX|AI 9 36[05]|AI 7 35[05]|AI 5 34[05]|AI 7 PRO 35|AI 5 33"; A = "gfx1150" }  # RDNA 3.5 (Strix/Krackan Point: Radeon 890M/880M iGPU, Ryzen AI 9 HX 370/375)
                 @{ P = "RX 7900|RX 7800|RX 7700(?!S)|PRO W7900|PRO W7800|PRO W7700"; A = "gfx1100" }  # RDNA 3 desktop / workstation (Navi 31)
                 @{ P = "RX 7600|RX 7700S|RX 7650|PRO W7600|PRO W7500|PRO V710"; A = "gfx1102" }  # RDNA 3 (Navi 33)

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -1136,7 +1136,7 @@ elif [ "$_setup_amd_detected" = true ]; then
         case "$_setup_mkt" in
             *"9070 XT"*|*9080*)                                                                            _setup_gfx="gfx1201" ;;  # RDNA 4
             *9070*|*9060*)                                                                                 _setup_gfx="gfx1200" ;;  # RDNA 4
-            *"8060S"*|*"8050S"*|*"8040S"*|*"Strix Halo"*|*"Ryzen AI Max"*|*"AI Max"*) _setup_gfx="gfx1151" ;;  # RDNA 3.5 (Strix Halo: Radeon 8060S/8050S/8040S iGPU, Ryzen AI Max+)
+            *"8065S"*|*"8060S"*|*"8050S"*|*"8040S"*|*"Strix Halo"*|*"Ryzen AI Max"*|*"AI Max"*) _setup_gfx="gfx1151" ;;  # RDNA 3.5 (Strix Halo + Gorgon Halo: Radeon 8065S/8060S/8050S/8040S iGPU, Ryzen AI Max / Max+)
             *"890M"*|*"880M"*|*"860M"*|*"840M"*|*"Strix Point"*|*"Krackan"*|*"HX 37"*|*"AI 9 HX"*|*"AI 9 36"*|*"AI 7 35"*|*"AI 5 34"*|*"AI 7 PRO 35"*|*"AI 5 33"*) _setup_gfx="gfx1150" ;;  # RDNA 3.5 (Strix/Krackan Point: Radeon 890M/880M iGPU, Ryzen AI 9 HX 370/375)
             *"RX 7600"*|*"RX 7700S"*|*"RX 7650"*|*"PRO W7600"*|*"PRO W7500"*|*"PRO V710"*)                  _setup_gfx="gfx1102" ;;  # RDNA 3 (Navi 33)
             *"RX 7900"*|*"RX 7800"*|*"RX 7700"*|*"PRO W7900"*|*"PRO W7800"*|*"PRO W7700"*)                  _setup_gfx="gfx1100" ;;  # RDNA 3 desktop / workstation (Navi 31)


### PR DESCRIPTION
## Summary

AMD's Ryzen AI Max 400 series (codename Gorgon Halo: Ryzen AI Max+ PRO 495 / PRO 490 / PRO 485) is a Strix Halo refresh. The iGPU is still RDNA 3.5 with 40 (or 32) compute units and ROCm reports it as `gfx1151`, same as Strix Halo. AMD rebrands it as **Radeon 8065S** (40 CU flagship) and **Radeon 8050S** (32 CU).

`gfx1151` is already fully supported (torch from `repo.amd.com/rocm/whl/gfx1151/`, the `gfx1151` llama.cpp prebuilt for Windows and Linux, the `torch>=2.11` `_grouped_mm` floor). The gap is only in GPU-name inference: when no HIP SDK / amd-smi is present and the arch is inferred from the marketing name, the tables listed `8060S/8050S/8040S` but not the new flagship name `8065S`, so a driver-only Windows host with a Radeon 8065S fell back to CPU torch. The 32 CU parts reuse `8050S`, which already matched.

## Fix

Add `8065S` to the five GPU-name -> gfx1151 tables and widen the two ROCm-on-WSL detection regexes from `Radeon 80[0-9]0S` to `Radeon 80[0-9][05]S` so both `8060S` and `8065S` match:

- `install.ps1` `$nameArchTable`
- `studio/setup.ps1` `$nameArchTable`
- `studio/install_python_stack.py` `_WIN_GPU_NAME_ARCH_TABLE`
- `install.sh` GPU-name `case` + the two `_maybe_*_rocm_wsl` detection greps
- `studio/setup.sh` GPU-name `case`

Additive keys only. The arch (`gfx1151`) and every downstream path are unchanged; parts that report the arch directly (always on Linux via rocminfo, on Windows with the HIP SDK, or via `UNSLOTH_ROCM_GFX_ARCH=gfx1151`) already worked. This only fixes the name-inference fallback.

## Verified

- Name resolution for `Radeon 8065S` -> `gfx1151` in all five files (Python `_WIN_GPU_NAME_ARCH_TABLE`, both PowerShell `$nameArchTable` maps, both bash `case` blocks), with no regressions: `8060S/8050S` still `gfx1151`, `RX 6800` still `gfx1030`, `RX 9070 XT` still `gfx1201`.
- WSL regex `Radeon 80[0-9][05]S` matches `8065S` and `8060S`, and `Ryzen AI Max+ PRO 495` still matches via the CPU-name branch.
- Syntax: PowerShell AST parse clean (install.ps1, setup.ps1), `python -m ast` clean, `bash -n` clean.
- `tests/sh/test_strixhalo_wsl_reroute.sh`: 53 passed, 0 failed.

## Note

ROCm added Gorgon Halo runtime support in 7.14; our wheels are `+rocm7.13.0`. The compute target and kernels are unchanged (`gfx1151`), but the new part's PCI device ID may need a newer ROCm runtime or an HSA override at runtime. That is an AMD runtime detail, independent of wheel/prebuilt selection.
