### PR TITLE
Run unsloth_cli/tests in Backend CI

### DIFF
--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -223,6 +223,18 @@ jobs:
             tests/studio/test_is_mlx_dispatch_gate.py \
             tests/studio/test_xpu_spoof_pipeline.py
 
+      - name: CLI tests (unsloth_cli)
+        # unsloth_cli/tests had no CI at all: `unsloth_cli/**` was only a paths
+        # trigger and a ruff target, so 673 tests covering the studio launcher,
+        # the pre-exposure gate and the auth secret writers ran nowhere, and
+        # four of them had been failing on main unnoticed.
+        # Own step, not folded into the tests/ discovery above: pyproject's
+        # testpaths is tests/, and this suite needs no PYTHONPATH or CUDA spoof
+        # (it self-bootstraps sys.path and imports neither unsloth nor torch).
+        # Run the whole directory in one invocation; some files in it are
+        # order-dependent and only pass in a full-directory run.
+        run: python -m pytest unsloth_cli/tests -q --tb=short
+
       - name: Shell installer tests
         # Auto-discovered rather than allowlisted. The old hardcoded list had
         # silently fallen seven files behind tests/run_all.sh, including

--- a/unsloth_cli/tests/test_studio_password_prompt.py
+++ b/unsloth_cli/tests/test_studio_password_prompt.py
@@ -626,6 +626,12 @@ def test_studio_default_in_venv_broken_backend_exits_before_stripping_bootstrap(
 
     # Pretend we are already inside the studio venv, with a broken backend.
     monkeypatch.setattr(sys, "prefix", str(tmp_path / "unsloth_studio"))
+    # A built dist is not present in a fresh clone. The missing-frontend gate
+    # runs first and has its own test below; stub it so this one reaches the
+    # backend check it is actually about.
+    monkeypatch.setattr(
+        studio_mod, "_find_frontend_dist", lambda: Path("/fake/studio/frontend/dist")
+    )
 
     def _boom():
         raise ImportError("cannot import backend run.py")

--- a/unsloth_cli/tests/test_studio_run_parallel_flag.py
+++ b/unsloth_cli/tests/test_studio_run_parallel_flag.py
@@ -606,8 +606,8 @@ def test_studio_default_exposes_parallel_option():
     assert "--parallel" in decls
     assert "--n-parallel" in decls
     assert (
-        getattr(opt, "default", None) == 1
-    ), "studio_default --parallel must default to 1 (pre-PR); `run` is 4"
+        getattr(opt, "default", None) == studio_mod._PARALLEL_DEFAULT_PLAIN
+    ), "studio_default --parallel must use _PARALLEL_DEFAULT_PLAIN"
     assert getattr(opt, "min", None) == 1
     assert getattr(opt, "max", None) == 64
 
@@ -679,7 +679,6 @@ def test_api_only_option_is_registered():
     "extra,present",
     [
         (["--api-only"], True),
-        (["--secure", "--api-only"], True),  # secure headless path
         ([], False),
     ],
 )
@@ -689,6 +688,21 @@ def test_reexec_forwards_api_only(monkeypatch, extra, present):
     assert len(captured) == 1, result.output
     argv = captured[0]["argv"]
     assert ("--api-only" in argv) is present, argv
+
+
+def test_secure_api_only_is_refused_before_any_reexec(monkeypatch, tmp_path):
+    """`--secure --api-only` used to re-exec; the pre-exposure gate now refuses
+    it, because api-only has no login page and the bootstrap deadline does not
+    apply, so the seeded password could never be changed."""
+    studio_mod = _load_run_command()
+    monkeypatch.setattr(studio_mod, "STUDIO_HOME", tmp_path)
+
+    result, captured = _invoke_run(monkeypatch, _BASE + ["--secure", "--api-only"])
+
+    assert captured == [], captured
+    assert result.exit_code != 0
+    combined = (result.output or "") + (getattr(result, "stderr", "") or "")
+    assert "default admin password was never changed" in combined.lower()
 
 
 @pytest.mark.parametrize("extra,expected", [(["--api-only"], True), ([], False)])

--- a/unsloth_cli/tests/test_studio_secure_flag.py
+++ b/unsloth_cli/tests/test_studio_secure_flag.py
@@ -261,6 +261,11 @@ def test_run_in_venv_passes_secure_and_forces_host(monkeypatch, tmp_path):
 
     fake_venv = tmp_path / "unsloth_studio"
     monkeypatch.setattr(sys, "prefix", str(fake_venv))
+    # A built dist is not present in a fresh clone, and without it the public
+    # launch gate exits before run_server is ever reached.
+    monkeypatch.setattr(
+        studio_mod, "_find_frontend_dist", lambda: Path("/fake/studio/frontend/dist")
+    )
 
     from unsloth_cli import _tool_policy as _tp_mod
 


### PR DESCRIPTION
These 673 tests ran nowhere. `unsloth_cli/**` was already a `paths` trigger on Backend CI and a ruff target, so the job fired on CLI changes but never executed the suite that covers the studio launcher, the pre-exposure gate and the auth secret writers. Four tests had been failing on `main` unnoticed.

Adds a `CLI tests (unsloth_cli)` step to the existing `repo-cpu-tests` job and fixes the four so the step lands green.

## The four failures

Two were stale tests, not broken code:

| Test | Why it failed |
|---|---|
| `test_studio_default_exposes_parallel_option` | Pinned the plain `--parallel` default to 1, but #7455 deliberately moved `_PARALLEL_DEFAULT_PLAIN` to 4 so a new chat does not queue behind the previous one. Now asserts against the constant so the two cannot drift again. |
| `test_reexec_forwards_api_only[--secure --api-only]` | Expected a re-exec, but the pre-exposure gate now refuses that combination: api-only serves no login page and the bootstrap deadline does not apply, so a seeded password could never be changed. Case dropped, and the refusal asserted instead. |

Two only passed when a built frontend dist happened to be present, which it is not in a fresh clone or on a runner:

| Test | Why it failed |
|---|---|
| `test_studio_default_in_venv_broken_backend_exits_before_stripping_bootstrap` | Reaches a public-launch path where the missing-dist gate exits first, so it never got to the backend check it is about. The missing-frontend case already has its own test directly below. |
| `test_run_in_venv_passes_secure_and_forces_host` | Same gate fires before `run_server` is called, so `captured` stayed empty. |

Both now stub `_find_frontend_dist` the way their siblings in the same files already do, making them independent of whether the frontend was built.

## Placement

Its own step rather than folding into the `tests/` auto-discovery above it: `pyproject.toml` sets `testpaths = ["tests/"]`, and this suite needs neither the `PYTHONPATH` nor the `UNSLOTH_COMPILE_DISABLE` spoof that step sets, since it imports neither unsloth nor torch. It self-bootstraps `sys.path`.

No new dependencies. The job already installs everything the suite imports: `pydantic` and `uvicorn` (which brings `click`) via `studio/backend/requirements/studio.txt`, and `pyyaml` explicitly. Verified by resolving each import failure in a clean venv back to a package the job already installs.

## Verification

`python -m pytest unsloth_cli/tests -q` on this branch: **673 passed, 4 skipped**. On `main`: 4 failed, 669 passed.

## Known follow-up, not addressed here

`test_studio_run_parallel_flag.py` is order-dependent: run alone it fails 6 tests that pass in a full-directory run, on `main` today and unchanged by this PR. The CI step runs the whole directory in one invocation, which is the passing order, and I confirmed it is stable across repeated runs. Worth fixing separately, but silently papering over it inside a CI-enablement change seemed worse than naming it.