### PR TITLE
Remove the no-op rmtree guard around the GGUF save

### DIFF
--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -187,6 +187,8 @@ def _save_pretrained_gguf(
         tokenizer = self.tokenizer
 
     # 4. Call Unsloth's GGUF saver on the inner model targeting the transformer subdirectory
+    # No rmtree guard here: the merge cleanup that deletes save_directory is gated on
+    # push_to_hub, which is forced False below.
     result = unsloth_save_pretrained_gguf(
         inner_model,
         save_directory = transformer_dir,

--- a/unsloth/models/sentence_transformer.py
+++ b/unsloth/models/sentence_transformer.py
@@ -186,32 +186,21 @@ def _save_pretrained_gguf(
     if tokenizer is None:
         tokenizer = self.tokenizer
 
-    # 4. Patch environment so Unsloth treats this embedding model correctly
-    @contextlib.contextmanager
-    def patch_unsloth_gguf_save():
-        # Prevent deletion of the directory self.save_pretrained just created
-        original_rmtree = shutil.rmtree
-        try:
-            yield
-        finally:
-            shutil.rmtree = original_rmtree
+    # 4. Call Unsloth's GGUF saver on the inner model targeting the transformer subdirectory
+    result = unsloth_save_pretrained_gguf(
+        inner_model,
+        save_directory = transformer_dir,
+        tokenizer = tokenizer,
+        quantization_method = quantization_method,
+        first_conversion = first_conversion,
+        push_to_hub = False,  # Force local first to move files
+        token = token,
+        max_shard_size = max_shard_size,
+        temporary_location = temporary_location,
+        maximum_memory_usage = maximum_memory_usage,
+    )
 
-    # 5. Call Unsloth's GGUF saver on the inner model targeting the transformer subdirectory
-    with patch_unsloth_gguf_save():
-        result = unsloth_save_pretrained_gguf(
-            inner_model,
-            save_directory = transformer_dir,
-            tokenizer = tokenizer,
-            quantization_method = quantization_method,
-            first_conversion = first_conversion,
-            push_to_hub = False,  # Force local first to move files
-            token = token,
-            max_shard_size = max_shard_size,
-            temporary_location = temporary_location,
-            maximum_memory_usage = maximum_memory_usage,
-        )
-
-    # 6. Move GGUF files from the subdirectory (0_Transformer) to the root save_directory
+    # 5. Move GGUF files from the subdirectory (0_Transformer) to the root save_directory
     gguf_files = result.get("gguf_files", [])
 
     new_gguf_locations = []
@@ -241,7 +230,7 @@ def _save_pretrained_gguf(
 
     result["gguf_files"] = new_gguf_locations
 
-    # 7. Add branding
+    # 6. Add branding
     try:
         FastSentenceTransformer._add_unsloth_branding(save_directory)
 
@@ -256,7 +245,7 @@ def _save_pretrained_gguf(
     except:
         pass
 
-    # 8. Handle Push to Hub if requested
+    # 7. Handle Push to Hub if requested
     if push_to_hub:
         if token is None:
             token = get_token()


### PR DESCRIPTION
Follow-up to #7149, doing the cleanup @oobabooga named when closing it: *"the correct cleanup is to remove the dead context manager instead."*

`patch_unsloth_gguf_save` saves `shutil.rmtree` and restores it, but never replaces it, so the context manager does nothing while its comment says it prevents deletion of the directory `save_pretrained` just created:

```python
@contextlib.contextmanager
def patch_unsloth_gguf_save():
    # Prevent deletion of the directory self.save_pretrained just created
    original_rmtree = shutil.rmtree
    try:
        yield
    finally:
        shutil.rmtree = original_rmtree
```

It looks like a copy of the `patch_unsloth_save` sibling ~100 lines above, minus the one line that does the work (`shutil.rmtree = lambda *args, **kwargs: None`), which is why my first instinct in #7149 was to add that line back.

That was the wrong call, and @oobabooga's reasoning in #7149 is why: the GGUF call forces `push_to_hub=False`, and the merge cleanup that would remove the save directory is gated on `push_to_hub=True`, so nothing on this path calls `rmtree` at all. They confirmed it on a real LoRA-backed `q8_0` export with every `rmtree` call logged: zero calls, output directory intact. A guard for something that does not happen is not worth a process-wide monkeypatch.

So this deletes it rather than completing it. Behaviour is unchanged, and the point is to stop shipping something that reads as a safety guard and is not one, so the next person does not have to re-derive that it is inert.

The following step comments are renumbered to stay contiguous. `contextlib` and `shutil` are both still used elsewhere in the file, so the imports stay.

No test: there is no behaviour to pin, which is the whole point. Happy to close if you would rather leave it.
