### PR TITLE
tests: stop the installer constraint test counting occurrences

### DIFF
--- a/tests/sh/test_torch_constraint.sh
+++ b/tests/sh/test_torch_constraint.sh
@@ -94,28 +94,34 @@ echo "=== Structural: TORCH_CONSTRAINT in install.sh ==="
 
 _SH_CONTENT=$(cat "$INSTALL_SH")
 
-_count=$(grep -c 'TORCH_CONSTRAINT="torch>=2.4,<2.11.0"' "$INSTALL_SH" || true)
+# Each hardware branch assigns its own triple, so counting every occurrence made
+# adding a branch (gfx906 in #7354) a test edit. The default is the one assigned at
+# top level; a branch's is always indented, so anchor on that instead of counting.
+_count=$(grep -c '^TORCH_CONSTRAINT="torch>=2.4,<2.11.0"$' "$INSTALL_SH" || true)
 assert_eq "default TORCH_CONSTRAINT assignment exists" "1" "$_count"
 
 _count=$(grep -c 'TORCH_CONSTRAINT="torch>=2.6,<2.11.0"' "$INSTALL_SH" || true)
-assert_eq "tightened TORCH_CONSTRAINT assignment exists" "1" "$_count"
+_has=$([ "$_count" -ge 1 ] && echo "yes" || echo "no")
+assert_eq "tightened TORCH_CONSTRAINT assignment exists" "yes" "$_has"
 
 _count=$(grep -c '"\$TORCH_CONSTRAINT"' "$INSTALL_SH" || true)
 _has_var=$([ "$_count" -ge 1 ] && echo "yes" || echo "no")
 assert_eq "\$TORCH_CONSTRAINT used in pip install" "yes" "$_has_var"
 
-# Hardcoded torch>=2.4,<2.11.0 should only appear once (the default assignment)
-_hardcoded=$(grep -c '"torch>=2.4,<2.11.0"' "$INSTALL_SH" || true)
-assert_eq "hardcoded torch>=2.4 appears exactly once" "1" "$_hardcoded"
+# What the old "appears exactly once" count was really guarding: an install line that
+# spells the pin out ignores whatever the branch above it chose.
+_literal=$(grep -cE 'uv pip install .*"torch>=' "$INSTALL_SH" || true)
+assert_eq "no pip install hardcodes a torch pin" "0" "$_literal"
 
-# Companions must be bounded to torch's window everywhere: the <2.11 bound appears
-# twice (default assignments + the pinned custom-leaf block), never bare. torchaudio
-# 2.11 dropped its exact torch pin, so a bare companion next to a <2.11-capped torch
-# resolves a mismatched 2.11 build.
-_count=$(grep -c 'TORCHVISION_CONSTRAINT="torchvision>=0.19,<0.26.0"' "$INSTALL_SH" || true)
-assert_eq "torchvision bounded (<0.26) at default + custom-leaf" "2" "$_count"
-_count=$(grep -c 'TORCHAUDIO_CONSTRAINT="torchaudio>=2.4,<2.11.0"' "$INSTALL_SH" || true)
-assert_eq "torchaudio bounded (<2.11) at default + custom-leaf" "2" "$_count"
+# Companions must be bounded to torch's window everywhere, never bare: torchaudio 2.11
+# dropped its exact torch pin, so a bare companion next to a <2.11-capped torch resolves
+# a mismatched 2.11 build. Every assignment, not a fixed number of them.
+_total=$(grep -cE '^[[:space:]]*TORCHVISION_CONSTRAINT="' "$INSTALL_SH" || true)
+_bounded=$(grep -cE '^[[:space:]]*TORCHVISION_CONSTRAINT="torchvision>=[0-9][0-9.]*,<[0-9][0-9.]*"$' "$INSTALL_SH" || true)
+assert_eq "every torchvision constraint is upper-bounded" "$_total" "$_bounded"
+_total=$(grep -cE '^[[:space:]]*TORCHAUDIO_CONSTRAINT="' "$INSTALL_SH" || true)
+_bounded=$(grep -cE '^[[:space:]]*TORCHAUDIO_CONSTRAINT="torchaudio>=[0-9][0-9.]*,<[0-9][0-9.]*"$' "$INSTALL_SH" || true)
+assert_eq "every torchaudio constraint is upper-bounded" "$_total" "$_bounded"
 _count=$(grep -c 'TORCHVISION_CONSTRAINT="torchvision"$' "$INSTALL_SH" || true)
 assert_eq "no bare torchvision companion remains" "0" "$_count"
 _count=$(grep -c 'TORCHAUDIO_CONSTRAINT="torchaudio"$' "$INSTALL_SH" || true)


### PR DESCRIPTION
`tests/sh/test_torch_constraint.sh` asserts how many times each pin literal appears in `install.sh`. Every hardware branch assigns its own torch / torchvision / torchaudio triple, so #7354 adding the gfx906 branch pushed three of those counts up by one, and the Backend CI "Shell installer tests" step has been failing on main since:

```
FAIL: default TORCH_CONSTRAINT assignment exists (expected '1', got '2')
FAIL: hardcoded torch>=2.4 appears exactly once (expected '1', got '2')
FAIL: torchvision bounded (<0.26) at default + custom-leaf (expected '2', got '3')
FAIL: torchaudio bounded (<2.11) at default + custom-leaf (expected '2', got '3')
```

Every expectation is off by exactly one, which is the three lines #7354 added:

```
+            TORCH_CONSTRAINT="torch>=2.4,<2.11.0"
+            TORCHVISION_CONSTRAINT="torchvision>=0.19,<0.26.0"
+            TORCHAUDIO_CONSTRAINT="torchaudio>=2.4,<2.11.0"
```

`install.sh` is right; the numbers were the stale part. Rather than bump them to 2 and 3 and have the next hardware branch break the file again, this asserts the invariants the counts were standing in for.

### What changed

- **Default assignment.** The default is the one assigned at top level, and a branch's is always indented, so the grep is anchored at column 0 instead of counting occurrences. This is stronger than before: with the old count, deleting the top-level default while a branch kept the same literal still passed.
- **"Hardcoded torch>=2.4 appears exactly once".** What that was guarding is that no `uv pip install` line spells a pin out instead of using `"$TORCH_CONSTRAINT"`, since a literal there ignores whatever the branch above it chose. Checked directly now, because the premise that the literal can only appear once is no longer true.
- **Companion bounds.** Compares bounded assignments against total assignments rather than pinning a count of 2. torchaudio 2.11 dropped its exact torch pin, so a bare companion next to a `<2.11`-capped torch resolves a mismatched 2.11 build, and that has to hold for every assignment. It now covers all 7 rather than the 2 the old numbers happened to name.

### Testing

`bash tests/sh/test_torch_constraint.sh` goes from 41 pass / 4 fail to **45 pass / 0 fail**.

Each new assertion was checked by breaking the property it guards and confirming it reddens:

| mutation | assertion that fails |
|---|---|
| make one torchvision companion bare | every torchvision constraint is upper-bounded |
| drop the upper bound from one torchaudio companion | every torchaudio constraint is upper-bounded |
| put a literal `"torch>=2.4,<2.11.0"` on a pip install line | no pip install hardcodes a torch pin |
| remove the top-level default assignment | default TORCH_CONSTRAINT assignment exists |

The whole `tests/sh` suite was run against this branch and against `main`: the only difference is `test_torch_constraint.sh` going green. `test_install_host_defaults.sh` fails on both, and the Backend CI workflow skips it deliberately.
