### PR TITLE
fix(rocm): prefer system LLVM runtime on native Linux

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -298,14 +298,15 @@ def _native_linux_system_rocm_lib_dirs(binary_dir: str = "") -> "list[str]":
                 os.path.join(d, "libhsa-runtime64.so.1")
             ):
                 out.append(d)
-                # ROCm keeps LLVM's versioned runtime one level below its main
-                # lib dir. Keep it ahead of the prebuilt bundle as well so
-                # system libamd_comgr cannot bind to a bundled, incompatible
-                # libLLVM.so.* from build/bin.
-                llvm_lib = os.path.join(d, "llvm", "lib")
-                if llvm_lib not in seen and os.path.exists(llvm_lib):
-                    seen.add(llvm_lib)
-                    out.append(llvm_lib)
+                # ROCm keeps LLVM's versioned runtime under <root>/lib/llvm, so a
+                # lib64 host still finds it under lib. Probe both and keep them
+                # ahead of the bundle, else system libamd_comgr binds to the
+                # bundle's incompatible libLLVM.so.*.
+                for _sub in (lib_sub, "lib"):
+                    llvm_lib = os.path.join(base, _sub, "llvm", "lib")
+                    if llvm_lib not in seen and os.path.isdir(llvm_lib):
+                        seen.add(llvm_lib)
+                        out.append(llvm_lib)
     return out
 
 

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -298,6 +298,14 @@ def _native_linux_system_rocm_lib_dirs(binary_dir: str = "") -> "list[str]":
                 os.path.join(d, "libhsa-runtime64.so.1")
             ):
                 out.append(d)
+                # ROCm keeps LLVM's versioned runtime one level below its main
+                # lib dir. Keep it ahead of the prebuilt bundle as well so
+                # system libamd_comgr cannot bind to a bundled, incompatible
+                # libLLVM.so.* from build/bin.
+                llvm_lib = os.path.join(d, "llvm", "lib")
+                if llvm_lib not in seen and os.path.exists(llvm_lib):
+                    seen.add(llvm_lib)
+                    out.append(llvm_lib)
     return out
 
 

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4730,6 +4730,14 @@ def _native_linux_system_rocm_lib_dirs(binary_dir: str = "") -> list[str]:
                 os.path.join(d, "libhsa-runtime64.so.1")
             ):
                 out.append(d)
+                # ROCm keeps LLVM's versioned runtime one level below its main
+                # lib dir. Keep it ahead of the prebuilt bundle as well so
+                # system libamd_comgr cannot bind to a bundled, incompatible
+                # libLLVM.so.* from build/bin.
+                llvm_lib = os.path.join(d, "llvm", "lib")
+                if llvm_lib not in seen and os.path.exists(llvm_lib):
+                    seen.add(llvm_lib)
+                    out.append(llvm_lib)
     return out
 
 

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -4730,14 +4730,15 @@ def _native_linux_system_rocm_lib_dirs(binary_dir: str = "") -> list[str]:
                 os.path.join(d, "libhsa-runtime64.so.1")
             ):
                 out.append(d)
-                # ROCm keeps LLVM's versioned runtime one level below its main
-                # lib dir. Keep it ahead of the prebuilt bundle as well so
-                # system libamd_comgr cannot bind to a bundled, incompatible
-                # libLLVM.so.* from build/bin.
-                llvm_lib = os.path.join(d, "llvm", "lib")
-                if llvm_lib not in seen and os.path.exists(llvm_lib):
-                    seen.add(llvm_lib)
-                    out.append(llvm_lib)
+                # ROCm keeps LLVM's versioned runtime under <root>/lib/llvm, so a
+                # lib64 host still finds it under lib. Probe both and keep them
+                # ahead of the bundle, else system libamd_comgr binds to the
+                # bundle's incompatible libLLVM.so.*.
+                for _sub in (lib_sub, "lib"):
+                    llvm_lib = os.path.join(base, _sub, "llvm", "lib")
+                    if llvm_lib not in seen and os.path.isdir(llvm_lib):
+                        seen.add(llvm_lib)
+                        out.append(llvm_lib)
     return out
 
 

--- a/tests/studio/install/test_rocm_native_linux_lib_dirs.py
+++ b/tests/studio/install/test_rocm_native_linux_lib_dirs.py
@@ -126,8 +126,10 @@ def _call(
     with patch.object(sys, "platform", platform):
         # isdir too: the llvm probe requires a directory, so a fake host that only
         # answers exists() would report every nested llvm dir as missing.
-        with patch("os.path.exists", _fake_exists(present)), \
-             patch("os.path.isdir", _fake_exists(present)):
+        with (
+            patch("os.path.exists", _fake_exists(present)),
+            patch("os.path.isdir", _fake_exists(present)),
+        ):
             return _norm(impl(str(bundle)))
 
 
@@ -326,9 +328,11 @@ class TestNativeLinuxRootResolution:
         # A test host may itself have a real /opt/rocm (the default candidate), so
         # assert on the bogus entry rather than on the whole list.
         for where, impl in _impls().items():
-            with patch.object(sys, "platform", "linux"), \
-                 patch.dict(os.environ, {"ROCM_PATH": str(root)}, clear = True), \
-                 patch("os.path.exists", _exists):
+            with (
+                patch.object(sys, "platform", "linux"),
+                patch.dict(os.environ, {"ROCM_PATH": str(root)}, clear = True),
+                patch("os.path.exists", _exists),
+            ):
                 out = impl(str(bundle_dir))
             assert str(root / "lib") in out, where
             assert str(root / "lib" / "llvm" / "lib") not in out, where

--- a/tests/studio/install/test_rocm_native_linux_lib_dirs.py
+++ b/tests/studio/install/test_rocm_native_linux_lib_dirs.py
@@ -260,6 +260,20 @@ class TestNativeLinuxRootResolution:
         for where, impl in _impls().items():
             assert self._run(impl, bundle_dir, present) == ["/opt/rocm/lib64"], where
 
+    def test_nested_llvm_runtime_follows_system_rocm_lib(self, bundle_dir):
+        """#7446: libamd_comgr depends on ROCm's versioned LLVM runtime, which is
+        installed below lib/llvm/lib rather than directly in lib."""
+        present = {
+            "/dev/kfd",
+            "/opt/rocm/lib/libhsa-runtime64.so",
+            "/opt/rocm/lib/llvm/lib",
+        }
+        for where, impl in _impls().items():
+            assert self._run(impl, bundle_dir, present) == [
+                "/opt/rocm/lib",
+                "/opt/rocm/lib/llvm/lib",
+            ], where
+
     def test_lib_precedes_lib64_when_both_exist(self, bundle_dir):
         present = {
             "/dev/kfd",

--- a/tests/studio/install/test_rocm_native_linux_lib_dirs.py
+++ b/tests/studio/install/test_rocm_native_linux_lib_dirs.py
@@ -124,7 +124,10 @@ def _call(
     tmp_path factory branches on it, so a session-wide patch breaks the fixture on
     a Windows test host."""
     with patch.object(sys, "platform", platform):
-        with patch("os.path.exists", _fake_exists(present)):
+        # isdir too: the llvm probe requires a directory, so a fake host that only
+        # answers exists() would report every nested llvm dir as missing.
+        with patch("os.path.exists", _fake_exists(present)), \
+             patch("os.path.isdir", _fake_exists(present)):
             return _norm(impl(str(bundle)))
 
 
@@ -273,6 +276,62 @@ class TestNativeLinuxRootResolution:
                 "/opt/rocm/lib",
                 "/opt/rocm/lib/llvm/lib",
             ], where
+
+    def test_lib64_host_still_finds_llvm_under_lib(self, bundle_dir):
+        """ROCm puts LLVM under <root>/lib/llvm even where HSA lives in lib64, so
+        deriving the llvm dir from the HSA dir alone would miss it and leave
+        libamd_comgr binding to the bundle's libLLVM."""
+        present = {
+            "/dev/kfd",
+            "/opt/rocm/lib64/libhsa-runtime64.so",
+            "/opt/rocm/lib/llvm/lib",
+        }
+        for where, impl in _impls().items():
+            assert self._run(impl, bundle_dir, present) == [
+                "/opt/rocm/lib64",
+                "/opt/rocm/lib/llvm/lib",
+            ], where
+
+    def test_lib64_host_prefers_its_own_llvm_dir_when_both_exist(self, bundle_dir):
+        present = {
+            "/dev/kfd",
+            "/opt/rocm/lib64/libhsa-runtime64.so",
+            "/opt/rocm/lib64/llvm/lib",
+            "/opt/rocm/lib/llvm/lib",
+        }
+        for where, impl in _impls().items():
+            assert self._run(impl, bundle_dir, present) == [
+                "/opt/rocm/lib64",
+                "/opt/rocm/lib64/llvm/lib",
+                "/opt/rocm/lib/llvm/lib",
+            ], where
+
+    def test_llvm_path_that_is_a_file_is_not_prepended(self, tmp_path, bundle_dir):
+        """Real filesystem: the serve-time caller joins these straight into
+        LD_LIBRARY_PATH without an is-dir filter, so a non-directory must not
+        reach it."""
+        root = tmp_path / "rocm"
+        (root / "lib").mkdir(parents = True)
+        (root / "lib" / "libhsa-runtime64.so").write_text("")
+        (root / "lib" / "llvm").mkdir()
+        (root / "lib" / "llvm" / "lib").write_text("not a directory")
+        real_exists = os.path.exists
+        # Pin both device nodes: a WSL test host really has /dev/dxg, which would
+        # take the WSL early-return and make this pass for the wrong reason.
+        pinned = {"/dev/kfd": True, "/dev/dxg": False}
+
+        def _exists(p):
+            return pinned.get(str(p), None) if str(p) in pinned else real_exists(p)
+
+        # A test host may itself have a real /opt/rocm (the default candidate), so
+        # assert on the bogus entry rather than on the whole list.
+        for where, impl in _impls().items():
+            with patch.object(sys, "platform", "linux"), \
+                 patch.dict(os.environ, {"ROCM_PATH": str(root)}, clear = True), \
+                 patch("os.path.exists", _exists):
+                out = impl(str(bundle_dir))
+            assert str(root / "lib") in out, where
+            assert str(root / "lib" / "llvm" / "lib") not in out, where
 
     def test_lib_precedes_lib64_when_both_exist(self, bundle_dir):
         present = {


### PR DESCRIPTION
Fixes #7446

## Summary

- Include ROCm's nested `lib/llvm/lib` directory in the native-Linux system runtime paths.
- Keep the install-time validator and serve-time launcher helpers in sync.
- Add regression coverage for the nested LLVM runtime ordering.

## Root Cause

The native-Linux ROCm path already puts the system `lib` directory ahead of the llama.cpp prebuilt bundle. However, ROCm installs its versioned LLVM runtime under `lib/llvm/lib`. When `libamd_comgr.so.3` came from the system ROCm installation, the loader could still fall through to an incompatible `libLLVM.so.*` in `build/bin`, causing the missing `LLVMInitializeSPIRVTarget` symbol.

The nested system LLVM directory is now placed after the corresponding system ROCm `lib` directory and before the prebuilt bundle.

## Verification

- `uv run --no-project --python 3.11 --with pytest pytest tests/studio/install/test_rocm_native_linux_lib_dirs.py -q --tb=short` -> 27 passed
- `uv run --no-project --python 3.11 --with pytest pytest tests/studio/install/test_install_llama_prebuilt_logic.py -q --tb=short` -> 60 passed, 1 skipped
- `uvx --from pre-commit pre-commit run --files studio/install_llama_prebuilt.py studio/backend/core/inference/llama_cpp.py tests/studio/install/test_rocm_native_linux_lib_dirs.py` -> passed
- `uv run --no-project --python 3.11 --with pytest pytest tests/studio/install/test_rocm_support.py -q --tb=short` -> 358 passed, 16 failed, 3 skipped; the same 16 `TestEnsureRocmTorch` failures reproduce on an unmodified `main` worktree in this macOS environment

## Notes for Reviewers

- Full hardware reproduction was not run because this environment does not have the reported Ubuntu 24.04 / ROCm 7.14 / gfx1201 host. The regression test covers both mirrored helpers and the required path order.
