### PR TITLE
install.sh: do not assume sudo consent when there is no terminal

### DIFF
--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -223,6 +223,7 @@ jobs:
         run: |
           set -e
           for s in \
+              tests/sh/test_apt_distro_prompt.sh \
               tests/sh/test_get_torch_index_url.sh \
               tests/sh/test_mac_intel_compat.sh \
               tests/sh/test_node_decision.sh \

--- a/install.sh
+++ b/install.sh
@@ -685,6 +685,30 @@ _smart_apt_install() {
 
     # Step 3: Escalate -- need elevated permissions for remaining packages
     if command -v sudo >/dev/null 2>&1; then
+        # `sudo -n` succeeds only when no password is required. Without a
+        # terminal we cannot supply one, and every sudo call below closes stdin,
+        # so probe first rather than letting sudo die on its own prompt (#7307).
+        if sudo -n true >/dev/null 2>&1; then
+            _sudo_unattended=true
+        else
+            _sudo_unattended=false
+        fi
+
+        # Nothing to prompt on and sudo wants a password: this cannot succeed.
+        # Exit with the same actionable message as the no-sudo path instead of
+        # assuming consent and failing inside sudo.
+        if [ ! -r /dev/tty ] && [ "$_sudo_unattended" != true ]; then
+            echo ""
+            echo "    These packages are missing and need sudo to install:"
+            echo "    $_STILL_MISSING"
+            echo "    Detected $(_apt_distro_description)."
+            echo "    No terminal is available to confirm on and sudo requires a"
+            echo "    password here, so this cannot be done unattended."
+            echo "    Please install them first, then re-run Unsloth Studio setup:"
+            echo "    sudo apt-get update -y && sudo apt-get install -y $_STILL_MISSING"
+            exit 1
+        fi
+
         _ad_desc="$(_apt_distro_description)"
         echo ""
         echo "    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
@@ -695,10 +719,13 @@ _smart_apt_install() {
         echo "    from your distro's official repositories (not a third-party tarball)."
         echo "    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
         echo ""
-        printf "    Accept? [Y/n] "
         if [ -r /dev/tty ]; then
+            printf "    Accept? [Y/n] "
             read -r REPLY </dev/tty || REPLY="y"
         else
+            # Unattended with passwordless sudo: no one can answer, and asking
+            # would only leave a dangling prompt in the log.
+            echo "    No terminal to confirm on; proceeding with passwordless sudo."
             REPLY="y"
         fi
         case "$REPLY" in

--- a/install.sh
+++ b/install.sh
@@ -656,10 +656,10 @@ _apt_distro_description() {
 }
 
 # ── Helper: can the controlling terminal actually be opened for reading? ──
-# `test -r /dev/tty` only checks the device node's permission bits, and those
-# look fine inside containers and systemd units where open() then fails with
-# ENXIO. Probe with a real open instead. The subshell is required: in dash a
-# failed redirection on the special builtin `:` exits the whole script.
+# `test -r` only checks permission bits, which look fine in containers and
+# systemd units where open() then fails with ENXIO. Probe with a real open.
+# The subshell is required: in dash a failed redirection on the special
+# builtin `:` exits the whole script.
 _can_read_tty() {
     ( : </dev/tty ) >/dev/null 2>&1
 }
@@ -706,9 +706,9 @@ _smart_apt_install() {
         echo ""
         if _can_read_tty; then
             printf "    Accept? [Y/n] "
-            # The device opened, so a failed read is EOF, not consent. Decline,
-            # as the autostart prompt below already does. Enter is still yes:
-            # that is a successful read of an empty line.
+            # The device opened, so a failed read is EOF, not consent: decline,
+            # as the autostart prompt below does. Enter is still yes (a
+            # successful read of an empty line).
             read -r REPLY </dev/tty || REPLY="n"
             case "$REPLY" in
                 [nN]*)
@@ -722,15 +722,13 @@ _smart_apt_install() {
             sudo apt-get install -y $_STILL_MISSING </dev/null
         else
             # Nobody can answer a prompt or type a password here. -n makes sudo
-            # refuse outright rather than prompt into a closed stdin, which is
-            # how #7307 died. Probe with the real commands: `sudo -l` answers
-            # whether they are *authorized*, not whether running them needs
-            # authentication. -k ignores any cached timestamp, so this succeeds
-            # only under a real NOPASSWD rule and not because someone ran sudo
-            # in another shell minutes ago. Per sudo(8), -k alongside a command
-            # ignores the cached credentials for this invocation and "will not
-            # update the user's cached credentials", so an interactive session
-            # elsewhere does not have to re-authenticate afterwards.
+            # refuse rather than prompt into a closed stdin, which is how #7307
+            # died. Probe with the real commands: `sudo -l` answers whether they
+            # are *authorized*, not whether running them needs authentication.
+            # -k ignores any cached timestamp, so only a real NOPASSWD rule gets
+            # through, not someone's sudo in another shell minutes ago. Per
+            # sudo(8), -k alongside a command ignores the cached credentials and
+            # "will not update" them, so other sessions keep theirs.
             echo "    No terminal to confirm on; trying passwordless sudo."
             if sudo -n -k apt-get update -y </dev/null &&
                 sudo -n -k apt-get install -y $_STILL_MISSING </dev/null; then
@@ -739,11 +737,10 @@ _smart_apt_install() {
                 echo ""
                 echo "    Could not install these packages: $_STILL_MISSING"
                 echo "    Detected ${_ad_desc}."
-                # Either sudo refused (no NOPASSWD rule) or apt itself failed on
-                # a bad repo, a dpkg lock, a network outage. sudo exits 1 on an
-                # auth or config problem but passes the command's own status
-                # through otherwise, and it also exits 1 when the command cannot
-                # be executed, so state both rather than guessing a cause.
+                # Either sudo refused, or apt failed on a bad repo, dpkg lock or
+                # network outage. sudo exits 1 on an auth/config problem and
+                # when the command cannot be executed, but otherwise passes the
+                # command's own status through, so state both causes.
                 echo "    Either sudo needs a password here, or apt-get itself"
                 echo "    failed; see the error above. With no terminal to"
                 echo "    authenticate on, this cannot be done unattended."

--- a/install.sh
+++ b/install.sh
@@ -706,7 +706,11 @@ _smart_apt_install() {
         echo ""
         if _can_read_tty; then
             printf "    Accept? [Y/n] "
-            read -r REPLY </dev/tty || REPLY="y"
+            # An unreadable answer declines. _can_read_tty proved the device
+            # opens, so a failed read here is EOF, not consent; treating it as
+            # "yes" escalates on input nobody supplied, which is the same bug
+            # this branch exists to remove. Matches the autostart prompt below.
+            read -r REPLY </dev/tty || REPLY="n"
             case "$REPLY" in
                 [nN]*)
                     echo ""

--- a/install.sh
+++ b/install.sh
@@ -706,10 +706,9 @@ _smart_apt_install() {
         echo ""
         if _can_read_tty; then
             printf "    Accept? [Y/n] "
-            # An unreadable answer declines. _can_read_tty proved the device
-            # opens, so a failed read here is EOF, not consent; treating it as
-            # "yes" escalates on input nobody supplied, which is the same bug
-            # this branch exists to remove. Matches the autostart prompt below.
+            # The device opened, so a failed read is EOF, not consent. Decline,
+            # as the autostart prompt below already does. Enter is still yes:
+            # that is a successful read of an empty line.
             read -r REPLY </dev/tty || REPLY="n"
             case "$REPLY" in
                 [nN]*)
@@ -722,20 +721,16 @@ _smart_apt_install() {
             sudo apt-get update -y </dev/null
             sudo apt-get install -y $_STILL_MISSING </dev/null
         else
-            # Nobody can answer a prompt or type a password here, so pass -n:
-            # sudo then refuses outright instead of prompting into a closed
-            # stdin, which is how #7307 died. Running the real commands is the
-            # only reliable test of whether they are passwordless -- `sudo -l`
-            # reports whether a command is *authorized*, which is a different
-            # question from whether running it needs authentication.
-            #
-            # -k on top of that ignores any cached authentication timestamp, so
-            # this succeeds only under a real NOPASSWD rule, not because someone
-            # ran sudo in another shell minutes ago -- that would escalate here
-            # with nobody having answered the prompt. Per sudo(8), -k alongside
-            # a command ignores the cached credentials for this invocation and
-            # "will not update the user's cached credentials", so an interactive
-            # session elsewhere does not have to re-authenticate afterwards.
+            # Nobody can answer a prompt or type a password here. -n makes sudo
+            # refuse outright rather than prompt into a closed stdin, which is
+            # how #7307 died. Probe with the real commands: `sudo -l` answers
+            # whether they are *authorized*, not whether running them needs
+            # authentication. -k ignores any cached timestamp, so this succeeds
+            # only under a real NOPASSWD rule and not because someone ran sudo
+            # in another shell minutes ago. Per sudo(8), -k alongside a command
+            # ignores the cached credentials for this invocation and "will not
+            # update the user's cached credentials", so an interactive session
+            # elsewhere does not have to re-authenticate afterwards.
             echo "    No terminal to confirm on; trying passwordless sudo."
             if sudo -n -k apt-get update -y </dev/null &&
                 sudo -n -k apt-get install -y $_STILL_MISSING </dev/null; then
@@ -744,11 +739,11 @@ _smart_apt_install() {
                 echo ""
                 echo "    Could not install these packages: $_STILL_MISSING"
                 echo "    Detected ${_ad_desc}."
-                # A nonzero status here is sudo refusing (needs a password, or
-                # no NOPASSWD rule) OR apt's own failure -- a bad repo, a dpkg
-                # lock, a network outage. sudo returns the command's exit status
-                # when it does run, so the two are not distinguishable from the
-                # status alone; report both honestly rather than guessing.
+                # Either sudo refused (no NOPASSWD rule) or apt itself failed on
+                # a bad repo, a dpkg lock, a network outage. sudo exits 1 on an
+                # auth or config problem but passes the command's own status
+                # through otherwise, and it also exits 1 when the command cannot
+                # be executed, so state both rather than guessing a cause.
                 echo "    Either sudo needs a password here, or apt-get itself"
                 echo "    failed; see the error above. With no terminal to"
                 echo "    authenticate on, this cannot be done unattended."

--- a/install.sh
+++ b/install.sh
@@ -655,6 +655,24 @@ _apt_distro_description() {
     )
 }
 
+# ── Helper: can the controlling terminal actually be opened for reading? ──
+# `test -r /dev/tty` only checks the device node's permission bits, and those
+# look fine inside containers and systemd units where open() then fails with
+# ENXIO. Probe with a real open instead. The subshell is required: in dash a
+# failed redirection on the special builtin `:` exits the whole script.
+_can_read_tty() {
+    ( : </dev/tty ) >/dev/null 2>&1
+}
+
+# ── Helper: will sudo run this exact command without prompting? ──
+# `sudo -n -l -- cmd args...` asks the sudoers policy whether the command is
+# permitted, without running it, and fails instead of prompting. `sudo -n true`
+# only proves `true` is allowed, which says nothing under command-specific
+# NOPASSWD rules like `NOPASSWD: /usr/bin/apt-get`.
+_sudo_runs_unattended() {
+    sudo -n -l -- "$@" >/dev/null 2>&1
+}
+
 # ── Helper: install packages via apt, escalating to sudo only if needed ──
 # Usage: _smart_apt_install pkg1 pkg2 pkg3 ...
 _smart_apt_install() {
@@ -685,10 +703,12 @@ _smart_apt_install() {
 
     # Step 3: Escalate -- need elevated permissions for remaining packages
     if command -v sudo >/dev/null 2>&1; then
-        # `sudo -n` succeeds only when no password is required. Without a
-        # terminal we cannot supply one, and every sudo call below closes stdin,
-        # so probe first rather than letting sudo die on its own prompt (#7307).
-        if sudo -n true >/dev/null 2>&1; then
+        # Probe the argument vectors we are actually going to elevate. Without a
+        # terminal we cannot supply a password, and every sudo call below closes
+        # stdin, so check first rather than letting sudo die on its own prompt
+        # (#7307).
+        if _sudo_runs_unattended apt-get update -y \
+            && _sudo_runs_unattended apt-get install -y $_STILL_MISSING; then
             _sudo_unattended=true
         else
             _sudo_unattended=false
@@ -697,7 +717,7 @@ _smart_apt_install() {
         # Nothing to prompt on and sudo wants a password: this cannot succeed.
         # Exit with the same actionable message as the no-sudo path instead of
         # assuming consent and failing inside sudo.
-        if [ ! -r /dev/tty ] && [ "$_sudo_unattended" != true ]; then
+        if ! _can_read_tty && [ "$_sudo_unattended" != true ]; then
             echo ""
             echo "    These packages are missing and need sudo to install:"
             echo "    $_STILL_MISSING"
@@ -719,7 +739,7 @@ _smart_apt_install() {
         echo "    from your distro's official repositories (not a third-party tarball)."
         echo "    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
         echo ""
-        if [ -r /dev/tty ]; then
+        if _can_read_tty; then
             printf "    Accept? [Y/n] "
             read -r REPLY </dev/tty || REPLY="y"
         else

--- a/install.sh
+++ b/install.sh
@@ -724,16 +724,30 @@ _smart_apt_install() {
             # only reliable test of whether they are passwordless -- `sudo -l`
             # reports whether a command is *authorized*, which is a different
             # question from whether running it needs authentication.
+            #
+            # -k on top of that ignores any cached authentication timestamp, so
+            # this succeeds only under a real NOPASSWD rule, not because someone
+            # ran sudo in another shell minutes ago -- that would escalate here
+            # with nobody having answered the prompt. Per sudo(8), -k alongside
+            # a command ignores the cached credentials for this invocation and
+            # "will not update the user's cached credentials", so an interactive
+            # session elsewhere does not have to re-authenticate afterwards.
             echo "    No terminal to confirm on; trying passwordless sudo."
-            if sudo -n apt-get update -y </dev/null &&
-                sudo -n apt-get install -y $_STILL_MISSING </dev/null; then
+            if sudo -n -k apt-get update -y </dev/null &&
+                sudo -n -k apt-get install -y $_STILL_MISSING </dev/null; then
                 echo "    Installed with passwordless sudo."
             else
                 echo ""
                 echo "    Could not install these packages: $_STILL_MISSING"
                 echo "    Detected ${_ad_desc}."
-                echo "    sudo likely needs a password here and there is no terminal to"
-                echo "    enter one on, so this cannot be done unattended."
+                # A nonzero status here is sudo refusing (needs a password, or
+                # no NOPASSWD rule) OR apt's own failure -- a bad repo, a dpkg
+                # lock, a network outage. sudo returns the command's exit status
+                # when it does run, so the two are not distinguishable from the
+                # status alone; report both honestly rather than guessing.
+                echo "    Either sudo needs a password here, or apt-get itself"
+                echo "    failed; see the error above. With no terminal to"
+                echo "    authenticate on, this cannot be done unattended."
                 echo "    Please install them first, then re-run Unsloth Studio setup:"
                 echo "    sudo apt-get update -y && sudo apt-get install -y $_STILL_MISSING"
                 exit 1

--- a/install.sh
+++ b/install.sh
@@ -664,15 +664,6 @@ _can_read_tty() {
     ( : </dev/tty ) >/dev/null 2>&1
 }
 
-# ── Helper: will sudo run this exact command without prompting? ──
-# `sudo -n -l -- cmd args...` asks the sudoers policy whether the command is
-# permitted, without running it, and fails instead of prompting. `sudo -n true`
-# only proves `true` is allowed, which says nothing under command-specific
-# NOPASSWD rules like `NOPASSWD: /usr/bin/apt-get`.
-_sudo_runs_unattended() {
-    sudo -n -l -- "$@" >/dev/null 2>&1
-}
-
 # ── Helper: install packages via apt, escalating to sudo only if needed ──
 # Usage: _smart_apt_install pkg1 pkg2 pkg3 ...
 _smart_apt_install() {
@@ -703,32 +694,6 @@ _smart_apt_install() {
 
     # Step 3: Escalate -- need elevated permissions for remaining packages
     if command -v sudo >/dev/null 2>&1; then
-        # Probe the argument vectors we are actually going to elevate. Without a
-        # terminal we cannot supply a password, and every sudo call below closes
-        # stdin, so check first rather than letting sudo die on its own prompt
-        # (#7307).
-        if _sudo_runs_unattended apt-get update -y \
-            && _sudo_runs_unattended apt-get install -y $_STILL_MISSING; then
-            _sudo_unattended=true
-        else
-            _sudo_unattended=false
-        fi
-
-        # Nothing to prompt on and sudo wants a password: this cannot succeed.
-        # Exit with the same actionable message as the no-sudo path instead of
-        # assuming consent and failing inside sudo.
-        if ! _can_read_tty && [ "$_sudo_unattended" != true ]; then
-            echo ""
-            echo "    These packages are missing and need sudo to install:"
-            echo "    $_STILL_MISSING"
-            echo "    Detected $(_apt_distro_description)."
-            echo "    No terminal is available to confirm on and sudo requires a"
-            echo "    password here, so this cannot be done unattended."
-            echo "    Please install them first, then re-run Unsloth Studio setup:"
-            echo "    sudo apt-get update -y && sudo apt-get install -y $_STILL_MISSING"
-            exit 1
-        fi
-
         _ad_desc="$(_apt_distro_description)"
         echo ""
         echo "    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
@@ -742,24 +707,38 @@ _smart_apt_install() {
         if _can_read_tty; then
             printf "    Accept? [Y/n] "
             read -r REPLY </dev/tty || REPLY="y"
+            case "$REPLY" in
+                [nN]*)
+                    echo ""
+                    echo "    Please install these packages first, then re-run Unsloth Studio setup:"
+                    echo "    sudo apt-get update -y && sudo apt-get install -y $_STILL_MISSING"
+                    exit 1
+                    ;;
+            esac
+            sudo apt-get update -y </dev/null
+            sudo apt-get install -y $_STILL_MISSING </dev/null
         else
-            # Unattended with passwordless sudo: no one can answer, and asking
-            # would only leave a dangling prompt in the log.
-            echo "    No terminal to confirm on; proceeding with passwordless sudo."
-            REPLY="y"
-        fi
-        case "$REPLY" in
-            [nN]*)
+            # Nobody can answer a prompt or type a password here, so pass -n:
+            # sudo then refuses outright instead of prompting into a closed
+            # stdin, which is how #7307 died. Running the real commands is the
+            # only reliable test of whether they are passwordless -- `sudo -l`
+            # reports whether a command is *authorized*, which is a different
+            # question from whether running it needs authentication.
+            echo "    No terminal to confirm on; trying passwordless sudo."
+            if sudo -n apt-get update -y </dev/null &&
+                sudo -n apt-get install -y $_STILL_MISSING </dev/null; then
+                echo "    Installed with passwordless sudo."
+            else
                 echo ""
-                echo "    Please install these packages first, then re-run Unsloth Studio setup:"
+                echo "    Could not install these packages: $_STILL_MISSING"
+                echo "    Detected ${_ad_desc}."
+                echo "    sudo likely needs a password here and there is no terminal to"
+                echo "    enter one on, so this cannot be done unattended."
+                echo "    Please install them first, then re-run Unsloth Studio setup:"
                 echo "    sudo apt-get update -y && sudo apt-get install -y $_STILL_MISSING"
                 exit 1
-                ;;
-            *)
-                sudo apt-get update -y </dev/null
-                sudo apt-get install -y $_STILL_MISSING </dev/null
-                ;;
-        esac
+            fi
+        fi
     else
         echo ""
         echo "    sudo is not available on this system."

--- a/tests/sh/test_apt_distro_prompt.sh
+++ b/tests/sh/test_apt_distro_prompt.sh
@@ -89,6 +89,79 @@ assert_contains "mentions apt-get" "$_smart" 'sudo apt-get'
 assert_contains "mentions official repos" "$_smart" "official repositories"
 assert_contains "rejects tarball worry" "$_smart" "not a third-party tarball"
 
+# ── No-TTY sudo escalation (#7307 Problem 7) ────────────────────────
+# The old code assumed consent when /dev/tty was unreadable, then ran sudo with
+# stdin closed, so a password-requiring host died on a raw sudo error instead of
+# printing the actionable "install these first" message. Drive the real function
+# with /dev/tty rewritten to a fixture path, the same trick used for
+# /etc/os-release above, so both TTY states are reachable hermetically.
+echo "=== _smart_apt_install no-TTY escalation ==="
+
+# $1 tty: "tty" | "notty"   $2 sudo: "nopasswd" | "needspasswd" | "absent"
+run_smart() {
+    _tty_mode="$1"; _sudo_mode="$2"
+    _d=$(mktemp -d -p "$_TMP_ROOT")
+    [ "$_tty_mode" = tty ] && printf 'y\n' > "$_d/tty"
+
+    _f=$(mktemp -p "$_TMP_ROOT")
+    sed -n '/^_smart_apt_install()/,/^}/p' "$INSTALL_SH" \
+        | sed -e "s#/dev/tty#$_d/tty#g" > "$_f"
+
+    (
+        TAURI_MODE=false
+        _apt_distro_description() { echo "TestOS 1.0 (debian-like)"; }
+        _is_pkg_installed() { return 1; }          # nothing ever installs
+        apt-get() { return 1; }                    # unprivileged attempt fails
+        command() {
+            if [ "$1" = -v ] && [ "$2" = sudo ]; then
+                [ "$_sudo_mode" != absent ]; return $?
+            fi
+            builtin command "$@"
+        }
+        sudo() {
+            if [ "$1" = -n ]; then
+                [ "$_sudo_mode" = nopasswd ]; return $?
+            fi
+            echo "SUDO_RAN: $*"
+        }
+        # shellcheck disable=SC1090
+        . "$_f"
+        _smart_apt_install cmake 2>&1
+        echo "EXIT:$?"
+    ) || true
+}
+
+_out=$(run_smart notty needspasswd)
+assert_contains "no tty + password sudo: says it cannot run unattended" \
+    "$_out" "cannot be done unattended"
+assert_contains "no tty + password sudo: gives the manual command" \
+    "$_out" "sudo apt-get update -y && sudo apt-get install -y cmake"
+assert_contains "no tty + password sudo: names the distro" \
+    "$_out" "TestOS 1.0 (debian-like)"
+case "$_out" in
+    *SUDO_RAN*) echo "  FAIL: no tty + password sudo must not invoke sudo"; FAIL=$((FAIL + 1)) ;;
+    *) echo "  PASS: no tty + password sudo does not invoke sudo"; PASS=$((PASS + 1)) ;;
+esac
+case "$_out" in
+    *"Accept? [Y/n]"*) echo "  FAIL: must not print an unanswerable prompt"; FAIL=$((FAIL + 1)) ;;
+    *) echo "  PASS: no dangling Accept? prompt without a tty"; PASS=$((PASS + 1)) ;;
+esac
+
+# Passwordless sudo is the one case where unattended escalation is legitimate.
+_out=$(run_smart notty nopasswd)
+assert_contains "no tty + passwordless sudo: still installs" "$_out" "SUDO_RAN: apt-get install -y cmake"
+assert_contains "no tty + passwordless sudo: says why it proceeded" \
+    "$_out" "proceeding with passwordless sudo"
+
+# A readable tty must behave exactly as before: prompt, then honour the answer.
+_out=$(run_smart tty needspasswd)
+assert_contains "tty present: still prompts" "$_out" "Accept? [Y/n]"
+assert_contains "tty present: accepts and installs" "$_out" "SUDO_RAN: apt-get install -y cmake"
+
+# No sudo at all keeps its own message.
+_out=$(run_smart notty absent)
+assert_contains "no sudo binary: unchanged message" "$_out" "sudo is not available on this system"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tests/sh/test_apt_distro_prompt.sh
+++ b/tests/sh/test_apt_distro_prompt.sh
@@ -97,14 +97,28 @@ assert_contains "rejects tarball worry" "$_smart" "not a third-party tarball"
 # /etc/os-release above, so both TTY states are reachable hermetically.
 echo "=== _smart_apt_install no-TTY escalation ==="
 
-# $1 tty: "tty" | "notty"   $2 sudo: "nopasswd" | "needspasswd" | "absent"
+# A unix socket is the closest portable stand-in for the /dev/tty found inside
+# containers and systemd units: the mode bits satisfy `test -r`, but open()
+# fails with ENXIO. Callers must verify the shape before relying on it.
+make_unopenable() {
+    python3 -c 'import socket,sys; socket.socket(socket.AF_UNIX).bind(sys.argv[1])' \
+        "$1" 2>/dev/null
+}
+
+# $1 tty:  "tty" | "notty" | "unopenable"
+# $2 sudo: "nopasswd" | "needspasswd" | "aptneedspasswd" | "absent"
 run_smart() {
     _tty_mode="$1"; _sudo_mode="$2"
     _d=$(mktemp -d -p "$_TMP_ROOT")
-    [ "$_tty_mode" = tty ] && printf 'y\n' > "$_d/tty"
+    case "$_tty_mode" in
+        tty)        printf 'y\n' > "$_d/tty" ;;
+        unopenable) make_unopenable "$_d/tty" ;;
+    esac
 
     _f=$(mktemp -p "$_TMP_ROOT")
-    sed -n '/^_smart_apt_install()/,/^}/p' "$INSTALL_SH" \
+    sed -n -e '/^_can_read_tty()/,/^}/p' \
+           -e '/^_sudo_runs_unattended()/,/^}/p' \
+           -e '/^_smart_apt_install()/,/^}/p' "$INSTALL_SH" \
         | sed -e "s#/dev/tty#$_d/tty#g" > "$_f"
 
     (
@@ -120,7 +134,18 @@ run_smart() {
         }
         sudo() {
             if [ "$1" = -n ]; then
-                [ "$_sudo_mode" = nopasswd ]; return $?
+                case "$_sudo_mode" in
+                    nopasswd) return 0 ;;
+                    # Trivial commands are NOPASSWD but apt-get is not, which is
+                    # exactly what a `sudo -n true` probe reads as unattended.
+                    aptneedspasswd)
+                        case " $* " in
+                            *" apt-get "*) return 1 ;;
+                            *) return 0 ;;
+                        esac
+                        ;;
+                    *) return 1 ;;
+                esac
             fi
             echo "SUDO_RAN: $*"
         }
@@ -161,6 +186,30 @@ assert_contains "tty present: accepts and installs" "$_out" "SUDO_RAN: apt-get i
 # No sudo at all keeps its own message.
 _out=$(run_smart notty absent)
 assert_contains "no sudo binary: unchanged message" "$_out" "sudo is not available on this system"
+
+# A /dev/tty that passes `test -r` but cannot be opened must count as no tty.
+# Only assert when this platform can actually produce that shape.
+_probe=$(mktemp -d -p "$_TMP_ROOT")
+if make_unopenable "$_probe/tty" && [ -r "$_probe/tty" ] && ! ( : <"$_probe/tty" ) 2>/dev/null; then
+    _out=$(run_smart unopenable needspasswd)
+    assert_contains "unopenable tty: treated as no tty" "$_out" "cannot be done unattended"
+    case "$_out" in
+        *"Accept? [Y/n]"*) echo "  FAIL: unopenable tty must not print a prompt"; FAIL=$((FAIL + 1)) ;;
+        *) echo "  PASS: unopenable tty prints no prompt"; PASS=$((PASS + 1)) ;;
+    esac
+else
+    echo "  SKIP: this platform cannot fake a readable-but-unopenable /dev/tty"
+fi
+
+# NOPASSWD on trivial commands but not on apt-get: the case `sudo -n true` got
+# wrong. Must fall back to the actionable message, not blind escalation.
+_out=$(run_smart notty aptneedspasswd)
+assert_contains "apt-get needs a password: says it cannot run unattended" \
+    "$_out" "cannot be done unattended"
+case "$_out" in
+    *SUDO_RAN*) echo "  FAIL: apt-get needing a password must not invoke sudo"; FAIL=$((FAIL + 1)) ;;
+    *) echo "  PASS: apt-get needing a password does not invoke sudo"; PASS=$((PASS + 1)) ;;
+esac
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/sh/test_apt_distro_prompt.sh
+++ b/tests/sh/test_apt_distro_prompt.sh
@@ -112,6 +112,9 @@ run_smart() {
     _d=$(mktemp -d -p "$_TMP_ROOT")
     case "$_tty_mode" in
         tty)        printf 'y\n' > "$_d/tty" ;;
+        # Opens fine, but read gets EOF straight away: a drained or half-closed
+        # terminal. Being openable is not the same as being answerable.
+        eof)        : > "$_d/tty" ;;
         unopenable) make_unopenable "$_d/tty" ;;
     esac
 
@@ -215,6 +218,17 @@ if make_unopenable "$_probe/tty" && [ -r "$_probe/tty" ] && ! ( : <"$_probe/tty"
 else
     echo "  SKIP: this platform cannot fake a readable-but-unopenable /dev/tty"
 fi
+
+# A tty that opens but yields EOF must decline. Opening the device only proves
+# it exists; a failed read is nobody answering, and calling that "yes" escalates
+# through the branch that does have a terminal.
+_out=$(run_smart eof needspasswd)
+assert_contains "eof tty: declines instead of escalating" \
+    "$_out" "Please install these packages first"
+case "$_out" in
+    *SUDO_RAN*) echo "  FAIL: eof tty must not escalate"; FAIL=$((FAIL + 1)) ;;
+    *) echo "  PASS: eof tty runs nothing as root"; PASS=$((PASS + 1)) ;;
+esac
 
 # A cached authentication timestamp from an earlier, unrelated sudo must not
 # count as passwordless: nobody answered the prompt in this run, and the

--- a/tests/sh/test_apt_distro_prompt.sh
+++ b/tests/sh/test_apt_distro_prompt.sh
@@ -106,7 +106,7 @@ make_unopenable() {
 }
 
 # $1 tty:  "tty" | "notty" | "unopenable"
-# $2 sudo: "nopasswd" | "needspasswd" | "aptneedspasswd" | "absent"
+# $2 sudo: "nopasswd" | "needspasswd" | "aptneedspasswd" | "cached" | "absent"
 run_smart() {
     _tty_mode="$1"; _sudo_mode="$2"
     _d=$(mktemp -d -p "$_TMP_ROOT")
@@ -132,13 +132,25 @@ run_smart() {
             builtin command "$@"
         }
         # Models real sudo: -n refuses (exit 1, nothing runs) whenever the
-        # command would need a password; otherwise the command runs.
+        # command would need a password; otherwise the command runs. -k makes
+        # it ignore any cached authentication timestamp for this invocation,
+        # per sudo(8), so only a real NOPASSWD rule still counts as passwordless.
         sudo() {
             _noninteractive=false
-            if [ "$1" = -n ]; then _noninteractive=true; shift; fi
+            _ignore_cache=false
+            while :; do
+                case "$1" in
+                    -n) _noninteractive=true; shift ;;
+                    -k) _ignore_cache=true; shift ;;
+                    *)  break ;;
+                esac
+            done
             if [ "$_noninteractive" = true ]; then
                 case "$_sudo_mode" in
                     nopasswd) ;;
+                    # A valid timestamp from an earlier, unrelated sudo. Without
+                    # -k this looks passwordless; with -k it must not.
+                    cached) [ "$_ignore_cache" = true ] && return 1 ;;
                     # Authorized for everything, but only trivial commands are
                     # NOPASSWD. `sudo -l` says yes here while execution needs a
                     # password, so authorization is not the question to ask.
@@ -203,6 +215,23 @@ if make_unopenable "$_probe/tty" && [ -r "$_probe/tty" ] && ! ( : <"$_probe/tty"
 else
     echo "  SKIP: this platform cannot fake a readable-but-unopenable /dev/tty"
 fi
+
+# A cached authentication timestamp from an earlier, unrelated sudo must not
+# count as passwordless: nobody answered the prompt in this run, and the
+# sudoers rule for apt-get still carries PASSWD. -k is what makes the probe
+# ignore the timestamp, so this asserts the -k is actually there and effective.
+_out=$(run_smart notty cached)
+assert_contains "cached credentials: says it cannot run unattended" \
+    "$_out" "cannot be done unattended"
+case "$_out" in
+    *SUDO_RAN*) echo "  FAIL: a cached timestamp must not authorise unattended install"; FAIL=$((FAIL + 1)) ;;
+    *) echo "  PASS: cached credentials run nothing as root"; PASS=$((PASS + 1)) ;;
+esac
+
+# The failure message must not claim a missing password when apt itself failed:
+# sudo returns the command's own exit status when the command does run.
+assert_contains "failure message does not blame a password exclusively" \
+    "$_out" "or apt-get itself"
 
 # Authorized for apt-get but not NOPASSWD on it: `sudo -n true` reads this as
 # unattended, and so does `sudo -n -l -- apt-get ...`, since list mode answers

--- a/tests/sh/test_apt_distro_prompt.sh
+++ b/tests/sh/test_apt_distro_prompt.sh
@@ -117,7 +117,6 @@ run_smart() {
 
     _f=$(mktemp -p "$_TMP_ROOT")
     sed -n -e '/^_can_read_tty()/,/^}/p' \
-           -e '/^_sudo_runs_unattended()/,/^}/p' \
            -e '/^_smart_apt_install()/,/^}/p' "$INSTALL_SH" \
         | sed -e "s#/dev/tty#$_d/tty#g" > "$_f"
 
@@ -132,16 +131,20 @@ run_smart() {
             fi
             builtin command "$@"
         }
+        # Models real sudo: -n refuses (exit 1, nothing runs) whenever the
+        # command would need a password; otherwise the command runs.
         sudo() {
-            if [ "$1" = -n ]; then
+            _noninteractive=false
+            if [ "$1" = -n ]; then _noninteractive=true; shift; fi
+            if [ "$_noninteractive" = true ]; then
                 case "$_sudo_mode" in
-                    nopasswd) return 0 ;;
-                    # Trivial commands are NOPASSWD but apt-get is not, which is
-                    # exactly what a `sudo -n true` probe reads as unattended.
+                    nopasswd) ;;
+                    # Authorized for everything, but only trivial commands are
+                    # NOPASSWD. `sudo -l` says yes here while execution needs a
+                    # password, so authorization is not the question to ask.
                     aptneedspasswd)
                         case " $* " in
                             *" apt-get "*) return 1 ;;
-                            *) return 0 ;;
                         esac
                         ;;
                     *) return 1 ;;
@@ -164,8 +167,8 @@ assert_contains "no tty + password sudo: gives the manual command" \
 assert_contains "no tty + password sudo: names the distro" \
     "$_out" "TestOS 1.0 (debian-like)"
 case "$_out" in
-    *SUDO_RAN*) echo "  FAIL: no tty + password sudo must not invoke sudo"; FAIL=$((FAIL + 1)) ;;
-    *) echo "  PASS: no tty + password sudo does not invoke sudo"; PASS=$((PASS + 1)) ;;
+    *SUDO_RAN*) echo "  FAIL: no tty + password sudo must not run apt-get as root"; FAIL=$((FAIL + 1)) ;;
+    *) echo "  PASS: no tty + password sudo runs nothing as root"; PASS=$((PASS + 1)) ;;
 esac
 case "$_out" in
     *"Accept? [Y/n]"*) echo "  FAIL: must not print an unanswerable prompt"; FAIL=$((FAIL + 1)) ;;
@@ -176,7 +179,7 @@ esac
 _out=$(run_smart notty nopasswd)
 assert_contains "no tty + passwordless sudo: still installs" "$_out" "SUDO_RAN: apt-get install -y cmake"
 assert_contains "no tty + passwordless sudo: says why it proceeded" \
-    "$_out" "proceeding with passwordless sudo"
+    "$_out" "passwordless sudo"
 
 # A readable tty must behave exactly as before: prompt, then honour the answer.
 _out=$(run_smart tty needspasswd)
@@ -201,14 +204,15 @@ else
     echo "  SKIP: this platform cannot fake a readable-but-unopenable /dev/tty"
 fi
 
-# NOPASSWD on trivial commands but not on apt-get: the case `sudo -n true` got
-# wrong. Must fall back to the actionable message, not blind escalation.
+# Authorized for apt-get but not NOPASSWD on it: `sudo -n true` reads this as
+# unattended, and so does `sudo -n -l -- apt-get ...`, since list mode answers
+# authorization rather than authentication. Only running it with -n is truthful.
 _out=$(run_smart notty aptneedspasswd)
 assert_contains "apt-get needs a password: says it cannot run unattended" \
     "$_out" "cannot be done unattended"
 case "$_out" in
-    *SUDO_RAN*) echo "  FAIL: apt-get needing a password must not invoke sudo"; FAIL=$((FAIL + 1)) ;;
-    *) echo "  PASS: apt-get needing a password does not invoke sudo"; PASS=$((PASS + 1)) ;;
+    *SUDO_RAN*) echo "  FAIL: apt-get needing a password must not run as root"; FAIL=$((FAIL + 1)) ;;
+    *) echo "  PASS: apt-get needing a password runs nothing as root"; PASS=$((PASS + 1)) ;;
 esac
 
 echo ""

--- a/tests/sh/test_apt_distro_prompt.sh
+++ b/tests/sh/test_apt_distro_prompt.sh
@@ -91,15 +91,14 @@ assert_contains "rejects tarball worry" "$_smart" "not a third-party tarball"
 
 # ── No-TTY sudo escalation (#7307 Problem 7) ────────────────────────
 # The old code assumed consent when /dev/tty was unreadable, then ran sudo with
-# stdin closed, so a password-requiring host died on a raw sudo error instead of
-# printing the actionable "install these first" message. Drive the real function
-# with /dev/tty rewritten to a fixture path, the same trick used for
-# /etc/os-release above, so both TTY states are reachable hermetically.
+# stdin closed, so a password-requiring host died on a raw sudo error. Drive the
+# real function with /dev/tty rewritten to a fixture, the same trick used for
+# /etc/os-release above, so every TTY state is reachable hermetically.
 echo "=== _smart_apt_install no-TTY escalation ==="
 
-# A unix socket is the closest portable stand-in for the /dev/tty found inside
-# containers and systemd units: the mode bits satisfy `test -r`, but open()
-# fails with ENXIO. Callers must verify the shape before relying on it.
+# Closest portable stand-in for the /dev/tty inside containers and systemd
+# units: the mode bits satisfy `test -r`, but open() fails with ENXIO. Callers
+# must verify the shape before relying on it.
 make_unopenable() {
     python3 -c 'import socket,sys; socket.socket(socket.AF_UNIX).bind(sys.argv[1])' \
         "$1" 2>/dev/null
@@ -112,8 +111,8 @@ run_smart() {
     _d=$(mktemp -d -p "$_TMP_ROOT")
     case "$_tty_mode" in
         tty)        printf 'y\n' > "$_d/tty" ;;
-        # Opens fine, but read gets EOF straight away: a drained or half-closed
-        # terminal. Being openable is not the same as being answerable.
+        # Opens fine but reads EOF straight away (drained/half-closed
+        # terminal): openable is not the same as answerable.
         eof)        : > "$_d/tty" ;;
         unopenable) make_unopenable "$_d/tty" ;;
     esac
@@ -134,10 +133,9 @@ run_smart() {
             fi
             builtin command "$@"
         }
-        # Models real sudo: -n refuses (exit 1, nothing runs) whenever the
-        # command would need a password; otherwise the command runs. -k makes
-        # it ignore any cached authentication timestamp for this invocation,
-        # per sudo(8), so only a real NOPASSWD rule still counts as passwordless.
+        # Models real sudo: -n refuses (exit 1, nothing runs) when a password
+        # would be needed. -k ignores any cached timestamp for this invocation
+        # (sudo(8)), so only a real NOPASSWD rule counts as passwordless.
         sudo() {
             _noninteractive=false
             _ignore_cache=false
@@ -154,9 +152,9 @@ run_smart() {
                     # A valid timestamp from an earlier, unrelated sudo. Without
                     # -k this looks passwordless; with -k it must not.
                     cached) [ "$_ignore_cache" = true ] && return 1 ;;
-                    # Authorized for everything, but only trivial commands are
-                    # NOPASSWD. `sudo -l` says yes here while execution needs a
-                    # password, so authorization is not the question to ask.
+                    # Authorized for everything, NOPASSWD only on trivial
+                    # commands: `sudo -l` says yes while execution still needs
+                    # a password. Authorization is not the question to ask.
                     aptneedspasswd)
                         case " $* " in
                             *" apt-get "*) return 1 ;;
@@ -205,8 +203,8 @@ assert_contains "tty present: accepts and installs" "$_out" "SUDO_RAN: apt-get i
 _out=$(run_smart notty absent)
 assert_contains "no sudo binary: unchanged message" "$_out" "sudo is not available on this system"
 
-# A /dev/tty that passes `test -r` but cannot be opened must count as no tty.
-# Only assert when this platform can actually produce that shape.
+# A /dev/tty that passes `test -r` but cannot be opened counts as no tty.
+# Only assert where the platform can actually produce that shape.
 _probe=$(mktemp -d -p "$_TMP_ROOT")
 if make_unopenable "$_probe/tty" && [ -r "$_probe/tty" ] && ! ( : <"$_probe/tty" ) 2>/dev/null; then
     _out=$(run_smart unopenable needspasswd)
@@ -219,9 +217,9 @@ else
     echo "  SKIP: this platform cannot fake a readable-but-unopenable /dev/tty"
 fi
 
-# A tty that opens but yields EOF must decline. Opening the device only proves
-# it exists; a failed read is nobody answering, and calling that "yes" escalates
-# through the branch that does have a terminal.
+# A tty that opens but yields EOF must decline: a failed read is nobody
+# answering, and calling that "yes" escalates through the branch that does
+# have a terminal.
 _out=$(run_smart eof needspasswd)
 assert_contains "eof tty: declines instead of escalating" \
     "$_out" "Please install these packages first"
@@ -230,10 +228,9 @@ case "$_out" in
     *) echo "  PASS: eof tty runs nothing as root"; PASS=$((PASS + 1)) ;;
 esac
 
-# A cached authentication timestamp from an earlier, unrelated sudo must not
-# count as passwordless: nobody answered the prompt in this run, and the
-# sudoers rule for apt-get still carries PASSWD. -k is what makes the probe
-# ignore the timestamp, so this asserts the -k is actually there and effective.
+# A cached timestamp from an earlier, unrelated sudo must not count as
+# passwordless: nobody answered this run's prompt and the apt-get rule still
+# carries PASSWD. Asserts the -k is present and effective.
 _out=$(run_smart notty cached)
 assert_contains "cached credentials: says it cannot run unattended" \
     "$_out" "cannot be done unattended"
@@ -242,14 +239,14 @@ case "$_out" in
     *) echo "  PASS: cached credentials run nothing as root"; PASS=$((PASS + 1)) ;;
 esac
 
-# The failure message must not claim a missing password when apt itself failed:
-# sudo returns the command's own exit status when the command does run.
+# The failure message must not blame a password when apt itself failed: sudo
+# passes the command's own exit status through when the command runs.
 assert_contains "failure message does not blame a password exclusively" \
     "$_out" "or apt-get itself"
 
-# Authorized for apt-get but not NOPASSWD on it: `sudo -n true` reads this as
-# unattended, and so does `sudo -n -l -- apt-get ...`, since list mode answers
-# authorization rather than authentication. Only running it with -n is truthful.
+# Authorized for apt-get but not NOPASSWD on it. Both `sudo -n true` and
+# `sudo -n -l -- apt-get ...` read this as unattended, since list mode answers
+# authorization, not authentication. Only running it with -n is truthful.
 _out=$(run_smart notty aptneedspasswd)
 assert_contains "apt-get needs a password: says it cannot run unattended" \
     "$_out" "cannot be done unattended"


### PR DESCRIPTION
Addresses Problem 7 of #7307.

### Problem

`_smart_apt_install()` in `install.sh` prints a consent prompt, then decides the
answer itself when there is no terminal:

```sh
printf "    Accept? [Y/n] "
if [ -r /dev/tty ]; then
    read -r REPLY </dev/tty || REPLY="y"
else
    REPLY="y"
fi
case "$REPLY" in
    [nN]*) ... exit 1 ;;
    *)
        sudo apt-get update -y </dev/null
        sudo apt-get install -y $_STILL_MISSING </dev/null
        ;;
esac
```

Two things go wrong when `/dev/tty` is unreadable:

1. It **assumes consent** for a sudo escalation nobody approved.
2. It then runs `sudo` with **stdin redirected from `/dev/null`**, so on any host
   where sudo needs a password, sudo cannot prompt and dies with its own raw
   error.

The result is the worst of both paths. The script neither degrades gracefully nor
explains itself, even though the no-sudo branch a few lines below already prints
exactly the message the user needs. This hits containers, CI, and locked-down
corporate machines. It also prints `Accept? [Y/n]` into logs where nothing can
answer it.

### Fix

Probe with `sudo -n true`, which succeeds only when no password is required.

- **No terminal and sudo needs a password:** exit with the missing packages and
  the exact command to run, mirroring the existing no-sudo message, instead of
  invoking sudo and letting it fail.
- **No terminal but sudo is passwordless:** still escalate. This is the one case
  where unattended escalation is legitimate, and it now logs why it proceeded.
- **Readable `/dev/tty`:** unchanged. The prompt is simply moved inside the
  branch so it only prints when something can answer it.

`TAURI_MODE` already had the right shape for this (`tauri_log "NEED_SUDO"; exit 2`,
letting the Rust caller handle elevation). This gives the headless shell path
equivalent honesty.

### Tests

Extended `tests/sh/test_apt_distro_prompt.sh`, which already covers this function.
It drives the real `_smart_apt_install` across all four TTY/sudo combinations,
rewriting `/dev/tty` to a fixture path the same way the existing cases rewrite
`/etc/os-release`, with `sudo`, `apt-get`, `command -v` and `_is_pkg_installed`
stubbed. 20 assertions pass.

Against the previous `install.sh`, five of the new assertions fail. The captured
output is the bug itself:

```
    Accept? [Y/n] SUDO_RAN: apt-get update -y
SUDO_RAN: apt-get install -y cmake
EXIT:0
```

An unanswerable prompt, then escalation despite `sudo -n` reporting that a
password is required. The `tty present` and `no sudo binary` assertions pass both
before and after, confirming those paths are untouched.

This file was not in `studio-backend-ci.yml`'s shell-test allowlist, so it never
ran in CI. Registered it there, since the coverage is otherwise inert. It is
hermetic: it stubs every external command and only reads `install.sh` via `sed`.
