### PR TITLE
Studio: surface the tool-call nudge in the chat UI

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -12376,9 +12376,8 @@ class LlamaCppBackend:
                             _it_r = _iter_timings or {}
                             _accumulated_predicted_ms += _it_r.get("predicted_ms", 0)
                             _accumulated_predicted_n += _it_r.get("predicted_n", 0)
-                            # Blank first (the route resets its text cursor only on
-                            # an empty status), then the badge so the hidden retry
-                            # does not read as a hang.
+                            # Blank first (the route resets its text cursor only on an
+                            # empty status), then the badge so the retry is not a hang.
                             yield {"type": "status", "text": ""}
                             yield {"type": "status", "text": _NUDGE_TOOL_CALLS_STATUS}
                             continue

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -12376,11 +12376,9 @@ class LlamaCppBackend:
                             _it_r = _iter_timings or {}
                             _accumulated_predicted_ms += _it_r.get("predicted_ms", 0)
                             _accumulated_predicted_n += _it_r.get("predicted_n", 0)
-                            # Empty first: the route only resets its cumulative
-                            # text cursor on a blank status, so the retried turn
-                            # still streams cleanly. The badge follows, because
-                            # the retry itself is hidden (_suppress_visible_output)
-                            # and an unexplained pause reads as a hang.
+                            # Blank first (the route resets its text cursor only on
+                            # an empty status), then the badge so the hidden retry
+                            # does not read as a hang.
                             yield {"type": "status", "text": ""}
                             yield {"type": "status", "text": _NUDGE_TOOL_CALLS_STATUS}
                             continue

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -92,6 +92,7 @@ from utils.subprocess_compat import (
 from utils.process_lifetime import child_popen_kwargs as _child_popen_kwargs
 from core.inference.tool_call_parser import (
     MAX_ACT_REPROMPTS as _MAX_REPROMPTS,
+    NUDGE_TOOL_CALLS_STATUS as _NUDGE_TOOL_CALLS_STATUS,
     REPROMPT_MAX_CHARS as _REPROMPT_MAX_CHARS,
     is_short_intent_without_action as _is_short_intent_without_action,
     reprompt_to_act_message as _reprompt_to_act_message,
@@ -12375,7 +12376,13 @@ class LlamaCppBackend:
                             _it_r = _iter_timings or {}
                             _accumulated_predicted_ms += _it_r.get("predicted_ms", 0)
                             _accumulated_predicted_n += _it_r.get("predicted_n", 0)
+                            # Empty first: the route only resets its cumulative
+                            # text cursor on a blank status, so the retried turn
+                            # still streams cleanly. The badge follows, because
+                            # the retry itself is hidden (_suppress_visible_output)
+                            # and an unexplained pause reads as a hang.
                             yield {"type": "status", "text": ""}
+                            yield {"type": "status", "text": _NUDGE_TOOL_CALLS_STATUS}
                             continue
 
                         if _forced_tool_call_pending:

--- a/studio/backend/core/inference/safetensors_agentic.py
+++ b/studio/backend/core/inference/safetensors_agentic.py
@@ -1033,9 +1033,8 @@ def run_safetensors_tool_loop(
                             "content": reprompt_to_act_message(tool_hint),
                         }
                     )
-                    # Empty status clears the badge and resets the route's per-turn
-                    # text cursor before the re-prompted turn streams; the badge
-                    # that follows shows the pause is a re-prompt, not a stall.
+                    # Blank first: it clears the badge and resets the route's per-turn
+                    # text cursor. The badge then shows the pause is a re-prompt, not a stall.
                     yield {"type": "status", "text": ""}
                     yield {"type": "status", "text": NUDGE_TOOL_CALLS_STATUS}
                     continue

--- a/studio/backend/core/inference/safetensors_agentic.py
+++ b/studio/backend/core/inference/safetensors_agentic.py
@@ -1033,10 +1033,9 @@ def run_safetensors_tool_loop(
                             "content": reprompt_to_act_message(tool_hint),
                         }
                     )
-                    # Empty status clears the badge and resets the route's
-                    # per-turn text cursor before the re-prompted turn streams;
-                    # the badge that follows tells the user the pause is a
-                    # re-prompt in flight rather than a stalled generation.
+                    # Empty status clears the badge and resets the route's per-turn
+                    # text cursor before the re-prompted turn streams; the badge
+                    # that follows shows the pause is a re-prompt, not a stall.
                     yield {"type": "status", "text": ""}
                     yield {"type": "status", "text": NUDGE_TOOL_CALLS_STATUS}
                     continue

--- a/studio/backend/core/inference/safetensors_agentic.py
+++ b/studio/backend/core/inference/safetensors_agentic.py
@@ -35,6 +35,7 @@ from core.inference.tool_call_parser import (
     _strip_mistral_reasoning,
     BUDGET_EXHAUSTED_NUDGE,
     MAX_ACT_REPROMPTS,
+    NUDGE_TOOL_CALLS_STATUS,
     RAG_MAX_SEARCHES_PER_TURN,
     RAG_SEARCH_CAP_NUDGE,
     TOOL_XML_SIGNALS,
@@ -1033,8 +1034,11 @@ def run_safetensors_tool_loop(
                         }
                     )
                     # Empty status clears the badge and resets the route's
-                    # per-turn text cursor before the re-prompted turn streams.
+                    # per-turn text cursor before the re-prompted turn streams;
+                    # the badge that follows tells the user the pause is a
+                    # re-prompt in flight rather than a stalled generation.
                     yield {"type": "status", "text": ""}
+                    yield {"type": "status", "text": NUDGE_TOOL_CALLS_STATUS}
                     continue
 
                 # Final answer. If a literal tool marker in prose was buffered but

--- a/studio/backend/core/inference/tool_call_parser.py
+++ b/studio/backend/core/inference/tool_call_parser.py
@@ -183,11 +183,8 @@ INTENT_SIGNAL = re.compile(
 # times since #5620); safetensors and MLX inherit the same cap from here.
 MAX_ACT_REPROMPTS = 3
 REPROMPT_MAX_CHARS = 2000
-# Badge text for the chat composer while a re-prompted turn regenerates. The
-# retry is a whole hidden generation with its visible output suppressed, so
-# without this the UI sits blank and looks hung. The frontend matches this
-# string exactly (ToolStatusDisplay in components/assistant-ui/thread.tsx) to
-# swap the tool glyph for a spinner, so keep the two in sync.
+# Composer badge while a hidden re-prompted turn regenerates, else the UI looks
+# hung. Matched exactly by the frontend (utils/tool-status.ts); keep in sync.
 NUDGE_TOOL_CALLS_STATUS = "Nudging tool calls"
 
 

--- a/studio/backend/core/inference/tool_call_parser.py
+++ b/studio/backend/core/inference/tool_call_parser.py
@@ -183,6 +183,12 @@ INTENT_SIGNAL = re.compile(
 # times since #5620); safetensors and MLX inherit the same cap from here.
 MAX_ACT_REPROMPTS = 3
 REPROMPT_MAX_CHARS = 2000
+# Badge text for the chat composer while a re-prompted turn regenerates. The
+# retry is a whole hidden generation with its visible output suppressed, so
+# without this the UI sits blank and looks hung. The frontend matches this
+# string exactly (ToolStatusDisplay in components/assistant-ui/thread.tsx) to
+# swap the tool glyph for a spinner, so keep the two in sync.
+NUDGE_TOOL_CALLS_STATUS = "Nudging tool calls"
 
 
 def is_short_intent_without_action(text: str) -> bool:

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -1910,7 +1910,9 @@ def test_plan_without_action_nudge_is_announced_on_the_status_channel(monkeypatc
     index = statuses.index(NUDGE_TOOL_CALLS_STATUS)
     # The blank status has to come first: the route only resets its cumulative
     # text cursor on an empty one, and the retried turn streams against it.
-    assert statuses[index - 1] == ""
+    # index > 0 is load-bearing: at index 0 a bare statuses[index - 1] wraps to the
+    # terminal clear and the ordering assertion passes without proving anything.
+    assert index > 0 and statuses[index - 1] == ""
     # The tool the retry finally calls takes the badge over, and the request ends
     # with it cleared.
     assert statuses[index + 1].startswith("Searching:")

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -1908,13 +1908,10 @@ def test_plan_without_action_nudge_is_announced_on_the_status_channel(monkeypatc
     statuses = _status_texts(events)
     assert NUDGE_TOOL_CALLS_STATUS in statuses
     index = statuses.index(NUDGE_TOOL_CALLS_STATUS)
-    # The blank status has to come first: the route only resets its cumulative
-    # text cursor on an empty one, and the retried turn streams against it.
-    # index > 0 is load-bearing: at index 0 a bare statuses[index - 1] wraps to the
-    # terminal clear and the ordering assertion passes without proving anything.
+    # Blank first: the route resets its text cursor only on an empty status.
+    # index > 0 matters: at 0, statuses[-1] wraps to the terminal clear.
     assert index > 0 and statuses[index - 1] == ""
-    # The tool the retry finally calls takes the badge over, and the request ends
-    # with it cleared.
+    # The retry's tool takes the badge over, then it clears.
     assert statuses[index + 1].startswith("Searching:")
     assert statuses[-1] == ""
 

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -1911,7 +1911,6 @@ def test_plan_without_action_nudge_is_announced_on_the_status_channel(monkeypatc
     # Blank first: the route resets its text cursor only on an empty status.
     # index > 0 matters: at 0, statuses[-1] wraps to the terminal clear.
     assert index > 0 and statuses[index - 1] == ""
-    # The retry's tool takes the badge over, then it clears.
     assert statuses[index + 1].startswith("Searching:")
     assert statuses[-1] == ""
 

--- a/studio/backend/tests/test_llama_cpp_tool_loop.py
+++ b/studio/backend/tests/test_llama_cpp_tool_loop.py
@@ -26,6 +26,7 @@ from core.inference.llama_cpp import (
     _PROVISIONAL_ARGS_MIN_CHARS,
     LlamaCppBackend,
 )
+from core.inference.tool_call_parser import NUDGE_TOOL_CALLS_STATUS
 from state import tool_approvals
 from state.tool_approvals import TOOL_REJECTED_MESSAGE, resolve_tool_decision
 
@@ -1839,6 +1840,142 @@ def test_reprompted_tool_call_still_streams_final_answer(monkeypatch):
     assert content_texts == ["I will use render_html now.", "Final note after tool."]
     assert not any(event.get("type") == "reasoning_summary" for event in events)
     assert len(payloads) == 3
+
+
+def _status_texts(events: list[dict]) -> list[str]:
+    return [event["text"] for event in events if event.get("type") == "status"]
+
+
+_WEB_SEARCH_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "web_search",
+        "description": "Search the web.",
+        "parameters": {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+    },
+}
+
+
+def _nudge_then_search_streams() -> list[list[str]]:
+    """Stall, then a re-prompted turn that finally searches, then the answer."""
+
+    return [
+        [_sse({"content": "I will search the web now."}), _done()],
+        [
+            _sse(
+                {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_search",
+                            "type": "function",
+                            "function": {
+                                "name": "web_search",
+                                "arguments": json.dumps({"query": "red square"}),
+                            },
+                        }
+                    ]
+                }
+            ),
+            _done(),
+        ],
+        [_sse({"content": "Final answer: the square is red."}), _done()],
+    ]
+
+
+def test_plan_without_action_nudge_is_announced_on_the_status_channel(monkeypatch):
+    """The re-prompted turn is hidden, so without a badge the UI looks frozen."""
+
+    payloads: list[dict] = []
+    backend = _make_backend(monkeypatch, _nudge_then_search_streams(), payloads)
+    monkeypatch.setattr(
+        "core.inference.tools.execute_tool",
+        lambda *_a, **_k: "Search results: red is #f00.",
+    )
+
+    events = list(
+        backend.generate_chat_completion_with_tools(
+            messages = [{"role": "user", "content": "What colour is the square?"}],
+            tools = [_WEB_SEARCH_TOOL],
+            max_tool_iterations = 2,
+        )
+    )
+
+    statuses = _status_texts(events)
+    assert NUDGE_TOOL_CALLS_STATUS in statuses
+    index = statuses.index(NUDGE_TOOL_CALLS_STATUS)
+    # The blank status has to come first: the route only resets its cumulative
+    # text cursor on an empty one, and the retried turn streams against it.
+    assert statuses[index - 1] == ""
+    # The tool the retry finally calls takes the badge over, and the request ends
+    # with it cleared.
+    assert statuses[index + 1].startswith("Searching:")
+    assert statuses[-1] == ""
+
+
+def test_plan_without_action_nudge_status_clears_when_the_retry_just_answers(monkeypatch):
+    streams = [
+        [_sse({"content": "I will search the web now."}), _done()],
+        [_sse({"content": "No search needed. Final answer: the square is red."}), _done()],
+    ]
+    payloads: list[dict] = []
+    backend = _make_backend(monkeypatch, streams, payloads)
+
+    events = list(
+        backend.generate_chat_completion_with_tools(
+            messages = [{"role": "user", "content": "What colour is the square?"}],
+            tools = [_WEB_SEARCH_TOOL],
+            max_tool_iterations = 2,
+        )
+    )
+
+    statuses = _status_texts(events)
+    assert NUDGE_TOOL_CALLS_STATUS in statuses
+    assert statuses[-1] == ""
+
+
+def test_direct_answer_never_shows_the_nudge_status(monkeypatch):
+    payloads: list[dict] = []
+    backend = _make_backend(
+        monkeypatch,
+        [[_sse({"content": "The square is red."}), _done()]],
+        payloads,
+    )
+
+    events = list(
+        backend.generate_chat_completion_with_tools(
+            messages = [{"role": "user", "content": "What colour is the square?"}],
+            tools = [_WEB_SEARCH_TOOL],
+            max_tool_iterations = 2,
+        )
+    )
+
+    assert NUDGE_TOOL_CALLS_STATUS not in _status_texts(events)
+
+
+def test_nudge_status_absent_when_nudging_is_disabled(monkeypatch):
+    payloads: list[dict] = []
+    backend = _make_backend(monkeypatch, _nudge_then_search_streams(), payloads)
+    monkeypatch.setattr(
+        "core.inference.tools.execute_tool",
+        lambda *_a, **_k: "Search results: red is #f00.",
+    )
+
+    events = list(
+        backend.generate_chat_completion_with_tools(
+            messages = [{"role": "user", "content": "What colour is the square?"}],
+            tools = [_WEB_SEARCH_TOOL],
+            max_tool_iterations = 2,
+            nudge_tool_calls = False,
+        )
+    )
+
+    assert NUDGE_TOOL_CALLS_STATUS not in _status_texts(events)
+    assert len(payloads) == 1
 
 
 def test_confirm_tool_calls_allow_executes_gguf_tool(monkeypatch):

--- a/studio/backend/tests/test_safetensors_tool_loop.py
+++ b/studio/backend/tests/test_safetensors_tool_loop.py
@@ -2233,15 +2233,13 @@ def test_reprompt_names_only_active_tools_not_hardcoded():
 
 
 def test_reprompt_is_announced_on_the_status_channel():
-    # The re-prompted turn regenerates with nothing visible in between, so the
-    # badge is the only sign the model is still working. The blank status must
-    # still come first -- the route resets its text cursor on that one alone.
+    # The re-prompted turn is hidden, so the badge is the only sign of life.
+    # Blank still comes first: the route resets its text cursor only on that.
     _captured, events = _reprompt_loop(auto_heal_tool_calls = True)
     statuses = [e["text"] for e in events if e["type"] == "status"]
     assert NUDGE_TOOL_CALLS_STATUS in statuses
     index = statuses.index(NUDGE_TOOL_CALLS_STATUS)
-    # index > 0 is load-bearing: at index 0 a bare statuses[index - 1] wraps to the
-    # terminal clear and the ordering assertion passes without proving anything.
+    # index > 0 matters: at 0, statuses[-1] wraps to the terminal clear.
     assert index > 0 and statuses[index - 1] == ""
     assert statuses[-1] == ""
 

--- a/studio/backend/tests/test_safetensors_tool_loop.py
+++ b/studio/backend/tests/test_safetensors_tool_loop.py
@@ -24,6 +24,7 @@ from core.inference.safetensors_agentic import (
     strip_tool_markup_streaming,
 )
 from core.inference.tool_call_parser import (
+    NUDGE_TOOL_CALLS_STATUS,
     RAG_MAX_SEARCHES_PER_TURN,
     has_tool_signal,
     parse_tool_calls_from_text,
@@ -2229,6 +2230,24 @@ def test_reprompt_names_only_active_tools_not_hardcoded():
     assert "search_knowledge_base" in reprompt["content"]
     assert "web_search" not in reprompt["content"]
     assert "python" not in reprompt["content"]
+
+
+def test_reprompt_is_announced_on_the_status_channel():
+    # The re-prompted turn regenerates with nothing visible in between, so the
+    # badge is the only sign the model is still working. The blank status must
+    # still come first -- the route resets its text cursor on that one alone.
+    _captured, events = _reprompt_loop(auto_heal_tool_calls = True)
+    statuses = [e["text"] for e in events if e["type"] == "status"]
+    assert NUDGE_TOOL_CALLS_STATUS in statuses
+    index = statuses.index(NUDGE_TOOL_CALLS_STATUS)
+    assert statuses[index - 1] == ""
+    assert statuses[-1] == ""
+
+
+def test_reprompt_status_absent_without_a_nudge():
+    _captured, events = _reprompt_loop(auto_heal_tool_calls = False)
+    statuses = [e["text"] for e in events if e["type"] == "status"]
+    assert NUDGE_TOOL_CALLS_STATUS not in statuses
 
 
 def test_reprompt_suppressed_when_auto_heal_disabled():

--- a/studio/backend/tests/test_safetensors_tool_loop.py
+++ b/studio/backend/tests/test_safetensors_tool_loop.py
@@ -2240,7 +2240,9 @@ def test_reprompt_is_announced_on_the_status_channel():
     statuses = [e["text"] for e in events if e["type"] == "status"]
     assert NUDGE_TOOL_CALLS_STATUS in statuses
     index = statuses.index(NUDGE_TOOL_CALLS_STATUS)
-    assert statuses[index - 1] == ""
+    # index > 0 is load-bearing: at index 0 a bare statuses[index - 1] wraps to the
+    # terminal clear and the ordering assertion passes without proving anything.
+    assert index > 0 and statuses[index - 1] == ""
     assert statuses[-1] == ""
 
 

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -2859,8 +2859,7 @@ const ToolStatusDisplay: FC = () => {
       <div
         className={cn(
           "flex items-center gap-2 rounded-full border border-primary/20 bg-primary/5 px-3 py-1.5 text-xs text-primary",
-          // The spinner is its own motion cue; pulsing the pill as well just
-          // fades it in and out mid-spin.
+          // The spinner is its own motion cue; pulsing too just fades it mid-spin.
           !isNudging && "animate-pulse",
         )}
       >

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -91,6 +91,7 @@ import {
   useResearchRunStore,
 } from "@/features/chat/stores/research-run-store";
 import { parseExternalModelId } from "@/features/chat/external-providers";
+import { toolStatusKind } from "@/features/chat/utils/tool-status";
 import { McpComposerButton } from "@/features/chat/mcp-composer-button";
 import { getExternalReasoningCapabilities } from "@/features/chat/provider-capabilities";
 import { useRagToolDisabled } from "@/features/chat/hooks/use-rag-tool-disabled";
@@ -2847,15 +2848,27 @@ const ToolStatusDisplay: FC = () => {
   }
   // From the store's start time, so returning to the conversation resumes rather than restarting.
   const elapsed = Math.max(0, Math.floor((now - startedAt) / 1000));
-  const isRunning = toolStatus.startsWith("Running");
-  const StatusIcon = isRunning ? TerminalIcon : GlobeIcon;
+  const kind = toolStatusKind(toolStatus);
+  const isNudging = kind === "nudge";
+  const StatusIcon = kind === "terminal" ? TerminalIcon : GlobeIcon;
   return (
     <div
       data-testid="composer-tool-status"
       className="mb-2 flex w-full flex-row items-center gap-2 px-1.5 pt-0.5 pb-1"
     >
-      <div className="flex animate-pulse items-center gap-2 rounded-full border border-primary/20 bg-primary/5 px-3 py-1.5 text-xs text-primary">
-        <StatusIcon className="size-3.5" />
+      <div
+        className={cn(
+          "flex items-center gap-2 rounded-full border border-primary/20 bg-primary/5 px-3 py-1.5 text-xs text-primary",
+          // The spinner is its own motion cue; pulsing the pill as well just
+          // fades it in and out mid-spin.
+          !isNudging && "animate-pulse",
+        )}
+      >
+        {isNudging ? (
+          <Spinner className="size-3.5" />
+        ) : (
+          <StatusIcon className="size-3.5" />
+        )}
         <span>{toolStatus}</span>
         <span className="tabular-nums opacity-60">{elapsed}s</span>
       </div>

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -2864,7 +2864,9 @@ const ToolStatusDisplay: FC = () => {
         )}
       >
         {isNudging ? (
-          <Spinner className="size-3.5" />
+          // label, not the default "Loading": the spinner is the badge's only
+          // role="status" region, so its name is what gets announced.
+          <Spinner className="size-3.5" label={toolStatus} />
         ) : (
           <StatusIcon className="size-3.5" />
         )}

--- a/studio/frontend/src/features/chat/utils/tool-status.ts
+++ b/studio/frontend/src/features/chat/utils/tool-status.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * Mirrors NUDGE_TOOL_CALLS_STATUS in
+ * studio/backend/core/inference/tool_call_parser.py. The GGUF and safetensors
+ * tool loops send it while a plan-without-action re-prompt regenerates; that
+ * turn's output is hidden, so the badge is the only sign of life.
+ */
+export const NUDGE_TOOL_CALLS_STATUS = "Nudging tool calls";
+
+export type ToolStatusKind = "nudge" | "terminal" | "web";
+
+/**
+ * Which glyph the composer status badge shows. The backend sends prose, not a
+ * kind, so this is the one place that reads it: an exact match for the nudge,
+ * then the long-standing "Running ..." prefix for the local sandbox tools
+ * (status_for_tool in core/inference/tool_loop_controller.py), and the globe
+ * for everything else ("Searching: ...", "Reading: ...", "Calling: ...").
+ */
+export function toolStatusKind(status: string): ToolStatusKind {
+  if (status === NUDGE_TOOL_CALLS_STATUS) {
+    return "nudge";
+  }
+  return status.startsWith("Running") ? "terminal" : "web";
+}

--- a/studio/frontend/src/features/chat/utils/tool-status.ts
+++ b/studio/frontend/src/features/chat/utils/tool-status.ts
@@ -1,22 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-/**
- * Mirrors NUDGE_TOOL_CALLS_STATUS in
- * studio/backend/core/inference/tool_call_parser.py. The GGUF and safetensors
- * tool loops send it while a plan-without-action re-prompt regenerates; that
- * turn's output is hidden, so the badge is the only sign of life.
- */
+/** Mirrors NUDGE_TOOL_CALLS_STATUS in backend core/inference/tool_call_parser.py; keep in sync. */
 export const NUDGE_TOOL_CALLS_STATUS = "Nudging tool calls";
 
 export type ToolStatusKind = "nudge" | "terminal" | "web";
 
 /**
- * Which glyph the composer status badge shows. The backend sends prose, not a
- * kind, so this is the one place that reads it: an exact match for the nudge,
- * then the long-standing "Running ..." prefix for the local sandbox tools
- * (status_for_tool in core/inference/tool_loop_controller.py), and the globe
- * for everything else ("Searching: ...", "Reading: ...", "Calling: ...").
+ * Which glyph the composer badge shows: exact match for the nudge, the
+ * "Running ..." prefix for sandbox tools, globe for everything else.
  */
 export function toolStatusKind(status: string): ToolStatusKind {
   if (status === NUDGE_TOOL_CALLS_STATUS) {

--- a/studio/frontend/src/features/chat/utils/tool-status.ts
+++ b/studio/frontend/src/features/chat/utils/tool-status.ts
@@ -6,10 +6,7 @@ export const NUDGE_TOOL_CALLS_STATUS = "Nudging tool calls";
 
 export type ToolStatusKind = "nudge" | "terminal" | "web";
 
-/**
- * Which glyph the composer badge shows: exact match for the nudge, the
- * "Running ..." prefix for sandbox tools, globe for everything else.
- */
+/** Which glyph the badge shows: exact match for the nudge, "Running" prefix for sandbox tools, globe otherwise. */
 export function toolStatusKind(status: string): ToolStatusKind {
   if (status === NUDGE_TOOL_CALLS_STATUS) {
     return "nudge";

--- a/studio/frontend/tests/tool-status.test.ts
+++ b/studio/frontend/tests/tool-status.test.ts
@@ -10,8 +10,8 @@ import {
 } from "../src/features/chat/utils/tool-status.ts";
 
 test("the nudge status is the exact string the backend sends", () => {
-  // core/inference/tool_call_parser.py: NUDGE_TOOL_CALLS_STATUS. The badge
-  // matches on the text itself, so a reword on either side must break here.
+  // Mirrors NUDGE_TOOL_CALLS_STATUS in core/inference/tool_call_parser.py, so a
+  // reword on either side must break here.
   assert.equal(NUDGE_TOOL_CALLS_STATUS, "Nudging tool calls");
   assert.equal(toolStatusKind(NUDGE_TOOL_CALLS_STATUS), "nudge");
 });

--- a/studio/frontend/tests/tool-status.test.ts
+++ b/studio/frontend/tests/tool-status.test.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  NUDGE_TOOL_CALLS_STATUS,
+  toolStatusKind,
+} from "../src/features/chat/utils/tool-status.ts";
+
+test("the nudge status is the exact string the backend sends", () => {
+  // core/inference/tool_call_parser.py: NUDGE_TOOL_CALLS_STATUS. The badge
+  // matches on the text itself, so a reword on either side must break here.
+  assert.equal(NUDGE_TOOL_CALLS_STATUS, "Nudging tool calls");
+  assert.equal(toolStatusKind(NUDGE_TOOL_CALLS_STATUS), "nudge");
+});
+
+test("sandbox tools keep the terminal glyph", () => {
+  for (const status of [
+    "Running Python: print(1)",
+    "Running Python...",
+    "Running: ls -la",
+    "Running command...",
+  ]) {
+    assert.equal(toolStatusKind(status), "terminal", status);
+  }
+});
+
+test("every other status keeps the globe", () => {
+  for (const status of [
+    "Searching: red square",
+    "Reading: unsloth.ai",
+    "Reading page...",
+    "Searching documents: quarterly report",
+    "Calling: get_weather",
+  ]) {
+    assert.equal(toolStatusKind(status), "web", status);
+  }
+});
+
+test("a status that merely mentions nudging is not the nudge itself", () => {
+  // Exact match only: a tool named after the phrase must not steal the spinner.
+  assert.equal(toolStatusKind("Calling: Nudging tool calls"), "web");
+  assert.equal(toolStatusKind("Nudging tool calls again"), "web");
+});

--- a/studio/frontend/tests/tool-status.test.ts
+++ b/studio/frontend/tests/tool-status.test.ts
@@ -10,8 +10,7 @@ import {
 } from "../src/features/chat/utils/tool-status.ts";
 
 test("the nudge status is the exact string the backend sends", () => {
-  // Mirrors NUDGE_TOOL_CALLS_STATUS in core/inference/tool_call_parser.py, so a
-  // reword on either side must break here.
+  // Mirrors tool_call_parser.py, so a reword on either side must break here.
   assert.equal(NUDGE_TOOL_CALLS_STATUS, "Nudging tool calls");
   assert.equal(toolStatusKind(NUDGE_TOOL_CALLS_STATUS), "nudge");
 });


### PR DESCRIPTION
## Problem

When the tool loop nudges the model (the plan-without-action re-prompt), Studio's chat UI goes completely silent for a full extra generation.

The GGUF loop appends a hidden assistant + user turn, sets `_forced_tool_call_pending`, and re-generates with `_suppress_visible_output = True`, so every content chunk of the retried turn is dropped. The one thing it yields is `{"type": "status", "text": ""}`, which *clears* the composer badge. The safetensors and MLX loop does the same. So exactly when the model is doing extra work on the user's behalf, the UI shows nothing at all, and people reasonably conclude it has hung.

The Nudge Tool Calls setting is on by default for the Unsloth inference paths, so this is the common case, not an edge case.

## Change

The status channel that already drives "Searching: ...", "Reading: ...", and "Running Python: ..." now also carries the nudge, and the badge shows a spinner for it.

Backend, one shared constant plus two call sites:

- `core/inference/tool_call_parser.py` gains `NUDGE_TOOL_CALLS_STATUS = "Nudging tool calls"`, next to the other nudge constants.
- `core/inference/llama_cpp.py` and `core/inference/safetensors_agentic.py` yield it right after the existing empty status at the re-prompt boundary.

The empty event stays, and stays first. Both route handlers gate their cumulative-text cursor reset on `if not event["text"]` (`routes/inference.py` for the GGUF and safetensors streams), so that blank status is not just a badge clear, it is the iteration boundary the retried turn streams against. Swapping its text would corrupt the next turn's diff. The visible status is a second event on top.

Nothing else in the loop moved. Every exit from the retried iteration already emits a blank status, and a retry that goes on to call a tool is superseded by that tool's own status, so the badge clears on its own in all paths.

Frontend:

- New `features/chat/utils/tool-status.ts` with `toolStatusKind`, which folds the badge's glyph choice into one tested function: exact match for the nudge, the long-standing `Running` prefix for the sandbox tools, globe for everything else.
- `ToolStatusDisplay` renders the existing `Spinner` for the nudge and drops the pill's `animate-pulse` in that case only, so the spinner does not spin and fade at the same time.

Scope is the plan-without-action re-prompt on the local backends. Tool-error retries, no-op corrections, the knowledge-base search cap and the budget-exhausted nudge are different behaviours and would be mislabelled by this string. The non-streaming passthrough heal for external providers has no SSE channel open at that moment, so it is out of scope too.

## Behaviour

Live SSE from a local Studio running a GGUF with web search on, one turn:

```
[ 0.95s] tool_status='Searching: current weather in Reykjavik'
[ 0.95s] tool_start web_search
[ 1.68s] tool_end web_search
[ 1.68s] tool_status=''
[ 2.56s] tool_status=''
[ 2.56s] tool_status='Nudging tool calls'
[ 2.69s] tool_status=''
[  3.3s] tool_status=''
```

Confirmed in a browser against a running Studio as well: with a small GGUF and web search on, the composer shows a spinning `Nudging tool calls` pill with the elapsed counter while the hidden retry runs, then hands off to the tool status or clears.

The badge keeps the existing 300ms debounce, so a nudge that resolves faster than that never paints. That is the behaviour you want: a 130ms pause is not what people are complaining about, a multi-second one is.

## Tests

- `test_llama_cpp_tool_loop.py`: the blank status immediately precedes the nudge status; a retry that calls a tool hands the badge to that tool; a retry that just answers ends cleared; a direct answer and `nudge_tool_calls=False` never emit it.
- `test_safetensors_tool_loop.py`: same ordering assertions for the shared loop.
- `tests/tool-status.test.ts`: pins the exact string against the backend constant and covers the terminal, globe and near-miss cases.

Full backend suite compared against a clean `main` checkout in the same environment: identical failures on both sides, no regressions. `npm run typecheck`, `npm run build` and `npm test` pass.
