### PR TITLE
Add Atlas Cloud as an external LLM provider

### DIFF
--- a/studio/backend/core/inference/providers.py
+++ b/studio/backend/core/inference/providers.py
@@ -129,6 +129,22 @@ PROVIDER_REGISTRY: dict[str, dict[str, Any]] = {
         "auth_prefix": "Bearer ",
         "notes": "OpenAI-compatible API. deepseek-chat = V3, deepseek-reasoner = R1 thinking mode.",
     },
+    "atlascloud": {
+        "display_name": "Atlas Cloud",
+        "base_url": "https://api.atlascloud.ai/v1",
+        "default_models": [
+            "deepseek-ai/deepseek-v4-pro",
+        ],
+        "supports_streaming": True,
+        "supports_vision": False,
+        "supports_tool_calling": True,
+        "auth_header": "Authorization",
+        "auth_prefix": "Bearer ",
+        "notes": "OpenAI-compatible chat completions API.",
+        # The remote catalog also contains image and video models. Keep the
+        # chat picker scoped to verified LLM defaults while allowing manual IDs.
+        "model_list_mode": "curated",
+    },
     "mistral": {
         "display_name": "Mistral AI",
         "base_url": "https://api.mistral.ai/v1",

--- a/studio/backend/tests/test_atlascloud_provider.py
+++ b/studio/backend/tests/test_atlascloud_provider.py
@@ -17,9 +17,7 @@ def test_atlascloud_registry_entry():
     assert info["base_url"] == "https://api.atlascloud.ai/v1"
     assert info["default_models"] == ["deepseek-ai/deepseek-v4-pro"]
     assert info["model_list_mode"] == "curated"
-    assert any(
-        entry["provider_type"] == "atlascloud" for entry in list_available_providers()
-    )
+    assert any(entry["provider_type"] == "atlascloud" for entry in list_available_providers())
 
 
 @pytest.mark.asyncio

--- a/studio/backend/tests/test_atlascloud_provider.py
+++ b/studio/backend/tests/test_atlascloud_provider.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Focused coverage for the Atlas Cloud provider preset."""
+
+import pytest
+
+import core.inference.external_provider as external_provider
+from core.inference.external_provider import ExternalProviderClient
+from core.inference.providers import get_provider_info, list_available_providers
+
+
+def test_atlascloud_registry_entry():
+    info = get_provider_info("atlascloud")
+
+    assert info is not None
+    assert info["base_url"] == "https://api.atlascloud.ai/v1"
+    assert info["default_models"] == ["deepseek-ai/deepseek-v4-pro"]
+    assert info["model_list_mode"] == "curated"
+    assert any(
+        entry["provider_type"] == "atlascloud" for entry in list_available_providers()
+    )
+
+
+@pytest.mark.asyncio
+async def test_atlascloud_chat_uses_openai_compatible_endpoint(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+    class HTTPClient:
+        async def post(self, url, *, json, headers, timeout):
+            captured.update(
+                {
+                    "url": url,
+                    "json": json,
+                    "headers": headers,
+                    "timeout": timeout,
+                }
+            )
+            return Response()
+
+    monkeypatch.setattr(external_provider, "_http_client", HTTPClient())
+    client = ExternalProviderClient(
+        provider_type = "atlascloud",
+        base_url = "https://api.atlascloud.ai/v1",
+        api_key = "test-key",
+    )
+
+    response = await client.chat_completion(
+        messages = [{"role": "user", "content": "ping"}],
+        model = "deepseek-ai/deepseek-v4-pro",
+        max_tokens = 8,
+    )
+
+    assert response["choices"][0]["message"]["content"] == "ok"
+    assert captured["url"] == "https://api.atlascloud.ai/v1/chat/completions"
+    assert captured["headers"]["Authorization"] == "Bearer test-key"
+    assert captured["json"]["model"] == "deepseek-ai/deepseek-v4-pro"

--- a/studio/backend/tests/test_providers_api.py
+++ b/studio/backend/tests/test_providers_api.py
@@ -17,6 +17,7 @@ Requires a running Unsloth Studio server. Configure via env vars:
     export TOGETHER_API_KEY="..."
     export FIREWORKS_API_KEY="..."
     export PERPLEXITY_API_KEY="..."
+    export ATLASCLOUD_API_KEY="..."
 
 Run:
     cd studio/backend
@@ -53,6 +54,7 @@ _PROVIDER_CONFIGS: dict[str, tuple[str, str]] = {
     "openrouter": ("OPENROUTER_API_KEY", "openai/gpt-4o-mini"),
     "anthropic": ("ANTHROPIC_API_KEY", "claude-haiku-4-5"),
     "deepseek": ("DEEPSEEK_API_KEY", "deepseek-chat"),
+    "atlascloud": ("ATLASCLOUD_API_KEY", "deepseek-ai/deepseek-v4-pro"),
     "huggingface": ("HUGGINGFACE_API_KEY", "meta-llama/Llama-3.3-70B-Instruct"),
     "kimi": ("MOONSHOT_API_KEY", "moonshot-v1-8k"),
     "qwen": ("DASHSCOPE_API_KEY", "qwen-turbo"),
@@ -243,7 +245,9 @@ class TestRegistry:
         )
         assert resp.status_code == 200, f"Registry failed: {resp.text}"
         providers = resp.json()
-        assert len(providers) == 9, f"Expected 9 providers, got {len(providers)}: {providers}"
+        assert len(providers) == len(
+            EXPECTED_PROVIDER_TYPES
+        ), f"Expected {len(EXPECTED_PROVIDER_TYPES)} providers, got {len(providers)}: {providers}"
         print(f"\n  {'Provider':<12} {'Base URL'}")
         print(f"  {'-'*12} {'-'*45}")
         for p in providers:


### PR DESCRIPTION
## Summary
- register Atlas Cloud as a first-class OpenAI-compatible external provider
- expose a verified default chat model while keeping the mixed media catalog out of the chat picker
- cover registry wiring, request routing, and the live-provider integration matrix

## Testing
- `python -m pytest studio/backend/tests/test_atlascloud_provider.py -q` (2 passed)
- `python -m ruff check studio/backend/core/inference/providers.py studio/backend/tests/test_atlascloud_provider.py studio/backend/tests/test_providers_api.py`
- `python -m compileall` on changed Python files
- `git diff --check`
- live Atlas Cloud validation: model catalog and default model lookup, non-streaming chat, streaming completion, and forced tool call