### PR TITLE
Route the explicit Vulkan setup failures through the setup failure helpers

### DIFF
--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -3885,7 +3885,7 @@ if ($LocalLlamaCppLinked) {
     Write-Host ""
     step "llama.cpp" "Vulkan was explicitly requested, but this installation requires a source build" "Red"
     substep "Vulkan source builds are not supported by this installer; use the prebuilt Vulkan bundle or unset the Vulkan override" "Yellow"
-    exit 1
+    Exit-SetupFailure "Vulkan was explicitly requested, but this installation requires a source build, which this installer does not support. Use the prebuilt Vulkan bundle or unset the Vulkan override."
 } elseif ($env:UNSLOTH_LLAMA_FORCE_COMPILE -eq "1") {
     Write-Host ""
     substep "UNSLOTH_LLAMA_FORCE_COMPILE=1 -- skipping prebuilt llama.cpp install" "Yellow"
@@ -4057,7 +4057,7 @@ if ($LocalLlamaCppLinked) {
             # run reports success on the backend the user asked to replace.
             if ($explicitVulkanBackend) {
                 step "llama.cpp" "Vulkan was explicitly requested, so the installer will not keep the existing backend" "Red"
-                exit 1
+                Exit-SetupFailure "Vulkan was explicitly requested, so the installer will not keep the existing llama.cpp backend."
             }
         } else {
             step "llama.cpp" "prebuilt install failed" "Yellow"
@@ -4068,7 +4068,7 @@ if ($LocalLlamaCppLinked) {
             if ($explicitVulkanBackend) {
                 step "llama.cpp" "Vulkan was explicitly requested, so the installer will not substitute a CUDA, ROCm, or CPU source build" "Red"
                 substep "Check the download error above or try a different UNSLOTH_LLAMA_RELEASE_TAG" "Yellow"
-                exit 1
+                Exit-SetupFailure "Vulkan was explicitly requested, so the installer will not substitute a CUDA, ROCm, or CPU source build. Check the download error above or try a different UNSLOTH_LLAMA_RELEASE_TAG."
             } else {
                 substep "Prebuilt llama.cpp path unavailable or failed validation -- falling back to source build" "Yellow"
                 $NeedLlamaSourceBuild = $true

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -1459,7 +1459,7 @@ if [ "$_LOCAL_LLAMA_CPP_LINKED" = true ]; then
 elif [ "$_explicit_vulkan_source_build" = true ] && [ "$_NEED_LLAMA_SOURCE_BUILD" = true ]; then
     step "llama.cpp" "Vulkan was explicitly requested, but this installation requires a source build" "$C_ERR"
     substep "Vulkan source builds are not supported by this installer; use the prebuilt Vulkan bundle or unset the Vulkan override"
-    exit 1
+    setup_fail 1 "Vulkan was explicitly requested, but this installation requires a source build, which this installer does not support. Use the prebuilt Vulkan bundle or unset the Vulkan override."
 elif [ "$_LLAMA_FORCE_COMPILE" = "1" ]; then
     step "llama.cpp" "UNSLOTH_LLAMA_FORCE_COMPILE=1 -- skipping prebuilt" "$C_WARN"
     _NEED_LLAMA_SOURCE_BUILD=true
@@ -1578,7 +1578,7 @@ else
         # run reports success on the backend the user asked to replace.
         if [ "$_explicit_vulkan_backend" = true ]; then
             step "llama.cpp" "Vulkan was explicitly requested, so the installer will not keep the existing backend" "$C_ERR"
-            exit 1
+            setup_fail 1 "Vulkan was explicitly requested, so the installer will not keep the existing llama.cpp backend."
         fi
     else
         step "llama.cpp" "prebuilt install failed" "$C_WARN"
@@ -1590,7 +1590,7 @@ else
         if [ "$_explicit_vulkan_backend" = true ]; then
             step "llama.cpp" "Vulkan was explicitly requested, so the installer will not substitute a ROCm or CPU source build" "$C_ERR"
             substep "check the download error above or try a different UNSLOTH_LLAMA_RELEASE_TAG"
-            exit 1
+            setup_fail 1 "Vulkan was explicitly requested, so the installer will not substitute a ROCm or CPU source build. Check the download error above or try a different UNSLOTH_LLAMA_RELEASE_TAG."
         else
             substep "falling back to source build"
             _NEED_LLAMA_SOURCE_BUILD=true


### PR DESCRIPTION
## Problem

`tests/sh/test_tauri_retry_failure_context.sh` fails on current `main`:

```
FAIL: Unix setup has explicit exits outside setup_fail
```

`studio/setup.sh` carries 4 explicit `exit` statements and `studio/setup.ps1` carries 4, where the guard allows exactly 1 each: the one inside `setup_fail` / `Exit-SetupFailure`. The three extra in each file are the explicit-Vulkan paths added by #7188.

## Why it matters

#7529 added the `[TAURI:ERROR] <message>` channel so Studio desktop can surface an actionable reason when the installer fails. `setup_fail` and `Exit-SetupFailure` are the only places that emit it. A bare `exit 1` bypasses them, so a user who explicitly requests Vulkan and hits one of these three conditions gets a failed install in Studio desktop with no context attached, which is the exact failure mode #7529 set out to remove.

## Why nobody noticed

Backend CI runs `Shell installer tests` after `Repo tests (CPU, auto-discovered)` in the same job. That earlier step had been failing on an unrelated encoding assertion, so every later step was **skipped**, including the one that runs this guard. #7642 fixed the encoding assertion, the shell step started running again, and this surfaced immediately.

## Change

Each of the six sites now calls the helper instead of exiting directly, carrying the message that the adjacent `step` / `substep` already prints. The preceding `step` / `substep` output is untouched, so the terminal experience is identical.

Exit codes are unchanged. Verified directly against the extracted helper:

| `UNSLOTH_TAURI_MODE` | exit code | stdout |
|---|---|---|
| unset | 1 | (none) |
| `0` | 1 | (none) |
| `1` | 1 | `[TAURI:ERROR] <message>` |
| `true` | 1 | `[TAURI:ERROR] <message>` |

Identical to the bare `exit 1` for CLI users, and it restores the Tauri channel.

## Verification

- `tests/sh/test_tauri_retry_failure_context.sh`: all assertions pass, including the two that were previously unreachable (`Windows setup routes explicit exits through Exit-SetupFailure` never ran before, because the Unix assertion exited first).
- The full Backend CI `Shell installer tests` step run verbatim: **26 files, 0 failed** (was 1 failed).
- `bash -n studio/setup.sh` clean; `studio/setup.ps1` parses under the PowerShell AST parser.
- The 25 Python test files that reference either setup script: 1387 passed. The 4 unrelated failures in `test_managed_node_runtime.py` and `test_tokenizers_and_torch_constraint.py` reproduce identically on unmodified `main`.