### PR TITLE
Studio: Write auth secret files with a trailing newline

### DIFF
--- a/studio/backend/auth/storage.py
+++ b/studio/backend/auth/storage.py
@@ -32,20 +32,18 @@ _bootstrap_password: Optional[str] = None
 
 
 def _bootstrap_file_bytes(password: str) -> bytes:
-    """The exact on-disk form: the secret plus one LF.
+    """Exact on-disk form: the secret plus one LF.
 
-    Encoded rather than written as text because text mode translates "\\n" to
-    CRLF on Windows, and `$(cat ...)` strips the LF but leaves the CR attached
-    to the credential.
+    Bytes, not text: text mode writes CRLF on Windows, and `$(cat ...)` strips
+    the LF but leaves the CR attached to the credential.
     """
     return (password + "\n").encode("utf-8")
 
 
 def _persist_bootstrap_password(password: str) -> None:
-    """Write the bootstrap password 0600, with a trailing LF on every OS.
+    """Atomically write the bootstrap password 0600, LF terminated on every OS.
 
-    Atomic: this can rewrite a live file, and a partial write would destroy the
-    only plaintext copy of the recovery credential.
+    A partial write would destroy the only plaintext recovery credential.
     """
     fd, tmp_name = tempfile.mkstemp(
         prefix = f".{_BOOTSTRAP_PW_PATH.name}.", dir = _BOOTSTRAP_PW_PATH.parent
@@ -69,22 +67,20 @@ def _persist_bootstrap_password(password: str) -> None:
 def _normalise_bootstrap_file(raw: bytes, password: str) -> None:
     """Append the LF a pre-newline release left off.
 
-    Append-only, and only to a file that is exactly the credential. Rewriting
-    could restore revoked plaintext, because clear_bootstrap_password() may
-    unlink or (when unlink fails, notably on Windows while this descriptor is
-    open) truncate the file through another descriptor at any point after we
-    read it. Appending cannot: the worst case is a lone "\\n" over a cleared
-    file, which strips to empty and reads back as no bootstrap password.
-
-    Releases before the newline wrote the password with no terminator at all,
-    so that is the only shape in the wild. Anything else is left alone and
-    keeps working, since every reader strips.
+    Append-only, and only when the file is exactly the credential:
+    clear_bootstrap_password() may unlink or (when unlink fails, notably on
+    Windows while this descriptor is open) truncate through another descriptor
+    after we read, so a rewrite could restore revoked plaintext. An append
+    cannot: worst case is a lone "\\n" over a cleared file, which strips back to
+    no bootstrap password. Pre-newline releases wrote no terminator at all, so
+    that is the only shape in the wild; anything else reads fine, since every
+    reader strips, and is left alone.
     """
     if raw != password.encode("utf-8"):
         return
 
-    # O_BINARY or Windows opens the descriptor in text mode and turns the LF
-    # straight back into CRLF, which is the bug this exists to fix.
+    # O_BINARY: without it Windows opens in text mode and turns the LF straight
+    # back into CRLF, the bug being fixed.
     fd = os.open(
         _BOOTSTRAP_PW_PATH,
         os.O_WRONLY | os.O_APPEND | getattr(os, "O_BINARY", 0),
@@ -106,8 +102,8 @@ def _read_persisted_bootstrap_password() -> Optional[str]:
         return None
 
     # No caller handles a raise, so an unreadable file has to mean "no bootstrap
-    # password", not a dead backend. We write UTF-8, so bytes that will not
-    # decode are damage whose plaintext is worthless anyway.
+    # password", not a dead backend. We write UTF-8, so undecodable bytes are
+    # damage whose plaintext is worthless anyway.
     try:
         raw = _BOOTSTRAP_PW_PATH.read_bytes()
         password = raw.decode("utf-8").strip()
@@ -116,8 +112,8 @@ def _read_persisted_bootstrap_password() -> Optional[str]:
     if not password:
         return None
 
-    # Older releases wrote no terminator, so upgrades kept the `cat` problem.
-    # Best-effort: a read-only auth dir must not fail startup.
+    # Older releases wrote no terminator; best-effort, a read-only auth dir must
+    # not fail startup.
     if raw != _bootstrap_file_bytes(password):
         try:
             _normalise_bootstrap_file(raw, password)
@@ -166,9 +162,9 @@ def get_bootstrap_password() -> Optional[str]:
 def _load_bootstrap_password() -> Optional[str]:
     """Load an existing bootstrap password without creating one.
 
-    This, not generate_bootstrap_password(), is the path an upgraded install
-    takes (ensure_default_admin short-circuits once the admin row exists), so
-    the normalisation has to happen here too.
+    Upgrades take this path, not generate_bootstrap_password()
+    (ensure_default_admin short-circuits once the admin row exists), so it has
+    to normalise too.
     """
     global _bootstrap_password
     _bootstrap_password = _read_persisted_bootstrap_password()

--- a/studio/backend/auth/storage.py
+++ b/studio/backend/auth/storage.py
@@ -57,7 +57,8 @@ def generate_bootstrap_password() -> str:
 
     # Persist so the same passphrase survives restarts until password change.
     ensure_dir(_BOOTSTRAP_PW_PATH.parent)
-    _BOOTSTRAP_PW_PATH.write_text(_bootstrap_password, encoding = "utf-8")
+    # Newline so `cat` doesn't run it into the shell prompt; readers strip.
+    _BOOTSTRAP_PW_PATH.write_text(_bootstrap_password + "\n", encoding = "utf-8")
     try:
         os.chmod(_BOOTSTRAP_PW_PATH, 0o600)
     except OSError:

--- a/studio/backend/auth/storage.py
+++ b/studio/backend/auth/storage.py
@@ -9,6 +9,7 @@ import ipaddress
 import os
 import secrets
 import sqlite3
+import tempfile
 import threading
 from datetime import datetime, timezone
 from typing import Optional, Tuple
@@ -41,12 +42,55 @@ def _bootstrap_file_bytes(password: str) -> bytes:
 
 
 def _persist_bootstrap_password(password: str) -> None:
-    """Write the bootstrap password 0600, with a trailing LF on every OS."""
-    _BOOTSTRAP_PW_PATH.write_bytes(_bootstrap_file_bytes(password))
+    """Write the bootstrap password 0600, with a trailing LF on every OS.
+
+    Atomic: this can rewrite a live file, and a partial write would destroy the
+    only plaintext copy of the recovery credential.
+    """
+    fd, tmp_name = tempfile.mkstemp(
+        prefix = f".{_BOOTSTRAP_PW_PATH.name}.", dir = _BOOTSTRAP_PW_PATH.parent
+    )
     try:
-        os.chmod(_BOOTSTRAP_PW_PATH, 0o600)
-    except OSError:
-        pass
+        with os.fdopen(fd, "wb") as f:
+            f.write(_bootstrap_file_bytes(password))
+        try:
+            os.chmod(tmp_name, 0o600)
+        except OSError:
+            pass
+        os.replace(tmp_name, _BOOTSTRAP_PW_PATH)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _read_persisted_bootstrap_password() -> Optional[str]:
+    """Read the persisted password, normalising the file if it is malformed."""
+    if not _BOOTSTRAP_PW_PATH.is_file():
+        return None
+
+    # No caller handles a raise, so an unreadable file has to mean "no bootstrap
+    # password", not a dead backend. We write UTF-8, so bytes that will not
+    # decode are damage whose plaintext is worthless anyway.
+    try:
+        raw = _BOOTSTRAP_PW_PATH.read_bytes()
+        password = raw.decode("utf-8").strip()
+    except (OSError, UnicodeDecodeError):
+        return None
+    if not password:
+        return None
+
+    # Older releases wrote no terminator, and text mode wrote CRLF on Windows,
+    # so upgrades kept the `cat` problem. Rewrite anything that isn't exactly
+    # "<secret>\n". Best-effort: a read-only auth dir must not fail startup.
+    if raw != _bootstrap_file_bytes(password):
+        try:
+            _persist_bootstrap_password(password)
+        except OSError:
+            pass
+    return password
 
 
 def generate_bootstrap_password() -> str:
@@ -62,19 +106,10 @@ def generate_bootstrap_password() -> str:
         return _bootstrap_password
 
     # Persisted from a previous run?
-    if _BOOTSTRAP_PW_PATH.is_file():
-        raw = _BOOTSTRAP_PW_PATH.read_bytes()
-        _bootstrap_password = raw.decode("utf-8").strip()
-        if _bootstrap_password:
-            # Older releases wrote no terminator, so upgrades kept the `cat`
-            # problem. Rewrite anything that isn't exactly "<secret>\n".
-            # Best-effort: a read-only auth dir must not fail startup.
-            if raw != _bootstrap_file_bytes(_bootstrap_password):
-                try:
-                    _persist_bootstrap_password(_bootstrap_password)
-                except OSError:
-                    pass
-            return _bootstrap_password
+    persisted = _read_persisted_bootstrap_password()
+    if persisted:
+        _bootstrap_password = persisted
+        return _bootstrap_password
 
     # First startup: generate a fresh passphrase.
     import diceware
@@ -96,19 +131,14 @@ def get_bootstrap_password() -> Optional[str]:
 
 
 def _load_bootstrap_password() -> Optional[str]:
-    """Load an existing bootstrap password without creating one."""
+    """Load an existing bootstrap password without creating one.
+
+    This, not generate_bootstrap_password(), is the path an upgraded install
+    takes (ensure_default_admin short-circuits once the admin row exists), so
+    the normalisation has to happen here too.
+    """
     global _bootstrap_password
-    _bootstrap_password = None
-    if _BOOTSTRAP_PW_PATH.is_file():
-        # No caller handles a raise, so an unreadable file has to mean "no bootstrap
-        # password", not a dead backend. We write UTF-8, so bytes that will not
-        # decode are damage whose plaintext is worthless anyway.
-        try:
-            bootstrap_password = _BOOTSTRAP_PW_PATH.read_text(encoding = "utf-8").strip()
-        except (OSError, UnicodeDecodeError):
-            return _bootstrap_password
-        if bootstrap_password:
-            _bootstrap_password = bootstrap_password
+    _bootstrap_password = _read_persisted_bootstrap_password()
     return _bootstrap_password
 
 

--- a/studio/backend/auth/storage.py
+++ b/studio/backend/auth/storage.py
@@ -30,6 +30,25 @@ _BOOTSTRAP_PW_PATH = DB_PATH.parent / ".bootstrap_password"
 _bootstrap_password: Optional[str] = None
 
 
+def _bootstrap_file_bytes(password: str) -> bytes:
+    """The exact on-disk form: the secret plus one LF.
+
+    Encoded rather than written as text because text mode translates "\\n" to
+    CRLF on Windows, and `$(cat ...)` strips the LF but leaves the CR attached
+    to the credential.
+    """
+    return (password + "\n").encode("utf-8")
+
+
+def _persist_bootstrap_password(password: str) -> None:
+    """Write the bootstrap password 0600, with a trailing LF on every OS."""
+    _BOOTSTRAP_PW_PATH.write_bytes(_bootstrap_file_bytes(password))
+    try:
+        os.chmod(_BOOTSTRAP_PW_PATH, 0o600)
+    except OSError:
+        pass
+
+
 def generate_bootstrap_password() -> str:
     """Generate a 4-word diceware passphrase and persist it to disk.
 
@@ -44,8 +63,17 @@ def generate_bootstrap_password() -> str:
 
     # Persisted from a previous run?
     if _BOOTSTRAP_PW_PATH.is_file():
-        _bootstrap_password = _BOOTSTRAP_PW_PATH.read_text(encoding = "utf-8").strip()
+        raw = _BOOTSTRAP_PW_PATH.read_bytes()
+        _bootstrap_password = raw.decode("utf-8").strip()
         if _bootstrap_password:
+            # Older releases wrote no terminator, so upgrades kept the `cat`
+            # problem. Rewrite anything that isn't exactly "<secret>\n".
+            # Best-effort: a read-only auth dir must not fail startup.
+            if raw != _bootstrap_file_bytes(_bootstrap_password):
+                try:
+                    _persist_bootstrap_password(_bootstrap_password)
+                except OSError:
+                    pass
             return _bootstrap_password
 
     # First startup: generate a fresh passphrase.
@@ -57,12 +85,7 @@ def generate_bootstrap_password() -> str:
 
     # Persist so the same passphrase survives restarts until password change.
     ensure_dir(_BOOTSTRAP_PW_PATH.parent)
-    # Newline so `cat` doesn't run it into the shell prompt; readers strip.
-    _BOOTSTRAP_PW_PATH.write_text(_bootstrap_password + "\n", encoding = "utf-8")
-    try:
-        os.chmod(_BOOTSTRAP_PW_PATH, 0o600)
-    except OSError:
-        pass
+    _persist_bootstrap_password(_bootstrap_password)
 
     return _bootstrap_password
 

--- a/studio/backend/auth/storage.py
+++ b/studio/backend/auth/storage.py
@@ -83,16 +83,27 @@ def _normalise_bootstrap_file(raw: bytes, password: str) -> None:
     if not raw.startswith(data[:-1]):
         return
 
-    fd = os.open(_BOOTSTRAP_PW_PATH, os.O_RDWR)
+    # O_BINARY or Windows opens the descriptor in text mode and os.write turns
+    # the LF straight back into CRLF, which is the bug this path exists to fix.
+    fd = os.open(_BOOTSTRAP_PW_PATH, os.O_RDWR | getattr(os, "O_BINARY", 0))
     try:
         if os.read(fd, len(raw) + 1) != raw:
             return
         os.lseek(fd, 0, os.SEEK_SET)
-        os.write(fd, data)
+        # os.write may write fewer bytes than asked; truncating after a short
+        # write would NUL-fill the credential and lock the admin out.
+        written = 0
+        while written < len(data):
+            n = os.write(fd, data[written:])
+            if not n:
+                return
+            written += n
         os.ftruncate(fd, len(data))
         try:
             os.fchmod(fd, 0o600)
-        except OSError:
+        except (AttributeError, OSError):
+            # fchmod only reached Windows in 3.13. Staying on the descriptor
+            # matters more than re-applying a mode the writer already set.
             pass
     finally:
         os.close(fd)

--- a/studio/backend/auth/storage.py
+++ b/studio/backend/auth/storage.py
@@ -66,6 +66,38 @@ def _persist_bootstrap_password(password: str) -> None:
         raise
 
 
+def _normalise_bootstrap_file(raw: bytes, password: str) -> None:
+    """Give an existing malformed file its trailing LF, in place.
+
+    Deliberately not the atomic replace above: a rename would recreate the file
+    if clear_bootstrap_password() or the CLI cleanup deleted it after we read
+    it, putting revoked plaintext back on disk for a later reset to re-seed.
+    Opening without O_CREAT cannot resurrect a deleted file, and the contents
+    are re-checked through the descriptor so an in-place truncation is not
+    undone either.
+    """
+    data = _bootstrap_file_bytes(password)
+    # Only a trailing-whitespace rewrite is safe without a rename: every partial
+    # state is then "<secret>\n" plus leftover whitespace, which still strips to
+    # the same credential. Anything else keeps working unnormalised.
+    if not raw.startswith(data[:-1]):
+        return
+
+    fd = os.open(_BOOTSTRAP_PW_PATH, os.O_RDWR)
+    try:
+        if os.read(fd, len(raw) + 1) != raw:
+            return
+        os.lseek(fd, 0, os.SEEK_SET)
+        os.write(fd, data)
+        os.ftruncate(fd, len(data))
+        try:
+            os.fchmod(fd, 0o600)
+        except OSError:
+            pass
+    finally:
+        os.close(fd)
+
+
 def _read_persisted_bootstrap_password() -> Optional[str]:
     """Read the persisted password, normalising the file if it is malformed."""
     if not _BOOTSTRAP_PW_PATH.is_file():
@@ -83,11 +115,11 @@ def _read_persisted_bootstrap_password() -> Optional[str]:
         return None
 
     # Older releases wrote no terminator, and text mode wrote CRLF on Windows,
-    # so upgrades kept the `cat` problem. Rewrite anything that isn't exactly
-    # "<secret>\n". Best-effort: a read-only auth dir must not fail startup.
+    # so upgrades kept the `cat` problem. Best-effort: a read-only auth dir or a
+    # credential cleared underneath us must not fail startup.
     if raw != _bootstrap_file_bytes(password):
         try:
-            _persist_bootstrap_password(password)
+            _normalise_bootstrap_file(raw, password)
         except OSError:
             pass
     return password

--- a/studio/backend/auth/storage.py
+++ b/studio/backend/auth/storage.py
@@ -67,43 +67,34 @@ def _persist_bootstrap_password(password: str) -> None:
 
 
 def _normalise_bootstrap_file(raw: bytes, password: str) -> None:
-    """Give an existing malformed file its trailing LF, in place.
+    """Append the LF a pre-newline release left off.
 
-    Deliberately not the atomic replace above: a rename would recreate the file
-    if clear_bootstrap_password() or the CLI cleanup deleted it after we read
-    it, putting revoked plaintext back on disk for a later reset to re-seed.
-    Opening without O_CREAT cannot resurrect a deleted file, and the contents
-    are re-checked through the descriptor so an in-place truncation is not
-    undone either.
+    Append-only, and only to a file that is exactly the credential. Rewriting
+    could restore revoked plaintext, because clear_bootstrap_password() may
+    unlink or (when unlink fails, notably on Windows while this descriptor is
+    open) truncate the file through another descriptor at any point after we
+    read it. Appending cannot: the worst case is a lone "\\n" over a cleared
+    file, which strips to empty and reads back as no bootstrap password.
+
+    Releases before the newline wrote the password with no terminator at all,
+    so that is the only shape in the wild. Anything else is left alone and
+    keeps working, since every reader strips.
     """
-    data = _bootstrap_file_bytes(password)
-    # Only a trailing-whitespace rewrite is safe without a rename: every partial
-    # state is then "<secret>\n" plus leftover whitespace, which still strips to
-    # the same credential. Anything else keeps working unnormalised.
-    if not raw.startswith(data[:-1]):
+    if raw != password.encode("utf-8"):
         return
 
-    # O_BINARY or Windows opens the descriptor in text mode and os.write turns
-    # the LF straight back into CRLF, which is the bug this path exists to fix.
-    fd = os.open(_BOOTSTRAP_PW_PATH, os.O_RDWR | getattr(os, "O_BINARY", 0))
+    # O_BINARY or Windows opens the descriptor in text mode and turns the LF
+    # straight back into CRLF, which is the bug this exists to fix.
+    fd = os.open(
+        _BOOTSTRAP_PW_PATH,
+        os.O_WRONLY | os.O_APPEND | getattr(os, "O_BINARY", 0),
+    )
     try:
-        if os.read(fd, len(raw) + 1) != raw:
-            return
-        os.lseek(fd, 0, os.SEEK_SET)
-        # os.write may write fewer bytes than asked; truncating after a short
-        # write would NUL-fill the credential and lock the admin out.
-        written = 0
-        while written < len(data):
-            n = os.write(fd, data[written:])
-            if not n:
-                return
-            written += n
-        os.ftruncate(fd, len(data))
+        os.write(fd, b"\n")
         try:
             os.fchmod(fd, 0o600)
         except (AttributeError, OSError):
-            # fchmod only reached Windows in 3.13. Staying on the descriptor
-            # matters more than re-applying a mode the writer already set.
+            # fchmod only reached Windows in 3.13.
             pass
     finally:
         os.close(fd)
@@ -125,9 +116,8 @@ def _read_persisted_bootstrap_password() -> Optional[str]:
     if not password:
         return None
 
-    # Older releases wrote no terminator, and text mode wrote CRLF on Windows,
-    # so upgrades kept the `cat` problem. Best-effort: a read-only auth dir or a
-    # credential cleared underneath us must not fail startup.
+    # Older releases wrote no terminator, so upgrades kept the `cat` problem.
+    # Best-effort: a read-only auth dir must not fail startup.
     if raw != _bootstrap_file_bytes(password):
         try:
             _normalise_bootstrap_file(raw, password)

--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -134,6 +134,26 @@ def test_ensure_default_admin_loads_existing_bootstrap_after_restart(monkeypatch
     assert storage.get_bootstrap_password() == bootstrap_pw
 
 
+def test_bootstrap_password_file_ends_with_a_newline():
+    # Otherwise `cat` welds the passphrase to the shell prompt and both get copied.
+    storage.ensure_default_admin()
+
+    raw = storage._BOOTSTRAP_PW_PATH.read_text(encoding = "utf-8")
+
+    assert raw.endswith("\n")
+    assert raw.strip() == storage.get_bootstrap_password()
+    assert "\n" not in raw.strip()
+
+
+def test_bootstrap_password_round_trips_across_a_restart_with_the_newline():
+    storage.ensure_default_admin()
+    original = storage.get_bootstrap_password()
+
+    storage._bootstrap_password = None
+
+    assert storage.generate_bootstrap_password() == original
+
+
 def test_ensure_default_admin_does_not_generate_for_empty_existing_bootstrap():
     seed_user()
     storage._BOOTSTRAP_PW_PATH.write_text(" \n", encoding = "utf-8")
@@ -358,7 +378,7 @@ def test_write_desktop_secret_file_is_0600_on_unix(tmp_path):
 
     studio_cli._write_auth_secret(path, "desktop-secret")
 
-    assert path.read_text() == "desktop-secret"
+    assert path.read_text() == "desktop-secret\n"
     if platform.system() != "Windows":
         assert oct(path.stat().st_mode & 0o777) == "0o600"
 
@@ -525,7 +545,8 @@ if result.exit_code != 0:
         capture_output = True,
     )
     assert result.returncode == 0, result.stderr + result.stdout
-    secret = (auth_dir / ".desktop_secret").read_text()
+    # Strip like the src-tauri readers do.
+    secret = (auth_dir / ".desktop_secret").read_text().strip()
     assert secret.startswith("desktop-")
 
     conn = sqlite3.connect(auth_dir / "auth.db")

--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -257,6 +257,56 @@ def test_leading_whitespace_bootstrap_file_is_left_alone(monkeypatch):
     assert storage._BOOTSTRAP_PW_PATH.read_bytes() == b"  legacy-bootstrap-secret  "
 
 
+def test_normalising_opens_the_file_in_binary_mode(monkeypatch):
+    # Without O_BINARY, Windows opens the descriptor in text mode and os.write
+    # turns the LF back into CRLF, reintroducing the bug being fixed.
+    seed_user()
+    storage._BOOTSTRAP_PW_PATH.write_bytes(b"legacy-bootstrap-secret")
+    monkeypatch.setattr(storage.os, "O_BINARY", 0x8000, raising = False)
+    seen = []
+    real_open = storage.os.open
+
+    def spy(path, flags, *args, **kwargs):
+        if str(path) == str(storage._BOOTSTRAP_PW_PATH):
+            seen.append(flags)
+        return real_open(path, flags & ~0x8000, *args, **kwargs)
+
+    monkeypatch.setattr(storage.os, "open", spy)
+
+    storage.ensure_default_admin()
+
+    assert seen and all(f & 0x8000 for f in seen), seen
+
+
+def test_normalising_survives_a_short_write(monkeypatch):
+    # A short write followed by ftruncate would NUL-fill the credential.
+    seed_user()
+    storage._BOOTSTRAP_PW_PATH.write_bytes(b"legacy-bootstrap-secret")
+    real_write = storage.os.write
+
+    def one_byte_at_a_time(fd, data):
+        return real_write(fd, data[:1])
+
+    monkeypatch.setattr(storage.os, "write", one_byte_at_a_time)
+
+    storage.ensure_default_admin()
+
+    assert storage._BOOTSTRAP_PW_PATH.read_bytes() == b"legacy-bootstrap-secret\n"
+    assert storage.get_bootstrap_password() == "legacy-bootstrap-secret"
+
+
+def test_normalising_works_without_fchmod(monkeypatch):
+    # os.fchmod only reached Windows in 3.13; its absence must not raise.
+    seed_user()
+    storage._BOOTSTRAP_PW_PATH.write_bytes(b"legacy-bootstrap-secret")
+    monkeypatch.delattr(storage.os, "fchmod", raising = False)
+
+    storage.ensure_default_admin()
+
+    assert storage._BOOTSTRAP_PW_PATH.read_bytes() == b"legacy-bootstrap-secret\n"
+    assert storage.get_bootstrap_password() == "legacy-bootstrap-secret"
+
+
 def test_persisting_the_bootstrap_password_is_atomic(monkeypatch, tmp_path):
     # A partial write would destroy the only plaintext recovery credential.
     storage._persist_bootstrap_password("original-secret")

--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -153,23 +153,33 @@ def test_bootstrap_password_round_trips_across_a_restart_with_the_newline():
     assert storage.generate_bootstrap_password() == original
 
 
-@pytest.mark.parametrize(
-    "legacy",
-    [
-        b"legacy-bootstrap-secret",  # written before the newline existed
-        b"legacy-bootstrap-secret\r\n",  # written by text mode on Windows
-    ],
-)
-def test_upgrade_normalises_the_bootstrap_file(legacy):
+def test_upgrade_normalises_the_bootstrap_file():
     # The upgrade path is ensure_default_admin() on an install that already has
     # the admin row, which never reaches generate_bootstrap_password().
     seed_user()
-    storage._BOOTSTRAP_PW_PATH.write_bytes(legacy)
+    storage._BOOTSTRAP_PW_PATH.write_bytes(b"legacy-bootstrap-secret")
 
     storage.ensure_default_admin()
 
     assert storage._BOOTSTRAP_PW_PATH.read_bytes() == b"legacy-bootstrap-secret\n"
     assert storage.get_bootstrap_password() == "legacy-bootstrap-secret"
+
+
+@pytest.mark.parametrize("other", [
+    b"legacy-bootstrap-secret\r\n",     # only an unreleased build wrote this
+    b"legacy-bootstrap-secret\r",
+    b"legacy-bootstrap-secret   ",
+])
+def test_only_an_exactly_untermimated_bootstrap_file_is_touched(other):
+    # Appending is safe precisely because it is restricted to the one shape
+    # released code produced. Everything else reads fine and is left alone.
+    seed_user()
+    storage._BOOTSTRAP_PW_PATH.write_bytes(other)
+
+    storage.ensure_default_admin()
+
+    assert storage.get_bootstrap_password() == "legacy-bootstrap-secret"
+    assert storage._BOOTSTRAP_PW_PATH.read_bytes() == other
 
 
 def test_upgrade_normalises_when_the_admin_row_is_missing():
@@ -242,7 +252,11 @@ def test_normalising_does_not_overwrite_a_rotated_bootstrap_file(monkeypatch):
 
     storage._read_persisted_bootstrap_password()
 
-    assert storage._BOOTSTRAP_PW_PATH.read_bytes() == b"brand-new-secret\n"
+    # The append may add a second newline; the rotated credential must survive.
+    raw = storage._BOOTSTRAP_PW_PATH.read_bytes()
+    assert raw.strip() == b"brand-new-secret"
+    storage._bootstrap_password = None
+    assert storage._load_bootstrap_password() == "brand-new-secret"
 
 
 def test_leading_whitespace_bootstrap_file_is_left_alone(monkeypatch):
@@ -278,21 +292,29 @@ def test_normalising_opens_the_file_in_binary_mode(monkeypatch):
     assert seen and all(f & 0x8000 for f in seen), seen
 
 
-def test_normalising_survives_a_short_write(monkeypatch):
-    # A short write followed by ftruncate would NUL-fill the credential.
+def test_clearing_by_truncation_mid_normalisation_is_not_undone(monkeypatch):
+    # clear_bootstrap_password() truncates through its own descriptor when the
+    # unlink fails, which is what happens on Windows while ours is open. The
+    # append must not put the revoked plaintext back.
     seed_user()
     storage._BOOTSTRAP_PW_PATH.write_bytes(b"legacy-bootstrap-secret")
-    real_write = storage.os.write
 
-    def one_byte_at_a_time(fd, data):
-        return real_write(fd, data[:1])
+    real_open = storage.os.open
 
-    monkeypatch.setattr(storage.os, "write", one_byte_at_a_time)
+    def truncate_then_open(path, flags, *args, **kwargs):
+        fd = real_open(path, flags, *args, **kwargs)
+        if str(path) == str(storage._BOOTSTRAP_PW_PATH):
+            storage._BOOTSTRAP_PW_PATH.write_text("", encoding = "utf-8")
+        return fd
 
-    storage.ensure_default_admin()
+    monkeypatch.setattr(storage.os, "open", truncate_then_open)
 
-    assert storage._BOOTSTRAP_PW_PATH.read_bytes() == b"legacy-bootstrap-secret\n"
-    assert storage.get_bootstrap_password() == "legacy-bootstrap-secret"
+    storage._read_persisted_bootstrap_password()
+
+    # A lone newline over a cleared file still reads back as no password.
+    assert storage._BOOTSTRAP_PW_PATH.read_bytes().strip() == b""
+    storage._bootstrap_password = None
+    assert storage._load_bootstrap_password() is None
 
 
 def test_normalising_works_without_fchmod(monkeypatch):

--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -135,10 +135,10 @@ def test_ensure_default_admin_loads_existing_bootstrap_after_restart(monkeypatch
 
 
 def test_bootstrap_password_file_ends_with_a_newline():
-    # Otherwise `cat` welds the passphrase to the shell prompt and both get copied.
+    # Otherwise `cat` welds the passphrase onto the shell prompt.
     storage.ensure_default_admin()
 
-    # Bytes, not read_text: that decodes CRLF back to "\n" and hides a CR.
+    # Bytes: read_text would decode CRLF back to "\n" and hide a CR.
     raw = storage._BOOTSTRAP_PW_PATH.read_bytes()
 
     assert raw == storage.get_bootstrap_password().encode("utf-8") + b"\n"
@@ -154,8 +154,7 @@ def test_bootstrap_password_round_trips_across_a_restart_with_the_newline():
 
 
 def test_upgrade_normalises_the_bootstrap_file():
-    # The upgrade path is ensure_default_admin() on an install that already has
-    # the admin row, which never reaches generate_bootstrap_password().
+    # Upgrade path: the admin row exists, so generate_bootstrap_password() never runs.
     seed_user()
     storage._BOOTSTRAP_PW_PATH.write_bytes(b"legacy-bootstrap-secret")
 
@@ -174,8 +173,7 @@ def test_upgrade_normalises_the_bootstrap_file():
     ],
 )
 def test_only_an_exactly_unterminated_bootstrap_file_is_touched(other):
-    # Appending is safe precisely because it is restricted to the one shape
-    # released code produced. Everything else reads fine and is left alone.
+    # Appending is safe only because it is restricted to the one released shape.
     seed_user()
     storage._BOOTSTRAP_PW_PATH.write_bytes(other)
 
@@ -222,8 +220,7 @@ def test_migration_failure_does_not_break_startup(monkeypatch):
 
 
 def test_normalising_never_recreates_a_cleared_bootstrap_file(monkeypatch):
-    # A rename would resurrect the file if the password changed after the read,
-    # leaving revoked plaintext for a later auth.db reset to re-seed.
+    # A rename would resurrect revoked plaintext if the password changed after the read.
     seed_user()
     storage._BOOTSTRAP_PW_PATH.write_bytes(b"legacy-bootstrap-secret")
 
@@ -263,8 +260,7 @@ def test_normalising_does_not_overwrite_a_rotated_bootstrap_file(monkeypatch):
 
 
 def test_leading_whitespace_bootstrap_file_is_left_alone(monkeypatch):
-    # Only trailing whitespace is rewritten in place: without a rename there is
-    # no atomicity, and a partial rewrite here could mis-strip.
+    # An in-place rewrite is not atomic, so only the exact unterminated shape is touched.
     seed_user()
     storage._BOOTSTRAP_PW_PATH.write_bytes(b"  legacy-bootstrap-secret  ")
 
@@ -275,8 +271,7 @@ def test_leading_whitespace_bootstrap_file_is_left_alone(monkeypatch):
 
 
 def test_normalising_opens_the_file_in_binary_mode(monkeypatch):
-    # Without O_BINARY, Windows opens the descriptor in text mode and os.write
-    # turns the LF back into CRLF, reintroducing the bug being fixed.
+    # Without O_BINARY, Windows text mode turns the written LF back into CRLF.
     seed_user()
     storage._BOOTSTRAP_PW_PATH.write_bytes(b"legacy-bootstrap-secret")
     monkeypatch.setattr(storage.os, "O_BINARY", 0x8000, raising = False)
@@ -296,9 +291,8 @@ def test_normalising_opens_the_file_in_binary_mode(monkeypatch):
 
 
 def test_clearing_by_truncation_mid_normalisation_is_not_undone(monkeypatch):
-    # clear_bootstrap_password() truncates through its own descriptor when the
-    # unlink fails, which is what happens on Windows while ours is open. The
-    # append must not put the revoked plaintext back.
+    # clear_bootstrap_password() truncates through its own descriptor when the unlink
+    # fails (Windows, while ours is open); the append must not restore the plaintext.
     seed_user()
     storage._BOOTSTRAP_PW_PATH.write_bytes(b"legacy-bootstrap-secret")
 

--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -153,30 +153,69 @@ def test_bootstrap_password_round_trips_across_a_restart_with_the_newline():
     assert storage.generate_bootstrap_password() == original
 
 
-def test_legacy_bootstrap_password_without_a_newline_is_migrated():
-    # Upgrades kept the `cat` problem: the file is read, not rewritten.
+@pytest.mark.parametrize("legacy", [
+    b"legacy-bootstrap-secret",         # written before the newline existed
+    b"legacy-bootstrap-secret\r\n",     # written by text mode on Windows
+])
+def test_upgrade_normalises_the_bootstrap_file(legacy):
+    # The upgrade path is ensure_default_admin() on an install that already has
+    # the admin row, which never reaches generate_bootstrap_password().
+    seed_user()
+    storage._BOOTSTRAP_PW_PATH.write_bytes(legacy)
+
+    storage.ensure_default_admin()
+
+    assert storage._BOOTSTRAP_PW_PATH.read_bytes() == b"legacy-bootstrap-secret\n"
+    assert storage.get_bootstrap_password() == "legacy-bootstrap-secret"
+
+
+def test_upgrade_normalises_when_the_admin_row_is_missing():
     storage._BOOTSTRAP_PW_PATH.write_bytes(b"legacy-bootstrap-secret")
 
     assert storage.generate_bootstrap_password() == "legacy-bootstrap-secret"
     assert storage._BOOTSTRAP_PW_PATH.read_bytes() == b"legacy-bootstrap-secret\n"
 
 
-def test_legacy_bootstrap_password_with_crlf_is_migrated():
-    storage._BOOTSTRAP_PW_PATH.write_bytes(b"crlf-bootstrap-secret\r\n")
+def test_a_well_formed_bootstrap_file_is_not_rewritten():
+    seed_user()
+    storage._BOOTSTRAP_PW_PATH.write_bytes(b"legacy-bootstrap-secret\n")
+    mtime = storage._BOOTSTRAP_PW_PATH.stat().st_mtime_ns
 
-    assert storage.generate_bootstrap_password() == "crlf-bootstrap-secret"
-    assert storage._BOOTSTRAP_PW_PATH.read_bytes() == b"crlf-bootstrap-secret\n"
+    storage.ensure_default_admin()
+
+    assert storage._BOOTSTRAP_PW_PATH.stat().st_mtime_ns == mtime
 
 
-def test_migrating_a_legacy_bootstrap_password_survives_a_read_only_dir(monkeypatch):
+def test_migration_failure_does_not_break_startup(monkeypatch):
+    seed_user()
     storage._BOOTSTRAP_PW_PATH.write_bytes(b"legacy-bootstrap-secret")
 
     def refuse(*args, **kwargs):
-        raise OSError("read-only auth dir")
+        raise PermissionError("read-only auth dir")
 
-    monkeypatch.setattr(Path, "write_bytes", refuse)
+    monkeypatch.setattr(storage.tempfile, "mkstemp", refuse)
 
-    assert storage.generate_bootstrap_password() == "legacy-bootstrap-secret"
+    storage.ensure_default_admin()
+
+    assert storage.get_bootstrap_password() == "legacy-bootstrap-secret"
+    assert storage._BOOTSTRAP_PW_PATH.read_bytes() == b"legacy-bootstrap-secret"
+
+
+def test_persisting_the_bootstrap_password_is_atomic(monkeypatch, tmp_path):
+    # A partial write would destroy the only plaintext recovery credential.
+    storage._persist_bootstrap_password("original-secret")
+
+    def boom(src, dst):
+        raise OSError("crash before replace")
+
+    monkeypatch.setattr(storage.os, "replace", boom)
+    with pytest.raises(OSError):
+        storage._persist_bootstrap_password("new-secret")
+
+    assert storage._BOOTSTRAP_PW_PATH.read_bytes() == b"original-secret\n"
+    leftovers = [p.name for p in storage._BOOTSTRAP_PW_PATH.parent.iterdir()
+                 if "bootstrap_password." in p.name]
+    assert leftovers == []
 
 
 def test_ensure_default_admin_does_not_generate_for_empty_existing_bootstrap():

--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -173,7 +173,7 @@ def test_upgrade_normalises_the_bootstrap_file():
         b"legacy-bootstrap-secret   ",
     ],
 )
-def test_only_an_exactly_untermimated_bootstrap_file_is_touched(other):
+def test_only_an_exactly_unterminated_bootstrap_file_is_touched(other):
     # Appending is safe precisely because it is restricted to the one shape
     # released code produced. Everything else reads fine and is left alone.
     seed_user()

--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -165,11 +165,14 @@ def test_upgrade_normalises_the_bootstrap_file():
     assert storage.get_bootstrap_password() == "legacy-bootstrap-secret"
 
 
-@pytest.mark.parametrize("other", [
-    b"legacy-bootstrap-secret\r\n",     # only an unreleased build wrote this
-    b"legacy-bootstrap-secret\r",
-    b"legacy-bootstrap-secret   ",
-])
+@pytest.mark.parametrize(
+    "other",
+    [
+        b"legacy-bootstrap-secret\r\n",  # only an unreleased build wrote this
+        b"legacy-bootstrap-secret\r",
+        b"legacy-bootstrap-secret   ",
+    ],
+)
 def test_only_an_exactly_untermimated_bootstrap_file_is_touched(other):
     # Appending is safe precisely because it is restricted to the one shape
     # released code produced. Everything else reads fine and is left alone.

--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -153,10 +153,13 @@ def test_bootstrap_password_round_trips_across_a_restart_with_the_newline():
     assert storage.generate_bootstrap_password() == original
 
 
-@pytest.mark.parametrize("legacy", [
-    b"legacy-bootstrap-secret",         # written before the newline existed
-    b"legacy-bootstrap-secret\r\n",     # written by text mode on Windows
-])
+@pytest.mark.parametrize(
+    "legacy",
+    [
+        b"legacy-bootstrap-secret",  # written before the newline existed
+        b"legacy-bootstrap-secret\r\n",  # written by text mode on Windows
+    ],
+)
 def test_upgrade_normalises_the_bootstrap_file(legacy):
     # The upgrade path is ensure_default_admin() on an install that already has
     # the admin row, which never reaches generate_bootstrap_password().
@@ -213,8 +216,11 @@ def test_persisting_the_bootstrap_password_is_atomic(monkeypatch, tmp_path):
         storage._persist_bootstrap_password("new-secret")
 
     assert storage._BOOTSTRAP_PW_PATH.read_bytes() == b"original-secret\n"
-    leftovers = [p.name for p in storage._BOOTSTRAP_PW_PATH.parent.iterdir()
-                 if "bootstrap_password." in p.name]
+    leftovers = [
+        p.name
+        for p in storage._BOOTSTRAP_PW_PATH.parent.iterdir()
+        if "bootstrap_password." in p.name
+    ]
     assert leftovers == []
 
 

--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -193,15 +193,68 @@ def test_migration_failure_does_not_break_startup(monkeypatch):
     seed_user()
     storage._BOOTSTRAP_PW_PATH.write_bytes(b"legacy-bootstrap-secret")
 
-    def refuse(*args, **kwargs):
-        raise PermissionError("read-only auth dir")
+    real_open = storage.os.open
 
-    monkeypatch.setattr(storage.tempfile, "mkstemp", refuse)
+    def refuse(path, flags, *args, **kwargs):
+        if str(path) == str(storage._BOOTSTRAP_PW_PATH):
+            raise PermissionError("read-only auth dir")
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(storage.os, "open", refuse)
 
     storage.ensure_default_admin()
 
     assert storage.get_bootstrap_password() == "legacy-bootstrap-secret"
     assert storage._BOOTSTRAP_PW_PATH.read_bytes() == b"legacy-bootstrap-secret"
+
+
+def test_normalising_never_recreates_a_cleared_bootstrap_file(monkeypatch):
+    # A rename would resurrect the file if the password changed after the read,
+    # leaving revoked plaintext for a later auth.db reset to re-seed.
+    seed_user()
+    storage._BOOTSTRAP_PW_PATH.write_bytes(b"legacy-bootstrap-secret")
+
+    real_open = storage.os.open
+
+    def clear_then_open(path, flags, *args, **kwargs):
+        if str(path) == str(storage._BOOTSTRAP_PW_PATH):
+            storage._BOOTSTRAP_PW_PATH.unlink(missing_ok = True)
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(storage.os, "open", clear_then_open)
+
+    assert storage._read_persisted_bootstrap_password() == "legacy-bootstrap-secret"
+    assert not storage._BOOTSTRAP_PW_PATH.exists()
+
+
+def test_normalising_does_not_overwrite_a_rotated_bootstrap_file(monkeypatch):
+    seed_user()
+    storage._BOOTSTRAP_PW_PATH.write_bytes(b"legacy-bootstrap-secret")
+
+    real_open = storage.os.open
+
+    def rotate_then_open(path, flags, *args, **kwargs):
+        if str(path) == str(storage._BOOTSTRAP_PW_PATH):
+            storage._BOOTSTRAP_PW_PATH.write_bytes(b"brand-new-secret\n")
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(storage.os, "open", rotate_then_open)
+
+    storage._read_persisted_bootstrap_password()
+
+    assert storage._BOOTSTRAP_PW_PATH.read_bytes() == b"brand-new-secret\n"
+
+
+def test_leading_whitespace_bootstrap_file_is_left_alone(monkeypatch):
+    # Only trailing whitespace is rewritten in place: without a rename there is
+    # no atomicity, and a partial rewrite here could mis-strip.
+    seed_user()
+    storage._BOOTSTRAP_PW_PATH.write_bytes(b"  legacy-bootstrap-secret  ")
+
+    storage.ensure_default_admin()
+
+    assert storage.get_bootstrap_password() == "legacy-bootstrap-secret"
+    assert storage._BOOTSTRAP_PW_PATH.read_bytes() == b"  legacy-bootstrap-secret  "
 
 
 def test_persisting_the_bootstrap_password_is_atomic(monkeypatch, tmp_path):

--- a/studio/backend/tests/test_desktop_auth.py
+++ b/studio/backend/tests/test_desktop_auth.py
@@ -138,11 +138,10 @@ def test_bootstrap_password_file_ends_with_a_newline():
     # Otherwise `cat` welds the passphrase to the shell prompt and both get copied.
     storage.ensure_default_admin()
 
-    raw = storage._BOOTSTRAP_PW_PATH.read_text(encoding = "utf-8")
+    # Bytes, not read_text: that decodes CRLF back to "\n" and hides a CR.
+    raw = storage._BOOTSTRAP_PW_PATH.read_bytes()
 
-    assert raw.endswith("\n")
-    assert raw.strip() == storage.get_bootstrap_password()
-    assert "\n" not in raw.strip()
+    assert raw == storage.get_bootstrap_password().encode("utf-8") + b"\n"
 
 
 def test_bootstrap_password_round_trips_across_a_restart_with_the_newline():
@@ -152,6 +151,32 @@ def test_bootstrap_password_round_trips_across_a_restart_with_the_newline():
     storage._bootstrap_password = None
 
     assert storage.generate_bootstrap_password() == original
+
+
+def test_legacy_bootstrap_password_without_a_newline_is_migrated():
+    # Upgrades kept the `cat` problem: the file is read, not rewritten.
+    storage._BOOTSTRAP_PW_PATH.write_bytes(b"legacy-bootstrap-secret")
+
+    assert storage.generate_bootstrap_password() == "legacy-bootstrap-secret"
+    assert storage._BOOTSTRAP_PW_PATH.read_bytes() == b"legacy-bootstrap-secret\n"
+
+
+def test_legacy_bootstrap_password_with_crlf_is_migrated():
+    storage._BOOTSTRAP_PW_PATH.write_bytes(b"crlf-bootstrap-secret\r\n")
+
+    assert storage.generate_bootstrap_password() == "crlf-bootstrap-secret"
+    assert storage._BOOTSTRAP_PW_PATH.read_bytes() == b"crlf-bootstrap-secret\n"
+
+
+def test_migrating_a_legacy_bootstrap_password_survives_a_read_only_dir(monkeypatch):
+    storage._BOOTSTRAP_PW_PATH.write_bytes(b"legacy-bootstrap-secret")
+
+    def refuse(*args, **kwargs):
+        raise OSError("read-only auth dir")
+
+    monkeypatch.setattr(Path, "write_bytes", refuse)
+
+    assert storage.generate_bootstrap_password() == "legacy-bootstrap-secret"
 
 
 def test_ensure_default_admin_does_not_generate_for_empty_existing_bootstrap():
@@ -378,7 +403,7 @@ def test_write_desktop_secret_file_is_0600_on_unix(tmp_path):
 
     studio_cli._write_auth_secret(path, "desktop-secret")
 
-    assert path.read_text() == "desktop-secret\n"
+    assert path.read_bytes() == b"desktop-secret\n"
     if platform.system() != "Windows":
         assert oct(path.stat().st_mode & 0o777) == "0o600"
 

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -485,7 +485,8 @@ def _write_auth_secret(path: Path, secret: str) -> None:
             pass
         with os.fdopen(fd, "w", encoding = "utf-8") as f:
             fd = -1
-            f.write(secret)
+            # Newline so `cat` doesn't run it into the shell prompt; readers strip.
+            f.write(secret + "\n")
         os.replace(tmp_path, path)
     except Exception:
         if fd >= 0:

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -483,7 +483,7 @@ def _write_auth_secret(path: Path, secret: str) -> None:
             os.chmod(tmp_path, 0o600)
         except OSError:
             pass
-        # newline pins LF: text mode would write CRLF on Windows, and `$(cat ...)`
+        # newline pins LF: text mode writes CRLF on Windows, and `$(cat ...)`
         # strips the LF but leaves the CR glued to the credential.
         with os.fdopen(fd, "w", encoding = "utf-8", newline = "\n") as f:
             fd = -1

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -483,7 +483,9 @@ def _write_auth_secret(path: Path, secret: str) -> None:
             os.chmod(tmp_path, 0o600)
         except OSError:
             pass
-        with os.fdopen(fd, "w", encoding = "utf-8") as f:
+        # newline pins LF: text mode would write CRLF on Windows, and `$(cat ...)`
+        # strips the LF but leaves the CR glued to the credential.
+        with os.fdopen(fd, "w", encoding = "utf-8", newline = "\n") as f:
             fd = -1
             # Newline so `cat` doesn't run it into the shell prompt; readers strip.
             f.write(secret + "\n")

--- a/unsloth_cli/tests/test_studio_password_prompt.py
+++ b/unsloth_cli/tests/test_studio_password_prompt.py
@@ -1232,9 +1232,7 @@ def test_seeded_bootstrap_file_ends_with_a_newline(monkeypatch, tmp_path):
         ).fetchone()
     finally:
         conn.close()
-    assert studio_mod._pbkdf2_hex(
-        raw.decode("utf-8").strip(), salt.encode("utf-8")
-    ) == pwd_hash
+    assert studio_mod._pbkdf2_hex(raw.decode("utf-8").strip(), salt.encode("utf-8")) == pwd_hash
 
 
 # ── non-interactive --password / UNSLOTH_STUDIO_PASSWORD / stdin ──────

--- a/unsloth_cli/tests/test_studio_password_prompt.py
+++ b/unsloth_cli/tests/test_studio_password_prompt.py
@@ -251,7 +251,9 @@ def test_studio_default_prompt_rejects_current_password(monkeypatch, tmp_path):
     studio_mod = _studio()
     events = _install_prompt_env(monkeypatch, tmp_path, interactive = True)
     _seed_auth(studio_mod)
-    bootstrap_pw = (tmp_path / "auth" / studio_mod.BOOTSTRAP_PASSWORD_FILE).read_text()
+    bootstrap_pw = (
+        tmp_path / "auth" / studio_mod.BOOTSTRAP_PASSWORD_FILE
+    ).read_text().strip()
 
     _invoke_studio_default(monkeypatch, events, ["--secure"])
 
@@ -1204,6 +1206,40 @@ def test_connect_auth_db_creates_private_files(monkeypatch, tmp_path):
     assert stat.S_IMODE((auth_dir / "auth.db").stat().st_mode) == 0o600
 
 
+def test_write_auth_secret_terminates_the_file_with_a_newline(monkeypatch, tmp_path):
+    # Shared by .bootstrap_password and .desktop_secret; every reader strips.
+    studio_mod = _studio()
+    path = tmp_path / ".desktop_secret"
+
+    studio_mod._write_auth_secret(path, "desktop-abc123")
+
+    raw = path.read_text(encoding = "utf-8")
+    assert raw == "desktop-abc123\n"
+    assert raw.strip() == "desktop-abc123"
+
+
+def test_seeded_bootstrap_file_ends_with_a_newline(monkeypatch, tmp_path):
+    studio_mod = _studio()
+    monkeypatch.setattr(studio_mod, "STUDIO_HOME", tmp_path)
+    _seed_auth(studio_mod)
+
+    raw = (tmp_path / "auth" / studio_mod.BOOTSTRAP_PASSWORD_FILE).read_text(
+        encoding = "utf-8"
+    )
+
+    assert raw.endswith("\n")
+
+    conn = sqlite3.connect(_auth_db(tmp_path))
+    try:
+        salt, pwd_hash = conn.execute(
+            "SELECT password_salt, password_hash FROM auth_user WHERE username = ?",
+            (studio_mod.DEFAULT_ADMIN_USERNAME,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert studio_mod._pbkdf2_hex(raw.strip(), salt.encode("utf-8")) == pwd_hash
+
+
 # ── non-interactive --password / UNSLOTH_STUDIO_PASSWORD / stdin ──────
 
 
@@ -1284,7 +1320,9 @@ def test_studio_default_password_must_differ_fails_closed(monkeypatch, tmp_path)
     studio_mod = _studio()
     events = _install_prompt_env(monkeypatch, tmp_path, interactive = True)
     _seed_auth(studio_mod)
-    bootstrap_pw = (tmp_path / "auth" / studio_mod.BOOTSTRAP_PASSWORD_FILE).read_text()
+    bootstrap_pw = (
+        tmp_path / "auth" / studio_mod.BOOTSTRAP_PASSWORD_FILE
+    ).read_text().strip()
 
     result = _invoke_studio_default(monkeypatch, events, ["--secure", "--password", bootstrap_pw])
 

--- a/unsloth_cli/tests/test_studio_password_prompt.py
+++ b/unsloth_cli/tests/test_studio_password_prompt.py
@@ -1211,9 +1211,8 @@ def test_write_auth_secret_terminates_the_file_with_a_newline(monkeypatch, tmp_p
 
     studio_mod._write_auth_secret(path, "desktop-abc123")
 
-    raw = path.read_text(encoding = "utf-8")
-    assert raw == "desktop-abc123\n"
-    assert raw.strip() == "desktop-abc123"
+    # Bytes, not read_text: that decodes CRLF back to "\n" and hides a CR.
+    assert path.read_bytes() == b"desktop-abc123\n"
 
 
 def test_seeded_bootstrap_file_ends_with_a_newline(monkeypatch, tmp_path):
@@ -1221,9 +1220,9 @@ def test_seeded_bootstrap_file_ends_with_a_newline(monkeypatch, tmp_path):
     monkeypatch.setattr(studio_mod, "STUDIO_HOME", tmp_path)
     _seed_auth(studio_mod)
 
-    raw = (tmp_path / "auth" / studio_mod.BOOTSTRAP_PASSWORD_FILE).read_text(encoding = "utf-8")
+    raw = (tmp_path / "auth" / studio_mod.BOOTSTRAP_PASSWORD_FILE).read_bytes()
 
-    assert raw.endswith("\n")
+    assert raw.endswith(b"\n") and not raw.endswith(b"\r\n")
 
     conn = sqlite3.connect(_auth_db(tmp_path))
     try:
@@ -1233,7 +1232,9 @@ def test_seeded_bootstrap_file_ends_with_a_newline(monkeypatch, tmp_path):
         ).fetchone()
     finally:
         conn.close()
-    assert studio_mod._pbkdf2_hex(raw.strip(), salt.encode("utf-8")) == pwd_hash
+    assert studio_mod._pbkdf2_hex(
+        raw.decode("utf-8").strip(), salt.encode("utf-8")
+    ) == pwd_hash
 
 
 # ── non-interactive --password / UNSLOTH_STUDIO_PASSWORD / stdin ──────

--- a/unsloth_cli/tests/test_studio_password_prompt.py
+++ b/unsloth_cli/tests/test_studio_password_prompt.py
@@ -251,9 +251,7 @@ def test_studio_default_prompt_rejects_current_password(monkeypatch, tmp_path):
     studio_mod = _studio()
     events = _install_prompt_env(monkeypatch, tmp_path, interactive = True)
     _seed_auth(studio_mod)
-    bootstrap_pw = (
-        tmp_path / "auth" / studio_mod.BOOTSTRAP_PASSWORD_FILE
-    ).read_text().strip()
+    bootstrap_pw = (tmp_path / "auth" / studio_mod.BOOTSTRAP_PASSWORD_FILE).read_text().strip()
 
     _invoke_studio_default(monkeypatch, events, ["--secure"])
 
@@ -1223,9 +1221,7 @@ def test_seeded_bootstrap_file_ends_with_a_newline(monkeypatch, tmp_path):
     monkeypatch.setattr(studio_mod, "STUDIO_HOME", tmp_path)
     _seed_auth(studio_mod)
 
-    raw = (tmp_path / "auth" / studio_mod.BOOTSTRAP_PASSWORD_FILE).read_text(
-        encoding = "utf-8"
-    )
+    raw = (tmp_path / "auth" / studio_mod.BOOTSTRAP_PASSWORD_FILE).read_text(encoding = "utf-8")
 
     assert raw.endswith("\n")
 
@@ -1320,9 +1316,7 @@ def test_studio_default_password_must_differ_fails_closed(monkeypatch, tmp_path)
     studio_mod = _studio()
     events = _install_prompt_env(monkeypatch, tmp_path, interactive = True)
     _seed_auth(studio_mod)
-    bootstrap_pw = (
-        tmp_path / "auth" / studio_mod.BOOTSTRAP_PASSWORD_FILE
-    ).read_text().strip()
+    bootstrap_pw = (tmp_path / "auth" / studio_mod.BOOTSTRAP_PASSWORD_FILE).read_text().strip()
 
     result = _invoke_studio_default(monkeypatch, events, ["--secure", "--password", bootstrap_pw])
 

--- a/unsloth_cli/tests/test_studio_password_prompt.py
+++ b/unsloth_cli/tests/test_studio_password_prompt.py
@@ -1211,7 +1211,7 @@ def test_write_auth_secret_terminates_the_file_with_a_newline(monkeypatch, tmp_p
 
     studio_mod._write_auth_secret(path, "desktop-abc123")
 
-    # Bytes, not read_text: that decodes CRLF back to "\n" and hides a CR.
+    # Bytes: read_text would decode CRLF back to "\n" and hide a CR.
     assert path.read_bytes() == b"desktop-abc123\n"
 
 


### PR DESCRIPTION
`.bootstrap_password` and `.desktop_secret` were written without a trailing newline, so `cat` runs the credential straight into the shell prompt and the prompt gets selected along with it. The paste then fails as "Login failed", which reads as a wrong password rather than a bad copy.

Fixes both writers the backend's `generate_bootstrap_password()` (the one that runs on a normal server boot) and the CLI's shared `_write_auth_secret()`. Every reader already strips: backend storage, both src-tauri readers, and `$(cat)` in
CI. Updates four tests that read these files without stripping, and adds coverage that the files end in `\n` and still authenticate.