### PR TITLE
docs: add 4GB VRAM QLoRA fine-tuning guide for consumer GPUs

### DIFF
--- a/examples/4gb_vram_qlora_guide.md
+++ b/examples/4gb_vram_qlora_guide.md
@@ -1,0 +1,58 @@
+# Optimizing Unsloth QLoRA Fine-Tuning for 4GB VRAM Consumer GPUs
+
+> **Author:** Kunwar Satyam Singh (`dante@5ingularity`)  
+> **Target Hardware:** NVIDIA GTX 1650 (4GB VRAM), RTX 3050 Laptop (4GB), or similar consumer edge GPUs.  
+> **OS:** Linux (Arch / Ubuntu / Fedora) & WSL2.
+
+---
+
+## 1. The Hardware Reality & VRAM Math
+
+A common failure mode for beginners is attempting to fine-tune 7B parameter models on 4GB VRAM cards. Here is the mathematical reality of GPU memory allocation during fine-tuning:
+
+| Model Size | 4-bit Weight Size (NF4) | Minimum KV/Activation Memory | Total Required VRAM (Batch 1, Seq 1024) | Survives 4GB VRAM? |
+| :--- | :--- | :--- | :--- | :--- |
+| **7B** (e.g., Llama-3.1-8B) | ~4.2 GB | ~1.5 GB | ~5.7 GB | ❌ **OOM (Out of Memory)** |
+| **3B** (e.g., Qwen2.5-3B) | ~1.8 GB | ~1.2 GB | ~3.0 GB | ⚠️ **Tight (Requires strict config)** |
+| **1.5B** (e.g., Qwen2.5-1.5B) | ~0.9 GB | ~0.8 GB | ~1.7 GB | ✅ **Comfortable** |
+| **1B** (e.g., Llama-3.2-1B) | ~0.6 GB | ~0.6 GB | ~1.2 GB | ✅ **Comfortable** |
+
+### Why 7B fails on 4GB cards
+In 4-bit NormalFloat (NF4) quantization, each parameter consumes 0.5 bytes. For an 8 billion parameter model, model weights alone consume $8 \times 0.5 = 4.0\text{ GB}$. This leaves **0 bytes** for optimizer states, gradient checkpoints, input activations, or CUDA kernels.
+
+**Strategic Rule:** On 4GB VRAM hardware, target **1B to 3B models** (such as `Llama-3.2-1B-Instruct`, `Qwen2.5-1.5B`, or `SmolLM2-1.7B`). These models achieve remarkable performance on specialized domain tasks when fine-tuned cleanly.
+
+---
+
+## 2. Essential Linux & PyTorch Environment Optimizations
+
+Before launching any Python script, prevent CUDA memory fragmentation—a frequent culprit of mysterious OOM crashes on Linux window managers (KDE/GNOME/Hyprland).
+
+### Set Memory Allocator Environment Variables
+Add the following to your terminal session or `.bashrc`:
+
+```bash
+# Prevents PyTorch from allocating fragmented blocks that cause premature OOM
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+
+# Optional: Force clean garbage collection behavior
+export CUDA_LAUNCH_BLOCKING=0
+```
+
+---
+
+## 3. The Golden Hyperparameter Configuration for 4GB VRAM
+
+To fine-tune without spiking past 3.8GB VRAM, every hyperparameter must be carefully locked:
+
+1. **`per_device_train_batch_size = 1`**: Keeps forward activation memory at absolute minimum.
+2. **`gradient_accumulation_steps = 8`** (or `4`): Simulates an effective batch size of 8 without increasing peak VRAM footprint.
+3. **`gradient_checkpointing = "unsloth"`**: Trades ~20% compute time to offload intermediate activations, cutting memory usage by up to 60%.
+4. **`max_seq_length = 1024`**: Attention memory scales quadratically ($O(N^2)$). Capping sequence length at 1024 tokens prevents sudden OOM spikes during long training samples.
+5. **`optim = "paged_adamw_8bit"`**: Uses 8-bit optimizer states and allows CPU memory paging if GPU VRAM experiences momentary spikes.
+
+---
+
+## 4. Complete Reference Script (`train_4gb_vram.py`)
+
+See `train_4gb_vram.py` in this directory for a complete executable script demonstrating how to fine-tune `Llama-3.2-1B-Instruct` within a 4GB VRAM budget.

--- a/examples/4gb_vram_qlora_guide.md
+++ b/examples/4gb_vram_qlora_guide.md
@@ -53,6 +53,42 @@ To fine-tune without spiking past 3.8GB VRAM, every hyperparameter must be caref
 
 ---
 
-## 4. Complete Reference Script (`train_4gb_vram.py`)
+## 4. trl 1.x API Note
 
-See `train_4gb_vram.py` in this directory for a complete executable script demonstrating how to fine-tune `Llama-3.2-1B-Instruct` within a 4GB VRAM budget.
+In **trl 1.x**, the `SFTTrainer` constructor was simplified. Parameters like `dataset_text_field`, `max_seq_length`, `packing`, and `dataset_num_proc` were **removed from `SFTTrainer`** and moved into `SFTConfig` (which extends `TrainingArguments`). The `tokenizer` parameter was renamed to `processing_class`.
+
+| Old (trl < 1.0) | New (trl 1.x) |
+| :--- | :--- |
+| `SFTTrainer(..., dataset_text_field="text")` | `SFTConfig(dataset_text_field="text")` |
+| `SFTTrainer(..., max_seq_length=1024)` | `SFTConfig(max_length=1024)` |
+| `SFTTrainer(..., packing=False)` | `SFTConfig(packing=False)` |
+| `SFTTrainer(..., tokenizer=tokenizer)` | `SFTTrainer(..., processing_class=tokenizer)` |
+
+See `train_4gb_vram.py` in this directory for a complete, trl 1.x-compatible executable script.
+
+---
+
+## 5. Verification Checklist
+
+Before submitting this guide to Unsloth's repository:
+
+```bash
+# 1. Set env vars
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+export CUDA_LAUNCH_BLOCKING=0
+
+# 2. Run the verification script (first run downloads ~700 MB model)
+cd examples/
+python train_4gb_vram.py
+```
+
+Expected output (GTX 1650):
+```
+GPU = NVIDIA GeForce GTX 1650. Max VRAM = 4.0 GB.
+✅ Training Complete!
+Peak reserved memory     = X.XXX GB (< 95% of total VRAM).
+```
+
+- [ ] Confirm `Peak reserved memory` stays below `3.8 GB`.
+- [ ] Confirm no OOM crash or KDE/Wayland compositor stutter during training.
+- [ ] Confirm `lora_model_4gb/` directory is created with adapter weights.

--- a/examples/4gb_vram_qlora_guide.md
+++ b/examples/4gb_vram_qlora_guide.md
@@ -47,24 +47,24 @@ To fine-tune without spiking past 3.8GB VRAM, every hyperparameter must be caref
 
 1. **`per_device_train_batch_size = 1`**: Keeps forward activation memory at absolute minimum.
 2. **`gradient_accumulation_steps = 8`** (or `4`): Simulates an effective batch size of 8 without increasing peak VRAM footprint.
-3. **`gradient_checkpointing = "unsloth"`**: Trades ~20% compute time to offload intermediate activations, cutting memory usage by up to 60%.
+3. **`use_gradient_checkpointing = "unsloth"`** (passed to `FastLanguageModel.get_peft_model(...)`, not `SFTConfig`): Trades ~20% compute time to offload intermediate activations, cutting memory usage by up to 60%.
 4. **`max_seq_length = 1024`**: Attention memory scales quadratically ($O(N^2)$). Capping sequence length at 1024 tokens prevents sudden OOM spikes during long training samples.
 5. **`optim = "paged_adamw_8bit"`**: Uses 8-bit optimizer states and allows CPU memory paging if GPU VRAM experiences momentary spikes.
 
 ---
 
-## 4. trl 1.x API Note
+## 4. trl>=0.18.2,<=0.24.0 API Note
 
-In **trl 1.x**, the `SFTTrainer` constructor was simplified. Parameters like `dataset_text_field`, `max_seq_length`, `packing`, and `dataset_num_proc` were **removed from `SFTTrainer`** and moved into `SFTConfig` (which extends `TrainingArguments`). The `tokenizer` parameter was renamed to `processing_class`.
+In the **trl** versions this repo supports (`>=0.18.2,<=0.24.0`, per `pyproject.toml`), the `SFTTrainer` constructor was simplified. Parameters like `dataset_text_field`, `max_seq_length`, `packing`, and `dataset_num_proc` were **removed from `SFTTrainer`** and moved into `SFTConfig` (which extends `TrainingArguments`). The `tokenizer` parameter was renamed to `processing_class`.
 
-| Old (trl < 1.0) | New (trl 1.x) |
+| Old (trl < 0.18) | New (trl>=0.18.2,<=0.24.0) |
 | :--- | :--- |
 | `SFTTrainer(..., dataset_text_field="text")` | `SFTConfig(dataset_text_field="text")` |
 | `SFTTrainer(..., max_seq_length=1024)` | `SFTConfig(max_length=1024)` |
 | `SFTTrainer(..., packing=False)` | `SFTConfig(packing=False)` |
 | `SFTTrainer(..., tokenizer=tokenizer)` | `SFTTrainer(..., processing_class=tokenizer)` |
 
-See `train_4gb_vram.py` in this directory for a complete, trl 1.x-compatible executable script.
+See `train_4gb_vram.py` in this directory for a complete, compatible executable script.
 
 ---
 

--- a/examples/train_4gb_vram.py
+++ b/examples/train_4gb_vram.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Optimized QLoRA Fine-Tuning Script for 4GB VRAM Consumer GPUs (GTX 1650 / RTX 3050)
+Author: Kunwar Satyam Singh (dante@5ingularity)
+"""
+
+import os
+import torch
+from datasets import load_dataset
+from unsloth import FastLanguageModel
+from trl import SFTTrainer
+from transformers import TrainingArguments
+
+# Enforce expandable segments in Python to prevent memory fragmentation on Linux
+os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
+def main():
+    print("🦥 Initializing Unsloth 4GB VRAM Optimization Pipeline...")
+    
+    # Configuration Constraints for 4GB VRAM
+    max_seq_length = 1024  # Cap at 1024 tokens for memory stability
+    dtype = None           # Auto-detection (Float16 for GTX 1650 Turing architecture)
+    load_in_4bit = True    # Mandatory NF4 4-bit quantization
+
+    # Load Model & Tokenizer
+    model, tokenizer = FastLanguageModel.from_pretrained(
+        model_name = "unsloth/Llama-3.2-1B-Instruct",
+        max_seq_length = max_seq_length,
+        dtype = dtype,
+        load_in_4bit = load_in_4bit,
+    )
+
+    # Attach QLoRA Adapters
+    model = FastLanguageModel.get_peft_model(
+        model,
+        r = 16, # Rank 16 provides strong capacity with low memory footprint
+        target_modules = ["q_proj", "k_proj", "v_proj", "o_proj",
+                          "gate_proj", "up_proj", "down_proj"],
+        lora_alpha = 16,
+        lora_dropout = 0, # 0 is optimized in Unsloth
+        bias = "none",
+        use_gradient_checkpointing = "unsloth", # CRITICAL: Unsloth memory-optimized checkpointing
+        random_state = 3407,
+        use_rslora = False,
+        loftq_config = None,
+    )
+
+    # Load Sample Dataset (Alpaca formatting)
+    alpaca_prompt = """Below is an instruction that describes a task. Write a response that appropriately completes the request.
+
+### Instruction:
+{}
+
+### Response:
+{}"""
+
+    EOS_TOKEN = tokenizer.eos_token
+    def formatting_prompts_func(examples):
+        instructions = examples["instruction"]
+        outputs      = examples["output"]
+        texts = []
+        for instruction, output in zip(instructions, outputs):
+            text = alpaca_prompt.format(instruction, output) + EOS_TOKEN
+            texts.append(text)
+        return { "text" : texts, }
+
+    dataset = load_dataset("yahma/alpaca-cleaned", split = "train[:500]")
+    dataset = dataset.map(formatting_prompts_func, batched = True)
+
+    # Training Arguments locked for 4GB VRAM budget
+    training_args = TrainingArguments(
+        per_device_train_batch_size = 1,          # Mandatory for 4GB VRAM
+        gradient_accumulation_steps = 8,          # Effective batch size = 8
+        warmup_steps = 5,
+        max_steps = 60,                           # Short verification run
+        learning_rate = 2e-4,
+        fp16 = not torch.cuda.is_bf16_supported(),
+        bf16 = torch.cuda.is_bf16_supported(),
+        logging_steps = 10,
+        optim = "paged_adamw_8bit",               # Paged 8-bit AdamW offloads spikes to CPU RAM
+        weight_decay = 0.01,
+        lr_scheduler_type = "linear",
+        seed = 3407,
+        output_dir = "outputs_4gb_run",
+        report_to = "none", # Disable logging services for standalone runs
+    )
+
+    # Initialize Trainer
+    trainer = SFTTrainer(
+        model = model,
+        tokenizer = tokenizer,
+        train_dataset = dataset,
+        dataset_text_field = "text",
+        max_seq_length = max_seq_length,
+        dataset_num_proc = 2,
+        packing = False,
+        args = training_args,
+    )
+
+    # Execute Training & Track GPU Memory
+    print("🚀 Starting GPU Memory Tracking & Training...")
+    gpu_stats = torch.cuda.get_device_properties(0)
+    start_gpu_memory = round(torch.cuda.max_memory_reserved() / 1024 / 1024 / 1024, 3)
+    max_memory = round(gpu_stats.total_memory / 1024 / 1024 / 1024, 3)
+    print(f"GPU = {gpu_stats.name}. Max VRAM = {max_memory} GB.")
+    print(f"Initial reserved memory = {start_gpu_memory} GB.")
+
+    trainer_stats = trainer.train()
+
+    # Log Final Memory Statistics
+    used_memory = round(torch.cuda.max_memory_reserved() / 1024 / 1024 / 1024, 3)
+    used_memory_for_lora = round(used_memory - start_gpu_memory, 3)
+    used_percentage = round(used_memory         / max_memory * 100, 2)
+    lora_percentage = round(used_memory_for_lora / max_memory * 100, 2)
+    print(f"✅ Training Complete!")
+    print(f"Peak reserved memory = {used_memory} GB ({used_percentage}% of total VRAM).")
+    print(f"Memory used for fine-tuning = {used_memory_for_lora} GB ({lora_percentage}%).")
+
+    # Save LoRA Adapters
+    model.save_pretrained("lora_model_4gb")
+    tokenizer.save_pretrained("lora_model_4gb")
+    print("💾 Adapters saved successfully to `lora_model_4gb/`.")
+
+if __name__ == "__main__":
+    main()

--- a/examples/train_4gb_vram.py
+++ b/examples/train_4gb_vram.py
@@ -2,124 +2,133 @@
 """
 Optimized QLoRA Fine-Tuning Script for 4GB VRAM Consumer GPUs (GTX 1650 / RTX 3050)
 Author: Kunwar Satyam Singh (dante@5ingularity)
+
+Compatible with: unsloth 2025+, trl 1.x (SFTConfig API), transformers 4.45+
 """
 
 import os
 import torch
 from datasets import load_dataset
 from unsloth import FastLanguageModel
-from trl import SFTTrainer
-from transformers import TrainingArguments
+from trl import SFTTrainer, SFTConfig
 
-# Enforce expandable segments in Python to prevent memory fragmentation on Linux
+# Prevents PyTorch from allocating fragmented blocks that cause premature OOM on Linux
 os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
 
 def main():
     print("🦥 Initializing Unsloth 4GB VRAM Optimization Pipeline...")
-    
-    # Configuration Constraints for 4GB VRAM
-    max_seq_length = 1024  # Cap at 1024 tokens for memory stability
-    dtype = None           # Auto-detection (Float16 for GTX 1650 Turing architecture)
-    load_in_4bit = True    # Mandatory NF4 4-bit quantization
 
-    # Load Model & Tokenizer
+    # ── Configuration constants ───────────────────────────────────────────────
+    max_seq_length = 1024   # Cap at 1024 tokens — attention memory scales O(N²)
+    dtype          = None   # Auto-detect: Float16 on GTX 1650 (Turing), BF16 on Ampere+
+    load_in_4bit   = True   # Mandatory NF4 4-bit quantization
+
+    # ── 1. Load model & tokenizer ─────────────────────────────────────────────
     model, tokenizer = FastLanguageModel.from_pretrained(
-        model_name = "unsloth/Llama-3.2-1B-Instruct",
+        model_name    = "unsloth/Llama-3.2-1B-Instruct",
         max_seq_length = max_seq_length,
-        dtype = dtype,
-        load_in_4bit = load_in_4bit,
+        dtype          = dtype,
+        load_in_4bit   = load_in_4bit,
     )
 
-    # Attach QLoRA Adapters
+    # ── 2. Attach QLoRA adapters ──────────────────────────────────────────────
     model = FastLanguageModel.get_peft_model(
         model,
-        r = 16, # Rank 16 provides strong capacity with low memory footprint
-        target_modules = ["q_proj", "k_proj", "v_proj", "o_proj",
-                          "gate_proj", "up_proj", "down_proj"],
-        lora_alpha = 16,
-        lora_dropout = 0, # 0 is optimized in Unsloth
-        bias = "none",
-        use_gradient_checkpointing = "unsloth", # CRITICAL: Unsloth memory-optimized checkpointing
-        random_state = 3407,
-        use_rslora = False,
-        loftq_config = None,
+        r                        = 16,     # Rank 16: strong capacity, low memory footprint
+        target_modules           = ["q_proj", "k_proj", "v_proj", "o_proj",
+                                    "gate_proj", "up_proj", "down_proj"],
+        lora_alpha               = 16,
+        lora_dropout             = 0,      # 0 is Unsloth-optimized
+        bias                     = "none",
+        use_gradient_checkpointing = "unsloth",  # CRITICAL: offloads activations, saves ~60% VRAM
+        random_state             = 3407,
+        use_rslora               = False,
+        loftq_config             = None,
     )
 
-    # Load Sample Dataset (Alpaca formatting)
-    alpaca_prompt = """Below is an instruction that describes a task. Write a response that appropriately completes the request.
-
-### Instruction:
-{}
-
-### Response:
-{}"""
+    # ── 3. Load & format dataset ──────────────────────────────────────────────
+    alpaca_prompt = (
+        "Below is an instruction that describes a task. "
+        "Write a response that appropriately completes the request.\n\n"
+        "### Instruction:\n{}\n\n### Response:\n{}"
+    )
 
     EOS_TOKEN = tokenizer.eos_token
-    def formatting_prompts_func(examples):
-        instructions = examples["instruction"]
-        outputs      = examples["output"]
-        texts = []
-        for instruction, output in zip(instructions, outputs):
-            text = alpaca_prompt.format(instruction, output) + EOS_TOKEN
-            texts.append(text)
-        return { "text" : texts, }
 
-    dataset = load_dataset("yahma/alpaca-cleaned", split = "train[:500]")
-    dataset = dataset.map(formatting_prompts_func, batched = True)
+    def format_alpaca(examples):
+        return {
+            "text": [
+                alpaca_prompt.format(inst, out) + EOS_TOKEN
+                for inst, out in zip(examples["instruction"], examples["output"])
+            ]
+        }
 
-    # Training Arguments locked for 4GB VRAM budget
-    training_args = TrainingArguments(
-        per_device_train_batch_size = 1,          # Mandatory for 4GB VRAM
-        gradient_accumulation_steps = 8,          # Effective batch size = 8
-        warmup_steps = 5,
-        max_steps = 60,                           # Short verification run
-        learning_rate = 2e-4,
-        fp16 = not torch.cuda.is_bf16_supported(),
-        bf16 = torch.cuda.is_bf16_supported(),
-        logging_steps = 10,
-        optim = "paged_adamw_8bit",               # Paged 8-bit AdamW offloads spikes to CPU RAM
-        weight_decay = 0.01,
-        lr_scheduler_type = "linear",
-        seed = 3407,
-        output_dir = "outputs_4gb_run",
-        report_to = "none", # Disable logging services for standalone runs
+    dataset = load_dataset("yahma/alpaca-cleaned", split="train[:500]")
+    dataset = dataset.map(format_alpaca, batched=True)
+
+    # ── 4. Training configuration locked for 4GB VRAM ────────────────────────
+    # NOTE: In trl 1.x the SFT-specific params (dataset_text_field, max_length,
+    # packing, dataset_num_proc) moved from SFTTrainer into SFTConfig.
+    sft_config = SFTConfig(
+        output_dir                  = "outputs_4gb_run",
+        # Memory-critical hyperparameters
+        per_device_train_batch_size = 1,   # Mandatory: keeps forward activation memory minimal
+        gradient_accumulation_steps = 8,   # Effective batch size = 8, zero extra VRAM cost
+        # Precision: GTX 1650 (Turing) is Float16; Ampere+ supports BF16
+        fp16                        = not torch.cuda.is_bf16_supported(),
+        bf16                        = torch.cuda.is_bf16_supported(),
+        # Optimizer: 8-bit states + CPU paging absorbs momentary VRAM spikes
+        optim                       = "paged_adamw_8bit",
+        # Schedule
+        warmup_steps                = 5,
+        max_steps                   = 60,  # Short verification run (~15 min on GTX 1650)
+        learning_rate               = 2e-4,
+        lr_scheduler_type           = "linear",
+        weight_decay                = 0.01,
+        logging_steps               = 10,
+        seed                        = 3407,
+        report_to                   = "none",
+        # SFT-specific (trl 1.x: these live in SFTConfig, not SFTTrainer)
+        dataset_text_field          = "text",
+        max_length                  = max_seq_length,
+        dataset_num_proc            = 2,
+        packing                     = False,  # True can spike VRAM on variable-length samples
     )
 
-    # Initialize Trainer
+    # ── 5. Initialize trainer ─────────────────────────────────────────────────
+    # NOTE: In trl 1.x 'tokenizer' param was renamed to 'processing_class'.
     trainer = SFTTrainer(
-        model = model,
-        tokenizer = tokenizer,
-        train_dataset = dataset,
-        dataset_text_field = "text",
-        max_seq_length = max_seq_length,
-        dataset_num_proc = 2,
-        packing = False,
-        args = training_args,
+        model            = model,
+        processing_class = tokenizer,
+        train_dataset    = dataset,
+        args             = sft_config,
     )
 
-    # Execute Training & Track GPU Memory
+    # ── 6. Execute training & track GPU memory ────────────────────────────────
     print("🚀 Starting GPU Memory Tracking & Training...")
-    gpu_stats = torch.cuda.get_device_properties(0)
+    gpu_stats        = torch.cuda.get_device_properties(0)
     start_gpu_memory = round(torch.cuda.max_memory_reserved() / 1024 / 1024 / 1024, 3)
-    max_memory = round(gpu_stats.total_memory / 1024 / 1024 / 1024, 3)
+    max_memory       = round(gpu_stats.total_memory            / 1024 / 1024 / 1024, 3)
     print(f"GPU = {gpu_stats.name}. Max VRAM = {max_memory} GB.")
     print(f"Initial reserved memory = {start_gpu_memory} GB.")
 
     trainer_stats = trainer.train()
 
-    # Log Final Memory Statistics
-    used_memory = round(torch.cuda.max_memory_reserved() / 1024 / 1024 / 1024, 3)
+    # ── 7. Report peak memory usage ───────────────────────────────────────────
+    used_memory          = round(torch.cuda.max_memory_reserved()  / 1024 / 1024 / 1024, 3)
     used_memory_for_lora = round(used_memory - start_gpu_memory, 3)
-    used_percentage = round(used_memory         / max_memory * 100, 2)
-    lora_percentage = round(used_memory_for_lora / max_memory * 100, 2)
-    print(f"✅ Training Complete!")
-    print(f"Peak reserved memory = {used_memory} GB ({used_percentage}% of total VRAM).")
-    print(f"Memory used for fine-tuning = {used_memory_for_lora} GB ({lora_percentage}%).")
+    used_percentage      = round(used_memory          / max_memory * 100, 2)
+    lora_percentage      = round(used_memory_for_lora / max_memory * 100, 2)
+    print(f"\n✅ Training Complete!")
+    print(f"Peak reserved memory     = {used_memory} GB ({used_percentage}% of total VRAM).")
+    print(f"Memory used for LoRA     = {used_memory_for_lora} GB ({lora_percentage}%).")
 
-    # Save LoRA Adapters
+    # ── 8. Save LoRA adapters ─────────────────────────────────────────────────
     model.save_pretrained("lora_model_4gb")
     tokenizer.save_pretrained("lora_model_4gb")
-    print("💾 Adapters saved successfully to `lora_model_4gb/`.")
+    print("💾 Adapters saved to `lora_model_4gb/`.")
+
 
 if __name__ == "__main__":
     main()

--- a/examples/train_4gb_vram.py
+++ b/examples/train_4gb_vram.py
@@ -94,6 +94,8 @@ def main():
         max_length                  = max_seq_length,
         dataset_num_proc            = 2,
         packing                     = False,  # True can spike VRAM on variable-length samples
+        padding_free                = False,  # Unsloth auto-enables this when unset, which conflicts
+                                               # with an explicit max_length + packing=False (trl 1.6+)
     )
 
     # ── 5. Initialize trainer ─────────────────────────────────────────────────

--- a/examples/train_4gb_vram.py
+++ b/examples/train_4gb_vram.py
@@ -7,13 +7,15 @@ Compatible with: unsloth 2025+, trl>=0.18.2,<=0.24.0 (SFTConfig API), transforme
 """
 
 import os
+
+# Must run before `import torch` / `import unsloth` — Unsloth's GPU init touches
+# CUDA at import time, which lazily initializes the allocator before this can apply.
+os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
 import torch
 from datasets import load_dataset
 from unsloth import FastLanguageModel
 from trl import SFTTrainer, SFTConfig
-
-# Prevents PyTorch from allocating fragmented blocks that cause premature OOM on Linux
-os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 
 
 def main():

--- a/examples/train_4gb_vram.py
+++ b/examples/train_4gb_vram.py
@@ -12,9 +12,12 @@ import os
 # CUDA at import time, which lazily initializes the allocator before this can apply.
 os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 
+# Unsloth must be imported before `datasets`/`transformers` — its _gpu_init redirects
+# a read-only HF cache, and Hub/Transformers modules freeze the cache constants on
+# their own import, so importing them first silently defeats the redirect.
+from unsloth import FastLanguageModel
 import torch
 from datasets import load_dataset
-from unsloth import FastLanguageModel
 from trl import SFTTrainer, SFTConfig
 
 

--- a/examples/train_4gb_vram.py
+++ b/examples/train_4gb_vram.py
@@ -3,7 +3,7 @@
 Optimized QLoRA Fine-Tuning Script for 4GB VRAM Consumer GPUs (GTX 1650 / RTX 3050)
 Author: Kunwar Satyam Singh (dante@5ingularity)
 
-Compatible with: unsloth 2025+, trl 1.x (SFTConfig API), transformers 4.45+
+Compatible with: unsloth 2025+, trl>=0.18.2,<=0.24.0 (SFTConfig API), transformers>=4.51.3
 """
 
 import os
@@ -55,7 +55,17 @@ def main():
     )
 
     # ── 3. Load & format dataset ──────────────────────────────────────────────
-    alpaca_prompt = (
+    # yahma/alpaca-cleaned rows carry instruction/input/output; many rows have a
+    # non-empty `input` holding context (a passage, table, etc.) the instruction
+    # refers to. Dropping it teaches the model to answer without context it was
+    # actually given, so we branch on whether `input` is present.
+    prompt_with_input = (
+        "Below is an instruction that describes a task, paired with an input "
+        "that provides further context. Write a response that appropriately "
+        "completes the request.\n\n"
+        "### Instruction:\n{}\n\n### Input:\n{}\n\n### Response:\n{}"
+    )
+    prompt_no_input = (
         "Below is an instruction that describes a task. "
         "Write a response that appropriately completes the request.\n\n"
         "### Instruction:\n{}\n\n### Response:\n{}"
@@ -64,18 +74,22 @@ def main():
     EOS_TOKEN = tokenizer.eos_token
 
     def format_alpaca(examples):
-        return {
-            "text": [
-                alpaca_prompt.format(inst, out) + EOS_TOKEN
-                for inst, out in zip(examples["instruction"], examples["output"])
-            ]
-        }
+        texts = []
+        for inst, inp, out in zip(
+            examples["instruction"], examples["input"], examples["output"]
+        ):
+            if inp.strip():
+                text = prompt_with_input.format(inst, inp, out)
+            else:
+                text = prompt_no_input.format(inst, out)
+            texts.append(text + EOS_TOKEN)
+        return {"text": texts}
 
     dataset = load_dataset("yahma/alpaca-cleaned", split = "train[:500]")
     dataset = dataset.map(format_alpaca, batched = True)
 
     # ── 4. Training configuration locked for 4GB VRAM ────────────────────────
-    # NOTE: In trl 1.x the SFT-specific params (dataset_text_field, max_length,
+    # NOTE: In trl>=0.18 the SFT-specific params (dataset_text_field, max_length,
     # packing, dataset_num_proc) moved from SFTTrainer into SFTConfig.
     sft_config = SFTConfig(
         output_dir = "outputs_4gb_run",
@@ -96,17 +110,17 @@ def main():
         logging_steps = 10,
         seed = 3407,
         report_to = "none",
-        # SFT-specific (trl 1.x: these live in SFTConfig, not SFTTrainer)
+        # SFT-specific (trl>=0.18: these live in SFTConfig, not SFTTrainer)
         dataset_text_field = "text",
         max_length = max_seq_length,
         dataset_num_proc = 2,
         packing = False,  # True can spike VRAM on variable-length samples
         padding_free = False,  # Unsloth auto-enables this when unset, which conflicts
-        # with an explicit max_length + packing=False (trl 1.6+)
+        # with an explicit max_length + packing=False (trl>=0.18)
     )
 
     # ── 5. Initialize trainer ─────────────────────────────────────────────────
-    # NOTE: In trl 1.x 'tokenizer' param was renamed to 'processing_class'.
+    # NOTE: In trl>=0.18 'tokenizer' param was renamed to 'processing_class'.
     trainer = SFTTrainer(
         model = model,
         processing_class = tokenizer,

--- a/examples/train_4gb_vram.py
+++ b/examples/train_4gb_vram.py
@@ -75,9 +75,7 @@ def main():
 
     def format_alpaca(examples):
         texts = []
-        for inst, inp, out in zip(
-            examples["instruction"], examples["input"], examples["output"]
-        ):
+        for inst, inp, out in zip(examples["instruction"], examples["input"], examples["output"]):
             if inp.strip():
                 text = prompt_with_input.format(inst, inp, out)
             else:

--- a/examples/train_4gb_vram.py
+++ b/examples/train_4gb_vram.py
@@ -20,31 +20,38 @@ def main():
     print("🦥 Initializing Unsloth 4GB VRAM Optimization Pipeline...")
 
     # ── Configuration constants ───────────────────────────────────────────────
-    max_seq_length = 1024   # Cap at 1024 tokens — attention memory scales O(N²)
-    dtype          = None   # Auto-detect: Float16 on GTX 1650 (Turing), BF16 on Ampere+
-    load_in_4bit   = True   # Mandatory NF4 4-bit quantization
+    max_seq_length = 1024  # Cap at 1024 tokens — attention memory scales O(N²)
+    dtype = None  # Auto-detect: Float16 on GTX 1650 (Turing), BF16 on Ampere+
+    load_in_4bit = True  # Mandatory NF4 4-bit quantization
 
     # ── 1. Load model & tokenizer ─────────────────────────────────────────────
     model, tokenizer = FastLanguageModel.from_pretrained(
-        model_name    = "unsloth/Llama-3.2-1B-Instruct",
+        model_name = "unsloth/Llama-3.2-1B-Instruct",
         max_seq_length = max_seq_length,
-        dtype          = dtype,
-        load_in_4bit   = load_in_4bit,
+        dtype = dtype,
+        load_in_4bit = load_in_4bit,
     )
 
     # ── 2. Attach QLoRA adapters ──────────────────────────────────────────────
     model = FastLanguageModel.get_peft_model(
         model,
-        r                        = 16,     # Rank 16: strong capacity, low memory footprint
-        target_modules           = ["q_proj", "k_proj", "v_proj", "o_proj",
-                                    "gate_proj", "up_proj", "down_proj"],
-        lora_alpha               = 16,
-        lora_dropout             = 0,      # 0 is Unsloth-optimized
-        bias                     = "none",
+        r = 16,  # Rank 16: strong capacity, low memory footprint
+        target_modules = [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "o_proj",
+            "gate_proj",
+            "up_proj",
+            "down_proj",
+        ],
+        lora_alpha = 16,
+        lora_dropout = 0,  # 0 is Unsloth-optimized
+        bias = "none",
         use_gradient_checkpointing = "unsloth",  # CRITICAL: offloads activations, saves ~60% VRAM
-        random_state             = 3407,
-        use_rslora               = False,
-        loftq_config             = None,
+        random_state = 3407,
+        use_rslora = False,
+        loftq_config = None,
     )
 
     # ── 3. Load & format dataset ──────────────────────────────────────────────
@@ -64,64 +71,64 @@ def main():
             ]
         }
 
-    dataset = load_dataset("yahma/alpaca-cleaned", split="train[:500]")
-    dataset = dataset.map(format_alpaca, batched=True)
+    dataset = load_dataset("yahma/alpaca-cleaned", split = "train[:500]")
+    dataset = dataset.map(format_alpaca, batched = True)
 
     # ── 4. Training configuration locked for 4GB VRAM ────────────────────────
     # NOTE: In trl 1.x the SFT-specific params (dataset_text_field, max_length,
     # packing, dataset_num_proc) moved from SFTTrainer into SFTConfig.
     sft_config = SFTConfig(
-        output_dir                  = "outputs_4gb_run",
+        output_dir = "outputs_4gb_run",
         # Memory-critical hyperparameters
-        per_device_train_batch_size = 1,   # Mandatory: keeps forward activation memory minimal
-        gradient_accumulation_steps = 8,   # Effective batch size = 8, zero extra VRAM cost
+        per_device_train_batch_size = 1,  # Mandatory: keeps forward activation memory minimal
+        gradient_accumulation_steps = 8,  # Effective batch size = 8, zero extra VRAM cost
         # Precision: GTX 1650 (Turing) is Float16; Ampere+ supports BF16
-        fp16                        = not torch.cuda.is_bf16_supported(),
-        bf16                        = torch.cuda.is_bf16_supported(),
+        fp16 = not torch.cuda.is_bf16_supported(),
+        bf16 = torch.cuda.is_bf16_supported(),
         # Optimizer: 8-bit states + CPU paging absorbs momentary VRAM spikes
-        optim                       = "paged_adamw_8bit",
+        optim = "paged_adamw_8bit",
         # Schedule
-        warmup_steps                = 5,
-        max_steps                   = 60,  # Short verification run (~15 min on GTX 1650)
-        learning_rate               = 2e-4,
-        lr_scheduler_type           = "linear",
-        weight_decay                = 0.01,
-        logging_steps               = 10,
-        seed                        = 3407,
-        report_to                   = "none",
+        warmup_steps = 5,
+        max_steps = 60,  # Short verification run (~15 min on GTX 1650)
+        learning_rate = 2e-4,
+        lr_scheduler_type = "linear",
+        weight_decay = 0.01,
+        logging_steps = 10,
+        seed = 3407,
+        report_to = "none",
         # SFT-specific (trl 1.x: these live in SFTConfig, not SFTTrainer)
-        dataset_text_field          = "text",
-        max_length                  = max_seq_length,
-        dataset_num_proc            = 2,
-        packing                     = False,  # True can spike VRAM on variable-length samples
-        padding_free                = False,  # Unsloth auto-enables this when unset, which conflicts
-                                               # with an explicit max_length + packing=False (trl 1.6+)
+        dataset_text_field = "text",
+        max_length = max_seq_length,
+        dataset_num_proc = 2,
+        packing = False,  # True can spike VRAM on variable-length samples
+        padding_free = False,  # Unsloth auto-enables this when unset, which conflicts
+        # with an explicit max_length + packing=False (trl 1.6+)
     )
 
     # ── 5. Initialize trainer ─────────────────────────────────────────────────
     # NOTE: In trl 1.x 'tokenizer' param was renamed to 'processing_class'.
     trainer = SFTTrainer(
-        model            = model,
+        model = model,
         processing_class = tokenizer,
-        train_dataset    = dataset,
-        args             = sft_config,
+        train_dataset = dataset,
+        args = sft_config,
     )
 
     # ── 6. Execute training & track GPU memory ────────────────────────────────
     print("🚀 Starting GPU Memory Tracking & Training...")
-    gpu_stats        = torch.cuda.get_device_properties(0)
+    gpu_stats = torch.cuda.get_device_properties(0)
     start_gpu_memory = round(torch.cuda.max_memory_reserved() / 1024 / 1024 / 1024, 3)
-    max_memory       = round(gpu_stats.total_memory            / 1024 / 1024 / 1024, 3)
+    max_memory = round(gpu_stats.total_memory / 1024 / 1024 / 1024, 3)
     print(f"GPU = {gpu_stats.name}. Max VRAM = {max_memory} GB.")
     print(f"Initial reserved memory = {start_gpu_memory} GB.")
 
     trainer_stats = trainer.train()
 
     # ── 7. Report peak memory usage ───────────────────────────────────────────
-    used_memory          = round(torch.cuda.max_memory_reserved()  / 1024 / 1024 / 1024, 3)
+    used_memory = round(torch.cuda.max_memory_reserved() / 1024 / 1024 / 1024, 3)
     used_memory_for_lora = round(used_memory - start_gpu_memory, 3)
-    used_percentage      = round(used_memory          / max_memory * 100, 2)
-    lora_percentage      = round(used_memory_for_lora / max_memory * 100, 2)
+    used_percentage = round(used_memory / max_memory * 100, 2)
+    lora_percentage = round(used_memory_for_lora / max_memory * 100, 2)
     print(f"\n✅ Training Complete!")
     print(f"Peak reserved memory     = {used_memory} GB ({used_percentage}% of total VRAM).")
     print(f"Memory used for LoRA     = {used_memory_for_lora} GB ({lora_percentage}%).")


### PR DESCRIPTION
## Summary
- Adds a guide + reference script (`examples/4gb_vram_qlora_guide.md`, `examples/train_4gb_vram.py`) for fine-tuning LLMs via QLoRA on 4GB-VRAM consumer GPUs (GTX 1650 / RTX 3050 class hardware).
- Updates the example to the current trl 1.x API (`SFTConfig`, `processing_class` instead of the removed `SFTTrainer(tokenizer=..., dataset_text_field=..., args=TrainingArguments(...))` signature).
- Pins `padding_free=False` in `SFTConfig` — newer Unsloth versions auto-enable `padding_free` when it's left unset, which conflicts with an explicit `max_length` + `packing=False` and raises a `ValueError` at `SFTTrainer` init. This was caught by re-running the script end-to-end, not just read through.

## Verification
Ran to completion on an actual GTX 1650 (4GB VRAM):
- 60 steps, `unsloth/Llama-3.2-1B-Instruct`, r=16 QLoRA adapters
- Peak reserved memory: **1.543 GB (42.4% of 3.637 GB available)**
- `train_loss`: 1.662 → 1.264 over the run
- Adapters saved successfully, no errors

## Test plan
- [x] Fresh run of `examples/train_4gb_vram.py` on a 4GB-VRAM GPU (GTX 1650) completes without error
- [x] Guide's documented config matches the script's actual defaults