### PR TITLE
tests: read checked-in files as UTF-8 instead of the platform default

### DIFF
--- a/scripts/lint_workflow_triggers.py
+++ b/scripts/lint_workflow_triggers.py
@@ -52,14 +52,14 @@ def _normalise_on(on_field):
 
 def _load_workflow(path: Path):
     try:
-        return yaml.safe_load(path.read_text())
+        return yaml.safe_load(path.read_text(encoding = "utf-8"))
     except Exception as exc:
         print(f"ERROR: failed to parse {path}: {exc}", file = sys.stderr)
         sys.exit(2)
 
 
 def _extract_cache_keys(path: Path) -> list[str]:
-    text = path.read_text()
+    text = path.read_text(encoding = "utf-8")
     keys: list[str] = []
     for m in re.finditer(r"(?:^|\n)\s*key:\s*([^\n]+)", text):
         keys.append(m.group(1).strip())
@@ -104,7 +104,7 @@ def main() -> int:
 
         for t in RESTRICTED_TRIGGERS:
             if t in triggers:
-                text = path.read_text()
+                text = path.read_text(encoding = "utf-8")
                 if "lint:workflow_triggers-allow-workflow_run" not in text:
                     findings.append(
                         f"{path.name}: RESTRICTED trigger '{t}' requires an "

--- a/studio/backend/tests/test_cloudflare_tunnel.py
+++ b/studio/backend/tests/test_cloudflare_tunnel.py
@@ -915,17 +915,17 @@ def _argparse_default(source, option):
 
 
 def test_run_server_cloudflare_default_off():
-    defaults = _func_param_defaults(_RUN_PY.read_text(), "run_server")
+    defaults = _func_param_defaults(_RUN_PY.read_text(encoding = "utf-8"), "run_server")
     assert "cloudflare" in defaults
     assert defaults["cloudflare"] is None
 
 
 def test_argparse_cloudflare_default_off():
-    assert _argparse_default(_RUN_PY.read_text(), "--cloudflare") is None
+    assert _argparse_default(_RUN_PY.read_text(encoding = "utf-8"), "--cloudflare") is None
 
 
 def test_verify_global_reachability_marks_private_address_unreachable():
-    src = _RUN_PY.read_text()
+    src = _RUN_PY.read_text(encoding = "utf-8")
     tree = ast.parse(src)
     func_src = next(
         ast.get_source_segment(src, n)
@@ -949,7 +949,7 @@ def test_verify_global_reachability_marks_private_address_unreachable():
 def test_run_server_registers_tunnel_atexit_backstop():
     # An abnormal exit (exception after startup -> sys.exit) bypasses
     # _graceful_shutdown; an atexit backstop must still stop the tunnel.
-    src = _RUN_PY.read_text()
+    src = _RUN_PY.read_text(encoding = "utf-8")
     assert "atexit.register(stop_studio_tunnel)" in src
 
 
@@ -965,7 +965,7 @@ def _run_print_cloudflare_line(
     color = False,
 ):
     """Exec _print_cloudflare_line without importing run.py's heavy deps."""
-    src = _RUN_PY.read_text()
+    src = _RUN_PY.read_text(encoding = "utf-8")
     tree = ast.parse(src)
     func_src = next(
         ast.get_source_segment(src, n)

--- a/studio/backend/tests/test_consent_gate.py
+++ b/studio/backend/tests/test_consent_gate.py
@@ -410,14 +410,14 @@ class TestWorkersWireTheGate:
     def test_mlx_training_path_gates_before_load(self):
         # The Apple-Silicon path returns before run_training_process's gate, so it must
         # scan before FastMLXModel.from_pretrained runs repo code.
-        src = (_BACKEND / "core/training/worker.py").read_text()
+        src = (_BACKEND / "core/training/worker.py").read_text(encoding = "utf-8")
         head = src[: src.index("FastMLXModel.from_pretrained(")]
         assert "evaluate_remote_code_consent" in head
 
     def test_lora_base_model_is_gated(self):
         # Inference + export expand the consent scan to the LoRA base model's code.
         for rel in ("core/inference/worker.py", "core/export/worker.py"):
-            src = (_BACKEND / rel).read_text()
+            src = (_BACKEND / rel).read_text(encoding = "utf-8")
             assert "evaluate_remote_code_consent" in src
             assert "get_base_model_from_lora" in src or "mc.base_model" in src
 
@@ -431,12 +431,12 @@ class TestWorkersWireTheGate:
             "core/training/worker.py",
             "core/export/worker.py",
         ):
-            src = (_BACKEND / rel).read_text()
+            src = (_BACKEND / rel).read_text(encoding = "utf-8")
             assert "get_base_model_from_lora_identifier" in src, rel
 
     def test_embedding_training_path_gates_before_load(self):
         # The embedding pipeline must run the malware + consent gates before loading, like the other paths.
-        src = (_BACKEND / "core/training/worker.py").read_text()
+        src = (_BACKEND / "core/training/worker.py").read_text(encoding = "utf-8")
         start = src.index("def _run_embedding_training(")
         end = src.index("FastSentenceTransformer.from_pretrained(", start)
         region = src[start:end]
@@ -740,7 +740,7 @@ class TestNemotronGateUsesTrustCheck:
         ],
     )
     def test_worker_nemotron_block_calls_trust_check(self, rel):
-        src = (_BACKEND / rel).read_text()
+        src = (_BACKEND / rel).read_text(encoding = "utf-8")
         assert "_NEMOTRON_TRUST_SUBSTRINGS" in src
         assert "is_trusted_org_repo(" in src
 
@@ -1527,6 +1527,6 @@ class TestDiscardRemoteCodeDownload:
         assert res == {"deleted": False, "reason": "not_cached"}
 
     def test_route_source_reports_created_by_scan(self):
-        src = (_BACKEND / "routes/models.py").read_text()
+        src = (_BACKEND / "routes/models.py").read_text(encoding = "utf-8")
         assert "created_by_scan" in src
         assert "discard-remote-code" in src

--- a/studio/backend/tests/test_consent_gate.py
+++ b/studio/backend/tests/test_consent_gate.py
@@ -402,7 +402,7 @@ class TestWorkersWireTheGate:
         ],
     )
     def test_worker_invokes_gate(self, rel):
-        src = (Path(__file__).resolve().parent.parent / rel).read_text()
+        src = (Path(__file__).resolve().parent.parent / rel).read_text(encoding = "utf-8")
         assert "evaluate_remote_code_consent" in src
         assert "remote_code_blocked" in src
         assert ".blocked" in src
@@ -505,7 +505,9 @@ class TestStructuredFindingsForDialog:
         assert d.findings and d.fingerprint  # structured findings for the UI
 
     def test_scan_route_uses_preflight(self):
-        src = (Path(__file__).resolve().parent.parent / "routes/models.py").read_text()
+        src = (Path(__file__).resolve().parent.parent / "routes/models.py").read_text(
+            encoding = "utf-8"
+        )
         assert "remote-code-scan" in src
         # The scan route pins one combined fingerprint over adapter + base, so adapter code is reviewed and approvable too.
         assert "preflight_remote_code_consent_for_targets" in src
@@ -636,7 +638,7 @@ class TestStructuredFindingsForDialog:
         ],
     )
     def test_fingerprint_threaded_to_worker(self, rel):
-        src = (Path(__file__).resolve().parent.parent / rel).read_text()
+        src = (Path(__file__).resolve().parent.parent / rel).read_text(encoding = "utf-8")
         assert "approved_remote_code_fingerprint" in src
         # The per-user approval cache rides the same path as the fingerprint.
         assert "subject" in src

--- a/studio/backend/tests/test_cpu_threads.py
+++ b/studio/backend/tests/test_cpu_threads.py
@@ -120,7 +120,7 @@ def _ast_line_of_platform_compat_import(source: str) -> int:
 # run.py and main.py. Robust to formatting / line shifts.
 @pytest.mark.parametrize("entry_point", [_RUN_PY, _MAIN_PY])
 def test_cpu_thread_configuration_runs_before_backend_imports(entry_point):
-    source = entry_point.read_text()
+    source = entry_point.read_text(encoding = "utf-8")
     call_line = _ast_line_of_configure_call(source)
     compat_line = _ast_line_of_platform_compat_import(source)
     assert call_line < compat_line, (

--- a/studio/backend/tests/test_data_recipe_seed.py
+++ b/studio/backend/tests/test_data_recipe_seed.py
@@ -11,7 +11,7 @@ import pytest
 def _seed_route_source() -> str:
     return (
         Path(__file__).resolve().parent.parent / "routes" / "data_recipe" / "seed.py"
-    ).read_text()
+    ).read_text(encoding = "utf-8")
 
 
 def test_seed_inspect_load_kwargs_disables_remote_code_execution():

--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -123,7 +123,7 @@ def test_ensure_default_admin_does_not_recreate_bootstrap_for_existing_admin():
 
 def test_ensure_default_admin_loads_existing_bootstrap_after_restart(monkeypatch):
     created = storage.ensure_default_admin()
-    bootstrap_pw = storage._BOOTSTRAP_PW_PATH.read_text().strip()
+    bootstrap_pw = storage._BOOTSTRAP_PW_PATH.read_text(encoding = "utf-8").strip()
 
     monkeypatch.setattr(storage, "_bootstrap_password", None)
     created_again = storage.ensure_default_admin()
@@ -136,12 +136,12 @@ def test_ensure_default_admin_loads_existing_bootstrap_after_restart(monkeypatch
 
 def test_ensure_default_admin_does_not_generate_for_empty_existing_bootstrap():
     seed_user()
-    storage._BOOTSTRAP_PW_PATH.write_text(" \n")
+    storage._BOOTSTRAP_PW_PATH.write_text(" \n", encoding = "utf-8")
 
     created = storage.ensure_default_admin()
 
     assert created is False
-    assert storage._BOOTSTRAP_PW_PATH.read_text() == " \n"
+    assert storage._BOOTSTRAP_PW_PATH.read_text(encoding = "utf-8") == " \n"
     assert storage.get_bootstrap_password() is None
 
 

--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -649,7 +649,7 @@ def test_desktop_auth_provision_has_bounded_timeout():
     rs_path = (
         Path(__file__).resolve().parents[3] / "studio" / "src-tauri" / "src" / "desktop_auth.rs"
     )
-    src = rs_path.read_text()
+    src = rs_path.read_text(encoding = "utf-8")
     start = src.index("async fn provision_desktop_auth(")
     depth = 0
     body_start = src.index("{", start)

--- a/studio/backend/tests/test_gguf_load_cache_reuse.py
+++ b/studio/backend/tests/test_gguf_load_cache_reuse.py
@@ -809,7 +809,9 @@ class TestLoadHubDownloadExclusion:
         asyncio.run(scenario())
 
     def test_load_marker_precedes_hub_guard_and_unload(self):
-        source = (Path(__file__).resolve().parent.parent / "routes" / "inference.py").read_text()
+        source = (Path(__file__).resolve().parent.parent / "routes" / "inference.py").read_text(
+            encoding = "utf-8"
+        )
         # _load_model_impl has more than one `if config.is_gguf:`, so anchor on
         # the branch that actually owns the load marker rather than the first
         # one in the file, which belongs to an earlier check.
@@ -832,7 +834,7 @@ class TestLoadHubDownloadExclusion:
         )
         llama_source = (
             Path(__file__).resolve().parent.parent / "core" / "inference" / "llama_cpp.py"
-        ).read_text()
+        ).read_text(encoding = "utf-8")
         assert "@_with_gguf_load_marker\n    def load_model(" in llama_source
 
     def _capture_hub_guard_require_mmproj(

--- a/studio/backend/tests/test_host_defaults.py
+++ b/studio/backend/tests/test_host_defaults.py
@@ -64,7 +64,7 @@ def test_run_server_default_host_is_loopback():
     0.0.0.0 exposes the service on all interfaces; loopback is the
     least-permissive default. Users needing network access pass -H 0.0.0.0.
     """
-    source = _RUN_PY.read_text()
+    source = _RUN_PY.read_text(encoding = "utf-8")
     defaults = _parse_function_param_defaults(source, "run_server")
     assert "host" in defaults, "run_server() must have a 'host' parameter with a default"
     host_default = defaults["host"]
@@ -81,9 +81,9 @@ def test_argparse_default_host_is_loopback():
     When run.py is invoked directly (python run.py), the argparse default
     must match the function default so direct execution is equally safe.
     """
-    source = _RUN_PY.read_text()
+    source = _RUN_PY.read_text(encoding = "utf-8")
     host_default = _parse_argparse_add_argument_default(source, "--host")
     assert host_default is not None, "Could not find add_argument('--host', ...) in run.py"
-    assert (
-        host_default == "127.0.0.1"
-    ), f"run.py argparse --host default must be '127.0.0.1', got '{host_default}'"
+    assert host_default == "127.0.0.1", (
+        f"run.py argparse --host default must be '127.0.0.1', got '{host_default}'"
+    )

--- a/studio/backend/tests/test_host_defaults.py
+++ b/studio/backend/tests/test_host_defaults.py
@@ -84,6 +84,6 @@ def test_argparse_default_host_is_loopback():
     source = _RUN_PY.read_text(encoding = "utf-8")
     host_default = _parse_argparse_add_argument_default(source, "--host")
     assert host_default is not None, "Could not find add_argument('--host', ...) in run.py"
-    assert host_default == "127.0.0.1", (
-        f"run.py argparse --host default must be '127.0.0.1', got '{host_default}'"
-    )
+    assert (
+        host_default == "127.0.0.1"
+    ), f"run.py argparse --host default must be '127.0.0.1', got '{host_default}'"

--- a/studio/backend/tests/test_mcp_servers.py
+++ b/studio/backend/tests/test_mcp_servers.py
@@ -599,7 +599,9 @@ def test_tool_xml_strip_handles_hyphenated_function_names():
 
     from core.inference.tool_call_parser import _DEEPSEEK_OPEN_RE_SRC as _DS_OPEN_SRC
 
-    src = (Path(__file__).resolve().parent.parent / "routes/inference.py").read_text()
+    src = (Path(__file__).resolve().parent.parent / "routes/inference.py").read_text(
+        encoding = "utf-8"
+    )
     m = _re.search(r"_TOOL_XML_RE = _re\.compile\((.*?)\n\)", src, _re.DOTALL)
     assert m, "could not extract _TOOL_XML_RE"
     ns: dict = {"_re": _re, "_DS_OPEN_SRC": _DS_OPEN_SRC}

--- a/studio/backend/tests/test_mlx_training_worker_config.py
+++ b/studio/backend/tests/test_mlx_training_worker_config.py
@@ -102,9 +102,9 @@ def test_mlx_wandb_run_config_excludes_subject_and_secrets():
         encoding = "utf-8"
     )
 
-    assert '_wandb_sensitive = {"hf_token", "wandb_token", "s3_config", "subject"}' in source, (
-        "MLX W&B run config must exclude subject and the token/s3 secrets"
-    )
+    assert (
+        '_wandb_sensitive = {"hf_token", "wandb_token", "s3_config", "subject"}' in source
+    ), "MLX W&B run config must exclude subject and the token/s3 secrets"
 
 
 def test_mlx_vlm_resize_uses_max_dimension_like_torch_trainer():

--- a/studio/backend/tests/test_mlx_training_worker_config.py
+++ b/studio/backend/tests/test_mlx_training_worker_config.py
@@ -86,7 +86,9 @@ def test_mlx_studio_rejects_unknown_scheduler():
 
 
 def test_mlx_studio_keeps_hf_style_tokenizer_dual_purpose():
-    source = (Path(__file__).resolve().parents[1] / "core" / "training" / "worker.py").read_text()
+    source = (Path(__file__).resolve().parents[1] / "core" / "training" / "worker.py").read_text(
+        encoding = "utf-8"
+    )
 
     assert "tokenizer = tokenizer" in source
     assert "processor = tokenizer if is_vlm else None" not in source
@@ -96,11 +98,13 @@ def test_mlx_wandb_run_config_excludes_subject_and_secrets():
     # The MLX W&B run config uploads the whole config minus a sensitive set. The owner's
     # subject (authenticated username / API-key id) must be filtered alongside the secrets,
     # otherwise it lands in W&B run config even though DB history already strips it.
-    source = (Path(__file__).resolve().parents[1] / "core" / "training" / "worker.py").read_text()
+    source = (Path(__file__).resolve().parents[1] / "core" / "training" / "worker.py").read_text(
+        encoding = "utf-8"
+    )
 
-    assert (
-        '_wandb_sensitive = {"hf_token", "wandb_token", "s3_config", "subject"}' in source
-    ), "MLX W&B run config must exclude subject and the token/s3 secrets"
+    assert '_wandb_sensitive = {"hf_token", "wandb_token", "s3_config", "subject"}' in source, (
+        "MLX W&B run config must exclude subject and the token/s3 secrets"
+    )
 
 
 def test_mlx_vlm_resize_uses_max_dimension_like_torch_trainer():

--- a/studio/backend/tests/test_mtp_vram_budget.py
+++ b/studio/backend/tests/test_mtp_vram_budget.py
@@ -320,7 +320,7 @@ class TestFitContextWithMtp:
     def _fit_backend(self, kv_per_token = 325_000):
         b = _make_backend()
         b._can_estimate_kv = lambda: True
-        b._estimate_kv_cache_bytes = lambda n, _t = None, **_k: (0 if n <= 0 else n * kv_per_token)
+        b._estimate_kv_cache_bytes = lambda n, _t = None, **_k: 0 if n <= 0 else n * kv_per_token
         return b
 
     def test_overhead_fn_lowers_context(self):
@@ -347,19 +347,23 @@ class TestFitContextWithMtp:
             131072,
             avail_mib,
             model,
-            mtp_overhead_fn = lambda c: b._estimate_mtp_overhead_bytes(
-                c, draft_cache_type_k = "f16", draft_cache_type_v = "f16"
-            )
-            or 0,
+            mtp_overhead_fn = lambda c: (
+                b._estimate_mtp_overhead_bytes(
+                    c, draft_cache_type_k = "f16", draft_cache_type_v = "f16"
+                )
+                or 0
+            ),
         )
         q4 = b._fit_context_to_vram(
             131072,
             avail_mib,
             model,
-            mtp_overhead_fn = lambda c: b._estimate_mtp_overhead_bytes(
-                c, draft_cache_type_k = "q4_0", draft_cache_type_v = "q4_0"
-            )
-            or 0,
+            mtp_overhead_fn = lambda c: (
+                b._estimate_mtp_overhead_bytes(
+                    c, draft_cache_type_k = "q4_0", draft_cache_type_v = "q4_0"
+                )
+                or 0
+            ),
         )
         assert 0 < q4 == f16
 
@@ -818,9 +822,9 @@ class TestExtraArgsMtpDetection:
         # helper, or an env-driven tensor server (or its layer downgrade) is
         # needlessly reloaded (#6312). Read from disk (importing routes.inference
         # drags in heavy deps).
-        routes_src = (
-            Path(__file__).resolve().parent.parent / "routes" / "inference.py"
-        ).read_text()
+        routes_src = (Path(__file__).resolve().parent.parent / "routes" / "inference.py").read_text(
+            encoding = "utf-8"
+        )
         start = routes_src.index("def _request_matches_loaded_settings")
         end = routes_src.index("\ndef ", start + 1)
         body = "".join(routes_src[start:end].split())
@@ -832,9 +836,9 @@ class TestExtraArgsMtpDetection:
     def test_route_matcher_retries_after_drafter_not_found(self):
         # drafter_not_found must not report "already loaded" or the reload never
         # retries the download (#6459). Read source: importing routes pulls deps.
-        routes_src = (
-            Path(__file__).resolve().parent.parent / "routes" / "inference.py"
-        ).read_text()
+        routes_src = (Path(__file__).resolve().parent.parent / "routes" / "inference.py").read_text(
+            encoding = "utf-8"
+        )
         start = routes_src.index("def _request_matches_loaded_settings")
         end = routes_src.index("\ndef ", start + 1)
         body = "".join(routes_src[start:end].split())
@@ -990,7 +994,7 @@ def test_qwen36_class_regression_picks_lower_ctx_with_mtp():
     strictly lower one once the MTP draft reserve is accounted for."""
     b = _make_backend()
     b._can_estimate_kv = lambda: True
-    b._estimate_kv_cache_bytes = lambda n, _t = None, **_k: (0 if n <= 0 else int(n * 66_000))
+    b._estimate_kv_cache_bytes = lambda n, _t = None, **_k: 0 if n <= 0 else int(n * 66_000)
     avail_mib = 24_000
     model = int(17.9 * GIB)  # UD-Q4_K_XL weights
     no_mtp = b._fit_context_to_vram(262144, avail_mib, model)

--- a/studio/backend/tests/test_native_context_length.py
+++ b/studio/backend/tests/test_native_context_length.py
@@ -374,7 +374,7 @@ class TestRouteCompleteness:
     def _load_source(self):
         """Read routes/inference.py source once."""
         routes_path = Path(__file__).resolve().parent.parent / "routes" / "inference.py"
-        self._source = routes_path.read_text()
+        self._source = routes_path.read_text(encoding = "utf-8")
 
     def _find_construction_blocks(self, class_name: str) -> list[str]:
         """Extract all code blocks that construct a given response class."""

--- a/studio/backend/tests/test_native_template_trust_remote_code.py
+++ b/studio/backend/tests/test_native_template_trust_remote_code.py
@@ -170,7 +170,9 @@ def test_backend_model_info_persists_trust_remote_code():
     """Both backends must store ``trust_remote_code`` on their per-model info dict so
     ``render_native_template`` can source the consent value. Guards against the read
     landing on a key ``load_model`` never sets (which would silently no-op the fix)."""
-    inf = (Path(_BACKEND_DIR) / "core" / "inference" / "inference.py").read_text()
-    mlx = (Path(_BACKEND_DIR) / "core" / "inference" / "mlx_inference.py").read_text()
+    inf = (Path(_BACKEND_DIR) / "core" / "inference" / "inference.py").read_text(encoding = "utf-8")
+    mlx = (Path(_BACKEND_DIR) / "core" / "inference" / "mlx_inference.py").read_text(
+        encoding = "utf-8"
+    )
     assert '"trust_remote_code": trust_remote_code,' in inf
     assert '"trust_remote_code": trust_remote_code,' in mlx

--- a/studio/backend/tests/test_offline_inference_parent.py
+++ b/studio/backend/tests/test_offline_inference_parent.py
@@ -205,7 +205,7 @@ class TestTrainingWorkerProbeNoGlobalTimeout:
         import re
         from pathlib import Path
 
-        src = Path(_BACKEND_DIR, "core", "training", "worker.py").read_text()
+        src = Path(_BACKEND_DIR, "core", "training", "worker.py").read_text(encoding = "utf-8")
         m = re.search(
             r'if\s+"HF_HUB_OFFLINE"\s+not\s+in\s+os\.environ\s*:.*?'
             r"print\([^)]*HF_HUB_OFFLINE=1[^)]*\)",

--- a/studio/backend/tests/test_recommended_folders_has_model.py
+++ b/studio/backend/tests/test_recommended_folders_has_model.py
@@ -32,7 +32,7 @@ def _load_has_downloaded_model():
     """Return the real ``_dir_has_downloaded_model`` (plus its ``_safe_is_dir``
     and ``_is_weight_bin`` deps, and the ``_WEIGHT_BIN_PREFIXES`` constant the
     latter reads) without importing the heavy module."""
-    tree = ast.parse(_models_src.read_text())
+    tree = ast.parse(_models_src.read_text(encoding = "utf-8"))
     wanted = {"_safe_is_dir", "_dir_has_downloaded_model", "_is_weight_bin"}
     body = []
     for node in tree.body:

--- a/studio/backend/tests/test_recommended_folders_permission.py
+++ b/studio/backend/tests/test_recommended_folders_permission.py
@@ -36,7 +36,7 @@ _models_src = _backend_root / "routes" / "models.py"
 def _load_safe_is_dir():
     """Return the real ``_safe_is_dir`` from routes/models.py without
     importing the dependency-laden module."""
-    tree = ast.parse(_models_src.read_text())
+    tree = ast.parse(_models_src.read_text(encoding = "utf-8"))
     fn = next(
         node
         for node in tree.body

--- a/studio/backend/tests/test_sandbox_tools.py
+++ b/studio/backend/tests/test_sandbox_tools.py
@@ -558,24 +558,24 @@ class TestSandboxCpuRlimitDefault:
     """Pin the default so a regression below 600s without opt-in is caught."""
 
     def test_default_cpu_s_is_600(self):
-        src = (_BACKEND_ROOT / "core" / "inference" / "tools.py").read_text()
+        src = (_BACKEND_ROOT / "core" / "inference" / "tools.py").read_text(encoding = "utf-8")
         assert 'UNSLOTH_STUDIO_SANDBOX_CPU_S", "600"' in src
 
     def test_clone_newnet_removed(self):
-        src = (_BACKEND_ROOT / "core" / "inference" / "tools.py").read_text()
+        src = (_BACKEND_ROOT / "core" / "inference" / "tools.py").read_text(encoding = "utf-8")
         assert "_libc.unshare(0x40000000)" not in src
         # Explanatory comment retained.
         assert "CLONE_NEWNET" in src
 
     def test_nofile_env_tunable(self):
-        src = (_BACKEND_ROOT / "core" / "inference" / "tools.py").read_text()
+        src = (_BACKEND_ROOT / "core" / "inference" / "tools.py").read_text(encoding = "utf-8")
         # Parity with the other rlimits: must come from the env, not be hardcoded.
         assert "UNSLOTH_STUDIO_SANDBOX_NOFILE" in src
 
 
 class TestMaxBodyDefault:
     def test_default_is_500_mb(self):
-        src = (_BACKEND_ROOT / "utils" / "upload_limits.py").read_text()
+        src = (_BACKEND_ROOT / "utils" / "upload_limits.py").read_text(encoding = "utf-8")
         assert "DEFAULT_UPLOAD_LIMIT_MB = 500" in src
         assert "UNSLOTH_STUDIO_MAX_BODY_MB" in src
 

--- a/studio/backend/tests/test_security_gate_consistency.py
+++ b/studio/backend/tests/test_security_gate_consistency.py
@@ -43,7 +43,7 @@ def test_capability_probes_thread_the_hf_token():
     offenders = []
     for path in _iter_caller_files():
         try:
-            tree = ast.parse(path.read_text())
+            tree = ast.parse(path.read_text(encoding = "utf-8"))
         except SyntaxError:
             continue
         for node in ast.walk(tree):
@@ -60,7 +60,7 @@ def test_capability_probes_thread_the_hf_token():
 def test_gguf_trust_remote_code_reported_inert_not_from_yaml():
     """GGUF never executes auto_map, so requires_trust_remote_code is reported via the
     resolver or False, never the raw YAML bool() (the round-6 regression)."""
-    src = (_BACKEND / "routes" / "inference.py").read_text()
+    src = (_BACKEND / "routes" / "inference.py").read_text(encoding = "utf-8")
     assert "requires_trust_remote_code = bool(" not in src, (
         "Report requires_trust_remote_code via _resolve_loaded_trust_remote_code "
         "(non-GGUF) or set it False (GGUF); never bool(inference_config.get(...))."
@@ -70,7 +70,7 @@ def test_gguf_trust_remote_code_reported_inert_not_from_yaml():
 def test_capability_detection_caches_are_token_aware():
     """Every capability cache is keyed by (model, token_fingerprint) so an unauthenticated
     miss cannot poison a later authenticated lookup (the audio-cache regression)."""
-    src = (_BACKEND / "utils" / "models" / "model_config.py").read_text()
+    src = (_BACKEND / "utils" / "models" / "model_config.py").read_text(encoding = "utf-8")
     offenders = []
     for line in src.splitlines():
         stripped = line.strip()
@@ -93,7 +93,7 @@ def test_malware_and_consent_gates_cover_the_lora_base():
     ]
     offenders = []
     for rel in gated_workers:
-        src = (_BACKEND / rel).read_text()
+        src = (_BACKEND / rel).read_text(encoding = "utf-8")
         runs_gate = "evaluate_file_security(" in src or "evaluate_remote_code_consent" in src
         resolves_base = "get_base_model_from_lora_identifier(" in src or "base_model" in src
         if runs_gate and not resolves_base:
@@ -107,7 +107,7 @@ def test_rag_embedding_path_runs_the_malware_gate():
     or a flagged repo loads unscanned (bypassing the normal model-load protections)."""
     offenders = []
     for rel in ("routes/settings.py", "core/rag/embeddings.py"):
-        if "evaluate_file_security(" not in (_BACKEND / rel).read_text():
+        if "evaluate_file_security(" not in (_BACKEND / rel).read_text(encoding = "utf-8"):
             offenders.append(
                 f"{rel} loads/persists an embedding model without evaluate_file_security"
             )

--- a/studio/backend/tests/test_ssm_runtime.py
+++ b/studio/backend/tests/test_ssm_runtime.py
@@ -401,13 +401,13 @@ def test_hip_uv_source_build_uses_no_cache(monkeypatch):
 
 
 def test_inference_worker_calls_ensure_ssm_runtime():
-    src = (_BACKEND / "core" / "inference" / "worker.py").read_text()
+    src = (_BACKEND / "core" / "inference" / "worker.py").read_text(encoding = "utf-8")
     assert "from utils.ssm_runtime import ensure_ssm_runtime" in src
     assert "ensure_ssm_runtime(" in src
 
 
 def test_inference_worker_skips_ssm_on_mlx_and_checks_lora_base():
-    src = (_BACKEND / "core" / "inference" / "worker.py").read_text()
+    src = (_BACKEND / "core" / "inference" / "worker.py").read_text(encoding = "utf-8")
     # MLX (Apple Silicon) must not try to build CUDA/ROCm SSM kernels.
     assert 'getattr(backend, "device", None) != "mlx"' in src
     # A LoRA load must also check its base model, not just the adapter id.
@@ -417,12 +417,12 @@ def test_inference_worker_skips_ssm_on_mlx_and_checks_lora_base():
 def test_inference_worker_resolves_remote_lora_base_pre_import():
     # A remote LoRA's base (from the Hub adapter_config.json) must be resolved before the
     # transformers import so its SSM kernels are pre-installed, not too late in _handle_load.
-    src = (_BACKEND / "core" / "inference" / "worker.py").read_text()
+    src = (_BACKEND / "core" / "inference" / "worker.py").read_text(encoding = "utf-8")
     assert "_remote_lora_base" in src
 
 
 def test_inference_worker_tiers_on_base_and_gates_lora_base_only():
-    src = (_BACKEND / "core" / "inference" / "worker.py").read_text()
+    src = (_BACKEND / "core" / "inference" / "worker.py").read_text(encoding = "utf-8")
     # Tier activation runs on the resolved base, not the raw adapter id (remote-LoRA fix).
     assert "_activate_transformers_version(_base" in src
     # The gate only adds a genuine LoRA base, never a full fine-tune's recorded (unloaded) base.
@@ -432,7 +432,7 @@ def test_inference_worker_tiers_on_base_and_gates_lora_base_only():
 def test_inference_worker_probes_base_for_ssm_kernels():
     # Both the pre-import path and _handle_load must derive SSM targets from a real model id
     # via ssm_probe_identifier, not the raw adapter id / local checkpoint path.
-    src = (_BACKEND / "core" / "inference" / "worker.py").read_text()
+    src = (_BACKEND / "core" / "inference" / "worker.py").read_text(encoding = "utf-8")
     assert src.count("ssm_probe_identifier(") >= 2
 
 
@@ -484,7 +484,7 @@ def test_pre_import_gate_is_transformers_free():
 def test_pre_import_gate_skips_subdir_computation():
     # The worker's pre-import preflight must call the gate with compute_subdirs=False so it
     # never imports model_config/transformers before the SSM kernels are installed.
-    src = (_BACKEND / "core" / "inference" / "worker.py").read_text()
+    src = (_BACKEND / "core" / "inference" / "worker.py").read_text(encoding = "utf-8")
     assert "compute_subdirs = False" in src
 
 
@@ -506,7 +506,7 @@ def test_security_gates_run_before_ssm_install():
     # The SSM install is name-based and can source-build native packages, so a malware /
     # blocked-code model must be refused first -- in both the pre-import path and _handle_load.
     import ast
-    tree = ast.parse((_BACKEND / "core" / "inference" / "worker.py").read_text())
+    tree = ast.parse((_BACKEND / "core" / "inference" / "worker.py").read_text(encoding = "utf-8"))
     for fn in ("run_inference_process", "_handle_load"):
         gates = _call_linenos(tree, fn, "_run_security_gates")
         ssm = _call_linenos(tree, fn, "_ensure_ssm_kernels")

--- a/studio/backend/tests/test_studio_api.py
+++ b/studio/backend/tests/test_studio_api.py
@@ -784,11 +784,16 @@ def _start_server(model: str, variant: str | None) -> tuple[subprocess.Popen, st
 
     LOG_FILE.parent.mkdir(parents = True, exist_ok = True)
     log_fh = open(LOG_FILE, "w", encoding = "utf-8")
+    # The child writes to this descriptor itself, so the parent's encoding does
+    # not transcode anything: tell the child to emit utf-8 or the reads below
+    # decode its locale bytes as utf-8 and raise on the first non-ASCII glyph.
+    child_env = {**os.environ, "PYTHONIOENCODING": "utf-8", "PYTHONUTF8": "1"}
     proc = subprocess.Popen(
         cmd,
         stdout = log_fh,
         stderr = subprocess.STDOUT,
         preexec_fn = os.setsid,
+        env = child_env,
     )
 
     # Wait for the banner containing the API key

--- a/studio/backend/tests/test_studio_api.py
+++ b/studio/backend/tests/test_studio_api.py
@@ -363,17 +363,17 @@ def test_openai_tools_nonstream(base_url: str, api_key: str):
     data = json.loads(text)
     assert "choices" in data, f"Missing 'choices': {text[:300]}"
     choice = data["choices"][0]
-    assert choice["finish_reason"] == "tool_calls", (
-        f"Expected finish_reason='tool_calls', got {choice['finish_reason']!r}"
-    )
+    assert (
+        choice["finish_reason"] == "tool_calls"
+    ), f"Expected finish_reason='tool_calls', got {choice['finish_reason']!r}"
     msg = choice["message"]
     tool_calls = msg.get("tool_calls") or []
     assert len(tool_calls) >= 1, f"No tool_calls in response: {msg}"
     first = tool_calls[0]
     assert first["type"] == "function"
-    assert first["function"]["name"] == "get_weather", (
-        f"Wrong tool name: {first['function']['name']!r}"
-    )
+    assert (
+        first["function"]["name"] == "get_weather"
+    ), f"Wrong tool name: {first['function']['name']!r}"
     # arguments must be valid JSON
     parsed = json.loads(first["function"]["arguments"])
     assert "city" in parsed, f"Tool call missing required 'city' arg: {parsed}"
@@ -403,9 +403,9 @@ def test_openai_tools_stream(base_url: str, api_key: str):
     )
     assert status == 200, f"Expected 200, got {status}"
     assert len(chunks) > 0, "No SSE chunks received"
-    assert _final_finish_reason(chunks) == "tool_calls", (
-        f"Expected final finish_reason='tool_calls', got {_final_finish_reason(chunks)!r}"
-    )
+    assert (
+        _final_finish_reason(chunks) == "tool_calls"
+    ), f"Expected final finish_reason='tool_calls', got {_final_finish_reason(chunks)!r}"
     assembled = _collect_streamed_tool_calls(chunks)
     assert len(assembled) >= 1, "No tool_calls reassembled from stream"
     first = assembled[0]
@@ -464,9 +464,9 @@ def test_openai_tools_multiturn(base_url: str, api_key: str):
     msg = data["choices"][0]["message"]
     # The model should respond with text now it has the tool result
     content = msg.get("content") or ""
-    assert len(content) > 0 or msg.get("tool_calls"), (
-        f"Expected text or follow-up tool call, got empty message: {msg}"
-    )
+    assert len(content) > 0 or msg.get(
+        "tool_calls"
+    ), f"Expected text or follow-up tool call, got empty message: {msg}"
     print(f"  PASS  openai tools multiturn: {content[:80]!r}")
 
 
@@ -486,9 +486,9 @@ def test_openai_sdk_tool_calling(base_url: str, api_key: str):
         tool_choice = "required",
         stream = False,
     )
-    assert resp.choices[0].finish_reason == "tool_calls", (
-        f"Expected finish_reason='tool_calls', got {resp.choices[0].finish_reason!r}"
-    )
+    assert (
+        resp.choices[0].finish_reason == "tool_calls"
+    ), f"Expected finish_reason='tool_calls', got {resp.choices[0].finish_reason!r}"
     tool_calls = resp.choices[0].message.tool_calls
     assert tool_calls and len(tool_calls) >= 1, "No tool_calls from SDK"
     tc = tool_calls[0]

--- a/studio/backend/tests/test_studio_api.py
+++ b/studio/backend/tests/test_studio_api.py
@@ -363,17 +363,17 @@ def test_openai_tools_nonstream(base_url: str, api_key: str):
     data = json.loads(text)
     assert "choices" in data, f"Missing 'choices': {text[:300]}"
     choice = data["choices"][0]
-    assert (
-        choice["finish_reason"] == "tool_calls"
-    ), f"Expected finish_reason='tool_calls', got {choice['finish_reason']!r}"
+    assert choice["finish_reason"] == "tool_calls", (
+        f"Expected finish_reason='tool_calls', got {choice['finish_reason']!r}"
+    )
     msg = choice["message"]
     tool_calls = msg.get("tool_calls") or []
     assert len(tool_calls) >= 1, f"No tool_calls in response: {msg}"
     first = tool_calls[0]
     assert first["type"] == "function"
-    assert (
-        first["function"]["name"] == "get_weather"
-    ), f"Wrong tool name: {first['function']['name']!r}"
+    assert first["function"]["name"] == "get_weather", (
+        f"Wrong tool name: {first['function']['name']!r}"
+    )
     # arguments must be valid JSON
     parsed = json.loads(first["function"]["arguments"])
     assert "city" in parsed, f"Tool call missing required 'city' arg: {parsed}"
@@ -404,7 +404,7 @@ def test_openai_tools_stream(base_url: str, api_key: str):
     assert status == 200, f"Expected 200, got {status}"
     assert len(chunks) > 0, "No SSE chunks received"
     assert _final_finish_reason(chunks) == "tool_calls", (
-        f"Expected final finish_reason='tool_calls', got " f"{_final_finish_reason(chunks)!r}"
+        f"Expected final finish_reason='tool_calls', got {_final_finish_reason(chunks)!r}"
     )
     assembled = _collect_streamed_tool_calls(chunks)
     assert len(assembled) >= 1, "No tool_calls reassembled from stream"
@@ -464,9 +464,9 @@ def test_openai_tools_multiturn(base_url: str, api_key: str):
     msg = data["choices"][0]["message"]
     # The model should respond with text now it has the tool result
     content = msg.get("content") or ""
-    assert len(content) > 0 or msg.get(
-        "tool_calls"
-    ), f"Expected text or follow-up tool call, got empty message: {msg}"
+    assert len(content) > 0 or msg.get("tool_calls"), (
+        f"Expected text or follow-up tool call, got empty message: {msg}"
+    )
     print(f"  PASS  openai tools multiturn: {content[:80]!r}")
 
 
@@ -487,7 +487,7 @@ def test_openai_sdk_tool_calling(base_url: str, api_key: str):
         stream = False,
     )
     assert resp.choices[0].finish_reason == "tool_calls", (
-        f"Expected finish_reason='tool_calls', got " f"{resp.choices[0].finish_reason!r}"
+        f"Expected finish_reason='tool_calls', got {resp.choices[0].finish_reason!r}"
     )
     tool_calls = resp.choices[0].message.tool_calls
     assert tool_calls and len(tool_calls) >= 1, "No tool_calls from SDK"
@@ -495,7 +495,7 @@ def test_openai_sdk_tool_calling(base_url: str, api_key: str):
     assert tc.function.name == "get_weather"
     parsed = json.loads(tc.function.arguments)
     assert "city" in parsed
-    print(f"  PASS  openai SDK tool calling: " f"tool={tc.function.name}, args={parsed}")
+    print(f"  PASS  openai SDK tool calling: tool={tc.function.name}, args={parsed}")
 
 
 def test_invalid_key_rejected(base_url: str):
@@ -783,7 +783,7 @@ def _start_server(model: str, variant: str | None) -> tuple[subprocess.Popen, st
         cmd.extend(["--gguf-variant", variant])
 
     LOG_FILE.parent.mkdir(parents = True, exist_ok = True)
-    log_fh = open(LOG_FILE, "w")
+    log_fh = open(LOG_FILE, "w", encoding = "utf-8")
     proc = subprocess.Popen(
         cmd,
         stdout = log_fh,
@@ -798,16 +798,16 @@ def _start_server(model: str, variant: str | None) -> tuple[subprocess.Popen, st
         time.sleep(2)
         if proc.poll() is not None:
             log_fh.flush()
-            log_text = LOG_FILE.read_text()
+            log_text = LOG_FILE.read_text(encoding = "utf-8")
             raise RuntimeError(f"Server exited early (code {proc.returncode}):\n{log_text[-2000:]}")
-        log_text = LOG_FILE.read_text()
+        log_text = LOG_FILE.read_text(encoding = "utf-8")
         m = re.search(r"API Key:\s+(sk-unsloth-[a-f0-9]+)", log_text)
         if m:
             api_key = m.group(1)
             break
 
     if not api_key:
-        log_text = LOG_FILE.read_text()
+        log_text = LOG_FILE.read_text(encoding = "utf-8")
         _kill_server(proc)
         raise RuntimeError(f"Timed out waiting for API key in server output:\n{log_text[-2000:]}")
 

--- a/studio/backend/tests/test_tool_call_parser_strict.py
+++ b/studio/backend/tests/test_tool_call_parser_strict.py
@@ -64,9 +64,7 @@ class TestFunctionStyleTrailingText:
         # The real closing </function> is the last one; the literal inside
         # the code argument must survive (rfind, not the first match).
         text = (
-            "<function=python><parameter=code>"
-            'print("</function>")'
-            "</parameter></function> all done"
+            '<function=python><parameter=code>print("</function>")</parameter></function> all done'
         )
         call = _only(text)
         assert call == {"name": "python", "arguments": {"code": 'print("</function>")'}}
@@ -146,9 +144,7 @@ class TestParityWithJsonStyle:
 
 class TestGemmaNativeStyle:
     def test_closed_native_call_with_trailing_prose_is_accepted(self):
-        text = (
-            '<|tool_call>call:terminal{command:"ls -la",workdir:"."}<tool_call|>' " running it now"
-        )
+        text = '<|tool_call>call:terminal{command:"ls -la",workdir:"."}<tool_call|> running it now'
         calls = parse_tool_calls_from_text(text, allow_incomplete = False)
         assert len(calls) == 1
         assert calls[0]["function"]["name"] == "terminal"
@@ -792,7 +788,7 @@ def test_tool_call_parser_declares_future_annotations_for_py39_import():
     from pathlib import Path
     src = (
         Path(__file__).resolve().parent.parent / "core" / "inference" / "tool_call_parser.py"
-    ).read_text()
+    ).read_text(encoding = "utf-8")
     assert "from __future__ import annotations" in src
 
 
@@ -1069,8 +1065,7 @@ class TestBareJsonOuterOverXmlLiteral:
 
     def test_bare_json_code_arg_quoting_function_xml(self):
         text = (
-            '{"name": "python", "arguments": '
-            '{"code": "run() # <function=terminal>ls</function>"}}'
+            '{"name": "python", "arguments": {"code": "run() # <function=terminal>ls</function>"}}'
         )
         calls = parse_tool_calls_from_text(text, enabled_tool_names = {"python"})
         assert [c["function"]["name"] for c in calls] == ["python"]
@@ -1300,8 +1295,7 @@ class TestLeadingWrapperlessGemmaOverEmbeddedMarkers:
 
     def test_leading_gemma_wins_over_quoted_xml_literal(self):
         text = (
-            'call:web_search{query:"explain <tool_call>'
-            '{"name":"evil","arguments":{}}</tool_call>"}'
+            'call:web_search{query:"explain <tool_call>{"name":"evil","arguments":{}}</tool_call>"}'
         )
         calls = parse_tool_calls_from_text(text, enabled_tool_names = {"web_search", "evil"})
         assert [c["function"]["name"] for c in calls] == ["web_search"]

--- a/studio/backend/tests/test_tool_xml_strip.py
+++ b/studio/backend/tests/test_tool_xml_strip.py
@@ -21,7 +21,7 @@ if _BACKEND_DIR not in sys.path:
 # Extract the regex from source (routes module needs heavy stubbing to import).
 import re as _re
 
-_src = (Path(_BACKEND_DIR) / "routes" / "inference.py").read_text()
+_src = (Path(_BACKEND_DIR) / "routes" / "inference.py").read_text(encoding = "utf-8")
 _m = _re.search(r"_TOOL_XML_RE = _re\.compile\((.*?)\n\)", _src, _re.DOTALL)
 assert _m, "could not extract _TOOL_XML_RE source"
 # The lazy ``(.*?)\n\)`` could grab a shorter expression if an arm is ever wrapped;

--- a/studio/backend/tests/test_tp_vision_regression.py
+++ b/studio/backend/tests/test_tp_vision_regression.py
@@ -450,7 +450,7 @@ def test_fallback_hint_uses_effective_tensor_request_not_just_toggle():
     """Tensor intent keys off _effective_tensor_parallel (toggle + extras + env), not
     just the toggle, so extra/env-driven tensor users keep multi-GPU (#6659)."""
     route = Path(_BACKEND_DIR) / "routes" / "inference.py"
-    src = route.read_text()
+    src = route.read_text(encoding = "utf-8")
     idx = src.find("_tensor_intent_overall = _effective_tensor_parallel(")
     assert idx != -1, "the GGUF load closure must compute tensor intent"
     block = src[idx : idx + 300]
@@ -482,7 +482,7 @@ def test_preserved_fallback_carried_across_non_drop_reload():
     gated on the same model loaded, so a ctx-only reload keeps multi-GPU but a model
     switch / explicit drop doesn't inherit it (#6659)."""
     route = Path(_BACKEND_DIR) / "routes" / "inference.py"
-    src = route.read_text()
+    src = route.read_text(encoding = "utf-8")
     idx = src.find("_tensor_intent_overall = _effective_tensor_parallel(")
     assert idx != -1
     block = src[idx : idx + 400]
@@ -499,7 +499,7 @@ def test_same_model_guard_checks_path_and_variant():
     repo), so a reload keeps the carry-forward and a different variant doesn't inherit
     the prior one's preserved tensor intent (#6659)."""
     route = Path(_BACKEND_DIR) / "routes" / "inference.py"
-    src = route.read_text()
+    src = route.read_text(encoding = "utf-8")
     idx = src.find("_same_model_loaded = (")
     assert idx != -1
     block = src[idx : idx + 1300]
@@ -748,7 +748,7 @@ def test_explicit_tensor_drop_uses_shared_helper_in_both_readers():
     _is_explicit_tensor_drop, so they agree on what counts as a drop -- a reload for
     an unrelated extra still carries the preserved intent rather than collapsing to one
     GPU (Codex #6659)."""
-    src = (Path(_BACKEND_DIR) / "routes" / "inference.py").read_text()
+    src = (Path(_BACKEND_DIR) / "routes" / "inference.py").read_text(encoding = "utf-8")
     # Dedup reader (the preserved-fallback reload guard).
     assert "layer_preserves_tensor_intent and _is_explicit_tensor_drop(request)" in src
     # Load carry-forward reader feeds the same decision into the carry-forward.

--- a/studio/backend/tests/test_training_raw_support.py
+++ b/studio/backend/tests/test_training_raw_support.py
@@ -163,13 +163,13 @@ class TestTrainingRawSupport(unittest.TestCase):
     def test_route_forwards_all_grad_clipping_fields(self):
         # The HTTP route builds the config dict by hand; a schema field that
         # is not forwarded here is silently dropped for REST callers.
-        source = (_BACKEND_ROOT / "routes" / "training.py").read_text()
+        source = (_BACKEND_ROOT / "routes" / "training.py").read_text(encoding = "utf-8")
         self.assertIn('"max_grad_norm": request.max_grad_norm', source)
         self.assertIn('"max_grad_value": request.max_grad_value', source)
         self.assertIn('"max_grad_leaf_norm": request.max_grad_leaf_norm', source)
 
     def test_mlx_worker_falls_back_init_seeds_to_random_seed(self):
-        source = (_BACKEND_ROOT / "core" / "training" / "worker.py").read_text()
+        source = (_BACKEND_ROOT / "core" / "training" / "worker.py").read_text(encoding = "utf-8")
 
         # random_seed itself is normalized first so explicit None coming
         # from a raw / backend caller does not propagate through the chain.
@@ -198,7 +198,7 @@ class TestTrainingRawSupport(unittest.TestCase):
         self.assertIn("seed = random_seed,", source)
 
     def test_mlx_worker_preserves_null_max_grad_value_for_trainer_default(self):
-        source = (_BACKEND_ROOT / "core" / "training" / "worker.py").read_text()
+        source = (_BACKEND_ROOT / "core" / "training" / "worker.py").read_text(encoding = "utf-8")
 
         # None must survive to the MLX trainer so it picks its own runtime
         # default, and any other value must coerce to float without
@@ -251,7 +251,7 @@ class TestTrainingRawSupport(unittest.TestCase):
         # unsloth-zoo update. Until that floor is in place, the
         # worker must gate them so releases that predate those fields can
         # still construct MLXTrainingConfig without TypeError.
-        source = (_BACKEND_ROOT / "core" / "training" / "worker.py").read_text()
+        source = (_BACKEND_ROOT / "core" / "training" / "worker.py").read_text(encoding = "utf-8")
 
         self.assertIn(
             'getattr(MLXTrainingConfig, "__dataclass_fields__", {})',

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -2672,7 +2672,7 @@ class TestLatestTierForces16Bit:
 
     def _read(self, rel):
         backend_dir = Path(__file__).resolve().parent.parent
-        return (backend_dir / rel).read_text()
+        return (backend_dir / rel).read_text(encoding = "utf-8")
 
     def test_worker_guard_present(self):
         src = self._read("core/inference/worker.py")

--- a/studio/backend/tests/test_yaml_trust_remote_code_removed.py
+++ b/studio/backend/tests/test_yaml_trust_remote_code_removed.py
@@ -19,7 +19,7 @@ _MODEL_DEFAULTS = _CONFIGS / "model_defaults"
 def test_no_model_default_yaml_sets_trust_remote_code():
     offenders = []
     for f in _MODEL_DEFAULTS.rglob("*.yaml"):
-        doc = yaml.safe_load(f.read_text()) or {}
+        doc = yaml.safe_load(f.read_text(encoding = "utf-8")) or {}
         if not isinstance(doc, dict):
             continue
         for section, body in doc.items():
@@ -37,7 +37,7 @@ def test_no_model_default_yaml_has_empty_or_none_section():
     # A bare `inference:` header (no keys) parses to None and crashes the .get() loaders.
     offenders = []
     for f in _MODEL_DEFAULTS.rglob("*.yaml"):
-        doc = yaml.safe_load(f.read_text())
+        doc = yaml.safe_load(f.read_text(encoding = "utf-8"))
         if not isinstance(doc, dict):
             offenders.append(f"{f.relative_to(_CONFIGS)} (not a mapping)")
             continue
@@ -96,7 +96,7 @@ def test_all_model_yamls_load_for_training_and_inference():
 
 def test_base_templates_have_no_trust_remote_code():
     for name in ("full_finetune.yaml", "lora_text.yaml", "vision_lora.yaml"):
-        doc = yaml.safe_load((_CONFIGS / name).read_text()) or {}
+        doc = yaml.safe_load((_CONFIGS / name).read_text(encoding = "utf-8")) or {}
         flat = yaml.safe_dump(doc)
         assert "trust_remote_code" not in flat, f"{name} should not set trust_remote_code"
 

--- a/tests/python/test_cpo_processor_text_tokenizer.py
+++ b/tests/python/test_cpo_processor_text_tokenizer.py
@@ -40,7 +40,7 @@ def _registrations(source):
 
 
 def test_cpo_registration_matches_orpo():
-    regs = _registrations(open(RL_PATH).read())
+    regs = _registrations(open(RL_PATH, encoding = "utf-8").read())
     shared = {"orpo_trainer_text_tokenizer", "orpo_trainer_processor_pad_token"}
     assert shared <= set(regs.get("orpo_trainer", []))
     assert shared <= set(regs.get("cpo_trainer", []))
@@ -48,7 +48,7 @@ def test_cpo_registration_matches_orpo():
 
 def _load_pad_rewriter():
     """Exec orpo_trainer_processor_pad_token (+ _PAD_FALLBACK) without importing unsloth."""
-    tree = ast.parse(open(RL_PATH).read())
+    tree = ast.parse(open(RL_PATH, encoding = "utf-8").read())
     nodes = []
     for n in tree.body:
         if isinstance(n, ast.Assign) and any(

--- a/tests/python/test_dpo_vision_processor_passthrough.py
+++ b/tests/python/test_dpo_vision_processor_passthrough.py
@@ -11,7 +11,7 @@ RL_PATH = os.path.join(REPO_ROOT, "unsloth", "models", "rl_replacements.py")
 
 
 def _load_helpers():
-    src = open(RL_PATH).read()
+    src = open(RL_PATH, encoding = "utf-8").read()
     tree = ast.parse(src)
     import torch as _torch
 

--- a/tests/python/test_e2e_no_torch_sandbox.py
+++ b/tests/python/test_e2e_no_torch_sandbox.py
@@ -193,7 +193,7 @@ class TestBeforeAfterImportChain:
             mm = types.ModuleType('model_mappings')
             mm.MODEL_TO_TEMPLATE_MAPPER = {{}}
             sys.modules['model_mappings'] = mm
-            source = open({str(before_file)!r}).read()
+            source = open({str(before_file)!r}, encoding = "utf-8").read()
             source = source.replace('from .format_detection import', 'from format_detection import')
             source = source.replace('from .model_mappings import', 'from model_mappings import')
             exec(source)
@@ -215,7 +215,7 @@ class TestBeforeAfterImportChain:
             loggers = types.ModuleType('loggers')
             loggers.get_logger = lambda n: None
             sys.modules['loggers'] = loggers
-            exec(open({str(before_file)!r}).read())
+            exec(open({str(before_file)!r}, encoding = "utf-8").read())
         """)
         result = _run_in_sandbox(no_torch_venv, code)
         assert result.returncode != 0, "BEFORE data_collators.py should crash without torch"
@@ -284,7 +284,7 @@ class TestBeforeAfterImportChain:
             it = types.ModuleType('iterable')
             it.is_streaming_dataset = lambda *a, **k: False
             sys.modules['iterable'] = it
-            source = open({str(CHAT_TEMPLATES)!r}).read()
+            source = open({str(CHAT_TEMPLATES)!r}, encoding = "utf-8").read()
             source = source.replace('from .format_detection import', 'from format_detection import')
             source = source.replace('from .model_mappings import', 'from model_mappings import')
             source = source.replace('from .iterable import', 'from iterable import')
@@ -304,7 +304,7 @@ class TestBeforeAfterImportChain:
             loggers = types.ModuleType('loggers')
             loggers.get_logger = lambda n: None
             sys.modules['loggers'] = loggers
-            exec(open({str(DATA_COLLATORS)!r}).read())
+            exec(open({str(DATA_COLLATORS)!r}, encoding = "utf-8").read())
             print("OK")
         """)
         result = _run_in_sandbox(no_torch_venv, code)
@@ -382,7 +382,7 @@ class TestDataclassInstantiation:
             loggers = types.ModuleType('loggers')
             loggers.get_logger = lambda n: None
             sys.modules['loggers'] = loggers
-            exec(open({str(DATA_COLLATORS)!r}).read())
+            exec(open({str(DATA_COLLATORS)!r}, encoding = "utf-8").read())
             obj = DataCollatorSpeechSeq2SeqWithPadding(processor=None)
             assert obj.processor is None
             print("OK")
@@ -397,7 +397,7 @@ class TestDataclassInstantiation:
             loggers = types.ModuleType('loggers')
             loggers.get_logger = lambda n: None
             sys.modules['loggers'] = loggers
-            exec(open({str(DATA_COLLATORS)!r}).read())
+            exec(open({str(DATA_COLLATORS)!r}, encoding = "utf-8").read())
             obj = DeepSeekOCRDataCollator(processor=None)
             assert obj.processor is None
             assert obj.max_length == 2048
@@ -414,7 +414,7 @@ class TestDataclassInstantiation:
             loggers = types.ModuleType('loggers')
             loggers.get_logger = lambda n: None
             sys.modules['loggers'] = loggers
-            exec(open({str(DATA_COLLATORS)!r}).read())
+            exec(open({str(DATA_COLLATORS)!r}, encoding = "utf-8").read())
             obj = VLMDataCollator(processor=None)
             assert obj.processor is None
             assert obj.max_length == 2048
@@ -441,7 +441,7 @@ class TestDataclassInstantiation:
             it.is_streaming_dataset = lambda *a, **k: False
             sys.modules['iterable'] = it
             ns = {{}}
-            source = open({str(CHAT_TEMPLATES)!r}).read()
+            source = open({str(CHAT_TEMPLATES)!r}, encoding = "utf-8").read()
             source = source.replace('from .format_detection import', 'from format_detection import')
             source = source.replace('from .model_mappings import', 'from model_mappings import')
             source = source.replace('from .iterable import', 'from iterable import')
@@ -473,7 +473,7 @@ class TestEdgeCasesBrokenTorch:
         code = textwrap.dedent(f"""\
             import sys
             sys.path.insert(0, {str(sandbox_dir)!r})
-            exec(open({str(sandbox_dir / 'data_collators.py')!r}).read())
+            exec(open({str(sandbox_dir / 'data_collators.py')!r}, encoding = "utf-8").read())
             obj = DataCollatorSpeechSeq2SeqWithPadding(processor=None)
             print("OK: data_collators works despite broken torch on sys.path")
         """)
@@ -495,7 +495,7 @@ class TestEdgeCasesBrokenTorch:
         code = textwrap.dedent(f"""\
             import sys
             sys.path.insert(0, {str(sandbox_dir)!r})
-            source = open({str(HARDWARE_PY)!r}).read()
+            source = open({str(HARDWARE_PY)!r}, encoding = "utf-8").read()
             ns = {{'__name__': '__test__'}}
             exec(source, ns)
             result = ns['detect_hardware']()
@@ -530,7 +530,7 @@ class TestEdgeCasesBrokenTorch:
         code = textwrap.dedent(f"""\
             import sys
             sys.path.insert(0, {str(sandbox_dir)!r})
-            source = open({str(HARDWARE_PY)!r}).read()
+            source = open({str(HARDWARE_PY)!r}, encoding = "utf-8").read()
             ns = {{'__name__': '__test__'}}
             exec(source, ns)
             result = ns['detect_hardware']()
@@ -559,7 +559,7 @@ class TestEdgeCasesBrokenTorch:
             sys.modules['iterable'] = it
 
             ns = {{}}
-            source = open({str(CHAT_TEMPLATES)!r}).read()
+            source = open({str(CHAT_TEMPLATES)!r}, encoding = "utf-8").read()
             source = source.replace('from .format_detection import', 'from format_detection import')
             source = source.replace('from .model_mappings import', 'from model_mappings import')
             source = source.replace('from .iterable import', 'from iterable import')
@@ -604,7 +604,7 @@ class TestHardwareDetectionNoTorch:
         code = textwrap.dedent(f"""\
             import sys
             sys.path.insert(0, {str(sandbox_dir)!r})
-            source = open({str(HARDWARE_PY)!r}).read()
+            source = open({str(HARDWARE_PY)!r}, encoding = "utf-8").read()
             ns = {{'__name__': '__test__'}}
             exec(source, ns)
             device = ns['detect_hardware']()
@@ -624,7 +624,7 @@ class TestHardwareDetectionNoTorch:
         code = textwrap.dedent(f"""\
             import sys
             sys.path.insert(0, {str(sandbox_dir)!r})
-            source = open({str(HARDWARE_PY)!r}).read()
+            source = open({str(HARDWARE_PY)!r}, encoding = "utf-8").read()
             ns = {{'__name__': '__test__'}}
             exec(source, ns)
             versions = ns['get_package_versions']()
@@ -651,7 +651,7 @@ class TestHardwareDetectionNoTorch:
         code = textwrap.dedent(f"""\
             import sys
             sys.path.insert(0, {str(sandbox_dir)!r})
-            source = open({str(hw_sandbox / 'hardware.py')!r}).read()
+            source = open({str(hw_sandbox / 'hardware.py')!r}, encoding = "utf-8").read()
             ns = {{'__name__': '__test__'}}
             exec(source, ns)
             assert callable(ns['detect_hardware'])

--- a/tests/python/test_fast_language_model_text_only.py
+++ b/tests/python/test_fast_language_model_text_only.py
@@ -14,7 +14,7 @@ UTILS_PATH = REPO_ROOT / "unsloth" / "models" / "_utils.py"
 
 
 def _source(path):
-    return path.read_text()
+    return path.read_text(encoding = "utf-8")
 
 
 def _class_method(tree, class_name, method_name):

--- a/tests/python/test_fast_model_config_passthrough.py
+++ b/tests/python/test_fast_model_config_passthrough.py
@@ -12,7 +12,7 @@ LLAMA_PATH = REPO_ROOT / "unsloth" / "models" / "llama.py"
 
 
 def _source(path):
-    return path.read_text()
+    return path.read_text(encoding = "utf-8")
 
 
 def _class_method(tree, class_name, method_name):

--- a/tests/python/test_gpu_init_ldconfig_guard.py
+++ b/tests/python/test_gpu_init_ldconfig_guard.py
@@ -17,13 +17,13 @@ def _find_geteuid_guard(tree: ast.AST):
 
 
 def test_gpu_init_has_geteuid_guard():
-    tree = ast.parse(GPU_INIT.read_text())
+    tree = ast.parse(GPU_INIT.read_text(encoding = "utf-8"))
     guard = _find_geteuid_guard(tree)
     assert guard is not None, "_gpu_init.py must guard ldconfig recovery on os.geteuid()"
 
 
 def test_ldconfig_calls_only_inside_geteuid_guard():
-    src = GPU_INIT.read_text()
+    src = GPU_INIT.read_text(encoding = "utf-8")
     tree = ast.parse(src)
     guard = _find_geteuid_guard(tree)
     assert guard is not None
@@ -39,6 +39,6 @@ def test_ldconfig_calls_only_inside_geteuid_guard():
 
 
 def test_non_root_branch_warns_when_bnb_present():
-    src = GPU_INIT.read_text()
+    src = GPU_INIT.read_text(encoding = "utf-8")
     assert "elif bnb is not None" in src
     assert "sudo ldconfig" in src

--- a/tests/python/test_grpo_ddp_model_config.py
+++ b/tests/python/test_grpo_ddp_model_config.py
@@ -9,7 +9,7 @@ SOURCE_PATH = os.path.join(REPO_ROOT, "unsloth", "models", "rl_replacements.py")
 
 
 def _read_source() -> str:
-    with open(SOURCE_PATH, "r") as fh:
+    with open(SOURCE_PATH, "r", encoding = "utf-8") as fh:
         return fh.read()
 
 

--- a/tests/python/test_orpo_processor_text_tokenizer.py
+++ b/tests/python/test_orpo_processor_text_tokenizer.py
@@ -10,7 +10,7 @@ RL_PATH = os.path.join(REPO_ROOT, "unsloth", "models", "rl_replacements.py")
 
 
 def _load_orpo_rewriter(name = "orpo_trainer_text_tokenizer"):
-    src = open(RL_PATH).read()
+    src = open(RL_PATH, encoding = "utf-8").read()
     tree = ast.parse(src)
     ns = {"re": re}
     # Materialise sibling module-level _-prefixed assignments the rewriter may reference.

--- a/tests/python/test_pad_token_fix.py
+++ b/tests/python/test_pad_token_fix.py
@@ -21,7 +21,7 @@ WANTED = {
 
 def _load_pad_helpers():
     """Exec only the pad-token helpers with a stub logger (no heavy imports)."""
-    tree = ast.parse(open(TOK_PATH).read())
+    tree = ast.parse(open(TOK_PATH, encoding = "utf-8").read())
     nodes = []
     for node in tree.body:
         if isinstance(node, ast.Assign):

--- a/tests/python/test_studio_import_no_torch.py
+++ b/tests/python/test_studio_import_no_torch.py
@@ -148,7 +148,7 @@ class TestDataCollatorsNoTorchVenv:
             loggers = types.ModuleType('loggers')
             loggers.get_logger = lambda n: None
             sys.modules['loggers'] = loggers
-            exec(open({str(DATA_COLLATORS)!r}).read())
+            exec(open({str(DATA_COLLATORS)!r}, encoding = "utf-8").read())
             print("OK: exec succeeded")
         """)
         result = subprocess.run(
@@ -168,7 +168,7 @@ class TestDataCollatorsNoTorchVenv:
             loggers = types.ModuleType('loggers')
             loggers.get_logger = lambda n: None
             sys.modules['loggers'] = loggers
-            exec(open({str(DATA_COLLATORS)!r}).read())
+            exec(open({str(DATA_COLLATORS)!r}, encoding = "utf-8").read())
             obj = DataCollatorSpeechSeq2SeqWithPadding(processor=None)
             assert obj.processor is None, "processor should be None"
             print("OK: DataCollatorSpeechSeq2SeqWithPadding instantiated")
@@ -190,7 +190,7 @@ class TestDataCollatorsNoTorchVenv:
             loggers = types.ModuleType('loggers')
             loggers.get_logger = lambda n: None
             sys.modules['loggers'] = loggers
-            exec(open({str(DATA_COLLATORS)!r}).read())
+            exec(open({str(DATA_COLLATORS)!r}, encoding = "utf-8").read())
             obj = DeepSeekOCRDataCollator(processor=None)
             assert obj.processor is None, "processor should be None"
             assert obj.max_length == 2048, "default max_length should be 2048"
@@ -212,7 +212,7 @@ class TestDataCollatorsNoTorchVenv:
             loggers = types.ModuleType('loggers')
             loggers.get_logger = lambda n: None
             sys.modules['loggers'] = loggers
-            exec(open({str(DATA_COLLATORS)!r}).read())
+            exec(open({str(DATA_COLLATORS)!r}, encoding = "utf-8").read())
             obj = VLMDataCollator(processor=None)
             assert obj.processor is None
             assert obj.mask_input_tokens is True, "default mask_input_tokens should be True"
@@ -259,7 +259,7 @@ class TestChatTemplatesNoTorchVenv:
             sys.modules['iterable'] = iterable
 
             # Read and transform the source: replace relative imports with absolute
-            source = open({str(CHAT_TEMPLATES)!r}).read()
+            source = open({str(CHAT_TEMPLATES)!r}, encoding = "utf-8").read()
             source = source.replace('from .format_detection import', 'from format_detection import')
             source = source.replace('from .model_mappings import', 'from model_mappings import')
             source = source.replace('from .iterable import', 'from iterable import')
@@ -305,7 +305,7 @@ class TestChatTemplatesNoTorchVenv:
             sys.modules['iterable'] = iterable
 
             ns = {{}}
-            source = open({str(CHAT_TEMPLATES)!r}).read()
+            source = open({str(CHAT_TEMPLATES)!r}, encoding = "utf-8").read()
             source = source.replace('from .format_detection import', 'from format_detection import')
             source = source.replace('from .model_mappings import', 'from model_mappings import')
             source = source.replace('from .iterable import', 'from iterable import')
@@ -402,7 +402,7 @@ class TestFormatConversionNoTorchVenv:
             sys.modules['utils.hardware'] = hardware_mod
 
             # Read and exec format_conversion.py
-            source = open({str(FORMAT_CONVERSION)!r}).read()
+            source = open({str(FORMAT_CONVERSION)!r}, encoding = "utf-8").read()
             source = source.replace('from .format_detection import', 'from format_detection import')
             source = source.replace('from .iterable import', 'from iterable import')
             ns = {{'__name__': '__test__'}}
@@ -463,7 +463,7 @@ class TestFormatConversionNoTorchVenv:
             sys.modules['utils'] = utils_mod
             sys.modules['utils.hardware'] = hardware_mod
 
-            source = open({str(FORMAT_CONVERSION)!r}).read()
+            source = open({str(FORMAT_CONVERSION)!r}, encoding = "utf-8").read()
             source = source.replace('from .format_detection import', 'from format_detection import')
             source = source.replace('from .iterable import', 'from iterable import')
             ns = {{'__name__': '__test__'}}
@@ -517,7 +517,7 @@ class TestNegativeControls:
                 loggers = types.ModuleType('loggers')
                 loggers.get_logger = lambda n: None
                 sys.modules['loggers'] = loggers
-                exec(open({temp_file!r}).read())
+                exec(open({temp_file!r}, encoding = "utf-8").read())
             """)
             result = subprocess.run(
                 [no_torch_venv, "-c", code],

--- a/tests/python/test_v100_fullft_precision.py
+++ b/tests/python/test_v100_fullft_precision.py
@@ -29,7 +29,7 @@ RL_PY = Path(__file__).resolve().parents[2] / "unsloth" / "models" / "rl.py"
 
 
 def _extract_mixed_precision_code() -> str:
-    lines = RL_PY.read_text().split("\n")
+    lines = RL_PY.read_text(encoding = "utf-8").split("\n")
     try:
         start = next(i for i, l in enumerate(lines) if "mixed_precision = (" in l)
     except StopIteration:

--- a/tests/python/test_vision_lora_targeting.py
+++ b/tests/python/test_vision_lora_targeting.py
@@ -37,7 +37,7 @@ def test_vlm_lora_regex_respects_language_only_with_explicit_targets():
 
 
 def test_fast_vision_model_wraps_explicit_targets_when_layer_filters_are_used():
-    source = Path("unsloth/models/vision.py").read_text()
+    source = Path("unsloth/models/vision.py").read_text(encoding = "utf-8")
 
     assert "target_modules = get_peft_regex(" in source
     assert "target_modules = list(target_modules)" in source

--- a/tests/saving/test_fix_sentencepiece_gguf_robustness.py
+++ b/tests/saving/test_fix_sentencepiece_gguf_robustness.py
@@ -82,7 +82,7 @@ def test_entry_with_non_int_id_is_skipped(tmp_path):
 
 
 def test_save_py_except_clause_is_broad_exception():
-    with open(_SAVE_PY) as f:
+    with open(_SAVE_PY, encoding = "utf-8") as f:
         tree = ast.parse(f.read())
     for node in ast.walk(tree):
         if isinstance(node, ast.FunctionDef) and node.name == "unsloth_save_pretrained_gguf":
@@ -102,7 +102,7 @@ def test_save_py_except_clause_is_broad_exception():
 
 
 def test_tokenizer_utils_uses_import_protobuf_fallback_pattern():
-    with open(_TOK_PY) as f:
+    with open(_TOK_PY, encoding = "utf-8") as f:
         src = f.read()
     tree = ast.parse(src)
     for node in ast.walk(tree):

--- a/tests/security/test_scan_packages.py
+++ b/tests/security/test_scan_packages.py
@@ -37,7 +37,9 @@ def test_fixture_bytes_are_deterministic(tmp_path):
     # The build helper writes to its own dir; copy + patch HERE.
     builder_src = (FIXTURES / "_build.py").read_text(encoding = "utf-8")
     rebuilt_helper = rebuild_dir / "_build.py"
-    rebuilt_helper.write_text(builder_src)
+    # builder_src came out of a checked-in file, so it carries whatever
+    # non-ASCII that file holds and cp1252 cannot encode it back out.
+    rebuilt_helper.write_text(builder_src, encoding = "utf-8")
     # Run with SOURCE_DATE_EPOCH=0 and HERE override via a shim.
     shim = rebuild_dir / "run.py"
     shim.write_text(

--- a/tests/security/test_scan_packages.py
+++ b/tests/security/test_scan_packages.py
@@ -35,7 +35,7 @@ def test_fixture_bytes_are_deterministic(tmp_path):
     rebuild_dir = tmp_path / "rebuild"
     rebuild_dir.mkdir()
     # The build helper writes to its own dir; copy + patch HERE.
-    builder_src = (FIXTURES / "_build.py").read_text()
+    builder_src = (FIXTURES / "_build.py").read_text(encoding = "utf-8")
     rebuilt_helper = rebuild_dir / "_build.py"
     rebuilt_helper.write_text(builder_src)
     # Run with SOURCE_DATE_EPOCH=0 and HERE override via a shim.
@@ -1260,7 +1260,7 @@ def test_committed_baseline_suppresses_known_but_not_a_new_payload():
     import json
 
     baseline_path = REPO_ROOT / "scripts" / "scan_packages_baseline.json"
-    entries = json.loads(baseline_path.read_text())["entries"]
+    entries = json.loads(baseline_path.read_text(encoding = "utf-8"))["entries"]
     target = next(
         e
         for e in entries
@@ -1296,7 +1296,7 @@ def test_committed_baseline_entries_all_carry_evidence_hash():
     import json
 
     baseline_path = REPO_ROOT / "scripts" / "scan_packages_baseline.json"
-    entries = json.loads(baseline_path.read_text())["entries"]
+    entries = json.loads(baseline_path.read_text(encoding = "utf-8"))["entries"]
     assert entries, "committed baseline should not be empty"
     missing = [
         f"{e['package']}:{e['file']}:{e['check']}" for e in entries if not e.get("evidence_hash")

--- a/tests/studio/install/test_llama_pr_force_and_source.py
+++ b/tests/studio/install/test_llama_pr_force_and_source.py
@@ -346,7 +346,7 @@ class TestSourcePatternsSh:
 
     @pytest.fixture(autouse = True)
     def _load_source(self):
-        self.content = SETUP_SH.read_text()
+        self.content = SETUP_SH.read_text(encoding = "utf-8")
 
     def test_has_default_pr_force(self):
         assert '_DEFAULT_LLAMA_PR_FORCE=""' in self.content
@@ -412,7 +412,7 @@ class TestSourcePatternsPs1:
 
     @pytest.fixture(autouse = True)
     def _load_source(self):
-        self.content = SETUP_PS1.read_text()
+        self.content = SETUP_PS1.read_text(encoding = "utf-8")
 
     def test_has_default_pr_force(self):
         assert '$DefaultLlamaPrForce = ""' in self.content

--- a/tests/studio/install/test_managed_node_runtime.py
+++ b/tests/studio/install/test_managed_node_runtime.py
@@ -125,7 +125,7 @@ def test_resolve_falls_back_to_managed_when_no_system(monkeypatch, tmp_path):
     monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path))
     managed = nr.managed_node_binary()
     managed.parent.mkdir(parents = True, exist_ok = True)
-    managed.write_text("#!/bin/sh\necho v24.17.0\n")
+    managed.write_text("#!/bin/sh\necho v24.17.0\n", encoding = "utf-8")
     monkeypatch.setattr(nr.shutil, "which", lambda name: None)
     monkeypatch.setattr(nr, "_node_version_ok", lambda exe: str(exe) == str(managed))
     assert nr.resolve_node_executable() == str(managed)
@@ -136,7 +136,7 @@ def test_resolve_prefers_managed_over_unsuitable_system(monkeypatch, tmp_path):
     monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path))
     managed = nr.managed_node_binary()
     managed.parent.mkdir(parents = True, exist_ok = True)
-    managed.write_text("fake")
+    managed.write_text("fake", encoding = "utf-8")
     monkeypatch.setattr(nr.shutil, "which", lambda name: "/old/node")
     monkeypatch.setattr(nr, "_node_version_ok", lambda exe: str(exe) == str(managed))
     assert nr.resolve_node_executable() == str(managed)
@@ -167,7 +167,7 @@ def test_negative_result_is_not_cached(monkeypatch, tmp_path):
 
     managed = nr.managed_node_binary()
     managed.parent.mkdir(parents = True, exist_ok = True)
-    managed.write_text("now-installed")
+    managed.write_text("now-installed", encoding = "utf-8")
     monkeypatch.setattr(nr, "_node_version_ok", lambda exe: str(exe) == str(managed))
     assert nr.resolve_node_executable() == str(managed)
 

--- a/tests/studio/install/test_pr4562_bugfixes.py
+++ b/tests/studio/install/test_pr4562_bugfixes.py
@@ -70,9 +70,9 @@ def run_bash(
         timeout = timeout,
         env = run_env,
     )
-    assert result.returncode == 0, (
-        f"bash script failed (exit {result.returncode}):\n{result.stderr}"
-    )
+    assert (
+        result.returncode == 0
+    ), f"bash script failed (exit {result.returncode}):\n{result.stderr}"
     return result.stdout.strip()
 
 
@@ -632,13 +632,13 @@ class TestSourceCodePatterns:
         """git clone in source-build should use --branch via the clone args array."""
         content = SETUP_SH.read_text(encoding = "utf-8")
         assert "_CLONE_ARGS=(git clone --depth 1)" in content
-        assert '_CLONE_ARGS+=(--branch "$_RESOLVED_SOURCE_REF")' in content, (
-            "_CLONE_ARGS should be extended with --branch $_RESOLVED_SOURCE_REF"
-        )
+        assert (
+            '_CLONE_ARGS+=(--branch "$_RESOLVED_SOURCE_REF")' in content
+        ), "_CLONE_ARGS should be extended with --branch $_RESOLVED_SOURCE_REF"
         # --branch only when tag is not "latest".
-        assert '_RESOLVED_SOURCE_REF" != "latest"' in content, (
-            "Should guard against literal 'latest' tag"
-        )
+        assert (
+            '_RESOLVED_SOURCE_REF" != "latest"' in content
+        ), "Should guard against literal 'latest' tag"
 
     def test_setup_sh_source_build_uses_helper_latest_tag_only(self):
         """Shell source fallback should only use helper latest-tag resolution."""
@@ -719,9 +719,9 @@ class TestSourceCodePatterns:
         # Via NVCC_PREPEND_FLAGS (covers the configure-time probe too), not CMAKE_ARGS.
         assert "export NVCC_PREPEND_FLAGS=" in content
         cmake_args_lines = [line for line in content.splitlines() if "CMAKE_ARGS=" in line]
-        assert all("-allow-unsupported-compiler" not in line for line in cmake_args_lines), (
-            "flag must stay out of CMAKE_ARGS (bash word-splitting safety)"
-        )
+        assert all(
+            "-allow-unsupported-compiler" not in line for line in cmake_args_lines
+        ), "flag must stay out of CMAKE_ARGS (bash word-splitting safety)"
 
     def test_setup_ps1_exports_allow_unsupported_compiler(self):
         """Windows parity for PR #5826: CUDA toolkit whitelist lags MSVC. setup.ps1 sets
@@ -731,9 +731,9 @@ class TestSourceCodePatterns:
         # Via process env, not $CmakeArgs, so it reaches both the configure probe and `cmake --build`.
         assert "$env:NVCC_PREPEND_FLAGS" in content
         cmake_args_lines = [line for line in content.splitlines() if "$CmakeArgs +=" in line]
-        assert all("-allow-unsupported-compiler" not in line for line in cmake_args_lines), (
-            "flag must not be pushed into the $CmakeArgs array"
-        )
+        assert all(
+            "-allow-unsupported-compiler" not in line for line in cmake_args_lines
+        ), "flag must not be pushed into the $CmakeArgs array"
         # Must be scoped to the CUDA-on branch, not set for CPU-only builds. The
         # branch also has an early GGML_CUDA=OFF (undetectable-arch CPU fallback,
         # #5854), so anchor on GGML_CUDA=ON and the final (no-GPU) GGML_CUDA=OFF.
@@ -754,12 +754,12 @@ class TestSourceCodePatterns:
             line for line in output.splitlines() if line.startswith("CPU_FALLBACK_CMAKE_ARGS=")
         )
         assert "-DGGML_METAL=OFF" in fallback_line
-        assert "@loader_path" not in fallback_line, (
-            "CPU fallback args should not contain RPATH flags"
-        )
-        assert "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON" not in fallback_line, (
-            "CPU fallback args should not contain RPATH build flag"
-        )
+        assert (
+            "@loader_path" not in fallback_line
+        ), "CPU fallback args should not contain RPATH flags"
+        assert (
+            "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON" not in fallback_line
+        ), "CPU fallback args should not contain RPATH build flag"
 
     def test_setup_sh_does_not_enable_metal_for_intel_macos(self):
         """Intel macOS should stay on the existing non-Metal path in this patch."""
@@ -1004,24 +1004,24 @@ class TestMacOSMetalBuildLogic:
         assert "FALLBACK_TRIGGERED" in output
         assert "BUILD_OK=true" in output
         assert "BUILD_DESC=building (CPU fallback)" in output
-        assert "TRY_METAL_CPU_FALLBACK=false" in output, (
-            "Fallback flag should be reset to false after configure fallback"
-        )
+        assert (
+            "TRY_METAL_CPU_FALLBACK=false" in output
+        ), "Fallback flag should be reset to false after configure fallback"
 
         # First cmake call has Metal ON, second has Metal OFF.
         calls = calls_file.read_text().splitlines()
         assert len(calls) >= 2, f"Expected >= 2 cmake calls, got {len(calls)}"
         assert "-DGGML_METAL=ON" in calls[0], f"First cmake call should have Metal ON: {calls[0]}"
-        assert "-DGGML_METAL=OFF" in calls[1], (
-            f"Second cmake call should have Metal OFF: {calls[1]}"
-        )
-        assert "-DGGML_METAL=ON" not in calls[1], (
-            f"Second cmake call should NOT have Metal ON: {calls[1]}"
-        )
+        assert (
+            "-DGGML_METAL=OFF" in calls[1]
+        ), f"Second cmake call should have Metal OFF: {calls[1]}"
+        assert (
+            "-DGGML_METAL=ON" not in calls[1]
+        ), f"Second cmake call should NOT have Metal ON: {calls[1]}"
         assert "@loader_path" not in calls[1], f"CPU fallback should not have RPATH: {calls[1]}"
-        assert "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON" not in calls[1], (
-            f"CPU fallback should not have RPATH build flag: {calls[1]}"
-        )
+        assert (
+            "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON" not in calls[1]
+        ), f"CPU fallback should not have RPATH build flag: {calls[1]}"
 
     def test_metal_build_failure_retries_cpu_fallback(self, tmp_path: Path):
         """When cmake --build fails on Metal, the fallback should re-configure and rebuild with CPU."""
@@ -1112,9 +1112,9 @@ class TestMacOSMetalBuildLogic:
         assert "BUILD_FALLBACK_TRIGGERED" in output
         assert "BUILD_OK=true" in output
         assert "BUILD_DESC=building (CPU fallback)" in output
-        assert "TRY_METAL_CPU_FALLBACK=false" in output, (
-            "Fallback flag should be reset to false after build fallback"
-        )
+        assert (
+            "TRY_METAL_CPU_FALLBACK=false" in output
+        ), "Fallback flag should be reset to false after build fallback"
 
         # configure (Metal ON), build (fails), re-configure (Metal OFF), rebuild.
         calls = calls_file.read_text().splitlines()
@@ -1124,10 +1124,10 @@ class TestMacOSMetalBuildLogic:
         assert "-DGGML_METAL=OFF" in calls[2]
         assert "-DGGML_METAL=ON" not in calls[2]
         assert "@loader_path" not in calls[2], f"CPU fallback should not have RPATH: {calls[2]}"
-        assert "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON" not in calls[2], (
-            f"CPU fallback should not have RPATH build flag: {calls[2]}"
-        )
-        assert "-DLLAMA_BUILD_TESTS=OFF" in calls[2], (
-            f"CPU fallback should preserve baseline flags: {calls[2]}"
-        )
+        assert (
+            "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON" not in calls[2]
+        ), f"CPU fallback should not have RPATH build flag: {calls[2]}"
+        assert (
+            "-DLLAMA_BUILD_TESTS=OFF" in calls[2]
+        ), f"CPU fallback should preserve baseline flags: {calls[2]}"
         assert "--build" in calls[3]

--- a/tests/studio/install/test_pr4562_bugfixes.py
+++ b/tests/studio/install/test_pr4562_bugfixes.py
@@ -70,9 +70,9 @@ def run_bash(
         timeout = timeout,
         env = run_env,
     )
-    assert (
-        result.returncode == 0
-    ), f"bash script failed (exit {result.returncode}):\n{result.stderr}"
+    assert result.returncode == 0, (
+        f"bash script failed (exit {result.returncode}):\n{result.stderr}"
+    )
     return result.stdout.strip()
 
 
@@ -617,7 +617,7 @@ class TestSourceCodePatterns:
 
     def test_setup_sh_no_rm_before_prereq_check(self):
         """rm -rf must appear AFTER cmake/git checks, not before."""
-        content = SETUP_SH.read_text()
+        content = SETUP_SH.read_text(encoding = "utf-8")
         # Anchor on the source-build cmake check block.
         idx_block = content.find("command -v cmake")
         assert idx_block != -1
@@ -630,19 +630,19 @@ class TestSourceCodePatterns:
 
     def test_setup_sh_clone_uses_branch_tag(self):
         """git clone in source-build should use --branch via the clone args array."""
-        content = SETUP_SH.read_text()
+        content = SETUP_SH.read_text(encoding = "utf-8")
         assert "_CLONE_ARGS=(git clone --depth 1)" in content
-        assert (
-            '_CLONE_ARGS+=(--branch "$_RESOLVED_SOURCE_REF")' in content
-        ), "_CLONE_ARGS should be extended with --branch $_RESOLVED_SOURCE_REF"
+        assert '_CLONE_ARGS+=(--branch "$_RESOLVED_SOURCE_REF")' in content, (
+            "_CLONE_ARGS should be extended with --branch $_RESOLVED_SOURCE_REF"
+        )
         # --branch only when tag is not "latest".
-        assert (
-            '_RESOLVED_SOURCE_REF" != "latest"' in content
-        ), "Should guard against literal 'latest' tag"
+        assert '_RESOLVED_SOURCE_REF" != "latest"' in content, (
+            "Should guard against literal 'latest' tag"
+        )
 
     def test_setup_sh_source_build_uses_helper_latest_tag_only(self):
         """Shell source fallback should only use helper latest-tag resolution."""
-        content = SETUP_SH.read_text()
+        content = SETUP_SH.read_text(encoding = "utf-8")
         assert "--resolve-source-build" not in content
         assert "--resolve-install-tag" not in content
         assert '--resolve-llama-tag latest --published-repo "ggml-org/llama.cpp"' in content
@@ -653,7 +653,7 @@ class TestSourceCodePatterns:
 
     def test_setup_sh_prebuilt_install_entrypoint(self):
         """Shell prebuilt path uses the helper install entrypoint, not the old releases-latest flow."""
-        content = SETUP_SH.read_text()
+        content = SETUP_SH.read_text(encoding = "utf-8")
         assert "--resolve-install-tag" not in content
         assert "_HELPER_RELEASE_REPO}/releases/latest" not in content
         assert "ggml-org/llama.cpp/releases/latest" not in content
@@ -663,7 +663,7 @@ class TestSourceCodePatterns:
         fork like every other host, so the release-repo decision is unconditional.
         Guards against a silent reintroduction of a ggml-org CPU routing branch.
         GPU usability detection (used for PyTorch / source decisions) must stay."""
-        content = SETUP_SH.read_text()
+        content = SETUP_SH.read_text(encoding = "utf-8")
         assert '_HELPER_RELEASE_REPO="unslothai/llama.cpp"' in content
         assert '_HELPER_RELEASE_REPO="ggml-org/llama.cpp"' not in content
         # Usability gating (not routing) still distinguishes a hidden GPU.
@@ -676,14 +676,14 @@ class TestSourceCodePatterns:
 
     def test_setup_sh_reports_installed_prebuilt_release(self):
         """Shell wrapper should report the installed prebuilt release from metadata."""
-        content = SETUP_SH.read_text()
+        content = SETUP_SH.read_text(encoding = "utf-8")
         assert "UNSLOTH_PREBUILT_INFO.json" in content
         assert "installed release:" in content
         assert 'print_installed_llama_prebuilt_release "$LLAMA_CPP_DIR"' in content
 
     def test_setup_sh_macos_arm64_uses_metal_flags(self):
         """Apple Silicon source builds should explicitly enable Metal like upstream."""
-        content = SETUP_SH.read_text()
+        content = SETUP_SH.read_text(encoding = "utf-8")
         assert "_IS_MACOS_ARM64=true" in content
         assert 'if [ "$_IS_MACOS_ARM64" = true ]; then' in content
         assert "-DGGML_METAL=ON" in content
@@ -695,7 +695,7 @@ class TestSourceCodePatterns:
     def test_setup_sh_macos_metal_configure_has_cpu_fallback(self):
         """GPU configure/build failure retries a CPU build. Stays label-agnostic
         (PR #5826 generalised the Metal-only wording via $_FB_LABEL)."""
-        content = SETUP_SH.read_text()
+        content = SETUP_SH.read_text(encoding = "utf-8")
         assert "_TRY_METAL_CPU_FALLBACK=true" in content
         assert 'configure failed; retrying CPU build..." "$C_WARN"' in content
         assert 'build failed; retrying CPU build..." "$C_WARN"' in content
@@ -714,26 +714,26 @@ class TestSourceCodePatterns:
         """PR #5826: a fresh CUDA toolkit's host-compiler whitelist lags distro gcc/clang
         (nvcc "#error -- unsupported GNU version"). setup.sh exports
         NVCC_PREPEND_FLAGS=-allow-unsupported-compiler via env, not CMAKE_ARGS (word-splitting safety)."""
-        content = SETUP_SH.read_text()
+        content = SETUP_SH.read_text(encoding = "utf-8")
         assert "-allow-unsupported-compiler" in content
         # Via NVCC_PREPEND_FLAGS (covers the configure-time probe too), not CMAKE_ARGS.
         assert "export NVCC_PREPEND_FLAGS=" in content
         cmake_args_lines = [line for line in content.splitlines() if "CMAKE_ARGS=" in line]
-        assert all(
-            "-allow-unsupported-compiler" not in line for line in cmake_args_lines
-        ), "flag must stay out of CMAKE_ARGS (bash word-splitting safety)"
+        assert all("-allow-unsupported-compiler" not in line for line in cmake_args_lines), (
+            "flag must stay out of CMAKE_ARGS (bash word-splitting safety)"
+        )
 
     def test_setup_ps1_exports_allow_unsupported_compiler(self):
         """Windows parity for PR #5826: CUDA toolkit whitelist lags MSVC. setup.ps1 sets
         NVCC_PREPEND_FLAGS=-allow-unsupported-compiler in the CUDA branch via env, out of $CmakeArgs."""
-        content = SETUP_PS1.read_text()
+        content = SETUP_PS1.read_text(encoding = "utf-8")
         assert "-allow-unsupported-compiler" in content
         # Via process env, not $CmakeArgs, so it reaches both the configure probe and `cmake --build`.
         assert "$env:NVCC_PREPEND_FLAGS" in content
         cmake_args_lines = [line for line in content.splitlines() if "$CmakeArgs +=" in line]
-        assert all(
-            "-allow-unsupported-compiler" not in line for line in cmake_args_lines
-        ), "flag must not be pushed into the $CmakeArgs array"
+        assert all("-allow-unsupported-compiler" not in line for line in cmake_args_lines), (
+            "flag must not be pushed into the $CmakeArgs array"
+        )
         # Must be scoped to the CUDA-on branch, not set for CPU-only builds. The
         # branch also has an early GGML_CUDA=OFF (undetectable-arch CPU fallback,
         # #5854), so anchor on GGML_CUDA=ON and the final (no-GPU) GGML_CUDA=OFF.
@@ -754,16 +754,16 @@ class TestSourceCodePatterns:
             line for line in output.splitlines() if line.startswith("CPU_FALLBACK_CMAKE_ARGS=")
         )
         assert "-DGGML_METAL=OFF" in fallback_line
-        assert (
-            "@loader_path" not in fallback_line
-        ), "CPU fallback args should not contain RPATH flags"
-        assert (
-            "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON" not in fallback_line
-        ), "CPU fallback args should not contain RPATH build flag"
+        assert "@loader_path" not in fallback_line, (
+            "CPU fallback args should not contain RPATH flags"
+        )
+        assert "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON" not in fallback_line, (
+            "CPU fallback args should not contain RPATH build flag"
+        )
 
     def test_setup_sh_does_not_enable_metal_for_intel_macos(self):
         """Intel macOS should stay on the existing non-Metal path in this patch."""
-        content = SETUP_SH.read_text()
+        content = SETUP_SH.read_text(encoding = "utf-8")
         assert 'if [ "$_IS_MACOS_ARM64" = true ]; then' in content
         assert (
             'Darwin" ] && { [ "$_HOST_MACHINE" = "arm64" ] || [ "$_HOST_MACHINE" = "aarch64" ]; }'
@@ -778,20 +778,20 @@ class TestSourceCodePatterns:
 
     def test_setup_ps1_uses_checkout_b(self):
         """PS1 should use checkout -B, not checkout --force FETCH_HEAD."""
-        content = SETUP_PS1.read_text()
+        content = SETUP_PS1.read_text(encoding = "utf-8")
         assert "checkout -B unsloth-llama-build" in content
         assert "checkout --force FETCH_HEAD" not in content
 
     def test_setup_ps1_clone_uses_branch_tag(self):
         """PS1 clone should use --branch with the resolved tag."""
-        content = SETUP_PS1.read_text()
+        content = SETUP_PS1.read_text(encoding = "utf-8")
         assert "--branch" in content and "$ResolvedSourceRef" in content
         # The old commented-out clone line should be gone.
         assert "# git clone --depth 1 --branch" not in content
 
     def test_setup_ps1_no_git_pull(self):
         """PS1 should use fetch, not pull (which fails in detached HEAD)."""
-        content = SETUP_PS1.read_text()
+        content = SETUP_PS1.read_text(encoding = "utf-8")
         # No "git pull" in the source-build section (only valid on a branch).
         lines = content.splitlines()
         for i, line in enumerate(lines):
@@ -800,18 +800,18 @@ class TestSourceCodePatterns:
                 # Allowed elsewhere; fail only in the llama.cpp build section.
                 context = "\n".join(lines[max(0, i - 5) : i + 5])
                 if "LlamaCppDir" in context:
-                    pytest.fail(f"Found 'git pull' in llama.cpp build section at line {i+1}")
+                    pytest.fail(f"Found 'git pull' in llama.cpp build section at line {i + 1}")
 
     def test_setup_ps1_prebuilt_install_entrypoint(self):
         """PS1 prebuilt path uses the helper install entrypoint, not the old releases-latest flow."""
-        content = SETUP_PS1.read_text()
+        content = SETUP_PS1.read_text(encoding = "utf-8")
         assert "--resolve-install-tag" not in content
         assert "$HelperReleaseRepo/releases/latest" not in content
         assert "ggml-org/llama.cpp/releases/latest" not in content
 
     def test_setup_ps1_reports_installed_prebuilt_release(self):
         """PS1 wrapper should report the installed prebuilt release from metadata."""
-        content = SETUP_PS1.read_text()
+        content = SETUP_PS1.read_text(encoding = "utf-8")
         assert "Get-InstalledLlamaPrebuiltRelease" in content
         assert "UNSLOTH_PREBUILT_INFO.json" in content
         assert "installed release:" in content
@@ -822,7 +822,7 @@ class TestSourceCodePatterns:
 
     def test_setup_ps1_source_build_uses_helper_latest_tag_only(self):
         """PS1 source fallback should only use helper latest-tag resolution."""
-        content = SETUP_PS1.read_text()
+        content = SETUP_PS1.read_text(encoding = "utf-8")
         assert "--resolve-source-build" not in content
         assert "--resolve-install-tag" not in content
         assert (
@@ -835,7 +835,7 @@ class TestSourceCodePatterns:
 
     def test_setup_ps1_prebuilt_install_disables_native_error_abort(self):
         """PS1 prebuilt install should not abort setup on helper stderr."""
-        content = SETUP_PS1.read_text()
+        content = SETUP_PS1.read_text(encoding = "utf-8")
         install_idx = content.index("& python @prebuiltArgs 2>&1")
         block = content[max(0, install_idx - 800) : install_idx + 800]
         assert "$PSNativeCommandUseErrorActionPreference = $false" in block
@@ -844,7 +844,7 @@ class TestSourceCodePatterns:
 
     def test_setup_ps1_helper_disables_error_action_abort(self):
         """Helper resolution should suppress terminating NativeCommandError on PS 5.1."""
-        content = SETUP_PS1.read_text()
+        content = SETUP_PS1.read_text(encoding = "utf-8")
         helper_idx = content.index("function Invoke-LlamaHelper")
         block = content[helper_idx : helper_idx + 2200]
         assert "$previousErrorActionPreference = $ErrorActionPreference" in block
@@ -853,19 +853,19 @@ class TestSourceCodePatterns:
 
     def test_setup_ps1_uses_local_tempfile_helper(self):
         """PS1 should not depend on New-TemporaryFile being available anywhere."""
-        content = SETUP_PS1.read_text()
+        content = SETUP_PS1.read_text(encoding = "utf-8")
         assert "function New-UnslothTemporaryFile" in content
         assert "$resolveErrorLog = New-TemporaryFile" not in content
 
     def test_setup_ps1_find_nvcc_uses_version_sort_for_latest_toolkit(self):
         """The unconstrained nvcc fallback should not sort toolkit dirs lexicographically."""
-        content = SETUP_PS1.read_text()
+        content = SETUP_PS1.read_text(encoding = "utf-8")
         assert "Sort-Object Name | Select-Object -Last 1" not in content
         assert "Sort-Object { [version]($_.Name -replace '^v','') } -Descending" in content
 
     def test_binary_env_linux_has_binary_parent(self):
         """The Linux branch of binary_env should include binary_path.parent."""
-        content = MODULE_PATH.read_text()
+        content = MODULE_PATH.read_text(encoding = "utf-8")
         in_func = False
         in_linux = False
         found = False
@@ -1004,24 +1004,24 @@ class TestMacOSMetalBuildLogic:
         assert "FALLBACK_TRIGGERED" in output
         assert "BUILD_OK=true" in output
         assert "BUILD_DESC=building (CPU fallback)" in output
-        assert (
-            "TRY_METAL_CPU_FALLBACK=false" in output
-        ), "Fallback flag should be reset to false after configure fallback"
+        assert "TRY_METAL_CPU_FALLBACK=false" in output, (
+            "Fallback flag should be reset to false after configure fallback"
+        )
 
         # First cmake call has Metal ON, second has Metal OFF.
         calls = calls_file.read_text().splitlines()
         assert len(calls) >= 2, f"Expected >= 2 cmake calls, got {len(calls)}"
         assert "-DGGML_METAL=ON" in calls[0], f"First cmake call should have Metal ON: {calls[0]}"
-        assert (
-            "-DGGML_METAL=OFF" in calls[1]
-        ), f"Second cmake call should have Metal OFF: {calls[1]}"
-        assert (
-            "-DGGML_METAL=ON" not in calls[1]
-        ), f"Second cmake call should NOT have Metal ON: {calls[1]}"
+        assert "-DGGML_METAL=OFF" in calls[1], (
+            f"Second cmake call should have Metal OFF: {calls[1]}"
+        )
+        assert "-DGGML_METAL=ON" not in calls[1], (
+            f"Second cmake call should NOT have Metal ON: {calls[1]}"
+        )
         assert "@loader_path" not in calls[1], f"CPU fallback should not have RPATH: {calls[1]}"
-        assert (
-            "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON" not in calls[1]
-        ), f"CPU fallback should not have RPATH build flag: {calls[1]}"
+        assert "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON" not in calls[1], (
+            f"CPU fallback should not have RPATH build flag: {calls[1]}"
+        )
 
     def test_metal_build_failure_retries_cpu_fallback(self, tmp_path: Path):
         """When cmake --build fails on Metal, the fallback should re-configure and rebuild with CPU."""
@@ -1112,9 +1112,9 @@ class TestMacOSMetalBuildLogic:
         assert "BUILD_FALLBACK_TRIGGERED" in output
         assert "BUILD_OK=true" in output
         assert "BUILD_DESC=building (CPU fallback)" in output
-        assert (
-            "TRY_METAL_CPU_FALLBACK=false" in output
-        ), "Fallback flag should be reset to false after build fallback"
+        assert "TRY_METAL_CPU_FALLBACK=false" in output, (
+            "Fallback flag should be reset to false after build fallback"
+        )
 
         # configure (Metal ON), build (fails), re-configure (Metal OFF), rebuild.
         calls = calls_file.read_text().splitlines()
@@ -1124,10 +1124,10 @@ class TestMacOSMetalBuildLogic:
         assert "-DGGML_METAL=OFF" in calls[2]
         assert "-DGGML_METAL=ON" not in calls[2]
         assert "@loader_path" not in calls[2], f"CPU fallback should not have RPATH: {calls[2]}"
-        assert (
-            "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON" not in calls[2]
-        ), f"CPU fallback should not have RPATH build flag: {calls[2]}"
-        assert (
-            "-DLLAMA_BUILD_TESTS=OFF" in calls[2]
-        ), f"CPU fallback should preserve baseline flags: {calls[2]}"
+        assert "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON" not in calls[2], (
+            f"CPU fallback should not have RPATH build flag: {calls[2]}"
+        )
+        assert "-DLLAMA_BUILD_TESTS=OFF" in calls[2], (
+            f"CPU fallback should preserve baseline flags: {calls[2]}"
+        )
         assert "--build" in calls[3]

--- a/tests/studio/load_freeze/test_load_orchestrator.py
+++ b/tests/studio/load_freeze/test_load_orchestrator.py
@@ -441,7 +441,7 @@ def test_load_model_caches_audio_type_inside_serial_load_lock():
     """Audio-type detection must run inside load_model under _serial_load_lock,
     else a concurrent /load can replace the backend mid-probe (review on #5669)."""
     f = _REPO_ROOT / "studio" / "backend" / "core" / "inference" / "llama_cpp.py"
-    text = f.read_text()
+    text = f.read_text(encoding = "utf-8")
     assert (
         "with self._serial_load_lock" in text
     ), "LlamaCppBackend.load_model must hold self._serial_load_lock"
@@ -462,7 +462,7 @@ def test_routes_inference_reads_cached_audio_type_not_calls_detect():
     """routes/inference.py must read cached _audio_type/_is_audio, not call
     detect_audio_type / init_audio_codec directly (both moved into load_model)."""
     f = _REPO_ROOT / "studio" / "backend" / "routes" / "inference.py"
-    text = f.read_text()
+    text = f.read_text(encoding = "utf-8")
     assert "llama_backend.detect_audio_type(" not in text, (
         "routes/inference.py should not call detect_audio_type directly; "
         "load_model already cached it under the lock."
@@ -485,7 +485,7 @@ def test_no_other_async_route_calls_detect_audio_type_unwrapped():
     # function helper is excluded below.
     pattern = re.compile(r"\b\w+\.detect_audio_type\s*\(")
     for path in routes_dir.rglob("*.py"):
-        for i, line in enumerate(path.read_text().splitlines(), start = 1):
+        for i, line in enumerate(path.read_text(encoding = "utf-8").splitlines(), start = 1):
             m = pattern.search(line)
             if not m:
                 continue

--- a/tests/studio/playwright_chat_ime_i18n.py
+++ b/tests/studio/playwright_chat_ime_i18n.py
@@ -241,10 +241,12 @@ with sync_playwright() as p:
 
     # Source-level guard: grep the unmounted edit/compare composers' JSX for dir="auto".
     _repo_root = Path(__file__).resolve().parents[2]
-    _thread_src = (
-        _repo_root / "studio/frontend/src/components/assistant-ui/thread.tsx"
-    ).read_text()
-    _shared_src = (_repo_root / "studio/frontend/src/features/chat/shared-composer.tsx").read_text()
+    _thread_src = (_repo_root / "studio/frontend/src/components/assistant-ui/thread.tsx").read_text(
+        encoding = "utf-8"
+    )
+    _shared_src = (_repo_root / "studio/frontend/src/features/chat/shared-composer.tsx").read_text(
+        encoding = "utf-8"
+    )
     _edit_idx = _thread_src.find("aui-edit-composer-input")
     if _edit_idx == -1 or 'dir="auto"' not in _thread_src[_edit_idx : _edit_idx + 600]:
         soft_fail('edit composer source is missing dir="auto"')

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -98,7 +98,7 @@ def expected_default_model():
         / "defaults.py"
     )
     try:
-        tree = ast.parse(defaults_path.read_text())
+        tree = ast.parse(defaults_path.read_text(encoding = "utf-8"))
     except Exception as exc:
         fail(f"could not read {defaults_path}: {exc}")
     models = None

--- a/tests/studio/studio_api_smoke.py
+++ b/tests/studio/studio_api_smoke.py
@@ -142,7 +142,7 @@ except Exception as exc:
 # GET / cross-origin must NOT leak the bootstrap password in the served HTML.
 boot_path = AUTH_DIR / ".bootstrap_password"
 if boot_path.exists():
-    bootstrap_pw = boot_path.read_text().strip()
+    bootstrap_pw = boot_path.read_text(encoding = "utf-8").strip()
     if bootstrap_pw:
         req = urllib.request.Request(
             f"{BASE}/",

--- a/tests/studio/test_auth_form_input_count.py
+++ b/tests/studio/test_auth_form_input_count.py
@@ -169,12 +169,14 @@ def test_login_jsx_declares_exactly_one_password_input():
 
 
 def test_auth_flow_routes_do_not_mount_global_settings():
-    root = (FRONTEND / "app/routes/__root.tsx").read_text()
+    root = (FRONTEND / "app/routes/__root.tsx").read_text(encoding = "utf-8")
     assert "{!isAuthFlowRoute && <SettingsDialog />}" in root
     assert "useSettingsDialogStore.getState().closeDialog();" in root
     assert "if (isAuthFlowRoute) return;" in root
     for route in ("login", "change-password", "onboarding"):
-        assert "isAuthFlow: true" in (FRONTEND / f"app/routes/{route}.tsx").read_text()
+        assert "isAuthFlow: true" in (FRONTEND / f"app/routes/{route}.tsx").read_text(
+            encoding = "utf-8"
+        )
 
 
 def test_auth_redirect_targets_are_idempotent_and_concurrent(tmp_path: Path):

--- a/tests/studio/test_auth_form_input_count.py
+++ b/tests/studio/test_auth_form_input_count.py
@@ -51,7 +51,7 @@ def _conditional_extent(src: str) -> tuple[int, int]:
 def test_hasbootstrappassword_constant_is_derived_from_bootstrap_window_value():
     """The guard must read from window.__UNSLOTH_BOOTSTRAP__, matching the backend's
     bootstrap-injection contract in studio/backend/main.py::_inject_bootstrap."""
-    src = AUTH_FORM.read_text()
+    src = AUTH_FORM.read_text(encoding = "utf-8")
     assert "const hasBootstrapPassword = Boolean(window.__UNSLOTH_BOOTSTRAP__?.password);" in src, (
         "hasBootstrapPassword constant missing or its derivation drifted; "
         "this is the gate that hides the Current password input on first boot"
@@ -61,7 +61,7 @@ def test_hasbootstrappassword_constant_is_derived_from_bootstrap_window_value():
 def test_exactly_one_hasBootstrapPassword_conditional_exists():
     """Only one `!hasBootstrapPassword` JSX check is allowed; a second would split
     rendering into branches and likely hide or duplicate the New / Confirm inputs."""
-    src = AUTH_FORM.read_text()
+    src = AUTH_FORM.read_text(encoding = "utf-8")
     count = src.count("!hasBootstrapPassword")
     assert count == 1, (
         f"expected exactly one !hasBootstrapPassword usage, found {count}; "
@@ -72,7 +72,7 @@ def test_exactly_one_hasBootstrapPassword_conditional_exists():
 def test_current_password_input_is_inside_the_hasBootstrapPassword_conditional():
     """`id="current-password"` must sit inside `{!hasBootstrapPassword && (...)}`,
     else it renders on first boot too, regressing the pre-#5490 UX that PR #5545 restores."""
-    src = AUTH_FORM.read_text()
+    src = AUTH_FORM.read_text(encoding = "utf-8")
     s, e = _conditional_extent(src)
     idx = src.find('id="current-password"')
     assert idx != -1, "the Current password input was removed entirely"
@@ -86,7 +86,7 @@ def test_current_password_input_is_inside_the_hasBootstrapPassword_conditional()
 def test_new_password_input_is_outside_the_hasBootstrapPassword_conditional():
     """`id="new-password"` must sit outside `{!hasBootstrapPassword && (...)}`,
     else it disappears on admin-forced resets, regressing PR #5490."""
-    src = AUTH_FORM.read_text()
+    src = AUTH_FORM.read_text(encoding = "utf-8")
     s, e = _conditional_extent(src)
     idx = src.find('id="new-password"')
     assert idx != -1, "the New password input was removed entirely"
@@ -99,7 +99,7 @@ def test_new_password_input_is_outside_the_hasBootstrapPassword_conditional():
 
 def test_confirm_password_input_is_outside_the_hasBootstrapPassword_conditional():
     """Same as New password, for `id="confirm-password"`."""
-    src = AUTH_FORM.read_text()
+    src = AUTH_FORM.read_text(encoding = "utf-8")
     s, e = _conditional_extent(src)
     idx = src.find('id="confirm-password"')
     assert idx != -1, "the Confirm password input was removed entirely"
@@ -114,7 +114,7 @@ def test_change_password_jsx_declares_exactly_three_password_inputs():
     """The change-password JSX block (`{!isLoginMode && (...)}`) must declare exactly
     current/new/confirm; a fourth would break the 2-input first-boot contract (the
     conditional only hides Current)."""
-    src = AUTH_FORM.read_text()
+    src = AUTH_FORM.read_text(encoding = "utf-8")
     start = src.find("{!isLoginMode && (")
     assert start != -1, (
         "the change-password JSX subtree marker {!isLoginMode && (...)} "
@@ -147,7 +147,7 @@ def test_change_password_jsx_declares_exactly_three_password_inputs():
 def test_login_jsx_declares_exactly_one_password_input():
     """The login JSX block (`isLoginMode && (...)`) must declare exactly one password
     input (the bootstrap password pasted from the CLI); a second breaks the per-mode matrix."""
-    src = AUTH_FORM.read_text()
+    src = AUTH_FORM.read_text(encoding = "utf-8")
     start = src.find("{isLoginMode && (")
     assert start != -1, "the login JSX subtree marker is missing"
     depth = 1
@@ -164,7 +164,7 @@ def test_login_jsx_declares_exactly_one_password_input():
     # Lock the count, not the spelling, so a rename does not falsely fail.
     pw_ids = [x for x in ids if "password" in x]
     assert len(pw_ids) == 1, (
-        f"login JSX must declare exactly one password-typed input; " f"found {pw_ids!r}"
+        f"login JSX must declare exactly one password-typed input; found {pw_ids!r}"
     )
 
 
@@ -190,7 +190,7 @@ def test_auth_redirect_targets_are_idempotent_and_concurrent(tmp_path: Path):
         pytest.skip("node --experimental-strip-types not available")
 
     source = (
-        AUTH_API.read_text()
+        AUTH_API.read_text(encoding = "utf-8")
         .replace('from "@/lib/api-base"', 'from "./stubs.mjs"')
         .replace('from "./session"', 'from "./stubs.mjs"')
     )

--- a/tests/studio/test_auth_form_input_count.py
+++ b/tests/studio/test_auth_form_input_count.py
@@ -163,9 +163,9 @@ def test_login_jsx_declares_exactly_one_password_input():
     ids = re.findall(r'id="([a-z-]+)"', subtree)
     # Lock the count, not the spelling, so a rename does not falsely fail.
     pw_ids = [x for x in ids if "password" in x]
-    assert len(pw_ids) == 1, (
-        f"login JSX must declare exactly one password-typed input; found {pw_ids!r}"
-    )
+    assert (
+        len(pw_ids) == 1
+    ), f"login JSX must declare exactly one password-typed input; found {pw_ids!r}"
 
 
 def test_auth_flow_routes_do_not_mount_global_settings():

--- a/tests/studio/test_cancel_atomicity.py
+++ b/tests/studio/test_cancel_atomicity.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 
 SOURCE_PATH = Path(__file__).resolve().parents[2] / "studio" / "backend" / "routes" / "inference.py"
-_SRC = SOURCE_PATH.read_text()
+_SRC = SOURCE_PATH.read_text(encoding = "utf-8")
 _TREE = ast.parse(_SRC)
 
 

--- a/tests/studio/test_cancel_id_wiring.py
+++ b/tests/studio/test_cancel_id_wiring.py
@@ -13,10 +13,14 @@ from pathlib import Path
 
 
 WORKSPACE = Path(__file__).resolve().parents[2]
-MODELS_SRC = (WORKSPACE / "studio/backend/models/inference.py").read_text()
-ROUTES_SRC = (WORKSPACE / "studio/backend/routes/inference.py").read_text()
-ADAPTER_SRC = (WORKSPACE / "studio/frontend/src/features/chat/api/chat-adapter.ts").read_text()
-API_TYPES_SRC = (WORKSPACE / "studio/frontend/src/features/chat/types/api.ts").read_text()
+MODELS_SRC = (WORKSPACE / "studio/backend/models/inference.py").read_text(encoding = "utf-8")
+ROUTES_SRC = (WORKSPACE / "studio/backend/routes/inference.py").read_text(encoding = "utf-8")
+ADAPTER_SRC = (WORKSPACE / "studio/frontend/src/features/chat/api/chat-adapter.ts").read_text(
+    encoding = "utf-8"
+)
+API_TYPES_SRC = (WORKSPACE / "studio/frontend/src/features/chat/types/api.ts").read_text(
+    encoding = "utf-8"
+)
 
 
 def _find_class(tree: ast.AST, name: str) -> ast.ClassDef | None:

--- a/tests/studio/test_chat_preset_builtin_invariants.py
+++ b/tests/studio/test_chat_preset_builtin_invariants.py
@@ -40,13 +40,15 @@ def _require_node():
 def _ensure_harness():
     TEMP.mkdir(parents = True, exist_ok = True)
     (TEMP / "register.mjs").write_text(
-        "import { register } from 'node:module';\nregister('./loader.mjs', import.meta.url);\n"
+        "import { register } from 'node:module';\nregister('./loader.mjs', import.meta.url);\n",
+        encoding = "utf-8",
     )
     (TEMP / "loader.mjs").write_text(
         "export function resolve(specifier, context, next) {\n"
         "  if (specifier.endsWith('/types/runtime')) return next(specifier + '.ts', context);\n"
         "  return next(specifier, context);\n"
-        "}\n"
+        "}\n",
+        encoding = "utf-8",
     )
 
 
@@ -54,7 +56,7 @@ def _run(script: str):
     _require_node()
     _ensure_harness()
     script_path = TEMP / "run.mts"
-    script_path.write_text(script)
+    script_path.write_text(script, encoding = "utf-8")
     env = dict(os.environ, NODE_NO_WARNINGS = "1")
     result = subprocess.run(
         [

--- a/tests/studio/test_chat_prompt_variables.py
+++ b/tests/studio/test_chat_prompt_variables.py
@@ -6,7 +6,9 @@ from pathlib import Path
 
 
 WORKSPACE = Path(__file__).resolve().parents[2]
-ADAPTER_SRC = (WORKSPACE / "studio/frontend/src/features/chat/api/chat-adapter.ts").read_text()
+ADAPTER_SRC = (WORKSPACE / "studio/frontend/src/features/chat/api/chat-adapter.ts").read_text(
+    encoding = "utf-8"
+)
 
 
 def _function_source(name: str) -> str:

--- a/tests/studio/test_chat_response_details_ui_contract.py
+++ b/tests/studio/test_chat_response_details_ui_contract.py
@@ -20,14 +20,14 @@ CHAT_TAB_TSX = REPO / "studio/frontend/src/features/settings/tabs/chat-tab.tsx"
 
 
 def test_assistant_more_menu_exposes_response_details_action():
-    src = THREAD_TSX.read_text()
+    src = THREAD_TSX.read_text(encoding = "utf-8")
     assert "MessageResponseDetailsSheet" in src
     assert "See response details" in src
     assert "setDetailsOpen(true)" in src
 
 
 def test_response_details_sheet_uses_unsloth_sheet_and_key_sections():
-    src = DETAILS_TSX.read_text()
+    src = DETAILS_TSX.read_text(encoding = "utf-8")
     assert "SheetContent" in src
     assert "Response details" in src
     assert "MessageResponseModelBadge" in src
@@ -45,17 +45,17 @@ def test_response_details_sheet_uses_unsloth_sheet_and_key_sections():
 
 
 def test_response_model_badge_is_user_configurable_and_rendered_once_per_message():
-    prefs_src = CHAT_PREFS_TS.read_text()
-    chat_tab_src = CHAT_TAB_TSX.read_text()
-    thread_src = THREAD_TSX.read_text()
-    reasoning_src = REASONING_TSX.read_text()
+    prefs_src = CHAT_PREFS_TS.read_text(encoding = "utf-8")
+    chat_tab_src = CHAT_TAB_TSX.read_text(encoding = "utf-8")
+    thread_src = THREAD_TSX.read_text(encoding = "utf-8")
+    reasoning_src = REASONING_TSX.read_text(encoding = "utf-8")
 
     assert "showResponseModel: boolean" in prefs_src
     assert "showResponseModel: false" in prefs_src
     assert "showResponseModel: saved?.showResponseModel ?? false" in prefs_src
     assert "Show response model" in chat_tab_src
     assert "setShowResponseModel" in chat_tab_src
-    details_src = DETAILS_TSX.read_text()
+    details_src = DETAILS_TSX.read_text(encoding = "utf-8")
     assert (
         "aui-response-model-badge pointer-events-none relative inline-flex min-h-5" in details_src
     )
@@ -76,7 +76,7 @@ def test_response_model_badge_is_user_configurable_and_rendered_once_per_message
 
 
 def test_reasoning_keeps_streaming_height_cap_through_automatic_collapse():
-    src = REASONING_TSX.read_text()
+    src = REASONING_TSX.read_text(encoding = "utf-8")
 
     assert "const [retainStreamingHeight, setRetainStreamingHeight]" in src
     assert "setRetainStreamingHeight(false)" in src
@@ -91,7 +91,7 @@ def test_reasoning_clears_manual_open_on_a_new_stream():
     isOpen is `(streaming && !dismissed) || manualOpen` and manualOpen is only
     settable while idle, so the new-stream reset has to clear it too.
     """
-    src = REASONING_TSX.read_text()
+    src = REASONING_TSX.read_text(encoding = "utf-8")
 
     marker = "setDismissedWhileStreaming(false)"
     start = src.find(marker)
@@ -101,7 +101,7 @@ def test_reasoning_clears_manual_open_on_a_new_stream():
 
 
 def test_response_details_metadata_is_persisted_without_backend_schema_change():
-    src = ADAPTER_TS.read_text()
+    src = ADAPTER_TS.read_text(encoding = "utf-8")
     assert "interface ResponseDetailsMetadata" in src
     assert "buildResponseDetails" in src
     assert "responseDetails: buildResponseDetails(finishedAt)" in src

--- a/tests/studio/test_chat_title_generation.py
+++ b/tests/studio/test_chat_title_generation.py
@@ -41,7 +41,7 @@ def _balanced_block(src: str, anchor: str) -> str:
 
 def test_title_model_prompt_targets_conversation_topic():
     block = _source_until(
-        RUNTIME_TSX.read_text(),
+        RUNTIME_TSX.read_text(encoding = "utf-8"),
         "async function generateTitleWithModel",
         "\nconst inflightTitleByKey",
     )
@@ -54,7 +54,7 @@ def test_title_model_prompt_targets_conversation_topic():
 
 def test_title_model_payload_includes_optional_assistant_reply():
     block = _source_until(
-        RUNTIME_TSX.read_text(),
+        RUNTIME_TSX.read_text(encoding = "utf-8"),
         "async function generateTitleWithModel",
         "\nconst inflightTitleByKey",
     )
@@ -71,7 +71,7 @@ def test_title_model_payload_includes_optional_assistant_reply():
 
 def test_generate_title_passes_first_assistant_reply_after_first_user():
     block = _balanced_block(
-        RUNTIME_TSX.read_text(),
+        RUNTIME_TSX.read_text(encoding = "utf-8"),
         "async generateTitle(remoteId",
     )
 
@@ -84,7 +84,7 @@ def test_generate_title_passes_first_assistant_reply_after_first_user():
 
 
 def test_tool_call_only_first_assistant_still_uses_first_user_message():
-    source = RUNTIME_TSX.read_text()
+    source = RUNTIME_TSX.read_text(encoding = "utf-8")
     extract_block = " ".join(_balanced_block(source, "function extractTextParts").split())
     generate_block = " ".join(_balanced_block(source, "async generateTitle(remoteId").split())
 
@@ -104,7 +104,7 @@ def test_tool_call_only_first_assistant_still_uses_first_user_message():
 
 def test_auto_title_disabled_uses_deterministic_user_text_fallback():
     block = _balanced_block(
-        RUNTIME_TSX.read_text(),
+        RUNTIME_TSX.read_text(encoding = "utf-8"),
         "async generateTitle(remoteId",
     )
     auto_title_off = _balanced_block(block, "if (!autoTitle)")
@@ -114,7 +114,7 @@ def test_auto_title_disabled_uses_deterministic_user_text_fallback():
 
 
 def test_model_failure_still_falls_back_to_user_text():
-    source = RUNTIME_TSX.read_text()
+    source = RUNTIME_TSX.read_text(encoding = "utf-8")
     model_block = _source_until(
         source,
         "async function generateTitleWithModel",
@@ -130,7 +130,7 @@ def test_model_failure_still_falls_back_to_user_text():
 
 def test_title_normalizer_still_enforces_output_constraints():
     block = _source_until(
-        RUNTIME_TSX.read_text(),
+        RUNTIME_TSX.read_text(encoding = "utf-8"),
         "async function generateTitleWithModel",
         "\nconst inflightTitleByKey",
     )

--- a/tests/studio/test_cli_run_alias.py
+++ b/tests/studio/test_cli_run_alias.py
@@ -17,7 +17,7 @@ def _module_calls(source: str):
 
 def test_top_level_run_alias_registered():
     """`app.command("run", ...)` must be invoked with studio_run as its target."""
-    source = _CLI_INIT.read_text()
+    source = _CLI_INIT.read_text(encoding = "utf-8")
 
     # Find ``app.command("run", ...)`` call -- the decorator-call form.
     found_decorator_call = False
@@ -39,14 +39,14 @@ def test_top_level_run_alias_registered():
         if is_run:
             found_decorator_call = True
             break
-    assert (
-        found_decorator_call
-    ), 'Expected `app.command("run", ...)` registration in unsloth_cli/__init__.py'
+    assert found_decorator_call, (
+        'Expected `app.command("run", ...)` registration in unsloth_cli/__init__.py'
+    )
 
 
 def test_studio_run_imported_for_alias():
     """The alias must wire up to the studio.run function, not redefine it."""
-    source = _CLI_INIT.read_text()
+    source = _CLI_INIT.read_text(encoding = "utf-8")
     tree = ast.parse(source)
     has_import = False
     for node in ast.walk(tree):
@@ -58,6 +58,6 @@ def test_studio_run_imported_for_alias():
             if alias.name == "run":
                 has_import = True
                 break
-    assert (
-        has_import
-    ), "Expected `from unsloth_cli.commands.studio import run` in unsloth_cli/__init__.py"
+    assert has_import, (
+        "Expected `from unsloth_cli.commands.studio import run` in unsloth_cli/__init__.py"
+    )

--- a/tests/studio/test_cli_run_alias.py
+++ b/tests/studio/test_cli_run_alias.py
@@ -39,9 +39,9 @@ def test_top_level_run_alias_registered():
         if is_run:
             found_decorator_call = True
             break
-    assert found_decorator_call, (
-        'Expected `app.command("run", ...)` registration in unsloth_cli/__init__.py'
-    )
+    assert (
+        found_decorator_call
+    ), 'Expected `app.command("run", ...)` registration in unsloth_cli/__init__.py'
 
 
 def test_studio_run_imported_for_alias():
@@ -58,6 +58,6 @@ def test_studio_run_imported_for_alias():
             if alias.name == "run":
                 has_import = True
                 break
-    assert has_import, (
-        "Expected `from unsloth_cli.commands.studio import run` in unsloth_cli/__init__.py"
-    )
+    assert (
+        has_import
+    ), "Expected `from unsloth_cli.commands.studio import run` in unsloth_cli/__init__.py"

--- a/tests/studio/test_cli_studio_defaults.py
+++ b/tests/studio/test_cli_studio_defaults.py
@@ -48,20 +48,19 @@ def _find_typer_option_default(source: str, func_name: str, long_option: str):
 
 def test_studio_default_host_is_loopback():
     """`unsloth studio` (studio_default) --host default must be 127.0.0.1."""
-    source = _STUDIO_CMD_PY.read_text()
+    source = _STUDIO_CMD_PY.read_text(encoding = "utf-8")
     host_default = _find_typer_option_default(source, "studio_default", "--host")
-    assert (
-        host_default is not None
-    ), "Could not find --host typer.Option default in studio_default()"
+    assert host_default is not None, (
+        "Could not find --host typer.Option default in studio_default()"
+    )
     assert host_default == "127.0.0.1", (
-        f"studio_default() --host default must be '127.0.0.1' (loopback) "
-        f"but got '{host_default}'."
+        f"studio_default() --host default must be '127.0.0.1' (loopback) but got '{host_default}'."
     )
 
 
 def test_studio_run_host_is_loopback():
     """`unsloth studio run` --host default must be 127.0.0.1."""
-    source = _STUDIO_CMD_PY.read_text()
+    source = _STUDIO_CMD_PY.read_text(encoding = "utf-8")
     host_default = _find_typer_option_default(source, "run", "--host")
     assert host_default is not None, "Could not find --host typer.Option default in run()"
     assert host_default == "127.0.0.1", (
@@ -71,7 +70,7 @@ def test_studio_run_host_is_loopback():
 
 
 def test_dns_pinning_opt_out_is_registered_safe_by_default():
-    source = _STUDIO_CMD_PY.read_text()
+    source = _STUDIO_CMD_PY.read_text(encoding = "utf-8")
     for func_name in ("studio_default", "run"):
         default = _find_typer_option_default(source, func_name, "--disable-dns-pinning")
         assert default is False, f"{func_name} must keep DNS pinning enabled by default"

--- a/tests/studio/test_cli_studio_defaults.py
+++ b/tests/studio/test_cli_studio_defaults.py
@@ -50,12 +50,12 @@ def test_studio_default_host_is_loopback():
     """`unsloth studio` (studio_default) --host default must be 127.0.0.1."""
     source = _STUDIO_CMD_PY.read_text(encoding = "utf-8")
     host_default = _find_typer_option_default(source, "studio_default", "--host")
-    assert host_default is not None, (
-        "Could not find --host typer.Option default in studio_default()"
-    )
-    assert host_default == "127.0.0.1", (
-        f"studio_default() --host default must be '127.0.0.1' (loopback) but got '{host_default}'."
-    )
+    assert (
+        host_default is not None
+    ), "Could not find --host typer.Option default in studio_default()"
+    assert (
+        host_default == "127.0.0.1"
+    ), f"studio_default() --host default must be '127.0.0.1' (loopback) but got '{host_default}'."
 
 
 def test_studio_run_host_is_loopback():

--- a/tests/studio/test_composer_rtl_bidi_attribute.py
+++ b/tests/studio/test_composer_rtl_bidi_attribute.py
@@ -26,60 +26,60 @@ def _block_around(
 def test_main_composer_has_dir_auto():
     # PR #5784 turned the attribute into a JSX conditional; anchor on the inner
     # "Message input" literal, which survives both spellings.
-    block = _block_around(THREAD_TSX.read_text(), '"Message input"')
+    block = _block_around(THREAD_TSX.read_text(encoding = "utf-8"), '"Message input"')
     assert 'dir="auto"' in block, 'main composer is missing dir="auto"'
 
 
 def test_edit_composer_has_dir_auto():
-    block = _block_around(THREAD_TSX.read_text(), "aui-edit-composer-input")
+    block = _block_around(THREAD_TSX.read_text(encoding = "utf-8"), "aui-edit-composer-input")
     assert 'dir="auto"' in block, 'edit composer is missing dir="auto"'
 
 
 def test_compare_composer_has_dir_auto():
-    block = _block_around(SHARED_TSX.read_text(), "Send to both models")
+    block = _block_around(SHARED_TSX.read_text(encoding = "utf-8"), "Send to both models")
     assert 'dir="auto"' in block, 'compare composer is missing dir="auto"'
 
 
 def test_ime_workflow_step_does_not_set_studio_old_pw():
-    yml = WORKFLOW_YML.read_text()
+    yml = WORKFLOW_YML.read_text(encoding = "utf-8")
     drive_idx = yml.find("Drive IME + multilingual paste regression")
     assert drive_idx != -1, "IME drive step not found in workflow"
     next_step_idx = yml.find("- name:", drive_idx + 1)
     drive_block = yml[drive_idx : next_step_idx if next_step_idx != -1 else None]
-    assert (
-        "STUDIO_OLD_PW" not in drive_block
-    ), "IME drive step still passes dead STUDIO_OLD_PW env var"
+    assert "STUDIO_OLD_PW" not in drive_block, (
+        "IME drive step still passes dead STUDIO_OLD_PW env var"
+    )
     assert "STUDIO_NEW_PW" in drive_block, "IME drive step missing STUDIO_NEW_PW"
 
 
 def test_ime_pass_password_step_does_not_export_old_pw():
-    yml = WORKFLOW_YML.read_text()
+    yml = WORKFLOW_YML.read_text(encoding = "utf-8")
     pass_idx = yml.find("Pass bootstrap pw for IME / i18n test")
     assert pass_idx != -1, "IME password setup step not found"
     next_step_idx = yml.find("- name:", pass_idx + 1)
     pass_block = yml[pass_idx : next_step_idx if next_step_idx != -1 else None]
-    assert (
-        "STUDIO_IME_OLD_PW" not in pass_block
-    ), "IME password setup still exports dead STUDIO_IME_OLD_PW"
+    assert "STUDIO_IME_OLD_PW" not in pass_block, (
+        "IME password setup still exports dead STUDIO_IME_OLD_PW"
+    )
     assert "STUDIO_IME_NEW_PW" in pass_block
 
 
 def test_ime_playwright_script_does_not_read_studio_old_pw():
-    src = IME_PY.read_text()
+    src = IME_PY.read_text(encoding = "utf-8")
     code_only = re.sub(r'""".*?"""', "", src, flags = re.DOTALL)
-    assert (
-        "STUDIO_OLD_PW" not in code_only
-    ), "IME Playwright script still references dead STUDIO_OLD_PW env var"
+    assert "STUDIO_OLD_PW" not in code_only, (
+        "IME Playwright script still references dead STUDIO_OLD_PW env var"
+    )
     assert 'os.environ["STUDIO_NEW_PW"]' in code_only
 
 
 def test_main_composer_has_stuck_compositionend_watchdog():
     """Issue #5546: WSL Chrome never emits compositionend after IME commit, so the
     composer needs a watchdog releasing the composing flag or Send stays disabled."""
-    src = THREAD_TSX.read_text()
-    assert (
-        "IME_STUCK_TIMEOUT_MS" in src
-    ), "main composer is missing the stuck-compositionend watchdog (issue #5546)"
+    src = THREAD_TSX.read_text(encoding = "utf-8")
+    assert "IME_STUCK_TIMEOUT_MS" in src, (
+        "main composer is missing the stuck-compositionend watchdog (issue #5546)"
+    )
     assert "onCompositionUpdate" in src, (
         "main composer is missing onCompositionUpdate wiring; the "
         "watchdog only resets while the IME is actively emitting events"
@@ -87,17 +87,17 @@ def test_main_composer_has_stuck_compositionend_watchdog():
 
 
 def test_compare_composer_has_stuck_compositionend_watchdog():
-    src = SHARED_TSX.read_text()
-    assert (
-        "IME_STUCK_TIMEOUT_MS" in src
-    ), "compare composer is missing the stuck-compositionend watchdog (issue #5546)"
+    src = SHARED_TSX.read_text(encoding = "utf-8")
+    assert "IME_STUCK_TIMEOUT_MS" in src, (
+        "compare composer is missing the stuck-compositionend watchdog (issue #5546)"
+    )
     assert "onCompositionUpdate" in src, "compare composer is missing onCompositionUpdate wiring"
 
 
 def test_main_composer_keydown_repins_composing_during_ime():
     """Issue #5546: the keydown IME gate must re-pin composingRef so a follow-up
     Enter does not submit preedit text after the watchdog clears it."""
-    src = THREAD_TSX.read_text()
+    src = THREAD_TSX.read_text(encoding = "utf-8")
     assert "onKeyDown" in src, "main composer is missing onKeyDown IME gate"
     assert "e.nativeEvent.isComposing" in src and "keyCode === 229" in src, (
         "main composer keydown gate must check both nativeEvent.isComposing "
@@ -108,7 +108,7 @@ def test_main_composer_keydown_repins_composing_during_ime():
 def test_compare_composer_keydown_repins_composing_during_ime():
     """Compare composer onKeyDown re-pins composingRef on IME keypress so a
     follow-up click-Send during the watchdog window does not slip preedit text."""
-    src = SHARED_TSX.read_text()
+    src = SHARED_TSX.read_text(encoding = "utf-8")
     assert "composingRef.current = true" in src, (
         "compare composer keydown gate must re-pin composingRef when the "
         "browser still considers the IME active"
@@ -142,7 +142,7 @@ def _extract_block(
 def test_main_composer_keydown_rearms_watchdog():
     """After keydown re-pins composingRef the watchdog must re-arm, else the
     WSL+Chrome no-compositionend path locks Send after any IME keypress (#5546)."""
-    src = THREAD_TSX.read_text()
+    src = THREAD_TSX.read_text(encoding = "utf-8")
     block = _extract_block(src, "const onKeyDown = useCallback")
     assert "refreshStuckTimer" in block, (
         "main composer keydown gate must call refreshStuckTimer after "
@@ -159,11 +159,10 @@ def test_main_composer_keydown_rearms_watchdog():
 
 def test_compare_composer_keydown_rearms_watchdog():
     """Same re-arm contract for the compare-mode composer."""
-    src = SHARED_TSX.read_text()
+    src = SHARED_TSX.read_text(encoding = "utf-8")
     block = _extract_block(src, "function onKeyDown", opener = "{", closer = "}")
     assert "refreshStuckImeTimer" in block, (
-        "compare composer keydown gate must call refreshStuckImeTimer "
-        "after re-pinning composingRef"
+        "compare composer keydown gate must call refreshStuckImeTimer after re-pinning composingRef"
     )
 
 
@@ -178,24 +177,23 @@ def _assert_enter_guard_before_immediate_recovery(block: str, refresh_call: str)
     )
     guard_block = block[enter_idx:recovery_idx]
     assert "preventDefault()" in guard_block, (
-        "Enter while composingRef is stuck must prevent the same key from "
-        "falling through to submit"
+        "Enter while composingRef is stuck must prevent the same key from falling through to submit"
     )
-    assert (
-        refresh_call in guard_block
-    ), "Enter while composingRef is stuck must keep the watchdog armed"
-    assert (
-        "return;" in guard_block
-    ), "Enter while composingRef is stuck must not reach immediate recovery"
+    assert refresh_call in guard_block, (
+        "Enter while composingRef is stuck must keep the watchdog armed"
+    )
+    assert "return;" in guard_block, (
+        "Enter while composingRef is stuck must not reach immediate recovery"
+    )
 
 
 def test_main_composer_stuck_enter_does_not_clear_before_submit():
-    src = THREAD_TSX.read_text()
+    src = THREAD_TSX.read_text(encoding = "utf-8")
     block = _extract_block(src, "const onKeyDown = useCallback")
     _assert_enter_guard_before_immediate_recovery(block, "refreshStuckTimer")
 
 
 def test_compare_composer_stuck_enter_does_not_clear_before_submit():
-    src = SHARED_TSX.read_text()
+    src = SHARED_TSX.read_text(encoding = "utf-8")
     block = _extract_block(src, "function onKeyDown", opener = "{", closer = "}")
     _assert_enter_guard_before_immediate_recovery(block, "refreshStuckImeTimer")

--- a/tests/studio/test_composer_rtl_bidi_attribute.py
+++ b/tests/studio/test_composer_rtl_bidi_attribute.py
@@ -46,9 +46,9 @@ def test_ime_workflow_step_does_not_set_studio_old_pw():
     assert drive_idx != -1, "IME drive step not found in workflow"
     next_step_idx = yml.find("- name:", drive_idx + 1)
     drive_block = yml[drive_idx : next_step_idx if next_step_idx != -1 else None]
-    assert "STUDIO_OLD_PW" not in drive_block, (
-        "IME drive step still passes dead STUDIO_OLD_PW env var"
-    )
+    assert (
+        "STUDIO_OLD_PW" not in drive_block
+    ), "IME drive step still passes dead STUDIO_OLD_PW env var"
     assert "STUDIO_NEW_PW" in drive_block, "IME drive step missing STUDIO_NEW_PW"
 
 
@@ -58,18 +58,18 @@ def test_ime_pass_password_step_does_not_export_old_pw():
     assert pass_idx != -1, "IME password setup step not found"
     next_step_idx = yml.find("- name:", pass_idx + 1)
     pass_block = yml[pass_idx : next_step_idx if next_step_idx != -1 else None]
-    assert "STUDIO_IME_OLD_PW" not in pass_block, (
-        "IME password setup still exports dead STUDIO_IME_OLD_PW"
-    )
+    assert (
+        "STUDIO_IME_OLD_PW" not in pass_block
+    ), "IME password setup still exports dead STUDIO_IME_OLD_PW"
     assert "STUDIO_IME_NEW_PW" in pass_block
 
 
 def test_ime_playwright_script_does_not_read_studio_old_pw():
     src = IME_PY.read_text(encoding = "utf-8")
     code_only = re.sub(r'""".*?"""', "", src, flags = re.DOTALL)
-    assert "STUDIO_OLD_PW" not in code_only, (
-        "IME Playwright script still references dead STUDIO_OLD_PW env var"
-    )
+    assert (
+        "STUDIO_OLD_PW" not in code_only
+    ), "IME Playwright script still references dead STUDIO_OLD_PW env var"
     assert 'os.environ["STUDIO_NEW_PW"]' in code_only
 
 
@@ -77,9 +77,9 @@ def test_main_composer_has_stuck_compositionend_watchdog():
     """Issue #5546: WSL Chrome never emits compositionend after IME commit, so the
     composer needs a watchdog releasing the composing flag or Send stays disabled."""
     src = THREAD_TSX.read_text(encoding = "utf-8")
-    assert "IME_STUCK_TIMEOUT_MS" in src, (
-        "main composer is missing the stuck-compositionend watchdog (issue #5546)"
-    )
+    assert (
+        "IME_STUCK_TIMEOUT_MS" in src
+    ), "main composer is missing the stuck-compositionend watchdog (issue #5546)"
     assert "onCompositionUpdate" in src, (
         "main composer is missing onCompositionUpdate wiring; the "
         "watchdog only resets while the IME is actively emitting events"
@@ -88,9 +88,9 @@ def test_main_composer_has_stuck_compositionend_watchdog():
 
 def test_compare_composer_has_stuck_compositionend_watchdog():
     src = SHARED_TSX.read_text(encoding = "utf-8")
-    assert "IME_STUCK_TIMEOUT_MS" in src, (
-        "compare composer is missing the stuck-compositionend watchdog (issue #5546)"
-    )
+    assert (
+        "IME_STUCK_TIMEOUT_MS" in src
+    ), "compare composer is missing the stuck-compositionend watchdog (issue #5546)"
     assert "onCompositionUpdate" in src, "compare composer is missing onCompositionUpdate wiring"
 
 
@@ -161,9 +161,9 @@ def test_compare_composer_keydown_rearms_watchdog():
     """Same re-arm contract for the compare-mode composer."""
     src = SHARED_TSX.read_text(encoding = "utf-8")
     block = _extract_block(src, "function onKeyDown", opener = "{", closer = "}")
-    assert "refreshStuckImeTimer" in block, (
-        "compare composer keydown gate must call refreshStuckImeTimer after re-pinning composingRef"
-    )
+    assert (
+        "refreshStuckImeTimer" in block
+    ), "compare composer keydown gate must call refreshStuckImeTimer after re-pinning composingRef"
 
 
 def _assert_enter_guard_before_immediate_recovery(block: str, refresh_call: str) -> None:
@@ -176,15 +176,15 @@ def _assert_enter_guard_before_immediate_recovery(block: str, refresh_call: str)
         "composingRef; candidate-confirming Enter must not submit"
     )
     guard_block = block[enter_idx:recovery_idx]
-    assert "preventDefault()" in guard_block, (
-        "Enter while composingRef is stuck must prevent the same key from falling through to submit"
-    )
-    assert refresh_call in guard_block, (
-        "Enter while composingRef is stuck must keep the watchdog armed"
-    )
-    assert "return;" in guard_block, (
-        "Enter while composingRef is stuck must not reach immediate recovery"
-    )
+    assert (
+        "preventDefault()" in guard_block
+    ), "Enter while composingRef is stuck must prevent the same key from falling through to submit"
+    assert (
+        refresh_call in guard_block
+    ), "Enter while composingRef is stuck must keep the watchdog armed"
+    assert (
+        "return;" in guard_block
+    ), "Enter while composingRef is stuck must not reach immediate recovery"
 
 
 def test_main_composer_stuck_enter_does_not_clear_before_submit():

--- a/tests/studio/test_export_output_path_contract.py
+++ b/tests/studio/test_export_output_path_contract.py
@@ -40,9 +40,9 @@ def test_export_methods_return_three_tuple_annotation():
         assert isinstance(ret, ast.Subscript), f"{fn_name} return must be Tuple[...]"
         slc = ret.slice
         elts = slc.elts if isinstance(slc, ast.Tuple) else None
-        assert elts is not None and len(elts) == 3, (
-            f"{fn_name} return annotation must be a 3-tuple, got {ast.dump(ret)}"
-        )
+        assert (
+            elts is not None and len(elts) == 3
+        ), f"{fn_name} return annotation must be a 3-tuple, got {ast.dump(ret)}"
 
 
 def test_export_methods_return_three_element_tuples():
@@ -104,9 +104,9 @@ def test_gpu_save_method_bound_for_hub_only():
 
 def test_mlx_hub_only_uses_temp_directory():
     src = EXPORT.read_text(encoding = "utf-8")
-    assert src.count("tempfile.TemporaryDirectory") >= 3, (
-        "expected TemporaryDirectory in merged, base, and lora hub-push paths"
-    )
+    assert (
+        src.count("tempfile.TemporaryDirectory") >= 3
+    ), "expected TemporaryDirectory in merged, base, and lora hub-push paths"
     assert "import tempfile" in src.split("class ExportBackend")[0]
 
 

--- a/tests/studio/test_export_output_path_contract.py
+++ b/tests/studio/test_export_output_path_contract.py
@@ -32,7 +32,7 @@ def _return_tuple_arity(fn):
 
 
 def test_export_methods_return_three_tuple_annotation():
-    tree = ast.parse(EXPORT.read_text())
+    tree = ast.parse(EXPORT.read_text(encoding = "utf-8"))
     for fn_name in EXPORT_FNS:
         fn = _find_method(tree, "ExportBackend", fn_name)
         assert fn is not None, f"missing ExportBackend.{fn_name}"
@@ -40,13 +40,13 @@ def test_export_methods_return_three_tuple_annotation():
         assert isinstance(ret, ast.Subscript), f"{fn_name} return must be Tuple[...]"
         slc = ret.slice
         elts = slc.elts if isinstance(slc, ast.Tuple) else None
-        assert (
-            elts is not None and len(elts) == 3
-        ), f"{fn_name} return annotation must be a 3-tuple, got {ast.dump(ret)}"
+        assert elts is not None and len(elts) == 3, (
+            f"{fn_name} return annotation must be a 3-tuple, got {ast.dump(ret)}"
+        )
 
 
 def test_export_methods_return_three_element_tuples():
-    tree = ast.parse(EXPORT.read_text())
+    tree = ast.parse(EXPORT.read_text(encoding = "utf-8"))
     for fn_name in EXPORT_FNS:
         fn = _find_method(tree, "ExportBackend", fn_name)
         assert fn is not None
@@ -57,7 +57,7 @@ def test_export_methods_return_three_element_tuples():
 
 
 def test_local_save_assigns_output_path():
-    tree = ast.parse(EXPORT.read_text())
+    tree = ast.parse(EXPORT.read_text(encoding = "utf-8"))
     for fn_name in EXPORT_FNS:
         fn = _find_method(tree, "ExportBackend", fn_name)
         assert fn is not None
@@ -74,7 +74,7 @@ def test_local_save_assigns_output_path():
 
 
 def test_gpu_save_method_bound_for_hub_only():
-    tree = ast.parse(EXPORT.read_text())
+    tree = ast.parse(EXPORT.read_text(encoding = "utf-8"))
     fn = _find_method(tree, "ExportBackend", "export_merged_model")
     assert fn is not None
     found_pre_save_method = False
@@ -103,15 +103,15 @@ def test_gpu_save_method_bound_for_hub_only():
 
 
 def test_mlx_hub_only_uses_temp_directory():
-    src = EXPORT.read_text()
-    assert (
-        src.count("tempfile.TemporaryDirectory") >= 3
-    ), "expected TemporaryDirectory in merged, base, and lora hub-push paths"
+    src = EXPORT.read_text(encoding = "utf-8")
+    assert src.count("tempfile.TemporaryDirectory") >= 3, (
+        "expected TemporaryDirectory in merged, base, and lora hub-push paths"
+    )
     assert "import tempfile" in src.split("class ExportBackend")[0]
 
 
 def test_is_mlx_imported_from_unsloth():
-    src = EXPORT.read_text()
+    src = EXPORT.read_text(encoding = "utf-8")
     assert "from unsloth import" in src
     head = src.split("class ExportBackend")[0]
     assert "_IS_MLX" in head

--- a/tests/studio/test_frontend_dep_removal.py
+++ b/tests/studio/test_frontend_dep_removal.py
@@ -1114,7 +1114,7 @@ def run_adversarial_cases() -> int:
         # Drop the synthetic file.
         fpath = ADVERSARIAL_TMP_DIR / ac.filename
         try:
-            fpath.write_text(ac.content)
+            fpath.write_text(ac.content, encoding = "utf-8")
             # Base adds the target pkg; real head lacks it, so the script
             # treats it as removed and scans the repo (now with our file).
             synth_base = json.loads(json.dumps(head_pkg))

--- a/tests/studio/test_frontend_dep_removal.py
+++ b/tests/studio/test_frontend_dep_removal.py
@@ -53,8 +53,7 @@ CASES: list[Case] = [
     ),
     Case(
         "C3",
-        "removing katex is safe: streamdown/math, mermaid, "
-        "rehype-katex all keep it at top level",
+        "removing katex is safe: streamdown/math, mermaid, rehype-katex all keep it at top level",
         ["katex"],
         "PASS",
         [],
@@ -69,8 +68,7 @@ CASES: list[Case] = [
     ),
     Case(
         "C6",
-        "removing @radix-ui/react-slot is safe: pulled by "
-        "radix-ui umbrella + @assistant-ui/react",
+        "removing @radix-ui/react-slot is safe: pulled by radix-ui umbrella + @assistant-ui/react",
         ["@radix-ui/react-slot"],
         "PASS",
         [],
@@ -852,7 +850,7 @@ ADV_CASES: list[AdvCase] = [
         "A12",
         "JSDoc @import of removed pkg should FAIL",
         "adv12.ts",
-        '/** @type {import("__adv_only_pkg_l__").Foo} */\n' "const x = null;\n",
+        '/** @type {import("__adv_only_pkg_l__").Foo} */\nconst x = null;\n',
         "__adv_only_pkg_l__",
         "FAIL",
         ["__adv_only_pkg_l__"],
@@ -1047,7 +1045,7 @@ PKG_FIELD_CASES: list[PkgFieldCase] = [
 
 
 def run_pkg_field_cases() -> int:
-    head_pkg = json.loads(HEAD_PKG.read_text())
+    head_pkg = json.loads(HEAD_PKG.read_text(encoding = "utf-8"))
     passed = 0
     for pc in PKG_FIELD_CASES:
         synth_head = json.loads(json.dumps(head_pkg))
@@ -1110,7 +1108,7 @@ def run_pkg_field_cases() -> int:
 
 def run_adversarial_cases() -> int:
     ADVERSARIAL_TMP_DIR.mkdir(parents = True, exist_ok = True)
-    head_pkg = json.loads(HEAD_PKG.read_text())
+    head_pkg = json.loads(HEAD_PKG.read_text(encoding = "utf-8"))
     passed = 0
     for ac in ADV_CASES:
         # Drop the synthetic file.
@@ -1259,7 +1257,7 @@ ENUM_CASES: list[EnumCase] = [
 
 
 def run_enum_cases() -> int:
-    head_pkg = json.loads(HEAD_PKG.read_text())
+    head_pkg = json.loads(HEAD_PKG.read_text(encoding = "utf-8"))
     passed = 0
     ADVERSARIAL_TMP_DIR.mkdir(parents = True, exist_ok = True)
     for ec in ENUM_CASES:
@@ -1508,7 +1506,7 @@ def run_wrapper_cases() -> int:
 
 
 def main() -> int:
-    head_pkg = json.loads(HEAD_PKG.read_text())
+    head_pkg = json.loads(HEAD_PKG.read_text(encoding = "utf-8"))
     print(f"Running {len(CASES)} edge cases against {SCRIPT.relative_to(REPO)}")
     print()
     results: list[tuple[Case, bool, str]] = []

--- a/tests/studio/test_is_mlx_dispatch_gate.py
+++ b/tests/studio/test_is_mlx_dispatch_gate.py
@@ -27,7 +27,7 @@ UNSLOTH_INIT = REPO_ROOT / "unsloth" / "__init__.py"
 
 def test_is_mlx_gate_uses_three_required_predicates():
     """_IS_MLX must AND Darwin+arm64+importable-mlx; dropping any breaks dispatch."""
-    tree = ast.parse(UNSLOTH_INIT.read_text())
+    tree = ast.parse(UNSLOTH_INIT.read_text(encoding = "utf-8"))
 
     target = None
     for node in ast.walk(tree):

--- a/tests/studio/test_llama_cpp_wall_clock_cap.py
+++ b/tests/studio/test_llama_cpp_wall_clock_cap.py
@@ -14,7 +14,7 @@ SOURCE_PATH = (
     / "inference"
     / "llama_cpp.py"
 )
-SRC = SOURCE_PATH.read_text()
+SRC = SOURCE_PATH.read_text(encoding = "utf-8")
 TREE = ast.parse(SRC)
 
 

--- a/tests/studio/test_mlx_training_worker_behaviors.py
+++ b/tests/studio/test_mlx_training_worker_behaviors.py
@@ -28,9 +28,9 @@ def test_run_mlx_training_passes_token_to_from_pretrained():
             and node.func.value.id == "FastMLXModel"
         ):
             kwarg_names = {kw.arg for kw in node.keywords if kw.arg}
-            assert "token" in kwarg_names, (
-                f"FastMLXModel.from_pretrained must forward token=hf_token; got {kwarg_names!r}"
-            )
+            assert (
+                "token" in kwarg_names
+            ), f"FastMLXModel.from_pretrained must forward token=hf_token; got {kwarg_names!r}"
             found = True
     assert found, "FastMLXModel.from_pretrained call not found in _run_mlx_training"
 
@@ -39,9 +39,9 @@ def test_wandb_init_strips_secret_keys():
     src = WORKER.read_text(encoding = "utf-8")
     assert "_wandb_sensitive" in src, "expected a sensitive-key set near wandb.init"
     assert '"hf_token"' in src and '"wandb_token"' in src
-    assert "config = dict(config)" not in src, (
-        "wandb.init received raw config dict; secrets would leak"
-    )
+    assert (
+        "config = dict(config)" not in src
+    ), "wandb.init received raw config dict; secrets would leak"
 
 
 def test_local_dataset_loader_uses_load_dataset_path():
@@ -73,9 +73,9 @@ def test_poll_stop_returns_on_broken_pipe():
                 stripped = lines[j].strip()
                 if not stripped or stripped.startswith("#"):
                     continue
-                assert stripped.startswith("return"), (
-                    f"expected return after EOFError/OSError, got {stripped!r}"
-                )
+                assert stripped.startswith(
+                    "return"
+                ), f"expected return after EOFError/OSError, got {stripped!r}"
                 break
             break
     else:

--- a/tests/studio/test_mlx_training_worker_behaviors.py
+++ b/tests/studio/test_mlx_training_worker_behaviors.py
@@ -15,7 +15,7 @@ def _find_func(tree, name):
 
 
 def test_run_mlx_training_passes_token_to_from_pretrained():
-    tree = ast.parse(WORKER.read_text())
+    tree = ast.parse(WORKER.read_text(encoding = "utf-8"))
     fn = _find_func(tree, "_run_mlx_training")
     assert fn is not None
     found = False
@@ -28,43 +28,43 @@ def test_run_mlx_training_passes_token_to_from_pretrained():
             and node.func.value.id == "FastMLXModel"
         ):
             kwarg_names = {kw.arg for kw in node.keywords if kw.arg}
-            assert (
-                "token" in kwarg_names
-            ), f"FastMLXModel.from_pretrained must forward token=hf_token; got {kwarg_names!r}"
+            assert "token" in kwarg_names, (
+                f"FastMLXModel.from_pretrained must forward token=hf_token; got {kwarg_names!r}"
+            )
             found = True
     assert found, "FastMLXModel.from_pretrained call not found in _run_mlx_training"
 
 
 def test_wandb_init_strips_secret_keys():
-    src = WORKER.read_text()
+    src = WORKER.read_text(encoding = "utf-8")
     assert "_wandb_sensitive" in src, "expected a sensitive-key set near wandb.init"
     assert '"hf_token"' in src and '"wandb_token"' in src
-    assert (
-        "config = dict(config)" not in src
-    ), "wandb.init received raw config dict; secrets would leak"
+    assert "config = dict(config)" not in src, (
+        "wandb.init received raw config dict; secrets would leak"
+    )
 
 
 def test_local_dataset_loader_uses_load_dataset_path():
-    src = WORKER.read_text()
+    src = WORKER.read_text(encoding = "utf-8")
     assert "_resolve_mlx_local_dataset_files" in src
     assert "_mlx_local_dataset_loader_for_files" in src
     assert "data_files = all_files" in src or "data_files=all_files" in src
 
 
 def test_send_aliases_status_message_to_message():
-    src = WORKER.read_text()
+    src = WORKER.read_text(encoding = "utf-8")
     assert 'kwargs["message"] = sm' in src or 'kwargs["message"]=sm' in src
 
 
 def test_slice_uses_inclusive_end_and_handles_zero():
-    src = WORKER.read_text()
+    src = WORKER.read_text(encoding = "utf-8")
     assert "min(end + 1, len(ds))" in src or "min(end+1, len(ds))" in src
     assert "slice_start if slice_start is not None else 0" in src
     assert "slice_end if slice_end is not None else len(ds) - 1" in src
 
 
 def test_poll_stop_returns_on_broken_pipe():
-    src = WORKER.read_text()
+    src = WORKER.read_text(encoding = "utf-8")
     assert "except (EOFError, OSError)" in src
     lines = src.splitlines()
     for i, line in enumerate(lines):
@@ -73,9 +73,9 @@ def test_poll_stop_returns_on_broken_pipe():
                 stripped = lines[j].strip()
                 if not stripped or stripped.startswith("#"):
                     continue
-                assert stripped.startswith(
-                    "return"
-                ), f"expected return after EOFError/OSError, got {stripped!r}"
+                assert stripped.startswith("return"), (
+                    f"expected return after EOFError/OSError, got {stripped!r}"
+                )
                 break
             break
     else:
@@ -83,7 +83,7 @@ def test_poll_stop_returns_on_broken_pipe():
 
 
 def test_unsloth_zoo_mlx_imports_have_friendly_error():
-    src = WORKER.read_text()
+    src = WORKER.read_text(encoding = "utf-8")
     assert "from unsloth_zoo.mlx.loader import FastMLXModel" in src
     assert "from unsloth_zoo.mlx.trainer import" in src
     assert "raise ImportError" in src

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -23,7 +23,7 @@ FRONTEND = WORKDIR / "studio" / "frontend" / "src"
 def _read(rel: str) -> str:
     path = FRONTEND / rel
     assert path.exists(), f"missing source file: {path}"
-    return path.read_text()
+    return path.read_text(encoding = "utf-8")
 
 
 def test_models_api_sends_token_via_header_not_query():

--- a/tests/studio/test_studio_gguf_export_script_pin.py
+++ b/tests/studio/test_studio_gguf_export_script_pin.py
@@ -12,7 +12,7 @@ from pathlib import Path
 SOURCE_PATH = (
     Path(__file__).resolve().parents[2] / "studio" / "backend" / "core" / "export" / "export.py"
 )
-SRC = SOURCE_PATH.read_text()
+SRC = SOURCE_PATH.read_text(encoding = "utf-8")
 TREE = ast.parse(SRC)
 
 

--- a/tests/studio/test_studio_text_descender_clipping.py
+++ b/tests/studio/test_studio_text_descender_clipping.py
@@ -24,7 +24,7 @@ APP_SIDEBAR = WORKDIR / "studio" / "frontend" / "src" / "components" / "app-side
 
 def _read(path: Path) -> str:
     assert path.exists(), f"missing source file: {path}"
-    return path.read_text()
+    return path.read_text(encoding = "utf-8")
 
 
 def test_model_selector_trigger_label_uses_leading_tight():

--- a/tests/test_fast_generate_slow_guard.py
+++ b/tests/test_fast_generate_slow_guard.py
@@ -13,7 +13,7 @@ UTILS = os.path.join(HERE, "unsloth", "models", "_utils.py")
 
 
 def _load_factory():
-    src = open(UTILS).read()
+    src = open(UTILS, encoding = "utf-8").read()
     for node in ast.parse(src).body:
         if isinstance(node, ast.FunctionDef) and node.name == "make_fast_generate_wrapper":
             ns = {"functools": functools}

--- a/tests/test_fp8_device_context.py
+++ b/tests/test_fp8_device_context.py
@@ -78,7 +78,7 @@ class _LaunchVisitor(ast.NodeVisitor):
 
 
 def _load_device_context_helper(fake_torch: _FakeTorch):
-    source = FP8_SOURCE.read_text()
+    source = FP8_SOURCE.read_text(encoding = "utf-8")
     tree = ast.parse(source)
     for node in tree.body:
         if isinstance(node, ast.FunctionDef) and node.name == "_fp8_triton_device_context":
@@ -144,7 +144,7 @@ def test_fp8_device_context_is_noop_for_non_cuda_tensor() -> None:
 
 
 def test_fp8_triton_launches_enter_tensor_device_context() -> None:
-    tree = ast.parse(FP8_SOURCE.read_text())
+    tree = ast.parse(FP8_SOURCE.read_text(encoding = "utf-8"))
     function_names = {node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)}
     assert "_fp8_triton_device_context" in function_names
 

--- a/tests/test_gemma4_chat_template.py
+++ b/tests/test_gemma4_chat_template.py
@@ -14,7 +14,7 @@ CHAT_TEMPLATES_PATH = os.path.join(
 
 
 def _extract_template(name):
-    src = open(CHAT_TEMPLATES_PATH).read()
+    src = open(CHAT_TEMPLATES_PATH, encoding = "utf-8").read()
     pattern = rf'{re.escape(name)}\s*=\s*\\\n"""(.*?)"""'
     m = re.search(pattern, src, flags = re.DOTALL)
     assert m, f"Could not extract {name} from chat_templates.py"

--- a/tests/test_gemma_2b_mapper_key.py
+++ b/tests/test_gemma_2b_mapper_key.py
@@ -18,7 +18,7 @@ MAPPER_PATH = os.path.join(os.path.dirname(__file__), os.pardir, "unsloth", "mod
 
 
 def _load_mappers():
-    with open(MAPPER_PATH) as f:
+    with open(MAPPER_PATH, encoding = "utf-8") as f:
         source = f.read()
     namespace = {}
     exec(compile(source, MAPPER_PATH, "exec"), namespace)

--- a/tests/test_generate_kwarg_gate.py
+++ b/tests/test_generate_kwarg_gate.py
@@ -9,7 +9,7 @@ VISION = os.path.join(HERE, "unsloth", "models", "vision.py")
 
 
 def _load_helper():
-    src = open(VISION).read()
+    src = open(VISION, encoding = "utf-8").read()
     mod = ast.parse(src)
     for node in mod.body:
         if isinstance(node, ast.FunctionDef) and node.name == "_unsloth_generate_accepts_kwarg":

--- a/tests/test_gradient_checkpointing_restore.py
+++ b/tests/test_gradient_checkpointing_restore.py
@@ -28,8 +28,8 @@ import re
 from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parent.parent / "unsloth" / "models"
-_RL = (_ROOT / "rl.py").read_text()
-_RL_REPLACEMENTS = (_ROOT / "rl_replacements.py").read_text()
+_RL = (_ROOT / "rl.py").read_text(encoding = "utf-8")
+_RL_REPLACEMENTS = (_ROOT / "rl_replacements.py").read_text(encoding = "utf-8")
 
 # The single-line ternary form used at the trainer call sites:
 #   <obj>._unsloth_gradient_checkpointing if hasattr(<obj>, '...') else getattr(<args>, 'gradient_checkpointing', True)
@@ -162,7 +162,7 @@ def test_recording_sites_are_real_module_code():
     # string. Assert it's present at the choke point (patch_peft_model, so loaded adapters
     # are covered) and at the pre-wrapped pass-through, both of which bypass the old
     # get_peft_model-only recording.
-    llama = (_ROOT / "llama.py").read_text()
+    llama = (_ROOT / "llama.py").read_text(encoding = "utf-8")
     tree = ast.parse(llama)
 
     def assigns_marker(node):

--- a/tests/test_import_fixes_drift.py
+++ b/tests/test_import_fixes_drift.py
@@ -704,7 +704,7 @@ def test_accelerate_find_device_skips_empty_logits():
 def test_accelerate_patch_wired_into_gpu_init():
     """The patch must be installed at startup, not only importable."""
     source = Path(__file__).resolve().parent.parent / "unsloth" / "_gpu_init.py"
-    source = source.read_text()
+    source = source.read_text(encoding = "utf-8")
     assert "patch_accelerate_recursively_apply()" in source, (
         "DRIFT DETECTED: patch_accelerate_recursively_apply is defined but "
         "never called in _gpu_init.py, so real imports never install it."

--- a/tests/test_loader_glob_skip.py
+++ b/tests/test_loader_glob_skip.py
@@ -116,7 +116,7 @@ class TestLoaderSourceHasGuard(unittest.TestCase):
         loader_path = os.path.join(
             os.path.dirname(__file__), os.pardir, "unsloth", "models", "loader.py"
         )
-        with open(loader_path) as f:
+        with open(loader_path, encoding = "utf-8") as f:
             source = f.read()
 
         lines = source.splitlines()

--- a/tests/test_multi_image_grpo_chunking.py
+++ b/tests/test_multi_image_grpo_chunking.py
@@ -180,6 +180,6 @@ def test_guard_only_raises_when_both_checks_fail():
 def test_guard_introspection_failure_does_not_silent_no_op():
     src = _read_source()
     assert "(TypeError, OSError)" in src, "guard must catch inspect.getsource failures explicitly"
-    assert re.search(r"_zoo_src\s*=\s*['\"]{2}", src), (
-        "introspection failure path must default _zoo_src to empty string"
-    )
+    assert re.search(
+        r"_zoo_src\s*=\s*['\"]{2}", src
+    ), "introspection failure path must default _zoo_src to empty string"

--- a/tests/test_multi_image_grpo_chunking.py
+++ b/tests/test_multi_image_grpo_chunking.py
@@ -12,7 +12,7 @@ SOURCE_PATH = os.path.join(REPO_ROOT, "unsloth", "models", "rl_replacements.py")
 
 
 def _read_source() -> str:
-    with open(SOURCE_PATH, "r") as fh:
+    with open(SOURCE_PATH, "r", encoding = "utf-8") as fh:
         return fh.read()
 
 
@@ -180,6 +180,6 @@ def test_guard_only_raises_when_both_checks_fail():
 def test_guard_introspection_failure_does_not_silent_no_op():
     src = _read_source()
     assert "(TypeError, OSError)" in src, "guard must catch inspect.getsource failures explicitly"
-    assert re.search(
-        r"_zoo_src\s*=\s*['\"]{2}", src
-    ), "introspection failure path must default _zoo_src to empty string"
+    assert re.search(r"_zoo_src\s*=\s*['\"]{2}", src), (
+        "introspection failure path must default _zoo_src to empty string"
+    )

--- a/tests/test_offload_embedding_hooks.py
+++ b/tests/test_offload_embedding_hooks.py
@@ -11,7 +11,7 @@ VISION = os.path.join(HERE, "unsloth", "models", "vision.py")
 
 
 def _load_installer():
-    src = open(VISION).read()
+    src = open(VISION, encoding = "utf-8").read()
     mod = ast.parse(src)
     for node in mod.body:
         if isinstance(node, ast.FunctionDef) and node.name == "_install_offload_embedding_hooks":

--- a/tests/test_offload_tied_guard.py
+++ b/tests/test_offload_tied_guard.py
@@ -11,7 +11,7 @@ VISION = os.path.join(HERE, "unsloth", "models", "vision.py")
 
 
 def _load_fn():
-    src = open(VISION).read()
+    src = open(VISION, encoding = "utf-8").read()
     mod = ast.parse(src)
     for node in mod.body:
         if isinstance(node, ast.FunctionDef) and node.name == "_embeddings_are_tied":

--- a/tests/test_source_read_encoding.py
+++ b/tests/test_source_read_encoding.py
@@ -125,6 +125,7 @@ EAGER_CONSUMERS = {
     "list",
     "max",
     "min",
+    "next",
     "set",
     "sorted",
     "sum",
@@ -147,6 +148,7 @@ PATH_METHODS = {
     "resolve",
     "rglob",
     "with_name",
+    "with_stem",
     "with_suffix",
 }
 # Where each API takes its encoding positionally, for the bound call.
@@ -408,6 +410,24 @@ def _imports_at_each_call(tree: ast.Module) -> dict:
     return visible_at
 
 
+def _open_alias(name, modules):
+    """What a bare callable resolves to: "builtin", a COMPRESSED_OPENERS key, or None.
+
+    `from io import open as io_open` is the builtin under another name and
+    `from gzip import open as gzopen` is gzip's, while `from PIL.Image import
+    open` is neither and takes no encoding at all.
+    """
+    origin = modules.get(name)
+    if origin is None:
+        return "builtin" if name == "open" else None
+    parts = origin.split(".")
+    if parts[-1] != "open":
+        return None
+    if parts[0] == "io" or origin == "open":
+        return "builtin"
+    return parts[0] if parts[0] in COMPRESSED_OPENERS else None
+
+
 def _origin_root(name, modules) -> str:
     """The top-level module a bound name came from, or the name itself."""
     return modules.get(name, name).split(".")[0]
@@ -443,7 +463,7 @@ def _path_expr(call: ast.Call, modules = NO_MODULES):
         if isinstance(func.value, ast.Name) and _is_module_receiver(func.value.id, modules):
             return call.args[0] if call.args else None
         return func.value
-    if isinstance(func, ast.Name) and func.id == "open":
+    if isinstance(func, ast.Name) and _open_alias(func.id, modules) is not None:
         if call.args:
             return call.args[0]
         # open(file = CHECKED_IN) is the same call spelled out.
@@ -532,6 +552,28 @@ def _reads_itself(name: str, value: ast.AST) -> bool:
     return isinstance(expr, ast.Name) and expr.id == name
 
 
+def _unpack(target, value, paired: bool):
+    """Yield (name node, the value it is bound to) for one binding.
+
+    A destructured target contributes every name inside it. Where the two sides
+    line up, as in `A, B = P1, P2`, each name takes its own element; where they
+    do not, as in `for name, path in CASES`, they all take the iterable, which
+    is the thing whose provenance is known.
+    """
+    if isinstance(target, ast.Name):
+        yield target, value
+        return
+    if not isinstance(target, (ast.Tuple, ast.List)):
+        return
+    elements = None
+    if paired and isinstance(value, (ast.Tuple, ast.List)) and len(value.elts) == len(target.elts):
+        elements = value.elts
+    for index, element in enumerate(target.elts):
+        if isinstance(element, ast.Starred):
+            element = element.value
+        yield from _unpack(element, elements[index] if elements else value, paired)
+
+
 def _checked_in_locals(
     func,
     module_names: set,
@@ -549,17 +591,20 @@ def _checked_in_locals(
     targets = set()
     bad = set()
     for node in ast.walk(func):
+        paired = False
         if isinstance(node, ast.Assign) and len(node.targets) == 1:
             target, value = node.targets[0], node.value
+            paired = True  # `A, B = P1, P2` lines its sides up element by element
         elif isinstance(node, (ast.For, ast.AsyncFor, ast.comprehension)):
-            # `for p in SRC_DIR.rglob("*.py")` binds p to a checked-in path too.
+            # `for p in SRC_DIR.rglob("*.py")` binds p to a checked-in path too,
+            # and `for name, path in CASES` binds both to the same iterable.
             target, value = node.target, node.iter
         else:
             continue
-        if isinstance(target, ast.Name):
-            targets.add(id(target))
-            if not _reads_itself(target.id, value):
-                assignments.append((target.id, value))
+        for name_node, bound in _unpack(target, value, paired):
+            targets.add(id(name_node))
+            if not _reads_itself(name_node.id, bound):
+                assignments.append((name_node.id, bound))
     for node in ast.walk(func):
         # A with-as or an augassign says nothing about the value it binds.
         if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
@@ -664,8 +709,11 @@ def _checked_in_params(tree: ast.Module, module_names: set) -> set:
                 params = {p for f, p in good if f == caller.name}
                 here = _checked_in_locals(caller, module_names, _local_names(caller), params)
                 scope[id(caller)] = here
-            params = [a.arg for a in [*func.args.posonlyargs, *func.args.args]]
-            supplied = dict(zip(params, call.args))
+            positional = [a.arg for a in [*func.args.posonlyargs, *func.args.args]]
+            # A keyword-only parameter never takes a positional slot, so it is
+            # matched by name alone.
+            params = positional + [a.arg for a in func.args.kwonlyargs]
+            supplied = dict(zip(positional, call.args))
             supplied.update({k.arg: k.value for k in call.keywords if k.arg in params})
             for param in params:
                 value = supplied.get(param)
@@ -839,14 +887,17 @@ def _offender(call: ast.Call, modules = NO_MODULES) -> str | None:
                 else "Path.open()"
             )
         return None
-    # Binary handles have no encoding to name.
-    if isinstance(func, ast.Name) and func.id == "open" and _is_text(call, 1):
-        # `from PIL.Image import open` is not the builtin and takes no
-        # encoding; `from io import open` is the builtin under another roof.
-        origin = modules.get("open")
-        if origin is not None and origin.split(".")[0] != "io":
-            return None
-        return None if _pins_encoding(call, ENCODING_POSITION["open"]) else "open()"
+    if isinstance(func, ast.Name):
+        alias = _open_alias(func.id, modules)
+        # Binary handles have no encoding to name.
+        if alias == "builtin" and _is_text(call, 1):
+            return None if _pins_encoding(call, ENCODING_POSITION["open"]) else "open()"
+        if alias is not None and alias != "builtin":
+            mode = _open_mode(call, 1)
+            if mode is UNKNOWN_MODE or "t" not in str(mode):
+                return None  # "rb" default, so binary unless asked otherwise
+            position = COMPRESSED_OPENERS[alias]
+            return None if _pins_encoding(call, position) else f"{alias}.open()"
     return None
 
 

--- a/tests/test_source_read_encoding.py
+++ b/tests/test_source_read_encoding.py
@@ -124,6 +124,9 @@ PATH_METHODS = {
 ENCODING_POSITION = {"read_text": 0, "write_text": 1, "Path.open": 2, "open": 3}
 # Distinct from None so that "no mode argument at all" still means text.
 UNKNOWN_MODE = object()
+# Stand-in for a file whose imports are not to hand, so every helper can be
+# called on its own without pretending it knows what was imported.
+NO_MODULES: dict = {}
 
 
 def _is_main_guard(node: ast.AST) -> bool:
@@ -239,13 +242,27 @@ def _eagerly_consumed(tree: ast.Module) -> set:
     generator function. Neither runs its body until something pulls from it, so
     an unconsumed one has not happened yet.
     """
+    # `texts = (p.read_text() for p in ...)` then `list(texts)` consumes the
+    # generator through a name, so the name has to lead back to it.
+    named: dict = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if isinstance(target, ast.Name) and isinstance(node.value, ast.GeneratorExp):
+                named.setdefault(target.id, node.value)
+
+    def _resolve(node):
+        if isinstance(node, ast.Name) and node.id in named:
+            return named[node.id]
+        return node
+
     consumed = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Call) and _is_eager_consumer(node.func):
-            consumed.update(id(a) for a in node.args)
-            consumed.update(id(k.value) for k in node.keywords)
+            consumed.update(id(_resolve(a)) for a in node.args)
+            consumed.update(id(_resolve(k.value)) for k in node.keywords)
         elif isinstance(node, (ast.For, ast.AsyncFor, ast.comprehension)):
-            consumed.add(id(node.iter))  # the loop pulls every item
+            consumed.add(id(_resolve(node.iter)))  # the loop pulls every item
     return consumed
 
 
@@ -299,27 +316,50 @@ def _local_names(func) -> set:
     return names
 
 
-def _imported_names(tree: ast.Module) -> set:
-    """Every name an import binds anywhere in the file.
+def _imported_names(tree: ast.Module) -> dict:
+    """Every name an import binds, mapped to where it came from.
 
-    A receiver bound that way is a module, so `Image.open(...)` after
-    `from PIL import Image` and `tf.open(...)` after `import tarfile as tf` are
-    both somebody else's opener. Reading the imports instead of keeping a list
-    of module names is what makes aliases and unfamiliar libraries work.
+    The name alone is not enough in either direction. `import gzip as gz` binds
+    a name nobody would recognise to an opener that does take an encoding, and
+    `from PIL.Image import open` binds a name everybody recognises to one that
+    does not. Keeping the origin settles both.
     """
-    names = set()
+    bound = {}
     for node in ast.walk(tree):
-        if isinstance(node, (ast.Import, ast.ImportFrom)):
-            names.update((a.asname or a.name).split(".")[0] for a in node.names)
-    return names
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                bound[(alias.asname or alias.name).split(".")[0]] = alias.name
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                origin = f"{node.module}.{alias.name}" if node.module else alias.name
+                bound[alias.asname or alias.name] = origin
+    return bound
+
+
+def _origin_root(name, modules) -> str:
+    """The top-level module a bound name came from, or the name itself."""
+    return modules.get(name, name).split(".")[0]
+
+
+def _compressed_key(name, modules):
+    """The COMPRESSED_OPENERS entry this receiver resolves to, if any."""
+    for candidate in (name, _origin_root(name, modules)):
+        if candidate in COMPRESSED_OPENERS:
+            return candidate
+    return None
 
 
 def _is_module_receiver(name, modules) -> bool:
     """True for a receiver that is not itself a path."""
-    return name in modules or name in PATH_CLASSES or name in COMPRESSED_OPENERS or name == "io"
+    return (
+        name in modules
+        or name in PATH_CLASSES
+        or _compressed_key(name, modules) is not None
+        or _origin_root(name, modules) == "io"
+    )
 
 
-def _path_expr(call: ast.Call, modules = frozenset()):
+def _path_expr(call: ast.Call, modules = NO_MODULES):
     """The expression naming the file the call reads.
 
     Usually the receiver, but a module or the Path class in that slot means the
@@ -476,6 +516,32 @@ def _checked_in_locals(
         good = grown
 
 
+def _parametrized_values(func) -> dict:
+    """Parameter values supplied by @pytest.mark.parametrize.
+
+    pytest calls a parametrized test itself, so the decorator is the only call
+    site there is; without reading it every such parameter looks unprovable.
+    """
+    supplied: dict = {}
+    for decorator in func.decorator_list:
+        if not isinstance(decorator, ast.Call) or len(decorator.args) < 2:
+            continue
+        if not isinstance(decorator.func, ast.Attribute) or decorator.func.attr != "parametrize":
+            continue
+        names, values = decorator.args[0], decorator.args[1]
+        if not isinstance(names, ast.Constant) or not isinstance(names.value, str):
+            continue
+        if not isinstance(values, (ast.List, ast.Tuple, ast.Set)):
+            continue
+        argnames = [n.strip() for n in names.value.split(",") if n.strip()]
+        for element in values.elts:
+            paired = len(argnames) > 1 and isinstance(element, (ast.Tuple, ast.List))
+            row = element.elts if paired else [element]
+            for argname, value in zip(argnames, row):
+                supplied.setdefault(argname, []).append(value)
+    return supplied
+
+
 def _checked_in_params(tree: ast.Module, module_names: set) -> set:
     """(function, parameter) pairs that only ever receive a checked-in path.
 
@@ -504,6 +570,10 @@ def _checked_in_params(tree: ast.Module, module_names: set) -> set:
     good: set = set()
     while True:
         grown, bad = set(), set()
+        for fname, fnode in funcs.items():
+            for argname, values in _parametrized_values(fnode).items():
+                ok = all(_is_checked_in_root(v, module_names, ()) for v in values)
+                (grown if ok else bad).add((fname, argname))
         # What the calling function itself can prove, recomputed each pass so a
         # parameter resolved last time can feed a local this time.
         scope: dict = {}
@@ -535,7 +605,7 @@ def _checked_in_params(tree: ast.Module, module_names: set) -> set:
         good = grown
 
 
-def _checked_in_path_calls(tree: ast.Module, modules = frozenset()):
+def _checked_in_path_calls(tree: ast.Module, modules = NO_MODULES):
     """Yield calls, at any depth, whose path is provably a checked-in file.
 
     The import-time walk alone leaves test bodies unguarded, and a bare read
@@ -560,9 +630,10 @@ def _checked_in_path_calls(tree: ast.Module, modules = frozenset()):
     ):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
             shadowed = shadowed | _local_names(node)
-            derived = _checked_in_locals(node, module_names, shadowed)
-            name = getattr(node, "name", None)
-            derived = derived | {p for f, p in params if f == name}
+            # Seed with the parameters first: `p = root / "x.py"` is only
+            # derivable once `root` is known to hold a checked-in path.
+            seeded = {p for f, p in params if f == getattr(node, "name", None)}
+            derived = _checked_in_locals(node, module_names, shadowed, seeded)
         elif _is_main_guard(node):
             # Never runs under pytest, so rule 1 skips it for the same reason.
             for child in node.orelse:
@@ -642,7 +713,7 @@ def _pins_encoding(call: ast.Call, position: int | None) -> bool:
     return _names_encoding(call)
 
 
-def _offender(call: ast.Call, modules = frozenset()) -> str | None:
+def _offender(call: ast.Call, modules = NO_MODULES) -> str | None:
     """The call's name if it reads text without an encoding, else None."""
     func = call.func
     if isinstance(func, ast.Attribute):
@@ -664,16 +735,20 @@ def _offender(call: ast.Call, modules = frozenset()) -> str | None:
         if func.attr == "open":
             # io.open IS the builtin, so it takes the builtin's argument
             # positions and carries the same platform default.
-            if receiver == "io":
+            if receiver is not None and _origin_root(receiver, modules) == "io":
                 if not _is_text(call, 1) or _pins_encoding(call, ENCODING_POSITION["open"]):
                     return None
                 return "io.open()"
-            if receiver in COMPRESSED_OPENERS:
+            compressed = _compressed_key(receiver, modules) if receiver else None
+            if compressed is not None:
                 mode = _open_mode(call, 1)
                 if mode is UNKNOWN_MODE or "t" not in str(mode):
                     return None  # "rb" default, so binary unless asked otherwise
-                position = COMPRESSED_OPENERS[receiver]
-                return None if _pins_encoding(call, position) else f"{receiver}.open()"
+                return (
+                    None
+                    if _pins_encoding(call, COMPRESSED_OPENERS[compressed])
+                    else f"{compressed}.open()"
+                )
             # Any other module receiver is somebody else's opener: tarfile.open
             # takes a compression mode, Image.open takes a binary file. Neither
             # has an encoding to name, so demanding one leaves no correct edit.
@@ -689,6 +764,11 @@ def _offender(call: ast.Call, modules = frozenset()) -> str | None:
         return None
     # Binary handles have no encoding to name.
     if isinstance(func, ast.Name) and func.id == "open" and _is_text(call, 1):
+        # `from PIL.Image import open` is not the builtin and takes no
+        # encoding; `from io import open` is the builtin under another roof.
+        origin = modules.get("open")
+        if origin is not None and origin.split(".")[0] != "io":
+            return None
         return None if _pins_encoding(call, ENCODING_POSITION["open"]) else "open()"
     return None
 

--- a/tests/test_source_read_encoding.py
+++ b/tests/test_source_read_encoding.py
@@ -44,10 +44,12 @@ says nothing about itself at the read. Text read from a checked-in file and
 then written back to a tmp_path, at test_studio_install_workspace_guard.py:851
 and test_scan_packages.py:40, is unsafe only because of where the string came
 from. And a read inside a `python -c` snippet, as test_studio_import_no_torch.py
-builds for eight subprocess tests, runs in a child interpreter this scan never
-parses: the snippet is an f-string whose paths are replacement fields, so
-recovering it would mean evaluating the interpolation. Reviewers have to catch
-those three.
+and test_e2e_no_torch_sandbox.py build for their subprocess tests, runs in a
+child interpreter this scan never parses: the snippet is an f-string whose paths
+are replacement fields, so recovering it would mean evaluating the
+interpolation. Reviewers have to catch those three; running the suite under
+LC_ALL=C is the cheapest way to find them, since ASCII rejects every byte cp1252
+does and more.
 """
 
 # `str | None` below is evaluated at import on Python 3.9 without this, and

--- a/tests/test_source_read_encoding.py
+++ b/tests/test_source_read_encoding.py
@@ -61,12 +61,13 @@ def _is_main_guard(node: ast.AST) -> bool:
     """
     if not isinstance(node, ast.If) or not isinstance(node.test, ast.Compare):
         return False
-    left = node.test.left
-    if not (isinstance(left, ast.Name) and left.id == "__name__"):
-        return False
     if not all(isinstance(op, ast.Eq) for op in node.test.ops):
         return False
-    return any(isinstance(c, ast.Constant) and c.value == "__main__" for c in node.test.comparators)
+    operands = [node.test.left, *node.test.comparators]
+    # Either spelling: `__name__ == "__main__"` or `"__main__" == __name__`.
+    has_name = any(isinstance(o, ast.Name) and o.id == "__name__" for o in operands)
+    has_main = any(isinstance(o, ast.Constant) and o.value == "__main__" for o in operands)
+    return has_name and has_main
 
 
 def _import_time_calls(tree: ast.Module):
@@ -90,10 +91,25 @@ def _import_time_calls(tree: ast.Module):
     so that is walked), and non-name calls, which are left unresolved rather
     than guessed at.
     """
-    helpers = {
-        node.name: node
-        for node in tree.body
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    # Defs reachable from a scope that executes at import: module body and any
+    # class body, at any nesting. `class F: def _load(): ...; DATA = _load()`
+    # runs _load while the class is constructed.
+    helpers = {}
+    scopes = [tree.body]
+    while scopes:
+        for node in scopes.pop():
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                helpers.setdefault(node.name, node)
+            elif isinstance(node, ast.ClassDef):
+                scopes.append(node.body)
+    # A generator expression handed straight to a call is consumed there, so its
+    # element runs at import; one merely bound to a name does not.
+    consumed = {
+        id(arg)
+        for call in ast.walk(tree)
+        if isinstance(call, ast.Call)
+        for arg in [*call.args, *(k.value for k in call.keywords)]
+        if isinstance(arg, ast.GeneratorExp)
     }
     entered = set()
     frontier = [list(tree.body)]
@@ -111,7 +127,7 @@ def _import_time_calls(tree: ast.Module):
                 stack.extend(d for d in node.args.defaults if d is not None)
                 stack.extend(d for d in node.args.kw_defaults if d is not None)
                 continue
-            if isinstance(node, ast.GeneratorExp):
+            if isinstance(node, ast.GeneratorExp) and id(node) not in consumed:
                 # Lazy: only the outermost iterable is evaluated where written.
                 if node.generators:
                     stack.append(node.generators[0].iter)

--- a/tests/test_source_read_encoding.py
+++ b/tests/test_source_read_encoding.py
@@ -14,27 +14,32 @@ source-scanning tests do constantly:
     "byte 0x81", taking test_cancel_atomicity.py and test_cancel_id_wiring.py
     out at collection time.
 
-A call is an offence when it does un-pinned text I/O and any of three things
-holds. It runs at import, where nothing can see a tmp_path fixture yet. Its
-path is a module-level constant, which a fixture parameter cannot be. Or its
-path is built from `__file__`, which is checked in by construction. The last
-two reach test bodies, where the same failure lands one step later:
+A call is an offence when it does un-pinned text I/O and either of two things
+holds. It runs at import, where nothing can see a tmp_path fixture yet. Or the
+path it reads anchors on something checked in: a module-level constant, which a
+fixture parameter can never be, or `__file__`. Anchoring is what decides the
+second one, followed through `/` joins, path methods, and the locals and loop
+variables of the enclosing function, so `for p in (_B / "routes").rglob("*.py")`
+is in scope and anything growing out of a tmp_path is not. That rule reaches
+test bodies, where the same failure lands one step later:
 
     test_gemma4_chat_template.py opens unsloth/chat_templates.py through a
     helper its tests call, and cp1252 cannot decode that file ("byte 0x90").
-    test_gguf_load_cache_reuse.py reads routes/inference.py the same way, via
-    `Path(__file__).parent.parent`, and dies on the same 0x81 as the two cancel
-    modules do at collection.
+    test_consent_gate.py reads routes/inference.py as `(_BACKEND / rel)` and
+    test_gguf_load_cache_reuse.py as `Path(__file__).parent.parent / ...`, both
+    dying on the same 0x81 the two cancel modules hit at collection.
 
-Each rule is a property of the path expression alone, so together they stay
-mechanical enough to enforce with no allowlist while staying quiet about
-temp-dir I/O, where the platform default is harmless and the test wrote the
-bytes itself.
+Every question the rules ask is answered inside one function, which keeps them
+mechanical enough to enforce with no allowlist and quiet about temp-dir I/O,
+where the platform default is harmless and the test wrote the bytes itself.
 
-One shape is deliberately out of reach: text read from a checked-in file and
-then written back out to a tmp_path, as at test_studio_install_workspace_guard
-.py:851, is only unsafe because of where the string came from, and tracing that
-needs dataflow rather than a look at the call.
+Two shapes are consequently out of reach, both fixed by hand and neither
+detectable without whole-program dataflow. A path that arrives from another
+function, as `for path in _iter_caller_files()` does in
+test_security_gate_consistency.py, says nothing about itself at the read. And
+text read from a checked-in file then written back to a tmp_path, as at
+test_studio_install_workspace_guard.py:851, is unsafe only because of where the
+string came from. Reviewers have to catch those two.
 """
 
 # `str | None` below is evaluated at import on Python 3.9 without this, and
@@ -51,12 +56,9 @@ REPO = TESTS.parent
 ROOTS = (TESTS, REPO / "studio" / "backend" / "tests")
 GUARDED_METHODS = {"read_text", "write_text"}
 NOT_PATH_RECEIVERS = {
-    "bz2",
     "codecs",
     "dbm",
     "fitz",
-    "gzip",
-    "lzma",
     "os",
     "pymupdf",
     "shelve",
@@ -66,6 +68,10 @@ NOT_PATH_RECEIVERS = {
     "webbrowser",
     "zipfile",
 }
+# These wrap their stream in a TextIOWrapper for a "t" mode, which takes the
+# platform default exactly like builtin open. Unlike open they default to "rb",
+# so only an explicit text mode is in scope. lzma takes encoding keyword-only.
+COMPRESSED_OPENERS = {"bz2": 3, "gzip": 3, "lzma": None}
 # Callables that drain a generator argument immediately.
 EAGER_CONSUMERS = {
     "all",
@@ -86,6 +92,19 @@ PLATFORM_DEFAULT_ENCODINGS = (None, "locale")
 # platform default, but the instance takes the first slot so every argument
 # shifts one place right.
 PATH_CLASSES = {"Path", "PosixPath", "PurePath", "WindowsPath"}
+# Path methods that hand back another path, so the receiver is still the anchor.
+PATH_METHODS = {
+    "absolute",
+    "as_posix",
+    "expanduser",
+    "glob",
+    "iterdir",
+    "joinpath",
+    "resolve",
+    "rglob",
+    "with_name",
+    "with_suffix",
+}
 # Where each API takes its encoding positionally, for the bound call.
 ENCODING_POSITION = {"read_text": 0, "write_text": 1, "Path.open": 2, "open": 3}
 # Distinct from None so that "no mode argument at all" still means text.
@@ -157,7 +176,7 @@ def _import_time_calls(tree: ast.Module):
                     scopes.append(node.body)
 
     _collect(tree.body)
-    consumed = _consumed_genexps(tree)
+    consumed = _eagerly_consumed(tree)
     entered = set()
     frontier = [list(tree.body)]
     while frontier:
@@ -186,26 +205,49 @@ def _import_time_calls(tree: ast.Module):
                 yield node
                 func = node.func
                 if isinstance(func, ast.Name) and func.id in helpers and func.id not in entered:
-                    entered.add(func.id)
-                    body = list(helpers[func.id].body)
-                    _collect(body)  # a def nested in this helper is now callable
-                    frontier.append(body)
+                    helper = helpers[func.id]
+                    # `READS = _load(paths)` on a generator function only builds
+                    # the generator, so its body waits for a consumer just as a
+                    # genexp does.
+                    if not _is_generator(helper) or id(node) in consumed:
+                        entered.add(func.id)
+                        body = list(helper.body)
+                        _collect(body)  # a def nested here is now callable
+                        frontier.append(body)
             stack.extend(ast.iter_child_nodes(node))
 
 
-def _consumed_genexps(tree: ast.Module) -> set:
-    """Generator expressions handed straight to something that drains them.
+def _eagerly_consumed(tree: ast.Module) -> set:
+    """Nodes whose lazy value is drained right where it is written.
 
-    An unconsumed one has not run where it is written, so neither rule should
-    read anything into the calls inside it.
+    Covers both things that defer: a generator expression, and a call to a
+    generator function. Neither runs its body until something pulls from it, so
+    an unconsumed one has not happened yet.
     """
-    return {
-        id(arg)
-        for call in ast.walk(tree)
-        if isinstance(call, ast.Call) and _is_eager_consumer(call.func)
-        for arg in [*call.args, *(k.value for k in call.keywords)]
-        if isinstance(arg, ast.GeneratorExp)
-    }
+    consumed = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and _is_eager_consumer(node.func):
+            consumed.update(id(a) for a in node.args)
+            consumed.update(id(k.value) for k in node.keywords)
+        elif isinstance(node, (ast.For, ast.AsyncFor, ast.comprehension)):
+            consumed.add(id(node.iter))  # the loop pulls every item
+    return consumed
+
+
+def _is_generator(func) -> bool:
+    """True when calling this only builds a generator, leaving the body unrun.
+
+    Yields inside a nested def belong to that def, so those do not count.
+    """
+    stack = list(func.body)
+    while stack:
+        node = stack.pop()
+        if isinstance(node, (ast.Yield, ast.YieldFrom)):
+            return True
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            continue
+        stack.extend(ast.iter_child_nodes(node))
+    return False
 
 
 def _module_level_names(tree: ast.Module) -> set:
@@ -248,14 +290,97 @@ def _path_expr(call: ast.Call):
     return None
 
 
-def _rooted_at_file(node: ast.AST) -> bool:
-    """True for a path built from `__file__`, which is checked in by definition.
+def _path_root(node: ast.AST) -> ast.AST:
+    """Follow a path expression back to whatever it is anchored on.
 
-    `(Path(__file__).parent.parent / "routes" / "inference.py").read_text()` is
-    the same read as through a constant, just spelled inline, and no tmp_path
-    can be written that way.
+    `(_BACKEND / rel).read_text()` anchors on _BACKEND and
+    `Path(__file__).parent / "routes"` on __file__, so joining a relative name
+    onto a checked-in root stays in scope. Anchoring is what decides it, not the
+    names further down: `tmp_path / SUBDIR` anchors on the fixture, so a
+    constant used as a leaf cannot drag temp-dir I/O in.
     """
-    return any(isinstance(n, ast.Name) and n.id == "__file__" for n in ast.walk(node))
+    while True:
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+            node = node.left
+        elif isinstance(node, (ast.Attribute, ast.Subscript)):
+            node = node.value
+        elif isinstance(node, ast.Call):
+            func = node.func
+            # `p.rglob("*.py")` anchors on p, not on the pattern, while
+            # Path(x), str(x) and os.path.join(x, ...) anchor on the argument.
+            if isinstance(func, ast.Attribute) and func.attr in PATH_METHODS:
+                node = func.value
+            elif node.args:
+                node = node.args[0]
+            elif isinstance(func, ast.Attribute):
+                node = func.value
+            else:
+                return node
+        else:
+            return node
+
+
+def _is_checked_in_root(
+    node: ast.AST,
+    module_names: set,
+    shadowed,
+    derived = (),
+) -> bool:
+    """True when a path expression anchors on something that ships in the repo."""
+    root = _path_root(node)
+    if not isinstance(root, ast.Name):
+        return False
+    if root.id in derived:
+        return True
+    return root.id == "__file__" or (root.id in module_names and root.id not in shadowed)
+
+
+def _checked_in_locals(func, module_names: set, shadowed) -> set:
+    """Locals that only ever hold a checked-in path.
+
+    `route = Path(_BACKEND_DIR) / "routes" / "inference.py"` followed by
+    `route.read_text()` is the same read one line apart. A name bound any other
+    way, or assigned anything else anywhere in the scope, is not tracked, and
+    the pass repeats so that a path built up over several locals still counts.
+    """
+    assignments = []
+    targets = set()
+    bad = set()
+    for node in ast.walk(func):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target, value = node.targets[0], node.value
+        elif isinstance(node, (ast.For, ast.AsyncFor, ast.comprehension)):
+            # `for p in SRC_DIR.rglob("*.py")` binds p to a checked-in path too.
+            target, value = node.target, node.iter
+        else:
+            continue
+        if isinstance(target, ast.Name):
+            targets.add(id(target))
+            assignments.append((target.id, value))
+    for node in ast.walk(func):
+        # A with-as or an augassign says nothing about the value it binds.
+        if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
+            if id(node) not in targets:
+                bad.add(node.id)
+    args = func.args
+    bad.update(a.arg for a in [*args.posonlyargs, *args.args, *args.kwonlyargs])
+    good: set = set()
+    while True:
+        grown = {
+            name
+            for name, value in assignments
+            if name not in bad and _is_checked_in_root(value, module_names, shadowed, good)
+        }
+        # A name assigned a checked-in path somewhere and something else
+        # elsewhere stays out, since only one of the two is provable.
+        grown -= {
+            name
+            for name, value in assignments
+            if name in grown and not _is_checked_in_root(value, module_names, shadowed, good)
+        }
+        if grown == good:
+            return good
+        good = grown
 
 
 def _checked_in_path_calls(tree: ast.Module):
@@ -273,29 +398,34 @@ def _checked_in_path_calls(tree: ast.Module):
     the bytes itself.
     """
     module_names = _module_level_names(tree)
-    consumed = _consumed_genexps(tree)
+    consumed = _eagerly_consumed(tree)
 
-    def visit(node, shadowed):
+    def visit(
+        node,
+        shadowed,
+        derived = frozenset(),
+    ):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
             shadowed = shadowed | _local_names(node)
+            derived = _checked_in_locals(node, module_names, shadowed)
         elif _is_main_guard(node):
             # Never runs under pytest, so rule 1 skips it for the same reason.
             for child in node.orelse:
-                yield from visit(child, shadowed)
+                yield from visit(child, shadowed, derived)
             return
         elif isinstance(node, ast.GeneratorExp) and id(node) not in consumed:
             if node.generators:
-                yield from visit(node.generators[0].iter, shadowed)
+                yield from visit(node.generators[0].iter, shadowed, derived)
             return
         elif isinstance(node, ast.Call):
             expr = _path_expr(node)
-            name = expr.id if isinstance(expr, ast.Name) else None
-            if expr is not None and (
-                _rooted_at_file(expr) or (name in module_names and name not in shadowed)
+            root = _path_root(expr) if expr is not None else None
+            if isinstance(root, ast.Name) and (
+                root.id in derived or _is_checked_in_root(root, module_names, shadowed)
             ):
                 yield node
         for child in ast.iter_child_nodes(node):
-            yield from visit(child, shadowed)
+            yield from visit(child, shadowed, derived)
 
     yield from visit(tree, frozenset())
 
@@ -343,15 +473,16 @@ def _names_encoding(call: ast.Call) -> bool:
     return False
 
 
-def _pins_encoding(call: ast.Call, position: int) -> bool:
+def _pins_encoding(call: ast.Call, position: int | None) -> bool:
     """True when the call names an encoding, positionally or by keyword.
 
-    A splat makes the positions meaningless, so it counts as named rather than
-    demanding an edit the contributor cannot make correctly.
+    `position` is None where the API takes it keyword-only. A splat makes the
+    positions meaningless, so it counts as named rather than demanding an edit
+    the contributor cannot make correctly.
     """
     if any(isinstance(a, ast.Starred) for a in call.args):
         return True
-    if len(call.args) > position:
+    if position is not None and len(call.args) > position:
         node = call.args[position]
         if isinstance(node, ast.Constant):
             return node.value not in PLATFORM_DEFAULT_ENCODINGS
@@ -385,6 +516,12 @@ def _offender(call: ast.Call) -> str | None:
                 if not _is_text(call, 1) or _pins_encoding(call, ENCODING_POSITION["open"]):
                     return None
                 return "io.open()"
+            if receiver in COMPRESSED_OPENERS:
+                mode = _open_mode(call, 1)
+                if mode is UNKNOWN_MODE or "t" not in str(mode):
+                    return None  # "rb" default, so binary unless asked otherwise
+                position = COMPRESSED_OPENERS[receiver]
+                return None if _pins_encoding(call, position) else f"{receiver}.open()"
             # Any other `<module>.open(...)` is somebody else's opener:
             # tarfile.open takes a compression mode, fitz.open takes filetype=.
             if receiver in NOT_PATH_RECEIVERS:

--- a/tests/test_source_read_encoding.py
+++ b/tests/test_source_read_encoding.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 
 import ast
 import os
+import subprocess
 from pathlib import Path
 
 TESTS = Path(__file__).resolve().parent
@@ -67,18 +68,46 @@ REPO = TESTS.parent
 SKIP_DIRS = {".git", ".venv", "build", "dist", "frontend", "node_modules", "site-packages"}
 
 
-def _test_roots(repo: Path) -> tuple:
-    """Every checked-in pytest tree, discovered rather than enumerated."""
-    roots = []
-    for dirpath, dirnames, _ in os.walk(repo):
+def _walked_test_files(repo: Path):
+    """Every *.py under a tests directory, found by walking."""
+    found = []
+    for dirpath, dirnames, filenames in os.walk(repo):
         dirnames[:] = sorted(d for d in dirnames if d not in SKIP_DIRS)
-        if os.path.basename(dirpath) == "tests":
-            roots.append(Path(dirpath))
-            dirnames[:] = []  # rglob below already covers everything under it
-    return tuple(roots)
+        if "tests" not in Path(dirpath).relative_to(repo).parts:
+            continue
+        found.extend(Path(dirpath) / f for f in filenames if f.endswith(".py"))
+    return found
 
 
-ROOTS = _test_roots(REPO)
+def _tracked_test_files(repo: Path):
+    """The same, but only what git is actually tracking.
+
+    A walk picks up whatever happens to be lying in the checkout: a scratch
+    directory, a nested worktree, a vendored dependency. None of those are ours
+    to police, and a single syntax error in one would fail this test for
+    everybody who has one. Asking git keeps the promise the docstring makes.
+    """
+    try:
+        listed = subprocess.run(
+            ["git", "-C", str(repo), "ls-files", "-z", "--", "*.py"],
+            capture_output = True,
+            timeout = 60,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if listed.returncode != 0:
+        return None  # not a checkout, so fall back to walking
+    names = listed.stdout.decode("utf-8", errors = "replace").split("\0")
+    return [
+        repo / name
+        for name in names
+        if name and "tests" in Path(name).parts and not SKIP_DIRS.intersection(Path(name).parts)
+    ]
+
+
+SOURCES = _tracked_test_files(REPO)
+if SOURCES is None:
+    SOURCES = _walked_test_files(REPO)
 GUARDED_METHODS = {"read_text", "write_text"}
 # Openers that are somebody else's are recognised by the file's own imports
 # rather than a fixed list, so `import tarfile as tf` and `from PIL import
@@ -284,12 +313,24 @@ def _is_generator(func) -> bool:
 
 def _module_level_names(tree: ast.Module) -> set:
     """Names assigned at module scope."""
+
+    def _bound(target):
+        # `SOURCE, CONFIG = Path(...), Path(...)` binds both.
+        if isinstance(target, ast.Name):
+            yield target.id
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            for element in target.elts:
+                yield from _bound(element)
+        elif isinstance(target, ast.Starred):
+            yield from _bound(target.value)
+
     names = set()
     for node in tree.body:
         if isinstance(node, ast.Assign):
-            names.update(t.id for t in node.targets if isinstance(t, ast.Name))
-        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
-            names.add(node.target.id)
+            for target in node.targets:
+                names.update(_bound(target))
+        elif isinstance(node, ast.AnnAssign):
+            names.update(_bound(node.target))
         elif isinstance(node, (ast.Import, ast.ImportFrom)):
             # `start._CODEX_FALLBACK_PROMPT` is a path another module defines at
             # its own module scope, so the import is an anchor like any constant.
@@ -316,24 +357,55 @@ def _local_names(func) -> set:
     return names
 
 
-def _imported_names(tree: ast.Module) -> dict:
-    """Every name an import binds, mapped to where it came from.
+def _imported_names(node) -> dict:
+    """Names this scope's own imports bind, mapped to where they came from.
 
     The name alone is not enough in either direction. `import gzip as gz` binds
     a name nobody would recognise to an opener that does take an encoding, and
     `from PIL.Image import open` binds a name everybody recognises to one that
     does not. Keeping the origin settles both.
+
+    Nested function bodies are left out: an import inside one is that
+    function's business, and treating it as the module's would let a single
+    local `from PIL.Image import open` turn off the builtin check everywhere.
     """
     bound = {}
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
+    stack = list(ast.iter_child_nodes(node))
+    while stack:
+        item = stack.pop()
+        if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            continue
+        if isinstance(item, ast.Import):
+            for alias in item.names:
                 bound[(alias.asname or alias.name).split(".")[0]] = alias.name
-        elif isinstance(node, ast.ImportFrom):
-            for alias in node.names:
-                origin = f"{node.module}.{alias.name}" if node.module else alias.name
+        elif isinstance(item, ast.ImportFrom):
+            for alias in item.names:
+                origin = f"{item.module}.{alias.name}" if item.module else alias.name
                 bound[alias.asname or alias.name] = origin
+        else:
+            stack.extend(ast.iter_child_nodes(item))
     return bound
+
+
+def _imports_at_each_call(tree: ast.Module) -> dict:
+    """The imports visible at every call, keyed by node id.
+
+    A function's own imports are added on the way in and go out of view again
+    on the way out, which is what keeps a local alias local.
+    """
+    visible_at = {}
+
+    def walk(node, visible):
+        if isinstance(node, ast.Call):
+            visible_at[id(node)] = visible
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+                walk(child, {**visible, **_imported_names(child)})
+            else:
+                walk(child, visible)
+
+    walk(tree, _imported_names(tree))
+    return visible_at
 
 
 def _origin_root(name, modules) -> str:
@@ -605,7 +677,11 @@ def _checked_in_params(tree: ast.Module, module_names: set) -> set:
         good = grown
 
 
-def _checked_in_path_calls(tree: ast.Module, modules = NO_MODULES):
+def _checked_in_path_calls(
+    tree: ast.Module,
+    modules = NO_MODULES,
+    visible_at = None,
+):
     """Yield calls, at any depth, whose path is provably a checked-in file.
 
     The import-time walk alone leaves test bodies unguarded, and a bare read
@@ -621,6 +697,7 @@ def _checked_in_path_calls(tree: ast.Module, modules = NO_MODULES):
     """
     module_names = _module_level_names(tree)
     consumed = _eagerly_consumed(tree)
+    visible_at = _imports_at_each_call(tree) if visible_at is None else visible_at
     params = _checked_in_params(tree, module_names)
 
     def visit(
@@ -644,7 +721,7 @@ def _checked_in_path_calls(tree: ast.Module, modules = NO_MODULES):
                 yield from visit(node.generators[0].iter, shadowed, derived)
             return
         elif isinstance(node, ast.Call):
-            expr = _path_expr(node, modules)
+            expr = _path_expr(node, visible_at.get(id(node), modules))
             if expr is not None and _is_checked_in_root(expr, module_names, shadowed, derived):
                 yield node
         for child in ast.iter_child_nodes(node):
@@ -776,20 +853,20 @@ def _offender(call: ast.Call, modules = NO_MODULES) -> str | None:
 def _scan(tree: ast.Module, rel: str):
     """Offenders from both rules, reported once each and in source order."""
     modules = _imported_names(tree)
+    visible_at = _imports_at_each_call(tree)
     calls = {id(c): c for c in _import_time_calls(tree)}
-    calls.update({id(c): c for c in _checked_in_path_calls(tree, modules)})
+    calls.update({id(c): c for c in _checked_in_path_calls(tree, modules, visible_at)})
     for call in sorted(calls.values(), key = lambda c: (c.lineno, c.col_offset)):
-        name = _offender(call, modules)
+        name = _offender(call, visible_at.get(id(call), modules))
         if name is not None:
             yield f"{rel}:{call.lineno}: {name}"
 
 
 def test_checked_in_file_reads_name_an_encoding():
     offenders = []
-    for root in ROOTS:
-        for path in sorted(root.rglob("*.py")):
-            tree = ast.parse(path.read_text(encoding = "utf-8"), filename = str(path))
-            offenders.extend(_scan(tree, path.relative_to(REPO).as_posix()))
+    for path in sorted(SOURCES):
+        tree = ast.parse(path.read_text(encoding = "utf-8"), filename = str(path))
+        offenders.extend(_scan(tree, path.relative_to(REPO).as_posix()))
     assert offenders == [], (
         f"{len(offenders)} file reads in the test trees touch a checked-in file "
         "with the platform default encoding, so they break on Windows as soon "

--- a/tests/test_source_read_encoding.py
+++ b/tests/test_source_read_encoding.py
@@ -44,9 +44,7 @@ def _is_main_guard(node: ast.AST) -> bool:
     left = node.test.left
     if not (isinstance(left, ast.Name) and left.id == "__name__"):
         return False
-    return any(
-        isinstance(c, ast.Constant) and c.value == "__main__" for c in node.test.comparators
-    )
+    return any(isinstance(c, ast.Constant) and c.value == "__main__" for c in node.test.comparators)
 
 
 def _import_time_calls(tree: ast.Module):

--- a/tests/test_source_read_encoding.py
+++ b/tests/test_source_read_encoding.py
@@ -3,22 +3,21 @@
 
 """Guard: tests that read checked-in files must name their encoding.
 
-`Path.read_text()` and `open()` with no encoding use
-`locale.getpreferredencoding()`, which is UTF-8 on the Linux runners and cp1252
-on a stock Windows install. A test that reads a repo file that way passes in CI
-and raises UnicodeDecodeError for a Windows contributor the moment that file
-gains a non-ASCII byte, which the source-scanning tests do constantly:
+`Path.read_text()` and `open()` with no encoding use `locale.getencoding()`:
+UTF-8 on the Linux and macOS runners, cp1252 on a stock Windows install. A test
+that reads a repo file that way passes in CI and raises UnicodeDecodeError for a
+Windows contributor as soon as that file gains a non-ASCII byte, which the
+source-scanning tests do constantly:
 
     studio/backend/routes/inference.py carries the DeepSeek tool-call token
-    regexes, so it contains U+FF5C and U+2581. Reading it with cp1252 died on
-    "byte 0x81 in position 97806", taking test_cancel_atomicity.py and
-    test_cancel_id_wiring.py out at collection time.
+    regexes, so it holds U+FF5C and U+2581. Reading it as cp1252 dies on
+    "byte 0x81", taking test_cancel_atomicity.py and test_cancel_id_wiring.py
+    out at collection time.
 
 Nothing that runs at import can see a tmp_path fixture, so a bare read there is
 always touching a checked-in file. That makes the rule mechanical enough to
-enforce with no allowlist, and it stays quiet about temp-dir I/O inside test
-bodies where the platform default is harmless. The repo already spells this
-correctly in 464 other places; this only stops the stragglers coming back.
+enforce with no allowlist, while staying quiet about temp-dir I/O inside test
+bodies where the platform default is harmless.
 """
 
 # `str | None` below is evaluated at import on Python 3.9 without this, and
@@ -30,19 +29,43 @@ from pathlib import Path
 
 TESTS = Path(__file__).resolve().parent
 REPO = TESTS.parent
-# tests/ and studio/backend/tests/ are collected by separate CI jobs
-# (repo-cpu-tests and studio-backend-ci) and both collect on Windows, so the
-# rule has to cover both trees.
+# Both trees ship to Windows contributors, and separate CI jobs collect them
+# (repo-cpu-tests and the studio-backend matrix), so the rule covers both.
 ROOTS = (TESTS, REPO / "studio" / "backend" / "tests")
 GUARDED_METHODS = {"read_text", "write_text"}
+NOT_PATH_RECEIVERS = {
+    "bz2",
+    "codecs",
+    "dbm",
+    "fitz",
+    "gzip",
+    "io",
+    "lzma",
+    "os",
+    "pymupdf",
+    "shelve",
+    "sqlite3",
+    "tarfile",
+    "wave",
+    "webbrowser",
+    "zipfile",
+}
+# Distinct from None so that "no mode argument at all" still means text.
+UNKNOWN_MODE = object()
 
 
 def _is_main_guard(node: ast.AST) -> bool:
-    """True for `if __name__ == "__main__":`, whose body never runs at import."""
+    """True for `if __name__ == "__main__":`, whose body never runs at import.
+
+    The operator has to be `==`: `if __name__ != "__main__":` runs its body at
+    import, so treating it as script-only would invert the rule.
+    """
     if not isinstance(node, ast.If) or not isinstance(node.test, ast.Compare):
         return False
     left = node.test.left
     if not (isinstance(left, ast.Name) and left.id == "__name__"):
+        return False
+    if not all(isinstance(op, ast.Eq) for op in node.test.ops):
         return False
     return any(isinstance(c, ast.Constant) and c.value == "__main__" for c in node.test.comparators)
 
@@ -50,18 +73,22 @@ def _is_main_guard(node: ast.AST) -> bool:
 def _import_time_calls(tree: ast.Module):
     """Yield Call nodes that run at import time.
 
-    That is module scope, class bodies (which execute on definition), and the
-    bodies of module-level helpers invoked from either. A helper is the same
-    hazard as an inline read: `CODE = _extract_mixed_precision_code()` runs its
-    `read_text()` during collection, so skipping every def would let the
-    Windows failure back in unreported.
+    That is module scope, class bodies, and the bodies of module-level helpers
+    invoked from either. A helper is the same hazard as an inline read:
+    `CODE = _extract_mixed_precision_code()` runs its `read_text()` during
+    collection, so skipping every def would let the Windows failure back in.
 
-    Bodies are only ever entered through an executed statement, never by
-    walking into a def, so the "this definitely runs" property that makes the
-    rule allowlist-free is preserved. Two things are deliberately not followed:
-    `if __name__ == "__main__":` blocks, which pytest never executes, and
-    non-name calls (attribute, dynamic), which aren't resolved rather than
-    guessed at.
+    A def's body waits for a call, but its decorators and argument defaults run
+    when the def executes, so those are followed. Lambda bodies and
+    comprehension elements do not run at definition and are skipped, which
+    keeps the rule free of false positives.
+
+    A body is only ever entered through an executed statement, never by walking
+    into a def, so the "this definitely runs" property that makes the rule
+    allowlist-free holds. Not followed: the body of
+    `if __name__ == "__main__":`, which pytest never runs (its `else` arm does,
+    so that is walked), and non-name calls, which are left unresolved rather
+    than guessed at.
     """
     helpers = {
         node.name: node
@@ -74,9 +101,23 @@ def _import_time_calls(tree: ast.Module):
         stack = frontier.pop()
         while stack:
             node = stack.pop()
-            # A def is only reached by calling it, handled below; a __main__
-            # block is script-only.
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) or _is_main_guard(node):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                # The body waits for a call; these two run right now.
+                stack.extend(node.decorator_list)
+                stack.extend(d for d in node.args.defaults if d is not None)
+                stack.extend(d for d in node.args.kw_defaults if d is not None)
+                continue
+            if isinstance(node, ast.Lambda):
+                stack.extend(d for d in node.args.defaults if d is not None)
+                stack.extend(d for d in node.args.kw_defaults if d is not None)
+                continue
+            if isinstance(node, (ast.GeneratorExp, ast.ListComp, ast.SetComp, ast.DictComp)):
+                # Only the outermost iterable is evaluated where it is written.
+                if node.generators:
+                    stack.append(node.generators[0].iter)
+                continue
+            if _is_main_guard(node):
+                stack.extend(node.orelse)  # the else arm runs at import
                 continue
             if isinstance(node, ast.Call):
                 yield node
@@ -87,26 +128,72 @@ def _import_time_calls(tree: ast.Module):
             stack.extend(ast.iter_child_nodes(node))
 
 
-def _open_mode(call: ast.Call) -> str:
-    """The mode string of an open() call, defaulting to text read."""
-    if len(call.args) > 1 and isinstance(call.args[1], ast.Constant):
-        return str(call.args[1].value)
+def _open_mode(call: ast.Call, mode_index: int):
+    """The literal mode of an open() call, or UNKNOWN_MODE.
+
+    A splat or a non-literal hides the mode. Defaulting those to "r" would
+    demand an encoding on a call that may resolve to "rb", where passing one is
+    a ValueError, so the contributor would have no compliant edit.
+    """
+    if any(isinstance(a, ast.Starred) for a in call.args):
+        return UNKNOWN_MODE
+    if any(kw.arg is None for kw in call.keywords):
+        return UNKNOWN_MODE
+    if len(call.args) > mode_index:
+        node = call.args[mode_index]
+        return node.value if isinstance(node, ast.Constant) else UNKNOWN_MODE
     for kw in call.keywords:
-        if kw.arg == "mode" and isinstance(kw.value, ast.Constant):
-            return str(kw.value.value)
+        if kw.arg == "mode":
+            return kw.value.value if isinstance(kw.value, ast.Constant) else UNKNOWN_MODE
     return "r"
+
+
+def _is_text(call: ast.Call, mode_index: int) -> bool:
+    mode = _open_mode(call, mode_index)
+    return mode is not UNKNOWN_MODE and "b" not in str(mode)
+
+
+def _names_encoding(call: ast.Call) -> bool:
+    """True only for an encoding that actually pins one.
+
+    `encoding = None` and `encoding = "locale"` both re-select the platform
+    default, so the keyword being present is not enough. A `**kwargs` may carry
+    one we cannot see, so it counts as named rather than risking a false alarm.
+    """
+    for kw in call.keywords:
+        if kw.arg is None:
+            return True
+        if kw.arg != "encoding":
+            continue
+        if isinstance(kw.value, ast.Constant) and kw.value.value in (None, "locale"):
+            return False
+        return True
+    return False
 
 
 def _offender(call: ast.Call) -> str | None:
     """The call's name if it reads text without an encoding, else None."""
-    if any(kw.arg == "encoding" for kw in call.keywords):
-        return None
     func = call.func
-    if isinstance(func, ast.Attribute) and func.attr in GUARDED_METHODS:
-        return f"{func.attr}()"
+    if isinstance(func, ast.Attribute):
+        if func.attr in GUARDED_METHODS:
+            # importlib.metadata's Distribution.read_text takes a positional
+            # filename and has no encoding parameter, so a positional argument
+            # means the receiver is not a Path.
+            if func.attr == "read_text" and call.args:
+                return None
+            return None if _names_encoding(call) else f"{func.attr}()"
+        if func.attr == "open":
+            # `<module>.open(...)` is somebody else's opener: tarfile.open takes
+            # a compression mode, fitz.open takes filetype=.
+            if isinstance(func.value, ast.Name) and func.value.id in NOT_PATH_RECEIVERS:
+                return None
+            if not _is_text(call, 0):
+                return None
+            return None if _names_encoding(call) else "Path.open()"
+        return None
     # Binary handles have no encoding to name.
-    if isinstance(func, ast.Name) and func.id == "open" and "b" not in _open_mode(call):
-        return "open()"
+    if isinstance(func, ast.Name) and func.id == "open" and _is_text(call, 1):
+        return None if _names_encoding(call) else "open()"
     return None
 
 

--- a/tests/test_source_read_encoding.py
+++ b/tests/test_source_read_encoding.py
@@ -37,14 +37,17 @@ the call sites of the helper it sits in, which keeps them mechanical enough to
 enforce with no allowlist and quiet about temp-dir I/O, where the platform
 default is harmless and the test wrote the bytes itself.
 
-Two shapes are consequently out of reach, both fixed by hand and neither
-decidable without tracking values through returns. A path a helper hands back
-rather than takes in, as `for path in _iter_caller_files()` does in
-test_security_gate_consistency.py, says nothing about itself at the read. And
-text read from a checked-in file then written back to a tmp_path, as at
-test_studio_install_workspace_guard.py:851 and test_scan_packages.py:40, is
-unsafe only because of where the string came from. Reviewers have to catch
-those two.
+Three shapes are consequently out of reach, all fixed by hand and none decidable
+from the call. A path a helper hands back rather than takes in, as
+`for path in _iter_caller_files()` does in test_security_gate_consistency.py,
+says nothing about itself at the read. Text read from a checked-in file and
+then written back to a tmp_path, at test_studio_install_workspace_guard.py:851
+and test_scan_packages.py:40, is unsafe only because of where the string came
+from. And a read inside a `python -c` snippet, as test_studio_import_no_torch.py
+builds for eight subprocess tests, runs in a child interpreter this scan never
+parses: the snippet is an f-string whose paths are replacement fields, so
+recovering it would mean evaluating the interpolation. Reviewers have to catch
+those three.
 """
 
 # `str | None` below is evaluated at import on Python 3.9 without this, and
@@ -77,19 +80,9 @@ def _test_roots(repo: Path) -> tuple:
 
 ROOTS = _test_roots(REPO)
 GUARDED_METHODS = {"read_text", "write_text"}
-NOT_PATH_RECEIVERS = {
-    "codecs",
-    "dbm",
-    "fitz",
-    "os",
-    "pymupdf",
-    "shelve",
-    "sqlite3",
-    "tarfile",
-    "wave",
-    "webbrowser",
-    "zipfile",
-}
+# Openers that are somebody else's are recognised by the file's own imports
+# rather than a fixed list, so `import tarfile as tf` and `from PIL import
+# Image` are both covered without naming either.
 # These wrap their stream in a TextIOWrapper for a "t" mode, which takes the
 # platform default exactly like builtin open. Unlike open they default to "rb",
 # so only an explicit text mode is in scope. lzma takes encoding keyword-only.
@@ -127,8 +120,6 @@ PATH_METHODS = {
     "with_name",
     "with_suffix",
 }
-# Receivers that are not themselves a path, so the path is the first argument.
-MODULE_RECEIVERS = set(NOT_PATH_RECEIVERS) | set(COMPRESSED_OPENERS) | PATH_CLASSES | {"io"}
 # Where each API takes its encoding positionally, for the bound call.
 ENCODING_POSITION = {"read_text": 0, "write_text": 1, "Path.open": 2, "open": 3}
 # Distinct from None so that "no mode argument at all" still means text.
@@ -308,7 +299,27 @@ def _local_names(func) -> set:
     return names
 
 
-def _path_expr(call: ast.Call):
+def _imported_names(tree: ast.Module) -> set:
+    """Every name an import binds anywhere in the file.
+
+    A receiver bound that way is a module, so `Image.open(...)` after
+    `from PIL import Image` and `tf.open(...)` after `import tarfile as tf` are
+    both somebody else's opener. Reading the imports instead of keeping a list
+    of module names is what makes aliases and unfamiliar libraries work.
+    """
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            names.update((a.asname or a.name).split(".")[0] for a in node.names)
+    return names
+
+
+def _is_module_receiver(name, modules) -> bool:
+    """True for a receiver that is not itself a path."""
+    return name in modules or name in PATH_CLASSES or name in COMPRESSED_OPENERS or name == "io"
+
+
+def _path_expr(call: ast.Call, modules = frozenset()):
     """The expression naming the file the call reads.
 
     Usually the receiver, but a module or the Path class in that slot means the
@@ -317,7 +328,7 @@ def _path_expr(call: ast.Call):
     """
     func = call.func
     if isinstance(func, ast.Attribute):
-        if isinstance(func.value, ast.Name) and func.value.id in MODULE_RECEIVERS:
+        if isinstance(func.value, ast.Name) and _is_module_receiver(func.value.id, modules):
             return call.args[0] if call.args else None
         return func.value
     if isinstance(func, ast.Name) and func.id == "open":
@@ -371,7 +382,13 @@ def _is_checked_in_root(
         # `for path in (MODEL_SELECTOR, APP_SIDEBAR)` is checked in when every
         # element is, which is what makes the loop variable one too.
         return bool(node.elts) and all(
-            _is_checked_in_root(e, module_names, shadowed, derived) for e in node.elts
+            _is_checked_in_root(
+                e.value if isinstance(e, ast.Starred) else e,
+                module_names,
+                shadowed,
+                derived,
+            )
+            for e in node.elts
         )
     root = _path_root(node)
     if isinstance(root, ast.Constant) and isinstance(root.value, str):
@@ -518,7 +535,7 @@ def _checked_in_params(tree: ast.Module, module_names: set) -> set:
         good = grown
 
 
-def _checked_in_path_calls(tree: ast.Module):
+def _checked_in_path_calls(tree: ast.Module, modules = frozenset()):
     """Yield calls, at any depth, whose path is provably a checked-in file.
 
     The import-time walk alone leaves test bodies unguarded, and a bare read
@@ -556,7 +573,7 @@ def _checked_in_path_calls(tree: ast.Module):
                 yield from visit(node.generators[0].iter, shadowed, derived)
             return
         elif isinstance(node, ast.Call):
-            expr = _path_expr(node)
+            expr = _path_expr(node, modules)
             if expr is not None and _is_checked_in_root(expr, module_names, shadowed, derived):
                 yield node
         for child in ast.iter_child_nodes(node):
@@ -625,7 +642,7 @@ def _pins_encoding(call: ast.Call, position: int | None) -> bool:
     return _names_encoding(call)
 
 
-def _offender(call: ast.Call) -> str | None:
+def _offender(call: ast.Call, modules = frozenset()) -> str | None:
     """The call's name if it reads text without an encoding, else None."""
     func = call.func
     if isinstance(func, ast.Attribute):
@@ -657,9 +674,10 @@ def _offender(call: ast.Call) -> str | None:
                     return None  # "rb" default, so binary unless asked otherwise
                 position = COMPRESSED_OPENERS[receiver]
                 return None if _pins_encoding(call, position) else f"{receiver}.open()"
-            # Any other `<module>.open(...)` is somebody else's opener:
-            # tarfile.open takes a compression mode, fitz.open takes filetype=.
-            if receiver in NOT_PATH_RECEIVERS:
+            # Any other module receiver is somebody else's opener: tarfile.open
+            # takes a compression mode, Image.open takes a binary file. Neither
+            # has an encoding to name, so demanding one leaves no correct edit.
+            if receiver is not None and receiver in modules and receiver not in PATH_CLASSES:
                 return None
             if not _is_text(call, shift):
                 return None
@@ -677,10 +695,11 @@ def _offender(call: ast.Call) -> str | None:
 
 def _scan(tree: ast.Module, rel: str):
     """Offenders from both rules, reported once each and in source order."""
+    modules = _imported_names(tree)
     calls = {id(c): c for c in _import_time_calls(tree)}
-    calls.update({id(c): c for c in _checked_in_path_calls(tree)})
+    calls.update({id(c): c for c in _checked_in_path_calls(tree, modules)})
     for call in sorted(calls.values(), key = lambda c: (c.lineno, c.col_offset)):
-        name = _offender(call)
+        name = _offender(call, modules)
         if name is not None:
             yield f"{rel}:{call.lineno}: {name}"
 

--- a/tests/test_source_read_encoding.py
+++ b/tests/test_source_read_encoding.py
@@ -382,6 +382,22 @@ def _eagerly_consumed(tree: ast.Module) -> set:
     return consumed
 
 
+def _temp_rooted_names(tree: ast.Module) -> set:
+    """Module-level names anchored on a directory the run itself created."""
+    names = set()
+    for node in tree.body:
+        value = node.value if isinstance(node, (ast.Assign, ast.AnnAssign)) else None
+        if value is None:
+            continue
+        if any(
+            isinstance(n, ast.Call) and _callee_name(n.func) in TEMP_FACTORIES
+            for n in ast.walk(value)
+        ):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            names.update(t.id for t in targets if isinstance(t, ast.Name))
+    return names
+
+
 def _non_path_names(tree: ast.Module) -> set:
     """Module-level names bound to a call that plainly does not make a path.
 
@@ -533,6 +549,18 @@ def _imports_at_each_call(tree: ast.Module) -> dict:
         if isinstance(node, (ast.Import, ast.ImportFrom)):
             visible.update(_import_bindings(node))
             return
+        if isinstance(node, ast.If):
+            # Only a branch that certainly runs may bind a name for the code
+            # after it; the others are explored with a copy that is thrown away.
+            taken = _static_truth(node.test)
+            walk(node.test, visible)
+            for arm, runs in ((node.body, taken is not False), (node.orelse, taken is not True)):
+                if not runs:
+                    continue
+                inner = visible if taken is not None else dict(visible)
+                for child in arm:
+                    walk(child, inner)
+            return
         for child in ast.iter_child_nodes(node):
             if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
                 walk(child, dict(visible))  # its own scope, so its own copy
@@ -585,6 +613,11 @@ def _is_path_class(name, modules) -> bool:
     return (modules.get(name) or name).split(".")[-1] in PATH_CLASSES
 
 
+def _is_path_attr(node: ast.AST) -> bool:
+    """True for a qualified path class, as in `pathlib.Path` or `pl.Path`."""
+    return isinstance(node, ast.Attribute) and node.attr in PATH_CLASSES
+
+
 def _is_path_preserving(func) -> bool:
     """True for a call whose result still points at its first argument.
 
@@ -614,7 +647,9 @@ def _path_expr(call: ast.Call, modules = NO_MODULES):
     """
     func = call.func
     if isinstance(func, ast.Attribute):
-        if isinstance(func.value, ast.Name) and _is_module_receiver(func.value.id, modules):
+        if _is_path_attr(func.value) or (
+            isinstance(func.value, ast.Name) and _is_module_receiver(func.value.id, modules)
+        ):
             return call.args[0] if call.args else _path_keyword(call)
         return func.value
     if isinstance(func, ast.Name) and _open_alias(func.id, modules) is not None:
@@ -1115,8 +1150,9 @@ def _offender(call: ast.Call, modules = NO_MODULES) -> str | None:
     func = call.func
     if isinstance(func, ast.Attribute):
         receiver = func.value.id if isinstance(func.value, ast.Name) else None
-        # An unbound `Path.read_text(p)` puts the instance in slot 0.
-        shift = 1 if _is_path_class(receiver, modules) else 0
+        # An unbound `Path.read_text(p)` puts the instance in slot 0, and
+        # `pathlib.Path.read_text(p)` is the same call fully qualified.
+        shift = 1 if _is_path_class(receiver, modules) or _is_path_attr(func.value) else 0
         if func.attr in GUARDED_METHODS:
             if func.attr == "read_text" and not shift and call.args:
                 first = call.args[0]
@@ -1184,15 +1220,20 @@ def _scan(tree: ast.Module, rel: str):
     calls = {id(c): c for c in _import_time_calls(tree)}
     calls.update({id(c): c for c in _checked_in_path_calls(tree, modules, visible_at)})
     not_paths = _non_path_names(tree)
+    temp_roots = _temp_rooted_names(tree)
     for call in sorted(calls.values(), key = lambda c: (c.lineno, c.col_offset)):
         func = call.func
         if (
             isinstance(func, ast.Attribute)
-            and func.attr in GUARDED_METHODS
+            and (func.attr in GUARDED_METHODS or func.attr == "open")
             and isinstance(func.value, ast.Name)
             and func.value.id in not_paths
         ):
-            continue
+            continue  # ZipFile.open and friends have no encoding to name
+        expr = _path_expr(call, visible_at.get(id(call), modules))
+        root = _path_root(expr) if expr is not None else None
+        if isinstance(root, ast.Name) and root.id in temp_roots:
+            continue  # the run made this file, so the platform default is safe
         name = _offender(call, visible_at.get(id(call), modules))
         if name is not None:
             yield f"{rel}:{call.lineno}: {name}"

--- a/tests/test_source_read_encoding.py
+++ b/tests/test_source_read_encoding.py
@@ -139,6 +139,24 @@ PLATFORM_DEFAULT_ENCODINGS = (None, "locale")
 # platform default, but the instance takes the first slot so every argument
 # shifts one place right.
 PATH_CLASSES = {"Path", "PosixPath", "PurePath", "WindowsPath"}
+# Modules whose `open` IS the builtin: same signature, same platform default.
+BUILTIN_OPEN_MODULES = {"builtins", "io"}
+# Receivers `self.SOURCE` and `cls.SOURCE` reach a class attribute through.
+SELF_NAMES = {"cls", "self"}
+# Functions that hand back a path still pointing at their first argument. An
+# unlisted call is left unresolved: a helper may well return a temp copy of what
+# it was given, and following it would put test-created files back in scope.
+PATH_FUNCTIONS = {
+    "abspath",
+    "dirname",
+    "expanduser",
+    "fspath",
+    "join",
+    "normpath",
+    "realpath",
+    "relpath",
+    "str",
+}
 # Path methods that hand back another path, so the receiver is still the anchor.
 PATH_METHODS = {
     "absolute",
@@ -160,6 +178,39 @@ UNKNOWN_MODE = object()
 # Stand-in for a file whose imports are not to hand, so every helper can be
 # called on its own without pretending it knows what was imported.
 NO_MODULES: dict = {}
+
+
+def _static_truth(node: ast.AST):
+    """Whether a condition is a literal true or false, else None for "depends"."""
+    return bool(node.value) if isinstance(node, ast.Constant) else None
+
+
+def _live_branches(node: ast.AST):
+    """The children of a branch that can actually run, or None if it is not one.
+
+    `if False:` and the right of `False and ...` never execute, so reporting a
+    read there is a CI failure with no reachable cause and no correct edit.
+    """
+    if isinstance(node, ast.If):
+        taken = _static_truth(node.test)
+        if taken is None:
+            return None
+        return [node.test, *(node.body if taken else node.orelse)]
+    if isinstance(node, ast.IfExp):
+        taken = _static_truth(node.test)
+        if taken is None:
+            return None
+        return [node.test, node.body if taken else node.orelse]
+    if isinstance(node, ast.BoolOp) and node.values:
+        # `and` stops at the first false operand, `or` at the first true one.
+        stops = isinstance(node.op, ast.Or)
+        live = []
+        for value in node.values:
+            live.append(value)
+            if _static_truth(value) is stops:
+                break
+        return live if len(live) < len(node.values) else None
+    return None
 
 
 def _is_main_guard(node: ast.AST) -> bool:
@@ -251,6 +302,10 @@ def _import_time_calls(tree: ast.Module):
                 continue
             if _is_main_guard(node):
                 stack.extend(node.orelse)  # the else arm runs at import
+                continue
+            live = _live_branches(node)
+            if live is not None:
+                stack.extend(live)  # the dead arm never runs, so nothing in it does
                 continue
             if isinstance(node, ast.Call):
                 yield node
@@ -353,11 +408,22 @@ def _local_names(func) -> set:
     for extra in (args.vararg, args.kwarg):
         if extra is not None:
             names.add(extra.arg)
-    for node in ast.walk(func):
+    stack = list(ast.iter_child_nodes(func))
+    while stack:
+        node = stack.pop()
+        if isinstance(node, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
+            # A comprehension target binds in its own scope, so it shadows
+            # nothing out here; the rest of the comprehension still does.
+            for gen in node.generators:
+                stack.append(gen.iter)
+                stack.extend(gen.ifs)
+            stack.extend([node.key, node.value] if isinstance(node, ast.DictComp) else [node.elt])
+            continue
         if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
             names.add(node.id)
         elif isinstance(node, (ast.Import, ast.ImportFrom)):
             names.update((a.asname or a.name).split(".")[0] for a in node.names)
+        stack.extend(ast.iter_child_nodes(node))
     return names
 
 
@@ -425,7 +491,7 @@ def _open_alias(name, modules):
     parts = origin.split(".")
     if parts[-1] != "open":
         return None
-    if parts[0] == "io" or origin == "open":
+    if parts[0] in BUILTIN_OPEN_MODULES or origin == "open":
         return "builtin"
     return parts[0] if parts[0] in COMPRESSED_OPENERS else None
 
@@ -443,13 +509,31 @@ def _compressed_key(name, modules):
     return None
 
 
+def _is_path_class(name, modules) -> bool:
+    """True for a pathlib class, including under an alias.
+
+    `from pathlib import Path as P` still puts the instance in slot 0 of an
+    unbound `P.read_text(SOURCE)`, so matching the bare name is not enough.
+    """
+    if name is None:
+        return False
+    return (modules.get(name) or name).split(".")[-1] in PATH_CLASSES
+
+
+def _is_path_preserving(func) -> bool:
+    """True for a call whose result still points at its first argument."""
+    if isinstance(func, ast.Name):
+        return func.id in PATH_CLASSES or func.id in PATH_FUNCTIONS
+    return isinstance(func, ast.Attribute) and func.attr in PATH_FUNCTIONS
+
+
 def _is_module_receiver(name, modules) -> bool:
     """True for a receiver that is not itself a path."""
     return (
         name in modules
-        or name in PATH_CLASSES
+        or _is_path_class(name, modules)
         or _compressed_key(name, modules) is not None
-        or _origin_root(name, modules) == "io"
+        or _origin_root(name, modules) in BUILTIN_OPEN_MODULES
     )
 
 
@@ -463,15 +547,18 @@ def _path_expr(call: ast.Call, modules = NO_MODULES):
     func = call.func
     if isinstance(func, ast.Attribute):
         if isinstance(func.value, ast.Name) and _is_module_receiver(func.value.id, modules):
-            return call.args[0] if call.args else None
+            return call.args[0] if call.args else _path_keyword(call)
         return func.value
     if isinstance(func, ast.Name) and _open_alias(func.id, modules) is not None:
-        if call.args:
-            return call.args[0]
-        # open(file = CHECKED_IN) is the same call spelled out.
-        for kw in call.keywords:
-            if kw.arg == "file":
-                return kw.value
+        return call.args[0] if call.args else _path_keyword(call)
+    return None
+
+
+def _path_keyword(call: ast.Call):
+    """The path passed by keyword: `file` for open, `filename` for gzip and kin."""
+    for kw in call.keywords:
+        if kw.arg in ("file", "filename"):
+            return kw.value
     return None
 
 
@@ -488,6 +575,12 @@ def _path_root(node: ast.AST) -> ast.AST:
         if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
             node = node.left
         elif isinstance(node, (ast.Attribute, ast.Subscript)):
+            if (
+                isinstance(node, ast.Attribute)
+                and isinstance(node.value, ast.Name)
+                and node.value.id in SELF_NAMES
+            ):
+                return node  # self.SOURCE names the class attribute, not self
             node = node.value
         elif isinstance(node, ast.Call):
             func = node.func
@@ -495,11 +588,12 @@ def _path_root(node: ast.AST) -> ast.AST:
             # Path(x), str(x) and os.path.join(x, ...) anchor on the argument.
             if isinstance(func, ast.Attribute) and func.attr in PATH_METHODS:
                 node = func.value
-            elif node.args:
+            elif _is_path_preserving(func) and node.args:
                 node = node.args[0]
             else:
-                # An unrecognised no-argument method says nothing about where
-                # its result points, so tempfile.mkdtemp() stops here.
+                # An unrecognised call says nothing about where its result
+                # points, so tempfile.mkdtemp() and a helper that copies its
+                # argument into a temp dir both stop here.
                 return node
         else:
             return node
@@ -510,6 +604,7 @@ def _is_checked_in_root(
     module_names: set,
     shadowed,
     derived = (),
+    attrs = (),
 ) -> bool:
     """True when a path expression anchors on something that ships in the repo."""
     if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
@@ -521,6 +616,7 @@ def _is_checked_in_root(
                 module_names,
                 shadowed,
                 derived,
+                attrs,
             )
             for e in node.elts
         )
@@ -535,11 +631,40 @@ def _is_checked_in_root(
             return (REPO / value).exists()
         except OSError:
             return False  # too long to be a name, so not one
+    if isinstance(root, ast.Attribute):
+        # `self.SOURCE`, where the class body bound SOURCE to a checked-in path.
+        return root.attr in attrs
     if not isinstance(root, ast.Name):
         return False
     if root.id in derived:
         return True
     return root.id == "__file__" or (root.id in module_names and root.id not in shadowed)
+
+
+def _class_path_attrs(tree: ast.Module, module_names: set) -> set:
+    """Class-body names bound to a checked-in path, read back as `self.NAME`.
+
+    `class T: _SETUP_SH = ROOT / "setup.sh"` then `self._SETUP_SH.read_text()`
+    is as statically provable as the module-level spelling, and the repository
+    reads seven real source files exactly that way.
+    """
+    attrs, mixed = set(), set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for stmt in node.body:
+            if isinstance(stmt, ast.Assign):
+                targets = stmt.targets
+            elif isinstance(stmt, ast.AnnAssign) and stmt.value is not None:
+                targets = [stmt.target]
+            else:
+                continue
+            bound = {t.id for t in targets if isinstance(t, ast.Name)}
+            # One attribute name, two classes, two meanings: only one of them is
+            # provable, so neither is claimed. Same rule as the local walk.
+            found = attrs if _is_checked_in_root(stmt.value, module_names, ()) else mixed
+            found.update(bound)
+    return attrs - mixed
 
 
 def _reads_itself(name: str, value: ast.AST) -> bool:
@@ -668,12 +793,37 @@ def _checked_in_params(tree: ast.Module, module_names: set) -> set:
     `_source` is reading a file that ships in the repo; the bare
     `path.read_text()` inside it cannot say so on its own. One hop only, and a
     parameter any call leaves out, or passes anything else, is not tracked.
+
+    Definitions are held by identity, not by name. Two tests that each nest a
+    `_read` helper are two different functions, and merging them would let the
+    one handed a tmp_path rule out what the other proves.
     """
-    funcs = {
-        node.name: node
-        for node in ast.walk(tree)
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-    }
+    # Every definition, plus which scope it was written in, so a call resolves
+    # to the nearest enclosing `def` of that name the way Python resolves it.
+    scope_of: dict = {}
+    defs_in: dict = {}
+
+    def _index(node, scope):
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                defs_in.setdefault(id(scope), {}).setdefault(child.name, child)
+                scope_of[id(child)] = scope
+                _index(child, child)
+            elif isinstance(child, ast.ClassDef):
+                _index(child, scope)  # a class body is not a name lookup scope
+            else:
+                _index(child, scope)
+
+    _index(tree, tree)
+
+    def _lookup(name, scope):
+        while scope is not None:
+            found = defs_in.get(id(scope), {}).get(name)
+            if found is not None:
+                return found
+            scope = scope_of.get(id(scope))
+        return None
+
     # Which function each call sits in, so a parameter already known to hold a
     # checked-in path can be passed on to the next helper.
     owner: dict = {}
@@ -689,26 +839,26 @@ def _checked_in_params(tree: ast.Module, module_names: set) -> set:
     good: set = set()
     while True:
         grown, bad = set(), set()
-        for fname, fnode in funcs.items():
+        for fnode in [d for scope in defs_in.values() for d in scope.values()]:
             for argname, values in _parametrized_values(fnode).items():
                 ok = all(_is_checked_in_root(v, module_names, ()) for v in values)
-                (grown if ok else bad).add((fname, argname))
+                (grown if ok else bad).add((id(fnode), argname))
         # What the calling function itself can prove, recomputed each pass so a
         # parameter resolved last time can feed a local this time.
         scope: dict = {}
         for call in ast.walk(tree):
             if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Name):
                 continue
-            func = funcs.get(call.func.id)
+            caller = owner.get(id(call))
+            func = _lookup(call.func.id, caller if caller is not None else tree)
             if func is None or any(isinstance(a, ast.Starred) for a in call.args):
                 continue
-            caller = owner.get(id(call))
             if caller is None:
                 here = set()
             elif id(caller) in scope:
                 here = scope[id(caller)]
             else:
-                params = {p for f, p in good if f == caller.name}
+                params = {p for f, p in good if f == id(caller)}
                 here = _checked_in_locals(caller, module_names, _local_names(caller), params)
                 scope[id(caller)] = here
             positional = [a.arg for a in [*func.args.posonlyargs, *func.args.args]]
@@ -720,7 +870,7 @@ def _checked_in_params(tree: ast.Module, module_names: set) -> set:
             for param in params:
                 value = supplied.get(param)
                 ok = value is not None and _is_checked_in_root(value, module_names, (), here)
-                (grown if ok else bad).add((func.name, param))
+                (grown if ok else bad).add((id(func), param))
         grown -= bad
         if grown == good:
             return good
@@ -749,6 +899,7 @@ def _checked_in_path_calls(
     consumed = _eagerly_consumed(tree)
     visible_at = _imports_at_each_call(tree) if visible_at is None else visible_at
     params = _checked_in_params(tree, module_names)
+    attrs = _class_path_attrs(tree, module_names)
 
     def visit(
         node,
@@ -759,7 +910,7 @@ def _checked_in_path_calls(
             shadowed = shadowed | _local_names(node)
             # Seed with the parameters first: `p = root / "x.py"` is only
             # derivable once `root` is known to hold a checked-in path.
-            seeded = {p for f, p in params if f == getattr(node, "name", None)}
+            seeded = {p for f, p in params if f == id(node)}
             derived = _checked_in_locals(node, module_names, shadowed, seeded)
         elif _is_main_guard(node):
             # Never runs under pytest, so rule 1 skips it for the same reason.
@@ -770,9 +921,15 @@ def _checked_in_path_calls(
             if node.generators:
                 yield from visit(node.generators[0].iter, shadowed, derived)
             return
+        elif (live := _live_branches(node)) is not None:
+            for child in live:
+                yield from visit(child, shadowed, derived)
+            return
         elif isinstance(node, ast.Call):
             expr = _path_expr(node, visible_at.get(id(node), modules))
-            if expr is not None and _is_checked_in_root(expr, module_names, shadowed, derived):
+            if expr is not None and _is_checked_in_root(
+                expr, module_names, shadowed, derived, attrs
+            ):
                 yield node
         for child in ast.iter_child_nodes(node):
             yield from visit(child, shadowed, derived)
@@ -846,7 +1003,7 @@ def _offender(call: ast.Call, modules = NO_MODULES) -> str | None:
     if isinstance(func, ast.Attribute):
         receiver = func.value.id if isinstance(func.value, ast.Name) else None
         # An unbound `Path.read_text(p)` puts the instance in slot 0.
-        shift = 1 if receiver in PATH_CLASSES else 0
+        shift = 1 if _is_path_class(receiver, modules) else 0
         if func.attr in GUARDED_METHODS:
             if func.attr == "read_text" and not shift and call.args:
                 first = call.args[0]
@@ -860,12 +1017,12 @@ def _offender(call: ast.Call, modules = NO_MODULES) -> str | None:
             position = ENCODING_POSITION[func.attr] + shift
             return None if _pins_encoding(call, position) else f"{func.attr}()"
         if func.attr == "open":
-            # io.open IS the builtin, so it takes the builtin's argument
-            # positions and carries the same platform default.
-            if receiver is not None and _origin_root(receiver, modules) == "io":
+            # io.open and builtins.open ARE the builtin, so they take the
+            # builtin's argument positions and the same platform default.
+            if receiver is not None and _origin_root(receiver, modules) in BUILTIN_OPEN_MODULES:
                 if not _is_text(call, 1) or _pins_encoding(call, ENCODING_POSITION["open"]):
                     return None
-                return "io.open()"
+                return f"{receiver}.open()"
             compressed = _compressed_key(receiver, modules) if receiver else None
             if compressed is not None:
                 mode = _open_mode(call, 1)
@@ -879,7 +1036,11 @@ def _offender(call: ast.Call, modules = NO_MODULES) -> str | None:
             # Any other module receiver is somebody else's opener: tarfile.open
             # takes a compression mode, Image.open takes a binary file. Neither
             # has an encoding to name, so demanding one leaves no correct edit.
-            if receiver is not None and receiver in modules and receiver not in PATH_CLASSES:
+            if (
+                receiver is not None
+                and receiver in modules
+                and not _is_path_class(receiver, modules)
+            ):
                 return None
             if not _is_text(call, shift):
                 return None

--- a/tests/test_source_read_encoding.py
+++ b/tests/test_source_read_encoding.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Guard: tests that read checked-in files must name their encoding.
+
+`Path.read_text()` and `open()` with no encoding use
+`locale.getpreferredencoding()`, which is UTF-8 on the Linux runners and cp1252
+on a stock Windows install. A test that reads a repo file that way passes in CI
+and raises UnicodeDecodeError for a Windows contributor the moment that file
+gains a non-ASCII byte, which the source-scanning tests do constantly:
+
+    studio/backend/routes/inference.py carries the DeepSeek tool-call token
+    regexes, so it contains U+FF5C and U+2581. Reading it with cp1252 died on
+    "byte 0x81 in position 97806", taking test_cancel_atomicity.py and
+    test_cancel_id_wiring.py out at collection time.
+
+At module scope there is no tmp_path fixture, so a bare read here is always
+touching a checked-in file. That makes the rule mechanical enough to enforce
+with no allowlist, and it stays quiet about temp-dir I/O inside test bodies
+where the platform default is harmless. The repo already spells this correctly
+in 464 other places; this only stops the stragglers coming back.
+"""
+
+import ast
+from pathlib import Path
+
+TESTS = Path(__file__).resolve().parent
+GUARDED_METHODS = {"read_text", "write_text"}
+
+
+def _module_level_calls(tree: ast.Module):
+    """Yield Call nodes reachable without entering a def or class body."""
+    stack = list(tree.body)
+    while stack:
+        node = stack.pop()
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        if isinstance(node, ast.Call):
+            yield node
+        stack.extend(ast.iter_child_nodes(node))
+
+
+def _open_mode(call: ast.Call) -> str:
+    """The mode string of an open() call, defaulting to text read."""
+    if len(call.args) > 1 and isinstance(call.args[1], ast.Constant):
+        return str(call.args[1].value)
+    for kw in call.keywords:
+        if kw.arg == "mode" and isinstance(kw.value, ast.Constant):
+            return str(kw.value.value)
+    return "r"
+
+
+def _offender(call: ast.Call) -> str | None:
+    """The call's name if it reads text without an encoding, else None."""
+    if any(kw.arg == "encoding" for kw in call.keywords):
+        return None
+    func = call.func
+    if isinstance(func, ast.Attribute) and func.attr in GUARDED_METHODS:
+        return f"{func.attr}()"
+    # Binary handles have no encoding to name.
+    if isinstance(func, ast.Name) and func.id == "open" and "b" not in _open_mode(call):
+        return "open()"
+    return None
+
+
+def test_module_level_file_reads_name_an_encoding():
+    offenders = []
+    for path in sorted(TESTS.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding = "utf-8"), filename = str(path))
+        for call in _module_level_calls(tree):
+            name = _offender(call)
+            if name is None:
+                continue
+            rel = path.relative_to(TESTS).as_posix()
+            offenders.append(f"tests/{rel}:{call.lineno}: {name}")
+    assert offenders == [], (
+        "Module-level file reads in tests/ touch a checked-in file with the "
+        "platform default encoding, so they break on Windows as soon as that "
+        'file gains a non-ASCII byte. Pass encoding = "utf-8": '
+        f"{offenders[:10]}"
+    )

--- a/tests/test_source_read_encoding.py
+++ b/tests/test_source_read_encoding.py
@@ -14,30 +14,79 @@ gains a non-ASCII byte, which the source-scanning tests do constantly:
     "byte 0x81 in position 97806", taking test_cancel_atomicity.py and
     test_cancel_id_wiring.py out at collection time.
 
-At module scope there is no tmp_path fixture, so a bare read here is always
-touching a checked-in file. That makes the rule mechanical enough to enforce
-with no allowlist, and it stays quiet about temp-dir I/O inside test bodies
-where the platform default is harmless. The repo already spells this correctly
-in 464 other places; this only stops the stragglers coming back.
+Nothing that runs at import can see a tmp_path fixture, so a bare read there is
+always touching a checked-in file. That makes the rule mechanical enough to
+enforce with no allowlist, and it stays quiet about temp-dir I/O inside test
+bodies where the platform default is harmless. The repo already spells this
+correctly in 464 other places; this only stops the stragglers coming back.
 """
+
+# `str | None` below is evaluated at import on Python 3.9 without this, and
+# pyproject declares requires-python = ">=3.9,<3.15".
+from __future__ import annotations
 
 import ast
 from pathlib import Path
 
 TESTS = Path(__file__).resolve().parent
+REPO = TESTS.parent
+# tests/ and studio/backend/tests/ are collected by separate CI jobs
+# (repo-cpu-tests and studio-backend-ci) and both collect on Windows, so the
+# rule has to cover both trees.
+ROOTS = (TESTS, REPO / "studio" / "backend" / "tests")
 GUARDED_METHODS = {"read_text", "write_text"}
 
 
-def _module_level_calls(tree: ast.Module):
-    """Yield Call nodes reachable without entering a def or class body."""
-    stack = list(tree.body)
-    while stack:
-        node = stack.pop()
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-            continue
-        if isinstance(node, ast.Call):
-            yield node
-        stack.extend(ast.iter_child_nodes(node))
+def _is_main_guard(node: ast.AST) -> bool:
+    """True for `if __name__ == "__main__":`, whose body never runs at import."""
+    if not isinstance(node, ast.If) or not isinstance(node.test, ast.Compare):
+        return False
+    left = node.test.left
+    if not (isinstance(left, ast.Name) and left.id == "__name__"):
+        return False
+    return any(
+        isinstance(c, ast.Constant) and c.value == "__main__" for c in node.test.comparators
+    )
+
+
+def _import_time_calls(tree: ast.Module):
+    """Yield Call nodes that run at import time.
+
+    That is module scope, class bodies (which execute on definition), and the
+    bodies of module-level helpers invoked from either. A helper is the same
+    hazard as an inline read: `CODE = _extract_mixed_precision_code()` runs its
+    `read_text()` during collection, so skipping every def would let the
+    Windows failure back in unreported.
+
+    Bodies are only ever entered through an executed statement, never by
+    walking into a def, so the "this definitely runs" property that makes the
+    rule allowlist-free is preserved. Two things are deliberately not followed:
+    `if __name__ == "__main__":` blocks, which pytest never executes, and
+    non-name calls (attribute, dynamic), which aren't resolved rather than
+    guessed at.
+    """
+    helpers = {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    entered = set()
+    frontier = [list(tree.body)]
+    while frontier:
+        stack = frontier.pop()
+        while stack:
+            node = stack.pop()
+            # A def is only reached by calling it, handled below; a __main__
+            # block is script-only.
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) or _is_main_guard(node):
+                continue
+            if isinstance(node, ast.Call):
+                yield node
+                func = node.func
+                if isinstance(func, ast.Name) and func.id in helpers and func.id not in entered:
+                    entered.add(func.id)
+                    frontier.append(list(helpers[func.id].body))
+            stack.extend(ast.iter_child_nodes(node))
 
 
 def _open_mode(call: ast.Call) -> str:
@@ -65,17 +114,18 @@ def _offender(call: ast.Call) -> str | None:
 
 def test_module_level_file_reads_name_an_encoding():
     offenders = []
-    for path in sorted(TESTS.rglob("*.py")):
-        tree = ast.parse(path.read_text(encoding = "utf-8"), filename = str(path))
-        for call in _module_level_calls(tree):
-            name = _offender(call)
-            if name is None:
-                continue
-            rel = path.relative_to(TESTS).as_posix()
-            offenders.append(f"tests/{rel}:{call.lineno}: {name}")
+    for root in ROOTS:
+        for path in sorted(root.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding = "utf-8"), filename = str(path))
+            for call in _import_time_calls(tree):
+                name = _offender(call)
+                if name is None:
+                    continue
+                rel = path.relative_to(REPO).as_posix()
+                offenders.append(f"{rel}:{call.lineno}: {name}")
     assert offenders == [], (
-        "Module-level file reads in tests/ touch a checked-in file with the "
-        "platform default encoding, so they break on Windows as soon as that "
-        'file gains a non-ASCII byte. Pass encoding = "utf-8": '
+        "Import-time file reads in the test trees touch a checked-in file with "
+        "the platform default encoding, so they break on Windows as soon as "
+        'that file gains a non-ASCII byte. Pass encoding = "utf-8": '
         f"{offenders[:10]}"
     )

--- a/tests/test_source_read_encoding.py
+++ b/tests/test_source_read_encoding.py
@@ -118,6 +118,8 @@ GUARDED_METHODS = {"read_text", "write_text"}
 # platform default exactly like builtin open. Unlike open they default to "rb",
 # so only an explicit text mode is in scope. lzma takes encoding keyword-only.
 COMPRESSED_OPENERS = {"bz2": 3, "gzip": 3, "lzma": None}
+# Wrappers that stay lazy, so draining one drains what it was given.
+LAZY_ADAPTERS = {"enumerate", "filter", "islice", "map", "reversed", "zip"}
 # Callables that drain a generator argument immediately.
 EAGER_CONSUMERS = {
     "all",
@@ -143,6 +145,16 @@ PATH_CLASSES = {"Path", "PosixPath", "PurePath", "WindowsPath"}
 BUILTIN_OPEN_MODULES = {"builtins", "io"}
 # Receivers `self.SOURCE` and `cls.SOURCE` reach a class attribute through.
 SELF_NAMES = {"cls", "self"}
+# A module-level name is normally an anchor, since a fixture cannot reach one.
+# These build a directory the run owns, so a name rooted in one is temp I/O
+# however it is spelled, and the platform default there is harmless.
+TEMP_FACTORIES = {
+    "NamedTemporaryFile",
+    "TemporaryDirectory",
+    "gettempdir",
+    "mkdtemp",
+    "mkstemp",
+}
 # Functions that hand back a path still pointing at their first argument. An
 # unlisted call is left unresolved: a helper may well return a temp copy of what
 # it was given, and following it would put test-created files back in scope.
@@ -211,6 +223,11 @@ def _live_branches(node: ast.AST):
                 break
         return live if len(live) < len(node.values) else None
     return None
+
+
+def _callee_name(func: ast.AST):
+    """The bare name a callee ends in, whether or not it is qualified."""
+    return func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
 
 
 def _is_main_guard(node: ast.AST) -> bool:
@@ -351,7 +368,35 @@ def _eagerly_consumed(tree: ast.Module) -> set:
             consumed.update(id(_resolve(k.value)) for k in node.keywords)
         elif isinstance(node, (ast.For, ast.AsyncFor, ast.comprehension)):
             consumed.add(id(_resolve(node.iter)))  # the loop pulls every item
+    # `list(enumerate(_paths()))` drains _paths() as well, one wrapper down.
+    by_id = {id(n): n for n in ast.walk(tree)}
+    queue = [by_id[i] for i in list(consumed) if i in by_id]
+    while queue:
+        node = queue.pop()
+        if isinstance(node, ast.Call) and _callee_name(node.func) in LAZY_ADAPTERS:
+            for arg in node.args:
+                target = _resolve(arg)
+                if id(target) not in consumed:
+                    consumed.add(id(target))
+                    queue.append(target)
     return consumed
+
+
+def _non_path_names(tree: ast.Module) -> set:
+    """Module-level names bound to a call that plainly does not make a path.
+
+    `response = requests.get(...)` then `response.read_text()` at import is not
+    pathlib I/O, and demanding an encoding there leaves no compliant edit.
+    """
+    names = set()
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
+            continue
+        func = node.value.func
+        if _is_path_preserving(func) or _callee_name(func) in PATH_METHODS:
+            continue
+        names.update(t.id for t in node.targets if isinstance(t, ast.Name))
+    return names
 
 
 def _is_generator(func) -> bool:
@@ -383,12 +428,22 @@ def _module_level_names(tree: ast.Module) -> set:
         elif isinstance(target, ast.Starred):
             yield from _bound(target.value)
 
+    def _is_temp(value) -> bool:
+        return value is not None and any(
+            isinstance(n, ast.Call) and _callee_name(n.func) in TEMP_FACTORIES
+            for n in ast.walk(value)
+        )
+
     names = set()
     for node in tree.body:
         if isinstance(node, ast.Assign):
+            if _is_temp(node.value):
+                continue  # TMP = Path(tempfile.mkdtemp()) is not checked in
             for target in node.targets:
                 names.update(_bound(target))
         elif isinstance(node, ast.AnnAssign):
+            if _is_temp(node.value):
+                continue
             names.update(_bound(node.target))
         elif isinstance(node, (ast.Import, ast.ImportFrom)):
             # `start._CODEX_FALLBACK_PROMPT` is a path another module defines at
@@ -445,36 +500,46 @@ def _imported_names(node) -> dict:
         item = stack.pop()
         if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
             continue
-        if isinstance(item, ast.Import):
-            for alias in item.names:
-                bound[(alias.asname or alias.name).split(".")[0]] = alias.name
-        elif isinstance(item, ast.ImportFrom):
-            for alias in item.names:
-                origin = f"{item.module}.{alias.name}" if item.module else alias.name
-                bound[alias.asname or alias.name] = origin
+        if isinstance(item, (ast.Import, ast.ImportFrom)):
+            bound.update(_import_bindings(item))
         else:
             stack.extend(ast.iter_child_nodes(item))
     return bound
+
+
+def _import_bindings(node) -> dict:
+    """What one import statement binds, mapped to where each name came from."""
+    if isinstance(node, ast.Import):
+        return {(a.asname or a.name).split(".")[0]: a.name for a in node.names}
+    return {
+        a.asname or a.name: (f"{node.module}.{a.name}" if node.module else a.name)
+        for a in node.names
+    }
 
 
 def _imports_at_each_call(tree: ast.Module) -> dict:
     """The imports visible at every call, keyed by node id.
 
     A function's own imports are added on the way in and go out of view again
-    on the way out, which is what keeps a local alias local.
+    on the way out, which is what keeps a local alias local. Within a scope they
+    accumulate in statement order, so `DATA = open(p)` above a later
+    `from gzip import open` still resolves to the builtin it actually called.
     """
     visible_at = {}
 
     def walk(node, visible):
         if isinstance(node, ast.Call):
-            visible_at[id(node)] = visible
+            visible_at[id(node)] = dict(visible)
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            visible.update(_import_bindings(node))
+            return
         for child in ast.iter_child_nodes(node):
             if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
-                walk(child, {**visible, **_imported_names(child)})
+                walk(child, dict(visible))  # its own scope, so its own copy
             else:
                 walk(child, visible)
 
-    walk(tree, _imported_names(tree))
+    walk(tree, {})
     return visible_at
 
 
@@ -521,10 +586,13 @@ def _is_path_class(name, modules) -> bool:
 
 
 def _is_path_preserving(func) -> bool:
-    """True for a call whose result still points at its first argument."""
-    if isinstance(func, ast.Name):
-        return func.id in PATH_CLASSES or func.id in PATH_FUNCTIONS
-    return isinstance(func, ast.Attribute) and func.attr in PATH_FUNCTIONS
+    """True for a call whose result still points at its first argument.
+
+    Qualified spellings count: `pathlib.Path(p)` and `os.path.join(p, x)` are
+    the same constructors as the bare names.
+    """
+    name = _callee_name(func)
+    return name in PATH_CLASSES or name in PATH_FUNCTIONS
 
 
 def _is_module_receiver(name, modules) -> bool:
@@ -760,6 +828,18 @@ def _checked_in_locals(
         good = grown
 
 
+def _unwrap_param(node: ast.AST) -> ast.AST:
+    """`pytest.param(SOURCE, id = "x")` is a wrapper around the real value."""
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "param"
+        and node.args
+    ):
+        return node.args[0]
+    return node
+
+
 def _parametrized_values(func) -> dict:
     """Parameter values supplied by @pytest.mark.parametrize.
 
@@ -782,7 +862,7 @@ def _parametrized_values(func) -> dict:
             paired = len(argnames) > 1 and isinstance(element, (ast.Tuple, ast.List))
             row = element.elts if paired else [element]
             for argname, value in zip(argnames, row):
-                supplied.setdefault(argname, []).append(value)
+                supplied.setdefault(argname, []).append(_unwrap_param(value))
     return supplied
 
 
@@ -836,6 +916,26 @@ def _checked_in_params(tree: ast.Module, module_names: set) -> set:
             _mark(child, child if nested else owning)
 
     _mark(tree, None)
+    # Which class body each call sits in, so `self._read(...)` resolves to that
+    # class's method and not a same-named one in a sibling class.
+    in_class: dict = {}
+
+    def _mark_class(node, cls):
+        if isinstance(node, ast.Call):
+            in_class[id(node)] = cls
+        for child in ast.iter_child_nodes(node):
+            _mark_class(child, child if isinstance(child, ast.ClassDef) else cls)
+
+    _mark_class(tree, None)
+
+    def _method(cls, name):
+        if cls is None:
+            return None
+        for stmt in cls.body:
+            if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)) and stmt.name == name:
+                return stmt
+        return None
+
     good: set = set()
     while True:
         grown, bad = set(), set()
@@ -847,10 +947,21 @@ def _checked_in_params(tree: ast.Module, module_names: set) -> set:
         # parameter resolved last time can feed a local this time.
         scope: dict = {}
         for call in ast.walk(tree):
-            if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Name):
+            if not isinstance(call, ast.Call):
                 continue
             caller = owner.get(id(call))
-            func = _lookup(call.func.id, caller if caller is not None else tree)
+            callee, bound = call.func, False
+            if isinstance(callee, ast.Name):
+                func = _lookup(callee.id, caller if caller is not None else tree)
+            elif (
+                isinstance(callee, ast.Attribute)
+                and isinstance(callee.value, ast.Name)
+                and callee.value.id in SELF_NAMES
+            ):
+                # `self._read(ROOT / "x.py")` seeds `_read`'s path parameter too.
+                func, bound = _method(in_class.get(id(call)), callee.attr), True
+            else:
+                continue
             if func is None or any(isinstance(a, ast.Starred) for a in call.args):
                 continue
             if caller is None:
@@ -862,6 +973,8 @@ def _checked_in_params(tree: ast.Module, module_names: set) -> set:
                 here = _checked_in_locals(caller, module_names, _local_names(caller), params)
                 scope[id(caller)] = here
             positional = [a.arg for a in [*func.args.posonlyargs, *func.args.args]]
+            if bound:
+                positional = positional[1:]  # the receiver already fills `self`
             # A keyword-only parameter never takes a positional slot, so it is
             # matched by name alone.
             params = positional + [a.arg for a in func.args.kwonlyargs]
@@ -1070,7 +1183,16 @@ def _scan(tree: ast.Module, rel: str):
     visible_at = _imports_at_each_call(tree)
     calls = {id(c): c for c in _import_time_calls(tree)}
     calls.update({id(c): c for c in _checked_in_path_calls(tree, modules, visible_at)})
+    not_paths = _non_path_names(tree)
     for call in sorted(calls.values(), key = lambda c: (c.lineno, c.col_offset)):
+        func = call.func
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr in GUARDED_METHODS
+            and isinstance(func.value, ast.Name)
+            and func.value.id in not_paths
+        ):
+            continue
         name = _offender(call, visible_at.get(id(call), modules))
         if name is not None:
             yield f"{rel}:{call.lineno}: {name}"

--- a/tests/test_source_read_encoding.py
+++ b/tests/test_source_read_encoding.py
@@ -16,12 +16,15 @@ source-scanning tests do constantly:
 
 A call is an offence when it does un-pinned text I/O and either of two things
 holds. It runs at import, where nothing can see a tmp_path fixture yet. Or the
-path it reads anchors on something checked in: a module-level constant, which a
-fixture parameter can never be, or `__file__`. Anchoring is what decides the
-second one, followed through `/` joins, path methods, and the locals and loop
-variables of the enclosing function, so `for p in (_B / "routes").rglob("*.py")`
-is in scope and anything growing out of a tmp_path is not. That rule reaches
-test bodies, where the same failure lands one step later:
+path it reads anchors on something checked in: a module-level constant or
+import, which a fixture parameter can never be, or `__file__`. Anchoring is
+what decides the second one, followed through `/` joins, path methods, the
+locals and loop variables of the enclosing function, and the parameters of
+helpers every caller hands a checked-in path. So
+`for p in (_B / "routes").rglob("*.py")` is in scope, `_source(LOADER_PATH)`
+puts the bare read inside `_source` in scope, and anything growing out of a
+tmp_path stays out. That reaches test bodies, where the same failure lands one
+step later:
 
     test_gemma4_chat_template.py opens unsloth/chat_templates.py through a
     helper its tests call, and cp1252 cannot decode that file ("byte 0x90").
@@ -29,17 +32,19 @@ test bodies, where the same failure lands one step later:
     test_gguf_load_cache_reuse.py as `Path(__file__).parent.parent / ...`, both
     dying on the same 0x81 the two cancel modules hit at collection.
 
-Every question the rules ask is answered inside one function, which keeps them
-mechanical enough to enforce with no allowlist and quiet about temp-dir I/O,
-where the platform default is harmless and the test wrote the bytes itself.
+Every question the rules ask is answered by the call, its path expression, or
+the call sites of the helper it sits in, which keeps them mechanical enough to
+enforce with no allowlist and quiet about temp-dir I/O, where the platform
+default is harmless and the test wrote the bytes itself.
 
 Two shapes are consequently out of reach, both fixed by hand and neither
-detectable without whole-program dataflow. A path that arrives from another
-function, as `for path in _iter_caller_files()` does in
+decidable without tracking values through returns. A path a helper hands back
+rather than takes in, as `for path in _iter_caller_files()` does in
 test_security_gate_consistency.py, says nothing about itself at the read. And
 text read from a checked-in file then written back to a tmp_path, as at
-test_studio_install_workspace_guard.py:851, is unsafe only because of where the
-string came from. Reviewers have to catch those two.
+test_studio_install_workspace_guard.py:851 and test_scan_packages.py:40, is
+unsafe only because of where the string came from. Reviewers have to catch
+those two.
 """
 
 # `str | None` below is evaluated at import on Python 3.9 without this, and
@@ -53,7 +58,7 @@ TESTS = Path(__file__).resolve().parent
 REPO = TESTS.parent
 # Both trees ship to Windows contributors, and separate CI jobs collect them
 # (repo-cpu-tests and the studio-backend matrix), so the rule covers both.
-ROOTS = (TESTS, REPO / "studio" / "backend" / "tests")
+ROOTS = (TESTS, REPO / "studio" / "backend" / "tests", REPO / "unsloth_cli" / "tests")
 GUARDED_METHODS = {"read_text", "write_text"}
 NOT_PATH_RECEIVERS = {
     "codecs",
@@ -105,6 +110,8 @@ PATH_METHODS = {
     "with_name",
     "with_suffix",
 }
+# Receivers that are not themselves a path, so the path is the first argument.
+MODULE_RECEIVERS = set(NOT_PATH_RECEIVERS) | set(COMPRESSED_OPENERS) | PATH_CLASSES | {"io"}
 # Where each API takes its encoding positionally, for the bound call.
 ENCODING_POSITION = {"read_text": 0, "write_text": 1, "Path.open": 2, "open": 3}
 # Distinct from None so that "no mode argument at all" still means text.
@@ -258,6 +265,10 @@ def _module_level_names(tree: ast.Module) -> set:
             names.update(t.id for t in node.targets if isinstance(t, ast.Name))
         elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
             names.add(node.target.id)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            # `start._CODEX_FALLBACK_PROMPT` is a path another module defines at
+            # its own module scope, so the import is an anchor like any constant.
+            names.update((a.asname or a.name).split(".")[0] for a in node.names)
     return names
 
 
@@ -281,9 +292,16 @@ def _local_names(func) -> set:
 
 
 def _path_expr(call: ast.Call):
-    """The expression the call reads from."""
+    """The expression naming the file the call reads.
+
+    Usually the receiver, but a module or the Path class in that slot means the
+    path is the first argument instead: `Path.read_text(REPO / "x.py")` and
+    `gzip.open(path, "rt")` both read their argument, not `Path` or `gzip`.
+    """
     func = call.func
     if isinstance(func, ast.Attribute):
+        if isinstance(func.value, ast.Name) and func.value.id in MODULE_RECEIVERS:
+            return call.args[0] if call.args else None
         return func.value
     if isinstance(func, ast.Name) and func.id == "open" and call.args:
         return call.args[0]
@@ -312,9 +330,9 @@ def _path_root(node: ast.AST) -> ast.AST:
                 node = func.value
             elif node.args:
                 node = node.args[0]
-            elif isinstance(func, ast.Attribute):
-                node = func.value
             else:
+                # An unrecognised no-argument method says nothing about where
+                # its result points, so tempfile.mkdtemp() stops here.
                 return node
         else:
             return node
@@ -383,6 +401,53 @@ def _checked_in_locals(func, module_names: set, shadowed) -> set:
         good = grown
 
 
+def _checked_in_params(tree: ast.Module, module_names: set) -> set:
+    """(function, parameter) pairs that only ever receive a checked-in path.
+
+    `_source(LOADER_PATH)` is what tells us that the `path` parameter of
+    `_source` is reading a file that ships in the repo; the bare
+    `path.read_text()` inside it cannot say so on its own. One hop only, and a
+    parameter any call leaves out, or passes anything else, is not tracked.
+    """
+    funcs = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    # Which function each call sits in, so a parameter already known to hold a
+    # checked-in path can be passed on to the next helper.
+    owner: dict = {}
+
+    def _mark(node, name):
+        if isinstance(node, ast.Call):
+            owner[id(node)] = name
+        for child in ast.iter_child_nodes(node):
+            _mark(child, child.name if isinstance(child, ast.FunctionDef) else name)
+
+    _mark(tree, None)
+    good: set = set()
+    while True:
+        grown, bad = set(), set()
+        for call in ast.walk(tree):
+            if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Name):
+                continue
+            func = funcs.get(call.func.id)
+            if func is None or any(isinstance(a, ast.Starred) for a in call.args):
+                continue
+            here = {p for f, p in good if f == owner.get(id(call))}
+            params = [a.arg for a in [*func.args.posonlyargs, *func.args.args]]
+            supplied = dict(zip(params, call.args))
+            supplied.update({k.arg: k.value for k in call.keywords if k.arg in params})
+            for param in params:
+                value = supplied.get(param)
+                ok = value is not None and _is_checked_in_root(value, module_names, (), here)
+                (grown if ok else bad).add((func.name, param))
+        grown -= bad
+        if grown == good:
+            return good
+        good = grown
+
+
 def _checked_in_path_calls(tree: ast.Module):
     """Yield calls, at any depth, whose path is provably a checked-in file.
 
@@ -399,6 +464,7 @@ def _checked_in_path_calls(tree: ast.Module):
     """
     module_names = _module_level_names(tree)
     consumed = _eagerly_consumed(tree)
+    params = _checked_in_params(tree, module_names)
 
     def visit(
         node,
@@ -408,6 +474,8 @@ def _checked_in_path_calls(tree: ast.Module):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
             shadowed = shadowed | _local_names(node)
             derived = _checked_in_locals(node, module_names, shadowed)
+            name = getattr(node, "name", None)
+            derived = derived | {p for f, p in params if f == name}
         elif _is_main_guard(node):
             # Never runs under pytest, so rule 1 skips it for the same reason.
             for child in node.orelse:

--- a/tests/test_source_read_encoding.py
+++ b/tests/test_source_read_encoding.py
@@ -17,14 +17,14 @@ source-scanning tests do constantly:
 A call is an offence when it does un-pinned text I/O and either of two things
 holds. It runs at import, where nothing can see a tmp_path fixture yet. Or the
 path it reads anchors on something checked in: a module-level constant or
-import, which a fixture parameter can never be, or `__file__`. Anchoring is
-what decides the second one, followed through `/` joins, path methods, the
-locals and loop variables of the enclosing function, and the parameters of
-helpers every caller hands a checked-in path. So
-`for p in (_B / "routes").rglob("*.py")` is in scope, `_source(LOADER_PATH)`
-puts the bare read inside `_source` in scope, and anything growing out of a
-tmp_path stays out. That reaches test bodies, where the same failure lands one
-step later:
+import, which a fixture parameter can never be, `__file__`, or a relative
+literal that names a file actually present in the tree. Anchoring is what
+decides the second one, followed through `/` joins, path methods, the locals
+and loop variables of the enclosing function, and the parameters of helpers
+every caller hands a checked-in path. So `for p in (_B / "routes").rglob("*.py")`
+is in scope, `_source(LOADER_PATH)` puts the bare read inside `_source` in
+scope, and anything growing out of a tmp_path stays out. That reaches test
+bodies, where the same failure lands one step later:
 
     test_gemma4_chat_template.py opens unsloth/chat_templates.py through a
     helper its tests call, and cp1252 cannot decode that file ("byte 0x90").
@@ -52,13 +52,30 @@ those two.
 from __future__ import annotations
 
 import ast
+import os
 from pathlib import Path
 
 TESTS = Path(__file__).resolve().parent
 REPO = TESTS.parent
 # Both trees ship to Windows contributors, and separate CI jobs collect them
 # (repo-cpu-tests and the studio-backend matrix), so the rule covers both.
-ROOTS = (TESTS, REPO / "studio" / "backend" / "tests", REPO / "unsloth_cli" / "tests")
+# Not a hand-written list: studio/backend/hub/tests and unsloth/kernels/moe/tests
+# are already here, and the next one has to be covered the day it lands.
+SKIP_DIRS = {".git", ".venv", "build", "dist", "frontend", "node_modules", "site-packages"}
+
+
+def _test_roots(repo: Path) -> tuple:
+    """Every checked-in pytest tree, discovered rather than enumerated."""
+    roots = []
+    for dirpath, dirnames, _ in os.walk(repo):
+        dirnames[:] = sorted(d for d in dirnames if d not in SKIP_DIRS)
+        if os.path.basename(dirpath) == "tests":
+            roots.append(Path(dirpath))
+            dirnames[:] = []  # rglob below already covers everything under it
+    return tuple(roots)
+
+
+ROOTS = _test_roots(REPO)
 GUARDED_METHODS = {"read_text", "write_text"}
 NOT_PATH_RECEIVERS = {
     "codecs",
@@ -303,8 +320,13 @@ def _path_expr(call: ast.Call):
         if isinstance(func.value, ast.Name) and func.value.id in MODULE_RECEIVERS:
             return call.args[0] if call.args else None
         return func.value
-    if isinstance(func, ast.Name) and func.id == "open" and call.args:
-        return call.args[0]
+    if isinstance(func, ast.Name) and func.id == "open":
+        if call.args:
+            return call.args[0]
+        # open(file = CHECKED_IN) is the same call spelled out.
+        for kw in call.keywords:
+            if kw.arg == "file":
+                return kw.value
     return None
 
 
@@ -345,7 +367,23 @@ def _is_checked_in_root(
     derived = (),
 ) -> bool:
     """True when a path expression anchors on something that ships in the repo."""
+    if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+        # `for path in (MODEL_SELECTOR, APP_SIDEBAR)` is checked in when every
+        # element is, which is what makes the loop variable one too.
+        return bool(node.elts) and all(
+            _is_checked_in_root(e, module_names, shadowed, derived) for e in node.elts
+        )
     root = _path_root(node)
+    if isinstance(root, ast.Constant) and isinstance(root.value, str):
+        # A relative literal naming something that exists here is checked in; a
+        # path the test creates at runtime is not in the tree to be found.
+        value = root.value
+        if not value or "\n" in value or "\0" in value or os.path.isabs(value):
+            return False
+        try:
+            return (REPO / value).exists()
+        except OSError:
+            return False  # too long to be a name, so not one
     if not isinstance(root, ast.Name):
         return False
     if root.id in derived:
@@ -353,7 +391,24 @@ def _is_checked_in_root(
     return root.id == "__file__" or (root.id in module_names and root.id not in shadowed)
 
 
-def _checked_in_locals(func, module_names: set, shadowed) -> set:
+def _reads_itself(name: str, value: ast.AST) -> bool:
+    """`source = source.read_text()` reads the path before replacing it.
+
+    The name holds a checked-in path right up to that call, so the assignment
+    is not evidence against it; it is the very read we are looking for.
+    """
+    if not isinstance(value, ast.Call):
+        return False
+    expr = _path_expr(value)
+    return isinstance(expr, ast.Name) and expr.id == name
+
+
+def _checked_in_locals(
+    func,
+    module_names: set,
+    shadowed,
+    seed = (),
+) -> set:
     """Locals that only ever hold a checked-in path.
 
     `route = Path(_BACKEND_DIR) / "routes" / "inference.py"` followed by
@@ -374,7 +429,8 @@ def _checked_in_locals(func, module_names: set, shadowed) -> set:
             continue
         if isinstance(target, ast.Name):
             targets.add(id(target))
-            assignments.append((target.id, value))
+            if not _reads_itself(target.id, value):
+                assignments.append((target.id, value))
     for node in ast.walk(func):
         # A with-as or an augassign says nothing about the value it binds.
         if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
@@ -382,9 +438,11 @@ def _checked_in_locals(func, module_names: set, shadowed) -> set:
                 bad.add(node.id)
     args = func.args
     bad.update(a.arg for a in [*args.posonlyargs, *args.args, *args.kwonlyargs])
-    good: set = set()
+    # A parameter every caller hands a checked-in path is the exception.
+    bad -= set(seed)
+    good: set = set(seed)
     while True:
-        grown = {
+        grown = set(good) | {
             name
             for name, value in assignments
             if name not in bad and _is_checked_in_root(value, module_names, shadowed, good)
@@ -418,23 +476,35 @@ def _checked_in_params(tree: ast.Module, module_names: set) -> set:
     # checked-in path can be passed on to the next helper.
     owner: dict = {}
 
-    def _mark(node, name):
+    def _mark(node, owning):
         if isinstance(node, ast.Call):
-            owner[id(node)] = name
+            owner[id(node)] = owning
         for child in ast.iter_child_nodes(node):
-            _mark(child, child.name if isinstance(child, ast.FunctionDef) else name)
+            nested = isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+            _mark(child, child if nested else owning)
 
     _mark(tree, None)
     good: set = set()
     while True:
         grown, bad = set(), set()
+        # What the calling function itself can prove, recomputed each pass so a
+        # parameter resolved last time can feed a local this time.
+        scope: dict = {}
         for call in ast.walk(tree):
             if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Name):
                 continue
             func = funcs.get(call.func.id)
             if func is None or any(isinstance(a, ast.Starred) for a in call.args):
                 continue
-            here = {p for f, p in good if f == owner.get(id(call))}
+            caller = owner.get(id(call))
+            if caller is None:
+                here = set()
+            elif id(caller) in scope:
+                here = scope[id(caller)]
+            else:
+                params = {p for f, p in good if f == caller.name}
+                here = _checked_in_locals(caller, module_names, _local_names(caller), params)
+                scope[id(caller)] = here
             params = [a.arg for a in [*func.args.posonlyargs, *func.args.args]]
             supplied = dict(zip(params, call.args))
             supplied.update({k.arg: k.value for k in call.keywords if k.arg in params})
@@ -487,10 +557,7 @@ def _checked_in_path_calls(tree: ast.Module):
             return
         elif isinstance(node, ast.Call):
             expr = _path_expr(node)
-            root = _path_root(expr) if expr is not None else None
-            if isinstance(root, ast.Name) and (
-                root.id in derived or _is_checked_in_root(root, module_names, shadowed)
-            ):
+            if expr is not None and _is_checked_in_root(expr, module_names, shadowed, derived):
                 yield node
         for child in ast.iter_child_nodes(node):
             yield from visit(child, shadowed, derived)

--- a/tests/test_source_read_encoding.py
+++ b/tests/test_source_read_encoding.py
@@ -39,7 +39,6 @@ NOT_PATH_RECEIVERS = {
     "dbm",
     "fitz",
     "gzip",
-    "io",
     "lzma",
     "os",
     "pymupdf",
@@ -79,9 +78,10 @@ def _import_time_calls(tree: ast.Module):
     collection, so skipping every def would let the Windows failure back in.
 
     A def's body waits for a call, but its decorators and argument defaults run
-    when the def executes, so those are followed. Lambda bodies and
-    comprehension elements do not run at definition and are skipped, which
-    keeps the rule free of false positives.
+    when the def executes, so those are followed. Lambda bodies are skipped for
+    the same reason, as is everything but the outermost iterable of a generator
+    expression. List, set and dict comprehensions are walked in full: unlike a
+    genexp they run their element, filters and nested iterators immediately.
 
     A body is only ever entered through an executed statement, never by walking
     into a def, so the "this definitely runs" property that makes the rule
@@ -111,8 +111,8 @@ def _import_time_calls(tree: ast.Module):
                 stack.extend(d for d in node.args.defaults if d is not None)
                 stack.extend(d for d in node.args.kw_defaults if d is not None)
                 continue
-            if isinstance(node, (ast.GeneratorExp, ast.ListComp, ast.SetComp, ast.DictComp)):
-                # Only the outermost iterable is evaluated where it is written.
+            if isinstance(node, ast.GeneratorExp):
+                # Lazy: only the outermost iterable is evaluated where written.
                 if node.generators:
                     stack.append(node.generators[0].iter)
                 continue
@@ -183,9 +183,14 @@ def _offender(call: ast.Call) -> str | None:
                 return None
             return None if _names_encoding(call) else f"{func.attr}()"
         if func.attr == "open":
-            # `<module>.open(...)` is somebody else's opener: tarfile.open takes
-            # a compression mode, fitz.open takes filetype=.
-            if isinstance(func.value, ast.Name) and func.value.id in NOT_PATH_RECEIVERS:
+            receiver = func.value.id if isinstance(func.value, ast.Name) else None
+            # io.open IS the builtin, so it takes the builtin's mode position
+            # and carries the same platform default.
+            if receiver == "io":
+                return None if not _is_text(call, 1) or _names_encoding(call) else "io.open()"
+            # Any other `<module>.open(...)` is somebody else's opener:
+            # tarfile.open takes a compression mode, fitz.open takes filetype=.
+            if receiver in NOT_PATH_RECEIVERS:
                 return None
             if not _is_text(call, 0):
                 return None

--- a/tests/test_source_read_encoding.py
+++ b/tests/test_source_read_encoding.py
@@ -49,6 +49,22 @@ NOT_PATH_RECEIVERS = {
     "webbrowser",
     "zipfile",
 }
+# Callables that drain a generator argument immediately.
+EAGER_CONSUMERS = {
+    "all",
+    "any",
+    "dict",
+    "frozenset",
+    "list",
+    "max",
+    "min",
+    "set",
+    "sorted",
+    "sum",
+    "tuple",
+}
+# Values that re-select the platform default when passed as the encoding.
+PLATFORM_DEFAULT_ENCODINGS = (None, "locale")
 # Distinct from None so that "no mode argument at all" still means text.
 UNKNOWN_MODE = object()
 
@@ -68,6 +84,17 @@ def _is_main_guard(node: ast.AST) -> bool:
     has_name = any(isinstance(o, ast.Name) and o.id == "__name__" for o in operands)
     has_main = any(isinstance(o, ast.Constant) and o.value == "__main__" for o in operands)
     return has_name and has_main
+
+
+def _is_eager_consumer(func: ast.expr) -> bool:
+    """True for a callee that drains a generator argument on the spot.
+
+    iter/zip/map/filter/enumerate/reversed hand back another lazy object, so a
+    genexp passed to those still has not run.
+    """
+    if isinstance(func, ast.Attribute):
+        return func.attr in {"join", "extend", "update", "writelines"}
+    return isinstance(func, ast.Name) and func.id in EAGER_CONSUMERS
 
 
 def _import_time_calls(tree: ast.Module):
@@ -91,23 +118,28 @@ def _import_time_calls(tree: ast.Module):
     so that is walked), and non-name calls, which are left unresolved rather
     than guessed at.
     """
-    # Defs reachable from a scope that executes at import: module body and any
-    # class body, at any nesting. `class F: def _load(): ...; DATA = _load()`
-    # runs _load while the class is constructed.
-    helpers = {}
-    scopes = [tree.body]
-    while scopes:
-        for node in scopes.pop():
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                helpers.setdefault(node.name, node)
-            elif isinstance(node, ast.ClassDef):
-                scopes.append(node.body)
-    # A generator expression handed straight to a call is consumed there, so its
-    # element runs at import; one merely bound to a name does not.
+    # Defs reachable from a scope that executes at import: module body, any
+    # class body, and (added when the helper is entered) any def nested inside
+    # a helper we follow. `class F: def _load(): ...; DATA = _load()` runs
+    # _load while the class is constructed.
+    helpers: dict = {}
+
+    def _collect(body):
+        scopes = [body]
+        while scopes:
+            for node in scopes.pop():
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    helpers.setdefault(node.name, node)
+                elif isinstance(node, ast.ClassDef):
+                    scopes.append(node.body)
+
+    _collect(tree.body)
+    # A generator expression only runs its element where an EAGER consumer takes
+    # it. iter/zip/map/enumerate leave it lazy, so those must not count.
     consumed = {
         id(arg)
         for call in ast.walk(tree)
-        if isinstance(call, ast.Call)
+        if isinstance(call, ast.Call) and _is_eager_consumer(call.func)
         for arg in [*call.args, *(k.value for k in call.keywords)]
         if isinstance(arg, ast.GeneratorExp)
     }
@@ -140,7 +172,9 @@ def _import_time_calls(tree: ast.Module):
                 func = node.func
                 if isinstance(func, ast.Name) and func.id in helpers and func.id not in entered:
                     entered.add(func.id)
-                    frontier.append(list(helpers[func.id].body))
+                    body = list(helpers[func.id].body)
+                    _collect(body)  # a def nested in this helper is now callable
+                    frontier.append(body)
             stack.extend(ast.iter_child_nodes(node))
 
 
@@ -181,7 +215,7 @@ def _names_encoding(call: ast.Call) -> bool:
             return True
         if kw.arg != "encoding":
             continue
-        if isinstance(kw.value, ast.Constant) and kw.value.value in (None, "locale"):
+        if isinstance(kw.value, ast.Constant) and kw.value.value in PLATFORM_DEFAULT_ENCODINGS:
             return False
         return True
     return False
@@ -192,10 +226,14 @@ def _offender(call: ast.Call) -> str | None:
     func = call.func
     if isinstance(func, ast.Attribute):
         if func.attr in GUARDED_METHODS:
-            # importlib.metadata's Distribution.read_text takes a positional
-            # filename and has no encoding parameter, so a positional argument
-            # means the receiver is not a Path.
             if func.attr == "read_text" and call.args:
+                first = call.args[0]
+                # Path.read_text takes encoding first, so None or "locale" there
+                # is a platform-default read. Any other positional means the
+                # receiver is importlib.metadata's Distribution, whose argument
+                # is a filename and which has no encoding parameter at all.
+                if isinstance(first, ast.Constant) and first.value in PLATFORM_DEFAULT_ENCODINGS:
+                    return "read_text()"
                 return None
             return None if _names_encoding(call) else f"{func.attr}()"
         if func.attr == "open":

--- a/tests/test_source_read_encoding.py
+++ b/tests/test_source_read_encoding.py
@@ -14,10 +14,27 @@ source-scanning tests do constantly:
     "byte 0x81", taking test_cancel_atomicity.py and test_cancel_id_wiring.py
     out at collection time.
 
-Nothing that runs at import can see a tmp_path fixture, so a bare read there is
-always touching a checked-in file. That makes the rule mechanical enough to
-enforce with no allowlist, while staying quiet about temp-dir I/O inside test
-bodies where the platform default is harmless.
+A call is an offence when it does un-pinned text I/O and any of three things
+holds. It runs at import, where nothing can see a tmp_path fixture yet. Its
+path is a module-level constant, which a fixture parameter cannot be. Or its
+path is built from `__file__`, which is checked in by construction. The last
+two reach test bodies, where the same failure lands one step later:
+
+    test_gemma4_chat_template.py opens unsloth/chat_templates.py through a
+    helper its tests call, and cp1252 cannot decode that file ("byte 0x90").
+    test_gguf_load_cache_reuse.py reads routes/inference.py the same way, via
+    `Path(__file__).parent.parent`, and dies on the same 0x81 as the two cancel
+    modules do at collection.
+
+Each rule is a property of the path expression alone, so together they stay
+mechanical enough to enforce with no allowlist while staying quiet about
+temp-dir I/O, where the platform default is harmless and the test wrote the
+bytes itself.
+
+One shape is deliberately out of reach: text read from a checked-in file and
+then written back out to a tmp_path, as at test_studio_install_workspace_guard
+.py:851, is only unsafe because of where the string came from, and tracing that
+needs dataflow rather than a look at the call.
 """
 
 # `str | None` below is evaluated at import on Python 3.9 without this, and
@@ -65,6 +82,12 @@ EAGER_CONSUMERS = {
 }
 # Values that re-select the platform default when passed as the encoding.
 PLATFORM_DEFAULT_ENCODINGS = (None, "locale")
+# `Path.read_text(p)` is the unbound spelling of `p.read_text()`: same API, same
+# platform default, but the instance takes the first slot so every argument
+# shifts one place right.
+PATH_CLASSES = {"Path", "PosixPath", "PurePath", "WindowsPath"}
+# Where each API takes its encoding positionally, for the bound call.
+ENCODING_POSITION = {"read_text": 0, "write_text": 1, "Path.open": 2, "open": 3}
 # Distinct from None so that "no mode argument at all" still means text.
 UNKNOWN_MODE = object()
 
@@ -134,15 +157,7 @@ def _import_time_calls(tree: ast.Module):
                     scopes.append(node.body)
 
     _collect(tree.body)
-    # A generator expression only runs its element where an EAGER consumer takes
-    # it. iter/zip/map/enumerate leave it lazy, so those must not count.
-    consumed = {
-        id(arg)
-        for call in ast.walk(tree)
-        if isinstance(call, ast.Call) and _is_eager_consumer(call.func)
-        for arg in [*call.args, *(k.value for k in call.keywords)]
-        if isinstance(arg, ast.GeneratorExp)
-    }
+    consumed = _consumed_genexps(tree)
     entered = set()
     frontier = [list(tree.body)]
     while frontier:
@@ -176,6 +191,113 @@ def _import_time_calls(tree: ast.Module):
                     _collect(body)  # a def nested in this helper is now callable
                     frontier.append(body)
             stack.extend(ast.iter_child_nodes(node))
+
+
+def _consumed_genexps(tree: ast.Module) -> set:
+    """Generator expressions handed straight to something that drains them.
+
+    An unconsumed one has not run where it is written, so neither rule should
+    read anything into the calls inside it.
+    """
+    return {
+        id(arg)
+        for call in ast.walk(tree)
+        if isinstance(call, ast.Call) and _is_eager_consumer(call.func)
+        for arg in [*call.args, *(k.value for k in call.keywords)]
+        if isinstance(arg, ast.GeneratorExp)
+    }
+
+
+def _module_level_names(tree: ast.Module) -> set:
+    """Names assigned at module scope."""
+    names = set()
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            names.update(t.id for t in node.targets if isinstance(t, ast.Name))
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            names.add(node.target.id)
+    return names
+
+
+def _local_names(func) -> set:
+    """Every name the function binds, so a module constant it shadows is skipped.
+
+    Walking nested defs too over-approximates, which only ever drops a call from
+    the scan.
+    """
+    args = func.args
+    names = {a.arg for a in [*args.posonlyargs, *args.args, *args.kwonlyargs]}
+    for extra in (args.vararg, args.kwarg):
+        if extra is not None:
+            names.add(extra.arg)
+    for node in ast.walk(func):
+        if isinstance(node, ast.Name) and isinstance(node.ctx, (ast.Store, ast.Del)):
+            names.add(node.id)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            names.update((a.asname or a.name).split(".")[0] for a in node.names)
+    return names
+
+
+def _path_expr(call: ast.Call):
+    """The expression the call reads from."""
+    func = call.func
+    if isinstance(func, ast.Attribute):
+        return func.value
+    if isinstance(func, ast.Name) and func.id == "open" and call.args:
+        return call.args[0]
+    return None
+
+
+def _rooted_at_file(node: ast.AST) -> bool:
+    """True for a path built from `__file__`, which is checked in by definition.
+
+    `(Path(__file__).parent.parent / "routes" / "inference.py").read_text()` is
+    the same read as through a constant, just spelled inline, and no tmp_path
+    can be written that way.
+    """
+    return any(isinstance(n, ast.Name) and n.id == "__file__" for n in ast.walk(node))
+
+
+def _checked_in_path_calls(tree: ast.Module):
+    """Yield calls, at any depth, whose path is provably a checked-in file.
+
+    The import-time walk alone leaves test bodies unguarded, and a bare read
+    there is the same Windows failure one step later: `_extract_template()` in
+    test_gemma4_chat_template.py opens unsloth/chat_templates.py, which cp1252
+    cannot decode ("byte 0x90"), so the test errors rather than the collection.
+
+    Two spellings qualify. A tmp_path arrives as a fixture parameter and a
+    tempfile is built in the body, so neither can be bound at module scope nor
+    derived from `__file__`. That keeps temp-dir I/O out of scope without an
+    allowlist, since there the platform default is harmless and the test wrote
+    the bytes itself.
+    """
+    module_names = _module_level_names(tree)
+    consumed = _consumed_genexps(tree)
+
+    def visit(node, shadowed):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            shadowed = shadowed | _local_names(node)
+        elif _is_main_guard(node):
+            # Never runs under pytest, so rule 1 skips it for the same reason.
+            for child in node.orelse:
+                yield from visit(child, shadowed)
+            return
+        elif isinstance(node, ast.GeneratorExp) and id(node) not in consumed:
+            if node.generators:
+                yield from visit(node.generators[0].iter, shadowed)
+            return
+        elif isinstance(node, ast.Call):
+            expr = _path_expr(node)
+            name = expr.id if isinstance(expr, ast.Name) else None
+            if expr is not None and (
+                _rooted_at_file(expr) or (name in module_names and name not in shadowed)
+            ):
+                yield node
+        for child in ast.iter_child_nodes(node):
+            yield from visit(child, shadowed)
+
+    yield from visit(tree, frozenset())
 
 
 def _open_mode(call: ast.Call, mode_index: int):
@@ -221,55 +343,85 @@ def _names_encoding(call: ast.Call) -> bool:
     return False
 
 
+def _pins_encoding(call: ast.Call, position: int) -> bool:
+    """True when the call names an encoding, positionally or by keyword.
+
+    A splat makes the positions meaningless, so it counts as named rather than
+    demanding an edit the contributor cannot make correctly.
+    """
+    if any(isinstance(a, ast.Starred) for a in call.args):
+        return True
+    if len(call.args) > position:
+        node = call.args[position]
+        if isinstance(node, ast.Constant):
+            return node.value not in PLATFORM_DEFAULT_ENCODINGS
+        return True
+    return _names_encoding(call)
+
+
 def _offender(call: ast.Call) -> str | None:
     """The call's name if it reads text without an encoding, else None."""
     func = call.func
     if isinstance(func, ast.Attribute):
+        receiver = func.value.id if isinstance(func.value, ast.Name) else None
+        # An unbound `Path.read_text(p)` puts the instance in slot 0.
+        shift = 1 if receiver in PATH_CLASSES else 0
         if func.attr in GUARDED_METHODS:
-            if func.attr == "read_text" and call.args:
+            if func.attr == "read_text" and not shift and call.args:
                 first = call.args[0]
-                # Path.read_text takes encoding first, so None or "locale" there
-                # is a platform-default read. Any other positional means the
-                # receiver is importlib.metadata's Distribution, whose argument
-                # is a filename and which has no encoding parameter at all.
+                # Bound read_text takes encoding first, so None or "locale"
+                # there is a platform-default read. Any other positional means
+                # the receiver is importlib.metadata's Distribution, whose
+                # argument is a filename and which takes no encoding at all.
                 if isinstance(first, ast.Constant) and first.value in PLATFORM_DEFAULT_ENCODINGS:
                     return "read_text()"
                 return None
-            return None if _names_encoding(call) else f"{func.attr}()"
+            position = ENCODING_POSITION[func.attr] + shift
+            return None if _pins_encoding(call, position) else f"{func.attr}()"
         if func.attr == "open":
-            receiver = func.value.id if isinstance(func.value, ast.Name) else None
-            # io.open IS the builtin, so it takes the builtin's mode position
-            # and carries the same platform default.
+            # io.open IS the builtin, so it takes the builtin's argument
+            # positions and carries the same platform default.
             if receiver == "io":
-                return None if not _is_text(call, 1) or _names_encoding(call) else "io.open()"
+                if not _is_text(call, 1) or _pins_encoding(call, ENCODING_POSITION["open"]):
+                    return None
+                return "io.open()"
             # Any other `<module>.open(...)` is somebody else's opener:
             # tarfile.open takes a compression mode, fitz.open takes filetype=.
             if receiver in NOT_PATH_RECEIVERS:
                 return None
-            if not _is_text(call, 0):
+            if not _is_text(call, shift):
                 return None
-            return None if _names_encoding(call) else "Path.open()"
+            return (
+                None
+                if _pins_encoding(call, ENCODING_POSITION["Path.open"] + shift)
+                else "Path.open()"
+            )
         return None
     # Binary handles have no encoding to name.
     if isinstance(func, ast.Name) and func.id == "open" and _is_text(call, 1):
-        return None if _names_encoding(call) else "open()"
+        return None if _pins_encoding(call, ENCODING_POSITION["open"]) else "open()"
     return None
 
 
-def test_module_level_file_reads_name_an_encoding():
+def _scan(tree: ast.Module, rel: str):
+    """Offenders from both rules, reported once each and in source order."""
+    calls = {id(c): c for c in _import_time_calls(tree)}
+    calls.update({id(c): c for c in _checked_in_path_calls(tree)})
+    for call in sorted(calls.values(), key = lambda c: (c.lineno, c.col_offset)):
+        name = _offender(call)
+        if name is not None:
+            yield f"{rel}:{call.lineno}: {name}"
+
+
+def test_checked_in_file_reads_name_an_encoding():
     offenders = []
     for root in ROOTS:
         for path in sorted(root.rglob("*.py")):
             tree = ast.parse(path.read_text(encoding = "utf-8"), filename = str(path))
-            for call in _import_time_calls(tree):
-                name = _offender(call)
-                if name is None:
-                    continue
-                rel = path.relative_to(REPO).as_posix()
-                offenders.append(f"{rel}:{call.lineno}: {name}")
+            offenders.extend(_scan(tree, path.relative_to(REPO).as_posix()))
     assert offenders == [], (
-        "Import-time file reads in the test trees touch a checked-in file with "
-        "the platform default encoding, so they break on Windows as soon as "
-        'that file gains a non-ASCII byte. Pass encoding = "utf-8": '
+        f"{len(offenders)} file reads in the test trees touch a checked-in file "
+        "with the platform default encoding, so they break on Windows as soon "
+        'as that file gains a non-ASCII byte. Pass encoding = "utf-8": '
         f"{offenders[:10]}"
     )

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -15,16 +15,13 @@ SETUP_SH = REPO_ROOT / "studio" / "setup.sh"
 # Stubs for helpers the extracted guard block calls; mv-based replacement reproduces the venv-gone
 # effect without the full rollback machinery.
 _INSTALL_GUARD_STUBS = (
-    "substep() { :; }\n"
-    "_start_studio_venv_replacement() {\n"
-    '    mv -- "$1" "$1.replaced"\n'
-    "}\n"
+    'substep() { :; }\n_start_studio_venv_replacement() {\n    mv -- "$1" "$1.replaced"\n}\n'
 )
 
 
 def _extract_install_sh_guard_block() -> str:
     """Extract install.sh's venv guard block (up to the first elif) as a self-contained snippet."""
-    src = INSTALL_SH.read_text()
+    src = INSTALL_SH.read_text(encoding = "utf-8")
     m = re.search(
         r'(if \[ -x "\$VENV_DIR/bin/python" \]; then\n.*?)elif \[ "\$_STUDIO_HOME_REDIRECT" != "env"',
         src,
@@ -119,27 +116,27 @@ def test_default_mode_skips_sentinel_check(tmp_path):
 
 
 def test_install_ps1_has_matching_env_mode_guard():
-    src = INSTALL_PS1.read_text()
+    src = INSTALL_PS1.read_text(encoding = "utf-8")
     block_start = src.index("if (Test-Path -LiteralPath $VenvPython)")
     block = src[block_start : block_start + 2000]
-    assert (
-        "$StudioRedirectMode -eq 'env'" in block
-    ), "install.ps1 must gate Remove-Item $VenvDir on env-mode"
+    assert "$StudioRedirectMode -eq 'env'" in block, (
+        "install.ps1 must gate Remove-Item $VenvDir on env-mode"
+    )
     assert "share\\studio.conf" in block, "install.ps1 guard must check share\\studio.conf sentinel"
     assert "bin\\unsloth.exe" in block, "install.ps1 guard must check bin\\unsloth.exe sentinel"
     assert "Refusing to delete non-Unsloth venv" in block
 
 
 def test_setup_ps1_has_writability_probe():
-    src = SETUP_PS1.read_text()
+    src = SETUP_PS1.read_text(encoding = "utf-8")
     idx = src.index("if (Test-Path -LiteralPath $_studioOverride -PathType Container)")
     block = src[idx : idx + 2000]
-    assert (
-        "WriteAllText" in block
-    ), "setup.ps1 must write-probe UNSLOTH_STUDIO_HOME like setup.sh:417"
-    assert (
-        "is not writable" in block
-    ), "setup.ps1 probe failure must produce a clear writable-error message"
+    assert "WriteAllText" in block, (
+        "setup.ps1 must write-probe UNSLOTH_STUDIO_HOME like setup.sh:417"
+    )
+    assert "is not writable" in block, (
+        "setup.ps1 probe failure must produce a clear writable-error message"
+    )
 
 
 def test_env_mode_blocks_when_bin_unsloth_is_a_directory(tmp_path):
@@ -193,31 +190,31 @@ def test_env_mode_passes_when_bin_unsloth_is_a_symlink(tmp_path):
 
 def test_install_ps1_sentinel_uses_pathtype_leaf():
     """Remove-Item $VenvDir gate must use -PathType Leaf so a sentinel-path directory cannot satisfy it."""
-    src = INSTALL_PS1.read_text()
+    src = INSTALL_PS1.read_text(encoding = "utf-8")
     block_start = src.index("if (Test-Path -LiteralPath $VenvPython)")
     block = src[block_start : block_start + 2000]
-    assert (
-        'share\\studio.conf") -PathType Leaf' in block
-    ), "install.ps1 share\\studio.conf check must use -PathType Leaf"
-    assert (
-        'bin\\unsloth.exe") -PathType Leaf' in block
-    ), "install.ps1 bin\\unsloth.exe check must use -PathType Leaf"
+    assert 'share\\studio.conf") -PathType Leaf' in block, (
+        "install.ps1 share\\studio.conf check must use -PathType Leaf"
+    )
+    assert 'bin\\unsloth.exe") -PathType Leaf' in block, (
+        "install.ps1 bin\\unsloth.exe check must use -PathType Leaf"
+    )
 
 
 def test_setup_ps1_stale_venv_has_env_mode_guard():
     """setup.ps1 stale-venv branch must gate Remove-Item $VenvDir on a custom-root Unsloth sentinel."""
-    src = SETUP_PS1.read_text()
+    src = SETUP_PS1.read_text(encoding = "utf-8")
     idx = src.index("Stale venv detected")
     block = src[idx : idx + 1500]
-    assert (
-        "$StudioHomeIsCustom" in block
-    ), "setup.ps1 stale-venv branch must gate on $StudioHomeIsCustom"
-    assert (
-        'share\\studio.conf") -PathType Leaf' in block
-    ), "setup.ps1 stale-venv guard must check share\\studio.conf with -PathType Leaf"
-    assert (
-        'bin\\unsloth.exe") -PathType Leaf' in block
-    ), "setup.ps1 stale-venv guard must check bin\\unsloth.exe with -PathType Leaf"
+    assert "$StudioHomeIsCustom" in block, (
+        "setup.ps1 stale-venv branch must gate on $StudioHomeIsCustom"
+    )
+    assert 'share\\studio.conf") -PathType Leaf' in block, (
+        "setup.ps1 stale-venv guard must check share\\studio.conf with -PathType Leaf"
+    )
+    assert 'bin\\unsloth.exe") -PathType Leaf' in block, (
+        "setup.ps1 stale-venv guard must check bin\\unsloth.exe with -PathType Leaf"
+    )
     # The guard must fire BEFORE the destructive call.
     guard_idx = block.index("$StudioHomeIsCustom")
     rm_idx = block.index("Remove-Item -LiteralPath $VenvDir")
@@ -226,12 +223,12 @@ def test_setup_ps1_stale_venv_has_env_mode_guard():
 
 def test_setup_sh_prebuilt_llama_cpp_has_ownership_guard():
     """setup.sh prebuilt llama.cpp path must _assert_studio_owned_or_absent before install_llama_prebuilt.py."""
-    src = SETUP_SH.read_text()
+    src = SETUP_SH.read_text(encoding = "utf-8")
     idx = src.index("installing prebuilt llama.cpp...")
     block = src[idx : idx + 2000]
-    assert (
-        '_assert_studio_owned_or_absent "$LLAMA_CPP_DIR" "llama.cpp install"' in block
-    ), "setup.sh must guard the prebuilt llama.cpp path with the ownership marker"
+    assert '_assert_studio_owned_or_absent "$LLAMA_CPP_DIR" "llama.cpp install"' in block, (
+        "setup.sh must guard the prebuilt llama.cpp path with the ownership marker"
+    )
     guard_idx = block.index('_assert_studio_owned_or_absent "$LLAMA_CPP_DIR"')
     # Anchor on the actual command-array entry, not the why-comment mention.
     helper_idx = block.index('python "$SCRIPT_DIR/install_llama_prebuilt.py"')
@@ -240,18 +237,18 @@ def test_setup_sh_prebuilt_llama_cpp_has_ownership_guard():
 
 def test_setup_ps1_prebuilt_llama_cpp_has_ownership_guard():
     """setup.ps1 prebuilt llama.cpp path must Assert-StudioOwnedOrAbsent before install_llama_prebuilt.py."""
-    src = SETUP_PS1.read_text()
+    src = SETUP_PS1.read_text(encoding = "utf-8")
     idx = src.index("installing prebuilt llama.cpp bundle (preferred path)")
     block = src[idx : idx + 2000]
-    assert (
-        'Assert-StudioOwnedOrAbsent -Path $LlamaCppDir -Label "llama.cpp install"' in block
-    ), "setup.ps1 must guard the prebuilt llama.cpp path with Assert-StudioOwnedOrAbsent"
+    assert 'Assert-StudioOwnedOrAbsent -Path $LlamaCppDir -Label "llama.cpp install"' in block, (
+        "setup.ps1 must guard the prebuilt llama.cpp path with Assert-StudioOwnedOrAbsent"
+    )
     guard_idx = block.index("Assert-StudioOwnedOrAbsent -Path $LlamaCppDir")
     # Anchor on the actual command-array entry, not the why-comment mention.
     helper_idx = block.index('"$PSScriptRoot\\install_llama_prebuilt.py"')
-    assert (
-        guard_idx < helper_idx
-    ), "Assert-StudioOwnedOrAbsent must precede the install_llama_prebuilt.py call"
+    assert guard_idx < helper_idx, (
+        "Assert-StudioOwnedOrAbsent must precede the install_llama_prebuilt.py call"
+    )
 
 
 def test_setup_ps1_adopts_existing_whisper_prebuilt_marker():
@@ -267,7 +264,7 @@ def test_env_mode_passes_when_venv_marker_present(tmp_path):
     studio_home = tmp_path / "ws"
     res = _run_install_guard(studio_home, redirect = "env", create_venv_marker = True)
     assert res.returncode == 0, (
-        f"in-VENV marker must allow cleanup; " f"stdout={res.stdout!r} stderr={res.stderr!r}"
+        f"in-VENV marker must allow cleanup; stdout={res.stdout!r} stderr={res.stderr!r}"
     )
     assert "RESULT=ok" in res.stdout
     assert not (studio_home / "unsloth_studio").exists()
@@ -319,98 +316,97 @@ def test_env_mode_blocks_when_bin_unsloth_is_broken_symlink(tmp_path):
         capture_output = True,
     )
     assert res.returncode != 0, (
-        "broken symlink at bin/unsloth must NOT pass; "
-        f"stdout={res.stdout!r} stderr={res.stderr!r}"
+        f"broken symlink at bin/unsloth must NOT pass; stdout={res.stdout!r} stderr={res.stderr!r}"
     )
     assert (venv / "important.txt").is_file()
 
 
 def test_install_sh_writes_venv_marker_after_uv_venv():
     """install.sh must write .unsloth-studio-owned into $VENV_DIR right after `uv venv` succeeds."""
-    src = INSTALL_SH.read_text()
+    src = INSTALL_SH.read_text(encoding = "utf-8")
     create_idx = src.index('run_install_cmd "create venv" uv venv "$VENV_DIR"')
     tail = src[create_idx : create_idx + 600]
-    assert (
-        ".unsloth-studio-owned" in tail
-    ), "install.sh must write .unsloth-studio-owned after uv venv create"
+    assert ".unsloth-studio-owned" in tail, (
+        "install.sh must write .unsloth-studio-owned after uv venv create"
+    )
 
 
 def test_install_ps1_writes_venv_marker_after_uv_venv():
     """install.ps1 must write .unsloth-studio-owned into $VenvDir after `uv venv` succeeds."""
-    src = INSTALL_PS1.read_text()
+    src = INSTALL_PS1.read_text(encoding = "utf-8")
     venv_create = src.index("uv venv $VenvDir --python")
     tail = src[venv_create : venv_create + 1500]
-    assert (
-        ".unsloth-studio-owned" in tail
-    ), "install.ps1 must write .unsloth-studio-owned after uv venv create"
+    assert ".unsloth-studio-owned" in tail, (
+        "install.ps1 must write .unsloth-studio-owned after uv venv create"
+    )
 
 
 def test_install_ps1_guard_accepts_venv_marker():
     """install.ps1 env-mode guard must accept the in-VENV .unsloth-studio-owned marker as a sentinel."""
-    src = INSTALL_PS1.read_text()
+    src = INSTALL_PS1.read_text(encoding = "utf-8")
     block_start = src.index("if (Test-Path -LiteralPath $VenvPython)")
     block = src[block_start : block_start + 2000]
-    assert (
-        '$VenvDir ".unsloth-studio-owned") -PathType Leaf' in block
-    ), "install.ps1 guard must check the in-VENV marker with -PathType Leaf"
+    assert '$VenvDir ".unsloth-studio-owned") -PathType Leaf' in block, (
+        "install.ps1 guard must check the in-VENV marker with -PathType Leaf"
+    )
 
 
 def test_setup_helpers_gate_on_canonical_custom_root():
     """setup.sh/setup.ps1 ownership guards must gate on a canonical custom-vs-legacy root comparison."""
-    sh_src = SETUP_SH.read_text()
+    sh_src = SETUP_SH.read_text(encoding = "utf-8")
     sh_idx = sh_src.index("_assert_studio_owned_or_absent() {")
     sh_func = sh_src[sh_idx : sh_idx + 600]
-    assert (
-        '"$_STUDIO_HOME_IS_CUSTOM" = true' in sh_func
-    ), "setup.sh _assert_studio_owned_or_absent must gate on _STUDIO_HOME_IS_CUSTOM"
+    assert '"$_STUDIO_HOME_IS_CUSTOM" = true' in sh_func, (
+        "setup.sh _assert_studio_owned_or_absent must gate on _STUDIO_HOME_IS_CUSTOM"
+    )
     assert (
         "_LEGACY_STUDIO_HOME=" in sh_src
         and "_studio_home_canon=" in sh_src
         and "_STUDIO_HOME_IS_CUSTOM=" in sh_src
     ), "setup.sh must compute the canonical custom-root flag"
 
-    ps_src = SETUP_PS1.read_text()
+    ps_src = SETUP_PS1.read_text(encoding = "utf-8")
     ps_idx = ps_src.index("function Assert-StudioOwnedOrAbsent")
     ps_func = ps_src[ps_idx : ps_idx + 800]
-    assert (
-        "$StudioHomeIsCustom -and" in ps_func
-    ), "setup.ps1 Assert-StudioOwnedOrAbsent must gate on $StudioHomeIsCustom"
-    assert (
-        "$StudioOwnedMarker) -PathType Leaf" in ps_func
-    ), "setup.ps1 marker check must use -PathType Leaf so a directory cannot satisfy it"
+    assert "$StudioHomeIsCustom -and" in ps_func, (
+        "setup.ps1 Assert-StudioOwnedOrAbsent must gate on $StudioHomeIsCustom"
+    )
+    assert "$StudioOwnedMarker) -PathType Leaf" in ps_func, (
+        "setup.ps1 marker check must use -PathType Leaf so a directory cannot satisfy it"
+    )
 
 
 def test_setup_ps1_inplace_git_sync_marks_studio_owned():
     """setup.ps1 in-place git-sync branch must Mark-StudioOwned after a successful sync."""
-    src = SETUP_PS1.read_text()
+    src = SETUP_PS1.read_text(encoding = "utf-8")
     inplace_idx = src.index('Test-Path -LiteralPath (Join-Path $LlamaCppDir ".git")')
     # The in-place branch ends just before the temp-dir clone branch.
     clone_idx = src.index("Cloning llama.cpp @", inplace_idx)
     inplace_block = src[inplace_idx:clone_idx]
-    assert (
-        "Mark-StudioOwned -Path $LlamaCppDir" in inplace_block
-    ), "in-place git-sync branch must call Mark-StudioOwned on success"
-    assert (
-        "$StudioHomeIsCustom" in inplace_block
-    ), "in-place Mark-StudioOwned call should be gated on $StudioHomeIsCustom"
+    assert "Mark-StudioOwned -Path $LlamaCppDir" in inplace_block, (
+        "in-place git-sync branch must call Mark-StudioOwned on success"
+    )
+    assert "$StudioHomeIsCustom" in inplace_block, (
+        "in-place Mark-StudioOwned call should be gated on $StudioHomeIsCustom"
+    )
 
 
 def test_setup_ps1_inplace_git_sync_asserts_studio_owned_before_mutation():
     """setup.ps1 in-place git-sync must Assert-StudioOwnedOrAbsent before any destructive git op."""
-    src = SETUP_PS1.read_text()
+    src = SETUP_PS1.read_text(encoding = "utf-8")
     inplace_idx = src.index('Test-Path -LiteralPath (Join-Path $LlamaCppDir ".git")')
     clone_idx = src.index("Cloning llama.cpp @", inplace_idx)
     inplace_block = src[inplace_idx:clone_idx]
-    assert (
-        "Assert-StudioOwnedOrAbsent -Path $LlamaCppDir" in inplace_block
-    ), "in-place git-sync must Assert-StudioOwnedOrAbsent before mutating $LlamaCppDir"
+    assert "Assert-StudioOwnedOrAbsent -Path $LlamaCppDir" in inplace_block, (
+        "in-place git-sync must Assert-StudioOwnedOrAbsent before mutating $LlamaCppDir"
+    )
     guard_idx = inplace_block.index("Assert-StudioOwnedOrAbsent -Path $LlamaCppDir")
     git_idx = inplace_block.index("git -C $LlamaCppDir remote set-url")
     assert guard_idx < git_idx, "Assert-StudioOwnedOrAbsent must precede the first git mutation"
 
 
 def _extract_check_health_function() -> str:
-    src = INSTALL_SH.read_text()
+    src = INSTALL_SH.read_text(encoding = "utf-8")
     fn_start = src.index("_check_health() {")
     fn_end = src.index("\n}\n", fn_start) + 2
     return src[fn_start:fn_end]
@@ -498,29 +494,29 @@ def test_check_health_handles_arbitrary_id_token():
 
 def test_install_ps1_test_studio_health_verifies_studio_root_id():
     """install.ps1 Test-StudioHealth must compare studio_root_id against baked $_ExpectedStudioRootId."""
-    src = INSTALL_PS1.read_text()
+    src = INSTALL_PS1.read_text(encoding = "utf-8")
     fn_start = src.index("function Test-StudioHealth")
     fn_end = src.index("\n}\n", fn_start) + 2
     fn = src[fn_start:fn_end]
     assert "studio_root_id" in fn, "Test-StudioHealth must inspect the studio_root_id field"
-    assert (
-        "$_ExpectedStudioRootId" in fn
-    ), "Test-StudioHealth must compare against the install-time baked $_ExpectedStudioRootId"
+    assert "$_ExpectedStudioRootId" in fn, (
+        "Test-StudioHealth must compare against the install-time baked $_ExpectedStudioRootId"
+    )
 
 
 def test_install_ps1_bakes_studio_root_id_into_launcher():
     """install.ps1 must persist a CSPRNG id at share/studio_install_id and bake it as $_ExpectedStudioRootId."""
-    src = INSTALL_PS1.read_text()
+    src = INSTALL_PS1.read_text(encoding = "utf-8")
     assert "$_studioRootId" in src, "install.ps1 must compute $_studioRootId for the launcher"
-    assert (
-        '"share"' in src and "studio_install_id" in src
-    ), "install.ps1 must persist the id at $StudioHome\\share\\studio_install_id"
-    assert (
-        "RandomNumberGenerator" in src
-    ), "install.ps1 must seed the id from a CSPRNG (RandomNumberGenerator)"
-    assert (
-        "$_ExpectedStudioRootId" in src
-    ), "install.ps1 must bake $_ExpectedStudioRootId into the launcher"
+    assert '"share"' in src and "studio_install_id" in src, (
+        "install.ps1 must persist the id at $StudioHome\\share\\studio_install_id"
+    )
+    assert "RandomNumberGenerator" in src, (
+        "install.ps1 must seed the id from a CSPRNG (RandomNumberGenerator)"
+    )
+    assert "$_ExpectedStudioRootId" in src, (
+        "install.ps1 must bake $_ExpectedStudioRootId into the launcher"
+    )
 
 
 def test_health_endpoint_exposes_studio_root_id_not_raw_path():
@@ -534,30 +530,30 @@ def test_health_endpoint_exposes_studio_root_id_not_raw_path():
         next_app_idx = len(src)
     health_block = src[health_idx:next_app_idx]
     assert '"studio_root_id"' in health_block, "/api/health must expose studio_root_id (hex digest)"
-    assert (
-        '"studio_root":' not in health_block
-    ), "/api/health must NOT expose the raw studio_root path (information disclosure)"
+    assert '"studio_root":' not in health_block, (
+        "/api/health must NOT expose the raw studio_root path (information disclosure)"
+    )
     assert "_studio_root_id()" in health_block, "/api/health must call the _studio_root_id helper"
 
 
 def test_install_sh_bakes_studio_root_id_into_launcher():
     """install.sh must persist the id at share/studio_install_id and bake it into the launcher for ALL modes."""
-    src = INSTALL_SH.read_text()
-    assert (
-        "_css_studio_root_id" in src
-    ), "install.sh must compute _css_studio_root_id for the launcher"
-    assert (
-        '_css_id_file="$_css_id_dir/studio_install_id"' in src
-    ), "install.sh must persist the id at $STUDIO_HOME/share/studio_install_id"
-    assert (
-        "od -An -N32 -tx1 /dev/urandom" in src
-    ), "install.sh must seed new ids from /dev/urandom (CSPRNG)"
-    assert (
-        "@@STUDIO_ROOT_ID@@" in src
-    ), "install.sh must use @@STUDIO_ROOT_ID@@ placeholder in the launcher heredoc"
-    assert (
-        "s|@@STUDIO_ROOT_ID@@|$_css_studio_root_id|g" in src
-    ), "install.sh must sed-substitute @@STUDIO_ROOT_ID@@ unconditionally (not just env-mode)"
+    src = INSTALL_SH.read_text(encoding = "utf-8")
+    assert "_css_studio_root_id" in src, (
+        "install.sh must compute _css_studio_root_id for the launcher"
+    )
+    assert '_css_id_file="$_css_id_dir/studio_install_id"' in src, (
+        "install.sh must persist the id at $STUDIO_HOME/share/studio_install_id"
+    )
+    assert "od -An -N32 -tx1 /dev/urandom" in src, (
+        "install.sh must seed new ids from /dev/urandom (CSPRNG)"
+    )
+    assert "@@STUDIO_ROOT_ID@@" in src, (
+        "install.sh must use @@STUDIO_ROOT_ID@@ placeholder in the launcher heredoc"
+    )
+    assert "s|@@STUDIO_ROOT_ID@@|$_css_studio_root_id|g" in src, (
+        "install.sh must sed-substitute @@STUDIO_ROOT_ID@@ unconditionally (not just env-mode)"
+    )
 
 
 def test_tauri_preflight_scrubs_studio_home_env():
@@ -571,47 +567,47 @@ def test_tauri_preflight_scrubs_studio_home_env():
     preflight = "\n".join(p.read_text() for p in preflight_paths if p.exists())
     commands = (REPO_ROOT / "studio" / "src-tauri" / "src" / "commands.rs").read_text()
     # Expect 2 scrubs in preflight (run_cli_probe + probe_cli_capability), 1 in commands.
-    assert (
-        preflight.count('cmd.env_remove("UNSLOTH_STUDIO_HOME")') >= 2
-    ), "preflight must scrub UNSLOTH_STUDIO_HOME in both run_cli_probe and probe_cli_capability"
-    assert (
-        preflight.count('cmd.env_remove("STUDIO_HOME")') >= 2
-    ), "preflight must scrub STUDIO_HOME in both run_cli_probe and probe_cli_capability"
-    assert (
-        'cmd.env_remove("UNSLOTH_STUDIO_HOME")' in commands
-    ), "commands.rs check_install_status must scrub UNSLOTH_STUDIO_HOME"
-    assert (
-        'cmd.env_remove("STUDIO_HOME")' in commands
-    ), "commands.rs check_install_status must scrub STUDIO_HOME"
+    assert preflight.count('cmd.env_remove("UNSLOTH_STUDIO_HOME")') >= 2, (
+        "preflight must scrub UNSLOTH_STUDIO_HOME in both run_cli_probe and probe_cli_capability"
+    )
+    assert preflight.count('cmd.env_remove("STUDIO_HOME")') >= 2, (
+        "preflight must scrub STUDIO_HOME in both run_cli_probe and probe_cli_capability"
+    )
+    assert 'cmd.env_remove("UNSLOTH_STUDIO_HOME")' in commands, (
+        "commands.rs check_install_status must scrub UNSLOTH_STUDIO_HOME"
+    )
+    assert 'cmd.env_remove("STUDIO_HOME")' in commands, (
+        "commands.rs check_install_status must scrub STUDIO_HOME"
+    )
 
 
 def test_install_sh_shim_uses_atomic_replace():
     """install.sh shim install must use ln -sfn for atomic replace (rm+ln left a missing-shim window)."""
-    src = INSTALL_SH.read_text()
+    src = INSTALL_SH.read_text(encoding = "utf-8")
     shim_idx = src.index('_shim_path="$_LOCAL_BIN/unsloth"')
     block = src[shim_idx : shim_idx + 1500]
-    assert (
-        'ln -sfn "$VENV_DIR/bin/unsloth" "$_shim_path"' in block
-    ), "install.sh must use ln -sfn for atomic shim replacement"
-    assert (
-        'rm -f -- "$_shim_path"' not in block
-    ), "the explicit rm + ln pair must be replaced by atomic ln -sfn"
+    assert 'ln -sfn "$VENV_DIR/bin/unsloth" "$_shim_path"' in block, (
+        "install.sh must use ln -sfn for atomic shim replacement"
+    )
+    assert 'rm -f -- "$_shim_path"' not in block, (
+        "the explicit rm + ln pair must be replaced by atomic ln -sfn"
+    )
 
 
 def test_install_sh_create_shortcuts_seeds_id_from_csprng_with_python_fallback(tmp_path):
     """_create_shortcuts seeds ids from /dev/urandom (python3 secrets fallback) and is re-run idempotent."""
-    src = INSTALL_SH.read_text()
+    src = INSTALL_SH.read_text(encoding = "utf-8")
     fn_start = src.index('_css_data_dir="$DATA_DIR"')
     block = src[fn_start : fn_start + 3000]
     urandom_idx = block.index("od -An -N32 -tx1 /dev/urandom")
     py_fallback_idx = block.index("python3 -c 'import secrets;", urandom_idx)
-    assert (
-        urandom_idx < py_fallback_idx
-    ), "/dev/urandom must be tried before the python3 secrets fallback"
+    assert urandom_idx < py_fallback_idx, (
+        "/dev/urandom must be tried before the python3 secrets fallback"
+    )
     # Non-empty id file check before generation is what makes re-runs idempotent.
-    assert (
-        'if [ ! -s "$_css_id_file" ]; then' in block
-    ), "install.sh must skip id generation when the file already has content"
+    assert 'if [ ! -s "$_css_id_file" ]; then' in block, (
+        "install.sh must skip id generation when the file already has content"
+    )
 
     # Behavioral check: run the generation block twice to confirm idempotence.
     studio_home = tmp_path / "studio"
@@ -638,58 +634,58 @@ def test_install_sh_create_shortcuts_seeds_id_from_csprng_with_python_fallback(t
     assert res.returncode == 0, res.stderr
     out = dict(line.split("=", 1) for line in res.stdout.strip().splitlines() if "=" in line)
     assert out.get("LEN") == "64", f"id must be 64 hex chars, got LEN={out.get('LEN')!r}"
-    assert all(
-        c in "0123456789abcdef" for c in out.get("ID", "")
-    ), f"id must be lowercase hex, got {out.get('ID')!r}"
+    assert all(c in "0123456789abcdef" for c in out.get("ID", "")), (
+        f"id must be lowercase hex, got {out.get('ID')!r}"
+    )
 
 
 def test_install_sh_create_shortcuts_fails_fast_when_no_entropy():
     """With no entropy source, _create_shortcuts must `return 1` not bake an empty studio_root_id."""
-    src = INSTALL_SH.read_text()
+    src = INSTALL_SH.read_text(encoding = "utf-8")
     fn_start = src.index('_css_data_dir="$DATA_DIR"')
     block = src[fn_start : fn_start + 3000]
-    assert (
-        "[WARN] Cannot create launcher: no entropy source for studio_install_id" in block
-    ), "install.sh must warn when neither urandom nor python3 is available"
-    assert (
-        "[WARN] Cannot create launcher: failed to read" in block
-    ), "install.sh must warn when the id file read produces no content"
-    assert (
-        block.count("return 1") >= 2
-    ), "both the no-entropy branch and the empty-read branch must `return 1`"
+    assert "[WARN] Cannot create launcher: no entropy source for studio_install_id" in block, (
+        "install.sh must warn when neither urandom nor python3 is available"
+    )
+    assert "[WARN] Cannot create launcher: failed to read" in block, (
+        "install.sh must warn when the id file read produces no content"
+    )
+    assert block.count("return 1") >= 2, (
+        "both the no-entropy branch and the empty-read branch must `return 1`"
+    )
 
 
 def test_install_sh_bakes_installed_is_env_mode_flag_in_launcher():
     """install.sh must bake the install-time mode into the launcher so a sourced studio.conf can't flip it."""
-    src = INSTALL_SH.read_text()
-    assert (
-        "_INSTALLED_IS_ENV_MODE='@@INSTALLED_IS_ENV_MODE@@'" in src
-    ), "launcher heredoc must declare _INSTALLED_IS_ENV_MODE='@@INSTALLED_IS_ENV_MODE@@'"
+    src = INSTALL_SH.read_text(encoding = "utf-8")
+    assert "_INSTALLED_IS_ENV_MODE='@@INSTALLED_IS_ENV_MODE@@'" in src, (
+        "launcher heredoc must declare _INSTALLED_IS_ENV_MODE='@@INSTALLED_IS_ENV_MODE@@'"
+    )
     assert "_css_is_env_mode=false" in src, "install.sh must default _css_is_env_mode to false"
-    assert (
-        '[ "$_STUDIO_HOME_REDIRECT" = "env" ] && _css_is_env_mode=true' in src
-    ), "install.sh must set _css_is_env_mode=true only when _STUDIO_HOME_REDIRECT=env"
-    assert (
-        "s|@@INSTALLED_IS_ENV_MODE@@|$_css_is_env_mode|g" in src
-    ), "install.sh sed pipeline must substitute @@INSTALLED_IS_ENV_MODE@@"
+    assert '[ "$_STUDIO_HOME_REDIRECT" = "env" ] && _css_is_env_mode=true' in src, (
+        "install.sh must set _css_is_env_mode=true only when _STUDIO_HOME_REDIRECT=env"
+    )
+    assert "s|@@INSTALLED_IS_ENV_MODE@@|$_css_is_env_mode|g" in src, (
+        "install.sh sed pipeline must substitute @@INSTALLED_IS_ENV_MODE@@"
+    )
 
 
 def test_install_sh_launcher_gates_port_file_on_baked_flag_not_runtime_env():
     """Launcher PORT_FILE/LOCK_DIR must gate on baked $_INSTALLED_IS_ENV_MODE, not runtime $UNSLOTH_STUDIO_HOME."""
-    src = INSTALL_SH.read_text()
+    src = INSTALL_SH.read_text(encoding = "utf-8")
     heredoc_start = src.index("cat > \"$_css_launcher\" << 'LAUNCHER_EOF'")
     heredoc_end = src.index("LAUNCHER_EOF\n", heredoc_start)
     heredoc = src[heredoc_start:heredoc_end]
-    assert (
-        'if [ "$_INSTALLED_IS_ENV_MODE" = "true" ]; then' in heredoc
-    ), "launcher must gate PORT_FILE/LOCK_DIR on baked _INSTALLED_IS_ENV_MODE"
+    assert 'if [ "$_INSTALLED_IS_ENV_MODE" = "true" ]; then' in heredoc, (
+        "launcher must gate PORT_FILE/LOCK_DIR on baked _INSTALLED_IS_ENV_MODE"
+    )
     port_block_start = heredoc.index('if [ "$_INSTALLED_IS_ENV_MODE" = "true" ]; then')
     port_block_end = heredoc.index("\nfi\n", port_block_start) + len("\nfi\n")
     port_block = heredoc[port_block_start:port_block_end]
     assert 'PORT_FILE="$DATA_DIR/studio.port"' in port_block
-    assert (
-        'if [ -n "${UNSLOTH_STUDIO_HOME:-}" ]; then\n    if command -v cksum' not in heredoc
-    ), "launcher must NOT gate PORT_FILE on runtime UNSLOTH_STUDIO_HOME"
+    assert 'if [ -n "${UNSLOTH_STUDIO_HOME:-}" ]; then\n    if command -v cksum' not in heredoc, (
+        "launcher must NOT gate PORT_FILE on runtime UNSLOTH_STUDIO_HOME"
+    )
 
     def _run_launcher_gate(installed_flag: str, runtime_env: dict) -> str:
         # Run the LOCK_DIR/PORT_FILE init block in isolation.
@@ -713,30 +709,30 @@ def test_install_sh_launcher_gates_port_file_on_baked_flag_not_runtime_env():
         return ""
 
     # default-mode must keep PORT_FILE empty even if UNSLOTH_STUDIO_HOME leaks in.
-    assert (
-        _run_launcher_gate("false", {"UNSLOTH_STUDIO_HOME": "/tmp/leaked"}) == ""
-    ), "default-mode launcher must keep PORT_FILE empty even with UNSLOTH_STUDIO_HOME in env"
+    assert _run_launcher_gate("false", {"UNSLOTH_STUDIO_HOME": "/tmp/leaked"}) == "", (
+        "default-mode launcher must keep PORT_FILE empty even with UNSLOTH_STUDIO_HOME in env"
+    )
     # env-mode must set PORT_FILE regardless of runtime env.
-    assert (
-        _run_launcher_gate("true", {}) == "/tmp/test_data_dir/studio.port"
-    ), "env-mode launcher must set PORT_FILE based on baked DATA_DIR"
+    assert _run_launcher_gate("true", {}) == "/tmp/test_data_dir/studio.port", (
+        "env-mode launcher must set PORT_FILE based on baked DATA_DIR"
+    )
 
 
 def test_main_py_studio_root_id_caches_at_module_load():
     """_studio_root_id() must read the id once at module load and reuse it (no per-poll FS/hash work)."""
     main_py = (REPO_ROOT / "studio" / "backend" / "main.py").read_text()
-    assert (
-        "_STUDIO_ROOT_ID_CACHE: str = _read_studio_install_id()" in main_py
-    ), "main.py must populate _STUDIO_ROOT_ID_CACHE from _read_studio_install_id() at module load"
+    assert "_STUDIO_ROOT_ID_CACHE: str = _read_studio_install_id()" in main_py, (
+        "main.py must populate _STUDIO_ROOT_ID_CACHE from _read_studio_install_id() at module load"
+    )
     fn_idx = main_py.index("def _studio_root_id() -> str:")
     next_def_idx = main_py.index("\ndef ", fn_idx + 1)
     fn_block = main_py[fn_idx:next_def_idx]
-    assert (
-        "return _STUDIO_ROOT_ID_CACHE" in fn_block
-    ), "_studio_root_id() body must return the cached value"
-    assert (
-        "read_text(" not in fn_block and "hashlib" not in fn_block
-    ), "_studio_root_id() must NOT do filesystem or hash work on every call"
+    assert "return _STUDIO_ROOT_ID_CACHE" in fn_block, (
+        "_studio_root_id() body must return the cached value"
+    )
+    assert "read_text(" not in fn_block and "hashlib" not in fn_block, (
+        "_studio_root_id() must NOT do filesystem or hash work on every call"
+    )
 
 
 def test_main_py_read_studio_install_id_validates_hex_and_handles_missing(tmp_path, monkeypatch):
@@ -794,15 +790,16 @@ def test_llama_cpp_search_roots_handles_studio_root_oserror():
         nxt = llama_cpp.find(f"\n{indent}def ", start + 1)
         return llama_cpp[start : nxt if nxt != -1 else len(llama_cpp)]
 
-    assert (
-        "except (ImportError, OSError, ValueError):"
-        in _method_body("_resolved_studio_root_and_is_legacy")
-    ), "_resolved_studio_root_and_is_legacy must catch (ImportError, OSError, ValueError) from studio_root()"
+    assert "except (ImportError, OSError, ValueError):" in _method_body(
+        "_resolved_studio_root_and_is_legacy"
+    ), (
+        "_resolved_studio_root_and_is_legacy must catch (ImportError, OSError, ValueError) from studio_root()"
+    )
     # Both callers must route through the shared classifier so neither crashes.
     for caller in ("_find_llama_server_binary", "_kill_orphaned_servers"):
-        assert "LlamaCppBackend._resolved_studio_root_and_is_legacy()" in _method_body(
-            caller
-        ), f"{caller} must resolve the install root via the shared classifier"
+        assert "LlamaCppBackend._resolved_studio_root_and_is_legacy()" in _method_body(caller), (
+            f"{caller} must resolve the install root via the shared classifier"
+        )
 
 
 def test_install_sh_install_id_survives_symlinked_studio_home(tmp_path):
@@ -830,7 +827,7 @@ def test_install_sh_install_id_survives_symlinked_studio_home(tmp_path):
 
 def test_install_sh_substitutes_root_id_before_data_dir():
     """sed must bake the non-user-controlled placeholders before @@DATA_DIR@@ so a crafted $DATA_DIR isn't mutated."""
-    src = INSTALL_SH.read_text()
+    src = INSTALL_SH.read_text(encoding = "utf-8")
     root_id_idx = src.index("s|@@STUDIO_ROOT_ID@@|$_css_studio_root_id|g")
     env_mode_idx = src.index("s|@@INSTALLED_IS_ENV_MODE@@|$_css_is_env_mode|g")
     data_dir_idx = src.index("s|@@DATA_DIR@@|$_sed_safe|g")
@@ -838,20 +835,22 @@ def test_install_sh_substitutes_root_id_before_data_dir():
         "@@STUDIO_ROOT_ID@@ substitution must happen BEFORE @@DATA_DIR@@ "
         "(non-user-controlled placeholders first)"
     )
-    assert (
-        env_mode_idx < data_dir_idx
-    ), "@@INSTALLED_IS_ENV_MODE@@ substitution must happen BEFORE @@DATA_DIR@@"
+    assert env_mode_idx < data_dir_idx, (
+        "@@INSTALLED_IS_ENV_MODE@@ substitution must happen BEFORE @@DATA_DIR@@"
+    )
 
 
 def test_install_sh_root_id_pass_does_not_mutate_user_data_dir(tmp_path):
     """A $DATA_DIR containing the literal @@STUDIO_ROOT_ID@@ must survive the placeholder-first sed passes."""
-    src = INSTALL_SH.read_text()
+    src = INSTALL_SH.read_text(encoding = "utf-8")
     heredoc_start = src.index("cat > \"$_css_launcher\" << 'LAUNCHER_EOF'")
     heredoc_body_start = src.index("\n", heredoc_start) + 1
     heredoc_body_end = src.index("LAUNCHER_EOF\n", heredoc_start)
     template = src[heredoc_body_start:heredoc_body_end]
     launcher_path = tmp_path / "launch.sh"
-    launcher_path.write_text(template)
+    # template comes out of install.sh, so it carries whatever non-ASCII that
+    # file holds and cp1252 cannot encode it back out.
+    launcher_path.write_text(template, encoding = "utf-8")
     # sed order: root-id first, then data-dir.
     weird_data_dir = "/tmp/with-@@STUDIO_ROOT_ID@@/share"
     root_id = "deadbeef" * 8
@@ -867,28 +866,28 @@ sed "s|@@DATA_DIR@@|$_sed_safe|g" "{launcher_path}" > "{launcher_path}.tmp" \\
 """
     subprocess.run(["bash", "-c", script], check = True)
     final = launcher_path.read_text()
-    assert (
-        f"DATA_DIR='{weird_data_dir}'" in final
-    ), f"DATA_DIR must be preserved verbatim (no @@STUDIO_ROOT_ID@@ mutation); got: {final[:500]}"
-    assert (
-        f"_EXPECTED_STUDIO_ROOT_ID='{root_id}'" in final
-    ), "STUDIO_ROOT_ID placeholder must still be substituted in the launcher heredoc"
+    assert f"DATA_DIR='{weird_data_dir}'" in final, (
+        f"DATA_DIR must be preserved verbatim (no @@STUDIO_ROOT_ID@@ mutation); got: {final[:500]}"
+    )
+    assert f"_EXPECTED_STUDIO_ROOT_ID='{root_id}'" in final, (
+        "STUDIO_ROOT_ID placeholder must still be substituted in the launcher heredoc"
+    )
 
 
 def test_install_ps1_install_id_file_layout_matches_backend_read_path():
     """install.ps1 must write the id at share/studio_install_id where the backend reads it, idempotently."""
-    src = INSTALL_PS1.read_text()
+    src = INSTALL_PS1.read_text(encoding = "utf-8")
     id_idx = src.index('$_studioIdDir = Join-Path $StudioHome "share"')
     context = src[id_idx : id_idx + 1500]
-    assert (
-        '$_studioIdFile = Join-Path $_studioIdDir "studio_install_id"' in context
-    ), "install.ps1 must persist the id at $StudioHome\\share\\studio_install_id"
-    assert (
-        "Test-Path -LiteralPath $_studioIdFile" in context
-    ), "install.ps1 must skip id generation when the file already has content (re-run idempotence)"
-    assert (
-        "RandomNumberGenerator" in context and "GetBytes($_idBytes)" in context
-    ), "install.ps1 must seed new ids from a CSPRNG (RandomNumberGenerator)"
-    assert (
-        "Move-Item -LiteralPath $_idTmp" in context
-    ), "install.ps1 must atomic-rename the temp file into place to avoid half-written ids"
+    assert '$_studioIdFile = Join-Path $_studioIdDir "studio_install_id"' in context, (
+        "install.ps1 must persist the id at $StudioHome\\share\\studio_install_id"
+    )
+    assert "Test-Path -LiteralPath $_studioIdFile" in context, (
+        "install.ps1 must skip id generation when the file already has content (re-run idempotence)"
+    )
+    assert "RandomNumberGenerator" in context and "GetBytes($_idBytes)" in context, (
+        "install.ps1 must seed new ids from a CSPRNG (RandomNumberGenerator)"
+    )
+    assert "Move-Item -LiteralPath $_idTmp" in context, (
+        "install.ps1 must atomic-rename the temp file into place to avoid half-written ids"
+    )

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -866,7 +866,8 @@ sed "s|@@DATA_DIR@@|$_sed_safe|g" "{launcher_path}" > "{launcher_path}.tmp" \\
     && mv "{launcher_path}.tmp" "{launcher_path}"
 """
     subprocess.run(["bash", "-c", script], check = True)
-    final = launcher_path.read_text()
+    # written as utf-8 just above, and the template carries U+2500.
+    final = launcher_path.read_text(encoding = "utf-8")
     assert (
         f"DATA_DIR='{weird_data_dir}'" in final
     ), f"DATA_DIR must be preserved verbatim (no @@STUDIO_ROOT_ID@@ mutation); got: {final[:500]}"

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -522,7 +522,7 @@ def test_install_ps1_bakes_studio_root_id_into_launcher():
 def test_health_endpoint_exposes_studio_root_id_not_raw_path():
     """/api/health must expose studio_root_id (hex digest), NOT the raw path (info disclosure on -H 0.0.0.0)."""
     main_py = REPO_ROOT / "studio" / "backend" / "main.py"
-    src = main_py.read_text()
+    src = main_py.read_text(encoding = "utf-8")
     health_idx = src.index('@app.get("/api/health")')
     # Slice up to the next top-level @app. so a growing body stays in scope.
     next_app_idx = src.find("\n@app.", health_idx + 1)
@@ -565,7 +565,9 @@ def test_tauri_preflight_scrubs_studio_home_env():
         *(preflight_root / "preflight").glob("*.rs"),
     ]
     preflight = "\n".join(p.read_text() for p in preflight_paths if p.exists())
-    commands = (REPO_ROOT / "studio" / "src-tauri" / "src" / "commands.rs").read_text()
+    commands = (REPO_ROOT / "studio" / "src-tauri" / "src" / "commands.rs").read_text(
+        encoding = "utf-8"
+    )
     # Expect 2 scrubs in preflight (run_cli_probe + probe_cli_capability), 1 in commands.
     assert (
         preflight.count('cmd.env_remove("UNSLOTH_STUDIO_HOME")') >= 2
@@ -720,7 +722,7 @@ def test_install_sh_launcher_gates_port_file_on_baked_flag_not_runtime_env():
 
 def test_main_py_studio_root_id_caches_at_module_load():
     """_studio_root_id() must read the id once at module load and reuse it (no per-poll FS/hash work)."""
-    main_py = (REPO_ROOT / "studio" / "backend" / "main.py").read_text()
+    main_py = (REPO_ROOT / "studio" / "backend" / "main.py").read_text(encoding = "utf-8")
     assert (
         "_STUDIO_ROOT_ID_CACHE: str = _read_studio_install_id()" in main_py
     ), "main.py must populate _STUDIO_ROOT_ID_CACHE from _read_studio_install_id() at module load"
@@ -781,7 +783,7 @@ def test_llama_cpp_search_roots_handles_studio_root_oserror():
     holds the handler so the two never disagree on which root is legacy."""
     llama_cpp = (
         REPO_ROOT / "studio" / "backend" / "core" / "inference" / "llama_cpp.py"
-    ).read_text()
+    ).read_text(encoding = "utf-8")
 
     def _method_body(name: str) -> str:
         # Whole method body (def to next sibling def) so the check survives growth.

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -119,9 +119,9 @@ def test_install_ps1_has_matching_env_mode_guard():
     src = INSTALL_PS1.read_text(encoding = "utf-8")
     block_start = src.index("if (Test-Path -LiteralPath $VenvPython)")
     block = src[block_start : block_start + 2000]
-    assert "$StudioRedirectMode -eq 'env'" in block, (
-        "install.ps1 must gate Remove-Item $VenvDir on env-mode"
-    )
+    assert (
+        "$StudioRedirectMode -eq 'env'" in block
+    ), "install.ps1 must gate Remove-Item $VenvDir on env-mode"
     assert "share\\studio.conf" in block, "install.ps1 guard must check share\\studio.conf sentinel"
     assert "bin\\unsloth.exe" in block, "install.ps1 guard must check bin\\unsloth.exe sentinel"
     assert "Refusing to delete non-Unsloth venv" in block
@@ -131,12 +131,12 @@ def test_setup_ps1_has_writability_probe():
     src = SETUP_PS1.read_text(encoding = "utf-8")
     idx = src.index("if (Test-Path -LiteralPath $_studioOverride -PathType Container)")
     block = src[idx : idx + 2000]
-    assert "WriteAllText" in block, (
-        "setup.ps1 must write-probe UNSLOTH_STUDIO_HOME like setup.sh:417"
-    )
-    assert "is not writable" in block, (
-        "setup.ps1 probe failure must produce a clear writable-error message"
-    )
+    assert (
+        "WriteAllText" in block
+    ), "setup.ps1 must write-probe UNSLOTH_STUDIO_HOME like setup.sh:417"
+    assert (
+        "is not writable" in block
+    ), "setup.ps1 probe failure must produce a clear writable-error message"
 
 
 def test_env_mode_blocks_when_bin_unsloth_is_a_directory(tmp_path):
@@ -193,12 +193,12 @@ def test_install_ps1_sentinel_uses_pathtype_leaf():
     src = INSTALL_PS1.read_text(encoding = "utf-8")
     block_start = src.index("if (Test-Path -LiteralPath $VenvPython)")
     block = src[block_start : block_start + 2000]
-    assert 'share\\studio.conf") -PathType Leaf' in block, (
-        "install.ps1 share\\studio.conf check must use -PathType Leaf"
-    )
-    assert 'bin\\unsloth.exe") -PathType Leaf' in block, (
-        "install.ps1 bin\\unsloth.exe check must use -PathType Leaf"
-    )
+    assert (
+        'share\\studio.conf") -PathType Leaf' in block
+    ), "install.ps1 share\\studio.conf check must use -PathType Leaf"
+    assert (
+        'bin\\unsloth.exe") -PathType Leaf' in block
+    ), "install.ps1 bin\\unsloth.exe check must use -PathType Leaf"
 
 
 def test_setup_ps1_stale_venv_has_env_mode_guard():
@@ -206,15 +206,15 @@ def test_setup_ps1_stale_venv_has_env_mode_guard():
     src = SETUP_PS1.read_text(encoding = "utf-8")
     idx = src.index("Stale venv detected")
     block = src[idx : idx + 1500]
-    assert "$StudioHomeIsCustom" in block, (
-        "setup.ps1 stale-venv branch must gate on $StudioHomeIsCustom"
-    )
-    assert 'share\\studio.conf") -PathType Leaf' in block, (
-        "setup.ps1 stale-venv guard must check share\\studio.conf with -PathType Leaf"
-    )
-    assert 'bin\\unsloth.exe") -PathType Leaf' in block, (
-        "setup.ps1 stale-venv guard must check bin\\unsloth.exe with -PathType Leaf"
-    )
+    assert (
+        "$StudioHomeIsCustom" in block
+    ), "setup.ps1 stale-venv branch must gate on $StudioHomeIsCustom"
+    assert (
+        'share\\studio.conf") -PathType Leaf' in block
+    ), "setup.ps1 stale-venv guard must check share\\studio.conf with -PathType Leaf"
+    assert (
+        'bin\\unsloth.exe") -PathType Leaf' in block
+    ), "setup.ps1 stale-venv guard must check bin\\unsloth.exe with -PathType Leaf"
     # The guard must fire BEFORE the destructive call.
     guard_idx = block.index("$StudioHomeIsCustom")
     rm_idx = block.index("Remove-Item -LiteralPath $VenvDir")
@@ -226,9 +226,9 @@ def test_setup_sh_prebuilt_llama_cpp_has_ownership_guard():
     src = SETUP_SH.read_text(encoding = "utf-8")
     idx = src.index("installing prebuilt llama.cpp...")
     block = src[idx : idx + 2000]
-    assert '_assert_studio_owned_or_absent "$LLAMA_CPP_DIR" "llama.cpp install"' in block, (
-        "setup.sh must guard the prebuilt llama.cpp path with the ownership marker"
-    )
+    assert (
+        '_assert_studio_owned_or_absent "$LLAMA_CPP_DIR" "llama.cpp install"' in block
+    ), "setup.sh must guard the prebuilt llama.cpp path with the ownership marker"
     guard_idx = block.index('_assert_studio_owned_or_absent "$LLAMA_CPP_DIR"')
     # Anchor on the actual command-array entry, not the why-comment mention.
     helper_idx = block.index('python "$SCRIPT_DIR/install_llama_prebuilt.py"')
@@ -240,15 +240,15 @@ def test_setup_ps1_prebuilt_llama_cpp_has_ownership_guard():
     src = SETUP_PS1.read_text(encoding = "utf-8")
     idx = src.index("installing prebuilt llama.cpp bundle (preferred path)")
     block = src[idx : idx + 2000]
-    assert 'Assert-StudioOwnedOrAbsent -Path $LlamaCppDir -Label "llama.cpp install"' in block, (
-        "setup.ps1 must guard the prebuilt llama.cpp path with Assert-StudioOwnedOrAbsent"
-    )
+    assert (
+        'Assert-StudioOwnedOrAbsent -Path $LlamaCppDir -Label "llama.cpp install"' in block
+    ), "setup.ps1 must guard the prebuilt llama.cpp path with Assert-StudioOwnedOrAbsent"
     guard_idx = block.index("Assert-StudioOwnedOrAbsent -Path $LlamaCppDir")
     # Anchor on the actual command-array entry, not the why-comment mention.
     helper_idx = block.index('"$PSScriptRoot\\install_llama_prebuilt.py"')
-    assert guard_idx < helper_idx, (
-        "Assert-StudioOwnedOrAbsent must precede the install_llama_prebuilt.py call"
-    )
+    assert (
+        guard_idx < helper_idx
+    ), "Assert-StudioOwnedOrAbsent must precede the install_llama_prebuilt.py call"
 
 
 def test_setup_ps1_adopts_existing_whisper_prebuilt_marker():
@@ -263,9 +263,9 @@ def test_env_mode_passes_when_venv_marker_present(tmp_path):
     """install.sh env-mode guard must accept the in-VENV .unsloth-studio-owned marker as a sentinel."""
     studio_home = tmp_path / "ws"
     res = _run_install_guard(studio_home, redirect = "env", create_venv_marker = True)
-    assert res.returncode == 0, (
-        f"in-VENV marker must allow cleanup; stdout={res.stdout!r} stderr={res.stderr!r}"
-    )
+    assert (
+        res.returncode == 0
+    ), f"in-VENV marker must allow cleanup; stdout={res.stdout!r} stderr={res.stderr!r}"
     assert "RESULT=ok" in res.stdout
     assert not (studio_home / "unsloth_studio").exists()
 
@@ -315,9 +315,9 @@ def test_env_mode_blocks_when_bin_unsloth_is_broken_symlink(tmp_path):
         text = True,
         capture_output = True,
     )
-    assert res.returncode != 0, (
-        f"broken symlink at bin/unsloth must NOT pass; stdout={res.stdout!r} stderr={res.stderr!r}"
-    )
+    assert (
+        res.returncode != 0
+    ), f"broken symlink at bin/unsloth must NOT pass; stdout={res.stdout!r} stderr={res.stderr!r}"
     assert (venv / "important.txt").is_file()
 
 
@@ -326,9 +326,9 @@ def test_install_sh_writes_venv_marker_after_uv_venv():
     src = INSTALL_SH.read_text(encoding = "utf-8")
     create_idx = src.index('run_install_cmd "create venv" uv venv "$VENV_DIR"')
     tail = src[create_idx : create_idx + 600]
-    assert ".unsloth-studio-owned" in tail, (
-        "install.sh must write .unsloth-studio-owned after uv venv create"
-    )
+    assert (
+        ".unsloth-studio-owned" in tail
+    ), "install.sh must write .unsloth-studio-owned after uv venv create"
 
 
 def test_install_ps1_writes_venv_marker_after_uv_venv():
@@ -336,9 +336,9 @@ def test_install_ps1_writes_venv_marker_after_uv_venv():
     src = INSTALL_PS1.read_text(encoding = "utf-8")
     venv_create = src.index("uv venv $VenvDir --python")
     tail = src[venv_create : venv_create + 1500]
-    assert ".unsloth-studio-owned" in tail, (
-        "install.ps1 must write .unsloth-studio-owned after uv venv create"
-    )
+    assert (
+        ".unsloth-studio-owned" in tail
+    ), "install.ps1 must write .unsloth-studio-owned after uv venv create"
 
 
 def test_install_ps1_guard_accepts_venv_marker():
@@ -346,9 +346,9 @@ def test_install_ps1_guard_accepts_venv_marker():
     src = INSTALL_PS1.read_text(encoding = "utf-8")
     block_start = src.index("if (Test-Path -LiteralPath $VenvPython)")
     block = src[block_start : block_start + 2000]
-    assert '$VenvDir ".unsloth-studio-owned") -PathType Leaf' in block, (
-        "install.ps1 guard must check the in-VENV marker with -PathType Leaf"
-    )
+    assert (
+        '$VenvDir ".unsloth-studio-owned") -PathType Leaf' in block
+    ), "install.ps1 guard must check the in-VENV marker with -PathType Leaf"
 
 
 def test_setup_helpers_gate_on_canonical_custom_root():
@@ -356,9 +356,9 @@ def test_setup_helpers_gate_on_canonical_custom_root():
     sh_src = SETUP_SH.read_text(encoding = "utf-8")
     sh_idx = sh_src.index("_assert_studio_owned_or_absent() {")
     sh_func = sh_src[sh_idx : sh_idx + 600]
-    assert '"$_STUDIO_HOME_IS_CUSTOM" = true' in sh_func, (
-        "setup.sh _assert_studio_owned_or_absent must gate on _STUDIO_HOME_IS_CUSTOM"
-    )
+    assert (
+        '"$_STUDIO_HOME_IS_CUSTOM" = true' in sh_func
+    ), "setup.sh _assert_studio_owned_or_absent must gate on _STUDIO_HOME_IS_CUSTOM"
     assert (
         "_LEGACY_STUDIO_HOME=" in sh_src
         and "_studio_home_canon=" in sh_src
@@ -368,12 +368,12 @@ def test_setup_helpers_gate_on_canonical_custom_root():
     ps_src = SETUP_PS1.read_text(encoding = "utf-8")
     ps_idx = ps_src.index("function Assert-StudioOwnedOrAbsent")
     ps_func = ps_src[ps_idx : ps_idx + 800]
-    assert "$StudioHomeIsCustom -and" in ps_func, (
-        "setup.ps1 Assert-StudioOwnedOrAbsent must gate on $StudioHomeIsCustom"
-    )
-    assert "$StudioOwnedMarker) -PathType Leaf" in ps_func, (
-        "setup.ps1 marker check must use -PathType Leaf so a directory cannot satisfy it"
-    )
+    assert (
+        "$StudioHomeIsCustom -and" in ps_func
+    ), "setup.ps1 Assert-StudioOwnedOrAbsent must gate on $StudioHomeIsCustom"
+    assert (
+        "$StudioOwnedMarker) -PathType Leaf" in ps_func
+    ), "setup.ps1 marker check must use -PathType Leaf so a directory cannot satisfy it"
 
 
 def test_setup_ps1_inplace_git_sync_marks_studio_owned():
@@ -383,12 +383,12 @@ def test_setup_ps1_inplace_git_sync_marks_studio_owned():
     # The in-place branch ends just before the temp-dir clone branch.
     clone_idx = src.index("Cloning llama.cpp @", inplace_idx)
     inplace_block = src[inplace_idx:clone_idx]
-    assert "Mark-StudioOwned -Path $LlamaCppDir" in inplace_block, (
-        "in-place git-sync branch must call Mark-StudioOwned on success"
-    )
-    assert "$StudioHomeIsCustom" in inplace_block, (
-        "in-place Mark-StudioOwned call should be gated on $StudioHomeIsCustom"
-    )
+    assert (
+        "Mark-StudioOwned -Path $LlamaCppDir" in inplace_block
+    ), "in-place git-sync branch must call Mark-StudioOwned on success"
+    assert (
+        "$StudioHomeIsCustom" in inplace_block
+    ), "in-place Mark-StudioOwned call should be gated on $StudioHomeIsCustom"
 
 
 def test_setup_ps1_inplace_git_sync_asserts_studio_owned_before_mutation():
@@ -397,9 +397,9 @@ def test_setup_ps1_inplace_git_sync_asserts_studio_owned_before_mutation():
     inplace_idx = src.index('Test-Path -LiteralPath (Join-Path $LlamaCppDir ".git")')
     clone_idx = src.index("Cloning llama.cpp @", inplace_idx)
     inplace_block = src[inplace_idx:clone_idx]
-    assert "Assert-StudioOwnedOrAbsent -Path $LlamaCppDir" in inplace_block, (
-        "in-place git-sync must Assert-StudioOwnedOrAbsent before mutating $LlamaCppDir"
-    )
+    assert (
+        "Assert-StudioOwnedOrAbsent -Path $LlamaCppDir" in inplace_block
+    ), "in-place git-sync must Assert-StudioOwnedOrAbsent before mutating $LlamaCppDir"
     guard_idx = inplace_block.index("Assert-StudioOwnedOrAbsent -Path $LlamaCppDir")
     git_idx = inplace_block.index("git -C $LlamaCppDir remote set-url")
     assert guard_idx < git_idx, "Assert-StudioOwnedOrAbsent must precede the first git mutation"
@@ -499,24 +499,24 @@ def test_install_ps1_test_studio_health_verifies_studio_root_id():
     fn_end = src.index("\n}\n", fn_start) + 2
     fn = src[fn_start:fn_end]
     assert "studio_root_id" in fn, "Test-StudioHealth must inspect the studio_root_id field"
-    assert "$_ExpectedStudioRootId" in fn, (
-        "Test-StudioHealth must compare against the install-time baked $_ExpectedStudioRootId"
-    )
+    assert (
+        "$_ExpectedStudioRootId" in fn
+    ), "Test-StudioHealth must compare against the install-time baked $_ExpectedStudioRootId"
 
 
 def test_install_ps1_bakes_studio_root_id_into_launcher():
     """install.ps1 must persist a CSPRNG id at share/studio_install_id and bake it as $_ExpectedStudioRootId."""
     src = INSTALL_PS1.read_text(encoding = "utf-8")
     assert "$_studioRootId" in src, "install.ps1 must compute $_studioRootId for the launcher"
-    assert '"share"' in src and "studio_install_id" in src, (
-        "install.ps1 must persist the id at $StudioHome\\share\\studio_install_id"
-    )
-    assert "RandomNumberGenerator" in src, (
-        "install.ps1 must seed the id from a CSPRNG (RandomNumberGenerator)"
-    )
-    assert "$_ExpectedStudioRootId" in src, (
-        "install.ps1 must bake $_ExpectedStudioRootId into the launcher"
-    )
+    assert (
+        '"share"' in src and "studio_install_id" in src
+    ), "install.ps1 must persist the id at $StudioHome\\share\\studio_install_id"
+    assert (
+        "RandomNumberGenerator" in src
+    ), "install.ps1 must seed the id from a CSPRNG (RandomNumberGenerator)"
+    assert (
+        "$_ExpectedStudioRootId" in src
+    ), "install.ps1 must bake $_ExpectedStudioRootId into the launcher"
 
 
 def test_health_endpoint_exposes_studio_root_id_not_raw_path():
@@ -530,30 +530,30 @@ def test_health_endpoint_exposes_studio_root_id_not_raw_path():
         next_app_idx = len(src)
     health_block = src[health_idx:next_app_idx]
     assert '"studio_root_id"' in health_block, "/api/health must expose studio_root_id (hex digest)"
-    assert '"studio_root":' not in health_block, (
-        "/api/health must NOT expose the raw studio_root path (information disclosure)"
-    )
+    assert (
+        '"studio_root":' not in health_block
+    ), "/api/health must NOT expose the raw studio_root path (information disclosure)"
     assert "_studio_root_id()" in health_block, "/api/health must call the _studio_root_id helper"
 
 
 def test_install_sh_bakes_studio_root_id_into_launcher():
     """install.sh must persist the id at share/studio_install_id and bake it into the launcher for ALL modes."""
     src = INSTALL_SH.read_text(encoding = "utf-8")
-    assert "_css_studio_root_id" in src, (
-        "install.sh must compute _css_studio_root_id for the launcher"
-    )
-    assert '_css_id_file="$_css_id_dir/studio_install_id"' in src, (
-        "install.sh must persist the id at $STUDIO_HOME/share/studio_install_id"
-    )
-    assert "od -An -N32 -tx1 /dev/urandom" in src, (
-        "install.sh must seed new ids from /dev/urandom (CSPRNG)"
-    )
-    assert "@@STUDIO_ROOT_ID@@" in src, (
-        "install.sh must use @@STUDIO_ROOT_ID@@ placeholder in the launcher heredoc"
-    )
-    assert "s|@@STUDIO_ROOT_ID@@|$_css_studio_root_id|g" in src, (
-        "install.sh must sed-substitute @@STUDIO_ROOT_ID@@ unconditionally (not just env-mode)"
-    )
+    assert (
+        "_css_studio_root_id" in src
+    ), "install.sh must compute _css_studio_root_id for the launcher"
+    assert (
+        '_css_id_file="$_css_id_dir/studio_install_id"' in src
+    ), "install.sh must persist the id at $STUDIO_HOME/share/studio_install_id"
+    assert (
+        "od -An -N32 -tx1 /dev/urandom" in src
+    ), "install.sh must seed new ids from /dev/urandom (CSPRNG)"
+    assert (
+        "@@STUDIO_ROOT_ID@@" in src
+    ), "install.sh must use @@STUDIO_ROOT_ID@@ placeholder in the launcher heredoc"
+    assert (
+        "s|@@STUDIO_ROOT_ID@@|$_css_studio_root_id|g" in src
+    ), "install.sh must sed-substitute @@STUDIO_ROOT_ID@@ unconditionally (not just env-mode)"
 
 
 def test_tauri_preflight_scrubs_studio_home_env():
@@ -567,18 +567,18 @@ def test_tauri_preflight_scrubs_studio_home_env():
     preflight = "\n".join(p.read_text() for p in preflight_paths if p.exists())
     commands = (REPO_ROOT / "studio" / "src-tauri" / "src" / "commands.rs").read_text()
     # Expect 2 scrubs in preflight (run_cli_probe + probe_cli_capability), 1 in commands.
-    assert preflight.count('cmd.env_remove("UNSLOTH_STUDIO_HOME")') >= 2, (
-        "preflight must scrub UNSLOTH_STUDIO_HOME in both run_cli_probe and probe_cli_capability"
-    )
-    assert preflight.count('cmd.env_remove("STUDIO_HOME")') >= 2, (
-        "preflight must scrub STUDIO_HOME in both run_cli_probe and probe_cli_capability"
-    )
-    assert 'cmd.env_remove("UNSLOTH_STUDIO_HOME")' in commands, (
-        "commands.rs check_install_status must scrub UNSLOTH_STUDIO_HOME"
-    )
-    assert 'cmd.env_remove("STUDIO_HOME")' in commands, (
-        "commands.rs check_install_status must scrub STUDIO_HOME"
-    )
+    assert (
+        preflight.count('cmd.env_remove("UNSLOTH_STUDIO_HOME")') >= 2
+    ), "preflight must scrub UNSLOTH_STUDIO_HOME in both run_cli_probe and probe_cli_capability"
+    assert (
+        preflight.count('cmd.env_remove("STUDIO_HOME")') >= 2
+    ), "preflight must scrub STUDIO_HOME in both run_cli_probe and probe_cli_capability"
+    assert (
+        'cmd.env_remove("UNSLOTH_STUDIO_HOME")' in commands
+    ), "commands.rs check_install_status must scrub UNSLOTH_STUDIO_HOME"
+    assert (
+        'cmd.env_remove("STUDIO_HOME")' in commands
+    ), "commands.rs check_install_status must scrub STUDIO_HOME"
 
 
 def test_install_sh_shim_uses_atomic_replace():
@@ -586,12 +586,12 @@ def test_install_sh_shim_uses_atomic_replace():
     src = INSTALL_SH.read_text(encoding = "utf-8")
     shim_idx = src.index('_shim_path="$_LOCAL_BIN/unsloth"')
     block = src[shim_idx : shim_idx + 1500]
-    assert 'ln -sfn "$VENV_DIR/bin/unsloth" "$_shim_path"' in block, (
-        "install.sh must use ln -sfn for atomic shim replacement"
-    )
-    assert 'rm -f -- "$_shim_path"' not in block, (
-        "the explicit rm + ln pair must be replaced by atomic ln -sfn"
-    )
+    assert (
+        'ln -sfn "$VENV_DIR/bin/unsloth" "$_shim_path"' in block
+    ), "install.sh must use ln -sfn for atomic shim replacement"
+    assert (
+        'rm -f -- "$_shim_path"' not in block
+    ), "the explicit rm + ln pair must be replaced by atomic ln -sfn"
 
 
 def test_install_sh_create_shortcuts_seeds_id_from_csprng_with_python_fallback(tmp_path):
@@ -601,13 +601,13 @@ def test_install_sh_create_shortcuts_seeds_id_from_csprng_with_python_fallback(t
     block = src[fn_start : fn_start + 3000]
     urandom_idx = block.index("od -An -N32 -tx1 /dev/urandom")
     py_fallback_idx = block.index("python3 -c 'import secrets;", urandom_idx)
-    assert urandom_idx < py_fallback_idx, (
-        "/dev/urandom must be tried before the python3 secrets fallback"
-    )
+    assert (
+        urandom_idx < py_fallback_idx
+    ), "/dev/urandom must be tried before the python3 secrets fallback"
     # Non-empty id file check before generation is what makes re-runs idempotent.
-    assert 'if [ ! -s "$_css_id_file" ]; then' in block, (
-        "install.sh must skip id generation when the file already has content"
-    )
+    assert (
+        'if [ ! -s "$_css_id_file" ]; then' in block
+    ), "install.sh must skip id generation when the file already has content"
 
     # Behavioral check: run the generation block twice to confirm idempotence.
     studio_home = tmp_path / "studio"
@@ -634,9 +634,9 @@ def test_install_sh_create_shortcuts_seeds_id_from_csprng_with_python_fallback(t
     assert res.returncode == 0, res.stderr
     out = dict(line.split("=", 1) for line in res.stdout.strip().splitlines() if "=" in line)
     assert out.get("LEN") == "64", f"id must be 64 hex chars, got LEN={out.get('LEN')!r}"
-    assert all(c in "0123456789abcdef" for c in out.get("ID", "")), (
-        f"id must be lowercase hex, got {out.get('ID')!r}"
-    )
+    assert all(
+        c in "0123456789abcdef" for c in out.get("ID", "")
+    ), f"id must be lowercase hex, got {out.get('ID')!r}"
 
 
 def test_install_sh_create_shortcuts_fails_fast_when_no_entropy():
@@ -644,30 +644,30 @@ def test_install_sh_create_shortcuts_fails_fast_when_no_entropy():
     src = INSTALL_SH.read_text(encoding = "utf-8")
     fn_start = src.index('_css_data_dir="$DATA_DIR"')
     block = src[fn_start : fn_start + 3000]
-    assert "[WARN] Cannot create launcher: no entropy source for studio_install_id" in block, (
-        "install.sh must warn when neither urandom nor python3 is available"
-    )
-    assert "[WARN] Cannot create launcher: failed to read" in block, (
-        "install.sh must warn when the id file read produces no content"
-    )
-    assert block.count("return 1") >= 2, (
-        "both the no-entropy branch and the empty-read branch must `return 1`"
-    )
+    assert (
+        "[WARN] Cannot create launcher: no entropy source for studio_install_id" in block
+    ), "install.sh must warn when neither urandom nor python3 is available"
+    assert (
+        "[WARN] Cannot create launcher: failed to read" in block
+    ), "install.sh must warn when the id file read produces no content"
+    assert (
+        block.count("return 1") >= 2
+    ), "both the no-entropy branch and the empty-read branch must `return 1`"
 
 
 def test_install_sh_bakes_installed_is_env_mode_flag_in_launcher():
     """install.sh must bake the install-time mode into the launcher so a sourced studio.conf can't flip it."""
     src = INSTALL_SH.read_text(encoding = "utf-8")
-    assert "_INSTALLED_IS_ENV_MODE='@@INSTALLED_IS_ENV_MODE@@'" in src, (
-        "launcher heredoc must declare _INSTALLED_IS_ENV_MODE='@@INSTALLED_IS_ENV_MODE@@'"
-    )
+    assert (
+        "_INSTALLED_IS_ENV_MODE='@@INSTALLED_IS_ENV_MODE@@'" in src
+    ), "launcher heredoc must declare _INSTALLED_IS_ENV_MODE='@@INSTALLED_IS_ENV_MODE@@'"
     assert "_css_is_env_mode=false" in src, "install.sh must default _css_is_env_mode to false"
-    assert '[ "$_STUDIO_HOME_REDIRECT" = "env" ] && _css_is_env_mode=true' in src, (
-        "install.sh must set _css_is_env_mode=true only when _STUDIO_HOME_REDIRECT=env"
-    )
-    assert "s|@@INSTALLED_IS_ENV_MODE@@|$_css_is_env_mode|g" in src, (
-        "install.sh sed pipeline must substitute @@INSTALLED_IS_ENV_MODE@@"
-    )
+    assert (
+        '[ "$_STUDIO_HOME_REDIRECT" = "env" ] && _css_is_env_mode=true' in src
+    ), "install.sh must set _css_is_env_mode=true only when _STUDIO_HOME_REDIRECT=env"
+    assert (
+        "s|@@INSTALLED_IS_ENV_MODE@@|$_css_is_env_mode|g" in src
+    ), "install.sh sed pipeline must substitute @@INSTALLED_IS_ENV_MODE@@"
 
 
 def test_install_sh_launcher_gates_port_file_on_baked_flag_not_runtime_env():
@@ -676,16 +676,16 @@ def test_install_sh_launcher_gates_port_file_on_baked_flag_not_runtime_env():
     heredoc_start = src.index("cat > \"$_css_launcher\" << 'LAUNCHER_EOF'")
     heredoc_end = src.index("LAUNCHER_EOF\n", heredoc_start)
     heredoc = src[heredoc_start:heredoc_end]
-    assert 'if [ "$_INSTALLED_IS_ENV_MODE" = "true" ]; then' in heredoc, (
-        "launcher must gate PORT_FILE/LOCK_DIR on baked _INSTALLED_IS_ENV_MODE"
-    )
+    assert (
+        'if [ "$_INSTALLED_IS_ENV_MODE" = "true" ]; then' in heredoc
+    ), "launcher must gate PORT_FILE/LOCK_DIR on baked _INSTALLED_IS_ENV_MODE"
     port_block_start = heredoc.index('if [ "$_INSTALLED_IS_ENV_MODE" = "true" ]; then')
     port_block_end = heredoc.index("\nfi\n", port_block_start) + len("\nfi\n")
     port_block = heredoc[port_block_start:port_block_end]
     assert 'PORT_FILE="$DATA_DIR/studio.port"' in port_block
-    assert 'if [ -n "${UNSLOTH_STUDIO_HOME:-}" ]; then\n    if command -v cksum' not in heredoc, (
-        "launcher must NOT gate PORT_FILE on runtime UNSLOTH_STUDIO_HOME"
-    )
+    assert (
+        'if [ -n "${UNSLOTH_STUDIO_HOME:-}" ]; then\n    if command -v cksum' not in heredoc
+    ), "launcher must NOT gate PORT_FILE on runtime UNSLOTH_STUDIO_HOME"
 
     def _run_launcher_gate(installed_flag: str, runtime_env: dict) -> str:
         # Run the LOCK_DIR/PORT_FILE init block in isolation.
@@ -709,30 +709,30 @@ def test_install_sh_launcher_gates_port_file_on_baked_flag_not_runtime_env():
         return ""
 
     # default-mode must keep PORT_FILE empty even if UNSLOTH_STUDIO_HOME leaks in.
-    assert _run_launcher_gate("false", {"UNSLOTH_STUDIO_HOME": "/tmp/leaked"}) == "", (
-        "default-mode launcher must keep PORT_FILE empty even with UNSLOTH_STUDIO_HOME in env"
-    )
+    assert (
+        _run_launcher_gate("false", {"UNSLOTH_STUDIO_HOME": "/tmp/leaked"}) == ""
+    ), "default-mode launcher must keep PORT_FILE empty even with UNSLOTH_STUDIO_HOME in env"
     # env-mode must set PORT_FILE regardless of runtime env.
-    assert _run_launcher_gate("true", {}) == "/tmp/test_data_dir/studio.port", (
-        "env-mode launcher must set PORT_FILE based on baked DATA_DIR"
-    )
+    assert (
+        _run_launcher_gate("true", {}) == "/tmp/test_data_dir/studio.port"
+    ), "env-mode launcher must set PORT_FILE based on baked DATA_DIR"
 
 
 def test_main_py_studio_root_id_caches_at_module_load():
     """_studio_root_id() must read the id once at module load and reuse it (no per-poll FS/hash work)."""
     main_py = (REPO_ROOT / "studio" / "backend" / "main.py").read_text()
-    assert "_STUDIO_ROOT_ID_CACHE: str = _read_studio_install_id()" in main_py, (
-        "main.py must populate _STUDIO_ROOT_ID_CACHE from _read_studio_install_id() at module load"
-    )
+    assert (
+        "_STUDIO_ROOT_ID_CACHE: str = _read_studio_install_id()" in main_py
+    ), "main.py must populate _STUDIO_ROOT_ID_CACHE from _read_studio_install_id() at module load"
     fn_idx = main_py.index("def _studio_root_id() -> str:")
     next_def_idx = main_py.index("\ndef ", fn_idx + 1)
     fn_block = main_py[fn_idx:next_def_idx]
-    assert "return _STUDIO_ROOT_ID_CACHE" in fn_block, (
-        "_studio_root_id() body must return the cached value"
-    )
-    assert "read_text(" not in fn_block and "hashlib" not in fn_block, (
-        "_studio_root_id() must NOT do filesystem or hash work on every call"
-    )
+    assert (
+        "return _STUDIO_ROOT_ID_CACHE" in fn_block
+    ), "_studio_root_id() body must return the cached value"
+    assert (
+        "read_text(" not in fn_block and "hashlib" not in fn_block
+    ), "_studio_root_id() must NOT do filesystem or hash work on every call"
 
 
 def test_main_py_read_studio_install_id_validates_hex_and_handles_missing(tmp_path, monkeypatch):
@@ -790,16 +790,15 @@ def test_llama_cpp_search_roots_handles_studio_root_oserror():
         nxt = llama_cpp.find(f"\n{indent}def ", start + 1)
         return llama_cpp[start : nxt if nxt != -1 else len(llama_cpp)]
 
-    assert "except (ImportError, OSError, ValueError):" in _method_body(
-        "_resolved_studio_root_and_is_legacy"
-    ), (
-        "_resolved_studio_root_and_is_legacy must catch (ImportError, OSError, ValueError) from studio_root()"
-    )
+    assert (
+        "except (ImportError, OSError, ValueError):"
+        in _method_body("_resolved_studio_root_and_is_legacy")
+    ), "_resolved_studio_root_and_is_legacy must catch (ImportError, OSError, ValueError) from studio_root()"
     # Both callers must route through the shared classifier so neither crashes.
     for caller in ("_find_llama_server_binary", "_kill_orphaned_servers"):
-        assert "LlamaCppBackend._resolved_studio_root_and_is_legacy()" in _method_body(caller), (
-            f"{caller} must resolve the install root via the shared classifier"
-        )
+        assert "LlamaCppBackend._resolved_studio_root_and_is_legacy()" in _method_body(
+            caller
+        ), f"{caller} must resolve the install root via the shared classifier"
 
 
 def test_install_sh_install_id_survives_symlinked_studio_home(tmp_path):
@@ -835,9 +834,9 @@ def test_install_sh_substitutes_root_id_before_data_dir():
         "@@STUDIO_ROOT_ID@@ substitution must happen BEFORE @@DATA_DIR@@ "
         "(non-user-controlled placeholders first)"
     )
-    assert env_mode_idx < data_dir_idx, (
-        "@@INSTALLED_IS_ENV_MODE@@ substitution must happen BEFORE @@DATA_DIR@@"
-    )
+    assert (
+        env_mode_idx < data_dir_idx
+    ), "@@INSTALLED_IS_ENV_MODE@@ substitution must happen BEFORE @@DATA_DIR@@"
 
 
 def test_install_sh_root_id_pass_does_not_mutate_user_data_dir(tmp_path):
@@ -866,12 +865,12 @@ sed "s|@@DATA_DIR@@|$_sed_safe|g" "{launcher_path}" > "{launcher_path}.tmp" \\
 """
     subprocess.run(["bash", "-c", script], check = True)
     final = launcher_path.read_text()
-    assert f"DATA_DIR='{weird_data_dir}'" in final, (
-        f"DATA_DIR must be preserved verbatim (no @@STUDIO_ROOT_ID@@ mutation); got: {final[:500]}"
-    )
-    assert f"_EXPECTED_STUDIO_ROOT_ID='{root_id}'" in final, (
-        "STUDIO_ROOT_ID placeholder must still be substituted in the launcher heredoc"
-    )
+    assert (
+        f"DATA_DIR='{weird_data_dir}'" in final
+    ), f"DATA_DIR must be preserved verbatim (no @@STUDIO_ROOT_ID@@ mutation); got: {final[:500]}"
+    assert (
+        f"_EXPECTED_STUDIO_ROOT_ID='{root_id}'" in final
+    ), "STUDIO_ROOT_ID placeholder must still be substituted in the launcher heredoc"
 
 
 def test_install_ps1_install_id_file_layout_matches_backend_read_path():
@@ -879,15 +878,15 @@ def test_install_ps1_install_id_file_layout_matches_backend_read_path():
     src = INSTALL_PS1.read_text(encoding = "utf-8")
     id_idx = src.index('$_studioIdDir = Join-Path $StudioHome "share"')
     context = src[id_idx : id_idx + 1500]
-    assert '$_studioIdFile = Join-Path $_studioIdDir "studio_install_id"' in context, (
-        "install.ps1 must persist the id at $StudioHome\\share\\studio_install_id"
-    )
-    assert "Test-Path -LiteralPath $_studioIdFile" in context, (
-        "install.ps1 must skip id generation when the file already has content (re-run idempotence)"
-    )
-    assert "RandomNumberGenerator" in context and "GetBytes($_idBytes)" in context, (
-        "install.ps1 must seed new ids from a CSPRNG (RandomNumberGenerator)"
-    )
-    assert "Move-Item -LiteralPath $_idTmp" in context, (
-        "install.ps1 must atomic-rename the temp file into place to avoid half-written ids"
-    )
+    assert (
+        '$_studioIdFile = Join-Path $_studioIdDir "studio_install_id"' in context
+    ), "install.ps1 must persist the id at $StudioHome\\share\\studio_install_id"
+    assert (
+        "Test-Path -LiteralPath $_studioIdFile" in context
+    ), "install.ps1 must skip id generation when the file already has content (re-run idempotence)"
+    assert (
+        "RandomNumberGenerator" in context and "GetBytes($_idBytes)" in context
+    ), "install.ps1 must seed new ids from a CSPRNG (RandomNumberGenerator)"
+    assert (
+        "Move-Item -LiteralPath $_idTmp" in context
+    ), "install.ps1 must atomic-rename the temp file into place to avoid half-written ids"

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -564,7 +564,7 @@ def test_tauri_preflight_scrubs_studio_home_env():
         preflight_root / "preflight.rs",
         *(preflight_root / "preflight").glob("*.rs"),
     ]
-    preflight = "\n".join(p.read_text() for p in preflight_paths if p.exists())
+    preflight = "\n".join(p.read_text(encoding = "utf-8") for p in preflight_paths if p.exists())
     commands = (REPO_ROOT / "studio" / "src-tauri" / "src" / "commands.rs").read_text(
         encoding = "utf-8"
     )

--- a/tests/test_studio_root_resilience.py
+++ b/tests/test_studio_root_resilience.py
@@ -64,7 +64,7 @@ def test_kill_orphan_catches_oserror_from_studio_root():
     """Cleanup must not crash when studio_root() raises. _kill_orphaned_servers
     resolves the install root through the shared _resolved_studio_root_and_is_legacy()
     classifier, which swallows (ImportError, OSError, ValueError) on the probe."""
-    src = LLAMA_CPP.read_text()
+    src = LLAMA_CPP.read_text(encoding = "utf-8")
     # Cleanup delegates to the shared classifier rather than importing studio_root inline.
     assert "LlamaCppBackend._resolved_studio_root_and_is_legacy()" in _method_body(
         src, "_kill_orphaned_servers"
@@ -85,7 +85,7 @@ def _exec_search_roots_block(
     """Run _find_llama_server_binary's search_roots derivation -- plus the shared
     _resolved_studio_root_and_is_legacy() classifier it delegates to -- with a
     controlled studio_root() and resolve(), without importing the heavy module."""
-    src = LLAMA_CPP.read_text()
+    src = LLAMA_CPP.read_text(encoding = "utf-8")
     # Shared root classifier (holds the defensive try/except for studio_root()).
     # End the slice at the next sibling def/decorator at the same indent rather
     # than the literal "@staticmethod" string, so a future docstring mentioning a
@@ -143,9 +143,9 @@ def test_search_roots_keeps_custom_when_resolve_fails(tmp_path):
     # custom != legacy_studio so the custom root must remain in search_roots.
     assert custom / "llama.cpp" in roots, f"custom root dropped on resolve() failure: {roots}"
     # custom-mode discovery excludes the legacy tree to match _kill_orphaned_servers.
-    assert (
-        home / ".unsloth" / "llama.cpp"
-    ) not in roots, f"legacy llama path must not appear in custom-mode search_roots: {roots}"
+    assert (home / ".unsloth" / "llama.cpp") not in roots, (
+        f"legacy llama path must not appear in custom-mode search_roots: {roots}"
+    )
 
 
 def test_search_roots_default_mode_uses_legacy_only(tmp_path):

--- a/tests/test_studio_root_resilience.py
+++ b/tests/test_studio_root_resilience.py
@@ -143,9 +143,9 @@ def test_search_roots_keeps_custom_when_resolve_fails(tmp_path):
     # custom != legacy_studio so the custom root must remain in search_roots.
     assert custom / "llama.cpp" in roots, f"custom root dropped on resolve() failure: {roots}"
     # custom-mode discovery excludes the legacy tree to match _kill_orphaned_servers.
-    assert (home / ".unsloth" / "llama.cpp") not in roots, (
-        f"legacy llama path must not appear in custom-mode search_roots: {roots}"
-    )
+    assert (
+        home / ".unsloth" / "llama.cpp"
+    ) not in roots, f"legacy llama path must not appear in custom-mode search_roots: {roots}"
 
 
 def test_search_roots_default_mode_uses_legacy_only(tmp_path):

--- a/tests/test_tool_mask_zoo_compat.py
+++ b/tests/test_tool_mask_zoo_compat.py
@@ -15,7 +15,7 @@ RL_REPLACEMENTS_SOURCE_PATH = os.path.join(REPO_ROOT, "unsloth", "models", "rl_r
 
 
 def _read(path: str) -> str:
-    with open(path, "r") as fh:
+    with open(path, "r", encoding = "utf-8") as fh:
         return fh.read()
 
 

--- a/tests/utils/test_prepare_inputs_leftpad.py
+++ b/tests/utils/test_prepare_inputs_leftpad.py
@@ -207,7 +207,7 @@ def test_model_families_stay_wired_to_shared_prepare_inputs():
         path = REPO_ROOT / "unsloth" / "models" / fname
         if not path.exists():
             continue
-        if "fix_prepare_inputs_for_generation(" not in path.read_text():
+        if "fix_prepare_inputs_for_generation(" not in path.read_text(encoding = "utf-8"):
             missing.append(fname)
     assert not missing, (
         "these model files no longer call fix_prepare_inputs_for_generation, "

--- a/tests/utils/test_prepare_inputs_leftpad.py
+++ b/tests/utils/test_prepare_inputs_leftpad.py
@@ -119,17 +119,17 @@ def test_mask_derived_position_ids_branch_exists():
         "attention_mask.cumsum(...); reintroducing cache_position-based "
         "positions breaks left-padded batched generation (issue #3699)"
     )
-    assert "masked_fill_" in body_names or "masked_fill" in body_names, (
-        "the attention-mask branch must mask pad positions (masked_fill on mask == 0)"
-    )
+    assert (
+        "masked_fill_" in body_names or "masked_fill" in body_names
+    ), "the attention-mask branch must mask pad positions (masked_fill on mask == 0)"
     assigns_kwargs = any(
         isinstance(stmt, ast.Assign)
         and any(_is_kwargs_position_ids_target(t) for t in stmt.targets)
         for stmt in ast.walk(ast.Module(body = branch.body, type_ignores = []))
     )
-    assert assigns_kwargs, (
-        'the attention-mask branch must store the derived positions into kwargs["position_ids"]'
-    )
+    assert (
+        assigns_kwargs
+    ), 'the attention-mask branch must store the derived positions into kwargs["position_ids"]'
 
 
 def test_cache_position_only_used_as_fallback_for_position_ids():
@@ -305,9 +305,9 @@ def test_prefill_position_ids_derived_from_left_padded_mask():
     result = _prepare(FakeModel(), input_ids, MASK)
 
     position_ids = result.get("position_ids", None)
-    assert position_ids is not None, (
-        "prefill with a left-padded 2D attention mask must populate position_ids"
-    )
+    assert (
+        position_ids is not None
+    ), "prefill with a left-padded 2D attention mask must populate position_ids"
     assert torch.equal(position_ids.long().cpu(), EXPECTED_PREFILL_POSITIONS), (
         "prefill position_ids must be derived per row from the attention mask "
         "(cumsum - 1, pads masked), so each row starts counting at its first "
@@ -379,9 +379,9 @@ def test_caller_supplied_position_ids_are_passed_through():
     input_ids = torch.arange(BS * SEQ).reshape(BS, SEQ)
     custom = torch.full((BS, SEQ), 7, dtype = torch.long)
     result = _prepare(FakeModel(), input_ids, MASK, position_ids = custom)
-    assert torch.equal(result["position_ids"], custom), (
-        "caller-supplied position_ids must not be overwritten"
-    )
+    assert torch.equal(
+        result["position_ids"], custom
+    ), "caller-supplied position_ids must not be overwritten"
 
 
 def test_legacy_tuple_cache_still_takes_cached_decode_path():

--- a/tests/utils/test_prepare_inputs_leftpad.py
+++ b/tests/utils/test_prepare_inputs_leftpad.py
@@ -46,7 +46,7 @@ WIRED_MODEL_FILES = [
 
 
 def _load_function():
-    tree = ast.parse(LLAMA_PY.read_text())
+    tree = ast.parse(LLAMA_PY.read_text(encoding = "utf-8"))
     for node in ast.walk(tree):
         if isinstance(node, ast.FunctionDef) and node.name == FUNC_NAME:
             return node
@@ -119,17 +119,17 @@ def test_mask_derived_position_ids_branch_exists():
         "attention_mask.cumsum(...); reintroducing cache_position-based "
         "positions breaks left-padded batched generation (issue #3699)"
     )
-    assert (
-        "masked_fill_" in body_names or "masked_fill" in body_names
-    ), "the attention-mask branch must mask pad positions (masked_fill on mask == 0)"
+    assert "masked_fill_" in body_names or "masked_fill" in body_names, (
+        "the attention-mask branch must mask pad positions (masked_fill on mask == 0)"
+    )
     assigns_kwargs = any(
         isinstance(stmt, ast.Assign)
         and any(_is_kwargs_position_ids_target(t) for t in stmt.targets)
         for stmt in ast.walk(ast.Module(body = branch.body, type_ignores = []))
     )
-    assert (
-        assigns_kwargs
-    ), 'the attention-mask branch must store the derived positions into kwargs["position_ids"]'
+    assert assigns_kwargs, (
+        'the attention-mask branch must store the derived positions into kwargs["position_ids"]'
+    )
 
 
 def test_cache_position_only_used_as_fallback_for_position_ids():
@@ -305,9 +305,9 @@ def test_prefill_position_ids_derived_from_left_padded_mask():
     result = _prepare(FakeModel(), input_ids, MASK)
 
     position_ids = result.get("position_ids", None)
-    assert (
-        position_ids is not None
-    ), "prefill with a left-padded 2D attention mask must populate position_ids"
+    assert position_ids is not None, (
+        "prefill with a left-padded 2D attention mask must populate position_ids"
+    )
     assert torch.equal(position_ids.long().cpu(), EXPECTED_PREFILL_POSITIONS), (
         "prefill position_ids must be derived per row from the attention mask "
         "(cumsum - 1, pads masked), so each row starts counting at its first "
@@ -379,9 +379,9 @@ def test_caller_supplied_position_ids_are_passed_through():
     input_ids = torch.arange(BS * SEQ).reshape(BS, SEQ)
     custom = torch.full((BS, SEQ), 7, dtype = torch.long)
     result = _prepare(FakeModel(), input_ids, MASK, position_ids = custom)
-    assert torch.equal(
-        result["position_ids"], custom
-    ), "caller-supplied position_ids must not be overwritten"
+    assert torch.equal(result["position_ids"], custom), (
+        "caller-supplied position_ids must not be overwritten"
+    )
 
 
 def test_legacy_tuple_cache_still_takes_cached_decode_path():

--- a/tests/utils/test_rope_scaling_drift.py
+++ b/tests/utils/test_rope_scaling_drift.py
@@ -209,9 +209,9 @@ def test_llama3_scaling_applied_to_inv_freq():
     vanilla = _vanilla_inv_freq()
 
     # Guard against a vacuous test: scaled inv_freq must differ from vanilla.
-    assert not torch.allclose(expected, vanilla, rtol = 1e-4), (
-        "test setup error: llama3-scaled inv_freq should differ from vanilla"
-    )
+    assert not torch.allclose(
+        expected, vanilla, rtol = 1e-4
+    ), "test setup error: llama3-scaled inv_freq should differ from vanilla"
     assert got is not None, (
         "_compute_config_rope_inv_freq returned None for a llama3 config; the "
         "config path is dropping config.rope_scaling, so long-context inference "
@@ -267,9 +267,9 @@ def test_extended_rope_scaling_keeps_llama3_and_carries_theta():
 
     # llama3 model: keep native scaling, do not synthesize linear.
     scaling, native = _extended_rope_scaling(_make_config(LLAMA3_ROPE_SCALING), 2.0)
-    assert scaling is None and native == "llama3", (
-        "must keep native llama3 scaling instead of overwriting it with linear."
-    )
+    assert (
+        scaling is None and native == "llama3"
+    ), "must keep native llama3 scaling instead of overwriting it with linear."
 
     # yarn is not rebuildable by the patcher -> keep the safe linear fallback, not native.
     yarn = SimpleNamespace(rope_scaling = {"rope_type": "yarn", "factor": 2.0}, rope_theta = 500000.0)
@@ -366,9 +366,9 @@ def test_constructor_applies_llama3_scaling():
     rot = _unsloth_rotary(config)
     got = rot.inv_freq.float().cpu()
     expected = _reference_inv_freq(config, "llama3")
-    assert torch.allclose(got, expected, rtol = 1e-4, atol = 1e-6), (
-        "LlamaRotaryEmbedding built from a llama3 config produced unscaled inv_freq (issue #2405)."
-    )
+    assert torch.allclose(
+        got, expected, rtol = 1e-4, atol = 1e-6
+    ), "LlamaRotaryEmbedding built from a llama3 config produced unscaled inv_freq (issue #2405)."
 
 
 @requires_cuda
@@ -376,9 +376,9 @@ def test_constructor_unscaled_config_uses_vanilla_inv_freq():
     rot = _unsloth_rotary(_make_config(None))
     got = rot.inv_freq.float().cpu()
     vanilla = _vanilla_inv_freq()
-    assert torch.allclose(got, vanilla, rtol = 1e-4, atol = 1e-6), (
-        "LlamaRotaryEmbedding with no rope_scaling must use the vanilla inv_freq"
-    )
+    assert torch.allclose(
+        got, vanilla, rtol = 1e-4, atol = 1e-6
+    ), "LlamaRotaryEmbedding with no rope_scaling must use the vanilla inv_freq"
 
 
 @requires_cuda
@@ -477,9 +477,9 @@ def test_v5_blank_repair_roundtrip(build):
     assert snapshot, "rotary registers no buffers; nothing to guard"
 
     _blank_nonpersistent_buffers(rot)
-    assert any(not torch.equal(rot.get_buffer(name), snapshot[name]) for name in snapshot), (
-        "blanking changed no buffer; the round-trip would be vacuous"
-    )
+    assert any(
+        not torch.equal(rot.get_buffer(name), snapshot[name]) for name in snapshot
+    ), "blanking changed no buffer; the round-trip would be vacuous"
 
     wrapper = torch.nn.Module()
     wrapper.add_module("rotary_emb", rot)

--- a/tests/utils/test_rope_scaling_drift.py
+++ b/tests/utils/test_rope_scaling_drift.py
@@ -96,7 +96,7 @@ def _iter_names_and_calls(node):
 
 
 def _find_method(source_path, class_name, method_name):
-    for node in ast.walk(ast.parse(source_path.read_text())):
+    for node in ast.walk(ast.parse(source_path.read_text(encoding = "utf-8"))):
         if isinstance(node, ast.ClassDef) and node.name == class_name:
             for sub in node.body:
                 if isinstance(sub, ast.FunctionDef) and sub.name == method_name:
@@ -105,7 +105,7 @@ def _find_method(source_path, class_name, method_name):
 
 
 def _find_function(source_path, function_name):
-    for node in ast.walk(ast.parse(source_path.read_text())):
+    for node in ast.walk(ast.parse(source_path.read_text(encoding = "utf-8"))):
         if isinstance(node, ast.FunctionDef) and node.name == function_name:
             return node
     return None

--- a/tests/utils/test_rope_scaling_drift.py
+++ b/tests/utils/test_rope_scaling_drift.py
@@ -52,7 +52,7 @@ MAX_POS = 131072
 
 
 def _load_class_init():
-    tree = ast.parse(LLAMA_PY.read_text())
+    tree = ast.parse(LLAMA_PY.read_text(encoding = "utf-8"))
     for node in ast.walk(tree):
         if isinstance(node, ast.ClassDef) and node.name == CLASS_NAME:
             for sub in node.body:
@@ -209,9 +209,9 @@ def test_llama3_scaling_applied_to_inv_freq():
     vanilla = _vanilla_inv_freq()
 
     # Guard against a vacuous test: scaled inv_freq must differ from vanilla.
-    assert not torch.allclose(
-        expected, vanilla, rtol = 1e-4
-    ), "test setup error: llama3-scaled inv_freq should differ from vanilla"
+    assert not torch.allclose(expected, vanilla, rtol = 1e-4), (
+        "test setup error: llama3-scaled inv_freq should differ from vanilla"
+    )
     assert got is not None, (
         "_compute_config_rope_inv_freq returned None for a llama3 config; the "
         "config path is dropping config.rope_scaling, so long-context inference "
@@ -267,9 +267,9 @@ def test_extended_rope_scaling_keeps_llama3_and_carries_theta():
 
     # llama3 model: keep native scaling, do not synthesize linear.
     scaling, native = _extended_rope_scaling(_make_config(LLAMA3_ROPE_SCALING), 2.0)
-    assert (
-        scaling is None and native == "llama3"
-    ), "must keep native llama3 scaling instead of overwriting it with linear."
+    assert scaling is None and native == "llama3", (
+        "must keep native llama3 scaling instead of overwriting it with linear."
+    )
 
     # yarn is not rebuildable by the patcher -> keep the safe linear fallback, not native.
     yarn = SimpleNamespace(rope_scaling = {"rope_type": "yarn", "factor": 2.0}, rope_theta = 500000.0)
@@ -366,9 +366,9 @@ def test_constructor_applies_llama3_scaling():
     rot = _unsloth_rotary(config)
     got = rot.inv_freq.float().cpu()
     expected = _reference_inv_freq(config, "llama3")
-    assert torch.allclose(
-        got, expected, rtol = 1e-4, atol = 1e-6
-    ), "LlamaRotaryEmbedding built from a llama3 config produced unscaled inv_freq (issue #2405)."
+    assert torch.allclose(got, expected, rtol = 1e-4, atol = 1e-6), (
+        "LlamaRotaryEmbedding built from a llama3 config produced unscaled inv_freq (issue #2405)."
+    )
 
 
 @requires_cuda
@@ -376,9 +376,9 @@ def test_constructor_unscaled_config_uses_vanilla_inv_freq():
     rot = _unsloth_rotary(_make_config(None))
     got = rot.inv_freq.float().cpu()
     vanilla = _vanilla_inv_freq()
-    assert torch.allclose(
-        got, vanilla, rtol = 1e-4, atol = 1e-6
-    ), "LlamaRotaryEmbedding with no rope_scaling must use the vanilla inv_freq"
+    assert torch.allclose(got, vanilla, rtol = 1e-4, atol = 1e-6), (
+        "LlamaRotaryEmbedding with no rope_scaling must use the vanilla inv_freq"
+    )
 
 
 @requires_cuda
@@ -477,9 +477,9 @@ def test_v5_blank_repair_roundtrip(build):
     assert snapshot, "rotary registers no buffers; nothing to guard"
 
     _blank_nonpersistent_buffers(rot)
-    assert any(
-        not torch.equal(rot.get_buffer(name), snapshot[name]) for name in snapshot
-    ), "blanking changed no buffer; the round-trip would be vacuous"
+    assert any(not torch.equal(rot.get_buffer(name), snapshot[name]) for name in snapshot), (
+        "blanking changed no buffer; the round-trip would be vacuous"
+    )
 
     wrapper = torch.nn.Module()
     wrapper.add_module("rotary_emb", rot)

--- a/unsloth_cli/__init__.py
+++ b/unsloth_cli/__init__.py
@@ -4,20 +4,27 @@
 import os as _os
 import sys as _sys
 
+# Are we the `unsloth` console script, rather than a library import? Both the
+# stream guard below and the `-np<N>` rewrite further down are entry-point
+# behaviour and must not reach into a host application that imports us.
+_entry_base = _os.path.basename(_sys.argv[0]).lower() if _sys.argv else ""
+_is_entry_point = _entry_base in {"unsloth", "unsloth.exe"}
+
 # Typer renders help via rich, whose box characters cp1252 and cp437 cannot encode,
 # so `unsloth --help` dies once stdout is a pipe or a file. Windows gets UTF-8, as
 # unsloth/__init__ already does; elsewhere the caller's encoding is kept and only
 # the error handler is relaxed, so an explicit PYTHONIOENCODING still picks the
 # bytes and only loses unencodable glyphs. Before typer, which binds the stream.
-_to_utf8 = _sys.platform == "win32"
-for _name in ("stdout", "stderr"):
-    _stream = getattr(_sys, _name, None)
-    try:
-        if "utf" not in (_stream.encoding or "").lower():
-            _stream.reconfigure(encoding = "utf-8" if _to_utf8 else None, errors = "replace")
-    except Exception:
-        pass
-del _name, _stream, _to_utf8
+if _is_entry_point:
+    _to_utf8 = _sys.platform == "win32"
+    for _name in ("stdout", "stderr"):
+        _stream = getattr(_sys, _name, None)
+        try:
+            if "utf" not in (_stream.encoding or "").lower():
+                _stream.reconfigure(encoding = "utf-8" if _to_utf8 else None, errors = "replace")
+        except Exception:
+            pass
+    del _name, _stream, _to_utf8
 
 import typer
 from importlib.metadata import version as package_version, PackageNotFoundError
@@ -37,10 +44,9 @@ from unsloth_cli.commands.studio import (
 
 # Canonicalise `-np<N>` only under the `unsloth` console-script;
 # third-party scripts that import unsloth_cli keep their argv intact.
-_entry_base = _os.path.basename(_sys.argv[0]).lower() if _sys.argv else ""
-if _entry_base in {"unsloth", "unsloth.exe"}:
+if _is_entry_point:
     _expand_attached_np_short()
-del _entry_base
+del _entry_base, _is_entry_point
 
 
 def show_version(value: bool):

--- a/unsloth_cli/__init__.py
+++ b/unsloth_cli/__init__.py
@@ -4,6 +4,20 @@
 import os as _os
 import sys as _sys
 
+# Typer renders help through rich, which draws box characters cp1252 and cp437
+# cannot encode, so `unsloth --help` dies once stdout is a pipe or a file. The
+# same guard runs in unsloth/__init__.py, but the CLI does not import that just
+# to print help. Must happen before typer, which binds the stream encoding.
+for _name in ("stdout", "stderr"):
+    _stream = getattr(_sys, _name, None)
+    try:
+        _encoding = (getattr(_stream, "encoding", None) or "").lower()
+        if _stream is not None and hasattr(_stream, "reconfigure") and "utf" not in _encoding:
+            _stream.reconfigure(encoding = "utf-8", errors = "replace")
+    except Exception:
+        pass
+del _name, _stream, _encoding
+
 import typer
 from importlib.metadata import version as package_version, PackageNotFoundError
 

--- a/unsloth_cli/__init__.py
+++ b/unsloth_cli/__init__.py
@@ -5,16 +5,19 @@ import os as _os
 import sys as _sys
 
 # Typer renders help via rich, whose box characters cp1252 and cp437 cannot encode,
-# so `unsloth --help` dies once stdout is a pipe or a file. unsloth/__init__ guards
-# this too, but the CLI skips it; must run before typer binds the stream encoding.
+# so `unsloth --help` dies once stdout is a pipe or a file. Windows gets UTF-8, as
+# unsloth/__init__ already does; elsewhere the caller's encoding is kept and only
+# the error handler is relaxed, so an explicit PYTHONIOENCODING still picks the
+# bytes and only loses unencodable glyphs. Before typer, which binds the stream.
+_to_utf8 = _sys.platform == "win32"
 for _name in ("stdout", "stderr"):
     _stream = getattr(_sys, _name, None)
     try:
         if "utf" not in (_stream.encoding or "").lower():
-            _stream.reconfigure(encoding = "utf-8", errors = "replace")
+            _stream.reconfigure(encoding = "utf-8" if _to_utf8 else None, errors = "replace")
     except Exception:
         pass
-del _name, _stream
+del _name, _stream, _to_utf8
 
 import typer
 from importlib.metadata import version as package_version, PackageNotFoundError

--- a/unsloth_cli/__init__.py
+++ b/unsloth_cli/__init__.py
@@ -4,19 +4,17 @@
 import os as _os
 import sys as _sys
 
-# Typer renders help through rich, which draws box characters cp1252 and cp437
-# cannot encode, so `unsloth --help` dies once stdout is a pipe or a file. The
-# same guard runs in unsloth/__init__.py, but the CLI does not import that just
-# to print help. Must happen before typer, which binds the stream encoding.
+# Typer renders help via rich, whose box characters cp1252 and cp437 cannot encode,
+# so `unsloth --help` dies once stdout is a pipe or a file. unsloth/__init__ guards
+# this too, but the CLI skips it; must run before typer binds the stream encoding.
 for _name in ("stdout", "stderr"):
     _stream = getattr(_sys, _name, None)
     try:
-        _encoding = (getattr(_stream, "encoding", None) or "").lower()
-        if _stream is not None and hasattr(_stream, "reconfigure") and "utf" not in _encoding:
+        if "utf" not in (_stream.encoding or "").lower():
             _stream.reconfigure(encoding = "utf-8", errors = "replace")
     except Exception:
         pass
-del _name, _stream, _encoding
+del _name, _stream
 
 import typer
 from importlib.metadata import version as package_version, PackageNotFoundError

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -587,7 +587,9 @@ def test_write_codex_config_profile(tmp_path, monkeypatch):
     assert catalog["models"][0]["supports_reasoning_summary_parameter"] is False
     assert catalog["models"][0]["supports_parallel_tool_calls"] is False
 
-    assert catalog["models"][0]["base_instructions"] == start._CODEX_FALLBACK_PROMPT.read_text()
+    assert catalog["models"][0]["base_instructions"] == start._CODEX_FALLBACK_PROMPT.read_text(
+        encoding = "utf-8"
+    )
     config = _parse_toml((tmp_path / "config.toml").read_text())
     assert config["model_providers"]["unsloth_api"]["env_key"] == "UNSLOTH_STUDIO_AUTH_TOKEN"
 
@@ -631,7 +633,7 @@ def test_write_codex_subagent_bridge_keeps_parent_credentials_out(tmp_path, monk
         tmp_path,
         yolo = False,
     )
-    assert json.loads(path.read_text()) == {
+    assert json.loads(path.read_text(encoding = "utf-8")) == {
         "api_key": "private-token",
         "codex_home": str(tmp_path / "child"),
         "bypass_permissions": False,


### PR DESCRIPTION
## The bug

`Path.read_text()` with no `encoding` uses `locale.getpreferredencoding()`: UTF-8 on the Linux runners, **cp1252** on a stock Windows install. Nine module-level reads of checked-in source files were relying on that default.

`studio/backend/routes/inference.py` carries the DeepSeek tool-call token regexes, so it holds U+FF5C and U+2581. Under cp1252 that read raises:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 97806
```

Because the reads run at import time, this doesn't show up as a test failure. It takes `test_cancel_atomicity.py` and `test_cancel_id_wiring.py` out at **collection**, so 20 tests silently don't run. Green on CI, permanently broken for a Windows contributor running the suite locally.

## The fix

Pass `encoding = "utf-8"` at the 9 sites. The repo already spells it that way in 464 other places, so this just aligns the stragglers with existing house style.

## The guard

`tests/test_source_read_encoding.py` keeps it from coming back.

The trick that makes it enforceable: **at module scope there is no `tmp_path` fixture**, so a bare `read_text()` / `write_text()` / `open()` there is always touching a checked-in file. That makes the rule mechanical with **no allowlist and no false positives**, while staying quiet about temp-dir I/O inside test bodies where the platform default is harmless. Binary-mode `open()` is skipped since it has no encoding to name.

Uses only `ast` and `pathlib`: no new dependencies. It sits at `tests/` root, which `repo-cpu-tests` already auto-discovers, so no workflow change is needed.

## Verification

- Collection on Windows: **4103 collected / 50 errors → 4124 collected / 48 errors**. The +21 is 20 recovered tests plus the new guard. Precisely additive, nothing else moved.
- Stashing the encoding fixes makes the guard fail and list all 13 offending sites, so it does catch the bug it's written for.
- 29 tests pass locally.
- `scripts/enforce_kwargs_spacing.py` clean, `ruff check` clean, and the diff is already run through the repo's own `scripts/run_ruff_format.py` (ruff 0.6.9) so pre-commit.ci has nothing to reformat.

## Scope

Test-only. No runtime or user-facing behavior changes.

Not covered here: `tests/python/test_e2e_no_torch_sandbox.py` builds `open(...)` snippets that run in subprocesses and hit the same decode error through a different mechanism. Different fix, separate PR.
