### PR TITLE
Isolate Studio PostCSS configuration

### DIFF
--- a/studio/frontend/vite.config.ts
+++ b/studio/frontend/vite.config.ts
@@ -9,6 +9,13 @@ import { defineConfig } from "vite";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  // Keep an unrelated PostCSS config in an ancestor directory from leaking
+  // into Studio installs. Tailwind is provided by its dedicated Vite plugin.
+  css: {
+    postcss: {
+      plugins: [],
+    },
+  },
   optimizeDeps: {
     include: ["@dagrejs/dagre", "@dagrejs/graphlib"],
   },


### PR DESCRIPTION
## Summary

Give Studio an explicit inline PostCSS configuration.

Vite otherwise searches parent directories for PostCSS configuration. A fresh
Studio install nested below an unrelated `postcss.config.js` can therefore load
the ancestor project's plugins and fail its production build. Studio's
Tailwind integration is already supplied by the dedicated Vite plugin, so an
empty inline PostCSS plugin list is sufficient and isolates the build.

## A/B verification

- Added a hostile ancestor `postcss.config.js` referencing a deliberately
  missing plugin.
- Before: `npm run build` failed while loading the ancestor configuration.
- After, with the same hostile ancestor present: production build completed
  successfully (7,736 modules).
- `npm run typecheck` passes.
