### PR TITLE
Sidebar: settings gear above the profile in the collapsed rail

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1855,6 +1855,18 @@ export function AppSidebar() {
               </button>
             </SidebarMenuItem>
           )}
+          {/* Collapsed rail has no room for the cog on the profile row, so it
+              sits above the avatar instead. */}
+          <NavItem
+            className="hidden group-data-[collapsible=icon]:block"
+            icon={Settings02Icon}
+            label={t("shell.navigation.settings")}
+            active={false}
+            onClick={() => {
+              useSettingsDialogStore.getState().openDialog();
+              closeMobileIfOpen();
+            }}
+          />
           <SidebarMenuItem>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>


### PR DESCRIPTION
The settings cog on the profile row is hidden when the rail collapses (`group-data-[collapsible=icon]:hidden`), so in the collapsed state there is no direct way to open settings. You have to open the account menu first.

This puts a gear directly above the avatar in the collapsed rail, which is where you would reach for it.

### Implementation

Reuses the existing `NavItem`, so the gear picks up the same 32px circular styling, hover state and hover tooltip as the other rail icons, and reuses the existing `shell.navigation.settings` label. No new translation keys.

The item is `hidden group-data-[collapsible=icon]:block`, the mirror of the row cog it stands in for, so exactly one of the two is ever visible.

### Notes

- The expanded rail is untouched. The profile row and its cog behave exactly as before.
- Mobile is unaffected. The sidebar renders as a sheet there, where `data-collapsible` is never `icon`, so the gear stays hidden.
- One file, 12 added lines, no logic changes elsewhere.

### Testing

30 assertions across Chromium, Firefox and WebKit, all passing:

| state | checks |
| --- | --- |
| collapsed | gear visible, sits above the avatar, centred on it to within 1px |
| collapsed | profile-row cog stays hidden, so there is no duplicate control |
| collapsed | gear is hit-testable and a real click lands |
| collapsed | gear stays inside the rail, no overflow |
| expanded | gear hidden and row cog visible, so the current UI is unchanged |

Geometry was measured against the real compiled CSS, with the class strings and DOM order asserted against `app-sidebar.tsx` so the test cannot drift from the component. `bun run build` (including `tsc -b`) and `bun run i18n:check` both pass.