### PR TITLE
fix(studio): route Astral custom-code models to transformers 5.10 sidecar (#7353)

### DIFF
--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -605,6 +605,25 @@ class TestCheckConfigNeeds510:
         assert "modeling_layers" in text
         assert seen["url"].startswith("https://hf-mirror.example/org/custom-remote/raw/main/")
 
+    def test_tokenizer_external_auto_map_needs_v5(self, monkeypatch, tmp_path: Path):
+        """Tokenizer auto_map pointing at an external repo must be scanned."""
+        _tokenizer_class_cache.clear()
+        tc = {
+            "tokenizer_class": "CustomTokenizer",
+            "auto_map": {
+                "AutoTokenizer": ["other/tokenizer-repo--tokenization_x.CustomTokenizer", None],
+            },
+        }
+        (tmp_path / "tokenizer_config.json").write_text(json.dumps(tc))
+
+        def _fake_read(model_name, filename, hf_token = None):
+            if model_name == "other/tokenizer-repo" and filename == "tokenization_x.py":
+                return "from transformers.tokenization_utils_tokenizers import TokenizersBackend\n"
+            return None
+
+        monkeypatch.setattr("utils.transformers_version._read_repo_text_file", _fake_read)
+        assert _check_tokenizer_config_needs_v5(str(tmp_path)) is True
+
     def test_gemma4_non_unified_returns_false(self, tmp_path: Path):
         """Older Gemma 4 config should stay on the 550 tier."""
         cfg = {
@@ -933,6 +952,50 @@ class TestGetTransformersTier:
         (tmp_path / "config.json").write_text(json.dumps(cfg))
         (tmp_path / "modeling_custom.py").write_text(
             "from transformers.modeling_layers import GradientCheckpointingLayer\n"
+        )
+
+        assert get_transformers_tier(str(tmp_path)) == "510"
+
+    def test_local_helper_auto_map_returns_510(self, tmp_path: Path):
+        """Helper modules imported by auto_map entry must be scanned (Codex #4)."""
+        cfg = {
+            "model_type": "custom_remote",
+            "auto_map": {"AutoModelForCausalLM": "modeling_custom.CustomForCausalLM"},
+        }
+        (tmp_path / "config.json").write_text(json.dumps(cfg))
+        (tmp_path / "modeling_custom.py").write_text("from helpers import sub\n")
+        helpers = tmp_path / "helpers"
+        helpers.mkdir()
+        (helpers / "sub.py").write_text(
+            "from transformers.modeling_layers import GradientCheckpointingLayer\n"
+        )
+
+        assert get_transformers_tier(str(tmp_path)) == "510"
+
+    def test_external_auto_map_repo_returns_510(self, monkeypatch, tmp_path: Path):
+        """External auto_map repos and their helpers must be scanned (Codex #4)."""
+        cfg = {
+            "model_type": "custom_remote",
+            "auto_map": {
+                "AutoModelForCausalLM": "evilorg/evilrepo--modeling_evil.Model",
+            },
+        }
+        (tmp_path / "config.json").write_text(json.dumps(cfg))
+
+        scanned = {
+            "evilorg/evilrepo--modeling_evil.py": "from .helper import run\n",
+            "evilorg/evilrepo--helper.py": (
+                "from transformers.modeling_layers import GradientCheckpointingLayer\n"
+            ),
+        }
+
+        def _fake_repo_remote_code_files(model_name, hf_token = None):
+            assert model_name == str(tmp_path)
+            return scanned
+
+        monkeypatch.setattr(
+            "utils.security.remote_code_scan.repo_remote_code_files",
+            _fake_repo_remote_code_files,
         )
 
         assert get_transformers_tier(str(tmp_path)) == "510"

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -36,6 +36,7 @@ from utils.transformers_version import (
     _remote_lora_base,
     _check_tokenizer_config_needs_v5,
     _check_config_needs_510,
+    _check_remote_auto_map_needs_510,
     _check_config_needs_530,
     _check_config_needs_550,
     _config_needs_510,
@@ -50,6 +51,7 @@ from utils.transformers_version import (
     _config_json_cache,
     _tokenizer_class_cache,
     _config_needs_510_cache,
+    _remote_auto_map_needs_510_cache,
     _config_needs_530_cache,
     _config_needs_550_cache,
     _probe_tier_cache,
@@ -301,6 +303,19 @@ class TestCheckTokenizerConfigNeedsV5:
         result = _check_tokenizer_config_needs_v5(str(tmp_path))
         assert result is False
 
+    def test_tokenizer_auto_map_remote_import_needs_v5(self, tmp_path: Path):
+        """Remote tokenizer code importing TokenizersBackend should require 5.x (#7353)."""
+        tc = {
+            "tokenizer_class": "AstralTokenizer",
+            "auto_map": {"AutoTokenizer": ["tokenization_astral.AstralTokenizer", None]},
+        }
+        (tmp_path / "tokenizer_config.json").write_text(json.dumps(tc))
+        (tmp_path / "tokenization_astral.py").write_text(
+            "from transformers.tokenization_utils_tokenizers import TokenizersBackend\n"
+        )
+
+        assert _check_tokenizer_config_needs_v5(str(tmp_path)) is True
+
     def test_local_file_skips_network(self, tmp_path: Path):
         """When local file exists, no network request should be made."""
         tc = {"tokenizer_class": "LlamaTokenizerFast"}
@@ -470,6 +485,7 @@ class TestCheckConfigNeeds510:
     def setup_method(self):
         _config_json_cache.clear()
         _config_needs_510_cache.clear()
+        _remote_auto_map_needs_510_cache.clear()
 
     def test_gemma4_unified_architecture(self, tmp_path: Path):
         """config.json with Gemma4UnifiedForConditionalGeneration should return True."""
@@ -520,6 +536,34 @@ class TestCheckConfigNeeds510:
         cfg = {"model_type": "gemma4_assistant"}
         (tmp_path / "config.json").write_text(json.dumps(cfg))
 
+        assert _check_config_needs_510(str(tmp_path)) is True
+
+    def test_astral_architecture(self, tmp_path: Path):
+        """Astral custom-code configs should route to the 5.10 sidecar (#7353)."""
+        cfg = {
+            "architectures": ["AstralForCausalLM"],
+            "model_type": "astral",
+            "auto_map": {
+                "AutoModelForCausalLM": "modeling_astral.AstralForCausalLM",
+            },
+        }
+        (tmp_path / "config.json").write_text(json.dumps(cfg))
+
+        assert _check_config_needs_510(str(tmp_path)) is True
+
+    def test_remote_modeling_auto_map_needs_510(self, tmp_path: Path):
+        """Unknown architectures with 5.10-only remote imports should return True."""
+        _remote_auto_map_needs_510_cache.clear()
+        cfg = {
+            "model_type": "custom_remote",
+            "auto_map": {"AutoModelForCausalLM": "modeling_custom.CustomForCausalLM"},
+        }
+        (tmp_path / "config.json").write_text(json.dumps(cfg))
+        (tmp_path / "modeling_custom.py").write_text(
+            "from transformers.modeling_layers import GradientCheckpointingLayer\n"
+        )
+
+        assert _check_remote_auto_map_needs_510(str(tmp_path)) is True
         assert _check_config_needs_510(str(tmp_path)) is True
 
     def test_gemma4_non_unified_returns_false(self, tmp_path: Path):
@@ -825,6 +869,21 @@ class TestGetTransformersTier:
         _config_json_cache.clear()
         _config_needs_510_cache.clear()
         _config_needs_550_cache.clear()
+        _remote_auto_map_needs_510_cache.clear()
+
+    def test_astral_local_checkpoint_returns_510(self, tmp_path: Path):
+        """Astral custom-code checkpoints should use the 5.10 sidecar (#7353)."""
+        cfg = {
+            "architectures": ["AstralForCausalLM"],
+            "model_type": "astral",
+            "auto_map": {"AutoModelForCausalLM": "modeling_astral.AstralForCausalLM"},
+        }
+        (tmp_path / "config.json").write_text(json.dumps(cfg))
+        (tmp_path / "modeling_astral.py").write_text(
+            "from transformers.modeling_layers import GradientCheckpointingLayer\n"
+        )
+
+        assert get_transformers_tier(str(tmp_path)) == "510"
 
     def test_gemma4_substring_returns_550(self):
         assert get_transformers_tier("google/gemma-4-E2B-it") == "550"

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -1069,7 +1069,11 @@ class TestGetTransformersTier:
                 return {"modeling_custom.py"}, True
             return set(), False
 
-        def _fake_read(model_name, filename, hf_token = None):
+        def _fake_read(
+            model_name,
+            filename,
+            hf_token = None,
+        ):
             if model_name == "org/qwen3.5-custom-remote" and filename == "modeling_custom.py":
                 return "from transformers.modeling_layers import GradientCheckpointingLayer\n"
             return None
@@ -1099,7 +1103,13 @@ class TestGetTransformersTier:
         real_import = builtins.__import__
         blocked = {"huggingface_hub"}
 
-        def _guarded_import(name, globals = None, locals = None, fromlist = (), level = 0):
+        def _guarded_import(
+            name,
+            globals = None,
+            locals = None,
+            fromlist = (),
+            level = 0,
+        ):
             root = name.split(".", 1)[0]
             if root in blocked:
                 raise AssertionError(f"tier detection imported {name}")

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -616,17 +616,54 @@ class TestCheckConfigNeeds510:
         }
         (tmp_path / "tokenizer_config.json").write_text(json.dumps(tc))
 
-        def _fake_read(
-            model_name,
-            filename,
-            hf_token = None,
-        ):
-            if model_name == "other/tokenizer-repo" and filename == "tokenization_x.py":
-                return "from transformers.tokenization_utils_tokenizers import TokenizersBackend\n"
-            return None
+        def _fake_fetch(repo_id, hf_token = None):
+            if repo_id == "other/tokenizer-repo":
+                return [
+                    "from transformers.tokenization_utils_tokenizers import TokenizersBackend\n"
+                ], True
+            return [], False
 
-        monkeypatch.setattr("utils.transformers_version._read_repo_text_file", _fake_read)
+        monkeypatch.setattr("utils.transformers_version._fetch_hub_py_sources", _fake_fetch)
         assert _check_tokenizer_config_needs_v5(str(tmp_path)) is True
+
+    def test_tokenizer_helper_auto_map_needs_v5(self, tmp_path: Path):
+        """Tokenizer helper modules imported by auto_map must be scanned."""
+        _tokenizer_class_cache.clear()
+        tc = {
+            "tokenizer_class": "CustomTokenizer",
+            "auto_map": {"AutoTokenizer": "tokenization_custom.CustomTokenizer"},
+        }
+        (tmp_path / "tokenizer_config.json").write_text(json.dumps(tc))
+        (tmp_path / "tokenization_custom.py").write_text("from helpers import sub\n")
+        helpers = tmp_path / "helpers"
+        helpers.mkdir()
+        (helpers / "sub.py").write_text(
+            "from transformers.tokenization_utils_tokenizers import TokenizersBackend\n"
+        )
+        assert _check_tokenizer_config_needs_v5(str(tmp_path)) is True
+
+    def test_transient_auto_map_scan_miss_not_cached(self, monkeypatch):
+        """Inconclusive auto_map scans must not cache a false negative."""
+        import utils.transformers_version as tv
+
+        _remote_auto_map_needs_510_cache.clear()
+        _config_needs_510_cache.clear()
+        cfg = {
+            "model_type": "custom_remote",
+            "auto_map": {"AutoModelForCausalLM": "modeling_custom.CustomForCausalLM"},
+        }
+        monkeypatch.setattr(tv, "_load_config_json", lambda *a, **k: cfg)
+        monkeypatch.setattr(tv, "_config_json_is_definitive", lambda *a, **k: True)
+        monkeypatch.setattr(tv, "_remote_auto_map_py_contents", lambda *a, **k: ([], False))
+        assert _check_remote_auto_map_needs_510("org/custom-remote") is False
+        assert ("org/custom-remote", None) not in _remote_auto_map_needs_510_cache
+        monkeypatch.setattr(
+            tv,
+            "_remote_auto_map_py_contents",
+            lambda *a, **k: (["from transformers.modeling_layers import X\n"], True),
+        )
+        assert _check_remote_auto_map_needs_510("org/custom-remote") is True
+        assert _check_config_needs_510("org/custom-remote") is True
 
     def test_gemma4_non_unified_returns_false(self, tmp_path: Path):
         """Older Gemma 4 config should stay on the 550 tier."""
@@ -978,6 +1015,8 @@ class TestGetTransformersTier:
 
     def test_external_auto_map_repo_returns_510(self, monkeypatch, tmp_path: Path):
         """External auto_map repos and their helpers must be scanned (Codex #4)."""
+        import utils.transformers_version as tv
+
         cfg = {
             "model_type": "custom_remote",
             "auto_map": {
@@ -986,22 +1025,87 @@ class TestGetTransformersTier:
         }
         (tmp_path / "config.json").write_text(json.dumps(cfg))
 
-        scanned = {
-            "evilorg/evilrepo--modeling_evil.py": "from .helper import run\n",
-            "evilorg/evilrepo--helper.py": (
-                "from transformers.modeling_layers import GradientCheckpointingLayer\n"
-            ),
+        def _fake_fetch(repo_id, hf_token = None):
+            if repo_id == "evilorg/evilrepo":
+                return [
+                    "from .helper import run\n",
+                    "from transformers.modeling_layers import GradientCheckpointingLayer\n",
+                ], True
+            return [], False
+
+        monkeypatch.setattr(tv, "_fetch_hub_py_sources", _fake_fetch)
+
+        assert get_transformers_tier(str(tmp_path)) == "510"
+
+    def test_local_lower_tier_model_type_with_auto_map_returns_510(self, tmp_path: Path):
+        """Lower-tier model_type must not skip auto_map scan (Codex round 2)."""
+        cfg = {
+            "model_type": "qwen3_moe",
+            "auto_map": {"AutoModelForCausalLM": "modeling_custom.CustomForCausalLM"},
         }
-
-        def _fake_repo_remote_code_files(model_name, hf_token = None):
-            assert model_name == str(tmp_path)
-            return scanned
-
-        monkeypatch.setattr(
-            "utils.security.remote_code_scan.repo_remote_code_files",
-            _fake_repo_remote_code_files,
+        (tmp_path / "config.json").write_text(json.dumps(cfg))
+        (tmp_path / "modeling_custom.py").write_text(
+            "from transformers.modeling_layers import GradientCheckpointingLayer\n"
         )
 
+        assert get_transformers_tier(str(tmp_path)) == "510"
+
+    def test_name_substring_upgraded_by_remote_auto_map(self, monkeypatch):
+        """Name fast path must upgrade when auto_map needs 5.10 (Codex round 2)."""
+        import utils.transformers_version as tv
+
+        cfg = {
+            "model_type": "custom_remote",
+            "auto_map": {"AutoModelForCausalLM": "modeling_custom.CustomForCausalLM"},
+        }
+
+        def _fake_load(model_name, hf_token = None):
+            if model_name == "org/qwen3.5-custom-remote":
+                return cfg
+            return None
+
+        def _fake_list(repo_id, hf_token = None):
+            if repo_id == "org/qwen3.5-custom-remote":
+                return {"modeling_custom.py"}, True
+            return set(), False
+
+        def _fake_read(model_name, filename, hf_token = None):
+            if model_name == "org/qwen3.5-custom-remote" and filename == "modeling_custom.py":
+                return "from transformers.modeling_layers import GradientCheckpointingLayer\n"
+            return None
+
+        monkeypatch.setattr(tv, "_load_config_json", _fake_load)
+        monkeypatch.setattr(tv, "_config_json_is_definitive", lambda *a, **k: True)
+        monkeypatch.setattr(tv, "_list_hub_repo_py_files", _fake_list)
+        monkeypatch.setattr(tv, "_read_repo_text_file", _fake_read)
+        _remote_auto_map_needs_510_cache.clear()
+
+        assert get_transformers_tier("org/qwen3.5-custom-remote") == "510"
+
+    def test_tier_detection_does_not_import_huggingface_hub(self, monkeypatch, tmp_path: Path):
+        """Pre-activation tier scan must stay on stdlib urllib (Codex round 2)."""
+        import builtins
+        import utils.transformers_version as tv
+
+        cfg = {
+            "model_type": "custom_remote",
+            "auto_map": {"AutoModelForCausalLM": "modeling_custom.CustomForCausalLM"},
+        }
+        (tmp_path / "config.json").write_text(json.dumps(cfg))
+        (tmp_path / "modeling_custom.py").write_text(
+            "from transformers.modeling_layers import GradientCheckpointingLayer\n"
+        )
+
+        real_import = builtins.__import__
+        blocked = {"huggingface_hub"}
+
+        def _guarded_import(name, globals = None, locals = None, fromlist = (), level = 0):
+            root = name.split(".", 1)[0]
+            if root in blocked:
+                raise AssertionError(f"tier detection imported {name}")
+            return real_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", _guarded_import)
         assert get_transformers_tier(str(tmp_path)) == "510"
 
     def test_gemma4_substring_returns_550(self):

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -616,7 +616,11 @@ class TestCheckConfigNeeds510:
         }
         (tmp_path / "tokenizer_config.json").write_text(json.dumps(tc))
 
-        def _fake_read(model_name, filename, hf_token = None):
+        def _fake_read(
+            model_name,
+            filename,
+            hf_token = None,
+        ):
             if model_name == "other/tokenizer-repo" and filename == "tokenization_x.py":
                 return "from transformers.tokenization_utils_tokenizers import TokenizersBackend\n"
             return None

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -566,6 +566,45 @@ class TestCheckConfigNeeds510:
         assert _check_remote_auto_map_needs_510(str(tmp_path)) is True
         assert _check_config_needs_510(str(tmp_path)) is True
 
+    def test_offline_hub_remote_auto_map_not_cached(self, monkeypatch):
+        """Offline Hub scan negatives must not poison a later online read."""
+        import utils.transformers_version as tv
+
+        _remote_auto_map_needs_510_cache.clear()
+        monkeypatch.setattr(tv, "_env_offline", lambda: True)
+        assert _check_remote_auto_map_needs_510("org/custom-remote") is False
+        assert ("org/custom-remote", None) not in _remote_auto_map_needs_510_cache
+
+    def test_hf_endpoint_used_for_remote_auto_map_fetch(self, monkeypatch):
+        """Remote auto_map fetches must honor HF_ENDPOINT mirrors."""
+        from utils.transformers_version import _read_repo_text_file
+
+        monkeypatch.setenv("HF_ENDPOINT", "https://hf-mirror.example")
+        monkeypatch.setattr(
+            "utils.transformers_version._env_offline",
+            lambda: False,
+        )
+        seen = {}
+
+        class _Resp:
+            def read(self):
+                return b"from transformers.modeling_layers import X\n"
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        def _urlopen(req, timeout = 10):
+            seen["url"] = req.full_url
+            return _Resp()
+
+        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        text = _read_repo_text_file("org/custom-remote", "modeling_custom.py")
+        assert "modeling_layers" in text
+        assert seen["url"].startswith("https://hf-mirror.example/org/custom-remote/raw/main/")
+
     def test_gemma4_non_unified_returns_false(self, tmp_path: Path):
         """Older Gemma 4 config should stay on the 550 tier."""
         cfg = {
@@ -880,6 +919,19 @@ class TestGetTransformersTier:
         }
         (tmp_path / "config.json").write_text(json.dumps(cfg))
         (tmp_path / "modeling_astral.py").write_text(
+            "from transformers.modeling_layers import GradientCheckpointingLayer\n"
+        )
+
+        assert get_transformers_tier(str(tmp_path)) == "510"
+
+    def test_local_custom_remote_auto_map_returns_510(self, tmp_path: Path):
+        """Local unknown model_types must scan auto_map before default (#7353 Codex)."""
+        cfg = {
+            "model_type": "custom_remote",
+            "auto_map": {"AutoModelForCausalLM": "modeling_custom.CustomForCausalLM"},
+        }
+        (tmp_path / "config.json").write_text(json.dumps(cfg))
+        (tmp_path / "modeling_custom.py").write_text(
             "from transformers.modeling_layers import GradientCheckpointingLayer\n"
         )
 

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -5247,14 +5247,12 @@ class TestAttributeReadOffADynamicImport:
 
     def _matches(self, src: str) -> bool:
         import utils.transformers_version as tv
-
         return tv._remote_auto_map_py_matches(self.MARKERS, [src])
 
     @pytest.mark.parametrize(
         "src",
         [
-            "import importlib\n"
-            'b = importlib.import_module("transformers").TokenizersBackend\n',
+            "import importlib\n" 'b = importlib.import_module("transformers").TokenizersBackend\n',
             '__import__("transformers").TokenizersBackend()\n',
             "from importlib import import_module\n"
             'import_module("transformers").TokenizersBackend()\n',
@@ -5293,8 +5291,7 @@ class TestAttributeReadOffADynamicImport:
     def test_attribute_off_dynamic_import_reaches_the_tier(self, tmp_path: Path):
         _auto_map_checkpoint(
             tmp_path,
-            "import importlib\n"
-            'b = importlib.import_module("transformers").TokenizersBackend\n',
+            "import importlib\n" 'b = importlib.import_module("transformers").TokenizersBackend\n',
         )
         assert _remote_auto_map_tier(str(tmp_path))[0] == "530"
 

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -3567,7 +3567,11 @@ class TestRaiseTierForNested:
 _V5_IMPORT = "from transformers.utils.output_capturing import capture_outputs\n"
 
 
-def _auto_map_checkpoint(root: Path, modeling_src: str, model_type: str = "custom_remote"):
+def _auto_map_checkpoint(
+    root: Path,
+    modeling_src: str,
+    model_type: str = "custom_remote",
+):
     """A local custom-code checkpoint whose auto_map points at ``modeling_custom.py``."""
     (root / "config.json").write_text(
         json.dumps(
@@ -3601,9 +3605,7 @@ class TestRemoteImportSpellings:
         assert get_transformers_tier(str(tmp_path)) == "510"
 
     def test_aliased_parent_import_returns_510(self, tmp_path: Path):
-        _auto_map_checkpoint(
-            tmp_path, "from transformers.utils import output_capturing as oc\n"
-        )
+        _auto_map_checkpoint(tmp_path, "from transformers.utils import output_capturing as oc\n")
         assert get_transformers_tier(str(tmp_path)) == "510"
 
     def test_parent_package_alone_stays_default(self, tmp_path: Path):

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -5187,7 +5187,9 @@ class TestQualifiedAccessToPublicExports:
         assert self._matches(src) is False
 
     def test_qualified_access_reaches_the_tier(self, tmp_path: Path):
-        _auto_map_checkpoint(tmp_path, "import transformers\nb = transformers.TokenizersBackend()\n")
+        _auto_map_checkpoint(
+            tmp_path, "import transformers\nb = transformers.TokenizersBackend()\n"
+        )
         assert _remote_auto_map_tier(str(tmp_path))[0] == "530"
 
 
@@ -5206,10 +5208,13 @@ class TestAliasedDynamicImportFunction:
         return tv._remote_auto_map_py_matches(self.MARKERS, [src])
 
     def test_aliased_import_module_promotes(self):
-        assert self._matches(
-            "from importlib import import_module as load_module\n"
-            'load_module("transformers.tokenization_utils_tokenizers")\n'
-        ) is True
+        assert (
+            self._matches(
+                "from importlib import import_module as load_module\n"
+                'load_module("transformers.tokenization_utils_tokenizers")\n'
+            )
+            is True
+        )
 
     @pytest.mark.parametrize(
         "src",
@@ -5218,10 +5223,8 @@ class TestAliasedDynamicImportFunction:
             "from mypkg import loader as load_module\n"
             'load_module("transformers.tokenization_utils_tokenizers")\n',
             'load_module("transformers.tokenization_utils_tokenizers")\n',
-            "from importlib import import_module as lm\n"
-            'lm(".tokenization_utils_tokenizers")\n',
-            "from importlib import import_module as lm\n"
-            'lm(f"transformers.{mod}")\n',
+            "from importlib import import_module as lm\n" 'lm(".tokenization_utils_tokenizers")\n',
+            "from importlib import import_module as lm\n" 'lm(f"transformers.{mod}")\n',
         ],
     )
     def test_unrelated_or_computed_callee_does_not_promote(self, src):

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -331,7 +331,10 @@ class TestCheckTokenizerConfigNeedsV5:
         tc = {"tokenizer_class": "TokenizersBackend"}
         (tmp_path / "tokenizer_config.json").write_text(json.dumps(tc))
 
-        key = (str(tmp_path), None)
+        import utils.transformers_version as tv
+
+        # The key carries the local scan signature so replacing the checkpoint re-reads it.
+        key = (str(tmp_path), None, tv._local_scan_signature(str(tmp_path)))
         _check_tokenizer_config_needs_v5(str(tmp_path))
         assert key in _tokenizer_class_cache
         assert _tokenizer_class_cache[key] is True
@@ -368,7 +371,8 @@ class TestCheckTokenizerConfigNeedsV5:
         assert _check_tokenizer_config_needs_v5("org/gated") is False  # unauth miss
         assert _check_tokenizer_config_needs_v5("org/gated", "tok") is True  # authed hit
         assert seen_auth == [None, "Bearer tok"]
-        assert _tokenizer_class_cache[("org/gated", None)] is False  # miss not poisoning
+        # A Hub id has an empty local signature, so its key stays (model, token, "").
+        assert _tokenizer_class_cache[("org/gated", None, "")] is False  # miss not poisoning
 
 
 # ---------------------------------------------------------------------------
@@ -1616,7 +1620,7 @@ class TestProbeTier:
     def test_get_tier_uses_probe_for_remote_tokenizer_signal(self, monkeypatch):
         # tokenizer says 5.x but no architecture/substring match -> probe (not a 530 guess).
         monkeypatch.setattr(
-            "utils.transformers_version._check_config_needs_510", lambda m, t = None: False
+            "utils.transformers_version._check_config_needs_510", lambda m, t = None, **kw: False
         )
         monkeypatch.setattr(
             "utils.transformers_version._check_config_needs_550", lambda m, t = None: False
@@ -1639,7 +1643,7 @@ class TestProbeTier:
         seen = {}
         monkeypatch.setattr(
             "utils.transformers_version._check_config_needs_510",
-            lambda m, t = None: seen.update({"510": t}) or False,
+            lambda m, t = None, **kw: seen.update({"510": t}) or False,
         )
         monkeypatch.setattr(
             "utils.transformers_version._check_config_needs_550",
@@ -1727,7 +1731,7 @@ class TestProbeGating:
 
     def _patch_checks_to_tokenizer(self, monkeypatch):
         monkeypatch.setattr(
-            "utils.transformers_version._check_config_needs_510", lambda m, t = None: False
+            "utils.transformers_version._check_config_needs_510", lambda m, t = None, **kw: False
         )
         monkeypatch.setattr(
             "utils.transformers_version._check_config_needs_550", lambda m, t = None: False
@@ -1816,7 +1820,7 @@ class TestProbeGating:
         # A 5.x-saved standard-tokenizer model must report as 5.x (for vision routing)
         # without spawning a probe.
         monkeypatch.setattr(
-            "utils.transformers_version._check_config_needs_510", lambda m, t = None: False
+            "utils.transformers_version._check_config_needs_510", lambda m, t = None, **kw: False
         )
         monkeypatch.setattr(
             "utils.transformers_version._check_config_needs_550", lambda m, t = None: False
@@ -3712,7 +3716,7 @@ class TestLocalScanCacheFreshness:
             )
         )
         assert _check_tokenizer_config_needs_v5(str(tmp_path)) is False
-        assert (str(tmp_path), None) not in _tokenizer_class_cache
+        assert not _tokenizer_class_cache  # nothing memoized at any key
         (tmp_path / "tokenization_my.py").write_text(
             "from transformers.tokenization_utils_tokenizers import TokenizersBackend\n"
         )
@@ -3752,7 +3756,7 @@ class TestTokenizerAutoMapTransientScan:
         )
         with patch("urllib.request.urlopen", return_value = _hf_response(tok_cfg)):
             assert _check_tokenizer_config_needs_v5("org/tok-only") is False
-            assert ("org/tok-only", None) not in _tokenizer_class_cache
+            assert not _tokenizer_class_cache  # nothing memoized at any key
             state["listing_ok"] = True
             assert _check_tokenizer_config_needs_v5("org/tok-only") is True
 
@@ -3775,7 +3779,7 @@ class TestTokenizerAutoMapTransientScan:
             after_first = mock_url.call_count
             assert _check_tokenizer_config_needs_v5("org/tok-only") is False
             assert mock_url.call_count == after_first  # second call served from the cache
-        assert _tokenizer_class_cache[("org/tok-only", None)] is False
+        assert _tokenizer_class_cache[("org/tok-only", None, "")] is False
 
 
 class TestProbeFalseSkipsAutoMapScan:
@@ -4160,3 +4164,217 @@ class TestImportScanIgnoresNonImportText:
             "from transformers.utils.output_capturing import (\n    capture,\n)\n",
         ):
             assert self._matches(src) is True
+
+
+# ---------------------------------------------------------------------------
+# Round 3: partial scans, signature coverage, mirror endpoint, probe=False cost
+# ---------------------------------------------------------------------------
+
+_V5_TOK_IMPORT = "from transformers.tokenization_utils_tokenizers import TokenizersBackend\n"
+
+
+def _tokenizer_checkpoint(root: Path, refs: list, tok_src: str):
+    """A local checkpoint whose tokenizer auto_map points at ``refs``."""
+    (root / "tokenizer_config.json").write_text(
+        json.dumps({"tokenizer_class": "MyTok", "auto_map": {"AutoTokenizer": refs}})
+    )
+    (root / "tokenization_my.py").write_text(tok_src)
+    return root
+
+
+class TestPartialTokenizerScanKeepsPositiveMatch:
+    """An unreachable external repo must not discard proof already read from disk."""
+
+    def setup_method(self):
+        _config_json_cache.clear()
+        _tokenizer_class_cache.clear()
+        _remote_auto_map_needs_510_cache.clear()
+
+    def test_local_proof_survives_external_repo_failure(self, monkeypatch, tmp_path: Path):
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        _tokenizer_checkpoint(
+            tmp_path,
+            ["tokenization_my.MyTok", "other/repo--tokenization_fast.MyTokFast"],
+            _V5_TOK_IMPORT,
+        )
+        monkeypatch.setattr(tv, "_list_hub_repo_py_files", lambda repo, tok = None: (set(), False))
+        assert _check_tokenizer_config_needs_v5(str(tmp_path)) is True
+
+    def test_incomplete_scan_without_proof_is_still_uncached(self, monkeypatch, tmp_path: Path):
+        """Negative control: no local proof means inconclusive, and nothing is memoized."""
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        _tokenizer_checkpoint(
+            tmp_path,
+            ["tokenization_my.MyTok", "other/repo--tokenization_fast.MyTokFast"],
+            "import torch\n",
+        )
+        monkeypatch.setattr(tv, "_list_hub_repo_py_files", lambda repo, tok = None: (set(), False))
+        assert _check_tokenizer_config_needs_v5(str(tmp_path)) is False
+        assert not _tokenizer_class_cache  # nothing memoized at any key
+
+
+class TestScanSignatureCoversAutoMapConfigs:
+    """The scan cache key must follow the declaration, not just the code."""
+
+    def setup_method(self):
+        _config_json_cache.clear()
+        _tokenizer_class_cache.clear()
+        _remote_auto_map_needs_510_cache.clear()
+
+    def test_auto_map_added_after_the_code_is_rescanned(self, tmp_path: Path):
+        """A staged checkpoint: .py first, processor auto_map afterwards."""
+        (tmp_path / "config.json").write_text(json.dumps({"model_type": "custom_remote"}))
+        (tmp_path / "processing_custom.py").write_text(_V5_IMPORT)
+        assert _check_remote_auto_map_needs_510(str(tmp_path)) is False
+        (tmp_path / "preprocessor_config.json").write_text(
+            json.dumps({"auto_map": {"AutoProcessor": "processing_custom.CustomProcessor"}})
+        )
+        assert _check_remote_auto_map_needs_510(str(tmp_path)) is True
+
+    def test_unrelated_file_still_serves_the_cache(self, monkeypatch, tmp_path: Path):
+        """Negative control: only .py and auto_map configs may bust the scan cache."""
+        import utils.transformers_version as tv
+
+        _auto_map_checkpoint(tmp_path, _V5_IMPORT)
+        assert _check_remote_auto_map_needs_510(str(tmp_path)) is True
+        (tmp_path / "generation_config.json").write_text(json.dumps({"do_sample": True}))
+        monkeypatch.setattr(
+            tv,
+            "_remote_auto_map_py_contents",
+            lambda *a, **k: (_ for _ in ()).throw(AssertionError("rescanned unchanged inputs")),
+        )
+        assert _check_remote_auto_map_needs_510(str(tmp_path)) is True
+
+
+class TestTokenizerScanCacheFreshness:
+    """The tokenizer cache must not answer from a checkpoint that has since changed."""
+
+    def setup_method(self):
+        _config_json_cache.clear()
+        _tokenizer_class_cache.clear()
+        _remote_auto_map_needs_510_cache.clear()
+
+    def test_rescanned_when_tokenizer_source_replaced(self, tmp_path: Path):
+        _tokenizer_checkpoint(tmp_path, ["tokenization_my.MyTok", None], "import torch\n")
+        assert _check_tokenizer_config_needs_v5(str(tmp_path)) is False
+        (tmp_path / "tokenization_my.py").write_text(_V5_TOK_IMPORT)
+        assert _check_tokenizer_config_needs_v5(str(tmp_path)) is True
+
+    def test_rescanned_when_tokenizer_config_replaced(self, tmp_path: Path):
+        (tmp_path / "tokenizer_config.json").write_text(
+            json.dumps({"tokenizer_class": "LlamaTokenizerFast"})
+        )
+        assert _check_tokenizer_config_needs_v5(str(tmp_path)) is False
+        (tmp_path / "tokenizer_config.json").write_text(
+            json.dumps({"tokenizer_class": "TokenizersBackend"})
+        )
+        assert _check_tokenizer_config_needs_v5(str(tmp_path)) is True
+
+    def test_unchanged_checkpoint_is_served_from_cache(self, monkeypatch, tmp_path: Path):
+        """Negative control: an untouched checkpoint must not be re-read every call."""
+        import utils.transformers_version as tv
+
+        _tokenizer_checkpoint(tmp_path, ["tokenization_my.MyTok", None], "import torch\n")
+        assert _check_tokenizer_config_needs_v5(str(tmp_path)) is False
+        monkeypatch.setattr(
+            tv,
+            "_tokenizer_auto_map_needs_v5",
+            lambda *a, **k: (_ for _ in ()).throw(AssertionError("rescanned unchanged inputs")),
+        )
+        assert _check_tokenizer_config_needs_v5(str(tmp_path)) is False
+
+
+class TestTokenizerConfigFetchHonorsEndpoint:
+    """A mirror-only deployment must reach the tokenizer config, or the scan never runs."""
+
+    def setup_method(self):
+        _config_json_cache.clear()
+        _tokenizer_class_cache.clear()
+        _remote_auto_map_needs_510_cache.clear()
+
+    def _serve(self, monkeypatch, mirror: str | None):
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        if mirror:
+            monkeypatch.setenv("HF_ENDPOINT", mirror)
+        else:
+            monkeypatch.delenv("HF_ENDPOINT", raising = False)
+        urls = []
+        tok_cfg = json.dumps(
+            {"tokenizer_class": "MyTok", "auto_map": {"AutoTokenizer": ["tokenization_my.M", None]}}
+        ).encode()
+
+        def _urlopen(req, timeout = 10):
+            urls.append(req.full_url)
+            if mirror and not req.full_url.startswith(mirror):
+                raise OSError("huggingface.co is blocked in this deployment")
+            if req.full_url.endswith("/tokenizer_config.json"):
+                return _PagedResponse(tok_cfg)
+            raise _http_error(req.full_url, 404)
+
+        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        monkeypatch.setattr(
+            tv, "_list_hub_repo_py_files", lambda repo, tok = None: ({"tokenization_my.py"}, True)
+        )
+        monkeypatch.setattr(tv, "_read_repo_text_file", lambda m, fn, tok = None: _V5_TOK_IMPORT)
+        return urls
+
+    def test_mirror_endpoint_reaches_the_auto_map_scan(self, monkeypatch):
+        urls = self._serve(monkeypatch, "https://hf-mirror.example")
+        assert _check_tokenizer_config_needs_v5("org/mirror-only") is True
+        assert urls and all(u.startswith("https://hf-mirror.example") for u in urls)
+
+    def test_public_endpoint_is_the_default(self, monkeypatch):
+        """Negative control: with no HF_ENDPOINT the public host is still used."""
+        urls = self._serve(monkeypatch, None)
+        assert _check_tokenizer_config_needs_v5("org/public") is True
+        assert urls[0] == "https://huggingface.co/org/public/raw/main/tokenizer_config.json"
+
+
+class TestProbeFalseSkipsConfigFallbackScan:
+    """probe=False is the cheap parent-side path: no tree listing, no per-.py fetches."""
+
+    def setup_method(self):
+        _config_json_cache.clear()
+        _config_needs_510_cache.clear()
+        _remote_auto_map_needs_510_cache.clear()
+
+    def _hub(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "empty-hub"))
+        urls = []
+        cfg = json.dumps(
+            {"model_type": "custom_remote", "auto_map": {"AutoModel": "modeling_custom.Model"}}
+        ).encode()
+        tree = json.dumps([{"type": "file", "path": f"modeling_{i}.py"} for i in range(12)]).encode()
+
+        def _urlopen(req, timeout = 10):
+            urls.append(req.full_url)
+            if req.full_url.endswith("/config.json"):
+                return _PagedResponse(cfg)
+            if "/tree/" in req.full_url:
+                return _PagedResponse(tree)
+            if req.full_url.endswith(".py"):
+                return _PagedResponse(_V5_IMPORT.encode())
+            raise _http_error(req.full_url, 404)
+
+        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        return urls
+
+    def test_probe_false_does_not_list_or_fetch_repo_code(self, monkeypatch, tmp_path):
+        urls = self._hub(monkeypatch, tmp_path)
+        assert get_transformers_tier("org/custom-remote", probe = False) == "default"
+        assert not [u for u in urls if "/tree/" in u or u.endswith(".py")]
+
+    def test_probe_false_negative_does_not_poison_activation(self, monkeypatch, tmp_path):
+        """Negative control: the skipped scan must not be memoized as a 510 negative."""
+        urls = self._hub(monkeypatch, tmp_path)
+        assert get_transformers_tier("org/custom-remote", probe = False) == "default"
+        assert ("org/custom-remote", None) not in _config_needs_510_cache
+        assert get_transformers_tier("org/custom-remote", probe = True) == "510"
+        assert [u for u in urls if u.endswith(".py")]  # the activation path did scan

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -3839,6 +3839,11 @@ class TestProbeFalseSkipsAutoMapScan:
         monkeypatch.setattr(
             tv, "_load_config_json", lambda name, tok = None: cfg if "qwen3.5" in name else None
         )
+        # The stub returns a config without recording how it was obtained, and a config is
+        # only conclusive when the real loader cached it or the Hub gave an access answer.
+        # Stand that bookkeeping in too, the way the sibling scan tests stub
+        # _config_json_is_definitive, so this stays a test of the activation path.
+        monkeypatch.setattr(tv, "_config_json_answer_is_definitive", lambda name, tok = None: True)
         monkeypatch.setattr(
             tv, "_list_hub_repo_py_files", lambda repo, tok = None: ({"modeling_custom.py"}, True)
         )
@@ -3997,6 +4002,92 @@ class TestUnreadableAutoMapConfigIsInconclusive:
         monkeypatch.setattr("utils.transformers_version._hub_urlopen", _urlopen)
         assert tv._remote_auto_map_scan_result("org/plain-model") == (False, True)
         assert _remote_auto_map_tier_cache  # definitive, so memoized
+
+
+class TestCachedConfigFallbackStaysInconclusive:
+    """A hub-cache config served after a failed fetch is not a reading of the current one.
+
+    ``_load_config_json`` answers a transient failure from an older snapshot and deliberately
+    does not cache it, so the next call retries. ``_load_repo_json_checked`` still called that
+    fallback definitive purely because it was non-None, so a snapshot taken before the repo
+    gained its ``auto_map`` memoized a definitive default tier without the live remote code
+    ever being scanned. Being a process-lifetime memo, it then kept routing the model to
+    4.57.x after connectivity recovered, for the life of the worker.
+    """
+
+    def setup_method(self):
+        _clear_scan_caches()
+        import utils.transformers_version as tv
+        tv._config_json_absent.clear()
+
+    @staticmethod
+    def _hub(monkeypatch, tmp_path, state):
+        """Serve the CURRENT config (with auto_map) except while ``state["down"]``."""
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "empty-hub"))
+        current = json.dumps(
+            {"model_type": "custom", "auto_map": {"AutoModel": "modeling_custom.Model"}}
+        ).encode()
+
+        def _urlopen(req, timeout = 10):
+            url = req.full_url
+            if url.endswith("/config.json"):
+                if state["down"]:
+                    raise OSError("temporary Hub outage")
+                return _PagedResponse(current)
+            if "/tree/" in url:
+                return _PagedResponse(
+                    json.dumps([{"type": "file", "path": "modeling_custom.py"}]).encode()
+                )
+            if url.endswith("modeling_custom.py"):
+                return _PagedResponse(_V5_IMPORT.encode())
+            raise _http_error(url, 404)
+
+        monkeypatch.setattr(tv, "_hub_urlopen", _urlopen)
+        # The stale snapshot on disk, downloaded before auto_map was added.
+        monkeypatch.setattr(
+            tv, "_config_json_from_hf_cache", lambda name: {"model_type": "custom"}
+        )
+        monkeypatch.setattr(tv, "_hf_cache_snapshot_dir", lambda name: None)
+
+    def test_stale_snapshot_answer_is_not_definitive(self, monkeypatch, tmp_path):
+        import utils.transformers_version as tv
+
+        self._hub(monkeypatch, tmp_path, {"down": True})
+        cfg, definitive = tv._load_repo_json_checked("org/newly-remote", "config.json")
+        assert cfg == {"model_type": "custom"}  # the snapshot still answers the caller
+        assert definitive is False  # but it is not a read of the live config
+
+    def test_outage_does_not_memoize_a_default_tier(self, monkeypatch, tmp_path):
+        import utils.transformers_version as tv
+
+        state = {"down": True}
+        self._hub(monkeypatch, tmp_path, state)
+        assert tv._remote_auto_map_tier("org/newly-remote") == ("default", False)
+        assert not _remote_auto_map_tier_cache  # nothing memoized off the snapshot
+
+        state["down"] = False
+        assert tv._remote_auto_map_tier("org/newly-remote") == ("530", True)
+
+    def test_a_real_read_is_still_definitive(self, monkeypatch, tmp_path):
+        """Negative control: a config the Hub actually served must stay conclusive."""
+        import utils.transformers_version as tv
+
+        self._hub(monkeypatch, tmp_path, {"down": False})
+        cfg, definitive = tv._load_repo_json_checked("org/newly-remote", "config.json")
+        assert definitive is True and "auto_map" in cfg
+        assert tv._remote_auto_map_tier("org/newly-remote") == ("530", True)
+
+    def test_local_path_answer_is_still_definitive(self, monkeypatch, tmp_path):
+        """Negative control: only a Hub id can fall back to a snapshot."""
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setattr(tv, "_looks_like_hf_id", lambda name: False)
+        monkeypatch.setattr(tv, "_load_config_json", lambda name, tok = None: None)
+        assert tv._load_repo_json_checked("./nowhere", "config.json") == (None, True)
 
 
 class TestProcessorOnlyAutoMapIsScanned:
@@ -5296,6 +5387,107 @@ class TestAttributeReadOffADynamicImport:
         assert _remote_auto_map_tier(str(tmp_path))[0] == "530"
 
 
+class TestConstantGetattrReadsTheExport:
+    """``getattr(transformers, "X")`` reads the same export as ``transformers.X``.
+
+    The call walker saw no dynamic import (the first argument is a name, not a string) and the
+    attribute walker saw no ``ast.Attribute`` at all, so only the bare module was recorded.
+    The static spelling promotes, so this one, which raises the very same ``AttributeError``
+    on a sidecar without the export, has to promote too.
+    """
+
+    MARKERS = ("transformers.TokenizersBackend", "transformers.utils.output_capturing")
+
+    def setup_method(self):
+        _clear_scan_caches()
+
+    def _matches(self, src: str) -> bool:
+        import utils.transformers_version as tv
+        return tv._remote_auto_map_py_matches(self.MARKERS, [src])
+
+    @pytest.mark.parametrize(
+        "src",
+        [
+            'import transformers\nb = getattr(transformers, "TokenizersBackend")\n',
+            'import transformers\ngetattr(transformers, "TokenizersBackend")()\n',
+            # An alias resolves through the file's own bindings, like the static spelling.
+            'import transformers as tf\nb = getattr(tf, "TokenizersBackend")\n',
+            # Reading further off the result reads the export first.
+            'import transformers\ngetattr(transformers, "TokenizersBackend").from_file("t")\n',
+            # Mixed spellings along one path, in both orders.
+            'import transformers\nb = getattr(transformers.utils, "output_capturing")\n',
+            'import transformers\nb = getattr(transformers, "utils").output_capturing\n',
+            # Nested constant getattr walks the same chain.
+            'import transformers\nb = getattr(getattr(transformers, "utils"), '
+            '"output_capturing")\n',
+            # Off a dynamic import, the spelling the attribute chain already handles.
+            "import importlib\n"
+            'b = getattr(importlib.import_module("transformers"), "TokenizersBackend")\n',
+        ],
+    )
+    def test_constant_getattr_promotes(self, src):
+        assert self._matches(src) is True
+
+    @pytest.mark.parametrize(
+        "src",
+        [
+            # Computed name: never resolved to a literal, so nothing is known to be read.
+            "import transformers\nb = getattr(transformers, name)\n",
+            "import transformers\nb = getattr(transformers, prefix + suffix)\n",
+            'import transformers\nb = getattr(transformers, f"Tokenizers{x}")\n',
+            # A different export proves nothing about the marker.
+            'import transformers\nb = getattr(transformers, "AutoModel")\n',
+            # Never imported here, so the root binds to nothing.
+            'b = getattr(mystery, "TokenizersBackend")\n',
+            'import mypkg\nb = getattr(mypkg, "TokenizersBackend")\n',
+            # The guard body does not run.
+            "from typing import TYPE_CHECKING\nimport transformers\n"
+            "if TYPE_CHECKING:\n"
+            '    b = getattr(transformers, "TokenizersBackend")\n',
+            # hasattr answers False on 4.57.x instead of raising.
+            'import transformers\nif hasattr(transformers, "TokenizersBackend"):\n    pass\n',
+            # Not a builtin attribute read at all.
+            'import transformers\nb = obj.getattr(transformers, "TokenizersBackend")\n',
+        ],
+    )
+    def test_unread_or_safe_getattr_does_not_promote(self, src):
+        """Negative control: only a constant name really read off a real import counts."""
+        assert self._matches(src) is False
+
+    @pytest.mark.parametrize(
+        "src",
+        [
+            'import transformers\nb = getattr(transformers, "TokenizersBackend", None)\n',
+            "import transformers\n"
+            'b = getattr(transformers, "TokenizersBackend", FallbackBackend)\n',
+            'import transformers\nb = getattr(transformers, "TokenizersBackend", None).x\n',
+        ],
+    )
+    def test_defaulted_getattr_does_not_promote(self, src):
+        """A supplied default is the idiom for handling the export being absent.
+
+        Three-argument ``getattr`` cannot raise, so the module really does load on 4.57.x and
+        the repo does not need a sidecar. Promoting it would strand every version-portable
+        repo on 5.x, the opposite of what its author wrote. Same rule as ``if TYPE_CHECKING:``:
+        an access that cannot fail must not raise the tier.
+        """
+        assert self._matches(src) is False
+
+    def test_constant_getattr_reaches_the_tier(self, tmp_path: Path):
+        _auto_map_checkpoint(
+            tmp_path,
+            'import transformers\nb = getattr(transformers, "TokenizersBackend")\n',
+        )
+        assert _remote_auto_map_tier(str(tmp_path)) == ("530", True)
+
+    def test_defaulted_getattr_leaves_the_tier_alone(self, tmp_path: Path):
+        _auto_map_checkpoint(
+            tmp_path,
+            'import transformers\nb = getattr(transformers, "TokenizersBackend", None)\n',
+        )
+        assert _remote_auto_map_tier(str(tmp_path)) == ("default", True)
+
+
 class TestImpossible510ScanIsSkipped:
     """The name fast path must not pay Hub I/O for an answer it cannot use.
 
@@ -5970,6 +6162,97 @@ class TestRemoteScanDownloadsAreBounded:
         _, complete = tv._collect_external_py_sources(refs, None, tv._RemoteScanBudget())
         assert len(fetched) == tv._REMOTE_SCAN_MAX_FILES
         assert complete is False
+
+    @staticmethod
+    def _counted_listings(monkeypatch, tree: set):
+        """Count repo tree listings, serving every repo the same *tree*."""
+        import utils.transformers_version as tv
+
+        listed: list[str] = []
+        monkeypatch.setattr(
+            tv,
+            "_list_hub_repo_py_files",
+            lambda repo, tok = None: (listed.append(repo), (set(tree), True))[1],
+        )
+        monkeypatch.setattr(tv, "_read_repo_text_file", lambda repo, fn, tok = None: "import torch\n")
+        monkeypatch.setattr(tv, "_hf_cache_snapshot_dir", lambda name: None)
+        return listed
+
+    def test_listings_stop_once_the_download_budget_is_spent(self, monkeypatch):
+        """Listing a repo pages its whole tree before ``take_file`` is consulted.
+
+        The loop kept calling ``_fetch_hub_py_sources`` for every named repo after the shared
+        budget was gone, so each one still paid a full recursive listing (up to
+        ``_HF_API_MAX_PAGES`` authenticated 10s-timeout requests) for sources it could no
+        longer keep, all ahead of the remote-code consent gate.
+        """
+        import utils.transformers_version as tv
+
+        listed = self._counted_listings(monkeypatch, {f"m{i:05d}.py" for i in range(1000)})
+        refs = {(f"evil/repo{i:04d}", "modeling.py") for i in range(500)}
+        _, complete = tv._collect_external_py_sources(refs, None, tv._RemoteScanBudget())
+        # The first repo alone spends the file budget, so no other repo is worth listing.
+        assert listed == ["evil/repo0000"]
+        assert complete is False
+
+    def test_repo_count_is_capped_when_no_file_budget_is_spent(self, monkeypatch):
+        """A repo holding no ``.py`` charges no file slot, so the file cap bounds nothing."""
+        import utils.transformers_version as tv
+
+        listed = self._counted_listings(monkeypatch, set())
+        refs = {(f"evil/repo{i:04d}", "modeling.py") for i in range(500)}
+        budget = tv._RemoteScanBudget()
+        _, complete = tv._collect_external_py_sources(refs, None, budget)
+        assert len(listed) == tv._REMOTE_SCAN_MAX_EXTERNAL_REPOS
+        assert budget.files_left == tv._REMOTE_SCAN_MAX_FILES  # nothing was downloadable
+        assert budget.truncated is True
+        # A capped closure is incomplete, so no negative is memoized off it.
+        assert complete is False
+
+    def test_a_realistic_closure_is_listed_in_full(self, monkeypatch):
+        """Negative control: the cap must not truncate a real auto_map closure.
+
+        An ``auto_map`` names an external repo to borrow a base implementation, so real
+        closures reach a couple of repos and must still be scanned completely.
+        """
+        import utils.transformers_version as tv
+
+        listed = self._counted_listings(monkeypatch, {"modeling_base.py"})
+        refs = {("org/base", "modeling_base.Model"), ("org/vision", "modeling_vision.Tower")}
+        sources, complete = tv._collect_external_py_sources(refs, None, tv._RemoteScanBudget())
+        assert listed == ["org/base", "org/vision"]
+        assert len(sources) == 2 and complete is True
+
+    def test_the_bound_holds_from_the_tier_entry_point(self, monkeypatch, tmp_path):
+        """The cap has to hold on the path a selected model actually takes."""
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "empty-hub"))
+        cfg = json.dumps(
+            {
+                "model_type": "custom",
+                "auto_map": {
+                    f"AutoModel{i}": f"evil/repo{i:04d}--modeling_x.Klass" for i in range(500)
+                },
+            }
+        ).encode()
+        trees = []
+
+        def _urlopen(req, timeout = 10):
+            url = req.full_url
+            if url.endswith("/config.json"):
+                return _PagedResponse(cfg)
+            if "/tree/" in url:
+                trees.append(url)
+                return _PagedResponse(b"[]")
+            raise _http_error(url, 404)
+
+        monkeypatch.setattr(tv, "_hub_urlopen", _urlopen)
+        monkeypatch.setattr(tv, "_hf_cache_snapshot_dir", lambda name: None)
+        assert tv._remote_auto_map_tier("org/hostile") == ("default", False)
+        # One listing for the model's own repo, then the external cap.
+        assert len(trees) == tv._REMOTE_SCAN_MAX_EXTERNAL_REPOS + 1
 
     def test_one_enormous_source_is_not_read_into_memory(self, monkeypatch):
         """The aggregate cap can only charge a file already read, so bound the read."""

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -585,9 +585,8 @@ class TestCheckConfigNeeds510:
     ):
         """Offline must reach the Hub API for nothing, even via an external auto_map.
 
-        A local checkpoint is scanned offline, so its external ``auto_map`` refs would
-        otherwise hit the repo-tree endpoint and block on the connect timeout every
-        call (the incomplete scan is never cached).
+        A local checkpoint is still scanned offline, so its external ``auto_map`` refs would
+        otherwise block on the repo-tree connect timeout every call (the scan is never cached).
         """
         import utils.transformers_version as tv
 
@@ -1021,9 +1020,9 @@ class TestGetTransformersTier:
     def test_remote_code_importable_on_default_stays_default(self, tmp_path: Path):
         """4.57.x-importable remote code must NOT be pushed onto the sidecar.
 
-        ``transformers.modeling_layers`` (4.52+) and ``use_kernel_forward_from_hub``
-        (4.51+) both exist in the default tier, so custom-code models built on them
-        (EXAONE, MiniMax, Molmo2, step3, ...) must keep loading on default.
+        ``transformers.modeling_layers`` (4.52+) and ``use_kernel_forward_from_hub`` (4.51+)
+        exist in the default tier, so models built on them (EXAONE, MiniMax, Molmo2, step3)
+        must keep loading there.
         """
         cfg = {
             "model_type": "custom_remote",
@@ -1066,7 +1065,7 @@ class TestGetTransformersTier:
         assert get_transformers_tier(str(tmp_path)) == "default"
 
     def test_local_custom_remote_auto_map_returns_530(self, tmp_path: Path):
-        """Local unknown model_types must scan auto_map before default (#7353 Codex)."""
+        """Local unknown model_types must scan auto_map before default (#7353)."""
         cfg = {
             "model_type": "custom_remote",
             "auto_map": {"AutoModelForCausalLM": "modeling_custom.CustomForCausalLM"},
@@ -1079,7 +1078,7 @@ class TestGetTransformersTier:
         assert get_transformers_tier(str(tmp_path), probe = False) == "530"
 
     def test_local_helper_auto_map_returns_530(self, tmp_path: Path):
-        """Helper modules imported by auto_map entry must be scanned (Codex #4)."""
+        """Helper modules imported by auto_map entry must be scanned."""
         cfg = {
             "model_type": "custom_remote",
             "auto_map": {"AutoModelForCausalLM": "modeling_custom.CustomForCausalLM"},
@@ -1095,7 +1094,7 @@ class TestGetTransformersTier:
         assert get_transformers_tier(str(tmp_path), probe = False) == "530"
 
     def test_external_auto_map_repo_returns_530(self, monkeypatch, tmp_path: Path):
-        """External auto_map repos and their helpers must be scanned (Codex #4)."""
+        """External auto_map repos and their helpers must be scanned."""
         import utils.transformers_version as tv
 
         cfg = {
@@ -1123,7 +1122,7 @@ class TestGetTransformersTier:
         assert get_transformers_tier(str(tmp_path), probe = False) == "530"
 
     def test_local_lower_tier_model_type_with_auto_map_still_scans(self, tmp_path: Path):
-        """Lower-tier model_type must not skip auto_map scan (Codex round 2)."""
+        """Lower-tier model_type must not skip auto_map scan."""
         cfg = {
             "model_type": "qwen3_moe",
             "auto_map": {"AutoModelForCausalLM": "modeling_custom.CustomForCausalLM"},
@@ -1137,7 +1136,7 @@ class TestGetTransformersTier:
         assert get_transformers_tier(str(tmp_path), probe = False) == "530"
 
     def test_name_substring_not_downgraded_by_remote_auto_map(self, monkeypatch):
-        """Name fast path keeps its tier once the auto_map scan agrees (Codex round 2)."""
+        """Name fast path keeps its tier once the auto_map scan agrees."""
         import utils.transformers_version as tv
 
         cfg = {
@@ -1173,7 +1172,7 @@ class TestGetTransformersTier:
         assert get_transformers_tier("org/qwen3.5-custom-remote") == "530"
 
     def test_tier_detection_does_not_import_huggingface_hub(self, monkeypatch, tmp_path: Path):
-        """Pre-activation tier scan must stay on stdlib urllib (Codex round 2)."""
+        """Pre-activation tier scan must stay on stdlib urllib."""
         import builtins
         import utils.transformers_version as tv
 
@@ -1306,10 +1305,10 @@ class TestGetTransformersTier:
     def test_remote_config_json_is_fetched_once_for_config_tiers(self):
         """510 and 550 slow-path checks should share one config.json fetch.
 
-        The auto_map scan additionally reads the remote-code configs once each (a processor
-        declared only in preprocessor/processor config is executable too), so pin the real
-        invariant: config.json is fetched exactly once, and nothing beyond the remote-code
-        config set is fetched for a repo that declares no auto_map.
+        The auto_map scan also reads each remote-code config once (a processor declared only
+        in preprocessor/processor config is executable too), so pin the real invariant:
+        config.json fetched exactly once, and nothing beyond the remote-code config set for a
+        repo that declares no auto_map.
         """
         from utils.security.remote_code_scan import REMOTE_CODE_CONFIG_FILES
 
@@ -3815,10 +3814,9 @@ class TestProbeFalseSkipsAutoMapScan:
     def test_probe_true_still_runs_the_auto_map_scan(self, monkeypatch):
         """probe=True scans -- once a 5.10-only marker makes the answer reachable.
 
-        The scan is gated on ``_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS``, empty today, so the
-        marker is patched in here to assert the activation path still reaches the repo. With
-        the tuple empty the fast path deliberately makes no request; that half of the
-        contract is covered by ``TestImpossible510ScanIsSkipped``.
+        The scan is gated on ``_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS``, empty today, so a
+        marker is patched in to assert the activation path still reaches the repo. The empty
+        case (no request) is covered by ``TestImpossible510ScanIsSkipped``.
         """
         import utils.transformers_version as tv
 
@@ -4282,11 +4280,11 @@ class TestScanSignatureCoversAutoMapConfigs:
 
 class TestScanSignatureSeesSameSizedReplacement:
     """size + mtime cannot see an archival redeploy that restores the timestamp, so the
-    signature also carries ctime and inode (round 7 Codex).
+    signature also carries ctime and inode.
 
-    ``rsync --archive`` / ``tar -xp`` put back the original mtime, and a same-sized rewrite
-    leaves the size alone, so a long-lived worker kept serving the tier it computed from
-    code no longer on disk.
+    ``rsync --archive`` / ``tar -xp`` put back the original mtime and a same-sized rewrite
+    leaves the size alone, so a long-lived worker kept serving a tier computed from code no
+    longer on disk.
     """
 
     # Same byte length, so only the content differs.
@@ -4505,9 +4503,9 @@ def _clear_scan_caches():
 class TestPartialHubFetchKeepsProof:
     """A .py that fails to fetch must not discard the sources already read.
 
-    The scan trusts a positive from an incomplete closure, so dropping the earlier files
-    throws away an already-observed 5.x-only import and routes the worker to a sidecar
-    that cannot import the remote code.
+    The scan trusts a positive from an incomplete closure, so dropping the earlier files would
+    throw away an observed 5.x-only import and route the worker to a sidecar that cannot
+    import the remote code.
     """
 
     def setup_method(self):
@@ -4568,9 +4566,9 @@ class TestPartialHubFetchKeepsProof:
 class TestLocalConfigRewriteIsRescanned:
     """A staged checkpoint can write its code first and its ``auto_map`` afterwards.
 
-    The changed scan signature forces a rescan; that rescan must read the new
-    ``config.json`` from disk instead of the process-lifetime ``_config_json_cache``,
-    or it memoizes a fresh negative under the new signature.
+    The changed scan signature forces a rescan, and that rescan must read the new
+    ``config.json`` from disk rather than the process-lifetime ``_config_json_cache``, or it
+    memoizes a fresh negative under the new signature.
     """
 
     def setup_method(self):
@@ -4612,8 +4610,8 @@ class TestLocalConfigRewriteIsRescanned:
 class TestAutoMapImportsOf5xTokenizerBackend:
     """Remote code reached through config.json, not tokenizer_config.json.
 
-    ``transformers.tokenization_utils_tokenizers`` does not exist on the default 4.57.x
-    tier, so a modeling/processor module importing it must not route there just because
+    ``transformers.tokenization_utils_tokenizers`` does not exist on 4.57.x, so a
+    modeling/processor module importing it must not route there just because
     ``tokenizer_config.json`` declares no ``auto_map`` of its own.
     """
 
@@ -4741,8 +4739,8 @@ class TestTypeCheckingImportsAreNotRuntimeImports:
 
 
 class TestOutputCapturingTakesThe53Floor:
-    """``transformers.utils.output_capturing`` ships since 5.2.0, so the 5.3 sidecar can
-    import it and the marker must not force the 5.10 one (round 5 Codex)."""
+    """``transformers.utils.output_capturing`` ships since 5.2.0, so the marker must take
+    the 5.3 sidecar, not the 5.10 one."""
 
     def setup_method(self):
         _clear_scan_caches()
@@ -4782,8 +4780,8 @@ class TestOutputCapturingTakesThe53Floor:
 
 
 class TestHubPaginationStaysOnTheConfiguredOrigin:
-    """A ``rel="next"`` cursor is refetched with the caller's ``Authorization`` header, so it
-    must never leave the configured endpoint (round 5 Codex)."""
+    """A ``rel="next"`` cursor is refetched with the caller's ``Authorization``, so it must
+    never leave the configured endpoint."""
 
     def setup_method(self):
         _clear_scan_caches()
@@ -4871,8 +4869,8 @@ class TestHubPaginationStaysOnTheConfiguredOrigin:
 
 
 class TestOfflineAutoMapScanUsesTheHubCache:
-    """Offline, a downloaded snapshot is exactly the code that will be executed, so it must
-    be scanned instead of assumed clean (round 5 Codex)."""
+    """Offline, a downloaded snapshot is the code that will run, so scan it rather than
+    assume it is clean."""
 
     def setup_method(self):
         _clear_scan_caches()
@@ -4904,8 +4902,7 @@ class TestOfflineAutoMapScanUsesTheHubCache:
         monkeypatch.setenv("HF_HUB_OFFLINE", "1")
         tier, definitive = tv._remote_auto_map_tier("org/cached-5x")
         assert tier == "530"
-        # Offline can never reach an external auto_map repo, so the answer stays provisional
-        # and nothing is memoized under the Hub id.
+        # External auto_map repos are unreachable offline, so nothing is memoized.
         assert definitive is False
         assert not [key for key in _remote_auto_map_tier_cache if key[0] == "org/cached-5x"]
 
@@ -4946,13 +4943,12 @@ class TestOfflineAutoMapScanUsesTheHubCache:
 
 
 class TestInconclusiveScanFallsBackToTheHubCache:
-    """Online but inconclusive is not a negative: an already downloaded snapshot is the
-    code the load will execute, so read it instead of reporting the default tier (round 7
-    Codex).
+    """Online but inconclusive is not a negative: a downloaded snapshot is the code the load
+    will execute, so read it instead of reporting the default tier.
 
-    Same fallback as the offline branch above; the trigger here is a transient Hub failure
-    while nominally online, which otherwise hands ``get_transformers_tier`` a bare
-    ``"default"`` it cannot tell apart from a repo that really has no 5.x import.
+    Same fallback as the offline branch above, triggered by a transient Hub failure while
+    nominally online, which otherwise hands ``get_transformers_tier`` a bare ``"default"`` it
+    cannot tell apart from a repo that really has no 5.x import.
     """
 
     def setup_method(self):
@@ -4974,8 +4970,7 @@ class TestInconclusiveScanFallsBackToTheHubCache:
 
         tier, definitive = tv._remote_auto_map_tier("org/outage-5x")
         assert tier == "530"
-        # The Hub still never answered, so the result stays provisional and nothing is
-        # memoized under the Hub id: a recovered Hub must re-scan.
+        # The Hub never answered, so nothing is memoized: a recovered Hub must re-scan.
         assert definitive is False
         assert not [key for key in _remote_auto_map_tier_cache if key[0] == "org/outage-5x"]
 
@@ -5006,9 +5001,8 @@ class TestInconclusiveScanFallsBackToTheHubCache:
     def test_no_snapshot_stays_default(self, monkeypatch, tmp_path: Path):
         """Negative control: an outage with nothing downloaded invents no requirement.
 
-        A blanket 5.3 floor for every inconclusive scan would push plain repos onto the
-        5.3 sidecar for the length of any Hub outage, so the fallback is the snapshot and
-        only the snapshot.
+        A blanket 5.3 floor for every inconclusive scan would push plain repos onto the 5.3
+        sidecar for the length of any Hub outage, so the fallback is the snapshot and only it.
         """
         import utils.transformers_version as tv
 
@@ -5030,8 +5024,7 @@ class TestInconclusiveScanFallsBackToTheHubCache:
     def test_definitive_negative_does_not_consult_the_snapshot(self, monkeypatch, tmp_path: Path):
         """Negative control: a repo that really has no auto_map keeps its cached negative.
 
-        A 404 is an answer, so a stale snapshot left over from an older revision must not
-        override it (that would resurrect the Hub-side staleness this PR declined to fix).
+        A 404 is an answer, so a stale snapshot from an older revision must not override it.
         """
         import utils.transformers_version as tv
 
@@ -5067,8 +5060,8 @@ def _raise(exc):
 
 
 class TestDynamicImportsOfVersionedModules:
-    """Remote code that loads a module through ``importlib`` really does import it, so the
-    scan must see it (round 5 Codex)."""
+    """Remote code loading a module through ``importlib`` really imports it, so the scan
+    must see it."""
 
     MARKERS = ("transformers.tokenization_utils_tokenizers",)
 
@@ -5138,9 +5131,9 @@ class TestDynamicImportsOfVersionedModules:
 
 
 class TestQualifiedAccessToPublicExports:
-    """``import transformers`` then ``transformers.TokenizersBackend`` is the ordinary
-    spelling of a public-export marker; recording only ``transformers`` left the checkpoint
-    on 4.57.x, where the attribute does not exist (round 9 Codex)."""
+    """``import transformers`` then ``transformers.TokenizersBackend`` is the ordinary spelling
+    of a public-export marker; recording only ``transformers`` left the checkpoint on 4.57.x,
+    where the attribute does not exist."""
 
     MARKERS = ("transformers.TokenizersBackend", "transformers.utils.output_capturing")
 
@@ -5195,8 +5188,8 @@ class TestQualifiedAccessToPublicExports:
 
 class TestAliasedDynamicImportFunction:
     """``from importlib import import_module as load_module`` then ``load_module(...)``
-    imports the module for real, so the literal-name check alone missed it (round 9 Codex).
-    Only a callee the file itself bound to ``importlib.import_module`` counts."""
+    really imports, which the literal-name check alone missed. Only a callee the file itself
+    bound to ``importlib.import_module`` counts."""
 
     MARKERS = ("transformers.tokenization_utils_tokenizers",)
 
@@ -5235,11 +5228,10 @@ class TestAliasedDynamicImportFunction:
 class TestImpossible510ScanIsSkipped:
     """The name fast path must not pay Hub I/O for an answer it cannot use.
 
-    ``_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS`` is empty, so the auto_map scan cannot
-    classify anything as 5.10: on a ``_tier_from_name`` hit with ``probe=True`` it would read
-    every remote-code config, page the repo tree and fetch each ``.py`` only to return the
-    tier the name already produced. The skip is gated on the tuple, never on the call site,
-    so re-adding a 5.10-only module restores the scan by itself (proved below).
+    ``_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS`` is empty, so on a ``_tier_from_name`` hit with
+    ``probe=True`` the scan would read every remote-code config, page the repo tree and fetch
+    each ``.py`` only to return the tier the name already produced. The skip is gated on the
+    tuple, not the call site, so re-adding a 5.10-only module restores it (proved below).
     """
 
     _FUTURE_MARKER = "transformers.models.some_future_510_only"
@@ -5340,9 +5332,9 @@ class TestImpossible510ScanIsSkipped:
 def _throwaway_origin(respond):
     """Start a local HTTP origin on an ephemeral port for the redirect tests.
 
-    ``respond(path)`` returns ``(status, extra_headers, body)``. Returns
-    ``(base_url, seen, close)`` where ``seen`` collects ``(path, Authorization)`` for every
-    request the origin received, so a leaked token is directly observable.
+    ``respond(path)`` returns ``(status, extra_headers, body)``. Returns ``(base_url, seen,
+    close)``, where ``seen`` collects ``(path, Authorization)`` per request so a leaked token
+    is directly observable.
     """
     import http.server
     import threading
@@ -5378,11 +5370,10 @@ def _throwaway_origin(respond):
 class TestHubRedirectDoesNotReplayTheToken:
     """A 3xx must not hand ``Authorization: Bearer <hf_token>`` to another origin.
 
-    ``urllib.request.HTTPRedirectHandler.redirect_request`` copies every header except
-    content-length/content-type onto the redirect target with no host comparison, and this
-    module attaches the token via ``Request(headers=...)`` (so it lands in ``req.headers``,
-    not ``unredirected_hdrs``). ``HF_ENDPOINT`` is user-configurable, so the redirecting host
-    is not necessarily the Hub.
+    Stock ``HTTPRedirectHandler.redirect_request`` copies every header onto the target with no
+    host comparison, and this module attaches the token via ``Request(headers=...)`` (so it
+    lands in ``req.headers``, not ``unredirected_hdrs``). ``HF_ENDPOINT`` is user-configurable,
+    so the redirecting host is not necessarily the Hub.
     """
 
     def setup_method(self):
@@ -5396,8 +5387,8 @@ class TestHubRedirectDoesNotReplayTheToken:
     def test_stock_urlopen_leaks_the_token_across_origins(self):
         """The mechanism itself, so this stays honest if urllib ever changes.
 
-        Nothing under test here: it is plain ``urllib.request.urlopen`` against two origins,
-        and it is exactly what every fetch in this module used to do.
+        Nothing under test: plain ``urllib.request.urlopen`` against two origins, exactly what
+        every fetch in this module used to do.
         """
         import urllib.request
 
@@ -5448,10 +5439,10 @@ class TestHubRedirectDoesNotReplayTheToken:
         assert (data, ok) == ([], True)
 
     def test_same_origin_redirect_keeps_the_token(self, monkeypatch):
-        """Negative control. The Hub really does this: ``/gpt2/raw/main/config.json`` 307s to
-        ``/openai-community/gpt2/raw/main/config.json``, and ``/api/models/gpt2/tree/main``
-        307s likewise. Dropping the header on those turns an authenticated read of a renamed
-        private repo into a 401, which this module caches as a definitive "absent".
+        """Negative control. The Hub really 307s ``/gpt2/raw/main/config.json`` to
+        ``/openai-community/gpt2/raw/main/config.json`` (and the tree endpoint likewise), so
+        dropping the header there turns an authenticated read of a renamed private repo into a
+        401, which this module caches as a definitive "absent".
         """
         import utils.transformers_version as tv
 
@@ -5523,8 +5514,7 @@ class TestHubRedirectDoesNotReplayTheToken:
     def test_every_authenticated_fetch_uses_the_opener(self):
         """Guards the remaining call sites, and any added later.
 
-        ``hf_endpoint_unreachable`` is the one exemption: it sends no credentials, so it has
-        nothing to replay across a redirect.
+        ``hf_endpoint_unreachable`` is the one exemption: it sends no credentials.
         """
         import ast
         import inspect
@@ -5557,8 +5547,7 @@ class TestHubRedirectDoesNotReplayTheToken:
 
 class TestPaginationOriginNormalizesDefaultPorts:
     """``https://host`` and ``https://host:443`` are one origin (RFC 6454), so a textual
-    ``netloc`` compare rejects an endpoint's own cursor and turns a multi-page listing
-    inconclusive (round 8 Codex)."""
+    ``netloc`` compare would reject an endpoint's own cursor."""
 
     def setup_method(self):
         _clear_scan_caches()
@@ -5596,8 +5585,8 @@ class TestPaginationOriginNormalizesDefaultPorts:
                 False,
                 "suffix",
             ),
-            # ``hostname`` drops userinfo, so it must be rejected before the compare: urllib
-            # sends the whole ``user@host`` string as the connection host.
+            # ``hostname`` drops userinfo, but urllib connects to the whole ``user@host``
+            # string, so reject it before comparing.
             ("https://mirror.internal", "https://mirror.internal@evil.example/api", False, "decoy"),
             (
                 "https://mirror.internal",
@@ -5657,9 +5646,8 @@ class TestPaginationOriginNormalizesDefaultPorts:
 
 
 class TestLinkRelIsFoundAtAnyParameterPosition:
-    """RFC 8288 lets ``rel`` sit anywhere in an entry's parameter list. Missing it makes
-    ``_hf_api_get_json`` report a truncated first page as a complete listing, which is
-    cacheable as a confirmed default tier (round 8 Codex)."""
+    """RFC 8288 lets ``rel`` sit anywhere in an entry's parameter list; missing it makes
+    ``_hf_api_get_json`` cache a truncated first page as a confirmed default tier."""
 
     def setup_method(self):
         _clear_scan_caches()
@@ -5738,8 +5726,8 @@ class TestLinkRelIsFoundAtAnyParameterPosition:
 
 
 class TestPublicReExportOf5xSymbolIsRecognized:
-    """``from transformers import TokenizersBackend`` is the public spelling of a class the
-    default 4.57.x tier does not have (round 8 Codex)."""
+    """``from transformers import TokenizersBackend`` is the public spelling of a class
+    4.57.x does not have."""
 
     def setup_method(self):
         _clear_scan_caches()
@@ -5794,9 +5782,8 @@ class TestPublicReExportOf5xSymbolIsRecognized:
 
 
 class TestRemoteScanDownloadsAreBounded:
-    """Workers activate a sidecar (and so run this scan) before the remote-code consent
-    gate, so a selected repo must not be able to spend unbounded requests or memory
-    (round 8 Codex)."""
+    """Workers run this scan before the remote-code consent gate, so a selected repo must not
+    be able to spend unbounded requests or memory."""
 
     def setup_method(self):
         _clear_scan_caches()
@@ -5820,8 +5807,7 @@ class TestRemoteScanDownloadsAreBounded:
         sources, complete = tv._fetch_hub_py_sources("org/hostile", None, budget)
         assert len(fetched) == tv._REMOTE_SCAN_MAX_FILES
         assert len(sources) == tv._REMOTE_SCAN_MAX_FILES
-        # Truncation is an incomplete closure, never a clean scan: the caller must not
-        # memoize a confirmed default tier from it.
+        # Truncation is an incomplete closure, never a clean scan, so nothing is memoized.
         assert complete is False
         assert budget.truncated is True
 
@@ -5865,8 +5851,7 @@ class TestRemoteScanDownloadsAreBounded:
         assert complete is False
 
     def test_one_enormous_source_is_not_read_into_memory(self, monkeypatch):
-        """The aggregate cap can only charge a file already read, so the read itself is
-        bounded."""
+        """The aggregate cap can only charge a file already read, so bound the read."""
         import utils.transformers_version as tv
 
         monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -30,8 +30,6 @@ _loggers_stub.get_logger = lambda name: __import__("logging").getLogger(name)
 sys.modules.setdefault("loggers", _loggers_stub)
 
 from utils.transformers_version import (
-
-
     _resolve_base_model,
     _is_lora_adapter_dir,
     _has_adapter_weights,
@@ -5660,6 +5658,7 @@ def _link_headers(*values):
     ``Link`` field line, which is the shape that returns a truncated page as whole.
     """
     import email.message
+
     msg = email.message.Message()
     for value in values:
         if value is not None:

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -4351,7 +4351,9 @@ class TestProbeFalseSkipsConfigFallbackScan:
         cfg = json.dumps(
             {"model_type": "custom_remote", "auto_map": {"AutoModel": "modeling_custom.Model"}}
         ).encode()
-        tree = json.dumps([{"type": "file", "path": f"modeling_{i}.py"} for i in range(12)]).encode()
+        tree = json.dumps(
+            [{"type": "file", "path": f"modeling_{i}.py"} for i in range(12)]
+        ).encode()
 
         def _urlopen(req, timeout = 10):
             urls.append(req.full_url)

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -51,7 +51,7 @@ from utils.transformers_version import (
     _config_json_cache,
     _tokenizer_class_cache,
     _config_needs_510_cache,
-    _remote_auto_map_needs_510_cache,
+    _remote_auto_map_tier_cache,
     _config_needs_530_cache,
     _config_needs_550_cache,
     _probe_tier_cache,
@@ -489,7 +489,7 @@ class TestCheckConfigNeeds510:
     def setup_method(self):
         _config_json_cache.clear()
         _config_needs_510_cache.clear()
-        _remote_auto_map_needs_510_cache.clear()
+        _remote_auto_map_tier_cache.clear()
 
     def test_gemma4_unified_architecture(self, tmp_path: Path):
         """config.json with Gemma4UnifiedForConditionalGeneration should return True."""
@@ -557,7 +557,7 @@ class TestCheckConfigNeeds510:
 
     def test_remote_modeling_auto_map_needs_510(self, tmp_path: Path):
         """Unknown architectures with 5.10-only remote imports should return True."""
-        _remote_auto_map_needs_510_cache.clear()
+        _remote_auto_map_tier_cache.clear()
         cfg = {
             "model_type": "custom_remote",
             "auto_map": {"AutoModelForCausalLM": "modeling_custom.CustomForCausalLM"},
@@ -574,10 +574,10 @@ class TestCheckConfigNeeds510:
         """Offline Hub scan negatives must not poison a later online read."""
         import utils.transformers_version as tv
 
-        _remote_auto_map_needs_510_cache.clear()
+        _remote_auto_map_tier_cache.clear()
         monkeypatch.setattr(tv, "_env_offline", lambda: True)
         assert _check_remote_auto_map_needs_510("org/custom-remote") is False
-        assert not _remote_auto_map_needs_510_cache  # nothing memoized at any key
+        assert not _remote_auto_map_tier_cache  # nothing memoized at any key
 
     def test_offline_local_checkpoint_external_auto_map_makes_no_request(
         self, monkeypatch, tmp_path: Path
@@ -590,7 +590,7 @@ class TestCheckConfigNeeds510:
         """
         import utils.transformers_version as tv
 
-        _remote_auto_map_needs_510_cache.clear()
+        _remote_auto_map_tier_cache.clear()
         cfg = {
             "model_type": "custom_remote",
             "auto_map": {"AutoModelForCausalLM": "extorg/extrepo--modeling_ext.Model"},
@@ -673,7 +673,7 @@ class TestCheckConfigNeeds510:
         """Inconclusive auto_map scans must not cache a false negative."""
         import utils.transformers_version as tv
 
-        _remote_auto_map_needs_510_cache.clear()
+        _remote_auto_map_tier_cache.clear()
         _config_needs_510_cache.clear()
         cfg = {
             "model_type": "custom_remote",
@@ -683,7 +683,7 @@ class TestCheckConfigNeeds510:
         monkeypatch.setattr(tv, "_config_json_is_definitive", lambda *a, **k: True)
         monkeypatch.setattr(tv, "_remote_auto_map_py_contents", lambda *a, **k: ([], False))
         assert _check_remote_auto_map_needs_510("org/custom-remote") is False
-        assert not _remote_auto_map_needs_510_cache  # nothing memoized at any key
+        assert not _remote_auto_map_tier_cache  # nothing memoized at any key
         monkeypatch.setattr(
             tv,
             "_remote_auto_map_py_contents",
@@ -995,7 +995,7 @@ class TestGetTransformersTier:
         _config_json_cache.clear()
         _config_needs_510_cache.clear()
         _config_needs_550_cache.clear()
-        _remote_auto_map_needs_510_cache.clear()
+        _remote_auto_map_tier_cache.clear()
 
     def test_astral_local_checkpoint_returns_510(self, tmp_path: Path):
         """Astral custom-code checkpoints should use the 5.10 sidecar (#7353)."""
@@ -1156,7 +1156,7 @@ class TestGetTransformersTier:
         monkeypatch.setattr(tv, "_config_json_is_definitive", lambda *a, **k: True)
         monkeypatch.setattr(tv, "_list_hub_repo_py_files", _fake_list)
         monkeypatch.setattr(tv, "_read_repo_text_file", _fake_read)
-        _remote_auto_map_needs_510_cache.clear()
+        _remote_auto_map_tier_cache.clear()
 
         assert get_transformers_tier("org/qwen3.5-custom-remote") == "510"
 
@@ -3614,7 +3614,7 @@ class TestRemoteImportSpellings:
 
     def setup_method(self):
         _config_json_cache.clear()
-        _remote_auto_map_needs_510_cache.clear()
+        _remote_auto_map_tier_cache.clear()
 
     def test_parent_package_import_returns_510(self, tmp_path: Path):
         """``from transformers.utils import output_capturing`` loads the same module."""
@@ -3670,7 +3670,7 @@ class TestLocalScanCacheFreshness:
     def setup_method(self):
         _config_json_cache.clear()
         _tokenizer_class_cache.clear()
-        _remote_auto_map_needs_510_cache.clear()
+        _remote_auto_map_tier_cache.clear()
 
     def test_rescanned_when_entry_file_appears(self, tmp_path: Path):
         """config.json lands before the remote code (in-progress checkpoint)."""
@@ -3729,7 +3729,7 @@ class TestTokenizerAutoMapTransientScan:
     def setup_method(self):
         _config_json_cache.clear()
         _tokenizer_class_cache.clear()
-        _remote_auto_map_needs_510_cache.clear()
+        _remote_auto_map_tier_cache.clear()
 
     def test_transient_listing_failure_retried(self, monkeypatch):
         import utils.transformers_version as tv
@@ -3787,7 +3787,7 @@ class TestProbeFalseSkipsAutoMapScan:
 
     def setup_method(self):
         _config_json_cache.clear()
-        _remote_auto_map_needs_510_cache.clear()
+        _remote_auto_map_tier_cache.clear()
 
     def test_probe_false_does_no_hub_io(self, monkeypatch):
         monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
@@ -3845,7 +3845,7 @@ class TestHubTreePagination:
 
     def setup_method(self):
         _config_json_cache.clear()
-        _remote_auto_map_needs_510_cache.clear()
+        _remote_auto_map_tier_cache.clear()
 
     def test_py_file_on_second_page_is_found(self, monkeypatch):
         import utils.transformers_version as tv
@@ -3914,7 +3914,7 @@ class TestUnreadableAutoMapConfigIsInconclusive:
 
     def setup_method(self):
         _config_json_cache.clear()
-        _remote_auto_map_needs_510_cache.clear()
+        _remote_auto_map_tier_cache.clear()
         tv_mod = __import__("utils.transformers_version", fromlist = ["x"])
         tv_mod._config_json_absent.clear()
 
@@ -3945,7 +3945,7 @@ class TestUnreadableAutoMapConfigIsInconclusive:
         monkeypatch.setattr("urllib.request.urlopen", _urlopen)
         needs, definitive = tv._remote_auto_map_scan_result("org/custom-remote")
         assert (needs, definitive) == (False, False)
-        assert not _remote_auto_map_needs_510_cache  # the outage cached nothing
+        assert not _remote_auto_map_tier_cache  # the outage cached nothing
 
         state["up"] = True
         _config_json_cache.clear()
@@ -3963,7 +3963,7 @@ class TestUnreadableAutoMapConfigIsInconclusive:
 
         monkeypatch.setattr("urllib.request.urlopen", _urlopen)
         assert tv._remote_auto_map_scan_result("org/plain-model") == (False, True)
-        assert _remote_auto_map_needs_510_cache  # definitive, so memoized
+        assert _remote_auto_map_tier_cache  # definitive, so memoized
 
 
 class TestProcessorOnlyAutoMapIsScanned:
@@ -3971,7 +3971,7 @@ class TestProcessorOnlyAutoMapIsScanned:
 
     def setup_method(self):
         _config_json_cache.clear()
-        _remote_auto_map_needs_510_cache.clear()
+        _remote_auto_map_tier_cache.clear()
 
     def test_hub_preprocessor_config_auto_map_promotes_tier(self, monkeypatch, tmp_path):
         """Mirrors TencentARC/TimeLens-7B: stock config.json, processor auto_map only."""
@@ -4026,7 +4026,7 @@ class TestScanPrerequisiteConfigHonorsHfEndpoint:
 
     def setup_method(self):
         _config_json_cache.clear()
-        _remote_auto_map_needs_510_cache.clear()
+        _remote_auto_map_tier_cache.clear()
 
     def test_config_json_fetched_from_mirror(self, monkeypatch, tmp_path):
         import utils.transformers_version as tv
@@ -4079,7 +4079,7 @@ class TestRemoteSourceEncoding:
 
     def setup_method(self):
         _config_json_cache.clear()
-        _remote_auto_map_needs_510_cache.clear()
+        _remote_auto_map_tier_cache.clear()
 
     def test_pep263_cookie_module_is_decoded(self, monkeypatch):
         import utils.transformers_version as tv
@@ -4188,7 +4188,7 @@ class TestPartialTokenizerScanKeepsPositiveMatch:
     def setup_method(self):
         _config_json_cache.clear()
         _tokenizer_class_cache.clear()
-        _remote_auto_map_needs_510_cache.clear()
+        _remote_auto_map_tier_cache.clear()
 
     def test_local_proof_survives_external_repo_failure(self, monkeypatch, tmp_path: Path):
         import utils.transformers_version as tv
@@ -4223,7 +4223,7 @@ class TestScanSignatureCoversAutoMapConfigs:
     def setup_method(self):
         _config_json_cache.clear()
         _tokenizer_class_cache.clear()
-        _remote_auto_map_needs_510_cache.clear()
+        _remote_auto_map_tier_cache.clear()
 
     def test_auto_map_added_after_the_code_is_rescanned(self, tmp_path: Path):
         """A staged checkpoint: .py first, processor auto_map afterwards."""
@@ -4256,7 +4256,7 @@ class TestTokenizerScanCacheFreshness:
     def setup_method(self):
         _config_json_cache.clear()
         _tokenizer_class_cache.clear()
-        _remote_auto_map_needs_510_cache.clear()
+        _remote_auto_map_tier_cache.clear()
 
     def test_rescanned_when_tokenizer_source_replaced(self, tmp_path: Path):
         _tokenizer_checkpoint(tmp_path, ["tokenization_my.MyTok", None], "import torch\n")
@@ -4294,7 +4294,7 @@ class TestTokenizerConfigFetchHonorsEndpoint:
     def setup_method(self):
         _config_json_cache.clear()
         _tokenizer_class_cache.clear()
-        _remote_auto_map_needs_510_cache.clear()
+        _remote_auto_map_tier_cache.clear()
 
     def _serve(self, monkeypatch, mirror: str | None):
         import utils.transformers_version as tv
@@ -4342,7 +4342,7 @@ class TestProbeFalseSkipsConfigFallbackScan:
     def setup_method(self):
         _config_json_cache.clear()
         _config_needs_510_cache.clear()
-        _remote_auto_map_needs_510_cache.clear()
+        _remote_auto_map_tier_cache.clear()
 
     def _hub(self, monkeypatch, tmp_path):
         monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
@@ -4380,3 +4380,254 @@ class TestProbeFalseSkipsConfigFallbackScan:
         assert ("org/custom-remote", None) not in _config_needs_510_cache
         assert get_transformers_tier("org/custom-remote", probe = True) == "510"
         assert [u for u in urls if u.endswith(".py")]  # the activation path did scan
+
+
+_V5_TOKENIZER_IMPORT = "from transformers.tokenization_utils_tokenizers import TokenizersBackend\n"
+
+
+def _clear_scan_caches():
+    _config_json_cache.clear()
+    _remote_auto_map_tier_cache.clear()
+    _tokenizer_class_cache.clear()
+    _config_needs_510_cache.clear()
+    _config_needs_530_cache.clear()
+    _config_needs_550_cache.clear()
+    _probe_tier_cache.clear()
+
+
+class TestPartialHubFetchKeepsProof:
+    """A .py that fails to fetch must not discard the sources already read.
+
+    The scan trusts a positive from an incomplete closure, so dropping the earlier files
+    throws away an already-observed 5.x-only import and routes the worker to a sidecar
+    that cannot import the remote code.
+    """
+
+    def setup_method(self):
+        _clear_scan_caches()
+
+    def _hub(
+        self,
+        monkeypatch,
+        tmp_path,
+        sources,
+        cfg = None,
+    ):
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "empty-hub"))
+        cfg = cfg or {"auto_map": {"AutoModel": "a_modeling.Model"}}
+
+        def _urlopen(req, timeout = 10):
+            url = req.full_url
+            if url.endswith("/config.json"):
+                return _PagedResponse(json.dumps(cfg).encode())
+            if "/tree/" in url:
+                return _PagedResponse(
+                    json.dumps([{"type": "file", "path": p} for p in sorted(sources)]).encode()
+                )
+            for name, text in sources.items():
+                if url.endswith(name):
+                    if text is None:
+                        raise OSError("temporary Hub outage")
+                    return _PagedResponse(text.encode())
+            raise _http_error(url, 404)
+
+        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+
+    def test_marker_in_earlier_file_survives_a_later_fetch_failure(self, monkeypatch, tmp_path):
+        import utils.transformers_version as tv
+
+        self._hub(monkeypatch, tmp_path, {"a_modeling.py": _V5_IMPORT, "z_helper.py": None})
+        assert tv._remote_auto_map_scan_result("org/multi-file") == (True, False)
+        assert not _remote_auto_map_tier_cache  # incomplete, so nothing memoized
+
+    def test_partial_fetch_without_the_marker_stays_inconclusive(self, monkeypatch, tmp_path):
+        """Negative control: a partial closure never turns into a cacheable negative."""
+        import utils.transformers_version as tv
+
+        self._hub(monkeypatch, tmp_path, {"a_modeling.py": "import torch\n", "z_helper.py": None})
+        assert tv._remote_auto_map_scan_result("org/multi-file") == (False, False)
+        assert not _remote_auto_map_tier_cache
+
+    def test_complete_fetch_without_the_marker_is_definitive(self, monkeypatch, tmp_path):
+        """Negative control: nothing failed, so the negative is a real answer."""
+        import utils.transformers_version as tv
+
+        self._hub(monkeypatch, tmp_path, {"a_modeling.py": "import torch\n"})
+        assert tv._remote_auto_map_scan_result("org/multi-file") == (False, True)
+        assert _remote_auto_map_tier_cache
+
+
+class TestLocalConfigRewriteIsRescanned:
+    """A staged checkpoint can write its code first and its ``auto_map`` afterwards.
+
+    The changed scan signature forces a rescan; that rescan must read the new
+    ``config.json`` from disk instead of the process-lifetime ``_config_json_cache``,
+    or it memoizes a fresh negative under the new signature.
+    """
+
+    def setup_method(self):
+        _clear_scan_caches()
+
+    @staticmethod
+    def _write(path: Path, cfg: dict):
+        path.write_text(json.dumps(cfg))
+        os.utime(path, (1, 1))  # force a distinct mtime from the previous write
+
+    def test_auto_map_added_after_the_first_scan_is_observed(self, tmp_path):
+        import utils.transformers_version as tv
+
+        ckpt = tmp_path / "staged"
+        ckpt.mkdir()
+        (ckpt / "modeling_custom.py").write_text(_V5_IMPORT)
+        self._write(ckpt / "config.json", {"model_type": "llama"})
+        assert tv._check_remote_auto_map_needs_510(str(ckpt)) is False
+
+        (ckpt / "config.json").write_text(
+            json.dumps({"model_type": "llama", "auto_map": {"AutoModel": "modeling_custom.Model"}})
+        )
+        assert tv._check_remote_auto_map_needs_510(str(ckpt)) is True
+
+    def test_rewrite_that_declares_no_auto_map_stays_negative(self, tmp_path):
+        """Negative control: re-reading the config must not invent remote code."""
+        import utils.transformers_version as tv
+
+        ckpt = tmp_path / "staged-plain"
+        ckpt.mkdir()
+        (ckpt / "modeling_custom.py").write_text(_V5_IMPORT)
+        self._write(ckpt / "config.json", {"model_type": "llama"})
+        assert tv._check_remote_auto_map_needs_510(str(ckpt)) is False
+
+        (ckpt / "config.json").write_text(json.dumps({"model_type": "llama", "vocab_size": 32000}))
+        assert tv._check_remote_auto_map_needs_510(str(ckpt)) is False
+
+
+class TestAutoMapImportsOf5xTokenizerBackend:
+    """Remote code reached through config.json, not tokenizer_config.json.
+
+    ``transformers.tokenization_utils_tokenizers`` does not exist on the default 4.57.x
+    tier, so a modeling/processor module importing it must not route there just because
+    ``tokenizer_config.json`` declares no ``auto_map`` of its own.
+    """
+
+    def setup_method(self):
+        _clear_scan_caches()
+
+    @staticmethod
+    def _ckpt(tmp_path, name, modeling_src, tokenizer_cfg):
+        ckpt = tmp_path / name
+        ckpt.mkdir()
+        (ckpt / "modeling_custom.py").write_text(modeling_src)
+        (ckpt / "config.json").write_text(
+            json.dumps(
+                {
+                    "model_type": "llama",
+                    "architectures": ["LlamaForCausalLM"],
+                    "transformers_version": "4.57.0",
+                    "auto_map": {"AutoModel": "modeling_custom.Model"},
+                }
+            )
+        )
+        (ckpt / "tokenizer_config.json").write_text(json.dumps(tokenizer_cfg))
+        return ckpt
+
+    def test_config_declared_module_importing_the_backend_routes_to_530(self, tmp_path):
+        ckpt = self._ckpt(
+            tmp_path, "backend-model", _V5_TOKENIZER_IMPORT, {"tokenizer_class": "LlamaTokenizer"}
+        )
+        assert get_transformers_tier(str(ckpt), probe = False) == "530"
+
+    def test_ordinary_custom_code_stays_on_default(self, tmp_path):
+        """Negative control: no 5.x-only import, no promotion."""
+        ckpt = self._ckpt(
+            tmp_path,
+            "plain-model",
+            "import torch\nfrom transformers import PreTrainedModel\n",
+            {"tokenizer_class": "LlamaTokenizer"},
+        )
+        assert get_transformers_tier(str(ckpt), probe = False) == "default"
+
+    def test_510_marker_still_outranks_the_tokenizer_backend_marker(self, tmp_path):
+        """Negative control: the 5.10 classification keeps priority."""
+        ckpt = self._ckpt(
+            tmp_path,
+            "both-markers",
+            _V5_IMPORT + _V5_TOKENIZER_IMPORT,
+            {"tokenizer_class": "LlamaTokenizer"},
+        )
+        assert get_transformers_tier(str(ckpt), probe = False) == "510"
+
+    def test_needs_510_helper_keeps_its_510_only_meaning(self, tmp_path):
+        """Negative control: the 5.x tokenizer marker is not a 5.10 answer."""
+        import utils.transformers_version as tv
+
+        ckpt = self._ckpt(
+            tmp_path, "backend-only", _V5_TOKENIZER_IMPORT, {"tokenizer_class": "LlamaTokenizer"}
+        )
+        assert tv._check_remote_auto_map_needs_510(str(ckpt)) is False
+        assert tv._remote_auto_map_tier(str(ckpt))[0] == "530"
+
+
+class TestTypeCheckingImportsAreNotRuntimeImports:
+    """``if TYPE_CHECKING:`` never executes, so it must not promote the tier."""
+
+    def setup_method(self):
+        _clear_scan_caches()
+
+    _GUARD = (
+        "from typing import TYPE_CHECKING\n"
+        "if TYPE_CHECKING:\n"
+        "    from transformers.utils.output_capturing import capture_outputs\n"
+    )
+    _GUARD_QUALIFIED = (
+        "import typing\n"
+        "if typing.TYPE_CHECKING:\n"
+        "    from transformers.utils.output_capturing import capture_outputs\n"
+    )
+    _ELSE_BRANCH = (
+        "from typing import TYPE_CHECKING\n"
+        "if TYPE_CHECKING:\n"
+        "    pass\n"
+        "else:\n"
+        "    from transformers.utils.output_capturing import capture_outputs\n"
+    )
+    _NEGATED_GUARD = (
+        "from typing import TYPE_CHECKING\n"
+        "if not TYPE_CHECKING:\n"
+        "    from transformers.utils.output_capturing import capture_outputs\n"
+    )
+
+    @pytest.mark.parametrize("src", [_GUARD, _GUARD_QUALIFIED])
+    def test_type_only_import_does_not_promote(self, src):
+        import utils.transformers_version as tv
+        markers = tv._TRANSFORMERS_510_REMOTE_IMPORT_MARKERS
+        assert tv._remote_auto_map_py_matches(markers, [src]) is False
+
+    @pytest.mark.parametrize("src", [_V5_IMPORT, _ELSE_BRANCH, _NEGATED_GUARD])
+    def test_runtime_import_still_promotes(self, src):
+        """Negative control: only the guard's own body is dropped."""
+        import utils.transformers_version as tv
+
+        markers = tv._TRANSFORMERS_510_REMOTE_IMPORT_MARKERS
+        assert tv._remote_auto_map_py_matches(markers, [src]) is True
+
+    def test_unparseable_source_still_falls_back_to_the_line_scan(self):
+        """Negative control: source ``ast`` cannot read is never a silent negative."""
+        import utils.transformers_version as tv
+
+        markers = tv._TRANSFORMERS_510_REMOTE_IMPORT_MARKERS
+        assert tv._remote_auto_map_py_matches(markers, [self._GUARD + "def broken(:\n"]) is True
+
+    def test_unparseable_and_import_free_stay_distinct(self):
+        """Negative control: ``None`` (unparseable) is not ``set()`` (imports nothing)."""
+        import utils.transformers_version as tv
+
+        assert tv._parsed_dotted_imports("def broken(:\n") is None
+        assert tv._parsed_dotted_imports("x = 1\n") == set()
+
+    def test_guard_does_not_drop_sibling_runtime_imports(self):
+        """Negative control: pruning the guard body keeps the rest of the module."""
+        import utils.transformers_version as tv
+
+        names = tv._parsed_dotted_imports(self._GUARD + _V5_IMPORT)
+        assert "transformers.utils.output_capturing" in names

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -180,7 +180,7 @@ class TestRemoteLoraBase:
     def test_fetches_base_from_remote_adapter_config(self, monkeypatch):
         monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
         cfg = {"base_model_name_or_path": "nvidia/NVIDIA-Nemotron-3-Nano-4B"}
-        with patch("urllib.request.urlopen", return_value = self._resp(cfg)):
+        with patch("utils.transformers_version._hub_urlopen", return_value = self._resp(cfg)):
             assert (
                 _remote_lora_base("someuser/my-nemotron-lora") == "nvidia/NVIDIA-Nemotron-3-Nano-4B"
             )
@@ -199,7 +199,7 @@ class TestRemoteLoraBase:
             seen["url"] = req.full_url
             return self._resp({"base_model_name_or_path": "org/base"})
 
-        with patch("urllib.request.urlopen", side_effect = fake_urlopen):
+        with patch("utils.transformers_version._hub_urlopen", side_effect = fake_urlopen):
             assert _remote_lora_base("user/adapter") == "org/base"
         assert seen["url"].startswith("https://hf.mirror.internal/user/adapter/raw/main/")
 
@@ -221,7 +221,7 @@ class TestRemoteLoraBase:
         self._seed_adapter_cache(tmp_path, "user/cached-lora", "nvidia/Nemotron-H-8B")
         monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
         monkeypatch.setenv("HF_HUB_OFFLINE", "1")
-        with patch("urllib.request.urlopen") as mock_url:
+        with patch("utils.transformers_version._hub_urlopen") as mock_url:
             assert _remote_lora_base("user/cached-lora") == "nvidia/Nemotron-H-8B"
             mock_url.assert_not_called()  # offline: cache only, no network
 
@@ -229,20 +229,20 @@ class TestRemoteLoraBase:
         self._seed_adapter_cache(tmp_path, "user/cached-lora", "nvidia/Nemotron-H-8B")
         monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
         monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
-        with patch("urllib.request.urlopen", side_effect = OSError("boom")):
+        with patch("utils.transformers_version._hub_urlopen", side_effect = OSError("boom")):
             assert _remote_lora_base("user/cached-lora") == "nvidia/Nemotron-H-8B"
 
     def test_offline_uncached_makes_no_request(self, tmp_path: Path, monkeypatch):
         monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
         monkeypatch.setenv("HF_HUB_OFFLINE", "1")
-        with patch("urllib.request.urlopen") as mock_url:
+        with patch("utils.transformers_version._hub_urlopen") as mock_url:
             assert _remote_lora_base("org/adapter") is None
             mock_url.assert_not_called()
 
     def test_non_adapter_repo_returns_none(self, tmp_path: Path, monkeypatch):
         monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
         monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
-        with patch("urllib.request.urlopen", side_effect = OSError("boom")):
+        with patch("utils.transformers_version._hub_urlopen", side_effect = OSError("boom")):
             assert _remote_lora_base("org/not-an-adapter") is None
 
     def test_existing_relative_path_not_treated_as_repo(self, monkeypatch):
@@ -250,7 +250,7 @@ class TestRemoteLoraBase:
         # a Hub repo: no request, no risk of matching an unrelated remote/cached adapter.
         import utils.paths as paths
         monkeypatch.setattr(paths, "is_local_path", lambda p: True)
-        with patch("urllib.request.urlopen") as mock_url:
+        with patch("utils.transformers_version._hub_urlopen") as mock_url:
             assert _remote_lora_base("outputs/run1") is None
             mock_url.assert_not_called()
 
@@ -263,7 +263,7 @@ class TestRemoteLoraBase:
         monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
         monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
         err = urllib.error.HTTPError("url", 404, "Not Found", {}, None)
-        with patch("urllib.request.urlopen", side_effect = err):
+        with patch("utils.transformers_version._hub_urlopen", side_effect = err):
             assert _remote_lora_base("user/was-a-lora") is None
 
     def test_transient_http_error_falls_back_to_cache(self, tmp_path: Path, monkeypatch):
@@ -273,7 +273,7 @@ class TestRemoteLoraBase:
         monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
         monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
         err = urllib.error.HTTPError("url", 503, "Service Unavailable", {}, None)
-        with patch("urllib.request.urlopen", side_effect = err):
+        with patch("utils.transformers_version._hub_urlopen", side_effect = err):
             assert _remote_lora_base("user/cached-lora") == "nvidia/Nemotron-H-8B"
 
 
@@ -322,7 +322,7 @@ class TestCheckTokenizerConfigNeedsV5:
         tc = {"tokenizer_class": "LlamaTokenizerFast"}
         (tmp_path / "tokenizer_config.json").write_text(json.dumps(tc))
 
-        with patch("urllib.request.urlopen") as mock_urlopen:
+        with patch("utils.transformers_version._hub_urlopen") as mock_urlopen:
             result = _check_tokenizer_config_needs_v5(str(tmp_path))
             mock_urlopen.assert_not_called()
         assert result is False
@@ -368,7 +368,7 @@ class TestCheckTokenizerConfigNeedsV5:
                 return _Resp(json.dumps({"tokenizer_class": "TokenizersBackend"}))
             raise OSError("HTTP 401")
 
-        monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+        monkeypatch.setattr("utils.transformers_version._hub_urlopen", fake_urlopen)
         assert _check_tokenizer_config_needs_v5("org/gated") is False  # unauth miss
         assert _check_tokenizer_config_needs_v5("org/gated", "tok") is True  # authed hit
         assert seen_auth == [None, "Bearer tok"]
@@ -455,7 +455,7 @@ class TestCheckConfigNeeds550:
     def test_no_config_json(self, tmp_path: Path):
         """Missing config.json should return False (fail-open)."""
         # Patch network call to avoid a real fetch.
-        with patch("urllib.request.urlopen") as mock_urlopen:
+        with patch("utils.transformers_version._hub_urlopen") as mock_urlopen:
             mock_urlopen.side_effect = Exception("no network")
             assert _check_config_needs_550(str(tmp_path)) is False
 
@@ -474,7 +474,7 @@ class TestCheckConfigNeeds550:
         cfg = {"architectures": ["LlamaForCausalLM"]}
         (tmp_path / "config.json").write_text(json.dumps(cfg))
 
-        with patch("urllib.request.urlopen") as mock_urlopen:
+        with patch("utils.transformers_version._hub_urlopen") as mock_urlopen:
             _check_config_needs_550(str(tmp_path))
             mock_urlopen.assert_not_called()
 
@@ -599,7 +599,7 @@ class TestCheckConfigNeeds510:
         (tmp_path / "config.json").write_text(json.dumps(cfg))
         monkeypatch.setattr(tv, "_env_offline", lambda: True)
 
-        with patch("urllib.request.urlopen") as mock_urlopen:
+        with patch("utils.transformers_version._hub_urlopen") as mock_urlopen:
             assert get_transformers_tier(str(tmp_path), probe = False) == "default"
             mock_urlopen.assert_not_called()
 
@@ -628,7 +628,7 @@ class TestCheckConfigNeeds510:
             seen["url"] = req.full_url
             return _Resp()
 
-        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        monkeypatch.setattr("utils.transformers_version._hub_urlopen", _urlopen)
         text = _read_repo_text_file("org/custom-remote", "modeling_custom.py")
         assert "output_capturing" in text
         assert seen["url"].startswith("https://hf-mirror.example/org/custom-remote/raw/main/")
@@ -706,7 +706,7 @@ class TestCheckConfigNeeds510:
     def test_no_config_json(self, tmp_path: Path):
         """Missing config.json should return False (fail-open)."""
         # Patch network call to avoid real fetch
-        with patch("urllib.request.urlopen") as mock_urlopen:
+        with patch("utils.transformers_version._hub_urlopen") as mock_urlopen:
             mock_urlopen.side_effect = Exception("no network")
             assert _check_config_needs_510(str(tmp_path)) is False
 
@@ -725,7 +725,7 @@ class TestCheckConfigNeeds510:
         cfg = {"architectures": ["LlamaForCausalLM"]}
         (tmp_path / "config.json").write_text(json.dumps(cfg))
 
-        with patch("urllib.request.urlopen") as mock_urlopen:
+        with patch("utils.transformers_version._hub_urlopen") as mock_urlopen:
             _check_config_needs_510(str(tmp_path))
             mock_urlopen.assert_not_called()
 
@@ -838,7 +838,7 @@ class TestConfigJsonHfCacheFallback:
         self._seed_cache(tmp_path, "unsloth/NVIDIA-Nemotron-3-Nano-4B", cfg)
         monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
         monkeypatch.setenv("HF_HUB_OFFLINE", "1")
-        with patch("urllib.request.urlopen") as mock_url:
+        with patch("utils.transformers_version._hub_urlopen") as mock_url:
             assert _load_config_json("unsloth/NVIDIA-Nemotron-3-Nano-4B") == cfg
             mock_url.assert_not_called()
 
@@ -849,7 +849,7 @@ class TestConfigJsonHfCacheFallback:
         monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
         monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
         monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising = False)
-        with patch("urllib.request.urlopen", return_value = _hf_response(fresh)):
+        with patch("utils.transformers_version._hub_urlopen", return_value = _hf_response(fresh)):
             assert _load_config_json("org/model") == fresh  # network wins, not stale cache
 
     def test_network_failure_falls_back_to_cache(self, tmp_path: Path, monkeypatch):
@@ -857,13 +857,13 @@ class TestConfigJsonHfCacheFallback:
         self._seed_cache(tmp_path, "org/model", cfg)
         monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
         monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
-        with patch("urllib.request.urlopen", side_effect = OSError("boom")):
+        with patch("utils.transformers_version._hub_urlopen", side_effect = OSError("boom")):
             assert _load_config_json("org/model") == cfg
 
     def test_offline_uncached_returns_none(self, tmp_path: Path, monkeypatch):
         monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
         monkeypatch.setenv("HF_HUB_OFFLINE", "1")
-        with patch("urllib.request.urlopen") as mock_url:
+        with patch("utils.transformers_version._hub_urlopen") as mock_url:
             assert _load_config_json("private/unknown") is None
             mock_url.assert_not_called()
 
@@ -894,10 +894,10 @@ class TestConfigJsonHfCacheFallback:
         monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
         monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
         # Network fails -> serve the cached snapshot, but it must not be memoized.
-        with patch("urllib.request.urlopen", side_effect = OSError("boom")):
+        with patch("utils.transformers_version._hub_urlopen", side_effect = OSError("boom")):
             assert _load_config_json("org/model") == stale
         # Connectivity returns: the next call must hit the network for the fresh config.
-        with patch("urllib.request.urlopen", return_value = _hf_response(fresh)):
+        with patch("utils.transformers_version._hub_urlopen", return_value = _hf_response(fresh)):
             assert _load_config_json("org/model") == fresh
 
     def test_auth_failure_does_not_serve_cache(self, tmp_path: Path, monkeypatch):
@@ -912,7 +912,7 @@ class TestConfigJsonHfCacheFallback:
         for code in (401, 403, 404):
             _config_json_cache.clear()
             err = urllib.error.HTTPError("url", code, "denied", {}, None)
-            with patch("urllib.request.urlopen", side_effect = err):
+            with patch("utils.transformers_version._hub_urlopen", side_effect = err):
                 assert _load_config_json("private/model") is None
 
     def test_server_error_still_falls_back_to_cache(self, tmp_path: Path, monkeypatch):
@@ -924,7 +924,7 @@ class TestConfigJsonHfCacheFallback:
         monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
         # A 5xx is transient, not an access decision: keep serving the cache.
         err = urllib.error.HTTPError("url", 503, "busy", {}, None)
-        with patch("urllib.request.urlopen", side_effect = err):
+        with patch("utils.transformers_version._hub_urlopen", side_effect = err):
             assert _load_config_json("org/model") == cfg
 
 
@@ -957,11 +957,11 @@ class TestTierCheckTransientRetry:
         monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
         monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
         # Network blip -> serve the cache, but do NOT pin the tier result.
-        with patch("urllib.request.urlopen", side_effect = OSError("boom")):
+        with patch("utils.transformers_version._hub_urlopen", side_effect = OSError("boom")):
             assert _check_config_needs_510("org/model") is False
         assert ("org/model", None) not in _config_needs_510_cache
         # Connectivity returns: the next call re-fetches and sees the higher tier.
-        with patch("urllib.request.urlopen", return_value = _hf_response(fresh)):
+        with patch("utils.transformers_version._hub_urlopen", return_value = _hf_response(fresh)):
             assert _check_config_needs_510("org/model") is True
         assert _config_needs_510_cache[("org/model", None)] is True  # definitive read memoized
 
@@ -969,7 +969,7 @@ class TestTierCheckTransientRetry:
         fresh = {"architectures": ["Gemma4ForConditionalGeneration"]}  # needs 550
         monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
         monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
-        with patch("urllib.request.urlopen", return_value = _hf_response(fresh)) as mock_url:
+        with patch("utils.transformers_version._hub_urlopen", return_value = _hf_response(fresh)) as mock_url:
             assert _check_config_needs_550("org/model") is True
             assert _check_config_needs_550("org/model") is True
             assert mock_url.call_count == 1  # second call served from the tier cache
@@ -1248,7 +1248,7 @@ class TestGetTransformersTier:
             json.dumps({"tokenizer_class": "TokenizersBackend"})
         )
 
-        with patch("urllib.request.urlopen") as mock_urlopen:
+        with patch("utils.transformers_version._hub_urlopen") as mock_urlopen:
             assert get_transformers_tier(str(tmp_path)) == "510"
             mock_urlopen.assert_not_called()
 
@@ -1270,7 +1270,7 @@ class TestGetTransformersTier:
                     }
                 ).encode()
 
-        with patch("urllib.request.urlopen", return_value = _Response()):
+        with patch("utils.transformers_version._hub_urlopen", return_value = _Response()):
             assert get_transformers_tier("unsloth/NVIDIA-Nemotron-3-Nano-4B") == "510"
 
     def test_local_config_json_short_circuits_path_substrings(self, tmp_path: Path):
@@ -1289,7 +1289,7 @@ class TestGetTransformersTier:
             json.dumps({"tokenizer_class": "LlamaTokenizerFast"})
         )
 
-        with patch("urllib.request.urlopen") as mock_urlopen:
+        with patch("utils.transformers_version._hub_urlopen") as mock_urlopen:
             assert get_transformers_tier(str(model_dir)) == "default"
             mock_urlopen.assert_not_called()
 
@@ -1327,7 +1327,7 @@ class TestGetTransformersTier:
             urls.append(req.full_url)
             return _Response()
 
-        with patch("urllib.request.urlopen", side_effect = _fake_urlopen):
+        with patch("utils.transformers_version._hub_urlopen", side_effect = _fake_urlopen):
             assert get_transformers_tier("org/no-fast-substring-model") == "550"
 
         assert sum(u.endswith("/config.json") for u in urls) == 1
@@ -1878,7 +1878,7 @@ class TestLocalCheckpointFilesAppear:
         def boom(*a, **k):
             raise AssertionError("a local checkpoint must not be fetched from the Hub")
 
-        monkeypatch.setattr("urllib.request.urlopen", boom)
+        monkeypatch.setattr("utils.transformers_version._hub_urlopen", boom)
         # Before the file exists: not 5.x, no network, and the miss must not be pinned.
         assert _check_tokenizer_config_needs_v5(local) is False
         # The file appears with a 5.x-only tokenizer -> the next call must read it.
@@ -1893,7 +1893,7 @@ class TestLocalCheckpointFilesAppear:
         def boom(*a, **k):
             raise AssertionError("a local checkpoint must not be fetched from the Hub")
 
-        monkeypatch.setattr("urllib.request.urlopen", boom)
+        monkeypatch.setattr("utils.transformers_version._hub_urlopen", boom)
         assert _load_config_json(local) is None
         (tmp_path / "config.json").write_text(json.dumps({"model_type": "gemma4"}))
         assert _load_config_json(local) == {"model_type": "gemma4"}
@@ -2860,7 +2860,7 @@ class TestOfflineCacheNotPoisoned:
             def __exit__(self, *a):
                 return False
 
-        monkeypatch.setattr("urllib.request.urlopen", lambda req, timeout = 10: _Resp())
+        monkeypatch.setattr("utils.transformers_version._hub_urlopen", lambda req, timeout = 10: _Resp())
         assert _check_tokenizer_config_needs_v5("org/needs5") is True
 
     def test_offline_config_miss_not_cached(self, monkeypatch):
@@ -3756,7 +3756,7 @@ class TestTokenizerAutoMapTransientScan:
                 "from transformers.tokenization_utils_tokenizers import TokenizersBackend\n"
             ),
         )
-        with patch("urllib.request.urlopen", return_value = _hf_response(tok_cfg)):
+        with patch("utils.transformers_version._hub_urlopen", return_value = _hf_response(tok_cfg)):
             assert _check_tokenizer_config_needs_v5("org/tok-only") is False
             assert not _tokenizer_class_cache  # nothing memoized at any key
             state["listing_ok"] = True
@@ -3776,7 +3776,7 @@ class TestTokenizerAutoMapTransientScan:
         monkeypatch.setattr(
             tv, "_read_repo_text_file", lambda model, fn, tok = None: "import torch\n"
         )
-        with patch("urllib.request.urlopen", return_value = _hf_response(tok_cfg)) as mock_url:
+        with patch("utils.transformers_version._hub_urlopen", return_value = _hf_response(tok_cfg)) as mock_url:
             assert _check_tokenizer_config_needs_v5("org/tok-only") is False
             after_first = mock_url.call_count
             assert _check_tokenizer_config_needs_v5("org/tok-only") is False
@@ -3793,7 +3793,7 @@ class TestProbeFalseSkipsAutoMapScan:
 
     def test_probe_false_does_no_hub_io(self, monkeypatch):
         monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
-        with patch("urllib.request.urlopen") as mock_url:
+        with patch("utils.transformers_version._hub_urlopen") as mock_url:
             assert get_transformers_tier("Qwen/Qwen3.5-9B", probe = False) == "530"
             mock_url.assert_not_called()
         assert needs_transformers_5("Qwen/Qwen3.5-9B") is True
@@ -3878,7 +3878,7 @@ class TestHubTreePagination:
                 return _PagedResponse(json.dumps(page2).encode())
             raise _http_error(url, 404)
 
-        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        monkeypatch.setattr("utils.transformers_version._hub_urlopen", _urlopen)
         assert tv._list_hub_repo_py_files("org/big") == ({"modeling_custom.py"}, True)
 
     def test_single_page_still_one_request(self, monkeypatch):
@@ -3892,7 +3892,7 @@ class TestHubTreePagination:
             calls.append(req.full_url)
             return _PagedResponse(json.dumps([{"type": "file", "path": "a.py"}]).encode())
 
-        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        monkeypatch.setattr("utils.transformers_version._hub_urlopen", _urlopen)
         assert tv._list_hub_repo_py_files("org/small") == ({"a.py"}, True)
         assert len(calls) == 1
 
@@ -3908,7 +3908,7 @@ class TestHubTreePagination:
                 raise OSError("connection reset on page 2")
             return _PagedResponse(json.dumps([{"type": "file", "path": "a.py"}]).encode(), cursor)
 
-        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        monkeypatch.setattr("utils.transformers_version._hub_urlopen", _urlopen)
         assert tv._list_hub_repo_py_files("org/big") == (set(), False)
 
     def test_non_http_pagination_link_is_refused(self, monkeypatch):
@@ -3920,7 +3920,7 @@ class TestHubTreePagination:
         def _urlopen(req, timeout = 10):
             return _PagedResponse(json.dumps([]).encode(), "file:///etc/passwd")
 
-        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        monkeypatch.setattr("utils.transformers_version._hub_urlopen", _urlopen)
         assert tv._list_hub_repo_py_files("org/evil") == (set(), False)
 
 
@@ -3957,7 +3957,7 @@ class TestUnreadableAutoMapConfigIsInconclusive:
                 return _PagedResponse(_V5_IMPORT.encode())
             raise _http_error(url, 404)
 
-        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        monkeypatch.setattr("utils.transformers_version._hub_urlopen", _urlopen)
         needs, definitive = tv._remote_auto_map_scan_result("org/custom-remote")
         assert (needs, definitive) == (False, False)
         assert not _remote_auto_map_tier_cache  # the outage cached nothing
@@ -3976,7 +3976,7 @@ class TestUnreadableAutoMapConfigIsInconclusive:
         def _urlopen(req, timeout = 10):
             raise _http_error(req.full_url, 404)
 
-        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        monkeypatch.setattr("utils.transformers_version._hub_urlopen", _urlopen)
         assert tv._remote_auto_map_scan_result("org/plain-model") == (False, True)
         assert _remote_auto_map_tier_cache  # definitive, so memoized
 
@@ -4013,7 +4013,7 @@ class TestProcessorOnlyAutoMapIsScanned:
                 return _PagedResponse(_V5_IMPORT.encode())
             raise _http_error(url, 404)
 
-        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        monkeypatch.setattr("utils.transformers_version._hub_urlopen", _urlopen)
         assert tv._remote_auto_map_tier("org/vlm-remote")[0] == "530"
 
     def test_repo_without_any_auto_map_fetches_no_py(self, monkeypatch, tmp_path):
@@ -4030,7 +4030,7 @@ class TestProcessorOnlyAutoMapIsScanned:
                 return _PagedResponse(json.dumps({"model_type": "llama"}).encode())
             raise _http_error(req.full_url, 404)
 
-        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        monkeypatch.setattr("utils.transformers_version._hub_urlopen", _urlopen)
         assert tv._check_remote_auto_map_needs_510("org/plain-model") is False
         assert not any("/tree/" in u for u in urls)
         assert not any(u.endswith(".py") for u in urls)
@@ -4067,7 +4067,7 @@ class TestScanPrerequisiteConfigHonorsHfEndpoint:
                 return _PagedResponse(_V5_IMPORT.encode())
             raise _http_error(url, 404)
 
-        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        monkeypatch.setattr("utils.transformers_version._hub_urlopen", _urlopen)
         assert tv._load_config_json("org/custom-remote") is not None
         assert tv._remote_auto_map_tier("org/custom-remote")[0] == "530"
 
@@ -4084,7 +4084,7 @@ class TestScanPrerequisiteConfigHonorsHfEndpoint:
             seen["url"] = req.full_url
             return _PagedResponse(json.dumps({"model_type": "llama"}).encode())
 
-        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        monkeypatch.setattr("utils.transformers_version._hub_urlopen", _urlopen)
         tv._load_config_json("org/model")
         assert seen["url"] == "https://huggingface.co/org/model/raw/main/config.json"
 
@@ -4109,7 +4109,7 @@ class TestRemoteSourceEncoding:
             latin1.decode("utf-8")
 
         monkeypatch.setattr(
-            "urllib.request.urlopen", lambda req, timeout = 10: _PagedResponse(latin1)
+            "utils.transformers_version._hub_urlopen", lambda req, timeout = 10: _PagedResponse(latin1)
         )
         text = tv._read_repo_text_file("org/custom-remote", "modeling_custom.py")
         assert text is not None
@@ -4122,7 +4122,7 @@ class TestRemoteSourceEncoding:
 
         monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
         monkeypatch.setattr(
-            "urllib.request.urlopen",
+            "utils.transformers_version._hub_urlopen",
             lambda req, timeout = 10: _PagedResponse(b"\xff\xfe\x00\x01 not utf-8"),
         )
         assert tv._read_repo_text_file("org/custom-remote", "modeling_custom.py") is not None
@@ -4134,7 +4134,7 @@ class TestRemoteSourceEncoding:
         monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
         src = "# café\nfrom transformers.utils.output_capturing import capture\n"
         monkeypatch.setattr(
-            "urllib.request.urlopen",
+            "utils.transformers_version._hub_urlopen",
             lambda req, timeout = 10: _PagedResponse(src.encode("utf-8")),
         )
         assert tv._read_repo_text_file("org/custom-remote", "modeling_custom.py") == src
@@ -4332,7 +4332,7 @@ class TestTokenizerConfigFetchHonorsEndpoint:
                 return _PagedResponse(tok_cfg)
             raise _http_error(req.full_url, 404)
 
-        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        monkeypatch.setattr("utils.transformers_version._hub_urlopen", _urlopen)
         monkeypatch.setattr(
             tv, "_list_hub_repo_py_files", lambda repo, tok = None: ({"tokenization_my.py"}, True)
         )
@@ -4380,7 +4380,7 @@ class TestProbeFalseSkipsConfigFallbackScan:
                 return _PagedResponse(_V5_IMPORT.encode())
             raise _http_error(req.full_url, 404)
 
-        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        monkeypatch.setattr("utils.transformers_version._hub_urlopen", _urlopen)
         return urls
 
     def test_probe_false_does_not_list_or_fetch_repo_code(self, monkeypatch, tmp_path):
@@ -4451,7 +4451,7 @@ class TestPartialHubFetchKeepsProof:
                     return _PagedResponse(text.encode())
             raise _http_error(url, 404)
 
-        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        monkeypatch.setattr("utils.transformers_version._hub_urlopen", _urlopen)
 
     def test_marker_in_earlier_file_survives_a_later_fetch_failure(self, monkeypatch, tmp_path):
         import utils.transformers_version as tv
@@ -4718,7 +4718,7 @@ class TestHubPaginationStaysOnTheConfiguredOrigin:
                 ["a.py"], next_url = "https://evil.example/api/models/x/tree/main?cursor=2"
             )
 
-        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        monkeypatch.setattr("utils.transformers_version._hub_urlopen", _urlopen)
         assert tv._hf_api_get_json("/api/models/org/m/tree/main", "hf_secret") == (None, False)
         assert [url for url, _ in seen] == ["https://hub.internal/api/models/org/m/tree/main"]
         assert not any("evil.example" in url for url, _ in seen)
@@ -4740,7 +4740,7 @@ class TestHubPaginationStaysOnTheConfiguredOrigin:
                 next_url = "https://huggingface.co/api/models/org/m/tree/main?cursor=2",
             )
 
-        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        monkeypatch.setattr("utils.transformers_version._hub_urlopen", _urlopen)
         data, ok = tv._hf_api_get_json("/api/models/org/m/tree/main", "hf_secret")
         assert ok is True
         assert [item["path"] for item in data] == ["a.py", "b.py"]
@@ -4760,7 +4760,7 @@ class TestHubPaginationStaysOnTheConfiguredOrigin:
                 ["a.py"], next_url = "https://mirror.internal/api/models/org/m/tree?cursor=2"
             )
 
-        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        monkeypatch.setattr("utils.transformers_version._hub_urlopen", _urlopen)
         data, ok = tv._hf_api_get_json("/api/models/org/m/tree", None)
         assert ok is True and len(data) == 2
 
@@ -4985,14 +4985,14 @@ class TestImpossible510ScanIsSkipped:
         import utils.transformers_version as tv
 
         monkeypatch.setattr(tv, "latest_venv_pinned_version", lambda *a, **k: None)
-        with patch("urllib.request.urlopen") as mock_urlopen:
+        with patch("utils.transformers_version._hub_urlopen") as mock_urlopen:
             tier = get_transformers_tier("mistralai/Ministral-3-8B-Instruct-2512", probe = True)
         assert tier == "530"
         mock_urlopen.assert_not_called()
 
     def test_helper_is_false_without_reading_the_repo(self):
         """The 5.10 question is answerable offline while no 5.10-only marker exists."""
-        with patch("urllib.request.urlopen") as mock_urlopen:
+        with patch("utils.transformers_version._hub_urlopen") as mock_urlopen:
             assert _check_remote_auto_map_needs_510("org/custom-remote") is False
         mock_urlopen.assert_not_called()
 
@@ -5004,7 +5004,7 @@ class TestImpossible510ScanIsSkipped:
         monkeypatch.setattr(tv, "latest_venv_pinned_version", lambda *a, **k: None)
         log: list = []
         monkeypatch.setattr(
-            "urllib.request.urlopen",
+            "utils.transformers_version._hub_urlopen",
             self._fake_hub(f"from {self._FUTURE_MARKER} import Thing\n", log),
         )
         tier = get_transformers_tier("mistralai/Ministral-3-8B-Instruct-2512", probe = True)
@@ -5019,7 +5019,7 @@ class TestImpossible510ScanIsSkipped:
         monkeypatch.setattr(tv, "latest_venv_pinned_version", lambda *a, **k: None)
         log: list = []
         monkeypatch.setattr(
-            "urllib.request.urlopen",
+            "utils.transformers_version._hub_urlopen",
             self._fake_hub("from transformers.modeling_utils import PreTrainedModel\n", log),
         )
         tier = get_transformers_tier("mistralai/Ministral-3-8B-Instruct-2512", probe = True)
@@ -5031,3 +5031,222 @@ class TestImpossible510ScanIsSkipped:
         _auto_map_checkpoint(tmp_path, _V5_IMPORT)
         assert _check_remote_auto_map_needs_510(str(tmp_path)) is False
         assert _remote_auto_map_tier(str(tmp_path)) == ("530", True)
+
+
+def _throwaway_origin(respond):
+    """Start a local HTTP origin on an ephemeral port for the redirect tests.
+
+    ``respond(path)`` returns ``(status, extra_headers, body)``. Returns
+    ``(base_url, seen, close)`` where ``seen`` collects ``(path, Authorization)`` for every
+    request the origin received, so a leaked token is directly observable.
+    """
+    import http.server
+    import threading
+
+    seen: list = []
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def do_GET(self):
+            seen.append((self.path, self.headers.get("Authorization")))
+            status, extra, body = respond(self.path)
+            self.send_response(status)
+            for key, value in extra.items():
+                self.send_header(key, value)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):
+            pass
+
+    srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    threading.Thread(target = srv.serve_forever, daemon = True).start()
+
+    def _close():
+        srv.shutdown()
+        srv.server_close()
+
+    return f"http://127.0.0.1:{srv.server_port}", seen, _close
+
+
+class TestHubRedirectDoesNotReplayTheToken:
+    """A 3xx must not hand ``Authorization: Bearer <hf_token>`` to another origin.
+
+    ``urllib.request.HTTPRedirectHandler.redirect_request`` copies every header except
+    content-length/content-type onto the redirect target with no host comparison, and this
+    module attaches the token via ``Request(headers=...)`` (so it lands in ``req.headers``,
+    not ``unredirected_hdrs``). ``HF_ENDPOINT`` is user-configurable, so the redirecting host
+    is not necessarily the Hub.
+    """
+
+    def setup_method(self):
+        _clear_scan_caches()
+
+    @staticmethod
+    def _online(monkeypatch):
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.delenv("TRANSFORMERS_OFFLINE", raising = False)
+
+    def test_stock_urlopen_leaks_the_token_across_origins(self):
+        """The mechanism itself, so this stays honest if urllib ever changes.
+
+        Nothing under test here: it is plain ``urllib.request.urlopen`` against two origins,
+        and it is exactly what every fetch in this module used to do.
+        """
+        import urllib.request
+
+        victim, victim_seen, close_victim = _throwaway_origin(
+            lambda path: (200, {"Content-Type": "application/json"}, b"[]")
+        )
+        hub, _, close_hub = _throwaway_origin(
+            lambda path: (302, {"Location": victim + "/moved"}, b"")
+        )
+        try:
+            req = urllib.request.Request(
+                hub + "/api/models/org/m/tree/main",
+                headers = {"User-Agent": "unsloth-studio",
+                           "Authorization": "Bearer hf_SECRET_TOKEN"},
+            )
+            with urllib.request.urlopen(req, timeout = 10) as resp:
+                resp.read()
+        finally:
+            close_hub()
+            close_victim()
+
+        assert victim_seen, "the redirect was not followed"
+        assert victim_seen[0][1] == "Bearer hf_SECRET_TOKEN", (
+            "stock urlopen is expected to replay the token; if this ever stops being true "
+            "the opener below can be dropped"
+        )
+
+    def test_cross_origin_redirect_drops_the_token(self, monkeypatch):
+        """The fix, driven through a real call site rather than the opener in isolation."""
+        import utils.transformers_version as tv
+
+        self._online(monkeypatch)
+        victim, victim_seen, close_victim = _throwaway_origin(
+            lambda path: (200, {"Content-Type": "application/json"}, b"[]")
+        )
+        hub, hub_seen, close_hub = _throwaway_origin(
+            lambda path: (302, {"Location": victim + "/moved"}, b"")
+        )
+        try:
+            monkeypatch.setenv("HF_ENDPOINT", hub)
+            data, ok = tv._hf_api_get_json("/api/models/org/m/tree/main", "hf_SECRET_TOKEN")
+        finally:
+            close_hub()
+            close_victim()
+
+        assert hub_seen[0][1] == "Bearer hf_SECRET_TOKEN", "the endpoint itself must authenticate"
+        assert victim_seen, "the redirect must still be followed"
+        assert victim_seen[0][1] is None, f"token replayed to another origin: {victim_seen}"
+        assert (data, ok) == ([], True)
+
+    def test_same_origin_redirect_keeps_the_token(self, monkeypatch):
+        """Negative control. The Hub really does this: ``/gpt2/raw/main/config.json`` 307s to
+        ``/openai-community/gpt2/raw/main/config.json``, and ``/api/models/gpt2/tree/main``
+        307s likewise. Dropping the header on those turns an authenticated read of a renamed
+        private repo into a 401, which this module caches as a definitive "absent".
+        """
+        import utils.transformers_version as tv
+
+        self._online(monkeypatch)
+
+        def _respond(path):
+            if path.endswith("/moved"):
+                return 200, {"Content-Type": "application/json"}, b"[]"
+            return 307, {"Location": "/api/models/org/renamed/tree/main/moved"}, b""
+
+        hub, hub_seen, close_hub = _throwaway_origin(_respond)
+        try:
+            monkeypatch.setenv("HF_ENDPOINT", hub)
+            data, ok = tv._hf_api_get_json("/api/models/org/m/tree/main", "hf_SECRET_TOKEN")
+        finally:
+            close_hub()
+
+        assert len(hub_seen) == 2, f"expected the redirect to be followed once: {hub_seen}"
+        assert [auth for _, auth in hub_seen] == ["Bearer hf_SECRET_TOKEN"] * 2
+        assert (data, ok) == ([], True)
+
+    def test_unauthenticated_redirect_is_unaffected(self, monkeypatch):
+        """Negative control: with no token nothing is stripped and the hop still works."""
+        import utils.transformers_version as tv
+
+        self._online(monkeypatch)
+        victim, victim_seen, close_victim = _throwaway_origin(
+            lambda path: (200, {"Content-Type": "application/json"}, b'[{"path": "a.py"}]')
+        )
+        hub, hub_seen, close_hub = _throwaway_origin(
+            lambda path: (302, {"Location": victim + "/moved"}, b"")
+        )
+        try:
+            monkeypatch.setenv("HF_ENDPOINT", hub)
+            data, ok = tv._hf_api_get_json("/api/models/org/m/tree/main", None)
+        finally:
+            close_hub()
+            close_victim()
+
+        assert [auth for _, auth in hub_seen + victim_seen] == [None, None]
+        assert ok is True and data == [{"path": "a.py"}]
+
+    @pytest.mark.parametrize(
+        "old,new,drops",
+        [
+            # same origin: keep
+            ("https://huggingface.co/a", "https://huggingface.co/b", False),
+            ("https://huggingface.co/a", "https://HuggingFace.CO/b", False),
+            ("https://huggingface.co:443/a", "https://huggingface.co/b", False),
+            # plain-http to TLS on the same host: keep (the token already went out in clear)
+            ("http://hub.internal/a", "https://hub.internal/b", False),
+            # different host: drop
+            ("https://huggingface.co/a", "https://us.aws.cdn.hf.co/x", True),
+            ("https://huggingface.co/a", "https://huggingface.co.evil.example/x", True),
+            ("https://hf.co/a", "https://huggingface.co/b", True),
+            ("https://huggingface.co/a", "https://huggingface.co@evil.example/x", True),
+            # same host, different port or a downgrade: drop
+            ("https://hub.internal/a", "https://hub.internal:8443/b", True),
+            ("https://hub.internal/a", "http://hub.internal/b", True),
+            # unparseable or non-http: drop
+            ("https://hub.internal/a", "file:///etc/passwd", True),
+            ("https://hub.internal/a", "http://hub.internal:notaport/b", True),
+        ],
+    )
+    def test_redirect_predicate(self, old, new, drops):
+        import utils.transformers_version as tv
+
+        assert tv._redirect_drops_auth(old, new) is drops
+
+    def test_every_authenticated_fetch_uses_the_opener(self):
+        """Guards the remaining call sites, and any added later.
+
+        ``hf_endpoint_unreachable`` is the one exemption: it sends no credentials, so it has
+        nothing to replay across a redirect.
+        """
+        import ast
+        import inspect
+        import utils.transformers_version as tv
+
+        exempt = {"hf_endpoint_unreachable", "_hub_opener", "_hub_urlopen"}
+        offenders: list = []
+
+        class _Visitor(ast.NodeVisitor):
+            def __init__(self):
+                self.stack: list = []
+
+            def visit_FunctionDef(self, node):
+                self.stack.append(node.name)
+                self.generic_visit(node)
+                self.stack.pop()
+
+            def visit_Call(self, node):
+                func = node.func
+                if isinstance(func, ast.Attribute) and func.attr == "urlopen":
+                    if not set(self.stack) & exempt:
+                        offenders.append((self.stack[-1] if self.stack else "<module>",
+                                          node.lineno))
+                self.generic_visit(node)
+
+        _Visitor().visit(ast.parse(inspect.getsource(tv)))
+        assert offenders == [], f"these fetch sites bypass _hub_urlopen: {offenders}"

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -5940,14 +5940,27 @@ class TestExternalAutoMapRepoFallsBackToTheHubCache:
         return snap
 
     @classmethod
-    def _pair(cls, hub: Path, external_marker: str = _V5_IMPORT, cache_external: bool = True):
-        cls._snapshot(hub, "org/primary", {
-            "config.json": json.dumps({
-                "model_type": "custom_remote",
-                "auto_map": {"AutoModelForCausalLM": "ext/repo--modeling_ext.ExtForCausalLM"},
-            }),
-            "modeling_local.py": "import torch\n",
-        })
+    def _pair(
+        cls,
+        hub: Path,
+        external_marker: str = _V5_IMPORT,
+        cache_external: bool = True,
+    ):
+        cls._snapshot(
+            hub,
+            "org/primary",
+            {
+                "config.json": json.dumps(
+                    {
+                        "model_type": "custom_remote",
+                        "auto_map": {
+                            "AutoModelForCausalLM": "ext/repo--modeling_ext.ExtForCausalLM"
+                        },
+                    }
+                ),
+                "modeling_local.py": "import torch\n",
+            },
+        )
         if cache_external:
             cls._snapshot(hub, "ext/repo", {"modeling_ext.py": external_marker})
 
@@ -5981,8 +5994,9 @@ class TestExternalAutoMapRepoFallsBackToTheHubCache:
         monkeypatch.setenv("HF_HUB_OFFLINE", "1")
         assert tv._remote_auto_map_tier("org/primary") == ("default", False)
 
-    def test_transient_external_failure_is_never_reported_complete(self, monkeypatch,
-                                                                   tmp_path: Path):
+    def test_transient_external_failure_is_never_reported_complete(
+        self, monkeypatch, tmp_path: Path
+    ):
         """Negative control: a snapshot substitution must not close an unread closure.
 
         Online, a repo the Hub failed on stays incomplete even though its snapshot answered,
@@ -6001,9 +6015,15 @@ class TestExternalAutoMapRepoFallsBackToTheHubCache:
         """The scan-wide ceiling still applies, so N repos cannot multiply it."""
         import utils.transformers_version as tv
 
-        self._snapshot(tmp_path, "ext/repo", {
-            "a.py": "import torch\n", "b.py": "import torch\n", "c.py": "import torch\n",
-        })
+        self._snapshot(
+            tmp_path,
+            "ext/repo",
+            {
+                "a.py": "import torch\n",
+                "b.py": "import torch\n",
+                "c.py": "import torch\n",
+            },
+        )
         monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
         monkeypatch.setenv("HF_HUB_OFFLINE", "1")
         budget = tv._RemoteScanBudget()
@@ -6040,7 +6060,8 @@ class TestScannedTierSurvivesOneResolution:
         monkeypatch.setattr(tv, "_load_config_json", lambda m, t = None: cfg)
         monkeypatch.setattr(tv, "_config_json_is_definitive", lambda m, t = None: True)
         monkeypatch.setattr(
-            tv, "_load_repo_json_checked",
+            tv,
+            "_load_repo_json_checked",
             lambda m, fn, t = None: (cfg, True) if fn == "config.json" else (None, True),
         )
         monkeypatch.setattr(tv, "_check_tokenizer_config_needs_v5", lambda m, t = None, **kw: False)
@@ -6048,11 +6069,16 @@ class TestScannedTierSurvivesOneResolution:
         monkeypatch.setattr(tv, "_tier_from_config_mapping", lambda c: None)
         monkeypatch.setattr(tv, "_probe_tier", lambda m, t, r, **kw: kw.get("floor", "530"))
         monkeypatch.setattr(
-            tv, "_list_hub_repo_py_files",
+            tv,
+            "_list_hub_repo_py_files",
             lambda repo, tok = None: ({"modeling_custom.py", "other.py"}, True),
         )
 
-        def _read(model_name, filename, tok = None):
+        def _read(
+            model_name,
+            filename,
+            tok = None,
+        ):
             return reads[min(scans["n"], len(reads) - 1)].get(filename)
 
         original = tv._remote_auto_map_py_contents
@@ -6069,18 +6095,24 @@ class TestScannedTierSurvivesOneResolution:
     def test_marker_read_by_the_first_scan_still_activates_5x(self, monkeypatch):
         # Scan 1 reads the marker but a sibling .py fails, so nothing is memoized; scan 2
         # would then lose the marker file itself.
-        scans = self._hub(monkeypatch, [
-            {"modeling_custom.py": _V5_IMPORT, "other.py": None},
-            {"modeling_custom.py": None, "other.py": "import torch\n"},
-        ])
+        scans = self._hub(
+            monkeypatch,
+            [
+                {"modeling_custom.py": _V5_IMPORT, "other.py": None},
+                {"modeling_custom.py": None, "other.py": "import torch\n"},
+            ],
+        )
         assert get_transformers_tier("org/flaky-remote", probe = True) == "530"
         assert scans["n"] == 1  # the resolution reused its own scan
 
     def test_complete_scan_without_the_marker_stays_default(self, monkeypatch):
         """Negative control: reusing the scanned tier must not invent a promotion."""
-        scans = self._hub(monkeypatch, [
-            {"modeling_custom.py": "import torch\n", "other.py": "import torch\n"},
-        ])
+        scans = self._hub(
+            monkeypatch,
+            [
+                {"modeling_custom.py": "import torch\n", "other.py": "import torch\n"},
+            ],
+        )
         assert get_transformers_tier("org/plain-remote", probe = True) == "default"
         assert scans["n"] == 1
 
@@ -6103,60 +6135,74 @@ class TestTypeCheckingGuardMustResolveToTyping:
     @staticmethod
     def _matches(src: str) -> bool:
         import utils.transformers_version as tv
-
         return tv._remote_auto_map_py_matches(tv._TRANSFORMERS_5_REMOTE_IMPORT_MARKERS, [src])
 
-    @pytest.mark.parametrize("src, label", [
-        (f"TYPE_CHECKING = True\nif TYPE_CHECKING:\n    {_V5_IMPORT}", "module-level assignment"),
-        (
-            f"def build(TYPE_CHECKING = True):\n    if TYPE_CHECKING:\n        {_V5_IMPORT}",
-            "function parameter",
-        ),
-        (
-            f"import myconfig\nif myconfig.TYPE_CHECKING:\n    {_V5_IMPORT}",
-            "unrelated object attribute",
-        ),
-        (
-            f"for TYPE_CHECKING in flags:\n    if TYPE_CHECKING:\n        {_V5_IMPORT}",
-            "loop target",
-        ),
-        (
-            f"from .flags import TYPE_CHECKING\nif TYPE_CHECKING:\n    {_V5_IMPORT}",
-            "relative import of the repo's own name",
-        ),
-    ])
+    @pytest.mark.parametrize(
+        "src, label",
+        [
+            (
+                f"TYPE_CHECKING = True\nif TYPE_CHECKING:\n    {_V5_IMPORT}",
+                "module-level assignment",
+            ),
+            (
+                f"def build(TYPE_CHECKING = True):\n    if TYPE_CHECKING:\n        {_V5_IMPORT}",
+                "function parameter",
+            ),
+            (
+                f"import myconfig\nif myconfig.TYPE_CHECKING:\n    {_V5_IMPORT}",
+                "unrelated object attribute",
+            ),
+            (
+                f"for TYPE_CHECKING in flags:\n    if TYPE_CHECKING:\n        {_V5_IMPORT}",
+                "loop target",
+            ),
+            (
+                f"from .flags import TYPE_CHECKING\nif TYPE_CHECKING:\n    {_V5_IMPORT}",
+                "relative import of the repo's own name",
+            ),
+        ],
+    )
     def test_shadowed_guard_still_reaches_the_tier(self, src, label):
         assert self._matches(src) is True, label
 
-    @pytest.mark.parametrize("src, label", [
-        (f"from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n    {_V5_IMPORT}", "plain"),
-        (f"from typing import TYPE_CHECKING as TC\nif TC:\n    {_V5_IMPORT}", "aliased"),
-        (
-            f"from typing_extensions import TYPE_CHECKING as TC\nif TC:\n    {_V5_IMPORT}",
-            "aliased typing_extensions",
-        ),
-        (f"import typing\nif typing.TYPE_CHECKING:\n    {_V5_IMPORT}", "qualified"),
-        (f"import typing as t\nif t.TYPE_CHECKING:\n    {_V5_IMPORT}", "aliased module"),
-        (
-            f"TYPE_CHECKING = False\nif TYPE_CHECKING:\n    {_V5_IMPORT}",
-            "the no-import False idiom",
-        ),
-    ])
+    @pytest.mark.parametrize(
+        "src, label",
+        [
+            (f"from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n    {_V5_IMPORT}", "plain"),
+            (f"from typing import TYPE_CHECKING as TC\nif TC:\n    {_V5_IMPORT}", "aliased"),
+            (
+                f"from typing_extensions import TYPE_CHECKING as TC\nif TC:\n    {_V5_IMPORT}",
+                "aliased typing_extensions",
+            ),
+            (f"import typing\nif typing.TYPE_CHECKING:\n    {_V5_IMPORT}", "qualified"),
+            (f"import typing as t\nif t.TYPE_CHECKING:\n    {_V5_IMPORT}", "aliased module"),
+            (
+                f"TYPE_CHECKING = False\nif TYPE_CHECKING:\n    {_V5_IMPORT}",
+                "the no-import False idiom",
+            ),
+        ],
+    )
     def test_real_typing_guard_never_promotes(self, src, label):
         """Negative control: a genuinely dead branch must still be pruned."""
         assert self._matches(src) is False, label
 
     def test_else_branch_of_a_real_guard_still_counts(self):
         """Negative control: only the guard's own body is dropped."""
-        assert self._matches(
-            f"from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n    pass\nelse:\n    {_V5_IMPORT}"
-        ) is True
+        assert (
+            self._matches(
+                f"from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n    pass\nelse:\n    {_V5_IMPORT}"
+            )
+            is True
+        )
 
     def test_guard_resolves_when_the_import_follows_the_branch(self):
         """The walk reaches the ``if`` before the import that binds the name."""
-        assert self._matches(
-            f"if TYPE_CHECKING:\n    {_V5_IMPORT}\nfrom typing import TYPE_CHECKING\n"
-        ) is False
+        assert (
+            self._matches(
+                f"if TYPE_CHECKING:\n    {_V5_IMPORT}\nfrom typing import TYPE_CHECKING\n"
+            )
+            is False
+        )
 
 
 class TestProbeFalseSkipsTokenizerAutoMapScan:

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -4047,9 +4047,7 @@ class TestCachedConfigFallbackStaysInconclusive:
 
         monkeypatch.setattr(tv, "_hub_urlopen", _urlopen)
         # The stale snapshot on disk, downloaded before auto_map was added.
-        monkeypatch.setattr(
-            tv, "_config_json_from_hf_cache", lambda name: {"model_type": "custom"}
-        )
+        monkeypatch.setattr(tv, "_config_json_from_hf_cache", lambda name: {"model_type": "custom"})
         monkeypatch.setattr(tv, "_hf_cache_snapshot_dir", lambda name: None)
 
     def test_stale_snapshot_answer_is_not_definitive(self, monkeypatch, tmp_path):

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -969,7 +969,9 @@ class TestTierCheckTransientRetry:
         fresh = {"architectures": ["Gemma4ForConditionalGeneration"]}  # needs 550
         monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
         monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
-        with patch("utils.transformers_version._hub_urlopen", return_value = _hf_response(fresh)) as mock_url:
+        with patch(
+            "utils.transformers_version._hub_urlopen", return_value = _hf_response(fresh)
+        ) as mock_url:
             assert _check_config_needs_550("org/model") is True
             assert _check_config_needs_550("org/model") is True
             assert mock_url.call_count == 1  # second call served from the tier cache
@@ -2860,7 +2862,9 @@ class TestOfflineCacheNotPoisoned:
             def __exit__(self, *a):
                 return False
 
-        monkeypatch.setattr("utils.transformers_version._hub_urlopen", lambda req, timeout = 10: _Resp())
+        monkeypatch.setattr(
+            "utils.transformers_version._hub_urlopen", lambda req, timeout = 10: _Resp()
+        )
         assert _check_tokenizer_config_needs_v5("org/needs5") is True
 
     def test_offline_config_miss_not_cached(self, monkeypatch):
@@ -3776,7 +3780,9 @@ class TestTokenizerAutoMapTransientScan:
         monkeypatch.setattr(
             tv, "_read_repo_text_file", lambda model, fn, tok = None: "import torch\n"
         )
-        with patch("utils.transformers_version._hub_urlopen", return_value = _hf_response(tok_cfg)) as mock_url:
+        with patch(
+            "utils.transformers_version._hub_urlopen", return_value = _hf_response(tok_cfg)
+        ) as mock_url:
             assert _check_tokenizer_config_needs_v5("org/tok-only") is False
             after_first = mock_url.call_count
             assert _check_tokenizer_config_needs_v5("org/tok-only") is False
@@ -4109,7 +4115,8 @@ class TestRemoteSourceEncoding:
             latin1.decode("utf-8")
 
         monkeypatch.setattr(
-            "utils.transformers_version._hub_urlopen", lambda req, timeout = 10: _PagedResponse(latin1)
+            "utils.transformers_version._hub_urlopen",
+            lambda req, timeout = 10: _PagedResponse(latin1),
         )
         text = tv._read_repo_text_file("org/custom-remote", "modeling_custom.py")
         assert text is not None
@@ -5106,8 +5113,7 @@ class TestHubRedirectDoesNotReplayTheToken:
         try:
             req = urllib.request.Request(
                 hub + "/api/models/org/m/tree/main",
-                headers = {"User-Agent": "unsloth-studio",
-                           "Authorization": "Bearer hf_SECRET_TOKEN"},
+                headers = {"User-Agent": "unsloth-studio", "Authorization": "Bearer hf_SECRET_TOKEN"},
             )
             with urllib.request.urlopen(req, timeout = 10) as resp:
                 resp.read()
@@ -5215,7 +5221,6 @@ class TestHubRedirectDoesNotReplayTheToken:
     )
     def test_redirect_predicate(self, old, new, drops):
         import utils.transformers_version as tv
-
         assert tv._redirect_drops_auth(old, new) is drops
 
     def test_every_authenticated_fetch_uses_the_opener(self):
@@ -5244,8 +5249,9 @@ class TestHubRedirectDoesNotReplayTheToken:
                 func = node.func
                 if isinstance(func, ast.Attribute) and func.attr == "urlopen":
                     if not set(self.stack) & exempt:
-                        offenders.append((self.stack[-1] if self.stack else "<module>",
-                                          node.lineno))
+                        offenders.append(
+                            (self.stack[-1] if self.stack else "<module>", node.lineno)
+                        )
                 self.generic_visit(node)
 
         _Visitor().visit(ast.parse(inspect.getsource(tv)))

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -172,7 +172,7 @@ class TestRemoteLoraBase:
             def __exit__(self, *a):
                 return False
 
-            def read(self):
+            def read(self, n = -1):
                 return json.dumps(cfg).encode()
 
         return _Resp()
@@ -352,7 +352,7 @@ class TestCheckTokenizerConfigNeedsV5:
             def __init__(self, body):
                 self._b = body
 
-            def read(self):
+            def read(self, n = -1):
                 return self._b.encode()
 
             def __enter__(self):
@@ -615,7 +615,7 @@ class TestCheckConfigNeeds510:
         seen = {}
 
         class _Resp:
-            def read(self):
+            def read(self, n = -1):
                 return b"from transformers.utils.output_capturing import X\n"
 
             def __enter__(self):
@@ -644,7 +644,7 @@ class TestCheckConfigNeeds510:
         }
         (tmp_path / "tokenizer_config.json").write_text(json.dumps(tc))
 
-        def _fake_fetch(repo_id, hf_token = None):
+        def _fake_fetch(repo_id, hf_token = None, budget = None):
             if repo_id == "other/tokenizer-repo":
                 return [
                     "from transformers.tokenization_utils_tokenizers import TokenizersBackend\n"
@@ -807,7 +807,7 @@ def _hf_response(cfg: dict):
         def __exit__(self, *a):
             return False
 
-        def read(self):
+        def read(self, n = -1):
             return json.dumps(cfg).encode()
 
     return _Resp()
@@ -1102,7 +1102,7 @@ class TestGetTransformersTier:
         }
         (tmp_path / "config.json").write_text(json.dumps(cfg))
 
-        def _fake_fetch(repo_id, hf_token = None):
+        def _fake_fetch(repo_id, hf_token = None, budget = None):
             if repo_id == "evilorg/evilrepo":
                 return [
                     "from .helper import run\n",
@@ -1264,7 +1264,7 @@ class TestGetTransformersTier:
             def __exit__(self, exc_type, exc, tb):
                 return False
 
-            def read(self):
+            def read(self, n = -1):
                 return json.dumps(
                     {
                         "model_type": "nemotron_h",
@@ -1315,7 +1315,7 @@ class TestGetTransformersTier:
             def __exit__(self, exc_type, exc, tb):
                 return False
 
-            def read(self):
+            def read(self, n = -1):
                 return json.dumps(
                     {
                         "architectures": ["Gemma4ForConditionalGeneration"],
@@ -2853,7 +2853,7 @@ class TestOfflineCacheNotPoisoned:
         monkeypatch.setattr(tv, "_env_offline", lambda: False)
 
         class _Resp:
-            def read(self):
+            def read(self, n = -1):
                 return json.dumps({"tokenizer_class": "TokenizersBackend"}).encode()
 
             def __enter__(self):
@@ -3846,7 +3846,7 @@ class _PagedResponse:
         self._payload = payload
         self.headers = {"Link": f'<{next_url}>; rel="next"'} if next_url else {}
 
-    def read(self):
+    def read(self, n = -1):
         return self._payload
 
     def __enter__(self):
@@ -5158,7 +5158,7 @@ class TestImpossible510ScanIsSkipped:
                 self._body = body
                 self.headers = {"Link": None}
 
-            def read(self):
+            def read(self, n = -1):
                 return self._body
 
             def __enter__(self):
@@ -5450,3 +5450,336 @@ class TestHubRedirectDoesNotReplayTheToken:
 
         _Visitor().visit(ast.parse(inspect.getsource(tv)))
         assert offenders == [], f"these fetch sites bypass _hub_urlopen: {offenders}"
+
+
+class TestPaginationOriginNormalizesDefaultPorts:
+    """``https://host`` and ``https://host:443`` are one origin (RFC 6454), so a textual
+    ``netloc`` compare rejects an endpoint's own cursor and turns a multi-page listing
+    inconclusive (round 8 Codex)."""
+
+    def setup_method(self):
+        _clear_scan_caches()
+
+    @pytest.mark.parametrize(
+        "endpoint,url,expected,why",
+        [
+            # The bug: an endpoint's own authority spelled with its default port.
+            ("https://mirror.internal", "https://mirror.internal:443/api/x", True, "https default"),
+            ("http://mirror.internal", "http://mirror.internal:80/api/x", True, "http default"),
+            ("https://mirror.internal:443", "https://mirror.internal/api/x", True, "other way round"),
+            # Negative controls: normalizing the default port must not widen the guard.
+            ("https://mirror.internal", "https://mirror.internal:8443/api/x", False, "other port"),
+            ("https://mirror.internal:8443", "https://mirror.internal/api/x", False, "port dropped"),
+            ("https://mirror.internal", "http://mirror.internal:443/api/x", False, "scheme differs"),
+            ("https://mirror.internal", "https://evil.example:443/api/x", False, "other host"),
+            ("https://mirror.internal", "https://mirror.internal.evil.example/api", False, "suffix"),
+            # ``hostname`` drops userinfo, so it must be rejected before the compare: urllib
+            # sends the whole ``user@host`` string as the connection host.
+            ("https://mirror.internal", "https://mirror.internal@evil.example/api", False, "decoy"),
+            ("https://mirror.internal", "https://evil.example@mirror.internal/api", False, "userinfo"),
+            # A port that ``urlsplit`` refuses to parse must not raise out of the guard.
+            ("https://mirror.internal", "https://mirror.internal:notaport/api", False, "bad port"),
+            ("https://mirror.internal", "https://mirror.internal:99999/api", False, "port range"),
+        ],
+    )
+    def test_origin_predicate_uses_effective_port(
+        self, monkeypatch, endpoint, url, expected, why
+    ):
+        import utils.transformers_version as tv
+
+        monkeypatch.setenv("HF_ENDPOINT", endpoint)
+        assert tv._is_same_hub_origin(url) is expected, why
+
+    def test_mirror_cursor_with_explicit_default_port_is_followed(self, monkeypatch):
+        """End to end: the second page is what carries the 5.x-only import."""
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setenv("HF_ENDPOINT", "https://mirror.internal")
+
+        def _urlopen(req, timeout = 10):
+            if "cursor=2" in req.full_url:
+                return _PagedResponse(
+                    json.dumps([{"type": "file", "path": "b.py"}]).encode()
+                )
+            return _PagedResponse(
+                json.dumps([{"type": "file", "path": "a.py"}]).encode(),
+                # Same origin, spelled with the port the scheme already implies.
+                next_url = "https://mirror.internal:443/api/models/o/m/tree/main?cursor=2",
+            )
+
+        monkeypatch.setattr(tv, "_hub_urlopen", _urlopen)
+        data, ok = tv._hf_api_get_json("/api/models/o/m/tree/main", "hf_secret")
+        assert ok is True
+        assert [item["path"] for item in data] == ["a.py", "b.py"]
+
+    def test_foreign_port_cursor_is_still_refused(self, monkeypatch):
+        """Negative control: the round-5 guard still holds for a non-default port."""
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setenv("HF_ENDPOINT", "https://mirror.internal")
+        seen = []
+
+        def _urlopen(req, timeout = 10):
+            seen.append(req.full_url)
+            return _PagedResponse(
+                json.dumps([{"type": "file", "path": "a.py"}]).encode(),
+                next_url = "https://mirror.internal:8443/api/models/o/m/tree/main?cursor=2",
+            )
+
+        monkeypatch.setattr(tv, "_hub_urlopen", _urlopen)
+        assert tv._hf_api_get_json("/api/models/o/m/tree/main", "hf_secret") == (None, False)
+        assert len(seen) == 1
+
+
+class TestLinkRelIsFoundAtAnyParameterPosition:
+    """RFC 8288 lets ``rel`` sit anywhere in an entry's parameter list. Missing it makes
+    ``_hf_api_get_json`` report a truncated first page as a complete listing, which is
+    cacheable as a confirmed default tier (round 8 Codex)."""
+
+    def setup_method(self):
+        _clear_scan_caches()
+
+    _NEXT = "https://huggingface.co/api/models/o/m/tree/main?cursor=2"
+
+    @pytest.mark.parametrize(
+        "header,expected,why",
+        [
+            (f'<{_NEXT}>; rel="next"', _NEXT, "the shape the real Hub sends"),
+            (f'<{_NEXT}>; type="application/json"; rel="next"', _NEXT, "rel is not first"),
+            (f'<{_NEXT}>; rel=next', _NEXT, "rel as an unquoted token"),
+            (f'<{_NEXT}>; rel="prev next"', _NEXT, "rel holds a relation list"),
+            (f'<{_NEXT}>; rel="NEXT"', _NEXT, "relation types are case-insensitive"),
+            (f'<{_NEXT}>; title="a,b"; rel="next"', _NEXT, "comma inside a quoted value"),
+            (f'<{_NEXT}>; title="x;y"; rel="next"', _NEXT, "semicolon inside a quoted value"),
+            (f'<https://h/p>; rel="prev", <{_NEXT}>; rel="next"', _NEXT, "second entry"),
+            # Negative controls: nothing that is not a next relation may be followed.
+            ('<https://h/p>; rel="prev"', None, "no next relation anywhere"),
+            ('<https://h/p>; rel="nextpage"', None, "relation must not substring-match"),
+            ('<https://h/p>; type="next"', None, "next as some other parameter's value"),
+            ('<https://h/p>; rel="prev"; rel="next"', None, "only the first rel counts"),
+            ('<https://h/p>', None, "entry with no parameters"),
+            ("", None, "empty header"),
+            ("garbage", None, "unparseable header"),
+        ],
+    )
+    def test_parse_link_next(self, header, expected, why):
+        import utils.transformers_version as tv
+
+        assert tv._parse_link_next(header) == expected, why
+
+    def test_no_header_is_the_last_page(self):
+        import utils.transformers_version as tv
+
+        assert tv._parse_link_next(None) is None
+
+    def test_later_page_marker_is_not_truncated_away(self, monkeypatch):
+        """End to end: the 5.x-only import lives on page 2, behind a decoy parameter."""
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.delenv("HF_ENDPOINT", raising = False)
+
+        class _Resp:
+            def __init__(self, payload, link = None):
+                self._payload = payload
+                self.headers = {"Link": link} if link else {}
+
+            def read(self, n = -1):
+                return self._payload
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        def _urlopen(req, timeout = 10):
+            if req.full_url.endswith("modeling_late.py"):
+                return _Resp(_V5_IMPORT.encode())
+            if "cursor=2" in req.full_url:
+                return _Resp(json.dumps([{"type": "file", "path": "modeling_late.py"}]).encode())
+            return _Resp(
+                json.dumps([]).encode(),
+                link = f'<{self._NEXT}>; type="application/json"; rel="next"',
+            )
+
+        monkeypatch.setattr(tv, "_hub_urlopen", _urlopen)
+        sources, complete = tv._fetch_hub_py_sources("o/m", "hf_secret")
+        assert complete is True
+        assert sources == [_V5_IMPORT]
+        assert tv._remote_auto_map_py_matches(tv._TRANSFORMERS_5_REMOTE_IMPORT_MARKERS, sources)
+
+
+class TestPublicReExportOf5xSymbolIsRecognized:
+    """``from transformers import TokenizersBackend`` is the public spelling of a class the
+    default 4.57.x tier does not have (round 8 Codex)."""
+
+    def setup_method(self):
+        _clear_scan_caches()
+
+    @pytest.mark.parametrize(
+        "src,expected,why",
+        [
+            ("from transformers import TokenizersBackend\n", True, "public re-export"),
+            (
+                "from transformers import AutoModel, TokenizersBackend\n",
+                True, "public re-export beside a 4.x name",
+            ),
+            (_V5_TOK_IMPORT, True, "defining submodule still matches"),
+            (
+                "import importlib\nTB = importlib.import_module('transformers').TokenizersBackend\n",
+                False, "attribute access is not an import of the symbol",
+            ),
+            # Negative controls: only 5.x-only names may promote the tier.
+            ("from transformers import AutoModel\n", False, "4.57.x public name"),
+            (
+                "from transformers import PreTrainedTokenizerFast\n",
+                False, "re-exported by 5.x from the same module but present in 4.57.x",
+            ),
+            (
+                '"""Docs mention transformers.TokenizersBackend."""\nimport torch\n',
+                False, "a docstring is not an import",
+            ),
+            (
+                "from .transformers import TokenizersBackend\n",
+                False, "a repo's own same-named helper is relative",
+            ),
+        ],
+    )
+    def test_marker_match(self, src, expected, why):
+        import utils.transformers_version as tv
+
+        got = tv._remote_auto_map_py_matches(tv._TRANSFORMERS_5_REMOTE_IMPORT_MARKERS, [src])
+        assert got is expected, why
+
+    def test_marker_names_are_absent_from_the_default_tier(self):
+        """Guard on the marker list itself: a name 4.57.x also has would push ordinary
+        custom-code models onto a sidecar."""
+        import utils.transformers_version as tv
+
+        assert "transformers.TokenizersBackend" in tv._TRANSFORMERS_5_REMOTE_IMPORT_MARKERS
+        for marker in tv._TRANSFORMERS_5_REMOTE_IMPORT_MARKERS:
+            assert marker.startswith("transformers.")
+
+
+class TestRemoteScanDownloadsAreBounded:
+    """Workers activate a sidecar (and so run this scan) before the remote-code consent
+    gate, so a selected repo must not be able to spend unbounded requests or memory
+    (round 8 Codex)."""
+
+    def setup_method(self):
+        _clear_scan_caches()
+
+    def test_file_count_is_capped_and_reported_incomplete(self, monkeypatch):
+        import utils.transformers_version as tv
+
+        advertised = tv._REMOTE_SCAN_MAX_FILES * 10
+        fetched = []
+        monkeypatch.setattr(
+            tv, "_list_hub_repo_py_files",
+            lambda repo, tok = None: ({f"m{i:05d}.py" for i in range(advertised)}, True),
+        )
+        monkeypatch.setattr(
+            tv, "_read_repo_text_file",
+            lambda repo, fn, tok = None: (fetched.append(fn), "import torch\n")[1],
+        )
+        budget = tv._RemoteScanBudget()
+        sources, complete = tv._fetch_hub_py_sources("org/hostile", None, budget)
+        assert len(fetched) == tv._REMOTE_SCAN_MAX_FILES
+        assert len(sources) == tv._REMOTE_SCAN_MAX_FILES
+        # Truncation is an incomplete closure, never a clean scan: the caller must not
+        # memoize a confirmed default tier from it.
+        assert complete is False
+        assert budget.truncated is True
+
+    def test_aggregate_size_is_capped(self, monkeypatch):
+        import utils.transformers_version as tv
+
+        chunk = "x" * (tv._REMOTE_SCAN_MAX_TOTAL_CHARS // 4)
+        fetched = []
+        monkeypatch.setattr(
+            tv, "_list_hub_repo_py_files",
+            lambda repo, tok = None: ({f"m{i:03d}.py" for i in range(64)}, True),
+        )
+        monkeypatch.setattr(
+            tv, "_read_repo_text_file",
+            lambda repo, fn, tok = None: (fetched.append(fn), chunk)[1],
+        )
+        budget = tv._RemoteScanBudget()
+        _, complete = tv._fetch_hub_py_sources("org/hostile", None, budget)
+        assert len(fetched) < 64 and complete is False and budget.truncated is True
+
+    def test_budget_spans_every_repo_in_one_closure(self, monkeypatch):
+        """N referenced repos must not multiply the ceiling."""
+        import utils.transformers_version as tv
+
+        fetched = []
+        monkeypatch.setattr(
+            tv, "_list_hub_repo_py_files",
+            lambda repo, tok = None: ({f"m{i:05d}.py" for i in range(1000)}, True),
+        )
+        monkeypatch.setattr(
+            tv, "_read_repo_text_file",
+            lambda repo, fn, tok = None: (fetched.append((repo, fn)), "import torch\n")[1],
+        )
+        refs = {(f"org/ext{i}", "modeling.py") for i in range(5)}
+        _, complete = tv._collect_external_py_sources(refs, None, tv._RemoteScanBudget())
+        assert len(fetched) == tv._REMOTE_SCAN_MAX_FILES
+        assert complete is False
+
+    def test_one_enormous_source_is_not_read_into_memory(self, monkeypatch):
+        """The aggregate cap can only charge a file already read, so the read itself is
+        bounded."""
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        asked = []
+
+        class _Huge:
+            def read(self, n = -1):
+                asked.append(n)
+                # More than any cap, and more than the caller may hold.
+                return b"#" * (n if n and n > 0 else tv._REMOTE_SCAN_MAX_FILE_BYTES * 4)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        monkeypatch.setattr(tv, "_hub_urlopen", lambda req, timeout = 10: _Huge())
+        assert tv._read_repo_text_file("org/hostile", "modeling.py") is None
+        assert asked == [tv._REMOTE_SCAN_MAX_FILE_BYTES + 1]
+
+    def test_real_sized_repo_is_not_truncated(self, monkeypatch):
+        """Negative control. Survey of the 300 most-downloaded trust_remote_code repos:
+        max 26 .py, max 933 KiB aggregate, max 216 KiB in one file."""
+        import utils.transformers_version as tv
+
+        src = "import torch\n" * 20_000  # ~260 KiB, above the largest real single file
+        monkeypatch.setattr(
+            tv, "_list_hub_repo_py_files",
+            lambda repo, tok = None: ({f"m{i:02d}.py" for i in range(26)}, True),
+        )
+        monkeypatch.setattr(
+            tv, "_read_repo_text_file", lambda repo, fn, tok = None: src,
+        )
+        budget = tv._RemoteScanBudget()
+        sources, complete = tv._fetch_hub_py_sources("org/big-but-real", None, budget)
+        assert len(sources) == 26 and complete is True and budget.truncated is False
+
+    def test_no_budget_keeps_the_previous_behaviour(self, monkeypatch):
+        """Back-compat: the parameter defaults to unbounded for any other caller."""
+        import utils.transformers_version as tv
+
+        monkeypatch.setattr(
+            tv, "_list_hub_repo_py_files",
+            lambda repo, tok = None: ({f"m{i:04d}.py" for i in range(300)}, True),
+        )
+        monkeypatch.setattr(
+            tv, "_read_repo_text_file", lambda repo, fn, tok = None: "import torch\n",
+        )
+        sources, complete = tv._fetch_hub_py_sources("org/m", None)
+        assert len(sources) == 300 and complete is True

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -5000,9 +5000,7 @@ class TestImpossible510ScanIsSkipped:
         """Negative control: re-adding a 5.10-only module must reopen the fast-path scan."""
         import utils.transformers_version as tv
 
-        monkeypatch.setattr(
-            tv, "_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS", (self._FUTURE_MARKER,)
-        )
+        monkeypatch.setattr(tv, "_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS", (self._FUTURE_MARKER,))
         monkeypatch.setattr(tv, "latest_venv_pinned_version", lambda *a, **k: None)
         log: list = []
         monkeypatch.setattr(
@@ -5017,9 +5015,7 @@ class TestImpossible510ScanIsSkipped:
         """Negative control: the reopened scan must not promote a repo that lacks it."""
         import utils.transformers_version as tv
 
-        monkeypatch.setattr(
-            tv, "_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS", (self._FUTURE_MARKER,)
-        )
+        monkeypatch.setattr(tv, "_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS", (self._FUTURE_MARKER,))
         monkeypatch.setattr(tv, "latest_venv_pinned_version", lambda *a, **k: None)
         log: list = []
         monkeypatch.setattr(

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -5137,6 +5137,98 @@ class TestDynamicImportsOfVersionedModules:
         assert tv._parsed_dotted_imports('log("transformers.anything")\n') == set()
 
 
+class TestQualifiedAccessToPublicExports:
+    """``import transformers`` then ``transformers.TokenizersBackend`` is the ordinary
+    spelling of a public-export marker; recording only ``transformers`` left the checkpoint
+    on 4.57.x, where the attribute does not exist (round 9 Codex)."""
+
+    MARKERS = ("transformers.TokenizersBackend", "transformers.utils.output_capturing")
+
+    def setup_method(self):
+        _clear_scan_caches()
+
+    def _matches(self, src: str) -> bool:
+        import utils.transformers_version as tv
+        return tv._remote_auto_map_py_matches(self.MARKERS, [src])
+
+    @pytest.mark.parametrize(
+        "src",
+        [
+            "import transformers\nb = transformers.TokenizersBackend()\n",
+            "import transformers as tf\nb = tf.TokenizersBackend()\n",
+            # The binding may sit below the use; resolution happens after the walk.
+            "def f():\n    return tf.TokenizersBackend()\nimport transformers as tf\n",
+            "from transformers import utils\nutils.output_capturing.capture_outputs()\n",
+            "import transformers\n\n\nclass M:\n    def f(self):\n"
+            "        return transformers.TokenizersBackend()\n",
+        ],
+    )
+    def test_qualified_access_promotes(self, src):
+        assert self._matches(src) is True
+
+    @pytest.mark.parametrize(
+        "src",
+        [
+            # Never imported here, so the attribute root resolves to nothing.
+            "b = transformers.TokenizersBackend()\n",
+            "import transformers\nm = transformers.AutoModel\n",
+            "import transformers\nif hasattr(transformers, 'TokenizersBackend'):\n    pass\n",
+            "'''transformers.TokenizersBackend'''\n",
+            "x = 'transformers.TokenizersBackend'\n",
+            "from typing import TYPE_CHECKING\nimport transformers\n"
+            "if TYPE_CHECKING:\n    b: transformers.TokenizersBackend\n",
+            # An alias bound only under the guard is not bound at runtime.
+            "from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n"
+            "    import transformers as tf\nb = tf.TokenizersBackend()\n",
+        ],
+    )
+    def test_unbound_inert_or_type_only_access_does_not_promote(self, src):
+        """Negative control: attribute handling must not promote what never runs."""
+        assert self._matches(src) is False
+
+    def test_qualified_access_reaches_the_tier(self, tmp_path: Path):
+        _auto_map_checkpoint(tmp_path, "import transformers\nb = transformers.TokenizersBackend()\n")
+        assert _remote_auto_map_tier(str(tmp_path))[0] == "530"
+
+
+class TestAliasedDynamicImportFunction:
+    """``from importlib import import_module as load_module`` then ``load_module(...)``
+    imports the module for real, so the literal-name check alone missed it (round 9 Codex).
+    Only a callee the file itself bound to ``importlib.import_module`` counts."""
+
+    MARKERS = ("transformers.tokenization_utils_tokenizers",)
+
+    def setup_method(self):
+        _clear_scan_caches()
+
+    def _matches(self, src: str) -> bool:
+        import utils.transformers_version as tv
+        return tv._remote_auto_map_py_matches(self.MARKERS, [src])
+
+    def test_aliased_import_module_promotes(self):
+        assert self._matches(
+            "from importlib import import_module as load_module\n"
+            'load_module("transformers.tokenization_utils_tokenizers")\n'
+        ) is True
+
+    @pytest.mark.parametrize(
+        "src",
+        [
+            # Same alias name, different origin: not an import at all.
+            "from mypkg import loader as load_module\n"
+            'load_module("transformers.tokenization_utils_tokenizers")\n',
+            'load_module("transformers.tokenization_utils_tokenizers")\n',
+            "from importlib import import_module as lm\n"
+            'lm(".tokenization_utils_tokenizers")\n',
+            "from importlib import import_module as lm\n"
+            'lm(f"transformers.{mod}")\n',
+        ],
+    )
+    def test_unrelated_or_computed_callee_does_not_promote(self, src):
+        """Negative control: the alias must resolve to ``importlib.import_module``."""
+        assert self._matches(src) is False
+
+
 class TestImpossible510ScanIsSkipped:
     """The name fast path must not pay Hub I/O for an answer it cannot use.
 

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -5231,6 +5231,74 @@ class TestAliasedDynamicImportFunction:
         assert self._matches(src) is False
 
 
+class TestAttributeReadOffADynamicImport:
+    """``importlib.import_module("transformers").TokenizersBackend`` really reads that export.
+
+    It is the dynamic spelling of ``import transformers`` then ``transformers.X`` and must
+    count the same. Only the bare module was recorded, because the attribute chain's root is a
+    call rather than a name, so the 5.x-only export went unseen and the checkpoint was routed
+    to 4.57.x, where reading it raises.
+    """
+
+    MARKERS = ("transformers.TokenizersBackend", "transformers.utils.output_capturing")
+
+    def setup_method(self):
+        _clear_scan_caches()
+
+    def _matches(self, src: str) -> bool:
+        import utils.transformers_version as tv
+
+        return tv._remote_auto_map_py_matches(self.MARKERS, [src])
+
+    @pytest.mark.parametrize(
+        "src",
+        [
+            "import importlib\n"
+            'b = importlib.import_module("transformers").TokenizersBackend\n',
+            '__import__("transformers").TokenizersBackend()\n',
+            "from importlib import import_module\n"
+            'import_module("transformers").TokenizersBackend()\n',
+            "from importlib import import_module as load_module\n"
+            'load_module("transformers").TokenizersBackend()\n',
+            # The whole path off the imported module counts, not just the first attribute.
+            "import importlib\n"
+            'importlib.import_module("transformers").utils.output_capturing.capture()\n',
+        ],
+    )
+    def test_attribute_off_dynamic_import_promotes(self, src):
+        assert self._matches(src) is True
+
+    @pytest.mark.parametrize(
+        "src",
+        [
+            # The bare module alone reads no 5.x-only attribute.
+            'import importlib\nm = importlib.import_module("transformers")\n',
+            # A method call is not an import, so the attribute off it proves nothing.
+            'self.loader.load("transformers").TokenizersBackend()\n',
+            # Same alias spelling, different origin.
+            "from mypkg import loader as load_module\n"
+            'load_module("transformers").TokenizersBackend()\n',
+            # Computed module name: never resolved to a literal.
+            'import importlib\nimportlib.import_module(f"transf{x}").TokenizersBackend\n',
+            # Type-only: the guard body does not run.
+            "from typing import TYPE_CHECKING\nimport importlib\n"
+            "if TYPE_CHECKING:\n"
+            '    b: importlib.import_module("transformers").TokenizersBackend\n',
+        ],
+    )
+    def test_non_import_or_dead_attribute_does_not_promote(self, src):
+        """Negative control: only an attribute really read off a real import counts."""
+        assert self._matches(src) is False
+
+    def test_attribute_off_dynamic_import_reaches_the_tier(self, tmp_path: Path):
+        _auto_map_checkpoint(
+            tmp_path,
+            "import importlib\n"
+            'b = importlib.import_module("transformers").TokenizersBackend\n',
+        )
+        assert _remote_auto_map_tier(str(tmp_path))[0] == "530"
+
+
 class TestImpossible510ScanIsSkipped:
     """The name fast path must not pay Hub I/O for an answer it cannot use.
 
@@ -5800,8 +5868,8 @@ class TestPublicReExportOf5xSymbolIsRecognized:
             (_V5_TOK_IMPORT, True, "defining submodule still matches"),
             (
                 "import importlib\nTB = importlib.import_module('transformers').TokenizersBackend\n",
-                False,
-                "attribute access is not an import of the symbol",
+                True,
+                "the dynamic import runs and the 5.x-only attribute is really read",
             ),
             # Negative controls: only 5.x-only names may promote the tier.
             ("from transformers import AutoModel\n", False, "4.57.x public name"),
@@ -5928,6 +5996,58 @@ class TestRemoteScanDownloadsAreBounded:
         monkeypatch.setattr(tv, "_hub_urlopen", lambda req, timeout = 10: _Huge())
         assert tv._read_repo_text_file("org/hostile", "modeling.py") is None
         assert asked == [tv._REMOTE_SCAN_MAX_FILE_BYTES + 1]
+
+    def test_one_enormous_config_is_not_read_into_memory(self, monkeypatch):
+        """Same bound for the remote-code configs.
+
+        They are fetched before the remote-code consent gate and outside the budget, so an
+        unbounded read of a hostile ``processor_config.json`` exhausts the worker even though
+        the ``.py`` downloads are capped.
+        """
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        asked = []
+
+        class _Huge:
+            def read(self, n = -1):
+                asked.append(n)
+                return b"#" * (n if n and n > 0 else tv._REMOTE_SCAN_MAX_FILE_BYTES * 4)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        monkeypatch.setattr(tv, "_hub_urlopen", lambda req, timeout = 10: _Huge())
+        cfg, definitive = tv._load_repo_json_checked("org/hostile", "processor_config.json")
+        assert asked == [tv._REMOTE_SCAN_MAX_FILE_BYTES + 1]
+        # Over-cap is an unread config, never a confirmed "declares no auto_map".
+        assert cfg is None and definitive is False
+
+    def test_real_sized_config_still_parses(self, monkeypatch):
+        """Negative control: the bound must not disturb an ordinary config read."""
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        payload = json.dumps({"auto_map": {"AutoProcessor": "processing_custom.CustomProc"}})
+
+        class _Normal:
+            def read(self, n = -1):
+                raw = payload.encode()
+                return raw if (n is None or n < 0) else raw[:n]
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        monkeypatch.setattr(tv, "_hub_urlopen", lambda req, timeout = 10: _Normal())
+        cfg, definitive = tv._load_repo_json_checked("org/normal", "processor_config.json")
+        assert definitive is True
+        assert cfg == {"auto_map": {"AutoProcessor": "processing_custom.CustomProc"}}
 
     def test_real_sized_repo_is_not_truncated(self, monkeypatch):
         """Negative control. Survey of the 300 most-downloaded trust_remote_code repos:

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -560,7 +560,7 @@ class TestCheckConfigNeeds510:
         }
         (tmp_path / "config.json").write_text(json.dumps(cfg))
         (tmp_path / "modeling_custom.py").write_text(
-            "from transformers.modeling_layers import GradientCheckpointingLayer\n"
+            "from transformers.utils.output_capturing import capture_outputs\n"
         )
 
         assert _check_remote_auto_map_needs_510(str(tmp_path)) is True
@@ -575,6 +575,29 @@ class TestCheckConfigNeeds510:
         assert _check_remote_auto_map_needs_510("org/custom-remote") is False
         assert ("org/custom-remote", None) not in _remote_auto_map_needs_510_cache
 
+    def test_offline_local_checkpoint_external_auto_map_makes_no_request(
+        self, monkeypatch, tmp_path: Path
+    ):
+        """Offline must reach the Hub API for nothing, even via an external auto_map.
+
+        A local checkpoint is scanned offline, so its external ``auto_map`` refs would
+        otherwise hit the repo-tree endpoint and block on the connect timeout every
+        call (the incomplete scan is never cached).
+        """
+        import utils.transformers_version as tv
+
+        _remote_auto_map_needs_510_cache.clear()
+        cfg = {
+            "model_type": "custom_remote",
+            "auto_map": {"AutoModelForCausalLM": "extorg/extrepo--modeling_ext.Model"},
+        }
+        (tmp_path / "config.json").write_text(json.dumps(cfg))
+        monkeypatch.setattr(tv, "_env_offline", lambda: True)
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            assert get_transformers_tier(str(tmp_path), probe = False) == "default"
+            mock_urlopen.assert_not_called()
+
     def test_hf_endpoint_used_for_remote_auto_map_fetch(self, monkeypatch):
         """Remote auto_map fetches must honor HF_ENDPOINT mirrors."""
         from utils.transformers_version import _read_repo_text_file
@@ -588,7 +611,7 @@ class TestCheckConfigNeeds510:
 
         class _Resp:
             def read(self):
-                return b"from transformers.modeling_layers import X\n"
+                return b"from transformers.utils.output_capturing import X\n"
 
             def __enter__(self):
                 return self
@@ -602,7 +625,7 @@ class TestCheckConfigNeeds510:
 
         monkeypatch.setattr("urllib.request.urlopen", _urlopen)
         text = _read_repo_text_file("org/custom-remote", "modeling_custom.py")
-        assert "modeling_layers" in text
+        assert "output_capturing" in text
         assert seen["url"].startswith("https://hf-mirror.example/org/custom-remote/raw/main/")
 
     def test_tokenizer_external_auto_map_needs_v5(self, monkeypatch, tmp_path: Path):
@@ -660,7 +683,7 @@ class TestCheckConfigNeeds510:
         monkeypatch.setattr(
             tv,
             "_remote_auto_map_py_contents",
-            lambda *a, **k: (["from transformers.modeling_layers import X\n"], True),
+            lambda *a, **k: (["from transformers.utils.output_capturing import X\n"], True),
         )
         assert _check_remote_auto_map_needs_510("org/custom-remote") is True
         assert _check_config_needs_510("org/custom-remote") is True
@@ -979,10 +1002,57 @@ class TestGetTransformersTier:
         }
         (tmp_path / "config.json").write_text(json.dumps(cfg))
         (tmp_path / "modeling_astral.py").write_text(
-            "from transformers.modeling_layers import GradientCheckpointingLayer\n"
+            "from transformers.utils.output_capturing import capture_outputs\n"
         )
 
         assert get_transformers_tier(str(tmp_path)) == "510"
+
+    def test_remote_code_importable_on_default_stays_default(self, tmp_path: Path):
+        """4.57.x-importable remote code must NOT be pushed onto the sidecar.
+
+        ``transformers.modeling_layers`` (4.52+) and ``use_kernel_forward_from_hub``
+        (4.51+) both exist in the default tier, so custom-code models built on them
+        (EXAONE, MiniMax, Molmo2, step3, ...) must keep loading on default.
+        """
+        cfg = {
+            "model_type": "custom_remote",
+            "auto_map": {"AutoModelForCausalLM": "modeling_custom.CustomForCausalLM"},
+        }
+        (tmp_path / "config.json").write_text(json.dumps(cfg))
+        (tmp_path / "modeling_custom.py").write_text(
+            "from transformers.integrations import use_kernel_forward_from_hub\n"
+            "from transformers.modeling_layers import GradientCheckpointingLayer\n"
+        )
+
+        assert _check_remote_auto_map_needs_510(str(tmp_path)) is False
+        assert get_transformers_tier(str(tmp_path)) == "default"
+
+    def test_lower_tier_config_kept_when_remote_code_loads_on_default(self, tmp_path: Path):
+        """Remote code that needs no 5.x symbol must not hoist a 550 config to 510."""
+        cfg = {
+            "architectures": ["Gemma4ForConditionalGeneration"],
+            "model_type": "gemma4",
+            "auto_map": {"AutoModelForCausalLM": "modeling_custom.CustomForCausalLM"},
+        }
+        (tmp_path / "config.json").write_text(json.dumps(cfg))
+        (tmp_path / "modeling_custom.py").write_text(
+            "from transformers.modeling_layers import GradientCheckpointingLayer\n"
+        )
+
+        assert get_transformers_tier(str(tmp_path)) == "550"
+
+    def test_repo_owned_module_of_same_name_does_not_match(self, tmp_path: Path):
+        """Markers are transformers-qualified, so a repo's own helper cannot match."""
+        cfg = {
+            "model_type": "custom_remote",
+            "auto_map": {"AutoModelForCausalLM": "modeling_custom.CustomForCausalLM"},
+        }
+        (tmp_path / "config.json").write_text(json.dumps(cfg))
+        (tmp_path / "modeling_custom.py").write_text(
+            "from .utils.output_capturing import capture_outputs\n"
+        )
+
+        assert get_transformers_tier(str(tmp_path)) == "default"
 
     def test_local_custom_remote_auto_map_returns_510(self, tmp_path: Path):
         """Local unknown model_types must scan auto_map before default (#7353 Codex)."""
@@ -992,7 +1062,7 @@ class TestGetTransformersTier:
         }
         (tmp_path / "config.json").write_text(json.dumps(cfg))
         (tmp_path / "modeling_custom.py").write_text(
-            "from transformers.modeling_layers import GradientCheckpointingLayer\n"
+            "from transformers.utils.output_capturing import capture_outputs\n"
         )
 
         assert get_transformers_tier(str(tmp_path)) == "510"
@@ -1008,7 +1078,7 @@ class TestGetTransformersTier:
         helpers = tmp_path / "helpers"
         helpers.mkdir()
         (helpers / "sub.py").write_text(
-            "from transformers.modeling_layers import GradientCheckpointingLayer\n"
+            "from transformers.utils.output_capturing import capture_outputs\n"
         )
 
         assert get_transformers_tier(str(tmp_path)) == "510"
@@ -1029,7 +1099,7 @@ class TestGetTransformersTier:
             if repo_id == "evilorg/evilrepo":
                 return [
                     "from .helper import run\n",
-                    "from transformers.modeling_layers import GradientCheckpointingLayer\n",
+                    "from transformers.utils.output_capturing import capture_outputs\n",
                 ], True
             return [], False
 
@@ -1045,7 +1115,7 @@ class TestGetTransformersTier:
         }
         (tmp_path / "config.json").write_text(json.dumps(cfg))
         (tmp_path / "modeling_custom.py").write_text(
-            "from transformers.modeling_layers import GradientCheckpointingLayer\n"
+            "from transformers.utils.output_capturing import capture_outputs\n"
         )
 
         assert get_transformers_tier(str(tmp_path)) == "510"
@@ -1075,7 +1145,7 @@ class TestGetTransformersTier:
             hf_token = None,
         ):
             if model_name == "org/qwen3.5-custom-remote" and filename == "modeling_custom.py":
-                return "from transformers.modeling_layers import GradientCheckpointingLayer\n"
+                return "from transformers.utils.output_capturing import capture_outputs\n"
             return None
 
         monkeypatch.setattr(tv, "_load_config_json", _fake_load)
@@ -1097,7 +1167,7 @@ class TestGetTransformersTier:
         }
         (tmp_path / "config.json").write_text(json.dumps(cfg))
         (tmp_path / "modeling_custom.py").write_text(
-            "from transformers.modeling_layers import GradientCheckpointingLayer\n"
+            "from transformers.utils.output_capturing import capture_outputs\n"
         )
 
         real_import = builtins.__import__

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -30,6 +30,8 @@ _loggers_stub.get_logger = lambda name: __import__("logging").getLogger(name)
 sys.modules.setdefault("loggers", _loggers_stub)
 
 from utils.transformers_version import (
+
+
     _resolve_base_model,
     _is_lora_adapter_dir,
     _has_adapter_weights,
@@ -1314,7 +1316,7 @@ class TestGetTransformersTier:
 
         class _Response:
             def __init__(self):
-                self.headers = {}
+                self.headers = _link_headers()
 
             def __enter__(self):
                 return self
@@ -3856,7 +3858,7 @@ class _PagedResponse:
         next_url: str | None = None,
     ):
         self._payload = payload
-        self.headers = {"Link": f'<{next_url}>; rel="next"'} if next_url else {}
+        self.headers = _link_headers(f'<{next_url}>; rel="next"' if next_url else None)
 
     def read(self, n = -1):
         return self._payload
@@ -5257,7 +5259,7 @@ class TestImpossible510ScanIsSkipped:
         class _Resp:
             def __init__(self, body: bytes):
                 self._body = body
-                self.headers = {"Link": None}
+                self.headers = _link_headers()
 
             def read(self, n = -1):
                 return self._body
@@ -5651,6 +5653,20 @@ class TestPaginationOriginNormalizesDefaultPorts:
         assert len(seen) == 1
 
 
+def _link_headers(*values):
+    """A real ``HTTPMessage``, the container urllib actually returns.
+
+    A dict stub only has ``get``, so it cannot show a cursor announced by a second repeated
+    ``Link`` field line, which is the shape that returns a truncated page as whole.
+    """
+    import email.message
+    msg = email.message.Message()
+    for value in values:
+        if value is not None:
+            msg.add_header("Link", value)
+    return msg
+
+
 class TestLinkRelIsFoundAtAnyParameterPosition:
     """RFC 8288 lets ``rel`` sit anywhere in an entry's parameter list; missing it makes
     ``_hf_api_get_json`` cache a truncated first page as a confirmed default tier."""
@@ -5689,6 +5705,41 @@ class TestLinkRelIsFoundAtAnyParameterPosition:
         import utils.transformers_version as tv
         assert tv._parse_link_next(None) is None
 
+    @pytest.mark.parametrize(
+        "fields,expected,why",
+        [
+            ([f'<{_NEXT}>; rel="next"'], _NEXT, "one field, same answer as the string form"),
+            (
+                ['<https://h/p>; rel="prev"', f'<{_NEXT}>; rel="next"'],
+                _NEXT,
+                "cursor in the second field: HTTPMessage.get would return only the first",
+            ),
+            ([f'<{_NEXT}>; rel="next"', '<https://h/p>; rel="prev"'], _NEXT, "cursor first"),
+            # Negative controls: repeated fields must not invent a cursor.
+            (['<https://h/p>; rel="prev"', '<https://h/l>; rel="last"'], None, "no next field"),
+            ([], None, "header absent"),
+            (None, None, "get_all returns None when the header is absent"),
+        ],
+    )
+    def test_every_repeated_link_field_is_read(self, fields, expected, why):
+        """RFC 7230 lets a server repeat ``Link`` as separate field lines. Reading only the
+        first returns a truncated page as whole, which caches a later-page 5.x import as a
+        confirmed default tier."""
+        import utils.transformers_version as tv
+        assert tv._parse_link_next(fields) == expected, why
+
+    def test_repeated_link_fields_reach_the_tier(self, monkeypatch):
+        """End to end through the real header container: the marker lives on page 2, whose
+        cursor is only announced by a second ``Link`` field line."""
+        import email.message
+        import utils.transformers_version as tv
+
+        headers = email.message.Message()
+        headers.add_header("Link", '<https://huggingface.co/api/x?cursor=0>; rel="prev"')
+        headers.add_header("Link", f'<{self._NEXT}>; rel="next"')
+        assert headers.get("Link") != headers.get_all("Link")[-1], "precondition: get hides it"
+        assert tv._parse_link_next(headers.get_all("Link")) == self._NEXT
+
     def test_later_page_marker_is_not_truncated_away(self, monkeypatch):
         """End to end: the 5.x-only import lives on page 2, behind a decoy parameter."""
         import utils.transformers_version as tv
@@ -5703,7 +5754,7 @@ class TestLinkRelIsFoundAtAnyParameterPosition:
                 link = None,
             ):
                 self._payload = payload
-                self.headers = {"Link": link} if link else {}
+                self.headers = _link_headers(link)
 
             def read(self, n = -1):
                 return self._payload

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -1637,7 +1637,8 @@ class TestProbeTier:
             "utils.transformers_version._check_config_needs_550", lambda m, t = None: False
         )
         monkeypatch.setattr(
-            "utils.transformers_version._check_tokenizer_config_needs_v5", lambda m, t = None: True
+            "utils.transformers_version._check_tokenizer_config_needs_v5",
+            lambda m, t = None, **kw: True,
         )
         monkeypatch.setattr("utils.transformers_version._probe_tier", lambda m, t, reason: "510")
         assert get_transformers_tier("org/unknown-5x-arch") == "510"
@@ -1662,7 +1663,7 @@ class TestProbeTier:
         )
         monkeypatch.setattr(
             "utils.transformers_version._check_tokenizer_config_needs_v5",
-            lambda m, t = None: seen.update({"tok": t}) or True,
+            lambda m, t = None, **kw: seen.update({"tok": t}) or True,
         )
         monkeypatch.setattr(
             "utils.transformers_version._probe_tier",
@@ -1748,7 +1749,8 @@ class TestProbeGating:
             "utils.transformers_version._check_config_needs_550", lambda m, t = None: False
         )
         monkeypatch.setattr(
-            "utils.transformers_version._check_tokenizer_config_needs_v5", lambda m, t = None: True
+            "utils.transformers_version._check_tokenizer_config_needs_v5",
+            lambda m, t = None, **kw: True,
         )
 
     # ---- needs_transformers_5 / probe=False must not spawn probes --------------
@@ -1777,7 +1779,8 @@ class TestProbeGating:
     def test_version_field_probe_stays_default_when_default_parses(self, monkeypatch):
         self._patch_venvs(monkeypatch)
         monkeypatch.setattr(
-            "utils.transformers_version._check_tokenizer_config_needs_v5", lambda m, t = None: False
+            "utils.transformers_version._check_tokenizer_config_needs_v5",
+            lambda m, t = None, **kw: False,
         )
         _config_json_cache[("org/new", None)] = {
             "model_type": "brandnew",
@@ -1796,7 +1799,8 @@ class TestProbeGating:
 
         self._patch_venvs(monkeypatch)
         monkeypatch.setattr(
-            "utils.transformers_version._check_tokenizer_config_needs_v5", lambda m, t = None: False
+            "utils.transformers_version._check_tokenizer_config_needs_v5",
+            lambda m, t = None, **kw: False,
         )
         _config_json_cache[("org/new", None)] = {
             "model_type": "brandnew",
@@ -1814,7 +1818,8 @@ class TestProbeGating:
     def test_ordinary_4x_config_does_not_probe(self, monkeypatch):
         self._patch_venvs(monkeypatch)
         monkeypatch.setattr(
-            "utils.transformers_version._check_tokenizer_config_needs_v5", lambda m, t = None: False
+            "utils.transformers_version._check_tokenizer_config_needs_v5",
+            lambda m, t = None, **kw: False,
         )
         _config_json_cache[("org/llama", None)] = {
             "model_type": "llama",
@@ -1837,7 +1842,8 @@ class TestProbeGating:
             "utils.transformers_version._check_config_needs_550", lambda m, t = None: False
         )
         monkeypatch.setattr(
-            "utils.transformers_version._check_tokenizer_config_needs_v5", lambda m, t = None: False
+            "utils.transformers_version._check_tokenizer_config_needs_v5",
+            lambda m, t = None, **kw: False,
         )
         _config_json_cache[("org/new", None)] = {
             "model_type": "brandnew",
@@ -5909,3 +5915,307 @@ class TestRemoteScanDownloadsAreBounded:
         )
         sources, complete = tv._fetch_hub_py_sources("org/m", None)
         assert len(sources) == 300 and complete is True
+
+
+class TestExternalAutoMapRepoFallsBackToTheHubCache:
+    """An external ``auto_map`` repo the Hub will not list falls back to its own snapshot.
+
+    Offline, the primary model already substitutes its cached snapshot, but a marker living
+    only in a separate repo named by ``owner/name--module.Class`` was never seen, so the
+    worker activated 4.57.x for code it cannot import.
+    """
+
+    def setup_method(self):
+        _clear_scan_caches()
+
+    @staticmethod
+    def _snapshot(hub: Path, repo: str, files: dict):
+        repo_dir = hub / ("models--" + repo.replace("/", "--"))
+        snap = repo_dir / "snapshots" / "deadbeef"
+        snap.mkdir(parents = True)
+        for name, text in files.items():
+            (snap / name).write_text(text)
+        (repo_dir / "refs").mkdir(parents = True)
+        (repo_dir / "refs" / "main").write_text("deadbeef")
+        return snap
+
+    @classmethod
+    def _pair(cls, hub: Path, external_marker: str = _V5_IMPORT, cache_external: bool = True):
+        cls._snapshot(hub, "org/primary", {
+            "config.json": json.dumps({
+                "model_type": "custom_remote",
+                "auto_map": {"AutoModelForCausalLM": "ext/repo--modeling_ext.ExtForCausalLM"},
+            }),
+            "modeling_local.py": "import torch\n",
+        })
+        if cache_external:
+            cls._snapshot(hub, "ext/repo", {"modeling_ext.py": external_marker})
+
+    def test_external_snapshot_supplies_the_marker(self, monkeypatch, tmp_path: Path):
+        import utils.transformers_version as tv
+
+        self._pair(tmp_path)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+        tier, definitive = tv._remote_auto_map_tier("org/primary")
+        assert tier == "530"
+        # A cached copy is not proof the Hub repo still matches, so nothing is memoized.
+        assert definitive is False
+        assert not _remote_auto_map_tier_cache
+
+    def test_uncached_external_repo_stays_default(self, monkeypatch, tmp_path: Path):
+        """Negative control: no snapshot for the external repo means nothing to read."""
+        import utils.transformers_version as tv
+
+        self._pair(tmp_path, cache_external = False)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+        assert tv._remote_auto_map_tier("org/primary") == ("default", False)
+
+    def test_external_snapshot_without_the_marker_stays_default(self, monkeypatch, tmp_path: Path):
+        """Negative control: reading the external cache must not invent a 5.x requirement."""
+        import utils.transformers_version as tv
+
+        self._pair(tmp_path, external_marker = "import torch\n")
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+        assert tv._remote_auto_map_tier("org/primary") == ("default", False)
+
+    def test_transient_external_failure_is_never_reported_complete(self, monkeypatch,
+                                                                   tmp_path: Path):
+        """Negative control: a snapshot substitution must not close an unread closure.
+
+        Online, a repo the Hub failed on stays incomplete even though its snapshot answered,
+        so a negative can never be memoized off an on-disk copy.
+        """
+        import utils.transformers_version as tv
+
+        self._snapshot(tmp_path, "ext/repo", {"modeling_ext.py": _V5_IMPORT})
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setattr(tv, "_list_hub_repo_py_files", lambda repo, tok = None: (set(), False))
+        sources, complete = tv._collect_external_py_sources({("ext/repo", "modeling_ext.py")})
+        assert sources and complete is False
+
+    def test_snapshot_fallback_draws_on_the_shared_budget(self, monkeypatch, tmp_path: Path):
+        """The scan-wide ceiling still applies, so N repos cannot multiply it."""
+        import utils.transformers_version as tv
+
+        self._snapshot(tmp_path, "ext/repo", {
+            "a.py": "import torch\n", "b.py": "import torch\n", "c.py": "import torch\n",
+        })
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+        budget = tv._RemoteScanBudget()
+        budget.files_left = 2
+        sources, complete = tv._collect_external_py_sources(
+            {("ext/repo", "modeling_ext.py")}, None, budget
+        )
+        assert len(sources) == 2 and complete is False
+
+
+class TestScannedTierSurvivesOneResolution:
+    """A 5.x marker read once during an activation must not be lost to a second scan.
+
+    ``_check_config_needs_510`` returns a 5.10 boolean, so a ``"530"`` scan collapsed to
+    False and the later 5.3 check rescanned. Only a definitive scan is memoized, so exactly
+    when the first scan was inconclusive did the second refetch, and a marker file that
+    failed that time routed the model to 4.57.x despite having already been read.
+    """
+
+    def setup_method(self):
+        _clear_scan_caches()
+
+    @staticmethod
+    def _hub(monkeypatch, reads: list):
+        """Serve one dict of ``{filename: source or None}`` per scan, in order."""
+        import utils.transformers_version as tv
+
+        scans = {"n": 0}
+        cfg = {
+            "model_type": "custom_remote",
+            "auto_map": {"AutoModelForCausalLM": "modeling_custom.CustomForCausalLM"},
+        }
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setattr(tv, "_load_config_json", lambda m, t = None: cfg)
+        monkeypatch.setattr(tv, "_config_json_is_definitive", lambda m, t = None: True)
+        monkeypatch.setattr(
+            tv, "_load_repo_json_checked",
+            lambda m, fn, t = None: (cfg, True) if fn == "config.json" else (None, True),
+        )
+        monkeypatch.setattr(tv, "_check_tokenizer_config_needs_v5", lambda m, t = None, **kw: False)
+        monkeypatch.setattr(tv, "_hf_cache_snapshot_dir", lambda m: None)
+        monkeypatch.setattr(tv, "_tier_from_config_mapping", lambda c: None)
+        monkeypatch.setattr(tv, "_probe_tier", lambda m, t, r, **kw: kw.get("floor", "530"))
+        monkeypatch.setattr(
+            tv, "_list_hub_repo_py_files",
+            lambda repo, tok = None: ({"modeling_custom.py", "other.py"}, True),
+        )
+
+        def _read(model_name, filename, tok = None):
+            return reads[min(scans["n"], len(reads) - 1)].get(filename)
+
+        original = tv._remote_auto_map_py_contents
+
+        def _counting(*a, **kw):
+            out = original(*a, **kw)
+            scans["n"] += 1
+            return out
+
+        monkeypatch.setattr(tv, "_read_repo_text_file", _read)
+        monkeypatch.setattr(tv, "_remote_auto_map_py_contents", _counting)
+        return scans
+
+    def test_marker_read_by_the_first_scan_still_activates_5x(self, monkeypatch):
+        # Scan 1 reads the marker but a sibling .py fails, so nothing is memoized; scan 2
+        # would then lose the marker file itself.
+        scans = self._hub(monkeypatch, [
+            {"modeling_custom.py": _V5_IMPORT, "other.py": None},
+            {"modeling_custom.py": None, "other.py": "import torch\n"},
+        ])
+        assert get_transformers_tier("org/flaky-remote", probe = True) == "530"
+        assert scans["n"] == 1  # the resolution reused its own scan
+
+    def test_complete_scan_without_the_marker_stays_default(self, monkeypatch):
+        """Negative control: reusing the scanned tier must not invent a promotion."""
+        scans = self._hub(monkeypatch, [
+            {"modeling_custom.py": "import torch\n", "other.py": "import torch\n"},
+        ])
+        assert get_transformers_tier("org/plain-remote", probe = True) == "default"
+        assert scans["n"] == 1
+
+    def test_inconclusive_positive_is_never_memoized(self, monkeypatch):
+        """Negative control: carrying a tier forward must stay inside the one call."""
+        self._hub(monkeypatch, [{"modeling_custom.py": _V5_IMPORT, "other.py": None}])
+        assert get_transformers_tier("org/flaky-remote", probe = True) == "530"
+        assert not _remote_auto_map_tier_cache
+        assert not _config_needs_510_cache
+
+
+class TestTypeCheckingGuardMustResolveToTyping:
+    """``if TYPE_CHECKING:`` is pruned only when the name really is typing's.
+
+    Matching the spelling alone let a module shadow ``TYPE_CHECKING`` with its own truthy
+    value and have a branch that really executes dropped, hiding a 5.x-only import behind
+    the default tier.
+    """
+
+    @staticmethod
+    def _matches(src: str) -> bool:
+        import utils.transformers_version as tv
+
+        return tv._remote_auto_map_py_matches(tv._TRANSFORMERS_5_REMOTE_IMPORT_MARKERS, [src])
+
+    @pytest.mark.parametrize("src, label", [
+        (f"TYPE_CHECKING = True\nif TYPE_CHECKING:\n    {_V5_IMPORT}", "module-level assignment"),
+        (
+            f"def build(TYPE_CHECKING = True):\n    if TYPE_CHECKING:\n        {_V5_IMPORT}",
+            "function parameter",
+        ),
+        (
+            f"import myconfig\nif myconfig.TYPE_CHECKING:\n    {_V5_IMPORT}",
+            "unrelated object attribute",
+        ),
+        (
+            f"for TYPE_CHECKING in flags:\n    if TYPE_CHECKING:\n        {_V5_IMPORT}",
+            "loop target",
+        ),
+        (
+            f"from .flags import TYPE_CHECKING\nif TYPE_CHECKING:\n    {_V5_IMPORT}",
+            "relative import of the repo's own name",
+        ),
+    ])
+    def test_shadowed_guard_still_reaches_the_tier(self, src, label):
+        assert self._matches(src) is True, label
+
+    @pytest.mark.parametrize("src, label", [
+        (f"from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n    {_V5_IMPORT}", "plain"),
+        (f"from typing import TYPE_CHECKING as TC\nif TC:\n    {_V5_IMPORT}", "aliased"),
+        (
+            f"from typing_extensions import TYPE_CHECKING as TC\nif TC:\n    {_V5_IMPORT}",
+            "aliased typing_extensions",
+        ),
+        (f"import typing\nif typing.TYPE_CHECKING:\n    {_V5_IMPORT}", "qualified"),
+        (f"import typing as t\nif t.TYPE_CHECKING:\n    {_V5_IMPORT}", "aliased module"),
+        (
+            f"TYPE_CHECKING = False\nif TYPE_CHECKING:\n    {_V5_IMPORT}",
+            "the no-import False idiom",
+        ),
+    ])
+    def test_real_typing_guard_never_promotes(self, src, label):
+        """Negative control: a genuinely dead branch must still be pruned."""
+        assert self._matches(src) is False, label
+
+    def test_else_branch_of_a_real_guard_still_counts(self):
+        """Negative control: only the guard's own body is dropped."""
+        assert self._matches(
+            f"from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n    pass\nelse:\n    {_V5_IMPORT}"
+        ) is True
+
+    def test_guard_resolves_when_the_import_follows_the_branch(self):
+        """The walk reaches the ``if`` before the import that binds the name."""
+        assert self._matches(
+            f"if TYPE_CHECKING:\n    {_V5_IMPORT}\nfrom typing import TYPE_CHECKING\n"
+        ) is False
+
+
+class TestProbeFalseSkipsTokenizerAutoMapScan:
+    """The cheap parent-side check must not page a repo and download its Python files.
+
+    The config fallback is already gated on ``probe``; the tokenizer ``auto_map`` closure was
+    the one remaining path that still paid a tree listing plus a request per ``.py``.
+    """
+
+    def setup_method(self):
+        _clear_scan_caches()
+
+    @staticmethod
+    def _hub(monkeypatch, tokenizer_class: str = "PreTrainedTokenizerFast"):
+        """Record every Hub URL a resolution touches."""
+        import utils.transformers_version as tv
+
+        urls: list[str] = []
+        cfg = {"model_type": "mysteryarch", "architectures": ["MysteryForCausalLM"]}
+        tok = {
+            "tokenizer_class": tokenizer_class,
+            "auto_map": {"AutoTokenizer": ["tokenization_mystery.MysteryTokenizer", None]},
+        }
+
+        def _urlopen(req, timeout = 10):
+            url = req.full_url
+            urls.append(url)
+            if url.endswith("tokenizer_config.json"):
+                return _PagedResponse(json.dumps(tok).encode())
+            if url.endswith("config.json"):
+                return _PagedResponse(json.dumps(cfg).encode())
+            if "/tree/" in url:
+                payload = [{"type": "file", "path": "tokenization_mystery.py"}]
+                return _PagedResponse(json.dumps(payload).encode())
+            if url.endswith(".py"):
+                return _PagedResponse(_V5_IMPORT.encode())
+            raise _http_error(url, 404)
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setattr(tv, "_hub_urlopen", _urlopen)
+        monkeypatch.setattr(tv, "_hf_cache_snapshot_dir", lambda m: None)
+        monkeypatch.setattr(tv, "_probe_tier", lambda m, t, r, **kw: kw.get("floor", "530"))
+        return urls
+
+    def test_probe_false_does_not_list_or_fetch_tokenizer_code(self, monkeypatch):
+        urls = self._hub(monkeypatch)
+        assert needs_transformers_5("org/tok-remote") is False
+        assert not [u for u in urls if "/tree/" in u or u.endswith(".py")]
+
+    def test_probe_false_negative_does_not_poison_activation(self, monkeypatch):
+        """Negative control: the skipped scan is not cached, and probe=True still scans."""
+        urls = self._hub(monkeypatch)
+        assert get_transformers_tier("org/tok-remote", probe = False) == "default"
+        assert not _tokenizer_class_cache
+        assert get_transformers_tier("org/tok-remote", probe = True) == "530"
+        assert [u for u in urls if u.endswith(".py")]
+
+    def test_five_x_tokenizer_class_still_answers_on_the_cheap_path(self, monkeypatch):
+        """Negative control: the gate drops the scan, not the tokenizer_class signal."""
+        urls = self._hub(monkeypatch, tokenizer_class = "TokenizersBackend")
+        assert get_transformers_tier("org/tok-backend", probe = False) == "530"
+        assert not [u for u in urls if "/tree/" in u or u.endswith(".py")]

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -573,7 +573,7 @@ class TestCheckConfigNeeds510:
         _remote_auto_map_needs_510_cache.clear()
         monkeypatch.setattr(tv, "_env_offline", lambda: True)
         assert _check_remote_auto_map_needs_510("org/custom-remote") is False
-        assert ("org/custom-remote", None) not in _remote_auto_map_needs_510_cache
+        assert not _remote_auto_map_needs_510_cache  # nothing memoized at any key
 
     def test_offline_local_checkpoint_external_auto_map_makes_no_request(
         self, monkeypatch, tmp_path: Path
@@ -679,7 +679,7 @@ class TestCheckConfigNeeds510:
         monkeypatch.setattr(tv, "_config_json_is_definitive", lambda *a, **k: True)
         monkeypatch.setattr(tv, "_remote_auto_map_py_contents", lambda *a, **k: ([], False))
         assert _check_remote_auto_map_needs_510("org/custom-remote") is False
-        assert ("org/custom-remote", None) not in _remote_auto_map_needs_510_cache
+        assert not _remote_auto_map_needs_510_cache  # nothing memoized at any key
         monkeypatch.setattr(
             tv,
             "_remote_auto_map_py_contents",
@@ -3558,3 +3558,231 @@ class TestRaiseTierForNested:
         monkeypatch.setattr(tv, "_config_needs_510", lambda cfg: False)
         monkeypatch.setattr(tv, "_config_needs_550", lambda cfg: True)
         assert tv.get_transformers_tier(str(ckpt), probe = False) == "latest"
+
+
+# ---------------------------------------------------------------------------
+# auto_map remote-code scan: import spellings, cache freshness, probe=False cost
+# ---------------------------------------------------------------------------
+
+_V5_IMPORT = "from transformers.utils.output_capturing import capture_outputs\n"
+
+
+def _auto_map_checkpoint(root: Path, modeling_src: str, model_type: str = "custom_remote"):
+    """A local custom-code checkpoint whose auto_map points at ``modeling_custom.py``."""
+    (root / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": model_type,
+                "auto_map": {"AutoModelForCausalLM": "modeling_custom.CustomForCausalLM"},
+            }
+        )
+    )
+    (root / "modeling_custom.py").write_text(modeling_src)
+    return root
+
+
+class TestRemoteImportSpellings:
+    """The marker scan must see every spelling that imports the 5.x-only module."""
+
+    def setup_method(self):
+        _config_json_cache.clear()
+        _remote_auto_map_needs_510_cache.clear()
+
+    def test_parent_package_import_returns_510(self, tmp_path: Path):
+        """``from transformers.utils import output_capturing`` loads the same module."""
+        _auto_map_checkpoint(tmp_path, "from transformers.utils import output_capturing\n")
+        assert get_transformers_tier(str(tmp_path)) == "510"
+
+    def test_parenthesized_multiline_import_returns_510(self, tmp_path: Path):
+        _auto_map_checkpoint(
+            tmp_path,
+            "from transformers.utils import (\n    logging,\n    output_capturing,\n)\n",
+        )
+        assert get_transformers_tier(str(tmp_path)) == "510"
+
+    def test_aliased_parent_import_returns_510(self, tmp_path: Path):
+        _auto_map_checkpoint(
+            tmp_path, "from transformers.utils import output_capturing as oc\n"
+        )
+        assert get_transformers_tier(str(tmp_path)) == "510"
+
+    def test_parent_package_alone_stays_default(self, tmp_path: Path):
+        """``from transformers import utils`` does not pull the 5.x-only submodule."""
+        _auto_map_checkpoint(tmp_path, "from transformers import utils\n")
+        assert get_transformers_tier(str(tmp_path)) == "default"
+
+    def test_relative_parent_import_stays_default(self, tmp_path: Path):
+        """A repo's own ``utils`` package must not match the transformers marker."""
+        _auto_map_checkpoint(tmp_path, "from .utils import output_capturing\n")
+        (tmp_path / "utils.py").write_text("output_capturing = None\n")
+        assert get_transformers_tier(str(tmp_path)) == "default"
+
+    def test_unparseable_source_still_matched_by_line_scan(self, tmp_path: Path):
+        """A syntax error must not silently downgrade the tier."""
+        _auto_map_checkpoint(tmp_path, _V5_IMPORT + "def broken(:\n")
+        assert get_transformers_tier(str(tmp_path)) == "510"
+
+    def test_tokenizer_parent_package_import_returns_v5(self, tmp_path: Path):
+        (tmp_path / "config.json").write_text(json.dumps({"model_type": "plain_thing"}))
+        (tmp_path / "tokenizer_config.json").write_text(
+            json.dumps(
+                {
+                    "tokenizer_class": "MyTok",
+                    "auto_map": {"AutoTokenizer": ["tokenization_my.MyTok", None]},
+                }
+            )
+        )
+        (tmp_path / "tokenization_my.py").write_text(
+            "from transformers import (\n    tokenization_utils_tokenizers,\n)\n"
+        )
+        assert _check_tokenizer_config_needs_v5(str(tmp_path)) is True
+
+
+class TestLocalScanCacheFreshness:
+    """A cached local scan must not survive the checkpoint's own .py files changing."""
+
+    def setup_method(self):
+        _config_json_cache.clear()
+        _tokenizer_class_cache.clear()
+        _remote_auto_map_needs_510_cache.clear()
+
+    def test_rescanned_when_entry_file_appears(self, tmp_path: Path):
+        """config.json lands before the remote code (in-progress checkpoint)."""
+        (tmp_path / "config.json").write_text(
+            json.dumps(
+                {
+                    "model_type": "custom_remote",
+                    "auto_map": {"AutoModelForCausalLM": "modeling_custom.CustomForCausalLM"},
+                }
+            )
+        )
+        assert get_transformers_tier(str(tmp_path)) == "default"
+        (tmp_path / "modeling_custom.py").write_text(_V5_IMPORT)
+        assert get_transformers_tier(str(tmp_path)) == "510"
+
+    def test_rescanned_when_entry_file_replaced(self, tmp_path: Path):
+        _auto_map_checkpoint(
+            tmp_path, "from transformers.modeling_layers import GradientCheckpointingLayer\n"
+        )
+        assert get_transformers_tier(str(tmp_path)) == "default"
+        (tmp_path / "modeling_custom.py").write_text(_V5_IMPORT)
+        assert get_transformers_tier(str(tmp_path)) == "510"
+
+    def test_unchanged_checkpoint_is_served_from_cache(self, tmp_path: Path, monkeypatch):
+        import utils.transformers_version as tv
+
+        _auto_map_checkpoint(tmp_path, _V5_IMPORT)
+        assert get_transformers_tier(str(tmp_path)) == "510"
+        monkeypatch.setattr(
+            tv,
+            "_remote_auto_map_py_contents",
+            lambda *a, **k: (_ for _ in ()).throw(AssertionError("rescanned unchanged files")),
+        )
+        assert get_transformers_tier(str(tmp_path)) == "510"
+
+    def test_tokenizer_scan_not_cached_while_entry_file_missing(self, tmp_path: Path):
+        (tmp_path / "tokenizer_config.json").write_text(
+            json.dumps(
+                {
+                    "tokenizer_class": "MyTok",
+                    "auto_map": {"AutoTokenizer": ["tokenization_my.MyTok", None]},
+                }
+            )
+        )
+        assert _check_tokenizer_config_needs_v5(str(tmp_path)) is False
+        assert (str(tmp_path), None) not in _tokenizer_class_cache
+        (tmp_path / "tokenization_my.py").write_text(
+            "from transformers.tokenization_utils_tokenizers import TokenizersBackend\n"
+        )
+        assert _check_tokenizer_config_needs_v5(str(tmp_path)) is True
+
+
+class TestTokenizerAutoMapTransientScan:
+    """An incomplete Hub tokenizer auto_map scan must not memoize its negative."""
+
+    def setup_method(self):
+        _config_json_cache.clear()
+        _tokenizer_class_cache.clear()
+        _remote_auto_map_needs_510_cache.clear()
+
+    def test_transient_listing_failure_retried(self, monkeypatch):
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        tok_cfg = {
+            "tokenizer_class": "MyTok",
+            "auto_map": {"AutoTokenizer": ["tokenization_my.MyTok", None]},
+        }
+        state = {"listing_ok": False}
+
+        def _fake_list(repo_id, hf_token = None):
+            if not state["listing_ok"]:
+                return set(), False
+            return {"tokenization_my.py"}, True
+
+        monkeypatch.setattr(tv, "_list_hub_repo_py_files", _fake_list)
+        monkeypatch.setattr(
+            tv,
+            "_read_repo_text_file",
+            lambda model, fn, tok = None: (
+                "from transformers.tokenization_utils_tokenizers import TokenizersBackend\n"
+            ),
+        )
+        with patch("urllib.request.urlopen", return_value = _hf_response(tok_cfg)):
+            assert _check_tokenizer_config_needs_v5("org/tok-only") is False
+            assert ("org/tok-only", None) not in _tokenizer_class_cache
+            state["listing_ok"] = True
+            assert _check_tokenizer_config_needs_v5("org/tok-only") is True
+
+    def test_definitive_negative_is_memoized(self, monkeypatch):
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        tok_cfg = {
+            "tokenizer_class": "MyTok",
+            "auto_map": {"AutoTokenizer": ["tokenization_my.MyTok", None]},
+        }
+        monkeypatch.setattr(
+            tv, "_list_hub_repo_py_files", lambda repo, tok = None: ({"tokenization_my.py"}, True)
+        )
+        monkeypatch.setattr(
+            tv, "_read_repo_text_file", lambda model, fn, tok = None: "import torch\n"
+        )
+        with patch("urllib.request.urlopen", return_value = _hf_response(tok_cfg)) as mock_url:
+            assert _check_tokenizer_config_needs_v5("org/tok-only") is False
+            after_first = mock_url.call_count
+            assert _check_tokenizer_config_needs_v5("org/tok-only") is False
+            assert mock_url.call_count == after_first  # second call served from the cache
+        assert _tokenizer_class_cache[("org/tok-only", None)] is False
+
+
+class TestProbeFalseSkipsAutoMapScan:
+    """The name fast path must stay I/O-free for the cheap parent-side check."""
+
+    def setup_method(self):
+        _config_json_cache.clear()
+        _remote_auto_map_needs_510_cache.clear()
+
+    def test_probe_false_does_no_hub_io(self, monkeypatch):
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        with patch("urllib.request.urlopen") as mock_url:
+            assert get_transformers_tier("Qwen/Qwen3.5-9B", probe = False) == "530"
+            mock_url.assert_not_called()
+        assert needs_transformers_5("Qwen/Qwen3.5-9B") is True
+
+    def test_probe_true_still_upgrades_to_510(self, monkeypatch):
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        cfg = {
+            "model_type": "custom_remote",
+            "auto_map": {"AutoModelForCausalLM": "modeling_custom.CustomForCausalLM"},
+        }
+        monkeypatch.setattr(
+            tv, "_load_config_json", lambda name, tok = None: cfg if "qwen3.5" in name else None
+        )
+        monkeypatch.setattr(
+            tv, "_list_hub_repo_py_files", lambda repo, tok = None: ({"modeling_custom.py"}, True)
+        )
+        monkeypatch.setattr(tv, "_read_repo_text_file", lambda m, fn, tok = None: _V5_IMPORT)
+        assert get_transformers_tier("org/qwen3.5-remote", probe = True) == "510"

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -3799,9 +3799,21 @@ class TestProbeFalseSkipsAutoMapScan:
         assert needs_transformers_5("Qwen/Qwen3.5-9B") is True
 
     def test_probe_true_still_runs_the_auto_map_scan(self, monkeypatch):
+        """probe=True scans -- once a 5.10-only marker makes the answer reachable.
+
+        The scan is gated on ``_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS``, empty today, so the
+        marker is patched in here to assert the activation path still reaches the repo. With
+        the tuple empty the fast path deliberately makes no request; that half of the
+        contract is covered by ``TestImpossible510ScanIsSkipped``.
+        """
         import utils.transformers_version as tv
 
         monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setattr(
+            tv,
+            "_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS",
+            ("transformers.models.some_future_510_only",),
+        )
         cfg = {
             "model_type": "custom_remote",
             "auto_map": {"AutoModelForCausalLM": "modeling_custom.CustomForCausalLM"},
@@ -4914,3 +4926,112 @@ class TestDynamicImportsOfVersionedModules:
         assert tv._parsed_dotted_imports("def broken(:\n") is None
         assert tv._parsed_dotted_imports("x = 1\n") == set()
         assert tv._parsed_dotted_imports('log("transformers.anything")\n') == set()
+
+
+class TestImpossible510ScanIsSkipped:
+    """The name fast path must not pay Hub I/O for an answer it cannot use.
+
+    ``_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS`` is empty, so the auto_map scan cannot
+    classify anything as 5.10: on a ``_tier_from_name`` hit with ``probe=True`` it would read
+    every remote-code config, page the repo tree and fetch each ``.py`` only to return the
+    tier the name already produced. The skip is gated on the tuple, never on the call site,
+    so re-adding a 5.10-only module restores the scan by itself (proved below).
+    """
+
+    _FUTURE_MARKER = "transformers.models.some_future_510_only"
+
+    def setup_method(self):
+        _clear_scan_caches()
+
+    def _fake_hub(self, py_body: str, log: list):
+        """urlopen stand-in for a Hub repo whose config.json declares an auto_map."""
+        import urllib.error
+
+        cfg = {
+            "model_type": "ministral",
+            "auto_map": {"AutoModelForCausalLM": "modeling_custom.Model"},
+        }
+
+        class _Resp:
+            def __init__(self, body: bytes):
+                self._body = body
+                self.headers = {"Link": None}
+
+            def read(self):
+                return self._body
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        def _urlopen(req, timeout = 10):
+            url = req.full_url if hasattr(req, "full_url") else str(req)
+            log.append(url)
+            if "/api/models/" in url and "/tree/" in url:
+                tree = [{"type": "file", "path": "modeling_custom.py"}]
+                return _Resp(json.dumps(tree).encode())
+            if url.endswith("/config.json"):
+                return _Resp(json.dumps(cfg).encode())
+            if url.endswith(".py"):
+                return _Resp(py_body.encode())
+            raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)
+
+        return _urlopen
+
+    def test_name_fast_path_makes_no_hub_request(self, monkeypatch):
+        """A 5.3 name match with probe=True must resolve with zero Hub round trips."""
+        import utils.transformers_version as tv
+
+        monkeypatch.setattr(tv, "latest_venv_pinned_version", lambda *a, **k: None)
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            tier = get_transformers_tier("mistralai/Ministral-3-8B-Instruct-2512", probe = True)
+        assert tier == "530"
+        mock_urlopen.assert_not_called()
+
+    def test_helper_is_false_without_reading_the_repo(self):
+        """The 5.10 question is answerable offline while no 5.10-only marker exists."""
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            assert _check_remote_auto_map_needs_510("org/custom-remote") is False
+        mock_urlopen.assert_not_called()
+
+    def test_a_future_marker_restores_the_scan(self, monkeypatch):
+        """Negative control: re-adding a 5.10-only module must reopen the fast-path scan."""
+        import utils.transformers_version as tv
+
+        monkeypatch.setattr(
+            tv, "_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS", (self._FUTURE_MARKER,)
+        )
+        monkeypatch.setattr(tv, "latest_venv_pinned_version", lambda *a, **k: None)
+        log: list = []
+        monkeypatch.setattr(
+            "urllib.request.urlopen",
+            self._fake_hub(f"from {self._FUTURE_MARKER} import Thing\n", log),
+        )
+        tier = get_transformers_tier("mistralai/Ministral-3-8B-Instruct-2512", probe = True)
+        assert tier == "510"
+        assert log, "the scan must run once a 5.10-only marker exists"
+
+    def test_a_future_marker_that_does_not_match_keeps_the_name_tier(self, monkeypatch):
+        """Negative control: the reopened scan must not promote a repo that lacks it."""
+        import utils.transformers_version as tv
+
+        monkeypatch.setattr(
+            tv, "_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS", (self._FUTURE_MARKER,)
+        )
+        monkeypatch.setattr(tv, "latest_venv_pinned_version", lambda *a, **k: None)
+        log: list = []
+        monkeypatch.setattr(
+            "urllib.request.urlopen",
+            self._fake_hub("from transformers.modeling_utils import PreTrainedModel\n", log),
+        )
+        tier = get_transformers_tier("mistralai/Ministral-3-8B-Instruct-2512", probe = True)
+        assert tier == "530"
+        assert log, "the scan must still run; it simply finds no 5.10 marker"
+
+    def test_the_5_3_classification_is_untouched(self, tmp_path: Path):
+        """Skipping the 5.10 question must not disturb the 5.3 answer the same scan gives."""
+        _auto_map_checkpoint(tmp_path, _V5_IMPORT)
+        assert _check_remote_auto_map_needs_510(str(tmp_path)) is False
+        assert _remote_auto_map_tier(str(tmp_path)) == ("530", True)

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -4272,6 +4272,81 @@ class TestScanSignatureCoversAutoMapConfigs:
         assert _remote_auto_map_tier(str(tmp_path))[0] == "530"
 
 
+class TestScanSignatureSeesSameSizedReplacement:
+    """size + mtime cannot see an archival redeploy that restores the timestamp, so the
+    signature also carries ctime and inode (round 7 Codex).
+
+    ``rsync --archive`` / ``tar -xp`` put back the original mtime, and a same-sized rewrite
+    leaves the size alone, so a long-lived worker kept serving the tier it computed from
+    code no longer on disk.
+    """
+
+    # Same byte length, so only the content differs.
+    V4_SRC = "from transformers.modeling_utils import PreTrainedModel  # pad!\n"
+
+    def setup_method(self):
+        _config_json_cache.clear()
+        _tokenizer_class_cache.clear()
+        _remote_auto_map_tier_cache.clear()
+        assert len(self.V4_SRC) == len(_V5_IMPORT)
+
+    def test_in_place_rewrite_with_restored_mtime_is_rescanned(self, tmp_path: Path):
+        _auto_map_checkpoint(tmp_path, self.V4_SRC)
+        assert _remote_auto_map_tier(str(tmp_path))[0] == "default"
+
+        entry = tmp_path / "modeling_custom.py"
+        before = entry.stat()
+        with open(entry, "r+") as handle:
+            handle.write(_V5_IMPORT)
+            handle.truncate()
+        os.utime(entry, ns = (before.st_atime_ns, before.st_mtime_ns))
+        after = entry.stat()
+        assert (after.st_size, after.st_mtime_ns) == (before.st_size, before.st_mtime_ns)
+
+        assert _remote_auto_map_tier(str(tmp_path))[0] == "530"
+
+    def test_atomic_replace_with_restored_mtime_is_rescanned(self, tmp_path: Path):
+        """The rename spelling of the same redeploy: new inode, same size and mtime."""
+        _auto_map_checkpoint(tmp_path, self.V4_SRC)
+        assert _remote_auto_map_tier(str(tmp_path))[0] == "default"
+
+        entry = tmp_path / "modeling_custom.py"
+        before = entry.stat()
+        staged = tmp_path / ".staged.py"
+        staged.write_text(_V5_IMPORT)
+        os.replace(staged, entry)
+        os.utime(entry, ns = (before.st_atime_ns, before.st_mtime_ns))
+        after = entry.stat()
+        assert (after.st_size, after.st_mtime_ns) == (before.st_size, before.st_mtime_ns)
+
+        assert _remote_auto_map_tier(str(tmp_path))[0] == "530"
+
+    def test_untouched_checkpoint_is_still_served_from_cache(
+        self, monkeypatch, tmp_path: Path
+    ):
+        """Negative control: the extra fields must not turn every lookup into a re-scan."""
+        import utils.transformers_version as tv
+
+        _auto_map_checkpoint(tmp_path, _V5_IMPORT)
+        assert _remote_auto_map_tier(str(tmp_path))[0] == "530"
+        monkeypatch.setattr(
+            tv,
+            "_remote_auto_map_py_contents",
+            lambda *a, **k: (_ for _ in ()).throw(AssertionError("rescanned unchanged inputs")),
+        )
+        assert _remote_auto_map_tier(str(tmp_path))[0] == "530"
+        assert _remote_auto_map_tier(str(tmp_path))[0] == "530"
+
+    def test_reading_a_file_does_not_bust_the_cache(self, monkeypatch, tmp_path: Path):
+        """Negative control: atime moves on every read; only ctime/inode may invalidate."""
+        import utils.transformers_version as tv
+
+        _auto_map_checkpoint(tmp_path, _V5_IMPORT)
+        signature = tv._local_scan_signature(str(tmp_path))
+        (tmp_path / "modeling_custom.py").read_text()
+        assert tv._local_scan_signature(str(tmp_path)) == signature
+
+
 class TestTokenizerScanCacheFreshness:
     """The tokenizer cache must not answer from a checkpoint that has since changed."""
 
@@ -4862,6 +4937,127 @@ class TestOfflineAutoMapScanUsesTheHubCache:
         assert tv._hf_cache_snapshot_dir(str(tmp_path)) is None
         assert tv._hf_cache_snapshot_dir("./org/model") is None
         assert tv._hf_cache_snapshot_dir("org/sub/model") is None
+
+
+class TestInconclusiveScanFallsBackToTheHubCache:
+    """Online but inconclusive is not a negative: an already downloaded snapshot is the
+    code the load will execute, so read it instead of reporting the default tier (round 7
+    Codex).
+
+    Same fallback as the offline branch above; the trigger here is a transient Hub failure
+    while nominally online, which otherwise hands ``get_transformers_tier`` a bare
+    ``"default"`` it cannot tell apart from a repo that really has no 5.x import.
+    """
+
+    def setup_method(self):
+        _clear_scan_caches()
+
+    _snapshot = staticmethod(TestOfflineAutoMapScanUsesTheHubCache._snapshot)
+
+    @staticmethod
+    def _down(_req, timeout = 10):
+        raise OSError("temporary Hub outage")
+
+    def test_snapshot_answers_when_the_hub_is_unreachable(self, monkeypatch, tmp_path: Path):
+        import utils.transformers_version as tv
+
+        self._snapshot(tmp_path, "org/outage-5x", _V5_IMPORT)
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.setattr(tv, "_hub_urlopen", self._down)
+
+        tier, definitive = tv._remote_auto_map_tier("org/outage-5x")
+        assert tier == "530"
+        # The Hub still never answered, so the result stays provisional and nothing is
+        # memoized under the Hub id: a recovered Hub must re-scan.
+        assert definitive is False
+        assert not [key for key in _remote_auto_map_tier_cache if key[0] == "org/outage-5x"]
+
+    def test_tree_listing_failure_alone_still_uses_the_snapshot(
+        self, monkeypatch, tmp_path: Path
+    ):
+        """Only the repo listing fails; the configs read fine. Still inconclusive."""
+        import utils.transformers_version as tv
+
+        self._snapshot(tmp_path, "org/partial-5x", _V5_IMPORT)
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        cfg = json.dumps(
+            {
+                "model_type": "custom_remote",
+                "auto_map": {"AutoModelForCausalLM": "modeling_custom.CustomForCausalLM"},
+            }
+        ).encode()
+
+        def _urlopen(req, timeout = 10):
+            if "/tree/" in req.full_url:
+                raise OSError("temporary Hub outage")
+            if req.full_url.endswith("/config.json"):
+                return _PagedResponse(cfg)
+            raise _http_error(req.full_url, 404)
+
+        monkeypatch.setattr(tv, "_hub_urlopen", _urlopen)
+        assert tv._remote_auto_map_tier("org/partial-5x") == ("530", False)
+
+    def test_no_snapshot_stays_default(self, monkeypatch, tmp_path: Path):
+        """Negative control: an outage with nothing downloaded invents no requirement.
+
+        A blanket 5.3 floor for every inconclusive scan would push plain repos onto the
+        5.3 sidecar for the length of any Hub outage, so the fallback is the snapshot and
+        only the snapshot.
+        """
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.setattr(tv, "_hub_urlopen", self._down)
+        assert tv._remote_auto_map_tier("org/never-downloaded") == ("default", False)
+
+    def test_snapshot_without_the_marker_stays_default(self, monkeypatch, tmp_path: Path):
+        """Negative control: the fallback reads the snapshot, it does not assume 5.x."""
+        import utils.transformers_version as tv
+
+        self._snapshot(tmp_path, "org/outage-plain", "import torch\n")
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.setattr(tv, "_hub_urlopen", self._down)
+        assert tv._remote_auto_map_tier("org/outage-plain") == ("default", False)
+
+    def test_definitive_negative_does_not_consult_the_snapshot(
+        self, monkeypatch, tmp_path: Path
+    ):
+        """Negative control: a repo that really has no auto_map keeps its cached negative.
+
+        A 404 is an answer, so a stale snapshot left over from an older revision must not
+        override it (that would resurrect the Hub-side staleness this PR declined to fix).
+        """
+        import utils.transformers_version as tv
+
+        self._snapshot(tmp_path, "org/plain-model", _V5_IMPORT)
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.setattr(
+            tv, "_hub_urlopen", lambda req, timeout = 10: _raise(_http_error(req.full_url, 404))
+        )
+        assert tv._remote_auto_map_tier("org/plain-model") == ("default", True)
+
+    def test_local_dir_does_not_consult_the_hub_cache(self, monkeypatch, tmp_path: Path):
+        """Negative control: a local checkpoint scans itself, never a same-named snapshot."""
+        import utils.transformers_version as tv
+
+        ckpt = tmp_path / "ckpt"
+        ckpt.mkdir()
+        _auto_map_checkpoint(ckpt, "import torch\n")
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.setattr(tv, "_hf_cache_snapshot_dir", lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("local dir consulted the hub cache")
+        ))
+        assert tv._remote_auto_map_tier(str(ckpt))[0] == "default"
+
+
+def _raise(exc):
+    raise exc
 
 
 class TestDynamicImportsOfVersionedModules:

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -1288,9 +1288,19 @@ class TestGetTransformersTier:
             mock_urlopen.assert_not_called()
 
     def test_remote_config_json_is_fetched_once_for_config_tiers(self):
-        """510 and 550 slow-path checks should share one config.json fetch."""
+        """510 and 550 slow-path checks should share one config.json fetch.
+
+        The auto_map scan additionally reads the remote-code configs once each (a processor
+        declared only in preprocessor/processor config is executable too), so pin the real
+        invariant: config.json is fetched exactly once, and nothing beyond the remote-code
+        config set is fetched for a repo that declares no auto_map.
+        """
+        from utils.security.remote_code_scan import REMOTE_CODE_CONFIG_FILES
 
         class _Response:
+            def __init__(self):
+                self.headers = {}
+
             def __enter__(self):
                 return self
 
@@ -1305,10 +1315,20 @@ class TestGetTransformersTier:
                     }
                 ).encode()
 
-        with patch("urllib.request.urlopen", return_value = _Response()) as mock_urlopen:
+        urls = []
+
+        def _fake_urlopen(req, timeout = 10):
+            urls.append(req.full_url)
+            return _Response()
+
+        with patch("urllib.request.urlopen", side_effect = _fake_urlopen):
             assert get_transformers_tier("org/no-fast-substring-model") == "550"
 
-        assert mock_urlopen.call_count == 1
+        assert sum(u.endswith("/config.json") for u in urls) == 1
+        assert {u.rsplit("/", 1)[1] for u in urls} <= set(REMOTE_CODE_CONFIG_FILES)
+        # No repo tree listing and no .py fetches: nothing declared auto_map.
+        assert not any("/tree/" in u for u in urls)
+        assert not any(u.endswith(".py") for u in urls)
 
     def test_qwen35_returns_530(self):
         with (
@@ -3788,3 +3808,355 @@ class TestProbeFalseSkipsAutoMapScan:
         )
         monkeypatch.setattr(tv, "_read_repo_text_file", lambda m, fn, tok = None: _V5_IMPORT)
         assert get_transformers_tier("org/qwen3.5-remote", probe = True) == "510"
+
+
+class _PagedResponse:
+    """urlopen stand-in that can carry a ``Link: rel="next"`` header."""
+
+    def __init__(
+        self,
+        payload: bytes,
+        next_url: str | None = None,
+    ):
+        self._payload = payload
+        self.headers = {"Link": f'<{next_url}>; rel="next"'} if next_url else {}
+
+    def read(self):
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _http_error(url: str, code: int):
+    import urllib.error
+    return urllib.error.HTTPError(url, code, "err", {}, None)
+
+
+class TestHubTreePagination:
+    """The Hub tree endpoint pages at 1000 entries; a partial listing is not a negative."""
+
+    def setup_method(self):
+        _config_json_cache.clear()
+        _remote_auto_map_needs_510_cache.clear()
+
+    def test_py_file_on_second_page_is_found(self, monkeypatch):
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        page1 = [{"type": "file", "path": f"w-{i}.safetensors"} for i in range(1000)]
+        page2 = [{"type": "file", "path": "modeling_custom.py"}]
+        cursor = "https://huggingface.co/api/models/org/big/tree/main?recursive=1&cursor=abc"
+
+        def _urlopen(req, timeout = 10):
+            url = req.full_url
+            if "/tree/" in url and "cursor=" not in url:
+                return _PagedResponse(json.dumps(page1).encode(), cursor)
+            if "cursor=" in url:
+                return _PagedResponse(json.dumps(page2).encode())
+            raise _http_error(url, 404)
+
+        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        assert tv._list_hub_repo_py_files("org/big") == ({"modeling_custom.py"}, True)
+
+    def test_single_page_still_one_request(self, monkeypatch):
+        """Negative control: no Link header means exactly one request."""
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        calls = []
+
+        def _urlopen(req, timeout = 10):
+            calls.append(req.full_url)
+            return _PagedResponse(json.dumps([{"type": "file", "path": "a.py"}]).encode())
+
+        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        assert tv._list_hub_repo_py_files("org/small") == ({"a.py"}, True)
+        assert len(calls) == 1
+
+    def test_failed_later_page_is_not_a_complete_listing(self, monkeypatch):
+        """Negative control: losing page 2 must report failure, never a truncated success."""
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        cursor = "https://huggingface.co/api/models/org/big/tree/main?recursive=1&cursor=abc"
+
+        def _urlopen(req, timeout = 10):
+            if "cursor=" in req.full_url:
+                raise OSError("connection reset on page 2")
+            return _PagedResponse(json.dumps([{"type": "file", "path": "a.py"}]).encode(), cursor)
+
+        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        assert tv._list_hub_repo_py_files("org/big") == (set(), False)
+
+    def test_non_http_pagination_link_is_refused(self, monkeypatch):
+        """Negative control: never follow a cursor that leaves http(s)."""
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+
+        def _urlopen(req, timeout = 10):
+            return _PagedResponse(json.dumps([]).encode(), "file:///etc/passwd")
+
+        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        assert tv._list_hub_repo_py_files("org/evil") == (set(), False)
+
+
+class TestUnreadableAutoMapConfigIsInconclusive:
+    """A config nobody could read is not proof that a repo declares no auto_map."""
+
+    def setup_method(self):
+        _config_json_cache.clear()
+        _remote_auto_map_needs_510_cache.clear()
+        tv_mod = __import__("utils.transformers_version", fromlist = ["x"])
+        tv_mod._config_json_absent.clear()
+
+    def test_transient_config_failure_is_not_cached_and_recovers(self, monkeypatch, tmp_path):
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "empty-hub"))
+        cfg = json.dumps(
+            {"model_type": "custom", "auto_map": {"AutoModel": "modeling_custom.Model"}}
+        ).encode()
+        state = {"up": False}
+
+        def _urlopen(req, timeout = 10):
+            url = req.full_url
+            if not state["up"]:
+                raise OSError("temporary Hub outage")
+            if url.endswith("/config.json"):
+                return _PagedResponse(cfg)
+            if "/tree/" in url:
+                return _PagedResponse(
+                    json.dumps([{"type": "file", "path": "modeling_custom.py"}]).encode()
+                )
+            if url.endswith("modeling_custom.py"):
+                return _PagedResponse(_V5_IMPORT.encode())
+            raise _http_error(url, 404)
+
+        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        needs, definitive = tv._remote_auto_map_scan_result("org/custom-remote")
+        assert (needs, definitive) == (False, False)
+        assert not _remote_auto_map_needs_510_cache  # the outage cached nothing
+
+        state["up"] = True
+        _config_json_cache.clear()
+        assert tv._remote_auto_map_scan_result("org/custom-remote") == (True, True)
+
+    def test_missing_config_is_still_a_definitive_negative(self, monkeypatch, tmp_path):
+        """Negative control: a real 404 is an answer, so the negative may be cached."""
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "empty-hub"))
+
+        def _urlopen(req, timeout = 10):
+            raise _http_error(req.full_url, 404)
+
+        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        assert tv._remote_auto_map_scan_result("org/plain-model") == (False, True)
+        assert _remote_auto_map_needs_510_cache  # definitive, so memoized
+
+
+class TestProcessorOnlyAutoMapIsScanned:
+    """A processor declared only in a processor config is executable remote code too."""
+
+    def setup_method(self):
+        _config_json_cache.clear()
+        _remote_auto_map_needs_510_cache.clear()
+
+    def test_hub_preprocessor_config_auto_map_promotes_tier(self, monkeypatch, tmp_path):
+        """Mirrors TencentARC/TimeLens-7B: stock config.json, processor auto_map only."""
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "empty-hub"))
+        base_cfg = json.dumps({"model_type": "qwen2_5_vl"}).encode()
+        pre_cfg = json.dumps(
+            {"auto_map": {"AutoProcessor": "processing_custom.CustomProcessor"}}
+        ).encode()
+
+        def _urlopen(req, timeout = 10):
+            url = req.full_url
+            if url.endswith("/config.json"):
+                return _PagedResponse(base_cfg)
+            if url.endswith("/preprocessor_config.json"):
+                return _PagedResponse(pre_cfg)
+            if "/tree/" in url:
+                return _PagedResponse(
+                    json.dumps([{"type": "file", "path": "processing_custom.py"}]).encode()
+                )
+            if url.endswith("processing_custom.py"):
+                return _PagedResponse(_V5_IMPORT.encode())
+            raise _http_error(url, 404)
+
+        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        assert tv._check_remote_auto_map_needs_510("org/vlm-remote") is True
+
+    def test_repo_without_any_auto_map_fetches_no_py(self, monkeypatch, tmp_path):
+        """Negative control: no auto_map anywhere means no listing and no .py fetches."""
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "empty-hub"))
+        urls = []
+
+        def _urlopen(req, timeout = 10):
+            urls.append(req.full_url)
+            if req.full_url.endswith("/config.json"):
+                return _PagedResponse(json.dumps({"model_type": "llama"}).encode())
+            raise _http_error(req.full_url, 404)
+
+        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        assert tv._check_remote_auto_map_needs_510("org/plain-model") is False
+        assert not any("/tree/" in u for u in urls)
+        assert not any(u.endswith(".py") for u in urls)
+
+
+class TestScanPrerequisiteConfigHonorsHfEndpoint:
+    """A mirror-only deployment must be able to read the config that gates the scan."""
+
+    def setup_method(self):
+        _config_json_cache.clear()
+        _remote_auto_map_needs_510_cache.clear()
+
+    def test_config_json_fetched_from_mirror(self, monkeypatch, tmp_path):
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "empty-hub"))
+        monkeypatch.setenv("HF_ENDPOINT", "https://hf.mirror.internal")
+        cfg = json.dumps(
+            {"model_type": "custom", "auto_map": {"AutoModel": "modeling_custom.Model"}}
+        ).encode()
+
+        def _urlopen(req, timeout = 10):
+            url = req.full_url
+            if url.startswith("https://huggingface.co"):
+                raise OSError("huggingface.co is blocked by the firewall")
+            if url.endswith("/config.json"):
+                return _PagedResponse(cfg)
+            if "/tree/" in url:
+                return _PagedResponse(
+                    json.dumps([{"type": "file", "path": "modeling_custom.py"}]).encode()
+                )
+            if url.endswith("modeling_custom.py"):
+                return _PagedResponse(_V5_IMPORT.encode())
+            raise _http_error(url, 404)
+
+        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        assert tv._load_config_json("org/custom-remote") is not None
+        assert tv._check_remote_auto_map_needs_510("org/custom-remote") is True
+
+    def test_default_endpoint_unchanged(self, monkeypatch, tmp_path):
+        """Negative control: without HF_ENDPOINT the canonical host is still used."""
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.delenv("HF_ENDPOINT", raising = False)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "empty-hub"))
+        seen = {}
+
+        def _urlopen(req, timeout = 10):
+            seen["url"] = req.full_url
+            return _PagedResponse(json.dumps({"model_type": "llama"}).encode())
+
+        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        tv._load_config_json("org/model")
+        assert seen["url"] == "https://huggingface.co/org/model/raw/main/config.json"
+
+
+class TestRemoteSourceEncoding:
+    """Remote Python must decode by its declared encoding, as CPython does (PEP 263)."""
+
+    def setup_method(self):
+        _config_json_cache.clear()
+        _remote_auto_map_needs_510_cache.clear()
+
+    def test_pep263_cookie_module_is_decoded(self, monkeypatch):
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        latin1 = (
+            "# -*- coding: latin-1 -*-\n"
+            "# auteur Andr\xe9\n"
+            "from transformers.utils.output_capturing import capture\n"
+        ).encode("latin-1")
+        with pytest.raises(UnicodeDecodeError):
+            latin1.decode("utf-8")
+
+        monkeypatch.setattr(
+            "urllib.request.urlopen", lambda req, timeout = 10: _PagedResponse(latin1)
+        )
+        text = tv._read_repo_text_file("org/custom-remote", "modeling_custom.py")
+        assert text is not None
+        assert "output_capturing" in text
+        assert tv._remote_auto_map_py_matches(tv._TRANSFORMERS_510_REMOTE_IMPORT_MARKERS, [text])
+
+    def test_undeclared_binary_still_decodes_without_raising(self, monkeypatch):
+        """Negative control: garbage bytes degrade to replacement, never an exception."""
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setattr(
+            "urllib.request.urlopen",
+            lambda req, timeout = 10: _PagedResponse(b"\xff\xfe\x00\x01 not utf-8"),
+        )
+        assert tv._read_repo_text_file("org/custom-remote", "modeling_custom.py") is not None
+
+    def test_plain_utf8_unchanged(self, monkeypatch):
+        """Negative control: ordinary UTF-8 source round-trips exactly."""
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        src = "# café\nfrom transformers.utils.output_capturing import capture\n"
+        monkeypatch.setattr(
+            "urllib.request.urlopen",
+            lambda req, timeout = 10: _PagedResponse(src.encode("utf-8")),
+        )
+        assert tv._read_repo_text_file("org/custom-remote", "modeling_custom.py") == src
+
+
+class TestImportScanIgnoresNonImportText:
+    """Only real import statements promote the tier; unparseable source keeps the fallback."""
+
+    MARKERS = ("transformers.utils.output_capturing",)
+
+    def _matches(self, src: str) -> bool:
+        import utils.transformers_version as tv
+        return tv._remote_auto_map_py_matches(tv._TRANSFORMERS_510_REMOTE_IMPORT_MARKERS, [src])
+
+    def test_marker_in_docstring_does_not_match(self):
+        src = (
+            '"""Custom model.\n\n'
+            "On transformers>=5.10 you would write:\n\n"
+            "from transformers.utils.output_capturing import capture\n\n"
+            '"""\nimport torch\n'
+        )
+        assert self._matches(src) is False
+
+    def test_marker_in_plain_string_does_not_match(self):
+        src = 'import torch\n\nHELP = """\nfrom transformers.utils.output_capturing import c\n"""\n'
+        assert self._matches(src) is False
+
+    def test_marker_in_comment_does_not_match(self):
+        src = "import torch\n# from transformers.utils.output_capturing import capture\n"
+        assert self._matches(src) is False
+
+    def test_unparseable_source_still_matches_by_line(self):
+        """The round-1 property: broken remote code must never become a silent negative."""
+        src = "from transformers.utils.output_capturing import capture\n\ndef broken(:\n    pass\n"
+        assert self._matches(src) is True
+
+    def test_real_imports_still_match(self):
+        for src in (
+            "from transformers.utils.output_capturing import capture\n",
+            "import transformers.utils.output_capturing\n",
+            "from transformers.utils import output_capturing\n",
+            "from transformers.utils.output_capturing import (\n    capture,\n)\n",
+        ):
+            assert self._matches(src) is True

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -644,7 +644,11 @@ class TestCheckConfigNeeds510:
         }
         (tmp_path / "tokenizer_config.json").write_text(json.dumps(tc))
 
-        def _fake_fetch(repo_id, hf_token = None, budget = None):
+        def _fake_fetch(
+            repo_id,
+            hf_token = None,
+            budget = None,
+        ):
             if repo_id == "other/tokenizer-repo":
                 return [
                     "from transformers.tokenization_utils_tokenizers import TokenizersBackend\n"
@@ -1102,7 +1106,11 @@ class TestGetTransformersTier:
         }
         (tmp_path / "config.json").write_text(json.dumps(cfg))
 
-        def _fake_fetch(repo_id, hf_token = None, budget = None):
+        def _fake_fetch(
+            repo_id,
+            hf_token = None,
+            budget = None,
+        ):
             if repo_id == "evilorg/evilrepo":
                 return [
                     "from .helper import run\n",
@@ -5466,27 +5474,49 @@ class TestPaginationOriginNormalizesDefaultPorts:
             # The bug: an endpoint's own authority spelled with its default port.
             ("https://mirror.internal", "https://mirror.internal:443/api/x", True, "https default"),
             ("http://mirror.internal", "http://mirror.internal:80/api/x", True, "http default"),
-            ("https://mirror.internal:443", "https://mirror.internal/api/x", True, "other way round"),
+            (
+                "https://mirror.internal:443",
+                "https://mirror.internal/api/x",
+                True,
+                "other way round",
+            ),
             # Negative controls: normalizing the default port must not widen the guard.
             ("https://mirror.internal", "https://mirror.internal:8443/api/x", False, "other port"),
-            ("https://mirror.internal:8443", "https://mirror.internal/api/x", False, "port dropped"),
-            ("https://mirror.internal", "http://mirror.internal:443/api/x", False, "scheme differs"),
+            (
+                "https://mirror.internal:8443",
+                "https://mirror.internal/api/x",
+                False,
+                "port dropped",
+            ),
+            (
+                "https://mirror.internal",
+                "http://mirror.internal:443/api/x",
+                False,
+                "scheme differs",
+            ),
             ("https://mirror.internal", "https://evil.example:443/api/x", False, "other host"),
-            ("https://mirror.internal", "https://mirror.internal.evil.example/api", False, "suffix"),
+            (
+                "https://mirror.internal",
+                "https://mirror.internal.evil.example/api",
+                False,
+                "suffix",
+            ),
             # ``hostname`` drops userinfo, so it must be rejected before the compare: urllib
             # sends the whole ``user@host`` string as the connection host.
             ("https://mirror.internal", "https://mirror.internal@evil.example/api", False, "decoy"),
-            ("https://mirror.internal", "https://evil.example@mirror.internal/api", False, "userinfo"),
+            (
+                "https://mirror.internal",
+                "https://evil.example@mirror.internal/api",
+                False,
+                "userinfo",
+            ),
             # A port that ``urlsplit`` refuses to parse must not raise out of the guard.
             ("https://mirror.internal", "https://mirror.internal:notaport/api", False, "bad port"),
             ("https://mirror.internal", "https://mirror.internal:99999/api", False, "port range"),
         ],
     )
-    def test_origin_predicate_uses_effective_port(
-        self, monkeypatch, endpoint, url, expected, why
-    ):
+    def test_origin_predicate_uses_effective_port(self, monkeypatch, endpoint, url, expected, why):
         import utils.transformers_version as tv
-
         monkeypatch.setenv("HF_ENDPOINT", endpoint)
         assert tv._is_same_hub_origin(url) is expected, why
 
@@ -5499,9 +5529,7 @@ class TestPaginationOriginNormalizesDefaultPorts:
 
         def _urlopen(req, timeout = 10):
             if "cursor=2" in req.full_url:
-                return _PagedResponse(
-                    json.dumps([{"type": "file", "path": "b.py"}]).encode()
-                )
+                return _PagedResponse(json.dumps([{"type": "file", "path": "b.py"}]).encode())
             return _PagedResponse(
                 json.dumps([{"type": "file", "path": "a.py"}]).encode(),
                 # Same origin, spelled with the port the scheme already implies.
@@ -5548,7 +5576,7 @@ class TestLinkRelIsFoundAtAnyParameterPosition:
         [
             (f'<{_NEXT}>; rel="next"', _NEXT, "the shape the real Hub sends"),
             (f'<{_NEXT}>; type="application/json"; rel="next"', _NEXT, "rel is not first"),
-            (f'<{_NEXT}>; rel=next', _NEXT, "rel as an unquoted token"),
+            (f"<{_NEXT}>; rel=next", _NEXT, "rel as an unquoted token"),
             (f'<{_NEXT}>; rel="prev next"', _NEXT, "rel holds a relation list"),
             (f'<{_NEXT}>; rel="NEXT"', _NEXT, "relation types are case-insensitive"),
             (f'<{_NEXT}>; title="a,b"; rel="next"', _NEXT, "comma inside a quoted value"),
@@ -5559,19 +5587,17 @@ class TestLinkRelIsFoundAtAnyParameterPosition:
             ('<https://h/p>; rel="nextpage"', None, "relation must not substring-match"),
             ('<https://h/p>; type="next"', None, "next as some other parameter's value"),
             ('<https://h/p>; rel="prev"; rel="next"', None, "only the first rel counts"),
-            ('<https://h/p>', None, "entry with no parameters"),
+            ("<https://h/p>", None, "entry with no parameters"),
             ("", None, "empty header"),
             ("garbage", None, "unparseable header"),
         ],
     )
     def test_parse_link_next(self, header, expected, why):
         import utils.transformers_version as tv
-
         assert tv._parse_link_next(header) == expected, why
 
     def test_no_header_is_the_last_page(self):
         import utils.transformers_version as tv
-
         assert tv._parse_link_next(None) is None
 
     def test_later_page_marker_is_not_truncated_away(self, monkeypatch):
@@ -5582,7 +5608,11 @@ class TestLinkRelIsFoundAtAnyParameterPosition:
         monkeypatch.delenv("HF_ENDPOINT", raising = False)
 
         class _Resp:
-            def __init__(self, payload, link = None):
+            def __init__(
+                self,
+                payload,
+                link = None,
+            ):
                 self._payload = payload
                 self.headers = {"Link": link} if link else {}
 
@@ -5625,32 +5655,36 @@ class TestPublicReExportOf5xSymbolIsRecognized:
             ("from transformers import TokenizersBackend\n", True, "public re-export"),
             (
                 "from transformers import AutoModel, TokenizersBackend\n",
-                True, "public re-export beside a 4.x name",
+                True,
+                "public re-export beside a 4.x name",
             ),
             (_V5_TOK_IMPORT, True, "defining submodule still matches"),
             (
                 "import importlib\nTB = importlib.import_module('transformers').TokenizersBackend\n",
-                False, "attribute access is not an import of the symbol",
+                False,
+                "attribute access is not an import of the symbol",
             ),
             # Negative controls: only 5.x-only names may promote the tier.
             ("from transformers import AutoModel\n", False, "4.57.x public name"),
             (
                 "from transformers import PreTrainedTokenizerFast\n",
-                False, "re-exported by 5.x from the same module but present in 4.57.x",
+                False,
+                "re-exported by 5.x from the same module but present in 4.57.x",
             ),
             (
                 '"""Docs mention transformers.TokenizersBackend."""\nimport torch\n',
-                False, "a docstring is not an import",
+                False,
+                "a docstring is not an import",
             ),
             (
                 "from .transformers import TokenizersBackend\n",
-                False, "a repo's own same-named helper is relative",
+                False,
+                "a repo's own same-named helper is relative",
             ),
         ],
     )
     def test_marker_match(self, src, expected, why):
         import utils.transformers_version as tv
-
         got = tv._remote_auto_map_py_matches(tv._TRANSFORMERS_5_REMOTE_IMPORT_MARKERS, [src])
         assert got is expected, why
 
@@ -5678,11 +5712,13 @@ class TestRemoteScanDownloadsAreBounded:
         advertised = tv._REMOTE_SCAN_MAX_FILES * 10
         fetched = []
         monkeypatch.setattr(
-            tv, "_list_hub_repo_py_files",
+            tv,
+            "_list_hub_repo_py_files",
             lambda repo, tok = None: ({f"m{i:05d}.py" for i in range(advertised)}, True),
         )
         monkeypatch.setattr(
-            tv, "_read_repo_text_file",
+            tv,
+            "_read_repo_text_file",
             lambda repo, fn, tok = None: (fetched.append(fn), "import torch\n")[1],
         )
         budget = tv._RemoteScanBudget()
@@ -5700,11 +5736,13 @@ class TestRemoteScanDownloadsAreBounded:
         chunk = "x" * (tv._REMOTE_SCAN_MAX_TOTAL_CHARS // 4)
         fetched = []
         monkeypatch.setattr(
-            tv, "_list_hub_repo_py_files",
+            tv,
+            "_list_hub_repo_py_files",
             lambda repo, tok = None: ({f"m{i:03d}.py" for i in range(64)}, True),
         )
         monkeypatch.setattr(
-            tv, "_read_repo_text_file",
+            tv,
+            "_read_repo_text_file",
             lambda repo, fn, tok = None: (fetched.append(fn), chunk)[1],
         )
         budget = tv._RemoteScanBudget()
@@ -5717,11 +5755,13 @@ class TestRemoteScanDownloadsAreBounded:
 
         fetched = []
         monkeypatch.setattr(
-            tv, "_list_hub_repo_py_files",
+            tv,
+            "_list_hub_repo_py_files",
             lambda repo, tok = None: ({f"m{i:05d}.py" for i in range(1000)}, True),
         )
         monkeypatch.setattr(
-            tv, "_read_repo_text_file",
+            tv,
+            "_read_repo_text_file",
             lambda repo, fn, tok = None: (fetched.append((repo, fn)), "import torch\n")[1],
         )
         refs = {(f"org/ext{i}", "modeling.py") for i in range(5)}
@@ -5760,11 +5800,14 @@ class TestRemoteScanDownloadsAreBounded:
 
         src = "import torch\n" * 20_000  # ~260 KiB, above the largest real single file
         monkeypatch.setattr(
-            tv, "_list_hub_repo_py_files",
+            tv,
+            "_list_hub_repo_py_files",
             lambda repo, tok = None: ({f"m{i:02d}.py" for i in range(26)}, True),
         )
         monkeypatch.setattr(
-            tv, "_read_repo_text_file", lambda repo, fn, tok = None: src,
+            tv,
+            "_read_repo_text_file",
+            lambda repo, fn, tok = None: src,
         )
         budget = tv._RemoteScanBudget()
         sources, complete = tv._fetch_hub_py_sources("org/big-but-real", None, budget)
@@ -5775,11 +5818,14 @@ class TestRemoteScanDownloadsAreBounded:
         import utils.transformers_version as tv
 
         monkeypatch.setattr(
-            tv, "_list_hub_repo_py_files",
+            tv,
+            "_list_hub_repo_py_files",
             lambda repo, tok = None: ({f"m{i:04d}.py" for i in range(300)}, True),
         )
         monkeypatch.setattr(
-            tv, "_read_repo_text_file", lambda repo, fn, tok = None: "import torch\n",
+            tv,
+            "_read_repo_text_file",
+            lambda repo, fn, tok = None: "import torch\n",
         )
         sources, complete = tv._fetch_hub_py_sources("org/m", None)
         assert len(sources) == 300 and complete is True

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -37,6 +37,7 @@ from utils.transformers_version import (
     _check_tokenizer_config_needs_v5,
     _check_config_needs_510,
     _check_remote_auto_map_needs_510,
+    _remote_auto_map_tier,
     _check_config_needs_530,
     _check_config_needs_550,
     _config_needs_510,
@@ -555,8 +556,8 @@ class TestCheckConfigNeeds510:
 
         assert _check_config_needs_510(str(tmp_path)) is True
 
-    def test_remote_modeling_auto_map_needs_510(self, tmp_path: Path):
-        """Unknown architectures with 5.10-only remote imports should return True."""
+    def test_remote_modeling_auto_map_needs_the_5_3_floor(self, tmp_path: Path):
+        """Unknown architectures importing a module absent from 4.57.x take the 5.3 floor."""
         _remote_auto_map_tier_cache.clear()
         cfg = {
             "model_type": "custom_remote",
@@ -567,8 +568,8 @@ class TestCheckConfigNeeds510:
             "from transformers.utils.output_capturing import capture_outputs\n"
         )
 
-        assert _check_remote_auto_map_needs_510(str(tmp_path)) is True
-        assert _check_config_needs_510(str(tmp_path)) is True
+        assert _remote_auto_map_tier(str(tmp_path))[0] == "530"
+        assert _check_config_needs_510(str(tmp_path)) is False
 
     def test_offline_hub_remote_auto_map_not_cached(self, monkeypatch):
         """Offline Hub scan negatives must not poison a later online read."""
@@ -689,8 +690,8 @@ class TestCheckConfigNeeds510:
             "_remote_auto_map_py_contents",
             lambda *a, **k: (["from transformers.utils.output_capturing import X\n"], True),
         )
-        assert _check_remote_auto_map_needs_510("org/custom-remote") is True
-        assert _check_config_needs_510("org/custom-remote") is True
+        assert _remote_auto_map_tier("org/custom-remote") == ("530", True)
+        assert _check_config_needs_510("org/custom-remote") is False
 
     def test_gemma4_non_unified_returns_false(self, tmp_path: Path):
         """Older Gemma 4 config should stay on the 550 tier."""
@@ -1058,7 +1059,7 @@ class TestGetTransformersTier:
 
         assert get_transformers_tier(str(tmp_path)) == "default"
 
-    def test_local_custom_remote_auto_map_returns_510(self, tmp_path: Path):
+    def test_local_custom_remote_auto_map_returns_530(self, tmp_path: Path):
         """Local unknown model_types must scan auto_map before default (#7353 Codex)."""
         cfg = {
             "model_type": "custom_remote",
@@ -1069,9 +1070,9 @@ class TestGetTransformersTier:
             "from transformers.utils.output_capturing import capture_outputs\n"
         )
 
-        assert get_transformers_tier(str(tmp_path)) == "510"
+        assert get_transformers_tier(str(tmp_path), probe = False) == "530"
 
-    def test_local_helper_auto_map_returns_510(self, tmp_path: Path):
+    def test_local_helper_auto_map_returns_530(self, tmp_path: Path):
         """Helper modules imported by auto_map entry must be scanned (Codex #4)."""
         cfg = {
             "model_type": "custom_remote",
@@ -1085,9 +1086,9 @@ class TestGetTransformersTier:
             "from transformers.utils.output_capturing import capture_outputs\n"
         )
 
-        assert get_transformers_tier(str(tmp_path)) == "510"
+        assert get_transformers_tier(str(tmp_path), probe = False) == "530"
 
-    def test_external_auto_map_repo_returns_510(self, monkeypatch, tmp_path: Path):
+    def test_external_auto_map_repo_returns_530(self, monkeypatch, tmp_path: Path):
         """External auto_map repos and their helpers must be scanned (Codex #4)."""
         import utils.transformers_version as tv
 
@@ -1109,9 +1110,9 @@ class TestGetTransformersTier:
 
         monkeypatch.setattr(tv, "_fetch_hub_py_sources", _fake_fetch)
 
-        assert get_transformers_tier(str(tmp_path)) == "510"
+        assert get_transformers_tier(str(tmp_path), probe = False) == "530"
 
-    def test_local_lower_tier_model_type_with_auto_map_returns_510(self, tmp_path: Path):
+    def test_local_lower_tier_model_type_with_auto_map_still_scans(self, tmp_path: Path):
         """Lower-tier model_type must not skip auto_map scan (Codex round 2)."""
         cfg = {
             "model_type": "qwen3_moe",
@@ -1122,10 +1123,11 @@ class TestGetTransformersTier:
             "from transformers.utils.output_capturing import capture_outputs\n"
         )
 
-        assert get_transformers_tier(str(tmp_path)) == "510"
+        assert _remote_auto_map_tier(str(tmp_path))[0] == "530"
+        assert get_transformers_tier(str(tmp_path), probe = False) == "530"
 
-    def test_name_substring_upgraded_by_remote_auto_map(self, monkeypatch):
-        """Name fast path must upgrade when auto_map needs 5.10 (Codex round 2)."""
+    def test_name_substring_not_downgraded_by_remote_auto_map(self, monkeypatch):
+        """Name fast path keeps its tier once the auto_map scan agrees (Codex round 2)."""
         import utils.transformers_version as tv
 
         cfg = {
@@ -1158,7 +1160,7 @@ class TestGetTransformersTier:
         monkeypatch.setattr(tv, "_read_repo_text_file", _fake_read)
         _remote_auto_map_tier_cache.clear()
 
-        assert get_transformers_tier("org/qwen3.5-custom-remote") == "510"
+        assert get_transformers_tier("org/qwen3.5-custom-remote") == "530"
 
     def test_tier_detection_does_not_import_huggingface_hub(self, monkeypatch, tmp_path: Path):
         """Pre-activation tier scan must stay on stdlib urllib (Codex round 2)."""
@@ -1190,7 +1192,7 @@ class TestGetTransformersTier:
             return real_import(name, globals, locals, fromlist, level)
 
         monkeypatch.setattr(builtins, "__import__", _guarded_import)
-        assert get_transformers_tier(str(tmp_path)) == "510"
+        assert get_transformers_tier(str(tmp_path), probe = False) == "530"
 
     def test_gemma4_substring_returns_550(self):
         assert get_transformers_tier("google/gemma-4-E2B-it") == "550"
@@ -3616,21 +3618,21 @@ class TestRemoteImportSpellings:
         _config_json_cache.clear()
         _remote_auto_map_tier_cache.clear()
 
-    def test_parent_package_import_returns_510(self, tmp_path: Path):
+    def test_parent_package_import_returns_530(self, tmp_path: Path):
         """``from transformers.utils import output_capturing`` loads the same module."""
         _auto_map_checkpoint(tmp_path, "from transformers.utils import output_capturing\n")
-        assert get_transformers_tier(str(tmp_path)) == "510"
+        assert get_transformers_tier(str(tmp_path), probe = False) == "530"
 
-    def test_parenthesized_multiline_import_returns_510(self, tmp_path: Path):
+    def test_parenthesized_multiline_import_returns_530(self, tmp_path: Path):
         _auto_map_checkpoint(
             tmp_path,
             "from transformers.utils import (\n    logging,\n    output_capturing,\n)\n",
         )
-        assert get_transformers_tier(str(tmp_path)) == "510"
+        assert get_transformers_tier(str(tmp_path), probe = False) == "530"
 
-    def test_aliased_parent_import_returns_510(self, tmp_path: Path):
+    def test_aliased_parent_import_returns_530(self, tmp_path: Path):
         _auto_map_checkpoint(tmp_path, "from transformers.utils import output_capturing as oc\n")
-        assert get_transformers_tier(str(tmp_path)) == "510"
+        assert get_transformers_tier(str(tmp_path), probe = False) == "530"
 
     def test_parent_package_alone_stays_default(self, tmp_path: Path):
         """``from transformers import utils`` does not pull the 5.x-only submodule."""
@@ -3646,7 +3648,7 @@ class TestRemoteImportSpellings:
     def test_unparseable_source_still_matched_by_line_scan(self, tmp_path: Path):
         """A syntax error must not silently downgrade the tier."""
         _auto_map_checkpoint(tmp_path, _V5_IMPORT + "def broken(:\n")
-        assert get_transformers_tier(str(tmp_path)) == "510"
+        assert get_transformers_tier(str(tmp_path), probe = False) == "530"
 
     def test_tokenizer_parent_package_import_returns_v5(self, tmp_path: Path):
         (tmp_path / "config.json").write_text(json.dumps({"model_type": "plain_thing"}))
@@ -3682,29 +3684,29 @@ class TestLocalScanCacheFreshness:
                 }
             )
         )
-        assert get_transformers_tier(str(tmp_path)) == "default"
+        assert get_transformers_tier(str(tmp_path), probe = False) == "default"
         (tmp_path / "modeling_custom.py").write_text(_V5_IMPORT)
-        assert get_transformers_tier(str(tmp_path)) == "510"
+        assert get_transformers_tier(str(tmp_path), probe = False) == "530"
 
     def test_rescanned_when_entry_file_replaced(self, tmp_path: Path):
         _auto_map_checkpoint(
             tmp_path, "from transformers.modeling_layers import GradientCheckpointingLayer\n"
         )
-        assert get_transformers_tier(str(tmp_path)) == "default"
+        assert get_transformers_tier(str(tmp_path), probe = False) == "default"
         (tmp_path / "modeling_custom.py").write_text(_V5_IMPORT)
-        assert get_transformers_tier(str(tmp_path)) == "510"
+        assert get_transformers_tier(str(tmp_path), probe = False) == "530"
 
     def test_unchanged_checkpoint_is_served_from_cache(self, tmp_path: Path, monkeypatch):
         import utils.transformers_version as tv
 
         _auto_map_checkpoint(tmp_path, _V5_IMPORT)
-        assert get_transformers_tier(str(tmp_path)) == "510"
+        assert get_transformers_tier(str(tmp_path), probe = False) == "530"
         monkeypatch.setattr(
             tv,
             "_remote_auto_map_py_contents",
             lambda *a, **k: (_ for _ in ()).throw(AssertionError("rescanned unchanged files")),
         )
-        assert get_transformers_tier(str(tmp_path)) == "510"
+        assert get_transformers_tier(str(tmp_path), probe = False) == "530"
 
     def test_tokenizer_scan_not_cached_while_entry_file_missing(self, tmp_path: Path):
         (tmp_path / "tokenizer_config.json").write_text(
@@ -3796,7 +3798,7 @@ class TestProbeFalseSkipsAutoMapScan:
             mock_url.assert_not_called()
         assert needs_transformers_5("Qwen/Qwen3.5-9B") is True
 
-    def test_probe_true_still_upgrades_to_510(self, monkeypatch):
+    def test_probe_true_still_runs_the_auto_map_scan(self, monkeypatch):
         import utils.transformers_version as tv
 
         monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
@@ -3811,7 +3813,8 @@ class TestProbeFalseSkipsAutoMapScan:
             tv, "_list_hub_repo_py_files", lambda repo, tok = None: ({"modeling_custom.py"}, True)
         )
         monkeypatch.setattr(tv, "_read_repo_text_file", lambda m, fn, tok = None: _V5_IMPORT)
-        assert get_transformers_tier("org/qwen3.5-remote", probe = True) == "510"
+        assert get_transformers_tier("org/qwen3.5-remote", probe = True) == "530"
+        assert _remote_auto_map_tier_cache  # probe=True really did scan the repo
 
 
 class _PagedResponse:
@@ -3949,7 +3952,7 @@ class TestUnreadableAutoMapConfigIsInconclusive:
 
         state["up"] = True
         _config_json_cache.clear()
-        assert tv._remote_auto_map_scan_result("org/custom-remote") == (True, True)
+        assert tv._remote_auto_map_tier("org/custom-remote") == ("530", True)
 
     def test_missing_config_is_still_a_definitive_negative(self, monkeypatch, tmp_path):
         """Negative control: a real 404 is an answer, so the negative may be cached."""
@@ -3999,7 +4002,7 @@ class TestProcessorOnlyAutoMapIsScanned:
             raise _http_error(url, 404)
 
         monkeypatch.setattr("urllib.request.urlopen", _urlopen)
-        assert tv._check_remote_auto_map_needs_510("org/vlm-remote") is True
+        assert tv._remote_auto_map_tier("org/vlm-remote")[0] == "530"
 
     def test_repo_without_any_auto_map_fetches_no_py(self, monkeypatch, tmp_path):
         """Negative control: no auto_map anywhere means no listing and no .py fetches."""
@@ -4054,7 +4057,7 @@ class TestScanPrerequisiteConfigHonorsHfEndpoint:
 
         monkeypatch.setattr("urllib.request.urlopen", _urlopen)
         assert tv._load_config_json("org/custom-remote") is not None
-        assert tv._check_remote_auto_map_needs_510("org/custom-remote") is True
+        assert tv._remote_auto_map_tier("org/custom-remote")[0] == "530"
 
     def test_default_endpoint_unchanged(self, monkeypatch, tmp_path):
         """Negative control: without HF_ENDPOINT the canonical host is still used."""
@@ -4099,7 +4102,7 @@ class TestRemoteSourceEncoding:
         text = tv._read_repo_text_file("org/custom-remote", "modeling_custom.py")
         assert text is not None
         assert "output_capturing" in text
-        assert tv._remote_auto_map_py_matches(tv._TRANSFORMERS_510_REMOTE_IMPORT_MARKERS, [text])
+        assert tv._remote_auto_map_py_matches(tv._TRANSFORMERS_5_REMOTE_IMPORT_MARKERS, [text])
 
     def test_undeclared_binary_still_decodes_without_raising(self, monkeypatch):
         """Negative control: garbage bytes degrade to replacement, never an exception."""
@@ -4132,7 +4135,7 @@ class TestImportScanIgnoresNonImportText:
 
     def _matches(self, src: str) -> bool:
         import utils.transformers_version as tv
-        return tv._remote_auto_map_py_matches(tv._TRANSFORMERS_510_REMOTE_IMPORT_MARKERS, [src])
+        return tv._remote_auto_map_py_matches(tv._TRANSFORMERS_5_REMOTE_IMPORT_MARKERS, [src])
 
     def test_marker_in_docstring_does_not_match(self):
         src = (
@@ -4233,21 +4236,21 @@ class TestScanSignatureCoversAutoMapConfigs:
         (tmp_path / "preprocessor_config.json").write_text(
             json.dumps({"auto_map": {"AutoProcessor": "processing_custom.CustomProcessor"}})
         )
-        assert _check_remote_auto_map_needs_510(str(tmp_path)) is True
+        assert _remote_auto_map_tier(str(tmp_path))[0] == "530"
 
     def test_unrelated_file_still_serves_the_cache(self, monkeypatch, tmp_path: Path):
         """Negative control: only .py and auto_map configs may bust the scan cache."""
         import utils.transformers_version as tv
 
         _auto_map_checkpoint(tmp_path, _V5_IMPORT)
-        assert _check_remote_auto_map_needs_510(str(tmp_path)) is True
+        assert _remote_auto_map_tier(str(tmp_path))[0] == "530"
         (tmp_path / "generation_config.json").write_text(json.dumps({"do_sample": True}))
         monkeypatch.setattr(
             tv,
             "_remote_auto_map_py_contents",
             lambda *a, **k: (_ for _ in ()).throw(AssertionError("rescanned unchanged inputs")),
         )
-        assert _check_remote_auto_map_needs_510(str(tmp_path)) is True
+        assert _remote_auto_map_tier(str(tmp_path))[0] == "530"
 
 
 class TestTokenizerScanCacheFreshness:
@@ -4378,7 +4381,11 @@ class TestProbeFalseSkipsConfigFallbackScan:
         urls = self._hub(monkeypatch, tmp_path)
         assert get_transformers_tier("org/custom-remote", probe = False) == "default"
         assert ("org/custom-remote", None) not in _config_needs_510_cache
-        assert get_transformers_tier("org/custom-remote", probe = True) == "510"
+        monkeypatch.setattr(
+            "utils.transformers_version._probe_tier",
+            lambda m, t, reason, **kw: kw.get("floor", "530"),
+        )
+        assert get_transformers_tier("org/custom-remote", probe = True) == "530"
         assert [u for u in urls if u.endswith(".py")]  # the activation path did scan
 
 
@@ -4438,7 +4445,7 @@ class TestPartialHubFetchKeepsProof:
         import utils.transformers_version as tv
 
         self._hub(monkeypatch, tmp_path, {"a_modeling.py": _V5_IMPORT, "z_helper.py": None})
-        assert tv._remote_auto_map_scan_result("org/multi-file") == (True, False)
+        assert tv._remote_auto_map_tier("org/multi-file") == ("530", False)
         assert not _remote_auto_map_tier_cache  # incomplete, so nothing memoized
 
     def test_partial_fetch_without_the_marker_stays_inconclusive(self, monkeypatch, tmp_path):
@@ -4486,7 +4493,7 @@ class TestLocalConfigRewriteIsRescanned:
         (ckpt / "config.json").write_text(
             json.dumps({"model_type": "llama", "auto_map": {"AutoModel": "modeling_custom.Model"}})
         )
-        assert tv._check_remote_auto_map_needs_510(str(ckpt)) is True
+        assert tv._remote_auto_map_tier(str(ckpt))[0] == "530"
 
     def test_rewrite_that_declares_no_auto_map_stays_negative(self, tmp_path):
         """Negative control: re-reading the config must not invent remote code."""
@@ -4547,15 +4554,15 @@ class TestAutoMapImportsOf5xTokenizerBackend:
         )
         assert get_transformers_tier(str(ckpt), probe = False) == "default"
 
-    def test_510_marker_still_outranks_the_tokenizer_backend_marker(self, tmp_path):
-        """Negative control: the 5.10 classification keeps priority."""
+    def test_both_5x_markers_agree_on_the_5_3_floor(self, tmp_path):
+        """Negative control: two 5.x markers in one file still resolve one tier."""
         ckpt = self._ckpt(
             tmp_path,
             "both-markers",
             _V5_IMPORT + _V5_TOKENIZER_IMPORT,
             {"tokenizer_class": "LlamaTokenizer"},
         )
-        assert get_transformers_tier(str(ckpt), probe = False) == "510"
+        assert get_transformers_tier(str(ckpt), probe = False) == "530"
 
     def test_needs_510_helper_keeps_its_510_only_meaning(self, tmp_path):
         """Negative control: the 5.x tokenizer marker is not a 5.10 answer."""
@@ -4600,7 +4607,7 @@ class TestTypeCheckingImportsAreNotRuntimeImports:
     @pytest.mark.parametrize("src", [_GUARD, _GUARD_QUALIFIED])
     def test_type_only_import_does_not_promote(self, src):
         import utils.transformers_version as tv
-        markers = tv._TRANSFORMERS_510_REMOTE_IMPORT_MARKERS
+        markers = tv._TRANSFORMERS_5_REMOTE_IMPORT_MARKERS
         assert tv._remote_auto_map_py_matches(markers, [src]) is False
 
     @pytest.mark.parametrize("src", [_V5_IMPORT, _ELSE_BRANCH, _NEGATED_GUARD])
@@ -4608,14 +4615,14 @@ class TestTypeCheckingImportsAreNotRuntimeImports:
         """Negative control: only the guard's own body is dropped."""
         import utils.transformers_version as tv
 
-        markers = tv._TRANSFORMERS_510_REMOTE_IMPORT_MARKERS
+        markers = tv._TRANSFORMERS_5_REMOTE_IMPORT_MARKERS
         assert tv._remote_auto_map_py_matches(markers, [src]) is True
 
     def test_unparseable_source_still_falls_back_to_the_line_scan(self):
         """Negative control: source ``ast`` cannot read is never a silent negative."""
         import utils.transformers_version as tv
 
-        markers = tv._TRANSFORMERS_510_REMOTE_IMPORT_MARKERS
+        markers = tv._TRANSFORMERS_5_REMOTE_IMPORT_MARKERS
         assert tv._remote_auto_map_py_matches(markers, [self._GUARD + "def broken(:\n"]) is True
 
     def test_unparseable_and_import_free_stay_distinct(self):
@@ -4631,3 +4638,277 @@ class TestTypeCheckingImportsAreNotRuntimeImports:
 
         names = tv._parsed_dotted_imports(self._GUARD + _V5_IMPORT)
         assert "transformers.utils.output_capturing" in names
+
+
+class TestOutputCapturingTakesThe53Floor:
+    """``transformers.utils.output_capturing`` ships since 5.2.0, so the 5.3 sidecar can
+    import it and the marker must not force the 5.10 one (round 5 Codex)."""
+
+    def setup_method(self):
+        _clear_scan_caches()
+
+    def test_marker_resolves_the_5_3_floor(self, tmp_path: Path):
+        _auto_map_checkpoint(tmp_path, _V5_IMPORT)
+        assert _remote_auto_map_tier(str(tmp_path)) == ("530", True)
+        assert _check_remote_auto_map_needs_510(str(tmp_path)) is False
+
+    def test_marker_is_classified_with_the_other_5x_modules(self):
+        import utils.transformers_version as tv
+
+        assert "transformers.utils.output_capturing" in tv._TRANSFORMERS_5_REMOTE_IMPORT_MARKERS
+        assert "transformers.utils.output_capturing" not in (
+            tv._TRANSFORMERS_510_REMOTE_IMPORT_MARKERS
+        )
+
+    def test_astral_still_reaches_510_by_architecture(self, tmp_path: Path):
+        """Negative control: #7353's model routes on its architecture, not on this import."""
+        (tmp_path / "config.json").write_text(
+            json.dumps(
+                {
+                    "architectures": ["AstralForCausalLM"],
+                    "model_type": "astral",
+                    "auto_map": {"AutoModelForCausalLM": "modeling_astral.AstralForCausalLM"},
+                }
+            )
+        )
+        (tmp_path / "modeling_astral.py").write_text(_V5_IMPORT)
+        assert get_transformers_tier(str(tmp_path)) == "510"
+
+    def test_empty_marker_tuple_never_matches(self):
+        """Negative control: an empty marker set is a negative, not a match-everything."""
+        import utils.transformers_version as tv
+
+        assert tv._remote_auto_map_py_matches((), [_V5_IMPORT]) is False
+        assert tv._remote_auto_map_py_matches((), ["def broken(:\n"]) is False
+
+
+class TestHubPaginationStaysOnTheConfiguredOrigin:
+    """A ``rel="next"`` cursor is refetched with the caller's ``Authorization`` header, so it
+    must never leave the configured endpoint (round 5 Codex)."""
+
+    def setup_method(self):
+        _clear_scan_caches()
+
+    @staticmethod
+    def _page(paths, next_url = None):
+        payload = json.dumps([{"type": "file", "path": p} for p in paths]).encode()
+        return _PagedResponse(payload, next_url = next_url)
+
+    def test_cross_origin_cursor_is_not_followed(self, monkeypatch):
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setenv("HF_ENDPOINT", "https://hub.internal")
+        seen = []
+
+        def _urlopen(req, timeout = 10):
+            seen.append((req.full_url, req.headers.get("Authorization")))
+            return self._page(
+                ["a.py"], next_url = "https://evil.example/api/models/x/tree/main?cursor=2"
+            )
+
+        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        assert tv._hf_api_get_json("/api/models/org/m/tree/main", "hf_secret") == (None, False)
+        assert [url for url, _ in seen] == ["https://hub.internal/api/models/org/m/tree/main"]
+        assert not any("evil.example" in url for url, _ in seen)
+
+    def test_same_origin_cursor_is_still_followed(self, monkeypatch):
+        """Negative control: real Hub pagination is absolute and same-origin."""
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.delenv("HF_ENDPOINT", raising = False)
+        seen = []
+
+        def _urlopen(req, timeout = 10):
+            seen.append(req.full_url)
+            if "cursor=2" in req.full_url:
+                return self._page(["b.py"])
+            return self._page(
+                ["a.py"],
+                next_url = "https://huggingface.co/api/models/org/m/tree/main?cursor=2",
+            )
+
+        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        data, ok = tv._hf_api_get_json("/api/models/org/m/tree/main", "hf_secret")
+        assert ok is True
+        assert [item["path"] for item in data] == ["a.py", "b.py"]
+        assert len(seen) == 2
+
+    def test_mirror_may_paginate_within_itself(self, monkeypatch):
+        """Negative control: HF_ENDPOINT deployments keep working."""
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
+        monkeypatch.setenv("HF_ENDPOINT", "https://mirror.internal")
+
+        def _urlopen(req, timeout = 10):
+            if "cursor=2" in req.full_url:
+                return self._page(["b.py"])
+            return self._page(
+                ["a.py"], next_url = "https://mirror.internal/api/models/org/m/tree?cursor=2"
+            )
+
+        monkeypatch.setattr("urllib.request.urlopen", _urlopen)
+        data, ok = tv._hf_api_get_json("/api/models/org/m/tree", None)
+        assert ok is True and len(data) == 2
+
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            ("https://huggingface.co/api/models/x", True),
+            ("https://HuggingFace.CO/api/models/x", True),
+            ("http://huggingface.co/api/models/x", False),  # scheme downgrade
+            ("https://huggingface.co.evil.example/api", False),
+            ("https://evil.example/api", False),
+            ("file:///etc/passwd", False),
+            ("//huggingface.co/api", False),  # protocol-relative
+        ],
+    )
+    def test_origin_predicate(self, monkeypatch, url, expected):
+        import utils.transformers_version as tv
+
+        monkeypatch.delenv("HF_ENDPOINT", raising = False)
+        assert tv._is_same_hub_origin(url) is expected
+
+
+class TestOfflineAutoMapScanUsesTheHubCache:
+    """Offline, a downloaded snapshot is exactly the code that will be executed, so it must
+    be scanned instead of assumed clean (round 5 Codex)."""
+
+    def setup_method(self):
+        _clear_scan_caches()
+
+    @staticmethod
+    def _snapshot(hub: Path, repo: str, modeling_src: str, auto_map: bool = True):
+        repo_dir = hub / ("models--" + repo.replace("/", "--"))
+        snap = repo_dir / "snapshots" / "deadbeef"
+        snap.mkdir(parents = True)
+        cfg: dict = {"model_type": "custom_remote"}
+        if auto_map:
+            cfg["auto_map"] = {"AutoModelForCausalLM": "modeling_custom.CustomForCausalLM"}
+        (snap / "config.json").write_text(json.dumps(cfg))
+        (snap / "modeling_custom.py").write_text(modeling_src)
+        (repo_dir / "refs").mkdir(parents = True)
+        (repo_dir / "refs" / "main").write_text("deadbeef")
+        return snap
+
+    def test_cached_snapshot_is_scanned(self, monkeypatch, tmp_path: Path):
+        import utils.transformers_version as tv
+
+        self._snapshot(tmp_path, "org/cached-5x", _V5_IMPORT)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+        tier, definitive = tv._remote_auto_map_tier("org/cached-5x")
+        assert tier == "530"
+        # Offline can never reach an external auto_map repo, so the answer stays provisional
+        # and nothing is memoized under the Hub id.
+        assert definitive is False
+        assert not [key for key in _remote_auto_map_tier_cache if key[0] == "org/cached-5x"]
+
+    def test_uncached_hub_id_still_inconclusive(self, monkeypatch, tmp_path: Path):
+        """Negative control: nothing downloaded means nothing to scan."""
+        import utils.transformers_version as tv
+
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+        assert tv._remote_auto_map_tier("org/never-downloaded") == ("default", False)
+
+    def test_cached_snapshot_without_the_marker_stays_default(self, monkeypatch, tmp_path: Path):
+        """Negative control: scanning the cache must not invent a 5.x requirement."""
+        import utils.transformers_version as tv
+
+        self._snapshot(tmp_path, "org/cached-plain", "import torch\n")
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+        assert tv._remote_auto_map_tier("org/cached-plain") == ("default", False)
+
+    def test_cached_snapshot_without_auto_map_stays_default(self, monkeypatch, tmp_path: Path):
+        """Negative control: no auto_map means transformers never executes that .py."""
+        import utils.transformers_version as tv
+
+        self._snapshot(tmp_path, "org/cached-noauto", _V5_IMPORT, auto_map = False)
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+        assert tv._remote_auto_map_tier("org/cached-noauto") == ("default", False)
+
+    def test_local_path_is_not_treated_as_a_hub_id(self, monkeypatch, tmp_path: Path):
+        """Negative control: only a canonical owner/repo maps to a cache directory."""
+        import utils.transformers_version as tv
+
+        monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+        assert tv._hf_cache_snapshot_dir(str(tmp_path)) is None
+        assert tv._hf_cache_snapshot_dir("./org/model") is None
+        assert tv._hf_cache_snapshot_dir("org/sub/model") is None
+
+
+class TestDynamicImportsOfVersionedModules:
+    """Remote code that loads a module through ``importlib`` really does import it, so the
+    scan must see it (round 5 Codex)."""
+
+    MARKERS = ("transformers.tokenization_utils_tokenizers",)
+
+    def setup_method(self):
+        _clear_scan_caches()
+
+    def _matches(self, src: str) -> bool:
+        import utils.transformers_version as tv
+
+        return tv._remote_auto_map_py_matches(self.MARKERS, [src])
+
+    @pytest.mark.parametrize(
+        "src",
+        [
+            'import importlib\n'
+            'm = importlib.import_module("transformers.tokenization_utils_tokenizers")\n',
+            'from importlib import import_module\n'
+            'import_module("transformers.tokenization_utils_tokenizers")\n',
+            '__import__("transformers.tokenization_utils_tokenizers")\n',
+            'import importlib\n'
+            'def load():\n'
+            '    return importlib.import_module("transformers.tokenization_utils_tokenizers")\n',
+            'import importlib\n'
+            'try:\n'
+            '    importlib.import_module("transformers.tokenization_utils_tokenizers")\n'
+            'except ImportError:\n'
+            '    pass\n',
+        ],
+    )
+    def test_constant_string_dynamic_import_promotes(self, src):
+        assert self._matches(src) is True
+
+    @pytest.mark.parametrize(
+        "src",
+        [
+            '"""\nimportlib.import_module("transformers.tokenization_utils_tokenizers")\n"""\n',
+            '# importlib.import_module("transformers.tokenization_utils_tokenizers")\n',
+            'NAME = "transformers.tokenization_utils_tokenizers"\n',
+            'log("transformers.tokenization_utils_tokenizers")\n',
+            'import importlib\nimportlib.import_module("transformers." + suffix)\n',
+            'import importlib\nimportlib.import_module(f"transformers.{mod}")\n',
+            'import importlib\nimportlib.import_module(".tokenization_utils_tokenizers", __package__)\n',
+            'from typing import TYPE_CHECKING\n'
+            'import importlib\n'
+            'if TYPE_CHECKING:\n'
+            '    importlib.import_module("transformers.tokenization_utils_tokenizers")\n',
+        ],
+    )
+    def test_inert_or_computed_names_do_not_promote(self, src):
+        """Negative control: only a literal module name a call really imports counts."""
+        assert self._matches(src) is False
+
+    def test_dynamic_import_reaches_the_tier(self, tmp_path: Path):
+        _auto_map_checkpoint(
+            tmp_path,
+            'import importlib\n'
+            'importlib.import_module("transformers.tokenization_utils_tokenizers")\n',
+        )
+        assert _remote_auto_map_tier(str(tmp_path))[0] == "530"
+
+    def test_unparseable_and_import_free_stay_distinct(self):
+        """Negative control: adding Call handling must not blur the two answers."""
+        import utils.transformers_version as tv
+
+        assert tv._parsed_dotted_imports("def broken(:\n") is None
+        assert tv._parsed_dotted_imports("x = 1\n") == set()
+        assert tv._parsed_dotted_imports('log("transformers.anything")\n') == set()

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -4321,9 +4321,7 @@ class TestScanSignatureSeesSameSizedReplacement:
 
         assert _remote_auto_map_tier(str(tmp_path))[0] == "530"
 
-    def test_untouched_checkpoint_is_still_served_from_cache(
-        self, monkeypatch, tmp_path: Path
-    ):
+    def test_untouched_checkpoint_is_still_served_from_cache(self, monkeypatch, tmp_path: Path):
         """Negative control: the extra fields must not turn every lookup into a re-scan."""
         import utils.transformers_version as tv
 
@@ -4973,9 +4971,7 @@ class TestInconclusiveScanFallsBackToTheHubCache:
         assert definitive is False
         assert not [key for key in _remote_auto_map_tier_cache if key[0] == "org/outage-5x"]
 
-    def test_tree_listing_failure_alone_still_uses_the_snapshot(
-        self, monkeypatch, tmp_path: Path
-    ):
+    def test_tree_listing_failure_alone_still_uses_the_snapshot(self, monkeypatch, tmp_path: Path):
         """Only the repo listing fails; the configs read fine. Still inconclusive."""
         import utils.transformers_version as tv
 
@@ -5023,9 +5019,7 @@ class TestInconclusiveScanFallsBackToTheHubCache:
         monkeypatch.setattr(tv, "_hub_urlopen", self._down)
         assert tv._remote_auto_map_tier("org/outage-plain") == ("default", False)
 
-    def test_definitive_negative_does_not_consult_the_snapshot(
-        self, monkeypatch, tmp_path: Path
-    ):
+    def test_definitive_negative_does_not_consult_the_snapshot(self, monkeypatch, tmp_path: Path):
         """Negative control: a repo that really has no auto_map keeps its cached negative.
 
         A 404 is an answer, so a stale snapshot left over from an older revision must not
@@ -5050,9 +5044,13 @@ class TestInconclusiveScanFallsBackToTheHubCache:
         _auto_map_checkpoint(ckpt, "import torch\n")
         monkeypatch.delenv("HF_HUB_OFFLINE", raising = False)
         monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
-        monkeypatch.setattr(tv, "_hf_cache_snapshot_dir", lambda *a, **k: (_ for _ in ()).throw(
-            AssertionError("local dir consulted the hub cache")
-        ))
+        monkeypatch.setattr(
+            tv,
+            "_hf_cache_snapshot_dir",
+            lambda *a, **k: (_ for _ in ()).throw(
+                AssertionError("local dir consulted the hub cache")
+            ),
+        )
         assert tv._remote_auto_map_tier(str(ckpt))[0] == "default"
 
 

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -4654,7 +4654,6 @@ class TestOutputCapturingTakesThe53Floor:
 
     def test_marker_is_classified_with_the_other_5x_modules(self):
         import utils.transformers_version as tv
-
         assert "transformers.utils.output_capturing" in tv._TRANSFORMERS_5_REMOTE_IMPORT_MARKERS
         assert "transformers.utils.output_capturing" not in (
             tv._TRANSFORMERS_510_REMOTE_IMPORT_MARKERS
@@ -4767,7 +4766,6 @@ class TestHubPaginationStaysOnTheConfiguredOrigin:
     )
     def test_origin_predicate(self, monkeypatch, url, expected):
         import utils.transformers_version as tv
-
         monkeypatch.delenv("HF_ENDPOINT", raising = False)
         assert tv._is_same_hub_origin(url) is expected
 
@@ -4780,7 +4778,12 @@ class TestOfflineAutoMapScanUsesTheHubCache:
         _clear_scan_caches()
 
     @staticmethod
-    def _snapshot(hub: Path, repo: str, modeling_src: str, auto_map: bool = True):
+    def _snapshot(
+        hub: Path,
+        repo: str,
+        modeling_src: str,
+        auto_map: bool = True,
+    ):
         repo_dir = hub / ("models--" + repo.replace("/", "--"))
         snap = repo_dir / "snapshots" / "deadbeef"
         snap.mkdir(parents = True)
@@ -4853,25 +4856,24 @@ class TestDynamicImportsOfVersionedModules:
 
     def _matches(self, src: str) -> bool:
         import utils.transformers_version as tv
-
         return tv._remote_auto_map_py_matches(self.MARKERS, [src])
 
     @pytest.mark.parametrize(
         "src",
         [
-            'import importlib\n'
+            "import importlib\n"
             'm = importlib.import_module("transformers.tokenization_utils_tokenizers")\n',
-            'from importlib import import_module\n'
+            "from importlib import import_module\n"
             'import_module("transformers.tokenization_utils_tokenizers")\n',
             '__import__("transformers.tokenization_utils_tokenizers")\n',
-            'import importlib\n'
-            'def load():\n'
+            "import importlib\n"
+            "def load():\n"
             '    return importlib.import_module("transformers.tokenization_utils_tokenizers")\n',
-            'import importlib\n'
-            'try:\n'
+            "import importlib\n"
+            "try:\n"
             '    importlib.import_module("transformers.tokenization_utils_tokenizers")\n'
-            'except ImportError:\n'
-            '    pass\n',
+            "except ImportError:\n"
+            "    pass\n",
         ],
     )
     def test_constant_string_dynamic_import_promotes(self, src):
@@ -4887,9 +4889,9 @@ class TestDynamicImportsOfVersionedModules:
             'import importlib\nimportlib.import_module("transformers." + suffix)\n',
             'import importlib\nimportlib.import_module(f"transformers.{mod}")\n',
             'import importlib\nimportlib.import_module(".tokenization_utils_tokenizers", __package__)\n',
-            'from typing import TYPE_CHECKING\n'
-            'import importlib\n'
-            'if TYPE_CHECKING:\n'
+            "from typing import TYPE_CHECKING\n"
+            "import importlib\n"
+            "if TYPE_CHECKING:\n"
             '    importlib.import_module("transformers.tokenization_utils_tokenizers")\n',
         ],
     )
@@ -4900,7 +4902,7 @@ class TestDynamicImportsOfVersionedModules:
     def test_dynamic_import_reaches_the_tier(self, tmp_path: Path):
         _auto_map_checkpoint(
             tmp_path,
-            'import importlib\n'
+            "import importlib\n"
             'importlib.import_module("transformers.tokenization_utils_tokenizers")\n',
         )
         assert _remote_auto_map_tier(str(tmp_path))[0] == "530"

--- a/studio/backend/tests/test_worker_activates_correct_transformers.py
+++ b/studio/backend/tests/test_worker_activates_correct_transformers.py
@@ -109,6 +109,74 @@ import transformers
 print(f"RESULT tier={tier} preload={preload} active={transformers.__version__}")
 """
 
+# Astral (#7353): custom-code checkpoints must activate the 5.10 sidecar, not default 4.57.x.
+# Uses a local stub checkpoint (no Hub fetch) with the same worker preflight + activation path.
+_SNIPPET_ASTRAL_510 = r"""
+import json, os, sys
+sys.path.insert(0, os.getcwd())
+
+try:
+    import torch  # noqa: F401
+    _sp = os.environ.get("SPOOF_PATH")
+    if _sp and os.path.exists(_sp):
+        import importlib.util
+        _spec = importlib.util.spec_from_file_location("_zoo_aggressive_cuda_spoof", _sp)
+        _mod = importlib.util.module_from_spec(_spec)
+        _spec.loader.exec_module(_mod)
+        _mod.apply()
+    else:
+        torch.cuda.is_available = lambda: True
+        torch.cuda.device_count = lambda: 1
+        torch.cuda.current_device = lambda: 0
+        torch.cuda.get_device_capability = lambda *a, **k: (8, 0)
+        torch.cuda.get_device_name = lambda *a, **k: "NVIDIA A100-SPOOFED"
+        torch.cuda.is_bf16_supported = lambda *a, **k: True
+        class _Props:
+            name = "NVIDIA A100-SPOOFED"
+            major = 8
+            minor = 0
+            total_memory = 80 * 1024**3
+            multi_processor_count = 108
+        torch.cuda.get_device_properties = lambda *a, **k: _Props()
+        torch.cuda.mem_get_info = lambda *a, **k: (0, 80 * 1024**3)
+except Exception:
+    pass
+os.environ["UNSLOTH_IS_PRESENT"] = "1"
+
+home = os.environ["STUB_HOME"]
+model_dir = os.path.join(home, "astral-checkpoint")
+os.makedirs(model_dir, exist_ok = True)
+cfg = {
+    "architectures": ["AstralForCausalLM"],
+    "model_type": "astral",
+    "auto_map": {"AutoModelForCausalLM": "modeling_astral.AstralForCausalLM"},
+}
+with open(os.path.join(model_dir, "config.json"), "w") as f:
+    json.dump(cfg, f)
+with open(os.path.join(model_dir, "modeling_astral.py"), "w") as f:
+    f.write("from transformers.modeling_layers import GradientCheckpointingLayer\n")
+
+pkg = os.path.join(home, ".venv_t5_510", "transformers")
+os.makedirs(pkg, exist_ok = True)
+with open(os.path.join(pkg, "__init__.py"), "w") as f:
+    f.write('__version__ = "5.10.2"\n')
+os.environ["UNSLOTH_STUDIO_HOME"] = home
+
+from utils.hf_xet_fallback import child_should_disable_xet
+child_should_disable_xet({})
+_tf = sys.modules.get("transformers")
+preload = _tf.__version__ if _tf is not None else None
+
+import utils.transformers_version as tv
+tv._VENV_T5_510_DIR = os.path.join(home, ".venv_t5_510")
+tv._ensure_venv_t5_510_exists = lambda: True
+tier = tv.get_transformers_tier(model_dir, None)
+tv.activate_transformers_for_subprocess(model_dir, None)
+
+import transformers
+print(f"RESULT tier={tier} preload={preload} active={transformers.__version__}")
+"""
+
 
 def _parse(stdout: str) -> dict[str, str]:
     for line in stdout.splitlines():
@@ -152,4 +220,41 @@ def test_worker_activates_correct_transformers_version(tmp_path):
         f"(active={parsed['active']}, preloaded-before-activation={parsed['preload']}). A pre-activation "
         "transformers import (directly or via unsloth_zoo) defeated the sidecar; 5.x models (Qwen3.5, "
         "GLM-4.7, gemma-4) then fail with 'Tokenizer class TokenizersBackend does not exist'. See #6951."
+    )
+
+
+def test_worker_activates_transformers_510_for_astral(tmp_path):
+    """Astral custom-code checkpoints (#7353) must route to tier 510 and swap in the 5.10 sidecar.
+
+    Without this, training fails before model load with
+    ``No module named 'transformers.tokenization_utils_tokenizers'`` because the default
+    4.57.x sidecar is still active after worker preflight.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", _SNIPPET_ASTRAL_510],
+        cwd = str(_BACKEND_DIR),
+        env = {
+            **__import__("os").environ,
+            "STUB_HOME": str(tmp_path),
+            **({"SPOOF_PATH": str(_SPOOF_PATH)} if _SPOOF_PATH.exists() else {}),
+        },
+        capture_output = True,
+        text = True,
+    )
+    assert result.returncode == 0, (
+        "Astral worker preflight + activation harness crashed.\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+    parsed = _parse(result.stdout)
+    assert parsed, f"No RESULT line.\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+
+    assert parsed["tier"] == "510", (
+        f"Wrong transformers tier for Astral (expected 510, got {parsed['tier']}). "
+        "Custom-code Astral checkpoints must use the 5.10 sidecar. See #7353."
+    )
+    assert parsed["active"] == "5.10.2", (
+        "Sidecar activation did NOT switch the in-process transformers to Astral's 5.10.x version "
+        f"(active={parsed['active']}, preloaded-before-activation={parsed['preload']}). "
+        "A stale pre-activation transformers import defeats the sidecar; Astral then crashes loading "
+        "its remote tokenizer. See #7353."
     )

--- a/studio/backend/tests/test_worker_activates_correct_transformers.py
+++ b/studio/backend/tests/test_worker_activates_correct_transformers.py
@@ -154,7 +154,7 @@ cfg = {
 with open(os.path.join(model_dir, "config.json"), "w") as f:
     json.dump(cfg, f)
 with open(os.path.join(model_dir, "modeling_astral.py"), "w") as f:
-    f.write("from transformers.modeling_layers import GradientCheckpointingLayer\n")
+    f.write("from transformers.utils.output_capturing import capture_outputs\n")
 
 pkg = os.path.join(home, ".venv_t5_510", "transformers")
 os.makedirs(pkg, exist_ok = True)

--- a/studio/backend/tests/test_worker_activates_correct_transformers.py
+++ b/studio/backend/tests/test_worker_activates_correct_transformers.py
@@ -110,7 +110,7 @@ print(f"RESULT tier={tier} preload={preload} active={transformers.__version__}")
 """
 
 # Astral (#7353): custom-code checkpoints must activate the 5.10 sidecar, not default 4.57.x.
-# Uses a local stub checkpoint (no Hub fetch) with the same worker preflight + activation path.
+# Local stub checkpoint (no Hub fetch), same worker preflight + activation path.
 _SNIPPET_ASTRAL_510 = r"""
 import json, os, sys
 sys.path.insert(0, os.getcwd())
@@ -226,9 +226,8 @@ def test_worker_activates_correct_transformers_version(tmp_path):
 def test_worker_activates_transformers_510_for_astral(tmp_path):
     """Astral custom-code checkpoints (#7353) must route to tier 510 and swap in the 5.10 sidecar.
 
-    Without this, training fails before model load with
-    ``No module named 'transformers.tokenization_utils_tokenizers'`` because the default
-    4.57.x sidecar is still active after worker preflight.
+    Otherwise training fails before model load with ``No module named
+    'transformers.tokenization_utils_tokenizers'``, the default 4.57.x still active.
     """
     result = subprocess.run(
         [sys.executable, "-c", _SNIPPET_ASTRAL_510],

--- a/studio/backend/utils/security/remote_code_scan.py
+++ b/studio/backend/utils/security/remote_code_scan.py
@@ -626,16 +626,19 @@ def _add_external_refs(files: dict, refs, hf_token, model_name: str) -> bool:
     the referenced entry files). Returns False if any external repo cannot be listed or a
     file cannot be fetched, so the caller fails closed.
     """
-    from pathlib import Path
-
-    from huggingface_hub import hf_hub_download, list_repo_files
-
     # Group the explicit entry refs by external repo.
     entries: dict = {}
     for repo, fn in refs:
         if repo is None:
             continue
         entries.setdefault(repo, set()).add(fn)
+
+    if not entries:
+        return True
+
+    from pathlib import Path
+
+    from huggingface_hub import hf_hub_download, list_repo_files
 
     for repo, entry_files in entries.items():
         try:

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -608,10 +608,86 @@ def _remote_lora_base(model_name: str, hf_token: str | None = None) -> str | Non
         return _adapter_base_from_hf_cache(model_name)
 
 
+def _hf_endpoint_base() -> str:
+    """Hub base URL honoring ``HF_ENDPOINT`` (mirrors ``_remote_lora_base``)."""
+    return (os.environ.get("HF_ENDPOINT") or "https://huggingface.co").rstrip("/")
+
+
 def _hf_raw_file_url(model_name: str, filename: str) -> str:
     """Raw Hub file URL honoring ``HF_ENDPOINT`` (mirrors ``_remote_lora_base``)."""
-    endpoint = (os.environ.get("HF_ENDPOINT") or "https://huggingface.co").rstrip("/")
-    return f"{endpoint}/{model_name}/raw/main/{filename}"
+    return f"{_hf_endpoint_base()}/{model_name}/raw/main/{filename}"
+
+
+def _hf_api_url(path: str) -> str:
+    """Hub API URL honoring ``HF_ENDPOINT``."""
+    return f"{_hf_endpoint_base()}{path}"
+
+
+def _hf_api_get_json(path: str, hf_token: str | None = None) -> tuple[object | None, bool]:
+    """GET a Hub API path via stdlib urllib. Returns (parsed_json, success)."""
+    import urllib.request
+
+    headers = {"User-Agent": "unsloth-studio"}
+    if hf_token:
+        headers["Authorization"] = f"Bearer {hf_token}"
+    try:
+        req = urllib.request.Request(_hf_api_url(path), headers = headers)
+        with urllib.request.urlopen(req, timeout = 10) as resp:
+            return json.loads(resp.read().decode()), True
+    except Exception as exc:
+        logger.debug("HF API request failed for %s: %s", path, exc)
+        return None, False
+
+
+def _list_hub_repo_py_files(repo_id: str, hf_token: str | None = None) -> tuple[set[str], bool]:
+    """List ``.py`` paths in a Hub repo via the REST API (no huggingface_hub import)."""
+    data, ok = _hf_api_get_json(f"/api/models/{repo_id}/tree/main?recursive=1", hf_token)
+    if not ok or not isinstance(data, list):
+        return set(), False
+    return {
+        item["path"]
+        for item in data
+        if isinstance(item, dict) and item.get("type") == "file" and str(item.get("path", "")).endswith(".py")
+    }, True
+
+
+def _fetch_hub_py_sources(repo_id: str, hf_token: str | None = None) -> tuple[list[str], bool]:
+    """Fetch every present ``.py`` in a Hub repo. Returns (sources, definitive)."""
+    py_files, listing_ok = _list_hub_repo_py_files(repo_id, hf_token)
+    if not listing_ok:
+        return [], False
+    sources: list[str] = []
+    for fn in sorted(py_files):
+        text = _read_repo_text_file(repo_id, fn, hf_token)
+        if text is None:
+            return [], False
+        sources.append(text)
+    return sources, True
+
+
+def _collect_external_py_sources(refs: set, hf_token: str | None = None) -> tuple[list[str], bool]:
+    """Fetch all ``.py`` from external repos referenced by ``auto_map``."""
+    external_repos = {repo for repo, _ in refs if repo is not None}
+    if not external_repos:
+        return [], True
+    sources: list[str] = []
+    for repo in sorted(external_repos):
+        repo_sources, ok = _fetch_hub_py_sources(repo, hf_token)
+        if not ok:
+            return [], False
+        sources.extend(repo_sources)
+    return sources, True
+
+
+def _repo_has_auto_map(model_name: str, hf_token: str | None = None) -> bool:
+    """True when any remote-code config in the repo declares ``auto_map``."""
+    from utils.security.remote_code_scan import REMOTE_CODE_CONFIG_FILES, _auto_map_refs
+
+    for cfg_name in REMOTE_CODE_CONFIG_FILES:
+        cfg = _load_repo_json_file(model_name, cfg_name, hf_token)
+        if isinstance(cfg, dict) and _auto_map_refs(cfg):
+            return True
+    return False
 
 
 def _read_repo_text_file(
@@ -683,78 +759,116 @@ def _load_repo_json_file(
         return None
 
 
-def _remote_auto_map_py_contents(model_name: str, hf_token: str | None = None) -> list[str]:
+def _remote_auto_map_py_contents(model_name: str, hf_token: str | None = None) -> tuple[list[str], bool]:
     """Executable remote-code sources transformers may load (own, helper, external).
 
-    Delegates to ``repo_remote_code_files`` so tier detection scans the same closure
-    as the consent gate: every present ``.py`` in the repo plus external ``auto_map``
-    targets (and their repos' helper modules). Fail-open on unscannable repos.
+    Stdlib-only (urllib + HF REST API) so tier detection never imports ``huggingface_hub``
+    before a transformers sidecar is activated. Returns ``(sources, definitive)``; when
+    ``definitive`` is False the scan was incomplete and negatives must not be cached.
     """
-    from utils.security.remote_code_scan import (
-        REMOTE_CODE_CONFIG_FILES,
-        RemoteCodeUnscannable,
-        _auto_map_refs,
-        repo_remote_code_files,
-    )
+    from utils.security.remote_code_scan import REMOTE_CODE_CONFIG_FILES, _auto_map_refs
 
-    has_auto_map = False
+    if not _repo_has_auto_map(model_name, hf_token):
+        return [], True
+
+    ext_refs: set = set()
     for cfg_name in REMOTE_CODE_CONFIG_FILES:
         cfg = _load_repo_json_file(model_name, cfg_name, hf_token)
-        if isinstance(cfg, dict) and _auto_map_refs(cfg):
-            has_auto_map = True
-            break
-    if not has_auto_map:
-        return []
+        if isinstance(cfg, dict):
+            ext_refs |= _auto_map_refs(cfg)
 
-    try:
-        return list(repo_remote_code_files(model_name, hf_token).values())
-    except RemoteCodeUnscannable as exc:
-        logger.debug("Remote auto_map source scan incomplete for '%s': %s", model_name, exc)
-        return []
-    except Exception as exc:
-        logger.debug("Remote auto_map source scan failed for '%s': %s", model_name, exc)
-        return []
+    local_root = Path(model_name)
+    if _safe_is_dir(local_root):
+        sources: list[str] = []
+        for py_path in local_root.rglob("*.py"):
+            if py_path.is_file():
+                try:
+                    sources.append(py_path.read_text(encoding = "utf-8", errors = "replace"))
+                except Exception as exc:
+                    logger.debug("Could not read %s: %s", py_path, exc)
+                    return [], False
+        ext_sources, ext_ok = _collect_external_py_sources(ext_refs, hf_token)
+        if any(repo is not None for repo, _ in ext_refs) and not ext_ok:
+            return sources, False
+        sources.extend(ext_sources)
+        return sources, True
+
+    if _env_offline() or not _looks_like_hf_id(model_name):
+        return [], False
+
+    sources, repo_ok = _fetch_hub_py_sources(model_name, hf_token)
+    if not repo_ok:
+        return [], False
+    ext_sources, ext_ok = _collect_external_py_sources(ext_refs, hf_token)
+    if any(repo is not None for repo, _ in ext_refs) and not ext_ok:
+        return sources, False
+    sources.extend(ext_sources)
+    return sources, True
 
 
 def _remote_auto_map_py_matches(markers: tuple[str, ...], sources: list[str]) -> bool:
     return any(any(marker in src for marker in markers) for src in sources)
 
 
-def _check_remote_auto_map_needs_510(model_name: str, hf_token: str | None = None) -> bool:
-    """True when auto_map remote code imports transformers>=5.10-only symbols."""
+def _remote_auto_map_scan_result(
+    model_name: str,
+    hf_token: str | None = None,
+) -> tuple[bool, bool]:
+    """Return ``(needs_510, scan_was_definitive)`` for auto_map remote code."""
     cache_key = _token_cache_key(model_name, hf_token)
     if cache_key in _remote_auto_map_needs_510_cache:
-        return _remote_auto_map_needs_510_cache[cache_key]
+        return _remote_auto_map_needs_510_cache[cache_key], True
 
     # Offline Hub ids cannot be scanned here; do not cache the assumed negative so a
     # later online read re-fetches (mirrors _check_tokenizer_config_needs_v5).
     if _env_offline() and not _safe_is_dir(Path(model_name)):
-        return False
+        return False, False
 
-    sources = _remote_auto_map_py_contents(model_name, hf_token)
+    sources, definitive = _remote_auto_map_py_contents(model_name, hf_token)
     result = _remote_auto_map_py_matches(_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS, sources)
     if result:
         logger.info("Remote auto_map check: %s needs transformers 5.10.x", model_name)
-    _remote_auto_map_needs_510_cache[cache_key] = result
-    return result
+    if definitive:
+        _remote_auto_map_needs_510_cache[cache_key] = result
+    return result, definitive
+
+
+def _check_remote_auto_map_needs_510(model_name: str, hf_token: str | None = None) -> bool:
+    """True when auto_map remote code imports transformers>=5.10-only symbols."""
+    needs, _ = _remote_auto_map_scan_result(model_name, hf_token)
+    return needs
 
 
 def _tokenizer_auto_map_needs_v5(data: dict, model_name: str, hf_token: str | None) -> bool:
-    """True when a tokenizer_config auto_map target imports transformers-5.x-only symbols."""
+    """True when tokenizer ``auto_map`` closure imports transformers-5.x-only symbols."""
     from utils.security.remote_code_scan import _auto_map_refs
 
-    for repo, fn in _auto_map_refs(data):
-        if repo is None:
-            text = _read_repo_text_file(model_name, fn, hf_token)
-        else:
-            text = _read_repo_text_file(repo, fn, hf_token)
-        if text and _remote_auto_map_py_matches(_TRANSFORMERS_5_REMOTE_IMPORT_MARKERS, [text]):
-            logger.info(
-                "Remote tokenizer auto_map check: %s/%s requires transformers 5.x",
-                repo or model_name,
-                fn,
-            )
-            return True
+    refs = _auto_map_refs(data)
+    if not refs:
+        return False
+
+    local_root = Path(model_name)
+    if _safe_is_dir(local_root):
+        sources: list[str] = []
+        for py_path in local_root.rglob("*.py"):
+            if py_path.is_file():
+                try:
+                    sources.append(py_path.read_text(encoding = "utf-8", errors = "replace"))
+                except Exception as exc:
+                    logger.debug("Could not read %s: %s", py_path, exc)
+                    return False
+        ext_sources, ext_ok = _collect_external_py_sources(refs, hf_token)
+        if any(repo is not None for repo, _ in refs) and not ext_ok:
+            return False
+        sources.extend(ext_sources)
+    else:
+        sources, definitive = _remote_auto_map_py_contents(model_name, hf_token)
+        if not definitive and not sources:
+            return False
+
+    if _remote_auto_map_py_matches(_TRANSFORMERS_5_REMOTE_IMPORT_MARKERS, sources):
+        logger.info("Remote tokenizer auto_map check: %s requires transformers 5.x", model_name)
+        return True
     return False
 
 
@@ -1061,10 +1175,10 @@ def _check_config_needs_510(model_name: str, hf_token: str | None = None) -> boo
         return _config_needs_510_cache[cache_key]
 
     cfg = _load_config_json(model_name, hf_token)
-    result = bool(cfg) and (
-        _config_needs_510(cfg) or _check_remote_auto_map_needs_510(model_name, hf_token)
-    )
-    if result:
+    config_definitive = _config_json_is_definitive(model_name, hf_token)
+    if cfg and _config_needs_510(cfg):
+        if config_definitive:
+            _config_needs_510_cache[cache_key] = True
         logger.info(
             "config.json check: %s needs transformers %s (architectures=%s, model_type=%s)",
             model_name,
@@ -1072,9 +1186,18 @@ def _check_config_needs_510(model_name: str, hf_token: str | None = None) -> boo
             cfg.get("architectures", []),
             cfg.get("model_type"),
         )
-    if _config_json_is_definitive(model_name, hf_token):
-        _config_needs_510_cache[cache_key] = result
-    return result
+        return True
+
+    remote_needs, remote_definitive = _remote_auto_map_scan_result(model_name, hf_token)
+    if remote_needs:
+        logger.info(
+            "config.json check: %s needs transformers %s (auto_map remote code)",
+            model_name,
+            TRANSFORMERS_510_VERSION,
+        )
+    if config_definitive and remote_definitive:
+        _config_needs_510_cache[cache_key] = remote_needs
+    return remote_needs
 
 
 def _config_saved_by_transformers_5(cfg: dict | None) -> bool:
@@ -1648,6 +1771,14 @@ def get_transformers_tier(
                     model_name,
                 )
                 return tier
+            if _check_remote_auto_map_needs_510(model_name, hf_token):
+                tier = _raise_tier_for_nested(cfg, "510")
+                logger.info(
+                    "Transformers tier %s selected for %s (local auto_map needs 5.10.x)",
+                    tier,
+                    model_name,
+                )
+                return tier
             if _config_needs_550(cfg):
                 tier = _raise_tier_for_nested(cfg, "550")
                 logger.info(
@@ -1733,14 +1864,6 @@ def get_transformers_tier(
                 )
                 if tier != "default":
                     return tier
-            if _check_remote_auto_map_needs_510(model_name, hf_token):
-                tier = _raise_tier_for_nested(cfg, "510")
-                logger.info(
-                    "Transformers tier %s selected for %s (local auto_map needs 5.10.x)",
-                    tier,
-                    model_name,
-                )
-                return tier
             logger.info(
                 "Transformers tier default (4.57.x) selected for %s (local config.json no match)",
                 model_name,
@@ -1757,6 +1880,9 @@ def get_transformers_tier(
         # actually routes to the sidecar it installed. Costs a config read only
         # in the pinned case, keeping the pre-latest path I/O-free.
         if latest_venv_pinned_version() is not None:
+            tier = _raise_tier_for_nested(_load_config_json(model_name, hf_token), tier)
+        if _check_remote_auto_map_needs_510(model_name, hf_token):
+            tier = _higher_tier(tier, "510")
             tier = _raise_tier_for_nested(_load_config_json(model_name, hf_token), tier)
         logger.info(
             "Transformers tier %s selected for %s (substring match: %s)",

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -201,9 +201,7 @@ _TRANSFORMERS_5_TOKENIZER_CLASSES: set[str] = {
 }
 
 # Import strings in auto_map remote .py that only exist in transformers>=5.x.
-_TRANSFORMERS_5_REMOTE_IMPORT_MARKERS: tuple[str, ...] = (
-    "tokenization_utils_tokenizers",
-)
+_TRANSFORMERS_5_REMOTE_IMPORT_MARKERS: tuple[str, ...] = ("tokenization_utils_tokenizers",)
 
 # Import strings in auto_map remote modeling code that require transformers>=5.10.
 _TRANSFORMERS_510_REMOTE_IMPORT_MARKERS: tuple[str, ...] = (
@@ -610,7 +608,11 @@ def _remote_lora_base(model_name: str, hf_token: str | None = None) -> str | Non
         return _adapter_base_from_hf_cache(model_name)
 
 
-def _read_repo_text_file(model_name: str, filename: str, hf_token: str | None = None) -> str | None:
+def _read_repo_text_file(
+    model_name: str,
+    filename: str,
+    hf_token: str | None = None,
+) -> str | None:
     """Return a repo-relative text file's contents; local first, else HuggingFace raw fetch."""
     local_path = Path(model_name) / filename
     if _safe_is_file(local_path):
@@ -639,7 +641,11 @@ def _read_repo_text_file(model_name: str, filename: str, hf_token: str | None = 
         return None
 
 
-def _load_repo_json_file(model_name: str, filename: str, hf_token: str | None = None) -> dict | None:
+def _load_repo_json_file(
+    model_name: str,
+    filename: str,
+    hf_token: str | None = None,
+) -> dict | None:
     """Parsed JSON from a repo-relative file; local first, else HuggingFace raw fetch."""
     if filename == "config.json":
         return _load_config_json(model_name, hf_token)

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -152,11 +152,13 @@ _TRANSFORMERS_510_ARCHITECTURES: set[str] = {
     "Gemma4UnifiedForConditionalGeneration",
     "Gemma4AssistantForCausalLM",
     "Gemma4UnifiedAssistantForCausalLM",
+    "AstralForCausalLM",
 }
 _TRANSFORMERS_510_MODEL_TYPES: set[str] = {
     "gemma4_unified",
     "gemma4_assistant",
     "gemma4_unified_assistant",
+    "astral",
 }
 
 # Architecture classes / model_type values that require transformers 5.5.0.
@@ -198,6 +200,18 @@ _TRANSFORMERS_5_TOKENIZER_CLASSES: set[str] = {
     "TokenizersBackend",
 }
 
+# Import strings in auto_map remote .py that only exist in transformers>=5.x.
+_TRANSFORMERS_5_REMOTE_IMPORT_MARKERS: tuple[str, ...] = (
+    "tokenization_utils_tokenizers",
+)
+
+# Import strings in auto_map remote modeling code that require transformers>=5.10.
+_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS: tuple[str, ...] = (
+    "modeling_layers",
+    "utils.output_capturing",
+    "use_kernel_forward_from_hub",
+)
+
 # Caches keyed on (model_name, token-hash) so authed/unauthed reads stay separate (a
 # gated/private repo's unauthenticated miss must not poison a later authenticated lookup).
 # Offline negatives are NOT written (see the _env_offline branches) so they cannot poison a
@@ -207,6 +221,7 @@ _config_json_cache: dict[tuple[str, str | None], dict | None] = {}
 _config_needs_510_cache: dict[tuple[str, str | None], bool] = {}
 _config_needs_550_cache: dict[tuple[str, str | None], bool] = {}
 _config_needs_530_cache: dict[tuple[str, str | None], bool] = {}
+_remote_auto_map_needs_510_cache: dict[tuple[str, str | None], bool] = {}
 
 # AutoConfig-probe tier cache for the process lifetime (cleared on restart), keyed by
 # model_name plus a local config.json signature (see _probe_cache_key) so an overwritten
@@ -595,6 +610,120 @@ def _remote_lora_base(model_name: str, hf_token: str | None = None) -> str | Non
         return _adapter_base_from_hf_cache(model_name)
 
 
+def _read_repo_text_file(model_name: str, filename: str, hf_token: str | None = None) -> str | None:
+    """Return a repo-relative text file's contents; local first, else HuggingFace raw fetch."""
+    local_path = Path(model_name) / filename
+    if _safe_is_file(local_path):
+        try:
+            return local_path.read_text(encoding = "utf-8")
+        except Exception as exc:
+            logger.debug("Could not read %s: %s", local_path, exc)
+            return None
+    if _safe_is_dir(Path(model_name)):
+        return None
+    if _env_offline() or not _looks_like_hf_id(model_name):
+        return None
+
+    import urllib.request
+
+    url = f"https://huggingface.co/{model_name}/raw/main/{filename}"
+    headers = {"User-Agent": "unsloth-studio"}
+    if hf_token:
+        headers["Authorization"] = f"Bearer {hf_token}"
+    try:
+        req = urllib.request.Request(url, headers = headers)
+        with urllib.request.urlopen(req, timeout = 10) as resp:
+            return resp.read().decode()
+    except Exception as exc:
+        logger.debug("Could not fetch %s for '%s': %s", filename, model_name, exc)
+        return None
+
+
+def _load_repo_json_file(model_name: str, filename: str, hf_token: str | None = None) -> dict | None:
+    """Parsed JSON from a repo-relative file; local first, else HuggingFace raw fetch."""
+    if filename == "config.json":
+        return _load_config_json(model_name, hf_token)
+    local_path = Path(model_name) / filename
+    if _safe_is_file(local_path):
+        try:
+            with open(local_path) as f:
+                return json.load(f)
+        except Exception as exc:
+            logger.debug("Could not read %s: %s", local_path, exc)
+            return None
+    if _safe_is_dir(Path(model_name)):
+        return None
+    if _env_offline() or not _looks_like_hf_id(model_name):
+        return None
+
+    import urllib.request
+
+    url = f"https://huggingface.co/{model_name}/raw/main/{filename}"
+    headers = {"User-Agent": "unsloth-studio"}
+    if hf_token:
+        headers["Authorization"] = f"Bearer {hf_token}"
+    try:
+        req = urllib.request.Request(url, headers = headers)
+        with urllib.request.urlopen(req, timeout = 10) as resp:
+            return json.loads(resp.read().decode())
+    except Exception as exc:
+        logger.debug("Could not fetch %s for '%s': %s", filename, model_name, exc)
+        return None
+
+
+def _own_repo_auto_map_py_contents(model_name: str, hf_token: str | None = None) -> list[str]:
+    """Contents of every own-repo ``.py`` referenced by any remote-code config file."""
+    from utils.security.remote_code_scan import REMOTE_CODE_CONFIG_FILES, _auto_map_refs
+
+    filenames: set[str] = set()
+    for cfg_name in REMOTE_CODE_CONFIG_FILES:
+        cfg = _load_repo_json_file(model_name, cfg_name, hf_token)
+        if isinstance(cfg, dict):
+            filenames.update(fn for repo, fn in _auto_map_refs(cfg) if repo is None)
+    contents: list[str] = []
+    for fn in sorted(filenames):
+        text = _read_repo_text_file(model_name, fn, hf_token)
+        if text is not None:
+            contents.append(text)
+    return contents
+
+
+def _remote_auto_map_py_matches(markers: tuple[str, ...], sources: list[str]) -> bool:
+    return any(any(marker in src for marker in markers) for src in sources)
+
+
+def _check_remote_auto_map_needs_510(model_name: str, hf_token: str | None = None) -> bool:
+    """True when auto_map remote code imports transformers>=5.10-only symbols."""
+    cache_key = _token_cache_key(model_name, hf_token)
+    if cache_key in _remote_auto_map_needs_510_cache:
+        return _remote_auto_map_needs_510_cache[cache_key]
+
+    sources = _own_repo_auto_map_py_contents(model_name, hf_token)
+    result = _remote_auto_map_py_matches(_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS, sources)
+    if result:
+        logger.info("Remote auto_map check: %s needs transformers 5.10.x", model_name)
+    _remote_auto_map_needs_510_cache[cache_key] = result
+    return result
+
+
+def _tokenizer_auto_map_needs_v5(data: dict, model_name: str, hf_token: str | None) -> bool:
+    """True when a tokenizer_config auto_map target imports transformers-5.x-only symbols."""
+    from utils.security.remote_code_scan import _auto_map_refs
+
+    for repo, fn in _auto_map_refs(data):
+        if repo is not None:
+            continue
+        text = _read_repo_text_file(model_name, fn, hf_token)
+        if text and _remote_auto_map_py_matches(_TRANSFORMERS_5_REMOTE_IMPORT_MARKERS, [text]):
+            logger.info(
+                "Remote tokenizer auto_map check: %s/%s requires transformers 5.x",
+                model_name,
+                fn,
+            )
+            return True
+    return False
+
+
 def _check_tokenizer_config_needs_v5(model_name: str, hf_token: str | None = None) -> bool:
     """True if the model's tokenizer_class requires transformers 5.x.
 
@@ -617,6 +746,8 @@ def _check_tokenizer_config_needs_v5(model_name: str, hf_token: str | None = Non
                 data = json.load(f)
             tokenizer_class = data.get("tokenizer_class", "")
             result = tokenizer_class in _TRANSFORMERS_5_TOKENIZER_CLASSES
+            if not result:
+                result = _tokenizer_auto_map_needs_v5(data, model_name, hf_token)
             if result:
                 logger.info(
                     "Local check: %s uses tokenizer_class=%s (requires transformers 5.x)",
@@ -651,6 +782,8 @@ def _check_tokenizer_config_needs_v5(model_name: str, hf_token: str | None = Non
             data = json.loads(resp.read().decode())
         tokenizer_class = data.get("tokenizer_class", "")
         result = tokenizer_class in _TRANSFORMERS_5_TOKENIZER_CLASSES
+        if not result:
+            result = _tokenizer_auto_map_needs_v5(data, model_name, hf_token)
         if result:
             logger.info(
                 "Dynamic check: %s uses tokenizer_class=%s (requires transformers 5.x)",
@@ -894,7 +1027,9 @@ def _check_config_needs_510(model_name: str, hf_token: str | None = None) -> boo
         return _config_needs_510_cache[cache_key]
 
     cfg = _load_config_json(model_name, hf_token)
-    result = bool(cfg) and _config_needs_510(cfg)
+    result = bool(cfg) and (
+        _config_needs_510(cfg) or _check_remote_auto_map_needs_510(model_name, hf_token)
+    )
     if result:
         logger.info(
             "config.json check: %s needs transformers %s (architectures=%s, model_type=%s)",

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -683,21 +683,37 @@ def _load_repo_json_file(
         return None
 
 
-def _own_repo_auto_map_py_contents(model_name: str, hf_token: str | None = None) -> list[str]:
-    """Contents of every own-repo ``.py`` referenced by any remote-code config file."""
-    from utils.security.remote_code_scan import REMOTE_CODE_CONFIG_FILES, _auto_map_refs
+def _remote_auto_map_py_contents(model_name: str, hf_token: str | None = None) -> list[str]:
+    """Executable remote-code sources transformers may load (own, helper, external).
 
-    filenames: set[str] = set()
+    Delegates to ``repo_remote_code_files`` so tier detection scans the same closure
+    as the consent gate: every present ``.py`` in the repo plus external ``auto_map``
+    targets (and their repos' helper modules). Fail-open on unscannable repos.
+    """
+    from utils.security.remote_code_scan import (
+        REMOTE_CODE_CONFIG_FILES,
+        RemoteCodeUnscannable,
+        _auto_map_refs,
+        repo_remote_code_files,
+    )
+
+    has_auto_map = False
     for cfg_name in REMOTE_CODE_CONFIG_FILES:
         cfg = _load_repo_json_file(model_name, cfg_name, hf_token)
-        if isinstance(cfg, dict):
-            filenames.update(fn for repo, fn in _auto_map_refs(cfg) if repo is None)
-    contents: list[str] = []
-    for fn in sorted(filenames):
-        text = _read_repo_text_file(model_name, fn, hf_token)
-        if text is not None:
-            contents.append(text)
-    return contents
+        if isinstance(cfg, dict) and _auto_map_refs(cfg):
+            has_auto_map = True
+            break
+    if not has_auto_map:
+        return []
+
+    try:
+        return list(repo_remote_code_files(model_name, hf_token).values())
+    except RemoteCodeUnscannable as exc:
+        logger.debug("Remote auto_map source scan incomplete for '%s': %s", model_name, exc)
+        return []
+    except Exception as exc:
+        logger.debug("Remote auto_map source scan failed for '%s': %s", model_name, exc)
+        return []
 
 
 def _remote_auto_map_py_matches(markers: tuple[str, ...], sources: list[str]) -> bool:
@@ -715,7 +731,7 @@ def _check_remote_auto_map_needs_510(model_name: str, hf_token: str | None = Non
     if _env_offline() and not _safe_is_dir(Path(model_name)):
         return False
 
-    sources = _own_repo_auto_map_py_contents(model_name, hf_token)
+    sources = _remote_auto_map_py_contents(model_name, hf_token)
     result = _remote_auto_map_py_matches(_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS, sources)
     if result:
         logger.info("Remote auto_map check: %s needs transformers 5.10.x", model_name)
@@ -728,13 +744,14 @@ def _tokenizer_auto_map_needs_v5(data: dict, model_name: str, hf_token: str | No
     from utils.security.remote_code_scan import _auto_map_refs
 
     for repo, fn in _auto_map_refs(data):
-        if repo is not None:
-            continue
-        text = _read_repo_text_file(model_name, fn, hf_token)
+        if repo is None:
+            text = _read_repo_text_file(model_name, fn, hf_token)
+        else:
+            text = _read_repo_text_file(repo, fn, hf_token)
         if text and _remote_auto_map_py_matches(_TRANSFORMERS_5_REMOTE_IMPORT_MARKERS, [text]):
             logger.info(
                 "Remote tokenizer auto_map check: %s/%s requires transformers 5.x",
-                model_name,
+                repo or model_name,
                 fn,
             )
             return True

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -647,7 +647,9 @@ def _list_hub_repo_py_files(repo_id: str, hf_token: str | None = None) -> tuple[
     return {
         item["path"]
         for item in data
-        if isinstance(item, dict) and item.get("type") == "file" and str(item.get("path", "")).endswith(".py")
+        if isinstance(item, dict)
+        and item.get("type") == "file"
+        and str(item.get("path", "")).endswith(".py")
     }, True
 
 
@@ -759,7 +761,9 @@ def _load_repo_json_file(
         return None
 
 
-def _remote_auto_map_py_contents(model_name: str, hf_token: str | None = None) -> tuple[list[str], bool]:
+def _remote_auto_map_py_contents(
+    model_name: str, hf_token: str | None = None
+) -> tuple[list[str], bool]:
     """Executable remote-code sources transformers may load (own, helper, external).
 
     Stdlib-only (urllib + HF REST API) so tier detection never imports ``huggingface_hub``
@@ -810,10 +814,7 @@ def _remote_auto_map_py_matches(markers: tuple[str, ...], sources: list[str]) ->
     return any(any(marker in src for marker in markers) for src in sources)
 
 
-def _remote_auto_map_scan_result(
-    model_name: str,
-    hf_token: str | None = None,
-) -> tuple[bool, bool]:
+def _remote_auto_map_scan_result(model_name: str, hf_token: str | None = None) -> tuple[bool, bool]:
     """Return ``(needs_510, scan_was_definitive)`` for auto_map remote code."""
     cache_key = _token_cache_key(model_name, hf_token)
     if cache_key in _remote_auto_map_needs_510_cache:

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -608,6 +608,12 @@ def _remote_lora_base(model_name: str, hf_token: str | None = None) -> str | Non
         return _adapter_base_from_hf_cache(model_name)
 
 
+def _hf_raw_file_url(model_name: str, filename: str) -> str:
+    """Raw Hub file URL honoring ``HF_ENDPOINT`` (mirrors ``_remote_lora_base``)."""
+    endpoint = (os.environ.get("HF_ENDPOINT") or "https://huggingface.co").rstrip("/")
+    return f"{endpoint}/{model_name}/raw/main/{filename}"
+
+
 def _read_repo_text_file(
     model_name: str,
     filename: str,
@@ -628,7 +634,7 @@ def _read_repo_text_file(
 
     import urllib.request
 
-    url = f"https://huggingface.co/{model_name}/raw/main/{filename}"
+    url = _hf_raw_file_url(model_name, filename)
     headers = {"User-Agent": "unsloth-studio"}
     if hf_token:
         headers["Authorization"] = f"Bearer {hf_token}"
@@ -664,7 +670,7 @@ def _load_repo_json_file(
 
     import urllib.request
 
-    url = f"https://huggingface.co/{model_name}/raw/main/{filename}"
+    url = _hf_raw_file_url(model_name, filename)
     headers = {"User-Agent": "unsloth-studio"}
     if hf_token:
         headers["Authorization"] = f"Bearer {hf_token}"
@@ -703,6 +709,11 @@ def _check_remote_auto_map_needs_510(model_name: str, hf_token: str | None = Non
     cache_key = _token_cache_key(model_name, hf_token)
     if cache_key in _remote_auto_map_needs_510_cache:
         return _remote_auto_map_needs_510_cache[cache_key]
+
+    # Offline Hub ids cannot be scanned here; do not cache the assumed negative so a
+    # later online read re-fetches (mirrors _check_tokenizer_config_needs_v5).
+    if _env_offline() and not _safe_is_dir(Path(model_name)):
+        return False
 
     sources = _own_repo_auto_map_py_contents(model_name, hf_token)
     result = _remote_auto_map_py_matches(_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS, sources)
@@ -1705,6 +1716,14 @@ def get_transformers_tier(
                 )
                 if tier != "default":
                     return tier
+            if _check_remote_auto_map_needs_510(model_name, hf_token):
+                tier = _raise_tier_for_nested(cfg, "510")
+                logger.info(
+                    "Transformers tier %s selected for %s (local auto_map needs 5.10.x)",
+                    tier,
+                    model_name,
+                )
+                return tier
             logger.info(
                 "Transformers tier default (4.57.x) selected for %s (local config.json no match)",
                 model_name,

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -703,9 +703,7 @@ def _hf_api_get_json(path: str, hf_token: str | None = None) -> tuple[object | N
             # Refusing is also the safe answer for the listing: success=False keeps a
             # truncated tree from passing as a complete one.
             if not _is_same_hub_origin(next_url):
-                logger.debug(
-                    "Refusing cross-origin Hub pagination link for %s: %s", path, next_url
-                )
+                logger.debug("Refusing cross-origin Hub pagination link for %s: %s", path, next_url)
                 return None, False
             url = next_url
         logger.debug("Hub API pagination exceeded %s pages for %s", _HF_API_MAX_PAGES, path)

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -1258,6 +1258,12 @@ def _parsed_dotted_imports(src: str) -> set[str] | None:
     nothing would route the model to a sidecar where that call raises. Only a literal string
     argument is read, so a marker sitting in a docstring, a comment or any other inert
     literal still cannot promote the tier; a computed or f-string name is left alone.
+
+    Qualified access counts too: ``import transformers`` then ``transformers.X`` is the
+    ordinary spelling of a public-export marker, and recording only the module would route
+    that code to a sidecar where the attribute does not exist. Module aliases and an aliased
+    ``import_module`` resolve through the file's own bindings, so a name that was never
+    imported still contributes nothing.
     """
     import ast
 
@@ -1266,8 +1272,8 @@ def _parsed_dotted_imports(src: str) -> set[str] | None:
             isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"
         )
 
-    def _dynamic_import_name(node) -> str | None:
-        """Module a constant-string ``import_module`` / ``__import__`` call loads."""
+    def _dynamic_import_call(node) -> tuple[str, str] | None:
+        """``(callee, module)`` for a constant-string import call, else ``None``."""
         func = node.func
         if isinstance(func, ast.Attribute):
             called = func.attr
@@ -1275,39 +1281,73 @@ def _parsed_dotted_imports(src: str) -> set[str] | None:
             called = func.id
         else:
             return None
-        if called not in ("import_module", "__import__") or not node.args:
+        if not node.args:
             return None
         arg = node.args[0]
         if not isinstance(arg, ast.Constant) or not isinstance(arg.value, str):
             return None
         # A leading dot is a relative import, skipped for the same reason as ImportFrom.
-        return None if arg.value.startswith(".") else arg.value
+        return None if arg.value.startswith(".") else (called, arg.value)
+
+    def _attribute_chain(node) -> tuple[str, str] | None:
+        """``(root name, dotted attribute path)`` for ``a.b.c``, else ``None``."""
+        parts: list[str] = []
+        while isinstance(node, ast.Attribute):
+            parts.append(node.attr)
+            node = node.value
+        if not isinstance(node, ast.Name):
+            return None
+        return node.id, ".".join(reversed(parts))
 
     try:
         tree = ast.parse(src)
     except Exception:
         return None
     names: set[str] = set()
+    bound: dict[str, str] = {}
+    chains: set[tuple[str, str]] = set()
+    deferred: list[tuple[str, str]] = []
     stack: list = [tree]
     while stack:
         node = stack.pop()
         if isinstance(node, ast.Import):
-            names.update(alias.name for alias in node.names)
+            for alias in node.names:
+                names.add(alias.name)
+                root = alias.name.split(".", 1)[0]
+                bound[alias.asname or root] = alias.name if alias.asname else root
             continue
         if isinstance(node, ast.ImportFrom):
             if not node.level and node.module:
                 names.add(node.module)
-                names.update(f"{node.module}.{alias.name}" for alias in node.names)
+                for alias in node.names:
+                    names.add(f"{node.module}.{alias.name}")
+                    bound[alias.asname or alias.name] = f"{node.module}.{alias.name}"
             continue
         if isinstance(node, ast.If) and _is_type_checking(node.test):
             stack.extend(node.orelse)
             continue
-        if isinstance(node, ast.Call):
-            dynamic = _dynamic_import_name(node)
-            if dynamic:
-                names.add(dynamic)
+        if isinstance(node, ast.Attribute):
+            chain = _attribute_chain(node)
+            if chain is not None:
+                chains.add(chain)
+        elif isinstance(node, ast.Call):
+            call = _dynamic_import_call(node)
+            if call is not None:
+                called, module = call
+                if called in ("import_module", "__import__"):
+                    names.add(module)
+                elif isinstance(node.func, ast.Name):
+                    deferred.append((called, module))
             # Not a terminal node: keep walking so a nested call or import still counts.
         stack.extend(ast.iter_child_nodes(node))
+    # Resolved after the walk: a binding can sit below the use that needs it.
+    for root, attr in chains:
+        module = bound.get(root)
+        if module:
+            names.add(f"{module}.{attr}")
+    for called, module in deferred:
+        if bound.get(called) == "importlib.import_module":
+            names.add(module)
     return names
 
 

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -200,19 +200,22 @@ _TRANSFORMERS_5_TOKENIZER_CLASSES: set[str] = {
     "TokenizersBackend",
 }
 
-# Import strings in auto_map remote .py that only exist in transformers>=5.x
-# (``tokenization_utils_tokenizers`` landed in 5.0.0). Fully qualified so a repo's
-# own same-named helper module cannot match.
+# Import strings in auto_map remote .py the default 4.57.x tier cannot satisfy, but the
+# 5.3 sidecar can (``tokenization_utils_tokenizers`` landed in 5.0.0,
+# ``utils.output_capturing`` in 5.2.0). Fully qualified so a repo's own same-named helper
+# module cannot match. Only modules ABSENT from 4.57.x belong here: ``modeling_layers``
+# (4.52+) and ``use_kernel_forward_from_hub`` (4.51+) import fine on default, so matching
+# them would push ordinary custom-code models (EXAONE, MiniMax, Molmo2, ...) onto a sidecar.
 _TRANSFORMERS_5_REMOTE_IMPORT_MARKERS: tuple[str, ...] = (
     "transformers.tokenization_utils_tokenizers",
+    "transformers.utils.output_capturing",
 )
 
-# Remote modeling imports the default 4.57.x tier cannot satisfy
-# (``utils.output_capturing`` landed in 5.3.0). Only symbols ABSENT from 4.57.x
-# belong here: ``modeling_layers`` (4.52+) and ``use_kernel_forward_from_hub``
-# (4.51+) import fine on default, so matching them would push ordinary
-# custom-code models (EXAONE, MiniMax, Molmo2, ...) onto the sidecar.
-_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS: tuple[str, ...] = ("transformers.utils.output_capturing",)
+# Remote modeling imports that not even the 5.3 sidecar can satisfy. A module belongs here
+# only when it is absent from 5.3.0/5.5.0 as well; anything merely newer than 4.57.x goes in
+# the set above, where the 5.3 floor plus the AutoConfig probe escalates to 5.5/5.10 when the
+# model really needs it. Empty today: every marker found so far imports fine on 5.3.0.
+_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS: tuple[str, ...] = ()
 
 # Caches keyed on (model_name, token-hash) so authed/unauthed reads stay separate (a
 # gated/private repo's unauthenticated miss must not poison a later authenticated lookup).
@@ -632,6 +635,24 @@ def _hf_api_url(path: str) -> str:
     return f"{_hf_endpoint_base()}{path}"
 
 
+def _is_same_hub_origin(url: str) -> bool:
+    """True when *url* has the same scheme and authority as the configured Hub endpoint.
+
+    Pagination cursors are echoed back by the endpoint and are followed with the caller's
+    ``Authorization: Bearer <hf_token>`` header attached, so a cross-origin ``rel="next"``
+    from a compromised Hub, a hostile mirror or a MITM on a plain-http ``HF_ENDPOINT`` would
+    hand the user's Hub token to an arbitrary host (and turn the backend into an SSRF probe).
+    The real Hub answers with an absolute same-origin cursor, so requiring one costs nothing.
+    """
+    from urllib.parse import urlsplit
+
+    base = urlsplit(_hf_endpoint_base())
+    nxt = urlsplit(url)
+    if nxt.scheme not in ("http", "https"):
+        return False
+    return (nxt.scheme.lower(), nxt.netloc.lower()) == (base.scheme.lower(), base.netloc.lower())
+
+
 def _parse_link_next(link_header: str | None) -> str | None:
     """Next-page URL from a GitHub-style ``Link`` header, or None."""
     for part in (link_header or "").split(","):
@@ -677,9 +698,14 @@ def _hf_api_get_json(path: str, hf_token: str | None = None) -> tuple[object | N
             merged.extend(payload)
             if not next_url:
                 return merged, True
-            # The cursor URL is echoed by the endpoint; only ever follow it over http(s).
-            if not next_url.startswith(("http://", "https://")):
-                logger.debug("Refusing non-http Hub pagination link for %s: %s", path, next_url)
+            # The cursor URL is echoed by the endpoint; only ever follow it back to that same
+            # origin, since the next request replays the Authorization header verbatim.
+            # Refusing is also the safe answer for the listing: success=False keeps a
+            # truncated tree from passing as a complete one.
+            if not _is_same_hub_origin(next_url):
+                logger.debug(
+                    "Refusing cross-origin Hub pagination link for %s: %s", path, next_url
+                )
                 return None, False
             url = next_url
         logger.debug("Hub API pagination exceeded %s pages for %s", _HF_API_MAX_PAGES, path)
@@ -961,6 +987,12 @@ def _parsed_dotted_imports(src: str) -> set[str] | None:
     4.57.x-loadable custom model onto a 5.x sidecar. Only the guard's own body is dropped;
     its ``else`` / ``elif`` branches do run and are still collected, and ``if not
     TYPE_CHECKING:`` is not the guard, so its body is collected too.
+
+    ``importlib.import_module("pkg.mod")`` / ``__import__("pkg.mod")`` count too: remote code
+    that loads a versioned module that way really does import it at runtime, and recording
+    nothing would route the model to a sidecar where that call raises. Only a literal string
+    argument is read, so a marker sitting in a docstring, a comment or any other inert
+    literal still cannot promote the tier; a computed or f-string name is left alone.
     """
     import ast
 
@@ -968,6 +1000,23 @@ def _parsed_dotted_imports(src: str) -> set[str] | None:
         return (isinstance(test, ast.Name) and test.id == "TYPE_CHECKING") or (
             isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"
         )
+
+    def _dynamic_import_name(node) -> str | None:
+        """Module a constant-string ``import_module`` / ``__import__`` call loads."""
+        func = node.func
+        if isinstance(func, ast.Attribute):
+            called = func.attr
+        elif isinstance(func, ast.Name):
+            called = func.id
+        else:
+            return None
+        if called not in ("import_module", "__import__") or not node.args:
+            return None
+        arg = node.args[0]
+        if not isinstance(arg, ast.Constant) or not isinstance(arg.value, str):
+            return None
+        # A leading dot is a relative import, skipped for the same reason as ImportFrom.
+        return None if arg.value.startswith(".") else arg.value
 
     try:
         tree = ast.parse(src)
@@ -988,6 +1037,11 @@ def _parsed_dotted_imports(src: str) -> set[str] | None:
         if isinstance(node, ast.If) and _is_type_checking(node.test):
             stack.extend(node.orelse)
             continue
+        if isinstance(node, ast.Call):
+            dynamic = _dynamic_import_name(node)
+            if dynamic:
+                names.add(dynamic)
+            # Not a terminal node: keep walking so a nested call or import still counts.
         stack.extend(ast.iter_child_nodes(node))
     return names
 
@@ -1006,6 +1060,8 @@ def _remote_auto_map_py_matches(markers: tuple[str, ...], sources: list[str]) ->
     unparseable remote code never turns into a silent negative that crashes on the default
     tier; that fallback is the only place a substring match is trusted.
     """
+    if not markers:
+        return False
     for src in sources:
         names = _parsed_dotted_imports(src)
         if names is None:
@@ -1056,13 +1112,47 @@ def _local_scan_signature(model_name: str) -> str | None:
         return None
 
 
+def _hf_cache_snapshot_dir(model_name: str) -> Path | None:
+    """Newest local HF hub cache snapshot directory for a Hub id, or None.
+
+    Stdlib-only path resolution mirroring :func:`_config_json_from_hf_cache` (no
+    ``huggingface_hub`` import), so tier detection never loads the default-env hub before a
+    sidecar venv is activated.
+    """
+    # Only a canonical ``owner/repo`` Hub id maps to a cache dir; reject local paths.
+    if not model_name or model_name.count("/") != 1 or model_name[0] in "/.~" or "\\" in model_name:
+        return None
+    hub = (
+        os.environ.get("HF_HUB_CACHE")
+        or os.environ.get("HUGGINGFACE_HUB_CACHE")
+        or os.path.join(
+            os.environ.get("HF_HOME") or os.path.expanduser("~/.cache/huggingface"), "hub"
+        )
+    )
+    repo_dir = Path(hub) / ("models--" + model_name.replace("/", "--"))
+    candidates: list[Path] = []
+    ref_main = repo_dir / "refs" / "main"
+    try:
+        if ref_main.is_file():
+            candidates.append(repo_dir / "snapshots" / ref_main.read_text().strip())
+        # No refs/main (e.g. commit-pinned downloads): newest snapshot by mtime, not a stale
+        # lexicographically-first SHA, matching what the Hub cache would actually load.
+        candidates += sorted(repo_dir.glob("snapshots/*"), key = _safe_mtime, reverse = True)
+        for path in candidates:
+            if path.is_dir():
+                return path
+    except Exception as exc:
+        logger.debug("HF cache snapshot lookup failed for '%s': %s", model_name, exc)
+    return None
+
+
 def _remote_auto_map_tier(model_name: str, hf_token: str | None = None) -> tuple[str, bool]:
     """Return ``(tier, scan_was_definitive)`` for auto_map remote code.
 
-    ``"510"`` when the closure imports a 5.10-only symbol, ``"530"`` when it imports the
-    5.x-only tokenizers backend module, else ``"default"``. The 5.x marker is classified
-    here and not only in the tokenizer check because remote code reached through
-    ``config.json`` or a processor config is never scanned by that check when
+    ``"510"`` when the closure imports a symbol no sidecar below 5.10 has, ``"530"`` when it
+    imports a module absent from 4.57.x but present in 5.3, else ``"default"``. The 5.x
+    marker is classified here and not only in the tokenizer check because remote code reached
+    through ``config.json`` or a processor config is never scanned by that check when
     ``tokenizer_config.json`` does not itself declare the module: the worker would then
     pick the default 4.57.x tier, which does not ship
     ``transformers.tokenization_utils_tokenizers`` at all.
@@ -1072,10 +1162,18 @@ def _remote_auto_map_tier(model_name: str, hf_token: str | None = None) -> tuple
     if signature is not None and cache_key in _remote_auto_map_tier_cache:
         return _remote_auto_map_tier_cache[cache_key], True
 
-    # Offline Hub ids cannot be scanned here; do not cache the assumed negative so a
-    # later online read re-fetches (mirrors _check_tokenizer_config_needs_v5).
+    # Offline Hub id: the Hub cannot be listed, but a previously downloaded snapshot is
+    # exactly the code an offline load would execute, so scan that instead of assuming the
+    # model has no 5.x-only import (which would activate 4.57.x and crash on a repo whose
+    # files are all present locally). The answer is still reported as non-definitive: the
+    # external auto_map repos cannot be reached offline, and nothing is cached under the Hub
+    # id, so a later online read re-fetches (mirrors _check_tokenizer_config_needs_v5).
     if _env_offline() and not _safe_is_dir(Path(model_name)):
-        return "default", False
+        snapshot = _hf_cache_snapshot_dir(model_name)
+        if snapshot is None:
+            return "default", False
+        tier, _ = _remote_auto_map_tier(str(snapshot), hf_token)
+        return tier, False
 
     sources, definitive = _remote_auto_map_py_contents(model_name, hf_token)
     if _remote_auto_map_py_matches(_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS, sources):

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -982,33 +982,43 @@ def _remote_auto_map_py_matches(markers: tuple[str, ...], sources: list[str]) ->
     return False
 
 
-def _local_py_signature(model_name: str) -> str | None:
-    """Signature of a local checkpoint's ``.py`` files (path + size + mtime), or ``""``
-    for a Hub id. ``None`` when the walk fails, which means "do not cache".
+def _local_scan_signature(model_name: str) -> str | None:
+    """Signature of a local checkpoint's scan inputs (path + size + mtime), or ``""`` for a
+    Hub id. ``None`` when the walk fails, which means "do not cache".
 
-    Folded into the scan cache key (mirrors ``_probe_cache_key``) so a checkpoint whose
-    remote code is written or replaced after a first lookup is re-scanned instead of
-    reusing a stale negative.
+    Covers the ``.py`` files AND every config that can declare an ``auto_map``, because both
+    decide the answer. A checkpoint materialized in stages can land its code first and gain
+    the ``auto_map`` afterwards: signing only the ``.py`` would keep serving the earlier
+    "no remote code" negative although not one byte of the new declaration was ever read.
+
+    Folded into the scan cache keys (mirrors ``_probe_cache_key``) so a checkpoint whose
+    remote code or whose declaration is written or replaced after a first lookup is
+    re-scanned instead of reusing a stale answer.
     """
-    if not _safe_is_dir(Path(model_name)):
+    root = Path(model_name)
+    if not _safe_is_dir(root):
         return ""
     try:
+        paths = sorted(root.rglob("*.py"))
+        paths += [root / name for name in _auto_map_config_files(model_name)]
         parts = []
-        for py_path in sorted(Path(model_name).rglob("*.py")):
+        for path in paths:
             try:
-                st = py_path.stat()
+                st = path.stat()
             except OSError:
+                # Absent (or unreadable) contributes nothing; it starts contributing the
+                # moment it appears, which is exactly the change we must notice.
                 continue
-            parts.append(f"{py_path}:{st.st_size}:{st.st_mtime_ns}")
+            parts.append(f"{path}:{st.st_size}:{st.st_mtime_ns}")
         return "\0".join(parts)
     except Exception as exc:
-        logger.debug("Could not signature local .py files under %s: %s", model_name, exc)
+        logger.debug("Could not signature local scan inputs under %s: %s", model_name, exc)
         return None
 
 
 def _remote_auto_map_scan_result(model_name: str, hf_token: str | None = None) -> tuple[bool, bool]:
     """Return ``(needs_510, scan_was_definitive)`` for auto_map remote code."""
-    signature = _local_py_signature(model_name)
+    signature = _local_scan_signature(model_name)
     cache_key = (*_token_cache_key(model_name, hf_token), signature)
     if signature is not None and cache_key in _remote_auto_map_needs_510_cache:
         return _remote_auto_map_needs_510_cache[cache_key], True
@@ -1064,7 +1074,13 @@ def _tokenizer_auto_map_needs_v5(
         definitive = all(repo is not None or _safe_is_file(local_root / fn) for repo, fn in refs)
         ext_sources, ext_ok = _collect_external_py_sources(refs, hf_token)
         if any(repo is not None for repo, _ in refs) and not ext_ok:
-            return False, False
+            # An unreachable external repo makes the closure incomplete, so the negative
+            # stays uncached -- but the local sources already read can still PROVE 5.x.
+            # Returning early here would drop that proof and route a checkpoint whose own
+            # tokenizer imports the 5.x-only backend to the default sidecar, so keep the
+            # partial sources and let the marker scan below decide (mirrors
+            # _remote_auto_map_py_contents, which also returns what it managed to read).
+            definitive = False
         sources.extend(ext_sources)
     else:
         # Pass the tokenizer refs: they already prove remote code exists, so a repo
@@ -1085,11 +1101,14 @@ def _check_tokenizer_config_needs_v5(model_name: str, hf_token: str | None = Non
     Checks local tokenizer_config.json, else fetches from HuggingFace (authenticated
     with ``hf_token`` so gated/private repos resolve). Cached in
     ``_tokenizer_class_cache``, keyed by (model, token) so an unauthenticated miss does
-    not poison a later authed read. Returns False on any network/parse error
+    not poison a later authed read, plus the local scan signature so a checkpoint whose
+    tokenizer config or remote code is replaced in this process is re-read rather than
+    answered from the previous contents. Returns False on any network/parse error
     (fail-open to default version).
     """
-    cache_key = _token_cache_key(model_name, hf_token)
-    if cache_key in _tokenizer_class_cache:
+    signature = _local_scan_signature(model_name)
+    cache_key = (*_token_cache_key(model_name, hf_token), signature)
+    if signature is not None and cache_key in _tokenizer_class_cache:
         return _tokenizer_class_cache[cache_key]
 
     # --- Check local tokenizer_config.json first ---------------------------
@@ -1129,7 +1148,10 @@ def _check_tokenizer_config_needs_v5(model_name: str, hf_token: str | None = Non
     # --- Fall back to fetching from HuggingFace ----------------------------
     import urllib.request
 
-    url = f"https://huggingface.co/{model_name}/raw/main/tokenizer_config.json"
+    # Endpoint-aware: a mirror-only deployment (HF_ENDPOINT set, huggingface.co blocked)
+    # must be able to read the tokenizer config, or the auto_map scan it gates below is
+    # never reached and a custom tokenizer silently routes to the default tier.
+    url = _hf_raw_file_url(model_name, "tokenizer_config.json")
     headers = {"User-Agent": "unsloth-studio"}
     if hf_token:
         headers["Authorization"] = f"Bearer {hf_token}"
@@ -1148,12 +1170,13 @@ def _check_tokenizer_config_needs_v5(model_name: str, hf_token: str | None = Non
                 model_name,
                 tokenizer_class,
             )
-        if definitive:
+        if definitive and signature is not None:
             _tokenizer_class_cache[cache_key] = result
         return result
     except Exception as exc:
         logger.debug("Could not fetch tokenizer_config.json for '%s': %s", model_name, exc)
-        _tokenizer_class_cache[cache_key] = False
+        if signature is not None:
+            _tokenizer_class_cache[cache_key] = False
         return False
 
 
@@ -1392,9 +1415,17 @@ def _check_config_needs_530(model_name: str, hf_token: str | None = None) -> boo
     return result
 
 
-def _check_config_needs_510(model_name: str, hf_token: str | None = None) -> bool:
+def _check_config_needs_510(
+    model_name: str,
+    hf_token: str | None = None,
+    scan_auto_map: bool = True,
+) -> bool:
     """Check ``config.json`` for Gemma 4 Unified / 12B architectures (authenticated with
-    ``hf_token``; cached by (model, token) only for a definitive read)."""
+    ``hf_token``; cached by (model, token) only for a definitive read).
+
+    ``scan_auto_map=False`` drops the remote-code scan for the cheap parent-side check
+    (``probe=False``), which only asks "is this 5.x at all" and never activates a sidecar.
+    """
     cache_key = _token_cache_key(model_name, hf_token)
     if cache_key in _config_needs_510_cache:
         return _config_needs_510_cache[cache_key]
@@ -1412,6 +1443,14 @@ def _check_config_needs_510(model_name: str, hf_token: str | None = None) -> boo
             cfg.get("model_type"),
         )
         return True
+
+    if not scan_auto_map:
+        # Same trade as the name fast path: the scan costs a read of every remote-code
+        # config, a recursively paged tree listing and one raw request per .py, which must
+        # not sit on the cheap parent-side path (model inspection, load logging) where a
+        # large repo or a degraded Hub would stall it. Never cached: this negative only
+        # says "no config match", and the activation path (probe=True) still scans.
+        return False
 
     remote_needs, remote_definitive = _remote_auto_map_scan_result(model_name, hf_token)
     if remote_needs:
@@ -2122,7 +2161,7 @@ def get_transformers_tier(
         return tier
 
     # --- Slow config fallbacks (network for HF IDs; authenticated with hf_token) --------
-    if _check_config_needs_510(model_name, hf_token):
+    if _check_config_needs_510(model_name, hf_token, scan_auto_map = probe):
         tier = _raise_tier_for_nested(_load_config_json(model_name, hf_token), "510")
         logger.info("Transformers tier %s selected for %s (config.json check)", tier, model_name)
         return tier

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -200,20 +200,15 @@ _TRANSFORMERS_5_TOKENIZER_CLASSES: set[str] = {
     "TokenizersBackend",
 }
 
-# Import strings in auto_map remote .py the default 4.57.x tier cannot satisfy, but the
-# 5.3 sidecar can (``tokenization_utils_tokenizers`` landed in 5.0.0,
-# ``utils.output_capturing`` in 5.2.0). Fully qualified so a repo's own same-named helper
-# module cannot match. Only modules ABSENT from 4.57.x belong here: ``modeling_layers``
-# (4.52+) and ``use_kernel_forward_from_hub`` (4.51+) import fine on default, so matching
-# them would push ordinary custom-code models (EXAONE, MiniMax, Molmo2, ...) onto a sidecar.
-#
-# ``transformers.TokenizersBackend`` is the public re-export of the same 5.x-only class, so
-# remote code that writes ``from transformers import TokenizersBackend`` never mentions the
-# defining submodule and would otherwise scan clean. Listing the symbol is safe because the
-# name does not exist anywhere in 4.57.x, so no 4.57.x-loadable repo can produce it; only
-# 5.x-only PUBLIC re-exports belong here, never a symbol 4.57.x also exports. The
-# ``transformers.utils.output_capturing`` names (``OutputRecorder``, ``capture_outputs``)
-# have no top-level re-export in 5.3.0, so the module spelling above is their only spelling.
+# Import strings in auto_map remote .py that 4.57.x cannot satisfy but the 5.3 sidecar can.
+# Fully qualified so a repo's own same-named helper cannot match. Only names ABSENT from
+# 4.57.x belong here: ``modeling_layers`` (4.52+) and ``use_kernel_forward_from_hub`` (4.51+)
+# import fine on default, so listing them would push ordinary custom-code models (EXAONE,
+# MiniMax, Molmo2, ...) onto a sidecar. ``transformers.TokenizersBackend`` is the 5.x-only
+# public re-export, listed because remote code writing ``from transformers import
+# TokenizersBackend`` never names the defining submodule; safe since 4.57.x has no such name
+# (only 5.x-only public re-exports belong here). The ``utils.output_capturing`` names have no
+# top-level re-export in 5.3.0, so the module spelling is their only spelling.
 _TRANSFORMERS_5_REMOTE_IMPORT_MARKERS: tuple[str, ...] = (
     "transformers.tokenization_utils_tokenizers",
     "transformers.utils.output_capturing",
@@ -237,9 +232,8 @@ _config_needs_550_cache: dict[tuple[str, str | None], bool] = {}
 _config_needs_530_cache: dict[tuple[str, str | None], bool] = {}
 _remote_auto_map_tier_cache: dict[tuple[str, str | None, str | None], str] = {}
 
-# Models whose config.json got a definitive 401/403/404 (absent, or not readable with this
-# token). Tracked separately from _config_json_cache, which only holds configs we could
-# read, so "no auto_map" from an unread config is never mistaken for "no auto_map".
+# Models whose config.json got a definitive 401/403/404. Kept apart from _config_json_cache
+# (configs we could read) so an unread config is never mistaken for "no auto_map".
 _config_json_absent: set[tuple[str, str | None]] = set()
 
 # AutoConfig-probe tier cache for the process lifetime (cleared on restart), keyed by
@@ -587,10 +581,9 @@ def _adapter_base_from_hf_cache(model_name: str) -> str | None:
 def _redirect_drops_auth(old_url: str, new_url: str) -> bool:
     """True when a redirect from *old_url* to *new_url* must not carry ``Authorization``.
 
-    Same rule ``requests`` (``SessionRedirectMixin.should_strip_auth``), curl and browsers
-    apply: a different host always drops the header, a plain-http to https upgrade of the
-    same host keeps it (that token was already on the wire), and any other scheme or port
-    change drops it. An unparseable ``Location`` drops it too.
+    Same rule as ``requests`` (``SessionRedirectMixin.should_strip_auth``), curl and browsers:
+    a different host drops the header, a same-host http-to-https upgrade keeps it (that token
+    was already on the wire), any other scheme/port change or an unparseable URL drops it.
     """
     from urllib.parse import urlsplit
 
@@ -615,21 +608,18 @@ _hub_opener_cache = None
 def _hub_opener():
     """Opener used by every Hub fetch here that can carry ``Authorization``.
 
-    ``urllib``'s stock ``HTTPRedirectHandler.redirect_request`` copies every header except
-    content-length/content-type onto the redirect target without comparing hosts, so a 3xx
-    replays ``Authorization: Bearer <hf_token>`` to whatever host the ``Location`` names.
-    ``HF_ENDPOINT`` is user-configurable, so that host is not necessarily the Hub. Dropping
-    the header outright is not an option: the Hub 307s ``/gpt2/raw/main/config.json`` to
-    ``/openai-community/gpt2/raw/main/config.json`` and 301s http to https, both same-origin,
-    and a renamed private repo answers 401 unauthenticated (which this module caches as a
-    definitive "absent"). So the handler keeps the header on a same-origin hop and strips it
-    on a cross-origin one.
+    Stock ``HTTPRedirectHandler`` copies every header onto the redirect target without
+    comparing hosts, so a 3xx replays ``Authorization: Bearer <hf_token>`` to whatever host
+    ``Location`` names, and ``HF_ENDPOINT`` is user-configurable. Dropping the header outright
+    is not an option either: the Hub 307s ``/gpt2/...`` to ``/openai-community/gpt2/...`` and
+    301s http to https, both same-origin, and a renamed private repo answers 401
+    unauthenticated (cached here as a definitive "absent"). So keep it same-origin, strip it
+    cross-origin.
 
-    Built once and never handed to ``install_opener``, so the rest of the process keeps stock
-    ``urlopen`` behaviour. ``build_opener`` retains the default proxy/HTTPS handlers, so
-    ``*_PROXY`` / ``NO_PROXY`` work exactly as they did. Racing builders are harmless: the
-    openers are equivalent and stateless. ``urllib.request`` stays a lazy import like every
-    other fetch below, hence the nested handler.
+    Built once and never installed, so the rest of the process keeps stock ``urlopen``;
+    ``build_opener`` retains the default proxy/HTTPS handlers, so ``*_PROXY`` / ``NO_PROXY``
+    still work. Racing builders are harmless (equivalent, stateless). ``urllib.request`` stays
+    a lazy import, hence the nested handler.
     """
     global _hub_opener_cache
     if _hub_opener_cache is not None:
@@ -652,8 +642,7 @@ def _hub_opener():
 def _hub_urlopen(req, timeout = 10):
     """``urlopen`` for the Hub fetches here, via the redirect-aware opener above.
 
-    ``hf_endpoint_unreachable`` deliberately stays on plain ``urlopen``: it sends no
-    credentials, so it has nothing to leak across a redirect.
+    ``hf_endpoint_unreachable`` stays on plain ``urlopen``: it sends no credentials.
     """
     return _hub_opener().open(req, timeout = timeout)
 
@@ -721,21 +710,18 @@ def _hf_api_url(path: str) -> str:
 def _is_same_hub_origin(url: str) -> bool:
     """True when *url* has the same scheme and authority as the configured Hub endpoint.
 
-    Pagination cursors are echoed back by the endpoint and are followed with the caller's
-    ``Authorization: Bearer <hf_token>`` header attached, so a cross-origin ``rel="next"``
-    from a compromised Hub, a hostile mirror or a MITM on a plain-http ``HF_ENDPOINT`` would
-    hand the user's Hub token to an arbitrary host (and turn the backend into an SSRF probe).
-    The real Hub answers with an absolute same-origin cursor, so requiring one costs nothing.
+    Pagination cursors are echoed by the endpoint and followed with the caller's
+    ``Authorization: Bearer <hf_token>``, so a cross-origin ``rel="next"`` would hand the Hub
+    token to an arbitrary host (and make the backend an SSRF probe). The real Hub answers with
+    an absolute same-origin cursor, so requiring one costs nothing.
 
-    Origin is compared as ``(scheme, host, effective port)``, the RFC 6454 tuple, not as raw
-    ``netloc`` text: an endpoint configured as ``https://mirror.internal`` that echoes the
-    equally valid ``https://mirror.internal:443`` is the same origin, and a textual compare
-    would reject it and turn a multi-page listing inconclusive. Normalizing the default port
-    only ever accepts authorities that already denote the configured origin, so it cannot let
-    an attacker-chosen host through -- an explicit port that differs from the endpoint's
-    effective port is still cross-origin. Userinfo is rejected outright: ``hostname`` ignores
-    it, so ``https://user@host`` would compare equal to ``https://host`` while urllib sends
-    the whole ``user@host`` string as the connection host.
+    Compared as the RFC 6454 ``(scheme, host, effective port)`` tuple, not as raw ``netloc``
+    text, so an endpoint ``https://mirror.internal`` echoing ``https://mirror.internal:443``
+    still matches instead of turning a multi-page listing inconclusive; normalizing the default
+    port only accepts authorities that already denote the configured origin, and an explicit
+    differing port is still cross-origin. Userinfo is rejected outright: ``hostname`` ignores
+    it, so ``https://user@host`` would compare equal to ``https://host`` while urllib connects
+    to the whole ``user@host`` string.
     """
     from urllib.parse import urlsplit
 
@@ -762,11 +748,10 @@ def _iter_link_entries(header: str):
     """Yield ``(uri, [(lowercased param name, value), ...])`` per RFC 8288 ``Link`` entry.
 
     Written out rather than split on ``;`` because a parameter value is a quoted string that
-    may itself contain ``;`` or ``,``, and because ``rel`` may sit at any position in the
-    parameter list. Deliberately lenient about the ``<>`` around the URI: the caller's
-    failure mode for an entry it cannot read is to stop paginating, which reports a truncated
-    listing as a complete one, so an unrecognized cursor is the more dangerous answer than an
-    odd one (an odd one is still rejected by :func:`_is_same_hub_origin`).
+    may contain ``;`` or ``,``, and ``rel`` may sit anywhere in the list. Lenient about the
+    ``<>`` around the URI: an unread entry stops pagination and reports a truncated listing as
+    complete, which is worse than accepting an odd cursor (still rejected by
+    :func:`_is_same_hub_origin`).
     """
     i, n = 0, len(header)
     while i < n:
@@ -829,13 +814,11 @@ def _iter_link_entries(header: str):
 def _parse_link_next(link_header: str | None) -> str | None:
     """Next-page URL from an RFC 8288 ``Link`` header, or None.
 
-    ``rel`` may appear at any position among an entry's parameters, may be an unquoted token,
-    and may carry a space-separated list of relation types, which are case-insensitive. Only
-    matching ``rel="next"`` as the first parameter drops a perfectly valid
-    ``<...>; type="application/json"; rel="next"``, and dropping it is not a safe default:
-    :func:`_hf_api_get_json` treats "no next cursor" as "listing finished" and returns the
-    truncated first page with ``success=True``, so a repo whose 5.x-only import sits on a
-    later page would be cached as a confirmed default tier.
+    ``rel`` may sit at any position, be unquoted, and carry a case-insensitive space-separated
+    list. Matching only a leading ``rel="next"`` would drop the valid
+    ``<...>; type="application/json"; rel="next"``, and that is not safe:
+    :func:`_hf_api_get_json` reads "no next cursor" as "listing finished" and returns the
+    truncated page with ``success=True``, caching a later-page 5.x-only import as default tier.
     """
     for uri, params in _iter_link_entries(link_header or ""):
         for name, value in params:
@@ -855,12 +838,11 @@ _HF_API_MAX_PAGES = 200
 def _hf_api_get_json(path: str, hf_token: str | None = None) -> tuple[object | None, bool]:
     """GET a Hub API path via stdlib urllib, following ``Link`` pagination.
 
-    The tree endpoint returns at most ``limit`` entries per response (1000 by default) and
-    advertises the next cursor as ``Link: rel="next"``, which is how ``huggingface_hub``'s
-    own ``list_repo_tree`` walks it. Reading only the first response silently truncates a
-    large repo, so list payloads are concatenated across pages. Returns
-    ``(parsed_json, success)``; success is False if any page fails, so a partial listing is
-    never mistaken for a complete one.
+    The tree endpoint caps each response (1000 entries) and advertises the next cursor as
+    ``Link: rel="next"``, the way ``huggingface_hub``'s ``list_repo_tree`` walks it, so list
+    payloads are concatenated across pages instead of silently truncating a large repo.
+    Returns ``(parsed_json, success)``; success is False if any page fails, so a partial
+    listing is never mistaken for a complete one.
     """
     if _env_offline():
         return None, False
@@ -883,10 +865,8 @@ def _hf_api_get_json(path: str, hf_token: str | None = None) -> tuple[object | N
             merged.extend(payload)
             if not next_url:
                 return merged, True
-            # The cursor URL is echoed by the endpoint; only ever follow it back to that same
-            # origin, since the next request replays the Authorization header verbatim.
-            # Refusing is also the safe answer for the listing: success=False keeps a
-            # truncated tree from passing as a complete one.
+            # The next request replays the Authorization header, so only follow a cursor back
+            # to the same origin; success=False keeps the truncated tree from passing as whole.
             if not _is_same_hub_origin(next_url):
                 logger.debug("Refusing cross-origin Hub pagination link for %s: %s", path, next_url)
                 return None, False
@@ -912,14 +892,11 @@ def _list_hub_repo_py_files(repo_id: str, hf_token: str | None = None) -> tuple[
     }, True
 
 
-# One activation's remote-code scan downloads every ``.py`` the ``auto_map`` closure can
-# reach, and training / inference / export workers run it BEFORE the remote-code consent
-# gate. Unbounded, a selected public repo can hold as many ``.py`` files as the 200-page
-# listing limit allows, or one enormous file, and keep a worker issuing 10-second requests
-# or exhaust its memory before Studio can reject the model. Survey of the 300
-# most-downloaded ``trust_remote_code`` repos: the largest holds 26 ``.py`` (p50 3, p95 11,
-# p99 21), the largest aggregate is 933 KiB and the largest single file is 216 KiB, so these
-# caps sit roughly 5x / 17x / 19x above the worst real repo and truncate none of them.
+# A scan downloads every ``.py`` the ``auto_map`` closure reaches, and workers run it BEFORE
+# the remote-code consent gate, so unbounded a repo could stall or OOM a worker before Studio
+# can reject the model. Survey of the 300 most-downloaded ``trust_remote_code`` repos: largest
+# is 26 ``.py`` (p50 3, p95 11, p99 21), 933 KiB aggregate, 216 KiB single file, so these caps
+# sit ~5x / 17x / 19x above the worst real repo and truncate none of them.
 _REMOTE_SCAN_MAX_FILES = 128
 _REMOTE_SCAN_MAX_TOTAL_CHARS = 16 * 1024 * 1024
 _REMOTE_SCAN_MAX_FILE_BYTES = 4 * 1024 * 1024
@@ -928,12 +905,11 @@ _REMOTE_SCAN_MAX_FILE_BYTES = 4 * 1024 * 1024
 class _RemoteScanBudget:
     """Cap on the remote ``.py`` downloads of ONE scan, shared across every repo it reaches.
 
-    The budget spans the model's own repo and every external ``auto_map`` repo together, so
-    the ceiling is on the whole activation rather than per repo (otherwise N referenced repos
-    multiply it). Running out is reported as an incomplete closure, never as "no 5.x import":
-    the caller turns that into a non-definitive result, so a truncated scan is not memoized
-    as a confirmed default tier. Sources read before the cap are kept, since the scan already
-    trusts a positive from a partial closure.
+    Spanning own repo plus every external ``auto_map`` repo keeps the ceiling on the whole
+    activation, so N referenced repos cannot multiply it. Running out is reported as an
+    incomplete closure, never as "no 5.x import", so a truncated scan is not memoized as a
+    confirmed default tier. Sources read before the cap are kept: the scan already trusts a
+    positive from a partial closure.
     """
 
     __slots__ = ("files_left", "chars_left", "truncated")
@@ -962,11 +938,9 @@ def _fetch_hub_py_sources(
 ) -> tuple[list[str], bool]:
     """Fetch every present ``.py`` in a Hub repo. Returns (sources, definitive).
 
-    A file that fails to fetch (transient error, or removed between the tree listing and
-    the raw request) only makes the closure incomplete; the sources already read are still
-    returned. The scan trusts a positive from a partial closure, so discarding them would
-    throw away an already-observed 5.x-only import and route the worker to a sidecar that
-    cannot import the remote code. A spent *budget* is the same kind of incompleteness.
+    A file that fails to fetch (or a spent *budget*) only makes the closure incomplete; the
+    sources already read are still returned, since discarding them would throw away an
+    already-observed 5.x-only import and route the worker to a sidecar that cannot import it.
     """
     py_files, listing_ok = _list_hub_repo_py_files(repo_id, hf_token)
     if not listing_ok:
@@ -1000,9 +974,8 @@ def _collect_external_py_sources(
     """Fetch all ``.py`` from external repos referenced by ``auto_map``.
 
     Like :func:`_fetch_hub_py_sources`, an unreachable repo marks the closure incomplete
-    without dropping the sources read from the repos that did answer. *budget* is the caller's
-    scan-wide download cap and is threaded through so every referenced repo draws on the same
-    ceiling.
+    without dropping what the repos that did answer returned. *budget* is the caller's
+    scan-wide cap, threaded through so every referenced repo draws on the same ceiling.
     """
     external_repos = {repo for repo, _ in refs if repo is not None}
     if not external_repos:
@@ -1023,9 +996,9 @@ def _auto_map_config_files(model_name: str) -> tuple[str, ...]:
     A processor declared only in ``preprocessor_config.json`` / ``processor_config.json`` /
     ``video_preprocessor_config.json`` (e.g. TencentARC/TimeLens-7B, whose config.json is a
     stock ``qwen2_5_vl``) is still executed by ``AutoProcessor.from_pretrained(...,
-    trust_remote_code=True)``, so restricting a Hub id to ``config.json`` reports a
-    definitive negative for remote code that really does run. The extra reads land only on
-    the probe=True activation path, once per model, and only when the repo is scanned.
+    trust_remote_code=True)``, so reading only ``config.json`` for a Hub id would report a
+    definitive negative for remote code that really runs. The extra reads land only on the
+    probe=True activation path, once per model, and only when the repo is scanned.
     """
     from utils.security.remote_code_scan import REMOTE_CODE_CONFIG_FILES
     return REMOTE_CODE_CONFIG_FILES
@@ -1034,9 +1007,9 @@ def _auto_map_config_files(model_name: str) -> tuple[str, ...]:
 def _repo_auto_map_refs(model_name: str, hf_token: str | None = None) -> tuple[set, bool, bool]:
     """``(refs, has_auto_map, definitive)`` from the repo's remote-code configs.
 
-    Each config is read exactly once. ``definitive`` is False when a config could not be
-    read at all (transient Hub failure, offline Hub id), so "this repo declares no
-    auto_map" is never concluded from a config nobody managed to look at.
+    Each config is read once. ``definitive`` is False when a config could not be read at all
+    (transient Hub failure, offline Hub id), so "declares no auto_map" is never concluded from
+    a config nobody managed to look at.
     """
     from utils.security.remote_code_scan import _auto_map_refs
 
@@ -1058,11 +1031,10 @@ def _repo_auto_map_refs(model_name: str, hf_token: str | None = None) -> tuple[s
 def _decode_source_bytes(raw: bytes) -> str:
     """Decode Python source bytes the way CPython does.
 
-    PEP 263: a BOM or a ``# -*- coding: <enc> -*-`` cookie in the first two lines declares
-    the file's encoding, so a legitimate non-UTF-8 module must not fail to decode here and
-    turn a real 5.x-only import into an unreadable source. ``tokenize.detect_encoding``
-    implements exactly that rule. Undecodable bytes fall back to replacement, matching how
-    local checkpoint files are already read.
+    PEP 263 (a BOM or a ``# -*- coding: <enc> -*-`` cookie in the first two lines), via
+    ``tokenize.detect_encoding``, so a legitimate non-UTF-8 module does not fail to decode and
+    turn a real 5.x-only import into unreadable source. Undecodable bytes fall back to
+    replacement, matching how local checkpoint files are read.
     """
     import io
     import tokenize
@@ -1085,11 +1057,10 @@ def _read_repo_text_file(
 ) -> str | None:
     """Return a repo-relative text file's contents; local first, else HuggingFace raw fetch.
 
-    The remote read stops at ``_REMOTE_SCAN_MAX_FILE_BYTES``. The aggregate budget in
-    :class:`_RemoteScanBudget` can only be charged once a file has been read, so a single
-    oversized source would already be resident by the time it noticed; bounding the read
-    itself is what keeps one enormous ``.py`` from exhausting a worker. Over-cap is reported
-    as an unread file (``None``), which the caller counts as an incomplete closure.
+    The remote read stops at ``_REMOTE_SCAN_MAX_FILE_BYTES``: :class:`_RemoteScanBudget` can
+    only be charged after a file is read, so bounding the read itself is what keeps one
+    enormous ``.py`` from exhausting a worker. Over-cap is reported as an unread file
+    (``None``), which the caller counts as an incomplete closure.
     """
     local_path = Path(model_name) / filename
     if _safe_is_file(local_path):
@@ -1132,18 +1103,16 @@ def _load_repo_json_checked(
     filename: str,
     hf_token: str | None = None,
 ) -> tuple[dict | None, bool]:
-    """``(parsed_json, definitive)`` for a repo-relative JSON file; local first, else a raw
-    Hub fetch.
+    """``(parsed_json, definitive)`` for a repo-relative JSON file; local first, else raw Hub.
 
-    ``definitive`` is False only when the answer is genuinely unknown: a transient remote
-    failure, or an offline Hub id. A local read, a 401/403/404 and a parse error are all
-    definitive answers, so only a read that never happened blocks caching.
+    ``definitive`` is False only when the answer is genuinely unknown (transient remote
+    failure, offline Hub id); a local read, a 401/403/404 and a parse error are all definitive,
+    so only a read that never happened blocks caching.
 
-    A local checkpoint's ``config.json`` is read straight from disk like every other config
-    here, NOT through ``_load_config_json``: that cache lives for the process and would keep
-    serving the pre-rewrite contents to a rescan the changed scan signature just forced (a
-    staged checkpoint that writes its code first and its ``auto_map`` afterwards), which
-    would then memoize a fresh negative under the new signature.
+    A local checkpoint's ``config.json`` is read straight from disk, NOT through
+    ``_load_config_json``: that process-lifetime cache would serve pre-rewrite contents to the
+    rescan a changed scan signature just forced (a staged checkpoint writing code first and
+    ``auto_map`` afterwards), memoizing a fresh negative under the new signature.
     """
     if filename == "config.json" and not _safe_is_dir(Path(model_name)):
         cfg = _load_config_json(model_name, hf_token)
@@ -1192,20 +1161,18 @@ def _remote_auto_map_py_contents(
     """Executable remote-code sources transformers may load (own, helper, external).
 
     Stdlib-only (urllib + HF REST API) so tier detection never imports ``huggingface_hub``
-    before a transformers sidecar is activated. ``known_refs`` are ``auto_map`` refs the
-    caller already parsed (tokenizer/processor config), which both proves remote code
-    exists and saves re-reading that config. Returns ``(sources, definitive)``; when
-    ``definitive`` is False the scan was incomplete and negatives must not be cached.
+    before a sidecar is activated. ``known_refs`` are ``auto_map`` refs the caller already
+    parsed, which both proves remote code exists and saves re-reading that config. Returns
+    ``(sources, definitive)``; when ``definitive`` is False negatives must not be cached.
     """
     own_refs, has_auto_map, cfg_definitive = _repo_auto_map_refs(model_name, hf_token)
     if not known_refs and not has_auto_map:
-        # An unread config proves nothing: report it as inconclusive rather than as a
-        # repo that declares no auto_map, so the negative is not cached until a real read.
+        # An unread config proves nothing: inconclusive, not "declares no auto_map", so the
+        # negative is not cached until a real read.
         return [], cfg_definitive
 
     ext_refs: set = set(known_refs or ()) | own_refs
-    # One ceiling for the whole closure: the model's own repo and every external auto_map
-    # repo draw on the same file/byte budget, so N referenced repos cannot multiply it.
+    # One ceiling for the whole closure, so N referenced repos cannot multiply it.
     budget = _RemoteScanBudget()
 
     local_root = Path(model_name)
@@ -1227,8 +1194,8 @@ def _remote_auto_map_py_contents(
     if _env_offline() or not _looks_like_hf_id(model_name):
         return [], False
 
-    # An incomplete own-repo listing/fetch does not end the scan: the external repos may
-    # still hold the marker, and whatever was read stays available to prove the tier.
+    # An incomplete own-repo listing does not end the scan: the external repos may still hold
+    # the marker, and whatever was read stays available to prove the tier.
     sources, repo_ok = _fetch_hub_py_sources(model_name, hf_token, budget)
     ext_sources, ext_ok = _collect_external_py_sources(ext_refs, hf_token, budget)
     sources.extend(ext_sources)
@@ -1238,32 +1205,26 @@ def _remote_auto_map_py_contents(
 
 
 def _parsed_dotted_imports(src: str) -> set[str] | None:
-    """Absolute module paths *src* imports, resolved with ``ast``; ``None`` if it does not
-    parse.
+    """Absolute module paths *src* imports, resolved with ``ast``; ``None`` if it does not parse.
 
-    Catches what a per-line substring scan cannot: a parenthesized multi-line import, and
-    the equivalent ``from <parent> import <submodule>`` spelling. Relative imports are
-    skipped (a repo's own same-named helper must not match). ``None`` (unparseable) and an
-    empty set (parsed, imports nothing) are different answers, so the caller only falls
-    back to the line scan for source ``ast`` could not read at all.
+    Catches what a per-line substring scan cannot: parenthesized multi-line imports and the
+    ``from <parent> import <submodule>`` spelling. Relative imports are skipped (a repo's own
+    same-named helper must not match). ``None`` (unparseable) and an empty set (parsed, imports
+    nothing) differ, so the caller only falls back to the line scan for unreadable source.
 
-    Bodies of ``if TYPE_CHECKING:`` are skipped: that guard is false at runtime, so a
-    type-only annotation import never executes and must not promote an otherwise
-    4.57.x-loadable custom model onto a 5.x sidecar. Only the guard's own body is dropped;
-    its ``else`` / ``elif`` branches do run and are still collected, and ``if not
-    TYPE_CHECKING:`` is not the guard, so its body is collected too.
+    ``if TYPE_CHECKING:`` bodies are skipped: that guard is false at runtime, so a type-only
+    import must not promote an otherwise 4.57.x-loadable model onto a sidecar. Only the guard's
+    own body is dropped; its ``else``/``elif`` branches and ``if not TYPE_CHECKING:`` do run
+    and are collected.
 
-    ``importlib.import_module("pkg.mod")`` / ``__import__("pkg.mod")`` count too: remote code
-    that loads a versioned module that way really does import it at runtime, and recording
-    nothing would route the model to a sidecar where that call raises. Only a literal string
-    argument is read, so a marker sitting in a docstring, a comment or any other inert
-    literal still cannot promote the tier; a computed or f-string name is left alone.
+    ``importlib.import_module("pkg.mod")`` / ``__import__("pkg.mod")`` count, since that call
+    really imports at runtime and would raise on the wrong sidecar. Only literal string args
+    are read, so a marker in a docstring, comment or other inert literal cannot promote the
+    tier, and computed or f-string names are left alone.
 
-    Qualified access counts too: ``import transformers`` then ``transformers.X`` is the
-    ordinary spelling of a public-export marker, and recording only the module would route
-    that code to a sidecar where the attribute does not exist. Module aliases and an aliased
-    ``import_module`` resolve through the file's own bindings, so a name that was never
-    imported still contributes nothing.
+    Qualified access counts too: ``import transformers`` then ``transformers.X`` is the usual
+    spelling of a public-export marker. Aliases (including an aliased ``import_module``)
+    resolve through the file's own bindings, so a never-imported name contributes nothing.
     """
     import ast
 
@@ -1286,7 +1247,7 @@ def _parsed_dotted_imports(src: str) -> set[str] | None:
         arg = node.args[0]
         if not isinstance(arg, ast.Constant) or not isinstance(arg.value, str):
             return None
-        # A leading dot is a relative import, skipped for the same reason as ImportFrom.
+        # A leading dot is relative, skipped for the same reason as ImportFrom.
         return None if arg.value.startswith(".") else (called, arg.value)
 
     def _attribute_chain(node) -> tuple[str, str] | None:
@@ -1338,7 +1299,7 @@ def _parsed_dotted_imports(src: str) -> set[str] | None:
                     names.add(module)
                 elif isinstance(node.func, ast.Name):
                     deferred.append((called, module))
-            # Not a terminal node: keep walking so a nested call or import still counts.
+            # Not terminal: keep walking so a nested call or import still counts.
         stack.extend(ast.iter_child_nodes(node))
     # Resolved after the walk: a binding can sit below the use that needs it.
     for root, attr in chains:
@@ -1359,11 +1320,10 @@ def _imported_dotted_names(src: str) -> set[str]:
 def _remote_auto_map_py_matches(markers: tuple[str, ...], sources: list[str]) -> bool:
     """True when a source *imports* one of *markers*.
 
-    Import statements only: a marker sitting in a docstring, a comment or any other string
-    literal must not promote the tier, since ``ast`` resolves what the module actually
-    imports. Source that ``ast`` cannot parse still falls back to the raw line scan, so
-    unparseable remote code never turns into a silent negative that crashes on the default
-    tier; that fallback is the only place a substring match is trusted.
+    Import statements only, resolved by ``ast``, so a marker in a docstring, comment or other
+    string literal cannot promote the tier. Source ``ast`` cannot parse falls back to the raw
+    line scan (the only place a substring match is trusted), so unparseable remote code never
+    becomes a silent negative that crashes on the default tier.
     """
     if not markers:
         return False
@@ -1387,27 +1347,20 @@ def _local_scan_signature(model_name: str) -> str | None:
     """Signature of a local checkpoint's scan inputs (path + size + mtime + ctime + inode),
     or ``""`` for a Hub id. ``None`` when the walk fails, which means "do not cache".
 
-    Covers the ``.py`` files AND every config that can declare an ``auto_map``, because both
-    decide the answer. A checkpoint materialized in stages can land its code first and gain
-    the ``auto_map`` afterwards: signing only the ``.py`` would keep serving the earlier
-    "no remote code" negative although not one byte of the new declaration was ever read.
+    Covers the ``.py`` files AND every config that can declare an ``auto_map``, since both
+    decide the answer: a checkpoint materialized in stages can land its code first and gain the
+    ``auto_map`` later, and signing only the ``.py`` would keep serving the earlier "no remote
+    code" negative. Folded into the scan cache keys (mirrors ``_probe_cache_key``) so a
+    replaced checkpoint is re-scanned instead of reusing a stale answer.
 
-    Folded into the scan cache keys (mirrors ``_probe_cache_key``) so a checkpoint whose
-    remote code or whose declaration is written or replaced after a first lookup is
-    re-scanned instead of reusing a stale answer.
-
-    Size and mtime alone do not see a same-sized replacement that restores the timestamp,
-    which is what an archival redeploy does (``rsync --archive``, ``tar -xp``): the
-    signature stays byte-identical and a long-lived worker keeps serving the tier it
-    computed from code that is no longer on disk. ``st_ctime_ns`` moves on any write to an
-    existing inode and ``st_ino`` moves when the file is replaced by rename, so the two
-    together cover both spellings of that redeploy at no extra cost -- both fields come
-    from the ``stat`` call already being made. A digest would also work but would read
-    every ``.py`` on each lookup, and this signature is recomputed on the hot path. On
-    Windows ``st_ctime_ns`` is a creation time rather than a change time, so only the
-    ``st_ino`` half applies there; that is strictly more than the previous signature saw.
-    A spurious miss (a touch, a chmod, a restore that moves the inode without changing
-    content) only costs one re-scan of local files, so this errs toward re-reading.
+    Size and mtime alone miss a same-sized replacement that restores the timestamp, i.e. an
+    archival redeploy (``rsync --archive``, ``tar -xp``), leaving a long-lived worker serving a
+    tier computed from code no longer on disk. ``st_ctime_ns`` moves on any write to an
+    existing inode and ``st_ino`` moves on replace-by-rename, so together they cover both
+    spellings for free (same ``stat`` call); a digest would work but would re-read every ``.py``
+    on this hot path. On Windows ``st_ctime_ns`` is a creation time, so only the ``st_ino`` half
+    applies, still more than before. A spurious miss costs one local re-scan, so this errs
+    toward re-reading.
     """
     root = Path(model_name)
     if not _safe_is_dir(root):
@@ -1420,8 +1373,7 @@ def _local_scan_signature(model_name: str) -> str | None:
             try:
                 st = path.stat()
             except OSError:
-                # Absent (or unreadable) contributes nothing; it starts contributing the
-                # moment it appears, which is exactly the change we must notice.
+                # Absent contributes nothing, and starts contributing the moment it appears.
                 continue
             parts.append(f"{path}:{st.st_size}:{st.st_mtime_ns}:{st.st_ctime_ns}:{st.st_ino}")
         return "\0".join(parts)
@@ -1433,9 +1385,8 @@ def _local_scan_signature(model_name: str) -> str | None:
 def _hf_cache_snapshot_dir(model_name: str) -> Path | None:
     """Newest local HF hub cache snapshot directory for a Hub id, or None.
 
-    Stdlib-only path resolution mirroring :func:`_config_json_from_hf_cache` (no
-    ``huggingface_hub`` import), so tier detection never loads the default-env hub before a
-    sidecar venv is activated.
+    Stdlib-only path resolution mirroring :func:`_config_json_from_hf_cache`, so tier detection
+    never loads the default-env ``huggingface_hub`` before a sidecar venv is activated.
     """
     # Only a canonical ``owner/repo`` Hub id maps to a cache dir; reject local paths.
     if not model_name or model_name.count("/") != 1 or model_name[0] in "/.~" or "\\" in model_name:
@@ -1453,8 +1404,8 @@ def _hf_cache_snapshot_dir(model_name: str) -> Path | None:
     try:
         if ref_main.is_file():
             candidates.append(repo_dir / "snapshots" / ref_main.read_text().strip())
-        # No refs/main (e.g. commit-pinned downloads): newest snapshot by mtime, not a stale
-        # lexicographically-first SHA, matching what the Hub cache would actually load.
+        # No refs/main (commit-pinned downloads): newest snapshot by mtime, not a stale
+        # lexicographically-first SHA, matching what the Hub cache would load.
         candidates += sorted(repo_dir.glob("snapshots/*"), key = _safe_mtime, reverse = True)
         for path in candidates:
             if path.is_dir():
@@ -1468,24 +1419,21 @@ def _remote_auto_map_tier(model_name: str, hf_token: str | None = None) -> tuple
     """Return ``(tier, scan_was_definitive)`` for auto_map remote code.
 
     ``"510"`` when the closure imports a symbol no sidecar below 5.10 has, ``"530"`` when it
-    imports a module absent from 4.57.x but present in 5.3, else ``"default"``. The 5.x
-    marker is classified here and not only in the tokenizer check because remote code reached
-    through ``config.json`` or a processor config is never scanned by that check when
-    ``tokenizer_config.json`` does not itself declare the module: the worker would then
-    pick the default 4.57.x tier, which does not ship
-    ``transformers.tokenization_utils_tokenizers`` at all.
+    imports a module absent from 4.57.x but present in 5.3, else ``"default"``. Classified here
+    and not only in the tokenizer check because remote code reached through ``config.json`` or
+    a processor config is never scanned by that check unless ``tokenizer_config.json`` itself
+    declares the module, leaving the worker on 4.57.x for code that needs 5.x.
     """
     signature = _local_scan_signature(model_name)
     cache_key = (*_token_cache_key(model_name, hf_token), signature)
     if signature is not None and cache_key in _remote_auto_map_tier_cache:
         return _remote_auto_map_tier_cache[cache_key], True
 
-    # Offline Hub id: the Hub cannot be listed, but a previously downloaded snapshot is
-    # exactly the code an offline load would execute, so scan that instead of assuming the
-    # model has no 5.x-only import (which would activate 4.57.x and crash on a repo whose
-    # files are all present locally). The answer is still reported as non-definitive: the
-    # external auto_map repos cannot be reached offline, and nothing is cached under the Hub
-    # id, so a later online read re-fetches (mirrors _check_tokenizer_config_needs_v5).
+    # Offline Hub id: a downloaded snapshot is exactly the code an offline load would execute,
+    # so scan it rather than assume no 5.x-only import (which would activate 4.57.x and crash
+    # on a repo whose files are all local). Still non-definitive, since external auto_map repos
+    # are unreachable offline, and nothing is cached under the Hub id, so a later online read
+    # re-fetches (mirrors _check_tokenizer_config_needs_v5).
     if _env_offline() and not _safe_is_dir(Path(model_name)):
         snapshot = _hf_cache_snapshot_dir(model_name)
         if snapshot is None:
@@ -1503,18 +1451,14 @@ def _remote_auto_map_tier(model_name: str, hf_token: str | None = None) -> tuple
     else:
         tier = "default"
     if not definitive and tier == "default" and not _safe_is_dir(Path(model_name)):
-        # An inconclusive scan is not a negative. Nothing was read that says "default";
-        # the Hub simply did not answer, and the caller (get_transformers_tier) can only
-        # see the tier, so a bare "default" here is indistinguishable from a repo that
-        # really has no 5.x import and activates 4.57.x for code that needs 5.x. A
-        # snapshot already in the hub cache is the same code an offline load would
-        # execute, so read it instead of guessing -- the same fallback the _env_offline
-        # branch above makes, now also for a transient failure while nominally online.
-        # Only ever raises the tier (_higher_tier), and the answer stays non-definitive so
-        # nothing is cached under the Hub id and a recovered Hub re-scans. Deliberately
-        # not a blanket 5.3 floor: an unread config is inconclusive for every model, so
-        # flooring here would push plain non-remote-code repos onto the 5.3 sidecar for
-        # the length of any Hub outage.
+        # An inconclusive scan is not a negative: the caller only sees the tier, so a bare
+        # "default" here is indistinguishable from a repo that really has no 5.x import and
+        # would activate 4.57.x for code needing 5.x. A hub-cache snapshot is the same code an
+        # offline load would execute, so read it rather than guess -- the _env_offline fallback
+        # above, now also for a transient failure while nominally online. Only ever raises the
+        # tier, and stays non-definitive so a recovered Hub re-scans. Deliberately not a blanket
+        # 5.3 floor: an unread config is inconclusive for every model, so flooring would push
+        # plain non-remote-code repos onto the 5.3 sidecar for the length of any Hub outage.
         snapshot = _hf_cache_snapshot_dir(model_name)
         if snapshot is not None:
             tier = _higher_tier(tier, _remote_auto_map_tier(str(snapshot), hf_token)[0])
@@ -1533,16 +1477,14 @@ def _check_remote_auto_map_needs_510(model_name: str, hf_token: str | None = Non
     """True when auto_map remote code imports transformers>=5.10-only symbols.
 
     While ``_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS`` is empty the answer is False for every
-    repo, so the scan is skipped instead of run: it would read each remote-code config, page
-    the repo tree and fetch every ``.py`` only to reach the answer it already has. That cost
-    lands on the name fast path, where common Qwen/Ministral/... activations otherwise pay a
-    string of Hub round trips that cannot move the tier.
+    repo, so the scan is skipped rather than run: it would read each remote-code config, page
+    the repo tree and fetch every ``.py`` to reach an answer it already has, and that cost lands
+    on the name fast path where common activations cannot move the tier anyway.
 
-    Gated on the tuple rather than removed at the call site, so re-adding a 5.10-only module
-    restores the scan everywhere by itself. The 5.3 classification the same scan produces is
-    not lost: callers that need it go through :func:`_remote_auto_map_tier` directly, and
-    :func:`_check_config_needs_510` still calls :func:`_remote_auto_map_scan_result` for the
-    ``definitive`` flag that decides whether its negative may be cached.
+    Gated on the tuple rather than at the call site, so re-adding a 5.10-only module restores
+    the scan everywhere by itself. The 5.3 classification is not lost: callers that need it go
+    through :func:`_remote_auto_map_tier`, and :func:`_check_config_needs_510` still calls
+    :func:`_remote_auto_map_scan_result` for the ``definitive`` flag.
     """
     if not _TRANSFORMERS_510_REMOTE_IMPORT_MARKERS:
         return False
@@ -1555,10 +1497,9 @@ def _tokenizer_auto_map_needs_v5(
 ) -> tuple[bool, bool]:
     """``(needs_v5, definitive)`` for the tokenizer ``auto_map`` closure.
 
-    ``definitive`` is False when the closure could not be read in full (missing local
-    file, unreachable external repo, incomplete Hub listing/fetch), so the caller must
-    not cache the negative and keep routing to the default sidecar once the Hub or the
-    checkpoint recovers.
+    ``definitive`` is False when the closure could not be read in full (missing local file,
+    unreachable external repo, incomplete Hub listing), so the caller must not cache the
+    negative and keep routing to the default sidecar once the Hub or checkpoint recovers.
     """
     from utils.security.remote_code_scan import _auto_map_refs
 
@@ -1576,22 +1517,20 @@ def _tokenizer_auto_map_needs_v5(
                 except Exception as exc:
                     logger.debug("Could not read %s: %s", py_path, exc)
                     return False, False
-        # An own-repo entry file that has not been written yet (in-progress checkpoint)
-        # means the closure is incomplete, not that it is 4.x-safe.
+        # An unwritten own-repo entry file (in-progress checkpoint) means the closure is
+        # incomplete, not that it is 4.x-safe.
         definitive = all(repo is not None or _safe_is_file(local_root / fn) for repo, fn in refs)
         ext_sources, ext_ok = _collect_external_py_sources(refs, hf_token, _RemoteScanBudget())
         if any(repo is not None for repo, _ in refs) and not ext_ok:
-            # An unreachable external repo makes the closure incomplete, so the negative
-            # stays uncached -- but the local sources already read can still PROVE 5.x.
-            # Returning early here would drop that proof and route a checkpoint whose own
-            # tokenizer imports the 5.x-only backend to the default sidecar, so keep the
-            # partial sources and let the marker scan below decide (mirrors
-            # _remote_auto_map_py_contents, which also returns what it managed to read).
+            # An unreachable external repo leaves the closure incomplete (negative uncached),
+            # but the local sources already read can still PROVE 5.x, so keep them and let the
+            # marker scan below decide instead of returning early and routing a checkpoint
+            # whose own tokenizer imports the 5.x-only backend to the default sidecar.
             definitive = False
         sources.extend(ext_sources)
     else:
-        # Pass the tokenizer refs: they already prove remote code exists, so a repo
-        # whose only auto_map is the tokenizer's is still scanned.
+        # The tokenizer refs already prove remote code exists, so a repo whose only auto_map
+        # is the tokenizer's is still scanned.
         sources, definitive = _remote_auto_map_py_contents(model_name, hf_token, known_refs = refs)
         if not definitive and not sources:
             return False, False
@@ -1605,13 +1544,10 @@ def _tokenizer_auto_map_needs_v5(
 def _check_tokenizer_config_needs_v5(model_name: str, hf_token: str | None = None) -> bool:
     """True if the model's tokenizer_class requires transformers 5.x.
 
-    Checks local tokenizer_config.json, else fetches from HuggingFace (authenticated
-    with ``hf_token`` so gated/private repos resolve). Cached in
-    ``_tokenizer_class_cache``, keyed by (model, token) so an unauthenticated miss does
-    not poison a later authed read, plus the local scan signature so a checkpoint whose
-    tokenizer config or remote code is replaced in this process is re-read rather than
-    answered from the previous contents. Returns False on any network/parse error
-    (fail-open to default version).
+    Checks local tokenizer_config.json, else fetches from HuggingFace (authenticated with
+    ``hf_token`` so gated/private repos resolve). Cached by (model, token) so an unauthenticated
+    miss cannot poison a later authed read, plus the local scan signature so a replaced
+    checkpoint is re-read. Returns False on any network/parse error (fail-open to default).
     """
     signature = _local_scan_signature(model_name)
     cache_key = (*_token_cache_key(model_name, hf_token), signature)
@@ -1655,9 +1591,8 @@ def _check_tokenizer_config_needs_v5(model_name: str, hf_token: str | None = Non
     # --- Fall back to fetching from HuggingFace ----------------------------
     import urllib.request
 
-    # Endpoint-aware: a mirror-only deployment (HF_ENDPOINT set, huggingface.co blocked)
-    # must be able to read the tokenizer config, or the auto_map scan it gates below is
-    # never reached and a custom tokenizer silently routes to the default tier.
+    # Endpoint-aware: a mirror-only deployment (HF_ENDPOINT set, huggingface.co blocked) must
+    # still read this, or the auto_map scan it gates is never reached.
     url = _hf_raw_file_url(model_name, "tokenizer_config.json")
     headers = {"User-Agent": "unsloth-studio"}
     if hf_token:
@@ -1773,9 +1708,8 @@ def _load_config_json(model_name: str, hf_token: str | None = None) -> dict | No
     import urllib.error
     import urllib.request
 
-    # Endpoint-aware: a mirror-only deployment (HF_ENDPOINT set, huggingface.co blocked)
-    # must be able to read the config that gates the whole auto_map scan, or the
-    # endpoint-aware tree/raw requests below it are never reached.
+    # Endpoint-aware: a mirror-only deployment (HF_ENDPOINT set, huggingface.co blocked) must
+    # still read the config that gates the whole auto_map scan.
     url = _hf_raw_file_url(model_name, "config.json")
     headers = {"User-Agent": "unsloth-studio"}
     if hf_token:
@@ -1787,8 +1721,8 @@ def _load_config_json(model_name: str, hf_token: str | None = None) -> dict | No
         _config_json_cache[cache_key] = cfg
         return cfg
     except urllib.error.HTTPError as exc:
-        # 401/403/404 is a definitive access answer: never serve another caller's cached
-        # private metadata to an unauthenticated/wrong-token request.
+        # A definitive access answer: never serve cached private metadata to a wrong-token
+        # or unauthenticated request.
         if exc.code in (401, 403, 404):
             logger.debug("config.json access denied for '%s': %s", model_name, exc)
             _config_json_absent.add(cache_key)
@@ -1808,11 +1742,9 @@ def _config_json_is_definitive(model_name: str, hf_token: str | None = None) -> 
 
 
 def _config_json_answer_is_definitive(model_name: str, hf_token: str | None = None) -> bool:
-    """True when ``_load_config_json`` actually established an answer for this model+token.
-
-    Either it read a config (cached) or the Hub said 401/403/404. A transient failure
-    stores neither, so "no config" stays inconclusive and no negative gets cached.
-    """
+    """True when ``_load_config_json`` established an answer for this model+token: it read a
+    config (cached) or the Hub said 401/403/404. A transient failure stores neither, so "no
+    config" stays inconclusive and no negative gets cached."""
     key = _token_cache_key(model_name, hf_token)
     return key in _config_json_cache or key in _config_json_absent
 
@@ -1952,11 +1884,10 @@ def _check_config_needs_510(
         return True
 
     if not scan_auto_map:
-        # Same trade as the name fast path: the scan costs a read of every remote-code
-        # config, a recursively paged tree listing and one raw request per .py, which must
-        # not sit on the cheap parent-side path (model inspection, load logging) where a
-        # large repo or a degraded Hub would stall it. Never cached: this negative only
-        # says "no config match", and the activation path (probe=True) still scans.
+        # The scan costs a read of every remote-code config, a paged tree listing and one raw
+        # request per .py, too much for the cheap parent-side path (model inspection, load
+        # logging) where a large repo or degraded Hub would stall it. Never cached: this
+        # negative only says "no config match", and probe=True still scans.
         return False
 
     remote_needs, remote_definitive = _remote_auto_map_scan_result(model_name, hf_token)
@@ -2625,9 +2556,8 @@ def get_transformers_tier(
                     return "530"
                 return _probe_tier(model_name, hf_token, "local tokenizer needs 5.x")
             # Remote code declared by config.json / a processor config that imports the
-            # 5.x-only tokenizers backend. The tokenizer check above only walks the closure
-            # tokenizer_config.json itself declares, so without this the module would route
-            # to the default tier that cannot import it. 510 already returned above.
+            # 5.x-only tokenizers backend: the check above only walks the closure
+            # tokenizer_config.json declares. 510 already returned above.
             if remote_tier != "default":
                 if not probe:
                     return "530"
@@ -2661,10 +2591,9 @@ def get_transformers_tier(
         # in the pinned case, keeping the pre-latest path I/O-free.
         if latest_venv_pinned_version() is not None:
             tier = _raise_tier_for_nested(_load_config_json(model_name, hf_token), tier)
-        # Only on the activation path: the name already resolved a 5.x tier, so the scan
-        # can only pick 510 over 530/550. Running it for probe=False would add a repo
-        # listing plus a fetch per remote .py to the cheap parent-side check, which only
-        # asks "is this 5.x at all" (needs_transformers_5) or "is this latest".
+        # Activation path only: the name already resolved a 5.x tier, so the scan can only
+        # pick 510 over 530/550, and probe=False must not pay a repo listing plus a fetch
+        # per remote .py just to answer "is this 5.x at all".
         if probe and _check_remote_auto_map_needs_510(model_name, hf_token):
             tier = _higher_tier(tier, "510")
             tier = _raise_tier_for_nested(_load_config_json(model_name, hf_token), tier)
@@ -2722,12 +2651,11 @@ def get_transformers_tier(
         return _probe_tier(model_name, hf_token, "tokenizer needs 5.x")
 
     # Same gap as the local branch, for a Hub id: remote code declared outside
-    # tokenizer_config.json that imports the 5.x-only tokenizers backend. Only on the
-    # activation path -- probe=False must not pay for a repo listing plus a fetch per
-    # remote .py (see _check_config_needs_510's scan_auto_map note). 510 already returned
-    # from _check_config_needs_510 above, so this can only add the 5.3 floor. That call
-    # memoized the scan, so this is a cache hit; it re-scans only when the closure could
-    # not be read in full, which is exactly when a negative must not be trusted.
+    # tokenizer_config.json that imports the 5.x-only tokenizers backend. Activation path
+    # only (see _check_config_needs_510's scan_auto_map note). 510 already returned above, so
+    # this can only add the 5.3 floor, and that call memoized the scan, so it is a cache hit
+    # except when the closure could not be read in full, which is when a negative must not
+    # be trusted anyway.
     if probe and _remote_auto_map_tier(model_name, hf_token)[0] != "default":
         return _probe_tier(model_name, hf_token, "auto_map needs 5.x")
 

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -206,9 +206,18 @@ _TRANSFORMERS_5_TOKENIZER_CLASSES: set[str] = {
 # module cannot match. Only modules ABSENT from 4.57.x belong here: ``modeling_layers``
 # (4.52+) and ``use_kernel_forward_from_hub`` (4.51+) import fine on default, so matching
 # them would push ordinary custom-code models (EXAONE, MiniMax, Molmo2, ...) onto a sidecar.
+#
+# ``transformers.TokenizersBackend`` is the public re-export of the same 5.x-only class, so
+# remote code that writes ``from transformers import TokenizersBackend`` never mentions the
+# defining submodule and would otherwise scan clean. Listing the symbol is safe because the
+# name does not exist anywhere in 4.57.x, so no 4.57.x-loadable repo can produce it; only
+# 5.x-only PUBLIC re-exports belong here, never a symbol 4.57.x also exports. The
+# ``transformers.utils.output_capturing`` names (``OutputRecorder``, ``capture_outputs``)
+# have no top-level re-export in 5.3.0, so the module spelling above is their only spelling.
 _TRANSFORMERS_5_REMOTE_IMPORT_MARKERS: tuple[str, ...] = (
     "transformers.tokenization_utils_tokenizers",
     "transformers.utils.output_capturing",
+    "transformers.TokenizersBackend",
 )
 
 # Remote modeling imports that not even the 5.3 sidecar can satisfy. A module belongs here
@@ -717,22 +726,122 @@ def _is_same_hub_origin(url: str) -> bool:
     from a compromised Hub, a hostile mirror or a MITM on a plain-http ``HF_ENDPOINT`` would
     hand the user's Hub token to an arbitrary host (and turn the backend into an SSRF probe).
     The real Hub answers with an absolute same-origin cursor, so requiring one costs nothing.
+
+    Origin is compared as ``(scheme, host, effective port)``, the RFC 6454 tuple, not as raw
+    ``netloc`` text: an endpoint configured as ``https://mirror.internal`` that echoes the
+    equally valid ``https://mirror.internal:443`` is the same origin, and a textual compare
+    would reject it and turn a multi-page listing inconclusive. Normalizing the default port
+    only ever accepts authorities that already denote the configured origin, so it cannot let
+    an attacker-chosen host through -- an explicit port that differs from the endpoint's
+    effective port is still cross-origin. Userinfo is rejected outright: ``hostname`` ignores
+    it, so ``https://user@host`` would compare equal to ``https://host`` while urllib sends
+    the whole ``user@host`` string as the connection host.
     """
     from urllib.parse import urlsplit
 
     base = urlsplit(_hf_endpoint_base())
     nxt = urlsplit(url)
-    if nxt.scheme not in ("http", "https"):
+    nxt_scheme = nxt.scheme.lower()
+    if nxt_scheme not in ("http", "https") or "@" in nxt.netloc:
         return False
-    return (nxt.scheme.lower(), nxt.netloc.lower()) == (base.scheme.lower(), base.netloc.lower())
+    defaults = {"http": 80, "https": 443}
+    base_scheme = base.scheme.lower()
+    try:
+        base_port = base.port or defaults.get(base_scheme)
+        nxt_port = nxt.port or defaults.get(nxt_scheme)
+    except ValueError:
+        return False  # out-of-range or non-numeric port
+    return (nxt_scheme, (nxt.hostname or "").lower(), nxt_port) == (
+        base_scheme, (base.hostname or "").lower(), base_port,
+    )
+
+
+def _iter_link_entries(header: str):
+    """Yield ``(uri, [(lowercased param name, value), ...])`` per RFC 8288 ``Link`` entry.
+
+    Written out rather than split on ``;`` because a parameter value is a quoted string that
+    may itself contain ``;`` or ``,``, and because ``rel`` may sit at any position in the
+    parameter list. Deliberately lenient about the ``<>`` around the URI: the caller's
+    failure mode for an entry it cannot read is to stop paginating, which reports a truncated
+    listing as a complete one, so an unrecognized cursor is the more dangerous answer than an
+    odd one (an odd one is still rejected by :func:`_is_same_hub_origin`).
+    """
+    i, n = 0, len(header)
+    while i < n:
+        while i < n and header[i] in ", \t":
+            i += 1
+        if i >= n:
+            return
+        if header[i] == "<":
+            end = header.find(">", i)
+            if end == -1:
+                return  # unterminated URI: the rest of the header cannot be split reliably
+            uri = header[i + 1:end].strip()
+            i = end + 1
+        else:
+            start = i
+            while i < n and header[i] not in ";,":
+                i += 1
+            uri = header[start:i].strip()
+        params: list[tuple[str, str]] = []
+        while i < n and header[i] != ",":
+            while i < n and header[i] in " \t":
+                i += 1
+            if i >= n or header[i] == ",":
+                break
+            if header[i] != ";":
+                return  # junk between parameters: stop rather than mis-attribute a rel
+            i += 1
+            start = i
+            while i < n and header[i] not in "=;,":
+                i += 1
+            name = header[start:i].strip().lower()
+            value = ""
+            if i < n and header[i] == "=":
+                i += 1
+                while i < n and header[i] in " \t":
+                    i += 1
+                if i < n and header[i] == '"':
+                    i += 1
+                    buf: list[str] = []
+                    while i < n and header[i] != '"':
+                        if header[i] == "\\" and i + 1 < n:
+                            i += 1
+                        buf.append(header[i])
+                        i += 1
+                    value = "".join(buf)
+                    i += 1  # closing quote
+                    while i < n and header[i] not in ";,":
+                        i += 1  # trailing junk after a quoted value
+                else:
+                    start = i
+                    while i < n and header[i] not in ";,":
+                        i += 1
+                    value = header[start:i].strip()
+            if name:
+                params.append((name, value))
+        if uri:
+            yield uri, params
 
 
 def _parse_link_next(link_header: str | None) -> str | None:
-    """Next-page URL from a GitHub-style ``Link`` header, or None."""
-    for part in (link_header or "").split(","):
-        seg = part.split(";")
-        if len(seg) >= 2 and 'rel="next"' in seg[1]:
-            return seg[0].strip().strip("<>")
+    """Next-page URL from an RFC 8288 ``Link`` header, or None.
+
+    ``rel`` may appear at any position among an entry's parameters, may be an unquoted token,
+    and may carry a space-separated list of relation types, which are case-insensitive. Only
+    matching ``rel="next"`` as the first parameter drops a perfectly valid
+    ``<...>; type="application/json"; rel="next"``, and dropping it is not a safe default:
+    :func:`_hf_api_get_json` treats "no next cursor" as "listing finished" and returns the
+    truncated first page with ``success=True``, so a repo whose 5.x-only import sits on a
+    later page would be cached as a confirmed default tier.
+    """
+    for uri, params in _iter_link_entries(link_header or ""):
+        for name, value in params:
+            if name != "rel":
+                continue
+            if "next" in value.lower().split():
+                return uri
+            break  # RFC 8288: only an entry's first rel parameter is significant
     return None
 
 
@@ -801,14 +910,61 @@ def _list_hub_repo_py_files(repo_id: str, hf_token: str | None = None) -> tuple[
     }, True
 
 
-def _fetch_hub_py_sources(repo_id: str, hf_token: str | None = None) -> tuple[list[str], bool]:
+# One activation's remote-code scan downloads every ``.py`` the ``auto_map`` closure can
+# reach, and training / inference / export workers run it BEFORE the remote-code consent
+# gate. Unbounded, a selected public repo can hold as many ``.py`` files as the 200-page
+# listing limit allows, or one enormous file, and keep a worker issuing 10-second requests
+# or exhaust its memory before Studio can reject the model. Survey of the 300
+# most-downloaded ``trust_remote_code`` repos: the largest holds 26 ``.py`` (p50 3, p95 11,
+# p99 21), the largest aggregate is 933 KiB and the largest single file is 216 KiB, so these
+# caps sit roughly 5x / 17x / 19x above the worst real repo and truncate none of them.
+_REMOTE_SCAN_MAX_FILES = 128
+_REMOTE_SCAN_MAX_TOTAL_CHARS = 16 * 1024 * 1024
+_REMOTE_SCAN_MAX_FILE_BYTES = 4 * 1024 * 1024
+
+
+class _RemoteScanBudget:
+    """Cap on the remote ``.py`` downloads of ONE scan, shared across every repo it reaches.
+
+    The budget spans the model's own repo and every external ``auto_map`` repo together, so
+    the ceiling is on the whole activation rather than per repo (otherwise N referenced repos
+    multiply it). Running out is reported as an incomplete closure, never as "no 5.x import":
+    the caller turns that into a non-definitive result, so a truncated scan is not memoized
+    as a confirmed default tier. Sources read before the cap are kept, since the scan already
+    trusts a positive from a partial closure.
+    """
+
+    __slots__ = ("files_left", "chars_left", "truncated")
+
+    def __init__(self) -> None:
+        self.files_left = _REMOTE_SCAN_MAX_FILES
+        self.chars_left = _REMOTE_SCAN_MAX_TOTAL_CHARS
+        self.truncated = False
+
+    def take_file(self) -> bool:
+        """Reserve one download slot. False once the file or aggregate budget is spent."""
+        if self.files_left <= 0 or self.chars_left <= 0:
+            self.truncated = True
+            return False
+        self.files_left -= 1
+        return True
+
+    def spend(self, size: int) -> None:
+        self.chars_left -= size
+
+
+def _fetch_hub_py_sources(
+    repo_id: str,
+    hf_token: str | None = None,
+    budget: "_RemoteScanBudget | None" = None,
+) -> tuple[list[str], bool]:
     """Fetch every present ``.py`` in a Hub repo. Returns (sources, definitive).
 
     A file that fails to fetch (transient error, or removed between the tree listing and
     the raw request) only makes the closure incomplete; the sources already read are still
     returned. The scan trusts a positive from a partial closure, so discarding them would
     throw away an already-observed 5.x-only import and route the worker to a sidecar that
-    cannot import the remote code.
+    cannot import the remote code. A spent *budget* is the same kind of incompleteness.
     """
     py_files, listing_ok = _list_hub_repo_py_files(repo_id, hf_token)
     if not listing_ok:
@@ -816,19 +972,33 @@ def _fetch_hub_py_sources(repo_id: str, hf_token: str | None = None) -> tuple[li
     sources: list[str] = []
     complete = True
     for fn in sorted(py_files):
+        if budget is not None and not budget.take_file():
+            logger.debug(
+                "Remote scan budget spent at '%s'; %d .py left unread", repo_id, len(py_files),
+            )
+            complete = False
+            break
         text = _read_repo_text_file(repo_id, fn, hf_token)
         if text is None:
             complete = False
             continue
+        if budget is not None:
+            budget.spend(len(text))
         sources.append(text)
     return sources, complete
 
 
-def _collect_external_py_sources(refs: set, hf_token: str | None = None) -> tuple[list[str], bool]:
+def _collect_external_py_sources(
+    refs: set,
+    hf_token: str | None = None,
+    budget: "_RemoteScanBudget | None" = None,
+) -> tuple[list[str], bool]:
     """Fetch all ``.py`` from external repos referenced by ``auto_map``.
 
     Like :func:`_fetch_hub_py_sources`, an unreachable repo marks the closure incomplete
-    without dropping the sources read from the repos that did answer.
+    without dropping the sources read from the repos that did answer. *budget* is the caller's
+    scan-wide download cap and is threaded through so every referenced repo draws on the same
+    ceiling.
     """
     external_repos = {repo for repo, _ in refs if repo is not None}
     if not external_repos:
@@ -836,7 +1006,7 @@ def _collect_external_py_sources(refs: set, hf_token: str | None = None) -> tupl
     sources: list[str] = []
     complete = True
     for repo in sorted(external_repos):
-        repo_sources, ok = _fetch_hub_py_sources(repo, hf_token)
+        repo_sources, ok = _fetch_hub_py_sources(repo, hf_token, budget)
         if not ok:
             complete = False
         sources.extend(repo_sources)
@@ -909,7 +1079,14 @@ def _read_repo_text_file(
     filename: str,
     hf_token: str | None = None,
 ) -> str | None:
-    """Return a repo-relative text file's contents; local first, else HuggingFace raw fetch."""
+    """Return a repo-relative text file's contents; local first, else HuggingFace raw fetch.
+
+    The remote read stops at ``_REMOTE_SCAN_MAX_FILE_BYTES``. The aggregate budget in
+    :class:`_RemoteScanBudget` can only be charged once a file has been read, so a single
+    oversized source would already be resident by the time it noticed; bounding the read
+    itself is what keeps one enormous ``.py`` from exhausting a worker. Over-cap is reported
+    as an unread file (``None``), which the caller counts as an incomplete closure.
+    """
     local_path = Path(model_name) / filename
     if _safe_is_file(local_path):
         try:
@@ -931,7 +1108,14 @@ def _read_repo_text_file(
     try:
         req = urllib.request.Request(url, headers = headers)
         with _hub_urlopen(req, timeout = 10) as resp:
-            return _decode_source_bytes(resp.read())
+            raw = resp.read(_REMOTE_SCAN_MAX_FILE_BYTES + 1)
+        if len(raw) > _REMOTE_SCAN_MAX_FILE_BYTES:
+            logger.debug(
+                "Skipping oversized remote source %s for '%s' (over %d bytes)",
+                filename, model_name, _REMOTE_SCAN_MAX_FILE_BYTES,
+            )
+            return None
+        return _decode_source_bytes(raw)
     except Exception as exc:
         logger.debug("Could not fetch %s for '%s': %s", filename, model_name, exc)
         return None
@@ -1014,6 +1198,9 @@ def _remote_auto_map_py_contents(
         return [], cfg_definitive
 
     ext_refs: set = set(known_refs or ()) | own_refs
+    # One ceiling for the whole closure: the model's own repo and every external auto_map
+    # repo draw on the same file/byte budget, so N referenced repos cannot multiply it.
+    budget = _RemoteScanBudget()
 
     local_root = Path(model_name)
     if _safe_is_dir(local_root):
@@ -1025,7 +1212,7 @@ def _remote_auto_map_py_contents(
                 except Exception as exc:
                     logger.debug("Could not read %s: %s", py_path, exc)
                     return [], False
-        ext_sources, ext_ok = _collect_external_py_sources(ext_refs, hf_token)
+        ext_sources, ext_ok = _collect_external_py_sources(ext_refs, hf_token, budget)
         sources.extend(ext_sources)
         if any(repo is not None for repo, _ in ext_refs) and not ext_ok:
             return sources, False
@@ -1036,8 +1223,8 @@ def _remote_auto_map_py_contents(
 
     # An incomplete own-repo listing/fetch does not end the scan: the external repos may
     # still hold the marker, and whatever was read stays available to prove the tier.
-    sources, repo_ok = _fetch_hub_py_sources(model_name, hf_token)
-    ext_sources, ext_ok = _collect_external_py_sources(ext_refs, hf_token)
+    sources, repo_ok = _fetch_hub_py_sources(model_name, hf_token, budget)
+    ext_sources, ext_ok = _collect_external_py_sources(ext_refs, hf_token, budget)
     sources.extend(ext_sources)
     if not repo_ok or (any(repo is not None for repo, _ in ext_refs) and not ext_ok):
         return sources, False
@@ -1346,7 +1533,7 @@ def _tokenizer_auto_map_needs_v5(
         # An own-repo entry file that has not been written yet (in-progress checkpoint)
         # means the closure is incomplete, not that it is 4.x-safe.
         definitive = all(repo is not None or _safe_is_file(local_root / fn) for repo, fn in refs)
-        ext_sources, ext_ok = _collect_external_py_sources(refs, hf_token)
+        ext_sources, ext_ok = _collect_external_py_sources(refs, hf_token, _RemoteScanBudget())
         if any(repo is not None for repo, _ in refs) and not ext_ok:
             # An unreachable external repo makes the closure incomplete, so the negative
             # stays uncached -- but the local sources already read can still PROVE 5.x.

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -200,14 +200,20 @@ _TRANSFORMERS_5_TOKENIZER_CLASSES: set[str] = {
     "TokenizersBackend",
 }
 
-# Import strings in auto_map remote .py that only exist in transformers>=5.x.
-_TRANSFORMERS_5_REMOTE_IMPORT_MARKERS: tuple[str, ...] = ("tokenization_utils_tokenizers",)
+# Import strings in auto_map remote .py that only exist in transformers>=5.x
+# (``tokenization_utils_tokenizers`` landed in 5.0.0). Fully qualified so a repo's
+# own same-named helper module cannot match.
+_TRANSFORMERS_5_REMOTE_IMPORT_MARKERS: tuple[str, ...] = (
+    "transformers.tokenization_utils_tokenizers",
+)
 
-# Import strings in auto_map remote modeling code that require transformers>=5.10.
+# Remote modeling imports the default 4.57.x tier cannot satisfy
+# (``utils.output_capturing`` landed in 5.3.0). Only symbols ABSENT from 4.57.x
+# belong here: ``modeling_layers`` (4.52+) and ``use_kernel_forward_from_hub``
+# (4.51+) import fine on default, so matching them would push ordinary
+# custom-code models (EXAONE, MiniMax, Molmo2, ...) onto the sidecar.
 _TRANSFORMERS_510_REMOTE_IMPORT_MARKERS: tuple[str, ...] = (
-    "modeling_layers",
-    "utils.output_capturing",
-    "use_kernel_forward_from_hub",
+    "transformers.utils.output_capturing",
 )
 
 # Caches keyed on (model_name, token-hash) so authed/unauthed reads stay separate (a
@@ -625,6 +631,9 @@ def _hf_api_url(path: str) -> str:
 
 def _hf_api_get_json(path: str, hf_token: str | None = None) -> tuple[object | None, bool]:
     """GET a Hub API path via stdlib urllib. Returns (parsed_json, success)."""
+    if _env_offline():
+        return None, False
+
     import urllib.request
 
     headers = {"User-Agent": "unsloth-studio"}
@@ -681,11 +690,22 @@ def _collect_external_py_sources(refs: set, hf_token: str | None = None) -> tupl
     return sources, True
 
 
-def _repo_has_auto_map(model_name: str, hf_token: str | None = None) -> bool:
-    """True when any remote-code config in the repo declares ``auto_map``."""
-    from utils.security.remote_code_scan import REMOTE_CODE_CONFIG_FILES, _auto_map_refs
+def _auto_map_config_files(model_name: str) -> tuple[str, ...]:
+    """Configs to read for ``auto_map``. A local dir is free to read, so use every
+    remote-code config; a Hub id uses only ``config.json`` (already cached) because
+    transformers resolves remote MODELING code from there, and the extra files would
+    add an uncached fetch each to every tier lookup. Tokenizer/processor auto_map is
+    passed in by its own caller (see ``known_refs``)."""
+    from utils.security.remote_code_scan import REMOTE_CODE_CONFIG_FILES
 
-    for cfg_name in REMOTE_CODE_CONFIG_FILES:
+    return REMOTE_CODE_CONFIG_FILES if _safe_is_dir(Path(model_name)) else ("config.json",)
+
+
+def _repo_has_auto_map(model_name: str, hf_token: str | None = None) -> bool:
+    """True when a remote-code config in the repo declares ``auto_map``."""
+    from utils.security.remote_code_scan import _auto_map_refs
+
+    for cfg_name in _auto_map_config_files(model_name):
         cfg = _load_repo_json_file(model_name, cfg_name, hf_token)
         if isinstance(cfg, dict) and _auto_map_refs(cfg):
             return True
@@ -762,21 +782,25 @@ def _load_repo_json_file(
 
 
 def _remote_auto_map_py_contents(
-    model_name: str, hf_token: str | None = None
+    model_name: str,
+    hf_token: str | None = None,
+    known_refs: set | None = None,
 ) -> tuple[list[str], bool]:
     """Executable remote-code sources transformers may load (own, helper, external).
 
     Stdlib-only (urllib + HF REST API) so tier detection never imports ``huggingface_hub``
-    before a transformers sidecar is activated. Returns ``(sources, definitive)``; when
+    before a transformers sidecar is activated. ``known_refs`` are ``auto_map`` refs the
+    caller already parsed (tokenizer/processor config), which both proves remote code
+    exists and saves re-reading that config. Returns ``(sources, definitive)``; when
     ``definitive`` is False the scan was incomplete and negatives must not be cached.
     """
-    from utils.security.remote_code_scan import REMOTE_CODE_CONFIG_FILES, _auto_map_refs
+    from utils.security.remote_code_scan import _auto_map_refs
 
-    if not _repo_has_auto_map(model_name, hf_token):
+    if not known_refs and not _repo_has_auto_map(model_name, hf_token):
         return [], True
 
-    ext_refs: set = set()
-    for cfg_name in REMOTE_CODE_CONFIG_FILES:
+    ext_refs: set = set(known_refs or ())
+    for cfg_name in _auto_map_config_files(model_name):
         cfg = _load_repo_json_file(model_name, cfg_name, hf_token)
         if isinstance(cfg, dict):
             ext_refs |= _auto_map_refs(cfg)
@@ -811,7 +835,18 @@ def _remote_auto_map_py_contents(
 
 
 def _remote_auto_map_py_matches(markers: tuple[str, ...], sources: list[str]) -> bool:
-    return any(any(marker in src for marker in markers) for src in sources)
+    """True when a source *imports* one of *markers*.
+
+    Import lines only: a marker named in a comment or docstring must not promote the
+    tier. Line matching (not ``ast``) on purpose, since remote code that fails to parse
+    would otherwise turn into a silent negative and crash on the default tier.
+    """
+    for src in sources:
+        for line in src.splitlines():
+            stripped = line.strip()
+            if stripped.startswith(("import ", "from ")) and any(m in stripped for m in markers):
+                return True
+    return False
 
 
 def _remote_auto_map_scan_result(model_name: str, hf_token: str | None = None) -> tuple[bool, bool]:
@@ -863,7 +898,9 @@ def _tokenizer_auto_map_needs_v5(data: dict, model_name: str, hf_token: str | No
             return False
         sources.extend(ext_sources)
     else:
-        sources, definitive = _remote_auto_map_py_contents(model_name, hf_token)
+        # Pass the tokenizer refs: they already prove remote code exists, so a repo
+        # whose only auto_map is the tokenizer's is still scanned.
+        sources, definitive = _remote_auto_map_py_contents(model_name, hf_token, known_refs = refs)
         if not definitive and not sources:
             return False
 

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -692,8 +692,9 @@ def _auto_map_config_files(model_name: str) -> tuple[str, ...]:
     """Configs to read for ``auto_map``. A local dir is free to read, so use every
     remote-code config; a Hub id uses only ``config.json`` (already cached) because
     transformers resolves remote MODELING code from there, and the extra files would
-    add an uncached fetch each to every tier lookup. Tokenizer/processor auto_map is
-    passed in by its own caller (see ``known_refs``)."""
+    add an uncached fetch each to every tier lookup. Tokenizer auto_map is passed in by
+    its own caller (see ``known_refs``); a repo declaring modeling auto_map has every
+    ``.py`` in it fetched, which covers its processor code too."""
     from utils.security.remote_code_scan import REMOTE_CODE_CONFIG_FILES
     return REMOTE_CODE_CONFIG_FILES if _safe_is_dir(Path(model_name)) else ("config.json",)
 
@@ -831,25 +832,79 @@ def _remote_auto_map_py_contents(
     return sources, True
 
 
+def _imported_dotted_names(src: str) -> set[str]:
+    """Absolute module paths *src* imports, resolved with ``ast``.
+
+    Catches what a per-line substring scan cannot: a parenthesized multi-line import,
+    and the equivalent ``from <parent> import <submodule>`` spelling. Relative imports
+    are skipped (a repo's own same-named helper must not match). Empty when the source
+    does not parse.
+    """
+    import ast
+
+    try:
+        tree = ast.parse(src)
+    except Exception:
+        return set()
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and not node.level and node.module:
+            names.add(node.module)
+            names.update(f"{node.module}.{alias.name}" for alias in node.names)
+    return names
+
+
 def _remote_auto_map_py_matches(markers: tuple[str, ...], sources: list[str]) -> bool:
     """True when a source *imports* one of *markers*.
 
     Import lines only: a marker named in a comment or docstring must not promote the
-    tier. Line matching (not ``ast``) on purpose, since remote code that fails to parse
-    would otherwise turn into a silent negative and crash on the default tier.
+    tier. The line scan runs first (not ``ast``) on purpose, since remote code that
+    fails to parse would otherwise turn into a silent negative and crash on the default
+    tier; the ``ast`` pass then only ADDS the spellings a line scan cannot see.
     """
     for src in sources:
         for line in src.splitlines():
             stripped = line.strip()
             if stripped.startswith(("import ", "from ")) and any(m in stripped for m in markers):
                 return True
+    for src in sources:
+        for name in _imported_dotted_names(src):
+            if any(name == m or name.startswith(m + ".") for m in markers):
+                return True
     return False
+
+
+def _local_py_signature(model_name: str) -> str | None:
+    """Signature of a local checkpoint's ``.py`` files (path + size + mtime), or ``""``
+    for a Hub id. ``None`` when the walk fails, which means "do not cache".
+
+    Folded into the scan cache key (mirrors ``_probe_cache_key``) so a checkpoint whose
+    remote code is written or replaced after a first lookup is re-scanned instead of
+    reusing a stale negative.
+    """
+    if not _safe_is_dir(Path(model_name)):
+        return ""
+    try:
+        parts = []
+        for py_path in sorted(Path(model_name).rglob("*.py")):
+            try:
+                st = py_path.stat()
+            except OSError:
+                continue
+            parts.append(f"{py_path}:{st.st_size}:{st.st_mtime_ns}")
+        return "\0".join(parts)
+    except Exception as exc:
+        logger.debug("Could not signature local .py files under %s: %s", model_name, exc)
+        return None
 
 
 def _remote_auto_map_scan_result(model_name: str, hf_token: str | None = None) -> tuple[bool, bool]:
     """Return ``(needs_510, scan_was_definitive)`` for auto_map remote code."""
-    cache_key = _token_cache_key(model_name, hf_token)
-    if cache_key in _remote_auto_map_needs_510_cache:
+    signature = _local_py_signature(model_name)
+    cache_key = (*_token_cache_key(model_name, hf_token), signature)
+    if signature is not None and cache_key in _remote_auto_map_needs_510_cache:
         return _remote_auto_map_needs_510_cache[cache_key], True
 
     # Offline Hub ids cannot be scanned here; do not cache the assumed negative so a
@@ -861,7 +916,7 @@ def _remote_auto_map_scan_result(model_name: str, hf_token: str | None = None) -
     result = _remote_auto_map_py_matches(_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS, sources)
     if result:
         logger.info("Remote auto_map check: %s needs transformers 5.10.x", model_name)
-    if definitive:
+    if definitive and signature is not None:
         _remote_auto_map_needs_510_cache[cache_key] = result
     return result, definitive
 
@@ -872,13 +927,23 @@ def _check_remote_auto_map_needs_510(model_name: str, hf_token: str | None = Non
     return needs
 
 
-def _tokenizer_auto_map_needs_v5(data: dict, model_name: str, hf_token: str | None) -> bool:
-    """True when tokenizer ``auto_map`` closure imports transformers-5.x-only symbols."""
+def _tokenizer_auto_map_needs_v5(
+    data: dict,
+    model_name: str,
+    hf_token: str | None,
+) -> tuple[bool, bool]:
+    """``(needs_v5, definitive)`` for the tokenizer ``auto_map`` closure.
+
+    ``definitive`` is False when the closure could not be read in full (missing local
+    file, unreachable external repo, incomplete Hub listing/fetch), so the caller must
+    not cache the negative and keep routing to the default sidecar once the Hub or the
+    checkpoint recovers.
+    """
     from utils.security.remote_code_scan import _auto_map_refs
 
     refs = _auto_map_refs(data)
     if not refs:
-        return False
+        return False, True
 
     local_root = Path(model_name)
     if _safe_is_dir(local_root):
@@ -889,22 +954,27 @@ def _tokenizer_auto_map_needs_v5(data: dict, model_name: str, hf_token: str | No
                     sources.append(py_path.read_text(encoding = "utf-8", errors = "replace"))
                 except Exception as exc:
                     logger.debug("Could not read %s: %s", py_path, exc)
-                    return False
+                    return False, False
+        # An own-repo entry file that has not been written yet (in-progress checkpoint)
+        # means the closure is incomplete, not that it is 4.x-safe.
+        definitive = all(
+            repo is not None or _safe_is_file(local_root / fn) for repo, fn in refs
+        )
         ext_sources, ext_ok = _collect_external_py_sources(refs, hf_token)
         if any(repo is not None for repo, _ in refs) and not ext_ok:
-            return False
+            return False, False
         sources.extend(ext_sources)
     else:
         # Pass the tokenizer refs: they already prove remote code exists, so a repo
         # whose only auto_map is the tokenizer's is still scanned.
         sources, definitive = _remote_auto_map_py_contents(model_name, hf_token, known_refs = refs)
         if not definitive and not sources:
-            return False
+            return False, False
 
     if _remote_auto_map_py_matches(_TRANSFORMERS_5_REMOTE_IMPORT_MARKERS, sources):
         logger.info("Remote tokenizer auto_map check: %s requires transformers 5.x", model_name)
-        return True
-    return False
+        return True, True
+    return False, definitive
 
 
 def _check_tokenizer_config_needs_v5(model_name: str, hf_token: str | None = None) -> bool:
@@ -929,15 +999,17 @@ def _check_tokenizer_config_needs_v5(model_name: str, hf_token: str | None = Non
                 data = json.load(f)
             tokenizer_class = data.get("tokenizer_class", "")
             result = tokenizer_class in _TRANSFORMERS_5_TOKENIZER_CLASSES
+            definitive = True
             if not result:
-                result = _tokenizer_auto_map_needs_v5(data, model_name, hf_token)
+                result, definitive = _tokenizer_auto_map_needs_v5(data, model_name, hf_token)
             if result:
                 logger.info(
                     "Local check: %s uses tokenizer_class=%s (requires transformers 5.x)",
                     model_name,
                     tokenizer_class,
                 )
-            _tokenizer_class_cache[cache_key] = result
+            if definitive:
+                _tokenizer_class_cache[cache_key] = result
             return result
         except Exception as exc:
             logger.debug("Could not read %s: %s", local_tc, exc)
@@ -965,15 +1037,17 @@ def _check_tokenizer_config_needs_v5(model_name: str, hf_token: str | None = Non
             data = json.loads(resp.read().decode())
         tokenizer_class = data.get("tokenizer_class", "")
         result = tokenizer_class in _TRANSFORMERS_5_TOKENIZER_CLASSES
+        definitive = True
         if not result:
-            result = _tokenizer_auto_map_needs_v5(data, model_name, hf_token)
+            result, definitive = _tokenizer_auto_map_needs_v5(data, model_name, hf_token)
         if result:
             logger.info(
                 "Dynamic check: %s uses tokenizer_class=%s (requires transformers 5.x)",
                 model_name,
                 tokenizer_class,
             )
-        _tokenizer_class_cache[cache_key] = result
+        if definitive:
+            _tokenizer_class_cache[cache_key] = result
         return result
     except Exception as exc:
         logger.debug("Could not fetch tokenizer_config.json for '%s': %s", model_name, exc)
@@ -1916,7 +1990,11 @@ def get_transformers_tier(
         # in the pinned case, keeping the pre-latest path I/O-free.
         if latest_venv_pinned_version() is not None:
             tier = _raise_tier_for_nested(_load_config_json(model_name, hf_token), tier)
-        if _check_remote_auto_map_needs_510(model_name, hf_token):
+        # Only on the activation path: the name already resolved a 5.x tier, so the scan
+        # can only pick 510 over 530/550. Running it for probe=False would add a repo
+        # listing plus a fetch per remote .py to the cheap parent-side check, which only
+        # asks "is this 5.x at all" (needs_transformers_5) or "is this latest".
+        if probe and _check_remote_auto_map_needs_510(model_name, hf_token):
             tier = _higher_tier(tier, "510")
             tier = _raise_tier_for_nested(_load_config_json(model_name, hf_token), tier)
         logger.info(

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -575,6 +575,80 @@ def _adapter_base_from_hf_cache(model_name: str) -> str | None:
     return None
 
 
+def _redirect_drops_auth(old_url: str, new_url: str) -> bool:
+    """True when a redirect from *old_url* to *new_url* must not carry ``Authorization``.
+
+    Same rule ``requests`` (``SessionRedirectMixin.should_strip_auth``), curl and browsers
+    apply: a different host always drops the header, a plain-http to https upgrade of the
+    same host keeps it (that token was already on the wire), and any other scheme or port
+    change drops it. An unparseable ``Location`` drops it too.
+    """
+    from urllib.parse import urlsplit
+
+    try:
+        old, new = urlsplit(old_url), urlsplit(new_url)
+        if (old.hostname or "").lower() != (new.hostname or "").lower():
+            return True
+        defaults = {"http": 80, "https": 443}
+        old_scheme, new_scheme = old.scheme.lower(), new.scheme.lower()
+        old_port = old.port or defaults.get(old_scheme)
+        new_port = new.port or defaults.get(new_scheme)
+    except ValueError:
+        return True
+    if old_scheme == "http" and old_port == 80 and new_scheme == "https" and new_port == 443:
+        return False
+    return (old_scheme, old_port) != (new_scheme, new_port)
+
+
+_hub_opener_cache = None
+
+
+def _hub_opener():
+    """Opener used by every Hub fetch here that can carry ``Authorization``.
+
+    ``urllib``'s stock ``HTTPRedirectHandler.redirect_request`` copies every header except
+    content-length/content-type onto the redirect target without comparing hosts, so a 3xx
+    replays ``Authorization: Bearer <hf_token>`` to whatever host the ``Location`` names.
+    ``HF_ENDPOINT`` is user-configurable, so that host is not necessarily the Hub. Dropping
+    the header outright is not an option: the Hub 307s ``/gpt2/raw/main/config.json`` to
+    ``/openai-community/gpt2/raw/main/config.json`` and 301s http to https, both same-origin,
+    and a renamed private repo answers 401 unauthenticated (which this module caches as a
+    definitive "absent"). So the handler keeps the header on a same-origin hop and strips it
+    on a cross-origin one.
+
+    Built once and never handed to ``install_opener``, so the rest of the process keeps stock
+    ``urlopen`` behaviour. ``build_opener`` retains the default proxy/HTTPS handlers, so
+    ``*_PROXY`` / ``NO_PROXY`` work exactly as they did. Racing builders are harmless: the
+    openers are equivalent and stateless. ``urllib.request`` stays a lazy import like every
+    other fetch below, hence the nested handler.
+    """
+    global _hub_opener_cache
+    if _hub_opener_cache is not None:
+        return _hub_opener_cache
+
+    import urllib.request
+
+    class _AuthStrippingRedirectHandler(urllib.request.HTTPRedirectHandler):
+        def redirect_request(self, req, fp, code, msg, headers, newurl):
+            new = super().redirect_request(req, fp, code, msg, headers, newurl)
+            if new is not None and _redirect_drops_auth(req.full_url, new.full_url):
+                for key in [k for k in new.headers if k.lower() == "authorization"]:
+                    del new.headers[key]
+            return new
+
+    _hub_opener_cache = urllib.request.build_opener(_AuthStrippingRedirectHandler)
+    return _hub_opener_cache
+
+
+def _hub_urlopen(req, timeout = 10):
+    """``urlopen`` for the Hub fetches here, via the redirect-aware opener above.
+
+    ``hf_endpoint_unreachable`` deliberately stays on plain ``urlopen``: it sends no
+    credentials, so it has nothing to leak across a redirect.
+    """
+    return _hub_opener().open(req, timeout = timeout)
+
+
 def _remote_lora_base(model_name: str, hf_token: str | None = None) -> str | None:
     """``base_model_name_or_path`` from a remote adapter's ``adapter_config.json``, or None.
 
@@ -604,7 +678,7 @@ def _remote_lora_base(model_name: str, hf_token: str | None = None) -> str | Non
         headers["Authorization"] = f"Bearer {hf_token}"
     try:
         req = urllib.request.Request(url, headers = headers)
-        with urllib.request.urlopen(req, timeout = 10) as resp:
+        with _hub_urlopen(req, timeout = 10) as resp:
             cfg = json.loads(resp.read().decode())
         base = cfg.get("base_model_name_or_path")
         if base:
@@ -690,7 +764,7 @@ def _hf_api_get_json(path: str, hf_token: str | None = None) -> tuple[object | N
     try:
         for _ in range(_HF_API_MAX_PAGES):
             req = urllib.request.Request(url, headers = headers)
-            with urllib.request.urlopen(req, timeout = 10) as resp:
+            with _hub_urlopen(req, timeout = 10) as resp:
                 payload = json.loads(resp.read().decode())
                 next_url = _parse_link_next(resp.headers.get("Link"))
             if not isinstance(payload, list):
@@ -856,7 +930,7 @@ def _read_repo_text_file(
         headers["Authorization"] = f"Bearer {hf_token}"
     try:
         req = urllib.request.Request(url, headers = headers)
-        with urllib.request.urlopen(req, timeout = 10) as resp:
+        with _hub_urlopen(req, timeout = 10) as resp:
             return _decode_source_bytes(resp.read())
     except Exception as exc:
         logger.debug("Could not fetch %s for '%s': %s", filename, model_name, exc)
@@ -908,7 +982,7 @@ def _load_repo_json_checked(
         headers["Authorization"] = f"Bearer {hf_token}"
     try:
         req = urllib.request.Request(url, headers = headers)
-        with urllib.request.urlopen(req, timeout = 10) as resp:
+        with _hub_urlopen(req, timeout = 10) as resp:
             return json.loads(resp.read().decode()), True
     except urllib.error.HTTPError as exc:
         # 404 = genuinely absent; 401/403 = definitively unreadable with this token.
@@ -1328,7 +1402,7 @@ def _check_tokenizer_config_needs_v5(model_name: str, hf_token: str | None = Non
         headers["Authorization"] = f"Bearer {hf_token}"
     try:
         req = urllib.request.Request(url, headers = headers)
-        with urllib.request.urlopen(req, timeout = 10) as resp:
+        with _hub_urlopen(req, timeout = 10) as resp:
             data = json.loads(resp.read().decode())
         tokenizer_class = data.get("tokenizer_class", "")
         result = tokenizer_class in _TRANSFORMERS_5_TOKENIZER_CLASSES
@@ -1446,7 +1520,7 @@ def _load_config_json(model_name: str, hf_token: str | None = None) -> dict | No
         headers["Authorization"] = f"Bearer {hf_token}"
     try:
         req = urllib.request.Request(url, headers = headers)
-        with urllib.request.urlopen(req, timeout = 10) as resp:
+        with _hub_urlopen(req, timeout = 10) as resp:
             cfg = json.loads(resp.read().decode())
         _config_json_cache[cache_key] = cfg
         return cfg

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -752,7 +752,9 @@ def _is_same_hub_origin(url: str) -> bool:
     except ValueError:
         return False  # out-of-range or non-numeric port
     return (nxt_scheme, (nxt.hostname or "").lower(), nxt_port) == (
-        base_scheme, (base.hostname or "").lower(), base_port,
+        base_scheme,
+        (base.hostname or "").lower(),
+        base_port,
     )
 
 
@@ -776,7 +778,7 @@ def _iter_link_entries(header: str):
             end = header.find(">", i)
             if end == -1:
                 return  # unterminated URI: the rest of the header cannot be split reliably
-            uri = header[i + 1:end].strip()
+            uri = header[i + 1 : end].strip()
             i = end + 1
         else:
             start = i
@@ -974,7 +976,9 @@ def _fetch_hub_py_sources(
     for fn in sorted(py_files):
         if budget is not None and not budget.take_file():
             logger.debug(
-                "Remote scan budget spent at '%s'; %d .py left unread", repo_id, len(py_files),
+                "Remote scan budget spent at '%s'; %d .py left unread",
+                repo_id,
+                len(py_files),
             )
             complete = False
             break
@@ -1112,7 +1116,9 @@ def _read_repo_text_file(
         if len(raw) > _REMOTE_SCAN_MAX_FILE_BYTES:
             logger.debug(
                 "Skipping oversized remote source %s for '%s' (over %d bytes)",
-                filename, model_name, _REMOTE_SCAN_MAX_FILE_BYTES,
+                filename,
+                model_name,
+                _REMOTE_SCAN_MAX_FILE_BYTES,
             )
             return None
         return _decode_source_bytes(raw)

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -212,9 +212,7 @@ _TRANSFORMERS_5_REMOTE_IMPORT_MARKERS: tuple[str, ...] = (
 # belong here: ``modeling_layers`` (4.52+) and ``use_kernel_forward_from_hub``
 # (4.51+) import fine on default, so matching them would push ordinary
 # custom-code models (EXAONE, MiniMax, Molmo2, ...) onto the sidecar.
-_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS: tuple[str, ...] = (
-    "transformers.utils.output_capturing",
-)
+_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS: tuple[str, ...] = ("transformers.utils.output_capturing",)
 
 # Caches keyed on (model_name, token-hash) so authed/unauthed reads stay separate (a
 # gated/private repo's unauthenticated miss must not poison a later authenticated lookup).
@@ -697,7 +695,6 @@ def _auto_map_config_files(model_name: str) -> tuple[str, ...]:
     add an uncached fetch each to every tier lookup. Tokenizer/processor auto_map is
     passed in by its own caller (see ``known_refs``)."""
     from utils.security.remote_code_scan import REMOTE_CODE_CONFIG_FILES
-
     return REMOTE_CODE_CONFIG_FILES if _safe_is_dir(Path(model_name)) else ("config.json",)
 
 

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -223,7 +223,7 @@ _config_json_cache: dict[tuple[str, str | None], dict | None] = {}
 _config_needs_510_cache: dict[tuple[str, str | None], bool] = {}
 _config_needs_550_cache: dict[tuple[str, str | None], bool] = {}
 _config_needs_530_cache: dict[tuple[str, str | None], bool] = {}
-_remote_auto_map_needs_510_cache: dict[tuple[str, str | None], bool] = {}
+_remote_auto_map_tier_cache: dict[tuple[str, str | None, str | None], str] = {}
 
 # Models whose config.json got a definitive 401/403/404 (absent, or not readable with this
 # token). Tracked separately from _config_json_cache, which only holds configs we could
@@ -704,31 +704,45 @@ def _list_hub_repo_py_files(repo_id: str, hf_token: str | None = None) -> tuple[
 
 
 def _fetch_hub_py_sources(repo_id: str, hf_token: str | None = None) -> tuple[list[str], bool]:
-    """Fetch every present ``.py`` in a Hub repo. Returns (sources, definitive)."""
+    """Fetch every present ``.py`` in a Hub repo. Returns (sources, definitive).
+
+    A file that fails to fetch (transient error, or removed between the tree listing and
+    the raw request) only makes the closure incomplete; the sources already read are still
+    returned. The scan trusts a positive from a partial closure, so discarding them would
+    throw away an already-observed 5.x-only import and route the worker to a sidecar that
+    cannot import the remote code.
+    """
     py_files, listing_ok = _list_hub_repo_py_files(repo_id, hf_token)
     if not listing_ok:
         return [], False
     sources: list[str] = []
+    complete = True
     for fn in sorted(py_files):
         text = _read_repo_text_file(repo_id, fn, hf_token)
         if text is None:
-            return [], False
+            complete = False
+            continue
         sources.append(text)
-    return sources, True
+    return sources, complete
 
 
 def _collect_external_py_sources(refs: set, hf_token: str | None = None) -> tuple[list[str], bool]:
-    """Fetch all ``.py`` from external repos referenced by ``auto_map``."""
+    """Fetch all ``.py`` from external repos referenced by ``auto_map``.
+
+    Like :func:`_fetch_hub_py_sources`, an unreachable repo marks the closure incomplete
+    without dropping the sources read from the repos that did answer.
+    """
     external_repos = {repo for repo, _ in refs if repo is not None}
     if not external_repos:
         return [], True
     sources: list[str] = []
+    complete = True
     for repo in sorted(external_repos):
         repo_sources, ok = _fetch_hub_py_sources(repo, hf_token)
         if not ok:
-            return [], False
+            complete = False
         sources.extend(repo_sources)
-    return sources, True
+    return sources, complete
 
 
 def _auto_map_config_files(model_name: str) -> tuple[str, ...]:
@@ -836,10 +850,16 @@ def _load_repo_json_checked(
     ``definitive`` is False only when the answer is genuinely unknown: a transient remote
     failure, or an offline Hub id. A local read, a 401/403/404 and a parse error are all
     definitive answers, so only a read that never happened blocks caching.
+
+    A local checkpoint's ``config.json`` is read straight from disk like every other config
+    here, NOT through ``_load_config_json``: that cache lives for the process and would keep
+    serving the pre-rewrite contents to a rescan the changed scan signature just forced (a
+    staged checkpoint that writes its code first and its ``auto_map`` afterwards), which
+    would then memoize a fresh negative under the new signature.
     """
-    if filename == "config.json":
+    if filename == "config.json" and not _safe_is_dir(Path(model_name)):
         cfg = _load_config_json(model_name, hf_token)
-        if cfg is not None or _safe_is_dir(Path(model_name)) or not _looks_like_hf_id(model_name):
+        if cfg is not None or not _looks_like_hf_id(model_name):
             return cfg, True
         return None, _config_json_answer_is_definitive(model_name, hf_token)
     local_path = Path(model_name) / filename
@@ -908,21 +928,21 @@ def _remote_auto_map_py_contents(
                     logger.debug("Could not read %s: %s", py_path, exc)
                     return [], False
         ext_sources, ext_ok = _collect_external_py_sources(ext_refs, hf_token)
+        sources.extend(ext_sources)
         if any(repo is not None for repo, _ in ext_refs) and not ext_ok:
             return sources, False
-        sources.extend(ext_sources)
         return sources, cfg_definitive
 
     if _env_offline() or not _looks_like_hf_id(model_name):
         return [], False
 
+    # An incomplete own-repo listing/fetch does not end the scan: the external repos may
+    # still hold the marker, and whatever was read stays available to prove the tier.
     sources, repo_ok = _fetch_hub_py_sources(model_name, hf_token)
-    if not repo_ok:
-        return [], False
     ext_sources, ext_ok = _collect_external_py_sources(ext_refs, hf_token)
-    if any(repo is not None for repo, _ in ext_refs) and not ext_ok:
-        return sources, False
     sources.extend(ext_sources)
+    if not repo_ok or (any(repo is not None for repo, _ in ext_refs) and not ext_ok):
+        return sources, False
     return sources, cfg_definitive
 
 
@@ -935,20 +955,40 @@ def _parsed_dotted_imports(src: str) -> set[str] | None:
     skipped (a repo's own same-named helper must not match). ``None`` (unparseable) and an
     empty set (parsed, imports nothing) are different answers, so the caller only falls
     back to the line scan for source ``ast`` could not read at all.
+
+    Bodies of ``if TYPE_CHECKING:`` are skipped: that guard is false at runtime, so a
+    type-only annotation import never executes and must not promote an otherwise
+    4.57.x-loadable custom model onto a 5.x sidecar. Only the guard's own body is dropped;
+    its ``else`` / ``elif`` branches do run and are still collected, and ``if not
+    TYPE_CHECKING:`` is not the guard, so its body is collected too.
     """
     import ast
+
+    def _is_type_checking(test) -> bool:
+        return (isinstance(test, ast.Name) and test.id == "TYPE_CHECKING") or (
+            isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"
+        )
 
     try:
         tree = ast.parse(src)
     except Exception:
         return None
     names: set[str] = set()
-    for node in ast.walk(tree):
+    stack: list = [tree]
+    while stack:
+        node = stack.pop()
         if isinstance(node, ast.Import):
             names.update(alias.name for alias in node.names)
-        elif isinstance(node, ast.ImportFrom) and not node.level and node.module:
-            names.add(node.module)
-            names.update(f"{node.module}.{alias.name}" for alias in node.names)
+            continue
+        if isinstance(node, ast.ImportFrom):
+            if not node.level and node.module:
+                names.add(node.module)
+                names.update(f"{node.module}.{alias.name}" for alias in node.names)
+            continue
+        if isinstance(node, ast.If) and _is_type_checking(node.test):
+            stack.extend(node.orelse)
+            continue
+        stack.extend(ast.iter_child_nodes(node))
     return names
 
 
@@ -1016,25 +1056,45 @@ def _local_scan_signature(model_name: str) -> str | None:
         return None
 
 
-def _remote_auto_map_scan_result(model_name: str, hf_token: str | None = None) -> tuple[bool, bool]:
-    """Return ``(needs_510, scan_was_definitive)`` for auto_map remote code."""
+def _remote_auto_map_tier(model_name: str, hf_token: str | None = None) -> tuple[str, bool]:
+    """Return ``(tier, scan_was_definitive)`` for auto_map remote code.
+
+    ``"510"`` when the closure imports a 5.10-only symbol, ``"530"`` when it imports the
+    5.x-only tokenizers backend module, else ``"default"``. The 5.x marker is classified
+    here and not only in the tokenizer check because remote code reached through
+    ``config.json`` or a processor config is never scanned by that check when
+    ``tokenizer_config.json`` does not itself declare the module: the worker would then
+    pick the default 4.57.x tier, which does not ship
+    ``transformers.tokenization_utils_tokenizers`` at all.
+    """
     signature = _local_scan_signature(model_name)
     cache_key = (*_token_cache_key(model_name, hf_token), signature)
-    if signature is not None and cache_key in _remote_auto_map_needs_510_cache:
-        return _remote_auto_map_needs_510_cache[cache_key], True
+    if signature is not None and cache_key in _remote_auto_map_tier_cache:
+        return _remote_auto_map_tier_cache[cache_key], True
 
     # Offline Hub ids cannot be scanned here; do not cache the assumed negative so a
     # later online read re-fetches (mirrors _check_tokenizer_config_needs_v5).
     if _env_offline() and not _safe_is_dir(Path(model_name)):
-        return False, False
+        return "default", False
 
     sources, definitive = _remote_auto_map_py_contents(model_name, hf_token)
-    result = _remote_auto_map_py_matches(_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS, sources)
-    if result:
+    if _remote_auto_map_py_matches(_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS, sources):
+        tier = "510"
         logger.info("Remote auto_map check: %s needs transformers 5.10.x", model_name)
+    elif _remote_auto_map_py_matches(_TRANSFORMERS_5_REMOTE_IMPORT_MARKERS, sources):
+        tier = "530"
+        logger.info("Remote auto_map check: %s requires transformers 5.x", model_name)
+    else:
+        tier = "default"
     if definitive and signature is not None:
-        _remote_auto_map_needs_510_cache[cache_key] = result
-    return result, definitive
+        _remote_auto_map_tier_cache[cache_key] = tier
+    return tier, definitive
+
+
+def _remote_auto_map_scan_result(model_name: str, hf_token: str | None = None) -> tuple[bool, bool]:
+    """Return ``(needs_510, scan_was_definitive)`` for auto_map remote code."""
+    tier, definitive = _remote_auto_map_tier(model_name, hf_token)
+    return tier == "510", definitive
 
 
 def _check_remote_auto_map_needs_510(model_name: str, hf_token: str | None = None) -> bool:
@@ -2035,7 +2095,8 @@ def get_transformers_tier(
                     model_name,
                 )
                 return tier
-            if _check_remote_auto_map_needs_510(model_name, hf_token):
+            remote_tier, _ = _remote_auto_map_tier(model_name, hf_token)
+            if remote_tier == "510":
                 tier = _raise_tier_for_nested(cfg, "510")
                 logger.info(
                     "Transformers tier %s selected for %s (local auto_map needs 5.10.x)",
@@ -2116,6 +2177,14 @@ def get_transformers_tier(
                 if not probe:
                     return "530"
                 return _probe_tier(model_name, hf_token, "local tokenizer needs 5.x")
+            # Remote code declared by config.json / a processor config that imports the
+            # 5.x-only tokenizers backend. The tokenizer check above only walks the closure
+            # tokenizer_config.json itself declares, so without this the module would route
+            # to the default tier that cannot import it. 510 already returned above.
+            if remote_tier != "default":
+                if not probe:
+                    return "530"
+                return _probe_tier(model_name, hf_token, "local auto_map needs 5.x")
             if _config_saved_by_transformers_5(cfg):
                 if not probe:
                     return "530"  # cheap 5.x hint; the real path resolves the exact tier
@@ -2204,6 +2273,16 @@ def get_transformers_tier(
         if not probe:
             return "530"
         return _probe_tier(model_name, hf_token, "tokenizer needs 5.x")
+
+    # Same gap as the local branch, for a Hub id: remote code declared outside
+    # tokenizer_config.json that imports the 5.x-only tokenizers backend. Only on the
+    # activation path -- probe=False must not pay for a repo listing plus a fetch per
+    # remote .py (see _check_config_needs_510's scan_auto_map note). 510 already returned
+    # from _check_config_needs_510 above, so this can only add the 5.3 floor. That call
+    # memoized the scan, so this is a cache hit; it re-scans only when the closure could
+    # not be read in full, which is exactly when a negative must not be trusted.
+    if probe and _remote_auto_map_tier(model_name, hf_token)[0] != "default":
+        return _probe_tier(model_name, hf_token, "auto_map needs 5.x")
 
     if _config_saved_by_transformers_5(_cached_config_json(model_name, hf_token)):
         if not probe:

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -1156,6 +1156,12 @@ def _load_repo_json_checked(
     failure, offline Hub id); a local read, a 401/403/404 and a parse error are all definitive,
     so only a read that never happened blocks caching.
 
+    The remote read stops at ``_REMOTE_SCAN_MAX_FILE_BYTES``, the bound
+    :func:`_read_repo_text_file` already puts on ``.py`` downloads. These configs are fetched
+    before the remote-code consent gate and outside :class:`_RemoteScanBudget`, so without it
+    one enormous ``processor_config.json`` could exhaust a worker. Over-cap is inconclusive
+    (``(None, False)``), never a confirmed "declares no auto_map".
+
     A local checkpoint's ``config.json`` is read straight from disk, NOT through
     ``_load_config_json``: that process-lifetime cache would serve pre-rewrite contents to the
     rescan a changed scan signature just forced (a staged checkpoint writing code first and
@@ -1189,7 +1195,16 @@ def _load_repo_json_checked(
     try:
         req = urllib.request.Request(url, headers = headers)
         with _hub_urlopen(req, timeout = 10) as resp:
-            return json.loads(resp.read().decode()), True
+            raw = resp.read(_REMOTE_SCAN_MAX_FILE_BYTES + 1)
+        if len(raw) > _REMOTE_SCAN_MAX_FILE_BYTES:
+            logger.debug(
+                "Skipping oversized remote config %s for '%s' (over %d bytes)",
+                filename,
+                model_name,
+                _REMOTE_SCAN_MAX_FILE_BYTES,
+            )
+            return None, False
+        return json.loads(raw.decode()), True
     except urllib.error.HTTPError as exc:
         # 404 = genuinely absent; 401/403 = definitively unreadable with this token.
         # Anything else (5xx, rate limit) is transient and must stay inconclusive.
@@ -1273,8 +1288,10 @@ def _parsed_dotted_imports(src: str) -> set[str] | None:
     tier, and computed or f-string names are left alone.
 
     Qualified access counts too: ``import transformers`` then ``transformers.X`` is the usual
-    spelling of a public-export marker. Aliases (including an aliased ``import_module``)
-    resolve through the file's own bindings, so a never-imported name contributes nothing.
+    spelling of a public-export marker, as is reading the attribute straight off the dynamic
+    import (``importlib.import_module("transformers").X``). Aliases (including an aliased
+    ``import_module``) resolve through the file's own bindings, so a never-imported name
+    contributes nothing.
     """
     import ast
 
@@ -1366,15 +1383,40 @@ def _parsed_dotted_imports(src: str) -> set[str] | None:
         # A leading dot is relative, skipped for the same reason as ImportFrom.
         return None if arg.value.startswith(".") else (called, arg.value)
 
-    def _attribute_chain(node) -> tuple[str, str] | None:
-        """``(root name, dotted attribute path)`` for ``a.b.c``, else ``None``."""
+    def _chain_root(node) -> tuple[object, str]:
+        """``(innermost non-attribute node, dotted attribute path)`` for ``a.b.c``."""
         parts: list[str] = []
         while isinstance(node, ast.Attribute):
             parts.append(node.attr)
             node = node.value
-        if not isinstance(node, ast.Name):
+        return node, ".".join(reversed(parts))
+
+    def _attribute_chain(node) -> tuple[str, str] | None:
+        """``(root name, dotted attribute path)`` for ``a.b.c``, else ``None``."""
+        root, attr = _chain_root(node)
+        return (root.id, attr) if isinstance(root, ast.Name) else None
+
+    def _dynamic_chain(node) -> tuple[str, str, str] | None:
+        """``(callee, module, attribute path)`` for ``import_module("pkg").a.b``, else ``None``.
+
+        The call really imports and the attribute is really read, so this is the dynamic
+        spelling of ``import pkg`` followed by ``pkg.a.b`` and has to count the same.
+        :func:`_attribute_chain` cannot see it: the chain's root is an ``ast.Call``, not an
+        ``ast.Name``, so only the bare module was recorded and a 5.x-only export read this way
+        stayed invisible, routing the checkpoint to 4.57.x where the attribute does not exist.
+        """
+        root, attr = _chain_root(node)
+        if not attr or not isinstance(root, ast.Call):
             return None
-        return node.id, ".".join(reversed(parts))
+        call = _dynamic_import_call(root)
+        if call is None:
+            return None
+        called, module = call
+        # An aliased callee must be a bare name, matching the plain-call branch below: a
+        # method call such as ``self.loader.load("pkg")`` is not an import.
+        if called in ("import_module", "__import__") or isinstance(root.func, ast.Name):
+            return called, module, attr
+        return None
 
     try:
         tree = ast.parse(src)
@@ -1408,6 +1450,14 @@ def _parsed_dotted_imports(src: str) -> set[str] | None:
             chain = _attribute_chain(node)
             if chain is not None:
                 chains.add(chain)
+            else:
+                dynamic = _dynamic_chain(node)
+                if dynamic is not None:
+                    called, module, attr = dynamic
+                    if called in ("import_module", "__import__"):
+                        names.add(f"{module}.{attr}")
+                    else:
+                        deferred.append((called, module, attr))
         elif isinstance(node, ast.Call):
             call = _dynamic_import_call(node)
             if call is not None:
@@ -1415,7 +1465,7 @@ def _parsed_dotted_imports(src: str) -> set[str] | None:
                 if called in ("import_module", "__import__"):
                     names.add(module)
                 elif isinstance(node.func, ast.Name):
-                    deferred.append((called, module))
+                    deferred.append((called, module, ""))
             # Not terminal: keep walking so a nested call or import still counts.
         stack.extend(ast.iter_child_nodes(node))
     # Resolved after the walk: a binding can sit below the use that needs it.
@@ -1423,9 +1473,9 @@ def _parsed_dotted_imports(src: str) -> set[str] | None:
         module = bound.get(root)
         if module:
             names.add(f"{module}.{attr}")
-    for called, module in deferred:
+    for called, module, attr in deferred:
         if bound.get(called) == "importlib.import_module":
-            names.add(module)
+            names.add(f"{module}.{attr}" if attr else module)
     return names
 
 

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -811,22 +811,28 @@ def _iter_link_entries(header: str):
             yield uri, params
 
 
-def _parse_link_next(link_header: str | None) -> str | None:
-    """Next-page URL from an RFC 8288 ``Link`` header, or None.
+def _parse_link_next(link_header: "str | list[str] | None") -> str | None:
+    """Next-page URL from RFC 8288 ``Link`` header field(s), or None.
 
     ``rel`` may sit at any position, be unquoted, and carry a case-insensitive space-separated
     list. Matching only a leading ``rel="next"`` would drop the valid
     ``<...>; type="application/json"; rel="next"``, and that is not safe:
     :func:`_hf_api_get_json` reads "no next cursor" as "listing finished" and returns the
     truncated page with ``success=True``, caching a later-page 5.x-only import as default tier.
+
+    A list is accepted because RFC 7230 lets a server repeat ``Link`` as separate field lines,
+    and ``HTTPMessage.get`` returns only the first: a cursor in a later line hits that same
+    truncated-page-cached-as-default failure.
     """
-    for uri, params in _iter_link_entries(link_header or ""):
-        for name, value in params:
-            if name != "rel":
-                continue
-            if "next" in value.lower().split():
-                return uri
-            break  # RFC 8288: only an entry's first rel parameter is significant
+    fields = [link_header] if isinstance(link_header, str) else list(link_header or ())
+    for field in fields:
+        for uri, params in _iter_link_entries(field or ""):
+            for name, value in params:
+                if name != "rel":
+                    continue
+                if "next" in value.lower().split():
+                    return uri
+                break  # RFC 8288: only an entry's first rel parameter is significant
     return None
 
 
@@ -859,7 +865,7 @@ def _hf_api_get_json(path: str, hf_token: str | None = None) -> tuple[object | N
             req = urllib.request.Request(url, headers = headers)
             with _hub_urlopen(req, timeout = 10) as resp:
                 payload = json.loads(resp.read().decode())
-                next_url = _parse_link_next(resp.headers.get("Link"))
+                next_url = _parse_link_next(resp.headers.get_all("Link"))
             if not isinstance(payload, list):
                 return payload, True
             merged.extend(payload)

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -928,9 +928,7 @@ def _check_remote_auto_map_needs_510(model_name: str, hf_token: str | None = Non
 
 
 def _tokenizer_auto_map_needs_v5(
-    data: dict,
-    model_name: str,
-    hf_token: str | None,
+    data: dict, model_name: str, hf_token: str | None
 ) -> tuple[bool, bool]:
     """``(needs_v5, definitive)`` for the tokenizer ``auto_map`` closure.
 
@@ -957,9 +955,7 @@ def _tokenizer_auto_map_needs_v5(
                     return False, False
         # An own-repo entry file that has not been written yet (in-progress checkpoint)
         # means the closure is incomplete, not that it is 4.x-safe.
-        definitive = all(
-            repo is not None or _safe_is_file(local_root / fn) for repo, fn in refs
-        )
+        definitive = all(repo is not None or _safe_is_file(local_root / fn) for repo, fn in refs)
         ext_sources, ext_ok = _collect_external_py_sources(refs, hf_token)
         if any(repo is not None for repo, _ in refs) and not ext_ok:
             return False, False

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -966,10 +966,7 @@ def _fetch_hub_py_sources(
     return sources, complete
 
 
-def _snapshot_py_sources(
-    snapshot: Path,
-    budget: "_RemoteScanBudget | None" = None,
-) -> list[str]:
+def _snapshot_py_sources(snapshot: Path, budget: "_RemoteScanBudget | None" = None) -> list[str]:
     """Every readable ``.py`` under a hub-cache snapshot dir, charged to *budget*.
 
     Stands in for a repo the Hub API would not list: the snapshot is the exact code an

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -1151,8 +1151,8 @@ def _remote_auto_map_py_matches(markers: tuple[str, ...], sources: list[str]) ->
 
 
 def _local_scan_signature(model_name: str) -> str | None:
-    """Signature of a local checkpoint's scan inputs (path + size + mtime), or ``""`` for a
-    Hub id. ``None`` when the walk fails, which means "do not cache".
+    """Signature of a local checkpoint's scan inputs (path + size + mtime + ctime + inode),
+    or ``""`` for a Hub id. ``None`` when the walk fails, which means "do not cache".
 
     Covers the ``.py`` files AND every config that can declare an ``auto_map``, because both
     decide the answer. A checkpoint materialized in stages can land its code first and gain
@@ -1162,6 +1162,19 @@ def _local_scan_signature(model_name: str) -> str | None:
     Folded into the scan cache keys (mirrors ``_probe_cache_key``) so a checkpoint whose
     remote code or whose declaration is written or replaced after a first lookup is
     re-scanned instead of reusing a stale answer.
+
+    Size and mtime alone do not see a same-sized replacement that restores the timestamp,
+    which is what an archival redeploy does (``rsync --archive``, ``tar -xp``): the
+    signature stays byte-identical and a long-lived worker keeps serving the tier it
+    computed from code that is no longer on disk. ``st_ctime_ns`` moves on any write to an
+    existing inode and ``st_ino`` moves when the file is replaced by rename, so the two
+    together cover both spellings of that redeploy at no extra cost -- both fields come
+    from the ``stat`` call already being made. A digest would also work but would read
+    every ``.py`` on each lookup, and this signature is recomputed on the hot path. On
+    Windows ``st_ctime_ns`` is a creation time rather than a change time, so only the
+    ``st_ino`` half applies there; that is strictly more than the previous signature saw.
+    A spurious miss (a touch, a chmod, a restore that moves the inode without changing
+    content) only costs one re-scan of local files, so this errs toward re-reading.
     """
     root = Path(model_name)
     if not _safe_is_dir(root):
@@ -1177,7 +1190,9 @@ def _local_scan_signature(model_name: str) -> str | None:
                 # Absent (or unreadable) contributes nothing; it starts contributing the
                 # moment it appears, which is exactly the change we must notice.
                 continue
-            parts.append(f"{path}:{st.st_size}:{st.st_mtime_ns}")
+            parts.append(
+                f"{path}:{st.st_size}:{st.st_mtime_ns}:{st.st_ctime_ns}:{st.st_ino}"
+            )
         return "\0".join(parts)
     except Exception as exc:
         logger.debug("Could not signature local scan inputs under %s: %s", model_name, exc)
@@ -1256,6 +1271,22 @@ def _remote_auto_map_tier(model_name: str, hf_token: str | None = None) -> tuple
         logger.info("Remote auto_map check: %s requires transformers 5.x", model_name)
     else:
         tier = "default"
+    if not definitive and tier == "default" and not _safe_is_dir(Path(model_name)):
+        # An inconclusive scan is not a negative. Nothing was read that says "default";
+        # the Hub simply did not answer, and the caller (get_transformers_tier) can only
+        # see the tier, so a bare "default" here is indistinguishable from a repo that
+        # really has no 5.x import and activates 4.57.x for code that needs 5.x. A
+        # snapshot already in the hub cache is the same code an offline load would
+        # execute, so read it instead of guessing -- the same fallback the _env_offline
+        # branch above makes, now also for a transient failure while nominally online.
+        # Only ever raises the tier (_higher_tier), and the answer stays non-definitive so
+        # nothing is cached under the Hub id and a recovered Hub re-scans. Deliberately
+        # not a blanket 5.3 floor: an unread config is inconclusive for every model, so
+        # flooring here would push plain non-remote-code repos onto the 5.3 sidecar for
+        # the length of any Hub outage.
+        snapshot = _hf_cache_snapshot_dir(model_name)
+        if snapshot is not None:
+            tier = _higher_tier(tier, _remote_auto_map_tier(str(snapshot), hf_token)[0])
     if definitive and signature is not None:
         _remote_auto_map_tier_cache[cache_key] = tier
     return tier, definitive

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -1190,9 +1190,7 @@ def _local_scan_signature(model_name: str) -> str | None:
                 # Absent (or unreadable) contributes nothing; it starts contributing the
                 # moment it appears, which is exactly the change we must notice.
                 continue
-            parts.append(
-                f"{path}:{st.st_size}:{st.st_mtime_ns}:{st.st_ctime_ns}:{st.st_ino}"
-            )
+            parts.append(f"{path}:{st.st_size}:{st.st_mtime_ns}:{st.st_ctime_ns}:{st.st_ino}")
         return "\0".join(parts)
     except Exception as exc:
         logger.debug("Could not signature local scan inputs under %s: %s", model_name, exc)

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -906,6 +906,11 @@ def _list_hub_repo_py_files(repo_id: str, hf_token: str | None = None) -> tuple[
 _REMOTE_SCAN_MAX_FILES = 128
 _REMOTE_SCAN_MAX_TOTAL_CHARS = 16 * 1024 * 1024
 _REMOTE_SCAN_MAX_FILE_BYTES = 4 * 1024 * 1024
+# Enumerating one repo costs a recursive tree listing (up to ``_HF_API_MAX_PAGES`` requests)
+# before a single ``.py`` is charged, so the caps above do not bound how many repos a config
+# can send the scan to. An ``auto_map`` names an external repo only to borrow a base
+# implementation, which is one or two entries; this leaves an order of magnitude of headroom.
+_REMOTE_SCAN_MAX_EXTERNAL_REPOS = 16
 
 
 class _RemoteScanBudget:
@@ -918,11 +923,12 @@ class _RemoteScanBudget:
     positive from a partial closure.
     """
 
-    __slots__ = ("files_left", "chars_left", "truncated")
+    __slots__ = ("files_left", "chars_left", "repos_left", "truncated")
 
     def __init__(self) -> None:
         self.files_left = _REMOTE_SCAN_MAX_FILES
         self.chars_left = _REMOTE_SCAN_MAX_TOTAL_CHARS
+        self.repos_left = _REMOTE_SCAN_MAX_EXTERNAL_REPOS
         self.truncated = False
 
     def take_file(self) -> bool:
@@ -931,6 +937,21 @@ class _RemoteScanBudget:
             self.truncated = True
             return False
         self.files_left -= 1
+        return True
+
+    def take_repo(self) -> bool:
+        """Reserve one external repo. False once the repo, file or aggregate budget is spent.
+
+        Charged before the repo is listed, because the listing is the expensive part and it
+        runs before ``take_file`` is ever consulted. Spending the file or character budget also
+        closes this gate: once nothing more can be downloaded, listing another repo can only
+        cost requests. A repo holding no ``.py`` charges no file slot at all, so without a
+        count of its own an ``auto_map`` naming N repos buys N full tree listings for free.
+        """
+        if self.repos_left <= 0 or self.files_left <= 0 or self.chars_left <= 0:
+            self.truncated = True
+            return False
+        self.repos_left -= 1
         return True
 
     def spend(self, size: int) -> None:
@@ -1020,13 +1041,28 @@ def _collect_external_py_sources(
     4.57.x for code it cannot import. ``complete`` stays False whenever the Hub was not read,
     snapshot or not: an on-disk copy is not proof the Hub repo still matches it, so the
     closure never becomes definitive and no negative is memoized.
+
+    ``budget.take_repo`` is charged BEFORE :func:`_fetch_hub_py_sources`, which lists the whole
+    repo tree before consulting ``take_file``. Without that the loop kept listing repos after
+    the download budget was spent, and a config naming many repos (or repos holding no ``.py``,
+    which charge no file slot) bought an unbounded run of authenticated 10s-timeout Hub
+    requests ahead of the remote-code consent gate.
     """
     external_repos = {repo for repo, _ in refs if repo is not None}
     if not external_repos:
         return [], True
     sources: list[str] = []
     complete = True
-    for repo in sorted(external_repos):
+    ordered = sorted(external_repos)
+    for index, repo in enumerate(ordered):
+        if budget is not None and not budget.take_repo():
+            logger.debug(
+                "Remote scan budget spent before '%s'; %d external repo(s) left unlisted",
+                repo,
+                len(ordered) - index,
+            )
+            complete = False
+            break
         repo_sources, ok = _fetch_hub_py_sources(repo, hf_token, budget)
         sources.extend(repo_sources)
         if not ok:
@@ -1166,12 +1202,21 @@ def _load_repo_json_checked(
     ``_load_config_json``: that process-lifetime cache would serve pre-rewrite contents to the
     rescan a changed scan signature just forced (a staged checkpoint writing code first and
     ``auto_map`` afterwards), memoizing a fresh negative under the new signature.
+
+    For a Hub id the ``config.json`` verdict is ``_config_json_answer_is_definitive`` whether
+    or not a config came back, because a non-None one is not proof it is the current one:
+    ``_load_config_json`` answers a transient network failure from an older hub-cache
+    snapshot, and deliberately does not cache that fallback so the next call retries. Calling
+    it definitive let a snapshot predating a newly added ``auto_map`` memoize a default tier in
+    :func:`_remote_auto_map_tier` without the live code ever being scanned, and that memo then
+    outlived the outage for the life of the worker, routing the model to 4.57.x long after
+    connectivity came back.
     """
     if filename == "config.json" and not _safe_is_dir(Path(model_name)):
         cfg = _load_config_json(model_name, hf_token)
-        if cfg is not None or not _looks_like_hf_id(model_name):
+        if not _looks_like_hf_id(model_name):
             return cfg, True
-        return None, _config_json_answer_is_definitive(model_name, hf_token)
+        return cfg, _config_json_answer_is_definitive(model_name, hf_token)
     local_path = Path(model_name) / filename
     if _safe_is_file(local_path):
         try:
@@ -1292,6 +1337,12 @@ def _parsed_dotted_imports(src: str) -> set[str] | None:
     import (``importlib.import_module("transformers").X``). Aliases (including an aliased
     ``import_module``) resolve through the file's own bindings, so a never-imported name
     contributes nothing.
+
+    Two-argument ``getattr(transformers, "X")`` is that same qualified access with the name in
+    a string, and raises the same ``AttributeError`` on a sidecar without the export, so it
+    counts identically. The three-argument form does not: a supplied default is the idiom for
+    code that handles the export being absent, that code loads fine on 4.57.x, and promoting
+    it would strand every version-portable repo on a sidecar it never asked for.
     """
     import ast
 
@@ -1383,13 +1434,44 @@ def _parsed_dotted_imports(src: str) -> set[str] | None:
         # A leading dot is relative, skipped for the same reason as ImportFrom.
         return None if arg.value.startswith(".") else (called, arg.value)
 
+    def _const_getattr(node) -> tuple[object, str] | None:
+        """``(object node, attribute name)`` for two-argument ``getattr(x, "name")``, else None.
+
+        Exactly two arguments. The three-argument form supplies a default, so it CANNOT raise
+        when the export is missing and the module really does load on 4.57.x; promoting on it
+        would push every repo using that portability idiom onto a sidecar it does not need.
+        Same rule as the ``if TYPE_CHECKING:`` bodies above: an access that cannot fail must
+        not raise the tier. ``hasattr`` is left alone for the same reason.
+        """
+        if not isinstance(node, ast.Call) or node.keywords or len(node.args) != 2:
+            return None
+        func = node.func
+        if not isinstance(func, ast.Name) or func.id != "getattr":
+            return None
+        attr = node.args[1]
+        if not isinstance(attr, ast.Constant) or not isinstance(attr.value, str):
+            return None
+        return node.args[0], attr.value
+
     def _chain_root(node) -> tuple[object, str]:
-        """``(innermost non-attribute node, dotted attribute path)`` for ``a.b.c``."""
+        """``(innermost non-attribute node, dotted attribute path)`` for ``a.b.c``.
+
+        ``getattr(x, "b")`` unwraps like ``x.b``: it reads the same attribute at runtime and
+        raises the same ``AttributeError`` on a sidecar that lacks the export, so the two
+        spellings have to reach the same tier. Only a constant name unwraps, so a computed
+        ``getattr(x, name)`` stays invisible, as it must.
+        """
         parts: list[str] = []
-        while isinstance(node, ast.Attribute):
-            parts.append(node.attr)
-            node = node.value
-        return node, ".".join(reversed(parts))
+        while True:
+            if isinstance(node, ast.Attribute):
+                parts.append(node.attr)
+                node = node.value
+                continue
+            target = _const_getattr(node)
+            if target is None:
+                return node, ".".join(reversed(parts))
+            node, attr = target
+            parts.append(attr)
 
     def _attribute_chain(node) -> tuple[str, str] | None:
         """``(root name, dotted attribute path)`` for ``a.b.c``, else ``None``."""
@@ -1446,7 +1528,9 @@ def _parsed_dotted_imports(src: str) -> set[str] | None:
         if isinstance(node, ast.If) and _is_type_checking(node.test):
             stack.extend(node.orelse)
             continue
-        if isinstance(node, ast.Attribute):
+        # A constant ``getattr`` is an attribute read spelled as a call, so it takes the
+        # attribute branch; the call branch below would only look for an import in it.
+        if isinstance(node, ast.Attribute) or _const_getattr(node) is not None:
             chain = _attribute_chain(node)
             if chain is not None:
                 chains.add(chain)

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -225,6 +225,11 @@ _config_needs_550_cache: dict[tuple[str, str | None], bool] = {}
 _config_needs_530_cache: dict[tuple[str, str | None], bool] = {}
 _remote_auto_map_needs_510_cache: dict[tuple[str, str | None], bool] = {}
 
+# Models whose config.json got a definitive 401/403/404 (absent, or not readable with this
+# token). Tracked separately from _config_json_cache, which only holds configs we could
+# read, so "no auto_map" from an unread config is never mistaken for "no auto_map".
+_config_json_absent: set[tuple[str, str | None]] = set()
+
 # AutoConfig-probe tier cache for the process lifetime (cleared on restart), keyed by
 # model_name plus a local config.json signature (see _probe_cache_key) so an overwritten
 # checkpoint re-probes. Not keyed by Hub sha, so the probe never imports huggingface_hub
@@ -627,8 +632,30 @@ def _hf_api_url(path: str) -> str:
     return f"{_hf_endpoint_base()}{path}"
 
 
+def _parse_link_next(link_header: str | None) -> str | None:
+    """Next-page URL from a GitHub-style ``Link`` header, or None."""
+    for part in (link_header or "").split(","):
+        seg = part.split(";")
+        if len(seg) >= 2 and 'rel="next"' in seg[1]:
+            return seg[0].strip().strip("<>")
+    return None
+
+
+# A repo tree needs one request per 1000 entries; stop well past any real repo rather
+# than follow a cursor loop forever.
+_HF_API_MAX_PAGES = 200
+
+
 def _hf_api_get_json(path: str, hf_token: str | None = None) -> tuple[object | None, bool]:
-    """GET a Hub API path via stdlib urllib. Returns (parsed_json, success)."""
+    """GET a Hub API path via stdlib urllib, following ``Link`` pagination.
+
+    The tree endpoint returns at most ``limit`` entries per response (1000 by default) and
+    advertises the next cursor as ``Link: rel="next"``, which is how ``huggingface_hub``'s
+    own ``list_repo_tree`` walks it. Reading only the first response silently truncates a
+    large repo, so list payloads are concatenated across pages. Returns
+    ``(parsed_json, success)``; success is False if any page fails, so a partial listing is
+    never mistaken for a complete one.
+    """
     if _env_offline():
         return None, False
 
@@ -637,10 +664,26 @@ def _hf_api_get_json(path: str, hf_token: str | None = None) -> tuple[object | N
     headers = {"User-Agent": "unsloth-studio"}
     if hf_token:
         headers["Authorization"] = f"Bearer {hf_token}"
+    url = _hf_api_url(path)
+    merged: list = []
     try:
-        req = urllib.request.Request(_hf_api_url(path), headers = headers)
-        with urllib.request.urlopen(req, timeout = 10) as resp:
-            return json.loads(resp.read().decode()), True
+        for _ in range(_HF_API_MAX_PAGES):
+            req = urllib.request.Request(url, headers = headers)
+            with urllib.request.urlopen(req, timeout = 10) as resp:
+                payload = json.loads(resp.read().decode())
+                next_url = _parse_link_next(resp.headers.get("Link"))
+            if not isinstance(payload, list):
+                return payload, True
+            merged.extend(payload)
+            if not next_url:
+                return merged, True
+            # The cursor URL is echoed by the endpoint; only ever follow it over http(s).
+            if not next_url.startswith(("http://", "https://")):
+                logger.debug("Refusing non-http Hub pagination link for %s: %s", path, next_url)
+                return None, False
+            url = next_url
+        logger.debug("Hub API pagination exceeded %s pages for %s", _HF_API_MAX_PAGES, path)
+        return None, False
     except Exception as exc:
         logger.debug("HF API request failed for %s: %s", path, exc)
         return None, False
@@ -689,25 +732,64 @@ def _collect_external_py_sources(refs: set, hf_token: str | None = None) -> tupl
 
 
 def _auto_map_config_files(model_name: str) -> tuple[str, ...]:
-    """Configs to read for ``auto_map``. A local dir is free to read, so use every
-    remote-code config; a Hub id uses only ``config.json`` (already cached) because
-    transformers resolves remote MODELING code from there, and the extra files would
-    add an uncached fetch each to every tier lookup. Tokenizer auto_map is passed in by
-    its own caller (see ``known_refs``); a repo declaring modeling auto_map has every
-    ``.py`` in it fetched, which covers its processor code too."""
+    """Configs to read for ``auto_map``, the same set for a local dir and a Hub id.
+
+    A processor declared only in ``preprocessor_config.json`` / ``processor_config.json`` /
+    ``video_preprocessor_config.json`` (e.g. TencentARC/TimeLens-7B, whose config.json is a
+    stock ``qwen2_5_vl``) is still executed by ``AutoProcessor.from_pretrained(...,
+    trust_remote_code=True)``, so restricting a Hub id to ``config.json`` reports a
+    definitive negative for remote code that really does run. The extra reads land only on
+    the probe=True activation path, once per model, and only when the repo is scanned.
+    """
     from utils.security.remote_code_scan import REMOTE_CODE_CONFIG_FILES
-    return REMOTE_CODE_CONFIG_FILES if _safe_is_dir(Path(model_name)) else ("config.json",)
+    return REMOTE_CODE_CONFIG_FILES
 
 
-def _repo_has_auto_map(model_name: str, hf_token: str | None = None) -> bool:
-    """True when a remote-code config in the repo declares ``auto_map``."""
+def _repo_auto_map_refs(model_name: str, hf_token: str | None = None) -> tuple[set, bool, bool]:
+    """``(refs, has_auto_map, definitive)`` from the repo's remote-code configs.
+
+    Each config is read exactly once. ``definitive`` is False when a config could not be
+    read at all (transient Hub failure, offline Hub id), so "this repo declares no
+    auto_map" is never concluded from a config nobody managed to look at.
+    """
     from utils.security.remote_code_scan import _auto_map_refs
 
+    refs: set = set()
+    has_auto_map = False
+    definitive = True
     for cfg_name in _auto_map_config_files(model_name):
-        cfg = _load_repo_json_file(model_name, cfg_name, hf_token)
-        if isinstance(cfg, dict) and _auto_map_refs(cfg):
-            return True
-    return False
+        cfg, cfg_definitive = _load_repo_json_checked(model_name, cfg_name, hf_token)
+        if not cfg_definitive:
+            definitive = False
+        if isinstance(cfg, dict):
+            found = _auto_map_refs(cfg)
+            if found:
+                has_auto_map = True
+                refs |= found
+    return refs, has_auto_map, definitive
+
+
+def _decode_source_bytes(raw: bytes) -> str:
+    """Decode Python source bytes the way CPython does.
+
+    PEP 263: a BOM or a ``# -*- coding: <enc> -*-`` cookie in the first two lines declares
+    the file's encoding, so a legitimate non-UTF-8 module must not fail to decode here and
+    turn a real 5.x-only import into an unreadable source. ``tokenize.detect_encoding``
+    implements exactly that rule. Undecodable bytes fall back to replacement, matching how
+    local checkpoint files are already read.
+    """
+    import io
+    import tokenize
+
+    encoding = "utf-8"
+    try:
+        encoding, _ = tokenize.detect_encoding(io.BytesIO(raw).readline)
+    except Exception:
+        pass
+    try:
+        return raw.decode(encoding)
+    except Exception:
+        return raw.decode(encoding, errors = "replace")
 
 
 def _read_repo_text_file(
@@ -737,33 +819,43 @@ def _read_repo_text_file(
     try:
         req = urllib.request.Request(url, headers = headers)
         with urllib.request.urlopen(req, timeout = 10) as resp:
-            return resp.read().decode()
+            return _decode_source_bytes(resp.read())
     except Exception as exc:
         logger.debug("Could not fetch %s for '%s': %s", filename, model_name, exc)
         return None
 
 
-def _load_repo_json_file(
+def _load_repo_json_checked(
     model_name: str,
     filename: str,
     hf_token: str | None = None,
-) -> dict | None:
-    """Parsed JSON from a repo-relative file; local first, else HuggingFace raw fetch."""
+) -> tuple[dict | None, bool]:
+    """``(parsed_json, definitive)`` for a repo-relative JSON file; local first, else a raw
+    Hub fetch.
+
+    ``definitive`` is False only when the answer is genuinely unknown: a transient remote
+    failure, or an offline Hub id. A local read, a 401/403/404 and a parse error are all
+    definitive answers, so only a read that never happened blocks caching.
+    """
     if filename == "config.json":
-        return _load_config_json(model_name, hf_token)
+        cfg = _load_config_json(model_name, hf_token)
+        if cfg is not None or _safe_is_dir(Path(model_name)) or not _looks_like_hf_id(model_name):
+            return cfg, True
+        return None, _config_json_answer_is_definitive(model_name, hf_token)
     local_path = Path(model_name) / filename
     if _safe_is_file(local_path):
         try:
             with open(local_path) as f:
-                return json.load(f)
+                return json.load(f), True
         except Exception as exc:
             logger.debug("Could not read %s: %s", local_path, exc)
-            return None
-    if _safe_is_dir(Path(model_name)):
-        return None
-    if _env_offline() or not _looks_like_hf_id(model_name):
-        return None
+            return None, True
+    if _safe_is_dir(Path(model_name)) or not _looks_like_hf_id(model_name):
+        return None, True
+    if _env_offline():
+        return None, False
 
+    import urllib.error
     import urllib.request
 
     url = _hf_raw_file_url(model_name, filename)
@@ -773,10 +865,15 @@ def _load_repo_json_file(
     try:
         req = urllib.request.Request(url, headers = headers)
         with urllib.request.urlopen(req, timeout = 10) as resp:
-            return json.loads(resp.read().decode())
+            return json.loads(resp.read().decode()), True
+    except urllib.error.HTTPError as exc:
+        # 404 = genuinely absent; 401/403 = definitively unreadable with this token.
+        # Anything else (5xx, rate limit) is transient and must stay inconclusive.
+        logger.debug("Could not fetch %s for '%s': %s", filename, model_name, exc)
+        return None, exc.code in (401, 403, 404)
     except Exception as exc:
         logger.debug("Could not fetch %s for '%s': %s", filename, model_name, exc)
-        return None
+        return None, False
 
 
 def _remote_auto_map_py_contents(
@@ -792,16 +889,13 @@ def _remote_auto_map_py_contents(
     exists and saves re-reading that config. Returns ``(sources, definitive)``; when
     ``definitive`` is False the scan was incomplete and negatives must not be cached.
     """
-    from utils.security.remote_code_scan import _auto_map_refs
+    own_refs, has_auto_map, cfg_definitive = _repo_auto_map_refs(model_name, hf_token)
+    if not known_refs and not has_auto_map:
+        # An unread config proves nothing: report it as inconclusive rather than as a
+        # repo that declares no auto_map, so the negative is not cached until a real read.
+        return [], cfg_definitive
 
-    if not known_refs and not _repo_has_auto_map(model_name, hf_token):
-        return [], True
-
-    ext_refs: set = set(known_refs or ())
-    for cfg_name in _auto_map_config_files(model_name):
-        cfg = _load_repo_json_file(model_name, cfg_name, hf_token)
-        if isinstance(cfg, dict):
-            ext_refs |= _auto_map_refs(cfg)
+    ext_refs: set = set(known_refs or ()) | own_refs
 
     local_root = Path(model_name)
     if _safe_is_dir(local_root):
@@ -817,7 +911,7 @@ def _remote_auto_map_py_contents(
         if any(repo is not None for repo, _ in ext_refs) and not ext_ok:
             return sources, False
         sources.extend(ext_sources)
-        return sources, True
+        return sources, cfg_definitive
 
     if _env_offline() or not _looks_like_hf_id(model_name):
         return [], False
@@ -829,23 +923,25 @@ def _remote_auto_map_py_contents(
     if any(repo is not None for repo, _ in ext_refs) and not ext_ok:
         return sources, False
     sources.extend(ext_sources)
-    return sources, True
+    return sources, cfg_definitive
 
 
-def _imported_dotted_names(src: str) -> set[str]:
-    """Absolute module paths *src* imports, resolved with ``ast``.
+def _parsed_dotted_imports(src: str) -> set[str] | None:
+    """Absolute module paths *src* imports, resolved with ``ast``; ``None`` if it does not
+    parse.
 
-    Catches what a per-line substring scan cannot: a parenthesized multi-line import,
-    and the equivalent ``from <parent> import <submodule>`` spelling. Relative imports
-    are skipped (a repo's own same-named helper must not match). Empty when the source
-    does not parse.
+    Catches what a per-line substring scan cannot: a parenthesized multi-line import, and
+    the equivalent ``from <parent> import <submodule>`` spelling. Relative imports are
+    skipped (a repo's own same-named helper must not match). ``None`` (unparseable) and an
+    empty set (parsed, imports nothing) are different answers, so the caller only falls
+    back to the line scan for source ``ast`` could not read at all.
     """
     import ast
 
     try:
         tree = ast.parse(src)
     except Exception:
-        return set()
+        return None
     names: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
@@ -856,21 +952,31 @@ def _imported_dotted_names(src: str) -> set[str]:
     return names
 
 
+def _imported_dotted_names(src: str) -> set[str]:
+    """Absolute module paths *src* imports; empty when the source does not parse."""
+    return _parsed_dotted_imports(src) or set()
+
+
 def _remote_auto_map_py_matches(markers: tuple[str, ...], sources: list[str]) -> bool:
     """True when a source *imports* one of *markers*.
 
-    Import lines only: a marker named in a comment or docstring must not promote the
-    tier. The line scan runs first (not ``ast``) on purpose, since remote code that
-    fails to parse would otherwise turn into a silent negative and crash on the default
-    tier; the ``ast`` pass then only ADDS the spellings a line scan cannot see.
+    Import statements only: a marker sitting in a docstring, a comment or any other string
+    literal must not promote the tier, since ``ast`` resolves what the module actually
+    imports. Source that ``ast`` cannot parse still falls back to the raw line scan, so
+    unparseable remote code never turns into a silent negative that crashes on the default
+    tier; that fallback is the only place a substring match is trusted.
     """
     for src in sources:
-        for line in src.splitlines():
-            stripped = line.strip()
-            if stripped.startswith(("import ", "from ")) and any(m in stripped for m in markers):
-                return True
-    for src in sources:
-        for name in _imported_dotted_names(src):
+        names = _parsed_dotted_imports(src)
+        if names is None:
+            for line in src.splitlines():
+                stripped = line.strip()
+                if stripped.startswith(("import ", "from ")) and any(
+                    m in stripped for m in markers
+                ):
+                    return True
+            continue
+        for name in names:
             if any(name == m or name.startswith(m + ".") for m in markers):
                 return True
     return False
@@ -1137,7 +1243,10 @@ def _load_config_json(model_name: str, hf_token: str | None = None) -> dict | No
     import urllib.error
     import urllib.request
 
-    url = f"https://huggingface.co/{model_name}/raw/main/config.json"
+    # Endpoint-aware: a mirror-only deployment (HF_ENDPOINT set, huggingface.co blocked)
+    # must be able to read the config that gates the whole auto_map scan, or the
+    # endpoint-aware tree/raw requests below it are never reached.
+    url = _hf_raw_file_url(model_name, "config.json")
     headers = {"User-Agent": "unsloth-studio"}
     if hf_token:
         headers["Authorization"] = f"Bearer {hf_token}"
@@ -1152,6 +1261,7 @@ def _load_config_json(model_name: str, hf_token: str | None = None) -> dict | No
         # private metadata to an unauthenticated/wrong-token request.
         if exc.code in (401, 403, 404):
             logger.debug("config.json access denied for '%s': %s", model_name, exc)
+            _config_json_absent.add(cache_key)
             return None
         logger.debug("Could not fetch config.json for '%s': %s", model_name, exc)
         return _config_json_from_hf_cache(model_name)
@@ -1165,6 +1275,16 @@ def _config_json_is_definitive(model_name: str, hf_token: str | None = None) -> 
     """True if the last ``_load_config_json`` read for this model+token was cached
     (definitive), not a transient fallback (not stored, so callers re-check next call)."""
     return _token_cache_key(model_name, hf_token) in _config_json_cache
+
+
+def _config_json_answer_is_definitive(model_name: str, hf_token: str | None = None) -> bool:
+    """True when ``_load_config_json`` actually established an answer for this model+token.
+
+    Either it read a config (cached) or the Hub said 401/403/404. A transient failure
+    stores neither, so "no config" stays inconclusive and no negative gets cached.
+    """
+    key = _token_cache_key(model_name, hf_token)
+    return key in _config_json_cache or key in _config_json_absent
 
 
 def _config_matches_tier(cfg: dict, architectures: set[str], model_types: set[str]) -> bool:

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -1194,7 +1194,22 @@ def _remote_auto_map_scan_result(model_name: str, hf_token: str | None = None) -
 
 
 def _check_remote_auto_map_needs_510(model_name: str, hf_token: str | None = None) -> bool:
-    """True when auto_map remote code imports transformers>=5.10-only symbols."""
+    """True when auto_map remote code imports transformers>=5.10-only symbols.
+
+    While ``_TRANSFORMERS_510_REMOTE_IMPORT_MARKERS`` is empty the answer is False for every
+    repo, so the scan is skipped instead of run: it would read each remote-code config, page
+    the repo tree and fetch every ``.py`` only to reach the answer it already has. That cost
+    lands on the name fast path, where common Qwen/Ministral/... activations otherwise pay a
+    string of Hub round trips that cannot move the tier.
+
+    Gated on the tuple rather than removed at the call site, so re-adding a 5.10-only module
+    restores the scan everywhere by itself. The 5.3 classification the same scan produces is
+    not lost: callers that need it go through :func:`_remote_auto_map_tier` directly, and
+    :func:`_check_config_needs_510` still calls :func:`_remote_auto_map_scan_result` for the
+    ``definitive`` flag that decides whether its negative may be cached.
+    """
+    if not _TRANSFORMERS_510_REMOTE_IMPORT_MARKERS:
+        return False
     needs, _ = _remote_auto_map_scan_result(model_name, hf_token)
     return needs
 

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -966,6 +966,39 @@ def _fetch_hub_py_sources(
     return sources, complete
 
 
+def _snapshot_py_sources(
+    snapshot: Path,
+    budget: "_RemoteScanBudget | None" = None,
+) -> list[str]:
+    """Every readable ``.py`` under a hub-cache snapshot dir, charged to *budget*.
+
+    Stands in for a repo the Hub API would not list: the snapshot is the exact code an
+    offline ``trust_remote_code`` load executes. Each read draws on the caller's scan-wide
+    budget, so substituting snapshots for N repos cannot lift one scan's ceiling.
+    """
+    sources: list[str] = []
+    try:
+        paths = sorted(snapshot.rglob("*.py"))
+    except Exception as exc:
+        logger.debug("Could not walk hub cache snapshot %s: %s", snapshot, exc)
+        return sources
+    for py_path in paths:
+        if not _safe_is_file(py_path):
+            continue
+        if budget is not None and not budget.take_file():
+            logger.debug("Remote scan budget spent walking hub cache snapshot %s", snapshot)
+            break
+        try:
+            text = py_path.read_text(encoding = "utf-8", errors = "replace")
+        except Exception as exc:
+            logger.debug("Could not read %s: %s", py_path, exc)
+            continue
+        if budget is not None:
+            budget.spend(len(text))
+        sources.append(text)
+    return sources
+
+
 def _collect_external_py_sources(
     refs: set,
     hf_token: str | None = None,
@@ -976,6 +1009,14 @@ def _collect_external_py_sources(
     Like :func:`_fetch_hub_py_sources`, an unreachable repo marks the closure incomplete
     without dropping what the repos that did answer returned. *budget* is the caller's
     scan-wide cap, threaded through so every referenced repo draws on the same ceiling.
+
+    A repo the Hub would not answer for falls back to its own hub-cache snapshot, the same
+    substitution :func:`_remote_auto_map_tier` makes for the primary model id. Without it an
+    offline model whose ``auto_map`` names a separate repo is scanned with that repo's code
+    missing, so a 5.x-only import living only there is never seen and the worker activates
+    4.57.x for code it cannot import. ``complete`` stays False whenever the Hub was not read,
+    snapshot or not: an on-disk copy is not proof the Hub repo still matches it, so the
+    closure never becomes definitive and no negative is memoized.
     """
     external_repos = {repo for repo, _ in refs if repo is not None}
     if not external_repos:
@@ -984,9 +1025,12 @@ def _collect_external_py_sources(
     complete = True
     for repo in sorted(external_repos):
         repo_sources, ok = _fetch_hub_py_sources(repo, hf_token, budget)
+        sources.extend(repo_sources)
         if not ok:
             complete = False
-        sources.extend(repo_sources)
+            snapshot = _hf_cache_snapshot_dir(repo)
+            if snapshot is not None:
+                sources.extend(_snapshot_py_sources(snapshot, budget))
     return sources, complete
 
 
@@ -1215,7 +1259,10 @@ def _parsed_dotted_imports(src: str) -> set[str] | None:
     ``if TYPE_CHECKING:`` bodies are skipped: that guard is false at runtime, so a type-only
     import must not promote an otherwise 4.57.x-loadable model onto a sidecar. Only the guard's
     own body is dropped; its ``else``/``elif`` branches and ``if not TYPE_CHECKING:`` do run
-    and are collected.
+    and are collected. The name must resolve to ``typing``/``typing_extensions``'
+    ``TYPE_CHECKING`` (aliases included) or to a literal ``False``: a module is free to bind
+    that spelling to its own truthy value, and dropping a branch that really executes would
+    hide a 5.x-only import behind the default tier.
 
     ``importlib.import_module("pkg.mod")`` / ``__import__("pkg.mod")`` count, since that call
     really imports at runtime and would raise on the wrong sidecar. Only literal string args
@@ -1228,10 +1275,76 @@ def _parsed_dotted_imports(src: str) -> set[str] | None:
     """
     import ast
 
+    _TYPING_GUARD_MODULES = ("typing", "typing_extensions")
+
+    def _type_checking_bindings(tree) -> tuple[set[str], set[str]]:
+        """``(names meaning typing's TYPE_CHECKING, names bound to a typing module)``.
+
+        A pre-pass, because the walk below pops off a stack seeded with the module and so
+        reaches an ``if TYPE_CHECKING:`` before the import that binds the name. ``deferred``
+        cannot help: pruning decides whether the children are walked at all.
+
+        A name qualifies only when the file binds it to ``typing``/``typing_extensions``'
+        ``TYPE_CHECKING`` (aliases included) or to a literal ``False``, the spelling that keeps
+        the guard without importing ``typing`` at runtime. Any other binding of that name is a
+        shadow whose branch really does execute, so it is subtracted. Erring toward keeping a
+        branch only costs a needless sidecar; dropping a live one hides a 5.x-only import.
+        """
+        direct: set[str] = set()
+        modules: set[str] = set()
+        shadowed: set[str] = set()
+        # Identities, so the sweep below can tell a dead ``X = False`` target apart from the
+        # same name reappearing as an ordinary store.
+        dead_targets: set[int] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant):
+                if node.value.value is False:
+                    for target in node.targets:
+                        if isinstance(target, ast.Name):
+                            direct.add(target.id)
+                            dead_targets.add(id(target))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    root = alias.name.split(".", 1)[0]
+                    if alias.asname:
+                        # ``import typing.io as tio`` binds the submodule, not ``typing``.
+                        if alias.name in _TYPING_GUARD_MODULES:
+                            modules.add(alias.asname)
+                    elif root in _TYPING_GUARD_MODULES:
+                        modules.add(root)
+            elif isinstance(node, ast.ImportFrom):
+                # A relative ``from .flags import TYPE_CHECKING`` is the repo's own name.
+                if node.level or node.module not in _TYPING_GUARD_MODULES:
+                    continue
+                for alias in node.names:
+                    if alias.name == "TYPE_CHECKING":
+                        direct.add(alias.asname or alias.name)
+                    elif alias.name == "*":
+                        # TYPE_CHECKING is in typing.__all__, so a star import binds it.
+                        direct.add("TYPE_CHECKING")
+            elif isinstance(node, ast.arg):
+                shadowed.add(node.arg)
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                shadowed.add(node.name)
+            elif isinstance(node, ast.ExceptHandler) and node.name:
+                shadowed.add(node.name)
+            elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+                # Covers assignment, for/with targets, walrus and comprehensions.
+                if id(node) not in dead_targets:
+                    shadowed.add(node.id)
+        return direct - shadowed, modules - shadowed
+
     def _is_type_checking(test) -> bool:
-        return (isinstance(test, ast.Name) and test.id == "TYPE_CHECKING") or (
-            isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"
-        )
+        if isinstance(test, ast.Name):
+            return test.id in type_checking_names
+        if isinstance(test, ast.Attribute):
+            return (
+                test.attr == "TYPE_CHECKING"
+                and isinstance(test.value, ast.Name)
+                and test.value.id in type_checking_modules
+            )
+        return False
 
     def _dynamic_import_call(node) -> tuple[str, str] | None:
         """``(callee, module)`` for a constant-string import call, else ``None``."""
@@ -1264,6 +1377,7 @@ def _parsed_dotted_imports(src: str) -> set[str] | None:
         tree = ast.parse(src)
     except Exception:
         return None
+    type_checking_names, type_checking_modules = _type_checking_bindings(tree)
     names: set[str] = set()
     bound: dict[str, str] = {}
     chains: set[tuple[str, str]] = set()
@@ -1483,8 +1597,8 @@ def _check_remote_auto_map_needs_510(model_name: str, hf_token: str | None = Non
 
     Gated on the tuple rather than at the call site, so re-adding a 5.10-only module restores
     the scan everywhere by itself. The 5.3 classification is not lost: callers that need it go
-    through :func:`_remote_auto_map_tier`, and :func:`_check_config_needs_510` still calls
-    :func:`_remote_auto_map_scan_result` for the ``definitive`` flag.
+    through :func:`_remote_auto_map_tier`, which :func:`_check_config_needs_510` also calls
+    for the ``definitive`` flag and the scanned tier.
     """
     if not _TRANSFORMERS_510_REMOTE_IMPORT_MARKERS:
         return False
@@ -1541,13 +1655,21 @@ def _tokenizer_auto_map_needs_v5(
     return False, definitive
 
 
-def _check_tokenizer_config_needs_v5(model_name: str, hf_token: str | None = None) -> bool:
+def _check_tokenizer_config_needs_v5(
+    model_name: str,
+    hf_token: str | None = None,
+    scan_auto_map: bool = True,
+) -> bool:
     """True if the model's tokenizer_class requires transformers 5.x.
 
     Checks local tokenizer_config.json, else fetches from HuggingFace (authenticated with
     ``hf_token`` so gated/private repos resolve). Cached by (model, token) so an unauthenticated
     miss cannot poison a later authed read, plus the local scan signature so a replaced
     checkpoint is re-read. Returns False on any network/parse error (fail-open to default).
+
+    ``scan_auto_map=False`` answers from the tokenizer class alone and drops the ``auto_map``
+    closure scan, mirroring :func:`_check_config_needs_510`. The skip happens before the cache
+    write, so a probe=False negative never poisons a later activation.
     """
     signature = _local_scan_signature(model_name)
     cache_key = (*_token_cache_key(model_name, hf_token), signature)
@@ -1565,6 +1687,8 @@ def _check_tokenizer_config_needs_v5(model_name: str, hf_token: str | None = Non
             result = tokenizer_class in _TRANSFORMERS_5_TOKENIZER_CLASSES
             definitive = True
             if not result:
+                if not scan_auto_map:
+                    return False
                 result, definitive = _tokenizer_auto_map_needs_v5(data, model_name, hf_token)
             if result:
                 logger.info(
@@ -1605,6 +1729,8 @@ def _check_tokenizer_config_needs_v5(model_name: str, hf_token: str | None = Non
         result = tokenizer_class in _TRANSFORMERS_5_TOKENIZER_CLASSES
         definitive = True
         if not result:
+            if not scan_auto_map:
+                return False
             result, definitive = _tokenizer_auto_map_needs_v5(data, model_name, hf_token)
         if result:
             logger.info(
@@ -1858,12 +1984,20 @@ def _check_config_needs_510(
     model_name: str,
     hf_token: str | None = None,
     scan_auto_map: bool = True,
+    scan_out: dict | None = None,
 ) -> bool:
     """Check ``config.json`` for Gemma 4 Unified / 12B architectures (authenticated with
     ``hf_token``; cached by (model, token) only for a definitive read).
 
     ``scan_auto_map=False`` drops the remote-code scan for the cheap parent-side check
     (``probe=False``), which only asks "is this 5.x at all" and never activates a sidecar.
+
+    ``scan_out`` receives ``{"tier": ...}`` from the remote-code scan this call runs, for a
+    caller resolving the full tier. The return value is a 5.10 boolean, so a ``"530"`` scan
+    collapses to False here, and re-deriving the tier from a second scan is not equivalent:
+    only a definitive scan is memoized, so precisely when the first scan was inconclusive does
+    the second one refetch, and a 5.3 marker read on the first pass is lost if the ``.py``
+    carrying it fails on the second.
     """
     cache_key = _token_cache_key(model_name, hf_token)
     if cache_key in _config_needs_510_cache:
@@ -1890,7 +2024,10 @@ def _check_config_needs_510(
         # negative only says "no config match", and probe=True still scans.
         return False
 
-    remote_needs, remote_definitive = _remote_auto_map_scan_result(model_name, hf_token)
+    remote_tier, remote_definitive = _remote_auto_map_tier(model_name, hf_token)
+    remote_needs = remote_tier == "510"
+    if scan_out is not None:
+        scan_out["tier"] = remote_tier
     if remote_needs:
         logger.info(
             "config.json check: %s needs transformers %s (auto_map remote code)",
@@ -2606,7 +2743,10 @@ def get_transformers_tier(
         return tier
 
     # --- Slow config fallbacks (network for HF IDs; authenticated with hf_token) --------
-    if _check_config_needs_510(model_name, hf_token, scan_auto_map = probe):
+    # The remote-code scan this call runs already resolves a full tier; keep it so the 5.3
+    # check below reuses what this resolution observed instead of scanning a second time.
+    remote_scan: dict = {}
+    if _check_config_needs_510(model_name, hf_token, scan_auto_map = probe, scan_out = remote_scan):
         tier = _raise_tier_for_nested(_load_config_json(model_name, hf_token), "510")
         logger.info("Transformers tier %s selected for %s (config.json check)", tier, model_name)
         return tier
@@ -2645,7 +2785,10 @@ def get_transformers_tier(
                 model_name,
             )
             return static
-    if _check_tokenizer_config_needs_v5(model_name, hf_token):
+    # Same probe gate as the config fallback above: probe=False must not pay a repo listing
+    # plus a fetch per remote .py, which this check reaches through the tokenizer auto_map
+    # closure. The skipped result is never cached, so the activation path still resolves it.
+    if _check_tokenizer_config_needs_v5(model_name, hf_token, scan_auto_map = probe):
         if not probe:
             return "530"
         return _probe_tier(model_name, hf_token, "tokenizer needs 5.x")
@@ -2653,11 +2796,18 @@ def get_transformers_tier(
     # Same gap as the local branch, for a Hub id: remote code declared outside
     # tokenizer_config.json that imports the 5.x-only tokenizers backend. Activation path
     # only (see _check_config_needs_510's scan_auto_map note). 510 already returned above, so
-    # this can only add the 5.3 floor, and that call memoized the scan, so it is a cache hit
-    # except when the closure could not be read in full, which is when a negative must not
-    # be trusted anyway.
-    if probe and _remote_auto_map_tier(model_name, hf_token)[0] != "default":
-        return _probe_tier(model_name, hf_token, "auto_map needs 5.x")
+    # this can only add the 5.3 floor. Reuse the tier that call's scan resolved: a definitive
+    # scan is memoized and would be a cache hit anyway, while a non-definitive one is exactly
+    # the scan that must not be repeated, since the .py carrying the marker can be the one
+    # that fails on the second pass, dropping a 5.3 answer this activation already read.
+    if probe:
+        remote_tier = remote_scan.get("tier")
+        if remote_tier is None:
+            # No scan ran here: config.json answered on its own, or a memoized 5.10 answer
+            # short-circuited the call, so ask for the tier directly.
+            remote_tier = _remote_auto_map_tier(model_name, hf_token)[0]
+        if remote_tier != "default":
+            return _probe_tier(model_name, hf_token, "auto_map needs 5.x")
 
     if _config_saved_by_transformers_5(_cached_config_json(model_name, hf_token)):
         if not probe:


### PR DESCRIPTION
Fixes #7353

## Problem

Fine-tuning `pihu21057w/astral-0.6b-base` in Unsloth Studio (Colab T4) fails during the lightweight tokenizer pre-load step, before any model weights are loaded:

```
ModuleNotFoundError: No module named 'transformers.tokenization_utils_tokenizers'
```

The Astral checkpoint ships custom remote code (`tokenization_astral.py`, `modeling_astral.py`) that imports transformers 5.x-only symbols such as `TokenizersBackend` and `modeling_layers`. Studio tier detection did not recognize `model_type: astral` or the custom `AstralTokenizer` class, so the training worker activated the default transformers 4.57.x sidecar. That sidecar does not provide `transformers.tokenization_utils_tokenizers`, so `AutoTokenizer.from_pretrained(..., trust_remote_code=True)` crashes immediately.

## Fix

- **`studio/backend/utils/transformers_version.py`**: Register `AstralForCausalLM` / `astral` as transformers 5.10.x models. Add remote `auto_map` scanning so custom-code repos that import 5.10-only modeling symbols (e.g. `modeling_layers`, `utils.output_capturing`) route to the `.venv_t5_510` sidecar. Extend tokenizer tier detection to scan `tokenizer_config.json` `auto_map` targets for `tokenization_utils_tokenizers` imports (covers cached remote tokenizers that still reference `TokenizersBackend`).
- **`studio/backend/tests/test_transformers_version.py`**: Add regression tests for Astral architecture detection, remote modeling auto_map scanning, and tokenizer auto_map v5 import detection.

## Verification

- `cd studio/backend && PYTHONPATH=. python -m pytest tests/test_transformers_version.py::TestCheckConfigNeeds510 tests/test_transformers_version.py::TestCheckTokenizerConfigNeedsV5 tests/test_transformers_version.py::TestGetTransformersTier::test_astral_local_checkpoint_returns_510 -q` — **19 passed**
- `cd studio/backend && PYTHONPATH=. python -m pytest tests/test_transformers_version.py -q` — **235 passed**, 7 failed (same pre-existing failures on this runner; e.g. `test_local_config_json_short_circuits_path_substrings` fails on `main` without this patch)
- Not run here: Colab T4 end-to-end fine-tune of `pihu21057w/astral-0.6b-base` — please retest on reporter setup

## Compatibility

No API or config changes. Models that already matched existing tier rules are unaffected. Custom-code models with 5.10-only remote imports now correctly upgrade from the default 4.57.x sidecar.