### PR TITLE
Studio: keep automatic model loading toast visible until completion

### DIFF
--- a/studio/frontend/src/components/ui/sonner.tsx
+++ b/studio/frontend/src/components/ui/sonner.tsx
@@ -8,8 +8,8 @@ import {
   MultiplicationSignCircleIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { Spinner } from "@/components/ui/spinner";
 import { useTheme } from "@/features/settings/stores/theme-store";
+import { createLoadingToastIcon } from "@/lib/toast";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
 // Make toast text selectable. Sonner's onPointerDown calls setPointerCapture(),
@@ -78,7 +78,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
             />
           ),
           // App-wide arc spinner so loading toasts match the "Downloading model" toast.
-          loading: <Spinner className="size-4 text-muted-foreground" />,
+          loading: createLoadingToastIcon(),
         }}
         style={
           {

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -1476,12 +1476,33 @@ async function autoLoadSmallestModel(): Promise<{
   const trustRemoteCode = store.params.trustRemoteCode ?? false;
   const specSettings = resolveSpeculativeSettingsForLoad();
   const lastLoaded = readLastLocalModelLoad();
-  const toastId = toast.loading("Loading a model…", {
+  let autoLoadToastDismissed = false;
+  const toastId = toast.message("Loading a model…", {
     description: lastLoaded
       ? "Loading last used model."
       : "Auto-selecting the smallest downloaded model.",
+    duration: Number.POSITIVE_INFINITY,
     closeButton: true,
+    onDismiss: () => {
+      autoLoadToastDismissed = true;
+    },
   });
+  const updateAutoLoadToast = (message: string, description: string): void => {
+    if (autoLoadToastDismissed) return;
+    toast.message(message, {
+      id: toastId,
+      description,
+      duration: Number.POSITIVE_INFINITY,
+    });
+  };
+  const showAutoLoadSuccess = (message: string): void => {
+    const options = { description: undefined, duration: 5000 };
+    if (autoLoadToastDismissed) {
+      toast.success(message, options);
+      return;
+    }
+    toast.success(message, { ...options, id: toastId });
+  };
   let blockedByTrustRemoteCode = false;
   let hadNonTrustFailure = false;
   let loadAttempts = 0;
@@ -1737,7 +1758,7 @@ async function autoLoadSmallestModel(): Promise<{
         ggufVariant: candidate.ggufVariant,
       });
     }
-    toast.success(candidate.successLabel, { id: toastId });
+    showAutoLoadSuccess(candidate.successLabel);
     return true;
   }
   try {
@@ -1763,10 +1784,10 @@ async function autoLoadSmallestModel(): Promise<{
                 isAutoLoadableGgufVariant(entry),
             );
             if (variant) {
-              toast.loading("Loading last used model…", {
-                id: toastId,
-                description: `${repo.repo_id} (${variant.quant})`,
-              });
+              updateAutoLoadToast(
+                "Loading last used model…",
+                `${repo.repo_id} (${variant.quant})`,
+              );
               if (
                 await loadAutoLoadCandidate({
                   id: repo.repo_id,
@@ -1791,10 +1812,7 @@ async function autoLoadSmallestModel(): Promise<{
         const repo = findCachedRepo(modelRepos, lastLoaded.id);
         if (repo) {
           try {
-            toast.loading("Loading last used model…", {
-              id: toastId,
-              description: repo.repo_id,
-            });
+            updateAutoLoadToast("Loading last used model…", repo.repo_id);
             if (
               await loadAutoLoadCandidate({
                 id: repo.repo_id,
@@ -1815,10 +1833,10 @@ async function autoLoadSmallestModel(): Promise<{
           }
         }
       }
-      toast.loading("Loading a model…", {
-        id: toastId,
-        description: "Auto-selecting the smallest downloaded model.",
-      });
+      updateAutoLoadToast(
+        "Loading a model…",
+        "Auto-selecting the smallest downloaded model.",
+      );
     }
 
     // GGUF first: smallest-total-size repo, then its smallest variant.
@@ -1909,11 +1927,10 @@ async function autoLoadSmallestModel(): Promise<{
     }
 
     // No cached models — try downloading a small default GGUF.
-    toast.loading("Downloading a small model…", {
-      id: toastId,
-      description:
-        "No downloaded models found. Fetching Qwen3.5-4B-MTP (UD-Q4_K_XL).",
-    });
+    updateAutoLoadToast(
+      "Downloading a small model…",
+      "No downloaded models found. Fetching Qwen3.5-4B-MTP (UD-Q4_K_XL).",
+    );
     try {
       const rt = useChatRuntimeStore.getState();
       if (
@@ -2009,7 +2026,7 @@ async function autoLoadSmallestModel(): Promise<{
         kind: "gguf",
         ggufVariant: "UD-Q4_K_XL",
       });
-      toast.success("Loaded Qwen3.5-4B-MTP (UD-Q4_K_XL)", { id: toastId });
+      showAutoLoadSuccess("Loaded Qwen3.5-4B-MTP (UD-Q4_K_XL)");
       return { loaded: true, blockedByTrustRemoteCode: false };
     } catch {
       toast.dismiss(toastId);

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -1476,11 +1476,10 @@ async function autoLoadSmallestModel(): Promise<{
   const trustRemoteCode = store.params.trustRemoteCode ?? false;
   const specSettings = resolveSpeculativeSettingsForLoad();
   const lastLoaded = readLastLocalModelLoad();
-  const toastId = toast("Loading a model…", {
+  const toastId = toast.loading("Loading a model…", {
     description: lastLoaded
       ? "Loading last used model."
       : "Auto-selecting the smallest downloaded model.",
-    duration: 5000,
     closeButton: true,
   });
   let blockedByTrustRemoteCode = false;
@@ -1764,10 +1763,9 @@ async function autoLoadSmallestModel(): Promise<{
                 isAutoLoadableGgufVariant(entry),
             );
             if (variant) {
-              toast("Loading last used model…", {
+              toast.loading("Loading last used model…", {
                 id: toastId,
                 description: `${repo.repo_id} (${variant.quant})`,
-                duration: 5000,
               });
               if (
                 await loadAutoLoadCandidate({
@@ -1793,10 +1791,9 @@ async function autoLoadSmallestModel(): Promise<{
         const repo = findCachedRepo(modelRepos, lastLoaded.id);
         if (repo) {
           try {
-            toast("Loading last used model…", {
+            toast.loading("Loading last used model…", {
               id: toastId,
               description: repo.repo_id,
-              duration: 5000,
             });
             if (
               await loadAutoLoadCandidate({
@@ -1818,10 +1815,9 @@ async function autoLoadSmallestModel(): Promise<{
           }
         }
       }
-      toast("Loading a model…", {
+      toast.loading("Loading a model…", {
         id: toastId,
         description: "Auto-selecting the smallest downloaded model.",
-        duration: 5000,
       });
     }
 
@@ -1913,11 +1909,10 @@ async function autoLoadSmallestModel(): Promise<{
     }
 
     // No cached models — try downloading a small default GGUF.
-    toast("Downloading a small model…", {
+    toast.loading("Downloading a small model…", {
       id: toastId,
       description:
         "No downloaded models found. Fetching Qwen3.5-4B-MTP (UD-Q4_K_XL).",
-      duration: 30000,
     });
     try {
       const rt = useChatRuntimeStore.getState();

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -6,7 +6,7 @@ import { resolveInitialConfig } from "@/features/model-picker";
 import { projectHasSources } from "@/features/rag/api/rag-api";
 import { apiUrl } from "@/lib/api-base";
 import { parseParamCountB } from "@/lib/model-size";
-import { toast } from "@/lib/toast";
+import { createLoadingToastIcon, toast } from "@/lib/toast";
 import type { MessageTiming, ToolCallMessagePart } from "@assistant-ui/core";
 import type { ChatModelAdapter } from "@assistant-ui/react";
 import { parsePartialJsonObject } from "assistant-stream/utils";
@@ -1483,6 +1483,7 @@ async function autoLoadSmallestModel(): Promise<{
       : "Auto-selecting the smallest downloaded model.",
     duration: Number.POSITIVE_INFINITY,
     closeButton: true,
+    icon: createLoadingToastIcon(),
     onDismiss: () => {
       autoLoadToastDismissed = true;
     },
@@ -1496,7 +1497,11 @@ async function autoLoadSmallestModel(): Promise<{
     });
   };
   const showAutoLoadSuccess = (message: string): void => {
-    const options = { description: undefined, duration: 5000 };
+    const options = {
+      description: undefined,
+      duration: 5000,
+      icon: undefined,
+    };
     if (autoLoadToastDismissed) {
       toast.success(message, options);
       return;

--- a/studio/frontend/src/features/recipe-studio/hooks/use-recipe-executions.ts
+++ b/studio/frontend/src/features/recipe-studio/hooks/use-recipe-executions.ts
@@ -2,7 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { getInferenceStatus, loadModel } from "@/features/chat";
-import { toast } from "@/lib/toast";
+import { createLoadingToastIcon, toast } from "@/lib/toast";
 import { toastError } from "@/shared/toast";
 import { useCallback, useEffect, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
@@ -243,6 +243,7 @@ async function loadLocalModelSelection(
     description: "Starting the local inference server for this recipe.",
     duration: Number.POSITIVE_INFINITY,
     closeButton: true,
+    icon: createLoadingToastIcon(),
     onDismiss: () => {
       loadToastDismissed = true;
     },
@@ -273,7 +274,11 @@ async function loadLocalModelSelection(
       // biome-ignore lint/style/useNamingConvention: api schema
       tensor_parallel: false,
     });
-    const successOptions = { description: undefined, duration: 2000 };
+    const successOptions = {
+      description: undefined,
+      duration: 2000,
+      icon: undefined,
+    };
     if (loadToastDismissed) {
       toast.success(`Loaded ${modelLabel}`, successOptions);
     } else {

--- a/studio/frontend/src/features/recipe-studio/hooks/use-recipe-executions.ts
+++ b/studio/frontend/src/features/recipe-studio/hooks/use-recipe-executions.ts
@@ -238,8 +238,14 @@ async function loadLocalModelSelection(
 ): Promise<string | null> {
   const { target, ggufVariant } = selection;
   const modelLabel = ggufVariant ? `${target} (${ggufVariant})` : target;
-  const toastId = toast.loading(`Loading ${modelLabel}...`, {
+  let loadToastDismissed = false;
+  const toastId = toast.message(`Loading ${modelLabel}...`, {
     description: "Starting the local inference server for this recipe.",
+    duration: Number.POSITIVE_INFINITY,
+    closeButton: true,
+    onDismiss: () => {
+      loadToastDismissed = true;
+    },
   });
   try {
     const isGguf = GGUF_MODEL_PATTERN.test(target) || Boolean(ggufVariant);
@@ -267,7 +273,12 @@ async function loadLocalModelSelection(
       // biome-ignore lint/style/useNamingConvention: api schema
       tensor_parallel: false,
     });
-    toast.success(`Loaded ${modelLabel}`, { id: toastId, duration: 2000 });
+    const successOptions = { description: undefined, duration: 2000 };
+    if (loadToastDismissed) {
+      toast.success(`Loaded ${modelLabel}`, successOptions);
+    } else {
+      toast.success(`Loaded ${modelLabel}`, { ...successOptions, id: toastId });
+    }
     return null;
   } catch (error) {
     toast.dismiss(toastId);

--- a/studio/frontend/src/lib/toast.ts
+++ b/studio/frontend/src/lib/toast.ts
@@ -4,5 +4,15 @@
 // Re-export of sonner. Swipe blocking lives on the Toaster via
 // `swipeDirections={[]}`, so no per-toast dismissible override.
 
+import { Spinner } from "@/components/ui/spinner";
+import { createElement } from "react";
+
+function createLoadingToastIcon() {
+  return createElement(Spinner, {
+    className: "size-4 text-muted-foreground",
+  });
+}
+
 export { toast } from "sonner";
 export type { ExternalToast } from "sonner";
+export { createLoadingToastIcon };

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -73,6 +73,25 @@ def test_autoload_records_backend_loaded_model_identity():
     assert "m.id === loadedModelId" in autoload
 
 
+def test_chat_autoload_toast_matches_explicit_load_lifetime():
+    """Send-triggered autoload must stay visible until the load settles, just
+    like the explicit model-loading toast, instead of expiring after 5 seconds."""
+    src = _read("features/chat/api/chat-adapter.ts")
+    auto_load = src.split("async function autoLoadSmallestModel", 1)[1]
+    auto_load = auto_load.split("export function createOpenAIStreamAdapter", 1)[0]
+    assert auto_load.count("toast.loading(") >= 5
+    # Sonner keeps loading toasts open by type. Do not store Infinity on the
+    # toast because the success update reuses its id and would inherit it.
+    assert "duration: Infinity" not in auto_load
+    assert "duration: 5000" not in auto_load
+    assert "duration: 30000" not in auto_load
+    assert auto_load.count("toast.success(") >= 2
+    assert auto_load.count("toast.dismiss(toastId)") >= 4
+
+    explicit_load = _read("features/chat/hooks/use-chat-model-runtime.ts")
+    assert "duration: Infinity" in explicit_load
+
+
 def test_rollback_restores_native_lease_expiry_with_token():
     """A failed model switch that rolls back to a previously loaded picked GGUF
     must restore the lease expiry paired with the token, never the token alone

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -73,23 +73,44 @@ def test_autoload_records_backend_loaded_model_identity():
     assert "m.id === loadedModelId" in autoload
 
 
-def test_chat_autoload_toast_matches_explicit_load_lifetime():
-    """Send-triggered autoload must stay visible until the load settles, just
-    like the explicit model-loading toast, instead of expiring after 5 seconds."""
+def test_chat_autoload_toast_is_persistent_and_dismissible():
+    """Send-triggered autoload stays visible until it settles but remains
+    dismissible, matching the explicit model-loading toast's lifetime."""
     src = _read("features/chat/api/chat-adapter.ts")
     auto_load = src.split("async function autoLoadSmallestModel", 1)[1]
     auto_load = auto_load.split("export function createOpenAIStreamAdapter", 1)[0]
-    assert auto_load.count("toast.loading(") >= 5
-    # Sonner keeps loading toasts open by type. Do not store Infinity on the
-    # toast because the success update reuses its id and would inherit it.
-    assert "duration: Infinity" not in auto_load
-    assert "duration: 5000" not in auto_load
+    assert "toast.loading(" not in auto_load
+    assert "const updateAutoLoadToast =" in auto_load
+    assert "if (autoLoadToastDismissed) return;" in auto_load
+    assert auto_load.count("toast.message(") == 2
+    assert auto_load.count("updateAutoLoadToast(") >= 4
+    assert "duration: Number.POSITIVE_INFINITY" in auto_load
+    assert "closeButton: true" in auto_load
+    assert "onDismiss:" in auto_load
+    # Terminal success uses a fresh finite toast after manual progress dismissal.
+    assert "showAutoLoadSuccess" in auto_load
+    assert "description: undefined" in auto_load
+    assert "duration: 5000" in auto_load
     assert "duration: 30000" not in auto_load
-    assert auto_load.count("toast.success(") >= 2
     assert auto_load.count("toast.dismiss(toastId)") >= 4
 
     explicit_load = _read("features/chat/hooks/use-chat-model-runtime.ts")
     assert "duration: Infinity" in explicit_load
+
+
+def test_recipe_model_load_toast_is_persistent_and_dismissible():
+    """Recipe model loading uses the same dismissible persistent lifecycle as
+    chat loading because both call the non-abortable loadModel API."""
+    src = _read("features/recipe-studio/hooks/use-recipe-executions.ts")
+    model_load = src.split("async function loadLocalModelSelection", 1)[1]
+    model_load = model_load.split("function getLocalModelLoadPlanForPayload", 1)[0]
+    assert "toast.loading(" not in model_load
+    assert "toast.message(" in model_load
+    assert "duration: Number.POSITIVE_INFINITY" in model_load
+    assert "closeButton: true" in model_load
+    assert "onDismiss:" in model_load
+    assert "description: undefined" in model_load
+    assert "duration: 2000" in model_load
 
 
 def test_rollback_restores_native_lease_expiry_with_token():

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -86,10 +86,12 @@ def test_chat_autoload_toast_is_persistent_and_dismissible():
     assert auto_load.count("updateAutoLoadToast(") >= 4
     assert "duration: Number.POSITIVE_INFINITY" in auto_load
     assert "closeButton: true" in auto_load
+    assert "icon: createLoadingToastIcon()" in auto_load
     assert "onDismiss:" in auto_load
     # Terminal success uses a fresh finite toast after manual progress dismissal.
     assert "showAutoLoadSuccess" in auto_load
     assert "description: undefined" in auto_load
+    assert "icon: undefined" in auto_load
     assert "duration: 5000" in auto_load
     assert "duration: 30000" not in auto_load
     assert auto_load.count("toast.dismiss(toastId)") >= 4
@@ -108,9 +110,18 @@ def test_recipe_model_load_toast_is_persistent_and_dismissible():
     assert "toast.message(" in model_load
     assert "duration: Number.POSITIVE_INFINITY" in model_load
     assert "closeButton: true" in model_load
+    assert "icon: createLoadingToastIcon()" in model_load
     assert "onDismiss:" in model_load
     assert "description: undefined" in model_load
+    assert "icon: undefined" in model_load
     assert "duration: 2000" in model_load
+
+    toast_lib = _read("lib/toast.ts")
+    assert "createElement(Spinner" in toast_lib
+    assert 'className: "size-4 text-muted-foreground"' in toast_lib
+
+    sonner = _read("components/ui/sonner.tsx")
+    assert "loading: createLoadingToastIcon()" in sonner
 
 
 def test_rollback_restores_native_lease_expiry_with_token():


### PR DESCRIPTION
The regular model-loading toast stays visible until loading finishes, but the send-triggered automatic loader used five-second timeouts for cached models and a 30-second timeout for the default fallback. The model load could continue for minutes after its status disappeared.

This aligns the sibling paths by making the automatic loading toast persistent too. It now remains visible until the load succeeds or fails, including when the user switches conversations.

## Reproduction

1. Start Studio without a loaded model.
2. Create a new chat and send a message.
3. Let the automatic model load run for more than five seconds.

Before this change, the toast disappeared while the model was still loading and the pending message was still waiting. Switching to another conversation and returning made the missing status especially noticeable, but navigation was not required to trigger the timeout.

## Fix

- use a persistent loading toast for every automatic-load stage
- keep one toast identity across remembered-model selection and fallback attempts
- resolve the persistent toast on success and dismiss it on failure
- add a source contract comparing automatic and explicit loading lifetimes

## Verification

- `pytest -q tests/studio/test_model_picker_contracts.py` (37 passed)
- `npm run typecheck`
- `npm run build`
- targeted ESLint check has no new findings; the two existing restricted-import findings remain unchanged
