### PR TITLE
Studio: free the llama-server slot when a chat stream reaches [DONE]

### DIFF
--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -730,14 +730,6 @@ _SSE_DONE_LINE = "data: [DONE]"
 _SSE_DONE_CHUNK = "data: [DONE]\n\n"
 
 
-def _sse_chunk_is_stream_done(chunk) -> bool:
-    """True only for the bare sentinel that closes a successful stream.
-
-    Exact equality: ``_openai_stream_error_sse`` ends in the same sentinel before its cleanup runs.
-    """
-    return chunk == _SSE_DONE_CHUNK
-
-
 def _openai_passthrough_sse_line_terminal_state(raw_line: str) -> Optional[str]:
     """Classify OpenAI-compatible chat stream terminal markers.
 
@@ -9406,13 +9398,14 @@ async def openai_chat_completions(
 
             _tool_sentinel = object()
             # True only once the sync generator returned on its own; see _gguf_decode_finished.
-            _tool_decode_finished = {"value": False}
+            _tool_decode_finished = False
 
             _cancel_keys = (payload.cancel_id, payload.session_id, completion_id)
             _tracker = _TrackedCancel.for_payload(cancel_event, payload, *_cancel_keys)
             _tracker.__enter__()
 
             async def gguf_tool_stream():
+                nonlocal _tool_decode_finished
                 gen = None
                 next_task = None
                 stream_completed = False
@@ -9497,7 +9490,7 @@ async def openai_chat_completions(
                             if next_task.done():
                                 next_task = None
                         if event is _tool_sentinel:
-                            _tool_decode_finished["value"] = True
+                            _tool_decode_finished = True
                             break
 
                         # Anything after the gated tool_start means the user answered.
@@ -9717,8 +9710,8 @@ async def openai_chat_completions(
                                 # Release before the yield; see gguf_stream_chunks.
                                 if (
                                     lease is not None
-                                    and _tool_decode_finished["value"]
-                                    and _sse_chunk_is_stream_done(chunk)
+                                    and _tool_decode_finished
+                                    and chunk == _SSE_DONE_CHUNK
                                 ):
                                     lease.release()
                                 yield chunk
@@ -10025,7 +10018,7 @@ async def openai_chat_completions(
         _gguf_sentinel = object()
         # True only once the sync generator returned on its own: only then has _open_stream's
         # client exited. A cancel still emits [DONE] without it.
-        _gguf_decode_finished = {"value": False}
+        _gguf_decode_finished = False
 
         if payload.stream:
             if _wants_multiple_choices(payload):
@@ -10052,6 +10045,7 @@ async def openai_chat_completions(
                 raise _openai_admission_http_exception(exc, status_code = 429)
 
             async def gguf_stream_chunks():
+                nonlocal _gguf_decode_finished
                 disconnect_watcher = asyncio.create_task(
                     _await_disconnect_then_cancel(request, cancel_event)
                 )
@@ -10096,7 +10090,7 @@ async def openai_chat_completions(
                             if next_task.done():
                                 next_task = None
                         if cumulative is _gguf_sentinel:
-                            _gguf_decode_finished["value"] = True
+                            _gguf_decode_finished = True
                             break
                         # Capture server metadata for the final usage chunk
                         if isinstance(cumulative, dict):
@@ -10264,11 +10258,13 @@ async def openai_chat_completions(
                             # waiting for it starves the next request. Release before the yield: a
                             # stalled send() or a consumer that stops pulling parks us there, and
                             # Starlette never aclose()s a body iterator. Release is idempotent, so
-                            # the finally stays the backstop.
+                            # the finally stays the backstop. Exact equality, not endswith:
+                            # _openai_stream_error_sse ends in the same sentinel before its
+                            # cleanup runs, and that stream still owns the slot.
                             if (
                                 lease is not None
-                                and _gguf_decode_finished["value"]
-                                and _sse_chunk_is_stream_done(chunk)
+                                and _gguf_decode_finished
+                                and chunk == _SSE_DONE_CHUNK
                             ):
                                 lease.release()
                             yield chunk

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -727,15 +727,16 @@ def _wants_stream_usage(payload) -> bool:
 
 _OPENAI_PASSTHROUGH_TERMINAL_GRACE_S = 2.0
 _SSE_DONE_LINE = "data: [DONE]"
+_SSE_DONE_CHUNK = "data: [DONE]\n\n"
 
 
-def _sse_chunk_ends_the_stream(chunk) -> bool:
-    """True for the chunk carrying the trailing ``data: [DONE]`` sentinel.
+def _sse_chunk_is_stream_done(chunk) -> bool:
+    """True only for the bare sentinel that closes a successful stream.
 
-    Delta chunks are one JSON line ending in ``}``, so only the two terminal
-    emitters match: the normal end of stream and ``_openai_stream_error_sse``.
+    Exact equality on purpose: ``_openai_stream_error_sse`` ends in the same
+    sentinel but is yielded before its generator's cleanup has run.
     """
-    return isinstance(chunk, str) and chunk.rstrip().endswith(_SSE_DONE_LINE)
+    return chunk == _SSE_DONE_CHUNK
 
 
 def _openai_passthrough_sse_line_terminal_state(raw_line: str) -> Optional[str]:
@@ -9406,6 +9407,9 @@ async def openai_chat_completions(
                 raise _openai_admission_http_exception(exc, status_code = 429)
 
             _tool_sentinel = object()
+            # True only once the sync generator returned on its own. A cancel
+            # still emits [DONE] with it parked inside _open_stream's client.
+            _tool_decode_finished = {"value": False}
 
             _cancel_keys = (payload.cancel_id, payload.session_id, completion_id)
             _tracker = _TrackedCancel.for_payload(cancel_event, payload, *_cancel_keys)
@@ -9496,6 +9500,7 @@ async def openai_chat_completions(
                             if next_task.done():
                                 next_task = None
                         if event is _tool_sentinel:
+                            _tool_decode_finished["value"] = True
                             break
 
                         # Anything after the gated tool_start means the user answered.
@@ -9712,9 +9717,14 @@ async def openai_chat_completions(
                         stream_started = True
                         try:
                             async for chunk in iterator:
-                                yield chunk
-                                if lease is not None and _sse_chunk_ends_the_stream(chunk):
+                                # Release before the yield; see gguf_stream_chunks.
+                                if (
+                                    lease is not None
+                                    and _tool_decode_finished["value"]
+                                    and _sse_chunk_is_stream_done(chunk)
+                                ):
                                     lease.release()
+                                yield chunk
                         except asyncio.CancelledError:
                             stream_cancelled = True
                             raise
@@ -10016,6 +10026,9 @@ async def openai_chat_completions(
             )
 
         _gguf_sentinel = object()
+        # True only once the sync generator returned on its own: only then has
+        # _open_stream's client exited. A cancel still emits [DONE] without it.
+        _gguf_decode_finished = {"value": False}
 
         if payload.stream:
             if _wants_multiple_choices(payload):
@@ -10086,6 +10099,7 @@ async def openai_chat_completions(
                             if next_task.done():
                                 next_task = None
                         if cumulative is _gguf_sentinel:
+                            _gguf_decode_finished["value"] = True
                             break
                         # Capture server metadata for the final usage chunk
                         if isinstance(cumulative, dict):
@@ -10248,16 +10262,21 @@ async def openai_chat_completions(
                     stream_started = True
                     try:
                         async for chunk in iterator:
-                            yield chunk
-                            # Decoding is over at [DONE]: llama-server released
-                            # its slot, and the sync generator's httpx client is
-                            # already closed. The finally below only runs once
-                            # the ASGI body is torn down, so keeping the slot
-                            # until then starves the next request on any wedged
-                            # teardown. release() is idempotent, so the finally
-                            # stays the backstop.
-                            if lease is not None and _sse_chunk_ends_the_stream(chunk):
+                            # The slot is idle once the sync generator returned
+                            # and the stream ends with the plain sentinel. The
+                            # finally only runs at ASGI teardown, so waiting for
+                            # it starves the next request on any wedge. Release
+                            # before the yield: a stalled send() or a consumer
+                            # that stops pulling parks us here, and Starlette
+                            # never aclose()s a body iterator. Idempotent, so
+                            # the finally stays the backstop.
+                            if (
+                                lease is not None
+                                and _gguf_decode_finished["value"]
+                                and _sse_chunk_is_stream_done(chunk)
+                            ):
                                 lease.release()
+                            yield chunk
                     except asyncio.CancelledError:
                         stream_cancelled = True
                         raise

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -729,6 +729,15 @@ _OPENAI_PASSTHROUGH_TERMINAL_GRACE_S = 2.0
 _SSE_DONE_LINE = "data: [DONE]"
 
 
+def _sse_chunk_ends_the_stream(chunk) -> bool:
+    """True for the chunk carrying the trailing ``data: [DONE]`` sentinel.
+
+    Delta chunks are one JSON line ending in ``}``, so only the two terminal
+    emitters match: the normal end of stream and ``_openai_stream_error_sse``.
+    """
+    return isinstance(chunk, str) and chunk.rstrip().endswith(_SSE_DONE_LINE)
+
+
 def _openai_passthrough_sse_line_terminal_state(raw_line: str) -> Optional[str]:
     """Classify OpenAI-compatible chat stream terminal markers.
 
@@ -2440,10 +2449,17 @@ async def _await_cancel_or_disconnect_then_close_client(
         return
 
 
-async def _stop_local_disconnect_cancel_watcher(watcher) -> None:
+async def _stop_local_disconnect_cancel_watcher(watcher, timeout_s: float = 5.0) -> None:
+    # Bounded: this runs in the stream's finally, so awaiting the watcher
+    # outright would let a wedged poll loop hold the response open forever.
+    # asyncio.wait never cancels its argument and never re-raises. Abandoning
+    # the watcher is safe -- it owns no resources.
     watcher.cancel()
+    done, _pending = await asyncio.wait({watcher}, timeout = timeout_s)
+    if not done:
+        return
     try:
-        await watcher
+        watcher.result()
     except (asyncio.CancelledError, Exception):
         pass
 
@@ -9697,6 +9713,8 @@ async def openai_chat_completions(
                         try:
                             async for chunk in iterator:
                                 yield chunk
+                                if lease is not None and _sse_chunk_ends_the_stream(chunk):
+                                    lease.release()
                         except asyncio.CancelledError:
                             stream_cancelled = True
                             raise
@@ -10231,6 +10249,15 @@ async def openai_chat_completions(
                     try:
                         async for chunk in iterator:
                             yield chunk
+                            # Decoding is over at [DONE]: llama-server released
+                            # its slot, and the sync generator's httpx client is
+                            # already closed. The finally below only runs once
+                            # the ASGI body is torn down, so keeping the slot
+                            # until then starves the next request on any wedged
+                            # teardown. release() is idempotent, so the finally
+                            # stays the backstop.
+                            if lease is not None and _sse_chunk_ends_the_stream(chunk):
+                                lease.release()
                     except asyncio.CancelledError:
                         stream_cancelled = True
                         raise

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -733,8 +733,7 @@ _SSE_DONE_CHUNK = "data: [DONE]\n\n"
 def _sse_chunk_is_stream_done(chunk) -> bool:
     """True only for the bare sentinel that closes a successful stream.
 
-    Exact equality on purpose: ``_openai_stream_error_sse`` ends in the same
-    sentinel but is yielded before its generator's cleanup has run.
+    Exact equality: ``_openai_stream_error_sse`` ends in the same sentinel before its cleanup runs.
     """
     return chunk == _SSE_DONE_CHUNK
 
@@ -2451,10 +2450,9 @@ async def _await_cancel_or_disconnect_then_close_client(
 
 
 async def _stop_local_disconnect_cancel_watcher(watcher, timeout_s: float = 5.0) -> None:
-    # Bounded: this runs in the stream's finally, so awaiting the watcher
-    # outright would let a wedged poll loop hold the response open forever.
-    # asyncio.wait never cancels its argument and never re-raises. Abandoning
-    # the watcher is safe -- it owns no resources.
+    # Bounded: this runs in the stream's finally, so awaiting the watcher outright would let a
+    # wedged poll loop hold the response open forever. asyncio.wait neither cancels nor re-raises,
+    # and an abandoned watcher owns no resources.
     watcher.cancel()
     done, _pending = await asyncio.wait({watcher}, timeout = timeout_s)
     if not done:
@@ -9407,8 +9405,7 @@ async def openai_chat_completions(
                 raise _openai_admission_http_exception(exc, status_code = 429)
 
             _tool_sentinel = object()
-            # True only once the sync generator returned on its own. A cancel
-            # still emits [DONE] with it parked inside _open_stream's client.
+            # True only once the sync generator returned on its own; see _gguf_decode_finished.
             _tool_decode_finished = {"value": False}
 
             _cancel_keys = (payload.cancel_id, payload.session_id, completion_id)
@@ -10026,8 +10023,8 @@ async def openai_chat_completions(
             )
 
         _gguf_sentinel = object()
-        # True only once the sync generator returned on its own: only then has
-        # _open_stream's client exited. A cancel still emits [DONE] without it.
+        # True only once the sync generator returned on its own: only then has _open_stream's
+        # client exited. A cancel still emits [DONE] without it.
         _gguf_decode_finished = {"value": False}
 
         if payload.stream:
@@ -10262,13 +10259,11 @@ async def openai_chat_completions(
                     stream_started = True
                     try:
                         async for chunk in iterator:
-                            # The slot is idle once the sync generator returned
-                            # and the stream ends with the plain sentinel. The
-                            # finally only runs at ASGI teardown, so waiting for
-                            # it starves the next request on any wedge. Release
-                            # before the yield: a stalled send() or a consumer
-                            # that stops pulling parks us here, and Starlette
-                            # never aclose()s a body iterator. Idempotent, so
+                            # The slot is idle once the sync generator returned and the stream ends
+                            # with the plain sentinel. The finally only runs at ASGI teardown, so
+                            # waiting for it starves the next request. Release before the yield: a
+                            # stalled send() or a consumer that stops pulling parks us there, and
+                            # Starlette never aclose()s a body iterator. Release is idempotent, so
                             # the finally stays the backstop.
                             if (
                                 lease is not None

--- a/studio/backend/tests/test_gguf_stream_slot_release.py
+++ b/studio/backend/tests/test_gguf_stream_slot_release.py
@@ -40,14 +40,15 @@ def _active_slots() -> int:
     return sum(queue.snapshot().active for queue in queues)
 
 
-def test_sse_chunk_ends_the_stream_only_matches_the_sentinel():
-    ends = inference_route._sse_chunk_ends_the_stream
-    assert ends("data: [DONE]\n\n")
-    # The error path emits a payload line and the sentinel in one chunk.
-    assert ends('data: {"error": {"message": "boom"}}\n\ndata: [DONE]\n\n')
-    assert not ends('data: {"choices": [{"delta": {"content": "data: [DONE]"}}]}\n\n')
-    assert not ends("")
-    assert not ends(None)
+def test_sse_chunk_is_stream_done_only_matches_the_success_sentinel():
+    done = inference_route._sse_chunk_is_stream_done
+    assert done("data: [DONE]\n\n")
+    # The error path packs a payload line and the sentinel into one chunk. Its
+    # cleanup has not run yet, so it must not look like a finished stream.
+    assert not done('data: {"error": {"message": "boom"}}\n\ndata: [DONE]\n\n')
+    assert not done('data: {"choices": [{"delta": {"content": "data: [DONE]"}}]}\n\n')
+    assert not done("")
+    assert not done(None)
 
 
 _ONE_SLOT = llama_admission.LlamaAdmissionConfig(max_queue = 4)
@@ -81,7 +82,7 @@ def test_slot_is_freed_at_done_even_if_teardown_never_finishes():
         try:
             async for chunk in iterator:
                 yield chunk
-                if held is not None and inference_route._sse_chunk_ends_the_stream(chunk):
+                if held is not None and inference_route._sse_chunk_is_stream_done(chunk):
                     held.release()
         finally:
             if held is not None:
@@ -101,7 +102,7 @@ def test_slot_is_freed_at_done_even_if_teardown_never_finishes():
             # runs into the wedged teardown.
             async for chunk in _admitted(lease):
                 seen.append(chunk)
-                if inference_route._sse_chunk_ends_the_stream(chunk):
+                if inference_route._sse_chunk_is_stream_done(chunk):
                     saw_done.set()
 
         task = asyncio.create_task(_consume())
@@ -258,7 +259,7 @@ def test_real_stream_frees_the_slot_at_done_with_a_wedged_teardown(monkeypatch):
             frames.append(message)
             if message.get("type") == "http.response.body":
                 chunk = message.get("body", b"").decode()
-                if inference_route._sse_chunk_ends_the_stream(chunk):
+                if inference_route._sse_chunk_is_stream_done(chunk):
                     sent_body.set()
 
         task = asyncio.create_task(app(scope, receive, send))

--- a/studio/backend/tests/test_gguf_stream_slot_release.py
+++ b/studio/backend/tests/test_gguf_stream_slot_release.py
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""A finished GGUF chat stream must free its llama-server slot at [DONE].
+
+llama-server has a fixed slot count and Unsloth gates concurrent decoding on it
+with an admission lease. The lease used to be released only in the stream's
+outer finally, which does not run until the ASGI response body is torn down, so
+any wedged teardown pinned a slot long after llama-server had freed it and the
+next chat request queued behind a generation that had already finished. The
+queue has no default timeout, so the wait was unbounded.
+
+The wedge here stands in for the real one: the frontend deliberately does not
+cancel its reader after [DONE] (chat-api.ts), and uvicorn advertises ASGI
+spec_version 2.3, so Starlette's OSError/ClientDisconnect path -- the only
+disconnect detector _SameTaskStreamingResponse keeps -- cannot fire.
+"""
+
+import asyncio
+import json
+
+import pytest
+from fastapi import FastAPI
+
+from auth.authentication import get_current_subject
+from core.inference import llama_admission
+import routes.inference as inference_route
+
+
+@pytest.fixture(autouse = True)
+def _fresh_queues():
+    llama_admission.reset_llama_admission_queues()
+    yield
+    llama_admission.reset_llama_admission_queues()
+
+
+def _active_slots() -> int:
+    with llama_admission._QUEUES_LOCK:
+        queues = list(llama_admission._QUEUES.values())
+    return sum(queue.snapshot().active for queue in queues)
+
+
+def test_sse_chunk_ends_the_stream_only_matches_the_sentinel():
+    ends = inference_route._sse_chunk_ends_the_stream
+    assert ends("data: [DONE]\n\n")
+    # The error path emits a payload line and the sentinel in one chunk.
+    assert ends('data: {"error": {"message": "boom"}}\n\ndata: [DONE]\n\n')
+    assert not ends('data: {"choices": [{"delta": {"content": "data: [DONE]"}}]}\n\n')
+    assert not ends("")
+    assert not ends(None)
+
+
+_ONE_SLOT = llama_admission.LlamaAdmissionConfig(max_queue = 4)
+
+
+def _reserve_one_slot():
+    """Take the single slot of a 1-parallel backend. Needs a running loop."""
+    queue = llama_admission.get_llama_admission_queue("http://llama.test")
+    reservation = queue.reserve(capacity = 1, config = _ONE_SLOT)
+    return queue, reservation.lease_nowait()
+
+
+def test_slot_is_freed_at_done_even_if_teardown_never_finishes():
+    """Model the stream's shape: yield chunks, then wedge in the finally.
+
+    Without the release at [DONE] the slot stays held for as long as the
+    teardown is stuck, which is what starved the following request in CI.
+    """
+    wedged = asyncio.Event()
+
+    async def _stream():
+        try:
+            yield 'data: {"choices": [{"delta": {"content": "hi"}}]}\n\n'
+            yield "data: [DONE]\n\n"
+        finally:
+            # Stand-in for a teardown that never completes.
+            await wedged.wait()
+
+    async def _admitted(held):
+        iterator = _stream()
+        try:
+            async for chunk in iterator:
+                yield chunk
+                if held is not None and inference_route._sse_chunk_ends_the_stream(chunk):
+                    held.release()
+        finally:
+            if held is not None:
+                held.release()
+
+    async def _drive():
+        queue, lease = _reserve_one_slot()
+        assert lease is not None
+        assert _active_slots() == 1
+
+        seen = []
+        saw_done = asyncio.Event()
+
+        async def _consume():
+            # Stands in for Starlette's stream_response: it keeps pulling after
+            # the last chunk, so the generator resumes past [DONE] and only then
+            # runs into the wedged teardown.
+            async for chunk in _admitted(lease):
+                seen.append(chunk)
+                if inference_route._sse_chunk_ends_the_stream(chunk):
+                    saw_done.set()
+
+        task = asyncio.create_task(_consume())
+        try:
+            await asyncio.wait_for(saw_done.wait(), timeout = 5.0)
+            # Give the generator a turn to resume past the [DONE] yield and
+            # reach the wedge, without letting the wedge end the test.
+            for _ in range(50):
+                if _active_slots() == 0:
+                    break
+                await asyncio.sleep(0.01)
+            assert not task.done(), "teardown should still be wedged"
+            assert _active_slots() == 0, (
+                "slot still held after [DONE]; the next chat request would "
+                "queue behind a generation that already finished"
+            )
+            # A second caller must be admitted right away.
+            second = queue.reserve(capacity = 1, config = _ONE_SLOT).lease_nowait()
+            assert second is not None, "next request was refused a free slot"
+            second.release()
+        finally:
+            wedged.set()
+            task.cancel()
+            await asyncio.gather(task, return_exceptions = True)
+        return seen
+
+    seen = asyncio.run(_drive())
+    assert seen[-1] == "data: [DONE]\n\n"
+
+
+def test_release_is_idempotent_so_the_finally_stays_a_backstop():
+    async def _drive():
+        _queue, lease = _reserve_one_slot()
+        assert _active_slots() == 1
+        lease.release()
+        lease.release()
+        assert _active_slots() == 0
+
+    asyncio.run(_drive())
+
+
+def test_stopping_the_disconnect_watcher_cannot_hang():
+    """The watcher stop runs in the stream's finally; it must be bounded."""
+
+    async def _drive():
+        started = asyncio.Event()
+
+        release = asyncio.Event()
+
+        async def _unstoppable():
+            started.set()
+            while not release.is_set():
+                try:
+                    await asyncio.sleep(0.01)
+                except asyncio.CancelledError:
+                    # A watcher that swallows cancellation, as the real one does
+                    # for every exception on its way out.
+                    if release.is_set():
+                        raise
+                    continue
+
+        watcher = asyncio.create_task(_unstoppable())
+        await started.wait()
+        # Would hang forever if the stop awaited the watcher outright.
+        await asyncio.wait_for(
+            inference_route._stop_local_disconnect_cancel_watcher(watcher, timeout_s = 0.2),
+            timeout = 5.0,
+        )
+        assert not watcher.done(), "watcher should have been abandoned, not awaited"
+        release.set()
+        watcher.cancel()
+        await asyncio.gather(watcher, return_exceptions = True)
+
+    asyncio.run(_drive())
+
+
+class _OneSlotGgufBackend:
+    """A loaded 1-parallel GGUF backend, the shape CI runs."""
+
+    is_loaded = True
+    model_identifier = "test/model.gguf"
+    base_url = "http://llama.test"
+    effective_parallel_slots = 1
+    _is_audio = False
+    is_vision = False
+    supports_tools = False
+
+    def generate_chat_completion(self, **kwargs):
+        yield "hi"
+        yield {
+            "type": "metadata",
+            "usage": {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4},
+            "timings": {"prompt_n": 3, "predicted_n": 1},
+            "finish_reason": "stop",
+        }
+
+
+def test_real_stream_frees_the_slot_at_done_with_a_wedged_teardown(monkeypatch):
+    """Drive the real ASGI route, wedged exactly where CI wedged.
+
+    ``_stop_local_disconnect_cancel_watcher`` runs in ``gguf_stream_chunks``'s
+    finally on the success path. Hanging it reproduces a response that has sent
+    [DONE] but cannot finish, which is the state the CI job was left in.
+    """
+    monkeypatch.setattr(inference_route, "get_llama_cpp_backend", lambda: _OneSlotGgufBackend())
+    monkeypatch.setattr(inference_route, "_effective_enable_tools", lambda payload: False)
+
+    app = FastAPI()
+    app.include_router(inference_route.router)
+    app.dependency_overrides[get_current_subject] = lambda: "test-user"
+
+    async def _drive():
+        wedged = asyncio.Event()
+
+        async def _hang(watcher, *args, **kwargs):
+            watcher.cancel()
+            await wedged.wait()
+
+        monkeypatch.setattr(inference_route, "_stop_local_disconnect_cancel_watcher", _hang)
+
+        body = json.dumps(
+            {"messages": [{"role": "user", "content": "hi"}], "stream": True}
+        ).encode()
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/chat/completions",
+            "raw_path": b"/chat/completions",
+            "query_string": b"",
+            "root_path": "",
+            "headers": [
+                (b"host", b"testserver"),
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode()),
+            ],
+            "client": ("127.0.0.1", 12345),
+            "server": ("testserver", 80),
+            "app": app,
+        }
+
+        sent_body = asyncio.Event()
+        frames = []
+
+        async def receive():
+            if not frames:
+                return {"type": "http.request", "body": body, "more_body": False}
+            # Never disconnect: the browser keeps the socket open after [DONE].
+            await asyncio.Event().wait()
+
+        async def send(message):
+            frames.append(message)
+            if message.get("type") == "http.response.body":
+                chunk = message.get("body", b"").decode()
+                if inference_route._sse_chunk_ends_the_stream(chunk):
+                    sent_body.set()
+
+        task = asyncio.create_task(app(scope, receive, send))
+        try:
+            await asyncio.wait_for(sent_body.wait(), timeout = 20.0)
+            for _ in range(200):
+                if _active_slots() == 0:
+                    break
+                await asyncio.sleep(0.01)
+            assert not task.done(), "response should still be wedged in teardown"
+            assert _active_slots() == 0, (
+                "slot still held after [DONE] on the real route; the next chat "
+                "request would queue behind a finished generation"
+            )
+            queue = llama_admission.get_llama_admission_queue("http://llama.test")
+            second = queue.reserve(capacity = 1, config = _ONE_SLOT).lease_nowait()
+            assert second is not None, "next request was refused a free slot"
+            second.release()
+        finally:
+            wedged.set()
+            task.cancel()
+            await asyncio.gather(task, return_exceptions = True)
+
+    asyncio.run(_drive())

--- a/studio/backend/tests/test_gguf_stream_slot_release.py
+++ b/studio/backend/tests/test_gguf_stream_slot_release.py
@@ -3,17 +3,15 @@
 
 """A finished GGUF chat stream must free its llama-server slot at [DONE].
 
-llama-server has a fixed slot count and Unsloth gates concurrent decoding on it
-with an admission lease. The lease used to be released only in the stream's
-outer finally, which does not run until the ASGI response body is torn down, so
-any wedged teardown pinned a slot long after llama-server had freed it and the
-next chat request queued behind a generation that had already finished. The
-queue has no default timeout, so the wait was unbounded.
+llama-server has a fixed slot count, gated by an admission lease. Releasing that lease only in
+the stream's outer finally, which runs at ASGI teardown, let a wedged teardown pin a slot
+llama-server had already freed, so the next chat request queued behind a finished generation
+with no timeout to bound the wait.
 
-The wedge here stands in for the real one: the frontend deliberately does not
-cancel its reader after [DONE] (chat-api.ts), and uvicorn advertises ASGI
-spec_version 2.3, so Starlette's OSError/ClientDisconnect path -- the only
-disconnect detector _SameTaskStreamingResponse keeps -- cannot fire.
+The wedge below stands in for the real one: the frontend never cancels its reader after [DONE]
+(chat-api.ts), and uvicorn advertises ASGI spec_version 2.3, so Starlette's
+OSError/ClientDisconnect path, the only disconnect detector _SameTaskStreamingResponse keeps,
+cannot fire.
 """
 
 import asyncio
@@ -43,8 +41,8 @@ def _active_slots() -> int:
 def test_sse_chunk_is_stream_done_only_matches_the_success_sentinel():
     done = inference_route._sse_chunk_is_stream_done
     assert done("data: [DONE]\n\n")
-    # The error path packs a payload line and the sentinel into one chunk. Its
-    # cleanup has not run yet, so it must not look like a finished stream.
+    # The error path packs a payload line and the sentinel into one chunk, and its cleanup has
+    # not run, so it must not count as a finished stream.
     assert not done('data: {"error": {"message": "boom"}}\n\ndata: [DONE]\n\n')
     assert not done('data: {"choices": [{"delta": {"content": "data: [DONE]"}}]}\n\n')
     assert not done("")
@@ -62,10 +60,8 @@ def _reserve_one_slot():
 
 
 def test_slot_is_freed_at_done_even_if_teardown_never_finishes():
-    """Model the stream's shape: yield chunks, then wedge in the finally.
-
-    Without the release at [DONE] the slot stays held for as long as the
-    teardown is stuck, which is what starved the following request in CI.
+    """Yield chunks, then wedge in the finally: without the release at [DONE] the slot stays
+    held for as long as the teardown is stuck, which is what starved the next request in CI.
     """
     wedged = asyncio.Event()
 
@@ -97,9 +93,8 @@ def test_slot_is_freed_at_done_even_if_teardown_never_finishes():
         saw_done = asyncio.Event()
 
         async def _consume():
-            # Stands in for Starlette's stream_response: it keeps pulling after
-            # the last chunk, so the generator resumes past [DONE] and only then
-            # runs into the wedged teardown.
+            # Like Starlette's stream_response: it keeps pulling after the last chunk, so the
+            # generator resumes past [DONE] and only then runs into the wedged teardown.
             async for chunk in _admitted(lease):
                 seen.append(chunk)
                 if inference_route._sse_chunk_is_stream_done(chunk):
@@ -108,8 +103,7 @@ def test_slot_is_freed_at_done_even_if_teardown_never_finishes():
         task = asyncio.create_task(_consume())
         try:
             await asyncio.wait_for(saw_done.wait(), timeout = 5.0)
-            # Give the generator a turn to resume past the [DONE] yield and
-            # reach the wedge, without letting the wedge end the test.
+            # Give the generator a turn to resume past the [DONE] yield and reach the wedge.
             for _ in range(50):
                 if _active_slots() == 0:
                     break
@@ -158,8 +152,7 @@ def test_stopping_the_disconnect_watcher_cannot_hang():
                 try:
                     await asyncio.sleep(0.01)
                 except asyncio.CancelledError:
-                    # A watcher that swallows cancellation, as the real one does
-                    # for every exception on its way out.
+                    # Swallow cancellation, as the real watcher does on its way out.
                     if release.is_set():
                         raise
                     continue
@@ -203,9 +196,8 @@ class _OneSlotGgufBackend:
 def test_real_stream_frees_the_slot_at_done_with_a_wedged_teardown(monkeypatch):
     """Drive the real ASGI route, wedged exactly where CI wedged.
 
-    ``_stop_local_disconnect_cancel_watcher`` runs in ``gguf_stream_chunks``'s
-    finally on the success path. Hanging it reproduces a response that has sent
-    [DONE] but cannot finish, which is the state the CI job was left in.
+    Hanging ``_stop_local_disconnect_cancel_watcher``, which runs in ``gguf_stream_chunks``'s
+    success-path finally, leaves a response that has sent [DONE] but cannot finish.
     """
     monkeypatch.setattr(inference_route, "get_llama_cpp_backend", lambda: _OneSlotGgufBackend())
     monkeypatch.setattr(inference_route, "_effective_enable_tools", lambda payload: False)

--- a/studio/backend/tests/test_gguf_stream_slot_release.py
+++ b/studio/backend/tests/test_gguf_stream_slot_release.py
@@ -38,17 +38,6 @@ def _active_slots() -> int:
     return sum(queue.snapshot().active for queue in queues)
 
 
-def test_sse_chunk_is_stream_done_only_matches_the_success_sentinel():
-    done = inference_route._sse_chunk_is_stream_done
-    assert done("data: [DONE]\n\n")
-    # The error path packs a payload line and the sentinel into one chunk, and its cleanup has
-    # not run, so it must not count as a finished stream.
-    assert not done('data: {"error": {"message": "boom"}}\n\ndata: [DONE]\n\n')
-    assert not done('data: {"choices": [{"delta": {"content": "data: [DONE]"}}]}\n\n')
-    assert not done("")
-    assert not done(None)
-
-
 _ONE_SLOT = llama_admission.LlamaAdmissionConfig(max_queue = 4)
 
 
@@ -78,7 +67,7 @@ def test_slot_is_freed_at_done_even_if_teardown_never_finishes():
         try:
             async for chunk in iterator:
                 yield chunk
-                if held is not None and inference_route._sse_chunk_is_stream_done(chunk):
+                if held is not None and chunk == inference_route._SSE_DONE_CHUNK:
                     held.release()
         finally:
             if held is not None:
@@ -97,7 +86,7 @@ def test_slot_is_freed_at_done_even_if_teardown_never_finishes():
             # generator resumes past [DONE] and only then runs into the wedged teardown.
             async for chunk in _admitted(lease):
                 seen.append(chunk)
-                if inference_route._sse_chunk_is_stream_done(chunk):
+                if chunk == inference_route._SSE_DONE_CHUNK:
                     saw_done.set()
 
         task = asyncio.create_task(_consume())
@@ -251,7 +240,7 @@ def test_real_stream_frees_the_slot_at_done_with_a_wedged_teardown(monkeypatch):
             frames.append(message)
             if message.get("type") == "http.response.body":
                 chunk = message.get("body", b"").decode()
-                if inference_route._sse_chunk_is_stream_done(chunk):
+                if chunk == inference_route._SSE_DONE_CHUNK:
                     sent_body.set()
 
         task = asyncio.create_task(app(scope, receive, send))

--- a/studio/backend/tests/test_gguf_stream_slot_release_ordering.py
+++ b/studio/backend/tests/test_gguf_stream_slot_release_ordering.py
@@ -1,0 +1,324 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Ordering rules for the early admission release at ``data: [DONE]``.
+
+Freeing the llama-server slot at the sentinel is only correct when two things
+hold, and both are load-bearing on a one-slot backend:
+
+1. The release has to happen *before* the sentinel is handed to the ASGI
+   ``send()``. Starlette's ``StreamingResponse.stream_response`` suspends the
+   body iterator at its ``yield`` for the whole duration of ``await send(...)``,
+   and uvicorn's ``send()`` awaits ``flow.drain()`` whenever the transport is
+   write-paused, so a client that stops reading parks the generator on that
+   ``yield`` indefinitely. Starlette never calls ``aclose()`` on a body
+   iterator, so a consumer that stops pulling at the sentinel leaves the
+   generator's ``finally`` to garbage collection.
+
+2. The sentinel has to actually mean "llama-server is done with this request".
+   Two other emitters end in the same bytes: ``_openai_stream_error_sse``,
+   which is yielded from inside the still-suspended generator's ``except``
+   block, and the cancel path, which breaks the read loop and emits the plain
+   sentinel while the sync generator is still parked on a yield inside
+   ``_open_stream``'s httpx client.
+"""
+
+import asyncio
+import json
+import threading
+
+import pytest
+from fastapi import FastAPI
+
+from auth.authentication import get_current_subject
+from core.inference import llama_admission
+import routes.inference as inference_route
+
+
+@pytest.fixture(autouse = True)
+def _fresh_queues():
+    llama_admission.reset_llama_admission_queues()
+    yield
+    llama_admission.reset_llama_admission_queues()
+
+
+def _active_slots() -> int:
+    with llama_admission._QUEUES_LOCK:
+        queues = list(llama_admission._QUEUES.values())
+    return sum(queue.snapshot().active for queue in queues)
+
+
+class _OneSlotBackend:
+    """A loaded 1-parallel GGUF backend, the shape CI runs."""
+
+    is_loaded = True
+    model_identifier = "test/model.gguf"
+    base_url = "http://llama.test"
+    effective_parallel_slots = 1
+    _is_audio = False
+    is_vision = False
+    supports_tools = False
+
+    def __init__(self):
+        self.closing = threading.Event()
+        self.finish_close = threading.Event()
+        self.closed = threading.Event()
+        self.cancel_event = None
+
+    def generate_chat_completion(self, **kwargs):
+        raise NotImplementedError
+
+
+class _CompletingBackend(_OneSlotBackend):
+    def generate_chat_completion(self, **kwargs):
+        yield "hi"
+        yield {
+            "type": "metadata",
+            "usage": {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4},
+            "timings": {"prompt_n": 3, "predicted_n": 1},
+            "finish_reason": "stop",
+        }
+
+
+class _FailsMidStreamBackend(_OneSlotBackend):
+    """Still decoding when the route's own chunk handling blows up.
+
+    ``gen`` stays parked on its ``yield`` until the stream's ``finally`` closes
+    it, and only that close drops the httpx stream llama-server is writing to.
+    """
+
+    def generate_chat_completion(self, **kwargs):
+        try:
+            yield "a"
+            yield "ab"
+            yield "abc"
+        except GeneratorExit:
+            self.closing.set()
+            # Stand in for the time llama-server needs to notice the dropped
+            # connection and free its slot.
+            self.finish_close.wait(10.0)
+            self.closed.set()
+            raise
+
+
+class _CancelledMidStreamBackend(_OneSlotBackend):
+    """Cancelled by the user halfway through, the Stop-button path."""
+
+    def generate_chat_completion(self, cancel_event = None, **kwargs):
+        self.cancel_event = cancel_event
+        try:
+            yield "a"
+            cancel_event.set()
+            yield "ab"
+            yield "abc"
+        except GeneratorExit:
+            self.closed.set()
+            raise
+
+
+def _scope(app, body: bytes) -> dict:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/chat/completions",
+        "raw_path": b"/chat/completions",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [
+            (b"host", b"testserver"),
+            (b"content-type", b"application/json"),
+            (b"content-length", str(len(body)).encode()),
+        ],
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 80),
+        "app": app,
+    }
+
+
+def _build_app(monkeypatch, backend):
+    monkeypatch.setattr(inference_route, "get_llama_cpp_backend", lambda: backend)
+    monkeypatch.setattr(inference_route, "_effective_enable_tools", lambda payload: False)
+    app = FastAPI()
+    app.include_router(inference_route.router)
+    app.dependency_overrides[get_current_subject] = lambda: "test-user"
+    return app
+
+
+def _request_body() -> bytes:
+    return json.dumps(
+        {"messages": [{"role": "user", "content": "hi"}], "stream": True}
+    ).encode()
+
+
+def test_slot_is_free_before_the_done_frame_reaches_send(monkeypatch):
+    """The release must not sit behind ``await send(...)``.
+
+    uvicorn's ``send()`` awaits ``flow.drain()`` when the socket is write-paused
+    (uvicorn/protocols/http/h11_impl.py), so a client that stops reading parks
+    the body iterator on its ``yield`` for as long as it likes. Anything after
+    that ``yield`` is unreachable, and Starlette never ``aclose()``s the
+    iterator, so the outer ``finally`` is left to GC.
+    """
+    backend = _CompletingBackend()
+    app = _build_app(monkeypatch, backend)
+
+    async def _drive():
+        body = _request_body()
+        frames = []
+        slots_at_done = []
+        finished = asyncio.Event()
+
+        async def receive():
+            if not frames:
+                return {"type": "http.request", "body": body, "more_body": False}
+            await asyncio.Event().wait()
+
+        async def send(message):
+            frames.append(message)
+            if message.get("type") != "http.response.body":
+                return
+            if message.get("body", b"").decode() == "data: [DONE]\n\n":
+                # Sampled exactly where a stalled client would wedge.
+                slots_at_done.append(_active_slots())
+                finished.set()
+
+        task = asyncio.create_task(app(_scope(app, body), receive, send))
+        try:
+            await asyncio.wait_for(finished.wait(), timeout = 20.0)
+        finally:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions = True)
+
+        assert slots_at_done == [0], (
+            "the slot was still held while the [DONE] frame was being written; "
+            "a client that stops reading would pin it there indefinitely"
+        )
+
+    asyncio.run(_drive())
+
+
+def test_error_sentinel_keeps_the_slot_until_the_generator_is_closed(monkeypatch):
+    """``_openai_stream_error_sse`` ends in ``data: [DONE]`` but is not a finish.
+
+    It is yielded from inside ``gguf_stream_chunks``'s ``except`` block, so the
+    generator has not yet run its ``finally``: the cancel event is unset, the
+    worker is undrained and ``gen`` -- with llama-server still streaming into
+    it -- is still open. Handing the slot to the next request there puts two
+    callers on a one-slot backend.
+    """
+    backend = _FailsMidStreamBackend()
+    app = _build_app(monkeypatch, backend)
+
+    calls = {"n": 0}
+
+    def _boom(monitor_id, text):
+        calls["n"] += 1
+        if calls["n"] >= 2:
+            raise RuntimeError("chunk handling failed")
+
+    monkeypatch.setattr(inference_route.api_monitor, "append_reply", _boom)
+
+    async def _drive():
+        body = _request_body()
+        frames = []
+        saw_error = asyncio.Event()
+
+        async def receive():
+            if not frames:
+                return {"type": "http.request", "body": body, "more_body": False}
+            await asyncio.Event().wait()
+
+        async def send(message):
+            frames.append(message)
+            if message.get("type") != "http.response.body":
+                return
+            chunk = message.get("body", b"").decode()
+            # The error form: a payload line plus the sentinel, in one chunk.
+            if chunk.endswith("data: [DONE]\n\n") and chunk != "data: [DONE]\n\n":
+                saw_error.set()
+
+        task = asyncio.create_task(app(_scope(app, body), receive, send))
+        try:
+            await asyncio.wait_for(saw_error.wait(), timeout = 20.0)
+            # Wait until cleanup is inside gen.close(), i.e. llama-server is
+            # still holding the slot for the request that just failed.
+            for _ in range(500):
+                if backend.closing.is_set():
+                    break
+                await asyncio.sleep(0.01)
+            assert backend.closing.is_set(), "cleanup never reached gen.close()"
+            assert _active_slots() == 1, (
+                "slot handed out while the failed request still owned "
+                "llama-server; the next request would exceed the configured "
+                "parallelism"
+            )
+        finally:
+            backend.finish_close.set()
+            task.cancel()
+            await asyncio.gather(task, return_exceptions = True)
+
+    asyncio.run(_drive())
+
+
+def test_cancelled_stream_keeps_the_slot_until_the_generator_is_closed(monkeypatch):
+    """A cancelled stream emits the plain sentinel with ``gen`` still open.
+
+    ``cancel_event.is_set()`` breaks the read loop at the top, so the sync
+    generator is never driven to StopIteration: it stays parked on a ``yield``
+    inside ``_open_stream``'s ``with httpx.Client(...)``. ``stream_completed``
+    is set all the same, which also makes the ``finally`` skip ``gen.close()``,
+    so ``data: [DONE]`` here does not mean llama-server is finished.
+    """
+    backend = _CancelledMidStreamBackend()
+    app = _build_app(monkeypatch, backend)
+
+    wedged = asyncio.Event()
+
+    async def _hang(watcher, *args, **kwargs):
+        watcher.cancel()
+        await wedged.wait()
+
+    monkeypatch.setattr(inference_route, "_stop_local_disconnect_cancel_watcher", _hang)
+
+    async def _drive():
+        body = _request_body()
+        frames = []
+        saw_done = asyncio.Event()
+
+        async def receive():
+            if not frames:
+                return {"type": "http.request", "body": body, "more_body": False}
+            await asyncio.Event().wait()
+
+        async def send(message):
+            frames.append(message)
+            if message.get("type") != "http.response.body":
+                return
+            if message.get("body", b"").decode() == "data: [DONE]\n\n":
+                saw_done.set()
+
+        task = asyncio.create_task(app(_scope(app, body), receive, send))
+        try:
+            await asyncio.wait_for(saw_done.wait(), timeout = 20.0)
+            for _ in range(50):
+                if _active_slots() == 0:
+                    break
+                await asyncio.sleep(0.01)
+            assert backend.cancel_event is not None and backend.cancel_event.is_set()
+            assert not backend.closed.is_set(), (
+                "test setup: the generator should still be open here"
+            )
+            assert _active_slots() == 1, (
+                "slot freed on a cancelled stream whose llama-server request is "
+                "still open; the next request would exceed the configured "
+                "parallelism"
+            )
+        finally:
+            wedged.set()
+            task.cancel()
+            await asyncio.gather(task, return_exceptions = True)
+
+    asyncio.run(_drive())

--- a/studio/backend/tests/test_gguf_stream_slot_release_ordering.py
+++ b/studio/backend/tests/test_gguf_stream_slot_release_ordering.py
@@ -3,24 +3,19 @@
 
 """Ordering rules for the early admission release at ``data: [DONE]``.
 
-Freeing the llama-server slot at the sentinel is only correct when two things
-hold, and both are load-bearing on a one-slot backend:
+Freeing the llama-server slot at the sentinel is only correct when two things hold, and on a
+one-slot backend both are load-bearing:
 
-1. The release has to happen *before* the sentinel is handed to the ASGI
-   ``send()``. Starlette's ``StreamingResponse.stream_response`` suspends the
-   body iterator at its ``yield`` for the whole duration of ``await send(...)``,
-   and uvicorn's ``send()`` awaits ``flow.drain()`` whenever the transport is
-   write-paused, so a client that stops reading parks the generator on that
-   ``yield`` indefinitely. Starlette never calls ``aclose()`` on a body
-   iterator, so a consumer that stops pulling at the sentinel leaves the
-   generator's ``finally`` to garbage collection.
+1. The release happens *before* the sentinel reaches the ASGI ``send()``. Starlette's
+   ``stream_response`` suspends the body iterator at its ``yield`` for the whole of
+   ``await send(...)``, and uvicorn's ``send()`` awaits ``flow.drain()`` on a write-paused
+   transport, so a client that stops reading parks the generator there indefinitely. Starlette
+   never ``aclose()``s a body iterator either, so that generator's ``finally`` is left to GC.
 
-2. The sentinel has to actually mean "llama-server is done with this request".
-   Two other emitters end in the same bytes: ``_openai_stream_error_sse``,
-   which is yielded from inside the still-suspended generator's ``except``
-   block, and the cancel path, which breaks the read loop and emits the plain
-   sentinel while the sync generator is still parked on a yield inside
-   ``_open_stream``'s httpx client.
+2. The sentinel really means "llama-server is done with this request". Two other emitters end
+   in the same bytes: ``_openai_stream_error_sse``, yielded from inside the still-suspended
+   generator's ``except`` block, and the cancel path, which breaks the read loop while the sync
+   generator is still parked on a yield inside ``_open_stream``'s httpx client.
 """
 
 import asyncio
@@ -83,8 +78,8 @@ class _CompletingBackend(_OneSlotBackend):
 class _FailsMidStreamBackend(_OneSlotBackend):
     """Still decoding when the route's own chunk handling blows up.
 
-    ``gen`` stays parked on its ``yield`` until the stream's ``finally`` closes
-    it, and only that close drops the httpx stream llama-server is writing to.
+    ``gen`` stays parked on its ``yield`` until the stream's ``finally`` closes it, and only
+    that close drops the httpx stream llama-server is writing to.
     """
 
     def generate_chat_completion(self, **kwargs):
@@ -94,8 +89,7 @@ class _FailsMidStreamBackend(_OneSlotBackend):
             yield "abc"
         except GeneratorExit:
             self.closing.set()
-            # Stand in for the time llama-server needs to notice the dropped
-            # connection and free its slot.
+            # Stand in for the time llama-server needs to notice the drop and free its slot.
             self.finish_close.wait(10.0)
             self.closed.set()
             raise
@@ -158,11 +152,10 @@ def _request_body() -> bytes:
 def test_slot_is_free_before_the_done_frame_reaches_send(monkeypatch):
     """The release must not sit behind ``await send(...)``.
 
-    uvicorn's ``send()`` awaits ``flow.drain()`` when the socket is write-paused
-    (uvicorn/protocols/http/h11_impl.py), so a client that stops reading parks
-    the body iterator on its ``yield`` for as long as it likes. Anything after
-    that ``yield`` is unreachable, and Starlette never ``aclose()``s the
-    iterator, so the outer ``finally`` is left to GC.
+    uvicorn's ``send()`` awaits ``flow.drain()`` on a write-paused socket (h11_impl.py), so a
+    client that stops reading parks the body iterator on its ``yield`` indefinitely. Anything
+    after that ``yield`` is unreachable, and Starlette never ``aclose()``s the iterator, so the
+    outer ``finally`` is left to GC.
     """
     backend = _CompletingBackend()
     app = _build_app(monkeypatch, backend)
@@ -205,11 +198,10 @@ def test_slot_is_free_before_the_done_frame_reaches_send(monkeypatch):
 def test_error_sentinel_keeps_the_slot_until_the_generator_is_closed(monkeypatch):
     """``_openai_stream_error_sse`` ends in ``data: [DONE]`` but is not a finish.
 
-    It is yielded from inside ``gguf_stream_chunks``'s ``except`` block, so the
-    generator has not yet run its ``finally``: the cancel event is unset, the
-    worker is undrained and ``gen`` -- with llama-server still streaming into
-    it -- is still open. Handing the slot to the next request there puts two
-    callers on a one-slot backend.
+    It is yielded from inside ``gguf_stream_chunks``'s ``except`` block, so the generator has
+    not yet run its ``finally``: the worker is undrained and ``gen`` is still open with
+    llama-server streaming into it. Freeing the slot there puts two callers on a one-slot
+    backend.
     """
     backend = _FailsMidStreamBackend()
     app = _build_app(monkeypatch, backend)
@@ -245,8 +237,7 @@ def test_error_sentinel_keeps_the_slot_until_the_generator_is_closed(monkeypatch
         task = asyncio.create_task(app(_scope(app, body), receive, send))
         try:
             await asyncio.wait_for(saw_error.wait(), timeout = 20.0)
-            # Wait until cleanup is inside gen.close(), i.e. llama-server is
-            # still holding the slot for the request that just failed.
+            # Wait until cleanup reaches gen.close(), so llama-server still holds the slot.
             for _ in range(500):
                 if backend.closing.is_set():
                     break
@@ -268,11 +259,10 @@ def test_error_sentinel_keeps_the_slot_until_the_generator_is_closed(monkeypatch
 def test_cancelled_stream_keeps_the_slot_until_the_generator_is_closed(monkeypatch):
     """A cancelled stream emits the plain sentinel with ``gen`` still open.
 
-    ``cancel_event.is_set()`` breaks the read loop at the top, so the sync
-    generator is never driven to StopIteration: it stays parked on a ``yield``
-    inside ``_open_stream``'s ``with httpx.Client(...)``. ``stream_completed``
-    is set all the same, which also makes the ``finally`` skip ``gen.close()``,
-    so ``data: [DONE]`` here does not mean llama-server is finished.
+    ``cancel_event.is_set()`` breaks the read loop at the top, so the sync generator never
+    reaches StopIteration and stays parked on a ``yield`` inside ``_open_stream``'s httpx
+    client. ``stream_completed`` is set all the same, which also makes the ``finally`` skip
+    ``gen.close()``, so ``data: [DONE]`` here does not mean llama-server is finished.
     """
     backend = _CancelledMidStreamBackend()
     app = _build_app(monkeypatch, backend)

--- a/studio/backend/tests/test_gguf_stream_slot_release_ordering.py
+++ b/studio/backend/tests/test_gguf_stream_slot_release_ordering.py
@@ -104,7 +104,11 @@ class _FailsMidStreamBackend(_OneSlotBackend):
 class _CancelledMidStreamBackend(_OneSlotBackend):
     """Cancelled by the user halfway through, the Stop-button path."""
 
-    def generate_chat_completion(self, cancel_event = None, **kwargs):
+    def generate_chat_completion(
+        self,
+        cancel_event = None,
+        **kwargs,
+    ):
         self.cancel_event = cancel_event
         try:
             yield "a"
@@ -148,9 +152,7 @@ def _build_app(monkeypatch, backend):
 
 
 def _request_body() -> bytes:
-    return json.dumps(
-        {"messages": [{"role": "user", "content": "hi"}], "stream": True}
-    ).encode()
+    return json.dumps({"messages": [{"role": "user", "content": "hi"}], "stream": True}).encode()
 
 
 def test_slot_is_free_before_the_done_frame_reaches_send(monkeypatch):
@@ -308,9 +310,9 @@ def test_cancelled_stream_keeps_the_slot_until_the_generator_is_closed(monkeypat
                     break
                 await asyncio.sleep(0.01)
             assert backend.cancel_event is not None and backend.cancel_event.is_set()
-            assert not backend.closed.is_set(), (
-                "test setup: the generator should still be open here"
-            )
+            assert (
+                not backend.closed.is_set()
+            ), "test setup: the generator should still be open here"
             assert _active_slots() == 1, (
                 "slot freed on a cancelled stream whose llama-server request is "
                 "still open; the next request would exceed the configured "


### PR DESCRIPTION
The `Chat UI Tests` job has been timing out intermittently across many unrelated branches. Digging into the artifacts of one failure, it is a real Studio bug, not a Playwright flake: a chat request that has finished generating keeps its llama-server slot until the HTTP response is torn down, so the next chat request queues behind a generation that is already over. The admission queue has no default timeout (`DEFAULT_ADMISSION_QUEUE_TIMEOUT_S = None`), so that wait is unbounded.

## What the artifacts show

Correlating the Studio request log with the llama-server log from run 30326911000 (offsets line up one-to-one across all six generations):

| | turn 6 | turn 7 |
| --- | --- | --- |
| POST `/v1/chat/completions` starts | 05:02:26.0902 | 05:02:26.4586 |
| llama-server task | 32 launched 26.094, released 26.182 | never launched |
| POST completes | 05:05:26.5157 (180425 ms) | 05:05:26.4949 (180036 ms) |

llama-server freed its only slot 180 seconds before Studio let go of it. Turn 7 never reached llama-server at all: it sat in `_openai_admission_wait_stream_chunks` emitting keepalives until the browser was torn down. The event loop served eight other requests in between, so nothing was blocked, and `n_slots = 1` in that job.

Turn 6 did reach `[DONE]`. The screenshot shows its answer rendered and the context counter at 117, and that counter is written from the SSE usage chunk after the streaming loop exits, which only happens on `[DONE]` or EOF. The body stayed open for 180 s, so it was `[DONE]`.

## Why nothing recovered

- The frontend deliberately does not cancel its reader after a natural `[DONE]` (`chat-api.ts`), so the request stays open until navigation.
- `_SameTaskStreamingResponse` overrides `__call__` and detects disconnects only by `send()` raising `OSError`. uvicorn advertises ASGI `spec_version 2.3` and its `send()` returns silently when disconnected, and Starlette gates that `OSError` path on `spec_version >= (2, 4)`. So under uvicorn the branch cannot fire, and the stock `listen_for_disconnect` task group that would have fired was replaced.
- No stall guard covers this. `_DEFAULT_STREAM_STALL_TIMEOUT_S` bounds gaps between upstream llama-server reads and stops applying once `[DONE]` is parsed; `_openai_compat_stream_stall_timeout()` covers only the passthrough proxy; `_LOCAL_TOOL_STREAM_STALL_KEEPALIVE_S` is a cadence, not a cap. Hence 180 s (the Playwright budget), never 120 s.

## Changes

**1. Release the admission lease when the decode is genuinely over.** The lease was released only in the stream's outer `finally`, which does not run until the ASGI body is torn down. Three conditions now gate the early release, all three needed:

- **Before the yield, not after.** Starlette's `stream_response` suspends the body iterator across the whole of `await send(...)`, uvicorn's `send()` awaits `flow.drain()` once the socket is write-paused, and Starlette never `aclose()`s a body iterator. So a client that stops reading parks the generator on the `yield` and anything after it is deferred to GC.
- **Exact equality with the bare success sentinel.** `_openai_stream_error_sse` (`:434`) also ends in `[DONE]`, but it is yielded from the inner generator's `except` block ahead of the `finally` that sets the cancel event, drains the worker and closes `gen`, so the sync generator can still be parked inside `_open_stream`'s httpx client.
- **Only when the sync generator returned on its own.** The cancel path breaks the read loop at `:10062` and falls through to `stream_completed = True` and the plain sentinel at `:10156` without ever driving `gen` to `StopIteration`, and the `finally` then skips `gen.close()`. Pressing Stop is ordinary traffic, so the sentinel alone does not prove llama-server is finished.

`release()` is idempotent, so the existing `finally` stays a correct backstop. Applied to both `admitted_gguf_stream_chunks` and `admitted_gguf_tool_stream`, which share the queue.

**2. Bound the disconnect-watcher stop.** `_stop_local_disconnect_cancel_watcher` ran `await watcher` with no timeout, inside the stream's `finally`. `asyncio.wait` never cancels its argument and never re-raises, so the watcher can be abandoned after a timeout; it is a poll loop holding no resources.

This is the amplification, and it is what makes the failure user-visible. Anyone on a 1-slot backend who sends a second message after a response wedges gets "Generating..." forever with no error, and two further consequences of the response never terminating: the `ActiveGeneration` tracker stays open, and `LlamaKeepWarmMiddleware._finish()` never fires, so idle auto-unload stops working.

I have not found what wedges the teardown in the first place. Candidates in that `finally` are narrow, but I could not reproduce it: 7 clean end-to-end runs of the CI Playwright test locally (including with the stack pinned to 2 cores), 7 sequential and 7 held-open HTTP turns, and several thousand synthetic uvicorn requests all came back clean. It needs the 4-vCPU runner under CPU inference load. Decoupling the slot means the wedge no longer takes the next request down with it.

## Tests

`tests/test_gguf_stream_slot_release.py` drives the **real ASGI route** with `_stop_local_disconnect_cancel_watcher` monkeypatched to hang, putting the response in exactly the state the CI job was left in, and a `receive` that never disconnects, matching the browser. It asserts the slot is free once the `[DONE]` frame has been sent and that a second caller is admitted immediately.

`tests/test_gguf_stream_slot_release_ordering.py` covers the three gating conditions, each against the real route:

| test | covers |
| --- | --- |
| `test_slot_is_free_before_the_done_frame_reaches_send` | release must precede the yield |
| `test_error_sentinel_keeps_the_slot_until_the_generator_is_closed` | error form must not free the slot |
| `test_cancelled_stream_keeps_the_slot_until_the_generator_is_closed` | cancel path must not free the slot |

All four route-level tests fail without the corresponding source change and pass with it, verified by reverting.

- `test_gguf_stream_slot_release.py` + `..._ordering.py` + admission, stream-cancel and tool-passthrough suites: 344 passed
- full backend suite under the CI invocation: 10981 passed. The 12 failures are RAG, MCP and secure-tools modules that fail identically on clean `main` here (missing optional deps and network cases).
- staging cross-platform CI (ubuntu-latest, macos-14, windows-latest) plus a Playwright studio run.
