### PR TITLE
Studio: fix composer reset after failed send

### DIFF
--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1440,6 +1440,12 @@ const Composer: FC<{
   disableQueue?: boolean;
 }> = ({ disabled, threadId, menuSide, disableQueue }) => {
   const aui = useAui();
+  const resetAfterComposerSendRef = useRef(false);
+  useAuiEvent("thread.runStart", () => {
+    if (!resetAfterComposerSendRef.current) return;
+    resetAfterComposerSendRef.current = false;
+    void aui.composer().reset();
+  });
   const isDictating = useAuiState((s) => s.composer.dictation != null);
   const pageDragging = useContext(PageDragContext);
   const { overlay, closeOverlay } = useGeneratedImageOverlay();
@@ -1822,6 +1828,8 @@ const Composer: FC<{
         });
         closeOverlay();
       }
+
+      resetAfterComposerSendRef.current = true;
     },
     [
       aui,

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1440,12 +1440,6 @@ const Composer: FC<{
   disableQueue?: boolean;
 }> = ({ disabled, threadId, menuSide, disableQueue }) => {
   const aui = useAui();
-  const resetAfterComposerSendRef = useRef(false);
-  useAuiEvent("thread.runStart", () => {
-    if (!resetAfterComposerSendRef.current) return;
-    resetAfterComposerSendRef.current = false;
-    void aui.composer().reset();
-  });
   const isDictating = useAuiState((s) => s.composer.dictation != null);
   const pageDragging = useContext(PageDragContext);
   const { overlay, closeOverlay } = useGeneratedImageOverlay();
@@ -1582,6 +1576,18 @@ const Composer: FC<{
     const t = setTimeout(() => writeComposerDraft(draftKey, composerText), 300);
     return () => clearTimeout(t);
   }, [composerText, draftKey]);
+  // Without this the restore effect above puts the sent text back when the
+  // runtime rebinds on the first message.
+  const draftKeyRef = useRef(draftKey);
+  useEffect(() => {
+    draftKeyRef.current = draftKey;
+  }, [draftKey]);
+  const clearStoredDraft = useCallback(() => {
+    const key = draftKeyRef.current;
+    if (key) {
+      writeComposerDraft(key, "");
+    }
+  }, []);
   // react-textarea-autosize re-measures only on value change or window resize,
   // not on the width swap from expanding, so it keeps the taller height and
   // leaves a stray blank row. Nudge a resize whenever input width changes.
@@ -1732,9 +1738,10 @@ const Composer: FC<{
     setPendingSend(false);
     dismissWaitToast();
     if (text.trim().length > 0 || attachments.length > 0) {
+      clearStoredDraft();
       aui.composer().send();
     }
-  }, [pendingSend, indexingActive, aui, dismissWaitToast]);
+  }, [pendingSend, indexingActive, aui, clearStoredDraft, dismissWaitToast]);
 
   // Drop any queued send + toast on unmount (e.g. thread switch).
   useEffect(
@@ -1777,6 +1784,7 @@ const Composer: FC<{
         flushResourcesSync(() => {
           aui.composer().setText("");
         });
+        clearStoredDraft();
         startPromptQueue(
           [queuedPrompt],
           createPromptQueueTarget(),
@@ -1810,6 +1818,7 @@ const Composer: FC<{
           closeOverlay();
           return;
         }
+        clearStoredDraft();
         setImageToolsEnabled(true);
         setPendingImageEditReference({
           threadId: overlay.threadId ?? referenceThreadId,
@@ -1827,13 +1836,15 @@ const Composer: FC<{
             );
         });
         closeOverlay();
+        return;
       }
 
-      resetAfterComposerSendRef.current = true;
+      clearStoredDraft();
     },
     [
       aui,
       canQueueCurrentPrompt,
+      clearStoredDraft,
       closeOverlay,
       composerText,
       createPromptQueueTarget,
@@ -1955,6 +1966,7 @@ const Composer: FC<{
                 flushResourcesSync(() => {
                   aui.composer().setText("");
                 });
+                clearStoredDraft();
                 startPromptQueue([queuedPrompt], createPromptQueueTarget(), true);
               }}
               onSendClick={interceptSend}

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1556,6 +1556,7 @@ const Composer: FC<{
   const draftThreadId = referenceThreadId;
   const draftKey = draftThreadId ? composerDraftKey(draftThreadId) : null;
   const lastDraftKeyRef = useRef(draftKey);
+  const draftSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
     const draft = draftKey ? (readComposerDraft(draftKey) ?? "") : "";
     const composer = aui.composer();
@@ -1574,6 +1575,7 @@ const Composer: FC<{
       return;
     }
     const t = setTimeout(() => writeComposerDraft(draftKey, composerText), 300);
+    draftSaveTimerRef.current = t;
     return () => clearTimeout(t);
   }, [composerText, draftKey]);
   // Without this the restore effect above puts the sent text back when the
@@ -1583,6 +1585,10 @@ const Composer: FC<{
     draftKeyRef.current = draftKey;
   }, [draftKey]);
   const clearStoredDraft = useCallback(() => {
+    if (draftSaveTimerRef.current !== null) {
+      clearTimeout(draftSaveTimerRef.current);
+      draftSaveTimerRef.current = null;
+    }
     const key = draftKeyRef.current;
     if (key) {
       writeComposerDraft(key, "");


### PR DESCRIPTION
The composer mirrors its text into a per-thread localStorage draft, and the first send in a chat remounts it before the empty draft is written, so the mounting composer restores the just-sent prompt. Clears the stored draft as part of sending the submit path, both queue paths, and the send parked on document indexing.