### PR TITLE
Desktop: clean up the backend on Unix termination signals

### DIFF
--- a/studio/src-tauri/Cargo.lock
+++ b/studio/src-tauri/Cargo.lock
@@ -4345,6 +4345,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5672,6 +5682,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "signal-hook",
  "simplelog",
  "tauri",
  "tauri-build",

--- a/studio/src-tauri/Cargo.toml
+++ b/studio/src-tauri/Cargo.toml
@@ -36,6 +36,7 @@ tauri-plugin-window-state = "2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+signal-hook = "0.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gdk = "0.18"

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -23,10 +23,17 @@ use simplelog::{
     CombinedLogger, Config, LevelFilter, SharedLogger, TermLogger, TerminalMode, WriteLogger,
 };
 use std::fs;
+use std::sync::Once;
 use tauri::menu::{MenuBuilder, MenuItemBuilder};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::{Emitter, Manager};
 use tauri_plugin_window_state::{AppHandleExt, StateFlags};
+
+/// Serializes the exit paths that must reap the backend: the tray "Quit" item,
+/// the Unix termination signal listener, and `RunEvent::Exit`. Exactly one path
+/// runs cleanup; the others block until it is done, so the process never exits
+/// out from under a cleanup that is still killing the backend tree.
+static TERMINATION_CLEANUP: Once = Once::new();
 
 #[tauri::command]
 fn has_saved_window_state(app: tauri::AppHandle) -> bool {
@@ -113,27 +120,95 @@ fn confirm_quit_during_install(app: &tauri::AppHandle) -> bool {
 }
 
 fn cleanup_child_processes(app: &tauri::AppHandle) {
-    let diagnostics_state = app
-        .try_state::<diagnostics::DiagnosticsState>()
-        .map(|state| state.inner().clone());
-    if let Some(install_state) = app.try_state::<install::InstallState>() {
-        if let Some(diagnostics) = diagnostics_state.as_ref() {
-            install::record_install_intentional_stop(&install_state, diagnostics);
+    // `call_once_force` rather than `call_once`: a panicking cleanup poisons the `Once`
+    // instead of deadlocking the exit paths waiting on it, and the next caller retries
+    // it rather than exiting on a backend that was never reaped.
+    TERMINATION_CLEANUP.call_once_force(|state| {
+        if state.is_poisoned() {
+            warn!("Previous termination cleanup panicked, retrying it");
         }
-        let _ = install::stop_install(&install_state);
-    }
-    if let Some(update_state) = app.try_state::<update::UpdateState>() {
-        if let Some(diagnostics) = diagnostics_state.as_ref() {
-            update::record_update_intentional_stop(&update_state, diagnostics);
+
+        let diagnostics_state = app
+            .try_state::<diagnostics::DiagnosticsState>()
+            .map(|state| state.inner().clone());
+        if let Some(install_state) = app.try_state::<install::InstallState>() {
+            if let Some(diagnostics) = diagnostics_state.as_ref() {
+                install::record_install_intentional_stop(&install_state, diagnostics);
+            }
+            let _ = install::stop_install(&install_state);
         }
-        let _ = update::stop_update(&update_state);
-    }
-    if let Some(backend_state) = app.try_state::<process::BackendState>() {
-        let shutdown = app
-            .try_state::<process::ShutdownFlag>()
-            .expect("ShutdownFlag must be managed");
-        let _ = process::stop_backend(&backend_state, &shutdown, diagnostics_state.as_ref());
-    }
+        if let Some(update_state) = app.try_state::<update::UpdateState>() {
+            if let Some(diagnostics) = diagnostics_state.as_ref() {
+                update::record_update_intentional_stop(&update_state, diagnostics);
+            }
+            let _ = update::stop_update(&update_state);
+        }
+        if let Some(backend_state) = app.try_state::<process::BackendState>() {
+            let shutdown = app
+                .try_state::<process::ShutdownFlag>()
+                .expect("ShutdownFlag must be managed");
+            let _ = process::stop_backend(&backend_state, &shutdown, diagnostics_state.as_ref());
+        }
+    });
+}
+
+/// The backend is spawned as its own process-group leader, so nothing reaps it when the
+/// desktop app is terminated by a signal (logout, `kill`, a shell Ctrl-C). Tauri installs
+/// no handler for those, so without this the app would die and leave the backend running.
+/// Windows gets the same guarantee from the kill-on-close job object in `windows_job`.
+#[cfg(unix)]
+fn setup_unix_termination_signals(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
+    use signal_hook::consts::signal::{SIGHUP, SIGINT, SIGQUIT, SIGTERM};
+    use signal_hook::iterator::Signals;
+
+    let mut signals = Signals::new([SIGHUP, SIGINT, SIGQUIT, SIGTERM])?;
+    let app_handle = app.handle().clone();
+    std::thread::Builder::new()
+        .name("desktop-termination-signal".to_string())
+        .spawn(move || {
+            // Terminating is not conditional on cleanup succeeding. If cleanup panicked
+            // and took the exit with it, the app would keep running after SIGTERM, the
+            // session manager would SIGKILL it once its timeout expired, and the backend
+            // would be orphaned: exactly the failure this listener exists to prevent.
+            let cleanup_and_exit = |app: &tauri::AppHandle, exit_code: i32| {
+                let cleanup = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    cleanup_child_processes(app)
+                }));
+                if cleanup.is_err() {
+                    warn!("Termination cleanup panicked, exiting anyway");
+                }
+                app.exit(exit_code);
+            };
+
+            let mut cleanup_started = false;
+            for signal in signals.forever() {
+                let name = signal_hook::low_level::signal_name(signal).unwrap_or("unknown signal");
+                let exit_code = 128 + signal;
+                if cleanup_started {
+                    // Cleanup blocks for as long as the backend takes to die. A repeat
+                    // signal is the user asking to stop waiting, so leave straight away
+                    // instead of swallowing it and forcing them to reach for SIGKILL.
+                    warn!("Received {name} ({signal}) while cleaning up, exiting immediately");
+                    std::process::exit(exit_code);
+                }
+                cleanup_started = true;
+                info!("Received Unix termination signal {name} ({signal})");
+
+                // Clean up on its own thread so this one stays in `signals.forever()` and
+                // can still observe a repeat signal. If that thread cannot be spawned we
+                // fall back to cleaning up here, which gives up the repeat-signal escape
+                // hatch until cleanup finishes.
+                let cleanup_handle = app_handle.clone();
+                let cleanup = std::thread::Builder::new()
+                    .name("desktop-termination-cleanup".to_string())
+                    .spawn(move || cleanup_and_exit(&cleanup_handle, exit_code));
+                if let Err(error) = cleanup {
+                    warn!("Could not spawn termination cleanup thread: {error}");
+                    cleanup_and_exit(&app_handle, exit_code);
+                }
+            }
+        })?;
+    Ok(())
 }
 
 fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
@@ -276,15 +351,18 @@ fn main() {
             #[cfg(any(target_os = "windows", target_os = "linux"))]
             setup_custom_titlebar(app)?;
             setup_tray(app)?;
+            #[cfg(unix)]
+            setup_unix_termination_signals(app)?;
             Ok(())
         })
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                // Hide window instead of closing — this is a tray app.
+                // Hide window instead of closing, because this is a tray app.
                 // Processes keep running so the backend stays available.
                 // Full cleanup happens via:
                 //   - Tray "Quit" menu item (explicit user action)
-                //   - RunEvent::Exit handler (OS shutdown, SIGTERM, etc.)
+                //   - The Unix termination signal listener (logout, kill, Ctrl-C)
+                //   - RunEvent::Exit, for framework-driven exits
                 let _ = window.hide();
                 api.prevent_close();
             }
@@ -293,7 +371,10 @@ fn main() {
         .expect("error while building tauri application")
         .run(|app, event| {
             if let tauri::RunEvent::Exit = event {
-                // Cleanup on ALL exit paths — safety net for non-tray exits
+                // Safety net for framework-driven exits. When another path already owns
+                // cleanup, this blocks the main event-loop thread until that path is
+                // done: worst case roughly 15s, waiting on the graceful-then-force stop
+                // of the installer (5s), the updater (5s) and the backend (5s).
                 cleanup_child_processes(app);
             }
         });


### PR DESCRIPTION
## Summary

The desktop app spawns the backend as its own process-group leader and installs no Unix signal handler, so a `SIGTERM` from a logout or a `kill` terminates the app and leaves the backend running. The comment on `CloseRequested` claims `RunEvent::Exit` covers "OS shutdown, SIGTERM, etc.", which is not true: Tauri never runs that handler for a signal. Windows already has this guarantee from the kill-on-close job object.

Handle Unix termination signals, and serialize the exit paths so exactly one performs cleanup.

## What changed

- Listen for `SIGTERM`, `SIGINT`, `SIGQUIT`, and `SIGHUP` and run the existing cleanup before exiting.
- Serialize the tray quit, the signal listener, and `RunEvent::Exit` through a `Once`, so exactly one path performs cleanup and the others block until it is done rather than exiting out from under it. `call_once_force` is deliberate: a panicking cleanup poisons instead of deadlocking the waiting paths, and the next caller retries rather than exiting on a backend that was never reaped.
- Terminate whether or not cleanup succeeds. If a panic took the exit with it, the app would keep running after `SIGTERM` until the session manager's timeout expired and SIGKILLed it, orphaning the backend, which is the failure this exists to prevent.
- Exit immediately on a repeat signal instead of ignoring it. Cleanup blocks for as long as the backend takes to die, and a second signal is the user asking to stop waiting.
- Correct the now-stale comments on `CloseRequested` and `RunEvent::Exit`, including the bound on how long the latter can now wait.

`RunEvent::Exit` blocking on another path's cleanup is not new cost: on main that handler ran the same cleanup inline. On a tray quit it is now cheaper, because main ran the whole cleanup twice.

## Behaviour boundary

Interrupting cleanup with a repeat signal deliberately gives up the rest of it. Specifically: the escalation from `SIGTERM` to `SIGKILL` for a backend that ignores the first signal, removal of the owner metadata file, and the window geometry save. All three were confirmed by observation. That is the right trade for not making the user reach for `SIGKILL`, but it is a real boundary.

## Testing

- `cargo test --locked` (104 passed)
- `cargo check --locked`
- `cargo fmt --check`

`cargo test` needs `studio/frontend/dist` to exist for `generate_context!`.

## Runtime validation

Debug builds of both `origin/main` and this branch, run headless against the real backend, with two unrelated Studio backends listening throughout.

- Reproduced on main: `kill -TERM` on the app killed the app; the backend survived, reparented to init, still listening.
- `SIGTERM` on this branch: app exited in about 2s, backend gone, port free, owner metadata removed.
- `SIGINT`: same result.
- Neither run disturbed the unrelated listeners.
- A backend that ignores `SIGTERM`: the app waited the full 5s, logged the forced group kill, and exited at about 5.2s leaving nothing behind.
- Repeat signal during that wait: the app exited within about 100ms of the second signal.

Not validated: packaged artifact behaviour, and macOS, which shares this code path but was not exercised here.

## Note on the dependency

`signal-hook` adds one crate and no new transitive dependencies; `signal-hook-registry` and `libc` were already in the graph. `tokio::signal` was available without any dependency change but was passed over deliberately: it delivers through the tokio reactor, and this is a shutdown path where the runtime may itself be winding down, whereas `signal-hook` reads a self-pipe on its own thread.

## Scope

This is the signal-handling fix only. Backend ownership metadata, adoption of a leftover backend, and the installer identity path are separate problems and are not touched here.
