### PR TITLE
Baseline the fastapi SSE keepalive loop after its 0.140.0 rewrite

### DIFF
--- a/scripts/scan_packages_baseline.json
+++ b/scripts/scan_packages_baseline.json
@@ -99,6 +99,14 @@
       "evidence_hash": "57acd497f404c203e4450d0580ad85aa8a33406e8d64ad06fbac6cf47d97b24d"
     },
     {
+      "package": "fastapi",
+      "file": "fastapi/routing.py",
+      "check": "C2 polling/beaconing loop detected",
+      "severity": "CRITICAL",
+      "evidence": "L592:                                 while True: sha256:84283c09277ded3296998b2a6a838744457b606829cf5ab5d0da6f222ff020a0",
+      "evidence_hash": "a7295004315e26a8f3c64fb837521e9fdd7268219bb43e000fb0236ab0259223"
+    },
+    {
       "package": "fastmcp-slim",
       "file": "fastmcp/cli/apps_dev.py",
       "check": "Creates archive with sensitive data AND makes network calls",


### PR DESCRIPTION
`Security audit` fails on main. The `pip scan-packages :: studio` job reports one unsuppressed CRITICAL:

```
Summary: 1 CRITICAL, 293 MEDIUM
150 finding(s) suppressed by baseline scripts/scan_packages_baseline.json (96 CRITICAL, 54 HIGH, 0 MEDIUM)

[1] CRITICAL  C2 polling/beaconing loop detected
    Package:  fastapi
    File:     fastapi/routing.py
    Evidence: L592:  while True: sha256:84283c09...
```

### Why it reopened

The same package, file and check are already in the baseline:

```json
{
  "package": "fastapi",
  "file": "fastapi/routing.py",
  "check": "C2 polling/beaconing loop detected",
  "evidence": "L587: while True: sha256:06c2c7f1...",
  "evidence_hash": "57acd497..."
}
```

Entries are keyed on `(package, package-relative file, check, evidence_hash)`, and the hash is taken over the matched code with the `L<NN>:` markers stripped. So a line shift alone would not reopen it, but fastapi 0.140.0 rewrote the block and the digest changed. That is the baseline behaving as designed, and it means the new code needs its own review rather than a regenerated file.

### Reviewing the new code

`fastapi/routing.py` at 0.140.0:

```python
async def _keepalive_inserter() -> None:
    """Read from the producer and forward to the output,
    inserting keepalive comments on timeout."""
    async with send_keepalive, receive_stream:
        try:
            while True:
                try:
                    with anyio.fail_after(_PING_INTERVAL):
                        data = await receive_stream.receive()
                    await send_keepalive.send(data)
                except TimeoutError:
                    await send_keepalive.send(KEEPALIVE_COMMENT)
        except anyio.EndOfStream:
            pass
```

This is the Server-Sent Events keepalive path. It reads from one in-memory `anyio` stream and forwards to another, emitting `KEEPALIVE_COMMENT` when a read exceeds `_PING_INTERVAL`. There is no socket, no outbound host, no fetched or executed command, and the loop exits on `EndOfStream`. The heuristic matches on shape alone, an unbounded loop containing a timeout and a send, so this is a false positive in the same way the previous revision was.

### Change

One entry added, generated by `scan_packages.py --write-baseline` against `fastapi==0.140.0` rather than hand-written. The pre-existing fastapi entry is kept, not replaced: `studio/backend/requirements/studio.txt` lists `fastapi` unpinned, so an older resolve still needs the old digest. No other entry is touched, and nothing is removed.

### Verification

```
$ python3 scripts/scan_packages.py -r <fastapi==0.140.0> --baseline scripts/scan_packages_baseline.json
  All clean. No suspicious patterns found.
  1 finding(s) suppressed by baseline (1 CRITICAL, 0 HIGH, 0 MEDIUM)
  EXIT=0
```

Confirmed the same run reports the CRITICAL with `--no-baseline`, so the suppression is doing the work and the finding is genuinely the one under review.
