### PR TITLE
fix(studio): show chat sidebar menu on touch devices

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -901,8 +901,8 @@ export function AppSidebar() {
         : "group/recent-item relative";
     const actionClass =
       variant === "project"
-        ? "sidebar-row-action group-hover/project-chat-item:opacity-100 group-hover/project-chat-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto"
-        : "sidebar-row-action group-hover/recent-item:opacity-100 group-hover/recent-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto";
+        ? "sidebar-row-action sidebar-touch-reveal group-hover/project-chat-item:opacity-100 group-hover/project-chat-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto"
+        : "sidebar-row-action sidebar-touch-reveal group-hover/recent-item:opacity-100 group-hover/recent-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto";
     const buttonClass = cn(
       "sidebar-nav-btn h-[33px] cursor-pointer rounded-full pr-4 text-[14.5px] leading-[19px] tracking-nav font-medium",
       // pl-3 (12px) over the content's pl-1.5 (6px) = 18px, aligning the
@@ -987,7 +987,7 @@ export function AppSidebar() {
               togglePinnedChat(item.id);
             }}
             aria-label={isPinned ? "Unpin chat" : "Pin chat"}
-            className="sidebar-row-action is-unpin-action group-hover/project-chat-item:opacity-100 group-hover/project-chat-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto"
+            className="sidebar-row-action sidebar-touch-reveal is-unpin-action group-hover/project-chat-item:opacity-100 group-hover/project-chat-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto"
           >
             <span className="sidebar-row-action-glyph">
               <HugeiconsIcon icon={isPinned ? PinOffIcon : PinIcon} strokeWidth={1.75} className="size-icon" />
@@ -1002,7 +1002,7 @@ export function AppSidebar() {
               togglePinnedChat(item.id);
             }}
             aria-label="Unpin chat"
-            className="sidebar-row-action is-unpin-action group-hover/recent-item:opacity-100 group-hover/recent-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto"
+            className="sidebar-row-action sidebar-touch-reveal is-unpin-action group-hover/recent-item:opacity-100 group-hover/recent-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto"
           >
             <span className="sidebar-row-action-glyph">
               <HugeiconsIcon icon={PinOffIcon} strokeWidth={1.75} className="size-icon" />

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -918,7 +918,8 @@ export function AppSidebar() {
             // (pr-8 when the menu is open keeps the unpin button clear of the title).
             "group-hover/recent-item:pr-16 group-has-[.sidebar-row-action[data-state=open]]/recent-item:pr-8 [@media(pointer:coarse)]:pr-16"
           : // Hover room for the kebab only; title keeps one more character.
-            "group-hover/recent-item:pr-6 group-has-[.sidebar-row-action[data-state=open]]/recent-item:pr-6 [@media(pointer:coarse)]:pr-6",
+            // Touch rows clear the full always-visible kebab hit area (pr-10).
+            "group-hover/recent-item:pr-6 group-has-[.sidebar-row-action[data-state=open]]/recent-item:pr-6 [@media(pointer:coarse)]:pr-10",
     );
 
     const isRenamingThis =

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -895,24 +895,14 @@ export function AppSidebar() {
     variant: "project" | "recent",
   ) {
     const isPinned = pinnedIdSet.has(item.id);
-    // Touch/coarse pointers have no hover, so reveal row actions immediately
-    // (mirrors hub model rows and project chat lists).
-    const touchVisibleAction =
-      "[@media(pointer:coarse)]:opacity-100 [@media(pointer:coarse)]:pointer-events-auto";
     const itemClass =
       variant === "project"
         ? "group/project-chat-item relative"
         : "group/recent-item relative";
     const actionClass =
       variant === "project"
-        ? cn(
-            "sidebar-row-action group-hover/project-chat-item:opacity-100 group-hover/project-chat-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto",
-            touchVisibleAction,
-          )
-        : cn(
-            "sidebar-row-action group-hover/recent-item:opacity-100 group-hover/recent-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto",
-            touchVisibleAction,
-          );
+        ? "sidebar-row-action group-hover/project-chat-item:opacity-100 group-hover/project-chat-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto"
+        : "sidebar-row-action group-hover/recent-item:opacity-100 group-hover/recent-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto";
     const buttonClass = cn(
       "sidebar-nav-btn h-[33px] cursor-pointer rounded-full pr-4 text-[14.5px] leading-[19px] tracking-nav font-medium",
       // pl-3 (12px) over the content's pl-1.5 (6px) = 18px, aligning the

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -815,27 +815,37 @@ export function AppSidebar() {
     variant: "project" | "recent",
   ) {
     const isPinned = pinnedIdSet.has(item.id);
+    // Touch/coarse pointers have no hover, so reveal row actions immediately
+    // (mirrors hub model rows and project chat lists).
+    const touchVisibleAction =
+      "[@media(pointer:coarse)]:opacity-100 [@media(pointer:coarse)]:pointer-events-auto";
     const itemClass =
       variant === "project"
         ? "group/project-chat-item relative"
         : "group/recent-item relative";
     const actionClass =
       variant === "project"
-        ? "sidebar-row-action group-hover/project-chat-item:opacity-100 group-hover/project-chat-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto"
-        : "sidebar-row-action group-hover/recent-item:opacity-100 group-hover/recent-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto";
+        ? cn(
+            "sidebar-row-action group-hover/project-chat-item:opacity-100 group-hover/project-chat-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto",
+            touchVisibleAction,
+          )
+        : cn(
+            "sidebar-row-action group-hover/recent-item:opacity-100 group-hover/recent-item:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto",
+            touchVisibleAction,
+          );
     const buttonClass = cn(
       "sidebar-nav-btn h-[33px] cursor-pointer rounded-full pr-4 text-[14.5px] leading-[19px] tracking-nav font-medium",
       // pl-3 (12px) over the content's pl-1.5 (6px) = 18px, aligning the
       // title with the nav items above.
       variant === "project" ? "pl-[39px]" : "pl-3",
       variant === "project"
-        ? "group-hover/project-chat-item:pr-6 group-has-[.sidebar-row-action[data-state=open]]/project-chat-item:pr-6"
+        ? "group-hover/project-chat-item:pr-6 group-has-[.sidebar-row-action[data-state=open]]/project-chat-item:pr-6 [@media(pointer:coarse)]:pr-6"
         : isPinned
           ? // Pinned rows show an extra unpin button on hover, so reserve more room
             // (pr-8 when the menu is open keeps the unpin button clear of the title).
-            "group-hover/recent-item:pr-16 group-has-[.sidebar-row-action[data-state=open]]/recent-item:pr-8"
+            "group-hover/recent-item:pr-16 group-has-[.sidebar-row-action[data-state=open]]/recent-item:pr-8 [@media(pointer:coarse)]:pr-16"
           : // Hover room for the kebab only; title keeps one more character.
-            "group-hover/recent-item:pr-6 group-has-[.sidebar-row-action[data-state=open]]/recent-item:pr-6",
+            "group-hover/recent-item:pr-6 group-has-[.sidebar-row-action[data-state=open]]/recent-item:pr-6 [@media(pointer:coarse)]:pr-6",
     );
 
     const isRenamingThis =

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -957,8 +957,7 @@ html[data-chat-font] .aui-root {
 		@apply absolute top-0 bottom-0 right-0 inline-flex cursor-pointer items-center justify-end pl-2 pr-1.5 opacity-0 pointer-events-none outline-none;
 	}
 	@media (pointer: coarse) {
-		/* Only chat rows that reserve touch padding (#7276). Project/run/nav
-		   row actions stay hover/focus revealed so labels are not clipped. */
+		/* Only chat rows reserve touch padding (#7276); other rows stay hover-revealed to avoid clipped labels. */
 		.sidebar-row-action.sidebar-touch-reveal {
 			@apply opacity-100 pointer-events-auto;
 		}

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -956,6 +956,11 @@ html[data-chat-font] .aui-root {
 	.sidebar-row-action {
 		@apply absolute top-0 bottom-0 right-0 inline-flex cursor-pointer items-center justify-end pl-2 pr-1.5 opacity-0 pointer-events-none outline-none;
 	}
+	@media (pointer: coarse) {
+		.sidebar-row-action {
+			@apply opacity-100 pointer-events-auto;
+		}
+	}
 	.sidebar-row-action[data-state="open"] {
 		@apply opacity-100 pointer-events-auto;
 	}

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -957,7 +957,9 @@ html[data-chat-font] .aui-root {
 		@apply absolute top-0 bottom-0 right-0 inline-flex cursor-pointer items-center justify-end pl-2 pr-1.5 opacity-0 pointer-events-none outline-none;
 	}
 	@media (pointer: coarse) {
-		.sidebar-row-action {
+		/* Only chat rows that reserve touch padding (#7276). Project/run/nav
+		   row actions stay hover/focus revealed so labels are not clipped. */
+		.sidebar-row-action.sidebar-touch-reveal {
 			@apply opacity-100 pointer-events-auto;
 		}
 	}

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -137,7 +137,9 @@ def test_chat_sidebar_row_actions_visible_on_coarse_pointers():
     sidebar_source = APP_SIDEBAR.read_text(encoding = "utf-8")
     css_source = INDEX_CSS.read_text(encoding = "utf-8")
     assert "renderChatSidebarItem" in sidebar_source
-    block = sidebar_source.split("function renderChatSidebarItem", 1)[1].split("\n  function ", 1)[0]
+    block = sidebar_source.split("function renderChatSidebarItem", 1)[1].split("\n  function ", 1)[
+        0
+    ]
     assert "[@media(pointer:coarse)]:pr-6" in block
     # Coarse-pointer visibility must come after .sidebar-row-action { opacity-0 }.
     coarse_idx = css_source.index("@media (pointer: coarse)")

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -14,6 +14,7 @@ DATA_TAB = FRONTEND / "features/settings/tabs/data-tab.tsx"
 PROMPT_STORAGE = FRONTEND / "features/chat/prompt-storage/prompt-storage-dialog.tsx"
 
 APP_SIDEBAR = FRONTEND / "components/app-sidebar.tsx"
+INDEX_CSS = FRONTEND / "index.css"
 THREAD = FRONTEND / "components/assistant-ui/thread.tsx"
 THREAD_SIDEBAR = FRONTEND / "features/chat/thread-sidebar.tsx"
 SHARED_COMPOSER = FRONTEND / "features/chat/shared-composer.tsx"
@@ -133,10 +134,15 @@ def test_expanded_titlebar_button_and_corner_match_sidebar_edge():
 
 def test_chat_sidebar_row_actions_visible_on_coarse_pointers():
     """unslothai/unsloth#7276: Recents chat kebab must be tappable on iPad."""
-    source = APP_SIDEBAR.read_text(encoding = "utf-8")
-    assert "[@media(pointer:coarse)]:opacity-100" in source
-    assert "[@media(pointer:coarse)]:pointer-events-auto" in source
-    assert "renderChatSidebarItem" in source
-    block = source.split("function renderChatSidebarItem", 1)[1].split("\n  function ", 1)[0]
-    assert "touchVisibleAction" in block
+    sidebar_source = APP_SIDEBAR.read_text(encoding = "utf-8")
+    css_source = INDEX_CSS.read_text(encoding = "utf-8")
+    assert "renderChatSidebarItem" in sidebar_source
+    block = sidebar_source.split("function renderChatSidebarItem", 1)[1].split("\n  function ", 1)[0]
     assert "[@media(pointer:coarse)]:pr-6" in block
+    # Coarse-pointer visibility must come after .sidebar-row-action { opacity-0 }.
+    coarse_idx = css_source.index("@media (pointer: coarse)")
+    base_idx = css_source.index(".sidebar-row-action {")
+    assert coarse_idx > base_idx
+    coarse_block = css_source[coarse_idx : coarse_idx + 200]
+    assert "opacity-100" in coarse_block
+    assert "pointer-events-auto" in coarse_block

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -129,3 +129,14 @@ def test_expanded_titlebar_button_and_corner_match_sidebar_edge():
         'className="pointer-events-none absolute top-full size-3 -translate-x-px rounded-tl-[12px] border-l border-t border-sidebar-border bg-background"'
         in source
     )
+
+
+def test_chat_sidebar_row_actions_visible_on_coarse_pointers():
+    """unslothai/unsloth#7276: Recents chat kebab must be tappable on iPad."""
+    source = APP_SIDEBAR.read_text(encoding = "utf-8")
+    assert "[@media(pointer:coarse)]:opacity-100" in source
+    assert "[@media(pointer:coarse)]:pointer-events-auto" in source
+    assert "renderChatSidebarItem" in source
+    block = source.split("function renderChatSidebarItem", 1)[1].split("\n  function ", 1)[0]
+    assert "touchVisibleAction" in block
+    assert "[@media(pointer:coarse)]:pr-6" in block

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -140,7 +140,7 @@ def test_chat_sidebar_row_actions_visible_on_coarse_pointers():
     block = sidebar_source.split("function renderChatSidebarItem", 1)[1].split("\n  function ", 1)[
         0
     ]
-    assert "[@media(pointer:coarse)]:pr-6" in block
+    assert "[@media(pointer:coarse)]:pr-10" in block
     assert "sidebar-touch-reveal" in block
     # Coarse-pointer visibility must come after .sidebar-row-action { opacity-0 }.
     coarse_idx = css_source.index("@media (pointer: coarse)")

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -141,10 +141,15 @@ def test_chat_sidebar_row_actions_visible_on_coarse_pointers():
         0
     ]
     assert "[@media(pointer:coarse)]:pr-6" in block
+    assert "sidebar-touch-reveal" in block
     # Coarse-pointer visibility must come after .sidebar-row-action { opacity-0 }.
     coarse_idx = css_source.index("@media (pointer: coarse)")
     base_idx = css_source.index(".sidebar-row-action {")
     assert coarse_idx > base_idx
-    coarse_block = css_source[coarse_idx : coarse_idx + 200]
+    coarse_block = css_source[coarse_idx : coarse_idx + 280]
+    assert "sidebar-touch-reveal" in coarse_block
     assert "opacity-100" in coarse_block
     assert "pointer-events-auto" in coarse_block
+    # Must not reveal every sidebar-row-action (project/run/nav rows lack padding).
+    assert ".sidebar-row-action {\n\t\t\t@apply opacity-100" not in coarse_block
+    assert ".sidebar-row-action.sidebar-touch-reveal" in coarse_block


### PR DESCRIPTION
## Problem

On iPad and other touch devices, chat rows in the Recents/Pinned sidebar could not be deleted. The kebab menu that exposes Rename / Pin / Delete is rendered with `sidebar-row-action`, which stays `opacity-0 pointer-events-none` until hover. Touch devices have no persistent hover, so the menu button was invisible and untappable.

Reported in #7276.

## Fix

Reveal chat row actions on coarse pointers (`[@media(pointer:coarse)]`) and reserve title padding on touch so the kebab stays tappable. This matches the existing Studio pattern used in hub model rows (`models-catalog-rows.tsx`) and project chat lists (`chat-page.tsx`), rather than adding a new long-press interaction.

Changes are limited to `renderChatSidebarItem()` in `app-sidebar.tsx`.

## Verification

- `npm run typecheck` (studio/frontend)
- `pytest tests/studio/test_desktop_reliability_frontend_contract.py::test_chat_sidebar_row_actions_visible_on_coarse_pointers`
- Manual (not run here): on iPad or a mobile viewport, open Chat → Recents → tap the kebab on a chat → Delete is reachable

## Compatibility

Frontend only, scoped to Recents/Pinned chat sidebar rows. Desktop hover behaviour is unchanged: fine pointers still hide the kebab until hover/focus/open. Training runs, Projects nav, and other sidebar rows are untouched.

Fixes #7276