### PR TITLE
Handle llama.cpp tool schema limits

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -14726,6 +14726,117 @@ async def _anthropic_plain_non_streaming(run_gen, message_id, model_name):
 # =====================================================================
 
 
+_JSON_SCHEMA_MAP_KEYWORDS = frozenset(
+    {
+        "$defs",
+        "definitions",
+        "dependentSchemas",
+        "patternProperties",
+        "properties",
+    }
+)
+_JSON_SCHEMA_SINGLE_KEYWORDS = frozenset(
+    {
+        "additionalProperties",
+        "contains",
+        "contentSchema",
+        "else",
+        "if",
+        "items",
+        "not",
+        "propertyNames",
+        "then",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+    }
+)
+_JSON_SCHEMA_LIST_KEYWORDS = frozenset({"allOf", "anyOf", "oneOf", "prefixItems"})
+_LLAMA_GRAMMAR_MAX_REPETITION = 2000
+_JSON_SCHEMA_REPETITION_KEYWORDS = frozenset(
+    {"maxItems", "maxLength", "minItems", "minLength"}
+)
+
+
+def _llama_compatible_tool_schema(schema):
+    """Return a llama.cpp-compatible copy of one JSON Schema node.
+
+    JSON Schema ``pattern`` expressions match anywhere in a string, so an
+    unanchored pattern is valid and cannot be made compatible by merely adding
+    ``^`` and ``$`` without changing its meaning. llama.cpp's grammar converter
+    currently rejects those patterns outright. Its grammar parser likewise
+    rejects repetition bounds above 2000. Omit only those unsupported
+    constraints from the local-backend copy; the agent retains and validates
+    its original schema, while every compatible constraint still reaches
+    llama.cpp.
+    """
+    if not isinstance(schema, dict):
+        return schema
+
+    compatible = dict(schema)
+    pattern = compatible.get("pattern")
+    if isinstance(pattern, str) and not (pattern.startswith("^") and pattern.endswith("$")):
+        compatible.pop("pattern")
+    # llama-grammar.cpp refuses repetition bounds above its sane-default
+    # threshold. Dropping the local-backend constraint preserves every value
+    # the client schema accepts; capping it would incorrectly reject otherwise
+    # valid tool arguments.
+    for keyword in _JSON_SCHEMA_REPETITION_KEYWORDS:
+        bound = compatible.get(keyword)
+        if (
+            isinstance(bound, int)
+            and not isinstance(bound, bool)
+            and bound > _LLAMA_GRAMMAR_MAX_REPETITION
+        ):
+            compatible.pop(keyword)
+
+    for keyword in _JSON_SCHEMA_MAP_KEYWORDS:
+        children = compatible.get(keyword)
+        if isinstance(children, dict):
+            compatible[keyword] = {
+                key: _llama_compatible_tool_schema(value) for key, value in children.items()
+            }
+
+    for keyword in _JSON_SCHEMA_SINGLE_KEYWORDS:
+        child = compatible.get(keyword)
+        if isinstance(child, dict):
+            compatible[keyword] = _llama_compatible_tool_schema(child)
+
+    for keyword in _JSON_SCHEMA_LIST_KEYWORDS:
+        children = compatible.get(keyword)
+        if isinstance(children, list):
+            compatible[keyword] = [
+                _llama_compatible_tool_schema(value) for value in children
+            ]
+
+    return compatible
+
+
+def _llama_compatible_tools(openai_tools):
+    if not isinstance(openai_tools, list):
+        return openai_tools
+
+    compatible_tools = []
+    for tool in openai_tools:
+        if not isinstance(tool, dict):
+            compatible_tools.append(tool)
+            continue
+        function = tool.get("function")
+        parameters = function.get("parameters") if isinstance(function, dict) else None
+        if not isinstance(parameters, dict):
+            compatible_tools.append(tool)
+            continue
+        compatible_tools.append(
+            {
+                **tool,
+                "function": {
+                    **function,
+                    "parameters": _llama_compatible_tool_schema(parameters),
+                },
+            }
+        )
+    return compatible_tools
+
+
 def _build_passthrough_payload(
     openai_messages,
     openai_tools,
@@ -14753,7 +14864,7 @@ def _build_passthrough_payload(
         "stream": stream,
     }
     if openai_tools:
-        body["tools"] = openai_tools
+        body["tools"] = _llama_compatible_tools(openai_tools)
         if tool_choice is not None:
             body["tool_choice"] = tool_choice
     if seed is not None:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -14752,9 +14752,7 @@ _JSON_SCHEMA_SINGLE_KEYWORDS = frozenset(
 )
 _JSON_SCHEMA_LIST_KEYWORDS = frozenset({"allOf", "anyOf", "oneOf", "prefixItems"})
 _LLAMA_GRAMMAR_MAX_REPETITION = 2000
-_JSON_SCHEMA_REPETITION_KEYWORDS = frozenset(
-    {"maxItems", "maxLength", "minItems", "minLength"}
-)
+_JSON_SCHEMA_REPETITION_KEYWORDS = frozenset({"maxItems", "maxLength", "minItems", "minLength"})
 
 
 def _llama_compatible_tool_schema(schema):
@@ -14804,9 +14802,7 @@ def _llama_compatible_tool_schema(schema):
     for keyword in _JSON_SCHEMA_LIST_KEYWORDS:
         children = compatible.get(keyword)
         if isinstance(children, list):
-            compatible[keyword] = [
-                _llama_compatible_tool_schema(value) for value in children
-            ]
+            compatible[keyword] = [_llama_compatible_tool_schema(value) for value in children]
 
     return compatible
 

--- a/studio/backend/tests/test_openai_tool_passthrough.py
+++ b/studio/backend/tests/test_openai_tool_passthrough.py
@@ -1191,6 +1191,41 @@ class TestBuildPassthroughPayloadToolChoice:
         body = _build_passthrough_payload(**self._args(), tool_choice = tc)
         assert body["tool_choice"] == tc
 
+    def test_llama_incompatible_tool_constraints_are_omitted(self):
+        args = self._args()
+        schema = args["openai_tools"][0]["function"]["parameters"]
+        schema["properties"] = {
+            "declarationKey": {"type": "string", "pattern": r"\S"},
+            "exactKey": {"type": "string", "pattern": r"^[A-Z]+$"},
+            "nested": {
+                "type": "array",
+                "items": {
+                    "anyOf": [
+                        {"type": "string", "pattern": "token"},
+                        {"type": "string", "pattern": "^fixed$"},
+                    ],
+                    "default": {"pattern": "annotation data"},
+                },
+            },
+            "largeScript": {"type": "string", "minLength": 1, "maxLength": 65536},
+            "boundedScript": {"type": "string", "maxLength": 2000},
+        }
+
+        body = _build_passthrough_payload(**args)
+        forwarded = body["tools"][0]["function"]["parameters"]["properties"]
+
+        assert forwarded["declarationKey"] == {"type": "string"}
+        assert forwarded["exactKey"]["pattern"] == r"^[A-Z]+$"
+        nested = forwarded["nested"]["items"]
+        assert nested["anyOf"][0] == {"type": "string"}
+        assert nested["anyOf"][1]["pattern"] == "^fixed$"
+        assert nested["default"] == {"pattern": "annotation data"}
+        assert forwarded["largeScript"] == {"type": "string", "minLength": 1}
+        assert forwarded["boundedScript"]["maxLength"] == 2000
+        assert schema["properties"]["declarationKey"]["pattern"] == r"\S"
+        assert schema["properties"]["nested"]["items"]["anyOf"][0]["pattern"] == "token"
+        assert schema["properties"]["largeScript"]["maxLength"] == 65536
+
     def test_stream_omits_usage_options_when_client_did_not_request_them(self):
         args = self._args()
         args["stream"] = True


### PR DESCRIPTION
## Summary

Normalize tool schemas only in the payload sent to local llama.cpp.

Current OpenClaw coding tools include valid JSON Schema constructs that
llama.cpp's grammar converter cannot represent:

- unanchored regular-expression `pattern` values
- length/item repetition bounds above llama.cpp's grammar limit

The server now deep-copies the tool schema and omits only those unsupported
constraints from the local inference copy. The original client schema remains
unchanged for client-side validation, and supported anchored/bounded schemas
continue to pass through.

## A/B verification

- Captured the real OpenClaw default coding-tool request.
- Before: `Pattern must start with '^' and end with '$'`; after removing that
  first blocker, llama.cpp failed grammar parsing on `maxLength: 65536`.
- After: full live Windows smoke with cached
  `unsloth/Qwen3.5-4B-MTP-GGUF` used OpenClaw's default tool catalog, called the
  read tool, returned the expected file content, and exited 0.
- Targeted passthrough class: 12 passed.
- Full passthrough module: 250 passed; two existing 0.2-second Windows timing
  cases timed out under the test host and are outside the changed path.
