### PR TITLE
Studio: fix macOS titlebar drag and collapsed layout

### DIFF
--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -255,7 +255,7 @@ const MAC_NATIVE_CHROME_STYLE = {
   "--studio-non-chat-content-top-inset": "34px",
   "--studio-hidden-route-top-inset": "34px",
   "--studio-chat-header-height": "44px",
-  "--studio-chat-header-padding-top": "8px",
+  "--studio-chat-header-padding-top": "7px",
   "--studio-chat-control-height": "33px",
   "--studio-chat-header-right-inset": "0px",
 } as CSSProperties;

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1183,8 +1183,19 @@ export function AppSidebar() {
     <Sidebar
       collapsible="icon"
       variant="sidebar"
-      className="font-heading group-data-[collapsible=icon]:[&_[data-sidebar=sidebar]]:bg-white dark:group-data-[collapsible=icon]:[&_[data-sidebar=sidebar]]:bg-background"
+      className={cn(
+        "font-heading group-data-[collapsible=icon]:[&_[data-sidebar=sidebar]]:bg-white dark:group-data-[collapsible=icon]:[&_[data-sidebar=sidebar]]:bg-background",
+        usesNativeMacTitlebar &&
+          "group-data-[collapsible=icon]:[&_[data-sidebar=sidebar]]:border-r-0",
+      )}
     >
+
+      {usesNativeMacTitlebar && (
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute bottom-0 right-0 top-[var(--studio-mac-titlebar-height,34px)] z-20 hidden w-px bg-sidebar-border group-data-[collapsible=icon]:block dark:group-data-[collapsible=icon]:hidden"
+        />
+      )}
       <SidebarHeader
         className={cn(
           "relative",

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1205,6 +1205,7 @@ export function AppSidebar() {
               />
             )}
             <div
+              data-tauri-drag-region={usesNativeMacTitlebar || undefined}
               className={cn(
                 "relative z-10 flex items-center gap-[8.5px] group-data-[collapsible=icon]:hidden",
                 showCompactMacBrand &&

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1189,13 +1189,6 @@ export function AppSidebar() {
           "group-data-[collapsible=icon]:[&_[data-sidebar=sidebar]]:border-r-0",
       )}
     >
-
-      {usesNativeMacTitlebar && (
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute bottom-0 right-0 top-[var(--studio-mac-titlebar-height,34px)] z-20 hidden w-px bg-sidebar-border group-data-[collapsible=icon]:block dark:group-data-[collapsible=icon]:hidden"
-        />
-      )}
       <SidebarHeader
         className={cn(
           "relative",

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -16,7 +16,6 @@ import {
   useActiveModelConfig,
 } from "@/features/model-picker";
 import { ProjectComposer, Thread } from "@/components/assistant-ui/thread";
-import { shouldUseNativeMacWindowTitlebar } from "@/components/tauri/window-titlebar";
 import { CopyableErrorChip } from "@/components/ui/copyable-error-chip";
 import {
   DropdownMenu,
@@ -782,12 +781,16 @@ function GeneralCompareHeader({
   // Controlled so the body-portaled popover can't linger over another tab off-route.
   const active = useChatActive();
   const [selectorOpen, setSelectorOpen] = useState(false);
+
+  const { pinned } = useSidebar();
   return (
     <div
       className={cn(
         "pointer-events-none relative z-40 flex h-[48px] shrink-0 items-start gap-2 bg-background pt-[var(--studio-chat-header-padding-top,11px)]",
         side === "left"
-          ? "pl-12 pr-3 md:pl-2"
+          ? pinned
+            ? "pl-12 pr-3 md:pl-2"
+            : "pl-12 pr-3 md:pl-[calc(0.5rem+max(0px,var(--studio-mac-traffic-light-inset,0px)-var(--sidebar-width-icon,3rem)))]"
           : "pl-3 pr-[calc(3rem+var(--studio-chat-header-right-inset,var(--studio-window-control-inset,0px)))]",
       )}
     >
@@ -2845,8 +2848,6 @@ export function ChatPage({
   );
   const { isMobile, pinned } = useSidebar();
 
-  const [usesNativeMacTitlebar] = useState(shouldUseNativeMacWindowTitlebar);
-
   const enterCompare = useCallback(() => {
     viewBeforeCompareRef.current = { ...search };
     useChatRuntimeStore.getState().setActiveThreadId(null);
@@ -3192,15 +3193,7 @@ export function ChatPage({
     // Provides `active` to ChatRuntimeProvider (drops the message views/composers
     // while off-route, keeping the runtime alive) and to the compare chrome.
     <ChatActiveContext.Provider value={active}>
-    <div
-      className={cn(
-        "flex min-h-0 min-w-0 flex-1 basis-0 overflow-hidden bg-background",
-        usesNativeMacTitlebar &&
-          !isMobile &&
-          !pinned &&
-          "[--studio-content-top-inset:var(--studio-mac-titlebar-height,34px)]",
-      )}
-    >
+    <div className="flex min-h-0 min-w-0 flex-1 basis-0 overflow-hidden bg-background">
       {/* Portaled surfaces render to document.body, escaping the parent's hidden
           wrapper, so gate them on `active` to keep them off other tabs. */}
       {active && <GuidedTour {...tour.tourProps} />}
@@ -3223,7 +3216,11 @@ export function ChatPage({
         <div
           className={cn(
             "pointer-events-none absolute top-[var(--studio-content-top-inset,0px)] left-0 right-[10px] z-40 flex h-[var(--studio-chat-header-height,48px)] shrink-0 items-start bg-background pt-[var(--studio-chat-header-padding-top,11px)] pr-[calc(0.5rem+var(--studio-chat-header-right-inset,var(--studio-window-control-inset,0px)))]",
-            isMobile ? "pl-12" : "pl-2",
+            isMobile
+              ? "pl-12"
+              : pinned
+                ? "pl-2"
+                : "pl-[calc(0.5rem+max(0px,var(--studio-mac-traffic-light-inset,0px)-var(--sidebar-width-icon,3rem)))]",
             view.mode === "compare" &&
               "right-[10px] left-auto w-auto bg-transparent pl-0 pr-[calc(0.5rem+var(--studio-chat-header-right-inset,var(--studio-window-control-inset,0px)))]",
           )}

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -16,6 +16,7 @@ import {
   useActiveModelConfig,
 } from "@/features/model-picker";
 import { ProjectComposer, Thread } from "@/components/assistant-ui/thread";
+import { shouldUseNativeMacWindowTitlebar } from "@/components/tauri/window-titlebar";
 import { CopyableErrorChip } from "@/components/ui/copyable-error-chip";
 import {
   DropdownMenu,
@@ -781,15 +782,12 @@ function GeneralCompareHeader({
   // Controlled so the body-portaled popover can't linger over another tab off-route.
   const active = useChatActive();
   const [selectorOpen, setSelectorOpen] = useState(false);
-  const { pinned } = useSidebar();
   return (
     <div
       className={cn(
         "pointer-events-none relative z-40 flex h-[48px] shrink-0 items-start gap-2 bg-background pt-[var(--studio-chat-header-padding-top,11px)]",
         side === "left"
-          ? pinned
-            ? "pl-12 pr-3 md:pl-2"
-            : "pl-12 pr-3 md:pl-[calc(0.5rem+max(0px,var(--studio-mac-traffic-light-inset,0px)-var(--sidebar-width-icon,3rem)))]"
+          ? "pl-12 pr-3 md:pl-2"
           : "pl-3 pr-[calc(3rem+var(--studio-chat-header-right-inset,var(--studio-window-control-inset,0px)))]",
       )}
     >
@@ -2847,6 +2845,8 @@ export function ChatPage({
   );
   const { isMobile, pinned } = useSidebar();
 
+  const [usesNativeMacTitlebar] = useState(shouldUseNativeMacWindowTitlebar);
+
   const enterCompare = useCallback(() => {
     viewBeforeCompareRef.current = { ...search };
     useChatRuntimeStore.getState().setActiveThreadId(null);
@@ -3192,7 +3192,15 @@ export function ChatPage({
     // Provides `active` to ChatRuntimeProvider (drops the message views/composers
     // while off-route, keeping the runtime alive) and to the compare chrome.
     <ChatActiveContext.Provider value={active}>
-    <div className="flex min-h-0 min-w-0 flex-1 basis-0 bg-background overflow-hidden">
+    <div
+      className={cn(
+        "flex min-h-0 min-w-0 flex-1 basis-0 overflow-hidden bg-background",
+        usesNativeMacTitlebar &&
+          !isMobile &&
+          !pinned &&
+          "[--studio-content-top-inset:var(--studio-mac-titlebar-height,34px)]",
+      )}
+    >
       {/* Portaled surfaces render to document.body, escaping the parent's hidden
           wrapper, so gate them on `active` to keep them off other tabs. */}
       {active && <GuidedTour {...tour.tourProps} />}
@@ -3215,11 +3223,7 @@ export function ChatPage({
         <div
           className={cn(
             "pointer-events-none absolute top-[var(--studio-content-top-inset,0px)] left-0 right-[10px] z-40 flex h-[var(--studio-chat-header-height,48px)] shrink-0 items-start bg-background pt-[var(--studio-chat-header-padding-top,11px)] pr-[calc(0.5rem+var(--studio-chat-header-right-inset,var(--studio-window-control-inset,0px)))]",
-            isMobile
-              ? "pl-12"
-              : pinned
-                ? "pl-2"
-                : "pl-[calc(0.5rem+max(0px,var(--studio-mac-traffic-light-inset,0px)-var(--sidebar-width-icon,3rem)))]",
+            isMobile ? "pl-12" : "pl-2",
             view.mode === "compare" &&
               "right-[10px] left-auto w-auto bg-transparent pl-0 pr-[calc(0.5rem+var(--studio-chat-header-right-inset,var(--studio-window-control-inset,0px)))]",
           )}

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -226,17 +226,24 @@ def test_visible_mac_sidebar_header_is_a_drag_region():
     assert header.index(drag_region) < header.index('"relative z-10 flex items-center')
 
 
-def test_collapsed_native_mac_chat_header_clears_traffic_lights():
+def test_mac_chat_header_controls_share_the_titlebar_row():
     source = CHAT_PAGE.read_text(encoding = "utf-8")
+    provider = APP_PROVIDER.read_text(encoding = "utf-8")
 
-    assert "const [usesNativeMacTitlebar] = useState(shouldUseNativeMacWindowTitlebar);" in source
-    assert '"[--studio-content-top-inset:var(--studio-mac-titlebar-height,34px)]"' in source
-    assert "usesNativeMacTitlebar &&" in source
-    assert "!isMobile &&" in source
-    assert "!pinned &&" in source
-    assert "var(--studio-mac-traffic-light-inset" not in source
+    assert "shouldUseNativeMacWindowTitlebar" not in source
+    assert "[--studio-content-top-inset:var(--studio-mac-titlebar-height" not in source
+    assert source.count("var(--studio-mac-traffic-light-inset") == 2
+    assert '"--studio-chat-header-padding-top": "7px"' in provider
     assert "pt-[var(--studio-content-top-inset,0px)] md:flex-row" in source
     assert "absolute top-[var(--studio-content-top-inset,0px)]" in source
+
+
+def test_collapsed_mac_sidebar_divider_starts_below_titlebar():
+    source = APP_SIDEBAR.read_text(encoding = "utf-8")
+
+    assert "group-data-[collapsible=icon]:[&_[data-sidebar=sidebar]]:border-r-0" in source
+    assert "top-[var(--studio-mac-titlebar-height,34px)]" in source
+    assert "group-data-[collapsible=icon]:block" in source
 
 
 def test_chat_sidebar_row_actions_visible_on_coarse_pointers():

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -229,14 +229,8 @@ def test_visible_mac_sidebar_header_is_a_drag_region():
 def test_collapsed_native_mac_chat_header_clears_traffic_lights():
     source = CHAT_PAGE.read_text(encoding = "utf-8")
 
-    assert (
-        "const [usesNativeMacTitlebar] = useState(shouldUseNativeMacWindowTitlebar);"
-        in source
-    )
-    assert (
-        '"[--studio-content-top-inset:var(--studio-mac-titlebar-height,34px)]"'
-        in source
-    )
+    assert "const [usesNativeMacTitlebar] = useState(shouldUseNativeMacWindowTitlebar);" in source
+    assert '"[--studio-content-top-inset:var(--studio-mac-titlebar-height,34px)]"' in source
     assert "usesNativeMacTitlebar &&" in source
     assert "!isMobile &&" in source
     assert "!pinned &&" in source

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -238,12 +238,11 @@ def test_mac_chat_header_controls_share_the_titlebar_row():
     assert "absolute top-[var(--studio-content-top-inset,0px)]" in source
 
 
-def test_collapsed_mac_sidebar_divider_starts_below_titlebar():
+def test_collapsed_mac_sidebar_hides_divider():
     source = APP_SIDEBAR.read_text(encoding = "utf-8")
 
     assert "group-data-[collapsible=icon]:[&_[data-sidebar=sidebar]]:border-r-0" in source
-    assert "top-[var(--studio-mac-titlebar-height,34px)]" in source
-    assert "group-data-[collapsible=icon]:block" in source
+    assert "top-[var(--studio-mac-titlebar-height,34px)]" not in source
 
 
 def test_chat_sidebar_row_actions_visible_on_coarse_pointers():

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -28,6 +28,7 @@ APP_PROVIDER = FRONTEND / "app/provider.tsx"
 
 CLIPBOARD_FILES = FRONTEND / "features/chat/utils/clipboard-files.ts"
 TAURI_CAPABILITIES = REPO / "studio/src-tauri/capabilities/default.json"
+CHAT_PAGE = FRONTEND / "features/chat/chat-page.tsx"
 
 
 def test_file_actions_route_through_native_commands_only_in_tauri():
@@ -214,6 +215,34 @@ def test_expanded_titlebar_button_and_corner_match_sidebar_edge():
         'className="pointer-events-none absolute top-full size-3 -translate-x-px rounded-tl-[12px] border-l border-t border-sidebar-border bg-background"'
         in source
     )
+
+
+def test_visible_mac_sidebar_header_is_a_drag_region():
+    source = APP_SIDEBAR.read_text(encoding = "utf-8")
+    header = source.split("<SidebarHeader", 1)[1].split("</SidebarHeader>", 1)[0]
+    drag_region = "data-tauri-drag-region={usesNativeMacTitlebar || undefined}"
+
+    assert drag_region in header
+    assert header.index(drag_region) < header.index('"relative z-10 flex items-center')
+
+
+def test_collapsed_native_mac_chat_header_clears_traffic_lights():
+    source = CHAT_PAGE.read_text(encoding = "utf-8")
+
+    assert (
+        "const [usesNativeMacTitlebar] = useState(shouldUseNativeMacWindowTitlebar);"
+        in source
+    )
+    assert (
+        '"[--studio-content-top-inset:var(--studio-mac-titlebar-height,34px)]"'
+        in source
+    )
+    assert "usesNativeMacTitlebar &&" in source
+    assert "!isMobile &&" in source
+    assert "!pinned &&" in source
+    assert "var(--studio-mac-traffic-light-inset" not in source
+    assert "pt-[var(--studio-content-top-inset,0px)] md:flex-row" in source
+    assert "absolute top-[var(--studio-content-top-inset,0px)]" in source
 
 
 def test_chat_sidebar_row_actions_visible_on_coarse_pointers():


### PR DESCRIPTION
## What changed

- Mark the visible macOS sidebar header row as a Tauri drag region so blank titlebar space can drag the window and use native double-click maximize behavior.
- Keep collapsed single, project, and compare chat controls on the same titlebar row as the expanded layout while preserving horizontal clearance for the traffic lights.
- Hide the collapsed native Tauri sidebar border so it does not cross the traffic-light controls or leave an awkward partial divider.
- Reduce macOS chat header top padding by 1px to align model, search, collapse, and right-side controls with the native buttons.
- Add focused desktop contracts for the drag region, titlebar alignment, and collapsed border.

## Why

The existing drag region sat behind the visible header row, so the row intercepted pointer events across its blank space. The first collapsed-layout fix moved the full chat header down, which made the model selector and right-side controls inconsistent with the expanded layout. The collapsed sidebar border also crossed the native traffic-light area and looked unbalanced when only partially drawn.

## Verification

- `uvx --from pytest pytest tests/studio/test_desktop_reliability_frontend_contract.py -q` (11 passed)
- `npm run typecheck --prefix studio/frontend`
- `npm run build --prefix studio/frontend`