### PR TITLE
Studio: make the API keys list scrollable

### DIFF
--- a/studio/frontend/src/features/settings/tabs/api-keys-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/api-keys-tab.tsx
@@ -160,7 +160,7 @@ export function ApiKeysTab() {
             {t("settings.apiKeys.noAccess")}
           </p>
         ) : (
-          <div className="flex min-w-0 flex-col">
+          <div className="hover-scrollbar flex max-h-72 min-w-0 flex-col overflow-y-auto pr-1 [scrollbar-gutter:stable]">
             {keys.map((k) => (
               <ApiKeyRow key={k.id} apiKey={k} onRevoke={setRevokeTarget} />
             ))}


### PR DESCRIPTION
The access tokens list in Settings > API had no height limit, so it grew with every key created. Past a handful of tokens the list pushed the API monitor, usage examples, and model auto-switch sections down and off the visible area, and the tab itself became a long scroll.

Cap the list at 288px and give it its own scroll container. Sizing is chosen so the ~5th row is clipped mid-row, which signals there's more to scroll. Uses the existing `hover-scrollbar` treatment from the settings dialog and sidebar, plus `scrollbar-gutter: stable` so the scrollbar doesn't sit over each row's `⋯` menu button.