### PR TITLE
Studio: keep grouped Python scripts visible and save them natively

### DIFF
--- a/studio/frontend/src/components/assistant-ui/tool-group.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-group.tsx
@@ -211,11 +211,13 @@ const ToolGroupImpl: FC<
   PropsWithChildren<{ startIndex: number; endIndex: number }>
 > = ({ children, startIndex, endIndex }) => {
   const toolCount = endIndex - startIndex + 1;
-  const containsArtifactTool = useAuiState(({ message }) =>
+  const containsUngroupedTool = useAuiState(({ message }) =>
     message.parts
       .slice(startIndex, endIndex + 1)
       .some(
-        (part) => part.type === "tool-call" && part.toolName === "render_html",
+        (part) =>
+          part.type === "tool-call" &&
+          (part.toolName === "render_html" || part.toolName === "python"),
       ),
   );
   // A blocking allow/deny prompt must never be hidden inside a collapsed
@@ -260,9 +262,9 @@ const ToolGroupImpl: FC<
     (hasLiveOutput && messageRunning) ||
     (forcedOpenRef.current && messageRunning);
 
-  // Render single tool calls and canvases directly so cards never hide in a
-  // collapsed group.
-  if (toolCount <= 1 || containsArtifactTool) {
+  // Render single calls, canvases, and Python scripts directly so their
+  // persistent content never hides in a collapsed group.
+  if (toolCount <= 1 || containsUngroupedTool) {
     return <>{children}</>;
   }
 

--- a/studio/frontend/src/components/assistant-ui/tool-ui-python.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-ui-python.tsx
@@ -87,15 +87,18 @@ const PythonToolUIImpl: ToolCallMessagePartComponent = ({
   const isWriting = isWritingCode && !awaitingApproval;
 
   return (
-    // Script, status and output all collapse behind the one chevron.
+    // Status, output and images collapse from history; the executed script
+    // renders outside ToolFallbackContent so it stays visible on reopen
+    // (#7165). Terminal keeps its command inside the collapsible -- a one-line
+    // command is not the artifact a user comes back for, a script is.
     <ToolFallbackRoot defaultOpen={isRunning}>
       <ToolFallbackTrigger
         toolName={firstLine ? `Python: ${firstLine}` : "Python"}
         status={status}
         icon={CodeIcon}
       />
-      <ToolFallbackContent>
-        {code && (
+      {code && (
+        <div className="mt-1 pl-5">
           <ToolCodeCell
             label="script"
             code={code}
@@ -103,7 +106,9 @@ const PythonToolUIImpl: ToolCallMessagePartComponent = ({
             downloadName="script.py"
             streaming={isWriting}
           />
-        )}
+        </div>
+      )}
+      <ToolFallbackContent>
         <div className="border-l-2 border-muted-foreground/20 pl-2">
           {/* Output */}
           {isRunning ? (

--- a/studio/frontend/src/components/assistant-ui/tool-ui-python.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-ui-python.tsx
@@ -4,6 +4,8 @@
 "use client";
 
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
+import { downloadFile, isDownloadCancelled } from "@/lib/native-files";
+import { toast } from "@/lib/toast";
 import { getAuthToken } from "@/features/auth/session";
 import type { ToolCallMessagePartComponent } from "@assistant-ui/react";
 import { useToolArgsStatus } from "@assistant-ui/react";
@@ -83,27 +85,14 @@ function CopyBtn({ text }: { text: string }) {
   );
 }
 
-/** Save the script as a .py file via a client-side Blob. */
-function DownloadBtn({ code, name = "script.py" }: { code: string; name?: string }) {
-  const download = useCallback(() => {
-    if (typeof document === "undefined") {
-      return;
-    }
-    try {
-      const blob = new Blob([code], { type: "text/x-python" });
-      const url = URL.createObjectURL(blob);
-      const anchor = document.createElement("a");
-      anchor.href = url;
-      anchor.download = name;
-      document.body.appendChild(anchor);
-      anchor.click();
-      anchor.remove();
-      // Revoke next tick, after the click consumes the URL.
-      setTimeout(() => URL.revokeObjectURL(url), 0);
-    } catch {
-      // Best-effort: never break the transcript over a download.
-    }
-  }, [code, name]);
+function DownloadBtn({ code }: { code: string }) {
+  const download = () => {
+    void downloadFile(code, "script.py", "text/x-python").catch((error) => {
+      if (!isDownloadCancelled(error)) {
+        toast.error("Could not save Python script.");
+      }
+    });
+  };
 
   return (
     <button

--- a/studio/src-tauri/src/native_file_dialogs.rs
+++ b/studio/src-tauri/src/native_file_dialogs.rs
@@ -47,11 +47,12 @@ fn save_filter(file_name: &str) -> (&'static str, Vec<&'static str>) {
         Some("csv") => ("CSV", vec!["csv"]),
         Some("md") | Some("markdown") => ("Markdown", vec!["md", "markdown"]),
         Some("html") | Some("htm") => ("HTML", vec!["html", "htm"]),
+        Some("py") => ("Python", vec!["py"]),
         Some("zip") => ("ZIP archive", vec!["zip"]),
         _ => (
             "Export files",
             vec![
-                "json", "jsonl", "ndjson", "csv", "md", "markdown", "html", "htm", "zip",
+                "json", "jsonl", "ndjson", "csv", "md", "markdown", "html", "htm", "py", "zip",
             ],
         ),
     }
@@ -259,6 +260,12 @@ mod tests {
     fn html_canvas_exports_use_an_html_save_filter() {
         assert_eq!(save_filter("canvas.html"), ("HTML", vec!["html", "htm"]));
         assert_eq!(save_filter("canvas.HTM"), ("HTML", vec!["html", "htm"]));
+    }
+
+    #[test]
+    fn python_scripts_use_a_python_save_filter() {
+        assert_eq!(save_filter("script.py"), ("Python", vec!["py"]));
+        assert_eq!(save_filter("script.PY"), ("Python", vec!["py"]));
     }
 
     #[test]


### PR DESCRIPTION
#7240 keeps executed Python scripts visible outside the tool card's collapsed output and adds a `script.py` download. Two paths still bypassed that behavior:

1. Assistant messages with multiple adjacent tool calls are wrapped in a separate `ToolGroup`. Reopening the thread from history mounts that outer group closed, hiding every Python script and download control again.
2. The download button used a browser Blob directly. In the desktop app this bypassed Studio's native save chooser, and the native chooser did not yet allow `.py` files.

## Reproduction

1. Persist a chat turn containing two adjacent completed Python tool calls.
2. Reopen the thread from history.
3. Observe the closed `2 tool calls` group.

The executed scripts and both download controls are hidden until the group is expanded.

In the desktop app, clicking Download also follows the browser-anchor path instead of invoking `save_native_file`.

## Fix

- Render any adjacent tool-call range containing Python as standalone cards, matching the existing `render_html` exception, so the executed source cannot be hidden by the aggregate collapse. Ranges without Python remain grouped, and non-Python siblings in a mixed range retain their own collapsed cards.
- Route Python downloads through the shared `downloadFile` boundary. Browsers retain the normal download, while Tauri uses the native save chooser.
- Keep native chooser cancellation silent and show an error only for a real save failure.
- Add a Python file filter so the native chooser accepts and defaults to `script.py`.

Python status, output, and images remain collapsible. Copy and Download continue to use the full executed source even when the displayed code is truncated.

## Verification

- Playwright against compiled Studio reproduced the closed outer group on current main, then confirmed both scripts and both download controls remain visible after history hydration with this change.
- Browser Download saved `script.py` with byte-exact executed source.
- Tauri-mode UI checks confirmed one native save invocation, no browser download, byte-exact UTF-8 source, the encoded `script.py` filename, silent cancellation, and an error toast on native rejection.
- Native file-dialog tests: 9 passed.
- `npm run typecheck`
- `npm run build`
- `cargo fmt --check`
- `git diff --check`
- Targeted ESLint reported only the files' existing restricted-import, ref-during-render, and fast-refresh findings.
