### PR TITLE
Studio: reorder sidebar, rename Hub to Models

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1358,6 +1358,18 @@ export function AppSidebar() {
           <SidebarGroupContent>
             <SidebarMenu>
               <NavItem
+                icon={DashboardCircleIcon}
+                label={t("shell.navigation.hub")}
+                active={pathname === "/hub" || pathname.startsWith("/hub/")}
+                onClick={() => {
+                  navigate({ to: "/hub" });
+                  closeMobileIfOpen();
+                }}
+                onIntent={() => {
+                  preloadSilently(router.preloadRoute({ to: "/hub" }));
+                }}
+              />
+              <NavItem
                 icon={Folder01Icon}
                 label="Projects"
                 active={
@@ -1392,18 +1404,6 @@ export function AppSidebar() {
                   </span>
                 </button>
               </NavItem>
-              <NavItem
-                icon={DashboardCircleIcon}
-                label={t("shell.navigation.hub")}
-                active={pathname === "/hub" || pathname.startsWith("/hub/")}
-                onClick={() => {
-                  navigate({ to: "/hub" });
-                  closeMobileIfOpen();
-                }}
-                onIntent={() => {
-                  preloadSilently(router.preloadRoute({ to: "/hub" }));
-                }}
-              />
               {/* Train has a labelled section when expanded; plain icon here only when collapsed. */}
               <NavItem
                 icon={TestTubeOutlineIcon}

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -2268,9 +2268,9 @@ export function ChatPage({
                 "It'll be ready to load once the current model finishes.",
             });
           } else if (outcome === "conflict") {
-            toast.info("Resume this download from the Hub", {
+            toast.info("Resume this download from Models", {
               description:
-                "An earlier partial download used a different transport. Open the Hub tab to resume or restart it.",
+                "An earlier partial download used a different transport. Open the Models tab to resume or restart it.",
             });
           } else if (outcome === "busy") {
             toast.info("Download already in progress", {
@@ -2389,9 +2389,9 @@ export function ChatPage({
         // the conflict just recorded by requestStart (which the toast points the
         // user to); resolving it from the Hub completes the download and this
         // surface's onComplete auto-loads, mirroring the "started" branch.
-        toast.info("Resume this download from the Hub", {
+        toast.info("Resume this download from Models", {
           description:
-            "An earlier partial download used a different transport. Open the Hub tab to resume or restart it.",
+            "An earlier partial download used a different transport. Open the Models tab to resume or restart it.",
         });
         return;
       }

--- a/studio/frontend/src/features/hub/catalog/models-header.tsx
+++ b/studio/frontend/src/features/hub/catalog/models-header.tsx
@@ -64,7 +64,7 @@ export function ModelsHeader({
   return (
     <header className="font-heading flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
       <PageHeading
-        title="Models"
+        title={isDataset ? "Datasets" : "Models"}
         onTitleClick={onTitleClick}
         subtitle={
           isDataset

--- a/studio/frontend/src/features/hub/catalog/models-header.tsx
+++ b/studio/frontend/src/features/hub/catalog/models-header.tsx
@@ -64,7 +64,7 @@ export function ModelsHeader({
   return (
     <header className="font-heading flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
       <PageHeading
-        title="Hub"
+        title="Models"
         onTitleClick={onTitleClick}
         subtitle={
           isDataset

--- a/studio/frontend/src/i18n/locales/ar.ts
+++ b/studio/frontend/src/i18n/locales/ar.ts
@@ -39,7 +39,7 @@ export const ar = {
       returnToChat: "العودة إلى المحادثة",
       compare: "مقارنة",
       search: "بحث",
-      hub: "Hub",
+      hub: "النماذج",
       train: "تدريب",
       recipes: "الوصفات",
       export: "تصدير",

--- a/studio/frontend/src/i18n/locales/de.ts
+++ b/studio/frontend/src/i18n/locales/de.ts
@@ -39,7 +39,7 @@ export const de = {
       returnToChat: "Zurück zum Chat",
       compare: "Vergleichen",
       search: "Suchen",
-      hub: "Hub",
+      hub: "Modelle",
       train: "Trainieren",
       recipes: "Rezepte",
       export: "Exportieren",

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -32,11 +32,11 @@ export const en = {
       runOptions: "Run options",
     },
     navigation: {
-      newChat: "New Chat",
+      newChat: "New chat",
       returnToChat: "Return to Chat",
       compare: "Compare",
       search: "Search",
-      hub: "Hub",
+      hub: "Models",
       train: "Train",
       recipes: "Recipes",
       export: "Export",

--- a/studio/frontend/src/i18n/locales/es.ts
+++ b/studio/frontend/src/i18n/locales/es.ts
@@ -39,7 +39,7 @@ export const es = {
       returnToChat: "Volver al chat",
       compare: "Comparar",
       search: "Buscar",
-      hub: "Hub",
+      hub: "Modelos",
       train: "Entrenar",
       recipes: "Recetas",
       export: "Exportar",

--- a/studio/frontend/src/i18n/locales/fr.ts
+++ b/studio/frontend/src/i18n/locales/fr.ts
@@ -39,7 +39,7 @@ export const fr = {
       returnToChat: "Retour à la discussion",
       compare: "Comparer",
       search: "Rechercher",
-      hub: "Hub",
+      hub: "Modèles",
       train: "Entraîner",
       recipes: "Recettes",
       export: "Exporter",

--- a/studio/frontend/src/i18n/locales/hi.ts
+++ b/studio/frontend/src/i18n/locales/hi.ts
@@ -39,7 +39,7 @@ export const hi = {
       returnToChat: "चैट पर लौटें",
       compare: "तुलना करें",
       search: "खोजें",
-      hub: "Hub",
+      hub: "मॉडल",
       train: "ट्रेनिंग",
       recipes: "रेसिपी",
       export: "एक्सपोर्ट",

--- a/studio/frontend/src/i18n/locales/ja.ts
+++ b/studio/frontend/src/i18n/locales/ja.ts
@@ -40,7 +40,7 @@ export const ja = {
       returnToChat: "チャットに戻る",
       compare: "比較",
       search: "検索",
-      hub: "ハブ",
+      hub: "モデル",
       train: "トレーニング",
       recipes: "レシピ",
       export: "エクスポート",

--- a/studio/frontend/src/i18n/locales/ko.ts
+++ b/studio/frontend/src/i18n/locales/ko.ts
@@ -39,7 +39,7 @@ export const ko = {
       returnToChat: "채팅으로 돌아가기",
       compare: "비교",
       search: "검색",
-      hub: "Hub",
+      hub: "모델",
       train: "학습",
       recipes: "레시피",
       export: "내보내기",

--- a/studio/frontend/src/i18n/locales/pt-br.ts
+++ b/studio/frontend/src/i18n/locales/pt-br.ts
@@ -39,7 +39,7 @@ export const ptBR = {
       returnToChat: "Retornar ao Chat",
       compare: "Comparar",
       search: "Buscar",
-      hub: "Hub",
+      hub: "Modelos",
       train: "Treinar",
       recipes: "Receitas",
       export: "Exportar",

--- a/studio/frontend/src/i18n/locales/ru.ts
+++ b/studio/frontend/src/i18n/locales/ru.ts
@@ -39,7 +39,7 @@ export const ru = {
       returnToChat: "Вернуться к чату",
       compare: "Сравнить",
       search: "Поиск",
-      hub: "Hub",
+      hub: "Модели",
       train: "Обучение",
       recipes: "Рецепты",
       export: "Экспорт",

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -39,7 +39,7 @@ export const zhCN = {
       returnToChat: "返回聊天",
       compare: "对比",
       search: "搜索",
-      hub: "Hub",
+      hub: "模型",
       train: "训练",
       recipes: "配方",
       export: "导出",


### PR DESCRIPTION
## What this does

Sidebar label and order cleanups in Studio, on top of the search-in-header change from #7304:

- Put the Models row (formerly Hub) directly under New chat, ahead of Projects.
- Rename the Hub nav row and its page heading to Models. "Hub" alone was vague; Models says what the page is for. Localized across all locales.
- Use sentence case "New chat" for the English label.

## Scope and risk

Frontend only. This touches the sidebar order and i18n labels, and nothing in the training, inference, or backend paths, so no compute path is affected.
