### PR TITLE
Fix Studio model picker toolbar overflow

### DIFF
--- a/studio/frontend/src/features/model-picker/components/model-selector.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector.tsx
@@ -301,12 +301,12 @@ const HUB_SECTION_TABS: { value: string; label: string; icon?: ReactNode }[] = [
   {
     value: "recommended",
     label: "Recommended",
-    icon: <HugeiconsIcon icon={StarIcon} className="size-3.5" />,
+    icon: <HugeiconsIcon icon={StarIcon} className="size-3.5 shrink-0" />,
   },
   {
     value: "downloaded",
     label: "On Device",
-    icon: <HugeiconsIcon icon={Download01Icon} className="size-3.5" />,
+    icon: <HugeiconsIcon icon={Download01Icon} className="size-3.5 shrink-0" />,
   },
 ];
 
@@ -384,7 +384,9 @@ function ModelSelectorContent({
             {
               value: "connected",
               label: "Connected",
-              icon: <HugeiconsIcon icon={CloudIcon} className="size-3.5" />,
+              icon: (
+                <HugeiconsIcon icon={CloudIcon} className="size-3.5 shrink-0" />
+              ),
             },
           ]
         : HUB_SECTION_TABS,

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -3064,13 +3064,18 @@ export function HubModelPicker({
           ) : null}
         </div>
 
-        {/* Section tabs then the format and sort dropdowns, packed left with one
-          uniform gap between every control. The box is sized so the last
-          dropdown still lands on Search Hub's edge. Dropdowns hide on Connected. */}
-        <div className="flex items-center gap-2">
+        {/* Keep the left-packed controls on one line while they fit, then wrap
+          whole groups before their intrinsic widths cross the picker edge.
+          Dropdowns hide on Connected. */}
+        <div
+          className={cn(
+            "flex flex-wrap items-center gap-2",
+            hasConnected ? "-mr-4" : "-mr-2",
+          )}
+        >
           {sectionToggle}
           {showConnected ? null : (
-            <div className="flex items-center gap-2">
+            <div className="flex max-w-full min-w-0 flex-wrap items-center gap-2">
               <HubOptionMenu
                 value={formatFilter}
                 options={FORMAT_FILTER_OPTIONS}

--- a/studio/frontend/src/features/model-picker/components/model-selector/pill-tabs.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pill-tabs.tsx
@@ -29,7 +29,8 @@ export function PillTabs({
   className?: string;
   compact?: boolean;
   /** Size each tab to its label instead of equal widths. The active tab carries
-   * the pill background directly (the toggle never animates). */
+   * the pill background directly (the toggle never animates). Tabs only shrink
+   * when their combined intrinsic width exceeds the available space. */
   fit?: boolean;
 }) {
   const activeIndex = Math.max(
@@ -84,7 +85,7 @@ export function PillTabs({
           onClick={() => onValueChange(tab.value)}
           className={cn(
             "relative z-10 inline-flex items-center justify-center gap-1.5 rounded-full transition-colors",
-            fit ? "shrink-0" : "min-w-0 flex-1",
+            fit ? "min-w-0 shrink" : "min-w-0 flex-1",
             compact ? "h-7 px-2.5 text-ui-11" : "h-9 px-3 text-ui-12p5",
             value === tab.value
               ? "text-foreground"
@@ -97,7 +98,7 @@ export function PillTabs({
           )}
         >
           {tab.icon}
-          {tab.label}
+          <span className="min-w-0 truncate">{tab.label}</span>
         </button>
       ))}
     </div>

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -219,7 +219,7 @@ def test_local_picker_rows_require_chat_capability():
 
 def test_model_picker_toolbar_reflows_before_crossing_picker_edge():
     """The content-sized section tabs and fixed-width dropdowns must reflow,
-    while an individually oversized tab group must shrink its labels."""
+    while an oversized tab group must shrink labels but preserve its icons."""
     picker = _read("features/model-picker/components/model-selector/pickers.tsx")
     assert '"flex flex-wrap items-center gap-2"' in picker
     assert 'hasConnected ? "-mr-4" : "-mr-2"' in picker
@@ -228,6 +228,11 @@ def test_model_picker_toolbar_reflows_before_crossing_picker_edge():
     tabs = _read("features/model-picker/components/model-selector/pill-tabs.tsx")
     assert 'fit ? "min-w-0 shrink" : "min-w-0 flex-1"' in tabs
     assert '<span className="min-w-0 truncate">{tab.label}</span>' in tabs
+
+    selector = _read("features/model-picker/components/model-selector.tsx")
+    assert 'icon={StarIcon} className="size-3.5 shrink-0"' in selector
+    assert 'icon={Download01Icon} className="size-3.5 shrink-0"' in selector
+    assert 'icon={CloudIcon} className="size-3.5 shrink-0"' in selector
 
 
 def test_native_picked_gguf_template_read_through_lease():

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -217,6 +217,19 @@ def test_local_picker_rows_require_chat_capability():
     assert "row.capabilities.canChat" in memo.group(0)
 
 
+def test_model_picker_toolbar_reflows_before_crossing_picker_edge():
+    """The content-sized section tabs and fixed-width dropdowns must reflow,
+    while an individually oversized tab group must shrink its labels."""
+    picker = _read("features/model-picker/components/model-selector/pickers.tsx")
+    assert '"flex flex-wrap items-center gap-2"' in picker
+    assert 'hasConnected ? "-mr-4" : "-mr-2"' in picker
+    assert '"flex max-w-full min-w-0 flex-wrap items-center gap-2"' in picker
+
+    tabs = _read("features/model-picker/components/model-selector/pill-tabs.tsx")
+    assert 'fit ? "min-w-0 shrink" : "min-w-0 flex-1"' in tabs
+    assert '<span className="min-w-0 truncate">{tab.label}</span>' in tabs
+
+
 def test_native_picked_gguf_template_read_through_lease():
     """A native (picked / drag-drop) GGUF's path lives only in its signed lease,
     and the picker chat-template GET has no lease plumbing, so the default


### PR DESCRIPTION
## Summary

- keep the model-picker tabs and format/sort controls within the picker by wrapping their existing semantic groups only when space is constrained
- bound individually oversized fitted tab groups and truncate only visible label text as a last resort while retaining complete accessible names
- add focused contract coverage for the responsive layout invariants

## Root cause

The picker uses fixed desktop widths while its toolbar combined a content-sized, non-shrinking tab group with two fixed-width dropdowns in a non-wrapping flex row. Increasing the configurable UI font size widened the tabs without widening the picker, so the toolbar had no legal shrink or wrap opportunity and its final controls crossed the right boundary. Connected providers added another tab and changed the picker width, producing additional constrained cases.

## Behavior and impact

When sufficient space is available, the picker, tabs, and dropdowns retain their previous positions and dimensions. Under constrained widths or larger UI fonts, the existing groups wrap before crossing the picker edge. If the fitted tab group alone is wider than the available space, its visible labels can truncate while the controls retain their order, full accessible names, dropdown behavior, keyboard navigation, and focus handling.

## Validation

```text
python -m pytest tests/studio/test_model_picker_contracts.py -q
npm run typecheck
npm run build
npx eslint src/features/model-picker/components/model-selector/pickers.tsx src/features/model-picker/components/model-selector/pill-tabs.tsx
npx biome check src/features/model-picker/components/model-selector/pickers.tsx src/features/model-picker/components/model-selector/pill-tabs.tsx
git diff --check
```

The focused test suite passed with 36 tests. Typecheck and production build passed. Focused ESLint completed with no errors, and the remaining lint diagnostics were pre-existing warnings.

Browser validation covered viewport widths 420, 520, 646, and 1280 px; UI font sizes 12, 16, and 20; and Connected providers absent or present. All 24 combinations passed DOM descendant-to-picker bounding-box containment. A 320 px stress check also remained contained. Recommended, On Device, and Connected states; alternate format and sort selections; opened dropdown placement; keyboard selection; roving tab focus; and trigger-focus restoration were also checked. At 1280 px with the default UI font, the picker and control bounding boxes were unchanged from baseline.