### PR TITLE
Studio: hybrid MLA cache sizing, fenced HTML rendering, Kimi-K3 defaults

### DIFF
--- a/studio/backend/assets/configs/model_defaults/other/unsloth_Kimi-K3.yaml
+++ b/studio/backend/assets/configs/model_defaults/other/unsloth_Kimi-K3.yaml
@@ -1,0 +1,8 @@
+# Model defaults for unsloth/Kimi-K3
+# Also applies to: moonshotai/Kimi-K3, unsloth/Kimi-K3-GGUF
+# Inference values are Moonshot's recommended sampling settings.
+
+inference:
+  temperature: 1.0
+  top_p: 0.95
+  min_p: 0.0

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -4368,9 +4368,7 @@ class LlamaCppBackend:
         """
         if not self._n_kv_heads_by_layer or not self._n_layers or not self._kda_head_dim:
             return 0
-        n_recurrent = sum(
-            1 for i in range(self._n_layers) if self._kv_heads_for_layer(i, 1) == 0
-        )
+        n_recurrent = sum(1 for i in range(self._n_layers) if self._kv_heads_for_layer(i, 1) == 0)
         if n_recurrent == 0:
             return 0
         head_dim, n_head = self._kda_head_dim, self._n_heads or 1

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -2337,6 +2337,8 @@ class LlamaCppBackend:
         self._kv_value_length_swa: Optional[int] = None
         self._ssm_inner_size: Optional[int] = None
         self._ssm_state_size: Optional[int] = None
+        self._ssm_conv_kernel: Optional[int] = None
+        self._kda_head_dim: Optional[int] = None
         # Last N layers reuse earlier layers' KV and don't allocate their own
         # cache (Gemma 3n / Gemma 4: <arch>.attention.shared_kv_layers).
         self._shared_kv_layers: Optional[int] = None
@@ -4351,6 +4353,32 @@ class LlamaCppBackend:
             return self._n_kv_heads_by_layer[layer_idx]
         return fallback
 
+    def _recurrent_state_bytes(self, n_parallel: int = 1) -> int:
+        """VRAM for the conv + recurrent state of linear-attention layers.
+
+        Hybrids pair an MLA/attention cache with llama_memory_recurrent, which
+        allocates per recurrent layer and per sequence, always f32, offloaded
+        beside the KV cache. Unlike KV this does not scale with context, so it
+        is the whole reservation at short contexts and the bisection in
+        _fit_context_to_vram cannot shrink it away.
+
+        Sizes follow llama_hparams::n_embd_r/n_embd_s. Kimi KDA only: Mamba
+        needs ssm.group_count, which is not parsed, so those models keep the
+        previous behaviour rather than get a wrong number.
+        """
+        if not self._n_kv_heads_by_layer or not self._n_layers or not self._kda_head_dim:
+            return 0
+        n_recurrent = sum(
+            1 for i in range(self._n_layers) if self._kv_heads_for_layer(i, 1) == 0
+        )
+        if n_recurrent == 0:
+            return 0
+        head_dim, n_head = self._kda_head_dim, self._n_heads or 1
+        d_conv = self._ssm_conv_kernel or 4
+        n_embd_r = 3 * max(0, d_conv - 1) * n_head * head_dim
+        n_embd_s = head_dim * head_dim * n_head
+        return int(n_recurrent * (n_embd_r + n_embd_s) * 4 * max(1, n_parallel))
+
     def _legacy_head_dim(self) -> int:
         """Head-dim fallback for GGUFs without explicit key/value dims. Reached
         only via the legacy branch of _can_estimate_kv(), so _embedding_length
@@ -4458,7 +4486,9 @@ class LlamaCppBackend:
                     1 for i in range(n_layers_kv) if self._kv_heads_for_layer(i, n_kv_mla) > 0
                 )
                 n_mla_layers = max(1, attn)
-            return int(n_mla_layers * total_cells * n_kv_mla * key_len * bpe_k)
+            return int(
+                n_mla_layers * total_cells * n_kv_mla * key_len * bpe_k
+            ) + self._recurrent_state_bytes(n_parallel)
 
         key_len = self._kv_key_length
         val_len = self._kv_value_length
@@ -5223,6 +5253,8 @@ class LlamaCppBackend:
         self._kv_value_length_swa = None
         self._ssm_inner_size = None
         self._ssm_state_size = None
+        self._ssm_conv_kernel = None
+        self._kda_head_dim = None
         self._shared_kv_layers = None
         self._nextn_predict_layers = None
         self._architecture = None
@@ -5313,6 +5345,8 @@ class LlamaCppBackend:
                                         f"{arch}.attention.shared_kv_layers": "shared_kv_layers",
                                         f"{arch}.ssm.inner_size": "ssm_inner_size",
                                         f"{arch}.ssm.state_size": "ssm_state_size",
+                                        f"{arch}.ssm.conv_kernel": "ssm_conv_kernel",
+                                        f"{arch}.kda.head_dim": "kda_head_dim",
                                         f"{arch}.nextn_predict_layers": "nextn_predict_layers",
                                     }
                                 elif key == "tokenizer.chat_template":
@@ -10024,6 +10058,8 @@ class LlamaCppBackend:
             self._kv_value_length_swa = None
             self._ssm_inner_size = None
             self._ssm_state_size = None
+            self._ssm_conv_kernel = None
+            self._kda_head_dim = None
             self._shared_kv_layers = None
             self._nextn_predict_layers = None
             # Clean up temp chat template file.

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -4446,7 +4446,19 @@ class LlamaCppBackend:
             n_kv_mla = self._n_kv_heads or 1
             rope_dim = self._key_length_mla or 64
             key_len = self._kv_key_length or (self._kv_lora_rank + rope_dim)
-            return int(n_layers_kv * total_cells * n_kv_mla * key_len * bpe_k)
+            # Hybrid MLA (Kimi-K3): head_count_kv is a per-layer array whose KDA
+            # linear-attention layers are 0 and hold a constant-size state instead
+            # of a growing cache. Only the non-zero layers allocate KV, so counting
+            # every block overstates it by the hybrid ratio (93 blocks vs 24 real
+            # ones is 3.9x, or 78 GiB of phantom cache at 1M context) and shrinks
+            # the auto-fit context for no reason. Uniform MLA keeps n_layers_kv.
+            n_mla_layers = n_layers_kv
+            if self._n_kv_heads_by_layer:
+                attn = sum(
+                    1 for i in range(n_layers_kv) if self._kv_heads_for_layer(i, n_kv_mla) > 0
+                )
+                n_mla_layers = max(1, attn)
+            return int(n_mla_layers * total_cells * n_kv_mla * key_len * bpe_k)
 
         key_len = self._kv_key_length
         val_len = self._kv_value_length

--- a/studio/backend/tests/test_kv_cache_estimation.py
+++ b/studio/backend/tests/test_kv_cache_estimation.py
@@ -861,8 +861,11 @@ class TestMLAEstimation:
         pattern = [1 if (i % 4) == 3 else 0 for i in range(93)]
         pattern[92] = 1
         b = self._mla_backend(
-            _n_layers = 93, _n_kv_heads_by_layer = pattern, _n_heads = 96,
-            _kda_head_dim = 128, _ssm_conv_kernel = 4,
+            _n_layers = 93,
+            _n_kv_heads_by_layer = pattern,
+            _n_heads = 96,
+            _kda_head_dim = 128,
+            _ssm_conv_kernel = 4,
         )
         # 69 recurrent layers * (3*3*96*128 + 128*128*96) * 4 B
         rs = 69 * (110592 + 1572864) * 4

--- a/studio/backend/tests/test_kv_cache_estimation.py
+++ b/studio/backend/tests/test_kv_cache_estimation.py
@@ -840,6 +840,22 @@ class TestMLAEstimation:
         expected = 61 * _runtime_kv_cells(1000) * 1 * (512 + 64) * 2  # 576
         assert result == expected
 
+    def test_mla_hybrid_counts_only_attention_layers(self):
+        """Kimi-K3: KDA layers are 0 in head_count_kv and hold no growing cache."""
+        pattern = [1 if (i % 4) == 3 else 0 for i in range(93)]
+        pattern[92] = 1
+        b = self._mla_backend(_n_layers = 93, _n_kv_heads_by_layer = pattern)
+        n_attn = sum(1 for v in pattern if v)
+        assert n_attn == 24
+        expected = n_attn * _runtime_kv_cells(1000) * 1 * 576 * 2
+        assert b._estimate_kv_cache_bytes(1000, "f16") == expected
+
+    def test_mla_uniform_unaffected_by_hybrid_path(self):
+        """An all-attention per-layer array must match the plain layer count."""
+        b = self._mla_backend(_n_kv_heads_by_layer = [1] * 61)
+        expected = 61 * _runtime_kv_cells(1000) * 1 * 576 * 2
+        assert b._estimate_kv_cache_bytes(1000, "f16") == expected
+
     def test_mla_defaults_n_kv_to_1_when_heads_absent(self):
         """MLA uses n_kv=1 even if n_kv_heads is None (not n_heads)."""
         b = self._mla_backend(_n_kv_heads = None)  # n_heads=128 still set

--- a/studio/backend/tests/test_kv_cache_estimation.py
+++ b/studio/backend/tests/test_kv_cache_estimation.py
@@ -856,6 +856,28 @@ class TestMLAEstimation:
         expected = 61 * _runtime_kv_cells(1000) * 1 * 576 * 2
         assert b._estimate_kv_cache_bytes(1000, "f16") == expected
 
+    def test_hybrid_adds_recurrent_state(self):
+        """KDA conv+state is f32, per sequence, and does not scale with context."""
+        pattern = [1 if (i % 4) == 3 else 0 for i in range(93)]
+        pattern[92] = 1
+        b = self._mla_backend(
+            _n_layers = 93, _n_kv_heads_by_layer = pattern, _n_heads = 96,
+            _kda_head_dim = 128, _ssm_conv_kernel = 4,
+        )
+        # 69 recurrent layers * (3*3*96*128 + 128*128*96) * 4 B
+        rs = 69 * (110592 + 1572864) * 4
+        assert b._recurrent_state_bytes() == rs
+        kv = 24 * _runtime_kv_cells(1000) * 1 * 576 * 2
+        assert b._estimate_kv_cache_bytes(1000, "f16") == kv + rs
+        # per sequence, so --parallel multiplies it
+        assert b._recurrent_state_bytes(4) == rs * 4
+
+    def test_recurrent_state_zero_without_kda_dims(self):
+        """Uniform MLA and un-parsed Mamba keep the previous behaviour."""
+        assert self._mla_backend()._recurrent_state_bytes() == 0
+        b = self._mla_backend(_n_layers = 93, _n_kv_heads_by_layer = [1] * 93)
+        assert b._recurrent_state_bytes() == 0
+
     def test_mla_defaults_n_kv_to_1_when_heads_absent(self):
         """MLA uses n_kv=1 even if n_kv_heads is None (not n_heads)."""
         b = self._mla_backend(_n_kv_heads = None)  # n_heads=128 still set

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -461,6 +461,13 @@ MODEL_NAME_MAPPING = {
         "unsloth/whisper-large-v3",
         "openai/whisper-large-v3",
     ],
+    # GGUF repo listed too: Kimi-K3 ships GGUF-only, so the -GGUF id is what
+    # reaches the lookup.
+    "unsloth_Kimi-K3.yaml": [
+        "unsloth/kimi-k3",
+        "unsloth/kimi-k3-gguf",
+        "moonshotai/kimi-k3",
+    ],
 }
 
 # Reverse lookup: model_name -> canonical_filename

--- a/studio/frontend/src/components/assistant-ui/message-html-artifacts.tsx
+++ b/studio/frontend/src/components/assistant-ui/message-html-artifacts.tsx
@@ -45,13 +45,15 @@ export const MessageHtmlArtifacts: FC = () => {
   const loadedIsDiffusion = useChatRuntimeStore(
     (state) => state.loadedIsDiffusion,
   );
-  const cardsEnabled = artifactsEnabled || collapseHtmlArtifacts;
   // Full docs already shown by the in-place collapse; excluded for diffusion,
-  // which keeps its code inline instead.
-  const collapsesFullDocs = cardsEnabled && !loadedIsDiffusion;
+  // which keeps its code inline instead. This picks which path renders a full
+  // document, not whether fenced HTML renders at all: the Canvas control is
+  // gone and both flags default off, so gating the cards on them renders none.
+  const collapsesFullDocs =
+    (artifactsEnabled || collapseHtmlArtifacts) && !loadedIsDiffusion;
 
   const fences = useMemo(() => {
-    if (isRunning || hasRenderHtmlTool || !cardsEnabled) {
+    if (isRunning || hasRenderHtmlTool) {
       return [];
     }
     return textBlob
@@ -62,7 +64,7 @@ export const MessageHtmlArtifacts: FC = () => {
           // Skip only the plain fences the in-place collapse actually handles.
           !(fence.isFullDocument && fence.isPlainFence && collapsesFullDocs),
       );
-  }, [isRunning, hasRenderHtmlTool, cardsEnabled, textBlob, collapsesFullDocs]);
+  }, [isRunning, hasRenderHtmlTool, textBlob, collapsesFullDocs]);
 
   if (fences.length === 0) {
     return null;

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -150,75 +150,21 @@ export async function getActiveGenerations(): Promise<ActiveGenerationsResponse>
   return parseJsonOrThrow<ActiveGenerationsResponse>(response);
 }
 
-// A reverse proxy in front of Studio gives up long before a big model finishes
-// loading: Cloudflare's tunnel drops a request with no response headers after
-// ~100s, and nginx/ngrok defaults are similar. A 600 GB MoE takes minutes, so
-// the POST dies even though the load is running fine and completes. Treat these
-// as "response lost", not "load failed".
-const PROXY_TIMEOUT_STATUSES = new Set([502, 503, 504, 520, 522, 524]);
-const LOAD_POLL_INTERVAL_MS = 3000;
-const LOAD_POLL_MAX_MS = 60 * 60 * 1000;
-
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-
-/**
- * Wait out a load whose HTTP response was lost, then re-issue it.
- *
- * /load-progress reports the live load, so poll it until the model is ready or
- * no load is in flight. The retry is cheap and authoritative: the backend
- * short-circuits an already-resident model with status "already_loaded", and if
- * the load actually failed the retry surfaces the real error instead of the
- * proxy's.
- */
-async function awaitLostLoad(
-  send: () => Promise<Response>,
-): Promise<LoadModelResponse> {
-  const deadline = Date.now() + LOAD_POLL_MAX_MS;
-  // phase goes null both before the first sample and after the load settles, so
-  // only treat it as settled once it has been null on two consecutive polls.
-  let idlePolls = 0;
-  while (Date.now() < deadline) {
-    await sleep(LOAD_POLL_INTERVAL_MS);
-    let phase: ModelLoadPhase = null;
-    try {
-      phase = (await getLoadProgress()).phase;
-    } catch {
-      // The proxy can drop polls too; keep waiting rather than fail the load.
-      continue;
-    }
-    if (phase === "ready") break;
-    idlePolls = phase === null ? idlePolls + 1 : 0;
-    if (idlePolls >= 2) break;
-  }
-  return parseJsonOrThrow<LoadModelResponse>(await send());
-}
-
 export async function loadModel(
   payload: LoadModelRequest,
 ): Promise<LoadModelResponse> {
   const preparedToken = await prepareHfTokenForUse(payload.hf_token);
   if (!preparedToken.proceed) throw new Error("Model load cancelled.");
-  const send = () =>
-    authFetch("/api/inference/load", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        ...payload,
-        hf_token: preparedToken.token,
-        native_path_lease: payload.nativePathLease ?? null,
-        nativePathLease: undefined,
-      }),
-    });
-  let response: Response;
-  try {
-    response = await send();
-  } catch {
-    // Connection dropped mid-load; the server side is still going.
-    return awaitLostLoad(send);
-  }
-  if (PROXY_TIMEOUT_STATUSES.has(response.status)) {
-    return awaitLostLoad(send);
-  }
+  const response = await authFetch("/api/inference/load", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      ...payload,
+      hf_token: preparedToken.token,
+      native_path_lease: payload.nativePathLease ?? null,
+      nativePathLease: undefined,
+    }),
+  });
   return parseJsonOrThrow<LoadModelResponse>(response);
 }
 

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -150,21 +150,75 @@ export async function getActiveGenerations(): Promise<ActiveGenerationsResponse>
   return parseJsonOrThrow<ActiveGenerationsResponse>(response);
 }
 
+// A reverse proxy in front of Studio gives up long before a big model finishes
+// loading: Cloudflare's tunnel drops a request with no response headers after
+// ~100s, and nginx/ngrok defaults are similar. A 600 GB MoE takes minutes, so
+// the POST dies even though the load is running fine and completes. Treat these
+// as "response lost", not "load failed".
+const PROXY_TIMEOUT_STATUSES = new Set([502, 503, 504, 520, 522, 524]);
+const LOAD_POLL_INTERVAL_MS = 3000;
+const LOAD_POLL_MAX_MS = 60 * 60 * 1000;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Wait out a load whose HTTP response was lost, then re-issue it.
+ *
+ * /load-progress reports the live load, so poll it until the model is ready or
+ * no load is in flight. The retry is cheap and authoritative: the backend
+ * short-circuits an already-resident model with status "already_loaded", and if
+ * the load actually failed the retry surfaces the real error instead of the
+ * proxy's.
+ */
+async function awaitLostLoad(
+  send: () => Promise<Response>,
+): Promise<LoadModelResponse> {
+  const deadline = Date.now() + LOAD_POLL_MAX_MS;
+  // phase goes null both before the first sample and after the load settles, so
+  // only treat it as settled once it has been null on two consecutive polls.
+  let idlePolls = 0;
+  while (Date.now() < deadline) {
+    await sleep(LOAD_POLL_INTERVAL_MS);
+    let phase: ModelLoadPhase = null;
+    try {
+      phase = (await getLoadProgress()).phase;
+    } catch {
+      // The proxy can drop polls too; keep waiting rather than fail the load.
+      continue;
+    }
+    if (phase === "ready") break;
+    idlePolls = phase === null ? idlePolls + 1 : 0;
+    if (idlePolls >= 2) break;
+  }
+  return parseJsonOrThrow<LoadModelResponse>(await send());
+}
+
 export async function loadModel(
   payload: LoadModelRequest,
 ): Promise<LoadModelResponse> {
   const preparedToken = await prepareHfTokenForUse(payload.hf_token);
   if (!preparedToken.proceed) throw new Error("Model load cancelled.");
-  const response = await authFetch("/api/inference/load", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      ...payload,
-      hf_token: preparedToken.token,
-      native_path_lease: payload.nativePathLease ?? null,
-      nativePathLease: undefined,
-    }),
-  });
+  const send = () =>
+    authFetch("/api/inference/load", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...payload,
+        hf_token: preparedToken.token,
+        native_path_lease: payload.nativePathLease ?? null,
+        nativePathLease: undefined,
+      }),
+    });
+  let response: Response;
+  try {
+    response = await send();
+  } catch {
+    // Connection dropped mid-load; the server side is still going.
+    return awaitLostLoad(send);
+  }
+  if (PROXY_TIMEOUT_STATUSES.has(response.status)) {
+    return awaitLostLoad(send);
+  }
   return parseJsonOrThrow<LoadModelResponse>(response);
 }
 


### PR DESCRIPTION
Three fixes found while bringing up `unsloth/Kimi-K3-GGUF` in Studio.

## 1. Hybrid MLA cache was mis-sized in both directions

Kimi-K3 has 93 blocks but only 24 MLA attention layers. The other 69 are KDA
linear attention. The GGUF publishes this as a per-layer
`attention.head_count_kv` array (`[0, 0, 0, 1, ...]`, non-zero at blocks
3, 7, 11 ... 91, 92), which the loader already parses into
`_n_kv_heads_by_layer` and uses in the sliding-window path. The MLA branch of
`_estimate_kv_cache_bytes` ignored it and multiplied by every block.

That over-reserved the token-growing cache by 3.88x, 104.6 GiB against 27.0 GiB
at the model's 1M train context. But the KDA layers are not free either: they
allocate an f32 conv + delta state through `llama_memory_recurrent`, offloaded
beside the KV cache and sized by `llama_hparams::n_embd_r`/`n_embd_s`:

```
n_embd_r = 3 * (d_conv - 1) * n_head * kda_head_dim = 3*3*96*128 =   110,592
n_embd_s = kda_head_dim^2 * n_head                  = 128*128*96 = 1,572,864
69 layers * 1,683,456 * 4 B                                      = 443.11 MiB
```

That term is per sequence and context-independent, so it dominates at short
contexts and the bisection in `_fit_context_to_vram` cannot shrink it away.
Counting only the MLA layers without adding it would have traded a long-context
over-reserve for a short-context under-reserve:

| n_ctx | before | MLA layers only | with recurrent state |
|---|---:|---:|---:|
| 4K | 419 MiB | 108 MiB | 551 MiB |
| 1M | 104.6 GiB | 27.0 GiB | 27.43 GiB |

So this does both: counts only layers whose per-layer head count is non-zero,
and adds `_recurrent_state_bytes` scaled by `n_parallel`. `ssm.conv_kernel` and
`kda.head_dim` are now parsed; `ssm.state_size` was already parsed but never
read. Mamba hybrids need `ssm.group_count`, which is still unparsed, so they
keep the previous behaviour rather than get a wrong number. Uniform MLA models
publish no per-layer array and no KDA dims, so DeepSeek-V3, GLM and Kimi-K2.5
are unchanged.

## 2. Fenced HTML stopped rendering in chat

`#6374` rendered ` ```html ` blocks as canvas cards unconditionally and used
`artifactsEnabled || collapseHtmlArtifacts` only to decide which path shows a
full document. `#7514` reused those same flags as an on/off gate for the cards
themselves:

```js
const cardsEnabled = artifactsEnabled || collapseHtmlArtifacts;
if (isRunning || hasRenderHtmlTool || !cardsEnabled) return [];   // added
```

Both default to `false` and the Canvas control has since been removed, so
nothing can set them and no fenced HTML renders at all. The renderer was never
broken, the call was unreachable.

The gate returns to the `#6374` form. `collapsesFullDocs` keeps the meaning
`#7514` gave it, and it is deliberately the same expression the in-place
collapse uses at `markdown-text.tsx:233`. That shared expression is what keeps
exactly one path active: with the flags off the collapse is off and cards
render everything; with them on the collapse takes full plain documents and
cards skip precisely those. No double render either way.

## 3. Kimi-K3 inference defaults

Moonshot's recommended sampling (temperature 1.0, top_p 0.95, min_p 0.0), which
otherwise fell back to `default.yaml` at 0.7 and min_p 0.01. The mapping lists
the GGUF repo id too, since Kimi-K3 ships GGUF-only and that is the id that
reaches the lookup.

Reasoning needed no change: the chat template exposes low, high and max, and
`detect_reasoning_flags` already returns `enable_thinking_effort` with
`['none', 'low', 'high', 'max']`, where `none` renders as thinking off.

## Not included

An earlier revision also made `loadModel` survive a reverse-proxy timeout, so a
long load reported success instead of a 524. It is out until it can be done
properly. Polling `/load-progress` and resending the POST is unsafe: that
endpoint samples llama-server through `/proc`, so it reports null for
safetensors and for a still-downloading model and the retry fires early; a
genuine connection failure routes into the same path and is masked for up to an
hour; the resend carries no abort signal, so it can revive a load the user
cancelled through `/unload`; the `native_path_lease` is consumed before the
`already_loaded` short-circuit and has a 120s TTL, so a native-backed retry
fails deterministically; and replaying settings the backend normalized (a
tensor-parallel fallback, for instance) misses
`_request_matches_loaded_settings` and unloads a healthy model to repeat an
expensive load.

The right shape already exists in this repo: export handles the same 524 by
polling an authoritative status endpoint (`core/export/orchestrator.py:71`,
`features/export/api/export-api.ts:33-44`). A follow-up should use
`getInferenceStatus()` rather than the liveness sampler, thread the abort
signal, and re-mint the lease.

## Testing

- `tsc -b` clean. `eslint` clean on the changed file (the one remaining error
  in `message-html-artifacts.tsx:12` is a pre-existing restricted import,
  present on unmodified `main`).
- 215 backend tests pass across `test_kv_cache_estimation.py`,
  `test_llama_cpp_context_fit.py` and `test_model_defaults_none_guard.py`,
  including four new ones: hybrid vs uniform MLA layer counting, the recurrent
  state term and its `n_parallel` scaling, and that it stays zero for models
  without KDA dims.
- Verified against the real 594 GB `UD-IQ1_S` GGUF on 8x B200. Every figure
  above is computed from that file's own metadata.
