### PR TITLE
Pin utf-8 on the llama_backend marker rewrite

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5644,7 +5644,7 @@ def sync_marker_llama_backend(install_dir: Path, llama_backend: str | None) -> N
     """Sync the persisted llama.cpp backend when the bundle is reused unchanged."""
     marker_path = install_dir / "UNSLOTH_PREBUILT_INFO.json"
     try:
-        marker = json.loads(marker_path.read_text())
+        marker = json.loads(marker_path.read_text(encoding = "utf-8"))
     except (OSError, ValueError):
         return
     if not isinstance(marker, dict) or marker.get("llama_backend") == llama_backend:
@@ -5653,7 +5653,7 @@ def sync_marker_llama_backend(install_dir: Path, llama_backend: str | None) -> N
         marker.pop("llama_backend", None)
     else:
         marker["llama_backend"] = llama_backend
-    marker_path.write_text(json.dumps(marker, indent = 2) + "\n")
+    marker_path.write_text(json.dumps(marker, indent = 2) + "\n", encoding = "utf-8")
     log(f"existing install reused; recorded llama_backend={llama_backend!r} from this run")
 
 


### PR DESCRIPTION
## Summary

`tests/test_runtime_text_encoding.py::test_shipping_code_names_an_encoding` has been failing on `main` since #7373:

```
AssertionError: 2 text read/write call sites in shipping code let the operator's
locale decide the encoding, so they crash or silently produce mojibake on
Windows. Pass encoding = "utf-8":
  ['studio/install_llama_prebuilt.py:5656: write_text()',
   'studio/install_llama_prebuilt.py:5647: read_text()']
```

Both sites read and rewrite `UNSLOTH_PREBUILT_INFO.json` to record `llama_backend` on an install that is being reused. Without an explicit encoding they use the locale default, which on a Windows box whose ANSI code page is not UTF-8 raises `UnicodeDecodeError` on the read or writes mojibake on the write.

The sibling function fourteen lines above (`5633`, `5639`) already passes `encoding = "utf-8"` against the same file, so this only brings the copy into line with it.

## Testing

```
before:  1 failed, 7 passed
after:   8 passed
```

This is currently red on every open PR that runs the repo test job, so it is worth landing on its own.