### PR TITLE
fix(studio/colab): show the login password in the shareable link card

### DIFF
--- a/studio/backend/colab.py
+++ b/studio/backend/colab.py
@@ -579,6 +579,7 @@ def _show_and_embed(
     if cloudflare_url:
         try:
             from IPython.display import HTML, display
+
             username, password = colab_login if colab_login else (None, None)
             display(HTML(_shareable_link_html(cloudflare_url, password, username)))
             credentials_shown = bool(colab_login)

--- a/studio/backend/colab.py
+++ b/studio/backend/colab.py
@@ -218,11 +218,10 @@ def _colab_login_html(username: str, password: str) -> str:
             Unsloth Studio Login (Colab)
         </h2>
         <p style="color: #333333; margin: 0 0 12px 0; font-size: 14px; font-weight: bold;">
-            Log in to Studio with the Cloudflare link above using these credentials. This cell
-            is visible only in your notebook session.
+            Log in as <code>{username}</code> with this password. This cell is visible only in
+            your notebook session.
         </p>
         <p style="color: #333333; margin: 0; font-size: 14px; font-family: monospace; font-weight: bold;">
-            Username: <code>{username}</code><br>
             Password: <code>{password}</code>
         </p>
     </div>
@@ -441,8 +440,27 @@ def _is_studio_healthy(port: int, timeout: float = 2.0) -> bool:
         return False
 
 
-def _shareable_link_html(cloudflare_url: str) -> str:
-    """Branded card for the shareable Cloudflare link, styled like the show_link banner."""
+def _shareable_link_html(
+    cloudflare_url: str,
+    password: "str | None" = None,
+    username: "str | None" = None,
+) -> str:
+    """Branded card for the shareable Cloudflare link, styled like the show_link banner.
+
+    When *password* is given it is shown directly under the link, so the credential the
+    user needs sits in the same card as the button they click. The username is always the
+    default admin, so it is stated inline in prose rather than as its own labelled field.
+    """
+    login_block = ""
+    if password:
+        login_block = f"""
+        <p style="color: #333333; margin: 12px 0 0 0; font-size: 14px; font-weight: bold;">
+            Password: <code style="background:#f3f3f3;padding:2px 6px;border-radius:4px;">{password}</code>
+        </p>
+        <p style="color: #666666; margin: 4px 0 0 0; font-size: 12px;">
+            Log in as <code>{username}</code> with this password. Shown only in your
+            notebook session, and never included in the shared link.
+        </p>"""
     return f"""
     <div style="display: inline-block; padding: 20px; background: #ffffff; border: 2px solid #000000;
                 border-radius: 12px; margin: 10px 0; font-family: system-ui, -apple-system, sans-serif;">
@@ -460,11 +478,11 @@ def _shareable_link_html(cloudflare_url: str) -> str:
             Open Unsloth Studio
         </a>
         <p style="color: #333333; margin: 12px 0 0 0; font-size: 14px; font-weight: bold;">
-            This Cloudflare HTTPS link works from any device — share it with anyone. The Colab view below only works in this tab.
+            This Cloudflare HTTPS link works from any device — share it with anyone.
         </p>
         <p style="color: #333333; margin: 16px 0 0 0; font-size: 13px; font-family: monospace; font-weight: bold;">
             🔗 {cloudflare_url}
-        </p>
+        </p>{login_block}
     </div>
     """
 
@@ -555,28 +573,39 @@ def _show_and_embed(
         cloudflare_url = cloudflare_url,
     )
 
+    # The credentials belong next to the button they unlock, so fold them into the
+    # shareable-link card instead of rendering a separate login card below it.
+    credentials_shown = False
     if cloudflare_url:
         try:
             from IPython.display import HTML, display
-            display(HTML(_shareable_link_html(cloudflare_url)))
+            username, password = colab_login if colab_login else (None, None)
+            display(HTML(_shareable_link_html(cloudflare_url, password, username)))
+            credentials_shown = bool(colab_login)
         except Exception as e:
             logger.info(f"Could not render Cloudflare link card ({e}).")
 
-    if colab_login:
+    if colab_login and not credentials_shown:
         try:
             _show_colab_login_credentials(*colab_login)
         except Exception as e:
             logger.info(f"Could not render Colab login card ({e}).")
 
-    try:
-        show_link(
-            port,
-            _url = url,
-            has_cloudflare_link = bool(cloudflare_url),
-            cloudflare_requested = cloudflare_requested,
-        )
-    except Exception as e:
-        logger.info(f"Could not render Unsloth link card ({e}).")
+    # On Colab with a working tunnel the in-cell proxy embed is skipped below (it usually
+    # renders blank), so the ready card would only restate the link card above and print a
+    # proxy URL that 404s outside this tab. Skip it and keep the tunnel card as the one
+    # entry point.
+    skip_ready_card = _is_colab_runtime() and bool(cloudflare_url)
+    if not skip_ready_card:
+        try:
+            show_link(
+                port,
+                _url = url,
+                has_cloudflare_link = bool(cloudflare_url),
+                cloudflare_requested = cloudflare_requested,
+            )
+        except Exception as e:
+            logger.info(f"Could not render Unsloth link card ({e}).")
 
     # On Colab with a working tunnel, skip the in-cell proxy embed (often blank).
     if _is_colab_runtime() and cloudflare_url:

--- a/studio/backend/tests/test_colab_embed.py
+++ b/studio/backend/tests/test_colab_embed.py
@@ -336,17 +336,45 @@ def test_colab_login_html_includes_credentials():
     html = colab._colab_login_html("unsloth", "alpha-beta-gamma-delta")
     assert "unsloth" in html
     assert "alpha-beta-gamma-delta" in html
+    # The username is fixed, so it reads inline rather than as its own field.
+    assert "Username:" not in html
 
 
-def test_show_and_embed_renders_cloudflare_before_colab_login(monkeypatch):
+def test_shareable_link_html_embeds_password_under_the_link():
+    """The credential belongs in the same card as the button it unlocks (#7404 follow-up)."""
+    html = colab._shareable_link_html(
+        "https://share.trycloudflare.com", "secret-pass", "unsloth"
+    )
+    assert "share.trycloudflare.com" in html
+    assert "secret-pass" in html
+    # Username is stated inline, not as its own labelled field.
+    assert "Username:" not in html
+    assert "unsloth" in html
+    # The password must sit after the link, not above it.
+    assert html.index("share.trycloudflare.com") < html.index("secret-pass")
+
+
+def test_shareable_link_html_omits_login_block_without_password():
+    html = colab._shareable_link_html("https://share.trycloudflare.com")
+    assert "Password:" not in html
+
+
+def test_show_and_embed_folds_login_into_the_cloudflare_card(monkeypatch):
+    """One card, not two: the tunnel card carries the password itself."""
     displayed: list[str] = []
     ipython_display = SimpleNamespace(
         HTML = lambda html: SimpleNamespace(html = html),
         display = lambda html: displayed.append(html.html),
     )
+    login_cards: list[tuple] = []
 
     monkeypatch.setattr(colab, "get_colab_url", lambda port: "https://8888-test.prod.colab.dev/")
     monkeypatch.setattr(colab, "_is_colab_runtime", lambda: True)
+    monkeypatch.setattr(
+        colab,
+        "_show_colab_login_credentials",
+        lambda *args: login_cards.append(args),
+    )
     monkeypatch.setattr(
         colab,
         "show_link",
@@ -360,9 +388,66 @@ def test_show_and_embed_renders_cloudflare_before_colab_login(monkeypatch):
             colab_login = ("unsloth", "secret-pass"),
         )
 
-    assert len(displayed) == 2
+    assert len(displayed) == 1
     assert "share.trycloudflare.com" in displayed[0]
-    assert "secret-pass" in displayed[1]
+    assert "secret-pass" in displayed[0]
+    assert login_cards == []
+
+
+def test_show_and_embed_keeps_separate_login_card_without_tunnel(monkeypatch):
+    """No tunnel card to fold into, so the standalone login card still renders."""
+    login_cards: list[tuple] = []
+
+    monkeypatch.setattr(colab, "get_colab_url", lambda port: "https://8888-test.prod.colab.dev/")
+    monkeypatch.setattr(colab, "_is_colab_runtime", lambda: True)
+    monkeypatch.setattr(
+        colab,
+        "_show_colab_login_credentials",
+        lambda *args: login_cards.append(args),
+    )
+    monkeypatch.setattr(
+        colab,
+        "show_link",
+        lambda port, *, _url = None, has_cloudflare_link = False, cloudflare_requested = False: None,
+    )
+    monkeypatch.setattr(colab, "_embed_kernel_port_iframe", lambda port: True)
+    colab._show_and_embed(8888, colab_login = ("unsloth", "secret-pass"))
+
+    assert login_cards == [("unsloth", "secret-pass")]
+
+
+def test_show_and_embed_skips_ready_card_when_tunnel_is_up(monkeypatch):
+    """The ready card only restates the tunnel card and prints a proxy URL that 404s."""
+    calls: list[str] = []
+
+    monkeypatch.setattr(colab, "get_colab_url", lambda port: "https://8888-test.prod.colab.dev/")
+    monkeypatch.setattr(colab, "_is_colab_runtime", lambda: True)
+    monkeypatch.setattr(
+        colab,
+        "show_link",
+        lambda port, *, _url = None, has_cloudflare_link = False, cloudflare_requested = False: calls.append("show_link"),
+    )
+    monkeypatch.setattr(colab, "_embed_kernel_port_iframe", lambda port: True)
+    colab._show_and_embed(8888, cloudflare_url = "https://share.trycloudflare.com")
+
+    assert calls == []
+
+
+def test_show_and_embed_keeps_ready_card_without_tunnel(monkeypatch):
+    """Without a tunnel the ready card is the only guidance, so it must stay."""
+    calls: list[str] = []
+
+    monkeypatch.setattr(colab, "get_colab_url", lambda port: "https://8888-test.prod.colab.dev/")
+    monkeypatch.setattr(colab, "_is_colab_runtime", lambda: True)
+    monkeypatch.setattr(
+        colab,
+        "show_link",
+        lambda port, *, _url = None, has_cloudflare_link = False, cloudflare_requested = False: calls.append("show_link"),
+    )
+    monkeypatch.setattr(colab, "_embed_kernel_port_iframe", lambda port: True)
+    colab._show_and_embed(8888)
+
+    assert calls == ["show_link"]
 
 
 def test_show_and_embed_skips_iframe_on_colab_when_cloudflare_ready(monkeypatch):

--- a/studio/backend/tests/test_colab_embed.py
+++ b/studio/backend/tests/test_colab_embed.py
@@ -342,9 +342,7 @@ def test_colab_login_html_includes_credentials():
 
 def test_shareable_link_html_embeds_password_under_the_link():
     """The credential belongs in the same card as the button it unlocks (#7404 follow-up)."""
-    html = colab._shareable_link_html(
-        "https://share.trycloudflare.com", "secret-pass", "unsloth"
-    )
+    html = colab._shareable_link_html("https://share.trycloudflare.com", "secret-pass", "unsloth")
     assert "share.trycloudflare.com" in html
     assert "secret-pass" in html
     # Username is stated inline, not as its own labelled field.
@@ -425,7 +423,11 @@ def test_show_and_embed_skips_ready_card_when_tunnel_is_up(monkeypatch):
     monkeypatch.setattr(
         colab,
         "show_link",
-        lambda port, *, _url = None, has_cloudflare_link = False, cloudflare_requested = False: calls.append("show_link"),
+        lambda port,
+        *,
+        _url = None,
+        has_cloudflare_link = False,
+        cloudflare_requested = False: calls.append("show_link"),
     )
     monkeypatch.setattr(colab, "_embed_kernel_port_iframe", lambda port: True)
     colab._show_and_embed(8888, cloudflare_url = "https://share.trycloudflare.com")
@@ -442,7 +444,11 @@ def test_show_and_embed_keeps_ready_card_without_tunnel(monkeypatch):
     monkeypatch.setattr(
         colab,
         "show_link",
-        lambda port, *, _url = None, has_cloudflare_link = False, cloudflare_requested = False: calls.append("show_link"),
+        lambda port,
+        *,
+        _url = None,
+        has_cloudflare_link = False,
+        cloudflare_requested = False: calls.append("show_link"),
     )
     monkeypatch.setattr(colab, "_embed_kernel_port_iframe", lambda port: True)
     colab._show_and_embed(8888)


### PR DESCRIPTION
Follow-up to the Colab notebook output.

Three cards were rendering on a `start(cloudflare=True)` run: the shareable Cloudflare link, a separate login card, and a ready card. The credential the user needs was two cards away from the button that needs it, and the third card had nothing left to say once a tunnel was up.

Changes:

- The password now renders inside the shareable link card, directly under the link and the Open Unsloth Studio button. `_shareable_link_html` takes optional `password` and `username`.
- Dropped the `Username:` field. The admin user is always the default, so it now reads inline as "Log in as `unsloth` with this password" in both the link card and the standalone login card.
- The standalone login card is only rendered when there is no link card to fold it into (tunnel requested but failed), so the normal path shows one card instead of two.
- Skip the ready card on Colab when a tunnel is up. The in-cell proxy embed is already skipped in that case, so the card only repeated the guidance from the link card above it and printed a truncated `*.prod.colab.dev` proxy URL that 404s outside the notebook tab. It still renders on every other path, where it carries the real fallback guidance.

Tests: 36 pass in `test_colab_embed.py`, including new coverage that the password sits after the link, that the login card is not duplicated when folded in, that it still renders without a tunnel, and that the ready card is skipped only when a tunnel is up.