### PR TITLE
Studio: respect offline mode for RAG embedding-model checks

### DIFF
--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
+from contextlib import contextmanager, nullcontext
 from functools import lru_cache
 from typing import Callable
 
@@ -163,14 +164,20 @@ def _guard_model_security(name: str, local_only: bool = False) -> None:
         )
 
 
-def _st_accepts_local_files_only(st_cls) -> bool:
-    """Whether this SentenceTransformer version accepts ``local_files_only`` (added in newer
-    releases). Passing it to an older constructor raises, so gate on the signature."""
+@contextmanager
+def _force_hf_hub_offline():
+    """Force ``HF_HUB_OFFLINE`` for the duration so the load stays fully local even on a
+    sentence-transformers / huggingface_hub that ignores ``TRANSFORMERS_OFFLINE`` or predates
+    the ``local_files_only`` constructor arg. Restores the prior value afterward."""
+    prior = os.environ.get("HF_HUB_OFFLINE")
+    os.environ["HF_HUB_OFFLINE"] = "1"
     try:
-        import inspect
-        return "local_files_only" in inspect.signature(st_cls.__init__).parameters
-    except Exception:
-        return False
+        yield
+    finally:
+        if prior is None:
+            os.environ.pop("HF_HUB_OFFLINE", None)
+        else:
+            os.environ["HF_HUB_OFFLINE"] = prior
 
 
 def _get(model_name: str | None = None):
@@ -189,12 +196,13 @@ def _get(model_name: str | None = None):
             device = _device()
             logger.info("loading embedding model %s on %s", name, device)
             _guard_model_security(name, local_only)
-            st_kwargs = dict(device = device, model_kwargs = dtype_kwargs("float16"))
-            if local_only and _st_accepts_local_files_only(SentenceTransformer):
-                # Keep the load fully local so a TRANSFORMERS_OFFLINE-only session (which
-                # huggingface_hub ignores) still never reaches the network.
-                st_kwargs["local_files_only"] = True
-            _model = SentenceTransformer(name, **st_kwargs)
+            # Offline, force HF_HUB_OFFLINE around the load so any ST / huggingface_hub version
+            # (including ones that ignore TRANSFORMERS_OFFLINE or lack local_files_only) stays
+            # local and never retries the network for an uncached file.
+            with _force_hf_hub_offline() if local_only else nullcontext():
+                _model = SentenceTransformer(
+                    name, device = device, model_kwargs = dtype_kwargs("float16")
+                )
             _name = name
         return _model
 

--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -22,6 +22,7 @@ from typing import Callable
 
 from utils.hardware.hardware import DeviceType, get_device
 from utils.transformers_dtype import dtype_kwargs
+from utils.utils import hf_env_offline
 
 from . import config
 
@@ -119,30 +120,56 @@ def _st_module_subdirs(name: str, token: str | None) -> tuple[str, ...]:
         return ()
 
 
-def _guard_model_security(name: str) -> None:
+def _guard_model_security(name: str, local_only: bool = False) -> None:
     """Refuse to load a repo HF flagged as unsafe: a poisoned pickle deserializes inside
     SentenceTransformer regardless of trust_remote_code. Defense in depth behind the
     /settings gate (a name can also arrive via env/default); local paths and unreachable
     scans fail open inside evaluate_file_security. Never bricks the embedder on a gate error.
+
+    ``local_only`` (offline) inspects the local cache and fails closed on an unscanned pickle
+    weight; the subdir probes are skipped because they would hit the network and hang, and
+    the offline gate walks the whole snapshot anyway.
     """
     try:
         from utils.security import evaluate_file_security, security_load_subdirs
 
         token = _ambient_hf_token()
-        # Union the audio-model load roots with the ST module dirs so a flagged pickle
-        # directly under a Transformer module dir (0_Transformer/) blocks instead of
-        # passing as an unreferenced nested shard.
-        load_subdirs = tuple(
-            dict.fromkeys((*security_load_subdirs(name, token), *_st_module_subdirs(name, token)))
-        )
-        blocked = evaluate_file_security(name, hf_token = token, load_subdirs = load_subdirs).blocked
+        if local_only:
+            load_subdirs = ()
+        else:
+            # Union the audio-model load roots with the ST module dirs so a flagged pickle
+            # directly under a Transformer module dir (0_Transformer/) blocks instead of
+            # passing as an unreferenced nested shard.
+            load_subdirs = tuple(
+                dict.fromkeys((*security_load_subdirs(name, token), *_st_module_subdirs(name, token)))
+            )
+        blocked = evaluate_file_security(
+            name, hf_token = token, load_subdirs = load_subdirs, local_only_load = local_only
+        ).blocked
     except Exception:
         return
     if blocked:
-        raise UnsafeEmbeddingModelError(
-            f"Embedding model {name!r} is flagged as unsafe by Hugging Face's security "
-            "scan; refusing to load. Set a different RAG embedding model."
+        reason = (
+            "has cached pickle weights that cannot be security-scanned offline and no "
+            "safetensors alternative"
+            if local_only
+            else "is flagged as unsafe by Hugging Face's security scan"
         )
+        raise UnsafeEmbeddingModelError(
+            f"Embedding model {name!r} {reason}; refusing to load. "
+            "Set a different RAG embedding model."
+        )
+
+
+def _st_accepts_local_files_only(st_cls) -> bool:
+    """Whether this SentenceTransformer version accepts ``local_files_only`` (added in newer
+    releases). Passing it to an older constructor raises, so gate on the signature."""
+    try:
+        import inspect
+
+        return "local_files_only" in inspect.signature(st_cls.__init__).parameters
+    except Exception:
+        return False
 
 
 def _get(model_name: str | None = None):
@@ -150,6 +177,9 @@ def _get(model_name: str | None = None):
     for a ~1.5x speedup at negligible accuracy loss."""
     global _model, _name
     name = model_name or config.effective_embedding_model()
+    # Capture the offline state once so the security gate and the load agree (no window
+    # where the gate is skipped as offline but the constructor then reaches the network).
+    local_only = hf_env_offline()
     with _lock:
         if _model is None or _name != name:
             _install_torchao_stub_once()
@@ -157,8 +187,13 @@ def _get(model_name: str | None = None):
 
             device = _device()
             logger.info("loading embedding model %s on %s", name, device)
-            _guard_model_security(name)
-            _model = SentenceTransformer(name, device = device, model_kwargs = dtype_kwargs("float16"))
+            _guard_model_security(name, local_only)
+            st_kwargs = dict(device = device, model_kwargs = dtype_kwargs("float16"))
+            if local_only and _st_accepts_local_files_only(SentenceTransformer):
+                # Keep the load fully local so a TRANSFORMERS_OFFLINE-only session (which
+                # huggingface_hub ignores) still never reaches the network.
+                st_kwargs["local_files_only"] = True
+            _model = SentenceTransformer(name, **st_kwargs)
             _name = name
         return _model
 

--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -190,13 +190,20 @@ def _get(model_name: str | None = None):
             logger.info("loading embedding model %s on %s", name, device)
             _guard_model_security(name, local_only)
             st_kwargs = dict(device = device, model_kwargs = dtype_kwargs("float16"))
-            if local_only and _st_accepts_local_files_only(SentenceTransformer):
-                # local_files_only forces snapshot_download to cache-only for this call,
-                # independent of the process-wide HF_HUB_OFFLINE (frozen at import). An older ST
-                # without this arg relies on a launch-time HF_HUB_OFFLINE / TRANSFORMERS_OFFLINE,
-                # which huggingface_hub folds into its offline mode when first imported.
-                st_kwargs["local_files_only"] = True
-            _model = SentenceTransformer(name, **st_kwargs)
+            load_target = name
+            if local_only:
+                from utils.utils import hf_cache_snapshot_dir
+
+                snapshot = hf_cache_snapshot_dir(name)
+                if snapshot is not None:
+                    # Load from the resolved local snapshot dir: a local path never touches the
+                    # Hub, so this is offline-safe on ANY sentence-transformers version (even ones
+                    # predating local_files_only). If nothing is cached we fall through to a
+                    # cache-only repo load, which fails fast offline instead of hanging.
+                    load_target = str(snapshot)
+                elif _st_accepts_local_files_only(SentenceTransformer):
+                    st_kwargs["local_files_only"] = True
+            _model = SentenceTransformer(load_target, **st_kwargs)
             _name = name
         return _model
 

--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -193,7 +193,6 @@ def _get(model_name: str | None = None):
             load_target = name
             if local_only:
                 from utils.utils import hf_cache_snapshot_dir
-
                 snapshot = hf_cache_snapshot_dir(name)
                 if snapshot is not None:
                     # Load from the resolved local snapshot dir: a local path never touches the

--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import logging
 import os
 import threading
-from contextlib import contextmanager, nullcontext
 from functools import lru_cache
 from typing import Callable
 
@@ -164,20 +163,15 @@ def _guard_model_security(name: str, local_only: bool = False) -> None:
         )
 
 
-@contextmanager
-def _force_hf_hub_offline():
-    """Force ``HF_HUB_OFFLINE`` for the duration so the load stays fully local even on a
-    sentence-transformers / huggingface_hub that ignores ``TRANSFORMERS_OFFLINE`` or predates
-    the ``local_files_only`` constructor arg. Restores the prior value afterward."""
-    prior = os.environ.get("HF_HUB_OFFLINE")
-    os.environ["HF_HUB_OFFLINE"] = "1"
+def _st_accepts_local_files_only(st_cls) -> bool:
+    """Whether this SentenceTransformer version accepts ``local_files_only`` (added in newer
+    releases). Passing it to an older constructor raises, so gate on the signature."""
     try:
-        yield
-    finally:
-        if prior is None:
-            os.environ.pop("HF_HUB_OFFLINE", None)
-        else:
-            os.environ["HF_HUB_OFFLINE"] = prior
+        import inspect
+
+        return "local_files_only" in inspect.signature(st_cls.__init__).parameters
+    except Exception:
+        return False
 
 
 def _get(model_name: str | None = None):
@@ -196,13 +190,14 @@ def _get(model_name: str | None = None):
             device = _device()
             logger.info("loading embedding model %s on %s", name, device)
             _guard_model_security(name, local_only)
-            # Offline, force HF_HUB_OFFLINE around the load so any ST / huggingface_hub version
-            # (including ones that ignore TRANSFORMERS_OFFLINE or lack local_files_only) stays
-            # local and never retries the network for an uncached file.
-            with _force_hf_hub_offline() if local_only else nullcontext():
-                _model = SentenceTransformer(
-                    name, device = device, model_kwargs = dtype_kwargs("float16")
-                )
+            st_kwargs = dict(device = device, model_kwargs = dtype_kwargs("float16"))
+            if local_only and _st_accepts_local_files_only(SentenceTransformer):
+                # local_files_only forces snapshot_download to cache-only for this call,
+                # independent of the process-wide HF_HUB_OFFLINE (frozen at import). An older ST
+                # without this arg relies on a launch-time HF_HUB_OFFLINE / TRANSFORMERS_OFFLINE,
+                # which huggingface_hub folds into its offline mode when first imported.
+                st_kwargs["local_files_only"] = True
+            _model = SentenceTransformer(name, **st_kwargs)
             _name = name
         return _model
 

--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -141,7 +141,9 @@ def _guard_model_security(name: str, local_only: bool = False) -> None:
             # directly under a Transformer module dir (0_Transformer/) blocks instead of
             # passing as an unreferenced nested shard.
             load_subdirs = tuple(
-                dict.fromkeys((*security_load_subdirs(name, token), *_st_module_subdirs(name, token)))
+                dict.fromkeys(
+                    (*security_load_subdirs(name, token), *_st_module_subdirs(name, token))
+                )
             )
         blocked = evaluate_file_security(
             name, hf_token = token, load_subdirs = load_subdirs, local_only_load = local_only
@@ -166,7 +168,6 @@ def _st_accepts_local_files_only(st_cls) -> bool:
     releases). Passing it to an older constructor raises, so gate on the signature."""
     try:
         import inspect
-
         return "local_files_only" in inspect.signature(st_cls.__init__).parameters
     except Exception:
         return False

--- a/studio/backend/core/rag/embeddings.py
+++ b/studio/backend/core/rag/embeddings.py
@@ -168,7 +168,6 @@ def _st_accepts_local_files_only(st_cls) -> bool:
     releases). Passing it to an older constructor raises, so gate on the signature."""
     try:
         import inspect
-
         return "local_files_only" in inspect.signature(st_cls.__init__).parameters
     except Exception:
         return False

--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -494,8 +494,11 @@ def update_embedding_model(
             # like gte-modernbert) is unverifiable without the Hub metadata. If the repo is
             # already cached and loadable, accept it rather than raising a 409 that online
             # would not -- SentenceTransformer can load any cached encoder. Uncached -> 409.
-            from utils.utils import hf_cache_snapshot_dir
-            offline_cached = local_only_load and hf_cache_snapshot_dir(model) is not None
+            from utils.utils import hf_cache_snapshot_is_loadable
+
+            # Require a genuinely loadable cache (config + weights), not just a resolved
+            # refs/main, so a metadata-only partial cache still gets the forceable 409.
+            offline_cached = local_only_load and hf_cache_snapshot_is_loadable(model)
             if not offline_cached:
                 raise HTTPException(
                     status_code = 409,
@@ -505,7 +508,11 @@ def update_embedding_model(
                         "you may be offline)."
                     ),
                 )
-        gguf_error = _local_gguf_backend_error(model) or _hf_gguf_backend_error(model, hf_token)
+        # The GGUF availability probe below calls the Hub (list_repo_files); skip it offline
+        # so a dead-DNS session cannot hang. A local GGUF check stays (no network).
+        gguf_error = _local_gguf_backend_error(model)
+        if gguf_error is None and not local_only_load:
+            gguf_error = _hf_gguf_backend_error(model, hf_token)
         if gguf_error:
             raise HTTPException(status_code = 409, detail = gguf_error)
     set_rag_embedding_model(model)

--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -416,6 +416,11 @@ def update_embedding_model(
             log = logger,
         ) from exc
     hf_token = (payload.hf_token or "").strip() or None
+    from utils.utils import hf_env_offline
+
+    # Capture the offline state once: offline, both the Hub malware scan and the is-embedding
+    # metadata check are unreachable, so both degrade to the local cache below.
+    local_only_load = hf_env_offline()
     # The env/default model needs no verification; saving it is a no-op override.
     # A local GGUF on the llama-server backend is accepted as-is: it is exactly
     # what the backend loads, and HF metadata cannot verify a local path.
@@ -435,7 +440,6 @@ def update_embedding_model(
         # unreachable scans fail open inside evaluate_file_security.
         from utils.security import evaluate_file_security, security_load_subdirs
         from core.rag.embeddings import _st_module_subdirs
-        from utils.utils import hf_env_offline
 
         # Fall back to the loader's own token so a gated/private repo is actually scanned
         # (a token-less scan fails open for exactly the repo that would still load).
@@ -443,7 +447,6 @@ def update_embedding_model(
         # Offline the Hub scan is unreachable and the subdir probes below would hit the
         # network and hang on a dead DNS; the offline gate walks the whole cached snapshot,
         # so no load-subdir hints are needed.
-        local_only_load = hf_env_offline()
         if local_only_load:
             load_subdirs = ()
         else:
@@ -486,14 +489,23 @@ def update_embedding_model(
         # which would wrongly 409 a valid online GGUF embedder.
         gguf_named = _llama_backend_active() and rag_config._names_gguf(model)
         if not gguf_named and not is_embedding_model(model, hf_token = hf_token):
-            raise HTTPException(
-                status_code = 409,
-                detail = (
-                    f"Could not verify {model!r} as an embedding model on "
-                    "Hugging Face (it may be the wrong model type, gated, or "
-                    "you may be offline)."
-                ),
-            )
+            # Offline, is_embedding_model can only confirm the Sentence-Transformers layout
+            # (modules.json); a transformers-native embedder (e.g. a feature-extraction model
+            # like gte-modernbert) is unverifiable without the Hub metadata. If the repo is
+            # already cached and loadable, accept it rather than raising a 409 that online
+            # would not -- SentenceTransformer can load any cached encoder. Uncached -> 409.
+            from utils.utils import hf_cache_snapshot_dir
+
+            offline_cached = local_only_load and hf_cache_snapshot_dir(model) is not None
+            if not offline_cached:
+                raise HTTPException(
+                    status_code = 409,
+                    detail = (
+                        f"Could not verify {model!r} as an embedding model on "
+                        "Hugging Face (it may be the wrong model type, gated, or "
+                        "you may be offline)."
+                    ),
+                )
         gguf_error = _local_gguf_backend_error(model) or _hf_gguf_backend_error(model, hf_token)
         if gguf_error:
             raise HTTPException(status_code = 409, detail = gguf_error)

--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -495,7 +495,6 @@ def update_embedding_model(
             # already cached and loadable, accept it rather than raising a 409 that online
             # would not -- SentenceTransformer can load any cached encoder. Uncached -> 409.
             from utils.utils import hf_cache_snapshot_dir
-
             offline_cached = local_only_load and hf_cache_snapshot_dir(model) is not None
             if not offline_cached:
                 raise HTTPException(

--- a/studio/backend/routes/settings.py
+++ b/studio/backend/routes/settings.py
@@ -435,30 +435,48 @@ def update_embedding_model(
         # unreachable scans fail open inside evaluate_file_security.
         from utils.security import evaluate_file_security, security_load_subdirs
         from core.rag.embeddings import _st_module_subdirs
+        from utils.utils import hf_env_offline
 
         # Fall back to the loader's own token so a gated/private repo is actually scanned
         # (a token-less scan fails open for exactly the repo that would still load).
         scan_token = hf_token or _ambient_hf_token()
-        # Include the ST module dirs (0_Transformer/) so a flagged pickle directly under
-        # one blocks instead of passing as an unreferenced nested shard.
-        load_subdirs = tuple(
-            dict.fromkeys(
-                (
-                    *security_load_subdirs(model, scan_token),
-                    *_st_module_subdirs(model, scan_token),
+        # Offline the Hub scan is unreachable and the subdir probes below would hit the
+        # network and hang on a dead DNS; the offline gate walks the whole cached snapshot,
+        # so no load-subdir hints are needed.
+        local_only_load = hf_env_offline()
+        if local_only_load:
+            load_subdirs = ()
+        else:
+            # Include the ST module dirs (0_Transformer/) so a flagged pickle directly under
+            # one blocks instead of passing as an unreferenced nested shard.
+            load_subdirs = tuple(
+                dict.fromkeys(
+                    (
+                        *security_load_subdirs(model, scan_token),
+                        *_st_module_subdirs(model, scan_token),
+                    )
                 )
             )
-        )
-        if evaluate_file_security(model, hf_token = scan_token, load_subdirs = load_subdirs).blocked:
+        if evaluate_file_security(
+            model,
+            hf_token = scan_token,
+            load_subdirs = load_subdirs,
+            local_only_load = local_only_load,
+        ).blocked:
             # 403, not 409: the client routes every 409 into the forceable "save anyway"
             # flow, but this block is a hard, non-forceable security refusal.
-            raise HTTPException(
-                status_code = 403,
+            if local_only_load:
+                detail = (
+                    f"{model!r} has cached pickle weights that cannot be security-scanned "
+                    "offline and no safetensors alternative, so it cannot be used as the "
+                    "embedding model. Re-download it with safetensors weights while online."
+                )
+            else:
                 detail = (
                     f"{model!r} is flagged as unsafe by Hugging Face's security scan and "
                     "cannot be used as the embedding model."
-                ),
-            )
+                )
+            raise HTTPException(status_code = 403, detail = detail)
     if model != default_embedding_model() and not payload.force and not is_local_gguf:
         from core.rag import config as rag_config
 

--- a/studio/backend/tests/test_embedding_model_security_gate.py
+++ b/studio/backend/tests/test_embedding_model_security_gate.py
@@ -116,14 +116,15 @@ def test_offline_cached_non_st_model_is_accepted(client, monkeypatch):
     import utils.utils as _uu
 
     monkeypatch.setattr(_models, "is_embedding_model", lambda *a, **k: False)
-    monkeypatch.setattr(_uu, "hf_cache_snapshot_dir", lambda name: "cached-snapshot")
+    monkeypatch.setattr(_uu, "hf_cache_snapshot_is_loadable", lambda name: True)
     r = c.put("/embedding-model", json = {"embedding_model": "acme/gte-modernbert"})
     assert r.status_code == 200
     assert saved.get("model") == "acme/gte-modernbert"
 
 
-def test_offline_uncached_model_still_409(client, monkeypatch):
-    # Offline but NOT cached: the load would fail anyway, so keep the forceable 409.
+def test_offline_partial_or_uncached_model_still_409(client, monkeypatch):
+    # Offline but NOT loadable (uncached or a metadata-only partial cache): keep the forceable
+    # 409, since the cache-only load would fail anyway.
     c, _saved = client
     monkeypatch.setitem(sys.modules, "utils.security", _security_stub(blocked = False))
     monkeypatch.setenv("HF_HUB_OFFLINE", "1")
@@ -131,9 +132,28 @@ def test_offline_uncached_model_still_409(client, monkeypatch):
     import utils.utils as _uu
 
     monkeypatch.setattr(_models, "is_embedding_model", lambda *a, **k: False)
-    monkeypatch.setattr(_uu, "hf_cache_snapshot_dir", lambda name: None)
+    monkeypatch.setattr(_uu, "hf_cache_snapshot_is_loadable", lambda name: False)
     r = c.put("/embedding-model", json = {"embedding_model": "acme/uncached-embedder"})
     assert r.status_code == 409
+
+
+def test_offline_skips_remote_gguf_probe(client, monkeypatch):
+    # Offline + llama backend: the remote GGUF probe (list_repo_files) must be skipped so a
+    # dead-DNS session cannot hang.
+    c, _saved = client
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setattr(settings, "_llama_backend_active", lambda: True)
+    monkeypatch.setattr(settings, "_local_gguf_backend_error", lambda model: None)
+
+    def _boom(*a, **k):
+        raise AssertionError("hit the network for the GGUF probe")
+
+    monkeypatch.setattr(settings, "_hf_gguf_backend_error", _boom)
+    import utils.models as _models
+
+    monkeypatch.setattr(_models, "is_embedding_model", lambda *a, **k: True)
+    r = c.put("/embedding-model", json = {"embedding_model": "acme/embedder"})
+    assert r.status_code == 200
 
 
 def test_llama_backend_skips_the_st_pickle_scan(monkeypatch):

--- a/studio/backend/tests/test_embedding_model_security_gate.py
+++ b/studio/backend/tests/test_embedding_model_security_gate.py
@@ -106,6 +106,36 @@ def test_hard_block_uses_non_forceable_status(client, monkeypatch):
     assert unverified.status_code == 409
 
 
+def test_offline_cached_non_st_model_is_accepted(client, monkeypatch):
+    # Offline, a cached transformers-native embedder (no modules.json) is unverifiable via HF
+    # metadata; since SentenceTransformer can load any cached encoder, accept it (no 409).
+    c, saved = client
+    monkeypatch.setitem(sys.modules, "utils.security", _security_stub(blocked = False))
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    import utils.models as _models
+    import utils.utils as _uu
+
+    monkeypatch.setattr(_models, "is_embedding_model", lambda *a, **k: False)
+    monkeypatch.setattr(_uu, "hf_cache_snapshot_dir", lambda name: "cached-snapshot")
+    r = c.put("/embedding-model", json = {"embedding_model": "acme/gte-modernbert"})
+    assert r.status_code == 200
+    assert saved.get("model") == "acme/gte-modernbert"
+
+
+def test_offline_uncached_model_still_409(client, monkeypatch):
+    # Offline but NOT cached: the load would fail anyway, so keep the forceable 409.
+    c, _saved = client
+    monkeypatch.setitem(sys.modules, "utils.security", _security_stub(blocked = False))
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    import utils.models as _models
+    import utils.utils as _uu
+
+    monkeypatch.setattr(_models, "is_embedding_model", lambda *a, **k: False)
+    monkeypatch.setattr(_uu, "hf_cache_snapshot_dir", lambda name: None)
+    r = c.put("/embedding-model", json = {"embedding_model": "acme/uncached-embedder"})
+    assert r.status_code == 409
+
+
 def test_llama_backend_skips_the_st_pickle_scan(monkeypatch):
     # On the llama-server backend the embedder loads GGUF (inert), not the ST repo's
     # pickle, so a flagged ST repo with a clean GGUF companion must not be rejected here.

--- a/studio/backend/tests/test_offline_embedding_minimal.py
+++ b/studio/backend/tests/test_offline_embedding_minimal.py
@@ -302,9 +302,7 @@ def test_gate_blocks_adapter_pickle_without_safetensors(hf_cache):
 
 
 def test_gate_allows_adapter_pickle_with_adapter_safetensors(hf_cache):
-    _make_cache(
-        hf_cache, "org/ad2", {"adapter_model.bin": "x", "adapter_model.safetensors": "y"}
-    )
+    _make_cache(hf_cache, "org/ad2", {"adapter_model.bin": "x", "adapter_model.safetensors": "y"})
     with _no_network():
         assert _offline_decision("org/ad2").blocked is False
 
@@ -312,18 +310,14 @@ def test_gate_allows_adapter_pickle_with_adapter_safetensors(hf_cache):
 def test_gate_blocks_base_pickle_with_only_adapter_safetensors_decoy(hf_cache):
     # A decoy adapter_model.safetensors must NOT suppress a base pytorch_model.bin: the base
     # loader would still deserialize the unscanned pickle.
-    _make_cache(
-        hf_cache, "org/decoy", {"pytorch_model.bin": "x", "adapter_model.safetensors": "y"}
-    )
+    _make_cache(hf_cache, "org/decoy", {"pytorch_model.bin": "x", "adapter_model.safetensors": "y"})
     with _no_network():
         assert _offline_decision("org/decoy").blocked is True
 
 
 def test_gate_blocks_adapter_pickle_with_only_base_safetensors_decoy(hf_cache):
     # Symmetric: a base model.safetensors must NOT suppress an adapter_model.bin.
-    _make_cache(
-        hf_cache, "org/decoy2", {"adapter_model.bin": "x", "model.safetensors": "y"}
-    )
+    _make_cache(hf_cache, "org/decoy2", {"adapter_model.bin": "x", "model.safetensors": "y"})
     with _no_network():
         assert _offline_decision("org/decoy2").blocked is True
 
@@ -380,7 +374,14 @@ def test_guard_offline_allows_safetensors(hf_cache):
 
 def _install_fake_sentence_transformers(monkeypatch, captured):
     class FakeSentenceTransformer:
-        def __init__(self, name, *, device = None, model_kwargs = None, **kw):
+        def __init__(
+            self,
+            name,
+            *,
+            device = None,
+            model_kwargs = None,
+            **kw,
+        ):
             captured["name"] = name
             captured["device"] = device
             # Snapshot the env the load actually sees, to prove the offline force is active.

--- a/studio/backend/tests/test_offline_embedding_minimal.py
+++ b/studio/backend/tests/test_offline_embedding_minimal.py
@@ -1,0 +1,365 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Offline RAG embedding-model handling (issue #6817).
+
+Offline, the studio must never call the Hub: a DNS-dead session hangs on model_info /
+download retries. These tests build a fake HF cache under a temp ``HF_HUB_CACHE`` and
+assert that, offline:
+  * ``is_embedding_model`` classifies from the cached ``modules.json`` and never calls
+    the Hub (``model_info`` patched to raise if reached);
+  * the file-security gate fails CLOSED on an unscanned pickle weight with no safetensors
+    alternative, and allows an inert (safetensors/gguf) cache;
+  * the embedder threads ``local_files_only`` into the SentenceTransformer load.
+Online behavior is unchanged: a bounded ``model_info`` timeout with a local-cache fallback.
+"""
+
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from utils.security import evaluate_file_security
+from utils.utils import hf_cache_snapshot_dir, hf_env_offline, st_repo_id_candidates
+
+# A minimal sentence-transformers modules.json (the marker the local-path check keys on).
+MODULES_JSON = (
+    '[{"idx": 0, "name": "0", "path": "", '
+    '"type": "sentence_transformers.models.Transformer"}]'
+)
+
+_COMMIT = "0123456789abcdef0123456789abcdef01234567"
+
+
+def _make_cache(root, repo_id, files, commit = _COMMIT):
+    """Build a canonical HF-cache snapshot (``refs/main`` + ``snapshots/<commit>/``) for
+    ``repo_id`` under ``root`` with ``{relpath: contents}``. Returns the snapshot dir."""
+    from huggingface_hub.file_download import repo_folder_name
+
+    repo_dir = Path(root) / repo_folder_name(repo_id = repo_id, repo_type = "model")
+    (repo_dir / "refs").mkdir(parents = True, exist_ok = True)
+    (repo_dir / "refs" / "main").write_text(commit)
+    snapshot = repo_dir / "snapshots" / commit
+    snapshot.mkdir(parents = True, exist_ok = True)
+    for rel, contents in files.items():
+        path = snapshot / rel
+        path.parent.mkdir(parents = True, exist_ok = True)
+        path.write_text(contents)
+    return snapshot
+
+
+def _no_network():
+    """Patch the Hub metadata call to fail loudly if any offline path reaches it."""
+    return patch("huggingface_hub.model_info", side_effect = AssertionError("hit the network"))
+
+
+def _is_embedding_model(*args, **kwargs):
+    from utils.models.model_config import is_embedding_model
+
+    return is_embedding_model(*args, **kwargs)
+
+
+@pytest.fixture
+def hf_cache(tmp_path, monkeypatch):
+    """Point the HF cache at a fresh temp dir the resolver reads at call time."""
+    root = tmp_path / "hub"
+    root.mkdir()
+    monkeypatch.setenv("HF_HOME", str(tmp_path))
+    monkeypatch.setenv("HF_HUB_CACHE", str(root))
+    return root
+
+
+@pytest.fixture(autouse = True)
+def _clean_env(monkeypatch):
+    """Each test starts online with an empty detection cache; offline tests opt in."""
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+    monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising = False)
+    from utils.models import model_config as mc
+
+    mc._embedding_detection_cache.clear()
+    yield
+    mc._embedding_detection_cache.clear()
+
+
+# ── hf_env_offline ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", "  On  "])
+def test_hf_env_offline_true(monkeypatch, value):
+    monkeypatch.setenv("HF_HUB_OFFLINE", value)
+    assert hf_env_offline() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", ""])
+def test_hf_env_offline_false(monkeypatch, value):
+    monkeypatch.setenv("HF_HUB_OFFLINE", value)
+    assert hf_env_offline() is False
+
+
+def test_hf_env_offline_honors_transformers_flag(monkeypatch):
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+    assert hf_env_offline() is True
+
+
+def test_hf_env_offline_default_false():
+    assert hf_env_offline() is False
+
+
+# ── st_repo_id_candidates ────────────────────────────────────────
+
+
+def test_candidates_slashless_adds_st_alias():
+    assert st_repo_id_candidates("all-MiniLM-L6-v2") == [
+        "all-MiniLM-L6-v2",
+        "sentence-transformers/all-MiniLM-L6-v2",
+    ]
+
+
+def test_candidates_with_org_is_verbatim():
+    assert st_repo_id_candidates("org/model") == ["org/model"]
+
+
+def test_candidates_empty_name():
+    assert st_repo_id_candidates("   ") == []
+
+
+# ── hf_cache_snapshot_dir ────────────────────────────────────────
+
+
+def test_snapshot_dir_resolves_active_commit(hf_cache):
+    snapshot = _make_cache(hf_cache, "org/emb", {"modules.json": MODULES_JSON})
+    assert hf_cache_snapshot_dir("org/emb") == snapshot
+
+
+def test_snapshot_dir_none_when_uncached(hf_cache):
+    assert hf_cache_snapshot_dir("org/missing") is None
+
+
+def test_snapshot_dir_uses_st_alias_for_slashless(hf_cache):
+    snapshot = _make_cache(
+        hf_cache, "sentence-transformers/all-MiniLM-L6-v2", {"modules.json": MODULES_JSON}
+    )
+    assert hf_cache_snapshot_dir("all-MiniLM-L6-v2") == snapshot
+
+
+def test_snapshot_dir_none_when_snapshot_missing(hf_cache):
+    from huggingface_hub.file_download import repo_folder_name
+
+    repo_dir = hf_cache / repo_folder_name(repo_id = "org/broken", repo_type = "model")
+    (repo_dir / "refs").mkdir(parents = True)
+    (repo_dir / "refs" / "main").write_text("deadbeef")  # no snapshots/deadbeef dir
+    assert hf_cache_snapshot_dir("org/broken") is None
+
+
+# ── is_embedding_model: offline (no network) ─────────────────────
+
+
+def test_offline_true_for_cached_st_model(hf_cache, monkeypatch):
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    _make_cache(hf_cache, "org/emb", {"modules.json": MODULES_JSON, "config.json": "{}"})
+    with _no_network():
+        assert _is_embedding_model("org/emb") is True
+
+
+def test_offline_false_for_cached_non_st_model(hf_cache, monkeypatch):
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    _make_cache(hf_cache, "org/plain", {"config.json": "{}", "model.safetensors": "x"})
+    with _no_network():
+        assert _is_embedding_model("org/plain") is False
+
+
+def test_offline_false_when_uncached(hf_cache, monkeypatch):
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+    with _no_network():
+        assert _is_embedding_model("org/missing") is False
+
+
+def test_offline_slashless_resolves_via_alias(hf_cache, monkeypatch):
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    _make_cache(
+        hf_cache, "sentence-transformers/all-MiniLM-L6-v2", {"modules.json": MODULES_JSON}
+    )
+    with _no_network():
+        assert _is_embedding_model("all-MiniLM-L6-v2") is True
+
+
+# ── is_embedding_model: online (bounded + fallback) ──────────────
+
+
+def test_online_passes_bounded_timeout(hf_cache):
+    seen = {}
+
+    def _mi(name, token = None, timeout = None, **kw):
+        seen["timeout"] = timeout
+        return SimpleNamespace(tags = ["sentence-transformers"], pipeline_tag = None)
+
+    with patch("huggingface_hub.model_info", side_effect = _mi):
+        assert _is_embedding_model("org/emb") is True
+    assert seen["timeout"] == 15.0
+
+
+def test_online_error_falls_back_to_cache_marker(hf_cache):
+    _make_cache(hf_cache, "org/emb", {"modules.json": MODULES_JSON})
+    with patch("huggingface_hub.model_info", side_effect = RuntimeError("dns dead")):
+        assert _is_embedding_model("org/emb") is True
+
+
+def test_online_error_without_cache_returns_false(hf_cache):
+    with patch("huggingface_hub.model_info", side_effect = RuntimeError("dns dead")):
+        assert _is_embedding_model("org/missing") is False
+
+
+# ── evaluate_file_security: offline fail-closed gate ─────────────
+
+
+def _offline_decision(name):
+    return evaluate_file_security(name, local_only_load = True)
+
+
+def test_gate_allows_safetensors_only(hf_cache):
+    _make_cache(hf_cache, "org/st", {"modules.json": MODULES_JSON, "model.safetensors": "x"})
+    with _no_network():
+        assert _offline_decision("org/st").blocked is False
+
+
+def test_gate_blocks_pickle_without_safetensors(hf_cache):
+    _make_cache(hf_cache, "org/pk", {"config.json": "{}", "pytorch_model.bin": "x"})
+    with _no_network():
+        decision = _offline_decision("org/pk")
+    assert decision.blocked is True
+    assert any(u["path"] == "pytorch_model.bin" for u in decision.unsafe_files)
+
+
+def test_gate_allows_pickle_with_safetensors_sibling(hf_cache):
+    _make_cache(hf_cache, "org/both", {"pytorch_model.bin": "x", "model.safetensors": "y"})
+    with _no_network():
+        assert _offline_decision("org/both").blocked is False
+
+
+def test_gate_blocks_sharded_pickle(hf_cache):
+    _make_cache(
+        hf_cache,
+        "org/shard",
+        {
+            "pytorch_model-00001-of-00002.bin": "a",
+            "pytorch_model-00002-of-00002.bin": "b",
+        },
+    )
+    with _no_network():
+        assert _offline_decision("org/shard").blocked is True
+
+
+def test_gate_allows_nothing_cached(hf_cache):
+    with _no_network():
+        assert _offline_decision("org/missing").blocked is False
+
+
+def test_gate_allows_gguf_only(hf_cache):
+    _make_cache(hf_cache, "org/gg", {"model.gguf": "x"})
+    with _no_network():
+        assert _offline_decision("org/gg").blocked is False
+
+
+def test_gate_blocks_pickle_in_module_subdir(hf_cache):
+    _make_cache(
+        hf_cache,
+        "org/mod",
+        {"modules.json": MODULES_JSON, "0_Transformer/pytorch_model.bin": "x"},
+    )
+    with _no_network():
+        assert _offline_decision("org/mod").blocked is True
+
+
+def test_gate_allows_pickle_in_subdir_with_safetensors(hf_cache):
+    _make_cache(
+        hf_cache,
+        "org/mod2",
+        {
+            "0_Transformer/pytorch_model.bin": "x",
+            "0_Transformer/model.safetensors": "y",
+        },
+    )
+    with _no_network():
+        assert _offline_decision("org/mod2").blocked is False
+
+
+# ── evaluate_file_security: online path unchanged ────────────────
+
+
+def test_online_default_blocks_unsafe():
+    status = {"scansDone": True, "filesWithIssues": [{"path": "pytorch_model.bin", "level": "unsafe"}]}
+    with patch("huggingface_hub.model_info", side_effect = lambda *a, **k: SimpleNamespace(security_repo_status = status)):
+        assert evaluate_file_security("org/x").blocked is True
+
+
+def test_online_default_allows_clean():
+    status = {"scansDone": True, "filesWithIssues": []}
+    with patch("huggingface_hub.model_info", side_effect = lambda *a, **k: SimpleNamespace(security_repo_status = status)):
+        assert evaluate_file_security("org/x").blocked is False
+
+
+# ── embeddings guard + loader ────────────────────────────────────
+
+
+def test_guard_offline_blocks_pickle_only(hf_cache):
+    from core.rag.embeddings import UnsafeEmbeddingModelError, _guard_model_security
+
+    _make_cache(hf_cache, "org/pk", {"config.json": "{}", "pytorch_model.bin": "x"})
+    with _no_network():
+        with pytest.raises(UnsafeEmbeddingModelError):
+            _guard_model_security("org/pk", local_only = True)
+
+
+def test_guard_offline_allows_safetensors(hf_cache):
+    from core.rag.embeddings import _guard_model_security
+
+    _make_cache(hf_cache, "org/st", {"modules.json": MODULES_JSON, "model.safetensors": "x"})
+    with _no_network():
+        _guard_model_security("org/st", local_only = True)  # must not raise
+
+
+def _install_fake_sentence_transformers(monkeypatch, captured):
+    class FakeSentenceTransformer:
+        def __init__(self, name, *, device = None, model_kwargs = None, local_files_only = False, **kw):
+            captured["name"] = name
+            captured["device"] = device
+            captured["local_files_only"] = local_files_only
+
+    module = types.ModuleType("sentence_transformers")
+    module.SentenceTransformer = FakeSentenceTransformer
+    monkeypatch.setitem(sys.modules, "sentence_transformers", module)
+
+
+def test_get_offline_threads_local_files_only(hf_cache, monkeypatch):
+    from core.rag import embeddings
+
+    _make_cache(hf_cache, "org/st", {"modules.json": MODULES_JSON, "model.safetensors": "x"})
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setattr(embeddings, "_model", None, raising = False)
+    monkeypatch.setattr(embeddings, "_name", None, raising = False)
+    monkeypatch.setattr(embeddings, "_install_torchao_stub_once", lambda: None)
+    monkeypatch.setattr(embeddings, "_device", lambda: "cpu")
+    captured = {}
+    _install_fake_sentence_transformers(monkeypatch, captured)
+    with _no_network():
+        embeddings._get("org/st")
+    assert captured["name"] == "org/st"
+    assert captured["local_files_only"] is True
+
+
+def test_get_online_omits_local_files_only(monkeypatch):
+    from core.rag import embeddings
+
+    monkeypatch.setattr(embeddings, "_model", None, raising = False)
+    monkeypatch.setattr(embeddings, "_name", None, raising = False)
+    monkeypatch.setattr(embeddings, "_install_torchao_stub_once", lambda: None)
+    monkeypatch.setattr(embeddings, "_device", lambda: "cpu")
+    # Isolate the loader wiring from the online guard's network calls.
+    monkeypatch.setattr(embeddings, "_guard_model_security", lambda name, local_only = False: None)
+    captured = {}
+    _install_fake_sentence_transformers(monkeypatch, captured)
+    embeddings._get("org/online")
+    assert captured["local_files_only"] is False

--- a/studio/backend/tests/test_offline_embedding_minimal.py
+++ b/studio/backend/tests/test_offline_embedding_minimal.py
@@ -30,6 +30,18 @@ MODULES_JSON = (
     '[{"idx": 0, "name": "0", "path": "", "type": "sentence_transformers.models.Transformer"}]'
 )
 
+
+def _modules_json(*paths):
+    """A modules.json listing one Transformer module per ``path`` (a load root)."""
+    import json
+
+    return json.dumps(
+        [
+            {"idx": i, "name": str(i), "path": p, "type": "sentence_transformers.models.Transformer"}
+            for i, p in enumerate(paths)
+        ]
+    )
+
 _COMMIT = "0123456789abcdef0123456789abcdef01234567"
 
 
@@ -306,10 +318,11 @@ def test_gate_allows_gguf_only(hf_cache):
 
 
 def test_gate_blocks_pickle_in_module_subdir(hf_cache):
+    # 0_Transformer is a module load root (listed in modules.json), so its pickle blocks.
     _make_cache(
         hf_cache,
         "org/mod",
-        {"modules.json": MODULES_JSON, "0_Transformer/pytorch_model.bin": "x"},
+        {"modules.json": _modules_json("0_Transformer"), "0_Transformer/pytorch_model.bin": "x"},
     )
     with _no_network():
         assert _offline_decision("org/mod").blocked is True
@@ -320,12 +333,29 @@ def test_gate_allows_pickle_in_subdir_with_safetensors(hf_cache):
         hf_cache,
         "org/mod2",
         {
+            "modules.json": _modules_json("0_Transformer"),
             "0_Transformer/pytorch_model.bin": "x",
             "0_Transformer/model.safetensors": "y",
         },
     )
     with _no_network():
         assert _offline_decision("org/mod2").blocked is False
+
+
+def test_gate_allows_unreferenced_nested_pickle(hf_cache):
+    # A pickle in a dir NOT referenced by modules.json (e.g. nemo/) is never deserialized by
+    # SentenceTransformer, so it must not block the offline load (matches the online gate).
+    _make_cache(
+        hf_cache,
+        "org/aux",
+        {
+            "modules.json": MODULES_JSON,  # Transformer at the root only
+            "model.safetensors": "w",
+            "nemo/pytorch_model.bin": "x",
+        },
+    )
+    with _no_network():
+        assert _offline_decision("org/aux").blocked is False
 
 
 def test_gate_blocks_adapter_pickle_without_safetensors(hf_cache):
@@ -358,7 +388,11 @@ def test_gate_blocks_adapter_pickle_with_only_base_safetensors_decoy(hf_cache):
 
 
 def test_gate_reports_snapshot_relative_path(hf_cache):
-    _make_cache(hf_cache, "org/mod3", {"0_Transformer/pytorch_model.bin": "x"})
+    _make_cache(
+        hf_cache,
+        "org/mod3",
+        {"modules.json": _modules_json("0_Transformer"), "0_Transformer/pytorch_model.bin": "x"},
+    )
     with _no_network():
         decision = _offline_decision("org/mod3")
     assert decision.blocked is True

--- a/studio/backend/tests/test_offline_embedding_minimal.py
+++ b/studio/backend/tests/test_offline_embedding_minimal.py
@@ -409,7 +409,15 @@ def test_guard_offline_allows_safetensors(hf_cache):
 
 def _install_fake_sentence_transformers(monkeypatch, captured):
     class FakeSentenceTransformer:
-        def __init__(self, name, *, device = None, model_kwargs = None, local_files_only = False, **kw):
+        def __init__(
+            self,
+            name,
+            *,
+            device = None,
+            model_kwargs = None,
+            local_files_only = False,
+            **kw,
+        ):
             captured["name"] = name
             captured["device"] = device
             captured["local_files_only"] = local_files_only

--- a/studio/backend/tests/test_offline_embedding_minimal.py
+++ b/studio/backend/tests/test_offline_embedding_minimal.py
@@ -10,11 +10,10 @@ assert that, offline:
     the Hub (``model_info`` patched to raise if reached);
   * the file-security gate fails CLOSED on an unscanned pickle weight with no safetensors
     alternative, and allows an inert (safetensors/gguf) cache;
-  * the embedder forces ``HF_HUB_OFFLINE`` around the SentenceTransformer load.
+  * the embedder threads ``local_files_only`` into the SentenceTransformer load.
 Online behavior is unchanged: a bounded ``model_info`` timeout with a local-cache fallback.
 """
 
-import os
 import sys
 import types
 from pathlib import Path
@@ -156,6 +155,42 @@ def test_snapshot_dir_none_when_snapshot_missing(hf_cache):
     (repo_dir / "refs").mkdir(parents = True)
     (repo_dir / "refs" / "main").write_text("deadbeef")  # no snapshots/deadbeef dir
     assert hf_cache_snapshot_dir("org/broken") is None
+
+
+def test_snapshot_dir_expands_env_vars_in_cache_path(tmp_path, monkeypatch):
+    # HF_HUB_CACHE with an unexpanded $VAR must resolve to the same place the loader uses.
+    real = tmp_path / "hub"
+    real.mkdir()
+    monkeypatch.setenv("MY_HF_CACHE", str(real))
+    monkeypatch.setenv("HF_HUB_CACHE", "$MY_HF_CACHE")
+    monkeypatch.delenv("HF_HOME", raising = False)
+    monkeypatch.delenv("SENTENCE_TRANSFORMERS_HOME", raising = False)
+    snapshot = _make_cache(real, "org/emb", {"modules.json": MODULES_JSON})
+    assert hf_cache_snapshot_dir("org/emb") == snapshot
+
+
+def test_snapshot_dir_uses_sentence_transformers_home(tmp_path, monkeypatch):
+    # SentenceTransformer uses SENTENCE_TRANSFORMERS_HOME as its cache_folder, so the gate must
+    # inspect it too.
+    st_home = tmp_path / "st_home"
+    st_home.mkdir()
+    monkeypatch.setenv("SENTENCE_TRANSFORMERS_HOME", str(st_home))
+    monkeypatch.delenv("HF_HUB_CACHE", raising = False)
+    monkeypatch.delenv("HF_HOME", raising = False)
+    snapshot = _make_cache(st_home, "org/emb", {"modules.json": MODULES_JSON})
+    assert hf_cache_snapshot_dir("org/emb") == snapshot
+
+
+def test_gate_blocks_pickle_in_sentence_transformers_home(tmp_path, monkeypatch):
+    # A pickle cached under SENTENCE_TRANSFORMERS_HOME must still fail closed offline.
+    st_home = tmp_path / "st_home"
+    st_home.mkdir()
+    monkeypatch.setenv("SENTENCE_TRANSFORMERS_HOME", str(st_home))
+    monkeypatch.delenv("HF_HUB_CACHE", raising = False)
+    monkeypatch.delenv("HF_HOME", raising = False)
+    _make_cache(st_home, "org/pk", {"config.json": "{}", "pytorch_model.bin": "x"})
+    with _no_network():
+        assert evaluate_file_security("org/pk", local_only_load = True).blocked is True
 
 
 # ── is_embedding_model: offline (no network) ─────────────────────
@@ -374,30 +409,22 @@ def test_guard_offline_allows_safetensors(hf_cache):
 
 def _install_fake_sentence_transformers(monkeypatch, captured):
     class FakeSentenceTransformer:
-        def __init__(
-            self,
-            name,
-            *,
-            device = None,
-            model_kwargs = None,
-            **kw,
-        ):
+        def __init__(self, name, *, device = None, model_kwargs = None, local_files_only = False, **kw):
             captured["name"] = name
             captured["device"] = device
-            # Snapshot the env the load actually sees, to prove the offline force is active.
-            captured["hf_hub_offline"] = os.environ.get("HF_HUB_OFFLINE")
+            captured["local_files_only"] = local_files_only
 
     module = types.ModuleType("sentence_transformers")
     module.SentenceTransformer = FakeSentenceTransformer
     monkeypatch.setitem(sys.modules, "sentence_transformers", module)
 
 
-def test_get_offline_forces_hub_offline_during_load(hf_cache, monkeypatch):
+def test_get_offline_threads_local_files_only(hf_cache, monkeypatch):
     from core.rag import embeddings
 
     _make_cache(hf_cache, "org/st", {"modules.json": MODULES_JSON, "model.safetensors": "x"})
-    # TRANSFORMERS_OFFLINE only (huggingface_hub ignores it) -> the load must still be forced
-    # local via HF_HUB_OFFLINE, which works on any sentence-transformers version.
+    # TRANSFORMERS_OFFLINE only: local_files_only is passed per-call so the load is cache-only
+    # regardless of the process-wide (import-frozen) HF_HUB_OFFLINE constant.
     monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
     monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
     monkeypatch.setattr(embeddings, "_model", None, raising = False)
@@ -409,11 +436,10 @@ def test_get_offline_forces_hub_offline_during_load(hf_cache, monkeypatch):
     with _no_network():
         embeddings._get("org/st")
     assert captured["name"] == "org/st"
-    assert captured["hf_hub_offline"] == "1"  # forced local during the load
-    assert "HF_HUB_OFFLINE" not in os.environ  # and restored afterward (was unset)
+    assert captured["local_files_only"] is True
 
 
-def test_get_online_does_not_force_offline(monkeypatch):
+def test_get_online_omits_local_files_only(monkeypatch):
     from core.rag import embeddings
 
     monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
@@ -427,4 +453,4 @@ def test_get_online_does_not_force_offline(monkeypatch):
     captured = {}
     _install_fake_sentence_transformers(monkeypatch, captured)
     embeddings._get("org/online")
-    assert captured["hf_hub_offline"] is None  # not forced offline
+    assert captured["local_files_only"] is False

--- a/studio/backend/tests/test_offline_embedding_minimal.py
+++ b/studio/backend/tests/test_offline_embedding_minimal.py
@@ -34,13 +34,18 @@ MODULES_JSON = (
 def _modules_json(*paths):
     """A modules.json listing one Transformer module per ``path`` (a load root)."""
     import json
-
     return json.dumps(
         [
-            {"idx": i, "name": str(i), "path": p, "type": "sentence_transformers.models.Transformer"}
+            {
+                "idx": i,
+                "name": str(i),
+                "path": p,
+                "type": "sentence_transformers.models.Transformer",
+            }
             for i, p in enumerate(paths)
         ]
     )
+
 
 _COMMIT = "0123456789abcdef0123456789abcdef01234567"
 

--- a/studio/backend/tests/test_offline_embedding_minimal.py
+++ b/studio/backend/tests/test_offline_embedding_minimal.py
@@ -14,6 +14,7 @@ assert that, offline:
 Online behavior is unchanged: a bounded ``model_info`` timeout with a local-cache fallback.
 """
 
+import os
 import sys
 import types
 from pathlib import Path
@@ -292,6 +293,49 @@ def test_gate_allows_pickle_in_subdir_with_safetensors(hf_cache):
         assert _offline_decision("org/mod2").blocked is False
 
 
+def test_gate_blocks_adapter_pickle_without_safetensors(hf_cache):
+    _make_cache(hf_cache, "org/ad", {"config.json": "{}", "adapter_model.bin": "x"})
+    with _no_network():
+        decision = _offline_decision("org/ad")
+    assert decision.blocked is True
+    assert any(u["path"] == "adapter_model.bin" for u in decision.unsafe_files)
+
+
+def test_gate_allows_adapter_pickle_with_adapter_safetensors(hf_cache):
+    _make_cache(
+        hf_cache, "org/ad2", {"adapter_model.bin": "x", "adapter_model.safetensors": "y"}
+    )
+    with _no_network():
+        assert _offline_decision("org/ad2").blocked is False
+
+
+def test_gate_blocks_base_pickle_with_only_adapter_safetensors_decoy(hf_cache):
+    # A decoy adapter_model.safetensors must NOT suppress a base pytorch_model.bin: the base
+    # loader would still deserialize the unscanned pickle.
+    _make_cache(
+        hf_cache, "org/decoy", {"pytorch_model.bin": "x", "adapter_model.safetensors": "y"}
+    )
+    with _no_network():
+        assert _offline_decision("org/decoy").blocked is True
+
+
+def test_gate_blocks_adapter_pickle_with_only_base_safetensors_decoy(hf_cache):
+    # Symmetric: a base model.safetensors must NOT suppress an adapter_model.bin.
+    _make_cache(
+        hf_cache, "org/decoy2", {"adapter_model.bin": "x", "model.safetensors": "y"}
+    )
+    with _no_network():
+        assert _offline_decision("org/decoy2").blocked is True
+
+
+def test_gate_reports_snapshot_relative_path(hf_cache):
+    _make_cache(hf_cache, "org/mod3", {"0_Transformer/pytorch_model.bin": "x"})
+    with _no_network():
+        decision = _offline_decision("org/mod3")
+    assert decision.blocked is True
+    assert any(u["path"] == "0_Transformer/pytorch_model.bin" for u in decision.unsafe_files)
+
+
 # ── evaluate_file_security: online path unchanged ────────────────
 
 
@@ -336,29 +380,25 @@ def test_guard_offline_allows_safetensors(hf_cache):
 
 def _install_fake_sentence_transformers(monkeypatch, captured):
     class FakeSentenceTransformer:
-        def __init__(
-            self,
-            name,
-            *,
-            device = None,
-            model_kwargs = None,
-            local_files_only = False,
-            **kw,
-        ):
+        def __init__(self, name, *, device = None, model_kwargs = None, **kw):
             captured["name"] = name
             captured["device"] = device
-            captured["local_files_only"] = local_files_only
+            # Snapshot the env the load actually sees, to prove the offline force is active.
+            captured["hf_hub_offline"] = os.environ.get("HF_HUB_OFFLINE")
 
     module = types.ModuleType("sentence_transformers")
     module.SentenceTransformer = FakeSentenceTransformer
     monkeypatch.setitem(sys.modules, "sentence_transformers", module)
 
 
-def test_get_offline_threads_local_files_only(hf_cache, monkeypatch):
+def test_get_offline_forces_hub_offline_during_load(hf_cache, monkeypatch):
     from core.rag import embeddings
 
     _make_cache(hf_cache, "org/st", {"modules.json": MODULES_JSON, "model.safetensors": "x"})
-    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    # TRANSFORMERS_OFFLINE only (huggingface_hub ignores it) -> the load must still be forced
+    # local via HF_HUB_OFFLINE, which works on any sentence-transformers version.
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
     monkeypatch.setattr(embeddings, "_model", None, raising = False)
     monkeypatch.setattr(embeddings, "_name", None, raising = False)
     monkeypatch.setattr(embeddings, "_install_torchao_stub_once", lambda: None)
@@ -368,12 +408,15 @@ def test_get_offline_threads_local_files_only(hf_cache, monkeypatch):
     with _no_network():
         embeddings._get("org/st")
     assert captured["name"] == "org/st"
-    assert captured["local_files_only"] is True
+    assert captured["hf_hub_offline"] == "1"  # forced local during the load
+    assert "HF_HUB_OFFLINE" not in os.environ  # and restored afterward (was unset)
 
 
-def test_get_online_omits_local_files_only(monkeypatch):
+def test_get_online_does_not_force_offline(monkeypatch):
     from core.rag import embeddings
 
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+    monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising = False)
     monkeypatch.setattr(embeddings, "_model", None, raising = False)
     monkeypatch.setattr(embeddings, "_name", None, raising = False)
     monkeypatch.setattr(embeddings, "_install_torchao_stub_once", lambda: None)
@@ -383,4 +426,4 @@ def test_get_online_omits_local_files_only(monkeypatch):
     captured = {}
     _install_fake_sentence_transformers(monkeypatch, captured)
     embeddings._get("org/online")
-    assert captured["local_files_only"] is False
+    assert captured["hf_hub_offline"] is None  # not forced offline

--- a/studio/backend/tests/test_offline_embedding_minimal.py
+++ b/studio/backend/tests/test_offline_embedding_minimal.py
@@ -23,7 +23,12 @@ from unittest.mock import patch
 import pytest
 
 from utils.security import evaluate_file_security
-from utils.utils import hf_cache_snapshot_dir, hf_env_offline, st_repo_id_candidates
+from utils.utils import (
+    hf_cache_snapshot_dir,
+    hf_cache_snapshot_is_loadable,
+    hf_env_offline,
+    st_repo_id_candidates,
+)
 
 # A minimal sentence-transformers modules.json (the marker the local-path check keys on).
 MODULES_JSON = (
@@ -210,6 +215,21 @@ def test_snapshot_dir_st_home_is_exclusive(tmp_path, monkeypatch):
     monkeypatch.delenv("HF_HOME", raising = False)
     _make_cache(hub, "org/emb", {"modules.json": MODULES_JSON})  # only in the HF hub cache
     assert hf_cache_snapshot_dir("org/emb") is None
+
+
+def test_snapshot_is_loadable_with_config_and_weights(hf_cache):
+    _make_cache(hf_cache, "org/emb", {"config.json": "{}", "model.safetensors": "x"})
+    assert hf_cache_snapshot_is_loadable("org/emb") is True
+
+
+def test_snapshot_is_not_loadable_when_metadata_only(hf_cache):
+    # A partial cache (refs/main resolves, but no weight files) is not loadable.
+    _make_cache(hf_cache, "org/partial", {"config.json": "{}", "modules.json": MODULES_JSON})
+    assert hf_cache_snapshot_is_loadable("org/partial") is False
+
+
+def test_snapshot_is_not_loadable_when_uncached(hf_cache):
+    assert hf_cache_snapshot_is_loadable("org/missing") is False
 
 
 def test_gate_blocks_pickle_in_sentence_transformers_home(tmp_path, monkeypatch):
@@ -480,12 +500,14 @@ def _install_fake_sentence_transformers(monkeypatch, captured):
     monkeypatch.setitem(sys.modules, "sentence_transformers", module)
 
 
-def test_get_offline_threads_local_files_only(hf_cache, monkeypatch):
+def test_get_offline_loads_from_local_snapshot(hf_cache, monkeypatch):
     from core.rag import embeddings
 
-    _make_cache(hf_cache, "org/st", {"modules.json": MODULES_JSON, "model.safetensors": "x"})
-    # TRANSFORMERS_OFFLINE only: local_files_only is passed per-call so the load is cache-only
-    # regardless of the process-wide (import-frozen) HF_HUB_OFFLINE constant.
+    snapshot = _make_cache(
+        hf_cache, "org/st", {"modules.json": MODULES_JSON, "model.safetensors": "x"}
+    )
+    # TRANSFORMERS_OFFLINE only: a cached model is loaded from its local snapshot dir, a local
+    # path that never touches the Hub -- offline-safe on ANY sentence-transformers version.
     monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
     monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
     monkeypatch.setattr(embeddings, "_model", None, raising = False)
@@ -496,7 +518,29 @@ def test_get_offline_threads_local_files_only(hf_cache, monkeypatch):
     _install_fake_sentence_transformers(monkeypatch, captured)
     with _no_network():
         embeddings._get("org/st")
-    assert captured["name"] == "org/st"
+    assert captured["name"] == str(snapshot)
+
+
+def test_get_offline_uncached_uses_local_files_only(tmp_path, monkeypatch):
+    from core.rag import embeddings
+
+    empty = tmp_path / "hub"
+    empty.mkdir()
+    monkeypatch.setenv("HF_HUB_CACHE", str(empty))
+    monkeypatch.delenv("HF_HOME", raising = False)
+    monkeypatch.delenv("SENTENCE_TRANSFORMERS_HOME", raising = False)
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+    monkeypatch.setattr(embeddings, "_model", None, raising = False)
+    monkeypatch.setattr(embeddings, "_name", None, raising = False)
+    monkeypatch.setattr(embeddings, "_install_torchao_stub_once", lambda: None)
+    monkeypatch.setattr(embeddings, "_device", lambda: "cpu")
+    # No cache -> fall back to a repo-id load forced cache-only (fails fast offline, not a hang).
+    monkeypatch.setattr(embeddings, "_guard_model_security", lambda name, local_only = False: None)
+    captured = {}
+    _install_fake_sentence_transformers(monkeypatch, captured)
+    embeddings._get("org/uncached-xyz")
+    assert captured["name"] == "org/uncached-xyz"
     assert captured["local_files_only"] is True
 
 

--- a/studio/backend/tests/test_offline_embedding_minimal.py
+++ b/studio/backend/tests/test_offline_embedding_minimal.py
@@ -198,6 +198,20 @@ def test_snapshot_dir_uses_sentence_transformers_home(tmp_path, monkeypatch):
     assert hf_cache_snapshot_dir("org/emb") == snapshot
 
 
+def test_snapshot_dir_st_home_is_exclusive(tmp_path, monkeypatch):
+    # With SENTENCE_TRANSFORMERS_HOME set, ST loads only from it; a model that lives only under
+    # HF_HUB_CACHE is not what the loader would use, so the resolver must not report it.
+    st_home = tmp_path / "st_home"
+    st_home.mkdir()
+    hub = tmp_path / "hub"
+    hub.mkdir()
+    monkeypatch.setenv("SENTENCE_TRANSFORMERS_HOME", str(st_home))
+    monkeypatch.setenv("HF_HUB_CACHE", str(hub))
+    monkeypatch.delenv("HF_HOME", raising = False)
+    _make_cache(hub, "org/emb", {"modules.json": MODULES_JSON})  # only in the HF hub cache
+    assert hf_cache_snapshot_dir("org/emb") is None
+
+
 def test_gate_blocks_pickle_in_sentence_transformers_home(tmp_path, monkeypatch):
     # A pickle cached under SENTENCE_TRANSFORMERS_HOME must still fail closed offline.
     st_home = tmp_path / "st_home"

--- a/studio/backend/tests/test_offline_embedding_minimal.py
+++ b/studio/backend/tests/test_offline_embedding_minimal.py
@@ -27,14 +27,18 @@ from utils.utils import hf_cache_snapshot_dir, hf_env_offline, st_repo_id_candid
 
 # A minimal sentence-transformers modules.json (the marker the local-path check keys on).
 MODULES_JSON = (
-    '[{"idx": 0, "name": "0", "path": "", '
-    '"type": "sentence_transformers.models.Transformer"}]'
+    '[{"idx": 0, "name": "0", "path": "", "type": "sentence_transformers.models.Transformer"}]'
 )
 
 _COMMIT = "0123456789abcdef0123456789abcdef01234567"
 
 
-def _make_cache(root, repo_id, files, commit = _COMMIT):
+def _make_cache(
+    root,
+    repo_id,
+    files,
+    commit = _COMMIT,
+):
     """Build a canonical HF-cache snapshot (``refs/main`` + ``snapshots/<commit>/``) for
     ``repo_id`` under ``root`` with ``{relpath: contents}``. Returns the snapshot dir."""
     from huggingface_hub.file_download import repo_folder_name
@@ -58,7 +62,6 @@ def _no_network():
 
 def _is_embedding_model(*args, **kwargs):
     from utils.models.model_config import is_embedding_model
-
     return is_embedding_model(*args, **kwargs)
 
 
@@ -179,9 +182,7 @@ def test_offline_false_when_uncached(hf_cache, monkeypatch):
 
 def test_offline_slashless_resolves_via_alias(hf_cache, monkeypatch):
     monkeypatch.setenv("HF_HUB_OFFLINE", "1")
-    _make_cache(
-        hf_cache, "sentence-transformers/all-MiniLM-L6-v2", {"modules.json": MODULES_JSON}
-    )
+    _make_cache(hf_cache, "sentence-transformers/all-MiniLM-L6-v2", {"modules.json": MODULES_JSON})
     with _no_network():
         assert _is_embedding_model("all-MiniLM-L6-v2") is True
 
@@ -192,7 +193,12 @@ def test_offline_slashless_resolves_via_alias(hf_cache, monkeypatch):
 def test_online_passes_bounded_timeout(hf_cache):
     seen = {}
 
-    def _mi(name, token = None, timeout = None, **kw):
+    def _mi(
+        name,
+        token = None,
+        timeout = None,
+        **kw,
+    ):
         seen["timeout"] = timeout
         return SimpleNamespace(tags = ["sentence-transformers"], pipeline_tag = None)
 
@@ -290,14 +296,23 @@ def test_gate_allows_pickle_in_subdir_with_safetensors(hf_cache):
 
 
 def test_online_default_blocks_unsafe():
-    status = {"scansDone": True, "filesWithIssues": [{"path": "pytorch_model.bin", "level": "unsafe"}]}
-    with patch("huggingface_hub.model_info", side_effect = lambda *a, **k: SimpleNamespace(security_repo_status = status)):
+    status = {
+        "scansDone": True,
+        "filesWithIssues": [{"path": "pytorch_model.bin", "level": "unsafe"}],
+    }
+    with patch(
+        "huggingface_hub.model_info",
+        side_effect = lambda *a, **k: SimpleNamespace(security_repo_status = status),
+    ):
         assert evaluate_file_security("org/x").blocked is True
 
 
 def test_online_default_allows_clean():
     status = {"scansDone": True, "filesWithIssues": []}
-    with patch("huggingface_hub.model_info", side_effect = lambda *a, **k: SimpleNamespace(security_repo_status = status)):
+    with patch(
+        "huggingface_hub.model_info",
+        side_effect = lambda *a, **k: SimpleNamespace(security_repo_status = status),
+    ):
         assert evaluate_file_security("org/x").blocked is False
 
 
@@ -306,7 +321,6 @@ def test_online_default_allows_clean():
 
 def test_guard_offline_blocks_pickle_only(hf_cache):
     from core.rag.embeddings import UnsafeEmbeddingModelError, _guard_model_security
-
     _make_cache(hf_cache, "org/pk", {"config.json": "{}", "pytorch_model.bin": "x"})
     with _no_network():
         with pytest.raises(UnsafeEmbeddingModelError):
@@ -315,7 +329,6 @@ def test_guard_offline_blocks_pickle_only(hf_cache):
 
 def test_guard_offline_allows_safetensors(hf_cache):
     from core.rag.embeddings import _guard_model_security
-
     _make_cache(hf_cache, "org/st", {"modules.json": MODULES_JSON, "model.safetensors": "x"})
     with _no_network():
         _guard_model_security("org/st", local_only = True)  # must not raise
@@ -323,7 +336,15 @@ def test_guard_offline_allows_safetensors(hf_cache):
 
 def _install_fake_sentence_transformers(monkeypatch, captured):
     class FakeSentenceTransformer:
-        def __init__(self, name, *, device = None, model_kwargs = None, local_files_only = False, **kw):
+        def __init__(
+            self,
+            name,
+            *,
+            device = None,
+            model_kwargs = None,
+            local_files_only = False,
+            **kw,
+        ):
             captured["name"] = name
             captured["device"] = device
             captured["local_files_only"] = local_files_only

--- a/studio/backend/tests/test_offline_embedding_minimal.py
+++ b/studio/backend/tests/test_offline_embedding_minimal.py
@@ -10,7 +10,7 @@ assert that, offline:
     the Hub (``model_info`` patched to raise if reached);
   * the file-security gate fails CLOSED on an unscanned pickle weight with no safetensors
     alternative, and allows an inert (safetensors/gguf) cache;
-  * the embedder threads ``local_files_only`` into the SentenceTransformer load.
+  * the embedder forces ``HF_HUB_OFFLINE`` around the SentenceTransformer load.
 Online behavior is unchanged: a bounded ``model_info`` timeout with a local-cache fallback.
 """
 

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -2076,6 +2076,27 @@ def download_gguf_file(
 _embedding_detection_cache: Dict[tuple, bool] = {}
 
 
+# Bound the Hub metadata lookup so a DNS-dead session fails fast (and falls back to the
+# local cache) instead of hanging on huggingface_hub's default retry loop.
+_HUB_MODEL_INFO_TIMEOUT = 15.0
+
+
+def _embedding_marker_in_hf_cache(model_name: str) -> bool:
+    """True when ``model_name``'s active cached snapshot carries a ``modules.json`` -- the
+    Sentence-Transformers marker, mirroring the local-path check. Cache-only, no network;
+    used offline and as a fallback when a bounded Hub lookup times out.
+    """
+    from utils.utils import hf_cache_snapshot_dir
+
+    snapshot = hf_cache_snapshot_dir(model_name)
+    if snapshot is None:
+        return False
+    try:
+        return (snapshot / "modules.json").is_file()
+    except OSError:
+        return False
+
+
 def is_embedding_model(model_name: str, hf_token: Optional[str] = None) -> bool:
     """Detect embedding/sentence-transformer models via HF metadata.
 
@@ -2101,10 +2122,20 @@ def is_embedding_model(model_name: str, hf_token: Optional[str] = None) -> bool:
         _embedding_detection_cache[cache_key] = is_emb
         return is_emb
 
+    # Offline: never call the Hub -- a DNS-dead session hangs on model_info retries.
+    # Classify from the local cache the load will use: a cached modules.json marks a
+    # Sentence-Transformers repo, mirroring the local-path check above.
+    from utils.utils import hf_env_offline
+
+    if hf_env_offline():
+        is_emb = _embedding_marker_in_hf_cache(model_name)
+        _embedding_detection_cache[cache_key] = is_emb
+        return is_emb
+
     try:
         from huggingface_hub import model_info as hf_model_info
 
-        info = hf_model_info(model_name, token = hf_token)
+        info = hf_model_info(model_name, token = hf_token, timeout = _HUB_MODEL_INFO_TIMEOUT)
         tags = set(info.tags or [])
         pipeline_tag = info.pipeline_tag or ""
 
@@ -2125,9 +2156,12 @@ def is_embedding_model(model_name: str, hf_token: Optional[str] = None) -> bool:
         return is_emb
 
     except Exception as e:
+        # A bounded timeout or transient network error must not hang or hard-fail the UI.
+        # Best-effort fall back to the local cache marker before giving up.
         logger.warning(f"Could not determine if {model_name} is embedding model: {e}")
-        _embedding_detection_cache[cache_key] = False
-        return False
+        is_emb = _embedding_marker_in_hf_cache(model_name)
+        _embedding_detection_cache[cache_key] = is_emb
+        return is_emb
 
 
 def _has_model_weight_files(model_dir: Path) -> bool:

--- a/studio/backend/utils/security/file_security.py
+++ b/studio/backend/utils/security/file_security.py
@@ -38,11 +38,25 @@ from loggers import get_logger
 
 logger = get_logger(__name__)
 
-# Base-model pickle weights (plain or sharded) that execute code when a load deserializes
-# them; safetensors/gguf are inert (tensor-only) and never match. This scopes the offline
-# fail-closed gate to the actual RCE vector.
+# Pickle-format weight files (plain or sharded) that execute code when a load deserializes
+# them; safetensors/gguf are inert (tensor-only). Grouped by weight family so an inert
+# safetensors only suppresses the pickle it actually replaces (below): the base loader will
+# not use an adapter's safetensors in place of pytorch_model.bin, and vice versa.
 _PICKLE_WEIGHT_RE = re.compile(
-    r"^(model|pytorch_model)(-\d+-of-\d+)?\.(bin|pt|pth|ckpt|pkl|pickle)$",
+    r"^(model|pytorch_model|adapter_model|consolidated)(-\d+-of-\d+)?"
+    r"\.(bin|pt|pth|ckpt|pkl|pickle)$",
+    re.IGNORECASE,
+)
+# Base-model safetensors weight set. HF saves the torch pickle as ``pytorch_model.bin`` but the
+# safetensors as ``model.safetensors`` (the stems differ), so a base pickle is inert-replaced by
+# ``model.safetensors``, its shards, or the sharded index -- not by an adapter's safetensors.
+_BASE_SAFETENSORS_RE = re.compile(
+    r"^(model(-\d+-of-\d+)?\.safetensors|model\.safetensors\.index\.json)$",
+    re.IGNORECASE,
+)
+# Adapter (PEFT) safetensors weight set: ``adapter_model.safetensors``, its shards, or index.
+_ADAPTER_SAFETENSORS_RE = re.compile(
+    r"^(adapter_model(-\d+-of-\d+)?\.safetensors|adapter_model\.safetensors\.index\.json)$",
     re.IGNORECASE,
 )
 
@@ -276,23 +290,37 @@ def _fetch_security_status(model_name: str, hf_token: Optional[str]):
 
 
 def _cached_pickle_weight_files(snapshot: Path) -> list:
-    """Pickle-format weight files under ``snapshot`` that a load would deserialize, skipping
-    any directory that also ships a ``*.safetensors`` (the load prefers the inert weight). A
-    single filesystem walk. Raises ``OSError`` if the snapshot cannot be read (caller blocks).
+    """Pickle-format weight files under ``snapshot`` a load would deserialize, EXCLUDING those
+    whose own weight family also ships an inert ``safetensors`` in the same directory (the load
+    prefers the safetensors). A base pickle (``pytorch_model.bin`` / ``model.bin`` /
+    ``consolidated``) is suppressed only by a base ``model.safetensors`` weight; an
+    ``adapter_model`` pickle only by an ``adapter_model.safetensors`` -- an unrelated safetensors
+    is not a substitute the loader would pick. A single filesystem walk. Raises ``OSError`` if
+    the snapshot cannot be read (caller blocks).
     """
-    dirs_with_safetensors = set()
-    candidates = []
+    base_safetensors_dirs = set()
+    adapter_safetensors_dirs = set()
+    pickles = []
     for path in snapshot.rglob("*"):
         try:
             if not path.is_file():
                 continue
         except OSError:
             continue
-        if path.name.lower().endswith(".safetensors"):
-            dirs_with_safetensors.add(path.parent)
-        elif _PICKLE_WEIGHT_RE.match(path.name):
-            candidates.append(path)
-    return [p for p in candidates if p.parent not in dirs_with_safetensors]
+        name = path.name
+        if _BASE_SAFETENSORS_RE.match(name):
+            base_safetensors_dirs.add(path.parent)
+        elif _ADAPTER_SAFETENSORS_RE.match(name):
+            adapter_safetensors_dirs.add(path.parent)
+        elif _PICKLE_WEIGHT_RE.match(name):
+            pickles.append(path)
+    blocked = []
+    for path in pickles:
+        is_adapter = path.name.lower().startswith("adapter_model")
+        safe_dirs = adapter_safetensors_dirs if is_adapter else base_safetensors_dirs
+        if path.parent not in safe_dirs:
+            blocked.append(path)
+    return blocked
 
 
 def _evaluate_local_only(model_name: str) -> FileSecurityDecision:
@@ -327,7 +355,10 @@ def _evaluate_local_only(model_name: str) -> FileSecurityDecision:
             model_name, False, reason = "offline; cached weights are inert (safetensors/gguf)"
         )
 
-    names = ", ".join(sorted(p.name for p in pickles))
+    # Report snapshot-relative posix paths (matching the online gate, and disambiguating a
+    # same-named pickle in different module dirs).
+    rel_paths = sorted(p.relative_to(snapshot).as_posix() for p in pickles)
+    names = ", ".join(rel_paths)
     logger.warning(
         "Blocking offline load of '%s': cached pickle weight(s) cannot be malware-scanned "
         "offline and have no safetensors alternative (%s).",
@@ -337,7 +368,7 @@ def _evaluate_local_only(model_name: str) -> FileSecurityDecision:
     return FileSecurityDecision(
         model_name,
         True,
-        unsafe_files = [{"path": p.name, "level": "unscanned"} for p in pickles],
+        unsafe_files = [{"path": rel, "level": "unscanned"} for rel in rel_paths],
         reason = f"offline; unscanned pickle weights with no safetensors alternative: {names}",
     )
 

--- a/studio/backend/utils/security/file_security.py
+++ b/studio/backend/utils/security/file_security.py
@@ -289,37 +289,55 @@ def _fetch_security_status(model_name: str, hf_token: Optional[str]):
     return None
 
 
-def _cached_pickle_weight_files(snapshot: Path) -> list:
-    """Pickle-format weight files under ``snapshot`` a load would deserialize, EXCLUDING those
-    whose own weight family also ships an inert ``safetensors`` in the same directory (the load
-    prefers the safetensors). A base pickle (``pytorch_model.bin`` / ``model.bin`` /
-    ``consolidated``) is suppressed only by a base ``model.safetensors`` weight; an
-    ``adapter_model`` pickle only by an ``adapter_model.safetensors`` -- an unrelated safetensors
-    is not a substitute the loader would pick. A single filesystem walk. Raises ``OSError`` if
-    the snapshot cannot be read (caller blocks).
+def _st_load_roots(snapshot: Path) -> list:
+    """Directories a SentenceTransformer load actually deserializes weights from: the snapshot
+    root plus each module ``path`` in ``modules.json`` (e.g. ``0_Transformer``), read locally,
+    no network. Mirrors the online gate, which ignores unreferenced nested pickles (an example
+    artifact or a ``nemo/`` pickle ST never loads), so the offline gate does not over-block.
     """
-    base_safetensors_dirs = set()
-    adapter_safetensors_dirs = set()
-    pickles = []
-    for path in snapshot.rglob("*"):
-        try:
-            if not path.is_file():
-                continue
-        except OSError:
-            continue
-        name = path.name
-        if _BASE_SAFETENSORS_RE.match(name):
-            base_safetensors_dirs.add(path.parent)
-        elif _ADAPTER_SAFETENSORS_RE.match(name):
-            adapter_safetensors_dirs.add(path.parent)
-        elif _PICKLE_WEIGHT_RE.match(name):
-            pickles.append(path)
+    roots = [snapshot]
+    try:
+        import json
+
+        modules = json.loads((snapshot / "modules.json").read_text())
+    except (OSError, ValueError):
+        return roots  # no / invalid modules.json -> the snapshot root is the only load root
+    for module in modules or ():
+        path = str((module or {}).get("path", "")).strip().strip("/")
+        # A relative module path only; ignore a crafted "../" escape.
+        if path and ".." not in path.split("/"):
+            candidate = snapshot / path
+            if candidate not in roots:
+                roots.append(candidate)
+    return roots
+
+
+def _cached_pickle_weight_files(snapshot: Path) -> list:
+    """Pickle-format weight files in ``snapshot``'s ST load roots a load would deserialize,
+    EXCLUDING those whose own weight family also ships an inert ``safetensors`` in the same
+    directory (the load prefers the safetensors). A base pickle (``pytorch_model.bin`` /
+    ``model.bin`` / ``consolidated``) is suppressed only by a base ``model.safetensors`` weight;
+    an ``adapter_model`` pickle only by an ``adapter_model.safetensors`` -- an unrelated
+    safetensors is not a substitute the loader would pick. Scans only the load roots (not every
+    nested file). Raises ``OSError`` if the snapshot root cannot be read (caller blocks).
+    """
     blocked = []
-    for path in pickles:
-        is_adapter = path.name.lower().startswith("adapter_model")
-        safe_dirs = adapter_safetensors_dirs if is_adapter else base_safetensors_dirs
-        if path.parent not in safe_dirs:
-            blocked.append(path)
+    for root in _st_load_roots(snapshot):
+        try:
+            entries = [p for p in root.iterdir() if p.is_file()]
+        except OSError:
+            if root == snapshot:
+                raise  # top-level unreadable -> fail closed
+            continue  # an unreadable module subdir: nothing loadable to attest here
+        has_base_safetensors = any(_BASE_SAFETENSORS_RE.match(p.name) for p in entries)
+        has_adapter_safetensors = any(_ADAPTER_SAFETENSORS_RE.match(p.name) for p in entries)
+        for path in entries:
+            if not _PICKLE_WEIGHT_RE.match(path.name):
+                continue
+            is_adapter = path.name.lower().startswith("adapter_model")
+            has_alternative = has_adapter_safetensors if is_adapter else has_base_safetensors
+            if not has_alternative:
+                blocked.append(path)
     return blocked
 
 

--- a/studio/backend/utils/security/file_security.py
+++ b/studio/backend/utils/security/file_security.py
@@ -298,7 +298,6 @@ def _st_load_roots(snapshot: Path) -> list:
     roots = [snapshot]
     try:
         import json
-
         modules = json.loads((snapshot / "modules.json").read_text())
     except (OSError, ValueError):
         return roots  # no / invalid modules.json -> the snapshot root is the only load root

--- a/studio/backend/utils/security/file_security.py
+++ b/studio/backend/utils/security/file_security.py
@@ -29,12 +29,22 @@ Policy:
     scanned so a repo cannot dodge the gate by suffixing its name.
 """
 
+import re
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Optional
 
 from loggers import get_logger
 
 logger = get_logger(__name__)
+
+# Base-model pickle weights (plain or sharded) that execute code when a load deserializes
+# them; safetensors/gguf are inert (tensor-only) and never match. This scopes the offline
+# fail-closed gate to the actual RCE vector.
+_PICKLE_WEIGHT_RE = re.compile(
+    r"^(model|pytorch_model)(-\d+-of-\d+)?\.(bin|pt|pth|ckpt|pkl|pickle)$",
+    re.IGNORECASE,
+)
 
 # Non-blocking levels: clean or not-yet-finished. Anything else (unsafe/suspicious/
 # malicious or a future label) blocks, so Hub schema drift fails CLOSED.
@@ -265,11 +275,79 @@ def _fetch_security_status(model_name: str, hf_token: Optional[str]):
     return None
 
 
+def _cached_pickle_weight_files(snapshot: Path) -> list:
+    """Pickle-format weight files under ``snapshot`` that a load would deserialize, skipping
+    any directory that also ships a ``*.safetensors`` (the load prefers the inert weight). A
+    single filesystem walk. Raises ``OSError`` if the snapshot cannot be read (caller blocks).
+    """
+    dirs_with_safetensors = set()
+    candidates = []
+    for path in snapshot.rglob("*"):
+        try:
+            if not path.is_file():
+                continue
+        except OSError:
+            continue
+        if path.name.lower().endswith(".safetensors"):
+            dirs_with_safetensors.add(path.parent)
+        elif _PICKLE_WEIGHT_RE.match(path.name):
+            candidates.append(path)
+    return [p for p in candidates if p.parent not in dirs_with_safetensors]
+
+
+def _evaluate_local_only(model_name: str) -> FileSecurityDecision:
+    """Offline security gate. The Hub malware scan is unreachable, so inspect the local cache
+    and fail CLOSED on an unscanned pickle weight (code-executing on load) that has no inert
+    ``safetensors`` alternative, instead of failing open or hanging on the network. A
+    safetensors/gguf-only cache loads normally; nothing cached -> nothing to load -> allowed.
+    """
+    from utils.utils import hf_cache_snapshot_dir
+
+    try:
+        snapshot = hf_cache_snapshot_dir(model_name)
+    except Exception:
+        logger.warning("Offline gate: could not resolve the cache for '%s'; blocking.", model_name)
+        return FileSecurityDecision(
+            model_name, True, reason = "offline; could not inspect the local cache"
+        )
+
+    if snapshot is None:
+        return FileSecurityDecision(model_name, False, reason = "offline; nothing cached to load")
+
+    try:
+        pickles = _cached_pickle_weight_files(snapshot)
+    except OSError:
+        logger.warning("Offline gate: could not read the cache for '%s'; blocking.", model_name)
+        return FileSecurityDecision(
+            model_name, True, reason = "offline; could not read the local cache"
+        )
+
+    if not pickles:
+        return FileSecurityDecision(
+            model_name, False, reason = "offline; cached weights are inert (safetensors/gguf)"
+        )
+
+    names = ", ".join(sorted(p.name for p in pickles))
+    logger.warning(
+        "Blocking offline load of '%s': cached pickle weight(s) cannot be malware-scanned "
+        "offline and have no safetensors alternative (%s).",
+        model_name,
+        names,
+    )
+    return FileSecurityDecision(
+        model_name,
+        True,
+        unsafe_files = [{"path": p.name, "level": "unscanned"} for p in pickles],
+        reason = f"offline; unscanned pickle weights with no safetensors alternative: {names}",
+    )
+
+
 def evaluate_file_security(
     model_name: str,
     hf_token: Optional[str] = None,
     *,
     load_subdirs = (),
+    local_only_load: bool = False,
 ) -> FileSecurityDecision:
     """Block a load when HF's security scan flags unsafe serialized files.
 
@@ -280,6 +358,10 @@ def evaluate_file_security(
     ``load_subdirs`` names subdirs the load calls ``from_pretrained`` on (e.g. ``("LLM",)``
     for Spark-TTS / BiCodec, loading ``<snapshot>/LLM``): a flagged file directly under one
     is root-level there and blocks, and an index inside it is honored when scoping shards.
+
+    ``local_only_load`` marks an offline load (``HF_HUB_OFFLINE`` / ``TRANSFORMERS_OFFLINE``):
+    the Hub scan is unreachable, so instead of hanging or failing open, inspect the local
+    cache and fail CLOSED on an unscanned pickle weight with no safetensors alternative.
     """
     # Scan the repo the load actually fetches, not the literal alias (which 404s and
     # fails open): the Spark-TTS "<parent>/LLM" alias is really unsloth/<parent> from LLM/.
@@ -294,6 +376,11 @@ def evaluate_file_security(
     except Exception:
         # Cannot classify the path -> do not block on that account.
         return FileSecurityDecision(model_name, False, reason = "path check failed; not blocked")
+
+    # Offline: the Hub scan is unreachable; inspect the local cache and fail closed on an
+    # unscanned pickle weight instead of hanging on model_info or failing open.
+    if local_only_load:
+        return _evaluate_local_only(model_name)
 
     status = _fetch_security_status(model_name, hf_token)
     if not isinstance(status, dict):

--- a/studio/backend/utils/utils.py
+++ b/studio/backend/utils/utils.py
@@ -49,48 +49,70 @@ def st_repo_id_candidates(model_name: str) -> list:
     return candidates
 
 
-def _hf_cache_root() -> Path:
-    """Local HF hub cache root, honoring ``HF_HUB_CACHE`` / ``HF_HOME`` at call time
-    (mirrors huggingface_hub's own resolution so it tracks a test's env override)."""
-    root = os.environ.get("HF_HUB_CACHE") or os.environ.get("HUGGINGFACE_HUB_CACHE")
-    if root:
-        return Path(root)
+def _expand_path(raw: str) -> Path:
+    """Expand ``~`` and ``$VARS`` the way huggingface_hub does for its cache paths, so the gate
+    resolves the same directory the loader will."""
+    return Path(os.path.expandvars(os.path.expanduser(raw)))
+
+
+def _hf_cache_roots() -> list:
+    """Candidate local cache roots a Sentence-Transformers / huggingface_hub load may use, in
+    the loader's own precedence: an explicit ``SENTENCE_TRANSFORMERS_HOME`` (ST's cache_folder),
+    then ``HF_HUB_CACHE`` / ``HF_HOME/hub`` / ``XDG_CACHE_HOME`` / ``~/.cache``. Expanded (``~`` /
+    ``$VARS``) and de-duplicated, honoring the env at call time so a test override is tracked.
+    """
+    roots = []
+    st_home = os.environ.get("SENTENCE_TRANSFORMERS_HOME")
+    if st_home:
+        roots.append(_expand_path(st_home))
+    hub = os.environ.get("HF_HUB_CACHE") or os.environ.get("HUGGINGFACE_HUB_CACHE")
+    if hub:
+        roots.append(_expand_path(hub))
     hf_home = os.environ.get("HF_HOME")
     if hf_home:
-        return Path(hf_home) / "hub"
+        roots.append(_expand_path(hf_home) / "hub")
     xdg = os.environ.get("XDG_CACHE_HOME")
-    base = Path(xdg) if xdg else Path.home() / ".cache"
-    return base / "huggingface" / "hub"
+    if xdg:
+        roots.append(_expand_path(xdg) / "huggingface" / "hub")
+    roots.append(Path.home() / ".cache" / "huggingface" / "hub")
+    seen = set()
+    unique = []
+    for root in roots:
+        if root not in seen:
+            seen.add(root)
+            unique.append(root)
+    return unique
 
 
 def hf_cache_snapshot_dir(model_name: str) -> Optional[Path]:
-    """Active local snapshot dir for ``model_name``'s ``main`` revision, or None when the
-    repo is not cached. Reads ``refs/main`` then ``snapshots/<commit>``; never touches the
-    network. Tries the ``sentence-transformers/`` alias for a slashless name.
+    """Active local snapshot dir for ``model_name``'s ``main`` revision, or None when the repo
+    is not cached in any known cache root (including ``SENTENCE_TRANSFORMERS_HOME``). Reads
+    ``refs/main`` then ``snapshots/<commit>``; never touches the network. Tries the
+    ``sentence-transformers/`` alias for a slashless name.
     """
     try:
         from huggingface_hub.file_download import repo_folder_name
     except Exception:
         repo_folder_name = None
-    cache_root = _hf_cache_root()
-    for repo_id in st_repo_id_candidates(model_name):
-        try:
-            if repo_folder_name is not None:
-                folder = repo_folder_name(repo_id = repo_id, repo_type = "model")
-            else:
-                folder = "models--" + repo_id.replace("/", "--")
-            repo_dir = cache_root / folder
-            ref = repo_dir / "refs" / "main"
-            if not ref.is_file():
+    for cache_root in _hf_cache_roots():
+        for repo_id in st_repo_id_candidates(model_name):
+            try:
+                if repo_folder_name is not None:
+                    folder = repo_folder_name(repo_id = repo_id, repo_type = "model")
+                else:
+                    folder = "models--" + repo_id.replace("/", "--")
+                repo_dir = cache_root / folder
+                ref = repo_dir / "refs" / "main"
+                if not ref.is_file():
+                    continue
+                commit = ref.read_text().strip()
+                if not commit:
+                    continue
+                snapshot = repo_dir / "snapshots" / commit
+                if snapshot.is_dir():
+                    return snapshot
+            except OSError:
                 continue
-            commit = ref.read_text().strip()
-            if not commit:
-                continue
-            snapshot = repo_dir / "snapshots" / commit
-            if snapshot.is_dir():
-                return snapshot
-        except OSError:
-            continue
     return None
 
 

--- a/studio/backend/utils/utils.py
+++ b/studio/backend/utils/utils.py
@@ -106,6 +106,33 @@ def hf_cache_snapshot_dir(model_name: str) -> Optional[Path]:
     return None
 
 
+# Weight file suffixes a load can consume. Presence of one (plus a config) distinguishes a
+# real cached model from a metadata-only partial cache that would fail at load time.
+_LOADABLE_WEIGHT_SUFFIXES = frozenset(
+    {".safetensors", ".bin", ".gguf", ".pt", ".pth", ".ckpt"}
+)
+
+
+def hf_cache_snapshot_is_loadable(model_name: str) -> bool:
+    """True when ``model_name``'s active snapshot is cached AND actually loadable -- it has a
+    config (``config.json`` or ``modules.json``) and at least one weight file -- rather than a
+    metadata-only partial cache that resolves a ``refs/main`` but would fail at load. No network.
+    """
+    snapshot = hf_cache_snapshot_dir(model_name)
+    if snapshot is None:
+        return False
+    try:
+        has_config = (snapshot / "config.json").is_file() or (snapshot / "modules.json").is_file()
+        if not has_config:
+            return False
+        for path in snapshot.rglob("*"):
+            if path.suffix.lower() in _LOADABLE_WEIGHT_SUFFIXES and path.is_file():
+                return True
+    except OSError:
+        return False
+    return False
+
+
 # ── Client-safe error helpers ───────────────────────────────────
 # Never return raw exception text to clients; log server-side, return generic.
 

--- a/studio/backend/utils/utils.py
+++ b/studio/backend/utils/utils.py
@@ -108,9 +108,7 @@ def hf_cache_snapshot_dir(model_name: str) -> Optional[Path]:
 
 # Weight file suffixes a load can consume. Presence of one (plus a config) distinguishes a
 # real cached model from a metadata-only partial cache that would fail at load time.
-_LOADABLE_WEIGHT_SUFFIXES = frozenset(
-    {".safetensors", ".bin", ".gguf", ".pt", ".pth", ".ckpt"}
-)
+_LOADABLE_WEIGHT_SUFFIXES = frozenset({".safetensors", ".bin", ".gguf", ".pt", ".pth", ".ckpt"})
 
 
 def hf_cache_snapshot_is_loadable(model_name: str) -> bool:

--- a/studio/backend/utils/utils.py
+++ b/studio/backend/utils/utils.py
@@ -8,11 +8,90 @@ import structlog
 from loggers import get_logger
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Optional
 import shutil
 import tempfile
 
 
 logger = get_logger(__name__)
+
+
+# ── Offline / HF-cache helpers ──────────────────────────────────
+# An offline model load must never touch the network: a DNS-dead session hangs on
+# huggingface_hub download retries. These read the local HF cache the load itself uses.
+
+_HF_OFFLINE_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+def hf_env_offline() -> bool:
+    """True when ``HF_HUB_OFFLINE`` or ``TRANSFORMERS_OFFLINE`` requests offline mode.
+
+    Broader than huggingface_hub, which honors only ``HF_HUB_OFFLINE``; the studio also
+    honors ``TRANSFORMERS_OFFLINE`` because users set it to keep transformers loads local.
+    """
+    for var in ("HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE"):
+        if os.environ.get(var, "").strip().lower() in _HF_OFFLINE_TRUE_VALUES:
+            return True
+    return False
+
+
+def st_repo_id_candidates(model_name: str) -> list:
+    """Repo ids a Sentence-Transformers load may resolve ``model_name`` to. A slashless
+    name (``all-MiniLM-L6-v2``) is loaded as ``sentence-transformers/all-MiniLM-L6-v2``,
+    so both are candidate cache repos.
+    """
+    name = (model_name or "").strip().strip("/")
+    if not name:
+        return []
+    candidates = [name]
+    if "/" not in name:
+        candidates.append(f"sentence-transformers/{name}")
+    return candidates
+
+
+def _hf_cache_root() -> Path:
+    """Local HF hub cache root, honoring ``HF_HUB_CACHE`` / ``HF_HOME`` at call time
+    (mirrors huggingface_hub's own resolution so it tracks a test's env override)."""
+    root = os.environ.get("HF_HUB_CACHE") or os.environ.get("HUGGINGFACE_HUB_CACHE")
+    if root:
+        return Path(root)
+    hf_home = os.environ.get("HF_HOME")
+    if hf_home:
+        return Path(hf_home) / "hub"
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".cache"
+    return base / "huggingface" / "hub"
+
+
+def hf_cache_snapshot_dir(model_name: str) -> Optional[Path]:
+    """Active local snapshot dir for ``model_name``'s ``main`` revision, or None when the
+    repo is not cached. Reads ``refs/main`` then ``snapshots/<commit>``; never touches the
+    network. Tries the ``sentence-transformers/`` alias for a slashless name.
+    """
+    try:
+        from huggingface_hub.file_download import repo_folder_name
+    except Exception:
+        repo_folder_name = None
+    cache_root = _hf_cache_root()
+    for repo_id in st_repo_id_candidates(model_name):
+        try:
+            if repo_folder_name is not None:
+                folder = repo_folder_name(repo_id = repo_id, repo_type = "model")
+            else:
+                folder = "models--" + repo_id.replace("/", "--")
+            repo_dir = cache_root / folder
+            ref = repo_dir / "refs" / "main"
+            if not ref.is_file():
+                continue
+            commit = ref.read_text().strip()
+            if not commit:
+                continue
+            snapshot = repo_dir / "snapshots" / commit
+            if snapshot.is_dir():
+                return snapshot
+        except OSError:
+            continue
+    return None
 
 
 # ── Client-safe error helpers ───────────────────────────────────

--- a/studio/backend/utils/utils.py
+++ b/studio/backend/utils/utils.py
@@ -56,32 +56,22 @@ def _expand_path(raw: str) -> Path:
 
 
 def _hf_cache_roots() -> list:
-    """Candidate local cache roots a Sentence-Transformers / huggingface_hub load may use, in
-    the loader's own precedence: an explicit ``SENTENCE_TRANSFORMERS_HOME`` (ST's cache_folder),
-    then ``HF_HUB_CACHE`` / ``HF_HOME/hub`` / ``XDG_CACHE_HOME`` / ``~/.cache``. Expanded (``~`` /
-    ``$VARS``) and de-duplicated, honoring the env at call time so a test override is tracked.
+    """The single local cache root a Sentence-Transformers / huggingface_hub load resolves to,
+    by the loader's own precedence (it selects ONE ``cache_folder`` and does not fall through):
+    an explicit ``SENTENCE_TRANSFORMERS_HOME`` (ST's cache_folder), else ``HF_HUB_CACHE``, else
+    ``HF_HOME/hub``, else ``~/.cache/huggingface/hub`` (mirroring huggingface_hub). Expanded
+    (``~`` / ``$VARS``), read from the env at call time. Returned as a one-element list.
     """
-    roots = []
     st_home = os.environ.get("SENTENCE_TRANSFORMERS_HOME")
     if st_home:
-        roots.append(_expand_path(st_home))
+        return [_expand_path(st_home)]
     hub = os.environ.get("HF_HUB_CACHE") or os.environ.get("HUGGINGFACE_HUB_CACHE")
     if hub:
-        roots.append(_expand_path(hub))
+        return [_expand_path(hub)]
     hf_home = os.environ.get("HF_HOME")
     if hf_home:
-        roots.append(_expand_path(hf_home) / "hub")
-    xdg = os.environ.get("XDG_CACHE_HOME")
-    if xdg:
-        roots.append(_expand_path(xdg) / "huggingface" / "hub")
-    roots.append(Path.home() / ".cache" / "huggingface" / "hub")
-    seen = set()
-    unique = []
-    for root in roots:
-        if root not in seen:
-            seen.add(root)
-            unique.append(root)
-    return unique
+        return [_expand_path(hf_home) / "hub"]
+    return [Path.home() / ".cache" / "huggingface" / "hub"]
 
 
 def hf_cache_snapshot_dir(model_name: str) -> Optional[Path]:


### PR DESCRIPTION
## Summary

This addresses the RAG embedding path of #6817. When Unsloth Studio runs offline, the
embedding-model preflight made Hugging Face network calls that ignore the local cache and
the offline env flags, so a machine with no network hangs on download retries instead of
using the already-cached model:

- `is_embedding_model()` called `huggingface_hub.model_info()` with no timeout.
- The RAG embedder loaded `SentenceTransformer` without `local_files_only`.
- The `/settings` embedding-model gate probed the Hub for module subdirs before scanning.

## What this changes

- New `utils.utils.hf_env_offline()` treats `HF_HUB_OFFLINE` or `TRANSFORMERS_OFFLINE` as
  offline (huggingface_hub honors only the former); `hf_cache_snapshot_dir()` resolves the
  active cached snapshot from `refs/main` without touching the network.
- `is_embedding_model()` classifies offline from the cached `modules.json` (mirroring the
  existing local-path check), bounds the online `model_info` call with a 15s timeout, and
  falls back to the local cache marker on a transient error, so a dead network degrades
  gracefully instead of hanging.
- `evaluate_file_security()` gains a `local_only_load` flag. Offline the Hub malware scan is
  unreachable, so instead of failing open it inspects the local cache and fails closed on an
  unscanned pickle weight (`pytorch_model.bin` and friends, plain or sharded) that has no
  inert `safetensors` alternative. A safetensors/gguf-only cache loads normally; nothing
  cached means nothing to load, so it is allowed.
- The embedder (`core/rag/embeddings.py`) and the `/settings` route capture the offline state
  once, skip the network subdir probes offline, and thread `local_files_only` into the load
  (gated on the SentenceTransformer version that accepts it).

## Scope

Intentionally minimal and limited to the RAG embedding path, matching the title of #7218.
This is a smaller alternative to that PR, which I am keeping open for comparison. The other
offline symptoms in #6817 (the GGUF/model-size preflight and the transformers export-tokenizer
lookup) are separate call sites and out of scope here.

## Testing

- New `studio/backend/tests/test_offline_embedding_minimal.py` (41 tests): offline
  classification with no network calls, the fail-closed gate matrix (safetensors allowed,
  pickle-without-safetensors blocked, pickle-with-safetensors sibling allowed, sharded pickle
  blocked, gguf allowed, nothing-cached allowed, subdir cases), the online bounded-timeout and
  cache-fallback paths, and the loader wiring.
- Existing suites `test_file_security.py`, `test_embedding_model_security_gate.py`,
  `test_embedding_model_settings.py`, `test_rag_embeddings.py` still pass (101 total green
  with the new file).
