### PR TITLE
Studio tests: bump the tensor-abort mtime by 1ms so the case runs on Windows

### DIFF
--- a/studio/backend/tests/test_tp_vision_regression.py
+++ b/studio/backend/tests/test_tp_vision_regression.py
@@ -24,6 +24,8 @@ import textwrap
 import types as _types
 from pathlib import Path
 
+import pytest
+
 _BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
 if _BACKEND_DIR not in sys.path:
     sys.path.insert(0, _BACKEND_DIR)
@@ -327,14 +329,18 @@ def test_tensor_abort_cache_invalidated_on_binary_mtime_change(tmp_path):
         ), "a binary swapped in place (new mtime) must be re-probed"
         # A same-second replacement (sub-second mtime bump) must also re-probe:
         # second-resolution mtime would inherit the stale abort (reviewer.py P2).
+        # Bump by 1ms, not 1ns: NTFS stores mtime as 100ns FILETIME ticks, so a 1ns
+        # bump rounds away on Windows and the key never changes.
         sec_ns = (binp.stat().st_mtime_ns // 1_000_000_000) * 1_000_000_000
         os.utime(p, ns = (sec_ns, sec_ns))
         LlamaCppBackend._record_tensor_split_abort(p, "m")
         binp.write_text("v2")
-        os.utime(p, ns = (sec_ns, sec_ns + 1))
+        os.utime(p, ns = (sec_ns, sec_ns + 1_000_000))
+        if binp.stat().st_mtime_ns == sec_ns:
+            pytest.skip("filesystem cannot record a sub-second mtime change")
         assert (
             LlamaCppBackend._tensor_split_aborts(p, "m") is False
-        ), "a same-second in-place swap (ns mtime bump) must be re-probed"
+        ), "a same-second in-place swap (sub-second mtime bump) must be re-probed"
     finally:
         for key in list(LlamaCppBackend._tensor_split_abort_keys):
             if key and key[0] == p:


### PR DESCRIPTION
`test_tensor_abort_cache_invalidated_on_binary_mtime_change` bumps the binary's mtime by a single nanosecond to prove that a same-second in-place swap re-probes instead of inheriting the cached abort:

```python
os.utime(p, ns = (sec_ns, sec_ns + 1))
```

NTFS stores file times as 64-bit FILETIME values counted in 100-nanosecond ticks, so on Windows a 1 ns bump is rounded away. `st_mtime_ns` reads back unchanged, the `(path, mtime, model)` cache key is identical, the stale abort is inherited, and the assertion sees `True` where it wants `False`:

```
FAILED studio/backend/tests/test_tp_vision_regression.py::test_tensor_abort_cache_invalidated_on_binary_mtime_change
AssertionError: a same-second in-place swap (ns mtime bump) must be re-probed
assert True is False
```

1 ms is still a same-second, sub-second change and is exactly representable in 100 ns ticks, so the case the test exists to cover actually runs on Windows. If a filesystem cannot record any sub-second change at all (FAT is 2 s, HFS+ is 1 s), skip rather than assert product behaviour the platform cannot exercise.

The product code is unaffected: it already keys on `st_mtime_ns`, which is the right choice, since a float `st_mtime` cannot represent Windows' 100 ns ticks for modern epoch values at all.

## Why this was never seen

Both jobs in `.github/workflows/studio-backend-ci.yml` are `runs-on: ubuntu-latest`, so the studio backend tests only ever run on Linux, where a 1 ns bump is representable. It surfaced when I ran the suite across ubuntu-latest, macos-14 and windows-latest while validating #7530: 1 failed, 1284 passed on Windows only, and the failure predates that PR (introduced in `98a01e70c`, #6659).

## Verification

`python -m pytest studio/backend/tests/test_tp_vision_regression.py -q` passes 41/41 on Linux, and the skip branch was exercised directly to confirm it raises `Skipped` rather than `NameError`. Ruff clean.

Refs: [PEP 564](https://peps.python.org/pep-0564/) on why float timestamps lose Windows' 100 ns resolution, and [bpo-14127](https://bugs.python.org/issue14127) for the `st_*time_ns` / `os.utime(ns=...)` API.
