### PR TITLE
Studio: use text-ui-* tokens instead of raw px in the voice tab

### DIFF
--- a/studio/frontend/src/features/settings/tabs/voice-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/voice-tab.tsx
@@ -278,13 +278,13 @@ function SttModelPicker({
                       {sttModelName(model)}
                     </span>
                     {twoLines ? (
-                      <span className="mt-0.5 block truncate font-mono text-[9px] leading-tight text-muted-foreground">
+                      <span className="mt-0.5 block truncate font-mono text-ui-9 leading-tight text-muted-foreground">
                         {sttModelSource(model)}
                       </span>
                     ) : null}
                   </span>
                   {sttModelSize(model) ? (
-                    <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground">
+                    <span className="shrink-0 text-ui-10 tabular-nums text-muted-foreground">
                       {sttModelSize(model)}
                     </span>
                   ) : null}


### PR DESCRIPTION
## Summary

The STT model rows in the voice settings tab used raw `text-[9px]` and `text-[10px]` utilities. These ignore the UI font size preference (they do not multiply by `--ui-font-scale`), and they trip the UI font-scale contract test, so `Repo tests (CPU)` fails on main:

```
FAILED tests/studio/test_ui_font_scale_contract.py::test_no_raw_pixel_text_utilities
AssertionError: Raw px text utilities ignore the UI font size preference; use the
text-ui-* / leading-ui-* tokens in index.css instead:
['features/settings/tabs/voice-tab.tsx: text-[9px]', 'features/settings/tabs/voice-tab.tsx: text-[10px]']
```

## Fix

Swap the two utilities for the existing scale-aware tokens in `index.css`:

- `text-[9px]` to `text-ui-9` (`--text-ui-9: calc(0.5625rem * var(--ui-font-scale, 1))`, i.e. 9px at scale 1)
- `text-[10px]` to `text-ui-10` (`--text-ui-10: calc(0.625rem * var(--ui-font-scale, 1))`, i.e. 10px at scale 1)

Both are the exact px equivalents at the default scale and now respond to the Appearance font-size preference. `text-ui-10` is already used across the UI.

## Test

`python -m pytest tests/studio/test_ui_font_scale_contract.py -q` passes (9 passed).