### PR TITLE
Fix two pre-existing Backend CI failures blocking every open PR

### DIFF
--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -29,7 +29,7 @@ def _read(rel: str) -> str:
 def _read_backend(rel: str) -> str:
     path = WORKDIR / "studio" / "backend" / rel
     assert path.exists(), f"missing backend source file: {path}"
-    return path.read_text()
+    return path.read_text(encoding = "utf-8")
 
 
 def test_models_api_sends_token_via_header_not_query():

--- a/unsloth_cli/tests/conftest.py
+++ b/unsloth_cli/tests/conftest.py
@@ -9,6 +9,23 @@ import types
 import pytest
 
 
+@pytest.fixture(autouse = True)
+def _plain_cli_output(monkeypatch):
+    """Keep Typer/Rich from colouring the output these tests assert on.
+
+    Typer renders usage and parameter errors through Rich, which emits ANSI
+    escapes as soon as FORCE_COLOR is set -- and a runner that exports it (as
+    ours does) splits a plain substring like "Invalid value for
+    '--gpu-memory-mode'" across escape sequences, so `in result.output` stops
+    matching even though the message is right there. Setting NO_COLOR is not
+    enough on its own: FORCE_COLOR still wins, so it has to be removed.
+    """
+    for var in ("FORCE_COLOR", "CLICOLOR_FORCE"):
+        monkeypatch.delenv(var, raising = False)
+    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.setenv("TERM", "dumb")
+
+
 @pytest.fixture
 def stub_tool_policy_state(monkeypatch):
     """Stub the backend's `state.tool_policy`, which run() imports in-venv.


### PR DESCRIPTION
Repo tests (CPU) is currently red on main:

```
FAILED tests/test_source_read_encoding.py::test_checked_in_file_reads_name_an_encoding
AssertionError: 1 file reads in the test trees touch a checked-in file with the
platform default encoding, so they break on Windows as soon as that file gains a
non-ASCII byte. Pass encoding = "utf-8":
["tests/studio/test_model_picker_contracts.py:32: read_text()"]
```

`_read_backend` arrived in #7385 without an encoding. The sibling `_read` helper directly above it already passes `encoding = "utf-8"`, so this just makes the two agree.

Worth fixing promptly because CI for a `pull_request` runs the merge commit, so every open PR inherits this failure even when its own head does not contain the helper. It is currently red on unrelated PRs for that reason.

Verified on a clean `main` worktree: the guard test fails before, and `tests/test_source_read_encoding.py` plus the full `tests/studio/test_model_picker_contracts.py` (66 tests) pass after.