### PR TITLE
pip: declare click, which typer no longer pulls in

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,10 @@ dependencies = [
     # Every CLI command imports studio.backend.*, which reaches structlog at
     # module level. The rest of the server stack lives in the studio extra.
     "structlog>=24.1.0",
+    # unsloth_cli/commands/start.py imports click, and unsloth_cli/__init__.py
+    # imports that, so every command needs it. typer supplied it until 0.27
+    # dropped the dependency, which left this satisfied only by chance.
+    "click>=8.0",
 ]
 
 [project.scripts]

--- a/tests/studio/install/test_studio_extra_matches_requirements.py
+++ b/tests/studio/install/test_studio_extra_matches_requirements.py
@@ -17,8 +17,9 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 STUDIO_TXT = REPO_ROOT / "studio" / "backend" / "requirements" / "studio.txt"
 
-# Imported at module scope by the studio.backend chain every CLI command walks.
-CORE_RUNTIME_PACKAGES = ("structlog",)
+# Imported at module scope by the chain every CLI command walks: structlog via
+# studio.backend, click via unsloth_cli/commands/start.py.
+CORE_RUNTIME_PACKAGES = ("structlog", "click")
 
 
 def _load_pyproject() -> dict:


### PR DESCRIPTION
## Summary

`unsloth_cli/commands/start.py:25` imports `click` at module scope, and `unsloth_cli/__init__.py:36` imports that module, so every `unsloth` command needs click before it does anything. It is used for real: `click.Context` in `parse_args` and `click.clear()` in the connection output.

It was never declared. typer supplied it, until it stopped:

```
typer 0.12.0  click requirement -> NONE
typer 0.15.4  click requirement -> click<8.2,>=8.0.0
typer 0.19.0  click requirement -> click>=8.0.0
typer 0.27.0  click requirement -> NONE
```

The declared floor is `typer>=0.12.0`, so a fresh resolve today installs typer 0.27 and no click. The wheel still works because `huggingface_hub` requires `click<9,>=8.4.2`, so click arrives transitively. That is luck, not a declaration, and it is the same shape as the structlog gap in #7493: an undeclared import that something else happened to satisfy until it did not.

## How it showed up

Building a wheel from a dependency list that has typer but not huggingface_hub, and installing it into a fresh venv:

```
$ unsloth --help
  File ".../unsloth_cli/commands/start.py", line 25, in <module>
    import click
ModuleNotFoundError: No module named 'click'
```

Not one command, all of them, before argument parsing.

## Changes

- `click>=8.0` becomes a core dependency.
- `tests/studio/install/test_studio_extra_matches_requirements.py` now checks click alongside structlog, so the next import that a transitive dependency happens to satisfy does not go unnoticed.

## Testing

Wheel built from this branch: 29 core `Requires-Dist` entries with `click>=8.0` and `structlog>=24.1.0` both present, `Provides-Extra: studio` intact, torch and the rest of the ML stack unchanged. Drift test 4 passed. Fresh install of the fixed wheel: `unsloth --help` exits 0 with click 8.4.2.

Related: #7493
