### PR TITLE
Studio: use the scaling text tokens in the Agents settings tab

### DIFF
--- a/studio/frontend/src/features/settings/tabs/agents-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/agents-tab.tsx
@@ -104,7 +104,7 @@ function AgentIcon({
     <span
       aria-hidden={true}
       style={{ backgroundColor: color }}
-      className="flex size-7 shrink-0 items-center justify-center rounded-md font-heading text-[11px] font-semibold text-white"
+      className="flex size-7 shrink-0 items-center justify-center rounded-md font-heading text-ui-11 font-semibold text-white"
     >
       {mark}
     </span>
@@ -371,12 +371,12 @@ export function AgentsTab() {
                   {agent.name}
                 </span>
                 {detected.has(agent.id) ? (
-                  <span className="shrink-0 rounded-full bg-control-accent/10 px-2 py-1 text-[10px] leading-none font-semibold text-control-accent">
+                  <span className="shrink-0 rounded-full bg-control-accent/10 px-2 py-1 text-ui-10 leading-none font-semibold text-control-accent">
                     {t("settings.agents.quickstart.installed")}
                   </span>
                 ) : null}
                 {agent.id === "codex" && !isGguf ? (
-                  <span className="shrink-0 rounded-full bg-muted px-2 py-1 text-[10px] leading-none font-semibold text-muted-foreground">
+                  <span className="shrink-0 rounded-full bg-muted px-2 py-1 text-ui-10 leading-none font-semibold text-muted-foreground">
                     {t("settings.agents.supportedAgents.requiresGguf")}
                   </span>
                 ) : null}


### PR DESCRIPTION
The Agents settings tab added in #7303 sets three labels with raw px text utilities, which ignore the UI font size preference in Settings > Appearance. The avatar initial and both status pills stay at a fixed size while everything around them scales.

`tests/studio/test_ui_font_scale_contract.py::test_no_raw_pixel_text_utilities` guards against exactly this, so main is currently red and every open PR inherits the failure:

```
AssertionError: Raw px text utilities ignore the UI font size preference;
use the text-ui-* / leading-ui-* tokens in index.css instead:
['features/settings/tabs/agents-tab.tsx: text-[11px]',
 'features/settings/tabs/agents-tab.tsx: text-[10px]',
 'features/settings/tabs/agents-tab.tsx: text-[10px]']
```

### Change

Three class names in `studio/frontend/src/features/settings/tabs/agents-tab.tsx`:

| line | before | after |
| --- | --- | --- |
| 107 | `text-[11px]` | `text-ui-11` |
| 374 | `text-[10px]` | `text-ui-10` |
| 379 | `text-[10px]` | `text-ui-10` |

Both tokens already exist in `index.css` and are the same sizes multiplied by the preference:

```css
--text-ui-10: calc(0.625rem * var(--ui-font-scale, 1));
--text-ui-11: calc(0.6875rem * var(--ui-font-scale, 1));
```

At the default scale of 1 they render at 10px and 11px, so the appearance is unchanged; they now follow the preference like the rest of the tab.

### Verification

`tests/studio/test_ui_font_scale_contract.py` goes from 1 failed to 11 passed.
