### PR TITLE
Recipes: Add "Train on this dataset" card with training configuration

### DIFF
--- a/studio/frontend/src/features/recipe-studio/blocks/definitions.ts
+++ b/studio/frontend/src/features/recipe-studio/blocks/definitions.ts
@@ -17,6 +17,7 @@ import {
   Parabola02Icon,
   PencilEdit02Icon,
   Plant01Icon,
+  Rocket01Icon,
   Shield02Icon,
   Tag01Icon,
   TagsIcon,
@@ -37,6 +38,7 @@ import {
   makeToolProfileConfig,
   makeSamplerConfig,
   makeSeedConfig,
+  makeTrainConfig,
   makeValidatorConfig,
 } from "../utils";
 
@@ -46,7 +48,8 @@ export type BlockKind =
   | "validator"
   | "expression"
   | "seed"
-  | "note";
+  | "note"
+  | "train";
 export type BlockType =
   | SamplerType
   | LlmType
@@ -60,6 +63,7 @@ export type BlockType =
   | "seed_local"
   | "seed_unstructured"
   | "seed_github"
+  | "train"
   | "model_provider"
   | "model_config"
   | "tool_config";
@@ -96,6 +100,7 @@ export type BlockDialogKey =
   | "model_provider"
   | "model_config"
   | "tool_config"
+  | "train"
   | "expression";
 
 export type BlockDefinition = {
@@ -144,6 +149,12 @@ export const BLOCK_GROUPS: BlockGroup[] = [
     title: "Notes",
     description: "Add markdown notes to document your flow.",
     icon: PencilEdit02Icon,
+  },
+  {
+    kind: "train",
+    title: "Train",
+    description: "Fine-tune a model on the dataset this recipe generates.",
+    icon: Rocket01Icon,
   },
 ];
 
@@ -376,6 +387,16 @@ const BLOCK_DEFINITIONS: BlockDefinition[] = [
     dialogKey: "markdown_note",
     createConfig: (id, existing) => makeMarkdownNoteConfig(id, existing),
   },
+  {
+    kind: "train",
+    type: "train",
+    title: "Train on this dataset",
+    description:
+      "Fine-tune a base model on the generated dataset and launch the run.",
+    icon: Rocket01Icon,
+    dialogKey: "train",
+    createConfig: (id, existing) => makeTrainConfig(id, existing),
+  },
 ];
 
 export function getBlocksForKind(kind: BlockKind): BlockDefinition[] {
@@ -436,6 +457,9 @@ export function getBlockDefinitionForConfig(
   }
   if (config.kind === "markdown_note") {
     return getBlockDefinition("note", "markdown_note");
+  }
+  if (config.kind === "train") {
+    return getBlockDefinition("train", "train");
   }
   return getBlockDefinition("expression", "expression");
 }

--- a/studio/frontend/src/features/recipe-studio/blocks/render-dialog.tsx
+++ b/studio/frontend/src/features/recipe-studio/blocks/render-dialog.tsx
@@ -20,6 +20,7 @@ import { UniformDialog } from "../dialogs/samplers/uniform-dialog";
 import { UuidDialog } from "../dialogs/samplers/uuid-dialog";
 import { MarkdownNoteDialog } from "../dialogs/markdown-note/markdown-note-dialog";
 import { ToolProfileDialog } from "../dialogs/tool-profile/tool-profile-dialog";
+import { TrainDialog } from "../dialogs/train/train-dialog";
 import { ValidatorDialog } from "../dialogs/validators/validator-dialog";
 
 export function renderBlockDialog(
@@ -129,6 +130,10 @@ export function renderBlockDialog(
     case "markdown_note":
       return config.kind === "markdown_note" ? (
         <MarkdownNoteDialog config={config} onUpdate={update} />
+      ) : null;
+    case "train":
+      return config.kind === "train" ? (
+        <TrainDialog config={config} onUpdate={update} />
       ) : null;
   }
 }

--- a/studio/frontend/src/features/recipe-studio/components/block-sheet.tsx
+++ b/studio/frontend/src/features/recipe-studio/components/block-sheet.tsx
@@ -53,6 +53,7 @@ type SheetView =
   | "validator"
   | "expression"
   | "note"
+  | "train"
   | "processor";
 type SheetKind =
   | "sampler"
@@ -60,7 +61,8 @@ type SheetKind =
   | "llm"
   | "validator"
   | "expression"
-  | "note";
+  | "note"
+  | "train";
 type RootSheetView = Exclude<SheetView, "root">;
 type RootGroup = {
   kind: RootSheetView;
@@ -86,6 +88,7 @@ type BlockSheetProps = {
     type: "validator_python" | "validator_sql" | "validator_oxc",
   ) => void;
   onAddMarkdownNote: () => void;
+  onAddTrain: () => void;
   onOpenProcessors: () => void;
   copied: boolean;
   onCopy: () => void;
@@ -117,6 +120,9 @@ function getSheetTitle(sheetView: SheetView): string {
   if (sheetView === "note") {
     return "Notes";
   }
+  if (sheetView === "train") {
+    return "Train";
+  }
   if (sheetView === "processor") {
     return "Processor blocks";
   }
@@ -131,6 +137,7 @@ const VIEW_KIND: Record<SheetView, SheetKind | null> = {
   validator: "validator",
   expression: "expression",
   note: "note",
+  train: "train",
   processor: null,
 };
 
@@ -146,6 +153,7 @@ const SEARCHABLE_KINDS: SheetKind[] = [
   "validator",
   "expression",
   "note",
+  "train",
 ];
 const PROCESSOR_TITLE = "Final dataset shape";
 const PROCESSOR_DESCRIPTION = "Rename, reorder, or reshape the final dataset.";
@@ -245,6 +253,7 @@ export function BlockSheet({
   onAddExpression,
   onAddValidator,
   onAddMarkdownNote,
+  onAddTrain,
   onOpenProcessors,
   copied,
   onCopy,
@@ -256,6 +265,7 @@ export function BlockSheet({
   const expressionBlocks = useMemo(() => getBlocksForKind("expression"), []);
   const noteBlocks = useMemo(() => getBlocksForKind("note"), []);
   const seedBlocks = useMemo(() => getBlocksForKind("seed"), []);
+  const trainBlocks = useMemo(() => getBlocksForKind("train"), []);
   const isControlled = typeof open === "boolean";
   const sheetOpen = isControlled ? (open as boolean) : uncontrolledOpen;
   const normalizedSearch = search.trim().toLowerCase();
@@ -386,6 +396,10 @@ export function BlockSheet({
       onAddExpression();
       return;
     }
+    if (kind === "train") {
+      onAddTrain();
+      return;
+    }
     onAddMarkdownNote();
   };
 
@@ -509,16 +523,24 @@ export function BlockSheet({
                     icon={item.icon}
                     title={item.title}
                     description={item.description}
-                    draggable={item.kind === "expression" || item.kind === "note"}
+                    draggable={
+                      item.kind === "expression" ||
+                      item.kind === "note" ||
+                      item.kind === "train"
+                    }
                     onDragStart={
                       item.kind === "expression" && expressionBlocks[0]
                         ? buildDragStart("expression", expressionBlocks[0].type)
                         : item.kind === "note" && noteBlocks[0]
                           ? buildDragStart("note", noteBlocks[0].type)
-                          : undefined
+                          : item.kind === "train" && trainBlocks[0]
+                            ? buildDragStart("train", trainBlocks[0].type)
+                            : undefined
                     }
                     trailing={
-                      item.kind === "expression" || item.kind === "note"
+                      item.kind === "expression" ||
+                      item.kind === "note" ||
+                      item.kind === "train"
                         ? "drag"
                         : "chevron"
                     }
@@ -536,6 +558,11 @@ export function BlockSheet({
                       if (item.kind === "note" && noteBlocks.length === 1) {
                         setSheetOpen(false);
                         onAddMarkdownNote();
+                        return;
+                      }
+                      if (item.kind === "train" && trainBlocks.length === 1) {
+                        setSheetOpen(false);
+                        onAddTrain();
                         return;
                       }
                       onViewChange(item.kind);

--- a/studio/frontend/src/features/recipe-studio/components/recipe-graph-node.tsx
+++ b/studio/frontend/src/features/recipe-studio/components/recipe-graph-node.tsx
@@ -58,6 +58,7 @@ import { InlineModel } from "./inline/inline-model";
 import { isInlineConfig } from "./inline/inline-policy";
 import { InlineSampler } from "./inline/inline-sampler";
 import { InlineSeed } from "./inline/inline-seed";
+import { RecipeTrainNode } from "./recipe-train-node";
 import {
   BaseNode,
   BaseNodeContent,
@@ -107,6 +108,9 @@ const NODE_META = {
   },
   seed: {
     tone: RECIPE_STUDIO_NODE_TONES.seed,
+  },
+  train: {
+    tone: RECIPE_STUDIO_NODE_TONES.train,
   },
   model_provider: {
     tone: RECIPE_STUDIO_NODE_TONES.model_provider,
@@ -420,6 +424,10 @@ function RecipeGraphNodeBase({
         </BaseNodeContent>
       </BaseNode>
     );
+  }
+
+  if (config?.kind === "train") {
+    return <RecipeTrainNode id={id} data={data} selected={selected} />;
   }
 
   const showDataHandles =

--- a/studio/frontend/src/features/recipe-studio/components/recipe-train-node.tsx
+++ b/studio/frontend/src/features/recipe-studio/components/recipe-train-node.tsx
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  useTrainingActions,
+  useTrainingRuntimeStore,
+} from "@/features/training";
+import { getTrainingMethodLabel } from "@/features/training/lib/training-methods";
+import { Tick02Icon } from "@/lib/tick-icon";
+import { cn } from "@/lib/utils";
+import {
+  Alert02Icon,
+  Database02Icon,
+  Rocket01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { NodeResizer, Position, useUpdateNodeInternals } from "@xyflow/react";
+import { type ReactElement, useEffect, useMemo } from "react";
+import { MAX_NODE_WIDTH, MIN_NODE_WIDTH } from "../constants";
+import { useRecipeExecutionsStore } from "../stores/recipe-executions";
+import { useRecipeStudioStore } from "../stores/recipe-studio";
+import type {
+  RecipeNode as RecipeGraphNodeType,
+  TrainingCardConfig,
+} from "../types";
+import { NODE_HANDLE_CLASS } from "../utils/handle-layout";
+import { HANDLE_IDS } from "../utils/handles";
+import {
+  type WiredArtifact,
+  applyTrainCardToTrainingStore,
+  pickWiredArtifact,
+  resolveTrainDataset,
+} from "../utils/train-config";
+import { RECIPE_STUDIO_NODE_TONES } from "../utils/ui-tones";
+import {
+  BaseNode,
+  BaseNodeContent,
+  BaseNodeHeader,
+  BaseNodeHeaderTitle,
+} from "./rf-ui/base-node";
+import { LabeledHandle } from "./rf-ui/labeled-handle";
+
+function formatLearningRate(value: number): string {
+  if (!Number.isFinite(value) || value === 0) {
+    return "0";
+  }
+  const exponent = value.toExponential(1);
+  // 2.0e-4 -> 2e-4
+  return exponent.replace(".0e", "e");
+}
+
+type StatChip = { label: string; value: string };
+
+function buildStatChips(config: TrainingCardConfig): StatChip[] {
+  return [
+    { label: "Method", value: getTrainingMethodLabel(config.trainingMethod) },
+    { label: "Epochs", value: String(config.epochs) },
+    { label: "Rank", value: String(config.loraRank) },
+    { label: "Batch", value: String(config.batchSize) },
+    { label: "LR", value: formatLearningRate(config.learningRate) },
+    { label: "Seq", value: String(config.contextLength) },
+  ];
+}
+
+function describeDataset(
+  config: TrainingCardConfig,
+  wired: WiredArtifact | null,
+): string {
+  if (config.datasetSource === "huggingface") {
+    return config.hfDataset.trim() || "Choose a Hugging Face dataset";
+  }
+  if (config.datasetSource === "upload") {
+    return config.uploadedFile.trim() || "Choose a dataset file";
+  }
+  if (wired) {
+    return `Auto-wired from ${wired.runLabel} run · ${wired.rows} rows`;
+  }
+  return "Waiting for a completed recipe run";
+}
+
+function describeDatasetSource(config: TrainingCardConfig): string {
+  if (config.datasetSource === "huggingface") {
+    return "Dataset source: Hugging Face (override)";
+  }
+  if (config.datasetSource === "upload") {
+    return "Dataset source: uploaded file (override)";
+  }
+  return "Dataset source: upstream recipe output";
+}
+
+function resolveRunLabel(isRunning: boolean, isStarting: boolean): string {
+  if (isRunning) {
+    return "Training in progress";
+  }
+  return isStarting ? "Starting..." : "Run training";
+}
+
+type RecipeTrainNodeProps = {
+  id: string;
+  data: RecipeGraphNodeType["data"];
+  selected: boolean;
+};
+
+export function RecipeTrainNode({
+  id,
+  data,
+  selected,
+}: RecipeTrainNodeProps): ReactElement | null {
+  const config = useRecipeStudioStore((state) => state.configs[id]);
+  const openConfig = useRecipeStudioStore((state) => state.openConfig);
+  const executions = useRecipeExecutionsStore((state) => state.executions);
+  const { startTrainingRun } = useTrainingActions();
+  const isStarting = useTrainingRuntimeStore((state) => state.isStarting);
+  const isTrainingRunning = useTrainingRuntimeStore(
+    (state) => state.isTrainingRunning,
+  );
+  const startError = useTrainingRuntimeStore((state) => state.startError);
+  const updateNodeInternals = useUpdateNodeInternals();
+  const executionLocked = Boolean(data.executionLocked);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-measure handles when the graph orientation flips
+  useEffect(() => {
+    updateNodeInternals(id);
+  }, [id, data.layoutDirection, updateNodeInternals]);
+
+  const wired = useMemo(() => pickWiredArtifact(executions), [executions]);
+
+  if (config?.kind !== "train") {
+    return null;
+  }
+
+  const dataset = resolveTrainDataset(config, wired);
+  const hasDataset = Boolean(dataset.hfDataset || dataset.uploadedFile);
+  const hasModel = Boolean(config.baseModel.trim());
+  const busy = isStarting || isTrainingRunning;
+  const canRun = !(executionLocked || busy) && hasDataset && hasModel;
+
+  const stats = buildStatChips(config);
+  const datasetLabel = describeDataset(config, wired);
+  const datasetReady =
+    config.datasetSource === "recipe" ? Boolean(wired) : hasDataset;
+  const runLabel = resolveRunLabel(isTrainingRunning, isStarting);
+
+  const onRun = () => {
+    if (!canRun) {
+      return;
+    }
+    applyTrainCardToTrainingStore(config, wired);
+    startTrainingRun().catch(() => undefined);
+  };
+
+  return (
+    <BaseNode
+      className={cn(
+        "corner-squircle relative w-full min-w-0 overflow-visible rounded-4xl border-border/60 shadow-sm",
+        isTrainingRunning && "border-ring-strong shadow-md",
+      )}
+    >
+      <NodeResizer
+        isVisible={selected}
+        minWidth={MIN_NODE_WIDTH}
+        minHeight={160}
+        maxWidth={MAX_NODE_WIDTH}
+        maxHeight={640}
+        color="var(--primary)"
+        lineClassName="!border-transparent !shadow-none"
+        lineStyle={{ opacity: 0 }}
+        handleClassName="!h-3 !w-3 !border-transparent !bg-transparent"
+        handleStyle={{ opacity: 0 }}
+      />
+      <BaseNodeHeader className="border-b border-border/50 px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <div
+            className={cn(
+              "corner-squircle flex size-7 items-center justify-center rounded-md border",
+              RECIPE_STUDIO_NODE_TONES.train,
+            )}
+          >
+            <HugeiconsIcon icon={Rocket01Icon} className="size-3.5" />
+          </div>
+          <div className="min-w-0">
+            <BaseNodeHeaderTitle className="truncate text-sm">
+              {config.name}
+            </BaseNodeHeaderTitle>
+            <p className="truncate text-ui-11 text-muted-foreground">
+              {data.subtype} · {config.baseModel.trim() || "No base model yet"}
+            </p>
+          </div>
+        </div>
+        <Button
+          type="button"
+          size="xs"
+          variant="ghost"
+          className="nodrag"
+          disabled={executionLocked}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            openConfig(id);
+          }}
+        >
+          Configure
+        </Button>
+      </BaseNodeHeader>
+
+      <BaseNodeContent
+        className={cn(
+          "gap-3 px-3 py-3",
+          executionLocked && "pointer-events-none opacity-85",
+        )}
+      >
+        <div className="flex flex-wrap gap-1.5">
+          {stats.map((stat) => (
+            <Badge
+              key={stat.label}
+              variant="secondary"
+              className="corner-squircle font-mono text-ui-11"
+            >
+              <span className="text-muted-foreground">{stat.label}</span>
+              <span className="ml-1 text-foreground">{stat.value}</span>
+            </Badge>
+          ))}
+        </div>
+
+        <div
+          className={cn(
+            "corner-squircle flex items-center gap-2 rounded-2xl border px-3 py-2",
+            datasetReady
+              ? "border-emerald-500/40 bg-emerald-500/5"
+              : "border-amber-400/50 bg-amber-500/5",
+          )}
+        >
+          <HugeiconsIcon
+            icon={datasetReady ? Tick02Icon : Database02Icon}
+            className={cn(
+              "size-4 shrink-0",
+              datasetReady
+                ? "text-emerald-600 dark:text-emerald-400"
+                : "text-amber-600 dark:text-amber-400",
+            )}
+          />
+          <div className="min-w-0">
+            <p className="truncate text-xs font-medium text-foreground">
+              {datasetLabel}
+            </p>
+            <p className="truncate text-ui-11 text-muted-foreground">
+              {describeDatasetSource(config)}
+            </p>
+          </div>
+        </div>
+
+        {startError && (
+          <div className="corner-squircle flex items-start gap-2 rounded-2xl border border-rose-500/40 bg-rose-500/5 px-3 py-2">
+            <HugeiconsIcon
+              icon={Alert02Icon}
+              className="size-4 shrink-0 text-rose-600 dark:text-rose-400"
+            />
+            <p className="min-w-0 break-words text-ui-11 text-rose-700 dark:text-rose-300">
+              {startError}
+            </p>
+          </div>
+        )}
+
+        <Button
+          type="button"
+          size="sm"
+          className="nodrag w-full"
+          disabled={!canRun}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            onRun();
+          }}
+        >
+          {busy ? (
+            <Spinner className="size-4" />
+          ) : (
+            <HugeiconsIcon icon={Rocket01Icon} className="size-4" />
+          )}
+          {runLabel}
+        </Button>
+        {!hasModel && (
+          <p className="text-ui-11 text-muted-foreground">
+            Pick a base model in settings to enable training.
+          </p>
+        )}
+      </BaseNodeContent>
+
+      <LabeledHandle
+        id={HANDLE_IDS.dataIn}
+        title="Data input"
+        type="target"
+        position={Position.Left}
+        className="absolute inset-0 pointer-events-none"
+        labelClassName="sr-only"
+        handleClassName={NODE_HANDLE_CLASS}
+      />
+      <LabeledHandle
+        id={HANDLE_IDS.dataInTop}
+        title="Data input"
+        type="target"
+        position={Position.Top}
+        className="absolute inset-0 pointer-events-none"
+        labelClassName="sr-only"
+        handleClassName={NODE_HANDLE_CLASS}
+      />
+      <LabeledHandle
+        id={HANDLE_IDS.dataInRight}
+        title="Data input"
+        type="target"
+        position={Position.Right}
+        className="absolute inset-0 pointer-events-none opacity-0"
+        labelClassName="sr-only"
+        handleClassName={NODE_HANDLE_CLASS}
+      />
+      <LabeledHandle
+        id={HANDLE_IDS.dataInBottom}
+        title="Data input"
+        type="target"
+        position={Position.Bottom}
+        className="absolute inset-0 pointer-events-none"
+        labelClassName="sr-only"
+        handleClassName={NODE_HANDLE_CLASS}
+      />
+    </BaseNode>
+  );
+}

--- a/studio/frontend/src/features/recipe-studio/dialogs/train/train-dialog.tsx
+++ b/studio/frontend/src/features/recipe-studio/dialogs/train/train-dialog.tsx
@@ -1,0 +1,658 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import {
+  LR_SCHEDULER_OPTIONS,
+  OPTIMIZER_OPTIONS,
+  PRIORITY_TRAINING_MODELS,
+} from "@/config/training";
+import type {
+  DatasetFormat,
+  GradientCheckpointing,
+  TrainingMethod,
+} from "@/types/training";
+import {
+  type ChangeEvent,
+  type ReactElement,
+  useEffect,
+  useState,
+} from "react";
+import type {
+  TrainingCardConfig,
+  TrainingCardDatasetSource,
+  TrainingCardLoraVariant,
+} from "../../types";
+import { CollapsibleSectionTriggerButton } from "../shared/collapsible-section-trigger";
+import { FieldLabel } from "../shared/field-label";
+import { NameField } from "../shared/name-field";
+
+type TrainDialogProps = {
+  config: TrainingCardConfig;
+  onUpdate: (patch: Partial<TrainingCardConfig>) => void;
+};
+
+const METHOD_OPTIONS: ReadonlyArray<{ value: TrainingMethod; label: string }> =
+  [
+    { value: "qlora", label: "QLoRA (4-bit, lowest memory)" },
+    { value: "lora", label: "LoRA (16-bit adapters)" },
+    { value: "full", label: "Full fine-tuning" },
+    { value: "cpt", label: "Continued pretraining" },
+  ];
+
+const LORA_VARIANT_OPTIONS: ReadonlyArray<{
+  value: TrainingCardLoraVariant;
+  label: string;
+}> = [
+  { value: "lora", label: "Standard" },
+  { value: "rslora", label: "Rank-stabilized (rsLoRA)" },
+  { value: "loftq", label: "LoftQ" },
+];
+
+const DATASET_FORMAT_OPTIONS: ReadonlyArray<{
+  value: DatasetFormat;
+  label: string;
+}> = [
+  { value: "auto", label: "Auto-detect" },
+  { value: "alpaca", label: "Alpaca" },
+  { value: "chatml", label: "ChatML" },
+  { value: "sharegpt", label: "ShareGPT" },
+  { value: "raw", label: "Raw text" },
+];
+
+const GRADIENT_CHECKPOINTING_OPTIONS: ReadonlyArray<{
+  value: GradientCheckpointing;
+  label: string;
+}> = [
+  { value: "unsloth", label: "Unsloth (recommended)" },
+  { value: "true", label: "Standard" },
+  { value: "none", label: "Off" },
+];
+
+/** Numeric input that keeps a text draft while focused, committing on blur. */
+function NumberField({
+  id,
+  value,
+  onCommit,
+  disabled,
+  placeholder,
+}: {
+  id: string;
+  value: number;
+  onCommit: (value: number) => void;
+  disabled?: boolean;
+  placeholder?: string;
+}): ReactElement {
+  const [draft, setDraft] = useState(String(value));
+
+  useEffect(() => {
+    setDraft(String(value));
+  }, [value]);
+
+  const commit = () => {
+    const parsed = Number.parseFloat(draft);
+    if (Number.isFinite(parsed) && parsed !== value) {
+      onCommit(parsed);
+    } else {
+      setDraft(String(value));
+    }
+  };
+
+  return (
+    <Input
+      id={id}
+      inputMode="decimal"
+      className="nodrag"
+      value={draft}
+      placeholder={placeholder}
+      disabled={disabled}
+      onChange={(event: ChangeEvent<HTMLInputElement>) =>
+        setDraft(event.target.value)
+      }
+      onBlur={commit}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") {
+          event.currentTarget.blur();
+        }
+      }}
+    />
+  );
+}
+
+export function TrainDialog({
+  config,
+  onUpdate,
+}: TrainDialogProps): ReactElement {
+  const advancedOpen = config.advancedOpen ?? false;
+  const idFor = (suffix: string) => `${config.id}-${suffix}`;
+
+  return (
+    <div className="space-y-4">
+      <NameField
+        label="Train step name"
+        value={config.name}
+        onChange={(value) => onUpdate({ name: value })}
+      />
+
+      <div className="corner-squircle rounded-2xl border border-border/60 bg-muted/10 px-4 py-3">
+        <p className="text-sm font-semibold text-foreground">
+          Fine-tune a model on this recipe's dataset
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Connect the recipe output into this card. When the graph runs, the
+          generated dataset is trained on with the settings below.
+        </p>
+      </div>
+
+      {/* Model + method */}
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="grid gap-1.5">
+          <FieldLabel
+            label="Base model"
+            htmlFor={idFor("model")}
+            hint="Hugging Face model id to fine-tune, e.g. unsloth/Llama-3.2-3B-Instruct."
+          />
+          <Input
+            id={idFor("model")}
+            className="nodrag"
+            list={idFor("model-suggestions")}
+            placeholder="unsloth/Llama-3.2-3B-Instruct"
+            value={config.baseModel}
+            onChange={(event) => onUpdate({ baseModel: event.target.value })}
+          />
+          <datalist id={idFor("model-suggestions")}>
+            {PRIORITY_TRAINING_MODELS.map((model) => (
+              <option key={model} value={model} />
+            ))}
+          </datalist>
+        </div>
+        <div className="grid gap-1.5">
+          <FieldLabel
+            label="Training method"
+            htmlFor={idFor("method")}
+            hint="QLoRA is the most memory efficient. Full fine-tuning updates all weights."
+          />
+          <Select
+            value={config.trainingMethod}
+            onValueChange={(value) =>
+              onUpdate({ trainingMethod: value as TrainingMethod })
+            }
+          >
+            <SelectTrigger id={idFor("method")} className="nodrag">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {METHOD_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Dataset source */}
+      <div className="grid gap-1.5">
+        <FieldLabel
+          label="Dataset"
+          htmlFor={idFor("dataset-source")}
+          hint="Auto-wire the generated dataset from the connected recipe, or override it."
+        />
+        <Select
+          value={config.datasetSource}
+          onValueChange={(value) =>
+            onUpdate({ datasetSource: value as TrainingCardDatasetSource })
+          }
+        >
+          <SelectTrigger id={idFor("dataset-source")} className="nodrag">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="recipe">Auto-wire from recipe output</SelectItem>
+            <SelectItem value="huggingface">
+              Hugging Face dataset (override)
+            </SelectItem>
+            <SelectItem value="upload">Local file path (override)</SelectItem>
+          </SelectContent>
+        </Select>
+        {config.datasetSource === "recipe" && (
+          <p className="text-xs text-muted-foreground">
+            Uses the artifact from the connected recipe's most recent completed
+            run.
+          </p>
+        )}
+      </div>
+
+      {config.datasetSource === "huggingface" && (
+        <div className="grid gap-3 sm:grid-cols-3">
+          <div className="grid gap-1.5 sm:col-span-3">
+            <FieldLabel label="Dataset id" htmlFor={idFor("hf-dataset")} />
+            <Input
+              id={idFor("hf-dataset")}
+              className="nodrag"
+              placeholder="unsloth/OpenMathReasoning-mini"
+              value={config.hfDataset}
+              onChange={(event) => onUpdate({ hfDataset: event.target.value })}
+            />
+          </div>
+          <div className="grid gap-1.5">
+            <FieldLabel label="Subset" htmlFor={idFor("hf-subset")} />
+            <Input
+              id={idFor("hf-subset")}
+              className="nodrag"
+              placeholder="default"
+              value={config.hfSubset}
+              onChange={(event) => onUpdate({ hfSubset: event.target.value })}
+            />
+          </div>
+          <div className="grid gap-1.5">
+            <FieldLabel label="Split" htmlFor={idFor("hf-split")} />
+            <Input
+              id={idFor("hf-split")}
+              className="nodrag"
+              placeholder="train"
+              value={config.hfSplit}
+              onChange={(event) => onUpdate({ hfSplit: event.target.value })}
+            />
+          </div>
+        </div>
+      )}
+
+      {config.datasetSource === "upload" && (
+        <div className="grid gap-1.5">
+          <FieldLabel
+            label="Dataset file path"
+            htmlFor={idFor("upload")}
+            hint="Absolute path to a local JSON, JSONL, or CSV dataset file."
+          />
+          <Input
+            id={idFor("upload")}
+            className="nodrag"
+            placeholder="/path/to/dataset.jsonl"
+            value={config.uploadedFile}
+            onChange={(event) => onUpdate({ uploadedFile: event.target.value })}
+          />
+        </div>
+      )}
+
+      <div className="grid gap-1.5">
+        <FieldLabel
+          label="Dataset format"
+          htmlFor={idFor("dataset-format")}
+          hint="How rows map to the chat template. Auto-detect works for most datasets."
+        />
+        <Select
+          value={config.datasetFormat}
+          onValueChange={(value) =>
+            onUpdate({ datasetFormat: value as DatasetFormat })
+          }
+        >
+          <SelectTrigger id={idFor("dataset-format")} className="nodrag">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {DATASET_FORMAT_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Core hyperparameters */}
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="grid gap-1.5">
+          <FieldLabel label="Epochs" htmlFor={idFor("epochs")} />
+          <NumberField
+            id={idFor("epochs")}
+            value={config.epochs}
+            onCommit={(value) => onUpdate({ epochs: value })}
+          />
+        </div>
+        <div className="grid gap-1.5">
+          <FieldLabel
+            label="Max sequence length"
+            htmlFor={idFor("seq")}
+            hint="Longest input the model trains on, in tokens."
+          />
+          <NumberField
+            id={idFor("seq")}
+            value={config.contextLength}
+            onCommit={(value) => onUpdate({ contextLength: value })}
+          />
+        </div>
+        <div className="grid gap-1.5">
+          <FieldLabel
+            label="LoRA rank"
+            htmlFor={idFor("rank")}
+            hint="Higher rank = more trainable parameters."
+          />
+          <NumberField
+            id={idFor("rank")}
+            value={config.loraRank}
+            onCommit={(value) => onUpdate({ loraRank: value })}
+          />
+        </div>
+        <div className="grid gap-1.5">
+          <FieldLabel label="Batch size" htmlFor={idFor("batch")} />
+          <NumberField
+            id={idFor("batch")}
+            value={config.batchSize}
+            onCommit={(value) => onUpdate({ batchSize: value })}
+          />
+        </div>
+        <div className="grid gap-1.5">
+          <FieldLabel label="Learning rate" htmlFor={idFor("lr")} />
+          <NumberField
+            id={idFor("lr")}
+            value={config.learningRate}
+            onCommit={(value) => onUpdate({ learningRate: value })}
+          />
+        </div>
+        <div className="grid gap-1.5">
+          <FieldLabel
+            label="Output adapter name"
+            htmlFor={idFor("output")}
+            hint="Names the run and the saved adapter directory."
+          />
+          <Input
+            id={idFor("output")}
+            className="nodrag"
+            placeholder="my-finetune"
+            value={config.outputName}
+            onChange={(event) => onUpdate({ outputName: event.target.value })}
+          />
+        </div>
+      </div>
+
+      {/* Advanced */}
+      <Collapsible
+        open={advancedOpen}
+        onOpenChange={(open) => onUpdate({ advancedOpen: open })}
+      >
+        <CollapsibleTrigger asChild={true}>
+          <CollapsibleSectionTriggerButton
+            label="Advanced training settings"
+            open={advancedOpen}
+          />
+        </CollapsibleTrigger>
+        <CollapsibleContent className="mt-3 space-y-4">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="grid gap-1.5">
+              <FieldLabel label="LoRA alpha" htmlFor={idFor("alpha")} />
+              <NumberField
+                id={idFor("alpha")}
+                value={config.loraAlpha}
+                onCommit={(value) => onUpdate({ loraAlpha: value })}
+              />
+            </div>
+            <div className="grid gap-1.5">
+              <FieldLabel label="LoRA dropout" htmlFor={idFor("dropout")} />
+              <NumberField
+                id={idFor("dropout")}
+                value={config.loraDropout}
+                onCommit={(value) => onUpdate({ loraDropout: value })}
+              />
+            </div>
+            <div className="grid gap-1.5">
+              <FieldLabel label="LoRA variant" htmlFor={idFor("variant")} />
+              <Select
+                value={config.loraVariant}
+                onValueChange={(value) =>
+                  onUpdate({ loraVariant: value as TrainingCardLoraVariant })
+                }
+              >
+                <SelectTrigger id={idFor("variant")} className="nodrag">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {LORA_VARIANT_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid gap-1.5">
+              <FieldLabel
+                label="Gradient accumulation"
+                htmlFor={idFor("grad-accum")}
+              />
+              <NumberField
+                id={idFor("grad-accum")}
+                value={config.gradientAccumulation}
+                onCommit={(value) => onUpdate({ gradientAccumulation: value })}
+              />
+            </div>
+            <div className="grid gap-1.5">
+              <FieldLabel label="Warmup steps" htmlFor={idFor("warmup")} />
+              <NumberField
+                id={idFor("warmup")}
+                value={config.warmupSteps}
+                onCommit={(value) => onUpdate({ warmupSteps: value })}
+              />
+            </div>
+            <div className="grid gap-1.5">
+              <FieldLabel
+                label="Max steps"
+                htmlFor={idFor("max-steps")}
+                hint="Overrides epochs when greater than zero."
+              />
+              <NumberField
+                id={idFor("max-steps")}
+                value={config.maxSteps}
+                onCommit={(value) => onUpdate({ maxSteps: value })}
+              />
+            </div>
+            <div className="grid gap-1.5">
+              <FieldLabel
+                label="Weight decay"
+                htmlFor={idFor("weight-decay")}
+              />
+              <NumberField
+                id={idFor("weight-decay")}
+                value={config.weightDecay}
+                onCommit={(value) => onUpdate({ weightDecay: value })}
+              />
+            </div>
+            <div className="grid gap-1.5">
+              <FieldLabel label="Random seed" htmlFor={idFor("seed")} />
+              <NumberField
+                id={idFor("seed")}
+                value={config.randomSeed}
+                onCommit={(value) => onUpdate({ randomSeed: value })}
+              />
+            </div>
+            <div className="grid gap-1.5">
+              <FieldLabel label="Optimizer" htmlFor={idFor("optimizer")} />
+              <Select
+                value={config.optimizerType}
+                onValueChange={(value) => onUpdate({ optimizerType: value })}
+              >
+                <SelectTrigger id={idFor("optimizer")} className="nodrag">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {OPTIMIZER_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid gap-1.5">
+              <FieldLabel label="LR scheduler" htmlFor={idFor("scheduler")} />
+              <Select
+                value={config.lrSchedulerType}
+                onValueChange={(value) => onUpdate({ lrSchedulerType: value })}
+              >
+                <SelectTrigger id={idFor("scheduler")} className="nodrag">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {LR_SCHEDULER_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid gap-1.5">
+              <FieldLabel
+                label="Gradient checkpointing"
+                htmlFor={idFor("grad-ckpt")}
+              />
+              <Select
+                value={config.gradientCheckpointing}
+                onValueChange={(value) =>
+                  onUpdate({
+                    gradientCheckpointing: value as GradientCheckpointing,
+                  })
+                }
+              >
+                <SelectTrigger id={idFor("grad-ckpt")} className="nodrag">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {GRADIENT_CHECKPOINTING_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="grid gap-3">
+            <label
+              htmlFor={idFor("packing")}
+              className="flex items-center justify-between gap-3"
+            >
+              <span className="text-xs font-semibold uppercase text-muted-foreground">
+                Sequence packing
+              </span>
+              <Switch
+                id={idFor("packing")}
+                checked={config.packing}
+                onCheckedChange={(value) => onUpdate({ packing: value })}
+              />
+            </label>
+            <label
+              htmlFor={idFor("train-completions")}
+              className="flex items-center justify-between gap-3"
+            >
+              <span className="text-xs font-semibold uppercase text-muted-foreground">
+                Train on completions only
+              </span>
+              <Switch
+                id={idFor("train-completions")}
+                checked={config.trainOnCompletions}
+                onCheckedChange={(value) =>
+                  onUpdate({ trainOnCompletions: value })
+                }
+              />
+            </label>
+          </div>
+
+          <div className="grid gap-1.5">
+            <FieldLabel
+              label="Hugging Face token"
+              htmlFor={idFor("hf-token")}
+              hint="Needed for gated base models or private datasets."
+            />
+            <Input
+              id={idFor("hf-token")}
+              type="password"
+              className="nodrag"
+              placeholder="hf_..."
+              value={config.hfToken}
+              onChange={(event) => onUpdate({ hfToken: event.target.value })}
+            />
+          </div>
+
+          <div className="grid gap-3">
+            <label
+              htmlFor={idFor("wandb")}
+              className="flex items-center justify-between gap-3"
+            >
+              <span className="text-xs font-semibold uppercase text-muted-foreground">
+                Log to Weights & Biases
+              </span>
+              <Switch
+                id={idFor("wandb")}
+                checked={config.enableWandb}
+                onCheckedChange={(value) => onUpdate({ enableWandb: value })}
+              />
+            </label>
+            {config.enableWandb && (
+              <div className="grid gap-1.5">
+                <FieldLabel
+                  label="W&B project"
+                  htmlFor={idFor("wandb-project")}
+                />
+                <Input
+                  id={idFor("wandb-project")}
+                  className="nodrag"
+                  value={config.wandbProject}
+                  onChange={(event) =>
+                    onUpdate({ wandbProject: event.target.value })
+                  }
+                />
+              </div>
+            )}
+            <label
+              htmlFor={idFor("tensorboard")}
+              className="flex items-center justify-between gap-3"
+            >
+              <span className="text-xs font-semibold uppercase text-muted-foreground">
+                Log to TensorBoard
+              </span>
+              <Switch
+                id={idFor("tensorboard")}
+                checked={config.enableTensorboard}
+                onCheckedChange={(value) =>
+                  onUpdate({ enableTensorboard: value })
+                }
+              />
+            </label>
+            {config.enableTensorboard && (
+              <div className="grid gap-1.5">
+                <FieldLabel
+                  label="TensorBoard directory"
+                  htmlFor={idFor("tensorboard-dir")}
+                />
+                <Input
+                  id={idFor("tensorboard-dir")}
+                  className="nodrag"
+                  value={config.tensorboardDir}
+                  onChange={(event) =>
+                    onUpdate({ tensorboardDir: event.target.value })
+                  }
+                />
+              </div>
+            )}
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  );
+}

--- a/studio/frontend/src/features/recipe-studio/hooks/use-recipe-editor-graph.ts
+++ b/studio/frontend/src/features/recipe-studio/hooks/use-recipe-editor-graph.ts
@@ -34,6 +34,7 @@ const SUPPORTED_DRAG_KINDS: RecipeBlockDragPayload["kind"][] = [
   "validator",
   "expression",
   "note",
+  "train",
 ];
 
 function parseRecipeBlockDragPayload(raw: string): RecipeBlockDragPayload | null {
@@ -78,6 +79,7 @@ type UseRecipeEditorGraphArgs = {
     openDialog?: boolean,
   ) => void;
   addMarkdownNoteNode: (position?: XYPosition, openDialog?: boolean) => void;
+  addTrainNode: (position?: XYPosition, openDialog?: boolean) => void;
 };
 
 type UseRecipeEditorGraphResult = {
@@ -100,6 +102,7 @@ type UseRecipeEditorGraphResult = {
     type: "validator_python" | "validator_sql" | "validator_oxc",
   ) => void;
   handleAddMarkdownNoteFromSheet: () => void;
+  handleAddTrainFromSheet: () => void;
 };
 
 export function useRecipeEditorGraph({
@@ -122,6 +125,7 @@ export function useRecipeEditorGraph({
   addExpressionNode,
   addValidatorNode,
   addMarkdownNoteNode,
+  addTrainNode,
 }: UseRecipeEditorGraphArgs): UseRecipeEditorGraphResult {
   const baseNodeIds = useMemo(() => new Set(nodes.map((node) => node.id)), [nodes]);
   const baseEdgeIds = useMemo(() => new Set(edges.map((edge) => edge.id)), [edges]);
@@ -142,7 +146,7 @@ export function useRecipeEditorGraph({
         return;
       }
       const nodeConfig = configs[node.id];
-      if (nodeConfig?.kind === "markdown_note") {
+      if (nodeConfig?.kind === "markdown_note" || nodeConfig?.kind === "train") {
         openConfig(node.id);
       }
     },
@@ -229,6 +233,10 @@ export function useRecipeEditorGraph({
         addMarkdownNoteNode(position, false);
         return;
       }
+      if (payload.kind === "train") {
+        addTrainNode(position, false);
+        return;
+      }
       if (payload.type === "model_provider") {
         addModelProviderNode(position, false);
         return;
@@ -252,6 +260,7 @@ export function useRecipeEditorGraph({
       addToolProfileNode,
       addSamplerNode,
       addSeedNode,
+      addTrainNode,
       addValidatorNode,
       reactFlowInstance,
     ],
@@ -316,6 +325,10 @@ export function useRecipeEditorGraph({
     addMarkdownNoteNode(getViewportCenterPosition());
   }, [addMarkdownNoteNode, getViewportCenterPosition]);
 
+  const handleAddTrainFromSheet = useCallback(() => {
+    addTrainNode(getViewportCenterPosition());
+  }, [addTrainNode, getViewportCenterPosition]);
+
   return {
     handleNodeClick,
     handleNodeDoubleClick,
@@ -332,5 +345,6 @@ export function useRecipeEditorGraph({
     handleAddExpressionFromSheet,
     handleAddValidatorFromSheet,
     handleAddMarkdownNoteFromSheet,
+    handleAddTrainFromSheet,
   };
 }

--- a/studio/frontend/src/features/recipe-studio/recipe-studio-page.tsx
+++ b/studio/frontend/src/features/recipe-studio/recipe-studio-page.tsx
@@ -141,6 +141,7 @@ export function RecipeStudioPage({
     addExpressionNode,
     addValidatorNode,
     addMarkdownNoteNode,
+    addTrainNode,
     selectConfig,
     openConfig,
     updateConfig,
@@ -181,6 +182,7 @@ export function RecipeStudioPage({
       addExpressionNode: state.addExpressionNode,
       addValidatorNode: state.addValidatorNode,
       addMarkdownNoteNode: state.addMarkdownNoteNode,
+      addTrainNode: state.addTrainNode,
       selectConfig: state.selectConfig,
       openConfig: state.openConfig,
       updateConfig: state.updateConfig,
@@ -266,6 +268,7 @@ export function RecipeStudioPage({
     handleAddExpressionFromSheet,
     handleAddValidatorFromSheet,
     handleAddMarkdownNoteFromSheet,
+    handleAddTrainFromSheet,
   } = useRecipeEditorGraph({
     nodes,
     edges,
@@ -286,6 +289,7 @@ export function RecipeStudioPage({
     addExpressionNode,
     addValidatorNode,
     addMarkdownNoteNode,
+    addTrainNode,
   });
 
   const configList = useMemo(() => Object.values(configs), [configs]);
@@ -722,6 +726,7 @@ export function RecipeStudioPage({
             onAddExpression={handleAddExpressionFromSheet}
             onAddValidator={handleAddValidatorFromSheet}
             onAddMarkdownNote={handleAddMarkdownNoteFromSheet}
+            onAddTrain={handleAddTrainFromSheet}
             onOpenProcessors={openProcessorsFromSheet}
             copied={copied}
             onCopy={copyRecipe}

--- a/studio/frontend/src/features/recipe-studio/stores/recipe-studio.ts
+++ b/studio/frontend/src/features/recipe-studio/stores/recipe-studio.ts
@@ -59,6 +59,7 @@ type SheetView =
   | "validator"
   | "expression"
   | "note"
+  | "train"
   | "processor";
 
 type RecipeStudioState = {
@@ -119,6 +120,7 @@ type RecipeStudioState = {
     openDialog?: boolean,
   ) => void;
   addMarkdownNoteNode: (position?: XYPosition, openDialog?: boolean) => void;
+  addTrainNode: (position?: XYPosition, openDialog?: boolean) => void;
   updateConfig: (id: string, patch: Partial<NodeConfig>) => void;
   loadRecipe: (snapshot: RecipeSnapshot) => void;
   setAuxNodePosition: (id: string, position: XYPosition) => void;
@@ -722,6 +724,13 @@ export const useRecipeStudioStore = create<RecipeStudioState>((set, get) => ({
         position,
         openDialog,
       );
+    }),
+  addTrainNode: (position, openDialog = true) =>
+    set((state) => {
+      if (state.executionLocked) {
+        return state;
+      }
+      return buildAddedNodeState(state, "train", "train", position, openDialog);
     }),
   loadRecipe: (snapshot) =>
     set((state) => ({

--- a/studio/frontend/src/features/recipe-studio/types/index.ts
+++ b/studio/frontend/src/features/recipe-studio/types/index.ts
@@ -2,6 +2,11 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import type { Node } from "@xyflow/react";
+import type {
+  DatasetFormat,
+  GradientCheckpointing,
+  TrainingMethod,
+} from "@/types/training";
 
 export type SamplerType =
   | "category"
@@ -58,6 +63,7 @@ export type RecipeNodeData = {
     | "expression"
     | "seed"
     | "note"
+    | "train"
     | "model_provider"
     | "model_config"
     | "tool_config";
@@ -71,6 +77,7 @@ export type RecipeNodeData = {
     | "expression"
     | "seed"
     | "markdown_note"
+    | "train"
     | "model_provider"
     | "model_config"
     | "tool_config";
@@ -389,6 +396,64 @@ export type SchemaTransformProcessorConfig = {
 
 export type RecipeProcessorConfig = SchemaTransformProcessorConfig;
 
+/** Where the Train card sources its dataset from. */
+export type TrainingCardDatasetSource = "recipe" | "huggingface" | "upload";
+
+export type TrainingCardLoraVariant = "lora" | "rslora" | "loftq";
+
+/**
+ * Full training configuration held by a Train node. UI-only: it is not a
+ * dataset column, so it is excluded from the recipe payload and persisted in
+ * `ui.nodes` (mirroring markdown_note). On Run it is mapped into the global
+ * training-config store and launched via startTrainingRun.
+ */
+export type TrainingCardConfig = {
+  id: string;
+  kind: "train";
+  name: string;
+  // ui-only advanced-section accordion state
+  advancedOpen?: boolean;
+  // model + method
+  baseModel: string;
+  trainingMethod: TrainingMethod;
+  // dataset wiring: "recipe" auto-wires from the upstream completed run
+  datasetSource: TrainingCardDatasetSource;
+  hfDataset: string;
+  hfSubset: string;
+  hfSplit: string;
+  datasetFormat: DatasetFormat;
+  uploadedFile: string;
+  // core hyperparameters
+  epochs: number;
+  loraRank: number;
+  loraAlpha: number;
+  loraDropout: number;
+  loraVariant: TrainingCardLoraVariant;
+  batchSize: number;
+  learningRate: number;
+  // max sequence length (maps to training-config contextLength)
+  contextLength: number;
+  // output adapter / project name (maps to training-config projectName)
+  outputName: string;
+  // advanced hyperparameters
+  gradientAccumulation: number;
+  warmupSteps: number;
+  maxSteps: number;
+  weightDecay: number;
+  optimizerType: string;
+  lrSchedulerType: string;
+  packing: boolean;
+  trainOnCompletions: boolean;
+  gradientCheckpointing: GradientCheckpointing;
+  randomSeed: number;
+  targetModules: string[];
+  enableWandb: boolean;
+  wandbProject: string;
+  enableTensorboard: boolean;
+  tensorboardDir: string;
+  hfToken: string;
+};
+
 export type NodeConfig =
   | SamplerConfig
   | LlmConfig
@@ -396,6 +461,7 @@ export type NodeConfig =
   | ExpressionConfig
   | MarkdownNoteConfig
   | SeedConfig
+  | TrainingCardConfig
   | ModelProviderConfig
   | ModelConfig
   | ToolProfileConfig;

--- a/studio/frontend/src/features/recipe-studio/utils/config-factories.ts
+++ b/studio/frontend/src/features/recipe-studio/utils/config-factories.ts
@@ -14,10 +14,12 @@ import type {
   SamplerConfig,
   SamplerType,
   ToolProfileConfig,
+  TrainingCardConfig,
   ValidatorCodeLang,
   ValidatorType,
   ValidatorConfig,
 } from "../types";
+import { DEFAULT_HYPERPARAMS } from "@/config/training";
 import { nextName } from "./naming";
 
 export function makeUnstructuredUploadUid(): string {
@@ -386,6 +388,52 @@ export function makeMarkdownNoteConfig(
     markdown: "## Note\n\nAdd markdown here.",
     note_color: "#FDE68A",
     note_opacity: "35",
+  };
+}
+
+export function makeTrainConfig(
+  id: string,
+  existing: NodeConfig[],
+): TrainingCardConfig {
+  const name = nextName(existing, "train");
+  return {
+    id,
+    kind: "train",
+    name,
+    advancedOpen: false,
+    baseModel: "",
+    trainingMethod: "qlora",
+    datasetSource: "recipe",
+    hfDataset: "",
+    hfSubset: "",
+    hfSplit: "",
+    datasetFormat: "auto",
+    uploadedFile: "",
+    epochs: DEFAULT_HYPERPARAMS.epochs,
+    loraRank: DEFAULT_HYPERPARAMS.loraRank,
+    loraAlpha: DEFAULT_HYPERPARAMS.loraAlpha,
+    loraDropout: DEFAULT_HYPERPARAMS.loraDropout,
+    loraVariant: DEFAULT_HYPERPARAMS.loraVariant,
+    batchSize: DEFAULT_HYPERPARAMS.batchSize,
+    learningRate: DEFAULT_HYPERPARAMS.learningRate,
+    contextLength: DEFAULT_HYPERPARAMS.contextLength,
+    outputName: name,
+    gradientAccumulation: DEFAULT_HYPERPARAMS.gradientAccumulation,
+    warmupSteps: DEFAULT_HYPERPARAMS.warmupSteps,
+    maxSteps: DEFAULT_HYPERPARAMS.maxSteps,
+    weightDecay: DEFAULT_HYPERPARAMS.weightDecay,
+    optimizerType: DEFAULT_HYPERPARAMS.optimizerType,
+    lrSchedulerType: DEFAULT_HYPERPARAMS.lrSchedulerType,
+    packing: DEFAULT_HYPERPARAMS.packing,
+    trainOnCompletions: DEFAULT_HYPERPARAMS.trainOnCompletions,
+    gradientCheckpointing: DEFAULT_HYPERPARAMS.gradientCheckpointing,
+    randomSeed: DEFAULT_HYPERPARAMS.randomSeed,
+    targetModules: [...DEFAULT_HYPERPARAMS.targetModules],
+    enableWandb: DEFAULT_HYPERPARAMS.enableWandb,
+    wandbProject: DEFAULT_HYPERPARAMS.wandbProject,
+    enableTensorboard: DEFAULT_HYPERPARAMS.enableTensorboard,
+    tensorboardDir: DEFAULT_HYPERPARAMS.tensorboardDir,
+    hfToken: "",
   };
 }
 

--- a/studio/frontend/src/features/recipe-studio/utils/import/importer.ts
+++ b/studio/frontend/src/features/recipe-studio/utils/import/importer.ts
@@ -12,8 +12,10 @@ import type {
   SamplerConfig,
   SeedSourceType,
   ToolProfileConfig,
+  TrainingCardConfig,
   ValidatorConfig,
 } from "../../types";
+import { makeTrainConfig } from "../config-factories";
 import { buildEdges } from "./edges";
 import { isRecord, parseJson, readString } from "./helpers";
 import { parseColumn, parseModelConfig, parseModelProvider } from "./parsers";
@@ -256,6 +258,125 @@ function parseUiMarkdownNoteNodes(input: unknown): UiMarkdownNoteNode[] {
   return noteNodes;
 }
 
+type UiTrainNode = {
+  name: string;
+  raw: Record<string, unknown>;
+};
+
+function parseUiTrainNodes(input: unknown): UiTrainNode[] {
+  if (!Array.isArray(input)) {
+    return [];
+  }
+  const trainNodes: UiTrainNode[] = [];
+  for (const node of input) {
+    if (!isRecord(node)) {
+      continue;
+    }
+    const nodeType = readString(node.node_type) ?? readString(node.type);
+    if (nodeType !== "train") {
+      continue;
+    }
+    const name = readString(node.name) ?? readString(node.id);
+    if (!name?.trim()) {
+      continue;
+    }
+    trainNodes.push({
+      name: name.trim(),
+      raw: isRecord(node.train) ? node.train : {},
+    });
+  }
+  return trainNodes;
+}
+
+function buildTrainConfig(
+  node: UiTrainNode,
+  id: string,
+  existing: NodeConfig[],
+): TrainingCardConfig {
+  const base = makeTrainConfig(id, existing);
+  const raw = node.raw;
+  const num = (key: keyof TrainingCardConfig, fallback: number): number => {
+    const value = Number(raw[key]);
+    return Number.isFinite(value) ? value : fallback;
+  };
+  const str = (key: keyof TrainingCardConfig, fallback: string): string =>
+    typeof raw[key] === "string" ? (raw[key] as string) : fallback;
+  const bool = (key: keyof TrainingCardConfig, fallback: boolean): boolean =>
+    typeof raw[key] === "boolean" ? (raw[key] as boolean) : fallback;
+  const oneOf = <T extends string>(
+    key: keyof TrainingCardConfig,
+    allowed: readonly T[],
+    fallback: T,
+  ): T => {
+    const value = raw[key];
+    return typeof value === "string" && allowed.includes(value as T)
+      ? (value as T)
+      : fallback;
+  };
+  const targetModules = Array.isArray(raw.targetModules)
+    ? raw.targetModules.map((value) => String(value)).filter(Boolean)
+    : base.targetModules;
+
+  return {
+    ...base,
+    name: node.name,
+    advancedOpen: bool("advancedOpen", base.advancedOpen ?? false),
+    baseModel: str("baseModel", base.baseModel),
+    trainingMethod: oneOf(
+      "trainingMethod",
+      ["qlora", "lora", "full", "cpt"] as const,
+      base.trainingMethod,
+    ),
+    datasetSource: oneOf(
+      "datasetSource",
+      ["recipe", "huggingface", "upload"] as const,
+      base.datasetSource,
+    ),
+    hfDataset: str("hfDataset", base.hfDataset),
+    hfSubset: str("hfSubset", base.hfSubset),
+    hfSplit: str("hfSplit", base.hfSplit),
+    datasetFormat: oneOf(
+      "datasetFormat",
+      ["auto", "alpaca", "chatml", "sharegpt", "raw"] as const,
+      base.datasetFormat,
+    ),
+    uploadedFile: str("uploadedFile", base.uploadedFile),
+    epochs: num("epochs", base.epochs),
+    loraRank: num("loraRank", base.loraRank),
+    loraAlpha: num("loraAlpha", base.loraAlpha),
+    loraDropout: num("loraDropout", base.loraDropout),
+    loraVariant: oneOf(
+      "loraVariant",
+      ["lora", "rslora", "loftq"] as const,
+      base.loraVariant,
+    ),
+    batchSize: num("batchSize", base.batchSize),
+    learningRate: num("learningRate", base.learningRate),
+    contextLength: num("contextLength", base.contextLength),
+    outputName: str("outputName", node.name),
+    gradientAccumulation: num("gradientAccumulation", base.gradientAccumulation),
+    warmupSteps: num("warmupSteps", base.warmupSteps),
+    maxSteps: num("maxSteps", base.maxSteps),
+    weightDecay: num("weightDecay", base.weightDecay),
+    optimizerType: str("optimizerType", base.optimizerType),
+    lrSchedulerType: str("lrSchedulerType", base.lrSchedulerType),
+    packing: bool("packing", base.packing),
+    trainOnCompletions: bool("trainOnCompletions", base.trainOnCompletions),
+    gradientCheckpointing: oneOf(
+      "gradientCheckpointing",
+      ["none", "true", "unsloth", "mlx"] as const,
+      base.gradientCheckpointing,
+    ),
+    randomSeed: num("randomSeed", base.randomSeed),
+    targetModules,
+    enableWandb: bool("enableWandb", base.enableWandb),
+    wandbProject: str("wandbProject", base.wandbProject),
+    enableTensorboard: bool("enableTensorboard", base.enableTensorboard),
+    tensorboardDir: str("tensorboardDir", base.tensorboardDir),
+    hfToken: str("hfToken", base.hfToken),
+  };
+}
+
 function parseUiToolProfileNodes(
   input: unknown,
 ): Map<string, Record<string, string[]>> {
@@ -452,6 +573,7 @@ export function importRecipePayload(
     ui?.advanced_open_by_node,
   );
   const uiMarkdownNotes = parseUiMarkdownNoteNodes(ui?.nodes);
+  const uiTrainNodes = parseUiTrainNodes(ui?.nodes);
   const uiToolProfilesByName = parseUiToolProfileNodes(ui?.nodes);
 
   for (const note of uiMarkdownNotes) {
@@ -465,6 +587,18 @@ export function importRecipePayload(
       note_color: note.note_color ?? "#FDE68A",
       note_opacity: note.note_opacity ?? "35",
     };
+    if (nameToId.has(config.name)) {
+      errors.push(`Duplicate column name: ${config.name}.`);
+      continue;
+    }
+    nameToId.set(config.name, config.id);
+    configs.push(config);
+  }
+
+  for (const trainNode of uiTrainNodes) {
+    const id = `n${nextId}`;
+    nextId += 1;
+    const config = buildTrainConfig(trainNode, id, configs);
     if (nameToId.has(config.name)) {
       errors.push(`Duplicate column name: ${config.name}.`);
       continue;

--- a/studio/frontend/src/features/recipe-studio/utils/index.ts
+++ b/studio/frontend/src/features/recipe-studio/utils/index.ts
@@ -10,6 +10,7 @@ export {
   makeSamplerConfig,
   makeSeedConfig,
   makeToolProfileConfig,
+  makeTrainConfig,
   makeValidatorConfig,
 } from "./config-factories";
 export {

--- a/studio/frontend/src/features/recipe-studio/utils/node-data.ts
+++ b/studio/frontend/src/features/recipe-studio/utils/node-data.ts
@@ -82,6 +82,16 @@ export function nodeDataFromConfig(
       layoutDirection,
     };
   }
+  if (config.kind === "train") {
+    return {
+      title: "Train",
+      kind: "train",
+      subtype: "Fine-tune",
+      blockType: "train",
+      name: config.name,
+      layoutDirection,
+    };
+  }
   if (config.kind === "model_provider") {
     return {
       title: "Provider connection",

--- a/studio/frontend/src/features/recipe-studio/utils/payload/build-payload.ts
+++ b/studio/frontend/src/features/recipe-studio/utils/payload/build-payload.ts
@@ -199,6 +199,10 @@ export function buildRecipePayload(
     if (config.kind === "markdown_note") {
       continue;
     }
+    if (config.kind === "train") {
+      // Train is a launcher, not a dataset column; it round-trips via ui.nodes.
+      continue;
+    }
     if (config.kind === "model_provider") {
       modelProviderNames.add(config.name);
       if (config.is_local) {
@@ -272,6 +276,20 @@ export function buildRecipePayload(
           markdown: config.markdown,
           note_color: config.note_color,
           note_opacity: config.note_opacity,
+        },
+      ];
+    }
+    if (config.kind === "train") {
+      const { id: _id, kind: _kind, name: _name, ...trainFields } = config;
+      return [
+        {
+          id: config.name,
+          x: node.position.x,
+          y: node.position.y,
+          ...(width !== null ? { width } : {}),
+          node_type: "train" as const,
+          name: config.name,
+          train: trainFields,
         },
       ];
     }

--- a/studio/frontend/src/features/recipe-studio/utils/payload/types.ts
+++ b/studio/frontend/src/features/recipe-studio/utils/payload/types.ts
@@ -40,12 +40,14 @@ export type RecipePayload = {
       x: number;
       y: number;
       width?: number;
-      node_type?: "markdown_note" | "tool_config";
+      node_type?: "markdown_note" | "tool_config" | "train";
       name?: string;
       markdown?: string;
       note_color?: string;
       note_opacity?: string;
       tools_by_provider?: Record<string, string[]>;
+      // Train card config, persisted UI-side (train is not a dataset column).
+      train?: Record<string, unknown>;
     }>;
     edges: {
       from: string;

--- a/studio/frontend/src/features/recipe-studio/utils/train-config.ts
+++ b/studio/frontend/src/features/recipe-studio/utils/train-config.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { useTrainingConfigStore } from "@/features/training";
+import type { RecipeExecutionRecord } from "../execution-types";
+import type { TrainingCardConfig } from "../types";
+
+/** The generated-dataset artifact wired into a Train card from an upstream run. */
+export type WiredArtifact = {
+  executionId: string;
+  artifactPath: string;
+  runLabel: string;
+  rows: number;
+};
+
+/**
+ * Pick the freshest completed execution that produced a dataset artifact. The
+ * executions list is kept sorted most-recent-first, so the first match wins.
+ */
+export function pickWiredArtifact(
+  executions: RecipeExecutionRecord[],
+): WiredArtifact | null {
+  for (const execution of executions) {
+    if (execution.status !== "completed") {
+      continue;
+    }
+    const artifactPath = execution.artifact_path?.trim();
+    if (!artifactPath) {
+      continue;
+    }
+    return {
+      executionId: execution.id,
+      artifactPath,
+      runLabel: execution.run_name?.trim() || execution.kind,
+      rows: execution.rows,
+    };
+  }
+  return null;
+}
+
+/** Resolve the dataset that a Train card should train on, honoring its source mode. */
+export function resolveTrainDataset(
+  config: TrainingCardConfig,
+  wired: WiredArtifact | null,
+): { hfDataset: string | null; uploadedFile: string | null } {
+  if (config.datasetSource === "huggingface") {
+    return { hfDataset: config.hfDataset.trim() || null, uploadedFile: null };
+  }
+  if (config.datasetSource === "upload") {
+    return {
+      hfDataset: null,
+      uploadedFile: config.uploadedFile.trim() || null,
+    };
+  }
+  // "recipe": auto-wire from the upstream completed run.
+  return { hfDataset: null, uploadedFile: wired?.artifactPath ?? null };
+}
+
+/**
+ * Map a Train card's config into the global training-config store so the
+ * existing training runtime can launch it. Dataset fields are derived from the
+ * card's source mode (auto-wired artifact, uploaded file, or Hugging Face id).
+ */
+export function applyTrainCardToTrainingStore(
+  config: TrainingCardConfig,
+  wired: WiredArtifact | null,
+): void {
+  const { hfDataset, uploadedFile } = resolveTrainDataset(config, wired);
+  const usingHf = config.datasetSource === "huggingface" && Boolean(hfDataset);
+
+  useTrainingConfigStore.setState({
+    selectedModel: config.baseModel.trim() || null,
+    projectName: config.outputName.trim(),
+    trainingMethod: config.trainingMethod,
+    hfToken: config.hfToken,
+    datasetSource: usingHf ? "huggingface" : "upload",
+    datasetFormat: config.datasetFormat,
+    dataset: usingHf ? hfDataset : null,
+    datasetSubset: usingHf ? config.hfSubset.trim() || null : null,
+    datasetSplit: usingHf ? config.hfSplit.trim() || null : null,
+    uploadedFile: usingHf ? null : uploadedFile,
+    epochs: config.epochs,
+    contextLength: config.contextLength,
+    learningRate: config.learningRate,
+    optimizerType: config.optimizerType,
+    lrSchedulerType: config.lrSchedulerType,
+    loraRank: config.loraRank,
+    loraAlpha: config.loraAlpha,
+    loraDropout: config.loraDropout,
+    loraVariant: config.loraVariant,
+    batchSize: config.batchSize,
+    gradientAccumulation: config.gradientAccumulation,
+    weightDecay: config.weightDecay,
+    warmupSteps: config.warmupSteps,
+    maxSteps: config.maxSteps,
+    packing: config.packing,
+    trainOnCompletions: config.trainOnCompletions,
+    gradientCheckpointing: config.gradientCheckpointing,
+    randomSeed: config.randomSeed,
+    targetModules: [...config.targetModules],
+    enableWandb: config.enableWandb,
+    wandbProject: config.wandbProject,
+    enableTensorboard: config.enableTensorboard,
+    tensorboardDir: config.tensorboardDir,
+  });
+}

--- a/studio/frontend/src/features/recipe-studio/utils/ui-tones.ts
+++ b/studio/frontend/src/features/recipe-studio/utils/ui-tones.ts
@@ -14,6 +14,8 @@ export const RECIPE_STUDIO_NODE_TONES = {
     "bg-violet-50 text-violet-700 border-violet-100 dark:bg-violet-950/30 dark:text-violet-300 dark:border-violet-900/60",
   seed:
     "bg-lime-50 text-lime-700 border-lime-100 dark:bg-lime-950/30 dark:text-lime-300 dark:border-lime-900/60",
+  train:
+    "bg-fuchsia-50 text-fuchsia-700 border-fuchsia-100 dark:bg-fuchsia-950/30 dark:text-fuchsia-300 dark:border-fuchsia-900/60",
   model_provider:
     "bg-amber-50 text-amber-700 border-amber-100 dark:bg-amber-950/30 dark:text-amber-300 dark:border-amber-900/60",
   model_config:


### PR DESCRIPTION
Closes #6178

## Summary
Adds a first-class Train node to the Recipe Studio graph. A finished dataset pipeline connects into this card, which holds a full training config and kicks off a fine-tuning run on the generated output. It's the first step toward the closed loop: generate, train, benchmark, regenerate.

## What's included
- **New `train` node kind** with its own card, built on the existing `BaseNode` primitives so it matches the other nodes (fuchsia tone, stat chips, dataset-status row, primary action button). A single data-input handle lets the recipe output wire straight in.
- **Dataset auto-wiring.** The card defaults to "Auto-wire from recipe output": it reads the most recent completed execution's `artifact_path` (`RecipeExecutionRecord`) and trains on that. You can override it with a Hugging Face dataset or a local file.
- **Full training config** in the Configure dialog, mirroring the Studio training section. Base model, method (QLoRA/LoRA/Full/CPT), epochs, LoRA rank, batch size, learning rate, max sequence length, and output adapter name sit up front. Everything else (LoRA alpha/dropout/variant, gradient accumulation, warmup, max steps, weight decay, optimizer, scheduler, gradient checkpointing, seed, packing, train-on-completions, W&B/TensorBoard, HF token) lives behind an Advanced accordion, the same pattern the other cards use.
- **Inline launch.** "Run training" maps the card config into the shared training-config store and calls the existing `startTrainingRun()`, so it reuses the real training runtime, consent gates, and dataset checks. The button disables while a run is active and surfaces start errors on the card.
- **Palette, drag-and-drop, and round-trip.** Train shows up in the Add-a-step sheet, supports drag-drop, and survives recipe JSON export/import. It's persisted UI-side like `markdown_note`, so it stays out of the dataset payload but is restored on load.

## Data wired
- Recipe output: `RecipePayload.run.artifact_path`, `run.dataset_name`, `run.output_formats`
- Training input: `TrainingConfigState.datasetSource`, `uploadedFile`, `dataset`, `datasetFormat`

## Testing
- `npm run typecheck`: clean
- `biome check`: new files clean, no new lint introduced
- Builds and runs from source in a local studio (supervisor `install.ps1 --local`). Screenshots to follow.

The Train node is UI-only in the recipe payload (not a dataset column); the backend training API is unchanged.
