### PR TITLE
Studio Agents tab: use text-ui-* tokens instead of raw px text sizes

### DIFF
--- a/studio/frontend/src/features/settings/tabs/agents-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/agents-tab.tsx
@@ -104,7 +104,7 @@ function AgentIcon({
     <span
       aria-hidden={true}
       style={{ backgroundColor: color }}
-      className="flex size-7 shrink-0 items-center justify-center rounded-md font-heading text-[11px] font-semibold text-white"
+      className="flex size-7 shrink-0 items-center justify-center rounded-md font-heading text-ui-11 font-semibold text-white"
     >
       {mark}
     </span>
@@ -371,12 +371,12 @@ export function AgentsTab() {
                   {agent.name}
                 </span>
                 {detected.has(agent.id) ? (
-                  <span className="shrink-0 rounded-full bg-control-accent/10 px-2 py-1 text-[10px] leading-none font-semibold text-control-accent">
+                  <span className="shrink-0 rounded-full bg-control-accent/10 px-2 py-1 text-ui-10 leading-none font-semibold text-control-accent">
                     {t("settings.agents.quickstart.installed")}
                   </span>
                 ) : null}
                 {agent.id === "codex" && !isGguf ? (
-                  <span className="shrink-0 rounded-full bg-muted px-2 py-1 text-[10px] leading-none font-semibold text-muted-foreground">
+                  <span className="shrink-0 rounded-full bg-muted px-2 py-1 text-ui-10 leading-none font-semibold text-muted-foreground">
                     {t("settings.agents.supportedAgents.requiresGguf")}
                   </span>
                 ) : null}


### PR DESCRIPTION
### Problem

`Backend CI / Repo tests (CPU)` is red on `main` for a second reason, on top of the ROCm routing errors that #7461 fixes:

```
FAILED tests/studio/test_ui_font_scale_contract.py::test_no_raw_pixel_text_utilities
AssertionError: Raw px text utilities ignore the UI font size preference; use the
text-ui-* / leading-ui-* tokens in index.css instead:
['features/settings/tabs/agents-tab.tsx: text-[11px]',
 'features/settings/tabs/agents-tab.tsx: text-[10px]',
 'features/settings/tabs/agents-tab.tsx: text-[10px]']
```

The Agents settings tab added in #7303 carries three raw pixel text utilities. Raw `text-[Npx]` bypasses the `--ui-font-scale` tokens, so that text ignores the Settings > Appearance UI font size preference, which is exactly what the contract guards against.

### Fix

Swap them for the equivalent scaled tokens, the same treatment the voice tab got in #7378:

- `text-[11px]` -> `text-ui-11` (`calc(0.6875rem * var(--ui-font-scale, 1))`)
- `text-[10px]` -> `text-ui-10` (`calc(0.625rem * var(--ui-font-scale, 1))`)

Both resolve to the current pixel size at scale 1, so the default rendering is byte-for-byte the same size and the text now follows the preference when it is changed.

### Verification

`pytest tests/studio/test_ui_font_scale_contract.py -q` -> `11 passed` (was `1 failed, 10 passed`).