### PR TITLE
studio/tests: cover the GGUF load ordering behaviourally and make the structlog stub order-independent

### DIFF
--- a/studio/backend/tests/test_gguf_load_cache_reuse.py
+++ b/studio/backend/tests/test_gguf_load_cache_reuse.py
@@ -9,10 +9,14 @@ No GPU, network, or subprocesses are required.
 from __future__ import annotations
 
 import asyncio
+import importlib.util
+import logging
 import sys
 import threading
 import types as _types
+from contextlib import nullcontext
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -28,6 +32,10 @@ _loggers_stub.get_logger = lambda name: __import__("logging").getLogger(name)
 sys.modules.setdefault("loggers", _loggers_stub)
 
 _structlog_stub = _types.ModuleType("structlog")
+# routes/inference.py pulls in core.inference.external_provider, which binds a
+# structlog logger at import time; give the stub a working factory so the route
+# module is importable when structlog is not installed.
+_structlog_stub.get_logger = lambda *_args, **_kwargs: logging.getLogger("structlog_stub")
 sys.modules.setdefault("structlog", _structlog_stub)
 
 try:
@@ -118,6 +126,22 @@ def _fail_download(*_args, **_kwargs):
 
 def _fail_get_paths_info(*_args, **_kwargs):
     raise AssertionError("cached reuse must return before the sizing preflight")
+
+
+def _load_route_module(name: str, relative_path: str):
+    """Import a route module under a private name so patches can't leak."""
+    spec = importlib.util.spec_from_file_location(name, Path(_BACKEND_DIR) / relative_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+async def _inline_to_thread(func, /, *args, **kwargs):
+    return func(*args, **kwargs)
+
+
+async def _no_gguf_gpu_ids(*_args, **_kwargs):
+    return None
 
 
 class TestLoadReusesCachedCopy:
@@ -785,16 +809,16 @@ class TestLoadHubDownloadExclusion:
 
     def test_load_marker_precedes_hub_guard_and_unload(self):
         source = (Path(__file__).resolve().parent.parent / "routes" / "inference.py").read_text()
-        gguf_branch = source[source.index("if config.is_gguf:") :]
+        # Slice the GGUF *load* branch, i.e. the "if config.is_gguf:" nearest
+        # above the in-flight marker. _load_model_impl has earlier
+        # "if config.is_gguf:" statements (the GPU-pool validation added by
+        # #7239), so a plain first-match index anchors on the wrong statement.
+        marker = source.index("enter_context(gguf_load_in_flight")
+        gguf_branch = source[source.rindex("if config.is_gguf:", 0, marker) :]
 
         # The gguf_load_in_flight marker must be entered before the hub-download
         # guard and the unload so a concurrent load can't race the download
-        # manager. The llama_extra_args inheritance moved out of the branch into
-        # _resolve_inherited_extra_args, which must still run BEFORE it: the
-        # inherited value (e.g. a carried --no-mmproj) shapes the guard's
-        # require_mmproj. Anchor on the call form so the assertion pins the
-        # endpoint's call site, not the function definition.
-        assert source.index("= _resolve_inherited_extra_args(") < source.index("if config.is_gguf:")
+        # manager.
         assert (
             gguf_branch.index("enter_context(gguf_load_in_flight")
             < gguf_branch.index("_hub_download_blocks_gguf_load")
@@ -804,3 +828,121 @@ class TestLoadHubDownloadExclusion:
             Path(__file__).resolve().parent.parent / "core" / "inference" / "llama_cpp.py"
         ).read_text()
         assert "@_with_gguf_load_marker\n    def load_model(" in llama_source
+
+    def _capture_hub_guard_require_mmproj(
+        self,
+        stored_extra_args,
+        request_extra_args = None,
+    ):
+        """Drive /load's GGUF path and return the hub guard's require_mmproj.
+
+        Stops at the guard by making it report a conflicting download, so the
+        409 is the observation point and no llama-server is ever started.
+        """
+        import core.inference.llama_cpp as llama_cpp_module
+
+        from fastapi import HTTPException
+        from models.inference import LoadRequest
+
+        route = _load_route_module(
+            "inference_route_module_for_inherited_extra_args_test",
+            "routes/inference.py",
+        )
+        captured = {}
+
+        def _fake_blocks(
+            repo,
+            variant,
+            *,
+            require_mmproj,
+            hf_token = None,
+        ):
+            captured["repo"] = repo
+            captured["variant"] = variant
+            captured["require_mmproj"] = require_mmproj
+            return True
+
+        # A vision GGUF: require_mmproj is True unless the effective extras
+        # carry --no-mmproj.
+        config = SimpleNamespace(
+            is_gguf = True,
+            is_lora = False,
+            is_vision = True,
+            is_audio = False,
+            audio_type = None,
+            has_audio_input = False,
+            gguf_hf_repo = REPO,
+            gguf_variant = VARIANT,
+            gguf_file = None,
+            gguf_mmproj_file = None,
+            identifier = REPO,
+            display_name = REPO,
+        )
+        # Previous same-model load's pass-through extras, as the running
+        # llama.cpp backend records them.
+        llama_backend = SimpleNamespace(
+            is_loaded = False,
+            extra_args = list(stored_extra_args),
+            extra_args_source = (REPO, VARIANT),
+            hf_variant = VARIANT,
+            model_identifier = REPO,
+        )
+        request = LoadRequest(
+            model_path = REPO,
+            gguf_variant = VARIANT,
+            llama_extra_args = request_extra_args,
+        )
+
+        with (
+            patch.object(
+                route,
+                "ModelConfig",
+                SimpleNamespace(from_identifier = lambda **_kwargs: config),
+            ),
+            patch.object(route, "get_llama_cpp_backend", lambda: llama_backend),
+            patch.object(
+                route,
+                "get_inference_backend",
+                lambda: SimpleNamespace(active_model_name = None),
+            ),
+            patch.object(route, "_resolve_gguf_gpu_ids_for_request", _no_gguf_gpu_ids),
+            patch.object(route, "_guard_chat_load_against_training", return_value = None),
+            patch.object(route, "_effective_load_in_4bit", return_value = False),
+            patch.object(route, "_hf_offline_if_dns_dead", nullcontext),
+            patch.object(route.asyncio, "to_thread", new = _inline_to_thread),
+            patch.object(llama_cpp_module, "_hub_download_blocks_gguf_load", _fake_blocks),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    route._load_model_impl(
+                        request,
+                        SimpleNamespace(
+                            app = SimpleNamespace(
+                                state = SimpleNamespace(llama_parallel_slots = 1),
+                            ),
+                        ),
+                        current_subject = "test-user",
+                    )
+                )
+
+        assert exc_info.value.status_code == 409
+        assert captured["repo"] == REPO
+        return captured["require_mmproj"]
+
+    def test_inherited_extra_args_shape_hub_guard_require_mmproj(self):
+        # llama_extra_args inheritance must resolve before the hub-download
+        # guard runs: the inherited value (a carried --no-mmproj) decides the
+        # guard's require_mmproj, so resolving it later would reject a load
+        # over an mmproj download the effective arguments disable (#7251).
+        # Asserted behaviourally rather than by source offsets, which silently
+        # re-anchored onto an unrelated "if config.is_gguf:" (#7239).
+        assert self._capture_hub_guard_require_mmproj(["--no-mmproj"]) is False
+        # Control: nothing to inherit, so a vision GGUF still needs its mmproj.
+        assert self._capture_hub_guard_require_mmproj([]) is True
+        # An explicit request list wins over the stored one, both ways.
+        assert (
+            self._capture_hub_guard_require_mmproj([], request_extra_args = ["--no-mmproj"]) is False
+        )
+        assert (
+            self._capture_hub_guard_require_mmproj(["--no-mmproj"], request_extra_args = []) is True
+        )

--- a/studio/backend/tests/test_gguf_load_cache_reuse.py
+++ b/studio/backend/tests/test_gguf_load_cache_reuse.py
@@ -32,9 +32,8 @@ _loggers_stub.get_logger = lambda name: __import__("logging").getLogger(name)
 sys.modules.setdefault("loggers", _loggers_stub)
 
 _structlog_stub = _types.ModuleType("structlog")
-# routes/inference.py binds structlog.get_logger at import time through
-# core.inference.external_provider. setdefault keeps any bare stub an earlier
-# test module left behind, so repair that one too instead of relying on order.
+# routes/inference.py binds structlog.get_logger at import time, and setdefault
+# keeps a bare stub an earlier test left behind: repair it rather than rely on order.
 _structlog_stub.get_logger = lambda *_args, **_kwargs: logging.getLogger("structlog_stub")
 sys.modules.setdefault("structlog", _structlog_stub)
 if not hasattr(sys.modules["structlog"], "get_logger"):
@@ -843,8 +842,8 @@ class TestLoadHubDownloadExclusion:
     ):
         """Drive /load's GGUF path and return the hub guard's require_mmproj.
 
-        Stops at the guard by making it report a conflicting download, so the
-        409 is the observation point and no llama-server is ever started.
+        The guard reports a conflicting download, so the 409 is the observation
+        point and no llama-server ever starts.
         """
         import core.inference.llama_cpp as llama_cpp_module
 
@@ -935,9 +934,9 @@ class TestLoadHubDownloadExclusion:
         return captured["require_mmproj"]
 
     def test_inherited_extra_args_shape_hub_guard_require_mmproj(self):
-        # Inheritance must resolve before the hub-download guard: the inherited
-        # --no-mmproj decides require_mmproj, so resolving it later would reject
-        # a load over an mmproj download the effective arguments disable (#7251).
+        # Inheritance must resolve before the hub-download guard: an inherited
+        # --no-mmproj decides require_mmproj, so resolving later rejects a load
+        # over a download the effective arguments disable (#7251).
         assert self._capture_hub_guard_require_mmproj(["--no-mmproj"]) is False
         # Control: nothing to inherit, so a vision GGUF still needs its mmproj.
         assert self._capture_hub_guard_require_mmproj([]) is True

--- a/studio/backend/tests/test_gguf_load_cache_reuse.py
+++ b/studio/backend/tests/test_gguf_load_cache_reuse.py
@@ -32,16 +32,11 @@ _loggers_stub.get_logger = lambda name: __import__("logging").getLogger(name)
 sys.modules.setdefault("loggers", _loggers_stub)
 
 _structlog_stub = _types.ModuleType("structlog")
-# routes/inference.py pulls in core.inference.external_provider, which binds a
-# structlog logger at import time; give the stub a working factory so the route
-# module is importable when structlog is not installed.
+# routes/inference.py binds structlog.get_logger at import time through
+# core.inference.external_provider. setdefault keeps any bare stub an earlier
+# test module left behind, so repair that one too instead of relying on order.
 _structlog_stub.get_logger = lambda *_args, **_kwargs: logging.getLogger("structlog_stub")
 sys.modules.setdefault("structlog", _structlog_stub)
-# An earlier test module in the same session (e.g. test_checkpoints_scan.py) may
-# already have parked a bare ModuleType("structlog") in sys.modules, in which
-# case the setdefault above kept that one and get_logger is missing. Repair it
-# so the route import stays order-independent. The real structlog always has
-# get_logger, so this never shadows the installed package.
 if not hasattr(sys.modules["structlog"], "get_logger"):
     sys.modules["structlog"].get_logger = _structlog_stub.get_logger
 
@@ -816,10 +811,9 @@ class TestLoadHubDownloadExclusion:
 
     def test_load_marker_precedes_hub_guard_and_unload(self):
         source = (Path(__file__).resolve().parent.parent / "routes" / "inference.py").read_text()
-        # _load_model_impl has more than one `if config.is_gguf:` (the GPU-pool
-        # validation reworked by #7239 comes first), so anchor on the branch
-        # that actually owns the load marker rather than the first one in the
-        # file, which belongs to an earlier check.
+        # _load_model_impl has more than one `if config.is_gguf:`, so anchor on
+        # the branch that actually owns the load marker rather than the first
+        # one in the file, which belongs to an earlier check.
         marker = source.index("enter_context(gguf_load_in_flight")
         gguf_branch_start = source.rindex("if config.is_gguf:", 0, marker)
         gguf_branch = source[gguf_branch_start:]
@@ -831,8 +825,6 @@ class TestLoadHubDownloadExclusion:
         # inherited value (e.g. a carried --no-mmproj) shapes the guard's
         # require_mmproj. Anchor on the call form so the assertion pins the
         # endpoint's call site, not the function definition.
-        # test_inherited_extra_args_shape_hub_guard_require_mmproj below pins
-        # the same ordering behaviourally, without depending on source offsets.
         assert source.index("= _resolve_inherited_extra_args(") < gguf_branch_start
         assert (
             gguf_branch.index("enter_context(gguf_load_in_flight")
@@ -877,8 +869,7 @@ class TestLoadHubDownloadExclusion:
             captured["require_mmproj"] = require_mmproj
             return True
 
-        # A vision GGUF: require_mmproj is True unless the effective extras
-        # carry --no-mmproj.
+        # A vision GGUF: require_mmproj is True unless the extras say --no-mmproj.
         config = SimpleNamespace(
             is_gguf = True,
             is_lora = False,
@@ -893,8 +884,7 @@ class TestLoadHubDownloadExclusion:
             identifier = REPO,
             display_name = REPO,
         )
-        # Previous same-model load's pass-through extras, as the running
-        # llama.cpp backend records them.
+        # Pass-through extras the running backend recorded for the last load.
         llama_backend = SimpleNamespace(
             is_loaded = False,
             extra_args = list(stored_extra_args),
@@ -945,12 +935,9 @@ class TestLoadHubDownloadExclusion:
         return captured["require_mmproj"]
 
     def test_inherited_extra_args_shape_hub_guard_require_mmproj(self):
-        # llama_extra_args inheritance must resolve before the hub-download
-        # guard runs: the inherited value (a carried --no-mmproj) decides the
-        # guard's require_mmproj, so resolving it later would reject a load
-        # over an mmproj download the effective arguments disable (#7251).
-        # Asserted behaviourally rather than by source offsets, which silently
-        # re-anchored onto an unrelated "if config.is_gguf:" (#7239).
+        # Inheritance must resolve before the hub-download guard: the inherited
+        # --no-mmproj decides require_mmproj, so resolving it later would reject
+        # a load over an mmproj download the effective arguments disable (#7251).
         assert self._capture_hub_guard_require_mmproj(["--no-mmproj"]) is False
         # Control: nothing to inherit, so a vision GGUF still needs its mmproj.
         assert self._capture_hub_guard_require_mmproj([]) is True

--- a/studio/backend/tests/test_gguf_load_cache_reuse.py
+++ b/studio/backend/tests/test_gguf_load_cache_reuse.py
@@ -37,6 +37,13 @@ _structlog_stub = _types.ModuleType("structlog")
 # module is importable when structlog is not installed.
 _structlog_stub.get_logger = lambda *_args, **_kwargs: logging.getLogger("structlog_stub")
 sys.modules.setdefault("structlog", _structlog_stub)
+# An earlier test module in the same session (e.g. test_checkpoints_scan.py) may
+# already have parked a bare ModuleType("structlog") in sys.modules, in which
+# case the setdefault above kept that one and get_logger is missing. Repair it
+# so the route import stays order-independent. The real structlog always has
+# get_logger, so this never shadows the installed package.
+if not hasattr(sys.modules["structlog"], "get_logger"):
+    sys.modules["structlog"].get_logger = _structlog_stub.get_logger
 
 try:
     import httpx  # noqa: F401


### PR DESCRIPTION
## Status update

`main` no longer fails: #7443 (`85f6231a2`) landed the anchor fix for
`test_load_marker_precedes_hub_guard_and_unload`, so Backend CI is unblocked already. This branch is
now merged with `main` and keeps that landed assertion as is. What is left here is the extra
coverage this PR was carrying on top of it.

## Original failure

`studio/backend/tests/test_gguf_load_cache_reuse.py::TestLoadHubDownloadExclusion::test_load_marker_precedes_hub_guard_and_unload` failed on `main` itself, so every open PR inherited the failure regardless of its diff (seen on #7392 and #7404, neither of which touches the load path).

```
assert source.index("= _resolve_inherited_extra_args(") < source.index("if config.is_gguf:")
E   assert 186995 < 185014
```

The assertion anchored on `source.index("if config.is_gguf:")`, a first-match string search over `routes/inference.py`. #7239 (`a7761e174`) reworked the GGUF GPU-pool validation in `_load_model_impl` into a bare `if config.is_gguf:` placed earlier in the function than the GGUF load branch, so that new statement became the first match and the assertion silently started comparing against the GPU-pool check. The endpoint ordering was never broken; only the assertion was wrong.

## What this PR still adds

1. `test_inherited_extra_args_shape_hub_guard_require_mmproj`: a behavioural test for the same invariant. It drives `_load_model_impl` over a vision GGUF whose previous same-model load stored `--no-mmproj`, stubs the hub guard to report a conflicting download (so the 409 is the observation point and no llama-server starts), and captures the `require_mmproj` the guard was called with:

   - inherited `--no-mmproj` gives `require_mmproj = False`
   - nothing to inherit gives `require_mmproj = True`
   - an explicit request list wins over the stored one, both directions

   Moving the `_resolve_inherited_extra_args` call to after the guard makes the inherited case report `True` and the test fails, so it detects the reorder without depending on how many `if config.is_gguf:` statements the endpoint happens to contain.

2. Module-level `structlog` stub repair. `routes/inference.py` pulls in `core.inference.external_provider`, which binds `structlog.get_logger(__name__)` at import time. The stub gains a `get_logger` factory, and an existing bare `structlog` stub left in `sys.modules` by an earlier test module (for example `test_checkpoints_scan.py`) is repaired rather than silently kept by `setdefault`, so the import is order independent. Without it, `pytest tests/test_checkpoints_scan.py tests/test_gguf_load_cache_reuse.py` fails with `AttributeError: module 'structlog' has no attribute 'get_logger'`. The real `structlog` always has `get_logger`, so the installed package is never shadowed.

## Testing

- `tests/test_gguf_load_cache_reuse.py`: 34 passed, standalone
- `tests/test_checkpoints_scan.py tests/test_gguf_load_cache_reuse.py`: 40 passed (fails before the stub repair)
- Full backend run under the CI selection: no failures in this file
- Mutation check: with the resolution call moved below the guard, the new test fails and the rest of the file still passes
- `ruff check` clean
