### PR TITLE
Installer: name the encoding when syncing the prebuilt marker

### DIFF
--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5644,7 +5644,7 @@ def sync_marker_llama_backend(install_dir: Path, llama_backend: str | None) -> N
     """Sync the persisted llama.cpp backend when the bundle is reused unchanged."""
     marker_path = install_dir / "UNSLOTH_PREBUILT_INFO.json"
     try:
-        marker = json.loads(marker_path.read_text())
+        marker = json.loads(marker_path.read_text(encoding = "utf-8"))
     except (OSError, ValueError):
         return
     if not isinstance(marker, dict) or marker.get("llama_backend") == llama_backend:
@@ -5653,7 +5653,7 @@ def sync_marker_llama_backend(install_dir: Path, llama_backend: str | None) -> N
         marker.pop("llama_backend", None)
     else:
         marker["llama_backend"] = llama_backend
-    marker_path.write_text(json.dumps(marker, indent = 2) + "\n")
+    marker_path.write_text(json.dumps(marker, indent = 2) + "\n", encoding = "utf-8")
     log(f"existing install reused; recorded llama_backend={llama_backend!r} from this run")
 
 


### PR DESCRIPTION
`sync_marker_llama_backend` reads and writes `UNSLOTH_PREBUILT_INFO.json` without naming an encoding, so the operator's locale decides it. On Windows that either crashes or silently produces mojibake. The sibling helper 15 lines above (`persist_force_cpu`) already passes `encoding = "utf-8"` on both calls, so this just matches it.

```diff
-        marker = json.loads(marker_path.read_text())
+        marker = json.loads(marker_path.read_text(encoding = "utf-8"))
...
-    marker_path.write_text(json.dumps(marker, indent = 2) + "\n")
+    marker_path.write_text(json.dumps(marker, indent = 2) + "\n", encoding = "utf-8")
```

## Why it is worth doing now

These are the two call sites `tests/test_runtime_text_encoding.py::test_shipping_code_names_an_encoding` has been failing on:

```
AssertionError: 2 text read/write call sites in shipping code let the operator's locale
decide the encoding, so they crash or silently produce mojibake on Windows.
Pass encoding = "utf-8": ['studio/install_llama_prebuilt.py:5656: write_text()',
                          'studio/install_llama_prebuilt.py:5647: read_text()']
```

That test is a repo-wide AST scan over `git ls-files`, so it does not depend on the diff: it turns `Repo tests (CPU)` red on **every** PR that touches `studio/**`. It was red on #7530 for exactly this reason, with nothing to do with that PR.

Introduced in `7917c7828` (#7373), which copied the sibling helper and dropped the kwarg.

## Verification

`python -m pytest tests/test_runtime_text_encoding.py -q` now passes 8/8 (was 1 failed, 7 passed). Ruff clean.
