### PR TITLE
Fix bitsandbytes zombie module breaking test collection on CPU runners

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,7 +123,19 @@ def _install_device_type_stub(name: str) -> None:
     sys.modules[name] = stub
 
 
+def _preimport_bitsandbytes() -> None:
+    """Import bitsandbytes on the real CPU path, before anything mocks
+    torch.cuda.is_available(). Under the mock its __init__ enters the CUDA branch
+    on CPU-only torch and raises, leaving a half-imported package in sys.modules
+    that no later import can repair."""
+    try:
+        import bitsandbytes  # noqa: F401
+    except Exception:
+        pass
+
+
 if not _has_real_accelerator():
+    _preimport_bitsandbytes()
     if not _preload_device_type("unsloth_zoo", prereqs = ("utils",)):
         _install_device_type_stub("unsloth_zoo.device_type")
     if not _preload_device_type("unsloth"):

--- a/unsloth/_gpu_init.py
+++ b/unsloth/_gpu_init.py
@@ -303,13 +303,18 @@ if DEVICE_TYPE == "cuda":
     # Try loading bitsandbytes and triton
     try:
         import bitsandbytes as bnb
+        # Bind the submodule by name: a half-imported bitsandbytes leaves the parent
+        # without a `functional` attribute, which would otherwise be misreported below
+        # as a CUDA linking failure. See unsloth/kernels/utils.py.
+        import bitsandbytes.functional as bnb_functional
     except:
         print(
             "Unsloth: `bitsandbytes` is not installed - 4bit QLoRA unallowed, but 16bit and full finetuning works!"
         )
         bnb = None
+        bnb_functional = None
     try:
-        cdequantize_blockwise_fp32 = bnb.functional.lib.cdequantize_blockwise_fp32
+        cdequantize_blockwise_fp32 = bnb_functional.lib.cdequantize_blockwise_fp32
         libcuda_dirs()
     except:
         if hasattr(os, "geteuid") and os.geteuid() == 0:
@@ -351,7 +356,7 @@ if DEVICE_TYPE == "cuda":
                         pass
                 else:
                     from triton.common.build import libcuda_dirs
-                cdequantize_blockwise_fp32 = bnb.functional.lib.cdequantize_blockwise_fp32
+                cdequantize_blockwise_fp32 = bnb_functional.lib.cdequantize_blockwise_fp32
                 libcuda_dirs()
             except:
                 warnings.warn(

--- a/unsloth/_gpu_init.py
+++ b/unsloth/_gpu_init.py
@@ -303,6 +303,7 @@ if DEVICE_TYPE == "cuda":
     # Try loading bitsandbytes and triton
     try:
         import bitsandbytes as bnb
+
         # Bind the submodule by name: a half-imported bitsandbytes leaves the parent
         # without a `functional` attribute, which would otherwise be misreported below
         # as a CUDA linking failure. See unsloth/kernels/utils.py.

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -135,6 +135,7 @@ def calculate_settings(
 HAS_CUDA_STREAM = False
 try:
     import bitsandbytes as bnb
+
     # If an earlier `import bitsandbytes` died inside __init__, CPython evicts only
     # the parent from sys.modules and keeps its submodules, so this retry re-executes
     # __init__ without rebinding `bnb.functional`. `import x.y as z` reads sys.modules

--- a/unsloth/kernels/utils.py
+++ b/unsloth/kernels/utils.py
@@ -135,11 +135,17 @@ def calculate_settings(
 HAS_CUDA_STREAM = False
 try:
     import bitsandbytes as bnb
+    # If an earlier `import bitsandbytes` died inside __init__, CPython evicts only
+    # the parent from sys.modules and keeps its submodules, so this retry re-executes
+    # __init__ without rebinding `bnb.functional`. `import x.y as z` reads sys.modules
+    # directly and survives that, plain attribute access does not.
+    import bitsandbytes.functional as bnb_functional
 except Exception:
     # device_type.py already degrades to 16bit/full finetuning when bnb is missing
     # (e.g. gfx906, whose generic wheel has no kernels). Keep the import working and
     # fail only if a 4bit path is actually entered.
     bnb = None
+    bnb_functional = None
 
 
 def _bnb_required(*args, **kwargs):
@@ -152,7 +158,7 @@ def _bnb_required(*args, **kwargs):
 if bnb is not None:
     # https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1330/files
     HAS_CUDA_STREAM = Version(bnb.__version__) > Version("0.43.3")
-    get_ptr = bnb.functional.get_ptr
+    get_ptr = bnb_functional.get_ptr
 else:
     get_ptr = _bnb_required
 
@@ -259,18 +265,18 @@ if bnb is None:
     cgemm_4bit_inference_naive_fp16 = _bnb_required
     cgemm_4bit_inference_naive_bf16 = _bnb_required
 else:
-    cdequantize_blockwise_fp32 = bnb.functional.lib.cdequantize_blockwise_fp32
-    cdequantize_blockwise_fp16_nf4 = bnb.functional.lib.cdequantize_blockwise_fp16_nf4
-    cdequantize_blockwise_bf16_nf4 = bnb.functional.lib.cdequantize_blockwise_bf16_nf4
+    cdequantize_blockwise_fp32 = bnb_functional.lib.cdequantize_blockwise_fp32
+    cdequantize_blockwise_fp16_nf4 = bnb_functional.lib.cdequantize_blockwise_fp16_nf4
+    cdequantize_blockwise_bf16_nf4 = bnb_functional.lib.cdequantize_blockwise_bf16_nf4
 
     if DEVICE_TYPE == "xpu":
         # https://github.com/bitsandbytes-foundation/bitsandbytes/blob/c3b8de268fdb55a88f92feada23fc811a1e6877a/bitsandbytes/backends/xpu/ops.py#L115
         # for xpu, inference gemv using above link
-        cgemm_4bit_inference_naive_fp16 = bnb.functional.lib.cgemv_4bit_inference_fp16
-        cgemm_4bit_inference_naive_bf16 = bnb.functional.lib.cgemv_4bit_inference_bf16
+        cgemm_4bit_inference_naive_fp16 = bnb_functional.lib.cgemv_4bit_inference_fp16
+        cgemm_4bit_inference_naive_bf16 = bnb_functional.lib.cgemv_4bit_inference_bf16
     else:
-        cgemm_4bit_inference_naive_fp16 = bnb.functional.lib.cgemm_4bit_inference_naive_fp16
-        cgemm_4bit_inference_naive_bf16 = bnb.functional.lib.cgemm_4bit_inference_naive_bf16
+        cgemm_4bit_inference_naive_fp16 = bnb_functional.lib.cgemm_4bit_inference_naive_fp16
+        cgemm_4bit_inference_naive_bf16 = bnb_functional.lib.cgemm_4bit_inference_naive_bf16
 
 
 torch_device_stream = (


### PR DESCRIPTION
Scope narrowed after #7582 landed on main.

#7582 added the `tests/conftest.py` pre-import, which stops the test harness creating a half-imported bitsandbytes. That half of this PR is now redundant and has been dropped; the branch takes main's version verbatim.

What remains is the runtime half, which main does not have. `unsloth/kernels/utils.py:155` still reads `get_ptr = bnb.functional.get_ptr`, and that fails whenever an earlier `import bitsandbytes` died inside `__init__` from any cause, not just the test spoof. The realistic user path is a broken or mismatched CUDA wheel: `unsloth/device_type.py:127` imports bitsandbytes inside a bare `except Exception: pass`, so the failure is swallowed and the damage stays invisible until a later import trips over it.

CPython evicts only the parent package on that failure and keeps the submodules it already loaded, so a retry re-executes `__init__` against a fresh module object whose `from .x import y` lines are all served from cache, and never rebinds `functional` as an attribute. Reproduced against torch 2.10.0+cpu and bitsandbytes 0.50.0:

```
first import raised: AttributeError
bitsandbytes in sys.modules: False
bitsandbytes.functional cached: True
plain attribute access works: False
import-as works: True
```

`import bitsandbytes.functional as bnb_functional` reads `sys.modules` directly and survives this; plain attribute access does not. A bare `import bitsandbytes.functional` does not work either, because `_gcd_import` short-circuits on the cache hit without setting the parent attribute.

Also included: the same rename at `unsloth/_gpu_init.py:312` and `:354`, which read `bnb.functional.lib...` inside bare try/except blocks. With a half-imported bitsandbytes they fall through silently and emit a misleading `UserWarning` about CUDA not being linked properly, advising an ldconfig command that has nothing to do with the real cause. That warning was observed in the original reproduction.
