### PR TITLE
Gate the torchcodec audio extras to platforms that have a wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,14 +128,19 @@ huggingfacenotorch = [
 ]
 # torchcodec backend for Gemma audio / datasets>=4 (#7225).
 # Pick the audio-torch* pin matching your torch minor (see TORCH_TORCHCODEC).
+# torchcodec publishes no sdist and only manylinux_2_28_x86_64, macosx_*_arm64
+# and win_amd64 wheels, so Linux aarch64, Windows ARM64 and Intel Mac have
+# nothing to resolve and pip fails the whole install rather than skipping audio.
+# Gate on the platforms that have a wheel, matching
+# PLATFORM_LACKS_TORCHCODEC_WHEEL in studio/install_python_stack.py.
 audio-torch210 = [
-    "torchcodec>=0.10.0,<0.11.0 ; python_version >= '3.10'",
+    "torchcodec>=0.10.0,<0.11.0 ; python_version >= '3.10' and (((sys_platform == 'linux' or sys_platform == 'win32') and (platform_machine == 'x86_64' or platform_machine == 'AMD64')) or (sys_platform == 'darwin' and platform_machine == 'arm64'))",
 ]
 audio-torch290 = [
-    "torchcodec>=0.8.0,<0.10.0 ; python_version >= '3.10'",
+    "torchcodec>=0.8.0,<0.10.0 ; python_version >= '3.10' and (((sys_platform == 'linux' or sys_platform == 'win32') and (platform_machine == 'x86_64' or platform_machine == 'AMD64')) or (sys_platform == 'darwin' and platform_machine == 'arm64'))",
 ]
 audio-torch280 = [
-    "torchcodec>=0.6.0,<0.8.0 ; python_version >= '3.9'",
+    "torchcodec>=0.6.0,<0.8.0 ; python_version >= '3.9' and (((sys_platform == 'linux' or sys_platform == 'win32') and (platform_machine == 'x86_64' or platform_machine == 'AMD64')) or (sys_platform == 'darwin' and platform_machine == 'arm64'))",
 ]
 huggingface = [
     "unsloth[huggingfacenotorch]",

--- a/tests/python/test_torchcodec_torch_compat.py
+++ b/tests/python/test_torchcodec_torch_compat.py
@@ -11,10 +11,19 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 IMPORT_FIXES_PATH = REPO_ROOT / "unsloth" / "import_fixes.py"
+
+
+def _tomllib():
+    if sys.version_info >= (3, 11):
+        import tomllib
+        return tomllib
+    return pytest.importorskip("tomli")
 
 
 def _load_import_fixes_module():
@@ -127,3 +136,41 @@ def test_import_fixes_loads_on_python39_syntax():
     """Regression: module must import on 3.9 (postponed annotations for str | None)."""
     fixes = _load_import_fixes_module()
     assert callable(fixes._torchcodec_version_mismatch_hint)
+
+
+def test_audio_extras_are_gated_to_platforms_with_a_torchcodec_wheel():
+    """torchcodec publishes no sdist and no wheel for Linux aarch64, Windows ARM64 or
+    Intel Mac, so an ungated pin makes pip fail the whole install on those hosts instead
+    of just skipping audio -- and the cu*/rocm*/intel torch 2.10 extras pull it in.
+    The marker must match PLATFORM_LACKS_TORCHCODEC_WHEEL in install_python_stack.py.
+    """
+    markers = pytest.importorskip("packaging.markers")
+    tomllib = _tomllib()
+    extras = tomllib.loads(PYPROJECT.read_text(encoding = "utf-8"))["project"][
+        "optional-dependencies"
+    ]
+    audio = {n: d for n, d in extras.items() if n.startswith("audio-torch")}
+    assert audio, "expected audio-torch* extras"
+
+    supported = [
+        {"sys_platform": "linux", "platform_machine": "x86_64"},
+        {"sys_platform": "win32", "platform_machine": "AMD64"},
+        {"sys_platform": "darwin", "platform_machine": "arm64"},
+    ]
+    unsupported = [
+        {"sys_platform": "linux", "platform_machine": "aarch64"},
+        {"sys_platform": "win32", "platform_machine": "ARM64"},
+        {"sys_platform": "darwin", "platform_machine": "x86_64"},
+    ]
+    for name, deps in audio.items():
+        for dep in deps:
+            _, _, marker_text = dep.partition(";")
+            assert marker_text.strip(), f"{name}: {dep!r} has no marker"
+            marker = markers.Marker(marker_text.strip())
+            env = {"python_version": "3.12"}
+            for case in supported:
+                assert marker.evaluate({**env, **case}), f"{name} must install on {case}"
+            for case in unsupported:
+                assert not marker.evaluate(
+                    {**env, **case}
+                ), f"{name} has no wheel for {case} and must not be resolved there"


### PR DESCRIPTION
## What

Adds a platform marker to `audio-torch210`, `audio-torch290` and `audio-torch280` so they only resolve where torchcodec actually publishes a wheel, plus a regression test.

```
python_version >= '3.10' and (((sys_platform == 'linux' or sys_platform == 'win32') and (platform_machine == 'x86_64' or platform_machine == 'AMD64')) or (sys_platform == 'darwin' and platform_machine == 'arm64'))
```

## Why

torchcodec publishes **no sdist at all**, and its wheels cover only `manylinux_2_28_x86_64`, `macosx_11/12_0_arm64` and `win_amd64`. I checked 0.6.0, 0.7.0, 0.9.0 and 0.10.0 on the index; every one of them is wheels-only with that same platform set. With no sdist there is not even a source fallback, so on Linux aarch64, Windows ARM64 or Intel Mac pip cannot resolve torchcodec and fails the entire install rather than skipping audio.

Nine extras pull the audio extras in, so this is reachable without asking for audio at all:

```
cu126-torch2100        cu126-ampere-torch2100
cu128-torch2100        cu128-ampere-torch2100
cu130-torch2100        cu130-ampere-torch2100
rocm711-torch2100      rocm72-torch2100
intel-gpu-torch210
```

`pip install 'unsloth[cu128-torch2100]'` on a Grace Hopper or other aarch64 Linux host is a normal thing to do, and it currently dies before the user gets an environment.

The installer already knows this. `PLATFORM_LACKS_TORCHCODEC_WHEEL` in `studio/install_python_stack.py:59` filters torchcodec out on exactly Linux aarch64, Windows ARM64 and Intel Mac, with a comment naming the same three wheel platforms. So the installer has been compensating for metadata that promised more than torchcodec ships; this makes the metadata agree with it instead.

## Verification

Evaluated the marker with `packaging.markers` across all six cases:

| platform | resolves torchcodec | matches installer |
|---|---|---|
| linux x86_64 | yes | yes |
| linux aarch64 | no | yes |
| win AMD64 | yes | yes |
| win ARM64 | no | yes |
| mac arm64 | yes | yes |
| mac x86_64 (Intel) | no | yes |

That is exactly the complement of `PLATFORM_LACKS_TORCHCODEC_WHEEL`.

Built the wheel and confirmed the marker survives into `Requires-Dist` for all three extras.

`test_audio_extras_are_gated_to_platforms_with_a_torchcodec_wheel` asserts each audio extra installs on the three supported platforms and does not resolve on the three unsupported ones. I confirmed it fails when the gate is removed from a single extra, so it is not vacuous.

Tests: 85 passed across `test_torchcodec_torch_compat.py`, `test_cross_platform_parity.py` and `test_studio_extra_matches_requirements.py`.

## Note

The same fix landed on the `pip` branch in #7583, where the exposure was narrower (six extras, no rocm or intel families). This is the `main` counterpart so the two branches do not drift.