### PR TITLE
Make the uninstaller test suites run on macOS and Windows PowerShell 5.1

### DIFF
--- a/.github/workflows/studio-windows-update-smoke.yml
+++ b/.github/workflows/studio-windows-update-smoke.yml
@@ -74,6 +74,16 @@ jobs:
           pwsh -NoProfile -File tests/studio/test_uninstall_dual_install_icon.ps1
           if ($LASTEXITCODE) { exit $LASTEXITCODE }
 
+      # The argument guard is self-hosting via (Get-Process -Id $PID).Path, so
+      # launching it from powershell.exe exercises Windows PowerShell 5.1, the
+      # shell the README one-liner lands in on a stock Windows box. Nothing else
+      # in CI runs 5.1, and its native-stderr handling differs from pwsh 7.
+      - name: uninstall.ps1 argument guard under Windows PowerShell 5.1
+        shell: powershell
+        run: |
+          powershell -NoProfile -File tests/studio/test_uninstall_arg_guard.ps1
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: '22'

--- a/tests/sh/test_uninstall_arg_guard.sh
+++ b/tests/sh/test_uninstall_arg_guard.sh
@@ -74,7 +74,10 @@ assert_fixture() {
 # hidden by command-substitution errexit behavior.
 FIXTURE_HOME=""
 make_home() {
-    FIXTURE_HOME=$(TMPDIR="$_TMP_ROOT" mktemp -d) || FIXTURE_HOME=""
+    # Explicit template, not TMPDIR: BSD mktemp with no template implies -t and
+    # resolves the directory itself, so on macOS TMPDIR= lands a sibling of
+    # _TMP_ROOT and the check below aborts the suite.
+    FIXTURE_HOME=$(mktemp -d "$_TMP_ROOT/home.XXXXXX") || FIXTURE_HOME=""
     case "$FIXTURE_HOME" in
         "$_TMP_ROOT"/*) ;;
         *) echo "FATAL: no fixture home under $_TMP_ROOT (got '$FIXTURE_HOME')" >&2; exit 1 ;;

--- a/tests/sh/test_uninstall_shared_icon.sh
+++ b/tests/sh/test_uninstall_shared_icon.sh
@@ -29,7 +29,7 @@ assert_dir()    { _l="$1"; [ -d "$2" ] && { echo "  PASS: $_l"; PASS=$((PASS+1))
 assert_nodir()  { _l="$1"; [ -d "$2" ] && { echo "  FAIL: $_l (unexpected dir $2)"; FAIL=$((FAIL+1)); } || { echo "  PASS: $_l"; PASS=$((PASS+1)); }; }
 
 # Match the function's closing brace without depending on its nesting depth.
-FUNC_FILE=$(mktemp -p "$_TMP_ROOT")
+FUNC_FILE=$(mktemp "$_TMP_ROOT/func.XXXXXX")
 sed -n '/_drop_shared_icon_if_unused() {/,/^[[:space:]]*}$/p' "$UNINSTALL_SH" > "$FUNC_FILE"
 # shellcheck disable=SC1090
 . "$FUNC_FILE"
@@ -37,7 +37,7 @@ sed -n '/_drop_shared_icon_if_unused() {/,/^[[:space:]]*}$/p' "$UNINSTALL_SH" > 
 # make_user [shortcut_relpath] : a fresh fake Windows user dir with unsloth.ico,
 # optionally placing an "Unsloth Studio*.lnk" at the given relative path.
 make_user() {
-    _u=$(mktemp -d -p "$_TMP_ROOT")
+    _u=$(mktemp -d "$_TMP_ROOT/user.XXXXXX")
     mkdir -p "$_u/AppData/Local/Unsloth Studio"
     : > "$_u/AppData/Local/Unsloth Studio/unsloth.ico"
     if [ -n "${1:-}" ]; then
@@ -85,7 +85,7 @@ assert_nofile "no shortcut -> icon removed (non-empty dir)" "$u/$ICO"
 assert_dir    "non-empty dir kept" "$u/$DIR"
 
 # 7. Missing data dir is a safe no-op (no error, exit 0).
-u=$(mktemp -d -p "$_TMP_ROOT")
+u=$(mktemp -d "$_TMP_ROOT/user.XXXXXX")
 if _drop_shared_icon_if_unused "$u"; then
     echo "  PASS: missing data dir -> no-op"; PASS=$((PASS+1))
 else

--- a/tests/studio/test_uninstall_arg_guard.ps1
+++ b/tests/studio/test_uninstall_arg_guard.ps1
@@ -41,10 +41,21 @@ function Check($name, $cond) {
     else { Write-Host "  FAIL  $name" -ForegroundColor Red; $script:failures++ }
 }
 
+# Capture a native command's merged output without letting its stderr abort us.
+# Windows PowerShell 5.1 raises a terminating NativeCommandError when a native
+# command writes to stderr under $ErrorActionPreference = "Stop"; PowerShell
+# 7.1+ does not. This suite is self-hosting via (Get-Process -Id $PID).Path, so
+# it can run under 5.1, where every rejected-argument case writes to stderr.
+function Invoke-Native([scriptblock]$Command) {
+    $prev = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try { return (& $Command | Out-String) } finally { $ErrorActionPreference = $prev }
+}
+
 # Run the instrumented uninstaller in a child pwsh.
 function Invoke-Uninstaller([string[]]$ScriptArgs) {
     $argv = @("-NoProfile", "-File", $uninstallPath) + $ScriptArgs
-    $out = & $pwshPath @argv 2>&1 | Out-String
+    $out = Invoke-Native { & $pwshPath @argv 2>&1 }
     return [pscustomobject]@{ Code = $LASTEXITCODE; Output = $out }
 }
 
@@ -95,7 +106,7 @@ $s = Get-Content -Raw '__PATH__'
 try { & ([scriptblock]::Create($s)) --dry-run } catch { Write-Host $_.Exception.Message }
 Write-Host 'SESSION SURVIVED'
 '@ -replace '__PATH__', $uninstallPath
-    $out = & $pwshPath -NoProfile -Command $probe 2>&1 | Out-String
+    $out = Invoke-Native { & $pwshPath -NoProfile -Command $probe 2>&1 }
     Check "a bad argument does not kill the caller's session" ($out -match "SESSION SURVIVED")
     Check "the scriptblock flow never starts the uninstall"   ($out -notmatch $bodyMarker)
 } finally {


### PR DESCRIPTION
## Problem

The uninstaller suites added in #7631 pass on the ubuntu runner, which is the only place CI runs them. On the other two platforms they abort before finishing.

Verified on real runners (macos-14, windows-latest, and Windows PowerShell 5.1) before this change:

| Suite | ubuntu-latest | macos-14 | Windows PowerShell 5.1 |
|---|---|---|---|
| `tests/sh/test_uninstall_arg_guard.sh` | 25 passed | **aborts at the first case** | n/a |
| `tests/studio/test_uninstall_arg_guard.ps1` | 39 checks | 39 checks | **aborts at the first case** |

## Root causes

**macOS.** `make_home` built its fixture with `TMPDIR="$_TMP_ROOT" mktemp -d`. BSD `mktemp` with no template implies `-t` and resolves the directory itself, so the result lands beside `_TMP_ROOT` instead of inside it. The validation immediately below then fires and `exit 1`s the whole suite:

```
FATAL: no fixture home under /var/folders/.../T/tmp.iWsJO96MVD (got '/var/folders/.../T/tmp.15xzcgEyvp')
```

An explicit template is portable across GNU and BSD and keeps the existing containment check meaningful.

`tests/sh/test_uninstall_shared_icon.sh` had the same class of problem with `mktemp -p`, which is GNU only.

**Windows PowerShell 5.1.** The suite sets `$ErrorActionPreference = "Stop"` and then merges a native command's stderr with `2>&1`. Windows PowerShell turns that into a terminating `NativeCommandError`, so the run dies on the first rejected-argument case, which is the first case that writes to stderr:

```
powershell.exe : __UNSLOTH_TEST_BODY_REACHED__
+ $out = & $pwshPath @argv 2>&1 | Out-String
+ FullyQualifiedErrorId : NativeCommandError
```

PowerShell 7.1 and later do not do this, which is why the pwsh runs are green. The preference is now scoped down around the two native invocations.

## Why 5.1 matters here

The suite is self-hosting through `(Get-Process -Id $PID).Path`, so launching it from `powershell.exe` exercises 5.1, and 5.1 is the shell the README one-liner lands in on a stock Windows box. Nothing in CI ran 5.1 before, which is why this went unnoticed, so the Windows workflow now runs the guard suite there too.

## Verification

Re-run on the same runners after the change:

| Job | Before | After |
|---|---|---|
| shell suites (ubuntu-latest) | pass | pass |
| shell suites (macos-14) | **fail** | pass |
| powershell suites (ubuntu-latest / macos-14 / windows-latest) | pass | pass |
| Windows PowerShell 5.1 argument guard | **fail** | pass |

Locally: `test_uninstall_arg_guard.sh` 25 passed, `test_uninstall_shared_icon.sh` 11 passed, `test_uninstall_arg_guard.ps1` 39 checks passed; `dash -n` / `bash -n` / `busybox sh -n` clean and the ps1 parses; `tests/studio/test_ci_shell_suite_coverage.py` 15 passed.

No production code changes. `scripts/uninstall.sh` and `scripts/uninstall.ps1` are untouched.