### PR TITLE
Studio: keep a slow model load alive through a proxy timeout

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -8295,7 +8295,9 @@ class LlamaCppBackend:
                         f"est. KV cache: {kv_cache_bytes / (1024**3):.1f} GB, "
                         f"{_mtp_note}"
                         f"context: {effective_ctx}, "
-                        f"GPUs free: {gpus}, selected: {gpu_indices}, fit: {use_fit}"
+                        # "--fit on", not "does it fit": False means the subset above
+                        # was proven to hold the model and is pinned with --fit off.
+                        f"GPUs free: {gpus}, selected: {gpu_indices}, --fit: {'on' if use_fit else 'off'}"
                     )
                 except Exception as e:
                     logger.warning(f"GPU selection failed ({e}), using --fit on")

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -8295,8 +8295,7 @@ class LlamaCppBackend:
                         f"est. KV cache: {kv_cache_bytes / (1024**3):.1f} GB, "
                         f"{_mtp_note}"
                         f"context: {effective_ctx}, "
-                        # "--fit on", not "does it fit": False means the subset above
-                        # was proven to hold the model and is pinned with --fit off.
+                        # --fit flag state, not "does it fit": off means this subset provably fits.
                         f"GPUs free: {gpus}, selected: {gpu_indices}, --fit: {'on' if use_fit else 'off'}"
                     )
                 except Exception as e:

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -5468,6 +5468,24 @@ async def load_model(
 
     GGUF models load via llama-server (llama.cpp) instead of Unsloth.
     """
+    return await _tunnel_safe_json(
+        load_model_gated(request, fastapi_request, current_subject), label = "Model load"
+    )
+
+
+async def load_model_gated(
+    request: LoadRequest,
+    fastapi_request: Request,
+    current_subject: str,
+):
+    """Everything ``POST /load`` does except the tunnel-safe padding.
+
+    In-process callers (preview) must await THIS, never the route: the route's
+    slow path returns a StreamingResponse whose body nobody in-process drains, so
+    awaiting the route would return while the load is still running and would hide
+    a late failure in a body that is never read. Awaiting this instead blocks until
+    the model is really loaded and raises the real exception.
+    """
     # A sidecar install that has reserved the swap must not lose to a load that
     # then gets unloaded by the pre-swap teardown. Rechecked under the gate: an
     # install can reserve while this request queues on the gate, so the pre-gate
@@ -5475,27 +5493,23 @@ async def load_model(
     from core.inference.llama_keepwarm import inference_lifecycle_gate
 
     _raise_if_sidecar_swap_in_progress()
-
-    async def _load():
-        # Hold the lifecycle gate across the load so idle auto-unload can't unload the
-        # model mid-load. Auto-switch calls _load_model_impl directly since it already
-        # holds this gate.
-        async with inference_lifecycle_gate():
-            _raise_if_sidecar_swap_in_progress()
-            # The active-generation gate runs inside _load_model_impl, once it knows this is a real
-            # reload, and still under the lifecycle gate so the check stays atomic with the teardown.
-            return await _load_model_impl(
-                request,
-                fastapi_request,
-                current_subject,
-                on_reload_confirmed = lambda *, cancel: _raise_or_cancel_active_generations(
-                    force = request.force_cancel_active,
-                    action = "Loading a model",
-                    cancel = cancel,
-                ),
-            )
-
-    return await _tunnel_safe_json(_load(), label = "Model load")
+    # Hold the lifecycle gate across the load so idle auto-unload can't unload the
+    # model mid-load. Auto-switch calls _load_model_impl directly since it already
+    # holds this gate.
+    async with inference_lifecycle_gate():
+        _raise_if_sidecar_swap_in_progress()
+        # The active-generation gate runs inside _load_model_impl, once it knows this is a real
+        # reload, and still under the lifecycle gate so the check stays atomic with the teardown.
+        return await _load_model_impl(
+            request,
+            fastapi_request,
+            current_subject,
+            on_reload_confirmed = lambda *, cancel: _raise_or_cancel_active_generations(
+                force = request.force_cancel_active,
+                action = "Loading a model",
+                cancel = cancel,
+            ),
+        )
 
 
 async def _load_model_impl(
@@ -6944,7 +6958,10 @@ async def unload_model(request: UnloadRequest, current_subject: str = Depends(ge
     """Unload a model from memory.
 
     Padded like /load: a 600 GB GGUF teardown measures 160s, past the proxy
-    timer. See ``_tunnel_safe_json``.
+    timer. See ``_tunnel_safe_json``. Nothing calls this in-process today; a
+    future in-process caller must await ``_unload_model_impl`` (as ``/load``'s
+    must await ``load_model_gated``), because the padded path returns a
+    StreamingResponse instead of the payload.
     """
     return await _tunnel_safe_json(
         _unload_model_impl(request, current_subject), label = "Model unload"

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -11,6 +11,7 @@ import time
 import uuid
 from pathlib import Path
 from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.encoders import jsonable_encoder
 from fastapi.responses import StreamingResponse, JSONResponse, Response
 from starlette.requests import ClientDisconnect
 from typing import Any, Callable, List, Literal, Optional, Union
@@ -1563,6 +1564,79 @@ def _tracked_cancel_unstarted_cleanup(tracker):
         tracker.__exit__(None, None, None)
 
     return _cleanup
+
+
+# Cloudflare quick tunnels (--secure mode) drop a request whose origin has sent
+# no body bytes for ~100s, and a 600 GB GGUF load runs for 100-330s: the browser
+# shows "Request failed" on a load the server completes fine. Measured against a
+# real quick tunnel, flushing the status line early is NOT enough -- a response
+# with headers at t=0 and no body still 524s -- but a single space every 20s
+# survives indefinitely. So a slow call commits a 200 and pads until its payload
+# is ready. Leading whitespace is legal JSON, so clients parse the body as-is.
+_TUNNEL_KEEPALIVE_AFTER_S = 15.0
+_TUNNEL_KEEPALIVE_EVERY_S = 20.0
+
+# Underscored so it cannot collide with a real field or the OpenAI ``error``
+# envelope: once the status is committed, a late failure can only travel in-band.
+_DEFERRED_ERROR_KEY = "_deferred_error"
+
+
+def _deferred_error_body(status_code: int, detail) -> bytes:
+    body = {_DEFERRED_ERROR_KEY: {"status_code": status_code, "detail": detail}}
+    return json.dumps(body).encode()
+
+
+async def _tunnel_safe_json(coro, *, label: str):
+    """Await ``coro``, padding the response body if it outruns the tunnel timer.
+
+    A call that finishes within ``_TUNNEL_KEEPALIVE_AFTER_S`` keeps the current
+    contract exactly, HTTPException and its status code included. Only a slower
+    one switches to a padded stream, and it pays for that by having to report a
+    late failure in the body: the status line is long gone by the time it is
+    known. Every failure raised before the delay elapses -- argument validation,
+    an unknown identifier, the download-manager and sidecar 409s -- still gets a
+    real status code, because those all raise in the first moments.
+
+    A client disconnect does not cancel the work: the load should finish and
+    leave the model resident either way, as it does today.
+    """
+    task = asyncio.ensure_future(coro)
+    # A client that disconnects mid-pad leaves nobody to await the task, and an
+    # unretrieved exception would log "Task exception was never retrieved".
+    # Retrieving it here does not consume it: result() below still raises.
+    task.add_done_callback(lambda t: t.cancelled() or t.exception())
+    done, _ = await asyncio.wait({task}, timeout = _TUNNEL_KEEPALIVE_AFTER_S)
+    if done:
+        return task.result()  # re-raises exactly as an un-wrapped await would
+
+    logger.info(
+        f"{label} exceeded {_TUNNEL_KEEPALIVE_AFTER_S:.0f}s; "
+        "padding the response so a proxy cannot time it out"
+    )
+
+    async def _body():
+        while True:
+            finished, _ = await asyncio.wait({task}, timeout = _TUNNEL_KEEPALIVE_EVERY_S)
+            if not finished:
+                yield b" "
+                continue
+            try:
+                payload = task.result()
+            except HTTPException as exc:
+                logger.info(f"{label} failed with {exc.status_code} after the response committed")
+                yield _deferred_error_body(exc.status_code, exc.detail)
+            except Exception as exc:
+                logger.exception(f"{label} failed after the response was committed")
+                yield _deferred_error_body(500, f"{type(exc).__name__}: {exc}")
+            else:
+                yield json.dumps(jsonable_encoder(payload)).encode()
+            return
+
+    return _SameTaskStreamingResponse(
+        _body(),
+        media_type = "application/json",
+        headers = {"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
 
 
 async def _aclose_stream_resources(
@@ -5406,23 +5480,27 @@ async def load_model(
     from core.inference.llama_keepwarm import inference_lifecycle_gate
 
     _raise_if_sidecar_swap_in_progress()
-    # Hold the lifecycle gate across the load so idle auto-unload can't unload the
-    # model mid-load. Auto-switch calls _load_model_impl directly since it already
-    # holds this gate.
-    async with inference_lifecycle_gate():
-        _raise_if_sidecar_swap_in_progress()
-        # The active-generation gate runs inside _load_model_impl, once it knows this is a real
-        # reload, and still under the lifecycle gate so the check stays atomic with the teardown.
-        return await _load_model_impl(
-            request,
-            fastapi_request,
-            current_subject,
-            on_reload_confirmed = lambda *, cancel: _raise_or_cancel_active_generations(
-                force = request.force_cancel_active,
-                action = "Loading a model",
-                cancel = cancel,
-            ),
-        )
+
+    async def _load():
+        # Hold the lifecycle gate across the load so idle auto-unload can't unload the
+        # model mid-load. Auto-switch calls _load_model_impl directly since it already
+        # holds this gate.
+        async with inference_lifecycle_gate():
+            _raise_if_sidecar_swap_in_progress()
+            # The active-generation gate runs inside _load_model_impl, once it knows this is a real
+            # reload, and still under the lifecycle gate so the check stays atomic with the teardown.
+            return await _load_model_impl(
+                request,
+                fastapi_request,
+                current_subject,
+                on_reload_confirmed = lambda *, cancel: _raise_or_cancel_active_generations(
+                    force = request.force_cancel_active,
+                    action = "Loading a model",
+                    cancel = cancel,
+                ),
+            )
+
+    return await _tunnel_safe_json(_load(), label = "Model load")
 
 
 async def _load_model_impl(
@@ -6868,6 +6946,17 @@ async def install_latest_transformers_route(
 
 @router.post("/unload", response_model = UnloadResponse)
 async def unload_model(request: UnloadRequest, current_subject: str = Depends(get_current_subject)):
+    """Unload a model from memory.
+
+    Padded like /load: tearing a 600 GB GGUF down has been measured at 160s,
+    past the proxy timer. See ``_tunnel_safe_json``.
+    """
+    return await _tunnel_safe_json(
+        _unload_model_impl(request, current_subject), label = "Model unload"
+    )
+
+
+async def _unload_model_impl(request: UnloadRequest, current_subject: str):
     """
     Unload a model from memory.
     Routes to the correct backend (llama-server for GGUF, Unsloth otherwise).

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -5473,11 +5473,7 @@ async def load_model(
     )
 
 
-async def load_model_gated(
-    request: LoadRequest,
-    fastapi_request: Request,
-    current_subject: str,
-):
+async def load_model_gated(request: LoadRequest, fastapi_request: Request, current_subject: str):
     """Everything ``POST /load`` does except the tunnel-safe padding.
 
     In-process callers (preview) must await THIS, never the route: the route's

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -6177,10 +6177,11 @@ async def _load_model_impl(
                 current_request_counted = current_request_counted,
                 timeout_s = _POST_CANCEL_DRAIN_TIMEOUT_S,
             )
-        # Unload any active GGUF model first
+        # Unload any active GGUF model first. Off the event loop: a 600 GB teardown
+        # measures 160s, and on-loop it would block _tunnel_safe_json's own padding.
         if llama_backend.is_loaded:
             logger.info("Unloading GGUF model before loading Unsloth model")
-            llama_backend.unload_model()
+            await asyncio.to_thread(llama_backend.unload_model)
 
         # Shut down any export subprocess to free VRAM
         try:
@@ -7064,7 +7065,9 @@ async def _unload_model_impl(request: UnloadRequest, current_subject: str):
                 await _drain_and_recancel_before_teardown(
                     force = request.force_cancel_active, action = "Unloading the model"
                 )
-                llama_backend.unload_model()
+                # Off the event loop like the in-flight branch above: a 600 GB teardown
+                # measures 160s, and on-loop it would block this route's own padding.
+                await asyncio.to_thread(llama_backend.unload_model)
                 note_model_unloaded()
                 api_monitor.record_lifecycle(
                     event = "unload",

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -5476,11 +5476,10 @@ async def load_model(
 async def load_model_gated(request: LoadRequest, fastapi_request: Request, current_subject: str):
     """Everything ``POST /load`` does except the tunnel-safe padding.
 
-    In-process callers (preview) must await THIS, never the route: the route's
-    slow path returns a StreamingResponse whose body nobody in-process drains, so
-    awaiting the route would return while the load is still running and would hide
-    a late failure in a body that is never read. Awaiting this instead blocks until
-    the model is really loaded and raises the real exception.
+    In-process callers (preview) must await THIS, not the route: the route's slow
+    path returns a StreamingResponse nobody in-process drains, so awaiting it would
+    return mid-load and hide a late failure in an unread body. This blocks until the
+    model is resident and raises the real exception.
     """
     # A sidecar install that has reserved the swap must not lose to a load that
     # then gets unloaded by the pre-swap teardown. Rechecked under the gate: an
@@ -6177,8 +6176,8 @@ async def _load_model_impl(
                 current_request_counted = current_request_counted,
                 timeout_s = _POST_CANCEL_DRAIN_TIMEOUT_S,
             )
-        # Unload any active GGUF model first. Off the event loop: a 600 GB teardown
-        # measures 160s, and on-loop it would block _tunnel_safe_json's own padding.
+        # Unload any active GGUF model first, off-loop: a 600 GB teardown measures
+        # 160s and on-loop would block _tunnel_safe_json's own padding.
         if llama_backend.is_loaded:
             logger.info("Unloading GGUF model before loading Unsloth model")
             await asyncio.to_thread(llama_backend.unload_model)
@@ -6954,11 +6953,10 @@ async def install_latest_transformers_route(
 async def unload_model(request: UnloadRequest, current_subject: str = Depends(get_current_subject)):
     """Unload a model from memory.
 
-    Padded like /load: a 600 GB GGUF teardown measures 160s, past the proxy
-    timer. See ``_tunnel_safe_json``. Nothing calls this in-process today; a
-    future in-process caller must await ``_unload_model_impl`` (as ``/load``'s
-    must await ``load_model_gated``), because the padded path returns a
-    StreamingResponse instead of the payload.
+    Padded like /load: a 600 GB GGUF teardown measures 160s, past the proxy timer.
+    See ``_tunnel_safe_json``. No in-process caller today; a future one must await
+    ``_unload_model_impl`` (as preview awaits ``load_model_gated``), since the padded
+    path returns a StreamingResponse, not the payload.
     """
     return await _tunnel_safe_json(
         _unload_model_impl(request, current_subject), label = "Model unload"
@@ -7065,8 +7063,8 @@ async def _unload_model_impl(request: UnloadRequest, current_subject: str):
                 await _drain_and_recancel_before_teardown(
                     force = request.force_cancel_active, action = "Unloading the model"
                 )
-                # Off the event loop like the in-flight branch above: a 600 GB teardown
-                # measures 160s, and on-loop it would block this route's own padding.
+                # Off-loop like the in-flight branch above: a 160s teardown on the
+                # loop would block this route's own padding.
                 await asyncio.to_thread(llama_backend.unload_model)
                 note_model_unloaded()
                 api_monitor.record_lifecycle(

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -1566,18 +1566,15 @@ def _tracked_cancel_unstarted_cleanup(tracker):
     return _cleanup
 
 
-# Cloudflare quick tunnels (--secure mode) drop a request whose origin has sent
-# no body bytes for ~100s, and a 600 GB GGUF load runs for 100-330s: the browser
-# shows "Request failed" on a load the server completes fine. Measured against a
-# real quick tunnel, flushing the status line early is NOT enough -- a response
-# with headers at t=0 and no body still 524s -- but a single space every 20s
-# survives indefinitely. So a slow call commits a 200 and pads until its payload
-# is ready. Leading whitespace is legal JSON, so clients parse the body as-is.
+# Cloudflare quick tunnels (--secure) drop a request whose origin has sent no body
+# bytes for ~100s, and a 600 GB GGUF load runs 100-330s. Measured on a real quick
+# tunnel: headers at t=0 with no body still 524s, one space every 20s survives. So
+# a slow call commits a 200 and pads until its payload is ready; leading whitespace
+# is legal JSON, so clients parse the body as-is.
 _TUNNEL_KEEPALIVE_AFTER_S = 15.0
 _TUNNEL_KEEPALIVE_EVERY_S = 20.0
 
-# Underscored so it cannot collide with a real field or the OpenAI ``error``
-# envelope: once the status is committed, a late failure can only travel in-band.
+# Underscored so it cannot collide with a real field or the OpenAI ``error`` envelope.
 _DEFERRED_ERROR_KEY = "_deferred_error"
 
 
@@ -1589,21 +1586,19 @@ def _deferred_error_body(status_code: int, detail) -> bytes:
 async def _tunnel_safe_json(coro, *, label: str):
     """Await ``coro``, padding the response body if it outruns the tunnel timer.
 
-    A call that finishes within ``_TUNNEL_KEEPALIVE_AFTER_S`` keeps the current
-    contract exactly, HTTPException and its status code included. Only a slower
-    one switches to a padded stream, and it pays for that by having to report a
-    late failure in the body: the status line is long gone by the time it is
-    known. Every failure raised before the delay elapses -- argument validation,
-    an unknown identifier, the download-manager and sidecar 409s -- still gets a
-    real status code, because those all raise in the first moments.
+    A call finishing within ``_TUNNEL_KEEPALIVE_AFTER_S`` keeps the current
+    contract exactly, HTTPException status code included; every early failure
+    (validation, unknown identifier, download-manager and sidecar 409s) raises in
+    that window. Only a slower call switches to a padded stream, and it must
+    report a late failure in the body because the status line is already gone.
 
-    A client disconnect does not cancel the work: the load should finish and
-    leave the model resident either way, as it does today.
+    A client disconnect does not cancel the work: the model stays resident, as
+    it does today.
     """
     task = asyncio.ensure_future(coro)
     # A client that disconnects mid-pad leaves nobody to await the task, and an
-    # unretrieved exception would log "Task exception was never retrieved".
-    # Retrieving it here does not consume it: result() below still raises.
+    # unretrieved exception logs "Task exception was never retrieved". Retrieving
+    # it here does not consume it: result() below still raises.
     task.add_done_callback(lambda t: t.cancelled() or t.exception())
     done, _ = await asyncio.wait({task}, timeout = _TUNNEL_KEEPALIVE_AFTER_S)
     if done:
@@ -6948,8 +6943,8 @@ async def install_latest_transformers_route(
 async def unload_model(request: UnloadRequest, current_subject: str = Depends(get_current_subject)):
     """Unload a model from memory.
 
-    Padded like /load: tearing a 600 GB GGUF down has been measured at 160s,
-    past the proxy timer. See ``_tunnel_safe_json``.
+    Padded like /load: a 600 GB GGUF teardown measures 160s, past the proxy
+    timer. See ``_tunnel_safe_json``.
     """
     return await _tunnel_safe_json(
         _unload_model_impl(request, current_subject), label = "Model unload"

--- a/studio/backend/routes/preview.py
+++ b/studio/backend/routes/preview.py
@@ -19,7 +19,7 @@ from auth.storage import DEFAULT_ADMIN_USERNAME
 from models.inference import ChatCompletionRequest, LoadRequest
 from routes.inference import (
     disable_openai_auto_switch_for_request,
-    load_model,
+    load_model_gated,
     openai_chat_completions,
 )
 from state.tool_policy import tools_force_disabled
@@ -165,7 +165,11 @@ async def _serve_chat(
     await _preview_lock.acquire()
     keep_locked = False
     try:
-        await load_model(LoadRequest(model_path = str(path)), request, DEFAULT_ADMIN_USERNAME)
+        # The gated coroutine, not the /load route: the route pads a slow body to
+        # survive a proxy, and that padded StreamingResponse would hand control back
+        # here while the checkpoint is still loading, so the chat below would run
+        # against the previous model (or none).
+        await load_model_gated(LoadRequest(model_path = str(path)), request, DEFAULT_ADMIN_USERNAME)
         # Beats a process-wide `--enable-tools` (enable_tools=False alone wouldn't).
         with tools_force_disabled():
             response = await openai_chat_completions(payload, request, DEFAULT_ADMIN_USERNAME)

--- a/studio/backend/routes/preview.py
+++ b/studio/backend/routes/preview.py
@@ -165,10 +165,9 @@ async def _serve_chat(
     await _preview_lock.acquire()
     keep_locked = False
     try:
-        # The gated coroutine, not the /load route: the route pads a slow body to
-        # survive a proxy, and that padded StreamingResponse would hand control back
-        # here while the checkpoint is still loading, so the chat below would run
-        # against the previous model (or none).
+        # The gated coroutine, not the /load route: the route's padding returns a
+        # StreamingResponse while the checkpoint is still loading, so the chat below
+        # would run against the previous model (or none).
         await load_model_gated(LoadRequest(model_path = str(path)), request, DEFAULT_ADMIN_USERNAME)
         # Beats a process-wide `--enable-tools` (enable_tools=False alone wouldn't).
         with tools_force_disabled():

--- a/studio/backend/tests/test_log_filter_no_truncation.py
+++ b/studio/backend/tests/test_log_filter_no_truncation.py
@@ -21,7 +21,7 @@ class TestNoTruncation:
         # Mirrors the f-string at studio/backend/core/inference/llama_cpp.py:2117
         event = (
             "GGUF size: 232.9 GB, est. KV cache: 87.0 GB, context: 259072, "
-            "GPUs free: [(0, 80000), (1, 80000)], selected: [0, 1], fit: False"
+            "GPUs free: [(0, 80000), (1, 80000)], selected: [0, 1], --fit: off"
         )
         out = _run({"event": event})
         assert out["event"] == event

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -3182,8 +3182,10 @@ def test_note_model_unloaded_clears_reload_stash(monkeypatch):
 
 def test_unload_route_clears_reload_stash(monkeypatch):
     # The /unload route must clear the stash on both the GGUF and non-GGUF branches.
+    # The body lives in the impl; the route itself only wraps it in the padded
+    # response that keeps a slow unload alive through a proxy.
     import inspect
-    src = inspect.getsource(inference_route.unload_model)
+    src = inspect.getsource(inference_route._unload_model_impl)
     assert src.count("note_model_unloaded()") >= 2
 
 

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -3182,8 +3182,7 @@ def test_note_model_unloaded_clears_reload_stash(monkeypatch):
 
 def test_unload_route_clears_reload_stash(monkeypatch):
     # The /unload route must clear the stash on both the GGUF and non-GGUF branches.
-    # The body lives in the impl; the route itself only wraps it in the padded
-    # response that keeps a slow unload alive through a proxy.
+    # Asserted on the impl: the route only wraps it in the padded response.
     import inspect
     src = inspect.getsource(inference_route._unload_model_impl)
     assert src.count("note_model_unloaded()") >= 2

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -1598,8 +1598,7 @@ def test_idle_alias_reload_preserves_override_via_advertised_id(monkeypatch):
 def test_load_route_holds_lifecycle_gate(monkeypatch):
     # Lock the manual /load gate against silent revert: the route must wrap the
     # load in inference_lifecycle_gate so idle-unload can't fire mid-load.
-    # Asserted on the gated coroutine: the route only wraps it in the padded
-    # response, and in-process callers await this instead (see load_model_gated).
+    # Asserted on the gated coroutine: the route only adds the padded response.
     import inspect
 
     src = inspect.getsource(inference_route.load_model_gated)
@@ -1625,8 +1624,8 @@ def test_model_replacements_recheck_sidecar_swap_before_either_backend_is_unload
     standard_wait = src.index("await _wait_for_model_switch_idle", standard_branch)
     standard_sidecar_check = src.index("_raise_if_sidecar_swap_in_progress()", standard_wait)
     standard_cancel = src.index("on_reload_confirmed(cancel = True)", standard_wait)
-    # No parens: both teardowns are asyncio.to_thread arguments (a 600 GB one measures
-    # 160s and on-loop would block /load's tunnel padding).
+    # No parens: both teardowns are asyncio.to_thread args (on-loop a 160s one would
+    # block /load's tunnel padding).
     unload_gguf = src.index("llama_backend.unload_model", standard_wait)
 
     assert already_loaded < gguf_wait < gguf_sidecar_check < gguf_cancel < unload_unsloth
@@ -3186,7 +3185,7 @@ def test_note_model_unloaded_clears_reload_stash(monkeypatch):
 
 def test_unload_route_clears_reload_stash(monkeypatch):
     # The /unload route must clear the stash on both the GGUF and non-GGUF branches.
-    # Asserted on the impl: the route only wraps it in the padded response.
+    # Asserted on the impl: the route only adds the padded response.
     import inspect
     src = inspect.getsource(inference_route._unload_model_impl)
     assert src.count("note_model_unloaded()") >= 2

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -1598,9 +1598,11 @@ def test_idle_alias_reload_preserves_override_via_advertised_id(monkeypatch):
 def test_load_route_holds_lifecycle_gate(monkeypatch):
     # Lock the manual /load gate against silent revert: the route must wrap the
     # load in inference_lifecycle_gate so idle-unload can't fire mid-load.
+    # Asserted on the gated coroutine: the route only wraps it in the padded
+    # response, and in-process callers await this instead (see load_model_gated).
     import inspect
 
-    src = inspect.getsource(inference_route.load_model)
+    src = inspect.getsource(inference_route.load_model_gated)
     assert "inference_lifecycle_gate" in src
     assert "_load_model_impl" in src
 

--- a/studio/backend/tests/test_openai_auto_switch.py
+++ b/studio/backend/tests/test_openai_auto_switch.py
@@ -1625,7 +1625,9 @@ def test_model_replacements_recheck_sidecar_swap_before_either_backend_is_unload
     standard_wait = src.index("await _wait_for_model_switch_idle", standard_branch)
     standard_sidecar_check = src.index("_raise_if_sidecar_swap_in_progress()", standard_wait)
     standard_cancel = src.index("on_reload_confirmed(cancel = True)", standard_wait)
-    unload_gguf = src.index("llama_backend.unload_model()", standard_wait)
+    # No parens: both teardowns are asyncio.to_thread arguments (a 600 GB one measures
+    # 160s and on-loop would block /load's tunnel padding).
+    unload_gguf = src.index("llama_backend.unload_model", standard_wait)
 
     assert already_loaded < gguf_wait < gguf_sidecar_check < gguf_cancel < unload_unsloth
     assert standard_branch < standard_wait < standard_sidecar_check

--- a/studio/backend/tests/test_preview_routes.py
+++ b/studio/backend/tests/test_preview_routes.py
@@ -4,7 +4,7 @@
 """Security smoke for the public /p preview routes.
 
 Exercises the route layer with a real ``preview_router`` while stubbing the
-expensive model calls (``load_model`` / ``openai_chat_completions``). Covers the
+expensive model calls (``load_model_gated`` / ``openai_chat_completions``). Covers the
 public-surface guarantees: HMAC capability gating (a valid ``?k=`` token or
 Bearer credential is required; missing/invalid/wrong-ref tokens 404 before any
 model load), path-traversal rejection, request sanitization (tools / provider
@@ -96,7 +96,7 @@ def client(tmp_path, monkeypatch, captured):
         captured["payload"] = payload
         return {"ok": True}
 
-    monkeypatch.setattr(preview, "load_model", _fake_load_model)
+    monkeypatch.setattr(preview, "load_model_gated", _fake_load_model)
     monkeypatch.setattr(preview, "openai_chat_completions", _fake_chat)
 
     app = FastAPI()
@@ -291,7 +291,7 @@ def test_merged_checkpoint_strips_use_adapter(tmp_path, monkeypatch, captured):
         captured["payload"] = payload
         return {"ok": True}
 
-    monkeypatch.setattr(preview, "load_model", _fake_load)
+    monkeypatch.setattr(preview, "load_model_gated", _fake_load)
     monkeypatch.setattr(preview, "openai_chat_completions", _fake_chat)
 
     app = FastAPI()
@@ -325,7 +325,7 @@ def test_streaming_holds_lock_until_drained(tmp_path, monkeypatch, captured):
     async def _fake_chat(payload, request, subject):
         return StreamingResponse(_gen())
 
-    monkeypatch.setattr(preview, "load_model", _fake_load_model)
+    monkeypatch.setattr(preview, "load_model_gated", _fake_load_model)
     monkeypatch.setattr(preview, "openai_chat_completions", _fake_chat)
 
     async def _run():

--- a/studio/backend/tests/test_tunnel_safe_long_post.py
+++ b/studio/backend/tests/test_tunnel_safe_long_post.py
@@ -3,20 +3,19 @@
 
 """A load slower than a proxy's idle timer still reaches the client.
 
-Cloudflare quick tunnels (`--secure` mode) drop a request whose origin has sent
-no body bytes for ~100s, and a 600 GB GGUF load runs for 100-330s: the browser
-reported "Request failed" on loads the server completed with a 200.
+Cloudflare quick tunnels (`--secure`) drop a request whose origin has sent no body
+bytes for ~100s, and a 600 GB GGUF load runs 100-330s, so the browser reported
+"Request failed" on loads the server completed with a 200. Measured on a real
+quick tunnel:
 
-Measured against a real quick tunnel before choosing this design:
+  * no body for 150s                -> 524
+  * headers at t=0, no body         -> 524 (headers are NOT enough)
+  * one byte at t=90s, then silence -> killed ~125s later, client sees 200 with an
+                                       EMPTY body
+  * one space every 20s             -> survives, body intact
 
-  * no body at all for 150s                      -> 524
-  * status line + headers at t=0, no body         -> 524 (headers are NOT enough)
-  * one byte at t=90s, then silence               -> connection killed ~125s later,
-                                                     client sees 200 with an EMPTY body
-  * one space every 20s                           -> survives, body intact
-
-So the padding has to be continuous, and because the status is committed before
-the work finishes, a failure discovered later can only travel in the body.
+So the padding must be continuous, and a failure found after the status commits
+can only travel in the body.
 """
 
 from __future__ import annotations
@@ -38,7 +37,7 @@ if str(_backend_root) not in sys.path:
 def route(monkeypatch):
     from routes import inference as route_mod
 
-    # Keep the test fast while preserving the ordering the real values encode.
+    # Keep the test fast; the real defaults are guarded by the last test below.
     monkeypatch.setattr(route_mod, "_TUNNEL_KEEPALIVE_AFTER_S", 0.05)
     monkeypatch.setattr(route_mod, "_TUNNEL_KEEPALIVE_EVERY_S", 0.02)
     return route_mod
@@ -80,7 +79,6 @@ def test_a_slow_call_pads_then_sends_valid_json(route):
     response, chunks = asyncio.run(run())
     assert response.media_type == "application/json"
     assert response.headers["x-accel-buffering"] == "no"
-    # Padding first, real payload last, and it keeps arriving until then.
     assert chunks[0] == b" "
     assert len(chunks) > 2, "a call this slow must be padded more than once"
     assert all(c == b" " for c in chunks[:-1])
@@ -137,8 +135,8 @@ def test_the_work_survives_a_client_disconnect(route):
 def test_the_pad_interval_stays_inside_the_proxy_window():
     """The tunnel kills a connection ~100s after the last byte, so leave margin.
 
-    Reads the source rather than the module so the ``route`` fixture's fast
-    values cannot mask a bad default.
+    Reads the source, not the module, so the fixture's fast values cannot mask a
+    bad default.
     """
     src = (_backend_root / "routes" / "inference.py").read_text(encoding = "utf-8")
     after = float(src.split("_TUNNEL_KEEPALIVE_AFTER_S = ")[1].split("\n")[0])

--- a/studio/backend/tests/test_tunnel_safe_long_post.py
+++ b/studio/backend/tests/test_tunnel_safe_long_post.py
@@ -17,10 +17,9 @@ quick tunnel:
 So the padding must be continuous, and a failure found after the status commits
 can only travel in the body.
 
-Two consequences the tests below pin down. The padded reply is a StreamingResponse,
-so anything that does not drain a body must not go through the route: in-process
-callers await ``load_model_gated`` instead. And a client that reads the body but
-treats any 200 as success still has to be taught the in-band failure key.
+Two consequences below: the padded reply is a StreamingResponse, so an in-process
+caller that drains no body awaits ``load_model_gated`` instead; and a client that
+treats any 200 as success has to learn the in-band failure key.
 """
 
 from __future__ import annotations
@@ -156,8 +155,7 @@ def test_the_work_survives_a_client_disconnect(route):
 
 @pytest.fixture
 def slow_load(route, monkeypatch):
-    """/load whose work outruns the keepalive timer. Returns the recorder of
-    model paths the load actually finished for."""
+    """/load whose work outruns the keepalive timer; records the finished model paths."""
     finished = []
 
     async def _slow_impl(request, fastapi_request, current_subject, **kwargs):
@@ -177,10 +175,8 @@ def _load_request(model_path = "unsloth/Kimi-K3-GGUF"):
 
 
 def test_an_in_process_caller_gets_the_real_result(route, slow_load):
-    """preview awaits load_model_gated, so a slow load blocks it until the model
-    is really resident. Awaiting the route instead would hand back a
-    StreamingResponse that nothing in-process drains, and the preview chat would
-    run against the previous model."""
+    """preview awaits load_model_gated, so a slow load blocks until the model is
+    resident; awaiting the route would hand back an undrained StreamingResponse."""
     result = asyncio.run(route.load_model_gated(_load_request(), None, "admin"))
 
     assert not isinstance(result, StreamingResponse)
@@ -190,8 +186,7 @@ def test_an_in_process_caller_gets_the_real_result(route, slow_load):
 
 
 def test_an_in_process_caller_sees_a_late_failure(route, monkeypatch):
-    """The same load failing late raises for a direct caller, instead of becoming
-    a 200 whose body carries `_deferred_error`."""
+    """A late failure raises for a direct caller, not a 200 carrying `_deferred_error`."""
 
     async def _slow_boom(request, fastapi_request, current_subject, **kwargs):
         await asyncio.sleep(0.2)
@@ -220,8 +215,7 @@ def test_the_route_still_pads_the_same_slow_load(route, slow_load):
 
 
 def test_only_the_route_pads(route):
-    """``_tunnel_safe_json`` belongs to the route, not to the gated coroutine: a
-    future in-process caller of the latter must not inherit a StreamingResponse."""
+    """Padding belongs to the route: a gated-coroutine caller must not inherit a stream."""
     import inspect
 
     assert "_tunnel_safe_json" in inspect.getsource(route.load_model)
@@ -242,8 +236,7 @@ def test_preview_awaits_the_gated_load(route):
 
 
 def test_preview_chat_waits_for_a_slow_checkpoint_load(route, slow_load, monkeypatch, tmp_path):
-    """End to end through the real in-process caller: /p must not start generating
-    while the checkpoint is still loading."""
+    """End to end: /p must not start generating while the checkpoint is still loading."""
     import routes.preview as preview
     from models.inference import ChatCompletionRequest
 
@@ -268,8 +261,7 @@ def test_preview_chat_waits_for_a_slow_checkpoint_load(route, slow_load, monkeyp
         )
 
     assert asyncio.run(run()) == {"ok": True}
-    # The load had finished before the chat ran; pre-fix this list was empty
-    # because the padded StreamingResponse returned at the keepalive threshold.
+    # Pre-fix this was empty: the padded StreamingResponse returned at the threshold.
     assert loaded_when_chat_started == [[str(checkpoint)]]
     assert not preview._preview_lock.locked()
 
@@ -277,16 +269,14 @@ def test_preview_chat_waits_for_a_slow_checkpoint_load(route, slow_load, monkeyp
 # ── The slow teardown must not sit on the event loop ──────────────────────────
 #
 # ``LlamaCppBackend.unload_model`` is a plain ``def`` and a 600 GB teardown measures
-# ~160s. Called bare, it blocks the loop that runs _tunnel_safe_json's own timer and
-# its pad generator, so zero bytes leave and the proxy 524s the padded response
-# anyway: the padding is dead code on exactly the two slowest paths.
+# ~160s. Called bare it blocks _tunnel_safe_json's own timer and pad generator, so
+# zero bytes leave and the proxy 524s anyway: padding dead on the two slowest paths.
 
 
 class _SlowSyncTeardown:
-    """A synchronous GGUF teardown that finishes only once the padding has flowed.
+    """A synchronous GGUF teardown that returns only once the padding has flowed.
 
-    Left on the event loop it can never see a pad byte, so it falls out on ``cap_s``
-    having recorded none -- which is precisely the bug.
+    On the event loop it never sees a pad byte and falls out on ``cap_s`` with none.
     """
 
     def __init__(
@@ -330,8 +320,7 @@ def _no_active_generation_checks(route, monkeypatch):
 
 
 def _stub_unsloth_load_over_a_resident_gguf(route, monkeypatch, *, teardown):
-    """POST /load for a non-GGUF model while a GGUF is resident: the branch that
-    tears the llama-server down before handing the GPUs to Unsloth."""
+    """POST /load over a resident GGUF: the branch that tears llama-server down first."""
     import core.export
 
     from core.inference import llama_keepwarm as kw
@@ -430,8 +419,7 @@ def test_a_slow_gguf_teardown_before_an_unsloth_load_still_pads(route, monkeypat
         return response
 
     response = asyncio.run(run())
-    # Pre-fix the teardown ran inside the task's first step, so the loop never got
-    # to time out and this was a plain LoadResponse: not one pad byte on the wire.
+    # Pre-fix the teardown ran in the task's first step: a plain LoadResponse, no pads.
     assert isinstance(
         response, StreamingResponse
     ), "a load whose teardown blocks the loop can never be padded"
@@ -470,8 +458,7 @@ def _stub_gguf_unload(route, monkeypatch, *, teardown):
 
 
 def test_a_slow_gguf_unload_still_pads(route, monkeypatch):
-    """POST /unload of a resident GGUF -- the path whose 160s measurement is the
-    reason /unload is padded at all."""
+    """POST /unload of a resident GGUF: the 160s path /unload is padded for."""
     from models.inference import UnloadRequest
 
     chunks: list[bytes] = []
@@ -494,8 +481,7 @@ def test_a_slow_gguf_unload_still_pads(route, monkeypatch):
 
 
 def test_every_gguf_teardown_on_a_padded_route_is_off_loop():
-    """A regression fence for the two call sites above: a new bare
-    ``unload_model()`` anywhere in /load or /unload silently un-pads that path."""
+    """Fence: a new bare ``unload_model()`` in /load or /unload silently un-pads it."""
     import ast
 
     src = (_backend_root / "routes" / "inference.py").read_text(encoding = "utf-8")
@@ -525,9 +511,8 @@ def test_every_gguf_teardown_on_a_padded_route_is_off_loop():
 
 
 def test_a_python_client_can_recognise_the_late_failure(route):
-    """The browser learned `_deferred_error` (chat-api.ts); the CLI is not a
-    browser and treats any 200 as success, so it has to know the same key and
-    fields or a late OOM is reported as a successful load."""
+    """The CLI is not a browser: it treats any 200 as success, so it must know the same
+    `_deferred_error` key and fields or a late OOM reads as a successful load."""
 
     async def slow_boom():
         await asyncio.sleep(0.2)
@@ -539,8 +524,7 @@ def test_a_python_client_can_recognise_the_late_failure(route):
     payload = json.loads(asyncio.run(run()))[route._DEFERRED_ERROR_KEY]
     assert payload == {"status_code": 507, "detail": "CUDA out of memory"}
 
-    # The shared CLI helper every unsloth_cli load path funnels through. Read as
-    # text, not imported: the backend test env need not import the CLI.
+    # Read as text, not imported: the backend test env need not import the CLI.
     cli = (_repo_root / "unsloth_cli" / "_inference.py").read_text(encoding = "utf-8")
     assert f'_DEFERRED_ERROR_KEY = "{route._DEFERRED_ERROR_KEY}"' in cli
     assert 'deferred.get("status_code")' in cli
@@ -550,13 +534,11 @@ def test_a_python_client_can_recognise_the_late_failure(route):
 
 
 def test_both_clients_reject_a_truncated_padded_body():
-    """The proxy can also kill a padded response after the 200 committed: measured
-    above as a 200 with an EMPTY body. Both clients must call that a failure -- if
-    one accepts it, the same reply means "loaded" to one and "failed" to the other.
-
-    Behaviour lives in the clients' own suites (unsloth_cli/tests/test_inference_chat.py
-    and studio/frontend/tests/padded-response.test.ts); this only pins that neither
-    side can quietly drop the check.
+    """A proxy killing a padded response after the 200 committed leaves the measured
+    200 with an EMPTY body. Both clients must call that a failure, else the same reply
+    means "loaded" to one and "failed" to the other. Behaviour is tested in their own
+    suites (test_inference_chat.py, padded-response.test.ts); this only pins that
+    neither side can drop the check.
     """
     cli = (_repo_root / "unsloth_cli" / "_inference.py").read_text(encoding = "utf-8")
     assert "def require_completed_padded_body(" in cli
@@ -573,8 +555,8 @@ def test_both_clients_reject_a_truncated_padded_body():
         / "padded-response.ts"
     ).read_text(encoding = "utf-8")
     assert "export function assertCompletedPaddedBody(" in web
-    # Scoped to /load and /unload: the shared parseJsonOrThrow serves ~30 endpoints,
-    # some of which legitimately answer with no body.
+    # Scoped to /load and /unload: shared parseJsonOrThrow serves ~30 endpoints,
+    # some legitimately with no body.
     chat_api = (
         _repo_root / "studio" / "frontend" / "src" / "features" / "chat" / "api" / "chat-api.ts"
     ).read_text(encoding = "utf-8")

--- a/studio/backend/tests/test_tunnel_safe_long_post.py
+++ b/studio/backend/tests/test_tunnel_safe_long_post.py
@@ -16,19 +16,27 @@ quick tunnel:
 
 So the padding must be continuous, and a failure found after the status commits
 can only travel in the body.
+
+Two consequences the tests below pin down. The padded reply is a StreamingResponse,
+so anything that does not drain a body must not go through the route: in-process
+callers await ``load_model_gated`` instead. And a client that reads the body but
+treats any 200 as success still has to be taught the in-band failure key.
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
+import re
 import sys
 from pathlib import Path
 
 import pytest
 from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
 
 _backend_root = Path(__file__).resolve().parent.parent
+_repo_root = _backend_root.parents[1]
 if str(_backend_root) not in sys.path:
     sys.path.insert(0, str(_backend_root))
 
@@ -130,6 +138,158 @@ def test_the_work_survives_a_client_disconnect(route):
 
     asyncio.run(run())
     assert finished == [True]
+
+
+# ── Direct (in-process) callers must not get the padded response ──────────────
+
+
+@pytest.fixture
+def slow_load(route, monkeypatch):
+    """/load whose work outruns the keepalive timer. Returns the recorder of
+    model paths the load actually finished for."""
+    finished = []
+
+    async def _slow_impl(request, fastapi_request, current_subject, **kwargs):
+        await asyncio.sleep(0.2)  # >> the fixture's 0.05s keepalive threshold
+        finished.append(request.model_path)
+        return {"status": "loaded", "model": request.model_path}
+
+    monkeypatch.setattr(route, "_load_model_impl", _slow_impl)
+    # The sidecar-swap guard reads real install state; it has its own tests.
+    monkeypatch.setattr(route, "_raise_if_sidecar_swap_in_progress", lambda: None)
+    return finished
+
+
+def _load_request(model_path = "unsloth/Kimi-K3-GGUF"):
+    from models.inference import LoadRequest
+
+    return LoadRequest(model_path = model_path)
+
+
+def test_an_in_process_caller_gets_the_real_result(route, slow_load):
+    """preview awaits load_model_gated, so a slow load blocks it until the model
+    is really resident. Awaiting the route instead would hand back a
+    StreamingResponse that nothing in-process drains, and the preview chat would
+    run against the previous model."""
+    result = asyncio.run(route.load_model_gated(_load_request(), None, "admin"))
+
+    assert not isinstance(result, StreamingResponse)
+    assert result == {"status": "loaded", "model": "unsloth/Kimi-K3-GGUF"}
+    # Returned only after the load finished, not at the 15s mark.
+    assert slow_load == ["unsloth/Kimi-K3-GGUF"]
+
+
+def test_an_in_process_caller_sees_a_late_failure(route, monkeypatch):
+    """The same load failing late raises for a direct caller, instead of becoming
+    a 200 whose body carries `_deferred_error`."""
+
+    async def _slow_boom(request, fastapi_request, current_subject, **kwargs):
+        await asyncio.sleep(0.2)
+        raise HTTPException(status_code = 507, detail = "CUDA out of memory")
+
+    monkeypatch.setattr(route, "_load_model_impl", _slow_boom)
+    monkeypatch.setattr(route, "_raise_if_sidecar_swap_in_progress", lambda: None)
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(route.load_model_gated(_load_request(), None, "admin"))
+    assert excinfo.value.status_code == 507
+    assert excinfo.value.detail == "CUDA out of memory"
+
+
+def test_the_route_still_pads_the_same_slow_load(route, slow_load):
+    """The other half of the split: real HTTP clients keep the padding."""
+
+    async def run():
+        response = await route.load_model(_load_request(), None, "admin")
+        return response, b"".join(await _collect(response))
+
+    response, body = asyncio.run(run())
+    assert isinstance(response, StreamingResponse)
+    assert body.startswith(b" ")
+    assert json.loads(body) == {"status": "loaded", "model": "unsloth/Kimi-K3-GGUF"}
+
+
+def test_only_the_route_pads(route):
+    """``_tunnel_safe_json`` belongs to the route, not to the gated coroutine: a
+    future in-process caller of the latter must not inherit a StreamingResponse."""
+    import inspect
+
+    assert "_tunnel_safe_json" in inspect.getsource(route.load_model)
+    assert "_tunnel_safe_json" not in inspect.getsource(route.load_model_gated)
+    # /unload has no in-process caller today; _unload_model_impl is its equivalent.
+    assert "_tunnel_safe_json" in inspect.getsource(route.unload_model)
+    assert "_tunnel_safe_json" not in inspect.getsource(route._unload_model_impl)
+
+
+def test_preview_awaits_the_gated_load(route):
+    """preview.py is the one in-process caller; it must bypass the padding."""
+    src = (_backend_root / "routes" / "preview.py").read_text(encoding = "utf-8")
+    assert "load_model_gated(" in src
+    assert re.search(r"\bawait load_model\(", src) is None, (
+        "preview must not await the padded /load route: its StreamingResponse "
+        "returns before the checkpoint is loaded"
+    )
+
+
+def test_preview_chat_waits_for_a_slow_checkpoint_load(route, slow_load, monkeypatch, tmp_path):
+    """End to end through the real in-process caller: /p must not start generating
+    while the checkpoint is still loading."""
+    import routes.preview as preview
+    from models.inference import ChatCompletionRequest
+
+    checkpoint = tmp_path / "run" / "checkpoint-1"
+    checkpoint.mkdir(parents = True)
+    monkeypatch.setattr(preview, "_resolve_or_4xx", lambda run, cp: checkpoint)
+
+    loaded_when_chat_started = []
+
+    async def _fake_chat(payload, request, subject):
+        loaded_when_chat_started.append(list(slow_load))
+        return {"ok": True}
+
+    monkeypatch.setattr(preview, "openai_chat_completions", _fake_chat)
+
+    async def run():
+        return await preview._serve_chat(
+            "run",
+            "checkpoint-1",
+            ChatCompletionRequest(messages = [{"role": "user", "content": "hi"}]),
+            request = None,
+        )
+
+    assert asyncio.run(run()) == {"ok": True}
+    # The load had finished before the chat ran; pre-fix this list was empty
+    # because the padded StreamingResponse returned at the keepalive threshold.
+    assert loaded_when_chat_started == [[str(checkpoint)]]
+    assert not preview._preview_lock.locked()
+
+
+# ── Non-browser clients ───────────────────────────────────────────────────────
+
+
+def test_a_python_client_can_recognise_the_late_failure(route):
+    """The browser learned `_deferred_error` (chat-api.ts); the CLI is not a
+    browser and treats any 200 as success, so it has to know the same key and
+    fields or a late OOM is reported as a successful load."""
+
+    async def slow_boom():
+        await asyncio.sleep(0.2)
+        raise HTTPException(status_code = 507, detail = "CUDA out of memory")
+
+    async def run():
+        return b"".join(await _collect(await route._tunnel_safe_json(slow_boom(), label = "t")))
+
+    payload = json.loads(asyncio.run(run()))[route._DEFERRED_ERROR_KEY]
+    assert payload == {"status_code": 507, "detail": "CUDA out of memory"}
+
+    # The shared CLI helper every unsloth_cli load path funnels through. Read as
+    # text, not imported: the backend test env need not import the CLI.
+    cli = (_repo_root / "unsloth_cli" / "_inference.py").read_text(encoding = "utf-8")
+    assert f'_DEFERRED_ERROR_KEY = "{route._DEFERRED_ERROR_KEY}"' in cli
+    assert 'deferred.get("status_code")' in cli
+    assert 'deferred.get("detail")' in cli
+    # unsloth_cli/tests/test_inference_chat.py asserts it actually raises.
+    assert "def raise_for_deferred_error(" in cli
 
 
 def test_the_pad_interval_stays_inside_the_proxy_window():

--- a/studio/backend/tests/test_tunnel_safe_long_post.py
+++ b/studio/backend/tests/test_tunnel_safe_long_post.py
@@ -162,7 +162,6 @@ def slow_load(route, monkeypatch):
 
 def _load_request(model_path = "unsloth/Kimi-K3-GGUF"):
     from models.inference import LoadRequest
-
     return LoadRequest(model_path = model_path)
 
 

--- a/studio/backend/tests/test_tunnel_safe_long_post.py
+++ b/studio/backend/tests/test_tunnel_safe_long_post.py
@@ -26,10 +26,14 @@ treats any 200 as success still has to be taught the in-band failure key.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import re
 import sys
+import threading
+import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
@@ -54,6 +58,13 @@ def route(monkeypatch):
 async def _collect(response):
     """Chunks a client would receive, in order."""
     return [chunk async for chunk in response.body_iterator]
+
+
+async def _collect_into(response, sink):
+    """As _collect, but visible to another thread while the stream is still open."""
+    async for chunk in response.body_iterator:
+        sink.append(chunk)
+    return sink
 
 
 def test_a_fast_call_keeps_the_plain_response(route):
@@ -263,6 +274,253 @@ def test_preview_chat_waits_for_a_slow_checkpoint_load(route, slow_load, monkeyp
     assert not preview._preview_lock.locked()
 
 
+# ── The slow teardown must not sit on the event loop ──────────────────────────
+#
+# ``LlamaCppBackend.unload_model`` is a plain ``def`` and a 600 GB teardown measures
+# ~160s. Called bare, it blocks the loop that runs _tunnel_safe_json's own timer and
+# its pad generator, so zero bytes leave and the proxy 524s the padded response
+# anyway: the padding is dead code on exactly the two slowest paths.
+
+
+class _SlowSyncTeardown:
+    """A synchronous GGUF teardown that finishes only once the padding has flowed.
+
+    Left on the event loop it can never see a pad byte, so it falls out on ``cap_s``
+    having recorded none -- which is precisely the bug.
+    """
+
+    def __init__(
+        self,
+        chunks,
+        *,
+        want = 3,
+        cap_s = 2.0,
+    ):
+        self._chunks = chunks
+        self._want = want
+        self._cap_s = cap_s
+        self.thread = None
+        self.pads_while_running = None
+
+    def __call__(self, *args, **kwargs):
+        self.thread = threading.current_thread()
+        deadline = time.monotonic() + self._cap_s
+        while len(self._chunks) < self._want and time.monotonic() < deadline:
+            time.sleep(0.005)
+        self.pads_while_running = len(self._chunks)
+        return True
+
+    def assert_padded_off_the_loop(self, label):
+        assert self.thread is not None, f"{label} never ran"
+        assert self.thread is not threading.main_thread(), f"{label} ran on the event loop thread"
+        assert self.pads_while_running is not None and self.pads_while_running >= self._want, (
+            f"{label} blocked the padding: {self.pads_while_running} pad bytes went out "
+            "while it ran, so a proxy would have timed the response out"
+        )
+
+
+def _no_active_generation_checks(route, monkeypatch):
+    """Neutralise the chat-cancellation gate; test_active_generations owns it."""
+    monkeypatch.setattr(route, "_raise_or_cancel_active_generations", lambda **kwargs: 0)
+
+    async def _drain(**kwargs):
+        return None
+
+    monkeypatch.setattr(route, "_drain_and_recancel_before_teardown", _drain)
+
+
+def _stub_unsloth_load_over_a_resident_gguf(route, monkeypatch, *, teardown):
+    """POST /load for a non-GGUF model while a GGUF is resident: the branch that
+    tears the llama-server down before handing the GPUs to Unsloth."""
+    import core.export
+
+    from core.inference import llama_keepwarm as kw
+
+    _no_active_generation_checks(route, monkeypatch)
+    monkeypatch.setattr(route, "_raise_if_sidecar_swap_in_progress", lambda: None)
+    monkeypatch.setattr(route, "validate_extra_args", lambda args: [])
+    monkeypatch.setattr(
+        route,
+        "_resolve_model_identifier_for_request",
+        lambda request, operation: (request.model_path, request.model_path, False),
+    )
+    monkeypatch.setattr(
+        route,
+        "resolve_effective_chat_template_override",
+        lambda model_identifier = None, user_override = None: None,
+    )
+    monkeypatch.setattr(route, "_hf_offline_if_dns_dead", contextlib.nullcontext)
+    monkeypatch.setattr(route, "_mlx_distributed_launch_detected", lambda: False)
+    monkeypatch.setattr(
+        route.ModelConfig,
+        "from_identifier",
+        staticmethod(
+            lambda **kwargs: SimpleNamespace(
+                is_gguf = False,
+                identifier = "org/A",
+                display_name = "A",
+                is_vision = False,
+                is_lora = False,
+                is_audio = False,
+                audio_type = None,
+                has_audio_input = False,
+                is_local = False,
+                gguf_hf_repo = None,
+                gguf_variant = None,
+            )
+        ),
+    )
+    monkeypatch.setattr(route, "_effective_load_in_4bit", lambda config, requested: False)
+    monkeypatch.setattr(route, "_resolve_inherited_extra_args", lambda *a, **k: None)
+    monkeypatch.setattr(route, "_guard_chat_load_against_training", lambda *a, **k: None)
+    monkeypatch.setattr(route, "load_inference_config", lambda name: {})
+    monkeypatch.setattr(
+        route,
+        "_detect_safetensors_features",
+        lambda backend, template, tools = None: {
+            "supports_reasoning": False,
+            "reasoning_style": "enable_thinking",
+            "reasoning_effort_levels": [],
+            "reasoning_always_on": False,
+            "supports_preserve_thinking": False,
+            "supports_tools": False,
+        },
+    )
+    monkeypatch.setattr(route, "_resolve_loaded_trust_remote_code", lambda *a, **k: False)
+    monkeypatch.setattr(
+        core.export, "get_export_backend", lambda: SimpleNamespace(current_checkpoint = None)
+    )
+    monkeypatch.setattr(kw, "note_model_loaded", lambda *a, **k: None)
+    monkeypatch.setattr(
+        route,
+        "get_llama_cpp_backend",
+        lambda: SimpleNamespace(
+            is_loaded = True,  # a GGUF is resident and must come down first
+            is_active = True,
+            hf_variant = None,
+            model_identifier = "org/OLD-GGUF",
+            layer_preserves_tensor_intent = False,
+            unload_model = teardown,
+        ),
+    )
+    monkeypatch.setattr(
+        route,
+        "get_inference_backend",
+        lambda: SimpleNamespace(
+            active_model_name = "org/OTHER",
+            models = {},
+            load_model = lambda **kwargs: True,
+        ),
+    )
+
+
+def test_a_slow_gguf_teardown_before_an_unsloth_load_still_pads(route, monkeypatch):
+    """POST /load replacing a resident GGUF with a non-GGUF model."""
+    from models.inference import LoadRequest
+
+    chunks: list[bytes] = []
+    teardown = _SlowSyncTeardown(chunks)
+    _stub_unsloth_load_over_a_resident_gguf(route, monkeypatch, teardown = teardown)
+
+    async def run():
+        response = await route.load_model(LoadRequest(model_path = "org/A"), None, "tester")
+        if not isinstance(response, StreamingResponse):
+            return response
+        await _collect_into(response, chunks)
+        return response
+
+    response = asyncio.run(run())
+    # Pre-fix the teardown ran inside the task's first step, so the loop never got
+    # to time out and this was a plain LoadResponse: not one pad byte on the wire.
+    assert isinstance(
+        response, StreamingResponse
+    ), "a load whose teardown blocks the loop can never be padded"
+    teardown.assert_padded_off_the_loop("the pre-load GGUF teardown")
+    assert json.loads(b"".join(chunks))["status"] == "loaded"
+
+
+def _stub_gguf_unload(route, monkeypatch, *, teardown):
+    """POST /unload for the already-loaded GGUF: the manual teardown branch."""
+    from core.inference import llama_keepwarm as kw
+
+    _no_active_generation_checks(route, monkeypatch)
+    monkeypatch.setattr(route, "is_registered_native_path_label", lambda *a: False)
+    monkeypatch.setattr(kw, "note_model_unloaded", lambda: None)
+    monkeypatch.setattr(
+        route,
+        "get_llama_cpp_backend",
+        lambda: SimpleNamespace(
+            is_active = True,
+            is_loaded = True,
+            model_identifier = "org/A-GGUF",
+            hf_variant = "UD-Q4_K_XL",
+            unload_model = teardown,
+        ),
+    )
+    monkeypatch.setattr(
+        route,
+        "get_inference_backend",
+        lambda: SimpleNamespace(
+            get_loading_model = lambda: None,
+            active_model_name = None,
+            models = {},
+            unload_model = lambda path: None,
+        ),
+    )
+
+
+def test_a_slow_gguf_unload_still_pads(route, monkeypatch):
+    """POST /unload of a resident GGUF -- the path whose 160s measurement is the
+    reason /unload is padded at all."""
+    from models.inference import UnloadRequest
+
+    chunks: list[bytes] = []
+    teardown = _SlowSyncTeardown(chunks)
+    _stub_gguf_unload(route, monkeypatch, teardown = teardown)
+
+    async def run():
+        response = await route.unload_model(UnloadRequest(model_path = "org/A-GGUF"), "tester")
+        if not isinstance(response, StreamingResponse):
+            return response
+        await _collect_into(response, chunks)
+        return response
+
+    response = asyncio.run(run())
+    assert isinstance(
+        response, StreamingResponse
+    ), "an unload whose teardown blocks the loop can never be padded"
+    teardown.assert_padded_off_the_loop("the manual GGUF teardown")
+    assert json.loads(b"".join(chunks)) == {"status": "unloaded", "model": "org/A-GGUF"}
+
+
+def test_every_gguf_teardown_on_a_padded_route_is_off_loop():
+    """A regression fence for the two call sites above: a new bare
+    ``unload_model()`` anywhere in /load or /unload silently un-pads that path."""
+    import ast
+
+    src = (_backend_root / "routes" / "inference.py").read_text(encoding = "utf-8")
+    tree = ast.parse(src)
+    bare: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef) or node.name not in (
+            "_load_model_impl",
+            "_unload_model_impl",
+        ):
+            continue
+        for call in ast.walk(node):
+            # A bare call: attribute .unload_model(...) rather than a to_thread arg.
+            if (
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Attribute)
+                and call.func.attr == "unload_model"
+            ):
+                bare.append(call.lineno)
+    assert bare == [], (
+        f"unload_model called on the event loop at routes/inference.py:{bare}; "
+        "wrap it in asyncio.to_thread or the padding never gets to run"
+    )
+
+
 # ── Non-browser clients ───────────────────────────────────────────────────────
 
 
@@ -289,6 +547,41 @@ def test_a_python_client_can_recognise_the_late_failure(route):
     assert 'deferred.get("detail")' in cli
     # unsloth_cli/tests/test_inference_chat.py asserts it actually raises.
     assert "def raise_for_deferred_error(" in cli
+
+
+def test_both_clients_reject_a_truncated_padded_body():
+    """The proxy can also kill a padded response after the 200 committed: measured
+    above as a 200 with an EMPTY body. Both clients must call that a failure -- if
+    one accepts it, the same reply means "loaded" to one and "failed" to the other.
+
+    Behaviour lives in the clients' own suites (unsloth_cli/tests/test_inference_chat.py
+    and studio/frontend/tests/padded-response.test.ts); this only pins that neither
+    side can quietly drop the check.
+    """
+    cli = (_repo_root / "unsloth_cli" / "_inference.py").read_text(encoding = "utf-8")
+    assert "def require_completed_padded_body(" in cli
+    assert "require_completed_padded_body(url, raise_for_deferred_error(url, body))" in cli
+
+    web = (
+        _repo_root
+        / "studio"
+        / "frontend"
+        / "src"
+        / "features"
+        / "chat"
+        / "api"
+        / "padded-response.ts"
+    ).read_text(encoding = "utf-8")
+    assert "export function assertCompletedPaddedBody(" in web
+    # Scoped to /load and /unload: the shared parseJsonOrThrow serves ~30 endpoints,
+    # some of which legitimately answer with no body.
+    chat_api = (
+        _repo_root / "studio" / "frontend" / "src" / "features" / "chat" / "api" / "chat-api.ts"
+    ).read_text(encoding = "utf-8")
+    assert re.findall(r'parseJsonOrThrow<[^>]*>\(\s*response,\s*"([^"]+)"', chat_api) == [
+        "Model load",
+        "Model unload",
+    ]
 
 
 def test_the_pad_interval_stays_inside_the_proxy_window():

--- a/studio/backend/tests/test_tunnel_safe_long_post.py
+++ b/studio/backend/tests/test_tunnel_safe_long_post.py
@@ -98,10 +98,7 @@ def test_a_slow_failure_travels_in_the_body(route):
         return await _collect(await route._tunnel_safe_json(slow_boom(), label = "t"))
 
     body = json.loads(b"".join(asyncio.run(run())))
-    assert body["_deferred_error"] == {
-        "status_code": 500,
-        "detail": "llama-server died",
-    }
+    assert body["_deferred_error"] == {"status_code": 500, "detail": "llama-server died"}
 
 
 def test_an_unexpected_slow_failure_becomes_a_500(route):

--- a/studio/backend/tests/test_tunnel_safe_long_post.py
+++ b/studio/backend/tests/test_tunnel_safe_long_post.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""A load slower than a proxy's idle timer still reaches the client.
+
+Cloudflare quick tunnels (`--secure` mode) drop a request whose origin has sent
+no body bytes for ~100s, and a 600 GB GGUF load runs for 100-330s: the browser
+reported "Request failed" on loads the server completed with a 200.
+
+Measured against a real quick tunnel before choosing this design:
+
+  * no body at all for 150s                      -> 524
+  * status line + headers at t=0, no body         -> 524 (headers are NOT enough)
+  * one byte at t=90s, then silence               -> connection killed ~125s later,
+                                                     client sees 200 with an EMPTY body
+  * one space every 20s                           -> survives, body intact
+
+So the padding has to be continuous, and because the status is committed before
+the work finishes, a failure discovered later can only travel in the body.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+_backend_root = Path(__file__).resolve().parent.parent
+if str(_backend_root) not in sys.path:
+    sys.path.insert(0, str(_backend_root))
+
+
+@pytest.fixture
+def route(monkeypatch):
+    from routes import inference as route_mod
+
+    # Keep the test fast while preserving the ordering the real values encode.
+    monkeypatch.setattr(route_mod, "_TUNNEL_KEEPALIVE_AFTER_S", 0.05)
+    monkeypatch.setattr(route_mod, "_TUNNEL_KEEPALIVE_EVERY_S", 0.02)
+    return route_mod
+
+
+async def _collect(response):
+    """Chunks a client would receive, in order."""
+    return [chunk async for chunk in response.body_iterator]
+
+
+def test_a_fast_call_keeps_the_plain_response(route):
+    async def quick():
+        return {"status": "loaded"}
+
+    result = asyncio.run(route._tunnel_safe_json(quick(), label = "t"))
+    # Not a Response: FastAPI serialises it through response_model as before.
+    assert result == {"status": "loaded"}
+
+
+def test_a_fast_failure_keeps_its_status_code(route):
+    async def boom():
+        raise HTTPException(status_code = 409, detail = "busy")
+
+    with pytest.raises(HTTPException) as excinfo:
+        asyncio.run(route._tunnel_safe_json(boom(), label = "t"))
+    assert excinfo.value.status_code == 409
+    assert excinfo.value.detail == "busy"
+
+
+def test_a_slow_call_pads_then_sends_valid_json(route):
+    async def slow():
+        await asyncio.sleep(0.2)
+        return {"status": "loaded", "model": "unsloth/Kimi-K3-GGUF"}
+
+    async def run():
+        response = await route._tunnel_safe_json(slow(), label = "t")
+        return response, await _collect(response)
+
+    response, chunks = asyncio.run(run())
+    assert response.media_type == "application/json"
+    assert response.headers["x-accel-buffering"] == "no"
+    # Padding first, real payload last, and it keeps arriving until then.
+    assert chunks[0] == b" "
+    assert len(chunks) > 2, "a call this slow must be padded more than once"
+    assert all(c == b" " for c in chunks[:-1])
+    body = b"".join(chunks)
+    # Leading whitespace is legal JSON, which is why no client had to change.
+    assert json.loads(body) == {"status": "loaded", "model": "unsloth/Kimi-K3-GGUF"}
+
+
+def test_a_slow_failure_travels_in_the_body(route):
+    async def slow_boom():
+        await asyncio.sleep(0.2)
+        raise HTTPException(status_code = 500, detail = "llama-server died")
+
+    async def run():
+        return await _collect(await route._tunnel_safe_json(slow_boom(), label = "t"))
+
+    body = json.loads(b"".join(asyncio.run(run())))
+    assert body["_deferred_error"] == {
+        "status_code": 500,
+        "detail": "llama-server died",
+    }
+
+
+def test_an_unexpected_slow_failure_becomes_a_500(route):
+    async def slow_boom():
+        await asyncio.sleep(0.2)
+        raise RuntimeError("out of VRAM")
+
+    async def run():
+        return await _collect(await route._tunnel_safe_json(slow_boom(), label = "t"))
+
+    body = json.loads(b"".join(asyncio.run(run())))
+    assert body["_deferred_error"]["status_code"] == 500
+    assert "out of VRAM" in body["_deferred_error"]["detail"]
+
+
+def test_the_work_survives_a_client_disconnect(route):
+    """Abandoning the stream must not cancel the load: the model still lands."""
+    finished = []
+
+    async def slow():
+        await asyncio.sleep(0.2)
+        finished.append(True)
+        return {"status": "loaded"}
+
+    async def run():
+        response = await route._tunnel_safe_json(slow(), label = "t")
+        it = response.body_iterator
+        assert await it.__anext__() == b" "  # one pad, then the client vanishes
+        await it.aclose()
+        await asyncio.sleep(0.4)
+
+    asyncio.run(run())
+    assert finished == [True]
+
+
+def test_the_pad_interval_stays_inside_the_proxy_window():
+    """The tunnel kills a connection ~100s after the last byte, so leave margin.
+
+    Reads the source rather than the module so the ``route`` fixture's fast
+    values cannot mask a bad default.
+    """
+    src = (_backend_root / "routes" / "inference.py").read_text(encoding = "utf-8")
+    after = float(src.split("_TUNNEL_KEEPALIVE_AFTER_S = ")[1].split("\n")[0])
+    every = float(src.split("_TUNNEL_KEEPALIVE_EVERY_S = ")[1].split("\n")[0])
+    assert after + every < 90.0, "first pad must land well before the ~100s cutoff"
+    assert every < 90.0, "every subsequent gap resets the timer, so it must too"

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -90,10 +90,9 @@ function parseErrorText(status: number, body: unknown): string {
 }
 
 /**
- * A long endpoint (`/api/inference/load`, `/unload`) pads its body so a proxy
- * cannot time the request out, which means its status is committed before the
- * work finishes. A failure discovered after that can only arrive in-band, under
- * a 200, as `_deferred_error`. Anything else keeps its real status code.
+ * `/api/inference/load` and `/unload` pad their body so a proxy cannot time the
+ * request out, which commits the status before the work finishes: a failure found
+ * after that can only arrive in-band, under a 200, as `_deferred_error`.
  */
 function deferredError(body: unknown): { status: number; message: string } | null {
   const deferred =

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -31,6 +31,7 @@ import type {
   UnloadModelRequest,
   ValidateModelResponse,
 } from "../types/api";
+import { assertCompletedPaddedBody } from "./padded-response";
 
 export const CHAT_HISTORY_UPDATED_EVENT = "unsloth-chat-history-updated";
 export const CHAT_PROJECTS_UPDATED_EVENT = "unsloth-chat-projects-updated";
@@ -106,7 +107,15 @@ function deferredError(body: unknown): { status: number; message: string } | nul
   return { status, message: parseErrorText(status, { detail: deferred.detail }) };
 }
 
-async function parseJsonOrThrow<T>(response: Response): Promise<T> {
+/**
+ * `paddedLabel` opts a caller into `assertCompletedPaddedBody`, and only the two
+ * padded routes may: a truncated body is an unfinished operation there, while
+ * elsewhere an empty one is legitimate.
+ */
+async function parseJsonOrThrow<T>(
+  response: Response,
+  paddedLabel?: string,
+): Promise<T> {
   const body = await response.json().catch(() => null);
   if (!response.ok) {
     throw new Error(parseErrorText(response.status, body));
@@ -114,6 +123,9 @@ async function parseJsonOrThrow<T>(response: Response): Promise<T> {
   const deferred = deferredError(body);
   if (deferred) {
     throw new Error(deferred.message);
+  }
+  if (paddedLabel !== undefined) {
+    assertCompletedPaddedBody(body, paddedLabel);
   }
   return body as T;
 }
@@ -186,7 +198,7 @@ export async function loadModel(
       nativePathLease: undefined,
     }),
   });
-  return parseJsonOrThrow<LoadModelResponse>(response);
+  return parseJsonOrThrow<LoadModelResponse>(response, "Model load");
 }
 
 export async function validateModel(
@@ -281,7 +293,7 @@ export async function unloadModel(payload: UnloadModelRequest): Promise<void> {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
   });
-  await parseJsonOrThrow<unknown>(response);
+  await parseJsonOrThrow<unknown>(response, "Model unload");
 }
 
 /**

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -108,9 +108,8 @@ function deferredError(body: unknown): { status: number; message: string } | nul
 }
 
 /**
- * `paddedLabel` opts a caller into `assertCompletedPaddedBody`, and only the two
- * padded routes may: a truncated body is an unfinished operation there, while
- * elsewhere an empty one is legitimate.
+ * `paddedLabel` opts a caller into `assertCompletedPaddedBody`; only the two padded
+ * routes may, since a truncated body means unfinished there but is legitimate elsewhere.
  */
 async function parseJsonOrThrow<T>(
   response: Response,

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -89,10 +89,32 @@ function parseErrorText(status: number, body: unknown): string {
   return `Request failed (${status})`;
 }
 
+/**
+ * A long endpoint (`/api/inference/load`, `/unload`) pads its body so a proxy
+ * cannot time the request out, which means its status is committed before the
+ * work finishes. A failure discovered after that can only arrive in-band, under
+ * a 200, as `_deferred_error`. Anything else keeps its real status code.
+ */
+function deferredError(body: unknown): { status: number; message: string } | null {
+  const deferred =
+    body && typeof body === "object"
+      ? (body as { _deferred_error?: { status_code?: unknown; detail?: unknown } })
+          ._deferred_error
+      : undefined;
+  if (!deferred || typeof deferred !== "object") return null;
+  const status =
+    typeof deferred.status_code === "number" ? deferred.status_code : 500;
+  return { status, message: parseErrorText(status, { detail: deferred.detail }) };
+}
+
 async function parseJsonOrThrow<T>(response: Response): Promise<T> {
   const body = await response.json().catch(() => null);
   if (!response.ok) {
     throw new Error(parseErrorText(response.status, body));
+  }
+  const deferred = deferredError(body);
+  if (deferred) {
+    throw new Error(deferred.message);
   }
   return body as T;
 }

--- a/studio/frontend/src/features/chat/api/padded-response.ts
+++ b/studio/frontend/src/features/chat/api/padded-response.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * `/api/inference/load` and `/unload` pad their body so a proxy cannot time the
+ * request out, which commits the 200 before the work finishes (see
+ * `_tunnel_safe_json` in studio/backend/routes/inference.py). A proxy that then
+ * gives up mid-pad leaves the client a 200 with an empty or truncated body, so a
+ * client that accepts it reports an unfinished load or unload as done. These are
+ * the only two routes that can do that, so they are the only ones that require a
+ * payload; every other endpoint writes its body in one shot and some send none.
+ *
+ * Mirrored by `require_completed_padded_body` in unsloth_cli/_inference.py.
+ */
+export function assertCompletedPaddedBody(body: unknown, label: string): void {
+  const complete =
+    typeof body === "object" &&
+    body !== null &&
+    !Array.isArray(body) &&
+    Object.keys(body).length > 0;
+  if (complete) {
+    return;
+  }
+  throw new Error(
+    `${label} did not report completion: the connection closed before the server's reply arrived. Check the model's status before retrying.`,
+  );
+}

--- a/studio/frontend/src/features/chat/api/padded-response.ts
+++ b/studio/frontend/src/features/chat/api/padded-response.ts
@@ -2,15 +2,13 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 /**
- * `/api/inference/load` and `/unload` pad their body so a proxy cannot time the
- * request out, which commits the 200 before the work finishes (see
- * `_tunnel_safe_json` in studio/backend/routes/inference.py). A proxy that then
- * gives up mid-pad leaves the client a 200 with an empty or truncated body, so a
- * client that accepts it reports an unfinished load or unload as done. These are
- * the only two routes that can do that, so they are the only ones that require a
- * payload; every other endpoint writes its body in one shot and some send none.
- *
- * Mirrored by `require_completed_padded_body` in unsloth_cli/_inference.py.
+ * `/api/inference/load` and `/unload` pad their body so a proxy cannot time the request
+ * out, committing the 200 before the work finishes (`_tunnel_safe_json` in
+ * studio/backend/routes/inference.py). A proxy giving up mid-pad leaves a 200 with an
+ * empty or truncated body; accepting that reports an unfinished load as done. Only
+ * these two routes commit that early, so only they require a payload; elsewhere an
+ * empty body is by design. Mirrored by `require_completed_padded_body` in
+ * unsloth_cli/_inference.py.
  */
 export function assertCompletedPaddedBody(body: unknown, label: string): void {
   const complete =

--- a/studio/frontend/tests/padded-response.test.ts
+++ b/studio/frontend/tests/padded-response.test.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * A truncated padded reply is not a successful load.
+ *
+ * `/api/inference/load` and `/unload` pad their body so a proxy cannot time the
+ * request out, which commits the 200 before the work finishes. The tunnel probe in
+ * studio/backend/tests/test_tunnel_safe_long_post.py measured the failure mode: one
+ * byte at t=90s then silence is killed ~125s later and the client sees a 200 with an
+ * EMPTY body. `response.json()` throws on that, so a `catch(() => null)` turns it
+ * into a 200 with a null body -- reported as success unless the padded callers say
+ * otherwise. `unloadModel` would then clear the checkpoint and a recipe load would
+ * proceed against a model that may not be ready.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { assertCompletedPaddedBody } from "../src/features/chat/api/padded-response.ts";
+
+const chatApi = readFileSync(
+  new URL("../src/features/chat/api/chat-api.ts", import.meta.url),
+  "utf8",
+);
+
+test("a real payload passes through", () => {
+  assertCompletedPaddedBody({ status: "loaded", model: "org/A" }, "Model load");
+  assertCompletedPaddedBody({ status: "unloaded" }, "Model unload");
+});
+
+test("a body the proxy truncated is rejected, not accepted as success", () => {
+  // What `await response.json().catch(() => null)` yields for an empty body, a
+  // pad-only body ("   ") and a payload cut mid-object: all three are null.
+  for (const body of [null, undefined, {}, [], "", "loaded", 0]) {
+    assert.throws(
+      () => assertCompletedPaddedBody(body, "Model load"),
+      /Model load did not report completion/,
+      JSON.stringify(body) ?? "undefined",
+    );
+  }
+});
+
+test("the message names the operation and points at the model's status", () => {
+  assert.throws(
+    () => assertCompletedPaddedBody(null, "Model unload"),
+    (err: unknown) => {
+      const message = (err as Error).message;
+      assert.match(message, /^Model unload did not report completion/);
+      assert.match(message, /connection closed/);
+      assert.match(message, /Check the model's status/);
+      return true;
+    },
+  );
+});
+
+test("only the two padded routes require a payload", () => {
+  // Deliberately scoped: parseJsonOrThrow is shared with ~30 endpoints and some
+  // legitimately answer with no body, so a null body must stay OK for them.
+  const labelled = [
+    ...chatApi.matchAll(/parseJsonOrThrow<[^>]*>\(\s*response,\s*"([^"]+)"/g),
+  ].map((match) => match[1]);
+  assert.deepEqual(labelled, ["Model load", "Model unload"]);
+  assert.ok(chatApi.includes("assertCompletedPaddedBody(body, paddedLabel)"));
+});
+
+test("the Python client agrees", () => {
+  // unsloth_cli is the non-browser client; if only one side rejects a truncated
+  // reply, the same server response means success to one and failure to the other.
+  const cli = readFileSync(
+    new URL("../../../unsloth_cli/_inference.py", import.meta.url),
+    "utf8",
+  );
+  assert.ok(cli.includes("def require_completed_padded_body("));
+  // unsloth_cli/tests/test_inference_chat.py asserts it actually raises.
+  assert.ok(cli.includes("if isinstance(body, dict) and body:"));
+});

--- a/studio/frontend/tests/padded-response.test.ts
+++ b/studio/frontend/tests/padded-response.test.ts
@@ -4,14 +4,12 @@
 /**
  * A truncated padded reply is not a successful load.
  *
- * `/api/inference/load` and `/unload` pad their body so a proxy cannot time the
- * request out, which commits the 200 before the work finishes. The tunnel probe in
- * studio/backend/tests/test_tunnel_safe_long_post.py measured the failure mode: one
- * byte at t=90s then silence is killed ~125s later and the client sees a 200 with an
- * EMPTY body. `response.json()` throws on that, so a `catch(() => null)` turns it
- * into a 200 with a null body -- reported as success unless the padded callers say
- * otherwise. `unloadModel` would then clear the checkpoint and a recipe load would
- * proceed against a model that may not be ready.
+ * `/api/inference/load` and `/unload` pad their body so a proxy cannot time the request
+ * out, which commits the 200 before the work finishes. The tunnel probe measured the
+ * failure mode (studio/backend/tests/test_tunnel_safe_long_post.py): one byte at t=90s
+ * then silence is killed ~125s later and the client sees a 200 with an EMPTY body.
+ * `response.json()` throws on that and `catch(() => null)` makes it a 200 with a null
+ * body, read as success unless the padded callers say otherwise.
  */
 
 import assert from "node:assert/strict";
@@ -31,8 +29,7 @@ test("a real payload passes through", () => {
 });
 
 test("a body the proxy truncated is rejected, not accepted as success", () => {
-  // What `await response.json().catch(() => null)` yields for an empty body, a
-  // pad-only body ("   ") and a payload cut mid-object: all three are null.
+  // An empty body, a pad-only body ("   ") and a half payload all decode to null.
   for (const body of [null, undefined, {}, [], "", "loaded", 0]) {
     assert.throws(
       () => assertCompletedPaddedBody(body, "Model load"),
@@ -56,8 +53,7 @@ test("the message names the operation and points at the model's status", () => {
 });
 
 test("only the two padded routes require a payload", () => {
-  // Deliberately scoped: parseJsonOrThrow is shared with ~30 endpoints and some
-  // legitimately answer with no body, so a null body must stay OK for them.
+  // Scoped: parseJsonOrThrow serves ~30 endpoints, some legitimately with no body.
   const labelled = [
     ...chatApi.matchAll(/parseJsonOrThrow<[^>]*>\(\s*response,\s*"([^"]+)"/g),
   ].map((match) => match[1]);
@@ -66,8 +62,7 @@ test("only the two padded routes require a payload", () => {
 });
 
 test("the Python client agrees", () => {
-  // unsloth_cli is the non-browser client; if only one side rejects a truncated
-  // reply, the same server response means success to one and failure to the other.
+  // If only one client rejects a truncated reply, one reads success where the other fails.
   const cli = readFileSync(
     new URL("../../../unsloth_cli/_inference.py", import.meta.url),
     "utf8",

--- a/unsloth_cli/_inference.py
+++ b/unsloth_cli/_inference.py
@@ -52,6 +52,63 @@ def urlopen_no_redirect(request, timeout):
     return _no_redirect_opener.open(request, timeout = timeout)
 
 
+# /api/inference/load and /unload pad their response body so a proxy cannot time a
+# slow load out, which commits the 200 before the work finishes. A failure found
+# after that can only travel in-band, under this key (_DEFERRED_ERROR_KEY in
+# studio/backend/routes/inference.py), so a client that treats any 200 as success
+# reports a failed load as a successful one.
+_DEFERRED_ERROR_KEY = "_deferred_error"
+
+
+def raise_for_deferred_error(url: str, body):
+    """Raise the late failure a padded 200 body carries; else return ``body``.
+
+    Raised as ``urllib.error.HTTPError`` -- the class every CLI caller already
+    handles for a plain HTTP failure -- carrying the deferred status and message,
+    so existing ``except`` blocks, messages and exit codes keep working. ``.read()``
+    yields the same ``{"detail": ...}`` shape a real error response would.
+    """
+    if not isinstance(body, dict):
+        return body
+    deferred = body.get(_DEFERRED_ERROR_KEY)
+    if not isinstance(deferred, dict):
+        return body
+
+    import email.message
+    import io
+    import urllib.error
+
+    status = deferred.get("status_code")
+    if not isinstance(status, int) or isinstance(status, bool):
+        status = 500
+    detail = deferred.get("detail")
+    if not isinstance(detail, str) or not detail:
+        detail = "unknown error" if detail is None else json.dumps(detail)
+    headers = email.message.Message()
+    headers["Content-Type"] = "application/json"
+    raise urllib.error.HTTPError(
+        url, status, detail, headers, io.BytesIO(json.dumps({"detail": detail}).encode())
+    )
+
+
+def read_json_checking_deferred_error(url: str, response):
+    """Drain ``response``, then raise any deferred error its body carries.
+
+    Draining matters on its own: stopping at the headers of a padded /load leaves
+    the load still running, so the caller resumes too early. Returns the decoded
+    body, or None when it is not JSON (nothing to check, and no caller reads it).
+    """
+    try:
+        raw = response.read()
+    finally:
+        response.close()
+    try:
+        body = json.loads(raw.decode(errors = "replace") or "{}")
+    except ValueError:
+        return None
+    return raise_for_deferred_error(url, body)
+
+
 def ensure_studio_backend_path() -> None:
     backend_dir = str(Path(__file__).resolve().parents[1] / "studio" / "backend")
     if backend_dir not in sys.path:
@@ -684,11 +741,14 @@ class HttpChatBackend:
         if llama_extra_args:
             payload["llama_extra_args"] = llama_extra_args
         try:
-            self._request(
-                "POST",
-                "/api/inference/load",
-                payload,
-            ).close()
+            # Read the body, don't close at the headers: a load slower than the
+            # tunnel timer commits its 200 early and pads until it is done, so
+            # closing here would start generating mid-load and would throw away
+            # the only report of a late failure.
+            read_json_checking_deferred_error(
+                self._base + "/api/inference/load",
+                self._request("POST", "/api/inference/load", payload),
+            )
         except Exception as exc:
             typer.echo(f"Model load failed: {exc}", err = True)
             raise typer.Exit(code = 1)

--- a/unsloth_cli/_inference.py
+++ b/unsloth_cli/_inference.py
@@ -91,12 +91,32 @@ def raise_for_deferred_error(url: str, body):
     )
 
 
+def require_completed_padded_body(url: str, body):
+    """Return ``body``, or raise if it is not the payload a padded route promised.
+
+    A proxy that gives up mid-pad leaves a 200 with an empty or truncated body, so
+    accepting it reports an unfinished load or unload as a completed one. Only the
+    two padded routes commit their status that early, so only they require a
+    payload (an empty dict counts: it is what a blank body decodes to here).
+
+    Mirrored by ``assertCompletedPaddedBody`` in
+    studio/frontend/src/features/chat/api/padded-response.ts.
+    """
+    if isinstance(body, dict) and body:
+        return body
+    raise RuntimeError(
+        f"{url} did not report completion: the connection closed before the "
+        "server's reply arrived. Check the model's status before retrying."
+    )
+
+
 def read_json_checking_deferred_error(url: str, response):
     """Drain ``response``, then raise any deferred error its body carries.
 
     Draining matters on its own: stopping at the headers of a padded /load leaves
-    the load still running, so the caller resumes too early. Returns the decoded
-    body, or None when it is not JSON (nothing to check, and no caller reads it).
+    the load still running, so the caller resumes too early. A body that is not a
+    complete JSON payload is a truncated padded reply, not a success, so it raises
+    (see ``require_completed_padded_body``).
     """
     try:
         raw = response.read()
@@ -105,8 +125,8 @@ def read_json_checking_deferred_error(url: str, response):
     try:
         body = json.loads(raw.decode(errors = "replace") or "{}")
     except ValueError:
-        return None
-    return raise_for_deferred_error(url, body)
+        body = None
+    return require_completed_padded_body(url, raise_for_deferred_error(url, body))
 
 
 def ensure_studio_backend_path() -> None:

--- a/unsloth_cli/_inference.py
+++ b/unsloth_cli/_inference.py
@@ -52,21 +52,19 @@ def urlopen_no_redirect(request, timeout):
     return _no_redirect_opener.open(request, timeout = timeout)
 
 
-# /api/inference/load and /unload pad their response body so a proxy cannot time a
-# slow load out, which commits the 200 before the work finishes. A failure found
-# after that can only travel in-band, under this key (_DEFERRED_ERROR_KEY in
-# studio/backend/routes/inference.py), so a client that treats any 200 as success
-# reports a failed load as a successful one.
+# /api/inference/load and /unload pad their body so a proxy cannot time a slow load
+# out, committing the 200 before the work finishes. A failure found after that travels
+# only in-band under this key (studio/backend/routes/inference.py), so a client that
+# treats any 200 as success reports a failed load as a successful one.
 _DEFERRED_ERROR_KEY = "_deferred_error"
 
 
 def raise_for_deferred_error(url: str, body):
     """Raise the late failure a padded 200 body carries; else return ``body``.
 
-    Raised as ``urllib.error.HTTPError`` -- the class every CLI caller already
-    handles for a plain HTTP failure -- carrying the deferred status and message,
-    so existing ``except`` blocks, messages and exit codes keep working. ``.read()``
-    yields the same ``{"detail": ...}`` shape a real error response would.
+    ``urllib.error.HTTPError`` specifically: it is the class every CLI caller already
+    handles for a plain HTTP failure, so existing ``except`` blocks, messages and exit
+    codes keep working, and ``.read()`` yields the same ``{"detail": ...}`` shape.
     """
     if not isinstance(body, dict):
         return body
@@ -95,12 +93,10 @@ def require_completed_padded_body(url: str, body):
     """Return ``body``, or raise if it is not the payload a padded route promised.
 
     A proxy that gives up mid-pad leaves a 200 with an empty or truncated body, so
-    accepting it reports an unfinished load or unload as a completed one. Only the
-    two padded routes commit their status that early, so only they require a
-    payload (an empty dict counts: it is what a blank body decodes to here).
-
-    Mirrored by ``assertCompletedPaddedBody`` in
-    studio/frontend/src/features/chat/api/padded-response.ts.
+    accepting it reports an unfinished load or unload as completed. Only the two padded
+    routes commit their status that early, so only they require a payload; ``{}`` is
+    rejected too, since that is what a blank body decodes to here. Mirrored by
+    ``assertCompletedPaddedBody`` in studio/frontend/src/features/chat/api/padded-response.ts.
     """
     if isinstance(body, dict) and body:
         return body
@@ -113,10 +109,9 @@ def require_completed_padded_body(url: str, body):
 def read_json_checking_deferred_error(url: str, response):
     """Drain ``response``, then raise any deferred error its body carries.
 
-    Draining matters on its own: stopping at the headers of a padded /load leaves
-    the load still running, so the caller resumes too early. A body that is not a
-    complete JSON payload is a truncated padded reply, not a success, so it raises
-    (see ``require_completed_padded_body``).
+    Draining matters on its own: stopping at the headers of a padded /load leaves the
+    load running, so the caller resumes too early. An incomplete JSON payload is a
+    truncated padded reply, not a success (see ``require_completed_padded_body``).
     """
     try:
         raw = response.read()
@@ -761,10 +756,9 @@ class HttpChatBackend:
         if llama_extra_args:
             payload["llama_extra_args"] = llama_extra_args
         try:
-            # Read the body, don't close at the headers: a load slower than the
-            # tunnel timer commits its 200 early and pads until it is done, so
-            # closing here would start generating mid-load and would throw away
-            # the only report of a late failure.
+            # Read the body, don't close at the headers: a slow load commits its 200
+            # early and pads until done, so closing here would generate mid-load and
+            # discard the only report of a late failure.
             read_json_checking_deferred_error(
                 self._base + "/api/inference/load",
                 self._request("POST", "/api/inference/load", payload),

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -35,6 +35,7 @@ from unsloth_cli._inference import (
     find_studio_server,
     is_loopback_url,
     raise_for_deferred_error,
+    require_completed_padded_body,
     urlopen_no_redirect,
     verify_studio_identity,
 )
@@ -897,6 +898,7 @@ def _load_model_with_progress(
     base: str, key: str, model: str, load: LoadOptions, payload: dict
 ) -> dict:
     """Run the blocking load request while polling its download progress."""
+    load_url = f"{base}/api/inference/load"
     result: list[tuple[bool, object]] = []
     done = threading.Event()
 
@@ -904,7 +906,7 @@ def _load_model_with_progress(
         try:
             value = _http_json(
                 "POST",
-                f"{base}/api/inference/load",
+                load_url,
                 key,
                 payload,
                 timeout = 3600,
@@ -928,9 +930,15 @@ def _load_model_with_progress(
         ok, value = result[0]
         if not ok:
             assert isinstance(value, BaseException)
+            # A pad-only or half-written body fails `_http_json`'s json.loads: report
+            # the padded 200 that never completed, not a JSON error from the API.
+            if isinstance(value, ValueError):
+                require_completed_padded_body(load_url, None)
             raise value
         progress.complete()
-        return value if isinstance(value, dict) else {}
+        # `_http_json` decodes a blank body as `{}`, which a truncated padded reply
+        # would otherwise make look like a completed load.
+        return require_completed_padded_body(load_url, value)
     finally:
         progress.close()
 

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -34,6 +34,7 @@ from unsloth_cli._inference import (
     ensure_studio_backend_path,
     find_studio_server,
     is_loopback_url,
+    raise_for_deferred_error,
     urlopen_no_redirect,
     verify_studio_identity,
 )
@@ -658,7 +659,10 @@ def _http_json(
     try:
         # No redirects: a 3xx would leak this bearer token to an unvetted base.
         with urlopen_no_redirect(request, timeout = timeout) as response:
-            return json.loads(response.read().decode() or "{}")
+            body = json.loads(response.read().decode() or "{}")
+        # A padded /load or /unload commits its 200 before the work finishes, so a
+        # late failure arrives in-band; raise it as the HTTPError handled below.
+        return raise_for_deferred_error(url, body)
     except urllib.error.HTTPError as exc:
         if error is None:
             raise

--- a/unsloth_cli/commands/start.py
+++ b/unsloth_cli/commands/start.py
@@ -661,8 +661,8 @@ def _http_json(
         # No redirects: a 3xx would leak this bearer token to an unvetted base.
         with urlopen_no_redirect(request, timeout = timeout) as response:
             body = json.loads(response.read().decode() or "{}")
-        # A padded /load or /unload commits its 200 before the work finishes, so a
-        # late failure arrives in-band; raise it as the HTTPError handled below.
+        # A padded /load or /unload commits its 200 early, so a late failure arrives
+        # in-band; raise it as the HTTPError handled below.
         return raise_for_deferred_error(url, body)
     except urllib.error.HTTPError as exc:
         if error is None:
@@ -936,8 +936,7 @@ def _load_model_with_progress(
                 require_completed_padded_body(load_url, None)
             raise value
         progress.complete()
-        # `_http_json` decodes a blank body as `{}`, which a truncated padded reply
-        # would otherwise make look like a completed load.
+        # `_http_json` decodes a blank body as `{}`, which would look like a completed load.
         return require_completed_padded_body(load_url, value)
     finally:
         progress.close()

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1256,10 +1256,9 @@ def _load_model_via_http(
                 body = json.loads(resp.read())
             except ValueError:
                 body = None  # truncated padded reply; rejected below
-        # A load slower than the tunnel timer commits its 200 before it finishes and
-        # pads the body, so a late failure arrives in-band; raise it as the HTTPError
-        # this function already turns into the RuntimeError the caller reports. A body
-        # the proxy truncated instead is no completion report at all.
+        # A slow load commits its 200 before it finishes and pads the body, so a late
+        # failure arrives in-band; raise it as the HTTPError this function already turns
+        # into the RuntimeError the caller reports. A truncated body is no report at all.
         return require_completed_padded_body(url, raise_for_deferred_error(url, body))
     except urllib.error.HTTPError as exc:
         body = exc.read().decode(errors = "replace")

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1222,7 +1222,7 @@ def _load_model_via_http(
     import urllib.request
     import urllib.error
 
-    from unsloth_cli._inference import raise_for_deferred_error
+    from unsloth_cli._inference import raise_for_deferred_error, require_completed_padded_body
 
     payload: dict = {
         "model_path": model,
@@ -1252,11 +1252,15 @@ def _load_model_via_http(
     )
     try:
         with urllib.request.urlopen(req, timeout = timeout) as resp:
-            body = json.loads(resp.read())
+            try:
+                body = json.loads(resp.read())
+            except ValueError:
+                body = None  # truncated padded reply; rejected below
         # A load slower than the tunnel timer commits its 200 before it finishes and
         # pads the body, so a late failure arrives in-band; raise it as the HTTPError
-        # this function already turns into the RuntimeError the caller reports.
-        return raise_for_deferred_error(url, body)
+        # this function already turns into the RuntimeError the caller reports. A body
+        # the proxy truncated instead is no completion report at all.
+        return require_completed_padded_body(url, raise_for_deferred_error(url, body))
     except urllib.error.HTTPError as exc:
         body = exc.read().decode(errors = "replace")
         raise RuntimeError(f"Model load failed (HTTP {exc.code}): {body}") from exc

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -1222,6 +1222,8 @@ def _load_model_via_http(
     import urllib.request
     import urllib.error
 
+    from unsloth_cli._inference import raise_for_deferred_error
+
     payload: dict = {
         "model_path": model,
         "max_seq_length": max_seq_length,
@@ -1238,8 +1240,9 @@ def _load_model_via_http(
         payload["llama_extra_args"] = list(llama_extra_args)
 
     data = json.dumps(payload).encode()
+    url = f"http://127.0.0.1:{port}/api/inference/load"
     req = urllib.request.Request(
-        f"http://127.0.0.1:{port}/api/inference/load",
+        url,
         data = data,
         headers = {
             "Content-Type": "application/json",
@@ -1249,7 +1252,11 @@ def _load_model_via_http(
     )
     try:
         with urllib.request.urlopen(req, timeout = timeout) as resp:
-            return json.loads(resp.read())
+            body = json.loads(resp.read())
+        # A load slower than the tunnel timer commits its 200 before it finishes and
+        # pads the body, so a late failure arrives in-band; raise it as the HTTPError
+        # this function already turns into the RuntimeError the caller reports.
+        return raise_for_deferred_error(url, body)
     except urllib.error.HTTPError as exc:
         body = exc.read().decode(errors = "replace")
         raise RuntimeError(f"Model load failed (HTTP {exc.code}): {body}") from exc

--- a/unsloth_cli/tests/test_inference_chat.py
+++ b/unsloth_cli/tests/test_inference_chat.py
@@ -439,9 +439,8 @@ def test_http_backend_streams_cumulative_text(monkeypatch):
 class _FakeLoadResponse:
     """A /api/inference/load reply that records whether its body was drained.
 
-    /load pads a slow body to survive a proxy, so closing at the headers both
-    resumes before the load finishes and discards a late failure; these fakes
-    therefore have to distinguish read() from close().
+    Closing a padded body at the headers resumes before the load finishes and discards
+    a late failure, so the fake must distinguish read() from close().
     """
 
     def __init__(self, body: bytes = b'{"status": "loaded"}') -> None:
@@ -526,8 +525,7 @@ def test_http_backend_load_sends_explicit_false_tensor_parallel(monkeypatch):
 
 
 def test_http_backend_load_drains_the_padded_body(monkeypatch):
-    """Closing at the headers would abandon the padding and start generating
-    while the model is still loading, so the body has to be read to the end."""
+    """Closing at the headers would start generating while the model is still loading."""
     backend = HttpChatBackend("http://localhost:8888", "token")
     # What a padded slow load looks like on the wire: spaces, then the payload.
     response = _FakeLoadResponse(b'   {"status": "loaded"}')
@@ -545,8 +543,7 @@ def test_http_backend_load_drains_the_padded_body(monkeypatch):
 
 
 def test_http_backend_load_fails_on_a_deferred_error(monkeypatch, capsys):
-    """A failure found after the 200 committed rides in the body; a 200 alone is
-    not success."""
+    """A failure found after the 200 committed rides in the body; a 200 is not success."""
     backend = HttpChatBackend("http://localhost:8888", "token")
     response = _FakeLoadResponse(
         json.dumps(
@@ -583,9 +580,8 @@ def test_http_backend_load_fails_on_a_deferred_error(monkeypatch, capsys):
 def test_http_backend_load_rejects_a_truncated_padded_body(monkeypatch, capsys, body, what):
     """A proxy that gives up mid-pad leaves a 200 the padded route never finished.
 
-    The tunnel probe measured it: one byte at t=90s then silence is killed ~125s
-    later and the client sees a 200 with an EMPTY body. Accepting that would report
-    an unfinished load as done and start generating against the previous model.
+    Measured: one byte at t=90s then silence is killed ~125s later and the client sees
+    a 200 with an EMPTY body. Accepting it reports an unfinished load as done.
     """
     backend = HttpChatBackend("http://localhost:8888", "token")
     response = _FakeLoadResponse(body)

--- a/unsloth_cli/tests/test_inference_chat.py
+++ b/unsloth_cli/tests/test_inference_chat.py
@@ -570,6 +570,64 @@ def test_http_backend_load_fails_on_a_deferred_error(monkeypatch, capsys):
     assert "507" in err and "CUDA out of memory" in err
 
 
+@pytest.mark.parametrize(
+    ("body", "what"),
+    [
+        (b"", "an empty body"),
+        (b"   ", "pad bytes only"),
+        (b'  {"status": "loa', "a payload cut in half"),
+        (b"null", "a literal null"),
+        (b"{}", "an empty object"),
+    ],
+)
+def test_http_backend_load_rejects_a_truncated_padded_body(monkeypatch, capsys, body, what):
+    """A proxy that gives up mid-pad leaves a 200 the padded route never finished.
+
+    The tunnel probe measured it: one byte at t=90s then silence is killed ~125s
+    later and the client sees a 200 with an EMPTY body. Accepting that would report
+    an unfinished load as done and start generating against the previous model.
+    """
+    backend = HttpChatBackend("http://localhost:8888", "token")
+    response = _FakeLoadResponse(body)
+    monkeypatch.setattr(backend, "_request", lambda *a, **k: response)
+
+    with pytest.raises(typer.Exit) as excinfo:
+        backend.ensure_loaded(
+            "org/model-GGUF",
+            hf_token = None,
+            max_seq_length = 4096,
+            load_in_4bit = True,
+        )
+
+    assert excinfo.value.exit_code == 1, what
+    err = capsys.readouterr().err
+    assert "Model load failed" in err
+    assert "did not report completion" in err
+    # Still drained, so the load is not abandoned at the headers.
+    assert response.reads == 1 and response.closed
+
+
+def test_padded_body_helper_passes_a_real_payload_through():
+    from unsloth_cli._inference import require_completed_padded_body
+
+    body = {"status": "loaded", "model": "org/model-GGUF"}
+    assert require_completed_padded_body("http://x/api/inference/load", body) is body
+    assert require_completed_padded_body("http://x", {"status": "unloaded"}) == {
+        "status": "unloaded"
+    }
+
+
+def test_padded_body_helper_names_the_route_and_the_recovery():
+    from unsloth_cli._inference import require_completed_padded_body
+    url = "http://x/api/inference/load"
+    for body in (None, {}, [], "", 0, "loaded"):
+        with pytest.raises(RuntimeError) as excinfo:
+            require_completed_padded_body(url, body)
+        message = str(excinfo.value)
+        assert message.startswith(f"{url} did not report completion")
+        assert "Check the model's status" in message
+
+
 def test_deferred_error_helper_passes_a_normal_body_through():
     from unsloth_cli._inference import raise_for_deferred_error
 

--- a/unsloth_cli/tests/test_inference_chat.py
+++ b/unsloth_cli/tests/test_inference_chat.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import inspect
+import json
 import sys
 import types
 from pathlib import Path
@@ -435,13 +436,30 @@ def test_http_backend_streams_cumulative_text(monkeypatch):
     assert out == ["He", "Hello"]
 
 
+class _FakeLoadResponse:
+    """A /api/inference/load reply that records whether its body was drained.
+
+    /load pads a slow body to survive a proxy, so closing at the headers both
+    resumes before the load finishes and discards a late failure; these fakes
+    therefore have to distinguish read() from close().
+    """
+
+    def __init__(self, body: bytes = b'{"status": "loaded"}') -> None:
+        self._body = body
+        self.reads = 0
+        self.closed = False
+
+    def read(self) -> bytes:
+        self.reads += 1
+        return self._body
+
+    def close(self) -> None:
+        self.closed = True
+
+
 def test_http_backend_load_forwards_gguf_runtime_options(monkeypatch):
     backend = HttpChatBackend("http://localhost:8888", "token")
     requests = []
-
-    class _OK:
-        def close(self):
-            pass
 
     def fake_request(
         method,
@@ -450,7 +468,7 @@ def test_http_backend_load_forwards_gguf_runtime_options(monkeypatch):
         timeout = None,
     ):
         requests.append((method, path, payload, timeout))
-        return _OK()
+        return _FakeLoadResponse()
 
     monkeypatch.setattr(backend, "_request", fake_request)
 
@@ -484,16 +502,12 @@ def test_http_backend_load_sends_explicit_false_tensor_parallel(monkeypatch):
     backend = HttpChatBackend("http://localhost:8888", "token")
     requests = []
 
-    class _OK:
-        def close(self):
-            pass
-
     monkeypatch.setattr(
         backend,
         "_request",
         lambda method, path, payload = None, timeout = None: (
             requests.append((method, path, payload, timeout)),
-            _OK(),
+            _FakeLoadResponse(),
         )[1],
     )
 
@@ -506,6 +520,93 @@ def test_http_backend_load_sends_explicit_false_tensor_parallel(monkeypatch):
     )
 
     assert requests[0][2]["tensor_parallel"] is False
+
+
+# ── A load slower than the proxy timer (see routes/inference.py _tunnel_safe_json) ──
+
+
+def test_http_backend_load_drains_the_padded_body(monkeypatch):
+    """Closing at the headers would abandon the padding and start generating
+    while the model is still loading, so the body has to be read to the end."""
+    backend = HttpChatBackend("http://localhost:8888", "token")
+    # What a padded slow load looks like on the wire: spaces, then the payload.
+    response = _FakeLoadResponse(b'   {"status": "loaded"}')
+    monkeypatch.setattr(backend, "_request", lambda *a, **k: response)
+
+    backend.ensure_loaded(
+        "org/model-GGUF",
+        hf_token = None,
+        max_seq_length = 4096,
+        load_in_4bit = True,
+    )
+
+    assert response.reads == 1, "the padded body must be drained, not closed at the headers"
+    assert response.closed
+
+
+def test_http_backend_load_fails_on_a_deferred_error(monkeypatch, capsys):
+    """A failure found after the 200 committed rides in the body; a 200 alone is
+    not success."""
+    backend = HttpChatBackend("http://localhost:8888", "token")
+    response = _FakeLoadResponse(
+        json.dumps(
+            {"_deferred_error": {"status_code": 507, "detail": "CUDA out of memory"}}
+        ).encode()
+    )
+    monkeypatch.setattr(backend, "_request", lambda *a, **k: response)
+
+    with pytest.raises(typer.Exit) as excinfo:
+        backend.ensure_loaded(
+            "org/model-GGUF",
+            hf_token = None,
+            max_seq_length = 4096,
+            load_in_4bit = True,
+        )
+
+    # Same exit code as an early HTTP failure: ensure_loaded's except block is reused.
+    assert excinfo.value.exit_code == 1
+    err = capsys.readouterr().err
+    assert "Model load failed" in err
+    assert "507" in err and "CUDA out of memory" in err
+
+
+def test_deferred_error_helper_passes_a_normal_body_through():
+    from unsloth_cli._inference import raise_for_deferred_error
+
+    body = {"status": "loaded", "model": "org/model-GGUF"}
+    assert raise_for_deferred_error("http://x/api/inference/load", body) is body
+    # Not a dict, and a look-alike that is not the documented shape, both pass.
+    assert raise_for_deferred_error("http://x", [1, 2]) == [1, 2]
+    assert raise_for_deferred_error("http://x", {"_deferred_error": None}) == {
+        "_deferred_error": None
+    }
+
+
+def test_deferred_error_helper_reads_like_a_real_error_response():
+    """Callers recover the detail with exc.read(), exactly as for a real 5xx."""
+    import urllib.error
+
+    from unsloth_cli._inference import raise_for_deferred_error
+
+    with pytest.raises(urllib.error.HTTPError) as excinfo:
+        raise_for_deferred_error(
+            "http://x/api/inference/load",
+            {"_deferred_error": {"status_code": 500, "detail": "llama-server died"}},
+        )
+    exc = excinfo.value
+    assert exc.code == 500
+    assert json.loads(exc.read().decode()) == {"detail": "llama-server died"}
+    assert "llama-server died" in str(exc)
+
+
+def test_deferred_error_helper_defaults_a_missing_status():
+    import urllib.error
+
+    from unsloth_cli._inference import raise_for_deferred_error
+
+    with pytest.raises(urllib.error.HTTPError) as excinfo:
+        raise_for_deferred_error("http://x", {"_deferred_error": {}})
+    assert excinfo.value.code == 500
 
 
 def test_load_gguf_backend_forwards_local_runtime_options(monkeypatch):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import re
@@ -3224,6 +3225,84 @@ def test_load_model_with_progress_uses_selected_gguf_size(monkeypatch, capsys):
     progress_url = next(url for method, url, _ in calls if "gguf-download-progress" in url)
     assert "variant=UD-Q4_K_XL" in progress_url
     assert f"expected_bytes={4 * 1024**3}" in progress_url
+
+
+# ── A load slower than the proxy timer (routes/inference.py _tunnel_safe_json) ──
+#
+# /api/inference/load pads its body so a proxy cannot time a slow load out, which
+# commits the 200 before the load finishes. A failure found after that can only
+# travel in the body, as `_deferred_error`, so `_http_json` has to raise on it --
+# otherwise a late OOM reads as a successful load.
+
+_DEFERRED_OOM = {
+    "_deferred_error": {"status_code": 507, "detail": "CUDA out of memory"},
+}
+
+
+def _padded(body: dict) -> io.BytesIO:
+    """A padded response body: keepalive spaces, then the JSON payload."""
+    return io.BytesIO(b"   " + json.dumps(body).encode())
+
+
+def test_http_json_reads_a_padded_success(monkeypatch):
+    """Leading pad bytes are legal JSON, so a slow success is unchanged."""
+    monkeypatch.setattr(
+        start, "urlopen_no_redirect", lambda request, timeout: _padded({"status": "loaded"})
+    )
+    assert start._http_json("POST", f"{BASE}/api/inference/load", "sk-test") == {
+        "status": "loaded"
+    }
+
+
+def test_http_json_raises_a_deferred_error_as_an_http_error(monkeypatch):
+    monkeypatch.setattr(
+        start, "urlopen_no_redirect", lambda request, timeout: _padded(_DEFERRED_OOM)
+    )
+    with pytest.raises(urllib.error.HTTPError) as excinfo:
+        start._http_json("POST", f"{BASE}/api/inference/load", "sk-test")
+    # The same class every caller already handles for an early HTTP failure.
+    assert excinfo.value.code == 507
+    assert "CUDA out of memory" in str(excinfo.value)
+
+
+def test_http_json_deferred_error_fails_like_an_http_failure(monkeypatch, capsys):
+    """With `error` set, a late failure exits 1 with the server's detail -- exactly
+    what an early 507 does, via the same _fail path."""
+    monkeypatch.setattr(
+        start, "urlopen_no_redirect", lambda request, timeout: _padded(_DEFERRED_OOM)
+    )
+    with pytest.raises(typer.Exit) as excinfo:
+        start._http_json(
+            "POST",
+            f"{BASE}/api/inference/load",
+            "sk-test",
+            error = "Model load failed",
+        )
+    assert excinfo.value.exit_code == 1
+    # _http_error_detail reads the raised error's body, so the detail survives.
+    assert "Model load failed: CUDA out of memory" in capsys.readouterr().err
+
+
+def test_load_model_with_progress_fails_on_a_deferred_error(monkeypatch):
+    """The real /load caller: a late failure must not be returned as a result."""
+
+    def urlopen(request, timeout):
+        if request.full_url.endswith("/api/inference/load"):
+            return _padded(_DEFERRED_OOM)
+        # Progress polling is best-effort; 404 it so the display just disables.
+        raise urllib.error.HTTPError(request.full_url, 404, "not found", None, None)
+
+    monkeypatch.setattr(start, "urlopen_no_redirect", urlopen)
+    monkeypatch.setattr(start, "_DOWNLOAD_POLL_INTERVAL_S", 0.001)
+    with pytest.raises(typer.Exit) as excinfo:
+        start._load_model_with_progress(
+            BASE,
+            "sk-test",
+            "owner/model-GGUF",
+            start.LoadOptions(),
+            {"model_path": "owner/model-GGUF"},
+        )
+    assert excinfo.value.exit_code == 1
 
 
 def test_download_progress_ignores_fully_cached_bytes(capsys):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -3303,6 +3303,43 @@ def test_load_model_with_progress_fails_on_a_deferred_error(monkeypatch):
     assert excinfo.value.exit_code == 1
 
 
+@pytest.mark.parametrize(
+    ("body", "what"),
+    [
+        (b"", "an empty body"),
+        (b"   ", "pad bytes only"),
+        (b'  {"status": "loa', "a payload cut in half"),
+    ],
+)
+def test_load_model_with_progress_rejects_a_truncated_padded_body(monkeypatch, body, what):
+    """A proxy that gives up mid-pad leaves a 200 the load never finished under.
+
+    The measured shape (test_tunnel_safe_long_post.py): one byte at t=90s, silence,
+    killed ~125s later, client sees a 200 with an EMPTY body. `_http_json` decodes a
+    blank body as `{}`, so without the check this returned a successful-looking result
+    and the agent connected to whatever model was still resident.
+    """
+
+    def urlopen(request, timeout):
+        if request.full_url.endswith("/api/inference/load"):
+            return io.BytesIO(body)
+        # Progress polling is best-effort; 404 it so the display just disables.
+        raise urllib.error.HTTPError(request.full_url, 404, "not found", None, None)
+
+    monkeypatch.setattr(start, "urlopen_no_redirect", urlopen)
+    monkeypatch.setattr(start, "_DOWNLOAD_POLL_INTERVAL_S", 0.001)
+    with pytest.raises(RuntimeError) as excinfo:
+        start._load_model_with_progress(
+            BASE,
+            "sk-test",
+            "owner/model-GGUF",
+            start.LoadOptions(),
+            {"model_path": "owner/model-GGUF"},
+        )
+    assert "did not report completion" in str(excinfo.value), what
+    assert "/api/inference/load" in str(excinfo.value)
+
+
 def test_download_progress_ignores_fully_cached_bytes(capsys):
     display = start._DownloadProgressDisplay()
     display.update(

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -3229,10 +3229,9 @@ def test_load_model_with_progress_uses_selected_gguf_size(monkeypatch, capsys):
 
 # ── A load slower than the proxy timer (routes/inference.py _tunnel_safe_json) ──
 #
-# /api/inference/load pads its body so a proxy cannot time a slow load out, which
-# commits the 200 before the load finishes. A failure found after that can only
-# travel in the body, as `_deferred_error`, so `_http_json` has to raise on it --
-# otherwise a late OOM reads as a successful load.
+# /api/inference/load pads its body so a proxy cannot time a slow load out, committing
+# the 200 before the load finishes. A failure after that travels only in the body, as
+# `_deferred_error`, so `_http_json` must raise on it or a late OOM reads as success.
 
 _DEFERRED_OOM = {
     "_deferred_error": {"status_code": 507, "detail": "CUDA out of memory"},
@@ -3264,8 +3263,8 @@ def test_http_json_raises_a_deferred_error_as_an_http_error(monkeypatch):
 
 
 def test_http_json_deferred_error_fails_like_an_http_failure(monkeypatch, capsys):
-    """With `error` set, a late failure exits 1 with the server's detail -- exactly
-    what an early 507 does, via the same _fail path."""
+    """With `error` set, a late failure exits 1 with the server's detail, as an early 507
+    does, via the same _fail path."""
     monkeypatch.setattr(
         start, "urlopen_no_redirect", lambda request, timeout: _padded(_DEFERRED_OOM)
     )
@@ -3314,10 +3313,9 @@ def test_load_model_with_progress_fails_on_a_deferred_error(monkeypatch):
 def test_load_model_with_progress_rejects_a_truncated_padded_body(monkeypatch, body, what):
     """A proxy that gives up mid-pad leaves a 200 the load never finished under.
 
-    The measured shape (test_tunnel_safe_long_post.py): one byte at t=90s, silence,
-    killed ~125s later, client sees a 200 with an EMPTY body. `_http_json` decodes a
-    blank body as `{}`, so without the check this returned a successful-looking result
-    and the agent connected to whatever model was still resident.
+    Measured: one byte at t=90s, silence, killed ~125s later, a 200 with an EMPTY body.
+    `_http_json` decodes a blank body as `{}`, so without the check this returned a
+    successful-looking result and the agent connected to whatever was still resident.
     """
 
     def urlopen(request, timeout):

--- a/unsloth_cli/tests/test_start.py
+++ b/unsloth_cli/tests/test_start.py
@@ -3249,9 +3249,7 @@ def test_http_json_reads_a_padded_success(monkeypatch):
     monkeypatch.setattr(
         start, "urlopen_no_redirect", lambda request, timeout: _padded({"status": "loaded"})
     )
-    assert start._http_json("POST", f"{BASE}/api/inference/load", "sk-test") == {
-        "status": "loaded"
-    }
+    assert start._http_json("POST", f"{BASE}/api/inference/load", "sk-test") == {"status": "loaded"}
 
 
 def test_http_json_raises_a_deferred_error_as_an_http_error(monkeypatch):

--- a/unsloth_cli/tests/test_studio_run_parallel_flag.py
+++ b/unsloth_cli/tests/test_studio_run_parallel_flag.py
@@ -462,10 +462,9 @@ def test_load_model_http_payload_for_gpu_memory_mode(monkeypatch, mode, expected
 
 
 def test_load_model_http_fails_on_a_deferred_error(monkeypatch):
-    """A load slower than the proxy timer commits its 200 before it finishes and
-    pads the body (routes/inference.py _tunnel_safe_json), so a late failure can
-    only arrive in-band. It must still surface as the RuntimeError `run` reports,
-    not as a successful load."""
+    """A slow load commits its 200 and pads the body (routes/inference.py
+    _tunnel_safe_json), so a late failure arrives in-band; it must still surface as the
+    RuntimeError `run` reports, not as a successful load."""
     studio_mod = _load_run_command()
 
     def urlopen(request, timeout):
@@ -493,8 +492,7 @@ def test_load_model_http_fails_on_a_deferred_error(monkeypatch):
 
 @pytest.mark.parametrize("body", [b"", b"   ", b'  {"status": "loa', b"{}"])
 def test_load_model_http_rejects_a_truncated_padded_body(monkeypatch, body):
-    """A proxy that gives up mid-pad leaves a 200 the load never finished under, so
-    it must fail like any other load failure rather than read as completion."""
+    """A 200 the load never finished under must fail like any other load failure."""
     studio_mod = _load_run_command()
 
     monkeypatch.setattr(

--- a/unsloth_cli/tests/test_studio_run_parallel_flag.py
+++ b/unsloth_cli/tests/test_studio_run_parallel_flag.py
@@ -491,6 +491,27 @@ def test_load_model_http_fails_on_a_deferred_error(monkeypatch):
     assert "CUDA out of memory" in str(excinfo.value)
 
 
+@pytest.mark.parametrize("body", [b"", b"   ", b'  {"status": "loa', b"{}"])
+def test_load_model_http_rejects_a_truncated_padded_body(monkeypatch, body):
+    """A proxy that gives up mid-pad leaves a 200 the load never finished under, so
+    it must fail like any other load failure rather than read as completion."""
+    studio_mod = _load_run_command()
+
+    monkeypatch.setattr(
+        studio_mod.urllib.request, "urlopen", lambda request, timeout: BytesIO(body)
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        studio_mod._load_model_via_http(
+            port = 8888,
+            api_key = "sk-test",
+            model = "owner/model-GGUF",
+            gguf_variant = None,
+            max_seq_length = 0,
+            load_in_4bit = True,
+        )
+    assert "did not report completion" in str(excinfo.value)
+
+
 def test_reexec_mixed_parallel_with_passthrough(monkeypatch):
     """--parallel + llama-server pass-through flags must all reach the child."""
     result, captured = _invoke_run(

--- a/unsloth_cli/tests/test_studio_run_parallel_flag.py
+++ b/unsloth_cli/tests/test_studio_run_parallel_flag.py
@@ -461,6 +461,36 @@ def test_load_model_http_payload_for_gpu_memory_mode(monkeypatch, mode, expected
     assert captured["request"].get_header("Authorization") == "Bearer sk-test"
 
 
+def test_load_model_http_fails_on_a_deferred_error(monkeypatch):
+    """A load slower than the proxy timer commits its 200 before it finishes and
+    pads the body (routes/inference.py _tunnel_safe_json), so a late failure can
+    only arrive in-band. It must still surface as the RuntimeError `run` reports,
+    not as a successful load."""
+    studio_mod = _load_run_command()
+
+    def urlopen(request, timeout):
+        # Keepalive pad, then the deferred failure: what the wire really carries.
+        return BytesIO(
+            b"  "
+            + json.dumps(
+                {"_deferred_error": {"status_code": 507, "detail": "CUDA out of memory"}}
+            ).encode()
+        )
+
+    monkeypatch.setattr(studio_mod.urllib.request, "urlopen", urlopen)
+    with pytest.raises(RuntimeError) as excinfo:
+        studio_mod._load_model_via_http(
+            port = 8888,
+            api_key = "sk-test",
+            model = "owner/model-GGUF",
+            gguf_variant = None,
+            max_seq_length = 0,
+            load_in_4bit = True,
+        )
+    assert "HTTP 507" in str(excinfo.value)
+    assert "CUDA out of memory" in str(excinfo.value)
+
+
 def test_reexec_mixed_parallel_with_passthrough(monkeypatch):
     """--parallel + llama-server pass-through flags must all reach the child."""
     result, captured = _invoke_run(


### PR DESCRIPTION
## Problem

Loading a large GGUF in Studio behind `--secure` shows "Request failed" in the browser while the server completes the load and returns 200.

Cloudflare quick tunnels drop a request whose origin has sent no body bytes for ~100s. Over one session (384 requests, 0 server errors) 12 requests passed that mark, and **every one of them returned 200**:

| request | count | durations |
|---|---:|---|
| `POST /api/inference/load` | 6 | 102.6, 112.4, 140.8, 257.2, 295.1, 327.1 s |
| `POST /api/inference/unload` | 1 | 160.9 s |
| `POST /v1/chat/completions` | 5 | 180.3, 228.3, 279.7, 1413.2, 2254.9 s |

Chat is unaffected and needs no change: it sends `stream: true`, so bytes flow from the first token and the connection stays alive. The 2254.9 s completion is the proof. Load and unload send nothing until they finish, so only those are killed.

## What the tunnel actually does

Measured against a real `trycloudflare.com` quick tunnel with a throwaway origin, before choosing a design:

| origin behaviour | result |
|---|---|
| no body at all for 150 s | **524** at ~125 s |
| status line + headers at t=0, then no body for 150 s | **524** at ~125 s |
| one byte at t=90 s, then silence | connection killed ~125 s later; client sees **200 with an empty body** |
| one space every 20 s, real JSON last | **200**, body intact |

Two conclusions drove the implementation. Flushing the status line early is not enough, the timer wants body bytes. And the timer **resets on each byte**, so padding has to be continuous; if the gap is too long the failure mode is a silent 200 with an empty body, which is worse than a clean 524.

An SSE progress stream was considered and rejected. `routes/export.py:213-217` already documents that quick tunnels buffer `text/event-stream` and only flush on close, and my probe reproduced that: the padded body arrived in one piece at the end rather than incrementally. It does not matter here, because survival depends on the origin sending, not on Cloudflare forwarding.

## Change

`/load` and `/unload` hand off to `_tunnel_safe_json`:

- A call that finishes within 15 s keeps today's contract exactly, `HTTPException` and status code included.
- A slower one commits a `200` and emits a single space every 20 s until the payload is ready, then writes the real JSON as the final chunk.

Leading whitespace is legal JSON, so all six `loadModel` callers parse the body unchanged: `use-chat-model-runtime.ts:1055` and `:1291`, `chat-adapter.ts:1649` and `:1998`, `shared-composer.tsx:1216`, `use-recipe-executions.ts:253`.

The cost is that a failure discovered after the status is committed can only travel in the body, as `_deferred_error`, which `parseJsonOrThrow` now raises on. Everything that fails before the 15 s mark still gets a real status code, which covers argument validation, an unknown identifier, and the download-manager and sidecar 409s. The key is underscored so it cannot collide with a real field or with the OpenAI `error` envelope.

A client disconnect does not cancel the work, so an abandoned load still leaves the model resident, exactly as today.

Re-POSTing was explicitly not used: the `native_path_lease` nonce is single use (`native_path_leases.py:210,350-358`), so a local `.gguf` retry is a deterministic 400, and a second concurrent `POST /load` does not 409 but queues on a process-wide lock for the whole remaining load (`llama_keepwarm.py:40-54`).

## Also

Renames the `fit` field in the load log line. It is `use_fit`, i.e. whether `--fit on` is passed, so `fit: False` meant "fits, GPUs pinned, `--fit off`" which reads as the exact opposite.

```
before  GPUs free: [...], selected: [3, 4, 6, 7], fit: False
after   GPUs free: [...], selected: [3, 4, 6, 7], --fit: off
```

## Tests

`test_tunnel_safe_long_post.py`, 7 tests: the fast path stays a plain response, a fast failure keeps its status code, a slow call pads then emits valid JSON, a slow `HTTPException` and an unexpected exception both arrive as `_deferred_error`, the work survives a client disconnect, and a guard that the pad interval stays inside the proxy window (read from source so the fast test values cannot mask a bad default).

Full backend suite green apart from failures that reproduce on unmodified main in this environment: the 12 `test_studio_api.py` e2e tests (401 against the locally booted server) and `test_text_io_encoding.py::test_a_corrupt_pid_file_does_not_abort_shutdown`. `npx tsc --noEmit`, `eslint` and `npm test` all clean.
