### PR TITLE
Add project pinning, Projects list view, and project chat-session fixes

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -804,7 +804,15 @@ export function AppSidebar() {
         await deleteChatProject(target.project.id, {
           deleteFiles: shouldDeleteProjectFiles,
         });
-        if (activeProjectId === target.project.id) {
+        // activeProjectId is only the ?project= param; on a thread-only URL the
+        // project is resolved from the thread into the runtime store, so check
+        // that too or we strand the user on a now-deleted thread.
+        const runtimeProjectId =
+          useChatRuntimeStore.getState().activeProjectId;
+        if (
+          activeProjectId === target.project.id ||
+          runtimeProjectId === target.project.id
+        ) {
           useChatRuntimeStore.getState().setActiveProjectId(null);
           navigate({ to: "/chat", search: { new: createNavigationNonce() } });
         }

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -55,6 +55,7 @@ import {
   Archive03Icon,
   ArrowRight02Icon,
   BadgeInfoIcon,
+  BubbleChatIcon,
   ChefHatIcon,
   CloudIcon,
   CpuIcon,
@@ -468,7 +469,6 @@ export function AppSidebar() {
   // first). The section only appears once at least one project is pinned.
   const pinnedProjectIds = usePinnedProjectsStore((s) => s.pinnedIds);
   const unpinProject = usePinnedProjectsStore((s) => s.unpin);
-  const [projectsOpen, setProjectsOpen] = useState(true);
   const pinnedProjectRecords = useMemo(() => {
     const byId = new Map(projects.map((p) => [p.id, p]));
     return pinnedProjectIds
@@ -885,6 +885,8 @@ export function AppSidebar() {
       // pl-3 (12px) over the content's pl-1.5 (6px) = 18px, aligning the
       // title with the nav items above.
       variant === "project" ? "pl-[39px]" : "pl-3",
+      // Pinned chats carry a chat icon, so add the nav-item icon gap.
+      isPinned && variant !== "project" && "gap-[8.5px]",
       variant === "project"
         ? "group-hover/project-chat-item:pr-6 group-has-[.sidebar-row-action[data-state=open]]/project-chat-item:pr-6"
         : isPinned
@@ -946,6 +948,9 @@ export function AppSidebar() {
             closeMobileIfOpen();
           }}
         >
+          {isPinned && variant !== "project" && (
+            <HugeiconsIcon icon={BubbleChatIcon} strokeWidth={1.75} className="size-icon! shrink-0" />
+          )}
           <span className="truncate">
             {pendingRename?.id === item.id ? pendingRename.title : item.title}
           </span>
@@ -1401,19 +1406,16 @@ export function AppSidebar() {
           </SidebarGroup>
         </Collapsible>
 
-        {/* Projects: the ones the user pinned, above Recents */}
+        {/* Pinned: pinned projects (with their chats) and pinned chats */}
         {!isStudioRoute &&
           !showTrainingRecents &&
-          pinnedProjectRecords.length > 0 && (
-            <Collapsible
-              open={projectsOpen}
-              onOpenChange={setProjectsOpen}
-              asChild
-            >
+          (pinnedProjectRecords.length > 0 ||
+            pinnedChatItems.length > 0) && (
+            <Collapsible open={pinnedOpen} onOpenChange={setPinnedOpen} asChild>
               <SidebarGroup className="group-data-[collapsible=icon]:hidden px-0 py-0">
                 <SidebarGroupLabel className={cn("sidebar-sticky-label sidebar-sticky-label-following", scrolled && "is-scrolled")} asChild>
                   <CollapsibleTrigger className="cursor-pointer flex w-full items-center gap-1 group/sb-collap">
-                    Projects
+                    Pinned
                     <ChevronDown className="size-3.5 opacity-0 transition-[transform,opacity] duration-200 group-hover/sb-collap:opacity-100 group-focus-visible/sb-collap:opacity-100 data-[state=open]:rotate-0 [[data-state=closed]_&]:rotate-[-90deg] [[data-state=closed]_&]:opacity-100" />
                   </CollapsibleTrigger>
                 </SidebarGroupLabel>
@@ -1538,9 +1540,9 @@ export function AppSidebar() {
                             <SidebarMenuItem>
                               <SidebarMenuButton
                                 onClick={() => toggleProjectShowAll(project.id)}
-                                className="sidebar-nav-btn h-[33px] rounded-full pl-9 pr-4 font-medium text-sidebar-foreground/55"
+                                className="sidebar-nav-btn h-[30px] rounded-full pl-9 pr-4 font-medium text-muted-foreground"
                               >
-                                <span className="text-[14.5px] leading-[19px] tracking-nav">
+                                <span className="text-[13px] leading-[18px] tracking-nav">
                                   {showAll ? "Show less" : "Show more"}
                                 </span>
                               </SidebarMenuButton>
@@ -1549,35 +1551,15 @@ export function AppSidebar() {
                         </Fragment>
                         );
                       })}
+                      {pinnedChatItems.map((item) =>
+                        renderChatSidebarItem(item, "recent"),
+                      )}
                     </SidebarMenu>
                   </SidebarGroupContent>
                 </CollapsibleContent>
               </SidebarGroup>
             </Collapsible>
           )}
-
-        {/* Pinned chats: own section above Recents */}
-        {!isStudioRoute && !showTrainingRecents && pinnedChatItems.length > 0 && (
-          <Collapsible open={pinnedOpen} onOpenChange={setPinnedOpen} asChild>
-            <SidebarGroup className="group-data-[collapsible=icon]:hidden px-0 py-0">
-              <SidebarGroupLabel className={cn("sidebar-sticky-label sidebar-sticky-label-following", scrolled && "is-scrolled")} asChild>
-                <CollapsibleTrigger className="cursor-pointer flex w-full items-center gap-1 group/sb-collap">
-                  Pinned
-                  <ChevronDown className="size-3.5 opacity-0 transition-[transform,opacity] duration-200 group-hover/sb-collap:opacity-100 group-focus-visible/sb-collap:opacity-100 data-[state=open]:rotate-0 [[data-state=closed]_&]:rotate-[-90deg] [[data-state=closed]_&]:opacity-100" />
-                </CollapsibleTrigger>
-              </SidebarGroupLabel>
-              <CollapsibleContent>
-                <SidebarGroupContent className="pl-1.5 pr-2">
-                  <SidebarMenu>
-                    {pinnedChatItems.map((item) =>
-                      renderChatSidebarItem(item, "recent"),
-                    )}
-                  </SidebarMenu>
-                </SidebarGroupContent>
-              </CollapsibleContent>
-            </SidebarGroup>
-          </Collapsible>
-        )}
 
         {!isStudioRoute && !showTrainingRecents && (
           <Collapsible open={chatOpen} onOpenChange={setChatOpen} asChild>

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -462,34 +462,28 @@ export function AppSidebar() {
   // first). The section only appears once at least one project is pinned.
   const pinnedProjectIds = usePinnedProjectsStore((s) => s.pinnedIds);
   const unpinProject = usePinnedProjectsStore((s) => s.unpin);
-  const pinnedProjectIdSet = useMemo(
-    () => new Set(pinnedProjectIds),
-    [pinnedProjectIds],
-  );
   const pinnedProjectRecords = useMemo(() => {
     const byId = new Map(projects.map((p) => [p.id, p]));
     return pinnedProjectIds
       .map((id) => byId.get(id))
       .filter((p): p is ProjectRecord => Boolean(p));
   }, [projects, pinnedProjectIds]);
-  // Pinned chats, in pin order (most recent first). Chats that live inside a
-  // pinned project already render nested under it, so drop them here to avoid
-  // showing the same chat twice in the Pinned section.
+  // Pinned chats, in pin order (most recent first). Includes chats that live
+  // inside a project: pinning promotes a chat into this list, and it is removed
+  // from the project's nested list below so it never shows twice.
   const pinnedChatItems = useMemo(() => {
     const byId = new Map(allChatItems.map((item) => [item.id, item]));
     return pinnedIds
       .map((id) => byId.get(id))
-      .filter((item): item is SidebarItem => Boolean(item))
-      .filter(
-        (item) =>
-          !(item.projectId && pinnedProjectIdSet.has(item.projectId)),
-      );
-  }, [allChatItems, pinnedIds, pinnedProjectIdSet]);
+      .filter((item): item is SidebarItem => Boolean(item));
+  }, [allChatItems, pinnedIds]);
   // A pinned project reveals its recent chats (most recent first) nested below.
+  // Pinned chats are excluded here since they render in the pinned-chats list.
   const chatsByProjectId = useMemo(() => {
     const map = new Map<string, SidebarItem[]>();
     for (const item of allChatItems) {
       if (!item.projectId) continue;
+      if (pinnedIdSet.has(item.id)) continue;
       const list = map.get(item.projectId);
       if (list) list.push(item);
       else map.set(item.projectId, [item]);
@@ -497,7 +491,7 @@ export function AppSidebar() {
     for (const list of map.values())
       list.sort((a, b) => b.updatedAt - a.updatedAt);
     return map;
-  }, [allChatItems]);
+  }, [allChatItems, pinnedIdSet]);
   // Default expanded (not collapsed); the row toggles this. Show-more reveals
   // chats past the first PINNED_PROJECT_CHAT_LIMIT.
   const [collapsedProjectIds, setCollapsedProjectIds] = useState<Set<string>>(
@@ -1465,7 +1459,9 @@ export function AppSidebar() {
                           className="group/recent-item relative"
                         >
                           <SidebarMenuButton
-                            isActive={activeProjectId === project.id}
+                            // Highlight the folder only on the project home; when
+                            // a chat inside it is open, only that chat row is active.
+                            isActive={activeProjectId === project.id && !activeThreadId}
                             onClick={() => toggleProjectCollapsed(project.id)}
                             className="sidebar-nav-btn h-[33px] rounded-full gap-[8.5px] pl-3 pr-2.5 font-medium group-hover/recent-item:pr-16 group-has-[.sidebar-row-action[data-state=open]]/recent-item:pr-8"
                           >
@@ -1526,7 +1522,7 @@ export function AppSidebar() {
                                   });
                                 }}
                               >
-                                <HugeiconsIcon icon={PencilEdit02Icon} strokeWidth={1.75} className="size-icon" />
+                                <HugeiconsIcon icon={Edit03Icon} strokeWidth={1.75} className="size-icon" />
                                 <span>Rename project</span>
                               </DropdownMenuItem>
                               <DropdownMenuItem onSelect={() => unpinProject(project.id)}>

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -109,6 +109,7 @@ import {
   deleteChatItem,
   listStoredChatThreads,
   moveChatItemToProject,
+  notifyChatHistoryUpdated,
   renameChatItem,
   renameChatProject,
   useChatRuntimeStore,
@@ -804,14 +805,19 @@ export function AppSidebar() {
         await deleteChatProject(target.project.id, {
           deleteFiles: shouldDeleteProjectFiles,
         });
+        // Refresh chat history so the project's reparented chats don't linger
+        // as stale top-level rows.
+        notifyChatHistoryUpdated();
         // activeProjectId is only the ?project= param; on a thread-only URL the
         // project is resolved from the thread into the runtime store, so check
-        // that too or we strand the user on a now-deleted thread.
+        // that too or we strand the user on a now-deleted thread. Only redirect
+        // from a chat route: the runtime store value can be stale elsewhere.
         const runtimeProjectId =
           useChatRuntimeStore.getState().activeProjectId;
         if (
-          activeProjectId === target.project.id ||
-          runtimeProjectId === target.project.id
+          isChatRoute &&
+          (activeProjectId === target.project.id ||
+            runtimeProjectId === target.project.id)
         ) {
           useChatRuntimeStore.getState().setActiveProjectId(null);
           navigate({ to: "/chat", search: { new: createNavigationNonce() } });

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -457,24 +457,34 @@ export function AppSidebar() {
       ),
     [allChatItems, pinnedIdSet],
   );
-  // Pinned chats, in pin order (most recent first).
-  const pinnedChatItems = useMemo(() => {
-    const byId = new Map(allChatItems.map((item) => [item.id, item]));
-    return pinnedIds
-      .map((id) => byId.get(id))
-      .filter((item): item is SidebarItem => Boolean(item));
-  }, [allChatItems, pinnedIds]);
   const [pinnedOpen, setPinnedOpen] = useState(true);
   // "Projects" section: projects the user pinned, in pin order (most recent
   // first). The section only appears once at least one project is pinned.
   const pinnedProjectIds = usePinnedProjectsStore((s) => s.pinnedIds);
   const unpinProject = usePinnedProjectsStore((s) => s.unpin);
+  const pinnedProjectIdSet = useMemo(
+    () => new Set(pinnedProjectIds),
+    [pinnedProjectIds],
+  );
   const pinnedProjectRecords = useMemo(() => {
     const byId = new Map(projects.map((p) => [p.id, p]));
     return pinnedProjectIds
       .map((id) => byId.get(id))
       .filter((p): p is ProjectRecord => Boolean(p));
   }, [projects, pinnedProjectIds]);
+  // Pinned chats, in pin order (most recent first). Chats that live inside a
+  // pinned project already render nested under it, so drop them here to avoid
+  // showing the same chat twice in the Pinned section.
+  const pinnedChatItems = useMemo(() => {
+    const byId = new Map(allChatItems.map((item) => [item.id, item]));
+    return pinnedIds
+      .map((id) => byId.get(id))
+      .filter((item): item is SidebarItem => Boolean(item))
+      .filter(
+        (item) =>
+          !(item.projectId && pinnedProjectIdSet.has(item.projectId)),
+      );
+  }, [allChatItems, pinnedIds, pinnedProjectIdSet]);
   // A pinned project reveals its recent chats (most recent first) nested below.
   const chatsByProjectId = useMemo(() => {
     const map = new Map<string, SidebarItem[]>();
@@ -1510,9 +1520,13 @@ export function AppSidebar() {
                               <DropdownMenuSeparator />
                               <DropdownMenuItem
                                 variant="destructive"
-                                onSelect={() =>
-                                  setConfirmingDelete({ kind: "project", project })
-                                }
+                                onSelect={() => {
+                                  // Start each delete with the file toggle off:
+                                  // Cancel closes programmatically and skips the
+                                  // dialog onOpenChange reset.
+                                  setDeleteProjectFiles(false);
+                                  setConfirmingDelete({ kind: "project", project });
+                                }}
                               >
                                 <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.75} className="size-icon" />
                                 <span>Delete project</span>
@@ -1525,15 +1539,18 @@ export function AppSidebar() {
                             <SidebarMenuItem key={chat.id}>
                               <SidebarMenuButton
                                 isActive={activeThreadId === chat.id}
-                                onClick={() =>
+                                onClick={() => {
                                   navigate({
                                     to: "/chat",
                                     search:
                                       chat.type === "single"
                                         ? { thread: chat.id, project: project.id }
                                         : { compare: chat.id, project: project.id },
-                                  })
-                                }
+                                  });
+                                  // Match the other nav handlers: close the
+                                  // mobile drawer over the opened chat.
+                                  closeMobileIfOpen();
+                                }}
                                 className="sidebar-nav-btn h-[33px] rounded-full pl-9 pr-4 font-medium text-sidebar-foreground/80"
                               >
                                 <span className="truncate text-[14.5px] leading-[19px] tracking-nav">{chat.title}</span>

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -115,6 +115,7 @@ import {
   useChatSearchStore,
   useChatSidebarItems,
   usePinnedChatsStore,
+  usePinnedProjectsStore,
   useChatPreferencesStore,
   type ProjectRecord,
   type SidebarItem,
@@ -140,7 +141,14 @@ import {
 } from "@/features/training";
 import type { TrainingRunSummary } from "@/features/training";
 import { useExportRuntimeStore } from "@/features/export";
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  Fragment,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { isDownloadCancelled } from "@/lib/native-files";
 import { toast } from "@/lib/toast";
 import { ShutdownDialog } from "@/components/shutdown-dialog";
@@ -198,6 +206,9 @@ const TestTubeOutlineIcon = TestTube01Icon.slice(
 
 
 type ConversationExportFormat = "raw-jsonl" | "csv" | "sharegpt-jsonl";
+
+// A pinned project shows this many recent chats before "Show more".
+const PINNED_PROJECT_CHAT_LIMIT = 4;
 
 const CHAT_EXPORT_OPTIONS: Array<{
   label: string;
@@ -453,6 +464,52 @@ export function AppSidebar() {
       .filter((item): item is SidebarItem => Boolean(item));
   }, [allChatItems, pinnedIds]);
   const [pinnedOpen, setPinnedOpen] = useState(true);
+  // "Projects" section: projects the user pinned, in pin order (most recent
+  // first). The section only appears once at least one project is pinned.
+  const pinnedProjectIds = usePinnedProjectsStore((s) => s.pinnedIds);
+  const unpinProject = usePinnedProjectsStore((s) => s.unpin);
+  const [projectsOpen, setProjectsOpen] = useState(true);
+  const pinnedProjectRecords = useMemo(() => {
+    const byId = new Map(projects.map((p) => [p.id, p]));
+    return pinnedProjectIds
+      .map((id) => byId.get(id))
+      .filter((p): p is ProjectRecord => Boolean(p));
+  }, [projects, pinnedProjectIds]);
+  // A pinned project reveals its recent chats (most recent first) nested below.
+  const chatsByProjectId = useMemo(() => {
+    const map = new Map<string, SidebarItem[]>();
+    for (const item of allChatItems) {
+      if (!item.projectId) continue;
+      const list = map.get(item.projectId);
+      if (list) list.push(item);
+      else map.set(item.projectId, [item]);
+    }
+    for (const list of map.values())
+      list.sort((a, b) => b.updatedAt - a.updatedAt);
+    return map;
+  }, [allChatItems]);
+  // Default expanded (not collapsed); the row toggles this. Show-more reveals
+  // chats past the first PINNED_PROJECT_CHAT_LIMIT.
+  const [collapsedProjectIds, setCollapsedProjectIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [expandedChatProjectIds, setExpandedChatProjectIds] = useState<
+    Set<string>
+  >(() => new Set());
+  const toggleProjectCollapsed = (id: string) =>
+    setCollapsedProjectIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  const toggleProjectShowAll = (id: string) =>
+    setExpandedChatProjectIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
   const storeThreadId = useChatRuntimeStore((s) => s.activeThreadId);
   const setActiveThreadId = useChatRuntimeStore((s) => s.setActiveThreadId);
   const anyChatRunning = useChatRuntimeStore((s) =>
@@ -1343,6 +1400,161 @@ export function AppSidebar() {
             </CollapsibleContent>
           </SidebarGroup>
         </Collapsible>
+
+        {/* Projects: the ones the user pinned, above Recents */}
+        {!isStudioRoute &&
+          !showTrainingRecents &&
+          pinnedProjectRecords.length > 0 && (
+            <Collapsible
+              open={projectsOpen}
+              onOpenChange={setProjectsOpen}
+              asChild
+            >
+              <SidebarGroup className="group-data-[collapsible=icon]:hidden px-0 py-0">
+                <SidebarGroupLabel className={cn("sidebar-sticky-label sidebar-sticky-label-following", scrolled && "is-scrolled")} asChild>
+                  <CollapsibleTrigger className="cursor-pointer flex w-full items-center gap-1 group/sb-collap">
+                    Projects
+                    <ChevronDown className="size-3.5 opacity-0 transition-[transform,opacity] duration-200 group-hover/sb-collap:opacity-100 group-focus-visible/sb-collap:opacity-100 data-[state=open]:rotate-0 [[data-state=closed]_&]:rotate-[-90deg] [[data-state=closed]_&]:opacity-100" />
+                  </CollapsibleTrigger>
+                </SidebarGroupLabel>
+                <CollapsibleContent>
+                  <SidebarGroupContent className="pl-1.5 pr-2">
+                    <SidebarMenu>
+                      {pinnedProjectRecords.map((project) => {
+                        const projectChats =
+                          chatsByProjectId.get(project.id) ?? [];
+                        const expanded = !collapsedProjectIds.has(project.id);
+                        const showAll = expandedChatProjectIds.has(project.id);
+                        const visibleChats =
+                          expanded && !showAll
+                            ? projectChats.slice(0, PINNED_PROJECT_CHAT_LIMIT)
+                            : projectChats;
+                        return (
+                        <Fragment key={project.id}>
+                        <SidebarMenuItem
+                          className="group/recent-item relative"
+                        >
+                          <SidebarMenuButton
+                            isActive={activeProjectId === project.id}
+                            onClick={() => toggleProjectCollapsed(project.id)}
+                            className="sidebar-nav-btn h-[33px] rounded-full gap-[8.5px] pl-3 pr-2.5 font-medium group-hover/recent-item:pr-16 group-has-[.sidebar-row-action[data-state=open]]/recent-item:pr-8"
+                          >
+                            <HugeiconsIcon icon={Folder01Icon} strokeWidth={1.75} className="size-icon! shrink-0" />
+                            <span className="truncate text-[14.5px] leading-[19px] tracking-nav">{project.name}</span>
+                          </SidebarMenuButton>
+                          {/* New chat in this project */}
+                          <button
+                            type="button"
+                            aria-label="New chat"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              openNewChat(project.id);
+                            }}
+                            className="sidebar-row-action is-unpin-action group-hover/recent-item:opacity-100 group-hover/recent-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto"
+                          >
+                            <span className="sidebar-row-action-glyph">
+                              <HugeiconsIcon icon={PencilEdit02Icon} strokeWidth={1.75} className="size-icon" />
+                            </span>
+                          </button>
+                          {/* Project options */}
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <button
+                                type="button"
+                                onClick={(e) => e.stopPropagation()}
+                                aria-label="Project options"
+                                className="sidebar-row-action group-hover/recent-item:opacity-100 group-hover/recent-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto"
+                              >
+                                <span className="sidebar-row-action-glyph">
+                                  <HugeiconsIcon icon={MoreVerticalIcon} strokeWidth={1.75} className="size-icon" />
+                                </span>
+                              </button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent
+                              side="bottom"
+                              align="start"
+                              sideOffset={0}
+                              className="unsloth-plus-menu menu-flat-destructive w-56"
+                            >
+                              <DropdownMenuItem onSelect={() => openProject(project.id)}>
+                                <HugeiconsIcon icon={Folder01Icon} strokeWidth={1.75} className="size-icon" />
+                                <span>Project home</span>
+                              </DropdownMenuItem>
+                              <DropdownMenuItem onSelect={() => openNewChat(project.id)}>
+                                <HugeiconsIcon icon={PencilEdit02Icon} strokeWidth={1.75} className="size-icon" />
+                                <span>New chat</span>
+                              </DropdownMenuItem>
+                              <DropdownMenuItem
+                                onSelect={() =>
+                                  setRenamingTarget({
+                                    kind: "project",
+                                    project,
+                                    current: project.name,
+                                  })
+                                }
+                              >
+                                <HugeiconsIcon icon={PencilEdit02Icon} strokeWidth={1.75} className="size-icon" />
+                                <span>Rename project</span>
+                              </DropdownMenuItem>
+                              <DropdownMenuItem onSelect={() => unpinProject(project.id)}>
+                                <HugeiconsIcon icon={PinOffIcon} strokeWidth={1.75} className="size-icon" />
+                                <span>Unpin project</span>
+                              </DropdownMenuItem>
+                              <DropdownMenuSeparator />
+                              <DropdownMenuItem
+                                variant="destructive"
+                                onSelect={() =>
+                                  setConfirmingDelete({ kind: "project", project })
+                                }
+                              >
+                                <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.75} className="size-icon" />
+                                <span>Delete project</span>
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        </SidebarMenuItem>
+                        {expanded &&
+                          visibleChats.map((chat) => (
+                            <SidebarMenuItem key={chat.id}>
+                              <SidebarMenuButton
+                                isActive={activeThreadId === chat.id}
+                                onClick={() =>
+                                  navigate({
+                                    to: "/chat",
+                                    search:
+                                      chat.type === "single"
+                                        ? { thread: chat.id, project: project.id }
+                                        : { compare: chat.id, project: project.id },
+                                  })
+                                }
+                                className="sidebar-nav-btn h-[33px] rounded-full pl-9 pr-4 font-medium text-sidebar-foreground/80"
+                              >
+                                <span className="truncate text-[14.5px] leading-[19px] tracking-nav">{chat.title}</span>
+                              </SidebarMenuButton>
+                            </SidebarMenuItem>
+                          ))}
+                        {expanded &&
+                          projectChats.length > PINNED_PROJECT_CHAT_LIMIT && (
+                            <SidebarMenuItem>
+                              <SidebarMenuButton
+                                onClick={() => toggleProjectShowAll(project.id)}
+                                className="sidebar-nav-btn h-[33px] rounded-full pl-9 pr-4 font-medium text-sidebar-foreground/55"
+                              >
+                                <span className="text-[14.5px] leading-[19px] tracking-nav">
+                                  {showAll ? "Show less" : "Show more"}
+                                </span>
+                              </SidebarMenuButton>
+                            </SidebarMenuItem>
+                          )}
+                        </Fragment>
+                        );
+                      })}
+                    </SidebarMenu>
+                  </SidebarGroupContent>
+                </CollapsibleContent>
+              </SidebarGroup>
+            </Collapsible>
+          )}
 
         {/* Pinned chats: own section above Recents */}
         {!isStudioRoute && !showTrainingRecents && pinnedChatItems.length > 0 && (

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -900,7 +900,8 @@ export function AppSidebar() {
       // Pinned chats carry a chat icon, so add the nav-item icon gap.
       isPinned && variant !== "project" && "gap-[8.5px]",
       variant === "project"
-        ? "group-hover/project-chat-item:pr-6 group-has-[.sidebar-row-action[data-state=open]]/project-chat-item:pr-6"
+        ? // Room for the hover pin quick-action plus the kebab.
+          "group-hover/project-chat-item:pr-14 group-has-[.sidebar-row-action[data-state=open]]/project-chat-item:pr-8"
         : isPinned
           ? // Pinned rows show an extra unpin button on hover, so reserve more room
             // (pr-8 when the menu is open keeps the unpin button clear of the title).
@@ -967,6 +968,21 @@ export function AppSidebar() {
             {pendingRename?.id === item.id ? pendingRename.title : item.title}
           </span>
         </SidebarMenuButton>
+        {variant === "project" && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              togglePinnedChat(item.id);
+            }}
+            aria-label={isPinned ? "Unpin chat" : "Pin chat"}
+            className="sidebar-row-action is-unpin-action group-hover/project-chat-item:opacity-100 group-hover/project-chat-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto"
+          >
+            <span className="sidebar-row-action-glyph">
+              <HugeiconsIcon icon={isPinned ? PinOffIcon : PinIcon} strokeWidth={1.75} className="size-icon" />
+            </span>
+          </button>
+        )}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <button
@@ -1535,34 +1551,18 @@ export function AppSidebar() {
                           </DropdownMenu>
                         </SidebarMenuItem>
                         {expanded &&
-                          visibleChats.map((chat) => (
-                            <SidebarMenuItem key={chat.id}>
-                              <SidebarMenuButton
-                                isActive={activeThreadId === chat.id}
-                                onClick={() => {
-                                  navigate({
-                                    to: "/chat",
-                                    search:
-                                      chat.type === "single"
-                                        ? { thread: chat.id, project: project.id }
-                                        : { compare: chat.id, project: project.id },
-                                  });
-                                  // Match the other nav handlers: close the
-                                  // mobile drawer over the opened chat.
-                                  closeMobileIfOpen();
-                                }}
-                                className="sidebar-nav-btn h-[33px] rounded-full pl-9 pr-4 font-medium text-sidebar-foreground/80"
-                              >
-                                <span className="truncate text-[14.5px] leading-[19px] tracking-nav">{chat.title}</span>
-                              </SidebarMenuButton>
-                            </SidebarMenuItem>
-                          ))}
+                          visibleChats.map((chat) =>
+                            renderChatSidebarItem(chat, "project"),
+                          )}
                         {expanded &&
                           projectChats.length > PINNED_PROJECT_CHAT_LIMIT && (
                             <SidebarMenuItem>
                               <SidebarMenuButton
                                 onClick={() => toggleProjectShowAll(project.id)}
-                                className="sidebar-nav-btn h-[30px] rounded-full pl-9 pr-4 font-medium text-muted-foreground"
+                                // Force the muted token: .sidebar-nav-btn's own
+                                // color rule outweighs a plain text utility, so
+                                // Show more would otherwise match the chat rows.
+                                className="sidebar-nav-btn h-[30px] rounded-full pl-9 pr-4 font-medium text-nav-fg-muted!"
                               >
                                 <span className="text-[13px] leading-[18px] tracking-nav">
                                   {showAll ? "Show less" : "Show more"}

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -985,6 +985,21 @@ export function AppSidebar() {
             </span>
           </button>
         )}
+        {variant === "recent" && isPinned && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              togglePinnedChat(item.id);
+            }}
+            aria-label="Unpin chat"
+            className="sidebar-row-action is-unpin-action group-hover/recent-item:opacity-100 group-hover/recent-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto"
+          >
+            <span className="sidebar-row-action-glyph">
+              <HugeiconsIcon icon={PinOffIcon} strokeWidth={1.75} className="size-icon" />
+            </span>
+          </button>
+        )}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <button

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -789,6 +789,8 @@ export function AppSidebar() {
     const shouldDeleteProjectFiles =
       target.kind === "project" && deleteProjectFiles;
     setConfirmingDelete(null);
+    // Reset so the next project delete never inherits this checkbox.
+    setDeleteProjectFiles(false);
     if (target.kind === "chat") {
       await deleteChatWithCleanup(target.item);
       return;
@@ -1487,13 +1489,16 @@ export function AppSidebar() {
                                 <span>New chat</span>
                               </DropdownMenuItem>
                               <DropdownMenuItem
-                                onSelect={() =>
+                                onSelect={() => {
+                                  // Seed the shared draft so the dialog opens
+                                  // with the current name, not stale text.
+                                  setRenameDraft(project.name);
                                   setRenamingTarget({
                                     kind: "project",
                                     project,
                                     current: project.name,
-                                  })
-                                }
+                                  });
+                                }}
                               >
                                 <HugeiconsIcon icon={PencilEdit02Icon} strokeWidth={1.75} className="size-icon" />
                                 <span>Rename project</span>

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1841,9 +1841,12 @@ const Composer: FC<{
 
   const startQueue = useCallback(
     (items: string[], waitForCurrentRun = threadIsRunning) => {
+      // Saved-prompt Run-list calls this directly, so honour disableQueue here
+      // too: queuing from the project new-chat composer misbinds the thread.
+      if (disableQueue) return;
       startPromptQueue(items, createPromptQueueTarget(), waitForCurrentRun);
     },
-    [createPromptQueueTarget, threadIsRunning],
+    [createPromptQueueTarget, threadIsRunning, disableQueue],
   );
 
   const queueContextValue: PromptQueueCallbacks = { startQueue, stopQueue };

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1903,8 +1903,11 @@ const Composer: FC<{
             isComposing ||
             hasPendingAttachments
           }
-          queueDisabled={!canQueueCurrentPrompt}
+          // disableQueue (project new-chat composer) also blocks the queue
+          // button, so a running thread shows Stop instead of Queue.
+          queueDisabled={disableQueue || !canQueueCurrentPrompt}
           onQueueClick={() => {
+            if (disableQueue) return;
             const queuedPrompt = composerText.trim();
             if (queuedPrompt.length === 0) {
               return;

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1370,7 +1370,13 @@ export const ProjectComposer: FC<{
 }> = ({ disabled, placeholder }) => {
   return (
     <GeneratedImageOverlayProvider>
-      <ComposerAnimated disabled={disabled} placeholder={placeholder} />
+      {/* New chat in a project: queuing follow-ups here misbinds the thread,
+          so the queue only runs once the user is inside a chat session. */}
+      <ComposerAnimated
+        disabled={disabled}
+        placeholder={placeholder}
+        disableQueue
+      />
     </GeneratedImageOverlayProvider>
   );
 };
@@ -1380,11 +1386,17 @@ const ComposerAnimated: FC<{
   placeholder?: string;
   threadId?: string | null;
   menuSide?: "top" | "bottom";
-}> = ({ disabled, threadId, menuSide }) => {
+  disableQueue?: boolean;
+}> = ({ disabled, threadId, menuSide, disableQueue }) => {
   return (
     <div className="relative mx-auto min-w-0 w-full max-w-[46rem]">
       <div className="relative z-10 w-full">
-        <Composer disabled={disabled} threadId={threadId} menuSide={menuSide} />
+        <Composer
+          disabled={disabled}
+          threadId={threadId}
+          menuSide={menuSide}
+          disableQueue={disableQueue}
+        />
       </div>
     </div>
   );
@@ -1419,7 +1431,8 @@ const Composer: FC<{
   placeholder?: string;
   threadId?: string | null;
   menuSide?: "top" | "bottom";
-}> = ({ disabled, threadId, menuSide }) => {
+  disableQueue?: boolean;
+}> = ({ disabled, threadId, menuSide, disableQueue }) => {
   const aui = useAui();
   const pageDragging = useContext(PageDragContext);
   const { overlay, closeOverlay } = useGeneratedImageOverlay();
@@ -1726,6 +1739,11 @@ const Composer: FC<{
 
       if (threadIsRunning || promptQueueActive) {
         event.preventDefault();
+        // Project new-chat composer: never queue, just ask the user to wait.
+        if (disableQueue) {
+          toast.error("Wait for the current response to finish");
+          return;
+        }
         if (!canQueueCurrentPrompt) {
           if (overlay || hasAttachments || hasPendingAudio) {
             toast.error(
@@ -1803,6 +1821,7 @@ const Composer: FC<{
       composerText,
       createPromptQueueTarget,
       disabled,
+      disableQueue,
       hasAttachments,
       hasPendingAudio,
       interceptSend,

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -21,8 +21,22 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import {
   ResizableHandle,
   ResizablePanel,
@@ -46,14 +60,22 @@ import {
 } from "@/features/native-intents";
 import { GuidedTour, useGuidedTourController } from "@/features/tour";
 import { isTauri } from "@/lib/api-base";
+import { isDownloadCancelled } from "@/lib/native-files";
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import {
+  Archive03Icon,
   BubbleChatTemporaryIcon,
+  Delete02Icon,
+  Download01Icon,
   Edit03Icon,
+  Folder01Icon,
   Folder02Icon,
+  FolderExportIcon,
   LayoutAlignRightIcon,
   MoreVerticalIcon,
+  PinIcon,
+  PinOffIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useNavigate } from "@tanstack/react-router";
@@ -90,12 +112,18 @@ import {
 } from "./external-providers";
 import { useChatModelRuntime } from "./hooks/use-chat-model-runtime";
 import type { SelectedModelInput } from "./hooks/use-chat-model-runtime";
-import { useChatProjects } from "./hooks/use-chat-projects";
+import {
+  moveChatItemToProject,
+  useChatProjects,
+} from "./hooks/use-chat-projects";
 import {
   type SidebarItem,
+  archiveChatItem,
+  deleteChatItem,
   renameChatItem,
   useChatSidebarItems,
 } from "./hooks/use-chat-sidebar-items";
+import { usePinnedChatsStore } from "./stores/pinned-chats-store";
 import {
   clearTrainingCompareHandoff,
   getTrainingCompareHandoff,
@@ -876,6 +904,38 @@ function formatProjectChatDate(timestamp: number): string {
   }).format(new Date(timestamp));
 }
 
+// Chat export formats, mirroring the sidebar chat menu.
+type ProjectChatExportFormat = "raw-jsonl" | "csv" | "sharegpt-jsonl";
+const PROJECT_CHAT_EXPORT_OPTIONS: Array<{
+  label: string;
+  format: ProjectChatExportFormat;
+}> = [
+  { label: "Raw JSONL", format: "raw-jsonl" },
+  { label: "CSV", format: "csv" },
+  { label: "ShareGPT JSONL", format: "sharegpt-jsonl" },
+];
+
+async function exportProjectConversation(
+  threadId: string,
+  format: ProjectChatExportFormat,
+): Promise<void> {
+  const exports = await import("./prompt-storage/prompt-storage-dialog");
+  if (format === "raw-jsonl") return exports.exportConversationRawJsonl(threadId);
+  if (format === "csv") return exports.exportConversationCsv(threadId);
+  return exports.exportConversationShareGPT(threadId);
+}
+
+async function exportProjectChatItem(
+  item: SidebarItem,
+  format: ProjectChatExportFormat,
+): Promise<void> {
+  const ids =
+    item.type === "single"
+      ? [item.id]
+      : (await listStoredChatThreads({ pairId: item.id })).map((t) => t.id);
+  for (const id of ids) await exportProjectConversation(id, format);
+}
+
 function extractMessageText(content: MessageRecord["content"]): string {
   if (typeof content === "string") {
     return content;
@@ -977,16 +1037,98 @@ function ProjectLanding({
     [renameDraft],
   );
 
+  // Full chat actions, matching the sidebar chat menu.
+  const { projects } = useChatProjects();
+  const pinnedChatIds = usePinnedChatsStore((s) => s.pinnedIds);
+  const togglePinnedChat = usePinnedChatsStore((s) => s.togglePin);
+  const confirmDeleteChats = useChatPreferencesStore(
+    (s) => s.confirmDeleteChats,
+  );
+  const pinnedChatIdSet = useMemo(
+    () => new Set(pinnedChatIds),
+    [pinnedChatIds],
+  );
+  const [confirmingDelete, setConfirmingDelete] = useState<SidebarItem | null>(
+    null,
+  );
+
+  // Landing has no active thread selected, so the onView callback here is a
+  // no-op; the items list refreshes itself once storage emits its update.
+  const noopView = useCallback(() => {}, []);
+
+  const handleArchive = useCallback(
+    async (item: SidebarItem) => {
+      try {
+        await archiveChatItem(item, activeThreadId ?? undefined, noopView);
+      } catch (err) {
+        toast.error("Failed to archive chat", {
+          description: err instanceof Error ? err.message : undefined,
+        });
+      }
+    },
+    [activeThreadId, noopView],
+  );
+
+  const runDelete = useCallback(
+    async (item: SidebarItem) => {
+      try {
+        await deleteChatItem(item, activeThreadId ?? undefined, noopView);
+      } catch (err) {
+        toast.error("Failed to delete chat", {
+          description: err instanceof Error ? err.message : undefined,
+        });
+      }
+    },
+    [activeThreadId, noopView],
+  );
+
+  const handleDelete = useCallback(
+    (item: SidebarItem) => {
+      if (confirmDeleteChats) setConfirmingDelete(item);
+      else void runDelete(item);
+    },
+    [confirmDeleteChats, runDelete],
+  );
+
+  const handleMoveToProject = useCallback(
+    async (item: SidebarItem, targetId: string | null) => {
+      try {
+        await moveChatItemToProject(item, targetId);
+      } catch (err) {
+        toast.error("Failed to move chat", {
+          description: err instanceof Error ? err.message : undefined,
+        });
+      }
+    },
+    [],
+  );
+
+  const handleExport = useCallback(
+    async (item: SidebarItem, format: ProjectChatExportFormat) => {
+      try {
+        await exportProjectChatItem(item, format);
+      } catch (error) {
+        if (!isDownloadCancelled(error)) toast.error("Export failed.");
+      }
+    },
+    [],
+  );
+
   useEffect(() => {
     if (!activeThreadId) {
-      setPendingNewThreadId(null);
+      // Leaving a created chat for a new one: rotate the nonce so the runtime
+      // switches to a fresh thread instead of appending to the old chat.
+      if (pendingNewThreadId) {
+        setNewThreadNonce(crypto.randomUUID());
+        setPendingNewThreadId(null);
+      }
       return;
     }
     if (activeThreadId === initialActiveThreadRef.current) {
       return;
     }
     setPendingNewThreadId(activeThreadId);
-  }, [activeThreadId]);
+  }, [activeThreadId, pendingNewThreadId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1148,11 +1290,6 @@ function ProjectLanding({
                             aria-label="Rename chat"
                             className="w-full border-0 bg-transparent text-[15px] font-semibold leading-5 text-foreground outline-none"
                           />
-                          {preview?.snippet ? (
-                            <div className="mt-0.5 truncate text-[14px] leading-5 text-muted-foreground">
-                              {preview.snippet}
-                            </div>
-                          ) : null}
                         </div>
                       </div>
                     );
@@ -1179,11 +1316,6 @@ function ProjectLanding({
                           <div className="truncate text-[15px] font-semibold leading-5 text-foreground">
                             {displayTitle}
                           </div>
-                          {preview?.snippet ? (
-                            <div className="mt-0.5 truncate text-[14px] leading-5 text-muted-foreground">
-                              {preview.snippet}
-                            </div>
-                          ) : null}
                         </div>
                         <span className="shrink-0 text-[14px] text-muted-foreground transition-opacity max-md:opacity-0 pointer-coarse:opacity-0 group-hover:opacity-0 group-has-[[data-state=open]]:opacity-0">
                           {preview?.date ??
@@ -1209,7 +1341,7 @@ function ProjectLanding({
                           side="bottom"
                           align="end"
                           sideOffset={4}
-                          className="unsloth-plus-menu w-56"
+                          className="unsloth-plus-menu menu-flat-destructive w-56"
                         >
                           <DropdownMenuItem onSelect={() => openRename(item)}>
                             <HugeiconsIcon
@@ -1218,6 +1350,106 @@ function ProjectLanding({
                               className="size-icon"
                             />
                             <span>Rename</span>
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onSelect={() => togglePinnedChat(item.id)}
+                          >
+                            <HugeiconsIcon
+                              icon={
+                                pinnedChatIdSet.has(item.id)
+                                  ? PinOffIcon
+                                  : PinIcon
+                              }
+                              strokeWidth={1.75}
+                              className="size-icon"
+                            />
+                            <span>
+                              {pinnedChatIdSet.has(item.id)
+                                ? "Unpin chat"
+                                : "Pin chat"}
+                            </span>
+                          </DropdownMenuItem>
+                          <DropdownMenuSub>
+                            <DropdownMenuSubTrigger>
+                              <HugeiconsIcon
+                                icon={FolderExportIcon}
+                                strokeWidth={1.75}
+                                className="size-icon"
+                              />
+                              <span>Move to project</span>
+                            </DropdownMenuSubTrigger>
+                            <DropdownMenuSubContent className="unsloth-plus-menu w-52">
+                              <DropdownMenuItem
+                                disabled={item.projectId !== projectId}
+                                onSelect={() =>
+                                  void handleMoveToProject(item, null)
+                                }
+                              >
+                                <span>Recents</span>
+                              </DropdownMenuItem>
+                              {projects.map((p) => (
+                                <DropdownMenuItem
+                                  key={p.id}
+                                  disabled={item.projectId === p.id}
+                                  onSelect={() =>
+                                    void handleMoveToProject(item, p.id)
+                                  }
+                                >
+                                  <HugeiconsIcon
+                                    icon={Folder01Icon}
+                                    strokeWidth={1.75}
+                                    className="size-icon"
+                                  />
+                                  <span className="truncate">{p.name}</span>
+                                </DropdownMenuItem>
+                              ))}
+                            </DropdownMenuSubContent>
+                          </DropdownMenuSub>
+                          <DropdownMenuSub>
+                            <DropdownMenuSubTrigger>
+                              <HugeiconsIcon
+                                icon={Download01Icon}
+                                strokeWidth={1.75}
+                                className="size-icon"
+                              />
+                              <span>Export</span>
+                            </DropdownMenuSubTrigger>
+                            <DropdownMenuSubContent className="unsloth-plus-menu w-52">
+                              {PROJECT_CHAT_EXPORT_OPTIONS.map(
+                                ({ label, format }) => (
+                                  <DropdownMenuItem
+                                    key={format}
+                                    onSelect={() =>
+                                      void handleExport(item, format)
+                                    }
+                                  >
+                                    {label}
+                                  </DropdownMenuItem>
+                                ),
+                              )}
+                            </DropdownMenuSubContent>
+                          </DropdownMenuSub>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            onSelect={() => void handleArchive(item)}
+                          >
+                            <HugeiconsIcon
+                              icon={Archive03Icon}
+                              strokeWidth={1.75}
+                              className="size-icon"
+                            />
+                            <span>Archive</span>
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            variant="destructive"
+                            onSelect={() => handleDelete(item)}
+                          >
+                            <HugeiconsIcon
+                              icon={Delete02Icon}
+                              strokeWidth={1.75}
+                              className="size-icon"
+                            />
+                            <span>Delete</span>
                           </DropdownMenuItem>
                         </DropdownMenuContent>
                       </DropdownMenu>
@@ -1229,6 +1461,34 @@ function ProjectLanding({
           </div>
         </div>
       )}
+      <AlertDialog
+        open={confirmingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmingDelete(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete chat</AlertDialogTitle>
+            <AlertDialogDescription>
+              This permanently deletes "{confirmingDelete?.title}". This cannot
+              be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                const target = confirmingDelete;
+                setConfirmingDelete(null);
+                if (target) void runDelete(target);
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </ChatRuntimeProvider>
   );
 }

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -1201,8 +1201,8 @@ function ProjectLanding({
             } as CSSProperties
           }
         >
-          {/* 46rem matches the composer so every block shares the same edges. */}
-          <div className="mx-auto flex w-full max-w-[46rem] flex-col pt-[120px] pb-14">
+          {/* Slightly narrower than the composer max; every block shares this. */}
+          <div className="mx-auto flex w-full max-w-[44rem] flex-col pt-[120px] pb-14">
             <div className="mb-12 flex items-center gap-4">
               <span className="flex size-13 shrink-0 items-center justify-center rounded-[18px] bg-muted text-foreground/80">
                 <HugeiconsIcon
@@ -1234,12 +1234,9 @@ function ProjectLanding({
                 type="button"
                 onClick={() => setProjectTab("sources")}
                 data-active={projectTab === "sources"}
-                className="flex h-10 items-center gap-1.5 rounded-full px-5 text-[14px] font-semibold transition-colors data-[active=true]:bg-muted data-[active=true]:text-foreground data-[active=false]:text-muted-foreground data-[active=false]:hover:bg-nav-surface-hover"
+                className="h-10 rounded-full px-5 text-[14px] font-semibold transition-colors data-[active=true]:bg-muted data-[active=true]:text-foreground data-[active=false]:text-muted-foreground data-[active=false]:hover:bg-nav-surface-hover"
               >
                 Sources
-                <span className="rounded-full bg-emerald-500/10 px-2 py-1 text-[10px] font-semibold leading-none text-emerald-700 dark:text-emerald-300">
-                  New
-                </span>
               </button>
             </div>
 

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -992,6 +992,9 @@ function ProjectLanding({
   items: SidebarItem[];
 }): ReactElement {
   const navigate = useNavigate();
+  // Gates body-portaled surfaces so they can't linger or act while the landing
+  // is off-route (e.g. behind another tab).
+  const active = useChatActive();
   const activeThreadId = useChatRuntimeStore((s) => s.activeThreadId);
   const initialActiveThreadRef = useRef<string | null>(null);
   const [projectTab, setProjectTab] = useState<"chats" | "sources">("chats");
@@ -1613,7 +1616,7 @@ function ProjectLanding({
         </AlertDialogContent>
       </AlertDialog>
       <Dialog
-        open={renamingProject}
+        open={active && renamingProject}
         onOpenChange={(open) => {
           if (!open) setRenamingProject(false);
         }}
@@ -1654,7 +1657,7 @@ function ProjectLanding({
         </DialogContent>
       </Dialog>
       <AlertDialog
-        open={deletingProject}
+        open={active && deletingProject}
         onOpenChange={(open) => {
           if (!open) setDeletingProject(false);
         }}

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -904,6 +904,15 @@ function formatProjectChatDate(timestamp: number): string {
   }).format(new Date(timestamp));
 }
 
+// Unique thread nonce; falls back off crypto.randomUUID for non-secure
+// (HTTP LAN) contexts where it is unavailable.
+function createThreadNonce(): string {
+  if (typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
 // Chat export formats, mirroring the sidebar chat menu.
 type ProjectChatExportFormat = "raw-jsonl" | "csv" | "sharegpt-jsonl";
 const PROJECT_CHAT_EXPORT_OPTIONS: Array<{
@@ -977,7 +986,7 @@ function ProjectLanding({
     null,
   );
   const [newThreadNonce, setNewThreadNonce] = useState(() =>
-    crypto.randomUUID(),
+    createThreadNonce(),
   );
   const [previews, setPreviews] = useState<
     Record<string, { snippet: string; date: string }>
@@ -1002,7 +1011,7 @@ function ProjectLanding({
     useChatRuntimeStore.getState().setActiveThreadId(null);
     useChatRuntimeStore.getState().setContextUsage(null);
     setPendingNewThreadId(null);
-    setNewThreadNonce(crypto.randomUUID());
+    setNewThreadNonce(createThreadNonce());
     setRenamingId(null);
     setPendingRename(null);
   }, [projectId]);
@@ -1119,7 +1128,7 @@ function ProjectLanding({
       // Leaving a created chat for a new one: rotate the nonce so the runtime
       // switches to a fresh thread instead of appending to the old chat.
       if (pendingNewThreadId) {
-        setNewThreadNonce(crypto.randomUUID());
+        setNewThreadNonce(createThreadNonce());
         setPendingNewThreadId(null);
       }
       return;

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -103,7 +103,7 @@ import {
   useState,
 } from "react";
 import type { PanelImperativeHandle } from "react-resizable-panels";
-import { listLocalModels } from "./api/chat-api";
+import { listLocalModels, notifyChatHistoryUpdated } from "./api/chat-api";
 import { ArtifactSurface } from "./artifacts/artifact-surface";
 import {
   clearAutoOpenedArtifacts,
@@ -1061,6 +1061,9 @@ function ProjectLanding({
     setDeletingProject(false);
     try {
       await deleteChatProject(projectId);
+      // Refresh chat history so the project's now-deleted chats don't linger
+      // in the sidebar, matching the sidebar delete path.
+      notifyChatHistoryUpdated();
       useChatRuntimeStore.getState().setActiveProjectId(null);
       navigate({ to: "/chat", search: { new: createThreadNonce() } });
     } catch (err) {
@@ -1588,7 +1591,7 @@ function ProjectLanding({
         </div>
       )}
       <AlertDialog
-        open={confirmingDelete !== null}
+        open={active && confirmingDelete !== null}
         onOpenChange={(open) => {
           if (!open) setConfirmingDelete(null);
         }}
@@ -1666,7 +1669,7 @@ function ProjectLanding({
           <AlertDialogHeader>
             <AlertDialogTitle>Delete project</AlertDialogTitle>
             <AlertDialogDescription>
-              Delete "{projectName}"? Its chats will be moved back to Recents.
+              Delete "{projectName}"? Its chats will be permanently deleted.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -37,6 +37,15 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import {
   ResizableHandle,
   ResizablePanel,
@@ -73,6 +82,7 @@ import {
   Folder02Icon,
   FolderExportIcon,
   LayoutAlignRightIcon,
+  MoreHorizontalIcon,
   MoreVerticalIcon,
   PinIcon,
   PinOffIcon,
@@ -113,7 +123,9 @@ import {
 import { useChatModelRuntime } from "./hooks/use-chat-model-runtime";
 import type { SelectedModelInput } from "./hooks/use-chat-model-runtime";
 import {
+  deleteChatProject,
   moveChatItemToProject,
+  renameChatProject,
   useChatProjects,
 } from "./hooks/use-chat-projects";
 import {
@@ -124,6 +136,7 @@ import {
   useChatSidebarItems,
 } from "./hooks/use-chat-sidebar-items";
 import { usePinnedChatsStore } from "./stores/pinned-chats-store";
+import { usePinnedProjectsStore } from "./stores/pinned-projects-store";
 import {
   clearTrainingCompareHandoff,
   getTrainingCompareHandoff,
@@ -1005,6 +1018,55 @@ function ProjectLanding({
     title: string;
   } | null>(null);
 
+  // Project-level options (the header kebab menu).
+  const pinnedProjectIds = usePinnedProjectsStore((s) => s.pinnedIds);
+  const togglePinProject = usePinnedProjectsStore((s) => s.togglePin);
+  const projectPinned = pinnedProjectIds.includes(projectId);
+  const [renamingProject, setRenamingProject] = useState(false);
+  const [projectNameDraft, setProjectNameDraft] = useState("");
+  const [deletingProject, setDeletingProject] = useState(false);
+
+  async function handleProjectExport(
+    format: ProjectChatExportFormat,
+  ): Promise<void> {
+    try {
+      const threads = await listStoredChatThreads({
+        projectId,
+        includeArchived: false,
+      });
+      const ids = [...new Set(threads.map((t) => t.id))];
+      for (const id of ids) await exportProjectConversation(id, format);
+    } catch (error) {
+      if (!isDownloadCancelled(error)) toast.error("Export failed.");
+    }
+  }
+
+  async function commitProjectRename(): Promise<void> {
+    const name = projectNameDraft.trim();
+    setRenamingProject(false);
+    if (!name || name === projectName) return;
+    try {
+      await renameChatProject(projectId, name);
+    } catch (err) {
+      toast.error("Failed to rename project", {
+        description: err instanceof Error ? err.message : undefined,
+      });
+    }
+  }
+
+  async function commitProjectDelete(): Promise<void> {
+    setDeletingProject(false);
+    try {
+      await deleteChatProject(projectId);
+      useChatRuntimeStore.getState().setActiveProjectId(null);
+      navigate({ to: "/chat", search: { new: createThreadNonce() } });
+    } catch (err) {
+      toast.error("Failed to delete project", {
+        description: err instanceof Error ? err.message : undefined,
+      });
+    }
+  }
+
   useEffect(() => {
     initialActiveThreadRef.current =
       useChatRuntimeStore.getState().activeThreadId;
@@ -1211,9 +1273,64 @@ function ProjectLanding({
                   className="size-6.5"
                 />
               </span>
-              <h1 className="truncate font-sans text-[30px] font-medium leading-tight tracking-normal text-foreground">
+              <h1 className="min-w-0 flex-1 truncate font-sans text-[30px] font-medium leading-tight tracking-normal text-foreground">
                 {projectName}
               </h1>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild={true}>
+                  <button
+                    type="button"
+                    aria-label="Project options"
+                    className="inline-flex size-9 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring data-[state=open]:bg-muted data-[state=open]:text-foreground"
+                  >
+                    <HugeiconsIcon icon={MoreHorizontalIcon} strokeWidth={1.75} className="size-5" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  side="bottom"
+                  align="end"
+                  sideOffset={6}
+                  className="unsloth-plus-menu menu-flat-destructive w-52"
+                >
+                  <DropdownMenuItem
+                    onSelect={() => {
+                      setProjectNameDraft(projectName);
+                      setRenamingProject(true);
+                    }}
+                  >
+                    <HugeiconsIcon icon={Edit03Icon} strokeWidth={1.75} className="size-icon" />
+                    <span>Rename project</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => togglePinProject(projectId)}>
+                    <HugeiconsIcon icon={projectPinned ? PinOffIcon : PinIcon} strokeWidth={1.75} className="size-icon" />
+                    <span>{projectPinned ? "Unpin project" : "Pin project"}</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuSub>
+                    <DropdownMenuSubTrigger>
+                      <HugeiconsIcon icon={Download01Icon} strokeWidth={1.75} className="size-icon" />
+                      <span>Export</span>
+                    </DropdownMenuSubTrigger>
+                    <DropdownMenuSubContent className="unsloth-plus-menu w-48">
+                      {PROJECT_CHAT_EXPORT_OPTIONS.map(({ label, format }) => (
+                        <DropdownMenuItem
+                          key={format}
+                          onSelect={() => void handleProjectExport(format)}
+                        >
+                          {label}
+                        </DropdownMenuItem>
+                      ))}
+                    </DropdownMenuSubContent>
+                  </DropdownMenuSub>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    variant="destructive"
+                    onSelect={() => setDeletingProject(true)}
+                  >
+                    <HugeiconsIcon icon={Delete02Icon} strokeWidth={1.75} className="size-icon" />
+                    <span>Delete project</span>
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
 
             <ProjectComposer
@@ -1490,6 +1607,68 @@ function ProjectLanding({
                 if (target) void runDelete(target);
               }}
             >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+      <Dialog
+        open={renamingProject}
+        onOpenChange={(open) => {
+          if (!open) setRenamingProject(false);
+        }}
+      >
+        <DialogContent className="corner-squircle dialog-soft-surface sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Rename project</DialogTitle>
+          </DialogHeader>
+          <Input
+            value={projectNameDraft}
+            onChange={(e) => setProjectNameDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                void commitProjectRename();
+              }
+            }}
+            autoFocus={true}
+            maxLength={120}
+            placeholder="Project name"
+            aria-label="Project name"
+            className="focus-visible:border-input focus-visible:ring-0"
+          />
+          <DialogFooter className="flex-wrap gap-2 sm:justify-end">
+            <Button type="button" variant="ghost" onClick={() => setRenamingProject(false)}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={() => void commitProjectRename()}
+              disabled={
+                !projectNameDraft.trim() || projectNameDraft.trim() === projectName
+              }
+            >
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <AlertDialog
+        open={deletingProject}
+        onOpenChange={(open) => {
+          if (!open) setDeletingProject(false);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete project</AlertDialogTitle>
+            <AlertDialogDescription>
+              Delete "{projectName}"? Its chats will be moved back to Recents.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={() => void commitProjectDelete()}>
               Delete
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/studio/frontend/src/features/chat/components/project-switcher.tsx
+++ b/studio/frontend/src/features/chat/components/project-switcher.tsx
@@ -75,7 +75,7 @@ export function ProjectSwitcher({
         side="bottom"
         align="start"
         sideOffset={0}
-        className="unsloth-plus-menu ring-0 min-w-56 max-w-72 max-h-72 font-heading"
+        className="unsloth-plus-menu project-switcher-menu ring-0 min-w-56 max-w-72 max-h-72 font-heading"
       >
         {showLoadingRow ? (
           <DropdownMenuItem disabled={true} className="text-muted-foreground">

--- a/studio/frontend/src/features/chat/components/project-switcher.tsx
+++ b/studio/frontend/src/features/chat/components/project-switcher.tsx
@@ -75,8 +75,11 @@ export function ProjectSwitcher({
         side="bottom"
         align="start"
         sideOffset={0}
-        className="unsloth-plus-menu project-switcher-menu ring-0 min-w-56 max-w-72 max-h-72 font-heading"
+        className="unsloth-plus-menu ring-0 min-w-56 max-w-72 font-heading"
       >
+        {/* Scroll the list here, not the container, so the rounded corners on
+            the scrollbar side are not squared off. */}
+        <div className="max-h-72 overflow-y-auto">
         {showLoadingRow ? (
           <DropdownMenuItem disabled={true} className="text-muted-foreground">
             Loading…
@@ -117,6 +120,7 @@ export function ProjectSwitcher({
         <DropdownMenuItem onSelect={onViewAllProjects}>
           View all projects
         </DropdownMenuItem>
+        </div>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/studio/frontend/src/features/chat/index.ts
+++ b/studio/frontend/src/features/chat/index.ts
@@ -53,6 +53,7 @@ export {
 export { PermissionModeDropdown } from "./permission-mode-select";
 export { useChatSearchStore } from "./stores/chat-search-store";
 export { usePinnedChatsStore } from "./stores/pinned-chats-store";
+export { usePinnedProjectsStore } from "./stores/pinned-projects-store";
 export { useChatPreferencesStore } from "./stores/chat-preferences-store";
 export {
   PLUS_MENU_ORDER,

--- a/studio/frontend/src/features/chat/index.ts
+++ b/studio/frontend/src/features/chat/index.ts
@@ -17,6 +17,7 @@ export {
   listRecommendedFolders,
   listScanFolders,
   loadModel,
+  notifyChatHistoryUpdated,
   removeScanFolder,
   revealCachedModel,
   type BrowseFoldersResponse,

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -74,21 +74,31 @@ type SortMode = "activity" | "name";
 // Default grid shows this many projects before "Show more".
 const PROJECTS_DEFAULT_LIMIT = 4;
 
-function formatUpdatedAgo(ts: number): string {
-  const diff = Date.now() - ts;
-  if (!Number.isFinite(diff) || diff < 0) return "just now";
-  const s = Math.floor(diff / 1000);
-  if (s < 60) return "just now";
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m} minute${m === 1 ? "" : "s"} ago`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h} hour${h === 1 ? "" : "s"} ago`;
-  const d = Math.floor(h / 24);
-  if (d < 30) return `${d} day${d === 1 ? "" : "s"} ago`;
-  const mo = Math.floor(d / 30);
-  if (mo < 12) return `${mo} month${mo === 1 ? "" : "s"} ago`;
-  const y = Math.floor(mo / 12);
-  return `${y} year${y === 1 ? "" : "s"} ago`;
+// Modified column, matching a file-list feel: Today / Yesterday / N days ago,
+// then a short date once it is over a week old.
+function formatModified(ts: number): string {
+  if (!Number.isFinite(ts)) return "";
+  const now = new Date();
+  const then = new Date(ts);
+  const startOfToday = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+  ).getTime();
+  const startOfThen = new Date(
+    then.getFullYear(),
+    then.getMonth(),
+    then.getDate(),
+  ).getTime();
+  const dayDiff = Math.round((startOfToday - startOfThen) / 86_400_000);
+  if (dayDiff <= 0) return "Today";
+  if (dayDiff === 1) return "Yesterday";
+  if (dayDiff < 7) return `${dayDiff} days ago`;
+  return then.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: then.getFullYear() === now.getFullYear() ? undefined : "numeric",
+  });
 }
 
 export function ProjectsPage() {
@@ -428,16 +438,22 @@ export function ProjectsPage() {
       </div>
 
       {!hasLoaded ? (
-        <div className="mt-12 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="mt-10">
+          <div className="flex items-center border-b border-border/60 px-3 pb-2 text-[13px] font-medium text-muted-foreground">
+            <span className="flex-1">Name</span>
+            <span className="w-40 shrink-0">Modified</span>
+            <span className="w-8 shrink-0" />
+          </div>
           {Array.from({ length: 6 }).map((_, index) => (
             <div
               key={index}
-              className="min-h-[172px] rounded-[26px] bg-card p-6 shadow-[0_2px_12px_-4px_rgba(0,0,0,0.10)] dark:shadow-none"
+              className="flex items-center gap-3 border-b border-border/40 px-3 py-3"
             >
-              <Skeleton className="size-10 rounded-[14px]" />
-              <Skeleton className="mt-4 h-5 w-2/3 rounded-[8px]" />
-              <Skeleton className="mt-2 h-4 w-4/5 rounded-[8px]" />
-              <Skeleton className="mt-8 h-3 w-24 rounded-[8px]" />
+              <Skeleton className="size-9 shrink-0 rounded-[10px]" />
+              <Skeleton className="h-4 w-40 rounded-[8px]" />
+              <span className="flex-1" />
+              <Skeleton className="h-4 w-16 rounded-[8px]" />
+              <span className="w-8 shrink-0" />
             </div>
           ))}
         </div>
@@ -464,9 +480,16 @@ export function ProjectsPage() {
         </div>
       ) : (
         <>
-        <div className="mt-12 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
-          {visibleProjects.map((project) => (
-            <div key={`wrap-${project.id}`} className="contents">
+        <div className="mt-10">
+          <div className="flex items-center border-b border-border/60 px-3 pb-2 text-[13px] font-medium text-muted-foreground">
+            <span className="flex-1">Name</span>
+            <span className="w-40 shrink-0">Modified</span>
+            <span className="w-8 shrink-0" />
+          </div>
+          {visibleProjects.map((project) => {
+            const pinned = pinnedProjectIdSet.has(project.id);
+            return (
+            <div key={`wrap-${project.id}`}>
             <input
               key={`import-${project.id}`}
               type="file"
@@ -493,23 +516,36 @@ export function ProjectsPage() {
                   openProject(project.id);
                 }
               }}
-              className="group/project-card relative flex min-h-[172px] cursor-pointer flex-col rounded-[26px] bg-card p-6 text-left shadow-[0_2px_12px_-4px_rgba(0,0,0,0.10)] transition-colors duration-150 hover:bg-[#f2f2f2] dark:shadow-none dark:hover:bg-accent/30 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              className="group/project-row relative flex cursor-pointer items-center gap-3 border-b border-border/50 px-3 py-2.5 text-left transition-colors duration-150 hover:bg-muted/60 dark:hover:bg-accent/30 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             >
-              <div className="flex items-start justify-between gap-2">
-                <span className="flex size-10 shrink-0 items-center justify-center rounded-[14px] bg-muted text-foreground/70 transition-colors group-hover/project-card:bg-primary/10 group-hover/project-card:text-primary">
-                  <HugeiconsIcon
-                    icon={Folder02Icon}
-                    strokeWidth={1.75}
-                    className="size-5"
-                  />
-                </span>
+              <span className="flex size-9 shrink-0 items-center justify-center rounded-[10px] bg-muted text-foreground/70 transition-colors group-hover/project-row:bg-primary/10 group-hover/project-row:text-primary">
+                <HugeiconsIcon
+                  icon={Folder02Icon}
+                  strokeWidth={1.75}
+                  className="size-5"
+                />
+              </span>
+              <span className="min-w-0 flex-1 truncate text-[15px] font-semibold text-foreground">
+                {project.name}
+              </span>
+              <span className="w-40 shrink-0 text-sm text-muted-foreground">
+                {formatModified(project.updatedAt)}
+              </span>
+              <div className="relative flex w-8 shrink-0 items-center justify-end">
+                {/* Pinned indicator; fades out on hover so the options button
+                    (absolutely placed) takes the same slot without reflow. */}
+                {pinned && (
+                  <span className="text-muted-foreground transition-opacity group-hover/project-row:opacity-0">
+                    <HugeiconsIcon icon={PinIcon} strokeWidth={1.75} className="size-4" />
+                  </span>
+                )}
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <button
                       type="button"
                       onClick={(e) => e.stopPropagation()}
                       aria-label="Project options"
-                      className="-mr-1 -mt-1 inline-flex size-7 shrink-0 items-center justify-center rounded-full text-muted-foreground opacity-0 transition-opacity hover:bg-black/5 hover:text-foreground dark:hover:bg-white/10 focus-visible:opacity-100 group-hover/project-card:opacity-100 data-[state=open]:bg-black/5 data-[state=open]:opacity-100 dark:data-[state=open]:bg-white/10"
+                      className="absolute right-0 top-1/2 inline-flex size-7 shrink-0 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground opacity-0 transition-opacity hover:bg-black/5 hover:text-foreground dark:hover:bg-white/10 focus-visible:opacity-100 group-hover/project-row:opacity-100 data-[state=open]:bg-black/5 data-[state=open]:opacity-100 dark:data-[state=open]:bg-white/10"
                     >
                       <MoreHorizontalIcon strokeWidth={1.75} className="size-icon" />
                     </button>
@@ -526,19 +562,11 @@ export function ProjectsPage() {
                       onSelect={() => togglePinProject(project.id)}
                     >
                       <HugeiconsIcon
-                        icon={
-                          pinnedProjectIdSet.has(project.id)
-                            ? PinOffIcon
-                            : PinIcon
-                        }
+                        icon={pinned ? PinOffIcon : PinIcon}
                         strokeWidth={1.75}
                         className="size-icon"
                       />
-                      <span>
-                        {pinnedProjectIdSet.has(project.id)
-                          ? "Unpin project"
-                          : "Pin project"}
-                      </span>
+                      <span>{pinned ? "Unpin project" : "Pin project"}</span>
                     </DropdownMenuItem>
                     <DropdownMenuItem
                       onSelect={() => {
@@ -588,20 +616,10 @@ export function ProjectsPage() {
                   </DropdownMenuContent>
                 </DropdownMenu>
               </div>
-              <h2 className="mt-4 truncate text-[16px] font-semibold text-foreground">
-                {project.name}
-              </h2>
-              {project.instructions ? (
-                <p className="mt-1.5 line-clamp-2 text-sm leading-relaxed text-muted-foreground">
-                  {project.instructions}
-                </p>
-              ) : null}
-              <span className="mt-auto pt-4 text-xs text-muted-foreground/80">
-                Updated {formatUpdatedAgo(project.updatedAt)}
-              </span>
             </div>
             </div>
-          ))}
+            );
+          })}
         </div>
         {!isSearching && (hiddenProjectCount > 0 || showAllProjects) && (
           <div className="mt-6 flex justify-center">

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -577,11 +577,12 @@ export function ProjectsPage() {
               <span className="w-40 shrink-0 text-sm text-muted-foreground">
                 {formatModified(project.updatedAt)}
               </span>
-              <div className="flex w-8 shrink-0 items-center justify-end">
-                {/* Pin indicator and options button swap via display so they
-                    never overlap: pin when idle, kebab on hover or menu open. */}
+              <div className="relative flex w-8 shrink-0 items-center justify-end">
+                {/* Pin fades out and the kebab fades in on hover, focus, or
+                    menu open. Absolute + opacity gating keeps them from
+                    overlapping while leaving the button keyboard-focusable. */}
                 {pinned && (
-                  <span className="text-muted-foreground group-hover/project-row:hidden group-has-[[data-state=open]]/project-row:hidden">
+                  <span className="text-muted-foreground transition-opacity group-hover/project-row:opacity-0 group-focus-within/project-row:opacity-0 group-has-[[data-state=open]]/project-row:opacity-0">
                     <HugeiconsIcon icon={PinIcon} strokeWidth={1.75} className="size-4" />
                   </span>
                 )}
@@ -591,7 +592,7 @@ export function ProjectsPage() {
                       type="button"
                       onClick={(e) => e.stopPropagation()}
                       aria-label="Project options"
-                      className="hidden size-7 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-black/5 hover:text-foreground dark:hover:bg-white/10 group-hover/project-row:flex data-[state=open]:flex data-[state=open]:bg-black/5 dark:data-[state=open]:bg-white/10"
+                      className="absolute right-0 flex size-7 shrink-0 items-center justify-center rounded-full text-muted-foreground opacity-0 transition hover:bg-black/5 hover:text-foreground focus-visible:opacity-100 group-hover/project-row:opacity-100 data-[state=open]:bg-black/5 data-[state=open]:opacity-100 dark:hover:bg-white/10 dark:data-[state=open]:bg-white/10"
                     >
                       <MoreHorizontalIcon strokeWidth={1.75} className="size-icon" />
                     </button>

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -39,6 +39,7 @@ import {
   renameChatProject,
   useChatProjects,
   useChatRuntimeStore,
+  usePinnedProjectsStore,
   type ProjectRecord,
 } from "@/features/chat";
 import {
@@ -47,6 +48,8 @@ import {
   Edit03Icon,
   Folder02Icon,
   FolderAddIcon,
+  PinIcon,
+  PinOffIcon,
   Search01Icon,
   Upload01Icon,
 } from "@hugeicons/core-free-icons";
@@ -91,6 +94,12 @@ export function ProjectsPage() {
 
   const [query, setQuery] = useState("");
   const [sortMode, setSortMode] = useState<SortMode>("activity");
+  const pinnedProjectIds = usePinnedProjectsStore((s) => s.pinnedIds);
+  const togglePinProject = usePinnedProjectsStore((s) => s.togglePin);
+  const pinnedProjectIdSet = useMemo(
+    () => new Set(pinnedProjectIds),
+    [pinnedProjectIds],
+  );
 
   const [creating, setCreating] = useState(false);
   const [nameDraft, setNameDraft] = useState("");
@@ -172,7 +181,8 @@ export function ProjectsPage() {
         ? a.name.localeCompare(b.name)
         : b.updatedAt - a.updatedAt,
     );
-    return filtered;
+    // Default view shows only the 4 most recent; search still spans all matches.
+    return trimmed ? filtered : filtered.slice(0, 4);
   }, [projects, query, sortMode]);
 
   function openProject(projectId: string) {
@@ -498,6 +508,24 @@ export function ProjectsPage() {
                     onKeyDown={(e) => e.stopPropagation()}
                     className="app-user-menu menu-soft-surface menu-flat-destructive ring-0 w-44 py-2 font-heading rounded-[14px] border-0"
                   >
+                    <DropdownMenuItem
+                      onSelect={() => togglePinProject(project.id)}
+                    >
+                      <HugeiconsIcon
+                        icon={
+                          pinnedProjectIdSet.has(project.id)
+                            ? PinOffIcon
+                            : PinIcon
+                        }
+                        strokeWidth={1.75}
+                        className="size-icon"
+                      />
+                      <span>
+                        {pinnedProjectIdSet.has(project.id)
+                          ? "Unpin project"
+                          : "Pin project"}
+                      </span>
+                    </DropdownMenuItem>
                     <DropdownMenuItem
                       onSelect={() => {
                         setRenameDraft(project.name);

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -332,7 +332,7 @@ export function ProjectsPage() {
   }
 
   return (
-    <main className="mx-auto w-full max-w-6xl px-6 py-10 font-heading sm:px-10">
+    <main className="mx-auto w-full max-w-4xl px-6 py-10 font-heading sm:px-10">
       {/* Global import file input */}
       <input
         ref={globalImportRef}
@@ -465,7 +465,6 @@ export function ProjectsPage() {
       {!hasLoaded ? (
         <div className="mt-10">
           <div className="flex items-center gap-3 border-b border-border/60 px-5 pb-2 text-[13px] font-medium text-muted-foreground">
-            <span className="mr-1 size-9 shrink-0" />
             <span className="flex-1">Name</span>
             <span className="w-40 shrink-0">Modified</span>
             <span className="w-8 shrink-0" />
@@ -507,10 +506,9 @@ export function ProjectsPage() {
       ) : (
         <>
         <div className="mt-10">
-          {/* Column header. The leading spacer matches the row folder icon so
-              Name and Modified line up with the values below. */}
+          {/* Column header. Name starts at the folder icon's left edge; the
+              right-anchored columns keep Modified over its values. */}
           <div className="flex items-center gap-3 border-b border-border/60 px-5 pb-2 text-[13px] font-medium text-muted-foreground">
-            <span className="mr-1 size-9 shrink-0" />
             <span className="flex-1">Name</span>
             <span className="w-40 shrink-0">Modified</span>
             <span className="w-8 shrink-0" />

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -56,7 +56,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { MoreHorizontalIcon } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   exportProjectConversations,
   exportBulkConversationsMerged,
@@ -71,8 +71,12 @@ import {
 
 type SortMode = "activity" | "name";
 
-// Default grid shows this many projects before "Show more".
-const PROJECTS_DEFAULT_LIMIT = 4;
+// Reveal this many more projects each time Show more is clicked.
+const PROJECTS_PAGE_STEP = 5;
+// Visible count before the fit-to-height measurement runs.
+const PROJECTS_INITIAL_FALLBACK = 8;
+// Approx list row height in px, used to estimate how many rows fit the page.
+const PROJECTS_ROW_HEIGHT = 57;
 
 // Modified column, matching a file-list feel: Today / Yesterday / N days ago,
 // then a short date once it is over a week old.
@@ -107,7 +111,10 @@ export function ProjectsPage() {
 
   const [query, setQuery] = useState("");
   const [sortMode, setSortMode] = useState<SortMode>("activity");
-  const [showAllProjects, setShowAllProjects] = useState(false);
+  // Rows that fit the page height (measured), plus any revealed via Show more.
+  const [baseFit, setBaseFit] = useState(PROJECTS_INITIAL_FALLBACK);
+  const [extraCount, setExtraCount] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
   const pinnedProjectIds = usePinnedProjectsStore((s) => s.pinnedIds);
   const togglePinProject = usePinnedProjectsStore((s) => s.togglePin);
   const pinnedProjectIdSet = useMemo(
@@ -197,16 +204,34 @@ export function ProjectsPage() {
     );
     return filtered;
   }, [projects, query, sortMode]);
-  // Default view shows only the 4 most recent, with "Show more" to reveal the
-  // rest. Search always spans all matches.
+  // Default view shows as many rows as fit the page; Show more reveals another
+  // page-step each click. Search always spans all matches.
   const isSearching = query.trim() !== "";
-  const capProjects = !isSearching && !showAllProjects;
-  const visibleProjects = capProjects
-    ? sortedProjects.slice(0, PROJECTS_DEFAULT_LIMIT)
-    : sortedProjects;
-  const hiddenProjectCount = capProjects
-    ? Math.max(0, sortedProjects.length - PROJECTS_DEFAULT_LIMIT)
-    : 0;
+  const visibleCount = baseFit + extraCount;
+  const visibleProjects = isSearching
+    ? sortedProjects
+    : sortedProjects.slice(0, visibleCount);
+  const hiddenProjectCount = isSearching
+    ? 0
+    : Math.max(0, sortedProjects.length - visibleCount);
+
+  // Estimate how many rows fit below the list's top so Show more only appears
+  // once projects overflow the page height.
+  useEffect(() => {
+    function measure() {
+      const el = listRef.current;
+      if (!el) return;
+      const top = el.getBoundingClientRect().top;
+      const reserve = 72; // Show more control plus bottom breathing room.
+      const fits = Math.floor(
+        (window.innerHeight - top - reserve) / PROJECTS_ROW_HEIGHT,
+      );
+      setBaseFit(Math.max(PROJECTS_PAGE_STEP, fits));
+    }
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [hasLoaded]);
 
   function openProject(projectId: string) {
     const runtime = useChatRuntimeStore.getState();
@@ -439,7 +464,8 @@ export function ProjectsPage() {
 
       {!hasLoaded ? (
         <div className="mt-10">
-          <div className="flex items-center border-b border-border/60 px-3 pb-2 text-[13px] font-medium text-muted-foreground">
+          <div className="flex items-center gap-3 border-b border-border/60 px-5 pb-2 text-[13px] font-medium text-muted-foreground">
+            <span className="mr-1 size-9 shrink-0" />
             <span className="flex-1">Name</span>
             <span className="w-40 shrink-0">Modified</span>
             <span className="w-8 shrink-0" />
@@ -447,9 +473,9 @@ export function ProjectsPage() {
           {Array.from({ length: 6 }).map((_, index) => (
             <div
               key={index}
-              className="flex items-center gap-3 border-b border-border/40 px-3 py-3"
+              className="flex items-center gap-3 border-b border-border/40 px-5 py-3"
             >
-              <Skeleton className="size-9 shrink-0 rounded-[10px]" />
+              <Skeleton className="mr-1 size-9 shrink-0 rounded-[10px]" />
               <Skeleton className="h-4 w-40 rounded-[8px]" />
               <span className="flex-1" />
               <Skeleton className="h-4 w-16 rounded-[8px]" />
@@ -481,11 +507,15 @@ export function ProjectsPage() {
       ) : (
         <>
         <div className="mt-10">
-          <div className="flex items-center border-b border-border/60 px-3 pb-2 text-[13px] font-medium text-muted-foreground">
+          {/* Column header. The leading spacer matches the row folder icon so
+              Name and Modified line up with the values below. */}
+          <div className="flex items-center gap-3 border-b border-border/60 px-5 pb-2 text-[13px] font-medium text-muted-foreground">
+            <span className="mr-1 size-9 shrink-0" />
             <span className="flex-1">Name</span>
             <span className="w-40 shrink-0">Modified</span>
             <span className="w-8 shrink-0" />
           </div>
+          <div ref={listRef}>
           {visibleProjects.map((project) => {
             const pinned = pinnedProjectIdSet.has(project.id);
             return (
@@ -516,9 +546,9 @@ export function ProjectsPage() {
                   openProject(project.id);
                 }
               }}
-              className="group/project-row relative flex cursor-pointer items-center gap-3 border-b border-border/50 px-3 py-2.5 text-left transition-colors duration-150 hover:bg-muted/60 dark:hover:bg-accent/30 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              className="group/project-row relative flex cursor-pointer items-center gap-3 border-b border-border/50 px-5 py-2.5 text-left transition-colors duration-150 hover:bg-muted/60 dark:hover:bg-accent/30 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             >
-              <span className="flex size-9 shrink-0 items-center justify-center rounded-[10px] bg-muted text-foreground/70 transition-colors group-hover/project-row:bg-primary/10 group-hover/project-row:text-primary">
+              <span className="mr-1 flex size-9 shrink-0 items-center justify-center rounded-[10px] bg-muted text-foreground/70 transition-colors group-hover/project-row:bg-primary/10 group-hover/project-row:text-primary">
                 <HugeiconsIcon
                   icon={Folder02Icon}
                   strokeWidth={1.75}
@@ -531,11 +561,11 @@ export function ProjectsPage() {
               <span className="w-40 shrink-0 text-sm text-muted-foreground">
                 {formatModified(project.updatedAt)}
               </span>
-              <div className="relative flex w-8 shrink-0 items-center justify-end">
-                {/* Pinned indicator; fades out on hover so the options button
-                    (absolutely placed) takes the same slot without reflow. */}
+              <div className="flex w-8 shrink-0 items-center justify-end">
+                {/* Pin indicator and options button swap via display so they
+                    never overlap: pin when idle, kebab on hover or menu open. */}
                 {pinned && (
-                  <span className="text-muted-foreground transition-opacity group-hover/project-row:opacity-0">
+                  <span className="text-muted-foreground group-hover/project-row:hidden group-has-[[data-state=open]]/project-row:hidden">
                     <HugeiconsIcon icon={PinIcon} strokeWidth={1.75} className="size-4" />
                   </span>
                 )}
@@ -545,7 +575,7 @@ export function ProjectsPage() {
                       type="button"
                       onClick={(e) => e.stopPropagation()}
                       aria-label="Project options"
-                      className="absolute right-0 top-1/2 inline-flex size-7 shrink-0 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground opacity-0 transition-opacity hover:bg-black/5 hover:text-foreground dark:hover:bg-white/10 focus-visible:opacity-100 group-hover/project-row:opacity-100 data-[state=open]:bg-black/5 data-[state=open]:opacity-100 dark:data-[state=open]:bg-white/10"
+                      className="hidden size-7 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-black/5 hover:text-foreground dark:hover:bg-white/10 group-hover/project-row:flex data-[state=open]:flex data-[state=open]:bg-black/5 dark:data-[state=open]:bg-white/10"
                     >
                       <MoreHorizontalIcon strokeWidth={1.75} className="size-icon" />
                     </button>
@@ -620,17 +650,18 @@ export function ProjectsPage() {
             </div>
             );
           })}
+          </div>
         </div>
-        {!isSearching && (hiddenProjectCount > 0 || showAllProjects) && (
+        {hiddenProjectCount > 0 && (
           <div className="mt-6 flex justify-center">
             <button
               type="button"
-              onClick={() => setShowAllProjects((v) => !v)}
+              onClick={() =>
+                setExtraCount((n) => n + PROJECTS_PAGE_STEP)
+              }
               className="text-[13px] font-medium text-muted-foreground transition-colors hover:text-foreground"
             >
-              {showAllProjects
-                ? "Show less"
-                : `Show more (${hiddenProjectCount})`}
+              {`Show more (${hiddenProjectCount})`}
             </button>
           </div>
         )}

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -76,7 +76,7 @@ const PROJECTS_PAGE_STEP = 12;
 // Visible count before the fit-to-height measurement runs.
 const PROJECTS_INITIAL_FALLBACK = 8;
 // Approx list row height in px, used to estimate how many rows fit the page.
-const PROJECTS_ROW_HEIGHT = 57;
+const PROJECTS_ROW_HEIGHT = 68;
 
 // Modified column, matching a file-list feel: Today / Yesterday / N days ago,
 // then a short date once it is over a week old.
@@ -490,7 +490,7 @@ export function ProjectsPage() {
           {Array.from({ length: 6 }).map((_, index) => (
             <div
               key={index}
-              className="flex items-center gap-3 rounded-2xl px-5 py-3"
+              className="flex items-center gap-3 rounded-xl px-5 py-4"
             >
               <Skeleton className="mr-1 size-9 shrink-0 rounded-[10px]" />
               <Skeleton className="h-4 w-40 rounded-[8px]" />
@@ -562,7 +562,7 @@ export function ProjectsPage() {
                   openProject(project.id);
                 }
               }}
-              className="group/project-row relative flex cursor-pointer items-center gap-3 rounded-2xl px-5 py-2.5 text-left transition-colors duration-150 hover:bg-muted/70 dark:hover:bg-white/[0.055] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              className="group/project-row relative flex cursor-pointer items-center gap-3 rounded-xl px-5 py-4 text-left transition-colors duration-150 hover:bg-muted/70 dark:hover:bg-white/[0.055] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             >
               <span className="mr-1 flex size-9 shrink-0 items-center justify-center rounded-[10px] bg-muted text-foreground/70 transition-colors group-hover/project-row:bg-primary/10 group-hover/project-row:text-primary">
                 <HugeiconsIcon

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -482,7 +482,7 @@ export function ProjectsPage() {
 
       {!hasLoaded ? (
         <div className="mt-10">
-          <div className="flex items-center gap-3 border-b border-border/60 px-5 pb-2 text-[13px] font-medium text-muted-foreground">
+          <div className="mb-1 flex items-center gap-3 px-5 pb-1 text-[13px] font-medium text-muted-foreground">
             <span className="flex-1">Name</span>
             <span className="w-40 shrink-0">Modified</span>
             <span className="w-8 shrink-0" />
@@ -490,7 +490,7 @@ export function ProjectsPage() {
           {Array.from({ length: 6 }).map((_, index) => (
             <div
               key={index}
-              className="flex items-center gap-3 border-b border-border/40 px-5 py-3"
+              className="flex items-center gap-3 rounded-2xl px-5 py-3"
             >
               <Skeleton className="mr-1 size-9 shrink-0 rounded-[10px]" />
               <Skeleton className="h-4 w-40 rounded-[8px]" />
@@ -526,7 +526,7 @@ export function ProjectsPage() {
         <div className="mt-10">
           {/* Column header. Name starts at the folder icon's left edge; the
               right-anchored columns keep Modified over its values. */}
-          <div className="flex items-center gap-3 border-b border-border/60 px-5 pb-2 text-[13px] font-medium text-muted-foreground">
+          <div className="mb-1 flex items-center gap-3 px-5 pb-1 text-[13px] font-medium text-muted-foreground">
             <span className="flex-1">Name</span>
             <span className="w-40 shrink-0">Modified</span>
             <span className="w-8 shrink-0" />
@@ -562,7 +562,7 @@ export function ProjectsPage() {
                   openProject(project.id);
                 }
               }}
-              className="group/project-row relative flex cursor-pointer items-center gap-3 border-b border-border/50 px-5 py-2.5 text-left transition-colors duration-150 hover:bg-muted/60 dark:hover:bg-accent/30 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              className="group/project-row relative flex cursor-pointer items-center gap-3 rounded-2xl px-5 py-2.5 text-left transition-colors duration-150 hover:bg-muted/70 dark:hover:bg-white/[0.055] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             >
               <span className="mr-1 flex size-9 shrink-0 items-center justify-center rounded-[10px] bg-muted text-foreground/70 transition-colors group-hover/project-row:bg-primary/10 group-hover/project-row:text-primary">
                 <HugeiconsIcon

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -481,7 +481,7 @@ export function ProjectsPage() {
       </div>
 
       {!hasLoaded ? (
-        <div className="mt-10">
+        <div className="mt-16">
           <div className="mb-1 flex items-center gap-3 px-5 pb-1 text-[13px] font-medium text-muted-foreground">
             <span className="flex-1">Name</span>
             <span className="w-40 shrink-0">Modified</span>
@@ -523,7 +523,7 @@ export function ProjectsPage() {
         </div>
       ) : (
         <>
-        <div className="mt-10">
+        <div className="mt-16">
           {/* Column header. Name starts at the folder icon's left edge; the
               right-anchored columns keep Modified over its values. */}
           <div className="mb-1 flex items-center gap-3 px-5 pb-1 text-[13px] font-medium text-muted-foreground">

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -71,6 +71,9 @@ import {
 
 type SortMode = "activity" | "name";
 
+// Default grid shows this many projects before "Show more".
+const PROJECTS_DEFAULT_LIMIT = 4;
+
 function formatUpdatedAgo(ts: number): string {
   const diff = Date.now() - ts;
   if (!Number.isFinite(diff) || diff < 0) return "just now";
@@ -94,6 +97,7 @@ export function ProjectsPage() {
 
   const [query, setQuery] = useState("");
   const [sortMode, setSortMode] = useState<SortMode>("activity");
+  const [showAllProjects, setShowAllProjects] = useState(false);
   const pinnedProjectIds = usePinnedProjectsStore((s) => s.pinnedIds);
   const togglePinProject = usePinnedProjectsStore((s) => s.togglePin);
   const pinnedProjectIdSet = useMemo(
@@ -171,7 +175,7 @@ export function ProjectsPage() {
     await handleImport(file, target);
   }
 
-  const visibleProjects = useMemo(() => {
+  const sortedProjects = useMemo(() => {
     const trimmed = query.trim().toLowerCase();
     const filtered = trimmed
       ? projects.filter((p) => p.name.toLowerCase().includes(trimmed))
@@ -181,9 +185,18 @@ export function ProjectsPage() {
         ? a.name.localeCompare(b.name)
         : b.updatedAt - a.updatedAt,
     );
-    // Default view shows only the 4 most recent; search still spans all matches.
-    return trimmed ? filtered : filtered.slice(0, 4);
+    return filtered;
   }, [projects, query, sortMode]);
+  // Default view shows only the 4 most recent, with "Show more" to reveal the
+  // rest. Search always spans all matches.
+  const isSearching = query.trim() !== "";
+  const capProjects = !isSearching && !showAllProjects;
+  const visibleProjects = capProjects
+    ? sortedProjects.slice(0, PROJECTS_DEFAULT_LIMIT)
+    : sortedProjects;
+  const hiddenProjectCount = capProjects
+    ? Math.max(0, sortedProjects.length - PROJECTS_DEFAULT_LIMIT)
+    : 0;
 
   function openProject(projectId: string) {
     const runtime = useChatRuntimeStore.getState();
@@ -450,6 +463,7 @@ export function ProjectsPage() {
           )}
         </div>
       ) : (
+        <>
         <div className="mt-12 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
           {visibleProjects.map((project) => (
             <div key={`wrap-${project.id}`} className="contents">
@@ -589,6 +603,20 @@ export function ProjectsPage() {
             </div>
           ))}
         </div>
+        {!isSearching && (hiddenProjectCount > 0 || showAllProjects) && (
+          <div className="mt-6 flex justify-center">
+            <button
+              type="button"
+              onClick={() => setShowAllProjects((v) => !v)}
+              className="text-[13px] font-medium text-muted-foreground transition-colors hover:text-foreground"
+            >
+              {showAllProjects
+                ? "Show less"
+                : `Show more (${hiddenProjectCount})`}
+            </button>
+          </div>
+        )}
+        </>
       )}
 
       {/* Create project */}

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -332,7 +332,7 @@ export function ProjectsPage() {
   }
 
   return (
-    <main className="mx-auto w-full max-w-4xl px-6 py-10 font-heading sm:px-10">
+    <main className="mx-auto w-full max-w-5xl px-6 pb-10 pt-16 font-heading sm:px-10">
       {/* Global import file input */}
       <input
         ref={globalImportRef}

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -71,8 +71,8 @@ import {
 
 type SortMode = "activity" | "name";
 
-// Reveal this many more projects each time Show more is clicked.
-const PROJECTS_PAGE_STEP = 5;
+// Reveal this many more projects each time the user scrolls near the bottom.
+const PROJECTS_PAGE_STEP = 12;
 // Visible count before the fit-to-height measurement runs.
 const PROJECTS_INITIAL_FALLBACK = 8;
 // Approx list row height in px, used to estimate how many rows fit the page.
@@ -115,6 +115,7 @@ export function ProjectsPage() {
   const [baseFit, setBaseFit] = useState(PROJECTS_INITIAL_FALLBACK);
   const [extraCount, setExtraCount] = useState(0);
   const listRef = useRef<HTMLDivElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
   const pinnedProjectIds = usePinnedProjectsStore((s) => s.pinnedIds);
   const togglePinProject = usePinnedProjectsStore((s) => s.togglePin);
   const pinnedProjectIdSet = useMemo(
@@ -204,25 +205,23 @@ export function ProjectsPage() {
     );
     return filtered;
   }, [projects, query, sortMode]);
-  // Default view shows as many rows as fit the page; Show more reveals another
-  // page-step each click. Search always spans all matches.
+  // Default view shows as many rows as fit the page, then loads more as the
+  // user scrolls near the bottom. Search always spans every project.
   const isSearching = query.trim() !== "";
   const visibleCount = baseFit + extraCount;
   const visibleProjects = isSearching
     ? sortedProjects
     : sortedProjects.slice(0, visibleCount);
-  const hiddenProjectCount = isSearching
-    ? 0
-    : Math.max(0, sortedProjects.length - visibleCount);
+  const hasMore = !isSearching && sortedProjects.length > visibleCount;
 
-  // Estimate how many rows fit below the list's top so Show more only appears
-  // once projects overflow the page height.
+  // Estimate how many rows fit below the list's top so the first page fills the
+  // screen without loading everything up front.
   useEffect(() => {
     function measure() {
       const el = listRef.current;
       if (!el) return;
       const top = el.getBoundingClientRect().top;
-      const reserve = 72; // Show more control plus bottom breathing room.
+      const reserve = 24; // bottom breathing room
       const fits = Math.floor(
         (window.innerHeight - top - reserve) / PROJECTS_ROW_HEIGHT,
       );
@@ -232,6 +231,25 @@ export function ProjectsPage() {
     window.addEventListener("resize", measure);
     return () => window.removeEventListener("resize", measure);
   }, [hasLoaded]);
+
+  // Infinite scroll: reveal another page-step whenever the sentinel near the
+  // list bottom scrolls into view.
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el || !hasMore) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          setExtraCount((n) => n + PROJECTS_PAGE_STEP);
+        }
+      },
+      { rootMargin: "300px" },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+    // Re-observe after each load so it keeps filling while the sentinel stays
+    // in view (IntersectionObserver does not re-fire on a steady intersection).
+  }, [hasMore, visibleCount]);
 
   function openProject(projectId: string) {
     const runtime = useChatRuntimeStore.getState();
@@ -648,21 +666,10 @@ export function ProjectsPage() {
             </div>
             );
           })}
+          {/* Loads the next page-step when scrolled into view. */}
+          {hasMore && <div ref={sentinelRef} className="h-px w-full" />}
           </div>
         </div>
-        {hiddenProjectCount > 0 && (
-          <div className="mt-6 flex justify-center">
-            <button
-              type="button"
-              onClick={() =>
-                setExtraCount((n) => n + PROJECTS_PAGE_STEP)
-              }
-              className="text-[13px] font-medium text-muted-foreground transition-colors hover:text-foreground"
-            >
-              {`Show more (${hiddenProjectCount})`}
-            </button>
-          </div>
-        )}
         </>
       )}
 

--- a/studio/frontend/src/features/chat/projects-page.tsx
+++ b/studio/frontend/src/features/chat/projects-page.tsx
@@ -795,8 +795,8 @@ export function ProjectsPage() {
             <DialogTitle>Delete project</DialogTitle>
           </DialogHeader>
           <p className="text-sm text-muted-foreground">
-            Are you sure you want to delete <em>{deleting?.name}</em>? Chats in this
-            project will be moved back to Recents.
+            Are you sure you want to delete <em>{deleting?.name}</em>? Its chats will
+            be permanently deleted.
           </p>
           <DialogFooter className="flex-wrap gap-2 sm:justify-end">
             <Button type="button" variant="ghost" onClick={() => setDeleting(null)}>

--- a/studio/frontend/src/features/chat/stores/pinned-projects-store.ts
+++ b/studio/frontend/src/features/chat/stores/pinned-projects-store.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+// Client-side pin state for projects, keyed by project id. Kept in
+// localStorage. Pinned projects drive the sidebar "Projects" section; new pins
+// are prepended so the most recently pinned project sorts first.
+export interface PinnedProjectsState {
+  pinnedIds: string[];
+  togglePin: (id: string) => void;
+  unpin: (id: string) => void;
+}
+
+export const usePinnedProjectsStore = create<PinnedProjectsState>()(
+  persist(
+    (set) => ({
+      pinnedIds: [],
+      togglePin: (id) =>
+        set((state) => ({
+          pinnedIds: state.pinnedIds.includes(id)
+            ? state.pinnedIds.filter((x) => x !== id)
+            : [id, ...state.pinnedIds],
+        })),
+      unpin: (id) =>
+        set((state) => ({
+          pinnedIds: state.pinnedIds.filter((x) => x !== id),
+        })),
+    }),
+    {
+      name: "unsloth_pinned_projects",
+      merge: (persisted, current) => {
+        const saved = persisted as Partial<PinnedProjectsState> | undefined;
+        return {
+          ...current,
+          pinnedIds: Array.isArray(saved?.pinnedIds) ? saved.pinnedIds : [],
+        };
+      },
+    },
+  ),
+);

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1818,6 +1818,15 @@ html[data-chat-font] .aui-root {
 		border-radius: 12px;
 	}
 
+	/* Project switcher rows are short, so a smaller radius reads as a rounded
+	   rectangle rather than a pill. */
+	.unsloth-plus-menu.project-switcher-menu :is(
+			[data-slot="dropdown-menu-item"],
+			[data-slot="dropdown-menu-sub-trigger"]
+		) {
+		border-radius: 9px;
+	}
+
 	.unsloth-plus-menu [data-slot="dropdown-menu-label"] {
 		@apply pl-3 pr-3 py-1.5 text-[12px];
 	}

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1818,15 +1818,6 @@ html[data-chat-font] .aui-root {
 		border-radius: 12px;
 	}
 
-	/* Project switcher rows are short, so a smaller radius reads as a rounded
-	   rectangle rather than a pill. */
-	.unsloth-plus-menu.project-switcher-menu :is(
-			[data-slot="dropdown-menu-item"],
-			[data-slot="dropdown-menu-sub-trigger"]
-		) {
-		border-radius: 9px;
-	}
-
 	.unsloth-plus-menu [data-slot="dropdown-menu-label"] {
 		@apply pl-3 pr-3 py-1.5 text-[12px];
 	}


### PR DESCRIPTION
## What

Turns Studio projects into first-class, pinnable items, reworks the Projects page into a list, and fixes several chat-session and dialog bugs in projects.

### Project pinning
- New per-project pin, mirroring how chats pin. Pin or unpin from the Projects page row menu or from the sidebar.
- Pinned projects fold into the existing Pinned section (no separate heading), the same way ChatGPT groups pins. Pinned projects show a folder icon; pinned chats show a chat icon.
- Each pinned project reveals its recent chats nested below: the 4 most recent, with "Show more" to reveal the rest. Clicking the project row expands or collapses its chats. Show more/less uses a lighter, slightly smaller label in both light and dark mode.
- Each pinned project has a new-chat button and an options menu (Project home, New chat, Rename project, Unpin project, Delete project), reusing the existing rename and delete dialogs.

### Projects page
- The card grid is now a list with Name and Modified columns. Pinned rows show a pin indicator; the row options menu appears on hover.
- Default view shows the 4 most recent projects with a Show more toggle. Search still spans all projects.
- Row menu keeps Pin, Rename, Import chats, Export, and Delete.

### Project chats in the sidebar
- Chats nested under a pinned project use the same row as any other chat, so they get the full options menu (Rename, Pin, Move to project, Export, Archive, Delete) plus a hover pin quick-action.
- Pinning a chat inside a project promotes it into the pinned chats list and removes it from the project's nested list, so it appears once and is never hidden by the recent-chats cap.
- The sidebar highlights only the open chat, not its parent project folder, while a chat inside the project is active.
- Rename project uses the edit icon so it no longer matches the New chat icon.

### Chat-session and dialog fixes
- The project landing composer no longer queues prompts. Queuing a new chat there misbound the thread, so the queue (including the queue button and saved-prompt Run list) now runs only once you are inside a chat session.
- Starting a new chat inside a project no longer reuses the previous chat. Project new-chat navigation now rotates the thread nonce so each new chat is its own session.
- Thread nonces fall back off crypto.randomUUID for non-secure (HTTP LAN) contexts where it is undefined.
- The delete-files toggle resets when a project delete dialog opens, so a later delete never inherits it. The rename dialog seeds its draft from the project name.
- Deleting a project while viewing one of its chats through a thread-only URL now redirects to a fresh chat instead of leaving the user on a deleted thread.

## How
- New `pinned-projects-store` (localStorage, same shape as the pinned-chats store), exported from the chat feature index.
- The sidebar Pinned section renders pinned projects and their nested chats, then pinned chats, styled to match the existing nav pills (height, roundness, icon and font size).
- Project chat actions reuse the shared archive, delete, move, and export helpers, so behavior matches the sidebar.

## Notes
- No backend or hardware paths change. This is frontend only.
- Pin state is per user in localStorage; behavior is unchanged when nothing is pinned.
