### PR TITLE
Make the unsloth_cli studio tests pass in isolation

### DIFF
--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -231,8 +231,6 @@ jobs:
         # Own step, not folded into the tests/ discovery above: pyproject's
         # testpaths is tests/, and this suite needs no PYTHONPATH or CUDA spoof
         # (it self-bootstraps sys.path and imports neither unsloth nor torch).
-        # Run the whole directory in one invocation; some files in it are
-        # order-dependent and only pass in a full-directory run.
         run: python -m pytest unsloth_cli/tests -q --tb=short
 
       - name: Shell installer tests

--- a/unsloth_cli/tests/conftest.py
+++ b/unsloth_cli/tests/conftest.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Shared fixtures for the unsloth_cli tests."""
+
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture
+def stub_tool_policy_state(monkeypatch):
+    """Stub the backend's `state.tool_policy`, which run() imports in-venv.
+
+    It lives under studio/backend, so it only imports once something has put
+    that directory on sys.path. Tests that reach the in-venv branch of run()
+    used to get that for free from whichever file ran earlier and did it as a
+    side effect, which made them pass only in a full-directory run.
+    """
+    state_mod = types.ModuleType("state")
+    tp_mod = types.ModuleType("state.tool_policy")
+    tp_mod.set_tool_policy = lambda *a, **k: None
+    state_mod.tool_policy = tp_mod
+    monkeypatch.setitem(sys.modules, "state", state_mod)
+    monkeypatch.setitem(sys.modules, "state.tool_policy", tp_mod)

--- a/unsloth_cli/tests/test_studio_run_parallel_flag.py
+++ b/unsloth_cli/tests/test_studio_run_parallel_flag.py
@@ -613,7 +613,9 @@ def test_studio_default_exposes_parallel_option():
 
 
 @pytest.mark.parametrize("value", [1, 4, 8, 64])
-def test_in_venv_path_passes_parallel_to_run_server(monkeypatch, value):
+def test_in_venv_path_passes_parallel_to_run_server(
+    monkeypatch, value, stub_tool_policy_state
+):
     """In-venv path must forward --parallel to
     run_server(llama_parallel_slots=N), not the old hardcoded 4."""
     studio_mod = _load_run_command()
@@ -706,7 +708,9 @@ def test_secure_api_only_is_refused_before_any_reexec(monkeypatch, tmp_path):
 
 
 @pytest.mark.parametrize("extra,expected", [(["--api-only"], True), ([], False)])
-def test_in_venv_path_passes_api_only_to_run_server(monkeypatch, extra, expected):
+def test_in_venv_path_passes_api_only_to_run_server(
+    monkeypatch, extra, expected, stub_tool_policy_state
+):
     """In-venv path must forward --api-only to run_server(api_only=...)."""
     studio_mod = _load_run_command()
 

--- a/unsloth_cli/tests/test_studio_run_parallel_flag.py
+++ b/unsloth_cli/tests/test_studio_run_parallel_flag.py
@@ -613,9 +613,7 @@ def test_studio_default_exposes_parallel_option():
 
 
 @pytest.mark.parametrize("value", [1, 4, 8, 64])
-def test_in_venv_path_passes_parallel_to_run_server(
-    monkeypatch, value, stub_tool_policy_state
-):
+def test_in_venv_path_passes_parallel_to_run_server(monkeypatch, value, stub_tool_policy_state):
     """In-venv path must forward --parallel to
     run_server(llama_parallel_slots=N), not the old hardcoded 4."""
     studio_mod = _load_run_command()

--- a/unsloth_cli/tests/test_studio_secure_flag.py
+++ b/unsloth_cli/tests/test_studio_secure_flag.py
@@ -244,9 +244,7 @@ class _RunServerCaptured(SystemExit):
         self.kwargs = dict(kwargs)
 
 
-def test_run_in_venv_passes_secure_and_forces_host(
-    monkeypatch, tmp_path, stub_tool_policy_state
-):
+def test_run_in_venv_passes_secure_and_forces_host(monkeypatch, tmp_path, stub_tool_policy_state):
     import types
 
     studio_mod = _studio()

--- a/unsloth_cli/tests/test_studio_secure_flag.py
+++ b/unsloth_cli/tests/test_studio_secure_flag.py
@@ -244,7 +244,9 @@ class _RunServerCaptured(SystemExit):
         self.kwargs = dict(kwargs)
 
 
-def test_run_in_venv_passes_secure_and_forces_host(monkeypatch, tmp_path):
+def test_run_in_venv_passes_secure_and_forces_host(
+    monkeypatch, tmp_path, stub_tool_policy_state
+):
     import types
 
     studio_mod = _studio()


### PR DESCRIPTION
Follow-up to #7598, which noted this and deliberately left it.

Seven tests only passed in a full-directory run. On `main` today:

```
pytest unsloth_cli/tests/test_studio_run_parallel_flag.py   ->  6 failed, 51 passed
pytest unsloth_cli/tests/test_studio_secure_flag.py         ->  1 failed, 24 passed
pytest unsloth_cli/tests                                    ->      673 passed
```

## Cause

All seven reach the in-venv branch of `run()`, which does:

```python
from state.tool_policy import set_tool_policy   # unsloth_cli/commands/studio.py:2228
```

`state` lives under `studio/backend`, so it only imports once something has put that directory on `sys.path`. Neither file does. They were getting it from whichever file happened to run first:

- `test_start.py` calls `ensure_studio_backend_path()`, a real `sys.path` mutation that is not monkeypatched and therefore leaks to every later test in the process.
- `test_studio_cloudflare_flag.py` stubs `state` and `state.tool_policy` in `sys.modules`.

Bisecting every other file in the directory as a predecessor confirmed it: those two, and only those two, make the file pass.

The symptom was silent. `CliRunner(catch_exceptions = True)` swallowed the `ModuleNotFoundError`, so `run_server` was simply never reached and the assertions read `captured == {}` with no hint of an import failure.

## Fix

A `stub_tool_policy_state` fixture in a new `unsloth_cli/tests/conftest.py` (the directory had none), used by the seven tests, so the state comes from the test rather than from whatever ran first. Same shape `test_studio_cloudflare_flag.py` already used inline.

## Verification

Every file in the directory now passes on its own:

```
test_claude_plan_gate.py                20 passed      test_start.py                          346 passed
test_claude_subagent_mcp.py             16 passed      test_studio_cloudflare_flag.py          20 passed
test_codex_subagent_mcp.py               8 passed      test_studio_password_prompt.py          67 passed
test_inference_chat.py                  46 passed      test_studio_run_parallel_flag.py        57 passed
test_pi_subagent.py                          passed    test_studio_run_short_alias_clashes.py  61 passed
test_studio_verbose_flag.py              7 passed      test_studio_secure_flag.py              25 passed
```

Whole directory: 673 passed, 4 skipped. Stable across four `pytest-randomly` seeds (1, 42, 777, 12345), which it was not before.

Also drops the line in the CI step comment from #7598 that described the order dependence, since it no longer holds.