### PR TITLE
Security audit: refresh scan baselines for current dependency set

### DIFF
--- a/scripts/scan_packages_baseline.json
+++ b/scripts/scan_packages_baseline.json
@@ -1561,6 +1561,62 @@
       "severity": "CRITICAL",
       "evidence": "L111:         out = extract_audio_info(msgs({\"type\": \"audio\", key: \"/tmp/a.wav\"})) sha256:2efe23ffbe2b91b8403aec9b700736919b59e5ca770f8e1f5501651b44b7d398",
       "evidence_hash": "d416b79dd17b24214f3f7653ac01354507d7bf0fc464dee30a4a4b8998f063ba"
+    },
+    {
+      "package": "openai",
+      "file": "openai/_base_client.py",
+      "check": "C2 polling/beaconing loop detected",
+      "severity": "CRITICAL",
+      "evidence": "L274:         while True: sha256:90a38e5c1e26893c7c273354143612640e9a9c0f079d3e2b60612d79f24e80a6",
+      "evidence_hash": "1022e8e8649436ec64a98a9d9141d085452c49549fd2157b0278fc369a83ac66"
+    },
+    {
+      "package": "openai",
+      "file": "openai/auth/_workload.py",
+      "check": "Accesses cloud metadata/IMDS AND makes network calls",
+      "severity": "CRITICAL",
+      "evidence": "IMDS: L97:             url = \"http://169.254.169.254/metadata/identity/oauth2/token\" | L150:             url = \"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity\"\nNetwork: L78:     http_client: httpx.Client | None = None, | L109:                 with httpx.Client() as client: | L134:     http_client: httpx.Client | None = None, | L156:                 with httpx.Client() as client: | L251:         exchange_client = DefaultHttpx2Client(follow_redirects=False) if self._use_httpx2 else httpx.Client()",
+      "evidence_hash": "9717e51cb961dc14c458955d91a1e48e3753997346ecea0106bded3a8d64bfe0"
+    },
+    {
+      "package": "openai",
+      "file": "openai/resources/beta/responses/responses.py",
+      "check": "C2 polling/beaconing loop detected",
+      "severity": "CRITICAL",
+      "evidence": "L4000:         while True: sha256:f8ab538118daba9ec06e27399dbdc90a4521c3390e6a47a6348a1f180a83effd",
+      "evidence_hash": "31481ea83c687acc27144d72d3832d4fb98dd1c79fb5e0ddd85080de95997b9f"
+    },
+    {
+      "package": "openai",
+      "file": "openai/resources/realtime/realtime.py",
+      "check": "C2 polling/beaconing loop detected",
+      "severity": "CRITICAL",
+      "evidence": "L311:         while True: sha256:5b63313072aae9ca28677e03426513ccf12221e4f4e0ea6c31efbe09790633b5",
+      "evidence_hash": "05e1af469d651b51673763a7c4cdf759af9472fb627b7b470adc28cc237bd650"
+    },
+    {
+      "package": "openai",
+      "file": "openai/resources/responses/responses.py",
+      "check": "C2 polling/beaconing loop detected",
+      "severity": "CRITICAL",
+      "evidence": "L3951:         while True: sha256:d68ef896bf0743ca430cfacb9a3353da1f3b9c51c3a21b6450a07a32b55aa2ac",
+      "evidence_hash": "160eecdd79b521bffbe8476f782b69a0724c35d1b19376a7600807165fd54f9f"
+    },
+    {
+      "package": "unsloth-zoo",
+      "file": "tests/test_gemma4_forced_float32_ple_dtype.py",
+      "check": "Advanced obfuscation (marshal/compile/zlib) + exec/eval",
+      "severity": "HIGH",
+      "evidence": "Obfusc: L277:     compile(rewritten + _GEMMA4_PLE_CAST_HELPER, \"<gemma4-ple-generated>\", \"exec\") | L440:     compile(on, \"<gemma4-ple-append>\", \"exec\") | L468:     compile(generated, \"<gemma4-ple-crosspath>\", \"exec\")\nExec: L19:     exec(_GEMMA4_PLE_CAST_HELPER, namespace)",
+      "evidence_hash": "a85e24d8e7c431563cbd83b70f91a3b971abde0f37083d68e70984147960cc70"
+    },
+    {
+      "package": "unsloth-zoo",
+      "file": "tests/test_vision_collator_audio.py",
+      "check": "Writes to /tmp and executes (staged dropper)",
+      "severity": "CRITICAL",
+      "evidence": "L111:         out = extract_audio_info(msgs({\"type\": \"audio\", key: \"/tmp/a.wav\"})) sha256:022f81dd21acfc6a35a058de96132834c218404a9e37b3d09a7768a8c8f6c728",
+      "evidence_hash": "2d1e75446af120d9133a42aa8af426a839d3434d9dc109cc1d6c1b22ca1ddb75"
     }
   ]
 }


### PR DESCRIPTION
## Why

The Security audit workflow is red on main and on every PR: the `pip scan-packages :: extras` shard exits 1 with 5 non-baselined CRITICAL findings (last completed run on main: 29982017685, only that shard failed). Root cause is baseline drift, not a real detection:

- openai 2.47.0 rewrote the code inside five previously baselined findings (the websocket event loops gained reconnect handling, the workload identity module changed), so their `evidence_hash` keys no longer match the committed allowlist and the findings reopened by design.
- The just-merged dictation stack pulled new deps (av, argbind, openai, randomname, omegaconf, ...) into the extras shard; all of their findings are MEDIUM and do not gate, but they account for most of the 186 lines of scanner noise in the log.
- While reproducing, the hf-stack shard turned out to be one dependency release away from the same failure: unsloth-zoo 2026.7.5 changed two baselined test files (1 CRITICAL, 1 HIGH reopened). Those are refreshed here too.

## What

Adds 7 provenance-verified entries to `scripts/scan_packages_baseline.json` (195 -> 202). No existing entry is removed or modified, so the currently green shards cannot regress. No blind `--write-baseline` regeneration: each entry was generated by scanning the exact resolved archive (openai 2.47.0 wheel, unsloth_zoo 2026.7.5 sdist) and the flagged file was opened and read at the flagged lines first.

## Verification of reopened findings

| Package | Version | File | Check | Verdict | Justification |
|---|---|---|---|---|---|
| openai | 2.47.0 | `openai/_base_client.py` | C2 polling loop | benign | `while True` is `SyncPage.iter_pages`, the pagination iterator |
| openai | 2.47.0 | `openai/auth/_workload.py` | IMDS + network | benign | Azure IMDS / GCP metadata token providers for the documented workload identity federation feature |
| openai | 2.47.0 | `openai/resources/beta/responses/responses.py` | C2 polling loop | benign | websocket `__aiter__` yield/recv loop; hash drifted because 2.47.0 added `_reconnect` handling |
| openai | 2.47.0 | `openai/resources/realtime/realtime.py` | C2 polling loop | benign | same websocket `__aiter__` pattern |
| openai | 2.47.0 | `openai/resources/responses/responses.py` | C2 polling loop | benign | same websocket `__aiter__` pattern |
| unsloth-zoo | 2026.7.5 | `tests/test_vision_collator_audio.py` | writes /tmp + executes | benign | test asserts an inline `/tmp/a.wav` path is passed through `extract_audio_info` |
| unsloth-zoo | 2026.7.5 | `tests/test_gemma4_forced_float32_ple_dtype.py` | obfuscation + exec | benign | tests `compile()`/`exec()` the project's own generated Gemma4 PLE cast helper source |

The remaining 181 extras findings are MEDIUM (non-gating). They were reviewed by package and are all textbook false positives on top-1000 PyPI code: build machinery and plugin `__import__` (setuptools, numba, sklearn/scipy `array_api_compat`), bytecode `marshal` caches (jinja2, setuptools), env config reads (click, huggingface-hub, triton knobs, omegaconf, argbind), `chr()` unicode fixtures in tests (networkx, regex), base64-embedded fonts/payloads with legitimate consumers (pillow ImageFont, pydantic Base64 types), and "bc1" wallet-prefix collisions with the BC1 DDS pixel format (pillow), spline boundary conditions (scipy), and theano broadcastables (sympy). Nothing suspicious was found: no typosquats, no obfuscated payloads, no unexpected network exfiltration.

## Local shard results (same requirement sets and Python 3.12 as CI)

- `pip scan-packages :: extras`: exit 0, 99 suppressed (was exit 1 with 5 active CRITICAL)
- `pip scan-packages :: hf-stack`: exit 0, 122 suppressed (was exit 1 with 1 CRITICAL + 1 HIGH after the unsloth-zoo 2026.7.5 release)
- `pip scan-packages :: studio`: exit 0, 151 suppressed

Local extras resolution matched the failing CI run exactly (124 archives, identical versions), and the five added openai evidence blocks are byte-identical to the CI log's active findings.
