### PR TITLE
Studio: load Kimi-K3 with thinking on, and fix its sampling defaults

### DIFF
--- a/studio/backend/assets/configs/inference_defaults.json
+++ b/studio/backend/assets/configs/inference_defaults.json
@@ -319,6 +319,13 @@
       "min_p": 0.01,
       "repetition_penalty": 1.0
     },
+    "kimi-k3": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": -1,
+      "min_p": 0.0,
+      "repetition_penalty": 1.0
+    },
     "kimi-k2": {
       "temperature": 0.6,
       "top_p": 0.95,
@@ -406,7 +413,7 @@
     "nemotron",
     "minimax-m2.7", "minimax-m2.5", "minimax",
     "gpt-oss", "granite-4",
-    "kimi-k2", "kimi",
+    "kimi-k3", "kimi-k2", "kimi",
     "lfm2", "smollm", "olmo", "falcon", "ernie", "seed", "grok", "mimo"
   ]
 }

--- a/studio/backend/assets/configs/model_defaults/other/unsloth_Kimi-K3.yaml
+++ b/studio/backend/assets/configs/model_defaults/other/unsloth_Kimi-K3.yaml
@@ -1,8 +1,0 @@
-# Model defaults for unsloth/Kimi-K3
-# Also applies to: moonshotai/Kimi-K3, unsloth/Kimi-K3-GGUF
-# Inference values are Moonshot's recommended sampling settings.
-
-inference:
-  temperature: 1.0
-  top_p: 0.95
-  min_p: 0.0

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -895,8 +895,12 @@ def detect_reasoning_flags(
     tpl = chat_template
     prefix = f"{log_source}: " if log_source else ""
 
+    # 'none' is this style's disable sentinel, not an effort level: the off
+    # switch is enable_thinking=false, and the Think menu already hides it.
+    # Left in, it is the weakest level, so a stored effort the model does not
+    # offer clamps onto it and silently disables thinking (Kimi-K3).
     effort_levels = (
-        _extract_reasoning_effort_levels(tpl)
+        [lv for lv in _extract_reasoning_effort_levels(tpl) if lv != "none"]
         if ("reasoning_effort" in tpl and "enable_thinking" in tpl)
         else []
     )
@@ -904,7 +908,7 @@ def detect_reasoning_flags(
         # DeepSeek-V4's encoder accepts reasoning_effort {'high', 'max'} but its
         # template only branches on 'max', so the literal scan misses 'high'. Add it
         # (matched on whole repo-name segments, so 'deepseek-v40' won't false-match)
-        # to expose the full none/high/max ladder instead of none/max.
+        # to expose the full high/max ladder instead of max alone.
         segments = re.split(r"[-_.]", (model_identifier or "").lower().split("/")[-1])
         is_dsv4 = "deepseek4" in segments or any(
             a == "deepseek" and b == "v4" for a, b in zip(segments, segments[1:])

--- a/studio/backend/tests/test_kimi_k3_reasoning_defaults.py
+++ b/studio/backend/tests/test_kimi_k3_reasoning_defaults.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Kimi-K3 loads with thinking on, and with Moonshot's sampling.
+
+Kimi-K3's template branches ``reasoning_effort`` on ``'none'`` as its disable
+sentinel, so the literal scan used to surface ``none`` as the weakest level.
+The chat store ships ``medium``, which the ladder does not offer, so the clamp
+fell back to ``levels[0] == 'none'`` -- which ``_request_reasoning_kwargs``
+turns into ``enable_thinking=false``. A reasoning model therefore loaded with
+reasoning off, via a level the Think menu hides and no one can pick. Dropping
+the sentinel leaves ``low`` as the floor, so the same fallback now lands on a
+real level; the Think menu still offers high and max, and the pick persists.
+
+The sampling defaults live in ``inference_defaults.json`` rather than a
+``model_defaults`` YAML: those are matched by family substring, so every id
+shape resolves (bare repo, ``repo:variant``, cache snapshot path, ``.gguf``
+path), and the training form still resets from ``default.yaml``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_backend_root = Path(__file__).resolve().parent.parent
+if str(_backend_root) not in sys.path:
+    sys.path.insert(0, str(_backend_root))
+
+
+# Faithful slice of the Kimi-K3 template: the reasoning_effort pre-pass that
+# maps 'none' to off and 'low'/'high'/'max' to a level, plus the enable_thinking
+# gate layered over it.
+KIMI_K3_TEMPLATE = """
+{%- set rens = namespace(off = false, effort = none) -%}
+{%- if reasoning_effort is defined and reasoning_effort is not none -%}
+{%- if reasoning_effort == 'none' -%}{%- set rens.off = true -%}
+{%- elif reasoning_effort in ['low', 'high', 'max'] -%}
+{%- set rens.effort = reasoning_effort -%}{%- endif -%}{%- endif -%}
+{%- if thinking is not defined -%}
+{%- if enable_thinking is defined -%}{%- set thinking = enable_thinking -%}
+{%- elif rens.off -%}{%- set thinking = false -%}
+{%- else -%}{%- set thinking = true -%}{%- endif -%}{%- endif -%}
+"""
+
+KIMI_K3_IDS = [
+    "unsloth/Kimi-K3-GGUF",
+    "unsloth/Kimi-K3",
+    "moonshotai/Kimi-K3",
+    "unsloth/Kimi-K3-GGUF:UD-IQ1_S",
+    "/home/u/.cache/huggingface/hub/models--unsloth--Kimi-K3-GGUF/snapshots/deadbeef",
+    "/data/models/Kimi-K3-GGUF/UD-IQ1_S/Kimi-K3-UD-IQ1_S-00001-of-00014.gguf",
+]
+
+
+def _detect(template, model_id = "unsloth/Kimi-K3-GGUF"):
+    from core.inference.llama_cpp import detect_reasoning_flags
+
+    return detect_reasoning_flags(template, model_id)
+
+
+def test_none_is_not_offered_as_an_effort_level():
+    flags = _detect(KIMI_K3_TEMPLATE)
+    assert flags["supports_reasoning"] is True
+    assert flags["reasoning_style"] == "enable_thinking_effort"
+    assert flags["reasoning_effort_levels"] == ["low", "high", "max"]
+
+
+def test_a_template_offering_only_none_is_not_an_effort_ladder():
+    # Dropping the sentinel leaves nothing, so this is a plain on/off model.
+    flags = _detect("{% if reasoning_effort == 'none' %}{{ enable_thinking }}{% endif %}")
+    assert flags["reasoning_style"] == "enable_thinking"
+    assert flags["reasoning_effort_levels"] == []
+
+
+def test_disabling_still_reaches_the_template():
+    # The off switch is enable_thinking=false, so removing the level costs
+    # nothing: a raw caller sending reasoning_effort="none" still disables.
+    from core.inference.llama_cpp import LlamaCppBackend
+
+    backend = LlamaCppBackend()
+    backend._supports_reasoning = True
+    backend._reasoning_always_on = False
+    backend._reasoning_style = "enable_thinking_effort"
+    backend._reasoning_effort_levels = ["low", "high", "max"]
+
+    assert backend._request_reasoning_kwargs(False, None) == {"enable_thinking": False}
+    assert backend._request_reasoning_kwargs(None, "none") == {"enable_thinking": False}
+    assert backend._request_reasoning_kwargs(True, "high") == {
+        "enable_thinking": True,
+        "reasoning_effort": "high",
+    }
+
+
+@pytest.mark.parametrize("model_id", KIMI_K3_IDS)
+def test_sampling_defaults_resolve_for_every_id_shape(model_id):
+    from utils.inference.inference_config import load_inference_config
+
+    config = load_inference_config(model_id)
+    assert config["temperature"] == 1.0
+    assert config["top_p"] == 0.95
+    assert config["min_p"] == 0.0
+
+
+def test_kimi_k2_keeps_its_own_defaults():
+    from utils.inference.inference_config import load_inference_config
+
+    config = load_inference_config("unsloth/Kimi-K2-Instruct")
+    assert config["temperature"] == 0.6
+    assert config["min_p"] == 0.01
+
+
+@pytest.mark.parametrize("model_id", ["unsloth/Kimi-K3", "moonshotai/Kimi-K3"])
+def test_training_defaults_still_come_from_default_yaml(model_id):
+    # load_model_defaults replaces default.yaml rather than merging with it, so
+    # an inference-only YAML would leave the previous model's hyperparameters
+    # in the training form.
+    from utils.models.model_config import load_model_defaults
+
+    assert "training" in load_model_defaults(model_id)
+
+
+def test_every_mapping_entry_points_at_a_real_file():
+    from utils.models.model_config import MODEL_NAME_MAPPING
+
+    defaults_dir = _backend_root / "assets" / "configs" / "model_defaults"
+    missing = [
+        name
+        for name in MODEL_NAME_MAPPING
+        if not any(defaults_dir.rglob(name))
+    ]
+    assert missing == []

--- a/studio/backend/utils/models/model_config.py
+++ b/studio/backend/utils/models/model_config.py
@@ -461,13 +461,6 @@ MODEL_NAME_MAPPING = {
         "unsloth/whisper-large-v3",
         "openai/whisper-large-v3",
     ],
-    # GGUF repo listed too: Kimi-K3 ships GGUF-only, so the -GGUF id is what
-    # reaches the lookup.
-    "unsloth_Kimi-K3.yaml": [
-        "unsloth/kimi-k3",
-        "unsloth/kimi-k3-gguf",
-        "moonshotai/kimi-k3",
-    ],
 }
 
 # Reverse lookup: model_name -> canonical_filename


### PR DESCRIPTION
## Problem

Loading `unsloth/Kimi-K3-GGUF` in Chat gives you a reasoning model with reasoning switched off, and no way to tell why from the UI.

Kimi-K3's template uses `reasoning_effort == 'none'` as its disable sentinel, not as an effort level:

```jinja
{%- if reasoning_effort == 'none' -%}{%- set rens.off = true -%}
{%- elif reasoning_effort in ['low', 'high', 'max'] -%}
{%- set rens.effort = reasoning_effort -%}{%- endif -%}
```

`_extract_reasoning_effort_levels` scans quoted literals, so `'none'` was swept into the ladder as its weakest entry: `['none', 'low', 'high', 'max']`. The chat store ships `reasoningEffort: "medium"`, which Kimi-K3 does not offer, so `clampReasoningEffortToLevels` fell back to `effortLevels[0]` -- `'none'`. `_request_reasoning_kwargs` turns that into `enable_thinking=false`.

The Think menu filters `'none'` out of the dropdown, so the level was never selectable by hand. It could only ever arrive from that fallback.

Rendering the shipped template end to end:

| | levels | clamped effort | chat_template_kwargs | rendered |
|---|---|---|---|---|
| before | `['none', 'low', 'high', 'max']` | `none` | `{'enable_thinking': False}` | thinking **off** |
| after | `['low', 'high', 'max']` | `low` | `{'enable_thinking': True, 'reasoning_effort': 'low'}` | thinking **on** |

## Fix

Drop the sentinel from the `enable_thinking_effort` ladder. The clamp itself is untouched: with `'none'` gone it lands on `low`, thinking is on, and high and max stay one click away in the Think menu with the choice persisted.

Disabling is unaffected. `_request_reasoning_kwargs` compares `reasoning_effort == "none"` directly rather than testing list membership, so a raw API caller sending the OpenAI-style sentinel still gets `enable_thinking=false`.

## Blast radius

Ran 33 chat templates through `detect_reasoning_flags` before and after: 29 pulled from the Hub (Qwen3, GLM-4.5 / 4.6 / Air, DeepSeek V3.1 / V3.2 / R1, gpt-oss 20b and 120b, MiniMax, Nemotron, granite-4, Gemma-3, Llama-4, Phi-4, ERNIE, Seed-OSS, Ling, Hunyuan, Kimi-K2) plus the four fixtures in `test_deepseek_v4_thinking_effort.py`. Only Kimi-K3 changes:

| template | levels | |
|---|---|---|
| Kimi-K3 | `['none','low','high','max']` -> `['low','high','max']` | changed |
| GLM-5.2 fixture | `['high', 'max']` | unchanged |
| DeepSeek-V4-Flash fixture | `['high', 'max']` | unchanged |
| max-only fixture | `['max']` | unchanged |
| high-only fixture | `['high']` | unchanged |
| the other 28 | no effort ladder | unchanged |

## Sampling defaults

Also moves the Kimi-K3 sampling defaults added in #7616 from `model_defaults/other/unsloth_Kimi-K3.yaml` into `inference_defaults.json`, which is where the other large inference-only MoEs live.

The YAML is reached by exact alias or a one/two-component path suffix, so only the bare repo id matched. Everything else fell through to the pre-existing `kimi` family at temperature 0.6 / min_p 0.01:

| id | before | after |
|---|---|---|
| `unsloth/Kimi-K3-GGUF` | 1.0 / 0.0 | 1.0 / 0.0 |
| `unsloth/Kimi-K3-GGUF:UD-IQ1_S` | 0.6 / 0.01 | 1.0 / 0.0 |
| `.../models--unsloth--Kimi-K3-GGUF/snapshots/<sha>` | 0.6 / 0.01 | 1.0 / 0.0 |
| `/data/models/Kimi-K3-GGUF/UD-IQ1_S/....gguf` | 0.6 / 0.01 | 1.0 / 0.0 |

The snapshot path is not hypothetical: `_repo_gguf_load_id` publishes a snapshot filesystem path as the `load_id` for a GGUF repo in a non-active cache root, which is where a 2.8 TB repo tends to live.

It also restores the training-form reset. `load_model_defaults` replaces `default.yaml` rather than merging with it, and that YAML was the only one of 79 with no `training:` block, so selecting `unsloth/Kimi-K3` left the previously selected model's LR, batch size and target modules in the form. `load_model_defaults("unsloth/Kimi-K3")` returned `['inference']` and now returns `['inference', 'logging', 'lora', 'training']` again.

Diffed the resolved inference config for 394 model ids before and after: exactly the two broken Kimi-K3 path forms change. Kimi-K2 keeps 0.6 / 0.01.

## Tests

13 new tests in `test_kimi_k3_reasoning_defaults.py` covering the ladder, the only-`none` edge case, both disable routes, all six Kimi-K3 id shapes, Kimi-K2 staying put, the training-block invariant, and a guard that every `MODEL_NAME_MAPPING` entry points at a file that exists.

Full backend suite: 9647 passed. The 12 `test_studio_api.py` e2e failures are pre-existing on main in this environment (401 against the locally booted server) and reproduce identically without this branch.
