### PR TITLE
fix(studio): name utf-8 when syncing the llama backend marker

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5644,7 +5644,7 @@ def sync_marker_llama_backend(install_dir: Path, llama_backend: str | None) -> N
     """Sync the persisted llama.cpp backend when the bundle is reused unchanged."""
     marker_path = install_dir / "UNSLOTH_PREBUILT_INFO.json"
     try:
-        marker = json.loads(marker_path.read_text())
+        marker = json.loads(marker_path.read_text(encoding = "utf-8"))
     except (OSError, ValueError):
         return
     if not isinstance(marker, dict) or marker.get("llama_backend") == llama_backend:
@@ -5653,7 +5653,7 @@ def sync_marker_llama_backend(install_dir: Path, llama_backend: str | None) -> N
         marker.pop("llama_backend", None)
     else:
         marker["llama_backend"] = llama_backend
-    marker_path.write_text(json.dumps(marker, indent = 2) + "\n")
+    marker_path.write_text(json.dumps(marker, indent = 2) + "\n", encoding = "utf-8")
     log(f"existing install reused; recorded llama_backend={llama_backend!r} from this run")
 
 


### PR DESCRIPTION
## Problem

`Repo tests (CPU)` is red on `main`:

```
AssertionError: 2 text read/write call sites in shipping code let the operator's
locale decide the encoding, so they crash or silently produce mojibake on Windows.
Pass encoding = "utf-8":
  ['studio/install_llama_prebuilt.py:5656: write_text()',
   'studio/install_llama_prebuilt.py:5647: read_text()']
```

`sync_marker_llama_backend` reads and writes `UNSLOTH_PREBUILT_INFO.json` without naming an encoding. On a stock Windows install both calls resolve to cp1252, so the read can raise or round trip mojibake into a file we then re-serialise.

The sibling helper immediately above it, `sync_marker_force_cpu`, already passes `encoding = "utf-8"` on both calls, so this looks like a plain oversight rather than a deliberate difference.

## Fix

Pass `encoding = "utf-8"` on the read and the write, matching the style already used at lines 4341, 5633, 5639 and 5702 of the same file.

## Verification

```
before:  1 failed, 7 passed   (test_shipping_code_names_an_encoding)
after:   8 passed
```

Two lines, no behaviour change on Linux or macOS where the locale encoding was already UTF-8.

This is unrelated to #7537 and #7538, both of which inherit this failure from `main`.
