### PR TITLE
tests: record the gfx1152 llama.cpp bundle gap so the next one is not silent

### DIFF
--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -3016,12 +3016,8 @@ class TestPublishedRocmBundleCoverage:
 
         # Read the table from source rather than importing the installer module,
         # which pulls in a heavy dependency chain this suite does not need.
-        stack = (PACKAGE_ROOT / "studio" / "install_python_stack.py").read_text(
-            encoding = "utf-8"
-        )
-        body = re.search(
-            r"_GFX_TO_AMD_INDEX_ARCH.*?=\s*\{(.*?)\n\}", stack, re.S
-        )
+        stack = (PACKAGE_ROOT / "studio" / "install_python_stack.py").read_text(encoding = "utf-8")
+        body = re.search(r"_GFX_TO_AMD_INDEX_ARCH.*?=\s*\{(.*?)\n\}", stack, re.S)
         assert body, "_GFX_TO_AMD_INDEX_ARCH not found in install_python_stack.py"
         routed = set(re.findall(r'"(gfx[0-9a-z]+)":', body.group(1)))
         assert routed, "parsed no arches out of _GFX_TO_AMD_INDEX_ARCH"

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -2935,6 +2935,104 @@ class TestPublishedRocmGfxSelection:
         assert choice.name == "app-b9457-windows-x64-rocm-gfx120X.zip"
 
 
+class TestPublishedRocmBundleCoverage:
+    """Every arch the installer routes torch for should also have a llama.cpp
+    bundle, or be recorded here as a known gap. Routing an arch for torch while
+    no bundle covers it is silent: the GPU works for training and drops to a HIP
+    source build for inference, which is correct but much slower to install."""
+
+    # mapped_targets of each published ROCm bundle, mirroring
+    # unslothai/llama.cpp's llama-prebuilt-manifest.json.
+    PUBLISHED = {
+        "gfx103X": ["gfx1030", "gfx1031", "gfx1032", "gfx1034"],
+        "gfx110X": ["gfx1100", "gfx1101", "gfx1102", "gfx1103"],
+        "gfx120X": ["gfx1200", "gfx1201"],
+        "gfx1150": ["gfx1150"],
+        "gfx1151": ["gfx1151"],
+        "gfx908": ["gfx908"],
+        "gfx90a": ["gfx90a"],
+    }
+
+    # Arches _GFX_TO_AMD_INDEX_ARCH routes torch for that no bundle covers.
+    #   gfx1033/1035/1036: RDNA 2 variants, never built.
+    #   gfx1152: Krackan Point (Radeon 860M/840M). Torch goes to its own
+    #     repo.amd.com/rocm/whl/gfx1152 leaf, but no llama.cpp bundle exists, so
+    #     these hosts source-build. Publish a -gfx1152 bundle, or add gfx1152 to
+    #     the gfx1150 bundle's mapped_targets if that build genuinely covers it,
+    #     then drop it from this set.
+    KNOWN_GAPS = {"gfx1033", "gfx1035", "gfx1036", "gfx1152"}
+
+    def _release(self):
+        return make_release(
+            [
+                make_artifact(
+                    f"app-b9457-linux-x64-rocm-{fam}.tar.gz",
+                    install_kind = "linux-rocm",
+                    runtime_line = None,
+                    coverage_class = None,
+                    supported_sms = [],
+                    min_sm = None,
+                    max_sm = None,
+                    bundle_profile = None,
+                    rank = 1000,
+                    gfx_target = fam,
+                    mapped_targets = targets,
+                )
+                for fam, targets in self.PUBLISHED.items()
+            ],
+            upstream_tag = "b9457",
+        )
+
+    def _host(self, gfx):
+        return make_host(
+            machine = "x86_64",
+            nvidia_smi = None,
+            driver_cuda_version = None,
+            compute_caps = [],
+            has_physical_nvidia = False,
+            has_usable_nvidia = False,
+            has_rocm = True,
+            rocm_gfx_target = gfx,
+        )
+
+    def test_known_gaps_fall_back_to_source_build(self):
+        """A gap arch must return None rather than be served a sibling bundle:
+        a wrong-ISA binary fails at the first BLAS call instead of installing
+        slowly, which is the worse of the two outcomes."""
+        release = self._release()
+        for gfx in sorted(self.KNOWN_GAPS):
+            assert (
+                INSTALL_LLAMA_PREBUILT.published_rocm_choice_for_host(
+                    release, self._host(gfx), "linux-rocm"
+                )
+                is None
+            ), f"{gfx} is in KNOWN_GAPS but a bundle now matches it; drop it from the set"
+
+    def test_every_torch_routed_arch_is_covered_or_a_known_gap(self):
+        """The guard that would have caught gfx1152: adding an arch to
+        _GFX_TO_AMD_INDEX_ARCH without a bundle must be a deliberate entry in
+        KNOWN_GAPS, not an unnoticed drop to source builds."""
+        import re
+
+        # Read the table from source rather than importing the installer module,
+        # which pulls in a heavy dependency chain this suite does not need.
+        stack = (PACKAGE_ROOT / "studio" / "install_python_stack.py").read_text(
+            encoding = "utf-8"
+        )
+        body = re.search(
+            r"_GFX_TO_AMD_INDEX_ARCH.*?=\s*\{(.*?)\n\}", stack, re.S
+        )
+        assert body, "_GFX_TO_AMD_INDEX_ARCH not found in install_python_stack.py"
+        routed = set(re.findall(r'"(gfx[0-9a-z]+)":', body.group(1)))
+        assert routed, "parsed no arches out of _GFX_TO_AMD_INDEX_ARCH"
+        covered = {t.lower() for targets in self.PUBLISHED.values() for t in targets}
+        uncovered = {a for a in routed if a.lower() not in covered}
+        assert uncovered == self.KNOWN_GAPS, (
+            f"llama.cpp bundle coverage drifted: {sorted(uncovered - self.KNOWN_GAPS)} "
+            f"newly uncovered, {sorted(self.KNOWN_GAPS - uncovered)} no longer a gap"
+        )
+
+
 class TestPublishedMacosForkSelection:
     """macOS routes to the fork's llama-<tag>-bin-macos-<arch>.tar.gz, selected by install_kind."""
 


### PR DESCRIPTION
Follow-up to #7431. Tests only, no production code changes.

#7431 made gfx1152 (Krackan Point, Radeon 860M/840M) a first-class arch. That fixed the torch side: those laptops were pulling gfx1150 wheels built for a different LLVM target, and `repo.amd.com` publishes gfx1150 and gfx1152 as separate index leaves with separately built wheels.

It also changed llama.cpp prebuilt selection, which we did not notice at the time. No gfx1152 bundle is published:

```
gfx103X  mapped_targets=['gfx1030', 'gfx1031', 'gfx1032', 'gfx1034']
gfx110X  mapped_targets=['gfx1100', 'gfx1101', 'gfx1102', 'gfx1103']
gfx1150  mapped_targets=['gfx1150']
gfx1151  mapped_targets=['gfx1151']
gfx120X  mapped_targets=['gfx1200', 'gfx1201']
gfx908   mapped_targets=['gfx908']
gfx90a   mapped_targets=['gfx90a']
```

`published_rocm_choice_for_host` deliberately refuses to serve a sibling-family bundle, so a Krackan host now falls back to a HIP source build where it previously downloaded the gfx1150 prebuilt.

## Why this is not a revert

The source build is the correct outcome. The gfx1150 binary was being handed to gfx1152 hardware before, and these bundles carry the ROCm runtime inside them (`rocblas.dll`, `hipblas.dll`, `amdhip64_7.dll`), whose Tensile kernels are arch-specific. That is the same failure mode as the gfx906 breakage in #7354: a wrong-ISA binary dies at the first BLAS call rather than merely installing slowly. Trading a fast broken install for a slow working one is the right direction.

What was wrong is that nothing recorded the gap and nothing would have caught it. `TestPublishedRocmGfxSelection` builds its release from a hardcoded family list, so it can only assert about arches someone already thought to add.

## What this adds

`TestPublishedRocmBundleCoverage`:

- `PUBLISHED` mirrors the `mapped_targets` in `llama-prebuilt-manifest.json`.
- `KNOWN_GAPS` lists the arches `_GFX_TO_AMD_INDEX_ARCH` routes torch for that no bundle covers: `gfx1033/1035/1036` (RDNA 2, never built) and `gfx1152`, each with the reason and, for gfx1152, how to close it.
- `test_known_gaps_fall_back_to_source_build` pins each gap to `None`.
- `test_every_torch_routed_arch_is_covered_or_a_known_gap` compares the torch-routed set against bundle coverage, so adding an arch for torch without a bundle has to be a deliberate `KNOWN_GAPS` entry rather than an unnoticed drop to source builds.

The invariant fires in both directions. Simulating a new routed arch:

```
AssertionError: llama.cpp bundle coverage drifted: ['gfx1153'] newly uncovered, [] no longer a gap
```

Simulating a published gfx1152 bundle:

```
AssertionError: gfx1152 is in KNOWN_GAPS but a bundle now matches it; drop it from the set
AssertionError: llama.cpp bundle coverage drifted: [] newly uncovered, ['gfx1152'] no longer a gap
```

So closing the gap cannot leave the list stale.

## On whether to publish a gfx1152 bundle

I looked at how common this hardware is before deciding. Per-arch ROCm bundle download counts, unsloth's last three releases next to lemonade's:

| arch | product | unsloth | lemonade |
|---|---|---|---|
| gfx110X | RX 7000 | 30.0% | 21.3% |
| gfx120X | RX 9000 | 27.4% | 21.7% |
| gfx1151 | Strix Halo | 24.1% | 36.6% |
| gfx103X | RX 6000 | 11.8% | 12.6% |
| gfx1150 | Strix Point | 5.9% | 5.3% |

Two independently maintained repos agreeing at 5.9 and 5.3 percent makes gfx1150 a trustworthy number, and ROCm is only about 4 percent of platform binary downloads overall. Krackan sits below Strix Point in the stack and, before #7431, was being counted inside that gfx1150 bucket, so the affected population is a minority of an already small slice.

Worth noting AMD's own lemonade has the same gap on its nightly channel, and fails harder: `rocm_asset_families` does not list gfx1152, unlisted ISAs are used verbatim, so it requests an asset that does not exist and 404s. Its default stable channel sidesteps this entirely by shipping one arch-agnostic binary keyed by ROCm version and injecting per-arch runtime libraries from TheRock, which is why it can claim gfx1152 support without building for it.

So I would not add a bundle just for this. Recording the gap is the proportionate step, and if a Krackan user reports the slow install we have the entry to point at. The near-zero-cost alternative, if we want it sooner, is checking whether the gfx1150 build already lists gfx1152 in its `HIP_ARCHITECTURES`; if it does, adding gfx1152 to that bundle's `mapped_targets` closes this with no new artifact, and these tests will tell us to update `KNOWN_GAPS` when it lands.

## Verification

Windows 11, Strix Halo (gfx1151). Install suite 1355 passed with no new failures against a clean `main` baseline.
