### PR TITLE
Desktop: show the app version in Settings > About

### DIFF
--- a/studio/frontend/src/features/settings/components/studio-version-section.tsx
+++ b/studio/frontend/src/features/settings/components/studio-version-section.tsx
@@ -68,8 +68,10 @@ async function fetchStudioVersions(): Promise<StudioVersions> {
 // the version rows; General omits it, so the row only shows on About.
 export function StudioVersionSection({
   llamaCppVersion,
+  desktopAppVersion,
 }: {
   llamaCppVersion?: string | null;
+  desktopAppVersion?: string | null;
 } = {}) {
   const t = useT();
   const [packageVersion, setPackageVersion] = useState("dev");
@@ -99,6 +101,14 @@ export function StudioVersionSection({
           {packageVersion}
         </code>
       </SettingsRow>
+      {desktopAppVersion !== undefined ? (
+        <SettingsRow label={t("settings.about.desktopAppVersion")}>
+          <code className="font-mono text-xs text-muted-foreground">
+            {desktopAppVersion ??
+              t("settings.about.desktopAppVersionUnavailable")}
+          </code>
+        </SettingsRow>
+      ) : null}
       {llamaCppVersion ? (
         <SettingsRow label={t("settings.about.llamaCppVersion")}>
           <code className="font-mono text-xs text-muted-foreground">

--- a/studio/frontend/src/features/settings/desktop-app-version.ts
+++ b/studio/frontend/src/features/settings/desktop-app-version.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+type VersionReader = () => Promise<string>;
+
+async function readTauriAppVersion(): Promise<string> {
+  const { getVersion } = await import("@tauri-apps/api/app");
+  return getVersion();
+}
+
+// Callers gate this on isTauri: null means desktop without a readable version,
+// and never reaching the loader is what keeps the row off browser builds.
+export async function loadDesktopAppVersion(
+  readVersion: VersionReader = readTauriAppVersion,
+): Promise<string | null> {
+  try {
+    const version = await readVersion();
+    return version.trim() || null;
+  } catch (error) {
+    console.warn(
+      "Tauri app version read failed; showing it as unavailable",
+      error,
+    );
+    return null;
+  }
+}

--- a/studio/frontend/src/features/settings/tabs/about-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/about-tab.tsx
@@ -25,6 +25,7 @@ import {
   type UpdateInstallSource,
   UpdateStudioInstructions,
 } from "../components/update-studio-instructions";
+import { loadDesktopAppVersion } from "../desktop-app-version";
 import { useSettingsDialogStore } from "../stores/settings-dialog-store";
 
 type ApiObject = Record<string, unknown>;
@@ -86,6 +87,7 @@ export function AboutTab() {
   const [installSource, setInstallSource] = useState<
     UpdateInstallSource | "loading"
   >("loading");
+  const [desktopAppVersion, setDesktopAppVersion] = useState<string | null>();
 
   useEffect(() => {
     let canceled = false;
@@ -95,6 +97,14 @@ export function AboutTab() {
         setInstallSource(nextInstallSource);
       }
     });
+    // Left undefined on browser builds so the row stays off entirely.
+    if (isTauri) {
+      loadDesktopAppVersion().then((version) => {
+        if (!canceled) {
+          setDesktopAppVersion(version);
+        }
+      });
+    }
 
     return () => {
       canceled = true;
@@ -128,7 +138,10 @@ export function AboutTab() {
 
       {/* llama.cpp row lives in the shared version section so it sits with the
           Unsloth/Package rows; the prop keeps it About-only (General passes none). */}
-      <StudioVersionSection llamaCppVersion={hw.llamaCpp} />
+      <StudioVersionSection
+        llamaCppVersion={hw.llamaCpp}
+        desktopAppVersion={desktopAppVersion}
+      />
 
       <div ref={updateSectionRef} className="scroll-mt-5">
         <SettingsSection title={t("settings.about.updates")}>

--- a/studio/frontend/src/i18n/locales/en.ts
+++ b/studio/frontend/src/i18n/locales/en.ts
@@ -885,6 +885,8 @@ export const en = {
       description: "Docs, release notes, feedback, and build info.",
       studioVersion: "Unsloth Version",
       packageVersion: "Package Version",
+      desktopAppVersion: "Desktop App Version",
+      desktopAppVersionUnavailable: "Unavailable",
       llamaCppVersion: "llama.cpp Version",
       hardware: "Hardware",
       gpu: "GPU",

--- a/studio/frontend/tests/desktop-app-version.test.ts
+++ b/studio/frontend/tests/desktop-app-version.test.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { loadDesktopAppVersion } from "../src/features/settings/desktop-app-version.ts";
+
+test("loads the Tauri SemVer displayed by About", async () => {
+  assert.equal(
+    await loadDesktopAppVersion(() => Promise.resolve("1.8.3")),
+    "1.8.3",
+  );
+});
+
+test("reports an unavailable desktop version when the Tauri API rejects", async () => {
+  const version = await loadDesktopAppVersion(() =>
+    Promise.reject(new Error("Tauri app API unavailable")),
+  );
+
+  assert.equal(version, null);
+});


### PR DESCRIPTION
## Summary

Settings > About lists the Unsloth, package, and llama.cpp versions but not the version of the desktop application itself. The release workflow stamps the release SemVer into `studio/src-tauri/Cargo.toml`, so that value is available at runtime and is the one that drifts when the shell and the backend package are updated separately.

Add the row on desktop and leave browser mode unchanged.

## What changed

- Read the version through the Tauri app API and render it in the shared version section, so it sits with the existing Unsloth and package rows.
- Omit the row entirely in browser mode rather than rendering it empty, and show a localized unavailable fallback when the read fails on desktop.

## Testing

- `npm test` (28 passed)
- `npm run typecheck`
- `npm run i18n:check`
- `npm run build`

Coverage:

- The version the About row displays, and the unavailable fallback when the Tauri read rejects.

The frontend suite runs under `node --test` with no DOM, so nothing here renders the row itself. Browser-mode omission is enforced at the call site rather than inside the loader, and is likewise not covered by a test.

## Notes

On a matched release install this row reads the same version as the Unsloth row without its leading `v`. The two only diverge when the desktop shell and the backend package come from different releases, which is the case the row exists for.
