### PR TITLE
gitignore: match the stray "~" TMPDIR dir at any depth, plus /temp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,4 +238,5 @@ package-lock.json
 !studio/package-lock.json
 llama.cpp/
 # Stray "~" dir some tools create from a literal ~ TMPDIR; never part of the repo.
-/~/
+~/
+/temp/


### PR DESCRIPTION
The `/~/` rule is root-anchored, so it only catches a stray `~` directory created at the repo root. Tools run from a subdirectory create it there instead, and `studio/frontend/~/CLAUDE_CODE_TMPDIR/` reached #7356 as **708 tracked files** (a Node compile cache plus cwd markers). Unanchoring it to `~/` matches at any depth.

Also ignores `/temp/`, the repo-root scratch directory `tests/studio/test_chat_preset_builtin_invariants.py` writes into, which showed up as 3 more tracked files in the same PR.

Verified with `git check-ignore` that both real paths from #7356 now match, that `~/` and `/temp/` catch nothing legitimate, and that nothing under either path has ever been tracked on main.