### PR TITLE
Use leading-tight on the truncating sidebar model name

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1242,7 +1242,7 @@ export function AppSidebar() {
                     alt="Unsloth"
                     className="h-[calc(26px+0.5rem*var(--ui-font-scale,1))] w-[calc(26px+0.5rem*var(--ui-font-scale,1))] shrink-0 rounded-full object-cover"
                   />
-                  <span className="truncate font-heading text-[calc(13px+0.5rem*var(--ui-font-scale,1))] font-semibold tracking-[0em] leading-none text-black dark:text-white dark:tracking-[0.02em]">
+                  <span className="truncate font-heading text-[calc(13px+0.5rem*var(--ui-font-scale,1))] font-semibold tracking-[0em] leading-tight text-black dark:text-white dark:tracking-[0.02em]">
                     unsloth
                   </span>
                   <span className="nav-badge ml-0.5 inline-flex shrink-0 items-center justify-center rounded-full border border-nav-beta-border px-[5px] pt-[3px] pb-[2px] text-[calc(0.5rem*var(--ui-font-scale,1))] font-medium leading-none tracking-[0.04em] text-nav-fg-muted antialiased subpixel-antialiased shadow-[0_1px_2px_rgba(0,0,0,0.06)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.35)]">


### PR DESCRIPTION
## Summary

`Repo tests (CPU)` is failing on main and therefore on every open PR, including PRs that touch no frontend files.

`tests/studio/test_studio_text_descender_clipping.py::test_no_truncate_plus_leading_none_in_changed_files` rejects `truncate` and `leading-none` on the same line, because the clipped line box cuts the descenders on letters like g, p and y. `app-sidebar.tsx:1245` has both on the model-name span.

The remedy is the one this suite already prescribes for the neighbouring block: `test_sidebar_account_block_uses_leading_tight` requires `leading-tight`. This applies the same class here.

Confirmed against `origin/main` with no other changes: the failure reproduces there, so it is not attributable to any PR.

## Test plan

`python3 -m pytest tests/studio/test_studio_text_descender_clipping.py -q`

- Before: `1 failed, 2 passed`
- After: `3 passed`
