### PR TITLE
Studio: reset the reasoning open state when a new stream starts

### DIFF
--- a/studio/frontend/src/components/assistant-ui/reasoning.tsx
+++ b/studio/frontend/src/components/assistant-ui/reasoning.tsx
@@ -362,10 +362,12 @@ const ReasoningGroupImpl: ReasoningGroupComponent = ({
     }
   }, [isReasoningStreaming]);
 
-  // Reset dismissed flag on new stream.
+  // Reset per-round open state. manualOpen is sticky and regenerate reuses this
+  // instance, so a hand-opened block would stay pinned open and never collapse.
   useEffect(() => {
     if (isReasoningStreaming) {
       setDismissedWhileStreaming(false);
+      setManualOpen(false);
     }
   }, [isReasoningStreaming]);
 

--- a/tests/studio/test_chat_response_details_ui_contract.py
+++ b/tests/studio/test_chat_response_details_ui_contract.py
@@ -85,6 +85,21 @@ def test_reasoning_keeps_streaming_height_cap_through_automatic_collapse():
     assert "streaming={isReasoningStreaming || retainStreamingHeight}" in src
 
 
+def test_reasoning_clears_manual_open_on_a_new_stream():
+    """A hand-opened block must not stay pinned open when the stream restarts.
+
+    isOpen is `(streaming && !dismissed) || manualOpen` and manualOpen is only
+    settable while idle, so the new-stream reset has to clear it too.
+    """
+    src = REASONING_TSX.read_text()
+
+    marker = "setDismissedWhileStreaming(false)"
+    start = src.find(marker)
+    assert start != -1, "new-stream reset effect is missing"
+    effect = src[src.rfind("useEffect(() => {", 0, start) : src.find("});", start)]
+    assert "setManualOpen(false)" in effect
+
+
 def test_response_details_metadata_is_persisted_without_backend_schema_change():
     src = ADAPTER_TS.read_text()
     assert "interface ResponseDetailsMetadata" in src


### PR DESCRIPTION
Follow up to #7388.

A reasoning block that the user opened by hand stays pinned open once the same message streams again, so the trigger stops responding and the automatic collapse never runs.

## Cause

`isOpen` is:

```
const isOpen = (isReasoningStreaming && !dismissedWhileStreaming) || manualOpen;
```

`manualOpen` is only settable while idle, and the new-stream reset clears `dismissedWhileStreaming` but leaves `manualOpen` alone. Once it is true the `|| manualOpen` arm pins `isOpen` true for every later round. Clicking the trigger mid-stream only sets `dismissedWhileStreaming`, which that arm overrides.

The component instance survives a regenerate, so the stale flag carries over: `ThreadPrimitive.MessageByIndex` is memoized on the message index, and the reasoning group is keyed `group-<groupIndex>-<groupKey>`.

## Reproduction

1. Send a prompt to a reasoning model and let it finish.
2. Click the finished "Thought for N seconds" block to open it.
3. Regenerate the same message.
4. Click the trigger while it streams. The block does not close, and it stays expanded after the stream ends instead of collapsing.

## Fix

Clear `manualOpen` alongside `dismissedWhileStreaming` when a new stream starts. A new stream is a new round, and the manual open referred to content that has been replaced.

This also removes a second, smaller artifact from the same stale flag. When `manualOpen` kept the block open through completion, #7388's height cap was still held for `ANIMATION_DURATION` and then dropped, so a block that never collapsed expanded 200ms late. With the flag reset the block takes the normal auto-collapse path and the cap is released as intended.

## Verification

Behaviour was checked by driving the hook logic under React 19 in jsdom, comparing `main` against the fix across the streaming, completion and regenerate transitions.

| Scenario | main | with fix |
|---|---|---|
| Close click during a re-stream after a manual open | stays open after 1 and 3 clicks | closes on the first click |
| Block open at completion | capped, then expands 200ms later | collapses normally |
| Normal stream to completion (#7388 path) | cap held at the completion frame, auto-collapse, cap released after 200ms | unchanged |

The last row is the regression check for #7388: the anti-jump behaviour is byte for byte the same before and after.

- `tsc -b` passes.
- `tests/studio/test_chat_response_details_ui_contract.py`: 6 passed.
- Full `tests/studio` run matches the `main` baseline, same 8 pre-existing `test_hardware_dispatch_matrix.py` MLX failures and no new ones.
- The new test fails when the reset line is removed, so it is not vacuous.
