### PR TITLE
fix(studio): honor run settings on initial model load (#7346)

### DIFF
--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -2657,7 +2657,7 @@ export function ChatPage({
           config: meta?.config,
           nativePathToken: meta?.nativePathToken,
           nativePathExpiresAtMs: meta?.nativePathExpiresAtMs,
-          forceReload: isSameLoadedModel || undefined,
+          forceReload: meta?.forceReload ?? (isSameLoadedModel || undefined),
         };
         await stageOrLoad(selection);
       })();

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -62,6 +62,7 @@ import {
 import { isExternalModelId } from "../external-providers";
 import {
   applyPerModelConfigToRuntime,
+  normalizeMaxSeqLength,
   type PerModelConfig,
 } from "@/features/model-picker";
 import type {
@@ -604,12 +605,19 @@ export function useChatModelRuntime() {
         async function performLoad(): Promise<void> {
           if (abortCtrl.signal.aborted) throw new Error("Cancelled");
           let previousWasUnloaded = false;
+          const pendingLoadConfig =
+            typeof selection !== "string" ? selection.config : undefined;
+          if (pendingLoadConfig) {
+            applyPerModelConfigToRuntime(pendingLoadConfig);
+          }
           const currentCheckpoint =
             useChatRuntimeStore.getState().params.checkpoint;
           const stateBeforeUnload = useChatRuntimeStore.getState();
           let trustRemoteCode = stateBeforeUnload.params.trustRemoteCode ?? false;
           let approvedRemoteCodeFingerprint: string | null = null;
-          const maxSeqLength = stateBeforeUnload.params.maxSeqLength;
+          const maxSeqLength =
+            normalizeMaxSeqLength(pendingLoadConfig?.maxSeqLength) ??
+            stateBeforeUnload.params.maxSeqLength;
           const previousActiveNativePathToken =
             stateBeforeUnload.activeNativePathToken;
           const previousIsGguf =
@@ -643,34 +651,54 @@ export function useChatModelRuntime() {
           const previousActiveNativePathExpiresAtMs =
             stateBeforeUnload.activeNativePathExpiresAtMs;
           // Snapshot the load settings at click time, before the awaits below
-          // (validation, the trust dialog, unload).
-          const loadChatTemplateOverride = stateBeforeUnload.chatTemplateOverride;
-          const loadKvCacheDtype = stateBeforeUnload.kvCacheDtype;
+          // (validation, the trust dialog, unload). When the picker staged a
+          // config payload, prefer it over the store: React may not have
+          // flushed NumericValueInput's blur commit into state yet.
+          const loadChatTemplateOverride =
+            pendingLoadConfig?.chatTemplateOverride?.trim()
+              ? pendingLoadConfig.chatTemplateOverride
+              : stateBeforeUnload.chatTemplateOverride;
+          const loadKvCacheDtype =
+            pendingLoadConfig?.kvCacheDtype ?? stateBeforeUnload.kvCacheDtype;
           // gpuMemoryMode is a standing preference (kept across a model switch);
           // the rest are per-model knobs the reset below clears, so they are
           // re-baselined there in lock-step with the store.
-          let loadCustomContextLength = stateBeforeUnload.customContextLength;
+          let loadCustomContextLength =
+            pendingLoadConfig?.customContextLength ??
+            stateBeforeUnload.customContextLength;
           const loadGgufContextLength = stateBeforeUnload.ggufContextLength;
-          const loadTensorParallel = stateBeforeUnload.tensorParallel;
+          const loadTensorParallel =
+            pendingLoadConfig?.tensorParallel ?? stateBeforeUnload.tensorParallel;
           const loadActivePresetSource = stateBeforeUnload.activePresetSource;
           const loadActiveGgufVariant = stateBeforeUnload.activeGgufVariant;
-          const loadGpuMemoryMode = stateBeforeUnload.gpuMemoryMode;
-          let loadGpuLayers = stateBeforeUnload.gpuLayers;
-          let loadNCpuMoe = stateBeforeUnload.nCpuMoe;
+          const loadGpuMemoryMode =
+            pendingLoadConfig?.gpuMemoryMode ?? stateBeforeUnload.gpuMemoryMode;
+          let loadGpuLayers =
+            pendingLoadConfig?.gpuLayers ?? stateBeforeUnload.gpuLayers;
+          let loadNCpuMoe =
+            pendingLoadConfig?.nCpuMoe ?? stateBeforeUnload.nCpuMoe;
           let loadSplitRatio = stateBeforeUnload.splitRatio;
           // Reconcile the persisted pick against the GPUs present now, so a stale
           // cross-host / now-hidden pick is dropped before /load rather than
           // rejected there. Warm the device cache first: load-on-selection can
           // run before any GPU hook mounted, and a cold cache would pass the
           // pick through unvalidated. validateGpuIds derives from this too.
-          if (stateBeforeUnload.selectedGpuIds != null) {
+          if (
+            pendingLoadConfig?.selectedGpuIds !== undefined ||
+            stateBeforeUnload.selectedGpuIds != null
+          ) {
             await ensureGpuDeviceCache();
           }
-          let loadSelectedGpuIds = reconcilePersistedGpuIds(
-            stateBeforeUnload.selectedGpuIds,
-          );
-          let loadSpeculativeType = stateBeforeUnload.speculativeType;
-          let loadSpecDraftNMax = stateBeforeUnload.specDraftNMax;
+          let loadSelectedGpuIds =
+            pendingLoadConfig?.selectedGpuIds !== undefined
+              ? reconcilePersistedGpuIds(pendingLoadConfig.selectedGpuIds)
+              : reconcilePersistedGpuIds(stateBeforeUnload.selectedGpuIds);
+          let loadSpeculativeType =
+            pendingLoadConfig?.speculativeType != null
+              ? normalizeSpeculativeType(pendingLoadConfig.speculativeType)
+              : stateBeforeUnload.speculativeType;
+          let loadSpecDraftNMax =
+            pendingLoadConfig?.specDraftNMax ?? stateBeforeUnload.specDraftNMax;
           try {
             // Lightweight pre-flight validation: avoid unloading a working model
             // if the new identifier is clearly invalid (e.g. bad HF id / path).

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -838,15 +838,23 @@ export function useChatModelRuntime() {
                 // model loads at Auto/native, not the previous model's pin.
                 customContextLength: null,
               });
-              loadSpeculativeType = persistedSpeculativeType;
-              loadSpecDraftNMax = null;
+              loadSpeculativeType =
+                pendingLoadConfig?.speculativeType != null
+                  ? normalizeSpeculativeType(pendingLoadConfig.speculativeType)
+                  : persistedSpeculativeType;
+              loadSpecDraftNMax = pendingLoadConfig?.specDraftNMax ?? null;
               // Keep the click-time snapshot in lock-step with the store reset so
               // the load below sizes against the cleared per-model knobs, not the
               // previous model's (gpuMemoryMode is standing, so left as captured).
-              loadCustomContextLength = null;
-              loadSelectedGpuIds = null;
-              loadGpuLayers = GPU_LAYERS_AUTO;
-              loadNCpuMoe = 0;
+              // An explicit staged config from run-settings still wins.
+              loadCustomContextLength =
+                pendingLoadConfig?.customContextLength ?? null;
+              loadSelectedGpuIds =
+                pendingLoadConfig?.selectedGpuIds !== undefined
+                  ? reconcilePersistedGpuIds(pendingLoadConfig.selectedGpuIds)
+                  : null;
+              loadGpuLayers = pendingLoadConfig?.gpuLayers ?? GPU_LAYERS_AUTO;
+              loadNCpuMoe = pendingLoadConfig?.nCpuMoe ?? 0;
               loadSplitRatio = null;
             }
 

--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -24,7 +24,7 @@ import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
 import { toast } from "@/lib/toast";
 import { ArrowLeft01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { type ReactNode, useEffect, useId, useState } from "react";
+import { type ReactNode, useEffect, useId, useRef, useState } from "react";
 import {
   useDefaultChatTemplate,
   useModelMaxPositionEmbeddings,
@@ -50,7 +50,10 @@ import {
 } from "../model-config/per-model-config";
 import { ChatTemplateEditorDialog } from "./chat-template-editor-dialog";
 import type { ModelPickTarget } from "./model-selector/types";
-import { NumericValueInput } from "./numeric-value-input";
+import {
+  NumericValueInput,
+  type NumericValueInputHandle,
+} from "./numeric-value-input";
 
 const ROW_CLASS = "flex min-h-8 items-center justify-between gap-3";
 const LABEL_CLASS =
@@ -596,6 +599,7 @@ export function ModelConfigPage({
   const [showAdvanced, setShowAdvanced] = useState(() =>
     hasNonDefaultAdvanced(config),
   );
+  const contextInputRef = useRef<NumericValueInputHandle>(null);
   const nativePathToken =
     target.meta.nativePathToken ??
     (isActiveModel ? activeNativePathToken : null);
@@ -743,11 +747,6 @@ export function ModelConfigPage({
       ? { ...config, customContextLength: activeLoadedContext }
       : config
     : config;
-  // Load request needs a concrete max length; substitute the fallback here only,
-  // never in the persisted runtimeConfig.
-  const loadConfig = target.isGguf
-    ? runtimeConfig
-    : { ...runtimeConfig, maxSeqLength: maxSeqLengthValue };
   const rememberChanged = remember !== savedRemember;
   const persistenceOnly = isActiveModel && atBaseline && rememberChanged;
   const primaryActionLabel = persistenceOnly
@@ -759,13 +758,19 @@ export function ModelConfigPage({
       : "Load model";
 
   const handleRun = () => {
-    const defaultConfig = isDefaultConfig(runtimeConfig);
+    const committedContext =
+      target.isGguf ? contextInputRef.current?.commit() : undefined;
+    const effectiveRuntimeConfig =
+      committedContext != null
+        ? { ...runtimeConfig, customContextLength: committedContext }
+        : runtimeConfig;
+    const defaultConfig = isDefaultConfig(effectiveRuntimeConfig);
     let saveFailed = false;
     if (remember) {
       saveFailed = !savePerModelConfig(
         target.id,
         target.ggufVariant,
-        runtimeConfig,
+        effectiveRuntimeConfig,
       );
     } else {
       saveFailed = !deletePerModelConfig(target.id, target.ggufVariant);
@@ -790,7 +795,10 @@ export function ModelConfigPage({
     if (saveFailed) {
       toast.error("Couldn't save these settings, loading with them anyway.");
     }
-    onRun(loadConfig);
+    const effectiveLoadConfig = target.isGguf
+      ? effectiveRuntimeConfig
+      : { ...effectiveRuntimeConfig, maxSeqLength: maxSeqLengthValue };
+    onRun(effectiveLoadConfig);
   };
 
   return (
@@ -837,6 +845,7 @@ export function ModelConfigPage({
                   </InfoHint>
                 </div>
                 <NumericValueInput
+                  ref={contextInputRef}
                   value={contextValue}
                   min={minContext}
                   max={maxContext}

--- a/studio/frontend/src/features/model-picker/components/numeric-value-input.tsx
+++ b/studio/frontend/src/features/model-picker/components/numeric-value-input.tsx
@@ -2,7 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { cn } from "@/lib/utils";
-import { useRef, useState } from "react";
+import { forwardRef, useImperativeHandle, useRef, useState } from "react";
 
 export function snapToStep(
   value: number,
@@ -28,43 +28,70 @@ function sanitizeNumeric(raw: string, allowNegative: boolean): string {
   return `${sign}${head}${tail}`;
 }
 
-export function NumericValueInput({
-  value,
-  min,
-  max,
-  step,
-  onChange,
-  displayValue,
-  className,
-  ariaLabel,
-  size: sizeAttr,
-  disabled = false,
-}: {
-  value: number;
-  min?: number;
-  max?: number;
-  step: number;
-  onChange: (v: number) => void;
-  displayValue?: string;
-  className?: string;
-  ariaLabel?: string;
-  size?: number;
-  disabled?: boolean;
-}) {
+export type NumericValueInputHandle = {
+  /** Commit a focused draft and return the resolved numeric value. */
+  commit: () => number;
+};
+
+export const NumericValueInput = forwardRef<
+  NumericValueInputHandle,
+  {
+    value: number;
+    min?: number;
+    max?: number;
+    step: number;
+    onChange: (v: number) => void;
+    displayValue?: string;
+    className?: string;
+    ariaLabel?: string;
+    size?: number;
+    disabled?: boolean;
+  }
+>(function NumericValueInput(
+  {
+    value,
+    min,
+    max,
+    step,
+    onChange,
+    displayValue,
+    className,
+    ariaLabel,
+    size: sizeAttr,
+    disabled = false,
+  },
+  ref,
+) {
   const [focused, setFocused] = useState(false);
   const [draft, setDraft] = useState("");
   const cancelBlurCommitRef = useRef(false);
 
-  const commit = (raw: string) => {
+  const commitDraft = (raw: string): number => {
     const parsed = Number.parseFloat(raw);
     if (!Number.isFinite(parsed)) {
-      return;
+      return value;
     }
     const final = snapToStep(parsed, step, min, max);
     if (final !== value) {
       onChange(final);
     }
+    return final;
   };
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      commit: () => {
+        if (!focused) {
+          return value;
+        }
+        const final = commitDraft(draft);
+        setFocused(false);
+        return final;
+      },
+    }),
+    [draft, focused, max, min, onChange, step, value],
+  );
 
   const displayed = focused ? draft : (displayValue ?? String(value));
 
@@ -91,7 +118,7 @@ export function NumericValueInput({
         if (cancelBlurCommitRef.current) {
           cancelBlurCommitRef.current = false;
         } else {
-          commit(draft);
+          commitDraft(draft);
         }
         setFocused(false);
       }}
@@ -110,4 +137,4 @@ export function NumericValueInput({
       className={cn(className)}
     />
   );
-}
+});

--- a/studio/frontend/src/features/model-picker/index.ts
+++ b/studio/frontend/src/features/model-picker/index.ts
@@ -12,6 +12,7 @@ export {
 export { hfModelFitsDevice } from "./components/model-selector/recommended-fit";
 export {
   NumericValueInput,
+  type NumericValueInputHandle,
   snapToStep,
 } from "./components/numeric-value-input";
 export { SidebarModelConfig } from "./components/sidebar-model-config";

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -316,11 +316,26 @@ def test_reset_persists_null_max_length_and_substitutes_only_for_load():
     src = _read("features/model-picker/components/model-config-page.tsx")
     # Load-only substitution of the resolved value.
     assert "maxSeqLength: maxSeqLengthValue" in src
-    assert "const loadConfig" in src
-    # The persisted record is loaded via onRun(loadConfig), and save uses the
-    # untouched runtimeConfig (so a reset/default config stays default).
-    assert "onRun(loadConfig)" in src
+    assert "const effectiveLoadConfig" in src
+    # The persisted record is saved from effectiveRuntimeConfig; the load request
+    # carries effectiveLoadConfig (with any committed context input).
+    assert "onRun(effectiveLoadConfig)" in src
     assert "savePerModelConfig(" in src
+
+
+def test_initial_load_uses_staged_config_payload():
+    """Run-settings Load must pass the staged config through to /load even when
+    React has not flushed NumericValueInput blur commits into the store yet."""
+    runtime = _read("features/chat/hooks/use-chat-model-runtime.ts")
+    assert "const pendingLoadConfig =" in runtime
+    assert "pendingLoadConfig?.kvCacheDtype" in runtime
+    assert "pendingLoadConfig?.customContextLength" in runtime
+    page = _read("features/model-picker/components/model-config-page.tsx")
+    assert "contextInputRef" in page
+    assert "contextInputRef.current?.commit()" in page
+    numeric = _read("features/model-picker/components/numeric-value-input.tsx")
+    assert "export type NumericValueInputHandle" in numeric
+    assert "commit:" in numeric
 
 
 def test_reset_enabled_for_explicit_context_pin_at_native():


### PR DESCRIPTION
Fixes #7346

## Problem

Opening **Configure run settings** (gear icon) before loading a model and clicking **Load model** ignored Context Length and KV Cache Dtype:

1. **Context Length** — `NumericValueInput` only commits on blur. Clicking Load before tabbing out could send the old/default value (e.g. 4096).
2. **KV cache & other knobs** — `performLoad` read from the runtime store, not the staged `selection.config` from the run-settings page.

## Fix

- `numeric-value-input.tsx` — add `NumericValueInputHandle.commit()` to flush a focused draft synchronously
- `model-config-page.tsx` — commit context input on Load, pass `effectiveLoadConfig` (incl. KV cache dtype) to `onRun`
- `use-chat-model-runtime.ts` — `performLoad` prefers `selection.config` for load knobs; preserve staged config when switching models
- `chat-page.tsx` — preserve `meta.forceReload` from the config-page reload path

## Verification

```bash
pytest tests/studio/test_model_picker_contracts.py -q
cd studio/frontend && npm run typecheck
```

- [x] `test_model_picker_contracts.py` — 32 passed
- [x] `npm run typecheck` — clean
- [ ] Manual: gear icon → set context + KV dtype → Load model without blurring context field → settings apply on first load