### PR TITLE
Baseline two benign unsloth-zoo test-file findings in scan_packages

### DIFF
--- a/scripts/scan_packages_baseline.json
+++ b/scripts/scan_packages_baseline.json
@@ -1545,6 +1545,22 @@
       "severity": "HIGH",
       "evidence": "Obfusc: L836:         code = compile(module, \"<werkzeug routing>\", \"exec\")\nExec: L736:         exec(code, globs, locs)",
       "evidence_hash": "5c0992c90f05c772abd94d00784f157de337e1f8567f8b3aee1b15e46c96cd5d"
+    },
+    {
+      "package": "unsloth-zoo",
+      "file": "tests/test_mlx_save_export_regressions.py",
+      "check": "Writes to /tmp and executes (staged dropper)",
+      "severity": "CRITICAL",
+      "evidence": "L165:         temporary_location=\"/tmp/ignored\", sha256:ab5c587f9ec31a0cc10ee55698ab133a417148d9d3f371bbc81b1e13fa119c13",
+      "evidence_hash": "93a11159147aad94f353ec4d2e0b8486b256abef88cd96d741813222cd32b138"
+    },
+    {
+      "package": "unsloth-zoo",
+      "file": "tests/test_vision_collator_audio.py",
+      "check": "Writes to /tmp and executes (staged dropper)",
+      "severity": "CRITICAL",
+      "evidence": "L111:         out = extract_audio_info(msgs({\"type\": \"audio\", key: \"/tmp/a.wav\"})) sha256:2efe23ffbe2b91b8403aec9b700736919b59e5ca770f8e1f5501651b44b7d398",
+      "evidence_hash": "d416b79dd17b24214f3f7653ac01354507d7bf0fc464dee30a4a4b8998f063ba"
     }
   ]
 }


### PR DESCRIPTION
## Summary

The enforcing `pip scan-packages :: hf-stack` shard in security-audit.yml currently red-fails on `main` (and therefore on every open PR) with two CRITICAL findings:

```
Summary: 2 CRITICAL, 181 MEDIUM
```

Both are false positives in `unsloth-zoo` test files, flagged by the scanner's "Writes to /tmp and executes (staged dropper)" combination heuristic:

- `tests/test_mlx_save_export_regressions.py` L165: `temporary_location="/tmp/ignored",` (a keyword argument in a mocked save/export regression test)
- `tests/test_vision_collator_audio.py` L111: `out = extract_audio_info(msgs({"type": "audio", key: "/tmp/a.wav"}))` (an asserted path-literal fixture)

The heuristic matches a `/tmp` path literal alongside unrelated `subprocess`/`__import__` references elsewhere in the same file. Those references are all mocking (`monkeypatch.setattr(subprocess, "run", fake_run)`, `monkeypatch.setattr(builtins, "__import__", ...)`) and subprocess-based test isolation, not a staged dropper. These test files postdate the last baseline triage, so they are not yet suppressed.

## Change

Add both findings to the reviewed allowlist `scripts/scan_packages_baseline.json`, keyed on `(package, package-relative file, check, evidence_hash)` like every other entry. Only comment-free data; no scanner logic changes.

## Validation

- Direct `python scripts/scan_packages.py unsloth-zoo`: was `2 CRITICAL, 17 MEDIUM`, now `17 MEDIUM`, exit 0 (the two CRITICALs move to suppressed: 27 to 29).
- Exact hf-stack shard command `scan_packages.py --with-deps -r audit-reqs/unsloth-deps.txt -r audit-reqs/no-torch-runtime.txt` (109 archives): was `2 CRITICAL, 181 MEDIUM` exit 1, now `181 MEDIUM` exit 0 (suppressed 119 to 121).
- `tests/security/test_scan_packages.py` baseline/partition/evidence-hash suite: 12 passed, including `test_committed_baseline_entries_all_carry_evidence_hash` which asserts each entry's `evidence_hash` recomputes from its stored evidence.

Note: the separate `pip scan-packages :: extras` shard's intermittent `SCAN INCOMPLETE` on `openai-whisper` resolution is an environmental PyPI-availability issue, not addressed here.