### PR TITLE
CI: extract Get-HostMachineArch for the VC++ round-trip test

### DIFF
--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -1888,8 +1888,11 @@ jobs:
           # (step/substep -> Write-StudioStdoutMirror / Get-StudioAnsi).
           $script:StudioVtOk = $false
           $script:UnslothVerbose = $false
+          # Get-HostMachineArch is reached only on the absent path, where
+          # Test-VCRedistInstalled consults it before trusting the System32 DLL, so
+          # part A passes without it and only the clean-box part fails.
           foreach ($fn in @('Get-StudioAnsi', 'Write-StudioStdoutMirror', 'step', 'substep',
-                            'Invoke-SetupCommand', 'Refresh-Environment',
+                            'Invoke-SetupCommand', 'Refresh-Environment', 'Get-HostMachineArch',
                             'Test-VCRedistInstalled', 'Ensure-VCRedist')) {
               $src = Get-FunctionSource -Path $setup -Name $fn
               if (-not $src) { throw "Function '$fn' not found in setup.ps1" }


### PR DESCRIPTION
`Test-VCRedistInstalled` gained a `Get-HostMachineArch` call in #7549 so it stops
trusting the System32 `vcruntime140_1.dll` on ARM64. The `VC++ runtime detect +
install round-trip` job in `studio-windows-inference-smoke.yml` dot-sources a
fixed list of functions out of `studio/setup.ps1`, and that list was not updated,
so the helper is undefined in the harness scope.

Part A does not notice: on a stock runner the registry hit returns before the
call. Only part B, which removes both signals to prove detection fires on a clean
box, reaches it, and the job fails there with `Get-HostMachineArch is not
recognized`. Currently red on main and on every PR.

Both functions exist in `setup.ps1` (`:874` and `:897`), so this is a harness gap
rather than a product defect.

Reproduced and verified locally by dot-sourcing each list and calling the guard:

    pre-fix list:  The term 'Get-HostMachineArch' is not recognized...
    post-fix list: all 9 extracted OK
                   Get-HostMachineArch -> other
                   Test-VCRedistInstalled -> False