### PR TITLE
Extract Get-HostMachineArch for the setup.ps1 Pester suite

### DIFF
--- a/tests/studio_setup_ps1/Studio.Setup.Vs2026.Tests.ps1
+++ b/tests/studio_setup_ps1/Studio.Setup.Vs2026.Tests.ps1
@@ -30,7 +30,8 @@ BeforeAll {
     foreach ($fn in @('Resolve-VsGeneratorFromLabel', 'Find-VsBuildTools', 'Get-VcBuildCustomizationsDir',
                       'Test-CmakeSupportsGenerator', 'Get-CmakeVersion', 'Test-CmakeListsGenerator',
                       'Test-CmakeCanDriveGenerator', 'Get-FallbackVsGenerator',
-                      'Ensure-BuildToolsForLlamaSourceBuild', 'Test-VCRedistInstalled')) {
+                      'Ensure-BuildToolsForLlamaSourceBuild', 'Test-VCRedistInstalled',
+                      'Get-HostMachineArch')) {
         $src = Get-FunctionSource -Path $script:SetupPs1 -Name $fn
         if (-not $src) { throw "Function '$fn' not found in $script:SetupPs1 - cannot test the real code." }
         . ([scriptblock]::Create($src))


### PR DESCRIPTION
## Summary

`setup.ps1 unit tests (VS 2026 / CMake guard)` is failing on main and on every open PR, including PRs that touch no PowerShell at all.

`Test-VCRedistInstalled` (`studio/setup.ps1:887`) calls `Get-HostMachineArch` at line 897 to short-circuit on arm64. The Pester suite extracts the functions under test by name and dot-sources each one, and `Get-HostMachineArch` was never added to that list, so the call resolves to nothing:

```
CommandNotFoundException: The term 'Get-HostMachineArch' is not recognized as a name of a cmdlet, function, script file, or executable program.
Pester run failed, because 2 tests failed
```

Adding it to the extraction list is the whole fix. `studio/setup.ps1` is unchanged.

The three Windows install jobs (`VC++ runtime detect + install round-trip` on `windows-latest` and `windows-2025-vs2026`, and `JSON, images`) fail alongside it, since they exercise the same VC++ runtime detection path.

## Test plan

Run under a real pwsh host, against `tests/studio_setup_ps1/Studio.Setup.Vs2026.Tests.ps1`:

- Before: `Passed=28 Failed=3`, all three in `Test-VCRedistInstalled`
- After: `Passed=31 Failed=0`
