### PR TITLE
tests: anchor the gguf ordering assertion on the branch that owns the marker

### DIFF
--- a/studio/backend/tests/test_gguf_load_cache_reuse.py
+++ b/studio/backend/tests/test_gguf_load_cache_reuse.py
@@ -785,7 +785,12 @@ class TestLoadHubDownloadExclusion:
 
     def test_load_marker_precedes_hub_guard_and_unload(self):
         source = (Path(__file__).resolve().parent.parent / "routes" / "inference.py").read_text()
-        gguf_branch = source[source.index("if config.is_gguf:") :]
+        # _load_model_impl has more than one `if config.is_gguf:`, so anchor on
+        # the branch that actually owns the load marker rather than the first
+        # one in the file, which belongs to an earlier check.
+        marker = source.index("enter_context(gguf_load_in_flight")
+        gguf_branch_start = source.rindex("if config.is_gguf:", 0, marker)
+        gguf_branch = source[gguf_branch_start:]
 
         # The gguf_load_in_flight marker must be entered before the hub-download
         # guard and the unload so a concurrent load can't race the download
@@ -794,7 +799,7 @@ class TestLoadHubDownloadExclusion:
         # inherited value (e.g. a carried --no-mmproj) shapes the guard's
         # require_mmproj. Anchor on the call form so the assertion pins the
         # endpoint's call site, not the function definition.
-        assert source.index("= _resolve_inherited_extra_args(") < source.index("if config.is_gguf:")
+        assert source.index("= _resolve_inherited_extra_args(") < gguf_branch_start
         assert (
             gguf_branch.index("enter_context(gguf_load_in_flight")
             < gguf_branch.index("_hub_download_blocks_gguf_load")


### PR DESCRIPTION
`test_load_marker_precedes_hub_guard_and_unload` fails on main, which turns Repo tests (CPU) and the Python 3.10 through 3.13 backend jobs red on every branch.

### What happens

The assertion added in #7251 is:

```python
assert source.index("= _resolve_inherited_extra_args(") < source.index("if config.is_gguf:")
```

`_load_model_impl` contains more than one `if config.is_gguf:`, and `str.index` returns the first match in the file. That first match belongs to an earlier check, not to the branch the assertion is reasoning about:

| landmark | line | offset |
| --- | --- | --- |
| earlier `if config.is_gguf:` | 4508 | 185014 |
| `= _resolve_inherited_extra_args(` | 4543 | 186995 |
| `if config.is_gguf:` holding the load marker | 4567 | 187973 |

So the comparison reads `186995 < 185014` and fails, even though the ordering it means to check is satisfied: the inheritance call at 4543 does precede the branch at 4567.

### The fix

Locate the branch from the load marker itself, which is the landmark the rest of the test already relies on, then compare against that. The slice the following assertions use is anchored the same way, which tightens them as well: they previously searched from the earlier branch to end of file.

The invariant from #7251 is unchanged, and still has teeth. Moving the inheritance call after the branch makes the assertion fail.

### Verification

`python -m pytest tests/test_gguf_load_cache_reuse.py` in `studio/backend`: 33 passed, against 1 failed / 32 passed on main.
