### PR TITLE
Name the encoding on the tasklist liveness probe

### DIFF
--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -806,6 +806,8 @@ def _pid_alive(pid: int) -> bool:
                 ["tasklist", "/FI", f"PID eq {int(pid)}", "/NH", "/FO", "CSV"],
                 capture_output = True,
                 text = True,
+                encoding = "utf-8",
+                errors = "replace",
                 timeout = 10,
             ).stdout
         except Exception:


### PR DESCRIPTION
## Summary

`Repo tests (CPU)` is failing on main, and therefore on every open PR.

`studio/backend/tests/test_text_io_encoding.py` requires every text-mode subprocess to name its encoding, because the default falls back to the Windows ANSI codepage and corrupts non-ASCII. The `tasklist` liveness probe added at `studio/backend/run.py:805` does not:

```
run.py:805: subprocess(text = True) without encoding
```

This names it the same way `cloudflare_tunnel.py:312` already does. `errors = "replace"` matters here specifically: `tasklist` writes in the console codepage, so a process name outside UTF-8 would otherwise raise `UnicodeDecodeError` inside a probe whose whole job is to answer whether a PID is alive.

Confirmed against `origin/main` with no other changes, so this is not attributable to any PR.

## Test plan

`python3 -m pytest studio/backend/tests/test_text_io_encoding.py -q`

- Before: `1 failed, 324 passed`
- After: `325 passed`
