### PR TITLE
fix(studio): stop re-tokenizing the whole code block on every frame while streaming

### DIFF
--- a/studio/frontend/src/components/assistant-ui/code-plugin.ts
+++ b/studio/frontend/src/components/assistant-ui/code-plugin.ts
@@ -53,6 +53,9 @@ const normalizeLanguage = (language: string): BundledLanguage => {
 // unstyled, re-tokenizing in full at most every REFRESH_MS.
 const MIN_INCREMENTAL_CHARS = 2000;
 const REFRESH_MS = 250;
+// One slot per fence in flight. A message can hold several large fences, and
+// Streamdown revisits all of them on every render.
+const MAX_SLOTS_PER_KEY = 8;
 
 type TokenLine = HighlightResult["tokens"][number];
 type Dispatch = {
@@ -60,15 +63,15 @@ type Dispatch = {
   language: BundledLanguage;
   callback?: (result: HighlightResult) => void;
 };
-type CacheEntry = {
-  /** Code the cached tokens were produced from. */
+type Slot = {
+  /** Code that produced `result`. Only ever set together with it. */
   code: string;
   result: HighlightResult | null;
-  /** When inner.highlight() was last dispatched for this key. */
-  dispatchedAt: number;
-  /** Trailing re-tokenize that closes out a run of reused results. */
+  /** Code of the dispatch awaiting a callback. */
+  inFlight: string | null;
+  lastDispatchAt: number;
   trailing: ReturnType<typeof setTimeout> | null;
-  latest: Dispatch | null;
+  pending: Dispatch | null;
 };
 
 // Unstyled line: no colour fields, so it renders in the default foreground
@@ -80,15 +83,26 @@ export function createCodePlugin(
   options: CodePluginOptions = {},
 ): CodeHighlighterPlugin {
   const inner = createShikiCodePlugin(options);
-  const cache = new Map<string, CacheEntry>();
+  const slotsByKey = new Map<string, Slot[]>();
 
-  const dispatch = (entry: CacheEntry, { opts, language, callback }: Dispatch) => {
-    entry.code = opts.code;
-    entry.dispatchedAt = Date.now();
-    return inner.highlight({ ...opts, language }, (result) => {
-      // Ignore stale results from a superseded dispatch.
-      if (entry.code === opts.code) entry.result = result;
-      callback?.(result);
+  const clearTrailing = (slot: Slot) => {
+    if (slot.trailing !== null) clearTimeout(slot.trailing);
+    slot.trailing = null;
+    slot.pending = null;
+  };
+
+  const dispatch = (slot: Slot, d: Dispatch) => {
+    slot.inFlight = d.opts.code;
+    slot.lastDispatchAt = Date.now();
+    return inner.highlight({ ...d.opts, language: d.language }, (result) => {
+      // Adopt only the dispatch still in flight, and move code/result together
+      // so a reuse can never slice one against the other.
+      if (slot.inFlight === d.opts.code) {
+        slot.code = d.opts.code;
+        slot.result = result;
+        slot.inFlight = null;
+      }
+      d.callback?.(result);
     });
   };
 
@@ -106,44 +120,58 @@ export function createCodePlugin(
       }
 
       const key = `${language} ${JSON.stringify(opts.themes)}`;
-      let entry = cache.get(key);
-      if (!entry) {
-        entry = { code: "", result: null, dispatchedAt: 0, trailing: null, latest: null };
-        cache.set(key, entry);
-      }
-      const now = Date.now();
-      const elapsed = now - entry.dispatchedAt;
-      // Kept lines are byte-identical to the cached run (strict prefix), so
-      // their tokens are still correct; only the tail is unstyled.
-      const canReuse =
-        entry.result != null &&
-        opts.code.length > entry.code.length &&
-        opts.code.startsWith(entry.code) &&
-        elapsed < REFRESH_MS;
-
-      if (!canReuse) {
-        return dispatch(entry, { opts, language, callback });
+      let slots = slotsByKey.get(key);
+      if (!slots) {
+        slots = [];
+        slotsByKey.set(key, slots);
       }
 
-      // Always close out a reused run, so the block cannot be left showing an
-      // unstyled tail if this turns out to be the final render.
-      entry.latest = { opts, language, callback };
-      if (entry.trailing === null) {
-        const wait = Math.max(0, REFRESH_MS - elapsed);
-        entry.trailing = setTimeout(() => {
-          const e = entry as CacheEntry;
-          e.trailing = null;
-          const pending = e.latest;
-          e.latest = null;
-          if (pending) dispatch(e, pending);
-        }, wait);
+      // Match this fence to its own slot by longest prefix, so sibling fences
+      // do not evict each other.
+      let slot: Slot | null = null;
+      let bestLength = -1;
+      for (const candidate of slots) {
+        const anchor = candidate.code || candidate.inFlight || "";
+        if (!anchor || !opts.code.startsWith(anchor)) continue;
+        if (anchor.length > bestLength) {
+          slot = candidate;
+          bestLength = anchor.length;
+        }
+      }
+      if (!slot) {
+        slot = { code: "", result: null, inFlight: null, lastDispatchAt: 0, trailing: null, pending: null };
+        slots.unshift(slot);
+        for (const dropped of slots.splice(MAX_SLOTS_PER_KEY)) clearTrailing(dropped);
       }
 
-      const previous = entry.result as HighlightResult;
+      // Finished fence re-rendered unchanged: serve it, never re-tokenize.
+      if (slot.result && slot.code === opts.code) return slot.result;
+
+      const elapsed = Date.now() - slot.lastDispatchAt;
+      const grew = slot.result !== null && opts.code.length > slot.code.length;
+      if (!grew || elapsed >= REFRESH_MS) {
+        clearTrailing(slot);
+        return dispatch(slot, { opts, language, callback });
+      }
+
+      // Always close out a reused run, so the fence cannot be left showing an
+      // unstyled tail if this turns out to be its final render.
+      slot.pending = { opts, language, callback };
+      if (slot.trailing === null) {
+        const target = slot;
+        target.trailing = setTimeout(() => {
+          target.trailing = null;
+          const next = target.pending;
+          target.pending = null;
+          if (next) dispatch(target, next);
+        }, Math.max(0, REFRESH_MS - elapsed));
+      }
+
+      const previous = slot.result as HighlightResult;
       // Drop the cached final line: it may have been cut mid-token.
       const keptLines = previous.tokens.slice(
         0,
-        Math.max(0, entry.code.split("\n").length - 1),
+        Math.max(0, slot.code.split("\n").length - 1),
       );
       const tail = opts.code.split("\n").slice(keptLines.length);
       return { ...previous, tokens: [...keptLines, ...tail.map(plainLine)] };

--- a/studio/frontend/src/components/assistant-ui/code-plugin.ts
+++ b/studio/frontend/src/components/assistant-ui/code-plugin.ts
@@ -53,6 +53,15 @@ const normalizeLanguage = (language: string): BundledLanguage => {
 // unstyled, re-tokenizing in full at most every REFRESH_MS.
 const MIN_INCREMENTAL_CHARS = 2000;
 const REFRESH_MS = 250;
+// Date.now() is wall clock: a backward step (an NTP correction, or resuming
+// from sleep) makes `elapsed` negative, which pins the reuse branch on and
+// schedules the trailing refresh by the size of the step. The throttle only
+// needs elapsed time, which the monotonic clock provides.
+const monotonicNow = (): number =>
+  typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : Date.now();
+
 // One slot per fence in flight. A message can hold several large fences, and
 // Streamdown revisits all of them on every render.
 const MAX_SLOTS_PER_KEY = 8;
@@ -91,19 +100,31 @@ export function createCodePlugin(
     slot.pending = null;
   };
 
+  const adopt = (slot: Slot, code: string, result: HighlightResult) => {
+    // Move code and result together so a reuse can never slice one against the
+    // other.
+    slot.code = code;
+    slot.result = result;
+    slot.inFlight = null;
+  };
+
   const dispatch = (slot: Slot, d: Dispatch) => {
     slot.inFlight = d.opts.code;
-    slot.lastDispatchAt = Date.now();
-    return inner.highlight({ ...d.opts, language: d.language }, (result) => {
-      // Adopt only the dispatch still in flight, and move code/result together
-      // so a reuse can never slice one against the other.
+    slot.lastDispatchAt = monotonicNow();
+    const immediate = inner.highlight({ ...d.opts, language: d.language }, (result) => {
+      // Adopt only the dispatch still in flight.
       if (slot.inFlight === d.opts.code) {
-        slot.code = d.opts.code;
-        slot.result = result;
-        slot.inFlight = null;
+        adopt(slot, d.opts.code, result);
       }
       d.callback?.(result);
     });
+    // @streamdown/code answers out of its own cache synchronously and then
+    // never invokes the callback, so adopt that result here as well; otherwise
+    // the slot keeps pointing at the older tokens.
+    if (immediate) {
+      adopt(slot, d.opts.code, immediate);
+    }
+    return immediate;
   };
 
   return {
@@ -147,7 +168,7 @@ export function createCodePlugin(
       // Finished fence re-rendered unchanged: serve it, never re-tokenize.
       if (slot.result && slot.code === opts.code) return slot.result;
 
-      const elapsed = Date.now() - slot.lastDispatchAt;
+      const elapsed = monotonicNow() - slot.lastDispatchAt;
       const grew = slot.result !== null && opts.code.length > slot.code.length;
       if (!grew || elapsed >= REFRESH_MS) {
         clearTrailing(slot);
@@ -163,7 +184,12 @@ export function createCodePlugin(
           target.trailing = null;
           const next = target.pending;
           target.pending = null;
-          if (next) dispatch(target, next);
+          if (!next) return;
+          const immediate = dispatch(target, next);
+          // Nothing consumes dispatch()'s return value on this path, so a
+          // synchronous inner cache hit has to be handed over by hand or the
+          // fence keeps its unstyled tail for good.
+          if (immediate) next.callback?.(immediate);
         }, Math.max(0, REFRESH_MS - elapsed));
       }
 

--- a/studio/frontend/src/components/assistant-ui/code-plugin.ts
+++ b/studio/frontend/src/components/assistant-ui/code-plugin.ts
@@ -55,13 +55,26 @@ const MIN_INCREMENTAL_CHARS = 2000;
 const REFRESH_MS = 250;
 
 type TokenLine = HighlightResult["tokens"][number];
+type Dispatch = {
+  opts: HighlightOptions;
+  language: BundledLanguage;
+  callback?: (result: HighlightResult) => void;
+};
 type CacheEntry = {
   /** Code the cached tokens were produced from. */
   code: string;
   result: HighlightResult | null;
   /** When inner.highlight() was last dispatched for this key. */
   dispatchedAt: number;
+  /** Trailing re-tokenize that closes out a run of reused results. */
+  trailing: ReturnType<typeof setTimeout> | null;
+  latest: Dispatch | null;
 };
+
+// Unstyled line: no colour fields, so it renders in the default foreground
+// rather than inheriting a neighbouring token's colour.
+const plainLine = (text: string): TokenLine =>
+  [{ content: text, offset: 0 }] as unknown as TokenLine;
 
 export function createCodePlugin(
   options: CodePluginOptions = {},
@@ -69,9 +82,15 @@ export function createCodePlugin(
   const inner = createShikiCodePlugin(options);
   const cache = new Map<string, CacheEntry>();
 
-  // Copies an existing token so dual-theme `variants` stay well-formed.
-  const plainLine = (text: string, template?: TokenLine[number]): TokenLine =>
-    [{ ...(template ?? {}), content: text, offset: 0 }] as TokenLine;
+  const dispatch = (entry: CacheEntry, { opts, language, callback }: Dispatch) => {
+    entry.code = opts.code;
+    entry.dispatchedAt = Date.now();
+    return inner.highlight({ ...opts, language }, (result) => {
+      // Ignore stale results from a superseded dispatch.
+      if (entry.code === opts.code) entry.result = result;
+      callback?.(result);
+    });
+  };
 
   return {
     ...inner,
@@ -87,48 +106,47 @@ export function createCodePlugin(
       }
 
       const key = `${language} ${JSON.stringify(opts.themes)}`;
-      const cached = cache.get(key);
+      let entry = cache.get(key);
+      if (!entry) {
+        entry = { code: "", result: null, dispatchedAt: 0, trailing: null, latest: null };
+        cache.set(key, entry);
+      }
       const now = Date.now();
-      const grewFrom =
-        cached?.result != null &&
-        opts.code.length > cached.code.length &&
-        opts.code.startsWith(cached.code)
-          ? cached
-          : null;
+      const elapsed = now - entry.dispatchedAt;
+      // Kept lines are byte-identical to the cached run (strict prefix), so
+      // their tokens are still correct; only the tail is unstyled.
+      const canReuse =
+        entry.result != null &&
+        opts.code.length > entry.code.length &&
+        opts.code.startsWith(entry.code) &&
+        elapsed < REFRESH_MS;
 
-      // Shiki returns null synchronously and resolves via callback, so
-      // throttling the dispatch is what removes the per-frame work.
-      if (grewFrom && now - grewFrom.dispatchedAt < REFRESH_MS) {
-        const previous = grewFrom.result as HighlightResult;
-        // Drop the cached final line: it may have been cut mid-token.
-        const keptLines = previous.tokens.slice(
-          0,
-          Math.max(0, grewFrom.code.split("\n").length - 1),
-        );
-        const template = previous.tokens[0]?.[0];
-        const tail = opts.code.split("\n").slice(keptLines.length);
-        return {
-          ...previous,
-          tokens: [
-            ...keptLines,
-            ...tail.map((line) => plainLine(line, template)),
-          ],
-        };
+      if (!canReuse) {
+        return dispatch(entry, { opts, language, callback });
       }
 
-      cache.set(key, {
-        code: opts.code,
-        result: cached?.result ?? null,
-        dispatchedAt: now,
-      });
-      return inner.highlight({ ...opts, language }, (result) => {
-        const entry = cache.get(key);
-        // Ignore stale results from a superseded dispatch.
-        if (entry && entry.code === opts.code) {
-          entry.result = result;
-        }
-        callback?.(result);
-      });
+      // Always close out a reused run, so the block cannot be left showing an
+      // unstyled tail if this turns out to be the final render.
+      entry.latest = { opts, language, callback };
+      if (entry.trailing === null) {
+        const wait = Math.max(0, REFRESH_MS - elapsed);
+        entry.trailing = setTimeout(() => {
+          const e = entry as CacheEntry;
+          e.trailing = null;
+          const pending = e.latest;
+          e.latest = null;
+          if (pending) dispatch(e, pending);
+        }, wait);
+      }
+
+      const previous = entry.result as HighlightResult;
+      // Drop the cached final line: it may have been cut mid-token.
+      const keptLines = previous.tokens.slice(
+        0,
+        Math.max(0, entry.code.split("\n").length - 1),
+      );
+      const tail = opts.code.split("\n").slice(keptLines.length);
+      return { ...previous, tokens: [...keptLines, ...tail.map(plainLine)] };
     },
   };
 }

--- a/studio/frontend/src/components/assistant-ui/code-plugin.ts
+++ b/studio/frontend/src/components/assistant-ui/code-plugin.ts
@@ -48,22 +48,19 @@ const normalizeLanguage = (language: string): BundledLanguage => {
 };
 
 // A streaming fence re-enters highlight() every frame with the whole block, so
-// Shiki re-tokenizes it from scratch ~60x/sec: O(length) per frame. Past
-// MIN_INCREMENTAL_CHARS, reuse the cached tokens and append the new tail
-// unstyled, re-tokenizing in full at most every REFRESH_MS.
+// Shiki re-tokenizes it in full ~60x/sec. Past MIN_INCREMENTAL_CHARS, reuse the
+// cached tokens with an unstyled tail, re-tokenizing at most every REFRESH_MS.
 const MIN_INCREMENTAL_CHARS = 2000;
 const REFRESH_MS = 250;
-// Date.now() is wall clock: a backward step (an NTP correction, or resuming
-// from sleep) makes `elapsed` negative, which pins the reuse branch on and
-// schedules the trailing refresh by the size of the step. The throttle only
-// needs elapsed time, which the monotonic clock provides.
+// Wall-clock Date.now() can step backwards (NTP, sleep resume) and make
+// `elapsed` negative; the throttle only needs elapsed time, so stay monotonic.
 const monotonicNow = (): number =>
   typeof performance !== "undefined" && typeof performance.now === "function"
     ? performance.now()
     : Date.now();
 
-// One slot per fence in flight. A message can hold several large fences, and
-// Streamdown revisits all of them on every render.
+// One slot per fence: a message can hold several large fences, and Streamdown
+// revisits all of them on every render.
 const MAX_SLOTS_PER_KEY = 8;
 
 type TokenLine = HighlightResult["tokens"][number];
@@ -83,8 +80,8 @@ type Slot = {
   pending: Dispatch | null;
 };
 
-// Unstyled line: no colour fields, so it renders in the default foreground
-// rather than inheriting a neighbouring token's colour.
+// No colour fields, so it renders in the default foreground instead of
+// inheriting a neighbouring token's colour.
 const plainLine = (text: string): TokenLine =>
   [{ content: text, offset: 0 }] as unknown as TokenLine;
 
@@ -101,8 +98,7 @@ export function createCodePlugin(
   };
 
   const adopt = (slot: Slot, code: string, result: HighlightResult) => {
-    // Move code and result together so a reuse can never slice one against the
-    // other.
+    // Write code and result together so a reuse cannot slice one against the other.
     slot.code = code;
     slot.result = result;
     slot.inFlight = null;
@@ -112,15 +108,13 @@ export function createCodePlugin(
     slot.inFlight = d.opts.code;
     slot.lastDispatchAt = monotonicNow();
     const immediate = inner.highlight({ ...d.opts, language: d.language }, (result) => {
-      // Adopt only the dispatch still in flight.
       if (slot.inFlight === d.opts.code) {
         adopt(slot, d.opts.code, result);
       }
       d.callback?.(result);
     });
-    // @streamdown/code answers out of its own cache synchronously and then
-    // never invokes the callback, so adopt that result here as well; otherwise
-    // the slot keeps pointing at the older tokens.
+    // @streamdown/code answers out of its own cache synchronously and never
+    // invokes the callback, so adopt here too or the slot keeps older tokens.
     if (immediate) {
       adopt(slot, d.opts.code, immediate);
     }
@@ -147,8 +141,7 @@ export function createCodePlugin(
         slotsByKey.set(key, slots);
       }
 
-      // Match this fence to its own slot by longest prefix, so sibling fences
-      // do not evict each other.
+      // Longest-prefix match, so sibling fences do not evict each other.
       let slot: Slot | null = null;
       let bestLength = -1;
       for (const candidate of slots) {
@@ -175,8 +168,7 @@ export function createCodePlugin(
         return dispatch(slot, { opts, language, callback });
       }
 
-      // Always close out a reused run, so the fence cannot be left showing an
-      // unstyled tail if this turns out to be its final render.
+      // Close out a reused run, so a final render is never left unstyled.
       slot.pending = { opts, language, callback };
       if (slot.trailing === null) {
         const target = slot;
@@ -186,9 +178,8 @@ export function createCodePlugin(
           target.pending = null;
           if (!next) return;
           const immediate = dispatch(target, next);
-          // Nothing consumes dispatch()'s return value on this path, so a
-          // synchronous inner cache hit has to be handed over by hand or the
-          // fence keeps its unstyled tail for good.
+          // Nothing consumes this return value, so hand a synchronous cache
+          // hit to the callback or the fence keeps its unstyled tail.
           if (immediate) next.callback?.(immediate);
         }, Math.max(0, REFRESH_MS - elapsed));
       }

--- a/studio/frontend/src/components/assistant-ui/code-plugin.ts
+++ b/studio/frontend/src/components/assistant-ui/code-plugin.ts
@@ -47,20 +47,88 @@ const normalizeLanguage = (language: string): BundledLanguage => {
   return (override ?? (key as BundledLanguage));
 };
 
+// A streaming fence re-enters highlight() every frame with the whole block, so
+// Shiki re-tokenizes it from scratch ~60x/sec: O(length) per frame. Past
+// MIN_INCREMENTAL_CHARS, reuse the cached tokens and append the new tail
+// unstyled, re-tokenizing in full at most every REFRESH_MS.
+const MIN_INCREMENTAL_CHARS = 2000;
+const REFRESH_MS = 250;
+
+type TokenLine = HighlightResult["tokens"][number];
+type CacheEntry = {
+  /** Code the cached tokens were produced from. */
+  code: string;
+  result: HighlightResult | null;
+  /** When inner.highlight() was last dispatched for this key. */
+  dispatchedAt: number;
+};
+
 export function createCodePlugin(
   options: CodePluginOptions = {},
 ): CodeHighlighterPlugin {
   const inner = createShikiCodePlugin(options);
+  const cache = new Map<string, CacheEntry>();
+
+  // Copies an existing token so dual-theme `variants` stay well-formed.
+  const plainLine = (text: string, template?: TokenLine[number]): TokenLine =>
+    [{ ...(template ?? {}), content: text, offset: 0 }] as TokenLine;
+
   return {
     ...inner,
-    supportsLanguage: (language) => inner.supportsLanguage(normalizeLanguage(language)),
+    supportsLanguage: (language) =>
+      inner.supportsLanguage(normalizeLanguage(language)),
     highlight: (
       opts: HighlightOptions,
       callback?: (result: HighlightResult) => void,
-    ) =>
-      inner.highlight(
-        { ...opts, language: normalizeLanguage(opts.language) },
-        callback,
-      ),
+    ) => {
+      const language = normalizeLanguage(opts.language);
+      if (opts.code.length < MIN_INCREMENTAL_CHARS) {
+        return inner.highlight({ ...opts, language }, callback);
+      }
+
+      const key = `${language} ${JSON.stringify(opts.themes)}`;
+      const cached = cache.get(key);
+      const now = Date.now();
+      const grewFrom =
+        cached?.result != null &&
+        opts.code.length > cached.code.length &&
+        opts.code.startsWith(cached.code)
+          ? cached
+          : null;
+
+      // Shiki returns null synchronously and resolves via callback, so
+      // throttling the dispatch is what removes the per-frame work.
+      if (grewFrom && now - grewFrom.dispatchedAt < REFRESH_MS) {
+        const previous = grewFrom.result as HighlightResult;
+        // Drop the cached final line: it may have been cut mid-token.
+        const keptLines = previous.tokens.slice(
+          0,
+          Math.max(0, grewFrom.code.split("\n").length - 1),
+        );
+        const template = previous.tokens[0]?.[0];
+        const tail = opts.code.split("\n").slice(keptLines.length);
+        return {
+          ...previous,
+          tokens: [
+            ...keptLines,
+            ...tail.map((line) => plainLine(line, template)),
+          ],
+        };
+      }
+
+      cache.set(key, {
+        code: opts.code,
+        result: cached?.result ?? null,
+        dispatchedAt: now,
+      });
+      return inner.highlight({ ...opts, language }, (result) => {
+        const entry = cache.get(key);
+        // Ignore stale results from a superseded dispatch.
+        if (entry && entry.code === opts.code) {
+          entry.result = result;
+        }
+        callback?.(result);
+      });
+    },
   };
 }


### PR DESCRIPTION
## Problem

Reported in #7522. The chat UI gets progressively laggy while a model is generating, and it is much worse once the answer contains a large block of code. The video in that thread shows the reasoning text streaming smoothly and then the code arriving in lumps.

The cause is in the Shiki code plugin. While a fence is still streaming, `highlight()` is called on every animation frame with the entire block, and Shiki re-tokenizes it from scratch each time. That is O(length) per frame and O(length^2) over the message.

Instrumenting one generation:

```
highlight() calls:  808        (~50/sec, i.e. every frame)
chars tokenized:    5,504,216
rendered block:     13,561 chars
```

5.5MB of tokenization to render a 13.5KB block. A CPU profile of 8.2s mid-stream put about 4s, roughly half the renderer main thread, inside the TextMate tokenizer (`findNextMatchSync` 2.78s, plus `_pushAttributed` and the grammar matchers).

Worth noting for the issue thread: this is not specific to HTML and not caused by the canvas preview. A Python block of the same size degrades identically. "write a html flappy bird game" is simply a prompt that reliably produces a big code block very quickly.

## Fix

Blocks under 2000 chars are unchanged, since a full re-tokenize is cheap there. Above that, a growing fence reuses the tokens from the last real tokenization for the lines it already covered and appends the newly arrived tail as unstyled lines, so text still lands every frame. A full re-tokenize runs at most every 250ms, which colours the tail and fixes up any construct spanning the boundary.

Shiki always returns `null` synchronously and resolves through the callback, so throttling the dispatch is what actually removes the per-frame work.

## Results

Measured against the real UI by replaying a stream at 230 tok/s, the generation rate from the reporter's log, so rendering is isolated from inference.

| emitted chars | frame p50 before | dropped before | frame p50 after | dropped after |
| --- | --- | --- | --- | --- |
| 0 to 8k | 16.7ms | 0 | 16.7ms | 0 |
| 16k | 26.3ms | 2 | 16.6ms | 4 |
| 22k | 8.0ms | 110 | 16.7ms | 9 |
| 26k | 8.8ms | 112 | 16.7ms | 9 |

Total dropped frames over the generation: 460 to 63 for the HTML block, 567 to 50 for the Python one. Frame p50 stays pinned at 16.7ms instead of collapsing into lumps (the low p50 values before the fix are frames bunching together, not frames being fast).

Tokenizer time went from about 4s to about 280ms per 8s of streaming, and the main thread went from roughly 50% busy to 57% idle.

## Verification

The finished block renders byte identical to before the change (28,320 chars in, 28,320 out) and fully highlighted (9,078 spans, 8,181 coloured). Typecheck and build pass.

## Not covered here

While measuring I found two more streaming render costs that are separate from this one:

- Large markdown tables are worse than this was. A 600 row table spent 40.5s of a 72s stream in long tasks, dominated by micromark's GFM table resolver. Fine under about 200 rows, degrades sharply past 400.
- Inline code heavy text is slowed by a character scan inside Streamdown.

Both sit upstream of us rather than in this plugin, so they are not touched here.

Closes #7522
