### PR TITLE
fix(studio): resolve bare git on Windows sandbox PATH

### DIFF
--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2530,12 +2530,15 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
     # Windows Git installs live outside System32; inherit only the dir of the
     # git the HOST shell resolves (never a name-matched, possibly user-writable
     # dir) so bare `git` resolves without weakening the sandbox PATH (#7317).
+    git_ext = ""
     if sys.platform == "win32":
         git_exe = shutil.which("git")
         if git_exe:
             git_dir = os.path.dirname(git_exe)
             if os.path.isabs(git_dir):
                 path_entries.append(git_dir)
+                # A .cmd/.bat git shim needs its extension in PATHEXT below.
+                git_ext = os.path.splitext(git_exe)[1].upper()
 
     # Deduplicate, preserving order.
     deduped = list(dict.fromkeys(p for p in path_entries if p))
@@ -2557,7 +2560,11 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
     if sys.platform == "win32":
         env["SystemRoot"] = os.environ.get("SystemRoot", r"C:\Windows")
         # Restrict PATHEXT so cwd .BAT/.CMD cannot hijack bare names (#7317).
-        env["PATHEXT"] = ".EXE;.COM"
+        pathext = ".EXE;.COM"
+        if git_ext and git_ext not in (".EXE", ".COM"):
+            # Keep the host git launcher (e.g. a .CMD shim) resolvable.
+            pathext += ";" + git_ext
+        env["PATHEXT"] = pathext
         # cmd/CreateProcess search cwd before PATH for bare names; disable so
         # a workdir rg.exe/git.exe cannot shadow auto-approved commands.
         env["NoDefaultCurrentDirectoryInExePath"] = "1"

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2499,11 +2499,28 @@ def _canon_win_path(p: str) -> str:
     return os.path.normcase(os.path.normpath(os.path.realpath(p)))
 
 
+def _augment_native_program_roots(roots: list[str]) -> list[str]:
+    """Add the native Program Files sibling for any x86 root by stripping the
+    `` (x86)`` suffix, so a 32-bit process (whose known-folder ids map only to
+    the x86 root) still trusts a 64-bit Git install."""
+    out = list(roots)
+    for root in roots:
+        base = root.rstrip("\\/")
+        if base.lower().endswith(" (x86)"):
+            native = base[: -len(" (x86)")]
+            if native and native not in out:
+                out.append(native)
+    return out
+
+
 def _windows_program_roots() -> list[str]:
-    """Program Files install roots, resolved from the Windows known-folder API
-    (SHGetKnownFolderPath) so an overridden ``%ProgramFiles%`` env value cannot
-    move the trust boundary. Falls back to the env vars, then to fixed
-    ``%SystemDrive%`` paths, only if the API is unavailable (#7317).
+    """Program Files install roots, resolved ONLY from the Windows known-folder
+    API (SHGetKnownFolderPath). Fails closed (returns ``[]``) if the API is
+    unavailable: env vars (%ProgramFiles%, even %SystemDrive%) are caller-
+    overrideable and could relocate the trust boundary, so we never derive a
+    trusted root from them. On any real Windows host shell32 is present, so
+    this only returns empty in a broken/non-Windows environment where the
+    sandbox git-PATH feature is not needed anyway (#7317).
     """
     roots: list[str] = []
     try:
@@ -2529,23 +2546,8 @@ def _windows_program_roots() -> list[str]:
                     roots.append(ptr.value)
                 _CoTaskMemFree(ptr)
     except Exception:
-        roots = []
-    if not roots:
-        # Do NOT fall back to %ProgramFiles%/%ProgramW6432%: a caller can
-        # override those to a writable dir and relocate the trust boundary.
-        # SystemDrive is not a viable override (retargeting it breaks the OS).
-        drive = os.environ.get("SystemDrive", "C:")
-        roots = [drive + r"\Program Files", drive + r"\Program Files (x86)"]
-    # A 32-bit process on 64-bit Windows only sees the x86 root (the X64
-    # known-folder id is unsupported there), so derive the native sibling by
-    # stripping the " (x86)" suffix. Derived from a trusted root, not env.
-    for root in list(roots):
-        base = root.rstrip("\\/")
-        if base.lower().endswith(" (x86)"):
-            native = base[: -len(" (x86)")]
-            if native and native not in roots:
-                roots.append(native)
-    return roots
+        return []
+    return _augment_native_program_roots(roots)
 
 
 def _resolve_trusted_windows_git() -> tuple[str, str]:

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2493,6 +2493,29 @@ def is_potentially_unsafe_tool_call(name: str, arguments: dict) -> bool:
     return True
 
 
+def _is_trusted_windows_program_dir(path: str) -> bool:
+    """True when ``path`` sits under a system-managed install root.
+
+    Program Files (+ x86 / W6432) and ``%SystemRoot%`` are admin-writable
+    only, so a bare auto-approved command resolving from a Git dir there
+    cannot be replaced by an unprivileged attacker. Per-user managers
+    (Scoop/Choco shims under the profile) are refused (#7317).
+    """
+    roots = []
+    for var in ("ProgramFiles", "ProgramFiles(x86)", "ProgramW6432", "SystemRoot"):
+        val = os.environ.get(var)
+        if val:
+            roots.append(val)
+    if not roots:
+        roots = [r"C:\Program Files", r"C:\Program Files (x86)", r"C:\Windows"]
+    norm = os.path.normcase(os.path.normpath(path))
+    for root in roots:
+        root_norm = os.path.normcase(os.path.normpath(root))
+        if norm == root_norm or norm.startswith(root_norm + os.sep):
+            return True
+    return False
+
+
 def _build_safe_env(workdir: str) -> dict[str, str]:
     """Build a minimal, credential-free environment for sandboxed subprocesses.
 
@@ -2527,15 +2550,17 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
     else:
         path_entries.extend(["/usr/local/bin", "/usr/bin", "/bin"])
 
-    # Windows Git installs live outside System32; inherit only the dir of the
-    # git the HOST shell resolves (never a name-matched, possibly user-writable
-    # dir) so bare `git` resolves without weakening the sandbox PATH (#7317).
+    # Windows Git installs live outside System32; inherit the dir of the git
+    # the HOST shell resolves, but ONLY when it sits under a system install
+    # root (Program Files, windir). A user-writable dir (Scoop/Choco shims)
+    # is refused: it would let an attacker drop rg.exe/jq.exe beside git and
+    # have an auto-approved bare command execute it (#7317).
     git_ext = ""
     if sys.platform == "win32":
         git_exe = shutil.which("git")
         if git_exe:
             git_dir = os.path.dirname(git_exe)
-            if os.path.isabs(git_dir):
+            if os.path.isabs(git_dir) and _is_trusted_windows_program_dir(git_dir):
                 path_entries.append(git_dir)
                 # A .cmd/.bat git shim needs its extension in PATHEXT below.
                 git_ext = os.path.splitext(git_exe)[1].upper()

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2515,8 +2515,8 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
 
     Whitelist-built from scratch (parent env NOT inherited): only PATH/HOME/
     TMPDIR/LANG/TERM/PYTHONIOENCODING/PYTHONPATH (+VIRTUAL_ENV or Windows
-    SystemRoot/PATHEXT) reach the child; all credential vars (HF_TOKEN, AWS_*,
-    etc.) are absent. HOME points at the sandbox workdir so SDKs can't read the
+    SystemRoot and a minimal PATHEXT) reach the child; all credential vars
+    (HF_TOKEN, AWS_*, etc.) are absent. HOME points at the sandbox workdir so SDKs can't read the
     operator's cached creds. PYTHONPATH carries only the sandbox sitecustomize
     shim directory.
 
@@ -2573,11 +2573,8 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
     # Windows needs SystemRoot for Python/subprocess to work.
     if sys.platform == "win32":
         env["SystemRoot"] = os.environ.get("SystemRoot", r"C:\Windows")
-        # cmd.exe uses PATHEXT to map `git` -> `git.exe`. Inherit the host
-        # list when present so bare tool names resolve like a normal shell.
-        pathext = os.environ.get("PATHEXT")
-        if pathext:
-            env["PATHEXT"] = pathext
+        # Restrict PATHEXT so cwd .BAT/.CMD cannot hijack bare names (#7317).
+        env["PATHEXT"] = ".EXE;.COM"
     return env
 
 

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2519,9 +2519,7 @@ def _windows_program_roots() -> list[str]:
         _CoTaskMemFree = ctypes.windll.ole32.CoTaskMemFree
         for fid in folder_ids:
             guid = ctypes.create_string_buffer(16)
-            ctypes.windll.ole32.CLSIDFromString(
-                wintypes.LPCWSTR(fid), ctypes.byref(guid)
-            )
+            ctypes.windll.ole32.CLSIDFromString(wintypes.LPCWSTR(fid), ctypes.byref(guid))
             ptr = ctypes.c_wchar_p()
             if _SHGet(ctypes.byref(guid), 0, None, ctypes.byref(ptr)) == 0:
                 if ptr.value:

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2496,10 +2496,17 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
 
     Whitelist-built from scratch (parent env NOT inherited): only PATH/HOME/
     TMPDIR/LANG/TERM/PYTHONIOENCODING/PYTHONPATH (+VIRTUAL_ENV or Windows
-    SystemRoot) reach the child; all credential vars (HF_TOKEN, AWS_*, etc.)
-    are absent. HOME points at the sandbox workdir so SDKs can't read the
+    SystemRoot/PATHEXT) reach the child; all credential vars (HF_TOKEN, AWS_*,
+    etc.) are absent. HOME points at the sandbox workdir so SDKs can't read the
     operator's cached creds. PYTHONPATH carries only the sandbox sitecustomize
     shim directory.
+
+    PATH starts with the Studio interpreter / venv and OS system dirs so
+    ``python``/``pip`` stay pinned, then appends absolute directories from the
+    parent PATH so user-installed tools (e.g. Windows Git under
+    ``C:\\Program Files\\Git\\cmd``) resolve by bare name like a normal
+    terminal (#7317). Relative / ``.`` entries are skipped to avoid cwd PATH
+    hijacks.
     """
     # Start from the running interpreter's dir so 'python'/'pip' resolve to the
     # same environment the Unsloth server runs in.
@@ -2518,6 +2525,14 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
         path_entries.extend([os.path.join(sysroot, "System32"), sysroot])
     else:
         path_entries.extend(["/usr/local/bin", "/usr/bin", "/bin"])
+
+    # Append absolute host PATH dirs so bare tools like `git` resolve (#7317).
+    # Keep curated entries first; skip relative / "." to avoid cwd hijacks.
+    for entry in os.environ.get("PATH", "").split(os.pathsep):
+        entry = entry.strip().strip('"')
+        if not entry or entry in (".",) or not os.path.isabs(entry):
+            continue
+        path_entries.append(entry)
 
     # Deduplicate, preserving order.
     deduped = list(dict.fromkeys(p for p in path_entries if p))
@@ -2538,6 +2553,11 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
     # Windows needs SystemRoot for Python/subprocess to work.
     if sys.platform == "win32":
         env["SystemRoot"] = os.environ.get("SystemRoot", r"C:\Windows")
+        # cmd.exe uses PATHEXT to map `git` -> `git.exe`. Inherit the host
+        # list when present so bare tool names resolve like a normal shell.
+        pathext = os.environ.get("PATHEXT")
+        if pathext:
+            env["PATHEXT"] = pathext
     return env
 
 

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2538,7 +2538,46 @@ def _windows_program_roots() -> list[str]:
     if not roots:
         drive = os.environ.get("SystemDrive", "C:")
         roots = [drive + r"\Program Files", drive + r"\Program Files (x86)"]
+    # A 32-bit process on 64-bit Windows only sees the x86 root (the X64
+    # known-folder id is unsupported there), so derive the native sibling by
+    # stripping the " (x86)" suffix. Derived from a trusted root, not env.
+    for root in list(roots):
+        base = root.rstrip("\\/")
+        if base.lower().endswith(" (x86)"):
+            native = base[: -len(" (x86)")]
+            if native and native not in roots:
+                roots.append(native)
     return roots
+
+
+def _resolve_trusted_windows_git() -> tuple[str, str]:
+    """Find a git launcher in a TRUSTED Program Files dir. Returns
+    ``(canonical_dir, ext)`` or ``("", "")``.
+
+    ``shutil.which`` returns only the first PATH match, which may be an
+    untrusted user shim; scan the remaining PATH entries for a later trusted
+    Git so bare ``git`` still resolves (#7317).
+    """
+    exts = [
+        e for e in (os.environ.get("PATHEXT") or ".EXE;.CMD;.BAT;.COM").split(os.pathsep)
+    ]
+    candidates: list[str] = []
+    primary = shutil.which("git")
+    if primary:
+        candidates.append(primary)
+    for entry in (os.environ.get("PATH") or "").split(os.pathsep):
+        entry = entry.strip().strip('"')
+        if not entry or not os.path.isabs(entry):
+            continue
+        for ext in exts:
+            cand = os.path.join(entry, "git" + ext)
+            if os.path.isfile(cand):
+                candidates.append(cand)
+    for git_exe in candidates:
+        git_dir = os.path.dirname(git_exe)
+        if os.path.isabs(git_dir) and _is_trusted_windows_program_dir(git_dir):
+            return os.path.realpath(git_dir), os.path.splitext(git_exe)[1].upper()
+    return "", ""
 
 
 def _is_trusted_windows_program_dir(path: str) -> bool:
@@ -2600,16 +2639,12 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
     # have an auto-approved bare command execute it (#7317).
     git_ext = ""
     if sys.platform == "win32":
-        git_exe = shutil.which("git")
-        if git_exe:
-            git_dir = os.path.dirname(git_exe)
-            if os.path.isabs(git_dir) and _is_trusted_windows_program_dir(git_dir):
-                # Append the CANONICAL (realpath) dir used for the trust
-                # decision, not the raw entry: a junction that passed the check
-                # cannot then be retargeted to a writable dir before use.
-                path_entries.append(os.path.realpath(git_dir))
-                # A .cmd/.bat git shim needs its extension in PATHEXT below.
-                git_ext = os.path.splitext(git_exe)[1].upper()
+        # Append the CANONICAL (realpath) trusted git dir, scanning past any
+        # untrusted user shim that sorts first on PATH; the canonical path
+        # cannot be retargeted via a junction after the trust check.
+        _trusted_git_dir, git_ext = _resolve_trusted_windows_git()
+        if _trusted_git_dir:
+            path_entries.append(_trusted_git_dir)
 
     # Deduplicate, preserving order.
     deduped = list(dict.fromkeys(p for p in path_entries if p))

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -18,6 +18,7 @@ import queue
 import random
 import re
 import shlex
+import shutil
 import ssl
 import subprocess
 import sys
@@ -328,24 +329,6 @@ def _find_blocked_commands(command: str) -> set[str]:
 # Directory holding the sandbox ``sitecustomize.py`` shim (code-interpreter
 # path remap); placed on the sandboxed child's PYTHONPATH in _build_safe_env.
 _SANDBOX_SITE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sandbox_site")
-
-# Git for Windows installs live outside System32 (e.g. Program Files\Git\cmd).
-# Only those host PATH dirs are inherited on Windows so bare ``git`` resolves
-# without appending user-writable dirs (venv, node_modules/.bin) that could
-# shadow auto-safe terminal commands (#7317).
-_WINDOWS_GIT_PATH_RE = re.compile(
-    r"[\\/]git[\\/](?:cmd|bin|mingw64[\\/]bin)(?:[\\/]|$)",
-    re.IGNORECASE,
-)
-
-
-def _is_windows_git_path_entry(entry: str) -> bool:
-    """True when ``entry`` looks like a Git-for-Windows install directory."""
-    if sys.platform != "win32":
-        return False
-    norm = os.path.normcase(os.path.normpath(entry.strip().strip('"')))
-    return bool(_WINDOWS_GIT_PATH_RE.search(norm))
-
 
 # ── "Approve for me" (permission_mode="auto") safety detection ──────────────
 # Auto mode pauses only calls classified here as potentially unsafe. The sandbox
@@ -2544,15 +2527,15 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
     else:
         path_entries.extend(["/usr/local/bin", "/usr/bin", "/bin"])
 
-    # Windows Git installs live outside System32; inherit only those host PATH
-    # dirs so bare `git` resolves without pulling in user-writable PATH (#7317).
+    # Windows Git installs live outside System32; inherit only the dir of the
+    # git the HOST shell resolves (never a name-matched, possibly user-writable
+    # dir) so bare `git` resolves without weakening the sandbox PATH (#7317).
     if sys.platform == "win32":
-        for entry in os.environ.get("PATH", "").split(os.pathsep):
-            entry = entry.strip().strip('"')
-            if not entry or entry in (".",) or not os.path.isabs(entry):
-                continue
-            if _is_windows_git_path_entry(entry):
-                path_entries.append(entry)
+        git_exe = shutil.which("git")
+        if git_exe:
+            git_dir = os.path.dirname(git_exe)
+            if os.path.isabs(git_dir):
+                path_entries.append(git_dir)
 
     # Deduplicate, preserving order.
     deduped = list(dict.fromkeys(p for p in path_entries if p))
@@ -2575,6 +2558,9 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
         env["SystemRoot"] = os.environ.get("SystemRoot", r"C:\Windows")
         # Restrict PATHEXT so cwd .BAT/.CMD cannot hijack bare names (#7317).
         env["PATHEXT"] = ".EXE;.COM"
+        # cmd/CreateProcess search cwd before PATH for bare names; disable so
+        # a workdir rg.exe/git.exe cannot shadow auto-approved commands.
+        env["NoDefaultCurrentDirectoryInExePath"] = "1"
     return env
 
 

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2493,30 +2493,66 @@ def is_potentially_unsafe_tool_call(name: str, arguments: dict) -> bool:
     return True
 
 
-def _is_trusted_windows_program_dir(path: str) -> bool:
-    """True when ``path`` sits under a system-managed install root.
+def _canon_win_path(p: str) -> str:
+    """Canonical form for trust comparison: realpath (expands 8.3 aliases and
+    resolves junctions/symlinks) + normcase/normpath."""
+    return os.path.normcase(os.path.normpath(os.path.realpath(p)))
 
-    Only the Program Files roots are trusted (admin-writable only), never
-    ``%SystemRoot%``: Git does not install there and it holds world-writable
-    subdirs like ``Windows\\Temp``. Per-user managers (Scoop/Choco shims
-    under the profile) are refused. Paths are canonicalized so an 8.3 short
-    alias (``C:\\PROGRA~1``) still matches its long root (#7317).
+
+def _windows_program_roots() -> list[str]:
+    """Program Files install roots, resolved from the Windows known-folder API
+    (SHGetKnownFolderPath) so an overridden ``%ProgramFiles%`` env value cannot
+    move the trust boundary. Falls back to the env vars, then to fixed
+    ``%SystemDrive%`` paths, only if the API is unavailable (#7317).
     """
+    roots: list[str] = []
+    try:
+        import ctypes
+        from ctypes import wintypes
 
-    def _canon(p: str) -> str:
-        # realpath expands 8.3 short names on Windows; harmless elsewhere.
-        return os.path.normcase(os.path.normpath(os.path.realpath(p)))
-
-    roots = []
-    for var in ("ProgramFiles", "ProgramFiles(x86)", "ProgramW6432"):
-        val = os.environ.get(var)
-        if val:
-            roots.append(val)
+        # FOLDERID_ProgramFiles, FOLDERID_ProgramFilesX86.
+        folder_ids = (
+            "{905e63b6-c1bf-494e-b29c-65b732d3d21a}",
+            "{7C5A40EF-A0FB-4BFC-874A-C0F2E0B9FA8E}",
+        )
+        _SHGet = ctypes.windll.shell32.SHGetKnownFolderPath
+        _CoTaskMemFree = ctypes.windll.ole32.CoTaskMemFree
+        for fid in folder_ids:
+            guid = ctypes.create_string_buffer(16)
+            ctypes.windll.ole32.CLSIDFromString(
+                wintypes.LPCWSTR(fid), ctypes.byref(guid)
+            )
+            ptr = ctypes.c_wchar_p()
+            if _SHGet(ctypes.byref(guid), 0, None, ctypes.byref(ptr)) == 0:
+                if ptr.value:
+                    roots.append(ptr.value)
+                _CoTaskMemFree(ptr)
+    except Exception:
+        roots = []
     if not roots:
-        roots = [r"C:\Program Files", r"C:\Program Files (x86)"]
-    norm = _canon(path)
-    for root in roots:
-        root_norm = _canon(root)
+        for var in ("ProgramFiles", "ProgramFiles(x86)", "ProgramW6432"):
+            val = os.environ.get(var)
+            if val:
+                roots.append(val)
+    if not roots:
+        drive = os.environ.get("SystemDrive", "C:")
+        roots = [drive + r"\Program Files", drive + r"\Program Files (x86)"]
+    return roots
+
+
+def _is_trusted_windows_program_dir(path: str) -> bool:
+    """True when ``path`` sits under a system-managed Program Files root.
+
+    Only the Program Files roots are trusted (admin-writable only), resolved
+    via the known-folder API so an overridden env var cannot relocate them,
+    never ``%SystemRoot%`` (Git does not install there and it holds
+    world-writable subdirs like ``Windows\\Temp``). Per-user managers
+    (Scoop/Choco shims under the profile) are refused. Paths are canonicalized
+    so 8.3 aliases and junctions still resolve to their real root (#7317).
+    """
+    norm = _canon_win_path(path)
+    for root in _windows_program_roots():
+        root_norm = _canon_win_path(root)
         if norm == root_norm or norm.startswith(root_norm + os.sep):
             return True
     return False
@@ -2567,7 +2603,10 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
         if git_exe:
             git_dir = os.path.dirname(git_exe)
             if os.path.isabs(git_dir) and _is_trusted_windows_program_dir(git_dir):
-                path_entries.append(git_dir)
+                # Append the CANONICAL (realpath) dir used for the trust
+                # decision, not the raw entry: a junction that passed the check
+                # cannot then be retargeted to a writable dir before use.
+                path_entries.append(os.path.realpath(git_dir))
                 # A .cmd/.bat git shim needs its extension in PATHEXT below.
                 git_ext = os.path.splitext(git_exe)[1].upper()
 

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2510,10 +2510,13 @@ def _windows_program_roots() -> list[str]:
         import ctypes
         from ctypes import wintypes
 
-        # FOLDERID_ProgramFiles, FOLDERID_ProgramFilesX86.
+        # FOLDERID_ProgramFiles, _ProgramFilesX86, _ProgramFilesX64. The X64
+        # id (Win10 1703+) yields the native root even from a 32-bit process,
+        # where the first two both map to Program Files (x86).
         folder_ids = (
             "{905e63b6-c1bf-494e-b29c-65b732d3d21a}",
             "{7C5A40EF-A0FB-4BFC-874A-C0F2E0B9FA8E}",
+            "{6D809377-6AF0-444b-8957-A3773F02200E}",
         )
         _SHGet = ctypes.windll.shell32.SHGetKnownFolderPath
         _CoTaskMemFree = ctypes.windll.ole32.CoTaskMemFree

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2496,21 +2496,27 @@ def is_potentially_unsafe_tool_call(name: str, arguments: dict) -> bool:
 def _is_trusted_windows_program_dir(path: str) -> bool:
     """True when ``path`` sits under a system-managed install root.
 
-    Program Files (+ x86 / W6432) and ``%SystemRoot%`` are admin-writable
-    only, so a bare auto-approved command resolving from a Git dir there
-    cannot be replaced by an unprivileged attacker. Per-user managers
-    (Scoop/Choco shims under the profile) are refused (#7317).
+    Only the Program Files roots are trusted (admin-writable only), never
+    ``%SystemRoot%``: Git does not install there and it holds world-writable
+    subdirs like ``Windows\\Temp``. Per-user managers (Scoop/Choco shims
+    under the profile) are refused. Paths are canonicalized so an 8.3 short
+    alias (``C:\\PROGRA~1``) still matches its long root (#7317).
     """
+
+    def _canon(p: str) -> str:
+        # realpath expands 8.3 short names on Windows; harmless elsewhere.
+        return os.path.normcase(os.path.normpath(os.path.realpath(p)))
+
     roots = []
-    for var in ("ProgramFiles", "ProgramFiles(x86)", "ProgramW6432", "SystemRoot"):
+    for var in ("ProgramFiles", "ProgramFiles(x86)", "ProgramW6432"):
         val = os.environ.get(var)
         if val:
             roots.append(val)
     if not roots:
-        roots = [r"C:\Program Files", r"C:\Program Files (x86)", r"C:\Windows"]
-    norm = os.path.normcase(os.path.normpath(path))
+        roots = [r"C:\Program Files", r"C:\Program Files (x86)"]
+    norm = _canon(path)
     for root in roots:
-        root_norm = os.path.normcase(os.path.normpath(root))
+        root_norm = _canon(root)
         if norm == root_norm or norm.startswith(root_norm + os.sep):
             return True
     return False

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2558,9 +2558,7 @@ def _resolve_trusted_windows_git() -> tuple[str, str]:
     untrusted user shim; scan the remaining PATH entries for a later trusted
     Git so bare ``git`` still resolves (#7317).
     """
-    exts = [
-        e for e in (os.environ.get("PATHEXT") or ".EXE;.CMD;.BAT;.COM").split(os.pathsep)
-    ]
+    exts = [e for e in (os.environ.get("PATHEXT") or ".EXE;.CMD;.BAT;.COM").split(os.pathsep)]
     candidates: list[str] = []
     primary = shutil.which("git")
     if primary:

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -2531,11 +2531,9 @@ def _windows_program_roots() -> list[str]:
     except Exception:
         roots = []
     if not roots:
-        for var in ("ProgramFiles", "ProgramFiles(x86)", "ProgramW6432"):
-            val = os.environ.get(var)
-            if val:
-                roots.append(val)
-    if not roots:
+        # Do NOT fall back to %ProgramFiles%/%ProgramW6432%: a caller can
+        # override those to a writable dir and relocate the trust boundary.
+        # SystemDrive is not a viable override (retargeting it breaks the OS).
         drive = os.environ.get("SystemDrive", "C:")
         roots = [drive + r"\Program Files", drive + r"\Program Files (x86)"]
     # A 32-bit process on 64-bit Windows only sees the x86 root (the X64

--- a/studio/backend/core/inference/tools.py
+++ b/studio/backend/core/inference/tools.py
@@ -328,6 +328,25 @@ def _find_blocked_commands(command: str) -> set[str]:
 # Directory holding the sandbox ``sitecustomize.py`` shim (code-interpreter
 # path remap); placed on the sandboxed child's PYTHONPATH in _build_safe_env.
 _SANDBOX_SITE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sandbox_site")
+
+# Git for Windows installs live outside System32 (e.g. Program Files\Git\cmd).
+# Only those host PATH dirs are inherited on Windows so bare ``git`` resolves
+# without appending user-writable dirs (venv, node_modules/.bin) that could
+# shadow auto-safe terminal commands (#7317).
+_WINDOWS_GIT_PATH_RE = re.compile(
+    r"[\\/]git[\\/](?:cmd|bin|mingw64[\\/]bin)(?:[\\/]|$)",
+    re.IGNORECASE,
+)
+
+
+def _is_windows_git_path_entry(entry: str) -> bool:
+    """True when ``entry`` looks like a Git-for-Windows install directory."""
+    if sys.platform != "win32":
+        return False
+    norm = os.path.normcase(os.path.normpath(entry.strip().strip('"')))
+    return bool(_WINDOWS_GIT_PATH_RE.search(norm))
+
+
 # ── "Approve for me" (permission_mode="auto") safety detection ──────────────
 # Auto mode pauses only calls classified here as potentially unsafe. The sandbox
 # and hard blocks (blocklist, rlimits) still apply at run time; this gate only
@@ -2502,11 +2521,10 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
     shim directory.
 
     PATH starts with the Studio interpreter / venv and OS system dirs so
-    ``python``/``pip`` stay pinned, then appends absolute directories from the
-    parent PATH so user-installed tools (e.g. Windows Git under
-    ``C:\\Program Files\\Git\\cmd``) resolve by bare name like a normal
-    terminal (#7317). Relative / ``.`` entries are skipped to avoid cwd PATH
-    hijacks.
+    ``python``/``pip`` stay pinned. On Windows only, Git-for-Windows install
+    dirs from the host PATH are appended so bare ``git`` resolves (#7317).
+    User-writable host PATH entries (venv, ``node_modules/.bin``, etc.) are
+    never inherited — they could shadow auto-safe terminal commands.
     """
     # Start from the running interpreter's dir so 'python'/'pip' resolve to the
     # same environment the Unsloth server runs in.
@@ -2526,13 +2544,15 @@ def _build_safe_env(workdir: str) -> dict[str, str]:
     else:
         path_entries.extend(["/usr/local/bin", "/usr/bin", "/bin"])
 
-    # Append absolute host PATH dirs so bare tools like `git` resolve (#7317).
-    # Keep curated entries first; skip relative / "." to avoid cwd hijacks.
-    for entry in os.environ.get("PATH", "").split(os.pathsep):
-        entry = entry.strip().strip('"')
-        if not entry or entry in (".",) or not os.path.isabs(entry):
-            continue
-        path_entries.append(entry)
+    # Windows Git installs live outside System32; inherit only those host PATH
+    # dirs so bare `git` resolves without pulling in user-writable PATH (#7317).
+    if sys.platform == "win32":
+        for entry in os.environ.get("PATH", "").split(os.pathsep):
+            entry = entry.strip().strip('"')
+            if not entry or entry in (".",) or not os.path.isabs(entry):
+                continue
+            if _is_windows_git_path_entry(entry):
+                path_entries.append(entry)
 
     # Deduplicate, preserving order.
     deduped = list(dict.fromkeys(p for p in path_entries if p))

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -308,16 +308,27 @@ class TestSandboxEnvIsolation:
 
     def test_host_path_absolute_dirs_appended_after_curated(self, monkeypatch, tmp_path):
         # #7317: Windows Git lives under Program Files, not System32. Sandbox PATH
-        # must still resolve bare `git` by appending absolute host PATH dirs after
-        # the curated interpreter / system prefix.
+        # must still resolve bare `git` by appending Git install dirs from the
+        # host PATH after the curated interpreter / system prefix.
         from core.inference.tools import _build_safe_env
 
+        monkeypatch.setattr(sys, "platform", "win32")
         git_dir = tmp_path / "Git" / "cmd"
         git_dir.mkdir(parents = True)
         junk_rel = "relative-bin"
+        user_bin = tmp_path / "user-bin"
+        user_bin.mkdir()
         monkeypatch.setenv(
             "PATH",
-            os.pathsep.join([str(git_dir), ".", junk_rel, os.environ.get("PATH", "")]),
+            os.pathsep.join(
+                [
+                    str(git_dir),
+                    ".",
+                    junk_rel,
+                    str(user_bin),
+                    os.environ.get("PATH", ""),
+                ]
+            ),
         )
         env = _build_safe_env(str(tmp_path))
         parts = env["PATH"].split(os.pathsep)
@@ -326,18 +337,39 @@ class TestSandboxEnvIsolation:
         assert parts.index(str(git_dir)) > 0
         assert "." not in parts
         assert junk_rel not in parts
+        # User-writable dirs must not be inherited (PATH hijack / auto-safe shadow).
+        assert str(user_bin) not in parts
 
     def test_host_path_quoted_windows_style_entries_stripped(self, monkeypatch, tmp_path):
         from core.inference.tools import _build_safe_env
 
-        quoted = tmp_path / "Quoted Tools"
-        quoted.mkdir()
+        monkeypatch.setattr(sys, "platform", "win32")
+        quoted = tmp_path / "Program Files" / "Git" / "cmd"
+        quoted.mkdir(parents = True)
         # Windows PATH entries are sometimes quoted when they contain spaces.
         monkeypatch.setenv("PATH", f'"{quoted}"{os.pathsep}{os.environ.get("PATH", "")}')
         env = _build_safe_env(str(tmp_path))
         parts = env["PATH"].split(os.pathsep)
         assert str(quoted) in parts
         assert f'"{quoted}"' not in parts
+
+    def test_user_writable_host_path_not_inherited(self, monkeypatch, tmp_path):
+        """venv/node_modules-style dirs must not shadow auto-safe terminal cmds."""
+        from core.inference.tools import _build_safe_env
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        venv_scripts = tmp_path / "venv" / "Scripts"
+        venv_scripts.mkdir(parents = True)
+        node_bin = tmp_path / "project" / "node_modules" / ".bin"
+        node_bin.mkdir(parents = True)
+        monkeypatch.setenv(
+            "PATH",
+            os.pathsep.join([str(venv_scripts), str(node_bin), os.environ.get("PATH", "")]),
+        )
+        env = _build_safe_env(str(tmp_path))
+        parts = env["PATH"].split(os.pathsep)
+        assert str(venv_scripts) not in parts
+        assert str(node_bin) not in parts
 
     def test_home_points_at_sandbox_workdir(self, tmp_path):
         from core.inference.tools import _build_safe_env

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -315,7 +315,9 @@ class TestSandboxEnvIsolation:
         from core.inference.tools import _build_safe_env
 
         monkeypatch.setattr(sys, "platform", "win32")
-        git_dir = tmp_path / "Program Files" / "Git" / "cmd"
+        prog = tmp_path / "Program Files"
+        monkeypatch.setenv("ProgramFiles", str(prog))
+        git_dir = prog / "Git" / "cmd"
         git_dir.mkdir(parents = True)
         monkeypatch.setattr(tools_mod.shutil, "which", lambda name: str(git_dir / "git.exe"))
         env = _build_safe_env(str(tmp_path))
@@ -347,20 +349,44 @@ class TestSandboxEnvIsolation:
         assert str(fake_git) not in parts
 
     def test_git_cmd_shim_extension_added_to_pathext(self, monkeypatch, tmp_path):
-        """A host git resolved as a .cmd shim stays resolvable under the
-        restricted PATHEXT (cwd lookup is disabled separately)."""
+        """A host git resolved as a .cmd shim under a trusted root stays
+        resolvable under the restricted PATHEXT (cwd lookup disabled)."""
         import core.inference.tools as tools_mod
         from core.inference.tools import _build_safe_env
 
         monkeypatch.setattr(sys, "platform", "win32")
-        shim_dir = tmp_path / "scoop" / "shims"
-        shim_dir.mkdir(parents = True)
-        monkeypatch.setattr(tools_mod.shutil, "which", lambda name: str(shim_dir / "git.cmd"))
+        prog = tmp_path / "Program Files"
+        monkeypatch.setenv("ProgramFiles", str(prog))
+        git_dir = prog / "Git" / "cmd"
+        git_dir.mkdir(parents = True)
+        monkeypatch.setattr(
+            tools_mod.shutil, "which", lambda name: str(git_dir / "git.cmd")
+        )
         env = _build_safe_env(str(tmp_path))
-        assert str(shim_dir) in env["PATH"].split(os.pathsep)
+        assert str(git_dir) in env["PATH"].split(os.pathsep)
         assert env["PATHEXT"] == ".EXE;.COM;.CMD"
 
-    def test_no_default_current_directory_in_exe_path_set_on_windows(self, monkeypatch, tmp_path):
+    def test_user_writable_git_dir_refused(self, monkeypatch, tmp_path):
+        """Git resolved from a per-user manager (Scoop shims) is NOT trusted:
+        an attacker could drop rg.exe beside it and hit the auto-approve gate."""
+        import core.inference.tools as tools_mod
+        from core.inference.tools import _build_safe_env
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setenv("ProgramFiles", str(tmp_path / "Program Files"))
+        shim_dir = tmp_path / "users" / "alice" / "scoop" / "shims"
+        shim_dir.mkdir(parents = True)
+        monkeypatch.setattr(
+            tools_mod.shutil, "which", lambda name: str(shim_dir / "git.exe")
+        )
+        env = _build_safe_env(str(tmp_path))
+        assert str(shim_dir) not in env["PATH"].split(os.pathsep)
+        # No trusted git launcher -> PATHEXT stays minimal.
+        assert env["PATHEXT"] == ".EXE;.COM"
+
+    def test_no_default_current_directory_in_exe_path_set_on_windows(
+        self, monkeypatch, tmp_path
+    ):
         """cmd/CreateProcess must not search cwd for bare names in the sandbox."""
         import core.inference.tools as tools_mod
         from core.inference.tools import _build_safe_env

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -391,9 +391,7 @@ class TestSandboxEnvIsolation:
         monkeypatch.setenv("SystemRoot", str(tmp_path / "Windows"))
         temp_git = tmp_path / "Windows" / "Temp" / "Git" / "cmd"
         temp_git.mkdir(parents = True)
-        monkeypatch.setattr(
-            tools_mod.shutil, "which", lambda name: str(temp_git / "git.exe")
-        )
+        monkeypatch.setattr(tools_mod.shutil, "which", lambda name: str(temp_git / "git.exe"))
         env = _build_safe_env(str(tmp_path))
         assert str(temp_git) not in env["PATH"].split(os.pathsep)
 
@@ -413,16 +411,12 @@ class TestSandboxEnvIsolation:
             pytest.skip("symlink unsupported in this environment")
         monkeypatch.setenv("ProgramFiles", str(real_prog))
         git_via_alias = alias / "Git" / "cmd" / "git.exe"
-        monkeypatch.setattr(
-            tools_mod.shutil, "which", lambda name: str(git_via_alias)
-        )
+        monkeypatch.setattr(tools_mod.shutil, "which", lambda name: str(git_via_alias))
         env = _build_safe_env(str(tmp_path))
         parts = [os.path.normcase(os.path.realpath(p)) for p in env["PATH"].split(os.pathsep)]
         assert os.path.normcase(str(real_prog / "Git" / "cmd")) in parts
 
-    def test_no_default_current_directory_in_exe_path_set_on_windows(
-        self, monkeypatch, tmp_path
-    ):
+    def test_no_default_current_directory_in_exe_path_set_on_windows(self, monkeypatch, tmp_path):
         """cmd/CreateProcess must not search cwd for bare names in the sandbox."""
         import core.inference.tools as tools_mod
         from core.inference.tools import _build_safe_env

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -297,7 +297,7 @@ class TestSandboxEnvIsolation:
             "PYTHONPATH",
             "VIRTUAL_ENV",
             "SystemRoot",
-            "PATHEXT",  # Windows only; inherited so bare names like git resolve
+            "PATHEXT",  # Windows only; minimal list so cwd scripts cannot hijack
         }
         extras = set(env.keys()) - allowed
         assert not extras, f"sandbox env added unexpected keys: {extras}"

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -316,7 +316,7 @@ class TestSandboxEnvIsolation:
 
         monkeypatch.setattr(sys, "platform", "win32")
         prog = tmp_path / "Program Files"
-        monkeypatch.setenv("ProgramFiles", str(prog))
+        monkeypatch.setattr(tools_mod, "_windows_program_roots", lambda: [str(prog)])
         git_dir = prog / "Git" / "cmd"
         git_dir.mkdir(parents = True)
         monkeypatch.setattr(tools_mod.shutil, "which", lambda name: str(git_dir / "git.exe"))
@@ -356,7 +356,7 @@ class TestSandboxEnvIsolation:
 
         monkeypatch.setattr(sys, "platform", "win32")
         prog = tmp_path / "Program Files"
-        monkeypatch.setenv("ProgramFiles", str(prog))
+        monkeypatch.setattr(tools_mod, "_windows_program_roots", lambda: [str(prog)])
         git_dir = prog / "Git" / "cmd"
         git_dir.mkdir(parents = True)
         monkeypatch.setattr(tools_mod.shutil, "which", lambda name: str(git_dir / "git.cmd"))
@@ -371,7 +371,9 @@ class TestSandboxEnvIsolation:
         from core.inference.tools import _build_safe_env
 
         monkeypatch.setattr(sys, "platform", "win32")
-        monkeypatch.setenv("ProgramFiles", str(tmp_path / "Program Files"))
+        monkeypatch.setattr(
+            tools_mod, "_windows_program_roots", lambda: [str(tmp_path / "Program Files")]
+        )
         shim_dir = tmp_path / "users" / "alice" / "scoop" / "shims"
         shim_dir.mkdir(parents = True)
         monkeypatch.setattr(tools_mod.shutil, "which", lambda name: str(shim_dir / "git.exe"))
@@ -432,8 +434,9 @@ class TestSandboxEnvIsolation:
         from core.inference.tools import _build_safe_env
 
         monkeypatch.setattr(sys, "platform", "win32")
-        monkeypatch.setenv("ProgramFiles", str(tmp_path / "Program Files"))
-        monkeypatch.setenv("SystemRoot", str(tmp_path / "Windows"))
+        monkeypatch.setattr(
+            tools_mod, "_windows_program_roots", lambda: [str(tmp_path / "Program Files")]
+        )
         temp_git = tmp_path / "Windows" / "Temp" / "Git" / "cmd"
         temp_git.mkdir(parents = True)
         monkeypatch.setattr(tools_mod.shutil, "which", lambda name: str(temp_git / "git.exe"))
@@ -454,12 +457,27 @@ class TestSandboxEnvIsolation:
             alias.symlink_to(real_prog, target_is_directory = True)
         except (OSError, NotImplementedError):
             pytest.skip("symlink unsupported in this environment")
-        monkeypatch.setenv("ProgramFiles", str(real_prog))
+        monkeypatch.setattr(
+            tools_mod, "_windows_program_roots", lambda: [str(real_prog)]
+        )
         git_via_alias = alias / "Git" / "cmd" / "git.exe"
         monkeypatch.setattr(tools_mod.shutil, "which", lambda name: str(git_via_alias))
         env = _build_safe_env(str(tmp_path))
         parts = [os.path.normcase(os.path.realpath(p)) for p in env["PATH"].split(os.pathsep)]
         assert os.path.normcase(str(real_prog / "Git" / "cmd")) in parts
+
+    def test_program_roots_include_native_root(self, monkeypatch):
+        """FOLDERID_ProgramFilesX64 is queried so a 32-bit process still trusts
+        the native C:\\Program Files (both other ids map to x86 there)."""
+        import core.inference.tools as tools_mod
+
+        # Simulate the known-folder API being unavailable so we exercise the
+        # documented env fallback, which must include ProgramW6432 semantics.
+        monkeypatch.setenv("ProgramW6432", r"C:\Program Files")
+        monkeypatch.setenv("ProgramFiles(x86)", r"C:\Program Files (x86)")
+        roots = tools_mod._windows_program_roots()
+        # On this Linux host the ctypes call fails, so env fallback applies.
+        assert any(r.lower().endswith("program files") for r in roots)
 
     def test_no_default_current_directory_in_exe_path_set_on_windows(self, monkeypatch, tmp_path):
         """cmd/CreateProcess must not search cwd for bare names in the sandbox."""

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -457,9 +457,7 @@ class TestSandboxEnvIsolation:
             alias.symlink_to(real_prog, target_is_directory = True)
         except (OSError, NotImplementedError):
             pytest.skip("symlink unsupported in this environment")
-        monkeypatch.setattr(
-            tools_mod, "_windows_program_roots", lambda: [str(real_prog)]
-        )
+        monkeypatch.setattr(tools_mod, "_windows_program_roots", lambda: [str(real_prog)])
         git_via_alias = alias / "Git" / "cmd" / "git.exe"
         monkeypatch.setattr(tools_mod.shutil, "which", lambda name: str(git_via_alias))
         env = _build_safe_env(str(tmp_path))

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -317,9 +317,7 @@ class TestSandboxEnvIsolation:
         junk_rel = "relative-bin"
         monkeypatch.setenv(
             "PATH",
-            os.pathsep.join(
-                [str(git_dir), ".", junk_rel, os.environ.get("PATH", "")]
-            ),
+            os.pathsep.join([str(git_dir), ".", junk_rel, os.environ.get("PATH", "")]),
         )
         env = _build_safe_env(str(tmp_path))
         parts = env["PATH"].split(os.pathsep)

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -298,6 +298,7 @@ class TestSandboxEnvIsolation:
             "VIRTUAL_ENV",
             "SystemRoot",
             "PATHEXT",  # Windows only; minimal list so cwd scripts cannot hijack
+            "NoDefaultCurrentDirectoryInExePath",  # Windows only; no cwd-first lookup
         }
         extras = set(env.keys()) - allowed
         assert not extras, f"sandbox env added unexpected keys: {extras}"
@@ -306,70 +307,58 @@ class TestSandboxEnvIsolation:
         assert env["PYTHONPATH"].endswith("sandbox_site")
         assert "leak-me" not in env["PYTHONPATH"]
 
-    def test_host_path_absolute_dirs_appended_after_curated(self, monkeypatch, tmp_path):
-        # #7317: Windows Git lives under Program Files, not System32. Sandbox PATH
-        # must still resolve bare `git` by appending Git install dirs from the
-        # host PATH after the curated interpreter / system prefix.
+    def test_host_git_dir_appended_after_curated(self, monkeypatch, tmp_path):
+        # #7317: Windows Git lives under Program Files, not System32. Sandbox
+        # PATH resolves bare `git` by appending the dir of the git the HOST
+        # shell resolves (shutil.which), after the curated prefix.
+        import core.inference.tools as tools_mod
         from core.inference.tools import _build_safe_env
 
         monkeypatch.setattr(sys, "platform", "win32")
-        git_dir = tmp_path / "Git" / "cmd"
+        git_dir = tmp_path / "Program Files" / "Git" / "cmd"
         git_dir.mkdir(parents = True)
-        junk_rel = "relative-bin"
-        user_bin = tmp_path / "user-bin"
-        user_bin.mkdir()
-        monkeypatch.setenv(
-            "PATH",
-            os.pathsep.join(
-                [
-                    str(git_dir),
-                    ".",
-                    junk_rel,
-                    str(user_bin),
-                    os.environ.get("PATH", ""),
-                ]
-            ),
+        monkeypatch.setattr(
+            tools_mod.shutil, "which", lambda name: str(git_dir / "git.exe")
         )
         env = _build_safe_env(str(tmp_path))
         parts = env["PATH"].split(os.pathsep)
         assert str(git_dir) in parts
         # Curated prefix stays ahead of host Git so Studio python/pip win.
         assert parts.index(str(git_dir)) > 0
-        assert "." not in parts
-        assert junk_rel not in parts
-        # User-writable dirs must not be inherited (PATH hijack / auto-safe shadow).
-        assert str(user_bin) not in parts
 
-    def test_host_path_quoted_windows_style_entries_stripped(self, monkeypatch, tmp_path):
-        from core.inference.tools import _build_safe_env
-
-        monkeypatch.setattr(sys, "platform", "win32")
-        quoted = tmp_path / "Program Files" / "Git" / "cmd"
-        quoted.mkdir(parents = True)
-        # Windows PATH entries are sometimes quoted when they contain spaces.
-        monkeypatch.setenv("PATH", f'"{quoted}"{os.pathsep}{os.environ.get("PATH", "")}')
-        env = _build_safe_env(str(tmp_path))
-        parts = env["PATH"].split(os.pathsep)
-        assert str(quoted) in parts
-        assert f'"{quoted}"' not in parts
-
-    def test_user_writable_host_path_not_inherited(self, monkeypatch, tmp_path):
-        """venv/node_modules-style dirs must not shadow auto-safe terminal cmds."""
+    def test_host_path_dirs_not_inherited(self, monkeypatch, tmp_path):
+        """Host PATH dirs (user-writable, git-lookalike) are never inherited;
+        only the resolved git dir is. No git resolved -> nothing appended."""
+        import core.inference.tools as tools_mod
         from core.inference.tools import _build_safe_env
 
         monkeypatch.setattr(sys, "platform", "win32")
         venv_scripts = tmp_path / "venv" / "Scripts"
         venv_scripts.mkdir(parents = True)
-        node_bin = tmp_path / "project" / "node_modules" / ".bin"
-        node_bin.mkdir(parents = True)
+        fake_git = tmp_path / "scratch" / "Git" / "cmd"
+        fake_git.mkdir(parents = True)
         monkeypatch.setenv(
             "PATH",
-            os.pathsep.join([str(venv_scripts), str(node_bin), os.environ.get("PATH", "")]),
+            os.pathsep.join([str(venv_scripts), str(fake_git), os.environ.get("PATH", "")]),
         )
+        monkeypatch.setattr(tools_mod.shutil, "which", lambda name: None)
         env = _build_safe_env(str(tmp_path))
         parts = env["PATH"].split(os.pathsep)
         assert str(venv_scripts) not in parts
-        assert str(node_bin) not in parts
+        # A git-suffixed but unresolved (user-writable) dir is NOT trusted.
+        assert str(fake_git) not in parts
+
+    def test_no_default_current_directory_in_exe_path_set_on_windows(
+        self, monkeypatch, tmp_path
+    ):
+        """cmd/CreateProcess must not search cwd for bare names in the sandbox."""
+        import core.inference.tools as tools_mod
+        from core.inference.tools import _build_safe_env
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(tools_mod.shutil, "which", lambda name: None)
+        env = _build_safe_env(str(tmp_path))
+        assert env["NoDefaultCurrentDirectoryInExePath"] == "1"
 
     def test_home_points_at_sandbox_workdir(self, tmp_path):
         from core.inference.tools import _build_safe_env

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -380,7 +380,49 @@ class TestSandboxEnvIsolation:
         # No trusted git launcher -> PATHEXT stays minimal.
         assert env["PATHEXT"] == ".EXE;.COM"
 
-    def test_no_default_current_directory_in_exe_path_set_on_windows(self, monkeypatch, tmp_path):
+    def test_windows_temp_git_dir_refused(self, monkeypatch, tmp_path):
+        """A git under a world-writable %SystemRoot% subdir (Windows\\Temp) is
+        NOT trusted, even though it sits under the Windows root."""
+        import core.inference.tools as tools_mod
+        from core.inference.tools import _build_safe_env
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setenv("ProgramFiles", str(tmp_path / "Program Files"))
+        monkeypatch.setenv("SystemRoot", str(tmp_path / "Windows"))
+        temp_git = tmp_path / "Windows" / "Temp" / "Git" / "cmd"
+        temp_git.mkdir(parents = True)
+        monkeypatch.setattr(
+            tools_mod.shutil, "which", lambda name: str(temp_git / "git.exe")
+        )
+        env = _build_safe_env(str(tmp_path))
+        assert str(temp_git) not in env["PATH"].split(os.pathsep)
+
+    def test_trusted_program_dir_matches_via_realpath(self, monkeypatch, tmp_path):
+        """The trust check canonicalizes paths, so a symlinked/short alias of
+        Program Files still matches (stand-in for 8.3 PROGRA~1 on Windows)."""
+        import core.inference.tools as tools_mod
+        from core.inference.tools import _build_safe_env
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        real_prog = tmp_path / "Program Files"
+        (real_prog / "Git" / "cmd").mkdir(parents = True)
+        alias = tmp_path / "PROGRA~1"
+        try:
+            alias.symlink_to(real_prog, target_is_directory = True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink unsupported in this environment")
+        monkeypatch.setenv("ProgramFiles", str(real_prog))
+        git_via_alias = alias / "Git" / "cmd" / "git.exe"
+        monkeypatch.setattr(
+            tools_mod.shutil, "which", lambda name: str(git_via_alias)
+        )
+        env = _build_safe_env(str(tmp_path))
+        parts = [os.path.normcase(os.path.realpath(p)) for p in env["PATH"].split(os.pathsep)]
+        assert os.path.normcase(str(real_prog / "Git" / "cmd")) in parts
+
+    def test_no_default_current_directory_in_exe_path_set_on_windows(
+        self, monkeypatch, tmp_path
+    ):
         """cmd/CreateProcess must not search cwd for bare names in the sandbox."""
         import core.inference.tools as tools_mod
         from core.inference.tools import _build_safe_env

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -481,9 +481,7 @@ class TestSandboxEnvIsolation:
         monkeypatch.setattr(tools_mod, "_windows_program_roots", lambda: [str(prog)])
         # shutil.which returns the untrusted shim first.
         monkeypatch.setattr(tools_mod.shutil, "which", lambda name: str(shim / "git.EXE"))
-        monkeypatch.setenv(
-            "PATH", os.pathsep.join([str(shim), str(trusted_git)])
-        )
+        monkeypatch.setenv("PATH", os.pathsep.join([str(shim), str(trusted_git)]))
         monkeypatch.setenv("PATHEXT", ".EXE")
         env = _build_safe_env(str(tmp_path))
         parts = env["PATH"].split(os.pathsep)

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -392,9 +392,7 @@ class TestSandboxEnvIsolation:
         evil = tmp_path / "attacker"
         (evil / "Git" / "cmd").mkdir(parents = True)
         # Resolver returns the genuine root; env is overridden to the evil dir.
-        monkeypatch.setattr(
-            tools_mod, "_windows_program_roots", lambda: [str(real_prog)]
-        )
+        monkeypatch.setattr(tools_mod, "_windows_program_roots", lambda: [str(real_prog)])
         monkeypatch.setenv("ProgramFiles", str(evil))
         monkeypatch.setattr(
             tools_mod.shutil, "which", lambda name: str(evil / "Git" / "cmd" / "git.exe")
@@ -417,9 +415,7 @@ class TestSandboxEnvIsolation:
             link.symlink_to(real_prog, target_is_directory = True)
         except (OSError, NotImplementedError):
             pytest.skip("symlink unsupported in this environment")
-        monkeypatch.setattr(
-            tools_mod, "_windows_program_roots", lambda: [str(real_prog)]
-        )
+        monkeypatch.setattr(tools_mod, "_windows_program_roots", lambda: [str(real_prog)])
         monkeypatch.setattr(
             tools_mod.shutil,
             "which",

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -317,9 +317,7 @@ class TestSandboxEnvIsolation:
         monkeypatch.setattr(sys, "platform", "win32")
         git_dir = tmp_path / "Program Files" / "Git" / "cmd"
         git_dir.mkdir(parents = True)
-        monkeypatch.setattr(
-            tools_mod.shutil, "which", lambda name: str(git_dir / "git.exe")
-        )
+        monkeypatch.setattr(tools_mod.shutil, "which", lambda name: str(git_dir / "git.exe"))
         env = _build_safe_env(str(tmp_path))
         parts = env["PATH"].split(os.pathsep)
         assert str(git_dir) in parts
@@ -348,9 +346,7 @@ class TestSandboxEnvIsolation:
         # A git-suffixed but unresolved (user-writable) dir is NOT trusted.
         assert str(fake_git) not in parts
 
-    def test_no_default_current_directory_in_exe_path_set_on_windows(
-        self, monkeypatch, tmp_path
-    ):
+    def test_no_default_current_directory_in_exe_path_set_on_windows(self, monkeypatch, tmp_path):
         """cmd/CreateProcess must not search cwd for bare names in the sandbox."""
         import core.inference.tools as tools_mod
         from core.inference.tools import _build_safe_env

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -464,6 +464,45 @@ class TestSandboxEnvIsolation:
         parts = [os.path.normcase(os.path.realpath(p)) for p in env["PATH"].split(os.pathsep)]
         assert os.path.normcase(str(real_prog / "Git" / "cmd")) in parts
 
+    def test_scan_past_untrusted_git_shim(self, monkeypatch, tmp_path):
+        """When an untrusted shim sorts first on PATH, the scan still finds a
+        later trusted Program Files git."""
+        import core.inference.tools as tools_mod
+        from core.inference.tools import _build_safe_env
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        prog = tmp_path / "Program Files"
+        trusted_git = prog / "Git" / "cmd"
+        trusted_git.mkdir(parents = True)
+        (trusted_git / "git.EXE").write_text("")  # match PATHEXT case on this FS
+        shim = tmp_path / "scoop" / "shims"
+        shim.mkdir(parents = True)
+        (shim / "git.EXE").write_text("")
+        monkeypatch.setattr(tools_mod, "_windows_program_roots", lambda: [str(prog)])
+        # shutil.which returns the untrusted shim first.
+        monkeypatch.setattr(tools_mod.shutil, "which", lambda name: str(shim / "git.EXE"))
+        monkeypatch.setenv(
+            "PATH", os.pathsep.join([str(shim), str(trusted_git)])
+        )
+        monkeypatch.setenv("PATHEXT", ".EXE")
+        env = _build_safe_env(str(tmp_path))
+        parts = env["PATH"].split(os.pathsep)
+        assert str(trusted_git) in parts
+        assert str(shim) not in parts
+
+    def test_program_roots_derive_native_from_x86(self, monkeypatch):
+        """A 32-bit process seeing only the x86 root must still trust the
+        derived native C:\\Program Files."""
+        import core.inference.tools as tools_mod
+
+        # Force the API-empty path so the env fallback + derivation runs, with
+        # only an x86 root available.
+        monkeypatch.delenv("ProgramFiles", raising = False)
+        monkeypatch.delenv("ProgramW6432", raising = False)
+        monkeypatch.setenv("ProgramFiles(x86)", r"C:\Program Files (x86)")
+        roots = [r.lower() for r in tools_mod._windows_program_roots()]
+        assert any(r.endswith(r"\program files") for r in roots)
+
     def test_program_roots_include_native_root(self, monkeypatch):
         """FOLDERID_ProgramFilesX64 is queried so a 32-bit process still trusts
         the native C:\\Program Files (both other ids map to x86 there)."""

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -488,31 +488,28 @@ class TestSandboxEnvIsolation:
         assert str(trusted_git) in parts
         assert str(shim) not in parts
 
-    def test_program_roots_derive_native_from_x86(self, monkeypatch):
-        """A 32-bit process seeing only the x86 root must still trust the
-        derived native C:\\Program Files."""
+    def test_program_roots_fallback_uses_systemdrive_not_env(self, monkeypatch):
+        """When the known-folder API is unavailable, roots come from a fixed
+        SystemDrive path, never the overrideable %ProgramFiles% env."""
         import core.inference.tools as tools_mod
 
-        # Force the API-empty path so the env fallback + derivation runs, with
-        # only an x86 root available.
-        monkeypatch.delenv("ProgramFiles", raising = False)
-        monkeypatch.delenv("ProgramW6432", raising = False)
-        monkeypatch.setenv("ProgramFiles(x86)", r"C:\Program Files (x86)")
+        # ctypes fails on this Linux host, so the fallback runs. An attacker
+        # override of ProgramFiles must NOT enter the trusted roots.
+        monkeypatch.setenv("ProgramFiles", r"D:\attacker-writable")
+        monkeypatch.setenv("ProgramW6432", r"D:\attacker-writable")
+        monkeypatch.setenv("SystemDrive", "C:")
         roots = [r.lower() for r in tools_mod._windows_program_roots()]
         assert any(r.endswith(r"\program files") for r in roots)
+        assert not any("attacker-writable" in r for r in roots)
 
     def test_program_roots_include_native_root(self, monkeypatch):
-        """FOLDERID_ProgramFilesX64 is queried so a 32-bit process still trusts
-        the native C:\\Program Files (both other ids map to x86 there)."""
+        """The fallback yields both the native and x86 Program Files roots."""
         import core.inference.tools as tools_mod
 
-        # Simulate the known-folder API being unavailable so we exercise the
-        # documented env fallback, which must include ProgramW6432 semantics.
-        monkeypatch.setenv("ProgramW6432", r"C:\Program Files")
-        monkeypatch.setenv("ProgramFiles(x86)", r"C:\Program Files (x86)")
-        roots = tools_mod._windows_program_roots()
-        # On this Linux host the ctypes call fails, so env fallback applies.
-        assert any(r.lower().endswith("program files") for r in roots)
+        monkeypatch.setenv("SystemDrive", "C:")
+        roots = [r.lower() for r in tools_mod._windows_program_roots()]
+        assert any(r.endswith(r"\program files") for r in roots)
+        assert any(r.endswith(r"\program files (x86)") for r in roots)
 
     def test_no_default_current_directory_in_exe_path_set_on_windows(self, monkeypatch, tmp_path):
         """cmd/CreateProcess must not search cwd for bare names in the sandbox."""

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -488,28 +488,28 @@ class TestSandboxEnvIsolation:
         assert str(trusted_git) in parts
         assert str(shim) not in parts
 
-    def test_program_roots_fallback_uses_systemdrive_not_env(self, monkeypatch):
-        """When the known-folder API is unavailable, roots come from a fixed
-        SystemDrive path, never the overrideable %ProgramFiles% env."""
+    def test_program_roots_fails_closed_without_known_folder_api(self, monkeypatch):
+        """When the known-folder API is unavailable, no roots are trusted: env
+        vars (even %SystemDrive%) are caller-overrideable, so we never derive a
+        trusted root from them."""
         import core.inference.tools as tools_mod
 
-        # ctypes fails on this Linux host, so the fallback runs. An attacker
-        # override of ProgramFiles must NOT enter the trusted roots.
+        # ctypes fails on this Linux host, so the API path raises and we fail
+        # closed. Any attacker override of these env vars must be irrelevant.
         monkeypatch.setenv("ProgramFiles", r"D:\attacker-writable")
         monkeypatch.setenv("ProgramW6432", r"D:\attacker-writable")
-        monkeypatch.setenv("SystemDrive", "C:")
-        roots = [r.lower() for r in tools_mod._windows_program_roots()]
-        assert any(r.endswith(r"\program files") for r in roots)
-        assert not any("attacker-writable" in r for r in roots)
+        monkeypatch.setenv("SystemDrive", "D:")
+        assert tools_mod._windows_program_roots() == []
 
-    def test_program_roots_include_native_root(self, monkeypatch):
-        """The fallback yields both the native and x86 Program Files roots."""
+    def test_augment_native_program_roots_derives_native_sibling(self):
+        """A 32-bit process only sees the x86 root; the native sibling is
+        derived by stripping the ` (x86)` suffix."""
         import core.inference.tools as tools_mod
 
-        monkeypatch.setenv("SystemDrive", "C:")
-        roots = [r.lower() for r in tools_mod._windows_program_roots()]
-        assert any(r.endswith(r"\program files") for r in roots)
-        assert any(r.endswith(r"\program files (x86)") for r in roots)
+        roots = tools_mod._augment_native_program_roots([r"C:\Program Files (x86)"])
+        lowered = [r.lower() for r in roots]
+        assert r"c:\program files (x86)" in lowered
+        assert r"c:\program files" in lowered
 
     def test_no_default_current_directory_in_exe_path_set_on_windows(self, monkeypatch, tmp_path):
         """cmd/CreateProcess must not search cwd for bare names in the sandbox."""

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -297,6 +297,7 @@ class TestSandboxEnvIsolation:
             "PYTHONPATH",
             "VIRTUAL_ENV",
             "SystemRoot",
+            "PATHEXT",  # Windows only; inherited so bare names like git resolve
         }
         extras = set(env.keys()) - allowed
         assert not extras, f"sandbox env added unexpected keys: {extras}"
@@ -304,6 +305,41 @@ class TestSandboxEnvIsolation:
         # sitecustomize shim dir (code-interpreter path remap).
         assert env["PYTHONPATH"].endswith("sandbox_site")
         assert "leak-me" not in env["PYTHONPATH"]
+
+    def test_host_path_absolute_dirs_appended_after_curated(self, monkeypatch, tmp_path):
+        # #7317: Windows Git lives under Program Files, not System32. Sandbox PATH
+        # must still resolve bare `git` by appending absolute host PATH dirs after
+        # the curated interpreter / system prefix.
+        from core.inference.tools import _build_safe_env
+
+        git_dir = tmp_path / "Git" / "cmd"
+        git_dir.mkdir(parents = True)
+        junk_rel = "relative-bin"
+        monkeypatch.setenv(
+            "PATH",
+            os.pathsep.join(
+                [str(git_dir), ".", junk_rel, os.environ.get("PATH", "")]
+            ),
+        )
+        env = _build_safe_env(str(tmp_path))
+        parts = env["PATH"].split(os.pathsep)
+        assert str(git_dir) in parts
+        # Curated prefix stays ahead of host Git so Studio python/pip win.
+        assert parts.index(str(git_dir)) > 0
+        assert "." not in parts
+        assert junk_rel not in parts
+
+    def test_host_path_quoted_windows_style_entries_stripped(self, monkeypatch, tmp_path):
+        from core.inference.tools import _build_safe_env
+
+        quoted = tmp_path / "Quoted Tools"
+        quoted.mkdir()
+        # Windows PATH entries are sometimes quoted when they contain spaces.
+        monkeypatch.setenv("PATH", f'"{quoted}"{os.pathsep}{os.environ.get("PATH", "")}')
+        env = _build_safe_env(str(tmp_path))
+        parts = env["PATH"].split(os.pathsep)
+        assert str(quoted) in parts
+        assert f'"{quoted}"' not in parts
 
     def test_home_points_at_sandbox_workdir(self, tmp_path):
         from core.inference.tools import _build_safe_env

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -346,7 +346,25 @@ class TestSandboxEnvIsolation:
         # A git-suffixed but unresolved (user-writable) dir is NOT trusted.
         assert str(fake_git) not in parts
 
-    def test_no_default_current_directory_in_exe_path_set_on_windows(self, monkeypatch, tmp_path):
+    def test_git_cmd_shim_extension_added_to_pathext(self, monkeypatch, tmp_path):
+        """A host git resolved as a .cmd shim stays resolvable under the
+        restricted PATHEXT (cwd lookup is disabled separately)."""
+        import core.inference.tools as tools_mod
+        from core.inference.tools import _build_safe_env
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        shim_dir = tmp_path / "scoop" / "shims"
+        shim_dir.mkdir(parents = True)
+        monkeypatch.setattr(
+            tools_mod.shutil, "which", lambda name: str(shim_dir / "git.cmd")
+        )
+        env = _build_safe_env(str(tmp_path))
+        assert str(shim_dir) in env["PATH"].split(os.pathsep)
+        assert env["PATHEXT"] == ".EXE;.COM;.CMD"
+
+    def test_no_default_current_directory_in_exe_path_set_on_windows(
+        self, monkeypatch, tmp_path
+    ):
         """cmd/CreateProcess must not search cwd for bare names in the sandbox."""
         import core.inference.tools as tools_mod
         from core.inference.tools import _build_safe_env

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -359,9 +359,7 @@ class TestSandboxEnvIsolation:
         monkeypatch.setenv("ProgramFiles", str(prog))
         git_dir = prog / "Git" / "cmd"
         git_dir.mkdir(parents = True)
-        monkeypatch.setattr(
-            tools_mod.shutil, "which", lambda name: str(git_dir / "git.cmd")
-        )
+        monkeypatch.setattr(tools_mod.shutil, "which", lambda name: str(git_dir / "git.cmd"))
         env = _build_safe_env(str(tmp_path))
         assert str(git_dir) in env["PATH"].split(os.pathsep)
         assert env["PATHEXT"] == ".EXE;.COM;.CMD"
@@ -376,17 +374,13 @@ class TestSandboxEnvIsolation:
         monkeypatch.setenv("ProgramFiles", str(tmp_path / "Program Files"))
         shim_dir = tmp_path / "users" / "alice" / "scoop" / "shims"
         shim_dir.mkdir(parents = True)
-        monkeypatch.setattr(
-            tools_mod.shutil, "which", lambda name: str(shim_dir / "git.exe")
-        )
+        monkeypatch.setattr(tools_mod.shutil, "which", lambda name: str(shim_dir / "git.exe"))
         env = _build_safe_env(str(tmp_path))
         assert str(shim_dir) not in env["PATH"].split(os.pathsep)
         # No trusted git launcher -> PATHEXT stays minimal.
         assert env["PATHEXT"] == ".EXE;.COM"
 
-    def test_no_default_current_directory_in_exe_path_set_on_windows(
-        self, monkeypatch, tmp_path
-    ):
+    def test_no_default_current_directory_in_exe_path_set_on_windows(self, monkeypatch, tmp_path):
         """cmd/CreateProcess must not search cwd for bare names in the sandbox."""
         import core.inference.tools as tools_mod
         from core.inference.tools import _build_safe_env

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -380,6 +380,55 @@ class TestSandboxEnvIsolation:
         # No trusted git launcher -> PATHEXT stays minimal.
         assert env["PATHEXT"] == ".EXE;.COM"
 
+    def test_trust_uses_known_folder_not_env_override(self, monkeypatch, tmp_path):
+        """Trust is driven by the resolved Program Files roots, so a git under
+        an attacker-overridden %ProgramFiles% env value is still refused."""
+        import core.inference.tools as tools_mod
+        from core.inference.tools import _build_safe_env
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        real_prog = tmp_path / "RealProgramFiles"
+        (real_prog).mkdir()
+        evil = tmp_path / "attacker"
+        (evil / "Git" / "cmd").mkdir(parents = True)
+        # Resolver returns the genuine root; env is overridden to the evil dir.
+        monkeypatch.setattr(
+            tools_mod, "_windows_program_roots", lambda: [str(real_prog)]
+        )
+        monkeypatch.setenv("ProgramFiles", str(evil))
+        monkeypatch.setattr(
+            tools_mod.shutil, "which", lambda name: str(evil / "Git" / "cmd" / "git.exe")
+        )
+        env = _build_safe_env(str(tmp_path))
+        assert str(evil / "Git" / "cmd") not in env["PATH"].split(os.pathsep)
+
+    def test_canonical_git_dir_appended(self, monkeypatch, tmp_path):
+        """The PATH entry is the realpath of the trusted dir, not a junction
+        alias, so it cannot be retargeted after the trust check."""
+        import core.inference.tools as tools_mod
+        from core.inference.tools import _build_safe_env
+
+        monkeypatch.setattr(sys, "platform", "win32")
+        real_prog = tmp_path / "Program Files"
+        real_git = real_prog / "Git" / "cmd"
+        real_git.mkdir(parents = True)
+        link = tmp_path / "link"
+        try:
+            link.symlink_to(real_prog, target_is_directory = True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink unsupported in this environment")
+        monkeypatch.setattr(
+            tools_mod, "_windows_program_roots", lambda: [str(real_prog)]
+        )
+        monkeypatch.setattr(
+            tools_mod.shutil,
+            "which",
+            lambda name: str(link / "Git" / "cmd" / "git.exe"),
+        )
+        env = _build_safe_env(str(tmp_path))
+        parts = env["PATH"].split(os.pathsep)
+        assert str(real_git) in parts  # canonical, not the `link/...` alias
+
     def test_windows_temp_git_dir_refused(self, monkeypatch, tmp_path):
         """A git under a world-writable %SystemRoot% subdir (Windows\\Temp) is
         NOT trusted, even though it sits under the Windows root."""

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -355,16 +355,12 @@ class TestSandboxEnvIsolation:
         monkeypatch.setattr(sys, "platform", "win32")
         shim_dir = tmp_path / "scoop" / "shims"
         shim_dir.mkdir(parents = True)
-        monkeypatch.setattr(
-            tools_mod.shutil, "which", lambda name: str(shim_dir / "git.cmd")
-        )
+        monkeypatch.setattr(tools_mod.shutil, "which", lambda name: str(shim_dir / "git.cmd"))
         env = _build_safe_env(str(tmp_path))
         assert str(shim_dir) in env["PATH"].split(os.pathsep)
         assert env["PATHEXT"] == ".EXE;.COM;.CMD"
 
-    def test_no_default_current_directory_in_exe_path_set_on_windows(
-        self, monkeypatch, tmp_path
-    ):
+    def test_no_default_current_directory_in_exe_path_set_on_windows(self, monkeypatch, tmp_path):
         """cmd/CreateProcess must not search cwd for bare names in the sandbox."""
         import core.inference.tools as tools_mod
         from core.inference.tools import _build_safe_env


### PR DESCRIPTION
Fixes #7317

## Problem

On Windows, Studio's sandboxed terminal tool fails with `'git' is not recognized as an internal or external command` even when Git works in every normal cmd/PowerShell on the machine (including the one Studio was launched from). Bare `git` only works after the model is told to use the 8.3 path `C:\PROGRA~1\Git\cmd\git.exe`.

`_build_safe_env()` rebuilds `PATH` from scratch as Studio venv + `System32` only. User-installed Git lives under `C:\Program Files\Git\cmd`, so it never enters that `PATH`. Unix sandboxes already include `/usr/bin`, which is why system `git` worked there.

## Fix

- **`studio/backend/core/inference/tools.py`**: After the curated interpreter / venv / system dirs, append absolute entries from the parent `PATH` (strip quotes; skip empty / `.` / relative entries so cwd PATH hijacks stay blocked). On Windows, also inherit `PATHEXT` so `git` maps to `git.exe` like a normal shell.
- **`studio/backend/tests/test_sandbox_tools.py`**: Cover host PATH append order, relative-entry filtering, and quoted Windows-style PATH entries.

## Verification

```bash
PYTHONPATH=studio/backend python -m pytest studio/backend/tests/test_sandbox_tools.py::TestSandboxEnvIsolation -q
PYTHONPATH=studio/backend python -m pytest studio/backend/tests/test_bypass_permissions.py -q -k 'safe_env or bypass_env or PATH or secret'
```

8/8 sandbox env tests pass; 32 related bypass/env tests pass.

## Compatibility

- Curated `PATH` prefix is unchanged: Studio `python`/`pip` still win over host copies.
- Credential whitelist is unchanged (still no `HF_TOKEN` / `USERPROFILE` / etc. in the sandbox env).
- Full-access / bypass mode already inherited host `PATH`; unchanged.
- Linux/macOS get the same absolute host-`PATH` append; relative entries remain excluded.