### PR TITLE
Clear ALLOW_BITSANDBYTES when the bitsandbytes native kernels are not real

### DIFF
--- a/tests/python/test_bitsandbytes_kernel_readiness.py
+++ b/tests/python/test_bitsandbytes_kernel_readiness.py
@@ -100,9 +100,14 @@ def test_a_lib_that_never_loaded_is_not_ready():
     assert probe.native_kernels_ready(_fake_bnb(None), "cuda") is False
 
 
-def test_a_partially_exporting_library_stays_ready():
-    """``ALLOW_BITSANDBYTES`` gates 8bit as well as 4bit, so writing a wheel off over
-    one missing symbol would silently downgrade a working LLM.int8 request."""
+def test_a_partially_exporting_library_is_not_ready():
+    """Every probed handle has to be native, not just one.
+
+    The same verdict gates the module-scope binds, so a library that resolves one symbol
+    and not another would pass the probe and then raise `AttributeError` at the bind it
+    was meant to prevent. It costs 8bit too (`ALLOW_BITSANDBYTES` gates both), but a
+    wheel missing a symbol is a shape no flag makes safe.
+    """
 
     class _MissingOne(_RealHandleLib):
         def __getattr__(self, name):
@@ -111,7 +116,20 @@ def test_a_partially_exporting_library_stays_ready():
             return super().__getattr__(name)
 
     probe = _load_probe()
-    assert probe.native_kernels_ready(_fake_bnb(_MissingOne()), "cuda") is True
+    assert probe.native_kernels_ready(_fake_bnb(_MissingOne()), "cuda") is False
+
+
+def test_one_dead_handle_among_live_ones_is_not_ready():
+    """The realistic partial shape: the library loaded but one symbol is a closure."""
+
+    class _OneDeferred(_RealHandleLib):
+        def __getattr__(self, name):
+            if name == "cdequantize_blockwise_bf16_nf4":
+                return lambda *a, **k: None
+            return super().__getattr__(name)
+
+    probe = _load_probe()
+    assert probe.native_kernels_ready(_fake_bnb(_OneDeferred()), "cuda") is False
 
 
 def test_absent_bitsandbytes_is_not_ready():

--- a/tests/python/test_bitsandbytes_kernel_readiness.py
+++ b/tests/python/test_bitsandbytes_kernel_readiness.py
@@ -141,6 +141,25 @@ def test_device_type_gates_the_flags_on_the_kernels():
     ), "both the failed-import path and the dead-kernels path must clear the flag"
 
 
+def test_the_ctypes_binds_are_gated_on_the_same_verdict():
+    """Clearing the flag is not enough on its own.
+
+    ``bnb is None`` was the only guard on the ``bnb.functional.lib.*`` binds, so an
+    importable-but-dead wheel still reached them at module scope - 0.45.5, the floor in
+    pyproject.toml, sets ``functional.lib = None`` on a native-load failure, and
+    ``None.cdequantize_blockwise_fp32`` raises there. That kills ``import unsloth``
+    outright instead of degrading to 16bit, which is the fallback the cleared flag is
+    supposed to reach.
+    """
+    source = (REPO_ROOT / "unsloth" / "kernels" / "utils.py").read_text(encoding = "utf-8")
+    assert "from ..bnb_availability import native_kernels_ready" in source
+    assert (
+        "if bnb is None or not native_kernels_ready(bnb, DEVICE_TYPE):" in source
+    ), "the ctypes bind block must take the _bnb_required branch on a dead library too"
+    guarded = source.split("if bnb is None or not native_kernels_ready(bnb, DEVICE_TYPE):")[1]
+    assert "bnb.functional.lib" in guarded, "the binds must sit under that guard"
+
+
 def test_the_kernel_check_reads_the_submodule_not_the_parent_attribute():
     """A bitsandbytes whose __init__ died part way leaves the parent without
     ``functional`` while the submodule stays in sys.modules, so the check has to go

--- a/tests/python/test_bitsandbytes_kernel_readiness.py
+++ b/tests/python/test_bitsandbytes_kernel_readiness.py
@@ -4,11 +4,9 @@
 """`ALLOW_BITSANDBYTES` must follow the kernels, not the mere presence of the module.
 
 From bitsandbytes 0.46 a wheel whose native library never loaded still imports and
-resolves every ctypes handle: `BNBNativeLibrary.__getattr__` returns a `throw_on_call`
-closure, and a dead library is replaced wholesale by `ErrorHandlerMockBNBNativeLibrary`,
-which does the same for every name. Nothing raises while `kernels/utils.py` binds them,
-so a probe made of attribute reads alone sees a healthy wheel, the loader selects a 4bit
-checkpoint, and the failure lands inside a kernel mid-run instead of degrading to 16bit.
+resolves every ctypes handle to a `throw_on_call` closure, so a probe made of attribute
+reads alone sees a healthy wheel, the loader selects a 4bit checkpoint, and the failure
+lands inside a kernel mid-run instead of degrading to 16bit.
 """
 
 from __future__ import annotations
@@ -22,10 +20,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _load_probe():
-    """Import unsloth/bnb_availability.py by path, not as ``unsloth.bnb_availability``,
-    which would run the package __init__ and pull in torch. Works only because the
-    module is a leaf - the property that lets device_type.py, imported very early, use
-    it without a cycle."""
+    """Import by path, not as ``unsloth.bnb_availability``, which would run the package
+    __init__ and pull in torch. Works only because the module is a leaf - the property
+    that lets device_type.py, imported very early, use it without a cycle."""
     path = REPO_ROOT / "unsloth" / "bnb_availability.py"
     spec = importlib.util.spec_from_file_location("_unsloth_bnb_availability", path)
     module = importlib.util.module_from_spec(spec)
@@ -66,8 +63,7 @@ class _RealHandleLib:
 
 
 def test_probe_covers_every_module_scope_ctypes_bind():
-    """kernels/utils.py binds these off ``bnb.functional.lib`` at import time, so a
-    probe that misses one lets that shape through."""
+    """A probe that misses one of the import-time binds lets a dead wheel through."""
     tree = ast.parse((REPO_ROOT / "unsloth" / "kernels" / "utils.py").read_text(encoding = "utf-8"))
     bound = {
         node.attr
@@ -80,8 +76,7 @@ def test_probe_covers_every_module_scope_ctypes_bind():
     xpu = set(probe.bitsandbytes_symbols("xpu"))
     cuda = set(probe.bitsandbytes_symbols("cuda"))
     assert bound == xpu | cuda, f"probe and module-scope binds differ: {bound ^ (xpu | cuda)}"
-    # xpu binds the gemv pair, every other device the naive gemm pair; neither probes
-    # the other's names, which its wheel will not export.
+    # xpu probes the gemv pair, every other device the naive gemm pair, never both.
     assert xpu - cuda and cuda - xpu, "the device split collapsed"
 
 
@@ -106,13 +101,8 @@ def test_a_lib_that_never_loaded_is_not_ready():
 
 
 def test_a_partially_exporting_library_stays_ready():
-    """One missing symbol does not mean a dead library.
-
-    ``ALLOW_BITSANDBYTES`` gates 8bit as well as 4bit - loader.py clears both - so
-    writing the wheel off here would silently downgrade a working LLM.int8 request.
-    The missing symbol raises where kernels/utils.py binds it, which is a crash no
-    flag can rescue, not something to trade 8bit for.
-    """
+    """``ALLOW_BITSANDBYTES`` gates 8bit as well as 4bit, so writing a wheel off over
+    one missing symbol would silently downgrade a working LLM.int8 request."""
 
     class _MissingOne(_RealHandleLib):
         def __getattr__(self, name):
@@ -142,15 +132,10 @@ def test_device_type_gates_the_flags_on_the_kernels():
 
 
 def test_the_ctypes_binds_are_gated_on_the_same_verdict():
-    """Clearing the flag is not enough on its own.
-
-    ``bnb is None`` was the only guard on the ``bnb.functional.lib.*`` binds, so an
-    importable-but-dead wheel still reached them at module scope - 0.45.5, the floor in
-    pyproject.toml, sets ``functional.lib = None`` on a native-load failure, and
-    ``None.cdequantize_blockwise_fp32`` raises there. That kills ``import unsloth``
-    outright instead of degrading to 16bit, which is the fallback the cleared flag is
-    supposed to reach.
-    """
+    """Clearing the flag is not enough on its own: ``bnb is None`` alone let an
+    importable-but-dead wheel reach the binds, and 0.45.5 sets ``functional.lib = None``
+    on a native-load failure, so they killed ``import unsloth`` outright instead of
+    degrading to 16bit."""
     source = (REPO_ROOT / "unsloth" / "kernels" / "utils.py").read_text(encoding = "utf-8")
     assert "from ..bnb_availability import native_kernels_ready" in source
     assert (
@@ -161,9 +146,9 @@ def test_the_ctypes_binds_are_gated_on_the_same_verdict():
 
 
 def test_the_kernel_check_reads_the_submodule_not_the_parent_attribute():
-    """A bitsandbytes whose __init__ died part way leaves the parent without
-    ``functional`` while the submodule stays in sys.modules, so the check has to go
-    through ``import bitsandbytes.functional``, which reads sys.modules directly."""
+    """A part-initialised bitsandbytes leaves the parent without ``functional`` while
+    the submodule stays in sys.modules, which ``import bitsandbytes.functional`` reads
+    directly."""
     probe = _load_probe()
     bnb = types.ModuleType("bitsandbytes")  # zombie: parent has no `functional`
     bnb.__version__ = "0.50.0"
@@ -172,6 +157,5 @@ def test_the_kernel_check_reads_the_submodule_not_the_parent_attribute():
     real = sys.modules.get("bitsandbytes.functional")
     if real is None:
         return  # bitsandbytes not importable here; the fallback has nothing to read
-    # Must not raise AttributeError on the missing parent attribute: it falls back
-    # to the cached submodule and returns a verdict either way.
+    # Falls back to the cached submodule instead of raising on the missing attribute.
     assert probe.native_kernels_ready(bnb, "cuda") in (True, False)

--- a/tests/python/test_bitsandbytes_kernel_readiness.py
+++ b/tests/python/test_bitsandbytes_kernel_readiness.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""`ALLOW_BITSANDBYTES` must follow the kernels, not the mere presence of the module.
+
+From bitsandbytes 0.46 a wheel whose native library never loaded still imports and
+resolves every ctypes handle: `BNBNativeLibrary.__getattr__` returns a `throw_on_call`
+closure, and a dead library is replaced wholesale by `ErrorHandlerMockBNBNativeLibrary`,
+which does the same for every name. Nothing raises while `kernels/utils.py` binds them,
+so a probe made of attribute reads alone sees a healthy wheel, the loader selects a 4bit
+checkpoint, and the failure lands inside a kernel mid-run instead of degrading to 16bit.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import types
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_probe():
+    """Import unsloth/bnb_availability.py by path, not as ``unsloth.bnb_availability``,
+    which would run the package __init__ and pull in torch. Works only because the
+    module is a leaf - the property that lets device_type.py, imported very early, use
+    it without a cycle."""
+    path = REPO_ROOT / "unsloth" / "bnb_availability.py"
+    spec = importlib.util.spec_from_file_location("_unsloth_bnb_availability", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fake_bnb(lib):
+    functional = types.ModuleType("bitsandbytes.functional")
+    functional.get_ptr = lambda tensor: None
+    functional.lib = lib
+    bnb = types.ModuleType("bitsandbytes")
+    bnb.__version__ = "0.50.0"
+    bnb.functional = functional
+    return bnb
+
+
+class _DeferredFailureLib:
+    """What bitsandbytes >= 0.46 hands back when the native library is dead."""
+
+    def __getattr__(self, name):
+        def throw_on_call(*args, **kwargs):
+            raise RuntimeError(f"Method '{name}' not available in CPU-only version")
+
+        return throw_on_call
+
+
+class _RealHandleLib:
+    """ctypes caches the function object on first lookup; its handles carry restype."""
+
+    def __getattr__(self, name):
+        def handle(*args, **kwargs):
+            return None
+
+        handle.restype = None
+        setattr(self, name, handle)
+        return handle
+
+
+def test_probe_covers_every_module_scope_ctypes_bind():
+    """kernels/utils.py binds these off ``bnb.functional.lib`` at import time, so a
+    probe that misses one lets that shape through."""
+    tree = ast.parse((REPO_ROOT / "unsloth" / "kernels" / "utils.py").read_text(encoding = "utf-8"))
+    bound = {
+        node.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Attribute)
+        and node.value.attr == "lib"
+    }
+    probe = _load_probe()
+    xpu = set(probe.bitsandbytes_symbols("xpu"))
+    cuda = set(probe.bitsandbytes_symbols("cuda"))
+    assert bound == xpu | cuda, f"probe and module-scope binds differ: {bound ^ (xpu | cuda)}"
+    # xpu binds the gemv pair, every other device the naive gemm pair; neither probes
+    # the other's names, which its wheel will not export.
+    assert xpu - cuda and cuda - xpu, "the device split collapsed"
+
+
+def test_a_deferred_failure_handle_is_not_ready():
+    probe = _load_probe()
+    bnb = _fake_bnb(_DeferredFailureLib())
+    for device in ("cuda", "xpu"):
+        assert probe.native_kernels_ready(bnb, device) is False, device
+
+
+def test_a_real_ctypes_handle_is_ready():
+    probe = _load_probe()
+    bnb = _fake_bnb(_RealHandleLib())
+    for device in ("cuda", "xpu"):
+        assert probe.native_kernels_ready(bnb, device) is True, device
+
+
+def test_a_lib_that_never_loaded_is_not_ready():
+    """bitsandbytes 0.45.5, the floor in pyproject.toml, sets ``functional.lib = None``."""
+    probe = _load_probe()
+    assert probe.native_kernels_ready(_fake_bnb(None), "cuda") is False
+
+
+def test_a_missing_symbol_is_not_ready():
+    """A partially loaded or backend-mismatched wheel resolves most names; ctypes
+    raises AttributeError on the first one it does not export."""
+
+    class _MissingOne(_RealHandleLib):
+        def __getattr__(self, name):
+            if name == "cgemm_4bit_inference_naive_bf16":
+                raise AttributeError(name)
+            return super().__getattr__(name)
+
+    probe = _load_probe()
+    assert probe.native_kernels_ready(_fake_bnb(_MissingOne()), "cuda") is False
+
+
+def test_absent_bitsandbytes_is_not_ready():
+    probe = _load_probe()
+    assert probe.native_kernels_ready(None, "cuda") is False
+
+
+def test_device_type_gates_the_flags_on_the_kernels():
+    """The flags must follow ``native_kernels_ready``, not the bare import."""
+    head = (REPO_ROOT / "unsloth" / "device_type.py").read_text(encoding = "utf-8")
+    head = head.split('if DEVICE_TYPE == "hip":')[0]
+    assert "import bitsandbytes as _bnb_probe" in head
+    assert 'find_spec("bitsandbytes")' not in head, "find_spec cannot see a broken wheel"
+    assert "native_kernels_ready(_bnb_probe, DEVICE_TYPE)" in head
+    assert head.count("ALLOW_BITSANDBYTES = False") >= 2, (
+        "both the failed-import path and the dead-kernels path must clear the flag"
+    )
+
+
+def test_the_kernel_check_reads_the_submodule_not_the_parent_attribute():
+    """A bitsandbytes whose __init__ died part way leaves the parent without
+    ``functional`` while the submodule stays in sys.modules, so the check has to go
+    through ``import bitsandbytes.functional``, which reads sys.modules directly."""
+    probe = _load_probe()
+    bnb = types.ModuleType("bitsandbytes")   # zombie: parent has no `functional`
+    bnb.__version__ = "0.50.0"
+    import sys
+    real = sys.modules.get("bitsandbytes.functional")
+    if real is None:
+        return  # bitsandbytes not importable here; the fallback has nothing to read
+    # Must not raise AttributeError on the missing parent attribute: it falls back
+    # to the cached submodule and returns a verdict either way.
+    assert probe.native_kernels_ready(bnb, "cuda") in (True, False)

--- a/tests/python/test_bitsandbytes_kernel_readiness.py
+++ b/tests/python/test_bitsandbytes_kernel_readiness.py
@@ -101,13 +101,8 @@ def test_a_lib_that_never_loaded_is_not_ready():
 
 
 def test_a_partially_exporting_library_is_not_ready():
-    """Every probed handle has to be native, not just one.
-
-    The same verdict gates the module-scope binds, so a library that resolves one symbol
-    and not another would pass the probe and then raise `AttributeError` at the bind it
-    was meant to prevent. It costs 8bit too (`ALLOW_BITSANDBYTES` gates both), but a
-    wheel missing a symbol is a shape no flag makes safe.
-    """
+    """One resolvable symbol is not enough: the same verdict gates the module-scope
+    binds, so a partial library would pass here and raise `AttributeError` at the bind."""
 
     class _MissingOne(_RealHandleLib):
         def __getattr__(self, name):

--- a/tests/python/test_bitsandbytes_kernel_readiness.py
+++ b/tests/python/test_bitsandbytes_kernel_readiness.py
@@ -105,9 +105,14 @@ def test_a_lib_that_never_loaded_is_not_ready():
     assert probe.native_kernels_ready(_fake_bnb(None), "cuda") is False
 
 
-def test_a_missing_symbol_is_not_ready():
-    """A partially loaded or backend-mismatched wheel resolves most names; ctypes
-    raises AttributeError on the first one it does not export."""
+def test_a_partially_exporting_library_stays_ready():
+    """One missing symbol does not mean a dead library.
+
+    ``ALLOW_BITSANDBYTES`` gates 8bit as well as 4bit - loader.py clears both - so
+    writing the wheel off here would silently downgrade a working LLM.int8 request.
+    The missing symbol raises where kernels/utils.py binds it, which is a crash no
+    flag can rescue, not something to trade 8bit for.
+    """
 
     class _MissingOne(_RealHandleLib):
         def __getattr__(self, name):
@@ -116,7 +121,7 @@ def test_a_missing_symbol_is_not_ready():
             return super().__getattr__(name)
 
     probe = _load_probe()
-    assert probe.native_kernels_ready(_fake_bnb(_MissingOne()), "cuda") is False
+    assert probe.native_kernels_ready(_fake_bnb(_MissingOne()), "cuda") is True
 
 
 def test_absent_bitsandbytes_is_not_ready():

--- a/tests/python/test_bitsandbytes_kernel_readiness.py
+++ b/tests/python/test_bitsandbytes_kernel_readiness.py
@@ -131,9 +131,9 @@ def test_device_type_gates_the_flags_on_the_kernels():
     assert "import bitsandbytes as _bnb_probe" in head
     assert 'find_spec("bitsandbytes")' not in head, "find_spec cannot see a broken wheel"
     assert "native_kernels_ready(_bnb_probe, DEVICE_TYPE)" in head
-    assert head.count("ALLOW_BITSANDBYTES = False") >= 2, (
-        "both the failed-import path and the dead-kernels path must clear the flag"
-    )
+    assert (
+        head.count("ALLOW_BITSANDBYTES = False") >= 2
+    ), "both the failed-import path and the dead-kernels path must clear the flag"
 
 
 def test_the_kernel_check_reads_the_submodule_not_the_parent_attribute():
@@ -141,9 +141,10 @@ def test_the_kernel_check_reads_the_submodule_not_the_parent_attribute():
     ``functional`` while the submodule stays in sys.modules, so the check has to go
     through ``import bitsandbytes.functional``, which reads sys.modules directly."""
     probe = _load_probe()
-    bnb = types.ModuleType("bitsandbytes")   # zombie: parent has no `functional`
+    bnb = types.ModuleType("bitsandbytes")  # zombie: parent has no `functional`
     bnb.__version__ = "0.50.0"
     import sys
+
     real = sys.modules.get("bitsandbytes.functional")
     if real is None:
         return  # bitsandbytes not importable here; the fallback has nothing to read

--- a/unsloth/bnb_availability.py
+++ b/unsloth/bnb_availability.py
@@ -18,10 +18,9 @@ From 0.46 a wheel whose native library never loaded still imports and hands back
 `throw_on_call` closure for every symbol, so attribute reads alone see a healthy wheel,
 `ALLOW_BITSANDBYTES` stays true and 4bit dies inside a kernel instead of falling back to
 16bit up front. A real handle is a ctypes function pointer and carries `restype`; a
-deferred failure is a plain Python function and does not. That is the whole test.
-
-Every probed handle has to be native, since the same verdict gates the module-scope binds
-in kernels/utils.py and one bad symbol there is the crash this exists to prevent.
+deferred failure is a plain Python function and does not. That is the whole test, applied
+to every probed handle: the same verdict gates the module-scope binds in kernels/utils.py,
+where one bad symbol is the crash this exists to prevent.
 
 Decides the capability flags only, never importability - a CPU-only install is exactly
 this shape and its Python side works. A leaf module: imports nothing from unsloth
@@ -62,12 +61,10 @@ def bitsandbytes_symbols(device_type):
 def check_native_kernels(bnb, device_type):
     """Raise unless every handle kernels/utils.py is about to bind is a real kernel.
 
-    All of them, not just one: this same verdict gates the module-scope binds, and a
-    symbol that resolves for the probe but not for the bind gives back the AttributeError
-    this exists to prevent. Partial export costs 8bit too, since `ALLOW_BITSANDBYTES`
-    gates both (loader.py clears each), but a wheel missing a symbol is a shape no flag
-    can make safe - refusing it beats crashing on it. Safe to repeat: ctypes caches each
-    handle on first lookup, so these are the ones bound later.
+    All of them: one that resolves here but not at the bind gives back the AttributeError
+    this prevents. Partial export costs 8bit too (`ALLOW_BITSANDBYTES` gates both), but a
+    wheel missing a symbol is a shape no flag makes safe. Safe to repeat - ctypes caches
+    each handle on first lookup, so these are the ones bound later.
     """
     if bnb is None:
         raise ImportError("Unsloth: `bitsandbytes` is not installed.")

--- a/unsloth/bnb_availability.py
+++ b/unsloth/bnb_availability.py
@@ -56,7 +56,13 @@ def bitsandbytes_symbols(device_type):
 
 
 def check_native_kernels(bnb, device_type):
-    """Raise unless every 4bit handle on `bnb` is a real native kernel.
+    """Raise when `bnb`'s native library is dead: no handle it offers is a real kernel.
+
+    Not "every handle resolves". A library that exports some of these and not others is
+    alive, and `ALLOW_BITSANDBYTES` gates 8bit as well as 4bit (loader.py clears both),
+    so writing it off there would silently downgrade a working LLM.int8 request. A
+    missing symbol is a different failure anyway - it raises where kernels/utils.py
+    binds it, which no flag can rescue.
 
     Safe to repeat: ctypes caches the function object on the first lookup and
     bitsandbytes memoizes its wrapper, so these are the handles bound later.
@@ -70,17 +76,25 @@ def check_native_kernels(bnb, device_type):
         # reads sys.modules directly where plain attribute access does not.
         import bitsandbytes.functional as functional
 
-    lib = functional.lib  # None on a 0.45.5 native-load failure
+    lib = functional.lib
+    if lib is None:
+        # 0.45.5, the floor in pyproject.toml, on a native-load failure.
+        raise AttributeError("Unsloth: `bitsandbytes.functional.lib` is None.")
     for symbol in bitsandbytes_symbols(device_type):
-        if not hasattr(getattr(lib, symbol), "restype"):
-            raise AttributeError(
-                f"Unsloth: `bitsandbytes.functional.lib.{symbol}` is not a native "
-                "handle - the bitsandbytes native library did not load."
-            )
+        try:
+            handle = getattr(lib, symbol)
+        except Exception:
+            continue  # not exported: a partial library, not a dead one
+        if hasattr(handle, "restype"):
+            return  # a ctypes function pointer, so the library really loaded
+    raise AttributeError(
+        "Unsloth: no `bitsandbytes.functional.lib` 4bit handle is a native function "
+        "pointer - the bitsandbytes native library did not load."
+    )
 
 
 def native_kernels_ready(bnb, device_type):
-    """Can 4bit actually run here? Gates the capability flags, never the import."""
+    """Is the bitsandbytes native library alive? Gates the flags, never the import."""
     try:
         check_native_kernels(bnb, device_type)
     except Exception:

--- a/unsloth/bnb_availability.py
+++ b/unsloth/bnb_availability.py
@@ -1,27 +1,18 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
 
-"""Can bitsandbytes actually run a 4bit kernel on this host?
+"""Can bitsandbytes actually run a 4bit kernel here? A successful import does not say.
 
-A successful `import bitsandbytes` does not answer that. From 0.46 onwards a wheel
-whose native library never loaded still imports, and `BNBNativeLibrary.__getattr__`
-hands back a plain `throw_on_call` closure for every symbol - a dead library is
-replaced wholesale by `ErrorHandlerMockBNBNativeLibrary`, which does the same. So
-the ctypes handles `kernels/utils.py` binds at import time all resolve, nothing
-raises, `ALLOW_BITSANDBYTES` stays true, the loader selects a 4bit checkpoint, and
-the run dies inside a kernel with "Method 'cdequantize_blockwise_fp32' is not
-available in CPU-only version" instead of falling back to 16bit up front.
+From 0.46 a wheel whose native library never loaded still imports and hands back a
+`throw_on_call` closure for every symbol, so attribute reads alone see a healthy wheel,
+`ALLOW_BITSANDBYTES` stays true and 4bit dies inside a kernel instead of falling back to
+16bit up front. A real handle is a ctypes function pointer and carries `restype`; a
+deferred failure is a plain Python function and does not. That is the whole test.
 
-A real handle is a ctypes function pointer and carries `restype`; a deferred failure
-is a Python function and does not. That is the whole test.
-
-Deliberately narrow. This decides the capability flags only - it never decides
-whether the module is importable, because these shapes import perfectly well and
-treating them as absent would disable a wheel whose Python side works. A CPU-only
-install is exactly that shape.
-
-A leaf module on purpose: it imports nothing from unsloth (device_type.py is
-imported very early and would be a cycle) and takes the device type as an argument.
+Decides the capability flags only, never importability - a CPU-only install is exactly
+this shape and its Python side works. A leaf module: imports nothing from unsloth
+(device_type.py imports it very early, so anything else is a cycle) and takes the
+device type as an argument.
 """
 
 __all__ = [
@@ -30,15 +21,14 @@ __all__ = [
     "native_kernels_ready",
 ]
 
-# The ctypes handles kernels/utils.py binds at module scope. Keep in step with the
-# `bnb.functional.lib.*` reads there - a test asserts the two match.
+# The ctypes handles kernels/utils.py binds at module scope; a test asserts they match.
 _C_SYMBOLS = (
     "cdequantize_blockwise_fp32",
     "cdequantize_blockwise_fp16_nf4",
     "cdequantize_blockwise_bf16_nf4",
 )
-# 4bit inference is a gemv on xpu and a naive gemm everywhere else, so probing the
-# xpu names on cuda would write off a perfectly good wheel.
+# 4bit inference is a gemv on xpu and a naive gemm elsewhere; probing the wrong pair
+# would write off a perfectly good wheel.
 _C_SYMBOLS_XPU = (
     "cgemv_4bit_inference_fp16",
     "cgemv_4bit_inference_bf16",
@@ -58,22 +48,17 @@ def bitsandbytes_symbols(device_type):
 def check_native_kernels(bnb, device_type):
     """Raise when `bnb`'s native library is dead: no handle it offers is a real kernel.
 
-    Not "every handle resolves". A library that exports some of these and not others is
-    alive, and `ALLOW_BITSANDBYTES` gates 8bit as well as 4bit (loader.py clears both),
-    so writing it off there would silently downgrade a working LLM.int8 request. A
-    missing symbol is a different failure anyway - it raises where kernels/utils.py
-    binds it, which no flag can rescue.
-
-    Safe to repeat: ctypes caches the function object on the first lookup and
-    bitsandbytes memoizes its wrapper, so these are the handles bound later.
+    Not "every handle resolves": a partially exporting library is alive, and
+    `ALLOW_BITSANDBYTES` gates 8bit as well as 4bit (loader.py clears both), so writing
+    it off would silently downgrade a working LLM.int8 request. Safe to repeat - ctypes
+    caches each handle on first lookup, so these are the ones bound later.
     """
     if bnb is None:
         raise ImportError("Unsloth: `bitsandbytes` is not installed.")
     functional = getattr(bnb, "functional", None)
     if functional is None:
-        # A bitsandbytes whose __init__ died part way through leaves the parent without
-        # the attribute while the submodule stays in sys.modules, and `import x.y as z`
-        # reads sys.modules directly where plain attribute access does not.
+        # A part-initialised bitsandbytes leaves the parent without the attribute while
+        # the submodule stays in sys.modules, which `import x.y as z` reads directly.
         import bitsandbytes.functional as functional
 
     lib = functional.lib

--- a/unsloth/bnb_availability.py
+++ b/unsloth/bnb_availability.py
@@ -1,5 +1,16 @@
-# SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Can bitsandbytes actually run a 4bit kernel here? A successful import does not say.
 
@@ -8,6 +19,9 @@ From 0.46 a wheel whose native library never loaded still imports and hands back
 `ALLOW_BITSANDBYTES` stays true and 4bit dies inside a kernel instead of falling back to
 16bit up front. A real handle is a ctypes function pointer and carries `restype`; a
 deferred failure is a plain Python function and does not. That is the whole test.
+
+Every probed handle has to be native, since the same verdict gates the module-scope binds
+in kernels/utils.py and one bad symbol there is the crash this exists to prevent.
 
 Decides the capability flags only, never importability - a CPU-only install is exactly
 this shape and its Python side works. A leaf module: imports nothing from unsloth
@@ -46,12 +60,14 @@ def bitsandbytes_symbols(device_type):
 
 
 def check_native_kernels(bnb, device_type):
-    """Raise when `bnb`'s native library is dead: no handle it offers is a real kernel.
+    """Raise unless every handle kernels/utils.py is about to bind is a real kernel.
 
-    Not "every handle resolves": a partially exporting library is alive, and
-    `ALLOW_BITSANDBYTES` gates 8bit as well as 4bit (loader.py clears both), so writing
-    it off would silently downgrade a working LLM.int8 request. Safe to repeat - ctypes
-    caches each handle on first lookup, so these are the ones bound later.
+    All of them, not just one: this same verdict gates the module-scope binds, and a
+    symbol that resolves for the probe but not for the bind gives back the AttributeError
+    this exists to prevent. Partial export costs 8bit too, since `ALLOW_BITSANDBYTES`
+    gates both (loader.py clears each), but a wheel missing a symbol is a shape no flag
+    can make safe - refusing it beats crashing on it. Safe to repeat: ctypes caches each
+    handle on first lookup, so these are the ones bound later.
     """
     if bnb is None:
         raise ImportError("Unsloth: `bitsandbytes` is not installed.")
@@ -66,16 +82,12 @@ def check_native_kernels(bnb, device_type):
         # 0.45.5, the floor in pyproject.toml, on a native-load failure.
         raise AttributeError("Unsloth: `bitsandbytes.functional.lib` is None.")
     for symbol in bitsandbytes_symbols(device_type):
-        try:
-            handle = getattr(lib, symbol)
-        except Exception:
-            continue  # not exported: a partial library, not a dead one
-        if hasattr(handle, "restype"):
-            return  # a ctypes function pointer, so the library really loaded
-    raise AttributeError(
-        "Unsloth: no `bitsandbytes.functional.lib` 4bit handle is a native function "
-        "pointer - the bitsandbytes native library did not load."
-    )
+        handle = getattr(lib, symbol)  # AttributeError here is itself a failed check
+        if not hasattr(handle, "restype"):
+            raise AttributeError(
+                f"Unsloth: `bitsandbytes.functional.lib.{symbol}` is not a native "
+                "function pointer - the bitsandbytes native library did not load."
+            )
 
 
 def native_kernels_ready(bnb, device_type):

--- a/unsloth/bnb_availability.py
+++ b/unsloth/bnb_availability.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+
+"""Can bitsandbytes actually run a 4bit kernel on this host?
+
+A successful `import bitsandbytes` does not answer that. From 0.46 onwards a wheel
+whose native library never loaded still imports, and `BNBNativeLibrary.__getattr__`
+hands back a plain `throw_on_call` closure for every symbol - a dead library is
+replaced wholesale by `ErrorHandlerMockBNBNativeLibrary`, which does the same. So
+the ctypes handles `kernels/utils.py` binds at import time all resolve, nothing
+raises, `ALLOW_BITSANDBYTES` stays true, the loader selects a 4bit checkpoint, and
+the run dies inside a kernel with "Method 'cdequantize_blockwise_fp32' is not
+available in CPU-only version" instead of falling back to 16bit up front.
+
+A real handle is a ctypes function pointer and carries `restype`; a deferred failure
+is a Python function and does not. That is the whole test.
+
+Deliberately narrow. This decides the capability flags only - it never decides
+whether the module is importable, because these shapes import perfectly well and
+treating them as absent would disable a wheel whose Python side works. A CPU-only
+install is exactly that shape.
+
+A leaf module on purpose: it imports nothing from unsloth (device_type.py is
+imported very early and would be a cycle) and takes the device type as an argument.
+"""
+
+__all__ = [
+    "bitsandbytes_symbols",
+    "check_native_kernels",
+    "native_kernels_ready",
+]
+
+# The ctypes handles kernels/utils.py binds at module scope. Keep in step with the
+# `bnb.functional.lib.*` reads there - a test asserts the two match.
+_C_SYMBOLS = (
+    "cdequantize_blockwise_fp32",
+    "cdequantize_blockwise_fp16_nf4",
+    "cdequantize_blockwise_bf16_nf4",
+)
+# 4bit inference is a gemv on xpu and a naive gemm everywhere else, so probing the
+# xpu names on cuda would write off a perfectly good wheel.
+_C_SYMBOLS_XPU = (
+    "cgemv_4bit_inference_fp16",
+    "cgemv_4bit_inference_bf16",
+)
+_C_SYMBOLS_GEMM = (
+    "cgemm_4bit_inference_naive_fp16",
+    "cgemm_4bit_inference_naive_bf16",
+)
+
+
+def bitsandbytes_symbols(device_type):
+    """Names kernels/utils.py reads off `bitsandbytes.functional.lib`."""
+    tail = _C_SYMBOLS_XPU if device_type == "xpu" else _C_SYMBOLS_GEMM
+    return _C_SYMBOLS + tail
+
+
+def check_native_kernels(bnb, device_type):
+    """Raise unless every 4bit handle on `bnb` is a real native kernel.
+
+    Safe to repeat: ctypes caches the function object on the first lookup and
+    bitsandbytes memoizes its wrapper, so these are the handles bound later.
+    """
+    if bnb is None:
+        raise ImportError("Unsloth: `bitsandbytes` is not installed.")
+    functional = getattr(bnb, "functional", None)
+    if functional is None:
+        # A bitsandbytes whose __init__ died part way through leaves the parent without
+        # the attribute while the submodule stays in sys.modules, and `import x.y as z`
+        # reads sys.modules directly where plain attribute access does not.
+        import bitsandbytes.functional as functional
+
+    lib = functional.lib  # None on a 0.45.5 native-load failure
+    for symbol in bitsandbytes_symbols(device_type):
+        if not hasattr(getattr(lib, symbol), "restype"):
+            raise AttributeError(
+                f"Unsloth: `bitsandbytes.functional.lib.{symbol}` is not a native "
+                "handle - the bitsandbytes native library did not load."
+            )
+
+
+def native_kernels_ready(bnb, device_type):
+    """Can 4bit actually run here? Gates the capability flags, never the import."""
+    try:
+        check_native_kernels(bnb, device_type)
+    except Exception:
+        return False
+    return True

--- a/unsloth/device_type.py
+++ b/unsloth/device_type.py
@@ -27,6 +27,7 @@ import functools
 import inspect
 import os
 from unsloth_zoo.utils import Version
+from .bnb_availability import native_kernels_ready
 
 
 def is_mlx_available():
@@ -118,16 +119,22 @@ ALLOW_PREQUANTIZED_MODELS: bool = True
 # HSA_STATUS_ERROR_EXCEPTION checks - sometimes AMD fails for BnB
 ALLOW_BITSANDBYTES: bool = True
 # Unusable bitsandbytes on any backend, not just hip: clear the flags the loader
-# reads before it selects a 4bit checkpoint. Same guarded import the fallbacks in
-# _gpu_init.py and kernels/utils.py use rather than a find_spec probe, so an
-# installed-but-broken wheel (missing .so, wrong ROCm/CUDA build) is treated as
-# unavailable by all three, not only by the ones that import it.
+# reads before it selects a 4bit checkpoint. A guarded import rather than a
+# find_spec probe, so an installed-but-broken wheel counts as unavailable - and
+# importable is not the same as usable either. From bitsandbytes 0.46 a wheel whose
+# native library never loaded still imports and resolves every ctypes handle to a
+# closure that raises only when called, so without the kernel check the flags stay
+# true and 4bit dies inside a kernel instead of falling back to 16bit here.
 try:
     import bitsandbytes as _bnb_probe
-    del _bnb_probe
 except Exception:
     ALLOW_PREQUANTIZED_MODELS = False
     ALLOW_BITSANDBYTES = False
+else:
+    if not native_kernels_ready(_bnb_probe, DEVICE_TYPE):
+        ALLOW_PREQUANTIZED_MODELS = False
+        ALLOW_BITSANDBYTES = False
+    del _bnb_probe
 # gfx906 (MI50 / Radeon VII / Vega 20): Dynamo/Inductor codegen is broken on this
 # legacy GCN arch (ROCm dropped it after 6.3) - compiled graphs crash or miscompile
 # while the eager path trains fine. Default compile off; setdefault so a user

--- a/unsloth/device_type.py
+++ b/unsloth/device_type.py
@@ -118,13 +118,10 @@ DEVICE_COUNT: int = get_device_count()
 ALLOW_PREQUANTIZED_MODELS: bool = True
 # HSA_STATUS_ERROR_EXCEPTION checks - sometimes AMD fails for BnB
 ALLOW_BITSANDBYTES: bool = True
-# Unusable bitsandbytes on any backend, not just hip: clear the flags the loader
-# reads before it selects a 4bit checkpoint. A guarded import rather than a
-# find_spec probe, so an installed-but-broken wheel counts as unavailable - and
-# importable is not the same as usable either. From bitsandbytes 0.46 a wheel whose
-# native library never loaded still imports and resolves every ctypes handle to a
-# closure that raises only when called, so without the kernel check the flags stay
-# true and 4bit dies inside a kernel instead of falling back to 16bit here.
+# Unusable bitsandbytes on any backend, not just hip: clear the flags the loader reads
+# before it picks a 4bit checkpoint. A guarded import, not find_spec, since importable
+# is not usable - from 0.46 a dead native library still resolves every ctypes handle to
+# a closure that raises only when called, so 4bit would die mid-run, not fall back here.
 try:
     import bitsandbytes as _bnb_probe
 except Exception:

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -29,6 +29,7 @@ from ..device_type import (
     DEVICE_COUNT,
     ALLOW_PREQUANTIZED_MODELS,
 )
+from ..bnb_availability import native_kernels_ready
 from .fp8 import weight_dequant, fp8_linear
 import functools
 
@@ -252,7 +253,12 @@ else:
 # Bitsandbytes operations
 ctypes_c_int = ctypes.c_int
 ctypes_c_int32 = ctypes.c_int32
-if bnb is None:
+# Same verdict device_type.py used to clear ALLOW_BITSANDBYTES, applied to the binds
+# themselves. An importable bitsandbytes is not a working one: 0.45.5 leaves
+# `functional.lib = None` when the native library fails to load, so these lookups
+# raise here and `import unsloth` dies rather than degrading to 16bit - the fallback
+# the cleared flag exists to reach.
+if bnb is None or not native_kernels_ready(bnb, DEVICE_TYPE):
     cdequantize_blockwise_fp32 = _bnb_required
     cdequantize_blockwise_fp16_nf4 = _bnb_required
     cdequantize_blockwise_bf16_nf4 = _bnb_required

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -254,10 +254,8 @@ else:
 ctypes_c_int = ctypes.c_int
 ctypes_c_int32 = ctypes.c_int32
 # Same verdict device_type.py used to clear ALLOW_BITSANDBYTES, applied to the binds
-# themselves. An importable bitsandbytes is not a working one: 0.45.5 leaves
-# `functional.lib = None` when the native library fails to load, so these lookups
-# raise here and `import unsloth` dies rather than degrading to 16bit - the fallback
-# the cleared flag exists to reach.
+# themselves. 0.45.5 leaves `functional.lib = None` when the native library fails to
+# load, so these lookups would kill `import unsloth` instead of degrading to 16bit.
 if bnb is None or not native_kernels_ready(bnb, DEVICE_TYPE):
     cdequantize_blockwise_fp32 = _bnb_required
     cdequantize_blockwise_fp16_nf4 = _bnb_required


### PR DESCRIPTION
Rewritten and rebased on `main`. The original scope is gone: #7582 fixed the CI failure and #7580 covers the runtime crash, so what is left here is one narrow behaviour change that neither of those makes.

## Problem

From bitsandbytes 0.46 a wheel whose native library never loaded still imports and resolves every ctypes handle. `BNBNativeLibrary.__getattr__` returns a `throw_on_call` closure, and a dead library is replaced wholesale by `ErrorHandlerMockBNBNativeLibrary`, which does the same for every name. So all five handles `kernels/utils.py` binds at module scope resolve, nothing raises, `device_type.py`'s guarded import sees a healthy wheel, `ALLOW_BITSANDBYTES` stays true, `loader.py` forwards the default `load_in_4bit=True`, and the run dies inside a kernel:

```
RuntimeError: Method 'cdequantize_blockwise_fp32' not available in CPU-only version
```

instead of degrading to 16bit up front, which is what the guard exists to do. The realistic host is a mismatched CUDA or ROCm wheel.

## Change

Probe the handles the kernels actually bind, and clear `ALLOW_BITSANDBYTES` / `ALLOW_PREQUANTIZED_MODELS` when they are not native. A real handle is a ctypes function pointer and carries `restype`; a deferred failure is a Python function and does not.

`unsloth/bnb_availability.py` is a leaf module - it imports nothing from unsloth, so `device_type.py` can use it despite being imported very early - and takes the device type as an argument, because 4bit inference binds the gemv pair on xpu and the naive gemm pair everywhere else. Probing the wrong pair would write off a good wheel.

## Deliberately narrow

This decides the capability flags only, never whether the module is importable. `bnb` stays bound and `get_ptr` keeps pointing at `bitsandbytes.functional.get_ptr`, because these shapes import perfectly well and treating them as absent would disable a wheel whose Python side works. A CPU-only install is exactly that shape.

It also touches neither `kernels/utils.py` nor `_gpu_init.py`, so it does not overlap #7580 and the two can land in either order.

## Verification

CPU-only, matching the repo runners (`torch 2.10.0+cpu`, bitsandbytes 0.50.0, no GPU) - the flags go false, the module stays usable:

```
ALLOW_BITSANDBYTES : False | PREQUANT: False
get_ptr is real    : True
```

Real B200, nothing regressed:

```
ALLOW_BITSANDBYTES : True | PREQUANT: True
get_ptr is real    : True
Linear4bit modules : 109
losses             : [1.2996, 1.6039, ..., 1.3131, 1.1424]   10/10 steps
generation         : ### Response: Earth.
peak reserved GB   : 1.521
```

Full CPU suite in that environment, this branch against `main`, same harness:

```
branch : 24 failed, 3103 passed
main   : 24 failed, 3095 passed
```

Identical failure count - those 24 are environment gaps present on both - and the branch passes the 8 new tests. So clearing the flag on a CPU-only host breaks nothing in the suite.

`tests/python/test_bitsandbytes_kernel_readiness.py` covers the shapes: deferred-failure closure, real ctypes handle, `lib is None` (0.45.5), a lib missing one symbol, absent bitsandbytes, the device split, and that the probe's symbol list still matches the module-scope binds in `kernels/utils.py`. 19 passed together with the existing bitsandbytes tests.
