### PR TITLE
Fix MLX inference Transformers sidecar activation order

### DIFF
--- a/studio/backend/core/inference/worker.py
+++ b/studio/backend/core/inference/worker.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import Any
 
 logger = get_logger(__name__)
-from utils.hardware import apply_gpu_ids
+from utils.hardware import apply_gpu_ids, is_apple_silicon
 
 _SHARE_OBJECT_MAX_BYTES = 1 << 20
 _SHARE_OBJECT_ERROR_SIZE = -1
@@ -801,10 +801,7 @@ def run_inference_process(
     # ── 0. MLX fast-path — skip torch/transformers ──
     _ensure_backend_on_path()
 
-    from utils.hardware import hardware as _hw
-
-    _hw.detect_hardware()
-    if _hw.DEVICE == _hw.DeviceType.MLX:
+    if is_apple_silicon():
         # Non-fatal: fall through with the installed version, but log the cause
         # instead of swallowing it (issue #6103).
         try:
@@ -816,6 +813,11 @@ def run_inference_process(
                 model_name,
                 exc,
             )
+
+    from utils.hardware import hardware as _hw
+
+    _hw.detect_hardware()
+    if _hw.DEVICE == _hw.DeviceType.MLX:
         try:
             from core.inference.mlx_inference import MLXInferenceBackend, _init_mlx_distributed
 

--- a/studio/backend/tests/test_mlx_inference_backend.py
+++ b/studio/backend/tests/test_mlx_inference_backend.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
+import json
+import subprocess
 import sys
 import types
 from contextlib import contextmanager
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -374,6 +377,128 @@ def test_worker_share_object_receives_distributed_payload(monkeypatch):
 
     response = responses[0]
     assert response["object"] == shared_obj
+
+
+def test_worker_activates_mlx_sidecar_before_hardware_detection(tmp_path):
+    backend_dir = Path(__file__).resolve().parent.parent
+    fake_modules = tmp_path / "base"
+    sidecar = tmp_path / ".venv_t5_530"
+    packages = {
+        fake_modules / "transformers" / "__init__.py": '__version__ = "4.57.6"\n',
+        fake_modules / "mlx" / "__init__.py": "",
+        fake_modules / "mlx" / "core.py": "",
+        fake_modules / "mlx_lm" / "__init__.py": "import transformers\n",
+        fake_modules / "mlx_lm" / "sample_utils.py": "",
+        fake_modules / "mlx_vlm" / "__init__.py": "",
+        sidecar / "transformers" / "__init__.py": '__version__ = "5.3.0"\n',
+    }
+    for path, contents in packages.items():
+        path.parent.mkdir(parents = True, exist_ok = True)
+        path.write_text(contents)
+
+    script = r"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.environ["FAKE_MODULES"])
+from core.inference import worker
+from utils.hardware import hardware
+import utils.mlx_repair as mlx_repair
+import utils.transformers_version as transformers_version
+
+bootstrap_roots = sorted(
+    {
+        name.split(".", 1)[0]
+        for name in sys.modules
+        if name.split(".", 1)[0]
+        in {
+            "huggingface_hub",
+            "mlx",
+            "mlx_lm",
+            "mlx_vlm",
+            "torch",
+            "transformers",
+            "unsloth",
+            "unsloth_zoo",
+        }
+    }
+)
+assert not bootstrap_roots, f"worker bootstrap imported ML modules: {bootstrap_roots}"
+
+worker.is_apple_silicon = lambda: True
+hardware.is_apple_silicon = lambda: True
+hardware._has_torch = lambda: False
+mlx_repair._mlx_versions_satisfy_minimums = lambda: True
+transformers_version._VENV_T5_530_DIR = os.environ["SIDECAR"]
+transformers_version._ensure_venv_t5_530_exists = lambda: True
+
+observed = {"bootstrap_roots": bootstrap_roots}
+
+def capture_active_version(_backend, _config, _responses):
+    module = sys.modules["transformers"]
+    observed["active"] = module.__version__
+    observed["file"] = module.__file__
+    observed["device"] = hardware.DEVICE.value
+
+class CommandQueue:
+    def get(self, timeout):
+        return {"type": "shutdown"}
+
+class ResponseQueue:
+    def put(self, _response):
+        pass
+
+worker._handle_load = capture_active_version
+worker.run_inference_process(
+    cmd_queue = CommandQueue(),
+    resp_queue = ResponseQueue(),
+    cancel_event = None,
+    config = {
+        "model_name": "Ministral-3-regression",
+        "hf_token": "",
+        "resolved_gpu_ids": None,
+        "device_backend": "mlx",
+    },
+)
+observed["tier"] = transformers_version.get_transformers_tier(
+    "Ministral-3-regression"
+)
+print("RESULT " + json.dumps(observed, sort_keys = True))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd = backend_dir,
+        env = {
+            **__import__("os").environ,
+            "FAKE_MODULES": str(fake_modules),
+            "SIDECAR": str(sidecar),
+            "UNSLOTH_STUDIO_HOME": str(tmp_path),
+            "HF_HOME": str(tmp_path / "hf"),
+            "HF_HUB_CACHE": str(tmp_path / "hf" / "hub"),
+            "HF_HUB_OFFLINE": "1",
+            "TRANSFORMERS_OFFLINE": "1",
+        },
+        capture_output = True,
+        text = True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    result_line = next(
+        (
+            line.removeprefix("RESULT ")
+            for line in result.stdout.splitlines()
+            if line.startswith("RESULT ")
+        ),
+        None,
+    )
+    assert result_line is not None, result.stdout + result.stderr
+    observed = json.loads(result_line)
+    assert observed["bootstrap_roots"] == []
+    assert observed["tier"] == "530"
+    assert observed["device"] == "mlx"
+    assert observed["active"] == "5.3.0"
+    assert observed["file"] == str(sidecar / "transformers" / "__init__.py")
 
 
 def test_worker_share_object_oversize_notifies_peers(monkeypatch):


### PR DESCRIPTION
## Summary

- Activate the model-selected Transformers sidecar before the Apple Silicon MLX hardware and stack-health probe can import ML runtime packages.
- Add an offline fresh-process regression that exercises the real worker entrypoint, tier routing, sidecar activation, hardware detection, and the `mlx_lm` import that previously pinned the base Transformers package.
- Keep the existing MLX detection, repair, loading, and subprocess lifecycle after activation.

## Root cause

The inference worker called `detect_hardware()` before `_activate_transformers_version()`. On Apple Silicon, hardware detection validates the MLX stack by importing `mlx_lm`, which transitively imported the base Transformers 4.57.6 package. Tier selection still chose the correct 5.x sidecar afterward, but prepending that sidecar to `sys.path` could not replace the already cached `sys.modules["transformers"]`.

This caused Transformers 5 tokenizer and model configurations to run under 4.57.6. The failure was not specific to Ministral or `TokenizersBackend`; the same startup order affected MLX models routed to the 5.3, 5.5, 5.10, or latest sidecars.

## Confirmed VLM cases fixed

A local before/after run using the same release environment and cached candidates confirmed that this startup-order change fixes these modality cases:

- Gemma4 image processing: tokenizer-only fallback under Transformers 4.57.6 becomes a real `Gemma4Processor` under the selected 5.5 sidecar.
- Gemma4 audio processing: the same processor degradation is repaired by activating the 5.5 sidecar before MLX imports.
- GLM4V image inference: the `TokenizersBackend` load failure becomes successful processor loading and image inference under the selected 5.3 sidecar.
- Qwen3.6 image inference: the `Only returning PyTorch tensors is currently supported` failure becomes successful image inference under the selected 5.3 sidecar.

Other VLM failures investigated separately are not fixed by selecting another Transformers sidecar and are outside this PR.

## Compatibility

- Ordinary MLX models continue to select the default Transformers 4.57.6 tier.
- Existing 5.3, 5.5, 5.10, and latest-sidecar routing remains unchanged.
- MLX stack health checks and self-repair still run before model loading.
- CUDA, ROCm, XPU, CPU, export, training, and non-Apple inference startup ordering is unchanged.
- Fresh-spawn isolation and the existing inference worker lifecycle are preserved.

## Validation

- Demonstrated the regression test fails under the previous ordering with active Transformers 4.57.6 and passes after the change with 5.3.0.
- Loaded `mlx-community/Ministral-3-3B-Instruct-2512-4bit` completely through the Studio orchestrator and MLX inference backend under Transformers 5.3.0.
- Loaded `mlx-community/SmolLM-135M-Instruct-4bit` through the same Studio path under the default Transformers 4.57.6 tier.
- Verified fresh worker bootstrap imports none of `transformers`, `torch`, `mlx`, `mlx_lm`, `mlx_vlm`, `unsloth`, `unsloth_zoo`, or `huggingface_hub`.
- 86 inference and lifecycle tests passed.
- 262 Transformers routing, sidecar, and MLX repair tests passed.
- 56 hardware dispatch tests passed with 2 skipped.
- 46 hardware utility tests passed with the repository CI documented CUDA-only case deselected on Apple Silicon.
- All 32 MLX inference backend tests passed.
- Ruff, formatting hooks, and diff checks passed.
