### PR TITLE
Desktop: notarize the final macOS disk image on release

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -759,21 +759,31 @@ jobs:
               --wait
           )" || submit_status=$?
           printf '%s\n' "$submission"
-          if [ "$submit_status" -ne 0 ]; then
-            # A rejection reports only a submission ID; the reason lives in the
-            # log, and this runner is the last place that can fetch it.
-            submission_id="$(
-              printf '%s' "$submission" \
-                | python3 -c 'import json, sys; print(json.load(sys.stdin).get("id", ""))' \
-                2>/dev/null
-            )" || submission_id=""
+          submission_id="$(
+            printf '%s' "$submission" \
+              | python3 -c 'import json, sys; print(json.load(sys.stdin).get("id", ""))' \
+              2>/dev/null
+          )" || submission_id=""
+          submission_result="$(
+            printf '%s' "$submission" \
+              | python3 -c 'import json, sys; print(json.load(sys.stdin).get("status", ""))' \
+              2>/dev/null
+          )" || submission_result=""
+          if [ "$submit_status" -ne 0 ] || [ "$submission_result" != "Accepted" ]; then
+            # The service verdict is part of the JSON contract, independently
+            # of the command's exit code. Fetch the log whenever the response
+            # identifies a failed submission.
             if [ -n "$submission_id" ]; then
               xcrun notarytool log "$submission_id" \
                 --apple-id "$APPLE_ID" \
                 --password "$APPLE_PASSWORD" \
                 --team-id "$APPLE_TEAM_ID" >&2 || true
             fi
-            exit "$submit_status"
+            if [ "$submit_status" -ne 0 ]; then
+              exit "$submit_status"
+            fi
+            echo "Notarization did not return Accepted (status=${submission_result:-missing})." >&2
+            exit 1
           fi
 
           xcrun stapler staple "$dmg_path"

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -579,6 +579,27 @@ jobs:
         with:
           workspaces: 'studio/src-tauri -> target'
 
+      # ── macOS: fail before the build if notarization cannot run ──
+      - name: Check Apple notarization credentials
+        if: matrix.platform == 'macos-latest'
+        shell: bash
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          # A missing secret arrives as an empty string, so `set -u` never sees
+          # it, and tauri-action just skips notarization instead of failing.
+          # Check before the release build so a rotated secret costs seconds
+          # rather than a full compile.
+          for required in APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID; do
+            if [ -z "${!required:-}" ]; then
+              echo "Missing $required; refusing to publish an unnotarized disk image." >&2
+              exit 1
+            fi
+          done
+
       # ── macOS: import signing certificate ──
       - name: Import Apple certificate
         if: matrix.platform == 'macos-latest'
@@ -669,6 +690,103 @@ jobs:
           projectPath: studio
           tauriScript: npx --prefix . tauri
           args: -v ${{ matrix.args }}
+
+      # ── macOS: notarize + staple the disk image itself ──
+      # tauri-bundler notarizes and staples the .app, but only codesigns the
+      # .dmg it wraps around it (tauri-apps/tauri#7533). The disk image users
+      # actually download therefore ships signed but without a notarization
+      # ticket, so Gatekeeper has to phone home to clear it and blocks it
+      # outright offline. Close that gap here and fail the release if any part
+      # of it does not hold.
+      - name: Notarize final macOS disk image
+        if: matrix.platform == 'macos-latest'
+        shell: bash
+        # `--timeout` below caps the polling, but not the upload that precedes
+        # it. This job sets no timeout of its own, so without a backstop a stuck
+        # Notary service would hold `max-parallel: 1` for GitHub's 6h default
+        # and discard the Linux and Windows builds with it.
+        timeout-minutes: 45
+        env:
+          ARTIFACT_PATHS: ${{ steps.build_macos.outputs.artifactPaths }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          dmg_path="$(
+            python3 <<'PY'
+          import json
+          import os
+          import sys
+
+          raw_paths = os.environ.get('ARTIFACT_PATHS', '')
+          try:
+              artifact_paths = json.loads(raw_paths)
+          except json.JSONDecodeError as error:
+              sys.exit(f'Invalid tauri-action artifactPaths output: {error}')
+          if not isinstance(artifact_paths, list):
+              sys.exit('tauri-action artifactPaths must be a JSON list')
+          matches = [
+              path
+              for path in artifact_paths
+              if isinstance(path, str) and path.lower().endswith('.dmg')
+          ]
+          if len(matches) != 1:
+              sys.exit(f'Expected exactly one final DMG from tauri-action, found {len(matches)}')
+          print(matches[0])
+          PY
+          )"
+
+          # First gate, before the multi-minute upload: the bundler signs the
+          # DMG whenever a signing identity is configured, so an unsigned image
+          # here means the signing step silently did nothing.
+          codesign --verify --verbose=2 "$dmg_path"
+
+          # notarytool has no environment or stdin form for --password, so the
+          # credentials are visible in argv and in the process table. That is
+          # the accepted tradeoff on a single-tenant ephemeral runner;
+          # --keychain-profile only moves the same arguments one command
+          # earlier, and the one form without argv secrets is App Store Connect
+          # API key auth, which needs a different secret type.
+          submit_status=0
+          submission="$(
+            xcrun notarytool submit "$dmg_path" \
+              --apple-id "$APPLE_ID" \
+              --password "$APPLE_PASSWORD" \
+              --team-id "$APPLE_TEAM_ID" \
+              --output-format json \
+              --timeout 30m \
+              --wait
+          )" || submit_status=$?
+          printf '%s\n' "$submission"
+          if [ "$submit_status" -ne 0 ]; then
+            # A rejection reports only a submission ID; the reason lives in the
+            # log, and this runner is the last place that can fetch it.
+            submission_id="$(
+              printf '%s' "$submission" \
+                | python3 -c 'import json, sys; print(json.load(sys.stdin).get("id", ""))' \
+                2>/dev/null
+            )" || submission_id=""
+            if [ -n "$submission_id" ]; then
+              xcrun notarytool log "$submission_id" \
+                --apple-id "$APPLE_ID" \
+                --password "$APPLE_PASSWORD" \
+                --team-id "$APPLE_TEAM_ID" >&2 || true
+            fi
+            exit "$submit_status"
+          fi
+
+          xcrun stapler staple "$dmg_path"
+          # Stapling rewrites the image. `stapler validate` is what proves the
+          # offline case, since spctl can clear an unstapled image from an
+          # online CDN check; spctl then gives the verdict a user's machine
+          # would reach.
+          xcrun stapler validate "$dmg_path"
+          spctl --assess \
+            --type open \
+            --context context:primary-signature \
+            --verbose=4 \
+            "$dmg_path"
 
       # ── Windows: build + sign ──
       - name: Build Windows app

--- a/tests/security/test_release_desktop_notarization.py
+++ b/tests/security/test_release_desktop_notarization.py
@@ -1,0 +1,223 @@
+"""Behavior checks for the final macOS disk image notarization step."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release-desktop.yml"
+
+
+def _workflow():
+    return yaml.safe_load(WORKFLOW.read_text(encoding = "utf-8"))
+
+
+def _step(workflow, name):
+    steps = workflow["jobs"]["build"]["steps"]
+    return next(step for step in steps if step.get("name") == name)
+
+
+def _step_names(workflow):
+    return [step.get("name") for step in workflow["jobs"]["build"]["steps"]]
+
+
+def _write_fake_command(path: Path, body: str):
+    path.write_text("#!/bin/sh\nset -eu\n" + body, encoding = "utf-8")
+    path.chmod(0o755)
+
+
+def _run_script(run: str, env: dict[str, str], cwd: Path):
+    return subprocess.run(
+        ["bash", "-c", run],
+        cwd = cwd,
+        env = env,
+        text = True,
+        capture_output = True,
+        check = False,
+    )
+
+
+def _run_credential_check(
+    workflow,
+    tmp_path: Path,
+    *,
+    env_overrides: dict[str, str] | None = None,
+):
+    env = os.environ.copy()
+    env.update(
+        {
+            "APPLE_ID": "masked-apple-id",
+            "APPLE_PASSWORD": "masked-password",
+            "APPLE_TEAM_ID": "masked-team",
+        }
+    )
+    env.update(env_overrides or {})
+    return _run_script(
+        _step(workflow, "Check Apple notarization credentials")["run"], env, tmp_path
+    )
+
+
+def _run_notarization_step(
+    workflow,
+    tmp_path: Path,
+    *,
+    submit_output: str | None = None,
+    fail_submission: bool = False,
+    artifact_paths: str | None = None,
+):
+    """Run the step's shell body against stubbed Apple tooling and report the calls it made."""
+    dmg = tmp_path / "Final Desktop.dmg"
+    dmg.write_bytes(b"signed dmg")
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir(exist_ok = True)
+    log = tmp_path / "commands.log"
+    log.write_text("", encoding = "utf-8")
+    # Record the full argv so the assertions below read the flags the step
+    # actually passed, not the text of the YAML that produced them.
+    _write_fake_command(
+        fake_bin / "xcrun",
+        """
+printf 'xcrun %s\\n' "$*" >> "$COMMAND_LOG"
+if [ "$1 $2" = "notarytool submit" ]; then
+  printf '%s\\n' "$SUBMIT_OUTPUT"
+  if [ "$FAIL_SUBMISSION" = "true" ]; then
+    exit 23
+  fi
+elif [ "$1 $2" = "notarytool log" ]; then
+  printf 'issue: The signature does not include a secure timestamp.\\n'
+fi
+exit 0
+""",
+    )
+    for name in ("codesign", "spctl"):
+        _write_fake_command(fake_bin / name, f"""printf '{name} %s\\n' "$*" >> "$COMMAND_LOG"\n""")
+
+    status = "Invalid" if fail_submission else "Accepted"
+    env = os.environ.copy()
+    env.update(
+        {
+            "APPLE_ID": "masked-apple-id",
+            "APPLE_PASSWORD": "masked-password",
+            "APPLE_TEAM_ID": "masked-team",
+            "ARTIFACT_PATHS": (
+                json.dumps([str(dmg)]) if artifact_paths is None else artifact_paths
+            ),
+            "COMMAND_LOG": str(log),
+            "FAIL_SUBMISSION": "true" if fail_submission else "false",
+            "SUBMIT_OUTPUT": (
+                json.dumps({"id": "sub-1234", "status": status})
+                if submit_output is None
+                else submit_output
+            ),
+            "PATH": f"{fake_bin}:{env['PATH']}",
+        }
+    )
+    result = _run_script(_step(workflow, "Notarize final macOS disk image")["run"], env, tmp_path)
+    commands = log.read_text(encoding = "utf-8").splitlines()
+    return result, commands
+
+
+def _command_names(commands):
+    """Reduce recorded argv lines to `tool subcommand` for sequence assertions."""
+    names = []
+    for line in commands:
+        fields = line.split()
+        names.append(" ".join(fields[1:3]) if fields[0] == "xcrun" else fields[0])
+    return names
+
+
+def test_notarization_step_runs_after_the_macos_build_and_before_staging():
+    workflow = _workflow()
+    step = _step(workflow, "Notarize final macOS disk image")
+    assert step["if"] == "matrix.platform == 'macos-latest'"
+    assert step["env"]["ARTIFACT_PATHS"] == "${{ steps.build_macos.outputs.artifactPaths }}"
+    # notarytool's own --timeout only caps the polling, so the step still needs
+    # a backstop or a stalled upload holds the serial matrix until GitHub's 6h
+    # job limit.
+    assert isinstance(step["timeout-minutes"], int)
+
+    names = _step_names(workflow)
+    assert names.index("Build macOS app") < names.index("Notarize final macOS disk image")
+    assert names.index("Notarize final macOS disk image") < names.index("Stage release assets")
+
+
+def test_credentials_are_checked_before_the_expensive_build():
+    workflow = _workflow()
+    check = _step(workflow, "Check Apple notarization credentials")
+    assert check["if"] == "matrix.platform == 'macos-latest'"
+
+    names = _step_names(workflow)
+    assert names.index("Check Apple notarization credentials") < names.index("Build macOS app")
+
+
+def test_missing_apple_credentials_fail_the_release_instead_of_skipping(tmp_path):
+    workflow = _workflow()
+    for missing in ("APPLE_ID", "APPLE_PASSWORD", "APPLE_TEAM_ID"):
+        result = _run_credential_check(workflow, tmp_path, env_overrides = {missing: ""})
+        assert result.returncode == 1, missing
+        assert f"Missing {missing}" in result.stderr
+
+    assert _run_credential_check(workflow, tmp_path).returncode == 0
+
+
+def test_final_dmg_is_notarized_stapled_and_gatekeeper_checked(tmp_path):
+    result, commands = _run_notarization_step(_workflow(), tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert _command_names(commands) == [
+        "codesign",
+        "notarytool submit",
+        "stapler staple",
+        "stapler validate",
+        "spctl",
+    ]
+
+
+def test_submission_carries_every_credential_and_a_bounded_wait(tmp_path):
+    _, commands = _run_notarization_step(_workflow(), tmp_path)
+    submit = next(line for line in commands if line.startswith("xcrun notarytool submit"))
+    fields = submit.split()
+    # Without --wait the submission returns before Apple has a verdict and the
+    # staple would race it; --timeout then bounds that wait.
+    for flag in ("--apple-id", "--password", "--team-id", "--wait", "--timeout"):
+        assert flag in fields, submit
+    assert fields[fields.index("--timeout") + 1] != "--wait"
+    assert str(tmp_path / "Final Desktop.dmg") in submit
+
+
+def test_rejection_fetches_the_notarization_log_and_skips_stapling(tmp_path):
+    result, commands = _run_notarization_step(_workflow(), tmp_path, fail_submission = True)
+    assert result.returncode == 23
+    assert _command_names(commands) == ["codesign", "notarytool submit", "notarytool log"]
+
+    log_call = commands[-1].split()
+    assert "sub-1234" in log_call
+    for flag in ("--apple-id", "--password", "--team-id"):
+        assert flag in log_call, commands[-1]
+    assert "secure timestamp" in result.stderr
+    assert "masked-password" not in result.stdout
+    assert "masked-password" not in result.stderr
+
+
+def test_rejection_without_a_parseable_submission_id_still_fails(tmp_path):
+    result, commands = _run_notarization_step(
+        _workflow(),
+        tmp_path,
+        fail_submission = True,
+        submit_output = "Conn close by peer",
+    )
+    assert result.returncode == 23
+    assert _command_names(commands) == ["codesign", "notarytool submit"]
+
+
+def test_ambiguous_or_missing_disk_image_fails_closed(tmp_path):
+    workflow = _workflow()
+    for artifact_paths in ("[]", "{}", "not json", json.dumps(["/a/one.dmg", "/a/two.dmg"])):
+        result, commands = _run_notarization_step(workflow, tmp_path, artifact_paths = artifact_paths)
+        assert result.returncode != 0, artifact_paths
+        assert commands == []

--- a/tests/security/test_release_desktop_notarization.py
+++ b/tests/security/test_release_desktop_notarization.py
@@ -216,11 +216,7 @@ def test_nonaccepted_service_result_fails_even_when_notarytool_exits_zero(tmp_pa
         )
 
         assert result.returncode == 1
-        assert _command_names(commands) == [
-            "codesign",
-            "notarytool submit",
-            "notarytool log",
-        ]
+        assert _command_names(commands) == ["codesign", "notarytool submit", "notarytool log"]
         assert f"status={status}" in result.stderr
 
 

--- a/tests/security/test_release_desktop_notarization.py
+++ b/tests/security/test_release_desktop_notarization.py
@@ -69,6 +69,7 @@ def _run_notarization_step(
     *,
     submit_output: str | None = None,
     fail_submission: bool = False,
+    notary_status: str | None = None,
     artifact_paths: str | None = None,
 ):
     """Run the step's shell body against stubbed Apple tooling and report the calls it made."""
@@ -98,7 +99,7 @@ exit 0
     for name in ("codesign", "spctl"):
         _write_fake_command(fake_bin / name, f"""printf '{name} %s\\n' "$*" >> "$COMMAND_LOG"\n""")
 
-    status = "Invalid" if fail_submission else "Accepted"
+    status = notary_status or ("Invalid" if fail_submission else "Accepted")
     env = os.environ.copy()
     env.update(
         {
@@ -202,6 +203,25 @@ def test_rejection_fetches_the_notarization_log_and_skips_stapling(tmp_path):
     assert "secure timestamp" in result.stderr
     assert "masked-password" not in result.stdout
     assert "masked-password" not in result.stderr
+
+
+def test_nonaccepted_service_result_fails_even_when_notarytool_exits_zero(tmp_path):
+    for status in ("Invalid", "Rejected"):
+        case_dir = tmp_path / status
+        case_dir.mkdir()
+        result, commands = _run_notarization_step(
+            _workflow(),
+            case_dir,
+            notary_status = status,
+        )
+
+        assert result.returncode == 1
+        assert _command_names(commands) == [
+            "codesign",
+            "notarytool submit",
+            "notarytool log",
+        ]
+        assert f"status={status}" in result.stderr
 
 
 def test_rejection_without_a_parseable_submission_id_still_fails(tmp_path):


### PR DESCRIPTION
## Summary

`tauri-action` receives the Apple credentials, so notarization runs, but the bundler notarizes and staples only the `.app`. It signs the `.dmg` and stops there (`tauri-bundler` `macos/app.rs` versus `macos/dmg/mod.rs`, upstream tauri-apps/tauri#7533). The shipped disk image is therefore signed but carries no stapled ticket.

Notarize, staple, and Gatekeeper-check the final DMG before it is staged for release.

This is not a broken-today situation. The app inside the image is stapled, so an online first launch resolves the ticket and works. The gap is the offline first launch, and Gatekeeper evaluating the image itself, which is why Apple's guidance is to notarize what you actually distribute.

## What changed

- Add a notarization step after the macOS build: verify the DMG signature, submit it, staple the ticket, validate the staple, and assess it with `spctl`. The pre-staple signature check fails fast before a multi-minute upload; `stapler validate` is what proves the offline case, which `spctl` alone does not, since it can pass via an online check.
- Bound the wait. `notarytool submit --wait` polls indefinitely by default, and nothing in this workflow sets a timeout, so a degraded notary service would otherwise stall the run against GitHub's six-hour job default and discard the finished build.
- Require the JSON service verdict to be `Accepted`, independently of the command's exit code. On any other verdict, fetch and print `notarytool log` before exiting. The log is unreachable once the job ends, so diagnosing a rejection would otherwise cost another full macOS build.
- Check the notarization credentials in a small step before the build rather than after it. `tauri-action` silently skips notarization when they are absent, so a rotated secret would otherwise surface only after the Rust compile.

## Testing

- `python -m pytest -q tests/security` (180 passed)

Coverage:

- The command sequence the step actually executes, driven against stubbed `xcrun`, `codesign`, and `spctl`, plus the credentials and bounded wait read off recorded argv; failed and non-accepted submissions not stapling and not leaking the password, including an `Invalid` or `Rejected` verdict returned with exit code zero; each missing credential failing before anything runs; ambiguous, absent, and malformed artifact paths failing before submission; and the step's position relative to the build and staging steps.

## Validation notes

Everything real here needs maintainer secrets. The tests exercise the shell sequence against local fakes. Not verified: that `codesign --verify` passes on a genuine bundler-produced DMG, the notary service round trip, stapling a real image, and the Gatekeeper assessment. Each of those now fails the release job rather than passing silently, which is the intent, but the first hosted run is the first real test.

## Note on credentials

`notarytool` has no environment or stdin form for `--password`, so the credentials are passed as arguments and are visible in the process table for the life of the call. That is acceptable on a single-tenant ephemeral runner, and the workflow already does the same for signing. The only argv-free alternative is App Store Connect API key authentication, which would need a different secret provisioned.
