### PR TITLE
Installer: opt-in Vulkan llama.cpp backend (and fallback when no AMD card is HIP-supported)

### DIFF
--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -847,6 +847,47 @@ def test_route_to_vulkan_prebuilt_keeps_hip_when_one_gpu_is_supported():
     assert persist is None
 
 
+def test_route_to_vulkan_prebuilt_auto_fallback_uses_active_gfx_only():
+    # HIP_VISIBLE_DEVICES can hide a supported dGPU; fallback must follow the
+    # active arch (_pick_rocm_gfx_target), not every physical GPU in hipinfo.
+    host = _windows_amd_host(
+        rocm_gfx_target = "gfx803",
+        rocm_gfx_targets = ["gfx1201", "gfx803"],
+    )
+    routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
+    assert repo == UPSTREAM
+    assert persist == "vulkan"
+    assert routed.has_rocm is False
+
+
+def test_route_to_vulkan_prebuilt_unknown_gfx_does_not_auto_fallback():
+    host = _windows_amd_host(
+        has_rocm = True,
+        rocm_gfx_target = None,
+        rocm_gfx_targets = [],
+    )
+    routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
+    assert routed is host
+    assert repo == FORK
+    assert persist is None
+
+
+def test_route_to_vulkan_prebuilt_family_gfx_token_keeps_rocm():
+    host = _windows_amd_host(rocm_gfx_target = "gfx110X", rocm_gfx_targets = ["gfx110X"])
+    routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
+    assert routed is host
+    assert repo == FORK
+    assert persist is None
+
+
+def test_route_to_vulkan_prebuilt_gfx1103_keeps_rocm():
+    host = _windows_amd_host(rocm_gfx_target = "gfx1103", rocm_gfx_targets = ["gfx1103"])
+    routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
+    assert routed is host
+    assert repo == FORK
+    assert persist is None
+
+
 def test_route_to_vulkan_prebuilt_explicit_opt_in_on_mixed_amd(monkeypatch):
     monkeypatch.setenv("UNSLOTH_LLAMA_BACKEND", "vulkan")
     host = _windows_amd_host(

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -888,6 +888,16 @@ def test_route_to_vulkan_prebuilt_gfx1103_keeps_rocm():
     assert persist is None
 
 
+def test_route_to_vulkan_prebuilt_gfx1034_keeps_rocm():
+    # gfx1034 (RX 6500/6400-class) is covered by the fork windows-rocm gfx103X
+    # bundle, so it must stay on the ROCm path rather than fall back to Vulkan.
+    host = _windows_amd_host(rocm_gfx_target = "gfx1034", rocm_gfx_targets = ["gfx1034"])
+    routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
+    assert routed is host
+    assert repo == FORK
+    assert persist is None
+
+
 def test_route_to_vulkan_prebuilt_explicit_opt_in_on_mixed_amd(monkeypatch):
     monkeypatch.setenv("UNSLOTH_LLAMA_BACKEND", "vulkan")
     host = _windows_amd_host(

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -407,7 +407,9 @@ def test_route_to_vulkan_prebuilt_auto_intel_goes_upstream_and_drops_fork_pin():
     # Routing fork -> upstream also drops the fork release pin, which is in a
     # different tag namespace and would make the upstream resolver miss.
     host = _host(is_linux = True, is_x86_64 = True, has_intel_gpu = True)
-    routed, repo, tag, _persist = ilp._route_to_vulkan_prebuilt(host, FORK, "b9596-mix-abc", force_cpu = False)
+    routed, repo, tag, _persist = ilp._route_to_vulkan_prebuilt(
+        host, FORK, "b9596-mix-abc", force_cpu = False
+    )
     assert repo == UPSTREAM
     assert tag == ""
     assert routed.has_intel_gpu is True
@@ -416,7 +418,9 @@ def test_route_to_vulkan_prebuilt_auto_intel_goes_upstream_and_drops_fork_pin():
 def test_route_to_vulkan_prebuilt_preserves_explicit_upstream_pin():
     # A pin set WITH an explicit upstream repo is already on upstream -> kept.
     host = _host(is_linux = True, is_x86_64 = True, has_intel_gpu = True)
-    _routed, repo, tag, _persist = ilp._route_to_vulkan_prebuilt(host, UPSTREAM, "b9596", force_cpu = False)
+    _routed, repo, tag, _persist = ilp._route_to_vulkan_prebuilt(
+        host, UPSTREAM, "b9596", force_cpu = False
+    )
     assert repo == UPSTREAM
     assert tag == "b9596"
 
@@ -424,7 +428,9 @@ def test_route_to_vulkan_prebuilt_preserves_explicit_upstream_pin():
 def test_route_to_vulkan_prebuilt_cpu_fallback_wins():
     # --cpu-fallback suppresses Vulkan routing even for an Intel host.
     host = _host(is_linux = True, is_x86_64 = True, has_intel_gpu = True)
-    routed, repo, tag, _persist = ilp._route_to_vulkan_prebuilt(host, FORK, "b9596-mix-abc", force_cpu = True)
+    routed, repo, tag, _persist = ilp._route_to_vulkan_prebuilt(
+        host, FORK, "b9596-mix-abc", force_cpu = True
+    )
     assert repo == FORK
     assert tag == "b9596-mix-abc"
     assert routed is host

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -921,3 +921,45 @@ def test_llama_backend_env_requests_vulkan(monkeypatch):
     monkeypatch.setenv("UNSLOTH_LLAMA_BACKEND", "vulkan")
     assert ilp.llama_backend_from_env() == "vulkan"
     assert ilp.force_vulkan_requested() is True
+
+
+def test_llama_cpp_backend_env_does_not_trigger_vulkan(monkeypatch):
+    # UNSLOTH_LLAMA_CPP_BACKEND is a separate setup variable (auto/cpu); setup
+    # warns and ignores any other value, so the installer must not read a
+    # "vulkan" out of it or the opt-in would fire behind that warning.
+    monkeypatch.delenv("UNSLOTH_LLAMA_BACKEND", raising = False)
+    monkeypatch.delenv("UNSLOTH_FORCE_VULKAN", raising = False)
+    monkeypatch.setenv("UNSLOTH_LLAMA_CPP_BACKEND", "vulkan")
+    assert ilp.llama_backend_from_env() is None
+    assert ilp.force_vulkan_requested() is False
+
+
+def test_route_to_vulkan_prebuilt_hidden_physical_nvidia_amd_not_rerouted():
+    # A CUDA-masked NVIDIA card (has_physical_nvidia True, has_usable_nvidia
+    # False) alongside a legacy AMD gfx must NOT auto-route to Vulkan: Vulkan
+    # ignores CUDA_VISIBLE_DEVICES and could grab the reserved NVIDIA GPU.
+    host = _windows_amd_host(
+        rocm_gfx_target = "gfx803",
+        rocm_gfx_targets = ["gfx803"],
+        has_physical_nvidia = True,
+        has_usable_nvidia = False,
+    )
+    routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
+    assert routed is host
+    assert repo == FORK
+    assert persist is None
+
+
+def test_route_to_vulkan_prebuilt_explicit_opt_in_overrides_hidden_nvidia(monkeypatch):
+    # The physical-NVIDIA guard only gates the AMD AUTO path; an explicit opt-in
+    # still forces Vulkan (the user asked for it).
+    monkeypatch.setenv("UNSLOTH_LLAMA_BACKEND", "vulkan")
+    host = _windows_amd_host(
+        rocm_gfx_target = "gfx803",
+        rocm_gfx_targets = ["gfx803"],
+        has_physical_nvidia = True,
+        has_usable_nvidia = False,
+    )
+    routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
+    assert repo == UPSTREAM
+    assert persist == "vulkan"

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -407,7 +407,7 @@ def test_route_to_vulkan_prebuilt_auto_intel_goes_upstream_and_drops_fork_pin():
     # Routing fork -> upstream also drops the fork release pin, which is in a
     # different tag namespace and would make the upstream resolver miss.
     host = _host(is_linux = True, is_x86_64 = True, has_intel_gpu = True)
-    routed, repo, tag = ilp._route_to_vulkan_prebuilt(host, FORK, "b9596-mix-abc", force_cpu = False)
+    routed, repo, tag, _persist = ilp._route_to_vulkan_prebuilt(host, FORK, "b9596-mix-abc", force_cpu = False)
     assert repo == UPSTREAM
     assert tag == ""
     assert routed.has_intel_gpu is True
@@ -416,7 +416,7 @@ def test_route_to_vulkan_prebuilt_auto_intel_goes_upstream_and_drops_fork_pin():
 def test_route_to_vulkan_prebuilt_preserves_explicit_upstream_pin():
     # A pin set WITH an explicit upstream repo is already on upstream -> kept.
     host = _host(is_linux = True, is_x86_64 = True, has_intel_gpu = True)
-    _routed, repo, tag = ilp._route_to_vulkan_prebuilt(host, UPSTREAM, "b9596", force_cpu = False)
+    _routed, repo, tag, _persist = ilp._route_to_vulkan_prebuilt(host, UPSTREAM, "b9596", force_cpu = False)
     assert repo == UPSTREAM
     assert tag == "b9596"
 
@@ -424,7 +424,7 @@ def test_route_to_vulkan_prebuilt_preserves_explicit_upstream_pin():
 def test_route_to_vulkan_prebuilt_cpu_fallback_wins():
     # --cpu-fallback suppresses Vulkan routing even for an Intel host.
     host = _host(is_linux = True, is_x86_64 = True, has_intel_gpu = True)
-    routed, repo, tag = ilp._route_to_vulkan_prebuilt(host, FORK, "b9596-mix-abc", force_cpu = True)
+    routed, repo, tag, _persist = ilp._route_to_vulkan_prebuilt(host, FORK, "b9596-mix-abc", force_cpu = True)
     assert repo == FORK
     assert tag == "b9596-mix-abc"
     assert routed is host
@@ -536,20 +536,20 @@ def test_route_to_vulkan_prebuilt_hidden_nvidia_not_rerouted():
         has_physical_nvidia = True,
         has_usable_nvidia = False,
     )
-    _routed, repo, _tag = ilp._route_to_vulkan_prebuilt(host, FORK, "", force_cpu = False)
+    _routed, repo, _tag, _persist = ilp._route_to_vulkan_prebuilt(host, FORK, "", force_cpu = False)
     assert repo == FORK
 
 
 def test_route_to_vulkan_prebuilt_rocm_host_not_rerouted():
     # An Intel iGPU alongside a usable ROCm GPU stays on its ROCm/fork path.
     host = _host(is_linux = True, is_x86_64 = True, has_intel_gpu = True, has_rocm = True)
-    _routed, repo, _tag = ilp._route_to_vulkan_prebuilt(host, FORK, "", force_cpu = False)
+    _routed, repo, _tag, _persist = ilp._route_to_vulkan_prebuilt(host, FORK, "", force_cpu = False)
     assert repo == FORK
 
 
 def test_route_to_vulkan_prebuilt_non_intel_unchanged():
     host = _host(is_linux = True, is_x86_64 = True)
-    routed, repo, _tag = ilp._route_to_vulkan_prebuilt(host, FORK, "", force_cpu = False)
+    routed, repo, _tag, _persist = ilp._route_to_vulkan_prebuilt(host, FORK, "", force_cpu = False)
     assert repo == FORK
     assert routed is host
 
@@ -797,3 +797,80 @@ def test_detect_host_cim_rescues_exploding_registry(monkeypatch):
     )
     assert host.has_intel_gpu is True
     assert "powershell" in captured
+
+
+def _windows_amd_host(**overrides):
+    defaults = dict(
+        system = "Windows",
+        machine = "amd64",
+        is_windows = True,
+        is_linux = False,
+        is_macos = False,
+        is_x86_64 = True,
+        is_arm64 = False,
+        nvidia_smi = None,
+        driver_cuda_version = None,
+        compute_caps = [],
+        visible_cuda_devices = None,
+        has_physical_nvidia = False,
+        has_usable_nvidia = False,
+        has_rocm = True,
+        has_intel_gpu = False,
+    )
+    defaults.update(overrides)
+    return ilp.HostInfo(**defaults)
+
+
+def test_route_to_vulkan_prebuilt_auto_fallback_for_legacy_amd_gfx():
+    host = _windows_amd_host(rocm_gfx_target = "gfx803", rocm_gfx_targets = ["gfx803"])
+    routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
+    assert repo == UPSTREAM
+    assert persist == "vulkan"
+    assert routed.has_intel_gpu is True
+    assert routed.has_rocm is False
+
+
+def test_route_to_vulkan_prebuilt_keeps_hip_when_one_gpu_is_supported():
+    host = _windows_amd_host(
+        rocm_gfx_target = "gfx1201",
+        rocm_gfx_targets = ["gfx1201", "gfx803"],
+    )
+    routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
+    assert routed is host
+    assert repo == FORK
+    assert persist is None
+
+
+def test_route_to_vulkan_prebuilt_explicit_opt_in_on_mixed_amd(monkeypatch):
+    monkeypatch.setenv("UNSLOTH_LLAMA_BACKEND", "vulkan")
+    host = _windows_amd_host(
+        rocm_gfx_target = "gfx1201",
+        rocm_gfx_targets = ["gfx1201", "gfx803"],
+    )
+    routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
+    assert repo == UPSTREAM
+    assert persist == "vulkan"
+    assert routed.has_rocm is False
+
+
+def test_direct_upstream_windows_amd_legacy_gfx_routes_to_vulkan():
+    host = _windows_amd_host(rocm_gfx_target = "gfx803", rocm_gfx_targets = ["gfx803"])
+    routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
+    rel = _upstream_release(
+        "b9925",
+        [
+            "llama-b9925-bin-win-hip-radeon-x64.zip",
+            "llama-b9925-bin-win-vulkan-x64.zip",
+            "llama-b9925-bin-win-cpu-x64.zip",
+        ],
+    )
+    plan = ilp.direct_upstream_release_plan(rel, routed, repo, "latest")
+    assert persist == "vulkan"
+    assert plan.attempts[0].install_kind == "windows-vulkan"
+
+
+def test_llama_backend_env_requests_vulkan(monkeypatch):
+    assert ilp.llama_backend_from_env() is None
+    monkeypatch.setenv("UNSLOTH_LLAMA_BACKEND", "vulkan")
+    assert ilp.llama_backend_from_env() == "vulkan"
+    assert ilp.force_vulkan_requested() is True

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -848,8 +848,7 @@ def test_route_to_vulkan_prebuilt_keeps_hip_when_one_gpu_is_supported():
 
 
 def test_route_to_vulkan_prebuilt_auto_fallback_uses_active_gfx_only():
-    # HIP_VISIBLE_DEVICES can hide a supported dGPU; fallback must follow the
-    # active arch (_pick_rocm_gfx_target), not every physical GPU in hipinfo.
+    # HIP_VISIBLE_DEVICES can hide a supported dGPU, so follow the active arch.
     host = _windows_amd_host(
         rocm_gfx_target = "gfx803",
         rocm_gfx_targets = ["gfx1201", "gfx803"],
@@ -889,8 +888,7 @@ def test_route_to_vulkan_prebuilt_gfx1103_keeps_rocm():
 
 
 def test_route_to_vulkan_prebuilt_gfx1034_keeps_rocm():
-    # gfx1034 (RX 6500/6400-class) is covered by the fork windows-rocm gfx103X
-    # bundle, so it must stay on the ROCm path rather than fall back to Vulkan.
+    # gfx1034 (RX 6500/6400-class) is covered by the fork's gfx103X bundle.
     host = _windows_amd_host(rocm_gfx_target = "gfx1034", rocm_gfx_targets = ["gfx1034"])
     routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
     assert routed is host
@@ -934,9 +932,8 @@ def test_llama_backend_env_requests_vulkan(monkeypatch):
 
 
 def test_llama_cpp_backend_env_does_not_trigger_vulkan(monkeypatch):
-    # UNSLOTH_LLAMA_CPP_BACKEND is a separate setup variable (auto/cpu); setup
-    # warns and ignores any other value, so the installer must not read a
-    # "vulkan" out of it or the opt-in would fire behind that warning.
+    # UNSLOTH_LLAMA_CPP_BACKEND is a separate setup variable (auto/cpu) whose other values
+    # setup warns about and ignores, so reading it here would opt in behind that warning.
     monkeypatch.delenv("UNSLOTH_LLAMA_BACKEND", raising = False)
     monkeypatch.delenv("UNSLOTH_FORCE_VULKAN", raising = False)
     monkeypatch.setenv("UNSLOTH_LLAMA_CPP_BACKEND", "vulkan")
@@ -945,9 +942,8 @@ def test_llama_cpp_backend_env_does_not_trigger_vulkan(monkeypatch):
 
 
 def test_route_to_vulkan_prebuilt_hidden_physical_nvidia_amd_not_rerouted():
-    # A CUDA-masked NVIDIA card (has_physical_nvidia True, has_usable_nvidia
-    # False) alongside a legacy AMD gfx must NOT auto-route to Vulkan: Vulkan
-    # ignores CUDA_VISIBLE_DEVICES and could grab the reserved NVIDIA GPU.
+    # Vulkan ignores CUDA_VISIBLE_DEVICES, so a CUDA-masked NVIDIA card next to a legacy
+    # AMD gfx must not auto-route: Vulkan could grab the reserved NVIDIA GPU.
     host = _windows_amd_host(
         rocm_gfx_target = "gfx803",
         rocm_gfx_targets = ["gfx803"],
@@ -961,8 +957,7 @@ def test_route_to_vulkan_prebuilt_hidden_physical_nvidia_amd_not_rerouted():
 
 
 def test_route_to_vulkan_prebuilt_explicit_opt_in_overrides_hidden_nvidia(monkeypatch):
-    # The physical-NVIDIA guard only gates the AMD AUTO path; an explicit opt-in
-    # still forces Vulkan (the user asked for it).
+    # The physical-NVIDIA guard only gates the AMD auto path; an explicit opt-in wins.
     monkeypatch.setenv("UNSLOTH_LLAMA_BACKEND", "vulkan")
     host = _windows_amd_host(
         rocm_gfx_target = "gfx803",
@@ -975,9 +970,8 @@ def test_route_to_vulkan_prebuilt_explicit_opt_in_overrides_hidden_nvidia(monkey
     assert persist == "vulkan"
 
 
-# The gfx archs the fork's llama-prebuilt-manifest.json maps to a windows-rocm
-# bundle (gfx103X / gfx110X / gfx1150 / gfx1151 / gfx120X / gfx908 / gfx90a).
-# Auto-Vulkan must never steal a host one of these already covers.
+# The gfx archs the fork's llama-prebuilt-manifest.json maps to a windows-rocm bundle
+# (gfx103X / gfx110X / gfx1150 / gfx1151 / gfx120X / gfx908 / gfx90a).
 _FORK_WINDOWS_ROCM_GFX = (
     "gfx908",
     "gfx90a",
@@ -997,9 +991,8 @@ _FORK_WINDOWS_ROCM_GFX = (
 
 
 def test_windows_hip_gfx_floor_covers_every_fork_windows_rocm_bundle():
-    # A gfx missing here routes to Vulkan and bypasses the fork manifest entirely,
-    # silently downgrading a hash-approved windows-rocm bundle to an unhashed
-    # upstream Vulkan build. Keep this in sync with the published manifest.
+    # A gfx missing here bypasses the fork manifest, downgrading a hash-approved
+    # windows-rocm bundle to an unhashed upstream Vulkan build. Keep both in sync.
     missing = [
         gfx for gfx in _FORK_WINDOWS_ROCM_GFX if gfx not in ilp.WINDOWS_HIP_PREBUILT_GFX_TARGETS
     ]
@@ -1019,8 +1012,7 @@ def test_route_to_vulkan_prebuilt_keeps_every_fork_windows_rocm_arch(gfx, monkey
 
 
 def test_llama_backend_hip_opts_out_of_auto_vulkan(monkeypatch):
-    # UNSLOTH_LLAMA_BACKEND names a backend, so hip must keep the HIP/fork path
-    # even on an arch the auto-fallback would otherwise route to Vulkan.
+    # hip names a backend, so it keeps the fork path even on an auto-fallback arch.
     monkeypatch.setenv("UNSLOTH_LLAMA_BACKEND", "hip")
     host = _windows_amd_host(rocm_gfx_target = "gfx803", rocm_gfx_targets = ["gfx803"])
     routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
@@ -1031,8 +1023,7 @@ def test_llama_backend_hip_opts_out_of_auto_vulkan(monkeypatch):
 
 
 def test_explicit_backend_beats_legacy_force_vulkan(monkeypatch):
-    # The specific variable wins: a stale UNSLOTH_FORCE_VULKAN must not overrule
-    # an explicit UNSLOTH_LLAMA_BACKEND=hip (rocm is the same backend).
+    # A stale UNSLOTH_FORCE_VULKAN must not overrule UNSLOTH_LLAMA_BACKEND=rocm (== hip).
     monkeypatch.setenv("UNSLOTH_FORCE_VULKAN", "1")
     monkeypatch.setenv("UNSLOTH_LLAMA_BACKEND", "rocm")
     assert ilp.resolved_llama_backend() == "hip"
@@ -1044,8 +1035,7 @@ def test_explicit_backend_beats_legacy_force_vulkan(monkeypatch):
 
 
 def test_unknown_llama_backend_value_falls_through_to_legacy_flag(monkeypatch):
-    # An unrecognised value is ignored (not an error), so the legacy flag and the
-    # auto-fallback both keep working exactly as they did without it.
+    # An unrecognised value is ignored, not an error, so the legacy flag still works.
     monkeypatch.setenv("UNSLOTH_LLAMA_BACKEND", "banana")
     assert ilp.resolved_llama_backend() is None
     assert ilp.force_vulkan_requested() is False
@@ -1096,10 +1086,9 @@ def _windows_arm64_host(**overrides):
     ],
 )
 def test_vulkan_opt_in_ignored_on_windows_arm64(monkeypatch, env, flag):
-    # ggml-org release.yml builds win-vulkan for x64 only (arm64 gets
-    # win-cpu-arm64 + win-opencl-adreno-arm64), so rewriting the host to
-    # Vulkan-only would just swap the published arm64 bundle for the upstream
-    # CPU one and still never produce Vulkan. Keep the published bundle.
+    # ggml-org release.yml builds win-vulkan for x64 only (arm64 gets win-cpu-arm64 +
+    # win-opencl-adreno-arm64), so rewriting the host would only swap the published
+    # arm64 bundle for the upstream CPU one. Keep the published bundle.
     for name, value in env.items():
         monkeypatch.setenv(name, value)
     host = _windows_arm64_host()
@@ -1138,9 +1127,8 @@ def test_persisted_llama_backend_keeps_vulkan_for_a_vulkan_bundle(kind):
 
 @pytest.mark.parametrize("kind", ["windows-arm64", "windows-cpu", "linux-cpu", "windows-rocm"])
 def test_persisted_llama_backend_drops_vulkan_for_a_non_vulkan_bundle(kind):
-    # A Vulkan request that fell through to a CPU attempt must not leave a marker
-    # claiming Vulkan: _plan_llama_phase re-asserts the marker's backend on every
-    # later update, pinning the host to a backend it never installed.
+    # _plan_llama_phase re-asserts the marker's backend on every later update, so a
+    # Vulkan request that fell through to CPU must not leave a marker claiming Vulkan.
     assert ilp.persisted_llama_backend("vulkan", _choice(kind)) is None
 
 
@@ -1149,9 +1137,8 @@ def test_persisted_llama_backend_passes_none_through():
 
 
 def test_marker_records_no_backend_when_vulkan_fell_back_to_cpu(tmp_path):
-    # End to end over write_prebuilt_metadata: the CPU attempt that actually won
-    # must be described honestly, so the next update re-detects instead of
-    # re-asserting Vulkan forever.
+    # End to end over write_prebuilt_metadata: describe the CPU attempt that actually
+    # won, so the next update re-detects instead of re-asserting Vulkan forever.
     checksums = ilp.ApprovedReleaseChecksums(
         repo = UPSTREAM,
         release_tag = "b9925",

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -1063,3 +1063,129 @@ def test_llama_backend_flag_beats_conflicting_env(monkeypatch):
     )
     assert repo == UPSTREAM
     assert persist == "vulkan"
+
+
+def _windows_arm64_host(**overrides):
+    defaults = dict(
+        system = "Windows",
+        machine = "ARM64",
+        is_windows = True,
+        is_linux = False,
+        is_macos = False,
+        is_x86_64 = False,
+        is_arm64 = True,
+        nvidia_smi = None,
+        driver_cuda_version = None,
+        compute_caps = [],
+        visible_cuda_devices = None,
+        has_physical_nvidia = False,
+        has_usable_nvidia = False,
+        has_rocm = False,
+        has_intel_gpu = False,
+    )
+    defaults.update(overrides)
+    return ilp.HostInfo(**defaults)
+
+
+@pytest.mark.parametrize(
+    "env, flag",
+    [
+        ({"UNSLOTH_LLAMA_BACKEND": "vulkan"}, None),
+        ({"UNSLOTH_FORCE_VULKAN": "1"}, None),
+        ({}, "vulkan"),
+    ],
+)
+def test_vulkan_opt_in_ignored_on_windows_arm64(monkeypatch, env, flag):
+    # ggml-org release.yml builds win-vulkan for x64 only (arm64 gets
+    # win-cpu-arm64 + win-opencl-adreno-arm64), so rewriting the host to
+    # Vulkan-only would just swap the published arm64 bundle for the upstream
+    # CPU one and still never produce Vulkan. Keep the published bundle.
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+    host = _windows_arm64_host()
+    routed, repo, tag, persist = ilp._route_to_vulkan_prebuilt(
+        host, FORK, "pin", force_cpu = False, llama_backend = flag
+    )
+    assert routed is host
+    assert (repo, tag) == (FORK, "pin")
+    assert persist is None
+
+
+def test_vulkan_opt_in_still_routes_on_windows_x64(monkeypatch):
+    # Negative control for the arm64 guard: x64 keeps its Vulkan routing.
+    monkeypatch.setenv("UNSLOTH_LLAMA_BACKEND", "vulkan")
+    host = _windows_amd_host(rocm_gfx_target = "gfx1100", rocm_gfx_targets = ["gfx1100"])
+    _routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(
+        host, FORK, "pin", force_cpu = False
+    )
+    assert repo == UPSTREAM
+    assert persist == "vulkan"
+
+
+def _choice(install_kind, name = "asset.zip"):
+    return ilp.AssetChoice(
+        repo = UPSTREAM,
+        tag = "b9925",
+        name = name,
+        url = f"https://example/{name}",
+        source_label = "upstream",
+        install_kind = install_kind,
+    )
+
+
+@pytest.mark.parametrize("kind", ["windows-vulkan", "linux-vulkan"])
+def test_persisted_llama_backend_keeps_vulkan_for_a_vulkan_bundle(kind):
+    assert ilp.persisted_llama_backend("vulkan", _choice(kind)) == "vulkan"
+
+
+@pytest.mark.parametrize("kind", ["windows-arm64", "windows-cpu", "linux-cpu", "windows-rocm"])
+def test_persisted_llama_backend_drops_vulkan_for_a_non_vulkan_bundle(kind):
+    # A Vulkan request that fell through to a CPU attempt must not leave a marker
+    # claiming Vulkan: _plan_llama_phase re-asserts the marker's backend on every
+    # later update, pinning the host to a backend it never installed.
+    assert ilp.persisted_llama_backend("vulkan", _choice(kind)) is None
+
+
+def test_persisted_llama_backend_passes_none_through():
+    assert ilp.persisted_llama_backend(None, _choice("windows-vulkan")) is None
+
+
+def test_marker_records_no_backend_when_vulkan_fell_back_to_cpu(tmp_path):
+    # End to end over write_prebuilt_metadata: the CPU attempt that actually won
+    # must be described honestly, so the next update re-detects instead of
+    # re-asserting Vulkan forever.
+    checksums = ilp.ApprovedReleaseChecksums(
+        repo = UPSTREAM,
+        release_tag = "b9925",
+        upstream_tag = "b9925",
+        source_repo = UPSTREAM,
+        source_repo_url = f"https://github.com/{UPSTREAM}",
+    )
+    cpu = _choice("windows-arm64", "llama-b9925-bin-win-cpu-arm64.zip")
+    ilp.write_prebuilt_metadata(
+        tmp_path,
+        requested_tag = "latest",
+        llama_tag = "b9925",
+        release_tag = "b9925",
+        choice = cpu,
+        approved_checksums = checksums,
+        prebuilt_fallback_used = False,
+        llama_backend = "vulkan",
+    )
+    marker = json.loads((tmp_path / "UNSLOTH_PREBUILT_INFO.json").read_text())
+    assert marker["asset"] == "llama-b9925-bin-win-cpu-arm64.zip"
+    assert marker["llama_backend"] is None
+
+    vulkan = _choice("windows-vulkan", "llama-b9925-bin-win-vulkan-x64.zip")
+    ilp.write_prebuilt_metadata(
+        tmp_path,
+        requested_tag = "latest",
+        llama_tag = "b9925",
+        release_tag = "b9925",
+        choice = vulkan,
+        approved_checksums = checksums,
+        prebuilt_fallback_used = False,
+        llama_backend = "vulkan",
+    )
+    marker = json.loads((tmp_path / "UNSLOTH_PREBUILT_INFO.json").read_text())
+    assert marker["llama_backend"] == "vulkan"

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -38,11 +38,10 @@ UPSTREAM = ilp.UPSTREAM_REPO  # ggml-org/llama.cpp
 def _no_ambient_hip_device_mask(monkeypatch):
     """These tests describe hosts through HostInfo, not through the environment.
 
-    A HIP visible-device mask inherited from the shell (an ML box commonly exports
-    CUDA_VISIBLE_DEVICES) means the arch probe saw only part of the GPUs, which the
-    Windows auto-Vulkan guard treats as an unknown physical inventory. Clear all
-    three so a host is described by its fields alone; the tests that are about the
-    mask set it explicitly."""
+    A mask inherited from the shell (ML boxes commonly export CUDA_VISIBLE_DEVICES) means
+    the arch probe saw only part of the GPUs, which the Windows auto-Vulkan guard treats as
+    an unknown physical inventory. Clear all three so a host is described by its fields
+    alone; the tests that are about the mask set it explicitly."""
     for _env in ("HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"):
         monkeypatch.delenv(_env, raising = False)
 
@@ -863,10 +862,9 @@ def test_route_to_vulkan_prebuilt_keeps_hip_when_one_gpu_is_supported():
 
 
 def test_route_to_vulkan_prebuilt_auto_fallback_skips_hip_masked_hosts():
-    # HIP_VISIBLE_DEVICES / ROCR_VISIBLE_DEVICES can hide a HIP-capable dGPU, but the
-    # Vulkan runtime honours neither (it enumerates via GGML_VK_VISIBLE_DEVICES and
-    # Vulkan ordinals), so auto-routing here would let the installed backend grab the
-    # gfx1201 the user deliberately masked off. Stay on the HIP / fork / source path.
+    # A HIP mask can hide a HIP-capable dGPU, but the Vulkan runtime honours none of them,
+    # so auto-routing would let the installed backend grab the gfx1201 the user masked
+    # off.
     host = _windows_amd_host(
         rocm_gfx_target = "gfx803",
         rocm_gfx_targets = ["gfx1201", "gfx803"],
@@ -878,8 +876,8 @@ def test_route_to_vulkan_prebuilt_auto_fallback_skips_hip_masked_hosts():
 
 
 def test_route_to_vulkan_prebuilt_auto_fallback_when_no_amd_gpu_reaches_floor():
-    # Every physical AMD device is below the HIP prebuilt floor, so no card can be
-    # exposed to HIP and the #7357 auto-Vulkan fallback still fires.
+    # Every physical AMD device is below the floor, so no card can be exposed to HIP and
+    # the #7357 auto-Vulkan fallback still fires.
     host = _windows_amd_host(
         rocm_gfx_target = "gfx900",
         rocm_gfx_targets = ["gfx803", "gfx900"],
@@ -894,11 +892,10 @@ def test_route_to_vulkan_prebuilt_auto_fallback_when_no_amd_gpu_reaches_floor():
     "mask_env", ["HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"]
 )
 def test_auto_vulkan_declines_when_a_hip_device_mask_filtered_the_probe(mask_env, monkeypatch):
-    # hipinfo is a HIP application, so under a visible-device mask it enumerates only
-    # the devices that survived it: rocm_gfx_targets is then the VISIBLE set and a
-    # HIP-capable card can be masked out of view entirely. "No AMD GPU on this box
-    # reaches the floor" is unprovable there, and Vulkan honours none of these masks,
-    # so the automatic fallback must decline rather than hand it the reserved card.
+    # hipinfo is a HIP application, so under a mask rocm_gfx_targets is the VISIBLE set and
+    # a HIP-capable card can be hidden entirely. "No AMD GPU here reaches the floor" is then
+    # unprovable, and Vulkan honours none of these masks, so the auto fallback must decline
+    # rather than hand it the reserved card.
     monkeypatch.setenv(mask_env, "1")
     host = _windows_amd_host(rocm_gfx_target = "gfx803", rocm_gfx_targets = ["gfx803"])
     assert ilp._should_auto_vulkan_for_amd_windows(host, FORK) is False
@@ -910,11 +907,10 @@ def test_auto_vulkan_declines_when_a_hip_device_mask_filtered_the_probe(mask_env
 
 @pytest.mark.parametrize("mask_value", ["", "  ", "-1"])
 def test_auto_vulkan_declines_when_the_mask_hides_every_amd_gpu(mask_value, monkeypatch):
-    # An all-hiding mask is the strongest form of the same signal, not an exemption.
-    # detect_host() resolves no arch under it, but a forwarded --rocm-gfx still
-    # reconstructs one (setup infers the arch from the display-adapter name, which no
-    # HIP mask touches), so auto-routing here would hand Vulkan every AMD GPU the user
-    # deliberately hid from HIP.
+    # An all-hiding mask is the strongest form of the same signal, not an exemption:
+    # detect_host() resolves no arch under it, but a forwarded --rocm-gfx still reconstructs
+    # one (setup infers it from the display-adapter name, which no HIP mask touches), so
+    # auto-routing would hand Vulkan every AMD GPU the user hid from HIP.
     monkeypatch.setenv("HIP_VISIBLE_DEVICES", mask_value)
     host = _windows_amd_host(rocm_gfx_target = None, rocm_gfx_targets = [])
     host = ilp._apply_host_overrides(host, override_rocm_gfx = "gfx803")
@@ -927,8 +923,8 @@ def test_auto_vulkan_declines_when_the_mask_hides_every_amd_gpu(mask_value, monk
 
 
 def test_hip_device_mask_check_is_presence_not_value(monkeypatch):
-    # Presence is the whole test: any value means the HIP view of the GPUs is not the
-    # physical one, and no value can be read as "the probe saw everything".
+    # Presence is the whole test: any value means the HIP view is not the physical one, and
+    # no value can be read as "the probe saw everything".
     assert ilp._hip_visible_device_mask_set() is False
     for value in ("", "  ", "-1", "0", "1", "0,1"):
         monkeypatch.setenv("HIP_VISIBLE_DEVICES", value)
@@ -942,8 +938,7 @@ def test_hip_device_mask_check_is_presence_not_value(monkeypatch):
 
 
 def test_masked_probe_suppression_does_not_touch_non_amd_auto_paths(monkeypatch):
-    # The mask says nothing about an Intel iGPU, whose Vulkan auto path is unrelated
-    # and predates this feature.
+    # The mask says nothing about an Intel iGPU, whose Vulkan auto path is unrelated.
     monkeypatch.setenv("HIP_VISIBLE_DEVICES", "1")
     host = _host(
         system = "Windows",
@@ -960,8 +955,8 @@ def test_masked_probe_suppression_does_not_touch_non_amd_auto_paths(monkeypatch)
 
 
 def test_route_to_vulkan_prebuilt_hip_masked_host_still_honours_explicit_optin(monkeypatch):
-    # The mask guard only suppresses the AUTOMATIC fallback; an explicit opt-in is
-    # the user taking responsibility for the Vulkan device mask themselves.
+    # The mask guard only suppresses the AUTOMATIC fallback; an explicit opt-in is the user
+    # taking responsibility for the Vulkan device mask themselves.
     monkeypatch.delenv("UNSLOTH_FORCE_VULKAN", raising = False)
     host = _windows_amd_host(
         rocm_gfx_target = "gfx803",
@@ -975,9 +970,9 @@ def test_route_to_vulkan_prebuilt_hip_masked_host_still_honours_explicit_optin(m
 
 
 def test_auto_vulkan_is_repository_specific_for_fork_only_gfx():
-    # gfx1034 is served only by the fork's gfx103X bundle. ggml-org's windows-hip
-    # radeon build does not target it, and direct_upstream_release_plan() offers
-    # win-hip then CPU with no Vulkan branch, so the predicate must answer per repo.
+    # gfx1034 is served only by the fork's gfx103X bundle: ggml-org's windows-hip radeon
+    # build does not target it and direct_upstream_release_plan() offers win-hip then CPU
+    # with no Vulkan branch, so the predicate must answer per repo.
     host = _windows_amd_host(rocm_gfx_target = "gfx1034", rocm_gfx_targets = ["gfx1034"])
     assert ilp._should_auto_vulkan_for_amd_windows(host, FORK) is False
     assert ilp._should_auto_vulkan_for_amd_windows(host, UPSTREAM) is True
@@ -995,10 +990,10 @@ def test_auto_vulkan_is_repository_specific_for_fork_only_gfx():
 )
 def test_fork_only_gfx_coverage_is_not_granted_to_other_repos(repo):
     # Only the fork is planned from a manifest: resolve_simple_install_release_plans()
-    # compares == DEFAULT_PUBLISHED_REPO and sends everything else, mirrors and
-    # differently cased spellings alike, to direct_upstream_release_plan(). Granting a
-    # fork-only arch upstream coverage there lands it on win-hip-radeon or CPU instead
-    # of Vulkan, so the predicate must gate on the fork rather than exempt one name.
+    # compares == DEFAULT_PUBLISHED_REPO and sends everything else, mirrors and differently
+    # cased spellings alike, to direct_upstream_release_plan(). Granting a fork-only arch
+    # coverage there lands it on win-hip-radeon or CPU instead of Vulkan, so the predicate
+    # must gate on the fork rather than exempt one name.
     host = _windows_amd_host(rocm_gfx_target = "gfx1034", rocm_gfx_targets = ["gfx1034"])
     assert ilp._should_auto_vulkan_for_amd_windows(host, repo) is True
     supported = _windows_amd_host(rocm_gfx_target = "gfx1100", rocm_gfx_targets = ["gfx1100"])
@@ -1007,15 +1002,14 @@ def test_fork_only_gfx_coverage_is_not_granted_to_other_repos(repo):
 
 @pytest.mark.parametrize("repo", [None, ""])
 def test_empty_published_repo_gets_fork_coverage(repo):
-    # Negative control: the resolver defaults an empty repo to the fork, so the
-    # predicate must too, or the default install path loses its fork-only archs.
+    # Negative control: the resolver defaults an empty repo to the fork, so the predicate
+    # must too, or the default install path loses its fork-only archs.
     host = _windows_amd_host(rocm_gfx_target = "gfx1034", rocm_gfx_targets = ["gfx1034"])
     assert ilp._should_auto_vulkan_for_amd_windows(host, repo) is False
 
 
 def test_upstream_windows_hip_targets_are_a_subset_of_the_combined_floor():
-    # The combined floor must stay a superset, else auto-Vulkan would steal a host
-    # upstream already builds for.
+    # The floor must stay a superset, else auto-Vulkan steals a host upstream builds for.
     assert ilp.UPSTREAM_WINDOWS_HIP_GFX_TARGETS <= ilp.WINDOWS_HIP_PREBUILT_GFX_TARGETS
     # The fork-only extras are exactly the archs that must route to Vulkan upstream.
     assert ilp.WINDOWS_HIP_PREBUILT_GFX_TARGETS - ilp.UPSTREAM_WINDOWS_HIP_GFX_TARGETS == {
@@ -1137,11 +1131,10 @@ def test_route_to_vulkan_prebuilt_explicit_opt_in_overrides_hidden_nvidia(monkey
     assert persist == "vulkan"
 
 
-# The gfx archs the fork's llama-prebuilt-manifest.json maps to a windows-rocm bundle
-# (gfx103X / gfx110X / gfx1150 / gfx1151 / gfx120X / gfx908 / gfx90a). Static because
-# parametrisation happens at import time and the routing tests below must stay offline;
-# the guard further down re-derives it from the published manifest and fails on drift, so
-# this is a checked mirror rather than a second hand-maintained source of truth.
+# The gfx archs the fork's llama-prebuilt-manifest.json maps to a windows-rocm bundle.
+# Static because parametrisation happens at import time and the routing tests below must
+# stay offline; the guard further down re-derives it from the published manifest and fails
+# on drift, so this is a checked mirror, not a second source of truth.
 _FORK_WINDOWS_ROCM_GFX = (
     "gfx908",
     "gfx90a",
@@ -1163,16 +1156,16 @@ _FORK_WINDOWS_ROCM_GFX = (
 def _published_fork_windows_rocm_artifacts():
     """The fork's windows-rocm artifact records, read the way an install reads them.
 
-    _download_host_resolved_release is the path a default fork install takes first
-    (iter_resolved_published_releases): it resolves the latest release off the download
-    host and hands llama-prebuilt-manifest.json to parse_published_release_bundle, so
-    these are the very records published_rocm_choice_for_host later matches a host gfx
-    against. No api.github.com call, hence no shared rate-limit bucket to exhaust.
+    _download_host_resolved_release is the path a default fork install takes first: it
+    resolves the latest release off the download host and hands llama-prebuilt-manifest.json
+    to parse_published_release_bundle, so these are the very records
+    published_rocm_choice_for_host later matches a host gfx against. No api.github.com call,
+    hence no shared rate-limit bucket to exhaust.
 
-    The manifest ships only as a release asset, so this is the one honest source: nothing
-    in-tree mirrors it. Only OSError (URLError / HTTPError / socket) and the release-side
-    PrebuiltFallback become a skip, so a sandboxed or offline run stays quiet while a
-    manifest that fetches but no longer parses still fails loudly."""
+    The manifest ships only as a release asset and nothing in-tree mirrors it, so this is
+    the one honest source. Only OSError and the release-side PrebuiltFallback become a skip,
+    so an offline run stays quiet while a manifest that fetches but no longer parses still
+    fails loudly."""
     try:
         resolved = ilp._download_host_resolved_release(FORK)
     except OSError as exc:
@@ -1192,15 +1185,14 @@ def _published_fork_windows_rocm_artifacts():
 
 
 def test_windows_hip_gfx_floor_covers_every_fork_windows_rocm_bundle():
-    # Derived from the published manifest rather than compared against a second literal:
-    # a gfx the fork builds but the floor omits bypasses the fork manifest, downgrading a
-    # hash-approved windows-rocm bundle to an unhashed upstream Vulkan build. A newly
-    # published arch must redden here instead of silently rerouting those hosts.
+    # Derived from the published manifest, not a second literal: a gfx the fork builds but
+    # the floor omits bypasses the fork manifest, downgrading a hash-approved windows-rocm
+    # bundle to an unhashed upstream Vulkan build. A newly published arch must redden here.
     tag, artifacts = _published_fork_windows_rocm_artifacts()
-    # published_rocm_choice_for_host serves a bundle on a concrete mapped_targets entry or
-    # on the umbrella gfx_target itself, so both spellings have to clear a floor. A
-    # gfx_target absent from its own mapped_targets is the family label (gfx110X); one
-    # present in it is a standalone bundle (gfx908) already counted as concrete.
+    # published_rocm_choice_for_host serves a bundle on a concrete mapped_targets entry or on
+    # the umbrella gfx_target itself, so both spellings must clear a floor. A gfx_target
+    # absent from its own mapped_targets is the family label (gfx110X); one present in it is
+    # a standalone bundle (gfx908) already counted as concrete.
     concrete = {target.lower() for artifact in artifacts for target in artifact.mapped_targets}
     labels = {
         artifact.gfx_target.lower()
@@ -1237,11 +1229,10 @@ def test_route_to_vulkan_prebuilt_keeps_every_fork_windows_rocm_arch(gfx, monkey
 
 
 def test_forwarded_gfx_does_not_undo_visible_device_auto_vulkan(monkeypatch):
-    # Mixed-AMD Windows host: GPU 0 = gfx1100 (HIP prebuilt exists), GPU 1 = gfx1010
-    # (RDNA1, none). With CUDA_VISIBLE_DEVICES=1 -- or a comma mask on the amd-smi
-    # branch -- setup.ps1 still resolves GPU 0 and forwards gfx1100 via --rocm-gfx.
-    # detect_host() correctly resolved the visible gfx1010, so folding the forward in
-    # must not reinstate gfx1100 and install a HIP bundle the visible GPU cannot run.
+    # Mixed-AMD Windows host: GPU 0 = gfx1100 (HIP prebuilt exists), GPU 1 = gfx1010 (none).
+    # Under CUDA_VISIBLE_DEVICES=1 setup.ps1 still resolves GPU 0 and forwards gfx1100, but
+    # detect_host() resolved the visible gfx1010, so folding the forward in must not
+    # reinstate gfx1100 and install a HIP bundle the visible GPU cannot run.
     monkeypatch.delenv("UNSLOTH_LLAMA_BACKEND", raising = False)
     monkeypatch.delenv("UNSLOTH_FORCE_VULKAN", raising = False)
     monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
@@ -1249,8 +1240,8 @@ def test_forwarded_gfx_does_not_undo_visible_device_auto_vulkan(monkeypatch):
     host = ilp._apply_host_overrides(host, override_rocm_gfx = "gfx1100")
     assert ilp._active_rocm_gfx_target(host) == "gfx1010"
     assert host.rocm_gfx_targets == ["gfx1100", "gfx1010"]
-    # gfx1100 is merely masked off, not absent, and Vulkan does not honour the HIP
-    # mask -- so the automatic fallback stays off and the HIP / fork path is kept.
+    # gfx1100 is masked off, not absent, and Vulkan does not honour the HIP mask, so the
+    # automatic fallback stays off and the HIP / fork path is kept.
     assert ilp._should_auto_vulkan_for_amd_windows(host, FORK) is False
     _routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
     assert repo == FORK
@@ -1258,14 +1249,13 @@ def test_forwarded_gfx_does_not_undo_visible_device_auto_vulkan(monkeypatch):
 
 
 def test_forwarded_gfx_absent_from_probe_keeps_the_physical_hip_card(monkeypatch):
-    # Mixed-AMD Windows host: GPU 0 = gfx1100 (HIP prebuilt exists), GPU 1 = gfx803
-    # (below the floor). CUDA_VISIBLE_DEVICES=1 reserves the gfx1100 for another
-    # workload, so detect_host() picks gfx803 as active but still reports both cards.
-    # setup then forwards a third arch the probe never saw -- a stale
-    # UNSLOTH_ROCM_GFX_ARCH, or its name-inference table reading the other card.
-    # That forward selects the HIP target; it must not delete the probe's inventory,
-    # or the floor check concludes no AMD GPU here reaches HIP and auto-routes to
-    # Vulkan, which ignores the HIP mask and enumerates the reserved gfx1100.
+    # Mixed-AMD Windows host: GPU 0 = gfx1100 (HIP prebuilt exists), GPU 1 = gfx803 (below
+    # the floor). CUDA_VISIBLE_DEVICES=1 reserves the gfx1100, so detect_host() picks gfx803
+    # as active but still reports both cards, and setup forwards a third arch the probe never
+    # saw (a stale env var, or name inference reading the other card). That forward selects
+    # the HIP target but must not delete the probe's inventory, or the floor check concludes
+    # no AMD GPU here reaches HIP and auto-routes to Vulkan, which ignores the HIP mask and
+    # enumerates the reserved gfx1100.
     monkeypatch.delenv("UNSLOTH_LLAMA_BACKEND", raising = False)
     monkeypatch.delenv("UNSLOTH_FORCE_VULKAN", raising = False)
     monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
@@ -1280,8 +1270,8 @@ def test_forwarded_gfx_absent_from_probe_keeps_the_physical_hip_card(monkeypatch
 
 
 def test_forwarded_gfx_absent_from_probe_keeps_a_single_probed_hip_card(monkeypatch):
-    # Same rule on a single-GPU box: a stale below-floor forward over a
-    # probe-confirmed gfx1100 must not auto-route that machine to Vulkan.
+    # Same rule on a single-GPU box: a stale below-floor forward over a probe-confirmed
+    # gfx1100 must not auto-route that machine to Vulkan.
     monkeypatch.delenv("UNSLOTH_LLAMA_BACKEND", raising = False)
     monkeypatch.delenv("UNSLOTH_FORCE_VULKAN", raising = False)
     monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
@@ -1304,10 +1294,9 @@ def test_forwarded_gfx_absent_from_probe_still_allows_explicit_vulkan(monkeypatc
 
 
 def test_forwarded_gfx_on_unprobed_host_still_auto_vulkans(monkeypatch):
-    # Negative control: a Windows driver-only AMD host runs no successful probe
-    # (no HIP SDK hipinfo, amd-smi suppressed), so --rocm-gfx is the ONLY source of
-    # the arch and there is no inventory to preserve. This is the #7357 path the
-    # feature exists for and it must keep falling back to Vulkan.
+    # Negative control: a driver-only AMD host runs no successful probe (no hipinfo, amd-smi
+    # suppressed), so --rocm-gfx is the ONLY source of the arch and there is no inventory to
+    # preserve. This is the #7357 path the feature exists for; it must still reach Vulkan.
     monkeypatch.delenv("UNSLOTH_LLAMA_BACKEND", raising = False)
     monkeypatch.delenv("UNSLOTH_FORCE_VULKAN", raising = False)
     monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
@@ -1321,9 +1310,8 @@ def test_forwarded_gfx_on_unprobed_host_still_auto_vulkans(monkeypatch):
 
 
 def test_forwarded_gfx_still_fills_an_unprobed_arch(monkeypatch):
-    # Negative control: on an amd-smi-only / driver-only host detect_host() reports
-    # no arch at all, so the forward is the only source and must still apply --
-    # that is what --rocm-gfx exists for.
+    # Negative control: on an amd-smi-only host detect_host() reports no arch, so the
+    # forward is the only source and must still apply.
     monkeypatch.delenv("UNSLOTH_LLAMA_BACKEND", raising = False)
     monkeypatch.delenv("UNSLOTH_FORCE_VULKAN", raising = False)
     monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
@@ -1411,9 +1399,8 @@ def _windows_arm64_host(**overrides):
     ],
 )
 def test_vulkan_opt_in_ignored_on_windows_arm64(monkeypatch, env, flag):
-    # ggml-org release.yml builds win-vulkan for x64 only (arm64 gets win-cpu-arm64 +
-    # win-opencl-adreno-arm64), so rewriting the host would only swap the published
-    # arm64 bundle for the upstream CPU one. Keep the published bundle.
+    # Upstream builds win-vulkan for x64 only (arm64 gets CPU + opencl-adreno), so rewriting
+    # the host would only swap the published arm64 bundle for the upstream CPU one.
     for name, value in env.items():
         monkeypatch.setenv(name, value)
     host = _windows_arm64_host()
@@ -1452,8 +1439,8 @@ def test_persisted_llama_backend_keeps_vulkan_for_a_vulkan_bundle(kind):
 
 @pytest.mark.parametrize("kind", ["windows-arm64", "windows-cpu", "linux-cpu", "windows-rocm"])
 def test_persisted_llama_backend_drops_vulkan_for_a_non_vulkan_bundle(kind):
-    # _plan_llama_phase re-asserts the marker's backend on every later update, so a
-    # Vulkan request that fell through to CPU must not leave a marker claiming Vulkan.
+    # _plan_llama_phase re-asserts the marker's backend on every later update, so a Vulkan
+    # request that fell through to CPU must not leave a marker claiming Vulkan.
     assert ilp.persisted_llama_backend("vulkan", _choice(kind)) is None
 
 
@@ -1462,8 +1449,8 @@ def test_persisted_llama_backend_passes_none_through():
 
 
 def test_marker_records_no_backend_when_vulkan_fell_back_to_cpu(tmp_path):
-    # End to end over write_prebuilt_metadata: describe the CPU attempt that actually
-    # won, so the next update re-detects instead of re-asserting Vulkan forever.
+    # End to end over write_prebuilt_metadata: describe the CPU attempt that actually won,
+    # so the next update re-detects instead of re-asserting Vulkan forever.
     checksums = ilp.ApprovedReleaseChecksums(
         repo = UPSTREAM,
         release_tag = "b9925",

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -1115,9 +1115,7 @@ def test_vulkan_opt_in_still_routes_on_windows_x64(monkeypatch):
     # Negative control for the arm64 guard: x64 keeps its Vulkan routing.
     monkeypatch.setenv("UNSLOTH_LLAMA_BACKEND", "vulkan")
     host = _windows_amd_host(rocm_gfx_target = "gfx1100", rocm_gfx_targets = ["gfx1100"])
-    _routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(
-        host, FORK, "pin", force_cpu = False
-    )
+    _routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
     assert repo == UPSTREAM
     assert persist == "vulkan"
 

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -936,10 +936,16 @@ def test_masked_probe_suppression_does_not_touch_non_amd_auto_paths(monkeypatch)
     # and predates this feature.
     monkeypatch.setenv("HIP_VISIBLE_DEVICES", "1")
     host = _host(
-        system = "Windows", is_windows = True, has_intel_gpu = True,
-        has_rocm = False, has_physical_nvidia = False, has_usable_nvidia = False,
+        system = "Windows",
+        is_windows = True,
+        has_intel_gpu = True,
+        has_rocm = False,
+        has_physical_nvidia = False,
+        has_usable_nvidia = False,
     )
-    _routed, repo, _tag, _persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
+    _routed, repo, _tag, _persist = ilp._route_to_vulkan_prebuilt(
+        host, FORK, "pin", force_cpu = False
+    )
     assert repo == UPSTREAM
 
 

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -1208,9 +1208,9 @@ def test_windows_hip_gfx_floor_covers_every_fork_windows_rocm_bundle():
         if artifact.gfx_target and artifact.gfx_target.lower() not in concrete
     }
     unfloored = sorted(concrete - ilp.WINDOWS_HIP_PREBUILT_GFX_TARGETS)
-    assert not unfloored, (
-        f"auto-Vulkan would steal windows-rocm archs published in {FORK}@{tag}: {unfloored}"
-    )
+    assert (
+        not unfloored
+    ), f"auto-Vulkan would steal windows-rocm archs published in {FORK}@{tag}: {unfloored}"
     unlabelled = sorted(labels - ilp.WINDOWS_ROCM_FAMILY_GFX_LABELS)
     assert not unlabelled, (
         f"update markers forward family labels {FORK}@{tag} publishes but "

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -1488,3 +1488,76 @@ def test_marker_records_no_backend_when_vulkan_fell_back_to_cpu(tmp_path):
     )
     marker = json.loads((tmp_path / "UNSLOTH_PREBUILT_INFO.json").read_text())
     assert marker["llama_backend"] == "vulkan"
+
+
+# UNSLOTH_LLAMA_CPP_BACKEND (setup.sh/setup.ps1, "auto"|"cpu") and
+# UNSLOTH_LLAMA_BACKEND (this module, a backend name) are different variables at
+# different layers, and both accept "cpu". setup translates its own =cpu into
+# --force-cpu to pin the CPU-only bundle on a GPU host, which is what keeps Intel
+# iGPU Vulkan crashes away (#7213). Vulkan is opt-in here, so no trigger it adds
+# may outrank that flag on any host.
+_SIM_PLATFORMS = {
+    # WSL presents as Linux to this resolver, so it rides the Linux row.
+    "Linux": dict(system = "Linux", is_windows = False, is_linux = True, is_macos = False,
+                  machine = "x86_64", is_x86_64 = True, is_arm64 = False),
+    "Windows": dict(system = "Windows", is_windows = True, is_linux = False, is_macos = False,
+                    machine = "amd64", is_x86_64 = True, is_arm64 = False),
+    "macOS": dict(system = "Darwin", is_windows = False, is_linux = False, is_macos = True,
+                  machine = "arm64", is_x86_64 = False, is_arm64 = True),
+}
+_SIM_GPUS = {
+    "nvidia": dict(has_physical_nvidia = True, has_usable_nvidia = True, has_rocm = False,
+                   has_intel_gpu = False, nvidia_smi = "/usr/bin/nvidia-smi",
+                   driver_cuda_version = "12.4", compute_caps = ["8.9"]),
+    "amd": dict(has_physical_nvidia = False, has_usable_nvidia = False, has_rocm = True,
+                has_intel_gpu = False, nvidia_smi = None, driver_cuda_version = None,
+                compute_caps = [], rocm_gfx_target = "gfx803", rocm_gfx_targets = ["gfx803"]),
+    "intel": dict(has_physical_nvidia = False, has_usable_nvidia = False, has_rocm = False,
+                  has_intel_gpu = True, nvidia_smi = None, driver_cuda_version = None,
+                  compute_caps = []),
+    "cpu_only": dict(has_physical_nvidia = False, has_usable_nvidia = False, has_rocm = False,
+                     has_intel_gpu = False, nvidia_smi = None, driver_cuda_version = None,
+                     compute_caps = []),
+}
+
+
+def _sim_host(platform_name, gpu_name):
+    base = dict(visible_cuda_devices = None)
+    base.update(_SIM_PLATFORMS[platform_name])
+    base.update(_SIM_GPUS[gpu_name])
+    return ilp.HostInfo(**base)
+
+
+@pytest.mark.parametrize("platform_name", sorted(_SIM_PLATFORMS))
+@pytest.mark.parametrize("gpu_name", sorted(_SIM_GPUS))
+@pytest.mark.parametrize("backend_env", [None, "vulkan", "hip", "rocm", "cpu"])
+def test_forced_cpu_outranks_every_vulkan_trigger(
+    monkeypatch, platform_name, gpu_name, backend_env
+):
+    """A deliberate CPU install stays CPU on every host, whatever asks for Vulkan."""
+    monkeypatch.delenv("UNSLOTH_FORCE_VULKAN", raising = False)
+    if backend_env is None:
+        monkeypatch.delenv("UNSLOTH_LLAMA_BACKEND", raising = False)
+    else:
+        monkeypatch.setenv("UNSLOTH_LLAMA_BACKEND", backend_env)
+    # The legacy switch too, so a stale one cannot smuggle Vulkan past --force-cpu.
+    monkeypatch.setenv("UNSLOTH_FORCE_VULKAN", "1")
+
+    repo, tag = "unslothai/llama.cpp-prebuilt", "latest"
+    _, out_repo, _, persist = ilp._route_to_vulkan_prebuilt(
+        _sim_host(platform_name, gpu_name), repo, tag,
+        force_cpu = True, llama_backend = "vulkan",
+    )
+    assert out_repo == repo, (platform_name, gpu_name, backend_env)
+    assert persist is None, (platform_name, gpu_name, backend_env)
+
+
+def test_the_forced_cpu_guard_is_not_vacuous():
+    """The same host DOES take Vulkan once the CPU pin is gone, or the check above
+    would pass on a resolver that had stopped routing to Vulkan entirely."""
+    repo, tag = "unslothai/llama.cpp-prebuilt", "latest"
+    _, out_repo, _, persist = ilp._route_to_vulkan_prebuilt(
+        _sim_host("Linux", "amd"), repo, tag,
+        force_cpu = False, llama_backend = "vulkan",
+    )
+    assert out_repo != repo or persist == "vulkan"

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -979,10 +979,20 @@ def test_route_to_vulkan_prebuilt_explicit_opt_in_overrides_hidden_nvidia(monkey
 # bundle (gfx103X / gfx110X / gfx1150 / gfx1151 / gfx120X / gfx908 / gfx90a).
 # Auto-Vulkan must never steal a host one of these already covers.
 _FORK_WINDOWS_ROCM_GFX = (
-    "gfx908", "gfx90a",
-    "gfx1030", "gfx1031", "gfx1032", "gfx1034",
-    "gfx1100", "gfx1101", "gfx1102", "gfx1103",
-    "gfx1150", "gfx1151", "gfx1200", "gfx1201",
+    "gfx908",
+    "gfx90a",
+    "gfx1030",
+    "gfx1031",
+    "gfx1032",
+    "gfx1034",
+    "gfx1100",
+    "gfx1101",
+    "gfx1102",
+    "gfx1103",
+    "gfx1150",
+    "gfx1151",
+    "gfx1200",
+    "gfx1201",
 )
 
 
@@ -1028,9 +1038,7 @@ def test_explicit_backend_beats_legacy_force_vulkan(monkeypatch):
     assert ilp.resolved_llama_backend() == "hip"
     assert ilp.force_vulkan_requested() is False
     host = _windows_amd_host(rocm_gfx_target = "gfx1100", rocm_gfx_targets = ["gfx1100"])
-    _routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(
-        host, FORK, "pin", force_cpu = False
-    )
+    _routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
     assert repo == FORK
     assert persist is None
 

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -847,16 +847,76 @@ def test_route_to_vulkan_prebuilt_keeps_hip_when_one_gpu_is_supported():
     assert persist is None
 
 
-def test_route_to_vulkan_prebuilt_auto_fallback_uses_active_gfx_only():
-    # HIP_VISIBLE_DEVICES can hide a supported dGPU, so follow the active arch.
+def test_route_to_vulkan_prebuilt_auto_fallback_skips_hip_masked_hosts():
+    # HIP_VISIBLE_DEVICES / ROCR_VISIBLE_DEVICES can hide a HIP-capable dGPU, but the
+    # Vulkan runtime honours neither (it enumerates via GGML_VK_VISIBLE_DEVICES and
+    # Vulkan ordinals), so auto-routing here would let the installed backend grab the
+    # gfx1201 the user deliberately masked off. Stay on the HIP / fork / source path.
     host = _windows_amd_host(
         rocm_gfx_target = "gfx803",
         rocm_gfx_targets = ["gfx1201", "gfx803"],
     )
     routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
+    assert repo == FORK
+    assert persist is None
+    assert routed is host
+
+
+def test_route_to_vulkan_prebuilt_auto_fallback_when_no_amd_gpu_reaches_floor():
+    # Every physical AMD device is below the HIP prebuilt floor, so no card can be
+    # exposed to HIP and the #7357 auto-Vulkan fallback still fires.
+    host = _windows_amd_host(
+        rocm_gfx_target = "gfx900",
+        rocm_gfx_targets = ["gfx803", "gfx900"],
+    )
+    routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
     assert repo == UPSTREAM
     assert persist == "vulkan"
     assert routed.has_rocm is False
+
+
+def test_route_to_vulkan_prebuilt_hip_masked_host_still_honours_explicit_optin(monkeypatch):
+    # The mask guard only suppresses the AUTOMATIC fallback; an explicit opt-in is
+    # the user taking responsibility for the Vulkan device mask themselves.
+    monkeypatch.delenv("UNSLOTH_FORCE_VULKAN", raising = False)
+    host = _windows_amd_host(
+        rocm_gfx_target = "gfx803",
+        rocm_gfx_targets = ["gfx1201", "gfx803"],
+    )
+    _routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(
+        host, FORK, "pin", force_cpu = False, llama_backend = "vulkan"
+    )
+    assert repo == UPSTREAM
+    assert persist == "vulkan"
+
+
+def test_auto_vulkan_is_repository_specific_for_fork_only_gfx():
+    # gfx1034 is served only by the fork's gfx103X bundle. ggml-org's windows-hip
+    # radeon build does not target it, and direct_upstream_release_plan() offers
+    # win-hip then CPU with no Vulkan branch, so the predicate must answer per repo.
+    host = _windows_amd_host(rocm_gfx_target = "gfx1034", rocm_gfx_targets = ["gfx1034"])
+    assert ilp._should_auto_vulkan_for_amd_windows(host, FORK) is False
+    assert ilp._should_auto_vulkan_for_amd_windows(host, UPSTREAM) is True
+    # An arch upstream really does build stays on HIP for both repos.
+    supported = _windows_amd_host(rocm_gfx_target = "gfx1100", rocm_gfx_targets = ["gfx1100"])
+    assert ilp._should_auto_vulkan_for_amd_windows(supported, FORK) is False
+    assert ilp._should_auto_vulkan_for_amd_windows(supported, UPSTREAM) is False
+    # Family labels resolve to members both repos build, so neither needs Vulkan.
+    family = _windows_amd_host(rocm_gfx_target = "gfx110X", rocm_gfx_targets = ["gfx110X"])
+    assert ilp._should_auto_vulkan_for_amd_windows(family, UPSTREAM) is False
+
+
+def test_upstream_windows_hip_targets_are_a_subset_of_the_combined_floor():
+    # The combined floor must stay a superset, else auto-Vulkan would steal a host
+    # upstream already builds for.
+    assert ilp.UPSTREAM_WINDOWS_HIP_GFX_TARGETS <= ilp.WINDOWS_HIP_PREBUILT_GFX_TARGETS
+    # The fork-only extras are exactly the archs that must route to Vulkan upstream.
+    assert ilp.WINDOWS_HIP_PREBUILT_GFX_TARGETS - ilp.UPSTREAM_WINDOWS_HIP_GFX_TARGETS == {
+        "gfx908",
+        "gfx90a",
+        "gfx1034",
+        "gfx1103",
+    }
 
 
 def test_route_to_vulkan_prebuilt_unknown_gfx_does_not_auto_fallback():
@@ -1023,10 +1083,13 @@ def test_forwarded_gfx_does_not_undo_visible_device_auto_vulkan(monkeypatch):
     host = _windows_amd_host(rocm_gfx_target = "gfx1010", rocm_gfx_targets = ["gfx1100", "gfx1010"])
     host = ilp._apply_host_overrides(host, override_rocm_gfx = "gfx1100")
     assert ilp._active_rocm_gfx_target(host) == "gfx1010"
-    assert ilp._should_auto_vulkan_for_amd_windows(host) is True
+    assert host.rocm_gfx_targets == ["gfx1100", "gfx1010"]
+    # gfx1100 is merely masked off, not absent, and Vulkan does not honour the HIP
+    # mask -- so the automatic fallback stays off and the HIP / fork path is kept.
+    assert ilp._should_auto_vulkan_for_amd_windows(host, FORK) is False
     _routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
-    assert repo == UPSTREAM
-    assert persist == "vulkan"
+    assert repo == FORK
+    assert persist is None
 
 
 def test_forwarded_gfx_still_fills_an_unprobed_arch(monkeypatch):

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -6,7 +6,9 @@ by default; --published-repo overrides).
 
 These back the in-app update for source-build (markerless) installs: the backend
 asks the installer whether an official prebuilt exists for this host without
-downloading. Network and host detection are stubbed; no GPU or internet needed.
+downloading. Network and host detection are stubbed; no GPU or internet needed. The one
+exception is the windows-rocm floor guard, which reads the fork's published manifest
+because nothing in-tree mirrors it, and skips when that release is unreachable.
 """
 
 from __future__ import annotations
@@ -1136,7 +1138,10 @@ def test_route_to_vulkan_prebuilt_explicit_opt_in_overrides_hidden_nvidia(monkey
 
 
 # The gfx archs the fork's llama-prebuilt-manifest.json maps to a windows-rocm bundle
-# (gfx103X / gfx110X / gfx1150 / gfx1151 / gfx120X / gfx908 / gfx90a).
+# (gfx103X / gfx110X / gfx1150 / gfx1151 / gfx120X / gfx908 / gfx90a). Static because
+# parametrisation happens at import time and the routing tests below must stay offline;
+# the guard further down re-derives it from the published manifest and fails on drift, so
+# this is a checked mirror rather than a second hand-maintained source of truth.
 _FORK_WINDOWS_ROCM_GFX = (
     "gfx908",
     "gfx90a",
@@ -1155,13 +1160,68 @@ _FORK_WINDOWS_ROCM_GFX = (
 )
 
 
-def test_windows_hip_gfx_floor_covers_every_fork_windows_rocm_bundle():
-    # A gfx missing here bypasses the fork manifest, downgrading a hash-approved
-    # windows-rocm bundle to an unhashed upstream Vulkan build. Keep both in sync.
-    missing = [
-        gfx for gfx in _FORK_WINDOWS_ROCM_GFX if gfx not in ilp.WINDOWS_HIP_PREBUILT_GFX_TARGETS
+def _published_fork_windows_rocm_artifacts():
+    """The fork's windows-rocm artifact records, read the way an install reads them.
+
+    _download_host_resolved_release is the path a default fork install takes first
+    (iter_resolved_published_releases): it resolves the latest release off the download
+    host and hands llama-prebuilt-manifest.json to parse_published_release_bundle, so
+    these are the very records published_rocm_choice_for_host later matches a host gfx
+    against. No api.github.com call, hence no shared rate-limit bucket to exhaust.
+
+    The manifest ships only as a release asset, so this is the one honest source: nothing
+    in-tree mirrors it. Only OSError (URLError / HTTPError / socket) and the release-side
+    PrebuiltFallback become a skip, so a sandboxed or offline run stays quiet while a
+    manifest that fetches but no longer parses still fails loudly."""
+    try:
+        resolved = ilp._download_host_resolved_release(FORK)
+    except OSError as exc:
+        pytest.skip(f"{FORK} release manifest unreachable: {exc}")
+    except ilp.PrebuiltFallback as exc:
+        pytest.skip(f"{FORK} latest release was rejected before its manifest parsed: {exc}")
+    if resolved is None:
+        pytest.skip(f"{FORK} published no resolvable latest release")
+    tag = resolved.bundle.release_tag
+    artifacts = [
+        artifact
+        for artifact in resolved.bundle.artifacts
+        if artifact.install_kind == "windows-rocm"
     ]
-    assert not missing, f"auto-Vulkan would steal fork windows-rocm archs: {missing}"
+    assert artifacts, f"{FORK}@{tag} manifest listed no windows-rocm artifacts"
+    return tag, artifacts
+
+
+def test_windows_hip_gfx_floor_covers_every_fork_windows_rocm_bundle():
+    # Derived from the published manifest rather than compared against a second literal:
+    # a gfx the fork builds but the floor omits bypasses the fork manifest, downgrading a
+    # hash-approved windows-rocm bundle to an unhashed upstream Vulkan build. A newly
+    # published arch must redden here instead of silently rerouting those hosts.
+    tag, artifacts = _published_fork_windows_rocm_artifacts()
+    # published_rocm_choice_for_host serves a bundle on a concrete mapped_targets entry or
+    # on the umbrella gfx_target itself, so both spellings have to clear a floor. A
+    # gfx_target absent from its own mapped_targets is the family label (gfx110X); one
+    # present in it is a standalone bundle (gfx908) already counted as concrete.
+    concrete = {target.lower() for artifact in artifacts for target in artifact.mapped_targets}
+    labels = {
+        artifact.gfx_target.lower()
+        for artifact in artifacts
+        if artifact.gfx_target and artifact.gfx_target.lower() not in concrete
+    }
+    unfloored = sorted(concrete - ilp.WINDOWS_HIP_PREBUILT_GFX_TARGETS)
+    assert not unfloored, (
+        f"auto-Vulkan would steal windows-rocm archs published in {FORK}@{tag}: {unfloored}"
+    )
+    unlabelled = sorted(labels - ilp.WINDOWS_ROCM_FAMILY_GFX_LABELS)
+    assert not unlabelled, (
+        f"update markers forward family labels {FORK}@{tag} publishes but "
+        f"WINDOWS_ROCM_FAMILY_GFX_LABELS omits: {unlabelled}"
+    )
+    # Keep the import-time tuple the offline routing tests parametrise on an exact mirror.
+    assert set(_FORK_WINDOWS_ROCM_GFX) == concrete, (
+        f"_FORK_WINDOWS_ROCM_GFX drifted from {FORK}@{tag}: "
+        f"gained {sorted(concrete - set(_FORK_WINDOWS_ROCM_GFX))}, "
+        f"lost {sorted(set(_FORK_WINDOWS_ROCM_GFX) - concrete)}"
+    )
 
 
 @pytest.mark.parametrize("gfx", _FORK_WINDOWS_ROCM_GFX)

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -988,6 +988,29 @@ def test_auto_vulkan_is_repository_specific_for_fork_only_gfx():
     assert ilp._should_auto_vulkan_for_amd_windows(family, UPSTREAM) is False
 
 
+@pytest.mark.parametrize(
+    "repo", ["acme/llama.cpp-mirror", "GGML-ORG/llama.cpp", "unslothAI/llama.cpp"]
+)
+def test_fork_only_gfx_coverage_is_not_granted_to_other_repos(repo):
+    # Only the fork is planned from a manifest: resolve_simple_install_release_plans()
+    # compares == DEFAULT_PUBLISHED_REPO and sends everything else, mirrors and
+    # differently cased spellings alike, to direct_upstream_release_plan(). Granting a
+    # fork-only arch upstream coverage there lands it on win-hip-radeon or CPU instead
+    # of Vulkan, so the predicate must gate on the fork rather than exempt one name.
+    host = _windows_amd_host(rocm_gfx_target = "gfx1034", rocm_gfx_targets = ["gfx1034"])
+    assert ilp._should_auto_vulkan_for_amd_windows(host, repo) is True
+    supported = _windows_amd_host(rocm_gfx_target = "gfx1100", rocm_gfx_targets = ["gfx1100"])
+    assert ilp._should_auto_vulkan_for_amd_windows(supported, repo) is False
+
+
+@pytest.mark.parametrize("repo", [None, ""])
+def test_empty_published_repo_gets_fork_coverage(repo):
+    # Negative control: the resolver defaults an empty repo to the fork, so the
+    # predicate must too, or the default install path loses its fork-only archs.
+    host = _windows_amd_host(rocm_gfx_target = "gfx1034", rocm_gfx_targets = ["gfx1034"])
+    assert ilp._should_auto_vulkan_for_amd_windows(host, repo) is False
+
+
 def test_upstream_windows_hip_targets_are_a_subset_of_the_combined_floor():
     # The combined floor must stay a superset, else auto-Vulkan would steal a host
     # upstream already builds for.

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -907,27 +907,35 @@ def test_auto_vulkan_declines_when_a_hip_device_mask_filtered_the_probe(mask_env
 
 
 @pytest.mark.parametrize("mask_value", ["", "  ", "-1"])
-def test_auto_vulkan_still_fires_when_the_mask_hides_every_amd_gpu(mask_value, monkeypatch):
-    # Negative control: an empty / "-1" mask is not a partial view, it hides every AMD
-    # GPU, and _pick_rocm_gfx_target already reports that as no active target. Such a
-    # value must not be read as "the probe list may be incomplete" and suppress the
-    # fallback on a host whose arch came from --rocm-gfx.
+def test_auto_vulkan_declines_when_the_mask_hides_every_amd_gpu(mask_value, monkeypatch):
+    # An all-hiding mask is the strongest form of the same signal, not an exemption.
+    # detect_host() resolves no arch under it, but a forwarded --rocm-gfx still
+    # reconstructs one (setup infers the arch from the display-adapter name, which no
+    # HIP mask touches), so auto-routing here would hand Vulkan every AMD GPU the user
+    # deliberately hid from HIP.
     monkeypatch.setenv("HIP_VISIBLE_DEVICES", mask_value)
-    host = _windows_amd_host(rocm_gfx_target = "gfx803", rocm_gfx_targets = ["gfx803"])
-    assert ilp._should_auto_vulkan_for_amd_windows(host, FORK) is True
-    _routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
-    assert repo == UPSTREAM
-    assert persist == "vulkan"
+    host = _windows_amd_host(rocm_gfx_target = None, rocm_gfx_targets = [])
+    host = ilp._apply_host_overrides(host, override_rocm_gfx = "gfx803")
+    assert ilp._active_rocm_gfx_target(host) == "gfx803"
+    assert ilp._should_auto_vulkan_for_amd_windows(host, FORK) is False
+    routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
+    assert routed is host
+    assert repo == FORK
+    assert persist is None
 
 
-def test_hip_device_mask_check_takes_the_first_variable_that_is_set(monkeypatch):
-    # Same first-var-wins order as _pick_rocm_gfx_target, which reads the identical
-    # three: HIP_VISIBLE_DEVICES="" means no AMD GPU visible even with a later
-    # CUDA_VISIBLE_DEVICES set, so the two must not disagree about the host.
-    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "")
-    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "1")
+def test_hip_device_mask_check_is_presence_not_value(monkeypatch):
+    # Presence is the whole test: any value means the HIP view of the GPUs is not the
+    # physical one, and no value can be read as "the probe saw everything".
     assert ilp._hip_visible_device_mask_set() is False
-    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "1")
+    for value in ("", "  ", "-1", "0", "1", "0,1"):
+        monkeypatch.setenv("HIP_VISIBLE_DEVICES", value)
+        assert ilp._hip_visible_device_mask_set() is True, value
+    monkeypatch.delenv("HIP_VISIBLE_DEVICES")
+    monkeypatch.setenv("ROCR_VISIBLE_DEVICES", "0")
+    assert ilp._hip_visible_device_mask_set() is True
+    monkeypatch.delenv("ROCR_VISIBLE_DEVICES")
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
     assert ilp._hip_visible_device_mask_set() is True
 
 

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -1092,6 +1092,69 @@ def test_forwarded_gfx_does_not_undo_visible_device_auto_vulkan(monkeypatch):
     assert persist is None
 
 
+def test_forwarded_gfx_absent_from_probe_keeps_the_physical_hip_card(monkeypatch):
+    # Mixed-AMD Windows host: GPU 0 = gfx1100 (HIP prebuilt exists), GPU 1 = gfx803
+    # (below the floor). CUDA_VISIBLE_DEVICES=1 reserves the gfx1100 for another
+    # workload, so detect_host() picks gfx803 as active but still reports both cards.
+    # setup then forwards a third arch the probe never saw -- a stale
+    # UNSLOTH_ROCM_GFX_ARCH, or its name-inference table reading the other card.
+    # That forward selects the HIP target; it must not delete the probe's inventory,
+    # or the floor check concludes no AMD GPU here reaches HIP and auto-routes to
+    # Vulkan, which ignores the HIP mask and enumerates the reserved gfx1100.
+    monkeypatch.delenv("UNSLOTH_LLAMA_BACKEND", raising = False)
+    monkeypatch.delenv("UNSLOTH_FORCE_VULKAN", raising = False)
+    monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
+    host = _windows_amd_host(rocm_gfx_target = "gfx803", rocm_gfx_targets = ["gfx1100", "gfx803"])
+    host = ilp._apply_host_overrides(host, override_rocm_gfx = "gfx900")
+    assert ilp._active_rocm_gfx_target(host) == "gfx900"
+    assert host.rocm_gfx_targets == ["gfx1100", "gfx803", "gfx900"]
+    assert ilp._should_auto_vulkan_for_amd_windows(host, FORK) is False
+    _routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
+    assert repo == FORK
+    assert persist is None
+
+
+def test_forwarded_gfx_absent_from_probe_keeps_a_single_probed_hip_card(monkeypatch):
+    # Same rule on a single-GPU box: a stale below-floor forward over a
+    # probe-confirmed gfx1100 must not auto-route that machine to Vulkan.
+    monkeypatch.delenv("UNSLOTH_LLAMA_BACKEND", raising = False)
+    monkeypatch.delenv("UNSLOTH_FORCE_VULKAN", raising = False)
+    monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
+    host = _windows_amd_host(rocm_gfx_target = "gfx1100", rocm_gfx_targets = ["gfx1100"])
+    host = ilp._apply_host_overrides(host, override_rocm_gfx = "gfx803")
+    assert ilp._active_rocm_gfx_target(host) == "gfx803"
+    assert host.rocm_gfx_targets == ["gfx1100", "gfx803"]
+    assert ilp._should_auto_vulkan_for_amd_windows(host, FORK) is False
+
+
+def test_forwarded_gfx_absent_from_probe_still_allows_explicit_vulkan(monkeypatch):
+    # The physical-inventory rule gates the AUTO path only; naming the backend wins.
+    monkeypatch.setenv("UNSLOTH_LLAMA_BACKEND", "vulkan")
+    monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
+    host = _windows_amd_host(rocm_gfx_target = "gfx1100", rocm_gfx_targets = ["gfx1100"])
+    host = ilp._apply_host_overrides(host, override_rocm_gfx = "gfx803")
+    _routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
+    assert repo == UPSTREAM
+    assert persist == "vulkan"
+
+
+def test_forwarded_gfx_on_unprobed_host_still_auto_vulkans(monkeypatch):
+    # Negative control: a Windows driver-only AMD host runs no successful probe
+    # (no HIP SDK hipinfo, amd-smi suppressed), so --rocm-gfx is the ONLY source of
+    # the arch and there is no inventory to preserve. This is the #7357 path the
+    # feature exists for and it must keep falling back to Vulkan.
+    monkeypatch.delenv("UNSLOTH_LLAMA_BACKEND", raising = False)
+    monkeypatch.delenv("UNSLOTH_FORCE_VULKAN", raising = False)
+    monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
+    host = _windows_amd_host(rocm_gfx_target = None, rocm_gfx_targets = [])
+    host = ilp._apply_host_overrides(host, override_rocm_gfx = "gfx803")
+    assert host.rocm_gfx_targets == ["gfx803"]
+    assert ilp._should_auto_vulkan_for_amd_windows(host, FORK) is True
+    _routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
+    assert repo == UPSTREAM
+    assert persist == "vulkan"
+
+
 def test_forwarded_gfx_still_fills_an_unprobed_arch(monkeypatch):
     # Negative control: on an amd-smi-only / driver-only host detect_host() reports
     # no arch at all, so the forward is the only source and must still apply --

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -1498,26 +1498,73 @@ def test_marker_records_no_backend_when_vulkan_fell_back_to_cpu(tmp_path):
 # may outrank that flag on any host.
 _SIM_PLATFORMS = {
     # WSL presents as Linux to this resolver, so it rides the Linux row.
-    "Linux": dict(system = "Linux", is_windows = False, is_linux = True, is_macos = False,
-                  machine = "x86_64", is_x86_64 = True, is_arm64 = False),
-    "Windows": dict(system = "Windows", is_windows = True, is_linux = False, is_macos = False,
-                    machine = "amd64", is_x86_64 = True, is_arm64 = False),
-    "macOS": dict(system = "Darwin", is_windows = False, is_linux = False, is_macos = True,
-                  machine = "arm64", is_x86_64 = False, is_arm64 = True),
+    "Linux": dict(
+        system = "Linux",
+        is_windows = False,
+        is_linux = True,
+        is_macos = False,
+        machine = "x86_64",
+        is_x86_64 = True,
+        is_arm64 = False,
+    ),
+    "Windows": dict(
+        system = "Windows",
+        is_windows = True,
+        is_linux = False,
+        is_macos = False,
+        machine = "amd64",
+        is_x86_64 = True,
+        is_arm64 = False,
+    ),
+    "macOS": dict(
+        system = "Darwin",
+        is_windows = False,
+        is_linux = False,
+        is_macos = True,
+        machine = "arm64",
+        is_x86_64 = False,
+        is_arm64 = True,
+    ),
 }
 _SIM_GPUS = {
-    "nvidia": dict(has_physical_nvidia = True, has_usable_nvidia = True, has_rocm = False,
-                   has_intel_gpu = False, nvidia_smi = "/usr/bin/nvidia-smi",
-                   driver_cuda_version = "12.4", compute_caps = ["8.9"]),
-    "amd": dict(has_physical_nvidia = False, has_usable_nvidia = False, has_rocm = True,
-                has_intel_gpu = False, nvidia_smi = None, driver_cuda_version = None,
-                compute_caps = [], rocm_gfx_target = "gfx803", rocm_gfx_targets = ["gfx803"]),
-    "intel": dict(has_physical_nvidia = False, has_usable_nvidia = False, has_rocm = False,
-                  has_intel_gpu = True, nvidia_smi = None, driver_cuda_version = None,
-                  compute_caps = []),
-    "cpu_only": dict(has_physical_nvidia = False, has_usable_nvidia = False, has_rocm = False,
-                     has_intel_gpu = False, nvidia_smi = None, driver_cuda_version = None,
-                     compute_caps = []),
+    "nvidia": dict(
+        has_physical_nvidia = True,
+        has_usable_nvidia = True,
+        has_rocm = False,
+        has_intel_gpu = False,
+        nvidia_smi = "/usr/bin/nvidia-smi",
+        driver_cuda_version = "12.4",
+        compute_caps = ["8.9"],
+    ),
+    "amd": dict(
+        has_physical_nvidia = False,
+        has_usable_nvidia = False,
+        has_rocm = True,
+        has_intel_gpu = False,
+        nvidia_smi = None,
+        driver_cuda_version = None,
+        compute_caps = [],
+        rocm_gfx_target = "gfx803",
+        rocm_gfx_targets = ["gfx803"],
+    ),
+    "intel": dict(
+        has_physical_nvidia = False,
+        has_usable_nvidia = False,
+        has_rocm = False,
+        has_intel_gpu = True,
+        nvidia_smi = None,
+        driver_cuda_version = None,
+        compute_caps = [],
+    ),
+    "cpu_only": dict(
+        has_physical_nvidia = False,
+        has_usable_nvidia = False,
+        has_rocm = False,
+        has_intel_gpu = False,
+        nvidia_smi = None,
+        driver_cuda_version = None,
+        compute_caps = [],
+    ),
 }
 
 
@@ -1545,8 +1592,11 @@ def test_forced_cpu_outranks_every_vulkan_trigger(
 
     repo, tag = "unslothai/llama.cpp-prebuilt", "latest"
     _, out_repo, _, persist = ilp._route_to_vulkan_prebuilt(
-        _sim_host(platform_name, gpu_name), repo, tag,
-        force_cpu = True, llama_backend = "vulkan",
+        _sim_host(platform_name, gpu_name),
+        repo,
+        tag,
+        force_cpu = True,
+        llama_backend = "vulkan",
     )
     assert out_repo == repo, (platform_name, gpu_name, backend_env)
     assert persist is None, (platform_name, gpu_name, backend_env)
@@ -1557,7 +1607,10 @@ def test_the_forced_cpu_guard_is_not_vacuous():
     would pass on a resolver that had stopped routing to Vulkan entirely."""
     repo, tag = "unslothai/llama.cpp-prebuilt", "latest"
     _, out_repo, _, persist = ilp._route_to_vulkan_prebuilt(
-        _sim_host("Linux", "amd"), repo, tag,
-        force_cpu = False, llama_backend = "vulkan",
+        _sim_host("Linux", "amd"),
+        repo,
+        tag,
+        force_cpu = False,
+        llama_backend = "vulkan",
     )
     assert out_repo != repo or persist == "vulkan"

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -980,7 +980,9 @@ def test_auto_vulkan_is_repository_specific_for_fork_only_gfx():
     supported = _windows_amd_host(rocm_gfx_target = "gfx1100", rocm_gfx_targets = ["gfx1100"])
     assert ilp._should_auto_vulkan_for_amd_windows(supported, FORK) is False
     assert ilp._should_auto_vulkan_for_amd_windows(supported, UPSTREAM) is False
-    # Family labels resolve to members both repos build, so neither needs Vulkan.
+    # A family label is a bundle name, not an arch: upstream builds every member but
+    # gfx1034 / gfx1103, and the label cannot say which card this is, so it stays on HIP
+    # rather than moving the covered members onto Vulkan.
     family = _windows_amd_host(rocm_gfx_target = "gfx110X", rocm_gfx_targets = ["gfx110X"])
     assert ilp._should_auto_vulkan_for_amd_windows(family, UPSTREAM) is False
 

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -32,6 +32,19 @@ FORK = ilp.DEFAULT_PUBLISHED_REPO  # unslothai/llama.cpp
 UPSTREAM = ilp.UPSTREAM_REPO  # ggml-org/llama.cpp
 
 
+@pytest.fixture(autouse = True)
+def _no_ambient_hip_device_mask(monkeypatch):
+    """These tests describe hosts through HostInfo, not through the environment.
+
+    A HIP visible-device mask inherited from the shell (an ML box commonly exports
+    CUDA_VISIBLE_DEVICES) means the arch probe saw only part of the GPUs, which the
+    Windows auto-Vulkan guard treats as an unknown physical inventory. Clear all
+    three so a host is described by its fields alone; the tests that are about the
+    mask set it explicitly."""
+    for _env in ("HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"):
+        monkeypatch.delenv(_env, raising = False)
+
+
 def _host(**kw):
     base = dict(
         system = "Linux",
@@ -873,6 +886,61 @@ def test_route_to_vulkan_prebuilt_auto_fallback_when_no_amd_gpu_reaches_floor():
     assert repo == UPSTREAM
     assert persist == "vulkan"
     assert routed.has_rocm is False
+
+
+@pytest.mark.parametrize(
+    "mask_env", ["HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"]
+)
+def test_auto_vulkan_declines_when_a_hip_device_mask_filtered_the_probe(mask_env, monkeypatch):
+    # hipinfo is a HIP application, so under a visible-device mask it enumerates only
+    # the devices that survived it: rocm_gfx_targets is then the VISIBLE set and a
+    # HIP-capable card can be masked out of view entirely. "No AMD GPU on this box
+    # reaches the floor" is unprovable there, and Vulkan honours none of these masks,
+    # so the automatic fallback must decline rather than hand it the reserved card.
+    monkeypatch.setenv(mask_env, "1")
+    host = _windows_amd_host(rocm_gfx_target = "gfx803", rocm_gfx_targets = ["gfx803"])
+    assert ilp._should_auto_vulkan_for_amd_windows(host, FORK) is False
+    routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
+    assert routed is host
+    assert repo == FORK
+    assert persist is None
+
+
+@pytest.mark.parametrize("mask_value", ["", "  ", "-1"])
+def test_auto_vulkan_still_fires_when_the_mask_hides_every_amd_gpu(mask_value, monkeypatch):
+    # Negative control: an empty / "-1" mask is not a partial view, it hides every AMD
+    # GPU, and _pick_rocm_gfx_target already reports that as no active target. Such a
+    # value must not be read as "the probe list may be incomplete" and suppress the
+    # fallback on a host whose arch came from --rocm-gfx.
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", mask_value)
+    host = _windows_amd_host(rocm_gfx_target = "gfx803", rocm_gfx_targets = ["gfx803"])
+    assert ilp._should_auto_vulkan_for_amd_windows(host, FORK) is True
+    _routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
+    assert repo == UPSTREAM
+    assert persist == "vulkan"
+
+
+def test_hip_device_mask_check_takes_the_first_variable_that_is_set(monkeypatch):
+    # Same first-var-wins order as _pick_rocm_gfx_target, which reads the identical
+    # three: HIP_VISIBLE_DEVICES="" means no AMD GPU visible even with a later
+    # CUDA_VISIBLE_DEVICES set, so the two must not disagree about the host.
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "")
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "1")
+    assert ilp._hip_visible_device_mask_set() is False
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "1")
+    assert ilp._hip_visible_device_mask_set() is True
+
+
+def test_masked_probe_suppression_does_not_touch_non_amd_auto_paths(monkeypatch):
+    # The mask says nothing about an Intel iGPU, whose Vulkan auto path is unrelated
+    # and predates this feature.
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "1")
+    host = _host(
+        system = "Windows", is_windows = True, has_intel_gpu = True,
+        has_rocm = False, has_physical_nvidia = False, has_usable_nvidia = False,
+    )
+    _routed, repo, _tag, _persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
+    assert repo == UPSTREAM
 
 
 def test_route_to_vulkan_prebuilt_hip_masked_host_still_honours_explicit_optin(monkeypatch):

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -1011,6 +1011,46 @@ def test_route_to_vulkan_prebuilt_keeps_every_fork_windows_rocm_arch(gfx, monkey
     assert persist is None
 
 
+def test_forwarded_gfx_does_not_undo_visible_device_auto_vulkan(monkeypatch):
+    # Mixed-AMD Windows host: GPU 0 = gfx1100 (HIP prebuilt exists), GPU 1 = gfx1010
+    # (RDNA1, none). With CUDA_VISIBLE_DEVICES=1 -- or a comma mask on the amd-smi
+    # branch -- setup.ps1 still resolves GPU 0 and forwards gfx1100 via --rocm-gfx.
+    # detect_host() correctly resolved the visible gfx1010, so folding the forward in
+    # must not reinstate gfx1100 and install a HIP bundle the visible GPU cannot run.
+    monkeypatch.delenv("UNSLOTH_LLAMA_BACKEND", raising = False)
+    monkeypatch.delenv("UNSLOTH_FORCE_VULKAN", raising = False)
+    monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
+    host = _windows_amd_host(
+        rocm_gfx_target = "gfx1010", rocm_gfx_targets = ["gfx1100", "gfx1010"]
+    )
+    host = ilp._apply_host_overrides(host, override_rocm_gfx = "gfx1100")
+    assert ilp._active_rocm_gfx_target(host) == "gfx1010"
+    assert ilp._should_auto_vulkan_for_amd_windows(host) is True
+    _routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(
+        host, FORK, "pin", force_cpu = False
+    )
+    assert repo == UPSTREAM
+    assert persist == "vulkan"
+
+
+def test_forwarded_gfx_still_fills_an_unprobed_arch(monkeypatch):
+    # Negative control: on an amd-smi-only / driver-only host detect_host() reports
+    # no arch at all, so the forward is the only source and must still apply --
+    # that is what --rocm-gfx exists for.
+    monkeypatch.delenv("UNSLOTH_LLAMA_BACKEND", raising = False)
+    monkeypatch.delenv("UNSLOTH_FORCE_VULKAN", raising = False)
+    monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
+    host = _windows_amd_host(rocm_gfx_target = None, rocm_gfx_targets = [])
+    host = ilp._apply_host_overrides(host, override_rocm_gfx = "gfx1151")
+    assert ilp._active_rocm_gfx_target(host) == "gfx1151"
+    assert ilp._should_auto_vulkan_for_amd_windows(host) is False
+    _routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(
+        host, FORK, "pin", force_cpu = False
+    )
+    assert repo == FORK
+    assert persist is None
+
+
 def test_llama_backend_hip_opts_out_of_auto_vulkan(monkeypatch):
     # hip names a backend, so it keeps the fork path even on an auto-fallback arch.
     monkeypatch.setenv("UNSLOTH_LLAMA_BACKEND", "hip")

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -973,3 +973,85 @@ def test_route_to_vulkan_prebuilt_explicit_opt_in_overrides_hidden_nvidia(monkey
     routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
     assert repo == UPSTREAM
     assert persist == "vulkan"
+
+
+# The gfx archs the fork's llama-prebuilt-manifest.json maps to a windows-rocm
+# bundle (gfx103X / gfx110X / gfx1150 / gfx1151 / gfx120X / gfx908 / gfx90a).
+# Auto-Vulkan must never steal a host one of these already covers.
+_FORK_WINDOWS_ROCM_GFX = (
+    "gfx908", "gfx90a",
+    "gfx1030", "gfx1031", "gfx1032", "gfx1034",
+    "gfx1100", "gfx1101", "gfx1102", "gfx1103",
+    "gfx1150", "gfx1151", "gfx1200", "gfx1201",
+)
+
+
+def test_windows_hip_gfx_floor_covers_every_fork_windows_rocm_bundle():
+    # A gfx missing here routes to Vulkan and bypasses the fork manifest entirely,
+    # silently downgrading a hash-approved windows-rocm bundle to an unhashed
+    # upstream Vulkan build. Keep this in sync with the published manifest.
+    missing = [
+        gfx for gfx in _FORK_WINDOWS_ROCM_GFX if gfx not in ilp.WINDOWS_HIP_PREBUILT_GFX_TARGETS
+    ]
+    assert not missing, f"auto-Vulkan would steal fork windows-rocm archs: {missing}"
+
+
+@pytest.mark.parametrize("gfx", _FORK_WINDOWS_ROCM_GFX)
+def test_route_to_vulkan_prebuilt_keeps_every_fork_windows_rocm_arch(gfx, monkeypatch):
+    # No ambient opt-in: this asserts the AUTO path leaves covered archs alone.
+    monkeypatch.delenv("UNSLOTH_LLAMA_BACKEND", raising = False)
+    monkeypatch.delenv("UNSLOTH_FORCE_VULKAN", raising = False)
+    host = _windows_amd_host(rocm_gfx_target = gfx, rocm_gfx_targets = [gfx])
+    routed, repo, tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
+    assert routed is host
+    assert (repo, tag) == (FORK, "pin")
+    assert persist is None
+
+
+def test_llama_backend_hip_opts_out_of_auto_vulkan(monkeypatch):
+    # UNSLOTH_LLAMA_BACKEND names a backend, so hip must keep the HIP/fork path
+    # even on an arch the auto-fallback would otherwise route to Vulkan.
+    monkeypatch.setenv("UNSLOTH_LLAMA_BACKEND", "hip")
+    host = _windows_amd_host(rocm_gfx_target = "gfx803", rocm_gfx_targets = ["gfx803"])
+    routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
+    assert routed is host
+    assert repo == FORK
+    assert persist is None
+    assert ilp.force_vulkan_requested() is False
+
+
+def test_explicit_backend_beats_legacy_force_vulkan(monkeypatch):
+    # The specific variable wins: a stale UNSLOTH_FORCE_VULKAN must not overrule
+    # an explicit UNSLOTH_LLAMA_BACKEND=hip (rocm is the same backend).
+    monkeypatch.setenv("UNSLOTH_FORCE_VULKAN", "1")
+    monkeypatch.setenv("UNSLOTH_LLAMA_BACKEND", "rocm")
+    assert ilp.resolved_llama_backend() == "hip"
+    assert ilp.force_vulkan_requested() is False
+    host = _windows_amd_host(rocm_gfx_target = "gfx1100", rocm_gfx_targets = ["gfx1100"])
+    _routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(
+        host, FORK, "pin", force_cpu = False
+    )
+    assert repo == FORK
+    assert persist is None
+
+
+def test_unknown_llama_backend_value_falls_through_to_legacy_flag(monkeypatch):
+    # An unrecognised value is ignored (not an error), so the legacy flag and the
+    # auto-fallback both keep working exactly as they did without it.
+    monkeypatch.setenv("UNSLOTH_LLAMA_BACKEND", "banana")
+    assert ilp.resolved_llama_backend() is None
+    assert ilp.force_vulkan_requested() is False
+    monkeypatch.setenv("UNSLOTH_FORCE_VULKAN", "1")
+    assert ilp.force_vulkan_requested() is True
+
+
+def test_llama_backend_flag_beats_conflicting_env(monkeypatch):
+    # --llama-backend is the caller's explicit request and outranks the env.
+    monkeypatch.setenv("UNSLOTH_LLAMA_BACKEND", "hip")
+    assert ilp.force_vulkan_requested("vulkan") is True
+    host = _windows_amd_host(rocm_gfx_target = "gfx1100", rocm_gfx_targets = ["gfx1100"])
+    _routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(
+        host, FORK, "pin", force_cpu = False, llama_backend = "vulkan"
+    )
+    assert repo == UPSTREAM
+    assert persist == "vulkan"

--- a/studio/backend/tests/test_install_resolve_prebuilt.py
+++ b/studio/backend/tests/test_install_resolve_prebuilt.py
@@ -1020,15 +1020,11 @@ def test_forwarded_gfx_does_not_undo_visible_device_auto_vulkan(monkeypatch):
     monkeypatch.delenv("UNSLOTH_LLAMA_BACKEND", raising = False)
     monkeypatch.delenv("UNSLOTH_FORCE_VULKAN", raising = False)
     monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
-    host = _windows_amd_host(
-        rocm_gfx_target = "gfx1010", rocm_gfx_targets = ["gfx1100", "gfx1010"]
-    )
+    host = _windows_amd_host(rocm_gfx_target = "gfx1010", rocm_gfx_targets = ["gfx1100", "gfx1010"])
     host = ilp._apply_host_overrides(host, override_rocm_gfx = "gfx1100")
     assert ilp._active_rocm_gfx_target(host) == "gfx1010"
     assert ilp._should_auto_vulkan_for_amd_windows(host) is True
-    _routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(
-        host, FORK, "pin", force_cpu = False
-    )
+    _routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
     assert repo == UPSTREAM
     assert persist == "vulkan"
 
@@ -1044,9 +1040,7 @@ def test_forwarded_gfx_still_fills_an_unprobed_arch(monkeypatch):
     host = ilp._apply_host_overrides(host, override_rocm_gfx = "gfx1151")
     assert ilp._active_rocm_gfx_target(host) == "gfx1151"
     assert ilp._should_auto_vulkan_for_amd_windows(host) is False
-    _routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(
-        host, FORK, "pin", force_cpu = False
-    )
+    _routed, repo, _tag, persist = ilp._route_to_vulkan_prebuilt(host, FORK, "pin", force_cpu = False)
     assert repo == FORK
     assert persist is None
 

--- a/studio/backend/tests/test_llama_cpp_update.py
+++ b/studio/backend/tests/test_llama_cpp_update.py
@@ -473,6 +473,7 @@ def test_start_update_preserves_vulkan_via_env(monkeypatch, tmp_path):
     monkeypatch.setattr(freshness, "_fetch_latest_release_tag", lambda repo, timeout = 5.0: "b9518")
 
     def _on_start(cmd):
+        captured["cmd"] = cmd
         _write_install(
             install_dir,
             "b9518",
@@ -480,6 +481,7 @@ def test_start_update_preserves_vulkan_via_env(monkeypatch, tmp_path):
             asset = "llama-b9518-bin-ubuntu-vulkan-x64.tar.gz",
         )
 
+    captured: dict = {}
     popen_kwargs: dict = {}
     _patch_installer_popen(
         monkeypatch,
@@ -497,6 +499,8 @@ def test_start_update_preserves_vulkan_via_env(monkeypatch, tmp_path):
         time.sleep(0.05)
     assert job["state"] == "success", job
     assert popen_kwargs["env"]["UNSLOTH_FORCE_VULKAN"] == "1"
+    assert popen_kwargs["env"]["UNSLOTH_LLAMA_BACKEND"] == "vulkan"
+    assert "--llama-backend" in captured["cmd"] and "vulkan" in captured["cmd"]
 
 
 @pytest.mark.parametrize(

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -401,6 +401,7 @@ def _run_llama_phase(
     pin_release_tag: Optional[str],
     set_progress,
     force_cpu: bool = False,
+    llama_backend: Optional[str] = None,
 ) -> dict:
     """The llama phase of a chained update: put the backend into a maintenance
     state, run the installer for the latest prebuilt, then refresh caches so the
@@ -452,14 +453,17 @@ def _run_llama_phase(
         # updates. A natural fallback (or a legacy marker without the flag) heals to GPU (#6097).
         if force_cpu:
             cmd.append("--force-cpu")
+        if llama_backend == "vulkan":
+            cmd.extend(["--llama-backend", "vulkan"])
         logger.info("llama update: installing", cmd = " ".join(cmd))
         env = dict(os.environ, UNSLOTH_PROGRESS_PERCENT_STEP = "5")
         # Preserve a Vulkan install across updates: detect_host on a CUDA/ROCm
         # box would otherwise re-route and silently replace the Vulkan build.
-        # Re-assert it via the same env flag setup uses (mirrors
+        # Re-assert it via the same env/CLI flags setup uses (mirrors
         # _rocm_install_args).
-        if asset and "vulkan" in asset.lower():
+        if llama_backend == "vulkan" or (asset and "vulkan" in asset.lower()):
             env["UNSLOTH_FORCE_VULKAN"] = "1"
+            env["UNSLOTH_LLAMA_BACKEND"] = "vulkan"
         _flow.stream_installer(
             cmd,
             env,
@@ -566,6 +570,9 @@ def _plan_llama_phase() -> dict:
         from_tag = marker.get("tag") or marker.get("release_tag")
         asset = marker.get("asset")
         force_cpu = bool(marker.get("force_cpu"))
+        llama_backend = marker.get("llama_backend")
+        if llama_backend == "vulkan" or (asset and "vulkan" in str(asset).lower()):
+            llama_backend = "vulkan"
         # Install exactly the release the banner offered: the installer's own
         # "latest" is commit-date ordered and can lag the published_at pick
         # above, reinstalling the current build in a loop (the #6219 class).
@@ -609,6 +616,7 @@ def _plan_llama_phase() -> dict:
         asset = (res or {}).get("asset")
         # Source builds carry no forced-CPU marker, so nothing to preserve here.
         force_cpu = False
+        llama_backend = None
         # No pin: source-build detection resolves via --resolve-prebuilt latest,
         # the same resolver the unpinned apply uses, so the two already agree.
         pin_release_tag = None
@@ -631,6 +639,7 @@ def _plan_llama_phase() -> dict:
             "pin_release_tag": pin_release_tag,
             "from_tag": from_tag,
             "force_cpu": force_cpu,
+            "llama_backend": llama_backend,
         }
     }
 
@@ -683,6 +692,7 @@ def start_update() -> dict:
                         llama_spec["pin_release_tag"],
                         set_progress,
                         force_cpu = llama_spec.get("force_cpu", False),
+                        llama_backend = llama_spec.get("llama_backend"),
                     )
                 )
                 if llama_spec

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -458,8 +458,7 @@ def _run_llama_phase(
         logger.info("llama update: installing", cmd = " ".join(cmd))
         env = dict(os.environ, UNSLOTH_PROGRESS_PERCENT_STEP = "5")
         # Preserve a Vulkan install across updates: detect_host on a CUDA/ROCm box would
-        # otherwise re-route and silently replace it. Re-assert via the same env/CLI flags
-        # setup uses (mirrors _rocm_install_args).
+        # otherwise re-route and silently replace it. Re-assert via setup's env/CLI flags.
         if llama_backend == "vulkan" or (asset and "vulkan" in asset.lower()):
             env["UNSLOTH_FORCE_VULKAN"] = "1"
             env["UNSLOTH_LLAMA_BACKEND"] = "vulkan"

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -457,10 +457,9 @@ def _run_llama_phase(
             cmd.extend(["--llama-backend", "vulkan"])
         logger.info("llama update: installing", cmd = " ".join(cmd))
         env = dict(os.environ, UNSLOTH_PROGRESS_PERCENT_STEP = "5")
-        # Preserve a Vulkan install across updates: detect_host on a CUDA/ROCm
-        # box would otherwise re-route and silently replace the Vulkan build.
-        # Re-assert it via the same env/CLI flags setup uses (mirrors
-        # _rocm_install_args).
+        # Preserve a Vulkan install across updates: detect_host on a CUDA/ROCm box would
+        # otherwise re-route and silently replace it. Re-assert via the same env/CLI flags
+        # setup uses (mirrors _rocm_install_args).
         if llama_backend == "vulkan" or (asset and "vulkan" in asset.lower()):
             env["UNSLOTH_FORCE_VULKAN"] = "1"
             env["UNSLOTH_LLAMA_BACKEND"] = "vulkan"

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -64,15 +64,17 @@ EXIT_FALLBACK = 2
 EXIT_ERROR = 1
 EXIT_BUSY = 3
 
-# ggml-org/llama.cpp release.yml windows-hip job GPU_TARGETS, plus gfx1103 which
-# the fork windows-rocm gfx110X bundle covers. Cards below this floor (e.g.
-# gfx803 / RX 480) are invisible to the HIP prebuilt; Vulkan is the practical
-# llama-server backend on Windows for those hosts (#7357).
+# ggml-org/llama.cpp release.yml windows-hip job GPU_TARGETS, plus gfx1034 and
+# gfx1103 which the fork windows-rocm gfx103X / gfx110X bundles cover (see the
+# gfx103X members in tests/studio/install/test_selection_logic.py). Cards below
+# this floor (e.g. gfx803 / RX 480) are invisible to the HIP prebuilt; Vulkan is
+# the practical llama-server backend on Windows for those hosts (#7357).
 WINDOWS_HIP_PREBUILT_GFX_TARGETS = frozenset(
     {
         "gfx1030",
         "gfx1031",
         "gfx1032",
+        "gfx1034",
         "gfx1100",
         "gfx1101",
         "gfx1102",

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -64,9 +64,10 @@ EXIT_FALLBACK = 2
 EXIT_ERROR = 1
 EXIT_BUSY = 3
 
-# ggml-org/llama.cpp release.yml windows-hip job GPU_TARGETS. Cards below this
-# floor (e.g. gfx803 / RX 480) are invisible to the HIP prebuilt; Vulkan is the
-# practical llama-server backend on Windows for those hosts (#7357).
+# ggml-org/llama.cpp release.yml windows-hip job GPU_TARGETS, plus gfx1103 which
+# the fork windows-rocm gfx110X bundle covers. Cards below this floor (e.g.
+# gfx803 / RX 480) are invisible to the HIP prebuilt; Vulkan is the practical
+# llama-server backend on Windows for those hosts (#7357).
 WINDOWS_HIP_PREBUILT_GFX_TARGETS = frozenset(
     {
         "gfx1030",
@@ -75,12 +76,15 @@ WINDOWS_HIP_PREBUILT_GFX_TARGETS = frozenset(
         "gfx1100",
         "gfx1101",
         "gfx1102",
+        "gfx1103",
         "gfx1150",
         "gfx1151",
         "gfx1200",
         "gfx1201",
     }
 )
+# Family labels forwarded by update markers / --rocm-gfx (gfx110X.zip assets).
+WINDOWS_ROCM_FAMILY_GFX_LABELS = frozenset({"gfx103x", "gfx110x", "gfx120x"})
 
 # DiskPart-prompt suppression. RunAsInvoker does NOT stop amd-smi's runtime
 # elevation (its manifest is asInvoker), so this is just harmless belt-and-
@@ -6074,19 +6078,39 @@ def _host_rocm_gfx_targets(host: HostInfo) -> list[str]:
     return []
 
 
+def _active_rocm_gfx_target(host: HostInfo) -> str | None:
+    """The gfx HIP will run on (visible-device aware), not every physical GPU."""
+    if host.rocm_gfx_target:
+        return host.rocm_gfx_target.lower().strip()
+    return None
+
+
+def _gfx_is_windows_hip_supported(gfx: str) -> bool:
+    token = gfx.lower().strip()
+    if token in WINDOWS_ROCM_FAMILY_GFX_LABELS:
+        return True
+    return token in WINDOWS_HIP_PREBUILT_GFX_TARGETS
+
+
 def _host_has_windows_hip_prebuilt_gfx(host: HostInfo) -> bool:
-    return any(
-        target in WINDOWS_HIP_PREBUILT_GFX_TARGETS for target in _host_rocm_gfx_targets(host)
-    )
+    active = _active_rocm_gfx_target(host)
+    if not active:
+        return False
+    return _gfx_is_windows_hip_supported(active)
 
 
 def _should_auto_vulkan_for_amd_windows(host: HostInfo) -> bool:
-    """True when every detected AMD GPU is below the Windows HIP prebuilt floor."""
+    """True when the active AMD GPU is below the Windows HIP prebuilt floor."""
+    active = _active_rocm_gfx_target(host)
+    if not active:
+        # ROCm confirmed but gfx unknown (--has-rocm only): keep the legacy HIP /
+        # fork / source path instead of forcing Vulkan.
+        return False
     return (
         host.is_windows
         and host.has_rocm
         and not host.has_usable_nvidia
-        and not _host_has_windows_hip_prebuilt_gfx(host)
+        and not _gfx_is_windows_hip_supported(active)
     )
 
 
@@ -6151,10 +6175,10 @@ def _route_to_vulkan_prebuilt(
             )
         return host, published_repo, published_release_tag, None
     if auto_no_hip:
-        targets = ", ".join(_host_rocm_gfx_targets(host)) or "unknown"
+        active = _active_rocm_gfx_target(host) or "unknown"
         log(
-            "No detected AMD GPU arch is supported by the Windows HIP prebuilt "
-            f"({targets}); installing the upstream Vulkan llama.cpp prebuilt instead"
+            "Active AMD GPU arch is not supported by the Windows HIP prebuilt "
+            f"({active}); installing the upstream Vulkan llama.cpp prebuilt instead"
         )
         host = _vulkan_only_host(host)
         persist_backend = "vulkan"

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -64,6 +64,24 @@ EXIT_FALLBACK = 2
 EXIT_ERROR = 1
 EXIT_BUSY = 3
 
+# ggml-org/llama.cpp release.yml windows-hip job GPU_TARGETS. Cards below this
+# floor (e.g. gfx803 / RX 480) are invisible to the HIP prebuilt; Vulkan is the
+# practical llama-server backend on Windows for those hosts (#7357).
+WINDOWS_HIP_PREBUILT_GFX_TARGETS = frozenset(
+    {
+        "gfx1030",
+        "gfx1031",
+        "gfx1032",
+        "gfx1100",
+        "gfx1101",
+        "gfx1102",
+        "gfx1150",
+        "gfx1151",
+        "gfx1200",
+        "gfx1201",
+    }
+)
+
 # DiskPart-prompt suppression. RunAsInvoker does NOT stop amd-smi's runtime
 # elevation (its manifest is asInvoker), so this is just harmless belt-and-
 # suspenders for manifest-elevating tools. The real guard is _amd_smi_allowed():
@@ -265,6 +283,7 @@ class HostInfo:
     has_rocm: bool = False
     has_intel_gpu: bool = False
     rocm_gfx_target: str | None = None
+    rocm_gfx_targets: list[str] = field(default_factory = list)
     # (major, minor) from platform.mac_ver(); None off macOS or if unparseable.
     # Skips a macos prebuilt whose minimum-OS exceeds this host.
     macos_version: tuple[int, int] | None = None
@@ -2142,6 +2161,30 @@ def run_capture(
     return result
 
 
+def _list_rocm_gfx_targets(out: str) -> list[str]:
+    """List gfx targets rocminfo / hipinfo report, one entry per physical GPU.
+
+    rocminfo / hipinfo print the same gfx token multiple times per GPU (Name,
+    ISA, marketing-name). Split on per-GPU section headers when present so a
+    dual same-arch host keeps two entries; otherwise fall back to insertion-
+    order dedup for flat strings and unit-test stubs.
+    """
+    _sections = re.split(
+        r"(?mi)^\s*\*+\s*$\s*agent\s+\d+\s*$|\bdevice\s*#\s*\d+\b",
+        out,
+    )
+    if len(_sections) > 1:
+        _tokens: list[str] = []
+        for _sec in _sections[1:]:
+            _m = re.search(r"gfx[1-9][0-9a-z]{2,3}", _sec.lower())
+            if _m:
+                _tokens.append(_m.group(0))
+    else:
+        _raw = re.findall(r"gfx[1-9][0-9a-z]{2,3}", out.lower())
+        _tokens = list(dict.fromkeys(_raw))
+    return _tokens
+
+
 def _pick_rocm_gfx_target(out: str) -> str | None:
     """Choose the gfx target rocminfo / hipinfo report for the active GPU.
 
@@ -2151,38 +2194,10 @@ def _pick_rocm_gfx_target(out: str) -> str | None:
     asset matches what HIP actually runs on. Falls back to the first GPU when
     no env var is set.
 
-    rocminfo / hipinfo print the same gfx token multiple times per GPU (Name,
-    ISA, marketing-name). We first try to split the output on per-GPU section
-    headers (rocminfo: "Agent N" blocks, hipinfo: "device#N" entries) and take
-    exactly one gfx token per section. This gives the correct per-GPU list even
-    on same-arch multi-GPU hosts (e.g. two RX 7900 XTX cards) where global
-    dict.fromkeys dedup would collapse both cards to a single entry and make
-    HIP_VISIBLE_DEVICES=1 point out of range.
-
-    Falls back to insertion-order dedup when the output has no recognisable
-    section markers (flat gfx-string inputs, unit-test stubs, etc.).
-
-    Empty / "-1" env values mean no AMD GPU is visible to HIP: return None.
+    See ``_list_rocm_gfx_targets`` for per-GPU extraction. Empty / "-1" env
+    values mean no AMD GPU is visible to HIP: return None.
     """
-    # Try to build a per-GPU token list by splitting on section boundaries.
-    # rocminfo sections are introduced by "Agent N" lines (optionally between
-    # rows of asterisks). hipinfo sections start with "device#N".
-    _sections = re.split(
-        r"(?mi)^\s*\*+\s*$\s*agent\s+\d+\s*$|\bdevice\s*#\s*\d+\b",
-        out,
-    )
-    if len(_sections) > 1:
-        # Section-based: one gfx token per GPU section preserves physical order.
-        _tokens: list[str] = []
-        for _sec in _sections[1:]:
-            _m = re.search(r"gfx[1-9][0-9a-z]{2,3}", _sec.lower())
-            if _m:
-                _tokens.append(_m.group(0))
-    else:
-        # Fallback: insertion-order dedup (handles flat strings / unknown formats).
-        _raw = re.findall(r"gfx[1-9][0-9a-z]{2,3}", out.lower())
-        _tokens = list(dict.fromkeys(_raw))
-
+    _tokens = _list_rocm_gfx_targets(out)
     if not _tokens:
         return None
 
@@ -2390,6 +2405,7 @@ def detect_host() -> HostInfo:
 
     has_rocm = False
     rocm_gfx_target: str | None = None
+    rocm_gfx_targets: list[str] = []
     if is_linux and not has_usable_nvidia:
         # WSL2 ROCDXG: the system rocminfo enumerates the GPU over /dev/dxg
         # only when HSA_ENABLE_DXG_DETECTION=1 (a no-op on bare metal), and
@@ -2427,6 +2443,7 @@ def detect_host() -> HostInfo:
             if _result.returncode == 0 and _result.stdout.strip():
                 if _check(_result.stdout):
                     has_rocm = True
+                    rocm_gfx_targets = _list_rocm_gfx_targets(_result.stdout)
                     rocm_gfx_target = _pick_rocm_gfx_target(_result.stdout)
                     break
     elif is_windows and not has_usable_nvidia:
@@ -2472,6 +2489,7 @@ def detect_host() -> HostInfo:
                 if _check(_result.stdout):
                     has_rocm = True
                     # hipinfo reports "gcnArchName: gfx1100" -- extract if present
+                    rocm_gfx_targets = _list_rocm_gfx_targets(_result.stdout)
                     rocm_gfx_target = _pick_rocm_gfx_target(_result.stdout)
                     break
         # Note: amdhip64.dll presence alone is NOT treated as GPU evidence
@@ -2534,6 +2552,7 @@ def detect_host() -> HostInfo:
         has_rocm = has_rocm,
         has_intel_gpu = has_intel_gpu,
         rocm_gfx_target = rocm_gfx_target,
+        rocm_gfx_targets = rocm_gfx_targets,
         macos_version = macos_version,
     )
 
@@ -2569,11 +2588,17 @@ def _apply_host_overrides(
             has_physical_nvidia = False,
             has_rocm = False,
             rocm_gfx_target = None,
+            rocm_gfx_targets = [],
             has_intel_gpu = False,
         )
     gfx = _normalize_forwarded_gfx(override_rocm_gfx)
     if gfx:
-        return dataclasses_replace(host, has_rocm = True, rocm_gfx_target = gfx)
+        return dataclasses_replace(
+            host,
+            has_rocm = True,
+            rocm_gfx_target = gfx,
+            rocm_gfx_targets = [gfx],
+        )
     if override_has_rocm and not host.has_rocm:
         return dataclasses_replace(host, has_rocm = True)
     return host
@@ -5456,6 +5481,7 @@ def write_prebuilt_metadata(
     approved_checksums: ApprovedReleaseChecksums,
     prebuilt_fallback_used: bool,
     force_cpu: bool = False,
+    llama_backend: str | None = None,
 ) -> None:
     source_asset_name, source_sha256 = selected_source_archive_metadata(
         approved_checksums,
@@ -5484,6 +5510,9 @@ def write_prebuilt_metadata(
         # so a forced CPU install is not re-routed to a GPU bundle (#7213). An automatic
         # --cpu-fallback (e.g. arm64 GPU-build recovery) stays False so it can heal to GPU.
         "force_cpu": force_cpu,
+        # Deliberate or auto-selected Vulkan backend (#7357). The updater re-asserts it
+        # so AMD hosts are not silently swapped back to HIP on update.
+        "llama_backend": llama_backend,
         "asset_sha256": choice.expected_sha256,
         "source": choice.source_label,
         # Binary-side repo/tag for non-fork sources (e.g. the ggml-org upstream
@@ -5527,6 +5556,23 @@ def sync_marker_force_cpu(install_dir: Path, persist_force_cpu: bool) -> None:
     marker["force_cpu"] = persist_force_cpu
     marker_path.write_text(json.dumps(marker, indent = 2) + "\n")
     log(f"existing install reused; recorded force_cpu={persist_force_cpu} from this run")
+
+
+def sync_marker_llama_backend(install_dir: Path, llama_backend: str | None) -> None:
+    """Sync the persisted llama.cpp backend when the bundle is reused unchanged."""
+    marker_path = install_dir / "UNSLOTH_PREBUILT_INFO.json"
+    try:
+        marker = json.loads(marker_path.read_text())
+    except (OSError, ValueError):
+        return
+    if not isinstance(marker, dict) or marker.get("llama_backend") == llama_backend:
+        return
+    if llama_backend is None:
+        marker.pop("llama_backend", None)
+    else:
+        marker["llama_backend"] = llama_backend
+    marker_path.write_text(json.dumps(marker, indent = 2) + "\n")
+    log(f"existing install reused; recorded llama_backend={llama_backend!r} from this run")
 
 
 def expected_install_fingerprint(
@@ -5821,6 +5867,7 @@ def validate_prebuilt_choice(
     prebuilt_fallback_used: bool,
     quantized_path: Path,
     force_cpu: bool = False,
+    llama_backend: str | None = None,
 ) -> tuple[Path, Path]:
     source_repo, source_ref, source_archive, exact_source = preferred_source_archive(
         approved_checksums, llama_tag
@@ -5862,6 +5909,7 @@ def validate_prebuilt_choice(
         approved_checksums = approved_checksums,
         prebuilt_fallback_used = prebuilt_fallback_used,
         force_cpu = force_cpu,
+        llama_backend = llama_backend,
     )
     # Hashless external prebuilts are not in the approved-sha256
     # manifest and rely on the functional smoke test as their only integrity gate,
@@ -5905,6 +5953,7 @@ def validate_prebuilt_attempts(
     initial_fallback_used: bool = False,
     existing_install_dir: Path | None = None,
     force_cpu: bool = False,
+    llama_backend: str | None = None,
 ) -> tuple[AssetChoice, Path, bool]:
     attempt_list = list(attempts)
     if not attempt_list:
@@ -5958,6 +6007,7 @@ def validate_prebuilt_attempts(
                 prebuilt_fallback_used = tried_fallback,
                 quantized_path = quantized_path,
                 force_cpu = force_cpu,
+                llama_backend = llama_backend,
             )
         except Exception as exc:
             remove_tree(staging_dir)
@@ -5981,16 +6031,60 @@ def validate_prebuilt_attempts(
     raise PrebuiltFallback("no prebuilt bundle passed validation")
 
 
-def force_vulkan_requested() -> bool:
-    """Whether UNSLOTH_FORCE_VULKAN opts this host into the Vulkan llama.cpp
-    prebuilt instead of its detected CUDA/ROCm backend (e.g. so an AMD user can
-    run the Vulkan build for inference). Scoped to the llama.cpp backend; the
-    torch/training stack installs separately and still sees the real GPU.
+def _normalized_llama_backend(value: str | None) -> str | None:
+    if not value:
+        return None
+    backend = value.strip().lower()
+    if backend in {"vulkan", "hip", "rocm", "cpu"}:
+        return "hip" if backend == "rocm" else backend
+    return None
+
+
+def llama_backend_from_env() -> str | None:
+    """Read an explicit llama.cpp backend preference from the environment."""
+    for key in ("UNSLOTH_LLAMA_BACKEND", "UNSLOTH_LLAMA_CPP_BACKEND"):
+        backend = _normalized_llama_backend(os.environ.get(key))
+        if backend:
+            return backend
+    return None
+
+
+def force_vulkan_requested(llama_backend: str | None = None) -> bool:
+    """Whether this run should install the upstream Vulkan llama.cpp prebuilt.
+
+    Triggered by ``UNSLOTH_LLAMA_BACKEND=vulkan``, legacy ``UNSLOTH_FORCE_VULKAN``,
+    or ``--llama-backend vulkan``. Scoped to the llama.cpp backend; the torch/training
+    stack installs separately and still sees the real GPU.
     """
+    backend = _normalized_llama_backend(llama_backend) or llama_backend_from_env()
+    if backend == "vulkan":
+        return True
     return os.environ.get("UNSLOTH_FORCE_VULKAN", "").strip().lower() in (
         "1",
         "true",
         "yes",
+    )
+
+
+def _host_rocm_gfx_targets(host: HostInfo) -> list[str]:
+    if host.rocm_gfx_targets:
+        return [target.lower() for target in host.rocm_gfx_targets]
+    if host.rocm_gfx_target:
+        return [host.rocm_gfx_target.lower()]
+    return []
+
+
+def _host_has_windows_hip_prebuilt_gfx(host: HostInfo) -> bool:
+    return any(target in WINDOWS_HIP_PREBUILT_GFX_TARGETS for target in _host_rocm_gfx_targets(host))
+
+
+def _should_auto_vulkan_for_amd_windows(host: HostInfo) -> bool:
+    """True when every detected AMD GPU is below the Windows HIP prebuilt floor."""
+    return (
+        host.is_windows
+        and host.has_rocm
+        and not host.has_usable_nvidia
+        and not _host_has_windows_hip_prebuilt_gfx(host)
     )
 
 
@@ -6007,52 +6101,71 @@ def _vulkan_only_host(host: HostInfo) -> HostInfo:
         has_usable_nvidia = False,
         has_physical_nvidia = False,
         has_rocm = False,
+        rocm_gfx_target = None,
+        rocm_gfx_targets = [],
         has_intel_gpu = True,
     )
 
 
 def _route_to_vulkan_prebuilt(
-    host: HostInfo, published_repo: str, published_release_tag: str, *, force_cpu: bool
-) -> tuple[HostInfo, str, str]:
+    host: HostInfo,
+    published_repo: str,
+    published_release_tag: str,
+    *,
+    force_cpu: bool,
+    llama_backend: str | None = None,
+) -> tuple[HostInfo, str, str, str | None]:
     """Point a Vulkan-capable host at the upstream ggml-org Vulkan prebuilt.
 
     The unsloth published repo ships only CUDA/ROCm/CPU assets, so Vulkan comes
-    from UPSTREAM_REPO. Two triggers route here, both suppressed when a CPU flag
+    from UPSTREAM_REPO. Three triggers route here, all suppressed when a CPU flag
     (--cpu-fallback or --force-cpu, folded into force_cpu) wins:
-      * UNSLOTH_FORCE_VULKAN forces Vulkan over the detected CUDA/ROCm backend;
+      * ``UNSLOTH_LLAMA_BACKEND=vulkan`` / ``UNSLOTH_FORCE_VULKAN`` / ``--llama-backend vulkan``
+        forces Vulkan over the detected CUDA/ROCm backend;
+      * Windows AMD with no HIP-prebuilt gfx arch auto-falls back to Vulkan (#7357);
       * an auto-detected Intel GPU with NO physical NVIDIA/ROCm -- the purpose
         of the has_intel_gpu probe, since the fork manifest ships no Vulkan asset.
     Applied by BOTH the install path and the --resolve-prebuilt probe so the
     "is a prebuilt available" answer matches what actually gets installed.
 
-    Returns the (possibly rewritten) host, repo, and release tag.
+    Returns the (possibly rewritten) host, repo, release tag, and a backend
+    value to persist in the install marker when updates must re-assert Vulkan.
     """
-    forced = force_vulkan_requested()
+    forced = force_vulkan_requested(llama_backend)
+    auto_no_hip = _should_auto_vulkan_for_amd_windows(host)
     # Gate auto-routing on no PHYSICAL NVIDIA, not merely no usable one: a mixed
     # NVIDIA+Intel host that hides NVIDIA with CUDA_VISIBLE_DEVICES=""/-1 keeps
     # has_physical_nvidia=True while has_usable_nvidia goes False. Vulkan ignores
     # CUDA_VISIBLE_DEVICES, so auto-routing such a host would let it grab the
-    # reserved NVIDIA GPU. An explicit UNSLOTH_FORCE_VULKAN still overrides.
+    # reserved NVIDIA GPU. An explicit Vulkan opt-in still overrides.
     auto_intel = host.has_intel_gpu and not host.has_physical_nvidia and not host.has_rocm
-    if force_cpu or not (forced or auto_intel):
-        return host, published_repo, published_release_tag
+    if force_cpu or not (forced or auto_intel or auto_no_hip):
+        return host, published_repo, published_release_tag, None
     if host.is_macos:
         if forced:
             log(
-                "UNSLOTH_FORCE_VULKAN is set but ignored on macOS "
+                "UNSLOTH_LLAMA_BACKEND=vulkan is set but ignored on macOS "
                 "(Metal is used; there is no Vulkan prebuilt)"
             )
-        return host, published_repo, published_release_tag
-    if forced:
+        return host, published_repo, published_release_tag, None
+    if auto_no_hip:
+        targets = ", ".join(_host_rocm_gfx_targets(host)) or "unknown"
         log(
-            "UNSLOTH_FORCE_VULKAN is set; installing the upstream Vulkan "
-            "llama.cpp prebuilt instead of the detected GPU backend"
+            "No detected AMD GPU arch is supported by the Windows HIP prebuilt "
+            f"({targets}); installing the upstream Vulkan llama.cpp prebuilt instead"
         )
-        # Forcing may override a detected NVIDIA/ROCm host, so normalize it to
-        # Vulkan-only; an auto-detected Intel host already is.
         host = _vulkan_only_host(host)
+        persist_backend = "vulkan"
+    elif forced:
+        log(
+            "Vulkan llama.cpp backend requested; installing the upstream Vulkan "
+            "prebuilt instead of the detected GPU backend"
+        )
+        host = _vulkan_only_host(host)
+        persist_backend = "vulkan"
     else:
         log("Intel GPU detected; installing the upstream Vulkan llama.cpp prebuilt")
+        persist_backend = None
     # Swapping the fork for upstream invalidates a fork release pin: the two use
     # different tag namespaces (fork b9596-mix-<sha> vs upstream b9596), so a
     # pinned fork tag would make the upstream resolver query a nonexistent
@@ -6061,7 +6174,7 @@ def _route_to_vulkan_prebuilt(
     # (repo unchanged here) is preserved.
     if published_repo != UPSTREAM_REPO:
         published_release_tag = ""
-    return host, UPSTREAM_REPO, published_release_tag
+    return host, UPSTREAM_REPO, published_release_tag, persist_backend
 
 
 def diffusion_visual_server_backfill_needed(
@@ -6099,6 +6212,7 @@ def install_prebuilt(
     override_rocm_gfx: str | None = None,
     force_cpu: bool = False,
     persist_force_cpu: bool = False,
+    llama_backend: str | None = None,
     instruction_cleanup_root: Path | None = None,
 ) -> None:
     # force_cpu drops GPU detection (mechanism, both --cpu-fallback and --force-cpu);
@@ -6110,8 +6224,12 @@ def install_prebuilt(
         override_rocm_gfx = override_rocm_gfx,
         force_cpu = force_cpu,
     )
-    host, published_repo, published_release_tag = _route_to_vulkan_prebuilt(
-        host, published_repo, published_release_tag, force_cpu = force_cpu
+    host, published_repo, published_release_tag, persist_llama_backend = _route_to_vulkan_prebuilt(
+        host,
+        published_repo,
+        published_release_tag,
+        force_cpu = force_cpu,
+        llama_backend = llama_backend,
     )
     choice: AssetChoice | None = None
     cleanup_root = install_dir if instruction_cleanup_root is None else instruction_cleanup_root
@@ -6156,6 +6274,7 @@ def install_prebuilt(
                     # Reused bundle is unchanged, but a fresh --force-cpu still must be
                     # recorded so the updater re-asserts it (#7213).
                     sync_marker_force_cpu(install_dir, persist_force_cpu)
+                    sync_marker_llama_backend(install_dir, persist_llama_backend)
                     return
             with tempfile.TemporaryDirectory(prefix = "unsloth-llama-prebuilt-") as tmp:
                 work_dir = Path(tmp)
@@ -6177,6 +6296,7 @@ def install_prebuilt(
                                 f"{plan.release_tag} upstream_tag={plan.llama_tag}; skipping reinstall"
                             )
                             sync_marker_force_cpu(install_dir, persist_force_cpu)
+                            sync_marker_llama_backend(install_dir, persist_llama_backend)
                             return
                     log(
                         "selected "
@@ -6199,6 +6319,7 @@ def install_prebuilt(
                             existing_install_dir = install_dir,
                             # Persist only the deliberate choice, not a transient fallback.
                             force_cpu = persist_force_cpu,
+                            llama_backend = persist_llama_backend,
                         )
                     except ExistingInstallSatisfied:
                         return
@@ -6311,6 +6432,15 @@ def parse_args() -> argparse.Namespace:
             "detection like --cpu-fallback but also records force_cpu in the marker, so "
             "the in-app updater re-asserts CPU and never re-routes to a GPU/Vulkan "
             "bundle that would revive the Intel iGPU crash (#7213)."
+        ),
+    )
+    parser.add_argument(
+        "--llama-backend",
+        choices = ("vulkan",),
+        help = (
+            "Force the llama.cpp prebuilt backend. vulkan installs the upstream Vulkan "
+            "bundle on any host and records the choice so Studio updates keep it. "
+            "Same effect as UNSLOTH_LLAMA_BACKEND=vulkan / UNSLOTH_FORCE_VULKAN=1."
         ),
     )
     resolve_group = parser.add_mutually_exclusive_group()
@@ -6444,8 +6574,12 @@ def main() -> int:
         )
         # Same Vulkan routing the install path applies, so the probe's answer
         # matches what would install (an Intel/forced-Vulkan host -> upstream).
-        host, repo, release_tag = _route_to_vulkan_prebuilt(
-            host, args.published_repo, args.published_release_tag or "", force_cpu = _cpu_mechanism
+        host, repo, release_tag, _persist_llama_backend = _route_to_vulkan_prebuilt(
+            host,
+            args.published_repo,
+            args.published_release_tag or "",
+            force_cpu = _cpu_mechanism,
+            llama_backend = args.llama_backend,
         )
         try:
             _requested, plans = resolve_simple_install_release_plans(
@@ -6487,6 +6621,7 @@ def main() -> int:
         # updater re-asserts it. --cpu-fallback stays transient and heals to GPU.
         force_cpu = args.cpu_fallback or args.force_cpu,
         persist_force_cpu = args.force_cpu,
+        llama_backend = args.llama_backend,
         instruction_cleanup_root = install_arg.absolute(),
     )
     return EXIT_SUCCESS

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -6045,12 +6045,15 @@ def _normalized_llama_backend(value: str | None) -> str | None:
 
 
 def llama_backend_from_env() -> str | None:
-    """Read an explicit llama.cpp backend preference from the environment."""
-    for key in ("UNSLOTH_LLAMA_BACKEND", "UNSLOTH_LLAMA_CPP_BACKEND"):
-        backend = _normalized_llama_backend(os.environ.get(key))
-        if backend:
-            return backend
-    return None
+    """Read an explicit llama.cpp backend preference from the environment.
+
+    Only ``UNSLOTH_LLAMA_BACKEND`` is honored. ``UNSLOTH_LLAMA_CPP_BACKEND`` is a
+    separate, pre-existing setup variable meaning ``auto``/``cpu`` (not a backend
+    name); setup.sh/setup.ps1 warn and ignore any other value, so reading it here
+    would silently force Vulkan behind that warning. Keep the two namespaces
+    apart -- Vulkan opt-in rides UNSLOTH_LLAMA_BACKEND / UNSLOTH_FORCE_VULKAN.
+    """
+    return _normalized_llama_backend(os.environ.get("UNSLOTH_LLAMA_BACKEND"))
 
 
 def force_vulkan_requested(llama_backend: str | None = None) -> bool:
@@ -6109,7 +6112,12 @@ def _should_auto_vulkan_for_amd_windows(host: HostInfo) -> bool:
     return (
         host.is_windows
         and host.has_rocm
-        and not host.has_usable_nvidia
+        # No PHYSICAL NVIDIA, not merely no usable one: a host that hides an
+        # NVIDIA card via CUDA_VISIBLE_DEVICES=""/-1 keeps has_physical_nvidia
+        # while has_usable_nvidia goes False. Vulkan ignores that mask and could
+        # enumerate the reserved card, so don't auto-route it here. The Intel
+        # auto path gates the same way; an explicit Vulkan opt-in still overrides.
+        and not host.has_physical_nvidia
         and not _gfx_is_windows_hip_supported(active)
     )
 

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -6075,7 +6075,9 @@ def _host_rocm_gfx_targets(host: HostInfo) -> list[str]:
 
 
 def _host_has_windows_hip_prebuilt_gfx(host: HostInfo) -> bool:
-    return any(target in WINDOWS_HIP_PREBUILT_GFX_TARGETS for target in _host_rocm_gfx_targets(host))
+    return any(
+        target in WINDOWS_HIP_PREBUILT_GFX_TARGETS for target in _host_rocm_gfx_targets(host)
+    )
 
 
 def _should_auto_vulkan_for_amd_windows(host: HostInfo) -> bool:

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -64,13 +64,17 @@ EXIT_FALLBACK = 2
 EXIT_ERROR = 1
 EXIT_BUSY = 3
 
-# ggml-org/llama.cpp release.yml windows-hip job GPU_TARGETS, plus gfx1034 and
-# gfx1103 which the fork windows-rocm gfx103X / gfx110X bundles cover (see the
-# gfx103X members in tests/studio/install/test_selection_logic.py). Cards below
-# this floor (e.g. gfx803 / RX 480) are invisible to the HIP prebuilt; Vulkan is
-# the practical llama-server backend on Windows for those hosts (#7357).
+# Every gfx a Windows AMD host can already be served: ggml-org/llama.cpp
+# release.yml windows-hip GPU_TARGETS, plus the archs the fork's windows-rocm
+# bundles cover (gfx103X adds gfx1034, gfx110X adds gfx1103, and gfx908 / gfx90a
+# ship as their own bundles). Must stay a superset of the manifest's windows-rocm
+# mapped_targets, else auto-Vulkan would steal a host the fork already builds for.
+# Cards below this floor (e.g. gfx803 / RX 480) are invisible to the HIP prebuilt;
+# Vulkan is the practical llama-server backend on Windows for those hosts (#7357).
 WINDOWS_HIP_PREBUILT_GFX_TARGETS = frozenset(
     {
+        "gfx908",
+        "gfx90a",
         "gfx1030",
         "gfx1031",
         "gfx1032",
@@ -6058,6 +6062,12 @@ def llama_backend_from_env() -> str | None:
     return _normalized_llama_backend(os.environ.get("UNSLOTH_LLAMA_BACKEND"))
 
 
+def resolved_llama_backend(llama_backend: str | None = None) -> str | None:
+    """The explicit backend for this run: --llama-backend, else the env var.
+    None when neither is set or the value is not a backend name we know."""
+    return _normalized_llama_backend(llama_backend) or llama_backend_from_env()
+
+
 def force_vulkan_requested(llama_backend: str | None = None) -> bool:
     """Whether this run should install the upstream Vulkan llama.cpp prebuilt.
 
@@ -6065,9 +6075,11 @@ def force_vulkan_requested(llama_backend: str | None = None) -> bool:
     or ``--llama-backend vulkan``. Scoped to the llama.cpp backend; the torch/training
     stack installs separately and still sees the real GPU.
     """
-    backend = _normalized_llama_backend(llama_backend) or llama_backend_from_env()
-    if backend == "vulkan":
-        return True
+    backend = resolved_llama_backend(llama_backend)
+    if backend is not None:
+        # An explicit backend is authoritative, so UNSLOTH_LLAMA_BACKEND=hip is a
+        # real opt-out rather than being overruled by a stale UNSLOTH_FORCE_VULKAN.
+        return backend == "vulkan"
     return os.environ.get("UNSLOTH_FORCE_VULKAN", "").strip().lower() in (
         "1",
         "true",
@@ -6168,7 +6180,10 @@ def _route_to_vulkan_prebuilt(
     value to persist in the install marker when updates must re-assert Vulkan.
     """
     forced = force_vulkan_requested(llama_backend)
-    auto_no_hip = _should_auto_vulkan_for_amd_windows(host)
+    # Only auto-fall back when the run named no backend: an explicit hip/cpu is
+    # the opt-out for a host that would rather keep (or debug) its HIP bundle.
+    explicit_backend = resolved_llama_backend(llama_backend)
+    auto_no_hip = explicit_backend is None and _should_auto_vulkan_for_amd_windows(host)
     # Gate auto-routing on no PHYSICAL NVIDIA, not merely no usable one: a mixed
     # NVIDIA+Intel host that hides NVIDIA with CUDA_VISIBLE_DEVICES=""/-1 keeps
     # has_physical_nvidia=True while has_usable_nvidia goes False. Vulkan ignores

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -92,6 +92,12 @@ WINDOWS_HIP_PREBUILT_GFX_TARGETS = frozenset(
 # Family labels forwarded by update markers / --rocm-gfx (gfx110X.zip assets).
 WINDOWS_ROCM_FAMILY_GFX_LABELS = frozenset({"gfx103x", "gfx110x", "gfx120x"})
 
+# install_kind values that really are a Vulkan bundle. Used to keep the marker's
+# llama_backend honest: upstream ships no Vulkan archive for Windows arm64, and
+# the x64 selector falls through to the CPU asset when the Vulkan one is missing
+# or fails validation, so a Vulkan request can end on a CPU bundle (#7357).
+VULKAN_INSTALL_KINDS = frozenset({"linux-vulkan", "windows-vulkan"})
+
 # DiskPart-prompt suppression. RunAsInvoker does NOT stop amd-smi's runtime
 # elevation (its manifest is asInvoker), so this is just harmless belt-and-
 # suspenders for manifest-elevating tools. The real guard is _amd_smi_allowed():
@@ -5481,6 +5487,21 @@ def _fork_manifest_release_plans(
     raise PrebuiltFallback("no installable published llama.cpp releases were found")
 
 
+def persisted_llama_backend(llama_backend: str | None, choice: AssetChoice) -> str | None:
+    """The backend to record for an install that actually landed ``choice``.
+
+    A Vulkan request can end on a non-Vulkan bundle: Windows arm64 has no upstream
+    Vulkan archive at all (release.yml builds vulkan for x64 and opencl-adreno for
+    arm64), and the x64 branch falls through to win-cpu-x64 when the Vulkan archive
+    is missing or fails validation. Recording "vulkan" for such an install makes
+    the updater re-assert Vulkan on every later run for a backend that was never
+    installed, so the CPU bundle stays pinned to upstream instead of healing back
+    to the published bundle. Mirrors force_cpu: persist the real outcome only."""
+    if llama_backend == "vulkan" and choice.install_kind not in VULKAN_INSTALL_KINDS:
+        return None
+    return llama_backend
+
+
 def write_prebuilt_metadata(
     install_dir: Path,
     *,
@@ -5521,8 +5542,9 @@ def write_prebuilt_metadata(
         # --cpu-fallback (e.g. arm64 GPU-build recovery) stays False so it can heal to GPU.
         "force_cpu": force_cpu,
         # Deliberate or auto-selected Vulkan backend (#7357). The updater re-asserts it
-        # so AMD hosts are not silently swapped back to HIP on update.
-        "llama_backend": llama_backend,
+        # so AMD hosts are not silently swapped back to HIP on update. Dropped when the
+        # attempt that won is not actually a Vulkan bundle.
+        "llama_backend": persisted_llama_backend(llama_backend, choice),
         "asset_sha256": choice.expected_sha256,
         "source": choice.source_label,
         # Binary-side repo/tag for non-fork sources (e.g. the ggml-org upstream
@@ -6136,6 +6158,16 @@ def _should_auto_vulkan_for_amd_windows(host: HostInfo) -> bool:
     )
 
 
+def _has_no_vulkan_prebuilt(host: HostInfo) -> bool:
+    """Platforms that ship no Vulkan prebuilt at all, so routing there is pointless.
+
+    Upstream release.yml builds win-vulkan for x64 only; Windows arm64 gets
+    win-cpu-arm64 plus win-opencl-adreno-arm64. Rewriting such a host to
+    Vulkan-only just swaps the published arm64 bundle for the upstream CPU one
+    without ever producing Vulkan. macOS is handled separately (Metal)."""
+    return host.is_windows and host.is_arm64
+
+
 def _vulkan_only_host(host: HostInfo) -> HostInfo:
     """Rewrite ``host`` so the asset selectors take their Vulkan branch.
 
@@ -6197,6 +6229,13 @@ def _route_to_vulkan_prebuilt(
             log(
                 "UNSLOTH_LLAMA_BACKEND=vulkan is set but ignored on macOS "
                 "(Metal is used; there is no Vulkan prebuilt)"
+            )
+        return host, published_repo, published_release_tag, None
+    if _has_no_vulkan_prebuilt(host):
+        if forced:
+            log(
+                "Vulkan llama.cpp backend requested but ignored on Windows arm64 "
+                "(upstream ships no Vulkan arm64 prebuilt); keeping the published bundle"
             )
         return host, published_repo, published_release_tag, None
     if auto_no_hip:
@@ -6325,7 +6364,10 @@ def install_prebuilt(
                     # Reused bundle is unchanged, but a fresh --force-cpu still must be
                     # recorded so the updater re-asserts it (#7213).
                     sync_marker_force_cpu(install_dir, persist_force_cpu)
-                    sync_marker_llama_backend(install_dir, persist_llama_backend)
+                    sync_marker_llama_backend(
+                        install_dir,
+                        persisted_llama_backend(persist_llama_backend, current.attempts[0]),
+                    )
                     return
             with tempfile.TemporaryDirectory(prefix = "unsloth-llama-prebuilt-") as tmp:
                 work_dir = Path(tmp)
@@ -6347,7 +6389,10 @@ def install_prebuilt(
                                 f"{plan.release_tag} upstream_tag={plan.llama_tag}; skipping reinstall"
                             )
                             sync_marker_force_cpu(install_dir, persist_force_cpu)
-                            sync_marker_llama_backend(install_dir, persist_llama_backend)
+                            sync_marker_llama_backend(
+                                install_dir,
+                                persisted_llama_backend(persist_llama_backend, choice),
+                            )
                             return
                     log(
                         "selected "
@@ -6490,7 +6535,8 @@ def parse_args() -> argparse.Namespace:
         choices = ("vulkan",),
         help = (
             "Force the llama.cpp prebuilt backend. vulkan installs the upstream Vulkan "
-            "bundle on any host and records the choice so Studio updates keep it. "
+            "bundle and records the choice so Studio updates keep it; ignored on hosts "
+            "with no Vulkan prebuilt (macOS, Windows arm64). "
             "Same effect as UNSLOTH_LLAMA_BACKEND=vulkan / UNSLOTH_FORCE_VULKAN=1."
         ),
     )

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -91,6 +91,24 @@ WINDOWS_HIP_PREBUILT_GFX_TARGETS = frozenset(
 # Family labels forwarded by update markers / --rocm-gfx (gfx110X.zip assets).
 WINDOWS_ROCM_FAMILY_GFX_LABELS = frozenset({"gfx103x", "gfx110x", "gfx120x"})
 
+# Exactly ggml-org release.yml's windows-hip "radeon" gpu_targets. The set above adds
+# the fork-only bundles on top (gfx1034 via gfx103X, gfx1103 via gfx110X, standalone
+# gfx908 / gfx90a), so those four are served only when planning against the fork.
+UPSTREAM_WINDOWS_HIP_GFX_TARGETS = frozenset(
+    {
+        "gfx1030",
+        "gfx1031",
+        "gfx1032",
+        "gfx1100",
+        "gfx1101",
+        "gfx1102",
+        "gfx1150",
+        "gfx1151",
+        "gfx1200",
+        "gfx1201",
+    }
+)
+
 # install_kinds that really are a Vulkan bundle. Upstream ships no Vulkan archive for
 # Windows arm64 and x64 falls through to CPU when the Vulkan one is missing or fails
 # validation, so a Vulkan request can end on a CPU bundle; keeps the marker honest (#7357).
@@ -2587,8 +2605,8 @@ def _apply_host_overrides(
     A forwarded gfx (--rocm-gfx or UNSLOTH_ROCM_GFX_ARCH) implies ROCm: the
     installer's own hipinfo/amd-smi probe can miss the arch on amd-smi-only hosts
     or when setup inferred it from the GPU name, leaving rocm_gfx_target None and
-    no per-gfx ROCm prebuilt selected. It fills that gap but does not replace an
-    arch the probe did resolve -- see below. force_cpu is the opposite explicit
+    no per-gfx ROCm prebuilt selected. It fills that gap, and stays authoritative
+    except for the two advisory shapes narrowed below. force_cpu is the opposite explicit
     signal (arm64 Linux GPU host whose source build failed): drop GPU attributes
     so the CPU prebuilt for this OS/arch is selected."""
     if force_cpu:
@@ -2611,16 +2629,32 @@ def _apply_host_overrides(
         # when detect_host() resolved an active arch, keep it: replacing it with
         # GPU 0's arch makes _should_auto_vulkan_for_amd_windows() read a
         # HIP-supported GPU the user masked off, installing an unusable HIP bundle
-        # instead of Vulkan. An explicit UNSLOTH_ROCM_GFX_ARCH still wins -- it is
-        # the documented manual override for hosts whose arch the probes get wrong.
+        # instead of Vulkan.
+        # Narrow that to the two shapes a forward can only be advisory in:
+        #   * the arch is another GPU the probe saw ON THIS HOST, i.e. setup picked a
+        #     different physical GPU of the same box;
+        #   * the arch is a family label (gfx110X), which is a bundle name emitted by
+        #     the update path from the marker asset, never a real GPU arch. Letting it
+        #     replace a concrete probed arch would upgrade an in-generation-but-unbuilt
+        #     GPU (gfx1033) into the family bundle it must not be served.
+        # Anything else is an arch the probe never reported, so it is not a GPU-0
+        # mispick -- it is an operator override for a host whose arch the probe gets
+        # wrong or stale, which is exactly what --rocm-gfx documents, and it stays
+        # authoritative. UNSLOTH_ROCM_GFX_ARCH also still wins.
         _manual = _normalize_forwarded_gfx(os.environ.get("UNSLOTH_ROCM_GFX_ARCH"))
-        if gfx != _manual and _active_rocm_gfx_target(host):
+        _physical = _host_rocm_gfx_targets(host)
+        _active = _active_rocm_gfx_target(host)
+        _advisory = gfx in _physical or gfx in WINDOWS_ROCM_FAMILY_GFX_LABELS
+        if gfx != _manual and _active and gfx != _active and _advisory:
             return dataclasses_replace(host, has_rocm = True)
         return dataclasses_replace(
             host,
             has_rocm = True,
             rocm_gfx_target = gfx,
-            rocm_gfx_targets = [gfx],
+            # Keep the probe's per-GPU list when it already covers the forwarded
+            # arch: collapsing it to one entry would hide the host's other AMD
+            # cards from _should_auto_vulkan_for_amd_windows().
+            rocm_gfx_targets = list(host.rocm_gfx_targets) if gfx in _physical else [gfx],
         )
     if override_has_rocm and not host.has_rocm:
         return dataclasses_replace(host, has_rocm = True)
@@ -6126,34 +6160,60 @@ def _active_rocm_gfx_target(host: HostInfo) -> str | None:
     return None
 
 
-def _gfx_is_windows_hip_supported(gfx: str) -> bool:
+def _windows_hip_gfx_targets(published_repo: str | None) -> frozenset[str]:
+    """gfx targets the Windows HIP bundle of ``published_repo`` is actually built for.
+
+    The combined floor above is a union, so asking it "is this arch served?" is only
+    right for the fork. Planning against ggml-org directly (--published-repo) reaches
+    direct_upstream_release_plan(), whose AMD branch offers win-hip-radeon then CPU and
+    never Vulkan, so a fork-only arch answered "supported" there silently lands on CPU
+    instead of the Vulkan bundle that would actually run."""
+    if published_repo and published_repo.strip().lower() == UPSTREAM_REPO.lower():
+        return UPSTREAM_WINDOWS_HIP_GFX_TARGETS
+    return WINDOWS_HIP_PREBUILT_GFX_TARGETS
+
+
+def _gfx_is_windows_hip_supported(gfx: str, published_repo: str | None = None) -> bool:
     token = gfx.lower().strip()
     if token in WINDOWS_ROCM_FAMILY_GFX_LABELS:
+        # A family label names a fork bundle whose members are all built by upstream's
+        # windows-hip targets too (gfx103X -> gfx1030..1032, gfx110X -> gfx1100..1102,
+        # gfx120X -> gfx1200/1201), so HIP serves it whichever repo is planned against.
         return True
-    return token in WINDOWS_HIP_PREBUILT_GFX_TARGETS
+    return token in _windows_hip_gfx_targets(published_repo)
 
 
-def _host_has_windows_hip_prebuilt_gfx(host: HostInfo) -> bool:
+def _host_has_windows_hip_prebuilt_gfx(host: HostInfo, published_repo: str | None = None) -> bool:
     active = _active_rocm_gfx_target(host)
     if not active:
         return False
-    return _gfx_is_windows_hip_supported(active)
+    return _gfx_is_windows_hip_supported(active, published_repo)
 
 
-def _should_auto_vulkan_for_amd_windows(host: HostInfo) -> bool:
-    """True when the active AMD GPU is below the Windows HIP prebuilt floor."""
+def _should_auto_vulkan_for_amd_windows(host: HostInfo, published_repo: str | None = None) -> bool:
+    """True when NO AMD GPU on the host reaches the Windows HIP prebuilt floor."""
     active = _active_rocm_gfx_target(host)
     if not active:
         # ROCm confirmed but gfx unknown (--has-rocm only): keep the HIP / fork / source path.
         return False
-    return (
+    if not (
         host.is_windows
         and host.has_rocm
         # PHYSICAL, not merely usable: Vulkan ignores CUDA_VISIBLE_DEVICES and would
         # enumerate a card hidden by it. Same gate as the Intel auto path below.
         and not host.has_physical_nvidia
-        and not _gfx_is_windows_hip_supported(active)
-    )
+    ):
+        return False
+    # Every PHYSICAL AMD gfx, not just the active one. HIP_VISIBLE_DEVICES /
+    # ROCR_VISIBLE_DEVICES / CUDA_VISIBLE_DEVICES choose `active`, but the Vulkan
+    # runtime honours none of them: it enumerates through GGML_VK_VISIBLE_DEVICES and
+    # Vulkan ordinals (LlamaCppBackend._get_gpu_free_memory_vulkan). So masking down to
+    # a below-floor card must not route the install to Vulkan -- the installed backend
+    # would happily enumerate the HIP-capable card the user deliberately hid, possibly
+    # one reserved for another workload. Auto-fall back only when no AMD device on the
+    # box can be exposed to HIP; an explicit vulkan opt-in is unaffected.
+    targets = list(dict.fromkeys([*_host_rocm_gfx_targets(host), active]))
+    return not any(_gfx_is_windows_hip_supported(target, published_repo) for target in targets)
 
 
 def _has_no_vulkan_prebuilt(host: HostInfo) -> bool:
@@ -6211,7 +6271,9 @@ def _route_to_vulkan_prebuilt(
     forced = force_vulkan_requested(llama_backend)
     # Auto-fall back only when the run named no backend: an explicit hip/cpu is the opt-out.
     explicit_backend = resolved_llama_backend(llama_backend)
-    auto_no_hip = explicit_backend is None and _should_auto_vulkan_for_amd_windows(host)
+    auto_no_hip = explicit_backend is None and _should_auto_vulkan_for_amd_windows(
+        host, published_repo
+    )
     # No PHYSICAL NVIDIA, not merely no usable one: Vulkan ignores CUDA_VISIBLE_DEVICES, so
     # auto-routing a host that hides its NVIDIA card would let it grab the reserved GPU.
     # An explicit Vulkan opt-in still overrides.

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -6187,14 +6187,19 @@ def _hip_visible_device_mask_set() -> bool:
 def _windows_hip_gfx_targets(published_repo: str | None) -> frozenset[str]:
     """gfx targets the Windows HIP bundle of ``published_repo`` is actually built for.
 
-    The combined floor above is a union, so asking it "is this arch served?" is only
-    right for the fork. Planning against ggml-org directly (--published-repo) reaches
-    direct_upstream_release_plan(), whose AMD branch offers win-hip-radeon then CPU and
-    never Vulkan, so a fork-only arch answered "supported" there silently lands on CPU
-    instead of the Vulkan bundle that would actually run."""
-    if published_repo and published_repo.strip().lower() == UPSTREAM_REPO.lower():
-        return UPSTREAM_WINDOWS_HIP_GFX_TARGETS
-    return WINDOWS_HIP_PREBUILT_GFX_TARGETS
+    The combined floor above is a union of the FORK's windows-rocm bundles, and only the
+    fork is planned from a manifest: resolve_simple_install_release_plans() sends every
+    other --published-repo -- ggml-org itself, but equally any mirror carrying
+    upstream-standard assets -- to direct_upstream_release_plan(), whose AMD branch offers
+    win-hip-radeon then CPU and never Vulkan. Answering "supported" there for a fork-only
+    arch (gfx1034, gfx1103, gfx908, ...) silently lands it on HIP/CPU instead of the Vulkan
+    bundle that would actually run, so gate on the fork rather than exempting one repo.
+    Mirror that dispatch exactly, spelling included: it compares == DEFAULT_PUBLISHED_REPO
+    with an empty value defaulting to the fork, so a differently cased repo really does
+    take the upstream path and must be answered with upstream coverage."""
+    if (published_repo or DEFAULT_PUBLISHED_REPO) == DEFAULT_PUBLISHED_REPO:
+        return WINDOWS_HIP_PREBUILT_GFX_TARGETS
+    return UPSTREAM_WINDOWS_HIP_GFX_TARGETS
 
 
 def _gfx_is_windows_hip_supported(gfx: str, published_repo: str | None = None) -> bool:

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -6165,6 +6165,24 @@ def _active_rocm_gfx_target(host: HostInfo) -> str | None:
     return None
 
 
+def _hip_visible_device_mask_set() -> bool:
+    """Whether a HIP visible-device mask is filtering this process's view of the GPUs.
+
+    The Windows arch probe is hipinfo, itself a HIP application, and AMD documents these
+    as "only devices whose index is present in the sequence are visible to HIP" (with
+    HIP_VISIBLE_DEVICES the Windows spelling), so under a mask it enumerates the VISIBLE
+    devices, not the physical ones. Same first-var-wins order as _pick_rocm_gfx_target,
+    which reads the identical three. Empty / "-1" hides every AMD GPU, which that
+    function already reports as no active target, so it is not a partial mask here."""
+    for _env in ("HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"):
+        _val = os.environ.get(_env)
+        if _val is None:
+            continue
+        _val = _val.strip()
+        return bool(_val) and _val != "-1"
+    return False
+
+
 def _windows_hip_gfx_targets(published_repo: str | None) -> frozenset[str]:
     """gfx targets the Windows HIP bundle of ``published_repo`` is actually built for.
 
@@ -6217,6 +6235,15 @@ def _should_auto_vulkan_for_amd_windows(host: HostInfo, published_repo: str | No
     # would happily enumerate the HIP-capable card the user deliberately hid, possibly
     # one reserved for another workload. Auto-fall back only when no AMD device on the
     # box can be exposed to HIP; an explicit vulkan opt-in is unaffected.
+    #
+    # Under a mask the probe cannot supply that inventory at all: hipinfo is a HIP
+    # application, so it enumerates only the visible devices and rocm_gfx_targets lists
+    # what survived the mask rather than what is installed. "No AMD GPU here reaches the
+    # floor" is then unprovable, and guessing wrong is the same reserved-card handover,
+    # so decline to guess. The mask is only ever set deliberately, and the driver-only
+    # single-GPU host this fallback exists for does not set one.
+    if _hip_visible_device_mask_set():
+        return False
     targets = list(dict.fromkeys([*_host_rocm_gfx_targets(host), active]))
     return not any(_gfx_is_windows_hip_supported(target, published_repo) for target in targets)
 

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -6166,21 +6166,22 @@ def _active_rocm_gfx_target(host: HostInfo) -> str | None:
 
 
 def _hip_visible_device_mask_set() -> bool:
-    """Whether a HIP visible-device mask is filtering this process's view of the GPUs.
+    """Whether a HIP visible-device mask is in force for this process.
 
     The Windows arch probe is hipinfo, itself a HIP application, and AMD documents these
     as "only devices whose index is present in the sequence are visible to HIP" (with
     HIP_VISIBLE_DEVICES the Windows spelling), so under a mask it enumerates the VISIBLE
-    devices, not the physical ones. Same first-var-wins order as _pick_rocm_gfx_target,
-    which reads the identical three. Empty / "-1" hides every AMD GPU, which that
-    function already reports as no active target, so it is not a partial mask here."""
-    for _env in ("HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"):
-        _val = os.environ.get(_env)
-        if _val is None:
-            continue
-        _val = _val.strip()
-        return bool(_val) and _val != "-1"
-    return False
+    devices, not the physical ones. Presence is the whole test: a partial mask leaves the
+    inventory unknowable, and an all-hiding "" / "-1" is the strongest form of the same
+    signal rather than an exemption -- the probe reports no arch there, but --rocm-gfx
+    can still supply one (setup's name inference reads the display adapter, which no HIP
+    mask touches), so the guard would otherwise auto-route a host on which the user hid
+    every AMD GPU. Same first-var-wins order as _pick_rocm_gfx_target, which reads the
+    identical three, so the two cannot disagree about the host."""
+    return any(
+        os.environ.get(_env) is not None
+        for _env in ("HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES")
+    )
 
 
 def _windows_hip_gfx_targets(published_repo: str | None) -> frozenset[str]:
@@ -6240,8 +6241,10 @@ def _should_auto_vulkan_for_amd_windows(host: HostInfo, published_repo: str | No
     # application, so it enumerates only the visible devices and rocm_gfx_targets lists
     # what survived the mask rather than what is installed. "No AMD GPU here reaches the
     # floor" is then unprovable, and guessing wrong is the same reserved-card handover,
-    # so decline to guess. The mask is only ever set deliberately, and the driver-only
-    # single-GPU host this fallback exists for does not set one.
+    # so decline to guess. An all-hiding "" / "-1" is included: the probe reports no arch
+    # there, but a forwarded --rocm-gfx still reconstructs one, and auto-routing then
+    # hands Vulkan every AMD GPU the user hid. The mask is only ever set deliberately,
+    # and the driver-only single-GPU host this fallback exists for does not set one.
     if _hip_visible_device_mask_set():
         return False
     targets = list(dict.fromkeys([*_host_rocm_gfx_targets(host), active]))

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -2651,10 +2651,15 @@ def _apply_host_overrides(
             host,
             has_rocm = True,
             rocm_gfx_target = gfx,
-            # Keep the probe's per-GPU list when it already covers the forwarded
-            # arch: collapsing it to one entry would hide the host's other AMD
-            # cards from _should_auto_vulkan_for_amd_windows().
-            rocm_gfx_targets = list(host.rocm_gfx_targets) if gfx in _physical else [gfx],
+            # ADD the forwarded arch to the probe's per-GPU list, never replace it.
+            # That list is the PHYSICAL inventory _should_auto_vulkan_for_amd_windows()
+            # reads, and a forwarded arch says which GPU HIP should target, not which
+            # cards exist: dropping a probe-confirmed GPU would let a stale or
+            # name-inferred below-floor forward auto-route a box whose probe saw a
+            # HIP-capable card to Vulkan, which then enumerates that card regardless of
+            # HIP_VISIBLE_DEVICES. An empty probe still yields [gfx] -- the driver-only
+            # host the forward exists for keeps its auto-Vulkan fallback.
+            rocm_gfx_targets = list(dict.fromkeys([*_physical, gfx])),
         )
     if override_has_rocm and not host.has_rocm:
         return dataclasses_replace(host, has_rocm = True)

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -64,12 +64,11 @@ EXIT_FALLBACK = 2
 EXIT_ERROR = 1
 EXIT_BUSY = 3
 
-# Every gfx a Windows AMD host can already be served: ggml-org release.yml windows-hip
-# GPU_TARGETS plus the fork's windows-rocm bundles (gfx103X adds gfx1034, gfx110X adds
-# gfx1103; gfx908 / gfx90a ship standalone). Must stay a superset of the manifest's
-# windows-rocm mapped_targets, else auto-Vulkan steals a host the fork already builds
-# for. Below this floor (e.g. gfx803 / RX 480) HIP has no prebuilt and Vulkan is the
-# practical llama-server backend on Windows (#7357).
+# Every gfx a Windows AMD host can be served: ggml-org release.yml windows-hip GPU_TARGETS
+# plus the fork's windows-rocm bundles. Must stay a superset of the manifest's windows-rocm
+# mapped_targets, else auto-Vulkan steals a host the fork already builds for. Below this
+# floor (e.g. gfx803 / RX 480) HIP has no prebuilt and Vulkan is the practical Windows
+# llama-server backend (#7357).
 WINDOWS_HIP_PREBUILT_GFX_TARGETS = frozenset(
     {
         "gfx908",
@@ -91,9 +90,8 @@ WINDOWS_HIP_PREBUILT_GFX_TARGETS = frozenset(
 # Family labels forwarded by update markers / --rocm-gfx (gfx110X.zip assets).
 WINDOWS_ROCM_FAMILY_GFX_LABELS = frozenset({"gfx103x", "gfx110x", "gfx120x"})
 
-# Exactly ggml-org release.yml's windows-hip "radeon" gpu_targets. The set above adds
-# the fork-only bundles on top (gfx1034 via gfx103X, gfx1103 via gfx110X, standalone
-# gfx908 / gfx90a), so those four are served only when planning against the fork.
+# Exactly ggml-org release.yml's windows-hip "radeon" gpu_targets. The set above adds the
+# fork-only bundles (gfx1034, gfx1103, gfx908, gfx90a), served only against the fork.
 UPSTREAM_WINDOWS_HIP_GFX_TARGETS = frozenset(
     {
         "gfx1030",
@@ -109,9 +107,9 @@ UPSTREAM_WINDOWS_HIP_GFX_TARGETS = frozenset(
     }
 )
 
-# install_kinds that really are a Vulkan bundle. Upstream ships no Vulkan archive for
-# Windows arm64 and x64 falls through to CPU when the Vulkan one is missing or fails
-# validation, so a Vulkan request can end on a CPU bundle; keeps the marker honest (#7357).
+# install_kinds that really are a Vulkan bundle. A Vulkan request can still end on a CPU
+# bundle (no Vulkan archive on Windows arm64; x64 falls through when it is missing or fails
+# validation), so check against this to keep the marker honest (#7357).
 VULKAN_INSTALL_KINDS = frozenset({"linux-vulkan", "windows-vulkan"})
 
 # DiskPart-prompt suppression. RunAsInvoker does NOT stop amd-smi's runtime
@@ -2196,9 +2194,9 @@ def run_capture(
 def _list_rocm_gfx_targets(out: str) -> list[str]:
     """List gfx targets rocminfo / hipinfo report, one entry per physical GPU.
 
-    Both print the same gfx token several times per GPU (Name, ISA, marketing-name),
-    so split on per-GPU section headers to keep two entries on a dual same-arch host;
-    flat strings and test stubs fall back to insertion-order dedup.
+    Both repeat the same gfx token per GPU (Name, ISA, marketing-name), so split on per-GPU
+    section headers to keep two entries on a dual same-arch host; flat strings and test stubs
+    fall back to insertion-order dedup.
     """
     _sections = re.split(
         r"(?mi)^\s*\*+\s*$\s*agent\s+\d+\s*$|\bdevice\s*#\s*\d+\b",
@@ -2219,10 +2217,9 @@ def _list_rocm_gfx_targets(out: str) -> list[str]:
 def _pick_rocm_gfx_target(out: str) -> str | None:
     """Choose the gfx target rocminfo / hipinfo report for the active GPU.
 
-    A bare first-match picked the wrong device on mixed APU + dGPU hosts (e.g. Strix
-    Halo gfx1151 + discrete RX 7900 gfx1100), so honour HIP_VISIBLE_DEVICES /
-    ROCR_VISIBLE_DEVICES / CUDA_VISIBLE_DEVICES; no env var means the first GPU, and
-    empty / "-1" means no AMD GPU is visible to HIP (None).
+    A bare first-match picked the wrong device on mixed APU + dGPU hosts (Strix Halo gfx1151
+    + RX 7900 gfx1100), so honour HIP_VISIBLE_DEVICES / ROCR_VISIBLE_DEVICES /
+    CUDA_VISIBLE_DEVICES; no env var means the first GPU, empty / "-1" means none (None).
     """
     _tokens = _list_rocm_gfx_targets(out)
     if not _tokens:
@@ -2602,13 +2599,12 @@ def _apply_host_overrides(
     force_cpu: bool = False,
 ) -> HostInfo:
     """Fold setup.sh/setup.ps1's forwarded detection into the host profile.
-    A forwarded gfx (--rocm-gfx or UNSLOTH_ROCM_GFX_ARCH) implies ROCm: the
-    installer's own hipinfo/amd-smi probe can miss the arch on amd-smi-only hosts
-    or when setup inferred it from the GPU name, leaving rocm_gfx_target None and
-    no per-gfx ROCm prebuilt selected. It fills that gap, and stays authoritative
-    except for the two advisory shapes narrowed below. force_cpu is the opposite explicit
-    signal (arm64 Linux GPU host whose source build failed): drop GPU attributes
-    so the CPU prebuilt for this OS/arch is selected."""
+    A forwarded gfx (--rocm-gfx or UNSLOTH_ROCM_GFX_ARCH) implies ROCm and fills the gap
+    where our own hipinfo/amd-smi probe misses the arch (amd-smi-only hosts, or setup
+    inferring it from the GPU name), leaving no per-gfx ROCm prebuilt selected; it stays
+    authoritative except for the two advisory shapes narrowed below. force_cpu is the
+    opposite explicit signal (arm64 Linux GPU host whose source build failed): drop GPU
+    attributes so the CPU prebuilt for this OS/arch is selected."""
     if force_cpu:
         return dataclasses_replace(
             host,
@@ -2621,25 +2617,18 @@ def _apply_host_overrides(
         )
     gfx = _normalize_forwarded_gfx(override_rocm_gfx)
     if gfx:
-        # setup.ps1 picks the arch from its own probe, and that pick is not fully
-        # visible-device aware: neither its hipinfo nor its amd-smi branch reads
-        # CUDA_VISIBLE_DEVICES, and the amd-smi branch matches a bare integer only,
-        # so a comma-separated mask ("1,0") also falls back to GPU 0.
-        # _pick_rocm_gfx_target() honours all three vars with HIP's semantics, so
-        # when detect_host() resolved an active arch, keep it: replacing it with
-        # GPU 0's arch makes _should_auto_vulkan_for_amd_windows() read a
-        # HIP-supported GPU the user masked off, installing an unusable HIP bundle
-        # instead of Vulkan.
-        # Narrow that to the two shapes a forward can only be advisory in:
-        #   * the arch is another GPU the probe saw ON THIS HOST, i.e. setup picked a
-        #     different physical GPU of the same box;
-        #   * the arch is a family label (gfx110X), which is a bundle name emitted by
-        #     the update path from the marker asset, never a real GPU arch. Letting it
-        #     replace a concrete probed arch would upgrade an in-generation-but-unbuilt
-        #     GPU (gfx1033) into the family bundle it must not be served.
-        # Anything else is an arch the probe never reported, so it is not a GPU-0
-        # mispick -- it is an operator override for a host whose arch the probe gets
-        # wrong or stale, which is exactly what --rocm-gfx documents, and it stays
+        # setup.ps1's pick is not fully visible-device aware (neither branch reads
+        # CUDA_VISIBLE_DEVICES; amd-smi matches a bare integer only, so "1,0" falls back to
+        # GPU 0), while _pick_rocm_gfx_target() honours all three vars with HIP's semantics.
+        # So keep a probed active arch when the forward is only advisory, else
+        # _should_auto_vulkan_for_amd_windows() reads a HIP-supported GPU the user masked
+        # off and installs an unusable HIP bundle instead of Vulkan. Advisory means:
+        #   * another GPU the probe saw ON THIS HOST, i.e. setup picked a different card;
+        #   * a family label (gfx110X), a bundle name the update path emits from the marker
+        #     asset and never a real arch -- it would upgrade an in-generation-but-unbuilt
+        #     GPU (gfx1033) into a bundle it must not be served.
+        # Anything else the probe never reported is an operator override for a host whose
+        # arch the probe gets wrong or stale, exactly what --rocm-gfx documents, so it stays
         # authoritative. UNSLOTH_ROCM_GFX_ARCH also still wins.
         _manual = _normalize_forwarded_gfx(os.environ.get("UNSLOTH_ROCM_GFX_ARCH"))
         _physical = _host_rocm_gfx_targets(host)
@@ -2651,14 +2640,13 @@ def _apply_host_overrides(
             host,
             has_rocm = True,
             rocm_gfx_target = gfx,
-            # ADD the forwarded arch to the probe's per-GPU list, never replace it.
-            # That list is the PHYSICAL inventory _should_auto_vulkan_for_amd_windows()
-            # reads, and a forwarded arch says which GPU HIP should target, not which
-            # cards exist: dropping a probe-confirmed GPU would let a stale or
-            # name-inferred below-floor forward auto-route a box whose probe saw a
-            # HIP-capable card to Vulkan, which then enumerates that card regardless of
-            # HIP_VISIBLE_DEVICES. An empty probe still yields [gfx] -- the driver-only
-            # host the forward exists for keeps its auto-Vulkan fallback.
+            # ADD the forwarded arch to the probe's per-GPU list, never replace it: that
+            # list is the PHYSICAL inventory _should_auto_vulkan_for_amd_windows() reads,
+            # and a forward says which GPU HIP should target, not which cards exist.
+            # Dropping a probe-confirmed GPU would let a stale below-floor forward
+            # auto-route a box with a HIP-capable card to Vulkan, which then enumerates
+            # that card regardless of HIP_VISIBLE_DEVICES. An empty probe still yields
+            # [gfx], so the driver-only host the forward exists for keeps auto-Vulkan.
             rocm_gfx_targets = list(dict.fromkeys([*_physical, gfx])),
         )
     if override_has_rocm and not host.has_rocm:
@@ -5536,11 +5524,10 @@ def _fork_manifest_release_plans(
 def persisted_llama_backend(llama_backend: str | None, choice: AssetChoice) -> str | None:
     """The backend to record for an install that actually landed ``choice``.
 
-    A Vulkan request can end on a non-Vulkan bundle: Windows arm64 has no upstream
-    Vulkan archive (release.yml builds vulkan for x64, opencl-adreno for arm64), and
-    x64 falls through to win-cpu-x64 when the Vulkan archive is missing or fails
-    validation. Recording "vulkan" there would make the updater re-assert a backend
-    that was never installed. Mirrors force_cpu: persist the real outcome only."""
+    A Vulkan request can end on a non-Vulkan bundle (no upstream Vulkan archive for Windows
+    arm64; x64 falls through to win-cpu-x64 when it is missing or fails validation), and
+    recording "vulkan" there would make the updater re-assert a backend that was never
+    installed. Mirrors force_cpu: persist the real outcome only."""
     if llama_backend == "vulkan" and choice.install_kind not in VULKAN_INSTALL_KINDS:
         return None
     return llama_backend
@@ -6119,8 +6106,8 @@ def llama_backend_from_env() -> str | None:
     """Read an explicit llama.cpp backend preference from the environment.
 
     Only ``UNSLOTH_LLAMA_BACKEND`` is honored. ``UNSLOTH_LLAMA_CPP_BACKEND`` is a separate
-    setup variable meaning ``auto``/``cpu`` (not a backend name) that setup.sh/setup.ps1 warn
-    about and ignore otherwise, so reading it here would force Vulkan behind that warning.
+    setup variable meaning ``auto``/``cpu`` (not a backend name) that setup warns about and
+    otherwise ignores, so reading it here would force Vulkan behind that warning.
     """
     return _normalized_llama_backend(os.environ.get("UNSLOTH_LLAMA_BACKEND"))
 
@@ -6140,8 +6127,8 @@ def force_vulkan_requested(llama_backend: str | None = None) -> bool:
     """
     backend = resolved_llama_backend(llama_backend)
     if backend is not None:
-        # Authoritative, so =hip is a real opt-out and not overruled by a stale
-        # UNSLOTH_FORCE_VULKAN.
+        # Authoritative, so =hip is a real opt-out a stale UNSLOTH_FORCE_VULKAN cannot
+        # overrule.
         return backend == "vulkan"
     return os.environ.get("UNSLOTH_FORCE_VULKAN", "").strip().lower() in (
         "1",
@@ -6168,16 +6155,13 @@ def _active_rocm_gfx_target(host: HostInfo) -> str | None:
 def _hip_visible_device_mask_set() -> bool:
     """Whether a HIP visible-device mask is in force for this process.
 
-    The Windows arch probe is hipinfo, itself a HIP application, and AMD documents these
-    as "only devices whose index is present in the sequence are visible to HIP" (with
-    HIP_VISIBLE_DEVICES the Windows spelling), so under a mask it enumerates the VISIBLE
-    devices, not the physical ones. Presence is the whole test: a partial mask leaves the
-    inventory unknowable, and an all-hiding "" / "-1" is the strongest form of the same
-    signal rather than an exemption -- the probe reports no arch there, but --rocm-gfx
-    can still supply one (setup's name inference reads the display adapter, which no HIP
-    mask touches), so the guard would otherwise auto-route a host on which the user hid
-    every AMD GPU. Same first-var-wins order as _pick_rocm_gfx_target, which reads the
-    identical three, so the two cannot disagree about the host."""
+    The Windows arch probe is hipinfo, itself a HIP application, so under a mask it
+    enumerates the VISIBLE devices, not the physical ones. Presence is the whole test: a
+    partial mask leaves the inventory unknowable, and an all-hiding "" / "-1" is the
+    strongest form of that, not an exemption, since --rocm-gfx can still supply an arch
+    (setup infers it from the display adapter, which no HIP mask touches) and would
+    auto-route a host on which the user hid every AMD GPU. Reads the same three vars as
+    _pick_rocm_gfx_target, so the two cannot disagree about the host."""
     return any(
         os.environ.get(_env) is not None
         for _env in ("HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES")
@@ -6187,16 +6171,15 @@ def _hip_visible_device_mask_set() -> bool:
 def _windows_hip_gfx_targets(published_repo: str | None) -> frozenset[str]:
     """gfx targets the Windows HIP bundle of ``published_repo`` is actually built for.
 
-    The combined floor above is a union of the FORK's windows-rocm bundles, and only the
-    fork is planned from a manifest: resolve_simple_install_release_plans() sends every
-    other --published-repo -- ggml-org itself, but equally any mirror carrying
-    upstream-standard assets -- to direct_upstream_release_plan(), whose AMD branch offers
-    win-hip-radeon then CPU and never Vulkan. Answering "supported" there for a fork-only
-    arch (gfx1034, gfx1103, gfx908, ...) silently lands it on HIP/CPU instead of the Vulkan
-    bundle that would actually run, so gate on the fork rather than exempting one repo.
-    Mirror that dispatch exactly, spelling included: it compares == DEFAULT_PUBLISHED_REPO
-    with an empty value defaulting to the fork, so a differently cased repo really does
-    take the upstream path and must be answered with upstream coverage."""
+    The combined floor above includes the FORK's windows-rocm bundles, and only the fork is
+    planned from a manifest: resolve_simple_install_release_plans() sends every other
+    --published-repo (ggml-org, but equally any mirror of upstream-standard assets) to
+    direct_upstream_release_plan(), whose AMD branch offers win-hip-radeon then CPU and never
+    Vulkan. Answering "supported" there for a fork-only arch would silently land it on
+    HIP/CPU instead of the Vulkan bundle that would actually run, so gate on the fork rather
+    than exempting one repo, mirroring that dispatch exactly, spelling included: an empty
+    value defaults to the fork, and a differently cased repo really does take the upstream
+    path and must be answered with upstream coverage."""
     if (published_repo or DEFAULT_PUBLISHED_REPO) == DEFAULT_PUBLISHED_REPO:
         return WINDOWS_HIP_PREBUILT_GFX_TARGETS
     return UPSTREAM_WINDOWS_HIP_GFX_TARGETS
@@ -6205,9 +6188,9 @@ def _windows_hip_gfx_targets(published_repo: str | None) -> frozenset[str]:
 def _gfx_is_windows_hip_supported(gfx: str, published_repo: str | None = None) -> bool:
     token = gfx.lower().strip()
     if token in WINDOWS_ROCM_FAMILY_GFX_LABELS:
-        # A family label names a fork bundle whose members are all built by upstream's
-        # windows-hip targets too (gfx103X -> gfx1030..1032, gfx110X -> gfx1100..1102,
-        # gfx120X -> gfx1200/1201), so HIP serves it whichever repo is planned against.
+        # A family label names a fork bundle whose members upstream's windows-hip targets
+        # all build too (gfx103X -> gfx1030..1032 etc), so HIP serves it against either
+        # repo.
         return True
     return token in _windows_hip_gfx_targets(published_repo)
 
@@ -6233,23 +6216,20 @@ def _should_auto_vulkan_for_amd_windows(host: HostInfo, published_repo: str | No
         and not host.has_physical_nvidia
     ):
         return False
-    # Every PHYSICAL AMD gfx, not just the active one. HIP_VISIBLE_DEVICES /
-    # ROCR_VISIBLE_DEVICES / CUDA_VISIBLE_DEVICES choose `active`, but the Vulkan
-    # runtime honours none of them: it enumerates through GGML_VK_VISIBLE_DEVICES and
-    # Vulkan ordinals (LlamaCppBackend._get_gpu_free_memory_vulkan). So masking down to
-    # a below-floor card must not route the install to Vulkan -- the installed backend
-    # would happily enumerate the HIP-capable card the user deliberately hid, possibly
-    # one reserved for another workload. Auto-fall back only when no AMD device on the
-    # box can be exposed to HIP; an explicit vulkan opt-in is unaffected.
+    # Judge every PHYSICAL AMD gfx, not just the active one. The visible-device vars choose
+    # `active`, but the Vulkan runtime honours none of them (it enumerates through
+    # GGML_VK_VISIBLE_DEVICES and Vulkan ordinals), so masking down to a below-floor card
+    # must not route the install to Vulkan: the installed backend would happily enumerate
+    # the HIP-capable card the user deliberately hid, possibly one reserved for another
+    # workload. Auto-fall back only when no AMD device on the box can be exposed to HIP; an
+    # explicit vulkan opt-in is unaffected.
     #
-    # Under a mask the probe cannot supply that inventory at all: hipinfo is a HIP
-    # application, so it enumerates only the visible devices and rocm_gfx_targets lists
-    # what survived the mask rather than what is installed. "No AMD GPU here reaches the
-    # floor" is then unprovable, and guessing wrong is the same reserved-card handover,
-    # so decline to guess. An all-hiding "" / "-1" is included: the probe reports no arch
-    # there, but a forwarded --rocm-gfx still reconstructs one, and auto-routing then
-    # hands Vulkan every AMD GPU the user hid. The mask is only ever set deliberately,
-    # and the driver-only single-GPU host this fallback exists for does not set one.
+    # Under a mask the probe cannot supply that inventory at all (hipinfo sees only visible
+    # devices), so "no AMD GPU here reaches the floor" is unprovable and guessing wrong is
+    # the same reserved-card handover. An all-hiding "" / "-1" is included: a forwarded
+    # --rocm-gfx still reconstructs an arch there, and auto-routing would then hand Vulkan
+    # every AMD GPU the user hid. A mask is only ever set deliberately, and the driver-only
+    # single-GPU host this fallback exists for does not set one.
     if _hip_visible_device_mask_set():
         return False
     targets = list(dict.fromkeys([*_host_rocm_gfx_targets(host), active]))
@@ -6259,9 +6239,9 @@ def _should_auto_vulkan_for_amd_windows(host: HostInfo, published_repo: str | No
 def _has_no_vulkan_prebuilt(host: HostInfo) -> bool:
     """Platforms that ship no Vulkan prebuilt at all, so routing there is pointless.
 
-    Upstream release.yml builds win-vulkan for x64 only; Windows arm64 gets win-cpu-arm64
-    plus win-opencl-adreno-arm64, so rewriting it to Vulkan-only would just swap the
-    published bundle for the upstream CPU one. macOS is handled separately (Metal)."""
+    Upstream builds win-vulkan for x64 only; Windows arm64 gets CPU plus opencl-adreno, so
+    rewriting it to Vulkan-only would just swap the published bundle for the upstream CPU
+    one. macOS is handled separately (Metal)."""
     return host.is_windows and host.is_arm64
 
 
@@ -6294,19 +6274,19 @@ def _route_to_vulkan_prebuilt(
 ) -> tuple[HostInfo, str, str, str | None]:
     """Point a Vulkan-capable host at the upstream ggml-org Vulkan prebuilt.
 
-    The unsloth published repo ships only CUDA/ROCm/CPU assets, so Vulkan comes
-    from UPSTREAM_REPO. Three triggers route here, all suppressed when a CPU flag
-    (--cpu-fallback or --force-cpu, folded into force_cpu) wins:
+    The unsloth published repo ships only CUDA/ROCm/CPU assets, so Vulkan comes from
+    UPSTREAM_REPO. Three triggers route here, all suppressed when a CPU flag (--cpu-fallback
+    or --force-cpu, folded into force_cpu) wins:
       * ``UNSLOTH_LLAMA_BACKEND=vulkan`` / ``UNSLOTH_FORCE_VULKAN`` / ``--llama-backend
         vulkan`` forces Vulkan over the detected CUDA/ROCm backend;
       * Windows AMD with no HIP-prebuilt gfx arch auto-falls back to Vulkan (#7357);
-      * an auto-detected Intel GPU with NO physical NVIDIA/ROCm -- the purpose
-        of the has_intel_gpu probe, since the fork manifest ships no Vulkan asset.
-    Applied by BOTH the install path and the --resolve-prebuilt probe so the
-    "is a prebuilt available" answer matches what actually gets installed.
+      * an auto-detected Intel GPU with NO physical NVIDIA/ROCm, the purpose of the
+        has_intel_gpu probe, since the fork manifest ships no Vulkan asset.
+    Applied by BOTH the install path and the --resolve-prebuilt probe so the "is a prebuilt
+    available" answer matches what actually gets installed.
 
-    Returns the (possibly rewritten) host, repo, release tag, and a backend
-    value to persist in the install marker when updates must re-assert Vulkan.
+    Returns the (possibly rewritten) host, repo, release tag, and a backend to persist in
+    the install marker when updates must re-assert Vulkan.
     """
     forced = force_vulkan_requested(llama_backend)
     # Auto-fall back only when the run named no backend: an explicit hip/cpu is the opt-out.
@@ -6316,7 +6296,6 @@ def _route_to_vulkan_prebuilt(
     )
     # No PHYSICAL NVIDIA, not merely no usable one: Vulkan ignores CUDA_VISIBLE_DEVICES, so
     # auto-routing a host that hides its NVIDIA card would let it grab the reserved GPU.
-    # An explicit Vulkan opt-in still overrides.
     auto_intel = host.has_intel_gpu and not host.has_physical_nvidia and not host.has_rocm
     if force_cpu or not (forced or auto_intel or auto_no_hip):
         return host, published_repo, published_release_tag, None

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -6188,9 +6188,12 @@ def _windows_hip_gfx_targets(published_repo: str | None) -> frozenset[str]:
 def _gfx_is_windows_hip_supported(gfx: str, published_repo: str | None = None) -> bool:
     token = gfx.lower().strip()
     if token in WINDOWS_ROCM_FAMILY_GFX_LABELS:
-        # A family label names a fork bundle whose members upstream's windows-hip targets
-        # all build too (gfx103X -> gfx1030..1032 etc), so HIP serves it against either
-        # repo.
+        # A bundle name, not an arch, so the concrete GPU is unknown here. The fork builds
+        # every member; upstream builds all but gfx1034 / gfx1103. Answering "unsupported"
+        # to cover that pair would move gfx1030..1032 / gfx1100..1102 off a working HIP
+        # build onto Vulkan for a member the label cannot identify, so HIP serves it either
+        # way. A concrete arch below still answers per repo, which is where gfx1034 and
+        # gfx1103 do reach Vulkan.
         return True
     return token in _windows_hip_gfx_targets(published_repo)
 

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -2584,12 +2584,13 @@ def _apply_host_overrides(
     force_cpu: bool = False,
 ) -> HostInfo:
     """Fold setup.sh/setup.ps1's forwarded detection into the host profile.
-    A forwarded gfx (--rocm-gfx or UNSLOTH_ROCM_GFX_ARCH) is authoritative and
-    implies ROCm: the installer's own hipinfo/amd-smi probe can miss the arch on
-    amd-smi-only hosts or when setup inferred it from the GPU name, leaving
-    rocm_gfx_target None and no per-gfx ROCm prebuilt selected. force_cpu is the
-    opposite explicit signal (arm64 Linux GPU host whose source build failed):
-    drop GPU attributes so the CPU prebuilt for this OS/arch is selected."""
+    A forwarded gfx (--rocm-gfx or UNSLOTH_ROCM_GFX_ARCH) implies ROCm: the
+    installer's own hipinfo/amd-smi probe can miss the arch on amd-smi-only hosts
+    or when setup inferred it from the GPU name, leaving rocm_gfx_target None and
+    no per-gfx ROCm prebuilt selected. It fills that gap but does not replace an
+    arch the probe did resolve -- see below. force_cpu is the opposite explicit
+    signal (arm64 Linux GPU host whose source build failed): drop GPU attributes
+    so the CPU prebuilt for this OS/arch is selected."""
     if force_cpu:
         return dataclasses_replace(
             host,
@@ -2602,6 +2603,19 @@ def _apply_host_overrides(
         )
     gfx = _normalize_forwarded_gfx(override_rocm_gfx)
     if gfx:
+        # setup.ps1 picks the arch from its own probe, and that pick is not fully
+        # visible-device aware: neither its hipinfo nor its amd-smi branch reads
+        # CUDA_VISIBLE_DEVICES, and the amd-smi branch matches a bare integer only,
+        # so a comma-separated mask ("1,0") also falls back to GPU 0.
+        # _pick_rocm_gfx_target() honours all three vars with HIP's semantics, so
+        # when detect_host() resolved an active arch, keep it: replacing it with
+        # GPU 0's arch makes _should_auto_vulkan_for_amd_windows() read a
+        # HIP-supported GPU the user masked off, installing an unusable HIP bundle
+        # instead of Vulkan. An explicit UNSLOTH_ROCM_GFX_ARCH still wins -- it is
+        # the documented manual override for hosts whose arch the probes get wrong.
+        _manual = _normalize_forwarded_gfx(os.environ.get("UNSLOTH_ROCM_GFX_ARCH"))
+        if gfx != _manual and _active_rocm_gfx_target(host):
+            return dataclasses_replace(host, has_rocm = True)
         return dataclasses_replace(
             host,
             has_rocm = True,

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -64,13 +64,12 @@ EXIT_FALLBACK = 2
 EXIT_ERROR = 1
 EXIT_BUSY = 3
 
-# Every gfx a Windows AMD host can already be served: ggml-org/llama.cpp
-# release.yml windows-hip GPU_TARGETS, plus the archs the fork's windows-rocm
-# bundles cover (gfx103X adds gfx1034, gfx110X adds gfx1103, and gfx908 / gfx90a
-# ship as their own bundles). Must stay a superset of the manifest's windows-rocm
-# mapped_targets, else auto-Vulkan would steal a host the fork already builds for.
-# Cards below this floor (e.g. gfx803 / RX 480) are invisible to the HIP prebuilt;
-# Vulkan is the practical llama-server backend on Windows for those hosts (#7357).
+# Every gfx a Windows AMD host can already be served: ggml-org release.yml windows-hip
+# GPU_TARGETS plus the fork's windows-rocm bundles (gfx103X adds gfx1034, gfx110X adds
+# gfx1103; gfx908 / gfx90a ship standalone). Must stay a superset of the manifest's
+# windows-rocm mapped_targets, else auto-Vulkan steals a host the fork already builds
+# for. Below this floor (e.g. gfx803 / RX 480) HIP has no prebuilt and Vulkan is the
+# practical llama-server backend on Windows (#7357).
 WINDOWS_HIP_PREBUILT_GFX_TARGETS = frozenset(
     {
         "gfx908",
@@ -92,10 +91,9 @@ WINDOWS_HIP_PREBUILT_GFX_TARGETS = frozenset(
 # Family labels forwarded by update markers / --rocm-gfx (gfx110X.zip assets).
 WINDOWS_ROCM_FAMILY_GFX_LABELS = frozenset({"gfx103x", "gfx110x", "gfx120x"})
 
-# install_kind values that really are a Vulkan bundle. Used to keep the marker's
-# llama_backend honest: upstream ships no Vulkan archive for Windows arm64, and
-# the x64 selector falls through to the CPU asset when the Vulkan one is missing
-# or fails validation, so a Vulkan request can end on a CPU bundle (#7357).
+# install_kinds that really are a Vulkan bundle. Upstream ships no Vulkan archive for
+# Windows arm64 and x64 falls through to CPU when the Vulkan one is missing or fails
+# validation, so a Vulkan request can end on a CPU bundle; keeps the marker honest (#7357).
 VULKAN_INSTALL_KINDS = frozenset({"linux-vulkan", "windows-vulkan"})
 
 # DiskPart-prompt suppression. RunAsInvoker does NOT stop amd-smi's runtime
@@ -2180,10 +2178,9 @@ def run_capture(
 def _list_rocm_gfx_targets(out: str) -> list[str]:
     """List gfx targets rocminfo / hipinfo report, one entry per physical GPU.
 
-    rocminfo / hipinfo print the same gfx token multiple times per GPU (Name,
-    ISA, marketing-name). Split on per-GPU section headers when present so a
-    dual same-arch host keeps two entries; otherwise fall back to insertion-
-    order dedup for flat strings and unit-test stubs.
+    Both print the same gfx token several times per GPU (Name, ISA, marketing-name),
+    so split on per-GPU section headers to keep two entries on a dual same-arch host;
+    flat strings and test stubs fall back to insertion-order dedup.
     """
     _sections = re.split(
         r"(?mi)^\s*\*+\s*$\s*agent\s+\d+\s*$|\bdevice\s*#\s*\d+\b",
@@ -2204,14 +2201,10 @@ def _list_rocm_gfx_targets(out: str) -> list[str]:
 def _pick_rocm_gfx_target(out: str) -> str | None:
     """Choose the gfx target rocminfo / hipinfo report for the active GPU.
 
-    A bare first-match picked the wrong device on mixed APU + dGPU hosts
-    (e.g. Strix Halo gfx1151 + discrete RX 7900 gfx1100). Respect
-    HIP_VISIBLE_DEVICES / ROCR_VISIBLE_DEVICES / CUDA_VISIBLE_DEVICES so the
-    asset matches what HIP actually runs on. Falls back to the first GPU when
-    no env var is set.
-
-    See ``_list_rocm_gfx_targets`` for per-GPU extraction. Empty / "-1" env
-    values mean no AMD GPU is visible to HIP: return None.
+    A bare first-match picked the wrong device on mixed APU + dGPU hosts (e.g. Strix
+    Halo gfx1151 + discrete RX 7900 gfx1100), so honour HIP_VISIBLE_DEVICES /
+    ROCR_VISIBLE_DEVICES / CUDA_VISIBLE_DEVICES; no env var means the first GPU, and
+    empty / "-1" means no AMD GPU is visible to HIP (None).
     """
     _tokens = _list_rocm_gfx_targets(out)
     if not _tokens:
@@ -5491,12 +5484,10 @@ def persisted_llama_backend(llama_backend: str | None, choice: AssetChoice) -> s
     """The backend to record for an install that actually landed ``choice``.
 
     A Vulkan request can end on a non-Vulkan bundle: Windows arm64 has no upstream
-    Vulkan archive at all (release.yml builds vulkan for x64 and opencl-adreno for
-    arm64), and the x64 branch falls through to win-cpu-x64 when the Vulkan archive
-    is missing or fails validation. Recording "vulkan" for such an install makes
-    the updater re-assert Vulkan on every later run for a backend that was never
-    installed, so the CPU bundle stays pinned to upstream instead of healing back
-    to the published bundle. Mirrors force_cpu: persist the real outcome only."""
+    Vulkan archive (release.yml builds vulkan for x64, opencl-adreno for arm64), and
+    x64 falls through to win-cpu-x64 when the Vulkan archive is missing or fails
+    validation. Recording "vulkan" there would make the updater re-assert a backend
+    that was never installed. Mirrors force_cpu: persist the real outcome only."""
     if llama_backend == "vulkan" and choice.install_kind not in VULKAN_INSTALL_KINDS:
         return None
     return llama_backend
@@ -5541,9 +5532,8 @@ def write_prebuilt_metadata(
         # so a forced CPU install is not re-routed to a GPU bundle (#7213). An automatic
         # --cpu-fallback (e.g. arm64 GPU-build recovery) stays False so it can heal to GPU.
         "force_cpu": force_cpu,
-        # Deliberate or auto-selected Vulkan backend (#7357). The updater re-asserts it
-        # so AMD hosts are not silently swapped back to HIP on update. Dropped when the
-        # attempt that won is not actually a Vulkan bundle.
+        # Deliberate or auto-selected Vulkan backend (#7357); the updater re-asserts it so
+        # AMD hosts are not swapped back to HIP. Dropped if the winning attempt was not Vulkan.
         "llama_backend": persisted_llama_backend(llama_backend, choice),
         "asset_sha256": choice.expected_sha256,
         "source": choice.source_label,
@@ -6075,32 +6065,30 @@ def _normalized_llama_backend(value: str | None) -> str | None:
 def llama_backend_from_env() -> str | None:
     """Read an explicit llama.cpp backend preference from the environment.
 
-    Only ``UNSLOTH_LLAMA_BACKEND`` is honored. ``UNSLOTH_LLAMA_CPP_BACKEND`` is a
-    separate, pre-existing setup variable meaning ``auto``/``cpu`` (not a backend
-    name); setup.sh/setup.ps1 warn and ignore any other value, so reading it here
-    would silently force Vulkan behind that warning. Keep the two namespaces
-    apart -- Vulkan opt-in rides UNSLOTH_LLAMA_BACKEND / UNSLOTH_FORCE_VULKAN.
+    Only ``UNSLOTH_LLAMA_BACKEND`` is honored. ``UNSLOTH_LLAMA_CPP_BACKEND`` is a separate
+    setup variable meaning ``auto``/``cpu`` (not a backend name) that setup.sh/setup.ps1 warn
+    about and ignore otherwise, so reading it here would force Vulkan behind that warning.
     """
     return _normalized_llama_backend(os.environ.get("UNSLOTH_LLAMA_BACKEND"))
 
 
 def resolved_llama_backend(llama_backend: str | None = None) -> str | None:
-    """The explicit backend for this run: --llama-backend, else the env var.
-    None when neither is set or the value is not a backend name we know."""
+    """The explicit backend for this run: --llama-backend, else the env var. None when
+    neither is set or the value is not a backend name we know."""
     return _normalized_llama_backend(llama_backend) or llama_backend_from_env()
 
 
 def force_vulkan_requested(llama_backend: str | None = None) -> bool:
     """Whether this run should install the upstream Vulkan llama.cpp prebuilt.
 
-    Triggered by ``UNSLOTH_LLAMA_BACKEND=vulkan``, legacy ``UNSLOTH_FORCE_VULKAN``,
-    or ``--llama-backend vulkan``. Scoped to the llama.cpp backend; the torch/training
-    stack installs separately and still sees the real GPU.
+    Triggered by ``UNSLOTH_LLAMA_BACKEND=vulkan``, legacy ``UNSLOTH_FORCE_VULKAN``, or
+    ``--llama-backend vulkan``. Scoped to the llama.cpp backend; the torch/training stack
+    installs separately and still sees the real GPU.
     """
     backend = resolved_llama_backend(llama_backend)
     if backend is not None:
-        # An explicit backend is authoritative, so UNSLOTH_LLAMA_BACKEND=hip is a
-        # real opt-out rather than being overruled by a stale UNSLOTH_FORCE_VULKAN.
+        # Authoritative, so =hip is a real opt-out and not overruled by a stale
+        # UNSLOTH_FORCE_VULKAN.
         return backend == "vulkan"
     return os.environ.get("UNSLOTH_FORCE_VULKAN", "").strip().lower() in (
         "1",
@@ -6142,17 +6130,13 @@ def _should_auto_vulkan_for_amd_windows(host: HostInfo) -> bool:
     """True when the active AMD GPU is below the Windows HIP prebuilt floor."""
     active = _active_rocm_gfx_target(host)
     if not active:
-        # ROCm confirmed but gfx unknown (--has-rocm only): keep the legacy HIP /
-        # fork / source path instead of forcing Vulkan.
+        # ROCm confirmed but gfx unknown (--has-rocm only): keep the HIP / fork / source path.
         return False
     return (
         host.is_windows
         and host.has_rocm
-        # No PHYSICAL NVIDIA, not merely no usable one: a host that hides an
-        # NVIDIA card via CUDA_VISIBLE_DEVICES=""/-1 keeps has_physical_nvidia
-        # while has_usable_nvidia goes False. Vulkan ignores that mask and could
-        # enumerate the reserved card, so don't auto-route it here. The Intel
-        # auto path gates the same way; an explicit Vulkan opt-in still overrides.
+        # PHYSICAL, not merely usable: Vulkan ignores CUDA_VISIBLE_DEVICES and would
+        # enumerate a card hidden by it. Same gate as the Intel auto path below.
         and not host.has_physical_nvidia
         and not _gfx_is_windows_hip_supported(active)
     )
@@ -6161,10 +6145,9 @@ def _should_auto_vulkan_for_amd_windows(host: HostInfo) -> bool:
 def _has_no_vulkan_prebuilt(host: HostInfo) -> bool:
     """Platforms that ship no Vulkan prebuilt at all, so routing there is pointless.
 
-    Upstream release.yml builds win-vulkan for x64 only; Windows arm64 gets
-    win-cpu-arm64 plus win-opencl-adreno-arm64. Rewriting such a host to
-    Vulkan-only just swaps the published arm64 bundle for the upstream CPU one
-    without ever producing Vulkan. macOS is handled separately (Metal)."""
+    Upstream release.yml builds win-vulkan for x64 only; Windows arm64 gets win-cpu-arm64
+    plus win-opencl-adreno-arm64, so rewriting it to Vulkan-only would just swap the
+    published bundle for the upstream CPU one. macOS is handled separately (Metal)."""
     return host.is_windows and host.is_arm64
 
 
@@ -6200,8 +6183,8 @@ def _route_to_vulkan_prebuilt(
     The unsloth published repo ships only CUDA/ROCm/CPU assets, so Vulkan comes
     from UPSTREAM_REPO. Three triggers route here, all suppressed when a CPU flag
     (--cpu-fallback or --force-cpu, folded into force_cpu) wins:
-      * ``UNSLOTH_LLAMA_BACKEND=vulkan`` / ``UNSLOTH_FORCE_VULKAN`` / ``--llama-backend vulkan``
-        forces Vulkan over the detected CUDA/ROCm backend;
+      * ``UNSLOTH_LLAMA_BACKEND=vulkan`` / ``UNSLOTH_FORCE_VULKAN`` / ``--llama-backend
+        vulkan`` forces Vulkan over the detected CUDA/ROCm backend;
       * Windows AMD with no HIP-prebuilt gfx arch auto-falls back to Vulkan (#7357);
       * an auto-detected Intel GPU with NO physical NVIDIA/ROCm -- the purpose
         of the has_intel_gpu probe, since the fork manifest ships no Vulkan asset.
@@ -6212,15 +6195,12 @@ def _route_to_vulkan_prebuilt(
     value to persist in the install marker when updates must re-assert Vulkan.
     """
     forced = force_vulkan_requested(llama_backend)
-    # Only auto-fall back when the run named no backend: an explicit hip/cpu is
-    # the opt-out for a host that would rather keep (or debug) its HIP bundle.
+    # Auto-fall back only when the run named no backend: an explicit hip/cpu is the opt-out.
     explicit_backend = resolved_llama_backend(llama_backend)
     auto_no_hip = explicit_backend is None and _should_auto_vulkan_for_amd_windows(host)
-    # Gate auto-routing on no PHYSICAL NVIDIA, not merely no usable one: a mixed
-    # NVIDIA+Intel host that hides NVIDIA with CUDA_VISIBLE_DEVICES=""/-1 keeps
-    # has_physical_nvidia=True while has_usable_nvidia goes False. Vulkan ignores
-    # CUDA_VISIBLE_DEVICES, so auto-routing such a host would let it grab the
-    # reserved NVIDIA GPU. An explicit Vulkan opt-in still overrides.
+    # No PHYSICAL NVIDIA, not merely no usable one: Vulkan ignores CUDA_VISIBLE_DEVICES, so
+    # auto-routing a host that hides its NVIDIA card would let it grab the reserved GPU.
+    # An explicit Vulkan opt-in still overrides.
     auto_intel = host.has_intel_gpu and not host.has_physical_nvidia and not host.has_rocm
     if force_cpu or not (forced or auto_intel or auto_no_hip):
         return host, published_repo, published_release_tag, None

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -1253,6 +1253,7 @@ def test_install_prebuilt_falls_back_to_older_release_plan(
         initial_fallback_used = False,
         existing_install_dir = None,
         force_cpu = False,
+        llama_backend = None,
     ):
         call_log.append((llama_tag, initial_fallback_used))
         if llama_tag == "b9002":
@@ -2457,6 +2458,7 @@ def test_install_prebuilt_skips_when_older_release_fallback_matches_existing_ins
         initial_fallback_used = False,
         existing_install_dir = None,
         force_cpu = False,
+        llama_backend = None,
     ):
         call_log.append(llama_tag)
         raise PrebuiltFallback("validation failed for latest release")
@@ -2605,6 +2607,7 @@ def test_install_prebuilt_skips_same_release_fallback_attempt_when_installed(
         prebuilt_fallback_used,
         quantized_path,
         force_cpu = False,
+        llama_backend = None,
     ):
         attempted_names.append(choice.name)
         if choice.name == first_choice.name:
@@ -2732,6 +2735,7 @@ def test_install_prebuilt_same_tag_upstream_failure_uses_older_unsloth_release_p
         initial_fallback_used = False,
         existing_install_dir = None,
         force_cpu = False,
+        llama_backend = None,
     ):
         attempted.append((llama_tag, release_tag, attempts[0].source_label))
         if llama_tag == "b9002":

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -4490,11 +4490,26 @@ class TestApplyHostOverrides:
         assert out.has_rocm is True
         assert out.rocm_gfx_target == "gfx1200"
 
-    def test_forwarded_gfx_is_authoritative(self):
-        # setup already applied visible-device selection; its value wins.
-        host = rocm_host(rocm_gfx_target = "gfx1100")
+    def test_forwarded_gfx_does_not_clobber_probed_arch(self, monkeypatch):
+        # setup.ps1's own pick is NOT fully visible-device aware (it ignores
+        # CUDA_VISIBLE_DEVICES and its amd-smi branch drops comma masks), so it
+        # must not replace an arch detect_host() already resolved for the
+        # runtime-visible GPU.
+        monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
+        host = rocm_host(rocm_gfx_target = "gfx1100", rocm_gfx_targets = ["gfx1100"])
+        out = _apply_host_overrides(host, override_rocm_gfx = "gfx1151")
+        assert out.rocm_gfx_target == "gfx1100"
+        assert out.rocm_gfx_targets == ["gfx1100"]
+        assert out.has_rocm is True
+
+    def test_manual_env_override_still_wins_over_probe(self, monkeypatch):
+        # UNSLOTH_ROCM_GFX_ARCH is the documented manual escape hatch for hosts
+        # whose arch the probes get wrong; it stays authoritative.
+        monkeypatch.setenv("UNSLOTH_ROCM_GFX_ARCH", "gfx1151")
+        host = rocm_host(rocm_gfx_target = "gfx1100", rocm_gfx_targets = ["gfx1100"])
         out = _apply_host_overrides(host, override_rocm_gfx = "gfx1151")
         assert out.rocm_gfx_target == "gfx1151"
+        assert out.rocm_gfx_targets == ["gfx1151"]
 
     def test_has_rocm_only_keeps_probe_gfx(self):
         out = _apply_host_overrides(cpu_host(), override_has_rocm = True)

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -4510,7 +4510,9 @@ class TestApplyHostOverrides:
         host = rocm_host(rocm_gfx_target = "gfx1100", rocm_gfx_targets = ["gfx1100"])
         out = _apply_host_overrides(host, override_rocm_gfx = "gfx1151")
         assert out.rocm_gfx_target == "gfx1151"
-        assert out.rocm_gfx_targets == ["gfx1151"]
+        # ... but it says which arch HIP targets, not which cards exist: the probed
+        # gfx1100 is still physically in the box, so it stays in the per-GPU list.
+        assert out.rocm_gfx_targets == ["gfx1100", "gfx1151"]
         assert out.has_rocm is True
 
     def test_forwarded_family_label_never_overrides_a_probed_arch(self, monkeypatch):
@@ -4542,6 +4544,36 @@ class TestApplyHostOverrides:
         assert out.rocm_gfx_target == "gfx1010"
         assert out.rocm_gfx_targets == ["gfx1100", "gfx1010"]
 
+    def test_forwarded_gfx_never_drops_a_probed_physical_gpu(self, monkeypatch):
+        # The per-GPU list is the PHYSICAL inventory the Windows auto-Vulkan floor
+        # check reads. A forwarded arch the probe never saw (stale env var, a
+        # name-inferred arch for the other card) must be ADDED to it, not replace
+        # it: dropping the probe-confirmed gfx1100 would tell that check no AMD GPU
+        # on the box reaches the HIP floor when one plainly does.
+        monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
+        host = rocm_host(rocm_gfx_target = "gfx803", rocm_gfx_targets = ["gfx1100", "gfx803"])
+        out = _apply_host_overrides(host, override_rocm_gfx = "gfx900")
+        assert out.rocm_gfx_target == "gfx900"
+        assert out.rocm_gfx_targets == ["gfx1100", "gfx803", "gfx900"]
+
+    def test_forwarded_gfx_not_duplicated_when_already_probed(self, monkeypatch):
+        # UNSLOTH_ROCM_GFX_ARCH makes the forward win over the probe's visible-device
+        # pick, so this reaches the same branch; the list must stay deduplicated.
+        monkeypatch.setenv("UNSLOTH_ROCM_GFX_ARCH", "gfx803")
+        host = rocm_host(rocm_gfx_target = "gfx1100", rocm_gfx_targets = ["gfx1100", "gfx803"])
+        out = _apply_host_overrides(host, override_rocm_gfx = "gfx803")
+        assert out.rocm_gfx_target == "gfx803"
+        assert out.rocm_gfx_targets == ["gfx1100", "gfx803"]
+
+    def test_forwarded_gfx_on_an_unprobed_host_lists_only_itself(self, monkeypatch):
+        # Negative control for the two above: with nothing probed there is no
+        # physical inventory to preserve, so the driver-only host the forward
+        # exists for keeps a single-entry list and its auto-Vulkan fallback.
+        monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
+        out = _apply_host_overrides(cpu_host(), override_rocm_gfx = "gfx803")
+        assert out.rocm_gfx_target == "gfx803"
+        assert out.rocm_gfx_targets == ["gfx803"]
+
     def test_manual_env_override_still_wins_over_probe(self, monkeypatch):
         # UNSLOTH_ROCM_GFX_ARCH is the documented manual escape hatch for hosts
         # whose arch the probes get wrong; it stays authoritative.
@@ -4549,7 +4581,7 @@ class TestApplyHostOverrides:
         host = rocm_host(rocm_gfx_target = "gfx1100", rocm_gfx_targets = ["gfx1100"])
         out = _apply_host_overrides(host, override_rocm_gfx = "gfx1151")
         assert out.rocm_gfx_target == "gfx1151"
-        assert out.rocm_gfx_targets == ["gfx1151"]
+        assert out.rocm_gfx_targets == ["gfx1100", "gfx1151"]
 
     def test_has_rocm_only_keeps_probe_gfx(self):
         out = _apply_host_overrides(cpu_host(), override_has_rocm = True)

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -4492,15 +4492,55 @@ class TestApplyHostOverrides:
 
     def test_forwarded_gfx_does_not_clobber_probed_arch(self, monkeypatch):
         # setup.ps1's own pick is NOT fully visible-device aware (it ignores
-        # CUDA_VISIBLE_DEVICES and its amd-smi branch drops comma masks), so it
-        # must not replace an arch detect_host() already resolved for the
-        # runtime-visible GPU.
+        # CUDA_VISIBLE_DEVICES and its amd-smi branch drops comma masks), so on a
+        # host whose OTHER physical GPU it resolved it must not replace the arch
+        # detect_host() picked for the runtime-visible one.
+        monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
+        host = rocm_host(rocm_gfx_target = "gfx1010", rocm_gfx_targets = ["gfx1100", "gfx1010"])
+        out = _apply_host_overrides(host, override_rocm_gfx = "gfx1100")
+        assert out.rocm_gfx_target == "gfx1010"
+        assert out.rocm_gfx_targets == ["gfx1100", "gfx1010"]
+        assert out.has_rocm is True
+
+    def test_forwarded_gfx_absent_from_host_stays_authoritative(self, monkeypatch):
+        # An arch no probe on this host ever reported is not setup picking the wrong
+        # GPU -- it is an explicit --rocm-gfx for a host whose probe is wrong or
+        # stale, which is precisely what the flag documents. It must still win.
         monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
         host = rocm_host(rocm_gfx_target = "gfx1100", rocm_gfx_targets = ["gfx1100"])
         out = _apply_host_overrides(host, override_rocm_gfx = "gfx1151")
-        assert out.rocm_gfx_target == "gfx1100"
-        assert out.rocm_gfx_targets == ["gfx1100"]
+        assert out.rocm_gfx_target == "gfx1151"
+        assert out.rocm_gfx_targets == ["gfx1151"]
         assert out.has_rocm is True
+
+    def test_forwarded_family_label_never_overrides_a_probed_arch(self, monkeypatch):
+        # The llama.cpp update path re-derives --rocm-gfx from the marker's family
+        # named asset, so a family label is a bundle name and not a real GPU arch.
+        # It must stay advisory: gfx1033 is in-generation but unbuilt, and letting
+        # gfx103X win would serve it a family bundle it cannot run.
+        monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
+        host = rocm_host(rocm_gfx_target = "gfx1033", rocm_gfx_targets = ["gfx1033"])
+        out = _apply_host_overrides(host, override_rocm_gfx = "gfx103X")
+        assert out.rocm_gfx_target == "gfx1033"
+        assert out.has_rocm is True
+
+    def test_forwarded_family_label_still_fills_an_unprobed_arch(self, monkeypatch):
+        # Negative control: with no probed arch the marker forward is the only
+        # source, so the family label must still apply.
+        monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
+        out = _apply_host_overrides(cpu_host(), override_rocm_gfx = "gfx110X")
+        assert out.rocm_gfx_target == "gfx110x"
+        assert out.has_rocm is True
+
+    def test_forwarded_gfx_matching_active_keeps_physical_gfx_list(self, monkeypatch):
+        # When the forward agrees with the probe, the per-GPU list must survive:
+        # collapsing it to one entry would hide the host's other AMD cards from
+        # the Windows auto-Vulkan floor check.
+        monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
+        host = rocm_host(rocm_gfx_target = "gfx1010", rocm_gfx_targets = ["gfx1100", "gfx1010"])
+        out = _apply_host_overrides(host, override_rocm_gfx = "gfx1010")
+        assert out.rocm_gfx_target == "gfx1010"
+        assert out.rocm_gfx_targets == ["gfx1100", "gfx1010"]
 
     def test_manual_env_override_still_wins_over_probe(self, monkeypatch):
         # UNSLOTH_ROCM_GFX_ARCH is the documented manual escape hatch for hosts

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -4491,10 +4491,9 @@ class TestApplyHostOverrides:
         assert out.rocm_gfx_target == "gfx1200"
 
     def test_forwarded_gfx_does_not_clobber_probed_arch(self, monkeypatch):
-        # setup.ps1's own pick is NOT fully visible-device aware (it ignores
-        # CUDA_VISIBLE_DEVICES and its amd-smi branch drops comma masks), so on a
-        # host whose OTHER physical GPU it resolved it must not replace the arch
-        # detect_host() picked for the runtime-visible one.
+        # setup.ps1's pick is not fully visible-device aware (ignores CUDA_VISIBLE_DEVICES,
+        # amd-smi branch drops comma masks), so when it resolved the host's OTHER physical
+        # GPU it must not replace the arch detect_host() picked for the visible one.
         monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
         host = rocm_host(rocm_gfx_target = "gfx1010", rocm_gfx_targets = ["gfx1100", "gfx1010"])
         out = _apply_host_overrides(host, override_rocm_gfx = "gfx1100")
@@ -4503,23 +4502,21 @@ class TestApplyHostOverrides:
         assert out.has_rocm is True
 
     def test_forwarded_gfx_absent_from_host_stays_authoritative(self, monkeypatch):
-        # An arch no probe on this host ever reported is not setup picking the wrong
-        # GPU -- it is an explicit --rocm-gfx for a host whose probe is wrong or
-        # stale, which is precisely what the flag documents. It must still win.
+        # An arch no probe here ever reported is not a setup mispick: it is an explicit
+        # --rocm-gfx for a host whose probe is wrong or stale, so it must still win.
         monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
         host = rocm_host(rocm_gfx_target = "gfx1100", rocm_gfx_targets = ["gfx1100"])
         out = _apply_host_overrides(host, override_rocm_gfx = "gfx1151")
         assert out.rocm_gfx_target == "gfx1151"
-        # ... but it says which arch HIP targets, not which cards exist: the probed
-        # gfx1100 is still physically in the box, so it stays in the per-GPU list.
+        # ... but it says which arch HIP targets, not which cards exist, so the probed
+        # gfx1100 is still in the box and stays in the per-GPU list.
         assert out.rocm_gfx_targets == ["gfx1100", "gfx1151"]
         assert out.has_rocm is True
 
     def test_forwarded_family_label_never_overrides_a_probed_arch(self, monkeypatch):
-        # The llama.cpp update path re-derives --rocm-gfx from the marker's family
-        # named asset, so a family label is a bundle name and not a real GPU arch.
-        # It must stay advisory: gfx1033 is in-generation but unbuilt, and letting
-        # gfx103X win would serve it a family bundle it cannot run.
+        # The update path re-derives --rocm-gfx from the marker's family-named asset, so a
+        # family label is a bundle name, not a real arch, and must stay advisory: gfx1033 is
+        # in-generation but unbuilt, so gfx103X winning would serve a bundle it cannot run.
         monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
         host = rocm_host(rocm_gfx_target = "gfx1033", rocm_gfx_targets = ["gfx1033"])
         out = _apply_host_overrides(host, override_rocm_gfx = "gfx103X")
@@ -4527,17 +4524,17 @@ class TestApplyHostOverrides:
         assert out.has_rocm is True
 
     def test_forwarded_family_label_still_fills_an_unprobed_arch(self, monkeypatch):
-        # Negative control: with no probed arch the marker forward is the only
-        # source, so the family label must still apply.
+        # Negative control: with no probed arch the forward is the only source, so it
+        # applies.
         monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
         out = _apply_host_overrides(cpu_host(), override_rocm_gfx = "gfx110X")
         assert out.rocm_gfx_target == "gfx110x"
         assert out.has_rocm is True
 
     def test_forwarded_gfx_matching_active_keeps_physical_gfx_list(self, monkeypatch):
-        # When the forward agrees with the probe, the per-GPU list must survive:
-        # collapsing it to one entry would hide the host's other AMD cards from
-        # the Windows auto-Vulkan floor check.
+        # When the forward agrees with the probe the per-GPU list must survive: collapsing
+        # it would hide the host's other AMD cards from the Windows auto-Vulkan floor
+        # check.
         monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
         host = rocm_host(rocm_gfx_target = "gfx1010", rocm_gfx_targets = ["gfx1100", "gfx1010"])
         out = _apply_host_overrides(host, override_rocm_gfx = "gfx1010")
@@ -4545,11 +4542,10 @@ class TestApplyHostOverrides:
         assert out.rocm_gfx_targets == ["gfx1100", "gfx1010"]
 
     def test_forwarded_gfx_never_drops_a_probed_physical_gpu(self, monkeypatch):
-        # The per-GPU list is the PHYSICAL inventory the Windows auto-Vulkan floor
-        # check reads. A forwarded arch the probe never saw (stale env var, a
-        # name-inferred arch for the other card) must be ADDED to it, not replace
-        # it: dropping the probe-confirmed gfx1100 would tell that check no AMD GPU
-        # on the box reaches the HIP floor when one plainly does.
+        # The per-GPU list is the PHYSICAL inventory the Windows auto-Vulkan floor check
+        # reads, so a forwarded arch the probe never saw must be ADDED, not replace it:
+        # dropping the probe-confirmed gfx1100 would tell that check no AMD GPU on the box
+        # reaches the HIP floor when one plainly does.
         monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
         host = rocm_host(rocm_gfx_target = "gfx803", rocm_gfx_targets = ["gfx1100", "gfx803"])
         out = _apply_host_overrides(host, override_rocm_gfx = "gfx900")
@@ -4566,17 +4562,16 @@ class TestApplyHostOverrides:
         assert out.rocm_gfx_targets == ["gfx1100", "gfx803"]
 
     def test_forwarded_gfx_on_an_unprobed_host_lists_only_itself(self, monkeypatch):
-        # Negative control for the two above: with nothing probed there is no
-        # physical inventory to preserve, so the driver-only host the forward
-        # exists for keeps a single-entry list and its auto-Vulkan fallback.
+        # Negative control for the two above: nothing probed means no inventory to
+        # preserve, so the driver-only host keeps a single-entry list and auto-Vulkan.
         monkeypatch.delenv("UNSLOTH_ROCM_GFX_ARCH", raising = False)
         out = _apply_host_overrides(cpu_host(), override_rocm_gfx = "gfx803")
         assert out.rocm_gfx_target == "gfx803"
         assert out.rocm_gfx_targets == ["gfx803"]
 
     def test_manual_env_override_still_wins_over_probe(self, monkeypatch):
-        # UNSLOTH_ROCM_GFX_ARCH is the documented manual escape hatch for hosts
-        # whose arch the probes get wrong; it stays authoritative.
+        # UNSLOTH_ROCM_GFX_ARCH is the manual escape hatch for hosts whose arch the probes
+        # get wrong, so it stays authoritative.
         monkeypatch.setenv("UNSLOTH_ROCM_GFX_ARCH", "gfx1151")
         host = rocm_host(rocm_gfx_target = "gfx1100", rocm_gfx_targets = ["gfx1100"])
         out = _apply_host_overrides(host, override_rocm_gfx = "gfx1151")


### PR DESCRIPTION
## Problem

On Windows AMD, the installer only ever picks the `win-hip-radeon` prebuilt; Vulkan is auto-selected only for Intel/other GPUs (`install_llama_prebuilt.py`, `direct_upstream_release_plan`). Cards below the HIP prebuilt's gfx floor (e.g. RX 480, gfx803) are invisible to llama-server entirely.

A user with an RX 9070 XT + RX 480 worked around this by manually copying the official `llama-bin-win-vulkan-x64.zip` over the bundled build, which works (and Studio now understands it since #7356), but a Studio update clobbers the swap back to HIP.

Fixes #7357.

## Fix

- **Explicit opt-in:** `UNSLOTH_LLAMA_BACKEND=vulkan` (and legacy `UNSLOTH_FORCE_VULKAN=1`) plus `--llama-backend vulkan` route the installer to the upstream Vulkan prebuilt on any host. The choice is recorded as `llama_backend: "vulkan"` in `UNSLOTH_PREBUILT_INFO.json` and re-asserted on Studio updates.
- **Auto-fallback:** On Windows AMD, when the **active** gfx arch (the HIP-visible device) is unsupported by the HIP prebuilt and gfx is known, the installer selects Vulkan instead of shipping a build that cannot see the card.
- **Non-goal preserved:** Mixed setups where the default/active card is HIP-supported (e.g. RX 9070 XT + RX 480 with no device mask) still default to HIP. Vulkan on those hosts requires explicit opt-in.
- Auto-fallback honors fork ROCm family labels forwarded by update markers (`gfx110X`, etc.) and gfx1103 (Phoenix / 780M via the gfx110X bundle). `--has-rocm` without a resolved gfx arch does not force Vulkan.

## Verification

```bash
pytest studio/backend/tests/test_install_resolve_prebuilt.py -q -k "vulkan or llama_backend or route_to_vulkan"
pytest studio/backend/tests/test_llama_cpp_update.py -q -k vulkan
```

20 routing tests and the Vulkan update-preservation test pass with mocked host profiles.

Hardware validation not run here (no Windows AMD dual-GPU box). Suggested manual checks before merge:
- gfx803-only host auto-installs Vulkan and `llama-server` sees the GPU
- mixed 9070 XT + RX 480 stays on HIP by default; `UNSLOTH_LLAMA_BACKEND=vulkan` survives a Studio update