### PR TITLE
Remove the transient Studio desktop auth handoff

### DIFF
--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -395,9 +395,7 @@ function TauriWrapper({ children }: { children: ReactNode }) {
     );
   }
 
-  const showApp = status === "running";
-  const desktopBooting = status === "running" && !desktopAuthReady;
-  const showInteractiveApp = showApp && desktopAuthReady;
+  const showApp = status === "running" && desktopAuthReady;
   const startupStatus = status === "running" ? "starting" : status;
   const startupProgressDetail = progressDetail;
   const usesCustomTitlebar = shouldUseCustomWindowTitlebar();
@@ -409,28 +407,12 @@ function TauriWrapper({ children }: { children: ReactNode }) {
       <TauriUpdateLayer isExternalServer={isExternalServer}>
         <LlamaUpdateBanner
           positioned={false}
-          enabled={showInteractiveApp && !hidesTitlebarSidebar}
+          enabled={!hidesTitlebarSidebar}
         />
-        {showInteractiveApp ? (
-          <DownloadManagerPanel positioned={false} />
-        ) : null}
+        <DownloadManagerPanel positioned={false} />
       </TauriUpdateLayer>
-      {showInteractiveApp ? <NativeIntentDrain /> : null}
-      {showInteractiveApp ? children : null}
-      {desktopBooting ? (
-        <div className="pointer-events-none fixed inset-x-0 bottom-5 z-[9999] flex justify-center px-4">
-          <div className="absolute inset-x-4 bottom-16 mx-auto flex max-w-[520px] flex-col items-center gap-2 rounded-2xl border border-border/70 bg-background/95 px-6 py-5 text-center shadow-xl">
-            <div className="font-medium text-sm">Preparing Unsloth</div>
-            <div className="text-muted-foreground text-xs">
-              The local backend is ready. Signing in to your desktop session
-              before loading chats.
-            </div>
-          </div>
-          <div className="rounded-full border border-border/70 bg-background/95 px-4 py-2 text-xs text-muted-foreground shadow-lg">
-            Signing in to desktop session...
-          </div>
-        </div>
-      ) : null}
+      <NativeIntentDrain />
+      {children}
     </>
   ) : (
     <StartupScreen

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -110,7 +110,6 @@ def test_desktop_startup_waits_for_auth_without_intermediate_handoff():
     assert "{children}" in source
 
 
-
 def test_full_app_layout_uses_its_own_initialized_marker():
     source = APP_PROVIDER.read_text(encoding = "utf-8")
 

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -98,6 +98,19 @@ def test_chat_exports_await_native_saves_and_markdown_uses_shared_helper():
     assert "downloadFile(" in thread
 
 
+def test_desktop_startup_waits_for_auth_without_intermediate_handoff():
+    source = APP_PROVIDER.read_text(encoding = "utf-8")
+
+    assert 'const showApp = status === "running" && desktopAuthReady;' in source
+    assert "Preparing Unsloth" not in source
+    assert "Signing in to desktop session" not in source
+    assert "desktopBooting" not in source
+    assert "showInteractiveApp" not in source
+    assert "<NativeIntentDrain />" in source
+    assert "{children}" in source
+
+
+
 def test_full_app_layout_uses_its_own_initialized_marker():
     source = APP_PROVIDER.read_text(encoding = "utf-8")
 


### PR DESCRIPTION
The desktop startup wrapper switched away from the existing startup screen as soon as the backend reported `running`, before forced desktop authentication had completed. That short gap rendered a separate "Preparing Unsloth / Signing in" handoff which flashed after installation and during normal launches.

## Changes

- keep the existing startup screen mounted until both the backend and desktop authentication are ready
- mount chats, native intent handling, update UI, and downloads together after the authentication gate passes
- remove the transient handoff card and pill
- retain the existing authentication retry and failure handling
- add a focused desktop startup contract

## Verification

- Frontend typecheck passed.
- Frontend production build passed.
- All 6 focused desktop reliability contracts passed.
- Python compile and whitespace checks passed.