### PR TITLE
Studio: honour LLAMA_ARG_FLASH_ATTN when recording the launched flash-attention state

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -1688,9 +1688,20 @@ def _kv_unified_from_args(
     return enabled
 
 
-def _flash_attn_enabled_from_args(args: Optional[Iterable[str]], default: bool = True) -> bool:
-    """Resolve llama.cpp's last-wins flash-attention CLI setting."""
+def _flash_attn_enabled_from_args(
+    args: Optional[Iterable[str]],
+    default: bool = True,
+    env: Optional[Mapping[str, str]] = None,
+) -> bool:
+    """Resolve llama.cpp's environment and last-wins flash-attention settings."""
     enabled = default
+    # llama.cpp applies LLAMA_ARG_FLASH_ATTN before parsing argv (arg.cpp set_env),
+    # so the CLI still wins. --flash-attn has no args_neg, so no LLAMA_ARG_NO_ twin.
+    value = (os.environ if env is None else env).get("LLAMA_ARG_FLASH_ATTN")
+    if value in _LLAMA_ARG_FALSE_VALUES:
+        enabled = False
+    elif value in _LLAMA_ARG_TRUE_OR_AUTO_VALUES:
+        enabled = True
     values = [str(arg) for arg in args] if args else []
     for i, raw in enumerate(values):
         if _flag_name(raw) not in {"-fa", "--flash-attn"}:
@@ -9029,7 +9040,8 @@ class LlamaCppBackend:
                     int(self._DEFAULT_N_UBATCH if _effective_ubatch is None else _effective_ubatch),
                 )
                 self._flash_attn_enabled = (
-                    _flash_attn_enabled_from_args(_last_spawn_cmd) and self._architecture != "grok"
+                    _flash_attn_enabled_from_args(_last_spawn_cmd, env = env)
+                    and self._architecture != "grok"
                 )
                 self._effective_cache_types = _effective_main_cache_types(
                     _last_spawn_cmd,

--- a/studio/backend/tests/test_mtp_vram_budget.py
+++ b/studio/backend/tests/test_mtp_vram_budget.py
@@ -817,7 +817,26 @@ class TestExtraArgsMtpDetection:
         ],
     )
     def test_flash_attn_last_value_wins(self, args, expected):
-        assert _flash_attn_enabled_from_args(args) is expected
+        assert _flash_attn_enabled_from_args(args, env = {}) is expected
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("off", False),
+            ("disabled", False),
+            ("false", False),
+            ("0", False),
+            ("on", True),
+            ("auto", True),
+            ("garbage", True),  # llama.cpp refuses to start, so the default is moot
+        ],
+    )
+    def test_flash_attn_env_applies(self, value, expected):
+        env = {"LLAMA_ARG_FLASH_ATTN": value}
+        assert _flash_attn_enabled_from_args([], env = env) is expected
+        # llama.cpp parses the environment first, so an explicit flag still wins.
+        assert _flash_attn_enabled_from_args(["-fa", "on"], env = env) is True
+        assert _flash_attn_enabled_from_args(["-fa", "off"], env = env) is False
 
     def test_effective_main_cache_types_follow_env_then_cli(self):
         env = {


### PR DESCRIPTION
Follow-up to #7530. `_flash_attn_enabled_from_args` models llama.cpp's flash-attention resolution but looks only at argv. `--flash-attn` is declared with `.set_env("LLAMA_ARG_FLASH_ATTN")` (`common/arg.cpp`), and Studio's child server inherits the parent environment via `_llama_server_env_for_binary`, so the helper was an incomplete model of the thing it exists to mirror. Every sibling helper in this file already reads its env var (`_swa_full_from_args_or_env`, `_kv_unified_from_args`, `_prompt_cache_off`, `_effective_main_cache_types`); this brings the last one into line.

## Scope: hardening, not a behaviour change

I originally wrote this up as a live bug. It is not, and the earlier version of this description was wrong. `load_model` builds every command from one literal that always contains an explicit value:

```python
cmd = [
    binary, "-m", model_path, "--port", str(self._port),
    "--parallel", str(n_parallel),
    "--flash-attn",
    "on",  # Force flash attention for speed
    "--no-context-shift",
]
```

and every argv that can reach `_last_spawn_cmd` derives from it: the `--fit` retry only appends, `_with_flash_attn_off` rewrites in place and preserves length, the `--spec-default` fallback slices around the spec flags, and `_strip_mmproj_args` removes only the `--mmproj` pair. User extras are appended, never substituted. So the CLI loop always resolves an explicit value and always overrides whatever the env preamble set, which is also exactly what llama.cpp does. No reachable input changes `self._flash_attn_enabled`.

What this buys is that the helper is now a faithful model of llama.cpp rather than one that happens to agree because a hard-coded flag masks the gap. If `--flash-attn on` at that call site ever becomes conditional, the helper stays correct instead of silently reporting the wrong layout into `_slot_launch_fingerprint` and the `save_slots_for_resume` cap.

## Change

```python
value = (os.environ if env is None else env).get("LLAMA_ARG_FLASH_ATTN")
if value in _LLAMA_ARG_FALSE_VALUES:
    enabled = False
elif value in _LLAMA_ARG_TRUE_OR_AUTO_VALUES:
    enabled = True
```

before the existing last-wins argv loop, plus `env = env` at the single call site (its immediate neighbour, `_effective_main_cache_types`, already passes the same `env`).

Verified against the bundled llama.cpp build 10107 (`857c97607`):

- `common_params_parse_ex` runs its env loop (`// handle environment variables`) before the argv loop, and warns `"environment variable is set, but will be overwritten by command line argument"`, so the CLI wins. The server README says the same. Covered by the new test.
- `is_truthy` / `is_falsey` / `is_autoy` compare raw strings with no case folding or trimming, which is what the existing `_LLAMA_ARG_*` frozensets already do. Lowercasing here would be wrong: `LLAMA_ARG_FLASH_ATTN=" off"` makes llama.cpp throw, it does not disable flash attention.
- `-fa` is declared with a single brace-list and no `args_neg`, unlike `--kv-unified`, and `get_value_from_env` only synthesises the `LLAMA_ARG_NO_*` twin when `args_neg` is non-empty. So there is no `LLAMA_ARG_NO_FLASH_ATTN` to model.
- Grouping `auto` with true is right for `-fa`, which uses `handler_string` with `is_autoy`. `--kv-unified` uses `handler_bool`, whose `parse_bool_value` throws on `auto`, which is why the sibling helper treats it differently.
- An unparseable value throws in the handler and `common_params_parse` returns false, so llama-server exits before serving and the fallback to `default` is unreachable. The test pins the no-crash behaviour anyway.

## Tests

`test_flash_attn_env_applies` covers all four falsey spellings, `on`, `auto`, and an unparseable value, and asserts an explicit `-fa on` / `-fa off` still wins over each env value. `test_flash_attn_last_value_wins` now passes `env = {}`, so it no longer reads the ambient environment, which it previously did.

- `tests/test_mtp_vram_budget.py -k flash_attn`: 24 passed (fails without the source change)
- `test_mtp_vram_budget.py` + `test_kv_cache_estimation.py` + `test_llama_cpp_slot_resume.py` + `test_llama_server_args.py`: 598 passed
- full backend suite under the CI invocation: 10981 passed. The remaining failures are RAG, MCP and secure-tools modules that fail identically on clean `main` here (missing optional deps and network cases).
