### PR TITLE
pip: put a ceiling on fastapi so a minor bump does not red the audit

### DIFF
--- a/studio/backend/requirements/studio.txt
+++ b/studio/backend/requirements/studio.txt
@@ -1,6 +1,11 @@
 # Unsloth UI backend dependencies
 typer
-fastapi
+# Ceiling, not a freeze: patch releases still flow. A minor bump can rewrite
+# code that scan_packages.py has a reviewed entry for, which reopens the
+# finding and reds the security audit on whatever unrelated PR lands next
+# (0.140.0 rewrote the SSE keepalive loop and did exactly that). Raising the
+# ceiling is a deliberate PR that carries the re-review with it.
+fastapi<0.141
 uvicorn
 pydantic
 packaging


### PR DESCRIPTION
`scan_packages.py` keys each reviewed baseline entry on a digest of the matched code, so a dependency release that rewrites flagged code reopens the finding. That is the intended behaviour, and it is worth keeping.

The cost is where it lands. fastapi 0.140.0 rewrote the SSE keepalive loop in `fastapi/routing.py`, which reopened a CRITICAL that had already been reviewed and baselined once:

```
Summary: 1 CRITICAL, 293 MEDIUM
[1] CRITICAL  C2 polling/beaconing loop detected
    Package: fastapi   File: fastapi/routing.py
```

`Security audit` went red on main, and therefore on every open PR, until #7480 re-reviewed the same false positive and re-baselined it. `fastapi` is unpinned in `studio/backend/requirements/studio.txt`, so the next minor release repeats it, again on whatever unrelated PR happens to be open.

### Change

One line, plus the reason:

```diff
-fastapi
+fastapi<0.141
```

### Why a ceiling rather than an exact pin

A ceiling is not a freeze. `fastapi<0.141` still resolves patch releases inside the current minor, which is where fastapi ships fixes (0.138.1, 0.138.2, 0.139.1, 0.139.2 are all recent examples). What it stops is a *minor* bump arriving unreviewed, and minor is where the rewrites happen.

The effect is to move the re-review to where it belongs: raising the ceiling becomes a deliberate PR that carries the scanner re-review of whatever changed, instead of a surprise red check on someone else's work.

### Verification

```
$ uv pip install 'fastapi<0.141'
Resolved 10 packages
 + fastapi==0.140.0                      # current release still resolves

$ python3 scripts/scan_packages.py -r <fastapi> --baseline scripts/scan_packages_baseline.json
  All clean. No suspicious patterns found.
  1 finding(s) suppressed by baseline (1 CRITICAL, 0 HIGH, 0 MEDIUM)
  EXIT=0
```

### Note

This started as a two-part change. The other half, the Python 3.10 `asyncio.timeout` failure in `tests/test_research_runs_hardening.py`, was already fixed by #7488 while this was being prepared, so only the pin remains here.
