### PR TITLE
Studio: allow DoRA training on Apple Silicon

### DIFF
--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -2431,6 +2431,39 @@ def _normalize_mlx_studio_optimizer(value):
         return opt
 
 
+def _mlx_dora_peft_kwargs(config, get_peft_model):
+    """LoRA kwargs a DoRA request adds for MLX, or raise why it cannot run.
+
+    Only version skew is decided here; whether the selected modules can carry
+    DoRA depends on the loaded model, so the MLX backend refuses those itself.
+    """
+    import inspect
+
+    if not config.get("use_dora"):
+        return {}
+    try:
+        parameter = inspect.signature(get_peft_model).parameters.get("use_dora")
+    except (TypeError, ValueError):
+        parameter = None
+    # The name alone is not support: `**use_dora` collects anything, which is
+    # what the unsupporting version already does, and the positional-only and
+    # `*use_dora` kinds cannot be bound by keyword at all.
+    named = parameter is not None and parameter.kind in (
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    )
+    if not named:
+        raise NotImplementedError(
+            "DoRA on Apple Silicon needs an unsloth-zoo whose MLX "
+            "get_peft_model takes use_dora, and this install cannot be "
+            "confirmed to. The version that predates MLX DoRA accepts the "
+            "request and trains plain LoRA instead, so the run stops here "
+            "rather than guessing. Update unsloth-zoo, or pick a different "
+            "LoRA variant."
+        )
+    return {"use_dora": True}
+
+
 def _normalize_mlx_studio_scheduler(value):
     raw = str(value or "linear").strip().lower()
     if raw not in _MLX_STUDIO_LR_SCHEDULERS:
@@ -2659,10 +2692,6 @@ def _run_mlx_training(event_queue, stop_queue, config):
         message = "LoftQ is not supported for MLX training yet."
         _send("error", error = message)
         raise NotImplementedError(message)
-    if config.get("use_dora"):
-        message = "DoRA is not supported for MLX training yet."
-        _send("error", error = message)
-        raise NotImplementedError(message)
     if config.get("is_embedding"):
         message = "Embedding model training is not supported for MLX training yet."
         _send("error", error = message)
@@ -2671,6 +2700,12 @@ def _run_mlx_training(event_queue, stop_queue, config):
         message = "Continued Pretraining is not supported for MLX training yet."
         _send("error", error = message)
         raise NotImplementedError(message)
+    # Decided before the model loads, so version skew does not cost a download.
+    try:
+        mlx_dora_kwargs = _mlx_dora_peft_kwargs(config, FastMLXModel.get_peft_model)
+    except NotImplementedError as exc:
+        _send("error", error = str(exc))
+        raise
 
     optim_name = _normalize_mlx_studio_optimizer(config.get("optim", "adamw_8bit"))
     lr_scheduler_type = _normalize_mlx_studio_scheduler(config.get("lr_scheduler_type", "linear"))
@@ -2811,6 +2846,7 @@ def _run_mlx_training(event_queue, stop_queue, config):
             ],
             use_gradient_checkpointing = use_grad_checkpoint,
         )
+        peft_kwargs.update(mlx_dora_kwargs)
         finetune_language = config.get("finetune_language_layers", True)
         finetune_attention = config.get("finetune_attention_modules", True)
         finetune_mlp = config.get("finetune_mlp_modules", True)

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -2432,11 +2432,7 @@ def _normalize_mlx_studio_optimizer(value):
 
 
 def _mlx_dora_peft_kwargs(config, get_peft_model):
-    """LoRA kwargs a DoRA request adds for MLX, or raise why it cannot run.
-
-    Only version skew is decided here; whether the selected modules can carry
-    DoRA depends on the loaded model, so the MLX backend refuses those itself.
-    """
+    """LoRA kwargs a DoRA request adds for MLX, or raise why it cannot run."""
     import inspect
 
     if not config.get("use_dora"):
@@ -2445,9 +2441,8 @@ def _mlx_dora_peft_kwargs(config, get_peft_model):
         parameter = inspect.signature(get_peft_model).parameters.get("use_dora")
     except (TypeError, ValueError):
         parameter = None
-    # The name alone is not support: `**use_dora` collects anything, which is
-    # what the unsupporting version already does, and the positional-only and
-    # `*use_dora` kinds cannot be bound by keyword at all.
+    # A **kwargs catch-all absorbs use_dora and trains plain LoRA, so the
+    # parameter must be named and bindable by keyword.
     named = parameter is not None and parameter.kind in (
         inspect.Parameter.POSITIONAL_OR_KEYWORD,
         inspect.Parameter.KEYWORD_ONLY,

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -873,11 +873,6 @@ def _validate_training_platform(request: TrainingStartRequest) -> None:
             status_code = 400,
             detail = "LoftQ is not supported for MLX training yet.",
         )
-    if request.use_dora:
-        raise HTTPException(
-            status_code = 400,
-            detail = "DoRA is not supported for MLX training yet.",
-        )
 
 
 _RESUME_DATASET_DEFAULTS = {

--- a/studio/backend/tests/test_mlx_training_worker_config.py
+++ b/studio/backend/tests/test_mlx_training_worker_config.py
@@ -22,6 +22,7 @@ def _load_worker_module():
         "utils.native_tls",
         "utils.training_runs",
         "utils.wheel_utils",
+        "utils.training_runs",
     )
     previous_modules = {name: sys.modules.get(name) for name in stub_names}
 
@@ -33,7 +34,9 @@ def _load_worker_module():
         sys.modules["loggers"] = loggers
 
         utils = types.ModuleType("utils")
-        utils.__path__ = []
+        # Real package directory: an empty __path__ shadows the package and
+        # breaks the worker's own imports. Only the stubs below replace it.
+        utils.__path__ = [str(Path(__file__).resolve().parents[1] / "utils")]
         sys.modules["utils"] = utils
 
         child_stdio = types.ModuleType("utils.child_stdio")
@@ -92,6 +95,7 @@ _mlx_vlm_resized_image_layout = _worker._mlx_vlm_resized_image_layout
 _copy_mlx_vlm_image_processor = _worker._copy_mlx_vlm_image_processor
 _resize_mlx_vlm_image = _worker._resize_mlx_vlm_image
 _adapt_for_mlx_vlm = _worker._adapt_for_mlx_vlm
+_mlx_dora_peft_kwargs = _worker._mlx_dora_peft_kwargs
 
 
 def test_mlx_studio_optimizer_aliases_are_explicit():
@@ -108,6 +112,68 @@ def test_mlx_studio_rejects_unknown_optimizer():
 def test_mlx_studio_rejects_unknown_scheduler():
     with pytest.raises(ValueError, match = "Unsupported LR scheduler for MLX training"):
         _normalize_mlx_studio_scheduler("linear_typo")
+
+
+def test_mlx_dora_requires_the_named_use_dora_parameter():
+    # The release predating MLX DoRA swallows use_dora through this catch-all
+    # and trains plain LoRA, so accepting-the-keyword is not support.
+    def old_zoo(
+        model,
+        r = 16,
+        **kwargs,
+    ):
+        return model
+
+    def new_zoo(
+        model,
+        r = 16,
+        use_dora = False,
+        **kwargs,
+    ):
+        return model
+
+    def keyword_only_zoo(model, *, use_dora = False):
+        return model
+
+    def positional_only_zoo(
+        model,
+        use_dora = False,
+        /,
+        **kwargs,
+    ):
+        return model
+
+    def var_positional_zoo(model, *use_dora):
+        return model
+
+    def var_keyword_zoo(model, **use_dora):
+        return model
+
+    for usable in (new_zoo, keyword_only_zoo):
+        assert _mlx_dora_peft_kwargs({"use_dora": True}, usable) == {"use_dora": True}
+    with pytest.raises(NotImplementedError, match = "unsloth-zoo"):
+        _mlx_dora_peft_kwargs({"use_dora": True}, old_zoo)
+    # None of these kinds prove support: two cannot be bound by keyword, and
+    # `**use_dora` only collects it the way the unsupporting version does.
+    for unusable in (positional_only_zoo, var_positional_zoo, var_keyword_zoo):
+        with pytest.raises(NotImplementedError, match = "unsloth-zoo"):
+            _mlx_dora_peft_kwargs({"use_dora": True}, unusable)
+    # An unreadable signature (inspect.signature raises here) is not support.
+    with pytest.raises(NotImplementedError, match = "unsloth-zoo"):
+        _mlx_dora_peft_kwargs({"use_dora": True}, object())
+    # An image-bearing dataset is not proof of a vision model; a text model
+    # can still train language-only DoRA from it.
+    assert _mlx_dora_peft_kwargs(
+        {
+            "use_dora": True,
+            "is_dataset_image": True,
+            "finetune_vision_layers": True,
+        },
+        new_zoo,
+    ) == {"use_dora": True}
+    # Nothing added, nothing checked, when DoRA was not requested.
+    assert _mlx_dora_peft_kwargs({}, old_zoo) == {}
+    assert _mlx_dora_peft_kwargs({"use_dora": False}, old_zoo) == {}
 
 
 def test_mlx_studio_keeps_hf_style_tokenizer_dual_purpose():

--- a/studio/backend/tests/test_mlx_training_worker_config.py
+++ b/studio/backend/tests/test_mlx_training_worker_config.py
@@ -34,8 +34,8 @@ def _load_worker_module():
         sys.modules["loggers"] = loggers
 
         utils = types.ModuleType("utils")
-        # Real package directory: an empty __path__ shadows the package and
-        # breaks the worker's own imports. Only the stubs below replace it.
+        # An empty __path__ shadows the real package and breaks the worker's own
+        # imports; only the stubs below replace it.
         utils.__path__ = [str(Path(__file__).resolve().parents[1] / "utils")]
         sys.modules["utils"] = utils
 
@@ -115,8 +115,8 @@ def test_mlx_studio_rejects_unknown_scheduler():
 
 
 def test_mlx_dora_requires_the_named_use_dora_parameter():
-    # The release predating MLX DoRA swallows use_dora through this catch-all
-    # and trains plain LoRA, so accepting-the-keyword is not support.
+    # A **kwargs catch-all absorbs use_dora and trains plain LoRA, so accepting the
+    # keyword is not support.
     def old_zoo(
         model,
         r = 16,
@@ -153,16 +153,13 @@ def test_mlx_dora_requires_the_named_use_dora_parameter():
         assert _mlx_dora_peft_kwargs({"use_dora": True}, usable) == {"use_dora": True}
     with pytest.raises(NotImplementedError, match = "unsloth-zoo"):
         _mlx_dora_peft_kwargs({"use_dora": True}, old_zoo)
-    # None of these kinds prove support: two cannot be bound by keyword, and
-    # `**use_dora` only collects it the way the unsupporting version does.
     for unusable in (positional_only_zoo, var_positional_zoo, var_keyword_zoo):
         with pytest.raises(NotImplementedError, match = "unsloth-zoo"):
             _mlx_dora_peft_kwargs({"use_dora": True}, unusable)
-    # An unreadable signature (inspect.signature raises here) is not support.
     with pytest.raises(NotImplementedError, match = "unsloth-zoo"):
         _mlx_dora_peft_kwargs({"use_dora": True}, object())
-    # An image-bearing dataset is not proof of a vision model; a text model
-    # can still train language-only DoRA from it.
+    # An image-bearing dataset is not proof of a vision model; a text
+    # model can still train language-only DoRA.
     assert _mlx_dora_peft_kwargs(
         {
             "use_dora": True,
@@ -171,7 +168,6 @@ def test_mlx_dora_requires_the_named_use_dora_parameter():
         },
         new_zoo,
     ) == {"use_dora": True}
-    # Nothing added, nothing checked, when DoRA was not requested.
     assert _mlx_dora_peft_kwargs({}, old_zoo) == {}
     assert _mlx_dora_peft_kwargs({"use_dora": False}, old_zoo) == {}
 

--- a/studio/backend/tests/test_training_cached_start.py
+++ b/studio/backend/tests/test_training_cached_start.py
@@ -1239,7 +1239,6 @@ def test_streaming_rejects_cached_dataset_hints(cache_overrides):
         ({"is_embedding": True}, "Embedding model training"),
         ({"is_dataset_audio": True}, "Audio dataset training"),
         ({"use_loftq": True}, "LoftQ"),
-        ({"use_dora": True}, "DoRA"),
     ],
 )
 def test_mlx_start_rejects_unsupported_training_config(request_overrides, expected):
@@ -1257,6 +1256,22 @@ def test_mlx_start_rejects_unsupported_training_config(request_overrides, expect
 
     assert exc_info.value.status_code == 400
     assert expected in exc_info.value.detail
+
+
+def test_mlx_start_accepts_dora():
+    # MLX trains DoRA, so the platform gate must let it through. LoftQ is
+    # asserted alongside it so a gate that stopped refusing anything at all
+    # cannot pass this test.
+    from utils.hardware import hardware
+
+    route = _load_route_module("training_route_mlx_accepts_dora")
+
+    with patch.object(hardware, "DEVICE", hardware.DeviceType.MLX):
+        route._validate_training_platform(_request(use_dora = True))
+        with pytest.raises(HTTPException) as exc_info:
+            route._validate_training_platform(_request(use_loftq = True))
+
+    assert "LoftQ" in exc_info.value.detail
 
 
 def test_mlx_start_detects_hardware_before_platform_validation():

--- a/studio/backend/tests/test_training_cached_start.py
+++ b/studio/backend/tests/test_training_cached_start.py
@@ -1259,8 +1259,7 @@ def test_mlx_start_rejects_unsupported_training_config(request_overrides, expect
 
 
 def test_mlx_start_accepts_dora():
-    # MLX trains DoRA, so the platform gate must let it through. LoftQ is
-    # asserted alongside it so a gate that stopped refusing anything at all
+    # LoftQ is asserted alongside DoRA so a gate that stopped refusing anything at all
     # cannot pass this test.
     from utils.hardware import hardware
 

--- a/studio/frontend/src/features/studio/sections/lora-params-section.tsx
+++ b/studio/frontend/src/features/studio/sections/lora-params-section.tsx
@@ -54,6 +54,11 @@ export function LoraParamsSection(): ReactElement | null {
   const [open, setOpen] = useState(true);
   const isCpt = store.trainingMethod === "cpt";
   const showVisionLora = store.isVisionModel && store.isDatasetImage === true;
+  // MLX refuses DoRA once vision layers are in the run. `isVisionModel` is
+  // fetched metadata that can go stale, so this only stops the combination
+  // being newly selected; the loaded model still settles an existing one.
+  const doraNeedsVisionOff =
+    deviceType === "mac" && showVisionLora && store.finetuneVisionLayers;
 
   if (!isAdapterMethod(store.trainingMethod)) {
     return null;
@@ -246,11 +251,13 @@ export function LoraParamsSection(): ReactElement | null {
                 store.trainingMethod,
                 deviceType,
               );
+              const needsVisionOff =
+                option.value === "dora" && doraNeedsVisionOff;
               return (
                 <button
                   key={option.value}
                   type="button"
-                  disabled={unsupportedOnMlx}
+                  disabled={unsupportedOnMlx || needsVisionOff}
                   aria-pressed={store.loraVariant === option.value}
                   onClick={() => store.setLoraVariant(option.value)}
                   className={`flex-1 corner-squircle rounded-[14px] border px-3 py-2 text-left transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-60 ${selectableOptionStateClassName(store.loraVariant === option.value)}`}
@@ -259,7 +266,9 @@ export function LoraParamsSection(): ReactElement | null {
                   <p className="text-ui-10 text-muted-foreground">
                     {unsupportedOnMlx
                       ? t("studio.params.notSupportedAppleSilicon")
-                      : option.desc}
+                      : needsVisionOff
+                        ? t("studio.params.doraNeedsVisionLayersOff")
+                        : option.desc}
                   </p>
                 </button>
               );

--- a/studio/frontend/src/features/studio/sections/lora-params-section.tsx
+++ b/studio/frontend/src/features/studio/sections/lora-params-section.tsx
@@ -54,9 +54,8 @@ export function LoraParamsSection(): ReactElement | null {
   const [open, setOpen] = useState(true);
   const isCpt = store.trainingMethod === "cpt";
   const showVisionLora = store.isVisionModel && store.isDatasetImage === true;
-  // MLX refuses DoRA once vision layers are in the run. `isVisionModel` is
-  // fetched metadata that can go stale, so this only stops the combination
-  // being newly selected; the loaded model still settles an existing one.
+  // `isVisionModel` can go stale, so this blocks only a NEW selection;
+  // the backend settles an existing one.
   const doraNeedsVisionOff =
     deviceType === "mac" && showVisionLora && store.finetuneVisionLayers;
 

--- a/studio/frontend/src/features/studio/sections/use-mlx-training-config-policy.ts
+++ b/studio/frontend/src/features/studio/sections/use-mlx-training-config-policy.ts
@@ -15,8 +15,10 @@ export function useMlxTrainingConfigPolicy(): void {
     })),
   );
 
+  // Only loftq: MLX trains DoRA, so clearing a `dora` selection here would
+  // silently substitute plain LoRA for the run the user asked for.
   useEffect(() => {
-    if (isMac && (loraVariant === "loftq" || loraVariant === "dora")) {
+    if (isMac && loraVariant === "loftq") {
       useTrainingConfigStore.setState({ loraVariant: "lora" });
     }
   }, [isMac, loraVariant]);

--- a/studio/frontend/src/features/studio/sections/use-mlx-training-config-policy.ts
+++ b/studio/frontend/src/features/studio/sections/use-mlx-training-config-policy.ts
@@ -15,8 +15,8 @@ export function useMlxTrainingConfigPolicy(): void {
     })),
   );
 
-  // Only loftq: MLX trains DoRA, so clearing a `dora` selection here would
-  // silently substitute plain LoRA for the run the user asked for.
+  // Only loftq: clearing a persisted `dora` selection would silently substitute plain
+  // LoRA.
   useEffect(() => {
     if (isMac && loraVariant === "loftq") {
       useTrainingConfigStore.setState({ loraVariant: "lora" });

--- a/studio/frontend/src/features/training/lib/training-methods.ts
+++ b/studio/frontend/src/features/training/lib/training-methods.ts
@@ -63,11 +63,7 @@ export function isTrainingLoraVariantSupportedOnDevice(
     trainingMethod === "qlora" ||
     trainingMethod === "lora" ||
     trainingMethod === "cpt";
-  return (
-    deviceType !== "mac" ||
-    !usesAdapter ||
-    (loraVariant !== "loftq" && loraVariant !== "dora")
-  );
+  return deviceType !== "mac" || !usesAdapter || loraVariant !== "loftq";
 }
 
 export function parseBackendTrainingMethod(

--- a/studio/frontend/src/i18n/locales/ar.ts
+++ b/studio/frontend/src/i18n/locales/ar.ts
@@ -1709,6 +1709,7 @@ export const ar = {
       memoryEfficient: "موفّر للذاكرة",
       weightDecomposed: "أوزان مُفكَّكة",
       notSupportedAppleSilicon: "غير مدعوم على Apple Silicon",
+      doraNeedsVisionLayersOff: "أوقف تدريب طبقات الرؤية لاستخدام DoRA",
       optimization: "التحسين",
       schedule: "الجدولة",
       memory: "الذاكرة",

--- a/studio/frontend/src/i18n/locales/de.ts
+++ b/studio/frontend/src/i18n/locales/de.ts
@@ -1762,6 +1762,7 @@ export const de = {
       memoryEfficient: "Speichereffizient",
       weightDecomposed: "Gewichtszerlegt",
       notSupportedAppleSilicon: "Auf Apple Silicon nicht unterstützt",
+      doraNeedsVisionLayersOff: "Training der Vision-Schichten deaktivieren, um DoRA zu nutzen",
       optimization: "Optimierung",
       schedule: "Zeitplan",
       memory: "Speicher",

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -1696,6 +1696,7 @@ export const en = {
       memoryEfficient: "Memory Efficient",
       weightDecomposed: "Weight-Decomposed",
       notSupportedAppleSilicon: "Not supported on Apple Silicon",
+      doraNeedsVisionLayersOff: "Turn off vision layer training to use DoRA",
       optimization: "Optimization",
       schedule: "Schedule",
       memory: "Memory",

--- a/studio/frontend/src/i18n/locales/es.ts
+++ b/studio/frontend/src/i18n/locales/es.ts
@@ -1756,6 +1756,7 @@ export const es = {
       memoryEfficient: "Eficiente en memoria",
       weightDecomposed: "Pesos descompuestos",
       notSupportedAppleSilicon: "No compatible con Apple Silicon",
+      doraNeedsVisionLayersOff: "Desactiva el entrenamiento de las capas de visión para usar DoRA",
       optimization: "Optimización",
       schedule: "Programación",
       memory: "Memoria",

--- a/studio/frontend/src/i18n/locales/fr.ts
+++ b/studio/frontend/src/i18n/locales/fr.ts
@@ -1769,6 +1769,7 @@ export const fr = {
       memoryEfficient: "Économe en mémoire",
       weightDecomposed: "Poids décomposés",
       notSupportedAppleSilicon: "Non pris en charge sur Apple Silicon",
+      doraNeedsVisionLayersOff: "Désactivez l'entraînement des couches de vision pour utiliser DoRA",
       optimization: "Optimisation",
       schedule: "Planification",
       memory: "Mémoire",

--- a/studio/frontend/src/i18n/locales/hi.ts
+++ b/studio/frontend/src/i18n/locales/hi.ts
@@ -1717,6 +1717,7 @@ export const hi = {
       memoryEfficient: "मेमोरी कुशल",
       weightDecomposed: "भार-विघटित",
       notSupportedAppleSilicon: "Apple Silicon पर समर्थित नहीं",
+      doraNeedsVisionLayersOff: "DoRA उपयोग करने के लिए विज़न लेयर्स ट्रेनिंग बंद करें",
       optimization: "ऑप्टिमाइज़ेशन",
       schedule: "शेड्यूल",
       memory: "मेमोरी",

--- a/studio/frontend/src/i18n/locales/it.ts
+++ b/studio/frontend/src/i18n/locales/it.ts
@@ -1720,6 +1720,7 @@ export const it = {
         ariaLabel: "Modalità dei parametri",
       },
       notSupportedAppleSilicon: "Non supportato su Apple Silicon",
+      doraNeedsVisionLayersOff: "Disattiva l'addestramento dei livelli visivi per usare DoRA",
       projectName: "Nome del progetto",
       optional: "Facoltativo",
       projectNameDescription:

--- a/studio/frontend/src/i18n/locales/ja.ts
+++ b/studio/frontend/src/i18n/locales/ja.ts
@@ -1674,6 +1674,7 @@ export const ja = {
       memoryEfficient: "メモリ効率化",
       weightDecomposed: "重み分解",
       notSupportedAppleSilicon: "Apple Silicon ではサポートされていません",
+      doraNeedsVisionLayersOff: "DoRA を使うにはビジョンレイヤーの学習をオフにしてください",
       optimization: "最適化",
       schedule: "スケジュール",
       memory: "メモリ",

--- a/studio/frontend/src/i18n/locales/ko.ts
+++ b/studio/frontend/src/i18n/locales/ko.ts
@@ -1708,6 +1708,7 @@ export const ko = {
       memoryEfficient: "메모리 효율적",
       weightDecomposed: "가중치 분해",
       notSupportedAppleSilicon: "Apple Silicon에서는 지원되지 않음",
+      doraNeedsVisionLayersOff: "DoRA를 사용하려면 비전 레이어 학습을 끄세요",
       optimization: "최적화",
       schedule: "스케줄",
       memory: "메모리",

--- a/studio/frontend/src/i18n/locales/pt-br.ts
+++ b/studio/frontend/src/i18n/locales/pt-br.ts
@@ -1732,6 +1732,7 @@ export const ptBR = {
       memoryEfficient: "Eficiente em Memória",
       weightDecomposed: "Pesos Decompostos",
       notSupportedAppleSilicon: "Não compatível com Apple Silicon",
+      doraNeedsVisionLayersOff: "Desative o treinamento das camadas de visão para usar DoRA",
       optimization: "Otimização",
       schedule: "Cronograma",
       memory: "Memória",

--- a/studio/frontend/src/i18n/locales/ru.ts
+++ b/studio/frontend/src/i18n/locales/ru.ts
@@ -1733,6 +1733,7 @@ export const ru = {
       memoryEfficient: "Экономия памяти",
       weightDecomposed: "Декомпозиция весов",
       notSupportedAppleSilicon: "Не поддерживается на Apple Silicon",
+      doraNeedsVisionLayersOff: "Отключите обучение слоёв зрения, чтобы использовать DoRA",
       optimization: "Оптимизация",
       schedule: "Расписание",
       memory: "Память",

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -1649,6 +1649,7 @@ export const zhCN = {
       memoryEfficient: "节省内存",
       weightDecomposed: "权重分解",
       notSupportedAppleSilicon: "Apple 芯片暂不支持",
+      doraNeedsVisionLayersOff: "关闭视觉层训练以使用 DoRA",
       optimization: "优化",
       schedule: "计划",
       memory: "内存",

--- a/studio/frontend/tests/training-validation.test.ts
+++ b/studio/frontend/tests/training-validation.test.ts
@@ -263,19 +263,17 @@ test("training validation allows audio-capable vision models on MLX with image d
 });
 
 test("training validation rejects unsupported LoRA variants on MLX", () => {
-  for (const loraVariant of ["loftq", "dora"] as const) {
-    assert.deepEqual(
-      validateTrainingConfig({ ...validConfig, loraVariant }, "mac"),
-      {
-        ok: false,
-        errorKey: "studio.params.notSupportedAppleSilicon",
-      },
-    );
-    assert.deepEqual(
-      validateTrainingConfig({ ...validConfig, loraVariant }, "linux"),
-      { ok: true, errorKey: null },
-    );
-  }
+  assert.deepEqual(
+    validateTrainingConfig({ ...validConfig, loraVariant: "loftq" }, "mac"),
+    {
+      ok: false,
+      errorKey: "studio.params.notSupportedAppleSilicon",
+    },
+  );
+  assert.deepEqual(
+    validateTrainingConfig({ ...validConfig, loraVariant: "loftq" }, "linux"),
+    { ok: true, errorKey: null },
+  );
   assert.deepEqual(
     validateTrainingConfig(
       { ...validConfig, trainingMethod: "full", loraVariant: "dora" },
@@ -283,6 +281,22 @@ test("training validation rejects unsupported LoRA variants on MLX", () => {
     ),
     { ok: true, errorKey: null },
   );
+});
+
+test("training validation accepts DoRA on MLX under an adapter method", () => {
+  for (const trainingMethod of ["lora", "qlora", "cpt"] as const) {
+    assert.deepEqual(
+      validateTrainingConfig(
+        { ...validConfig, trainingMethod, loraVariant: "dora" },
+        "mac",
+      ),
+      // cpt is refused on MLX for its own reason, which must not be read as
+      // DoRA being refused.
+      trainingMethod === "cpt"
+        ? { ok: false, errorKey: "studio.params.notSupportedAppleSilicon" }
+        : { ok: true, errorKey: null },
+    );
+  }
 });
 
 test("training validation keeps CPT and embedding training available off MLX", () => {

--- a/studio/frontend/tests/training-validation.test.ts
+++ b/studio/frontend/tests/training-validation.test.ts
@@ -290,8 +290,7 @@ test("training validation accepts DoRA on MLX under an adapter method", () => {
         { ...validConfig, trainingMethod, loraVariant: "dora" },
         "mac",
       ),
-      // cpt is refused on MLX for its own reason, which must not be read as
-      // DoRA being refused.
+      // cpt is refused on MLX for its own reason, not for DoRA.
       trainingMethod === "cpt"
         ? { ok: false, errorKey: "studio.params.notSupportedAppleSilicon" }
         : { ok: true, errorKey: null },

--- a/tests/studio/test_mlx_training_worker_behaviors.py
+++ b/tests/studio/test_mlx_training_worker_behaviors.py
@@ -35,6 +35,105 @@ def test_run_mlx_training_passes_token_to_from_pretrained():
     assert found, "FastMLXModel.from_pretrained call not found in _run_mlx_training"
 
 
+def test_mlx_dora_decided_before_load_and_merged_into_peft_kwargs():
+    """The DoRA decision must be wired to happen before the base model is
+    fetched, and to feed the wrap call.
+
+    Dropping the merge would accept a DoRA request and silently train plain
+    LoRA; deciding after the load would make an unsupported unsloth-zoo cost
+    a multi-gigabyte download first.
+
+    This checks WIRING, not runtime behavior: the decision precedes the load,
+    takes the run config, probes the same callable the wrap invokes, and its
+    result is merged into the mapping that wrap expands without being rebound
+    in between. It cannot see through code that keeps the shape and defeats
+    the effect -- burying the merge under a false condition, unsetting the key
+    afterwards -- because the test and the code it reads live together; the
+    real-model behavior is covered by the MLX backend's own tests.
+
+    This asserts one specific shape — a `peft_kwargs.update(...)` call and a
+    `**peft_kwargs` wrap call — rather than trying to recognize every
+    equivalent formulation. Rewriting that seam another way (a merge
+    operator, explicit unpacking) is expected to fail here and to be
+    re-expressed, not worked around.
+    """
+    tree = ast.parse(WORKER.read_text(encoding = "utf-8"))
+    fn = _find_func(tree, "_run_mlx_training")
+    assert fn is not None
+
+    decided_at = None
+    decision_target = None
+    for node in ast.walk(fn):
+        if (
+            isinstance(node, ast.Assign)
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Name)
+            and node.value.func.id == "_mlx_dora_peft_kwargs"
+        ):
+            decided_at = node.lineno
+            decision_target = node.targets[0].id
+            # The run's own config and the same callable the wrap invokes --
+            # probing anything else answers for something else.
+            passed = [ast.unparse(arg) for arg in node.value.args]
+            assert passed == [
+                "config",
+                "FastMLXModel.get_peft_model",
+            ], f"unexpected arguments to _mlx_dora_peft_kwargs: {passed}"
+    assert decided_at is not None, "_mlx_dora_peft_kwargs is never called"
+
+    loaded_at = min(
+        node.lineno
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "from_pretrained"
+    )
+    assert decided_at < loaded_at, (
+        "DoRA support must be decided before the base model loads; "
+        f"decided at line {decided_at}, loaded at line {loaded_at}"
+    )
+
+    merge = f"peft_kwargs.update({decision_target})"
+    merged_at = [
+        node.lineno
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Call) and ast.unparse(node) == merge
+    ]
+    assert merged_at, f"expected {merge}, or a DoRA request silently trains plain LoRA"
+    wraps = [
+        node
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Call) and ast.unparse(node.func) == "FastMLXModel.get_peft_model"
+    ]
+    assert wraps, "FastMLXModel.get_peft_model is never called"
+    for wrap in wraps:
+        # A real ** expansion, not a string that merely looks like one.
+        assert any(
+            kw.arg is None and ast.unparse(kw.value) == "peft_kwargs" for kw in wrap.keywords
+        ), (
+            "get_peft_model must expand **peft_kwargs, or the merged DoRA "
+            f"kwargs never reach it: {ast.unparse(wrap)}"
+        )
+    first_wrap = min(wrap.lineno for wrap in wraps)
+    assert (
+        min(merged_at) < first_wrap
+    ), "peft_kwargs must be updated before get_peft_model is called"
+    # ...and not replaced in between, which would drop the merge again.
+    # A Store/Del context covers the rebinding forms a refactor realistically
+    # produces. This is a regression check over one function's line range, not
+    # a proof: string-bound names (import aliases, `case` captures) and
+    # anything sharing the merge's line are outside it.
+    rebound = [
+        node.lineno
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Name)
+        and node.id == "peft_kwargs"
+        and isinstance(node.ctx, (ast.Store, ast.Del))
+        and min(merged_at) < node.lineno < first_wrap
+    ]
+    assert not rebound, f"peft_kwargs rebound at {rebound}, discarding the merge"
+
+
 def test_wandb_init_strips_secret_keys():
     src = WORKER.read_text(encoding = "utf-8")
     assert "_wandb_sensitive" in src, "expected a sensitive-key set near wandb.init"

--- a/tests/studio/test_mlx_training_worker_behaviors.py
+++ b/tests/studio/test_mlx_training_worker_behaviors.py
@@ -36,27 +36,7 @@ def test_run_mlx_training_passes_token_to_from_pretrained():
 
 
 def test_mlx_dora_decided_before_load_and_merged_into_peft_kwargs():
-    """The DoRA decision must be wired to happen before the base model is
-    fetched, and to feed the wrap call.
-
-    Dropping the merge would accept a DoRA request and silently train plain
-    LoRA; deciding after the load would make an unsupported unsloth-zoo cost
-    a multi-gigabyte download first.
-
-    This checks WIRING, not runtime behavior: the decision precedes the load,
-    takes the run config, probes the same callable the wrap invokes, and its
-    result is merged into the mapping that wrap expands without being rebound
-    in between. It cannot see through code that keeps the shape and defeats
-    the effect -- burying the merge under a false condition, unsetting the key
-    afterwards -- because the test and the code it reads live together; the
-    real-model behavior is covered by the MLX backend's own tests.
-
-    This asserts one specific shape — a `peft_kwargs.update(...)` call and a
-    `**peft_kwargs` wrap call — rather than trying to recognize every
-    equivalent formulation. Rewriting that seam another way (a merge
-    operator, explicit unpacking) is expected to fail here and to be
-    re-expressed, not worked around.
-    """
+    """Wiring only: dropping the merge would silently train plain LoRA, and deciding after the load would make an unsupported unsloth-zoo cost a multi-gigabyte download first. One shape is asserted, so an equivalent rewrite is meant to fail here and be re-expressed."""
     tree = ast.parse(WORKER.read_text(encoding = "utf-8"))
     fn = _find_func(tree, "_run_mlx_training")
     assert fn is not None
@@ -72,8 +52,6 @@ def test_mlx_dora_decided_before_load_and_merged_into_peft_kwargs():
         ):
             decided_at = node.lineno
             decision_target = node.targets[0].id
-            # The run's own config and the same callable the wrap invokes --
-            # probing anything else answers for something else.
             passed = [ast.unparse(arg) for arg in node.value.args]
             assert passed == [
                 "config",
@@ -107,7 +85,6 @@ def test_mlx_dora_decided_before_load_and_merged_into_peft_kwargs():
     ]
     assert wraps, "FastMLXModel.get_peft_model is never called"
     for wrap in wraps:
-        # A real ** expansion, not a string that merely looks like one.
         assert any(
             kw.arg is None and ast.unparse(kw.value) == "peft_kwargs" for kw in wrap.keywords
         ), (
@@ -118,11 +95,8 @@ def test_mlx_dora_decided_before_load_and_merged_into_peft_kwargs():
     assert (
         min(merged_at) < first_wrap
     ), "peft_kwargs must be updated before get_peft_model is called"
-    # ...and not replaced in between, which would drop the merge again.
-    # A Store/Del context covers the rebinding forms a refactor realistically
-    # produces. This is a regression check over one function's line range, not
-    # a proof: string-bound names (import aliases, `case` captures) and
-    # anything sharing the merge's line are outside it.
+    # Store/Del only: string-bound names (import aliases, `case` captures)
+    # and the merge's own line are outside this check.
     rebound = [
         node.lineno
         for node in ast.walk(fn)


### PR DESCRIPTION
Follow-up to #7315, which exposed DoRA in Studio but rejected it on the MLX path. The MLX backend now builds DoRA wrappers (unslothai/unsloth-zoo#954), so the rejection can go and the flag can be forwarded instead.

### What changed

**Backend.** The blanket `NotImplementedError` for `use_dora` on the MLX path is gone. `use_dora` is forwarded to the MLX `get_peft_model` only when the installed unsloth-zoo actually supports it, and that decision runs beside the LoftQ / embedding / Continued Pretraining rejections — before the base model loads, so an incompatible pair costs no download.

Support means a **named** `use_dora` parameter of a kind that can carry a flag. This distinction matters: the version without MLX DoRA absorbs the keyword through its `**kwargs` catch-all and trains plain LoRA, so a probe that merely asks whether the callable accepts the keyword would report support on exactly the version that downgrades. Positional-only and `*use_dora` cannot be bound by keyword at all, and `**use_dora` only collects it the way that catch-all already does, so none of those count either; a signature that cannot be read counts as unsupported. Anything short of a usable parameter fails the run with an upgrade message rather than quietly training something else.

Nothing else is decided there. Whether the selected modules can carry DoRA depends on the loaded model — a vision tower or a routed expert cannot — so the MLX backend refuses those itself.

LoftQ, embedding models and Continued Pretraining stay rejected. The mutually-exclusive-variant validator is unchanged apart from its comment, which listed `use_dora` among the flags MLX refuses.

**Frontend.** The DoRA button is no longer disabled on Apple Silicon, and the effect that reset a persisted, model-default or imported `dora` selection back to `lora` no longer fires for it. That reset deserves a note: silently substituting plain LoRA for a requested DoRA run is precisely the failure this work removes, and the parameters panel is collapsed by default, so the swap would have gone unseen.

One narrower gate replaces it. While a vision model on an image dataset has vision-layer training enabled, the button is disabled with a note to turn vision layers off, since the backend refuses DoRA for vision and projector towers. That gate only prevents a **new** selection — `isVisionModel` is fetched metadata that can go stale, so an existing selection is left to the backend, which decides on the loaded model. Two stronger versions were tried and dropped: rewriting the selection (the silent substitution above) and blocking the Start button, which other submission paths bypass and which can falsely refuse a text model whose cached vision flag is stale. LoftQ gating and non-Mac behaviour are untouched.

### Validation

Two tests. One drives the capability decision directly: a named parameter is accepted, a `**kwargs`-only signature and the unusable parameter kinds are refused, an image-bearing dataset does not by itself imply a vision model, and nothing is added when DoRA was not requested. The other pins the wiring by reading the worker's syntax tree, beside the existing test that checks the token reaches `from_pretrained` — the decision precedes the load, takes the run config, probes the same callable the wrap invokes, and its result is merged into the mapping that wrap expands without being rebound in between. That second test was mutation-checked against eight separate ways to defeat the seam, including dropping the merge, moving the decision below the load, wrapping without `**peft_kwargs`, and rebinding the mapping in any of several syntactic forms.

The probe was also checked against real installs rather than only synthetic signatures: it refuses a pre-DoRA unsloth-zoo — which does carry `**kwargs`, so an accepts-the-keyword probe would have said yes — and accepts one with the new parameter.

End to end on Apple Silicon, a 15-step run on `unsloth/Qwen3.5-0.8B` through Studio produced an adapter with `fine_tune_type: "dora"` and one magnitude per adapted module (114/114), each moved off its seeded value; the same configuration with DoRA off produced a plain-LoRA adapter with none. Frontend typecheck and build are clean, and the frontend behaviour is covered by out-of-tree checks that render the real component, since this repository keeps no JS test harness.

Full `studio/backend/tests` shows no new failures against the same base.

### Also in here

The MLX worker-behaviour test file is repaired. Its `utils` stub blanked the package path, which shadowed the real package, so a module-level `from utils.training_runs import ...` in the worker made the whole file fail collection when run on its own. It now points at the real package directory and restores that submodule afterwards. The MLX CI step's name was updated for the one added test.

### Risk

The backend refusal is the authoritative one, and it needs the loaded model; the frontend gate is a convenience that cannot be complete. A user with a pre-existing DoRA selection on a vision model can still start a run that fails at wrap time with a named error. DoRA on a MoE base is likewise refused only after loading, since the default targets there are routed experts.
