### PR TITLE
Studio: Drop <header> from fetched page main content

### DIFF
--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -238,12 +238,15 @@ class _HeaderFrame:
         body, so keep it whole."""
         if not closed_by_own_tag:
             return "".join(self.parts)
-        big_enough = (
-            self.text_chars >= _HEADER_MIN_CHARS
-            or sum(len(part) for part in self.parts) >= _HEADER_MAX_RENDERED_CHARS
-        )
+        headings = "".join(self.heading_parts)
+        # Both sizes measure only the droppable part: a heading is kept either
+        # way, so a long one must not make the rest look big enough to drop.
+        droppable = sum(len(part) for part in self.parts) - len(headings)
+        big_enough = self.text_chars >= _HEADER_MIN_CHARS or droppable >= _HEADER_MAX_RENDERED_CHARS
         if big_enough and self.link_chars >= _HEADER_LINK_DENSITY * self.text_chars:
-            return "".join(self.heading_parts)
+            # The closing tag's blank line is emitted after the heading mark is
+            # popped, so terminate the heading or the body runs into it.
+            return headings + "\n\n" if headings.strip() else headings
         return "".join(self.parts)
 
 
@@ -445,6 +448,7 @@ class _MarkdownRenderer(HTMLParser):
         innermost frame can be the one its own ``</header>`` closed."""
         closed_by_own_tag = own_tag
         while self._header_stack and self._header_stack[-1].depth >= depth:
+            self._finalize_nested_buffers(self._header_stack[-1])
             frame = self._header_stack.pop()
             if self._header_stack:
                 # Roll the tally outward so an enclosing header is judged whole.
@@ -455,6 +459,28 @@ class _MarkdownRenderer(HTMLParser):
             self._dropped_chars += sum(len(part) for part in frame.parts) - len(out)
             self._emit(out)
             closed_by_own_tag = False
+
+    def _finalize_nested_buffers(self, frame: _HeaderFrame) -> None:
+        """Close side buffers opened inside *frame* whose end tags the page omitted.
+
+        Their content is the header's, so it has to land in the frame before the
+        strip is judged; otherwise it is emitted afterwards and escapes."""
+        if self._in_link:
+            self._finish_link()
+        if self._in_inline_code:
+            self._in_inline_code = False
+            self._emit("`")
+        if self._in_cell and not frame.outer_in_cell:
+            self._finish_cell()
+            self._finish_row()
+        if self._in_pre and not frame.outer_in_pre:
+            raw = "".join(self._pre_parts)
+            self._in_pre = False
+            self._emit("\n\n```\n" + raw + "\n```\n\n")
+        while len(self._bq_stack) > frame.outer_bq_depth:
+            prefixed = self._prefix_blockquote("".join(self._bq_stack.pop()))
+            if prefixed:
+                self._emit("\n\n" + prefixed + "\n\n")
 
     def _flush_header_frames(self) -> None:
         """Emit every open header unchanged, abandoning the strip."""

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -193,6 +193,10 @@ _HEADER_LINK_DENSITY = 0.93
 # noisy to trust, so it is left alone. Live link-list headers start at 182
 # chars; the largest link-dense header that carries real content is 93.
 _HEADER_MIN_CHARS = 150
+# A short label can carry a very long href, so a header whose rendered output
+# is this large displaces an article whatever its visible text measures. Live
+# content headers render to at most 363 chars, link lists to 1609 and up.
+_HEADER_MAX_RENDERED_CHARS = 800
 
 
 class _HeaderFrame:
@@ -202,7 +206,15 @@ class _HeaderFrame:
     when the whole subtree has been seen. A header that no end tag ever closes
     is emitted unchanged, which is what browsers render."""
 
-    __slots__ = ("depth", "parts", "heading_spans", "heading_start", "text_chars", "link_chars")
+    __slots__ = (
+        "depth",
+        "parts",
+        "heading_spans",
+        "heading_start",
+        "n_headings",
+        "text_chars",
+        "link_chars",
+    )
 
     def __init__(self, depth: int):
         self.depth = depth
@@ -210,15 +222,27 @@ class _HeaderFrame:
         # Index ranges into parts holding the headings, kept when the rest goes.
         self.heading_spans: list[tuple[int, int]] = []
         self.heading_start: int | None = None
+        self.n_headings: int = 0
+        # Heading text is excluded from both: it is never dropped, so it must not
+        # vote on dropping the rest. Only href anchors count as link furniture.
         self.text_chars: int = 0
         self.link_chars: int = 0
 
-    def render(self) -> str:
-        """The buffer, or only its headings when the header is link furniture."""
-        if (
+    def render(self, closed_by_own_tag: bool) -> str:
+        """The buffer, or only its headings when the header is link furniture.
+
+        Anything other than a matching ``</header>`` means the markup was
+        malformed and the header may have adopted the page body, so it is kept.
+        A heading buffered through a nested blockquote or table cell reaches
+        ``parts`` only when that buffer closes, leaving no usable span, so an
+        incomplete span set also keeps the whole buffer."""
+        if not closed_by_own_tag or len(self.heading_spans) != self.n_headings:
+            return "".join(self.parts)
+        big_enough = (
             self.text_chars >= _HEADER_MIN_CHARS
-            and self.link_chars >= _HEADER_LINK_DENSITY * self.text_chars
-        ):
+            or sum(len(part) for part in self.parts) >= _HEADER_MAX_RENDERED_CHARS
+        )
+        if big_enough and self.link_chars >= _HEADER_LINK_DENSITY * self.text_chars:
             return "".join("".join(self.parts[start:end]) for start, end in self.heading_spans)
         return "".join(self.parts)
 
@@ -258,6 +282,7 @@ class _MarkdownRenderer(HTMLParser):
         # Open <header> buffers, innermost last. Empty unless strip_header.
         self._strip_header = strip_header
         self._header_stack: list[_HeaderFrame] = []
+        self._in_heading: bool = False
 
         # Link state
         self._link_href: str | None = None
@@ -385,18 +410,25 @@ class _MarkdownRenderer(HTMLParser):
                 self._hidden_marks.pop()
             self._close_header_frames(close_at)
 
-    def _close_header_frames(self, depth: int) -> None:
+    def _close_header_frames(
+        self,
+        depth: int,
+        own_tag: bool = False,
+    ) -> None:
         """Judge and emit every buffered header at or below *depth*.
 
-        Any end tag that pops the header off the stack bounds it as conclusively
-        as ``</header>`` does, so an ancestor close judges it the same way."""
+        Only the innermost frame can be closed by its own ``</header>``; an
+        outer one popped by the same end tag was bounded by an ancestor."""
+        closed_by_own_tag = own_tag
         while self._header_stack and self._header_stack[-1].depth >= depth:
             frame = self._header_stack.pop()
             if self._header_stack:
                 # Roll the tally outward so an enclosing header is judged whole.
                 self._header_stack[-1].text_chars += frame.text_chars
                 self._header_stack[-1].link_chars += frame.link_chars
-            self._emit(frame.render())
+                self._header_stack[-1].n_headings += frame.n_headings
+            self._emit(frame.render(closed_by_own_tag))
+            closed_by_own_tag = False
 
     def _flush_header_frames(self) -> None:
         """Emit every open header unchanged, abandoning the strip."""
@@ -404,12 +436,16 @@ class _MarkdownRenderer(HTMLParser):
             self._emit("".join(self._header_stack.pop().parts))
 
     def _count_header_text(self, text: str) -> None:
-        """Tally visible text for the innermost header's link density."""
-        if not self._header_stack:
+        """Tally visible text for the innermost header's link density.
+
+        Heading text is skipped: ``render()`` never drops it, so counting it
+        would let a long linked heading condemn the byline beside it."""
+        if not self._header_stack or self._in_heading:
             return
         chars = len(text.strip())
         self._header_stack[-1].text_chars += chars
-        if self._in_link:
+        # An anchor with no usable href renders as prose, not as a link.
+        if self._in_link and self._link_href:
             self._link_header_chars += chars
 
     def _enter_tag(self, tag: str, attr_dict: dict) -> bool:
@@ -455,7 +491,7 @@ class _MarkdownRenderer(HTMLParser):
                     del self._open_tags[i:]
                     while self._hidden_marks and self._hidden_marks[-1] >= i:
                         self._hidden_marks.pop()
-                    self._close_header_frames(i)
+                    self._close_header_frames(i, own_tag = tag == "header")
                     break
         if self._scope_tags is not None and tag in self._scope_tags and self._scope_depth > 0:
             self._scope_depth -= 1
@@ -487,8 +523,10 @@ class _MarkdownRenderer(HTMLParser):
             return
 
         if tag in _HEADING_TAGS:
+            self._in_heading = True
             if self._header_stack and self._header_stack[-1].heading_start is None:
                 self._header_stack[-1].heading_start = len(self._header_stack[-1].parts)
+                self._header_stack[-1].n_headings += 1
             level = int(tag[1])
             self._emit("\n\n" + "#" * level + " ")
 
@@ -583,9 +621,12 @@ class _MarkdownRenderer(HTMLParser):
 
         if tag in _HEADING_TAGS:
             self._emit("\n\n")
+            self._in_heading = False
             frame = self._header_stack[-1] if self._header_stack else None
             if frame is not None and frame.heading_start is not None:
-                frame.heading_spans.append((frame.heading_start, len(frame.parts)))
+                # An empty span means the heading went into a nested buffer.
+                if len(frame.parts) > frame.heading_start:
+                    frame.heading_spans.append((frame.heading_start, len(frame.parts)))
                 frame.heading_start = None
 
         elif tag == "a":

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -425,6 +425,15 @@ class _MarkdownRenderer(HTMLParser):
         body prose. ATX headings carry their own ``#`` here and so score zero."""
         return _non_heading_chars("".join(self._seg_heading_texts))
 
+    def _drain_pre(self) -> None:
+        """Emit the open ``<pre>`` and empty it, so a late ``</pre>`` cannot replay
+        it outside a stripped header and push the article past the fetch cap."""
+        raw = "".join(self._pre_parts)
+        self._in_pre = False
+        self._pre_parts = []
+        fence = _fence_for(raw)
+        self._emit_replay(f"\n\n{fence}\n{raw}\n{fence}\n\n")
+
     def _emit_replay(self, text: str) -> None:
         """Emit a flushed buffer's own output, which must not be teed as a heading
         a second time (the raw text was teed when it entered the buffer)."""
@@ -497,6 +506,9 @@ class _MarkdownRenderer(HTMLParser):
             frame = self._header_stack[-1]
             frame.heading_parts.append(heading_text + "\n\n")
             frame.heading_chars += len(heading_text)
+            # Preserved by hand, so the gate needs telling too or a title-only card
+            # reads as body prose.
+            self._seg_heading_texts.append(heading_text)
 
     # ------------------------------------------------------------------
     # Tag handlers
@@ -576,17 +588,13 @@ class _MarkdownRenderer(HTMLParser):
         if self._in_inline_code and not frame.outer_in_code:
             self._in_inline_code = False
             self._emit("`")
+        # Before the cell: _finish_row emits, and an open <pre> would swallow the
+        # row into the code block as CODE|  | instead of a cell holding the code.
+        if self._in_pre and not frame.outer_in_pre:
+            self._drain_pre()
         if self._in_cell and self._cell_seq != frame.outer_cell_seq:
             self._finish_cell()
             self._finish_row()
-        if self._in_pre and not frame.outer_in_pre:
-            raw = "".join(self._pre_parts)
-            self._in_pre = False
-            # Drained, not just closed: a late </pre> would replay the block outside the stripped
-            # header and push the article past the cap.
-            self._pre_parts = []
-            fence = _fence_for(raw)
-            self._emit_replay(f"\n\n{fence}\n{raw}\n{fence}\n\n")
         while len(self._bq_stack) > frame.outer_bq_depth:
             prefixed = self._prefix_blockquote("".join(self._bq_stack.pop()))
             if prefixed:
@@ -1108,7 +1116,11 @@ def _select_main_scope_render(source_html: str, tag: str) -> tuple[int, str]:
     A candidate earns its place on the prose it RETAINED, then gets its dropped
     header furniture added back to rank against siblings. Furniture must not buy
     eligibility: a card whose header was the only bulk would otherwise clear the
-    gate on deleted bytes and suppress the ``<main>`` holding the real page."""
+    gate on deleted bytes and suppress the ``<main>`` holding the real page.
+
+    Nor may it dominate: the credit is capped at the retained render, so removed
+    furniture can never be the majority of a score. Uncapped, a teaser with a
+    1000 link header outranked a sibling holding five times its real text."""
     renderer = _new_renderer(source_html, frozenset({tag}), strip_header = True)
     dropped = renderer.scope_dropped
     heading_prose = renderer.scope_heading_prose
@@ -1119,7 +1131,7 @@ def _select_main_scope_render(source_html: str, tag: str) -> tuple[int, str]:
         prose = _non_heading_chars(rendered) - heading_prose[i]
         if prose < _MIN_MAIN_CONTENT_CHARS:
             continue
-        size = len(rendered) + dropped[i]
+        size = len(rendered) + min(dropped[i], len(rendered))
         if size > best_len:
             best_len = size
             best_render = rendered
@@ -1186,8 +1198,17 @@ def _visible_len(line: str) -> int:
     prose: a card holding one [Read](/x?<300 bytes>) otherwise scored 339 visible
     characters off 4 and displaced the article. Scanned, so no backtracking."""
     total, i, n = 0, 0, len(line)
+    open_bracket = False
     while i < n:
-        if line[i] == "]" and i + 1 < n and line[i + 1] == "(":
+        if line[i] == "\\":
+            total += 2
+            i += 2
+            continue
+        if line[i] == "[":
+            open_bracket = True
+        # Without a bracket that opened it, "](" is literal text and the parens after
+        # it are prose: skipping them dropped visible characters from the score.
+        if open_bracket and line[i] == "]" and i + 1 < n and line[i + 1] == "(":
             # Destinations may hold balanced or escaped parens (/card(foo)?q=..), so stopping at
             # the first ) leaves the rest scored as prose.
             j, depth = i + 2, 1
@@ -1205,6 +1226,7 @@ def _visible_len(line: str) -> int:
                 i += 1
                 continue
             i = j
+            open_bracket = False
             continue
         total += 1
         i += 1

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -184,27 +184,23 @@ _BLOCK_TAGS = frozenset(
 _HEADING_TAGS = frozenset({"h1", "h2", "h3", "h4", "h5", "h6"})
 _INLINE_EMPHASIS = {"strong": "**", "b": "**", "em": "*", "i": "*"}
 
-# A <header> is furniture only when it is almost entirely links: site nav, or the
-# 278-language dropdown Wikipedia's Vector 2022 skin puts inside <main>. Article
-# headers carry a byline, date or standfirst, so they are kept. Measured on live
-# pages, link-list headers sit at 0.94-1.00 and content headers at 0.13-0.90.
+# A <header> is furniture only when almost entirely links (site nav, Wikipedia's
+# in-<main> language dropdown). Live link lists measure 0.94-1.00, content headers
+# (byline, date, standfirst) 0.13-0.90.
 _HEADER_LINK_DENSITY = 0.93
-# Below this a header is too small to displace an article, and the ratio too
-# noisy to trust, so it is left alone. Live link-list headers start at 182
-# chars; the largest link-dense header that carries real content is 93.
+# Size floor: below it the ratio is too noisy and the header too small to displace an
+# article. Live link lists start at 182 chars, link-dense content headers top out at 93.
 _HEADER_MIN_CHARS = 150
-# A short label can carry a very long href, so a header whose rendered output
-# is this large displaces an article whatever its visible text measures. Live
-# content headers render to at most 363 chars, link lists to 1609 and up.
+# Short labels can carry huge hrefs, so judge rendered size too. Live content headers
+# render to at most 363 chars, link lists to 1609 and up.
 _HEADER_MAX_RENDERED_CHARS = 800
 
 
 class _HeaderFrame:
     """Buffered ``<header>`` output plus the link tally used to judge it.
 
-    Buffering (like ``_bq_stack``) lets the decision happen at ``</header>``,
-    when the whole subtree has been seen. A header that no end tag ever closes
-    is emitted unchanged, which is what browsers render."""
+    Buffering (like ``_bq_stack``) defers the decision to ``</header>``, once the
+    whole subtree is known. A header no end tag closes is emitted unchanged."""
 
     __slots__ = (
         "depth",
@@ -223,19 +219,17 @@ class _HeaderFrame:
         self.heading_spans: list[tuple[int, int]] = []
         self.heading_start: int | None = None
         self.n_headings: int = 0
-        # Heading text is excluded from both: it is never dropped, so it must not
-        # vote on dropping the rest. Only href anchors count as link furniture.
+        # Both exclude heading text (never dropped, so it must not vote on dropping
+        # the rest); only href anchors count as links.
         self.text_chars: int = 0
         self.link_chars: int = 0
 
     def render(self, closed_by_own_tag: bool) -> str:
         """The buffer, or only its headings when the header is link furniture.
 
-        Anything other than a matching ``</header>`` means the markup was
-        malformed and the header may have adopted the page body, so it is kept.
-        A heading buffered through a nested blockquote or table cell reaches
-        ``parts`` only when that buffer closes, leaving no usable span, so an
-        incomplete span set also keeps the whole buffer."""
+        Without a matching ``</header>`` the markup is malformed and the header may
+        have adopted the page body, so keep it whole. Same when a span is missing: a
+        heading nested in another buffer only reaches ``parts`` when that one closes."""
         if not closed_by_own_tag or len(self.heading_spans) != self.n_headings:
             return "".join(self.parts)
         big_enough = (
@@ -288,8 +282,8 @@ class _MarkdownRenderer(HTMLParser):
         self._link_href: str | None = None
         self._link_text_parts: list[str] = []
         self._in_link: bool = False
-        # Text under the open <a>, credited as link furniture only once </a>
-        # closes it: an <a> left open adopts body prose, which is not furniture.
+        # Text under the open <a>, credited as links only once </a> closes it: an
+        # <a> left open adopts body prose, which is not furniture.
         self._link_header_chars: int = 0
 
         # List state
@@ -415,10 +409,8 @@ class _MarkdownRenderer(HTMLParser):
         depth: int,
         own_tag: bool = False,
     ) -> None:
-        """Judge and emit every buffered header at or below *depth*.
-
-        Only the innermost frame can be closed by its own ``</header>``; an
-        outer one popped by the same end tag was bounded by an ancestor."""
+        """Judge and emit every buffered header at or below *depth*. Only the
+        innermost frame can be the one its own ``</header>`` closed."""
         closed_by_own_tag = own_tag
         while self._header_stack and self._header_stack[-1].depth >= depth:
             frame = self._header_stack.pop()
@@ -436,10 +428,8 @@ class _MarkdownRenderer(HTMLParser):
             self._emit("".join(self._header_stack.pop().parts))
 
     def _count_header_text(self, text: str) -> None:
-        """Tally visible text for the innermost header's link density.
-
-        Heading text is skipped: ``render()`` never drops it, so counting it
-        would let a long linked heading condemn the byline beside it."""
+        """Tally visible text for the innermost header's link density. Heading text
+        is skipped so a long linked heading cannot condemn the byline beside it."""
         if not self._header_stack or self._in_heading:
             return
         chars = len(text.strip())
@@ -462,8 +452,7 @@ class _MarkdownRenderer(HTMLParser):
             # Void elements never join the stack, so suppress a hidden one inline.
             return False
         if self._scope_tags is not None and tag in self._scope_tags:
-            # A scope element inside a header would strand its output in the
-            # buffer, so keep the header as-is and let scoping proceed normally.
+            # A scope element inside a header would strand its output in the buffer.
             self._flush_header_frames()
             if self._scope_depth == 0:
                 self._scope_seg_start = len(self._out)
@@ -477,8 +466,8 @@ class _MarkdownRenderer(HTMLParser):
     def _exit_tag(self, tag: str) -> bool:
         """Pop to the matching open tag; return True when the end tag should
         be rendered (False = it closed inside a hidden / out-of-scope region)."""
-        # A scope closing over an <a> the page left open would strand its text in
-        # the link buffer, so recover the link before the segment is recorded.
+        # A scope closing over an <a> the page left open would strand its text in the
+        # link buffer, so recover it before the segment is recorded.
         if self._in_link and self._scope_tags is not None and tag in self._scope_tags:
             self._finish_link()
         suppressed = bool(self._hidden_marks) or (
@@ -754,8 +743,8 @@ class _MarkdownRenderer(HTMLParser):
             else:
                 self._out.append("\n\n" + prefixed + "\n\n")
 
-        # A <header> no end tag ever closed adopts the page body under HTML5
-        # parsing, so emit it unchanged rather than judging a whole article.
+        # An unclosed <header> adopts the page body under HTML5 parsing, so emit it
+        # unchanged rather than judging a whole article.
         self._flush_header_frames()
 
         # A scope left open by truncated HTML never reached _exit_tag, so its output

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -184,6 +184,44 @@ _BLOCK_TAGS = frozenset(
 _HEADING_TAGS = frozenset({"h1", "h2", "h3", "h4", "h5", "h6"})
 _INLINE_EMPHASIS = {"strong": "**", "b": "**", "em": "*", "i": "*"}
 
+# A <header> is furniture only when it is almost entirely links: site nav, or the
+# 278-language dropdown Wikipedia's Vector 2022 skin puts inside <main>. Article
+# headers carry a byline, date or standfirst, so they are kept. Measured on live
+# pages, link-list headers sit at 0.94-1.00 and content headers at 0.13-0.90.
+_HEADER_LINK_DENSITY = 0.93
+# Below this a header is too small to displace an article, and the ratio too
+# noisy to trust, so it is left alone. Live link-list headers start at 182
+# chars; the largest link-dense header that carries real content is 93.
+_HEADER_MIN_CHARS = 150
+
+
+class _HeaderFrame:
+    """Buffered ``<header>`` output plus the link tally used to judge it.
+
+    Buffering (like ``_bq_stack``) lets the decision happen at ``</header>``,
+    when the whole subtree has been seen. A header that no end tag ever closes
+    is emitted unchanged, which is what browsers render."""
+
+    __slots__ = ("depth", "parts", "heading_spans", "heading_start", "text_chars", "link_chars")
+
+    def __init__(self, depth: int):
+        self.depth = depth
+        self.parts: list[str] = []
+        # Index ranges into parts holding the headings, kept when the rest goes.
+        self.heading_spans: list[tuple[int, int]] = []
+        self.heading_start: int | None = None
+        self.text_chars: int = 0
+        self.link_chars: int = 0
+
+    def render(self) -> str:
+        """The buffer, or only its headings when the header is link furniture."""
+        if (
+            self.text_chars >= _HEADER_MIN_CHARS
+            and self.link_chars >= _HEADER_LINK_DENSITY * self.text_chars
+        ):
+            return "".join("".join(self.parts[start:end]) for start, end in self.heading_spans)
+        return "".join(self.parts)
+
 
 class _MarkdownRenderer(HTMLParser):
     """HTMLParser subclass that emits Markdown tokens into a list.
@@ -217,20 +255,17 @@ class _MarkdownRenderer(HTMLParser):
         self._open_tags: list[str] = []
         self._hidden_marks: list[int] = []
 
-        # <header> is furniture apart from the heading it carries, so it cannot
-        # join _SKIP_TAGS. Marks are stack indices, like _hidden_marks.
+        # Open <header> buffers, innermost last. Empty unless strip_header.
         self._strip_header = strip_header
-        self._header_marks: list[int] = []
-        self._header_heading_marks: list[int] = []
-        self._header_prose_total: int = 0
-        self._open_header_prose: int = 0
-        self._seg_header_start: int = 0
-        self.scope_header_prose: list[int] = []
+        self._header_stack: list[_HeaderFrame] = []
 
         # Link state
         self._link_href: str | None = None
         self._link_text_parts: list[str] = []
         self._in_link: bool = False
+        # Text under the open <a>, credited as link furniture only once </a>
+        # closes it: an <a> left open adopts body prose, which is not furniture.
+        self._link_header_chars: int = 0
 
         # List state
         self._list_stack: list[str] = []  # "ul" or "ol"
@@ -263,6 +298,8 @@ class _MarkdownRenderer(HTMLParser):
             self._pre_parts.append(text)
         elif self._bq_stack:
             self._bq_stack[-1].append(text)
+        elif self._header_stack:
+            self._header_stack[-1].parts.append(text)
         else:
             self._out.append(text)
 
@@ -311,6 +348,8 @@ class _MarkdownRenderer(HTMLParser):
         text = re.sub(r"\s+", " ", "".join(self._link_text_parts)).strip()
         href = self._link_href or ""
         self._in_link = False
+        # Recovery paths reach here without </a>, so drop the uncredited tally.
+        self._link_header_chars = 0
         if href and text:
             self._emit(f"[{text}]({href})")
         elif text:
@@ -344,25 +383,34 @@ class _MarkdownRenderer(HTMLParser):
             del self._open_tags[close_at:]
             while self._hidden_marks and self._hidden_marks[-1] >= close_at:
                 self._hidden_marks.pop()
-            self._unwind_header_marks(close_at)
+            self._close_header_frames(close_at)
 
-    def _unwind_header_marks(
-        self,
-        depth: int,
-        closed_header: bool = False,
-    ) -> None:
-        if self._header_marks and self._header_marks[0] >= depth:
-            # A matching </header> proves it never adopted the body: refund.
-            if closed_header:
-                self._header_prose_total -= self._open_header_prose
-            self._open_header_prose = 0
-        while self._header_marks and self._header_marks[-1] >= depth:
-            self._header_marks.pop()
-        while self._header_heading_marks and self._header_heading_marks[-1] >= depth:
-            self._header_heading_marks.pop()
+    def _close_header_frames(self, depth: int) -> None:
+        """Judge and emit every buffered header at or below *depth*.
 
-    def _header_suppressed(self) -> bool:
-        return bool(self._header_marks) and not self._header_heading_marks
+        Any end tag that pops the header off the stack bounds it as conclusively
+        as ``</header>`` does, so an ancestor close judges it the same way."""
+        while self._header_stack and self._header_stack[-1].depth >= depth:
+            frame = self._header_stack.pop()
+            if self._header_stack:
+                # Roll the tally outward so an enclosing header is judged whole.
+                self._header_stack[-1].text_chars += frame.text_chars
+                self._header_stack[-1].link_chars += frame.link_chars
+            self._emit(frame.render())
+
+    def _flush_header_frames(self) -> None:
+        """Emit every open header unchanged, abandoning the strip."""
+        while self._header_stack:
+            self._emit("".join(self._header_stack.pop().parts))
+
+    def _count_header_text(self, text: str) -> None:
+        """Tally visible text for the innermost header's link density."""
+        if not self._header_stack:
+            return
+        chars = len(text.strip())
+        self._header_stack[-1].text_chars += chars
+        if self._in_link:
+            self._link_header_chars += chars
 
     def _enter_tag(self, tag: str, attr_dict: dict) -> bool:
         """Track open/hidden/scope state; return True when the tag's content
@@ -372,34 +420,33 @@ class _MarkdownRenderer(HTMLParser):
             self._open_tags.append(tag)
             if _is_hidden_element(attr_dict):
                 self._hidden_marks.append(len(self._open_tags) - 1)
-            if self._strip_header:
-                if tag == "header":
-                    self._header_marks.append(len(self._open_tags) - 1)
-                elif tag in _HEADING_TAGS and self._header_marks:
-                    self._header_heading_marks.append(len(self._open_tags) - 1)
+            if self._strip_header and tag == "header" and not self._hidden_marks:
+                self._header_stack.append(_HeaderFrame(len(self._open_tags) - 1))
         elif _is_hidden_element(attr_dict):
             # Void elements never join the stack, so suppress a hidden one inline.
             return False
         if self._scope_tags is not None and tag in self._scope_tags:
+            # A scope element inside a header would strand its output in the
+            # buffer, so keep the header as-is and let scoping proceed normally.
+            self._flush_header_frames()
             if self._scope_depth == 0:
                 self._scope_seg_start = len(self._out)
-                self._seg_header_start = self._header_prose_total
             self._scope_depth += 1
         if self._hidden_marks:
             return False
         if self._scope_tags is not None and self._scope_depth == 0:
-            return False
-        if self._header_suppressed():
             return False
         return True
 
     def _exit_tag(self, tag: str) -> bool:
         """Pop to the matching open tag; return True when the end tag should
         be rendered (False = it closed inside a hidden / out-of-scope region)."""
-        suppressed = (
-            bool(self._hidden_marks)
-            or self._header_suppressed()
-            or (self._scope_tags is not None and self._scope_depth == 0)
+        # A scope closing over an <a> the page left open would strand its text in
+        # the link buffer, so recover the link before the segment is recorded.
+        if self._in_link and self._scope_tags is not None and tag in self._scope_tags:
+            self._finish_link()
+        suppressed = bool(self._hidden_marks) or (
+            self._scope_tags is not None and self._scope_depth == 0
         )
         if tag not in _VOID_TAGS:
             # Pop to the innermost matching open tag (recovers omitted closes).
@@ -408,13 +455,12 @@ class _MarkdownRenderer(HTMLParser):
                     del self._open_tags[i:]
                     while self._hidden_marks and self._hidden_marks[-1] >= i:
                         self._hidden_marks.pop()
-                    self._unwind_header_marks(i, closed_header = tag == "header")
+                    self._close_header_frames(i)
                     break
         if self._scope_tags is not None and tag in self._scope_tags and self._scope_depth > 0:
             self._scope_depth -= 1
             if self._scope_depth == 0 and self._scope_seg_start is not None:
                 self.scope_segments.append("".join(self._out[self._scope_seg_start :]))
-                self.scope_header_prose.append(self._header_prose_total - self._seg_header_start)
                 self._scope_seg_start = None
         return not suppressed
 
@@ -441,6 +487,8 @@ class _MarkdownRenderer(HTMLParser):
             return
 
         if tag in _HEADING_TAGS:
+            if self._header_stack and self._header_stack[-1].heading_start is None:
+                self._header_stack[-1].heading_start = len(self._header_stack[-1].parts)
             level = int(tag[1])
             self._emit("\n\n" + "#" * level + " ")
 
@@ -448,6 +496,7 @@ class _MarkdownRenderer(HTMLParser):
             self._link_href = attr_dict.get("href")
             self._link_text_parts = []
             self._in_link = True
+            self._link_header_chars = 0
 
         elif tag in _INLINE_EMPHASIS:
             self._emit(_INLINE_EMPHASIS[tag])
@@ -534,8 +583,14 @@ class _MarkdownRenderer(HTMLParser):
 
         if tag in _HEADING_TAGS:
             self._emit("\n\n")
+            frame = self._header_stack[-1] if self._header_stack else None
+            if frame is not None and frame.heading_start is not None:
+                frame.heading_spans.append((frame.heading_start, len(frame.parts)))
+                frame.heading_start = None
 
         elif tag == "a":
+            if self._header_stack:
+                self._header_stack[-1].link_chars += self._link_header_chars
             self._finish_link()
 
         elif tag in _INLINE_EMPHASIS:
@@ -591,24 +646,14 @@ class _MarkdownRenderer(HTMLParser):
     # Text / entity handlers
     # ------------------------------------------------------------------
     def _text_suppressed(self) -> bool:
-        if self._skip_depth or self._hidden_marks or self._header_suppressed():
+        if self._skip_depth or self._hidden_marks:
             return True
         return self._scope_tags is not None and self._scope_depth == 0
 
     def handle_data(self, data: str) -> None:
         if self._text_suppressed():
-            # Only non-anchor prose in scope betrays a swallowed body.
-            if (
-                self._header_suppressed()
-                and not self._skip_depth
-                and not self._hidden_marks
-                and not (self._scope_tags is not None and self._scope_depth == 0)
-                and "a" not in self._open_tags[self._header_marks[0] :]
-            ):
-                dropped = len(data.strip())
-                self._header_prose_total += dropped
-                self._open_header_prose += dropped
             return
+        self._count_header_text(data)
         if self._in_pre:
             self._pre_parts.append(data)
             return
@@ -626,12 +671,16 @@ class _MarkdownRenderer(HTMLParser):
     def handle_entityref(self, name: str) -> None:
         if self._text_suppressed():
             return
-        self._emit(html.unescape(f"&{name};"))
+        text = html.unescape(f"&{name};")
+        self._count_header_text(text)
+        self._emit(text)
 
     def handle_charref(self, name: str) -> None:
         if self._text_suppressed():
             return
-        self._emit(html.unescape(f"&#{name};"))
+        text = html.unescape(f"&#{name};")
+        self._count_header_text(text)
+        self._emit(text)
 
     # Flush pending buffers (handles truncated HTML from capped fetches)
     def flush_pending(self) -> None:
@@ -664,12 +713,15 @@ class _MarkdownRenderer(HTMLParser):
             else:
                 self._out.append("\n\n" + prefixed + "\n\n")
 
+        # A <header> no end tag ever closed adopts the page body under HTML5
+        # parsing, so emit it unchanged rather than judging a whole article.
+        self._flush_header_frames()
+
         # A scope left open by truncated HTML never reached _exit_tag, so its output
         # never joined scope_segments and would score 0. Flush the still-open segment
         # here (after the side-buffers) so a truncated main-content page is scored.
         if self._scope_seg_start is not None:
             self.scope_segments.append("".join(self._out[self._scope_seg_start :]))
-            self.scope_header_prose.append(self._header_prose_total - self._seg_header_start)
             self._scope_seg_start = None
             self._scope_depth = 0
 
@@ -771,57 +823,34 @@ def _strip_boilerplate_lines(text: str) -> str:
     return re.sub(r"\n{3,}", "\n\n", "\n".join(out)).strip()
 
 
-def _render(
-    source_html: str,
-    scope_tags: frozenset[str] | None,
-    strip_header: bool = False,
-) -> tuple[str, int]:
+def _new_renderer(
+    source_html: str, scope_tags: frozenset[str] | None, strip_header: bool
+) -> _MarkdownRenderer:
     renderer = _MarkdownRenderer(scope_tags = scope_tags, strip_header = strip_header)
     renderer.feed(source_html)
     renderer.close()
     renderer.flush_pending()
-    raw = "".join(renderer._out)
-    return _cleanup(raw), renderer._header_prose_total
+    return renderer
 
 
-# An unclosed <header> adopts the body (as browsers parse it). Size cannot tell
-# that apart from furniture removal, but link density can: a real header holds
-# a title and links, so only non-anchor prose from a header that no </header>
-# ever closed counts as a swallowed body.
-def _header_strip_backfired(kept_chars: int, header_prose_chars: int) -> bool:
-    return header_prose_chars > kept_chars
-
-
-def _scope_segments(source_html: str, tag: str, strip_header: bool) -> tuple[list[str], list[int]]:
-    renderer = _MarkdownRenderer(scope_tags = frozenset({tag}), strip_header = strip_header)
-    renderer.feed(source_html)
-    renderer.close()
-    renderer.flush_pending()
-    return renderer.scope_segments, renderer.scope_header_prose
+def _render(
+    source_html: str,
+    scope_tags: frozenset[str] | None,
+    strip_header: bool = False,
+) -> str:
+    return _cleanup("".join(_new_renderer(source_html, scope_tags, strip_header)._out))
 
 
 def _select_main_scope_render(source_html: str, tag: str) -> tuple[int, str]:
     """Length and boilerplate-stripped render of the largest single ``<tag>``
     subtree. Sizing candidates one at a time stops many tiny sibling cards from
     clearing the threshold together, and returning that one subtree keeps
-    unrelated siblings (related cards, comment threads) out of the output.
-
-    Header stripping is judged per candidate, before the sizing comparison, so
-    an article whose body an unclosed ``<header>`` swallowed is restored to its
-    real size instead of losing the comparison to a sibling card."""
-    segments, header_prose = _scope_segments(source_html, tag, strip_header = True)
-    unstripped: list[str] | None = None
+    unrelated siblings (related cards, comment threads) out of the output."""
+    renderer = _new_renderer(source_html, frozenset({tag}), strip_header = True)
     best_len = 0
     best_render = ""
-    for i, seg in enumerate(segments):
+    for seg in renderer.scope_segments:
         rendered = _strip_boilerplate_lines(_cleanup(seg))
-        dropped = header_prose[i] if i < len(header_prose) else 0
-        if _header_strip_backfired(len(rendered), dropped):
-            if unstripped is None:
-                # Scope bookkeeping ignores header state, so the indices line up.
-                unstripped = _scope_segments(source_html, tag, strip_header = False)[0]
-            if i < len(unstripped):
-                rendered = _strip_boilerplate_lines(_cleanup(unstripped[i]))
         if len(rendered) > best_len:
             best_len = len(rendered)
             best_render = rendered
@@ -842,9 +871,9 @@ def html_to_markdown(source_html: str, *, main_content: bool = False) -> str:
 
     ``main_content=True`` applies a readability-style heuristic for page
     fetches: prefer the ``<article>`` subtree (GitHub renders READMEs there),
-    then ``<main>``, falling back to the whole document, drop ``<header>``
-    furniture while keeping the heading it carries, and strip known
-    boilerplate fragments from the result.
+    then ``<main>``, falling back to the whole document, reduce a link-only
+    ``<header>`` to the heading it carries, and strip known boilerplate
+    fragments from the result.
     """
     # Normalize line endings before parsing.
     source_html = source_html.replace("\r\n", "\n").replace("\r", "\n")
@@ -855,9 +884,5 @@ def html_to_markdown(source_html: str, *, main_content: bool = False) -> str:
             length, rendered = _select_main_scope_render(source_html, scope_tag)
             if length >= _MIN_MAIN_CONTENT_CHARS:
                 return rendered
-        rendered, header_prose = _render(source_html, None, strip_header = True)
-        rendered = _strip_boilerplate_lines(rendered)
-        if _header_strip_backfired(len(rendered), header_prose):
-            rendered = _strip_boilerplate_lines(_render(source_html, None)[0])
-        return rendered
-    return _render(source_html, None)[0]
+        return _strip_boilerplate_lines(_render(source_html, None, strip_header = True))
+    return _render(source_html, None)

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -194,14 +194,14 @@ _BLOCK_TAGS = frozenset(
 _HEADING_TAGS = frozenset({"h1", "h2", "h3", "h4", "h5", "h6"})
 _INLINE_EMPHASIS = {"strong": "**", "b": "**", "em": "*", "i": "*"}
 
-# Furniture is nearly all links: measured 0.94-1.00 for link lists, 0.13-0.90 for content headers.
+# Measured density: 0.94-1.00 for link lists, 0.13-0.90 for content headers.
 _HEADER_LINK_DENSITY = 0.93
-# Below this the ratio is noise: link lists start at 182 chars, link-dense content headers stop at 93.
+# Below this the ratio is noise: link lists start at 182 chars, link-dense headers stop at 93.
 _HEADER_MIN_CHARS = 150
-# Short labels can hide huge hrefs, so size the render too: content peaks at 363, link lists at 1609+.
+# Short labels hide huge hrefs, so size the render too: content peaks at 363, link lists at 1609+.
 _HEADER_MAX_RENDERED_CHARS = 800
 
-# Real pages nest headers one or two deep; past this, closing a frame cannot copy an unbounded chain.
+# Pages nest headers one or two deep; past this, closing a frame cannot copy an unbounded chain.
 _MAX_HEADER_NESTING = 8
 
 
@@ -240,21 +240,21 @@ class _HeaderFrame:
     ):
         self.depth = depth
         self.parts: list[str] = []
-        # Heading output, teed so a heading routed through a nested buffer survives.
+        # Teed, so a heading routed through a nested buffer survives.
         self.heading_parts: list[str] = []
         self.stripped: bool = False  # set by render()
-        # Tallied on emit: linear for nested headers, where re-cleaning each parent's buffer is quadratic.
+        # Tallied on emit; re-cleaning each parent's buffer would be quadratic.
         self.rendered_chars: int = 0
         self.heading_chars: int = 0
-        # Side buffers open now enclose the frame, later ones are nested. Links and cells are keyed by
-        # sequence number, not a flag: an inner one replaces the outer in the renderer's single slot.
+        # Buffers open now enclose the frame, later ones nest. Links and cells are keyed by sequence
+        # number, not a flag: an inner one replaces the outer in the renderer's single slot.
         self.outer_list_depth = list_depth
         self.outer_link_seq = link_seq
         self.outer_cell_seq = cell_seq
         self.outer_in_pre = in_pre
         self.outer_in_code = in_code
         self.outer_bq_depth = bq_depth
-        # Both exclude heading text (always kept, so it must not vote on dropping the rest).
+        # Both exclude heading text: it is kept anyway, so it must not vote on dropping the rest.
         self.text_chars: int = 0
         self.link_chars: int = 0
 
@@ -267,8 +267,8 @@ class _HeaderFrame:
         if not closed_by_own_tag:
             return "".join(self.parts)
         headings = "".join(self.heading_parts)
-        # Droppable visible chars only: headings are kept either way, and blank structure that
-        # _cleanup collapses (500 empty <div>s) must not make a tiny header look huge.
+        # Droppable visible chars only: headings are kept anyway, and blank structure _cleanup
+        # collapses (500 empty <div>s) must not make a tiny header look huge.
         droppable = self.rendered_chars - self.heading_chars
         big_enough = self.text_chars >= _HEADER_MIN_CHARS or droppable >= _HEADER_MAX_RENDERED_CHARS
         if big_enough and self.link_chars >= _HEADER_LINK_DENSITY * self.text_chars:
@@ -299,17 +299,15 @@ class _MarkdownRenderer(HTMLParser):
         self._scope_tags = scope_tags
         self._scope_depth: int = 0
 
-        # Output boundaries per top-level scope element, so a caller can size each
-        # candidate alone and a swarm of tiny sibling cards can't clear the threshold.
+        # One boundary per top-level scope element, so each candidate is sized alone and a swarm
+        # of tiny sibling cards cannot clear the threshold together.
         self.scope_segments: list[str] = []
         self._scope_seg_start: int | None = None
 
-        # Hidden-subtree tracking: stack of open non-void tags plus the indices
-        # where a hidden element started. End tags pop to the matching tag, so
-        # an omitted </p>/<li> close cannot leave the renderer stuck hidden.
+        # Open non-void tags plus the indices where a hidden element started. End tags pop to the
+        # matching tag, so an omitted </p>/</li> cannot leave the renderer stuck hidden.
         self._open_tags: list[str] = []
-        # How many open tags can be closed implicitly. Zero means _close_implicit
-        # has nothing to find, so it can skip scanning the stack entirely.
+        # Open tags that can be closed implicitly; zero lets _close_implicit skip the scan.
         self._closable_open: int = 0
         self._hidden_marks: list[int] = []
 
@@ -320,8 +318,8 @@ class _MarkdownRenderer(HTMLParser):
         self._dropped_chars: int = 0
         self._seg_dropped_start: int = 0
         self.scope_dropped: list[int] = []
-        # Heading text per segment: role="heading", <hgroup> and linked <h1> render
-        # as ordinary prose, so ATX reparsing alone cannot keep them out of the gate.
+        # Heading text per segment: role="heading", <hgroup> and linked <h1> render as ordinary
+        # prose, so ATX reparsing alone cannot keep them out of the gate.
         self._seg_heading_texts: list[str] = []
         self.scope_heading_prose: list[int] = []
         # Open-tag indices of headings, unwound with _hidden_marks.
@@ -332,14 +330,13 @@ class _MarkdownRenderer(HTMLParser):
         self._link_text_parts: list[str] = []
         self._in_link: bool = False
         self._link_seq: int = 0
-        # A link wrapping a heading emits after the heading mark is gone, so the
-        # tee is told to treat that one emit as heading output.
+        # A link wrapping a heading emits after the heading mark is gone, so the tee is told to
+        # treat that one emit as heading output.
         self._link_had_heading: bool = False
         self._link_heading_parts: list[str] = []
         self._emit_as_heading: bool = False
         self._replaying: bool = False
-        # Text under the open <a>, credited only at </a>: an <a> left open adopts
-        # body prose, which is not furniture.
+        # Credited only at </a>: an <a> left open adopts body prose, which is not furniture.
         self._link_header_chars: int = 0
 
         # List state
@@ -370,9 +367,8 @@ class _MarkdownRenderer(HTMLParser):
 
         Such a buffer emits into the frame when it closes; an enclosing one
         (already open at ``<header>``) must not capture it."""
-        # Only the buffer _emit would actually pick matters, and in its order: a
-        # blockquote inside a cell-enclosed header still routes to the cell, so
-        # OR-ing across all of them would wrongly call that nested.
+        # Only the buffer _emit would pick matters, in its order: a blockquote inside a
+        # cell-enclosed header still routes to the cell, so OR-ing them would call that nested.
         if self._in_link:
             return self._link_seq != frame.outer_link_seq
         if self._in_cell:
@@ -383,29 +379,29 @@ class _MarkdownRenderer(HTMLParser):
 
     def _emit(self, text: str) -> None:
         frame = self._header_stack[-1] if self._header_stack else None
-        # Tee wherever the text is routed, so a heading inside a nested buffer is captured. A link
-        # opened inside the frame delivers twice (raw, then formatted by _finish_link), so only the
+        # Tee wherever the text routes, so a heading in a nested buffer is captured. A link opened
+        # inside the frame delivers twice (raw, then formatted by _finish_link), so only the
         # formatted form is teed; an enclosing link never re-delivers and is teed as it comes.
         in_nested_link = (
             self._in_link and self._link_seq != frame.outer_link_seq if frame else False
         )
-        # A flushed buffer re-delivers text already teed on the way in, so replays
-        # never tee; _finish_link is the exception and re-arms the tee itself.
+        # A flushed buffer re-delivers text already teed on the way in, so replays never tee;
+        # _finish_link is the exception and re-arms the tee itself.
         as_heading = (
             self._heading_marks and not in_nested_link and not self._replaying
         ) or self._emit_as_heading
         if frame is not None and as_heading:
             frame.heading_parts.append(text)
             frame.heading_chars += len(text.strip())
-        # Tallied for the eligibility gate, independent of any header frame. Text
-        # inside a link waits for _finish_link so the formatted form counts once.
+        # Tallied for the eligibility gate, independent of any frame. Text inside a link waits for
+        # _finish_link so the formatted form counts once.
         if not self._replaying and (
             (self._heading_marks and not self._in_link) or self._emit_as_heading
         ):
             self._seg_heading_texts.append(text)
         nested_open = self._nested_buffer_open(frame) if frame is not None else False
         # Tally once, on the emit that reaches the frame: counting text going INTO a nested buffer
-        # and again when that buffer flushes doubled it, so a kept header stripped once quoted.
+        # and again when it flushes doubled it, so a kept header stripped once quoted.
         if frame is not None and not nested_open:
             frame.rendered_chars += len(text.strip())
             frame.parts.append(text)
@@ -485,8 +481,8 @@ class _MarkdownRenderer(HTMLParser):
         self._in_link = False
         self._link_text_parts = []
         self._link_heading_parts = []
-        # An anchor wrapping a heading AND other content is furniture carrying a
-        # title: tee the title alone, or the whole nav rides out as a heading.
+        # An anchor wrapping a heading AND other content is furniture carrying a title: tee the
+        # title alone, or the whole nav rides out as a heading.
         partial = bool(heading_text) and heading_text != text
         self._emit_as_heading = self._link_had_heading and not partial
         self._link_had_heading = False
@@ -572,10 +568,10 @@ class _MarkdownRenderer(HTMLParser):
         Their content is the header's, so it has to land in the frame before the
         strip is judged; otherwise it is emitted afterwards and escapes."""
         if self._in_link and self._link_seq != frame.outer_link_seq:
-            # The header boundary proves this anchor did not adopt the body, so its text is furniture.
+            # The header boundary proves this anchor did not adopt the body: its text is furniture.
             frame.link_chars += self._link_header_chars
             self._finish_link()
-        # Inline code opened OUTSIDE the header is the page's: closing it here would leave the real
+        # Inline code opened OUTSIDE the header is the page's; closing it here would leave the real
         # </code> to emit an unpaired backtick.
         if self._in_inline_code and not frame.outer_in_code:
             self._in_inline_code = False
@@ -586,8 +582,8 @@ class _MarkdownRenderer(HTMLParser):
         if self._in_pre and not frame.outer_in_pre:
             raw = "".join(self._pre_parts)
             self._in_pre = False
-            # Drained, not just closed: a late </pre> would otherwise replay the
-            # block outside the stripped header and push the article past the cap.
+            # Drained, not just closed: a late </pre> would replay the block outside the stripped
+            # header and push the article past the cap.
             self._pre_parts = []
             fence = _fence_for(raw)
             self._emit_replay(f"\n\n{fence}\n{raw}\n{fence}\n\n")
@@ -595,7 +591,7 @@ class _MarkdownRenderer(HTMLParser):
             prefixed = self._prefix_blockquote("".join(self._bq_stack.pop()))
             if prefixed:
                 self._emit_replay("\n\n" + prefixed + "\n\n")
-        # A list left open inside the header would indent the body's own lists under phantom nesting.
+        # A list left open in the header would indent the body's lists under phantom nesting.
         while len(self._list_stack) > frame.outer_list_depth:
             if self._list_stack.pop() == "ol" and self._ol_counter:
                 self._ol_counter.pop()
@@ -674,13 +670,13 @@ class _MarkdownRenderer(HTMLParser):
     def _exit_tag(self, tag: str) -> bool:
         """Pop to the matching open tag; return True when the end tag should
         be rendered (False = it closed inside a hidden / out-of-scope region)."""
-        # Recover an <a> the page left open before the segment is recorded, or its text is stranded.
+        # Recover an <a> left open before the segment is recorded, or its text is stranded.
         if self._in_link and self._scope_tags is not None and tag in self._scope_tags:
             self._finish_link()
         suppressed = bool(self._hidden_marks) or (
             self._scope_tags is not None and self._scope_depth == 0
         )
-        # An element that is itself the heading (e.g. <a role="heading">) emits when its buffer closes,
+        # An element that IS the heading (e.g. <a role="heading">) emits when its buffer closes,
         # after the mark below is popped, so flush it here while the tee still recognises it.
         if self._in_link and tag == "a" and self._heading_marks:
             self._finish_link()
@@ -863,8 +859,8 @@ class _MarkdownRenderer(HTMLParser):
             block = f"{fence}\n{raw}\n{fence}"
             self._emit_replay("\n\n" + block + "\n\n")
 
-        # Already closed means a header frame recovered it; emitting the second
-        # backtick here would leave the rest of the page formatted as code.
+        # Already closed means a header frame recovered it; a second backtick here would leave the
+        # rest of the page formatted as code.
         elif tag == "code" and not self._in_pre and self._in_inline_code:
             self._in_inline_code = False
             self._emit("`")
@@ -905,8 +901,8 @@ class _MarkdownRenderer(HTMLParser):
             return
         # Collapse all whitespace (including newlines) per HTML rules.
         text = re.sub(r"\s+", " ", data)
-        # Sized after collapsing, as the reader sees it: a run of source spaces in
-        # a link otherwise clears the floor at ~100% density and drops the byline.
+        # Sized after collapsing, as the reader sees it: a run of source spaces in a link otherwise
+        # clears the floor at ~100% density and drops the byline.
         self._count_header_text(text)
         # Suppress whitespace-only nodes between table elements (source indentation).
         if self._in_table and not self._in_cell and not text.strip():
@@ -930,8 +926,8 @@ class _MarkdownRenderer(HTMLParser):
     # Flush pending buffers (handles truncated HTML from capped fetches)
     def flush_pending(self) -> None:
         """Flush open side-buffers into ``_out`` after close(), recovering truncated HTML."""
-        # Headers first: each frame finalizes the buffers opened inside it, then emits into whatever
-        # encloses it, so an enclosing link or cell must still be open here and is finalized below.
+        # Headers first: each frame finalizes the buffers opened inside it, then emits into what
+        # encloses it, so an enclosing link or cell must still be open here; it is finalized below.
         self._flush_header_frames()
 
         # Flush innermost buffers first so their content propagates outward.
@@ -1149,8 +1145,8 @@ def _is_heading_line(line: str) -> bool:
             i = j + 1
         else:
             break
-    # ATX rules: 1-6 hashes closed by whitespace or line end. Without the closing check "#include"
-    # reads as a heading, and this decides whether a scope has content, so a C snippet loses to a teaser.
+    # ATX rules: 1-6 hashes closed by whitespace or line end; without the close check "#include"
+    # reads as a heading, and this gates whether a scope has content, so a C snippet loses.
     start = i
     while i < n and line[i] == "#":
         i += 1
@@ -1192,8 +1188,8 @@ def _visible_len(line: str) -> int:
     total, i, n = 0, 0, len(line)
     while i < n:
         if line[i] == "]" and i + 1 < n and line[i + 1] == "(":
-            # Destinations may hold balanced or escaped parens (/card(foo)?q=..),
-            # so stopping at the first ) leaves the rest scored as prose.
+            # Destinations may hold balanced or escaped parens (/card(foo)?q=..), so stopping at
+            # the first ) leaves the rest scored as prose.
             j, depth = i + 2, 1
             while j < n and depth:
                 char = line[j]
@@ -1203,9 +1199,8 @@ def _visible_len(line: str) -> int:
                 depth += (char == "(") - (char == ")")
                 j += 1
             if depth:
-                # Never balances, so this is not a link any reader would resolve;
-                # the bytes show as text. Count them rather than dropping the
-                # prose that follows on the same line.
+                # Never balances, so this is not a link a reader would resolve; the bytes show as
+                # text, so count them rather than dropping the prose on the rest of the line.
                 total += 1
                 i += 1
                 continue
@@ -1234,12 +1229,10 @@ def html_to_markdown(source_html: str, *, main_content: bool = False) -> str:
     ``<header>`` to the heading it carries, and strip known boilerplate
     fragments from the result.
     """
-    # Normalize line endings before parsing.
     source_html = source_html.replace("\r\n", "\n").replace("\r", "\n")
     if main_content:
         for scope_tag in ("article", "main"):
-            # Render only the chosen subtree so sibling <article>/<main>
-            # elements do not leak in once the largest passes the size gate.
+            # Render only the chosen subtree so sibling <article>/<main> elements do not leak in.
             length, rendered = _select_main_scope_render(source_html, scope_tag)
             if length >= _MIN_MAIN_CONTENT_CHARS:
                 return rendered

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -234,7 +234,7 @@ class _HeaderFrame:
         link_seq: int,
         cell_seq: int,
         in_pre: bool,
-        in_code: bool,
+        in_code: int,
         bq_depth: int,
         list_depth: int,
     ):
@@ -356,7 +356,9 @@ class _MarkdownRenderer(HTMLParser):
         # Pre/code state
         self._in_pre: bool = False
         self._pre_parts: list[str] = []
-        self._in_inline_code: bool = False
+        # Depth, not a flag: <code><code>x</code></code> opens two spans and each
+        # end tag owes a backtick, else the delimiters stop pairing.
+        self._inline_code_depth: int = 0
 
         # Blockquote state: stack of buffers so nested blockquotes get the right ">" depth.
         self._bq_stack: list[list[str]] = []
@@ -592,8 +594,8 @@ class _MarkdownRenderer(HTMLParser):
             self._finish_link()
         # Inline code opened OUTSIDE the header is the page's; closing it here would leave the real
         # </code> to emit an unpaired backtick.
-        if self._in_inline_code and not frame.outer_in_code:
-            self._in_inline_code = False
+        while self._inline_code_depth > frame.outer_in_code:
+            self._inline_code_depth -= 1
             self._emit("`")
         # Before the cell: _finish_row emits, and an open <pre> would swallow the
         # row into the code block as CODE|  | instead of a cell holding the code.
@@ -658,7 +660,7 @@ class _MarkdownRenderer(HTMLParser):
                         self._link_seq if self._in_link else -1,
                         self._cell_seq if self._in_cell else -1,
                         self._in_pre,
-                        self._in_inline_code,
+                        self._inline_code_depth,
                         len(self._bq_stack),
                         len(self._list_stack),
                     )
@@ -793,7 +795,7 @@ class _MarkdownRenderer(HTMLParser):
             self._in_pre = True
 
         elif tag == "code" and not self._in_pre:
-            self._in_inline_code = True
+            self._inline_code_depth += 1
             self._emit("`")
 
         elif tag == "table":
@@ -866,8 +868,8 @@ class _MarkdownRenderer(HTMLParser):
 
         # Already closed means a header frame recovered it; a second backtick here would leave the
         # rest of the page formatted as code.
-        elif tag == "code" and not self._in_pre and self._in_inline_code:
-            self._in_inline_code = False
+        elif tag == "code" and not self._in_pre and self._inline_code_depth:
+            self._inline_code_depth -= 1
             self._emit("`")
 
         elif tag in ("th", "td"):
@@ -900,7 +902,7 @@ class _MarkdownRenderer(HTMLParser):
             self._pre_parts.append(data)
             return
         # Preserve literal whitespace inside inline <code> spans.
-        if self._in_inline_code:
+        if self._inline_code_depth:
             self._count_header_text(data)
             self._emit(data)
             return
@@ -939,8 +941,8 @@ class _MarkdownRenderer(HTMLParser):
         if self._in_link:
             self._finish_link()
 
-        if self._in_inline_code:
-            self._in_inline_code = False
+        while self._inline_code_depth:
+            self._inline_code_depth -= 1
             self._emit("`")
 
         self._finish_cell()

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -243,9 +243,10 @@ class _HeaderFrame:
         if not closed_by_own_tag:
             return "".join(self.parts)
         headings = "".join(self.heading_parts)
-        # Both sizes measure only the droppable part: a heading is kept either
-        # way, so a long one must not make the rest look big enough to drop.
-        droppable = sum(len(part) for part in self.parts) - len(headings)
+        # Both sizes measure only the droppable part, cleaned: a heading is kept
+        # either way, and raw tokens count blank lines that _cleanup collapses,
+        # so 500 empty <div>s must not make a tiny header look huge.
+        droppable = len(_cleanup("".join(self.parts))) - len(_cleanup(headings))
         big_enough = self.text_chars >= _HEADER_MIN_CHARS or droppable >= _HEADER_MAX_RENDERED_CHARS
         if big_enough and self.link_chars >= _HEADER_LINK_DENSITY * self.text_chars:
             # The closing tag's blank line is emitted after the heading mark is
@@ -471,7 +472,7 @@ class _MarkdownRenderer(HTMLParser):
                 self._header_stack[-1].link_chars += frame.link_chars
                 self._header_stack[-1].heading_parts.extend(frame.heading_parts)
             out = frame.render(closed_by_own_tag)
-            self._dropped_chars += sum(len(part) for part in frame.parts) - len(out)
+            self._dropped_chars += max(0, len(_cleanup("".join(frame.parts))) - len(_cleanup(out)))
             self._emit(out)
             closed_by_own_tag = False
 
@@ -481,6 +482,9 @@ class _MarkdownRenderer(HTMLParser):
         Their content is the header's, so it has to land in the frame before the
         strip is judged; otherwise it is emitted afterwards and escapes."""
         if self._in_link and self._link_seq != frame.outer_link_seq:
+            # The header boundary proves this anchor did not adopt the body, so
+            # its text is link furniture even though no </a> arrived.
+            frame.link_chars += self._link_header_chars
             self._finish_link()
         if self._in_inline_code:
             self._in_inline_code = False
@@ -508,10 +512,16 @@ class _MarkdownRenderer(HTMLParser):
         is skipped so a long linked heading cannot condemn the byline beside it."""
         if not self._header_stack or self._heading_marks:
             return
+        frame = self._header_stack[-1]
         chars = len(text.strip())
-        self._header_stack[-1].text_chars += chars
+        frame.text_chars += chars
         # An anchor with no usable href renders as prose, not as a link.
-        if self._in_link and self._link_href:
+        if not (self._in_link and self._link_href):
+            return
+        if self._link_seq == frame.outer_link_seq:
+            # An enclosing anchor closes after the header, too late to credit.
+            frame.link_chars += chars
+        else:
             self._link_header_chars += chars
 
     def _enter_tag(self, tag: str, attr_dict: dict) -> bool:
@@ -522,7 +532,7 @@ class _MarkdownRenderer(HTMLParser):
             self._open_tags.append(tag)
             if _is_hidden_element(attr_dict):
                 self._hidden_marks.append(len(self._open_tags) - 1)
-            if tag in _HEADING_TAGS or _is_aria_heading(attr_dict):
+            if tag in _HEADING_TAGS or tag == "hgroup" or _is_aria_heading(attr_dict):
                 self._heading_marks.append(len(self._open_tags) - 1)
             if self._strip_header and tag == "header" and not self._hidden_marks:
                 self._header_stack.append(
@@ -801,6 +811,11 @@ class _MarkdownRenderer(HTMLParser):
     # Flush pending buffers (handles truncated HTML from capped fetches)
     def flush_pending(self) -> None:
         """Flush open side-buffers into ``_out`` after close(), recovering truncated HTML."""
+        # Headers first: each frame finalizes the buffers opened inside it, then
+        # emits into whatever encloses it, so an enclosing link or cell must still
+        # be open here and is finalized below.
+        self._flush_header_frames()
+
         # Flush innermost buffers first so their content propagates outward.
         if self._in_link:
             self._finish_link()
@@ -817,10 +832,6 @@ class _MarkdownRenderer(HTMLParser):
             self._in_pre = False
             block = "```\n" + raw + "\n```"
             self._emit("\n\n" + block + "\n\n")
-
-        # Headers first: a buffer nested in one belongs to it, so flushing the
-        # buffer on its own would emit that content ahead of the header text.
-        self._flush_header_frames()
 
         # Flatten any open blockquote buffers (innermost first).
         while self._bq_stack:
@@ -973,7 +984,7 @@ def _select_main_scope_render(source_html: str, tag: str) -> tuple[int, str]:
     best_render = ""
     for i, seg in enumerate(renderer.scope_segments):
         rendered = _strip_boilerplate_lines(_cleanup(seg))
-        credit = dropped[i] if len(rendered) >= _MIN_RETAINED_CHARS else 0
+        credit = dropped[i] if _non_heading_chars(rendered) >= _MIN_RETAINED_CHARS else 0
         size = len(rendered) + credit
         if size > best_len:
             best_len = size
@@ -981,10 +992,15 @@ def _select_main_scope_render(source_html: str, tag: str) -> tuple[int, str]:
     return best_len, best_render
 
 
-# Removed furniture only counts toward a candidate's size once it retained more
-# than a bare heading line, so a scope holding nothing else cannot qualify on
-# what was deleted from it.
+# Removed furniture only counts toward a candidate's size once the candidate
+# retained this much prose OUTSIDE its headings, so neither an empty scope nor a
+# stub carrying one long title can qualify on what was deleted from it.
 _MIN_RETAINED_CHARS = 50
+
+
+def _non_heading_chars(text: str) -> int:
+    """Length of *text* ignoring heading lines and blanks."""
+    return sum(len(line) for line in text.split("\n") if line.strip() and not line.startswith("#"))
 
 
 # A scoped conversion below this size is judged not to be the page's main

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -332,6 +332,7 @@ class _MarkdownRenderer(HTMLParser):
         # tee is told to treat that one emit as heading output.
         self._link_had_heading: bool = False
         self._emit_as_heading: bool = False
+        self._replaying: bool = False
         # Text under the open <a>, credited only at </a>: an <a> left open adopts
         # body prose, which is not furniture.
         self._link_header_chars: int = 0
@@ -383,7 +384,11 @@ class _MarkdownRenderer(HTMLParser):
         in_nested_link = (
             self._in_link and self._link_seq != frame.outer_link_seq if frame else False
         )
-        as_heading = (self._heading_marks and not in_nested_link) or self._emit_as_heading
+        # A flushed buffer re-delivers text already teed on the way in, so replays
+        # never tee; _finish_link is the exception and re-arms the tee itself.
+        as_heading = (
+            self._heading_marks and not in_nested_link and not self._replaying
+        ) or self._emit_as_heading
         if frame is not None and as_heading:
             frame.heading_parts.append(text)
             frame.heading_chars += len(text.strip())
@@ -406,6 +411,15 @@ class _MarkdownRenderer(HTMLParser):
             self._out.append(text)
 
     # ------------------------------------------------------------------
+    def _emit_replay(self, text: str) -> None:
+        """Emit a flushed buffer's own output, which must not be teed as a heading
+        a second time (the raw text was teed when it entered the buffer)."""
+        was, self._replaying = self._replaying, True
+        try:
+            self._emit(text)
+        finally:
+            self._replaying = was
+
     def _prefix_blockquote(self, content: str) -> str:
         """Prefix every line of *content* with ``> ``."""
         # Strip trailing whitespace, then collapse blank lines.
@@ -436,7 +450,7 @@ class _MarkdownRenderer(HTMLParser):
         if not self._current_row:
             return
         line = "| " + " | ".join(self._current_row) + " |"
-        self._emit(line + "\n")
+        self._emit_replay(line + "\n")
         if not self._header_row_done and (self._row_has_th or self._is_first_row):
             sep = "| " + " | ".join("---" for _ in self._current_row) + " |"
             self._emit(sep + "\n")
@@ -548,11 +562,12 @@ class _MarkdownRenderer(HTMLParser):
             # Drained, not just closed: a late </pre> would otherwise replay the
             # block outside the stripped header and push the article past the cap.
             self._pre_parts = []
-            self._emit("\n\n```\n" + raw + "\n```\n\n")
+            fence = _fence_for(raw)
+            self._emit_replay(f"\n\n{fence}\n{raw}\n{fence}\n\n")
         while len(self._bq_stack) > frame.outer_bq_depth:
             prefixed = self._prefix_blockquote("".join(self._bq_stack.pop()))
             if prefixed:
-                self._emit("\n\n" + prefixed + "\n\n")
+                self._emit_replay("\n\n" + prefixed + "\n\n")
         # A list left open inside the header would indent the body's own lists under phantom nesting.
         while len(self._list_stack) > frame.outer_list_depth:
             if self._list_stack.pop() == "ol" and self._ol_counter:
@@ -796,7 +811,7 @@ class _MarkdownRenderer(HTMLParser):
                 content = "".join(self._bq_stack.pop())
                 prefixed = self._prefix_blockquote(content)
                 if prefixed:
-                    self._emit("\n\n" + prefixed + "\n\n")
+                    self._emit_replay("\n\n" + prefixed + "\n\n")
 
         elif tag == "ul":
             if self._list_stack and self._list_stack[-1] == "ul":
@@ -814,10 +829,13 @@ class _MarkdownRenderer(HTMLParser):
             raw = "".join(self._pre_parts)
             self._in_pre = False
             self._pre_parts = []
-            block = "```\n" + raw + "\n```"
-            self._emit("\n\n" + block + "\n\n")
+            fence = _fence_for(raw)
+            block = f"{fence}\n{raw}\n{fence}"
+            self._emit_replay("\n\n" + block + "\n\n")
 
-        elif tag == "code" and not self._in_pre:
+        # Already closed means a header frame recovered it; emitting the second
+        # backtick here would leave the rest of the page formatted as code.
+        elif tag == "code" and not self._in_pre and self._in_inline_code:
             self._in_inline_code = False
             self._emit("`")
 
@@ -846,16 +864,20 @@ class _MarkdownRenderer(HTMLParser):
     def handle_data(self, data: str) -> None:
         if self._text_suppressed():
             return
-        self._count_header_text(data)
         if self._in_pre:
+            self._count_header_text(data)
             self._pre_parts.append(data)
             return
         # Preserve literal whitespace inside inline <code> spans.
         if self._in_inline_code:
+            self._count_header_text(data)
             self._emit(data)
             return
         # Collapse all whitespace (including newlines) per HTML rules.
         text = re.sub(r"\s+", " ", data)
+        # Sized after collapsing, as the reader sees it: a run of source spaces in
+        # a link otherwise clears the floor at ~100% density and drops the byline.
+        self._count_header_text(text)
         # Suppress whitespace-only nodes between table elements (source indentation).
         if self._in_table and not self._in_cell and not text.strip():
             return
@@ -896,8 +918,9 @@ class _MarkdownRenderer(HTMLParser):
         if self._in_pre:
             raw = "".join(self._pre_parts)
             self._in_pre = False
-            block = "```\n" + raw + "\n```"
-            self._emit("\n\n" + block + "\n\n")
+            fence = _fence_for(raw)
+            block = f"{fence}\n{raw}\n{fence}"
+            self._emit_replay("\n\n" + block + "\n\n")
 
         # Flatten any open blockquote buffers (innermost first).
         while self._bq_stack:
@@ -1093,14 +1116,31 @@ def _non_heading_chars(text: str) -> int:
     """Length of *text* ignoring blanks and heading lines, including headings
     behind blockquote or list prefixes (``> # Title``). Fenced code counts in
     full: a ``#`` there is a comment, not a heading."""
-    total, in_fence = 0, False
+    total, fence = 0, 0
     for line in text.split("\n"):
-        if line.lstrip().startswith("```"):
-            in_fence = not in_fence
-            continue
-        if line.strip() and (in_fence or not _is_heading_line(line)):
-            total += len(line) if in_fence else _visible_len(line)
+        stripped = line.strip()
+        # Only a run of backticks at least as long as the opener closes the block,
+        # so a literal ``` line in the code cannot end it early.
+        if len(stripped) >= 3 and stripped.count("`") == len(stripped):
+            if not fence:
+                fence = len(stripped)
+                continue
+            if len(stripped) >= fence:
+                fence = 0
+                continue
+        if stripped and (fence or not _is_heading_line(line)):
+            total += len(line) if fence else _visible_len(line)
     return total
+
+
+def _fence_for(raw: str) -> str:
+    """Fence long enough to survive backticks in *raw*, as CommonMark requires:
+    a literal ``` line inside the block would otherwise close it early."""
+    longest = run = 0
+    for char in raw:
+        run = run + 1 if char == "`" else 0
+        longest = max(longest, run)
+    return "`" * max(3, longest + 1)
 
 
 def _visible_len(line: str) -> int:
@@ -1110,10 +1150,19 @@ def _visible_len(line: str) -> int:
     total, i, n = 0, 0, len(line)
     while i < n:
         if line[i] == "]" and i + 1 < n and line[i + 1] == "(":
-            end = line.find(")", i + 2)
-            if end == -1:
+            # Destinations may hold balanced or escaped parens (/card(foo)?q=..),
+            # so stopping at the first ) leaves the rest scored as prose.
+            j, depth = i + 2, 1
+            while j < n and depth:
+                char = line[j]
+                if char == "\\":
+                    j += 2
+                    continue
+                depth += (char == "(") - (char == ")")
+                j += 1
+            if depth:
                 break
-            i = end + 1
+            i = j
             continue
         total += 1
         i += 1

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -189,19 +189,14 @@ _BLOCK_TAGS = frozenset(
 _HEADING_TAGS = frozenset({"h1", "h2", "h3", "h4", "h5", "h6"})
 _INLINE_EMPHASIS = {"strong": "**", "b": "**", "em": "*", "i": "*"}
 
-# A <header> is furniture only when almost all links (nav, Wikipedia's language
-# dropdown): live link lists measure 0.94-1.00, content headers 0.13-0.90.
+# Furniture is nearly all links: measured 0.94-1.00 for link lists, 0.13-0.90 for content headers.
 _HEADER_LINK_DENSITY = 0.93
-# Below this the ratio is too noisy: live link lists start at 182 chars, link-dense
-# content headers top out at 93.
+# Below this the ratio is noise: link lists start at 182 chars, link-dense content headers stop at 93.
 _HEADER_MIN_CHARS = 150
-# Short labels can carry huge hrefs, so judge rendered size too: content headers
-# render to at most 363 chars, link lists to 1609 and up.
+# Short labels can hide huge hrefs, so size the render too: content peaks at 363, link lists at 1609+.
 _HEADER_MAX_RENDERED_CHARS = 800
 
-
-# Real pages nest headers one or two deep. Past this they are left as ordinary
-# content, so closing a frame can never copy an unbounded chain of ancestors.
+# Real pages nest headers one or two deep; past this, closing a frame cannot copy an unbounded chain.
 _MAX_HEADER_NESTING = 8
 
 
@@ -242,23 +237,19 @@ class _HeaderFrame:
         self.parts: list[str] = []
         # Heading output, teed so a heading routed through a nested buffer survives.
         self.heading_parts: list[str] = []
-        # Visible chars tallied as they are emitted. Counting here keeps nested
-        # headers linear; re-cleaning each parent's cumulative buffer is quadratic.
-        # Set by render() so the caller need not re-measure its output.
-        self.stripped: bool = False
+        self.stripped: bool = False  # set by render()
+        # Tallied on emit: linear for nested headers, where re-cleaning each parent's buffer is quadratic.
         self.rendered_chars: int = 0
         self.heading_chars: int = 0
-        # Side buffers open at this point enclose the frame; later ones are nested.
-        # Links and cells are held by sequence number, not a flag: an inner one
-        # replaces the outer in the renderer's single slot, so identity is needed.
+        # Side buffers open now enclose the frame, later ones are nested. Links and cells are keyed by
+        # sequence number, not a flag: an inner one replaces the outer in the renderer's single slot.
         self.outer_list_depth = list_depth
         self.outer_link_seq = link_seq
         self.outer_cell_seq = cell_seq
         self.outer_in_pre = in_pre
         self.outer_in_code = in_code
         self.outer_bq_depth = bq_depth
-        # Both exclude heading text (never dropped, so it must not vote on dropping
-        # the rest); only href anchors count as links.
+        # Both exclude heading text (always kept, so it must not vote on dropping the rest).
         self.text_chars: int = 0
         self.link_chars: int = 0
 
@@ -271,15 +262,13 @@ class _HeaderFrame:
         if not closed_by_own_tag:
             return "".join(self.parts)
         headings = "".join(self.heading_parts)
-        # Only the droppable part, and only its visible characters: a heading is
-        # kept either way, and blank structure that _cleanup collapses (500 empty
-        # <div>s) must not make a tiny header look huge.
+        # Droppable visible chars only: headings are kept either way, and blank structure that
+        # _cleanup collapses (500 empty <div>s) must not make a tiny header look huge.
         droppable = self.rendered_chars - self.heading_chars
         big_enough = self.text_chars >= _HEADER_MIN_CHARS or droppable >= _HEADER_MAX_RENDERED_CHARS
         if big_enough and self.link_chars >= _HEADER_LINK_DENSITY * self.text_chars:
             self.stripped = True
-            # The closing tag's blank line is emitted after the heading mark is
-            # popped, so terminate the heading or the body runs into it.
+            # The closing tag's blank line lands after the heading mark pops, so terminate it here.
             return headings + "\n\n" if headings.strip() else headings
         return "".join(self.parts)
 
@@ -383,10 +372,9 @@ class _MarkdownRenderer(HTMLParser):
 
     def _emit(self, text: str) -> None:
         frame = self._header_stack[-1] if self._header_stack else None
-        # Tee wherever the text is routed, so a heading inside a nested buffer is
-        # captured. A link opened inside the frame delivers its text twice (raw,
-        # then formatted by _finish_link), so only the formatted form is teed; a
-        # link that encloses the frame never re-delivers, so it is teed as it comes.
+        # Tee wherever the text is routed, so a heading inside a nested buffer is captured. A link
+        # opened inside the frame delivers twice (raw, then formatted by _finish_link), so only the
+        # formatted form is teed; an enclosing link never re-delivers and is teed as it comes.
         in_nested_link = (
             self._in_link and self._link_seq != frame.outer_link_seq if frame else False
         )
@@ -395,9 +383,8 @@ class _MarkdownRenderer(HTMLParser):
             frame.heading_parts.append(text)
             frame.heading_chars += len(text.strip())
         nested_open = self._nested_buffer_open(frame) if frame is not None else False
-        # Size is tallied once, on the emit that reaches the frame. Counting text
-        # on its way INTO a nested buffer as well as when that buffer flushes its
-        # formatted output doubled it, so a kept header stripped once quoted.
+        # Tally once, on the emit that reaches the frame: counting text going INTO a nested buffer
+        # and again when that buffer flushes doubled it, so a kept header stripped once quoted.
         if frame is not None and not nested_open:
             frame.rendered_chars += len(text.strip())
             frame.parts.append(text)
@@ -539,12 +526,11 @@ class _MarkdownRenderer(HTMLParser):
         Their content is the header's, so it has to land in the frame before the
         strip is judged; otherwise it is emitted afterwards and escapes."""
         if self._in_link and self._link_seq != frame.outer_link_seq:
-            # The header boundary proves this anchor did not adopt the body, so
-            # its text is link furniture even though no </a> arrived.
+            # The header boundary proves this anchor did not adopt the body, so its text is furniture.
             frame.link_chars += self._link_header_chars
             self._finish_link()
-        # Inline code opened OUTSIDE the header is the page's, not the frame's:
-        # closing it here leaves the real </code> to emit an unpaired backtick.
+        # Inline code opened OUTSIDE the header is the page's: closing it here would leave the real
+        # </code> to emit an unpaired backtick.
         if self._in_inline_code and not frame.outer_in_code:
             self._in_inline_code = False
             self._emit("`")
@@ -559,8 +545,7 @@ class _MarkdownRenderer(HTMLParser):
             prefixed = self._prefix_blockquote("".join(self._bq_stack.pop()))
             if prefixed:
                 self._emit("\n\n" + prefixed + "\n\n")
-        # A list left open inside the header would otherwise indent the body's
-        # own lists under phantom nesting.
+        # A list left open inside the header would indent the body's own lists under phantom nesting.
         while len(self._list_stack) > frame.outer_list_depth:
             if self._list_stack.pop() == "ol" and self._ol_counter:
                 self._ol_counter.pop()
@@ -638,16 +623,14 @@ class _MarkdownRenderer(HTMLParser):
     def _exit_tag(self, tag: str) -> bool:
         """Pop to the matching open tag; return True when the end tag should
         be rendered (False = it closed inside a hidden / out-of-scope region)."""
-        # Recover an <a> the page left open before the segment is recorded, or its
-        # text is stranded in the link buffer.
+        # Recover an <a> the page left open before the segment is recorded, or its text is stranded.
         if self._in_link and self._scope_tags is not None and tag in self._scope_tags:
             self._finish_link()
         suppressed = bool(self._hidden_marks) or (
             self._scope_tags is not None and self._scope_depth == 0
         )
-        # An element that is itself the heading (e.g. <a role="heading">) emits
-        # its text when its buffer closes, which happens after the mark below is
-        # popped, so flush it here while the tee still recognises it.
+        # An element that is itself the heading (e.g. <a role="heading">) emits when its buffer closes,
+        # after the mark below is popped, so flush it here while the tee still recognises it.
         if self._in_link and tag == "a" and self._heading_marks:
             self._finish_link()
         if tag not in _VOID_TAGS:
@@ -886,9 +869,8 @@ class _MarkdownRenderer(HTMLParser):
     # Flush pending buffers (handles truncated HTML from capped fetches)
     def flush_pending(self) -> None:
         """Flush open side-buffers into ``_out`` after close(), recovering truncated HTML."""
-        # Headers first: each frame finalizes the buffers opened inside it, then
-        # emits into whatever encloses it, so an enclosing link or cell must still
-        # be open here and is finalized below.
+        # Headers first: each frame finalizes the buffers opened inside it, then emits into whatever
+        # encloses it, so an enclosing link or cell must still be open here and is finalized below.
         self._flush_header_frames()
 
         # Flush innermost buffers first so their content propagates outward.
@@ -1088,9 +1070,8 @@ def _is_heading_line(line: str) -> bool:
             i = j + 1
         else:
             break
-    # ATX rules: 1-6 hashes closed by whitespace or the line end. Without the
-    # closing check "#include" and "#hashtag" read as headings, and this decides
-    # whether a scope has any content, so a C snippet could lose to a teaser.
+    # ATX rules: 1-6 hashes closed by whitespace or line end. Without the closing check "#include"
+    # reads as a heading, and this decides whether a scope has content, so a C snippet loses to a teaser.
     start = i
     while i < n and line[i] == "#":
         i += 1

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -212,18 +212,21 @@ class _HeaderFrame:
         "heading_parts",
         "text_chars",
         "link_chars",
-        "outer_in_cell",
+        "outer_in_link",
+        "outer_cell_seq",
         "outer_in_pre",
         "outer_bq_depth",
     )
 
-    def __init__(self, depth: int, in_cell: bool, in_pre: bool, bq_depth: int):
+    def __init__(self, depth: int, in_link: bool, cell_seq: int, in_pre: bool, bq_depth: int):
         self.depth = depth
         self.parts: list[str] = []
         # Heading output, teed so a heading routed through a nested buffer survives.
         self.heading_parts: list[str] = []
         # Side buffers open at this point enclose the frame; later ones are nested.
-        self.outer_in_cell = in_cell
+        # The cell is held by sequence number, so a nested table's cells differ.
+        self.outer_in_link = in_link
+        self.outer_cell_seq = cell_seq
         self.outer_in_pre = in_pre
         self.outer_bq_depth = bq_depth
         # Both exclude heading text (never dropped, so it must not vote on dropping
@@ -309,6 +312,7 @@ class _MarkdownRenderer(HTMLParser):
         self._current_row: list[str] = []
         self._cell_parts: list[str] = []
         self._in_cell: bool = False
+        self._cell_seq: int = 0
         self._header_row_done: bool = False
         self._row_has_th: bool = False
         self._is_first_row: bool = False
@@ -328,8 +332,8 @@ class _MarkdownRenderer(HTMLParser):
         Such a buffer emits into the frame when it closes; an enclosing one
         (already open at ``<header>``) must not capture it."""
         return (
-            self._in_link
-            or (self._in_cell and not frame.outer_in_cell)
+            (self._in_link and not frame.outer_in_link)
+            or (self._in_cell and self._cell_seq != frame.outer_cell_seq)
             or (self._in_pre and not frame.outer_in_pre)
             or len(self._bq_stack) > frame.outer_bq_depth
         )
@@ -400,6 +404,7 @@ class _MarkdownRenderer(HTMLParser):
         text = re.sub(r"\s+", " ", "".join(self._link_text_parts)).strip()
         href = self._link_href or ""
         self._in_link = False
+        self._link_text_parts = []
         # Recovery paths reach here without </a>, so drop the uncredited tally.
         self._link_header_chars = 0
         if href and text:
@@ -465,12 +470,12 @@ class _MarkdownRenderer(HTMLParser):
 
         Their content is the header's, so it has to land in the frame before the
         strip is judged; otherwise it is emitted afterwards and escapes."""
-        if self._in_link:
+        if self._in_link and not frame.outer_in_link:
             self._finish_link()
         if self._in_inline_code:
             self._in_inline_code = False
             self._emit("`")
-        if self._in_cell and not frame.outer_in_cell:
+        if self._in_cell and self._cell_seq != frame.outer_cell_seq:
             self._finish_cell()
             self._finish_row()
         if self._in_pre and not frame.outer_in_pre:
@@ -485,6 +490,7 @@ class _MarkdownRenderer(HTMLParser):
     def _flush_header_frames(self) -> None:
         """Emit every open header unchanged, abandoning the strip."""
         while self._header_stack:
+            self._finalize_nested_buffers(self._header_stack[-1])
             self._emit("".join(self._header_stack.pop().parts))
 
     def _count_header_text(self, text: str) -> None:
@@ -512,7 +518,8 @@ class _MarkdownRenderer(HTMLParser):
                 self._header_stack.append(
                     _HeaderFrame(
                         len(self._open_tags) - 1,
-                        self._in_cell,
+                        self._in_link,
+                        self._cell_seq if self._in_cell else -1,
                         self._in_pre,
                         len(self._bq_stack),
                     )
@@ -543,6 +550,11 @@ class _MarkdownRenderer(HTMLParser):
         suppressed = bool(self._hidden_marks) or (
             self._scope_tags is not None and self._scope_depth == 0
         )
+        # An element that is itself the heading (e.g. <a role="heading">) emits
+        # its text when its buffer closes, which happens after the mark below is
+        # popped, so flush it here while the tee still recognises it.
+        if self._in_link and tag == "a" and self._heading_marks:
+            self._finish_link()
         if tag not in _VOID_TAGS:
             # Pop to the innermost matching open tag (recovers omitted closes).
             for i in range(len(self._open_tags) - 1, -1, -1):
@@ -658,6 +670,7 @@ class _MarkdownRenderer(HTMLParser):
             self._finish_cell()  # handles omitted </td>/</th>
             self._cell_parts = []
             self._in_cell = True
+            self._cell_seq += 1
             if tag == "th":
                 self._row_has_th = True
 
@@ -794,6 +807,10 @@ class _MarkdownRenderer(HTMLParser):
             block = "```\n" + raw + "\n```"
             self._emit("\n\n" + block + "\n\n")
 
+        # Headers first: a buffer nested in one belongs to it, so flushing the
+        # buffer on its own would emit that content ahead of the header text.
+        self._flush_header_frames()
+
         # Flatten any open blockquote buffers (innermost first).
         while self._bq_stack:
             content = "".join(self._bq_stack.pop())
@@ -804,9 +821,6 @@ class _MarkdownRenderer(HTMLParser):
                 self._bq_stack[-1].append("\n\n" + prefixed + "\n\n")
             else:
                 self._out.append("\n\n" + prefixed + "\n\n")
-
-        # An unclosed <header> adopts the page body, so emit it unchanged.
-        self._flush_header_frames()
 
         # A scope left open by truncated HTML never reached _exit_tag, so its output
         # never joined scope_segments and would score 0. Flush the still-open segment
@@ -940,18 +954,26 @@ def _select_main_scope_render(source_html: str, tag: str) -> tuple[int, str]:
     unrelated siblings (related cards, comment threads) out of the output.
 
     Candidates are sized with their dropped header furniture added back, so the
-    strip never costs an article the size gate or a sibling comparison."""
+    strip never costs an article the size gate or a sibling comparison. A
+    candidate that retained nothing is all furniture, and gets no such credit."""
     renderer = _new_renderer(source_html, frozenset({tag}), strip_header = True)
     dropped = renderer.scope_dropped
     best_len = 0
     best_render = ""
     for i, seg in enumerate(renderer.scope_segments):
         rendered = _strip_boilerplate_lines(_cleanup(seg))
-        size = len(rendered) + dropped[i]
+        credit = dropped[i] if len(rendered) >= _MIN_RETAINED_CHARS else 0
+        size = len(rendered) + credit
         if size > best_len:
             best_len = size
             best_render = rendered
     return best_len, best_render
+
+
+# Removed furniture only counts toward a candidate's size once it retained more
+# than a bare heading line, so a scope holding nothing else cannot qualify on
+# what was deleted from it.
+_MIN_RETAINED_CHARS = 50
 
 
 # A scoped conversion below this size is judged not to be the page's main

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -212,20 +212,33 @@ class _HeaderFrame:
         "heading_parts",
         "text_chars",
         "link_chars",
+        "stripped",
+        "rendered_chars",
+        "heading_chars",
+        "outer_list_depth",
         "outer_link_seq",
         "outer_cell_seq",
         "outer_in_pre",
         "outer_bq_depth",
     )
 
-    def __init__(self, depth: int, link_seq: int, cell_seq: int, in_pre: bool, bq_depth: int):
+    def __init__(
+        self, depth: int, link_seq: int, cell_seq: int, in_pre: bool, bq_depth: int, list_depth: int
+    ):
         self.depth = depth
         self.parts: list[str] = []
         # Heading output, teed so a heading routed through a nested buffer survives.
         self.heading_parts: list[str] = []
+        # Visible chars tallied as they are emitted. Counting here keeps nested
+        # headers linear; re-cleaning each parent's cumulative buffer is quadratic.
+        # Set by render() so the caller need not re-measure its output.
+        self.stripped: bool = False
+        self.rendered_chars: int = 0
+        self.heading_chars: int = 0
         # Side buffers open at this point enclose the frame; later ones are nested.
         # Links and cells are held by sequence number, not a flag: an inner one
         # replaces the outer in the renderer's single slot, so identity is needed.
+        self.outer_list_depth = list_depth
         self.outer_link_seq = link_seq
         self.outer_cell_seq = cell_seq
         self.outer_in_pre = in_pre
@@ -240,15 +253,17 @@ class _HeaderFrame:
 
         Without a matching ``</header>`` the header may have adopted the page
         body, so keep it whole."""
+        self.stripped = False
         if not closed_by_own_tag:
             return "".join(self.parts)
         headings = "".join(self.heading_parts)
-        # Both sizes measure only the droppable part, cleaned: a heading is kept
-        # either way, and raw tokens count blank lines that _cleanup collapses,
-        # so 500 empty <div>s must not make a tiny header look huge.
-        droppable = len(_cleanup("".join(self.parts))) - len(_cleanup(headings))
+        # Only the droppable part, and only its visible characters: a heading is
+        # kept either way, and blank structure that _cleanup collapses (500 empty
+        # <div>s) must not make a tiny header look huge.
+        droppable = self.rendered_chars - self.heading_chars
         big_enough = self.text_chars >= _HEADER_MIN_CHARS or droppable >= _HEADER_MAX_RENDERED_CHARS
         if big_enough and self.link_chars >= _HEADER_LINK_DENSITY * self.text_chars:
+            self.stripped = True
             # The closing tag's blank line is emitted after the heading mark is
             # popped, so terminate the heading or the body runs into it.
             return headings + "\n\n" if headings.strip() else headings
@@ -302,6 +317,10 @@ class _MarkdownRenderer(HTMLParser):
         self._link_text_parts: list[str] = []
         self._in_link: bool = False
         self._link_seq: int = 0
+        # A link wrapping a heading emits after the heading mark is gone, so the
+        # tee is told to treat that one emit as heading output.
+        self._link_had_heading: bool = False
+        self._emit_as_heading: bool = False
         # Text under the open <a>, credited only at </a>: an <a> left open adopts
         # body prose, which is not furniture.
         self._link_header_chars: int = 0
@@ -354,8 +373,12 @@ class _MarkdownRenderer(HTMLParser):
         in_nested_link = (
             self._in_link and self._link_seq != frame.outer_link_seq if frame else False
         )
-        if frame is not None and self._heading_marks and not in_nested_link:
+        as_heading = (self._heading_marks and not in_nested_link) or self._emit_as_heading
+        if frame is not None and as_heading:
             frame.heading_parts.append(text)
+            frame.heading_chars += len(text.strip())
+        if frame is not None:
+            frame.rendered_chars += len(text.strip())
         if frame is not None and not self._nested_buffer_open(frame):
             frame.parts.append(text)
             return
@@ -416,12 +439,15 @@ class _MarkdownRenderer(HTMLParser):
         href = self._link_href or ""
         self._in_link = False
         self._link_text_parts = []
+        self._emit_as_heading = self._link_had_heading
+        self._link_had_heading = False
         # Recovery paths reach here without </a>, so drop the uncredited tally.
         self._link_header_chars = 0
         if href and text:
             self._emit(f"[{text}]({href})")
         elif text:
             self._emit(text)
+        self._emit_as_heading = False
 
     # ------------------------------------------------------------------
     # Tag handlers
@@ -471,8 +497,10 @@ class _MarkdownRenderer(HTMLParser):
                 self._header_stack[-1].text_chars += frame.text_chars
                 self._header_stack[-1].link_chars += frame.link_chars
                 self._header_stack[-1].heading_parts.extend(frame.heading_parts)
+                self._header_stack[-1].heading_chars += frame.heading_chars
             out = frame.render(closed_by_own_tag)
-            self._dropped_chars += max(0, len(_cleanup("".join(frame.parts))) - len(_cleanup(out)))
+            if frame.stripped:
+                self._dropped_chars += max(0, frame.rendered_chars - frame.heading_chars)
             self._emit(out)
             closed_by_own_tag = False
 
@@ -500,6 +528,11 @@ class _MarkdownRenderer(HTMLParser):
             prefixed = self._prefix_blockquote("".join(self._bq_stack.pop()))
             if prefixed:
                 self._emit("\n\n" + prefixed + "\n\n")
+        # A list left open inside the header would otherwise indent the body's
+        # own lists under phantom nesting.
+        while len(self._list_stack) > frame.outer_list_depth:
+            if self._list_stack.pop() == "ol" and self._ol_counter:
+                self._ol_counter.pop()
 
     def _flush_header_frames(self) -> None:
         """Emit every open header unchanged, abandoning the strip."""
@@ -534,6 +567,8 @@ class _MarkdownRenderer(HTMLParser):
                 self._hidden_marks.append(len(self._open_tags) - 1)
             if tag in _HEADING_TAGS or tag == "hgroup" or _is_aria_heading(attr_dict):
                 self._heading_marks.append(len(self._open_tags) - 1)
+                if self._in_link:
+                    self._link_had_heading = True
             if self._strip_header and tag == "header" and not self._hidden_marks:
                 self._header_stack.append(
                     _HeaderFrame(
@@ -542,6 +577,7 @@ class _MarkdownRenderer(HTMLParser):
                         self._cell_seq if self._in_cell else -1,
                         self._in_pre,
                         len(self._bq_stack),
+                        len(self._list_stack),
                     )
                 )
         elif _is_hidden_element(attr_dict):
@@ -998,9 +1034,15 @@ def _select_main_scope_render(source_html: str, tag: str) -> tuple[int, str]:
 _MIN_RETAINED_CHARS = 50
 
 
+_HEADING_LINE = re.compile(r"^(?:\s*(?:[>*+-]|\d+\.)\s*)*#")
+
+
 def _non_heading_chars(text: str) -> int:
-    """Length of *text* ignoring heading lines and blanks."""
-    return sum(len(line) for line in text.split("\n") if line.strip() and not line.startswith("#"))
+    """Length of *text* ignoring blanks and heading lines, including headings
+    behind blockquote or list prefixes (``> # Title``)."""
+    return sum(
+        len(line) for line in text.split("\n") if line.strip() and not _HEADING_LINE.match(line)
+    )
 
 
 # A scoped conversion below this size is judged not to be the page's main

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -404,9 +404,7 @@ class _MarkdownRenderer(HTMLParser):
             self._scope_depth -= 1
             if self._scope_depth == 0 and self._scope_seg_start is not None:
                 self.scope_segments.append("".join(self._out[self._scope_seg_start :]))
-                self.scope_header_prose.append(
-                    self._header_prose_total - self._seg_header_start
-                )
+                self.scope_header_prose.append(self._header_prose_total - self._seg_header_start)
                 self._scope_seg_start = None
         return not suppressed
 
@@ -803,6 +801,7 @@ def _select_main_scope_render(
 # content (e.g. an empty <article> stub) and the next candidate is tried.
 _MIN_MAIN_CONTENT_CHARS = 200
 
+
 # An unclosed <header> adopts the body (as browsers parse it). Size cannot tell
 # that apart from furniture removal, but link density can: a real header holds
 # a title and links, so only non-anchor prose counts as a swallowed body.
@@ -830,7 +829,9 @@ def html_to_markdown(source_html: str, *, main_content: bool = False) -> str:
             # Render only the chosen subtree so sibling <article>/<main>
             # elements do not leak in once the largest passes the size gate.
             length, rendered, header_prose = _select_main_scope_render(
-                source_html, scope_tag, strip_header = True,
+                source_html,
+                scope_tag,
+                strip_header = True,
             )
             if _header_strip_backfired(length, header_prose):
                 length, rendered, _ = _select_main_scope_render(source_html, scope_tag)

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -208,14 +208,28 @@ class _HeaderFrame:
     Buffering (like ``_bq_stack``) defers the decision to ``</header>``, once the
     whole subtree is known. A header no end tag closes is emitted unchanged."""
 
-    __slots__ = ("depth", "parts", "heading_parts", "text_chars", "link_chars")
+    __slots__ = (
+        "depth",
+        "parts",
+        "heading_parts",
+        "text_chars",
+        "link_chars",
+        "outer_in_cell",
+        "outer_in_pre",
+        "outer_bq_depth",
+    )
 
-    def __init__(self, depth: int):
+    def __init__(self, depth: int, in_cell: bool, in_pre: bool, bq_depth: int):
         self.depth = depth
         self.parts: list[str] = []
         # A copy of the heading output, teed as it is emitted so a heading routed
         # through a nested blockquote or table cell is still recoverable.
         self.heading_parts: list[str] = []
+        # Side buffers already open here are ancestors, so their content belongs
+        # to this frame; ones opened later are nested and buffer normally.
+        self.outer_in_cell = in_cell
+        self.outer_in_pre = in_pre
+        self.outer_bq_depth = bq_depth
         # Both exclude heading text (never dropped, so it must not vote on dropping
         # the rest); only href anchors count as links.
         self.text_chars: int = 0
@@ -272,6 +286,10 @@ class _MarkdownRenderer(HTMLParser):
         # Open <header> buffers, innermost last. Empty unless strip_header.
         self._strip_header = strip_header
         self._header_stack: list[_HeaderFrame] = []
+        # Furniture chars removed, so a candidate is sized as the page wrote it.
+        self._dropped_chars: int = 0
+        self._seg_dropped_start: int = 0
+        self.scope_dropped: list[int] = []
         # Open-tag indices of elements acting as headings (h1-h6 or role=heading),
         # unwound with _hidden_marks so an unclosed one cannot stick.
         self._heading_marks: list[int] = []
@@ -306,9 +324,28 @@ class _MarkdownRenderer(HTMLParser):
         self._bq_stack: list[list[str]] = []
 
     # ------------------------------------------------------------------
+    def _nested_buffer_open(self, frame: _HeaderFrame) -> bool:
+        """True when a side buffer opened *inside* *frame* still holds content.
+
+        Such a buffer emits into the frame when it closes; one that was already
+        open when the header started encloses it and must not capture it."""
+        return (
+            self._in_link
+            or (self._in_cell and not frame.outer_in_cell)
+            or (self._in_pre and not frame.outer_in_pre)
+            or len(self._bq_stack) > frame.outer_bq_depth
+        )
+
     def _emit(self, text: str) -> None:
-        if self._heading_marks and self._header_stack:
-            self._header_stack[-1].heading_parts.append(text)
+        frame = self._header_stack[-1] if self._header_stack else None
+        # Tee wherever the text is routed, so a heading inside a nested buffer is
+        # still captured. Link text arrives raw and again formatted by
+        # _finish_link, which runs with _in_link cleared, so only that form is teed.
+        if frame is not None and self._heading_marks and not self._in_link:
+            frame.heading_parts.append(text)
+        if frame is not None and not self._nested_buffer_open(frame):
+            frame.parts.append(text)
+            return
         if self._in_link:
             self._link_text_parts.append(text)
         elif self._in_cell:
@@ -317,8 +354,6 @@ class _MarkdownRenderer(HTMLParser):
             self._pre_parts.append(text)
         elif self._bq_stack:
             self._bq_stack[-1].append(text)
-        elif self._header_stack:
-            self._header_stack[-1].parts.append(text)
         else:
             self._out.append(text)
 
@@ -421,7 +456,9 @@ class _MarkdownRenderer(HTMLParser):
                 self._header_stack[-1].text_chars += frame.text_chars
                 self._header_stack[-1].link_chars += frame.link_chars
                 self._header_stack[-1].heading_parts.extend(frame.heading_parts)
-            self._emit(frame.render(closed_by_own_tag))
+            out = frame.render(closed_by_own_tag)
+            self._dropped_chars += sum(len(part) for part in frame.parts) - len(out)
+            self._emit(out)
             closed_by_own_tag = False
 
     def _flush_header_frames(self) -> None:
@@ -451,7 +488,14 @@ class _MarkdownRenderer(HTMLParser):
             if tag in _HEADING_TAGS or _is_aria_heading(attr_dict):
                 self._heading_marks.append(len(self._open_tags) - 1)
             if self._strip_header and tag == "header" and not self._hidden_marks:
-                self._header_stack.append(_HeaderFrame(len(self._open_tags) - 1))
+                self._header_stack.append(
+                    _HeaderFrame(
+                        len(self._open_tags) - 1,
+                        self._in_cell,
+                        self._in_pre,
+                        len(self._bq_stack),
+                    )
+                )
         elif _is_hidden_element(attr_dict):
             # Void elements never join the stack, so suppress a hidden one inline.
             return False
@@ -460,6 +504,7 @@ class _MarkdownRenderer(HTMLParser):
             self._flush_header_frames()
             if self._scope_depth == 0:
                 self._scope_seg_start = len(self._out)
+                self._seg_dropped_start = self._dropped_chars
             self._scope_depth += 1
         if self._hidden_marks:
             return False
@@ -492,6 +537,7 @@ class _MarkdownRenderer(HTMLParser):
             self._scope_depth -= 1
             if self._scope_depth == 0 and self._scope_seg_start is not None:
                 self.scope_segments.append("".join(self._out[self._scope_seg_start :]))
+                self.scope_dropped.append(self._dropped_chars - self._seg_dropped_start)
                 self._scope_seg_start = None
         return not suppressed
 
@@ -747,6 +793,7 @@ class _MarkdownRenderer(HTMLParser):
         # here (after the side-buffers) so a truncated main-content page is scored.
         if self._scope_seg_start is not None:
             self.scope_segments.append("".join(self._out[self._scope_seg_start :]))
+            self.scope_dropped.append(self._dropped_chars - self._seg_dropped_start)
             self._scope_seg_start = None
             self._scope_depth = 0
 
@@ -870,14 +917,19 @@ def _select_main_scope_render(source_html: str, tag: str) -> tuple[int, str]:
     """Length and boilerplate-stripped render of the largest single ``<tag>``
     subtree. Sizing candidates one at a time stops many tiny sibling cards from
     clearing the threshold together, and returning that one subtree keeps
-    unrelated siblings (related cards, comment threads) out of the output."""
+    unrelated siblings (related cards, comment threads) out of the output.
+
+    Candidates are sized with their dropped header furniture added back, so
+    removing it never costs an article the size gate or a sibling comparison."""
     renderer = _new_renderer(source_html, frozenset({tag}), strip_header = True)
+    dropped = renderer.scope_dropped
     best_len = 0
     best_render = ""
-    for seg in renderer.scope_segments:
+    for i, seg in enumerate(renderer.scope_segments):
         rendered = _strip_boilerplate_lines(_cleanup(seg))
-        if len(rendered) > best_len:
-            best_len = len(rendered)
+        size = len(rendered) + dropped[i]
+        if size > best_len:
+            best_len = size
             best_render = rendered
     return best_len, best_render
 

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -423,7 +423,7 @@ class _MarkdownRenderer(HTMLParser):
     def _seg_heading_prose(self) -> int:
         """Heading characters in this segment that the gate would otherwise read as
         body prose. ATX headings carry their own ``#`` here and so score zero."""
-        return _non_heading_chars("".join(self._seg_heading_texts))
+        return _visible_chars("".join(self._seg_heading_texts))
 
     def _drain_pre(self) -> None:
         """Emit the open ``<pre>`` and empty it, so a late ``</pre>`` cannot replay
@@ -433,6 +433,13 @@ class _MarkdownRenderer(HTMLParser):
         self._pre_parts = []
         fence = _fence_for(raw)
         self._emit_replay(f"\n\n{fence}\n{raw}\n{fence}\n\n")
+
+    def _drain_blockquote(self) -> None:
+        """Pop the innermost quote and emit it prefixed. Not used by ``flush_pending``,
+        which re-nests into the parent stack instead of emitting."""
+        prefixed = self._prefix_blockquote("".join(self._bq_stack.pop()))
+        if prefixed:
+            self._emit_replay("\n\n" + prefixed + "\n\n")
 
     def _emit_replay(self, text: str) -> None:
         """Emit a flushed buffer's own output, which must not be teed as a heading
@@ -596,9 +603,7 @@ class _MarkdownRenderer(HTMLParser):
             self._finish_cell()
             self._finish_row()
         while len(self._bq_stack) > frame.outer_bq_depth:
-            prefixed = self._prefix_blockquote("".join(self._bq_stack.pop()))
-            if prefixed:
-                self._emit_replay("\n\n" + prefixed + "\n\n")
+            self._drain_blockquote()
         # A list left open in the header would indent the body's lists under phantom nesting.
         while len(self._list_stack) > frame.outer_list_depth:
             if self._list_stack.pop() == "ol" and self._ol_counter:
@@ -842,10 +847,7 @@ class _MarkdownRenderer(HTMLParser):
 
         elif tag == "blockquote":
             if self._bq_stack:
-                content = "".join(self._bq_stack.pop())
-                prefixed = self._prefix_blockquote(content)
-                if prefixed:
-                    self._emit_replay("\n\n" + prefixed + "\n\n")
+                self._drain_blockquote()
 
         elif tag == "ul":
             if self._list_stack and self._list_stack[-1] == "ul":
@@ -860,12 +862,7 @@ class _MarkdownRenderer(HTMLParser):
             self._emit("\n")
 
         elif tag == "pre" and self._in_pre:
-            raw = "".join(self._pre_parts)
-            self._in_pre = False
-            self._pre_parts = []
-            fence = _fence_for(raw)
-            block = f"{fence}\n{raw}\n{fence}"
-            self._emit_replay("\n\n" + block + "\n\n")
+            self._drain_pre()
 
         # Already closed means a header frame recovered it; a second backtick here would leave the
         # rest of the page formatted as code.
@@ -950,11 +947,7 @@ class _MarkdownRenderer(HTMLParser):
         self._finish_row()
 
         if self._in_pre:
-            raw = "".join(self._pre_parts)
-            self._in_pre = False
-            fence = _fence_for(raw)
-            block = f"{fence}\n{raw}\n{fence}"
-            self._emit_replay("\n\n" + block + "\n\n")
+            self._drain_pre()
 
         # Flatten any open blockquote buffers (innermost first).
         while self._bq_stack:
@@ -1128,7 +1121,7 @@ def _select_main_scope_render(source_html: str, tag: str) -> tuple[int, str]:
     best_render = ""
     for i, seg in enumerate(renderer.scope_segments):
         rendered = _strip_boilerplate_lines(_cleanup(seg))
-        prose = _non_heading_chars(rendered) - heading_prose[i]
+        prose = _visible_chars(rendered) - heading_prose[i]
         if prose < _MIN_MAIN_CONTENT_CHARS:
             continue
         size = len(rendered) + min(dropped[i], len(rendered))
@@ -1138,49 +1131,14 @@ def _select_main_scope_render(source_html: str, tag: str) -> tuple[int, str]:
     return best_len, best_render
 
 
-def _is_heading_line(line: str) -> bool:
-    """True when *line* is a heading, allowing blockquote and list prefixes.
+def _visible_chars(text: str) -> int:
+    """Visible characters in *text*, ignoring blank lines and link destinations.
 
-    Scanned rather than matched with a regex: nested prefixes make adjacent
-    whitespace patterns backtrack catastrophically on ``> > > prose``."""
-    i, n = 0, len(line)
-    while i < n:
-        char = line[i]
-        if char in " \t>*+-":
-            i += 1
-        elif char.isdigit():
-            j = i
-            while j < n and line[j].isdigit():
-                j += 1
-            if j >= n or line[j] != ".":
-                return False
-            i = j + 1
-        else:
-            break
-    # ATX rules: 1-6 hashes closed by whitespace or line end; without the close check "#include"
-    # reads as a heading, and this gates whether a scope has content, so a C snippet loses.
-    start = i
-    while i < n and line[i] == "#":
-        i += 1
-    if i == start or i - start > 6:
-        return False
-    return i >= n or line[i] in " \t"
-
-
-def _non_heading_chars(text: str) -> int:
-    """Length of *text* ignoring blanks and heading lines, including headings
-    behind blockquote or list prefixes (``> # Title``). Fenced code counts in
-    full: a ``#`` there is a comment, not a heading."""
-    total, fence = 0, 0
-    for line in text.split("\n"):
-        stripped = line.strip()
-        moved = _fence_state(line, fence)
-        if moved != fence:
-            fence = moved
-            continue
-        if stripped and (fence or not _is_heading_line(line)):
-            total += len(line) if fence else _visible_len(line)
-    return total
+    Headings are NOT discounted here. The renderer already tallies what it marked
+    as a heading (``_seg_heading_prose``), which sees ``role="heading"``, hgroup
+    and a linked ``h1``; re-deriving that from ATX syntax could not, and running
+    both meant two answers to one question."""
+    return sum(_visible_len(line) for line in text.split("\n") if line.strip())
 
 
 def _fence_for(raw: str) -> str:

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -246,8 +246,8 @@ class _HeaderFrame:
         # Tallied on emit; re-cleaning each parent's buffer would be quadratic.
         self.rendered_chars: int = 0
         self.heading_chars: int = 0
-        # Buffers open now enclose the frame, later ones nest. Links and cells are keyed by sequence
-        # number, not a flag: an inner one replaces the outer in the renderer's single slot.
+        # Buffers open now enclose the frame, later ones nest. Link/cell sequence numbers, not
+        # flags: an inner one replaces the outer in the renderer's single slot.
         self.outer_list_depth = list_depth
         self.outer_link_seq = link_seq
         self.outer_cell_seq = cell_seq
@@ -267,8 +267,8 @@ class _HeaderFrame:
         if not closed_by_own_tag:
             return "".join(self.parts)
         headings = "".join(self.heading_parts)
-        # Droppable visible chars only: headings are kept anyway, and blank structure _cleanup
-        # collapses (500 empty <div>s) must not make a tiny header look huge.
+        # Droppable chars only; headings survive, and blank structure _cleanup collapses must not
+        # inflate a tiny header.
         droppable = self.rendered_chars - self.heading_chars
         big_enough = self.text_chars >= _HEADER_MIN_CHARS or droppable >= _HEADER_MAX_RENDERED_CHARS
         if big_enough and self.link_chars >= _HEADER_LINK_DENSITY * self.text_chars:
@@ -299,13 +299,12 @@ class _MarkdownRenderer(HTMLParser):
         self._scope_tags = scope_tags
         self._scope_depth: int = 0
 
-        # One boundary per top-level scope element, so each candidate is sized alone and a swarm
-        # of tiny sibling cards cannot clear the threshold together.
+        # One boundary per top-level scope element, so a swarm of tiny cards cannot clear the gate.
         self.scope_segments: list[str] = []
         self._scope_seg_start: int | None = None
 
-        # Open non-void tags plus the indices where a hidden element started. End tags pop to the
-        # matching tag, so an omitted </p>/</li> cannot leave the renderer stuck hidden.
+        # Open non-void tags plus hidden-start indices, so an omitted </p>/</li> cannot leave the
+        # renderer stuck hidden.
         self._open_tags: list[str] = []
         # Open tags that can be closed implicitly; zero lets _close_implicit skip the scan.
         self._closable_open: int = 0
@@ -318,8 +317,8 @@ class _MarkdownRenderer(HTMLParser):
         self._dropped_chars: int = 0
         self._seg_dropped_start: int = 0
         self.scope_dropped: list[int] = []
-        # Heading text per segment: role="heading", <hgroup> and linked <h1> render as ordinary
-        # prose, so ATX reparsing alone cannot keep them out of the gate.
+        # Heading text per segment: role="heading", hgroup and linked h1 render as prose, so ATX
+        # reparsing alone cannot keep them out of the gate.
         self._seg_heading_texts: list[str] = []
         self.scope_heading_prose: list[int] = []
         # Open-tag indices of headings, unwound with _hidden_marks.
@@ -330,8 +329,7 @@ class _MarkdownRenderer(HTMLParser):
         self._link_text_parts: list[str] = []
         self._in_link: bool = False
         self._link_seq: int = 0
-        # A link wrapping a heading emits after the heading mark is gone, so the tee is told to
-        # treat that one emit as heading output.
+        # A link wrapping a heading emits after the mark pops, so the tee is told to treat it so.
         self._link_had_heading: bool = False
         self._link_heading_parts: list[str] = []
         self._emit_as_heading: bool = False
@@ -356,8 +354,7 @@ class _MarkdownRenderer(HTMLParser):
         # Pre/code state
         self._in_pre: bool = False
         self._pre_parts: list[str] = []
-        # Depth, not a flag: <code><code>x</code></code> opens two spans and each
-        # end tag owes a backtick, else the delimiters stop pairing.
+        # Depth, not a flag: nested <code> opens two spans and each </code> owes a backtick.
         self._inline_code_depth: int = 0
 
         # Blockquote state: stack of buffers so nested blockquotes get the right ">" depth.
@@ -369,8 +366,8 @@ class _MarkdownRenderer(HTMLParser):
 
         Such a buffer emits into the frame when it closes; an enclosing one
         (already open at ``<header>``) must not capture it."""
-        # Only the buffer _emit would pick matters, in its order: a blockquote inside a
-        # cell-enclosed header still routes to the cell, so OR-ing them would call that nested.
+        # Only the buffer _emit would pick matters, in its order; OR-ing them calls an enclosing
+        # one nested.
         if self._in_link:
             return self._link_seq != frame.outer_link_seq
         if self._in_cell:
@@ -382,28 +379,24 @@ class _MarkdownRenderer(HTMLParser):
     def _emit(self, text: str) -> None:
         frame = self._header_stack[-1] if self._header_stack else None
         # Tee wherever the text routes, so a heading in a nested buffer is captured. A link opened
-        # inside the frame delivers twice (raw, then formatted by _finish_link), so only the
-        # formatted form is teed; an enclosing link never re-delivers and is teed as it comes.
+        # inside the frame delivers twice, so tee only the formatted form; an enclosing link, once.
         in_nested_link = (
             self._in_link and self._link_seq != frame.outer_link_seq if frame else False
         )
-        # A flushed buffer re-delivers text already teed on the way in, so replays never tee;
-        # _finish_link is the exception and re-arms the tee itself.
+        # Replays never tee: the text was teed on the way in. _finish_link re-arms the tee itself.
         as_heading = (
             self._heading_marks and not in_nested_link and not self._replaying
         ) or self._emit_as_heading
         if frame is not None and as_heading:
             frame.heading_parts.append(text)
             frame.heading_chars += len(text.strip())
-        # Tallied for the eligibility gate, independent of any frame. Text inside a link waits for
-        # _finish_link so the formatted form counts once.
+        # For the eligibility gate, frame or not. Link text waits for _finish_link to count once.
         if not self._replaying and (
             (self._heading_marks and not self._in_link) or self._emit_as_heading
         ):
             self._seg_heading_texts.append(text)
         nested_open = self._nested_buffer_open(frame) if frame is not None else False
-        # Tally once, on the emit that reaches the frame: counting text going INTO a nested buffer
-        # and again when it flushes doubled it, so a kept header stripped once quoted.
+        # Tally once, on the emit reaching the frame; counting again on flush doubled it.
         if frame is not None and not nested_open:
             frame.rendered_chars += len(text.strip())
             frame.parts.append(text)
@@ -499,8 +492,7 @@ class _MarkdownRenderer(HTMLParser):
         self._in_link = False
         self._link_text_parts = []
         self._link_heading_parts = []
-        # An anchor wrapping a heading AND other content is furniture carrying a title: tee the
-        # title alone, or the whole nav rides out as a heading.
+        # An anchor wrapping a heading AND other content tees the title alone, else the nav rides.
         partial = bool(heading_text) and heading_text != text
         self._emit_as_heading = self._link_had_heading and not partial
         self._link_had_heading = False
@@ -515,8 +507,7 @@ class _MarkdownRenderer(HTMLParser):
             frame = self._header_stack[-1]
             frame.heading_parts.append(heading_text + "\n\n")
             frame.heading_chars += len(heading_text)
-            # Preserved by hand, so the gate needs telling too or a title-only card
-            # reads as body prose.
+            # Preserved by hand, so tell the gate too or a title-only card reads as body prose.
             self._seg_heading_texts.append(heading_text)
 
     # ------------------------------------------------------------------
@@ -592,13 +583,11 @@ class _MarkdownRenderer(HTMLParser):
             # The header boundary proves this anchor did not adopt the body: its text is furniture.
             frame.link_chars += self._link_header_chars
             self._finish_link()
-        # Inline code opened OUTSIDE the header is the page's; closing it here would leave the real
-        # </code> to emit an unpaired backtick.
+        # Code opened OUTSIDE the header is the page's; closing it here leaves </code> unpaired.
         while self._inline_code_depth > frame.outer_in_code:
             self._inline_code_depth -= 1
             self._emit("`")
-        # Before the cell: _finish_row emits, and an open <pre> would swallow the
-        # row into the code block as CODE|  | instead of a cell holding the code.
+        # Before the cell: _finish_row emits, and an open <pre> would swallow the row as CODE|  |.
         if self._in_pre and not frame.outer_in_pre:
             self._drain_pre()
         if self._in_cell and self._cell_seq != frame.outer_cell_seq:
@@ -691,8 +680,8 @@ class _MarkdownRenderer(HTMLParser):
         suppressed = bool(self._hidden_marks) or (
             self._scope_tags is not None and self._scope_depth == 0
         )
-        # An element that IS the heading (e.g. <a role="heading">) emits when its buffer closes,
-        # after the mark below is popped, so flush it here while the tee still recognises it.
+        # An element that IS the heading emits when its buffer closes, after the mark pops; flush
+        # it here while the tee still recognises it.
         if self._in_link and tag == "a" and self._heading_marks:
             self._finish_link()
         if tag not in _VOID_TAGS:
@@ -866,8 +855,7 @@ class _MarkdownRenderer(HTMLParser):
         elif tag == "pre" and self._in_pre:
             self._drain_pre()
 
-        # Already closed means a header frame recovered it; a second backtick here would leave the
-        # rest of the page formatted as code.
+        # Already closed means a frame recovered it; a second backtick codes the rest of the page.
         elif tag == "code" and not self._in_pre and self._inline_code_depth:
             self._inline_code_depth -= 1
             self._emit("`")
@@ -908,8 +896,8 @@ class _MarkdownRenderer(HTMLParser):
             return
         # Collapse all whitespace (including newlines) per HTML rules.
         text = re.sub(r"\s+", " ", data)
-        # Sized after collapsing, as the reader sees it: a run of source spaces in a link otherwise
-        # clears the floor at ~100% density and drops the byline.
+        # Sized after collapsing, as the reader sees it: raw spaces in a link cleared the floor at
+        # ~100% density and dropped the byline.
         self._count_header_text(text)
         # Suppress whitespace-only nodes between table elements (source indentation).
         if self._in_table and not self._in_cell and not text.strip():
@@ -933,8 +921,8 @@ class _MarkdownRenderer(HTMLParser):
     # Flush pending buffers (handles truncated HTML from capped fetches)
     def flush_pending(self) -> None:
         """Flush open side-buffers into ``_out`` after close(), recovering truncated HTML."""
-        # Headers first: each frame finalizes the buffers opened inside it, then emits into what
-        # encloses it, so an enclosing link or cell must still be open here; it is finalized below.
+        # Headers first: a frame finalizes its inner buffers, then emits into the enclosing link or
+        # cell, which must still be open here; it is finalized below.
         self._flush_header_frames()
 
         # Flush innermost buffers first so their content propagates outward.
@@ -1166,11 +1154,9 @@ def _visible_len(line: str) -> int:
             continue
         if line[i] == "[":
             open_bracket = True
-        # Without a bracket that opened it, "](" is literal text and the parens after
-        # it are prose: skipping them dropped visible characters from the score.
+        # With no opening bracket, "](" is literal and the parens after it are prose.
         if open_bracket and line[i] == "]" and i + 1 < n and line[i + 1] == "(":
-            # Destinations may hold balanced or escaped parens (/card(foo)?q=..), so stopping at
-            # the first ) leaves the rest scored as prose.
+            # Destinations may hold balanced or escaped parens, so the first ) does not end them.
             j, depth = i + 2, 1
             while j < n and depth:
                 char = line[j]
@@ -1180,8 +1166,7 @@ def _visible_len(line: str) -> int:
                 depth += (char == "(") - (char == ")")
                 j += 1
             if depth:
-                # Never balances, so this is not a link a reader would resolve; the bytes show as
-                # text, so count them rather than dropping the prose on the rest of the line.
+                # Never balances, so it is not a link; the bytes show as text, so count them.
                 total += 1
                 i += 1
                 continue

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -99,6 +99,12 @@ def _is_hidden_element(attr_dict: dict) -> bool:
     return _style_hides_element(attr_dict.get("style") or "")
 
 
+def _is_aria_heading(attr_dict: dict) -> bool:
+    """True for an accessible heading (``role="heading"``) built from a plain
+    element, which carries the page title just as an ``h1``-``h6`` does."""
+    return (attr_dict.get("role") or "").strip().lower() == "heading"
+
+
 # HTML5 optional end tags: a listed start tag implicitly closes an open element
 # of the key type (as browsers do), else an unclosed ``<p hidden>``/``<li hidden>``
 # swallows every following sibling. Keys: closable elements; values: closers.
@@ -202,23 +208,14 @@ class _HeaderFrame:
     Buffering (like ``_bq_stack``) defers the decision to ``</header>``, once the
     whole subtree is known. A header no end tag closes is emitted unchanged."""
 
-    __slots__ = (
-        "depth",
-        "parts",
-        "heading_spans",
-        "heading_start",
-        "n_headings",
-        "text_chars",
-        "link_chars",
-    )
+    __slots__ = ("depth", "parts", "heading_parts", "text_chars", "link_chars")
 
     def __init__(self, depth: int):
         self.depth = depth
         self.parts: list[str] = []
-        # Index ranges into parts holding the headings, kept when the rest goes.
-        self.heading_spans: list[tuple[int, int]] = []
-        self.heading_start: int | None = None
-        self.n_headings: int = 0
+        # A copy of the heading output, teed as it is emitted so a heading routed
+        # through a nested blockquote or table cell is still recoverable.
+        self.heading_parts: list[str] = []
         # Both exclude heading text (never dropped, so it must not vote on dropping
         # the rest); only href anchors count as links.
         self.text_chars: int = 0
@@ -228,16 +225,15 @@ class _HeaderFrame:
         """The buffer, or only its headings when the header is link furniture.
 
         Without a matching ``</header>`` the markup is malformed and the header may
-        have adopted the page body, so keep it whole. Same when a span is missing: a
-        heading nested in another buffer only reaches ``parts`` when that one closes."""
-        if not closed_by_own_tag or len(self.heading_spans) != self.n_headings:
+        have adopted the page body, so keep it whole."""
+        if not closed_by_own_tag:
             return "".join(self.parts)
         big_enough = (
             self.text_chars >= _HEADER_MIN_CHARS
             or sum(len(part) for part in self.parts) >= _HEADER_MAX_RENDERED_CHARS
         )
         if big_enough and self.link_chars >= _HEADER_LINK_DENSITY * self.text_chars:
-            return "".join("".join(self.parts[start:end]) for start, end in self.heading_spans)
+            return "".join(self.heading_parts)
         return "".join(self.parts)
 
 
@@ -276,7 +272,9 @@ class _MarkdownRenderer(HTMLParser):
         # Open <header> buffers, innermost last. Empty unless strip_header.
         self._strip_header = strip_header
         self._header_stack: list[_HeaderFrame] = []
-        self._in_heading: bool = False
+        # Open-tag indices of elements acting as headings (h1-h6 or role=heading),
+        # unwound with _hidden_marks so an unclosed one cannot stick.
+        self._heading_marks: list[int] = []
 
         # Link state
         self._link_href: str | None = None
@@ -309,6 +307,8 @@ class _MarkdownRenderer(HTMLParser):
 
     # ------------------------------------------------------------------
     def _emit(self, text: str) -> None:
+        if self._heading_marks and self._header_stack:
+            self._header_stack[-1].heading_parts.append(text)
         if self._in_link:
             self._link_text_parts.append(text)
         elif self._in_cell:
@@ -402,6 +402,8 @@ class _MarkdownRenderer(HTMLParser):
             del self._open_tags[close_at:]
             while self._hidden_marks and self._hidden_marks[-1] >= close_at:
                 self._hidden_marks.pop()
+            while self._heading_marks and self._heading_marks[-1] >= close_at:
+                self._heading_marks.pop()
             self._close_header_frames(close_at)
 
     def _close_header_frames(
@@ -418,7 +420,7 @@ class _MarkdownRenderer(HTMLParser):
                 # Roll the tally outward so an enclosing header is judged whole.
                 self._header_stack[-1].text_chars += frame.text_chars
                 self._header_stack[-1].link_chars += frame.link_chars
-                self._header_stack[-1].n_headings += frame.n_headings
+                self._header_stack[-1].heading_parts.extend(frame.heading_parts)
             self._emit(frame.render(closed_by_own_tag))
             closed_by_own_tag = False
 
@@ -430,7 +432,7 @@ class _MarkdownRenderer(HTMLParser):
     def _count_header_text(self, text: str) -> None:
         """Tally visible text for the innermost header's link density. Heading text
         is skipped so a long linked heading cannot condemn the byline beside it."""
-        if not self._header_stack or self._in_heading:
+        if not self._header_stack or self._heading_marks:
             return
         chars = len(text.strip())
         self._header_stack[-1].text_chars += chars
@@ -446,6 +448,8 @@ class _MarkdownRenderer(HTMLParser):
             self._open_tags.append(tag)
             if _is_hidden_element(attr_dict):
                 self._hidden_marks.append(len(self._open_tags) - 1)
+            if tag in _HEADING_TAGS or _is_aria_heading(attr_dict):
+                self._heading_marks.append(len(self._open_tags) - 1)
             if self._strip_header and tag == "header" and not self._hidden_marks:
                 self._header_stack.append(_HeaderFrame(len(self._open_tags) - 1))
         elif _is_hidden_element(attr_dict):
@@ -480,6 +484,8 @@ class _MarkdownRenderer(HTMLParser):
                     del self._open_tags[i:]
                     while self._hidden_marks and self._hidden_marks[-1] >= i:
                         self._hidden_marks.pop()
+                    while self._heading_marks and self._heading_marks[-1] >= i:
+                        self._heading_marks.pop()
                     self._close_header_frames(i, own_tag = tag == "header")
                     break
         if self._scope_tags is not None and tag in self._scope_tags and self._scope_depth > 0:
@@ -512,10 +518,6 @@ class _MarkdownRenderer(HTMLParser):
             return
 
         if tag in _HEADING_TAGS:
-            self._in_heading = True
-            if self._header_stack and self._header_stack[-1].heading_start is None:
-                self._header_stack[-1].heading_start = len(self._header_stack[-1].parts)
-                self._header_stack[-1].n_headings += 1
             level = int(tag[1])
             self._emit("\n\n" + "#" * level + " ")
 
@@ -610,13 +612,6 @@ class _MarkdownRenderer(HTMLParser):
 
         if tag in _HEADING_TAGS:
             self._emit("\n\n")
-            self._in_heading = False
-            frame = self._header_stack[-1] if self._header_stack else None
-            if frame is not None and frame.heading_start is not None:
-                # An empty span means the heading went into a nested buffer.
-                if len(frame.parts) > frame.heading_start:
-                    frame.heading_spans.append((frame.heading_start, len(frame.parts)))
-                frame.heading_start = None
 
         elif tag == "a":
             if self._header_stack:

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -394,9 +394,12 @@ class _MarkdownRenderer(HTMLParser):
         if frame is not None and as_heading:
             frame.heading_parts.append(text)
             frame.heading_chars += len(text.strip())
-        if frame is not None and not in_nested_link:
+        nested_open = self._nested_buffer_open(frame) if frame is not None else False
+        # Size is tallied once, on the emit that reaches the frame. Counting text
+        # on its way INTO a nested buffer as well as when that buffer flushes its
+        # formatted output doubled it, so a kept header stripped once quoted.
+        if frame is not None and not nested_open:
             frame.rendered_chars += len(text.strip())
-        if frame is not None and not self._nested_buffer_open(frame):
             frame.parts.append(text)
             return
         if self._in_link:
@@ -1085,7 +1088,15 @@ def _is_heading_line(line: str) -> bool:
             i = j + 1
         else:
             break
-    return i < n and line[i] == "#"
+    # ATX rules: 1-6 hashes closed by whitespace or the line end. Without the
+    # closing check "#include" and "#hashtag" read as headings, and this decides
+    # whether a scope has any content, so a C snippet could lose to a teaser.
+    start = i
+    while i < n and line[i] == "#":
+        i += 1
+    if i == start or i - start > 6:
+        return False
+    return i >= n or line[i] in " \t"
 
 
 def _non_heading_chars(text: str) -> int:

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -193,7 +193,11 @@ class _MarkdownRenderer(HTMLParser):
     how the readability-style main-content pass drops page furniture.
     """
 
-    def __init__(self, scope_tags: frozenset[str] | None = None):
+    def __init__(
+        self,
+        scope_tags: frozenset[str] | None = None,
+        strip_header: bool = False,
+    ):
         super().__init__(convert_charrefs = False)
         self._out: list[str] = []
         self._skip_depth: int = 0
@@ -212,6 +216,15 @@ class _MarkdownRenderer(HTMLParser):
         # an omitted </p>/<li> close cannot leave the renderer stuck hidden.
         self._open_tags: list[str] = []
         self._hidden_marks: list[int] = []
+
+        # <header> is furniture apart from the heading it carries, so it cannot
+        # join _SKIP_TAGS. Marks are stack indices, like _hidden_marks.
+        self._strip_header = strip_header
+        self._header_marks: list[int] = []
+        self._header_heading_marks: list[int] = []
+        self._header_prose_total: int = 0
+        self._seg_header_start: int = 0
+        self.scope_header_prose: list[int] = []
 
         # Link state
         self._link_href: str | None = None
@@ -330,6 +343,16 @@ class _MarkdownRenderer(HTMLParser):
             del self._open_tags[close_at:]
             while self._hidden_marks and self._hidden_marks[-1] >= close_at:
                 self._hidden_marks.pop()
+            self._unwind_header_marks(close_at)
+
+    def _unwind_header_marks(self, depth: int) -> None:
+        while self._header_marks and self._header_marks[-1] >= depth:
+            self._header_marks.pop()
+        while self._header_heading_marks and self._header_heading_marks[-1] >= depth:
+            self._header_heading_marks.pop()
+
+    def _header_suppressed(self) -> bool:
+        return bool(self._header_marks) and not self._header_heading_marks
 
     def _enter_tag(self, tag: str, attr_dict: dict) -> bool:
         """Track open/hidden/scope state; return True when the tag's content
@@ -339,24 +362,34 @@ class _MarkdownRenderer(HTMLParser):
             self._open_tags.append(tag)
             if _is_hidden_element(attr_dict):
                 self._hidden_marks.append(len(self._open_tags) - 1)
+            if self._strip_header:
+                if tag == "header":
+                    self._header_marks.append(len(self._open_tags) - 1)
+                elif tag in _HEADING_TAGS and self._header_marks:
+                    self._header_heading_marks.append(len(self._open_tags) - 1)
         elif _is_hidden_element(attr_dict):
             # Void elements never join the stack, so suppress a hidden one inline.
             return False
         if self._scope_tags is not None and tag in self._scope_tags:
             if self._scope_depth == 0:
                 self._scope_seg_start = len(self._out)
+                self._seg_header_start = self._header_prose_total
             self._scope_depth += 1
         if self._hidden_marks:
             return False
         if self._scope_tags is not None and self._scope_depth == 0:
+            return False
+        if self._header_suppressed():
             return False
         return True
 
     def _exit_tag(self, tag: str) -> bool:
         """Pop to the matching open tag; return True when the end tag should
         be rendered (False = it closed inside a hidden / out-of-scope region)."""
-        suppressed = bool(self._hidden_marks) or (
-            self._scope_tags is not None and self._scope_depth == 0
+        suppressed = (
+            bool(self._hidden_marks)
+            or self._header_suppressed()
+            or (self._scope_tags is not None and self._scope_depth == 0)
         )
         if tag not in _VOID_TAGS:
             # Pop to the innermost matching open tag (recovers omitted closes).
@@ -365,11 +398,15 @@ class _MarkdownRenderer(HTMLParser):
                     del self._open_tags[i:]
                     while self._hidden_marks and self._hidden_marks[-1] >= i:
                         self._hidden_marks.pop()
+                    self._unwind_header_marks(i)
                     break
         if self._scope_tags is not None and tag in self._scope_tags and self._scope_depth > 0:
             self._scope_depth -= 1
             if self._scope_depth == 0 and self._scope_seg_start is not None:
                 self.scope_segments.append("".join(self._out[self._scope_seg_start :]))
+                self.scope_header_prose.append(
+                    self._header_prose_total - self._seg_header_start
+                )
                 self._scope_seg_start = None
         return not suppressed
 
@@ -546,12 +583,21 @@ class _MarkdownRenderer(HTMLParser):
     # Text / entity handlers
     # ------------------------------------------------------------------
     def _text_suppressed(self) -> bool:
-        if self._skip_depth or self._hidden_marks:
+        if self._skip_depth or self._hidden_marks or self._header_suppressed():
             return True
         return self._scope_tags is not None and self._scope_depth == 0
 
     def handle_data(self, data: str) -> None:
         if self._text_suppressed():
+            # Only non-anchor prose in scope betrays a swallowed body.
+            if (
+                self._header_suppressed()
+                and not self._skip_depth
+                and not self._hidden_marks
+                and not (self._scope_tags is not None and self._scope_depth == 0)
+                and "a" not in self._open_tags[self._header_marks[0] :]
+            ):
+                self._header_prose_total += len(data.strip())
             return
         if self._in_pre:
             self._pre_parts.append(data)
@@ -714,37 +760,54 @@ def _strip_boilerplate_lines(text: str) -> str:
     return re.sub(r"\n{3,}", "\n\n", "\n".join(out)).strip()
 
 
-def _render(source_html: str, scope_tags: frozenset[str] | None) -> str:
-    renderer = _MarkdownRenderer(scope_tags = scope_tags)
+def _render(
+    source_html: str,
+    scope_tags: frozenset[str] | None,
+    strip_header: bool = False,
+) -> tuple[str, int]:
+    renderer = _MarkdownRenderer(scope_tags = scope_tags, strip_header = strip_header)
     renderer.feed(source_html)
     renderer.close()
     renderer.flush_pending()
     raw = "".join(renderer._out)
-    return _cleanup(raw)
+    return _cleanup(raw), renderer._header_prose_total
 
 
-def _select_main_scope_render(source_html: str, tag: str) -> tuple[int, str]:
-    """Length and boilerplate-stripped render of the largest single ``<tag>``
-    subtree. Sizing candidates one at a time stops many tiny sibling cards from
-    clearing the threshold together, and returning that one subtree keeps
-    unrelated siblings (related cards, comment threads) out of the output."""
-    renderer = _MarkdownRenderer(scope_tags = frozenset({tag}))
+def _select_main_scope_render(
+    source_html: str,
+    tag: str,
+    strip_header: bool = False,
+) -> tuple[int, str, int]:
+    """Length, boilerplate-stripped render, and dropped-prose count of the
+    largest single ``<tag>`` subtree. Sizing candidates one at a time stops many
+    tiny sibling cards from clearing the threshold together, and returning that
+    one subtree keeps unrelated siblings (related cards, comment threads) out."""
+    renderer = _MarkdownRenderer(scope_tags = frozenset({tag}), strip_header = strip_header)
     renderer.feed(source_html)
     renderer.close()
     renderer.flush_pending()
     best_len = 0
     best_render = ""
-    for seg in renderer.scope_segments:
+    best_header_prose = 0
+    header_prose = renderer.scope_header_prose
+    for i, seg in enumerate(renderer.scope_segments):
         rendered = _strip_boilerplate_lines(_cleanup(seg))
         if len(rendered) > best_len:
             best_len = len(rendered)
             best_render = rendered
-    return best_len, best_render
+            best_header_prose = header_prose[i] if i < len(header_prose) else 0
+    return best_len, best_render, best_header_prose
 
 
 # A scoped conversion below this size is judged not to be the page's main
 # content (e.g. an empty <article> stub) and the next candidate is tried.
 _MIN_MAIN_CONTENT_CHARS = 200
+
+# An unclosed <header> adopts the body (as browsers parse it). Size cannot tell
+# that apart from furniture removal, but link density can: a real header holds
+# a title and links, so only non-anchor prose counts as a swallowed body.
+def _header_strip_backfired(kept_chars: int, header_prose_chars: int) -> bool:
+    return header_prose_chars > kept_chars
 
 
 # Public API
@@ -756,7 +819,8 @@ def html_to_markdown(source_html: str, *, main_content: bool = False) -> str:
 
     ``main_content=True`` applies a readability-style heuristic for page
     fetches: prefer the ``<article>`` subtree (GitHub renders READMEs there),
-    then ``<main>``, falling back to the whole document, and strip known
+    then ``<main>``, falling back to the whole document, drop ``<header>``
+    furniture while keeping the heading it carries, and strip known
     boilerplate fragments from the result.
     """
     # Normalize line endings before parsing.
@@ -765,8 +829,16 @@ def html_to_markdown(source_html: str, *, main_content: bool = False) -> str:
         for scope_tag in ("article", "main"):
             # Render only the chosen subtree so sibling <article>/<main>
             # elements do not leak in once the largest passes the size gate.
-            length, rendered = _select_main_scope_render(source_html, scope_tag)
+            length, rendered, header_prose = _select_main_scope_render(
+                source_html, scope_tag, strip_header = True,
+            )
+            if _header_strip_backfired(length, header_prose):
+                length, rendered, _ = _select_main_scope_render(source_html, scope_tag)
             if length >= _MIN_MAIN_CONTENT_CHARS:
                 return rendered
-        return _strip_boilerplate_lines(_render(source_html, None))
-    return _render(source_html, None)
+        rendered, header_prose = _render(source_html, None, strip_header = True)
+        rendered = _strip_boilerplate_lines(rendered)
+        if _header_strip_backfired(len(rendered), header_prose):
+            rendered = _strip_boilerplate_lines(_render(source_html, None)[0])
+        return rendered
+    return _render(source_html, None)[0]

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -224,11 +224,19 @@ class _HeaderFrame:
         "outer_link_seq",
         "outer_cell_seq",
         "outer_in_pre",
+        "outer_in_code",
         "outer_bq_depth",
     )
 
     def __init__(
-        self, depth: int, link_seq: int, cell_seq: int, in_pre: bool, bq_depth: int, list_depth: int
+        self,
+        depth: int,
+        link_seq: int,
+        cell_seq: int,
+        in_pre: bool,
+        in_code: bool,
+        bq_depth: int,
+        list_depth: int,
     ):
         self.depth = depth
         self.parts: list[str] = []
@@ -247,6 +255,7 @@ class _HeaderFrame:
         self.outer_link_seq = link_seq
         self.outer_cell_seq = cell_seq
         self.outer_in_pre = in_pre
+        self.outer_in_code = in_code
         self.outer_bq_depth = bq_depth
         # Both exclude heading text (never dropped, so it must not vote on dropping
         # the rest); only href anchors count as links.
@@ -531,7 +540,9 @@ class _MarkdownRenderer(HTMLParser):
             # its text is link furniture even though no </a> arrived.
             frame.link_chars += self._link_header_chars
             self._finish_link()
-        if self._in_inline_code:
+        # Inline code opened OUTSIDE the header is the page's, not the frame's:
+        # closing it here leaves the real </code> to emit an unpaired backtick.
+        if self._in_inline_code and not frame.outer_in_code:
             self._in_inline_code = False
             self._emit("`")
         if self._in_cell and self._cell_seq != frame.outer_cell_seq:
@@ -600,6 +611,7 @@ class _MarkdownRenderer(HTMLParser):
                         self._link_seq if self._in_link else -1,
                         self._cell_seq if self._in_cell else -1,
                         self._in_pre,
+                        self._in_inline_code,
                         len(self._bq_stack),
                         len(self._list_stack),
                     )
@@ -1035,27 +1047,23 @@ def _select_main_scope_render(source_html: str, tag: str) -> tuple[int, str]:
     clearing the threshold together, and returning that one subtree keeps
     unrelated siblings (related cards, comment threads) out of the output.
 
-    Candidates are sized with their dropped header furniture added back, so the
-    strip never costs an article the size gate or a sibling comparison. A
-    candidate that retained nothing is all furniture, and gets no such credit."""
+    A candidate earns its place on the prose it RETAINED, then gets its dropped
+    header furniture added back to rank against siblings. Furniture must not buy
+    eligibility: a card whose header was the only bulk would otherwise clear the
+    gate on deleted bytes and suppress the ``<main>`` holding the real page."""
     renderer = _new_renderer(source_html, frozenset({tag}), strip_header = True)
     dropped = renderer.scope_dropped
     best_len = 0
     best_render = ""
     for i, seg in enumerate(renderer.scope_segments):
         rendered = _strip_boilerplate_lines(_cleanup(seg))
-        credit = dropped[i] if _non_heading_chars(rendered) >= _MIN_RETAINED_CHARS else 0
-        size = len(rendered) + credit
+        if _non_heading_chars(rendered) < _MIN_MAIN_CONTENT_CHARS:
+            continue
+        size = len(rendered) + dropped[i]
         if size > best_len:
             best_len = size
             best_render = rendered
     return best_len, best_render
-
-
-# Removed furniture only counts toward a candidate's size once the candidate
-# retained this much prose OUTSIDE its headings, so neither an empty scope nor a
-# stub carrying one long title can qualify on what was deleted from it.
-_MIN_RETAINED_CHARS = 50
 
 
 def _is_heading_line(line: str) -> bool:

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -200,6 +200,11 @@ _HEADER_MIN_CHARS = 150
 _HEADER_MAX_RENDERED_CHARS = 800
 
 
+# Real pages nest headers one or two deep. Past this they are left as ordinary
+# content, so closing a frame can never copy an unbounded chain of ancestors.
+_MAX_HEADER_NESTING = 8
+
+
 class _HeaderFrame:
     """Buffered ``<header>`` output plus the link tally used to judge it.
 
@@ -300,6 +305,9 @@ class _MarkdownRenderer(HTMLParser):
         # where a hidden element started. End tags pop to the matching tag, so
         # an omitted </p>/<li> close cannot leave the renderer stuck hidden.
         self._open_tags: list[str] = []
+        # How many open tags can be closed implicitly. Zero means _close_implicit
+        # has nothing to find, so it can skip scanning the stack entirely.
+        self._closable_open: int = 0
         self._hidden_marks: list[int] = []
 
         # Open <header> buffers, innermost last. Empty unless strip_header.
@@ -377,7 +385,7 @@ class _MarkdownRenderer(HTMLParser):
         if frame is not None and as_heading:
             frame.heading_parts.append(text)
             frame.heading_chars += len(text.strip())
-        if frame is not None:
+        if frame is not None and not in_nested_link:
             frame.rendered_chars += len(text.strip())
         if frame is not None and not self._nested_buffer_open(frame):
             frame.parts.append(text)
@@ -453,6 +461,13 @@ class _MarkdownRenderer(HTMLParser):
     # Tag handlers
     # ------------------------------------------------------------------
     # Structural bookkeeping shared by every start tag (skip/hidden/scope).
+    def _truncate_open_tags(self, index: int) -> None:
+        """Drop the open-tag stack above *index*, keeping the closable count."""
+        for name in self._open_tags[index:]:
+            if name in _IMPLICIT_CLOSERS:
+                self._closable_open -= 1
+        del self._open_tags[index:]
+
     def _close_implicit(self, tag: str) -> None:
         """HTML5 optional-end-tag recovery for a start tag about to open.
 
@@ -461,6 +476,8 @@ class _MarkdownRenderer(HTMLParser):
         ``<span>``. Stops at a ``_CLOSE_BARRIERS`` container so recovery never crosses
         a nested list/table/dl and leaks the outer item's hidden content. Runs even
         for skipped ``<nav>``/``<footer>``, which also close ``<p>``."""
+        if not self._closable_open:
+            return
         barriers = _CLOSE_BARRIERS.get(tag, ())
         while True:
             close_at = None
@@ -474,7 +491,7 @@ class _MarkdownRenderer(HTMLParser):
                     break
             if close_at is None:
                 break
-            del self._open_tags[close_at:]
+            self._truncate_open_tags(close_at)
             while self._hidden_marks and self._hidden_marks[-1] >= close_at:
                 self._hidden_marks.pop()
             while self._heading_marks and self._heading_marks[-1] >= close_at:
@@ -563,13 +580,20 @@ class _MarkdownRenderer(HTMLParser):
         first so recovery also fires for skipped tags."""
         if tag not in _VOID_TAGS:
             self._open_tags.append(tag)
+            if tag in _IMPLICIT_CLOSERS:
+                self._closable_open += 1
             if _is_hidden_element(attr_dict):
                 self._hidden_marks.append(len(self._open_tags) - 1)
             if tag in _HEADING_TAGS or tag == "hgroup" or _is_aria_heading(attr_dict):
                 self._heading_marks.append(len(self._open_tags) - 1)
                 if self._in_link:
                     self._link_had_heading = True
-            if self._strip_header and tag == "header" and not self._hidden_marks:
+            if (
+                self._strip_header
+                and tag == "header"
+                and not self._hidden_marks
+                and len(self._header_stack) < _MAX_HEADER_NESTING
+            ):
                 self._header_stack.append(
                     _HeaderFrame(
                         len(self._open_tags) - 1,
@@ -615,7 +639,7 @@ class _MarkdownRenderer(HTMLParser):
             # Pop to the innermost matching open tag (recovers omitted closes).
             for i in range(len(self._open_tags) - 1, -1, -1):
                 if self._open_tags[i] == tag:
-                    del self._open_tags[i:]
+                    self._truncate_open_tags(i)
                     while self._hidden_marks and self._hidden_marks[-1] >= i:
                         self._hidden_marks.pop()
                     while self._heading_marks and self._heading_marks[-1] >= i:
@@ -1034,15 +1058,40 @@ def _select_main_scope_render(source_html: str, tag: str) -> tuple[int, str]:
 _MIN_RETAINED_CHARS = 50
 
 
-_HEADING_LINE = re.compile(r"^(?:\s*(?:[>*+-]|\d+\.)\s*)*#")
+def _is_heading_line(line: str) -> bool:
+    """True when *line* is a heading, allowing blockquote and list prefixes.
+
+    Scanned rather than matched with a regex: nested prefixes make adjacent
+    whitespace patterns backtrack catastrophically on ``> > > prose``."""
+    i, n = 0, len(line)
+    while i < n:
+        char = line[i]
+        if char in " \t>*+-":
+            i += 1
+        elif char.isdigit():
+            j = i
+            while j < n and line[j].isdigit():
+                j += 1
+            if j >= n or line[j] != ".":
+                return False
+            i = j + 1
+        else:
+            break
+    return i < n and line[i] == "#"
 
 
 def _non_heading_chars(text: str) -> int:
     """Length of *text* ignoring blanks and heading lines, including headings
-    behind blockquote or list prefixes (``> # Title``)."""
-    return sum(
-        len(line) for line in text.split("\n") if line.strip() and not _HEADING_LINE.match(line)
-    )
+    behind blockquote or list prefixes (``> # Title``). Fenced code counts in
+    full: a ``#`` there is a comment, not a heading."""
+    total, in_fence = 0, False
+    for line in text.split("\n"):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if line.strip() and (in_fence or not _is_heading_line(line)):
+            total += len(line)
+    return total
 
 
 # A scoped conversion below this size is judged not to be the page's main

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -100,8 +100,13 @@ def _is_hidden_element(attr_dict: dict) -> bool:
 
 
 def _is_aria_heading(attr_dict: dict) -> bool:
-    """True for ``role="heading"``, which titles a page just as ``h1``-``h6`` does."""
-    return (attr_dict.get("role") or "").strip().lower() == "heading"
+    """True for ``role="heading"``, which titles a page just as ``h1``-``h6`` does.
+
+    ``role`` is a token list authors use for fallbacks (``role="future-role
+    heading"``), so any token counts. WAI-ARIA takes the first token naming a
+    real role, which would need the whole role table; matching anywhere is the
+    safe direction, since keeping a stray title beats dropping a real one."""
+    return "heading" in (attr_dict.get("role") or "").lower().split()
 
 
 # HTML5 optional end tags: a listed start tag implicitly closes an open element
@@ -540,6 +545,9 @@ class _MarkdownRenderer(HTMLParser):
         if self._in_pre and not frame.outer_in_pre:
             raw = "".join(self._pre_parts)
             self._in_pre = False
+            # Drained, not just closed: a late </pre> would otherwise replay the
+            # block outside the stripped header and push the article past the cap.
+            self._pre_parts = []
             self._emit("\n\n```\n" + raw + "\n```\n\n")
         while len(self._bq_stack) > frame.outer_bq_depth:
             prefixed = self._prefix_blockquote("".join(self._bq_stack.pop()))
@@ -802,9 +810,10 @@ class _MarkdownRenderer(HTMLParser):
                     self._ol_counter.pop()
             self._emit("\n")
 
-        elif tag == "pre":
+        elif tag == "pre" and self._in_pre:
             raw = "".join(self._pre_parts)
             self._in_pre = False
+            self._pre_parts = []
             block = "```\n" + raw + "\n```"
             self._emit("\n\n" + block + "\n\n")
 
@@ -1090,7 +1099,24 @@ def _non_heading_chars(text: str) -> int:
             in_fence = not in_fence
             continue
         if line.strip() and (in_fence or not _is_heading_line(line)):
-            total += len(line)
+            total += len(line) if in_fence else _visible_len(line)
+    return total
+
+
+def _visible_len(line: str) -> int:
+    """Length of *line* without Markdown link destinations. A tracking URL is not
+    prose: a card holding one [Read](/x?<300 bytes>) otherwise scored 339 visible
+    characters off 4 and displaced the article. Scanned, so no backtracking."""
+    total, i, n = 0, 0, len(line)
+    while i < n:
+        if line[i] == "]" and i + 1 < n and line[i + 1] == "(":
+            end = line.find(")", i + 2)
+            if end == -1:
+                break
+            i = end + 1
+            continue
+        total += 1
+        i += 1
     return total
 
 

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -212,20 +212,21 @@ class _HeaderFrame:
         "heading_parts",
         "text_chars",
         "link_chars",
-        "outer_in_link",
+        "outer_link_seq",
         "outer_cell_seq",
         "outer_in_pre",
         "outer_bq_depth",
     )
 
-    def __init__(self, depth: int, in_link: bool, cell_seq: int, in_pre: bool, bq_depth: int):
+    def __init__(self, depth: int, link_seq: int, cell_seq: int, in_pre: bool, bq_depth: int):
         self.depth = depth
         self.parts: list[str] = []
         # Heading output, teed so a heading routed through a nested buffer survives.
         self.heading_parts: list[str] = []
         # Side buffers open at this point enclose the frame; later ones are nested.
-        # The cell is held by sequence number, so a nested table's cells differ.
-        self.outer_in_link = in_link
+        # Links and cells are held by sequence number, not a flag: an inner one
+        # replaces the outer in the renderer's single slot, so identity is needed.
+        self.outer_link_seq = link_seq
         self.outer_cell_seq = cell_seq
         self.outer_in_pre = in_pre
         self.outer_bq_depth = bq_depth
@@ -299,6 +300,7 @@ class _MarkdownRenderer(HTMLParser):
         self._link_href: str | None = None
         self._link_text_parts: list[str] = []
         self._in_link: bool = False
+        self._link_seq: int = 0
         # Text under the open <a>, credited only at </a>: an <a> left open adopts
         # body prose, which is not furniture.
         self._link_header_chars: int = 0
@@ -331,19 +333,27 @@ class _MarkdownRenderer(HTMLParser):
 
         Such a buffer emits into the frame when it closes; an enclosing one
         (already open at ``<header>``) must not capture it."""
-        return (
-            (self._in_link and not frame.outer_in_link)
-            or (self._in_cell and self._cell_seq != frame.outer_cell_seq)
-            or (self._in_pre and not frame.outer_in_pre)
-            or len(self._bq_stack) > frame.outer_bq_depth
-        )
+        # Only the buffer _emit would actually pick matters, and in its order: a
+        # blockquote inside a cell-enclosed header still routes to the cell, so
+        # OR-ing across all of them would wrongly call that nested.
+        if self._in_link:
+            return self._link_seq != frame.outer_link_seq
+        if self._in_cell:
+            return self._cell_seq != frame.outer_cell_seq
+        if self._in_pre:
+            return not frame.outer_in_pre
+        return len(self._bq_stack) > frame.outer_bq_depth
 
     def _emit(self, text: str) -> None:
         frame = self._header_stack[-1] if self._header_stack else None
         # Tee wherever the text is routed, so a heading inside a nested buffer is
-        # captured. Link text arrives twice (raw, then formatted by _finish_link with
-        # _in_link cleared), so the _in_link guard tees only the formatted form.
-        if frame is not None and self._heading_marks and not self._in_link:
+        # captured. A link opened inside the frame delivers its text twice (raw,
+        # then formatted by _finish_link), so only the formatted form is teed; a
+        # link that encloses the frame never re-delivers, so it is teed as it comes.
+        in_nested_link = (
+            self._in_link and self._link_seq != frame.outer_link_seq if frame else False
+        )
+        if frame is not None and self._heading_marks and not in_nested_link:
             frame.heading_parts.append(text)
         if frame is not None and not self._nested_buffer_open(frame):
             frame.parts.append(text)
@@ -470,7 +480,7 @@ class _MarkdownRenderer(HTMLParser):
 
         Their content is the header's, so it has to land in the frame before the
         strip is judged; otherwise it is emitted afterwards and escapes."""
-        if self._in_link and not frame.outer_in_link:
+        if self._in_link and self._link_seq != frame.outer_link_seq:
             self._finish_link()
         if self._in_inline_code:
             self._in_inline_code = False
@@ -518,7 +528,7 @@ class _MarkdownRenderer(HTMLParser):
                 self._header_stack.append(
                     _HeaderFrame(
                         len(self._open_tags) - 1,
-                        self._in_link,
+                        self._link_seq if self._in_link else -1,
                         self._cell_seq if self._in_cell else -1,
                         self._in_pre,
                         len(self._bq_stack),
@@ -604,6 +614,7 @@ class _MarkdownRenderer(HTMLParser):
             self._link_href = attr_dict.get("href")
             self._link_text_parts = []
             self._in_link = True
+            self._link_seq += 1
             self._link_header_chars = 0
 
         elif tag in _INLINE_EMPHASIS:

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -223,6 +223,7 @@ class _MarkdownRenderer(HTMLParser):
         self._header_marks: list[int] = []
         self._header_heading_marks: list[int] = []
         self._header_prose_total: int = 0
+        self._open_header_prose: int = 0
         self._seg_header_start: int = 0
         self.scope_header_prose: list[int] = []
 
@@ -345,7 +346,16 @@ class _MarkdownRenderer(HTMLParser):
                 self._hidden_marks.pop()
             self._unwind_header_marks(close_at)
 
-    def _unwind_header_marks(self, depth: int) -> None:
+    def _unwind_header_marks(
+        self,
+        depth: int,
+        closed_header: bool = False,
+    ) -> None:
+        if self._header_marks and self._header_marks[0] >= depth:
+            # A matching </header> proves it never adopted the body: refund.
+            if closed_header:
+                self._header_prose_total -= self._open_header_prose
+            self._open_header_prose = 0
         while self._header_marks and self._header_marks[-1] >= depth:
             self._header_marks.pop()
         while self._header_heading_marks and self._header_heading_marks[-1] >= depth:
@@ -398,7 +408,7 @@ class _MarkdownRenderer(HTMLParser):
                     del self._open_tags[i:]
                     while self._hidden_marks and self._hidden_marks[-1] >= i:
                         self._hidden_marks.pop()
-                    self._unwind_header_marks(i)
+                    self._unwind_header_marks(i, closed_header = tag == "header")
                     break
         if self._scope_tags is not None and tag in self._scope_tags and self._scope_depth > 0:
             self._scope_depth -= 1
@@ -595,7 +605,9 @@ class _MarkdownRenderer(HTMLParser):
                 and not (self._scope_tags is not None and self._scope_depth == 0)
                 and "a" not in self._open_tags[self._header_marks[0] :]
             ):
-                self._header_prose_total += len(data.strip())
+                dropped = len(data.strip())
+                self._header_prose_total += dropped
+                self._open_header_prose += dropped
             return
         if self._in_pre:
             self._pre_parts.append(data)
@@ -657,6 +669,7 @@ class _MarkdownRenderer(HTMLParser):
         # here (after the side-buffers) so a truncated main-content page is scored.
         if self._scope_seg_start is not None:
             self.scope_segments.append("".join(self._out[self._scope_seg_start :]))
+            self.scope_header_prose.append(self._header_prose_total - self._seg_header_start)
             self._scope_seg_start = None
             self._scope_depth = 0
 
@@ -771,42 +784,53 @@ def _render(
     return _cleanup(raw), renderer._header_prose_total
 
 
-def _select_main_scope_render(
-    source_html: str,
-    tag: str,
-    strip_header: bool = False,
-) -> tuple[int, str, int]:
-    """Length, boilerplate-stripped render, and dropped-prose count of the
-    largest single ``<tag>`` subtree. Sizing candidates one at a time stops many
-    tiny sibling cards from clearing the threshold together, and returning that
-    one subtree keeps unrelated siblings (related cards, comment threads) out."""
+# An unclosed <header> adopts the body (as browsers parse it). Size cannot tell
+# that apart from furniture removal, but link density can: a real header holds
+# a title and links, so only non-anchor prose from a header that no </header>
+# ever closed counts as a swallowed body.
+def _header_strip_backfired(kept_chars: int, header_prose_chars: int) -> bool:
+    return header_prose_chars > kept_chars
+
+
+def _scope_segments(source_html: str, tag: str, strip_header: bool) -> tuple[list[str], list[int]]:
     renderer = _MarkdownRenderer(scope_tags = frozenset({tag}), strip_header = strip_header)
     renderer.feed(source_html)
     renderer.close()
     renderer.flush_pending()
+    return renderer.scope_segments, renderer.scope_header_prose
+
+
+def _select_main_scope_render(source_html: str, tag: str) -> tuple[int, str]:
+    """Length and boilerplate-stripped render of the largest single ``<tag>``
+    subtree. Sizing candidates one at a time stops many tiny sibling cards from
+    clearing the threshold together, and returning that one subtree keeps
+    unrelated siblings (related cards, comment threads) out of the output.
+
+    Header stripping is judged per candidate, before the sizing comparison, so
+    an article whose body an unclosed ``<header>`` swallowed is restored to its
+    real size instead of losing the comparison to a sibling card."""
+    segments, header_prose = _scope_segments(source_html, tag, strip_header = True)
+    unstripped: list[str] | None = None
     best_len = 0
     best_render = ""
-    best_header_prose = 0
-    header_prose = renderer.scope_header_prose
-    for i, seg in enumerate(renderer.scope_segments):
+    for i, seg in enumerate(segments):
         rendered = _strip_boilerplate_lines(_cleanup(seg))
+        dropped = header_prose[i] if i < len(header_prose) else 0
+        if _header_strip_backfired(len(rendered), dropped):
+            if unstripped is None:
+                # Scope bookkeeping ignores header state, so the indices line up.
+                unstripped = _scope_segments(source_html, tag, strip_header = False)[0]
+            if i < len(unstripped):
+                rendered = _strip_boilerplate_lines(_cleanup(unstripped[i]))
         if len(rendered) > best_len:
             best_len = len(rendered)
             best_render = rendered
-            best_header_prose = header_prose[i] if i < len(header_prose) else 0
-    return best_len, best_render, best_header_prose
+    return best_len, best_render
 
 
 # A scoped conversion below this size is judged not to be the page's main
 # content (e.g. an empty <article> stub) and the next candidate is tried.
 _MIN_MAIN_CONTENT_CHARS = 200
-
-
-# An unclosed <header> adopts the body (as browsers parse it). Size cannot tell
-# that apart from furniture removal, but link density can: a real header holds
-# a title and links, so only non-anchor prose counts as a swallowed body.
-def _header_strip_backfired(kept_chars: int, header_prose_chars: int) -> bool:
-    return header_prose_chars > kept_chars
 
 
 # Public API
@@ -828,13 +852,7 @@ def html_to_markdown(source_html: str, *, main_content: bool = False) -> str:
         for scope_tag in ("article", "main"):
             # Render only the chosen subtree so sibling <article>/<main>
             # elements do not leak in once the largest passes the size gate.
-            length, rendered, header_prose = _select_main_scope_render(
-                source_html,
-                scope_tag,
-                strip_header = True,
-            )
-            if _header_strip_backfired(length, header_prose):
-                length, rendered, _ = _select_main_scope_render(source_html, scope_tag)
+            length, rendered = _select_main_scope_render(source_html, scope_tag)
             if length >= _MIN_MAIN_CONTENT_CHARS:
                 return rendered
         rendered, header_prose = _render(source_html, None, strip_header = True)

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -320,6 +320,10 @@ class _MarkdownRenderer(HTMLParser):
         self._dropped_chars: int = 0
         self._seg_dropped_start: int = 0
         self.scope_dropped: list[int] = []
+        # Heading text per segment: role="heading", <hgroup> and linked <h1> render
+        # as ordinary prose, so ATX reparsing alone cannot keep them out of the gate.
+        self._seg_heading_texts: list[str] = []
+        self.scope_heading_prose: list[int] = []
         # Open-tag indices of headings, unwound with _hidden_marks.
         self._heading_marks: list[int] = []
 
@@ -331,6 +335,7 @@ class _MarkdownRenderer(HTMLParser):
         # A link wrapping a heading emits after the heading mark is gone, so the
         # tee is told to treat that one emit as heading output.
         self._link_had_heading: bool = False
+        self._link_heading_parts: list[str] = []
         self._emit_as_heading: bool = False
         self._replaying: bool = False
         # Text under the open <a>, credited only at </a>: an <a> left open adopts
@@ -392,6 +397,12 @@ class _MarkdownRenderer(HTMLParser):
         if frame is not None and as_heading:
             frame.heading_parts.append(text)
             frame.heading_chars += len(text.strip())
+        # Tallied for the eligibility gate, independent of any header frame. Text
+        # inside a link waits for _finish_link so the formatted form counts once.
+        if not self._replaying and (
+            (self._heading_marks and not self._in_link) or self._emit_as_heading
+        ):
+            self._seg_heading_texts.append(text)
         nested_open = self._nested_buffer_open(frame) if frame is not None else False
         # Tally once, on the emit that reaches the frame: counting text going INTO a nested buffer
         # and again when that buffer flushes doubled it, so a kept header stripped once quoted.
@@ -401,6 +412,8 @@ class _MarkdownRenderer(HTMLParser):
             return
         if self._in_link:
             self._link_text_parts.append(text)
+            if self._heading_marks:
+                self._link_heading_parts.append(text)
         elif self._in_cell:
             self._cell_parts.append(text)
         elif self._in_pre:
@@ -411,6 +424,11 @@ class _MarkdownRenderer(HTMLParser):
             self._out.append(text)
 
     # ------------------------------------------------------------------
+    def _seg_heading_prose(self) -> int:
+        """Heading characters in this segment that the gate would otherwise read as
+        body prose. ATX headings carry their own ``#`` here and so score zero."""
+        return _non_heading_chars("".join(self._seg_heading_texts))
+
     def _emit_replay(self, text: str) -> None:
         """Emit a flushed buffer's own output, which must not be teed as a heading
         a second time (the raw text was teed when it entered the buffer)."""
@@ -462,10 +480,15 @@ class _MarkdownRenderer(HTMLParser):
     # Link text helper: normalize whitespace so block content in <a> stays single-line.
     def _finish_link(self) -> None:
         text = re.sub(r"\s+", " ", "".join(self._link_text_parts)).strip()
+        heading_text = re.sub(r"\s+", " ", "".join(self._link_heading_parts)).strip()
         href = self._link_href or ""
         self._in_link = False
         self._link_text_parts = []
-        self._emit_as_heading = self._link_had_heading
+        self._link_heading_parts = []
+        # An anchor wrapping a heading AND other content is furniture carrying a
+        # title: tee the title alone, or the whole nav rides out as a heading.
+        partial = bool(heading_text) and heading_text != text
+        self._emit_as_heading = self._link_had_heading and not partial
         self._link_had_heading = False
         # Recovery paths reach here without </a>, so drop the uncredited tally.
         self._link_header_chars = 0
@@ -474,6 +497,10 @@ class _MarkdownRenderer(HTMLParser):
         elif text:
             self._emit(text)
         self._emit_as_heading = False
+        if partial and self._header_stack:
+            frame = self._header_stack[-1]
+            frame.heading_parts.append(heading_text + "\n\n")
+            frame.heading_chars += len(heading_text)
 
     # ------------------------------------------------------------------
     # Tag handlers
@@ -636,6 +663,7 @@ class _MarkdownRenderer(HTMLParser):
             if self._scope_depth == 0:
                 self._scope_seg_start = len(self._out)
                 self._seg_dropped_start = self._dropped_chars
+                self._seg_heading_texts = []
             self._scope_depth += 1
         if self._hidden_marks:
             return False
@@ -672,6 +700,7 @@ class _MarkdownRenderer(HTMLParser):
             if self._scope_depth == 0 and self._scope_seg_start is not None:
                 self.scope_segments.append("".join(self._out[self._scope_seg_start :]))
                 self.scope_dropped.append(self._dropped_chars - self._seg_dropped_start)
+                self.scope_heading_prose.append(self._seg_heading_prose())
                 self._scope_seg_start = None
         return not suppressed
 
@@ -704,6 +733,7 @@ class _MarkdownRenderer(HTMLParser):
         elif tag == "a":
             self._link_href = attr_dict.get("href")
             self._link_text_parts = []
+            self._link_heading_parts = []
             self._in_link = True
             self._link_seq += 1
             self._link_header_chars = 0
@@ -939,6 +969,7 @@ class _MarkdownRenderer(HTMLParser):
         if self._scope_seg_start is not None:
             self.scope_segments.append("".join(self._out[self._scope_seg_start :]))
             self.scope_dropped.append(self._dropped_chars - self._seg_dropped_start)
+            self.scope_heading_prose.append(self._seg_heading_prose())
             self._scope_seg_start = None
             self._scope_depth = 0
 
@@ -948,18 +979,19 @@ def _cleanup(text: str) -> str:
     """Normalize whitespace and blank lines, preserving fenced code blocks verbatim."""
     lines = text.split("\n")
     out: list[str] = []
-    in_fence = False
+    fence = 0
     blank_run = 0
 
     for line in lines:
         stripped = line.rstrip(" \t")
-        if stripped.startswith("```"):
-            in_fence = not in_fence
+        moved = _fence_state(stripped, fence)
+        if moved != fence:
+            fence = moved
             blank_run = 0
             out.append(stripped)
             continue
 
-        if in_fence:
+        if fence:
             out.append(line)
             continue
 
@@ -1021,19 +1053,32 @@ def _line_is_boilerplate(line: str) -> bool:
     return bool(segments) and all(segment in _BOILERPLATE_NORMALIZED for segment in segments)
 
 
+def _fence_state(line: str, fence: int) -> int:
+    """Fence width after *line*, 0 outside a block. Every pass over rendered text
+    must agree with ``_fence_for``: a block opened with a longer fence is closed
+    only by a run at least as long, so a literal ``` inside it is content."""
+    stripped = line.strip()
+    if len(stripped) < 3 or stripped.count("`") != len(stripped):
+        return fence
+    if not fence:
+        return len(stripped)
+    return 0 if len(stripped) >= fence else fence
+
+
 def _strip_boilerplate_lines(text: str) -> str:
     """Drop short lines that consist entirely of known page-furniture phrases.
 
     Fenced code blocks are preserved verbatim: boilerplate never renders
     inside ``<pre>``, while READMEs legitimately quote error strings."""
     out: list[str] = []
-    in_fence = False
+    fence = 0
     for line in text.split("\n"):
-        if line.lstrip().startswith("```"):
-            in_fence = not in_fence
+        moved = _fence_state(line, fence)
+        if moved != fence:
+            fence = moved
             out.append(line)
             continue
-        if not in_fence and len(line) <= _BOILERPLATE_MAX_LINE_CHARS and _line_is_boilerplate(line):
+        if not fence and len(line) <= _BOILERPLATE_MAX_LINE_CHARS and _line_is_boilerplate(line):
             continue
         out.append(line)
     # Collapse blank runs the dropped lines may have left behind.
@@ -1070,11 +1115,13 @@ def _select_main_scope_render(source_html: str, tag: str) -> tuple[int, str]:
     gate on deleted bytes and suppress the ``<main>`` holding the real page."""
     renderer = _new_renderer(source_html, frozenset({tag}), strip_header = True)
     dropped = renderer.scope_dropped
+    heading_prose = renderer.scope_heading_prose
     best_len = 0
     best_render = ""
     for i, seg in enumerate(renderer.scope_segments):
         rendered = _strip_boilerplate_lines(_cleanup(seg))
-        if _non_heading_chars(rendered) < _MIN_MAIN_CONTENT_CHARS:
+        prose = _non_heading_chars(rendered) - heading_prose[i]
+        if prose < _MIN_MAIN_CONTENT_CHARS:
             continue
         size = len(rendered) + dropped[i]
         if size > best_len:
@@ -1119,15 +1166,10 @@ def _non_heading_chars(text: str) -> int:
     total, fence = 0, 0
     for line in text.split("\n"):
         stripped = line.strip()
-        # Only a run of backticks at least as long as the opener closes the block,
-        # so a literal ``` line in the code cannot end it early.
-        if len(stripped) >= 3 and stripped.count("`") == len(stripped):
-            if not fence:
-                fence = len(stripped)
-                continue
-            if len(stripped) >= fence:
-                fence = 0
-                continue
+        moved = _fence_state(line, fence)
+        if moved != fence:
+            fence = moved
+            continue
         if stripped and (fence or not _is_heading_line(line)):
             total += len(line) if fence else _visible_len(line)
     return total
@@ -1161,7 +1203,12 @@ def _visible_len(line: str) -> int:
                 depth += (char == "(") - (char == ")")
                 j += 1
             if depth:
-                break
+                # Never balances, so this is not a link any reader would resolve;
+                # the bytes show as text. Count them rather than dropping the
+                # prose that follows on the same line.
+                total += 1
+                i += 1
+                continue
             i = j
             continue
         total += 1

--- a/studio/backend/core/inference/_html_to_md.py
+++ b/studio/backend/core/inference/_html_to_md.py
@@ -100,8 +100,7 @@ def _is_hidden_element(attr_dict: dict) -> bool:
 
 
 def _is_aria_heading(attr_dict: dict) -> bool:
-    """True for an accessible heading (``role="heading"``) built from a plain
-    element, which carries the page title just as an ``h1``-``h6`` does."""
+    """True for ``role="heading"``, which titles a page just as ``h1``-``h6`` does."""
     return (attr_dict.get("role") or "").strip().lower() == "heading"
 
 
@@ -190,14 +189,13 @@ _BLOCK_TAGS = frozenset(
 _HEADING_TAGS = frozenset({"h1", "h2", "h3", "h4", "h5", "h6"})
 _INLINE_EMPHASIS = {"strong": "**", "b": "**", "em": "*", "i": "*"}
 
-# A <header> is furniture only when almost entirely links (site nav, Wikipedia's
-# in-<main> language dropdown). Live link lists measure 0.94-1.00, content headers
-# (byline, date, standfirst) 0.13-0.90.
+# A <header> is furniture only when almost all links (nav, Wikipedia's language
+# dropdown): live link lists measure 0.94-1.00, content headers 0.13-0.90.
 _HEADER_LINK_DENSITY = 0.93
-# Size floor: below it the ratio is too noisy and the header too small to displace an
-# article. Live link lists start at 182 chars, link-dense content headers top out at 93.
+# Below this the ratio is too noisy: live link lists start at 182 chars, link-dense
+# content headers top out at 93.
 _HEADER_MIN_CHARS = 150
-# Short labels can carry huge hrefs, so judge rendered size too. Live content headers
+# Short labels can carry huge hrefs, so judge rendered size too: content headers
 # render to at most 363 chars, link lists to 1609 and up.
 _HEADER_MAX_RENDERED_CHARS = 800
 
@@ -222,11 +220,9 @@ class _HeaderFrame:
     def __init__(self, depth: int, in_cell: bool, in_pre: bool, bq_depth: int):
         self.depth = depth
         self.parts: list[str] = []
-        # A copy of the heading output, teed as it is emitted so a heading routed
-        # through a nested blockquote or table cell is still recoverable.
+        # Heading output, teed so a heading routed through a nested buffer survives.
         self.heading_parts: list[str] = []
-        # Side buffers already open here are ancestors, so their content belongs
-        # to this frame; ones opened later are nested and buffer normally.
+        # Side buffers open at this point enclose the frame; later ones are nested.
         self.outer_in_cell = in_cell
         self.outer_in_pre = in_pre
         self.outer_bq_depth = bq_depth
@@ -238,8 +234,8 @@ class _HeaderFrame:
     def render(self, closed_by_own_tag: bool) -> str:
         """The buffer, or only its headings when the header is link furniture.
 
-        Without a matching ``</header>`` the markup is malformed and the header may
-        have adopted the page body, so keep it whole."""
+        Without a matching ``</header>`` the header may have adopted the page
+        body, so keep it whole."""
         if not closed_by_own_tag:
             return "".join(self.parts)
         big_enough = (
@@ -290,16 +286,15 @@ class _MarkdownRenderer(HTMLParser):
         self._dropped_chars: int = 0
         self._seg_dropped_start: int = 0
         self.scope_dropped: list[int] = []
-        # Open-tag indices of elements acting as headings (h1-h6 or role=heading),
-        # unwound with _hidden_marks so an unclosed one cannot stick.
+        # Open-tag indices of headings, unwound with _hidden_marks.
         self._heading_marks: list[int] = []
 
         # Link state
         self._link_href: str | None = None
         self._link_text_parts: list[str] = []
         self._in_link: bool = False
-        # Text under the open <a>, credited as links only once </a> closes it: an
-        # <a> left open adopts body prose, which is not furniture.
+        # Text under the open <a>, credited only at </a>: an <a> left open adopts
+        # body prose, which is not furniture.
         self._link_header_chars: int = 0
 
         # List state
@@ -327,8 +322,8 @@ class _MarkdownRenderer(HTMLParser):
     def _nested_buffer_open(self, frame: _HeaderFrame) -> bool:
         """True when a side buffer opened *inside* *frame* still holds content.
 
-        Such a buffer emits into the frame when it closes; one that was already
-        open when the header started encloses it and must not capture it."""
+        Such a buffer emits into the frame when it closes; an enclosing one
+        (already open at ``<header>``) must not capture it."""
         return (
             self._in_link
             or (self._in_cell and not frame.outer_in_cell)
@@ -339,8 +334,8 @@ class _MarkdownRenderer(HTMLParser):
     def _emit(self, text: str) -> None:
         frame = self._header_stack[-1] if self._header_stack else None
         # Tee wherever the text is routed, so a heading inside a nested buffer is
-        # still captured. Link text arrives raw and again formatted by
-        # _finish_link, which runs with _in_link cleared, so only that form is teed.
+        # captured. Link text arrives twice (raw, then formatted by _finish_link with
+        # _in_link cleared), so the _in_link guard tees only the formatted form.
         if frame is not None and self._heading_marks and not self._in_link:
             frame.heading_parts.append(text)
         if frame is not None and not self._nested_buffer_open(frame):
@@ -515,8 +510,8 @@ class _MarkdownRenderer(HTMLParser):
     def _exit_tag(self, tag: str) -> bool:
         """Pop to the matching open tag; return True when the end tag should
         be rendered (False = it closed inside a hidden / out-of-scope region)."""
-        # A scope closing over an <a> the page left open would strand its text in the
-        # link buffer, so recover it before the segment is recorded.
+        # Recover an <a> the page left open before the segment is recorded, or its
+        # text is stranded in the link buffer.
         if self._in_link and self._scope_tags is not None and tag in self._scope_tags:
             self._finish_link()
         suppressed = bool(self._hidden_marks) or (
@@ -784,8 +779,7 @@ class _MarkdownRenderer(HTMLParser):
             else:
                 self._out.append("\n\n" + prefixed + "\n\n")
 
-        # An unclosed <header> adopts the page body under HTML5 parsing, so emit it
-        # unchanged rather than judging a whole article.
+        # An unclosed <header> adopts the page body, so emit it unchanged.
         self._flush_header_frames()
 
         # A scope left open by truncated HTML never reached _exit_tag, so its output
@@ -919,8 +913,8 @@ def _select_main_scope_render(source_html: str, tag: str) -> tuple[int, str]:
     clearing the threshold together, and returning that one subtree keeps
     unrelated siblings (related cards, comment threads) out of the output.
 
-    Candidates are sized with their dropped header furniture added back, so
-    removing it never costs an article the size gate or a sibling comparison."""
+    Candidates are sized with their dropped header furniture added back, so the
+    strip never costs an article the size gate or a sibling comparison."""
     renderer = _new_renderer(source_html, frozenset({tag}), strip_header = True)
     dropped = renderer.scope_dropped
     best_len = 0

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1831,3 +1831,63 @@ def test_deeply_nested_headers_do_not_blow_up_quadratically():
     # Four times the depth and payload must not cost far more than four times
     # the work; a quadratic implementation lands well above this.
     assert timings[1] < timings[0] * 12, timings
+
+
+def test_linked_heading_text_is_counted_once_for_the_size_floor():
+    body = (
+        "<article><header><h1><a href='/p'>%s</a></h1>"
+        "<a href='/author'>Jane</a></header><p>%s</p></article>"
+        % ("Headline word " * 60, "Article body. " * 30)
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Jane" in out
+
+
+def test_fenced_code_counts_as_retained_content():
+    # A leading # inside a fence is a comment, not a heading.
+    code = "<pre># comment line one\n# comment line two\n# comment line three</pre>"
+    article = "<article><header><h1>T</h1><ul>%s</ul></header>%s</article>" % (
+        _interlanguage_list(300),
+        code,
+    )
+    sibling = "<article><p>%s</p></article>" % ("Sibling teaser text here. " * 12)
+    out = html_to_markdown(f"<body>{article}{sibling}</body>", main_content = True)
+    assert "comment line one" in out
+
+
+def test_nested_blockquote_prose_does_not_backtrack():
+    # Heading detection must scan linearly: a regex with adjacent whitespace
+    # groups goes exponential on "> > > ... prose".
+    import time
+
+    html = (
+        "<body><main>"
+        + "<blockquote>" * 40
+        + "<p>prose text here</p>"
+        + "</blockquote>" * 40
+        + "</main></body>"
+    )
+    start = time.perf_counter()
+    html_to_markdown(html, main_content = True)
+    assert time.perf_counter() - start < 1.0
+
+
+def test_deeply_nested_tags_stay_linear():
+    # _close_implicit must not rescan the whole open-tag stack per start tag.
+    import time
+
+    def build(count):
+        return (
+            "<body><main>"
+            + "<header><h1>T</h1>" * count
+            + "</header>" * count
+            + "<p>body</p></main></body>"
+        )
+
+    timings = []
+    for count in (1000, 4000):
+        start = time.perf_counter()
+        html_to_markdown(build(count), main_content = True)
+        timings.append(time.perf_counter() - start)
+    # Four times the tags, well under sixteen times the work.
+    assert timings[1] < timings[0] * 12, timings

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1626,8 +1626,8 @@ def test_header_survives_every_buffer_combination(
     assert "Article body sentence." in out, "body lost"
     assert out.strip(), "empty output"
     assert out.index("Article body sentence.") < 16000, "body pushed past the fetch cap"
-    # The title holds only for closed markup with no <pre>: in <pre> a heading is verbatim text,
-    # and unclosed shapes get best-effort recovery from code predating this pass.
+    # The title holds only for closed markup with no <pre>: there a heading is verbatim text, and
+    # unclosed shapes get best-effort recovery predating this pass.
     well_formed = close_header and close_nested and "pre" not in (wrapper, nested)
     if _GRID_HEADINGS[heading] and well_formed:
         assert out.count("Page Title") == 1, "title duplicated or lost"
@@ -1760,8 +1760,8 @@ _FENCE = "`" * 3
 
 
 def test_dropped_furniture_cannot_dominate_sibling_ranking():
-    # Credit keeps a stripped article competitive but must not decide the match:
-    # a teaser with a 1000 link header outranked five times its own real text.
+    # Credit must not decide the match: a teaser with a 1000 link header outranked five times its
+    # own real text.
     teaser = "<article><header>%s</header><p>%s</p></article>" % (
         "".join('<a href="/l%d">Lang%d</a>' % (i, i) for i in range(1000)),
         "Teaser words here. " * 20,
@@ -1773,8 +1773,7 @@ def test_dropped_furniture_cannot_dominate_sibling_ranking():
 
 
 def test_literal_bracket_paren_is_prose_not_a_destination():
-    # No [ opened it, so "](" is literal text and the parens hold visible prose.
-    # Skipping them scored 192 of 295 and dropped the article under the gate.
+    # No [ opened it, so "](" is literal and the parens hold prose; skipping them scored 192 of 295.
     article = "<article><p>%s](%s) %s</p></article>" % (
         "Real article prose that the reader wants to see. " * 3,
         "y" * 100,
@@ -1787,8 +1786,8 @@ def test_literal_bracket_paren_is_prose_not_a_destination():
 
 
 def test_hand_preserved_heading_reaches_the_eligibility_tally():
-    # The partial branch writes the title straight into heading_parts, so the
-    # gate has to be told as well or a title-only card reads as body prose.
+    # The partial branch writes the title straight into heading_parts, so the gate needs telling
+    # too or a title-only card reads as body prose.
     card = (
         '<article><header><a href="/h"><div role="heading">%s</div>%s</a><ul>%s</ul></header></article>'
         % (
@@ -1803,8 +1802,7 @@ def test_hand_preserved_heading_reaches_the_eligibility_tally():
 
 
 def test_pre_inside_a_table_cell_is_drained_before_the_row():
-    # The row is emitted, so an open <pre> swallowed it and produced a fenced
-    # block holding CODEMARKER|  | instead of a cell holding the code.
+    # The row is emitted, so an open <pre> swallowed it into a fence as CODEMARKER|  |.
     body = "<main><header><h1>T</h1><table><tr><td><pre>CODEMARKER</header><p>%s</p></main>" % (
         "Article body. " * 30,
     )
@@ -1814,8 +1812,8 @@ def test_pre_inside_a_table_cell_is_drained_before_the_row():
 
 
 def test_post_processing_respects_the_widened_fence():
-    # _cleanup and _strip_boilerplate_lines toggled on any ``` line, so the literal one
-    # closed the block and its code was cleaned and de-boilerplated.
+    # Both passes toggled on any ``` line, so the literal one closed the block and its code was
+    # cleaned and de-boilerplated.
     code = "<pre>%s\nskip to content\n\nreal code line   \nmore code</pre>" % _FENCE
     body = "<article>%s<p>%s</p></article>" % (code, "Body text here. " * 20)
     out = html_to_markdown(f"<body><main>{body}</main></body>", main_content = True)
@@ -1836,8 +1834,8 @@ def test_unbalanced_destination_keeps_scoring_the_rest_of_the_line():
 
 
 def test_structural_headings_do_not_satisfy_the_eligibility_gate():
-    # role="heading" renders as plain prose, so ATX reparsing missed it and a header-only card
-    # cleared the gate on its title plus dropped-list credit.
+    # role="heading" renders as prose, so ATX reparsing missed it and a header-only card cleared
+    # the gate on its title plus dropped-list credit.
     card = '<article><header><div role="heading">%s</div><ul>%s</ul></header></article>' % (
         "Card Title Words " * 14,
         _interlanguage_list(300),
@@ -1908,8 +1906,7 @@ def test_heading_through_a_nested_buffer_is_emitted_once():
 
 
 def test_late_code_end_tag_after_a_recovered_header_is_a_no_op():
-    # </code> arrives after </header>; the frame already closed the span, so a second emit is
-    # unpaired across the rest of the page.
+    # </code> arrives after </header>; the frame already closed the span, so a second emit is odd.
     body = "<main><header><h1>T</h1><code>navcode<ul>%s</ul></header><p>%s</p></code></main>" % (
         _interlanguage_list(300),
         "Article body. " * 30,
@@ -1987,8 +1984,7 @@ def test_aria_heading_accepts_a_fallback_role_token_list():
     ],
 )
 def test_heading_survives_a_stripped_header(heading_markup, marker):
-    # However the title is expressed, reducing a link-only header keeps it and
-    # nothing else: through a cell, an ARIA role, a link, or an hgroup subtitle.
+    # However the title is expressed, reducing a link-only header keeps it and nothing else.
     body = "<main><header>%s<ul>%s</ul></header><p>%s</p></main>" % (
         heading_markup,
         _interlanguage_list(300),
@@ -2052,8 +2048,7 @@ def test_header_size_is_independent_of_the_buffer_it_renders_through():
 
 
 def test_nested_inline_code_closes_every_span_it_opened():
-    # Two <code> elements owe two closing backticks. Tracking open/closed as a
-    # flag let the first </code> answer for both and left the delimiters odd.
+    # Two <code> elements owe two backticks; as a flag the first </code> answered for both.
     body = "<main><article><p><code><code>x</code></code></p><p>%s</p></article></main>" % (
         "Body text here. " * 20,
     )

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1896,10 +1896,13 @@ def test_literal_bracket_paren_is_prose_not_a_destination():
 def test_hand_preserved_heading_reaches_the_eligibility_tally():
     # The partial branch writes the title straight into heading_parts, so the
     # gate has to be told as well or a title-only card reads as body prose.
-    card = '<article><header><a href="/h"><div role="heading">%s</div>%s</a><ul>%s</ul></header></article>' % (
-        "Card Title Words " * 14,
-        "nav text " * 40,
-        _interlanguage_list(300),
+    card = (
+        '<article><header><a href="/h"><div role="heading">%s</div>%s</a><ul>%s</ul></header></article>'
+        % (
+            "Card Title Words " * 14,
+            "nav text " * 40,
+            _interlanguage_list(300),
+        )
     )
     real = "<p>%s</p>" % ("The real page body text here. " * 30)
     out = html_to_markdown(f"<body><main>{real}{card}</main></body>", main_content = True)

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1866,6 +1866,76 @@ def test_fenced_code_counts_as_retained_content():
     assert "Sibling teaser" not in out
 
 
+_FENCE = "`" * 3
+
+
+def test_link_destination_scan_balances_parentheses():
+    # A destination may legally hold parens, so stopping at the first ) scored
+    # the rest of the URL as prose and handed the scope to a link-only card.
+    query = "utm_source=x&" * 25
+    card = '<article><header>%s</header><p><a href="/card(foo)?%s">Read</a></p></article>' % (
+        "".join('<a href="/l%d">Lang%d</a>' % (i, i) for i in range(120)),
+        query,
+    )
+    real = "<article><p>%s</p></article>" % ("The genuine article body text here. " * 20)
+    out = html_to_markdown(f"<body>{real}{card}</body>", main_content = True)
+    assert "The genuine article body text here." in out
+    assert "/card(foo)?" not in out
+
+
+def test_literal_fence_inside_pre_does_not_end_the_code_region():
+    # A ``` line in the source is content; ending the fence there made the rest
+    # of the snippet read as headings, so the article looked empty.
+    code = "<pre>%s\n%s</pre>" % (
+        _FENCE,
+        "\n".join("# code line %d" % i for i in range(20)),
+    )
+    article = "<article><header><h1>T</h1><ul>%s</ul></header>%s</article>" % (
+        _interlanguage_list(300),
+        code,
+    )
+    sibling = "<article><p>%s</p></article>" % ("Sibling teaser text here. " * 12)
+    out = html_to_markdown(f"<body>{article}{sibling}</body>", main_content = True)
+    assert "code line 1" in out
+    assert "Sibling teaser" not in out
+
+
+def test_heading_through_a_nested_buffer_is_emitted_once():
+    # The title was teed raw entering the blockquote and again when the quote
+    # flushed, so a stripped header kept two copies of it.
+    body = '<main><header><div role="heading"><blockquote>UniqueTitle</blockquote></div><ul>%s</ul></header><p>%s</p></main>' % (
+        _interlanguage_list(300),
+        "Article body. " * 30,
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert out.count("UniqueTitle") == 1
+
+
+def test_late_code_end_tag_after_a_recovered_header_is_a_no_op():
+    # </code> arrives after </header>; the frame already closed the span, so
+    # emitting again left an unmatched delimiter across the rest of the page.
+    body = "<main><header><h1>T</h1><code>navcode<ul>%s</ul></header><p>%s</p></code></main>" % (
+        _interlanguage_list(300),
+        "Article body. " * 30,
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert out.count("`") % 2 == 0
+    assert "Article body." in out
+
+
+def test_header_text_is_sized_after_whitespace_collapses():
+    # The run collapses to one space when rendered, so counting it raw pushed a
+    # short byline over the floor at near total link density and dropped it.
+    byline = '<a href="/a">Jane%sDoe</a><time>July 2026</time>' % (" " * 300)
+    body = "<main><header><h1>T</h1>%s</header><p>%s</p></main>" % (
+        byline,
+        "Article body. " * 30,
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Jane Doe" in out
+    assert "July 2026" in out
+
+
 def test_link_destinations_do_not_count_as_retained_prose():
     # A tracking URL is not prose: this card shows 4 visible characters but its
     # serialized destination scored 339, enough to displace the real article.

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1283,16 +1283,40 @@ def test_header_title_kept_when_article_is_shorter_than_its_language_list():
     assert "# Stub" in out
 
 
-def test_article_header_keeps_heading_drops_chrome():
-    body = (
-        "<article><header><h1>Post title</h1>"
-        "<a href='/subscribe'>Subscribe now</a></header>"
-        "<p>%s</p></article>"
-    ) % ("Real article content. " * 40)
+def test_link_only_article_header_reduces_to_its_heading():
+    body = ("<article><header><h1>Post title</h1><ul>%s</ul></header><p>%s</p></article>") % (
+        _interlanguage_list(300),
+        "Real article content. " * 40,
+    )
     out = html_to_markdown(f"<body>{body}</body>", main_content = True)
     assert "# Post title" in out
     assert "Real article content." in out
-    assert "Subscribe now" not in out
+    assert "Lang0" not in out
+
+
+def test_article_header_byline_and_date_are_kept():
+    # Standard semantic blog markup: only near-pure link lists are furniture.
+    body = (
+        "<article><header><h1>Why Rust</h1><p>By Jane Doe</p>"
+        "<time>2026-07-12</time><p>A summary of what this essay argues.</p></header>"
+        "<p>%s</p></article>"
+    ) % ("Real article content. " * 40)
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "# Why Rust" in out
+    assert "By Jane Doe" in out
+    assert "2026-07-12" in out
+    assert "A summary of what this essay argues." in out
+
+
+def test_small_link_header_is_left_alone():
+    # Under the size floor there is nothing large enough to displace an article.
+    body = (
+        "<article><header><h1>Post title</h1>"
+        "<a href='/subscribe'>Subscribe now</a></header><p>%s</p></article>"
+    ) % ("Real article content. " * 40)
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Subscribe now" in out
+    assert "Real article content." in out
 
 
 def test_unclosed_header_does_not_swallow_the_body():
@@ -1313,13 +1337,14 @@ def test_unclosed_header_with_many_headings_keeps_body():
 
 
 def test_header_strip_applies_without_article_or_main():
-    body = ("<header><h1>Site name</h1><a href='/pricing'>Pricing</a></header><p>%s</p>") % (
-        "Page prose without a main landmark. " * 20
+    body = ("<header><h1>Site name</h1><ul>%s</ul></header><p>%s</p>") % (
+        _interlanguage_list(300),
+        "Page prose without a main landmark. " * 20,
     )
     out = html_to_markdown(f"<body>{body}</body>", main_content = True)
     assert "Page prose without a main landmark." in out
     assert "# Site name" in out
-    assert "Pricing" not in out
+    assert "Lang0" not in out
 
 
 def test_header_kept_in_unscoped_conversion():
@@ -1352,12 +1377,48 @@ def test_sibling_card_does_not_beat_an_article_with_a_swallowed_body():
     assert "Related card teaser." not in out
 
 
-def test_closed_header_banner_stays_dropped_when_longer_than_the_body():
+def test_text_heavy_header_is_kept_even_when_longer_than_the_body():
+    # python.org keeps its hero carousel here, so size alone cannot condemn it.
     body = "<main><header><h1>Title</h1><p>%s</p></header><p>%s</p></main>" % (
-        "Cookie banner notice text. " * 30,
+        "Introductory hero text. " * 30,
         "The real body prose. " * 20,
     )
     out = html_to_markdown(f"<body>{body}</body>", main_content = True)
     assert "The real body prose." in out
-    assert "Cookie banner notice text." not in out
+    assert "Introductory hero text." in out
     assert "# Title" in out
+
+
+def test_unclosed_link_in_unclosed_header_keeps_the_body():
+    # The <a> adopts the body, so its text is not link furniture.
+    body = "<main><header><h1>Title</h1><a href='/'>Home<p>%s</p>" % ("Article body text. " * 40)
+    out = html_to_markdown(f"<body>{body}", main_content = True)
+    assert "Article body text." in out
+    assert "# Title" in out
+
+
+def test_unclosed_link_does_not_hand_the_scope_to_a_sibling_card():
+    real = "<article><header><h1>Real</h1><a href='/'>Home<p>%s</p></article>" % ("REAL " * 60)
+    card = "<article><p>%s</p></article>" % ("CARD " * 30)
+    out = html_to_markdown(f"<body>{real}{card}</body>", main_content = True)
+    assert "REAL" in out
+    assert "CARD" not in out
+
+
+def test_entity_encoded_body_is_not_lost_to_an_unclosed_header():
+    out = html_to_markdown(
+        "<body><main><header><h1>T</h1><p>%s</p>" % ("&alpha;" * 400),
+        main_content = True,
+    )
+    assert out.count("α") == 400
+
+
+def test_ancestor_end_tag_bounds_a_header_like_its_own_close():
+    body = "<div><header><h1>Site</h1><ul>%s</ul></div><p>%s</p>" % (
+        _interlanguage_list(300),
+        "The real body prose. " * 20,
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "The real body prose." in out
+    assert "# Site" in out
+    assert "Lang0" not in out

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1251,3 +1251,85 @@ def test_looks_like_html_document_only_matches_real_documents():
         "<dl><dt>x</dt></dl>",
     ):
         assert not _looks_like_html_document(frag), frag
+
+
+# <header> inside the selected scope (Wikipedia's Vector 2022 skin)
+def _interlanguage_list(count: int) -> str:
+    return "".join(
+        f'<li class="interlanguage-link">'
+        f'<a href="https://x{i}.wikipedia.org/wiki/K">Lang{i}</a></li>'
+        for i in range(count)
+    )
+
+
+def test_in_main_header_language_list_does_not_displace_article():
+    body = (
+        "<main><header><h1>Cat</h1><div id='p-lang-btn'><ul>%s</ul></div></header>"
+        "<div id='mw-content-text'><p>%s</p></div></main>"
+    ) % (_interlanguage_list(300), "The cat (Felis catus) is a small mammal. " * 30)
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Felis catus" in out
+    assert "Lang0" not in out
+    assert "x0.wikipedia.org" not in out
+    assert "# Cat" in out
+    assert out.index("Felis catus") < 200
+
+
+def test_header_title_kept_when_article_is_shorter_than_its_language_list():
+    body = (
+        "<main><header><h1>Stub</h1><ul>%s</ul></header>"
+        "<p>%s</p></main>"
+    ) % (_interlanguage_list(300), "Short article body. " * 15)
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Short article body." in out
+    assert "Lang0" not in out
+    assert "# Stub" in out
+
+
+def test_article_header_keeps_heading_drops_chrome():
+    body = (
+        "<article><header><h1>Post title</h1>"
+        "<a href='/subscribe'>Subscribe now</a></header>"
+        "<p>%s</p></article>"
+    ) % ("Real article content. " * 40)
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "# Post title" in out
+    assert "Real article content." in out
+    assert "Subscribe now" not in out
+
+
+def test_unclosed_header_does_not_swallow_the_body():
+    # Browsers adopt the rest of the subtree into an unclosed <header>.
+    body = "<main><header><h1>Title</h1><p>%s</p></main>" % ("Article body text. " * 40)
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Article body text." in out
+    assert "Title" in out
+
+
+def test_unclosed_header_with_many_headings_keeps_body():
+    # Headings survive, so a heading-rich page clears the size gate alone.
+    sections = "".join(
+        f"<h2>Section {i}</h2><p>{'Body prose here. ' * 10}</p>" for i in range(12)
+    )
+    body = f"<main><header><h1>T</h1>{sections}</main>"
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Body prose here." in out
+    assert "Section 0" in out
+
+
+def test_header_strip_applies_without_article_or_main():
+    body = (
+        "<header><h1>Site name</h1><a href='/pricing'>Pricing</a></header>"
+        "<p>%s</p>"
+    ) % ("Page prose without a main landmark. " * 20)
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Page prose without a main landmark." in out
+    assert "# Site name" in out
+    assert "Pricing" not in out
+
+
+def test_header_kept_in_unscoped_conversion():
+    body = "<header><h1>Site</h1><a href='/x'>Nav link</a></header><p>Text.</p>"
+    out = html_to_markdown(f"<body>{body}</body>")
+    assert "Nav link" in out
+    assert "Text." in out

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1640,3 +1640,67 @@ def test_table_nested_in_a_header_inside_a_cell_keeps_its_columns():
 def test_truncated_header_and_blockquote_keep_source_order():
     out = html_to_markdown("<body><main><header><h1>Title</h1><blockquote>Quote", main_content = True)
     assert out.index("Title") < out.index("Quote")
+
+
+# Header content interacts with every other buffer the renderer keeps, and each
+# pairing has a well-formed and a malformed case, so the grid is enumerated
+# rather than sampled: that is where the one-off bugs in this area have lived.
+_GRID_HEADINGS = {
+    "h1": "<h1>Page Title</h1>",
+    "aria": "<div role='heading'>Page Title</div>",
+    "in_quote": "<blockquote><h1>Page Title</h1></blockquote>",
+    "is_link": "<a role='heading' href='/t'>Page Title</a>",
+    "none": "",
+}
+_GRID_WRAPPERS = {
+    "bare": ("", ""),
+    "quote": ("<blockquote>", "</blockquote>"),
+    "cell": ("<table><tr><td>", "</td></tr></table>"),
+    "link": ("<a href='/x'>", "</a>"),
+    "item": ("<ul><li>", "</li></ul>"),
+    "pre": ("<pre>", "</pre>"),
+}
+_GRID_NESTED = {
+    "bare": ("", ""),
+    "quote": ("<blockquote>", "</blockquote>"),
+    "cell": ("<table><tr><td>", "</td></tr></table>"),
+    "pre": ("<pre>", "</pre>"),
+}
+_GRID_BODY = "Article body sentence. " * 30
+
+
+@pytest.mark.parametrize("heading", sorted(_GRID_HEADINGS))
+@pytest.mark.parametrize("wrapper", sorted(_GRID_WRAPPERS))
+@pytest.mark.parametrize("nested", sorted(_GRID_NESTED))
+@pytest.mark.parametrize("inner", ("link_dense", "content"))
+@pytest.mark.parametrize("close_header", (True, False))
+@pytest.mark.parametrize("close_nested", (True, False))
+def test_header_survives_every_buffer_combination(
+    heading, wrapper, nested, inner, close_header, close_nested
+):
+    open_wrap, close_wrap = _GRID_WRAPPERS[wrapper]
+    open_nest, close_nest = _GRID_NESTED[nested]
+    payload = (
+        f"<ul>{_interlanguage_list(300)}</ul>"
+        if inner == "link_dense"
+        else "<p>By Jane Doe, 12 July 2026</p><p>A summary of the argument.</p>"
+    )
+    header = (
+        f"<header>{_GRID_HEADINGS[heading]}{open_nest}{payload}"
+        f"{close_nest if close_nested else ''}{'</header>' if close_header else ''}"
+    )
+    html = (
+        f"<body><main>{open_wrap}{header}{close_wrap if close_header else ''}"
+        f"<p>{_GRID_BODY}</p></main></body>"
+    )
+    out = html_to_markdown(html, main_content = True)
+    # These hold for every shape, however malformed.
+    assert "Article body sentence." in out, "body lost"
+    assert out.strip(), "empty output"
+    assert out.index("Article body sentence.") < 16000, "body pushed past the fetch cap"
+    # The title is only guaranteed where the markup closes and no <pre> is
+    # involved: inside <pre> a heading is verbatim text, and unclosed shapes are
+    # recovered on a best-effort basis that predates this pass.
+    well_formed = close_header and close_nested and "pre" not in (wrapper, nested)
+    if _GRID_HEADINGS[heading] and well_formed:
+        assert out.count("Page Title") == 1, "title duplicated or lost"

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1511,3 +1511,42 @@ def test_anchor_without_href_is_prose_not_link_furniture():
     out = html_to_markdown(f"<body>{body}</body>", main_content = True)
     assert "Introductory prose" in out
     assert "Byline" in out
+
+
+def test_linked_heading_is_not_emitted_twice():
+    body = (
+        "<main><header><h1><a href='/post'>Title</a></h1><ul>%s</ul></header><p>%s</p></main>"
+        % (
+            _interlanguage_list(300),
+            "Article body. " * 30,
+        )
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "# [Title](/post)" in out
+    assert out.count("Title") == 1
+
+
+def test_header_inside_an_enclosing_blockquote_is_still_stripped():
+    # The blockquote encloses the header, so its content belongs to the frame.
+    body = (
+        "<main><blockquote><header><h1>T</h1><ul>%s</ul></header></blockquote><p>%s</p></main>"
+        % (
+            _interlanguage_list(300),
+            "Article body. " * 30,
+        )
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Lang0" not in out
+    assert out.index("Article body.") < 16000
+
+
+def test_short_article_still_beats_a_card_after_its_header_goes():
+    # Sizing adds the dropped furniture back, so stripping cannot cost the win.
+    real = "<article><header><h1>Real</h1><ul>%s</ul></header><p>%s</p></article>" % (
+        _interlanguage_list(300),
+        "Short real body. " * 6,
+    )
+    card = "<article><p>%s</p></article>" % ("Related card teaser text here. " * 8)
+    out = html_to_markdown(f"<body>{real}{card}</body>", main_content = True)
+    assert "Short real body." in out
+    assert "Related card teaser" not in out

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -21,11 +21,7 @@ _BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
 if _BACKEND_DIR not in sys.path:
     sys.path.insert(0, _BACKEND_DIR)
 
-from core.inference._html_to_md import (
-    _is_aria_heading,
-    _is_heading_line,
-    html_to_markdown,
-)
+from core.inference._html_to_md import _is_aria_heading, html_to_markdown
 from core.inference.tools import (
     _fetch_page_text,
     _fetch_url_raw,
@@ -1451,35 +1447,6 @@ def test_heading_inside_a_nested_buffer_is_kept_and_the_links_still_go():
     assert out.index("Article body.") < 16000
 
 
-def test_heading_inside_a_table_cell_is_kept():
-    body = (
-        "<main><header><table><tr><td><h1>Page Title</h1></td></tr></table>"
-        "<ul>%s</ul></header><p>%s</p></main>"
-        % (
-            _interlanguage_list(300),
-            "Article body. " * 30,
-        )
-    )
-    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
-    assert "Page Title" in out
-    assert "Lang0" not in out
-
-
-def test_aria_role_heading_is_preserved_like_a_real_heading():
-    body = (
-        "<main><header><div role='heading' aria-level='1'>Page Title</div>"
-        "<ul>%s</ul></header><p>%s</p></main>"
-        % (
-            _interlanguage_list(300),
-            "Article body. " * 30,
-        )
-    )
-    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
-    assert "Page Title" in out
-    assert "Lang0" not in out
-    assert "Article body." in out
-
-
 def test_long_hrefs_count_toward_the_header_size_floor():
     # Short labels, huge destinations: the rendered links are what displace it.
     nav = "".join('<a href="https://e.com/p?%s=%d">L%d</a>' % ("q" * 1000, i, i) for i in range(30))
@@ -1528,20 +1495,6 @@ def test_linked_heading_is_not_emitted_twice():
     assert out.count("Title") == 1
 
 
-def test_header_inside_an_enclosing_blockquote_is_still_stripped():
-    # The blockquote encloses the header, so its content belongs to the frame.
-    body = (
-        "<main><blockquote><header><h1>T</h1><ul>%s</ul></header></blockquote><p>%s</p></main>"
-        % (
-            _interlanguage_list(300),
-            "Article body. " * 30,
-        )
-    )
-    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
-    assert "Lang0" not in out
-    assert out.index("Article body.") < 16000
-
-
 def test_article_still_beats_a_bigger_card_after_its_header_goes():
     # Dropped furniture is added back when ranking siblings, so a stripped header still wins.
     real = "<article><header><h1>Real</h1><ul>%s</ul></header><p>%s</p></article>" % (
@@ -1564,27 +1517,6 @@ def test_furniture_only_card_does_not_suppress_the_main_it_sits_in():
     out = html_to_markdown(f"<body><main>{body}{card}</main></body>", main_content = True)
     assert "The real article body the reader wants." in out
     assert "Language 7" not in out
-
-
-def test_unclosed_nested_buffer_inside_a_header_is_still_stripped():
-    # The page omits </blockquote>, so the frame must claim its content before the strip is judged.
-    body = "<main><header><h1>T</h1><blockquote><ul>%s</ul></header><p>%s</p></main>" % (
-        _interlanguage_list(300),
-        "Article body. " * 30,
-    )
-    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
-    assert "Lang0" not in out
-    assert out.index("Article body.") < 16000
-
-
-def test_unclosed_table_cell_inside_a_header_is_still_stripped():
-    body = "<main><header><h1>T</h1><table><tr><td><ul>%s</ul></header><p>%s</p></main>" % (
-        _interlanguage_list(300),
-        "Article body. " * 30,
-    )
-    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
-    assert "Lang0" not in out
-    assert out.index("Article body.") < 16000
 
 
 def test_a_long_heading_href_does_not_condemn_the_rest_of_the_header():
@@ -1626,19 +1558,6 @@ def test_header_inside_an_enclosing_link_renders_once():
     )
     out = html_to_markdown(f"<body>{body}</body>", main_content = True)
     assert out.count("[# T](/x)") == 1
-
-
-def test_heading_that_is_itself_a_buffered_element_is_kept():
-    body = (
-        "<main><header><a role='heading' href='/title'>Page Title</a><ul>%s</ul></header><p>%s</p></main>"
-        % (
-            _interlanguage_list(300),
-            "Article body. " * 30,
-        )
-    )
-    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
-    assert "Page Title" in out
-    assert "Lang0" not in out
 
 
 def test_table_nested_in_a_header_inside_a_cell_keeps_its_columns():
@@ -1746,19 +1665,6 @@ def test_enclosing_anchor_text_counts_toward_header_density():
     assert "Article body." in out
 
 
-def test_hgroup_subtitle_survives_a_stripped_header():
-    body = (
-        "<main><header><hgroup><h1>Title</h1><p>Subtitle here</p></hgroup><ul>%s</ul></header><p>%s</p></main>"
-        % (
-            _interlanguage_list(300),
-            "Article body. " * 30,
-        )
-    )
-    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
-    assert "Subtitle here" in out
-    assert "Lang0" not in out
-
-
 def test_truncated_header_flushes_into_its_enclosing_buffer():
     # The header is inside the link/cell, so its text belongs there, in order.
     assert html_to_markdown(
@@ -1801,19 +1707,6 @@ def test_list_left_open_in_a_header_does_not_indent_the_body():
     out = html_to_markdown(f"<body>{body}</body>", main_content = True)
     item = next(line for line in out.split("\n") if "Body item one" in line)
     assert item.startswith("*"), item
-
-
-def test_link_wrapping_a_heading_keeps_the_title():
-    body = (
-        "<main><header><a href='/post'><h1>Page Title</h1></a><ul>%s</ul></header><p>%s</p></main>"
-        % (
-            _interlanguage_list(300),
-            "Article body. " * 30,
-        )
-    )
-    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
-    assert "Page Title" in out
-    assert "Lang0" not in out
 
 
 def test_deeply_nested_headers_do_not_blow_up_quadratically():
@@ -2082,15 +1975,47 @@ def test_aria_heading_accepts_a_fallback_role_token_list():
     assert "Lang0" not in out
 
 
-def test_only_valid_atx_syntax_counts_as_a_heading():
-    # 1-6 hashes must close with whitespace or line end, else a C snippet of #includes reads empty.
-    assert not _is_heading_line("#include <stdio.h>")
-    assert not _is_heading_line("#hashtag trending")
-    assert not _is_heading_line("####### seven hashes")
-    assert not _is_heading_line("##nospace")
-    assert _is_heading_line("# real heading")
-    assert _is_heading_line("###### six hashes")
-    assert _is_heading_line("> # quoted heading")
+@pytest.mark.parametrize(
+    ("heading_markup", "marker"),
+    [
+        ("<h1>Page Title</h1>", "Page Title"),
+        ("<table><tr><td><h1>Page Title</h1></td></tr></table>", "Page Title"),
+        ("<div role='heading' aria-level='1'>Page Title</div>", "Page Title"),
+        ("<a role='heading' href='/title'>Page Title</a>", "Page Title"),
+        ("<a href='/post'><h1>Page Title</h1></a>", "Page Title"),
+        ("<hgroup><h1>Title</h1><p>Subtitle here</p></hgroup>", "Subtitle here"),
+    ],
+)
+def test_heading_survives_a_stripped_header(heading_markup, marker):
+    # However the title is expressed, reducing a link-only header keeps it and
+    # nothing else: through a cell, an ARIA role, a link, or an hgroup subtitle.
+    body = "<main><header>%s<ul>%s</ul></header><p>%s</p></main>" % (
+        heading_markup,
+        _interlanguage_list(300),
+        "Article body. " * 30,
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert marker in out
+    assert "Lang0" not in out
+    assert "Article body." in out
+
+
+@pytest.mark.parametrize(
+    "body_markup",
+    [
+        # The blockquote encloses the header, so its content belongs to the frame.
+        "<main><blockquote><header><h1>T</h1><ul>{links}</ul></header></blockquote><p>{body}</p></main>",
+        # </blockquote> omitted: the frame must claim the content before judging.
+        "<main><header><h1>T</h1><blockquote><ul>{links}</ul></header><p>{body}</p></main>",
+        # </td> omitted, same requirement through the cell buffer.
+        "<main><header><h1>T</h1><table><tr><td><ul>{links}</ul></header><p>{body}</p></main>",
+    ],
+)
+def test_link_list_is_stripped_through_a_nested_buffer(body_markup):
+    body = body_markup.format(links = _interlanguage_list(300), body = "Article body. " * 30)
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Lang0" not in out
+    assert out.index("Article body.") < 16000
 
 
 def test_hash_prefixed_prose_still_wins_its_scope():

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1539,16 +1539,31 @@ def test_header_inside_an_enclosing_blockquote_is_still_stripped():
     assert out.index("Article body.") < 16000
 
 
-def test_short_article_still_beats_a_card_after_its_header_goes():
-    # Sizing adds the dropped furniture back, so stripping cannot cost the win.
+def test_article_still_beats_a_bigger_card_after_its_header_goes():
+    # Dropped furniture is added back for the sibling comparison, so stripping a
+    # link-only header cannot hand the win to a longer related card.
     real = "<article><header><h1>Real</h1><ul>%s</ul></header><p>%s</p></article>" % (
         _interlanguage_list(300),
-        "Short real body. " * 6,
+        "Short real body. " * 14,
     )
-    card = "<article><p>%s</p></article>" % ("Related card teaser text here. " * 8)
+    card = "<article><p>%s</p></article>" % ("Related card teaser text here. " * 12)
     out = html_to_markdown(f"<body>{real}{card}</body>", main_content = True)
     assert "Short real body." in out
     assert "Related card teaser" not in out
+
+
+def test_furniture_only_card_does_not_suppress_the_main_it_sits_in():
+    # Furniture may rank a candidate but must never make it eligible: astro.build
+    # returned a 225 char feature card for the whole homepage because a nav-only
+    # header cleared the gate on bytes that were about to be deleted.
+    card = "<article><header>%s</header><p>%s</p></article>" % (
+        "".join('<a href="/l%d">Language %d</a>' % (i, i) for i in range(120)),
+        "Short teaser about the related thing, read more.",
+    )
+    body = "<p>%s</p>" % ("The real article body the reader wants. " * 40)
+    out = html_to_markdown(f"<body><main>{body}{card}</main></body>", main_content = True)
+    assert "The real article body the reader wants." in out
+    assert "Language 7" not in out
 
 
 def test_unclosed_nested_buffer_inside_a_header_is_still_stripped():
@@ -1844,15 +1859,30 @@ def test_linked_heading_text_is_counted_once_for_the_size_floor():
 
 
 def test_fenced_code_counts_as_retained_content():
-    # A leading # inside a fence is a comment, not a heading.
-    code = "<pre># comment line one\n# comment line two\n# comment line three</pre>"
+    # A leading # inside a fence is a comment, not a heading. Eligibility is
+    # measured on non-heading text, so counting the fence as headings would drop
+    # this article for the sibling even though the code IS the content.
+    code = "<pre>%s</pre>" % "\n".join("# comment line %d" % i for i in range(16))
     article = "<article><header><h1>T</h1><ul>%s</ul></header>%s</article>" % (
         _interlanguage_list(300),
         code,
     )
     sibling = "<article><p>%s</p></article>" % ("Sibling teaser text here. " * 12)
     out = html_to_markdown(f"<body>{article}{sibling}</body>", main_content = True)
-    assert "comment line one" in out
+    assert "comment line 1" in out
+    assert "Sibling teaser" not in out
+
+
+def test_header_inside_open_inline_code_leaves_delimiters_paired():
+    # The <code> was opened outside the header, so the frame must not close it;
+    # doing so left the real </code> emitting a second, unpaired backtick.
+    body = "<main><code>head<header><h1>T</h1></header>tail</code><p>%s</p></main>" % (
+        "Article body. " * 30,
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert out.count("`") % 2 == 0
+    assert "`head`" not in out
+    assert "Article body." in out
 
 
 def test_nested_blockquote_prose_does_not_backtrack():

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1901,9 +1901,12 @@ def test_aria_heading_accepts_a_fallback_role_token_list():
     assert _is_aria_heading({"role": "HEADING"})
     assert not _is_aria_heading({"role": "banner"})
     assert not _is_aria_heading({})
-    body = '<main><header><div role="future-role heading">Page Title</div><ul>%s</ul></header><p>%s</p></main>' % (
-        _interlanguage_list(300),
-        "Article body. " * 30,
+    body = (
+        '<main><header><div role="future-role heading">Page Title</div><ul>%s</ul></header><p>%s</p></main>'
+        % (
+            _interlanguage_list(300),
+            "Article body. " * 30,
+        )
     )
     out = html_to_markdown(f"<body>{body}</body>", main_content = True)
     assert "Page Title" in out

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1276,10 +1276,10 @@ def test_in_main_header_language_list_does_not_displace_article():
 
 
 def test_header_title_kept_when_article_is_shorter_than_its_language_list():
-    body = (
-        "<main><header><h1>Stub</h1><ul>%s</ul></header>"
-        "<p>%s</p></main>"
-    ) % (_interlanguage_list(300), "Short article body. " * 15)
+    body = ("<main><header><h1>Stub</h1><ul>%s</ul></header><p>%s</p></main>") % (
+        _interlanguage_list(300),
+        "Short article body. " * 15,
+    )
     out = html_to_markdown(f"<body>{body}</body>", main_content = True)
     assert "Short article body." in out
     assert "Lang0" not in out
@@ -1308,9 +1308,7 @@ def test_unclosed_header_does_not_swallow_the_body():
 
 def test_unclosed_header_with_many_headings_keeps_body():
     # Headings survive, so a heading-rich page clears the size gate alone.
-    sections = "".join(
-        f"<h2>Section {i}</h2><p>{'Body prose here. ' * 10}</p>" for i in range(12)
-    )
+    sections = "".join(f"<h2>Section {i}</h2><p>{'Body prose here. ' * 10}</p>" for i in range(12))
     body = f"<main><header><h1>T</h1>{sections}</main>"
     out = html_to_markdown(f"<body>{body}</body>", main_content = True)
     assert "Body prose here." in out
@@ -1318,10 +1316,9 @@ def test_unclosed_header_with_many_headings_keeps_body():
 
 
 def test_header_strip_applies_without_article_or_main():
-    body = (
-        "<header><h1>Site name</h1><a href='/pricing'>Pricing</a></header>"
-        "<p>%s</p>"
-    ) % ("Page prose without a main landmark. " * 20)
+    body = ("<header><h1>Site name</h1><a href='/pricing'>Pricing</a></header><p>%s</p>") % (
+        "Page prose without a main landmark. " * 20
+    )
     out = html_to_markdown(f"<body>{body}</body>", main_content = True)
     assert "Page prose without a main landmark." in out
     assert "# Site name" in out

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1355,8 +1355,7 @@ def test_header_kept_in_unscoped_conversion():
 
 
 def test_unclosed_header_in_truncated_scope_keeps_body():
-    # A capped fetch ends before </main>: the flushed segment must still carry its
-    # dropped prose or the body is lost.
+    # A capped fetch ends before </main>: the flushed segment must still carry its dropped prose.
     sections = "".join(
         f"<h2>Section {i} of the article</h2><p>{'Body prose here. ' * 10}</p>" for i in range(12)
     )
@@ -1540,8 +1539,7 @@ def test_header_inside_an_enclosing_blockquote_is_still_stripped():
 
 
 def test_article_still_beats_a_bigger_card_after_its_header_goes():
-    # Dropped furniture is added back for the sibling comparison, so stripping a
-    # link-only header cannot hand the win to a longer related card.
+    # Dropped furniture is added back when ranking siblings, so a stripped header still wins.
     real = "<article><header><h1>Real</h1><ul>%s</ul></header><p>%s</p></article>" % (
         _interlanguage_list(300),
         "Short real body. " * 14,
@@ -1553,9 +1551,8 @@ def test_article_still_beats_a_bigger_card_after_its_header_goes():
 
 
 def test_furniture_only_card_does_not_suppress_the_main_it_sits_in():
-    # Furniture may rank a candidate but must never make it eligible: astro.build
-    # returned a 225 char feature card for the whole homepage because a nav-only
-    # header cleared the gate on bytes that were about to be deleted.
+    # Furniture may rank a candidate but never make it eligible: astro.build returned a 225 char
+    # feature card for the homepage because a nav-only header cleared the gate on deleted bytes.
     card = "<article><header>%s</header><p>%s</p></article>" % (
         "".join('<a href="/l%d">Language %d</a>' % (i, i) for i in range(120)),
         "Short teaser about the related thing, read more.",
@@ -1567,8 +1564,7 @@ def test_furniture_only_card_does_not_suppress_the_main_it_sits_in():
 
 
 def test_unclosed_nested_buffer_inside_a_header_is_still_stripped():
-    # The page omits </blockquote>, so the frame must claim its content before
-    # the strip is judged or the links escape and eat the fetch budget.
+    # The page omits </blockquote>, so the frame must claim its content before the strip is judged.
     body = "<main><header><h1>T</h1><blockquote><ul>%s</ul></header><p>%s</p></main>" % (
         _interlanguage_list(300),
         "Article body. " * 30,
@@ -1589,8 +1585,7 @@ def test_unclosed_table_cell_inside_a_header_is_still_stripped():
 
 
 def test_a_long_heading_href_does_not_condemn_the_rest_of_the_header():
-    # The heading is kept either way, so its size must not clear the floor for
-    # the metadata beside it.
+    # The heading is kept either way, so its size must not clear the floor for the metadata beside it.
     body = (
         "<article><header><h1><a href='/p?%s'>Title</a></h1>"
         "<a href='/author/jane'>Jane</a></header><p>%s</p></article>"
@@ -1602,8 +1597,7 @@ def test_a_long_heading_href_does_not_condemn_the_rest_of_the_header():
 
 
 def test_a_preserved_heading_is_terminated():
-    # The closing tag's blank line lands after the heading mark is popped, so
-    # the render has to supply it or the body joins the heading line.
+    # The closing tag's blank line lands after the heading mark pops, so render must supply it.
     body = "<main><header><h1>Title</h1><ul>%s</ul></header>Article body text here.</main>" % (
         _interlanguage_list(300)
     )
@@ -1614,8 +1608,7 @@ def test_a_preserved_heading_is_terminated():
 
 
 def test_scope_holding_only_furniture_does_not_win_or_blank_the_page():
-    # Removed furniture must not make an empty candidate eligible, or the
-    # fetch returns nothing at all.
+    # Removed furniture must not make an empty candidate eligible, or the fetch returns nothing.
     body = "<main><header><ul>%s</ul></header></main><p>%s</p>" % (
         _interlanguage_list(300),
         "Real page body prose. " * 30,
@@ -1657,8 +1650,7 @@ def test_truncated_header_and_blockquote_keep_source_order():
     assert out.index("Title") < out.index("Quote")
 
 
-# Header content interacts with every other buffer the renderer keeps, and each
-# pairing has a well-formed and a malformed case, so the grid is enumerated
+# Headers interact with every other buffer, well-formed and malformed, so the grid is enumerated
 # rather than sampled: that is where the one-off bugs in this area have lived.
 _GRID_HEADINGS = {
     "h1": "<h1>Page Title</h1>",
@@ -1713,9 +1705,8 @@ def test_header_survives_every_buffer_combination(
     assert "Article body sentence." in out, "body lost"
     assert out.strip(), "empty output"
     assert out.index("Article body sentence.") < 16000, "body pushed past the fetch cap"
-    # The title is only guaranteed where the markup closes and no <pre> is
-    # involved: inside <pre> a heading is verbatim text, and unclosed shapes are
-    # recovered on a best-effort basis that predates this pass.
+    # The title is only guaranteed for closed markup with no <pre>: inside <pre> a heading is
+    # verbatim text, and unclosed shapes are recovered best-effort by code predating this pass.
     well_formed = close_header and close_nested and "pre" not in (wrapper, nested)
     if _GRID_HEADINGS[heading] and well_formed:
         assert out.count("Page Title") == 1, "title duplicated or lost"
@@ -1843,8 +1834,7 @@ def test_deeply_nested_headers_do_not_blow_up_quadratically():
         start = time.perf_counter()
         html_to_markdown(html, main_content = True)
         timings.append(time.perf_counter() - start)
-    # Four times the depth and payload must not cost far more than four times
-    # the work; a quadratic implementation lands well above this.
+    # Four times the depth and payload, nowhere near quadratic cost.
     assert timings[1] < timings[0] * 12, timings
 
 
@@ -1859,9 +1849,8 @@ def test_linked_heading_text_is_counted_once_for_the_size_floor():
 
 
 def test_fenced_code_counts_as_retained_content():
-    # A leading # inside a fence is a comment, not a heading. Eligibility is
-    # measured on non-heading text, so counting the fence as headings would drop
-    # this article for the sibling even though the code IS the content.
+    # A leading # inside a fence is a comment, not a heading. Eligibility is measured on non-heading
+    # text, so counting the fence as headings would lose this article to the sibling.
     code = "<pre>%s</pre>" % "\n".join("# comment line %d" % i for i in range(16))
     article = "<article><header><h1>T</h1><ul>%s</ul></header>%s</article>" % (
         _interlanguage_list(300),
@@ -1874,9 +1863,8 @@ def test_fenced_code_counts_as_retained_content():
 
 
 def test_only_valid_atx_syntax_counts_as_a_heading():
-    # CommonMark needs 1-6 hashes closed by whitespace or the line end, so
-    # "#include" is prose. Eligibility is measured on non-heading text, and a C
-    # snippet whose every line began with # was reading as pure heading.
+    # CommonMark needs 1-6 hashes closed by whitespace or line end, so "#include" is prose; without
+    # that check a C snippet whose every line starts with # read as pure heading, so as empty.
     assert not _is_heading_line("#include <stdio.h>")
     assert not _is_heading_line("#hashtag trending")
     assert not _is_heading_line("####### seven hashes")
@@ -1887,8 +1875,7 @@ def test_only_valid_atx_syntax_counts_as_a_heading():
 
 
 def test_hash_prefixed_prose_still_wins_its_scope():
-    # Every line opens with a hash, so treating those as headings left the scope
-    # looking empty and handed the page to the sibling card.
+    # Every line opens with a hash, so treating those as headings left the scope looking empty.
     lines = "".join("<p>#include &lt;header_%02d.h&gt;</p>" % i for i in range(14))
     article = "<article><header><h1>T</h1><ul>%s</ul></header>%s</article>" % (
         _interlanguage_list(300),
@@ -1901,8 +1888,7 @@ def test_hash_prefixed_prose_still_wins_its_scope():
 
 
 def test_header_size_is_independent_of_the_buffer_it_renders_through():
-    # Text was counted entering a nested buffer AND when that buffer flushed, so
-    # the same links stripped once quoted but survived bare.
+    # Text counted entering a nested buffer AND on flush doubled it, so links stripped once quoted.
     links = "".join(
         '<a href="/very/long/section/path/number/%03d/index">L%03d</a>' % (i, i) for i in range(14)
     )
@@ -1922,8 +1908,7 @@ def test_header_size_is_independent_of_the_buffer_it_renders_through():
 
 
 def test_header_inside_open_inline_code_leaves_delimiters_paired():
-    # The <code> was opened outside the header, so the frame must not close it;
-    # doing so left the real </code> emitting a second, unpaired backtick.
+    # The <code> opened outside the header, so closing it in the frame left </code> unpaired.
     body = "<main><code>head<header><h1>T</h1></header>tail</code><p>%s</p></main>" % (
         "Article body. " * 30,
     )
@@ -1934,8 +1919,8 @@ def test_header_inside_open_inline_code_leaves_delimiters_paired():
 
 
 def test_nested_blockquote_prose_does_not_backtrack():
-    # Heading detection must scan linearly: a regex with adjacent whitespace
-    # groups goes exponential on "> > > ... prose".
+    # Heading detection must scan linearly: a regex with adjacent whitespace groups backtracks
+    # exponentially on "> > > ... prose".
     import time
 
     html = (

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1904,8 +1904,7 @@ def test_header_size_is_independent_of_the_buffer_it_renders_through():
     # Text was counted entering a nested buffer AND when that buffer flushed, so
     # the same links stripped once quoted but survived bare.
     links = "".join(
-        '<a href="/very/long/section/path/number/%03d/index">L%03d</a>' % (i, i)
-        for i in range(14)
+        '<a href="/very/long/section/path/number/%03d/index">L%03d</a>' % (i, i) for i in range(14)
     )
     wrapped = {
         "bare": links,

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1704,3 +1704,73 @@ def test_header_survives_every_buffer_combination(
     well_formed = close_header and close_nested and "pre" not in (wrapper, nested)
     if _GRID_HEADINGS[heading] and well_formed:
         assert out.count("Page Title") == 1, "title duplicated or lost"
+
+
+def test_a_stub_cannot_outrank_a_real_article_on_removed_navigation():
+    # A long title alone is not substantive retained content.
+    stub = "<article><header><h1>%s</h1><ul>%s</ul></header></article>" % (
+        "A Long Title That Exceeds Fifty Characters Easily Here",
+        _interlanguage_list(300),
+    )
+    real = "<article><p>%s</p></article>" % ("Genuine full article body text. " * 20)
+    out = html_to_markdown(f"<body>{stub}{real}</body>", main_content = True)
+    assert "Genuine full article body" in out
+
+
+def test_unclosed_link_in_a_closed_header_counts_as_furniture():
+    # The </header> proves the anchor did not adopt the body.
+    body = "<main><header><h1>T</h1><a href='/nav'>%s</header><p>%s</p></main>" % (
+        "Navigation label text. " * 20,
+        "Article body. " * 30,
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Navigation label text." not in out
+    assert "Article body." in out
+
+
+def test_enclosing_anchor_text_counts_toward_header_density():
+    body = "<main><a href='/nav'><header>%s</header></a><p>%s</p></main>" % (
+        "".join(f"<span>Nav label {i}</span>" for i in range(40)),
+        "Article body. " * 30,
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Nav label 0" not in out
+    assert "Article body." in out
+
+
+def test_hgroup_subtitle_survives_a_stripped_header():
+    body = (
+        "<main><header><hgroup><h1>Title</h1><p>Subtitle here</p></hgroup><ul>%s</ul></header><p>%s</p></main>"
+        % (
+            _interlanguage_list(300),
+            "Article body. " * 30,
+        )
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Subtitle here" in out
+    assert "Lang0" not in out
+
+
+def test_truncated_header_flushes_into_its_enclosing_buffer():
+    # The header is inside the link/cell, so its text belongs there, in order.
+    assert html_to_markdown(
+        "<body><main><a href='/x'>before<header><h1>Title", main_content = True
+    ).startswith("[before")
+    assert html_to_markdown(
+        "<body><main><table><tr><td><header><h1>Title", main_content = True
+    ).startswith("|")
+
+
+def test_empty_blocks_do_not_inflate_the_header_size():
+    # _cleanup collapses them, so the size threshold must see the cleaned form.
+    body = (
+        "<article><header><h1>%s</h1>%s<a href='/x'>L</a></header></article>"
+        "<article><p>%s</p></article>"
+        % (
+            "A Fairly Long Heading Title Here" * 2,
+            "<div></div>" * 500,
+            "Genuine full article body text. " * 20,
+        )
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Genuine full article body" in out

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -21,7 +21,7 @@ _BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
 if _BACKEND_DIR not in sys.path:
     sys.path.insert(0, _BACKEND_DIR)
 
-from core.inference._html_to_md import html_to_markdown
+from core.inference._html_to_md import _is_heading_line, html_to_markdown
 from core.inference.tools import (
     _fetch_page_text,
     _fetch_url_raw,
@@ -1871,6 +1871,55 @@ def test_fenced_code_counts_as_retained_content():
     out = html_to_markdown(f"<body>{article}{sibling}</body>", main_content = True)
     assert "comment line 1" in out
     assert "Sibling teaser" not in out
+
+
+def test_only_valid_atx_syntax_counts_as_a_heading():
+    # CommonMark needs 1-6 hashes closed by whitespace or the line end, so
+    # "#include" is prose. Eligibility is measured on non-heading text, and a C
+    # snippet whose every line began with # was reading as pure heading.
+    assert not _is_heading_line("#include <stdio.h>")
+    assert not _is_heading_line("#hashtag trending")
+    assert not _is_heading_line("####### seven hashes")
+    assert not _is_heading_line("##nospace")
+    assert _is_heading_line("# real heading")
+    assert _is_heading_line("###### six hashes")
+    assert _is_heading_line("> # quoted heading")
+
+
+def test_hash_prefixed_prose_still_wins_its_scope():
+    # Every line opens with a hash, so treating those as headings left the scope
+    # looking empty and handed the page to the sibling card.
+    lines = "".join("<p>#include &lt;header_%02d.h&gt;</p>" % i for i in range(14))
+    article = "<article><header><h1>T</h1><ul>%s</ul></header>%s</article>" % (
+        _interlanguage_list(300),
+        lines,
+    )
+    sibling = "<article><p>%s</p></article>" % ("Sibling teaser text here. " * 12)
+    out = html_to_markdown(f"<body>{article}{sibling}</body>", main_content = True)
+    assert "#include" in out
+    assert "Sibling teaser" not in out
+
+
+def test_header_size_is_independent_of_the_buffer_it_renders_through():
+    # Text was counted entering a nested buffer AND when that buffer flushed, so
+    # the same links stripped once quoted but survived bare.
+    links = "".join(
+        '<a href="/very/long/section/path/number/%03d/index">L%03d</a>' % (i, i)
+        for i in range(14)
+    )
+    wrapped = {
+        "bare": links,
+        "blockquote": f"<blockquote>{links}</blockquote>",
+        "cell": f"<table><tr><td>{links}</td></tr></table>",
+    }
+    kept = set()
+    for inner in wrapped.values():
+        body = "<main><header><h1>T</h1>%s</header><p>%s</p></main>" % (
+            inner,
+            "Article body. " * 30,
+        )
+        kept.add("L000" in html_to_markdown(f"<body>{body}</body>", main_content = True))
+    assert len(kept) == 1
 
 
 def test_header_inside_open_inline_code_leaves_delimiters_paired():

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1413,7 +1413,9 @@ def test_entity_encoded_body_is_not_lost_to_an_unclosed_header():
     assert out.count("α") == 400
 
 
-def test_ancestor_end_tag_bounds_a_header_like_its_own_close():
+def test_header_closed_by_an_ancestor_is_kept_whole():
+    # Without a matching </header> the header may have adopted the body, and
+    # size cannot tell that apart, so malformed markup keeps everything.
     body = "<div><header><h1>Site</h1><ul>%s</ul></div><p>%s</p>" % (
         _interlanguage_list(300),
         "The real body prose. " * 20,
@@ -1421,4 +1423,61 @@ def test_ancestor_end_tag_bounds_a_header_like_its_own_close():
     out = html_to_markdown(f"<body>{body}</body>", main_content = True)
     assert "The real body prose." in out
     assert "# Site" in out
-    assert "Lang0" not in out
+    assert "Lang0" in out
+
+
+def test_unclosed_header_does_not_strip_a_short_article_it_adopted():
+    body = "<main><header><h1>T</h1><ul>%s</ul><p>%s</p></main>" % (
+        _interlanguage_list(300),
+        "Short real article. " * 4,
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Short real article." in out
+
+
+def test_heading_inside_a_nested_buffer_is_not_lost():
+    body = (
+        "<main><header><blockquote><h1>Page Title</h1></blockquote><ul>%s</ul></header><p>%s</p></main>"
+        % (
+            _interlanguage_list(300),
+            "Article body. " * 30,
+        )
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Page Title" in out
+    assert "Article body." in out
+
+
+def test_long_hrefs_count_toward_the_header_size_floor():
+    # Short labels, huge destinations: the rendered links are what displace it.
+    nav = "".join('<a href="https://e.com/p?%s=%d">L%d</a>' % ("q" * 1000, i, i) for i in range(30))
+    body = "<main><header>%s</header><p>%s</p></main>" % (nav, "Article body. " * 30)
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "L0" not in out
+    assert out.index("Article body.") < 16000
+
+
+def test_linked_heading_does_not_condemn_the_byline_beside_it():
+    body = (
+        "<article><header><h1><a href='/p'>%s</a></h1><p>By Jane Doe, July 2026</p></header><p>%s</p></article>"
+        % (
+            "A Very Long Linked Headline About Assorted Things In The World Today " * 5,
+            "Article body. " * 30,
+        )
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "By Jane Doe" in out
+    assert "Very Long Linked" in out
+
+
+def test_anchor_without_href_is_prose_not_link_furniture():
+    body = (
+        "<article><header><h1>T</h1><a name='intro'>%s</a><p>Byline</p></header><p>%s</p></article>"
+        % (
+            "Introductory prose that renders as plain text. " * 8,
+            "Article body. " * 30,
+        )
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Introductory prose" in out
+    assert "Byline" in out

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1774,3 +1774,60 @@ def test_empty_blocks_do_not_inflate_the_header_size():
     )
     out = html_to_markdown(f"<body>{body}</body>", main_content = True)
     assert "Genuine full article body" in out
+
+
+def test_blockquoted_heading_is_not_counted_as_retained_prose():
+    stub = "<article><blockquote><header><h1>%s</h1><ul>%s</ul></header></blockquote></article>" % (
+        "A Long Title That Exceeds Fifty Characters Easily Here",
+        _interlanguage_list(300),
+    )
+    real = "<article><p>%s</p></article>" % ("Genuine full article body text. " * 20)
+    out = html_to_markdown(f"<body>{stub}{real}</body>", main_content = True)
+    assert "Genuine full article body" in out
+
+
+def test_list_left_open_in_a_header_does_not_indent_the_body():
+    body = "<main><header><h1>T</h1><ul>%s</header><ul><li>Body item one</li></ul></main>" % (
+        _interlanguage_list(300)
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    item = next(line for line in out.split("\n") if "Body item one" in line)
+    assert item.startswith("*"), item
+
+
+def test_link_wrapping_a_heading_keeps_the_title():
+    body = (
+        "<main><header><a href='/post'><h1>Page Title</h1></a><ul>%s</ul></header><p>%s</p></main>"
+        % (
+            _interlanguage_list(300),
+            "Article body. " * 30,
+        )
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Page Title" in out
+    assert "Lang0" not in out
+
+
+def test_deeply_nested_headers_do_not_blow_up_quadratically():
+    # Header sizing must not rescan each parent's cumulative buffer.
+    chunk = "<p>%s</p>" % ("filler text here. " * 100)
+
+    def build(depth):
+        return (
+            "<body><main>"
+            + "".join(f"<header>{chunk}" for _ in range(depth))
+            + "</header>" * depth
+            + "<p>body</p></main></body>"
+        )
+
+    import time
+
+    timings = []
+    for depth in (20, 80):
+        html = build(depth)
+        start = time.perf_counter()
+        html_to_markdown(html, main_content = True)
+        timings.append(time.perf_counter() - start)
+    # Four times the depth and payload must not cost far more than four times
+    # the work; a quadratic implementation lands well above this.
+    assert timings[1] < timings[0] * 12, timings

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -21,7 +21,11 @@ _BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
 if _BACKEND_DIR not in sys.path:
     sys.path.insert(0, _BACKEND_DIR)
 
-from core.inference._html_to_md import _is_heading_line, html_to_markdown
+from core.inference._html_to_md import (
+    _is_aria_heading,
+    _is_heading_line,
+    html_to_markdown,
+)
 from core.inference.tools import (
     _fetch_page_text,
     _fetch_url_raw,
@@ -1860,6 +1864,50 @@ def test_fenced_code_counts_as_retained_content():
     out = html_to_markdown(f"<body>{article}{sibling}</body>", main_content = True)
     assert "comment line 1" in out
     assert "Sibling teaser" not in out
+
+
+def test_link_destinations_do_not_count_as_retained_prose():
+    # A tracking URL is not prose: this card shows 4 visible characters but its
+    # serialized destination scored 339, enough to displace the real article.
+    query = "utm_source=x&" * 25
+    card = '<article><header>%s</header><p><a href="/card?%s">Read</a></p></article>' % (
+        "".join('<a href="/l%d">Lang%d</a>' % (i, i) for i in range(120)),
+        query,
+    )
+    real = "<article><p>%s</p></article>" % ("The genuine article body text here. " * 20)
+    out = html_to_markdown(f"<body>{real}{card}</body>", main_content = True)
+    assert "The genuine article body text here." in out
+    assert "/card?" not in out
+
+
+def test_late_end_tag_cannot_replay_a_recovered_pre_block():
+    # </header> arrives while <pre> is open, so the frame drains it; the later
+    # </pre> re-emitted the same buffer OUTSIDE the stripped header.
+    body = "<main><header><h1>T</h1><ul>%s</ul><pre>%s</header><p>%s</p></pre></main>" % (
+        _interlanguage_list(300),
+        "NAVJUNK_MARKER\n" * 3,
+        "Article body. " * 30,
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "NAVJUNK_MARKER" not in out
+    assert out.index("Article body.") < 16000
+
+
+def test_aria_heading_accepts_a_fallback_role_token_list():
+    # role is a token list authors use for fallbacks, so an exact match dropped
+    # the title of a header that was then reduced to its headings.
+    assert _is_aria_heading({"role": "heading"})
+    assert _is_aria_heading({"role": "future-role heading"})
+    assert _is_aria_heading({"role": "HEADING"})
+    assert not _is_aria_heading({"role": "banner"})
+    assert not _is_aria_heading({})
+    body = '<main><header><div role="future-role heading">Page Title</div><ul>%s</ul></header><p>%s</p></main>' % (
+        _interlanguage_list(300),
+        "Article body. " * 30,
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Page Title" in out
+    assert "Lang0" not in out
 
 
 def test_only_valid_atx_syntax_counts_as_a_heading():

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1433,9 +1433,26 @@ def test_unclosed_header_does_not_strip_a_short_article_it_adopted():
     assert "Short real article." in out
 
 
-def test_heading_inside_a_nested_buffer_is_not_lost():
+def test_heading_inside_a_nested_buffer_is_kept_and_the_links_still_go():
+    # The heading is teed as it is emitted, so routing it through a blockquote
+    # neither loses the title nor forces the whole language list back in.
     body = (
         "<main><header><blockquote><h1>Page Title</h1></blockquote><ul>%s</ul></header><p>%s</p></main>"
+        % (
+            _interlanguage_list(400),
+            "Article body. " * 30,
+        )
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Page Title" in out
+    assert "Lang0" not in out
+    assert out.index("Article body.") < 16000
+
+
+def test_heading_inside_a_table_cell_is_kept():
+    body = (
+        "<main><header><table><tr><td><h1>Page Title</h1></td></tr></table>"
+        "<ul>%s</ul></header><p>%s</p></main>"
         % (
             _interlanguage_list(300),
             "Article body. " * 30,
@@ -1443,6 +1460,21 @@ def test_heading_inside_a_nested_buffer_is_not_lost():
     )
     out = html_to_markdown(f"<body>{body}</body>", main_content = True)
     assert "Page Title" in out
+    assert "Lang0" not in out
+
+
+def test_aria_role_heading_is_preserved_like_a_real_heading():
+    body = (
+        "<main><header><div role='heading' aria-level='1'>Page Title</div>"
+        "<ul>%s</ul></header><p>%s</p></main>"
+        % (
+            _interlanguage_list(300),
+            "Article body. " * 30,
+        )
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Page Title" in out
+    assert "Lang0" not in out
     assert "Article body." in out
 
 

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1355,8 +1355,8 @@ def test_header_kept_in_unscoped_conversion():
 
 
 def test_unclosed_header_in_truncated_scope_keeps_body():
-    # A capped fetch ends before </main>, so the segment is flushed, not closed, and
-    # must still carry its dropped prose or the body is lost.
+    # A capped fetch ends before </main>: the flushed segment must still carry its
+    # dropped prose or the body is lost.
     sections = "".join(
         f"<h2>Section {i} of the article</h2><p>{'Body prose here. ' * 10}</p>" for i in range(12)
     )
@@ -1434,8 +1434,7 @@ def test_unclosed_header_does_not_strip_a_short_article_it_adopted():
 
 
 def test_heading_inside_a_nested_buffer_is_kept_and_the_links_still_go():
-    # The heading is teed as it is emitted, so routing it through a blockquote
-    # neither loses the title nor forces the whole language list back in.
+    # Teeing keeps the title without forcing the language list back in.
     body = (
         "<main><header><blockquote><h1>Page Title</h1></blockquote><ul>%s</ul></header><p>%s</p></main>"
         % (

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1355,9 +1355,8 @@ def test_header_kept_in_unscoped_conversion():
 
 
 def test_unclosed_header_in_truncated_scope_keeps_body():
-    # A capped fetch ends before </main>, so the segment is flushed, not closed.
-    # Headings survive the strip and alone clear the size gate, so the flushed
-    # segment must carry its dropped-prose count or the body is lost.
+    # A capped fetch ends before </main>, so the segment is flushed, not closed, and
+    # must still carry its dropped prose or the body is lost.
     sections = "".join(
         f"<h2>Section {i} of the article</h2><p>{'Body prose here. ' * 10}</p>" for i in range(12)
     )
@@ -1414,8 +1413,7 @@ def test_entity_encoded_body_is_not_lost_to_an_unclosed_header():
 
 
 def test_header_closed_by_an_ancestor_is_kept_whole():
-    # Without a matching </header> the header may have adopted the body, and
-    # size cannot tell that apart, so malformed markup keeps everything.
+    # Without a matching </header> the header may have adopted the body, so keep all.
     body = "<div><header><h1>Site</h1><ul>%s</ul></div><p>%s</p>" % (
         _interlanguage_list(300),
         "The real body prose. " * 20,

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1549,3 +1549,50 @@ def test_short_article_still_beats_a_card_after_its_header_goes():
     out = html_to_markdown(f"<body>{real}{card}</body>", main_content = True)
     assert "Short real body." in out
     assert "Related card teaser" not in out
+
+
+def test_unclosed_nested_buffer_inside_a_header_is_still_stripped():
+    # The page omits </blockquote>, so the frame must claim its content before
+    # the strip is judged or the links escape and eat the fetch budget.
+    body = "<main><header><h1>T</h1><blockquote><ul>%s</ul></header><p>%s</p></main>" % (
+        _interlanguage_list(300),
+        "Article body. " * 30,
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Lang0" not in out
+    assert out.index("Article body.") < 16000
+
+
+def test_unclosed_table_cell_inside_a_header_is_still_stripped():
+    body = "<main><header><h1>T</h1><table><tr><td><ul>%s</ul></header><p>%s</p></main>" % (
+        _interlanguage_list(300),
+        "Article body. " * 30,
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Lang0" not in out
+    assert out.index("Article body.") < 16000
+
+
+def test_a_long_heading_href_does_not_condemn_the_rest_of_the_header():
+    # The heading is kept either way, so its size must not clear the floor for
+    # the metadata beside it.
+    body = (
+        "<article><header><h1><a href='/p?%s'>Title</a></h1>"
+        "<a href='/author/jane'>Jane</a></header><p>%s</p></article>"
+        % ("q" * 900, "Article body. " * 30)
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Title" in out
+    assert "Jane" in out
+
+
+def test_a_preserved_heading_is_terminated():
+    # The closing tag's blank line lands after the heading mark is popped, so
+    # the render has to supply it or the body joins the heading line.
+    body = "<main><header><h1>Title</h1><ul>%s</ul></header>Article body text here.</main>" % (
+        _interlanguage_list(300)
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "# TitleArticle" not in out
+    assert out.startswith("# Title")
+    assert "Article body text here." in out

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1869,6 +1869,57 @@ def test_fenced_code_counts_as_retained_content():
 _FENCE = "`" * 3
 
 
+def test_post_processing_respects_the_widened_fence():
+    # _cleanup and _strip_boilerplate_lines toggled on any ``` line, so the
+    # literal one closed the block and its code was cleaned and de-boilerplated.
+    code = "<pre>%s\nskip to content\n\nreal code line   \nmore code</pre>" % _FENCE
+    body = "<article>%s<p>%s</p></article>" % (code, "Body text here. " * 20)
+    out = html_to_markdown(f"<body><main>{body}</main></body>", main_content = True)
+    assert "skip to content" in out
+    assert "skip to content\n\nreal code line" in out
+    assert "real code line   " in out
+
+
+def test_unbalanced_destination_keeps_scoring_the_rest_of_the_line():
+    # /docs/(draft never balances, so it is not a link any reader resolves; the
+    # scan must not discard the prose sharing that rendered line.
+    article = '<article><p><a href="/docs/(draft">Doc</a> %s</p></article>' % (
+        "Substantial article prose continues here. " * 6,
+    )
+    sibling = "<article><p>%s</p></article>" % ("Sibling teaser text. " * 12)
+    out = html_to_markdown(f"<body>{article}{sibling}</body>", main_content = True)
+    assert "Substantial article prose continues here." in out
+    assert "Sibling teaser" not in out
+
+
+def test_structural_headings_do_not_satisfy_the_eligibility_gate():
+    # role="heading" renders as plain prose, so reparsing ATX could not see it and
+    # a header-only card cleared the gate on its title plus dropped-list credit.
+    card = '<article><header><div role="heading">%s</div><ul>%s</ul></header></article>' % (
+        "Card Title Words " * 14,
+        _interlanguage_list(300),
+    )
+    real = "<article><p>%s</p></article>" % ("The real article body text here. " * 20)
+    out = html_to_markdown(f"<body>{real}{card}</body>", main_content = True)
+    assert "The real article body text here." in out
+    assert "Card Title Words" not in out
+
+
+def test_anchor_wrapping_a_heading_preserves_only_the_heading():
+    # <a><h1>Title</h1>...nav...</a> is furniture carrying a title; teeing the
+    # whole anchor returned 14k of navigation ahead of the article.
+    bulk = " ".join("NavWord%04d" % i for i in range(1200))
+    body = '<main><header><a href="/home"><h1>Title</h1>%s</a><ul>%s</ul></header><p>%s</p></main>' % (
+        bulk,
+        _interlanguage_list(300),
+        "Article body. " * 30,
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Title" in out
+    assert "NavWord0000" not in out
+    assert out.index("Article body.") < 16000
+
+
 def test_link_destination_scan_balances_parentheses():
     # A destination may legally hold parens, so stopping at the first ) scored
     # the rest of the URL as prose and handed the scope to a link-only card.

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1555,8 +1555,7 @@ def test_article_still_beats_a_bigger_card_after_its_header_goes():
 
 
 def test_furniture_only_card_does_not_suppress_the_main_it_sits_in():
-    # Furniture may rank a candidate but never make it eligible: astro.build returned a 225 char
-    # feature card for the homepage because a nav-only header cleared the gate on deleted bytes.
+    # Furniture ranks, never makes eligible: a nav-only header returned a 225 char astro.build card.
     card = "<article><header>%s</header><p>%s</p></article>" % (
         "".join('<a href="/l%d">Language %d</a>' % (i, i) for i in range(120)),
         "Short teaser about the related thing, read more.",
@@ -1589,7 +1588,7 @@ def test_unclosed_table_cell_inside_a_header_is_still_stripped():
 
 
 def test_a_long_heading_href_does_not_condemn_the_rest_of_the_header():
-    # The heading is kept either way, so its size must not clear the floor for the metadata beside it.
+    # The heading is kept anyway, so its size must not clear the floor for the metadata beside it.
     body = (
         "<article><header><h1><a href='/p?%s'>Title</a></h1>"
         "<a href='/author/jane'>Jane</a></header><p>%s</p></article>"
@@ -1654,8 +1653,7 @@ def test_truncated_header_and_blockquote_keep_source_order():
     assert out.index("Title") < out.index("Quote")
 
 
-# Headers interact with every other buffer, well-formed and malformed, so the grid is enumerated
-# rather than sampled: that is where the one-off bugs in this area have lived.
+# Headers interact with every buffer, so enumerate the grid: that is where the one-off bugs live.
 _GRID_HEADINGS = {
     "h1": "<h1>Page Title</h1>",
     "aria": "<div role='heading'>Page Title</div>",
@@ -1709,8 +1707,8 @@ def test_header_survives_every_buffer_combination(
     assert "Article body sentence." in out, "body lost"
     assert out.strip(), "empty output"
     assert out.index("Article body sentence.") < 16000, "body pushed past the fetch cap"
-    # The title is only guaranteed for closed markup with no <pre>: inside <pre> a heading is
-    # verbatim text, and unclosed shapes are recovered best-effort by code predating this pass.
+    # The title holds only for closed markup with no <pre>: in <pre> a heading is verbatim text,
+    # and unclosed shapes get best-effort recovery from code predating this pass.
     well_formed = close_header and close_nested and "pre" not in (wrapper, nested)
     if _GRID_HEADINGS[heading] and well_formed:
         assert out.count("Page Title") == 1, "title duplicated or lost"
@@ -1853,8 +1851,7 @@ def test_linked_heading_text_is_counted_once_for_the_size_floor():
 
 
 def test_fenced_code_counts_as_retained_content():
-    # A leading # inside a fence is a comment, not a heading. Eligibility is measured on non-heading
-    # text, so counting the fence as headings would lose this article to the sibling.
+    # A leading # inside a fence is a comment, not a heading; scoring it as one loses this article.
     code = "<pre>%s</pre>" % "\n".join("# comment line %d" % i for i in range(16))
     article = "<article><header><h1>T</h1><ul>%s</ul></header>%s</article>" % (
         _interlanguage_list(300),
@@ -1870,8 +1867,8 @@ _FENCE = "`" * 3
 
 
 def test_post_processing_respects_the_widened_fence():
-    # _cleanup and _strip_boilerplate_lines toggled on any ``` line, so the
-    # literal one closed the block and its code was cleaned and de-boilerplated.
+    # _cleanup and _strip_boilerplate_lines toggled on any ``` line, so the literal one
+    # closed the block and its code was cleaned and de-boilerplated.
     code = "<pre>%s\nskip to content\n\nreal code line   \nmore code</pre>" % _FENCE
     body = "<article>%s<p>%s</p></article>" % (code, "Body text here. " * 20)
     out = html_to_markdown(f"<body><main>{body}</main></body>", main_content = True)
@@ -1881,8 +1878,7 @@ def test_post_processing_respects_the_widened_fence():
 
 
 def test_unbalanced_destination_keeps_scoring_the_rest_of_the_line():
-    # /docs/(draft never balances, so it is not a link any reader resolves; the
-    # scan must not discard the prose sharing that rendered line.
+    # /docs/(draft never balances, so it is not a link; the scan must keep the prose on that line.
     article = '<article><p><a href="/docs/(draft">Doc</a> %s</p></article>' % (
         "Substantial article prose continues here. " * 6,
     )
@@ -1893,8 +1889,8 @@ def test_unbalanced_destination_keeps_scoring_the_rest_of_the_line():
 
 
 def test_structural_headings_do_not_satisfy_the_eligibility_gate():
-    # role="heading" renders as plain prose, so reparsing ATX could not see it and
-    # a header-only card cleared the gate on its title plus dropped-list credit.
+    # role="heading" renders as plain prose, so ATX reparsing missed it and a header-only card
+    # cleared the gate on its title plus dropped-list credit.
     card = '<article><header><div role="heading">%s</div><ul>%s</ul></header></article>' % (
         "Card Title Words " * 14,
         _interlanguage_list(300),
@@ -1906,8 +1902,7 @@ def test_structural_headings_do_not_satisfy_the_eligibility_gate():
 
 
 def test_anchor_wrapping_a_heading_preserves_only_the_heading():
-    # <a><h1>Title</h1>...nav...</a> is furniture carrying a title; teeing the
-    # whole anchor returned 14k of navigation ahead of the article.
+    # <a><h1>Title</h1>...nav...</a> carries a title; teeing the whole anchor returned 14k of nav.
     bulk = " ".join("NavWord%04d" % i for i in range(1200))
     body = (
         '<main><header><a href="/home"><h1>Title</h1>%s</a><ul>%s</ul></header><p>%s</p></main>'
@@ -1924,8 +1919,7 @@ def test_anchor_wrapping_a_heading_preserves_only_the_heading():
 
 
 def test_link_destination_scan_balances_parentheses():
-    # A destination may legally hold parens, so stopping at the first ) scored
-    # the rest of the URL as prose and handed the scope to a link-only card.
+    # A destination may hold parens, so stopping at the first ) scored the rest of the URL as prose.
     query = "utm_source=x&" * 25
     card = '<article><header>%s</header><p><a href="/card(foo)?%s">Read</a></p></article>' % (
         "".join('<a href="/l%d">Lang%d</a>' % (i, i) for i in range(120)),
@@ -1938,8 +1932,7 @@ def test_link_destination_scan_balances_parentheses():
 
 
 def test_literal_fence_inside_pre_does_not_end_the_code_region():
-    # A ``` line in the source is content; ending the fence there made the rest
-    # of the snippet read as headings, so the article looked empty.
+    # A ``` line in the source is content; ending the fence there made the rest read as headings.
     code = "<pre>%s\n%s</pre>" % (
         _FENCE,
         "\n".join("# code line %d" % i for i in range(20)),
@@ -1955,8 +1948,7 @@ def test_literal_fence_inside_pre_does_not_end_the_code_region():
 
 
 def test_heading_through_a_nested_buffer_is_emitted_once():
-    # The title was teed raw entering the blockquote and again when the quote
-    # flushed, so a stripped header kept two copies of it.
+    # The title was teed entering the blockquote and again on flush, so it was kept twice.
     body = (
         '<main><header><div role="heading"><blockquote>UniqueTitle</blockquote></div><ul>%s</ul></header><p>%s</p></main>'
         % (
@@ -1969,8 +1961,8 @@ def test_heading_through_a_nested_buffer_is_emitted_once():
 
 
 def test_late_code_end_tag_after_a_recovered_header_is_a_no_op():
-    # </code> arrives after </header>; the frame already closed the span, so
-    # emitting again left an unmatched delimiter across the rest of the page.
+    # </code> arrives after </header>; the frame already closed the span, so a second emit is
+    # unpaired across the rest of the page.
     body = "<main><header><h1>T</h1><code>navcode<ul>%s</ul></header><p>%s</p></code></main>" % (
         _interlanguage_list(300),
         "Article body. " * 30,
@@ -1981,8 +1973,7 @@ def test_late_code_end_tag_after_a_recovered_header_is_a_no_op():
 
 
 def test_header_text_is_sized_after_whitespace_collapses():
-    # The run collapses to one space when rendered, so counting it raw pushed a
-    # short byline over the floor at near total link density and dropped it.
+    # The run collapses to one space, so counting it raw pushed a short byline over the floor.
     byline = '<a href="/a">Jane%sDoe</a><time>July 2026</time>' % (" " * 300)
     body = "<main><header><h1>T</h1>%s</header><p>%s</p></main>" % (
         byline,
@@ -1994,8 +1985,7 @@ def test_header_text_is_sized_after_whitespace_collapses():
 
 
 def test_link_destinations_do_not_count_as_retained_prose():
-    # A tracking URL is not prose: this card shows 4 visible characters but its
-    # serialized destination scored 339, enough to displace the real article.
+    # A tracking URL is not prose: this card shows 4 visible chars but its destination scored 339.
     query = "utm_source=x&" * 25
     card = '<article><header>%s</header><p><a href="/card?%s">Read</a></p></article>' % (
         "".join('<a href="/l%d">Lang%d</a>' % (i, i) for i in range(120)),
@@ -2008,8 +1998,7 @@ def test_link_destinations_do_not_count_as_retained_prose():
 
 
 def test_late_end_tag_cannot_replay_a_recovered_pre_block():
-    # </header> arrives while <pre> is open, so the frame drains it; the later
-    # </pre> re-emitted the same buffer OUTSIDE the stripped header.
+    # </header> arrives while <pre> is open, so the frame drains it; the later </pre> replayed it.
     body = "<main><header><h1>T</h1><ul>%s</ul><pre>%s</header><p>%s</p></pre></main>" % (
         _interlanguage_list(300),
         "NAVJUNK_MARKER\n" * 3,
@@ -2021,8 +2010,7 @@ def test_late_end_tag_cannot_replay_a_recovered_pre_block():
 
 
 def test_aria_heading_accepts_a_fallback_role_token_list():
-    # role is a token list authors use for fallbacks, so an exact match dropped
-    # the title of a header that was then reduced to its headings.
+    # role is a token list authors use for fallbacks, so an exact match dropped the title.
     assert _is_aria_heading({"role": "heading"})
     assert _is_aria_heading({"role": "future-role heading"})
     assert _is_aria_heading({"role": "HEADING"})
@@ -2041,8 +2029,7 @@ def test_aria_heading_accepts_a_fallback_role_token_list():
 
 
 def test_only_valid_atx_syntax_counts_as_a_heading():
-    # CommonMark needs 1-6 hashes closed by whitespace or line end, so "#include" is prose; without
-    # that check a C snippet whose every line starts with # read as pure heading, so as empty.
+    # 1-6 hashes must close with whitespace or line end, else a C snippet of #includes reads empty.
     assert not _is_heading_line("#include <stdio.h>")
     assert not _is_heading_line("#hashtag trending")
     assert not _is_heading_line("####### seven hashes")
@@ -2097,8 +2084,7 @@ def test_header_inside_open_inline_code_leaves_delimiters_paired():
 
 
 def test_nested_blockquote_prose_does_not_backtrack():
-    # Heading detection must scan linearly: a regex with adjacent whitespace groups backtracks
-    # exponentially on "> > > ... prose".
+    # Heading detection must scan linearly: a regex backtracks exponentially on "> > > ... prose".
     import time
 
     html = (

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1903,9 +1903,12 @@ def test_literal_fence_inside_pre_does_not_end_the_code_region():
 def test_heading_through_a_nested_buffer_is_emitted_once():
     # The title was teed raw entering the blockquote and again when the quote
     # flushed, so a stripped header kept two copies of it.
-    body = '<main><header><div role="heading"><blockquote>UniqueTitle</blockquote></div><ul>%s</ul></header><p>%s</p></main>' % (
-        _interlanguage_list(300),
-        "Article body. " * 30,
+    body = (
+        '<main><header><div role="heading"><blockquote>UniqueTitle</blockquote></div><ul>%s</ul></header><p>%s</p></main>'
+        % (
+            _interlanguage_list(300),
+            "Article body. " * 30,
+        )
     )
     out = html_to_markdown(f"<body>{body}</body>", main_content = True)
     assert out.count("UniqueTitle") == 1

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1909,10 +1909,13 @@ def test_anchor_wrapping_a_heading_preserves_only_the_heading():
     # <a><h1>Title</h1>...nav...</a> is furniture carrying a title; teeing the
     # whole anchor returned 14k of navigation ahead of the article.
     bulk = " ".join("NavWord%04d" % i for i in range(1200))
-    body = '<main><header><a href="/home"><h1>Title</h1>%s</a><ul>%s</ul></header><p>%s</p></main>' % (
-        bulk,
-        _interlanguage_list(300),
-        "Article body. " * 30,
+    body = (
+        '<main><header><a href="/home"><h1>Title</h1>%s</a><ul>%s</ul></header><p>%s</p></main>'
+        % (
+            bulk,
+            _interlanguage_list(300),
+            "Article body. " * 30,
+        )
     )
     out = html_to_markdown(f"<body>{body}</body>", main_content = True)
     assert "Title" in out

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -163,9 +163,7 @@ def test_inline_style_display_none_important_is_dropped():
 
 
 def test_inline_style_display_none_among_other_declarations():
-    html = (
-        "<body><p>keep</p>" '<div style="color: red; display : none ; margin:0">gone</div></body>'
-    )
+    html = '<body><p>keep</p><div style="color: red; display : none ; margin:0">gone</div></body>'
     out = html_to_markdown(html)
     assert "keep" in out
     assert "gone" not in out
@@ -216,8 +214,7 @@ def test_hidden_paragraph_omitted_close_does_not_swallow_siblings():
     # HTML5 optional end tags: a sibling <p> start tag implicitly closes an open
     # <p hidden>, so the hidden region ends there instead of swallowing siblings.
     html = (
-        "<body><div><p hidden>secret"
-        "<p>visible one</p><p>visible two</p></div><p>after</p></body>"
+        "<body><div><p hidden>secret<p>visible one</p><p>visible two</p></div><p>after</p></body>"
     )
     out = html_to_markdown(html)
     assert "secret" not in out
@@ -1330,3 +1327,37 @@ def test_header_kept_in_unscoped_conversion():
     out = html_to_markdown(f"<body>{body}</body>")
     assert "Nav link" in out
     assert "Text." in out
+
+
+def test_unclosed_header_in_truncated_scope_keeps_body():
+    # A capped fetch ends before </main>, so the segment is flushed, not closed.
+    # Headings survive the strip and alone clear the size gate, so the flushed
+    # segment must carry its dropped-prose count or the body is lost.
+    sections = "".join(
+        f"<h2>Section {i} of the article</h2><p>{'Body prose here. ' * 10}</p>" for i in range(12)
+    )
+    out = html_to_markdown(
+        f"<body><main><header><h1>T</h1>{sections}",
+        main_content = True,
+    )
+    assert "Body prose here." in out
+    assert "Section 0 of the article" in out
+
+
+def test_sibling_card_does_not_beat_an_article_with_a_swallowed_body():
+    real = "<article><header><h1>Real</h1><p>%s</p></article>" % ("Real article body. " * 40)
+    card = "<article><p>%s</p></article>" % ("Related card teaser. " * 12)
+    out = html_to_markdown(f"<body>{real}{card}</body>", main_content = True)
+    assert "Real article body." in out
+    assert "Related card teaser." not in out
+
+
+def test_closed_header_banner_stays_dropped_when_longer_than_the_body():
+    body = "<main><header><h1>Title</h1><p>%s</p></header><p>%s</p></main>" % (
+        "Cookie banner notice text. " * 30,
+        "The real body prose. " * 20,
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "The real body prose." in out
+    assert "Cookie banner notice text." not in out
+    assert "# Title" in out

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1596,3 +1596,47 @@ def test_a_preserved_heading_is_terminated():
     assert "# TitleArticle" not in out
     assert out.startswith("# Title")
     assert "Article body text here." in out
+
+
+def test_scope_holding_only_furniture_does_not_win_or_blank_the_page():
+    # Removed furniture must not make an empty candidate eligible, or the
+    # fetch returns nothing at all.
+    body = "<main><header><ul>%s</ul></header></main><p>%s</p>" % (
+        _interlanguage_list(300),
+        "Real page body prose. " * 30,
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Real page body prose." in out
+
+
+def test_header_inside_an_enclosing_link_renders_once():
+    body = "<main><a href='/x'><header><h1>T</h1></header></a><p>%s</p></main>" % (
+        "Article body. " * 30
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert out.count("[# T](/x)") == 1
+
+
+def test_heading_that_is_itself_a_buffered_element_is_kept():
+    body = (
+        "<main><header><a role='heading' href='/title'>Page Title</a><ul>%s</ul></header><p>%s</p></main>"
+        % (
+            _interlanguage_list(300),
+            "Article body. " * 30,
+        )
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "Page Title" in out
+    assert "Lang0" not in out
+
+
+def test_table_nested_in_a_header_inside_a_cell_keeps_its_columns():
+    html = "<table><tr><td><header><table><tr><td>x</td></tr></table></header></td></tr></table>"
+    assert html_to_markdown(f"<body>{html}</body>", main_content = True) == html_to_markdown(
+        f"<body>{html}</body>"
+    )
+
+
+def test_truncated_header_and_blockquote_keep_source_order():
+    out = html_to_markdown("<body><main><header><h1>Title</h1><blockquote>Quote", main_content = True)
+    assert out.index("Title") < out.index("Quote")

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -1866,6 +1866,57 @@ def test_fenced_code_counts_as_retained_content():
 _FENCE = "`" * 3
 
 
+def test_dropped_furniture_cannot_dominate_sibling_ranking():
+    # Credit keeps a stripped article competitive but must not decide the match:
+    # a teaser with a 1000 link header outranked five times its own real text.
+    teaser = "<article><header>%s</header><p>%s</p></article>" % (
+        "".join('<a href="/l%d">Lang%d</a>' % (i, i) for i in range(1000)),
+        "Teaser words here. " * 20,
+    )
+    real = "<article><p>%s</p></article>" % ("The genuine article body text goes here. " * 55)
+    out = html_to_markdown(f"<body>{teaser}{real}</body>", main_content = True)
+    assert "The genuine article body text goes here." in out
+    assert "Teaser words here." not in out
+
+
+def test_literal_bracket_paren_is_prose_not_a_destination():
+    # No [ opened it, so "](" is literal text and the parens hold visible prose.
+    # Skipping them scored 192 of 295 and dropped the article under the gate.
+    article = "<article><p>%s](%s) %s</p></article>" % (
+        "Real article prose that the reader wants to see. " * 3,
+        "y" * 100,
+        "Tail prose to finish the paragraph off here.",
+    )
+    sibling = "<article><p>%s</p></article>" % ("Unrelated sibling teaser words. " * 8)
+    out = html_to_markdown(f"<body>{article}{sibling}</body>", main_content = True)
+    assert "Real article prose that the reader wants to see." in out
+    assert "Unrelated sibling teaser" not in out
+
+
+def test_hand_preserved_heading_reaches_the_eligibility_tally():
+    # The partial branch writes the title straight into heading_parts, so the
+    # gate has to be told as well or a title-only card reads as body prose.
+    card = '<article><header><a href="/h"><div role="heading">%s</div>%s</a><ul>%s</ul></header></article>' % (
+        "Card Title Words " * 14,
+        "nav text " * 40,
+        _interlanguage_list(300),
+    )
+    real = "<p>%s</p>" % ("The real page body text here. " * 30)
+    out = html_to_markdown(f"<body><main>{real}{card}</main></body>", main_content = True)
+    assert "The real page body text here." in out
+
+
+def test_pre_inside_a_table_cell_is_drained_before_the_row():
+    # The row is emitted, so an open <pre> swallowed it and produced a fenced
+    # block holding CODEMARKER|  | instead of a cell holding the code.
+    body = "<main><header><h1>T</h1><table><tr><td><pre>CODEMARKER</header><p>%s</p></main>" % (
+        "Article body. " * 30,
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert "CODEMARKER|" not in out
+    assert "Article body." in out
+
+
 def test_post_processing_respects_the_widened_fence():
     # _cleanup and _strip_boilerplate_lines toggled on any ``` line, so the literal one
     # closed the block and its code was cleaned and de-boilerplated.

--- a/studio/backend/tests/test_web_fetch_extraction.py
+++ b/studio/backend/tests/test_web_fetch_extraction.py
@@ -2051,6 +2051,17 @@ def test_header_size_is_independent_of_the_buffer_it_renders_through():
     assert len(kept) == 1
 
 
+def test_nested_inline_code_closes_every_span_it_opened():
+    # Two <code> elements owe two closing backticks. Tracking open/closed as a
+    # flag let the first </code> answer for both and left the delimiters odd.
+    body = "<main><article><p><code><code>x</code></code></p><p>%s</p></article></main>" % (
+        "Body text here. " * 20,
+    )
+    out = html_to_markdown(f"<body>{body}</body>", main_content = True)
+    assert out.count("`") % 2 == 0
+    assert "``x``" in out
+
+
 def test_header_inside_open_inline_code_leaves_delimiters_paired():
     # The <code> opened outside the header, so closing it in the frame left </code> unpaired.
     body = "<main><code>head<header><h1>T</h1></header>tail</code><p>%s</p></main>" % (


### PR DESCRIPTION
Reading a Wikipedia page returned interlanguage links instead of the article. Vector 2022 puts the 278-language dropdown in a `<header>` inside `<main>`, ahead of `#mw-content-text`. The `<main>` scoping heuristic therefore spent the entire 16k character budget on the language list before the article started. The links are CSS-hidden behind a dropdown, so the existing hidden-element stripping did not catch them.

`<header>` now counts as page furniture in the main-content pass, keeping the heading it carries so page titles survive. Marks are anchored to the open-tag stack like `_hidden_marks`, and a guard measures the non-anchor prose dropped:
an unclosed `<header>` adopts the page body under HTML5 parsing, so a header holding more prose than the render kept means malformed markup and the unstripped render is used instead.

Checked against 26 live sites: 18 byte-identical, 6 improved (Wikipedia, Wiktionary, Wikivoyage), none worse. 7 new tests cover the Wikipedia shape, title retention, unclosed headers, and the no-`<main>` path.

Before:
<img width="2560" height="1800" alt="wikipedia-fetch-before" src="https://github.com/user-attachments/assets/737ac477-d97b-46cd-ace6-8ca334b1f6b4" />

After:
<img width="2560" height="1800" alt="wikipedia-fetch-after" src="https://github.com/user-attachments/assets/cacbb7ca-7b0a-4865-b2ea-e7411ac33ba6" />
