### PR TITLE
pip: raise the AMD installer bitsandbytes fallback floors to 0.50.0

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -263,6 +263,7 @@ run_install_cmd_retry() {
 # pre-release URL is unreachable: 0.50.0 (2026-07-24) is the first PyPI release
 # carrying that fix, and its manylinux x86_64 wheel ships the same
 # libbitsandbytes_rocm{64,70,71,714,72}.so set as the pre-release.
+_BNB_ROCM_PYPI_FALLBACK="bitsandbytes>=0.50.0"
 _install_bnb_rocm() {
     _label="$1"
     _venv_py="$2"
@@ -304,10 +305,10 @@ _install_bnb_rocm() {
         fi
         rm -f "$_bnb_log"
         step "warning" "$_label (pre-release) failed (exit code $_bnb_rc)" "$C_WARN" >&2
-        substep "[WARN] bnb pre-release install failed; falling back to PyPI (4-bit decode broken on ROCm)" "$C_WARN"
+        substep "[WARN] bnb pre-release install failed; falling back to PyPI $_BNB_ROCM_PYPI_FALLBACK, which carries the ROCm 4-bit fix" "$C_WARN"
     fi
     run_install_cmd "$_label (pypi fallback)" "$_venv_py" -m pip install \
-        --force-reinstall --no-cache-dir --no-deps "bitsandbytes>=0.50.0"
+        --force-reinstall --no-cache-dir --no-deps "$_BNB_ROCM_PYPI_FALLBACK"
 }
 
 if [ "$_next_is_package" = true ]; then

--- a/install.sh
+++ b/install.sh
@@ -257,12 +257,9 @@ run_install_cmd_retry() {
     done
 }
 
-# Install bitsandbytes on AMD ROCm hosts. Uses the continuous-release_main
-# wheel for the ROCm 4-bit GEMV fix (bnb PR #1887, post-0.49.2); bnb <= 0.49.2
-# NaNs at decode shape on every AMD GPU. Falls back to PyPI >=0.50.0 if the
-# pre-release URL is unreachable: 0.50.0 (2026-07-24) is the first PyPI release
-# carrying that fix, and its manylinux x86_64 wheel ships the same
-# libbitsandbytes_rocm{64,70,71,714,72}.so set as the pre-release.
+# Install bitsandbytes on AMD ROCm hosts. bnb <= 0.49.2 NaNs at 4-bit decode
+# shape on every AMD GPU; the fix (bnb #1887) is in the continuous-release_main
+# wheel used below and first ships on PyPI in 0.50.0, hence the fallback floor.
 _BNB_ROCM_PYPI_FALLBACK="bitsandbytes>=0.50.0"
 _install_bnb_rocm() {
     _label="$1"
@@ -278,10 +275,8 @@ _install_bnb_rocm() {
             _bnb_whl_url=""
             ;;
     esac
-    # uv rejects the continuous-release_main bitsandbytes wheel because the
-    # filename version (1.33.7rc0) does not match the embedded metadata version
-    # (0.50.x.dev0, whatever main is at). pip accepts the mismatch, so bootstrap
-    # pip and use it.
+    # uv rejects the pre-release wheel: its filename version (1.33.7rc0) does not
+    # match its metadata version (0.50.x.dev0). pip accepts it, so bootstrap pip.
     if ! "$_venv_py" -m pip --version >/dev/null 2>&1; then
         if ! run_maybe_quiet "$_venv_py" -m ensurepip --upgrade; then
             run_maybe_quiet uv pip install --python "$_venv_py" pip || \

--- a/install.sh
+++ b/install.sh
@@ -259,8 +259,10 @@ run_install_cmd_retry() {
 
 # Install bitsandbytes on AMD ROCm hosts. Uses the continuous-release_main
 # wheel for the ROCm 4-bit GEMV fix (bnb PR #1887, post-0.49.2); bnb <= 0.49.2
-# NaNs at decode shape on every AMD GPU. Falls back to PyPI >=0.49.1 if the
-# pre-release URL is unreachable. Drop the pin once bnb 0.50+ ships on PyPI.
+# NaNs at decode shape on every AMD GPU. Falls back to PyPI >=0.50.0 if the
+# pre-release URL is unreachable: 0.50.0 (2026-07-24) is the first PyPI release
+# carrying that fix, and its manylinux x86_64 wheel ships the same
+# libbitsandbytes_rocm{64,70,71,714,72}.so set as the pre-release.
 _install_bnb_rocm() {
     _label="$1"
     _venv_py="$2"
@@ -277,7 +279,8 @@ _install_bnb_rocm() {
     esac
     # uv rejects the continuous-release_main bitsandbytes wheel because the
     # filename version (1.33.7rc0) does not match the embedded metadata version
-    # (0.50.0.dev0). pip accepts the mismatch, so bootstrap pip and use it.
+    # (0.50.x.dev0, whatever main is at). pip accepts the mismatch, so bootstrap
+    # pip and use it.
     if ! "$_venv_py" -m pip --version >/dev/null 2>&1; then
         if ! run_maybe_quiet "$_venv_py" -m ensurepip --upgrade; then
             run_maybe_quiet uv pip install --python "$_venv_py" pip || \
@@ -304,7 +307,7 @@ _install_bnb_rocm() {
         substep "[WARN] bnb pre-release install failed; falling back to PyPI (4-bit decode broken on ROCm)" "$C_WARN"
     fi
     run_install_cmd "$_label (pypi fallback)" "$_venv_py" -m pip install \
-        --force-reinstall --no-cache-dir --no-deps "bitsandbytes>=0.49.1"
+        --force-reinstall --no-cache-dir --no-deps "bitsandbytes>=0.50.0"
 }
 
 if [ "$_next_is_package" = true ]; then

--- a/install.sh
+++ b/install.sh
@@ -261,6 +261,20 @@ run_install_cmd_retry() {
 # shape on every AMD GPU; the fix (bnb #1887) is in the continuous-release_main
 # wheel used below and first ships on PyPI in 0.50.0, hence the fallback floor.
 _BNB_ROCM_PYPI_FALLBACK="bitsandbytes>=0.50.0"
+# bitsandbytes ships no ROCm binary in its aarch64 wheel at any version: the PyPI
+# 0.50.0 and continuous-release_main aarch64 wheels both carry only
+# libbitsandbytes_cpu.so plus CUDA variants. So neither install path below gives
+# aarch64 a 4-bit backend, and the messages must not claim one. Cf. gfx906.
+_bnb_rocm_arch_has_binary() {
+    case "$_ARCH" in
+        aarch64|arm64) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+_warn_bnb_no_rocm_binary() {
+    _bnb_rocm_arch_has_binary && return 0
+    substep "[WARN] aarch64: bitsandbytes ships no ROCm kernels on this arch; 4-bit QLoRA needs a source build -- https://docs.unsloth.ai/get-started/install-and-update/amd" "$C_WARN"
+}
 _install_bnb_rocm() {
     _label="$1"
     _venv_py="$2"
@@ -292,6 +306,7 @@ _install_bnb_rocm() {
             --retries 8 --timeout 90 \
             "$_bnb_whl_url" >"$_bnb_log" 2>&1; then
             rm -f "$_bnb_log"
+            _warn_bnb_no_rocm_binary
             return 0
         fi
         _bnb_rc=$?
@@ -300,10 +315,17 @@ _install_bnb_rocm() {
         fi
         rm -f "$_bnb_log"
         step "warning" "$_label (pre-release) failed (exit code $_bnb_rc)" "$C_WARN" >&2
-        substep "[WARN] bnb pre-release install failed; falling back to PyPI $_BNB_ROCM_PYPI_FALLBACK, which carries the ROCm 4-bit fix" "$C_WARN"
+        if _bnb_rocm_arch_has_binary; then
+            substep "[WARN] bnb pre-release install failed; falling back to PyPI $_BNB_ROCM_PYPI_FALLBACK, which carries the ROCm 4-bit fix" "$C_WARN"
+        else
+            substep "[WARN] bnb pre-release install failed; falling back to PyPI $_BNB_ROCM_PYPI_FALLBACK" "$C_WARN"
+        fi
     fi
     run_install_cmd "$_label (pypi fallback)" "$_venv_py" -m pip install \
         --force-reinstall --no-cache-dir --no-deps "$_BNB_ROCM_PYPI_FALLBACK"
+    _bnb_pypi_rc=$?
+    _warn_bnb_no_rocm_binary
+    return $_bnb_pypi_rc
 }
 
 if [ "$_next_is_package" = true ]; then

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -389,9 +389,7 @@ _GFX_TO_AMD_INDEX_ARCH: dict[str, str] = {
 }
 
 # bitsandbytes continuous-release_main wheels with the ROCm 4-bit GEMV fix
-# (bnb PR #1887, post-0.49.2). bnb <= 0.49.2 NaNs at decode shape on every
-# AMD GPU. PyPI 0.50.0 (2026-07-24) is the first release carrying that fix, so
-# _BNB_ROCM_PYPI_FALLBACK below is a safe floor when these URLs are unreachable.
+# (bnb #1887). bnb <= 0.49.2 NaNs at 4-bit decode shape on every AMD GPU.
 _BNB_ROCM_PRERELEASE_URLS: dict[str, str] = {
     "x86_64": (
         "https://github.com/bitsandbytes-foundation/bitsandbytes/releases/"
@@ -412,7 +410,8 @@ _BNB_ROCM_PRERELEASE_URLS: dict[str, str] = {
         "bitsandbytes-1.33.7.preview-py3-none-win_amd64.whl"
     ),
 }
-# Keep in step with the install.sh fallback (and the amd extra, once it lands here).
+# First PyPI release carrying bnb #1887. Keep in step with the install.sh
+# fallback (and the amd extra, once it lands here).
 _BNB_ROCM_PYPI_FALLBACK = "bitsandbytes>=0.50.0"
 
 

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -2032,9 +2032,7 @@ def _ensure_rocm_torch() -> None:
             )
             if not _bnb_installed:
                 _fallback_note = (
-                    ", which carries the ROCm 4-bit fix"
-                    if _bnb_rocm_arch_has_binary()
-                    else ""
+                    ", which carries the ROCm 4-bit fix" if _bnb_rocm_arch_has_binary() else ""
                 )
                 print(
                     _red(

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -424,6 +424,16 @@ def _bnb_rocm_prerelease_url() -> str | None:
     return _BNB_ROCM_PRERELEASE_URLS.get(arch)
 
 
+def _bnb_rocm_arch_has_binary() -> bool:
+    """False on aarch64: bitsandbytes ships no ROCm kernels there at any version.
+    The PyPI 0.50.0 and continuous-release_main aarch64 wheels both carry only
+    libbitsandbytes_cpu.so plus CUDA variants, so neither install path gives
+    aarch64 a 4-bit backend and neither message may claim one.
+    """
+    arch = platform.machine().lower()
+    return {"amd64": "x86_64", "arm64": "aarch64"}.get(arch, arch) != "aarch64"
+
+
 def _amd_smi_env() -> dict[str, str] | None:
     """On Windows, env with __COMPAT_LAYER=RunAsInvoker; None elsewhere.
     NB: RunAsInvoker doesn't stop amd-smi's runtime elevation (its manifest is
@@ -2021,10 +2031,15 @@ def _ensure_rocm_torch() -> None:
                 force_pip = True,
             )
             if not _bnb_installed:
+                _fallback_note = (
+                    ", which carries the ROCm 4-bit fix"
+                    if _bnb_rocm_arch_has_binary()
+                    else ""
+                )
                 print(
                     _red(
                         "   bnb pre-release install failed; falling back to PyPI "
-                        f"{_BNB_ROCM_PYPI_FALLBACK}, which carries the ROCm 4-bit fix"
+                        f"{_BNB_ROCM_PYPI_FALLBACK}{_fallback_note}"
                     )
                 )
         if not _bnb_installed:
@@ -2035,6 +2050,14 @@ def _ensure_rocm_torch() -> None:
                 "--no-deps",
                 _BNB_ROCM_PYPI_FALLBACK,
                 constrain = False,
+            )
+        if not _bnb_rocm_arch_has_binary():
+            print(
+                _red(
+                    "   aarch64: bitsandbytes ships no ROCm kernels on this arch; "
+                    "4-bit QLoRA needs a source build -- "
+                    "https://docs.unsloth.ai/get-started/install-and-update/amd"
+                )
             )
 
 

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -390,7 +390,8 @@ _GFX_TO_AMD_INDEX_ARCH: dict[str, str] = {
 
 # bitsandbytes continuous-release_main wheels with the ROCm 4-bit GEMV fix
 # (bnb PR #1887, post-0.49.2). bnb <= 0.49.2 NaNs at decode shape on every
-# AMD GPU. Drop the pin once bnb 0.50+ ships on PyPI.
+# AMD GPU. PyPI 0.50.0 (2026-07-24) is the first release carrying that fix, so
+# _BNB_ROCM_PYPI_FALLBACK below is a safe floor when these URLs are unreachable.
 _BNB_ROCM_PRERELEASE_URLS: dict[str, str] = {
     "x86_64": (
         "https://github.com/bitsandbytes-foundation/bitsandbytes/releases/"
@@ -411,7 +412,8 @@ _BNB_ROCM_PRERELEASE_URLS: dict[str, str] = {
         "bitsandbytes-1.33.7.preview-py3-none-win_amd64.whl"
     ),
 }
-_BNB_ROCM_PYPI_FALLBACK = "bitsandbytes>=0.49.1"
+# Keep in step with the install.sh fallback (and the amd extra, once it lands here).
+_BNB_ROCM_PYPI_FALLBACK = "bitsandbytes>=0.50.0"
 
 
 def _bnb_rocm_prerelease_url() -> str | None:
@@ -1182,7 +1184,7 @@ def _install_bnb_windows_rocm() -> bool:
 
     The continuous-release wheel is intentionally mismatched: the filename
     encodes 1.33.7.preview (parsed as 1.33.7rc0 by PEP 440) while the wheel
-    metadata reports 0.50.0.dev0. uv rejects this filename/metadata mismatch,
+    metadata reports 0.50.x.dev0. uv rejects this filename/metadata mismatch,
     and bypassing it with UV_SKIP_WHEEL_FILENAME_CHECK still leaves uv mangling
     the bitsandbytes install. Per the AMD install guide
     (https://unsloth.ai/docs/get-started/install/amd/amd-hackathon) the wheel

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -2025,7 +2025,7 @@ def _ensure_rocm_torch() -> None:
                 print(
                     _red(
                         "   bnb pre-release install failed; falling back to PyPI "
-                        "(4-bit decode will be broken on ROCm)"
+                        f"{_BNB_ROCM_PYPI_FALLBACK}, which carries the ROCm 4-bit fix"
                     )
                 )
         if not _bnb_installed:

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -1189,7 +1189,7 @@ _rocm_windows_torch_installed: bool = False
 
 
 def _install_bnb_windows_rocm() -> bool:
-    """Install the AMD Windows BNB prerelease wheel. Returns True on success.
+    """Install AMD Windows BNB, pre-release wheel first. Returns True on success.
 
     The continuous-release wheel is intentionally mismatched: the filename
     encodes 1.33.7.preview (parsed as 1.33.7rc0 by PEP 440) while the wheel
@@ -1199,19 +1199,39 @@ def _install_bnb_windows_rocm() -> bool:
     (https://unsloth.ai/docs/get-started/install/amd/amd-hackathon) the wheel
     must be installed with plain pip, not uv, so we force pip (force_pip=True);
     plain pip performs no wheel filename/metadata check.
+
+    When that URL is blocked, fall back to PyPI. Its win_amd64 wheel ships
+    libbitsandbytes_rocm{714,72}.dll from 0.50.0 on, so the fallback is a real
+    ROCm build; before 0.50.0 it was CUDA-only, which is why there was none.
     """
     _bnb_win_url = _BNB_ROCM_PRERELEASE_URLS.get("win_amd64")
-    if _bnb_win_url is None:
-        return False
-    _ok = pip_install_try(
-        "bitsandbytes (AMD Windows, pre-release main)",
-        "--force-reinstall",
-        "--no-cache-dir",
-        "--no-deps",
-        _bnb_win_url,
-        constrain = False,
-        force_pip = True,
-    )
+    _ok = False
+    if _bnb_win_url is not None:
+        _ok = pip_install_try(
+            "bitsandbytes (AMD Windows, pre-release main)",
+            "--force-reinstall",
+            "--no-cache-dir",
+            "--no-deps",
+            _bnb_win_url,
+            constrain = False,
+            force_pip = True,
+        )
+        if not _ok:
+            print(
+                _red(
+                    "   bnb pre-release install failed; falling back to PyPI "
+                    f"{_BNB_ROCM_PYPI_FALLBACK}, which carries the ROCm 4-bit fix"
+                )
+            )
+    if not _ok:
+        _ok = pip_install_try(
+            "bitsandbytes (AMD Windows)",
+            "--force-reinstall",
+            "--no-cache-dir",
+            "--no-deps",
+            _BNB_ROCM_PYPI_FALLBACK,
+            constrain = False,
+        )
     if not _ok:
         return False
     # Detect the actual ROCm DLL suffix in the wheel and set BNB_ROCM_VERSION so bnb
@@ -1701,8 +1721,8 @@ def _ensure_rocm_torch() -> None:
             pass
         if _torch_ok:
             _rocm_windows_torch_installed = True
-            # ROCm torch is already installed, but the AMD Windows BNB wheel is still
-            # needed (the PyPI bitsandbytes ships only CUDA DLLs, fails on ROCm).
+            # ROCm torch is already installed, but bnb still needs the ROCm build
+            # (pre-release wheel, else PyPI >=0.50.0).
             _install_bnb_windows_rocm()
             return
         # torch was wiped between runs; fall through to the full install path
@@ -1780,12 +1800,12 @@ def _ensure_rocm_torch() -> None:
         # separate dependency -- a BNB install failure must NOT roll back the
         # torch ROCm install.
         _rocm_windows_torch_installed = True
-        # Always install AMD Windows bitsandbytes -- the PyPI wheel ships only
-        # CUDA DLLs and fails on ROCm. Install even when torch was already a
-        # ROCm build so `studio update` repairs a broken bnb.
+        # Always install AMD Windows bitsandbytes, even when torch was already a
+        # ROCm build, so `studio update` repairs a broken bnb.
         if not _install_bnb_windows_rocm():
             print(
-                "   Warning: AMD Windows bitsandbytes install failed; "
+                "   Warning: AMD Windows bitsandbytes install failed "
+                "(pre-release and PyPI); "
                 "ROCm torch is installed but bitsandbytes may need manual install"
             )
         return

--- a/tests/python/test_cross_platform_parity.py
+++ b/tests/python/test_cross_platform_parity.py
@@ -833,7 +833,7 @@ class TestAmdBnbFloorParity:
     def test_install_sh_pypi_fallback_floor(self):
         text = INSTALL_SH.read_text(encoding = "utf-8")
         assert (
-            f'"bitsandbytes>={self.FLOOR}"' in text
+            f'_BNB_ROCM_PYPI_FALLBACK="bitsandbytes>={self.FLOOR}"' in text
         ), f"install.sh _install_bnb_rocm PyPI fallback must floor at {self.FLOOR}"
 
     def test_stack_py_pypi_fallback_floor(self):
@@ -864,3 +864,15 @@ class TestAmdBnbFloorParity:
                     raise AssertionError(
                         f"{path.name} still floors bitsandbytes in the broken ROCm range: {line.strip()!r}"
                     )
+
+    def test_fallback_is_not_reported_as_broken(self):
+        """The fallback now installs the first fixed release, so neither installer may
+        still tell the user it leaves 4-bit decode broken on ROCm."""
+        for path in (INSTALL_SH, STACK_PY):
+            text = path.read_text(encoding = "utf-8")
+            assert (
+                "4-bit decode broken on ROCm" not in text
+            ), f"{path.name} still reports the repaired PyPI fallback as broken"
+            assert (
+                "4-bit decode will be broken on ROCm" not in text
+            ), f"{path.name} still reports the repaired PyPI fallback as broken"

--- a/tests/python/test_cross_platform_parity.py
+++ b/tests/python/test_cross_platform_parity.py
@@ -832,15 +832,15 @@ class TestAmdBnbFloorParity:
 
     def test_install_sh_pypi_fallback_floor(self):
         text = INSTALL_SH.read_text(encoding = "utf-8")
-        assert f'"bitsandbytes>={self.FLOOR}"' in text, (
-            f"install.sh _install_bnb_rocm PyPI fallback must floor at {self.FLOOR}"
-        )
+        assert (
+            f'"bitsandbytes>={self.FLOOR}"' in text
+        ), f"install.sh _install_bnb_rocm PyPI fallback must floor at {self.FLOOR}"
 
     def test_stack_py_pypi_fallback_floor(self):
         text = STACK_PY.read_text(encoding = "utf-8")
-        assert f'_BNB_ROCM_PYPI_FALLBACK = "bitsandbytes>={self.FLOOR}"' in text, (
-            f"install_python_stack.py PyPI fallback must floor at {self.FLOOR}"
-        )
+        assert (
+            f'_BNB_ROCM_PYPI_FALLBACK = "bitsandbytes>={self.FLOOR}"' in text
+        ), f"install_python_stack.py PyPI fallback must floor at {self.FLOOR}"
 
     def test_amd_extra_floor_when_present(self):
         """The amd extra is not on this branch yet (#7278). Assert it only once it is,
@@ -852,9 +852,9 @@ class TestAmdBnbFloorParity:
         specs = re.findall(r'"(bitsandbytes[^"]*)"', amd.group(1))
         assert specs, "the amd extra must pin bitsandbytes"
         for spec in specs:
-            assert spec.startswith(f"bitsandbytes>={self.FLOOR}"), (
-                f"amd extra bitsandbytes floor must be >={self.FLOOR}, got {spec!r}"
-            )
+            assert spec.startswith(
+                f"bitsandbytes>={self.FLOOR}"
+            ), f"amd extra bitsandbytes floor must be >={self.FLOOR}, got {spec!r}"
 
     def test_no_installer_still_allows_the_broken_range(self):
         for path in (INSTALL_SH, INSTALL_PS1, SETUP_PS1, STACK_PY, self.PYPROJECT):

--- a/tests/python/test_cross_platform_parity.py
+++ b/tests/python/test_cross_platform_parity.py
@@ -876,3 +876,21 @@ class TestAmdBnbFloorParity:
             assert (
                 "4-bit decode will be broken on ROCm" not in text
             ), f"{path.name} still reports the repaired PyPI fallback as broken"
+
+    def test_aarch64_is_not_told_it_has_a_rocm_backend(self):
+        """bitsandbytes ships no ROCm kernels in its aarch64 wheel at any version, so
+        neither installer may hand aarch64 the x86_64 "carries the ROCm 4-bit fix"
+        message, and both must warn that 4-bit needs a source build there."""
+        sh = INSTALL_SH.read_text(encoding = "utf-8")
+        assert "_bnb_rocm_arch_has_binary()" in sh
+        assert "_warn_bnb_no_rocm_binary()" in sh
+        assert (
+            sh.count("_warn_bnb_no_rocm_binary\n") >= 2
+        ), "install.sh must warn on aarch64 after both the pre-release and the fallback install"
+        py = STACK_PY.read_text(encoding = "utf-8")
+        assert "def _bnb_rocm_arch_has_binary(" in py
+        assert "_bnb_rocm_arch_has_binary()" in py
+        for text, name in ((sh, "install.sh"), (py, "install_python_stack.py")):
+            assert (
+                "4-bit QLoRA needs a source build" in text
+            ), f"{name} must tell aarch64 users 4-bit needs a source build"

--- a/tests/python/test_cross_platform_parity.py
+++ b/tests/python/test_cross_platform_parity.py
@@ -818,3 +818,49 @@ class TestPipNoIndexScrubParity:
         text = SETUP_PS1.read_text(encoding = "utf-8")
         assert "'PIP_NO_INDEX'" in text
         assert "'PIP_INDEX_URL'" in text
+
+
+class TestAmdBnbFloorParity:
+    """bitsandbytes <= 0.49.2 NaNs at 4-bit decode shape on every AMD GPU; the ROCm
+    4-bit GEMV fix (bnb #1887) first ships on PyPI in 0.50.0. The install.sh PyPI
+    fallback and the Studio stack fallback are the two ways a supported AMD flow
+    resolves bitsandbytes when the pre-release wheel URL is unreachable, so neither
+    may float back into the broken range."""
+
+    FLOOR = "0.50.0"
+    PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+    def test_install_sh_pypi_fallback_floor(self):
+        text = INSTALL_SH.read_text(encoding = "utf-8")
+        assert f'"bitsandbytes>={self.FLOOR}"' in text, (
+            f"install.sh _install_bnb_rocm PyPI fallback must floor at {self.FLOOR}"
+        )
+
+    def test_stack_py_pypi_fallback_floor(self):
+        text = STACK_PY.read_text(encoding = "utf-8")
+        assert f'_BNB_ROCM_PYPI_FALLBACK = "bitsandbytes>={self.FLOOR}"' in text, (
+            f"install_python_stack.py PyPI fallback must floor at {self.FLOOR}"
+        )
+
+    def test_amd_extra_floor_when_present(self):
+        """The amd extra is not on this branch yet (#7278). Assert it only once it is,
+        so the extra and the two installer fallbacks cannot drift apart later."""
+        text = self.PYPROJECT.read_text(encoding = "utf-8")
+        amd = re.search(r"^amd = \[(.*?)^\]", text, re.S | re.M)
+        if amd is None:
+            pytest.skip("pyproject.toml has no amd extra on this branch")
+        specs = re.findall(r'"(bitsandbytes[^"]*)"', amd.group(1))
+        assert specs, "the amd extra must pin bitsandbytes"
+        for spec in specs:
+            assert spec.startswith(f"bitsandbytes>={self.FLOOR}"), (
+                f"amd extra bitsandbytes floor must be >={self.FLOOR}, got {spec!r}"
+            )
+
+    def test_no_installer_still_allows_the_broken_range(self):
+        for path in (INSTALL_SH, INSTALL_PS1, SETUP_PS1, STACK_PY, self.PYPROJECT):
+            text = path.read_text(encoding = "utf-8")
+            for line in text.splitlines():
+                if "bitsandbytes>=0.49" in line and not line.lstrip().startswith(("#", "//")):
+                    raise AssertionError(
+                        f"{path.name} still floors bitsandbytes in the broken ROCm range: {line.strip()!r}"
+                    )

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -2841,9 +2841,7 @@ class TestInstallBnbWindowsRocm:
     def test_falls_back_to_pypi_when_prerelease_install_fails(self):
         """A blocked GitHub pre-release URL must fall through to the PyPI floor rather
         than leaving Windows ROCm with no working bitsandbytes."""
-        with patch.object(
-            stack_mod, "pip_install_try", side_effect = [False, True]
-        ) as mock_pip:
+        with patch.object(stack_mod, "pip_install_try", side_effect = [False, True]) as mock_pip:
             with patch.object(stack_mod, "_detect_bnb_rocm_dll_ver", return_value = "72"):
                 result = stack_mod._install_bnb_windows_rocm()
         assert result is True

--- a/tests/studio/install/test_rocm_support.py
+++ b/tests/studio/install/test_rocm_support.py
@@ -2829,12 +2829,37 @@ class TestInstallBnbWindowsRocm:
             assert result is False
             assert "BNB_ROCM_VERSION" not in os.environ
 
-    def test_no_op_when_win_amd64_url_missing(self):
-        """Should be silent no-op if win_amd64 key absent from _BNB_ROCM_PRERELEASE_URLS."""
+    def test_falls_back_to_pypi_when_win_amd64_url_missing(self):
+        """No win_amd64 pre-release wheel must not mean no bitsandbytes: PyPI
+        >=0.50.0 ships libbitsandbytes_rocm{714,72}.dll, so it is a real ROCm build."""
         with patch.object(stack_mod, "_BNB_ROCM_PRERELEASE_URLS", {}):
-            with patch.object(stack_mod, "pip_install_try") as mock_pip:
+            with patch.object(stack_mod, "pip_install_try", return_value = True) as mock_pip:
                 stack_mod._install_bnb_windows_rocm()
-        mock_pip.assert_not_called()
+        assert mock_pip.call_count == 1
+        assert stack_mod._BNB_ROCM_PYPI_FALLBACK in mock_pip.call_args.args
+
+    def test_falls_back_to_pypi_when_prerelease_install_fails(self):
+        """A blocked GitHub pre-release URL must fall through to the PyPI floor rather
+        than leaving Windows ROCm with no working bitsandbytes."""
+        with patch.object(
+            stack_mod, "pip_install_try", side_effect = [False, True]
+        ) as mock_pip:
+            with patch.object(stack_mod, "_detect_bnb_rocm_dll_ver", return_value = "72"):
+                result = stack_mod._install_bnb_windows_rocm()
+        assert result is True
+        assert mock_pip.call_count == 2
+        assert "win_amd64" in str(mock_pip.call_args_list[0])
+        assert stack_mod._BNB_ROCM_PYPI_FALLBACK in mock_pip.call_args_list[1].args
+
+    def test_returns_false_only_when_both_paths_fail(self):
+        """Both the pre-release wheel and the PyPI fallback must fail before the
+        helper reports failure."""
+        with patch.dict(os.environ, {}, clear = False):
+            os.environ.pop("BNB_ROCM_VERSION", None)
+            with patch.object(stack_mod, "pip_install_try", return_value = False) as mock_pip:
+                result = stack_mod._install_bnb_windows_rocm()
+        assert result is False
+        assert mock_pip.call_count == 2
 
     def test_sets_bnb_rocm_version_from_detected_dll(self):
         """BNB_ROCM_VERSION is set from the DLL detected after install."""


### PR DESCRIPTION
## What

Raise the two AMD ROCm bitsandbytes PyPI fallback floors on the `pip` branch from `>=0.49.1` to `>=0.50.0`, and add a regression test that locks them there.

- `install.sh` `_install_bnb_rocm`, the PyPI fallback used when the continuous-release_main wheel URL is unreachable
- `_BNB_ROCM_PYPI_FALLBACK` in `studio/install_python_stack.py`, which is the path Studio and both PowerShell installers use (`install.ps1` and `studio/setup.ps1` carry no bitsandbytes spec of their own, they delegate to the stack script)

## Why

bitsandbytes <= 0.49.2 NaNs at decode shape on every AMD GPU. The ROCm 4-bit GEMV fix is bnb #1887, merged 2026-03-09, after 0.49.2 (2026-02-16) and before 0.50.0 (2026-07-24), so 0.50.0 is the first PyPI release that carries it. Both fallbacks still allowed the broken range, which is the one thing they exist to prevent: they fire precisely when the pre-release URL cannot be reached, and a host that cannot reach GitHub is also the host most likely to be sitting behind a lagging PyPI mirror that still offers 0.49.x as its newest.

The floor is real rather than nominal. The PyPI 0.50.0 `manylinux_2_24_x86_64` wheel ships `libbitsandbytes_rocm{64,70,71,714,72}.so` and the `win_amd64` wheel ships `libbitsandbytes_rocm{714,72}.dll`, the same ROCm set as the continuous-release wheel, so the fallback lands on a bitsandbytes that actually has ROCm kernels.

This is the `pip` branch counterpart to the same change on `main` (#7535), so the two branches do not drift.

## Test

`TestAmdBnbFloorParity` in `tests/python/test_cross_platform_parity.py` asserts both installer floors, and that no installer or `pyproject.toml` line floors bitsandbytes in the 0.49.x range. The `amd` extra does not exist on this branch yet (#7278 adds it), so the extra assertion skips until it lands and then holds it to the same floor.

```
tests/python/test_cross_platform_parity.py  64 passed, 1 skipped
tests/python/test_install_python_stack.py   22 passed
```

## Not changed

The continuous-release_main pre-release wheel stays first in line. Its ROCm binary coverage is identical to 0.50.0 today, so it could be dropped, but that would delete the `force_pip` and `BNB_ROCM_VERSION` plumbing built around it and rewrite the tests that cover it. Separate change if wanted.

The comments claiming the pre-release wheel's embedded metadata version is `0.50.0.dev0` were stale; the rolling artifact now reports `0.50.1.dev0`, so they now say `0.50.x.dev0`.