### PR TITLE
Tighten the comments around the uninstaller argument guard

### DIFF
--- a/.github/workflows/studio-windows-update-smoke.yml
+++ b/.github/workflows/studio-windows-update-smoke.yml
@@ -63,8 +63,7 @@ jobs:
         with:
           persist-credentials: false
 
-      # This workflow triggers on uninstall.ps1, so run both uninstaller unit
-      # tests here. The guard test cannot perform a real uninstall.
+      # This workflow triggers on uninstall.ps1; neither test really uninstalls.
       - name: uninstall.ps1 unit tests (argument guard, dual-install icon preserve)
         shell: pwsh
         run: |
@@ -74,10 +73,9 @@ jobs:
           pwsh -NoProfile -File tests/studio/test_uninstall_dual_install_icon.ps1
           if ($LASTEXITCODE) { exit $LASTEXITCODE }
 
-      # The argument guard is self-hosting via (Get-Process -Id $PID).Path, so
-      # launching it from powershell.exe exercises Windows PowerShell 5.1, the
-      # shell the README one-liner lands in on a stock Windows box. Nothing else
-      # in CI runs 5.1, and its native-stderr handling differs from pwsh 7.
+      # The guard is self-hosting, so launching it from powershell.exe covers
+      # Windows PowerShell 5.1: the shell the README one-liner lands in, handled
+      # nowhere else in CI, and it differs from pwsh 7 on native stderr.
       - name: uninstall.ps1 argument guard under Windows PowerShell 5.1
         shell: powershell
         run: |

--- a/scripts/uninstall.ps1
+++ b/scripts/uninstall.ps1
@@ -1,10 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 #
-# Unsloth Studio uninstaller for Windows PowerShell. Run -Help for removal
-# details and options.
-# Custom roots set via UNSLOTH_STUDIO_HOME / STUDIO_HOME at install time are
-# read back from share\studio.conf.
+# Unsloth Studio uninstaller for Windows PowerShell. Run -Help for details.
+# Custom roots (UNSLOTH_STUDIO_HOME / STUDIO_HOME) come from share\studio.conf.
 #
 # Usage:  irm https://raw.githubusercontent.com/unslothai/unsloth/main/scripts/uninstall.ps1 | iex
 # Local:  Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass; .\scripts\uninstall.ps1

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -2,10 +2,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 #
-# Unsloth Studio uninstaller (macOS / Linux / WSL). Run --help for removal
-# details and options.
-# Custom roots set via UNSLOTH_STUDIO_HOME / STUDIO_HOME at install time are
-# read back from studio.conf.
+# Unsloth Studio uninstaller (macOS / Linux / WSL). Run --help for details.
+# Custom roots (UNSLOTH_STUDIO_HOME / STUDIO_HOME) come from studio.conf.
 #
 # Usage: curl -fsSL https://raw.githubusercontent.com/unslothai/unsloth/main/scripts/uninstall.sh | sh
 

--- a/tests/sh/test_uninstall_arg_guard.sh
+++ b/tests/sh/test_uninstall_arg_guard.sh
@@ -2,10 +2,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 #
-# Argument and pipe-safety tests for scripts/uninstall.sh.
-#
-# Behavioral cases use an instrumented copy that aborts before uninstalling.
-# The real no-argument case is skipped on WSL because it reaches host state.
+# Argument and pipe-safety tests for scripts/uninstall.sh. Behavioral cases use
+# an instrumented copy that aborts before uninstalling.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -54,7 +52,6 @@ assert_not_says() {
     esac
 }
 
-# Check the fixture as a unit.
 FIXTURE_PATHS=".unsloth/studio .unsloth/studio/auth/.desktop_secret .local/bin/unsloth .local/share/unsloth"
 
 # assert_fixture <label> <home> present|gone
@@ -70,13 +67,11 @@ assert_fixture() {
     if [ -z "$_missing" ]; then ok "$1"; else nope "$1 (wrong state:$_missing)"; fi
 }
 
-# Publish a validated fixture path. A global keeps setup failures from being
-# hidden by command-substitution errexit behavior.
+# A global, not command substitution: $() would swallow setup failures under -e.
 FIXTURE_HOME=""
 make_home() {
-    # Explicit template, not TMPDIR: BSD mktemp with no template implies -t and
-    # resolves the directory itself, so on macOS TMPDIR= lands a sibling of
-    # _TMP_ROOT and the check below aborts the suite.
+    # Explicit template: BSD mktemp with no template implies -t and picks its
+    # own directory, so TMPDIR= lands outside _TMP_ROOT on macOS.
     FIXTURE_HOME=$(mktemp -d "$_TMP_ROOT/home.XXXXXX") || FIXTURE_HOME=""
     case "$FIXTURE_HOME" in
         "$_TMP_ROOT"/*) ;;
@@ -170,8 +165,7 @@ fi
 
 echo "=== behaviour: a piped --help must not break the writer ==="
 
-# Shrink the pipe so an unread script tail produces a broken writer. Skip where
-# Linux F_SETPIPE_SZ is unavailable.
+# Shrink the pipe so an unread script tail produces a broken writer.
 if python3 -c 'import fcntl, sys; sys.exit(0 if sys.platform.startswith("linux") else 1)' 2>/dev/null; then
     make_home
     verdict=$(UNINSTALL_SH="$UNINSTALL_SH" FAKE_HOME="$FIXTURE_HOME" python3 - <<'PY'
@@ -209,7 +203,6 @@ PY
     case "$verdict" in
         skip:*|vacuous:*) echo "  SKIP: ${verdict#*: }" ;;
         *)
-            # Check both the writer and script exit codes.
             check "piped --help stays guarded" "ok:0:guarded" "$verdict"
             ;;
     esac

--- a/tests/studio/test_uninstall_arg_guard.ps1
+++ b/tests/studio/test_uninstall_arg_guard.ps1
@@ -1,10 +1,9 @@
 #!/usr/bin/env pwsh
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
-# Argument contract for scripts/uninstall.ps1.
-#
-# Tests run against a temporary copy that aborts before the first uninstall
-# action, so a broken guard cannot perform a real uninstall.
+# Argument contract for scripts/uninstall.ps1. Tests run against a temporary
+# copy that aborts before the first uninstall action, so a broken guard cannot
+# perform a real uninstall.
 #
 # Run: pwsh -NoProfile -File tests/studio/test_uninstall_arg_guard.ps1
 
@@ -41,18 +40,15 @@ function Check($name, $cond) {
     else { Write-Host "  FAIL  $name" -ForegroundColor Red; $script:failures++ }
 }
 
-# Capture a native command's merged output without letting its stderr abort us.
-# Windows PowerShell 5.1 raises a terminating NativeCommandError when a native
-# command writes to stderr under $ErrorActionPreference = "Stop"; PowerShell
-# 7.1+ does not. This suite is self-hosting via (Get-Process -Id $PID).Path, so
-# it can run under 5.1, where every rejected-argument case writes to stderr.
+# Windows PowerShell 5.1 turns a native command's stderr into a terminating
+# NativeCommandError under $ErrorActionPreference = "Stop"; 7.1+ does not. This
+# suite can run under 5.1, where every rejected-argument case writes to stderr.
 function Invoke-Native([scriptblock]$Command) {
     $prev = $ErrorActionPreference
     $ErrorActionPreference = "Continue"
     try { return (& $Command | Out-String) } finally { $ErrorActionPreference = $prev }
 }
 
-# Run the instrumented uninstaller in a child pwsh.
 function Invoke-Uninstaller([string[]]$ScriptArgs) {
     $argv = @("-NoProfile", "-File", $uninstallPath) + $ScriptArgs
     $out = Invoke-Native { & $pwshPath @argv 2>&1 }
@@ -60,7 +56,6 @@ function Invoke-Uninstaller([string[]]$ScriptArgs) {
 }
 
 try {
-    # Both the source and instrumented copy must parse.
     foreach ($parseCase in @(
         @{ Name = "source uninstall.ps1"; Path = $sourceUninstallPath },
         @{ Name = "instrumented uninstall.ps1"; Path = $uninstallPath }


### PR DESCRIPTION
Follow-up to #7631. Comments only, no behaviour change.

## Change

Shortens the header blocks in `scripts/uninstall.sh`, `scripts/uninstall.ps1` and the two test files, and drops five comments that restate the line below them, for example:

```diff
-# Check the fixture as a unit.
 FIXTURE_PATHS=".unsloth/studio .unsloth/studio/auth/.desktop_secret ..."
```

```diff
-            # Check both the writer and script exit codes.
             check "piped --help stays guarded" "ok:0:guarded" "$verdict"
```

Net 20 insertions, 38 deletions across 5 files.

## What is deliberately kept

Every comment that carries a reason the code cannot state itself:

- why the trailing `{ ... }` compound block makes a truncated `curl | sh` inert,
- why PowerShell `throw`s instead of exiting, so an `irm | iex` session survives,
- why the real uninstall body is skipped on WSL,
- why the pipe test guards against going vacuous,
- why the fixture path is published through a global rather than a command substitution,
- why the argument guard runs before any destructive work.

The `_usage` heredoc and the `_Usage` here-string are program output rather than commentary, so they are untouched.

## Verification

`comment_tools.py` only parses Python, TypeScript and JavaScript, so its AST gate reports "No target files" here and would pass vacuously on shell and PowerShell. It is not evidence for this diff, so the change was gated behaviourally instead.

**Code is byte-identical to main.** With comments and blank lines stripped, all five files diff clean against `main`. Of the 58 changed lines, 0 are non-comment.

**Behaviour is byte-identical to main.** `scripts/uninstall.sh` was run against `main` under 60 scenarios covering `[Linux, macOS, WSL] x [NVIDIA, AMD, CPU-only] x [dash, bash, bash --posix, busybox sh]`, plus root and non-root, the privilege-escalation helper present and absent, WSL interop on and off, `UNSLOTH_UNINSTALL_ROCM`, five install layouts including ones predating `share/studio.conf`, and the `UNSLOTH_STUDIO_HOME` / `STUDIO_HOME` precedence cases. Each scenario compared the surviving file tree, the ordered trace of external commands, normalized output, and the exit code: **60 identical, 0 differing**. `scripts/uninstall.ps1` was compared the same way on its operation trace across default, `UNSLOTH_STUDIO_HOME` and `STUDIO_HOME` modes. Both harnesses carry a negative control that fails when a removal is dropped, so a green result is meaningful.

**Suites:** `test_uninstall_arg_guard.sh` 25 passed, `test_uninstall_shared_icon.sh` 11 passed, `test_install_pipe_safety.sh` 7 passed, `test_uninstall_arg_guard.ps1` all checks passed, `test_uninstall_dual_install_icon.ps1` passed, `tests/studio/test_ci_shell_suite_coverage.py` 15 passed. `dash -n`, `bash -n`, `bash --posix -n`, `busybox sh -n` and `zsh -n` are clean on `uninstall.sh`, and the workflow YAML parses.

The full `Shell installer tests` step runs 26 files with one failure, `test_tauri_retry_failure_context.sh`, which fails identically on unmodified `main` and is fixed by #7645.
