### PR TITLE
CI: stop printing the reset passphrase into the agent-guides job logs

### DIFF
--- a/.github/workflows/local-agent-guides-ci.yml
+++ b/.github/workflows/local-agent-guides-ci.yml
@@ -167,7 +167,9 @@ jobs:
       # ── boot the server under test (factored helper) ──────────────────
       - name: Serve unsloth run --disable-tools (gemma-4-E4B)
         run: |
-          unsloth studio reset-password
+          # Wipe, not reset-password: since #7573 the reset rotates in place and
+          # prints the new passphrase, which would land unmasked in the job log.
+          rm -rf ~/.unsloth/studio/auth
           bash .github/scripts/serve-unsloth-run.sh \
             --gguf-file "$GITHUB_WORKSPACE/gguf-cache/${GGUF_FILE}" \
             --port "$STUDIO_PORT" --log-dir logs \
@@ -371,7 +373,7 @@ jobs:
 
       - name: Serve unsloth run --disable-tools (gemma-4-E4B)
         run: |
-          unsloth studio reset-password
+          rm -rf ~/.unsloth/studio/auth
           bash .github/scripts/serve-unsloth-run.sh \
             --gguf-file "$GITHUB_WORKSPACE/gguf-cache/${GGUF_FILE}" \
             --port "$STUDIO_PORT" --log-dir logs \
@@ -554,7 +556,7 @@ jobs:
 
       - name: Serve unsloth run --disable-tools (gemma-4-E4B)
         run: |
-          unsloth studio reset-password
+          rm -rf ~/.unsloth/studio/auth
           bash .github/scripts/serve-unsloth-run.sh \
             --gguf-file "$GITHUB_WORKSPACE/gguf-cache/${GGUF_FILE}" \
             --port "$STUDIO_PORT" --log-dir logs \
@@ -718,7 +720,7 @@ jobs:
 
       - name: Serve unsloth run --disable-tools (gemma-3-270m)
         run: |
-          unsloth studio reset-password
+          rm -rf ~/.unsloth/studio/auth
           bash .github/scripts/serve-unsloth-run.sh \
             --model "$GGUF_REPO" --gguf-variant "$GGUF_VARIANT" \
             --port "$STUDIO_PORT" --log-dir logs \


### PR DESCRIPTION
## Problem

`local-agent-guides-ci.yml` starts each of its four server-under-test steps with:

```yaml
- name: Serve unsloth run --disable-tools (gemma-4-E4B)
  run: |
    unsloth studio reset-password
    bash .github/scripts/serve-unsloth-run.sh ...
```

That was fine when `reset-password` deleted `auth.db` and printed nothing but `Auth database deleted.`. Since #7573 it rotates the credential in place and prints the generated passphrase to stdout:

```
New password for 'unsloth': PlazaPebblyAscertainMantra
```

There is no `::add-mask::` on it, so the value lands unmasked in the job log. It is a throwaway credential on an ephemeral runner, so this is hygiene rather than an incident, but there is no reason for a password to be in a log at all.

The second problem is that the step no longer does what its position implies. After a rotation `auth.db` survives, `must_change_password` is 0 and `.bootstrap_password` is gone, which is a *used* auth state, not a clean one.

## Fix

Swap the rotation for the wipe that the other ten `studio-*` workflows already use:

```yaml
run: |
  rm -rf ~/.unsloth/studio/auth
  bash .github/scripts/serve-unsloth-run.sh ...
```

#7573 converted every workflow that reads `.bootstrap_password` to this form and deliberately left these four alone because they do not read it. That was the right call for that PR's scope, but they still want a clean slate, so they should have moved too.

## Why this is safe

* `serve-unsloth-run.sh` has zero references to `password`, `.bootstrap_password` or `reset-password`. It waits for the banner and greps `sk-unsloth-[A-Za-z0-9_-]+` out of it, then `::add-mask::`s that key. Nothing in the step depends on the admin password.
* `unsloth run` mints its own API key in-process on every launch (`_create_api_key_inprocess` in `unsloth_cli/commands/studio.py`) and prints it on the `API Key:` line, so it is unaffected by the state of `auth.db`.
* With `auth/` removed, the backend re-seeds the admin row and a fresh `.bootstrap_password` at startup, which is the same path a first install takes.
* The path is right for this workflow: it sets no `UNSLOTH_STUDIO_HOME`, installs with `bash install.sh --local --no-torch`, and therefore lands on the default `~/.unsloth/studio`, matching what the other ten files hardcode.

`actionlint` is clean on the file, before and after.

This workflow lists itself under `paths:`, so opening this PR runs all four jobs against the change.
