### PR TITLE
Fix the wall-clock timeout tests on Python 3.10

### DIFF
--- a/studio/backend/tests/test_research_runs_hardening.py
+++ b/studio/backend/tests/test_research_runs_hardening.py
@@ -861,7 +861,9 @@ def test_stream_completion_timeout_is_absolute_despite_keepalives(monkeypatch):
 
 
 def test_wall_clock_timeout_supports_python_without_asyncio_timeout(monkeypatch):
-    monkeypatch.delattr(research_runs.asyncio, "timeout")
+    # raising=False: on Python 3.10 asyncio.timeout does not exist to begin with,
+    # which is the very case these tests cover.
+    monkeypatch.delattr(research_runs.asyncio, "timeout", raising = False)
 
     async def run():
         async with research_runs._wall_clock_timeout(0.01):
@@ -872,7 +874,9 @@ def test_wall_clock_timeout_supports_python_without_asyncio_timeout(monkeypatch)
 
 
 def test_wall_clock_timeout_does_not_swallow_shutdown_cancellation(monkeypatch):
-    monkeypatch.delattr(research_runs.asyncio, "timeout")
+    # raising=False: on Python 3.10 asyncio.timeout does not exist to begin with,
+    # which is the very case these tests cover.
+    monkeypatch.delattr(research_runs.asyncio, "timeout", raising = False)
 
     async def run(cleanup_started: asyncio.Event):
         async with research_runs._wall_clock_timeout(0.01):


### PR DESCRIPTION
## Problem

`Backend CI` is red on its Python 3.10 leg:

```
FAILED tests/test_research_runs_hardening.py::test_wall_clock_timeout_supports_python_without_asyncio_timeout - AttributeError: timeout
FAILED tests/test_research_runs_hardening.py::test_wall_clock_timeout_does_not_swallow_shutdown_cancellation - AttributeError: timeout
```

Both tests do:

```python
monkeypatch.delattr(research_runs.asyncio, "timeout")
```

to exercise the fallback branch in `_wall_clock_timeout`. `asyncio.timeout` was added in Python 3.11, so on 3.10 the attribute does not exist to begin with and `monkeypatch.delattr` raises `AttributeError` before the test body runs.

The irony is that the failing case is exactly the one the tests are named after: 3.10 is the interpreter without `asyncio.timeout`. The helper itself is already correct, it uses `getattr(asyncio, "timeout", None)`.

## Fix

`raising = False` on both calls. The intent is "make sure the attribute is absent", and that holds whether it was there to delete or not.

## Verification

Simulated 3.10 by deleting `asyncio.timeout` before collection, then ran the two tests against the file before and after:

```
BEFORE fix:  2 failed
AFTER  fix:  2 passed
```

They also still pass normally on 3.13, where the attribute is present and actually gets removed.

AST check: the two calls gained a `raising` keyword and nothing else in the file changed.

## How I hit it

Staging CI for #7486 and #7487 on two different staging repos, both of which failed `Backend CI` on these same two tests while touching nothing related. The tests landed in #7219 earlier today.
