### PR TITLE
Studio: scale menu, toast, chat and composer icons with the UI font size

### DIFF
--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -966,7 +966,7 @@ export function ChatSettingsPanel({
                 Delete
               </Button>
             </div>
-            <p className="text-[11px] leading-relaxed text-muted-foreground">
+            <p className="text-ui-11 leading-relaxed text-muted-foreground">
               Saving a preset also stores current load settings (context length,
               KV cache dtype, speculative decoding, GPU layers).
               {currentLoadSummary ? (

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -282,8 +282,9 @@
 	/* Standard interactive-icon size for nav, menus, action bars, and
 	   in-message code-block actions. Sized one step above body text so
 	   icons read as minimally larger than adjacent labels (~14px text).
+	   Follows the UI font size preference; 18px at the default.
 	   Theme-independent — declared once in :root. */
-	--icon-size: 18px;
+	--icon-size: calc(18px * var(--ui-font-scale, 1));
 	/* Inset of a centered .size-icon glyph within a 2rem (size-8) action
 	   button — i.e. (32px − icon-size) / 2. Use as a negative margin on a
 	   chat-message action bar so the leftmost icon's visual edge aligns
@@ -1561,20 +1562,20 @@ html[data-chat-font] .aui-root {
 	/* Fixed-width icon slot so every pill's icon occupies the same space and
 	   the labels line up on an even rhythm, regardless of icon size. */
 	.composer-pill-glyph {
-		@apply relative inline-flex w-[19px] shrink-0 items-center justify-center transition-opacity;
+		@apply relative inline-flex w-[calc(19px*var(--ui-font-scale,1))] shrink-0 items-center justify-center transition-opacity;
 	}
 
 	/* On hover the icon swaps for an X inside a soft circle (ChatGPT-style),
 	   filling the icon slot so every pill's X is identical and centered. */
 	.composer-pill-x {
-		@apply pointer-events-none absolute inset-0 m-auto size-[19px] rounded-full bg-primary/15 p-[3px] opacity-0 transition-opacity dark:bg-white/[0.14];
+		@apply pointer-events-none absolute inset-0 m-auto size-[calc(19px*var(--ui-font-scale,1))] rounded-full bg-primary/15 p-[3px] opacity-0 transition-opacity dark:bg-white/[0.14];
 	}
 
 	/* Icon-only (compact) pills are too small for the circle, so show a bare x. */
 	[data-pill-compact="true"]
 		.composer-pill-btn:not([data-keep-label])
 		.composer-pill-x {
-		@apply size-[15px] bg-transparent p-0 dark:bg-transparent;
+		@apply size-[calc(15px*var(--ui-font-scale,1))] bg-transparent p-0 dark:bg-transparent;
 	}
 
 	/* Compact pills hide their labels, so surface the name as a hover
@@ -2769,4 +2770,75 @@ html[data-chat-font] .aui-root {
 [data-slot="select-content"] [data-radix-select-viewport]::-webkit-scrollbar {
 	display: block !important;
 	width: 8px;
+}
+
+/* Icons that sit beside scaled labels follow the UI font size: menu and
+   select surfaces, popovers, toasts, the chat thread and both composers.
+   Only glyphs scale; hit targets, paddings and surface geometry stay
+   fixed. Every value is identity at the default 16px setting. */
+:is(
+	[data-slot='dropdown-menu-content'],
+	[data-slot='dropdown-menu-sub-content'],
+	[data-slot='select-content'],
+	[data-slot='context-menu-content'],
+	[data-slot='context-menu-sub-content'],
+	[data-slot='menubar-content'],
+	[data-slot='popover-content'],
+	[data-slot='command'],
+	[data-sonner-toast],
+	.composer-action-wrapper,
+	.aui-composer-action-wrapper,
+	.aui-action-bar-more-content,
+	.aui-root
+) {
+	& svg.size-2\.5 { width: calc(0.625rem * var(--ui-font-scale, 1)); height: calc(0.625rem * var(--ui-font-scale, 1)); }
+	& svg.size-3 { width: calc(0.75rem * var(--ui-font-scale, 1)); height: calc(0.75rem * var(--ui-font-scale, 1)); }
+	& svg.size-3\.5 { width: calc(0.875rem * var(--ui-font-scale, 1)); height: calc(0.875rem * var(--ui-font-scale, 1)); }
+	& svg.size-4 { width: calc(1rem * var(--ui-font-scale, 1)); height: calc(1rem * var(--ui-font-scale, 1)); }
+	& svg.size-4\.5 { width: calc(1.125rem * var(--ui-font-scale, 1)); height: calc(1.125rem * var(--ui-font-scale, 1)); }
+	& svg.size-5 { width: calc(1.25rem * var(--ui-font-scale, 1)); height: calc(1.25rem * var(--ui-font-scale, 1)); }
+	& svg.size-6 { width: calc(1.5rem * var(--ui-font-scale, 1)); height: calc(1.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-\[10px\] { width: calc(10px * var(--ui-font-scale, 1)); height: calc(10px * var(--ui-font-scale, 1)); }
+	& svg.size-\[11px\] { width: calc(11px * var(--ui-font-scale, 1)); height: calc(11px * var(--ui-font-scale, 1)); }
+	& svg.size-\[12px\] { width: calc(12px * var(--ui-font-scale, 1)); height: calc(12px * var(--ui-font-scale, 1)); }
+	& svg.size-\[13px\] { width: calc(13px * var(--ui-font-scale, 1)); height: calc(13px * var(--ui-font-scale, 1)); }
+	& svg.size-\[14px\] { width: calc(14px * var(--ui-font-scale, 1)); height: calc(14px * var(--ui-font-scale, 1)); }
+	& svg.size-\[15px\] { width: calc(15px * var(--ui-font-scale, 1)); height: calc(15px * var(--ui-font-scale, 1)); }
+	& svg.size-\[15\.5px\] { width: calc(15.5px * var(--ui-font-scale, 1)); height: calc(15.5px * var(--ui-font-scale, 1)); }
+	& svg.size-\[16px\] { width: calc(16px * var(--ui-font-scale, 1)); height: calc(16px * var(--ui-font-scale, 1)); }
+	& svg.size-\[17px\] { width: calc(17px * var(--ui-font-scale, 1)); height: calc(17px * var(--ui-font-scale, 1)); }
+	& svg.size-\[18px\] { width: calc(18px * var(--ui-font-scale, 1)); height: calc(18px * var(--ui-font-scale, 1)); }
+	& svg.size-\[18\.5px\] { width: calc(18.5px * var(--ui-font-scale, 1)); height: calc(18.5px * var(--ui-font-scale, 1)); }
+	& svg.size-\[20px\] { width: calc(20px * var(--ui-font-scale, 1)); height: calc(20px * var(--ui-font-scale, 1)); }
+	& svg.size-\[21px\] { width: calc(21px * var(--ui-font-scale, 1)); height: calc(21px * var(--ui-font-scale, 1)); }
+	& svg.size-\[22px\] { width: calc(22px * var(--ui-font-scale, 1)); height: calc(22px * var(--ui-font-scale, 1)); }
+	& svg.size-\[5px\] { width: calc(5px * var(--ui-font-scale, 1)); height: calc(5px * var(--ui-font-scale, 1)); }
+	& svg.size-\[6px\] { width: calc(6px * var(--ui-font-scale, 1)); height: calc(6px * var(--ui-font-scale, 1)); }
+	& svg.w-3 { width: calc(0.75rem * var(--ui-font-scale, 1)); }
+	& svg.h-3 { height: calc(0.75rem * var(--ui-font-scale, 1)); }
+	& svg.w-3\.5 { width: calc(0.875rem * var(--ui-font-scale, 1)); }
+	& svg.h-3\.5 { height: calc(0.875rem * var(--ui-font-scale, 1)); }
+	& svg.w-4 { width: calc(1rem * var(--ui-font-scale, 1)); }
+	& svg.h-4 { height: calc(1rem * var(--ui-font-scale, 1)); }
+	& svg.w-5 { width: calc(1.25rem * var(--ui-font-scale, 1)); }
+	& svg.h-5 { height: calc(1.25rem * var(--ui-font-scale, 1)); }
+	/* Menu items default un-classed icons to size-4. */
+	& [data-slot*='item'] svg:not([class*='size-'], [class*='w-'], [class*='h-']) {
+		width: calc(1rem * var(--ui-font-scale, 1));
+		height: calc(1rem * var(--ui-font-scale, 1));
+	}
+}
+
+/* Sonner injects fixed 13px toast text at runtime; keep it on the scale.
+   Line heights are unitless so they follow automatically. */
+[data-sonner-toast][data-styled='true'] {
+	font-size: calc(13px * var(--ui-font-scale, 1)) !important;
+}
+[data-sonner-toast][data-styled='true'] [data-description] {
+	font-size: calc(13px * var(--ui-font-scale, 1)) !important;
+}
+/* Sonner's icon well is a fixed 16px box; track the glyph inside it. */
+[data-sonner-toast][data-styled='true'] [data-icon] {
+	width: calc(16px * var(--ui-font-scale, 1)) !important;
+	height: calc(16px * var(--ui-font-scale, 1)) !important;
 }

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -284,7 +284,7 @@
 	   icons read as minimally larger than adjacent labels (~14px text).
 	   Follows the UI font size preference; 18px at the default.
 	   Theme-independent — declared once in :root. */
-	--icon-size: calc(18px * var(--ui-font-scale, 1));
+	--icon-size: calc(10px + 0.5rem * var(--ui-font-scale, 1));
 	/* Inset of a centered .size-icon glyph within a 2rem (size-8) action
 	   button — i.e. (32px − icon-size) / 2. Use as a negative margin on a
 	   chat-message action bar so the leftmost icon's visual edge aligns
@@ -1266,8 +1266,8 @@ html[data-chat-font] .aui-root {
 	}
 	.app-user-menu [data-slot="dropdown-menu-item"] svg,
 	.app-user-menu [data-slot="dropdown-menu-sub-trigger"] svg {
-		width: 19px !important;
-		height: 19px !important;
+		width: calc(11px + 0.5rem * var(--ui-font-scale, 1)) !important;
+		height: calc(11px + 0.5rem * var(--ui-font-scale, 1)) !important;
 		flex-shrink: 0;
 	}
 	.app-user-menu [data-slot="dropdown-menu-item"]:focus,
@@ -1562,20 +1562,20 @@ html[data-chat-font] .aui-root {
 	/* Fixed-width icon slot so every pill's icon occupies the same space and
 	   the labels line up on an even rhythm, regardless of icon size. */
 	.composer-pill-glyph {
-		@apply relative inline-flex w-[calc(19px*var(--ui-font-scale,1))] shrink-0 items-center justify-center transition-opacity;
+		@apply relative inline-flex w-[calc(11px+0.5rem*var(--ui-font-scale,1))] shrink-0 items-center justify-center transition-opacity;
 	}
 
 	/* On hover the icon swaps for an X inside a soft circle (ChatGPT-style),
 	   filling the icon slot so every pill's X is identical and centered. */
 	.composer-pill-x {
-		@apply pointer-events-none absolute inset-0 m-auto size-[calc(19px*var(--ui-font-scale,1))] rounded-full bg-primary/15 p-[3px] opacity-0 transition-opacity dark:bg-white/[0.14];
+		@apply pointer-events-none absolute inset-0 m-auto size-[calc(11px+0.5rem*var(--ui-font-scale,1))] rounded-full bg-primary/15 p-[3px] opacity-0 transition-opacity dark:bg-white/[0.14];
 	}
 
 	/* Icon-only (compact) pills are too small for the circle, so show a bare x. */
 	[data-pill-compact="true"]
 		.composer-pill-btn:not([data-keep-label])
 		.composer-pill-x {
-		@apply size-[calc(15px*var(--ui-font-scale,1))] bg-transparent p-0 dark:bg-transparent;
+		@apply size-[calc(7px+0.5rem*var(--ui-font-scale,1))] bg-transparent p-0 dark:bg-transparent;
 	}
 
 	/* Compact pills hide their labels, so surface the name as a hover
@@ -1854,8 +1854,8 @@ html[data-chat-font] .aui-root {
 
 	/* Smaller tick for selected Thinking options. */
 	.unsloth-tick {
-		width: 0.8rem !important;
-		height: 0.8rem !important;
+		width: calc(4.8px + 0.5rem * var(--ui-font-scale, 1)) !important;
+		height: calc(4.8px + 0.5rem * var(--ui-font-scale, 1)) !important;
 	}
 
 	/* Soft elevation; [data-slot] outranks the component ring-1, dropping the border. */
@@ -1945,8 +1945,8 @@ html[data-chat-font] .aui-root {
 			[data-slot="dropdown-menu-sub-trigger"]
 		)
 		svg {
-		width: 1.15rem;
-		height: 1.15rem;
+		width: calc(10.4px + 0.5rem * var(--ui-font-scale, 1)) !important;
+		height: calc(10.4px + 0.5rem * var(--ui-font-scale, 1)) !important;
 	}
 
 	/* Destructive items keep red text and a red-tinted hover, not the grey one. */
@@ -2772,14 +2772,17 @@ html[data-chat-font] .aui-root {
 	width: 8px;
 }
 
-/* Icons that sit beside scaled labels follow the UI font size: menu and
-   select surfaces, popovers, toasts, the chat thread and both composers.
-   Only glyphs scale; hit targets, paddings and surface geometry stay
-   fixed. Every value is identity at the default 16px setting. */
+/* Icons that sit beside scaled labels follow the UI font size at half the
+   rate of the text, matching the logo lockup: base + (setting - 16) / 2,
+   written as calc((base - 8)px + 0.5rem * scale). Menu, select and closed
+   select trigger surfaces, popovers, toasts, the chat thread and both
+   composers. Only glyphs scale; hit targets, paddings and surface geometry
+   stay fixed. Every value is identity at the default 16px setting. */
 :is(
 	[data-slot='dropdown-menu-content'],
 	[data-slot='dropdown-menu-sub-content'],
 	[data-slot='select-content'],
+	[data-slot='select-trigger'],
 	[data-slot='context-menu-content'],
 	[data-slot='context-menu-sub-content'],
 	[data-slot='menubar-content'],
@@ -2791,54 +2794,63 @@ html[data-chat-font] .aui-root {
 	.aui-action-bar-more-content,
 	.aui-root
 ) {
-	& svg.size-2\.5 { width: calc(0.625rem * var(--ui-font-scale, 1)); height: calc(0.625rem * var(--ui-font-scale, 1)); }
-	& svg.size-3 { width: calc(0.75rem * var(--ui-font-scale, 1)); height: calc(0.75rem * var(--ui-font-scale, 1)); }
-	& svg.size-3\.5 { width: calc(0.875rem * var(--ui-font-scale, 1)); height: calc(0.875rem * var(--ui-font-scale, 1)); }
-	& svg.size-4 { width: calc(1rem * var(--ui-font-scale, 1)); height: calc(1rem * var(--ui-font-scale, 1)); }
-	& svg.size-4\.5 { width: calc(1.125rem * var(--ui-font-scale, 1)); height: calc(1.125rem * var(--ui-font-scale, 1)); }
-	& svg.size-5 { width: calc(1.25rem * var(--ui-font-scale, 1)); height: calc(1.25rem * var(--ui-font-scale, 1)); }
-	& svg.size-6 { width: calc(1.5rem * var(--ui-font-scale, 1)); height: calc(1.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-\[10px\] { width: calc(10px * var(--ui-font-scale, 1)); height: calc(10px * var(--ui-font-scale, 1)); }
-	& svg.size-\[11px\] { width: calc(11px * var(--ui-font-scale, 1)); height: calc(11px * var(--ui-font-scale, 1)); }
-	& svg.size-\[12px\] { width: calc(12px * var(--ui-font-scale, 1)); height: calc(12px * var(--ui-font-scale, 1)); }
-	& svg.size-\[13px\] { width: calc(13px * var(--ui-font-scale, 1)); height: calc(13px * var(--ui-font-scale, 1)); }
-	& svg.size-\[14px\] { width: calc(14px * var(--ui-font-scale, 1)); height: calc(14px * var(--ui-font-scale, 1)); }
-	& svg.size-\[15px\] { width: calc(15px * var(--ui-font-scale, 1)); height: calc(15px * var(--ui-font-scale, 1)); }
-	& svg.size-\[15\.5px\] { width: calc(15.5px * var(--ui-font-scale, 1)); height: calc(15.5px * var(--ui-font-scale, 1)); }
-	& svg.size-\[16px\] { width: calc(16px * var(--ui-font-scale, 1)); height: calc(16px * var(--ui-font-scale, 1)); }
-	& svg.size-\[17px\] { width: calc(17px * var(--ui-font-scale, 1)); height: calc(17px * var(--ui-font-scale, 1)); }
-	& svg.size-\[18px\] { width: calc(18px * var(--ui-font-scale, 1)); height: calc(18px * var(--ui-font-scale, 1)); }
-	& svg.size-\[18\.5px\] { width: calc(18.5px * var(--ui-font-scale, 1)); height: calc(18.5px * var(--ui-font-scale, 1)); }
-	& svg.size-\[20px\] { width: calc(20px * var(--ui-font-scale, 1)); height: calc(20px * var(--ui-font-scale, 1)); }
-	& svg.size-\[21px\] { width: calc(21px * var(--ui-font-scale, 1)); height: calc(21px * var(--ui-font-scale, 1)); }
-	& svg.size-\[22px\] { width: calc(22px * var(--ui-font-scale, 1)); height: calc(22px * var(--ui-font-scale, 1)); }
-	& svg.size-\[5px\] { width: calc(5px * var(--ui-font-scale, 1)); height: calc(5px * var(--ui-font-scale, 1)); }
-	& svg.size-\[6px\] { width: calc(6px * var(--ui-font-scale, 1)); height: calc(6px * var(--ui-font-scale, 1)); }
-	& svg.w-3 { width: calc(0.75rem * var(--ui-font-scale, 1)); }
-	& svg.h-3 { height: calc(0.75rem * var(--ui-font-scale, 1)); }
-	& svg.w-3\.5 { width: calc(0.875rem * var(--ui-font-scale, 1)); }
-	& svg.h-3\.5 { height: calc(0.875rem * var(--ui-font-scale, 1)); }
-	& svg.w-4 { width: calc(1rem * var(--ui-font-scale, 1)); }
-	& svg.h-4 { height: calc(1rem * var(--ui-font-scale, 1)); }
-	& svg.w-5 { width: calc(1.25rem * var(--ui-font-scale, 1)); }
-	& svg.h-5 { height: calc(1.25rem * var(--ui-font-scale, 1)); }
+	& svg.size-2\.5 { width: calc(2px + 0.5rem * var(--ui-font-scale, 1)); height: calc(2px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-3 { width: calc(4px + 0.5rem * var(--ui-font-scale, 1)); height: calc(4px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-3\.5 { width: calc(6px + 0.5rem * var(--ui-font-scale, 1)); height: calc(6px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-4 { width: calc(8px + 0.5rem * var(--ui-font-scale, 1)); height: calc(8px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-4\.5 { width: calc(10px + 0.5rem * var(--ui-font-scale, 1)); height: calc(10px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-5 { width: calc(12px + 0.5rem * var(--ui-font-scale, 1)); height: calc(12px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-6 { width: calc(16px + 0.5rem * var(--ui-font-scale, 1)); height: calc(16px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-\[5px\] { width: calc(-3px + 0.5rem * var(--ui-font-scale, 1)); height: calc(-3px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-\[6px\] { width: calc(-2px + 0.5rem * var(--ui-font-scale, 1)); height: calc(-2px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-\[10px\] { width: calc(2px + 0.5rem * var(--ui-font-scale, 1)); height: calc(2px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-\[11px\] { width: calc(3px + 0.5rem * var(--ui-font-scale, 1)); height: calc(3px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-\[12px\] { width: calc(4px + 0.5rem * var(--ui-font-scale, 1)); height: calc(4px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-\[13px\] { width: calc(5px + 0.5rem * var(--ui-font-scale, 1)); height: calc(5px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-\[14px\] { width: calc(6px + 0.5rem * var(--ui-font-scale, 1)); height: calc(6px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-\[15px\] { width: calc(7px + 0.5rem * var(--ui-font-scale, 1)); height: calc(7px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-\[15\.5px\] { width: calc(7.5px + 0.5rem * var(--ui-font-scale, 1)); height: calc(7.5px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-\[16px\] { width: calc(8px + 0.5rem * var(--ui-font-scale, 1)); height: calc(8px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-\[17px\] { width: calc(9px + 0.5rem * var(--ui-font-scale, 1)); height: calc(9px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-\[18px\] { width: calc(10px + 0.5rem * var(--ui-font-scale, 1)); height: calc(10px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-\[18\.5px\] { width: calc(10.5px + 0.5rem * var(--ui-font-scale, 1)); height: calc(10.5px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-\[20px\] { width: calc(12px + 0.5rem * var(--ui-font-scale, 1)); height: calc(12px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-\[21px\] { width: calc(13px + 0.5rem * var(--ui-font-scale, 1)); height: calc(13px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-\[22px\] { width: calc(14px + 0.5rem * var(--ui-font-scale, 1)); height: calc(14px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.w-3 { width: calc(4px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.h-3 { height: calc(4px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.w-3\.5 { width: calc(6px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.h-3\.5 { height: calc(6px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.w-4 { width: calc(8px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.h-4 { height: calc(8px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.w-5 { width: calc(12px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.h-5 { height: calc(12px + 0.5rem * var(--ui-font-scale, 1)); }
 	/* Menu items default un-classed icons to size-4. */
 	& [data-slot*='item'] svg:not([class*='size-'], [class*='w-'], [class*='h-']) {
-		width: calc(1rem * var(--ui-font-scale, 1));
-		height: calc(1rem * var(--ui-font-scale, 1));
+		width: calc(8px + 0.5rem * var(--ui-font-scale, 1));
+		height: calc(8px + 0.5rem * var(--ui-font-scale, 1));
 	}
 }
 
-/* Sonner injects fixed 13px toast text at runtime; keep it on the scale.
-   Line heights are unitless so they follow automatically. */
+/* Sonner injects fixed 13px toast text and 12px action labels at runtime;
+   text follows the preference at full rate. Line heights are unitless so
+   they track automatically. */
 [data-sonner-toast][data-styled='true'] {
 	font-size: calc(13px * var(--ui-font-scale, 1)) !important;
 }
 [data-sonner-toast][data-styled='true'] [data-description] {
 	font-size: calc(13px * var(--ui-font-scale, 1)) !important;
 }
-/* Sonner's icon well is a fixed 16px box; track the glyph inside it. */
+[data-sonner-toast][data-styled='true'] [data-button] {
+	font-size: calc(12px * var(--ui-font-scale, 1)) !important;
+}
+/* Sonner's icon well is a fixed 16px box; track the glyph at half rate. */
 [data-sonner-toast][data-styled='true'] [data-icon] {
-	width: calc(16px * var(--ui-font-scale, 1)) !important;
-	height: calc(16px * var(--ui-font-scale, 1)) !important;
+	width: calc(8px + 0.5rem * var(--ui-font-scale, 1)) !important;
+	height: calc(8px + 0.5rem * var(--ui-font-scale, 1)) !important;
+}
+/* Defensive: the built-in loader is unused (a custom loading icon is always
+   passed) but keep its fixed --size on the scale in case that changes. */
+[data-sonner-toast] .sonner-loading-wrapper {
+	--size: calc(8px + 0.5rem * var(--ui-font-scale, 1)) !important;
 }

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1948,7 +1948,7 @@ html[data-chat-font] .aui-root {
 			[data-slot="dropdown-menu-item"],
 			[data-slot="dropdown-menu-sub-trigger"]
 		)
-		svg {
+		svg:not(.unsloth-tick) {
 		width: var(--ui-icon-size) !important;
 		height: var(--ui-icon-size) !important;
 	}
@@ -2788,6 +2788,8 @@ html[data-chat-font] .aui-root {
 	[data-slot='dropdown-menu-sub-content'],
 	[data-slot='select-content'],
 	[data-slot='select-trigger'],
+	[data-slot='combobox-content'],
+	[data-slot='combobox-trigger'],
 	[data-slot='context-menu-content'],
 	[data-slot='context-menu-sub-content'],
 	[data-slot='menubar-content'],
@@ -2805,7 +2807,7 @@ html[data-chat-font] .aui-root {
 	& svg.size-4 { width: var(--ui-icon-size); height: var(--ui-icon-size); }
 	& svg.size-4\.5 { width: var(--ui-icon-size); height: var(--ui-icon-size); }
 	& svg.size-5 { width: var(--ui-icon-size); height: var(--ui-icon-size); }
-	& svg.size-6 { width: var(--ui-icon-size); height: var(--ui-icon-size); }
+	& svg.size-6 { width: min(calc(1.5rem * var(--ui-font-scale, 1)), calc(0.75rem + 0.75rem * var(--ui-font-scale, 1))); height: min(calc(1.5rem * var(--ui-font-scale, 1)), calc(0.75rem + 0.75rem * var(--ui-font-scale, 1))); }
 	& svg.size-\[5px\] { width: min(calc(5px * var(--ui-font-scale, 1)), calc(2.5px + 2.5px * var(--ui-font-scale, 1))); height: min(calc(5px * var(--ui-font-scale, 1)), calc(2.5px + 2.5px * var(--ui-font-scale, 1))); }
 	& svg.size-\[6px\] { width: min(calc(6px * var(--ui-font-scale, 1)), calc(3px + 3px * var(--ui-font-scale, 1))); height: min(calc(6px * var(--ui-font-scale, 1)), calc(3px + 3px * var(--ui-font-scale, 1))); }
 	& svg.size-\[10px\] { width: min(calc(10px * var(--ui-font-scale, 1)), calc(5px + 5px * var(--ui-font-scale, 1))); height: min(calc(10px * var(--ui-font-scale, 1)), calc(5px + 5px * var(--ui-font-scale, 1))); }
@@ -2822,6 +2824,7 @@ html[data-chat-font] .aui-root {
 	& svg.size-\[20px\] { width: var(--ui-icon-size); height: var(--ui-icon-size); }
 	& svg.size-\[21px\] { width: var(--ui-icon-size); height: var(--ui-icon-size); }
 	& svg.size-\[22px\] { width: var(--ui-icon-size); height: var(--ui-icon-size); }
+	& svg.size-\[36px\] { width: min(calc(36px * var(--ui-font-scale, 1)), calc(18px + 18px * var(--ui-font-scale, 1))); height: min(calc(36px * var(--ui-font-scale, 1)), calc(18px + 18px * var(--ui-font-scale, 1))); }
 	& svg.w-3 { width: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); }
 	& svg.h-3 { height: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); }
 	& svg.w-3\.5 { width: min(calc(0.875rem * var(--ui-font-scale, 1)), calc(0.4375rem + 0.4375rem * var(--ui-font-scale, 1))); }
@@ -2830,6 +2833,11 @@ html[data-chat-font] .aui-root {
 	& svg.h-4 { height: var(--ui-icon-size); }
 	& svg.w-5 { width: var(--ui-icon-size); }
 	& svg.h-5 { height: var(--ui-icon-size); }
+	/* Buttons default un-classed icons to size-4 the same way. */
+	& button:not([class*=':size-3']) svg:not([class*='size-'], [class*='w-'], [class*='h-'], .unsloth-tick) {
+		width: var(--ui-icon-size);
+		height: var(--ui-icon-size);
+	}
 	/* Menu items default un-classed icons to size-4. */
 	& [data-slot*='item'] svg:not([class*='size-'], [class*='w-'], [class*='h-']) {
 		width: var(--ui-icon-size);

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -284,7 +284,7 @@
 	   icons read as minimally larger than adjacent labels (~14px text).
 	   Follows the UI font size preference; 18px at the default.
 	   Theme-independent — declared once in :root. */
-	--icon-size: min(calc(18px * var(--ui-font-scale, 1)), calc(9px + 9px * var(--ui-font-scale, 1)));
+	--icon-size: min(calc(18px * var(--ui-font-scale, 1)), 18px);
 	/* Inset of a centered .size-icon glyph within a 2rem (size-8) action
 	   button — i.e. (32px − icon-size) / 2. Use as a negative margin on a
 	   chat-message action bar so the leftmost icon's visual edge aligns
@@ -1266,8 +1266,8 @@ html[data-chat-font] .aui-root {
 	}
 	.app-user-menu [data-slot="dropdown-menu-item"] svg,
 	.app-user-menu [data-slot="dropdown-menu-sub-trigger"] svg {
-		width: min(calc(19px * var(--ui-font-scale, 1)), calc(9.5px + 9.5px * var(--ui-font-scale, 1))) !important;
-		height: min(calc(19px * var(--ui-font-scale, 1)), calc(9.5px + 9.5px * var(--ui-font-scale, 1))) !important;
+		width: min(calc(19px * var(--ui-font-scale, 1)), 19px) !important;
+		height: min(calc(19px * var(--ui-font-scale, 1)), 19px) !important;
 		flex-shrink: 0;
 	}
 	.app-user-menu [data-slot="dropdown-menu-item"]:focus,
@@ -1562,20 +1562,20 @@ html[data-chat-font] .aui-root {
 	/* Fixed-width icon slot so every pill's icon occupies the same space and
 	   the labels line up on an even rhythm, regardless of icon size. */
 	.composer-pill-glyph {
-		@apply relative inline-flex w-[min(calc(19px*var(--ui-font-scale,1)),calc(9.5px+9.5px*var(--ui-font-scale,1)))] shrink-0 items-center justify-center transition-opacity;
+		@apply relative inline-flex w-[min(calc(19px*var(--ui-font-scale,1)),19px)] shrink-0 items-center justify-center transition-opacity;
 	}
 
 	/* On hover the icon swaps for an X inside a soft circle (ChatGPT-style),
 	   filling the icon slot so every pill's X is identical and centered. */
 	.composer-pill-x {
-		@apply pointer-events-none absolute inset-0 m-auto size-[min(calc(19px*var(--ui-font-scale,1)),calc(9.5px+9.5px*var(--ui-font-scale,1)))] rounded-full bg-primary/15 p-[3px] opacity-0 transition-opacity dark:bg-white/[0.14];
+		@apply pointer-events-none absolute inset-0 m-auto size-[min(calc(19px*var(--ui-font-scale,1)),19px)] rounded-full bg-primary/15 p-[3px] opacity-0 transition-opacity dark:bg-white/[0.14];
 	}
 
 	/* Icon-only (compact) pills are too small for the circle, so show a bare x. */
 	[data-pill-compact="true"]
 		.composer-pill-btn:not([data-keep-label])
 		.composer-pill-x {
-		@apply size-[min(calc(15px*var(--ui-font-scale,1)),calc(7.5px+7.5px*var(--ui-font-scale,1)))] bg-transparent p-0 dark:bg-transparent;
+		@apply size-[min(calc(15px*var(--ui-font-scale,1)),15px)] bg-transparent p-0 dark:bg-transparent;
 	}
 
 	/* Compact pills hide their labels, so surface the name as a hover
@@ -1854,8 +1854,8 @@ html[data-chat-font] .aui-root {
 
 	/* Smaller tick for selected Thinking options. */
 	.unsloth-tick {
-		width: min(calc(0.8rem * var(--ui-font-scale, 1)), calc(0.4rem + 0.4rem * var(--ui-font-scale, 1))) !important;
-		height: min(calc(0.8rem * var(--ui-font-scale, 1)), calc(0.4rem + 0.4rem * var(--ui-font-scale, 1))) !important;
+		width: min(calc(0.8rem * var(--ui-font-scale, 1)), 0.8rem) !important;
+		height: min(calc(0.8rem * var(--ui-font-scale, 1)), 0.8rem) !important;
 	}
 
 	/* Soft elevation; [data-slot] outranks the component ring-1, dropping the border. */
@@ -1945,8 +1945,8 @@ html[data-chat-font] .aui-root {
 			[data-slot="dropdown-menu-sub-trigger"]
 		)
 		svg {
-		width: min(calc(1.15rem * var(--ui-font-scale, 1)), calc(0.575rem + 0.575rem * var(--ui-font-scale, 1))) !important;
-		height: min(calc(1.15rem * var(--ui-font-scale, 1)), calc(0.575rem + 0.575rem * var(--ui-font-scale, 1))) !important;
+		width: min(calc(1.15rem * var(--ui-font-scale, 1)), 1.15rem) !important;
+		height: min(calc(1.15rem * var(--ui-font-scale, 1)), 1.15rem) !important;
 	}
 
 	/* Destructive items keep red text and a red-tinted hover, not the grey one. */
@@ -2773,10 +2773,9 @@ html[data-chat-font] .aui-root {
 }
 
 /* Icons that sit beside scaled labels follow the UI font size: below the
-   16px default they match the text scale, above it they move at half the
-   rate so glyphs stay slightly smaller than the text. Expressed as
-   min(full rate, half rate), since the smaller branch is correct on each
-   side. Menu, select and closed select trigger surfaces, popovers, toasts,
+   16px default they match the text scale, above it they keep their default
+   size so the enlarged text dominates and glyphs read slightly smaller
+   than the text. Expressed as min(full rate, base). Menu, select and closed select trigger surfaces, popovers, toasts,
    the chat thread and both composers. Only glyphs scale; hit targets,
    paddings and surface geometry stay fixed. Identity at the default. */
 :is(
@@ -2795,41 +2794,41 @@ html[data-chat-font] .aui-root {
 	.aui-action-bar-more-content,
 	.aui-root
 ) {
-	& svg.size-2\.5 { width: min(calc(0.625rem * var(--ui-font-scale, 1)), calc(0.3125rem + 0.3125rem * var(--ui-font-scale, 1))); height: min(calc(0.625rem * var(--ui-font-scale, 1)), calc(0.3125rem + 0.3125rem * var(--ui-font-scale, 1))); }
-	& svg.size-3 { width: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); height: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); }
-	& svg.size-3\.5 { width: min(calc(0.875rem * var(--ui-font-scale, 1)), calc(0.4375rem + 0.4375rem * var(--ui-font-scale, 1))); height: min(calc(0.875rem * var(--ui-font-scale, 1)), calc(0.4375rem + 0.4375rem * var(--ui-font-scale, 1))); }
-	& svg.size-4 { width: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1))); height: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1))); }
-	& svg.size-4\.5 { width: min(calc(1.125rem * var(--ui-font-scale, 1)), calc(0.5625rem + 0.5625rem * var(--ui-font-scale, 1))); height: min(calc(1.125rem * var(--ui-font-scale, 1)), calc(0.5625rem + 0.5625rem * var(--ui-font-scale, 1))); }
-	& svg.size-5 { width: min(calc(1.25rem * var(--ui-font-scale, 1)), calc(0.625rem + 0.625rem * var(--ui-font-scale, 1))); height: min(calc(1.25rem * var(--ui-font-scale, 1)), calc(0.625rem + 0.625rem * var(--ui-font-scale, 1))); }
-	& svg.size-6 { width: min(calc(1.5rem * var(--ui-font-scale, 1)), calc(0.75rem + 0.75rem * var(--ui-font-scale, 1))); height: min(calc(1.5rem * var(--ui-font-scale, 1)), calc(0.75rem + 0.75rem * var(--ui-font-scale, 1))); }
-	& svg.size-\[5px\] { width: min(calc(5px * var(--ui-font-scale, 1)), calc(2.5px + 2.5px * var(--ui-font-scale, 1))); height: min(calc(5px * var(--ui-font-scale, 1)), calc(2.5px + 2.5px * var(--ui-font-scale, 1))); }
-	& svg.size-\[6px\] { width: min(calc(6px * var(--ui-font-scale, 1)), calc(3px + 3px * var(--ui-font-scale, 1))); height: min(calc(6px * var(--ui-font-scale, 1)), calc(3px + 3px * var(--ui-font-scale, 1))); }
-	& svg.size-\[10px\] { width: min(calc(10px * var(--ui-font-scale, 1)), calc(5px + 5px * var(--ui-font-scale, 1))); height: min(calc(10px * var(--ui-font-scale, 1)), calc(5px + 5px * var(--ui-font-scale, 1))); }
-	& svg.size-\[11px\] { width: min(calc(11px * var(--ui-font-scale, 1)), calc(5.5px + 5.5px * var(--ui-font-scale, 1))); height: min(calc(11px * var(--ui-font-scale, 1)), calc(5.5px + 5.5px * var(--ui-font-scale, 1))); }
-	& svg.size-\[12px\] { width: min(calc(12px * var(--ui-font-scale, 1)), calc(6px + 6px * var(--ui-font-scale, 1))); height: min(calc(12px * var(--ui-font-scale, 1)), calc(6px + 6px * var(--ui-font-scale, 1))); }
-	& svg.size-\[13px\] { width: min(calc(13px * var(--ui-font-scale, 1)), calc(6.5px + 6.5px * var(--ui-font-scale, 1))); height: min(calc(13px * var(--ui-font-scale, 1)), calc(6.5px + 6.5px * var(--ui-font-scale, 1))); }
-	& svg.size-\[14px\] { width: min(calc(14px * var(--ui-font-scale, 1)), calc(7px + 7px * var(--ui-font-scale, 1))); height: min(calc(14px * var(--ui-font-scale, 1)), calc(7px + 7px * var(--ui-font-scale, 1))); }
-	& svg.size-\[15px\] { width: min(calc(15px * var(--ui-font-scale, 1)), calc(7.5px + 7.5px * var(--ui-font-scale, 1))); height: min(calc(15px * var(--ui-font-scale, 1)), calc(7.5px + 7.5px * var(--ui-font-scale, 1))); }
-	& svg.size-\[15\.5px\] { width: min(calc(15.5px * var(--ui-font-scale, 1)), calc(7.75px + 7.75px * var(--ui-font-scale, 1))); height: min(calc(15.5px * var(--ui-font-scale, 1)), calc(7.75px + 7.75px * var(--ui-font-scale, 1))); }
-	& svg.size-\[16px\] { width: min(calc(16px * var(--ui-font-scale, 1)), calc(8px + 8px * var(--ui-font-scale, 1))); height: min(calc(16px * var(--ui-font-scale, 1)), calc(8px + 8px * var(--ui-font-scale, 1))); }
-	& svg.size-\[17px\] { width: min(calc(17px * var(--ui-font-scale, 1)), calc(8.5px + 8.5px * var(--ui-font-scale, 1))); height: min(calc(17px * var(--ui-font-scale, 1)), calc(8.5px + 8.5px * var(--ui-font-scale, 1))); }
-	& svg.size-\[18px\] { width: min(calc(18px * var(--ui-font-scale, 1)), calc(9px + 9px * var(--ui-font-scale, 1))); height: min(calc(18px * var(--ui-font-scale, 1)), calc(9px + 9px * var(--ui-font-scale, 1))); }
-	& svg.size-\[18\.5px\] { width: min(calc(18.5px * var(--ui-font-scale, 1)), calc(9.25px + 9.25px * var(--ui-font-scale, 1))); height: min(calc(18.5px * var(--ui-font-scale, 1)), calc(9.25px + 9.25px * var(--ui-font-scale, 1))); }
-	& svg.size-\[20px\] { width: min(calc(20px * var(--ui-font-scale, 1)), calc(10px + 10px * var(--ui-font-scale, 1))); height: min(calc(20px * var(--ui-font-scale, 1)), calc(10px + 10px * var(--ui-font-scale, 1))); }
-	& svg.size-\[21px\] { width: min(calc(21px * var(--ui-font-scale, 1)), calc(10.5px + 10.5px * var(--ui-font-scale, 1))); height: min(calc(21px * var(--ui-font-scale, 1)), calc(10.5px + 10.5px * var(--ui-font-scale, 1))); }
-	& svg.size-\[22px\] { width: min(calc(22px * var(--ui-font-scale, 1)), calc(11px + 11px * var(--ui-font-scale, 1))); height: min(calc(22px * var(--ui-font-scale, 1)), calc(11px + 11px * var(--ui-font-scale, 1))); }
-	& svg.w-3 { width: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); }
-	& svg.h-3 { height: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); }
-	& svg.w-3\.5 { width: min(calc(0.875rem * var(--ui-font-scale, 1)), calc(0.4375rem + 0.4375rem * var(--ui-font-scale, 1))); }
-	& svg.h-3\.5 { height: min(calc(0.875rem * var(--ui-font-scale, 1)), calc(0.4375rem + 0.4375rem * var(--ui-font-scale, 1))); }
-	& svg.w-4 { width: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1))); }
-	& svg.h-4 { height: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1))); }
-	& svg.w-5 { width: min(calc(1.25rem * var(--ui-font-scale, 1)), calc(0.625rem + 0.625rem * var(--ui-font-scale, 1))); }
-	& svg.h-5 { height: min(calc(1.25rem * var(--ui-font-scale, 1)), calc(0.625rem + 0.625rem * var(--ui-font-scale, 1))); }
+	& svg.size-2\.5 { width: min(calc(0.625rem * var(--ui-font-scale, 1)), 0.625rem); height: min(calc(0.625rem * var(--ui-font-scale, 1)), 0.625rem); }
+	& svg.size-3 { width: min(calc(0.75rem * var(--ui-font-scale, 1)), 0.75rem); height: min(calc(0.75rem * var(--ui-font-scale, 1)), 0.75rem); }
+	& svg.size-3\.5 { width: min(calc(0.875rem * var(--ui-font-scale, 1)), 0.875rem); height: min(calc(0.875rem * var(--ui-font-scale, 1)), 0.875rem); }
+	& svg.size-4 { width: min(calc(1rem * var(--ui-font-scale, 1)), 1rem); height: min(calc(1rem * var(--ui-font-scale, 1)), 1rem); }
+	& svg.size-4\.5 { width: min(calc(1.125rem * var(--ui-font-scale, 1)), 1.125rem); height: min(calc(1.125rem * var(--ui-font-scale, 1)), 1.125rem); }
+	& svg.size-5 { width: min(calc(1.25rem * var(--ui-font-scale, 1)), 1.25rem); height: min(calc(1.25rem * var(--ui-font-scale, 1)), 1.25rem); }
+	& svg.size-6 { width: min(calc(1.5rem * var(--ui-font-scale, 1)), 1.5rem); height: min(calc(1.5rem * var(--ui-font-scale, 1)), 1.5rem); }
+	& svg.size-\[5px\] { width: min(calc(5px * var(--ui-font-scale, 1)), 5px); height: min(calc(5px * var(--ui-font-scale, 1)), 5px); }
+	& svg.size-\[6px\] { width: min(calc(6px * var(--ui-font-scale, 1)), 6px); height: min(calc(6px * var(--ui-font-scale, 1)), 6px); }
+	& svg.size-\[10px\] { width: min(calc(10px * var(--ui-font-scale, 1)), 10px); height: min(calc(10px * var(--ui-font-scale, 1)), 10px); }
+	& svg.size-\[11px\] { width: min(calc(11px * var(--ui-font-scale, 1)), 11px); height: min(calc(11px * var(--ui-font-scale, 1)), 11px); }
+	& svg.size-\[12px\] { width: min(calc(12px * var(--ui-font-scale, 1)), 12px); height: min(calc(12px * var(--ui-font-scale, 1)), 12px); }
+	& svg.size-\[13px\] { width: min(calc(13px * var(--ui-font-scale, 1)), 13px); height: min(calc(13px * var(--ui-font-scale, 1)), 13px); }
+	& svg.size-\[14px\] { width: min(calc(14px * var(--ui-font-scale, 1)), 14px); height: min(calc(14px * var(--ui-font-scale, 1)), 14px); }
+	& svg.size-\[15px\] { width: min(calc(15px * var(--ui-font-scale, 1)), 15px); height: min(calc(15px * var(--ui-font-scale, 1)), 15px); }
+	& svg.size-\[15\.5px\] { width: min(calc(15.5px * var(--ui-font-scale, 1)), 15.5px); height: min(calc(15.5px * var(--ui-font-scale, 1)), 15.5px); }
+	& svg.size-\[16px\] { width: min(calc(16px * var(--ui-font-scale, 1)), 16px); height: min(calc(16px * var(--ui-font-scale, 1)), 16px); }
+	& svg.size-\[17px\] { width: min(calc(17px * var(--ui-font-scale, 1)), 17px); height: min(calc(17px * var(--ui-font-scale, 1)), 17px); }
+	& svg.size-\[18px\] { width: min(calc(18px * var(--ui-font-scale, 1)), 18px); height: min(calc(18px * var(--ui-font-scale, 1)), 18px); }
+	& svg.size-\[18\.5px\] { width: min(calc(18.5px * var(--ui-font-scale, 1)), 18.5px); height: min(calc(18.5px * var(--ui-font-scale, 1)), 18.5px); }
+	& svg.size-\[20px\] { width: min(calc(20px * var(--ui-font-scale, 1)), 20px); height: min(calc(20px * var(--ui-font-scale, 1)), 20px); }
+	& svg.size-\[21px\] { width: min(calc(21px * var(--ui-font-scale, 1)), 21px); height: min(calc(21px * var(--ui-font-scale, 1)), 21px); }
+	& svg.size-\[22px\] { width: min(calc(22px * var(--ui-font-scale, 1)), 22px); height: min(calc(22px * var(--ui-font-scale, 1)), 22px); }
+	& svg.w-3 { width: min(calc(0.75rem * var(--ui-font-scale, 1)), 0.75rem); }
+	& svg.h-3 { height: min(calc(0.75rem * var(--ui-font-scale, 1)), 0.75rem); }
+	& svg.w-3\.5 { width: min(calc(0.875rem * var(--ui-font-scale, 1)), 0.875rem); }
+	& svg.h-3\.5 { height: min(calc(0.875rem * var(--ui-font-scale, 1)), 0.875rem); }
+	& svg.w-4 { width: min(calc(1rem * var(--ui-font-scale, 1)), 1rem); }
+	& svg.h-4 { height: min(calc(1rem * var(--ui-font-scale, 1)), 1rem); }
+	& svg.w-5 { width: min(calc(1.25rem * var(--ui-font-scale, 1)), 1.25rem); }
+	& svg.h-5 { height: min(calc(1.25rem * var(--ui-font-scale, 1)), 1.25rem); }
 	/* Menu items default un-classed icons to size-4. */
 	& [data-slot*='item'] svg:not([class*='size-'], [class*='w-'], [class*='h-']) {
-		width: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1)));
-		height: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1)));
+		width: min(calc(1rem * var(--ui-font-scale, 1)), 1rem);
+		height: min(calc(1rem * var(--ui-font-scale, 1)), 1rem);
 	}
 }
 
@@ -2847,11 +2846,11 @@ html[data-chat-font] .aui-root {
 }
 /* Sonner's icon well is a fixed 16px box; track the glyph. */
 [data-sonner-toast][data-styled='true'] [data-icon] {
-	width: min(calc(16px * var(--ui-font-scale, 1)), calc(8px + 8px * var(--ui-font-scale, 1))) !important;
-	height: min(calc(16px * var(--ui-font-scale, 1)), calc(8px + 8px * var(--ui-font-scale, 1))) !important;
+	width: min(calc(16px * var(--ui-font-scale, 1)), 16px) !important;
+	height: min(calc(16px * var(--ui-font-scale, 1)), 16px) !important;
 }
 /* Defensive: the built-in loader is unused (a custom loading icon is always
    passed) but keep its fixed --size on the scale in case that changes. */
 [data-sonner-toast] .sonner-loading-wrapper {
-	--size: min(calc(16px * var(--ui-font-scale, 1)), calc(8px + 8px * var(--ui-font-scale, 1))) !important;
+	--size: min(calc(16px * var(--ui-font-scale, 1)), 16px) !important;
 }

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2833,8 +2833,9 @@ html[data-chat-font] .aui-root {
 	& svg.h-4 { height: var(--ui-icon-size); }
 	& svg.w-5 { width: var(--ui-icon-size); }
 	& svg.h-5 { height: var(--ui-icon-size); }
-	/* Buttons default un-classed icons to size-4 the same way. */
-	& button:not([class*=':size-3']) svg:not([class*='size-'], [class*='w-'], [class*='h-'], .unsloth-tick) {
+	/* Buttons default un-classed icons to size-4 the same way. Sonner's
+	   close button keeps its compact 12px glyph inside a fixed control. */
+	& button:not([class*=':size-3'], [data-close-button]) svg:not([class*='size-'], [class*='w-'], [class*='h-'], .unsloth-tick) {
 		width: var(--ui-icon-size);
 		height: var(--ui-icon-size);
 	}

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -284,7 +284,7 @@
 	   icons read as minimally larger than adjacent labels (~14px text).
 	   Follows the UI font size preference; 18px at the default.
 	   Theme-independent — declared once in :root. */
-	--icon-size: calc(10px + 0.5rem * var(--ui-font-scale, 1));
+	--icon-size: min(calc(18px * var(--ui-font-scale, 1)), calc(9px + 9px * var(--ui-font-scale, 1)));
 	/* Inset of a centered .size-icon glyph within a 2rem (size-8) action
 	   button — i.e. (32px − icon-size) / 2. Use as a negative margin on a
 	   chat-message action bar so the leftmost icon's visual edge aligns
@@ -1266,8 +1266,8 @@ html[data-chat-font] .aui-root {
 	}
 	.app-user-menu [data-slot="dropdown-menu-item"] svg,
 	.app-user-menu [data-slot="dropdown-menu-sub-trigger"] svg {
-		width: calc(11px + 0.5rem * var(--ui-font-scale, 1)) !important;
-		height: calc(11px + 0.5rem * var(--ui-font-scale, 1)) !important;
+		width: min(calc(19px * var(--ui-font-scale, 1)), calc(9.5px + 9.5px * var(--ui-font-scale, 1))) !important;
+		height: min(calc(19px * var(--ui-font-scale, 1)), calc(9.5px + 9.5px * var(--ui-font-scale, 1))) !important;
 		flex-shrink: 0;
 	}
 	.app-user-menu [data-slot="dropdown-menu-item"]:focus,
@@ -1562,20 +1562,20 @@ html[data-chat-font] .aui-root {
 	/* Fixed-width icon slot so every pill's icon occupies the same space and
 	   the labels line up on an even rhythm, regardless of icon size. */
 	.composer-pill-glyph {
-		@apply relative inline-flex w-[calc(11px+0.5rem*var(--ui-font-scale,1))] shrink-0 items-center justify-center transition-opacity;
+		@apply relative inline-flex w-[min(calc(19px*var(--ui-font-scale,1)),calc(9.5px+9.5px*var(--ui-font-scale,1)))] shrink-0 items-center justify-center transition-opacity;
 	}
 
 	/* On hover the icon swaps for an X inside a soft circle (ChatGPT-style),
 	   filling the icon slot so every pill's X is identical and centered. */
 	.composer-pill-x {
-		@apply pointer-events-none absolute inset-0 m-auto size-[calc(11px+0.5rem*var(--ui-font-scale,1))] rounded-full bg-primary/15 p-[3px] opacity-0 transition-opacity dark:bg-white/[0.14];
+		@apply pointer-events-none absolute inset-0 m-auto size-[min(calc(19px*var(--ui-font-scale,1)),calc(9.5px+9.5px*var(--ui-font-scale,1)))] rounded-full bg-primary/15 p-[3px] opacity-0 transition-opacity dark:bg-white/[0.14];
 	}
 
 	/* Icon-only (compact) pills are too small for the circle, so show a bare x. */
 	[data-pill-compact="true"]
 		.composer-pill-btn:not([data-keep-label])
 		.composer-pill-x {
-		@apply size-[calc(7px+0.5rem*var(--ui-font-scale,1))] bg-transparent p-0 dark:bg-transparent;
+		@apply size-[min(calc(15px*var(--ui-font-scale,1)),calc(7.5px+7.5px*var(--ui-font-scale,1)))] bg-transparent p-0 dark:bg-transparent;
 	}
 
 	/* Compact pills hide their labels, so surface the name as a hover
@@ -1854,8 +1854,8 @@ html[data-chat-font] .aui-root {
 
 	/* Smaller tick for selected Thinking options. */
 	.unsloth-tick {
-		width: calc(4.8px + 0.5rem * var(--ui-font-scale, 1)) !important;
-		height: calc(4.8px + 0.5rem * var(--ui-font-scale, 1)) !important;
+		width: min(calc(0.8rem * var(--ui-font-scale, 1)), calc(0.4rem + 0.4rem * var(--ui-font-scale, 1))) !important;
+		height: min(calc(0.8rem * var(--ui-font-scale, 1)), calc(0.4rem + 0.4rem * var(--ui-font-scale, 1))) !important;
 	}
 
 	/* Soft elevation; [data-slot] outranks the component ring-1, dropping the border. */
@@ -1945,8 +1945,8 @@ html[data-chat-font] .aui-root {
 			[data-slot="dropdown-menu-sub-trigger"]
 		)
 		svg {
-		width: calc(10.4px + 0.5rem * var(--ui-font-scale, 1)) !important;
-		height: calc(10.4px + 0.5rem * var(--ui-font-scale, 1)) !important;
+		width: min(calc(1.15rem * var(--ui-font-scale, 1)), calc(0.575rem + 0.575rem * var(--ui-font-scale, 1))) !important;
+		height: min(calc(1.15rem * var(--ui-font-scale, 1)), calc(0.575rem + 0.575rem * var(--ui-font-scale, 1))) !important;
 	}
 
 	/* Destructive items keep red text and a red-tinted hover, not the grey one. */
@@ -2772,12 +2772,13 @@ html[data-chat-font] .aui-root {
 	width: 8px;
 }
 
-/* Icons that sit beside scaled labels follow the UI font size at half the
-   rate of the text, matching the logo lockup: base + (setting - 16) / 2,
-   written as calc((base - 8)px + 0.5rem * scale). Menu, select and closed
-   select trigger surfaces, popovers, toasts, the chat thread and both
-   composers. Only glyphs scale; hit targets, paddings and surface geometry
-   stay fixed. Every value is identity at the default 16px setting. */
+/* Icons that sit beside scaled labels follow the UI font size: below the
+   16px default they match the text scale, above it they move at half the
+   rate so glyphs stay slightly smaller than the text. Expressed as
+   min(full rate, half rate), since the smaller branch is correct on each
+   side. Menu, select and closed select trigger surfaces, popovers, toasts,
+   the chat thread and both composers. Only glyphs scale; hit targets,
+   paddings and surface geometry stay fixed. Identity at the default. */
 :is(
 	[data-slot='dropdown-menu-content'],
 	[data-slot='dropdown-menu-sub-content'],
@@ -2794,41 +2795,41 @@ html[data-chat-font] .aui-root {
 	.aui-action-bar-more-content,
 	.aui-root
 ) {
-	& svg.size-2\.5 { width: calc(2px + 0.5rem * var(--ui-font-scale, 1)); height: calc(2px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-3 { width: calc(4px + 0.5rem * var(--ui-font-scale, 1)); height: calc(4px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-3\.5 { width: calc(6px + 0.5rem * var(--ui-font-scale, 1)); height: calc(6px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-4 { width: calc(8px + 0.5rem * var(--ui-font-scale, 1)); height: calc(8px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-4\.5 { width: calc(10px + 0.5rem * var(--ui-font-scale, 1)); height: calc(10px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-5 { width: calc(12px + 0.5rem * var(--ui-font-scale, 1)); height: calc(12px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-6 { width: calc(16px + 0.5rem * var(--ui-font-scale, 1)); height: calc(16px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-\[5px\] { width: calc(-3px + 0.5rem * var(--ui-font-scale, 1)); height: calc(-3px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-\[6px\] { width: calc(-2px + 0.5rem * var(--ui-font-scale, 1)); height: calc(-2px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-\[10px\] { width: calc(2px + 0.5rem * var(--ui-font-scale, 1)); height: calc(2px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-\[11px\] { width: calc(3px + 0.5rem * var(--ui-font-scale, 1)); height: calc(3px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-\[12px\] { width: calc(4px + 0.5rem * var(--ui-font-scale, 1)); height: calc(4px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-\[13px\] { width: calc(5px + 0.5rem * var(--ui-font-scale, 1)); height: calc(5px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-\[14px\] { width: calc(6px + 0.5rem * var(--ui-font-scale, 1)); height: calc(6px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-\[15px\] { width: calc(7px + 0.5rem * var(--ui-font-scale, 1)); height: calc(7px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-\[15\.5px\] { width: calc(7.5px + 0.5rem * var(--ui-font-scale, 1)); height: calc(7.5px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-\[16px\] { width: calc(8px + 0.5rem * var(--ui-font-scale, 1)); height: calc(8px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-\[17px\] { width: calc(9px + 0.5rem * var(--ui-font-scale, 1)); height: calc(9px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-\[18px\] { width: calc(10px + 0.5rem * var(--ui-font-scale, 1)); height: calc(10px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-\[18\.5px\] { width: calc(10.5px + 0.5rem * var(--ui-font-scale, 1)); height: calc(10.5px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-\[20px\] { width: calc(12px + 0.5rem * var(--ui-font-scale, 1)); height: calc(12px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-\[21px\] { width: calc(13px + 0.5rem * var(--ui-font-scale, 1)); height: calc(13px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.size-\[22px\] { width: calc(14px + 0.5rem * var(--ui-font-scale, 1)); height: calc(14px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.w-3 { width: calc(4px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.h-3 { height: calc(4px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.w-3\.5 { width: calc(6px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.h-3\.5 { height: calc(6px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.w-4 { width: calc(8px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.h-4 { height: calc(8px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.w-5 { width: calc(12px + 0.5rem * var(--ui-font-scale, 1)); }
-	& svg.h-5 { height: calc(12px + 0.5rem * var(--ui-font-scale, 1)); }
+	& svg.size-2\.5 { width: min(calc(0.625rem * var(--ui-font-scale, 1)), calc(0.3125rem + 0.3125rem * var(--ui-font-scale, 1))); height: min(calc(0.625rem * var(--ui-font-scale, 1)), calc(0.3125rem + 0.3125rem * var(--ui-font-scale, 1))); }
+	& svg.size-3 { width: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); height: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); }
+	& svg.size-3\.5 { width: min(calc(0.875rem * var(--ui-font-scale, 1)), calc(0.4375rem + 0.4375rem * var(--ui-font-scale, 1))); height: min(calc(0.875rem * var(--ui-font-scale, 1)), calc(0.4375rem + 0.4375rem * var(--ui-font-scale, 1))); }
+	& svg.size-4 { width: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1))); height: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1))); }
+	& svg.size-4\.5 { width: min(calc(1.125rem * var(--ui-font-scale, 1)), calc(0.5625rem + 0.5625rem * var(--ui-font-scale, 1))); height: min(calc(1.125rem * var(--ui-font-scale, 1)), calc(0.5625rem + 0.5625rem * var(--ui-font-scale, 1))); }
+	& svg.size-5 { width: min(calc(1.25rem * var(--ui-font-scale, 1)), calc(0.625rem + 0.625rem * var(--ui-font-scale, 1))); height: min(calc(1.25rem * var(--ui-font-scale, 1)), calc(0.625rem + 0.625rem * var(--ui-font-scale, 1))); }
+	& svg.size-6 { width: min(calc(1.5rem * var(--ui-font-scale, 1)), calc(0.75rem + 0.75rem * var(--ui-font-scale, 1))); height: min(calc(1.5rem * var(--ui-font-scale, 1)), calc(0.75rem + 0.75rem * var(--ui-font-scale, 1))); }
+	& svg.size-\[5px\] { width: min(calc(5px * var(--ui-font-scale, 1)), calc(2.5px + 2.5px * var(--ui-font-scale, 1))); height: min(calc(5px * var(--ui-font-scale, 1)), calc(2.5px + 2.5px * var(--ui-font-scale, 1))); }
+	& svg.size-\[6px\] { width: min(calc(6px * var(--ui-font-scale, 1)), calc(3px + 3px * var(--ui-font-scale, 1))); height: min(calc(6px * var(--ui-font-scale, 1)), calc(3px + 3px * var(--ui-font-scale, 1))); }
+	& svg.size-\[10px\] { width: min(calc(10px * var(--ui-font-scale, 1)), calc(5px + 5px * var(--ui-font-scale, 1))); height: min(calc(10px * var(--ui-font-scale, 1)), calc(5px + 5px * var(--ui-font-scale, 1))); }
+	& svg.size-\[11px\] { width: min(calc(11px * var(--ui-font-scale, 1)), calc(5.5px + 5.5px * var(--ui-font-scale, 1))); height: min(calc(11px * var(--ui-font-scale, 1)), calc(5.5px + 5.5px * var(--ui-font-scale, 1))); }
+	& svg.size-\[12px\] { width: min(calc(12px * var(--ui-font-scale, 1)), calc(6px + 6px * var(--ui-font-scale, 1))); height: min(calc(12px * var(--ui-font-scale, 1)), calc(6px + 6px * var(--ui-font-scale, 1))); }
+	& svg.size-\[13px\] { width: min(calc(13px * var(--ui-font-scale, 1)), calc(6.5px + 6.5px * var(--ui-font-scale, 1))); height: min(calc(13px * var(--ui-font-scale, 1)), calc(6.5px + 6.5px * var(--ui-font-scale, 1))); }
+	& svg.size-\[14px\] { width: min(calc(14px * var(--ui-font-scale, 1)), calc(7px + 7px * var(--ui-font-scale, 1))); height: min(calc(14px * var(--ui-font-scale, 1)), calc(7px + 7px * var(--ui-font-scale, 1))); }
+	& svg.size-\[15px\] { width: min(calc(15px * var(--ui-font-scale, 1)), calc(7.5px + 7.5px * var(--ui-font-scale, 1))); height: min(calc(15px * var(--ui-font-scale, 1)), calc(7.5px + 7.5px * var(--ui-font-scale, 1))); }
+	& svg.size-\[15\.5px\] { width: min(calc(15.5px * var(--ui-font-scale, 1)), calc(7.75px + 7.75px * var(--ui-font-scale, 1))); height: min(calc(15.5px * var(--ui-font-scale, 1)), calc(7.75px + 7.75px * var(--ui-font-scale, 1))); }
+	& svg.size-\[16px\] { width: min(calc(16px * var(--ui-font-scale, 1)), calc(8px + 8px * var(--ui-font-scale, 1))); height: min(calc(16px * var(--ui-font-scale, 1)), calc(8px + 8px * var(--ui-font-scale, 1))); }
+	& svg.size-\[17px\] { width: min(calc(17px * var(--ui-font-scale, 1)), calc(8.5px + 8.5px * var(--ui-font-scale, 1))); height: min(calc(17px * var(--ui-font-scale, 1)), calc(8.5px + 8.5px * var(--ui-font-scale, 1))); }
+	& svg.size-\[18px\] { width: min(calc(18px * var(--ui-font-scale, 1)), calc(9px + 9px * var(--ui-font-scale, 1))); height: min(calc(18px * var(--ui-font-scale, 1)), calc(9px + 9px * var(--ui-font-scale, 1))); }
+	& svg.size-\[18\.5px\] { width: min(calc(18.5px * var(--ui-font-scale, 1)), calc(9.25px + 9.25px * var(--ui-font-scale, 1))); height: min(calc(18.5px * var(--ui-font-scale, 1)), calc(9.25px + 9.25px * var(--ui-font-scale, 1))); }
+	& svg.size-\[20px\] { width: min(calc(20px * var(--ui-font-scale, 1)), calc(10px + 10px * var(--ui-font-scale, 1))); height: min(calc(20px * var(--ui-font-scale, 1)), calc(10px + 10px * var(--ui-font-scale, 1))); }
+	& svg.size-\[21px\] { width: min(calc(21px * var(--ui-font-scale, 1)), calc(10.5px + 10.5px * var(--ui-font-scale, 1))); height: min(calc(21px * var(--ui-font-scale, 1)), calc(10.5px + 10.5px * var(--ui-font-scale, 1))); }
+	& svg.size-\[22px\] { width: min(calc(22px * var(--ui-font-scale, 1)), calc(11px + 11px * var(--ui-font-scale, 1))); height: min(calc(22px * var(--ui-font-scale, 1)), calc(11px + 11px * var(--ui-font-scale, 1))); }
+	& svg.w-3 { width: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); }
+	& svg.h-3 { height: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); }
+	& svg.w-3\.5 { width: min(calc(0.875rem * var(--ui-font-scale, 1)), calc(0.4375rem + 0.4375rem * var(--ui-font-scale, 1))); }
+	& svg.h-3\.5 { height: min(calc(0.875rem * var(--ui-font-scale, 1)), calc(0.4375rem + 0.4375rem * var(--ui-font-scale, 1))); }
+	& svg.w-4 { width: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1))); }
+	& svg.h-4 { height: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1))); }
+	& svg.w-5 { width: min(calc(1.25rem * var(--ui-font-scale, 1)), calc(0.625rem + 0.625rem * var(--ui-font-scale, 1))); }
+	& svg.h-5 { height: min(calc(1.25rem * var(--ui-font-scale, 1)), calc(0.625rem + 0.625rem * var(--ui-font-scale, 1))); }
 	/* Menu items default un-classed icons to size-4. */
 	& [data-slot*='item'] svg:not([class*='size-'], [class*='w-'], [class*='h-']) {
-		width: calc(8px + 0.5rem * var(--ui-font-scale, 1));
-		height: calc(8px + 0.5rem * var(--ui-font-scale, 1));
+		width: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1)));
+		height: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1)));
 	}
 }
 
@@ -2844,13 +2845,13 @@ html[data-chat-font] .aui-root {
 [data-sonner-toast][data-styled='true'] [data-button] {
 	font-size: calc(12px * var(--ui-font-scale, 1)) !important;
 }
-/* Sonner's icon well is a fixed 16px box; track the glyph at half rate. */
+/* Sonner's icon well is a fixed 16px box; track the glyph. */
 [data-sonner-toast][data-styled='true'] [data-icon] {
-	width: calc(8px + 0.5rem * var(--ui-font-scale, 1)) !important;
-	height: calc(8px + 0.5rem * var(--ui-font-scale, 1)) !important;
+	width: min(calc(16px * var(--ui-font-scale, 1)), calc(8px + 8px * var(--ui-font-scale, 1))) !important;
+	height: min(calc(16px * var(--ui-font-scale, 1)), calc(8px + 8px * var(--ui-font-scale, 1))) !important;
 }
 /* Defensive: the built-in loader is unused (a custom loading icon is always
    passed) but keep its fixed --size on the scale in case that changes. */
 [data-sonner-toast] .sonner-loading-wrapper {
-	--size: calc(8px + 0.5rem * var(--ui-font-scale, 1)) !important;
+	--size: min(calc(16px * var(--ui-font-scale, 1)), calc(8px + 8px * var(--ui-font-scale, 1))) !important;
 }

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -284,7 +284,11 @@
 	   icons read as minimally larger than adjacent labels (~14px text).
 	   Follows the UI font size preference; 18px at the default.
 	   Theme-independent — declared once in :root. */
-	--icon-size: min(calc(18px * var(--ui-font-scale, 1)), calc(9px + 9px * var(--ui-font-scale, 1)));
+	/* Standard icon size follows the UI font size itself: matches it below
+	   the 16px default, grows at half the change above it (setting 20 ->
+	   18px), so icons read slightly smaller than enlarged text. */
+	--ui-icon-size: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1)));
+	--icon-size: var(--ui-icon-size);
 	/* Inset of a centered .size-icon glyph within a 2rem (size-8) action
 	   button — i.e. (32px − icon-size) / 2. Use as a negative margin on a
 	   chat-message action bar so the leftmost icon's visual edge aligns
@@ -1266,8 +1270,8 @@ html[data-chat-font] .aui-root {
 	}
 	.app-user-menu [data-slot="dropdown-menu-item"] svg,
 	.app-user-menu [data-slot="dropdown-menu-sub-trigger"] svg {
-		width: min(calc(19px * var(--ui-font-scale, 1)), calc(9.5px + 9.5px * var(--ui-font-scale, 1))) !important;
-		height: min(calc(19px * var(--ui-font-scale, 1)), calc(9.5px + 9.5px * var(--ui-font-scale, 1))) !important;
+		width: var(--ui-icon-size) !important;
+		height: var(--ui-icon-size) !important;
 		flex-shrink: 0;
 	}
 	.app-user-menu [data-slot="dropdown-menu-item"]:focus,
@@ -1562,13 +1566,13 @@ html[data-chat-font] .aui-root {
 	/* Fixed-width icon slot so every pill's icon occupies the same space and
 	   the labels line up on an even rhythm, regardless of icon size. */
 	.composer-pill-glyph {
-		@apply relative inline-flex w-[min(calc(19px*var(--ui-font-scale,1)),calc(9.5px+9.5px*var(--ui-font-scale,1)))] shrink-0 items-center justify-center transition-opacity;
+		@apply relative inline-flex w-[var(--ui-icon-size)] shrink-0 items-center justify-center transition-opacity;
 	}
 
 	/* On hover the icon swaps for an X inside a soft circle (ChatGPT-style),
 	   filling the icon slot so every pill's X is identical and centered. */
 	.composer-pill-x {
-		@apply pointer-events-none absolute inset-0 m-auto size-[min(calc(19px*var(--ui-font-scale,1)),calc(9.5px+9.5px*var(--ui-font-scale,1)))] rounded-full bg-primary/15 p-[3px] opacity-0 transition-opacity dark:bg-white/[0.14];
+		@apply pointer-events-none absolute inset-0 m-auto size-[var(--ui-icon-size)] rounded-full bg-primary/15 p-[3px] opacity-0 transition-opacity dark:bg-white/[0.14];
 	}
 
 	/* Icon-only (compact) pills are too small for the circle, so show a bare x. */
@@ -1945,8 +1949,8 @@ html[data-chat-font] .aui-root {
 			[data-slot="dropdown-menu-sub-trigger"]
 		)
 		svg {
-		width: min(calc(1.15rem * var(--ui-font-scale, 1)), calc(0.575rem + 0.575rem * var(--ui-font-scale, 1))) !important;
-		height: min(calc(1.15rem * var(--ui-font-scale, 1)), calc(0.575rem + 0.575rem * var(--ui-font-scale, 1))) !important;
+		width: var(--ui-icon-size) !important;
+		height: var(--ui-icon-size) !important;
 	}
 
 	/* Destructive items keep red text and a red-tinted hover, not the grey one. */
@@ -2772,11 +2776,11 @@ html[data-chat-font] .aui-root {
 	width: 8px;
 }
 
-/* Icons that sit beside scaled labels follow the UI font size: below the
-   16px default they match the text scale, above it they move at half the
-   rate so glyphs stay slightly smaller than the text. Expressed as
-   min(full rate, half rate), since the smaller branch is correct on each
-   side. Menu, select and closed select trigger surfaces, popovers, toasts,
+/* Icons that sit beside scaled labels follow the UI font size itself:
+   glyphs at or above a 16px base render at --ui-icon-size (12 -> 12px,
+   16 -> 16px, 20 -> 18px), so icons track the text below the default and
+   read slightly smaller than it above. Sub-16px glyphs keep their
+   proportions through the same curve as a factor. Menu, select and closed select trigger surfaces, popovers, toasts,
    the chat thread and both composers. Only glyphs scale; hit targets,
    paddings and surface geometry stay fixed. Identity at the default. */
 :is(
@@ -2798,10 +2802,10 @@ html[data-chat-font] .aui-root {
 	& svg.size-2\.5 { width: min(calc(0.625rem * var(--ui-font-scale, 1)), calc(0.3125rem + 0.3125rem * var(--ui-font-scale, 1))); height: min(calc(0.625rem * var(--ui-font-scale, 1)), calc(0.3125rem + 0.3125rem * var(--ui-font-scale, 1))); }
 	& svg.size-3 { width: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); height: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); }
 	& svg.size-3\.5 { width: min(calc(0.875rem * var(--ui-font-scale, 1)), calc(0.4375rem + 0.4375rem * var(--ui-font-scale, 1))); height: min(calc(0.875rem * var(--ui-font-scale, 1)), calc(0.4375rem + 0.4375rem * var(--ui-font-scale, 1))); }
-	& svg.size-4 { width: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1))); height: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1))); }
-	& svg.size-4\.5 { width: min(calc(1.125rem * var(--ui-font-scale, 1)), calc(0.5625rem + 0.5625rem * var(--ui-font-scale, 1))); height: min(calc(1.125rem * var(--ui-font-scale, 1)), calc(0.5625rem + 0.5625rem * var(--ui-font-scale, 1))); }
-	& svg.size-5 { width: min(calc(1.25rem * var(--ui-font-scale, 1)), calc(0.625rem + 0.625rem * var(--ui-font-scale, 1))); height: min(calc(1.25rem * var(--ui-font-scale, 1)), calc(0.625rem + 0.625rem * var(--ui-font-scale, 1))); }
-	& svg.size-6 { width: min(calc(1.5rem * var(--ui-font-scale, 1)), calc(0.75rem + 0.75rem * var(--ui-font-scale, 1))); height: min(calc(1.5rem * var(--ui-font-scale, 1)), calc(0.75rem + 0.75rem * var(--ui-font-scale, 1))); }
+	& svg.size-4 { width: var(--ui-icon-size); height: var(--ui-icon-size); }
+	& svg.size-4\.5 { width: var(--ui-icon-size); height: var(--ui-icon-size); }
+	& svg.size-5 { width: var(--ui-icon-size); height: var(--ui-icon-size); }
+	& svg.size-6 { width: var(--ui-icon-size); height: var(--ui-icon-size); }
 	& svg.size-\[5px\] { width: min(calc(5px * var(--ui-font-scale, 1)), calc(2.5px + 2.5px * var(--ui-font-scale, 1))); height: min(calc(5px * var(--ui-font-scale, 1)), calc(2.5px + 2.5px * var(--ui-font-scale, 1))); }
 	& svg.size-\[6px\] { width: min(calc(6px * var(--ui-font-scale, 1)), calc(3px + 3px * var(--ui-font-scale, 1))); height: min(calc(6px * var(--ui-font-scale, 1)), calc(3px + 3px * var(--ui-font-scale, 1))); }
 	& svg.size-\[10px\] { width: min(calc(10px * var(--ui-font-scale, 1)), calc(5px + 5px * var(--ui-font-scale, 1))); height: min(calc(10px * var(--ui-font-scale, 1)), calc(5px + 5px * var(--ui-font-scale, 1))); }
@@ -2811,25 +2815,25 @@ html[data-chat-font] .aui-root {
 	& svg.size-\[14px\] { width: min(calc(14px * var(--ui-font-scale, 1)), calc(7px + 7px * var(--ui-font-scale, 1))); height: min(calc(14px * var(--ui-font-scale, 1)), calc(7px + 7px * var(--ui-font-scale, 1))); }
 	& svg.size-\[15px\] { width: min(calc(15px * var(--ui-font-scale, 1)), calc(7.5px + 7.5px * var(--ui-font-scale, 1))); height: min(calc(15px * var(--ui-font-scale, 1)), calc(7.5px + 7.5px * var(--ui-font-scale, 1))); }
 	& svg.size-\[15\.5px\] { width: min(calc(15.5px * var(--ui-font-scale, 1)), calc(7.75px + 7.75px * var(--ui-font-scale, 1))); height: min(calc(15.5px * var(--ui-font-scale, 1)), calc(7.75px + 7.75px * var(--ui-font-scale, 1))); }
-	& svg.size-\[16px\] { width: min(calc(16px * var(--ui-font-scale, 1)), calc(8px + 8px * var(--ui-font-scale, 1))); height: min(calc(16px * var(--ui-font-scale, 1)), calc(8px + 8px * var(--ui-font-scale, 1))); }
-	& svg.size-\[17px\] { width: min(calc(17px * var(--ui-font-scale, 1)), calc(8.5px + 8.5px * var(--ui-font-scale, 1))); height: min(calc(17px * var(--ui-font-scale, 1)), calc(8.5px + 8.5px * var(--ui-font-scale, 1))); }
-	& svg.size-\[18px\] { width: min(calc(18px * var(--ui-font-scale, 1)), calc(9px + 9px * var(--ui-font-scale, 1))); height: min(calc(18px * var(--ui-font-scale, 1)), calc(9px + 9px * var(--ui-font-scale, 1))); }
-	& svg.size-\[18\.5px\] { width: min(calc(18.5px * var(--ui-font-scale, 1)), calc(9.25px + 9.25px * var(--ui-font-scale, 1))); height: min(calc(18.5px * var(--ui-font-scale, 1)), calc(9.25px + 9.25px * var(--ui-font-scale, 1))); }
-	& svg.size-\[20px\] { width: min(calc(20px * var(--ui-font-scale, 1)), calc(10px + 10px * var(--ui-font-scale, 1))); height: min(calc(20px * var(--ui-font-scale, 1)), calc(10px + 10px * var(--ui-font-scale, 1))); }
-	& svg.size-\[21px\] { width: min(calc(21px * var(--ui-font-scale, 1)), calc(10.5px + 10.5px * var(--ui-font-scale, 1))); height: min(calc(21px * var(--ui-font-scale, 1)), calc(10.5px + 10.5px * var(--ui-font-scale, 1))); }
-	& svg.size-\[22px\] { width: min(calc(22px * var(--ui-font-scale, 1)), calc(11px + 11px * var(--ui-font-scale, 1))); height: min(calc(22px * var(--ui-font-scale, 1)), calc(11px + 11px * var(--ui-font-scale, 1))); }
+	& svg.size-\[16px\] { width: var(--ui-icon-size); height: var(--ui-icon-size); }
+	& svg.size-\[17px\] { width: var(--ui-icon-size); height: var(--ui-icon-size); }
+	& svg.size-\[18px\] { width: var(--ui-icon-size); height: var(--ui-icon-size); }
+	& svg.size-\[18\.5px\] { width: var(--ui-icon-size); height: var(--ui-icon-size); }
+	& svg.size-\[20px\] { width: var(--ui-icon-size); height: var(--ui-icon-size); }
+	& svg.size-\[21px\] { width: var(--ui-icon-size); height: var(--ui-icon-size); }
+	& svg.size-\[22px\] { width: var(--ui-icon-size); height: var(--ui-icon-size); }
 	& svg.w-3 { width: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); }
 	& svg.h-3 { height: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); }
 	& svg.w-3\.5 { width: min(calc(0.875rem * var(--ui-font-scale, 1)), calc(0.4375rem + 0.4375rem * var(--ui-font-scale, 1))); }
 	& svg.h-3\.5 { height: min(calc(0.875rem * var(--ui-font-scale, 1)), calc(0.4375rem + 0.4375rem * var(--ui-font-scale, 1))); }
-	& svg.w-4 { width: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1))); }
-	& svg.h-4 { height: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1))); }
-	& svg.w-5 { width: min(calc(1.25rem * var(--ui-font-scale, 1)), calc(0.625rem + 0.625rem * var(--ui-font-scale, 1))); }
-	& svg.h-5 { height: min(calc(1.25rem * var(--ui-font-scale, 1)), calc(0.625rem + 0.625rem * var(--ui-font-scale, 1))); }
+	& svg.w-4 { width: var(--ui-icon-size); }
+	& svg.h-4 { height: var(--ui-icon-size); }
+	& svg.w-5 { width: var(--ui-icon-size); }
+	& svg.h-5 { height: var(--ui-icon-size); }
 	/* Menu items default un-classed icons to size-4. */
 	& [data-slot*='item'] svg:not([class*='size-'], [class*='w-'], [class*='h-']) {
-		width: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1)));
-		height: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1)));
+		width: var(--ui-icon-size);
+		height: var(--ui-icon-size);
 	}
 }
 
@@ -2847,11 +2851,11 @@ html[data-chat-font] .aui-root {
 }
 /* Sonner's icon well is a fixed 16px box; track the glyph. */
 [data-sonner-toast][data-styled='true'] [data-icon] {
-	width: min(calc(16px * var(--ui-font-scale, 1)), calc(8px + 8px * var(--ui-font-scale, 1))) !important;
-	height: min(calc(16px * var(--ui-font-scale, 1)), calc(8px + 8px * var(--ui-font-scale, 1))) !important;
+	width: var(--ui-icon-size) !important;
+	height: var(--ui-icon-size) !important;
 }
 /* Defensive: the built-in loader is unused (a custom loading icon is always
    passed) but keep its fixed --size on the scale in case that changes. */
 [data-sonner-toast] .sonner-loading-wrapper {
-	--size: min(calc(16px * var(--ui-font-scale, 1)), calc(8px + 8px * var(--ui-font-scale, 1))) !important;
+	--size: var(--ui-icon-size) !important;
 }

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -284,7 +284,7 @@
 	   icons read as minimally larger than adjacent labels (~14px text).
 	   Follows the UI font size preference; 18px at the default.
 	   Theme-independent — declared once in :root. */
-	--icon-size: min(calc(18px * var(--ui-font-scale, 1)), 18px);
+	--icon-size: min(calc(18px * var(--ui-font-scale, 1)), calc(9px + 9px * var(--ui-font-scale, 1)));
 	/* Inset of a centered .size-icon glyph within a 2rem (size-8) action
 	   button — i.e. (32px − icon-size) / 2. Use as a negative margin on a
 	   chat-message action bar so the leftmost icon's visual edge aligns
@@ -1266,8 +1266,8 @@ html[data-chat-font] .aui-root {
 	}
 	.app-user-menu [data-slot="dropdown-menu-item"] svg,
 	.app-user-menu [data-slot="dropdown-menu-sub-trigger"] svg {
-		width: min(calc(19px * var(--ui-font-scale, 1)), 19px) !important;
-		height: min(calc(19px * var(--ui-font-scale, 1)), 19px) !important;
+		width: min(calc(19px * var(--ui-font-scale, 1)), calc(9.5px + 9.5px * var(--ui-font-scale, 1))) !important;
+		height: min(calc(19px * var(--ui-font-scale, 1)), calc(9.5px + 9.5px * var(--ui-font-scale, 1))) !important;
 		flex-shrink: 0;
 	}
 	.app-user-menu [data-slot="dropdown-menu-item"]:focus,
@@ -1562,20 +1562,20 @@ html[data-chat-font] .aui-root {
 	/* Fixed-width icon slot so every pill's icon occupies the same space and
 	   the labels line up on an even rhythm, regardless of icon size. */
 	.composer-pill-glyph {
-		@apply relative inline-flex w-[min(calc(19px*var(--ui-font-scale,1)),19px)] shrink-0 items-center justify-center transition-opacity;
+		@apply relative inline-flex w-[min(calc(19px*var(--ui-font-scale,1)),calc(9.5px+9.5px*var(--ui-font-scale,1)))] shrink-0 items-center justify-center transition-opacity;
 	}
 
 	/* On hover the icon swaps for an X inside a soft circle (ChatGPT-style),
 	   filling the icon slot so every pill's X is identical and centered. */
 	.composer-pill-x {
-		@apply pointer-events-none absolute inset-0 m-auto size-[min(calc(19px*var(--ui-font-scale,1)),19px)] rounded-full bg-primary/15 p-[3px] opacity-0 transition-opacity dark:bg-white/[0.14];
+		@apply pointer-events-none absolute inset-0 m-auto size-[min(calc(19px*var(--ui-font-scale,1)),calc(9.5px+9.5px*var(--ui-font-scale,1)))] rounded-full bg-primary/15 p-[3px] opacity-0 transition-opacity dark:bg-white/[0.14];
 	}
 
 	/* Icon-only (compact) pills are too small for the circle, so show a bare x. */
 	[data-pill-compact="true"]
 		.composer-pill-btn:not([data-keep-label])
 		.composer-pill-x {
-		@apply size-[min(calc(15px*var(--ui-font-scale,1)),15px)] bg-transparent p-0 dark:bg-transparent;
+		@apply size-[min(calc(15px*var(--ui-font-scale,1)),calc(7.5px+7.5px*var(--ui-font-scale,1)))] bg-transparent p-0 dark:bg-transparent;
 	}
 
 	/* Compact pills hide their labels, so surface the name as a hover
@@ -1854,8 +1854,8 @@ html[data-chat-font] .aui-root {
 
 	/* Smaller tick for selected Thinking options. */
 	.unsloth-tick {
-		width: min(calc(0.8rem * var(--ui-font-scale, 1)), 0.8rem) !important;
-		height: min(calc(0.8rem * var(--ui-font-scale, 1)), 0.8rem) !important;
+		width: min(calc(0.8rem * var(--ui-font-scale, 1)), calc(0.4rem + 0.4rem * var(--ui-font-scale, 1))) !important;
+		height: min(calc(0.8rem * var(--ui-font-scale, 1)), calc(0.4rem + 0.4rem * var(--ui-font-scale, 1))) !important;
 	}
 
 	/* Soft elevation; [data-slot] outranks the component ring-1, dropping the border. */
@@ -1945,8 +1945,8 @@ html[data-chat-font] .aui-root {
 			[data-slot="dropdown-menu-sub-trigger"]
 		)
 		svg {
-		width: min(calc(1.15rem * var(--ui-font-scale, 1)), 1.15rem) !important;
-		height: min(calc(1.15rem * var(--ui-font-scale, 1)), 1.15rem) !important;
+		width: min(calc(1.15rem * var(--ui-font-scale, 1)), calc(0.575rem + 0.575rem * var(--ui-font-scale, 1))) !important;
+		height: min(calc(1.15rem * var(--ui-font-scale, 1)), calc(0.575rem + 0.575rem * var(--ui-font-scale, 1))) !important;
 	}
 
 	/* Destructive items keep red text and a red-tinted hover, not the grey one. */
@@ -2773,9 +2773,10 @@ html[data-chat-font] .aui-root {
 }
 
 /* Icons that sit beside scaled labels follow the UI font size: below the
-   16px default they match the text scale, above it they keep their default
-   size so the enlarged text dominates and glyphs read slightly smaller
-   than the text. Expressed as min(full rate, base). Menu, select and closed select trigger surfaces, popovers, toasts,
+   16px default they match the text scale, above it they move at half the
+   rate so glyphs stay slightly smaller than the text. Expressed as
+   min(full rate, half rate), since the smaller branch is correct on each
+   side. Menu, select and closed select trigger surfaces, popovers, toasts,
    the chat thread and both composers. Only glyphs scale; hit targets,
    paddings and surface geometry stay fixed. Identity at the default. */
 :is(
@@ -2794,41 +2795,41 @@ html[data-chat-font] .aui-root {
 	.aui-action-bar-more-content,
 	.aui-root
 ) {
-	& svg.size-2\.5 { width: min(calc(0.625rem * var(--ui-font-scale, 1)), 0.625rem); height: min(calc(0.625rem * var(--ui-font-scale, 1)), 0.625rem); }
-	& svg.size-3 { width: min(calc(0.75rem * var(--ui-font-scale, 1)), 0.75rem); height: min(calc(0.75rem * var(--ui-font-scale, 1)), 0.75rem); }
-	& svg.size-3\.5 { width: min(calc(0.875rem * var(--ui-font-scale, 1)), 0.875rem); height: min(calc(0.875rem * var(--ui-font-scale, 1)), 0.875rem); }
-	& svg.size-4 { width: min(calc(1rem * var(--ui-font-scale, 1)), 1rem); height: min(calc(1rem * var(--ui-font-scale, 1)), 1rem); }
-	& svg.size-4\.5 { width: min(calc(1.125rem * var(--ui-font-scale, 1)), 1.125rem); height: min(calc(1.125rem * var(--ui-font-scale, 1)), 1.125rem); }
-	& svg.size-5 { width: min(calc(1.25rem * var(--ui-font-scale, 1)), 1.25rem); height: min(calc(1.25rem * var(--ui-font-scale, 1)), 1.25rem); }
-	& svg.size-6 { width: min(calc(1.5rem * var(--ui-font-scale, 1)), 1.5rem); height: min(calc(1.5rem * var(--ui-font-scale, 1)), 1.5rem); }
-	& svg.size-\[5px\] { width: min(calc(5px * var(--ui-font-scale, 1)), 5px); height: min(calc(5px * var(--ui-font-scale, 1)), 5px); }
-	& svg.size-\[6px\] { width: min(calc(6px * var(--ui-font-scale, 1)), 6px); height: min(calc(6px * var(--ui-font-scale, 1)), 6px); }
-	& svg.size-\[10px\] { width: min(calc(10px * var(--ui-font-scale, 1)), 10px); height: min(calc(10px * var(--ui-font-scale, 1)), 10px); }
-	& svg.size-\[11px\] { width: min(calc(11px * var(--ui-font-scale, 1)), 11px); height: min(calc(11px * var(--ui-font-scale, 1)), 11px); }
-	& svg.size-\[12px\] { width: min(calc(12px * var(--ui-font-scale, 1)), 12px); height: min(calc(12px * var(--ui-font-scale, 1)), 12px); }
-	& svg.size-\[13px\] { width: min(calc(13px * var(--ui-font-scale, 1)), 13px); height: min(calc(13px * var(--ui-font-scale, 1)), 13px); }
-	& svg.size-\[14px\] { width: min(calc(14px * var(--ui-font-scale, 1)), 14px); height: min(calc(14px * var(--ui-font-scale, 1)), 14px); }
-	& svg.size-\[15px\] { width: min(calc(15px * var(--ui-font-scale, 1)), 15px); height: min(calc(15px * var(--ui-font-scale, 1)), 15px); }
-	& svg.size-\[15\.5px\] { width: min(calc(15.5px * var(--ui-font-scale, 1)), 15.5px); height: min(calc(15.5px * var(--ui-font-scale, 1)), 15.5px); }
-	& svg.size-\[16px\] { width: min(calc(16px * var(--ui-font-scale, 1)), 16px); height: min(calc(16px * var(--ui-font-scale, 1)), 16px); }
-	& svg.size-\[17px\] { width: min(calc(17px * var(--ui-font-scale, 1)), 17px); height: min(calc(17px * var(--ui-font-scale, 1)), 17px); }
-	& svg.size-\[18px\] { width: min(calc(18px * var(--ui-font-scale, 1)), 18px); height: min(calc(18px * var(--ui-font-scale, 1)), 18px); }
-	& svg.size-\[18\.5px\] { width: min(calc(18.5px * var(--ui-font-scale, 1)), 18.5px); height: min(calc(18.5px * var(--ui-font-scale, 1)), 18.5px); }
-	& svg.size-\[20px\] { width: min(calc(20px * var(--ui-font-scale, 1)), 20px); height: min(calc(20px * var(--ui-font-scale, 1)), 20px); }
-	& svg.size-\[21px\] { width: min(calc(21px * var(--ui-font-scale, 1)), 21px); height: min(calc(21px * var(--ui-font-scale, 1)), 21px); }
-	& svg.size-\[22px\] { width: min(calc(22px * var(--ui-font-scale, 1)), 22px); height: min(calc(22px * var(--ui-font-scale, 1)), 22px); }
-	& svg.w-3 { width: min(calc(0.75rem * var(--ui-font-scale, 1)), 0.75rem); }
-	& svg.h-3 { height: min(calc(0.75rem * var(--ui-font-scale, 1)), 0.75rem); }
-	& svg.w-3\.5 { width: min(calc(0.875rem * var(--ui-font-scale, 1)), 0.875rem); }
-	& svg.h-3\.5 { height: min(calc(0.875rem * var(--ui-font-scale, 1)), 0.875rem); }
-	& svg.w-4 { width: min(calc(1rem * var(--ui-font-scale, 1)), 1rem); }
-	& svg.h-4 { height: min(calc(1rem * var(--ui-font-scale, 1)), 1rem); }
-	& svg.w-5 { width: min(calc(1.25rem * var(--ui-font-scale, 1)), 1.25rem); }
-	& svg.h-5 { height: min(calc(1.25rem * var(--ui-font-scale, 1)), 1.25rem); }
+	& svg.size-2\.5 { width: min(calc(0.625rem * var(--ui-font-scale, 1)), calc(0.3125rem + 0.3125rem * var(--ui-font-scale, 1))); height: min(calc(0.625rem * var(--ui-font-scale, 1)), calc(0.3125rem + 0.3125rem * var(--ui-font-scale, 1))); }
+	& svg.size-3 { width: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); height: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); }
+	& svg.size-3\.5 { width: min(calc(0.875rem * var(--ui-font-scale, 1)), calc(0.4375rem + 0.4375rem * var(--ui-font-scale, 1))); height: min(calc(0.875rem * var(--ui-font-scale, 1)), calc(0.4375rem + 0.4375rem * var(--ui-font-scale, 1))); }
+	& svg.size-4 { width: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1))); height: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1))); }
+	& svg.size-4\.5 { width: min(calc(1.125rem * var(--ui-font-scale, 1)), calc(0.5625rem + 0.5625rem * var(--ui-font-scale, 1))); height: min(calc(1.125rem * var(--ui-font-scale, 1)), calc(0.5625rem + 0.5625rem * var(--ui-font-scale, 1))); }
+	& svg.size-5 { width: min(calc(1.25rem * var(--ui-font-scale, 1)), calc(0.625rem + 0.625rem * var(--ui-font-scale, 1))); height: min(calc(1.25rem * var(--ui-font-scale, 1)), calc(0.625rem + 0.625rem * var(--ui-font-scale, 1))); }
+	& svg.size-6 { width: min(calc(1.5rem * var(--ui-font-scale, 1)), calc(0.75rem + 0.75rem * var(--ui-font-scale, 1))); height: min(calc(1.5rem * var(--ui-font-scale, 1)), calc(0.75rem + 0.75rem * var(--ui-font-scale, 1))); }
+	& svg.size-\[5px\] { width: min(calc(5px * var(--ui-font-scale, 1)), calc(2.5px + 2.5px * var(--ui-font-scale, 1))); height: min(calc(5px * var(--ui-font-scale, 1)), calc(2.5px + 2.5px * var(--ui-font-scale, 1))); }
+	& svg.size-\[6px\] { width: min(calc(6px * var(--ui-font-scale, 1)), calc(3px + 3px * var(--ui-font-scale, 1))); height: min(calc(6px * var(--ui-font-scale, 1)), calc(3px + 3px * var(--ui-font-scale, 1))); }
+	& svg.size-\[10px\] { width: min(calc(10px * var(--ui-font-scale, 1)), calc(5px + 5px * var(--ui-font-scale, 1))); height: min(calc(10px * var(--ui-font-scale, 1)), calc(5px + 5px * var(--ui-font-scale, 1))); }
+	& svg.size-\[11px\] { width: min(calc(11px * var(--ui-font-scale, 1)), calc(5.5px + 5.5px * var(--ui-font-scale, 1))); height: min(calc(11px * var(--ui-font-scale, 1)), calc(5.5px + 5.5px * var(--ui-font-scale, 1))); }
+	& svg.size-\[12px\] { width: min(calc(12px * var(--ui-font-scale, 1)), calc(6px + 6px * var(--ui-font-scale, 1))); height: min(calc(12px * var(--ui-font-scale, 1)), calc(6px + 6px * var(--ui-font-scale, 1))); }
+	& svg.size-\[13px\] { width: min(calc(13px * var(--ui-font-scale, 1)), calc(6.5px + 6.5px * var(--ui-font-scale, 1))); height: min(calc(13px * var(--ui-font-scale, 1)), calc(6.5px + 6.5px * var(--ui-font-scale, 1))); }
+	& svg.size-\[14px\] { width: min(calc(14px * var(--ui-font-scale, 1)), calc(7px + 7px * var(--ui-font-scale, 1))); height: min(calc(14px * var(--ui-font-scale, 1)), calc(7px + 7px * var(--ui-font-scale, 1))); }
+	& svg.size-\[15px\] { width: min(calc(15px * var(--ui-font-scale, 1)), calc(7.5px + 7.5px * var(--ui-font-scale, 1))); height: min(calc(15px * var(--ui-font-scale, 1)), calc(7.5px + 7.5px * var(--ui-font-scale, 1))); }
+	& svg.size-\[15\.5px\] { width: min(calc(15.5px * var(--ui-font-scale, 1)), calc(7.75px + 7.75px * var(--ui-font-scale, 1))); height: min(calc(15.5px * var(--ui-font-scale, 1)), calc(7.75px + 7.75px * var(--ui-font-scale, 1))); }
+	& svg.size-\[16px\] { width: min(calc(16px * var(--ui-font-scale, 1)), calc(8px + 8px * var(--ui-font-scale, 1))); height: min(calc(16px * var(--ui-font-scale, 1)), calc(8px + 8px * var(--ui-font-scale, 1))); }
+	& svg.size-\[17px\] { width: min(calc(17px * var(--ui-font-scale, 1)), calc(8.5px + 8.5px * var(--ui-font-scale, 1))); height: min(calc(17px * var(--ui-font-scale, 1)), calc(8.5px + 8.5px * var(--ui-font-scale, 1))); }
+	& svg.size-\[18px\] { width: min(calc(18px * var(--ui-font-scale, 1)), calc(9px + 9px * var(--ui-font-scale, 1))); height: min(calc(18px * var(--ui-font-scale, 1)), calc(9px + 9px * var(--ui-font-scale, 1))); }
+	& svg.size-\[18\.5px\] { width: min(calc(18.5px * var(--ui-font-scale, 1)), calc(9.25px + 9.25px * var(--ui-font-scale, 1))); height: min(calc(18.5px * var(--ui-font-scale, 1)), calc(9.25px + 9.25px * var(--ui-font-scale, 1))); }
+	& svg.size-\[20px\] { width: min(calc(20px * var(--ui-font-scale, 1)), calc(10px + 10px * var(--ui-font-scale, 1))); height: min(calc(20px * var(--ui-font-scale, 1)), calc(10px + 10px * var(--ui-font-scale, 1))); }
+	& svg.size-\[21px\] { width: min(calc(21px * var(--ui-font-scale, 1)), calc(10.5px + 10.5px * var(--ui-font-scale, 1))); height: min(calc(21px * var(--ui-font-scale, 1)), calc(10.5px + 10.5px * var(--ui-font-scale, 1))); }
+	& svg.size-\[22px\] { width: min(calc(22px * var(--ui-font-scale, 1)), calc(11px + 11px * var(--ui-font-scale, 1))); height: min(calc(22px * var(--ui-font-scale, 1)), calc(11px + 11px * var(--ui-font-scale, 1))); }
+	& svg.w-3 { width: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); }
+	& svg.h-3 { height: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); }
+	& svg.w-3\.5 { width: min(calc(0.875rem * var(--ui-font-scale, 1)), calc(0.4375rem + 0.4375rem * var(--ui-font-scale, 1))); }
+	& svg.h-3\.5 { height: min(calc(0.875rem * var(--ui-font-scale, 1)), calc(0.4375rem + 0.4375rem * var(--ui-font-scale, 1))); }
+	& svg.w-4 { width: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1))); }
+	& svg.h-4 { height: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1))); }
+	& svg.w-5 { width: min(calc(1.25rem * var(--ui-font-scale, 1)), calc(0.625rem + 0.625rem * var(--ui-font-scale, 1))); }
+	& svg.h-5 { height: min(calc(1.25rem * var(--ui-font-scale, 1)), calc(0.625rem + 0.625rem * var(--ui-font-scale, 1))); }
 	/* Menu items default un-classed icons to size-4. */
 	& [data-slot*='item'] svg:not([class*='size-'], [class*='w-'], [class*='h-']) {
-		width: min(calc(1rem * var(--ui-font-scale, 1)), 1rem);
-		height: min(calc(1rem * var(--ui-font-scale, 1)), 1rem);
+		width: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1)));
+		height: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1)));
 	}
 }
 
@@ -2846,11 +2847,11 @@ html[data-chat-font] .aui-root {
 }
 /* Sonner's icon well is a fixed 16px box; track the glyph. */
 [data-sonner-toast][data-styled='true'] [data-icon] {
-	width: min(calc(16px * var(--ui-font-scale, 1)), 16px) !important;
-	height: min(calc(16px * var(--ui-font-scale, 1)), 16px) !important;
+	width: min(calc(16px * var(--ui-font-scale, 1)), calc(8px + 8px * var(--ui-font-scale, 1))) !important;
+	height: min(calc(16px * var(--ui-font-scale, 1)), calc(8px + 8px * var(--ui-font-scale, 1))) !important;
 }
 /* Defensive: the built-in loader is unused (a custom loading icon is always
    passed) but keep its fixed --size on the scale in case that changes. */
 [data-sonner-toast] .sonner-loading-wrapper {
-	--size: min(calc(16px * var(--ui-font-scale, 1)), 16px) !important;
+	--size: min(calc(16px * var(--ui-font-scale, 1)), calc(8px + 8px * var(--ui-font-scale, 1))) !important;
 }

--- a/tests/studio/playwright_ui_font_scale.py
+++ b/tests/studio/playwright_ui_font_scale.py
@@ -208,6 +208,13 @@ def main():
         # text-ui-12p5 at scale 0.75; 16px means twMerge dropped the token.
         if not near(tab_font, 12.5 * 12 / 16):
             fail(f"hub tab font did not scale (twMerge drop?): {tab_font}")
+        icon_w = page.evaluate(
+            "() => { const el = document.querySelector('.size-icon');"
+            " return el ? parseFloat(getComputedStyle(el).width) : null; }"
+        )
+        # --icon-size is 18px at the default and follows the scale.
+        if not near(icon_w, 18 * 12 / 16):
+            fail(f"size-icon did not scale with the preference: {icon_w}")
         page.goto(BASE, wait_until = "domcontentloaded")
         page.wait_for_timeout(1500)
         open_appearance(page)

--- a/tests/studio/playwright_ui_font_scale.py
+++ b/tests/studio/playwright_ui_font_scale.py
@@ -212,10 +212,10 @@ def main():
             "() => { const el = document.querySelector('.size-icon');"
             " return el ? parseFloat(getComputedStyle(el).width) : null; }"
         )
-        # --icon-size is 18px at the default and follows the preference at
-        # half rate: 18 + (12 - 16) / 2 = 16.
-        if not near(icon_w, 18 + (12 - 16) / 2):
-            fail(f"size-icon did not scale at half rate: {icon_w}")
+        # --icon-size is 18px at the default; below the default icons match
+        # the text scale, so 18 * 12 / 16 = 13.5.
+        if not near(icon_w, 18 * 12 / 16):
+            fail(f"size-icon did not match the text scale below 16: {icon_w}")
         page.goto(BASE, wait_until = "domcontentloaded")
         page.wait_for_timeout(1500)
         open_appearance(page)

--- a/tests/studio/playwright_ui_font_scale.py
+++ b/tests/studio/playwright_ui_font_scale.py
@@ -212,9 +212,10 @@ def main():
             "() => { const el = document.querySelector('.size-icon');"
             " return el ? parseFloat(getComputedStyle(el).width) : null; }"
         )
-        # --icon-size is 18px at the default and follows the scale.
-        if not near(icon_w, 18 * 12 / 16):
-            fail(f"size-icon did not scale with the preference: {icon_w}")
+        # --icon-size is 18px at the default and follows the preference at
+        # half rate: 18 + (12 - 16) / 2 = 16.
+        if not near(icon_w, 18 + (12 - 16) / 2):
+            fail(f"size-icon did not scale at half rate: {icon_w}")
         page.goto(BASE, wait_until = "domcontentloaded")
         page.wait_for_timeout(1500)
         open_appearance(page)

--- a/tests/studio/playwright_ui_font_scale.py
+++ b/tests/studio/playwright_ui_font_scale.py
@@ -212,10 +212,10 @@ def main():
             "() => { const el = document.querySelector('.size-icon');"
             " return el ? parseFloat(getComputedStyle(el).width) : null; }"
         )
-        # --icon-size is 18px at the default; below the default icons match
-        # the text scale, so 18 * 12 / 16 = 13.5.
-        if not near(icon_w, 18 * 12 / 16):
-            fail(f"size-icon did not match the text scale below 16: {icon_w}")
+        # Standard icons render at the UI font size itself below the
+        # default, so setting 12 gives 12px glyphs.
+        if not near(icon_w, 12):
+            fail(f"size-icon did not match the UI font size below 16: {icon_w}")
         page.goto(BASE, wait_until = "domcontentloaded")
         page.wait_for_timeout(1500)
         open_appearance(page)

--- a/tests/studio/test_ui_font_scale_contract.py
+++ b/tests/studio/test_ui_font_scale_contract.py
@@ -98,6 +98,22 @@ def test_cn_knows_the_ui_typography_tokens():
     assert "/^ui-\\d+(p5)?$/.test(value)" in UTILS
 
 
+def test_icons_follow_the_ui_font_scale():
+    """Glyphs beside scaled labels track the preference: the shared
+    --icon-size token, the scoped menu/toast/chat svg overrides, and the
+    sonner toast text that is otherwise pinned at 13px."""
+    assert "--icon-size: calc(18px * var(--ui-font-scale, 1));" in INDEX_CSS
+    assert "& svg.size-4 { width: calc(1rem * var(--ui-font-scale, 1));" in INDEX_CSS
+    assert "font-size: calc(13px * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
+    for scope in (
+        "[data-slot='dropdown-menu-content']",
+        "[data-slot='select-content']",
+        "[data-sonner-toast]",
+        ".aui-root",
+    ):
+        assert scope in INDEX_CSS
+
+
 def test_no_raw_pixel_text_utilities():
     offenders = []
     for path in _frontend_sources():

--- a/tests/studio/test_ui_font_scale_contract.py
+++ b/tests/studio/test_ui_font_scale_contract.py
@@ -114,12 +114,17 @@ def test_icons_follow_the_ui_font_size_itself():
     assert "& svg.size-4 { width: var(--ui-icon-size); height: var(--ui-icon-size); }" in INDEX_CSS
     assert "font-size: calc(13px * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
     assert "font-size: calc(12px * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
-    # Menu rules that outrank the scoped block must carry the token too.
+    # Menu rules that outrank the scoped block must carry the token too,
+    # without flattening the smaller thinking ticks.
     assert "width: var(--ui-icon-size) !important;" in INDEX_CSS
+    assert "svg:not(.unsloth-tick) {" in INDEX_CSS
+    # Oversized art glyphs stay proportional instead of uniform.
+    assert "& svg.size-6 { width: min(calc(1.5rem" in INDEX_CSS
     for scope in (
         "[data-slot='dropdown-menu-content']",
         "[data-slot='select-content']",
         "[data-slot='select-trigger']",
+        "[data-slot='combobox-content']",
         "[data-sonner-toast]",
         ".aui-root",
     ):

--- a/tests/studio/test_ui_font_scale_contract.py
+++ b/tests/studio/test_ui_font_scale_contract.py
@@ -100,30 +100,26 @@ def test_cn_knows_the_ui_typography_tokens():
 
 def test_icons_follow_the_ui_font_scale_piecewise():
     """Glyphs beside scaled labels track the preference piecewise: below the
-    default they match the text scale, above it they move at half rate so
-    icons stay slightly smaller than the text. Written as min(full, half),
-    the smaller branch being correct on each side. Sonner toast text and
-    action labels are text, so they follow at full rate everywhere."""
-    icon16 = (
-        "min(calc(1rem * var(--ui-font-scale, 1)), "
-        "calc(0.5rem + 0.5rem * var(--ui-font-scale, 1)))"
-    )
+    default they match the text scale, above it they keep their default size
+    so enlarged text dominates and icons read slightly smaller than the
+    text. Written as min(full rate, base). Sonner toast text and action
+    labels are text, so they follow at full rate everywhere."""
+    icon16 = "min(calc(1rem * var(--ui-font-scale, 1)), 1rem)"
     assert (
-        "--icon-size: min(calc(18px * var(--ui-font-scale, 1)), "
-        "calc(9px + 9px * var(--ui-font-scale, 1)));"
-    ) in INDEX_CSS
+        "--icon-size: min(calc(18px * var(--ui-font-scale, 1)), 18px);" in INDEX_CSS
+    )
     assert f"& svg.size-4 {{ width: {icon16};" in INDEX_CSS
     assert "font-size: calc(13px * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
     assert "font-size: calc(12px * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
     # Menu rules that outrank the scoped block must carry the scale too.
     assert (
-        "width: min(calc(19px * var(--ui-font-scale, 1)), "
-        "calc(9.5px + 9.5px * var(--ui-font-scale, 1))) !important;"
-    ) in INDEX_CSS
+        "width: min(calc(19px * var(--ui-font-scale, 1)), 19px) !important;"
+        in INDEX_CSS
+    )
     assert (
-        "width: min(calc(1.15rem * var(--ui-font-scale, 1)), "
-        "calc(0.575rem + 0.575rem * var(--ui-font-scale, 1))) !important;"
-    ) in INDEX_CSS
+        "width: min(calc(1.15rem * var(--ui-font-scale, 1)), 1.15rem) !important;"
+        in INDEX_CSS
+    )
     for scope in (
         "[data-slot='dropdown-menu-content']",
         "[data-slot='select-content']",

--- a/tests/studio/test_ui_font_scale_contract.py
+++ b/tests/studio/test_ui_font_scale_contract.py
@@ -105,21 +105,13 @@ def test_icons_follow_the_ui_font_scale_piecewise():
     text. Written as min(full rate, base). Sonner toast text and action
     labels are text, so they follow at full rate everywhere."""
     icon16 = "min(calc(1rem * var(--ui-font-scale, 1)), 1rem)"
-    assert (
-        "--icon-size: min(calc(18px * var(--ui-font-scale, 1)), 18px);" in INDEX_CSS
-    )
+    assert "--icon-size: min(calc(18px * var(--ui-font-scale, 1)), 18px);" in INDEX_CSS
     assert f"& svg.size-4 {{ width: {icon16};" in INDEX_CSS
     assert "font-size: calc(13px * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
     assert "font-size: calc(12px * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
     # Menu rules that outrank the scoped block must carry the scale too.
-    assert (
-        "width: min(calc(19px * var(--ui-font-scale, 1)), 19px) !important;"
-        in INDEX_CSS
-    )
-    assert (
-        "width: min(calc(1.15rem * var(--ui-font-scale, 1)), 1.15rem) !important;"
-        in INDEX_CSS
-    )
+    assert "width: min(calc(19px * var(--ui-font-scale, 1)), 19px) !important;" in INDEX_CSS
+    assert "width: min(calc(1.15rem * var(--ui-font-scale, 1)), 1.15rem) !important;" in INDEX_CSS
     for scope in (
         "[data-slot='dropdown-menu-content']",
         "[data-slot='select-content']",

--- a/tests/studio/test_ui_font_scale_contract.py
+++ b/tests/studio/test_ui_font_scale_contract.py
@@ -98,32 +98,27 @@ def test_cn_knows_the_ui_typography_tokens():
     assert "/^ui-\\d+(p5)?$/.test(value)" in UTILS
 
 
-def test_icons_follow_the_ui_font_scale_piecewise():
-    """Glyphs beside scaled labels track the preference piecewise: below the
-    default they match the text scale, above it they move at half rate so
-    icons stay slightly smaller than the text. Written as min(full, half),
-    the smaller branch being correct on each side. Sonner toast text and
-    action labels are text, so they follow at full rate everywhere."""
-    icon16 = (
-        "min(calc(1rem * var(--ui-font-scale, 1)), "
-        "calc(0.5rem + 0.5rem * var(--ui-font-scale, 1)))"
-    )
+def test_icons_follow_the_ui_font_size_itself():
+    """Standard glyphs render at --ui-icon-size, which follows the UI font
+    size itself: matches it below the 16px default and grows at half the
+    change above it (setting 20 gives 18px icons), so icons track the text
+    when shrinking and read slightly smaller than it when growing. Sub 16px
+    glyphs keep their proportions through the same curve as a factor.
+    Sonner toast text and action labels are text, so they follow at full
+    rate everywhere."""
     assert (
-        "--icon-size: min(calc(18px * var(--ui-font-scale, 1)), "
-        "calc(9px + 9px * var(--ui-font-scale, 1)));"
+        "--ui-icon-size: min(calc(1rem * var(--ui-font-scale, 1)), "
+        "calc(0.5rem + 0.5rem * var(--ui-font-scale, 1)));"
     ) in INDEX_CSS
-    assert f"& svg.size-4 {{ width: {icon16};" in INDEX_CSS
+    assert "--icon-size: var(--ui-icon-size);" in INDEX_CSS
+    assert (
+        "& svg.size-4 { width: var(--ui-icon-size); height: var(--ui-icon-size); }"
+        in INDEX_CSS
+    )
     assert "font-size: calc(13px * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
     assert "font-size: calc(12px * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
-    # Menu rules that outrank the scoped block must carry the scale too.
-    assert (
-        "width: min(calc(19px * var(--ui-font-scale, 1)), "
-        "calc(9.5px + 9.5px * var(--ui-font-scale, 1))) !important;"
-    ) in INDEX_CSS
-    assert (
-        "width: min(calc(1.15rem * var(--ui-font-scale, 1)), "
-        "calc(0.575rem + 0.575rem * var(--ui-font-scale, 1))) !important;"
-    ) in INDEX_CSS
+    # Menu rules that outrank the scoped block must carry the token too.
+    assert "width: var(--ui-icon-size) !important;" in INDEX_CSS
     for scope in (
         "[data-slot='dropdown-menu-content']",
         "[data-slot='select-content']",

--- a/tests/studio/test_ui_font_scale_contract.py
+++ b/tests/studio/test_ui_font_scale_contract.py
@@ -100,18 +100,30 @@ def test_cn_knows_the_ui_typography_tokens():
 
 def test_icons_follow_the_ui_font_scale_piecewise():
     """Glyphs beside scaled labels track the preference piecewise: below the
-    default they match the text scale, above it they keep their default size
-    so enlarged text dominates and icons read slightly smaller than the
-    text. Written as min(full rate, base). Sonner toast text and action
-    labels are text, so they follow at full rate everywhere."""
-    icon16 = "min(calc(1rem * var(--ui-font-scale, 1)), 1rem)"
-    assert "--icon-size: min(calc(18px * var(--ui-font-scale, 1)), 18px);" in INDEX_CSS
+    default they match the text scale, above it they move at half rate so
+    icons stay slightly smaller than the text. Written as min(full, half),
+    the smaller branch being correct on each side. Sonner toast text and
+    action labels are text, so they follow at full rate everywhere."""
+    icon16 = (
+        "min(calc(1rem * var(--ui-font-scale, 1)), "
+        "calc(0.5rem + 0.5rem * var(--ui-font-scale, 1)))"
+    )
+    assert (
+        "--icon-size: min(calc(18px * var(--ui-font-scale, 1)), "
+        "calc(9px + 9px * var(--ui-font-scale, 1)));"
+    ) in INDEX_CSS
     assert f"& svg.size-4 {{ width: {icon16};" in INDEX_CSS
     assert "font-size: calc(13px * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
     assert "font-size: calc(12px * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
     # Menu rules that outrank the scoped block must carry the scale too.
-    assert "width: min(calc(19px * var(--ui-font-scale, 1)), 19px) !important;" in INDEX_CSS
-    assert "width: min(calc(1.15rem * var(--ui-font-scale, 1)), 1.15rem) !important;" in INDEX_CSS
+    assert (
+        "width: min(calc(19px * var(--ui-font-scale, 1)), "
+        "calc(9.5px + 9.5px * var(--ui-font-scale, 1))) !important;"
+    ) in INDEX_CSS
+    assert (
+        "width: min(calc(1.15rem * var(--ui-font-scale, 1)), "
+        "calc(0.575rem + 0.575rem * var(--ui-font-scale, 1))) !important;"
+    ) in INDEX_CSS
     for scope in (
         "[data-slot='dropdown-menu-content']",
         "[data-slot='select-content']",

--- a/tests/studio/test_ui_font_scale_contract.py
+++ b/tests/studio/test_ui_font_scale_contract.py
@@ -111,10 +111,7 @@ def test_icons_follow_the_ui_font_size_itself():
         "calc(0.5rem + 0.5rem * var(--ui-font-scale, 1)));"
     ) in INDEX_CSS
     assert "--icon-size: var(--ui-icon-size);" in INDEX_CSS
-    assert (
-        "& svg.size-4 { width: var(--ui-icon-size); height: var(--ui-icon-size); }"
-        in INDEX_CSS
-    )
+    assert "& svg.size-4 { width: var(--ui-icon-size); height: var(--ui-icon-size); }" in INDEX_CSS
     assert "font-size: calc(13px * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
     assert "font-size: calc(12px * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
     # Menu rules that outrank the scoped block must carry the token too.

--- a/tests/studio/test_ui_font_scale_contract.py
+++ b/tests/studio/test_ui_font_scale_contract.py
@@ -98,16 +98,26 @@ def test_cn_knows_the_ui_typography_tokens():
     assert "/^ui-\\d+(p5)?$/.test(value)" in UTILS
 
 
-def test_icons_follow_the_ui_font_scale():
-    """Glyphs beside scaled labels track the preference: the shared
+def test_icons_follow_the_ui_font_scale_at_half_rate():
+    """Glyphs beside scaled labels track the preference at half the rate of
+    the text (base + (setting - 16) / 2, like the logo lockup): the shared
     --icon-size token, the scoped menu/toast/chat svg overrides, and the
-    sonner toast text that is otherwise pinned at 13px."""
-    assert "--icon-size: calc(18px * var(--ui-font-scale, 1));" in INDEX_CSS
-    assert "& svg.size-4 { width: calc(1rem * var(--ui-font-scale, 1));" in INDEX_CSS
+    menu specific rules that use !important. Sonner toast text and action
+    labels are text, so they follow at full rate."""
+    assert "--icon-size: calc(10px + 0.5rem * var(--ui-font-scale, 1));" in INDEX_CSS
+    assert (
+        "& svg.size-4 { width: calc(8px + 0.5rem * var(--ui-font-scale, 1));"
+        in INDEX_CSS
+    )
     assert "font-size: calc(13px * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
+    assert "font-size: calc(12px * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
+    # Menu rules that outrank the scoped block must carry the scale too.
+    assert "width: calc(11px + 0.5rem * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
+    assert "width: calc(10.4px + 0.5rem * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
     for scope in (
         "[data-slot='dropdown-menu-content']",
         "[data-slot='select-content']",
+        "[data-slot='select-trigger']",
         "[data-sonner-toast]",
         ".aui-root",
     ):

--- a/tests/studio/test_ui_font_scale_contract.py
+++ b/tests/studio/test_ui_font_scale_contract.py
@@ -98,19 +98,32 @@ def test_cn_knows_the_ui_typography_tokens():
     assert "/^ui-\\d+(p5)?$/.test(value)" in UTILS
 
 
-def test_icons_follow_the_ui_font_scale_at_half_rate():
-    """Glyphs beside scaled labels track the preference at half the rate of
-    the text (base + (setting - 16) / 2, like the logo lockup): the shared
-    --icon-size token, the scoped menu/toast/chat svg overrides, and the
-    menu specific rules that use !important. Sonner toast text and action
-    labels are text, so they follow at full rate."""
-    assert "--icon-size: calc(10px + 0.5rem * var(--ui-font-scale, 1));" in INDEX_CSS
-    assert "& svg.size-4 { width: calc(8px + 0.5rem * var(--ui-font-scale, 1));" in INDEX_CSS
+def test_icons_follow_the_ui_font_scale_piecewise():
+    """Glyphs beside scaled labels track the preference piecewise: below the
+    default they match the text scale, above it they move at half rate so
+    icons stay slightly smaller than the text. Written as min(full, half),
+    the smaller branch being correct on each side. Sonner toast text and
+    action labels are text, so they follow at full rate everywhere."""
+    icon16 = (
+        "min(calc(1rem * var(--ui-font-scale, 1)), "
+        "calc(0.5rem + 0.5rem * var(--ui-font-scale, 1)))"
+    )
+    assert (
+        "--icon-size: min(calc(18px * var(--ui-font-scale, 1)), "
+        "calc(9px + 9px * var(--ui-font-scale, 1)));"
+    ) in INDEX_CSS
+    assert f"& svg.size-4 {{ width: {icon16};" in INDEX_CSS
     assert "font-size: calc(13px * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
     assert "font-size: calc(12px * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
     # Menu rules that outrank the scoped block must carry the scale too.
-    assert "width: calc(11px + 0.5rem * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
-    assert "width: calc(10.4px + 0.5rem * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
+    assert (
+        "width: min(calc(19px * var(--ui-font-scale, 1)), "
+        "calc(9.5px + 9.5px * var(--ui-font-scale, 1))) !important;"
+    ) in INDEX_CSS
+    assert (
+        "width: min(calc(1.15rem * var(--ui-font-scale, 1)), "
+        "calc(0.575rem + 0.575rem * var(--ui-font-scale, 1))) !important;"
+    ) in INDEX_CSS
     for scope in (
         "[data-slot='dropdown-menu-content']",
         "[data-slot='select-content']",

--- a/tests/studio/test_ui_font_scale_contract.py
+++ b/tests/studio/test_ui_font_scale_contract.py
@@ -105,10 +105,7 @@ def test_icons_follow_the_ui_font_scale_at_half_rate():
     menu specific rules that use !important. Sonner toast text and action
     labels are text, so they follow at full rate."""
     assert "--icon-size: calc(10px + 0.5rem * var(--ui-font-scale, 1));" in INDEX_CSS
-    assert (
-        "& svg.size-4 { width: calc(8px + 0.5rem * var(--ui-font-scale, 1));"
-        in INDEX_CSS
-    )
+    assert "& svg.size-4 { width: calc(8px + 0.5rem * var(--ui-font-scale, 1));" in INDEX_CSS
     assert "font-size: calc(13px * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
     assert "font-size: calc(12px * var(--ui-font-scale, 1)) !important;" in INDEX_CSS
     # Menu rules that outrank the scoped block must carry the scale too.


### PR DESCRIPTION
Follow up to #7396. Text scales with the UI font size preference but the icons next to it stayed at fixed pixel sizes, so glyphs in menus, toasts and the chat surface never tracked the preference.

### What changes

Standard icons render at a single shared token, --ui-icon-size, which follows the UI font size itself: it matches the setting below the 16px default and grows at half the change above it.

```
--ui-icon-size: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1)));
```

So setting 12 gives 12px icons, 16 gives 16px, and 20 gives 18px, keeping glyphs slightly smaller than enlarged text. Every glyph with a 16px or larger base uses the token uniformly (this also slims the previous 18px to 21px icon bases down to the font size at the default); sub 16px glyphs keep their proportions through the same curve as a factor. Hit targets, paddings and surface geometry stay fixed.

- The shared --icon-size token (sidebar nav, settings tabs, chat message action bars, code block actions) aliases --ui-icon-size; --icon-btn-inset keeps auto tracking it.
- A scoped stylesheet block covers classed svg glyphs inside dropdown, select and closed select trigger surfaces, context menus, menubars, popovers, command lists, toasts, the chat thread and both composers, plus the size-4 default for unclassed menu item icons.
- Menu specific rules that outrank the scoped block carry the token themselves: the app-user-menu icons, the plus menu icons and the unsloth-tick check marks.
- Sonner pins toast text at 13px and action labels at 12px in its injected stylesheet, ignoring the preference; both now scale at the full text rate. The icon well tracks the glyph, and the unused built-in loader gets a defensive size override.
- The composer pill glyph slot and hover X sized through @apply use the token, including the compact variant.

### Verification

- Measured live at settings 12, 16 and 20 across twelve surfaces (sidebar, settings tabs, dropdown items, plus menu, user menu, select trigger chevron, send arrow, pill glyph, toast icon well, loader, thinking tick, toast text): standard icons compute exactly 12, 16 and 18px; toast text scales by size/16 (9.75, 13, 16.25).
- Full text sweep unchanged: 1076 element checks across three pages at 12/16/20, zero violations.
- Cross engine matrix green on Chromium, WebKit and Firefox (381 assertions); contract suite and frontend build pass.

### Tests

- Contract test pinning the --ui-icon-size token, its use by --icon-size and the scoped svg rules, and the sonner text overrides.
- The Playwright regression script asserts a .size-icon glyph computes 12px at UI font size 12.
