### PR TITLE
Setup: clear stale WebView caches on install and update, keep user settings and data

### DIFF
--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1625,11 +1625,8 @@ if ($script:StudioVtOk -and -not $env:NO_COLOR) {
 
 # WebView2 caches keyed by the bundle id can keep serving the previous frontend
 # after an update. Cache-only: storage, cookies, settings, models and the studio
-# database are untouched.
-#
-# Defined here, called after the UNSLOTH_STUDIO_HOME / STUDIO_HOME override is validated.
-# Clearing first would make a mistyped override wipe the cache and then abort, the same
-# side effect setup.sh delays the call to avoid.
+# database are untouched. Called only once the UNSLOTH_STUDIO_HOME / STUDIO_HOME
+# override is validated, so a mistyped override cannot wipe the cache and then abort.
 function Clear-WebViewCaches {
     if (-not $env:LOCALAPPDATA) { return }
     $wvDefault = Join-Path $env:LOCALAPPDATA "ai.unsloth.studio\EBWebView\Default"
@@ -3444,12 +3441,10 @@ if ($_studioOverride) {
 
 $VenvDir = Join-Path $StudioHome "unsloth_studio"
 
-# The override is known good and points at a real installation, so the clear cannot turn
-# a typo into cache loss. Gated on the venv because validating the directory is not
-# enough: an override that exists and is writable but holds no Studio install fails at
-# the venv check further down, and clearing first would cost the cache for a run that
-# then does nothing. A fresh install has neither a venv nor a cache, so nothing real is
-# skipped. Still before any install work, which is the ordering that matters.
+# The override is validated, so a typo can no longer cost the cache. Venv-gated because
+# a writable-but-empty override still fails at the venv check below, and clearing first
+# would cost the cache for a run that then does nothing; a fresh install has neither venv
+# nor cache. Still before any install work.
 if (Test-Path -LiteralPath (Join-Path $VenvDir "Scripts\python.exe") -PathType Leaf) {
     Clear-WebViewCaches
 }

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1623,6 +1623,25 @@ if ($script:StudioVtOk -and -not $env:NO_COLOR) {
     Write-Host "  $Rule" -ForegroundColor DarkGray
 }
 
+# WebView2 caches keyed by the app bundle id hold copies of the previous
+# frontend and can keep serving it after an update (old styles linger).
+# Cache-only paths: Local Storage, IndexedDB, cookies, settings, models,
+# and the studio database are untouched.
+if ($env:LOCALAPPDATA) {
+    $wvDefault = Join-Path $env:LOCALAPPDATA "ai.unsloth.studio\EBWebView\Default"
+    $wvCleared = $false
+    foreach ($wvSub in @("Cache", "Code Cache", "GPUCache", "Service Worker")) {
+        $wvPath = Join-Path $wvDefault $wvSub
+        if (Test-Path -LiteralPath $wvPath) {
+            try {
+                Remove-Item -LiteralPath $wvPath -Recurse -Force -ErrorAction Stop
+                $wvCleared = $true
+            } catch { }
+        }
+    }
+    if ($wvCleared) { substep "cleared stale WebView caches (ai.unsloth.studio); settings and data kept" }
+}
+
 # Back up User PATH under HKCU\Software\Unsloth before any modifications.
 try {
     $envKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $false)

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -3442,12 +3442,17 @@ if ($_studioOverride) {
     $StudioHome = Join-Path $env:USERPROFILE ".unsloth\studio"
 }
 
-# The override is known good now, so the clear cannot turn a typo into cache loss.
-# Still before any install work, which is the ordering that matters: the caches have to
-# go while the old frontend is the one on disk.
-Clear-WebViewCaches
-
 $VenvDir = Join-Path $StudioHome "unsloth_studio"
+
+# The override is known good and points at a real installation, so the clear cannot turn
+# a typo into cache loss. Gated on the venv because validating the directory is not
+# enough: an override that exists and is writable but holds no Studio install fails at
+# the venv check further down, and clearing first would cost the cache for a run that
+# then does nothing. A fresh install has neither a venv nor a cache, so nothing real is
+# skipped. Still before any install work, which is the ordering that matters.
+if (Test-Path -LiteralPath (Join-Path $VenvDir "Scripts\python.exe") -PathType Leaf) {
+    Clear-WebViewCaches
+}
 
 # why: in env-override mode $StudioHome is user-chosen; require the
 # ownership marker before Remove-Item so unrelated dirs survive. Gated on

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1626,7 +1626,12 @@ if ($script:StudioVtOk -and -not $env:NO_COLOR) {
 # WebView2 caches keyed by the bundle id can keep serving the previous frontend
 # after an update. Cache-only: storage, cookies, settings, models and the studio
 # database are untouched.
-if ($env:LOCALAPPDATA) {
+#
+# Defined here, called after the UNSLOTH_STUDIO_HOME / STUDIO_HOME override is validated.
+# Clearing first would make a mistyped override wipe the cache and then abort, the same
+# side effect setup.sh delays the call to avoid.
+function Clear-WebViewCaches {
+    if (-not $env:LOCALAPPDATA) { return }
     $wvDefault = Join-Path $env:LOCALAPPDATA "ai.unsloth.studio\EBWebView\Default"
     # Drop the version stamp first. The old WebView still holds these files, which is
     # why the removals below can fail; the app's own clear is the retry, and it is
@@ -3436,6 +3441,12 @@ if ($_studioOverride) {
 } else {
     $StudioHome = Join-Path $env:USERPROFILE ".unsloth\studio"
 }
+
+# The override is known good now, so the clear cannot turn a typo into cache loss.
+# Still before any install work, which is the ordering that matters: the caches have to
+# go while the old frontend is the one on disk.
+Clear-WebViewCaches
+
 $VenvDir = Join-Path $StudioHome "unsloth_studio"
 
 # why: in env-override mode $StudioHome is user-chosen; require the

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1623,19 +1623,16 @@ if ($script:StudioVtOk -and -not $env:NO_COLOR) {
     Write-Host "  $Rule" -ForegroundColor DarkGray
 }
 
-# WebView2 caches keyed by the app bundle id hold copies of the previous
-# frontend and can keep serving it after an update (old styles linger).
-# Cache-only paths: Local Storage, IndexedDB, cookies, settings, models,
-# and the studio database are untouched.
+# WebView2 caches keyed by the bundle id can keep serving the previous frontend
+# after an update. Cache-only: storage, cookies, settings, models and the studio
+# database are untouched.
 if ($env:LOCALAPPDATA) {
     $wvDefault = Join-Path $env:LOCALAPPDATA "ai.unsloth.studio\EBWebView\Default"
-    # Drop the app's version stamp before touching anything. This runs while the old
-    # WebView still holds these files, which is exactly why the removals below can fail,
-    # and the app's own clear (the retry) is skipped whenever the stamp already matches
-    # the running version. A repair or a local frontend rebuild leaves the version
-    # unchanged, so without this the retry never happens. Unconditional: whether the
-    # deletes succeed is not knowable for files another process holds open, and a
-    # redundant clear on the next launch is the cheap side of the trade.
+    # Drop the version stamp first. The old WebView still holds these files, which is
+    # why the removals below can fail; the app's own clear is the retry, and it is
+    # skipped while the stamp matches the running version. Unconditional, since a
+    # repair or a local rebuild leaves the version unchanged and a redundant clear on
+    # the next launch is the cheap side of the trade.
     Remove-Item -LiteralPath (Join-Path $env:LOCALAPPDATA "ai.unsloth.studio\.webview-cache-cleared") `
         -Force -ErrorAction SilentlyContinue
     $wvCleared = $false

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1632,12 +1632,16 @@ if ($env:LOCALAPPDATA) {
     $wvCleared = $false
     foreach ($wvSub in @("Cache", "Code Cache", "GPUCache", "Service Worker")) {
         $wvPath = Join-Path $wvDefault $wvSub
-        if (Test-Path -LiteralPath $wvPath) {
-            try {
-                Remove-Item -LiteralPath $wvPath -Recurse -Force -ErrorAction Stop
-                $wvCleared = $true
-            } catch { }
-        }
+        # Get-Item -Force, not Test-Path: the probe throws on an ACL denial under
+        # "Stop", and a reparse point here must be unlinked rather than recursed
+        # into, which Remove-Item -Recurse -Force would do on PowerShell 5.1.
+        $wvItem = Get-Item -LiteralPath $wvPath -Force -ErrorAction SilentlyContinue
+        if (-not $wvItem) { continue }
+        try {
+            if ($wvItem.Attributes -band [System.IO.FileAttributes]::ReparsePoint) { $wvItem.Delete() }
+            else { Remove-Item -LiteralPath $wvPath -Recurse -Force -ErrorAction Stop }
+            $wvCleared = $true
+        } catch { }
     }
     if ($wvCleared) { substep "cleared stale WebView caches (ai.unsloth.studio); settings and data kept" }
 }

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1633,8 +1633,7 @@ if ($env:LOCALAPPDATA) {
     foreach ($wvSub in @("Cache", "Code Cache", "GPUCache", "Service Worker")) {
         $wvPath = Join-Path $wvDefault $wvSub
         # Get-Item -Force, not Test-Path: the probe throws on an ACL denial under
-        # "Stop", and a reparse point here must be unlinked rather than recursed
-        # into, which Remove-Item -Recurse -Force would do on PowerShell 5.1.
+        # "Stop", and a reparse point must be unlinked, not recursed into.
         $wvItem = Get-Item -LiteralPath $wvPath -Force -ErrorAction SilentlyContinue
         if (-not $wvItem) { continue }
         try {

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -1629,6 +1629,15 @@ if ($script:StudioVtOk -and -not $env:NO_COLOR) {
 # and the studio database are untouched.
 if ($env:LOCALAPPDATA) {
     $wvDefault = Join-Path $env:LOCALAPPDATA "ai.unsloth.studio\EBWebView\Default"
+    # Drop the app's version stamp before touching anything. This runs while the old
+    # WebView still holds these files, which is exactly why the removals below can fail,
+    # and the app's own clear (the retry) is skipped whenever the stamp already matches
+    # the running version. A repair or a local frontend rebuild leaves the version
+    # unchanged, so without this the retry never happens. Unconditional: whether the
+    # deletes succeed is not knowable for files another process holds open, and a
+    # redundant clear on the next launch is the cheap side of the trade.
+    Remove-Item -LiteralPath (Join-Path $env:LOCALAPPDATA "ai.unsloth.studio\.webview-cache-cleared") `
+        -Force -ErrorAction SilentlyContinue
     $wvCleared = $false
     foreach ($wvSub in @("Cache", "Code Cache", "GPUCache", "Service Worker")) {
         $wvPath = Join-Path $wvDefault $wvSub

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -552,7 +552,12 @@ _clear_webview_caches() {
         Linux)
             # wry points WebKitGTK's base-cache dir at the app data dir, so the
             # caches sit beside localstorage/, databases/ and cookies, which stay.
-            _wvc_data="${XDG_DATA_HOME:-$HOME/.local/share}/$_wvc_bid"
+            # A relative XDG_DATA_HOME is invalid per the XDG spec and is dropped
+            # by dirs, so Tauri uses the default; match that rather than rm -rf a
+            # relative path under whatever directory the installer runs from.
+            _wvc_data="${XDG_DATA_HOME:-$HOME/.local/share}"
+            case "$_wvc_data" in /*) ;; *) _wvc_data="$HOME/.local/share" ;; esac
+            _wvc_data="$_wvc_data/$_wvc_bid"
             _wvc_paths=(
                 "$_wvc_data/WebKitCache"
                 "$_wvc_data/CacheStorage"

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -577,7 +577,11 @@ _clear_webview_caches() {
     fi
     return 0
 }
-_clear_webview_caches
+# Deliberately NOT called here. setup.sh runs under `set -euo pipefail` with no
+# trap, and the UNSLOTH_STUDIO_HOME / STUDIO_HOME override is not validated until
+# further down. Clearing first means a typo'd override deletes the WebView cache
+# and only then aborts, which is a side effect the pre-existing fail-fast path
+# never had. The call site is after the override is known to be good.
 
 # ── Detect Colab ──
 IS_COLAB=false
@@ -623,6 +627,12 @@ if [ -n "$_studio_override" ]; then
 else
     STUDIO_HOME="$HOME/.unsloth/studio"
 fi
+
+# Now that the override has been validated, the clear can run without turning a
+# typo into cache loss. Still before any install work, which is the ordering that
+# matters: the caches must go while the old frontend is the one on disk.
+_clear_webview_caches
+
 VENV_DIR="$STUDIO_HOME/unsloth_studio"
 VENV_T5_530_DIR="$STUDIO_HOME/.venv_t5_530"
 VENV_T5_550_DIR="$STUDIO_HOME/.venv_t5_550"

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -589,10 +589,8 @@ _clear_webview_caches() {
     fi
     return 0
 }
-# Deliberately NOT called here: setup.sh runs under `set -euo pipefail` with no
-# trap and the UNSLOTH_STUDIO_HOME / STUDIO_HOME override is not validated until
-# further down, so clearing first would let a typo'd override delete the cache
-# and only then abort. The call site is after the override is known to be good.
+# Not called here: under `set -e` with no trap, clearing before the UNSLOTH_STUDIO_HOME
+# / STUDIO_HOME override is validated lets a typo'd override delete the cache, then abort.
 
 # ── Detect Colab ──
 IS_COLAB=false
@@ -644,13 +642,10 @@ VENV_T5_530_DIR="$STUDIO_HOME/.venv_t5_530"
 VENV_T5_550_DIR="$STUDIO_HOME/.venv_t5_550"
 VENV_T5_510_DIR="$STUDIO_HOME/.venv_t5_510"
 
-# The override is validated and points at a real installation, so a typo can no longer
-# cost the cache. Gated on the venv because validating the directory is not enough: an
-# override that exists and is writable but holds no Studio install aborts at the venv
-# check further down, and clearing first would make that path cost the cache for a run
-# that then does nothing. A genuinely fresh install has neither a venv nor a cache, so
-# the guard skips nothing real. Still before any install work, which is the ordering
-# that matters: the caches must go while the old frontend is the one on disk.
+# The override is validated, so a typo can no longer cost the cache. Venv-gated because
+# a writable-but-empty override still aborts at the venv check below, and clearing first
+# would cost the cache for a run that then does nothing; a fresh install has neither venv
+# nor cache. Still before any install work, while the old frontend is the one on disk.
 if [ -x "$VENV_DIR/bin/python" ]; then
     _clear_webview_caches
 fi

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -543,11 +543,15 @@ _clear_webview_caches() {
     [ -n "${HOME:-}" ] || return 0
     _wvc_bid="ai.unsloth.studio"
     _wvc_paths=()
+    # Where the desktop app keeps its version stamp (main.rs webview_profile_root).
+    # Not the same directory as the caches on macOS, so it is tracked separately.
+    _wvc_root=""
     case "$(uname -s 2>/dev/null)" in
         Darwin)
             # WKWebView keeps every cache-typed store under Library/Caches/<bid>;
             # Library/WebKit/<bid> is user storage and is left alone.
             _wvc_paths=("$HOME/Library/Caches/$_wvc_bid")
+            _wvc_root="$HOME/Library/Application Support/$_wvc_bid"
             ;;
         Linux)
             # wry points WebKitGTK's base-cache dir at the app data dir, so the
@@ -563,9 +567,22 @@ _clear_webview_caches() {
                 "$_wvc_data/CacheStorage"
                 "$_wvc_data/serviceworkers"
             )
+            _wvc_root="$_wvc_data"
             ;;
         *) return 0 ;;
     esac
+    # Drop the app's version stamp before touching anything. An update runs while the
+    # old WebView still holds these files, so an rm here can fail; the app's own clear
+    # is the retry, and it is skipped whenever the stamp already matches the running
+    # version. A repair or a local frontend rebuild leaves the version unchanged, so
+    # without this the retry never happens and the cache we failed to remove survives.
+    # Unconditional: whether the rm below succeeds is not knowable for files another
+    # process holds open, and a redundant clear on the next launch is the cheap side.
+    # An `if`, not `[ ... ] && rm`: under `set -e` that compound returns 1 when the
+    # guard is false and would abort the whole install.
+    if [ -n "$_wvc_root" ]; then
+        rm -f "$_wvc_root/.webview-cache-cleared" 2>/dev/null || true
+    fi
     _wvc_cleared=false
     for _wvc_p in "${_wvc_paths[@]}"; do
         # -L too: a dangling symlink still occupies the path.

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -533,18 +533,16 @@ rm -rf "$REPO_ROOT/unsloth_compiled_cache"
 rm -rf "$SCRIPT_DIR/backend/unsloth_compiled_cache"
 rm -rf "$SCRIPT_DIR/tmp/unsloth_compiled_cache"
 
-# WebView caches keyed by the app bundle id hold copies of the previous
-# frontend and can keep serving it after an update (old styles linger).
-# Cache-only paths: LocalStorage, IndexedDB, cookies, settings, models,
-# and the studio database are untouched.
+# WebView caches keyed by the bundle id can keep serving the previous frontend
+# after an update. Cache-only: storage, cookies, settings, models and the studio
+# database are untouched.
 _clear_webview_caches() {
-    # No HOME: bail rather than let `set -u` abort the install or "" expand
-    # to /Library and /.cache.
+    # No HOME: bail rather than let `set -u` abort or "" expand to /Library and /.cache.
     [ -n "${HOME:-}" ] || return 0
     _wvc_bid="ai.unsloth.studio"
     _wvc_paths=()
-    # Where the desktop app keeps its version stamp (main.rs webview_profile_root).
-    # Not the same directory as the caches on macOS, so it is tracked separately.
+    # The app's version stamp dir (main.rs webview_profile_root), which on macOS
+    # is not the cache dir, so it is tracked separately.
     _wvc_root=""
     case "$(uname -s 2>/dev/null)" in
         Darwin)
@@ -556,9 +554,9 @@ _clear_webview_caches() {
         Linux)
             # wry points WebKitGTK's base-cache dir at the app data dir, so the
             # caches sit beside localstorage/, databases/ and cookies, which stay.
-            # A relative XDG_DATA_HOME is invalid per the XDG spec and is dropped
-            # by dirs, so Tauri uses the default; match that rather than rm -rf a
-            # relative path under whatever directory the installer runs from.
+            # A relative XDG_DATA_HOME is invalid per the XDG spec and dropped by
+            # dirs, so match Tauri and use the default rather than rm -rf under
+            # whatever directory the installer runs from.
             _wvc_data="${XDG_DATA_HOME:-$HOME/.local/share}"
             case "$_wvc_data" in /*) ;; *) _wvc_data="$HOME/.local/share" ;; esac
             _wvc_data="$_wvc_data/$_wvc_bid"
@@ -571,15 +569,12 @@ _clear_webview_caches() {
             ;;
         *) return 0 ;;
     esac
-    # Drop the app's version stamp before touching anything. An update runs while the
-    # old WebView still holds these files, so an rm here can fail; the app's own clear
-    # is the retry, and it is skipped whenever the stamp already matches the running
-    # version. A repair or a local frontend rebuild leaves the version unchanged, so
-    # without this the retry never happens and the cache we failed to remove survives.
-    # Unconditional: whether the rm below succeeds is not knowable for files another
-    # process holds open, and a redundant clear on the next launch is the cheap side.
-    # An `if`, not `[ ... ] && rm`: under `set -e` that compound returns 1 when the
-    # guard is false and would abort the whole install.
+    # Drop the version stamp first. An update runs while the old WebView still holds
+    # these files, so the rm below can fail; the app's own clear is the retry, and it
+    # is skipped while the stamp matches the running version. Unconditional, since a
+    # repair or a local rebuild leaves the version unchanged and a redundant clear on
+    # the next launch is the cheap side. An `if`, not `[ ... ] && rm`: under `set -e`
+    # that compound returns 1 when the guard is false and would abort the install.
     if [ -n "$_wvc_root" ]; then
         rm -f "$_wvc_root/.webview-cache-cleared" 2>/dev/null || true
     fi
@@ -594,11 +589,10 @@ _clear_webview_caches() {
     fi
     return 0
 }
-# Deliberately NOT called here. setup.sh runs under `set -euo pipefail` with no
-# trap, and the UNSLOTH_STUDIO_HOME / STUDIO_HOME override is not validated until
-# further down. Clearing first means a typo'd override deletes the WebView cache
-# and only then aborts, which is a side effect the pre-existing fail-fast path
-# never had. The call site is after the override is known to be good.
+# Deliberately NOT called here: setup.sh runs under `set -euo pipefail` with no
+# trap and the UNSLOTH_STUDIO_HOME / STUDIO_HOME override is not validated until
+# further down, so clearing first would let a typo'd override delete the cache
+# and only then abort. The call site is after the override is known to be good.
 
 # ── Detect Colab ──
 IS_COLAB=false
@@ -645,9 +639,8 @@ else
     STUDIO_HOME="$HOME/.unsloth/studio"
 fi
 
-# Now that the override has been validated, the clear can run without turning a
-# typo into cache loss. Still before any install work, which is the ordering that
-# matters: the caches must go while the old frontend is the one on disk.
+# The override is validated, so a typo can no longer cost the cache. Still before
+# any install work: the caches must go while the old frontend is the one on disk.
 _clear_webview_caches
 
 VENV_DIR="$STUDIO_HOME/unsloth_studio"

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -538,36 +538,35 @@ rm -rf "$SCRIPT_DIR/tmp/unsloth_compiled_cache"
 # Cache-only paths: LocalStorage, IndexedDB, cookies, settings, models,
 # and the studio database are untouched.
 _clear_webview_caches() {
+    # No HOME means no per-user paths to derive; bailing keeps `set -u` from
+    # aborting the install and stops "" expanding to /Library or /.cache.
+    [ -n "${HOME:-}" ] || return 0
     _wvc_bid="ai.unsloth.studio"
     _wvc_paths=()
     case "$(uname -s 2>/dev/null)" in
         Darwin)
-            _wvc_paths=(
-                "$HOME/Library/Caches/$_wvc_bid"
-                "$HOME/Library/WebKit/$_wvc_bid/WebsiteData/CacheStorage"
-                "$HOME/Library/WebKit/$_wvc_bid/WebsiteData/ServiceWorkers"
-                "$HOME/Library/WebKit/$_wvc_bid/WebsiteData/DiskCache"
-            )
+            # WKWebView puts every cache-typed store under Library/Caches/<bid>
+            # (WebKit/{NetworkCache,CacheStorage,ServiceWorkers}); LocalStorage
+            # and IndexedDB live under Library/WebKit/<bid> and are left alone.
+            _wvc_paths=("$HOME/Library/Caches/$_wvc_bid")
             ;;
         Linux)
-            # wry keys the WebKitGTK base-cache dir to the app DATA dir (same
-            # as base-data), so cache subdirs also live under
-            # ~/.local/share/<bid>. Clear only the cache-typed subdirs there;
-            # sibling localstorage/, indexeddb/, and cookies stay.
+            # wry points WebKitGTK's base-cache dir at the app DATA dir (same as
+            # base-data), so the caches sit under ~/.local/share/<bid>. Clear
+            # those; sibling localstorage/, databases/ and cookies stay.
             _wvc_data="${XDG_DATA_HOME:-$HOME/.local/share}/$_wvc_bid"
             _wvc_paths=(
-                "${XDG_CACHE_HOME:-$HOME/.cache}/$_wvc_bid"
                 "$_wvc_data/WebKitCache"
                 "$_wvc_data/CacheStorage"
                 "$_wvc_data/serviceworkers"
-                "$_wvc_data/ServiceWorkers"
             )
             ;;
         *) return 0 ;;
     esac
     _wvc_cleared=false
     for _wvc_p in "${_wvc_paths[@]}"; do
-        [ -e "$_wvc_p" ] || continue
+        # -L too: a dangling symlink still occupies the path.
+        [ -e "$_wvc_p" ] || [ -L "$_wvc_p" ] || continue
         rm -rf "$_wvc_p" 2>/dev/null && _wvc_cleared=true || true
     done
     if [ "$_wvc_cleared" = true ]; then

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -639,14 +639,21 @@ else
     STUDIO_HOME="$HOME/.unsloth/studio"
 fi
 
-# The override is validated, so a typo can no longer cost the cache. Still before
-# any install work: the caches must go while the old frontend is the one on disk.
-_clear_webview_caches
-
 VENV_DIR="$STUDIO_HOME/unsloth_studio"
 VENV_T5_530_DIR="$STUDIO_HOME/.venv_t5_530"
 VENV_T5_550_DIR="$STUDIO_HOME/.venv_t5_550"
 VENV_T5_510_DIR="$STUDIO_HOME/.venv_t5_510"
+
+# The override is validated and points at a real installation, so a typo can no longer
+# cost the cache. Gated on the venv because validating the directory is not enough: an
+# override that exists and is writable but holds no Studio install aborts at the venv
+# check further down, and clearing first would make that path cost the cache for a run
+# that then does nothing. A genuinely fresh install has neither a venv nor a cache, so
+# the guard skips nothing real. Still before any install work, which is the ordering
+# that matters: the caches must go while the old frontend is the one on disk.
+if [ -x "$VENV_DIR/bin/python" ]; then
+    _clear_webview_caches
+fi
 
 _STUDIO_OWNED_MARKER=".unsloth-studio-owned"
 _LEGACY_STUDIO_HOME="$HOME/.unsloth/studio"

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -533,6 +533,39 @@ rm -rf "$REPO_ROOT/unsloth_compiled_cache"
 rm -rf "$SCRIPT_DIR/backend/unsloth_compiled_cache"
 rm -rf "$SCRIPT_DIR/tmp/unsloth_compiled_cache"
 
+# WebView caches keyed by the app bundle id hold copies of the previous
+# frontend and can keep serving it after an update (old styles linger).
+# Cache-only paths: LocalStorage, IndexedDB, cookies, settings, models,
+# and the studio database are untouched.
+_clear_webview_caches() {
+    _wvc_bid="ai.unsloth.studio"
+    _wvc_paths=()
+    case "$(uname -s 2>/dev/null)" in
+        Darwin)
+            _wvc_paths=(
+                "$HOME/Library/Caches/$_wvc_bid"
+                "$HOME/Library/WebKit/$_wvc_bid/WebsiteData/CacheStorage"
+                "$HOME/Library/WebKit/$_wvc_bid/WebsiteData/ServiceWorkers"
+                "$HOME/Library/WebKit/$_wvc_bid/WebsiteData/DiskCache"
+            )
+            ;;
+        Linux)
+            _wvc_paths=("${XDG_CACHE_HOME:-$HOME/.cache}/$_wvc_bid")
+            ;;
+        *) return 0 ;;
+    esac
+    _wvc_cleared=false
+    for _wvc_p in "${_wvc_paths[@]}"; do
+        [ -e "$_wvc_p" ] || continue
+        rm -rf "$_wvc_p" 2>/dev/null && _wvc_cleared=true || true
+    done
+    if [ "$_wvc_cleared" = true ]; then
+        substep "cleared stale WebView caches ($_wvc_bid); settings and data kept"
+    fi
+    return 0
+}
+_clear_webview_caches
+
 # ── Detect Colab ──
 IS_COLAB=false
 keynames=$'\n'$(printenv | cut -d= -f1)

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -538,22 +538,20 @@ rm -rf "$SCRIPT_DIR/tmp/unsloth_compiled_cache"
 # Cache-only paths: LocalStorage, IndexedDB, cookies, settings, models,
 # and the studio database are untouched.
 _clear_webview_caches() {
-    # No HOME means no per-user paths to derive; bailing keeps `set -u` from
-    # aborting the install and stops "" expanding to /Library or /.cache.
+    # No HOME: bail rather than let `set -u` abort the install or "" expand
+    # to /Library and /.cache.
     [ -n "${HOME:-}" ] || return 0
     _wvc_bid="ai.unsloth.studio"
     _wvc_paths=()
     case "$(uname -s 2>/dev/null)" in
         Darwin)
-            # WKWebView puts every cache-typed store under Library/Caches/<bid>
-            # (WebKit/{NetworkCache,CacheStorage,ServiceWorkers}); LocalStorage
-            # and IndexedDB live under Library/WebKit/<bid> and are left alone.
+            # WKWebView keeps every cache-typed store under Library/Caches/<bid>;
+            # Library/WebKit/<bid> is user storage and is left alone.
             _wvc_paths=("$HOME/Library/Caches/$_wvc_bid")
             ;;
         Linux)
-            # wry points WebKitGTK's base-cache dir at the app DATA dir (same as
-            # base-data), so the caches sit under ~/.local/share/<bid>. Clear
-            # those; sibling localstorage/, databases/ and cookies stay.
+            # wry points WebKitGTK's base-cache dir at the app data dir, so the
+            # caches sit beside localstorage/, databases/ and cookies, which stay.
             _wvc_data="${XDG_DATA_HOME:-$HOME/.local/share}/$_wvc_bid"
             _wvc_paths=(
                 "$_wvc_data/WebKitCache"

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -550,7 +550,18 @@ _clear_webview_caches() {
             )
             ;;
         Linux)
-            _wvc_paths=("${XDG_CACHE_HOME:-$HOME/.cache}/$_wvc_bid")
+            # wry keys the WebKitGTK base-cache dir to the app DATA dir (same
+            # as base-data), so cache subdirs also live under
+            # ~/.local/share/<bid>. Clear only the cache-typed subdirs there;
+            # sibling localstorage/, indexeddb/, and cookies stay.
+            _wvc_data="${XDG_DATA_HOME:-$HOME/.local/share}/$_wvc_bid"
+            _wvc_paths=(
+                "${XDG_CACHE_HOME:-$HOME/.cache}/$_wvc_bid"
+                "$_wvc_data/WebKitCache"
+                "$_wvc_data/CacheStorage"
+                "$_wvc_data/serviceworkers"
+                "$_wvc_data/ServiceWorkers"
+            )
             ;;
         *) return 0 ;;
     esac

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -800,25 +800,19 @@ fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-// Root shared by the WebView profile and the version stamp below. Tauri points the
-// WebView at BaseDirectory::LocalData/<bid> (PathResolver uses dirs::data_local_dir)
-// and wry keys the WebKitGTK base-cache dir to it, so resolve it through the same
-// call: dirs drops a relative XDG_DATA_HOME as the spec requires, and falls back to
-// the passwd database and the Windows known folder when the environment is stripped,
-// which a direct HOME/LOCALAPPDATA read cannot.
+// Root shared by the WebView profile and the version stamp below. dirs::data_local_dir
+// is the call Tauri's PathResolver makes for LocalData/<bid>, and it falls back to the
+// passwd database and the Windows known folder where a raw env read cannot.
 fn webview_profile_root(bundle_id: &str) -> Option<std::path::PathBuf> {
     dirs::data_local_dir().map(|d| d.join(bundle_id))
 }
 
-// Clear WebView caches after an update, before the webview initializes: the
-// in-app update runs setup.sh/setup.ps1 while the old WebView still holds these
-// files, so its clear fails and a relaunch can serve the previous frontend.
-// Version-stamped so an ordinary launch does not discard the Windows compiled-JS
-// cache for nothing. Cache-only; LocalStorage, IndexedDB, cookies and app data are
-// kept. Mirrors setup.sh _clear_webview_caches / setup.ps1. Runs from a plugin
-// registered after single-instance, so a duplicate launch has already exited; the
-// returned lock, held for the rest of the process, covers the case where that
-// arbitration is unavailable (no session bus) and a second launch reaches here.
+// Clear WebView caches after an update: the in-app update runs setup.sh/setup.ps1 while
+// the old WebView still holds these files, so its clear fails and a relaunch serves the
+// previous frontend. Version-stamped so an ordinary launch does not discard the Windows
+// compiled-JS cache. Cache-only (storage and cookies kept), mirroring setup.sh
+// _clear_webview_caches / setup.ps1. The caller runs after single-instance, so a duplicate
+// launch has exited; the returned lock covers the no-session-bus case, where it has not.
 #[must_use]
 fn clear_webview_caches(bundle_id: &str, version: &str) -> Option<fs::File> {
     let root = webview_profile_root(bundle_id)?;
@@ -872,14 +866,12 @@ fn clear_webview_caches(bundle_id: &str, version: &str) -> Option<fs::File> {
     Some(lock)
 }
 
-// Never dropped: the profile lock has to outlive the clear (see the function).
+// Never dropped: the lock has to outlive the clear (see the function).
 static WEBVIEW_PROFILE_LOCK: std::sync::OnceLock<Option<fs::File>> = std::sync::OnceLock::new();
 
-// Register this directly after tauri_plugin_single_instance. Plugin setup hooks run
-// inside Builder::build(), in registration order, and the config-defined window (with
-// the WebView that locks these files) is only created later, from App::run(). So this
-// is the one point that is both after a duplicate launch has exited and before the
-// WebView exists.
+// Register directly after tauri_plugin_single_instance: setup hooks run in registration
+// order inside Builder::build(), while the config window (and its WebView, which locks
+// these files) is only created later, from App::run().
 fn webview_cache_plugin<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
     tauri::plugin::Builder::new("unsloth-webview-cache")
         .setup(|app, _api| {
@@ -1168,8 +1160,7 @@ mod tests {
         assert!(live.is_some(), "the clearing instance must get the lock");
         assert!(!root.join("WebKitCache").exists(), "the first launch did not clear");
 
-        // A second launch that got past single-instance (no session bus) must
-        // leave the first one's live profile alone.
+        // A second launch past single-instance (no session bus) must leave it alone.
         fs::create_dir_all(root.join("WebKitCache")).unwrap();
         let second = with_xdg_data_home(xdg, || clear_webview_caches(BID, "1.0.1"));
         assert!(second.is_none(), "a duplicate launch took the lock");

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -851,16 +851,17 @@ fn webview_profile_root(bundle_id: &str) -> Option<std::path::PathBuf> {
 #[must_use]
 fn clear_webview_caches(bundle_id: &str, version: &str) -> Option<fs::File> {
     let root = webview_profile_root(bundle_id)?;
-    let stamp = root.join(".webview-cache-cleared");
-    if fs::read_to_string(&stamp).is_ok_and(|v| v.trim() == version) {
-        return None;
-    }
-    // The stamp read is not atomic, so claim the profile before deleting: the
-    // loser of a duplicate launch skips this launch instead of racing. The OS
-    // drops the lock if we crash, so a dead process never blocks a later clear.
+    // Claim the profile BEFORE reading the stamp, and keep the lock even when the
+    // stamp matches: an already-stamped launch that held nothing would let a
+    // newer executable started alongside it delete this instance's live profile.
+    // The OS drops the lock if we crash, so a dead process never blocks a clear.
     let _ = fs::create_dir_all(&root);
     let lock = fs::File::create(root.join(".webview-cache-lock")).ok()?;
     lock.try_lock().ok()?;
+    let stamp = root.join(".webview-cache-cleared");
+    if fs::read_to_string(&stamp).is_ok_and(|v| v.trim() == version) {
+        return Some(lock);
+    }
 
     let mut paths: Vec<std::path::PathBuf> = Vec::new();
     #[cfg(target_os = "windows")]
@@ -1192,6 +1193,18 @@ mod tests {
 
         // Exit or crash drops the lock, so the next launch clears.
         drop(live);
+
+        // A launch whose stamp already matches must still TAKE the lock, or a
+        // newer executable started alongside it could delete the live profile.
+        fs::create_dir_all(root.join("WebKitCache")).unwrap();
+        let stamped = with_xdg_data_home(xdg, || clear_webview_caches(BID, "1.0.0"));
+        assert!(stamped.is_some(), "a stamped launch dropped the profile lock");
+        assert!(root.join("WebKitCache").exists(), "a stamped launch cleared anyway");
+        let racer = with_xdg_data_home(xdg, || clear_webview_caches(BID, "1.0.1"));
+        assert!(racer.is_none(), "a newer launch took the lock from a stamped instance");
+        assert!(root.join("WebKitCache").exists(), "deleted a stamped instance's cache");
+        drop(stamped);
+
         let next = with_xdg_data_home(xdg, || clear_webview_caches(BID, "1.0.1"));
         assert!(!root.join("WebKitCache").exists(), "a released lock still blocked the clear");
         drop(next);

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -800,62 +800,91 @@ fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-// Clear WebView caches before the webview initializes. An in-app update runs
-// setup.sh/setup.ps1 while the old WebView still holds these files (its clear
-// silently fails), so without this a relaunch can serve the previous frontend
-// from cache. Cache-only paths; LocalStorage, IndexedDB, cookies, and app
-// data are kept. Mirrors setup.sh _clear_webview_caches / setup.ps1.
-fn clear_webview_caches(bundle_id: &str) {
+// Root the WebView profile shares with the stamp file below. None when the
+// environment gives us nothing to derive it from.
+fn webview_profile_root(bundle_id: &str) -> Option<std::path::PathBuf> {
     use std::path::PathBuf;
-    let mut paths: Vec<PathBuf> = Vec::new();
+    let from_env = |key: &str| {
+        std::env::var(key)
+            .ok()
+            .filter(|v| !v.is_empty())
+            .map(PathBuf::from)
+    };
     #[cfg(target_os = "windows")]
-    if let Ok(local) = std::env::var("LOCALAPPDATA") {
-        if !local.is_empty() {
-            let profile = PathBuf::from(local)
-                .join(bundle_id)
-                .join("EBWebView")
-                .join("Default");
-            for sub in ["Cache", "Code Cache", "GPUCache", "Service Worker"] {
-                paths.push(profile.join(sub));
-            }
+    {
+        from_env("LOCALAPPDATA").map(|d| d.join(bundle_id))
+    }
+    #[cfg(target_os = "macos")]
+    {
+        from_env("HOME").map(|h| h.join("Library/Application Support").join(bundle_id))
+    }
+    #[cfg(target_os = "linux")]
+    {
+        // Tauri points the WebView at LocalData/<bundle id>, and wry keys the
+        // WebKitGTK base-cache dir to that same dir.
+        from_env("XDG_DATA_HOME")
+            .or_else(|| from_env("HOME").map(|h| h.join(".local/share")))
+            .map(|d| d.join(bundle_id))
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    {
+        let _ = (bundle_id, from_env);
+        None
+    }
+}
+
+// Clear WebView caches after an update, before the webview initializes. The
+// in-app update runs setup.sh/setup.ps1 while the old WebView still holds
+// these files, so its clear silently fails and a relaunch can serve the
+// previous frontend from cache.
+//
+// Gated on a version stamp for two reasons: an unconditional clear makes every
+// launch a cold-cache launch (the Windows profile keeps the compiled-JS cache),
+// and this runs before the single-instance plugin, so an ungated clear lets a
+// duplicate launch delete a live instance's profile out from under it.
+//
+// Cache-only paths; LocalStorage, IndexedDB, cookies and app data are kept.
+// Mirrors setup.sh _clear_webview_caches / setup.ps1.
+fn clear_webview_caches(bundle_id: &str, version: &str) {
+    let Some(root) = webview_profile_root(bundle_id) else {
+        return;
+    };
+    let stamp = root.join(".webview-cache-cleared");
+    if fs::read_to_string(&stamp).is_ok_and(|v| v.trim() == version) {
+        return;
+    }
+
+    let mut paths: Vec<std::path::PathBuf> = Vec::new();
+    #[cfg(target_os = "windows")]
+    {
+        let profile = root.join("EBWebView").join("Default");
+        for sub in ["Cache", "Code Cache", "GPUCache", "Service Worker"] {
+            paths.push(profile.join(sub));
         }
     }
     #[cfg(target_os = "macos")]
     if let Ok(home) = std::env::var("HOME") {
-        if !home.is_empty() {
-            let home = PathBuf::from(home);
-            paths.push(home.join("Library/Caches").join(bundle_id));
-            let data = home.join("Library/WebKit").join(bundle_id).join("WebsiteData");
-            for sub in ["CacheStorage", "ServiceWorkers", "DiskCache"] {
-                paths.push(data.join(sub));
-            }
-        }
+        // WKWebView keeps every cache-typed store under Library/Caches/<bid>
+        // (WebKit/{NetworkCache,CacheStorage,ServiceWorkers}). LocalStorage and
+        // IndexedDB live under Library/WebKit/<bid> and are left alone.
+        paths.push(std::path::PathBuf::from(home).join("Library/Caches").join(bundle_id));
     }
     #[cfg(target_os = "linux")]
-    if let Ok(home) = std::env::var("HOME") {
-        if !home.is_empty() {
-            let home = PathBuf::from(home);
-            let cache = std::env::var("XDG_CACHE_HOME")
-                .ok()
-                .filter(|v| !v.is_empty())
-                .map(PathBuf::from)
-                .unwrap_or_else(|| home.join(".cache"));
-            paths.push(cache.join(bundle_id));
-            // wry keys the WebKitGTK base-cache dir to the app data dir.
-            let data = std::env::var("XDG_DATA_HOME")
-                .ok()
-                .filter(|v| !v.is_empty())
-                .map(PathBuf::from)
-                .unwrap_or_else(|| home.join(".local/share"))
-                .join(bundle_id);
-            for sub in ["WebKitCache", "CacheStorage", "serviceworkers", "ServiceWorkers"] {
-                paths.push(data.join(sub));
+    for sub in ["WebKitCache", "CacheStorage", "serviceworkers"] {
+        paths.push(root.join(sub));
+    }
+
+    for p in &paths {
+        // Absent is the normal case; anything else is worth a line in the log,
+        // since a silent failure here is what the stale frontend looked like.
+        if let Err(e) = fs::remove_dir_all(p) {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                warn!("could not clear WebView cache {}: {e}", p.display());
             }
         }
     }
-    for p in paths {
-        let _ = fs::remove_dir_all(&p);
-    }
+    let _ = fs::create_dir_all(&root);
+    let _ = fs::write(&stamp, version);
 }
 
 fn main() {
@@ -875,7 +904,10 @@ fn main() {
     // Must run before the Builder: the config-defined window (and its
     // WebView, which locks these files) exists by the time setup hooks run.
     let context = tauri::generate_context!();
-    clear_webview_caches(&context.config().identifier);
+    clear_webview_caches(
+        &context.config().identifier,
+        context.package_info().version.to_string().as_str(),
+    );
 
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -820,8 +820,11 @@ fn webview_profile_root(bundle_id: &str) -> Option<std::path::PathBuf> {
     #[cfg(target_os = "linux")]
     {
         // Tauri points the WebView at LocalData/<bid>, and wry keys the
-        // WebKitGTK base-cache dir to that same dir.
+        // WebKitGTK base-cache dir to that same dir. dirs, which resolves
+        // LocalData, drops a relative XDG_DATA_HOME as the XDG spec requires;
+        // following one would miss the real cache and delete under $PWD.
         from_env("XDG_DATA_HOME")
+            .filter(|d| d.is_absolute())
             .or_else(|| from_env("HOME").map(|h| h.join(".local/share")))
             .map(|d| d.join(bundle_id))
     }
@@ -842,14 +845,22 @@ fn webview_profile_root(bundle_id: &str) -> Option<std::path::PathBuf> {
 //
 // Cache-only; LocalStorage, IndexedDB, cookies and app data are kept.
 // Mirrors setup.sh _clear_webview_caches / setup.ps1.
-fn clear_webview_caches(bundle_id: &str, version: &str) {
-    let Some(root) = webview_profile_root(bundle_id) else {
-        return;
-    };
+//
+// The returned lock must be held for the rest of the process: it is what stops
+// a duplicate launch from clearing the profile this instance is already using.
+#[must_use]
+fn clear_webview_caches(bundle_id: &str, version: &str) -> Option<fs::File> {
+    let root = webview_profile_root(bundle_id)?;
     let stamp = root.join(".webview-cache-cleared");
     if fs::read_to_string(&stamp).is_ok_and(|v| v.trim() == version) {
-        return;
+        return None;
     }
+    // The stamp read is not atomic, so claim the profile before deleting: the
+    // loser of a duplicate launch skips this launch instead of racing. The OS
+    // drops the lock if we crash, so a dead process never blocks a later clear.
+    let _ = fs::create_dir_all(&root);
+    let lock = fs::File::create(root.join(".webview-cache-lock")).ok()?;
+    lock.try_lock().ok()?;
 
     let mut paths: Vec<std::path::PathBuf> = Vec::new();
     #[cfg(target_os = "windows")]
@@ -870,17 +881,23 @@ fn clear_webview_caches(bundle_id: &str, version: &str) {
         paths.push(root.join(sub));
     }
 
+    let mut cleared = true;
     for p in &paths {
         // Absent is normal; anything else is worth logging, since a silent
         // failure here is what the stale frontend looked like.
         if let Err(e) = fs::remove_dir_all(p) {
             if e.kind() != std::io::ErrorKind::NotFound {
                 warn!("could not clear WebView cache {}: {e}", p.display());
+                cleared = false;
             }
         }
     }
-    let _ = fs::create_dir_all(&root);
-    let _ = fs::write(&stamp, version);
+    // Stamping a partial clear (an update can still hold a cache file open)
+    // would make every later launch skip the retry and keep the stale cache.
+    if cleared {
+        let _ = fs::write(&stamp, version);
+    }
+    Some(lock)
 }
 
 fn main() {
@@ -900,7 +917,8 @@ fn main() {
     // Must run before the Builder: the config-defined window (and its
     // WebView, which locks these files) exists by the time setup hooks run.
     let context = tauri::generate_context!();
-    clear_webview_caches(
+    // Bound, not dropped: the lock has to outlive the clear (see the function).
+    let _webview_profile_lock = clear_webview_caches(
         &context.config().identifier,
         context.package_info().version.to_string().as_str(),
     );
@@ -1078,6 +1096,105 @@ mod tests {
         assert!(take_in_app_relaunch_marker(dir.path()));
         assert!(!take_in_app_relaunch_marker(dir.path()));
         assert!(!in_app_relaunch_marker_path(dir.path()).exists());
+    }
+
+    #[cfg(target_os = "linux")]
+    const BID: &str = "ai.unsloth.studio";
+
+    // Only XDG_DATA_HOME is swapped, and nothing else in the crate reads it, so
+    // these stay clear of the tests running beside them. HOME is left alone for
+    // the same reason: `dirs::home_dir` is all over this crate.
+    #[cfg(target_os = "linux")]
+    fn with_xdg_data_home<T>(value: &str, f: impl FnOnce() -> T) -> T {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let saved = std::env::var_os("XDG_DATA_HOME");
+        std::env::set_var("XDG_DATA_HOME", value);
+        let out = f();
+        match saved {
+            Some(v) => std::env::set_var("XDG_DATA_HOME", v),
+            None => std::env::remove_var("XDG_DATA_HOME"),
+        }
+        out
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn a_relative_xdg_data_home_resolves_like_tauri_does() {
+        // dirs, which resolves the LocalData dir Tauri hands the WebView, drops
+        // a relative XDG_DATA_HOME as the XDG spec requires. Following one would
+        // leave the real cache in place and rm -rf under the working directory.
+        let (got, expected) = with_xdg_data_home("reldata", || {
+            (
+                webview_profile_root(BID),
+                dirs::data_local_dir().map(|d| d.join(BID)),
+            )
+        });
+        assert_eq!(got, expected, "diverged from the resolver Tauri uses");
+        assert!(
+            got.is_none_or(|p| p.is_absolute()),
+            "resolved a deletion target relative to the working directory"
+        );
+
+        // An absolute override is still honoured.
+        let dir = tempfile::tempdir().unwrap();
+        let got = with_xdg_data_home(dir.path().to_str().unwrap(), || webview_profile_root(BID));
+        assert_eq!(got, Some(dir.path().join(BID)));
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn a_partial_clear_is_not_stamped_and_retries() {
+        let dir = tempfile::tempdir().unwrap();
+        let xdg = dir.path().to_str().unwrap();
+        let root = dir.path().join(BID);
+        fs::create_dir_all(root.join("CacheStorage")).unwrap();
+        // A plain file where a cache directory belongs fails remove_dir_all with
+        // something other than NotFound, exactly as a locked directory does.
+        fs::write(root.join("WebKitCache"), b"still open").unwrap();
+
+        let lock = with_xdg_data_home(xdg, || clear_webview_caches(BID, "1.0.0"));
+        assert!(!root.join("CacheStorage").exists(), "the deletable cache stayed");
+        assert!(
+            !root.join(".webview-cache-cleared").exists(),
+            "stamping a partial clear makes every later launch skip the retry"
+        );
+        drop(lock);
+
+        // The next launch, with the obstruction gone, clears and stamps.
+        fs::remove_file(root.join("WebKitCache")).unwrap();
+        fs::create_dir_all(root.join("WebKitCache")).unwrap();
+        let lock = with_xdg_data_home(xdg, || clear_webview_caches(BID, "1.0.0"));
+        assert!(!root.join("WebKitCache").exists(), "the retry did not run");
+        assert!(root.join(".webview-cache-cleared").exists(), "the retry did not stamp");
+        drop(lock);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn a_live_instance_lock_excludes_a_duplicate_launch() {
+        let dir = tempfile::tempdir().unwrap();
+        let xdg = dir.path().to_str().unwrap();
+        let root = dir.path().join(BID);
+        fs::create_dir_all(root.join("WebKitCache")).unwrap();
+
+        // The first launch clears and holds the lock, as main() does.
+        let live = with_xdg_data_home(xdg, || clear_webview_caches(BID, "1.0.0"));
+        assert!(live.is_some(), "the clearing instance must get the lock");
+        assert!(!root.join("WebKitCache").exists(), "the first launch did not clear");
+
+        // Single-instance arbitration is still several steps away, so a second
+        // launch must leave the profile the first one is using alone.
+        fs::create_dir_all(root.join("WebKitCache")).unwrap();
+        let second = with_xdg_data_home(xdg, || clear_webview_caches(BID, "1.0.1"));
+        assert!(second.is_none(), "a duplicate launch took the lock");
+        assert!(root.join("WebKitCache").exists(), "deleted a live instance's cache");
+
+        // Exit or crash drops the lock, so the next launch clears.
+        drop(live);
+        let next = with_xdg_data_home(xdg, || clear_webview_caches(BID, "1.0.1"));
+        assert!(!root.join("WebKitCache").exists(), "a released lock still blocked the clear");
+        drop(next);
     }
 
     // One test, not three: `QUIT_IN_PROGRESS` is process-global and cargo tests run in parallel.

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -819,10 +819,10 @@ fn webview_profile_root(bundle_id: &str) -> Option<std::path::PathBuf> {
     }
     #[cfg(target_os = "linux")]
     {
-        // Tauri points the WebView at LocalData/<bid>, and wry keys the
-        // WebKitGTK base-cache dir to that same dir. dirs, which resolves
-        // LocalData, drops a relative XDG_DATA_HOME as the XDG spec requires;
-        // following one would miss the real cache and delete under $PWD.
+        // Tauri points the WebView at LocalData/<bid> and wry keys the WebKitGTK
+        // base-cache dir to it. dirs, which resolves LocalData, drops a relative
+        // XDG_DATA_HOME as the XDG spec requires; following one would miss the
+        // real cache and delete under $PWD.
         from_env("XDG_DATA_HOME")
             .filter(|d| d.is_absolute())
             .or_else(|| from_env("HOME").map(|h| h.join(".local/share")))
@@ -838,23 +838,20 @@ fn webview_profile_root(bundle_id: &str) -> Option<std::path::PathBuf> {
 // Clear WebView caches after an update, before the webview initializes: the
 // in-app update runs setup.sh/setup.ps1 while the old WebView still holds these
 // files, so its clear fails and a relaunch can serve the previous frontend.
-//
-// Version-stamped, because this runs before the single-instance plugin. Ungated,
-// a duplicate launch would delete a live instance's profile, and every ordinary
+// Version-stamped, because this runs before the single-instance plugin: ungated,
+// a duplicate launch would delete a live instance's profile and every ordinary
 // launch would discard the Windows compiled-JS cache for nothing.
-//
-// Cache-only; LocalStorage, IndexedDB, cookies and app data are kept.
-// Mirrors setup.sh _clear_webview_caches / setup.ps1.
-//
-// The returned lock must be held for the rest of the process: it is what stops
-// a duplicate launch from clearing the profile this instance is already using.
+// Cache-only; LocalStorage, IndexedDB, cookies and app data are kept. Mirrors
+// setup.sh _clear_webview_caches / setup.ps1. The returned lock must be held for
+// the rest of the process: it is what stops a duplicate launch from clearing the
+// profile this instance is already using.
 #[must_use]
 fn clear_webview_caches(bundle_id: &str, version: &str) -> Option<fs::File> {
     let root = webview_profile_root(bundle_id)?;
-    // Claim the profile BEFORE reading the stamp, and keep the lock even when the
-    // stamp matches: an already-stamped launch that held nothing would let a
-    // newer executable started alongside it delete this instance's live profile.
-    // The OS drops the lock if we crash, so a dead process never blocks a clear.
+    // Claim the profile BEFORE reading the stamp, and keep the lock even when it
+    // matches: a stamped launch holding nothing would let a newer executable started
+    // alongside it delete this instance's live profile. The OS drops the lock if we
+    // crash, so a dead process never blocks a clear.
     let _ = fs::create_dir_all(&root);
     let lock = fs::File::create(root.join(".webview-cache-lock")).ok()?;
     lock.try_lock().ok()?;
@@ -884,8 +881,8 @@ fn clear_webview_caches(bundle_id: &str, version: &str) -> Option<fs::File> {
 
     let mut cleared = true;
     for p in &paths {
-        // Absent is normal; anything else is worth logging, since a silent
-        // failure here is what the stale frontend looked like.
+        // Absent is normal; anything else is the silent failure that shows up
+        // as a stale frontend, so log it.
         if let Err(e) = fs::remove_dir_all(p) {
             if e.kind() != std::io::ErrorKind::NotFound {
                 warn!("could not clear WebView cache {}: {e}", p.display());
@@ -1102,9 +1099,9 @@ mod tests {
     #[cfg(target_os = "linux")]
     const BID: &str = "ai.unsloth.studio";
 
-    // Only XDG_DATA_HOME is swapped, and nothing else in the crate reads it, so
-    // these stay clear of the tests running beside them. HOME is left alone for
-    // the same reason: `dirs::home_dir` is all over this crate.
+    // Only XDG_DATA_HOME is swapped, and nothing else in the crate reads it, so the
+    // tests running beside these stay clear. HOME is left alone for the same reason:
+    // `dirs::home_dir` is all over this crate.
     #[cfg(target_os = "linux")]
     fn with_xdg_data_home<T>(value: &str, f: impl FnOnce() -> T) -> T {
         static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -1122,9 +1119,9 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn a_relative_xdg_data_home_resolves_like_tauri_does() {
-        // dirs, which resolves the LocalData dir Tauri hands the WebView, drops
-        // a relative XDG_DATA_HOME as the XDG spec requires. Following one would
-        // leave the real cache in place and rm -rf under the working directory.
+        // dirs, which resolves the LocalData dir Tauri hands the WebView, drops a
+        // relative XDG_DATA_HOME; following one would leave the real cache in
+        // place and rm -rf under the working directory.
         let (got, expected) = with_xdg_data_home("reldata", || {
             (
                 webview_profile_root(BID),
@@ -1150,8 +1147,8 @@ mod tests {
         let xdg = dir.path().to_str().unwrap();
         let root = dir.path().join(BID);
         fs::create_dir_all(root.join("CacheStorage")).unwrap();
-        // A plain file where a cache directory belongs fails remove_dir_all with
-        // something other than NotFound, exactly as a locked directory does.
+        // A plain file where a cache dir belongs fails remove_dir_all with something
+        // other than NotFound, exactly as a locked directory does.
         fs::write(root.join("WebKitCache"), b"still open").unwrap();
 
         let lock = with_xdg_data_home(xdg, || clear_webview_caches(BID, "1.0.0"));
@@ -1185,7 +1182,7 @@ mod tests {
         assert!(!root.join("WebKitCache").exists(), "the first launch did not clear");
 
         // Single-instance arbitration is still several steps away, so a second
-        // launch must leave the profile the first one is using alone.
+        // launch must leave the first one's live profile alone.
         fs::create_dir_all(root.join("WebKitCache")).unwrap();
         let second = with_xdg_data_home(xdg, || clear_webview_caches(BID, "1.0.1"));
         assert!(second.is_none(), "a duplicate launch took the lock");

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -800,51 +800,25 @@ fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-// Root shared by the WebView profile and the version stamp below.
+// Root shared by the WebView profile and the version stamp below. Tauri points the
+// WebView at BaseDirectory::LocalData/<bid> (PathResolver uses dirs::data_local_dir)
+// and wry keys the WebKitGTK base-cache dir to it, so resolve it through the same
+// call: dirs drops a relative XDG_DATA_HOME as the spec requires, and falls back to
+// the passwd database and the Windows known folder when the environment is stripped,
+// which a direct HOME/LOCALAPPDATA read cannot.
 fn webview_profile_root(bundle_id: &str) -> Option<std::path::PathBuf> {
-    use std::path::PathBuf;
-    let from_env = |key: &str| {
-        std::env::var(key)
-            .ok()
-            .filter(|v| !v.is_empty())
-            .map(PathBuf::from)
-    };
-    #[cfg(target_os = "windows")]
-    {
-        from_env("LOCALAPPDATA").map(|d| d.join(bundle_id))
-    }
-    #[cfg(target_os = "macos")]
-    {
-        from_env("HOME").map(|h| h.join("Library/Application Support").join(bundle_id))
-    }
-    #[cfg(target_os = "linux")]
-    {
-        // Tauri points the WebView at LocalData/<bid> and wry keys the WebKitGTK
-        // base-cache dir to it. dirs, which resolves LocalData, drops a relative
-        // XDG_DATA_HOME as the XDG spec requires; following one would miss the
-        // real cache and delete under $PWD.
-        from_env("XDG_DATA_HOME")
-            .filter(|d| d.is_absolute())
-            .or_else(|| from_env("HOME").map(|h| h.join(".local/share")))
-            .map(|d| d.join(bundle_id))
-    }
-    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
-    {
-        let _ = (bundle_id, from_env);
-        None
-    }
+    dirs::data_local_dir().map(|d| d.join(bundle_id))
 }
 
 // Clear WebView caches after an update, before the webview initializes: the
 // in-app update runs setup.sh/setup.ps1 while the old WebView still holds these
 // files, so its clear fails and a relaunch can serve the previous frontend.
-// Version-stamped, because this runs before the single-instance plugin: ungated,
-// a duplicate launch would delete a live instance's profile and every ordinary
-// launch would discard the Windows compiled-JS cache for nothing.
-// Cache-only; LocalStorage, IndexedDB, cookies and app data are kept. Mirrors
-// setup.sh _clear_webview_caches / setup.ps1. The returned lock must be held for
-// the rest of the process: it is what stops a duplicate launch from clearing the
-// profile this instance is already using.
+// Version-stamped so an ordinary launch does not discard the Windows compiled-JS
+// cache for nothing. Cache-only; LocalStorage, IndexedDB, cookies and app data are
+// kept. Mirrors setup.sh _clear_webview_caches / setup.ps1. Runs from a plugin
+// registered after single-instance, so a duplicate launch has already exited; the
+// returned lock, held for the rest of the process, covers the case where that
+// arbitration is unavailable (no session bus) and a second launch reaches here.
 #[must_use]
 fn clear_webview_caches(bundle_id: &str, version: &str) -> Option<fs::File> {
     let root = webview_profile_root(bundle_id)?;
@@ -869,10 +843,10 @@ fn clear_webview_caches(bundle_id: &str, version: &str) -> Option<fs::File> {
         }
     }
     #[cfg(target_os = "macos")]
-    if let Ok(home) = std::env::var("HOME") {
+    if let Some(caches) = dirs::cache_dir() {
         // WKWebView keeps every cache-typed store under Library/Caches/<bid>;
         // Library/WebKit/<bid> is user storage and is left alone.
-        paths.push(std::path::PathBuf::from(home).join("Library/Caches").join(bundle_id));
+        paths.push(caches.join(bundle_id));
     }
     #[cfg(target_os = "linux")]
     for sub in ["WebKitCache", "CacheStorage", "serviceworkers"] {
@@ -898,6 +872,25 @@ fn clear_webview_caches(bundle_id: &str, version: &str) -> Option<fs::File> {
     Some(lock)
 }
 
+// Never dropped: the profile lock has to outlive the clear (see the function).
+static WEBVIEW_PROFILE_LOCK: std::sync::OnceLock<Option<fs::File>> = std::sync::OnceLock::new();
+
+// Register this directly after tauri_plugin_single_instance. Plugin setup hooks run
+// inside Builder::build(), in registration order, and the config-defined window (with
+// the WebView that locks these files) is only created later, from App::run(). So this
+// is the one point that is both after a duplicate launch has exited and before the
+// WebView exists.
+fn webview_cache_plugin<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
+    tauri::plugin::Builder::new("unsloth-webview-cache")
+        .setup(|app, _api| {
+            let version = app.package_info().version.to_string();
+            let _ = WEBVIEW_PROFILE_LOCK
+                .set(clear_webview_caches(&app.config().identifier, &version));
+            Ok(())
+        })
+        .build()
+}
+
 fn main() {
     // Must precede any Xlib call: GTK3 never calls XInitThreads and this
     // process drives X from several threads. See x11_threads for the crash.
@@ -912,19 +905,13 @@ fn main() {
     info!("Unsloth desktop app starting");
     windows_job::initialize();
 
-    // Must run before the Builder: the config-defined window (and its
-    // WebView, which locks these files) exists by the time setup hooks run.
     let context = tauri::generate_context!();
-    // Bound, not dropped: the lock has to outlive the clear (see the function).
-    let _webview_profile_lock = clear_webview_caches(
-        &context.config().identifier,
-        context.package_info().version.to_string().as_str(),
-    );
 
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             show_main_window(app);
         }))
+        .plugin(webview_cache_plugin())
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_autostart::init(
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,
@@ -1181,8 +1168,8 @@ mod tests {
         assert!(live.is_some(), "the clearing instance must get the lock");
         assert!(!root.join("WebKitCache").exists(), "the first launch did not clear");
 
-        // Single-instance arbitration is still several steps away, so a second
-        // launch must leave the first one's live profile alone.
+        // A second launch that got past single-instance (no session bus) must
+        // leave the first one's live profile alone.
         fs::create_dir_all(root.join("WebKitCache")).unwrap();
         let second = with_xdg_data_home(xdg, || clear_webview_caches(BID, "1.0.1"));
         assert!(second.is_none(), "a duplicate launch took the lock");

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -800,8 +800,7 @@ fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-// Root the WebView profile shares with the stamp file below. None when the
-// environment gives us nothing to derive it from.
+// Root shared by the WebView profile and the version stamp below.
 fn webview_profile_root(bundle_id: &str) -> Option<std::path::PathBuf> {
     use std::path::PathBuf;
     let from_env = |key: &str| {
@@ -820,7 +819,7 @@ fn webview_profile_root(bundle_id: &str) -> Option<std::path::PathBuf> {
     }
     #[cfg(target_os = "linux")]
     {
-        // Tauri points the WebView at LocalData/<bundle id>, and wry keys the
+        // Tauri points the WebView at LocalData/<bid>, and wry keys the
         // WebKitGTK base-cache dir to that same dir.
         from_env("XDG_DATA_HOME")
             .or_else(|| from_env("HOME").map(|h| h.join(".local/share")))
@@ -833,17 +832,15 @@ fn webview_profile_root(bundle_id: &str) -> Option<std::path::PathBuf> {
     }
 }
 
-// Clear WebView caches after an update, before the webview initializes. The
-// in-app update runs setup.sh/setup.ps1 while the old WebView still holds
-// these files, so its clear silently fails and a relaunch can serve the
-// previous frontend from cache.
+// Clear WebView caches after an update, before the webview initializes: the
+// in-app update runs setup.sh/setup.ps1 while the old WebView still holds these
+// files, so its clear fails and a relaunch can serve the previous frontend.
 //
-// Gated on a version stamp for two reasons: an unconditional clear makes every
-// launch a cold-cache launch (the Windows profile keeps the compiled-JS cache),
-// and this runs before the single-instance plugin, so an ungated clear lets a
-// duplicate launch delete a live instance's profile out from under it.
+// Version-stamped, because this runs before the single-instance plugin. Ungated,
+// a duplicate launch would delete a live instance's profile, and every ordinary
+// launch would discard the Windows compiled-JS cache for nothing.
 //
-// Cache-only paths; LocalStorage, IndexedDB, cookies and app data are kept.
+// Cache-only; LocalStorage, IndexedDB, cookies and app data are kept.
 // Mirrors setup.sh _clear_webview_caches / setup.ps1.
 fn clear_webview_caches(bundle_id: &str, version: &str) {
     let Some(root) = webview_profile_root(bundle_id) else {
@@ -864,9 +861,8 @@ fn clear_webview_caches(bundle_id: &str, version: &str) {
     }
     #[cfg(target_os = "macos")]
     if let Ok(home) = std::env::var("HOME") {
-        // WKWebView keeps every cache-typed store under Library/Caches/<bid>
-        // (WebKit/{NetworkCache,CacheStorage,ServiceWorkers}). LocalStorage and
-        // IndexedDB live under Library/WebKit/<bid> and are left alone.
+        // WKWebView keeps every cache-typed store under Library/Caches/<bid>;
+        // Library/WebKit/<bid> is user storage and is left alone.
         paths.push(std::path::PathBuf::from(home).join("Library/Caches").join(bundle_id));
     }
     #[cfg(target_os = "linux")]
@@ -875,8 +871,8 @@ fn clear_webview_caches(bundle_id: &str, version: &str) {
     }
 
     for p in &paths {
-        // Absent is the normal case; anything else is worth a line in the log,
-        // since a silent failure here is what the stale frontend looked like.
+        // Absent is normal; anything else is worth logging, since a silent
+        // failure here is what the stale frontend looked like.
         if let Err(e) = fs::remove_dir_all(p) {
             if e.kind() != std::io::ErrorKind::NotFound {
                 warn!("could not clear WebView cache {}: {e}", p.display());

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -800,6 +800,64 @@ fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+// Clear WebView caches before the webview initializes. An in-app update runs
+// setup.sh/setup.ps1 while the old WebView still holds these files (its clear
+// silently fails), so without this a relaunch can serve the previous frontend
+// from cache. Cache-only paths; LocalStorage, IndexedDB, cookies, and app
+// data are kept. Mirrors setup.sh _clear_webview_caches / setup.ps1.
+fn clear_webview_caches(bundle_id: &str) {
+    use std::path::PathBuf;
+    let mut paths: Vec<PathBuf> = Vec::new();
+    #[cfg(target_os = "windows")]
+    if let Ok(local) = std::env::var("LOCALAPPDATA") {
+        if !local.is_empty() {
+            let profile = PathBuf::from(local)
+                .join(bundle_id)
+                .join("EBWebView")
+                .join("Default");
+            for sub in ["Cache", "Code Cache", "GPUCache", "Service Worker"] {
+                paths.push(profile.join(sub));
+            }
+        }
+    }
+    #[cfg(target_os = "macos")]
+    if let Ok(home) = std::env::var("HOME") {
+        if !home.is_empty() {
+            let home = PathBuf::from(home);
+            paths.push(home.join("Library/Caches").join(bundle_id));
+            let data = home.join("Library/WebKit").join(bundle_id).join("WebsiteData");
+            for sub in ["CacheStorage", "ServiceWorkers", "DiskCache"] {
+                paths.push(data.join(sub));
+            }
+        }
+    }
+    #[cfg(target_os = "linux")]
+    if let Ok(home) = std::env::var("HOME") {
+        if !home.is_empty() {
+            let home = PathBuf::from(home);
+            let cache = std::env::var("XDG_CACHE_HOME")
+                .ok()
+                .filter(|v| !v.is_empty())
+                .map(PathBuf::from)
+                .unwrap_or_else(|| home.join(".cache"));
+            paths.push(cache.join(bundle_id));
+            // wry keys the WebKitGTK base-cache dir to the app data dir.
+            let data = std::env::var("XDG_DATA_HOME")
+                .ok()
+                .filter(|v| !v.is_empty())
+                .map(PathBuf::from)
+                .unwrap_or_else(|| home.join(".local/share"))
+                .join(bundle_id);
+            for sub in ["WebKitCache", "CacheStorage", "serviceworkers", "ServiceWorkers"] {
+                paths.push(data.join(sub));
+            }
+        }
+    }
+    for p in paths {
+        let _ = fs::remove_dir_all(&p);
+    }
+}
+
 fn main() {
     // Must precede any Xlib call: GTK3 never calls XInitThreads and this
     // process drives X from several threads. See x11_threads for the crash.
@@ -813,6 +871,11 @@ fn main() {
     setup_logging();
     info!("Unsloth desktop app starting");
     windows_job::initialize();
+
+    // Must run before the Builder: the config-defined window (and its
+    // WebView, which locks these files) exists by the time setup hooks run.
+    let context = tauri::generate_context!();
+    clear_webview_caches(&context.config().identifier);
 
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
@@ -936,7 +999,7 @@ fn main() {
                 }
             }
         })
-        .build(tauri::generate_context!())
+        .build(context)
         .expect("error while building tauri application")
         .run(|app, event| match event {
             #[cfg(target_os = "macos")]

--- a/tests/sh/test_setup_webview_cache_clear.sh
+++ b/tests/sh/test_setup_webview_cache_clear.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+# Unit tests for _clear_webview_caches() from studio/setup.sh.
+#
+# The WebView caches keyed by the app bundle id (ai.unsloth.studio) hold copies
+# of the previous frontend, so an install/update must clear them or the app can
+# keep rendering old styles. Clearing must be cache-only: LocalStorage,
+# IndexedDB, app data, and unrelated apps' caches stay intact.
+#
+# Follows the extract-via-sed pattern of test_uninstall_shared_icon.sh; uname
+# is overridden per test with a shell function to select the OS branch.
+# shellcheck disable=SC2329  # uname stubs are invoked inside the extracted function
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SETUP_SH="$SCRIPT_DIR/../../studio/setup.sh"
+BID="ai.unsloth.studio"
+PASS=0
+FAIL=0
+
+_TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$_TMP_ROOT"' EXIT
+
+assert_gone()    { _l="$1"; if [ -e "$2" ]; then echo "  FAIL: $_l (still present: $2)"; FAIL=$((FAIL+1)); else echo "  PASS: $_l"; PASS=$((PASS+1)); fi; }
+assert_present() { _l="$1"; if [ -e "$2" ]; then echo "  PASS: $_l"; PASS=$((PASS+1)); else echo "  FAIL: $_l (missing: $2)"; FAIL=$((FAIL+1)); fi; }
+
+# Extract just the function definition (top-level, closes at column 0).
+FUNC_FILE=$(mktemp -p "$_TMP_ROOT")
+sed -n '/^_clear_webview_caches() {/,/^}/p' "$SETUP_SH" > "$FUNC_FILE"
+# shellcheck disable=SC1090
+. "$FUNC_FILE"
+substep() { :; }  # stub the setup.sh logger
+
+# ── 1. macOS: cache paths removed, user-facing storage kept ──
+H=$(mktemp -d -p "$_TMP_ROOT")
+mkdir -p "$H/Library/Caches/$BID/WebKit/NetworkCache" \
+         "$H/Library/WebKit/$BID/WebsiteData/CacheStorage" \
+         "$H/Library/WebKit/$BID/WebsiteData/ServiceWorkers" \
+         "$H/Library/WebKit/$BID/WebsiteData/DiskCache" \
+         "$H/Library/WebKit/$BID/WebsiteData/LocalStorage" \
+         "$H/Library/WebKit/$BID/WebsiteData/IndexedDB" \
+         "$H/Library/Application Support/$BID" \
+         "$H/Library/Caches/com.other.app"
+uname() { echo Darwin; }
+HOME="$H" _clear_webview_caches
+assert_gone    "macOS: Caches/$BID removed"              "$H/Library/Caches/$BID"
+assert_gone    "macOS: WebsiteData/CacheStorage removed" "$H/Library/WebKit/$BID/WebsiteData/CacheStorage"
+assert_gone    "macOS: WebsiteData/ServiceWorkers removed" "$H/Library/WebKit/$BID/WebsiteData/ServiceWorkers"
+assert_gone    "macOS: WebsiteData/DiskCache removed"    "$H/Library/WebKit/$BID/WebsiteData/DiskCache"
+assert_present "macOS: LocalStorage kept"                "$H/Library/WebKit/$BID/WebsiteData/LocalStorage"
+assert_present "macOS: IndexedDB kept"                   "$H/Library/WebKit/$BID/WebsiteData/IndexedDB"
+assert_present "macOS: Application Support kept"         "$H/Library/Application Support/$BID"
+assert_present "macOS: unrelated app cache kept"         "$H/Library/Caches/com.other.app"
+
+# ── 2. Linux: cache dir removed, data/config kept ──
+H=$(mktemp -d -p "$_TMP_ROOT")
+mkdir -p "$H/.cache/$BID" "$H/.local/share/$BID" "$H/.config/$BID" "$H/.cache/other.app"
+uname() { echo Linux; }
+HOME="$H" XDG_CACHE_HOME="" _clear_webview_caches
+assert_gone    "linux: ~/.cache/$BID removed"     "$H/.cache/$BID"
+assert_present "linux: ~/.local/share/$BID kept"  "$H/.local/share/$BID"
+assert_present "linux: ~/.config/$BID kept"       "$H/.config/$BID"
+assert_present "linux: unrelated app cache kept"  "$H/.cache/other.app"
+
+# ── 3. Linux: XDG_CACHE_HOME override honored ──
+H=$(mktemp -d -p "$_TMP_ROOT")
+XDG=$(mktemp -d -p "$_TMP_ROOT")
+mkdir -p "$XDG/$BID" "$H/.cache/$BID"
+HOME="$H" XDG_CACHE_HOME="$XDG" _clear_webview_caches
+assert_gone    "linux: XDG_CACHE_HOME/$BID removed"        "$XDG/$BID"
+assert_present "linux: ~/.cache/$BID kept under override"  "$H/.cache/$BID"
+
+# ── 4. Nothing to clear is a clean no-op ──
+H=$(mktemp -d -p "$_TMP_ROOT")
+uname() { echo Darwin; }
+if HOME="$H" _clear_webview_caches; then
+    echo "  PASS: empty HOME -> no-op exit 0"; PASS=$((PASS+1))
+else
+    echo "  FAIL: empty HOME -> nonzero exit"; FAIL=$((FAIL+1))
+fi
+
+# ── 5. Unknown OS is a no-op ──
+H=$(mktemp -d -p "$_TMP_ROOT")
+mkdir -p "$H/Library/Caches/$BID"
+uname() { echo SunOS; }
+HOME="$H" _clear_webview_caches
+assert_present "unknown OS: nothing removed" "$H/Library/Caches/$BID"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" = 0 ]

--- a/tests/sh/test_setup_webview_cache_clear.sh
+++ b/tests/sh/test_setup_webview_cache_clear.sh
@@ -53,23 +53,34 @@ assert_present "macOS: IndexedDB kept"                   "$H/Library/WebKit/$BID
 assert_present "macOS: Application Support kept"         "$H/Library/Application Support/$BID"
 assert_present "macOS: unrelated app cache kept"         "$H/Library/Caches/com.other.app"
 
-# ── 2. Linux: cache dir removed, data/config kept ──
+# ── 2. Linux: cache paths removed (XDG cache dir AND the cache subdirs wry
+# keys to the app data dir), user-facing storage kept ──
 H=$(mktemp -d -p "$_TMP_ROOT")
-mkdir -p "$H/.cache/$BID" "$H/.local/share/$BID" "$H/.config/$BID" "$H/.cache/other.app"
+D="$H/.local/share/$BID"
+mkdir -p "$H/.cache/$BID" "$D/WebKitCache" "$D/CacheStorage" "$D/serviceworkers" \
+         "$D/localstorage" "$D/indexeddb" "$H/.config/$BID" "$H/.cache/other.app"
+: > "$D/cookies.sqlite"
 uname() { echo Linux; }
-HOME="$H" XDG_CACHE_HOME="" _clear_webview_caches
-assert_gone    "linux: ~/.cache/$BID removed"     "$H/.cache/$BID"
-assert_present "linux: ~/.local/share/$BID kept"  "$H/.local/share/$BID"
-assert_present "linux: ~/.config/$BID kept"       "$H/.config/$BID"
-assert_present "linux: unrelated app cache kept"  "$H/.cache/other.app"
+HOME="$H" XDG_CACHE_HOME="" XDG_DATA_HOME="" _clear_webview_caches
+assert_gone    "linux: ~/.cache/$BID removed"          "$H/.cache/$BID"
+assert_gone    "linux: data-dir WebKitCache removed"   "$D/WebKitCache"
+assert_gone    "linux: data-dir CacheStorage removed"  "$D/CacheStorage"
+assert_gone    "linux: data-dir serviceworkers removed" "$D/serviceworkers"
+assert_present "linux: localstorage kept"              "$D/localstorage"
+assert_present "linux: indexeddb kept"                 "$D/indexeddb"
+assert_present "linux: cookies kept"                   "$D/cookies.sqlite"
+assert_present "linux: ~/.config/$BID kept"            "$H/.config/$BID"
+assert_present "linux: unrelated app cache kept"       "$H/.cache/other.app"
 
-# ── 3. Linux: XDG_CACHE_HOME override honored ──
+# ── 3. Linux: XDG_CACHE_HOME / XDG_DATA_HOME overrides honored ──
 H=$(mktemp -d -p "$_TMP_ROOT")
 XDG=$(mktemp -d -p "$_TMP_ROOT")
-mkdir -p "$XDG/$BID" "$H/.cache/$BID"
-HOME="$H" XDG_CACHE_HOME="$XDG" _clear_webview_caches
-assert_gone    "linux: XDG_CACHE_HOME/$BID removed"        "$XDG/$BID"
-assert_present "linux: ~/.cache/$BID kept under override"  "$H/.cache/$BID"
+mkdir -p "$XDG/cache/$BID" "$XDG/data/$BID/WebKitCache" "$XDG/data/$BID/localstorage" "$H/.cache/$BID"
+HOME="$H" XDG_CACHE_HOME="$XDG/cache" XDG_DATA_HOME="$XDG/data" _clear_webview_caches
+assert_gone    "linux: XDG_CACHE_HOME/$BID removed"          "$XDG/cache/$BID"
+assert_gone    "linux: XDG_DATA_HOME WebKitCache removed"    "$XDG/data/$BID/WebKitCache"
+assert_present "linux: XDG_DATA_HOME localstorage kept"      "$XDG/data/$BID/localstorage"
+assert_present "linux: ~/.cache/$BID kept under override"    "$H/.cache/$BID"
 
 # ── 4. Nothing to clear is a clean no-op ──
 H=$(mktemp -d -p "$_TMP_ROOT")

--- a/tests/sh/test_setup_webview_cache_clear.sh
+++ b/tests/sh/test_setup_webview_cache_clear.sh
@@ -184,7 +184,7 @@ SETUP_PS1="$SCRIPT_DIR/../../studio/setup.ps1"
 if [ ! -f "$SETUP_PS1" ]; then
     echo "  FAIL: setup.ps1 not found"; FAIL=$((FAIL+1))
 else
-    _ps_call=$(grep -n '^Clear-WebViewCaches[[:space:]]*$' "$SETUP_PS1" | head -n1 | cut -d: -f1)
+    _ps_call=$(grep -n '^[[:space:]]*Clear-WebViewCaches[[:space:]]*$' "$SETUP_PS1" | head -n1 | cut -d: -f1)
     _ps_validate=$(grep -n 'does not exist"$' "$SETUP_PS1" | tail -n1 | cut -d: -f1)
     if [ -z "$_ps_call" ]; then
         echo "  FAIL: setup.ps1 never calls Clear-WebViewCaches"; FAIL=$((FAIL+1))
@@ -197,6 +197,28 @@ else
         FAIL=$((FAIL+1))
     fi
 fi
+
+# ── 7c. An override that EXISTS and is writable but holds no Studio install. Validating
+# the directory is not enough: setup aborts later at the venv check, and clearing first
+# would cost the cache for a run that then does nothing. ──
+_novenv_home=$(new_home)
+_novenv_root="$_TMP_ROOT/exists-but-empty.$$"
+mkdir -p "$_novenv_root"
+mkdir -p "$_novenv_home/.local/share/$BID/WebKitCache"
+: > "$_novenv_home/.local/share/$BID/WebKitCache/asset.js"
+_novenv_out=$(
+    cd "$(dirname "$SETUP_SH")" &&
+    env -u XDG_DATA_HOME -u STUDIO_HOME \
+        HOME="$_novenv_home" UNSLOTH_STUDIO_HOME="$_novenv_root" \
+        UNSLOTH_TAURI_MODE=0 bash "$SETUP_SH" 2>&1
+) && _novenv_rc=0 || _novenv_rc=$?
+if [ "$_novenv_rc" = 0 ]; then
+    echo "  FAIL: override without a venv did not abort"; FAIL=$((FAIL+1))
+else
+    echo "  PASS: override without a venv aborts (rc=$_novenv_rc)"; PASS=$((PASS+1))
+fi
+assert_present "existing-but-empty override leaves the cache alone" \
+    "$_novenv_home/.local/share/$BID/WebKitCache/asset.js"
 
 # ── 8. a bad override must not cost the user their cache ──
 # Every case above extracts the function, so none of them sees where the call sits.

--- a/tests/sh/test_setup_webview_cache_clear.sh
+++ b/tests/sh/test_setup_webview_cache_clear.sh
@@ -141,6 +141,33 @@ else
     echo "  FAIL: setup.sh never calls _clear_webview_caches"; FAIL=$((FAIL+1))
 fi
 
+# ── 8. a bad override must not cost the user their cache ──
+# Every case above extracts the function, so none of them sees the one thing
+# that is a property of the script rather than the function: where the call
+# sits. setup.sh runs under `set -euo pipefail` with no trap, so a clear placed
+# before the UNSLOTH_STUDIO_HOME validation turns a typo into cache loss plus
+# the same abort. Driven in situ, which is the only way to observe the ordering.
+_ord_home=$(new_home)
+mkdir -p "$_ord_home/.local/share/$BID/WebKitCache" "$_ord_home/.local/share/$BID/CacheStorage"
+: > "$_ord_home/.local/share/$BID/WebKitCache/asset.js"
+_ord_out=$(
+    cd "$(dirname "$SETUP_SH")" &&
+    env -u XDG_DATA_HOME -u STUDIO_HOME \
+        HOME="$_ord_home" UNSLOTH_STUDIO_HOME="$_ord_home/typo-not-a-real-dir" \
+        UNSLOTH_TAURI_MODE=0 bash "$SETUP_SH" 2>&1
+) && _ord_rc=0 || _ord_rc=$?
+if [ "$_ord_rc" = 0 ]; then
+    echo "  FAIL: bad override did not abort (rc=0)"; FAIL=$((FAIL+1))
+else
+    echo "  PASS: bad override still aborts (rc=$_ord_rc)"; PASS=$((PASS+1))
+fi
+case "$_ord_out" in
+    *"does not exist"*) echo "  PASS: abort names the bad override"; PASS=$((PASS+1)) ;;
+    *) echo "  FAIL: abort message missing: $_ord_out"; FAIL=$((FAIL+1)) ;;
+esac
+assert_present "bad override leaves the cache alone" \
+    "$_ord_home/.local/share/$BID/WebKitCache/asset.js"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" = 0 ]

--- a/tests/sh/test_setup_webview_cache_clear.sh
+++ b/tests/sh/test_setup_webview_cache_clear.sh
@@ -204,9 +204,8 @@ _novenv_root="$_TMP_ROOT/exists-but-empty.$$"
 mkdir -p "$_novenv_root"
 mkdir -p "$_novenv_home/.local/share/$BID/WebKitCache"
 : > "$_novenv_home/.local/share/$BID/WebKitCache/asset.js"
-# Between the clear and the venv check, setup.sh provisions Node and builds the
-# frontend. Report no system node/npm and opt out of the isolated install so
-# decide_node_source returns "skip": no download, no npm, no writes to dist/.
+# Stub node/npm as failing and opt out of the isolated install so setup.sh reaches the
+# venv check without provisioning Node or building the frontend.
 _novenv_bin="$_TMP_ROOT/no-node.$$"
 mkdir -p "$_novenv_bin"
 for _stub in node npm; do
@@ -225,7 +224,7 @@ if [ "$_novenv_rc" = 0 ]; then
 else
     echo "  PASS: override without a venv aborts (rc=$_novenv_rc)"; PASS=$((PASS+1))
 fi
-# The abort has to be the venv check, or the cache survived for an unrelated reason.
+# Or the cache survived for an unrelated reason.
 case "$_novenv_out" in
     *"venv not found at"*) echo "  PASS: the abort is the venv check"; PASS=$((PASS+1)) ;;
     *) echo "  FAIL: aborted before the venv check"; FAIL=$((FAIL+1)) ;;

--- a/tests/sh/test_setup_webview_cache_clear.sh
+++ b/tests/sh/test_setup_webview_cache_clear.sh
@@ -22,8 +22,10 @@ FAIL=0
 _TMP_ROOT=$(mktemp -d)
 trap 'rm -rf "$_TMP_ROOT"' EXIT
 
-assert_gone()    { _l="$1"; if [ -e "$2" ]; then echo "  FAIL: $_l (still present: $2)"; FAIL=$((FAIL+1)); else echo "  PASS: $_l"; PASS=$((PASS+1)); fi; }
-assert_present() { _l="$1"; if [ -e "$2" ]; then echo "  PASS: $_l"; PASS=$((PASS+1)); else echo "  FAIL: $_l (missing: $2)"; FAIL=$((FAIL+1)); fi; }
+# -e || -L, matching the production guard: -e alone is false for a dangling
+# symlink, so assert_gone would pass on one that was never removed.
+assert_gone()    { _l="$1"; if [ -e "$2" ] || [ -L "$2" ]; then echo "  FAIL: $_l (still present: $2)"; FAIL=$((FAIL+1)); else echo "  PASS: $_l"; PASS=$((PASS+1)); fi; }
+assert_present() { _l="$1"; if [ -e "$2" ] || [ -L "$2" ]; then echo "  PASS: $_l"; PASS=$((PASS+1)); else echo "  FAIL: $_l (missing: $2)"; FAIL=$((FAIL+1)); fi; }
 
 # Explicit template: -p is GNU-only (BSD got it in macOS 14) and a bare
 # mktemp -d implies -t, landing outside _TMP_ROOT on macOS.

--- a/tests/sh/test_setup_webview_cache_clear.sh
+++ b/tests/sh/test_setup_webview_cache_clear.sh
@@ -134,6 +134,44 @@ else
     echo "  FAIL: unset HOME -> rc=$_wvc_rc out=$_wvc_out"; FAIL=$((FAIL+1))
 fi
 
+# ── 6b. The clear must invalidate the app's version stamp. ──
+# The app skips its own clear whenever .webview-cache-cleared matches the running
+# version (main.rs). An update runs while the old WebView still holds these files, so
+# the rm here can fail and the app's clear is the retry. A repair or a local frontend
+# rebuild leaves the version unchanged, so a surviving stamp suppresses that retry and
+# the cache we could not remove stays forever.
+_st_home=$(new_home)
+_st_data="$_st_home/.local/share/$BID"
+mkdir -p "$_st_data/WebKitCache"
+: > "$_st_data/WebKitCache/asset.js"
+printf '2026.4.8' > "$_st_data/.webview-cache-cleared"
+uname() { echo Linux; }
+( HOME="$_st_home" _clear_webview_caches >/dev/null 2>&1 )
+assert_gone "linux: version stamp invalidated so the app retries" \
+    "$_st_data/.webview-cache-cleared"
+
+# The stamp must go even when nothing was removable, which is the case that matters:
+# an unremovable cache plus a surviving stamp is what makes the staleness permanent.
+_st_home=$(new_home)
+_st_data="$_st_home/.local/share/$BID"
+mkdir -p "$_st_data"
+printf '2026.4.8' > "$_st_data/.webview-cache-cleared"
+( HOME="$_st_home" _clear_webview_caches >/dev/null 2>&1 )
+assert_gone "linux: stamp dropped even with no cache dirs present" \
+    "$_st_data/.webview-cache-cleared"
+
+# macOS keeps the stamp under Application Support, not Caches, so the two paths differ.
+_st_home=$(new_home)
+mkdir -p "$_st_home/Library/Caches/$BID" "$_st_home/Library/Application Support/$BID"
+: > "$_st_home/Library/Caches/$BID/stale.js"
+printf '2026.4.8' > "$_st_home/Library/Application Support/$BID/.webview-cache-cleared"
+uname() { echo Darwin; }
+( HOME="$_st_home" _clear_webview_caches >/dev/null 2>&1 )
+assert_gone "macos: stamp under Application Support invalidated" \
+    "$_st_home/Library/Application Support/$BID/.webview-cache-cleared"
+assert_gone "macos: Caches/<bid> still cleared" "$_st_home/Library/Caches/$BID/stale.js"
+unset -f uname
+
 # ── 7. setup.sh still calls it (the sed extract above cannot prove that) ──
 if grep -qE '^[[:space:]]*_clear_webview_caches[[:space:]]*$' "$SETUP_SH"; then
     echo "  PASS: setup.sh invokes _clear_webview_caches"; PASS=$((PASS+1))

--- a/tests/sh/test_setup_webview_cache_clear.sh
+++ b/tests/sh/test_setup_webview_cache_clear.sh
@@ -85,6 +85,17 @@ assert_gone    "linux: XDG_DATA_HOME WebKitCache removed"    "$XDG/data/$BID/Web
 assert_present "linux: XDG_DATA_HOME localstorage kept"      "$XDG/data/$BID/localstorage"
 assert_present "linux: default data dir kept under override" "$H/.local/share/$BID/WebKitCache"
 
+# ── 3a. A relative XDG_DATA_HOME is invalid per the XDG spec, so dirs (and so
+# Tauri) ignores it. Following it would rm -rf under the installer's own cwd and
+# leave the cache Tauri actually uses in place ──
+H=$(new_home)
+W=$(mktemp -d "$_TMP_ROOT/work.XXXXXX")
+mkdir -p "$W/reldata/$BID/WebKitCache" "$H/.local/share/$BID/WebKitCache"
+uname() { echo Linux; }
+( cd "$W" && HOME="$H" XDG_CACHE_HOME="" XDG_DATA_HOME="reldata" _clear_webview_caches )
+assert_present "linux: relative XDG_DATA_HOME not followed under cwd" "$W/reldata/$BID/WebKitCache"
+assert_gone    "linux: relative XDG_DATA_HOME uses the default"       "$H/.local/share/$BID/WebKitCache"
+
 # ── 3b. A dangling cache symlink still occupies the path, so it must go ──
 H=$(new_home)
 mkdir -p "$H/.local/share/$BID"
@@ -108,12 +119,17 @@ uname() { echo SunOS; }
 HOME="$H" _clear_webview_caches
 assert_present "unknown OS: nothing removed" "$H/Library/Caches/$BID"
 
-# ── 6. No HOME is a no-op, not a delete under /Library or /.cache ──
+# ── 6. No HOME is a no-op, not a delete under /Library or /.cache. Unset, not
+# empty: `set -u` fires on unset only, and the empty case alone passes even with
+# the guard deleted, since the paths just miss. ──
 uname() { echo Darwin; }
-if ( set -u; HOME="" _clear_webview_caches ); then
-    echo "  PASS: empty HOME -> no-op exit 0"; PASS=$((PASS+1))
+_wvc_rc=0
+# `|| _wvc_rc=$?` keeps the abort we are testing for off `set -e`'s exit path.
+_wvc_out=$( set -u; unset HOME; _clear_webview_caches 2>&1 ) || _wvc_rc=$?
+if [ "$_wvc_rc" = 0 ] && [ -z "$_wvc_out" ]; then
+    echo "  PASS: unset HOME -> silent no-op"; PASS=$((PASS+1))
 else
-    echo "  FAIL: empty HOME -> nonzero exit"; FAIL=$((FAIL+1))
+    echo "  FAIL: unset HOME -> rc=$_wvc_rc out=$_wvc_out"; FAIL=$((FAIL+1))
 fi
 
 # ── 7. setup.sh still calls it (the sed extract above cannot prove that) ──

--- a/tests/sh/test_setup_webview_cache_clear.sh
+++ b/tests/sh/test_setup_webview_cache_clear.sh
@@ -177,6 +177,27 @@ else
     echo "  FAIL: setup.sh never calls _clear_webview_caches"; FAIL=$((FAIL+1))
 fi
 
+# ── 7b. setup.ps1 must have the same ordering. It is not driven here, so this is a
+# source-order assertion: the call has to come after the override validation, or a
+# mistyped UNSLOTH_STUDIO_HOME on Windows wipes the cache and then aborts. ──
+SETUP_PS1="$SCRIPT_DIR/../../studio/setup.ps1"
+if [ ! -f "$SETUP_PS1" ]; then
+    echo "  FAIL: setup.ps1 not found"; FAIL=$((FAIL+1))
+else
+    _ps_call=$(grep -n '^Clear-WebViewCaches[[:space:]]*$' "$SETUP_PS1" | head -n1 | cut -d: -f1)
+    _ps_validate=$(grep -n 'does not exist"$' "$SETUP_PS1" | tail -n1 | cut -d: -f1)
+    if [ -z "$_ps_call" ]; then
+        echo "  FAIL: setup.ps1 never calls Clear-WebViewCaches"; FAIL=$((FAIL+1))
+    elif [ -z "$_ps_validate" ]; then
+        echo "  FAIL: could not find the setup.ps1 override validation"; FAIL=$((FAIL+1))
+    elif [ "$_ps_call" -gt "$_ps_validate" ]; then
+        echo "  PASS: setup.ps1 clears after validating the override"; PASS=$((PASS+1))
+    else
+        echo "  FAIL: setup.ps1 clears at line $_ps_call, before validation at $_ps_validate"
+        FAIL=$((FAIL+1))
+    fi
+fi
+
 # ── 8. a bad override must not cost the user their cache ──
 # Every case above extracts the function, so none of them sees where the call sits.
 # setup.sh runs under `set -euo pipefail` with no trap, so a clear placed before the

--- a/tests/sh/test_setup_webview_cache_clear.sh
+++ b/tests/sh/test_setup_webview_cache_clear.sh
@@ -25,8 +25,8 @@ trap 'rm -rf "$_TMP_ROOT"' EXIT
 assert_gone()    { _l="$1"; if [ -e "$2" ]; then echo "  FAIL: $_l (still present: $2)"; FAIL=$((FAIL+1)); else echo "  PASS: $_l"; PASS=$((PASS+1)); fi; }
 assert_present() { _l="$1"; if [ -e "$2" ]; then echo "  PASS: $_l"; PASS=$((PASS+1)); else echo "  FAIL: $_l (missing: $2)"; FAIL=$((FAIL+1)); fi; }
 
-# Explicit mktemp templates: -p is GNU-only (BSD mktemp gained it in macOS 14),
-# and a bare mktemp -d implies -t and would land outside _TMP_ROOT on macOS.
+# Explicit template: -p is GNU-only (BSD got it in macOS 14) and a bare
+# mktemp -d implies -t, landing outside _TMP_ROOT on macOS.
 new_home() { mktemp -d "$_TMP_ROOT/home.XXXXXX"; }
 
 # Extract just the function definition (top-level, closes at column 0).
@@ -36,8 +36,8 @@ sed -n '/^_clear_webview_caches() {/,/^}/p' "$SETUP_SH" > "$FUNC_FILE"
 . "$FUNC_FILE"
 substep() { :; }  # stub the setup.sh logger
 
-# ── 1. macOS: the real WKWebView layout. Every cache-typed store hangs off
-# Library/Caches/<bid>/WebKit; Library/WebKit/<bid> holds only user storage. ──
+# ── 1. macOS: cache-typed stores hang off Library/Caches/<bid>/WebKit;
+# Library/WebKit/<bid> is user storage only ──
 H=$(new_home)
 mkdir -p "$H/Library/Caches/$BID/WebKit/NetworkCache/Version 17" \
          "$H/Library/Caches/$BID/WebKit/CacheStorage" \
@@ -56,8 +56,8 @@ assert_present "macOS: IndexedDB kept"                   "$H/Library/WebKit/$BID
 assert_present "macOS: Application Support kept"         "$H/Library/Application Support/$BID"
 assert_present "macOS: unrelated app cache kept"         "$H/Library/Caches/com.other.app"
 
-# ── 2. Linux: wry points WebKitGTK's base-cache dir at the app data dir, so
-# the caches sit beside the user storage under ~/.local/share/<bid>. ──
+# ── 2. Linux: wry points the base-cache dir at the app data dir, so caches
+# sit beside user storage under ~/.local/share/<bid> ──
 H=$(new_home)
 D="$H/.local/share/$BID"
 mkdir -p "$D/WebKitCache" "$D/CacheStorage" "$D/serviceworkers" \
@@ -116,7 +116,7 @@ else
     echo "  FAIL: empty HOME -> nonzero exit"; FAIL=$((FAIL+1))
 fi
 
-# ── 7. setup.sh still calls the function (the extract above cannot prove it) ──
+# ── 7. setup.sh still calls it (the sed extract above cannot prove that) ──
 if grep -qE '^[[:space:]]*_clear_webview_caches[[:space:]]*$' "$SETUP_SH"; then
     echo "  PASS: setup.sh invokes _clear_webview_caches"; PASS=$((PASS+1))
 else

--- a/tests/sh/test_setup_webview_cache_clear.sh
+++ b/tests/sh/test_setup_webview_cache_clear.sh
@@ -25,19 +25,24 @@ trap 'rm -rf "$_TMP_ROOT"' EXIT
 assert_gone()    { _l="$1"; if [ -e "$2" ]; then echo "  FAIL: $_l (still present: $2)"; FAIL=$((FAIL+1)); else echo "  PASS: $_l"; PASS=$((PASS+1)); fi; }
 assert_present() { _l="$1"; if [ -e "$2" ]; then echo "  PASS: $_l"; PASS=$((PASS+1)); else echo "  FAIL: $_l (missing: $2)"; FAIL=$((FAIL+1)); fi; }
 
+# Explicit mktemp templates: -p is GNU-only (BSD mktemp gained it in macOS 14),
+# and a bare mktemp -d implies -t and would land outside _TMP_ROOT on macOS.
+new_home() { mktemp -d "$_TMP_ROOT/home.XXXXXX"; }
+
 # Extract just the function definition (top-level, closes at column 0).
-FUNC_FILE=$(mktemp -p "$_TMP_ROOT")
+FUNC_FILE=$(mktemp "$_TMP_ROOT/fn.XXXXXX")
 sed -n '/^_clear_webview_caches() {/,/^}/p' "$SETUP_SH" > "$FUNC_FILE"
 # shellcheck disable=SC1090
 . "$FUNC_FILE"
 substep() { :; }  # stub the setup.sh logger
 
-# ── 1. macOS: cache paths removed, user-facing storage kept ──
-H=$(mktemp -d -p "$_TMP_ROOT")
-mkdir -p "$H/Library/Caches/$BID/WebKit/NetworkCache" \
-         "$H/Library/WebKit/$BID/WebsiteData/CacheStorage" \
-         "$H/Library/WebKit/$BID/WebsiteData/ServiceWorkers" \
-         "$H/Library/WebKit/$BID/WebsiteData/DiskCache" \
+# ── 1. macOS: the real WKWebView layout. Every cache-typed store hangs off
+# Library/Caches/<bid>/WebKit; Library/WebKit/<bid> holds only user storage. ──
+H=$(new_home)
+mkdir -p "$H/Library/Caches/$BID/WebKit/NetworkCache/Version 17" \
+         "$H/Library/Caches/$BID/WebKit/CacheStorage" \
+         "$H/Library/Caches/$BID/WebKit/ServiceWorkers" \
+         "$H/Library/WebKit/$BID/WebsiteData/Default" \
          "$H/Library/WebKit/$BID/WebsiteData/LocalStorage" \
          "$H/Library/WebKit/$BID/WebsiteData/IndexedDB" \
          "$H/Library/Application Support/$BID" \
@@ -45,45 +50,50 @@ mkdir -p "$H/Library/Caches/$BID/WebKit/NetworkCache" \
 uname() { echo Darwin; }
 HOME="$H" _clear_webview_caches
 assert_gone    "macOS: Caches/$BID removed"              "$H/Library/Caches/$BID"
-assert_gone    "macOS: WebsiteData/CacheStorage removed" "$H/Library/WebKit/$BID/WebsiteData/CacheStorage"
-assert_gone    "macOS: WebsiteData/ServiceWorkers removed" "$H/Library/WebKit/$BID/WebsiteData/ServiceWorkers"
-assert_gone    "macOS: WebsiteData/DiskCache removed"    "$H/Library/WebKit/$BID/WebsiteData/DiskCache"
+assert_present "macOS: origin-keyed storage kept"        "$H/Library/WebKit/$BID/WebsiteData/Default"
 assert_present "macOS: LocalStorage kept"                "$H/Library/WebKit/$BID/WebsiteData/LocalStorage"
 assert_present "macOS: IndexedDB kept"                   "$H/Library/WebKit/$BID/WebsiteData/IndexedDB"
 assert_present "macOS: Application Support kept"         "$H/Library/Application Support/$BID"
 assert_present "macOS: unrelated app cache kept"         "$H/Library/Caches/com.other.app"
 
-# ── 2. Linux: cache paths removed (XDG cache dir AND the cache subdirs wry
-# keys to the app data dir), user-facing storage kept ──
-H=$(mktemp -d -p "$_TMP_ROOT")
+# ── 2. Linux: wry points WebKitGTK's base-cache dir at the app data dir, so
+# the caches sit beside the user storage under ~/.local/share/<bid>. ──
+H=$(new_home)
 D="$H/.local/share/$BID"
-mkdir -p "$H/.cache/$BID" "$D/WebKitCache" "$D/CacheStorage" "$D/serviceworkers" \
-         "$D/localstorage" "$D/indexeddb" "$H/.config/$BID" "$H/.cache/other.app"
-: > "$D/cookies.sqlite"
+mkdir -p "$D/WebKitCache" "$D/CacheStorage" "$D/serviceworkers" \
+         "$D/localstorage" "$D/databases/indexeddb" "$H/.config/$BID" \
+         "$H/.local/share/${BID}2/WebKitCache" "$H/.cache/other.app"
+: > "$D/cookies"
 uname() { echo Linux; }
 HOME="$H" XDG_CACHE_HOME="" XDG_DATA_HOME="" _clear_webview_caches
-assert_gone    "linux: ~/.cache/$BID removed"          "$H/.cache/$BID"
 assert_gone    "linux: data-dir WebKitCache removed"   "$D/WebKitCache"
 assert_gone    "linux: data-dir CacheStorage removed"  "$D/CacheStorage"
 assert_gone    "linux: data-dir serviceworkers removed" "$D/serviceworkers"
 assert_present "linux: localstorage kept"              "$D/localstorage"
-assert_present "linux: indexeddb kept"                 "$D/indexeddb"
-assert_present "linux: cookies kept"                   "$D/cookies.sqlite"
+assert_present "linux: indexeddb kept"                 "$D/databases/indexeddb"
+assert_present "linux: cookies kept"                   "$D/cookies"
 assert_present "linux: ~/.config/$BID kept"            "$H/.config/$BID"
+assert_present "linux: prefix-decoy bundle id kept"    "$H/.local/share/${BID}2/WebKitCache"
 assert_present "linux: unrelated app cache kept"       "$H/.cache/other.app"
 
-# ── 3. Linux: XDG_CACHE_HOME / XDG_DATA_HOME overrides honored ──
-H=$(mktemp -d -p "$_TMP_ROOT")
-XDG=$(mktemp -d -p "$_TMP_ROOT")
-mkdir -p "$XDG/cache/$BID" "$XDG/data/$BID/WebKitCache" "$XDG/data/$BID/localstorage" "$H/.cache/$BID"
-HOME="$H" XDG_CACHE_HOME="$XDG/cache" XDG_DATA_HOME="$XDG/data" _clear_webview_caches
-assert_gone    "linux: XDG_CACHE_HOME/$BID removed"          "$XDG/cache/$BID"
+# ── 3. Linux: XDG_DATA_HOME override honored ──
+H=$(new_home)
+XDG=$(mktemp -d "$_TMP_ROOT/xdg.XXXXXX")
+mkdir -p "$XDG/data/$BID/WebKitCache" "$XDG/data/$BID/localstorage" "$H/.local/share/$BID/WebKitCache"
+HOME="$H" XDG_CACHE_HOME="" XDG_DATA_HOME="$XDG/data" _clear_webview_caches
 assert_gone    "linux: XDG_DATA_HOME WebKitCache removed"    "$XDG/data/$BID/WebKitCache"
 assert_present "linux: XDG_DATA_HOME localstorage kept"      "$XDG/data/$BID/localstorage"
-assert_present "linux: ~/.cache/$BID kept under override"    "$H/.cache/$BID"
+assert_present "linux: default data dir kept under override" "$H/.local/share/$BID/WebKitCache"
+
+# ── 3b. A dangling cache symlink still occupies the path, so it must go ──
+H=$(new_home)
+mkdir -p "$H/.local/share/$BID"
+ln -s "$_TMP_ROOT/does-not-exist" "$H/.local/share/$BID/WebKitCache"
+HOME="$H" XDG_CACHE_HOME="" XDG_DATA_HOME="" _clear_webview_caches
+assert_gone    "linux: dangling cache symlink removed"       "$H/.local/share/$BID/WebKitCache"
 
 # ── 4. Nothing to clear is a clean no-op ──
-H=$(mktemp -d -p "$_TMP_ROOT")
+H=$(new_home)
 uname() { echo Darwin; }
 if HOME="$H" _clear_webview_caches; then
     echo "  PASS: empty HOME -> no-op exit 0"; PASS=$((PASS+1))
@@ -92,11 +102,26 @@ else
 fi
 
 # ── 5. Unknown OS is a no-op ──
-H=$(mktemp -d -p "$_TMP_ROOT")
+H=$(new_home)
 mkdir -p "$H/Library/Caches/$BID"
 uname() { echo SunOS; }
 HOME="$H" _clear_webview_caches
 assert_present "unknown OS: nothing removed" "$H/Library/Caches/$BID"
+
+# ── 6. No HOME is a no-op, not a delete under /Library or /.cache ──
+uname() { echo Darwin; }
+if ( set -u; HOME="" _clear_webview_caches ); then
+    echo "  PASS: empty HOME -> no-op exit 0"; PASS=$((PASS+1))
+else
+    echo "  FAIL: empty HOME -> nonzero exit"; FAIL=$((FAIL+1))
+fi
+
+# ── 7. setup.sh still calls the function (the extract above cannot prove it) ──
+if grep -qE '^[[:space:]]*_clear_webview_caches[[:space:]]*$' "$SETUP_SH"; then
+    echo "  PASS: setup.sh invokes _clear_webview_caches"; PASS=$((PASS+1))
+else
+    echo "  FAIL: setup.sh never calls _clear_webview_caches"; FAIL=$((FAIL+1))
+fi
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/sh/test_setup_webview_cache_clear.sh
+++ b/tests/sh/test_setup_webview_cache_clear.sh
@@ -177,9 +177,8 @@ else
     echo "  FAIL: setup.sh never calls _clear_webview_caches"; FAIL=$((FAIL+1))
 fi
 
-# ── 7b. setup.ps1 must have the same ordering. It is not driven here, so this is a
-# source-order assertion: the call has to come after the override validation, or a
-# mistyped UNSLOTH_STUDIO_HOME on Windows wipes the cache and then aborts. ──
+# ── 7b. setup.ps1 is not driven here, so assert on source order: the call must come
+# after the override validation, or a mistyped override wipes the cache and then aborts ──
 SETUP_PS1="$SCRIPT_DIR/../../studio/setup.ps1"
 if [ ! -f "$SETUP_PS1" ]; then
     echo "  FAIL: setup.ps1 not found"; FAIL=$((FAIL+1))
@@ -198,9 +197,8 @@ else
     fi
 fi
 
-# ── 7c. An override that EXISTS and is writable but holds no Studio install. Validating
-# the directory is not enough: setup aborts later at the venv check, and clearing first
-# would cost the cache for a run that then does nothing. ──
+# ── 7c. An override that exists and is writable but holds no Studio install: setup
+# aborts later at the venv check, so clearing first would cost the cache for nothing ──
 _novenv_home=$(new_home)
 _novenv_root="$_TMP_ROOT/exists-but-empty.$$"
 mkdir -p "$_novenv_root"
@@ -221,10 +219,9 @@ assert_present "existing-but-empty override leaves the cache alone" \
     "$_novenv_home/.local/share/$BID/WebKitCache/asset.js"
 
 # ── 8. a bad override must not cost the user their cache ──
-# Every case above extracts the function, so none of them sees where the call sits.
-# setup.sh runs under `set -euo pipefail` with no trap, so a clear placed before the
-# UNSLOTH_STUDIO_HOME validation turns a typo into cache loss plus the same abort.
-# Driven in situ, the only way to observe the ordering.
+# The cases above extract the function, so none sees where the call sits; driven in situ.
+# Under `set -euo pipefail` with no trap, clearing before the UNSLOTH_STUDIO_HOME
+# validation turns a typo into cache loss plus the same abort.
 _ord_home=$(new_home)
 mkdir -p "$_ord_home/.local/share/$BID/WebKitCache" "$_ord_home/.local/share/$BID/CacheStorage"
 : > "$_ord_home/.local/share/$BID/WebKitCache/asset.js"

--- a/tests/sh/test_setup_webview_cache_clear.sh
+++ b/tests/sh/test_setup_webview_cache_clear.sh
@@ -3,10 +3,10 @@
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 # Unit tests for _clear_webview_caches() from studio/setup.sh.
 #
-# The WebView caches keyed by the app bundle id (ai.unsloth.studio) hold copies
-# of the previous frontend, so an install/update must clear them or the app can
-# keep rendering old styles. Clearing must be cache-only: LocalStorage,
-# IndexedDB, app data, and unrelated apps' caches stay intact.
+# WebView caches keyed by the bundle id (ai.unsloth.studio) hold copies of the
+# previous frontend, so an install/update must clear them or the app keeps
+# rendering old styles. Cache-only: LocalStorage, IndexedDB, app data and
+# unrelated apps' caches stay intact.
 #
 # Follows the extract-via-sed pattern of test_uninstall_shared_icon.sh; uname
 # is overridden per test with a shell function to select the OS branch.
@@ -87,9 +87,9 @@ assert_gone    "linux: XDG_DATA_HOME WebKitCache removed"    "$XDG/data/$BID/Web
 assert_present "linux: XDG_DATA_HOME localstorage kept"      "$XDG/data/$BID/localstorage"
 assert_present "linux: default data dir kept under override" "$H/.local/share/$BID/WebKitCache"
 
-# ── 3a. A relative XDG_DATA_HOME is invalid per the XDG spec, so dirs (and so
-# Tauri) ignores it. Following it would rm -rf under the installer's own cwd and
-# leave the cache Tauri actually uses in place ──
+# ── 3a. A relative XDG_DATA_HOME is invalid per the XDG spec, so dirs (and Tauri)
+# ignores it. Following it would rm -rf under the installer's cwd and leave the
+# cache Tauri actually uses in place ──
 H=$(new_home)
 W=$(mktemp -d "$_TMP_ROOT/work.XXXXXX")
 mkdir -p "$W/reldata/$BID/WebKitCache" "$H/.local/share/$BID/WebKitCache"
@@ -121,9 +121,8 @@ uname() { echo SunOS; }
 HOME="$H" _clear_webview_caches
 assert_present "unknown OS: nothing removed" "$H/Library/Caches/$BID"
 
-# ── 6. No HOME is a no-op, not a delete under /Library or /.cache. Unset, not
-# empty: `set -u` fires on unset only, and the empty case alone passes even with
-# the guard deleted, since the paths just miss. ──
+# ── 6. No HOME is a no-op, not a delete under /Library or /.cache. Unset, not empty:
+# `set -u` fires on unset only, and the empty case passes even without the guard ──
 uname() { echo Darwin; }
 _wvc_rc=0
 # `|| _wvc_rc=$?` keeps the abort we are testing for off `set -e`'s exit path.
@@ -136,10 +135,9 @@ fi
 
 # ── 6b. The clear must invalidate the app's version stamp. ──
 # The app skips its own clear whenever .webview-cache-cleared matches the running
-# version (main.rs). An update runs while the old WebView still holds these files, so
-# the rm here can fail and the app's clear is the retry. A repair or a local frontend
-# rebuild leaves the version unchanged, so a surviving stamp suppresses that retry and
-# the cache we could not remove stays forever.
+# version (main.rs), and that clear is the retry for an rm here that failed. A repair
+# or a local rebuild leaves the version unchanged, so a surviving stamp suppresses the
+# retry and the cache we could not remove stays forever.
 _st_home=$(new_home)
 _st_data="$_st_home/.local/share/$BID"
 mkdir -p "$_st_data/WebKitCache"
@@ -180,11 +178,10 @@ else
 fi
 
 # ── 8. a bad override must not cost the user their cache ──
-# Every case above extracts the function, so none of them sees the one thing
-# that is a property of the script rather than the function: where the call
-# sits. setup.sh runs under `set -euo pipefail` with no trap, so a clear placed
-# before the UNSLOTH_STUDIO_HOME validation turns a typo into cache loss plus
-# the same abort. Driven in situ, which is the only way to observe the ordering.
+# Every case above extracts the function, so none of them sees where the call sits.
+# setup.sh runs under `set -euo pipefail` with no trap, so a clear placed before the
+# UNSLOTH_STUDIO_HOME validation turns a typo into cache loss plus the same abort.
+# Driven in situ, the only way to observe the ordering.
 _ord_home=$(new_home)
 mkdir -p "$_ord_home/.local/share/$BID/WebKitCache" "$_ord_home/.local/share/$BID/CacheStorage"
 : > "$_ord_home/.local/share/$BID/WebKitCache/asset.js"

--- a/tests/sh/test_setup_webview_cache_clear.sh
+++ b/tests/sh/test_setup_webview_cache_clear.sh
@@ -204,10 +204,20 @@ _novenv_root="$_TMP_ROOT/exists-but-empty.$$"
 mkdir -p "$_novenv_root"
 mkdir -p "$_novenv_home/.local/share/$BID/WebKitCache"
 : > "$_novenv_home/.local/share/$BID/WebKitCache/asset.js"
+# Between the clear and the venv check, setup.sh provisions Node and builds the
+# frontend. Report no system node/npm and opt out of the isolated install so
+# decide_node_source returns "skip": no download, no npm, no writes to dist/.
+_novenv_bin="$_TMP_ROOT/no-node.$$"
+mkdir -p "$_novenv_bin"
+for _stub in node npm; do
+    printf '#!/bin/sh\nexit 1\n' > "$_novenv_bin/$_stub"
+    chmod +x "$_novenv_bin/$_stub"
+done
 _novenv_out=$(
     cd "$(dirname "$SETUP_SH")" &&
     env -u XDG_DATA_HOME -u STUDIO_HOME \
         HOME="$_novenv_home" UNSLOTH_STUDIO_HOME="$_novenv_root" \
+        PATH="$_novenv_bin:$PATH" UNSLOTH_SKIP_NODE_INSTALL=1 SKIP_STUDIO_FRONTEND=1 \
         UNSLOTH_TAURI_MODE=0 bash "$SETUP_SH" 2>&1
 ) && _novenv_rc=0 || _novenv_rc=$?
 if [ "$_novenv_rc" = 0 ]; then
@@ -215,6 +225,15 @@ if [ "$_novenv_rc" = 0 ]; then
 else
     echo "  PASS: override without a venv aborts (rc=$_novenv_rc)"; PASS=$((PASS+1))
 fi
+# The abort has to be the venv check, or the cache survived for an unrelated reason.
+case "$_novenv_out" in
+    *"venv not found at"*) echo "  PASS: the abort is the venv check"; PASS=$((PASS+1)) ;;
+    *) echo "  FAIL: aborted before the venv check"; FAIL=$((FAIL+1)) ;;
+esac
+case "$_novenv_out" in
+    *"no suitable Node"*) echo "  PASS: reached it without provisioning Node"; PASS=$((PASS+1)) ;;
+    *) echo "  FAIL: the fixture is not hermetic (Node/npm ran)"; FAIL=$((FAIL+1)) ;;
+esac
 assert_present "existing-but-empty override leaves the cache alone" \
     "$_novenv_home/.local/share/$BID/WebKitCache/asset.js"
 


### PR DESCRIPTION
## Problem

Follow-up to #7360. That PR makes a full uninstall remove the WebView runtime data. This PR covers the normal install/update path: the desktop app's WebView caches, keyed by the Tauri bundle id `ai.unsloth.studio`, hold copies of the previous frontend and can keep serving them after an update.

## Fix

Fresh installs (`install.sh` / `install.ps1`) and `unsloth studio update` both route through `studio/setup.sh` / `studio/setup.ps1`, so the clear lives there and runs on every install and update. An in-app update runs those scripts while the old WebView still holds the files, so the clear silently fails; `studio/src-tauri/src/main.rs` therefore repeats it in the relaunched process, before the WebView exists.

Only cache paths are cleared. LocalStorage, IndexedDB, cookies, customized settings, downloaded models and the studio database all survive.

### Paths

- macOS: `~/Library/Caches/ai.unsloth.studio`. WKWebView keeps every cache-typed store under that root as `WebKit/{NetworkCache,CacheStorage,ServiceWorkers}`, and `~/Library/WebKit/<bundle id>` is user storage, so it is left alone.
- Linux: `WebKitCache`, `CacheStorage` and `serviceworkers` under `${XDG_DATA_HOME:-~/.local/share}/ai.unsloth.studio`. Tauri points the WebView at `LocalData/<bundle id>` and wry keys the WebKitGTK base-cache dir to that same dir, so the caches sit beside the user storage rather than under `~/.cache`.
- Windows: `%LOCALAPPDATA%\ai.unsloth.studio\EBWebView\Default\{Cache, Code Cache, GPUCache, Service Worker}`. Local Storage, IndexedDB, Session Storage, cookies and Preferences are kept.

### The native clear is version-gated

`clear_webview_caches` runs before `tauri::Builder`, which means before `tauri_plugin_single_instance`. Ungated, that had two problems: a duplicate launch deleted the running instance's live profile before losing the single-instance race, and every ordinary launch became a cold-cache launch, discarding the Windows compiled-JS cache under `Code Cache` for nothing.

It now takes the app version and writes a `.webview-cache-cleared` stamp in the profile root, skipping when the stamp already matches. The first launch after an update clears and stamps; every launch after that is a no-op, including a duplicate launch racing a live instance.

Removal errors are logged rather than discarded. `NotFound` is the normal case and stays quiet; anything else prints the path and the OS error, since a silent failure here is what the stale frontend looked like from the outside.

### Robustness

- `studio/setup.sh` returns early when `HOME` is unset, so `set -u` cannot abort the install and an empty value cannot expand to `/Library/Caches` or `/.cache`. It also tests `-e || -L`, since a dangling symlink still occupies the path.
- `studio/setup.ps1` uses `Get-Item -Force` plus an explicit reparse-point branch instead of `Test-Path` plus `Remove-Item -Recurse -Force`. `Test-Path` throws rather than returning false when an ACL denies the probe and the script runs under `Stop`, and `Remove-Item -Recurse -Force` can traverse a junction on PowerShell 5.1. This matches the shape the same file already uses for the llama.cpp directory.

Browsers pointed at `http://localhost` are unaffected: the frontend build emits content-hashed asset filenames, so ordinary browser caches self-invalidate. The embedded WebView was the case with no hard-refresh escape hatch.

## Tests

New `tests/sh/test_setup_webview_cache_clear.sh` covers both OS branches against the real on-disk layouts, `XDG_DATA_HOME` overrides, a dangling cache symlink, a prefix-decoy bundle id, unknown OS, unset `HOME`, and that `setup.sh` still calls the function (the sed extract the test uses cannot prove that on its own).

```
Results: 23 passed, 0 failed
```

Fixtures use explicit `mktemp` templates rather than `mktemp -p`, which is GNU-only and aborts the whole test on macOS 13 and earlier.

`clear_webview_caches` was also lifted into a standalone crate and checked for `x86_64-unknown-linux-gnu`, `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`, so all three cfg arms compile, with 6 behavioural tests including the version gate: first run clears and stamps, a second run at the same version is a no-op, a new version clears again.

No `tests/run_all.sh` change is needed: main discovers `tests/sh/test_*.sh` and runs each with bash.

Whole shell suite passes (41 files). `cargo check --locked` clean, `shellcheck -e SC1090,SC2034` and `bash -n` clean, and `setup.ps1` parses clean through the PowerShell AST parser.
