### PR TITLE
Studio UI test: survive a renderer crash in the voice model-picker step

### DIFF
--- a/tests/studio/playwright_extra_ui.py
+++ b/tests/studio/playwright_extra_ui.py
@@ -36,6 +36,9 @@ ART_DIR = os.environ.get("PW_ART_DIR", "logs/playwright_extra")
 ART = Path(ART_DIR)
 ART.mkdir(parents = True, exist_ok = True)
 STRICT = os.environ.get("STUDIO_UI_STRICT", "0") == "1"
+# The Voice-picker media-access crash is specific to headless Chromium on macos-14; only there do we
+# downgrade a renderer crash to a warning. Linux/Windows strict smoke jobs keep hard crash coverage.
+MACOS_RUNNER = os.environ.get("RUNNER_OS", "").lower() == "macos" or sys.platform == "darwin"
 # Longer turn timeout: gemma-3-270m CPU inference is 3-5x slower on macos-14 runners.
 TURN_TIMEOUT_MS = int(os.environ.get("STUDIO_UI_TURN_TIMEOUT_MS", "180000"))
 WALL_TIMEOUT_S = float(os.environ.get("STUDIO_UI_WALL_TIMEOUT_S", "720"))
@@ -558,8 +561,8 @@ with sync_playwright() as p:
         else:
             # The dictation-engine dropdown touches a media-access path that can crash headless
             # Chromium on macos-14 (CheckMediaAccessPermission). A resulting TargetClosedError is CI
-            # flakiness, not a product bug, so a crash here is a runtime warning + page recovery; a
-            # live-page failure (missing control, wheel that does not scroll) stays a hard fail.
+            # flakiness there, not a product bug, so on macOS a crash is a runtime warning + page
+            # recovery; on Linux/Windows a crash and any live-page failure stay a hard fail.
             try:
                 voice_tab.click()
                 page.get_by_label("Dictation engine").click()
@@ -585,7 +588,7 @@ with sync_playwright() as p:
                 )
                 info("OK Voice model picker mouse wheel changed scrollTop")
             except Exception as exc:
-                if page_crashed(page, exc):
+                if page_crashed(page, exc) and MACOS_RUNNER:
                     runtime_warn(f"Voice model picker aborted (browser/page unstable): {exc!r}")
                     page = recover_or_replace_page(
                         page,

--- a/tests/studio/playwright_extra_ui.py
+++ b/tests/studio/playwright_extra_ui.py
@@ -71,6 +71,18 @@ def runtime_warn(m: str) -> None:
     info(f"WARN (runtime): {m}")
 
 
+def page_crashed(pg, exc: Exception) -> bool:
+    """True when the browser/page/context died (a macos-14 renderer crash) rather than a live-page
+    assertion failing -- so the caller can downgrade CI-environment flakiness to a runtime warning."""
+    try:
+        if pg.is_closed():
+            return True
+    except Exception:
+        return True
+    msg = str(exc).lower()
+    return "has been closed" in msg or "target closed" in msg or "crash" in msg
+
+
 with sync_playwright() as p:
     _watchdog = install_wall_clock_watchdog(
         WALL_TIMEOUT_S,
@@ -544,13 +556,17 @@ with sync_playwright() as p:
         if voice_tab.count() == 0:
             fail("Voice settings tab not found")
         else:
-            voice_tab.click()
-            page.get_by_label("Dictation engine").click()
-            page.get_by_role("option", name = "Local transcription").click()
-            page.get_by_label("Speech recognition model").click()
-            page.get_by_placeholder("Search model").fill("whisper")
-            results = page.get_by_test_id("stt-model-results")
+            # The dictation-engine dropdown touches a media-access path that can crash headless
+            # Chromium on macos-14 (CheckMediaAccessPermission). A resulting TargetClosedError is CI
+            # flakiness, not a product bug, so a crash here is a runtime warning + page recovery; a
+            # live-page failure (missing control, wheel that does not scroll) stays a hard fail.
             try:
+                voice_tab.click()
+                page.get_by_label("Dictation engine").click()
+                page.get_by_role("option", name = "Local transcription").click()
+                page.get_by_label("Speech recognition model").click()
+                page.get_by_placeholder("Search model").fill("whisper")
+                results = page.get_by_test_id("stt-model-results")
                 page.wait_for_function(
                     """() => {
                         const node = document.querySelector('[data-testid="stt-model-results"]');
@@ -569,7 +585,14 @@ with sync_playwright() as p:
                 )
                 info("OK Voice model picker mouse wheel changed scrollTop")
             except Exception as exc:
-                fail(f"Voice model picker did not wheel-scroll: {exc!r}")
+                if page_crashed(page, exc):
+                    runtime_warn(f"Voice model picker aborted (browser/page unstable): {exc!r}")
+                    page = recover_or_replace_page(
+                        page, ctx, default_timeout_ms = 60_000,
+                        info = lambda m: info(f"recovery: {m}"),
+                    )
+                else:
+                    fail(f"Voice model picker did not wheel-scroll: {exc!r}")
         shoot("10-settings-tabs-visited")
         page.keyboard.press("Escape")
         page.wait_for_timeout(300)

--- a/tests/studio/playwright_extra_ui.py
+++ b/tests/studio/playwright_extra_ui.py
@@ -588,7 +588,9 @@ with sync_playwright() as p:
                 if page_crashed(page, exc):
                     runtime_warn(f"Voice model picker aborted (browser/page unstable): {exc!r}")
                     page = recover_or_replace_page(
-                        page, ctx, default_timeout_ms = 60_000,
+                        page,
+                        ctx,
+                        default_timeout_ms = 60_000,
                         info = lambda m: info(f"recovery: {m}"),
                     )
                 else:

--- a/tests/studio/playwright_extra_ui.py
+++ b/tests/studio/playwright_extra_ui.py
@@ -595,9 +595,13 @@ with sync_playwright() as p:
                     )
                 else:
                     fail(f"Voice model picker did not wheel-scroll: {exc!r}")
-        shoot("10-settings-tabs-visited")
-        page.keyboard.press("Escape")
-        page.wait_for_timeout(300)
+        # When the crash closed the context/browser (not just the page), recover_or_replace_page
+        # cannot mint a replacement and hands back the closed page; skip the cosmetic teardown rather
+        # than re-raise TargetClosedError on it. is_closed() is a local check and never raises.
+        if not page.is_closed():
+            shoot("10-settings-tabs-visited")
+            page.keyboard.press("Escape")
+            page.wait_for_timeout(300)
         info(f"visited Settings tabs: {seen_tabs}")
         if not seen_tabs:
             soft_fail("no Settings tabs were visitable")
@@ -616,4 +620,7 @@ with sync_playwright() as p:
         sys.exit(1)
     info("PASS extra UI flow")
     _watchdog.cancel()
-    browser.close()
+    try:
+        browser.close()
+    except Exception:
+        pass  # a crashed browser may already be gone; never fail teardown after PASS


### PR DESCRIPTION
## Summary

The `Chat UI Tests` job (`Drive Compare/Recipes/Export/Unsloth/Settings with Playwright`, `tests/studio/playwright_extra_ui.py`) intermittently hard-fails on `macos-14`. Two of the three matrix shards pass and one dies, which points at a runtime flake rather than a product bug.

The traceback lands at the voice model-picker step:

```
File ".../tests/studio/playwright_extra_ui.py", line 548, in <module>
playwright._impl._errors.TargetClosedError: Locator.click: Target page, context or browser has been closed
```

The clicks in that step were unguarded, so the crash aborted the whole run.

## Root cause

The step opens the dictation-engine dropdown, which touches a media-access path. On the headless `macos-14` runner the log is full of:

```
ERROR:content/public/browser/web_contents_delegate.cc:300] WebContentsDelegate::CheckMediaAccessPermission: Not supported.
```

That path can kill the renderer between two adjacent clicks (`voice_tab.click()` succeeds, the next `get_by_label("Dictation engine").click()` hits a closed target). It is a headless-CI limitation, not something a real user with media support hits.

## Fix

Wrap the voice model-picker interaction:

- A browser/page crash (`TargetClosedError`, closed/crashed page) is downgraded to a `runtime_warn` and the page is recovered with `recover_or_replace_page` -- the same helper the auth and composer steps already use to survive renderer crashes on this runner.
- A genuine live-page failure (missing control, or a results list that will not wheel-scroll) still fails hard, so real regressions are unaffected.
- Genuine JS errors remain gated by the existing `pageerror` collection, so this does not hide product-side crashes.

The healthy-browser path is unchanged (the same clicks and assertions run in order), so there is no happy-path regression.

## Validation

- `python -m py_compile` and `ruff check` pass.
- Unit-checked the crash classifier: `TargetClosedError` / closed page / "crash" map to recover; timeouts and "0 elements" stay hard failures.
- The `studio-ui-smoke` workflow on this PR exercises the step on the real runners.