### PR TITLE
Settings: slightly wider and taller dialog

### DIFF
--- a/studio/frontend/src/features/settings/settings-dialog.tsx
+++ b/studio/frontend/src/features/settings/settings-dialog.tsx
@@ -249,9 +249,10 @@ export function SettingsDialog() {
             }
           }}
           className={cn(
-            // Cap at 880px but shrink to the viewport so it doesn't clip on
-            // iPad-portrait widths where a fixed width overflows.
-            "settings-surface !max-w-[min(880px,calc(100vw-2rem))] h-[560px] w-[min(880px,calc(100vw-2rem))] p-0 overflow-hidden",
+            // Cap at 960px but shrink to the viewport so it doesn't clip on
+            // iPad-portrait widths where a fixed width overflows. Height caps
+            // the same way so short viewports don't get a clipped dialog.
+            "settings-surface !max-w-[min(960px,calc(100vw-2rem))] h-[min(680px,calc(100dvh-2rem))] w-[min(960px,calc(100vw-2rem))] p-0 overflow-hidden",
             // Soft shadow, no outline ring. Pin --radius to the light value so
             // corner rounding matches in dark mode.
             "shadow-border rounded-xl ring-0 [--radius:1.1rem]",


### PR DESCRIPTION
The Settings dialog felt cramped, so this gives it more room. While testing the taller size I found the old fixed height was also a latent clipping bug, so this fixes that at the same time.

### Before

- Width capped at `880px`
- Height was a hard `h-[560px]`

`DialogContent` is `position: fixed`, centred with `top-1/2 -translate-y-1/2`, and has no `max-height`. On any viewport shorter than the dialog it overflowed equally off the top and bottom of the screen, and because it is fixed positioned that overflow could not be scrolled to. The top of the dialog, including the close button at `top-3 right-3`, was simply unreachable.

That was reachable in ordinary use:

- a phone in landscape, for example 844x390, where the width is above the `sm` breakpoint so the desktop path applies
- any short or half height desktop window, for example 1440x600 or 1024x400

### After

- Width capped at `960px`
- Height `min(680px, 100dvh - 2rem)`

The height now caps against the viewport the same way the width already did, so the dialog can never be taller than the screen. `100dvh` rather than `100vh` so mobile browser chrome is accounted for.

### Compatibility

- The `max-sm` full screen path (`h-dvh` / `w-dvw`) is unchanged and still wins below 640px. Tailwind emits that rule later in the sheet, so source order keeps it ahead of the base height rule.
- Tailwind unwraps the redundant `calc()` and emits `height: min(680px, 100dvh - 2rem)`, the same shape as the existing width rule, so no new CSS feature is relied on.
- Styling only, one file, no logic or API changes.

### Testing

Geometry was measured in real engines with Playwright: Chromium (Chrome and Edge), Firefox and WebKit (Safari). Layout here is engine driven rather than OS driven, so the same rules apply on Linux, macOS and Windows.

Viewport matrix of 242 measured cases (121 before, 121 after) across 36 viewports, 3 engines, and device scale factors 1x, 2x and 3x:

| variant | failing cases |
| --- | --- |
| before | 31 |
| after | 0 |

Edge cases, 150 assertions per variant, covering real device descriptors (iPhone, Pixel, Galaxy, iPad), classic space taking scrollbars, root font size at 16/20/24/32px, RTL, a real close button click, short content, live resize while the dialog is open, and dvh under mobile emulation:

| variant | failing assertions |
| --- | --- |
| before | 24 |
| after | 0 |

The before column confirms the tests actually catch the bug rather than passing vacuously. Results were stable across repeated runs, and `bun run build` (including `tsc -b`) passes.