### PR TITLE
Fix desktop repair version skew and output decoding

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -2716,51 +2716,6 @@ exit 0
         }
     }
 
-    # Overlay Tauri-bundled studio fixes that may be ahead of PyPI. Skipped
-    # for --local: the editable install above already makes _PACKAGE_ROOT in
-    # unsloth_cli/commands/studio.py resolve to the repo (PEP 660 __file__).
-    # Source paths match the Tauri bundle layout in studio/src-tauri/tauri.conf.json,
-    # which bundles install_python_stack.py at the bundle root next to install.ps1.
-    if ($TauriMode) {
-        $rawPath = if ($PSCommandPath) { $PSCommandPath } else { $MyInvocation.ScriptName }
-        if ($rawPath) {
-            # Strip leading \\?\ extended-length prefix if the launcher passed one.
-            $scriptDir = Split-Path -Parent ($rawPath -replace '^\\\\\?\\', '')
-            $overlayMap = [ordered]@{
-                "install_python_stack.py" = "Lib\site-packages\studio\install_python_stack.py"
-            }
-            foreach ($rel in $overlayMap.Keys) {
-                $src = Join-Path $scriptDir $rel
-                $dst = Join-Path $VenvDir $overlayMap[$rel]
-                # -LiteralPath: $VenvDir derives from $StudioHome which may
-                # contain [ ] * ? when the user overrode UNSLOTH_STUDIO_HOME.
-                if (-not (Test-Path -LiteralPath $src)) { continue }
-                $dstParent = Split-Path -Parent $dst
-                if (-not (Test-Path -LiteralPath $dstParent)) {
-                    Write-Host "[WARN] Overlay target dir missing: $dstParent; studio setup may use stale bundled file" -ForegroundColor Yellow
-                    continue
-                }
-                try {
-                    if (-not (Test-Path -LiteralPath $dst)) {
-                        # Backfill: target file missing but parent dir exists.
-                        Copy-Item -LiteralPath $src -Destination $dst -Force
-                        substep ("backfilled bundled " + (Split-Path -Leaf $rel))
-                    } else {
-                        # Hash-compare so re-runs are no-ops when files already match.
-                        $srcHash = (Get-FileHash -LiteralPath $src -Algorithm SHA256).Hash
-                        $dstHash = (Get-FileHash -LiteralPath $dst -Algorithm SHA256).Hash
-                        if ($srcHash -ne $dstHash) {
-                            Copy-Item -LiteralPath $src -Destination $dst -Force
-                            substep ("applied bundled " + (Split-Path -Leaf $rel))
-                        }
-                    }
-                } catch {
-                    Write-Host "[WARN] Could not overlay $($rel): $($_.Exception.Message); studio setup may use stale bundled file" -ForegroundColor Yellow
-                }
-            }
-        }
-    }
-
     # ── CI only: overlay a source checkout over the package just installed ──
     # Mirrors install.sh. Not a consumer knob: no switch, absent from the usage text,
     # ignored unless UNSLOTH_CI_SOURCE_OVERLAY names a directory with a pyproject.toml.

--- a/studio/src-tauri/src/update.rs
+++ b/studio/src-tauri/src/update.rs
@@ -1,4 +1,5 @@
 use crate::diagnostics::{self, AttemptLog, DiagnosticsState};
+use crate::process::trim_line_endings;
 use log::{error, info, warn};
 use process_wrap::std::*;
 use std::io::BufRead;
@@ -97,6 +98,21 @@ fn spawn_update(
 
 // ── Stream ──
 
+fn read_lossy_lines<R: std::io::Read>(
+    stream: R,
+    mut on_line: impl FnMut(String),
+) -> std::io::Result<()> {
+    let mut reader = std::io::BufReader::new(stream);
+    let mut buf = Vec::new();
+    loop {
+        buf.clear();
+        if reader.read_until(b'\n', &mut buf)? == 0 {
+            return Ok(());
+        }
+        on_line(String::from_utf8_lossy(trim_line_endings(&buf)).into_owned());
+    }
+}
+
 fn stream_output(
     app: &AppHandle,
     progress_event: &'static str,
@@ -112,34 +128,19 @@ fn stream_output(
         let diagnostics_clone = diagnostics.clone();
         let attempt_clone = attempt.clone();
         threads.push(std::thread::spawn(move || {
-            let reader = std::io::BufReader::new(out);
-            for line in reader.lines() {
-                match line {
-                    Ok(text) => {
-                        diagnostics::append_phase_line(&attempt_clone.handle, "stdout", &text);
-                        if let Some(step) = text.strip_prefix("[TAURI:STEP] ") {
-                            diagnostics::record_step(&diagnostics_clone, &attempt_clone, step);
-                        } else if let Some(progress) = text.strip_prefix("[TAURI:PROGRESS] ") {
-                            diagnostics::record_progress(
-                                &diagnostics_clone,
-                                &attempt_clone,
-                                progress,
-                            );
-                        } else if let Some(marker) = text.strip_prefix("[TAURI:DIAG] ") {
-                            diagnostics::record_diag_marker(
-                                &diagnostics_clone,
-                                &attempt_clone,
-                                marker,
-                            );
-                        }
-                        info!("[update][stdout] {}", text);
-                        let _ = app_clone.emit(progress_event, &text);
-                    }
-                    Err(e) => {
-                        warn!("[update] Error reading stdout: {}", e);
-                        break;
-                    }
+            if let Err(e) = read_lossy_lines(out, |text| {
+                diagnostics::append_phase_line(&attempt_clone.handle, "stdout", &text);
+                if let Some(step) = text.strip_prefix("[TAURI:STEP] ") {
+                    diagnostics::record_step(&diagnostics_clone, &attempt_clone, step);
+                } else if let Some(progress) = text.strip_prefix("[TAURI:PROGRESS] ") {
+                    diagnostics::record_progress(&diagnostics_clone, &attempt_clone, progress);
+                } else if let Some(marker) = text.strip_prefix("[TAURI:DIAG] ") {
+                    diagnostics::record_diag_marker(&diagnostics_clone, &attempt_clone, marker);
                 }
+                info!("[update][stdout] {}", text);
+                let _ = app_clone.emit(progress_event, &text);
+            }) {
+                warn!("[update] Error reading stdout: {}", e);
             }
         }));
     }
@@ -148,19 +149,12 @@ fn stream_output(
         let app_clone = app.clone();
         let attempt_clone = attempt.clone();
         threads.push(std::thread::spawn(move || {
-            let reader = std::io::BufReader::new(err);
-            for line in reader.lines() {
-                match line {
-                    Ok(text) => {
-                        diagnostics::append_phase_line(&attempt_clone.handle, "stderr", &text);
-                        warn!("[update][stderr] {}", text);
-                        let _ = app_clone.emit(progress_event, &text);
-                    }
-                    Err(e) => {
-                        warn!("[update] Error reading stderr: {}", e);
-                        break;
-                    }
-                }
+            if let Err(e) = read_lossy_lines(err, |text| {
+                diagnostics::append_phase_line(&attempt_clone.handle, "stderr", &text);
+                warn!("[update][stderr] {}", text);
+                let _ = app_clone.emit(progress_event, &text);
+            }) {
+                warn!("[update] Error reading stderr: {}", e);
             }
         }));
     }
@@ -419,5 +413,22 @@ pub fn stop_update(state: &UpdateState) -> Result<(), String> {
         let _ = child.wait();
         info!("Update process group force stopped");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn lossy_reader_keeps_invalid_utf8_and_later_lines() {
+        let mut lines = Vec::new();
+        read_lossy_lines(Cursor::new(b"bad\xff\r\n[TAURI:STEP] next\n"), |line| {
+            lines.push(line)
+        })
+        .unwrap();
+
+        assert_eq!(lines, ["bad\u{fffd}", "[TAURI:STEP] next"]);
     }
 }

--- a/tests/studio/test_tauri_installer_resource_contract.py
+++ b/tests/studio/test_tauri_installer_resource_contract.py
@@ -11,13 +11,9 @@ REPO = Path(__file__).resolve().parents[2]
 
 
 def test_tauri_never_overlays_install_python_stack() -> None:
-    config = json.loads(
-        (REPO / "studio/src-tauri/tauri.conf.json").read_text(encoding = "utf-8")
-    )
+    config = json.loads((REPO / "studio/src-tauri/tauri.conf.json").read_text(encoding = "utf-8"))
     resources = config["bundle"]["resources"]
-    assert not any(
-        "install_python_stack.py" in path for item in resources.items() for path in item
-    )
+    assert not any("install_python_stack.py" in path for item in resources.items() for path in item)
 
     installer = (REPO / "install.ps1").read_text(encoding = "utf-8")
     assert "Overlay Tauri-bundled studio fixes" not in installer

--- a/tests/studio/test_tauri_installer_resource_contract.py
+++ b/tests/studio/test_tauri_installer_resource_contract.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Keep Tauri repair helpers from mixing package versions."""
+
+import json
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def test_tauri_never_overlays_install_python_stack() -> None:
+    config = json.loads(
+        (REPO / "studio/src-tauri/tauri.conf.json").read_text(encoding = "utf-8")
+    )
+    resources = config["bundle"]["resources"]
+    assert not any(
+        "install_python_stack.py" in path for item in resources.items() for path in item
+    )
+
+    installer = (REPO / "install.ps1").read_text(encoding = "utf-8")
+    assert "Overlay Tauri-bundled studio fixes" not in installer
+    assert (
+        '"install_python_stack.py" = "Lib\\site-packages\\studio\\install_python_stack.py"'
+        not in installer
+    )


### PR DESCRIPTION
## Summary

- stop Tauri repair from overlaying a stale `install_python_stack.py` onto the current wheel
- read update stdout and stderr as bytes so invalid UTF-8 cannot close the pipe and force exit 120
- add focused regressions for resource skew and continued output streaming

## Testing

- `npm run build` in `studio/frontend`
- `cargo test --manifest-path studio/src-tauri/Cargo.toml --no-fail-fast`
- `cargo fmt --manifest-path studio/src-tauri/Cargo.toml -- --check`
- `uv run --no-project --with pytest pytest tests/studio/test_tauri_installer_resource_contract.py -q`