### PR TITLE
Studio: Don't disarm Ctrl+C in agents launched by unsloth start

### DIFF
--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -2717,8 +2717,9 @@ def _launch(
         # subprocess cwd was changed by the caller. Some Node CLIs use PWD for
         # project-root discovery instead of process.cwd().
         child_env["PWD"] = os.getcwd()
-    # Ctrl+C cancels a turn inside the agent; don't let it kill this wrapper.
-    previous = signal.signal(signal.SIGINT, signal.SIG_IGN)
+    # Ctrl+C cancels a turn inside the agent; don't let it kill this wrapper. A no-op
+    # handler, not SIG_IGN: exec preserves an ignored signal but resets a caught one.
+    previous = signal.signal(signal.SIGINT, lambda *_: None)
     try:
         code = subprocess.run([executable, *command[1:]], env = child_env).returncode
     finally:

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -9,6 +9,7 @@ import json
 import os
 import re
 import shlex
+import signal
 import sys
 import time
 import urllib.error
@@ -1459,6 +1460,25 @@ def test_launch_native_posix_child_gets_current_pwd(fake_studio, monkeypatch, tm
     assert captured["command"][0] == "/usr/local/bin/opencode"
     if os.name != "nt":
         assert captured["env"]["PWD"] == os.getcwd()
+
+
+@pytest.mark.skipif(os.name == "nt", reason = "POSIX exec signal semantics")
+def test_launch_leaves_child_able_to_handle_sigint(monkeypatch, tmp_path):
+    # SIG_IGN here reached the agent too, so hermes could never be interrupted.
+    probe = tmp_path / "probe.py"
+    probe.write_text(
+        "import signal, sys\n"
+        "sys.exit(17 if signal.getsignal(signal.SIGINT) == signal.SIG_IGN else 0)\n",
+        encoding = "utf-8",
+    )
+    monkeypatch.setattr(start.shutil, "which", lambda _: sys.executable)
+    monkeypatch.setattr(start, "_augment_path_with_install_dirs", lambda: None)
+    before = signal.getsignal(signal.SIGINT)
+
+    code = start._launch([sys.executable, str(probe)], {}, install_hint = "n/a")
+
+    assert code == 0, "child saw SIG_IGN and could never be interrupted"
+    assert signal.getsignal(signal.SIGINT) is before
 
 
 def test_connect_claude_launch_scrubs_conflicting_auth_env(fake_studio, monkeypatch):


### PR DESCRIPTION
Ctrl+C did nothing when running hermes through `unsloth start`. The task ran to completion and exited 0:
```
unsloth start hermes --model unsloth/gemma-4-E2B-it-GGUF -z "count from 1 to 300"
```
It now stops on the first Ctrl+C and exits 130. Cause: `_launch` set SIGINT to SIG_IGN to keep Ctrl+C from killing the wrapper, but exec preserves an ignored signal, so the agent inherited it and hermes installs no handler of its own. A no-op handler works instead, because exec resets a caught signal back to the default. Behavior first, then the mechanism. Same title as before: Don't disarm Ctrl+C in agents launched by unsloth start.
