### PR TITLE
Tests: import bitsandbytes before the GPU-free harness spoofs CUDA

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,7 +123,34 @@ def _install_device_type_stub(name: str) -> None:
     sys.modules[name] = stub
 
 
+def _preimport_bitsandbytes() -> None:
+    """Bind bitsandbytes against the real torch before the CUDA spoof below.
+
+    `bitsandbytes/__init__.py` runs `if torch.cuda.is_available(): from .backends.cuda
+    import ops`, and that module reads `torch._C._cuda_getCurrentRawStream`, which a
+    CPU-only torch build does not expose. `_preload_device_type` patches
+    `torch.cuda.is_available` to return True, so a bitsandbytes import landing inside
+    that window takes the CUDA branch and dies with AttributeError.
+
+    Python then drops `bitsandbytes` from sys.modules but leaves `bitsandbytes.functional`
+    and the rest of its submodules cached, so the next import re-executes __init__ against
+    those cached submodules, re-binds nothing, and hands back a module with no
+    `.functional`. `unsloth/kernels/utils.py` reads `bnb.functional.get_ptr` at module
+    scope, so every later `import unsloth` in that process dies with
+    "module 'bitsandbytes' has no attribute 'functional'".
+
+    Importing first, outside the window, keeps bitsandbytes on its CPU backend and fully
+    usable. Must stay ahead of the `_preload_device_type` calls below.
+    """
+    try:
+        import bitsandbytes  # noqa: F401
+    except Exception:
+        # A genuinely absent or broken wheel is unsloth's own degradation path.
+        pass
+
+
 if not _has_real_accelerator():
+    _preimport_bitsandbytes()
     if not _preload_device_type("unsloth_zoo", prereqs = ("utils",)):
         _install_device_type_stub("unsloth_zoo.device_type")
     if not _preload_device_type("unsloth"):

--- a/tests/python/test_conftest_bitsandbytes_preimport.py
+++ b/tests/python/test_conftest_bitsandbytes_preimport.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Guard the ordering that keeps bitsandbytes usable under the GPU-free harness.
+
+tests/conftest.py patches `torch.cuda.is_available` to return True so
+`device_type.py`'s @cache captures "cuda" on a GPU-less runner. bitsandbytes reads
+that same flag at import time to decide whether to import its CUDA backend, and that
+backend touches `torch._C._cuda_getCurrentRawStream`, absent from CPU-only torch
+builds. A bitsandbytes import landing inside the spoof window therefore raises, and
+the failure is not recoverable within the process: Python drops `bitsandbytes` from
+sys.modules while leaving its submodules cached, so every later import returns a
+module with no `.functional`, and `unsloth/kernels/utils.py` dies at module scope.
+
+Clearing sys.modules is not a way out either -- re-executing `bitsandbytes._ops`
+raises "Tried to register an operator ... multiple times". The import simply must not
+fail, which is what `_preimport_bitsandbytes()` guarantees by running first.
+
+Source-level rather than behavioural on purpose: the failure needs a CPU-only torch
+build to reproduce, so a runtime assertion would pass vacuously wherever CUDA torch
+is installed, which is most developer machines.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+CONFTEST = Path(__file__).resolve().parents[1] / "conftest.py"
+
+
+def _accelerator_guard_body(tree: ast.Module) -> list[ast.stmt]:
+    for node in tree.body:
+        if isinstance(node, ast.If) and "_has_real_accelerator" in ast.dump(node.test):
+            return node.body
+    raise AssertionError("tests/conftest.py has no `if not _has_real_accelerator():` block")
+
+
+def _called_names(body: list[ast.stmt]) -> list[str]:
+    names = []
+    for stmt in body:
+        for node in ast.walk(stmt):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                names.append(node.func.id)
+    return names
+
+
+def test_conftest_defines_the_bitsandbytes_preimport():
+    tree = ast.parse(CONFTEST.read_text(encoding = "utf-8"))
+    defined = {n.name for n in tree.body if isinstance(n, ast.FunctionDef)}
+    assert "_preimport_bitsandbytes" in defined, (
+        "tests/conftest.py must define _preimport_bitsandbytes(); without it a "
+        "bitsandbytes import inside the CUDA spoof window permanently breaks "
+        "`import unsloth` for the rest of the process"
+    )
+
+
+def test_bitsandbytes_is_preimported_before_the_cuda_spoof():
+    tree = ast.parse(CONFTEST.read_text(encoding = "utf-8"))
+    called = _called_names(_accelerator_guard_body(tree))
+
+    assert "_preimport_bitsandbytes" in called, (
+        "_preimport_bitsandbytes() is never called inside the "
+        "`if not _has_real_accelerator():` block"
+    )
+    assert "_preload_device_type" in called, "conftest no longer calls _preload_device_type"
+    assert called.index("_preimport_bitsandbytes") < called.index("_preload_device_type"), (
+        "_preimport_bitsandbytes() must run BEFORE _preload_device_type(), which is what "
+        "patches torch.cuda.is_available; importing bitsandbytes inside that window makes "
+        "it take its CUDA backend on a CPU-only torch and poisons sys.modules"
+    )
+
+
+def test_preimport_swallows_a_genuinely_missing_wheel():
+    """An absent bitsandbytes stays unsloth's own degradation path, not a collection error."""
+    tree = ast.parse(CONFTEST.read_text(encoding = "utf-8"))
+    fn = next(
+        n for n in tree.body
+        if isinstance(n, ast.FunctionDef) and n.name == "_preimport_bitsandbytes"
+    )
+    assert any(isinstance(node, ast.Try) for node in ast.walk(fn)), (
+        "_preimport_bitsandbytes() must guard its import with try/except so a missing or "
+        "broken wheel does not turn into a collection error"
+    )

--- a/tests/python/test_conftest_bitsandbytes_preimport.py
+++ b/tests/python/test_conftest_bitsandbytes_preimport.py
@@ -75,7 +75,8 @@ def test_preimport_swallows_a_genuinely_missing_wheel():
     """An absent bitsandbytes stays unsloth's own degradation path, not a collection error."""
     tree = ast.parse(CONFTEST.read_text(encoding = "utf-8"))
     fn = next(
-        n for n in tree.body
+        n
+        for n in tree.body
         if isinstance(n, ast.FunctionDef) and n.name == "_preimport_bitsandbytes"
     )
     assert any(isinstance(node, ast.Try) for node in ast.walk(fn)), (


### PR DESCRIPTION
## Problem

`Core` is red on `main`, all three matrix legs, and takes every open PR with it:

```
unsloth/kernels/utils.py:155: in <module>
    get_ptr = bnb.functional.get_ptr
E   AttributeError: module 'bitsandbytes' has no attribute 'functional'
```

The wheel is fine. In the same CPU-only venv, a plain `import bitsandbytes` gives `0.50.0` with `functional`, `functional.lib` and all five ctypes symbols present. What breaks it is our own test harness.

## Cause

`tests/conftest.py` patches `torch.cuda.is_available` to return `True` so `device_type.py`'s cache captures `"cuda"` on a GPU-less runner. `bitsandbytes/__init__.py` reads that same flag:

```python
if torch.cuda.is_available():
    from .backends.cuda import ops as cuda_ops
```

and `bitsandbytes/backends/cuda/ops.py:69` reads `torch._C._cuda_getCurrentRawStream`, which a CPU-only torch build does not expose. A bitsandbytes import landing inside the spoof window therefore raises:

```
!!! EXCEPTION during import of bitsandbytes : AttributeError module 'torch._C' has no attribute '_cuda_getCurrentRawStream'
  File ".../bitsandbytes/__init__.py", line 36, in <module>
    from .backends.cuda import ops as cuda_ops
  File ".../bitsandbytes/backends/cuda/ops.py", line 69, in <module>
    _get_raw_stream = torch._C._cuda_getCurrentRawStream
```

The failure is not recoverable inside the process. Python drops `bitsandbytes` from `sys.modules` but leaves `bitsandbytes.functional` and the rest of the submodules cached, so the next import re-executes `__init__` against those cached submodules, re-binds nothing, and returns a module with no `.functional`. An import trace of the failing run:

```
<-- DONE  bitsandbytes | bnb.functional=None     first import failed, module dropped
--> IMPORT bitsandbytes
<-- DONE  bitsandbytes | bnb.functional=False    re-import, permanently broken
```

`_gpu_init.py:304-309` swallows the original AttributeError with a bare `except:` and prints "bitsandbytes is not installed", which is why the real cause never surfaced.

Clearing `sys.modules` is not a way out either: re-executing `bitsandbytes._ops` raises `RuntimeError: Tried to register an operator (bitsandbytes::int8_mixed_scaled_mm) ... multiple times`. The import has to not fail in the first place.

## Fix

Import bitsandbytes once before the spoof window, so it binds against the real CPU-only torch, stays on its CPU backend, and remains fully usable. A genuinely missing or broken wheel still falls through to unsloth's own degradation path.

This keeps bitsandbytes **working** in CI. Declaring it absent would make the CPU matrix green while silently running with 4-bit disabled.

## Verification

Reproduced first, in a venv matching the failing job (`torch==2.10.0+cpu`, `bitsandbytes 0.50.0`, no GPU), then re-run with the fix:

```
before:  no tests collected, 2 errors      (the CI-named files)
after:   39 tests collected, 0 errors
```

```
full tests/ collection:  696 collected, zero "has no attribute 'functional'" errors
get_ptr is bnb.functional.get_ptr:  True
ALLOW_BITSANDBYTES:                 True
```

That last pair matters: bitsandbytes is genuinely active, not degraded to the `_bnb_required` stub.

`tests/python/test_conftest_bitsandbytes_preimport.py` guards the ordering: 3 passed here, 3 failed against `main`'s conftest. It is source-level on purpose. Reproducing the runtime failure needs a CPU-only torch build, so a behavioural assertion would pass vacuously on any machine with CUDA torch installed.

Separately confirmed that this is CI-only and not user-facing: `Llama3.2_(1B_and_3B)-Conversational.ipynb` with `load_in_4bit = True` on bitsandbytes 0.50.0 runs clean end to end on a B200 (193 `Linear4bit` modules, NF4 round-trip verified, 60/60 steps, generation and adapter save all fine).

## Note on #7578

#7578 guards the same crash by treating a half-loaded wheel as absent. Worth keeping as defence-in-depth, but on its own it would turn the CPU matrix green with 4-bit silently off, so I would land this as the actual repair. Two things to add there: it probes `bnb.functional.get_ptr` but not `bnb.functional.lib`, which is the third hazard at `kernels/utils.py:262-273`; and `device_type.py:125-130` derives `ALLOW_BITSANDBYTES` from a probe catching only import exceptions, so on a half-loaded module the flag stays `True` and the failure moves to the first forward pass instead of degrading to 16-bit.