### PR TITLE
Pin utf-8 on the two marker reads/writes added with the Vulkan backend

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5644,7 +5644,7 @@ def sync_marker_llama_backend(install_dir: Path, llama_backend: str | None) -> N
     """Sync the persisted llama.cpp backend when the bundle is reused unchanged."""
     marker_path = install_dir / "UNSLOTH_PREBUILT_INFO.json"
     try:
-        marker = json.loads(marker_path.read_text())
+        marker = json.loads(marker_path.read_text(encoding = "utf-8"))
     except (OSError, ValueError):
         return
     if not isinstance(marker, dict) or marker.get("llama_backend") == llama_backend:
@@ -5653,7 +5653,7 @@ def sync_marker_llama_backend(install_dir: Path, llama_backend: str | None) -> N
         marker.pop("llama_backend", None)
     else:
         marker["llama_backend"] = llama_backend
-    marker_path.write_text(json.dumps(marker, indent = 2) + "\n")
+    marker_path.write_text(json.dumps(marker, indent = 2) + "\n", encoding = "utf-8")
     log(f"existing install reused; recorded llama_backend={llama_backend!r} from this run")
 
 


### PR DESCRIPTION
`test_shipping_code_names_an_encoding` is red on `main` right now, so Backend CI fails on `main` itself and on every PR that merges it.

```
AssertionError: 2 text read/write call sites in shipping code let the operator's
locale decide the encoding, so they crash or silently produce mojibake on Windows.
Pass encoding = "utf-8":
['studio/install_llama_prebuilt.py:5656: write_text()',
 'studio/install_llama_prebuilt.py:5647: read_text()']
```

Reproduced on a clean checkout of `main` at `7917c7828`: **1 failed, 7 passed**.

## Cause

#7373 added `sync_marker_llama_backend`, whose `read_text()` / `write_text()` pair does not name an encoding, so both fall back to `locale.getencoding()`. The guard that forbids this landed in #7486 a few commits earlier, so the rule predates the call sites; nothing about the Vulkan work is wrong beyond the missing kwarg.

`main` is also internally inconsistent about this one file. The create path 26 lines above, at line 5621, already writes it as utf-8:

```python
(install_dir / "UNSLOTH_PREBUILT_INFO.json").write_text(
    json.dumps(metadata, indent = 2) + "\n", encoding = "utf-8"
)
```

so `UNSLOTH_PREBUILT_INFO.json` is written as utf-8 and read back under the operator locale.

## Scope

Stated plainly, because the guard's wording overstates it for these two particular call sites: `json.dumps` defaults to `ensure_ascii = True`, so the marker this module writes is pure ASCII and round-trips under cp1252 as well as utf-8. The real exposure is a marker produced or hand-edited by something else.

A decode failure on the read would not even surface as a crash: `UnicodeDecodeError` subclasses `ValueError`, and the surrounding `except (OSError, ValueError)` swallows it into the early `return`, leaving the backend silently unsynced.

So this restores a green suite and makes the file self-consistent. It is not a fix for a live crash, and I would rather say that than imply otherwise.

## Verification

| Suite | Before | After |
|---|---|---|
| `tests/test_runtime_text_encoding.py` | 1 failed, 7 passed | **8 passed** |
| `tests/test_source_read_encoding.py` | 1 passed | 1 passed |

`python -m py_compile studio/install_llama_prebuilt.py` clean. The diff is two `encoding = "utf-8"` kwargs and nothing else.
