### PR TITLE
Studio: use the UI font scale tokens in the Agents settings tab

### DIFF
--- a/studio/frontend/src/features/settings/tabs/agents-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/agents-tab.tsx
@@ -104,7 +104,7 @@ function AgentIcon({
     <span
       aria-hidden={true}
       style={{ backgroundColor: color }}
-      className="flex size-7 shrink-0 items-center justify-center rounded-md font-heading text-[11px] font-semibold text-white"
+      className="flex size-7 shrink-0 items-center justify-center rounded-md font-heading text-ui-11 font-semibold text-white"
     >
       {mark}
     </span>
@@ -371,12 +371,12 @@ export function AgentsTab() {
                   {agent.name}
                 </span>
                 {detected.has(agent.id) ? (
-                  <span className="shrink-0 rounded-full bg-control-accent/10 px-2 py-1 text-[10px] leading-none font-semibold text-control-accent">
+                  <span className="shrink-0 rounded-full bg-control-accent/10 px-2 py-1 text-ui-10 leading-none font-semibold text-control-accent">
                     {t("settings.agents.quickstart.installed")}
                   </span>
                 ) : null}
                 {agent.id === "codex" && !isGguf ? (
-                  <span className="shrink-0 rounded-full bg-muted px-2 py-1 text-[10px] leading-none font-semibold text-muted-foreground">
+                  <span className="shrink-0 rounded-full bg-muted px-2 py-1 text-ui-10 leading-none font-semibold text-muted-foreground">
                     {t("settings.agents.supportedAgents.requiresGguf")}
                   </span>
                 ) : null}


### PR DESCRIPTION
The Agents settings tab landed with three raw px text utilities, so its avatar initials and the two status pills ignore the UI font size preference: they stay fixed while the rest of the dialog scales.

This swaps them for the `text-ui-*` tokens the rest of the frontend already uses.

```
studio/frontend/src/features/settings/tabs/agents-tab.tsx

  text-[11px]  ->  text-ui-11    avatar initials
  text-[10px]  ->  text-ui-10    "default" pill
  text-[10px]  ->  text-ui-10    "configured" pill
```

Those tokens are the established convention, with 149 and 128 existing call sites respectively.

## Why this is worth landing on its own

`tests/studio/test_ui_font_scale_contract.py::test_no_raw_pixel_text_utilities` guards exactly this, so `Repo tests (CPU)` has been red on main since the tab was added, and every open PR inherits the failure regardless of what it touches.

## Verification

Run from the repo root against `tests/studio/`, excluding `test_cli_repo_variant.py` which fails to collect locally on an unrelated `typer` issue:

- without this change: 9 failed, 1729 passed
- with this change: 8 failed, 1730 passed

Diffing the two failure sets, the only difference is `test_no_raw_pixel_text_utilities` moving to passing. Nothing else changes, in either direction. `tests/studio/test_ui_font_scale_contract.py` on its own is 11 passed.