### PR TITLE
Rotate desktop updater signing key

### DIFF
--- a/studio/src-tauri/tauri.conf.json
+++ b/studio/src-tauri/tauri.conf.json
@@ -36,7 +36,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDE0NjlBNkEwQTc0QjY0Q0UKUldUT1pFdW5vS1pwRkl3TXRrOGlYdDNMeTh1bEhSbURrM3IyT2lTK1BiekpTc0Z2SXZFeVNibDIK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDFBQzA4RjczODM0RjE1QjcKUldTM0ZVK0RjNC9BR2t4R0RVaFR5cTkyUlRVQ1FwaGV0Nk04eWNwWXBhZnlzalJydllmZm1QTS8K",
       "endpoints": [
         "https://github.com/unslothai/unsloth/releases/download/desktop-latest/latest.json"
       ],


### PR DESCRIPTION
## Summary

- replace the desktop updater public key before the first public release
- keep the updater endpoint and artifact configuration unchanged
- pair the embedded public key with the rotated Actions signing secret

## Validation

- parsed `tauri.conf.json`
- confirmed the configured public key matches the generated keypair
- signed a test artifact through the release workflow environment variables
- verified the signature with Tauri's Minisign verification library
