### PR TITLE
Pin utf-8 on the llama.cpp install marker I/O

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5644,7 +5644,7 @@ def sync_marker_llama_backend(install_dir: Path, llama_backend: str | None) -> N
     """Sync the persisted llama.cpp backend when the bundle is reused unchanged."""
     marker_path = install_dir / "UNSLOTH_PREBUILT_INFO.json"
     try:
-        marker = json.loads(marker_path.read_text())
+        marker = json.loads(marker_path.read_text(encoding = "utf-8"))
     except (OSError, ValueError):
         return
     if not isinstance(marker, dict) or marker.get("llama_backend") == llama_backend:
@@ -5653,7 +5653,7 @@ def sync_marker_llama_backend(install_dir: Path, llama_backend: str | None) -> N
         marker.pop("llama_backend", None)
     else:
         marker["llama_backend"] = llama_backend
-    marker_path.write_text(json.dumps(marker, indent = 2) + "\n")
+    marker_path.write_text(json.dumps(marker, indent = 2) + "\n", encoding = "utf-8")
     log(f"existing install reused; recorded llama_backend={llama_backend!r} from this run")
 
 


### PR DESCRIPTION
main is currently red on `Repo tests (CPU)`:

```
FAILED tests/test_runtime_text_encoding.py::test_shipping_code_names_an_encoding
E  ['studio/install_llama_prebuilt.py:5656: write_text()',
    'studio/install_llama_prebuilt.py:5647: read_text()']
```

`sync_marker_llama_backend` reads and writes `UNSLOTH_PREBUILT_INFO.json` on the operator locale rather than a named encoding, which that test forbids for shipping code. It has been failing since #7373 landed, and every open PR inherits it: #7531, #7532 and #7533 all show the same single red check on a file none of them touch.

Two lines, matching the encoding the rest of the marker I/O in this file already pins. Reproduced on a pristine checkout at `3230a10a9` (fails), and `tests/test_runtime_text_encoding.py` is 8 passed with the fix.