### PR TITLE
Fix ROCm wheel-index unit test: extract the gfx-arch probe helpers get_torch_index_url now calls

### DIFF
--- a/tests/sh/test_get_torch_index_url.sh
+++ b/tests/sh/test_get_torch_index_url.sh
@@ -23,6 +23,23 @@ _FAKE_SMI_DIR=$(mktemp -d)
     echo ""
     sed -n '/^_has_usable_nvidia_gpu()/,/^}/p' "$INSTALL_SH"
     echo ""
+    # ROCm gfx-arch probe helpers that get_torch_index_url / _has_amd_rocm_gpu
+    # now call. These MUST stay in sync with install.sh: if get_torch_index_url
+    # references a helper that is not extracted here, the ROCm branch hits an
+    # undefined function, silently falls through to the CPU wheel index, and the
+    # ROCm assertions below fail.
+    sed -n '/^_ensure_rocm_probe_env()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_probe_amd_gfx_arch()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_amd_gpu_present_via_pci()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_infer_amd_gfx_arch_from_gpu_name()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_infer_linux_amd_gfx_arch()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_amd_arch_index_family_for_gfx()/,/^}/p' "$INSTALL_SH"
+    echo ""
     sed -n '/^_trim_index_path_slashes()/,/^}/p' "$INSTALL_SH"
     echo ""
     sed -n '/^get_torch_index_url()/,/^}/p' "$INSTALL_SH"

--- a/tests/sh/test_get_torch_index_url.sh
+++ b/tests/sh/test_get_torch_index_url.sh
@@ -14,6 +14,13 @@ FAIL=0
 # controllable path so we can test the "no GPU" scenario on GPU machines.
 _FUNC_FILE=$(mktemp)
 _FAKE_SMI_DIR=$(mktemp -d)
+# The ROCm probe helpers read the real /opt/rocm prefix by ABSOLUTE path
+# (_ensure_rocm_probe_env appends /opt/rocm/bin to PATH and runs the host
+# rocminfo; version detection reads /opt/rocm/.info/version). On a real ROCm
+# host that leaks the host GPU into the minimal-PATH harness and makes the
+# no-GPU / CPU assertions host-dependent. Redirect the whole prefix to an empty
+# temp dir so the probes stay hermetic (same idea as the nvidia-smi rewrite).
+_FAKE_ROCM_DIR=$(mktemp -d)
 {
     sed -n '/^_run_bounded()/,/^}/p' "$INSTALL_SH"
     echo ""
@@ -43,7 +50,8 @@ _FAKE_SMI_DIR=$(mktemp -d)
     sed -n '/^_trim_index_path_slashes()/,/^}/p' "$INSTALL_SH"
     echo ""
     sed -n '/^get_torch_index_url()/,/^}/p' "$INSTALL_SH"
-} | sed "s|/usr/bin/nvidia-smi|$_FAKE_SMI_DIR/nvidia-smi-absent|g" \
+} | sed -e "s|/usr/bin/nvidia-smi|$_FAKE_SMI_DIR/nvidia-smi-absent|g" \
+      -e "s|/opt/rocm|$_FAKE_ROCM_DIR|g" \
   > "$_FUNC_FILE"
 
 # Save system PATH so we always have basic tools (uname, grep, head, etc.)
@@ -455,6 +463,7 @@ assert_eq "url override preserves fragment slash" "https://mirror.example.com/wh
 
 rm -f "$_FUNC_FILE"
 rm -rf "$_FAKE_SMI_DIR"
+rm -rf "$_FAKE_ROCM_DIR"
 rm -rf "$_TOOLS_DIR"
 
 echo ""


### PR DESCRIPTION
### Problem

`tests/sh/test_get_torch_index_url.sh` fails on `main` with 9 failures. Every ROCm case resolves to the CPU wheel index:

```
FAIL: ROCm 6.3 -> rocm6.3 (expected 'https://download.pytorch.org/whl/rocm6.3', got 'https://download.pytorch.org/whl/cpu')
...
Results: 40 passed, 9 failed
```

This is what the `Repo tests (CPU)` CI job trips on.

### Root cause

The test sources a curated subset of `install.sh` functions (extracted with `sed`) so it can unit-test `get_torch_index_url` while stubbing `nvidia-smi`. The ROCm path in `get_torch_index_url` later gained a gfx-arch probe (the Strix reroute work), so it now calls:

- `_ensure_rocm_probe_env`
- `_probe_amd_gfx_arch`
- `_infer_linux_amd_gfx_arch` (and its `_amd_gpu_present_via_pci` / `_infer_amd_gfx_arch_from_gpu_name` helpers)
- `_amd_arch_index_family_for_gfx`

The extraction list was never updated. In the harness those helpers are undefined, so on the ROCm path `_amd_gfx_probe=$(_probe_amd_gfx_arch)` invokes an undefined function, the branch silently falls through to `echo "$_base/cpu"`, and every ROCm assertion fails. `install.sh` itself is correct: real installs define all of these, so ROCm hosts are unaffected. This is purely a test harness gap.

### Fix

Extract the six missing helpers alongside the ones already sourced. With the gfx-arch probe defined, the mock `amd-smi` (which reports `gfx1100`) lets the ROCm branch run end to end and select the right `rocmX.Y` index.

Added a comment noting the extraction list must stay in sync with `install.sh` so the next helper addition doesn't silently reintroduce this.

### Verification

```
bash tests/sh/test_get_torch_index_url.sh
...
Results: 49 passed, 0 failed
```
