### PR TITLE
Studio: viewport-gated highlight for the executed Python script (follow-up to #7240)

### DIFF
--- a/studio/frontend/src/components/assistant-ui/tool-ui-python.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-ui-python.tsx
@@ -167,9 +167,11 @@ function HighlightedCode({ code: source, language }: { code: string; language: s
         </Streamdown>
       ) : (
         // A div, not a <pre>: the container's [&_pre]:!p-0 would override a
-        // <pre>'s padding and shift the content by p-3 when shiki swaps in. This
-        // keeps the same p-3 the highlighted code block gets, so there is no jump.
-        <div className="whitespace-pre-wrap break-words p-3 font-mono text-xs text-muted-foreground">
+        // <pre>'s padding and shift the content by p-3 when shiki swaps in. Keep
+        // the same p-3, and whitespace-pre (not pre-wrap) so long lines scroll in
+        // the container's overflow-auto exactly like the highlighted <pre>, rather
+        // than wrapping taller and then collapsing when shiki swaps in.
+        <div className="whitespace-pre p-3 font-mono text-xs text-muted-foreground">
           {display}
         </div>
       )}

--- a/studio/frontend/src/components/assistant-ui/tool-ui-python.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-ui-python.tsx
@@ -118,22 +118,60 @@ function DownloadBtn({ code, name = "script.py" }: { code: string; name?: string
   );
 }
 
-/** Syntax-highlighted code via Streamdown + shiki; inherits parent container. */
+/** Syntax-highlighted code via Streamdown + shiki; inherits parent container.
+ * The script is always in the DOM (a plain monospace placeholder), but shiki
+ * only tokenizes once the block scrolls near the viewport, so a long transcript
+ * with many scripts doesn't highlight every one up front. Falls back to
+ * immediate highlight when IntersectionObserver is unavailable (SSR / tests). */
 function HighlightedCode({ code: source, language }: { code: string; language: string }) {
+  const display = useMemo(() => truncate(source), [source]);
   const markdown = useMemo(
-    () => `\`\`\`${language}\n${truncate(source)}\n\`\`\``,
-    [source, language],
+    () => `\`\`\`${language}\n${display}\n\`\`\``,
+    [display, language],
   );
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [highlight, setHighlight] = useState(
+    () => typeof IntersectionObserver === "undefined",
+  );
+  useEffect(() => {
+    if (highlight) return;
+    const el = containerRef.current;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setHighlight(true);
+          io.disconnect();
+        }
+      },
+      // Highlight just before the block enters view so it's colorized by the
+      // time the user reaches it, without tokenizing off-screen scripts.
+      { rootMargin: "200px" },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [highlight]);
   return (
-    <div className="max-h-48 overflow-auto text-xs [&_pre]:!m-0 [&_pre]:!bg-transparent [&_pre]:!p-0 [&_pre]:!text-xs [&_[data-streamdown=code-block]]:!my-0 [&_[data-streamdown=code-block]]:!p-3 [&_[data-streamdown=code-block]]:!border-0">
-      <Streamdown
-        mode="static"
-        plugins={{ code: codePlugin }}
-        controls={{ code: false }}
-        shikiTheme={SHIKI_THEME}
-      >
-        {markdown}
-      </Streamdown>
+    <div
+      ref={containerRef}
+      className="max-h-48 overflow-auto text-xs [&_pre]:!m-0 [&_pre]:!bg-transparent [&_pre]:!p-0 [&_pre]:!text-xs [&_[data-streamdown=code-block]]:!my-0 [&_[data-streamdown=code-block]]:!p-3 [&_[data-streamdown=code-block]]:!border-0"
+    >
+      {highlight ? (
+        <Streamdown
+          mode="static"
+          plugins={{ code: codePlugin }}
+          controls={{ code: false }}
+          shikiTheme={SHIKI_THEME}
+        >
+          {markdown}
+        </Streamdown>
+      ) : (
+        // Same p-3 padding as the highlighted code block so there is no layout
+        // jump when shiki swaps in.
+        <pre className="m-0 whitespace-pre-wrap break-words p-3 font-mono text-xs text-muted-foreground">
+          {display}
+        </pre>
+      )}
     </div>
   );
 }

--- a/studio/frontend/src/components/assistant-ui/tool-ui-python.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-ui-python.tsx
@@ -166,11 +166,12 @@ function HighlightedCode({ code: source, language }: { code: string; language: s
           {markdown}
         </Streamdown>
       ) : (
-        // Same p-3 padding as the highlighted code block so there is no layout
-        // jump when shiki swaps in.
-        <pre className="m-0 whitespace-pre-wrap break-words p-3 font-mono text-xs text-muted-foreground">
+        // A div, not a <pre>: the container's [&_pre]:!p-0 would override a
+        // <pre>'s padding and shift the content by p-3 when shiki swaps in. This
+        // keeps the same p-3 the highlighted code block gets, so there is no jump.
+        <div className="whitespace-pre-wrap break-words p-3 font-mono text-xs text-muted-foreground">
           {display}
-        </pre>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## What

Keep the executed Python script visible in the chat tool card, with Copy and a Download button, and highlight it lazily so long transcripts stay fast.

- The script source is rendered directly under the tool trigger instead of only inside the collapsible run/output section. That section is unmounted when a card is collapsed from history, so previously the script disappeared on reopen (#7165); now it stays visible.
- Adds a client-side `.py` Download button next to Copy (builds a Blob and clicks an anchor, the same pattern the image / audio / attachment / chat-export buttons use).
- shiki syntax-highlighting runs only once the script scrolls near the viewport (`IntersectionObserver`, 200px margin). Until then a plain monospace placeholder shows the same source with matching padding, so there is no layout jump. Falls back to immediate highlight when `IntersectionObserver` is unavailable (SSR / tests).

## Why the viewport gating

Rendering the script always (rather than only on expand) means its highlighting would otherwise run for every Python tool call on load. Measured with the bundled shiki (3.23.0, dual github themes, python):

| Script size | highlight time |
|---|---|
| ~2 KB (typical) | ~8 ms |
| 10 KB (max, truncated) | ~39 ms |

Eager highlighting of a long agentic transcript would add ~170 ms (20 calls) to ~420 ms (50 calls) of main-thread work on load. Viewport-gating bounds it to the handful of cards actually on screen (~15-35 ms) regardless of transcript length. Live/streaming chat is unchanged (the running card is already open).

## Notes

- Supersedes #7240 (same script-visibility + download, with the highlight perf fix folded in).
- Frontend-only, one file. `tsc -b` typecheck passes; the executed-script placeholder keeps the source visible and copyable at all times.
