### PR TITLE
Studio: bound how many tool approvals may park their slot

### DIFF
--- a/studio/backend/core/inference/llama_admission.py
+++ b/studio/backend/core/inference/llama_admission.py
@@ -56,14 +56,28 @@ DEFAULT_ADMISSION_QUEUE_PER_SLOT = 16
 # load downshifted to fit VRAM) keeps the depth it had before scaling existed
 # rather than dropping to 16 and rejecting callers that used to queue.
 DEFAULT_ADMISSION_MIN_QUEUE = 64
-# Executor threads kept clear of parked approvals, so generation steps, stream
-# teardown and unrelated to_thread work still run while prompts sit unanswered.
-_EXECUTOR_RESERVE = 4
-
-
 def _executor_workers() -> int:
-    """Threads asyncio's default executor runs to_thread work on."""
-    return min(32, (os.cpu_count() or 1) + 4)
+    """Threads asyncio's default executor runs to_thread work on.
+
+    Mirrors ThreadPoolExecutor's own default sizing, which is what
+    ``loop.run_in_executor(None, ...)`` builds. 3.13 moved that to
+    ``process_cpu_count()``, which honours CPU affinity and cgroup quotas, so
+    reading ``cpu_count()`` would size the budget from the whole host while the
+    executor was sized from the one core the container was given.
+    """
+    cpus = getattr(os, "process_cpu_count", os.cpu_count)() or 1
+    return min(32, cpus + 4)
+
+
+def _executor_reserve(workers: int) -> int:
+    """Threads kept clear of parked approvals.
+
+    For generation steps, stream teardown and unrelated to_thread work. A flat
+    count would leave a 5-worker executor (one usable CPU) with no budget at all,
+    which is the case that most wants a chat to keep moving while another sits on
+    a prompt.
+    """
+    return max(2, workers // 8)
 
 
 def _max_parked(capacity: int) -> int:
@@ -77,7 +91,12 @@ def _max_parked(capacity: int) -> int:
     before parking existed: the prompt holds its slot.
     """
     workers = _executor_workers()
-    return max(0, min(workers // 4, workers - _EXECUTOR_RESERVE - max(0, capacity)))
+    spare = workers - _executor_reserve(workers) - max(0, capacity)
+    # A quarter of the executor, but never fewer than two while there is room for
+    # them: a quarter of five is one, and one park cannot cover two chats sitting
+    # on prompts at once, which is the case #7455 exists for. `spare` still takes
+    # it to zero on an executor the pool already fills.
+    return max(0, min(max(2, workers // 4), spare))
 
 
 # Counted process-wide, not per queue. There is one default executor, but a

--- a/studio/backend/core/inference/llama_admission.py
+++ b/studio/backend/core/inference/llama_admission.py
@@ -56,6 +56,8 @@ DEFAULT_ADMISSION_QUEUE_PER_SLOT = 16
 # load downshifted to fit VRAM) keeps the depth it had before scaling existed
 # rather than dropping to 16 and rejecting callers that used to queue.
 DEFAULT_ADMISSION_MIN_QUEUE = 64
+
+
 def _executor_workers() -> int:
     """Threads asyncio's default executor runs to_thread work on.
 

--- a/studio/backend/core/inference/llama_admission.py
+++ b/studio/backend/core/inference/llama_admission.py
@@ -62,22 +62,18 @@ def _executor_workers() -> int:
     """Threads asyncio's default executor runs to_thread work on.
 
     Mirrors ThreadPoolExecutor's own default sizing, which is what
-    ``loop.run_in_executor(None, ...)`` builds. 3.13 moved that to
-    ``process_cpu_count()``, which honours CPU affinity and cgroup quotas, so
-    reading ``cpu_count()`` would size the budget from the whole host while the
-    executor was sized from the one core the container was given.
+    ``run_in_executor(None, ...)`` builds. 3.13 sizes it from
+    ``process_cpu_count()``, which honours CPU affinity and cgroup quotas;
+    ``cpu_count()`` would budget from the whole host inside a one-core container.
     """
     cpus = getattr(os, "process_cpu_count", os.cpu_count)() or 1
     return min(32, cpus + 4)
 
 
 def _executor_reserve(workers: int) -> int:
-    """Threads kept clear of parked approvals.
-
-    For generation steps, stream teardown and unrelated to_thread work. A flat
-    count would leave a 5-worker executor (one usable CPU) with no budget at all,
-    which is the case that most wants a chat to keep moving while another sits on
-    a prompt.
+    """Threads kept clear of parked approvals, for generation steps, stream
+    teardown and unrelated to_thread work. Scaled rather than flat: a flat count
+    would leave a 5-worker executor (one usable CPU) no budget at all.
     """
     return max(2, workers // 8)
 
@@ -85,26 +81,23 @@ def _executor_reserve(workers: int) -> int:
 def _max_parked(capacity: int) -> int:
     """How many holders may sit on an approval prompt with their slot given back.
 
-    The loop blocks inside the to_thread(next, gen) call that drives it, so a
-    pending prompt parks an executor thread whether or not it parked its slot.
-    The pool already permits `capacity` of those, and every park frees a slot
-    that admits one more, so budget only what the executor has left over. Zero on
-    a backend whose --parallel alone fills it, which then behaves as it did
-    before parking existed: the prompt holds its slot.
+    A pending prompt parks an executor thread (the loop blocks inside
+    to_thread(next, gen)) whether or not it parked its slot, the pool already
+    permits `capacity` of those, and every park admits one more, so budget only
+    what the executor has left over. Zero on a backend whose --parallel alone
+    fills it: the prompt then holds its slot, as it did before parking existed.
     """
     workers = _executor_workers()
     spare = workers - _executor_reserve(workers) - max(0, capacity)
-    # A quarter of the executor, but never fewer than two while there is room for
-    # them: a quarter of five is one, and one park cannot cover two chats sitting
-    # on prompts at once, which is the case #7455 exists for. `spare` still takes
-    # it to zero on an executor the pool already fills.
+    # A quarter of the executor, floored at two while `spare` allows: a quarter of
+    # five is one, and one park cannot cover the two simultaneous prompts #7455
+    # exists for.
     return max(0, min(max(2, workers // 4), spare))
 
 
-# Counted process-wide, not per queue. There is one default executor, but a
-# per-queue budget is the same allowance again for every backend, and base_url
-# carries a fresh port on every model load, so a reload would mint a queue that
-# knows nothing about the approvals still parked on the old one.
+# Process-wide, not per queue: there is one executor, and base_url takes a fresh
+# port on every load, so a per-queue budget would hand the same allowance to each
+# backend and to every reload, blind to the approvals parked on the old queue.
 _PARK_LOCK = threading.Lock()
 _parked_total = 0
 
@@ -127,11 +120,10 @@ def _drop_park() -> None:
 def _live_capacity(current: "LlamaAdmissionQueue") -> int:
     """Slots across every backend still serving requests.
 
-    A park is budgeted against the executor and there is only one of those, so
-    one queue's capacity is the wrong denominator. A reload mints a queue on a
-    new port while the old one drains, and prompts on both park threads: sizing
-    from either alone lets them add up past the reserve. Idle queues are the ones
-    the registry is about to evict and are holding nothing.
+    One queue's capacity is the wrong denominator for a budget sized against the
+    one executor: a reload drains the old queue alongside the new one, and
+    prompts on both park threads. Idle queues hold nothing and are about to be
+    evicted.
     """
     with _QUEUES_LOCK:
         queues = list(_QUEUES.values())
@@ -322,19 +314,18 @@ class LlamaAdmissionLease:
         slot would let unanswered prompts fill the pool while llama-server idles.
         The lease itself stays valid: releasing it after a park is still correct.
 
-        False when the park budget is spent, and nothing was given back: the
+        False when the park budget is spent and nothing was given back: the
         caller keeps its slot across the prompt, as it did before parking
-        existed. Slower for whoever is queued behind it, but freeing the slot
-        admits another run that can park too, and those pile up on the same
-        executor the generators themselves run on.
+        existed. Slower for whoever is behind it, but each freed slot admits
+        another run that can park too, on the executor the generators run on.
         """
         queue = self._queue
         with self._release_lock:
             if queue is None or self._released or self._parked:
                 return False
-            # Under the lease lock so the decision and the handover cannot be
-            # split. Nothing takes the queue lock and then a lease lock, so this
-            # order is the only one in play.
+            # Under the lease lock so the decision and the handover cannot split.
+            # Nothing takes the queue lock then a lease lock, so this order is
+            # the only one in play.
             if not queue.try_park(self._slot):
                 return False
             self._parked = True
@@ -345,11 +336,10 @@ class LlamaAdmissionLease:
     def _drop_budget(self) -> None:
         """Give the executor budget back now the prompt wait is over.
 
-        Separate from the queue's parked count, which has to last until the slot
-        is back. This is about executor threads, and the thread is free the
-        moment the answer arrives, before the resume has even queued for a slot.
-        Holding it until then refuses someone else's park for a wait that already
-        finished, and that someone keeps the slot the resumer is waiting for.
+        Separate from the queue's parked count, which lasts until the slot is
+        back: the executor thread is free the moment the answer arrives. Holding
+        the budget until the resume lands would refuse someone else's park for a
+        finished wait, and that someone holds the slot the resumer wants.
         """
         with self._release_lock:
             if not self._budgeted:
@@ -388,8 +378,8 @@ class LlamaAdmissionLease:
         queue = self._queue
         if queue is None or not self._parked:
             return
-        # Before the wait: the prompt is answered, so this holder is off the
-        # executor already and must not keep anyone else off it.
+        # Before the wait, not after: the prompt is answered, so this holder is
+        # already off the executor and must not keep anyone else off it.
         self._drop_budget()
         slot = await queue.acquire_parked_slot(cancel_event = cancel_event, poll_s = poll_s)
         stranded = None
@@ -631,9 +621,8 @@ class LlamaAdmissionQueue:
         """Return a parked holder's slot to the pool. See ``LlamaAdmissionLease.park``.
 
         False leaves the slot with its holder, so a refused park costs nothing to
-        undo. The per-queue count is only what ``is_idle`` reads; the budget it
-        is checked against is process-wide, and so is the capacity it is sized
-        from.
+        undo. The per-queue count is only what ``is_idle`` reads; the budget and
+        the capacity it is sized from are both process-wide.
         """
         if not _claim_park(_max_parked(_live_capacity(self))):
             return False
@@ -811,6 +800,6 @@ def reset_llama_admission_queues() -> None:
     with _QUEUES_LOCK:
         _QUEUES.clear()
     # The budget outlives the queues it was claimed against, so dropping them
-    # without it would leak the count and shrink the budget for good.
+    # without it leaks the count and shrinks the budget for good.
     with _PARK_LOCK:
         _parked_total = 0

--- a/studio/backend/core/inference/llama_admission.py
+++ b/studio/backend/core/inference/llama_admission.py
@@ -56,6 +56,51 @@ DEFAULT_ADMISSION_QUEUE_PER_SLOT = 16
 # load downshifted to fit VRAM) keeps the depth it had before scaling existed
 # rather than dropping to 16 and rejecting callers that used to queue.
 DEFAULT_ADMISSION_MIN_QUEUE = 64
+# Executor threads kept clear of parked approvals, so generation steps, stream
+# teardown and unrelated to_thread work still run while prompts sit unanswered.
+_EXECUTOR_RESERVE = 4
+
+
+def _executor_workers() -> int:
+    """Threads asyncio's default executor runs to_thread work on."""
+    return min(32, (os.cpu_count() or 1) + 4)
+
+
+def _max_parked(capacity: int) -> int:
+    """How many holders may sit on an approval prompt with their slot given back.
+
+    The loop blocks inside the to_thread(next, gen) call that drives it, so a
+    pending prompt parks an executor thread whether or not it parked its slot.
+    The pool already permits `capacity` of those, and every park frees a slot
+    that admits one more, so budget only what the executor has left over. Zero on
+    a backend whose --parallel alone fills it, which then behaves as it did
+    before parking existed: the prompt holds its slot.
+    """
+    workers = _executor_workers()
+    return max(0, min(workers // 4, workers - _EXECUTOR_RESERVE - max(0, capacity)))
+
+
+# Counted process-wide, not per queue. There is one default executor, but a
+# per-queue budget is the same allowance again for every backend, and base_url
+# carries a fresh port on every model load, so a reload would mint a queue that
+# knows nothing about the approvals still parked on the old one.
+_PARK_LOCK = threading.Lock()
+_parked_total = 0
+
+
+def _claim_park(limit: int) -> bool:
+    global _parked_total
+    with _PARK_LOCK:
+        if _parked_total >= limit:
+            return False
+        _parked_total += 1
+        return True
+
+
+def _drop_park() -> None:
+    global _parked_total
+    with _PARK_LOCK:
+        _parked_total = max(0, _parked_total - 1)
 
 
 @dataclass(frozen = True, **_SLOTS)
@@ -232,21 +277,31 @@ class LlamaAdmissionLease:
         """Pool slot this lease holds, or None when admission is disabled."""
         return self._slot
 
-    def park(self) -> None:
+    def park(self) -> bool:
         """Hand the slot back while this holder waits on something off the GPU.
 
         A run stopped on a tool approval prompt is not decoding, so holding its
         slot would let unanswered prompts fill the pool while llama-server idles.
         The lease itself stays valid: releasing it after a park is still correct.
+
+        False when the park budget is spent, and nothing was given back: the
+        caller keeps its slot across the prompt, as it did before parking
+        existed. Slower for whoever is queued behind it, but freeing the slot
+        admits another run that can park too, and those pile up on the same
+        executor the generators themselves run on.
         """
         queue = self._queue
-        slot = None
         with self._release_lock:
             if queue is None or self._released or self._parked:
-                return
+                return False
+            # Under the lease lock so the decision and the handover cannot be
+            # split. Nothing takes the queue lock and then a lease lock, so this
+            # order is the only one in play.
+            if not queue.try_park(self._slot):
+                return False
             self._parked = True
-            slot, self._slot = self._slot, None
-        queue.park(slot)
+            self._slot = None
+        return True
 
     def unpark(self) -> None:
         """Drop the parked state without reclaiming a slot.
@@ -513,17 +568,29 @@ class LlamaAdmissionQueue:
             self._release_slot_locked(slot)
             self._grant_waiters_locked()
 
-    def park(self, slot: Optional[int]) -> None:
-        """Return a parked holder's slot to the pool. See ``LlamaAdmissionLease.park``."""
+    def try_park(self, slot: Optional[int]) -> bool:
+        """Return a parked holder's slot to the pool. See ``LlamaAdmissionLease.park``.
+
+        False leaves the slot with its holder, so a refused park costs nothing to
+        undo. The per-queue count is only what ``is_idle`` reads; the budget it
+        is checked against is process-wide.
+        """
+        if not _claim_park(_max_parked(self._capacity)):
+            return False
         with self._lock:
             self._parked += 1
             self._release_slot_locked(slot)
             self._grant_waiters_locked()
+        return True
 
     def unpark(self) -> None:
+        dropped = False
         with self._lock:
             if self._parked > 0:
                 self._parked -= 1
+                dropped = True
+        if dropped:
+            _drop_park()
 
     async def acquire_parked_slot(
         self,
@@ -684,5 +751,10 @@ def get_llama_admission_queue(key: str) -> LlamaAdmissionQueue:
 
 
 def reset_llama_admission_queues() -> None:
+    global _parked_total
     with _QUEUES_LOCK:
         _QUEUES.clear()
+    # The budget outlives the queues it was claimed against, so dropping them
+    # without it would leak the count and shrink the budget for good.
+    with _PARK_LOCK:
+        _parked_total = 0

--- a/studio/backend/core/inference/llama_admission.py
+++ b/studio/backend/core/inference/llama_admission.py
@@ -136,10 +136,7 @@ def _live_capacity(current: "LlamaAdmissionQueue") -> int:
     with _QUEUES_LOCK:
         queues = list(_QUEUES.values())
     # is_idle takes each queue's own lock, so never while holding _QUEUES_LOCK.
-    total = sum(
-        queue._capacity for queue in queues
-        if queue is current or not queue.is_idle()
-    )
+    total = sum(queue._capacity for queue in queues if queue is current or not queue.is_idle())
     return total if any(queue is current for queue in queues) else total + current._capacity
 
 

--- a/studio/backend/core/inference/llama_admission.py
+++ b/studio/backend/core/inference/llama_admission.py
@@ -124,6 +124,25 @@ def _drop_park() -> None:
         _parked_total = max(0, _parked_total - 1)
 
 
+def _live_capacity(current: "LlamaAdmissionQueue") -> int:
+    """Slots across every backend still serving requests.
+
+    A park is budgeted against the executor and there is only one of those, so
+    one queue's capacity is the wrong denominator. A reload mints a queue on a
+    new port while the old one drains, and prompts on both park threads: sizing
+    from either alone lets them add up past the reserve. Idle queues are the ones
+    the registry is about to evict and are holding nothing.
+    """
+    with _QUEUES_LOCK:
+        queues = list(_QUEUES.values())
+    # is_idle takes each queue's own lock, so never while holding _QUEUES_LOCK.
+    total = sum(
+        queue._capacity for queue in queues
+        if queue is current or not queue.is_idle()
+    )
+    return total if any(queue is current for queue in queues) else total + current._capacity
+
+
 @dataclass(frozen = True, **_SLOTS)
 class LlamaAdmissionConfig:
     enabled: bool = DEFAULT_ADMISSION_ENABLED
@@ -280,7 +299,7 @@ class _Waiter:
 
 
 class LlamaAdmissionLease:
-    __slots__ = ("_queue", "_slot", "_released", "_release_lock", "_parked")
+    __slots__ = ("_queue", "_slot", "_released", "_release_lock", "_parked", "_budgeted")
 
     def __init__(
         self,
@@ -292,6 +311,7 @@ class LlamaAdmissionLease:
         self._released = False
         self._release_lock = threading.Lock()
         self._parked = False
+        self._budgeted = False
 
     @property
     def slot(self) -> Optional[int]:
@@ -321,8 +341,24 @@ class LlamaAdmissionLease:
             if not queue.try_park(self._slot):
                 return False
             self._parked = True
+            self._budgeted = True
             self._slot = None
         return True
+
+    def _drop_budget(self) -> None:
+        """Give the executor budget back now the prompt wait is over.
+
+        Separate from the queue's parked count, which has to last until the slot
+        is back. This is about executor threads, and the thread is free the
+        moment the answer arrives, before the resume has even queued for a slot.
+        Holding it until then refuses someone else's park for a wait that already
+        finished, and that someone keeps the slot the resumer is waiting for.
+        """
+        with self._release_lock:
+            if not self._budgeted:
+                return
+            self._budgeted = False
+        _drop_park()
 
     def unpark(self) -> None:
         """Drop the parked state without reclaiming a slot.
@@ -335,6 +371,7 @@ class LlamaAdmissionLease:
             if not self._parked:
                 return
             self._parked = False
+        self._drop_budget()
         if self._queue is not None:
             self._queue.unpark()
 
@@ -354,6 +391,9 @@ class LlamaAdmissionLease:
         queue = self._queue
         if queue is None or not self._parked:
             return
+        # Before the wait: the prompt is answered, so this holder is off the
+        # executor already and must not keep anyone else off it.
+        self._drop_budget()
         slot = await queue.acquire_parked_slot(cancel_event = cancel_event, poll_s = poll_s)
         stranded = None
         with self._release_lock:
@@ -380,6 +420,7 @@ class LlamaAdmissionLease:
             self._released = True
             queue = self._queue
             parked, self._parked = self._parked, False
+        self._drop_budget()
         if queue is not None:
             if parked:
                 queue.unpark()
@@ -594,9 +635,10 @@ class LlamaAdmissionQueue:
 
         False leaves the slot with its holder, so a refused park costs nothing to
         undo. The per-queue count is only what ``is_idle`` reads; the budget it
-        is checked against is process-wide.
+        is checked against is process-wide, and so is the capacity it is sized
+        from.
         """
-        if not _claim_park(_max_parked(self._capacity)):
+        if not _claim_park(_max_parked(_live_capacity(self))):
             return False
         with self._lock:
             self._parked += 1
@@ -605,13 +647,9 @@ class LlamaAdmissionQueue:
         return True
 
     def unpark(self) -> None:
-        dropped = False
         with self._lock:
             if self._parked > 0:
                 self._parked -= 1
-                dropped = True
-        if dropped:
-            _drop_park()
 
     async def acquire_parked_slot(
         self,

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -9413,7 +9413,10 @@ async def openai_chat_completions(
                     if lease is None:
                         return
                     if on:
-                        lease.park()
+                        # Refused when the park budget is spent: the slot stays with
+                        # this run, so there is nothing to take back afterwards.
+                        if not lease.park():
+                            return
                     elif wait:
                         # Resuming: park() may have handed our slot to a waiter, so wait for room instead
                         # of putting two holders on one slot.

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -9413,8 +9413,8 @@ async def openai_chat_completions(
                     if lease is None:
                         return
                     if on:
-                        # Refused when the park budget is spent: the slot stays with
-                        # this run, so there is nothing to take back afterwards.
+                        # Refused when the budget is spent: the slot stays here,
+                        # so there is nothing to take back afterwards.
                         if not lease.park():
                             return
                     elif wait:

--- a/studio/backend/tests/test_llama_admission.py
+++ b/studio/backend/tests/test_llama_admission.py
@@ -1068,11 +1068,15 @@ def test_an_immediate_arrival_cannot_take_an_approved_chats_slot():
     asyncio.run(scenario())
 
 
-def test_parking_is_bounded_so_the_thread_pool_cannot_be_drained():
+def test_parking_is_bounded_so_the_thread_pool_cannot_be_drained(monkeypatch):
     # The loop blocks inside the to_thread(next, gen) call that drives it, so a
     # pending prompt parks an executor thread whether or not it parked its slot.
     # Parking frees a slot, which admits another run that can park too, so
     # unbounded parking drains the pool the generators themselves run on.
+    # Pinned: the real budget follows the runner's usable CPUs, and a one-CPU
+    # container would otherwise run this against a different number.
+    monkeypatch.setattr(llama_admission, "_executor_workers", lambda: 32)
+
     async def scenario():
         queue = get_llama_admission_queue("http://llama.test")
         config = LlamaAdmissionConfig()
@@ -1101,9 +1105,11 @@ def test_parking_is_bounded_so_the_thread_pool_cannot_be_drained():
     asyncio.run(scenario())
 
 
-def test_the_park_budget_is_shared_by_every_queue():
+def test_the_park_budget_is_shared_by_every_queue(monkeypatch):
     # One executor, so a per-queue budget is the same budget handed out again to
     # every backend, and every reload onto a fresh ephemeral port.
+    monkeypatch.setattr(llama_admission, "_executor_workers", lambda: 32)
+
     async def scenario():
         config = LlamaAdmissionConfig()
         first = get_llama_admission_queue("http://llama.test:1")
@@ -1129,21 +1135,47 @@ def test_the_park_budget_is_shared_by_every_queue():
     asyncio.run(scenario())
 
 
-def test_the_park_budget_leaves_the_executor_room_to_work():
+def test_the_park_budget_leaves_the_executor_room_to_work(monkeypatch):
     # The pool already permits `capacity` pending prompts, and every park frees a
-    # slot that admits one more, so the budget has to account for both.
-    workers = llama_admission._executor_workers()
-    reserve = llama_admission._EXECUTOR_RESERVE
-    assert 1 <= llama_admission._max_parked(1) <= workers // 2
-    # A backend whose --parallel alone fills the executor gets no parks at all,
-    # rather than a budget that pushes it over.
-    assert llama_admission._max_parked(workers) == 0
-    for capacity in range(0, workers + 8):
-        budget = llama_admission._max_parked(capacity)
-        assert budget >= 0, f"negative budget at capacity {capacity}"
-        assert (
-            budget == 0 or capacity + budget <= workers - reserve
-        ), f"capacity {capacity} plus {budget} parks leaves the executor short"
+    # slot that admits one more, so the budget has to account for both. Swept
+    # across executor sizes rather than read off this host: 3.13 sizes the
+    # default executor from the usable CPUs, so a container gets a small one.
+    for cpus in (1, 2, 4, 8, 16, 28, 64):
+        workers = min(32, cpus + 4)
+        monkeypatch.setattr(llama_admission, "_executor_workers", lambda w = workers: w)
+        reserve = llama_admission._executor_reserve(workers)
+        assert reserve >= 2, f"{workers} workers left no reserve"
+
+        # Even the smallest executor lets two chats sit on prompts at once, which
+        # is what #7455's own two-approvals test needs.
+        assert llama_admission._max_parked(1) >= 2, f"no room for two on {workers} workers"
+        assert llama_admission._max_parked(1) <= workers // 2
+        # A backend whose --parallel alone fills the executor gets no parks,
+        # rather than a budget that pushes it over.
+        assert llama_admission._max_parked(workers) == 0
+        for capacity in range(0, workers + 8):
+            budget = llama_admission._max_parked(capacity)
+            assert budget >= 0, f"negative budget at capacity {capacity}"
+            assert (
+                budget == 0 or capacity + budget <= workers - reserve
+            ), f"{workers} workers: capacity {capacity} plus {budget} parks leaves no room"
+
+
+def test_the_park_budget_follows_the_executors_own_cpu_count(monkeypatch):
+    # 3.13 sizes ThreadPoolExecutor from process_cpu_count(), which honours CPU
+    # affinity and cgroup quotas. Reading cpu_count() would budget from the whole
+    # host while the executor was sized from the one core the container got, so
+    # pull the two apart: on this machine they are the same number.
+    import concurrent.futures
+
+    monkeypatch.setattr(os, "cpu_count", lambda: 64)
+    if hasattr(os, "process_cpu_count"):
+        monkeypatch.setattr(os, "process_cpu_count", lambda: 1)
+    # Against the real thing rather than the formula: asyncio's default executor
+    # is a plain ThreadPoolExecutor(), so its own default sizing is the answer,
+    # whichever interpreter this runs on.
+    with concurrent.futures.ThreadPoolExecutor() as pool:
+        assert llama_admission._executor_workers() == pool._max_workers
 
 
 def test_the_stream_retries_a_park_that_was_refused():

--- a/studio/backend/tests/test_llama_admission.py
+++ b/studio/backend/tests/test_llama_admission.py
@@ -1141,9 +1141,9 @@ def test_the_park_budget_leaves_the_executor_room_to_work():
     for capacity in range(0, workers + 8):
         budget = llama_admission._max_parked(capacity)
         assert budget >= 0, f"negative budget at capacity {capacity}"
-        assert budget == 0 or capacity + budget <= workers - reserve, (
-            f"capacity {capacity} plus {budget} parks leaves the executor short"
-        )
+        assert (
+            budget == 0 or capacity + budget <= workers - reserve
+        ), f"capacity {capacity} plus {budget} parks leaves the executor short"
 
 
 def test_the_stream_retries_a_park_that_was_refused():
@@ -1159,13 +1159,15 @@ def test_the_stream_retries_a_park_that_was_refused():
     with open(route, encoding = "utf-8") as handle:
         tree = ast.parse(handle.read())
     helpers = [
-        node for node in ast.walk(tree)
+        node
+        for node in ast.walk(tree)
         if isinstance(node, ast.AsyncFunctionDef) and node.name == "_park_admission"
     ]
     assert len(helpers) == 1, f"expected one _park_admission, found {len(helpers)}"
 
     guards = [
-        node for node in ast.walk(helpers[0])
+        node
+        for node in ast.walk(helpers[0])
         if isinstance(node, ast.If)
         and isinstance(node.test, ast.UnaryOp)
         and isinstance(node.test.op, ast.Not)
@@ -1174,6 +1176,6 @@ def test_the_stream_retries_a_park_that_was_refused():
         and getattr(node.test.operand.func.value, "id", None) == "lease"
     ]
     assert len(guards) == 1, "lease.park()'s answer is ignored"
-    assert all(isinstance(stmt, ast.Return) for stmt in guards[0].body), (
-        "a refused park must leave _parked alone, so a later approval retries it"
-    )
+    assert all(
+        isinstance(stmt, ast.Return) for stmt in guards[0].body
+    ), "a refused park must leave _parked alone, so a later approval retries it"

--- a/studio/backend/tests/test_llama_admission.py
+++ b/studio/backend/tests/test_llama_admission.py
@@ -1069,12 +1069,10 @@ def test_an_immediate_arrival_cannot_take_an_approved_chats_slot():
 
 
 def test_parking_is_bounded_so_the_thread_pool_cannot_be_drained(monkeypatch):
-    # The loop blocks inside the to_thread(next, gen) call that drives it, so a
-    # pending prompt parks an executor thread whether or not it parked its slot.
-    # Parking frees a slot, which admits another run that can park too, so
-    # unbounded parking drains the pool the generators themselves run on.
-    # Pinned: the real budget follows the runner's usable CPUs, and a one-CPU
-    # container would otherwise run this against a different number.
+    # A pending prompt parks an executor thread (the loop blocks inside
+    # to_thread(next, gen)) and frees a slot that admits another run which can
+    # park too, so unbounded parking drains the pool the generators run on.
+    # Pinned because the real budget follows the runner's usable CPUs.
     monkeypatch.setattr(llama_admission, "_executor_workers", lambda: 32)
 
     async def scenario():
@@ -1106,8 +1104,8 @@ def test_parking_is_bounded_so_the_thread_pool_cannot_be_drained(monkeypatch):
 
 
 def test_the_park_budget_is_shared_by_every_queue(monkeypatch):
-    # One executor, so a per-queue budget is the same budget handed out again to
-    # every backend, and every reload onto a fresh ephemeral port.
+    # One executor, so a per-queue budget would be handed out again to every
+    # backend and to every reload onto a fresh ephemeral port.
     monkeypatch.setattr(llama_admission, "_executor_workers", lambda: 32)
 
     async def scenario():
@@ -1124,8 +1122,8 @@ def test_the_park_budget_is_shared_by_every_queue(monkeypatch):
         spare = second.reserve(capacity = 1, config = config).lease_nowait()
         assert not spare.park(), "each queue got its own budget"
 
-        # A reset drops the queues the count was claimed against, so it has to
-        # drop the count too, or a leak shrinks the budget for the whole process.
+        # A reset drops the queues the count was claimed against, so it must drop
+        # the count too or the leak shrinks the budget process-wide.
         reset_llama_admission_queues()
         revived = get_llama_admission_queue("http://llama.test:1")
         fresh = revived.reserve(capacity = 1, config = config).lease_nowait()
@@ -1136,22 +1134,19 @@ def test_the_park_budget_is_shared_by_every_queue(monkeypatch):
 
 
 def test_the_park_budget_leaves_the_executor_room_to_work(monkeypatch):
-    # The pool already permits `capacity` pending prompts, and every park frees a
-    # slot that admits one more, so the budget has to account for both. Swept
-    # across executor sizes rather than read off this host: 3.13 sizes the
-    # default executor from the usable CPUs, so a container gets a small one.
+    # The pool already permits `capacity` pending prompts and every park admits
+    # one more, so the budget must account for both. Swept across executor sizes
+    # rather than read off this host, since a container gets a small one.
     for cpus in (1, 2, 4, 8, 16, 28, 64):
         workers = min(32, cpus + 4)
         monkeypatch.setattr(llama_admission, "_executor_workers", lambda w = workers: w)
         reserve = llama_admission._executor_reserve(workers)
         assert reserve >= 2, f"{workers} workers left no reserve"
 
-        # Even the smallest executor lets two chats sit on prompts at once, which
-        # is what #7455's own two-approvals test needs.
+        # Even the smallest executor fits the two simultaneous prompts #7455 needs.
         assert llama_admission._max_parked(1) >= 2, f"no room for two on {workers} workers"
         assert llama_admission._max_parked(1) <= workers // 2
-        # A backend whose --parallel alone fills the executor gets no parks,
-        # rather than a budget that pushes it over.
+        # A backend whose --parallel alone fills the executor gets no parks.
         assert llama_admission._max_parked(workers) == 0
         for capacity in range(0, workers + 8):
             budget = llama_admission._max_parked(capacity)
@@ -1163,27 +1158,23 @@ def test_the_park_budget_leaves_the_executor_room_to_work(monkeypatch):
 
 def test_the_park_budget_follows_the_executors_own_cpu_count(monkeypatch):
     # 3.13 sizes ThreadPoolExecutor from process_cpu_count(), which honours CPU
-    # affinity and cgroup quotas. Reading cpu_count() would budget from the whole
-    # host while the executor was sized from the one core the container got, so
-    # pull the two apart: on this machine they are the same number.
+    # affinity and cgroup quotas; cpu_count() would budget from the whole host
+    # inside a one-core container. Pulled apart here, since they usually match.
     import concurrent.futures
 
     monkeypatch.setattr(os, "cpu_count", lambda: 64)
     if hasattr(os, "process_cpu_count"):
         monkeypatch.setattr(os, "process_cpu_count", lambda: 1)
-    # Against the real thing rather than the formula: asyncio's default executor
-    # is a plain ThreadPoolExecutor(), so its own default sizing is the answer,
-    # whichever interpreter this runs on.
+    # Against the real thing rather than the formula: the default executor is a
+    # plain ThreadPoolExecutor(), so its own sizing is the answer on any version.
     with concurrent.futures.ThreadPoolExecutor() as pool:
         assert llama_admission._executor_workers() == pool._max_workers
 
 
 def test_the_stream_retries_a_park_that_was_refused():
     # _park_admission short-circuits on `on == _parked`, so recording a refused
-    # park as parked would make it skip the park for every later approval in the
-    # same run, even once the budget frees up. Structural: the difference only
-    # appears on the second approval of one stream, and everything else about a
-    # refused park (it keeps its slot, unpark is a no-op) is behavioural above.
+    # park as parked would skip every later approval in the run even once the
+    # budget frees up. Structural because that only shows on a second approval.
     import ast
 
     # Read rather than import: routes.inference pulls in the whole app.
@@ -1214,10 +1205,9 @@ def test_the_stream_retries_a_park_that_was_refused():
 
 
 def test_the_park_budget_counts_every_live_backend(monkeypatch):
-    # base_url carries a fresh port on every load, so a reload mints a queue
-    # while the old one drains. Prompts on both park executor threads, and there
-    # is one executor, so sizing the budget from either backend alone lets them
-    # add up past the reserve.
+    # base_url takes a fresh port on every load, so a reload mints a queue while
+    # the old one drains. Prompts on both park threads of the one executor, so a
+    # budget sized from either backend alone lets them add up past the reserve.
     monkeypatch.setattr(llama_admission, "_executor_workers", lambda: 32)
 
     async def scenario():
@@ -1243,9 +1233,8 @@ def test_the_park_budget_counts_every_live_backend(monkeypatch):
 
 def test_the_park_budget_is_freed_when_the_prompt_is_answered(monkeypatch):
     # The executor thread comes back the moment the answer arrives, before the
-    # resume has queued for a slot. Holding the budget until the slot lands
-    # refuses someone else's park for a wait that already finished, and that
-    # someone keeps holding the slot the resumer is waiting for.
+    # resume queues for a slot. Holding the budget until the slot lands refuses
+    # someone else's park, and that someone holds the slot the resumer wants.
     monkeypatch.setattr(llama_admission, "_executor_workers", lambda: 32)
 
     async def scenario():
@@ -1279,8 +1268,8 @@ def test_the_park_budget_is_freed_when_the_prompt_is_answered(monkeypatch):
 
 def test_releasing_a_parked_holder_returns_its_budget(monkeypatch):
     # A client that disconnects on the prompt releases straight out of parked,
-    # without ever unparking. Its executor thread is gone with it, so keeping the
-    # budget would lose one for the life of the process.
+    # never unparking. Its executor thread went with it, so keeping the budget
+    # would lose one for the life of the process.
     monkeypatch.setattr(llama_admission, "_executor_workers", lambda: 32)
 
     async def scenario():

--- a/studio/backend/tests/test_llama_admission.py
+++ b/studio/backend/tests/test_llama_admission.py
@@ -1066,3 +1066,114 @@ def test_an_immediate_arrival_cannot_take_an_approved_chats_slot():
         assert queue.snapshot().active <= 1
 
     asyncio.run(scenario())
+
+
+def test_parking_is_bounded_so_the_thread_pool_cannot_be_drained():
+    # The loop blocks inside the to_thread(next, gen) call that drives it, so a
+    # pending prompt parks an executor thread whether or not it parked its slot.
+    # Parking frees a slot, which admits another run that can park too, so
+    # unbounded parking drains the pool the generators themselves run on.
+    async def scenario():
+        queue = get_llama_admission_queue("http://llama.test")
+        config = LlamaAdmissionConfig()
+        limit = llama_admission._max_parked(1)
+        assert limit >= 1
+
+        leases = []
+        for _ in range(limit):
+            lease = queue.reserve(capacity = 1, config = config).lease_nowait()
+            assert lease is not None and lease.park()
+            leases.append(lease)
+
+        refused = queue.reserve(capacity = 1, config = config).lease_nowait()
+        assert refused is not None
+        assert not refused.park(), "parking is unbounded"
+        # Refusing means keeping the slot, the old behaviour, not an error.
+        assert refused.slot is not None
+        assert queue.snapshot().active == 1
+
+        leases[0].unpark()
+        assert refused.park(), "budget was not returned"
+        for lease in leases[1:] + [refused]:
+            lease.release()
+        leases[0].release()
+
+    asyncio.run(scenario())
+
+
+def test_the_park_budget_is_shared_by_every_queue():
+    # One executor, so a per-queue budget is the same budget handed out again to
+    # every backend, and every reload onto a fresh ephemeral port.
+    async def scenario():
+        config = LlamaAdmissionConfig()
+        first = get_llama_admission_queue("http://llama.test:1")
+        second = get_llama_admission_queue("http://llama.test:2")
+        limit = llama_admission._max_parked(1)
+
+        for index in range(limit):
+            queue = first if index % 2 == 0 else second
+            lease = queue.reserve(capacity = 1, config = config).lease_nowait()
+            assert lease.park()
+
+        spare = second.reserve(capacity = 1, config = config).lease_nowait()
+        assert not spare.park(), "each queue got its own budget"
+
+        # A reset drops the queues the count was claimed against, so it has to
+        # drop the count too, or a leak shrinks the budget for the whole process.
+        reset_llama_admission_queues()
+        revived = get_llama_admission_queue("http://llama.test:1")
+        fresh = revived.reserve(capacity = 1, config = config).lease_nowait()
+        assert fresh.park(), "reset leaked the park count"
+        fresh.release()
+
+    asyncio.run(scenario())
+
+
+def test_the_park_budget_leaves_the_executor_room_to_work():
+    # The pool already permits `capacity` pending prompts, and every park frees a
+    # slot that admits one more, so the budget has to account for both.
+    workers = llama_admission._executor_workers()
+    reserve = llama_admission._EXECUTOR_RESERVE
+    assert 1 <= llama_admission._max_parked(1) <= workers // 2
+    # A backend whose --parallel alone fills the executor gets no parks at all,
+    # rather than a budget that pushes it over.
+    assert llama_admission._max_parked(workers) == 0
+    for capacity in range(0, workers + 8):
+        budget = llama_admission._max_parked(capacity)
+        assert budget >= 0, f"negative budget at capacity {capacity}"
+        assert budget == 0 or capacity + budget <= workers - reserve, (
+            f"capacity {capacity} plus {budget} parks leaves the executor short"
+        )
+
+
+def test_the_stream_retries_a_park_that_was_refused():
+    # _park_admission short-circuits on `on == _parked`, so recording a refused
+    # park as parked would make it skip the park for every later approval in the
+    # same run, even once the budget frees up. Structural: the difference only
+    # appears on the second approval of one stream, and everything else about a
+    # refused park (it keeps its slot, unpark is a no-op) is behavioural above.
+    import ast
+
+    # Read rather than import: routes.inference pulls in the whole app.
+    route = os.path.join(_backend, "routes", "inference.py")
+    with open(route, encoding = "utf-8") as handle:
+        tree = ast.parse(handle.read())
+    helpers = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "_park_admission"
+    ]
+    assert len(helpers) == 1, f"expected one _park_admission, found {len(helpers)}"
+
+    guards = [
+        node for node in ast.walk(helpers[0])
+        if isinstance(node, ast.If)
+        and isinstance(node.test, ast.UnaryOp)
+        and isinstance(node.test.op, ast.Not)
+        and isinstance(node.test.operand, ast.Call)
+        and getattr(node.test.operand.func, "attr", None) == "park"
+        and getattr(node.test.operand.func.value, "id", None) == "lease"
+    ]
+    assert len(guards) == 1, "lease.park()'s answer is ignored"
+    assert all(isinstance(stmt, ast.Return) for stmt in guards[0].body), (
+        "a refused park must leave _parked alone, so a later approval retries it"
+    )

--- a/studio/backend/tests/test_llama_admission.py
+++ b/studio/backend/tests/test_llama_admission.py
@@ -1211,3 +1211,95 @@ def test_the_stream_retries_a_park_that_was_refused():
     assert all(
         isinstance(stmt, ast.Return) for stmt in guards[0].body
     ), "a refused park must leave _parked alone, so a later approval retries it"
+
+
+def test_the_park_budget_counts_every_live_backend(monkeypatch):
+    # base_url carries a fresh port on every load, so a reload mints a queue
+    # while the old one drains. Prompts on both park executor threads, and there
+    # is one executor, so sizing the budget from either backend alone lets them
+    # add up past the reserve.
+    monkeypatch.setattr(llama_admission, "_executor_workers", lambda: 32)
+
+    async def scenario():
+        config = LlamaAdmissionConfig()
+        old = get_llama_admission_queue("http://llama.test:1")
+        draining = old.reserve(capacity = 16, config = config).lease_nowait()
+        assert draining is not None  # in flight, so the registry keeps this queue
+
+        new = get_llama_admission_queue("http://llama.test:2")
+        lease = new.reserve(capacity = 16, config = config).lease_nowait()
+        assert lease is not None
+
+        # 16 slots each against 32 workers: their prompts alone can fill it.
+        assert llama_admission._max_parked(16) > 0, "this test needs a budget to remove"
+        assert not lease.park(), "budget sized from one backend of two"
+
+        draining.release()  # the old backend drains and is up for eviction
+        assert lease.park(), "an idle backend still counted against the budget"
+        lease.release()
+
+    asyncio.run(scenario())
+
+
+def test_the_park_budget_is_freed_when_the_prompt_is_answered(monkeypatch):
+    # The executor thread comes back the moment the answer arrives, before the
+    # resume has queued for a slot. Holding the budget until the slot lands
+    # refuses someone else's park for a wait that already finished, and that
+    # someone keeps holding the slot the resumer is waiting for.
+    monkeypatch.setattr(llama_admission, "_executor_workers", lambda: 32)
+
+    async def scenario():
+        config = LlamaAdmissionConfig()
+        queue = get_llama_admission_queue("http://llama.test")
+
+        parked = []
+        for _ in range(llama_admission._max_parked(1)):
+            lease = queue.reserve(capacity = 1, config = config).lease_nowait()
+            assert lease is not None and lease.park()
+            parked.append(lease)
+
+        blocked = queue.reserve(capacity = 1, config = config).lease_nowait()
+        assert blocked is not None
+        assert not blocked.park(), "the budget was not full to begin with"
+
+        # One prompt is answered. Its slot is taken, so the resume queues for one.
+        resumed = asyncio.ensure_future(parked[0].unpark_async(poll_s = 0.01))
+        await asyncio.sleep(0.05)
+        assert not resumed.done(), "the resume needs to still be waiting for its slot"
+
+        assert blocked.park(), "budget held for a prompt wait that is over"
+        # Which is what frees the slot the resumer was waiting for.
+        await asyncio.wait_for(resumed, timeout = 2)
+        for lease in parked[1:] + [blocked]:
+            lease.release()
+        parked[0].release()
+
+    asyncio.run(scenario())
+
+
+def test_releasing_a_parked_holder_returns_its_budget(monkeypatch):
+    # A client that disconnects on the prompt releases straight out of parked,
+    # without ever unparking. Its executor thread is gone with it, so keeping the
+    # budget would lose one for the life of the process.
+    monkeypatch.setattr(llama_admission, "_executor_workers", lambda: 32)
+
+    async def scenario():
+        config = LlamaAdmissionConfig()
+        queue = get_llama_admission_queue("http://llama.test")
+
+        parked = []
+        for _ in range(llama_admission._max_parked(1)):
+            lease = queue.reserve(capacity = 1, config = config).lease_nowait()
+            assert lease is not None and lease.park()
+            parked.append(lease)
+
+        blocked = queue.reserve(capacity = 1, config = config).lease_nowait()
+        assert blocked is not None
+        assert not blocked.park(), "the budget was not full to begin with"
+
+        parked[0].release()
+        assert blocked.park(), "a released park never gave its budget back"
+        for lease in parked[1:] + [blocked]:
+            lease.release()
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## What changed about this PR

This branch used to carry its own version of "give the slot back while a tool call waits on a human". #7455 landed that, in a better shape: it parks from the event loop off a `tool_start` event rather than reaching into the worker thread with a contextvar, and it gets FIFO resume ordering, cancellation and idle-eviction right. That work is gone from here.

What is left is the one thing #7455 does not do, and it is a live problem on `main`: parking is unbounded, and the resource it is unbounded against is not the GPU.

## Problem

A run stopped on an approval prompt is blocked inside the `to_thread(next, gen, ...)` call that drives it (`routes/inference.py:9463`), so it holds one of asyncio's default executor threads (`min(32, cpus + 4)`, five of them in a one-core container) until the user answers. The prompt timeout is 3600 s.

The slot cap used to bound how many of those there could be. Parking hands the slot back, which admits another run that can park too, so the ceiling became the wait line instead: 64 deep on a 1-slot backend. Long before that, the executor is full and nothing else in the backend runs. That includes generation steps for chats that already hold slots, and the stream teardown that would clean up after a disconnect, so unanswered prompts stall the chats that parking was meant to unstall.

`queue.park()` is just `self._parked += 1`, so nothing stops it today.

## Changes

**A park budget, sized from what the executor has left.** The pool already permits `capacity` pending prompts, and each park adds one more, so the budget is `workers - reserve - capacity`, capped at a quarter of the executor and floored at zero. On a backend whose `--parallel` alone fills the executor it is zero, and the prompt keeps its slot and behaves exactly as it does on `main` today.

`workers` comes from the same place `ThreadPoolExecutor` gets its own default, which 3.13 moved to `os.process_cpu_count()`: affinity and cgroup aware, so a container pinned to one core on a 64-core host is sized from the one core rather than the 64. The reserve scales too, since a flat count would leave that 5-thread executor nothing to budget and turn parking off in exactly the case that most wants a chat to keep moving. Measured:

| usable CPUs | workers | reserve | `--parallel` 1 | 4 | 16 | 24 | 28 |
|---|---|---|---|---|---|---|---|
| 1 | 5 | 2 | 2 | 0 | 0 | 0 | 0 |
| 2 | 6 | 2 | 2 | 0 | 0 | 0 | 0 |
| 4 | 8 | 2 | 2 | 2 | 0 | 0 | 0 |
| 8 | 12 | 2 | 3 | 3 | 0 | 0 | 0 |
| 16 | 20 | 2 | 5 | 5 | 2 | 0 | 0 |
| 28 or more | 32 | 4 | 8 | 8 | 8 | 4 | 0 |

The ceiling has a floor of two: a quarter of five is one, and one park cannot cover two chats sitting on prompts at once, which is what #7455's own two-approvals test needs.

**Counted process-wide, and sized that way too.** There is one default executor, but a per-queue budget is the same allowance handed out again to every backend. `base_url` carries a fresh port on every model load, so a reload mints a queue while the old one drains and prompts on both park threads: the budget is sized from the summed capacity of every backend still serving, skipping idle queues, which are the ones the registry is about to evict and are holding nothing. A reset clears the count too, since it drops the queues the count was claimed against.

**The budget lasts the wait, not the resume.** The generator yields its post-approval event before the stream queues for a slot, so the executor thread is back in the pool while `unpark_async` is still waiting. Holding the budget until the slot lands would refuse a different chat's park for a wait that already finished, and that chat then keeps the slot the resumer is waiting for. So the executor budget is released when the prompt wait ends, while the queue's own parked count runs until the slot is back, which is what guards idle eviction and the resume ordering. Every exit from a park drops the budget, including a client that disconnects on the prompt and releases straight out of parked.

**`park()` reports whether it took the budget.** A refusal costs nothing to undo: `try_park` claims the budget before the slot moves, so on refusal the slot never left its holder. The stream reads that answer rather than recording a refused park as parked, which matters because `_park_admission` short-circuits on `on == _parked` and would then skip the park for every later approval in the same run, even once the budget freed up.

## Blast radius

Three files, +397/-38. Nothing changes for a run whose park is granted, which is every run until the executor is under real pressure. A refused park is the pre-#7455 behaviour: the prompt holds its slot, slower for whoever is queued behind it, but it cannot drain the pool the generators themselves run on.

563 passed across the admission, tool-confirm and tool-loop suites. Two failures in `test_openai_tool_passthrough.py` (keepalive and preheader retry), both of which fail identically on `main` with this branch stashed.

## What could go wrong, and what is tested

The budget decision and the slot handover have to be one step, or a refused park could still lose its slot. `try_park` takes the budget first and only then releases the slot, under the lease lock; nothing in the queue takes the queue lock and then a lease lock, so that order is the only one in play.

Sixteen mutants, each parse-checked before running so red means a real assertion rather than a syntax error, and the harness treats pytest's exit 5 as "that test does not exist" rather than as a kill, with a deliberately wrong test name as a control. All caught: unbounded parking, a per-queue budget, one sized from a single backend, one that counts idle backends, a budget blind to capacity, to the reserve, or to the executor's own CPU count, a flat reserve, a missing floor of two, a budget held across the resume, and one kept through each of unpark, teardown and release, a reset that leaks the count, a refused park that loses its slot anyway, and the stream ignoring the refusal.

Two of those came back green with no test behind them and now have one: a release straight out of parked, which is a client disconnecting on the prompt and would have lost a budget slot for good, and the stream ignoring a refusal.

The sizing mutant was equivalent on this machine, where `cpu_count()` and `process_cpu_count()` are both 32, so its test pulls the two apart and compares against a real `ThreadPoolExecutor` rather than restating the formula. The whole suite also runs with the CPU count faked to 1, 2 and 4, which is how the low-resource cases were reproduced.

One of those, the stream ignoring a refusal, is covered structurally rather than behaviourally, and the comment on its test says so. A refused park recorded as parked is otherwise almost invisible, since `unpark_async` already returns immediately on an unparked lease; the only difference is a second approval in the same run, which is not reachable without driving the whole GGUF tool stream. Everything else about a refused park is asserted behaviourally.
