### PR TITLE
Studio: make the sidebar width draggable

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1221,7 +1221,9 @@ export function AppSidebar() {
                     openNewChat(null);
                   }}
                   className={cn(
-                    "flex items-center gap-[6px] select-none transition-opacity",
+                    // min-w-0 so a narrow sidebar truncates the wordmark
+                    // instead of pushing the search icon over the logo.
+                    "flex min-w-0 items-center gap-[6px] select-none transition-opacity",
                     chatDisabled && "pointer-events-none opacity-50",
                   )}
                   aria-label={t("shell.aria.home")}
@@ -1233,17 +1235,17 @@ export function AppSidebar() {
                   <img
                     src="/circle-logo-small.png"
                     alt="Unsloth"
-                    className="h-[calc(26px+0.5rem*var(--ui-font-scale,1))] w-[calc(26px+0.5rem*var(--ui-font-scale,1))] rounded-full object-cover"
+                    className="h-[calc(26px+0.5rem*var(--ui-font-scale,1))] w-[calc(26px+0.5rem*var(--ui-font-scale,1))] shrink-0 rounded-full object-cover"
                   />
-                  <span className="font-heading text-[calc(13px+0.5rem*var(--ui-font-scale,1))] font-semibold tracking-[0em] leading-none text-black dark:text-white dark:tracking-[0.02em]">
+                  <span className="truncate font-heading text-[calc(13px+0.5rem*var(--ui-font-scale,1))] font-semibold tracking-[0em] leading-none text-black dark:text-white dark:tracking-[0.02em]">
                     unsloth
                   </span>
-                  <span className="nav-badge ml-0.5 inline-flex items-center justify-center rounded-full border border-nav-beta-border px-[5px] pt-[3px] pb-[2px] text-[calc(0.5rem*var(--ui-font-scale,1))] font-medium leading-none tracking-[0.04em] text-nav-fg-muted antialiased subpixel-antialiased shadow-[0_1px_2px_rgba(0,0,0,0.06)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.35)]">
+                  <span className="nav-badge ml-0.5 inline-flex shrink-0 items-center justify-center rounded-full border border-nav-beta-border px-[5px] pt-[3px] pb-[2px] text-[calc(0.5rem*var(--ui-font-scale,1))] font-medium leading-none tracking-[0.04em] text-nav-fg-muted antialiased subpixel-antialiased shadow-[0_1px_2px_rgba(0,0,0,0.06)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.35)]">
                     {t("shell.beta")}
                   </span>
                 </Link>
               )}
-              <div className="flex items-center gap-0.5">
+              <div className="flex shrink-0 items-center gap-0.5">
                 <Tooltip>
                   <TooltipPrimitive.Trigger asChild>
                     <button

--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1245,7 +1245,7 @@ export function AppSidebar() {
                   </span>
                 </Link>
               )}
-              <div className="flex shrink-0 items-center gap-0.5">
+              <div className="flex shrink-0 items-center gap-0.25">
                 <Tooltip>
                   <TooltipPrimitive.Trigger asChild>
                     <button
@@ -1254,7 +1254,7 @@ export function AppSidebar() {
                         useChatSearchStore.getState().open();
                         closeMobileIfOpen();
                       }}
-                      className="inline-flex h-[33px] w-[32px] cursor-pointer items-center justify-center rounded-[10px] text-nav-icon-idle dark:text-nav-fg-muted transition-colors hover:bg-nav-surface-hover hover:text-black dark:hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                      className="inline-flex h-[33px] w-[28px] cursor-pointer items-center justify-center rounded-[10px] text-nav-icon-idle dark:text-nav-fg-muted transition-colors hover:bg-nav-surface-hover hover:text-black dark:hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                       aria-label={t("shell.navigation.search")}
                     >
                       <HugeiconsIcon icon={Search01Icon} strokeWidth={1.75} className="size-icon" />
@@ -1278,7 +1278,7 @@ export function AppSidebar() {
                       <button
                         type="button"
                         onClick={togglePinned}
-                        className="inline-flex h-[33px] w-[32px] cursor-pointer items-center justify-center rounded-[10px] text-nav-icon-idle dark:text-nav-fg-muted transition-colors hover:bg-nav-surface-hover hover:text-black dark:hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                        className="inline-flex h-[33px] w-[28px] cursor-pointer items-center justify-center rounded-[10px] text-nav-icon-idle dark:text-nav-fg-muted transition-colors hover:bg-nav-surface-hover hover:text-black dark:hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                         aria-label={t("shell.aria.closeSidebar")}
                       >
                         <HugeiconsIcon icon={LayoutAlignLeftIcon} strokeWidth={1.75} className="size-icon" />

--- a/studio/frontend/src/components/tauri/window-titlebar.tsx
+++ b/studio/frontend/src/components/tauri/window-titlebar.tsx
@@ -2,6 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { useSidebarPin } from "@/hooks/use-sidebar-pin";
+import { useSidebarWidth } from "@/hooks/use-sidebar-width";
 import { isTauri } from "@/lib/api-base";
 import { cn } from "@/lib/utils";
 import {
@@ -110,9 +111,12 @@ export function WindowTitlebar({
   const [enabled] = useState(shouldUseCustomWindowTitlebar);
   const [maximized, setMaximized] = useState(false);
   const { pinned, togglePinned } = useSidebarPin();
+  // The titlebar sits outside the sidebar wrapper, so it cannot inherit
+  // --sidebar-width. Read the resized width from the same store instead.
+  const { width } = useSidebarWidth();
   const sidebarWidth = showSidebarSurface
     ? pinned
-      ? "var(--studio-sidebar-expanded-width,17.5rem)"
+      ? `${width}px`
       : "var(--studio-sidebar-collapsed-width,3rem)"
     : "0px";
   const contentBorderLeft = pinned ? `calc(${sidebarWidth} + 12px)` : "0px";

--- a/studio/frontend/src/components/tauri/window-titlebar.tsx
+++ b/studio/frontend/src/components/tauri/window-titlebar.tsx
@@ -116,7 +116,8 @@ export function WindowTitlebar({
   const { width } = useSidebarWidth();
   const sidebarWidth = showSidebarSurface
     ? pinned
-      ? `${width}px`
+      ? // The live value only exists mid-drag; otherwise the committed width.
+        `var(--studio-sidebar-live-width, ${width}px)`
       : "var(--studio-sidebar-collapsed-width,3rem)"
     : "0px";
   const contentBorderLeft = pinned ? `calc(${sidebarWidth} + 12px)` : "0px";

--- a/studio/frontend/src/components/ui/panel-resize-handle.tsx
+++ b/studio/frontend/src/components/ui/panel-resize-handle.tsx
@@ -86,6 +86,9 @@ export function PanelResizeHandle({
   const targetRef = React.useRef<HTMLElement | null>(null)
   const frameRef = React.useRef(0)
   const pendingRef = React.useRef(0)
+  // What the pointer asked for, before the viewport cap. Committing the capped
+  // value instead would quietly downgrade a stored preference on a narrow window.
+  const rawRef = React.useRef(0)
   const committedRef = React.useRef(width)
   React.useEffect(() => {
     committedRef.current = width
@@ -142,6 +145,7 @@ export function PanelResizeHandle({
     const start = open ? width : measure()
     dragRef.current = { startX: event.clientX, startWidth: start, moved: false }
     pendingRef.current = start
+    rawRef.current = start
     targetRef.current?.setAttribute("data-resizing", "true")
     document.documentElement.setAttribute("data-panel-resizing", "true")
     setDragging(true)
@@ -158,6 +162,7 @@ export function PanelResizeHandle({
     drag.moved = true
 
     const next = drag.startWidth + delta
+    rawRef.current = next
     if (!open) {
       // Past the minimum, dragging the collapsed edge reopens it.
       if (next >= min) {
@@ -184,8 +189,9 @@ export function PanelResizeHandle({
     }
     // A drag below the minimum leaves the stored width alone.
     if (!open) return
-    // Commit the last requested width; a frame may still be queued.
-    setWidth(pendingRef.current)
+    // Commit what was asked for, not the capped paint, so a drag on a narrow
+    // window cannot shrink a larger stored preference. setWidth clamps.
+    setWidth(rawRef.current)
   }
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {

--- a/studio/frontend/src/components/ui/panel-resize-handle.tsx
+++ b/studio/frontend/src/components/ui/panel-resize-handle.tsx
@@ -29,6 +29,8 @@ export type PanelResizeHandleProps = {
   edge: "left" | "right"
   open: boolean
   width: number
+  /** Uncapped stored preference, so a capped drag does not lower it. */
+  stored: number
   min: number
   max: number
   clamp: (px: number) => number
@@ -42,6 +44,10 @@ export type PanelResizeHandleProps = {
   measure: () => number
   label: string
   toggleLabel: string
+  /** Translated tooltip copy; the caller owns the translation layer. */
+  collapseHint: string
+  expandHint: string
+  dragHint: string
   /** Shown in the tooltip when the panel has a toggle shortcut. */
   shortcut?: string
   dataSlot?: string
@@ -59,6 +65,7 @@ export function PanelResizeHandle({
   edge,
   open,
   width,
+  stored,
   min,
   max,
   clamp,
@@ -70,6 +77,9 @@ export function PanelResizeHandle({
   measure,
   label,
   toggleLabel,
+  collapseHint,
+  expandHint,
+  dragHint,
   shortcut,
   dataSlot = "panel-resize-handle",
   className,
@@ -79,6 +89,7 @@ export function PanelResizeHandle({
   const dragRef = React.useRef<DragState | null>(null)
   const [dragging, setDragging] = React.useState(false)
   const [hovered, setHovered] = React.useState(false)
+  const [focused, setFocused] = React.useState(false)
   const [isMacPlatform] = React.useState(() => getClientPlatform().includes("mac"))
   const hint = shortcut ? shortcut.replace("Mod", isMacPlatform ? "⌘" : "Ctrl+") : null
 
@@ -189,6 +200,10 @@ export function PanelResizeHandle({
     }
     // A drag below the minimum leaves the stored width alone.
     if (!open) return
+    // Capped: the visible edge is already at the cap, so an outward pull cannot
+    // express intent beyond it. Committing would silently lower the larger
+    // hidden preference. A deliberate inward drag still commits.
+    if (stored > max && rawRef.current >= max) return
     // Commit what was asked for, not the capped paint, so a drag on a narrow
     // window cannot shrink a larger stored preference. setWidth clamps.
     setWidth(rawRef.current)
@@ -211,6 +226,7 @@ export function PanelResizeHandle({
         if (event.key === outward) onToggle()
         return
       }
+      if (event.key === outward && stored > max && width >= max) return
       setWidth(width + (event.key === outward ? RESIZE_STEP : -RESIZE_STEP))
       return
     }
@@ -224,7 +240,7 @@ export function PanelResizeHandle({
   React.useEffect(() => endDrag, [endDrag])
 
   return (
-    <Tooltip open={hovered && !dragging}>
+    <Tooltip open={(hovered || focused) && !dragging}>
       <TooltipTrigger asChild>
         <button
           ref={ref}
@@ -233,9 +249,9 @@ export function PanelResizeHandle({
           data-dragging={dragging || undefined}
           aria-label={open ? label : toggleLabel}
           aria-orientation="vertical"
-          aria-valuenow={open ? width : min}
-          aria-valuemin={min}
-          aria-valuemax={max}
+          {...(open
+            ? { "aria-valuenow": width, "aria-valuemin": min, "aria-valuemax": max }
+            : {})}
           role="separator"
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
@@ -244,6 +260,8 @@ export function PanelResizeHandle({
           onKeyDown={handleKeyDown}
           onPointerEnter={() => setHovered(true)}
           onPointerLeave={() => setHovered(false)}
+          onFocus={(event) => setFocused(event.target.matches(":focus-visible"))}
+          onBlur={() => setFocused(false)}
           className={cn(
             "absolute inset-y-0 z-30 hidden w-2 touch-none select-none sm:block",
             edge === "left" ? "-left-1" : "-right-1",
@@ -257,6 +275,8 @@ export function PanelResizeHandle({
             "after:absolute after:inset-y-0 after:w-px after:bg-transparent after:transition-colors after:duration-150",
             edge === "left" ? "after:left-1" : "after:right-1",
             "hover:after:bg-sidebar-ring/25 data-dragging:after:bg-sidebar-ring/25",
+            // The app zeroes the native outline on buttons, so mark focus here.
+            "focus-visible:outline-none focus-visible:after:bg-sidebar-ring/60",
             className,
           )}
         />
@@ -268,10 +288,10 @@ export function PanelResizeHandle({
       >
         <span className="flex flex-col gap-px">
           <span>
-            {open ? "Click to collapse" : "Click to expand"}
+            {open ? collapseHint : expandHint}
             {hint ? ` ${hint}` : ""}
           </span>
-          <span className="opacity-70">Drag to resize</span>
+          <span className="opacity-70">{dragHint}</span>
         </span>
       </TooltipContent>
     </Tooltip>

--- a/studio/frontend/src/components/ui/panel-resize-handle.tsx
+++ b/studio/frontend/src/components/ui/panel-resize-handle.tsx
@@ -221,8 +221,9 @@ export function PanelResizeHandle({
     // The collapse/expand the label advertises, for keyboard users. Pointer-up
     // handles it for the mouse; a synthesized click never reaches it.
     if (event.key === "Enter" || event.key === " ") {
+      // preventDefault cancels the native click, so nothing follows to guard
+      // against; arming here would swallow the next assistive-tech click.
       event.preventDefault()
-      handledRef.current = true
       onToggle()
       return
     }

--- a/studio/frontend/src/components/ui/panel-resize-handle.tsx
+++ b/studio/frontend/src/components/ui/panel-resize-handle.tsx
@@ -133,10 +133,11 @@ export function PanelResizeHandle({
   )
 
   const endDrag = React.useCallback(() => {
-    // Any sequence that reached the element already decided the outcome, so the
-    // click the browser fires next must not toggle again. A cancelled drag ends
-    // here too, and must not collapse on release.
-    handledRef.current = true
+    // Only a sequence that actually started should suppress the click the
+    // browser sends next, whether it ended in a release or a cancel. This also
+    // runs as the effect cleanup, where no drag happened and a bare click from
+    // assistive tech must still get through.
+    if (dragRef.current) handledRef.current = true
     dragRef.current = null
     if (frameRef.current) {
       cancelAnimationFrame(frameRef.current)

--- a/studio/frontend/src/components/ui/panel-resize-handle.tsx
+++ b/studio/frontend/src/components/ui/panel-resize-handle.tsx
@@ -100,6 +100,9 @@ export function PanelResizeHandle({
   // What the pointer asked for, before the viewport cap. Committing the capped
   // value instead would quietly downgrade a stored preference on a narrow window.
   const rawRef = React.useRef(0)
+  // Set when a pointer or key sequence already toggled, so the click that
+  // follows does not toggle a second time.
+  const handledRef = React.useRef(false)
   const committedRef = React.useRef(width)
   React.useEffect(() => {
     committedRef.current = width
@@ -130,6 +133,10 @@ export function PanelResizeHandle({
   )
 
   const endDrag = React.useCallback(() => {
+    // Any sequence that reached the element already decided the outcome, so the
+    // click the browser fires next must not toggle again. A cancelled drag ends
+    // here too, and must not collapse on release.
+    handledRef.current = true
     dragRef.current = null
     if (frameRef.current) {
       cancelAnimationFrame(frameRef.current)
@@ -214,6 +221,7 @@ export function PanelResizeHandle({
     // handles it for the mouse; a synthesized click never reaches it.
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault()
+      handledRef.current = true
       onToggle()
       return
     }
@@ -248,16 +256,25 @@ export function PanelResizeHandle({
           data-slot={dataSlot}
           data-dragging={dragging || undefined}
           aria-label={open ? label : toggleLabel}
-          aria-orientation="vertical"
+          {...(open ? { "aria-orientation": "vertical" as const } : {})}
           {...(open
             ? { "aria-valuenow": width, "aria-valuemin": min, "aria-valuemax": max }
             : {})}
-          role="separator"
+          role={open ? "separator" : "button"}
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}
           onPointerCancel={endDrag}
           onKeyDown={handleKeyDown}
+          onClick={() => {
+            // Switch and voice control activate by dispatching a bare click
+            // with no pointer or key events, which nothing else here catches.
+            if (handledRef.current) {
+              handledRef.current = false
+              return
+            }
+            onToggle()
+          }}
           onPointerEnter={() => setHovered(true)}
           onPointerLeave={() => setHovered(false)}
           onFocus={(event) => setFocused(event.target.matches(":focus-visible"))}

--- a/studio/frontend/src/components/ui/panel-resize-handle.tsx
+++ b/studio/frontend/src/components/ui/panel-resize-handle.tsx
@@ -15,6 +15,8 @@ import { getClientPlatform } from "@/components/tauri/window-titlebar"
 
 /** Pointer travel (px) below which a drag counts as a plain click. */
 const DRAG_SLOP = 4
+/** A compatibility click lands immediately after pointer-up. */
+const CLICK_COMPAT_WINDOW_MS = 300
 /** Arrow-key resize step for keyboard users. */
 const RESIZE_STEP = 16
 
@@ -100,9 +102,11 @@ export function PanelResizeHandle({
   // What the pointer asked for, before the viewport cap. Committing the capped
   // value instead would quietly downgrade a stored preference on a narrow window.
   const rawRef = React.useRef(0)
-  // Set when a pointer or key sequence already toggled, so the click that
-  // follows does not toggle a second time.
-  const handledRef = React.useRef(false)
+  // When a pointer sequence last ended. The browser's compatibility click
+  // lands in the same tick, so only a click that close behind is a duplicate.
+  // A timestamp cannot go stale the way an armed flag does: a genuine cancel
+  // emits no click, and a later assistive-tech click still gets through.
+  const handledAtRef = React.useRef(0)
   const committedRef = React.useRef(width)
   React.useEffect(() => {
     committedRef.current = width
@@ -133,11 +137,9 @@ export function PanelResizeHandle({
   )
 
   const endDrag = React.useCallback(() => {
-    // Only a sequence that actually started should suppress the click the
-    // browser sends next, whether it ended in a release or a cancel. This also
-    // runs as the effect cleanup, where no drag happened and a bare click from
-    // assistive tech must still get through.
-    if (dragRef.current) handledRef.current = true
+    // Only a sequence that actually started can produce a compatibility click.
+    // This also runs as the effect cleanup, where no drag happened.
+    if (dragRef.current) handledAtRef.current = Date.now()
     dragRef.current = null
     if (frameRef.current) {
       cancelAnimationFrame(frameRef.current)
@@ -271,10 +273,7 @@ export function PanelResizeHandle({
           onClick={() => {
             // Switch and voice control activate by dispatching a bare click
             // with no pointer or key events, which nothing else here catches.
-            if (handledRef.current) {
-              handledRef.current = false
-              return
-            }
+            if (Date.now() - handledAtRef.current < CLICK_COMPAT_WINDOW_MS) return
             onToggle()
           }}
           onPointerEnter={() => setHovered(true)}

--- a/studio/frontend/src/components/ui/panel-resize-handle.tsx
+++ b/studio/frontend/src/components/ui/panel-resize-handle.tsx
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { getClientPlatform } from "@/components/tauri/window-titlebar"
+
+/** Pointer travel (px) below which a drag counts as a plain click. */
+const DRAG_SLOP = 4
+/** Arrow-key resize step for keyboard users. */
+const RESIZE_STEP = 16
+
+type DragState = {
+  startX: number
+  startWidth: number
+  moved: boolean
+}
+
+export type PanelResizeHandleProps = {
+  /** Which edge of the panel the handle sits on. */
+  edge: "left" | "right"
+  open: boolean
+  width: number
+  min: number
+  max: number
+  clamp: (px: number) => number
+  setWidth: (px: number) => void
+  resetWidth: () => void
+  onToggle: () => void
+  /** Element to paint the live width onto, and the property to paint. */
+  target: () => HTMLElement | null
+  cssVar: string
+  /** Measured to start a drag from the rendered size when collapsed. */
+  measure: () => number
+  label: string
+  toggleLabel: string
+  /** Shown in the tooltip when the panel has a toggle shortcut. */
+  shortcut?: string
+  dataSlot?: string
+  className?: string
+  /** Mirrors the live width onto :root for chrome outside the panel. */
+  rootVar?: string
+}
+
+/**
+ * A draggable panel edge: drag to resize, click to collapse or expand. Arrow
+ * keys resize, Home restores the default. The width is painted straight to the
+ * target while dragging and only persisted on release.
+ */
+export function PanelResizeHandle({
+  edge,
+  open,
+  width,
+  min,
+  max,
+  clamp,
+  setWidth,
+  resetWidth,
+  onToggle,
+  target,
+  cssVar,
+  measure,
+  label,
+  toggleLabel,
+  shortcut,
+  dataSlot = "panel-resize-handle",
+  className,
+  rootVar,
+}: PanelResizeHandleProps) {
+  const ref = React.useRef<HTMLButtonElement>(null)
+  const dragRef = React.useRef<DragState | null>(null)
+  const [dragging, setDragging] = React.useState(false)
+  const [hovered, setHovered] = React.useState(false)
+  const [isMacPlatform] = React.useState(() => getClientPlatform().includes("mac"))
+  const hint = shortcut ? shortcut.replace("Mod", isMacPlatform ? "⌘" : "Ctrl+") : null
+
+  // Cached on pointer down so no DOM walk per move.
+  const targetRef = React.useRef<HTMLElement | null>(null)
+  const frameRef = React.useRef(0)
+  const pendingRef = React.useRef(0)
+  const committedRef = React.useRef(width)
+  React.useEffect(() => {
+    committedRef.current = width
+  }, [width])
+
+  const paint = React.useCallback(
+    (value: string) => {
+      targetRef.current?.style.setProperty(cssVar, value)
+      if (rootVar) {
+        document.documentElement.style.setProperty(rootVar, value)
+      }
+    },
+    [cssVar, rootVar],
+  )
+
+  // Resizing relayouts the whole shell, and pointermove fires faster than the
+  // display refreshes, so coalesce to one paint per frame.
+  const paintWidth = React.useCallback(
+    (px: number) => {
+      pendingRef.current = px
+      if (frameRef.current) return
+      frameRef.current = requestAnimationFrame(() => {
+        frameRef.current = 0
+        paint(`${pendingRef.current}px`)
+      })
+    },
+    [paint],
+  )
+
+  const endDrag = React.useCallback(() => {
+    dragRef.current = null
+    if (frameRef.current) {
+      cancelAnimationFrame(frameRef.current)
+      frameRef.current = 0
+    }
+    // Hand the property back to the committed value. A commit re-renders with
+    // the new width; a cancel or a no-commit drag keeps DOM and store in step.
+    paint(`${committedRef.current}px`)
+    if (rootVar) document.documentElement.style.removeProperty(rootVar)
+    targetRef.current?.removeAttribute("data-resizing")
+    document.documentElement.removeAttribute("data-panel-resizing")
+    targetRef.current = null
+    setDragging(false)
+    document.body.style.removeProperty("cursor")
+    document.body.style.removeProperty("user-select")
+  }, [paint, rootVar])
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLButtonElement>) => {
+    if (event.button !== 0) return
+    event.preventDefault()
+    event.currentTarget.setPointerCapture(event.pointerId)
+    targetRef.current = target()
+    // Collapsed: grow from the rendered size so the edge tracks the pointer.
+    const start = open ? width : measure()
+    dragRef.current = { startX: event.clientX, startWidth: start, moved: false }
+    pendingRef.current = start
+    targetRef.current?.setAttribute("data-resizing", "true")
+    document.documentElement.setAttribute("data-panel-resizing", "true")
+    setDragging(true)
+    document.body.style.setProperty("cursor", "col-resize")
+    document.body.style.setProperty("user-select", "none")
+  }
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLButtonElement>) => {
+    const drag = dragRef.current
+    if (!drag) return
+    // A panel whose handle is on its left edge grows as the pointer moves left.
+    const delta = (edge === "left" ? -1 : 1) * (event.clientX - drag.startX)
+    if (!drag.moved && Math.abs(delta) < DRAG_SLOP) return
+    drag.moved = true
+
+    const next = drag.startWidth + delta
+    if (!open) {
+      // Past the minimum, dragging the collapsed edge reopens it.
+      if (next >= min) {
+        paintWidth(clamp(next))
+        onToggle()
+      }
+      return
+    }
+    // Dragging inward stops at the minimum. Collapsing is click or the shortcut.
+    paintWidth(clamp(next))
+  }
+
+  const handlePointerUp = (event: React.PointerEvent<HTMLButtonElement>) => {
+    const drag = dragRef.current
+    if (!drag) return
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
+    endDrag()
+
+    if (!drag.moved) {
+      onToggle()
+      return
+    }
+    // A drag below the minimum leaves the stored width alone.
+    if (!open) return
+    // Commit the last requested width; a frame may still be queued.
+    setWidth(pendingRef.current)
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    // The collapse/expand the label advertises, for keyboard users. Pointer-up
+    // handles it for the mouse; a synthesized click never reaches it.
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault()
+      onToggle()
+      return
+    }
+    const outward = edge === "left" ? "ArrowLeft" : "ArrowRight"
+    const inward = edge === "left" ? "ArrowRight" : "ArrowLeft"
+    if (event.key === outward || event.key === inward) {
+      event.preventDefault()
+      if (!open) {
+        // Collapsed there is nothing to resize, so the outward arrow reopens.
+        if (event.key === outward) onToggle()
+        return
+      }
+      setWidth(width + (event.key === outward ? RESIZE_STEP : -RESIZE_STEP))
+      return
+    }
+    if (event.key === "Home") {
+      event.preventDefault()
+      resetWidth()
+    }
+  }
+
+  // Clear a stuck cursor override if we unmount mid-drag.
+  React.useEffect(() => endDrag, [endDrag])
+
+  return (
+    <Tooltip open={hovered && !dragging}>
+      <TooltipTrigger asChild>
+        <button
+          ref={ref}
+          type="button"
+          data-slot={dataSlot}
+          data-dragging={dragging || undefined}
+          aria-label={open ? label : toggleLabel}
+          aria-orientation="vertical"
+          aria-valuenow={open ? width : min}
+          aria-valuemin={min}
+          aria-valuemax={max}
+          role="separator"
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={endDrag}
+          onKeyDown={handleKeyDown}
+          onPointerEnter={() => setHovered(true)}
+          onPointerLeave={() => setHovered(false)}
+          className={cn(
+            "absolute inset-y-0 z-30 hidden w-2 touch-none select-none sm:block",
+            edge === "left" ? "-left-1" : "-right-1",
+            // `!` overrides the app-wide hand cursor on buttons.
+            open
+              ? "cursor-col-resize!"
+              : edge === "left"
+                ? "cursor-w-resize!"
+                : "cursor-e-resize!",
+            // Sits exactly on the panel border so hover recolours one line.
+            "after:absolute after:inset-y-0 after:w-px after:bg-transparent after:transition-colors after:duration-150",
+            edge === "left" ? "after:left-1" : "after:right-1",
+            "hover:after:bg-sidebar-ring/25 data-dragging:after:bg-sidebar-ring/25",
+            className,
+          )}
+        />
+      </TooltipTrigger>
+      <TooltipContent
+        side={edge === "left" ? "left" : "right"}
+        align="center"
+        className="tooltip-compact"
+      >
+        <span className="flex flex-col gap-px">
+          <span>
+            {open ? "Click to collapse" : "Click to expand"}
+            {hint ? ` ${hint}` : ""}
+          </span>
+          <span className="opacity-70">Drag to resize</span>
+        </span>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/studio/frontend/src/components/ui/sidebar.tsx
+++ b/studio/frontend/src/components/ui/sidebar.tsx
@@ -25,6 +25,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { PanelResizeHandle } from "@/components/ui/panel-resize-handle"
+import { useT } from "@/i18n"
 import { useIsMobile } from "@/hooks/use-mobile"
 import {
   SIDEBAR_WIDTH_DEFAULT,
@@ -54,6 +55,7 @@ type SidebarContextProps = {
   setPinned: (value: boolean) => void
   togglePinned: () => void
   width: number
+  storedWidth: number
   maxWidth: number
   setWidth: (value: number) => void
   resetWidth: () => void
@@ -91,7 +93,13 @@ function SidebarProvider({
 }) {
   const isMobile = useIsMobile()
   const [openMobile, setOpenMobile] = React.useState(false)
-  const { width, max: maxWidth, setWidth, resetWidth } = useSidebarWidth()
+  const {
+    width,
+    max: maxWidth,
+    stored: storedWidth,
+    setWidth,
+    resetWidth,
+  } = useSidebarWidth()
 
   const prevIsMobileRef = React.useRef(isMobile)
   React.useEffect(() => {
@@ -176,11 +184,12 @@ function SidebarProvider({
       setPinned,
       togglePinned,
       width,
+      storedWidth,
       maxWidth,
       setWidth,
       resetWidth,
     }),
-    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar, hasPinMode, pinned, setPinned, togglePinned, width, maxWidth, setWidth, resetWidth]
+    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar, hasPinMode, pinned, setPinned, togglePinned, width, storedWidth, maxWidth, setWidth, resetWidth]
   )
 
   return (
@@ -344,8 +353,10 @@ function SidebarResizeHandle({
   className?: string
   side?: "left" | "right"
 }) {
-  const { open, toggleSidebar, width, maxWidth, setWidth, resetWidth } = useSidebar()
+  const { open, toggleSidebar, width, storedWidth, maxWidth, setWidth, resetWidth } =
+    useSidebar()
   const ref = React.useRef<HTMLDivElement>(null)
+  const t = useT()
 
   return (
     <div ref={ref} className="contents">
@@ -353,6 +364,7 @@ function SidebarResizeHandle({
         edge={side === "right" ? "left" : "right"}
         open={open}
         width={width}
+        stored={storedWidth}
         min={SIDEBAR_WIDTH_MIN}
         max={maxWidth}
         clamp={clampSidebarWidth}
@@ -370,8 +382,11 @@ function SidebarResizeHandle({
             ?.closest<HTMLElement>('[data-slot="sidebar-container"]')
             ?.getBoundingClientRect().width ?? SIDEBAR_WIDTH_MIN
         }
-        label="Resize or collapse sidebar"
-        toggleLabel="Expand sidebar"
+        label={t("shell.aria.resizeSidebar")}
+        toggleLabel={t("shell.aria.openSidebar")}
+        collapseHint={t("shell.resize.collapse")}
+        expandHint={t("shell.resize.expand")}
+        dragHint={t("shell.resize.drag")}
         shortcut="ModB"
         dataSlot="sidebar-resize-handle"
         className={className}

--- a/studio/frontend/src/components/ui/sidebar.tsx
+++ b/studio/frontend/src/components/ui/sidebar.tsx
@@ -24,13 +24,21 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { getClientPlatform } from "@/components/tauri/window-titlebar"
 import { useIsMobile } from "@/hooks/use-mobile"
+import {
+  SIDEBAR_WIDTH_DEFAULT,
+  SIDEBAR_WIDTH_MAX,
+  SIDEBAR_WIDTH_MIN,
+  clampSidebarWidth,
+  useSidebarWidth,
+} from "@/hooks/use-sidebar-width"
 import { HugeiconsIcon } from "@hugeicons/react"
 import { LayoutAlignLeftIcon } from "@hugeicons/core-free-icons"
 
 const noop = () => {}
 
-const SIDEBAR_WIDTH = "17.5rem"
+const SIDEBAR_WIDTH = `${SIDEBAR_WIDTH_DEFAULT}px`
 const SIDEBAR_WIDTH_ICON = "3rem"
 const SIDEBAR_KEYBOARD_SHORTCUT = "b"
 
@@ -46,6 +54,9 @@ type SidebarContextProps = {
   pinned: boolean
   setPinned: (value: boolean) => void
   togglePinned: () => void
+  width: number
+  setWidth: (value: number) => void
+  resetWidth: () => void
 }
 
 const SidebarContext = React.createContext<SidebarContextProps | null>(null)
@@ -80,6 +91,7 @@ function SidebarProvider({
 }) {
   const isMobile = useIsMobile()
   const [openMobile, setOpenMobile] = React.useState(false)
+  const { width, setWidth, resetWidth } = useSidebarWidth()
 
   const prevIsMobileRef = React.useRef(isMobile)
   React.useEffect(() => {
@@ -163,8 +175,11 @@ function SidebarProvider({
       pinned,
       setPinned,
       togglePinned,
+      width,
+      setWidth,
+      resetWidth,
     }),
-    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar, hasPinMode, pinned, setPinned, togglePinned]
+    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar, hasPinMode, pinned, setPinned, togglePinned, width, setWidth, resetWidth]
   )
 
   return (
@@ -173,7 +188,8 @@ function SidebarProvider({
         data-slot="sidebar-wrapper"
         style={
           {
-            "--sidebar-width": SIDEBAR_WIDTH,
+            // The drag handle writes this same property live while resizing.
+            "--sidebar-width": `${width}px`,
             "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
             ...style,
           } as React.CSSProperties
@@ -311,8 +327,194 @@ function Sidebar({
         >
           {children}
         </div>
+        <SidebarResizeHandle />
       </div>
     </div>
+  )
+}
+
+/** Pointer travel (px) below which a drag counts as a plain click. */
+const SIDEBAR_DRAG_SLOP = 4
+/** Arrow-key resize step for keyboard users. */
+const SIDEBAR_RESIZE_STEP = 16
+
+type SidebarDragState = {
+  startX: number
+  startWidth: number
+  moved: boolean
+}
+
+/**
+ * Sidebar edge: drag to resize, click to collapse or expand. Arrow keys
+ * resize, Home restores the default. The width is painted straight to the
+ * wrapper while dragging and only persisted on release.
+ */
+function SidebarResizeHandle({ className }: { className?: string }) {
+  const { open, toggleSidebar, width, setWidth, resetWidth } = useSidebar()
+  const ref = React.useRef<HTMLButtonElement>(null)
+  const dragRef = React.useRef<SidebarDragState | null>(null)
+  const [dragging, setDragging] = React.useState(false)
+  const [hovered, setHovered] = React.useState(false)
+  const [isMacPlatform] = React.useState(() => getClientPlatform().includes("mac"))
+
+  // Cached on pointer down so no DOM walk per move.
+  const wrapperRef = React.useRef<HTMLElement | null>(null)
+  const frameRef = React.useRef(0)
+  const pendingRef = React.useRef(0)
+
+  const wrapper = () =>
+    wrapperRef.current ??
+    ref.current?.closest<HTMLElement>('[data-slot="sidebar-wrapper"]') ??
+    null
+
+  // Resizing relayouts the whole shell, and pointermove fires faster than the
+  // display refreshes, so coalesce to one paint per frame.
+  const paintWidth = React.useCallback((px: number) => {
+    pendingRef.current = px
+    if (frameRef.current) return
+    frameRef.current = requestAnimationFrame(() => {
+      frameRef.current = 0
+      wrapperRef.current?.style.setProperty(
+        "--sidebar-width",
+        `${pendingRef.current}px`,
+      )
+    })
+  }, [])
+
+  const endDrag = React.useCallback(() => {
+    dragRef.current = null
+    if (frameRef.current) {
+      cancelAnimationFrame(frameRef.current)
+      frameRef.current = 0
+      // Flush the queued frame instead of dropping it.
+      wrapperRef.current?.style.setProperty(
+        "--sidebar-width",
+        `${pendingRef.current}px`,
+      )
+    }
+    wrapperRef.current?.removeAttribute("data-resizing")
+    wrapperRef.current = null
+    setDragging(false)
+    document.body.style.removeProperty("cursor")
+    document.body.style.removeProperty("user-select")
+  }, [])
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLButtonElement>) => {
+    if (event.button !== 0) return
+    event.preventDefault()
+    event.currentTarget.setPointerCapture(event.pointerId)
+    wrapperRef.current =
+      ref.current?.closest<HTMLElement>('[data-slot="sidebar-wrapper"]') ?? null
+    // Collapsed: grow from the measured rail so the edge tracks the pointer.
+    const wrapperLeft = wrapper()?.getBoundingClientRect().left ?? 0
+    const railWidth = (ref.current?.getBoundingClientRect().left ?? wrapperLeft) - wrapperLeft
+    dragRef.current = {
+      startX: event.clientX,
+      startWidth: open ? width : railWidth,
+      moved: false,
+    }
+    pendingRef.current = open ? width : railWidth
+    wrapperRef.current?.setAttribute("data-resizing", "true")
+    setDragging(true)
+    document.body.style.setProperty("cursor", "col-resize")
+    document.body.style.setProperty("user-select", "none")
+  }
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLButtonElement>) => {
+    const drag = dragRef.current
+    if (!drag) return
+    const delta = event.clientX - drag.startX
+    if (!drag.moved && Math.abs(delta) < SIDEBAR_DRAG_SLOP) return
+    drag.moved = true
+
+    const next = drag.startWidth + delta
+    if (!open) {
+      // Past the minimum, dragging the collapsed rail reopens it.
+      if (next >= SIDEBAR_WIDTH_MIN) {
+        paintWidth(clampSidebarWidth(next))
+        toggleSidebar()
+      }
+      return
+    }
+    // Dragging inward stops at the minimum. Collapsing is click or Cmd+B only.
+    paintWidth(clampSidebarWidth(next))
+  }
+
+  const handlePointerUp = (event: React.PointerEvent<HTMLButtonElement>) => {
+    const drag = dragRef.current
+    if (!drag) return
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
+    endDrag()
+
+    if (!drag.moved) {
+      toggleSidebar()
+      return
+    }
+    // Rail drag that never hit the minimum: leave the stored width alone.
+    if (!open) return
+    // Commit the last requested width; a frame may still be queued.
+    setWidth(pendingRef.current)
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
+      if (!open) return
+      event.preventDefault()
+      const step = event.key === "ArrowLeft" ? -SIDEBAR_RESIZE_STEP : SIDEBAR_RESIZE_STEP
+      setWidth(width + step)
+      return
+    }
+    if (event.key === "Home") {
+      event.preventDefault()
+      resetWidth()
+    }
+  }
+
+  // Clear a stuck cursor override if we unmount mid-drag.
+  React.useEffect(() => endDrag, [endDrag])
+
+  return (
+    <Tooltip open={hovered && !dragging}>
+      <TooltipTrigger asChild>
+        <button
+          ref={ref}
+          type="button"
+          data-slot="sidebar-resize-handle"
+          data-sidebar="resize-handle"
+          data-dragging={dragging || undefined}
+          aria-label={open ? "Resize or collapse sidebar" : "Expand sidebar"}
+          aria-orientation="vertical"
+          aria-valuenow={open ? width : SIDEBAR_WIDTH_MIN}
+          aria-valuemin={SIDEBAR_WIDTH_MIN}
+          aria-valuemax={SIDEBAR_WIDTH_MAX}
+          role="separator"
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={endDrag}
+          onKeyDown={handleKeyDown}
+          onPointerEnter={() => setHovered(true)}
+          onPointerLeave={() => setHovered(false)}
+          className={cn(
+            "absolute inset-y-0 -right-1 z-30 hidden w-2 touch-none select-none sm:block",
+            // `!` overrides the app-wide hand cursor on buttons.
+            open ? "cursor-col-resize!" : "cursor-e-resize!",
+            // Sits exactly on the sidebar border so hover recolours one line.
+            "after:absolute after:inset-y-0 after:right-1 after:w-px after:bg-transparent after:transition-colors after:duration-150",
+            "hover:after:bg-sidebar-ring/25 data-dragging:after:bg-sidebar-ring/25",
+            className
+          )}
+        />
+      </TooltipTrigger>
+      <TooltipContent side="right" align="center" className="tooltip-compact">
+        <span className="flex flex-col gap-px">
+          <span>{open ? "Click to collapse" : "Click to expand"} {isMacPlatform ? "⌘B" : "Ctrl+B"}</span>
+          <span className="opacity-70">Drag to resize</span>
+        </span>
+      </TooltipContent>
+    </Tooltip>
   )
 }
 
@@ -777,6 +979,7 @@ export {
   SidebarMenuSubItem,
   SidebarProvider,
   SidebarRail,
+  SidebarResizeHandle,
   SidebarSeparator,
   SidebarTrigger,
   useSidebar,

--- a/studio/frontend/src/components/ui/sidebar.tsx
+++ b/studio/frontend/src/components/ui/sidebar.tsx
@@ -24,11 +24,10 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
-import { getClientPlatform } from "@/components/tauri/window-titlebar"
+import { PanelResizeHandle } from "@/components/ui/panel-resize-handle"
 import { useIsMobile } from "@/hooks/use-mobile"
 import {
   SIDEBAR_WIDTH_DEFAULT,
-  SIDEBAR_WIDTH_MAX,
   SIDEBAR_WIDTH_MIN,
   clampSidebarWidth,
   useSidebarWidth,
@@ -55,6 +54,7 @@ type SidebarContextProps = {
   setPinned: (value: boolean) => void
   togglePinned: () => void
   width: number
+  maxWidth: number
   setWidth: (value: number) => void
   resetWidth: () => void
 }
@@ -91,7 +91,7 @@ function SidebarProvider({
 }) {
   const isMobile = useIsMobile()
   const [openMobile, setOpenMobile] = React.useState(false)
-  const { width, setWidth, resetWidth } = useSidebarWidth()
+  const { width, max: maxWidth, setWidth, resetWidth } = useSidebarWidth()
 
   const prevIsMobileRef = React.useRef(isMobile)
   React.useEffect(() => {
@@ -176,10 +176,11 @@ function SidebarProvider({
       setPinned,
       togglePinned,
       width,
+      maxWidth,
       setWidth,
       resetWidth,
     }),
-    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar, hasPinMode, pinned, setPinned, togglePinned, width, setWidth, resetWidth]
+    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar, hasPinMode, pinned, setPinned, togglePinned, width, maxWidth, setWidth, resetWidth]
   )
 
   return (
@@ -333,21 +334,8 @@ function Sidebar({
   )
 }
 
-/** Pointer travel (px) below which a drag counts as a plain click. */
-const SIDEBAR_DRAG_SLOP = 4
-/** Arrow-key resize step for keyboard users. */
-const SIDEBAR_RESIZE_STEP = 16
-
-type SidebarDragState = {
-  startX: number
-  startWidth: number
-  moved: boolean
-}
-
 /**
- * Sidebar edge: drag to resize, click to collapse or expand. Arrow keys
- * resize, Home restores the default. The width is painted straight to the
- * wrapper while dragging and only persisted on release.
+ * The sidebar's draggable edge, over the shared panel handle.
  */
 function SidebarResizeHandle({
   className,
@@ -356,185 +344,39 @@ function SidebarResizeHandle({
   className?: string
   side?: "left" | "right"
 }) {
-  const { open, toggleSidebar, width, setWidth, resetWidth } = useSidebar()
-  const ref = React.useRef<HTMLButtonElement>(null)
-  const dragRef = React.useRef<SidebarDragState | null>(null)
-  const [dragging, setDragging] = React.useState(false)
-  const [hovered, setHovered] = React.useState(false)
-  const [isMacPlatform] = React.useState(() => getClientPlatform().includes("mac"))
-
-  // Cached on pointer down so no DOM walk per move.
-  const wrapperRef = React.useRef<HTMLElement | null>(null)
-  const frameRef = React.useRef(0)
-  const pendingRef = React.useRef(0)
-  const committedRef = React.useRef(width)
-  React.useEffect(() => {
-    committedRef.current = width
-  }, [width])
-
-  // Resizing relayouts the whole shell, and pointermove fires faster than the
-  // display refreshes, so coalesce to one paint per frame.
-  const paintWidth = React.useCallback((px: number) => {
-    pendingRef.current = px
-    if (frameRef.current) return
-    frameRef.current = requestAnimationFrame(() => {
-      frameRef.current = 0
-      wrapperRef.current?.style.setProperty(
-        "--sidebar-width",
-        `${pendingRef.current}px`,
-      )
-    })
-  }, [])
-
-  const endDrag = React.useCallback(() => {
-    dragRef.current = null
-    if (frameRef.current) {
-      cancelAnimationFrame(frameRef.current)
-      frameRef.current = 0
-    }
-    // Hand the property back to the committed value. A commit re-renders with
-    // the new width; a cancel or a no-commit drag keeps DOM and store in step.
-    wrapperRef.current?.style.setProperty(
-      "--sidebar-width",
-      `${committedRef.current}px`,
-    )
-    wrapperRef.current?.removeAttribute("data-resizing")
-    wrapperRef.current = null
-    setDragging(false)
-    document.body.style.removeProperty("cursor")
-    document.body.style.removeProperty("user-select")
-  }, [])
-
-  const handlePointerDown = (event: React.PointerEvent<HTMLButtonElement>) => {
-    if (event.button !== 0) return
-    event.preventDefault()
-    event.currentTarget.setPointerCapture(event.pointerId)
-    wrapperRef.current =
-      ref.current?.closest<HTMLElement>('[data-slot="sidebar-wrapper"]') ?? null
-    // Collapsed: grow from the rendered rail so the edge tracks the pointer.
-    const railWidth =
-      ref.current
-        ?.closest<HTMLElement>('[data-slot="sidebar-container"]')
-        ?.getBoundingClientRect().width ?? SIDEBAR_WIDTH_MIN
-    dragRef.current = {
-      startX: event.clientX,
-      startWidth: open ? width : railWidth,
-      moved: false,
-    }
-    pendingRef.current = open ? width : railWidth
-    wrapperRef.current?.setAttribute("data-resizing", "true")
-    setDragging(true)
-    document.body.style.setProperty("cursor", "col-resize")
-    document.body.style.setProperty("user-select", "none")
-  }
-
-  const handlePointerMove = (event: React.PointerEvent<HTMLButtonElement>) => {
-    const drag = dragRef.current
-    if (!drag) return
-    // A right sidebar grows as the pointer moves left.
-    const delta =
-      (side === "right" ? -1 : 1) * (event.clientX - drag.startX)
-    if (!drag.moved && Math.abs(delta) < SIDEBAR_DRAG_SLOP) return
-    drag.moved = true
-
-    const next = drag.startWidth + delta
-    if (!open) {
-      // Past the minimum, dragging the collapsed rail reopens it.
-      if (next >= SIDEBAR_WIDTH_MIN) {
-        paintWidth(clampSidebarWidth(next))
-        toggleSidebar()
-      }
-      return
-    }
-    // Dragging inward stops at the minimum. Collapsing is click or Cmd+B only.
-    paintWidth(clampSidebarWidth(next))
-  }
-
-  const handlePointerUp = (event: React.PointerEvent<HTMLButtonElement>) => {
-    const drag = dragRef.current
-    if (!drag) return
-    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-      event.currentTarget.releasePointerCapture(event.pointerId)
-    }
-    endDrag()
-
-    if (!drag.moved) {
-      toggleSidebar()
-      return
-    }
-    // Rail drag that never hit the minimum: leave the stored width alone.
-    if (!open) return
-    // Commit the last requested width; a frame may still be queued.
-    setWidth(pendingRef.current)
-  }
-
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
-    if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
-      if (!open) return
-      event.preventDefault()
-      const step = event.key === "ArrowLeft" ? -SIDEBAR_RESIZE_STEP : SIDEBAR_RESIZE_STEP
-      setWidth(width + step)
-      return
-    }
-    if (event.key === "Home") {
-      event.preventDefault()
-      resetWidth()
-    }
-  }
-
-  // Clear a stuck cursor override if we unmount mid-drag.
-  React.useEffect(() => endDrag, [endDrag])
+  const { open, toggleSidebar, width, maxWidth, setWidth, resetWidth } = useSidebar()
+  const ref = React.useRef<HTMLDivElement>(null)
 
   return (
-    <Tooltip open={hovered && !dragging}>
-      <TooltipTrigger asChild>
-        <button
-          ref={ref}
-          type="button"
-          data-slot="sidebar-resize-handle"
-          data-sidebar="resize-handle"
-          data-dragging={dragging || undefined}
-          aria-label={open ? "Resize or collapse sidebar" : "Expand sidebar"}
-          aria-orientation="vertical"
-          aria-valuenow={open ? width : SIDEBAR_WIDTH_MIN}
-          aria-valuemin={SIDEBAR_WIDTH_MIN}
-          aria-valuemax={SIDEBAR_WIDTH_MAX}
-          role="separator"
-          onPointerDown={handlePointerDown}
-          onPointerMove={handlePointerMove}
-          onPointerUp={handlePointerUp}
-          onPointerCancel={endDrag}
-          onKeyDown={handleKeyDown}
-          onPointerEnter={() => setHovered(true)}
-          onPointerLeave={() => setHovered(false)}
-          className={cn(
-            "absolute inset-y-0 z-30 hidden w-2 touch-none select-none sm:block",
-            side === "right" ? "-left-1" : "-right-1",
-            // `!` overrides the app-wide hand cursor on buttons.
-            open
-              ? "cursor-col-resize!"
-              : side === "right"
-                ? "cursor-w-resize!"
-                : "cursor-e-resize!",
-            // Sits exactly on the sidebar border so hover recolours one line.
-            "after:absolute after:inset-y-0 after:w-px after:bg-transparent after:transition-colors after:duration-150",
-            side === "right" ? "after:left-1" : "after:right-1",
-            "hover:after:bg-sidebar-ring/25 data-dragging:after:bg-sidebar-ring/25",
-            className
-          )}
-        />
-      </TooltipTrigger>
-      <TooltipContent
-        side={side === "right" ? "left" : "right"}
-        align="center"
-        className="tooltip-compact"
-      >
-        <span className="flex flex-col gap-px">
-          <span>{open ? "Click to collapse" : "Click to expand"} {isMacPlatform ? "⌘B" : "Ctrl+B"}</span>
-          <span className="opacity-70">Drag to resize</span>
-        </span>
-      </TooltipContent>
-    </Tooltip>
+    <div ref={ref} className="contents">
+      <PanelResizeHandle
+        edge={side === "right" ? "left" : "right"}
+        open={open}
+        width={width}
+        min={SIDEBAR_WIDTH_MIN}
+        max={maxWidth}
+        clamp={clampSidebarWidth}
+        setWidth={setWidth}
+        resetWidth={resetWidth}
+        onToggle={toggleSidebar}
+        target={() =>
+          ref.current?.closest<HTMLElement>('[data-slot="sidebar-wrapper"]') ?? null
+        }
+        cssVar="--sidebar-width"
+        // The custom titlebar renders outside the wrapper and cannot inherit it.
+        rootVar="--studio-sidebar-live-width"
+        measure={() =>
+          ref.current
+            ?.closest<HTMLElement>('[data-slot="sidebar-container"]')
+            ?.getBoundingClientRect().width ?? SIDEBAR_WIDTH_MIN
+        }
+        label="Resize or collapse sidebar"
+        toggleLabel="Expand sidebar"
+        shortcut="ModB"
+        dataSlot="sidebar-resize-handle"
+        className={className}
+      />
+    </div>
   )
 }
 

--- a/studio/frontend/src/components/ui/sidebar.tsx
+++ b/studio/frontend/src/components/ui/sidebar.tsx
@@ -327,7 +327,7 @@ function Sidebar({
         >
           {children}
         </div>
-        <SidebarResizeHandle />
+        <SidebarResizeHandle side={side} />
       </div>
     </div>
   )
@@ -349,7 +349,13 @@ type SidebarDragState = {
  * resize, Home restores the default. The width is painted straight to the
  * wrapper while dragging and only persisted on release.
  */
-function SidebarResizeHandle({ className }: { className?: string }) {
+function SidebarResizeHandle({
+  className,
+  side = "left",
+}: {
+  className?: string
+  side?: "left" | "right"
+}) {
   const { open, toggleSidebar, width, setWidth, resetWidth } = useSidebar()
   const ref = React.useRef<HTMLButtonElement>(null)
   const dragRef = React.useRef<SidebarDragState | null>(null)
@@ -361,11 +367,10 @@ function SidebarResizeHandle({ className }: { className?: string }) {
   const wrapperRef = React.useRef<HTMLElement | null>(null)
   const frameRef = React.useRef(0)
   const pendingRef = React.useRef(0)
-
-  const wrapper = () =>
-    wrapperRef.current ??
-    ref.current?.closest<HTMLElement>('[data-slot="sidebar-wrapper"]') ??
-    null
+  const committedRef = React.useRef(width)
+  React.useEffect(() => {
+    committedRef.current = width
+  }, [width])
 
   // Resizing relayouts the whole shell, and pointermove fires faster than the
   // display refreshes, so coalesce to one paint per frame.
@@ -386,12 +391,13 @@ function SidebarResizeHandle({ className }: { className?: string }) {
     if (frameRef.current) {
       cancelAnimationFrame(frameRef.current)
       frameRef.current = 0
-      // Flush the queued frame instead of dropping it.
-      wrapperRef.current?.style.setProperty(
-        "--sidebar-width",
-        `${pendingRef.current}px`,
-      )
     }
+    // Hand the property back to the committed value. A commit re-renders with
+    // the new width; a cancel or a no-commit drag keeps DOM and store in step.
+    wrapperRef.current?.style.setProperty(
+      "--sidebar-width",
+      `${committedRef.current}px`,
+    )
     wrapperRef.current?.removeAttribute("data-resizing")
     wrapperRef.current = null
     setDragging(false)
@@ -405,9 +411,11 @@ function SidebarResizeHandle({ className }: { className?: string }) {
     event.currentTarget.setPointerCapture(event.pointerId)
     wrapperRef.current =
       ref.current?.closest<HTMLElement>('[data-slot="sidebar-wrapper"]') ?? null
-    // Collapsed: grow from the measured rail so the edge tracks the pointer.
-    const wrapperLeft = wrapper()?.getBoundingClientRect().left ?? 0
-    const railWidth = (ref.current?.getBoundingClientRect().left ?? wrapperLeft) - wrapperLeft
+    // Collapsed: grow from the rendered rail so the edge tracks the pointer.
+    const railWidth =
+      ref.current
+        ?.closest<HTMLElement>('[data-slot="sidebar-container"]')
+        ?.getBoundingClientRect().width ?? SIDEBAR_WIDTH_MIN
     dragRef.current = {
       startX: event.clientX,
       startWidth: open ? width : railWidth,
@@ -423,7 +431,9 @@ function SidebarResizeHandle({ className }: { className?: string }) {
   const handlePointerMove = (event: React.PointerEvent<HTMLButtonElement>) => {
     const drag = dragRef.current
     if (!drag) return
-    const delta = event.clientX - drag.startX
+    // A right sidebar grows as the pointer moves left.
+    const delta =
+      (side === "right" ? -1 : 1) * (event.clientX - drag.startX)
     if (!drag.moved && Math.abs(delta) < SIDEBAR_DRAG_SLOP) return
     drag.moved = true
 
@@ -498,17 +508,27 @@ function SidebarResizeHandle({ className }: { className?: string }) {
           onPointerEnter={() => setHovered(true)}
           onPointerLeave={() => setHovered(false)}
           className={cn(
-            "absolute inset-y-0 -right-1 z-30 hidden w-2 touch-none select-none sm:block",
+            "absolute inset-y-0 z-30 hidden w-2 touch-none select-none sm:block",
+            side === "right" ? "-left-1" : "-right-1",
             // `!` overrides the app-wide hand cursor on buttons.
-            open ? "cursor-col-resize!" : "cursor-e-resize!",
+            open
+              ? "cursor-col-resize!"
+              : side === "right"
+                ? "cursor-w-resize!"
+                : "cursor-e-resize!",
             // Sits exactly on the sidebar border so hover recolours one line.
-            "after:absolute after:inset-y-0 after:right-1 after:w-px after:bg-transparent after:transition-colors after:duration-150",
+            "after:absolute after:inset-y-0 after:w-px after:bg-transparent after:transition-colors after:duration-150",
+            side === "right" ? "after:left-1" : "after:right-1",
             "hover:after:bg-sidebar-ring/25 data-dragging:after:bg-sidebar-ring/25",
             className
           )}
         />
       </TooltipTrigger>
-      <TooltipContent side="right" align="center" className="tooltip-compact">
+      <TooltipContent
+        side={side === "right" ? "left" : "right"}
+        align="center"
+        className="tooltip-compact"
+      >
         <span className="flex flex-col gap-px">
           <span>{open ? "Click to collapse" : "Click to expand"} {isMacPlatform ? "⌘B" : "Ctrl+B"}</span>
           <span className="opacity-70">Drag to resize</span>

--- a/studio/frontend/src/features/settings/tabs/general-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/general-tab.tsx
@@ -74,6 +74,7 @@ const PREFS_KEYS: string[] = [
   LOCALE_STORAGE_KEY,
   // UI state
   "sidebar_pinned",
+  "sidebar_width",
   "unsloth_sidebar_navigate_open",
   "unsloth_settings_active_tab",
   // Chat runtime prefs

--- a/studio/frontend/src/hooks/use-panel-width.ts
+++ b/studio/frontend/src/hooks/use-panel-width.ts
@@ -12,6 +12,8 @@ export type PanelWidthStore = {
   useWidth: () => {
     width: number;
     max: number;
+    /** The uncapped stored preference. */
+    stored: number;
     setWidth: (value: number) => void;
     resetWidth: () => void;
   };
@@ -65,16 +67,29 @@ export function createPanelWidthStore({
   let effectiveMax = maxWidth();
   const listeners = new Set<() => void>();
 
+  let lastStored = storedWidth;
+
   function recompute() {
     const nextWidth = clamp(storedWidth);
     const nextMax = maxWidth();
-    if (nextWidth === effectiveWidth && nextMax === effectiveMax) return;
+    if (
+      nextWidth === effectiveWidth &&
+      nextMax === effectiveMax &&
+      storedWidth === lastStored
+    ) {
+      return;
+    }
     effectiveWidth = nextWidth;
     effectiveMax = nextMax;
+    lastStored = storedWidth;
     listeners.forEach((cb) => cb());
   }
 
   function subscribe(cb: () => void) {
+    // With no subscribers there is no resize listener, so the cache can be
+    // stale after a resize on a route that hides every panel. Refresh first;
+    // useSyncExternalStore re-reads the snapshot right after subscribing.
+    recompute();
     listeners.add(cb);
     if (typeof window === "undefined") {
       return () => listeners.delete(cb);
@@ -112,9 +127,11 @@ export function createPanelWidthStore({
     const width = useSyncExternalStore(subscribe, () => effectiveWidth, () => fallback);
     // What the viewport actually allows right now, for aria-valuemax.
     const panelMax = useSyncExternalStore(subscribe, () => effectiveMax, () => max);
+    // The uncapped preference, so a capped drag can avoid lowering it.
+    const preference = useSyncExternalStore(subscribe, () => storedWidth, () => fallback);
     const setWidth = useCallback((value: number) => setWidthGlobal(value), []);
     const resetWidth = useCallback(() => setWidthGlobal(fallback), []);
-    return { width, max: panelMax, setWidth, resetWidth };
+    return { width, max: panelMax, stored: preference, setWidth, resetWidth };
   }
 
   return { clamp, useWidth };

--- a/studio/frontend/src/hooks/use-panel-width.ts
+++ b/studio/frontend/src/hooks/use-panel-width.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { useCallback, useSyncExternalStore } from "react";
+
+/** Never let one panel eat more than this share of a narrow window. */
+const MAX_VIEWPORT_FRACTION = 0.4;
+
+export type PanelWidthStore = {
+  /** Clamps to what the current viewport allows. */
+  clamp: (px: number) => number;
+  useWidth: () => {
+    width: number;
+    max: number;
+    setWidth: (value: number) => void;
+    resetWidth: () => void;
+  };
+};
+
+/**
+ * A persisted, viewport-aware width for a draggable panel. The preference is
+ * stored whole and an effective width is derived from it, so narrowing the
+ * window shrinks the panel without losing what the user picked.
+ */
+export function createPanelWidthStore({
+  key,
+  min,
+  max,
+  fallback,
+}: {
+  key: string;
+  min: number;
+  max: number;
+  fallback: number;
+}): PanelWidthStore {
+  function maxWidth(): number {
+    if (typeof window === "undefined") return max;
+    // The floor wins on a narrow window; collapsing is the escape.
+    return Math.max(min, Math.min(max, window.innerWidth * MAX_VIEWPORT_FRACTION));
+  }
+
+  /** Clamps to the absolute range, ignoring the viewport. */
+  function clampStored(px: number): number {
+    if (!Number.isFinite(px)) return fallback;
+    return Math.min(max, Math.max(min, Math.round(px)));
+  }
+
+  function clamp(px: number): number {
+    return Math.min(maxWidth(), clampStored(px));
+  }
+
+  function load(): number {
+    if (typeof window === "undefined") return fallback;
+    try {
+      const raw = window.localStorage.getItem(key);
+      if (raw === null) return fallback;
+      return clampStored(Number.parseFloat(raw));
+    } catch {
+      return fallback;
+    }
+  }
+
+  let storedWidth = load();
+  let effectiveWidth = clamp(storedWidth);
+  let effectiveMax = maxWidth();
+  const listeners = new Set<() => void>();
+
+  function recompute() {
+    const nextWidth = clamp(storedWidth);
+    const nextMax = maxWidth();
+    if (nextWidth === effectiveWidth && nextMax === effectiveMax) return;
+    effectiveWidth = nextWidth;
+    effectiveMax = nextMax;
+    listeners.forEach((cb) => cb());
+  }
+
+  function subscribe(cb: () => void) {
+    listeners.add(cb);
+    if (typeof window === "undefined") {
+      return () => listeners.delete(cb);
+    }
+    // Keep tabs in sync, same as the pin flag.
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === key || e.key === null) {
+        storedWidth = load();
+        effectiveWidth = clamp(storedWidth);
+        effectiveMax = maxWidth();
+        cb();
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    window.addEventListener("resize", recompute);
+    return () => {
+      listeners.delete(cb);
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener("resize", recompute);
+    };
+  }
+
+  function setWidthGlobal(next: number) {
+    const stored = clampStored(next);
+    if (stored !== storedWidth) {
+      storedWidth = stored;
+      try {
+        window.localStorage.setItem(key, String(stored));
+      } catch {}
+    }
+    recompute();
+  }
+
+  function useWidth() {
+    const width = useSyncExternalStore(subscribe, () => effectiveWidth, () => fallback);
+    // What the viewport actually allows right now, for aria-valuemax.
+    const panelMax = useSyncExternalStore(subscribe, () => effectiveMax, () => max);
+    const setWidth = useCallback((value: number) => setWidthGlobal(value), []);
+    const resetWidth = useCallback(() => setWidthGlobal(fallback), []);
+    return { width, max: panelMax, setWidth, resetWidth };
+  }
+
+  return { clamp, useWidth };
+}

--- a/studio/frontend/src/hooks/use-sidebar-width.ts
+++ b/studio/frontend/src/hooks/use-sidebar-width.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { useCallback, useSyncExternalStore } from "react";
+
+const WIDTH_KEY = "sidebar_width";
+
+/** The previous fixed 17.5rem, at a 16px root font size. */
+export const SIDEBAR_WIDTH_DEFAULT = 280;
+/** Header lockup plus the search and collapse buttons need ~258px. */
+export const SIDEBAR_WIDTH_MIN = 264;
+export const SIDEBAR_WIDTH_MAX = 480;
+const SIDEBAR_MAX_VIEWPORT_FRACTION = 0.4;
+
+function maxWidth(): number {
+  if (typeof window === "undefined") return SIDEBAR_WIDTH_MAX;
+  const viewportCap = window.innerWidth * SIDEBAR_MAX_VIEWPORT_FRACTION;
+  // The floor wins on a narrow window; collapsing is the escape.
+  return Math.max(SIDEBAR_WIDTH_MIN, Math.min(SIDEBAR_WIDTH_MAX, viewportCap));
+}
+
+export function clampSidebarWidth(px: number): number {
+  if (!Number.isFinite(px)) return SIDEBAR_WIDTH_DEFAULT;
+  return Math.min(maxWidth(), Math.max(SIDEBAR_WIDTH_MIN, Math.round(px)));
+}
+
+function loadWidth(): number {
+  if (typeof window === "undefined") return SIDEBAR_WIDTH_DEFAULT;
+  try {
+    const raw = window.localStorage.getItem(WIDTH_KEY);
+    if (raw === null) return SIDEBAR_WIDTH_DEFAULT;
+    const parsed = Number.parseFloat(raw);
+    if (!Number.isFinite(parsed)) return SIDEBAR_WIDTH_DEFAULT;
+    return clampSidebarWidth(parsed);
+  } catch {
+    return SIDEBAR_WIDTH_DEFAULT;
+  }
+}
+
+let widthValue = loadWidth();
+const listeners = new Set<() => void>();
+
+function subscribe(cb: () => void) {
+  listeners.add(cb);
+  if (typeof window === "undefined") {
+    return () => listeners.delete(cb);
+  }
+  // Keep tabs in sync, same as the pin flag.
+  const onStorage = (e: StorageEvent) => {
+    if (e.key === WIDTH_KEY || e.key === null) {
+      widthValue = loadWidth();
+      cb();
+    }
+  };
+  window.addEventListener("storage", onStorage);
+  return () => {
+    listeners.delete(cb);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+
+function setWidthGlobal(next: number) {
+  const clamped = clampSidebarWidth(next);
+  if (clamped === widthValue) return;
+  widthValue = clamped;
+  try {
+    window.localStorage.setItem(WIDTH_KEY, String(clamped));
+  } catch {}
+  listeners.forEach((cb) => cb());
+}
+
+export function useSidebarWidth() {
+  const width = useSyncExternalStore(
+    subscribe,
+    () => widthValue,
+    () => SIDEBAR_WIDTH_DEFAULT,
+  );
+
+  const setWidth = useCallback((value: number) => setWidthGlobal(value), []);
+  const resetWidth = useCallback(
+    () => setWidthGlobal(SIDEBAR_WIDTH_DEFAULT),
+    [],
+  );
+
+  return { width, setWidth, resetWidth };
+}

--- a/studio/frontend/src/hooks/use-sidebar-width.ts
+++ b/studio/frontend/src/hooks/use-sidebar-width.ts
@@ -1,107 +1,20 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { useCallback, useSyncExternalStore } from "react";
-
-const WIDTH_KEY = "sidebar_width";
+import { createPanelWidthStore } from "./use-panel-width.ts";
 
 /** The previous fixed 17.5rem, at a 16px root font size. */
 export const SIDEBAR_WIDTH_DEFAULT = 280;
 /** Header lockup plus the search and collapse buttons need ~258px. */
 export const SIDEBAR_WIDTH_MIN = 264;
 export const SIDEBAR_WIDTH_MAX = 480;
-const SIDEBAR_MAX_VIEWPORT_FRACTION = 0.4;
 
-function maxWidth(): number {
-  if (typeof window === "undefined") return SIDEBAR_WIDTH_MAX;
-  const viewportCap = window.innerWidth * SIDEBAR_MAX_VIEWPORT_FRACTION;
-  // The floor wins on a narrow window; collapsing is the escape.
-  return Math.max(SIDEBAR_WIDTH_MIN, Math.min(SIDEBAR_WIDTH_MAX, viewportCap));
-}
+const store = createPanelWidthStore({
+  key: "sidebar_width",
+  min: SIDEBAR_WIDTH_MIN,
+  max: SIDEBAR_WIDTH_MAX,
+  fallback: SIDEBAR_WIDTH_DEFAULT,
+});
 
-/** Clamps to the absolute range, ignoring the viewport. */
-function clampStored(px: number): number {
-  if (!Number.isFinite(px)) return SIDEBAR_WIDTH_DEFAULT;
-  return Math.min(
-    SIDEBAR_WIDTH_MAX,
-    Math.max(SIDEBAR_WIDTH_MIN, Math.round(px)),
-  );
-}
-
-/** Clamps to what the current viewport allows. */
-export function clampSidebarWidth(px: number): number {
-  return Math.min(maxWidth(), clampStored(px));
-}
-
-function loadWidth(): number {
-  if (typeof window === "undefined") return SIDEBAR_WIDTH_DEFAULT;
-  try {
-    const raw = window.localStorage.getItem(WIDTH_KEY);
-    if (raw === null) return SIDEBAR_WIDTH_DEFAULT;
-    return clampStored(Number.parseFloat(raw));
-  } catch {
-    return SIDEBAR_WIDTH_DEFAULT;
-  }
-}
-
-// The preference is stored whole; `effective` is what the viewport allows.
-// Narrowing the window shrinks the sidebar without losing the preference.
-let storedWidth = loadWidth();
-let effectiveWidth = clampSidebarWidth(storedWidth);
-const listeners = new Set<() => void>();
-
-function recompute() {
-  const next = clampSidebarWidth(storedWidth);
-  if (next === effectiveWidth) return;
-  effectiveWidth = next;
-  listeners.forEach((cb) => cb());
-}
-
-function subscribe(cb: () => void) {
-  listeners.add(cb);
-  if (typeof window === "undefined") {
-    return () => listeners.delete(cb);
-  }
-  // Keep tabs in sync, same as the pin flag.
-  const onStorage = (e: StorageEvent) => {
-    if (e.key === WIDTH_KEY || e.key === null) {
-      storedWidth = loadWidth();
-      effectiveWidth = clampSidebarWidth(storedWidth);
-      cb();
-    }
-  };
-  window.addEventListener("storage", onStorage);
-  window.addEventListener("resize", recompute);
-  return () => {
-    listeners.delete(cb);
-    window.removeEventListener("storage", onStorage);
-    window.removeEventListener("resize", recompute);
-  };
-}
-
-function setWidthGlobal(next: number) {
-  const stored = clampStored(next);
-  if (stored !== storedWidth) {
-    storedWidth = stored;
-    try {
-      window.localStorage.setItem(WIDTH_KEY, String(stored));
-    } catch {}
-  }
-  recompute();
-}
-
-export function useSidebarWidth() {
-  const width = useSyncExternalStore(
-    subscribe,
-    () => effectiveWidth,
-    () => SIDEBAR_WIDTH_DEFAULT,
-  );
-
-  const setWidth = useCallback((value: number) => setWidthGlobal(value), []);
-  const resetWidth = useCallback(
-    () => setWidthGlobal(SIDEBAR_WIDTH_DEFAULT),
-    [],
-  );
-
-  return { width, setWidth, resetWidth };
-}
+export const clampSidebarWidth = store.clamp;
+export const useSidebarWidth = store.useWidth;

--- a/studio/frontend/src/hooks/use-sidebar-width.ts
+++ b/studio/frontend/src/hooks/use-sidebar-width.ts
@@ -19,9 +19,18 @@ function maxWidth(): number {
   return Math.max(SIDEBAR_WIDTH_MIN, Math.min(SIDEBAR_WIDTH_MAX, viewportCap));
 }
 
-export function clampSidebarWidth(px: number): number {
+/** Clamps to the absolute range, ignoring the viewport. */
+function clampStored(px: number): number {
   if (!Number.isFinite(px)) return SIDEBAR_WIDTH_DEFAULT;
-  return Math.min(maxWidth(), Math.max(SIDEBAR_WIDTH_MIN, Math.round(px)));
+  return Math.min(
+    SIDEBAR_WIDTH_MAX,
+    Math.max(SIDEBAR_WIDTH_MIN, Math.round(px)),
+  );
+}
+
+/** Clamps to what the current viewport allows. */
+export function clampSidebarWidth(px: number): number {
+  return Math.min(maxWidth(), clampStored(px));
 }
 
 function loadWidth(): number {
@@ -29,16 +38,24 @@ function loadWidth(): number {
   try {
     const raw = window.localStorage.getItem(WIDTH_KEY);
     if (raw === null) return SIDEBAR_WIDTH_DEFAULT;
-    const parsed = Number.parseFloat(raw);
-    if (!Number.isFinite(parsed)) return SIDEBAR_WIDTH_DEFAULT;
-    return clampSidebarWidth(parsed);
+    return clampStored(Number.parseFloat(raw));
   } catch {
     return SIDEBAR_WIDTH_DEFAULT;
   }
 }
 
-let widthValue = loadWidth();
+// The preference is stored whole; `effective` is what the viewport allows.
+// Narrowing the window shrinks the sidebar without losing the preference.
+let storedWidth = loadWidth();
+let effectiveWidth = clampSidebarWidth(storedWidth);
 const listeners = new Set<() => void>();
+
+function recompute() {
+  const next = clampSidebarWidth(storedWidth);
+  if (next === effectiveWidth) return;
+  effectiveWidth = next;
+  listeners.forEach((cb) => cb());
+}
 
 function subscribe(cb: () => void) {
   listeners.add(cb);
@@ -48,31 +65,35 @@ function subscribe(cb: () => void) {
   // Keep tabs in sync, same as the pin flag.
   const onStorage = (e: StorageEvent) => {
     if (e.key === WIDTH_KEY || e.key === null) {
-      widthValue = loadWidth();
+      storedWidth = loadWidth();
+      effectiveWidth = clampSidebarWidth(storedWidth);
       cb();
     }
   };
   window.addEventListener("storage", onStorage);
+  window.addEventListener("resize", recompute);
   return () => {
     listeners.delete(cb);
     window.removeEventListener("storage", onStorage);
+    window.removeEventListener("resize", recompute);
   };
 }
 
 function setWidthGlobal(next: number) {
-  const clamped = clampSidebarWidth(next);
-  if (clamped === widthValue) return;
-  widthValue = clamped;
-  try {
-    window.localStorage.setItem(WIDTH_KEY, String(clamped));
-  } catch {}
-  listeners.forEach((cb) => cb());
+  const stored = clampStored(next);
+  if (stored !== storedWidth) {
+    storedWidth = stored;
+    try {
+      window.localStorage.setItem(WIDTH_KEY, String(stored));
+    } catch {}
+  }
+  recompute();
 }
 
 export function useSidebarWidth() {
   const width = useSyncExternalStore(
     subscribe,
-    () => widthValue,
+    () => effectiveWidth,
     () => SIDEBAR_WIDTH_DEFAULT,
   );
 

--- a/studio/frontend/src/hooks/use-sidebar-width.ts
+++ b/studio/frontend/src/hooks/use-sidebar-width.ts
@@ -5,8 +5,9 @@ import { createPanelWidthStore } from "./use-panel-width.ts";
 
 /** The previous fixed 17.5rem, at a 16px root font size. */
 export const SIDEBAR_WIDTH_DEFAULT = 280;
-/** Header lockup plus the search and collapse buttons need ~258px. */
-export const SIDEBAR_WIDTH_MIN = 264;
+/** Narrowest width that still fits the wordmark. Firefox is the constraint:
+ * it renders the heading ~3px wider than Chromium and WebKit. */
+export const SIDEBAR_WIDTH_MIN = 260;
 export const SIDEBAR_WIDTH_MAX = 480;
 
 const store = createPanelWidthStore({

--- a/studio/frontend/src/i18n/locales/ar.ts
+++ b/studio/frontend/src/i18n/locales/ar.ts
@@ -27,10 +27,18 @@ export const ar = {
     product: "Unsloth Studio",
     accountMenu: "قائمة حساب {name}",
     updateAvailable: "يتوفر تحديث",
+    resize: {
+      collapse: "انقر للطي",
+      expand: "انقر للتوسيع",
+      drag: "اسحب لتغيير الحجم",
+    },
     aria: {
       home: "الصفحة الرئيسية لـ Unsloth",
       closeSidebar: "إغلاق الشريط الجانبي",
       openSidebar: "فتح الشريط الجانبي",
+      resizeSidebar: "تغيير حجم الشريط الجانبي أو طيه",
+      resizeRunSettings: "تغيير حجم إعدادات التشغيل أو إغلاقها",
+      openRunSettings: "فتح إعدادات التشغيل",
       chatOptions: "خيارات المحادثة",
       runOptions: "خيارات التدريب",
     },

--- a/studio/frontend/src/i18n/locales/de.ts
+++ b/studio/frontend/src/i18n/locales/de.ts
@@ -27,10 +27,18 @@ export const de = {
     product: "Unsloth Studio",
     accountMenu: "Kontomenü von {name}",
     updateAvailable: "Update verfügbar",
+    resize: {
+      collapse: "Zum Einklappen klicken",
+      expand: "Zum Ausklappen klicken",
+      drag: "Zum Ändern der Größe ziehen",
+    },
     aria: {
       home: "Unsloth Startseite",
       closeSidebar: "Seitenleiste schließen",
       openSidebar: "Seitenleiste öffnen",
+      resizeSidebar: "Seitenleiste anpassen oder einklappen",
+      resizeRunSettings: "Ausführungseinstellungen anpassen oder schließen",
+      openRunSettings: "Ausführungseinstellungen öffnen",
       chatOptions: "Chat-Optionen",
       runOptions: "Trainingslauf-Optionen",
     },

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -24,10 +24,18 @@ export const en = {
     product: "Unsloth Studio",
     accountMenu: "{name} account menu",
     updateAvailable: "Update available",
+    resize: {
+      collapse: "Click to collapse",
+      expand: "Click to expand",
+      drag: "Drag to resize",
+    },
     aria: {
       home: "Unsloth home",
       closeSidebar: "Close sidebar",
       openSidebar: "Open sidebar",
+      resizeSidebar: "Resize or collapse sidebar",
+      resizeRunSettings: "Resize or close run settings",
+      openRunSettings: "Open run settings",
       chatOptions: "Chat options",
       runOptions: "Run options",
     },

--- a/studio/frontend/src/i18n/locales/es.ts
+++ b/studio/frontend/src/i18n/locales/es.ts
@@ -27,10 +27,18 @@ export const es = {
     product: "Unsloth Studio",
     accountMenu: "Menú de cuenta de {name}",
     updateAvailable: "Actualización disponible",
+    resize: {
+      collapse: "Haz clic para contraer",
+      expand: "Haz clic para expandir",
+      drag: "Arrastra para redimensionar",
+    },
     aria: {
       home: "Inicio de Unsloth",
       closeSidebar: "Cerrar barra lateral",
       openSidebar: "Abrir barra lateral",
+      resizeSidebar: "Redimensionar o contraer la barra lateral",
+      resizeRunSettings: "Redimensionar o cerrar los ajustes de ejecución",
+      openRunSettings: "Abrir los ajustes de ejecución",
       chatOptions: "Opciones de chat",
       runOptions: "Opciones de ejecución",
     },

--- a/studio/frontend/src/i18n/locales/fr.ts
+++ b/studio/frontend/src/i18n/locales/fr.ts
@@ -27,10 +27,18 @@ export const fr = {
     product: "Unsloth Studio",
     accountMenu: "Menu du compte de {name}",
     updateAvailable: "Mise à jour disponible",
+    resize: {
+      collapse: "Cliquez pour réduire",
+      expand: "Cliquez pour développer",
+      drag: "Faites glisser pour redimensionner",
+    },
     aria: {
       home: "Accueil Unsloth",
       closeSidebar: "Fermer la barre latérale",
       openSidebar: "Ouvrir la barre latérale",
+      resizeSidebar: "Redimensionner ou réduire la barre latérale",
+      resizeRunSettings: "Redimensionner ou fermer les paramètres d'exécution",
+      openRunSettings: "Ouvrir les paramètres d'exécution",
       chatOptions: "Options de discussion",
       runOptions: "Options d'exécution",
     },

--- a/studio/frontend/src/i18n/locales/hi.ts
+++ b/studio/frontend/src/i18n/locales/hi.ts
@@ -27,10 +27,18 @@ export const hi = {
     product: "Unsloth Studio",
     accountMenu: "{name} खाता मेनू",
     updateAvailable: "अपडेट उपलब्ध है",
+    resize: {
+      collapse: "छोटा करने के लिए क्लिक करें",
+      expand: "विस्तार के लिए क्लिक करें",
+      drag: "आकार बदलने के लिए खींचें",
+    },
     aria: {
       home: "Unsloth होम",
       closeSidebar: "साइडबार बंद करें",
       openSidebar: "साइडबार खोलें",
+      resizeSidebar: "साइडबार का आकार बदलें या छोटा करें",
+      resizeRunSettings: "रन सेटिंग्स का आकार बदलें या बंद करें",
+      openRunSettings: "रन सेटिंग्स खोलें",
       chatOptions: "चैट विकल्प",
       runOptions: "रन विकल्प",
     },

--- a/studio/frontend/src/i18n/locales/ja.ts
+++ b/studio/frontend/src/i18n/locales/ja.ts
@@ -28,10 +28,18 @@ export const ja = {
     product: "Unsloth Studio",
     accountMenu: "{name} のアカウントメニュー",
     updateAvailable: "アップデートが利用可能です",
+    resize: {
+      collapse: "クリックで折りたたむ",
+      expand: "クリックで展開",
+      drag: "ドラッグでサイズ変更",
+    },
     aria: {
       home: "Unsloth ホーム",
       closeSidebar: "サイドバーを閉じる",
       openSidebar: "サイドバーを開く",
+      resizeSidebar: "サイドバーのサイズ変更または折りたたみ",
+      resizeRunSettings: "実行設定のサイズ変更または閉じる",
+      openRunSettings: "実行設定を開く",
       chatOptions: "チャットオプション",
       runOptions: "実行オプション",
     },

--- a/studio/frontend/src/i18n/locales/ko.ts
+++ b/studio/frontend/src/i18n/locales/ko.ts
@@ -27,10 +27,18 @@ export const ko = {
     product: "Unsloth Studio",
     accountMenu: "{name} 계정 메뉴",
     updateAvailable: "업데이트 사용 가능",
+    resize: {
+      collapse: "클릭하여 접기",
+      expand: "클릭하여 펼치기",
+      drag: "드래그하여 크기 조절",
+    },
     aria: {
       home: "Unsloth 홈",
       closeSidebar: "사이드바 닫기",
       openSidebar: "사이드바 열기",
+      resizeSidebar: "사이드바 크기 조절 또는 접기",
+      resizeRunSettings: "실행 설정 크기 조절 또는 닫기",
+      openRunSettings: "실행 설정 열기",
       chatOptions: "채팅 옵션",
       runOptions: "학습 옵션",
     },

--- a/studio/frontend/src/i18n/locales/pt-br.ts
+++ b/studio/frontend/src/i18n/locales/pt-br.ts
@@ -27,10 +27,18 @@ export const ptBR = {
     product: "Unsloth Studio",
     accountMenu: "Menu de conta {name}",
     updateAvailable: "Atualização disponível",
+    resize: {
+      collapse: "Clique para recolher",
+      expand: "Clique para expandir",
+      drag: "Arraste para redimensionar",
+    },
     aria: {
       home: "Início do Unsloth",
       closeSidebar: "Fechar barra lateral",
       openSidebar: "Abrir barra lateral",
+      resizeSidebar: "Redimensionar ou recolher a barra lateral",
+      resizeRunSettings: "Redimensionar ou fechar as configurações de execução",
+      openRunSettings: "Abrir as configurações de execução",
       chatOptions: "Opções de chat",
       runOptions: "Opções de execução",
     },

--- a/studio/frontend/src/i18n/locales/ru.ts
+++ b/studio/frontend/src/i18n/locales/ru.ts
@@ -27,10 +27,18 @@ export const ru = {
     product: "Unsloth Studio",
     accountMenu: "Меню аккаунта {name}",
     updateAvailable: "Доступно обновление",
+    resize: {
+      collapse: "Нажмите, чтобы свернуть",
+      expand: "Нажмите, чтобы развернуть",
+      drag: "Потяните, чтобы изменить размер",
+    },
     aria: {
       home: "Главная Unsloth",
       closeSidebar: "Закрыть боковую панель",
       openSidebar: "Открыть боковую панель",
+      resizeSidebar: "Изменить размер или свернуть боковую панель",
+      resizeRunSettings: "Изменить размер или закрыть настройки запуска",
+      openRunSettings: "Открыть настройки запуска",
       chatOptions: "Параметры чата",
       runOptions: "Параметры запуска",
     },

--- a/studio/frontend/src/i18n/locales/zh-CN.ts
+++ b/studio/frontend/src/i18n/locales/zh-CN.ts
@@ -27,10 +27,18 @@ export const zhCN = {
     product: "Unsloth Studio",
     accountMenu: "{name} 账号菜单",
     updateAvailable: "有可用更新",
+    resize: {
+      collapse: "点击折叠",
+      expand: "点击展开",
+      drag: "拖动调整大小",
+    },
     aria: {
       home: "Unsloth 首页",
       closeSidebar: "关闭侧边栏",
       openSidebar: "打开侧边栏",
+      resizeSidebar: "调整或折叠侧边栏",
+      resizeRunSettings: "调整或关闭运行设置",
+      openRunSettings: "打开运行设置",
       chatOptions: "聊天选项",
       runOptions: "训练选项",
     },

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1363,16 +1363,19 @@ html[data-chat-font] .aui-root {
 		cursor: pointer;
 	}
 
-	/* While the sidebar edge is dragged, keep the resize cursor even as the
-	   pointer travels over buttons and text that would claim their own. */
-	[data-slot="sidebar-wrapper"][data-resizing="true"],
-	[data-slot="sidebar-wrapper"][data-resizing="true"] * {
+	/* While a panel edge is dragged, keep the resize cursor even as the pointer
+	   travels over buttons and text that would claim their own. */
+	html[data-panel-resizing],
+	html[data-panel-resizing] * {
 		cursor: col-resize !important;
 		user-select: none !important;
 	}
 
-	[data-slot="sidebar-wrapper"][data-resizing="true"]
-		:is([data-slot="sidebar-inner"], [data-slot="sidebar-inset"]) {
+	html[data-panel-resizing]
+		:is(
+			[data-slot="sidebar-inner"],
+			[data-slot="sidebar-inset"]
+		) {
 		pointer-events: none;
 	}
 

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1363,6 +1363,19 @@ html[data-chat-font] .aui-root {
 		cursor: pointer;
 	}
 
+	/* While the sidebar edge is dragged, keep the resize cursor even as the
+	   pointer travels over buttons and text that would claim their own. */
+	[data-slot="sidebar-wrapper"][data-resizing="true"],
+	[data-slot="sidebar-wrapper"][data-resizing="true"] * {
+		cursor: col-resize !important;
+		user-select: none !important;
+	}
+
+	[data-slot="sidebar-wrapper"][data-resizing="true"]
+		:is([data-slot="sidebar-inner"], [data-slot="sidebar-inset"]) {
+		pointer-events: none;
+	}
+
 	/* Model selector: pointer cursor on every clickable element. */
 	.unsloth-model-selector-trigger,
 	.unsloth-model-selector-menu button {

--- a/studio/frontend/tests/sidebar-width.test.ts
+++ b/studio/frontend/tests/sidebar-width.test.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+// The store reads window at import time, so stub it before importing.
+const stubWindow = {
+  innerWidth: 1440,
+  localStorage: {
+    getItem: () => null,
+    setItem: () => {},
+  },
+  addEventListener: () => {},
+  removeEventListener: () => {},
+};
+(globalThis as { window?: unknown }).window = stubWindow;
+
+const {
+  clampSidebarWidth,
+  SIDEBAR_WIDTH_DEFAULT,
+  SIDEBAR_WIDTH_MAX,
+  SIDEBAR_WIDTH_MIN,
+} = await import("../src/hooks/use-sidebar-width.ts");
+
+test("clamps to the absolute range on a roomy window", () => {
+  stubWindow.innerWidth = 1440;
+  assert.equal(clampSidebarWidth(320), 320);
+  assert.equal(clampSidebarWidth(SIDEBAR_WIDTH_MAX + 200), SIDEBAR_WIDTH_MAX);
+  assert.equal(clampSidebarWidth(10), SIDEBAR_WIDTH_MIN);
+  assert.equal(clampSidebarWidth(Number.NaN), SIDEBAR_WIDTH_DEFAULT);
+});
+
+test("caps at 40% of a narrow window", () => {
+  stubWindow.innerWidth = 800;
+  assert.equal(clampSidebarWidth(SIDEBAR_WIDTH_MAX), 320);
+  assert.equal(clampSidebarWidth(300), 300);
+});
+
+test("the floor still wins when 40% falls below it", () => {
+  stubWindow.innerWidth = 500;
+  assert.equal(clampSidebarWidth(SIDEBAR_WIDTH_MAX), SIDEBAR_WIDTH_MIN);
+});
+
+test("re-evaluates the cap per call, so a resize can re-clamp", () => {
+  stubWindow.innerWidth = 1440;
+  assert.equal(clampSidebarWidth(SIDEBAR_WIDTH_MAX), SIDEBAR_WIDTH_MAX);
+  stubWindow.innerWidth = 900;
+  assert.equal(clampSidebarWidth(SIDEBAR_WIDTH_MAX), 360);
+  stubWindow.innerWidth = 1440;
+  assert.equal(clampSidebarWidth(SIDEBAR_WIDTH_MAX), SIDEBAR_WIDTH_MAX);
+});

--- a/studio/frontend/tests/sidebar-width.test.ts
+++ b/studio/frontend/tests/sidebar-width.test.ts
@@ -3,6 +3,10 @@
 
 import assert from "node:assert/strict";
 import test from "node:test";
+import { readFile } from "node:fs/promises";
+
+// Every localStorage key written by a panel width store.
+const PANEL_WIDTH_KEYS = ["sidebar_width"];
 
 // The store reads window at import time, so stub it before importing.
 const stubWindow = {
@@ -49,4 +53,20 @@ test("re-evaluates the cap per call, so a resize can re-clamp", () => {
   assert.equal(clampSidebarWidth(SIDEBAR_WIDTH_MAX), 360);
   stubWindow.innerWidth = 1440;
   assert.equal(clampSidebarWidth(SIDEBAR_WIDTH_MAX), SIDEBAR_WIDTH_MAX);
+});
+
+// The reset action promises to clear every stored preference, so a persisted
+// panel width that is missing from the list survives the reload.
+test("persisted panel widths are cleared by the preference reset", async () => {
+  const source = await readFile(
+    new URL("../src/features/settings/tabs/general-tab.tsx", import.meta.url),
+    "utf8",
+  );
+  const keys = source.slice(
+    source.indexOf("const PREFS_KEYS"),
+    source.indexOf("];", source.indexOf("const PREFS_KEYS")),
+  );
+  for (const key of PANEL_WIDTH_KEYS) {
+    assert.ok(keys.includes(`"${key}"`), `${key} missing from PREFS_KEYS`);
+  }
 });


### PR DESCRIPTION
The sidebar has been locked at 17.5rem since it landed. Long chat titles truncate early and there is no way to trade content width for sidebar width, so this adds a drag handle on the sidebar edge.

### What you get

- Drag the edge to resize, between 260px and 480px, additionally capped at 40% of the window so it cannot swallow the chat area on a small screen.
- Click the edge to collapse or expand, same as the existing Cmd+B.
- Arrow keys nudge the width, Home restores the default 280px.
- The width persists in `localStorage` next to the existing `sidebar_pinned` flag and syncs across tabs, so it survives reloads.

Dragging inward stops at the minimum instead of collapsing. Collapsing stays a deliberate click or Cmd+B, so an overshoot while resizing cannot snap the sidebar shut.

### Why 260px

The header sets the floor. The padding, logo mark, wordmark, beta badge and the two action buttons have to fit, and below that the search icon starts riding over the logo. The lockup now truncates the wordmark rather than overlapping, so a larger UI font scale degrades cleanly instead of colliding.

The floor is measured rather than derived. Sweeping the header from 236px to 286px in 2px steps and checking `scrollWidth` against `clientWidth` on the wordmark puts the clip-free point at 256px in Chromium and WebKit, but 260px in Firefox, which renders the heading about 3px wider. 260px is the narrowest value that is clean in all three.

While measuring this I also tightened the header actions. The search and collapse buttons were 32px wide around a 16px icon, so 8px of padding each side made the pair read as one wide block. They are now 28px with a 1px gap, which brings the glyphs from 18px apart to 13px and is what freed the 4px at the bottom of the range. The collapsed rail toggle stays at 32px, since it sits alone and should match the other rail icons.

### Performance

A live resize relayouts the whole shell, including the chat list and the composer's autosize measurement, and `pointermove` fires well above the display refresh rate. The in-progress width is painted straight to the wrapper's `--sidebar-width` custom property once per animation frame, and only committed to the store on release, so there is no React render per pointer move and the work stays bounded by the refresh rate. Pointer events on the shell are dropped for the duration of the drag.

### Notes

- The hover indicator sits exactly on the sidebar's existing 1px border and only recolours it, so no second line appears next to the first.
- The handle forces the resize cursor with `!`, since two app-wide rules give every button the hand cursor, and holds it through the drag as the pointer travels over buttons and text.

### Testing

`npm run typecheck`, `npm run test`, `npm run i18n:check` and `npm run build` pass.

Behaviour is covered by a Playwright suite driving a harness that imports the real sources, run against Chromium 149, Firefox 151 and WebKit 26.5. 276 checks pass on all three. It covers the drag maths and clamping, collapse and expand by click and by keyboard, persistence and cross-tab sync, corrupt and unavailable `localStorage`, viewport reclamping, pointer cancellation, unmount mid-drag, and the header lockup at the floor.

The header check asserts the wordmark is not clipped, not just that the boxes fail to overlap. `truncate` makes a literal overlap nearly impossible, so the weaker assertion passed regardless of the constant. Dropping the floor back to 256px fails it with `[firefox] clip: 3`.

Still worth a manual pass at a non-default UI font scale and in both themes, since the sweep above was run at the default scale.

