### PR TITLE
Windows setup: route the stale-manifest failure through Exit-SetupFailure

### DIFF
--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -3122,7 +3122,7 @@ sys.exit(0 if install_manifest.remove_manifest() else 1)
 if (-not $_ManifestDropped) {
     Write-Host "[ERROR] Could not remove the stale unsloth_install_manifest.json." -ForegroundColor Red
     Write-Host "        Refusing to install behind a marker that still reports this venv as complete." -ForegroundColor Red
-    exit 1
+    Exit-SetupFailure "Could not remove the stale unsloth_install_manifest.json"
 }
 
 if ($script:UnslothVerbose) {


### PR DESCRIPTION
## Problem

`Repo tests (CPU)` is red on `main`, and every open PR inherits it:

```
FAIL: Windows setup has explicit exits outside Exit-SetupFailure
```

`tests/sh/test_tauri_retry_failure_context.sh` asserts that `studio/setup.ps1` contains exactly one explicit `exit`, the `exit $Code` inside `Exit-SetupFailure`. The stale-manifest guard added in #7492 exits directly instead:

```powershell
if (-not $_ManifestDropped) {
    Write-Host "[ERROR] Could not remove the stale unsloth_install_manifest.json." -ForegroundColor Red
    Write-Host "        Refusing to install behind a marker that still reports this venv as complete." -ForegroundColor Red
    exit 1
}
```

That is not only a test invariant. `Exit-SetupFailure` is what emits the `[TAURI:ERROR] <message>` line, so on this path the desktop installer exits 1 with no structured error and the UI shows its generic fallback instead of naming the cause. The 34 other failure sites in the file all go through the helper.

## Fix

Route the one stray exit through `Exit-SetupFailure`, keeping the two `Write-Host` detail lines for the console, matching the pattern used everywhere else in the file.

## Verification

On a clean checkout of `main` at 52a9601, `tests/sh/test_tauri_retry_failure_context.sh` fails at that assertion. With this one line changed it passes:

```
before:  FAIL: Windows setup has explicit exits outside Exit-SetupFailure   (exit 1)
after:   PASS: Windows setup routes explicit exits through Exit-SetupFailure
         PASS: Windows command failures preserve output through retries and finalization
         (exit 0)
```

The rest of the shell suite that CI runs is green locally (`test_install_host_defaults.sh` and `test_install_rollback_lifecycle.sh` are the two the workflow skips by name).