### PR TITLE
Installer: stop requiring a developer toolchain on the consumer path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -779,10 +779,9 @@ _smart_apt_install() {
     fi
 
     if [ "$TAURI_MODE" = true ]; then
-        # Optional callers never elevate: the desktop turns NEED_SUDO into a mandatory
-        # "Permission needed" dialog whose Cancel leaves the user not-installed, which
-        # would re-impose the build-tool requirement this gate removes. Nothing here is
-        # needed to run; the caller falls through to prebuilt llama.cpp.
+        # Optional callers never elevate: NEED_SUDO raises a mandatory desktop
+        # permission dialog whose Cancel leaves the user not installed, over tools
+        # nothing needs. The caller falls through to prebuilt llama.cpp.
         if [ "${_SMART_APT_OPTIONAL:-false}" = true ]; then
             return 2
         fi
@@ -1983,33 +1982,26 @@ _maybe_reroute_strixhalo_to_2404() {
 _maybe_reroute_strixhalo_to_2404 || true
 
 # ── Check system dependencies ──
-# cmake/git are only needed to *build* llama.cpp from source. Unsloth downloads a
-# prebuilt by default, and setup.sh self-skips the source build when they're
-# absent -- so macOS doesn't block on cmake (requiring it would force a manual
-# Homebrew install). Linux keeps requiring them; its package manager has them.
 tauri_log "STEP" "Checking system dependencies"
 
-# A working git, not merely a present one: without the Xcode CLT, macOS still has
-# /usr/bin/git as a stub that errors "invalid active developer path" and pops a GUI
-# dialog. `command -v git` answers the wrong question; only running it tells the truth.
+# Without the Xcode CLT, macOS still ships /usr/bin/git as a stub that errors and pops
+# a GUI dialog, so `command -v git` is not enough -- only running it tells the truth.
 _has_working_git() {
     command -v git >/dev/null 2>&1 || return 1
     git --version >/dev/null 2>&1
 }
 
-# macOS system-dependency check. Kept a function so tests/sh can sed-extract it; the
-# old inline form was untestable, which is why this gate shipped broken.
+# macOS system-dependency check. A function so tests/sh can sed-extract it; the old
+# inline form was untestable, which is why this gate shipped broken.
 #
 # The consumer install needs no developer toolchain: uv is a prebuilt binary, CPython
 # is uv-managed, llama.cpp/whisper.cpp/Node are prebuilt downloads, and triton is
-# skipped on macOS. Requiring Xcode CLT blocked every brand-new Mac for a toolchain
-# nothing used. Only `--local` needs git, for the unsloth-zoo git+https URL.
+# skipped on macOS. Only `--local` needs git, for the unsloth-zoo git+https URL.
 _check_macos_deps() {
     _clt_missing=false
     xcode-select -p >/dev/null 2>&1 || _clt_missing=true
 
     if [ "$STUDIO_LOCAL_INSTALL" = true ] && ! _has_working_git; then
-        # Developer install only: pip needs git for the unsloth-zoo git+https URL.
         echo ""
         step "deps" "git is required for --local installs" "$C_ERR"
         substep "--local installs unsloth-zoo from git+https://github.com/unslothai/unsloth-zoo,"
@@ -2022,16 +2014,15 @@ _check_macos_deps() {
     fi
 
     if [ "$_clt_missing" = true ]; then
-        # Not fatal: nothing on the consumer path needs it. Say so instead of firing a
-        # GUI dialog and exiting, which is what stranded clean Macs.
+        # Not fatal, and no GUI dialog: firing xcode-select --install and exiting is
+        # what stranded clean Macs.
         step "deps" "no Xcode Command Line Tools (not required)" "$C_WARN"
         substep "Unsloth installs prebuilt binaries and wheels, so no compiler is needed."
         substep "Install them only for a llama.cpp source build: xcode-select --install"
     elif command -v cmake >/dev/null 2>&1; then
         step "deps" "all system dependencies found"
     else
-        # cmake is only needed for a source build; the default prebuilt path
-        # doesn't use it, so its absence is not fatal -- no Homebrew prerequisite.
+        # cmake is only for a source build, so its absence is not fatal.
         step "deps" "using prebuilt llama.cpp (cmake not found)" "$C_WARN"
         substep "Install cmake only if you want a source build: brew install cmake"
     fi
@@ -2042,27 +2033,25 @@ _check_macos_deps() {
 # reason: tests/sh can extract it.
 #
 # Only a download transport is required. cmake, gcc and the libcurl headers exist
-# solely for a llama.cpp source build, which the consumer path never does --
-# unslothai/llama.cpp publishes linux-x64/arm64 prebuilts for cpu, cuda12, cuda13,
-# rocm and vulkan. Requiring them turned every non-apt distro into a hard exit 1 over
-# unused tooling, the same defect as the macOS gate. git follows macOS: --local only.
+# solely for a llama.cpp source build the consumer path never does -- unslothai/
+# llama.cpp publishes linux-x64/arm64 prebuilts for cpu, cuda12, cuda13, rocm and
+# vulkan. Requiring them turned every non-apt distro into a hard exit 1 over unused
+# tooling. git follows macOS: --local only.
 _check_linux_deps() {
     _transport_missing=false
     if ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1; then
         _transport_missing=true
     fi
 
-    # Wanted but never required: git fetches the triton_kernels git+https requirement
-    # (a training speedup, skipped without it), the rest are for an optional llama.cpp
-    # source build. Auto-installed on apt, a warning elsewhere, never a stop.
+    # Wanted, never required: git fetches the triton_kernels git+https requirement (a
+    # training speedup), the rest serve the optional source build. Warn, never stop.
     _optional_missing=""
     command -v cmake       >/dev/null 2>&1 || _optional_missing="$_optional_missing cmake"
     _has_working_git                       || _optional_missing="$_optional_missing git"
     command -v gcc         >/dev/null 2>&1 || _optional_missing="$_optional_missing build-essential"
     command -v curl-config >/dev/null 2>&1 || _optional_missing="$_optional_missing libcurl4-openssl-dev"
-    # Parameter expansion, not `sed`: this runs before anything is installed and sed
-    # may not exist on a minimal image. A failed `$(... | sed ...)` yields "", which
-    # would report "all system dependencies found" on a machine that has none.
+    # Parameter expansion, not `sed`: sed may be absent on a minimal image, and a
+    # failed `$(... | sed ...)` yields "" -- "all found" on a machine that has none.
     _optional_missing="${_optional_missing# }"
 
     if [ "$STUDIO_LOCAL_INSTALL" = true ] && ! _has_working_git; then
@@ -2074,8 +2063,8 @@ _check_linux_deps() {
         return 1
     fi
 
-    # The one fatal case: nothing can be downloaded. Try apt first, the only distro
-    # family we can drive unattended.
+    # The one fatal case: nothing can be downloaded. apt is the only distro family we
+    # can drive unattended.
     if [ "$_transport_missing" = true ]; then
         if command -v apt-get >/dev/null 2>&1; then
             echo ""
@@ -2095,14 +2084,13 @@ _check_linux_deps() {
         fi
     fi
 
-    # Try apt for the optional set too. A failure only costs the features named below,
-    # but on Debian/Ubuntu we can just get them.
+    # Try apt for the optional set too; failing only costs the features warned about
+    # below.
     if [ -n "$_optional_missing" ] && command -v apt-get >/dev/null 2>&1; then
         step "deps" "installing optional build tools: $_optional_missing" "$C_DIM"
-        # Subshell: _smart_apt_install exits rather than returns, so `|| true` alone
-        # would not catch it and a missing optional tool aborted the install. And
-        # _SMART_APT_OPTIONAL suppresses the NEED_SUDO handshake, so no install hinges
-        # on a permission prompt for tools nothing here needs.
+        # Subshell because _smart_apt_install exits rather than returns, so `|| true`
+        # alone would not catch it. _SMART_APT_OPTIONAL suppresses the NEED_SUDO
+        # handshake, so no install hinges on a prompt for tools nothing here needs.
         ( _SMART_APT_OPTIONAL=true; _smart_apt_install $_optional_missing ) || true
         _optional_missing=""
         command -v cmake       >/dev/null 2>&1 || _optional_missing="$_optional_missing cmake"

--- a/install.sh
+++ b/install.sh
@@ -779,11 +779,10 @@ _smart_apt_install() {
     fi
 
     if [ "$TAURI_MODE" = true ]; then
-        # Optional callers never elevate. The desktop turns NEED_SUDO into a mandatory
-        # "Permission needed" dialog whose Cancel drops the user back to not-installed,
-        # so prompting for cmake, gcc or the libcurl headers would re-impose through a
-        # permission prompt the very build-tool requirement this gate removes. Nothing
-        # in that set is needed to run: the caller falls through to prebuilt llama.cpp.
+        # Optional callers never elevate: the desktop turns NEED_SUDO into a mandatory
+        # "Permission needed" dialog whose Cancel leaves the user not-installed, which
+        # would re-impose the build-tool requirement this gate removes. Nothing here is
+        # needed to run; the caller falls through to prebuilt llama.cpp.
         if [ "${_SMART_APT_OPTIONAL:-false}" = true ]; then
             return 2
         fi
@@ -1990,25 +1989,21 @@ _maybe_reroute_strixhalo_to_2404 || true
 # Homebrew install). Linux keeps requiring them; its package manager has them.
 tauri_log "STEP" "Checking system dependencies"
 
-# A working git, as opposed to a git that merely exists. On a Mac without the Xcode
-# Command Line Tools, /usr/bin/git IS present -- it is a stub that errors with
-# "invalid active developer path" and pops a GUI dialog. So `command -v git`
-# answers the wrong question here; only running it tells the truth.
+# A working git, not merely a present one: without the Xcode CLT, macOS still has
+# /usr/bin/git as a stub that errors "invalid active developer path" and pops a GUI
+# dialog. `command -v git` answers the wrong question; only running it tells the truth.
 _has_working_git() {
     command -v git >/dev/null 2>&1 || return 1
     git --version >/dev/null 2>&1
 }
 
-# macOS system-dependency check. A function, not inline code, so tests/sh can extract
-# and exercise it the way tests/sh/test_mac_intel_compat.sh does -- the old inline
-# form was untestable, which is why this gate shipped broken.
+# macOS system-dependency check. Kept a function so tests/sh can sed-extract it; the
+# old inline form was untestable, which is why this gate shipped broken.
 #
-# The consumer install needs NO developer toolchain: uv arrives as a prebuilt binary,
-# CPython comes from uv's managed python-build-standalone, llama.cpp and whisper.cpp
-# are prebuilt downloads, Node is a pinned nodejs.org archive, and triton is skipped
-# on macOS. Requiring Xcode CLT here therefore blocked every brand-new Mac for a
-# toolchain nothing downstream used. Only `--local` genuinely needs git, because it
-# installs unsloth-zoo from a git+https URL.
+# The consumer install needs no developer toolchain: uv is a prebuilt binary, CPython
+# is uv-managed, llama.cpp/whisper.cpp/Node are prebuilt downloads, and triton is
+# skipped on macOS. Requiring Xcode CLT blocked every brand-new Mac for a toolchain
+# nothing used. Only `--local` needs git, for the unsloth-zoo git+https URL.
 _check_macos_deps() {
     _clt_missing=false
     xcode-select -p >/dev/null 2>&1 || _clt_missing=true
@@ -2027,8 +2022,8 @@ _check_macos_deps() {
     fi
 
     if [ "$_clt_missing" = true ]; then
-        # Not fatal: nothing on the consumer path needs it. Say so plainly instead of
-        # firing a GUI dialog and exiting, which is what stranded clean Macs.
+        # Not fatal: nothing on the consumer path needs it. Say so instead of firing a
+        # GUI dialog and exiting, which is what stranded clean Macs.
         step "deps" "no Xcode Command Line Tools (not required)" "$C_WARN"
         substep "Unsloth installs prebuilt binaries and wheels, so no compiler is needed."
         substep "Install them only for a llama.cpp source build: xcode-select --install"
@@ -2044,34 +2039,30 @@ _check_macos_deps() {
 }
 
 # Linux/WSL system-dependency check. Same split as macOS, and a function for the same
-# reason: tests/sh can extract it, the old inline form could not be reached.
+# reason: tests/sh can extract it.
 #
-# Only a download transport is genuinely required. cmake, gcc and the libcurl headers
-# exist solely for a llama.cpp SOURCE build, and the consumer path never does one --
-# unslothai/llama.cpp publishes linux-x64 and linux-arm64 prebuilts covering cpu,
-# cuda12, cuda13, rocm and vulkan. Requiring them turned every non-apt distro into a
-# hard exit 1 (the Fedora/Arch/openSUSE message below) for tooling nothing downstream
-# used, which is the same defect the macOS Xcode CLT gate had. git follows macOS too:
-# needed only for --local, which installs unsloth-zoo from a git+https URL.
+# Only a download transport is required. cmake, gcc and the libcurl headers exist
+# solely for a llama.cpp source build, which the consumer path never does --
+# unslothai/llama.cpp publishes linux-x64/arm64 prebuilts for cpu, cuda12, cuda13,
+# rocm and vulkan. Requiring them turned every non-apt distro into a hard exit 1 over
+# unused tooling, the same defect as the macOS gate. git follows macOS: --local only.
 _check_linux_deps() {
     _transport_missing=false
     if ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1; then
         _transport_missing=true
     fi
 
-    # Not required to boot, but wanted when we can get them: git fetches the
-    # triton_kernels git+https requirement (a training speedup, skipped without it),
-    # the rest are for an optional llama.cpp source build. Auto-installed on apt,
-    # a warning everywhere else, never a stop.
+    # Wanted but never required: git fetches the triton_kernels git+https requirement
+    # (a training speedup, skipped without it), the rest are for an optional llama.cpp
+    # source build. Auto-installed on apt, a warning elsewhere, never a stop.
     _optional_missing=""
     command -v cmake       >/dev/null 2>&1 || _optional_missing="$_optional_missing cmake"
     _has_working_git                       || _optional_missing="$_optional_missing git"
     command -v gcc         >/dev/null 2>&1 || _optional_missing="$_optional_missing build-essential"
     command -v curl-config >/dev/null 2>&1 || _optional_missing="$_optional_missing libcurl4-openssl-dev"
-    # Parameter expansion, not `sed`: this gate runs before anything is installed, and
-    # on a minimal container image sed may not exist. A failed `$(... | sed ...)` yields
-    # the empty string, which would report "all system dependencies found" on a machine
-    # that has none of them.
+    # Parameter expansion, not `sed`: this runs before anything is installed and sed
+    # may not exist on a minimal image. A failed `$(... | sed ...)` yields "", which
+    # would report "all system dependencies found" on a machine that has none.
     _optional_missing="${_optional_missing# }"
 
     if [ "$STUDIO_LOCAL_INSTALL" = true ] && ! _has_working_git; then
@@ -2083,8 +2074,8 @@ _check_linux_deps() {
         return 1
     fi
 
-    # The one genuinely fatal case: nothing can be downloaded. Try apt first, since
-    # that is the distro family we can drive unattended.
+    # The one fatal case: nothing can be downloaded. Try apt first, the only distro
+    # family we can drive unattended.
     if [ "$_transport_missing" = true ]; then
         if command -v apt-get >/dev/null 2>&1; then
             echo ""
@@ -2104,15 +2095,14 @@ _check_linux_deps() {
         fi
     fi
 
-    # Try apt for the optional set too. Nothing here is fatal, so a failure only
-    # costs the features named below, but on Debian/Ubuntu we can just get them.
+    # Try apt for the optional set too. A failure only costs the features named below,
+    # but on Debian/Ubuntu we can just get them.
     if [ -n "$_optional_missing" ] && command -v apt-get >/dev/null 2>&1; then
         step "deps" "installing optional build tools: $_optional_missing" "$C_DIM"
         # Subshell: _smart_apt_install exits rather than returns, so `|| true` alone
-        # would not catch it and a missing optional tool aborted the very install this
-        # gate exists to let continue. _SMART_APT_OPTIONAL also suppresses the
-        # NEED_SUDO handshake: no install may hinge on a permission prompt for tools
-        # nothing here needs.
+        # would not catch it and a missing optional tool aborted the install. And
+        # _SMART_APT_OPTIONAL suppresses the NEED_SUDO handshake, so no install hinges
+        # on a permission prompt for tools nothing here needs.
         ( _SMART_APT_OPTIONAL=true; _smart_apt_install $_optional_missing ) || true
         _optional_missing=""
         command -v cmake       >/dev/null 2>&1 || _optional_missing="$_optional_missing cmake"

--- a/install.sh
+++ b/install.sh
@@ -778,14 +778,17 @@ _smart_apt_install() {
         return 0
     fi
 
+    # Optional callers never elevate, in any mode: nothing on the consumer path
+    # builds anything, so neither the terminal sudo prompt below nor the Tauri
+    # NEED_SUDO dialog (whose Cancel leaves the user not installed) may gate the
+    # run over unused tools. The caller falls through to prebuilt llama.cpp.
+    # Required packages such as curl still escalate.
+    if [ "${_SMART_APT_OPTIONAL:-false}" = true ]; then
+        return 2
+    fi
+
     if [ "$TAURI_MODE" = true ]; then
-        # Optional callers never elevate: NEED_SUDO raises a mandatory desktop
-        # permission dialog whose Cancel leaves the user not installed, over tools
-        # nothing needs. The caller falls through to prebuilt llama.cpp.
-        if [ "${_SMART_APT_OPTIONAL:-false}" = true ]; then
-            return 2
-        fi
-        # Otherwise report needed packages and exit — Rust handles elevation.
+        # Report needed packages and exit — Rust handles elevation.
         tauri_log "NEED_SUDO" "$_STILL_MISSING"
         exit 2
     fi
@@ -2089,8 +2092,8 @@ _check_linux_deps() {
     if [ -n "$_optional_missing" ] && command -v apt-get >/dev/null 2>&1; then
         step "deps" "installing optional build tools: $_optional_missing" "$C_DIM"
         # Subshell because _smart_apt_install exits rather than returns, so `|| true`
-        # alone would not catch it. _SMART_APT_OPTIONAL suppresses the NEED_SUDO
-        # handshake, so no install hinges on a prompt for tools nothing here needs.
+        # alone would not catch it. _SMART_APT_OPTIONAL suppresses every escalation
+        # path, so no install hinges on a prompt for tools nothing here needs.
         ( _SMART_APT_OPTIONAL=true; _smart_apt_install $_optional_missing ) || true
         _optional_missing=""
         command -v cmake       >/dev/null 2>&1 || _optional_missing="$_optional_missing cmake"

--- a/install.sh
+++ b/install.sh
@@ -1982,18 +1982,25 @@ _maybe_reroute_strixhalo_to_2404 || true
 # Homebrew install). Linux keeps requiring them; its package manager has them.
 tauri_log "STEP" "Checking system dependencies"
 
-# Without the Xcode CLT, /usr/bin/git exists but is a stub that errors and pops a
-# GUI dialog, so `command -v git` answers the wrong question. Run it instead.
+# A working git, as opposed to a git that merely exists. On a Mac without the Xcode
+# Command Line Tools, /usr/bin/git IS present -- it is a stub that errors with
+# "invalid active developer path" and pops a GUI dialog. So `command -v git`
+# answers the wrong question here; only running it tells the truth.
 _has_working_git() {
     command -v git >/dev/null 2>&1 || return 1
     git --version >/dev/null 2>&1
 }
 
-# The consumer install needs no toolchain: uv, CPython, llama.cpp, whisper.cpp and
-# Node all arrive prebuilt, and triton is skipped on macOS. Requiring the Xcode CLT
-# blocked every new Mac over tooling nothing used. Only --local needs git, for the
-# unsloth-zoo git+https URL. A function so tests/sh can extract it; the old inline
-# form was untestable, which is why this shipped broken.
+# macOS system-dependency check. A function, not inline code, so tests/sh can extract
+# and exercise it the way tests/sh/test_mac_intel_compat.sh does -- the old inline
+# form was untestable, which is why this gate shipped broken.
+#
+# The consumer install needs NO developer toolchain: uv arrives as a prebuilt binary,
+# CPython comes from uv's managed python-build-standalone, llama.cpp and whisper.cpp
+# are prebuilt downloads, Node is a pinned nodejs.org archive, and triton is skipped
+# on macOS. Requiring Xcode CLT here therefore blocked every brand-new Mac for a
+# toolchain nothing downstream used. Only `--local` genuinely needs git, because it
+# installs unsloth-zoo from a git+https URL.
 _check_macos_deps() {
     _clt_missing=false
     xcode-select -p >/dev/null 2>&1 || _clt_missing=true
@@ -2012,7 +2019,8 @@ _check_macos_deps() {
     fi
 
     if [ "$_clt_missing" = true ]; then
-        # Not fatal. Firing a GUI dialog and exiting is what stranded clean Macs.
+        # Not fatal: nothing on the consumer path needs it. Say so plainly instead of
+        # firing a GUI dialog and exiting, which is what stranded clean Macs.
         step "deps" "no Xcode Command Line Tools (not required)" "$C_WARN"
         substep "Unsloth installs prebuilt binaries and wheels, so no compiler is needed."
         substep "Install them only for a llama.cpp source build: xcode-select --install"
@@ -2027,24 +2035,35 @@ _check_macos_deps() {
     return 0
 }
 
-# Same split as macOS. Only a download transport is required: cmake, gcc and the
-# libcurl headers exist solely for a llama.cpp source build, which the consumer path
-# never does (unslothai/llama.cpp publishes linux-x64 and linux-arm64 prebuilts for
-# cpu, cuda12, cuda13, rocm and vulkan). Requiring them made every non-apt distro a
-# hard exit 1 over unused tooling, exactly as the macOS gate did.
+# Linux/WSL system-dependency check. Same split as macOS, and a function for the same
+# reason: tests/sh can extract it, the old inline form could not be reached.
+#
+# Only a download transport is genuinely required. cmake, gcc and the libcurl headers
+# exist solely for a llama.cpp SOURCE build, and the consumer path never does one --
+# unslothai/llama.cpp publishes linux-x64 and linux-arm64 prebuilts covering cpu,
+# cuda12, cuda13, rocm and vulkan. Requiring them turned every non-apt distro into a
+# hard exit 1 (the Fedora/Arch/openSUSE message below) for tooling nothing downstream
+# used, which is the same defect the macOS Xcode CLT gate had. git follows macOS too:
+# needed only for --local, which installs unsloth-zoo from a git+https URL.
 _check_linux_deps() {
     _transport_missing=false
     if ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1; then
         _transport_missing=true
     fi
 
-    # Source-build-only tooling. Absence is a warning, never a stop.
+    # Not required to boot, but wanted when we can get them: git fetches the
+    # triton_kernels git+https requirement (a training speedup, skipped without it),
+    # the rest are for an optional llama.cpp source build. Auto-installed on apt,
+    # a warning everywhere else, never a stop.
     _optional_missing=""
     command -v cmake       >/dev/null 2>&1 || _optional_missing="$_optional_missing cmake"
+    _has_working_git                       || _optional_missing="$_optional_missing git"
     command -v gcc         >/dev/null 2>&1 || _optional_missing="$_optional_missing build-essential"
     command -v curl-config >/dev/null 2>&1 || _optional_missing="$_optional_missing libcurl4-openssl-dev"
-    # Parameter expansion, not sed: this runs before anything is installed, and on a
-    # minimal image a failed $(... | sed ...) yields "" -> "all dependencies found".
+    # Parameter expansion, not `sed`: this gate runs before anything is installed, and
+    # on a minimal container image sed may not exist. A failed `$(... | sed ...)` yields
+    # the empty string, which would report "all system dependencies found" on a machine
+    # that has none of them.
     _optional_missing="${_optional_missing# }"
 
     if [ "$STUDIO_LOCAL_INSTALL" = true ] && ! _has_working_git; then
@@ -2056,8 +2075,8 @@ _check_linux_deps() {
         return 1
     fi
 
-    # The one fatal case: nothing can be downloaded. apt first, the family we can
-    # drive unattended.
+    # The one genuinely fatal case: nothing can be downloaded. Try apt first, since
+    # that is the distro family we can drive unattended.
     if [ "$_transport_missing" = true ]; then
         if command -v apt-get >/dev/null 2>&1; then
             echo ""
@@ -2077,10 +2096,25 @@ _check_linux_deps() {
         fi
     fi
 
+    # Try apt for the optional set too. Nothing here is fatal, so a failure only
+    # costs the features named below, but on Debian/Ubuntu we can just get them.
+    if [ -n "$_optional_missing" ] && command -v apt-get >/dev/null 2>&1; then
+        step "deps" "installing optional build tools: $_optional_missing" "$C_DIM"
+        _smart_apt_install $_optional_missing || true
+        _optional_missing=""
+        command -v cmake       >/dev/null 2>&1 || _optional_missing="$_optional_missing cmake"
+        _has_working_git                       || _optional_missing="$_optional_missing git"
+        command -v gcc         >/dev/null 2>&1 || _optional_missing="$_optional_missing build-essential"
+        command -v curl-config >/dev/null 2>&1 || _optional_missing="$_optional_missing libcurl4-openssl-dev"
+        _optional_missing="${_optional_missing# }"
+    fi
+
     if [ -n "$_optional_missing" ]; then
         step "deps" "using prebuilt llama.cpp (missing: $_optional_missing)" "$C_WARN"
-        substep "Not required: Unsloth downloads a prebuilt inference engine."
-        substep "Install them only for a llama.cpp source build."
+        substep "Not required to run: Unsloth downloads a prebuilt inference engine."
+        case " $_optional_missing " in
+            *" git "*) substep "Without git the triton kernels training speedup is skipped." ;;
+        esac
     else
         step "deps" "all system dependencies found"
     fi

--- a/install.sh
+++ b/install.sh
@@ -778,8 +778,16 @@ _smart_apt_install() {
         return 0
     fi
 
-    # In Tauri mode, report needed packages and exit — Rust handles elevation
     if [ "$TAURI_MODE" = true ]; then
+        # Optional callers never elevate. The desktop turns NEED_SUDO into a mandatory
+        # "Permission needed" dialog whose Cancel drops the user back to not-installed,
+        # so prompting for cmake, gcc or the libcurl headers would re-impose through a
+        # permission prompt the very build-tool requirement this gate removes. Nothing
+        # in that set is needed to run: the caller falls through to prebuilt llama.cpp.
+        if [ "${_SMART_APT_OPTIONAL:-false}" = true ]; then
+            return 2
+        fi
+        # Otherwise report needed packages and exit — Rust handles elevation.
         tauri_log "NEED_SUDO" "$_STILL_MISSING"
         exit 2
     fi
@@ -2100,13 +2108,12 @@ _check_linux_deps() {
     # costs the features named below, but on Debian/Ubuntu we can just get them.
     if [ -n "$_optional_missing" ] && command -v apt-get >/dev/null 2>&1; then
         step "deps" "installing optional build tools: $_optional_missing" "$C_DIM"
-        # Subshell: _smart_apt_install exits rather than returns, and `|| true`
-        # does not catch an exit, so a missing optional tool aborted the install
-        # this gate exists to let continue. Code 2 is still re-raised, it is the
-        # NEED_SUDO handshake install.rs answers with an elevation prompt.
-        _sai_rc=0
-        ( _smart_apt_install $_optional_missing ) || _sai_rc=$?
-        if [ "$_sai_rc" -eq 2 ]; then exit 2; fi
+        # Subshell: _smart_apt_install exits rather than returns, so `|| true` alone
+        # would not catch it and a missing optional tool aborted the very install this
+        # gate exists to let continue. _SMART_APT_OPTIONAL also suppresses the
+        # NEED_SUDO handshake: no install may hinge on a permission prompt for tools
+        # nothing here needs.
+        ( _SMART_APT_OPTIONAL=true; _smart_apt_install $_optional_missing ) || true
         _optional_missing=""
         command -v cmake       >/dev/null 2>&1 || _optional_missing="$_optional_missing cmake"
         _has_working_git                       || _optional_missing="$_optional_missing git"

--- a/install.sh
+++ b/install.sh
@@ -2100,7 +2100,13 @@ _check_linux_deps() {
     # costs the features named below, but on Debian/Ubuntu we can just get them.
     if [ -n "$_optional_missing" ] && command -v apt-get >/dev/null 2>&1; then
         step "deps" "installing optional build tools: $_optional_missing" "$C_DIM"
-        _smart_apt_install $_optional_missing || true
+        # Subshell: _smart_apt_install exits rather than returns, and `|| true`
+        # does not catch an exit, so a missing optional tool aborted the install
+        # this gate exists to let continue. Code 2 is still re-raised, it is the
+        # NEED_SUDO handshake install.rs answers with an elevation prompt.
+        _sai_rc=0
+        ( _smart_apt_install $_optional_missing ) || _sai_rc=$?
+        if [ "$_sai_rc" -eq 2 ]; then exit 2; fi
         _optional_missing=""
         command -v cmake       >/dev/null 2>&1 || _optional_missing="$_optional_missing cmake"
         _has_working_git                       || _optional_missing="$_optional_missing git"

--- a/install.sh
+++ b/install.sh
@@ -1982,61 +1982,117 @@ _maybe_reroute_strixhalo_to_2404 || true
 # Homebrew install). Linux keeps requiring them; its package manager has them.
 tauri_log "STEP" "Checking system dependencies"
 
-case "$OS" in
-    macos)
-        # Xcode Command Line Tools provide the C/C++ compiler and git.
-        if ! xcode-select -p >/dev/null 2>&1; then
-            echo ""
-            echo "==> Xcode Command Line Tools are required."
-            echo "    Installing (a system dialog will appear)..."
-            xcode-select --install </dev/null 2>/dev/null || true
-            echo "    After the installation completes, please re-run this script."
-            exit 1
-        fi
+# Without the Xcode CLT, /usr/bin/git exists but is a stub that errors and pops a
+# GUI dialog, so `command -v git` answers the wrong question. Run it instead.
+_has_working_git() {
+    command -v git >/dev/null 2>&1 || return 1
+    git --version >/dev/null 2>&1
+}
+
+# The consumer install needs no toolchain: uv, CPython, llama.cpp, whisper.cpp and
+# Node all arrive prebuilt, and triton is skipped on macOS. Requiring the Xcode CLT
+# blocked every new Mac over tooling nothing used. Only --local needs git, for the
+# unsloth-zoo git+https URL. A function so tests/sh can extract it; the old inline
+# form was untestable, which is why this shipped broken.
+_check_macos_deps() {
+    _clt_missing=false
+    xcode-select -p >/dev/null 2>&1 || _clt_missing=true
+
+    if [ "$STUDIO_LOCAL_INSTALL" = true ] && ! _has_working_git; then
+        # Developer install only: pip needs git for the unsloth-zoo git+https URL.
+        echo ""
+        step "deps" "git is required for --local installs" "$C_ERR"
+        substep "--local installs unsloth-zoo from git+https://github.com/unslothai/unsloth-zoo,"
+        substep "which needs a working git. Install the Xcode Command Line Tools:"
+        substep "  xcode-select --install"
+        substep "Then re-run this script. A normal (non---local) install needs no compiler"
+        substep "and no git -- it uses prebuilt binaries and wheels only."
+        tauri_log "NEED_XCODE_CLT" "git"
+        return 1
+    fi
+
+    if [ "$_clt_missing" = true ]; then
+        # Not fatal. Firing a GUI dialog and exiting is what stranded clean Macs.
+        step "deps" "no Xcode Command Line Tools (not required)" "$C_WARN"
+        substep "Unsloth installs prebuilt binaries and wheels, so no compiler is needed."
+        substep "Install them only for a llama.cpp source build: xcode-select --install"
+    elif command -v cmake >/dev/null 2>&1; then
+        step "deps" "all system dependencies found"
+    else
         # cmake is only needed for a source build; the default prebuilt path
         # doesn't use it, so its absence is not fatal -- no Homebrew prerequisite.
-        if command -v cmake >/dev/null 2>&1; then
-            step "deps" "all system dependencies found"
+        step "deps" "using prebuilt llama.cpp (cmake not found)" "$C_WARN"
+        substep "Install cmake only if you want a source build: brew install cmake"
+    fi
+    return 0
+}
+
+# Same split as macOS. Only a download transport is required: cmake, gcc and the
+# libcurl headers exist solely for a llama.cpp source build, which the consumer path
+# never does (unslothai/llama.cpp publishes linux-x64 and linux-arm64 prebuilts for
+# cpu, cuda12, cuda13, rocm and vulkan). Requiring them made every non-apt distro a
+# hard exit 1 over unused tooling, exactly as the macOS gate did.
+_check_linux_deps() {
+    _transport_missing=false
+    if ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1; then
+        _transport_missing=true
+    fi
+
+    # Source-build-only tooling. Absence is a warning, never a stop.
+    _optional_missing=""
+    command -v cmake       >/dev/null 2>&1 || _optional_missing="$_optional_missing cmake"
+    command -v gcc         >/dev/null 2>&1 || _optional_missing="$_optional_missing build-essential"
+    command -v curl-config >/dev/null 2>&1 || _optional_missing="$_optional_missing libcurl4-openssl-dev"
+    # Parameter expansion, not sed: this runs before anything is installed, and on a
+    # minimal image a failed $(... | sed ...) yields "" -> "all dependencies found".
+    _optional_missing="${_optional_missing# }"
+
+    if [ "$STUDIO_LOCAL_INSTALL" = true ] && ! _has_working_git; then
+        echo ""
+        step "deps" "git is required for --local installs" "$C_ERR"
+        substep "--local installs unsloth-zoo from git+https://github.com/unslothai/unsloth-zoo,"
+        substep "which needs git. Install it with your package manager, then re-run."
+        substep "A normal (non---local) install needs no git and no compiler."
+        return 1
+    fi
+
+    # The one fatal case: nothing can be downloaded. apt first, the family we can
+    # drive unattended.
+    if [ "$_transport_missing" = true ]; then
+        if command -v apt-get >/dev/null 2>&1; then
+            echo ""
+            step "deps" "missing: curl" "$C_WARN"
+            substep "Needed to download uv, Python and the prebuilt inference engine."
+            _smart_apt_install curl
+            echo ""
         else
-            step "deps" "using prebuilt llama.cpp (cmake not found)" "$C_WARN"
-            substep "Install cmake only if you want a source build: brew install cmake"
+            echo ""
+            step "deps" "missing: curl (or wget)" "$C_ERR"
+            substep "Unsloth needs one of them to download uv, Python and the prebuilt"
+            substep "inference engine. Install one, then re-run setup:"
+            substep "  Fedora/RHEL: sudo dnf install curl"
+            substep "  Arch:        sudo pacman -S --needed curl"
+            substep "  openSUSE:    sudo zypper install curl"
+            return 1
         fi
+    fi
+
+    if [ -n "$_optional_missing" ]; then
+        step "deps" "using prebuilt llama.cpp (missing: $_optional_missing)" "$C_WARN"
+        substep "Not required: Unsloth downloads a prebuilt inference engine."
+        substep "Install them only for a llama.cpp source build."
+    else
+        step "deps" "all system dependencies found"
+    fi
+    return 0
+}
+
+case "$OS" in
+    macos)
+        _check_macos_deps || exit 1
         ;;
     linux|wsl)
-        MISSING=""
-        command -v cmake >/dev/null 2>&1 || MISSING="$MISSING cmake"
-        command -v git   >/dev/null 2>&1 || MISSING="$MISSING git"
-        # curl or wget is needed for downloads; check both
-        if ! command -v curl >/dev/null 2>&1 && ! command -v wget >/dev/null 2>&1; then
-            MISSING="$MISSING curl"
-        fi
-        command -v gcc  >/dev/null 2>&1 || MISSING="$MISSING build-essential"
-        # libcurl dev headers for llama.cpp HTTPS support
-        command -v curl-config >/dev/null 2>&1 || MISSING="$MISSING libcurl4-openssl-dev"
-
-        MISSING=$(echo "$MISSING" | sed 's/^ *//')
-        if [ -n "$MISSING" ]; then
-            echo ""
-            step "deps" "missing: $MISSING" "$C_WARN"
-            substep "These are needed to build the GGUF inference engine."
-            if command -v apt-get >/dev/null 2>&1; then
-                _smart_apt_install $MISSING
-            else
-                echo "    Automatic system package installation is supported on apt-based"
-                echo "    Linux distributions (Ubuntu/Debian) only. Please install the"
-                echo "    missing dependencies with your package manager, then re-run setup:"
-                echo "    $MISSING"
-                echo ""
-                echo "    Examples:"
-                echo "      Fedora/RHEL: sudo dnf install cmake git gcc gcc-c++ make libcurl-devel"
-                echo "      Arch:       sudo pacman -S --needed cmake git base-devel curl"
-                echo "      openSUSE:   sudo zypper install cmake git gcc gcc-c++ make libcurl-devel"
-                exit 1
-            fi
-            echo ""
-        else
-            step "deps" "all system dependencies found"
-        fi
+        _check_linux_deps || exit 1
         ;;
 esac
 

--- a/studio/backend/requirements/extras-no-deps.txt
+++ b/studio/backend/requirements/extras-no-deps.txt
@@ -15,9 +15,8 @@ trl==0.23.1
 torch-c-dlpack-ext
 sentence_transformers==5.2.0
 transformers==4.57.6
-# No macOS x86_64 wheel at any version, so uv falls back to an sdist that shells out
-# to cmake. Skipping it on Intel Macs keeps that install compiler-free; every other
-# platform, arm64 macOS included, still gets it.
+# No macOS x86_64 wheel at any version, so uv falls back to an sdist that shells out to
+# cmake. Skipping it on Intel Macs keeps that install compiler-free.
 pytorch_tokenizers; sys_platform != "darwin" or platform_machine == "arm64"
 kernels==0.12.1
 # kernels<3.11 imports tomli as its tomllib fallback; --no-deps skips its own

--- a/studio/backend/requirements/extras-no-deps.txt
+++ b/studio/backend/requirements/extras-no-deps.txt
@@ -15,7 +15,10 @@ trl==0.23.1
 torch-c-dlpack-ext
 sentence_transformers==5.2.0
 transformers==4.57.6
-pytorch_tokenizers
+# No macOS x86_64 wheel at any version, so uv falls back to an sdist that shells
+# out to cmake. Every other platform has one. Skipping it on Intel Macs keeps the
+# consumer install compiler-free there; arm64 macOS still gets it.
+pytorch_tokenizers; sys_platform != "darwin" or platform_machine == "arm64"
 kernels==0.12.1
 # kernels<3.11 imports tomli as its tomllib fallback; --no-deps skips its own
 # marker dep, so list it here (no-op on the 3.12/3.13 default installs).

--- a/studio/backend/requirements/extras-no-deps.txt
+++ b/studio/backend/requirements/extras-no-deps.txt
@@ -15,9 +15,9 @@ trl==0.23.1
 torch-c-dlpack-ext
 sentence_transformers==5.2.0
 transformers==4.57.6
-# No macOS x86_64 wheel at any version, so uv falls back to an sdist that shells
-# out to cmake. Every other platform has one. Skipping it on Intel Macs keeps the
-# consumer install compiler-free there; arm64 macOS still gets it.
+# No macOS x86_64 wheel at any version, so uv falls back to an sdist that shells out
+# to cmake. Skipping it on Intel Macs keeps that install compiler-free; every other
+# platform, arm64 macOS included, still gets it.
 pytorch_tokenizers; sys_platform != "darwin" or platform_machine == "arm64"
 kernels==0.12.1
 # kernels<3.11 imports tomli as its tomllib fallback; --no-deps skips its own

--- a/studio/backend/requirements/single-env/constraints.txt
+++ b/studio/backend/requirements/single-env/constraints.txt
@@ -21,3 +21,16 @@ websockets>=15.0.1
 anyio<4.14.0
 
 pandas==2.3.3
+
+# Cap av (PyAV) below 16: 16+ ships no cp313 macOS arm64 wheel, so the resolver picks
+# 18.0.0 and then tries to BUILD it. PyAV is a C extension over FFmpeg, so that build
+# needs a compiler *and* FFmpeg headers -- which the Xcode Command Line Tools do not
+# provide either, meaning it fails on a stock Mac however many developer tools are
+# installed. 15.1.0 is the newest release with a prebuilt wheel for that target.
+#
+# This was the last package on the default macOS path that required a toolchain. The
+# other sdist-only packages there (openai-whisper, argbind, randomname, and
+# antlr4-python3-runtime pinned at 4.9.3) are pure Python and build with no compiler,
+# which is why they are allowlisted in .github/scripts/clean-machine-assert.sh instead
+# of being pinned here.
+av<16

--- a/studio/backend/requirements/single-env/constraints.txt
+++ b/studio/backend/requirements/single-env/constraints.txt
@@ -31,3 +31,9 @@ pandas==2.3.3
 # Last macOS-default package needing a toolchain: the other sdist-only ones there are
 # pure Python, hence allowlisted in .github/scripts/clean-machine-assert.sh instead.
 av<16
+
+# cryptography 49.0.0 dropped the macosx_10_9_universal2 wheel for arm64-only, so
+# x86_64 macOS has no wheel and builds the sdist, needing Rust plus a working
+# linker. 48.0.1 is the newest release with a universal2 wheel. Lift when
+# cryptography ships an x86_64-capable macOS wheel again.
+cryptography<49; sys_platform == "darwin" and platform_machine == "x86_64"

--- a/studio/backend/requirements/single-env/constraints.txt
+++ b/studio/backend/requirements/single-env/constraints.txt
@@ -22,10 +22,12 @@ anyio<4.14.0
 
 pandas==2.3.3
 
-# av (PyAV) 16+ ships no cp313 macOS arm64 wheel, so the resolver picks 18.0.0 and
-# tries to BUILD it. That needs a compiler *and* FFmpeg headers, and the Xcode CLT
-# supply no FFmpeg headers, so it fails on a Mac however equipped. 15.1.0 is the
-# newest release with a wheel for that target.
+# av (PyAV) 16+ builds its macOS arm64 wheels against macosx_14_0, so on macOS 13
+# none of them are installable and the resolver falls back to building from source.
+# That needs a compiler *and* FFmpeg headers, and the Xcode CLT supply no FFmpeg
+# headers, so it fails on such a Mac however equipped. 15.1.0 is the newest release
+# with a macosx_13_0 arm64 wheel. (16.0.0 does ship cp313; it is the deployment
+# target that rules it out, and 17+ moves to cp311-abi3 at macosx_14_0 as well.)
 #
 # This was the last macOS-default package needing a toolchain. The other sdist-only
 # ones there (openai-whisper, argbind, randomname, antlr4-python3-runtime==4.9.3) are

--- a/studio/backend/requirements/single-env/constraints.txt
+++ b/studio/backend/requirements/single-env/constraints.txt
@@ -22,14 +22,12 @@ anyio<4.14.0
 
 pandas==2.3.3
 
-# av (PyAV) 16+ builds its macOS arm64 wheels against macosx_14_0, so on macOS 13
-# none of them are installable and the resolver falls back to building from source.
-# That needs a compiler *and* FFmpeg headers, and the Xcode CLT supply no FFmpeg
-# headers, so it fails on such a Mac however equipped. 15.1.0 is the newest release
-# with a macosx_13_0 arm64 wheel. (16.0.0 does ship cp313; it is the deployment
-# target that rules it out, and 17+ moves to cp311-abi3 at macosx_14_0 as well.)
+# av (PyAV) 16+ builds its macOS arm64 wheels against macosx_14_0, so on macOS 13 none
+# are installable and the resolver falls back to a source build, which needs FFmpeg
+# headers the Xcode CLT do not supply and so fails however that Mac is equipped.
+# 15.1.0 is the newest release with a macosx_13_0 arm64 wheel; 17+ moves to cp311-abi3
+# at macosx_14_0 too.
 #
-# This was the last macOS-default package needing a toolchain. The other sdist-only
-# ones there (openai-whisper, argbind, randomname, antlr4-python3-runtime==4.9.3) are
+# Last macOS-default package needing a toolchain: the other sdist-only ones there are
 # pure Python, hence allowlisted in .github/scripts/clean-machine-assert.sh instead.
 av<16

--- a/studio/backend/requirements/single-env/constraints.txt
+++ b/studio/backend/requirements/single-env/constraints.txt
@@ -22,15 +22,12 @@ anyio<4.14.0
 
 pandas==2.3.3
 
-# Cap av (PyAV) below 16: 16+ ships no cp313 macOS arm64 wheel, so the resolver picks
-# 18.0.0 and then tries to BUILD it. PyAV is a C extension over FFmpeg, so that build
-# needs a compiler *and* FFmpeg headers -- which the Xcode Command Line Tools do not
-# provide either, meaning it fails on a stock Mac however many developer tools are
-# installed. 15.1.0 is the newest release with a prebuilt wheel for that target.
+# av (PyAV) 16+ ships no cp313 macOS arm64 wheel, so the resolver picks 18.0.0 and
+# tries to BUILD it. That needs a compiler *and* FFmpeg headers, and the Xcode CLT
+# supply no FFmpeg headers, so it fails on a Mac however equipped. 15.1.0 is the
+# newest release with a wheel for that target.
 #
-# This was the last package on the default macOS path that required a toolchain. The
-# other sdist-only packages there (openai-whisper, argbind, randomname, and
-# antlr4-python3-runtime pinned at 4.9.3) are pure Python and build with no compiler,
-# which is why they are allowlisted in .github/scripts/clean-machine-assert.sh instead
-# of being pinned here.
+# This was the last macOS-default package needing a toolchain. The other sdist-only
+# ones there (openai-whisper, argbind, randomname, antlr4-python3-runtime==4.9.3) are
+# pure Python, hence allowlisted in .github/scripts/clean-machine-assert.sh instead.
 av<16

--- a/studio/backend/requirements/single-env/constraints.txt
+++ b/studio/backend/requirements/single-env/constraints.txt
@@ -28,8 +28,9 @@ pandas==2.3.3
 # 15.1.0 is the newest release with a macosx_13_0 arm64 wheel; 17+ moves to cp311-abi3
 # at macosx_14_0 too.
 #
-# Last macOS-default package needing a toolchain: the other sdist-only ones there are
-# pure Python, hence allowlisted in .github/scripts/clean-machine-assert.sh instead.
+# The remaining sdist-only macOS defaults are pure Python, hence allowlisted in
+# .github/scripts/clean-machine-assert.sh instead; cryptography below is the one
+# other package that would compile.
 av<16
 
 # cryptography 49.0.0 dropped the macosx_10_9_universal2 wheel for arm64-only, so

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -3139,16 +3139,21 @@ def install_python_stack() -> int:
         )
 
     # 5. Triton kernels (no-deps, from source). Skip on Windows and macOS
-    #    (no support).
+    #    (no support), and on any machine without git: the requirement is a
+    #    git+https URL, so pip cannot fetch it. These are a training speedup, not
+    #    a boot requirement, so warn and continue rather than fail the install.
     if not IS_WINDOWS and not IS_MACOS:
-        _progress("triton kernels")
-        pip_install(
-            "Installing triton kernels",
-            "--no-deps",
-            "--no-cache-dir",
-            req = REQ_ROOT / "triton-kernels.txt",
-            constrain = False,
-        )
+        if shutil.which("git") is None:
+            _safe_print("   git not found -- skipping triton kernels (training speedup only)")
+        else:
+            _progress("triton kernels")
+            pip_install(
+                "Installing triton kernels",
+                "--no-deps",
+                "--no-cache-dir",
+                req = REQ_ROOT / "triton-kernels.txt",
+                constrain = False,
+            )
 
     if not IS_WINDOWS and not IS_MACOS and not NO_TORCH:
         _progress("flash-attn")

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -3169,6 +3169,7 @@ def install_python_stack() -> int:
     #    a boot requirement, so warn and continue rather than fail the install.
     if not IS_WINDOWS and not IS_MACOS:
         if not _has_working_git():
+            _progress("triton kernels (skipped, no git)")
             _safe_print("   no working git -- skipping triton kernels (training speedup only)")
         else:
             _progress("triton kernels")

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -2850,10 +2850,15 @@ def _has_working_git() -> bool:
     if exe is None:
         return False
     try:
-        return subprocess.run(
-            [exe, "--version"], stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL,
-            timeout = 30,
-        ).returncode == 0
+        return (
+            subprocess.run(
+                [exe, "--version"],
+                stdout = subprocess.DEVNULL,
+                stderr = subprocess.DEVNULL,
+                timeout = 30,
+            ).returncode
+            == 0
+        )
     except (OSError, subprocess.SubprocessError):
         return False
 

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -3163,10 +3163,9 @@ def install_python_stack() -> int:
             _torchao_spec,
         )
 
-    # 5. Triton kernels (no-deps, from source). Skip on Windows and macOS
-    #    (no support), and on any machine without git: the requirement is a
-    #    git+https URL, so pip cannot fetch it. These are a training speedup, not
-    #    a boot requirement, so warn and continue rather than fail the install.
+    # 5. Triton kernels (no-deps, from source). Skipped on Windows/macOS (no support)
+    #    and without git, since the requirement is a git+https URL. A training speedup
+    #    only, so warn and continue rather than fail the install.
     if not IS_WINDOWS and not IS_MACOS:
         if not _has_working_git():
             _progress("triton kernels (skipped, no git)")

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -2838,6 +2838,26 @@ def patch_package_file(package_name: str, relative_path: str, url: str) -> None:
 # -- Main install sequence ---------------------------------------------
 
 
+def _has_working_git() -> bool:
+    """Match install.sh's _has_working_git: on PATH *and* actually runnable.
+
+    A git that is present but broken (a bare xcrun shim, a masked toolchain) is
+    what install.sh already classifies as missing. Testing only shutil.which
+    disagreed with it, so the installer promised to skip the git+https triton
+    requirement and then tried to fetch it anyway.
+    """
+    exe = shutil.which("git")
+    if exe is None:
+        return False
+    try:
+        return subprocess.run(
+            [exe, "--version"], stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL,
+            timeout = 30,
+        ).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
 def install_python_stack() -> int:
     global USE_UV, _STEP, _TOTAL
     _STEP = 0
@@ -3143,8 +3163,8 @@ def install_python_stack() -> int:
     #    git+https URL, so pip cannot fetch it. These are a training speedup, not
     #    a boot requirement, so warn and continue rather than fail the install.
     if not IS_WINDOWS and not IS_MACOS:
-        if shutil.which("git") is None:
-            _safe_print("   git not found -- skipping triton kernels (training speedup only)")
+        if not _has_working_git():
+            _safe_print("   no working git -- skipping triton kernels (training speedup only)")
         else:
             _progress("triton kernels")
             pip_install(

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -2841,9 +2841,8 @@ def patch_package_file(package_name: str, relative_path: str, url: str) -> None:
 def _has_working_git() -> bool:
     """Match install.sh's _has_working_git: on PATH *and* actually runnable.
 
-    A git that is present but broken (a bare xcrun shim, a masked toolchain) is
-    what install.sh already classifies as missing. Testing only shutil.which
-    disagreed with it, so the installer promised to skip the git+https triton
+    A present-but-broken git (a bare xcrun shim) counts as missing there too. Testing
+    only shutil.which disagreed, so the installer promised to skip the git+https triton
     requirement and then tried to fetch it anyway.
     """
     exe = shutil.which("git")
@@ -3164,8 +3163,8 @@ def install_python_stack() -> int:
         )
 
     # 5. Triton kernels (no-deps, from source). Skipped on Windows/macOS (no support)
-    #    and without git, since the requirement is a git+https URL. A training speedup
-    #    only, so warn and continue rather than fail the install.
+    #    and without git (the requirement is a git+https URL); a training speedup
+    #    only, so warn rather than fail the install.
     if not IS_WINDOWS and not IS_MACOS:
         if not _has_working_git():
             _progress("triton kernels (skipped, no git)")

--- a/tests/sh/test_linux_deps_gate.sh
+++ b/tests/sh/test_linux_deps_gate.sh
@@ -4,17 +4,14 @@
 #
 # Guards the Linux/WSL system-dependency gate in install.sh.
 #
-# History: the gate hard-required cmake, git, gcc and libcurl4-openssl-dev "to build
-# the GGUF inference engine", auto-installing them on apt distros and `exit 1`-ing
-# everywhere else with a Fedora/Arch/openSUSE instruction. Nothing on the consumer
-# path builds anything: unslothai/llama.cpp publishes linux-x64 and linux-arm64
-# prebuilts covering cpu, cuda12, cuda13, rocm and vulkan. So the gate stranded every
-# non-apt distro over tooling that was never used -- the same defect the macOS Xcode
-# CLT gate had.
+# History: the gate hard-required cmake, git, gcc and libcurl4-openssl-dev, installing
+# them on apt distros and `exit 1`-ing everywhere else. Nothing on the consumer path
+# builds anything (unslothai/llama.cpp publishes linux-x64/arm64 prebuilts for cpu,
+# cuda12, cuda13, rocm and vulkan), so it stranded every non-apt distro over unused
+# tooling, the same defect the macOS Xcode CLT gate had.
 #
-# The contract now: only a download transport (curl or wget) is fatal. Build tooling
-# is a warning. git is required for --local only, because that mode installs
-# unsloth-zoo from a git+https URL.
+# The contract now: only a download transport (curl or wget) is fatal, build tooling
+# is a warning, and git is required for --local only (unsloth-zoo git+https URL).
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -62,8 +59,8 @@ C_WARN=''; C_ERR=''; C_OK=''; C_DIM=''; C_RST=''
 step()    { echo "STEP $1 $2"; }
 substep() { echo "SUBSTEP $1"; }
 tauri_log() { echo "[TAURI:$1] $2"; }
-# Stand-in for the real apt path. Records that it was reached and with what, so a
-# test can tell "asked apt for curl" from "asked apt for the whole build toolchain".
+# Stand-in for the real apt path, recording what it was called with so a test can
+# tell "asked apt for curl" from "asked apt for the whole build toolchain".
 _smart_apt_install() { echo "APT_CALLED: $*"; }
 HARNESS
 
@@ -71,8 +68,7 @@ _BIN=$(mktemp -d)
 _mk() { printf '#!/bin/sh\n%s\n' "$2" > "$_BIN/$1"; chmod +x "$_BIN/$1"; }
 
 # PATH is the sandbox and ONLY the sandbox, so an unstocked tool is genuinely absent
-# and the host's /usr/bin/cmake cannot turn an "absent" case into a "present" one.
-# bash therefore has to be invoked by absolute path.
+# and the host's /usr/bin/cmake cannot leak in. bash must then be invoked absolutely.
 _SH="${BASH:-/bin/bash}"
 
 _run_gate() {
@@ -82,8 +78,7 @@ _run_gate() {
 }
 
 echo "=== Fedora/Arch/openSUSE shape: curl present, no build tooling, no apt ==="
-# This is the case that used to exit 1 with "Automatic system package installation is
-# supported on apt-based Linux distributions only".
+# Used to exit 1 with "supported on apt-based Linux distributions only".
 rm -f "$_BIN"/*
 _mk curl 'exit 0'
 _out="$(_run_gate false)"
@@ -116,8 +111,8 @@ _out="$(_run_gate false)"
 assert_contains "install proceeds"                       "$_out" "RC=0"
 assert_contains "asks apt for curl"                      "$_out" "APT_CALLED: curl"
 assert_not_contains "does not ask apt for cmake"         "$_out" "APT_CALLED: curl cmake"
-# Only the transport goes to apt. The build tooling is still reported as missing in
-# the warning line, so match the apt call itself rather than the package names.
+# Only the transport goes to apt. Build tooling still appears in the warning line, so
+# match the apt call itself rather than the package names.
 assert_contains    "apt asked for exactly curl"          "$_out" "APT_CALLED: curl
 "
 assert_contains    "build tooling only warned about"     "$_out" "using prebuilt llama.cpp"

--- a/tests/sh/test_linux_deps_gate.sh
+++ b/tests/sh/test_linux_deps_gate.sh
@@ -130,6 +130,25 @@ assert_contains "install proceeds"                       "$_out" "RC=0"
 assert_contains "reports everything found"               "$_out" "all system dependencies found"
 assert_not_contains "no prebuilt fallback warning"       "$_out" "using prebuilt llama.cpp"
 
+echo "=== apt present: git is auto-installed, because triton_kernels needs it ==="
+# Regression: making git optional without this left ubuntu root/arm-root failing at
+# "6/14 triton kernels", whose requirement is a git+https URL.
+rm -f "$_BIN"/*
+_mk curl 'exit 0'
+_mk apt-get 'exit 0'
+_out="$(_run_gate false)"
+assert_contains "install proceeds"                       "$_out" "RC=0"
+assert_contains "apt is asked for git"                   "$_out" "git"
+assert_contains "apt is actually called"                 "$_out" "APT_CALLED"
+
+echo "=== no apt and no git: warn about the triton skip, do not fail ==="
+rm -f "$_BIN"/*
+_mk curl 'exit 0'
+_out="$(_run_gate false)"
+assert_contains "install proceeds"                       "$_out" "RC=0"
+assert_contains "names the consequence of no git"        "$_out" "triton kernels"
+assert_not_contains "does not call it required to run"   "$_out" "is required"
+
 echo "=== --local without git: must fail loudly (matches macOS) ==="
 rm -f "$_BIN"/*
 _mk curl 'exit 0'

--- a/tests/sh/test_linux_deps_gate.sh
+++ b/tests/sh/test_linux_deps_gate.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+#
+# Guards the Linux/WSL system-dependency gate in install.sh.
+#
+# History: the gate hard-required cmake, git, gcc and libcurl4-openssl-dev "to build
+# the GGUF inference engine", auto-installing them on apt distros and `exit 1`-ing
+# everywhere else with a Fedora/Arch/openSUSE instruction. Nothing on the consumer
+# path builds anything: unslothai/llama.cpp publishes linux-x64 and linux-arm64
+# prebuilts covering cpu, cuda12, cuda13, rocm and vulkan. So the gate stranded every
+# non-apt distro over tooling that was never used -- the same defect the macOS Xcode
+# CLT gate had.
+#
+# The contract now: only a download transport (curl or wget) is fatal. Build tooling
+# is a warning. git is required for --local only, because that mode installs
+# unsloth-zoo from a git+https URL.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALL_SH="$SCRIPT_DIR/../../install.sh"
+PASS=0
+FAIL=0
+
+assert_contains() {
+    _label="$1"; _haystack="$2"; _needle="$3"
+    if echo "$_haystack" | grep -qF "$_needle"; then
+        echo "  PASS: $_label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $_label (expected to find '$_needle')"
+        echo "  ---- output ----"; echo "$_haystack" | sed 's/^/  | /'
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    _label="$1"; _haystack="$2"; _needle="$3"
+    if echo "$_haystack" | grep -qF "$_needle"; then
+        echo "  FAIL: $_label (found '$_needle' but should not)"
+        FAIL=$((FAIL + 1))
+    else
+        echo "  PASS: $_label"
+        PASS=$((PASS + 1))
+    fi
+}
+
+# ── Extract the functions under test ──
+_FN_FILE=$(mktemp)
+sed -n '/^_has_working_git()/,/^}/p'   "$INSTALL_SH" >  "$_FN_FILE"
+sed -n '/^_check_linux_deps()/,/^}/p'  "$INSTALL_SH" >> "$_FN_FILE"
+
+if ! grep -q '_check_linux_deps()' "$_FN_FILE"; then
+    echo "FAIL: could not extract _check_linux_deps from install.sh"
+    echo "      (the gate must stay a top-level function so this test can reach it)"
+    exit 1
+fi
+
+_HARNESS=$(mktemp)
+cat > "$_HARNESS" <<'HARNESS'
+C_WARN=''; C_ERR=''; C_OK=''; C_DIM=''; C_RST=''
+step()    { echo "STEP $1 $2"; }
+substep() { echo "SUBSTEP $1"; }
+tauri_log() { echo "[TAURI:$1] $2"; }
+# Stand-in for the real apt path. Records that it was reached and with what, so a
+# test can tell "asked apt for curl" from "asked apt for the whole build toolchain".
+_smart_apt_install() { echo "APT_CALLED: $*"; }
+HARNESS
+
+_BIN=$(mktemp -d)
+_mk() { printf '#!/bin/sh\n%s\n' "$2" > "$_BIN/$1"; chmod +x "$_BIN/$1"; }
+
+# PATH is the sandbox and ONLY the sandbox, so an unstocked tool is genuinely absent
+# and the host's /usr/bin/cmake cannot turn an "absent" case into a "present" one.
+# bash therefore has to be invoked by absolute path.
+_SH="${BASH:-/bin/bash}"
+
+_run_gate() {
+    # $1 = STUDIO_LOCAL_INSTALL
+    ( PATH="$_BIN"; export PATH
+      "$_SH" -c ". '$_HARNESS'; . '$_FN_FILE'; STUDIO_LOCAL_INSTALL=$1; _check_linux_deps; echo \"RC=\$?\"" 2>&1 )
+}
+
+echo "=== Fedora/Arch/openSUSE shape: curl present, no build tooling, no apt ==="
+# This is the case that used to exit 1 with "Automatic system package installation is
+# supported on apt-based Linux distributions only".
+rm -f "$_BIN"/*
+_mk curl 'exit 0'
+_out="$(_run_gate false)"
+assert_contains "install proceeds"                       "$_out" "RC=0"
+assert_contains "says the prebuilt is used"              "$_out" "using prebuilt llama.cpp"
+assert_contains "names what is missing"                  "$_out" "cmake"
+assert_contains "says it is not required"                "$_out" "Not required"
+assert_not_contains "does not demand a package manager"  "$_out" "apt-based"
+assert_not_contains "does not reach apt for build tools" "$_out" "APT_CALLED"
+
+echo "=== wget instead of curl is an acceptable transport ==="
+rm -f "$_BIN"/*
+_mk wget 'exit 0'
+_out="$(_run_gate false)"
+assert_contains "install proceeds"                       "$_out" "RC=0"
+assert_not_contains "does not ask apt for curl"          "$_out" "APT_CALLED"
+
+echo "=== no transport at all, no apt: the one genuinely fatal case ==="
+rm -f "$_BIN"/*
+_out="$(_run_gate false)"
+assert_contains "fails"                                  "$_out" "RC=1"
+assert_contains "names the missing transport"            "$_out" "curl"
+assert_contains "explains what it is needed for"         "$_out" "download"
+assert_contains "gives a non-apt remedy"                 "$_out" "dnf install curl"
+
+echo "=== no transport, apt available: auto-install curl and ONLY curl ==="
+rm -f "$_BIN"/*
+_mk apt-get 'exit 0'
+_out="$(_run_gate false)"
+assert_contains "install proceeds"                       "$_out" "RC=0"
+assert_contains "asks apt for curl"                      "$_out" "APT_CALLED: curl"
+assert_not_contains "does not ask apt for cmake"         "$_out" "APT_CALLED: curl cmake"
+# Only the transport goes to apt. The build tooling is still reported as missing in
+# the warning line, so match the apt call itself rather than the package names.
+assert_contains    "apt asked for exactly curl"          "$_out" "APT_CALLED: curl
+"
+assert_contains    "build tooling only warned about"     "$_out" "using prebuilt llama.cpp"
+
+echo "=== fully equipped machine: no warnings ==="
+rm -f "$_BIN"/*
+for t in curl cmake gcc curl-config git; do _mk "$t" 'exit 0'; done
+_out="$(_run_gate false)"
+assert_contains "install proceeds"                       "$_out" "RC=0"
+assert_contains "reports everything found"               "$_out" "all system dependencies found"
+assert_not_contains "no prebuilt fallback warning"       "$_out" "using prebuilt llama.cpp"
+
+echo "=== --local without git: must fail loudly (matches macOS) ==="
+rm -f "$_BIN"/*
+_mk curl 'exit 0'
+_out="$(_run_gate true)"
+assert_contains "fails"                                  "$_out" "RC=1"
+assert_contains "explains why git is needed"             "$_out" "unsloth-zoo"
+assert_contains "says a normal install needs none"       "$_out" "non---local"
+
+echo "=== --local with a git that exists but does not work ==="
+# Mirrors the macOS CLT-stub shape: `command -v git` succeeds, running it fails.
+rm -f "$_BIN"/*
+_mk curl 'exit 0'
+_mk git 'echo "broken" >&2; exit 1'
+_out="$(_run_gate true)"
+assert_contains "still fails"                            "$_out" "RC=1"
+
+echo "=== --local with a working git proceeds ==="
+rm -f "$_BIN"/*
+_mk curl 'exit 0'
+_mk git 'exit 0'
+_out="$(_run_gate true)"
+assert_contains "install proceeds"                       "$_out" "RC=0"
+
+rm -rf "$_BIN" "$_FN_FILE" "$_HARNESS"
+echo ""
+echo "=== $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/tests/sh/test_linux_deps_gate.sh
+++ b/tests/sh/test_linux_deps_gate.sh
@@ -6,9 +6,7 @@
 #
 # History: the gate hard-required cmake, git, gcc and libcurl4-openssl-dev, installing
 # them on apt distros and `exit 1`-ing everywhere else. Nothing on the consumer path
-# builds anything (unslothai/llama.cpp publishes linux-x64/arm64 prebuilts for cpu,
-# cuda12, cuda13, rocm and vulkan), so it stranded every non-apt distro over unused
-# tooling, the same defect the macOS Xcode CLT gate had.
+# builds anything, so it stranded every non-apt distro over unused tooling.
 #
 # The contract now: only a download transport (curl or wget) is fatal, build tooling
 # is a warning, and git is required for --local only (unsloth-zoo git+https URL).
@@ -59,16 +57,15 @@ C_WARN=''; C_ERR=''; C_OK=''; C_DIM=''; C_RST=''
 step()    { echo "STEP $1 $2"; }
 substep() { echo "SUBSTEP $1"; }
 tauri_log() { echo "[TAURI:$1] $2"; }
-# Stand-in for the real apt path, recording what it was called with so a test can
-# tell "asked apt for curl" from "asked apt for the whole build toolchain".
+# Records its args so a test can tell "asked apt for curl" from "asked for everything".
 _smart_apt_install() { echo "APT_CALLED: $*"; }
 HARNESS
 
 _BIN=$(mktemp -d)
 _mk() { printf '#!/bin/sh\n%s\n' "$2" > "$_BIN/$1"; chmod +x "$_BIN/$1"; }
 
-# PATH is the sandbox and ONLY the sandbox, so an unstocked tool is genuinely absent
-# and the host's /usr/bin/cmake cannot leak in. bash must then be invoked absolutely.
+# PATH is the sandbox and ONLY the sandbox, so unstocked tools are genuinely absent and
+# the host's /usr/bin/cmake cannot leak in. bash must therefore be invoked absolutely.
 _SH="${BASH:-/bin/bash}"
 
 _run_gate() {
@@ -111,8 +108,7 @@ _out="$(_run_gate false)"
 assert_contains "install proceeds"                       "$_out" "RC=0"
 assert_contains "asks apt for curl"                      "$_out" "APT_CALLED: curl"
 assert_not_contains "does not ask apt for cmake"         "$_out" "APT_CALLED: curl cmake"
-# Only the transport goes to apt. Build tooling still appears in the warning line, so
-# match the apt call itself rather than the package names.
+# Build tooling still appears in the warning line, so match the apt call, not names.
 assert_contains    "apt asked for exactly curl"          "$_out" "APT_CALLED: curl
 "
 assert_contains    "build tooling only warned about"     "$_out" "using prebuilt llama.cpp"
@@ -126,8 +122,8 @@ assert_contains "reports everything found"               "$_out" "all system dep
 assert_not_contains "no prebuilt fallback warning"       "$_out" "using prebuilt llama.cpp"
 
 echo "=== apt present: git is auto-installed, because triton_kernels needs it ==="
-# Regression: making git optional without this left ubuntu root/arm-root failing at
-# "6/14 triton kernels", whose requirement is a git+https URL.
+# Regression: making git optional without this failed at "6/14 triton kernels", whose
+# requirement is a git+https URL.
 rm -f "$_BIN"/*
 _mk curl 'exit 0'
 _mk apt-get 'exit 0'

--- a/tests/sh/test_linux_deps_gate.sh
+++ b/tests/sh/test_linux_deps_gate.sh
@@ -163,6 +163,47 @@ _mk git 'exit 0'
 _out="$(_run_gate true)"
 assert_contains "install proceeds"                       "$_out" "RC=0"
 
+echo "=== optional apt packages never ask for elevation, in any mode ==="
+# Regression: the optional bypass sat inside the TAURI_MODE branch, so a plain
+# `curl | sh` on a non-root Debian box still hit the sudo prompt (default yes) and
+# installed cmake, GCC and dev headers that nothing on the consumer path uses.
+_APT_FN=$(mktemp)
+{
+    sed -n '/^_is_pkg_installed()/,/^}$/p'       "$INSTALL_SH"
+    sed -n '/^_apt_distro_description()/,/^}$/p' "$INSTALL_SH"
+    sed -n '/^_can_read_tty()/,/^}$/p'           "$INSTALL_SH"
+    sed -n '/^_smart_apt_install()/,/^}$/p'      "$INSTALL_SH"
+} > "$_APT_FN"
+
+_run_apt() {
+    # $1 = TAURI_MODE, $2 = _SMART_APT_OPTIONAL. apt-get always fails, as it does
+    # for a non-root user, so the function reaches its escalation decision.
+    rm -f "$_BIN"/*
+    _mk apt-get 'exit 100'
+    _mk sudo 'echo "ELEVATION_ATTEMPTED: $*"; exit 1'
+    ln -sf "$(command -v sed)" "$_BIN/sed"   # the function trims its list with sed
+    # _APT_FN after _HARNESS so the real function replaces the recording stub.
+    ( PATH="$_BIN"; export PATH
+      "$_SH" -c ". '$_HARNESS'; . '$_APT_FN'; TAURI_MODE=$1; _SMART_APT_OPTIONAL=$2
+                ( _smart_apt_install unsloth_absent_pkg ); echo \"RC=\$?\"" 2>&1 )
+}
+
+_out="$(_run_apt false true)"
+assert_contains "optional: returns 2 so the caller can continue" "$_out" "RC=2"
+assert_not_contains "optional: no sudo prompt"                   "$_out" "elevated permissions"
+assert_not_contains "optional: sudo never invoked"               "$_out" "ELEVATION_ATTEMPTED"
+
+_out="$(_run_apt true true)"
+assert_contains "optional in Tauri: returns 2"                   "$_out" "RC=2"
+assert_not_contains "optional in Tauri: no NEED_SUDO dialog"     "$_out" "NEED_SUDO"
+
+_out="$(_run_apt false false)"
+assert_contains "required: still escalates"                      "$_out" "ELEVATION_ATTEMPTED"
+
+_out="$(_run_apt true false)"
+assert_contains "required in Tauri: still asks Rust to elevate"  "$_out" "NEED_SUDO"
+
+rm -f "$_APT_FN"
 rm -rf "$_BIN" "$_FN_FILE" "$_HARNESS"
 echo ""
 echo "=== $PASS passed, $FAIL failed ==="

--- a/tests/sh/test_macos_clt_gate.sh
+++ b/tests/sh/test_macos_clt_gate.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+#
+# Guards the macOS system-dependency gate in install.sh.
+#
+# History: the gate used to be inline top-level code that ran
+#   xcode-select -p || { xcode-select --install; exit 1; }
+# so a brand-new Mac could not install at all -- and because it was inline rather
+# than a function, the tests/sh convention of sed-extracting a function could not
+# reach it, which is why it shipped broken and stayed broken.
+#
+# The contract now: a consumer install must SUCCEED with no Xcode Command Line
+# Tools (uv is a prebuilt binary, CPython is uv-managed, llama.cpp/whisper.cpp/Node
+# are prebuilt downloads, triton is skipped on macOS), while `--local` must still
+# fail loudly because it installs unsloth-zoo from a git+https URL.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALL_SH="$SCRIPT_DIR/../../install.sh"
+PASS=0
+FAIL=0
+
+assert_eq() {
+    _label="$1"; _expected="$2"; _actual="$3"
+    if [ "$_actual" = "$_expected" ]; then
+        echo "  PASS: $_label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $_label (expected '$_expected', got '$_actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    _label="$1"; _haystack="$2"; _needle="$3"
+    if echo "$_haystack" | grep -qF "$_needle"; then
+        echo "  PASS: $_label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $_label (expected to find '$_needle')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    _label="$1"; _haystack="$2"; _needle="$3"
+    if echo "$_haystack" | grep -qF "$_needle"; then
+        echo "  FAIL: $_label (found '$_needle' but should not)"
+        FAIL=$((FAIL + 1))
+    else
+        echo "  PASS: $_label"
+        PASS=$((PASS + 1))
+    fi
+}
+
+# ── Extract the functions under test ──
+_FN_FILE=$(mktemp)
+sed -n '/^_has_working_git()/,/^}/p'   "$INSTALL_SH" >  "$_FN_FILE"
+sed -n '/^_check_macos_deps()/,/^}/p'  "$INSTALL_SH" >> "$_FN_FILE"
+
+if ! grep -q '_check_macos_deps()' "$_FN_FILE"; then
+    echo "FAIL: could not extract _check_macos_deps from install.sh"
+    echo "      (the gate must stay a top-level function so this test can reach it)"
+    exit 1
+fi
+
+# Minimal harness: the output helpers install.sh would otherwise provide, plus a
+# PATH sandbox we can stock with fake tools.
+_HARNESS=$(mktemp)
+cat > "$_HARNESS" <<'HARNESS'
+C_WARN=''; C_ERR=''; C_OK=''; C_DIM=''; C_RST=''
+step()    { echo "STEP $1 $2"; }
+substep() { echo "SUBSTEP $1"; }
+tauri_log() { echo "[TAURI:$1] $2"; }
+HARNESS
+
+_BIN=$(mktemp -d)
+
+# Stock the sandbox PATH. Each tool is either absent, a working stub, or a broken
+# stub that mimics the Xcode CLT shim (exists, exits non-zero).
+_mk() { printf '#!/bin/sh\n%s\n' "$2" > "$_BIN/$1"; chmod +x "$_BIN/$1"; }
+
+# PATH is the sandbox and ONLY the sandbox, so a tool we did not stock is genuinely
+# absent (the host's /usr/bin/git must not leak in and turn an "absent" case into a
+# "present" one). That means bash itself has to be invoked by absolute path.
+_SH="${BASH:-/bin/bash}"
+
+_run_gate() {
+    # $1 = STUDIO_LOCAL_INSTALL
+    ( PATH="$_BIN"; export PATH
+      "$_SH" -c ". '$_HARNESS'; . '$_FN_FILE'; STUDIO_LOCAL_INSTALL=$1; _check_macos_deps; echo \"RC=\$?\"" 2>&1 )
+}
+
+echo "=== clean Mac: no CLT at all (xcode-select missing) ==="
+rm -f "$_BIN"/*
+_out="$(_run_gate false)"
+assert_contains "does not exit 1"                    "$_out" "RC=0"
+assert_contains "says CLT are not required"          "$_out" "not required"
+assert_not_contains "never claims CLT are required"  "$_out" "are required"
+
+echo "=== clean Mac: CLT stubs present but non-functional (the real virgin-Mac shape) ==="
+# On a Mac with no CLT, /usr/bin/git and /usr/bin/cc EXIST and fail when run, and
+# xcode-select -p exits non-zero. `command -v git` therefore succeeds -- the gate
+# must not be fooled by that.
+rm -f "$_BIN"/*
+_mk xcode-select 'exit 1'
+_mk git 'echo "xcrun: error: invalid active developer path" >&2; exit 1'
+_out="$(_run_gate false)"
+assert_contains "consumer install proceeds"          "$_out" "RC=0"
+assert_contains "reports CLT absent but optional"    "$_out" "not required"
+
+echo "=== --local with a non-functional git: must fail loudly ==="
+_out="$(_run_gate true)"
+assert_contains "fails"                              "$_out" "RC=1"
+assert_contains "explains why git is needed"         "$_out" "unsloth-zoo"
+assert_contains "names the remedy"                   "$_out" "xcode-select --install"
+assert_contains "emits a machine-readable marker"    "$_out" "[TAURI:NEED_XCODE_CLT]"
+assert_contains "says a normal install needs none"   "$_out" "non---local"
+
+echo "=== --local with a working git: proceeds ==="
+rm -f "$_BIN"/*
+_mk xcode-select 'exit 1'
+_mk git 'echo "git version 2.50.0"; exit 0'
+_out="$(_run_gate true)"
+assert_contains "--local proceeds when git works"    "$_out" "RC=0"
+
+echo "=== CLT installed + cmake present ==="
+rm -f "$_BIN"/*
+_mk xcode-select 'echo /Library/Developer/CommandLineTools; exit 0'
+_mk git 'echo "git version 2.50.0"; exit 0'
+_mk cmake 'echo "cmake version 3.30.0"; exit 0'
+_out="$(_run_gate false)"
+assert_contains "all deps found"                     "$_out" "all system dependencies found"
+assert_contains "rc 0"                               "$_out" "RC=0"
+
+echo "=== CLT installed, cmake missing: prebuilt path, not fatal ==="
+rm -f "$_BIN"/*
+_mk xcode-select 'echo /Library/Developer/CommandLineTools; exit 0'
+_mk git 'echo "git version 2.50.0"; exit 0'
+_out="$(_run_gate false)"
+assert_contains "uses prebuilt llama.cpp"            "$_out" "using prebuilt llama.cpp"
+assert_contains "rc 0"                               "$_out" "RC=0"
+
+echo "=== the gate never fires the GUI installer on the consumer path ==="
+# Firing `xcode-select --install` and exiting is what stranded users: the dialog
+# needs a GUI session that a curl-piped or Tauri-spawned install does not have.
+rm -f "$_BIN"/*
+_mk xcode-select 'if [ "$1" = "--install" ]; then echo "GUI-DIALOG-FIRED"; fi; exit 1'
+_out="$(_run_gate false)"
+assert_not_contains "no GUI dialog on consumer path" "$_out" "GUI-DIALOG-FIRED"
+
+echo "=== _has_working_git distinguishes present-but-broken from working ==="
+rm -f "$_BIN"/*
+_mk git 'exit 1'
+_r="$(PATH="$_BIN" "$_SH" -c ". '$_FN_FILE'; _has_working_git && echo yes || echo no")"
+assert_eq "broken git stub -> no" "no" "$_r"
+_mk git 'echo ok; exit 0'
+_r="$(PATH="$_BIN" "$_SH" -c ". '$_FN_FILE'; _has_working_git && echo yes || echo no")"
+assert_eq "working git -> yes" "yes" "$_r"
+rm -f "$_BIN"/git
+_r="$(PATH="$_BIN" "$_SH" -c ". '$_FN_FILE'; _has_working_git && echo yes || echo no")"
+assert_eq "absent git -> no" "no" "$_r"
+
+rm -rf "$_BIN" "$_FN_FILE" "$_HARNESS"
+
+echo ""
+echo "=== $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/sh/test_macos_clt_gate.sh
+++ b/tests/sh/test_macos_clt_gate.sh
@@ -4,16 +4,16 @@
 #
 # Guards the macOS system-dependency gate in install.sh.
 #
-# History: the gate used to be inline top-level code that ran
+# History: the gate was inline top-level code running
 #   xcode-select -p || { xcode-select --install; exit 1; }
-# so a brand-new Mac could not install at all -- and because it was inline rather
-# than a function, the tests/sh convention of sed-extracting a function could not
-# reach it, which is why it shipped broken and stayed broken.
+# so a brand-new Mac could not install at all, and being inline rather than a function
+# it was out of reach of the tests/sh sed-extraction convention, which is why it
+# shipped broken and stayed broken.
 #
-# The contract now: a consumer install must SUCCEED with no Xcode Command Line
-# Tools (uv is a prebuilt binary, CPython is uv-managed, llama.cpp/whisper.cpp/Node
-# are prebuilt downloads, triton is skipped on macOS), while `--local` must still
-# fail loudly because it installs unsloth-zoo from a git+https URL.
+# The contract now: a consumer install must SUCCEED with no Xcode Command Line Tools
+# (uv is a prebuilt binary, CPython is uv-managed, llama.cpp/whisper.cpp/Node are
+# prebuilt downloads, triton is skipped on macOS), while `--local` must still fail
+# loudly because it installs unsloth-zoo from a git+https URL.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -65,8 +65,7 @@ if ! grep -q '_check_macos_deps()' "$_FN_FILE"; then
     exit 1
 fi
 
-# Minimal harness: the output helpers install.sh would otherwise provide, plus a
-# PATH sandbox we can stock with fake tools.
+# Minimal harness: the output helpers install.sh would otherwise provide.
 _HARNESS=$(mktemp)
 cat > "$_HARNESS" <<'HARNESS'
 C_WARN=''; C_ERR=''; C_OK=''; C_DIM=''; C_RST=''
@@ -77,13 +76,12 @@ HARNESS
 
 _BIN=$(mktemp -d)
 
-# Stock the sandbox PATH. Each tool is either absent, a working stub, or a broken
-# stub that mimics the Xcode CLT shim (exists, exits non-zero).
+# Stock the sandbox PATH: each tool is absent, a working stub, or a broken stub
+# mimicking the Xcode CLT shim (exists, exits non-zero).
 _mk() { printf '#!/bin/sh\n%s\n' "$2" > "$_BIN/$1"; chmod +x "$_BIN/$1"; }
 
-# PATH is the sandbox and ONLY the sandbox, so a tool we did not stock is genuinely
-# absent (the host's /usr/bin/git must not leak in and turn an "absent" case into a
-# "present" one). That means bash itself has to be invoked by absolute path.
+# PATH is the sandbox and ONLY the sandbox, so an unstocked tool is genuinely absent
+# and the host's /usr/bin/git cannot leak in. bash must then be invoked absolutely.
 _SH="${BASH:-/bin/bash}"
 
 _run_gate() {
@@ -100,9 +98,8 @@ assert_contains "says CLT are not required"          "$_out" "not required"
 assert_not_contains "never claims CLT are required"  "$_out" "are required"
 
 echo "=== clean Mac: CLT stubs present but non-functional (the real virgin-Mac shape) ==="
-# On a Mac with no CLT, /usr/bin/git and /usr/bin/cc EXIST and fail when run, and
-# xcode-select -p exits non-zero. `command -v git` therefore succeeds -- the gate
-# must not be fooled by that.
+# With no CLT, /usr/bin/git and /usr/bin/cc EXIST and fail when run, so `command -v
+# git` succeeds. The gate must not be fooled by that.
 rm -f "$_BIN"/*
 _mk xcode-select 'exit 1'
 _mk git 'echo "xcrun: error: invalid active developer path" >&2; exit 1'
@@ -143,8 +140,8 @@ assert_contains "uses prebuilt llama.cpp"            "$_out" "using prebuilt lla
 assert_contains "rc 0"                               "$_out" "RC=0"
 
 echo "=== the gate never fires the GUI installer on the consumer path ==="
-# Firing `xcode-select --install` and exiting is what stranded users: the dialog
-# needs a GUI session that a curl-piped or Tauri-spawned install does not have.
+# Firing `xcode-select --install` and exiting is what stranded users: the dialog needs
+# a GUI session that a curl-piped or Tauri-spawned install does not have.
 rm -f "$_BIN"/*
 _mk xcode-select 'if [ "$1" = "--install" ]; then echo "GUI-DIALOG-FIRED"; fi; exit 1'
 _out="$(_run_gate false)"

--- a/tests/sh/test_macos_clt_gate.sh
+++ b/tests/sh/test_macos_clt_gate.sh
@@ -7,13 +7,13 @@
 # History: the gate was inline top-level code running
 #   xcode-select -p || { xcode-select --install; exit 1; }
 # so a brand-new Mac could not install at all, and being inline rather than a function
-# it was out of reach of the tests/sh sed-extraction convention, which is why it
-# shipped broken and stayed broken.
+# it was out of reach of the tests/sh sed-extraction convention that would have caught
+# it.
 #
 # The contract now: a consumer install must SUCCEED with no Xcode Command Line Tools
-# (uv is a prebuilt binary, CPython is uv-managed, llama.cpp/whisper.cpp/Node are
-# prebuilt downloads, triton is skipped on macOS), while `--local` must still fail
-# loudly because it installs unsloth-zoo from a git+https URL.
+# (uv, CPython, llama.cpp/whisper.cpp/Node are all prebuilt, triton is skipped on
+# macOS), while `--local` must still fail loudly: unsloth-zoo comes from a git+https
+# URL.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -76,12 +76,12 @@ HARNESS
 
 _BIN=$(mktemp -d)
 
-# Stock the sandbox PATH: each tool is absent, a working stub, or a broken stub
-# mimicking the Xcode CLT shim (exists, exits non-zero).
+# Each tool is absent, a working stub, or a broken stub mimicking the Xcode CLT shim
+# (exists, exits non-zero).
 _mk() { printf '#!/bin/sh\n%s\n' "$2" > "$_BIN/$1"; chmod +x "$_BIN/$1"; }
 
-# PATH is the sandbox and ONLY the sandbox, so an unstocked tool is genuinely absent
-# and the host's /usr/bin/git cannot leak in. bash must then be invoked absolutely.
+# PATH is the sandbox and ONLY the sandbox, so unstocked tools are genuinely absent and
+# the host's /usr/bin/git cannot leak in. bash must therefore be invoked absolutely.
 _SH="${BASH:-/bin/bash}"
 
 _run_gate() {
@@ -98,8 +98,8 @@ assert_contains "says CLT are not required"          "$_out" "not required"
 assert_not_contains "never claims CLT are required"  "$_out" "are required"
 
 echo "=== clean Mac: CLT stubs present but non-functional (the real virgin-Mac shape) ==="
-# With no CLT, /usr/bin/git and /usr/bin/cc EXIST and fail when run, so `command -v
-# git` succeeds. The gate must not be fooled by that.
+# With no CLT, /usr/bin/git EXISTS and fails when run, so `command -v git` succeeds.
+# The gate must not be fooled by that.
 rm -f "$_BIN"/*
 _mk xcode-select 'exit 1'
 _mk git 'echo "xcrun: error: invalid active developer path" >&2; exit 1'
@@ -140,8 +140,7 @@ assert_contains "uses prebuilt llama.cpp"            "$_out" "using prebuilt lla
 assert_contains "rc 0"                               "$_out" "RC=0"
 
 echo "=== the gate never fires the GUI installer on the consumer path ==="
-# Firing `xcode-select --install` and exiting is what stranded users: the dialog needs
-# a GUI session that a curl-piped or Tauri-spawned install does not have.
+# The dialog needs a GUI session a curl-piped or Tauri-spawned install does not have.
 rm -f "$_BIN"/*
 _mk xcode-select 'if [ "$1" = "--install" ]; then echo "GUI-DIALOG-FIRED"; fi; exit 1'
 _out="$(_run_gate false)"


### PR DESCRIPTION
## The problem

A brand new Mac cannot start the install. Both entry points fail the same way:

```
==> Xcode Command Line Tools are required.
```

Linux has the same shape: any non-apt distro exits 1 over `cmake git build-essential libcurl4-openssl-dev`, with the message "These are needed to build the GGUF inference engine."

## Nothing under either gate needs a toolchain

| Component | How it arrives | Compiler? |
|---|---|---|
| uv | prebuilt binary tarball | no |
| Python | uv-managed python-build-standalone | no |
| llama.cpp | prebuilt download | no |
| whisper.cpp | prebuilt, sha256-verified | no |
| Node | pinned nodejs.org archive | no |
| triton | skipped on macOS | n/a |
| unsloth-zoo via git+https | `--local` only | git, dev only |

`unslothai/llama.cpp` release `b10107-mix-1911198` publishes `macos-arm64`, `macos-x64`, `linux-x64` and `linux-arm64` builds covering cpu, cuda12, cuda13, rocm and vulkan. PR #6617 already removed the Homebrew/cmake hard stop on macOS for exactly this reason and left the CLT stop behind.

## What changes

- **macOS**: absent CLT warns and continues instead of `exit 1` plus a GUI dialog.
- **Linux/WSL**: only a download transport (curl or wget) is fatal. Build tooling warns and the prebuilt path proceeds. The non-apt `exit 1` is gone.
- **Both**: `--local` keeps a hard git requirement, and says why.
- Caps `av<16`. av 16+ ships no cp313 macOS arm64 wheel and is a C extension over FFmpeg, so uv would silently fall back to a source build needing a compiler *and* FFmpeg headers.

Both gates move into `_check_macos_deps()` and `_check_linux_deps()` so `tests/sh` can extract them. The old inline form could not be reached by the `tests/sh` convention, which is why this shipped broken and stayed broken.

## Tests

`tests/sh/test_macos_clt_gate.sh` (19 assertions) and `tests/sh/test_linux_deps_gate.sh` (25) cover the clean machine, the real virgin-Mac shape where `/usr/bin/git` exists but fails, the non-apt distro, the missing-transport case, and both `--local` paths. Backend CI globs `tests/sh/test_*.sh`, so they run automatically.

Writing the Linux test caught a latent bug: the gate trimmed its list with `$(echo ... | sed ...)`, so on a minimal image without `sed` the substitution yields empty and it reports "all system dependencies found" on a machine that has none of them. Now parameter expansion.

## Verification

Run on GitHub-hosted macOS runners with `/var/db/xcode_select_link`, `/Library/Developer/CommandLineTools`, `/Applications/Xcode*.app` and Homebrew moved aside, so `xcode-select -p`, `git`, `cc` and `clang` genuinely do not work:

| Leg | main | this branch |
|---|---|---|
| macos-14 pipe | fail | pass |
| macos-14 file | fail | pass |
| macos-15 pipe | fail | pass |
| macos-26 file | fail | pass |
| macos-14 file --no-torch | fail | pass |

The recorded tool-invocation trace for a full successful install is a single line, `xcode-select -p`, which is the detection probe this change makes non-fatal. Nothing compiled and nothing installed a toolchain.

The CI that produced those numbers is in a separate PR so this one stays reviewable.
