### PR TITLE
Fix multiline prompts through Windows npm shims

### DIFF
--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -2555,6 +2555,34 @@ def _wsl_shim_env(command: list, env: dict, unset_env: tuple) -> tuple[dict, tup
     return env, (*wsl_env_bridge, "PWD/p")
 
 
+def _resolved_launch_command(executable: str, arguments: list) -> list:
+    """Return an argv that preserves arguments through Windows npm shims."""
+    if os.name == "nt" and Path(executable).suffix.lower() in {".cmd", ".bat"}:
+        # cmd.exe treats CR/LF inside `%*` as command separators, and Windows
+        # PowerShell's native-command bridge also rewrites embedded quotes. npm's
+        # generated shim names its real entry point explicitly, so bypass the shell
+        # and let subprocess apply Windows argv quoting directly.
+        with contextlib.suppress(OSError, UnicodeError):
+            shim = Path(executable)
+            contents = shim.read_text(encoding = "utf-8")
+            matches = re.findall(r'"%dp0%[\\/](?P<target>[^"]+)"\s+%\*', contents)
+            for relative in reversed(matches):
+                if not relative.replace("/", "\\").lower().startswith("node_modules\\"):
+                    continue
+                target = shim.parent / Path(relative)
+                if not target.is_file():
+                    continue
+                suffix = target.suffix.lower()
+                if suffix in {".exe", ".com"}:
+                    return [str(target), *arguments]
+                if suffix in {".js", ".cjs", ".mjs"}:
+                    bundled_node = shim.parent / "node.exe"
+                    node = str(bundled_node) if bundled_node.is_file() else shutil.which("node")
+                    if node:
+                        return [node, str(target), *arguments]
+    return [executable, *arguments]
+
+
 def _launch(
     command: list,
     env: dict,
@@ -2587,7 +2615,8 @@ def _launch(
     # Ctrl+C cancels a turn inside the agent; don't let it kill this wrapper.
     previous = signal.signal(signal.SIGINT, signal.SIG_IGN)
     try:
-        code = subprocess.run([executable, *command[1:]], env = child_env).returncode
+        launch_command = _resolved_launch_command(executable, command[1:])
+        code = subprocess.run(launch_command, env = child_env).returncode
     finally:
         signal.signal(signal.SIGINT, previous)
     # Negative returncode means killed by signal N; shells expect 128+N.

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -2581,8 +2581,7 @@ _NPM_NODE_CMD_SHIM = re.compile(
     re.IGNORECASE,
 )
 _NPM_NATIVE_CMD_SHIM = re.compile(
-    re.escape(_NPM_CMD_SHIM_HEAD)
-    + r'"%dp0%\\(?P<target>[^"\r\n]+)"[ \t]+%\*',
+    re.escape(_NPM_CMD_SHIM_HEAD) + r'"%dp0%\\(?P<target>[^"\r\n]+)"[ \t]+%\*',
     re.IGNORECASE,
 )
 

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -2699,7 +2699,7 @@ def _resolved_launch_command(
                     continue
                 node_args, environment_updates = metadata
                 bundled_node = shim.parent / "node.exe"
-                node = str(bundled_node) if bundled_node.is_file() else shutil.which("node")
+                node = str(bundled_node) if bundled_node.is_file() else shutil.which("node.exe")
                 if node:
                     if environment is not None:
                         _apply_windows_environment(environment, environment_updates)

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -2555,27 +2555,65 @@ def _wsl_shim_env(command: list, env: dict, unset_env: tuple) -> tuple[dict, tup
     return env, (*wsl_env_bridge, "PWD/p")
 
 
+_NPM_CMD_SHIM_HEAD = (
+    "@ECHO off\n"
+    "GOTO start\n"
+    ":find_dp0\n"
+    "SET dp0=%~dp0\n"
+    "EXIT /b\n"
+    ":start\n"
+    "SETLOCAL\n"
+    "CALL :find_dp0\n"
+)
+_NPM_NODE_CMD_SHIM = re.compile(
+    re.escape(
+        _NPM_CMD_SHIM_HEAD
+        + '\nIF EXIST "%dp0%\\node.exe" (\n'
+        + '  SET "_prog=%dp0%\\node.exe"\n'
+        + ") ELSE (\n"
+        + '  SET "_prog=node"\n'
+        + "  SET PATHEXT=%PATHEXT:;.JS;=;%\n"
+        + ")\n"
+        + "\n"
+        + 'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"'
+    )
+    + r'[ \t]+"%dp0%\\(?P<target>[^"\r\n]+)"[ \t]+%\*',
+    re.IGNORECASE,
+)
+_NPM_NATIVE_CMD_SHIM = re.compile(
+    re.escape(_NPM_CMD_SHIM_HEAD)
+    + r'"%dp0%\\(?P<target>[^"\r\n]+)"[ \t]+%\*',
+    re.IGNORECASE,
+)
+
+
 def _resolved_launch_command(executable: str, arguments: list) -> list:
     """Return an argv that preserves arguments through Windows npm shims."""
     if os.name == "nt" and Path(executable).suffix.lower() in {".cmd", ".bat"}:
         # cmd.exe treats CR/LF inside `%*` as command separators, and Windows
-        # PowerShell's native-command bridge also rewrites embedded quotes. npm's
-        # generated shim names its real entry point explicitly, so bypass the shell
-        # and let subprocess apply Windows argv quoting directly.
+        # PowerShell's native-command bridge also rewrites embedded quotes. Match
+        # cmd-shim's complete generated structure so a custom wrapper that happens
+        # to invoke a node_modules entry point keeps its setup behavior.
         with contextlib.suppress(OSError, UnicodeError):
             shim = Path(executable)
-            contents = shim.read_text(encoding = "utf-8")
-            matches = re.findall(r'"%dp0%[\\/](?P<target>[^"]+)"\s+%\*', contents)
-            for relative in reversed(matches):
-                if not relative.replace("/", "\\").lower().startswith("node_modules\\"):
+            contents = shim.read_text(encoding = "utf-8").replace("\r\n", "\n").strip()
+            for pattern, uses_node in (
+                (_NPM_NODE_CMD_SHIM, True),
+                (_NPM_NATIVE_CMD_SHIM, False),
+            ):
+                match = pattern.fullmatch(contents)
+                if match is None:
                     continue
-                target = shim.parent / Path(relative)
-                if not target.is_file():
+                relative = Path(*re.split(r"[\\/]+", match.group("target")))
+                target = (shim.parent / relative).resolve()
+                if not target.is_file() or not any(
+                    part.casefold() == "node_modules" for part in target.parts
+                ):
                     continue
                 suffix = target.suffix.lower()
-                if suffix in {".exe", ".com"}:
+                if not uses_node and suffix in {".exe", ".com"}:
                     return [str(target), *arguments]
-                if suffix in {".js", ".cjs", ".mjs"}:
+                if uses_node and suffix in {".js", ".cjs", ".mjs"}:
                     bundled_node = shim.parent / "node.exe"
                     node = str(bundled_node) if bundled_node.is_file() else shutil.which("node")
                     if node:

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -2565,41 +2565,126 @@ _NPM_CMD_SHIM_HEAD = (
     "SETLOCAL\n"
     "CALL :find_dp0\n"
 )
-_NPM_NODE_CMD_SHIM = re.compile(
-    re.escape(
-        _NPM_CMD_SHIM_HEAD
-        + '\nIF EXIST "%dp0%\\node.exe" (\n'
+_NPM_NODE_CMD_SHIM_PREFIX = (
+    re.escape(_NPM_CMD_SHIM_HEAD)
+    + r"(?P<environment>(?:@SET [^=\r\n]+=[^\r\n]+\n)*)"
+    + re.escape(
+        '\nIF EXIST "%dp0%\\node.exe" (\n'
         + '  SET "_prog=%dp0%\\node.exe"\n'
         + ") ELSE (\n"
         + '  SET "_prog=node"\n'
-        + "  SET PATHEXT=%PATHEXT:;.JS;=;%\n"
-        + ")\n"
-        + "\n"
-        + 'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"'
     )
-    + r'[ \t]+"%dp0%\\(?P<target>[^"\r\n]+)"[ \t]+%\*',
-    re.IGNORECASE,
+)
+_NPM_NODE_CMD_SHIM_SUFFIX = (
+    r"(?P<node_args>[^\r\n]*?)[ \t]+" + r'"%dp0%\\(?P<target>[^"\r\n]+)"[ \t]+%\*'
+)
+_NPM_NODE_CMD_SHIMS = (
+    re.compile(
+        _NPM_NODE_CMD_SHIM_PREFIX
+        + re.escape(
+            "  SET PATHEXT=%PATHEXT:;.JS;=;%\n"
+            + ")\n\n"
+            + 'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"'
+        )
+        + _NPM_NODE_CMD_SHIM_SUFFIX,
+        re.IGNORECASE,
+    ),
+    re.compile(
+        _NPM_NODE_CMD_SHIM_PREFIX
+        + re.escape(
+            ")\n\n"
+            + "endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "
+            + "set PATHEXT=%PATHEXT:;.JS;=;% & "
+            + '"%_prog%"'
+        )
+        + _NPM_NODE_CMD_SHIM_SUFFIX,
+        re.IGNORECASE,
+    ),
 )
 _NPM_NATIVE_CMD_SHIM = re.compile(
     re.escape(_NPM_CMD_SHIM_HEAD) + r'"%dp0%\\(?P<target>[^"\r\n]+)"[ \t]+%\*',
     re.IGNORECASE,
 )
+_NPM_NODE_SHEBANG = re.compile(
+    r"^#!\s*(?:/usr/bin/env\s+(?:-S\s+)?((?:[^ \t=]+=[^ \t=]+\s+)*))?([^ \t]+)(.*)$"
+)
+_NPM_SHEBANG_DOLLAR = re.compile(r"\$\{?([^$@#?\- \t{}:]+)\}?")
 
 
-def _resolved_launch_command(executable: str, arguments: list) -> list:
-    """Return an argv that preserves arguments through Windows npm shims."""
+def _npm_batch_environment(declarations: str) -> str:
+    lines = []
+    for declaration in declarations.split():
+        name, separator, value = declaration.partition("=")
+        name = name.strip()
+        value = value.strip()
+        if separator and name and value:
+            value = _NPM_SHEBANG_DOLLAR.sub(lambda match: f"%{match.group(1)}%", value)
+            lines.append(f"@SET {name}={value}\n")
+    return "".join(lines)
+
+
+def _windows_expand_environment(value: str, environment: dict) -> str:
+    folded = {name.casefold(): item for name, item in environment.items()}
+    return re.sub(
+        r"%([^%\r\n]+)%",
+        lambda match: folded.get(match.group(1).casefold(), ""),
+        value,
+    )
+
+
+def _npm_node_shim_metadata(target: Path, match, environment: dict) -> Optional[tuple]:
+    environment_block = match.group("environment") or ""
+    node_args_text = (match.group("node_args") or "").strip()
+    known_node_suffix = target.suffix.lower() in {".js", ".cjs", ".mjs"}
+    if not environment_block and not node_args_text and known_node_suffix:
+        return [], {}
+
+    first_line = target.read_text(encoding = "utf-8").splitlines()[0]
+    shebang = _NPM_NODE_SHEBANG.fullmatch(first_line)
+    if shebang is None or Path(shebang.group(2)).name.casefold() not in {"node", "node.exe"}:
+        return None
+    declarations = shebang.group(1) or ""
+    if _npm_batch_environment(declarations).casefold() != environment_block.casefold():
+        return None
+    if (shebang.group(3) or "").strip() != node_args_text:
+        return None
+    try:
+        node_args = shlex.split(node_args_text) if node_args_text else []
+    except ValueError:
+        return None
+
+    updates = {}
+    expanded_environment = dict(environment)
+    for line in environment_block.splitlines():
+        name, value = line.removeprefix("@SET ").split("=", 1)
+        expanded = _windows_expand_environment(value, expanded_environment)
+        expanded_environment[name] = expanded
+        updates[name] = expanded
+    return node_args, updates
+
+
+def _apply_windows_environment(environment: dict, updates: dict) -> None:
+    for name, value in updates.items():
+        existing = next((key for key in environment if key.casefold() == name.casefold()), None)
+        if existing is not None and existing != name:
+            del environment[existing]
+        environment[name] = value
+
+
+def _resolved_launch_command(
+    executable: str,
+    arguments: list,
+    environment: Optional[dict] = None,
+) -> list:
+    """Return an argv that preserves arguments through standard Windows npm shims."""
     if os.name == "nt" and Path(executable).suffix.lower() in {".cmd", ".bat"}:
         # cmd.exe treats CR/LF inside `%*` as command separators, and Windows
         # PowerShell's native-command bridge also rewrites embedded quotes. Match
-        # cmd-shim's complete generated structure so a custom wrapper that happens
-        # to invoke a node_modules entry point keeps its setup behavior.
-        with contextlib.suppress(OSError, UnicodeError):
+        # complete cmd-shim templates so custom wrappers keep their setup behavior.
+        with contextlib.suppress(OSError, UnicodeError, IndexError):
             shim = Path(executable)
             contents = shim.read_text(encoding = "utf-8").replace("\r\n", "\n").strip()
-            for pattern, uses_node in (
-                (_NPM_NODE_CMD_SHIM, True),
-                (_NPM_NATIVE_CMD_SHIM, False),
-            ):
+            for pattern in _NPM_NODE_CMD_SHIMS:
                 match = pattern.fullmatch(contents)
                 if match is None:
                     continue
@@ -2609,14 +2694,27 @@ def _resolved_launch_command(executable: str, arguments: list) -> list:
                     part.casefold() == "node_modules" for part in target.parts
                 ):
                     continue
-                suffix = target.suffix.lower()
-                if not uses_node and suffix in {".exe", ".com"}:
+                metadata = _npm_node_shim_metadata(target, match, environment or os.environ)
+                if metadata is None:
+                    continue
+                node_args, environment_updates = metadata
+                bundled_node = shim.parent / "node.exe"
+                node = str(bundled_node) if bundled_node.is_file() else shutil.which("node")
+                if node:
+                    if environment is not None:
+                        _apply_windows_environment(environment, environment_updates)
+                    return [node, *node_args, str(target), *arguments]
+
+            match = _NPM_NATIVE_CMD_SHIM.fullmatch(contents)
+            if match is not None:
+                relative = Path(*re.split(r"[\\/]+", match.group("target")))
+                target = (shim.parent / relative).resolve()
+                if (
+                    target.is_file()
+                    and any(part.casefold() == "node_modules" for part in target.parts)
+                    and target.suffix.lower() in {".exe", ".com"}
+                ):
                     return [str(target), *arguments]
-                if uses_node and suffix in {".js", ".cjs", ".mjs"}:
-                    bundled_node = shim.parent / "node.exe"
-                    node = str(bundled_node) if bundled_node.is_file() else shutil.which("node")
-                    if node:
-                        return [node, str(target), *arguments]
     return [executable, *arguments]
 
 
@@ -2652,7 +2750,7 @@ def _launch(
     # Ctrl+C cancels a turn inside the agent; don't let it kill this wrapper.
     previous = signal.signal(signal.SIGINT, signal.SIG_IGN)
     try:
-        launch_command = _resolved_launch_command(executable, command[1:])
+        launch_command = _resolved_launch_command(executable, command[1:], child_env)
         code = subprocess.run(launch_command, env = child_env).returncode
     finally:
         signal.signal(signal.SIGINT, previous)

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1252,9 +1252,7 @@ def test_resolved_launch_command_handles_project_local_npm_shim(monkeypatch, tmp
     ]
 
 
-def test_resolved_launch_command_leaves_custom_npm_like_wrapper_unchanged(
-    monkeypatch, tmp_path
-):
+def test_resolved_launch_command_leaves_custom_npm_like_wrapper_unchanged(monkeypatch, tmp_path):
     _simulate_windows(monkeypatch)
     cmd = tmp_path / "custom-agent.cmd"
     target = tmp_path / "node_modules" / "fake-agent" / "index.js"

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1151,7 +1151,16 @@ def test_connect_claude_windows_shim_from_wsl_bridges_env(fake_studio, monkeypat
         assert name in captured["env"]["WSLENV"].split(":")
 
 
-def _npm_node_cmd_shim(target: str) -> str:
+def _npm_node_cmd_shim(
+    target: str,
+    *,
+    node_args: str = "",
+    environment: tuple[tuple[str, str], ...] = (),
+    cmd_shim_version: int = 7,
+) -> str:
+    environment_lines = "".join(f"@SET {name}={value}\r\n" for name, value in environment)
+    legacy_pathext = "  SET PATHEXT=%PATHEXT:;.JS;=;%\r\n" if cmd_shim_version < 9 else ""
+    current_pathext = "set PATHEXT=%PATHEXT:;.JS;=;% & " if cmd_shim_version >= 9 else ""
     return (
         "@ECHO off\r\n"
         "GOTO start\r\n"
@@ -1161,16 +1170,17 @@ def _npm_node_cmd_shim(target: str) -> str:
         ":start\r\n"
         "SETLOCAL\r\n"
         "CALL :find_dp0\r\n"
+        f"{environment_lines}"
         "\r\n"
         'IF EXIST "%dp0%\\node.exe" (\r\n'
         '  SET "_prog=%dp0%\\node.exe"\r\n'
         ") ELSE (\r\n"
         '  SET "_prog=node"\r\n'
-        "  SET PATHEXT=%PATHEXT:;.JS;=;%\r\n"
+        f"{legacy_pathext}"
         ")\r\n"
         "\r\n"
-        f'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  '
-        f'"%dp0%\\{target}" %*\r\n'
+        f"endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & {current_pathext}"
+        f'"%_prog%" {node_args} "%dp0%\\{target}" %*\r\n'
     )
 
 
@@ -1205,6 +1215,88 @@ def test_launch_windows_npm_shim_preserves_multiline_argument(monkeypatch, tmp_p
         str(target),
         'first line\nsecond "quoted" line',
     ]
+
+
+def test_resolved_launch_command_handles_current_npm_node_shim(monkeypatch, tmp_path):
+    _simulate_windows(monkeypatch)
+    cmd = tmp_path / "fake-agent.cmd"
+    target = tmp_path / "node_modules" / "fake-agent" / "index.js"
+    target.parent.mkdir(parents = True)
+    target.write_text("#!/usr/bin/env node\n", encoding = "utf-8")
+    cmd.write_bytes(
+        _npm_node_cmd_shim(
+            r"node_modules\fake-agent\index.js",
+            cmd_shim_version = 9,
+        ).encode()
+    )
+    monkeypatch.setattr(start.shutil, "which", lambda name: r"C:\Program Files\nodejs\node.exe")
+
+    assert start._resolved_launch_command(str(cmd), ["--flag"]) == [
+        r"C:\Program Files\nodejs\node.exe",
+        str(target),
+        "--flag",
+    ]
+
+
+def test_resolved_launch_command_accepts_extensionless_node_target(monkeypatch, tmp_path):
+    _simulate_windows(monkeypatch)
+    cmd = tmp_path / "fake-agent.cmd"
+    target = tmp_path / "node_modules" / "fake-agent" / "cli"
+    target.parent.mkdir(parents = True)
+    target.write_text("#!/usr/bin/env node\n", encoding = "utf-8")
+    cmd.write_bytes(_npm_node_cmd_shim(r"node_modules\fake-agent\cli").encode())
+    monkeypatch.setattr(start.shutil, "which", lambda name: r"C:\Program Files\nodejs\node.exe")
+
+    assert start._resolved_launch_command(str(cmd), ["--flag"]) == [
+        r"C:\Program Files\nodejs\node.exe",
+        str(target),
+        "--flag",
+    ]
+
+
+def test_launch_windows_npm_shim_preserves_shebang_args_and_environment(monkeypatch, tmp_path):
+    _simulate_windows(monkeypatch)
+    cmd = tmp_path / "fake-agent.cmd"
+    target = tmp_path / "node_modules" / "fake-agent" / "index.js"
+    target.parent.mkdir(parents = True)
+    target.write_text(
+        "#!/usr/bin/env NODE_OPTIONS=--trace-warnings node --no-warnings\n",
+        encoding = "utf-8",
+    )
+    cmd.write_bytes(
+        _npm_node_cmd_shim(
+            r"node_modules\fake-agent\index.js",
+            node_args = "--no-warnings",
+            environment = (("NODE_OPTIONS", "--trace-warnings"),),
+        ).encode()
+    )
+    captured = {}
+
+    def which(name):
+        return str(cmd) if name == "fake-agent" else r"C:\Program Files\nodejs\node.exe"
+
+    def run(command, env):
+        captured["command"] = command
+        captured["env"] = env
+        return SimpleNamespace(returncode = 0)
+
+    monkeypatch.setattr(start.shutil, "which", which)
+    monkeypatch.setattr(start.subprocess, "run", run)
+
+    code = start._launch(
+        ["fake-agent", 'first line\nsecond "quoted" line'],
+        {},
+        install_hint = "unused",
+    )
+
+    assert code == 0
+    assert captured["command"] == [
+        r"C:\Program Files\nodejs\node.exe",
+        "--no-warnings",
+        str(target),
+        'first line\nsecond "quoted" line',
+    ]
+    assert captured["env"]["NODE_OPTIONS"] == "--trace-warnings"
 
 
 def test_resolved_launch_command_uses_native_npm_entrypoint(monkeypatch, tmp_path):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1139,6 +1139,7 @@ def test_connect_claude_windows_shim_from_wsl_bridges_env(fake_studio, monkeypat
     assert captured["env"]["ANTHROPIC_BASE_URL"] == BASE
     assert captured["env"]["ANTHROPIC_MODEL"] == MODEL["id"]
     assert captured["env"]["PWD"] == str(tmp_path)
+
     assert "PWD/p" in captured["env"]["WSLENV"].split(":")
     for name in (
         "ANTHROPIC_AUTH_TOKEN",
@@ -1148,6 +1149,68 @@ def test_connect_claude_windows_shim_from_wsl_bridges_env(fake_studio, monkeypat
         "CLAUDE_CODE_OAUTH_TOKEN",
     ):
         assert name in captured["env"]["WSLENV"].split(":")
+
+
+@pytest.mark.skipif(os.name != "nt", reason = "Windows npm shim behavior")
+def test_launch_windows_npm_shim_preserves_multiline_argument(monkeypatch, tmp_path):
+    cmd = tmp_path / "fake-agent.cmd"
+    target = tmp_path / "node_modules" / "fake-agent" / "index.js"
+    target.parent.mkdir(parents = True)
+    target.write_text("", encoding = "utf-8")
+    cmd.write_text(
+        '@echo off\r\n"%_prog%" "%dp0%\\node_modules\\fake-agent\\index.js" %*\r\n',
+        encoding = "utf-8",
+    )
+    captured = {}
+
+    def which(name):
+        return str(cmd) if name == "fake-agent" else r"C:\Program Files\nodejs\node.exe"
+
+    def run(command, env):
+        captured["command"] = command
+        return SimpleNamespace(returncode = 0)
+
+    monkeypatch.setattr(start.shutil, "which", which)
+    monkeypatch.setattr(start.subprocess, "run", run)
+
+    code = start._launch(
+        ["fake-agent", 'first line\nsecond "quoted" line'],
+        {},
+        install_hint = "unused",
+    )
+
+    assert code == 0
+    assert captured["command"] == [
+        r"C:\Program Files\nodejs\node.exe",
+        str(target),
+        'first line\nsecond "quoted" line',
+    ]
+
+
+@pytest.mark.skipif(os.name != "nt", reason = "Windows npm shim behavior")
+def test_resolved_launch_command_uses_native_npm_entrypoint(tmp_path):
+    cmd = tmp_path / "fake-agent.cmd"
+    target = tmp_path / "node_modules" / "fake-agent" / "agent.exe"
+    target.parent.mkdir(parents = True)
+    target.write_bytes(b"")
+    cmd.write_text(
+        '@echo off\r\n"%dp0%\\node_modules\\fake-agent\\agent.exe" %*\r\n',
+        encoding = "utf-8",
+    )
+
+    assert start._resolved_launch_command(str(cmd), ["--flag", "two words"]) == [
+        str(target),
+        "--flag",
+        "two words",
+    ]
+
+
+@pytest.mark.skipif(os.name != "nt", reason = "Windows npm shim behavior")
+def test_resolved_launch_command_leaves_non_npm_batch_file_unchanged(tmp_path):
+    cmd = tmp_path / "custom-agent.cmd"
+    cmd.write_text('@echo off\r\n"%dp0%\\custom.exe" %*\r\n', encoding = "utf-8")
+
+    assert start._resolved_launch_command(str(cmd), ["--flag"]) == [str(cmd), "--flag"]
 
 
 @pytest.mark.skipif(

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1238,6 +1238,32 @@ def test_resolved_launch_command_handles_current_npm_node_shim(monkeypatch, tmp_
     ]
 
 
+def test_resolved_launch_command_ignores_node_js_pathext_shadow(monkeypatch, tmp_path):
+    _simulate_windows(monkeypatch)
+    cmd = tmp_path / "fake-agent.cmd"
+    target = tmp_path / "node_modules" / "fake-agent" / "index.js"
+    target.parent.mkdir(parents = True)
+    target.write_text("#!/usr/bin/env node\n", encoding = "utf-8")
+    cmd.write_bytes(_npm_node_cmd_shim(r"node_modules\fake-agent\index.js").encode())
+    resolved_names = []
+
+    def which(name):
+        resolved_names.append(name)
+        return {
+            "node": r"C:\shadow\node.js",
+            "node.exe": r"C:\Program Files\nodejs\node.exe",
+        }.get(name)
+
+    monkeypatch.setattr(start.shutil, "which", which)
+
+    assert start._resolved_launch_command(str(cmd), ["--flag"]) == [
+        r"C:\Program Files\nodejs\node.exe",
+        str(target),
+        "--flag",
+    ]
+    assert resolved_names == ["node.exe"]
+
+
 def test_resolved_launch_command_accepts_extensionless_node_target(monkeypatch, tmp_path):
     _simulate_windows(monkeypatch)
     cmd = tmp_path / "fake-agent.cmd"

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -1151,16 +1151,36 @@ def test_connect_claude_windows_shim_from_wsl_bridges_env(fake_studio, monkeypat
         assert name in captured["env"]["WSLENV"].split(":")
 
 
-@pytest.mark.skipif(os.name != "nt", reason = "Windows npm shim behavior")
+def _npm_node_cmd_shim(target: str) -> str:
+    return (
+        "@ECHO off\r\n"
+        "GOTO start\r\n"
+        ":find_dp0\r\n"
+        "SET dp0=%~dp0\r\n"
+        "EXIT /b\r\n"
+        ":start\r\n"
+        "SETLOCAL\r\n"
+        "CALL :find_dp0\r\n"
+        "\r\n"
+        'IF EXIST "%dp0%\\node.exe" (\r\n'
+        '  SET "_prog=%dp0%\\node.exe"\r\n'
+        ") ELSE (\r\n"
+        '  SET "_prog=node"\r\n'
+        "  SET PATHEXT=%PATHEXT:;.JS;=;%\r\n"
+        ")\r\n"
+        "\r\n"
+        f'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  '
+        f'"%dp0%\\{target}" %*\r\n'
+    )
+
+
 def test_launch_windows_npm_shim_preserves_multiline_argument(monkeypatch, tmp_path):
+    _simulate_windows(monkeypatch)
     cmd = tmp_path / "fake-agent.cmd"
     target = tmp_path / "node_modules" / "fake-agent" / "index.js"
     target.parent.mkdir(parents = True)
     target.write_text("", encoding = "utf-8")
-    cmd.write_text(
-        '@echo off\r\n"%_prog%" "%dp0%\\node_modules\\fake-agent\\index.js" %*\r\n',
-        encoding = "utf-8",
-    )
+    cmd.write_bytes(_npm_node_cmd_shim(r"node_modules\fake-agent\index.js").encode())
     captured = {}
 
     def which(name):
@@ -1187,15 +1207,24 @@ def test_launch_windows_npm_shim_preserves_multiline_argument(monkeypatch, tmp_p
     ]
 
 
-@pytest.mark.skipif(os.name != "nt", reason = "Windows npm shim behavior")
-def test_resolved_launch_command_uses_native_npm_entrypoint(tmp_path):
+def test_resolved_launch_command_uses_native_npm_entrypoint(monkeypatch, tmp_path):
+    _simulate_windows(monkeypatch)
     cmd = tmp_path / "fake-agent.cmd"
     target = tmp_path / "node_modules" / "fake-agent" / "agent.exe"
     target.parent.mkdir(parents = True)
     target.write_bytes(b"")
-    cmd.write_text(
-        '@echo off\r\n"%dp0%\\node_modules\\fake-agent\\agent.exe" %*\r\n',
-        encoding = "utf-8",
+    cmd.write_bytes(
+        (
+            "@ECHO off\r\n"
+            "GOTO start\r\n"
+            ":find_dp0\r\n"
+            "SET dp0=%~dp0\r\n"
+            "EXIT /b\r\n"
+            ":start\r\n"
+            "SETLOCAL\r\n"
+            "CALL :find_dp0\r\n"
+            '"%dp0%\\node_modules\\fake-agent\\agent.exe" %*\r\n'
+        ).encode()
     )
 
     assert start._resolved_launch_command(str(cmd), ["--flag", "two words"]) == [
@@ -1205,10 +1234,46 @@ def test_resolved_launch_command_uses_native_npm_entrypoint(tmp_path):
     ]
 
 
-@pytest.mark.skipif(os.name != "nt", reason = "Windows npm shim behavior")
-def test_resolved_launch_command_leaves_non_npm_batch_file_unchanged(tmp_path):
+def test_resolved_launch_command_handles_project_local_npm_shim(monkeypatch, tmp_path):
+    _simulate_windows(monkeypatch)
+    node_modules = tmp_path / "project" / "node_modules"
+    cmd = node_modules / ".bin" / "fake-agent.cmd"
+    target = node_modules / "fake-agent" / "index.js"
+    cmd.parent.mkdir(parents = True)
+    target.parent.mkdir(parents = True)
+    target.write_text("", encoding = "utf-8")
+    cmd.write_bytes(_npm_node_cmd_shim(r"..\fake-agent\index.js").encode())
+    monkeypatch.setattr(start.shutil, "which", lambda name: r"C:\Program Files\nodejs\node.exe")
+
+    assert start._resolved_launch_command(str(cmd), ["--flag"]) == [
+        r"C:\Program Files\nodejs\node.exe",
+        str(target),
+        "--flag",
+    ]
+
+
+def test_resolved_launch_command_leaves_custom_npm_like_wrapper_unchanged(
+    monkeypatch, tmp_path
+):
+    _simulate_windows(monkeypatch)
     cmd = tmp_path / "custom-agent.cmd"
-    cmd.write_text('@echo off\r\n"%dp0%\\custom.exe" %*\r\n', encoding = "utf-8")
+    target = tmp_path / "node_modules" / "fake-agent" / "index.js"
+    target.parent.mkdir(parents = True)
+    target.write_text("", encoding = "utf-8")
+    contents = _npm_node_cmd_shim(r"node_modules\fake-agent\index.js")
+    cmd.write_bytes(
+        contents.replace(
+            "CALL :find_dp0\r\n", "CALL :find_dp0\r\nSET AGENT_MODE=custom\r\n"
+        ).encode()
+    )
+
+    assert start._resolved_launch_command(str(cmd), ["--flag"]) == [str(cmd), "--flag"]
+
+
+def test_resolved_launch_command_leaves_non_npm_batch_file_unchanged(monkeypatch, tmp_path):
+    _simulate_windows(monkeypatch)
+    cmd = tmp_path / "custom-agent.cmd"
+    cmd.write_bytes(b'@echo off\r\n"%dp0%\\custom.exe" %*\r\n')
 
     assert start._resolved_launch_command(str(cmd), ["--flag"]) == [str(cmd), "--flag"]
 


### PR DESCRIPTION
## Summary

- preserve multiline and quoted prompt arguments on native Windows
- detect standard npm-generated `.cmd`/`.bat` shims and invoke their declared Node/EXE entry point directly
- leave non-npm batch files and non-Windows launch paths unchanged

## Why

`subprocess.run([npm_cmd, ..., prompt])` crosses `cmd.exe` through npm's `%*` shim. Embedded CR/LF is treated as command syntax, so npm-backed agents receive only part of a multiline prompt. Routing through the companion Windows PowerShell shim is not sufficient because its native-command bridge rewrites embedded quotes.

## A/B verification

On a fresh native-Windows install using cached `unsloth/Qwen3.5-9B-GGUF` (`UD-Q4_K_XL`) and Codex `0.145.0`:

- before: the persisted Codex session contained only the first prompt line
- after: the session contained the complete six-step calculator prompt, including newlines and `"division by zero"`; `unsloth start codex` exited 0

Tests:

- Windows: 3 new npm-shim regressions pass; full `test_start.py` is `333 passed, 9 skipped, 7 failed`
- exact parent commit on Windows: `330 passed, 9 skipped, 7 failed` with the same seven unrelated pre-existing failures
- WSL/Linux: full `test_start.py` is `346 passed, 3 skipped`

## Scope

The bypass is limited to Windows shims whose declared target is beneath `node_modules`. If the shim is custom, unreadable, lacks its target, or Node cannot be resolved, launch falls back to the existing path.
