### PR TITLE
fix(studio): reject Vulkan diffusion gpu_ids before Phase 1 teardown

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -126,8 +126,7 @@ LLAMA_SERVER_NOT_FOUND_DETAIL = (
     "then try again. (Advanced: set LLAMA_SERVER_PATH to an existing binary.)"
 )
 
-# Shared by the pre-teardown checks, the post-metadata defense and the route
-# preflight so the rejection wording stays consistent (#7205).
+# Shared by the route, pre-teardown and post-metadata rejections (#7205).
 _VULKAN_DIFFUSION_GPU_IDS_ERROR = (
     "GPU selection (gpu_ids) is not supported for a DiffusionGemma "
     "GGUF on a Vulkan llama.cpp build: the diffusion runner selects "
@@ -6432,10 +6431,7 @@ class LlamaCppBackend:
                         f"present. Available Vulkan devices: {sorted(_pf_probed)}."
                     )
 
-            # On Vulkan an explicit gpu_ids request cannot be mapped from ggml
-            # ordinals to the diffusion runner's CUDA physical index, so classify
-            # the header before killing the healthy server (#7205). Phase 2 below
-            # reuses any cached/downloaded preflight path.
+            # Classify before killing the healthy server (#7205); Phase 2 reuses this path.
             _preflight_model_path = None
             if is_vulkan_backend and gpu_ids and hf_repo:
                 _resolved_repo = _resolve_repo_id_casing(hf_repo)
@@ -6539,9 +6535,7 @@ class LlamaCppBackend:
             # Block-diffusion GGUFs (DiffusionGemma) cannot run on llama-server;
             # serve them with the diffusion runner (same OpenAI-compat interface).
             if self._is_diffusion:
-                # The runner pins its child by CUDA visibility mask, so a ggml Vulkan
-                # ordinal cannot be honored. Final defense: the route and pre-teardown
-                # preflights already reject before Phase 1.
+                # Final defense: route and pre-teardown preflights reject before Phase 1.
                 if is_vulkan_backend and gpu_ids:
                     raise ValueError(_VULKAN_DIFFUSION_GPU_IDS_ERROR)
                 # Not a tensor/layer GGUF: clear any preserved-fallback flag from a

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -4684,9 +4684,7 @@ class LlamaCppBackend:
         return probe._is_diffusion
 
     def _reject_vulkan_diffusion_gpu_ids_before_teardown(
-        self,
-        gguf_path: str,
-        model_identifier: str,
+        self, gguf_path: str, model_identifier: str
     ) -> None:
         """Reject Vulkan + gpu_ids for diffusion GGUFs before Phase 1 teardown."""
         if self._gguf_path_is_diffusion(gguf_path, model_identifier):
@@ -6434,7 +6432,6 @@ class LlamaCppBackend:
                 if hf_variant:
                     try:
                         from hub.utils.gguf import resolve_local_gguf_path
-
                         _cached_gguf = resolve_local_gguf_path(hf_repo, hf_variant)
                     except Exception:
                         _cached_gguf = None

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -126,8 +126,9 @@ LLAMA_SERVER_NOT_FOUND_DETAIL = (
     "then try again. (Advanced: set LLAMA_SERVER_PATH to an existing binary.)"
 )
 
-# Shared by route preflight, load-time pre-teardown checks, and the post-metadata
-# diffusion defense so the rejection text stays consistent (#7205).
+# Shared by the load-time pre-teardown checks and the post-metadata diffusion
+# defense so the rejection text stays consistent (#7205). The route preflight
+# raises the same wording as its own HTTP 400.
 _VULKAN_DIFFUSION_GPU_IDS_ERROR = (
     "GPU selection (gpu_ids) is not supported for a DiffusionGemma "
     "GGUF on a Vulkan llama.cpp build: the diffusion runner selects "

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -126,6 +126,16 @@ LLAMA_SERVER_NOT_FOUND_DETAIL = (
     "then try again. (Advanced: set LLAMA_SERVER_PATH to an existing binary.)"
 )
 
+# Shared by route preflight, load-time pre-teardown checks, and the post-metadata
+# diffusion defense so the rejection text stays consistent (#7205).
+_VULKAN_DIFFUSION_GPU_IDS_ERROR = (
+    "GPU selection (gpu_ids) is not supported for a DiffusionGemma "
+    "GGUF on a Vulkan llama.cpp build: the diffusion runner selects "
+    "its device by CUDA physical index, which has no defined mapping "
+    "to ggml Vulkan device ordinals. Omit gpu_ids to use the default "
+    "device."
+)
+
 
 # llama-server can serve HTTP 200 while running a model entirely on CPU when a
 # GPU backend fails to init (#5807 / #5106 / #5830). Classify the startup log so
@@ -4673,6 +4683,15 @@ class LlamaCppBackend:
         probe._read_gguf_metadata(gguf_path)
         return probe._is_diffusion
 
+    def _reject_vulkan_diffusion_gpu_ids_before_teardown(
+        self,
+        gguf_path: str,
+        model_identifier: str,
+    ) -> None:
+        """Reject Vulkan + gpu_ids for diffusion GGUFs before Phase 1 teardown."""
+        if self._gguf_path_is_diffusion(gguf_path, model_identifier):
+            raise ValueError(_VULKAN_DIFFUSION_GPU_IDS_ERROR)
+
     def _read_gguf_metadata(self, gguf_path: str) -> None:
         """Read context_length, architecture params, and chat_template from a GGUF header.
 
@@ -6395,12 +6414,12 @@ class LlamaCppBackend:
                         f"present. Available Vulkan devices: {sorted(_pf_probed)}."
                     )
 
-            # A remote uncached GGUF may only reveal that it needs the
-            # single-device diffusion runner after download. On Vulkan, an
-            # explicit gpu_ids request cannot be mapped from ggml ordinals to
-            # that runner's CUDA physical index. Download and classify the main
-            # file before killing the healthy server so this late rejection is
-            # non-destructive. The Phase 2 call below reuses this cached path.
+            # A GGUF may only reveal that it needs the single-device diffusion
+            # runner after its header is read. On Vulkan, an explicit gpu_ids
+            # request cannot be mapped from ggml ordinals to that runner's CUDA
+            # physical index. Classify the main file before killing the healthy
+            # server so this late rejection is non-destructive (#7205). The Phase
+            # 2 call below reuses any cached/downloaded preflight path.
             _preflight_model_path = None
             if is_vulkan_backend and gpu_ids and hf_repo:
                 _resolved_repo = _resolve_repo_id_casing(hf_repo)
@@ -6411,20 +6430,37 @@ class LlamaCppBackend:
                         hf_repo,
                     )
                     hf_repo = _resolved_repo
-                with _hf_offline_if_dns_dead():
-                    _preflight_model_path = self._download_gguf(
-                        hf_repo = hf_repo,
-                        hf_variant = hf_variant,
-                        hf_token = hf_token,
+                _cached_gguf = None
+                if hf_variant:
+                    try:
+                        from hub.utils.gguf import resolve_local_gguf_path
+
+                        _cached_gguf = resolve_local_gguf_path(hf_repo, hf_variant)
+                    except Exception:
+                        _cached_gguf = None
+                if _cached_gguf and Path(_cached_gguf).is_file():
+                    self._reject_vulkan_diffusion_gpu_ids_before_teardown(
+                        _cached_gguf,
+                        model_identifier,
                     )
-                if self._gguf_path_is_diffusion(_preflight_model_path, model_identifier):
-                    raise ValueError(
-                        "GPU selection (gpu_ids) is not supported for a DiffusionGemma "
-                        "GGUF on a Vulkan llama.cpp build: the diffusion runner selects "
-                        "its device by CUDA physical index, which has no defined mapping "
-                        "to ggml Vulkan device ordinals. Omit gpu_ids to use the default "
-                        "device."
+                else:
+                    with _hf_offline_if_dns_dead():
+                        _preflight_model_path = self._download_gguf(
+                            hf_repo = hf_repo,
+                            hf_variant = hf_variant,
+                            hf_token = hf_token,
+                        )
+                    self._reject_vulkan_diffusion_gpu_ids_before_teardown(
+                        _preflight_model_path,
+                        model_identifier,
                     )
+            elif is_vulkan_backend and gpu_ids and gguf_path and not hf_repo:
+                if not Path(gguf_path).is_file():
+                    raise FileNotFoundError(f"GGUF file not found: {gguf_path}")
+                self._reject_vulkan_diffusion_gpu_ids_before_teardown(
+                    gguf_path,
+                    model_identifier,
+                )
 
             # ── Phase 1: kill old process (under lock, fast) ──────────
             with self._lock:
@@ -6503,16 +6539,10 @@ class LlamaCppBackend:
             if self._is_diffusion:
                 # The diffusion runner pins its child by CUDA visibility mask, so a
                 # ggml Vulkan ordinal cannot be honored (wrong GPU / CPU fallback).
-                # Route and remote-download preflights reject before teardown; keep
-                # this as a final defense if classification ever disagrees.
+                # Route and pre-teardown preflights reject before Phase 1; keep this
+                # as a final defense if classification ever disagrees.
                 if is_vulkan_backend and gpu_ids:
-                    raise ValueError(
-                        "GPU selection (gpu_ids) is not supported for a DiffusionGemma "
-                        "GGUF on a Vulkan llama.cpp build: the diffusion runner selects "
-                        "its device by CUDA physical index, which has no defined mapping "
-                        "to ggml Vulkan device ordinals. Omit gpu_ids to use the default "
-                        "device."
-                    )
+                    raise ValueError(_VULKAN_DIFFUSION_GPU_IDS_ERROR)
                 # Not a tensor/layer GGUF: clear any preserved-fallback flag from a
                 # prior load (this path skips the command builder that clears it).
                 self._layer_preserves_tensor_intent = False

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -126,9 +126,8 @@ LLAMA_SERVER_NOT_FOUND_DETAIL = (
     "then try again. (Advanced: set LLAMA_SERVER_PATH to an existing binary.)"
 )
 
-# Shared by the load-time pre-teardown checks and the post-metadata diffusion
-# defense so the rejection text stays consistent (#7205). The route preflight
-# raises the same wording as its own HTTP 400.
+# Shared by the pre-teardown checks, the post-metadata defense and the route
+# preflight so the rejection wording stays consistent (#7205).
 _VULKAN_DIFFUSION_GPU_IDS_ERROR = (
     "GPU selection (gpu_ids) is not supported for a DiffusionGemma "
     "GGUF on a Vulkan llama.cpp build: the diffusion runner selects "
@@ -6433,12 +6432,10 @@ class LlamaCppBackend:
                         f"present. Available Vulkan devices: {sorted(_pf_probed)}."
                     )
 
-            # A GGUF may only reveal that it needs the single-device diffusion
-            # runner after its header is read. On Vulkan, an explicit gpu_ids
-            # request cannot be mapped from ggml ordinals to that runner's CUDA
-            # physical index. Classify the main file before killing the healthy
-            # server so this late rejection is non-destructive (#7205). The Phase
-            # 2 call below reuses any cached/downloaded preflight path.
+            # On Vulkan an explicit gpu_ids request cannot be mapped from ggml
+            # ordinals to the diffusion runner's CUDA physical index, so classify
+            # the header before killing the healthy server (#7205). Phase 2 below
+            # reuses any cached/downloaded preflight path.
             _preflight_model_path = None
             if is_vulkan_backend and gpu_ids and hf_repo:
                 _resolved_repo = _resolve_repo_id_casing(hf_repo)
@@ -6542,10 +6539,9 @@ class LlamaCppBackend:
             # Block-diffusion GGUFs (DiffusionGemma) cannot run on llama-server;
             # serve them with the diffusion runner (same OpenAI-compat interface).
             if self._is_diffusion:
-                # The diffusion runner pins its child by CUDA visibility mask, so a
-                # ggml Vulkan ordinal cannot be honored (wrong GPU / CPU fallback).
-                # Route and pre-teardown preflights reject before Phase 1; keep this
-                # as a final defense if classification ever disagrees.
+                # The runner pins its child by CUDA visibility mask, so a ggml Vulkan
+                # ordinal cannot be honored. Final defense: the route and pre-teardown
+                # preflights already reject before Phase 1.
                 if is_vulkan_backend and gpu_ids:
                     raise ValueError(_VULKAN_DIFFUSION_GPU_IDS_ERROR)
                 # Not a tensor/layer GGUF: clear any preserved-fallback flag from a

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -6428,29 +6428,16 @@ class LlamaCppBackend:
                         hf_repo,
                     )
                     hf_repo = _resolved_repo
-                _cached_gguf = None
-                if hf_variant:
-                    try:
-                        from hub.utils.gguf import resolve_local_gguf_path
-                        _cached_gguf = resolve_local_gguf_path(hf_repo, hf_variant)
-                    except Exception:
-                        _cached_gguf = None
-                if _cached_gguf and Path(_cached_gguf).is_file():
-                    self._reject_vulkan_diffusion_gpu_ids_before_teardown(
-                        _cached_gguf,
-                        model_identifier,
+                with _hf_offline_if_dns_dead():
+                    _preflight_model_path = self._download_gguf(
+                        hf_repo = hf_repo,
+                        hf_variant = hf_variant,
+                        hf_token = hf_token,
                     )
-                else:
-                    with _hf_offline_if_dns_dead():
-                        _preflight_model_path = self._download_gguf(
-                            hf_repo = hf_repo,
-                            hf_variant = hf_variant,
-                            hf_token = hf_token,
-                        )
-                    self._reject_vulkan_diffusion_gpu_ids_before_teardown(
-                        _preflight_model_path,
-                        model_identifier,
-                    )
+                self._reject_vulkan_diffusion_gpu_ids_before_teardown(
+                    _preflight_model_path,
+                    model_identifier,
+                )
             elif is_vulkan_backend and gpu_ids and gguf_path and not hf_repo:
                 if not Path(gguf_path).is_file():
                     raise FileNotFoundError(f"GGUF file not found: {gguf_path}")

--- a/studio/backend/tests/test_gpu_memory_mode.py
+++ b/studio/backend/tests/test_gpu_memory_mode.py
@@ -702,6 +702,16 @@ def test_remote_vulkan_diffusion_preflight_runs_before_teardown(monkeypatch):
     assert "model_path = _preflight_model_path or self._download_gguf(" in src
 
 
+def test_local_vulkan_diffusion_preflight_runs_before_teardown():
+    src = inspect.getsource(llama_cpp_module.LlamaCppBackend.load_model)
+    local_preflight = src.index(
+        "self._reject_vulkan_diffusion_gpu_ids_before_teardown(\n"
+        "                    gguf_path,"
+    )
+    teardown = src.index("# ── Phase 1: kill old process")
+    assert local_preflight < teardown
+
+
 def test_remote_vulkan_diffusion_rejection_keeps_active_server(monkeypatch):
     backend = LlamaCppBackend()
     killed = []
@@ -731,6 +741,28 @@ def test_remote_vulkan_diffusion_rejection_keeps_active_server(monkeypatch):
             hf_repo = "owner/model",
             hf_variant = "Q4_K_M",
             model_identifier = "owner/model",
+            gpu_ids = [0],
+        )
+
+    assert killed == []
+
+
+def test_local_vulkan_diffusion_rejection_keeps_active_server(monkeypatch, tmp_path):
+    gguf_path = tmp_path / "diffusion.gguf"
+    gguf_path.write_bytes(b"GGUF")
+
+    backend = LlamaCppBackend()
+    killed = []
+    monkeypatch.setattr(backend, "_find_llama_server_binary", lambda **_kwargs: "/bin/llama")
+    monkeypatch.setattr(backend, "_is_vulkan_backend", lambda _binary = None: True)
+    monkeypatch.setattr(backend, "_get_gpu_memory", lambda _binary = None: [(0, 1024, 2048)])
+    monkeypatch.setattr(backend, "_gguf_path_is_diffusion", lambda *_args: True)
+    monkeypatch.setattr(backend, "_kill_process", lambda: killed.append(True))
+
+    with pytest.raises(ValueError, match = "DiffusionGemma"):
+        backend.load_model(
+            gguf_path = str(gguf_path),
+            model_identifier = "local/diffusion",
             gpu_ids = [0],
         )
 

--- a/studio/backend/tests/test_gpu_memory_mode.py
+++ b/studio/backend/tests/test_gpu_memory_mode.py
@@ -705,8 +705,7 @@ def test_remote_vulkan_diffusion_preflight_runs_before_teardown(monkeypatch):
 def test_local_vulkan_diffusion_preflight_runs_before_teardown():
     src = inspect.getsource(llama_cpp_module.LlamaCppBackend.load_model)
     local_preflight = src.index(
-        "self._reject_vulkan_diffusion_gpu_ids_before_teardown(\n"
-        "                    gguf_path,"
+        "self._reject_vulkan_diffusion_gpu_ids_before_teardown(\n                    gguf_path,"
     )
     teardown = src.index("# ── Phase 1: kill old process")
     assert local_preflight < teardown

--- a/studio/backend/tests/test_gpu_memory_mode.py
+++ b/studio/backend/tests/test_gpu_memory_mode.py
@@ -773,7 +773,12 @@ class _ReachedServerStart(Exception):
     """Marks a load getting past the pre-teardown preflight."""
 
 
-def _write_gguf_header(path: Path, architecture: str, *, diffusion: bool = False) -> str:
+def _write_gguf_header(
+    path: Path,
+    architecture: str,
+    *,
+    diffusion: bool = False,
+) -> str:
     """Smallest GGUF the header probe can classify: arch, plus the canvas marker."""
 
     def _kv_str(key: str, value: str) -> bytes:

--- a/studio/backend/tests/test_gpu_memory_mode.py
+++ b/studio/backend/tests/test_gpu_memory_mode.py
@@ -22,6 +22,7 @@ and MoE offload itself (``--fit off``). These tests pin:
 from __future__ import annotations
 
 import inspect
+import struct
 import sys
 import types as _types
 from pathlib import Path
@@ -762,6 +763,90 @@ def test_local_vulkan_diffusion_rejection_keeps_active_server(monkeypatch, tmp_p
         backend.load_model(
             gguf_path = str(gguf_path),
             model_identifier = "local/diffusion",
+            gpu_ids = [0],
+        )
+
+    assert killed == []
+
+
+class _ReachedServerStart(Exception):
+    """Marks a load getting past the pre-teardown preflight."""
+
+
+def _write_gguf_header(path: Path, architecture: str, *, diffusion: bool = False) -> str:
+    """Smallest GGUF the header probe can classify: arch, plus the canvas marker."""
+
+    def _kv_str(key: str, value: str) -> bytes:
+        kb, vb = key.encode(), value.encode()
+        return (
+            struct.pack("<Q", len(kb)) + kb + struct.pack("<I", 8) + struct.pack("<Q", len(vb)) + vb
+        )
+
+    def _kv_u32(key: str, value: int) -> bytes:
+        kb = key.encode()
+        return struct.pack("<Q", len(kb)) + kb + struct.pack("<I", 4) + struct.pack("<I", value)
+
+    body = _kv_str("general.architecture", architecture)
+    if diffusion:
+        body += _kv_u32("diffusion.canvas_length", 256)
+    path.write_bytes(struct.pack("<IIQQ", 0x46554747, 3, 0, 2 if diffusion else 1) + body)
+    return str(path)
+
+
+def _vulkan_pinned_backend(monkeypatch, killed: list) -> LlamaCppBackend:
+    backend = LlamaCppBackend()
+    monkeypatch.setattr(backend, "_find_llama_server_binary", lambda **_kwargs: "/bin/llama")
+    monkeypatch.setattr(backend, "_is_vulkan_backend", lambda _binary = None: True)
+    monkeypatch.setattr(backend, "_get_gpu_memory", lambda _binary = None: [(0, 1024, 2048)])
+    monkeypatch.setattr(backend, "_kill_process", lambda: killed.append(True))
+    return backend
+
+
+def test_local_vulkan_pre_teardown_reads_the_real_gguf_header(monkeypatch, tmp_path):
+    # The pre-teardown branch must classify from the header, not from the
+    # Vulkan + gpu_ids combination alone, so a normal GGUF still loads.
+    killed = []
+    backend = _vulkan_pinned_backend(monkeypatch, killed)
+    monkeypatch.setattr(
+        backend,
+        "_wait_for_vram_settle",
+        lambda **_kwargs: (_ for _ in ()).throw(_ReachedServerStart()),
+    )
+
+    with pytest.raises(_ReachedServerStart):
+        backend.load_model(
+            gguf_path = _write_gguf_header(tmp_path / "chat.gguf", "llama"),
+            model_identifier = "local/chat",
+            gpu_ids = [0],
+        )
+
+    assert killed == [True]
+
+
+def test_local_vulkan_diffusion_header_rejects_before_teardown(monkeypatch, tmp_path):
+    # Same path, real DiffusionGemma canvas marker: rejected with the server intact.
+    killed = []
+    backend = _vulkan_pinned_backend(monkeypatch, killed)
+
+    with pytest.raises(ValueError, match = "DiffusionGemma"):
+        backend.load_model(
+            gguf_path = _write_gguf_header(tmp_path / "d.gguf", "gemma3", diffusion = True),
+            model_identifier = "local/diffusion",
+            gpu_ids = [0],
+        )
+
+    assert killed == []
+
+
+def test_local_vulkan_missing_gguf_is_reported_before_teardown(monkeypatch, tmp_path):
+    # The existence check the preflight needs must not cost the live model either.
+    killed = []
+    backend = _vulkan_pinned_backend(monkeypatch, killed)
+
+    with pytest.raises(FileNotFoundError):
+        backend.load_model(
+            gguf_path = str(tmp_path / "absent.gguf"),
+            model_identifier = "local/missing",
             gpu_ids = [0],
         )
 

--- a/studio/backend/tests/test_gpu_memory_mode.py
+++ b/studio/backend/tests/test_gpu_memory_mode.py
@@ -748,10 +748,8 @@ def test_remote_vulkan_diffusion_rejection_keeps_active_server(monkeypatch):
 
 
 def test_remote_vulkan_preflight_download_failure_keeps_active_server(monkeypatch, tmp_path):
-    # An incomplete cache (missing shard, no disk space, offline hub) must surface
-    # from the pre-teardown _download_gguf, never from Phase 2 after the kill: a
-    # resolvable shard-1 file does not prove the variant is complete, so the
-    # download has to run first even when such a file is resolvable.
+    # A resolvable shard-1 file does not prove the variant is complete, so download
+    # failures must surface from the pre-teardown _download_gguf, not after the kill.
     import hub.utils.gguf as hub_gguf
 
     cached_shard = tmp_path / "model-00001-of-00003.gguf"

--- a/studio/backend/tests/test_gpu_memory_mode.py
+++ b/studio/backend/tests/test_gpu_memory_mode.py
@@ -747,6 +747,59 @@ def test_remote_vulkan_diffusion_rejection_keeps_active_server(monkeypatch):
     assert killed == []
 
 
+def test_remote_vulkan_preflight_download_failure_keeps_active_server(monkeypatch, tmp_path):
+    # An incomplete cache (missing split shard, no disk space, offline hub) must
+    # surface from the pre-teardown _download_gguf, never from Phase 2 after the
+    # kill. A locally resolvable main/shard-1 file does NOT prove the variant is
+    # complete, so short-circuiting the preflight on it would classify a header
+    # and then tear the live server down on the Phase 2 download. Pin that the
+    # download runs first even when such a file is resolvable.
+    import hub.utils.gguf as hub_gguf
+
+    cached_shard = tmp_path / "model-00001-of-00003.gguf"
+    cached_shard.write_bytes(b"GGUF")
+    monkeypatch.setattr(
+        hub_gguf,
+        "resolve_local_gguf_path",
+        lambda _repo, _variant: str(cached_shard),
+    )
+
+    for failure in (
+        FileNotFoundError("shard 2 of 3 missing"),
+        OSError("[Errno 28] No space left on device"),
+        ConnectionError("hub unreachable"),
+    ):
+        backend = LlamaCppBackend()
+        order = []
+
+        def _download(_failure = failure, **_kwargs):
+            order.append("download")
+            raise _failure
+
+        monkeypatch.setattr(backend, "_find_llama_server_binary", lambda **_kwargs: "/bin/llama")
+        monkeypatch.setattr(backend, "_is_vulkan_backend", lambda _binary = None: True)
+        monkeypatch.setattr(backend, "_get_gpu_memory", lambda _binary = None: [(0, 1024, 2048)])
+        monkeypatch.setattr(backend, "_download_gguf", _download)
+        monkeypatch.setattr(backend, "_gguf_path_is_diffusion", lambda *_args: False)
+        monkeypatch.setattr(backend, "_kill_process", lambda: order.append("kill"))
+        monkeypatch.setattr(llama_cpp_module, "_resolve_repo_id_casing", lambda repo: repo)
+        monkeypatch.setattr(
+            llama_cpp_module,
+            "_hf_offline_if_dns_dead",
+            lambda: __import__("contextlib").nullcontext(),
+        )
+
+        with pytest.raises(type(failure)):
+            backend.load_model(
+                hf_repo = "owner/model",
+                hf_variant = "Q4_K_M",
+                model_identifier = "owner/model",
+                gpu_ids = [0],
+            )
+
+        assert order == ["download"], failure
+
+
 def test_local_vulkan_diffusion_rejection_keeps_active_server(monkeypatch, tmp_path):
     gguf_path = tmp_path / "diffusion.gguf"
     gguf_path.write_bytes(b"GGUF")

--- a/studio/backend/tests/test_gpu_memory_mode.py
+++ b/studio/backend/tests/test_gpu_memory_mode.py
@@ -748,12 +748,10 @@ def test_remote_vulkan_diffusion_rejection_keeps_active_server(monkeypatch):
 
 
 def test_remote_vulkan_preflight_download_failure_keeps_active_server(monkeypatch, tmp_path):
-    # An incomplete cache (missing split shard, no disk space, offline hub) must
-    # surface from the pre-teardown _download_gguf, never from Phase 2 after the
-    # kill. A locally resolvable main/shard-1 file does NOT prove the variant is
-    # complete, so short-circuiting the preflight on it would classify a header
-    # and then tear the live server down on the Phase 2 download. Pin that the
-    # download runs first even when such a file is resolvable.
+    # An incomplete cache (missing shard, no disk space, offline hub) must surface
+    # from the pre-teardown _download_gguf, never from Phase 2 after the kill: a
+    # resolvable shard-1 file does not prove the variant is complete, so the
+    # download has to run first even when such a file is resolvable.
     import hub.utils.gguf as hub_gguf
 
     cached_shard = tmp_path / "model-00001-of-00003.gguf"
@@ -861,8 +859,7 @@ def _vulkan_pinned_backend(monkeypatch, killed: list) -> LlamaCppBackend:
 
 
 def test_local_vulkan_pre_teardown_reads_the_real_gguf_header(monkeypatch, tmp_path):
-    # The pre-teardown branch must classify from the header, not from the
-    # Vulkan + gpu_ids combination alone, so a normal GGUF still loads.
+    # Classify from the header, not from Vulkan + gpu_ids alone: normal GGUFs load.
     killed = []
     backend = _vulkan_pinned_backend(monkeypatch, killed)
     monkeypatch.setattr(
@@ -897,7 +894,7 @@ def test_local_vulkan_diffusion_header_rejects_before_teardown(monkeypatch, tmp_
 
 
 def test_local_vulkan_missing_gguf_is_reported_before_teardown(monkeypatch, tmp_path):
-    # The existence check the preflight needs must not cost the live model either.
+    # The preflight existence check must not cost the live model either.
     killed = []
     backend = _vulkan_pinned_backend(monkeypatch, killed)
 


### PR DESCRIPTION
## Summary

Fixes #7205.

When loading a DiffusionGemma GGUF with explicit `gpu_ids` on a Vulkan llama.cpp build, `LlamaCppBackend.load_model` used to run Phase 1 (`_kill_process()`) before it could read the GGUF header and reject the unsupported combination. That tore down the active model and then returned 400.

This PR classifies diffusion GGUFs **before** Phase 1 teardown:

- **Local `gguf_path`**: read the header via `_gguf_path_is_diffusion` before killing the server
- **HF remote**: try a cached local GGUF via `resolve_local_gguf_path` first; download only when uncached (existing behavior)
- Shared rejection message via `_VULKAN_DIFFUSION_GPU_IDS_ERROR` and `_reject_vulkan_diffusion_gpu_ids_before_teardown()`

## Test plan

- [x] `test_local_vulkan_diffusion_preflight_runs_before_teardown`
- [x] `test_local_vulkan_diffusion_rejection_keeps_active_server`
- [x] Existing remote diffusion preflight tests still pass