### PR TITLE
fix: enable XPU support and update hardcoded CUDA selections for tests

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -370,12 +370,11 @@ jobs:
             tests/python/test_fast_language_model_text_only.py \
             tests/test_bad_mappings_redirect.py \
             tests/test_prefetch_snapshot_scope.py \
-            tests/test_gemma_2b_mapper_key.py \
-            --deselect 'tests/utils/test_attention_masks.py::test_run_attention_flash_varlen_receives_window_and_softcap'
-          # The deselected test monkeypatches flash_attn_varlen_func, which is
-          # only bound on the module when `flash_attn` is importable. flash_attn
-          # requires CUDA + dev toolchain, which the CPU-only ubuntu-latest
-          # runner does not have. The other Bucket-A tests pass cleanly.
+            tests/test_gemma_2b_mapper_key.py
+          # test_run_attention_flash_varlen_receives_window_and_softcap used to be
+          # deselected here: it monkeypatches flash_attn_varlen_func, which was only
+          # bound when `flash_attn` imported, so it failed on the CPU-only runner.
+          # attention_dispatch.py now predefines both names as None, so it runs.
 
       - name: unsloth_zoo @ ${{ env.UNSLOTH_ZOO_REF }} — full pytest (CPU)
         # 106 of 111 test_* in unsloth_zoo are CPU-only. The two CUDA-skip

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -371,10 +371,9 @@ jobs:
             tests/test_bad_mappings_redirect.py \
             tests/test_prefetch_snapshot_scope.py \
             tests/test_gemma_2b_mapper_key.py
-          # test_run_attention_flash_varlen_receives_window_and_softcap used to be
-          # deselected here: it monkeypatches flash_attn_varlen_func, which was only
-          # bound when `flash_attn` imported, so it failed on the CPU-only runner.
-          # attention_dispatch.py now predefines both names as None, so it runs.
+          # test_run_attention_flash_varlen_receives_window_and_softcap was deselected
+          # until attention_dispatch.py predefined flash_attn_varlen_func as None; it
+          # monkeypatches that name, so it no longer needs flash_attn on this runner.
 
       - name: unsloth_zoo @ ${{ env.UNSLOTH_ZOO_REF }} — full pytest (CPU)
         # 106 of 111 test_* in unsloth_zoo are CPU-only. The two CUDA-skip

--- a/tests/saving/language_models/test_merge_model_perplexity_llama-3.2.py
+++ b/tests/saving/language_models/test_merge_model_perplexity_llama-3.2.py
@@ -96,12 +96,11 @@ def load_and_compute_8bit_ppl(
 if __name__ == "__main__":
     mp.set_start_method("spawn", force = True)
 
-    if torch.cuda.is_bf16_supported():
-        compute_dtype = torch.bfloat16
-        attn_implementation = "flash_attention_2"
-    else:
-        compute_dtype = torch.float16
-        attn_implementation = "sdpa"
+    from unsloth import is_bfloat16_supported
+    from unsloth.models._utils import HAS_FLASH_ATTENTION
+
+    compute_dtype = torch.bfloat16 if is_bfloat16_supported() else torch.float16
+    attn_implementation = "flash_attention_2" if HAS_FLASH_ATTENTION else "sdpa"
 
     model, tokenizer = FastLanguageModel.from_pretrained(
         model_name = "unsloth/Llama-3.2-3B-Instruct",

--- a/tests/saving/language_models/test_merge_model_perplexity_mistral.py
+++ b/tests/saving/language_models/test_merge_model_perplexity_mistral.py
@@ -121,12 +121,11 @@ def load_and_compute_8bit_ppl(
 if __name__ == "__main__":
     mp.set_start_method("spawn", force = True)
 
-    if torch.cuda.is_bf16_supported():
-        compute_dtype = torch.bfloat16
-        attn_implementation = "flash_attention_2"
-    else:
-        compute_dtype = torch.float16
-        attn_implementation = "sdpa"
+    from unsloth import is_bfloat16_supported
+    from unsloth.models._utils import HAS_FLASH_ATTENTION
+
+    compute_dtype = torch.bfloat16 if is_bfloat16_supported() else torch.float16
+    attn_implementation = "flash_attention_2" if HAS_FLASH_ATTENTION else "sdpa"
 
     model, tokenizer = FastLanguageModel.from_pretrained(
         model_name = "unsloth/mistral-7b-v0.3",

--- a/tests/saving/language_models/test_merge_model_perplexity_phi_4.py
+++ b/tests/saving/language_models/test_merge_model_perplexity_phi_4.py
@@ -98,12 +98,11 @@ def load_and_compute_8bit_ppl(
 if __name__ == "__main__":
     mp.set_start_method("spawn", force = True)
 
-    if torch.cuda.is_bf16_supported():
-        compute_dtype = torch.bfloat16
-        attn_implementation = "flash_attention_2"
-    else:
-        compute_dtype = torch.float16
-        attn_implementation = "sdpa"
+    from unsloth import is_bfloat16_supported
+    from unsloth.models._utils import HAS_FLASH_ATTENTION
+
+    compute_dtype = torch.bfloat16 if is_bfloat16_supported() else torch.float16
+    attn_implementation = "flash_attention_2" if HAS_FLASH_ATTENTION else "sdpa"
 
     model, tokenizer = FastLanguageModel.from_pretrained(
         model_name = "unsloth/Phi-4",

--- a/tests/saving/language_models/test_merged_model_perplexity_llama-3.1-8b.py
+++ b/tests/saving/language_models/test_merged_model_perplexity_llama-3.1-8b.py
@@ -95,12 +95,11 @@ def load_and_compute_8bit_ppl(
 if __name__ == "__main__":
     mp.set_start_method("spawn", force = True)
 
-    if torch.cuda.is_bf16_supported():
-        compute_dtype = torch.bfloat16
-        attn_implementation = "flash_attention_2"
-    else:
-        compute_dtype = torch.float16
-        attn_implementation = "sdpa"
+    from unsloth import is_bfloat16_supported
+    from unsloth.models._utils import HAS_FLASH_ATTENTION
+
+    compute_dtype = torch.bfloat16 if is_bfloat16_supported() else torch.float16
+    attn_implementation = "flash_attention_2" if HAS_FLASH_ATTENTION else "sdpa"
 
     model, tokenizer = FastLanguageModel.from_pretrained(
         model_name = "unsloth/Llama-3.1-8B-Instruct",

--- a/tests/saving/language_models/test_merged_model_perplexity_qwen_2.5.py
+++ b/tests/saving/language_models/test_merged_model_perplexity_qwen_2.5.py
@@ -164,12 +164,11 @@ def load_and_compute_8bit_ppl(
 if __name__ == "__main__":
     mp.set_start_method("spawn", force = True)
 
-    if torch.cuda.is_bf16_supported():
-        compute_dtype = torch.bfloat16
-        attn_implementation = "flash_attention_2"
-    else:
-        compute_dtype = torch.float16
-        attn_implementation = "sdpa"
+    from unsloth import is_bfloat16_supported
+    from unsloth.models._utils import HAS_FLASH_ATTENTION
+    
+    compute_dtype = torch.bfloat16 if is_bfloat16_supported() else torch.float16
+    attn_implementation = "flash_attention_2" if HAS_FLASH_ATTENTION else "sdpa"
 
     model, tokenizer = FastLanguageModel.from_pretrained(
         model_name = "unsloth/Qwen2.5-7B-Instruct",
@@ -209,8 +208,6 @@ if __name__ == "__main__":
         use_rslora = False,
         loftq_config = None,
     )
-
-    from unsloth import is_bfloat16_supported
 
     trainer = SFTTrainer(
         model = model,

--- a/tests/saving/language_models/test_merged_model_perplexity_qwen_2.5.py
+++ b/tests/saving/language_models/test_merged_model_perplexity_qwen_2.5.py
@@ -166,7 +166,7 @@ if __name__ == "__main__":
 
     from unsloth import is_bfloat16_supported
     from unsloth.models._utils import HAS_FLASH_ATTENTION
-    
+
     compute_dtype = torch.bfloat16 if is_bfloat16_supported() else torch.float16
     attn_implementation = "flash_attention_2" if HAS_FLASH_ATTENTION else "sdpa"
 

--- a/tests/test_fp8_tiny_e8m0.py
+++ b/tests/test_fp8_tiny_e8m0.py
@@ -11,7 +11,10 @@ dequant reference.
 import pytest
 import torch
 
-pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason = "needs CUDA")
+gpu_available = torch.cuda.is_available() or torch.xpu.is_available()
+dev = "cuda" if torch.cuda.is_available() else "xpu" if torch.xpu.is_available() else "cpu"
+
+pytestmark = pytest.mark.skipif(not gpu_available, reason = "needs CUDA or XPU")
 
 
 def _reference(X, weight, scale, block):
@@ -27,7 +30,6 @@ def test_tiny_non_tileable_forward_backward_matches_reference():
     from unsloth.kernels.fp8 import FP8BlockQuantLinear
 
     torch.manual_seed(0)
-    dev = "cuda"
     block = [128, 128]
     m, n = 8, 8  # non-tileable, in-dim % 128 != 0
     weight = torch.randn(m, n, device = dev, dtype = torch.bfloat16)  # (out=m, in=n)
@@ -50,7 +52,6 @@ def test_e8m0_scale_is_upcast_and_runs():
     if not hasattr(torch, "float8_e8m0fnu"):
         pytest.skip("torch build lacks float8_e8m0fnu")
 
-    dev = "cuda"
     m, n = 8, 8
     weight = torch.randn(m, n, device = dev, dtype = torch.bfloat16)
     scale = (torch.rand(1, 1, device = dev) + 1.0).to(torch.float8_e8m0fnu)
@@ -70,7 +71,6 @@ def test_rectangular_block_dequant_matches_reference():
     from unsloth.kernels.fp8 import _blockwise_weight_dequant_any_shape
 
     torch.manual_seed(0)
-    dev = "cuda"
     block = [64, 128]
     m, n = 64, 256  # evenly tiled: 64 % 64 == 0, 256 % 128 == 0
     weight = torch.randn(m, n, device = dev, dtype = torch.bfloat16)
@@ -94,7 +94,6 @@ def test_e8m0_scale_preserves_non_default_block_size_attr():
         pytest.skip("torch build lacks float8_e8m0fnu")
 
     torch.manual_seed(0)
-    dev = "cuda"
     block = [64, 64]
     # in-dim 96 is not divisible by block[1]=64 -> forward takes the torch dequant
     # fallback (no fp8 matmul kernel). Scale shape (2, 2) validates for [64, 64] but

--- a/tests/test_fp8_tiny_e8m0.py
+++ b/tests/test_fp8_tiny_e8m0.py
@@ -11,10 +11,14 @@ dequant reference.
 import pytest
 import torch
 
-gpu_available = torch.cuda.is_available() or torch.xpu.is_available()
-dev = "cuda" if torch.cuda.is_available() else "xpu" if torch.xpu.is_available() else "cpu"
+cuda_available = torch.cuda.is_available()
+# hasattr: torch builds predating the xpu namespace still have to import this file.
+xpu_available = hasattr(torch, "xpu") and torch.xpu.is_available()
+dev = "cuda" if cuda_available else "xpu" if xpu_available else "cpu"
 
-pytestmark = pytest.mark.skipif(not gpu_available, reason = "needs CUDA or XPU")
+pytestmark = pytest.mark.skipif(
+    not (cuda_available or xpu_available), reason = "needs CUDA or XPU"
+)
 
 
 def _reference(X, weight, scale, block):

--- a/tests/test_fp8_tiny_e8m0.py
+++ b/tests/test_fp8_tiny_e8m0.py
@@ -16,9 +16,7 @@ cuda_available = torch.cuda.is_available()
 xpu_available = hasattr(torch, "xpu") and torch.xpu.is_available()
 dev = "cuda" if cuda_available else "xpu" if xpu_available else "cpu"
 
-pytestmark = pytest.mark.skipif(
-    not (cuda_available or xpu_available), reason = "needs CUDA or XPU"
-)
+pytestmark = pytest.mark.skipif(not (cuda_available or xpu_available), reason = "needs CUDA or XPU")
 
 
 def _reference(X, weight, scale, block):

--- a/tests/test_fp8_tiny_e8m0.py
+++ b/tests/test_fp8_tiny_e8m0.py
@@ -12,7 +12,6 @@ import pytest
 import torch
 
 cuda_available = torch.cuda.is_available()
-# hasattr: torch builds predating the xpu namespace still have to import this file.
 xpu_available = hasattr(torch, "xpu") and torch.xpu.is_available()
 dev = "cuda" if cuda_available else "xpu" if xpu_available else "cpu"
 

--- a/tests/utils/perplexity_eval.py
+++ b/tests/utils/perplexity_eval.py
@@ -2,6 +2,8 @@ from tqdm import tqdm
 import torch
 import pandas as pd
 
+from unsloth.device_type import DEVICE_TYPE
+
 model_comparison_results = {}
 
 
@@ -17,7 +19,7 @@ def ppl_model(model, tokenizer, dataset):
         for begin_loc in range(0, seq_len, stride):
             end_loc = min(begin_loc + max_length, seq_len)
             trg_len = end_loc - prev_end_loc
-            input_ids = encodings.input_ids[:, begin_loc:end_loc].to("cuda")
+            input_ids = encodings.input_ids[:, begin_loc:end_loc].to(DEVICE_TYPE)
             target_ids = input_ids.clone()
             target_ids[:, :-trg_len] = -100
             pad_token_id = tokenizer.pad_token_id if tokenizer.pad_token_id is not None else 0

--- a/tests/utils/perplexity_eval.py
+++ b/tests/utils/perplexity_eval.py
@@ -2,7 +2,8 @@ from tqdm import tqdm
 import torch
 import pandas as pd
 
-from unsloth.device_type import DEVICE_TYPE
+# DEVICE_TYPE_TORCH, not DEVICE_TYPE: the latter can be "hip"/"mlx", which .to() rejects.
+from unsloth.device_type import DEVICE_TYPE_TORCH
 
 model_comparison_results = {}
 
@@ -19,7 +20,7 @@ def ppl_model(model, tokenizer, dataset):
         for begin_loc in range(0, seq_len, stride):
             end_loc = min(begin_loc + max_length, seq_len)
             trg_len = end_loc - prev_end_loc
-            input_ids = encodings.input_ids[:, begin_loc:end_loc].to(DEVICE_TYPE)
+            input_ids = encodings.input_ids[:, begin_loc:end_loc].to(DEVICE_TYPE_TORCH)
             target_ids = input_ids.clone()
             target_ids[:, :-trg_len] = -100
             pad_token_id = tokenizer.pad_token_id if tokenizer.pad_token_id is not None else 0

--- a/tests/utils/test_batched_leftpad_generation_gpu.py
+++ b/tests/utils/test_batched_leftpad_generation_gpu.py
@@ -12,8 +12,11 @@ import pytest
 import torch
 
 cuda_available = torch.cuda.is_available()
+xpu_available = torch.xpu.is_available()
+gpu_available = cuda_available or xpu_available
+device = "cuda" if cuda_available else "xpu" if xpu_available else "cpu"
 
-pytestmark = pytest.mark.skipif(not cuda_available, reason = "requires a CUDA GPU")
+pytestmark = pytest.mark.skipif(not gpu_available, reason = "requires a CUDA or XPU GPU")
 
 MODEL_NAME = "unsloth/Qwen2.5-0.5B-Instruct"
 MAX_NEW_TOKENS = 32
@@ -53,7 +56,7 @@ def _chat(tokenizer, prompt):
 
 def _generate(model, tokenizer, texts):
     inputs = tokenizer(texts, return_tensors = "pt", padding = True, add_special_tokens = False).to(
-        "cuda"
+        device
     )
     with torch.inference_mode():
         out = model.generate(

--- a/tests/utils/test_batched_leftpad_generation_gpu.py
+++ b/tests/utils/test_batched_leftpad_generation_gpu.py
@@ -4,7 +4,7 @@ Greedy generation in a left-padded batch must match solo batch-size-1
 generation for the first PREFIX_TOKENS tokens (the bug makes padded rows
 diverge into garbage immediately; a full-length match would be flaky due to
 benign batch-numerics tie-flips deep in the sequence) and must not be
-gibberish. Skipped without CUDA. Run: `python -m pytest
+gibberish. Skipped without a GPU. Run: `python -m pytest
 tests/utils/test_batched_leftpad_generation_gpu.py -v`.
 """
 
@@ -12,11 +12,22 @@ import pytest
 import torch
 
 cuda_available = torch.cuda.is_available()
-xpu_available = torch.xpu.is_available()
-gpu_available = cuda_available or xpu_available
+# hasattr: torch builds predating the xpu namespace still have to import this file.
+xpu_available = hasattr(torch, "xpu") and torch.xpu.is_available()
 device = "cuda" if cuda_available else "xpu" if xpu_available else "cpu"
 
-pytestmark = pytest.mark.skipif(not gpu_available, reason = "requires a CUDA or XPU GPU")
+# XPU currently diverges here, so run it non-strict rather than hiding the gap
+# behind a CUDA-only guard: the xfail turns green the moment XPU is fixed.
+pytestmark = [
+    pytest.mark.skipif(
+        not (cuda_available or xpu_available), reason = "requires a CUDA or XPU GPU"
+    ),
+    pytest.mark.xfail(
+        xpu_available and not cuda_available,
+        reason = "batched left-padded generation diverges on XPU",
+        strict = False,
+    ),
+]
 
 MODEL_NAME = "unsloth/Qwen2.5-0.5B-Instruct"
 MAX_NEW_TOKENS = 32

--- a/tests/utils/test_batched_leftpad_generation_gpu.py
+++ b/tests/utils/test_batched_leftpad_generation_gpu.py
@@ -12,12 +12,11 @@ import pytest
 import torch
 
 cuda_available = torch.cuda.is_available()
-# hasattr: torch builds predating the xpu namespace still have to import this file.
 xpu_available = hasattr(torch, "xpu") and torch.xpu.is_available()
 device = "cuda" if cuda_available else "xpu" if xpu_available else "cpu"
 
-# XPU currently diverges here, so run it non-strict rather than hiding the gap
-# behind a CUDA-only guard: the xfail turns green the moment XPU is fixed.
+# Non-strict rather than CUDA-only: keeps the XPU divergence visible, and goes
+# green by itself once XPU generation is fixed.
 pytestmark = [
     pytest.mark.skipif(not (cuda_available or xpu_available), reason = "requires a CUDA or XPU GPU"),
     pytest.mark.xfail(

--- a/tests/utils/test_batched_leftpad_generation_gpu.py
+++ b/tests/utils/test_batched_leftpad_generation_gpu.py
@@ -19,9 +19,7 @@ device = "cuda" if cuda_available else "xpu" if xpu_available else "cpu"
 # XPU currently diverges here, so run it non-strict rather than hiding the gap
 # behind a CUDA-only guard: the xfail turns green the moment XPU is fixed.
 pytestmark = [
-    pytest.mark.skipif(
-        not (cuda_available or xpu_available), reason = "requires a CUDA or XPU GPU"
-    ),
+    pytest.mark.skipif(not (cuda_available or xpu_available), reason = "requires a CUDA or XPU GPU"),
     pytest.mark.xfail(
         xpu_available and not cuda_available,
         reason = "batched left-padded generation diverges on XPU",

--- a/tests/utils/test_packing.py
+++ b/tests/utils/test_packing.py
@@ -44,7 +44,9 @@ def _build_packed_training_setup(tmp_path, device):
             dtype = torch.bfloat16
         else:
             dtype = torch.float16
-
+    elif device.type == "xpu":
+        dtype = torch.bfloat16
+            
     try:
         model, tokenizer = FastLanguageModel.from_pretrained(
             model_name = "hf-internal-testing/tiny-random-LlamaForCausalLM",
@@ -76,8 +78,8 @@ def _build_packed_training_setup(tmp_path, device):
         max_length = 64,
         logging_steps = 1,
         max_steps = 1,
-        fp16 = device.type == "cuda" and not torch.cuda.is_bf16_supported(),
-        bf16 = device.type == "cuda" and torch.cuda.is_bf16_supported(),
+        fp16 = dtype == torch.float16,
+        bf16 = dtype == torch.bfloat16,
         dataset_num_proc = 1,
         output_dir = str(tmp_path),
         packing = True,
@@ -974,7 +976,12 @@ def test_enable_sample_packing():
 
 
 def test_enable_sample_packing_trl_collator(tmp_path):
-    device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.xpu.is_available():
+        device = torch.device("xpu")
+    else:
+        device = torch.device("cpu")
     model, _, trainer, _ = _build_packed_training_setup(tmp_path, device)
 
     enable_sample_packing(model, trainer)
@@ -1030,7 +1037,12 @@ def test_enable_padding_free_metadata():
 
 
 def test_packing_sdpa(tmp_path):
-    device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.xpu.is_available():
+        device = torch.device("xpu")
+    else:
+        device = torch.device("cpu")
     model, batch, trainer, llama_mod = _build_packed_training_setup(tmp_path, device)
 
     assert "packed_seq_lengths" in batch

--- a/tests/utils/test_packing.py
+++ b/tests/utils/test_packing.py
@@ -46,7 +46,7 @@ def _build_packed_training_setup(tmp_path, device):
             dtype = torch.float16
     elif device.type == "xpu":
         dtype = torch.bfloat16
-            
+
     try:
         model, tokenizer = FastLanguageModel.from_pretrained(
             model_name = "hf-internal-testing/tiny-random-LlamaForCausalLM",

--- a/tests/utils/test_qat.py
+++ b/tests/utils/test_qat.py
@@ -130,8 +130,14 @@ def _test_fake_quantizers_are_called(
                     # Weight fake quantizers must always be called.
                     assert child.weight_fake_quantizer.count == 1
 
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+    elif torch.xpu.is_available():
+        device = torch.device("xpu")
+    else:
+        pytest.skip("No GPU available")
     for k, v in example_inputs.items():
-        example_inputs[k] = v.cuda()
+        example_inputs[k] = v.to(device)
     model.apply(_swap_fake_quantizers)
     model(**example_inputs)
     model.apply(_assert_fake_quantizers_are_called)

--- a/tests/utils/test_rope_scaling_drift.py
+++ b/tests/utils/test_rope_scaling_drift.py
@@ -15,18 +15,20 @@ import pytest
 import torch
 
 
-def _has_real_cuda():
-    try:
-        torch.zeros(1).to("cuda")
-        return True
-    except Exception:
-        return False
+def _has_real_gpu():
+    for backend in ("cuda", "xpu"):
+        try:
+            torch.zeros(1).to(backend)
+            return True
+        except Exception:
+            pass
+    return False
 
 
-HAS_REAL_CUDA = _has_real_cuda()
-requires_cuda = pytest.mark.skipif(
-    not HAS_REAL_CUDA,
-    reason = "LlamaRotaryEmbedding builds per-device CUDA caches in __init__",
+HAS_REAL_GPU= _has_real_gpu()
+requires_gpu = pytest.mark.skipif(
+    not HAS_REAL_GPU,
+    reason = "LlamaRotaryEmbedding builds per-device caches in __init__ (needs CUDA or XPU)",
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -360,7 +362,7 @@ def _cos_at_position(rot, position):
 # --- Layer 3: CUDA behavioral guard (real instantiation needs a device) ---
 
 
-@requires_cuda
+@requires_gpu
 def test_constructor_applies_llama3_scaling():
     config = _make_config(LLAMA3_ROPE_SCALING)
     rot = _unsloth_rotary(config)
@@ -371,7 +373,7 @@ def test_constructor_applies_llama3_scaling():
     ), "LlamaRotaryEmbedding built from a llama3 config produced unscaled inv_freq (issue #2405)."
 
 
-@requires_cuda
+@requires_gpu
 def test_constructor_unscaled_config_uses_vanilla_inv_freq():
     rot = _unsloth_rotary(_make_config(None))
     got = rot.inv_freq.float().cpu()
@@ -381,7 +383,7 @@ def test_constructor_unscaled_config_uses_vanilla_inv_freq():
     ), "LlamaRotaryEmbedding with no rope_scaling must use the vanilla inv_freq"
 
 
-@requires_cuda
+@requires_gpu
 def test_cos_cache_differs_between_scaled_and_unscaled_at_long_position():
     scaled = _unsloth_rotary(_make_config(LLAMA3_ROPE_SCALING))
     unscaled = _unsloth_rotary(_make_config(None))
@@ -397,7 +399,7 @@ def test_cos_cache_differs_between_scaled_and_unscaled_at_long_position():
     )
 
 
-@requires_cuda
+@requires_gpu
 def test_extended_cache_keeps_scaling_after_growth():
     scaled = _unsloth_rotary(_make_config(LLAMA3_ROPE_SCALING))
     # Grow past the initial cache size (mirrors long-context decode).
@@ -456,7 +458,7 @@ def _build_longrope_rotary():
     return rot, config
 
 
-@requires_cuda
+@requires_gpu
 @pytest.mark.parametrize(
     "build", [_build_llama3_rotary, _build_longrope_rotary], ids = ["llama3", "longrope"]
 )

--- a/tests/utils/test_rope_scaling_drift.py
+++ b/tests/utils/test_rope_scaling_drift.py
@@ -25,7 +25,7 @@ def _has_real_gpu():
     return False
 
 
-HAS_REAL_GPU= _has_real_gpu()
+HAS_REAL_GPU = _has_real_gpu()
 requires_gpu = pytest.mark.skipif(
     not HAS_REAL_GPU,
     reason = "LlamaRotaryEmbedding builds per-device caches in __init__ (needs CUDA or XPU)",

--- a/unsloth/utils/attention_dispatch.py
+++ b/unsloth/utils/attention_dispatch.py
@@ -31,6 +31,8 @@ from ..utils.packing import (
     build_xformers_block_causal_mask,
 )
 
+flash_attn_func = None
+flash_attn_varlen_func = None
 if HAS_FLASH_ATTENTION:
     from flash_attn import flash_attn_func, flash_attn_varlen_func
 HAS_XFORMERS = xformers is not None


### PR DESCRIPTION
## What This PR Does

Adds Intel XPU compatibility for the tests listed below found under `tests/`. Removes the hardcoded CUDA device conditions and adds XPU device option.

## Changes

**1. Merge model perplexity files under `tests/saving/language_models`**

Adds XPU compatibility for bfloat16 dtype through `unsloth.is_bfloat16_supported()`.
Detects `attn_implementation` with `HAS_FLASH_ATTENTION` for `flash_attention_2` or `sdpa`.

**2. `tests/test_fp8_tiny_e8m0.py`**

Adds XPU device to run test.

**3. `tests/utils/test_packing.py::test_packing_sdpa`**
In the function `test_packing_sdpa()`, the device used defaults to `cpu` when not on a CUDA device. The model's forward pass went through unsloth's layer `Fast_RMS_Layernorm` which causes the error `ValueError: Expected a xpu device, but got: cpu` due to a device mismatch.
Fixed with adding a XPU device condition.

The same condition is added for `test_enable_sample_packing_trl_collator` to support XPU devices. 
Also added some additions for `_build_packed_training_setup` for XPU device and bfloat16 support on XPU.

**4. `tests/utils/test_qat.py`**

Adds XPU device condition and pytest skips if no GPU is detected.

**5. `test_run_attention_flash_varlen_receives_window_and_softcap`**

Failing as devices with `HAS_FLASH_ATTENTION=False` has no defined variable `flash_attn_func`. Added initial variable assignment as `None` before the `flash_attn` import in `unsloth/utils/attention_dispatch.py`:
```python
flash_attn_func = None
flash_attn_varlen_func = None
if HAS_FLASH_ATTENTION:
    from flash_attn import flash_attn_func, flash_attn_varlen_func
```

**6. `tests/utils/test_rope_scaling_drift.py`**

Updates `requires_cuda` condition to `requires_gpu` to include XPU

**7. `tests/utils/test_batched_leftpad_generation_gpu.py`**

Updates `cuda_available` to `gpu_available` to include XPU.
However, using XPU device gives a mismatch error. Error from pytest:

```bash
____________________________ test_batched_leftpad_matches_solo_generation _____________________________
tests/utils/test_batched_leftpad_generation_gpu.py:94: in test_batched_leftpad_matches_solo_generation
    assert batched[i][:PREFIX_TOKENS] == solo[i][:PREFIX_TOKENS], (
E   AssertionError: prompt 1 ('Here is an experiment log: run'...) diverged from solo generation within the first 16 tokens inside a left-padded batch; batched left-padded generation is broken again (issues #1066, #3699).
E     solo   : 'The overall conclusion can be summarized as "the system\'s performance has consistently met or exceeded expectations in all runs." This statement encapsulates the stability of the system across'
E     batched: "The overall conclusion of this experiment is that the system's performance was consistently high across all runs, with no instances of instability or anomalies occurring during testing."
E   assert [785, 8084, 16688, 315, 419, 9342, 374, 429, 279, 1849, 594, 5068, 572, 20699, 1550, 3941] == [785, 8084, 16688, 646, 387, 68629, 438, 330, 1782, 1849, 594, 5068, 702, 20699, 2270, 476]
E     
E     At index 3 diff: 315 != 646
E     
E     Full diff:
E       [
E           785,
E           8084,
E           16688,
E     +     315,
E     -     646,
E     ?     - ^
E     +     419,
E     ?      ^^
E     +     9342,
E     -     387,
E     ?      -
E     +     374,
E     ?       +
E     -     68629,
E     ?     ^^^
E     +     429,
E     ?     ^
E     +     279,
E     -     438,
E     -     330,
E     -     1782,
E           1849,
E           594,
E           5068,
E     -     702,
E     ?      -
E     +     572,
E     ?     +
E           20699,
E     -     2270,
E     -     476,
E     +     1550,
E     +     3941,
E       ]
```

## Validation

All tests tested and passing on Intel Arc Pro B60 24GB (XPU), except for `tests/utils/test_batched_leftpad_generation_gpu.py` which fails.