### PR TITLE
Studio: move sidebar search into the header

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1196,13 +1196,18 @@ export function AppSidebar() {
                 openNewChat(null);
               }}
             />
-            {/* Search now lives in the header; keep this row only for the
-                collapsed rail, where no header button shows. */}
+            {/* Search sits in the header when the brand row is shown (mac/web).
+                Hide this row there, but keep it in the collapsed rail. On custom
+                titlebars (win/linux) there's no header button, so keep the row. */}
             <NavItem
               icon={Search01Icon}
               label={t("shell.navigation.search")}
               active={false}
-              className="hidden group-data-[collapsible=icon]:block"
+              className={
+                showSidebarBrand
+                  ? "hidden group-data-[collapsible=icon]:block"
+                  : undefined
+              }
               onClick={() => {
                 useChatSearchStore.getState().open();
                 closeMobileIfOpen();

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -45,6 +45,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import { useAnimatedThemeToggle } from "@/components/ui/animated-theme-toggler";
 import {
+  getClientPlatform,
   shouldUseCustomWindowTitlebar,
   shouldUseNativeMacWindowTitlebar,
 } from "@/components/tauri/window-titlebar";
@@ -330,6 +331,8 @@ export function AppSidebar() {
   );
   const [usesCustomTitlebar] = useState(shouldUseCustomWindowTitlebar);
   const [usesNativeMacTitlebar] = useState(shouldUseNativeMacWindowTitlebar);
+  // Mac uses Cmd, others use Ctrl. Not Tauri-gated, so it's right on web too.
+  const [isMacPlatform] = useState(() => getClientPlatform().includes("mac"));
   const { pathname, search } = useRouterState({
     select: (s) => ({
       pathname: s.location.pathname,
@@ -1100,10 +1103,11 @@ export function AppSidebar() {
                     side="bottom"
                     sideOffset={6}
                     className="tooltip-compact flex items-center gap-1.5"
+                    hidden={isMobile}
                   >
                     {t("shell.navigation.search")}
                     <kbd className="rounded bg-black/10 px-1 py-px text-[10px] font-medium leading-none dark:bg-white/15">
-                      ⌘K
+                      {isMacPlatform ? "⌘K" : "Ctrl+K"}
                     </kbd>
                   </TooltipContent>
                 </Tooltip>

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1081,27 +1081,54 @@ export function AppSidebar() {
                   </span>
                 </Link>
               )}
-              {!isMobile && (
+              <div className="flex items-center gap-0.5">
                 <Tooltip>
                   <TooltipPrimitive.Trigger asChild>
                     <button
                       type="button"
-                      onClick={togglePinned}
+                      onClick={() => {
+                        useChatSearchStore.getState().open();
+                        closeMobileIfOpen();
+                      }}
                       className="inline-flex h-[33px] w-[32px] cursor-pointer items-center justify-center rounded-[10px] text-nav-icon-idle dark:text-nav-fg-muted transition-colors hover:bg-nav-surface-hover hover:text-black dark:hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                      aria-label={t("shell.aria.closeSidebar")}
+                      aria-label={t("shell.navigation.search")}
                     >
-                      <HugeiconsIcon icon={LayoutAlignLeftIcon} strokeWidth={1.75} className="size-icon" />
+                      <HugeiconsIcon icon={Search01Icon} strokeWidth={1.75} className="size-icon" />
                     </button>
                   </TooltipPrimitive.Trigger>
                   <TooltipContent
                     side="bottom"
                     sideOffset={6}
-                    className="tooltip-compact"
+                    className="tooltip-compact flex items-center gap-1.5"
                   >
-                    {t("shell.aria.closeSidebar")}
+                    {t("shell.navigation.search")}
+                    <kbd className="rounded bg-black/10 px-1 py-px text-[10px] font-medium leading-none dark:bg-white/15">
+                      ⌘K
+                    </kbd>
                   </TooltipContent>
                 </Tooltip>
-              )}
+                {!isMobile && (
+                  <Tooltip>
+                    <TooltipPrimitive.Trigger asChild>
+                      <button
+                        type="button"
+                        onClick={togglePinned}
+                        className="inline-flex h-[33px] w-[32px] cursor-pointer items-center justify-center rounded-[10px] text-nav-icon-idle dark:text-nav-fg-muted transition-colors hover:bg-nav-surface-hover hover:text-black dark:hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                        aria-label={t("shell.aria.closeSidebar")}
+                      >
+                        <HugeiconsIcon icon={LayoutAlignLeftIcon} strokeWidth={1.75} className="size-icon" />
+                      </button>
+                    </TooltipPrimitive.Trigger>
+                    <TooltipContent
+                      side="bottom"
+                      sideOffset={6}
+                      className="tooltip-compact"
+                    >
+                      {t("shell.aria.closeSidebar")}
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+              </div>
             </div>
             {!isMobile && (
               <div className="relative z-10 hidden group-data-[collapsible=icon]:flex h-[33px] items-center justify-center w-full">
@@ -1133,8 +1160,10 @@ export function AppSidebar() {
       {/* Uniform pl-1.5 pr-2 keeps every hover pill the same width, inset from the edge. */}
       <SidebarGroup
         className={cn(
-          "group-data-[collapsible=icon]:px-0 pl-1.5 pr-2 pb-px shrink-0",
+          "group-data-[collapsible=icon]:px-0 pl-1.5 pr-2 shrink-0 transition-[padding]",
           showCompactMacBrand ? "pt-0" : "pt-[9px]",
+          // Scrolled: New Chat is pinned, give a little gap below it.
+          scrolled ? "pb-[5px]" : "pb-px",
         )}
       >
         <SidebarGroupContent>
@@ -1167,10 +1196,13 @@ export function AppSidebar() {
                 openNewChat(null);
               }}
             />
+            {/* Search now lives in the header; keep this row only for the
+                collapsed rail, where no header button shows. */}
             <NavItem
               icon={Search01Icon}
               label={t("shell.navigation.search")}
               active={false}
+              className="hidden group-data-[collapsible=icon]:block"
               onClick={() => {
                 useChatSearchStore.getState().open();
                 closeMobileIfOpen();

--- a/studio/frontend/src/components/tauri/window-titlebar.tsx
+++ b/studio/frontend/src/components/tauri/window-titlebar.tsx
@@ -40,7 +40,7 @@ type NavigatorWithUserAgentData = Navigator & {
   };
 };
 
-function getClientPlatform(): string {
+export function getClientPlatform(): string {
   if (typeof navigator === "undefined") {
     return "";
   }


### PR DESCRIPTION
## What this does

Moves the Studio sidebar Search action out of its own full-width nav row and into the sidebar header, as an icon button sitting right next to the sidebar toggle. This keeps New Chat as the only fixed row above the scrolling thread list, which reads cleaner and matches the layout people expect.

## Changes

- Search is now an icon button in the sidebar header, placed just left of the collapse toggle. It opens the same search dialog and its tooltip shows the Cmd K shortcut.
- The old full-width Search row is hidden in the expanded sidebar on macOS and web, but kept for the collapsed icon rail.
- On Windows and Linux desktop builds the header uses a custom window titlebar, so there is no header search button there. On those platforms the full-width search row stays visible exactly as before, so no platform loses access to search.
- Added a small bottom gap (5px) under New Chat only while the list is scrolled and New Chat is pinned as a header. The normal, unscrolled spacing is unchanged, and the change eases in with a padding transition.

## Scope and risk

- Frontend only. This touches the sidebar component and nothing in the training, inference, or backend paths, so no compute pathway is affected.
- No behavior change to the search dialog itself or the Cmd K binding.
