### PR TITLE
Assert the Vulkan installer bailouts fail closed via the setup failure helper

### DIFF
--- a/studio/backend/tests/test_setup_llama_cpp_backend.py
+++ b/studio/backend/tests/test_setup_llama_cpp_backend.py
@@ -134,7 +134,8 @@ def test_explicit_vulkan_prebuilt_failure_does_not_change_backend():
     assert guard < source_build
     guarded = sh[guard:source_build]
     assert "will not substitute a ROCm or CPU source build" in guarded
-    assert "exit 1" in guarded
+    # Aborts through the helper, which exits AND emits [TAURI:ERROR] in desktop mode.
+    assert "setup_fail 1" in guarded
 
     ps1 = _SETUP_PS1.read_text(encoding = "utf-8")
     failure = ps1.index('step "llama.cpp" "prebuilt install failed"')
@@ -143,7 +144,7 @@ def test_explicit_vulkan_prebuilt_failure_does_not_change_backend():
     assert guard < source_build
     guarded = ps1[guard:source_build]
     assert "will not substitute a CUDA, ROCm, or CPU source build" in guarded
-    assert "exit 1" in guarded
+    assert "Exit-SetupFailure" in guarded
 
 
 def test_explicit_vulkan_source_build_fails_closed():
@@ -156,7 +157,7 @@ def test_explicit_vulkan_source_build_fails_closed():
         '[ "$_NEED_LLAMA_SOURCE_BUILD" = true ]; then'
     ) in guarded
     assert "Vulkan source builds are not supported" in guarded
-    assert "exit 1" in guarded
+    assert "setup_fail 1" in guarded
 
     ps1 = _SETUP_PS1.read_text(encoding = "utf-8")
     local_branch = ps1.index("if ($LocalLlamaCppLinked) {")
@@ -166,7 +167,7 @@ def test_explicit_vulkan_source_build_fails_closed():
     guarded = ps1[local_branch:prebuilt_branch]
     assert "} elseif ($explicitVulkanSourceBuild -and $NeedLlamaSourceBuild) {" in guarded
     assert "Vulkan source builds are not supported" in guarded
-    assert "exit 1" in guarded
+    assert "Exit-SetupFailure" in guarded
 
 
 def test_force_compile_sets_need_source_build_before_vulkan_guard():


### PR DESCRIPTION
## What

`studio/backend/tests/test_setup_llama_cpp_backend.py` asserts the literal string `exit 1` at the four explicit-Vulkan bailouts in `studio/setup.sh` and `studio/setup.ps1`. Those sites now abort through `setup_fail` / `Exit-SetupFailure`, so the assertions fail:

```
FAILED tests/test_setup_llama_cpp_backend.py::test_explicit_vulkan_prebuilt_failure_does_not_change_backend
FAILED tests/test_setup_llama_cpp_backend.py::test_explicit_vulkan_source_build_fails_closed
```

That takes `Repo tests (CPU)` down on `main`, and because CI builds the PR merge commit, every open PR inherits the red job.

The behaviour these tests exist to protect is unchanged: both helpers exit, so the paths still fail closed. Only the spelling moved. They now assert the helper, which covers "this path fails closed" rather than one way of writing it, and additionally checks the part that matters for the desktop app, that the failure is reported rather than silent.

## Scope change

This PR originally also routed those bailouts through the helpers in `studio/setup.sh` and `studio/setup.ps1`. `main` has since made that change independently, and did it better by keeping the `step` / `substep` lines and using fuller messages. I have dropped my version and rebased onto `main`, so this is now a one-file test fix, which is the piece `main` is still missing.

## Verification

On a pristine `origin/main` worktree, before this change:

- `tests/sh/test_tauri_retry_failure_context.sh` passes (main fixed it)
- `studio/backend/tests/test_setup_llama_cpp_backend.py` gives `2 failed, 58 passed`

With this change:

- `test_setup_llama_cpp_backend.py` gives `60 passed`
- `tests/sh/test_tauri_retry_failure_context.sh` still passes, so both invariants hold together
- full `tests/sh/` gives 27 pass; the one remaining failure, `test_install_host_defaults.sh`, fails identically on pristine `main` and is on the workflow's explicit skip list
- `ruff check studio tests unsloth_cli` passes