### PR TITLE
fix(studio): resolve bare git on Windows sandbox PATH

### DIFF
--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2496,10 +2496,17 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
 
     Whitelist-built from scratch (parent env NOT inherited): only PATH/HOME/
     TMPDIR/LANG/TERM/PYTHONIOENCODING/PYTHONPATH (+VIRTUAL_ENV or Windows
-    SystemRoot) reach the child; all credential vars (HF_TOKEN, AWS_*, etc.)
-    are absent. HOME points at the sandbox workdir so SDKs can't read the
+    SystemRoot/PATHEXT) reach the child; all credential vars (HF_TOKEN, AWS_*,
+    etc.) are absent. HOME points at the sandbox workdir so SDKs can't read the
     operator's cached creds. PYTHONPATH carries only the sandbox sitecustomize
     shim directory.
+
+    PATH starts with the Studio interpreter / venv and OS system dirs so
+    ``python``/``pip`` stay pinned, then appends absolute directories from the
+    parent PATH so user-installed tools (e.g. Windows Git under
+    ``C:\\Program Files\\Git\\cmd``) resolve by bare name like a normal
+    terminal (#7317). Relative / ``.`` entries are skipped to avoid cwd PATH
+    hijacks.
     """
     # Start from the running interpreter's dir so 'python'/'pip' resolve to the
     # same environment the Unsloth server runs in.
@@ -2518,6 +2525,14 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
         path_entries.extend([os.path.join(sysroot, "System32"), sysroot])
     else:
         path_entries.extend(["/usr/local/bin", "/usr/bin", "/bin"])
+
+    # Append absolute host PATH dirs so bare tools like `git` resolve (#7317).
+    # Keep curated entries first; skip relative / "." to avoid cwd hijacks.
+    for entry in os.environ.get("PATH", "").split(os.pathsep):
+        entry = entry.strip().strip('"')
+        if not entry or entry in (".",) or not os.path.isabs(entry):
+            continue
+        path_entries.append(entry)
 
     # Deduplicate, preserving order.
     deduped = list(dict.fromkeys(p for p in path_entries if p))
@@ -2538,6 +2553,11 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
     # Windows needs SystemRoot for Python/subprocess to work.
     if sys.platform == "win32":
         env["SystemRoot"] = os.environ.get("SystemRoot", r"C:\Windows")
+        # cmd.exe uses PATHEXT to map `git` -> `git.exe`. Inherit the host
+        # list when present so bare tool names resolve like a normal shell.
+        pathext = os.environ.get("PATHEXT")
+        if pathext:
+            env["PATHEXT"] = pathext
     return env
 
 

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -317,9 +317,7 @@ class TestSandboxEnvIsolation:
         junk_rel = "relative-bin"
         monkeypatch.setenv(
             "PATH",
-            os.pathsep.join(
-                [str(git_dir), ".", junk_rel, os.environ.get("PATH", "")]
-            ),
+            os.pathsep.join([str(git_dir), ".", junk_rel, os.environ.get("PATH", "")]),
         )
         env = _build_safe_env(str(tmp_path))
         parts = env["PATH"].split(os.pathsep)

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -297,6 +297,7 @@ class TestSandboxEnvIsolation:
             "PYTHONPATH",
             "VIRTUAL_ENV",
             "SystemRoot",
+            "PATHEXT",  # Windows only; inherited so bare names like git resolve
         }
         extras = set(env.keys()) - allowed
         assert not extras, f"sandbox env added unexpected keys: {extras}"
@@ -304,6 +305,41 @@ class TestSandboxEnvIsolation:
         # sitecustomize shim dir (code-interpreter path remap).
         assert env["PYTHONPATH"].endswith("sandbox_site")
         assert "leak-me" not in env["PYTHONPATH"]
+
+    def test_host_path_absolute_dirs_appended_after_curated(self, monkeypatch, tmp_path):
+        # #7317: Windows Git lives under Program Files, not System32. Sandbox PATH
+        # must still resolve bare `git` by appending absolute host PATH dirs after
+        # the curated interpreter / system prefix.
+        from core.inference.tools import _build_safe_env
+
+        git_dir = tmp_path / "Git" / "cmd"
+        git_dir.mkdir(parents = True)
+        junk_rel = "relative-bin"
+        monkeypatch.setenv(
+            "PATH",
+            os.pathsep.join(
+                [str(git_dir), ".", junk_rel, os.environ.get("PATH", "")]
+            ),
+        )
+        env = _build_safe_env(str(tmp_path))
+        parts = env["PATH"].split(os.pathsep)
+        assert str(git_dir) in parts
+        # Curated prefix stays ahead of host Git so Studio python/pip win.
+        assert parts.index(str(git_dir)) > 0
+        assert "." not in parts
+        assert junk_rel not in parts
+
+    def test_host_path_quoted_windows_style_entries_stripped(self, monkeypatch, tmp_path):
+        from core.inference.tools import _build_safe_env
+
+        quoted = tmp_path / "Quoted Tools"
+        quoted.mkdir()
+        # Windows PATH entries are sometimes quoted when they contain spaces.
+        monkeypatch.setenv("PATH", f'"{quoted}"{os.pathsep}{os.environ.get("PATH", "")}')
+        env = _build_safe_env(str(tmp_path))
+        parts = env["PATH"].split(os.pathsep)
+        assert str(quoted) in parts
+        assert f'"{quoted}"' not in parts
 
     def test_home_points_at_sandbox_workdir(self, tmp_path):
         from core.inference.tools import _build_safe_env


### PR DESCRIPTION
Fixes #7317

## Problem

On Windows, Studio's sandboxed terminal tool fails with `'git' is not recognized as an internal or external command` even when Git works in every normal cmd/PowerShell on the machine (including the one Studio was launched from). Bare `git` only works after the model is told to use the 8.3 path `C:\PROGRA~1\Git\cmd\git.exe`.

`_build_safe_env()` rebuilds `PATH` from scratch as Studio venv + `System32` only. User-installed Git lives under `C:\Program Files\Git\cmd`, so it never enters that `PATH`. Unix sandboxes already include `/usr/bin`, which is why system `git` worked there.

## Fix

- **`studio/backend/core/inference/tools.py`**: After the curated interpreter / venv / system dirs, append absolute entries from the parent `PATH` (strip quotes; skip empty / `.` / relative entries so cwd PATH hijacks stay blocked). On Windows, also inherit `PATHEXT` so `git` maps to `git.exe` like a normal shell.
- **`studio/backend/tests/test_sandbox_tools.py`**: Cover host PATH append order, relative-entry filtering, and quoted Windows-style PATH entries.

## Verification

```bash
PYTHONPATH=studio/backend python -m pytest studio/backend/tests/test_sandbox_tools.py::TestSandboxEnvIsolation -q
PYTHONPATH=studio/backend python -m pytest studio/backend/tests/test_bypass_permissions.py -q -k 'safe_env or bypass_env or PATH or secret'
```

8/8 sandbox env tests pass; 32 related bypass/env tests pass.

## Compatibility

- Curated `PATH` prefix is unchanged: Studio `python`/`pip` still win over host copies.
- Credential whitelist is unchanged (still no `HF_TOKEN` / `USERPROFILE` / etc. in the sandbox env).
- Full-access / bypass mode already inherited host `PATH`; unchanged.
- Linux/macOS get the same absolute host-`PATH` append; relative entries remain excluded.