### PR TITLE
fix(studio): show the selected artifact's source in the canvas Code view

### DIFF
--- a/studio/frontend/src/features/chat/artifacts/artifact-surface.tsx
+++ b/studio/frontend/src/features/chat/artifacts/artifact-surface.tsx
@@ -30,7 +30,7 @@ import { Streamdown } from "streamdown";
 import { ArtifactHtmlFrame, type ArtifactViewMode } from "./html-frame";
 import { useChatArtifactsStore } from "./store";
 import type { ChatArtifact } from "./types";
-import { getArtifactFilename } from "./types";
+import { getArtifactFilename, hashArtifactCode } from "./types";
 
 const COPY_RESET_MS = 2000;
 const artifactSourceCodePlugin = createCodePlugin({
@@ -115,6 +115,13 @@ export function ArtifactSurface({
   const sourceMarkdown = useMemo(
     () => buildHtmlFence(artifact.code),
     [artifact.code],
+  );
+  // Streamdown never revises a committed block in streaming mode, so the source
+  // view must remount on a code change, as the preview frame already does. Tool
+  // artifact IDs track the tool call, not the code, hence the hash.
+  const sourceKey = useMemo(
+    () => `${artifact.id}:${hashArtifactCode(artifact.code)}`,
+    [artifact.id, artifact.code],
   );
   const hasArtifactCode = artifact.code.trim().length > 0;
   const isLoadingArtifact = Boolean(artifact.isStreaming);
@@ -338,6 +345,7 @@ export function ArtifactSurface({
         ) : (
           <div className="h-full overflow-auto text-xs leading-relaxed [&_[data-streamdown=code-block]]:!my-0 [&_[data-streamdown=code-block]]:!gap-0 [&_[data-streamdown=code-block]]:!rounded-none [&_[data-streamdown=code-block]]:!border-0 [&_[data-streamdown=code-block]]:!bg-transparent [&_[data-streamdown=code-block]]:!p-0 [&_[data-streamdown=code-block-body]]:!border-0 [&_[data-streamdown=code-block-body]]:!bg-transparent [&_[data-streamdown=code-block-body]]:!p-0 [&_pre]:!m-0 [&_pre]:!bg-transparent [&_pre]:!p-0 [&_pre]:text-xs [&_pre]:leading-relaxed [&_code]:text-xs">
             <Streamdown
+              key={sourceKey}
               mode="streaming"
               plugins={{ code: artifactSourceCodePlugin }}
               controls={{ code: false }}


### PR DESCRIPTION
## What

Switching between HTML artifacts leaves the canvas Code view showing the source of whichever artifact was opened first. Preview follows the selection correctly, only the Code view is stuck. Copy is affected too: it reads `artifact.code` directly, so the pane can show one artifact while the Copy button puts a different one on the clipboard.

Spotted while going back over #7537. It reproduces on that PR's merge base, so it is pre-existing and not caused by the streaming work.

## Why

`ArtifactSurface` renders the source through `<Streamdown mode="streaming">`. In streaming mode Streamdown commits a block and does not revise it, so handing it a new string is not enough. The `ArtifactHtmlFrame` directly above it already carries `key={artifact.id}` for exactly this reason. The source view carried no key, so React reused one Streamdown instance across artifacts and the committed block stayed put.

Whether it shows depends on the artifact sizes, which is what makes it look intermittent. Three artifacts of differing source length happen to update; equal lengths never do.

## Fix

Key the source `Streamdown` on the artifact plus a hash of its code. `createArtifactId` already folds `hashArtifactCode` into fence artifact IDs, but tool artifact IDs are built from the tool call ID, so the code can change under a stable ID. Hashing covers both.

## Verification

Three artifacts in one message, walking the Code view across them in the order 0, 1, 0, 2, 1, 2. Playwright, Chromium / Firefox / WebKit, against a local Studio.

Equal source lengths:

| | Chromium | Firefox | WebKit |
| --- | --- | --- | --- |
| main | 4 of 6 stale | 4 of 6 stale | 4 of 6 stale |
| this PR | 0 stale | 0 stale | 0 stale |

Copy against the pane, Chromium: on `main` the pane showed BRAVOMARKER while the clipboard held ALPHAMARKER. With this PR they agree.

Differing source lengths (6.7 KB / 9.0 KB / 11.6 KB) pass on both, which is why the report is easy to miss.

Cost of the remount, three 27 KB artifacts, Chromium, blocking time per action:

| | first open | later switch |
| --- | --- | --- |
| main | 1793 ms | 0 ms, wrong document |
| this PR | 1823 ms | 53 ms to 133 ms |

The first open is unchanged. Switching now pays for tokenizing the document it is actually showing.

Unchanged either way: preview round trip, iframe count, highlighted span counts per artifact, and console output. `tsc -b` is clean, and biome and eslint output on the file is identical to `main` (3 errors and 11 warnings from biome, 1 eslint error, all pre-existing).

The existing cross-engine streaming code-block matrix reports the same results before and after this change, so nothing in the message render path moved.