### PR TITLE
perf(studio): remove quadratic region scan in LaTeX preprocessing

### DIFF
--- a/studio/frontend/src/lib/latex.ts
+++ b/studio/frontend/src/lib/latex.ts
@@ -33,19 +33,20 @@ function findCodeBlockRegions(content: string): Array<[number, number]> {
     regions.push([match.index, match.index + match[0].length]);
   }
 
-  // Inline code: `...` (skip spans inside fenced blocks, filtered below)
+  // Inline code: `...`, skipped when inside a fenced block. Both loops yield
+  // ascending matches, so walk the fenced list with a cursor rather than
+  // rescanning it per match (was quadratic on code-heavy text).
+  const fencedCount = regions.length;
   const inlineRe = /`[^`\n]+`/g;
+  let fencedIndex = 0;
   while ((match = inlineRe.exec(content)) !== null) {
     const start = match.index;
     const end = start + match[0].length;
-    let inside = false;
-    for (const [rs, re] of regions) {
-      if (start >= rs && end <= re) {
-        inside = true;
-        break;
-      }
+    while (fencedIndex < fencedCount && regions[fencedIndex][1] <= start) {
+      fencedIndex += 1;
     }
-    if (!inside) {
+    const fenced = fencedIndex < fencedCount ? regions[fencedIndex] : null;
+    if (!(fenced && start >= fenced[0] && end <= fenced[1])) {
       regions.push([start, end]);
     }
   }


### PR DESCRIPTION
## Problem

`findCodeBlockRegions` in `studio/frontend/src/lib/latex.ts` collects fenced regions first, then walks inline code spans. For each inline match it scanned every region found so far to decide whether that match sits inside a fence. Accepted inline spans are appended to the same array, so the scan grows with each match, making it quadratic in the number of inline spans.

This is on a hot path. `preprocessLaTeX` runs over the full message text on every animation frame while a response is streaming, and calls `findCodeBlockRegions` twice per call, so it shows up on code heavy answers.

## Fix

Fenced matches and inline matches are both produced by `RegExp.exec` in ascending, non overlapping order, so the fenced list can be walked with a cursor instead of rescanned per match. Only a fenced region can contain an inline span, so previously accepted inline regions never needed to be checked at all.

## Results

34,670 chars containing 2,100 inline spans, averaged over 40 calls:

```
before: 5.51 ms per call
after:  0.12 ms per call
```

In the app this is a secondary cost, so the end to end gain is smaller than the microbenchmark: on a stream of that text, dropped frames went from 167 to 76. The remaining cost there is a character scan inside Streamdown, not ours.

## Correctness

Output is unchanged. A 4,000 case fuzz over fenced blocks, tilde fences, unclosed fences, inline spans inside and outside fences, adjacent backticks, tables and currency text produced identical region lists from the old and new implementations, with zero mismatches.

Typecheck and build pass.
