### PR TITLE
Studio: prevent login error text clipping

### DIFF
--- a/studio/frontend/src/features/auth/components/auth-form.tsx
+++ b/studio/frontend/src/features/auth/components/auth-form.tsx
@@ -439,7 +439,11 @@ export function AuthForm({ mode }: AuthFormProps): ReactElement | null {
         {helperText && (
           <p className="text-center text-sm text-amber-600">{helperText}</p>
         )}
-        {error && <p className="text-center text-sm text-destructive">{error}</p>}
+        {error && (
+          <p className="text-center text-sm text-destructive [overflow-wrap:anywhere]">
+            {error}
+          </p>
+        )}
 
         <Button
           type="submit"


### PR DESCRIPTION
After an incorrect password is entered, the login screen shows a command for resetting it. When that command contains a long installation path, it extends beyond the error message and gets clipped by the login card.

## Fix

Allow long strings in login errors to wrap when they reach the edge of the card. The complete reset command now remains visible, while shorter messages continue to wrap normally.

## Comparison

**Before**
<img width="760" height="560" alt="unsloth-login-password-before" src="https://github.com/user-attachments/assets/dd85ddc4-9cb4-43eb-8993-f2ff102ddb5a" />


**After**
<img width="760" height="560" alt="unsloth-login-password-after" src="https://github.com/user-attachments/assets/c966cc5d-7f3e-4c34-9510-4c986aec04b2" />



## Verification

- Playwright before-and-after captures at Studio's 760 x 560 desktop size
- Production frontend build
- Focused ESLint and whitespace checks
