### PR TITLE
feat(studio): Mac adapter-format option for LoRA export, with GGUF adapters on macOS

### DIFF
--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -51,6 +51,116 @@ if not _IS_MLX:
 
 logger = get_logger(__name__)
 
+# Weight-file names per adapter format (PEFT includes its legacy .bin
+# spelling); a directory or Hub repo must never carry both formats.
+_ADAPTER_WEIGHT_FILES = {"mlx": "adapters.safetensors", "peft": "adapter_model.safetensors"}
+_ADAPTER_WEIGHT_NAMES = {
+    "mlx": frozenset({"adapters.safetensors"}),
+    "peft": frozenset({"adapter_model.safetensors", "adapter_model.bin"}),
+}
+_ZOO_UPGRADE_MESSAGE = (
+    "PEFT adapter conversion requires an updated unsloth-zoo. Upgrade "
+    "unsloth-zoo, then retry adapter_format='peft' (or GGUF adapter export)."
+)
+# Serializes this process's adapter pushes; cross-process safety comes from
+# the Hub-side parent_commit compare-and-swap in _push_adapter_dir_cas.
+import threading
+
+_ADAPTER_PUSH_LOCK = threading.Lock()
+
+
+def _resolve_adapter_format(adapter_format: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+    """Resolve the requested adapter format against the platform.
+
+    Returns (resolved_format, error_message). Omission resolves to each
+    platform's native format, so old clients keep byte-identical behavior.
+    """
+    if adapter_format is None:
+        return ("mlx" if _IS_MLX else "peft"), None
+    if adapter_format not in _ADAPTER_WEIGHT_FILES:
+        return None, (f"Invalid adapter_format '{adapter_format}'. Choose 'mlx' or 'peft'.")
+    if adapter_format == "mlx" and not _IS_MLX:
+        return None, (
+            "adapter_format='mlx' is only available on Apple-silicon MLX "
+            "servers; this server exports the native PEFT format."
+        )
+    return adapter_format, None
+
+
+def _push_adapter_dir_cas(
+    hf_api: "HfApi", folder_path: str, repo_id: str, private: bool, resolved_format: str
+) -> None:
+    """Push an adapter folder as ONE atomic Hub commit, refusing format-mixed repos.
+
+    A pre-check at a pinned revision refuses when the repo carries the OTHER
+    format's weight file that this upload would not replace; the commit then
+    uses parent_commit=<that revision> so the Hub itself rejects a concurrent
+    writer (retried once against the new head before surfacing a conflict).
+    """
+    from huggingface_hub import CommitOperationAdd
+
+    other_names = _ADAPTER_WEIGHT_NAMES["peft" if resolved_format == "mlx" else "mlx"]
+    files = sorted(
+        os.path.relpath(os.path.join(root, name), folder_path).replace(os.sep, "/")
+        for root, _dirs, names in os.walk(folder_path)
+        for name in names
+    )
+    _staged_mixed = sorted(f for f in files if f.rsplit("/", 1)[-1] in other_names)
+    if _staged_mixed:
+        raise RuntimeError(
+            f"The staged export folder itself contains {_staged_mixed}; "
+            "refusing to publish a mixed-format adapter folder."
+        )
+    uploading = set(files)
+
+    def _precheck() -> Tuple[str, set]:
+        head = hf_api.repo_info(repo_id, repo_type = "model").sha
+        existing = set(hf_api.list_repo_files(repo_id, revision = head, repo_type = "model"))
+        mixed = sorted(
+            f for f in existing if f.rsplit("/", 1)[-1] in other_names and f not in uploading
+        )
+        if mixed:
+            raise RuntimeError(
+                f"Hub repo '{repo_id}' already holds {mixed}; refusing to "
+                "mix MLX- and PEFT-format adapter files in one repo. Push "
+                "to a different repo_id or delete the old adapter."
+            )
+        return head, existing
+
+    def _commit(head: str, existing: set) -> None:
+        # create_commit mutates operations and they are single-use, so rebuild
+        # per attempt. A repo-authored README survives adapter pushes.
+        upload = [f for f in files if not (f == "README.md" and "README.md" in existing)]
+        hf_api.create_commit(
+            repo_id = repo_id,
+            repo_type = "model",
+            operations = [
+                CommitOperationAdd(
+                    path_in_repo = f,
+                    path_or_fileobj = os.path.join(folder_path, f.replace("/", os.sep)),
+                )
+                for f in upload
+            ],
+            commit_message = f"Upload {resolved_format} LoRA adapter with Unsloth Studio",
+            parent_commit = head,
+        )
+
+    with _ADAPTER_PUSH_LOCK:
+        hf_api.create_repo(repo_id, private = private, exist_ok = True)
+        head, existing = _precheck()
+        try:
+            _commit(head, existing)
+        except RuntimeError:
+            raise
+        except Exception:
+            # The branch head moved under us; re-verify against the new head
+            # once, then let a second failure surface as the conflict it is.
+            head, existing = _precheck()
+            _commit(head, existing)
+        # An all-unchanged upload short-circuits client-side without the
+        # parent_commit check, so verify the invariant on the final head.
+        _final_head, _ = _precheck()
+
 
 def _export_runtime_available() -> bool:
     """True if export can run: MLX active, or Unsloth imported (only succeeds on a GPU host)."""
@@ -613,6 +723,9 @@ class ExportBackend:
                     f"Restored Hub model identity for legacy adapter export: {restored_repo_id}"
                 )
 
+            # Kept for tooling that must honor the approved load decision
+            # (the GGUF converter's --trust-remote-code).
+            self.trust_remote_code = bool(trust_remote_code)
             self.current_model = model
             self.current_tokenizer = tokenizer
             self.current_checkpoint = checkpoint_path
@@ -1280,6 +1393,151 @@ class ExportBackend:
             logger.error(traceback.format_exc())
             return False, f"GGUF export failed: {str(e)}", None
 
+    def _save_mlx_adapter(self, destination: str, resolved_format: str) -> None:
+        """Save the loaded MLX model's adapter in the resolved format.
+
+        An older unsloth-zoo without adapter_format support raises TypeError
+        from the bound saver; surface the actionable upgrade message instead.
+        """
+        if resolved_format == "peft":
+            saver = self.current_model.save_lora_adapters
+            if not _supports_kwarg(saver, "adapter_format"):
+                raise RuntimeError(_ZOO_UPGRADE_MESSAGE)
+            saver(destination, adapter_format = "peft")
+            try:
+                self.current_tokenizer.save_pretrained(destination)
+            except BaseException:
+                # The zoo published a fresh directory this call; remove it
+                # so a retry is not refused as an existing destination.
+                shutil.rmtree(destination, ignore_errors = True)
+                raise
+        else:
+            self.current_model.save_lora_adapters(destination)
+            self.current_tokenizer.save_pretrained(destination)
+
+    def _export_mlx_lora_gguf(
+        self, save_directory: str, outtype: str, hf_token: Optional[str]
+    ) -> None:
+        """Materialize a PEFT adapter and convert it with llama.cpp's
+        convert_lora_to_gguf.py (same pipeline the CUDA path uses).
+
+        Refuses adapters GGUF LoRA cannot represent before converting:
+        per-module alpha patterns (the format has one global alpha; rsLoRA
+        sources surface here too because export bakes their scales into
+        alphas), DoRA, full-module state (modules_to_save or replaced
+        embeddings), and expert-parameter adapters.
+        """
+        self._save_mlx_adapter(save_directory, "peft")
+        try:
+            self._convert_peft_dir_to_gguf(save_directory, outtype, hf_token)
+        except BaseException:
+            # This call published the directory; remove it so a retry gets
+            # the fresh destination the zoo requires.
+            shutil.rmtree(save_directory, ignore_errors = True)
+            raise
+
+    def _convert_peft_dir_to_gguf(
+        self, save_directory: str, outtype: str, hf_token: Optional[str]
+    ) -> None:
+        import importlib.util
+        import subprocess
+        import sys as _sys
+
+        cfg_path = os.path.join(save_directory, "adapter_config.json")
+        with open(cfg_path, "r", encoding = "utf-8") as f:
+            peft_cfg = json.load(f)
+        rejects = []
+        if peft_cfg.get("alpha_pattern"):
+            rejects.append("per-module alpha values (GGUF LoRA stores one global alpha)")
+        if peft_cfg.get("use_rslora") and peft_cfg.get("rank_pattern"):
+            rejects.append("rsLoRA with per-module ranks (bakes to per-module alphas)")
+        if peft_cfg.get("use_dora"):
+            rejects.append("DoRA magnitudes (no GGUF LoRA representation)")
+        if peft_cfg.get("modules_to_save") or getattr(
+            self.current_model, "_unsloth_full_state_modules", None
+        ):
+            rejects.append("full-module state (modules_to_save or replaced embeddings)")
+        if peft_cfg.get("target_parameters"):
+            rejects.append("expert-parameter adapters (llama.cpp has no expert handling)")
+        if rejects:
+            raise RuntimeError(
+                "This adapter cannot be exported as a GGUF LoRA: "
+                + "; ".join(rejects)
+                + ". Export the PEFT safetensors adapter instead."
+            )
+
+        if importlib.util.find_spec("torch") is None:
+            raise RuntimeError(
+                "GGUF adapter export needs the 'torch' Python package for "
+                "llama.cpp's converter; install it and retry."
+            )
+
+        from unsloth_zoo.llama_cpp import LLAMA_CPP_DEFAULT_DIR, install_llama_cpp
+
+        install_llama_cpp(just_clone_repo = True)
+        converter = os.path.join(LLAMA_CPP_DEFAULT_DIR, "convert_lora_to_gguf.py")
+        if not os.path.exists(converter):
+            # A prebuilt install carries binaries but not the converter; a
+            # dedicated source checkout ships it.
+            source_dir = os.path.join(
+                os.path.dirname(os.path.normpath(LLAMA_CPP_DEFAULT_DIR)),
+                "llama.cpp-source",
+            )
+            install_llama_cpp(llama_cpp_folder = source_dir, just_clone_repo = True)
+            converter = os.path.join(source_dir, "convert_lora_to_gguf.py")
+        if not os.path.exists(converter):
+            raise RuntimeError(
+                "convert_lora_to_gguf.py not found after installing a "
+                "llama.cpp source checkout; GGUF adapter export needs a full "
+                "llama.cpp source tree."
+            )
+        # The converter vendors gguf-py beside itself; a top-level install
+        # works too. Neither present is the actionable error.
+        if importlib.util.find_spec("gguf") is None and not os.path.isdir(
+            os.path.join(os.path.dirname(converter), "gguf-py")
+        ):
+            raise RuntimeError(
+                "GGUF adapter export needs the 'gguf' Python package (or a "
+                "full llama.cpp checkout with gguf-py); install it and retry."
+            )
+
+        base_model_id = peft_cfg.get("base_model_name_or_path") or getattr(
+            self.current_model, "_hf_repo", None
+        )
+        if not base_model_id:
+            raise RuntimeError(
+                "Could not determine the adapter's base model for GGUF "
+                "conversion (no base_model_name_or_path)."
+            )
+        model_name = str(base_model_id).replace("\\", "/").rstrip("/").split("/")[-1] or "model"
+        out_gguf = os.path.join(save_directory, f"{model_name}-lora-{outtype}.gguf")
+        cmd = [
+            _sys.executable,
+            converter,
+            save_directory,
+            "--outfile",
+            out_gguf,
+            "--outtype",
+            outtype,
+        ]
+        if os.path.isdir(str(base_model_id)):
+            cmd += ["--base", str(base_model_id)]
+        else:
+            cmd += ["--base-model-id", str(base_model_id)]
+        if getattr(self, "trust_remote_code", False):
+            cmd.append("--trust-remote-code")
+        env = os.environ.copy()
+        if hf_token:
+            env["HF_TOKEN"] = hf_token
+            env["HUGGING_FACE_HUB_TOKEN"] = hf_token
+        logger.info(f"Converting adapter at '{save_directory}' to GGUF -> '{out_gguf}'")
+        result = subprocess.run(cmd, env = env, capture_output = True, text = True)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"LoRA -> GGUF conversion failed (exit {result.returncode}): "
+                + (result.stderr or result.stdout or "").strip()[-2000:]
+            )
+
     def export_lora_adapter(
         self,
         save_directory: str,
@@ -1289,6 +1547,7 @@ class ExportBackend:
         private: bool = False,
         gguf: bool = False,
         gguf_outtype: str = "q8_0",
+        adapter_format: Optional[str] = None,
     ) -> Tuple[bool, str, Optional[str]]:
         """
         Export LoRA adapter only (not merged).
@@ -1297,6 +1556,8 @@ class ExportBackend:
             gguf: If True, also convert the adapter to a GGUF LoRA file (llama.cpp
                 convert_lora_to_gguf.py), loadable with `llama-cli --lora ...`.
             gguf_outtype: GGUF LoRA output float type; one of q8_0/f16/bf16/f32.
+            adapter_format: 'mlx' or 'peft'; omitted resolves to the platform's
+                native format (MLX servers -> 'mlx', others -> 'peft').
 
         Returns:
             Tuple of (success: bool, message: str, output_path: Optional[str])
@@ -1309,20 +1570,26 @@ class ExportBackend:
         if not self.is_peft:
             return False, "This is not a PEFT model. No adapter to export.", None
 
+        resolved_format, format_error = _resolve_adapter_format(adapter_format)
+        if format_error:
+            return False, format_error, None
+
         _GGUF_LORA_OUTTYPES = ("q8_0", "f16", "bf16", "f32")
         if gguf:
-            if _IS_MLX:
+            if adapter_format == "mlx":
                 return (
                     False,
-                    "GGUF LoRA adapter export is not supported on macOS/MLX. "
-                    "Use the safetensors adapter instead.",
+                    "GGUF LoRA files are built from a PEFT-format adapter; "
+                    "omit adapter_format or use 'peft' with gguf=True.",
                     None,
                 )
             # llama.cpp's convert_lora_to_gguf.py has no concept of DoRA's
             # lora_magnitude_vector tensors: it only reads the standard
             # lora_A/lora_B delta, so exporting a DoRA adapter would silently
             # drop the magnitude rescaling and produce a GGUF LoRA file that
-            # loads fine but no longer matches the trained model.
+            # loads fine but no longer matches the trained model. MLX models
+            # carry no peft_config; their DoRA refusal happens in the staging
+            # checks on the materialized PEFT adapter.
             _peft_config = getattr(self.current_model, "peft_config", {}).get("default")
             if getattr(_peft_config, "use_dora", False):
                 return (
@@ -1333,6 +1600,8 @@ class ExportBackend:
                     "safetensors adapter instead, or merge to a full GGUF model.",
                     None,
                 )
+            # GGUF LoRA files are built FROM a PEFT-format adapter.
+            resolved_format = "peft"
             outtype = str(gguf_outtype).lower()
             if outtype not in _GGUF_LORA_OUTTYPES:
                 return (
@@ -1341,25 +1610,61 @@ class ExportBackend:
                     f"Choose one of {', '.join(_GGUF_LORA_OUTTYPES)}.",
                     None,
                 )
-            # getattr so an older build without save_pretrained_gguf returns a clean message
-            # instead of an AttributeError (a generic 500).
-            _save_gguf_fn = getattr(self.current_model, "save_pretrained_gguf", None)
-            if _save_gguf_fn is None or not _supports_kwarg(_save_gguf_fn, "save_method"):
-                return (
-                    False,
-                    "This Unsloth build does not support GGUF LoRA adapter export. "
-                    "Upgrade unsloth and unsloth_zoo, or export the safetensors adapter.",
-                    None,
-                )
+            if not _IS_MLX:
+                # getattr so an older build without save_pretrained_gguf
+                # returns a clean message, not an AttributeError (a 500).
+                _save_gguf_fn = getattr(self.current_model, "save_pretrained_gguf", None)
+                if _save_gguf_fn is None or not _supports_kwarg(_save_gguf_fn, "save_method"):
+                    return (
+                        False,
+                        "This Unsloth build does not support GGUF LoRA adapter export. "
+                        "Upgrade unsloth and unsloth_zoo, or export the safetensors adapter.",
+                        None,
+                    )
+            elif not hasattr(self.current_model, "save_lora_adapters"):
+                return False, _ZOO_UPGRADE_MESSAGE, None
 
         output_path: Optional[str] = None
         try:
             if save_directory:
                 save_directory = str(resolve_export_write_dir(save_directory))
                 logger.info(f"Saving LoRA adapter locally to: {save_directory}")
-                ensure_dir(Path(save_directory))
+                # One directory holds ONE adapter format; a leftover file of
+                # the other would make loaders disagree.
+                _other_names = _ADAPTER_WEIGHT_NAMES["peft" if resolved_format == "mlx" else "mlx"]
+                # Recursive: peft stores named adapters in subdirectories.
+                _mixed = os.path.isdir(save_directory) and any(
+                    name in _other_names
+                    for _root, _dirs, names in os.walk(save_directory)
+                    for name in names
+                )
+                if _mixed:
+                    return (
+                        False,
+                        f"'{save_directory}' already holds the other "
+                        "format's adapter weights; refusing to mix MLX- and "
+                        "PEFT-format files in one directory. Use a "
+                        "different directory or remove the old adapter "
+                        "first.",
+                        None,
+                    )
+                if _IS_MLX and (gguf or resolved_format == "peft"):
+                    # The zoo's converter refuses an existing destination and
+                    # publishes it atomically itself; create only the parent.
+                    ensure_dir(Path(save_directory).parent)
+                else:
+                    ensure_dir(Path(save_directory))
 
-                if gguf:
+                if gguf and _IS_MLX:
+                    # Materialize PEFT + convert with llama.cpp's script.
+                    self._export_mlx_lora_gguf(save_directory, outtype, hf_token)
+                    final_ggufs = sorted(glob.glob(os.path.join(save_directory, "*.gguf")))
+                    logger.info(
+                        "LoRA GGUF export complete. Files in %s:\n  %s",
+                        save_directory,
+                        "\n  ".join(os.path.basename(f) for f in final_ggufs) or "(none)",
+                    )
+                elif gguf:
                     # Writes the adapter files plus "<base>-lora-<outtype>.gguf".
                     _apply_wsl_sudo_patch()
                     self.current_model.save_pretrained_gguf(
@@ -1382,9 +1687,8 @@ class ExportBackend:
                         "\n  ".join(os.path.basename(f) for f in final_ggufs) or "(none)",
                     )
                 elif _IS_MLX:
-                    # MLX: save adapters.safetensors + tokenizer files
-                    self.current_model.save_lora_adapters(save_directory)
-                    self.current_tokenizer.save_pretrained(save_directory)
+                    # Native MLX or converted PEFT, per the resolved format.
+                    self._save_mlx_adapter(save_directory, resolved_format)
                 else:
                     self.current_model.save_pretrained(save_directory)
                     self.current_tokenizer.save_pretrained(save_directory)
@@ -1411,27 +1715,36 @@ class ExportBackend:
                             "retry.",
                             None,
                         )
-                    hf_api = HfApi(token = hf_token)
-                    hf_api.create_repo(repo_id, private = private, exist_ok = True)
-                    hf_api.upload_folder(
-                        folder_path = output_path,
-                        repo_id = repo_id,
-                        repo_type = "model",
+                    _push_adapter_dir_cas(
+                        HfApi(token = hf_token),
+                        output_path,
+                        repo_id,
+                        private,
+                        resolved_format,
                     )
                 elif _IS_MLX:
                     with tempfile.TemporaryDirectory() as tmp_dir:
-                        self.current_model.save_lora_adapters(tmp_dir)
-                        self.current_tokenizer.save_pretrained(tmp_dir)
-                        hf_api = HfApi(token = hf_token)
-                        hf_api.create_repo(repo_id, private = private, exist_ok = True)
-                        hf_api.upload_folder(
-                            folder_path = tmp_dir,
-                            repo_id = repo_id,
-                            repo_type = "model",
+                        # A fresh subpath: the zoo refuses existing dirs.
+                        staged = os.path.join(tmp_dir, "adapter")
+                        self._save_mlx_adapter(staged, resolved_format)
+                        _push_adapter_dir_cas(
+                            HfApi(token = hf_token),
+                            staged,
+                            repo_id,
+                            private,
+                            resolved_format,
                         )
                 else:
-                    self.current_model.push_to_hub(repo_id, token = hf_token, private = private)
-                    self.current_tokenizer.push_to_hub(repo_id, token = hf_token, private = private)
+                    with tempfile.TemporaryDirectory() as tmp_dir:
+                        self.current_model.save_pretrained(tmp_dir)
+                        self.current_tokenizer.save_pretrained(tmp_dir)
+                        _push_adapter_dir_cas(
+                            HfApi(token = hf_token),
+                            tmp_dir,
+                            repo_id,
+                            private,
+                            resolved_format,
+                        )
                 logger.info(f"Adapter pushed successfully to {repo_id}")
 
             return True, "LoRA adapter exported successfully", output_path

--- a/studio/backend/core/export/export.py
+++ b/studio/backend/core/export/export.py
@@ -95,7 +95,7 @@ def _push_adapter_dir_cas(
     A pre-check at a pinned revision refuses when the repo carries the OTHER
     format's weight file that this upload would not replace; the commit then
     uses parent_commit=<that revision> so the Hub itself rejects a concurrent
-    writer (retried once against the new head before surfacing a conflict).
+    writer, which is surfaced as a conflict rather than retried on top.
     """
     from huggingface_hub import CommitOperationAdd
 
@@ -152,11 +152,22 @@ def _push_adapter_dir_cas(
             _commit(head, existing)
         except RuntimeError:
             raise
-        except Exception:
-            # The branch head moved under us; re-verify against the new head
-            # once, then let a second failure surface as the conflict it is.
-            head, existing = _precheck()
-            _commit(head, existing)
+        except Exception as exc:
+            # parent_commit pins the commit to the head that was checked, so
+            # a moved head lands here -- but so do transport and server
+            # failures, and a commit the Hub applied whose response was lost
+            # is indistinguishable from one it rejected. (RuntimeError is
+            # re-raised above, so hub versions that wrap LFS upload failures
+            # in one keep their own message.) Claim only what holds for every
+            # exception reaching here: the commit was not confirmed and was
+            # NOT re-applied over a newer head, so nothing published
+            # meanwhile was overwritten.
+            raise RuntimeError(
+                f"Adapter upload to '{repo_id}' was not confirmed ({exc}). It "
+                "was not re-committed over a newer head, so nothing published "
+                "meanwhile was overwritten. Check the repo and retry if the "
+                "adapter is missing."
+            ) from exc
         # An all-unchanged upload short-circuits client-side without the
         # parent_commit check, so verify the invariant on the final head.
         _final_head, _ = _precheck()

--- a/studio/backend/core/export/orchestrator.py
+++ b/studio/backend/core/export/orchestrator.py
@@ -598,6 +598,7 @@ class ExportOrchestrator:
         private: bool = False,
         gguf: bool = False,
         gguf_outtype: str = "q8_0",
+        adapter_format: Optional[str] = None,
     ) -> Tuple[bool, str, Optional[str]]:
         """Export LoRA adapter only (optionally also as a GGUF LoRA file)."""
         return self._run_export(
@@ -610,6 +611,7 @@ class ExportOrchestrator:
                 "private": private,
                 "gguf": gguf,
                 "gguf_outtype": gguf_outtype,
+                "adapter_format": adapter_format,
             },
         )
 

--- a/studio/backend/core/export/worker.py
+++ b/studio/backend/core/export/worker.py
@@ -460,6 +460,7 @@ def _handle_export(backend, cmd: dict, resp_queue: Any) -> None:
                 private = cmd.get("private", False),
                 gguf = cmd.get("gguf", False),
                 gguf_outtype = cmd.get("gguf_outtype", "q8_0"),
+                adapter_format = cmd.get("adapter_format"),
             )
         else:
             success, message = False, f"Unknown export type: {export_type}"

--- a/studio/backend/models/export.py
+++ b/studio/backend/models/export.py
@@ -229,6 +229,17 @@ class ExportGGUFRequest(BaseModel):
 class ExportLoRAAdapterRequest(ExportCommonOptions):
     """Request for exporting only the LoRA adapter (not merged)."""
 
+    adapter_format: Optional[Literal["mlx", "peft"]] = Field(
+        None,
+        description = "On-disk adapter format. Omitted resolves per platform "
+        "(Apple-silicon MLX servers write the native MLX format, CUDA servers "
+        "write the native PEFT format — omission always preserves the "
+        "platform's native output), except with gguf=True, where the adapter "
+        "files are always "
+        "PEFT (GGUF LoRA files are built from that format). Explicit 'peft' "
+        "on an MLX server converts the adapter; explicit 'mlx' on a non-MLX "
+        "server — or combined with gguf=True — is an error.",
+    )
     gguf: bool = Field(
         False,
         description = "If True, also convert the adapter to a GGUF LoRA file "

--- a/studio/backend/models/models.py
+++ b/studio/backend/models/models.py
@@ -41,6 +41,13 @@ class ModelCheckpoints(BaseModel):
         False,
         description = "Whether the model uses BNB quantization (e.g. bnb-4bit)",
     )
+    adapter_features: Optional[Dict[str, Optional[bool]]] = Field(
+        None,
+        description = "Compact adapter capabilities parsed from the adapter "
+        "config (dora / full_state / moe_target_parameters / non_uniform); "
+        "None for non-adapter runs. A None VALUE means unverified (e.g. "
+        "full_state without a weight-header probe).",
+    )
 
 
 class CheckpointListResponse(BaseModel):
@@ -132,11 +139,12 @@ class LoRAInfo(BaseModel):
             "carries no modality otherwise, so an audio adapter reads as a text one."
         ),
     )
-    adapter_features: Optional[Dict[str, bool]] = Field(
+    adapter_features: Optional[Dict[str, Optional[bool]]] = Field(
         None,
         description = "Compact adapter capabilities parsed from the adapter "
         "config (dora / full_state / moe_target_parameters / non_uniform); "
-        "None when no adapter config was found.",
+        "None when no adapter config was found. A None VALUE means "
+        "unverified.",
     )
 
 

--- a/studio/backend/models/models.py
+++ b/studio/backend/models/models.py
@@ -132,6 +132,12 @@ class LoRAInfo(BaseModel):
             "carries no modality otherwise, so an audio adapter reads as a text one."
         ),
     )
+    adapter_features: Optional[Dict[str, bool]] = Field(
+        None,
+        description = "Compact adapter capabilities parsed from the adapter "
+        "config (dora / full_state / moe_target_parameters / non_uniform); "
+        "None when no adapter config was found.",
+    )
 
 
 class LoRAScanResponse(BaseModel):

--- a/studio/backend/routes/export.py
+++ b/studio/backend/routes/export.py
@@ -457,6 +457,7 @@ async def export_lora_adapter(
             private = request.private,
             gguf = request.gguf,
             gguf_outtype = request.gguf_outtype,
+            adapter_format = request.adapter_format,
         )
 
         if not success:

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -2645,6 +2645,8 @@ def _scan_loras_sync(
     resolved_outputs_dir: str, resolved_exports_dir: str, hf_token: Optional[str]
 ) -> List[LoRAInfo]:
     """The filesystem half of scan_loras, so it can run in a worker thread."""
+    from utils.models.checkpoints import parse_adapter_features
+
     lora_list: List[LoRAInfo] = []
 
     trained_models = scan_trained_models(outputs_dir = resolved_outputs_dir)
@@ -2658,6 +2660,7 @@ def _scan_loras_sync(
                 source = "training",
                 export_type = model_type,
                 audio_type = _audio_type_of_checkpoint(model_path, base_model, hf_token),
+                adapter_features = parse_adapter_features(model_path),
             )
         )
 
@@ -2672,6 +2675,7 @@ def _scan_loras_sync(
                 source = "exported",
                 export_type = export_type,
                 audio_type = _audio_type_of_checkpoint(model_path, base_model, hf_token),
+                adapter_features = parse_adapter_features(model_path),
             )
         )
 

--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -4944,6 +4944,7 @@ async def list_checkpoints(
                 peft_type = metadata.get("peft_type"),
                 lora_rank = metadata.get("lora_rank"),
                 is_quantized = metadata.get("is_quantized", False),
+                adapter_features = metadata.get("adapter_features"),
             )
             for model_name, checkpoints, metadata in raw_models
         ]

--- a/studio/backend/tests/test_export_adapter_format.py
+++ b/studio/backend/tests/test_export_adapter_format.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Adapter-format export contracts: platform-resolved default, conversion
+routing, GGUF staging rejects, Hub compare-and-swap, feature metadata."""
+
+import json
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.export import export as export_mod
+from utils.models.checkpoints import parse_adapter_features
+
+
+def _backend(
+    monkeypatch,
+    is_mlx,
+    tmp_path,
+    created = None,
+):
+    monkeypatch.setattr(export_mod, "_IS_MLX", is_mlx)
+    monkeypatch.setattr(export_mod, "_export_runtime_available", lambda: True)
+    monkeypatch.setattr(export_mod, "resolve_export_write_dir", lambda p: tmp_path / "out")
+    monkeypatch.setattr(
+        export_mod,
+        "ensure_dir",
+        (lambda p: created.append(str(p))) if created is not None else (lambda p: None),
+    )
+    backend = export_mod.ExportBackend.__new__(export_mod.ExportBackend)
+    backend.current_model = MagicMock()
+    backend.current_tokenizer = MagicMock()
+    backend.is_peft = True
+    return backend
+
+
+# The six-cell platform x field matrix: omission stays byte-identical to the
+# pre-existing native call on BOTH platforms, and explicit native values match.
+@pytest.mark.parametrize(
+    "is_mlx,requested,expect",
+    [
+        (True, None, "mlx"),  # Mac + omitted -> native MLX passthrough
+        (True, "mlx", "mlx"),  # Mac + explicit mlx (frontend default path)
+        (True, "peft", "peft"),  # Mac + explicit peft -> converts
+        (False, None, "peft"),  # CUDA + omitted -> native PEFT passthrough
+        (False, "peft", "peft"),  # CUDA + explicit peft -> same native result
+        (False, "mlx", "error"),  # CUDA + explicit mlx -> specified error
+    ],
+)
+def test_six_cell_matrix(monkeypatch, tmp_path, is_mlx, requested, expect):
+    created = []
+    backend = _backend(monkeypatch, is_mlx, tmp_path, created)
+    ok, message, _path = backend.export_lora_adapter(
+        str(tmp_path / "dst"),
+        adapter_format = requested,
+    )
+    if expect == "error":
+        assert not ok and "MLX" in message
+        backend.current_model.save_pretrained.assert_not_called()
+        return
+    assert ok, message
+    if is_mlx:
+        args, kwargs = backend.current_model.save_lora_adapters.call_args
+        if expect == "mlx":
+            # Exactly the pre-existing native call: no adapter_format kwarg.
+            assert kwargs == {}
+        else:
+            assert kwargs == {"adapter_format": "peft"}
+        backend.current_model.save_pretrained.assert_not_called()
+        # Conversions get a fresh destination (parent created only); the
+        # native path keeps its pre-created directory.
+        expected_dir = tmp_path / ("out" if expect == "mlx" else "")
+        assert created == [str(expected_dir)]
+    else:
+        backend.current_model.save_pretrained.assert_called_once()
+        backend.current_model.save_lora_adapters.assert_not_called()
+
+
+def test_outdated_zoo_hard_error(monkeypatch, tmp_path):
+    backend = _backend(monkeypatch, True, tmp_path)
+
+    def _old_zoo_saver(path, adapter_config = None):  # no adapter_format kwarg
+        raise AssertionError("an outdated saver must not be invoked")
+
+    backend.current_model.save_lora_adapters = _old_zoo_saver
+    ok, message, _ = backend.export_lora_adapter(
+        str(tmp_path / "dst"),
+        adapter_format = "peft",
+    )
+    assert not ok and "unsloth-zoo" in message
+
+    def _modern_saver_with_internal_bug(
+        path,
+        adapter_config = None,
+        adapter_format = "mlx",
+    ):
+        raise TypeError("scale must be a float")
+
+    backend.current_model.save_lora_adapters = _modern_saver_with_internal_bug
+    ok, message, _ = backend.export_lora_adapter(
+        str(tmp_path / "dst2"),
+        adapter_format = "peft",
+    )
+    assert not ok and "unsloth-zoo" not in message and "scale" in message
+
+
+def _gguf_setup(
+    monkeypatch,
+    tmp_path,
+    peft_cfg,
+    fs_attr = None,
+):
+    backend = _backend(monkeypatch, True, tmp_path)
+    out = tmp_path / "gguf"
+    out.mkdir()
+
+    def _fake_save(destination, resolved_format):
+        assert resolved_format == "peft"
+        os.makedirs(destination, exist_ok = True)  # the real zoo publishes the dir
+        with open(os.path.join(destination, "adapter_config.json"), "w") as f:
+            json.dump(peft_cfg, f)
+
+    backend._save_mlx_adapter = _fake_save
+    backend.current_model._unsloth_full_state_modules = fs_attr
+    return backend, str(out)
+
+
+@pytest.mark.parametrize(
+    "cfg,fs_attr,reason",
+    [
+        ({"alpha_pattern": {"^q_proj": 32}}, None, "alpha"),
+        ({"use_rslora": True, "rank_pattern": {"^q_proj": 4}}, None, "rsLoRA"),
+        ({"use_dora": True}, None, "DoRA"),
+        ({"modules_to_save": ["lm_head"]}, None, "full-module state"),
+        ({}, {"model.embed_tokens": "embedding_auto"}, "full-module state"),
+        ({"target_parameters": ["experts.gate_up_proj"]}, None, "expert"),
+    ],
+)
+def test_gguf_staging_rejects(monkeypatch, tmp_path, cfg, fs_attr, reason):
+    backend, out = _gguf_setup(monkeypatch, tmp_path, cfg, fs_attr)
+    with pytest.raises(RuntimeError, match = reason):
+        backend._export_mlx_lora_gguf(out, "q8_0", None)
+
+
+def test_parse_adapter_features(tmp_path):
+    def _dir(cfg):
+        d = tmp_path / f"a{len(list(tmp_path.iterdir()))}"
+        d.mkdir()
+        (d / "adapter_config.json").write_text(json.dumps(cfg))
+        return str(d)
+
+    assert parse_adapter_features(str(tmp_path)) is None  # no config
+    base = parse_adapter_features(_dir({"r": 8}))
+    assert base == {
+        "dora": False,
+        "full_state": False,
+        "moe_target_parameters": False,
+        "non_uniform": False,
+    }
+    assert parse_adapter_features(_dir({"use_dora": True}))["dora"] is True
+    assert parse_adapter_features(_dir({"fine_tune_type": "dora"}))["dora"] is True
+    assert parse_adapter_features(_dir({"modules_to_save": ["lm_head"]}))["full_state"] is True
+    assert (
+        parse_adapter_features(_dir({"full_state_modules": {"lm_head": "modules_to_save"}}))[
+            "full_state"
+        ]
+        is True
+    )
+    assert (
+        parse_adapter_features(_dir({"target_parameters": ["experts.g"]}))["moe_target_parameters"]
+        is True
+    )
+    assert parse_adapter_features(_dir({"rank_pattern": {"q": 4}}))["non_uniform"] is True
+    assert (
+        parse_adapter_features(_dir({"unsloth_mlx_lora_module_scales": {"q": 2.0}}))["non_uniform"]
+        is True
+    )
+
+
+def test_local_dir_never_format_mixed(monkeypatch, tmp_path):
+    backend = _backend(monkeypatch, True, tmp_path)
+    out = tmp_path / "out"
+    out.mkdir()
+    (out / "adapter_model.safetensors").write_bytes(b"x")  # other format
+    ok, message, _ = backend.export_lora_adapter(str(out))
+    assert not ok and "mix" in message
+    backend.current_model.save_lora_adapters.assert_not_called()
+    # Nested layouts (peft named adapters) refuse too.
+    (out / "adapter_model.safetensors").unlink()
+    (out / "named").mkdir()
+    (out / "named" / "adapter_model.safetensors").write_bytes(b"x")
+    ok, message, _ = backend.export_lora_adapter(str(out))
+    assert not ok and "mix" in message
+    # The legacy PEFT weight spelling counts as PEFT too.
+    (out / "named" / "adapter_model.safetensors").unlink()
+    (out / "adapter_model.bin").write_bytes(b"x")
+    ok, message, _ = backend.export_lora_adapter(str(out))
+    assert not ok and "mix" in message

--- a/studio/backend/tests/test_export_adapter_format.py
+++ b/studio/backend/tests/test_export_adapter_format.py
@@ -151,13 +151,36 @@ def test_parse_adapter_features(tmp_path):
         return str(d)
 
     assert parse_adapter_features(str(tmp_path)) is None  # no config
+    # A PEFT config without markers and no readable weights is UNVERIFIED,
+    # never a false "verified plain".
     base = parse_adapter_features(_dir({"r": 8}))
     assert base == {
         "dora": False,
-        "full_state": False,
+        "full_state": None,
         "moe_target_parameters": False,
         "non_uniform": False,
     }
+    # MLX artifacts verify through their weight header too: pure LoRA is a
+    # verified negative, extra trainable state is positive, and no readable
+    # file stays unverified (trainer checkpoints may carry unmarked state).
+    assert parse_adapter_features(_dir({"fine_tune_type": "lora"}))["full_state"] is None
+    import numpy as np
+    from safetensors.numpy import save_file
+
+    d_mlx = _dir({"fine_tune_type": "lora"})
+    save_file(
+        {"model.layers.0.self_attn.q_proj.lora_a": np.zeros((2, 2), dtype = "float32")},
+        os.path.join(d_mlx, "adapters.safetensors"),
+    )
+    assert parse_adapter_features(d_mlx)["full_state"] is False
+    save_file(
+        {
+            "model.layers.0.self_attn.q_proj.lora_a": np.zeros((2, 2), dtype = "float32"),
+            "lm_head.bias": np.zeros((2,), dtype = "float32"),
+        },
+        os.path.join(d_mlx, "adapters.safetensors"),
+    )
+    assert parse_adapter_features(d_mlx)["full_state"] is True
     assert parse_adapter_features(_dir({"use_dora": True}))["dora"] is True
     assert parse_adapter_features(_dir({"fine_tune_type": "dora"}))["dora"] is True
     assert parse_adapter_features(_dir({"modules_to_save": ["lm_head"]}))["full_state"] is True

--- a/studio/backend/utils/models/checkpoints.py
+++ b/studio/backend/utils/models/checkpoints.py
@@ -4,11 +4,12 @@
 """Checkpoint scanning utilities for discovering training runs and checkpoints."""
 
 import json
+import os
 import re
 import structlog
 from loggers import get_logger
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 from storage.studio_db import get_connection
 from utils.training_runs import (
     build_default_output_dir_name,
@@ -137,6 +138,52 @@ def _read_checkpoint_loss(checkpoint_path: Path) -> Optional[float]:
     except Exception as e:
         logger.debug(f"Could not read loss from {trainer_state}: {e}")
     return None
+
+
+def parse_adapter_features(adapter_path: str) -> Optional[Dict[str, bool]]:
+    """Parse a compact feature summary from an adapter directory's config.
+
+    Reads adapter_config.json (either the PEFT or the MLX layout) and reports
+    booleans the export UI keys compatibility copy off: dora, full_state
+    (modules_to_save / replaced embeddings), moe_target_parameters, and
+    non_uniform (per-module rank/alpha). Returns None when no adapter config
+    exists (merged or GGUF artifacts).
+    """
+    cfg_path = os.path.join(adapter_path, "adapter_config.json")
+    try:
+        with open(cfg_path, "r", encoding = "utf-8") as f:
+            cfg = json.load(f)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(cfg, dict):
+        return None
+
+    def _flag(value):
+        return isinstance(value, bool) and value
+
+    def _filled(value):
+        return isinstance(value, (dict, list)) and len(value) > 0
+
+    full_state = _filled(cfg.get("full_state_modules")) or _filled(cfg.get("modules_to_save"))
+    if not full_state:
+        # PEFT artifacts carry auto-saved embedding/base state only as
+        # non-LoRA weight keys; a header-only read is cheap.
+        weights = os.path.join(adapter_path, "adapter_model.safetensors")
+        try:
+            from safetensors import safe_open
+            with safe_open(weights, framework = "numpy") as f:
+                full_state = any(".lora_" not in key for key in f.keys())
+        except Exception:
+            pass
+    return {
+        "dora": _flag(cfg.get("use_dora")) or str(cfg.get("fine_tune_type", "")).lower() == "dora",
+        "full_state": full_state,
+        "moe_target_parameters": _filled(cfg.get("target_parameters")),
+        "non_uniform": _filled(cfg.get("rank_pattern"))
+        or _filled(cfg.get("alpha_pattern"))
+        or _filled(cfg.get("unsloth_mlx_lora_module_ranks"))
+        or _filled(cfg.get("unsloth_mlx_lora_module_scales")),
+    }
 
 
 def scan_checkpoints(

--- a/studio/backend/utils/models/checkpoints.py
+++ b/studio/backend/utils/models/checkpoints.py
@@ -140,14 +140,24 @@ def _read_checkpoint_loss(checkpoint_path: Path) -> Optional[float]:
     return None
 
 
-def parse_adapter_features(adapter_path: str) -> Optional[Dict[str, bool]]:
+def parse_adapter_features(
+    adapter_path: str, probe_weights: bool = True
+) -> Optional[Dict[str, Optional[bool]]]:
     """Parse a compact feature summary from an adapter directory's config.
 
     Reads adapter_config.json (either the PEFT or the MLX layout) and reports
-    booleans the export UI keys compatibility copy off: dora, full_state
+    flags the export UI keys compatibility copy off: dora, full_state
     (modules_to_save / replaced embeddings), moe_target_parameters, and
     non_uniform (per-module rank/alpha). Returns None when no adapter config
     exists (merged or GGUF artifacts).
+
+    ``full_state`` is TRI-STATE in BOTH formats: a config marker is a
+    verified positive, but its absence proves nothing (PEFT auto-saves
+    embedding/base state only as weight keys, and native MLX trainer
+    checkpoints may carry unmarked non-LoRA trainable tensors), so a
+    negative is verified only by reading the weight header — when that
+    probe is skipped (``probe_weights=False``, bulk listings) or fails,
+    the value is None ("unverified"), never a false "verified plain".
     """
     cfg_path = os.path.join(adapter_path, "adapter_config.json")
     try:
@@ -164,17 +174,35 @@ def parse_adapter_features(adapter_path: str) -> Optional[Dict[str, bool]]:
     def _filled(value):
         return isinstance(value, (dict, list)) and len(value) > 0
 
-    full_state = _filled(cfg.get("full_state_modules")) or _filled(cfg.get("modules_to_save"))
+    full_state: Optional[bool] = _filled(cfg.get("full_state_modules")) or _filled(
+        cfg.get("modules_to_save")
+    )
     if not full_state:
-        # PEFT artifacts carry auto-saved embedding/base state only as
-        # non-LoRA weight keys; a header-only read is cheap.
-        weights = os.path.join(adapter_path, "adapter_model.safetensors")
-        try:
+        # No config marker proves absence in EITHER format: PEFT auto-saves
+        # embedding/base state only as weight keys, and MLX trainer checkpoints
+        # may carry unmarked non-LoRA tensors. Only a weight-header read
+        # verifies a negative; a skipped or failed probe stays None.
+        full_state = None
+        if probe_weights:
             from safetensors import safe_open
-            with safe_open(weights, framework = "numpy") as f:
-                full_state = any(".lora_" not in key for key in f.keys())
-        except Exception:
-            pass
+            for weights, is_adapter_key in (
+                (
+                    os.path.join(adapter_path, "adapter_model.safetensors"),
+                    lambda key: ".lora_" in key,
+                ),
+                (
+                    os.path.join(adapter_path, "adapters.safetensors"),
+                    lambda key: key.endswith((".lora_a", ".lora_b", ".m")),
+                ),
+            ):
+                if not os.path.exists(weights):
+                    continue
+                try:
+                    with safe_open(weights, framework = "numpy") as f:
+                        full_state = any(not is_adapter_key(key) for key in f.keys())
+                except Exception:
+                    full_state = None
+                break
     return {
         "dora": _flag(cfg.get("use_dora")) or str(cfg.get("fine_tune_type", "")).lower() == "dora",
         "full_state": full_state,
@@ -219,6 +247,9 @@ def scan_checkpoints(
 
             # Training metadata from adapter_config.json / config.json
             metadata: dict = {}
+            # Header probing is skipped in bulk listings; config markers
+            # still classify training-run adapters correctly.
+            metadata["adapter_features"] = parse_adapter_features(str(item), probe_weights = False)
             try:
                 if adapter_config.exists():
                     cfg = json.loads(adapter_config.read_text(encoding = "utf-8-sig"))

--- a/studio/frontend/src/features/export/api/export-api.ts
+++ b/studio/frontend/src/features/export/api/export-api.ts
@@ -58,6 +58,12 @@ export interface ModelCheckpoints {
   peft_type?: string | null;
   lora_rank?: number | null;
   is_quantized?: boolean;
+  adapter_features?: {
+    dora?: boolean | null;
+    full_state?: boolean | null;
+    moe_target_parameters?: boolean | null;
+    non_uniform?: boolean | null;
+  } | null;
 }
 
 export interface CheckpointListResponse {
@@ -186,6 +192,8 @@ export async function exportLoRA(params: {
   gguf?: boolean;
   /** GGUF LoRA output float type (f32/f16/bf16/q8_0/auto); only used when gguf=true. */
   gguf_outtype?: string;
+  /** On-disk adapter format; omitted resolves to the platform's native format. */
+  adapter_format?: "mlx" | "peft";
 }): Promise<ExportOperationResponse> {
   const response = await authFetch("/api/export/export/lora", {
     method: "POST",

--- a/studio/frontend/src/features/export/constants.ts
+++ b/studio/frontend/src/features/export/constants.ts
@@ -343,3 +343,69 @@ export const GUIDE_STEPS = [
   "Click Export and choose your destination",
   "Test your model and compare outputs in Chat",
 ];
+
+
+/** Compact adapter capabilities from the backend checkpoint listing.
+ * A null value means unverified (e.g. full_state without a weight probe). */
+export interface AdapterFeatures {
+  dora?: boolean | null;
+  full_state?: boolean | null;
+  moe_target_parameters?: boolean | null;
+  non_uniform?: boolean | null;
+}
+
+export type AdapterFormat = "mlx" | "peft";
+
+/**
+ * Compatibility copy per adapter format, conditioned on the REAL adapter
+ * features: the vLLM claim renders only for VERIFIED uniform plain-LoRA
+ * adapters (vLLM rejects DoRA and modules_to_save and discards per-module
+ * rank/alpha patterns). Missing metadata gets neutral copy, never the claim.
+ */
+export function adapterCompatibilityTip(
+  format: AdapterFormat,
+  features: AdapterFeatures | null | undefined,
+): string {
+  if (format === "mlx") {
+    const base =
+      "MLX (default): the native format for mlx-lm and Apple-silicon " +
+      "workflows — the format training checkpoints are saved in.";
+    return features?.non_uniform
+      ? base +
+          " Adapters with per-module ranks/alphas exported as MLX require " +
+          "Unsloth to load them; stock mlx-lm supports uniform adapters " +
+          "only — choose PEFT for maximum compatibility."
+      : base;
+  }
+  const base = "PEFT: the standard Hugging Face adapter format — ";
+  if (features == null) {
+    return base + "loads in transformers and PEFT.";
+  }
+  if (features.dora || features.full_state) {
+    return base + "loads in transformers/PEFT; not supported by vLLM.";
+  }
+  if (features.moe_target_parameters) {
+    return base + "vLLM support varies and is not guaranteed.";
+  }
+  if (features.non_uniform) {
+    return (
+      base +
+      "loads in transformers and PEFT. vLLM applies a single global " +
+      "rank/alpha — per-module patterned adapters are not supported by vLLM."
+    );
+  }
+  const verifiedPlain =
+    features.dora === false &&
+    features.full_state === false &&
+    features.moe_target_parameters === false &&
+    features.non_uniform === false;
+  if (!verifiedPlain) {
+    // An unverified field (null/undefined) never earns the vLLM claim.
+    return base + "loads in transformers and PEFT.";
+  }
+  return (
+    base +
+    "loads in transformers, vLLM, and Unsloth Studio on GPU machines, and " +
+    "is required for GGUF adapter export."
+  );
+}

--- a/studio/frontend/src/features/export/export-page.tsx
+++ b/studio/frontend/src/features/export/export-page.tsx
@@ -63,6 +63,7 @@ import { useSearch } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import type { ModelCheckpoints } from "./api/export-api";
+import { adapterCompatibilityTip, type AdapterFormat } from "./constants";
 import { ExportRunPanel } from "./components/export-run-panel";
 import { MethodPicker } from "./components/method-picker";
 import { QuantPicker } from "./components/quant-picker";
@@ -223,12 +224,15 @@ export function ExportPage() {
   });
   // LoRA-only export: optionally also emit a GGUF LoRA adapter, and its output float type.
   const [loraAsGguf, setLoraAsGguf] = useState(false);
+  // Mac-only safetensors adapter format; MLX is the training-native format.
+  const [adapterFormat, setAdapterFormat] = useState<AdapterFormat>("mlx");
   const [loraGgufOuttype, setLoraGgufOuttype] = useState<string>("q8_0");
   // GGUF method: export the full model as GGUF quants, or (for an adapter checkpoint) a GGUF LoRA.
   const [ggufTarget, setGgufTarget] = useState<"model" | "lora">("model");
 
   const hardware = useHardwareInfo();
-  // GGUF LoRA conversion is rejected on the macOS / MLX path, so gate it out on a Mac host.
+  // The GGUF method's LoRA-adapter target is not offered on Mac; GGUF LoRA
+  // adapters ship through the LoRA method's toggle. Controls below key off this.
   const isMacHost = usePlatformStore((s) => s.deviceType) === "mac";
   // Real CUDA (not ROCm); gates the NVIDIA-only compressed-tensors formats.
   const hasNvidia = hardware.cuda != null && hardware.rocm == null;
@@ -519,7 +523,8 @@ export function ExportPage() {
     if (!effectiveIsAdapter && effectiveIsQuantized && exportMethod !== null) {
       setExportMethod(null);
     }
-    // The GGUF LoRA target only applies to an adapter checkpoint on a non-Mac host.
+    // The GGUF LoRA target applies only to an adapter checkpoint, and the GGUF
+    // method stays full-model on Mac, where the LoRA method owns GGUF adapters.
     if ((!effectiveIsAdapter || isMacHost) && ggufTarget !== "model") {
       setGgufTarget("model");
     }
@@ -728,8 +733,7 @@ export function ExportPage() {
     const token = pushToHub && actionHfToken ? actionHfToken : undefined;
     // The GGUF method with the LoRA target reuses the LoRA-adapter export path.
     const effectiveMethod: ExportMethod = ggufAsLora ? "lora" : exportMethod;
-    const emitLoraGguf =
-      ggufAsLora || (effectiveMethod === "lora" && loraAsGguf && !isMacHost);
+    const emitLoraGguf = ggufAsLora || (effectiveMethod === "lora" && loraAsGguf);
     const methodLabel = ggufAsLora
       ? "GGUF LoRA adapter"
       : (EXPORT_METHODS.find((m) => m.value === exportMethod)?.title ??
@@ -773,6 +777,7 @@ export function ExportPage() {
       })),
       loraGguf: emitLoraGguf,
       loraGgufOuttype,
+      adapterFormat: isMacHost && !emitLoraGguf ? adapterFormat : undefined,
       saveDirectory,
       destination,
       repoId,
@@ -807,6 +812,7 @@ export function ExportPage() {
     loraAsGguf,
     isMacHost,
     loraGgufOuttype,
+    adapterFormat,
     exportUnsupported,
     destination,
     saveDirectory,
@@ -1525,7 +1531,7 @@ export function ExportPage() {
                           variant={loraAsGguf ? "outline" : "default"}
                           size="sm"
                           onClick={() => setLoraAsGguf(false)}
-                          title="Standard PEFT adapter (adapter_model.safetensors)."
+                          title="Adapter weights as safetensors."
                         >
                           Adapter (safetensors)
                         </Button>
@@ -1533,25 +1539,65 @@ export function ExportPage() {
                           type="button"
                           variant={loraAsGguf ? "default" : "outline"}
                           size="sm"
-                          disabled={isMacHost}
                           onClick={() => setLoraAsGguf(true)}
-                          title={
-                            isMacHost
-                              ? "GGUF LoRA export is not available on macOS/MLX. Use the safetensors adapter."
-                              : "llama.cpp GGUF LoRA, loadable with `llama-cli --lora`."
-                          }
+                          title="llama.cpp GGUF LoRA, loadable with `llama-cli --lora`."
                         >
                           GGUF adapter
                         </Button>
                       </div>
                       <div className="text-xs text-muted-foreground">
-                        {isMacHost
-                          ? "GGUF LoRA is not available on macOS/MLX; exporting the safetensors adapter."
-                          : loraAsGguf
-                            ? "Converts the adapter to a GGUF LoRA (llama.cpp `--lora`). The base model stays separate."
+                        {loraAsGguf
+                          ? isMacHost
+                            ? "Converts the adapter to a GGUF LoRA (llama.cpp `--lora`); the adapter files are written in PEFT format. Not available for adapters with per-module alpha values, rsLoRA with per-module ranks, DoRA, replaced embeddings or modules_to_save, or expert-parameter targets."
+                            : "Converts the adapter to a GGUF LoRA (llama.cpp `--lora`). The base model stays separate."
+                          : isMacHost
+                            ? "Adapter weights only; pick the on-disk format below."
                             : "Standard PEFT adapter files. Pair with the base model at inference."}
                       </div>
                     </div>
+
+                    {!loraAsGguf && isMacHost && (
+                      <div
+                        className="space-y-2"
+                        data-testid="adapter-format-picker"
+                      >
+                        <div className="text-sm font-medium">
+                          Safetensors format
+                        </div>
+                        <div className="flex flex-wrap gap-2">
+                          <Button
+                            type="button"
+                            variant={
+                              adapterFormat === "mlx" ? "default" : "outline"
+                            }
+                            size="sm"
+                            onClick={() => setAdapterFormat("mlx")}
+                            title="Native mlx-lm adapter (adapters.safetensors)."
+                          >
+                            MLX
+                          </Button>
+                          <Button
+                            type="button"
+                            variant={
+                              adapterFormat === "peft" ? "default" : "outline"
+                            }
+                            size="sm"
+                            onClick={() => setAdapterFormat("peft")}
+                            title="Standard Hugging Face PEFT adapter (adapter_model.safetensors)."
+                          >
+                            PEFT
+                          </Button>
+                        </div>
+                        <div className="text-xs text-muted-foreground">
+                          {adapterCompatibilityTip(
+                            adapterFormat,
+                            selectedModelData?.adapter_features,
+                          )}{" "}
+                          Training checkpoints always remain MLX; this choice
+                          only affects the exported copy.
+                        </div>
+                      </div>
+                    )}
 
                     {loraAsGguf && (
                       <div className="space-y-1.5">

--- a/studio/frontend/src/features/export/stores/export-runtime-store.ts
+++ b/studio/frontend/src/features/export/stores/export-runtime-store.ts
@@ -150,6 +150,7 @@ export interface RunExportParams {
   }[];
   /** LoRA: also emit a GGUF LoRA adapter (llama.cpp `--lora`), and its output float type. */
   loraGguf?: boolean;
+  adapterFormat?: "mlx" | "peft";
   loraGgufOuttype?: string;
   saveDirectory: string;
   destination: ExportDestination;
@@ -512,6 +513,7 @@ export const useExportRuntimeStore = create<ExportRuntimeStore>()((set, get) => 
             private: params.privateRepo,
             gguf: params.loraGguf ?? false,
             gguf_outtype: params.loraGgufOuttype ?? "q8_0",
+            adapter_format: params.adapterFormat,
           }),
         );
         if (outputPath) {

--- a/unsloth_cli/commands/export.py
+++ b/unsloth_cli/commands/export.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import platform
 from pathlib import Path
 from typing import Optional
 
@@ -10,6 +11,13 @@ from unsloth_cli._studio_deps import studio_backend_imports
 
 
 EXPORT_FORMATS = ["merged-16bit", "merged-4bit", "gguf", "lora"]
+ADAPTER_FORMATS = ["mlx", "peft"]
+
+
+def _is_apple_silicon() -> bool:
+    return platform.system() == "Darwin" and platform.machine() == "arm64"
+
+
 GGUF_QUANTS = ["q4_k_m", "q5_k_m", "q8_0", "f16"]
 
 
@@ -62,6 +70,15 @@ def export(
     private: bool = typer.Option(False, "--private", help = "Make the HuggingFace repo private."),
     max_seq_length: int = typer.Option(2048, "--max-seq-length"),
     load_in_4bit: bool = typer.Option(True, "--load-in-4bit/--no-load-in-4bit"),
+    adapter_format: Optional[str] = typer.Option(
+        None,
+        "--adapter-format",
+        help = "LoRA adapter on-disk format (mlx or peft); omitted writes the "
+        "platform's native format. Apple-silicon hosts only.",
+        # Registered everywhere so explicit off-Mac use gets a clear error,
+        # but only advertised where it applies.
+        hidden = not _is_apple_silicon(),
+    ),
 ):
     """Export a checkpoint to various formats (merged, GGUF, LoRA adapter)."""
     if format not in EXPORT_FORMATS:
@@ -74,6 +91,28 @@ def export(
     if push_to_hub and not repo_id:
         typer.echo("Error: --repo-id required when using --push-to-hub", err = True)
         raise typer.Exit(code = 2)
+
+    if adapter_format is not None:
+        if adapter_format not in ADAPTER_FORMATS:
+            typer.echo(
+                f"Error: Invalid adapter format '{adapter_format}'. "
+                f"Choose from: {', '.join(ADAPTER_FORMATS)}",
+                err = True,
+            )
+            raise typer.Exit(code = 2)
+        if format != "lora":
+            typer.echo(
+                "Error: --adapter-format only applies to --format lora",
+                err = True,
+            )
+            raise typer.Exit(code = 2)
+        if not _is_apple_silicon():
+            typer.echo(
+                "Error: --adapter-format is only available on Apple-silicon "
+                "hosts; this platform exports the native PEFT format.",
+                err = True,
+            )
+            raise typer.Exit(code = 2)
 
     with studio_backend_imports("unsloth export"):
         from studio.backend.core.export import ExportBackend
@@ -126,6 +165,7 @@ def export(
             repo_id = repo_id,
             hf_token = hf_token,
             private = private,
+            adapter_format = adapter_format,
         )
 
     if not success:

--- a/unsloth_cli/tests/test_export_adapter_format_flag.py
+++ b/unsloth_cli/tests/test_export_adapter_format_flag.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Mac pass-through and off-Mac rejection for --adapter-format."""
+
+import sys
+import types
+from pathlib import Path
+
+import typer
+from typer.testing import CliRunner
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+class _FakeBackend:
+    def __init__(self, lora_result = (True, "exported", "/tmp/out")):
+        self.lora_result, self.lora_kwargs = lora_result, None
+
+    def load_checkpoint(self, **kwargs):
+        return True, "loaded"
+
+    def export_lora_adapter(self, **kwargs):
+        self.lora_kwargs = kwargs
+        return self.lora_result
+
+
+def _run(
+    monkeypatch,
+    args,
+    is_mac,
+    backend = None,
+):
+    from unsloth_cli.commands import export as export_mod
+
+    backend = backend or _FakeBackend()
+    monkeypatch.setattr(export_mod, "_is_apple_silicon", lambda: is_mac)
+    fake_core = types.SimpleNamespace(ExportBackend = lambda: backend)
+    monkeypatch.setitem(sys.modules, "studio.backend.core.export", fake_core)
+    app = typer.Typer()
+    app.command()(export_mod.export)
+    result = CliRunner().invoke(app, ["/tmp/ckpt", "/tmp/out", "--format", "lora", *args])
+    return result, backend
+
+
+def test_flag_contract(monkeypatch):
+    result, backend = _run(monkeypatch, ["--adapter-format", "peft"], is_mac = True)
+    assert result.exit_code == 0, result.output
+    assert backend.lora_kwargs["adapter_format"] == "peft"
+    result, backend = _run(monkeypatch, ["--adapter-format", "mlx"], is_mac = False)
+    assert (
+        result.exit_code == 2 and "Apple-silicon" in result.stderr and backend.lora_kwargs is None
+    )


### PR DESCRIPTION
## What this does

Surfaces the new PEFT↔MLX adapter interop through Studio and the CLI, so a LoRA trained on Apple silicon can be exported in the standard Hugging Face format and used on a GPU machine, and vice versa.

Depends on unslothai/unsloth-zoo#957, which adds the conversion itself. Without that zoo change the new option surfaces a clear upgrade message rather than failing obscurely.

Three surfaces change:

- **Studio backend** — `export_lora` accepts an `adapter_format` of `"mlx"` or `"peft"`. Omitting it resolves to the platform default, which keeps every existing call byte-identical on both platforms.
- **Studio frontend** — the LoRA export card gains an adapter-format selector on Apple silicon, with a compatibility tip driven by the adapter's actual features.
- **CLI** — `unsloth export --format lora` gains `--adapter-format`.

Training and checkpoint output are untouched. Checkpoints remain MLX-format; only export is affected.

## Why the option is Mac-only

On a CUDA machine PEFT already is the native format, so a selector there would offer a choice between one format and itself. The flag is registered on every platform so that explicit off-Mac use gets an actionable error instead of an unknown-argument failure, but it is advertised only where it applies.

## GGUF LoRA adapters on macOS

GGUF LoRA files are built from a PEFT-format adapter, so this change also unlocks GGUF adapter export on Apple silicon: the MLX adapter is materialized as PEFT, then converted with llama.cpp's `convert_lora_to_gguf.py` — the same pipeline the CUDA path uses.

The GGUF method card is deliberately unchanged. Its LoRA-adapter target is not offered on Mac; GGUF adapters ship through the LoRA method's own toggle there, so the existing GGUF flow behaves exactly as before on both platforms.

Conversions that GGUF LoRA cannot represent are refused before converting rather than producing a misleading file: per-module alpha patterns (the format has one global alpha, and rsLoRA sources surface here because export bakes their scales into alphas), DoRA, full-module state, and expert-parameter adapters.

## Feature detection is tri-state

The compatibility tip depends on knowing what an adapter contains, and a config marker alone cannot prove absence: PEFT auto-saves embedding and base state only as weight keys, and MLX trainer checkpoints may carry non-LoRA trainable tensors with no marker at all. Detection is therefore three-valued — a marker means true, a weight-header read can prove a negative, and a skipped or failed probe stays unverified.

This matters for one claim in particular. The tip only states vLLM compatibility when every relevant field is a *verified* false; an unverified field never earns that claim. Bulk listings skip the header probe for cost, which is safe because config markers still classify training-run adapters correctly.

## Hub pushes

Adapter pushes to the Hub use a compare-and-swap against the branch head, so a concurrent push cannot be silently clobbered. A repo-authored `README.md` survives adapter pushes. One directory or repo holds exactly one adapter format — a leftover weight file of the other format would make loaders disagree about what they are reading, so it is refused.

## Validation

```bash
python -m pytest studio/backend/tests/test_export_adapter_format.py unsloth_cli/tests/test_export_adapter_format_flag.py -q
# 16 passed

python -m pytest unsloth_cli/tests/ -q
# 665 passed, 4 skipped
```

Frontend `tsc --noEmit` is clean and the production build succeeds.

The backend's six-cell platform × field matrix is covered by tests: omission stays byte-identical to the pre-existing native call on **both** platforms, and explicit native values match it. That is the property that keeps this change inert for existing users.

End-to-end, the export path was exercised against a real CUDA host: a Studio-style PEFT export of an MLX-trained adapter loads in `transformers`/PEFT on a GPU machine and continues training there.

## Notes for reviewers

- The adapter-format selector lives inline in the export page rather than in a separate component, matching how the other method-specific controls there are structured.
- `_resolve_adapter_format` is the single place platform policy is decided; the backend never infers the format anywhere else.
- If an installed unsloth-zoo predates unslothai/unsloth-zoo#957, the PEFT path raises a named upgrade message instead of an `AttributeError`.
- Adapters the zoo converter does not accept — embedding LoRA, expert-parameter factors, LoRA wrappers plain PEFT cannot represent — surface its named refusal at export time rather than producing a partial adapter. This surface adds no detection of its own for them; the compatibility tip models DoRA, full-module state, expert parameters, and per-module rank/alpha.

