### PR TITLE
Route the stale-manifest abort through Exit-SetupFailure

### DIFF
--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -3122,7 +3122,7 @@ sys.exit(0 if install_manifest.remove_manifest() else 1)
 if (-not $_ManifestDropped) {
     Write-Host "[ERROR] Could not remove the stale unsloth_install_manifest.json." -ForegroundColor Red
     Write-Host "        Refusing to install behind a marker that still reports this venv as complete." -ForegroundColor Red
-    exit 1
+    Exit-SetupFailure "Could not remove the stale unsloth_install_manifest.json"
 }
 
 if ($script:UnslothVerbose) {


### PR DESCRIPTION
`Repo tests (CPU)` is red on every PR right now. The `Shell installer tests` step fails with:

```
FAIL: Windows setup has explicit exits outside Exit-SetupFailure
```

This is a semantic conflict between two PRs that landed the same day, so neither one's CI could have caught it:

- #7492 added a bare `exit 1` to `studio/setup.ps1` for the stale-install-manifest abort.
- #7529 added `tests/sh/test_tauri_retry_failure_context.sh`, which asserts `setup.ps1` has exactly one explicit exit and that it is the `exit $Code` inside `Exit-SetupFailure`.

On current `main` the file has two (`:88` and `:3125`), so the assertion fails. Reproduced locally on a clean `main` checkout before changing anything.

## Change

Route that abort through `Exit-SetupFailure`, which is the invariant #7529 exists to protect: it forces a non-zero code and, under `UNSLOTH_TAURI_MODE`, emits the single-line `[TAURI:ERROR]` the desktop app parses to surface an actionable failure. Without it, a Tauri install that trips this branch exits silently.

The two red `Write-Host` lines stay, matching every other call site in the file (for example the Git and Python aborts), which print the detailed console message and then hand `Exit-SetupFailure` a one-line summary.

## Tests

- `tests/sh/test_tauri_retry_failure_context.sh`: was failing on `main`, now passes end to end.
- Whole `tests/sh` suite: no new failures. `test_install_host_defaults.sh` still fails locally, but it is explicitly skipped in CI as a known `install.ps1` layout drift, and it fails identically on clean `main`.
- `tests/python/test_windows_no_torch_setup.py` + `tests/studio/test_ci_shell_suite_coverage.py`: 34 passed.
