### PR TITLE
Uninstall: remove WebView runtime data so reinstalls don't serve a stale frontend

### DIFF
--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -404,12 +404,21 @@ Environment:
     _StopStudioProcesses -KnownRoots $knownRoots
     # App and the WebView2 helpers holding its profile open must both exit before the EBWebView delete below.
     $webviewProfile = if ($env:LOCALAPPDATA) { Join-Path $env:LOCALAPPDATA "ai.unsloth.studio" } else { $null }
-    # Session-scoped, like every other kill here: the NSIS installMode is currentUser, so each
-    # user has their own copy, and an elevated run would otherwise stop another logged-in user's
-    # app. UAC elevation keeps our session, so our own instance still matches.
-    $mySession = (Get-Process -Id $PID).SessionId
-    $studioPids = @(Get-Process -Name "unsloth-studio" -ErrorAction SilentlyContinue |
-        Where-Object { $_.SessionId -eq $mySession } | ForEach-Object { $_.Id })
+    # Account-scoped, like every other kill here. installMode is currentUser, so the profile
+    # removed below is this account's and is shared by all of its sessions: a second console or
+    # RDS session of the same user must die too or it re-creates the profile mid-delete, while
+    # another user's Studio must not be touched. SIDs, so domain and locale do not matter; an
+    # owner we cannot read is skipped, and Stop-Process could not have touched it either.
+    $meSid = try { [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value } catch { $null }
+    $studioPids = @()
+    if ($meSid) {
+        try {
+            foreach ($sp in (Get-CimInstance Win32_Process -Filter "Name = 'unsloth-studio.exe'" -ErrorAction SilentlyContinue)) {
+                $spSid = try { (Invoke-CimMethod -InputObject $sp -MethodName GetOwnerSid -ErrorAction SilentlyContinue).Sid } catch { $null }
+                if ($spSid -eq $meSid) { $studioPids += [int]$sp.ProcessId }
+            }
+        } catch { }
+    }
     if ($webviewProfile) {
         # Unescaped "[" is a wildcard class: would miss our own profile and match others.
         # Trailing \ spares "<bid>2\EBWebView".

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -126,7 +126,16 @@ Environment:
         if ($hadDb) {
             try {
                 $dbItem = Get-Item -LiteralPath $dbPath -Force -ErrorAction SilentlyContinue
-                if ($dbItem -and $dbItem.Target) { $dbPath = @($dbItem.Target)[0] }
+                if ($dbItem -and $dbItem.Target) {
+                    $t = @($dbItem.Target)[0]
+                    # Target can be relative ("..\data\studio.db"). Anchor it to the
+                    # link's own directory, or the post-delete Test-Path resolves it
+                    # against the uninstaller's working directory and always reads absent.
+                    if (-not [System.IO.Path]::IsPathRooted($t)) {
+                        $t = Join-Path (Split-Path -LiteralPath $dbItem.FullName -Parent) $t
+                    }
+                    $dbPath = $t
+                }
             } catch { }
         }
         _RemovePath $Path
@@ -746,7 +755,9 @@ Environment:
         # No studio.db was deleted, so only the WebView-local data is accounted for.
         # Claiming the keys and history are gone would be false for an env-mode install
         # whose root this run never discovered.
-        Write-Host "Note: this also removed the app's WebView data, so the signed-in session is gone."
+        Write-Host "Note: this also removed the app's WebView data, so the desktop app's session"
+        Write-Host "      is gone. A browser session is not affected: its tokens live in the same"
+        Write-Host "      localStorage as the API keys below."
         Write-Host "      No studio.db was found, so any chat history in an install root this run"
         Write-Host "      did not see is still on disk."
     }

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -479,6 +479,10 @@ Environment:
     foreach ($r in $customRoots) {
         if (_IsUnsafeRoot $r) {
             _Substep "refusing to remove unsafe path: $r" "Yellow"
+            # install.ps1 accepts any writable root, so this can be a real install under a
+            # path the deny list covers. Nothing is deleted and it holds studio.db and the
+            # auth data, so the summary must say so. Mirrors uninstall.sh.
+            if (Test-Path -LiteralPath $r) { $script:RemoveFailed = $true }
             continue
         }
         if (-not (_IsStudioRoot $r)) {

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -402,18 +402,18 @@ Environment:
         _StopByPortFile -PortFile (Join-Path $r "share\studio.port") -KnownRoots $knownRoots
     }
     _StopStudioProcesses -KnownRoots $knownRoots
-    # Desktop app plus the WebView2 helpers holding its profile open: both must
-    # exit before the EBWebView dirs are deleted further down.
+    # The app and the WebView2 helpers holding its profile open must both exit
+    # before the EBWebView dirs are deleted below.
     $webviewProfile = if ($env:LOCALAPPDATA) { Join-Path $env:LOCALAPPDATA "ai.unsloth.studio" } else { $null }
     $studioPids = @(Get-Process -Name "unsloth-studio" -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
     if ($webviewProfile) {
-        # Escape: an unescaped "[" is a wildcard class, so the helper misses its
-        # own profile and matches others. Trailing \ spares "<bid>2\EBWebView".
+        # Unescaped "[" is a wildcard class: the helper would miss its own
+        # profile and match others. Trailing \ spares "<bid>2\EBWebView".
         $pattern = "*" + [System.Management.Automation.WildcardPattern]::Escape($webviewProfile) + "\*"
         try {
             foreach ($proc in (Get-CimInstance Win32_Process -Filter "Name = 'msedgewebview2.exe'" -ErrorAction SilentlyContinue)) {
-                # CommandLine is null across an elevation boundary: fall back to
-                # the parent chain rather than skipping the helper.
+                # CommandLine is null across an elevation boundary: fall back
+                # to the parent chain.
                 $mine = if ($proc.CommandLine) { $proc.CommandLine -ilike $pattern }
                         else { $studioPids -contains [int]$proc.ParentProcessId }
                 if ($mine) { try { Stop-Process -Id $proc.ProcessId -Force -ErrorAction SilentlyContinue } catch { } }
@@ -522,9 +522,9 @@ Environment:
         _RemovePath $defaultUnslothHome
     }
 
-    # Bundle-id runtime data, created at first app launch rather than by
-    # install.ps1: LOCALAPPDATA holds the EBWebView profile (a leftover copy
-    # serves a stale frontend), APPDATA the app config dir. Already stopped above.
+    # Runtime data, created at first app launch rather than by install.ps1:
+    # LOCALAPPDATA holds the EBWebView profile (a leftover copy serves a stale
+    # frontend), APPDATA the app config dir.
     _Step "Removing WebView caches and app data (ai.unsloth.studio)..."
     if ($env:LOCALAPPDATA) { _RemovePath (Join-Path $env:LOCALAPPDATA "ai.unsloth.studio") }
     if ($env:APPDATA) { _RemovePath (Join-Path $env:APPDATA "ai.unsloth.studio") }

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -402,20 +402,18 @@ Environment:
         _StopByPortFile -PortFile (Join-Path $r "share\studio.port") -KnownRoots $knownRoots
     }
     _StopStudioProcesses -KnownRoots $knownRoots
-    # Tauri desktop app and the WebView2 helpers holding its profile open. Both
-    # must exit before the EBWebView dirs are deleted below, so this belongs in
-    # the stop phase rather than next to the delete.
+    # Desktop app plus the WebView2 helpers holding its profile open: both must
+    # exit before the EBWebView dirs are deleted further down.
     $webviewProfile = if ($env:LOCALAPPDATA) { Join-Path $env:LOCALAPPDATA "ai.unsloth.studio" } else { $null }
     $studioPids = @(Get-Process -Name "unsloth-studio" -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
     if ($webviewProfile) {
-        # Escape the path: unescaped, a "[" in it is a wildcard character class,
-        # so the helper misses its own profile and can match an unrelated one.
-        # The trailing separator keeps "<id>2\EBWebView" from matching "<id>".
+        # Escape: an unescaped "[" is a wildcard class, so the helper misses its
+        # own profile and matches others. Trailing \ spares "<bid>2\EBWebView".
         $pattern = "*" + [System.Management.Automation.WildcardPattern]::Escape($webviewProfile) + "\*"
         try {
             foreach ($proc in (Get-CimInstance Win32_Process -Filter "Name = 'msedgewebview2.exe'" -ErrorAction SilentlyContinue)) {
-                # CommandLine reads back null across an elevation boundary, so
-                # fall back to the parent chain instead of skipping the helper.
+                # CommandLine is null across an elevation boundary: fall back to
+                # the parent chain rather than skipping the helper.
                 $mine = if ($proc.CommandLine) { $proc.CommandLine -ilike $pattern }
                         else { $studioPids -contains [int]$proc.ParentProcessId }
                 if ($mine) { try { Stop-Process -Id $proc.ProcessId -Force -ErrorAction SilentlyContinue } catch { } }
@@ -524,11 +522,9 @@ Environment:
         _RemovePath $defaultUnslothHome
     }
 
-    # WebView2/app runtime data keyed by the bundle id, created at first
-    # desktop-app launch rather than by install.ps1: LOCALAPPDATA holds the
-    # EBWebView profile whose leftover copy serves a stale frontend to the next
-    # install, APPDATA the app config dir. The processes holding these were
-    # stopped in the stop phase above.
+    # Bundle-id runtime data, created at first app launch rather than by
+    # install.ps1: LOCALAPPDATA holds the EBWebView profile (a leftover copy
+    # serves a stale frontend), APPDATA the app config dir. Already stopped above.
     _Step "Removing WebView caches and app data (ai.unsloth.studio)..."
     if ($env:LOCALAPPDATA) { _RemovePath (Join-Path $env:LOCALAPPDATA "ai.unsloth.studio") }
     if ($env:APPDATA) { _RemovePath (Join-Path $env:APPDATA "ai.unsloth.studio") }

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -103,11 +103,29 @@ Environment:
     # root, so an env-mode install keeps it inside the custom root. A bare run with neither
     # variable set cannot discover that root, so the summary must not claim the history is
     # gone unless a database was really deleted.
-    function _NoteStudioDb {
+    # Remove an install root and record whether its studio.db really went with it. The
+    # check runs on the RESOLVED target: a relocated install (a directory junction or
+    # symlink to another disk) satisfies the before-check through the link, but the delete
+    # unlinks the reparse point and leaves the target intact, and afterwards the link is
+    # gone so the original path stops resolving and reads as absent either way.
+    # Verifying rather than chasing the link is deliberate: following a reparse point out
+    # of the expected location to delete its target is what the deny list exists to stop.
+    function _RemoveRootRecordingDb {
         param([string]$Path)
         if ([string]::IsNullOrWhiteSpace($Path)) { return }
-        if (Test-Path -LiteralPath (Join-Path $Path "studio.db") -PathType Leaf) {
-            $script:StudioDbRemoved = $true
+        $real = $Path
+        try {
+            $item = Get-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
+            if ($item -and $item.Target) { $real = @($item.Target)[0] }
+        } catch { }
+        $hadDb = Test-Path -LiteralPath (Join-Path $real "studio.db") -PathType Leaf
+        _RemovePath $Path
+        if ($hadDb) {
+            if (Test-Path -LiteralPath (Join-Path $real "studio.db") -PathType Leaf) {
+                $script:RemoveFailed = $true
+            } else {
+                $script:StudioDbRemoved = $true
+            }
         }
     }
 
@@ -533,8 +551,7 @@ Environment:
             _Substep "refusing to remove non-Unsloth path: $r" "Yellow"
             continue
         }
-        _NoteStudioDb $r
-        _RemovePath $r
+        _RemoveRootRecordingDb $r
         # Native diffusion (stable-diffusion.cpp) for a custom/env-mode Studio installs beside
         # the root at <parent>\stable-diffusion.cpp -- find_sd_cpp_binary resolves it from
         # UNSLOTH_STUDIO_HOME.parent (sd_cpp_engine.py) -- so removing only the root leaves the
@@ -552,7 +569,7 @@ Environment:
         }
     }
     # Default install dir (always at %USERPROFILE%\.unsloth\studio when present).
-    if ($defaultStudioHome) { _NoteStudioDb $defaultStudioHome; _RemovePath $defaultStudioHome }
+    if ($defaultStudioHome) { _RemoveRootRecordingDb $defaultStudioHome }
     # Default data dir.
     if ($defaultDataDir) { _RemoveDataDirKeepingWslIcon $defaultDataDir }
     # Default-mode shared llama.cpp build + cache (siblings of studio under

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -10,6 +10,13 @@
 function Uninstall-UnslothStudio {
     $ErrorActionPreference = "Continue"
 
+    # Reset both summary flags at entry. The documented form is `irm ... | iex`, which
+    # defines this function in the caller's session, so a second run in the same window
+    # would otherwise inherit the first run's state: a past failure would keep reporting
+    # failure, and a past studio.db removal would claim the keys and history are gone.
+    $script:RemoveFailed = $false
+    $script:StudioDbRemoved = $false
+
     function _Usage {
         Write-Host @'
 Unsloth Studio uninstaller (Windows PowerShell).
@@ -441,10 +448,33 @@ Environment:
         # Trailing \ spares "<bid>2\EBWebView".
         $pattern = "*" + [System.Management.Automation.WildcardPattern]::Escape($webviewProfile) + "\*"
         try {
-            foreach ($proc in (Get-CimInstance Win32_Process -Filter "Name = 'msedgewebview2.exe'" -ErrorAction SilentlyContinue)) {
+            $wvProcs = @(Get-CimInstance Win32_Process -Filter "Name = 'msedgewebview2.exe'" -ErrorAction SilentlyContinue)
+            # Parent lookup for the ancestor walk below. Built from the WebView2 processes
+            # themselves, which is all the chain ever passes through.
+            $parentOf = @{}
+            foreach ($p in $wvProcs) { $parentOf[[int]$p.ProcessId] = [int]$p.ParentProcessId }
+            # WebView2 is Chromium's process model: one browser process per host app, and the
+            # renderer, GPU and utility helpers are children of THAT browser process, not of
+            # unsloth-studio.exe. Checking only the immediate parent therefore matches the
+            # browser and misses every helper, and Stop-Process is not recursive, so the
+            # helpers keep files under EBWebView locked until _RemovePath gives up.
+            # Depth-capped so a PID-reuse cycle cannot spin here.
+            $isOurs = {
+                param($StartPid)
+                $cur = $StartPid
+                for ($hop = 0; $hop -lt 12; $hop++) {
+                    if (-not $parentOf.ContainsKey($cur)) { return $false }
+                    $parent = $parentOf[$cur]
+                    if ($studioPids -contains $parent) { return $true }
+                    if ($parent -eq $cur -or $parent -le 0) { return $false }
+                    $cur = $parent
+                }
+                return $false
+            }
+            foreach ($proc in $wvProcs) {
                 # CommandLine is null across an elevation boundary: fall back to the parent chain.
                 $mine = if ($proc.CommandLine) { $proc.CommandLine -ilike $pattern }
-                        else { $studioPids -contains [int]$proc.ParentProcessId }
+                        else { & $isOurs ([int]$proc.ProcessId) }
                 if ($mine) { try { Stop-Process -Id $proc.ProcessId -Force -ErrorAction SilentlyContinue } catch { } }
             }
         } catch { }
@@ -561,8 +591,24 @@ Environment:
     # Runtime data, created at first launch rather than by install.ps1: LOCALAPPDATA holds the
     # EBWebView profile (a leftover copy serves a stale frontend), APPDATA the app config dir.
     _Step "Removing WebView caches and app data (ai.unsloth.studio)..."
-    if ($env:LOCALAPPDATA) { _RemovePath (Join-Path $env:LOCALAPPDATA "ai.unsloth.studio") }
-    if ($env:APPDATA) { _RemovePath (Join-Path $env:APPDATA "ai.unsloth.studio") }
+    # Fall back to the known folder when the variable is missing (service and CI contexts
+    # drop them), and count an unresolvable one as incomplete cleanup: silently skipping it
+    # would leave the profile on disk while the summary reports the session as gone.
+    foreach ($known in @(
+        @{ Var = $env:LOCALAPPDATA; Folder = 'LocalApplicationData' },
+        @{ Var = $env:APPDATA;      Folder = 'ApplicationData' }
+    )) {
+        $base = $known.Var
+        if ([string]::IsNullOrWhiteSpace($base)) {
+            $base = try { [Environment]::GetFolderPath($known.Folder) } catch { $null }
+        }
+        if ([string]::IsNullOrWhiteSpace($base)) {
+            _Substep "could not resolve $($known.Folder); WebView data may remain" "Yellow"
+            $script:RemoveFailed = $true
+            continue
+        }
+        _RemovePath (Join-Path $base "ai.unsloth.studio")
+    }
 
     # ── Remove desktop and Start Menu shortcuts ──
     _Step "Removing desktop and Start Menu shortcuts..."

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -62,6 +62,8 @@ Environment:
             } catch {
                 if ($attempt -lt 4) { Start-Sleep -Milliseconds 700; continue }
                 _Substep "could not remove: $Path ($($_.Exception.Message))" "Yellow"
+                # Read by the closing summary, which must not promise the data is gone.
+                $script:RemoveFailed = $true
                 return
             }
             # Remove-Item -Recurse can report success yet leave a transiently-locked
@@ -73,6 +75,7 @@ Environment:
             }
             if ($attempt -lt 4) { Start-Sleep -Milliseconds 700; continue }
             _Substep "still present (files held open): $Path" "Yellow"
+            $script:RemoveFailed = $true
         }
     }
 
@@ -626,8 +629,14 @@ Environment:
 
     Write-Host ""
     Write-Host "Unsloth Studio uninstalled."
-    Write-Host "Note: this also removed the app's WebView data, so the signed-in session,"
-    Write-Host "      saved provider API keys and local chat history are gone."
+    if ($script:RemoveFailed) {
+        Write-Host "Note: some paths could not be removed (see 'could not remove:' above), so the"
+        Write-Host "      signed-in session, saved provider API keys and local chat history may"
+        Write-Host "      still be on disk. Remove those paths by hand to clear them."
+    } else {
+        Write-Host "Note: this also removed the app's WebView data, so the signed-in session,"
+        Write-Host "      saved provider API keys and local chat history are gone."
+    }
     Write-Host "Note: Hugging Face model cache at %USERPROFILE%\.cache\huggingface was left in place."
     Write-Host "Remove it manually with 'Remove-Item -Recurse -Force `"$env:USERPROFILE\.cache\huggingface\hub`"' if desired."
     if (-not $env:UNSLOTH_STUDIO_HOME -and -not $env:STUDIO_HOME) {

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -79,6 +79,20 @@ Environment:
         }
     }
 
+    # Record whether the install root about to be removed carries a studio.db. That file
+    # holds chat_threads/chat_messages and the saved provider keys (backend/storage/
+    # studio_db.py, providers_db.py, both via studio_root()) and lives under the install
+    # root, so an env-mode install keeps it inside the custom root. A bare run with neither
+    # variable set cannot discover that root, so the summary must not claim the history is
+    # gone unless a database was really deleted.
+    function _NoteStudioDb {
+        param([string]$Path)
+        if ([string]::IsNullOrWhiteSpace($Path)) { return }
+        if (Test-Path -LiteralPath (Join-Path $Path "studio.db") -PathType Leaf) {
+            $script:StudioDbRemoved = $true
+        }
+    }
+
     # Remove the shared data dir, but keep unsloth.ico if a WSL shortcut still points
     # at it (else that shortcut blanks); uninstall.sh drops it when WSL is removed.
     function _RemoveDataDirKeepingWslIcon {
@@ -471,6 +485,7 @@ Environment:
             _Substep "refusing to remove non-Unsloth path: $r" "Yellow"
             continue
         }
+        _NoteStudioDb $r
         _RemovePath $r
         # Native diffusion (stable-diffusion.cpp) for a custom/env-mode Studio installs beside
         # the root at <parent>\stable-diffusion.cpp -- find_sd_cpp_binary resolves it from
@@ -489,7 +504,7 @@ Environment:
         }
     }
     # Default install dir (always at %USERPROFILE%\.unsloth\studio when present).
-    if ($defaultStudioHome) { _RemovePath $defaultStudioHome }
+    if ($defaultStudioHome) { _NoteStudioDb $defaultStudioHome; _RemovePath $defaultStudioHome }
     # Default data dir.
     if ($defaultDataDir) { _RemoveDataDirKeepingWslIcon $defaultDataDir }
     # Default-mode shared llama.cpp build + cache (siblings of studio under
@@ -633,9 +648,16 @@ Environment:
         Write-Host "Note: some paths could not be removed (see 'could not remove:' above), so the"
         Write-Host "      signed-in session, saved provider API keys and local chat history may"
         Write-Host "      still be on disk. Remove those paths by hand to clear them."
+    } elseif ($script:StudioDbRemoved) {
+        Write-Host "Note: this also removed the app's WebView data and studio.db, so the signed-in"
+        Write-Host "      session, saved provider API keys and local chat history are gone."
     } else {
-        Write-Host "Note: this also removed the app's WebView data, so the signed-in session,"
-        Write-Host "      saved provider API keys and local chat history are gone."
+        # No studio.db was deleted, so only the WebView-local data is accounted for.
+        # Claiming the keys and history are gone would be false for an env-mode install
+        # whose root this run never discovered.
+        Write-Host "Note: this also removed the app's WebView data, so the signed-in session is gone."
+        Write-Host "      No studio.db was found, so any saved provider API keys and chat history in"
+        Write-Host "      an install root this run did not see are still on disk."
     }
     Write-Host "Note: Hugging Face model cache at %USERPROFILE%\.cache\huggingface was left in place."
     Write-Host "Remove it manually with 'Remove-Item -Recurse -Force `"$env:USERPROFILE\.cache\huggingface\hub`"' if desired."

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -402,18 +402,16 @@ Environment:
         _StopByPortFile -PortFile (Join-Path $r "share\studio.port") -KnownRoots $knownRoots
     }
     _StopStudioProcesses -KnownRoots $knownRoots
-    # The app and the WebView2 helpers holding its profile open must both exit
-    # before the EBWebView dirs are deleted below.
+    # App and the WebView2 helpers holding its profile open must both exit before the EBWebView delete below.
     $webviewProfile = if ($env:LOCALAPPDATA) { Join-Path $env:LOCALAPPDATA "ai.unsloth.studio" } else { $null }
     $studioPids = @(Get-Process -Name "unsloth-studio" -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
     if ($webviewProfile) {
-        # Unescaped "[" is a wildcard class: the helper would miss its own
-        # profile and match others. Trailing \ spares "<bid>2\EBWebView".
+        # Unescaped "[" is a wildcard class: would miss our own profile and match others.
+        # Trailing \ spares "<bid>2\EBWebView".
         $pattern = "*" + [System.Management.Automation.WildcardPattern]::Escape($webviewProfile) + "\*"
         try {
             foreach ($proc in (Get-CimInstance Win32_Process -Filter "Name = 'msedgewebview2.exe'" -ErrorAction SilentlyContinue)) {
-                # CommandLine is null across an elevation boundary: fall back
-                # to the parent chain.
+                # CommandLine is null across an elevation boundary: fall back to the parent chain.
                 $mine = if ($proc.CommandLine) { $proc.CommandLine -ilike $pattern }
                         else { $studioPids -contains [int]$proc.ParentProcessId }
                 if ($mine) { try { Stop-Process -Id $proc.ProcessId -Force -ErrorAction SilentlyContinue } catch { } }
@@ -522,9 +520,8 @@ Environment:
         _RemovePath $defaultUnslothHome
     }
 
-    # Runtime data, created at first app launch rather than by install.ps1:
-    # LOCALAPPDATA holds the EBWebView profile (a leftover copy serves a stale
-    # frontend), APPDATA the app config dir.
+    # Runtime data, created at first launch rather than by install.ps1: LOCALAPPDATA holds the
+    # EBWebView profile (a leftover copy serves a stale frontend), APPDATA the app config dir.
     _Step "Removing WebView caches and app data (ai.unsloth.studio)..."
     if ($env:LOCALAPPDATA) { _RemovePath (Join-Path $env:LOCALAPPDATA "ai.unsloth.studio") }
     if ($env:APPDATA) { _RemovePath (Join-Path $env:APPDATA "ai.unsloth.studio") }

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -488,7 +488,13 @@ Environment:
     $studioPids = @()
     if ($meSid) {
         try {
-            foreach ($sp in (Get-CimInstance Win32_Process -Filter "Name = 'unsloth-studio.exe'" -ErrorAction SilentlyContinue)) {
+            # Unsloth.exe as well: older releases used the product name as MAINBINARYNAME
+            # (installer.nsi migrates away from it, so an install predating that rename
+            # still runs it). The uninstaller is always fetched fresh from main, so an old
+            # install meets this script, and a missed process re-creates the profile we
+            # just deleted. The owner-SID filter below keeps the broader name safe.
+            $filter = "Name = 'unsloth-studio.exe' OR Name = 'Unsloth.exe'"
+            foreach ($sp in (Get-CimInstance Win32_Process -Filter $filter -ErrorAction SilentlyContinue)) {
                 $spSid = try { (Invoke-CimMethod -InputObject $sp -MethodName GetOwnerSid -ErrorAction SilentlyContinue).Sid } catch { $null }
                 if ($spSid -eq $meSid) { $studioPids += [int]$sp.ProcessId }
             }

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -98,8 +98,9 @@ Environment:
     }
 
     # Record whether the install root about to be removed carries a studio.db. That file
-    # holds chat_threads/chat_messages and the saved provider keys (backend/storage/
-    # studio_db.py, providers_db.py, both via studio_root()) and lives under the install
+    # holds chat_threads/chat_messages (backend/storage/studio_db.py via studio_root()).
+    # Not the provider API keys: providers_db.py says they "live only in the browser
+    # (localStorage) and are sent encrypted per-request". studio.db lives under the install
     # root, so an env-mode install keeps it inside the custom root. A bare run with neither
     # variable set cannot discover that root, so the summary must not claim the history is
     # gone unless a database was really deleted.
@@ -724,22 +725,25 @@ Environment:
     Write-Host "Unsloth Studio uninstalled."
     if ($script:RemoveFailed) {
         Write-Host "Note: some paths could not be removed (see 'could not remove:' above), so the"
-        Write-Host "      signed-in session, saved provider API keys and local chat history may"
-        Write-Host "      still be on disk. Remove those paths by hand to clear them."
+        Write-Host "      signed-in session and local chat history may still be on disk. Remove"
+        Write-Host "      those paths by hand to clear them."
     } elseif ($script:StudioDbRemoved) {
         # Scoped to what was removed: a default and an env-mode install can coexist, and
         # with neither variable set the custom root is never discovered.
         Write-Host "Note: this also removed the app's WebView data and the studio.db it found, so"
-        Write-Host "      the signed-in session, saved provider API keys and chat history in the"
-        Write-Host "      install(s) removed above are gone."
+        Write-Host "      the desktop app's session and the chat history in the install(s) removed"
+        Write-Host "      above are gone."
     } else {
         # No studio.db was deleted, so only the WebView-local data is accounted for.
         # Claiming the keys and history are gone would be false for an env-mode install
         # whose root this run never discovered.
         Write-Host "Note: this also removed the app's WebView data, so the signed-in session is gone."
-        Write-Host "      No studio.db was found, so any saved provider API keys and chat history in"
-        Write-Host "      an install root this run did not see are still on disk."
+        Write-Host "      No studio.db was found, so any chat history in an install root this run"
+        Write-Host "      did not see is still on disk."
     }
+    Write-Host "Note: provider API keys are kept in the browser's localStorage, not in studio.db."
+    Write-Host "      Unless you ran Studio as the desktop app, clear site data for the"
+    Write-Host "      http://localhost:<port> origin you used to remove them."
     Write-Host "Note: Hugging Face model cache at %USERPROFILE%\.cache\huggingface was left in place."
     Write-Host "Remove it manually with 'Remove-Item -Recurse -Force `"$env:USERPROFILE\.cache\huggingface\hub`"' if desired."
     if (-not $env:UNSLOTH_STUDIO_HOME -and -not $env:STUDIO_HOME) {

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -402,6 +402,29 @@ Environment:
         _StopByPortFile -PortFile (Join-Path $r "share\studio.port") -KnownRoots $knownRoots
     }
     _StopStudioProcesses -KnownRoots $knownRoots
+    # Tauri desktop app and the WebView2 helpers holding its profile open. Both
+    # must exit before the EBWebView dirs are deleted below, so this belongs in
+    # the stop phase rather than next to the delete.
+    $webviewProfile = if ($env:LOCALAPPDATA) { Join-Path $env:LOCALAPPDATA "ai.unsloth.studio" } else { $null }
+    $studioPids = @(Get-Process -Name "unsloth-studio" -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
+    if ($webviewProfile) {
+        # Escape the path: unescaped, a "[" in it is a wildcard character class,
+        # so the helper misses its own profile and can match an unrelated one.
+        # The trailing separator keeps "<id>2\EBWebView" from matching "<id>".
+        $pattern = "*" + [System.Management.Automation.WildcardPattern]::Escape($webviewProfile) + "\*"
+        try {
+            foreach ($proc in (Get-CimInstance Win32_Process -Filter "Name = 'msedgewebview2.exe'" -ErrorAction SilentlyContinue)) {
+                # CommandLine reads back null across an elevation boundary, so
+                # fall back to the parent chain instead of skipping the helper.
+                $mine = if ($proc.CommandLine) { $proc.CommandLine -ilike $pattern }
+                        else { $studioPids -contains [int]$proc.ParentProcessId }
+                if ($mine) { try { Stop-Process -Id $proc.ProcessId -Force -ErrorAction SilentlyContinue } catch { } }
+            }
+        } catch { }
+    }
+    try { Stop-Process -Name "unsloth-studio" -Force -ErrorAction SilentlyContinue } catch { }
+    # WebView2 releases the profile only once its browser processes have exited.
+    if ($studioPids) { Wait-Process -Id $studioPids -Timeout 10 -ErrorAction SilentlyContinue }
     # Only stop the default sd.cpp dir when it carries our owner marker, so stop matches the
     # marker-gated delete and a user's own sd-server at this default path is left running.
     $defaultSdCppToStop = $null
@@ -501,6 +524,15 @@ Environment:
         _RemovePath $defaultUnslothHome
     }
 
+    # WebView2/app runtime data keyed by the bundle id, created at first
+    # desktop-app launch rather than by install.ps1: LOCALAPPDATA holds the
+    # EBWebView profile whose leftover copy serves a stale frontend to the next
+    # install, APPDATA the app config dir. The processes holding these were
+    # stopped in the stop phase above.
+    _Step "Removing WebView caches and app data (ai.unsloth.studio)..."
+    if ($env:LOCALAPPDATA) { _RemovePath (Join-Path $env:LOCALAPPDATA "ai.unsloth.studio") }
+    if ($env:APPDATA) { _RemovePath (Join-Path $env:APPDATA "ai.unsloth.studio") }
+
     # ── Remove desktop and Start Menu shortcuts ──
     _Step "Removing desktop and Start Menu shortcuts..."
     try {
@@ -585,6 +617,8 @@ Environment:
 
     Write-Host ""
     Write-Host "Unsloth Studio uninstalled."
+    Write-Host "Note: this also removed the app's WebView data, so the signed-in session,"
+    Write-Host "      saved provider API keys and local chat history are gone."
     Write-Host "Note: Hugging Face model cache at %USERPROFILE%\.cache\huggingface was left in place."
     Write-Host "Remove it manually with 'Remove-Item -Recurse -Force `"$env:USERPROFILE\.cache\huggingface\hub`"' if desired."
     if (-not $env:UNSLOTH_STUDIO_HOME -and -not $env:STUDIO_HOME) {

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -404,7 +404,12 @@ Environment:
     _StopStudioProcesses -KnownRoots $knownRoots
     # App and the WebView2 helpers holding its profile open must both exit before the EBWebView delete below.
     $webviewProfile = if ($env:LOCALAPPDATA) { Join-Path $env:LOCALAPPDATA "ai.unsloth.studio" } else { $null }
-    $studioPids = @(Get-Process -Name "unsloth-studio" -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
+    # Session-scoped, like every other kill here: the NSIS installMode is currentUser, so each
+    # user has their own copy, and an elevated run would otherwise stop another logged-in user's
+    # app. UAC elevation keeps our session, so our own instance still matches.
+    $mySession = (Get-Process -Id $PID).SessionId
+    $studioPids = @(Get-Process -Name "unsloth-studio" -ErrorAction SilentlyContinue |
+        Where-Object { $_.SessionId -eq $mySession } | ForEach-Object { $_.Id })
     if ($webviewProfile) {
         # Unescaped "[" is a wildcard class: would miss our own profile and match others.
         # Trailing \ spares "<bid>2\EBWebView".
@@ -418,9 +423,11 @@ Environment:
             }
         } catch { }
     }
-    try { Stop-Process -Name "unsloth-studio" -Force -ErrorAction SilentlyContinue } catch { }
-    # WebView2 releases the profile only once its browser processes have exited.
-    if ($studioPids) { Wait-Process -Id $studioPids -Timeout 10 -ErrorAction SilentlyContinue }
+    if ($studioPids) {
+        try { Stop-Process -Id $studioPids -Force -ErrorAction SilentlyContinue } catch { }
+        # WebView2 releases the profile only once its browser processes have exited.
+        Wait-Process -Id $studioPids -Timeout 10 -ErrorAction SilentlyContinue
+    }
     # Only stop the default sd.cpp dir when it carries our owner marker, so stop matches the
     # marker-gated delete and a user's own sd-server at this default path is left running.
     $defaultSdCppToStop = $null

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -10,10 +10,8 @@
 function Uninstall-UnslothStudio {
     $ErrorActionPreference = "Continue"
 
-    # Reset both summary flags at entry. The documented form is `irm ... | iex`, which
-    # defines this function in the caller's session, so a second run in the same window
-    # would otherwise inherit the first run's state: a past failure would keep reporting
-    # failure, and a past studio.db removal would claim the keys and history are gone.
+    # Reset at entry: `irm ... | iex` defines this function in the caller's session, so a
+    # second run in the same window would otherwise inherit the first run's flags.
     $script:RemoveFailed = $false
     $script:StudioDbRemoved = $false
 
@@ -69,7 +67,7 @@ Environment:
             } catch {
                 if ($attempt -lt 4) { Start-Sleep -Milliseconds 700; continue }
                 _Substep "could not remove: $Path ($($_.Exception.Message))" "Yellow"
-                # Read by the closing summary, which must not promise the data is gone.
+                # The closing summary must not promise the data is gone.
                 $script:RemoveFailed = $true
                 return
             }
@@ -86,9 +84,8 @@ Environment:
         }
     }
 
-    # LOCALAPPDATA / APPDATA are dropped in service and CI contexts. Fall back to the
-    # known folder so every consumer resolves the same directory; $null only when even
-    # that fails, which callers treat as incomplete cleanup.
+    # LOCALAPPDATA / APPDATA are dropped in service and CI contexts, so fall back to the known
+    # folder; $null only if that fails too, which callers treat as incomplete cleanup.
     function _AppDataRoot {
         param([string]$Var, [string]$Folder)
         if (-not [string]::IsNullOrWhiteSpace($Var)) { return $Var }
@@ -97,26 +94,20 @@ Environment:
         return $p
     }
 
-    # Record whether the install root about to be removed carries a studio.db. That file
-    # holds chat_threads/chat_messages (backend/storage/studio_db.py via studio_root()).
-    # Not the provider API keys: providers_db.py says they "live only in the browser
-    # (localStorage) and are sent encrypted per-request". studio.db lives under the install
-    # root, so an env-mode install keeps it inside the custom root. A bare run with neither
-    # variable set cannot discover that root, so the summary must not claim the history is
-    # gone unless a database was really deleted.
-    # Remove an install root and record whether its studio.db really went with it. The
-    # check runs on the RESOLVED target: a relocated install (a directory junction or
-    # symlink to another disk) satisfies the before-check through the link, but the delete
-    # unlinks the reparse point and leaves the target intact, and afterwards the link is
-    # gone so the original path stops resolving and reads as absent either way.
-    # Verifying rather than chasing the link is deliberate: following a reparse point out
-    # of the expected location to delete its target is what the deny list exists to stop.
+    # Remove an install root and record whether its studio.db really went with it. That file
+    # holds chat_threads/chat_messages (backend/storage/studio_db.py), not the provider API
+    # keys, which providers_db.py keeps in the browser's localStorage only. It sits under the
+    # install root, so an env-mode install keeps it in a custom root a bare run cannot find.
+    # The check runs on the RESOLVED target: a relocated install (junction or symlink to
+    # another disk) passes the before-check through the link, but the delete unlinks only the
+    # reparse point, and afterwards the path stops resolving and reads as absent either way.
+    # Verifying rather than chasing the link is deliberate: following a reparse point out of
+    # the expected location to delete its target is what the deny list exists to stop.
     function _RemoveRootRecordingDb {
         param([string]$Path)
         if ([string]::IsNullOrWhiteSpace($Path)) { return }
-        # Anchor a relative reparse-point target to the link's own parent. Same rule as
-        # the studio.db link below: assigned raw, Join-Path would resolve it from the
-        # uninstaller's working directory and the database test would read false.
+        # Anchor a relative reparse-point target to the link's own parent, or Join-Path
+        # resolves it from the uninstaller's working directory and the db test reads false.
         $resolveTarget = {
             param($Item, $Fallback)
             if (-not $Item -or -not $Item.Target) { return $Fallback }
@@ -132,8 +123,7 @@ Environment:
             $item = Get-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
             $real = & $resolveTarget $item $Path
         } catch { }
-        # The database itself can be a reparse point out of the tree, the same shape as
-        # the root: the delete unlinks the link and the target survives.
+        # The db itself can be a reparse point out of the tree: the target survives the delete.
         $dbPath = Join-Path $real "studio.db"
         $hadDb = Test-Path -LiteralPath $dbPath -PathType Leaf
         if ($hadDb) {
@@ -478,25 +468,22 @@ Environment:
         _StopByPortFile -PortFile (Join-Path $r "share\studio.port") -KnownRoots $knownRoots
     }
     _StopStudioProcesses -KnownRoots $knownRoots
-    # App and the WebView2 helpers holding its profile open must both exit before the EBWebView delete below.
-    # Same resolver as the removal below: resolving there but not here would skip the
-    # helper sweep for a profile we then try to delete, leaving helpers holding locks.
+    # The app and the WebView2 helpers holding its profile open must both exit before the
+    # EBWebView delete below. Same resolver as that removal, or the sweep misses the profile
+    # we then try to delete and the helpers keep holding locks.
     $localAppRoot = _AppDataRoot $env:LOCALAPPDATA 'LocalApplicationData'
     $webviewProfile = if ($localAppRoot) { Join-Path $localAppRoot "ai.unsloth.studio" } else { $null }
-    # Account-scoped, like every other kill here. installMode is currentUser, so the profile
-    # removed below is this account's and is shared by all of its sessions: a second console or
-    # RDS session of the same user must die too or it re-creates the profile mid-delete, while
-    # another user's Studio must not be touched. SIDs, so domain and locale do not matter; an
-    # owner we cannot read is skipped, and Stop-Process could not have touched it either.
+    # Account-scoped, like every other kill here. installMode is currentUser, so the profile is
+    # this account's and shared by all its sessions: a second console or RDS session must die
+    # too or it re-creates the profile mid-delete, while another user's Studio must not be
+    # touched. SIDs, so domain and locale do not matter; an unreadable owner is skipped.
     $meSid = try { [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value } catch { $null }
     $studioPids = @()
     if ($meSid) {
         try {
-            # Unsloth.exe as well: older releases used the product name as MAINBINARYNAME
-            # (installer.nsi migrates away from it, so an install predating that rename
-            # still runs it). The uninstaller is always fetched fresh from main, so an old
-            # install meets this script, and a missed process re-creates the profile we
-            # just deleted. The owner-SID filter below keeps the broader name safe.
+            # Unsloth.exe too: older releases used the product name as MAINBINARYNAME, and this
+            # script is always fetched fresh from main, so it meets those installs. A missed
+            # process re-creates the profile. The owner-SID filter keeps the broader name safe.
             $filter = "Name = 'unsloth-studio.exe' OR Name = 'Unsloth.exe'"
             foreach ($sp in (Get-CimInstance Win32_Process -Filter $filter -ErrorAction SilentlyContinue)) {
                 $spSid = try { (Invoke-CimMethod -InputObject $sp -MethodName GetOwnerSid -ErrorAction SilentlyContinue).Sid } catch { $null }
@@ -505,20 +492,17 @@ Environment:
         } catch { }
     }
     if ($webviewProfile) {
-        # Unescaped "[" is a wildcard class: would miss our own profile and match others.
-        # Trailing \ spares "<bid>2\EBWebView".
+        # Escape "[", a wildcard class, or we miss our profile and match others. Trailing \
+        # spares "<bid>2\EBWebView".
         $pattern = "*" + [System.Management.Automation.WildcardPattern]::Escape($webviewProfile) + "\*"
         try {
             $wvProcs = @(Get-CimInstance Win32_Process -Filter "Name = 'msedgewebview2.exe'" -ErrorAction SilentlyContinue)
-            # Parent lookup for the ancestor walk below. Built from the WebView2 processes
-            # themselves, which is all the chain ever passes through.
+            # Parent lookup for the ancestor walk; WebView2 procs are all the chain passes through.
             $parentOf = @{}
             foreach ($p in $wvProcs) { $parentOf[[int]$p.ProcessId] = [int]$p.ParentProcessId }
-            # WebView2 is Chromium's process model: one browser process per host app, and the
-            # renderer, GPU and utility helpers are children of THAT browser process, not of
-            # unsloth-studio.exe. Checking only the immediate parent therefore matches the
-            # browser and misses every helper, and Stop-Process is not recursive, so the
-            # helpers keep files under EBWebView locked until _RemovePath gives up.
+            # Chromium process model: the renderer, GPU and utility helpers are children of the
+            # browser process, not of unsloth-studio.exe, so an immediate-parent check misses
+            # them all and they keep EBWebView locked (Stop-Process is not recursive).
             # Depth-capped so a PID-reuse cycle cannot spin here.
             $isOurs = {
                 param($StartPid)
@@ -570,9 +554,8 @@ Environment:
     foreach ($r in $customRoots) {
         if (_IsUnsafeRoot $r) {
             _Substep "refusing to remove unsafe path: $r" "Yellow"
-            # install.ps1 accepts any writable root, so this can be a real install under a
-            # path the deny list covers. Nothing is deleted and it holds studio.db and the
-            # auth data, so the summary must say so. Mirrors uninstall.sh.
+            # install.ps1 accepts any writable root, so a real install can sit under a deny-listed
+            # path. Nothing is deleted and it holds studio.db, so say so. Mirrors uninstall.sh.
             if (Test-Path -LiteralPath $r) { $script:RemoveFailed = $true }
             continue
         }
@@ -651,9 +634,8 @@ Environment:
     # Runtime data, created at first launch rather than by install.ps1: LOCALAPPDATA holds the
     # EBWebView profile (a leftover copy serves a stale frontend), APPDATA the app config dir.
     _Step "Removing WebView caches and app data (ai.unsloth.studio)..."
-    # Fall back to the known folder when the variable is missing (service and CI contexts
-    # drop them), and count an unresolvable one as incomplete cleanup: silently skipping it
-    # would leave the profile on disk while the summary reports the session as gone.
+    # Count an unresolvable root as incomplete cleanup: skipping it silently would leave the
+    # profile on disk while the summary reports the session as gone.
     foreach ($known in @(
         @{ Var = $env:LOCALAPPDATA; Folder = 'LocalApplicationData' },
         @{ Var = $env:APPDATA;      Folder = 'ApplicationData' }
@@ -756,15 +738,13 @@ Environment:
         Write-Host "      signed-in session and local chat history may still be on disk. Remove"
         Write-Host "      those paths by hand to clear them."
     } elseif ($script:StudioDbRemoved) {
-        # Scoped to what was removed: a default and an env-mode install can coexist, and
-        # with neither variable set the custom root is never discovered.
+        # Scoped to what was removed: a bare run never discovers a coexisting env-mode root.
         Write-Host "Note: this also removed the app's WebView data and the studio.db it found, so"
         Write-Host "      the desktop app's session and the chat history in the install(s) removed"
         Write-Host "      above are gone."
     } else {
-        # No studio.db was deleted, so only the WebView-local data is accounted for.
-        # Claiming the keys and history are gone would be false for an env-mode install
-        # whose root this run never discovered.
+        # No studio.db was deleted, so only the WebView-local data is accounted for: an env-mode
+        # install this run never discovered still has its keys and history.
         Write-Host "Note: this also removed the app's WebView data, so the desktop app's session"
         Write-Host "      is gone. A browser session is not affected: its tokens live in the same"
         Write-Host "      localStorage as the API keys below."

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -114,10 +114,23 @@ Environment:
     function _RemoveRootRecordingDb {
         param([string]$Path)
         if ([string]::IsNullOrWhiteSpace($Path)) { return }
+        # Anchor a relative reparse-point target to the link's own parent. Same rule as
+        # the studio.db link below: assigned raw, Join-Path would resolve it from the
+        # uninstaller's working directory and the database test would read false.
+        $resolveTarget = {
+            param($Item, $Fallback)
+            if (-not $Item -or -not $Item.Target) { return $Fallback }
+            $t = @($Item.Target)[0]
+            if ([string]::IsNullOrWhiteSpace($t)) { return $Fallback }
+            if (-not [System.IO.Path]::IsPathRooted($t)) {
+                $t = Join-Path (Split-Path -LiteralPath $Item.FullName -Parent) $t
+            }
+            return $t
+        }
         $real = $Path
         try {
             $item = Get-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
-            if ($item -and $item.Target) { $real = @($item.Target)[0] }
+            $real = & $resolveTarget $item $Path
         } catch { }
         # The database itself can be a reparse point out of the tree, the same shape as
         # the root: the delete unlinks the link and the target survives.
@@ -126,16 +139,7 @@ Environment:
         if ($hadDb) {
             try {
                 $dbItem = Get-Item -LiteralPath $dbPath -Force -ErrorAction SilentlyContinue
-                if ($dbItem -and $dbItem.Target) {
-                    $t = @($dbItem.Target)[0]
-                    # Target can be relative ("..\data\studio.db"). Anchor it to the
-                    # link's own directory, or the post-delete Test-Path resolves it
-                    # against the uninstaller's working directory and always reads absent.
-                    if (-not [System.IO.Path]::IsPathRooted($t)) {
-                        $t = Join-Path (Split-Path -LiteralPath $dbItem.FullName -Parent) $t
-                    }
-                    $dbPath = $t
-                }
+                $dbPath = & $resolveTarget $dbItem $dbPath
             } catch { }
         }
         _RemovePath $Path

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -119,10 +119,19 @@ Environment:
             $item = Get-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
             if ($item -and $item.Target) { $real = @($item.Target)[0] }
         } catch { }
-        $hadDb = Test-Path -LiteralPath (Join-Path $real "studio.db") -PathType Leaf
+        # The database itself can be a reparse point out of the tree, the same shape as
+        # the root: the delete unlinks the link and the target survives.
+        $dbPath = Join-Path $real "studio.db"
+        $hadDb = Test-Path -LiteralPath $dbPath -PathType Leaf
+        if ($hadDb) {
+            try {
+                $dbItem = Get-Item -LiteralPath $dbPath -Force -ErrorAction SilentlyContinue
+                if ($dbItem -and $dbItem.Target) { $dbPath = @($dbItem.Target)[0] }
+            } catch { }
+        }
         _RemovePath $Path
         if ($hadDb) {
-            if (Test-Path -LiteralPath (Join-Path $real "studio.db") -PathType Leaf) {
+            if (Test-Path -LiteralPath $dbPath -PathType Leaf) {
                 $script:RemoveFailed = $true
             } else {
                 $script:StudioDbRemoved = $true

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -86,6 +86,17 @@ Environment:
         }
     }
 
+    # LOCALAPPDATA / APPDATA are dropped in service and CI contexts. Fall back to the
+    # known folder so every consumer resolves the same directory; $null only when even
+    # that fails, which callers treat as incomplete cleanup.
+    function _AppDataRoot {
+        param([string]$Var, [string]$Folder)
+        if (-not [string]::IsNullOrWhiteSpace($Var)) { return $Var }
+        $p = try { [Environment]::GetFolderPath($Folder) } catch { $null }
+        if ([string]::IsNullOrWhiteSpace($p)) { return $null }
+        return $p
+    }
+
     # Record whether the install root about to be removed carries a studio.db. That file
     # holds chat_threads/chat_messages and the saved provider keys (backend/storage/
     # studio_db.py, providers_db.py, both via studio_root()) and lives under the install
@@ -427,7 +438,10 @@ Environment:
     }
     _StopStudioProcesses -KnownRoots $knownRoots
     # App and the WebView2 helpers holding its profile open must both exit before the EBWebView delete below.
-    $webviewProfile = if ($env:LOCALAPPDATA) { Join-Path $env:LOCALAPPDATA "ai.unsloth.studio" } else { $null }
+    # Same resolver as the removal below: resolving there but not here would skip the
+    # helper sweep for a profile we then try to delete, leaving helpers holding locks.
+    $localAppRoot = _AppDataRoot $env:LOCALAPPDATA 'LocalApplicationData'
+    $webviewProfile = if ($localAppRoot) { Join-Path $localAppRoot "ai.unsloth.studio" } else { $null }
     # Account-scoped, like every other kill here. installMode is currentUser, so the profile
     # removed below is this account's and is shared by all of its sessions: a second console or
     # RDS session of the same user must die too or it re-creates the profile mid-delete, while
@@ -598,10 +612,7 @@ Environment:
         @{ Var = $env:LOCALAPPDATA; Folder = 'LocalApplicationData' },
         @{ Var = $env:APPDATA;      Folder = 'ApplicationData' }
     )) {
-        $base = $known.Var
-        if ([string]::IsNullOrWhiteSpace($base)) {
-            $base = try { [Environment]::GetFolderPath($known.Folder) } catch { $null }
-        }
+        $base = _AppDataRoot $known.Var $known.Folder
         if ([string]::IsNullOrWhiteSpace($base)) {
             _Substep "could not resolve $($known.Folder); WebView data may remain" "Yellow"
             $script:RemoveFailed = $true
@@ -699,8 +710,11 @@ Environment:
         Write-Host "      signed-in session, saved provider API keys and local chat history may"
         Write-Host "      still be on disk. Remove those paths by hand to clear them."
     } elseif ($script:StudioDbRemoved) {
-        Write-Host "Note: this also removed the app's WebView data and studio.db, so the signed-in"
-        Write-Host "      session, saved provider API keys and local chat history are gone."
+        # Scoped to what was removed: a default and an env-mode install can coexist, and
+        # with neither variable set the custom root is never discovered.
+        Write-Host "Note: this also removed the app's WebView data and the studio.db it found, so"
+        Write-Host "      the signed-in session, saved provider API keys and chat history in the"
+        Write-Host "      install(s) removed above are gone."
     } else {
         # No studio.db was deleted, so only the WebView-local data is accounted for.
         # Claiming the keys and history are gone would be false for an env-mode install

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -293,9 +293,21 @@ _remove_root_recording_db() {
         _rrd_had_db=1
         # The database itself can be a symlink out of the tree. -f follows it, but the
         # rm below unlinks the link and leaves the target, so track where the bytes are.
+        # readlink without -f: BSD readlink only gained -f in macOS 12.3, and there the
+        # GNU form fails, leaves the link path in place and the claim goes wrong again.
+        # The raw link text plus cd -P on its directory is portable to both.
         if [ -L "$_rrd_db" ]; then
-            _rrd_db_target=$(readlink -f "$_rrd_db" 2>/dev/null || true)
-            [ -n "$_rrd_db_target" ] && _rrd_db="$_rrd_db_target"
+            _rrd_link=$(readlink "$_rrd_db" 2>/dev/null || true)
+            if [ -n "$_rrd_link" ]; then
+                case "$_rrd_link" in
+                    /*) ;;
+                    *) _rrd_link="$(dirname "$_rrd_db")/$_rrd_link" ;;
+                esac
+                # shellcheck disable=SC1007
+                _rrd_ldir=$(CDPATH= cd -P -- "$(dirname "$_rrd_link")" 2>/dev/null && pwd -P) \
+                    || _rrd_ldir=""
+                [ -n "$_rrd_ldir" ] && _rrd_db="$_rrd_ldir/$(basename "$_rrd_link")"
+            fi
         fi
     fi
     _remove_path "$_rrd_root"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -219,6 +219,8 @@ _set_marker() {
     return 0
 }
 _marker_set() { [ -n "$1" ] && [ -f "$1" ]; }
+# No marker storage means no record of what failed, so the summary must not claim success.
+_markers_unavailable() { [ -z "$_MARKER_DIR" ]; }
 
 # EXIT, not a line at the end of main: --help returns early, an unknown argument exits
 # non-zero, and `set -e` can fire partway through, none of which would reach it.
@@ -688,13 +690,19 @@ _unsloth_uninstall_main() {
 
     echo ""
     echo "Unsloth Studio uninstalled."
-    if _marker_set "$_REMOVE_FAILED_FLAG"; then
+    if _markers_unavailable || _marker_set "$_REMOVE_FAILED_FLAG"; then
+        # Also the no-marker-storage case: without it a failed rm left no record, so
+        # reporting success would be a guess in the one direction that misleads.
         echo "Note: some paths could not be removed (see 'could not remove:' above), so the"
         echo "      signed-in session, saved provider API keys and local chat history may"
         echo "      still be on disk. Remove those paths by hand to clear them."
     elif _marker_set "$_DB_REMOVED_FLAG"; then
-        echo "Note: this also removed the app's WebView data and studio.db, so the signed-in"
-        echo "      session, saved provider API keys and local chat history are gone."
+        # Scoped to what was removed. A default and an env-mode install can coexist, and
+        # with neither variable exported the custom root is never discovered, so an
+        # unqualified "are gone" would be false for the database still sitting in it.
+        echo "Note: this also removed the app's WebView data and the studio.db it found, so"
+        echo "      the signed-in session, saved provider API keys and chat history in the"
+        echo "      install(s) removed above are gone."
     else
         # No studio.db was deleted, so only the WebView-local data is accounted for.
         # Claiming the keys and history are gone would be false for an env-mode install

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -101,18 +101,18 @@ _stop_owned_sd_cpp_processes() {
     done
 }
 
-# Numeric owner of $HOME, empty if it cannot be resolved. Not always the caller: macOS
-# ships `env_keep += "HOME MAIL"`, so sudo keeps the invoking user's home while euid is 0.
+# Numeric owner of $HOME, empty if unresolvable. Not always the caller: macOS sudo keeps
+# HOME (env_keep), so the home stays the invoking user's while euid is 0.
 _home_uid() {
-    # -L: both stats lstat by default, so a root-owned link to a user-owned home reads as 0.
+    # -L: stat lstats by default, so a root-owned link to a user home would read as uid 0.
     _hu=$(stat -L -c %u "$HOME" 2>/dev/null || stat -L -f %u "$HOME" 2>/dev/null || true)
     case "$_hu" in ''|*[!0-9]*) _hu=$(id -u 2>/dev/null || true) ;; esac
     case "$_hu" in *[!0-9]*) _hu= ;; esac
     printf '%s\n' "$_hu"
 }
 
-# Run "$@" as that owner when we are root and it is someone else, so per-user daemons see
-# the right domain. Plain "$@" otherwise, which is every non-elevated run.
+# Run "$@" as the $HOME owner when we are root and it is someone else, so per-user daemons
+# see the right domain. Plain "$@" otherwise, which is every non-elevated run.
 _run_as_home_owner() {
     _ro=$(_home_uid)
     if [ "$(id -u 2>/dev/null || echo 0)" = "0" ] && [ -n "$_ro" ] && [ "$_ro" != "0" ] &&
@@ -123,9 +123,8 @@ _run_as_home_owner() {
     fi
 }
 
-# Is the desktop app running? Only called when there is no pkill to ask, so it reads
-# /proc, the one process inventory such a system still has. Scoped to the owner of the
-# $HOME being cleared, matching the pkill -u call below.
+# Is the desktop app running? Only reached when there is no pkill to ask, so read /proc.
+# Scoped to the owner of the $HOME being cleared, matching the pkill -u call below.
 _studio_app_running() {
     [ -d /proc ] || return 1
     _sar_uid=$(_home_uid)
@@ -152,9 +151,8 @@ _pkill_studio() {
     done
 
     if ! command -v pkill >/dev/null 2>&1; then
-        # No procps. The PID-file sweep above is all we can do, and install.sh never
-        # requires pkill, so this is a real configuration. If the desktop app is still
-        # up, its WebView helpers re-create the profile right after we delete it, so
+        # No procps (install.sh never requires it): the PID sweep above is all we have.
+        # A live app's WebView helpers re-create the profile right after the delete, so
         # the removal is incomplete and the summary must not claim otherwise.
         if _studio_app_running; then
             echo "  pkill not found and Unsloth Studio is running; close it and re-run" >&2
@@ -205,10 +203,10 @@ $_roots_from_conf"
     _stop_owned_sd_cpp_processes KILL
 
     # The app's WebView helpers re-create the caches removed below, so it has to die here.
-    # -x is exact, so the "unsloth" CLI shim never matches. -u scopes to the owner of the
-    # $HOME being cleared, not the caller (macOS sudo keeps HOME), so a root run leaves other
-    # logged-in users alone. Numeric suits procps and BSD pkill; BSD reads the signal from
-    # argv[1] only, so it stays first. Unknown owner skips rather than signalling everyone.
+    # -x is exact, so the "unsloth" CLI shim never matches. -u takes the owner of the $HOME
+    # being cleared, not the caller (macOS sudo keeps HOME), so a root run spares other users;
+    # an unknown owner skips rather than signalling everyone. Numeric uid and signal-first
+    # suit BSD pkill, which reads the signal from argv[1] only.
     _studio_uid=$(_home_uid)
     if [ -n "$_studio_uid" ]; then
         pkill -TERM -x -u "$_studio_uid" unsloth-studio 2>/dev/null || true
@@ -217,20 +215,16 @@ $_roots_from_conf"
     fi
 }
 
-# Two pieces of state the closing summary needs, carried in files rather than variables:
-# custom roots are removed inside a pipeline subshell, where an assignment would never
-# reach the summary.
+# Summary state in files, not variables: custom roots are removed inside a pipeline
+# subshell, where an assignment would never reach the summary.
 #   remove-failed  an rm failed, or a root was skipped while still holding data
 #   db-removed     a removed install root actually held studio.db
-# studio.db is what holds chat_threads/chat_messages (backend/storage/studio_db.py via
-# studio_root()). Not the provider API keys: providers_db.py says they "live only in the
-# browser (localStorage) and are sent encrypted per-request". studio.db lives
-# under the install root, so an env-mode install keeps it inside the custom root. A bare
-# run with neither variable exported cannot discover that root, so the summary must not
-# claim the history is gone unless a database was really deleted.
-#
-# mktemp -d, not a PID-derived name under $TMPDIR: the directory is private (0700) and
-# unpredictable, so the markers cannot collide with, or be pre-created by, anything else.
+# studio.db holds chat_threads/chat_messages (backend/storage/studio_db.py via studio_root()),
+# not the provider API keys: providers_db.py keeps those in the browser's localStorage only.
+# It sits under the install root, so an env-mode install keeps it in a custom root a bare run
+# cannot discover; claim the history is gone only if a database was really deleted.
+# mktemp -d, not a $TMPDIR name: private (0700) and unpredictable, so the markers cannot
+# collide with, or be pre-created by, anything else.
 _MARKER_DIR=$(mktemp -d 2>/dev/null || true)
 _REMOVE_FAILED_FLAG=""
 _DB_REMOVED_FLAG=""
@@ -239,20 +233,18 @@ if [ -n "$_MARKER_DIR" ] && [ -d "$_MARKER_DIR" ]; then
     _DB_REMOVED_FLAG="$_MARKER_DIR/db-removed"
 fi
 
-# `printf`, never `: > "$f"`. `:` is a POSIX special builtin, so a redirection error on it
-# terminates a non-interactive shell outright, and `2>/dev/null || true` does not stop it:
-# dash exits 2 and busybox ash exits 1, aborting the uninstall partway through. printf is
-# a regular builtin, so the same failure is just a nonzero status.
+# `printf`, never `: > "$f"`: `:` is a POSIX special builtin, so a redirection error on it
+# kills a non-interactive shell outright (dash 2, busybox ash 1) and `|| true` does not stop
+# it. printf is a regular builtin, so the same failure is just a nonzero status.
 _set_marker() {
     [ -n "$1" ] || return 0
     printf '' > "$1" 2>/dev/null || true
     return 0
 }
 _marker_set() { [ -n "$1" ] && [ -f "$1" ]; }
-# No usable marker storage means no record of what failed, so the summary must not claim
-# success. Re-checked rather than trusting the startup result: the directory can be removed
-# or made unwritable while the uninstall is running, after which _set_marker silently
-# discards every failure and the pathname alone still looks fine.
+# No marker storage means no record of what failed, so the summary must not claim success.
+# Re-checked, not trusted from startup: the directory can vanish or lose write access mid-run,
+# after which _set_marker silently drops every failure while the pathname still looks fine.
 _markers_unavailable() {
     [ -n "$_MARKER_DIR" ] || return 0
     [ -d "$_MARKER_DIR" ] || return 0
@@ -260,8 +252,7 @@ _markers_unavailable() {
     return 1
 }
 
-# EXIT, not a line at the end of main: --help returns early, an unknown argument exits
-# non-zero, and `set -e` can fire partway through, none of which would reach it.
+# EXIT, not a line at the end of main: --help, a bad argument and `set -e` all skip that.
 _cleanup_markers() {
     if [ -n "$_MARKER_DIR" ]; then
         rm -rf "$_MARKER_DIR" 2>/dev/null || true
@@ -269,19 +260,12 @@ _cleanup_markers() {
 }
 trap _cleanup_markers EXIT
 
-# Record whether the install root about to be removed carries a studio.db.
 # Remove an install root and record whether its studio.db really went with it.
-#
-# The check has to happen on the RESOLVED directory, before and after. A relocated
-# install (`~/.unsloth/studio` a symlink to another disk) satisfies `-f "$root/studio.db"`
-# through the link, but `rm -rf` on a symlink unlinks the symlink and leaves the target
-# intact, so a naive before-check would report the database gone while it is still there.
-# Checking `$root/studio.db` afterwards is no better: the link is gone, so the path stops
-# resolving and the file reads as absent either way.
-#
-# Deliberately verifying rather than chasing the link: following a symlink out of the
-# expected location to `rm -rf` its target is exactly what the deny lists exist to prevent.
-# A relocated install keeps its database, and the summary now says so.
+# The check runs on the RESOLVED path: a relocated install (~/.unsloth/studio a symlink to
+# another disk) passes `-f "$root/studio.db"` through the link, but `rm -rf` unlinks only the
+# link, and afterwards the path stops resolving and reads as absent either way.
+# Verifying rather than chasing the link is deliberate: following a symlink out of the
+# expected location to `rm -rf` its target is what the deny lists exist to prevent.
 _remove_root_recording_db() {
     _rrd_root="$1"
     # shellcheck disable=SC1007
@@ -291,11 +275,9 @@ _remove_root_recording_db() {
     _rrd_db="$_rrd_real/studio.db"
     if [ -f "$_rrd_db" ]; then
         _rrd_had_db=1
-        # The database itself can be a symlink out of the tree. -f follows it, but the
-        # rm below unlinks the link and leaves the target, so track where the bytes are.
-        # readlink without -f: BSD readlink only gained -f in macOS 12.3, and there the
-        # GNU form fails, leaves the link path in place and the claim goes wrong again.
-        # The raw link text plus cd -P on its directory is portable to both.
+        # The db itself can be a symlink out of the tree: -f follows it but the rm below
+        # unlinks only the link, so track where the bytes are. readlink without -f: BSD
+        # gained -f in macOS 12.3, so use the raw link text plus cd -P, portable to both.
         if [ -L "$_rrd_db" ]; then
             _rrd_link=$(readlink "$_rrd_db" 2>/dev/null || true)
             if [ -n "$_rrd_link" ]; then
@@ -329,15 +311,14 @@ _remove_path() {
             echo "  removed: $_p"
         else
             echo "  could not remove: $_p" >&2
-            # A marker file, not a variable: custom roots are removed inside a pipeline
-            # subshell, where an assignment would never reach the summary below.
+            # A marker file, not a variable: custom roots are removed in a pipeline subshell.
             _set_marker "$_REMOVE_FAILED_FLAG"
         fi
     fi
 }
 
-# $1 override, $2 default. A relative override is invalid per the XDG spec and dropped by dirs,
-# which Tauri resolves through, so following one would spare the real data and rm -rf under our cwd.
+# $1 override, $2 default. A relative override is invalid per XDG and dropped by dirs (which
+# Tauri resolves through), so honouring one would spare the real data and rm -rf under our cwd.
 _xdg_dir() {
     case "$1" in /*) printf '%s\n' "$1" ;; *) printf '%s\n' "$2" ;; esac
 }
@@ -469,14 +450,13 @@ _unsloth_uninstall_main() {
         [ -n "$_custom_root" ] || continue
         if _is_unsafe_root "$_custom_root"; then
             echo "  refusing to remove unsafe path: $_custom_root" >&2
-            # install.sh accepts any writable root, so this can be a real install under a
-            # path the deny list covers (/var/tmp/studio needs no elevation). Nothing is
-            # deleted, and it holds studio.db and the auth data, so the summary must say so.
+            # install.sh accepts any writable root, so a real install can sit under a deny-listed
+            # path (/var/tmp/studio). Nothing is deleted and it holds studio.db, so say so.
             [ -d "$_custom_root" ] && _set_marker "$_REMOVE_FAILED_FLAG"
             continue
         fi
         if ! _is_studio_root "$_custom_root"; then
-            # Not ours, so nothing of the user's data is left behind by skipping it.
+            # Not ours, so skipping leaves none of the user's data behind.
             echo "  refusing to remove non-Unsloth path: $_custom_root" >&2
             continue
         fi
@@ -576,8 +556,7 @@ _unsloth_uninstall_main() {
             if [ -x "$_lsr" ]; then
                 "$_lsr" -u "$HOME/Applications/Unsloth Studio.app" 2>/dev/null || true
             fi
-            # WKWebView data, keyed by bundle id. Created at first launch, not by install.sh,
-            # so it outlived every uninstall.
+            # WKWebView data, keyed by bundle id. Created at first launch, not by install.sh.
             _bid="ai.unsloth.studio"
             echo "Removing WebView caches and app data ($_bid)..."
             _remove_path "$HOME/Library/Caches/$_bid"
@@ -587,10 +566,8 @@ _unsloth_uninstall_main() {
             _remove_path "$HOME/Library/HTTPStorages/$_bid.binarycookies"
             _remove_path "$HOME/Library/Cookies/$_bid.binarycookies"
             _remove_path "$HOME/Library/Saved Application State/$_bid.savedState"
-            # defaults, not rm: cfprefsd rewrites the plist from memory after a bare rm.
-            # ByHost is a separate domain.
-            # As the home's owner: under sudo, root's defaults edits root's domain and the
-            # target user's cfprefsd still rewrites the plist after the rm below.
+            # defaults, not rm: cfprefsd rewrites the plist from memory. ByHost is a separate
+            # domain. As the home's owner, or under sudo root just edits root's own domain.
             if command -v defaults >/dev/null 2>&1; then
                 _run_as_home_owner defaults delete "$_bid" >/dev/null 2>&1 || true
                 _run_as_home_owner defaults -currentHost delete "$_bid" >/dev/null 2>&1 || true
@@ -738,8 +715,8 @@ _unsloth_uninstall_main() {
                     echo "          sudo rm -rf /opt/rocm /opt/rocm-* && sudo ldconfig"
                 fi
             fi
-            # webkit2gtk data, keyed by bundle id. Tauri points the WebView at LocalData/<bid>,
-            # so caches sit under XDG_DATA_HOME; rest is app data.
+            # webkit2gtk data by bundle id: Tauri points the WebView at LocalData/<bid>, so the
+            # caches sit under XDG_DATA_HOME; the rest is app data.
             _bid="ai.unsloth.studio"
             echo "Removing WebView caches and app data ($_bid)..."
             _remove_path "$(_xdg_dir "${XDG_DATA_HOME:-}" "$HOME/.local/share")/$_bid"
@@ -748,20 +725,17 @@ _unsloth_uninstall_main() {
             _remove_path "$(_xdg_dir "${XDG_STATE_HOME:-}" "$HOME/.local/state")/$_bid"
             echo "Removing Linux .desktop entry..."
             _remove_path "$HOME/.local/share/applications/unsloth-studio.desktop"
-            # tauri-plugin-deep-link writes "<exe>-handler.desktop" next to it on
-            # every launch to register the unsloth:// scheme, so it exists on any
-            # machine the app has ever started on. Left behind it is a dangling
-            # handler that points at a binary we just deleted. Unlike install.sh's
-            # own shortcut, the plugin resolves the directory through Tauri's
-            # data_dir(), which honours XDG_DATA_HOME, so check both.
+            # tauri-plugin-deep-link rewrites "<exe>-handler.desktop" on every launch for the
+            # unsloth:// scheme, so it exists on any machine the app has started on and would
+            # be left pointing at a binary we just deleted. Unlike install.sh's own shortcut,
+            # it uses Tauri's data_dir(), which honours XDG_DATA_HOME, so check both.
             _un_appdir="$(_xdg_dir "${XDG_DATA_HOME:-}" "$HOME/.local/share")/applications"
             _remove_path "$_un_appdir/unsloth-studio-handler.desktop"
             if [ "$_un_appdir" != "$HOME/.local/share/applications" ]; then
                 _remove_path "$HOME/.local/share/applications/unsloth-studio-handler.desktop"
             fi
-            # Rebuild mimeinfo.cache in each directory an entry was removed from, or the
-            # cache beside the removed handler keeps advertising it. install.sh refreshes
-            # the directory it actually wrote to (install.sh:1574); do the same on the way out.
+            # Rebuild mimeinfo.cache wherever an entry was removed, or the stale cache keeps
+            # advertising it. Mirrors install.sh:1574 on the way out.
             if command -v update-desktop-database >/dev/null 2>&1; then
                 update-desktop-database "$HOME/.local/share/applications" 2>/dev/null || true
                 if [ "$_un_appdir" != "$HOME/.local/share/applications" ]; then
@@ -774,22 +748,19 @@ _unsloth_uninstall_main() {
     echo ""
     echo "Unsloth Studio uninstalled."
     if _markers_unavailable || _marker_set "$_REMOVE_FAILED_FLAG"; then
-        # Also the no-marker-storage case: without it a failed rm left no record, so
-        # reporting success would be a guess in the one direction that misleads.
+        # Also the no-marker-storage case: no record of a failed rm, so do not claim success.
         echo "Note: some paths could not be removed (see 'could not remove:' above), so the"
         echo "      signed-in session and local chat history may still be on disk. Remove"
         echo "      those paths by hand to clear them."
     elif _marker_set "$_DB_REMOVED_FLAG"; then
-        # Scoped to what was removed. A default and an env-mode install can coexist, and
-        # with neither variable exported the custom root is never discovered, so an
-        # unqualified "are gone" would be false for the database still sitting in it.
+        # Scoped to what was removed: a default and an env-mode install can coexist, and a bare
+        # run never discovers the custom root, so "are gone" would be false for its database.
         echo "Note: this also removed the app's WebView data and the studio.db it found, so"
         echo "      the desktop app's session and the chat history in the install(s) removed"
         echo "      above are gone."
     else
-        # No studio.db was deleted, so only the WebView-local data is accounted for.
-        # Claiming the keys and history are gone would be false for an env-mode install
-        # whose root this run never discovered.
+        # No studio.db was deleted, so only the WebView-local data is accounted for: an env-mode
+        # install this run never discovered still has its keys and history.
         echo "Note: this also removed the app's WebView data, so the desktop app's session is"
         echo "      gone. A browser session is not affected: its tokens live in the same"
         echo "      localStorage as the API keys below."

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -193,6 +193,22 @@ $_roots_from_conf"
 _REMOVE_FAILED_FLAG="${TMPDIR:-/tmp}/.unsloth-uninstall-failed.$$"
 rm -f "$_REMOVE_FAILED_FLAG" 2>/dev/null || true
 
+# Set when a removed install root actually held studio.db, read by the closing summary.
+# studio.db is what holds chat_threads/chat_messages and the saved provider keys
+# (backend/storage/studio_db.py, providers_db.py, both via studio_root()), and it lives
+# under the install root, so an env-mode install keeps it inside the custom root. A bare
+# run with neither variable exported cannot discover that root, so the summary must not
+# claim the history is gone unless a database was really deleted. Also a marker file, not
+# a variable: custom roots are removed inside a pipeline subshell.
+_DB_REMOVED_FLAG="${TMPDIR:-/tmp}/.unsloth-uninstall-db-removed.$$"
+rm -f "$_DB_REMOVED_FLAG" 2>/dev/null || true
+
+# Record whether the install root about to be removed carries a studio.db.
+_note_studio_db() {
+    [ -f "$1/studio.db" ] && { : > "$_DB_REMOVED_FLAG" 2>/dev/null || true; }
+    return 0
+}
+
 _remove_path() {
     _p="$1"
     if [ -e "$_p" ] || [ -L "$_p" ]; then
@@ -351,6 +367,7 @@ _unsloth_uninstall_main() {
             echo "  refusing to remove non-Unsloth path: $_custom_root" >&2
             continue
         fi
+        _note_studio_db "$_custom_root"
         _remove_path "$_custom_root"
         # Native diffusion (stable-diffusion.cpp) for a custom/env-mode Studio installs beside
         # the root at <parent>/stable-diffusion.cpp -- find_sd_cpp_binary resolves it from
@@ -369,6 +386,7 @@ _unsloth_uninstall_main() {
             _remove_path "$_custom_sd_cpp"
         fi
     done
+    _note_studio_db "$HOME/.unsloth/studio"
     _remove_path "$HOME/.unsloth/studio"
     # Default-mode shared llama.cpp build + cache are siblings of studio (not removed
     # by deleting it). No-op in env/custom mode (they nest under the custom root) and
@@ -643,10 +661,18 @@ _unsloth_uninstall_main() {
         echo "Note: some paths could not be removed (see 'could not remove:' above), so the"
         echo "      signed-in session, saved provider API keys and local chat history may"
         echo "      still be on disk. Remove those paths by hand to clear them."
+    elif [ -f "$_DB_REMOVED_FLAG" ]; then
+        echo "Note: this also removed the app's WebView data and studio.db, so the signed-in"
+        echo "      session, saved provider API keys and local chat history are gone."
     else
-        echo "Note: this also removed the app's WebView data, so the signed-in session,"
-        echo "      saved provider API keys and local chat history are gone."
+        # No studio.db was deleted, so only the WebView-local data is accounted for.
+        # Claiming the keys and history are gone would be false for an env-mode install
+        # whose root this run never discovered.
+        echo "Note: this also removed the app's WebView data, so the signed-in session is gone."
+        echo "      No studio.db was found, so any saved provider API keys and chat history in"
+        echo "      an install root this run did not see are still on disk."
     fi
+    rm -f "$_DB_REMOVED_FLAG" 2>/dev/null || true
     echo "Note: Hugging Face model cache at ~/.cache/huggingface was left in place."
     echo "Remove it manually with 'rm -rf ~/.cache/huggingface/hub' if desired."
     # Env-mode installs leave no breadcrumb in $HOME, so a custom root can

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -123,6 +123,25 @@ _run_as_home_owner() {
     fi
 }
 
+# Is the desktop app running? Only called when there is no pkill to ask, so it reads
+# /proc, the one process inventory such a system still has. Scoped to the owner of the
+# $HOME being cleared, matching the pkill -u call below.
+_studio_app_running() {
+    [ -d /proc ] || return 1
+    _sar_uid=$(_home_uid)
+    for _sar_p in /proc/[0-9]*; do
+        [ -r "$_sar_p/comm" ] || continue
+        _sar_comm=$(cat "$_sar_p/comm" 2>/dev/null || true)
+        [ "$_sar_comm" = "unsloth-studio" ] || continue
+        if [ -n "$_sar_uid" ]; then
+            _sar_owner=$(stat -c %u "$_sar_p" 2>/dev/null || stat -f %u "$_sar_p" 2>/dev/null || true)
+            [ "$_sar_owner" = "$_sar_uid" ] || continue
+        fi
+        return 0
+    done
+    return 1
+}
+
 _pkill_studio() {
     # Prefer PID files written by _spawn_terminal so we only touch our own installs.
     for _data_dir in "$HOME/.local/share/unsloth" $(_custom_studio_data_dirs); do
@@ -132,7 +151,17 @@ _pkill_studio() {
         done
     done
 
-    command -v pkill >/dev/null 2>&1 || return 0
+    if ! command -v pkill >/dev/null 2>&1; then
+        # No procps. The PID-file sweep above is all we can do, and install.sh never
+        # requires pkill, so this is a real configuration. If the desktop app is still
+        # up, its WebView helpers re-create the profile right after we delete it, so
+        # the removal is incomplete and the summary must not claim otherwise.
+        if _studio_app_running; then
+            echo "  pkill not found and Unsloth Studio is running; close it and re-run" >&2
+            _set_marker "$_REMOVE_FAILED_FLAG"
+        fi
+        return 0
+    fi
 
     # Scope fallback patterns to the install roots we are removing so a
     # different Unsloth install (different UNSLOTH_STUDIO_HOME) is not touched.
@@ -193,8 +222,9 @@ $_roots_from_conf"
 # reach the summary.
 #   remove-failed  an rm failed, or a root was skipped while still holding data
 #   db-removed     a removed install root actually held studio.db
-# studio.db is what holds chat_threads/chat_messages and the saved provider keys
-# (backend/storage/studio_db.py, providers_db.py, both via studio_root()), and it lives
+# studio.db is what holds chat_threads/chat_messages (backend/storage/studio_db.py via
+# studio_root()). Not the provider API keys: providers_db.py says they "live only in the
+# browser (localStorage) and are sent encrypted per-request". studio.db lives
 # under the install root, so an env-mode install keeps it inside the custom root. A bare
 # run with neither variable exported cannot discover that root, so the summary must not
 # claim the history is gone unless a database was really deleted.
@@ -258,12 +288,19 @@ _remove_root_recording_db() {
     _rrd_real=$(CDPATH= cd -P -- "$_rrd_root" 2>/dev/null && pwd -P) || _rrd_real=""
     [ -n "$_rrd_real" ] || _rrd_real="$_rrd_root"
     _rrd_had_db=0
-    if [ -f "$_rrd_real/studio.db" ]; then
+    _rrd_db="$_rrd_real/studio.db"
+    if [ -f "$_rrd_db" ]; then
         _rrd_had_db=1
+        # The database itself can be a symlink out of the tree. -f follows it, but the
+        # rm below unlinks the link and leaves the target, so track where the bytes are.
+        if [ -L "$_rrd_db" ]; then
+            _rrd_db_target=$(readlink -f "$_rrd_db" 2>/dev/null || true)
+            [ -n "$_rrd_db_target" ] && _rrd_db="$_rrd_db_target"
+        fi
     fi
     _remove_path "$_rrd_root"
     if [ "$_rrd_had_db" = 1 ]; then
-        if [ -f "$_rrd_real/studio.db" ]; then
+        if [ -f "$_rrd_db" ]; then
             # Only the link went, or the delete failed: the data is still on disk.
             _set_marker "$_REMOVE_FAILED_FLAG"
         else
@@ -728,23 +765,26 @@ _unsloth_uninstall_main() {
         # Also the no-marker-storage case: without it a failed rm left no record, so
         # reporting success would be a guess in the one direction that misleads.
         echo "Note: some paths could not be removed (see 'could not remove:' above), so the"
-        echo "      signed-in session, saved provider API keys and local chat history may"
-        echo "      still be on disk. Remove those paths by hand to clear them."
+        echo "      signed-in session and local chat history may still be on disk. Remove"
+        echo "      those paths by hand to clear them."
     elif _marker_set "$_DB_REMOVED_FLAG"; then
         # Scoped to what was removed. A default and an env-mode install can coexist, and
         # with neither variable exported the custom root is never discovered, so an
         # unqualified "are gone" would be false for the database still sitting in it.
         echo "Note: this also removed the app's WebView data and the studio.db it found, so"
-        echo "      the signed-in session, saved provider API keys and chat history in the"
-        echo "      install(s) removed above are gone."
+        echo "      the desktop app's session and the chat history in the install(s) removed"
+        echo "      above are gone."
     else
         # No studio.db was deleted, so only the WebView-local data is accounted for.
         # Claiming the keys and history are gone would be false for an env-mode install
         # whose root this run never discovered.
         echo "Note: this also removed the app's WebView data, so the signed-in session is gone."
-        echo "      No studio.db was found, so any saved provider API keys and chat history in"
-        echo "      an install root this run did not see are still on disk."
+        echo "      No studio.db was found, so any chat history in an install root this run"
+        echo "      did not see is still on disk."
     fi
+    echo "Note: provider API keys are kept in the browser's localStorage, not in studio.db."
+    echo "      Unless you ran Studio as the desktop app, clear site data for the"
+    echo "      http://localhost:<port> origin you used to remove them."
     echo "Note: Hugging Face model cache at ~/.cache/huggingface was left in place."
     echo "Remove it manually with 'rm -rf ~/.cache/huggingface/hub' if desired."
     # Env-mode installs leave no breadcrumb in $HOME, so a custom root can

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -340,9 +340,14 @@ _unsloth_uninstall_main() {
         [ -n "$_custom_root" ] || continue
         if _is_unsafe_root "$_custom_root"; then
             echo "  refusing to remove unsafe path: $_custom_root" >&2
+            # install.sh accepts any writable root, so this can be a real install under a
+            # path the deny list covers (/var/tmp/studio needs no elevation). Nothing is
+            # deleted, and it holds studio.db and the auth data, so the summary must say so.
+            [ -d "$_custom_root" ] && { : > "$_REMOVE_FAILED_FLAG" 2>/dev/null || true; }
             continue
         fi
         if ! _is_studio_root "$_custom_root"; then
+            # Not ours, so nothing of the user's data is left behind by skipping it.
             echo "  refusing to remove non-Unsloth path: $_custom_root" >&2
             continue
         fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -101,6 +101,27 @@ _stop_owned_sd_cpp_processes() {
     done
 }
 
+# Numeric owner of $HOME, empty if it cannot be resolved. Not always the caller: macOS
+# ships `env_keep += "HOME MAIL"`, so sudo keeps the invoking user's home while euid is 0.
+_home_uid() {
+    _hu=$(stat -c %u "$HOME" 2>/dev/null || stat -f %u "$HOME" 2>/dev/null || true)
+    case "$_hu" in ''|*[!0-9]*) _hu=$(id -u 2>/dev/null || true) ;; esac
+    case "$_hu" in *[!0-9]*) _hu= ;; esac
+    printf '%s\n' "$_hu"
+}
+
+# Run "$@" as that owner when we are root and it is someone else, so per-user daemons see
+# the right domain. Plain "$@" otherwise, which is every non-elevated run.
+_run_as_home_owner() {
+    _ro=$(_home_uid)
+    if [ "$(id -u 2>/dev/null || echo 0)" = "0" ] && [ -n "$_ro" ] && [ "$_ro" != "0" ] &&
+       command -v launchctl >/dev/null 2>&1 && command -v sudo >/dev/null 2>&1; then
+        launchctl asuser "$_ro" sudo -u "#$_ro" "$@"
+    else
+        "$@"
+    fi
+}
+
 _pkill_studio() {
     # Prefer PID files written by _spawn_terminal so we only touch our own installs.
     for _data_dir in "$HOME/.local/share/unsloth" $(_custom_studio_data_dirs); do
@@ -158,9 +179,7 @@ $_roots_from_conf"
     # $HOME being cleared, not the caller (macOS sudo keeps HOME), so a root run leaves other
     # logged-in users alone. Numeric suits procps and BSD pkill; BSD reads the signal from
     # argv[1] only, so it stays first. Unknown owner skips rather than signalling everyone.
-    _studio_uid=$(stat -c %u "$HOME" 2>/dev/null || stat -f %u "$HOME" 2>/dev/null || true)
-    case "$_studio_uid" in ''|*[!0-9]*) _studio_uid=$(id -u 2>/dev/null || true) ;; esac
-    case "$_studio_uid" in *[!0-9]*) _studio_uid= ;; esac
+    _studio_uid=$(_home_uid)
     if [ -n "$_studio_uid" ]; then
         pkill -TERM -x -u "$_studio_uid" unsloth-studio 2>/dev/null || true
         sleep 0.5
@@ -423,9 +442,11 @@ _unsloth_uninstall_main() {
             _remove_path "$HOME/Library/Saved Application State/$_bid.savedState"
             # defaults, not rm: cfprefsd rewrites the plist from memory after a bare rm.
             # ByHost is a separate domain.
+            # As the home's owner: under sudo, root's defaults edits root's domain and the
+            # target user's cfprefsd still rewrites the plist after the rm below.
             if command -v defaults >/dev/null 2>&1; then
-                defaults delete "$_bid" >/dev/null 2>&1 || true
-                defaults -currentHost delete "$_bid" >/dev/null 2>&1 || true
+                _run_as_home_owner defaults delete "$_bid" >/dev/null 2>&1 || true
+                _run_as_home_owner defaults -currentHost delete "$_bid" >/dev/null 2>&1 || true
             fi
             _remove_path "$HOME/Library/Preferences/$_bid.plist"
             ;;

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -153,9 +153,8 @@ $_roots_from_conf"
     sleep 0.5
     _stop_owned_sd_cpp_processes KILL
 
-    # Tauri desktop app: its WebView helpers re-create the runtime caches
-    # removed below. -x is an exact match on the binary name, so the "unsloth"
-    # CLI shim is never touched.
+    # Tauri desktop app, whose WebView helpers re-create the caches removed
+    # below. -x is exact, so the "unsloth" CLI shim is never matched.
     pkill -TERM -x unsloth-studio 2>/dev/null || true
     sleep 0.5
     pkill -KILL -x unsloth-studio 2>/dev/null || true
@@ -397,9 +396,8 @@ _unsloth_uninstall_main() {
             if [ -x "$_lsr" ]; then
                 "$_lsr" -u "$HOME/Applications/Unsloth Studio.app" 2>/dev/null || true
             fi
-            # WKWebView runtime data, keyed by bundle id and created at first
-            # app launch rather than by install.sh, so it outlived every
-            # uninstall and served a stale frontend to the next install.
+            # WKWebView data, keyed by bundle id. Created at first app launch,
+            # not by install.sh, so it outlived every uninstall.
             _bid="ai.unsloth.studio"
             echo "Removing WebView caches and app data ($_bid)..."
             _remove_path "$HOME/Library/Caches/$_bid"
@@ -409,8 +407,8 @@ _unsloth_uninstall_main() {
             _remove_path "$HOME/Library/HTTPStorages/$_bid.binarycookies"
             _remove_path "$HOME/Library/Cookies/$_bid.binarycookies"
             _remove_path "$HOME/Library/Saved Application State/$_bid.savedState"
-            # defaults, not rm: cfprefsd owns the plist and rewrites it from its
-            # in-memory cache after a bare rm. ByHost is a separate domain.
+            # defaults, not rm: cfprefsd rewrites the plist from memory after a
+            # bare rm. ByHost is a separate domain.
             if command -v defaults >/dev/null 2>&1; then
                 defaults delete "$_bid" >/dev/null 2>&1 || true
                 defaults -currentHost delete "$_bid" >/dev/null 2>&1 || true
@@ -558,9 +556,9 @@ _unsloth_uninstall_main() {
                     echo "          sudo rm -rf /opt/rocm /opt/rocm-* && sudo ldconfig"
                 fi
             fi
-            # webkit2gtk runtime data, keyed by bundle id. Tauri points the
-            # WebView at LocalData/<bundle id>, so the caches live under
-            # XDG_DATA_HOME; the other three are removed as app data.
+            # webkit2gtk data, keyed by bundle id. Tauri points the WebView at
+            # LocalData/<bid>, so the caches are under XDG_DATA_HOME; the rest
+            # is app data.
             _bid="ai.unsloth.studio"
             echo "Removing WebView caches and app data ($_bid)..."
             _remove_path "${XDG_DATA_HOME:-$HOME/.local/share}/$_bid"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -104,7 +104,8 @@ _stop_owned_sd_cpp_processes() {
 # Numeric owner of $HOME, empty if it cannot be resolved. Not always the caller: macOS
 # ships `env_keep += "HOME MAIL"`, so sudo keeps the invoking user's home while euid is 0.
 _home_uid() {
-    _hu=$(stat -c %u "$HOME" 2>/dev/null || stat -f %u "$HOME" 2>/dev/null || true)
+    # -L: both stats lstat by default, so a root-owned link to a user-owned home reads as 0.
+    _hu=$(stat -L -c %u "$HOME" 2>/dev/null || stat -L -f %u "$HOME" 2>/dev/null || true)
     case "$_hu" in ''|*[!0-9]*) _hu=$(id -u 2>/dev/null || true) ;; esac
     case "$_hu" in *[!0-9]*) _hu= ;; esac
     printf '%s\n' "$_hu"
@@ -190,7 +191,13 @@ $_roots_from_conf"
 _remove_path() {
     _p="$1"
     if [ -e "$_p" ] || [ -L "$_p" ]; then
-        rm -rf "$_p" 2>/dev/null && echo "  removed: $_p" || echo "  could not remove: $_p" >&2
+        if rm -rf "$_p" 2>/dev/null; then
+            echo "  removed: $_p"
+        else
+            echo "  could not remove: $_p" >&2
+            # Read by the closing summary, which must not promise the data is gone.
+            _remove_failed=1
+        fi
     fi
 }
 
@@ -609,8 +616,14 @@ _unsloth_uninstall_main() {
 
     echo ""
     echo "Unsloth Studio uninstalled."
-    echo "Note: this also removed the app's WebView data, so the signed-in session,"
-    echo "      saved provider API keys and local chat history are gone."
+    if [ "${_remove_failed:-0}" = "1" ]; then
+        echo "Note: some paths could not be removed (see 'could not remove:' above), so the"
+        echo "      signed-in session, saved provider API keys and local chat history may"
+        echo "      still be on disk. Remove those paths by hand to clear them."
+    else
+        echo "Note: this also removed the app's WebView data, so the signed-in session,"
+        echo "      saved provider API keys and local chat history are gone."
+    fi
     echo "Note: Hugging Face model cache at ~/.cache/huggingface was left in place."
     echo "Remove it manually with 'rm -rf ~/.cache/huggingface/hub' if desired."
     # Env-mode installs leave no breadcrumb in $HOME, so a custom root can

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -790,7 +790,9 @@ _unsloth_uninstall_main() {
         # No studio.db was deleted, so only the WebView-local data is accounted for.
         # Claiming the keys and history are gone would be false for an env-mode install
         # whose root this run never discovered.
-        echo "Note: this also removed the app's WebView data, so the signed-in session is gone."
+        echo "Note: this also removed the app's WebView data, so the desktop app's session is"
+        echo "      gone. A browser session is not affected: its tokens live in the same"
+        echo "      localStorage as the API keys below."
         echo "      No studio.db was found, so any chat history in an install root this run"
         echo "      did not see is still on disk."
     fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -154,10 +154,18 @@ $_roots_from_conf"
     _stop_owned_sd_cpp_processes KILL
 
     # The app's WebView helpers re-create the caches removed below, so it has to die here.
-    # -x is exact, so the "unsloth" CLI shim never matches.
-    pkill -TERM -x unsloth-studio 2>/dev/null || true
-    sleep 0.5
-    pkill -KILL -x unsloth-studio 2>/dev/null || true
+    # -x is exact, so the "unsloth" CLI shim never matches. -u scopes to the owner of the
+    # $HOME being cleared, not the caller (macOS sudo keeps HOME), so a root run leaves other
+    # logged-in users alone. Numeric suits procps and BSD pkill; BSD reads the signal from
+    # argv[1] only, so it stays first. Unknown owner skips rather than signalling everyone.
+    _studio_uid=$(stat -c %u "$HOME" 2>/dev/null || stat -f %u "$HOME" 2>/dev/null || true)
+    case "$_studio_uid" in ''|*[!0-9]*) _studio_uid=$(id -u 2>/dev/null || true) ;; esac
+    case "$_studio_uid" in *[!0-9]*) _studio_uid= ;; esac
+    if [ -n "$_studio_uid" ]; then
+        pkill -TERM -x -u "$_studio_uid" unsloth-studio 2>/dev/null || true
+        sleep 0.5
+        pkill -KILL -x -u "$_studio_uid" unsloth-studio 2>/dev/null || true
+    fi
 }
 
 _remove_path() {

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -153,8 +153,8 @@ $_roots_from_conf"
     sleep 0.5
     _stop_owned_sd_cpp_processes KILL
 
-    # Tauri desktop app, whose WebView helpers re-create the caches removed
-    # below. -x is exact, so the "unsloth" CLI shim is never matched.
+    # The app's WebView helpers re-create the caches removed below, so it has
+    # to die here. -x is exact, so the "unsloth" CLI shim never matches.
     pkill -TERM -x unsloth-studio 2>/dev/null || true
     sleep 0.5
     pkill -KILL -x unsloth-studio 2>/dev/null || true
@@ -396,8 +396,8 @@ _unsloth_uninstall_main() {
             if [ -x "$_lsr" ]; then
                 "$_lsr" -u "$HOME/Applications/Unsloth Studio.app" 2>/dev/null || true
             fi
-            # WKWebView data, keyed by bundle id. Created at first app launch,
-            # not by install.sh, so it outlived every uninstall.
+            # WKWebView data, keyed by bundle id. Created at first launch, not
+            # by install.sh, so it outlived every uninstall.
             _bid="ai.unsloth.studio"
             echo "Removing WebView caches and app data ($_bid)..."
             _remove_path "$HOME/Library/Caches/$_bid"
@@ -557,8 +557,7 @@ _unsloth_uninstall_main() {
                 fi
             fi
             # webkit2gtk data, keyed by bundle id. Tauri points the WebView at
-            # LocalData/<bid>, so the caches are under XDG_DATA_HOME; the rest
-            # is app data.
+            # LocalData/<bid>, so caches sit under XDG_DATA_HOME; rest is app data.
             _bid="ai.unsloth.studio"
             echo "Removing WebView caches and app data ($_bid)..."
             _remove_path "${XDG_DATA_HOME:-$HOME/.local/share}/$_bid"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -167,6 +167,13 @@ _remove_path() {
     fi
 }
 
+# $1 override, $2 default. A relative override is invalid per the XDG spec and
+# is dropped by dirs, which is what Tauri resolves these through, so following
+# one would spare the real data and rm -rf a same-named dir under our cwd.
+_xdg_dir() {
+    case "$1" in /*) printf '%s\n' "$1" ;; *) printf '%s\n' "$2" ;; esac
+}
+
 # Accept as Unsloth root only if Unsloth sentinels exist (matches install.sh's
 # env-mode ownership guard at install.sh:1358-1361). A bare unsloth_studio/
 # directory is NOT enough -- require the install-time owner marker so a user
@@ -560,10 +567,10 @@ _unsloth_uninstall_main() {
             # LocalData/<bid>, so caches sit under XDG_DATA_HOME; rest is app data.
             _bid="ai.unsloth.studio"
             echo "Removing WebView caches and app data ($_bid)..."
-            _remove_path "${XDG_DATA_HOME:-$HOME/.local/share}/$_bid"
-            _remove_path "${XDG_CACHE_HOME:-$HOME/.cache}/$_bid"
-            _remove_path "${XDG_CONFIG_HOME:-$HOME/.config}/$_bid"
-            _remove_path "${XDG_STATE_HOME:-$HOME/.local/state}/$_bid"
+            _remove_path "$(_xdg_dir "${XDG_DATA_HOME:-}" "$HOME/.local/share")/$_bid"
+            _remove_path "$(_xdg_dir "${XDG_CACHE_HOME:-}" "$HOME/.cache")/$_bid"
+            _remove_path "$(_xdg_dir "${XDG_CONFIG_HOME:-}" "$HOME/.config")/$_bid"
+            _remove_path "$(_xdg_dir "${XDG_STATE_HOME:-}" "$HOME/.local/state")/$_bid"
             echo "Removing Linux .desktop entry..."
             _remove_path "$HOME/.local/share/applications/unsloth-studio.desktop"
             if command -v update-desktop-database >/dev/null 2>&1; then

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -188,6 +188,11 @@ $_roots_from_conf"
     fi
 }
 
+# Set by _remove_path when an rm fails, read by the closing summary. Cleared up front so a
+# stale file from an interrupted run cannot make this one report a failure it never had.
+_REMOVE_FAILED_FLAG="${TMPDIR:-/tmp}/.unsloth-uninstall-failed.$$"
+rm -f "$_REMOVE_FAILED_FLAG" 2>/dev/null || true
+
 _remove_path() {
     _p="$1"
     if [ -e "$_p" ] || [ -L "$_p" ]; then
@@ -195,8 +200,9 @@ _remove_path() {
             echo "  removed: $_p"
         else
             echo "  could not remove: $_p" >&2
-            # Read by the closing summary, which must not promise the data is gone.
-            _remove_failed=1
+            # A marker file, not a variable: custom roots are removed inside a pipeline
+            # subshell, where an assignment would never reach the summary below.
+            : > "$_REMOVE_FAILED_FLAG" 2>/dev/null || true
         fi
     fi
 }
@@ -616,7 +622,8 @@ _unsloth_uninstall_main() {
 
     echo ""
     echo "Unsloth Studio uninstalled."
-    if [ "${_remove_failed:-0}" = "1" ]; then
+    if [ -f "$_REMOVE_FAILED_FLAG" ]; then
+        rm -f "$_REMOVE_FAILED_FLAG" 2>/dev/null || true
         echo "Note: some paths could not be removed (see 'could not remove:' above), so the"
         echo "      signed-in session, saved provider API keys and local chat history may"
         echo "      still be on disk. Remove those paths by hand to clear them."

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -219,8 +219,16 @@ _set_marker() {
     return 0
 }
 _marker_set() { [ -n "$1" ] && [ -f "$1" ]; }
-# No marker storage means no record of what failed, so the summary must not claim success.
-_markers_unavailable() { [ -z "$_MARKER_DIR" ]; }
+# No usable marker storage means no record of what failed, so the summary must not claim
+# success. Re-checked rather than trusting the startup result: the directory can be removed
+# or made unwritable while the uninstall is running, after which _set_marker silently
+# discards every failure and the pathname alone still looks fine.
+_markers_unavailable() {
+    [ -n "$_MARKER_DIR" ] || return 0
+    [ -d "$_MARKER_DIR" ] || return 0
+    [ -w "$_MARKER_DIR" ] || return 0
+    return 1
+}
 
 # EXIT, not a line at the end of main: --help returns early, an unknown argument exits
 # non-zero, and `set -e` can fire partway through, none of which would reach it.
@@ -232,8 +240,36 @@ _cleanup_markers() {
 trap _cleanup_markers EXIT
 
 # Record whether the install root about to be removed carries a studio.db.
-_note_studio_db() {
-    [ -f "$1/studio.db" ] && _set_marker "$_DB_REMOVED_FLAG"
+# Remove an install root and record whether its studio.db really went with it.
+#
+# The check has to happen on the RESOLVED directory, before and after. A relocated
+# install (`~/.unsloth/studio` a symlink to another disk) satisfies `-f "$root/studio.db"`
+# through the link, but `rm -rf` on a symlink unlinks the symlink and leaves the target
+# intact, so a naive before-check would report the database gone while it is still there.
+# Checking `$root/studio.db` afterwards is no better: the link is gone, so the path stops
+# resolving and the file reads as absent either way.
+#
+# Deliberately verifying rather than chasing the link: following a symlink out of the
+# expected location to `rm -rf` its target is exactly what the deny lists exist to prevent.
+# A relocated install keeps its database, and the summary now says so.
+_remove_root_recording_db() {
+    _rrd_root="$1"
+    # shellcheck disable=SC1007
+    _rrd_real=$(CDPATH= cd -P -- "$_rrd_root" 2>/dev/null && pwd -P) || _rrd_real=""
+    [ -n "$_rrd_real" ] || _rrd_real="$_rrd_root"
+    _rrd_had_db=0
+    if [ -f "$_rrd_real/studio.db" ]; then
+        _rrd_had_db=1
+    fi
+    _remove_path "$_rrd_root"
+    if [ "$_rrd_had_db" = 1 ]; then
+        if [ -f "$_rrd_real/studio.db" ]; then
+            # Only the link went, or the delete failed: the data is still on disk.
+            _set_marker "$_REMOVE_FAILED_FLAG"
+        else
+            _set_marker "$_DB_REMOVED_FLAG"
+        fi
+    fi
     return 0
 }
 
@@ -395,8 +431,7 @@ _unsloth_uninstall_main() {
             echo "  refusing to remove non-Unsloth path: $_custom_root" >&2
             continue
         fi
-        _note_studio_db "$_custom_root"
-        _remove_path "$_custom_root"
+        _remove_root_recording_db "$_custom_root"
         # Native diffusion (stable-diffusion.cpp) for a custom/env-mode Studio installs beside
         # the root at <parent>/stable-diffusion.cpp -- find_sd_cpp_binary resolves it from
         # UNSLOTH_STUDIO_HOME.parent (sd_cpp_engine.py) -- so removing only the root leaves the
@@ -414,8 +449,7 @@ _unsloth_uninstall_main() {
             _remove_path "$_custom_sd_cpp"
         fi
     done
-    _note_studio_db "$HOME/.unsloth/studio"
-    _remove_path "$HOME/.unsloth/studio"
+    _remove_root_recording_db "$HOME/.unsloth/studio"
     # Default-mode shared llama.cpp build + cache are siblings of studio (not removed
     # by deleting it). No-op in env/custom mode (they nest under the custom root) and
     # when absent. A user-set UNSLOTH_LLAMA_CPP_PATH is intentionally kept.

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -153,8 +153,8 @@ $_roots_from_conf"
     sleep 0.5
     _stop_owned_sd_cpp_processes KILL
 
-    # The app's WebView helpers re-create the caches removed below, so it has
-    # to die here. -x is exact, so the "unsloth" CLI shim never matches.
+    # The app's WebView helpers re-create the caches removed below, so it has to die here.
+    # -x is exact, so the "unsloth" CLI shim never matches.
     pkill -TERM -x unsloth-studio 2>/dev/null || true
     sleep 0.5
     pkill -KILL -x unsloth-studio 2>/dev/null || true
@@ -167,9 +167,8 @@ _remove_path() {
     fi
 }
 
-# $1 override, $2 default. A relative override is invalid per the XDG spec and
-# is dropped by dirs, which is what Tauri resolves these through, so following
-# one would spare the real data and rm -rf a same-named dir under our cwd.
+# $1 override, $2 default. A relative override is invalid per the XDG spec and dropped by dirs,
+# which Tauri resolves through, so following one would spare the real data and rm -rf under our cwd.
 _xdg_dir() {
     case "$1" in /*) printf '%s\n' "$1" ;; *) printf '%s\n' "$2" ;; esac
 }
@@ -403,8 +402,8 @@ _unsloth_uninstall_main() {
             if [ -x "$_lsr" ]; then
                 "$_lsr" -u "$HOME/Applications/Unsloth Studio.app" 2>/dev/null || true
             fi
-            # WKWebView data, keyed by bundle id. Created at first launch, not
-            # by install.sh, so it outlived every uninstall.
+            # WKWebView data, keyed by bundle id. Created at first launch, not by install.sh,
+            # so it outlived every uninstall.
             _bid="ai.unsloth.studio"
             echo "Removing WebView caches and app data ($_bid)..."
             _remove_path "$HOME/Library/Caches/$_bid"
@@ -414,8 +413,8 @@ _unsloth_uninstall_main() {
             _remove_path "$HOME/Library/HTTPStorages/$_bid.binarycookies"
             _remove_path "$HOME/Library/Cookies/$_bid.binarycookies"
             _remove_path "$HOME/Library/Saved Application State/$_bid.savedState"
-            # defaults, not rm: cfprefsd rewrites the plist from memory after a
-            # bare rm. ByHost is a separate domain.
+            # defaults, not rm: cfprefsd rewrites the plist from memory after a bare rm.
+            # ByHost is a separate domain.
             if command -v defaults >/dev/null 2>&1; then
                 defaults delete "$_bid" >/dev/null 2>&1 || true
                 defaults -currentHost delete "$_bid" >/dev/null 2>&1 || true
@@ -563,8 +562,8 @@ _unsloth_uninstall_main() {
                     echo "          sudo rm -rf /opt/rocm /opt/rocm-* && sudo ldconfig"
                 fi
             fi
-            # webkit2gtk data, keyed by bundle id. Tauri points the WebView at
-            # LocalData/<bid>, so caches sit under XDG_DATA_HOME; rest is app data.
+            # webkit2gtk data, keyed by bundle id. Tauri points the WebView at LocalData/<bid>,
+            # so caches sit under XDG_DATA_HOME; rest is app data.
             _bid="ai.unsloth.studio"
             echo "Removing WebView caches and app data ($_bid)..."
             _remove_path "$(_xdg_dir "${XDG_DATA_HOME:-}" "$HOME/.local/share")/$_bid"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -648,8 +648,14 @@ _unsloth_uninstall_main() {
             if [ "$_un_appdir" != "$HOME/.local/share/applications" ]; then
                 _remove_path "$HOME/.local/share/applications/unsloth-studio-handler.desktop"
             fi
+            # Rebuild mimeinfo.cache in each directory an entry was removed from, or the
+            # cache beside the removed handler keeps advertising it. install.sh refreshes
+            # the directory it actually wrote to (install.sh:1574); do the same on the way out.
             if command -v update-desktop-database >/dev/null 2>&1; then
                 update-desktop-database "$HOME/.local/share/applications" 2>/dev/null || true
+                if [ "$_un_appdir" != "$HOME/.local/share/applications" ]; then
+                    update-desktop-database "$_un_appdir" 2>/dev/null || true
+                fi
             fi
             ;;
     esac

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -152,6 +152,13 @@ $_roots_from_conf"
     _stop_owned_sd_cpp_processes TERM
     sleep 0.5
     _stop_owned_sd_cpp_processes KILL
+
+    # Tauri desktop app: its WebView helpers re-create the runtime caches
+    # removed below. -x is an exact match on the binary name, so the "unsloth"
+    # CLI shim is never touched.
+    pkill -TERM -x unsloth-studio 2>/dev/null || true
+    sleep 0.5
+    pkill -KILL -x unsloth-studio 2>/dev/null || true
 }
 
 _remove_path() {
@@ -390,6 +397,25 @@ _unsloth_uninstall_main() {
             if [ -x "$_lsr" ]; then
                 "$_lsr" -u "$HOME/Applications/Unsloth Studio.app" 2>/dev/null || true
             fi
+            # WKWebView runtime data, keyed by bundle id and created at first
+            # app launch rather than by install.sh, so it outlived every
+            # uninstall and served a stale frontend to the next install.
+            _bid="ai.unsloth.studio"
+            echo "Removing WebView caches and app data ($_bid)..."
+            _remove_path "$HOME/Library/Caches/$_bid"
+            _remove_path "$HOME/Library/WebKit/$_bid"
+            _remove_path "$HOME/Library/Application Support/$_bid"
+            _remove_path "$HOME/Library/HTTPStorages/$_bid"
+            _remove_path "$HOME/Library/HTTPStorages/$_bid.binarycookies"
+            _remove_path "$HOME/Library/Cookies/$_bid.binarycookies"
+            _remove_path "$HOME/Library/Saved Application State/$_bid.savedState"
+            # defaults, not rm: cfprefsd owns the plist and rewrites it from its
+            # in-memory cache after a bare rm. ByHost is a separate domain.
+            if command -v defaults >/dev/null 2>&1; then
+                defaults delete "$_bid" >/dev/null 2>&1 || true
+                defaults -currentHost delete "$_bid" >/dev/null 2>&1 || true
+            fi
+            _remove_path "$HOME/Library/Preferences/$_bid.plist"
             ;;
         Linux)
             if [ "$_is_wsl" = "1" ]; then
@@ -532,6 +558,15 @@ _unsloth_uninstall_main() {
                     echo "          sudo rm -rf /opt/rocm /opt/rocm-* && sudo ldconfig"
                 fi
             fi
+            # webkit2gtk runtime data, keyed by bundle id. Tauri points the
+            # WebView at LocalData/<bundle id>, so the caches live under
+            # XDG_DATA_HOME; the other three are removed as app data.
+            _bid="ai.unsloth.studio"
+            echo "Removing WebView caches and app data ($_bid)..."
+            _remove_path "${XDG_DATA_HOME:-$HOME/.local/share}/$_bid"
+            _remove_path "${XDG_CACHE_HOME:-$HOME/.cache}/$_bid"
+            _remove_path "${XDG_CONFIG_HOME:-$HOME/.config}/$_bid"
+            _remove_path "${XDG_STATE_HOME:-$HOME/.local/state}/$_bid"
             echo "Removing Linux .desktop entry..."
             _remove_path "$HOME/.local/share/applications/unsloth-studio.desktop"
             if command -v update-desktop-database >/dev/null 2>&1; then
@@ -542,6 +577,8 @@ _unsloth_uninstall_main() {
 
     echo ""
     echo "Unsloth Studio uninstalled."
+    echo "Note: this also removed the app's WebView data, so the signed-in session,"
+    echo "      saved provider API keys and local chat history are gone."
     echo "Note: Hugging Face model cache at ~/.cache/huggingface was left in place."
     echo "Remove it manually with 'rm -rf ~/.cache/huggingface/hub' if desired."
     # Env-mode installs leave no breadcrumb in $HOME, so a custom root can

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -619,6 +619,17 @@ _unsloth_uninstall_main() {
             _remove_path "$(_xdg_dir "${XDG_STATE_HOME:-}" "$HOME/.local/state")/$_bid"
             echo "Removing Linux .desktop entry..."
             _remove_path "$HOME/.local/share/applications/unsloth-studio.desktop"
+            # tauri-plugin-deep-link writes "<exe>-handler.desktop" next to it on
+            # every launch to register the unsloth:// scheme, so it exists on any
+            # machine the app has ever started on. Left behind it is a dangling
+            # handler that points at a binary we just deleted. Unlike install.sh's
+            # own shortcut, the plugin resolves the directory through Tauri's
+            # data_dir(), which honours XDG_DATA_HOME, so check both.
+            _un_appdir="$(_xdg_dir "${XDG_DATA_HOME:-}" "$HOME/.local/share")/applications"
+            _remove_path "$_un_appdir/unsloth-studio-handler.desktop"
+            if [ "$_un_appdir" != "$HOME/.local/share/applications" ]; then
+                _remove_path "$HOME/.local/share/applications/unsloth-studio-handler.desktop"
+            fi
             if command -v update-desktop-database >/dev/null 2>&1; then
                 update-desktop-database "$HOME/.local/share/applications" 2>/dev/null || true
             fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -188,24 +188,50 @@ $_roots_from_conf"
     fi
 }
 
-# Set by _remove_path when an rm fails, read by the closing summary. Cleared up front so a
-# stale file from an interrupted run cannot make this one report a failure it never had.
-_REMOVE_FAILED_FLAG="${TMPDIR:-/tmp}/.unsloth-uninstall-failed.$$"
-rm -f "$_REMOVE_FAILED_FLAG" 2>/dev/null || true
-
-# Set when a removed install root actually held studio.db, read by the closing summary.
+# Two pieces of state the closing summary needs, carried in files rather than variables:
+# custom roots are removed inside a pipeline subshell, where an assignment would never
+# reach the summary.
+#   remove-failed  an rm failed, or a root was skipped while still holding data
+#   db-removed     a removed install root actually held studio.db
 # studio.db is what holds chat_threads/chat_messages and the saved provider keys
 # (backend/storage/studio_db.py, providers_db.py, both via studio_root()), and it lives
 # under the install root, so an env-mode install keeps it inside the custom root. A bare
 # run with neither variable exported cannot discover that root, so the summary must not
-# claim the history is gone unless a database was really deleted. Also a marker file, not
-# a variable: custom roots are removed inside a pipeline subshell.
-_DB_REMOVED_FLAG="${TMPDIR:-/tmp}/.unsloth-uninstall-db-removed.$$"
-rm -f "$_DB_REMOVED_FLAG" 2>/dev/null || true
+# claim the history is gone unless a database was really deleted.
+#
+# mktemp -d, not a PID-derived name under $TMPDIR: the directory is private (0700) and
+# unpredictable, so the markers cannot collide with, or be pre-created by, anything else.
+_MARKER_DIR=$(mktemp -d 2>/dev/null || true)
+_REMOVE_FAILED_FLAG=""
+_DB_REMOVED_FLAG=""
+if [ -n "$_MARKER_DIR" ] && [ -d "$_MARKER_DIR" ]; then
+    _REMOVE_FAILED_FLAG="$_MARKER_DIR/remove-failed"
+    _DB_REMOVED_FLAG="$_MARKER_DIR/db-removed"
+fi
+
+# `printf`, never `: > "$f"`. `:` is a POSIX special builtin, so a redirection error on it
+# terminates a non-interactive shell outright, and `2>/dev/null || true` does not stop it:
+# dash exits 2 and busybox ash exits 1, aborting the uninstall partway through. printf is
+# a regular builtin, so the same failure is just a nonzero status.
+_set_marker() {
+    [ -n "$1" ] || return 0
+    printf '' > "$1" 2>/dev/null || true
+    return 0
+}
+_marker_set() { [ -n "$1" ] && [ -f "$1" ]; }
+
+# EXIT, not a line at the end of main: --help returns early, an unknown argument exits
+# non-zero, and `set -e` can fire partway through, none of which would reach it.
+_cleanup_markers() {
+    if [ -n "$_MARKER_DIR" ]; then
+        rm -rf "$_MARKER_DIR" 2>/dev/null || true
+    fi
+}
+trap _cleanup_markers EXIT
 
 # Record whether the install root about to be removed carries a studio.db.
 _note_studio_db() {
-    [ -f "$1/studio.db" ] && { : > "$_DB_REMOVED_FLAG" 2>/dev/null || true; }
+    [ -f "$1/studio.db" ] && _set_marker "$_DB_REMOVED_FLAG"
     return 0
 }
 
@@ -218,7 +244,7 @@ _remove_path() {
             echo "  could not remove: $_p" >&2
             # A marker file, not a variable: custom roots are removed inside a pipeline
             # subshell, where an assignment would never reach the summary below.
-            : > "$_REMOVE_FAILED_FLAG" 2>/dev/null || true
+            _set_marker "$_REMOVE_FAILED_FLAG"
         fi
     fi
 }
@@ -359,7 +385,7 @@ _unsloth_uninstall_main() {
             # install.sh accepts any writable root, so this can be a real install under a
             # path the deny list covers (/var/tmp/studio needs no elevation). Nothing is
             # deleted, and it holds studio.db and the auth data, so the summary must say so.
-            [ -d "$_custom_root" ] && { : > "$_REMOVE_FAILED_FLAG" 2>/dev/null || true; }
+            [ -d "$_custom_root" ] && _set_marker "$_REMOVE_FAILED_FLAG"
             continue
         fi
         if ! _is_studio_root "$_custom_root"; then
@@ -662,12 +688,11 @@ _unsloth_uninstall_main() {
 
     echo ""
     echo "Unsloth Studio uninstalled."
-    if [ -f "$_REMOVE_FAILED_FLAG" ]; then
-        rm -f "$_REMOVE_FAILED_FLAG" 2>/dev/null || true
+    if _marker_set "$_REMOVE_FAILED_FLAG"; then
         echo "Note: some paths could not be removed (see 'could not remove:' above), so the"
         echo "      signed-in session, saved provider API keys and local chat history may"
         echo "      still be on disk. Remove those paths by hand to clear them."
-    elif [ -f "$_DB_REMOVED_FLAG" ]; then
+    elif _marker_set "$_DB_REMOVED_FLAG"; then
         echo "Note: this also removed the app's WebView data and studio.db, so the signed-in"
         echo "      session, saved provider API keys and local chat history are gone."
     else
@@ -678,7 +703,6 @@ _unsloth_uninstall_main() {
         echo "      No studio.db was found, so any saved provider API keys and chat history in"
         echo "      an install root this run did not see are still on disk."
     fi
-    rm -f "$_DB_REMOVED_FLAG" 2>/dev/null || true
     echo "Note: Hugging Face model cache at ~/.cache/huggingface was left in place."
     echo "Remove it manually with 'rm -rf ~/.cache/huggingface/hub' if desired."
     # Env-mode installs leave no breadcrumb in $HOME, so a custom root can

--- a/tests/sh/test_uninstall_sd_cpp_custom_root.sh
+++ b/tests/sh/test_uninstall_sd_cpp_custom_root.sh
@@ -31,9 +31,8 @@ HELPERS_FILE=$(mktemp -p "$_TMP_ROOT")
     sed -n '/^_remove_path() {/,/^}/p'      "$UNINSTALL_SH"
     sed -n '/^_is_studio_root() {/,/^}/p'   "$UNINSTALL_SH"
     sed -n '/^_is_unsafe_root() {/,/^}/p'   "$UNINSTALL_SH"
-    # The loop removes each root through this wrapper; without it, and without the
-    # marker helpers it calls, the extracted fragment dies with "command not found"
-    # and every assertion below is vacuous.
+    # The loop removes roots through this wrapper; without it and its marker helper the
+    # fragment dies with "command not found" and every assertion below is vacuous.
     sed -n '/^_set_marker() {/,/^}/p'              "$UNINSTALL_SH"
     sed -n '/^_remove_root_recording_db() {/,/^}/p' "$UNINSTALL_SH"
 } > "$HELPERS_FILE"

--- a/tests/sh/test_uninstall_sd_cpp_custom_root.sh
+++ b/tests/sh/test_uninstall_sd_cpp_custom_root.sh
@@ -31,9 +31,11 @@ HELPERS_FILE=$(mktemp -p "$_TMP_ROOT")
     sed -n '/^_remove_path() {/,/^}/p'      "$UNINSTALL_SH"
     sed -n '/^_is_studio_root() {/,/^}/p'   "$UNINSTALL_SH"
     sed -n '/^_is_unsafe_root() {/,/^}/p'   "$UNINSTALL_SH"
-    # The loop calls this before removing a root; without it the extracted fragment
-    # dies with "command not found" and every assertion below is vacuous.
-    sed -n '/^_note_studio_db() {/,/^}/p'   "$UNINSTALL_SH"
+    # The loop removes each root through this wrapper; without it, and without the
+    # marker helpers it calls, the extracted fragment dies with "command not found"
+    # and every assertion below is vacuous.
+    sed -n '/^_set_marker() {/,/^}/p'              "$UNINSTALL_SH"
+    sed -n '/^_remove_root_recording_db() {/,/^}/p' "$UNINSTALL_SH"
 } > "$HELPERS_FILE"
 # Both blocks sit inside the main removal function, so they are indented: anchor on optional
 # leading whitespace, never on column 0, or the range matches nothing and every assertion below

--- a/tests/sh/test_uninstall_sd_cpp_custom_root.sh
+++ b/tests/sh/test_uninstall_sd_cpp_custom_root.sh
@@ -31,6 +31,9 @@ HELPERS_FILE=$(mktemp -p "$_TMP_ROOT")
     sed -n '/^_remove_path() {/,/^}/p'      "$UNINSTALL_SH"
     sed -n '/^_is_studio_root() {/,/^}/p'   "$UNINSTALL_SH"
     sed -n '/^_is_unsafe_root() {/,/^}/p'   "$UNINSTALL_SH"
+    # The loop calls this before removing a root; without it the extracted fragment
+    # dies with "command not found" and every assertion below is vacuous.
+    sed -n '/^_note_studio_db() {/,/^}/p'   "$UNINSTALL_SH"
 } > "$HELPERS_FILE"
 # Both blocks sit inside the main removal function, so they are indented: anchor on optional
 # leading whitespace, never on column 0, or the range matches nothing and every assertion below

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -7,8 +7,8 @@
 # at first app launch, not at install time, so the uninstaller used to miss it
 # and a leftover cache served a stale frontend to the next install. Runs the
 # full script against a fixture HOME (pkill/defaults stubbed via PATH, OS
-# branch picked by a stubbed uname) and asserts bundle-id paths are removed
-# while unrelated app data survives.
+# branch picked by a stubbed uname, /proc/version WSL probe force-failed) and
+# asserts bundle-id paths are removed while unrelated app data survives.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -28,6 +28,29 @@ assert_present() { _l="$1"; if [ -e "$2" ]; then echo "  PASS: $_l"; PASS=$((PAS
 STUB_BIN="$_TMP_ROOT/stubbin"
 mkdir -p "$STUB_BIN"
 for _tool in pkill defaults; do
+    printf '#!/bin/sh\nexit 0\n' > "$STUB_BIN/$_tool"
+    chmod +x "$STUB_BIN/$_tool"
+done
+# Force the non-WSL path: with uname stubbed to Linux on a WSL host, the
+# script's `grep -qi microsoft /proc/version` probe would still fire and the
+# real WSL cleanup would touch the host's /mnt/* shortcuts and /etc profile.
+# Fail that one probe; delegate every other grep call to the real grep.
+# REAL_GREP must be an absolute path: a bare "grep" (e.g. from an alias-shaped
+# `command -v` result) would resolve back to this stub and self-exec forever.
+REAL_GREP=$(command -v grep)
+case "$REAL_GREP" in /*) ;; *) REAL_GREP=/usr/bin/grep ;; esac
+cat > "$STUB_BIN/grep" <<EOF
+#!/bin/sh
+for _a in "\$@"; do
+    [ "\$_a" = "/proc/version" ] && exit 1
+done
+exec "$REAL_GREP" "\$@"
+EOF
+chmod +x "$STUB_BIN/grep"
+# Belt and braces should the WSL branch ever be entered anyway: powershell.exe
+# exiting 0 makes its no-op path taken (and skips the /mnt/* drvfs fallback);
+# sudo exiting 0 without running its argv keeps /etc untouched.
+for _tool in powershell.exe sudo; do
     printf '#!/bin/sh\nexit 0\n' > "$STUB_BIN/$_tool"
     chmod +x "$STUB_BIN/$_tool"
 done

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+# Regression tests for WebView runtime-data cleanup in scripts/uninstall.sh.
+#
+# WKWebView (macOS) and webkit2gtk (Linux) create data keyed by the bundle id
+# at first app launch, not at install time, so the uninstaller used to miss it
+# and a leftover cache served a stale frontend to the next install. Runs the
+# full script against a fixture HOME (pkill/defaults stubbed via PATH, OS
+# branch picked by a stubbed uname) and asserts bundle-id paths are removed
+# while unrelated app data survives.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+UNINSTALL_SH="$SCRIPT_DIR/../../scripts/uninstall.sh"
+BID="ai.unsloth.studio"
+PASS=0
+FAIL=0
+
+_TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$_TMP_ROOT"' EXIT
+
+assert_gone()    { _l="$1"; if [ -e "$2" ]; then echo "  FAIL: $_l (still present: $2)"; FAIL=$((FAIL+1)); else echo "  PASS: $_l"; PASS=$((PASS+1)); fi; }
+assert_present() { _l="$1"; if [ -e "$2" ]; then echo "  PASS: $_l"; PASS=$((PASS+1)); else echo "  FAIL: $_l (missing: $2)"; FAIL=$((FAIL+1)); fi; }
+
+# Stub out process kills and macOS pref/LaunchServices tools so the script can
+# run against a fixture HOME without touching the real system.
+STUB_BIN="$_TMP_ROOT/stubbin"
+mkdir -p "$STUB_BIN"
+for _tool in pkill defaults; do
+    printf '#!/bin/sh\nexit 0\n' > "$STUB_BIN/$_tool"
+    chmod +x "$STUB_BIN/$_tool"
+done
+
+# run_uninstall <home> <uname_output> : run the full script with a stubbed OS.
+run_uninstall() {
+    printf '#!/bin/sh\necho %s\n' "$2" > "$STUB_BIN/uname"
+    chmod +x "$STUB_BIN/uname"
+    env -u UNSLOTH_STUDIO_HOME -u STUDIO_HOME \
+        -u XDG_CACHE_HOME -u XDG_DATA_HOME -u XDG_CONFIG_HOME -u XDG_STATE_HOME \
+        HOME="$1" PATH="$STUB_BIN:$PATH" sh "$UNINSTALL_SH" >/dev/null 2>&1
+}
+
+# ── 1. macOS: every bundle-id-keyed ~/Library path is removed ──
+H=$(mktemp -d -p "$_TMP_ROOT")
+mkdir -p "$H/Library/Caches/$BID/WebKit/NetworkCache" \
+         "$H/Library/WebKit/$BID/WebsiteData/CacheStorage" \
+         "$H/Library/Application Support/$BID" \
+         "$H/Library/HTTPStorages/$BID" \
+         "$H/Library/Saved Application State/$BID.savedState" \
+         "$H/Library/Preferences" \
+         "$H/Library/Cookies" \
+         "$H/Library/Caches/com.other.app"
+: > "$H/Library/HTTPStorages/$BID.binarycookies"
+: > "$H/Library/Cookies/$BID.binarycookies"
+: > "$H/Library/Preferences/$BID.plist"
+: > "$H/Library/Caches/$BID/stale-frontend.js"
+: > "$H/Library/Caches/com.other.app/keepme"
+run_uninstall "$H" Darwin
+assert_gone "macOS: Caches/$BID removed"                     "$H/Library/Caches/$BID"
+assert_gone "macOS: WebKit/$BID removed"                     "$H/Library/WebKit/$BID"
+assert_gone "macOS: Application Support/$BID removed"        "$H/Library/Application Support/$BID"
+assert_gone "macOS: HTTPStorages/$BID removed"               "$H/Library/HTTPStorages/$BID"
+assert_gone "macOS: HTTPStorages/$BID.binarycookies removed" "$H/Library/HTTPStorages/$BID.binarycookies"
+assert_gone "macOS: Cookies/$BID.binarycookies removed"      "$H/Library/Cookies/$BID.binarycookies"
+assert_gone "macOS: Saved Application State removed"         "$H/Library/Saved Application State/$BID.savedState"
+assert_gone "macOS: Preferences/$BID.plist removed"          "$H/Library/Preferences/$BID.plist"
+assert_present "macOS: unrelated app cache kept"             "$H/Library/Caches/com.other.app/keepme"
+
+# ── 2. Linux: bundle-id-keyed XDG default paths are removed ──
+H=$(mktemp -d -p "$_TMP_ROOT")
+mkdir -p "$H/.cache/$BID" "$H/.local/share/$BID" "$H/.config/$BID" \
+         "$H/.local/state/$BID" "$H/.cache/other.app"
+run_uninstall "$H" Linux
+assert_gone "linux: ~/.cache/$BID removed"       "$H/.cache/$BID"
+assert_gone "linux: ~/.local/share/$BID removed" "$H/.local/share/$BID"
+assert_gone "linux: ~/.config/$BID removed"      "$H/.config/$BID"
+assert_gone "linux: ~/.local/state/$BID removed" "$H/.local/state/$BID"
+assert_present "linux: unrelated app cache kept" "$H/.cache/other.app"
+
+# ── 3. Linux: XDG_*_HOME overrides are honored ──
+H=$(mktemp -d -p "$_TMP_ROOT")
+XDG=$(mktemp -d -p "$_TMP_ROOT")
+mkdir -p "$XDG/cache/$BID" "$XDG/data/$BID" "$XDG/config/$BID" "$XDG/state/$BID"
+printf '#!/bin/sh\necho Linux\n' > "$STUB_BIN/uname"
+chmod +x "$STUB_BIN/uname"
+env -u UNSLOTH_STUDIO_HOME -u STUDIO_HOME \
+    XDG_CACHE_HOME="$XDG/cache" XDG_DATA_HOME="$XDG/data" \
+    XDG_CONFIG_HOME="$XDG/config" XDG_STATE_HOME="$XDG/state" \
+    HOME="$H" PATH="$STUB_BIN:$PATH" sh "$UNINSTALL_SH" >/dev/null 2>&1
+assert_gone "linux: XDG_CACHE_HOME override honored"  "$XDG/cache/$BID"
+assert_gone "linux: XDG_DATA_HOME override honored"   "$XDG/data/$BID"
+assert_gone "linux: XDG_CONFIG_HOME override honored" "$XDG/config/$BID"
+assert_gone "linux: XDG_STATE_HOME override honored"  "$XDG/state/$BID"
+
+# ── 4. Nothing to remove is a clean no-op (fresh HOME, exit 0) ──
+H=$(mktemp -d -p "$_TMP_ROOT")
+if run_uninstall "$H" Darwin; then
+    echo "  PASS: empty HOME -> no-op exit 0"; PASS=$((PASS+1))
+else
+    echo "  FAIL: empty HOME -> nonzero exit"; FAIL=$((FAIL+1))
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" = 0 ]

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -494,6 +494,15 @@ for _case in dbremoved nodb; do
             echo "  PASS: $_case: says where the keys actually are"; PASS=$((PASS+1)) ;;
         *)  echo "  FAIL: $_case: never says where the keys actually are"; FAIL=$((FAIL+1)) ;;
     esac
+    # Removing the WebView profile clears the desktop app's session only. A browser
+    # session keeps its tokens in localStorage (frontend/src/features/auth/session.ts),
+    # which this script never touches, so an unqualified claim is wrong there too.
+    case "$_out" in
+        *"the signed-in session is gone"*)
+            echo "  FAIL: $_case: unqualified signed-out claim"; FAIL=$((FAIL+1)) ;;
+        *)  echo "  PASS: $_case: signed-out claim scoped to the desktop app"
+            PASS=$((PASS+1)) ;;
+    esac
 done
 
 # ── 3k. _set_marker itself must survive a write it cannot perform. 3i only proves the

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -374,6 +374,56 @@ case "$_out" in
         FAIL=$((FAIL+1)) ;;
 esac
 
+# ── 3j3. A relocated install: ~/.unsloth/studio is a symlink to another disk. rm -rf on a
+# symlink unlinks the link and leaves the target, so the database survives and the summary
+# must not report it gone. Reachable whenever a user moves Studio off the system disk. ──
+H=$(new_home)
+_ELSEWHERE=$(mktemp -d "$_TMP_ROOT/otherdisk.XXXXXX")
+mkdir -p "$_ELSEWHERE/unsloth_studio" "$H/.unsloth"
+: > "$_ELSEWHERE/unsloth_studio/.unsloth-studio-owned"
+: > "$_ELSEWHERE/studio.db"
+ln -s "$_ELSEWHERE" "$H/.unsloth/studio"
+_out=$(run_uninstall_out "$H" Linux)
+assert_present "linux: relocated studio.db survived the symlink removal" "$_ELSEWHERE/studio.db"
+case "$_out" in
+    *"studio.db it found"*)
+        echo "  FAIL: linux: claimed the database is gone but it is on the other disk"
+        FAIL=$((FAIL+1)) ;;
+    *)
+        echo "  PASS: linux: relocated install -> no claim that the database is gone"
+        PASS=$((PASS+1)) ;;
+esac
+case "$_out" in
+    *"may"*"still be on disk"*)
+        echo "  PASS: linux: relocated install reported as incomplete"; PASS=$((PASS+1)) ;;
+    *)
+        echo "  FAIL: linux: relocated install not reported as incomplete"; FAIL=$((FAIL+1)) ;;
+esac
+
+# ── 3j4. Marker storage that vanishes mid-run. The pathname still looks fine, so a
+# predicate that only tests for emptiness keeps reporting success while every failure
+# _set_marker tried to record was silently dropped. ──
+H=$(new_home)
+mkdir -p "$H/.local/share/$BID"
+_VAN=$(mktemp -d "$_TMP_ROOT/vanish.XXXXXX")
+# mktemp -d names a directory it does not leave behind. Deterministic, rather than racing
+# a background delete: $_MARKER_DIR is non-empty so the pathname still looks usable, which
+# is the state the predicate has to catch.
+cat > "$STUB_BIN/mktemp" <<EOF
+#!/bin/sh
+printf '%s\n' "$_VAN/marker.gone"
+exit 0
+EOF
+chmod +x "$STUB_BIN/mktemp"
+_out=$(run_uninstall_out "$H" Linux)
+rm -f "$STUB_BIN/mktemp"
+case "$_out" in
+    *"may"*"still be on disk"*)
+        echo "  PASS: linux: vanished marker dir -> cautious summary"; PASS=$((PASS+1)) ;;
+    *)
+        echo "  FAIL: linux: vanished marker dir still reported success"; FAIL=$((FAIL+1)) ;;
+esac
+
 # ── 3k. _set_marker itself must survive a write it cannot perform. 3i only proves the
 # mktemp -d guard holds, since an unusable TMPDIR leaves the marker path empty and the
 # redirection never runs. This drives the redirection directly: the marker directory

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -34,10 +34,17 @@ assert_present() { _l="$1"; if [ -e "$2" ]; then echo "  PASS: $_l"; PASS=$((PAS
 # Kill and macOS pref tools, stubbed so the script leaves the real system alone.
 STUB_BIN="$_TMP_ROOT/stubbin"
 mkdir -p "$STUB_BIN"
-for _tool in pkill defaults; do
-    printf '#!/bin/sh\nexit 0\n' > "$STUB_BIN/$_tool"
-    chmod +x "$STUB_BIN/$_tool"
-done
+printf '#!/bin/sh\nexit 0\n' > "$STUB_BIN/defaults"
+chmod +x "$STUB_BIN/defaults"
+# pkill records its argv so the app kill can be asserted; real pkill exits 1 on no match,
+# so mimic that rather than a blanket 0, which would hide a missing `|| true`.
+PKILL_LOG="$_TMP_ROOT/pkill.args"
+cat > "$STUB_BIN/pkill" <<EOF
+#!/bin/sh
+printf '%s\n' "\$*" >> "$PKILL_LOG"
+exit 1
+EOF
+chmod +x "$STUB_BIN/pkill"
 # On a WSL host the script's `grep -qi microsoft /proc/version` probe fires even with uname
 # stubbed to Linux, and the real WSL cleanup would touch the host's /mnt/* shortcuts and /etc
 # profile. Fail that one probe, delegate the rest. REAL_GREP must be absolute or the stub
@@ -108,6 +115,14 @@ assert_gone "linux: ~/.local/share/$BID removed" "$H/.local/share/$BID"
 assert_gone "linux: ~/.config/$BID removed"      "$H/.config/$BID"
 assert_gone "linux: ~/.local/state/$BID removed" "$H/.local/state/$BID"
 assert_present "linux: unrelated app cache kept" "$H/.cache/other.app"
+# The app kill must be scoped: unscoped, a root-run uninstall signals every user's
+# unsloth-studio. -u takes the owner of the $HOME being cleared, not just `id -u`.
+_want_uid=$(stat -c %u "$H" 2>/dev/null || stat -f %u "$H")
+if grep -q -- "-x -u $_want_uid unsloth-studio" "$PKILL_LOG" 2>/dev/null; then
+    echo "  PASS: linux: app kill scoped to the \$HOME owner"; PASS=$((PASS+1))
+else
+    echo "  FAIL: linux: app kill not scoped (want '-x -u $_want_uid unsloth-studio')"; FAIL=$((FAIL+1))
+fi
 
 # ── 3. Linux: XDG_*_HOME overrides are honored ──
 H=$(new_home)

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -6,9 +6,9 @@
 # WKWebView (macOS) and webkit2gtk (Linux) create data keyed by the bundle id
 # at first app launch, not at install time, so the uninstaller used to miss it
 # and a leftover cache served a stale frontend to the next install. Runs the
-# full script against a fixture HOME (pkill/defaults stubbed via PATH, OS
-# branch picked by a stubbed uname, /proc/version WSL probe force-failed) and
-# asserts bundle-id paths are removed while unrelated app data survives.
+# full script against a fixture HOME with the OS branch and the system tools
+# it calls stubbed via PATH, and asserts bundle-id paths are removed while
+# unrelated app data survives.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -20,8 +20,8 @@ FAIL=0
 _TMP_ROOT=$(mktemp -d)
 trap 'rm -rf "$_TMP_ROOT"' EXIT
 
-# The script sweeps $XDG_RUNTIME_DIR/unsloth-studio-launcher-<uid>*.lock, so an
-# unsandboxed runtime dir means this test deletes the real launcher's locks.
+# The script sweeps $XDG_RUNTIME_DIR/unsloth-studio-launcher-<uid>*.lock, so
+# an unsandboxed runtime dir would cost the real launcher its locks.
 XDG_RUNTIME_DIR="$_TMP_ROOT/run"
 export XDG_RUNTIME_DIR
 mkdir -p "$XDG_RUNTIME_DIR"
@@ -33,20 +33,17 @@ new_home() { mktemp -d "$_TMP_ROOT/home.XXXXXX"; }
 assert_gone()    { _l="$1"; if [ -e "$2" ]; then echo "  FAIL: $_l (still present: $2)"; FAIL=$((FAIL+1)); else echo "  PASS: $_l"; PASS=$((PASS+1)); fi; }
 assert_present() { _l="$1"; if [ -e "$2" ]; then echo "  PASS: $_l"; PASS=$((PASS+1)); else echo "  FAIL: $_l (missing: $2)"; FAIL=$((FAIL+1)); fi; }
 
-# Stub out process kills and macOS pref/LaunchServices tools so the script can
-# run against a fixture HOME without touching the real system.
+# Kills and macOS pref tools, stubbed so the script leaves the real system alone.
 STUB_BIN="$_TMP_ROOT/stubbin"
 mkdir -p "$STUB_BIN"
 for _tool in pkill defaults; do
     printf '#!/bin/sh\nexit 0\n' > "$STUB_BIN/$_tool"
     chmod +x "$STUB_BIN/$_tool"
 done
-# Force the non-WSL path: with uname stubbed to Linux on a WSL host, the
-# script's `grep -qi microsoft /proc/version` probe would still fire and the
-# real WSL cleanup would touch the host's /mnt/* shortcuts and /etc profile.
-# Fail that one probe; delegate every other grep call to the real grep.
-# REAL_GREP must be an absolute path: a bare "grep" (e.g. from an alias-shaped
-# `command -v` result) would resolve back to this stub and self-exec forever.
+# On a WSL host the script's `grep -qi microsoft /proc/version` probe fires
+# even with uname stubbed to Linux, and the real WSL cleanup would touch the
+# host's /mnt/* shortcuts and /etc profile. Fail that one probe, delegate the
+# rest. REAL_GREP must be absolute or the stub execs itself forever.
 REAL_GREP=$(command -v grep)
 case "$REAL_GREP" in /*) ;; *) REAL_GREP=/usr/bin/grep ;; esac
 cat > "$STUB_BIN/grep" <<EOF
@@ -57,9 +54,9 @@ done
 exec "$REAL_GREP" "\$@"
 EOF
 chmod +x "$STUB_BIN/grep"
-# Belt and braces should the WSL branch ever be entered anyway: powershell.exe
-# exiting 0 makes its no-op path taken (and skips the /mnt/* drvfs fallback);
-# sudo exiting 0 without running its argv keeps /etc untouched.
+# Belt and braces if the WSL branch is entered anyway: powershell.exe exiting 0
+# takes the no-op path (skipping the /mnt/* drvfs fallback), and sudo exiting 0
+# without running its argv keeps /etc untouched.
 for _tool in powershell.exe sudo; do
     printf '#!/bin/sh\nexit 0\n' > "$STUB_BIN/$_tool"
     chmod +x "$STUB_BIN/$_tool"

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -264,7 +264,7 @@ _out=$(env -u UNSLOTH_STUDIO_HOME -u STUDIO_HOME \
     HOME="$H" PATH="$STUB_BIN:$PATH" sh "$UNINSTALL_SH" 2>/dev/null)
 assert_present "linux: undiscovered env-mode studio.db survives" "$CUSTOM2/studio.db"
 case "$_out" in
-    *"chat history are gone."*)
+    *"studio.db it found"*)
         echo "  FAIL: linux: claimed chat history is gone with studio.db still on disk"
         FAIL=$((FAIL+1)) ;;
     *) echo "  PASS: linux: no studio.db removed -> no claim that the history is gone"
@@ -280,7 +280,7 @@ mkdir -p "$H/.unsloth/studio/unsloth_studio"
 _out=$(run_uninstall_out "$H" Linux)
 assert_gone "linux: default-mode studio.db removed" "$H/.unsloth/studio/studio.db"
 case "$_out" in
-    *"chat history are gone."*)
+    *"studio.db it found"*)
         echo "  PASS: linux: studio.db removed -> summary states the history is gone"
         PASS=$((PASS+1)) ;;
     *) echo "  FAIL: linux: studio.db was removed but the summary never says so"
@@ -338,16 +338,41 @@ for _sh in sh dash busybox; do
     assert_gone "$_sh: cleanup still completed with an unusable TMPDIR" "$_H2/.cache/$BID"
 done
 
-# ── 3j. The marker directory is private and removed on the way out, not left in $TMPDIR ──
+# ── 3j. The marker directory is private and removed on the way out. TMPDIR points at a
+# fixture-owned directory so the check sees only what this run created: counting entries
+# in the shared temp dir would call a concurrent process's mktemp a leak, and an unrelated
+# directory disappearing at the same time would hide a real one. ──
 H=$(new_home)
-_before=$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'tmp.*' 2>/dev/null | wc -l)
-run_uninstall "$H" Linux
-_after=$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'tmp.*' 2>/dev/null | wc -l)
-if [ "$_before" = "$_after" ]; then
+_MK_TMP=$(mktemp -d "$_TMP_ROOT/markertmp.XXXXXX")
+printf '#!/bin/sh\necho Linux\n' > "$STUB_BIN/uname"; chmod +x "$STUB_BIN/uname"
+env -u UNSLOTH_STUDIO_HOME -u STUDIO_HOME \
+    -u XDG_CACHE_HOME -u XDG_DATA_HOME -u XDG_CONFIG_HOME -u XDG_STATE_HOME \
+    TMPDIR="$_MK_TMP" HOME="$H" PATH="$STUB_BIN:$PATH" sh "$UNINSTALL_SH" >/dev/null 2>&1
+_left=$(find "$_MK_TMP" -mindepth 1 2>/dev/null | wc -l)
+if [ "$_left" = 0 ]; then
     echo "  PASS: linux: marker directory cleaned up on exit"; PASS=$((PASS+1))
 else
-    echo "  FAIL: linux: leaked a temp dir ($_before -> $_after)"; FAIL=$((FAIL+1))
+    echo "  FAIL: linux: left $_left entries in TMPDIR"; FAIL=$((FAIL+1))
+    find "$_MK_TMP" -mindepth 1 | sed 's/^/         /'
 fi
+
+# ── 3j2. With no marker storage at all there is no record of what failed, so the summary
+# must take the cautious branch rather than reporting the session gone. mktemp is stubbed
+# to fail, which is what an unwritable or missing TMPDIR produces. ──
+H=$(new_home)
+mkdir -p "$H/.unsloth/studio/unsloth_studio"
+: > "$H/.unsloth/studio/unsloth_studio/.unsloth-studio-owned"
+: > "$H/.unsloth/studio/studio.db"
+printf '#!/bin/sh\nexit 1\n' > "$STUB_BIN/mktemp"; chmod +x "$STUB_BIN/mktemp"
+_out=$(run_uninstall_out "$H" Linux)
+rm -f "$STUB_BIN/mktemp"
+case "$_out" in
+    *"may"*"still be on disk"*)
+        echo "  PASS: linux: no marker storage -> cautious summary"; PASS=$((PASS+1)) ;;
+    *)
+        echo "  FAIL: linux: no marker storage but the summary still reported success"
+        FAIL=$((FAIL+1)) ;;
+esac
 
 # ── 3k. _set_marker itself must survive a write it cannot perform. 3i only proves the
 # mktemp -d guard holds, since an unusable TMPDIR leaves the marker path empty and the

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -20,15 +20,14 @@ FAIL=0
 _TMP_ROOT=$(mktemp -d)
 trap 'rm -rf "$_TMP_ROOT"' EXIT
 
-# The script deletes $XDG_RUNTIME_DIR/unsloth-studio-launcher-<uid>*.lock, so
-# without a fixture-owned runtime dir this test removes the real launcher's
-# locks (same pattern as test_uninstall_prebuilt_artifacts.sh).
+# The script sweeps $XDG_RUNTIME_DIR/unsloth-studio-launcher-<uid>*.lock, so an
+# unsandboxed runtime dir means this test deletes the real launcher's locks.
 XDG_RUNTIME_DIR="$_TMP_ROOT/run"
 export XDG_RUNTIME_DIR
 mkdir -p "$XDG_RUNTIME_DIR"
 
-# Explicit mktemp template: -p is GNU-only (BSD mktemp gained it in macOS 14),
-# and a bare mktemp -d implies -t and would land outside _TMP_ROOT on macOS.
+# Explicit template: -p is GNU-only (BSD got it in macOS 14) and a bare
+# mktemp -d implies -t, landing outside _TMP_ROOT on macOS.
 new_home() { mktemp -d "$_TMP_ROOT/home.XXXXXX"; }
 
 assert_gone()    { _l="$1"; if [ -e "$2" ]; then echo "  FAIL: $_l (still present: $2)"; FAIL=$((FAIL+1)); else echo "  PASS: $_l"; PASS=$((PASS+1)); fi; }
@@ -107,7 +106,7 @@ mkdir -p "$H/.cache/$BID" "$H/.local/share/$BID" "$H/.config/$BID" \
          "$H/.local/state/$BID" "$H/.cache/other.app"
 : > "$XDG_RUNTIME_DIR/unsloth-studio-launcher-$(id -u).lock"
 run_uninstall "$H" Linux
-# Proves the launcher-lock sweep landed in the fixture runtime dir, not the real one.
+# Proves the lock sweep hit the fixture runtime dir, not the real one.
 assert_gone "linux: fixture launcher lock removed" \
     "$XDG_RUNTIME_DIR/unsloth-studio-launcher-$(id -u).lock"
 assert_gone "linux: ~/.cache/$BID removed"       "$H/.cache/$BID"

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -239,6 +239,21 @@ case "$_out" in
     *) echo "  PASS: linux: custom-root failure reaches the summary"; PASS=$((PASS+1)) ;;
 esac
 
+# ── 3f. A custom root the deny list refuses is also incomplete removal. install.sh accepts any
+# writable root (mkdir -p + -w, no deny list), so /var/tmp/studio installs without elevation and
+# then survives uninstall untouched. Uses the fixture HOME, which _is_unsafe_root also refuses. ──
+H=$(new_home)
+mkdir -p "$H/share"
+: > "$H/share/studio.conf"
+printf '#!/bin/sh\necho Linux\n' > "$STUB_BIN/uname"; chmod +x "$STUB_BIN/uname"
+_out=$(env -u STUDIO_HOME -u XDG_CACHE_HOME -u XDG_DATA_HOME -u XDG_CONFIG_HOME -u XDG_STATE_HOME \
+    UNSLOTH_STUDIO_HOME="$H" HOME="$H" PATH="$STUB_BIN:$PATH" sh "$UNINSTALL_SH" 2>/dev/null)
+assert_present "linux: the deny-listed root was left alone" "$H/share/studio.conf"
+case "$_out" in
+    *"are gone."*) echo "  FAIL: linux: deny-listed root still claimed the data is gone"; FAIL=$((FAIL+1)) ;;
+    *) echo "  PASS: linux: deny-listed root counts as incomplete removal"; PASS=$((PASS+1)) ;;
+esac
+
 # ── 4. Nothing to remove is a clean no-op (fresh HOME, exit 0) ──
 H=$(new_home)
 if run_uninstall "$H" Darwin; then

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -106,6 +106,9 @@ H=$(new_home)
 mkdir -p "$H/.cache/$BID" "$H/.local/share/$BID" "$H/.config/$BID" \
          "$H/.local/state/$BID" "$H/.cache/other.app"
 : > "$XDG_RUNTIME_DIR/unsloth-studio-launcher-$(id -u).lock"
+# Truncate first: every fixture home has this user's uid, so the Darwin run above logged the
+# same argv and the assertion below would pass on it even if Linux emitted no kill at all.
+: > "$PKILL_LOG"
 run_uninstall "$H" Linux
 # Proves the lock sweep hit the fixture runtime dir, not the real one.
 assert_gone "linux: fixture launcher lock removed" \

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -424,6 +424,49 @@ case "$_out" in
         echo "  FAIL: linux: vanished marker dir still reported success"; FAIL=$((FAIL+1)) ;;
 esac
 
+# ── 3j5. studio.db itself a symlink out of the tree. -f follows it, rm -rf unlinks only
+# the link, so the database survives and the summary must not report it gone. Same root
+# cause as the relocated-install case, different shape. ──
+H=$(new_home)
+_DBTARGET=$(mktemp -d "$_TMP_ROOT/dbtarget.XXXXXX")
+mkdir -p "$H/.unsloth/studio/unsloth_studio"
+: > "$H/.unsloth/studio/unsloth_studio/.unsloth-studio-owned"
+: > "$_DBTARGET/studio.db"
+ln -s "$_DBTARGET/studio.db" "$H/.unsloth/studio/studio.db"
+_out=$(run_uninstall_out "$H" Linux)
+assert_present "linux: symlinked studio.db target survived" "$_DBTARGET/studio.db"
+case "$_out" in
+    *"studio.db it found"*)
+        echo "  FAIL: linux: claimed the database is gone but the target survived"
+        FAIL=$((FAIL+1)) ;;
+    *)  echo "  PASS: linux: symlinked studio.db -> no claim that it is gone"
+        PASS=$((PASS+1)) ;;
+esac
+
+# ── 3j6. Provider API keys are NOT in studio.db. providers_db.py: "API keys are NOT
+# stored here: they live only in the browser (localStorage) and are sent encrypted
+# per-request." install.sh runs with TAURI_MODE=false, so the default install serves the
+# UI to a normal browser and the keys sit in that browser's profile, which this script
+# never touches. No branch may claim they were removed. ──
+for _case in dbremoved nodb; do
+    H=$(new_home)
+    mkdir -p "$H/.unsloth/studio/unsloth_studio"
+    : > "$H/.unsloth/studio/unsloth_studio/.unsloth-studio-owned"
+    [ "$_case" = dbremoved ] && : > "$H/.unsloth/studio/studio.db"
+    _out=$(run_uninstall_out "$H" Linux)
+    case "$_out" in
+        *"saved provider API keys"*|*"API keys and chat history"*|*"API keys and local chat"*)
+            echo "  FAIL: $_case: claimed the provider API keys were removed"; FAIL=$((FAIL+1)) ;;
+        *)  echo "  PASS: $_case: no claim that the provider API keys were removed"
+            PASS=$((PASS+1)) ;;
+    esac
+    case "$_out" in
+        *"localStorage, not in studio.db"*)
+            echo "  PASS: $_case: says where the keys actually are"; PASS=$((PASS+1)) ;;
+        *)  echo "  FAIL: $_case: never says where the keys actually are"; FAIL=$((FAIL+1)) ;;
+    esac
+done
+
 # ── 3k. _set_marker itself must survive a write it cannot perform. 3i only proves the
 # mktemp -d guard holds, since an unusable TMPDIR leaves the marker path empty and the
 # redirection never runs. This drives the redirection directly: the marker directory

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -127,6 +127,24 @@ assert_gone "linux: XDG_DATA_HOME override honored"   "$XDG/data/$BID"
 assert_gone "linux: XDG_CONFIG_HOME override honored" "$XDG/config/$BID"
 assert_gone "linux: XDG_STATE_HOME override honored"  "$XDG/state/$BID"
 
+# ── 3b. Relative XDG overrides are invalid per the spec and dropped by the
+# resolver Tauri uses, so the $HOME default must be removed and the same-named
+# dir under the caller's cwd left alone. ──
+H=$(new_home)
+CWD=$(mktemp -d "$_TMP_ROOT/cwd.XXXXXX")
+mkdir -p "$H/.local/share/$BID" "$H/.cache/$BID" "$H/.config/$BID" "$H/.local/state/$BID" \
+         "$CWD/reldata/$BID" "$CWD/relcache/$BID"
+( cd "$CWD" && env -u UNSLOTH_STUDIO_HOME -u STUDIO_HOME \
+    XDG_DATA_HOME="reldata" XDG_CACHE_HOME="relcache" \
+    XDG_CONFIG_HOME="relconfig" XDG_STATE_HOME="relstate" \
+    HOME="$H" PATH="$STUB_BIN:$PATH" sh "$UNINSTALL_SH" >/dev/null 2>&1 )
+assert_gone    "linux: relative XDG_DATA_HOME falls back to HOME"   "$H/.local/share/$BID"
+assert_gone    "linux: relative XDG_CACHE_HOME falls back to HOME"  "$H/.cache/$BID"
+assert_gone    "linux: relative XDG_CONFIG_HOME falls back to HOME" "$H/.config/$BID"
+assert_gone    "linux: relative XDG_STATE_HOME falls back to HOME"  "$H/.local/state/$BID"
+assert_present "linux: relative XDG left cwd/reldata alone"         "$CWD/reldata/$BID"
+assert_present "linux: relative XDG left cwd/relcache alone"        "$CWD/relcache/$BID"
+
 # ── 4. Nothing to remove is a clean no-op (fresh HOME, exit 0) ──
 H=$(new_home)
 if run_uninstall "$H" Darwin; then

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -302,6 +302,86 @@ case "$_out" in
     *) echo "  PASS: linux: deny-listed root counts as incomplete removal"; PASS=$((PASS+1)) ;;
 esac
 
+# ── 3i. An unusable TMPDIR must not abort the run. The summary markers are written with
+# `printf`, not `: >`: `:` is a POSIX special builtin, so a redirection error on it kills a
+# non-interactive shell outright (dash exits 2, busybox ash 1) and `2>/dev/null || true`
+# does not stop it. The uninstall would then stop partway with most of the tree still there. ──
+H=$(new_home)
+mkdir -p "$H/.cache/$BID" "$H/.unsloth/studio/unsloth_studio"
+: > "$H/.unsloth/studio/unsloth_studio/.unsloth-studio-owned"
+: > "$H/.unsloth/studio/studio.db"
+printf '#!/bin/sh\necho Linux\n' > "$STUB_BIN/uname"; chmod +x "$STUB_BIN/uname"
+for _sh in sh dash busybox; do
+    command -v "$_sh" >/dev/null 2>&1 || continue
+    _H2=$(new_home)
+    mkdir -p "$_H2/.cache/$BID" "$_H2/.unsloth/studio/unsloth_studio"
+    : > "$_H2/.unsloth/studio/unsloth_studio/.unsloth-studio-owned"
+    _rc=0
+    # busybox needs its applet name as a separate argument; spelled out per branch
+    # rather than word-splitting one variable.
+    if [ "$_sh" = busybox ]; then
+        env -u UNSLOTH_STUDIO_HOME -u STUDIO_HOME \
+            -u XDG_CACHE_HOME -u XDG_DATA_HOME -u XDG_CONFIG_HOME -u XDG_STATE_HOME \
+            TMPDIR="$_TMP_ROOT/no-such-tmpdir" HOME="$_H2" PATH="$STUB_BIN:$PATH" \
+            busybox sh "$UNINSTALL_SH" >/dev/null 2>&1 || _rc=$?
+    else
+        env -u UNSLOTH_STUDIO_HOME -u STUDIO_HOME \
+            -u XDG_CACHE_HOME -u XDG_DATA_HOME -u XDG_CONFIG_HOME -u XDG_STATE_HOME \
+            TMPDIR="$_TMP_ROOT/no-such-tmpdir" HOME="$_H2" PATH="$STUB_BIN:$PATH" \
+            "$_sh" "$UNINSTALL_SH" >/dev/null 2>&1 || _rc=$?
+    fi
+    if [ "$_rc" = 0 ]; then
+        echo "  PASS: $_sh: unusable TMPDIR did not abort the run"; PASS=$((PASS+1))
+    else
+        echo "  FAIL: $_sh: unusable TMPDIR aborted with rc=$_rc"; FAIL=$((FAIL+1))
+    fi
+    assert_gone "$_sh: cleanup still completed with an unusable TMPDIR" "$_H2/.cache/$BID"
+done
+
+# ── 3j. The marker directory is private and removed on the way out, not left in $TMPDIR ──
+H=$(new_home)
+_before=$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'tmp.*' 2>/dev/null | wc -l)
+run_uninstall "$H" Linux
+_after=$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'tmp.*' 2>/dev/null | wc -l)
+if [ "$_before" = "$_after" ]; then
+    echo "  PASS: linux: marker directory cleaned up on exit"; PASS=$((PASS+1))
+else
+    echo "  FAIL: linux: leaked a temp dir ($_before -> $_after)"; FAIL=$((FAIL+1))
+fi
+
+# ── 3k. _set_marker itself must survive a write it cannot perform. 3i only proves the
+# mktemp -d guard holds, since an unusable TMPDIR leaves the marker path empty and the
+# redirection never runs. This drives the redirection directly: the marker directory
+# exists at startup and is gone by the time the write happens, which is what an operator
+# clearing /tmp mid-run looks like. With `: >` the shell dies here and takes the rest of
+# the uninstall with it. ──
+_SM_FILE=$(mktemp "$_TMP_ROOT/setmarker.XXXXXX")
+sed -n '/^_set_marker() {/,/^}/p' "$UNINSTALL_SH" > "$_SM_FILE"
+if [ ! -s "$_SM_FILE" ]; then
+    echo "  FAIL: could not extract _set_marker"; FAIL=$((FAIL+1))
+else
+    for _sh in dash busybox sh; do
+        command -v "$_sh" >/dev/null 2>&1 || continue
+        _probe=$(mktemp "$_TMP_ROOT/probe.XXXXXX")
+        {
+            cat "$_SM_FILE"
+            echo '_set_marker "'"$_TMP_ROOT"'/gone-dir/marker"'
+            echo 'echo SURVIVED'
+        } > "$_probe"
+        if [ "$_sh" = busybox ]; then
+            _got=$(busybox sh "$_probe" 2>/dev/null)
+        else
+            _got=$("$_sh" "$_probe" 2>/dev/null)
+        fi
+        if [ "$_got" = "SURVIVED" ]; then
+            echo "  PASS: $_sh: _set_marker survives an impossible write"; PASS=$((PASS+1))
+        else
+            echo "  FAIL: $_sh: _set_marker killed the shell (special-builtin redirection)"
+            FAIL=$((FAIL+1))
+        fi
+    done
+fi
+
 # ── 4. Nothing to remove is a clean no-op (fresh HOME, exit 0) ──
 H=$(new_home)
 if run_uninstall "$H" Darwin; then

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -75,6 +75,15 @@ run_uninstall() {
         HOME="$1" PATH="$STUB_BIN:$PATH" sh "$UNINSTALL_SH" >/dev/null 2>&1
 }
 
+# Same, but capture stdout so the closing summary can be asserted.
+run_uninstall_out() {
+    printf '#!/bin/sh\necho %s\n' "$2" > "$STUB_BIN/uname"
+    chmod +x "$STUB_BIN/uname"
+    env -u UNSLOTH_STUDIO_HOME -u STUDIO_HOME \
+        -u XDG_CACHE_HOME -u XDG_DATA_HOME -u XDG_CONFIG_HOME -u XDG_STATE_HOME \
+        HOME="$1" PATH="$STUB_BIN:$PATH" sh "$UNINSTALL_SH" 2>/dev/null
+}
+
 # ── 1. macOS: every bundle-id-keyed ~/Library path is removed ──
 H=$(new_home)
 mkdir -p "$H/Library/Caches/$BID/WebKit/NetworkCache" \
@@ -158,6 +167,40 @@ assert_gone    "linux: relative XDG_CONFIG_HOME falls back to HOME" "$H/.config/
 assert_gone    "linux: relative XDG_STATE_HOME falls back to HOME"  "$H/.local/state/$BID"
 assert_present "linux: relative XDG left cwd/reldata alone"         "$CWD/reldata/$BID"
 assert_present "linux: relative XDG left cwd/relcache alone"        "$CWD/relcache/$BID"
+
+# ── 3d. A symlinked $HOME still resolves an owner and still clears the target. stat lstats by
+# default, so without -L a root-owned link to a user-owned home would resolve to uid 0. Owner
+# and target owner match here, so this guards the symlink path, not the differing-owner case. ──
+H=$(new_home)
+_HL="$_TMP_ROOT/homelink.$$"
+ln -s "$H" "$_HL"
+mkdir -p "$H/.cache/$BID" "$H/.local/share/$BID"
+: > "$PKILL_LOG"
+run_uninstall "$_HL" Linux
+_want_uid=$(stat -L -c %u "$_HL" 2>/dev/null || stat -L -f %u "$_HL")
+if grep -q -- "-x -u $_want_uid unsloth-studio" "$PKILL_LOG" 2>/dev/null; then
+    echo "  PASS: linux: symlinked HOME still scopes the kill"; PASS=$((PASS+1))
+else
+    echo "  FAIL: linux: symlinked HOME lost the kill scope"; FAIL=$((FAIL+1))
+fi
+assert_gone "linux: symlinked HOME cleared through the link" "$H/.cache/$BID"
+rm -f "$_HL"
+
+# ── 3c. A path that cannot be removed must not be reported as gone. The summary names the
+# session, API keys and chat history, so claiming that after a failed rm is a false all-clear. ──
+H=$(new_home)
+mkdir -p "$H/.cache/$BID/locked"
+chmod 500 "$H/.cache/$BID"          # unlink inside it is refused, so rm -rf fails
+_out=$(run_uninstall_out "$H" Linux)
+chmod 700 "$H/.cache/$BID"          # let the fixture be cleaned up
+case "$_out" in
+    *"may"*"still be on disk"*) echo "  PASS: linux: failed removal is not reported as gone"; PASS=$((PASS+1)) ;;
+    *) echo "  FAIL: linux: failed removal still claimed the data is gone"; FAIL=$((FAIL+1)) ;;
+esac
+case "$_out" in
+    *"are gone."*) echo "  FAIL: linux: summary still asserts the data is gone"; FAIL=$((FAIL+1)) ;;
+    *) echo "  PASS: linux: summary drops the 'are gone' claim"; PASS=$((PASS+1)) ;;
+esac
 
 # ── 4. Nothing to remove is a clean no-op (fresh HOME, exit 0) ──
 H=$(new_home)

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -189,10 +189,22 @@ rm -f "$_HL"
 # ── 3c. A path that cannot be removed must not be reported as gone. The summary names the
 # session, API keys and chat history, so claiming that after a failed rm is a false all-clear. ──
 H=$(new_home)
-mkdir -p "$H/.cache/$BID/locked"
-chmod 500 "$H/.cache/$BID"          # unlink inside it is refused, so rm -rf fails
+mkdir -p "$H/.cache/$BID"
+# An rm stub that refuses this one path, not chmod: root ignores mode bits, so a permission
+# fixture deletes the dir anyway and the cleanup then aborts the suite under set -e.
+REAL_RM=$(command -v rm)
+case "$REAL_RM" in /*) ;; *) REAL_RM=/bin/rm ;; esac
+cat > "$STUB_BIN/rm" <<EOF
+#!/bin/sh
+for _a in "\$@"; do
+    [ "\$_a" = "$H/.cache/$BID" ] && exit 1
+done
+exec "$REAL_RM" "\$@"
+EOF
+chmod +x "$STUB_BIN/rm"
 _out=$(run_uninstall_out "$H" Linux)
-chmod 700 "$H/.cache/$BID"          # let the fixture be cleaned up
+rm -f "$STUB_BIN/rm"
+assert_present "linux: the refused path really did survive" "$H/.cache/$BID"
 case "$_out" in
     *"may"*"still be on disk"*) echo "  PASS: linux: failed removal is not reported as gone"; PASS=$((PASS+1)) ;;
     *) echo "  FAIL: linux: failed removal still claimed the data is gone"; FAIL=$((FAIL+1)) ;;
@@ -200,6 +212,31 @@ esac
 case "$_out" in
     *"are gone."*) echo "  FAIL: linux: summary still asserts the data is gone"; FAIL=$((FAIL+1)) ;;
     *) echo "  PASS: linux: summary drops the 'are gone' claim"; PASS=$((PASS+1)) ;;
+esac
+
+# ── 3e. Same, for a custom root. That removal runs inside a pipeline subshell, so a shell
+# variable set there never reaches the summary; custom roots hold studio.db and the auth data. ──
+H=$(new_home)
+CUSTOM="$_TMP_ROOT/customroot.$$"
+mkdir -p "$CUSTOM/share"
+: > "$CUSTOM/share/studio.conf"          # what _is_studio_root accepts as ownership
+cat > "$STUB_BIN/rm" <<EOF
+#!/bin/sh
+for _a in "\$@"; do
+    [ "\$_a" = "$CUSTOM" ] && exit 1
+done
+exec "$REAL_RM" "\$@"
+EOF
+chmod +x "$STUB_BIN/rm"
+printf '#!/bin/sh\necho Linux\n' > "$STUB_BIN/uname"; chmod +x "$STUB_BIN/uname"
+# Every -u before the first assignment: env stops parsing options at the first VAR=VALUE.
+_out=$(env -u STUDIO_HOME -u XDG_CACHE_HOME -u XDG_DATA_HOME -u XDG_CONFIG_HOME -u XDG_STATE_HOME \
+    UNSLOTH_STUDIO_HOME="$CUSTOM" HOME="$H" PATH="$STUB_BIN:$PATH" sh "$UNINSTALL_SH" 2>/dev/null)
+rm -f "$STUB_BIN/rm"
+assert_present "linux: the refused custom root really did survive" "$CUSTOM"
+case "$_out" in
+    *"are gone."*) echo "  FAIL: linux: custom-root failure still claimed the data is gone"; FAIL=$((FAIL+1)) ;;
+    *) echo "  PASS: linux: custom-root failure reaches the summary"; PASS=$((PASS+1)) ;;
 esac
 
 # ── 4. Nothing to remove is a clean no-op (fresh HOME, exit 0) ──

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -3,12 +3,10 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 # Regression tests for WebView runtime-data cleanup in scripts/uninstall.sh.
 #
-# WKWebView (macOS) and webkit2gtk (Linux) create data keyed by the bundle id
-# at first app launch, not at install time, so the uninstaller used to miss it
-# and a leftover cache served a stale frontend to the next install. Runs the
-# full script against a fixture HOME with the OS branch and the system tools
-# it calls stubbed via PATH, and asserts bundle-id paths are removed while
-# unrelated app data survives.
+# WKWebView (macOS) and webkit2gtk (Linux) key their data by bundle id and create it at first
+# launch, not at install time, so the uninstaller used to miss it and a leftover cache served a
+# stale frontend to the next install. Runs the full script against a fixture HOME with the OS
+# branch and the tools it calls stubbed via PATH, asserting bundle-id paths go and others stay.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -20,30 +18,30 @@ FAIL=0
 _TMP_ROOT=$(mktemp -d)
 trap 'rm -rf "$_TMP_ROOT"' EXIT
 
-# The script sweeps $XDG_RUNTIME_DIR/unsloth-studio-launcher-<uid>*.lock, so
-# an unsandboxed runtime dir would cost the real launcher its locks.
+# The script sweeps $XDG_RUNTIME_DIR/unsloth-studio-launcher-<uid>*.lock, so an unsandboxed
+# runtime dir would cost the real launcher its locks.
 XDG_RUNTIME_DIR="$_TMP_ROOT/run"
 export XDG_RUNTIME_DIR
 mkdir -p "$XDG_RUNTIME_DIR"
 
-# Explicit template: -p is GNU-only (BSD got it in macOS 14) and a bare
-# mktemp -d implies -t, landing outside _TMP_ROOT on macOS.
+# Explicit template: -p is GNU-only (BSD got it in macOS 14) and a bare mktemp -d implies -t,
+# landing outside _TMP_ROOT on macOS.
 new_home() { mktemp -d "$_TMP_ROOT/home.XXXXXX"; }
 
 assert_gone()    { _l="$1"; if [ -e "$2" ]; then echo "  FAIL: $_l (still present: $2)"; FAIL=$((FAIL+1)); else echo "  PASS: $_l"; PASS=$((PASS+1)); fi; }
 assert_present() { _l="$1"; if [ -e "$2" ]; then echo "  PASS: $_l"; PASS=$((PASS+1)); else echo "  FAIL: $_l (missing: $2)"; FAIL=$((FAIL+1)); fi; }
 
-# Kills and macOS pref tools, stubbed so the script leaves the real system alone.
+# Kill and macOS pref tools, stubbed so the script leaves the real system alone.
 STUB_BIN="$_TMP_ROOT/stubbin"
 mkdir -p "$STUB_BIN"
 for _tool in pkill defaults; do
     printf '#!/bin/sh\nexit 0\n' > "$STUB_BIN/$_tool"
     chmod +x "$STUB_BIN/$_tool"
 done
-# On a WSL host the script's `grep -qi microsoft /proc/version` probe fires
-# even with uname stubbed to Linux, and the real WSL cleanup would touch the
-# host's /mnt/* shortcuts and /etc profile. Fail that one probe, delegate the
-# rest. REAL_GREP must be absolute or the stub execs itself forever.
+# On a WSL host the script's `grep -qi microsoft /proc/version` probe fires even with uname
+# stubbed to Linux, and the real WSL cleanup would touch the host's /mnt/* shortcuts and /etc
+# profile. Fail that one probe, delegate the rest. REAL_GREP must be absolute or the stub
+# execs itself forever.
 REAL_GREP=$(command -v grep)
 case "$REAL_GREP" in /*) ;; *) REAL_GREP=/usr/bin/grep ;; esac
 cat > "$STUB_BIN/grep" <<EOF
@@ -54,9 +52,8 @@ done
 exec "$REAL_GREP" "\$@"
 EOF
 chmod +x "$STUB_BIN/grep"
-# Belt and braces if the WSL branch is entered anyway: powershell.exe exiting 0
-# takes the no-op path (skipping the /mnt/* drvfs fallback), and sudo exiting 0
-# without running its argv keeps /etc untouched.
+# Belt and braces if the WSL branch is entered anyway: powershell.exe exiting 0 takes the no-op
+# path (skipping the /mnt/* drvfs fallback), and sudo exiting 0 without its argv keeps /etc clean.
 for _tool in powershell.exe sudo; do
     printf '#!/bin/sh\nexit 0\n' > "$STUB_BIN/$_tool"
     chmod +x "$STUB_BIN/$_tool"
@@ -127,9 +124,8 @@ assert_gone "linux: XDG_DATA_HOME override honored"   "$XDG/data/$BID"
 assert_gone "linux: XDG_CONFIG_HOME override honored" "$XDG/config/$BID"
 assert_gone "linux: XDG_STATE_HOME override honored"  "$XDG/state/$BID"
 
-# ── 3b. Relative XDG overrides are invalid per the spec and dropped by the
-# resolver Tauri uses, so the $HOME default must be removed and the same-named
-# dir under the caller's cwd left alone. ──
+# ── 3b. Relative XDG overrides are invalid per the spec and dropped by the resolver Tauri uses,
+# so the $HOME default goes and the same-named dir under the caller's cwd is left alone. ──
 H=$(new_home)
 CWD=$(mktemp -d "$_TMP_ROOT/cwd.XXXXXX")
 mkdir -p "$H/.local/share/$BID" "$H/.cache/$BID" "$H/.config/$BID" "$H/.local/state/$BID" \

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -249,6 +249,44 @@ case "$_out" in
     *) echo "  PASS: linux: custom-root failure reaches the summary"; PASS=$((PASS+1)) ;;
 esac
 
+# ── 3g. Env-mode install, bare uninstall. An env-mode install writes studio.conf into
+# $STUDIO_HOME/share (install.sh:567), not $HOME, so nothing in $HOME points at the custom
+# root. Running the documented bare uninstaller leaves studio.db (chat_threads,
+# chat_messages, provider keys) untouched, so the summary must not say it is gone. ──
+H=$(new_home)
+CUSTOM2="$_TMP_ROOT/envroot.$$"
+mkdir -p "$CUSTOM2/share"
+: > "$CUSTOM2/share/studio.conf"
+: > "$CUSTOM2/studio.db"
+printf '#!/bin/sh\necho Linux\n' > "$STUB_BIN/uname"; chmod +x "$STUB_BIN/uname"
+_out=$(env -u UNSLOTH_STUDIO_HOME -u STUDIO_HOME \
+    -u XDG_CACHE_HOME -u XDG_DATA_HOME -u XDG_CONFIG_HOME -u XDG_STATE_HOME \
+    HOME="$H" PATH="$STUB_BIN:$PATH" sh "$UNINSTALL_SH" 2>/dev/null)
+assert_present "linux: undiscovered env-mode studio.db survives" "$CUSTOM2/studio.db"
+case "$_out" in
+    *"chat history are gone."*)
+        echo "  FAIL: linux: claimed chat history is gone with studio.db still on disk"
+        FAIL=$((FAIL+1)) ;;
+    *) echo "  PASS: linux: no studio.db removed -> no claim that the history is gone"
+        PASS=$((PASS+1)) ;;
+esac
+
+# ── 3h. The other side of 3g: when a studio.db IS removed, the full claim must return,
+# otherwise the softened wording above would just always fire and assert nothing. ──
+H=$(new_home)
+mkdir -p "$H/.unsloth/studio/unsloth_studio"
+: > "$H/.unsloth/studio/unsloth_studio/.unsloth-studio-owned"
+: > "$H/.unsloth/studio/studio.db"
+_out=$(run_uninstall_out "$H" Linux)
+assert_gone "linux: default-mode studio.db removed" "$H/.unsloth/studio/studio.db"
+case "$_out" in
+    *"chat history are gone."*)
+        echo "  PASS: linux: studio.db removed -> summary states the history is gone"
+        PASS=$((PASS+1)) ;;
+    *) echo "  FAIL: linux: studio.db was removed but the summary never says so"
+        FAIL=$((FAIL+1)) ;;
+esac
+
 # ── 3f. A custom root the deny list refuses is also incomplete removal. install.sh accepts any
 # writable root (mkdir -p + -w, no deny list), so /var/tmp/studio installs without elevation and
 # then survives uninstall untouched. Uses the fixture HOME, which _is_unsafe_root also refuses. ──

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -20,6 +20,17 @@ FAIL=0
 _TMP_ROOT=$(mktemp -d)
 trap 'rm -rf "$_TMP_ROOT"' EXIT
 
+# The script deletes $XDG_RUNTIME_DIR/unsloth-studio-launcher-<uid>*.lock, so
+# without a fixture-owned runtime dir this test removes the real launcher's
+# locks (same pattern as test_uninstall_prebuilt_artifacts.sh).
+XDG_RUNTIME_DIR="$_TMP_ROOT/run"
+export XDG_RUNTIME_DIR
+mkdir -p "$XDG_RUNTIME_DIR"
+
+# Explicit mktemp template: -p is GNU-only (BSD mktemp gained it in macOS 14),
+# and a bare mktemp -d implies -t and would land outside _TMP_ROOT on macOS.
+new_home() { mktemp -d "$_TMP_ROOT/home.XXXXXX"; }
+
 assert_gone()    { _l="$1"; if [ -e "$2" ]; then echo "  FAIL: $_l (still present: $2)"; FAIL=$((FAIL+1)); else echo "  PASS: $_l"; PASS=$((PASS+1)); fi; }
 assert_present() { _l="$1"; if [ -e "$2" ]; then echo "  PASS: $_l"; PASS=$((PASS+1)); else echo "  FAIL: $_l (missing: $2)"; FAIL=$((FAIL+1)); fi; }
 
@@ -65,7 +76,7 @@ run_uninstall() {
 }
 
 # ── 1. macOS: every bundle-id-keyed ~/Library path is removed ──
-H=$(mktemp -d -p "$_TMP_ROOT")
+H=$(new_home)
 mkdir -p "$H/Library/Caches/$BID/WebKit/NetworkCache" \
          "$H/Library/WebKit/$BID/WebsiteData/CacheStorage" \
          "$H/Library/Application Support/$BID" \
@@ -91,10 +102,14 @@ assert_gone "macOS: Preferences/$BID.plist removed"          "$H/Library/Prefere
 assert_present "macOS: unrelated app cache kept"             "$H/Library/Caches/com.other.app/keepme"
 
 # ── 2. Linux: bundle-id-keyed XDG default paths are removed ──
-H=$(mktemp -d -p "$_TMP_ROOT")
+H=$(new_home)
 mkdir -p "$H/.cache/$BID" "$H/.local/share/$BID" "$H/.config/$BID" \
          "$H/.local/state/$BID" "$H/.cache/other.app"
+: > "$XDG_RUNTIME_DIR/unsloth-studio-launcher-$(id -u).lock"
 run_uninstall "$H" Linux
+# Proves the launcher-lock sweep landed in the fixture runtime dir, not the real one.
+assert_gone "linux: fixture launcher lock removed" \
+    "$XDG_RUNTIME_DIR/unsloth-studio-launcher-$(id -u).lock"
 assert_gone "linux: ~/.cache/$BID removed"       "$H/.cache/$BID"
 assert_gone "linux: ~/.local/share/$BID removed" "$H/.local/share/$BID"
 assert_gone "linux: ~/.config/$BID removed"      "$H/.config/$BID"
@@ -102,8 +117,8 @@ assert_gone "linux: ~/.local/state/$BID removed" "$H/.local/state/$BID"
 assert_present "linux: unrelated app cache kept" "$H/.cache/other.app"
 
 # ── 3. Linux: XDG_*_HOME overrides are honored ──
-H=$(mktemp -d -p "$_TMP_ROOT")
-XDG=$(mktemp -d -p "$_TMP_ROOT")
+H=$(new_home)
+XDG=$(mktemp -d "$_TMP_ROOT/xdg.XXXXXX")
 mkdir -p "$XDG/cache/$BID" "$XDG/data/$BID" "$XDG/config/$BID" "$XDG/state/$BID"
 printf '#!/bin/sh\necho Linux\n' > "$STUB_BIN/uname"
 chmod +x "$STUB_BIN/uname"
@@ -117,7 +132,7 @@ assert_gone "linux: XDG_CONFIG_HOME override honored" "$XDG/config/$BID"
 assert_gone "linux: XDG_STATE_HOME override honored"  "$XDG/state/$BID"
 
 # ── 4. Nothing to remove is a clean no-op (fresh HOME, exit 0) ──
-H=$(mktemp -d -p "$_TMP_ROOT")
+H=$(new_home)
 if run_uninstall "$H" Darwin; then
     echo "  PASS: empty HOME -> no-op exit 0"; PASS=$((PASS+1))
 else

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -443,6 +443,35 @@ case "$_out" in
         PASS=$((PASS+1)) ;;
 esac
 
+# ── 3j5b. Same, with `readlink -f` unavailable and a RELATIVE link target. BSD readlink
+# only gained -f in macOS 12.3, so the GNU form fails on older macOS; the resolution has
+# to work from the raw link text. Stub rejects -f the way BSD readlink does. ──
+H=$(new_home)
+mkdir -p "$H/.unsloth/studio/unsloth_studio" "$H/dbdir"
+: > "$H/.unsloth/studio/unsloth_studio/.unsloth-studio-owned"
+: > "$H/dbdir/studio.db"
+ln -s "../../dbdir/studio.db" "$H/.unsloth/studio/studio.db"
+_REAL_READLINK=$(command -v readlink)
+cat > "$STUB_BIN/readlink" <<EOF
+#!/bin/sh
+for _a in "\$@"; do
+    [ "\$_a" = "-f" ] && { echo "readlink: illegal option -- f" >&2; exit 1; }
+done
+exec "$_REAL_READLINK" "\$@"
+EOF
+chmod +x "$STUB_BIN/readlink"
+_out=$(run_uninstall_out "$H" Linux)
+rm -f "$STUB_BIN/readlink"
+assert_present "linux: relative symlinked studio.db survived without readlink -f" \
+    "$H/dbdir/studio.db"
+case "$_out" in
+    *"studio.db it found"*)
+        echo "  FAIL: linux: claimed the database is gone (no readlink -f, relative link)"
+        FAIL=$((FAIL+1)) ;;
+    *)  echo "  PASS: linux: resolves a relative link without readlink -f"
+        PASS=$((PASS+1)) ;;
+esac
+
 # ── 3j6. Provider API keys are NOT in studio.db. providers_db.py: "API keys are NOT
 # stored here: they live only in the browser (localStorage) and are sent encrypted
 # per-request." install.sh runs with TAURI_MODE=false, so the default install serves the

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -3,10 +3,10 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 # Regression tests for WebView runtime-data cleanup in scripts/uninstall.sh.
 #
-# WKWebView (macOS) and webkit2gtk (Linux) key their data by bundle id and create it at first
-# launch, not at install time, so the uninstaller used to miss it and a leftover cache served a
-# stale frontend to the next install. Runs the full script against a fixture HOME with the OS
-# branch and the tools it calls stubbed via PATH, asserting bundle-id paths go and others stay.
+# WKWebView (macOS) and webkit2gtk (Linux) key data by bundle id and create it at first launch,
+# not at install time, so the uninstaller used to miss it and a leftover cache served a stale
+# frontend to the next install. Runs the full script against a fixture HOME with the OS branch
+# and its tools stubbed via PATH, asserting bundle-id paths go and others stay.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -18,14 +18,12 @@ FAIL=0
 _TMP_ROOT=$(mktemp -d)
 trap 'rm -rf "$_TMP_ROOT"' EXIT
 
-# The script sweeps $XDG_RUNTIME_DIR/unsloth-studio-launcher-<uid>*.lock, so an unsandboxed
-# runtime dir would cost the real launcher its locks.
+# The script sweeps $XDG_RUNTIME_DIR launcher locks, so sandbox it or the real launcher loses its own.
 XDG_RUNTIME_DIR="$_TMP_ROOT/run"
 export XDG_RUNTIME_DIR
 mkdir -p "$XDG_RUNTIME_DIR"
 
-# Explicit template: -p is GNU-only (BSD got it in macOS 14) and a bare mktemp -d implies -t,
-# landing outside _TMP_ROOT on macOS.
+# Explicit template: -p is GNU-only and a bare mktemp -d lands outside _TMP_ROOT on macOS.
 new_home() { mktemp -d "$_TMP_ROOT/home.XXXXXX"; }
 
 assert_gone()    { _l="$1"; if [ -e "$2" ]; then echo "  FAIL: $_l (still present: $2)"; FAIL=$((FAIL+1)); else echo "  PASS: $_l"; PASS=$((PASS+1)); fi; }
@@ -36,8 +34,8 @@ STUB_BIN="$_TMP_ROOT/stubbin"
 mkdir -p "$STUB_BIN"
 printf '#!/bin/sh\nexit 0\n' > "$STUB_BIN/defaults"
 chmod +x "$STUB_BIN/defaults"
-# pkill records its argv so the app kill can be asserted; real pkill exits 1 on no match,
-# so mimic that rather than a blanket 0, which would hide a missing `|| true`.
+# Records argv so the app kill can be asserted. Exits 1 like real pkill on no match: a
+# blanket 0 would hide a missing `|| true`.
 PKILL_LOG="$_TMP_ROOT/pkill.args"
 cat > "$STUB_BIN/pkill" <<EOF
 #!/bin/sh
@@ -45,10 +43,9 @@ printf '%s\n' "\$*" >> "$PKILL_LOG"
 exit 1
 EOF
 chmod +x "$STUB_BIN/pkill"
-# On a WSL host the script's `grep -qi microsoft /proc/version` probe fires even with uname
-# stubbed to Linux, and the real WSL cleanup would touch the host's /mnt/* shortcuts and /etc
-# profile. Fail that one probe, delegate the rest. REAL_GREP must be absolute or the stub
-# execs itself forever.
+# On a WSL host the /proc/version probe fires even with uname stubbed to Linux, and the WSL
+# branch would touch the host's /mnt/* shortcuts and /etc profile. Fail that one probe, delegate
+# the rest. REAL_GREP must be absolute or the stub execs itself forever.
 REAL_GREP=$(command -v grep)
 case "$REAL_GREP" in /*) ;; *) REAL_GREP=/usr/bin/grep ;; esac
 cat > "$STUB_BIN/grep" <<EOF
@@ -59,8 +56,8 @@ done
 exec "$REAL_GREP" "\$@"
 EOF
 chmod +x "$STUB_BIN/grep"
-# Belt and braces if the WSL branch is entered anyway: powershell.exe exiting 0 takes the no-op
-# path (skipping the /mnt/* drvfs fallback), and sudo exiting 0 without its argv keeps /etc clean.
+# If the WSL branch runs anyway: powershell.exe exiting 0 skips the /mnt/* drvfs fallback, and
+# sudo exiting 0 without running its argv keeps /etc clean.
 for _tool in powershell.exe sudo; do
     printf '#!/bin/sh\nexit 0\n' > "$STUB_BIN/$_tool"
     chmod +x "$STUB_BIN/$_tool"
@@ -118,8 +115,8 @@ mkdir -p "$H/.cache/$BID" "$H/.local/share/$BID" "$H/.config/$BID" \
 : > "$H/.local/share/applications/unsloth-studio-handler.desktop"
 : > "$H/.local/share/applications/other-app.desktop"
 : > "$XDG_RUNTIME_DIR/unsloth-studio-launcher-$(id -u).lock"
-# Truncate first: every fixture home has this user's uid, so the Darwin run above logged the
-# same argv and the assertion below would pass on it even if Linux emitted no kill at all.
+# Truncate first: the Darwin run logged the same uid argv, so the assertion below would pass
+# even if Linux emitted no kill at all.
 : > "$PKILL_LOG"
 run_uninstall "$H" Linux
 # Proves the lock sweep hit the fixture runtime dir, not the real one.
@@ -130,15 +127,14 @@ assert_gone "linux: ~/.local/share/$BID removed" "$H/.local/share/$BID"
 assert_gone "linux: ~/.config/$BID removed"      "$H/.config/$BID"
 assert_gone "linux: ~/.local/state/$BID removed" "$H/.local/state/$BID"
 assert_present "linux: unrelated app cache kept" "$H/.cache/other.app"
-# tauri-plugin-deep-link rewrites <exe>-handler.desktop on every launch to claim
-# the unsloth:// scheme, so it is present on any machine the app has ever run on.
-# Leaving it points the desktop's scheme handler at a binary that no longer exists.
+# tauri-plugin-deep-link rewrites <exe>-handler.desktop on every launch, so leaving it points
+# the unsloth:// handler at a binary that no longer exists.
 assert_gone "linux: deep-link handler .desktop removed" \
     "$H/.local/share/applications/unsloth-studio-handler.desktop"
 assert_present "linux: another app's .desktop kept" \
     "$H/.local/share/applications/other-app.desktop"
-# The app kill must be scoped: unscoped, a root-run uninstall signals every user's
-# unsloth-studio. -u takes the owner of the $HOME being cleared, not just `id -u`.
+# Unscoped, a root-run uninstall signals every user's unsloth-studio. -u takes the owner of
+# the $HOME being cleared, not just `id -u`.
 _want_uid=$(stat -c %u "$H" 2>/dev/null || stat -f %u "$H")
 if grep -q -- "-x -u $_want_uid unsloth-studio" "$PKILL_LOG" 2>/dev/null; then
     echo "  PASS: linux: app kill scoped to the \$HOME owner"; PASS=$((PASS+1))
@@ -178,9 +174,9 @@ assert_gone    "linux: relative XDG_STATE_HOME falls back to HOME"  "$H/.local/s
 assert_present "linux: relative XDG left cwd/reldata alone"         "$CWD/reldata/$BID"
 assert_present "linux: relative XDG left cwd/relcache alone"        "$CWD/relcache/$BID"
 
-# ── 3d. A symlinked $HOME still resolves an owner and still clears the target. stat lstats by
-# default, so without -L a root-owned link to a user-owned home would resolve to uid 0. Owner
-# and target owner match here, so this guards the symlink path, not the differing-owner case. ──
+# ── 3d. A symlinked $HOME still resolves an owner and clears the target. stat lstats by default,
+# so without -L a root-owned link to a user home resolves to uid 0. Owners match here, so this
+# guards the symlink path, not the differing-owner case. ──
 H=$(new_home)
 _HL="$_TMP_ROOT/homelink.$$"
 ln -s "$H" "$_HL"
@@ -200,8 +196,8 @@ rm -f "$_HL"
 # session, API keys and chat history, so claiming that after a failed rm is a false all-clear. ──
 H=$(new_home)
 mkdir -p "$H/.cache/$BID"
-# An rm stub that refuses this one path, not chmod: root ignores mode bits, so a permission
-# fixture deletes the dir anyway and the cleanup then aborts the suite under set -e.
+# An rm stub, not chmod: root ignores mode bits, so a permission fixture deletes the dir
+# anyway and the cleanup then aborts the suite under set -e.
 REAL_RM=$(command -v rm)
 case "$REAL_RM" in /*) ;; *) REAL_RM=/bin/rm ;; esac
 cat > "$STUB_BIN/rm" <<EOF
@@ -249,10 +245,9 @@ case "$_out" in
     *) echo "  PASS: linux: custom-root failure reaches the summary"; PASS=$((PASS+1)) ;;
 esac
 
-# ── 3g. Env-mode install, bare uninstall. An env-mode install writes studio.conf into
-# $STUDIO_HOME/share (install.sh:567), not $HOME, so nothing in $HOME points at the custom
-# root. Running the documented bare uninstaller leaves studio.db (chat_threads,
-# chat_messages, provider keys) untouched, so the summary must not say it is gone. ──
+# ── 3g. Env-mode install, bare uninstall. studio.conf goes to $STUDIO_HOME/share
+# (install.sh:567), not $HOME, so a bare run never finds the root and leaves studio.db
+# (chat_threads, chat_messages) untouched; the summary must not say it is gone. ──
 H=$(new_home)
 CUSTOM2="$_TMP_ROOT/envroot.$$"
 mkdir -p "$CUSTOM2/share"
@@ -287,9 +282,9 @@ case "$_out" in
         FAIL=$((FAIL+1)) ;;
 esac
 
-# ── 3f. A custom root the deny list refuses is also incomplete removal. install.sh accepts any
-# writable root (mkdir -p + -w, no deny list), so /var/tmp/studio installs without elevation and
-# then survives uninstall untouched. Uses the fixture HOME, which _is_unsafe_root also refuses. ──
+# ── 3f. A deny-listed custom root is also incomplete removal: install.sh accepts any writable
+# root (mkdir -p + -w), so /var/tmp/studio installs without elevation and then survives untouched.
+# Fixture HOME stands in for it, since _is_unsafe_root refuses that too. ──
 H=$(new_home)
 mkdir -p "$H/share"
 : > "$H/share/studio.conf"
@@ -302,10 +297,9 @@ case "$_out" in
     *) echo "  PASS: linux: deny-listed root counts as incomplete removal"; PASS=$((PASS+1)) ;;
 esac
 
-# ── 3i. An unusable TMPDIR must not abort the run. The summary markers are written with
-# `printf`, not `: >`: `:` is a POSIX special builtin, so a redirection error on it kills a
-# non-interactive shell outright (dash exits 2, busybox ash 1) and `2>/dev/null || true`
-# does not stop it. The uninstall would then stop partway with most of the tree still there. ──
+# ── 3i. An unusable TMPDIR must not abort the run. Markers use `printf`, not `: >`: `:` is a
+# POSIX special builtin, so a redirection error on it kills a non-interactive shell outright
+# (dash 2, busybox ash 1), `|| true` does not stop it, and the uninstall halts partway. ──
 H=$(new_home)
 mkdir -p "$H/.cache/$BID" "$H/.unsloth/studio/unsloth_studio"
 : > "$H/.unsloth/studio/unsloth_studio/.unsloth-studio-owned"
@@ -317,8 +311,7 @@ for _sh in sh dash busybox; do
     mkdir -p "$_H2/.cache/$BID" "$_H2/.unsloth/studio/unsloth_studio"
     : > "$_H2/.unsloth/studio/unsloth_studio/.unsloth-studio-owned"
     _rc=0
-    # busybox needs its applet name as a separate argument; spelled out per branch
-    # rather than word-splitting one variable.
+    # busybox needs its applet name as a separate argument, so spell out both branches.
     if [ "$_sh" = busybox ]; then
         env -u UNSLOTH_STUDIO_HOME -u STUDIO_HOME \
             -u XDG_CACHE_HOME -u XDG_DATA_HOME -u XDG_CONFIG_HOME -u XDG_STATE_HOME \
@@ -338,10 +331,8 @@ for _sh in sh dash busybox; do
     assert_gone "$_sh: cleanup still completed with an unusable TMPDIR" "$_H2/.cache/$BID"
 done
 
-# ── 3j. The marker directory is private and removed on the way out. TMPDIR points at a
-# fixture-owned directory so the check sees only what this run created: counting entries
-# in the shared temp dir would call a concurrent process's mktemp a leak, and an unrelated
-# directory disappearing at the same time would hide a real one. ──
+# ── 3j. The marker directory is removed on the way out. A fixture-owned TMPDIR so the check
+# sees only this run: entries in the shared temp dir would both fake and hide leaks. ──
 H=$(new_home)
 _MK_TMP=$(mktemp -d "$_TMP_ROOT/markertmp.XXXXXX")
 printf '#!/bin/sh\necho Linux\n' > "$STUB_BIN/uname"; chmod +x "$STUB_BIN/uname"
@@ -356,9 +347,8 @@ else
     find "$_MK_TMP" -mindepth 1 | sed 's/^/         /'
 fi
 
-# ── 3j2. With no marker storage at all there is no record of what failed, so the summary
-# must take the cautious branch rather than reporting the session gone. mktemp is stubbed
-# to fail, which is what an unwritable or missing TMPDIR produces. ──
+# ── 3j2. No marker storage means no record of what failed, so the summary must take the
+# cautious branch. mktemp stubbed to fail, as an unwritable or missing TMPDIR would. ──
 H=$(new_home)
 mkdir -p "$H/.unsloth/studio/unsloth_studio"
 : > "$H/.unsloth/studio/unsloth_studio/.unsloth-studio-owned"
@@ -374,9 +364,8 @@ case "$_out" in
         FAIL=$((FAIL+1)) ;;
 esac
 
-# ── 3j3. A relocated install: ~/.unsloth/studio is a symlink to another disk. rm -rf on a
-# symlink unlinks the link and leaves the target, so the database survives and the summary
-# must not report it gone. Reachable whenever a user moves Studio off the system disk. ──
+# ── 3j3. Relocated install: ~/.unsloth/studio a symlink to another disk. rm -rf unlinks only
+# the link, so the database survives and the summary must not report it gone. ──
 H=$(new_home)
 _ELSEWHERE=$(mktemp -d "$_TMP_ROOT/otherdisk.XXXXXX")
 mkdir -p "$_ELSEWHERE/unsloth_studio" "$H/.unsloth"
@@ -400,15 +389,13 @@ case "$_out" in
         echo "  FAIL: linux: relocated install not reported as incomplete"; FAIL=$((FAIL+1)) ;;
 esac
 
-# ── 3j4. Marker storage that vanishes mid-run. The pathname still looks fine, so a
-# predicate that only tests for emptiness keeps reporting success while every failure
-# _set_marker tried to record was silently dropped. ──
+# ── 3j4. Marker storage that vanishes mid-run: the pathname still looks fine, so an
+# emptiness-only predicate reports success while every failure is silently dropped. ──
 H=$(new_home)
 mkdir -p "$H/.local/share/$BID"
 _VAN=$(mktemp -d "$_TMP_ROOT/vanish.XXXXXX")
-# mktemp -d names a directory it does not leave behind. Deterministic, rather than racing
-# a background delete: $_MARKER_DIR is non-empty so the pathname still looks usable, which
-# is the state the predicate has to catch.
+# mktemp names a directory it does not create: deterministic, and $_MARKER_DIR is non-empty
+# so the pathname still looks usable, which is the state the predicate has to catch.
 cat > "$STUB_BIN/mktemp" <<EOF
 #!/bin/sh
 printf '%s\n' "$_VAN/marker.gone"
@@ -424,9 +411,8 @@ case "$_out" in
         echo "  FAIL: linux: vanished marker dir still reported success"; FAIL=$((FAIL+1)) ;;
 esac
 
-# ── 3j5. studio.db itself a symlink out of the tree. -f follows it, rm -rf unlinks only
-# the link, so the database survives and the summary must not report it gone. Same root
-# cause as the relocated-install case, different shape. ──
+# ── 3j5. studio.db itself a symlink out of the tree: -f follows it, rm -rf unlinks only the
+# link, so the database survives and the summary must not report it gone. ──
 H=$(new_home)
 _DBTARGET=$(mktemp -d "$_TMP_ROOT/dbtarget.XXXXXX")
 mkdir -p "$H/.unsloth/studio/unsloth_studio"
@@ -443,9 +429,8 @@ case "$_out" in
         PASS=$((PASS+1)) ;;
 esac
 
-# ── 3j5b. Same, with `readlink -f` unavailable and a RELATIVE link target. BSD readlink
-# only gained -f in macOS 12.3, so the GNU form fails on older macOS; the resolution has
-# to work from the raw link text. Stub rejects -f the way BSD readlink does. ──
+# ── 3j5b. Same, with `readlink -f` unavailable and a RELATIVE target. BSD readlink only gained
+# -f in macOS 12.3, so resolution must work from the raw link text. Stub rejects -f like BSD. ──
 H=$(new_home)
 mkdir -p "$H/.unsloth/studio/unsloth_studio" "$H/dbdir"
 : > "$H/.unsloth/studio/unsloth_studio/.unsloth-studio-owned"
@@ -472,11 +457,9 @@ case "$_out" in
         PASS=$((PASS+1)) ;;
 esac
 
-# ── 3j6. Provider API keys are NOT in studio.db. providers_db.py: "API keys are NOT
-# stored here: they live only in the browser (localStorage) and are sent encrypted
-# per-request." install.sh runs with TAURI_MODE=false, so the default install serves the
-# UI to a normal browser and the keys sit in that browser's profile, which this script
-# never touches. No branch may claim they were removed. ──
+# ── 3j6. Provider API keys are NOT in studio.db: providers_db.py keeps them in the browser's
+# localStorage only, and install.sh runs TAURI_MODE=false, so they sit in a browser profile
+# this script never touches. No branch may claim they were removed. ──
 for _case in dbremoved nodb; do
     H=$(new_home)
     mkdir -p "$H/.unsloth/studio/unsloth_studio"
@@ -494,9 +477,8 @@ for _case in dbremoved nodb; do
             echo "  PASS: $_case: says where the keys actually are"; PASS=$((PASS+1)) ;;
         *)  echo "  FAIL: $_case: never says where the keys actually are"; FAIL=$((FAIL+1)) ;;
     esac
-    # Removing the WebView profile clears the desktop app's session only. A browser
-    # session keeps its tokens in localStorage (frontend/src/features/auth/session.ts),
-    # which this script never touches, so an unqualified claim is wrong there too.
+    # The WebView profile is the desktop session only; a browser session keeps its tokens in
+    # localStorage (frontend/src/features/auth/session.ts), so an unqualified claim is wrong.
     case "$_out" in
         *"the signed-in session is gone"*)
             echo "  FAIL: $_case: unqualified signed-out claim"; FAIL=$((FAIL+1)) ;;
@@ -505,12 +487,10 @@ for _case in dbremoved nodb; do
     esac
 done
 
-# ── 3k. _set_marker itself must survive a write it cannot perform. 3i only proves the
-# mktemp -d guard holds, since an unusable TMPDIR leaves the marker path empty and the
-# redirection never runs. This drives the redirection directly: the marker directory
-# exists at startup and is gone by the time the write happens, which is what an operator
-# clearing /tmp mid-run looks like. With `: >` the shell dies here and takes the rest of
-# the uninstall with it. ──
+# ── 3k. _set_marker must survive a write it cannot perform. 3i only proves the mktemp guard,
+# since an empty marker path never runs the redirection. This drives it directly: the marker
+# dir exists at startup and is gone by the write, as an operator clearing /tmp mid-run would
+# leave it. With `: >` the shell dies here and takes the rest of the uninstall with it. ──
 _SM_FILE=$(mktemp "$_TMP_ROOT/setmarker.XXXXXX")
 sed -n '/^_set_marker() {/,/^}/p' "$UNINSTALL_SH" > "$_SM_FILE"
 if [ ! -s "$_SM_FILE" ]; then
@@ -538,12 +518,10 @@ else
     done
 fi
 
-# ── 3m. uninstall.ps1 must stop the legacy-named desktop process too. Older Windows
-# releases used the product name as MAINBINARYNAME, so they run Unsloth.exe rather than
-# unsloth-studio.exe (installer.nsi migrates away from it). The uninstaller is always
-# fetched fresh from main, so an old install meets this script, and a process it never
-# stops re-creates the WebView profile straight after the delete. Source assertion: the
-# .ps1 is not driven from this suite. ──
+# ── 3m. uninstall.ps1 must stop the legacy-named process too: older releases used the product
+# name as MAINBINARYNAME and run Unsloth.exe, and this script is always fetched fresh from main,
+# so it meets them. A missed process re-creates the WebView profile straight after the delete.
+# Source assertion: the .ps1 is not driven from this suite. ──
 UNINSTALL_PS1="$SCRIPT_DIR/../../scripts/uninstall.ps1"
 if [ ! -f "$UNINSTALL_PS1" ]; then
     echo "  FAIL: uninstall.ps1 not found"; FAIL=$((FAIL+1))

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -538,6 +538,25 @@ else
     done
 fi
 
+# ── 3m. uninstall.ps1 must stop the legacy-named desktop process too. Older Windows
+# releases used the product name as MAINBINARYNAME, so they run Unsloth.exe rather than
+# unsloth-studio.exe (installer.nsi migrates away from it). The uninstaller is always
+# fetched fresh from main, so an old install meets this script, and a process it never
+# stops re-creates the WebView profile straight after the delete. Source assertion: the
+# .ps1 is not driven from this suite. ──
+UNINSTALL_PS1="$SCRIPT_DIR/../../scripts/uninstall.ps1"
+if [ ! -f "$UNINSTALL_PS1" ]; then
+    echo "  FAIL: uninstall.ps1 not found"; FAIL=$((FAIL+1))
+else
+    _ps_filter=$(grep -n "Name = 'unsloth-studio.exe'" "$UNINSTALL_PS1" | head -n1 | cut -d: -f2-)
+    case "$_ps_filter" in
+        *"Unsloth.exe"*)
+            echo "  PASS: windows: process query covers the legacy binary name"; PASS=$((PASS+1)) ;;
+        *)
+            echo "  FAIL: windows: process query misses the legacy Unsloth.exe"; FAIL=$((FAIL+1)) ;;
+    esac
+fi
+
 # ── 4. Nothing to remove is a clean no-op (fresh HOME, exit 0) ──
 H=$(new_home)
 if run_uninstall "$H" Darwin; then

--- a/tests/sh/test_uninstall_webview_data.sh
+++ b/tests/sh/test_uninstall_webview_data.sh
@@ -113,7 +113,10 @@ assert_present "macOS: unrelated app cache kept"             "$H/Library/Caches/
 # ── 2. Linux: bundle-id-keyed XDG default paths are removed ──
 H=$(new_home)
 mkdir -p "$H/.cache/$BID" "$H/.local/share/$BID" "$H/.config/$BID" \
-         "$H/.local/state/$BID" "$H/.cache/other.app"
+         "$H/.local/state/$BID" "$H/.cache/other.app" \
+         "$H/.local/share/applications"
+: > "$H/.local/share/applications/unsloth-studio-handler.desktop"
+: > "$H/.local/share/applications/other-app.desktop"
 : > "$XDG_RUNTIME_DIR/unsloth-studio-launcher-$(id -u).lock"
 # Truncate first: every fixture home has this user's uid, so the Darwin run above logged the
 # same argv and the assertion below would pass on it even if Linux emitted no kill at all.
@@ -127,6 +130,13 @@ assert_gone "linux: ~/.local/share/$BID removed" "$H/.local/share/$BID"
 assert_gone "linux: ~/.config/$BID removed"      "$H/.config/$BID"
 assert_gone "linux: ~/.local/state/$BID removed" "$H/.local/state/$BID"
 assert_present "linux: unrelated app cache kept" "$H/.cache/other.app"
+# tauri-plugin-deep-link rewrites <exe>-handler.desktop on every launch to claim
+# the unsloth:// scheme, so it is present on any machine the app has ever run on.
+# Leaving it points the desktop's scheme handler at a binary that no longer exists.
+assert_gone "linux: deep-link handler .desktop removed" \
+    "$H/.local/share/applications/unsloth-studio-handler.desktop"
+assert_present "linux: another app's .desktop kept" \
+    "$H/.local/share/applications/other-app.desktop"
 # The app kill must be scoped: unscoped, a root-run uninstall signals every user's
 # unsloth-studio. -u takes the owner of the $HOME being cleared, not just `id -u`.
 _want_uid=$(stat -c %u "$H" 2>/dev/null || stat -f %u "$H")


### PR DESCRIPTION
## Problem

After running the uninstaller and doing a completely fresh install, Studio can still render a months-old frontend. The code on disk is current, but the app serves a stale cached copy.

The desktop app's WebView creates runtime data keyed by the Tauri bundle id (`ai.unsloth.studio`, from `studio/src-tauri/tauri.conf.json`) the first time the app launches, not at install time. Since the installer never writes these paths, the uninstallers never listed them, so they survive every uninstall:

- macOS: `~/Library/Caches`, `~/Library/WebKit`, `~/Library/Application Support`, `~/Library/HTTPStorages`, `~/Library/Cookies`, `~/Library/Saved Application State` and `~/Library/Preferences`, all keyed by the bundle id
- Windows: `%LOCALAPPDATA%\ai.unsloth.studio` (the `EBWebView` WebView2 profile) and `%APPDATA%\ai.unsloth.studio`
- Linux: the XDG equivalents under `~/.local/share`, `~/.cache`, `~/.config` and `~/.local/state`

## Fix

`scripts/uninstall.sh`

- macOS branch removes the bundle-id-keyed `~/Library` paths. Preferences go through `defaults delete` plus `defaults -currentHost delete`, because cfprefsd rewrites the plist from its in-memory cache after a bare `rm`, and ByHost is a separate domain. The plist `rm` stays as a fallback for when `defaults` is missing.
- Linux branch removes the webkit2gtk equivalents under the XDG dirs, honoring `XDG_*_HOME`. Tauri points the WebView at `LocalData/<bundle id>`, so `XDG_DATA_HOME` is where the caches actually live; the other three are removed as app data.
- `_pkill_studio` also stops the Tauri desktop binary (`pkill -x unsloth-studio`, exact name only, so the `unsloth` CLI shim is never matched) so WebView helpers cannot re-create the cache mid-uninstall.

`scripts/uninstall.ps1`

- Stops the desktop app and its `msedgewebview2.exe` helpers in the stop phase, next to `_StopStudioProcesses`, then removes `%LOCALAPPDATA%\ai.unsloth.studio` and `%APPDATA%\ai.unsloth.studio` with the other directory removals. Doing the kill at delete time was too late: the app holds `~/.unsloth/studio/tauri.log` open, so `_RemovePath` burned its retries and nothing retried afterwards.
- The helper match escapes the profile path with `[WildcardPattern]::Escape` and requires a trailing separator. Unescaped, a `[` in the path is a wildcard character class, so a helper under a directory such as `dev[1]` missed its own profile while matching an unrelated `dev1`; without the separator, `ai.unsloth.studio2\EBWebView` matched `ai.unsloth.studio`.
- `CommandLine` reads back null across a UAC elevation boundary, which the old code treated as "not ours". It now falls back to the parent chain from the captured app PIDs, then waits for the app processes to exit, since WebView2 only releases the user data folder once its browser processes are gone.

Both uninstallers now say that the WebView data is going, since it holds the signed-in session, saved provider API keys and local chat history.

Unrelated app data is untouched: only paths keyed by the exact bundle id are removed.

## Tests

New `tests/sh/test_uninstall_webview_data.sh` runs the full uninstall script against a fixture `HOME` with `pkill`/`defaults` stubbed via `PATH`, the OS branch selected by a stubbed `uname`, and the `/proc/version` WSL probe forced to fail:

- macOS: all 8 bundle-id paths removed, unrelated `com.other.app` cache kept
- Linux: all 4 XDG paths removed, `XDG_*_HOME` overrides honored, unrelated data kept
- The launcher-lock sweep lands in a fixture-owned `XDG_RUNTIME_DIR`, asserted rather than just contained. Without this the test deleted the real launcher's lock files while reporting green.
- Empty `HOME` is a clean no-op with exit 0

```
Results: 20 passed, 0 failed
```

Fixtures use the `mktemp -d "$_TMP_ROOT/home.XXXXXX"` template form rather than `mktemp -p`, which is GNU-only and aborts the whole test on macOS 13 and earlier.

No `tests/run_all.sh` change is needed: main discovers `tests/sh/test_*.sh` and runs each with bash, and Backend CI already has `scripts/**` in its path filter.

Whole shell suite passes (41 files). `shellcheck -e SC1090,SC2034` clean, `dash -n` and `bash --posix -n` clean on `uninstall.sh`, and `uninstall.ps1` parses clean through the PowerShell AST parser.
