### PR TITLE
Studio installer: name the encoding when syncing the llama_backend marker

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5644,7 +5644,7 @@ def sync_marker_llama_backend(install_dir: Path, llama_backend: str | None) -> N
     """Sync the persisted llama.cpp backend when the bundle is reused unchanged."""
     marker_path = install_dir / "UNSLOTH_PREBUILT_INFO.json"
     try:
-        marker = json.loads(marker_path.read_text())
+        marker = json.loads(marker_path.read_text(encoding = "utf-8"))
     except (OSError, ValueError):
         return
     if not isinstance(marker, dict) or marker.get("llama_backend") == llama_backend:
@@ -5653,7 +5653,7 @@ def sync_marker_llama_backend(install_dir: Path, llama_backend: str | None) -> N
         marker.pop("llama_backend", None)
     else:
         marker["llama_backend"] = llama_backend
-    marker_path.write_text(json.dumps(marker, indent = 2) + "\n")
+    marker_path.write_text(json.dumps(marker, indent = 2) + "\n", encoding = "utf-8")
     log(f"existing install reused; recorded llama_backend={llama_backend!r} from this run")
 
 


### PR DESCRIPTION
`sync_marker_llama_backend` reads and rewrites `UNSLOTH_PREBUILT_INFO.json` without an encoding, so the operator's locale decides it. On a Windows box whose ANSI code page is not UTF-8 that either raises or silently rewrites the marker as mojibake, and a corrupted marker sends the next run down a different install path.

Its sibling `sync_marker_force_cpu`, immediately above and reading the same file, already passes `encoding = "utf-8"` on both calls. This matches it.

## Why now

These are the two call sites that `tests/test_runtime_text_encoding.py::test_shipping_code_names_an_encoding` has been failing on, which is why **Repo tests (CPU) is currently red on main** (run for `1781770be`):

```
FAILED tests/test_runtime_text_encoding.py::test_shipping_code_names_an_encoding
AssertionError: 2 text read/write call sites in shipping code let the operator's
locale decide the encoding, so they crash or silently produce mojibake on Windows.
Pass encoding = "utf-8": ['studio/install_llama_prebuilt.py:5656: write_text()',
                          'studio/install_llama_prebuilt.py:5647: read_text()']
```

## Verification

- `tests/test_runtime_text_encoding.py`: 8 passed (was 1 failed, 7 passed).
- Negative control: reverting the two-line change makes the test fail again, so it is not vacuous.
- `tests/studio/install`: 1453 passed, 3 skipped.
- Ruff clean on the changed file.