### PR TITLE
Fix the red test on main from the #7578 / #7580 merge interaction

### DIFF
--- a/tests/python/test_bitsandbytes_kernel_readiness.py
+++ b/tests/python/test_bitsandbytes_kernel_readiness.py
@@ -155,7 +155,10 @@ def test_the_ctypes_binds_are_gated_on_the_same_verdict():
         "if bnb is None or not native_kernels_ready(bnb, DEVICE_TYPE):" in source
     ), "the ctypes bind block must take the _bnb_required branch on a dead library too"
     guarded = source.split("if bnb is None or not native_kernels_ready(bnb, DEVICE_TYPE):")[1]
-    assert "bnb.functional.lib" in guarded, "the binds must sit under that guard"
+    # Anchor on the symbol, not the module alias: #7580 renamed the binding from
+    # `bnb.functional.lib` to `bnb_functional.lib`, which is exactly the kind of rename
+    # this assertion should survive.
+    assert "lib.cdequantize_blockwise_fp32" in guarded, "the binds must sit under that guard"
 
 
 def test_the_kernel_check_reads_the_submodule_not_the_parent_attribute():


### PR DESCRIPTION
`main` is red at `7b068090b`: `tests/python/test_bitsandbytes_kernel_readiness.py::test_the_ctypes_binds_are_gated_on_the_same_verdict` fails.

My fault, and it is a merge interaction rather than either change being wrong. #7578 and #7580 landed 32 seconds apart and touch neighbouring lines in `unsloth/kernels/utils.py`, so git merged them cleanly and the runtime behaviour is correct:

```python
266: if bnb is None or not native_kernels_ready(bnb, DEVICE_TYPE):   # from #7578
273:     cdequantize_blockwise_fp32 = bnb_functional.lib.cdequantize_blockwise_fp32   # from #7580
```

What did not compose is the source-text assertion #7578 added. It looked for the literal `bnb.functional.lib` under that guard, and #7580 renamed the binding to `bnb_functional.lib` so it survives a half-imported bitsandbytes. Neither PR could see the conflict on its own branch.

Anchored on `lib.cdequantize_blockwise_fp32` instead. That still pins the ctypes binds to the guard, which is the whole point of the test, and it no longer breaks when the module alias changes.

### Verification

- `tests/python/test_bitsandbytes_kernel_readiness.py`: 10 passed.
- Full `tests/python` on merged `main` under the CI shape (torch 2.10.0+cpu, bitsandbytes 0.50.0, no GPU): this was the only new failure. The other two red items are pre-existing and unrelated (`test_negative_control_no_tokenizers`, plus a `pydantic` collection error in my scratch env).
- The merged runtime is fine, confirmed on a B200 before this change: `ALLOW_BITSANDBYTES True`, `get_ptr` real, 109 `Linear4bit` modules, 10/10 steps, generation clean.

Test-only change.
