### PR TITLE
Fix Studio training download readiness tracking

### DIFF
--- a/studio/backend/core/training/training.py
+++ b/studio/backend/core/training/training.py
@@ -819,6 +819,7 @@ class TrainingBackend:
         # Xet -> HTTP model-load fallback state (config kept for the respawn).
         self._last_full_config: Optional[dict] = None
         self._in_model_load: bool = False
+        self._model_download_repo_id: Optional[str] = None
         self._xet_fallback_used: bool = False
         self._needs_xet_respawn: bool = False
 
@@ -1008,6 +1009,7 @@ class TrainingBackend:
             self._last_full_config = config
             self._last_hf_cache_env = cache_env
             self._in_model_load = False
+            self._model_download_repo_id = None
             self._xet_fallback_used = False
             self._needs_xet_respawn = False
 
@@ -1782,10 +1784,15 @@ class TrainingBackend:
         if etype == "model_load_started":
             with self._lock:
                 self._in_model_load = True
+                repo_id = event.get("repo_id")
+                self._model_download_repo_id = (
+                    repo_id if isinstance(repo_id, str) and repo_id.strip() else None
+                )
             return
         if etype == "model_load_completed":
             with self._lock:
                 self._in_model_load = False
+                self._model_download_repo_id = None
             return
         if etype == "stall":
             self._handle_stall_event(event)

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -3126,14 +3126,6 @@ def run_training_process(*, event_queue: Any, stop_queue: Any, config: dict) -> 
         _send_status(event_queue, "Loading model...")
         from utils.hf_xet_fallback import start_watchdog
 
-        event_queue.put({"type": "model_load_started", "ts": time.time()})
-        _load_watchdog_stop = start_watchdog(
-            repo_ids = [model_name],
-            on_stall = lambda msg: event_queue.put(
-                {"type": "stall", "message": msg, "ts": time.time()}
-            ),
-            xet_disabled = os.environ.get("HF_HUB_DISABLE_XET") == "1",
-        )
         # Latest-sidecar models load 16-bit here too: bnb 4-bit feeds quantized
         # expert weights into unvalidated paths (same flip as the chat worker).
         _train_load_in_4bit = config["load_in_4bit"]
@@ -3147,7 +3139,81 @@ def run_training_process(*, event_queue: Any, stop_queue: Any, config: dict) -> 
                     model_name,
                 )
 
+        # Unsloth may transparently replace a requested base repo with its
+        # pre-quantized training repo. Tell the parent which HF cache is actually
+        # about to change so Studio does not keep polling the already-complete
+        # requested repo while the resolved weights download.
+        model_download_repo_id = model_name
+        if "/" in model_name and not os.path.exists(os.path.expanduser(model_name)):
+            try:
+                from unsloth.device_type import (
+                    ALLOW_BITSANDBYTES,
+                    ALLOW_PREQUANTIZED_MODELS,
+                )
+                from unsloth.models.loader import _strip_unsloth_bnb_4bit_suffix
+                from unsloth.models.loader_utils import (
+                    BAD_MAPPINGS,
+                    FLOAT_TO_INT_MAPPER,
+                    INT_TO_FLOAT_MAPPER,
+                    MAP_TO_UNSLOTH_16bit,
+                    get_model_name,
+                )
+
+                # Only call the installed mapper for known names. get_model_name
+                # probes GitHub when a name is unknown; the loader will do that
+                # itself, so probing here too would add a duplicate network wait.
+                model_key = model_name.lower()
+                known_to_installed_mapper = any(
+                    model_key in mapping
+                    for mapping in (
+                        FLOAT_TO_INT_MAPPER,
+                        INT_TO_FLOAT_MAPPER,
+                        MAP_TO_UNSLOTH_16bit,
+                        BAD_MAPPINGS,
+                    )
+                )
+                if known_to_installed_mapper:
+                    effective_load_in_4bit = (
+                        _train_load_in_4bit and ALLOW_BITSANDBYTES
+                    )
+                    model_download_repo_id = get_model_name(
+                        model_name,
+                        load_in_4bit = effective_load_in_4bit,
+                        token = hf_token,
+                        trust_remote_code = config.get("trust_remote_code", False),
+                    )
+                    if (
+                        not ALLOW_PREQUANTIZED_MODELS
+                        and model_download_repo_id.lower().endswith(
+                            ("-unsloth-bnb-4bit", "-bnb-4bit")
+                        )
+                    ):
+                        model_download_repo_id = _strip_unsloth_bnb_4bit_suffix(
+                            model_download_repo_id
+                        )
+            except Exception as exc:
+                logger.warning(
+                    "Could not resolve training download repo for %s: %s",
+                    model_name,
+                    exc,
+                )
+                model_download_repo_id = model_name
+
+        _load_watchdog_stop = start_watchdog(
+            repo_ids = [model_download_repo_id],
+            on_stall = lambda msg: event_queue.put(
+                {"type": "stall", "message": msg, "ts": time.time()}
+            ),
+            xet_disabled = os.environ.get("HF_HUB_DISABLE_XET") == "1",
+        )
         try:
+            event_queue.put(
+                {
+                    "type": "model_load_started",
+                    "repo_id": model_download_repo_id,
+                    "ts": time.time(),
+                }
+            )
             success = trainer.load_model(
                 model_name = model_name,
                 max_seq_length = config["max_seq_length"],

--- a/studio/backend/routes/training.py
+++ b/studio/backend/routes/training.py
@@ -633,6 +633,14 @@ async def get_training_status(current_subject: str = Depends(get_current_subject
             # Always present: an explicit null tells the client to drop a cached
             # path (stop without save clears the run's output_dir).
             details["output_dir"] = getattr(backend, "_output_dir", None) or None
+            # During model load this is the repo Unsloth resolved internally,
+            # which can differ from the model selected in Studio (for example a
+            # base repo resolving to an optimized -unsloth-bnb-4bit repo).
+            details["model_download_repo_id"] = (
+                getattr(backend, "_model_download_repo_id", None)
+                if getattr(backend, "_in_model_load", False)
+                else None
+            )
 
         # Metric history for chart recovery after SSE reconnection.
         metric_history = None

--- a/studio/backend/tests/test_training_xet_fallback.py
+++ b/studio/backend/tests/test_training_xet_fallback.py
@@ -43,6 +43,7 @@ _mpl.pyplot = _plt
 _stub("matplotlib", _mpl)
 _stub("matplotlib.pyplot", _plt)
 _hw = _types.ModuleType("utils.hardware")
+_hw.get_device = lambda: "cpu"
 _hw.prepare_gpu_selection = lambda *a, **k: (None, None)
 _stub("utils.hardware", _hw)
 _npl = _types.ModuleType("utils.native_path_leases")
@@ -187,8 +188,10 @@ def test_second_stall_surfaces_error_without_respawn():
 
 def test_model_load_completed_disarms_recovery():
     b, _ = _backend_mid_load()
+    b._model_download_repo_id = "unsloth/model-unsloth-bnb-4bit"
     b._handle_event({"type": "model_load_completed"})
     assert b._in_model_load is False
+    assert b._model_download_repo_id is None
     # A stall after the load finished is not a transport stall to recover from.
     b._handle_event({"type": "stall", "message": "post-load"})
     assert b._needs_xet_respawn is False
@@ -197,8 +200,23 @@ def test_model_load_completed_disarms_recovery():
 def test_model_load_started_arms_recovery_window():
     b = TrainingBackend()
     assert b._in_model_load is False
-    b._handle_event({"type": "model_load_started"})
+    b._handle_event(
+        {
+            "type": "model_load_started",
+            "repo_id": "unsloth/model-unsloth-bnb-4bit",
+        }
+    )
     assert b._in_model_load is True
+    assert b._model_download_repo_id == "unsloth/model-unsloth-bnb-4bit"
+
+
+def test_worker_reports_and_watches_the_resolved_download_repo():
+    worker_source = (
+        Path(__file__).resolve().parent.parent / "core" / "training" / "worker.py"
+    ).read_text(encoding = "utf-8")
+
+    assert '"repo_id": model_download_repo_id' in worker_source
+    assert "repo_ids = [model_download_repo_id]" in worker_source
 
 
 def test_child_should_disable_xet_truth_table():

--- a/studio/frontend/src/features/chat/api/chat-api.ts
+++ b/studio/frontend/src/features/chat/api/chat-api.ts
@@ -357,6 +357,8 @@ export interface DownloadProgressResponse {
   downloaded_bytes: number;
   expected_bytes: number;
   progress: number;
+  /** True only after the backend verifies the revision manifest on disk. */
+  complete_on_disk: boolean;
   /**
    * On-disk path of the snapshot dir (or cache repo root if no snapshot yet).
    * Null when nothing has been written to the cache for this repo.

--- a/studio/frontend/src/features/studio/training-download-progress.ts
+++ b/studio/frontend/src/features/studio/training-download-progress.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+type TrainingDownloadProgress = {
+  downloaded_bytes: number;
+  expected_bytes: number;
+  progress: number;
+  complete_on_disk: boolean;
+  cache_path: string | null;
+};
+
+export type TrainingDownloadState = {
+  downloadedBytes: number;
+  totalBytes: number;
+  percent: number;
+  completeOnDisk: boolean;
+  cachePath: string | null;
+};
+
+export const EMPTY_TRAINING_DOWNLOAD_STATE: TrainingDownloadState = {
+  downloadedBytes: 0,
+  totalBytes: 0,
+  percent: 0,
+  completeOnDisk: false,
+  cachePath: null,
+};
+
+export function toTrainingDownloadState(
+  progress: TrainingDownloadProgress,
+): TrainingDownloadState {
+  const downloadedBytes = Math.max(0, progress.downloaded_bytes ?? 0);
+  const totalBytes = Math.max(0, progress.expected_bytes ?? 0);
+  const ratio = Math.max(0, progress.progress ?? 0);
+  const completeOnDisk = progress.complete_on_disk === true;
+  const percent = completeOnDisk
+    ? 100
+    : totalBytes > 0
+      ? Math.min(99, Math.round(ratio * 100))
+      : 0;
+
+  return {
+    downloadedBytes,
+    totalBytes,
+    percent,
+    completeOnDisk,
+    cachePath: progress.cache_path ?? null,
+  };
+}

--- a/studio/frontend/src/features/studio/training-start-overlay.tsx
+++ b/studio/frontend/src/features/studio/training-start-overlay.tsx
@@ -31,6 +31,11 @@ import {
   useTrainingConfigStore,
   useTrainingRuntimeStore,
 } from "@/features/training";
+import {
+  EMPTY_TRAINING_DOWNLOAD_STATE,
+  toTrainingDownloadState,
+  type TrainingDownloadState,
+} from "./training-download-progress";
 import { Cancel01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useEffect, useState, type ReactElement } from "react";
@@ -57,50 +62,23 @@ function formatCachePath(path: string): string {
     .replace(/^[A-Za-z]:[/\\]Users[/\\][^/\\]+/, "~");
 }
 
-type DownloadState = {
-  downloadedBytes: number;
-  totalBytes: number;
-  percent: number;
-  cachePath: string | null;
-};
-
-const EMPTY_DOWNLOAD_STATE: DownloadState = {
-  downloadedBytes: 0,
-  totalBytes: 0,
-  percent: 0,
-  cachePath: null,
-};
-
-function coerceCachedStateReady(state: DownloadState): DownloadState {
-  if (!state.cachePath) return state;
-  if (state.downloadedBytes > 0 && state.percent < 100) return state;
-  const totalBytes =
-    state.totalBytes > 0 ? state.totalBytes : state.downloadedBytes;
-  if (totalBytes <= 0) {
-    return { ...state, percent: 100 };
-  }
-  return {
-    ...state,
-    downloadedBytes: totalBytes,
-    totalBytes,
-    percent: 100,
-  };
-}
-
 type Fetcher = (repoId: string) => Promise<DownloadProgressResponse>;
 
 /**
  * Polls a HF repo's download progress on a 1.5s tick. Serves both model weights
- * and dataset blobs by swapping the fetcher. Stops once `progress >= 1.0`; the
- * bar freezes at the final value rather than disappearing, matching chat flow.
+ * and dataset blobs by swapping the fetcher. Stops only after the backend's
+ * manifest-backed disk check verifies completion; byte totals and cache paths
+ * can look complete while a resolved model revision is still downloading.
  */
 function useHfDownloadProgress(
   repoId: string | null,
   fetcher: Fetcher,
-): DownloadState {
+): TrainingDownloadState {
   const phase = useTrainingRuntimeStore((s) => s.phase);
   const isStarting = useTrainingRuntimeStore((s) => s.isStarting);
-  const [state, setState] = useState<DownloadState>(EMPTY_DOWNLOAD_STATE);
+  const [state, setState] = useState<TrainingDownloadState>(
+    EMPTY_TRAINING_DOWNLOAD_STATE,
+  );
 
   const shouldPoll =
     isStarting ||
@@ -113,7 +91,7 @@ function useHfDownloadProgress(
 
   useEffect(() => {
     if (!repoId || !HF_REPO_REGEX.test(repoId) || !shouldPoll) {
-      setState(EMPTY_DOWNLOAD_STATE);
+      setState(EMPTY_TRAINING_DOWNLOAD_STATE);
       return;
     }
 
@@ -126,18 +104,9 @@ function useHfDownloadProgress(
       try {
         const prog = await fetcher(repoId);
         if (cancelled) return;
-        const downloaded = prog.downloaded_bytes ?? 0;
-        const total = prog.expected_bytes ?? 0;
-        const ratio = prog.progress ?? 0;
-        const pct =
-          total > 0 ? Math.min(100, Math.round(ratio * 100)) : 0;
-        setState({
-          downloadedBytes: downloaded,
-          totalBytes: total,
-          percent: pct,
-          cachePath: prog.cache_path ?? null,
-        });
-        if (ratio >= 1.0) {
+        const nextState = toTrainingDownloadState(prog);
+        setState(nextState);
+        if (prog.complete_on_disk === true) {
           finished = true;
           if (interval) {
             clearInterval(interval);
@@ -161,17 +130,21 @@ function useHfDownloadProgress(
   return state;
 }
 
-function useModelDownloadProgress(modelName: string | null): DownloadState {
+function useModelDownloadProgress(
+  modelName: string | null,
+): TrainingDownloadState {
   return useHfDownloadProgress(modelName, getDownloadProgress);
 }
 
-function useDatasetDownloadProgress(datasetName: string | null): DownloadState {
+function useDatasetDownloadProgress(
+  datasetName: string | null,
+): TrainingDownloadState {
   return useHfDownloadProgress(datasetName, getDatasetDownloadProgress);
 }
 
 type DownloadRowProps = {
   label: string;
-  state: DownloadState;
+  state: TrainingDownloadState;
 };
 
 function DownloadRow({ label, state }: DownloadRowProps): ReactElement | null {
@@ -181,13 +154,13 @@ function DownloadRow({ label, state }: DownloadRowProps): ReactElement | null {
   const stats = useTransferStats(state.downloadedBytes, state.totalBytes);
 
   if (state.downloadedBytes <= 0 && !state.cachePath) return null;
-  const isComplete = state.totalBytes > 0 && state.percent >= 100;
+  const isComplete = state.completeOnDisk;
   const statusLabel = isComplete
     ? t("studio.trainingStart.ready")
-    : state.totalBytes > 0
-      ? t("studio.trainingStart.downloading")
-      : state.downloadedBytes === 0
-        ? t("studio.trainingStart.preparing")
+    : state.downloadedBytes === 0
+      ? t("studio.trainingStart.preparing")
+      : state.totalBytes > 0
+        ? t("studio.trainingStart.downloading")
         : null;
   const showRate = stats.stable && !isComplete;
   const rateSuffix = showRate ? ` • ${formatRate(stats.rateBytesPerSecond)}` : "";
@@ -258,6 +231,9 @@ export function TrainingStartOverlay({
   const phase = useTrainingRuntimeStore((s) => s.phase);
   const jobId = useTrainingRuntimeStore((s) => s.jobId);
   const startModelName = useTrainingRuntimeStore((s) => s.startModelName);
+  const modelDownloadRepoId = useTrainingRuntimeStore(
+    (s) => s.modelDownloadRepoId,
+  );
   const startDatasetName = useTrainingRuntimeStore((s) => s.startDatasetName);
   const startFromResume = useTrainingRuntimeStore((s) => s.startFromResume);
   const configuredModel = useTrainingConfigStore((s) => s.selectedModel);
@@ -274,11 +250,13 @@ export function TrainingStartOverlay({
   const useConfiguredResources = !isStarting && !hasStartResources;
   const isDownloadPhase =
     phase === "downloading_model" || phase === "downloading_dataset";
-  const modelName = hasStartResources
-    ? startModelName
-    : useConfiguredResources
-      ? configuredModel
-      : null;
+  const modelName =
+    modelDownloadRepoId ??
+    (hasStartResources
+      ? startModelName
+      : useConfiguredResources
+        ? configuredModel
+        : null);
   const datasetName = hasStartResources
     ? startDatasetName
     : useConfiguredResources
@@ -288,14 +266,8 @@ export function TrainingStartOverlay({
     startFromResume && !isDownloadPhase && /^download/i.test(message)
       ? t("studio.trainingStart.resumingTraining")
       : message || t("studio.trainingStart.startingTraining");
-  const rawModelDownload = useModelDownloadProgress(modelName);
-  const rawDatasetDownload = useDatasetDownloadProgress(datasetName);
-  const modelDownload = isDownloadPhase
-    ? rawModelDownload
-    : coerceCachedStateReady(rawModelDownload);
-  const datasetDownload = isDownloadPhase
-    ? rawDatasetDownload
-    : coerceCachedStateReady(rawDatasetDownload);
+  const modelDownload = useModelDownloadProgress(modelName);
+  const datasetDownload = useDatasetDownloadProgress(datasetName);
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
   const [cancelRequested, setCancelRequested] = useState(false);
 

--- a/studio/frontend/src/features/training/stores/training-runtime-store.ts
+++ b/studio/frontend/src/features/training/stores/training-runtime-store.ts
@@ -23,6 +23,7 @@ const initialState: TrainingRuntimeState = {
   isStarting: false,
   startError: null,
   startModelName: null,
+  modelDownloadRepoId: null,
   startDatasetName: null,
   startProjectName: null,
   startFromResume: false,
@@ -153,6 +154,7 @@ export const useTrainingRuntimeStore = create<TrainingRuntimeStore>()((set) => (
       message,
       error: null,
       startError: null,
+      modelDownloadRepoId: null,
       phase: "configuring",
       isStarting: false,
       sseConnected: false,
@@ -227,6 +229,8 @@ export const useTrainingRuntimeStore = create<TrainingRuntimeStore>()((set) => (
           payload.details?.output_dir !== undefined
             ? payload.details.output_dir
             : state.outputDir,
+        modelDownloadRepoId:
+          payload.details?.model_download_repo_id ?? null,
         lossHistory: metricHistory.lossHistory ?? state.lossHistory,
         lrHistory: metricHistory.lrHistory ?? state.lrHistory,
         gradNormHistory: metricHistory.gradNormHistory ?? state.gradNormHistory,

--- a/studio/frontend/src/features/training/types/runtime.ts
+++ b/studio/frontend/src/features/training/types/runtime.ts
@@ -28,6 +28,8 @@ export interface TrainingStatusResponse {
     learning_rate?: number;
     // null = explicit clear (run stopped without saving); absent = unchanged.
     output_dir?: string | null;
+    // Resolved HF repo whose weights are changing during model load.
+    model_download_repo_id?: string | null;
   } | null;
   metric_history?: {
     steps?: number[];
@@ -83,6 +85,7 @@ export interface TrainingRuntimeState {
   isStarting: boolean;
   startError: string | null;
   startModelName: string | null;
+  modelDownloadRepoId: string | null;
   startDatasetName: string | null;
   startProjectName: string | null;
   startFromResume: boolean;

--- a/studio/frontend/tests/training-download-readiness.test.ts
+++ b/studio/frontend/tests/training-download-readiness.test.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { toTrainingDownloadState } from "../src/features/studio/training-download-progress.ts";
+
+const overlaySource = readFileSync(
+  new URL(
+    "../src/features/studio/training-start-overlay.tsx",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const chatApiSource = readFileSync(
+  new URL("../src/features/chat/api/chat-api.ts", import.meta.url),
+  "utf8",
+);
+const runtimeStoreSource = readFileSync(
+  new URL(
+    "../src/features/training/stores/training-runtime-store.ts",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+const TEN_GIB = Math.round(9.57 * 1024 ** 3);
+
+test("a cached path without disk verification stays in progress", () => {
+  const state = toTrainingDownloadState({
+    downloaded_bytes: 0,
+    expected_bytes: TEN_GIB,
+    progress: 0,
+    complete_on_disk: false,
+    cache_path: "~/.cache/huggingface/hub/models--unsloth--gemma-4-E2B-it",
+  });
+
+  assert.equal(state.downloadedBytes, 0);
+  assert.equal(state.totalBytes, TEN_GIB);
+  assert.equal(state.percent, 0);
+  assert.equal(state.completeOnDisk, false);
+});
+
+test("byte totals cannot round an unverified download up to ready", () => {
+  const state = toTrainingDownloadState({
+    downloaded_bytes: TEN_GIB,
+    expected_bytes: TEN_GIB,
+    progress: 1,
+    complete_on_disk: false,
+    cache_path: "~/.cache/huggingface/hub/models--unsloth--gemma-4-E2B-it",
+  });
+
+  assert.equal(state.percent, 99);
+  assert.equal(state.completeOnDisk, false);
+});
+
+test("manifest-backed disk completion is the only 100% state", () => {
+  const state = toTrainingDownloadState({
+    downloaded_bytes: TEN_GIB,
+    expected_bytes: TEN_GIB,
+    progress: 1,
+    complete_on_disk: true,
+    cache_path: "~/.cache/huggingface/hub/models--unsloth--gemma-4-E2B-it",
+  });
+
+  assert.equal(state.percent, 100);
+  assert.equal(state.completeOnDisk, true);
+});
+
+test("training progress never promotes a cache path to ready", () => {
+  assert.doesNotMatch(
+    overlaySource,
+    /coerceCachedStateReady/,
+    "a cache directory can exist while Hugging Face is still fetching the resolved model",
+  );
+});
+
+test("training readiness follows manifest-backed disk completion", () => {
+  assert.match(
+    chatApiSource,
+    /complete_on_disk:\s*boolean/,
+    "the training progress API type must expose backend disk verification",
+  );
+  assert.match(
+    overlaySource,
+    /prog\.complete_on_disk\s*===\s*true/,
+    "the overlay must consume manifest-backed completion",
+  );
+  assert.match(
+    overlaySource,
+    /completeOnDisk/,
+    "the rendered state must retain disk completion separately from rounded percentage",
+  );
+});
+
+test("training polls the model repo resolved by the worker", () => {
+  assert.match(
+    runtimeStoreSource,
+    /payload\.details\?\.model_download_repo_id/,
+    "the runtime store must retain the worker's resolved download repo",
+  );
+  assert.match(
+    overlaySource,
+    /modelDownloadRepoId\s*\?\?/,
+    "the overlay must prefer the resolved repo over the configured repo",
+  );
+});


### PR DESCRIPTION
## Summary

- report the Hugging Face repository that Unsloth actually resolves for a training model load
- poll that resolved repository in the Studio training-start overlay instead of the already-cached configured repository
- only render `Ready` / 100% after the backend's `complete_on_disk` signal, removing the cache-path coercion that could fabricate completion
- make the Xet stall watchdog follow the same resolved repository

## Reproduction / A-B

**A — current `main`**

Starting vision training with `unsloth/gemma-4-E2B-it` can resolve internally to `unsloth/gemma-4-e2b-it-unsloth-bnb-4bit`. The overlay continues polling the configured repository. Because that repository is already cached, `coerceCachedStateReady` displays `9.57 GB / 9.57 GB`, `Ready`, and `100%` while the worker is still fetching three files for the resolved repository. The focused regression test fails on unchanged `main`.

**B — this branch**

The worker includes the resolved repository in `model_load_started`; the parent exposes it through training status; and the frontend switches its progress polling target to that repository. Unverified byte totals are capped at 99%, and a cache path alone can no longer promote the row to `Ready`.

## Validation

- `python -m pytest studio/backend/tests/test_training_xet_fallback.py -q` — 7 passed
- `python -m ruff check` on changed backend files — passed
- `npm test` — 76 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- Python compilation of changed backend modules — passed
