### PR TITLE
Studio: lighten chat text weight on Linux to match macOS rendering

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -3598,7 +3598,7 @@ const AssistantMessage: FC = () => {
 
   return (
     <MessagePrimitive.Root
-      className="group/assistant-message aui-assistant-message-root relative mx-auto min-w-0 w-full max-w-(--thread-content-max-width) pt-0.5 pb-4 text-[15.5px] [font-weight:var(--chat-font-weight,410)] tracking-[0.01em] dark:tracking-[0.02em]"
+      className="group/assistant-message aui-assistant-message-root relative mx-auto min-w-0 w-full max-w-(--thread-content-max-width) pt-0.5 pb-4 text-[15.5px] [font-weight:410] tracking-[0.01em] dark:tracking-[0.02em]"
       data-role="assistant"
     >
       <div className="aui-assistant-message-content wrap-break-word min-w-0 text-[#0d0d0d] dark:text-foreground leading-relaxed">
@@ -4036,7 +4036,7 @@ const UserMessageAudio: FC = () => {
 const UserMessage: FC = () => {
   return (
     <MessagePrimitive.Root
-      className="aui-user-message-root fade-in slide-in-from-bottom-1 mx-auto flex w-full max-w-(--thread-content-max-width) animate-in flex-col items-end gap-y-2 pt-6 pb-4 text-[15.5px] [font-weight:var(--chat-font-weight,410)] tracking-[0.01em] dark:tracking-[0.02em] duration-150"
+      className="aui-user-message-root fade-in slide-in-from-bottom-1 mx-auto flex w-full max-w-(--thread-content-max-width) animate-in flex-col items-end gap-y-2 pt-6 pb-4 text-[15.5px] [font-weight:410] tracking-[0.01em] dark:tracking-[0.02em] duration-150"
       data-role="user"
     >
       <UserMessageAttachments />

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -3598,7 +3598,7 @@ const AssistantMessage: FC = () => {
 
   return (
     <MessagePrimitive.Root
-      className="group/assistant-message aui-assistant-message-root relative mx-auto min-w-0 w-full max-w-(--thread-content-max-width) pt-0.5 pb-4 text-[15.5px] [font-weight:410] tracking-[0.01em] dark:tracking-[0.02em]"
+      className="group/assistant-message aui-assistant-message-root relative mx-auto min-w-0 w-full max-w-(--thread-content-max-width) pt-0.5 pb-4 text-[15.5px] [font-weight:var(--chat-font-weight,410)] tracking-[0.01em] dark:tracking-[0.02em]"
       data-role="assistant"
     >
       <div className="aui-assistant-message-content wrap-break-word min-w-0 text-[#0d0d0d] dark:text-foreground leading-relaxed">
@@ -4036,7 +4036,7 @@ const UserMessageAudio: FC = () => {
 const UserMessage: FC = () => {
   return (
     <MessagePrimitive.Root
-      className="aui-user-message-root fade-in slide-in-from-bottom-1 mx-auto flex w-full max-w-(--thread-content-max-width) animate-in flex-col items-end gap-y-2 pt-6 pb-4 text-[15.5px] [font-weight:410] tracking-[0.01em] dark:tracking-[0.02em] duration-150"
+      className="aui-user-message-root fade-in slide-in-from-bottom-1 mx-auto flex w-full max-w-(--thread-content-max-width) animate-in flex-col items-end gap-y-2 pt-6 pb-4 text-[15.5px] [font-weight:var(--chat-font-weight,410)] tracking-[0.01em] dark:tracking-[0.02em] duration-150"
       data-role="user"
     >
       <UserMessageAttachments />

--- a/studio/frontend/src/features/settings/stores/appearance-custom-store.ts
+++ b/studio/frontend/src/features/settings/stores/appearance-custom-store.ts
@@ -479,6 +479,11 @@ export function applyCustomizationToDocument(
     "--font-sans",
     c.uiFont ? `"${c.uiFont}", ${DEFAULT_SANS_STACK}` : null,
   );
+  // A custom interface font cascades into chat text (message roots set no
+  // family of their own), so index.css keys the Linux chat-weight
+  // compensation off this marker too: the compensation is calibrated for
+  // Inter only.
+  el.toggleAttribute("data-ui-font", Boolean(c.uiFont));
   setVar(
     "--font-heading",
     c.headingFont ? `"${c.headingFont}", ${DEFAULT_HEADING_STACK}` : null,

--- a/studio/frontend/src/features/settings/stores/appearance-custom-store.ts
+++ b/studio/frontend/src/features/settings/stores/appearance-custom-store.ts
@@ -479,10 +479,7 @@ export function applyCustomizationToDocument(
     "--font-sans",
     c.uiFont ? `"${c.uiFont}", ${DEFAULT_SANS_STACK}` : null,
   );
-  // A custom interface font cascades into chat text (message roots set no
-  // family of their own), so index.css keys the Linux chat-weight
-  // compensation off this marker too: the compensation is calibrated for
-  // Inter only.
+  // Custom interface fonts cascade into chat and opt out of its Inter tuning.
   el.toggleAttribute("data-ui-font", Boolean(c.uiFont));
   setVar(
     "--font-heading",

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -633,6 +633,17 @@ html.no-font-smoothing body {
 	-moz-osx-font-smoothing: auto;
 }
 
+/* Chat text weight compensation. FreeType (Linux) rasterizes Inter's 410
+   weight visibly heavier than macOS CoreText does under the app's antialiased
+   smoothing (the design reference), so chat text renders one step lighter
+   there. Scoped to the default chat font (a custom font is the user's own
+   rendering choice) and tied to the Font smoothing toggle, so turning that
+   off restores native platform rendering. Chat message roots consume the
+   token via [font-weight:var(--chat-font-weight,410)]. */
+html.render-linux:not(.no-font-smoothing):not([data-chat-font]) {
+	--chat-font-weight: 350;
+}
+
 /* Chat font: only applies while a custom chat font is set. Elements with
    explicit font utilities (headings, code) keep their own families. */
 html[data-chat-font] .aui-root {

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -636,11 +636,13 @@ html.no-font-smoothing body {
 /* Chat text weight compensation. FreeType (Linux) rasterizes Inter's 410
    weight visibly heavier than macOS CoreText does under the app's antialiased
    smoothing (the design reference), so chat text renders one step lighter
-   there. Scoped to the default chat font (a custom font is the user's own
-   rendering choice) and tied to the Font smoothing toggle, so turning that
-   off restores native platform rendering. Chat message roots consume the
-   token via [font-weight:var(--chat-font-weight,410)]. */
-html.render-linux:not(.no-font-smoothing):not([data-chat-font]) {
+   there. Calibrated for Inter only, so any custom font that reaches chat
+   opts out: a dedicated chat font (data-chat-font) or a custom interface
+   font (data-ui-font), which cascades into chat via --font-sans. Tied to
+   the Font smoothing toggle, so turning that off restores native platform
+   rendering. Chat message roots consume the token via
+   [font-weight:var(--chat-font-weight,410)]. */
+html.render-linux:not(.no-font-smoothing):not([data-chat-font]):not([data-ui-font]) {
 	--chat-font-weight: 350;
 }
 

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -633,17 +633,11 @@ html.no-font-smoothing body {
 	-moz-osx-font-smoothing: auto;
 }
 
-/* Chat text weight compensation. FreeType (Linux) rasterizes Inter's 410
-   weight visibly heavier than macOS CoreText does under the app's antialiased
-   smoothing (the design reference), so chat text renders one step lighter
-   there. Calibrated for Inter only, so any custom font that reaches chat
-   opts out: a dedicated chat font (data-chat-font) or a custom interface
-   font (data-ui-font), which cascades into chat via --font-sans. Tied to
-   the Font smoothing toggle, so turning that off restores native platform
-   rendering. Chat message roots consume the token via
-   [font-weight:var(--chat-font-weight,410)]. */
-html.render-linux:not(.no-font-smoothing):not([data-chat-font]):not([data-ui-font]) {
-	--chat-font-weight: 350;
+/* Match Inter's lighter macOS rendering. Keep 410 when smoothing is off or a
+   custom font reaches chat. */
+html.render-linux:not(.no-font-smoothing):not([data-chat-font]):not([data-ui-font])
+	:is(.aui-assistant-message-root, .aui-user-message-root) {
+	font-weight: 350;
 }
 
 /* Chat font: only applies while a custom chat font is set. Elements with

--- a/studio/frontend/src/main.tsx
+++ b/studio/frontend/src/main.tsx
@@ -36,13 +36,8 @@ if (!rootElement) {
 
 initializeLocale();
 
-// Font rasterization happens in the rendering client, so key off navigator
-// rather than the server-reported platform (the backend may be a remote host
-// on a different OS). Linux FreeType draws Inter visibly heavier than macOS
-// CoreText renders it under the app's antialiased smoothing; index.css
-// lightens chat text under this class to compensate. Android is excluded:
-// it also uses FreeType, but its display densities hide the difference and
-// the compensation is untested there.
+// Rasterization follows the browser OS, not the potentially remote server.
+// This adjustment is calibrated for desktop Linux, so exclude Android.
 const uaLower = navigator.userAgent.toLowerCase();
 if (uaLower.includes("linux") && !uaLower.includes("android")) {
   document.documentElement.classList.add("render-linux");

--- a/studio/frontend/src/main.tsx
+++ b/studio/frontend/src/main.tsx
@@ -36,6 +36,18 @@ if (!rootElement) {
 
 initializeLocale();
 
+// Font rasterization happens in the rendering client, so key off navigator
+// rather than the server-reported platform (the backend may be a remote host
+// on a different OS). Linux FreeType draws Inter visibly heavier than macOS
+// CoreText renders it under the app's antialiased smoothing; index.css
+// lightens chat text under this class to compensate. Android is excluded:
+// it also uses FreeType, but its display densities hide the difference and
+// the compensation is untested there.
+const uaLower = navigator.userAgent.toLowerCase();
+if (uaLower.includes("linux") && !uaLower.includes("android")) {
+  document.documentElement.classList.add("render-linux");
+}
+
 createRoot(rootElement).render(
   <StrictMode>
     <App />


### PR DESCRIPTION
Studio's default Inter chat text renders heavier on Linux than the same build on macOS. The global `-webkit-font-smoothing: antialiased` only affects macOS rendering, so using weight 410 on both platforms does not produce the same visual weight.

## Fix

Render assistant and user message text at weight 350 on desktop Linux. Detection uses the browser user agent because the backend may run on a different OS. Android is unchanged.

Font smoothing off, custom chat fonts, and custom interface fonts keep weight 410. The adjustment is specific to the default Inter font.

Weight 350 was selected by testing values from 300 through 410. It noticeably reduces the difference without making text look washed out.

## Comparison

Same content and app CSS, rendered through the real code path.

**macOS reference (weight 410):**
<img width="720" height="360" alt="1-macos-reference-w410" src="https://github.com/user-attachments/assets/6d871877-f00f-4578-b78e-b019063ba31e" />


**Linux before (weight 410):**
<img width="720" height="360" alt="2-linux-before-w410" src="https://github.com/user-attachments/assets/15e70559-f0b3-4174-a5b0-ac78d115aa36" />


**Linux after (weight 350):**
<img width="720" height="360" alt="3-linux-after-w350" src="https://github.com/user-attachments/assets/a9499ba5-1343-41bf-8484-3f277d41bb41" />

## Verification

- Production frontend build passes (tsc + vite).
- Playwright against the compiled CSS confirms computed weight 350 on desktop Linux and 410 for every opt-out (smoothing off, custom chat font, custom interface font) and non-Linux clients.
- Selecting a custom interface font through Appearance keeps chat at 410; resetting it returns chat to 350.
- Rendered the same content through the real code path on Linux (FreeType) and a macOS machine (CoreText). By integrated ink, Linux text goes from +4.6% heavier than the macOS reference to +0.3%. Measured at 1x, where the gap is largest.
