### PR TITLE
Studio: register text-ui tokens with tailwind-merge so cn() keeps them

### DIFF
--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -2289,7 +2289,7 @@ export function ChatPage({
           } else if (outcome === "conflict") {
             toast.info("Resume this download from Models", {
               description:
-                "An earlier partial download used a different transport. Open the Models tab to resume or restart it.",
+                "An earlier partial download used a different transport. Open the Model hub tab to resume or restart it.",
             });
           } else if (outcome === "busy") {
             toast.info("Download already in progress", {
@@ -2410,7 +2410,7 @@ export function ChatPage({
         // surface's onComplete auto-loads, mirroring the "started" branch.
         toast.info("Resume this download from Models", {
           description:
-            "An earlier partial download used a different transport. Open the Models tab to resume or restart it.",
+            "An earlier partial download used a different transport. Open the Model hub tab to resume or restart it.",
         });
         return;
       }

--- a/studio/frontend/src/features/hub/catalog/models-header.tsx
+++ b/studio/frontend/src/features/hub/catalog/models-header.tsx
@@ -64,7 +64,7 @@ export function ModelsHeader({
   return (
     <header className="font-heading flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
       <PageHeading
-        title={isDataset ? "Datasets" : "Models"}
+        title={isDataset ? "Datasets" : "Model hub"}
         onTitleClick={onTitleClick}
         subtitle={
           isDataset

--- a/studio/frontend/src/i18n/locales/ar.ts
+++ b/studio/frontend/src/i18n/locales/ar.ts
@@ -39,7 +39,7 @@ export const ar = {
       returnToChat: "العودة إلى المحادثة",
       compare: "مقارنة",
       search: "بحث",
-      hub: "النماذج",
+      hub: "مركز النماذج",
       train: "تدريب",
       recipes: "الوصفات",
       export: "تصدير",

--- a/studio/frontend/src/i18n/locales/de.ts
+++ b/studio/frontend/src/i18n/locales/de.ts
@@ -39,7 +39,7 @@ export const de = {
       returnToChat: "Zurück zum Chat",
       compare: "Vergleichen",
       search: "Suchen",
-      hub: "Modelle",
+      hub: "Modell-Hub",
       train: "Trainieren",
       recipes: "Rezepte",
       export: "Exportieren",

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -36,7 +36,7 @@ export const en = {
       returnToChat: "Return to Chat",
       compare: "Compare",
       search: "Search",
-      hub: "Models",
+      hub: "Model hub",
       train: "Train",
       recipes: "Recipes",
       export: "Export",

--- a/studio/frontend/src/i18n/locales/es.ts
+++ b/studio/frontend/src/i18n/locales/es.ts
@@ -39,7 +39,7 @@ export const es = {
       returnToChat: "Volver al chat",
       compare: "Comparar",
       search: "Buscar",
-      hub: "Modelos",
+      hub: "Centro de modelos",
       train: "Entrenar",
       recipes: "Recetas",
       export: "Exportar",

--- a/studio/frontend/src/i18n/locales/fr.ts
+++ b/studio/frontend/src/i18n/locales/fr.ts
@@ -39,7 +39,7 @@ export const fr = {
       returnToChat: "Retour à la discussion",
       compare: "Comparer",
       search: "Rechercher",
-      hub: "Modèles",
+      hub: "Hub de modèles",
       train: "Entraîner",
       recipes: "Recettes",
       export: "Exporter",

--- a/studio/frontend/src/i18n/locales/hi.ts
+++ b/studio/frontend/src/i18n/locales/hi.ts
@@ -39,7 +39,7 @@ export const hi = {
       returnToChat: "चैट पर लौटें",
       compare: "तुलना करें",
       search: "खोजें",
-      hub: "मॉडल",
+      hub: "मॉडल हब",
       train: "ट्रेनिंग",
       recipes: "रेसिपी",
       export: "एक्सपोर्ट",

--- a/studio/frontend/src/i18n/locales/ja.ts
+++ b/studio/frontend/src/i18n/locales/ja.ts
@@ -40,7 +40,7 @@ export const ja = {
       returnToChat: "チャットに戻る",
       compare: "比較",
       search: "検索",
-      hub: "モデル",
+      hub: "モデルハブ",
       train: "トレーニング",
       recipes: "レシピ",
       export: "エクスポート",

--- a/studio/frontend/src/i18n/locales/ko.ts
+++ b/studio/frontend/src/i18n/locales/ko.ts
@@ -39,7 +39,7 @@ export const ko = {
       returnToChat: "채팅으로 돌아가기",
       compare: "비교",
       search: "검색",
-      hub: "모델",
+      hub: "모델 허브",
       train: "학습",
       recipes: "레시피",
       export: "내보내기",

--- a/studio/frontend/src/i18n/locales/pt-br.ts
+++ b/studio/frontend/src/i18n/locales/pt-br.ts
@@ -39,7 +39,7 @@ export const ptBR = {
       returnToChat: "Retornar ao Chat",
       compare: "Comparar",
       search: "Buscar",
-      hub: "Modelos",
+      hub: "Hub de modelos",
       train: "Treinar",
       recipes: "Receitas",
       export: "Exportar",

--- a/studio/frontend/src/i18n/locales/ru.ts
+++ b/studio/frontend/src/i18n/locales/ru.ts
@@ -39,7 +39,7 @@ export const ru = {
       returnToChat: "Вернуться к чату",
       compare: "Сравнить",
       search: "Поиск",
-      hub: "Модели",
+      hub: "Хаб моделей",
       train: "Обучение",
       recipes: "Рецепты",
       export: "Экспорт",

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -39,7 +39,7 @@ export const zhCN = {
       returnToChat: "返回聊天",
       compare: "对比",
       search: "搜索",
-      hub: "模型",
+      hub: "模型中心",
       train: "训练",
       recipes: "配方",
       export: "导出",

--- a/studio/frontend/src/lib/utils.ts
+++ b/studio/frontend/src/lib/utils.ts
@@ -2,7 +2,21 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
+
+// text-ui-* / leading-ui-* are the scaled typography tokens from index.css.
+// Register them as font-size / line-height so twMerge does not treat
+// text-ui-* as a text color and drop it when a color class follows.
+const isUiToken = (value: string) => /^ui-\d+(p5)?$/.test(value);
+
+const twMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      "font-size": [{ text: [isUiToken] }],
+      leading: [{ leading: [isUiToken] }],
+    },
+  },
+});
 
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));

--- a/tests/studio/playwright_ui_font_scale.py
+++ b/tests/studio/playwright_ui_font_scale.py
@@ -193,6 +193,25 @@ def main():
         page.set_viewport_size({"width": 1440, "height": 900})
         page.wait_for_timeout(400)
 
+        step("cn keeps text-ui-* next to color classes (hub tabs)")
+        page.keyboard.press("Escape")
+        page.wait_for_timeout(400)
+        page.goto(f"{BASE}/hub", wait_until = "domcontentloaded")
+        page.wait_for_timeout(2000)
+        open_appearance(page)
+        set_input(page, "UI font size", 12)
+        page.keyboard.press("Escape")
+        page.wait_for_timeout(400)
+        tab = page.get_by_role("radio").filter(has_text = "Discover").first
+        tab.wait_for(state = "visible", timeout = 15000)
+        tab_font = tab.evaluate("el => parseFloat(getComputedStyle(el).fontSize)")
+        # text-ui-12p5 at scale 0.75; 16px means twMerge dropped the token.
+        if not near(tab_font, 12.5 * 12 / 16):
+            fail(f"hub tab font did not scale (twMerge drop?): {tab_font}")
+        page.goto(BASE, wait_until = "domcontentloaded")
+        page.wait_for_timeout(1500)
+        open_appearance(page)
+
         step("default restores exactly")
         page.get_by_role("dialog").get_by_role("button").filter(has_text = "Appearance").first.click()
         page.wait_for_timeout(500)

--- a/tests/studio/test_ui_font_scale_contract.py
+++ b/tests/studio/test_ui_font_scale_contract.py
@@ -17,6 +17,7 @@ SRC = REPO / "studio/frontend/src"
 INDEX_CSS = (SRC / "index.css").read_text(encoding = "utf-8")
 STORE = (SRC / "features/settings/stores/appearance-custom-store.ts").read_text(encoding = "utf-8")
 SELECT = (SRC / "components/ui/select.tsx").read_text(encoding = "utf-8")
+UTILS = (SRC / "lib/utils.ts").read_text(encoding = "utf-8")
 
 # Raw numeric fontSize props are only allowed where a scaled stylesheet rule
 # (.recharts-text) overrides the presentation attribute at render time.
@@ -85,6 +86,16 @@ def test_radix_select_viewport_owns_the_scroll_state():
     assert content_cls is not None
     assert "overflow-hidden" in content_cls.group(1)
     assert "overflow-y-auto" not in content_cls.group(1)
+
+
+def test_cn_knows_the_ui_typography_tokens():
+    """Stock tailwind-merge classifies text-ui-* as a text color and deletes
+    it whenever a real color class follows in the same cn() call, so the
+    element falls back to the unscaled inherited font size."""
+    assert "extendTailwindMerge" in UTILS
+    assert '"font-size": [{ text: [isUiToken] }]' in UTILS
+    assert "leading: [{ leading: [isUiToken] }]" in UTILS
+    assert "/^ui-\\d+(p5)?$/.test(value)" in UTILS
 
 
 def test_no_raw_pixel_text_utilities():


### PR DESCRIPTION
Follow up to #7359. The token classes introduced there could be silently deleted by tailwind-merge, which made some text render oversized when the UI font size preference was lowered. Also renames the Models page to Model hub.

### Symptom

With UI font size set to 12, most of the app scales down correctly but a few elements render at a large unscaled size, for example the Discover and On Device tabs on the Model hub page and the capability pills like Conversational in the model inspector.

### Root cause

Stock tailwind-merge does not know the custom text-ui-* utilities, so it classifies them as text colors. Any cn() call that combines a text-ui-* size with a real color class, such as:

```
cn("... text-ui-12p5 ...", active ? "text-foreground" : "text-muted-foreground")
```

resolved the two as conflicting color classes and kept only the last one. The size class was stripped from the DOM, the element fell back to the inherited 16px root font, and it ignored the preference entirely. The same merge could also strip the color class when the order was reversed. Plain className strings that never pass through cn() were unaffected, which is why the breakage looked random.

### Fix

Register the token families with tailwind-merge in the cn() helper, so text-ui-* resolves in the font-size group and leading-ui-* in the line-height group. One-line behavior change, no component edits needed.

### Audit for other affected utilities

- Static: every distinct class token in the frontend source was merged against same-prefix probes of each kind (color, size, weight, family, width) under the extended config. No other token family is misclassified; the custom font-heading resolves as a font family, custom color tokens resolve as colors, and tracking utilities behave.
- Runtime: snapshotted every visible text element on the main, Model hub and Train pages at UI font sizes 16, 12 and 20 and asserted each element's font size and line height scale by exactly size/16. 1058 element checks, zero violations, with the half rate logo lockup as the only designed exception.

### Rename

The Models page is now titled Model hub: page heading, sidebar navigation label in all 11 locales, and the two chat toasts that point at the tab. List headings that count model results keep the plain Models label.

### Tests

- Contract test asserting the cn() helper registers both token families.
- Playwright regression step that sets UI font size 12, opens the Model hub page, and asserts the tab labels compute to 12.5px x 0.75 instead of the unscaled fallback.

### Verification

- Repro confirmed before the fix (tabs computed 16px at UI 12) and gone after (9.375px).
- tests/studio contract suite, frontend typecheck and build all pass; cross-engine checks green on Chromium, WebKit and Firefox.
