### PR TITLE
tests: import bitsandbytes before the CUDA/ROCm spoof so Repo tests (CPU) is green again

### DIFF
--- a/tests/_zoo_aggressive_cuda_spoof.py
+++ b/tests/_zoo_aggressive_cuda_spoof.py
@@ -15,12 +15,35 @@ import types
 from typing import Any
 
 
+def _preimport_bitsandbytes() -> None:
+    """Import the real bitsandbytes BEFORE the spoof flips torch.cuda.is_available().
+
+    bitsandbytes picks its backend at import time: `if torch.cuda.is_available():
+    from .backends.cuda import ops`, and that module binds
+    torch._C._cuda_getCurrentRawStream, which a CPU-only torch build does not
+    have. Under the spoof the probe answers True, so a later `import
+    bitsandbytes` (unsloth_zoo.temporary_patches.moe_utils, unsloth.models._utils)
+    takes the CUDA/ROCm branch and dies with AttributeError on a GPU-less runner.
+    Importing first pins the CPU backend; every later import reuses the cached
+    module. tests/conftest.py gets this ordering for free (it imports unsloth at
+    collection, before any fixture spoofs), subprocess children do not.
+    """
+    if "bitsandbytes" in sys.modules:
+        return
+    try:
+        import bitsandbytes  # noqa: F401
+    except Exception:
+        pass  # not installed, or a genuinely broken build: leave it to the caller
+
+
 def apply() -> None:
     """Apply the spoof. Idempotent: calling again has no effect."""
     import torch
 
     if getattr(torch.cuda, "_unsloth_consolidated_spoof", False):
         return
+
+    _preimport_bitsandbytes()  # must run while the device probes are still honest
 
     # Device probes (cheap, value-returning)
     torch.cuda.is_available = lambda: True

--- a/tests/_zoo_rocm_spoof.py
+++ b/tests/_zoo_rocm_spoof.py
@@ -54,7 +54,9 @@ def apply(gfx: str = "gfx1100", device_count: int = 1) -> None:
         raise KeyError(f"Unknown gfx {gfx!r}; known: {', '.join(_PROFILES)}")
     name, cap, hip = _PROFILES[gfx]
 
-    _cuda_spoof().apply()  # is_available/device_count/streams/rng/amp/...
+    # is_available/device_count/streams/rng/amp/..., and the bitsandbytes
+    # pre-import that has to happen before torch looks like a GPU host.
+    _cuda_spoof().apply()
 
     # Overlay the AMD identity on top of the (NVIDIA-shaped) CUDA spoof.
     torch.version.hip = hip

--- a/tests/studio/install/test_rocm_rdna_routing.py
+++ b/tests/studio/install/test_rocm_rdna_routing.py
@@ -62,7 +62,10 @@ def routed():
     code = _CHILD.format(tests = str(_TESTS_DIR), arches = list(_ARCHES))
     proc = subprocess.run([sys.executable, "-c", code], capture_output = True, text = True)
     line = next((l for l in proc.stdout.splitlines() if l.startswith("RESULT ")), None)
-    assert line, f"child produced no result.\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    assert line, (
+        f"child produced no result (exit code {proc.returncode}).\n"
+        f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
     return json.loads(line[len("RESULT ") :])
 
 


### PR DESCRIPTION
### Problem

`Backend CI / Repo tests (CPU)` is red on `main`, so every open PR inherits a red check. The last three completed runs on `main` fail identically (runs 30189939987, 30183620518, 30180331443): `2716 passed, 72 skipped, 12 errors`, with all 12 errors being setup errors in one file, `tests/studio/install/test_rocm_rdna_routing.py`:

```
ERROR at setup of test_detect_gpu_target[gfx1030 .. gfx1201]
ERROR at setup of test_device_type_is_hip
AssertionError: child produced no result.
```

### Root cause

The `routed` module fixture runs a child process that applies `tests/_zoo_rocm_spoof`, imports `unsloth_zoo.device_type` / `unsloth_zoo.llama_cpp`, and prints a `RESULT {json}` line the parent parses. The child dies before printing it.

`_zoo_aggressive_cuda_spoof.apply()` (which `_zoo_rocm_spoof.apply()` delegates to) sets `torch.cuda.is_available()` to `True`, and the ROCm spoof then layers `torch.version.hip` on top. `bitsandbytes` picks its backend at import time:

```python
if torch.cuda.is_available():
    from .backends.cuda import ops as cuda_ops
```

and `bitsandbytes/backends/cuda/ops.py` binds `torch._C._cuda_getCurrentRawStream`, which the CPU-only torch build on the runner does not have. The child imports `unsloth_zoo`, whose `temporary_patches.moe_utils` does `import bitsandbytes as bnb`, that import takes the CUDA/ROCm branch under the spoof, and the child dies with:

```
File ".../bitsandbytes/__init__.py", line 36, in <module>
    from .backends.cuda import ops as cuda_ops
File ".../bitsandbytes/backends/cuda/ops.py", line 69, in <module>
    _get_raw_stream = torch._C._cuda_getCurrentRawStream
AttributeError: module 'torch._C' has no attribute '_cuda_getCurrentRawStream'
```

The `libhipblas.so.2: cannot open shared object file` line and the `rocminfo` "no such file" line that appear earlier in the same stderr are logged by bitsandbytes and are **not** fatal: bitsandbytes catches that failure and installs a mock native library. They are the visible symptom of the spoofed HIP identity, not the cause of the crash.

The job started failing without a code change on our side because it installs `bitsandbytes>=0.45`, which now resolves to 0.50.0, and that release imports the CUDA backend ops module eagerly at package import.

### Fix

`tests/conftest.py` already gets the safe ordering for free: it imports `unsloth` at collection time, before any fixture spoofs torch, so in-process tests always see a bitsandbytes that was resolved against honest device probes. Subprocess children that apply the spoof standalone do not.

So the spoof itself now does the same thing: `_zoo_aggressive_cuda_spoof.apply()` imports bitsandbytes once, before it flips `torch.cuda.is_available()`. That pins the CPU backend and every later `import bitsandbytes` reuses the cached module. The import is guarded, so a host without bitsandbytes (or with a broken build) is unaffected.

This keeps the coverage intact. No test is deleted, xfailed, skipped, or weakened. The child still resolves `get_device_type()` to `"hip"`, `is_hip()` to `True`, and `lc._detect_gpu_target()` to `("rocm", gfx)` for all 11 RDNA2 / RDNA3 / RDNA3.5 / RDNA4 arches, against real `unsloth_zoo` code.

The fixture assertion also now reports the child's exit code alongside stdout and stderr, so the next breakage of this shape is obvious from the log.

### Verification

Reproduced locally in a venv that mirrors the job (Python 3.12, CPU-only `torch 2.10.0+cpu`, `bitsandbytes 0.50.0`, `unsloth_zoo` from git main, `pip install -e . --no-deps`):

- before: `11 passed, 12 errors` for `tests/studio/install/test_rocm_rdna_routing.py`, matching CI exactly (the 11 passes are the pure-mapping `test_rocm_gfx_family` cases, which never needed a child).
- after: `23 passed`.
- child under the fix now reports `DEVICE hip True`, `TARGET ('rocm', 'gfx1030')`, and `BNB backend CPU / HIP_ENVIRONMENT False`, with the real CPU native library loaded instead of the error mock, so no `libhipblas` or `rocminfo` probe is attempted at all.
- the same file passes on a CUDA torch build too, where it was already green.
- `tests/studio/install/`: `1411 passed, 2 skipped` (the 3 `test_managed_node_runtime.py` failures on my box are a pre-existing local-environment artifact, they fail identically on a clean checkout of `main`).
- full job command (`pytest tests/` with the workflow's ignores, markers and deselects): `2848 passed, 70 skipped, 23 deselected`, zero errors. The one failure, `tests/studio/test_ui_font_scale_contract.py::test_no_raw_pixel_text_utilities`, also fails on a clean checkout of `main` in this environment and is unrelated.
- the isolated hardware-spoof step (`test_hardware_dispatch_matrix.py`, `test_is_mlx_dispatch_gate.py`, `test_xpu_spoof_pipeline.py`): `57 passed, 1 skipped`.