### PR TITLE
Default coding-agent servers to reasoning off

### DIFF
--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -225,6 +225,16 @@ _TOOL_CALL_NUDGING_OPTION = typer.Option(
     help = "Retry once with a nudge when a non-streaming passthrough tool call can't be healed. "
     "On by default; when the flag is omitted an inherited UNSLOTH_TOOL_CALL_NUDGE is kept.",
 )
+_REASONING_OPTION = typer.Option(
+    "off",
+    "--reasoning",
+    rich_help_panel = _PANEL_SERVER,
+    help = (
+        "llama-server reasoning mode for an auto-started coding-agent server. "
+        "Defaults to off so tool calls stay in the structured tool channel; use "
+        "'auto' or 'on' to opt back into model reasoning."
+    ),
+)
 # Sampling overrides pin a value on the auto-started server (winning over the client and the
 # per-model recommendation). Default unset -> the model's recommended sampling is used.
 _TEMPERATURE_OPTION = typer.Option(
@@ -479,6 +489,7 @@ class ServerOptions(NamedTuple):
     enable_tools: bool = False
     tool_call_healing: Optional[bool] = None
     tool_call_nudging: Optional[bool] = None
+    reasoning: Literal["on", "off", "auto"] = "off"
     temperature: Optional[float] = None
     top_p: Optional[float] = None
     top_k: Optional[int] = None
@@ -994,6 +1005,8 @@ def _start_studio_server(
         str(parsed.port or 8888),
         "--enable-tools" if server.enable_tools else "--disable-tools",
         "--no-cloudflare",
+        "--reasoning",
+        server.reasoning,
         "--model",
         model,
     ]
@@ -3048,6 +3061,7 @@ def claude(
     enable_tools: bool = _ENABLE_TOOLS_OPTION,
     tool_call_healing: Optional[bool] = _TOOL_CALL_HEALING_OPTION,
     tool_call_nudging: Optional[bool] = _TOOL_CALL_NUDGING_OPTION,
+    reasoning: Literal["on", "off", "auto"] = _REASONING_OPTION,
     temperature: Optional[float] = _TEMPERATURE_OPTION,
     top_p: Optional[float] = _TOP_P_OPTION,
     top_k: Optional[int] = _TOP_K_OPTION,
@@ -3072,6 +3086,7 @@ def claude(
             enable_tools = enable_tools,
             tool_call_healing = tool_call_healing,
             tool_call_nudging = tool_call_nudging,
+            reasoning = reasoning,
             temperature = temperature,
             top_p = top_p,
             top_k = top_k,
@@ -3166,6 +3181,7 @@ def codex(
     enable_tools: bool = _ENABLE_TOOLS_OPTION,
     tool_call_healing: Optional[bool] = _TOOL_CALL_HEALING_OPTION,
     tool_call_nudging: Optional[bool] = _TOOL_CALL_NUDGING_OPTION,
+    reasoning: Literal["on", "off", "auto"] = _REASONING_OPTION,
     temperature: Optional[float] = _TEMPERATURE_OPTION,
     top_p: Optional[float] = _TOP_P_OPTION,
     top_k: Optional[int] = _TOP_K_OPTION,
@@ -3190,6 +3206,7 @@ def codex(
             enable_tools = enable_tools,
             tool_call_healing = tool_call_healing,
             tool_call_nudging = tool_call_nudging,
+            reasoning = reasoning,
             temperature = temperature,
             top_p = top_p,
             top_k = top_k,
@@ -3265,6 +3282,7 @@ def openclaw(
     enable_tools: bool = _ENABLE_TOOLS_OPTION,
     tool_call_healing: Optional[bool] = _TOOL_CALL_HEALING_OPTION,
     tool_call_nudging: Optional[bool] = _TOOL_CALL_NUDGING_OPTION,
+    reasoning: Literal["on", "off", "auto"] = _REASONING_OPTION,
     temperature: Optional[float] = _TEMPERATURE_OPTION,
     top_p: Optional[float] = _TOP_P_OPTION,
     top_k: Optional[int] = _TOP_K_OPTION,
@@ -3289,6 +3307,7 @@ def openclaw(
             enable_tools = enable_tools,
             tool_call_healing = tool_call_healing,
             tool_call_nudging = tool_call_nudging,
+            reasoning = reasoning,
             temperature = temperature,
             top_p = top_p,
             top_k = top_k,
@@ -3346,6 +3365,7 @@ def opencode(
     enable_tools: bool = _ENABLE_TOOLS_OPTION,
     tool_call_healing: Optional[bool] = _TOOL_CALL_HEALING_OPTION,
     tool_call_nudging: Optional[bool] = _TOOL_CALL_NUDGING_OPTION,
+    reasoning: Literal["on", "off", "auto"] = _REASONING_OPTION,
     temperature: Optional[float] = _TEMPERATURE_OPTION,
     top_p: Optional[float] = _TOP_P_OPTION,
     top_k: Optional[int] = _TOP_K_OPTION,
@@ -3370,6 +3390,7 @@ def opencode(
             enable_tools = enable_tools,
             tool_call_healing = tool_call_healing,
             tool_call_nudging = tool_call_nudging,
+            reasoning = reasoning,
             temperature = temperature,
             top_p = top_p,
             top_k = top_k,
@@ -3507,6 +3528,7 @@ def hermes(
     enable_tools: bool = _ENABLE_TOOLS_OPTION,
     tool_call_healing: Optional[bool] = _TOOL_CALL_HEALING_OPTION,
     tool_call_nudging: Optional[bool] = _TOOL_CALL_NUDGING_OPTION,
+    reasoning: Literal["on", "off", "auto"] = _REASONING_OPTION,
     temperature: Optional[float] = _TEMPERATURE_OPTION,
     top_p: Optional[float] = _TOP_P_OPTION,
     top_k: Optional[int] = _TOP_K_OPTION,
@@ -3533,6 +3555,7 @@ def hermes(
             enable_tools = enable_tools,
             tool_call_healing = tool_call_healing,
             tool_call_nudging = tool_call_nudging,
+            reasoning = reasoning,
             temperature = temperature,
             top_p = top_p,
             top_k = top_k,
@@ -3564,6 +3587,7 @@ def pi(
     enable_tools: bool = _ENABLE_TOOLS_OPTION,
     tool_call_healing: Optional[bool] = _TOOL_CALL_HEALING_OPTION,
     tool_call_nudging: Optional[bool] = _TOOL_CALL_NUDGING_OPTION,
+    reasoning: Literal["on", "off", "auto"] = _REASONING_OPTION,
     temperature: Optional[float] = _TEMPERATURE_OPTION,
     top_p: Optional[float] = _TOP_P_OPTION,
     top_k: Optional[int] = _TOP_K_OPTION,
@@ -3588,6 +3612,7 @@ def pi(
             enable_tools = enable_tools,
             tool_call_healing = tool_call_healing,
             tool_call_nudging = tool_call_nudging,
+            reasoning = reasoning,
             temperature = temperature,
             top_p = top_p,
             top_k = top_k,

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -226,7 +226,7 @@ _TOOL_CALL_NUDGING_OPTION = typer.Option(
     "On by default; when the flag is omitted an inherited UNSLOTH_TOOL_CALL_NUDGE is kept.",
 )
 _REASONING_OPTION = typer.Option(
-    "off",
+    None,
     "--reasoning",
     rich_help_panel = _PANEL_SERVER,
     help = (
@@ -489,7 +489,7 @@ class ServerOptions(NamedTuple):
     enable_tools: bool = False
     tool_call_healing: Optional[bool] = None
     tool_call_nudging: Optional[bool] = None
-    reasoning: Literal["on", "off", "auto"] = "off"
+    reasoning: Optional[Literal["on", "off", "auto"]] = None
     temperature: Optional[float] = None
     top_p: Optional[float] = None
     top_k: Optional[int] = None
@@ -1005,8 +1005,6 @@ def _start_studio_server(
         str(parsed.port or 8888),
         "--enable-tools" if server.enable_tools else "--disable-tools",
         "--no-cloudflare",
-        "--reasoning",
-        server.reasoning,
         "--model",
         model,
     ]
@@ -1033,6 +1031,10 @@ def _start_studio_server(
     # Own session/process group so a mid-session Ctrl+C (cancel a turn) doesn't reach the
     # server. It survives a successful agent session; torn down on startup/launch failure.
     child_env = os.environ.copy()
+    # Current llama-server versions read this documented env equivalent of --reasoning.
+    # Older managed versions ignore an unknown env variable instead of failing startup on
+    # an unknown passthrough CLI flag. An omitted start option still defaults to off.
+    child_env["LLAMA_ARG_REASONING"] = server.reasoning or "off"
     # Pass the marker via env so an older launcher ignores it instead of treating an
     # unknown CLI flag as a llama-server arg; new launchers preserve it across re-exec.
     child_env[_START_API_KEY_MARKER_ENV] = "1"
@@ -1170,6 +1172,14 @@ def _require_studio(
                 f"({', '.join(_pinned)}) apply only when this command starts the server, so the "
                 "running server keeps its current sampling. Stop it with `unsloth studio stop` "
                 "and re-run to apply them.",
+                err = True,
+            )
+        if server_options.reasoning is not None:
+            typer.echo(
+                f"Warning: an Unsloth server is already running at {base}; "
+                f"--reasoning {server_options.reasoning} applies only when this command starts "
+                "the server, so the running server keeps its current reasoning mode. Stop it "
+                "with `unsloth studio stop` and re-run to apply the override.",
                 err = True,
             )
         return base, None
@@ -3061,7 +3071,7 @@ def claude(
     enable_tools: bool = _ENABLE_TOOLS_OPTION,
     tool_call_healing: Optional[bool] = _TOOL_CALL_HEALING_OPTION,
     tool_call_nudging: Optional[bool] = _TOOL_CALL_NUDGING_OPTION,
-    reasoning: Literal["on", "off", "auto"] = _REASONING_OPTION,
+    reasoning: Optional[Literal["on", "off", "auto"]] = _REASONING_OPTION,
     temperature: Optional[float] = _TEMPERATURE_OPTION,
     top_p: Optional[float] = _TOP_P_OPTION,
     top_k: Optional[int] = _TOP_K_OPTION,
@@ -3181,7 +3191,7 @@ def codex(
     enable_tools: bool = _ENABLE_TOOLS_OPTION,
     tool_call_healing: Optional[bool] = _TOOL_CALL_HEALING_OPTION,
     tool_call_nudging: Optional[bool] = _TOOL_CALL_NUDGING_OPTION,
-    reasoning: Literal["on", "off", "auto"] = _REASONING_OPTION,
+    reasoning: Optional[Literal["on", "off", "auto"]] = _REASONING_OPTION,
     temperature: Optional[float] = _TEMPERATURE_OPTION,
     top_p: Optional[float] = _TOP_P_OPTION,
     top_k: Optional[int] = _TOP_K_OPTION,
@@ -3282,7 +3292,7 @@ def openclaw(
     enable_tools: bool = _ENABLE_TOOLS_OPTION,
     tool_call_healing: Optional[bool] = _TOOL_CALL_HEALING_OPTION,
     tool_call_nudging: Optional[bool] = _TOOL_CALL_NUDGING_OPTION,
-    reasoning: Literal["on", "off", "auto"] = _REASONING_OPTION,
+    reasoning: Optional[Literal["on", "off", "auto"]] = _REASONING_OPTION,
     temperature: Optional[float] = _TEMPERATURE_OPTION,
     top_p: Optional[float] = _TOP_P_OPTION,
     top_k: Optional[int] = _TOP_K_OPTION,
@@ -3365,7 +3375,7 @@ def opencode(
     enable_tools: bool = _ENABLE_TOOLS_OPTION,
     tool_call_healing: Optional[bool] = _TOOL_CALL_HEALING_OPTION,
     tool_call_nudging: Optional[bool] = _TOOL_CALL_NUDGING_OPTION,
-    reasoning: Literal["on", "off", "auto"] = _REASONING_OPTION,
+    reasoning: Optional[Literal["on", "off", "auto"]] = _REASONING_OPTION,
     temperature: Optional[float] = _TEMPERATURE_OPTION,
     top_p: Optional[float] = _TOP_P_OPTION,
     top_k: Optional[int] = _TOP_K_OPTION,
@@ -3528,7 +3538,7 @@ def hermes(
     enable_tools: bool = _ENABLE_TOOLS_OPTION,
     tool_call_healing: Optional[bool] = _TOOL_CALL_HEALING_OPTION,
     tool_call_nudging: Optional[bool] = _TOOL_CALL_NUDGING_OPTION,
-    reasoning: Literal["on", "off", "auto"] = _REASONING_OPTION,
+    reasoning: Optional[Literal["on", "off", "auto"]] = _REASONING_OPTION,
     temperature: Optional[float] = _TEMPERATURE_OPTION,
     top_p: Optional[float] = _TOP_P_OPTION,
     top_k: Optional[int] = _TOP_K_OPTION,
@@ -3587,7 +3597,7 @@ def pi(
     enable_tools: bool = _ENABLE_TOOLS_OPTION,
     tool_call_healing: Optional[bool] = _TOOL_CALL_HEALING_OPTION,
     tool_call_nudging: Optional[bool] = _TOOL_CALL_NUDGING_OPTION,
-    reasoning: Literal["on", "off", "auto"] = _REASONING_OPTION,
+    reasoning: Optional[Literal["on", "off", "auto"]] = _REASONING_OPTION,
     temperature: Optional[float] = _TEMPERATURE_OPTION,
     top_p: Optional[float] = _TOP_P_OPTION,
     top_k: Optional[int] = _TOP_K_OPTION,

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1993,7 +1993,8 @@ def test_start_studio_server_forwards_tool_flags_via_command_and_env(monkeypatch
     start._start_studio_server("http://127.0.0.1:8888", "unsloth/M-GGUF", start.LoadOptions())
     cmd, env = captured["command"], captured["kwargs"]["env"]
     assert "--disable-tools" in cmd and "--enable-tools" not in cmd
-    assert cmd[cmd.index("--reasoning") + 1] == "off"
+    assert "--reasoning" not in cmd
+    assert env["LLAMA_ARG_REASONING"] == "off"
     assert "--gpu-memory-mode" not in cmd
     assert env["UNSLOTH_DISABLE_TOOL_CALL_HEALING"] == "0"
     assert env["UNSLOTH_TOOL_CALL_NUDGE"] == "1"
@@ -2012,7 +2013,8 @@ def test_start_studio_server_forwards_tool_flags_via_command_and_env(monkeypatch
     )
     cmd, env = captured["command"], captured["kwargs"]["env"]
     assert "--enable-tools" in cmd and "--disable-tools" not in cmd
-    assert cmd[cmd.index("--reasoning") + 1] == "auto"
+    assert "--reasoning" not in cmd
+    assert env["LLAMA_ARG_REASONING"] == "auto"
     assert env["UNSLOTH_DISABLE_TOOL_CALL_HEALING"] == "1"
     assert env["UNSLOTH_TOOL_CALL_NUDGE"] == "0"
 
@@ -2125,7 +2127,25 @@ def test_require_studio_no_sampling_warning_without_pins(monkeypatch, capsys):
         server_options = start.ServerOptions(enable_tools = True),
     )
     assert base == BASE and server is None
-    assert "sampling" not in capsys.readouterr().err.lower()
+    assert capsys.readouterr().err == ""
+
+
+@pytest.mark.parametrize("reasoning", ["on", "off", "auto"])
+def test_require_studio_warns_on_explicit_reasoning_when_reusing_server(
+    monkeypatch, capsys, reasoning
+):
+    monkeypatch.setattr(start, "find_studio_server", lambda: BASE)
+    base, server = start._require_studio(
+        "unsloth/M-GGUF",
+        start.LoadOptions(),
+        serve = True,
+        server_options = start.ServerOptions(reasoning = reasoning),
+    )
+    assert base == BASE and server is None
+    err = capsys.readouterr().err
+    assert "already running" in err
+    assert f"--reasoning {reasoning}" in err
+    assert "unsloth studio stop" in err
 
 
 def test_start_claude_parses_sampling_flags(fake_studio, monkeypatch):
@@ -2691,7 +2711,8 @@ def test_start_studio_server_builds_command_and_waits(monkeypatch, capsys):
     cmd = captured["command"]
     assert cmd[1] == "run"
     assert "--disable-tools" in cmd and "--no-cloudflare" in cmd
-    assert cmd[cmd.index("--reasoning") + 1] == "off"
+    assert "--reasoning" not in cmd
+    assert captured["kwargs"]["env"]["LLAMA_ARG_REASONING"] == "off"
     assert cmd[cmd.index("--model") + 1] == "unsloth/Qwen3-1.7B-GGUF:UD-Q4_K_XL"
     assert cmd[cmd.index("--gguf-variant") + 1] == "UD-Q4_K_XL"
     assert cmd[cmd.index("--context-length") + 1] == "8192"

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1993,6 +1993,7 @@ def test_start_studio_server_forwards_tool_flags_via_command_and_env(monkeypatch
     start._start_studio_server("http://127.0.0.1:8888", "unsloth/M-GGUF", start.LoadOptions())
     cmd, env = captured["command"], captured["kwargs"]["env"]
     assert "--disable-tools" in cmd and "--enable-tools" not in cmd
+    assert cmd[cmd.index("--reasoning") + 1] == "off"
     assert "--gpu-memory-mode" not in cmd
     assert env["UNSLOTH_DISABLE_TOOL_CALL_HEALING"] == "0"
     assert env["UNSLOTH_TOOL_CALL_NUDGE"] == "1"
@@ -2002,10 +2003,16 @@ def test_start_studio_server_forwards_tool_flags_via_command_and_env(monkeypatch
         "http://127.0.0.1:8888",
         "unsloth/M-GGUF",
         start.LoadOptions(),
-        start.ServerOptions(enable_tools = True, tool_call_healing = False, tool_call_nudging = False),
+        start.ServerOptions(
+            enable_tools = True,
+            tool_call_healing = False,
+            tool_call_nudging = False,
+            reasoning = "auto",
+        ),
     )
     cmd, env = captured["command"], captured["kwargs"]["env"]
     assert "--enable-tools" in cmd and "--disable-tools" not in cmd
+    assert cmd[cmd.index("--reasoning") + 1] == "auto"
     assert env["UNSLOTH_DISABLE_TOOL_CALL_HEALING"] == "1"
     assert env["UNSLOTH_TOOL_CALL_NUDGE"] == "0"
 
@@ -2153,11 +2160,14 @@ def test_start_claude_parses_sampling_flags(fake_studio, monkeypatch):
             "0.3",
             "--top-k",
             "40",
+            "--reasoning",
+            "on",
         ],
     )
     assert result.exit_code == 0, result.output
     so = captured["server_options"]
     assert so.temperature == 0.3 and so.top_k == 40 and so.top_p is None
+    assert so.reasoning == "on"
 
 
 def test_connect_model_bare_id_matches_loaded_without_reload(fake_studio):
@@ -2681,6 +2691,7 @@ def test_start_studio_server_builds_command_and_waits(monkeypatch, capsys):
     cmd = captured["command"]
     assert cmd[1] == "run"
     assert "--disable-tools" in cmd and "--no-cloudflare" in cmd
+    assert cmd[cmd.index("--reasoning") + 1] == "off"
     assert cmd[cmd.index("--model") + 1] == "unsloth/Qwen3-1.7B-GGUF:UD-Q4_K_XL"
     assert cmd[cmd.index("--gguf-variant") + 1] == "UD-Q4_K_XL"
     assert cmd[cmd.index("--context-length") + 1] == "8192"


### PR DESCRIPTION
## Summary

- add `--reasoning on|off|auto` to `unsloth start`
- default auto-started coding-agent servers to `--reasoning off`
- allow `--reasoning auto` to restore llama.cpp model-detected behavior and `on` to force reasoning

## Why

Some reasoning models emit a complete tool call in `reasoning_content` instead of the structured `tool_calls` field expected by coding harnesses. The model can describe the correct edit without the harness ever executing it. This has also been reported upstream for Qwen3.5/3.6 in llama.cpp.

The default only applies when `unsloth start` launches its own server. Attaching to an existing Studio/server does not mutate or reload that server.

## Before / after

Before, a Qwen3.5-9B Hermes run generated the requested patch inside reasoning content, but no operation was executed.

After, a fresh Windows auto-start logged and launched llama.cpp with:

```text
--reasoning off
```

Pi then received a structured tool call, wrote and read `reasoning-proof.txt` containing `STRUCTURED_TOOL_OK`, and exited successfully.

## Validation

- targeted CLI/default/attach-path tests: 3 passed
- full `tests/test_start.py`: 335 passed, 3 skipped
- one unrelated existing Linux-only failure remains when a test monkeypatches `os.name` to `nt`, which makes `pathlib` reject `WindowsPath` on Linux

References:

- https://github.com/ggml-org/llama.cpp/issues/22684
- https://github.com/ggml-org/llama.cpp/blob/master/docs/function-calling.md
