### PR TITLE
Studio: route first-chat model downloads through Downloads

### DIFF
--- a/studio/backend/hub/schemas/downloads.py
+++ b/studio/backend/hub/schemas/downloads.py
@@ -61,6 +61,10 @@ class DownloadStartResponse(BaseModel):
     state: str
     accepted: bool
     generation: int
+    created: bool = Field(
+        ...,
+        description = "True only when this request claimed and launched a new download job.",
+    )
 
 
 class CancelDownloadResponse(BaseModel):

--- a/studio/backend/hub/services/models/downloads.py
+++ b/studio/backend/hub/services/models/downloads.py
@@ -207,6 +207,7 @@ async def download_model_response(
             "state": claim_state,
             "accepted": _registry.adoptable(key),
             "generation": generation,
+            "created": False,
         }
     download_manifest.clear_cancel_marker(
         "model",
@@ -246,6 +247,7 @@ async def download_model_response(
         "state": state,
         "accepted": True,
         "generation": generation,
+        "created": True,
     }
 
 

--- a/studio/backend/hub/tests/test_model_services.py
+++ b/studio/backend/hub/tests/test_model_services.py
@@ -3334,7 +3334,42 @@ def test_model_claim_register_cancel_uses_registry_marker_owner(monkeypatch):
     )
 
     assert result["state"] == "cancelled"
+    assert result["created"] is True
     assert killed
+
+
+def test_model_download_response_marks_an_adopted_job_as_not_created(monkeypatch):
+    class _Registry:
+        def claim(self, *_args, **_kwargs):
+            return False, "running"
+
+        def current_generation(self, _key):
+            return 7
+
+        def adoptable(self, _key):
+            return True
+
+    monkeypatch.setattr(downloads, "_registry", _Registry())
+    monkeypatch.setattr(
+        downloads,
+        "resolve_cached_repo_id_case",
+        lambda repo_id, **_kwargs: repo_id,
+    )
+    monkeypatch.setattr(downloads, "_load_in_flight", lambda _repo_id: False)
+
+    result = asyncio.run(
+        downloads.download_model_response(
+            SimpleNamespace(repo_id = "Org/Model", gguf_variant = None, use_xet = False)
+        )
+    )
+
+    assert result == {
+        "job_key": downloads._download_job_key("Org/Model", None),
+        "state": "running",
+        "accepted": True,
+        "generation": 7,
+        "created": False,
+    }
 
 
 def test_model_cancel_registered_worker_requests_and_kills(monkeypatch):

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -2027,6 +2027,20 @@ async function autoLoadSmallestModel(abortSignal: AbortSignal): Promise<{
       }
 
       abortSignal.throwIfAborted();
+      const runtimeAfterDownload = useChatRuntimeStore.getState();
+      if (
+        runtimeAfterDownload.params.checkpoint ||
+        runtimeAfterDownload.modelLoading
+      ) {
+        toast.dismiss(toastId);
+        if (runtimeAfterDownload.modelLoading) {
+          await waitForModelReady(abortSignal);
+        }
+        return {
+          loaded: Boolean(useChatRuntimeStore.getState().params.checkpoint),
+          blockedByTrustRemoteCode: false,
+        };
+      }
       updateAutoLoadToast(
         "Starting model…",
         "Download complete. Loading Qwen3.5-4B-MTP into memory.",

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -87,6 +87,7 @@ import {
 } from "../utils/last-local-model-load";
 import { getImageInputUnavailableReason } from "../utils/image-input-support";
 import { downloadModelWithManager } from "./managed-model-download-bridge";
+import { createSingleFlight } from "./single-flight";
 import {
   extractDeltaText,
   hasUnclosedThinkTag,
@@ -1385,6 +1386,11 @@ function waitForModelReady(abortSignal?: AbortSignal): Promise<void> {
 const MAX_AUTO_LOAD_ATTEMPTS = 3;
 const DEFAULT_AUTO_LOAD_MODEL_ID = "unsloth/Qwen3.5-4B-MTP-GGUF";
 const DEFAULT_AUTO_LOAD_GGUF_VARIANT = "UD-Q4_K_XL";
+type DefaultAutoLoadOutcome = {
+  loaded: boolean;
+  loadedDefault: boolean;
+};
+const defaultAutoLoadFlight = createSingleFlight<DefaultAutoLoadOutcome>();
 const BIG_ENDIAN_GGUF_FILENAME_RE = /(^|[-_])be(?:[._-]|$)/gi;
 const GGUF_KNOWN_QUANT_RE =
   /(UD-)?(MXFP[0-9]+(?:_[A-Z0-9]+)*|IQ[0-9]+_[A-Z]+(?:_[A-Z0-9]+)?|TQ[0-9]+_[0-9]+|Q[0-9]+_K_[A-Z]+|Q[0-9]+_[0-9]+|Q[0-9]+_K|BF16|F16|F32)/i;
@@ -2146,98 +2152,133 @@ async function autoLoadSmallestModel(abortSignal: AbortSignal): Promise<{
         return { loaded: false, blockedByTrustRemoteCode };
       }
 
-      updateAutoLoadToast(
-        "Starting model…",
-        "Download complete. Loading Qwen3.5-4B-MTP into memory.",
+      abortSignal.throwIfAborted();
+      const defaultLoadOutcome = await defaultAutoLoadFlight.run(
+        abortSignal,
+        async () => {
+          const runtimeBeforeDefaultLoad = useChatRuntimeStore.getState();
+          if (
+            runtimeBeforeDefaultLoad.params.checkpoint ||
+            runtimeBeforeDefaultLoad.modelLoading
+          ) {
+            if (runtimeBeforeDefaultLoad.modelLoading) {
+              await waitForModelReady();
+            }
+            return {
+              loaded: Boolean(
+                useChatRuntimeStore.getState().params.checkpoint,
+              ),
+              loadedDefault: false,
+            };
+          }
+
+          runtimeBeforeDefaultLoad.setModelLoading(true);
+          try {
+            updateAutoLoadToast(
+              "Starting model…",
+              "Download complete. Loading Qwen3.5-4B-MTP into memory.",
+            );
+            loadAttempts += 1;
+            const loadResp = await loadModel({
+              model_path: DEFAULT_AUTO_LOAD_MODEL_ID,
+              hf_token: defaultHfToken,
+              // Model default under both modes: Auto layers + no pin means
+              // resolveFitMaxSeqLength returns 0 for every mode (the canAutoLoad
+              // preflight above sends the same).
+              max_seq_length: 0,
+              load_in_4bit: true,
+              is_lora: false,
+              gguf_variant: DEFAULT_AUTO_LOAD_GGUF_VARIANT,
+              trust_remote_code: defaultTrustRemoteCode,
+              speculative_type: defaultSpecSettings.speculativeType,
+              spec_draft_n_max: defaultSpecSettings.specDraftNMax,
+              // GPU Memory mode is a standing preference, so honor it on auto-load.
+              // The layer/MoE/split knobs and the context pin are per-model: the live
+              // store may hold edits drafted for a staged pick, and a fresh default
+              // model has no remembered settings, so those stay at their defaults like
+              // the cached-candidate path. The GPU pick deliberately differs (it's the
+              // picker's current on-screen selection, which the canAutoLoad preflight
+              // above already committed to).
+              gpu_memory_mode: defaultGpuMemoryMode,
+              gpu_layers: GPU_LAYERS_AUTO,
+              n_cpu_moe: 0,
+              gpu_ids: defaultGpuIds ?? undefined,
+            });
+            saveSpeculativeType(defaultSpecSettings.speculativeType);
+            persistGpuMemoryModeOnLoad(loadResp, defaultGpuMemoryMode);
+            useChatRuntimeStore
+              .getState()
+              .setCheckpoint(
+                DEFAULT_AUTO_LOAD_MODEL_ID,
+                DEFAULT_AUTO_LOAD_GGUF_VARIANT,
+              );
+            const store = useChatRuntimeStore.getState();
+            store.setModelRequiresTrustRemoteCode(
+              loadResp.requires_trust_remote_code ?? false,
+            );
+            store.setParams({
+              ...store.params,
+              maxTokens: loadResp.context_length ?? 131072,
+            });
+            const defaultModel: ChatModelSummary = {
+              id: DEFAULT_AUTO_LOAD_MODEL_ID,
+              name: loadResp.display_name ?? "Qwen3.5-4B-MTP-GGUF",
+              isVision: loadResp.is_vision ?? false,
+              isLora: false,
+              isGguf: true,
+            };
+            if (!store.models.some((m) => m.id === DEFAULT_AUTO_LOAD_MODEL_ID)) {
+              store.setModels([...store.models, defaultModel]);
+            }
+            useChatRuntimeStore.setState({
+              ggufContextLength: loadResp.context_length ?? 131072,
+              ggufMaxContextLength:
+                loadResp.max_context_length ?? loadResp.context_length ?? 131072,
+              supportsReasoning: loadResp.supports_reasoning ?? false,
+              reasoningAlwaysOn: loadResp.reasoning_always_on ?? false,
+              reasoningEnabled: loadResp.supports_reasoning ?? false,
+              ...reasoningCapsFromLoad(loadResp),
+              supportsPreserveThinking: loadResp.supports_preserve_thinking ?? false,
+              supportsTools: loadResp.supports_tools ?? false,
+              ...resolveToolsEnabledOnLoad(loadResp.supports_tools ?? false),
+              kvCacheDtype: loadResp.cache_type_kv ?? null,
+              loadedKvCacheDtype: loadResp.cache_type_kv ?? null,
+              // The request above omits n_parallel: a staged override left from a
+              // preset would read as applied and be re-sent by the next Apply.
+              nParallel: null,
+              loadedNParallel: null,
+              tensorParallel: loadResp.tensor_parallel ?? false,
+              loadedTensorParallel: loadResp.tensor_parallel ?? false,
+              ...loadedGpuMemoryFields(loadResp),
+              // Drives the GPU Memory controls' diffusion gate; set alongside the
+              // GPU fields on every load path so the gate can't read stale.
+              loadedIsDiffusion: loadResp.is_diffusion ?? false,
+              defaultChatTemplate: loadResp.chat_template ?? null,
+              chatTemplateOverride: null,
+              loadedIsMultimodal: isMultimodalResponse(loadResp),
+              activeModelIsLocal: loadResp.is_local_model ?? false,
+              ...resolveLoadedSpeculativeSettings(loadResp),
+            });
+            recordLastLocalModelLoad({
+              id: DEFAULT_AUTO_LOAD_MODEL_ID,
+              kind: "gguf",
+              ggufVariant: DEFAULT_AUTO_LOAD_GGUF_VARIANT,
+            });
+            return { loaded: true, loadedDefault: true };
+          } finally {
+            useChatRuntimeStore.getState().setModelLoading(false);
+          }
+        },
       );
-      loadAttempts += 1;
-      const loadResp = await loadModel({
-        model_path: DEFAULT_AUTO_LOAD_MODEL_ID,
-        hf_token: defaultHfToken,
-        // Model default under both modes: Auto layers + no pin means
-        // resolveFitMaxSeqLength returns 0 for every mode (the canAutoLoad
-        // preflight above sends the same).
-        max_seq_length: 0,
-        load_in_4bit: true,
-        is_lora: false,
-        gguf_variant: DEFAULT_AUTO_LOAD_GGUF_VARIANT,
-        trust_remote_code: defaultTrustRemoteCode,
-        speculative_type: defaultSpecSettings.speculativeType,
-        spec_draft_n_max: defaultSpecSettings.specDraftNMax,
-        // GPU Memory mode is a standing preference, so honor it on auto-load.
-        // The layer/MoE/split knobs and the context pin are per-model: the live
-        // store may hold edits drafted for a staged pick, and a fresh default
-        // model has no remembered settings, so those stay at their defaults like
-        // the cached-candidate path. The GPU pick deliberately differs (it's the
-        // picker's current on-screen selection, which the canAutoLoad preflight
-        // above already committed to).
-        gpu_memory_mode: defaultGpuMemoryMode,
-        gpu_layers: GPU_LAYERS_AUTO,
-        n_cpu_moe: 0,
-        gpu_ids: defaultGpuIds ?? undefined,
-      });
-      saveSpeculativeType(defaultSpecSettings.speculativeType);
-      persistGpuMemoryModeOnLoad(loadResp, defaultGpuMemoryMode);
-      useChatRuntimeStore
-        .getState()
-        .setCheckpoint(
-          DEFAULT_AUTO_LOAD_MODEL_ID,
-          DEFAULT_AUTO_LOAD_GGUF_VARIANT,
-        );
-      const store = useChatRuntimeStore.getState();
-      store.setModelRequiresTrustRemoteCode(
-        loadResp.requires_trust_remote_code ?? false,
-      );
-      store.setParams({
-        ...store.params,
-        maxTokens: loadResp.context_length ?? 131072,
-      });
-      const defaultModel: ChatModelSummary = {
-        id: DEFAULT_AUTO_LOAD_MODEL_ID,
-        name: loadResp.display_name ?? "Qwen3.5-4B-MTP-GGUF",
-        isVision: loadResp.is_vision ?? false,
-        isLora: false,
-        isGguf: true,
-      };
-      if (!store.models.some((m) => m.id === DEFAULT_AUTO_LOAD_MODEL_ID)) {
-        store.setModels([...store.models, defaultModel]);
+      if (defaultLoadOutcome.loadedDefault) {
+        showAutoLoadSuccess("Loaded Qwen3.5-4B-MTP (UD-Q4_K_XL)");
+      } else {
+        toast.dismiss(toastId);
       }
-      useChatRuntimeStore.setState({
-        ggufContextLength: loadResp.context_length ?? 131072,
-        ggufMaxContextLength:
-          loadResp.max_context_length ?? loadResp.context_length ?? 131072,
-        supportsReasoning: loadResp.supports_reasoning ?? false,
-        reasoningAlwaysOn: loadResp.reasoning_always_on ?? false,
-        reasoningEnabled: loadResp.supports_reasoning ?? false,
-        ...reasoningCapsFromLoad(loadResp),
-        supportsPreserveThinking: loadResp.supports_preserve_thinking ?? false,
-        supportsTools: loadResp.supports_tools ?? false,
-        ...resolveToolsEnabledOnLoad(loadResp.supports_tools ?? false),
-        kvCacheDtype: loadResp.cache_type_kv ?? null,
-        loadedKvCacheDtype: loadResp.cache_type_kv ?? null,
-        // The request above omits n_parallel: a staged override left from a
-        // preset would read as applied and be re-sent by the next Apply.
-        nParallel: null,
-        loadedNParallel: null,
-        tensorParallel: loadResp.tensor_parallel ?? false,
-        loadedTensorParallel: loadResp.tensor_parallel ?? false,
-        ...loadedGpuMemoryFields(loadResp),
-        // Drives the GPU Memory controls' diffusion gate; set alongside the
-        // GPU fields on every load path so the gate can't read stale.
-        loadedIsDiffusion: loadResp.is_diffusion ?? false,
-        defaultChatTemplate: loadResp.chat_template ?? null,
-        chatTemplateOverride: null,
-        loadedIsMultimodal: isMultimodalResponse(loadResp),
-        activeModelIsLocal: loadResp.is_local_model ?? false,
-        ...resolveLoadedSpeculativeSettings(loadResp),
-      });
-      recordLastLocalModelLoad({
-        id: DEFAULT_AUTO_LOAD_MODEL_ID,
-        kind: "gguf",
-        ggufVariant: DEFAULT_AUTO_LOAD_GGUF_VARIANT,
-      });
-      showAutoLoadSuccess("Loaded Qwen3.5-4B-MTP (UD-Q4_K_XL)");
-      return { loaded: true, blockedByTrustRemoteCode: false };
+      return {
+        loaded: defaultLoadOutcome.loaded,
+        blockedByTrustRemoteCode: false,
+      };
     } catch (error) {
       toast.dismiss(toastId);
       if (abortSignal.aborted) throw error;

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -86,6 +86,7 @@ import {
   type LastLocalModelKind,
 } from "../utils/last-local-model-load";
 import { getImageInputUnavailableReason } from "../utils/image-input-support";
+import { downloadModelWithManager } from "./managed-model-download-bridge";
 import {
   extractDeltaText,
   hasUnclosedThinkTag,
@@ -1382,6 +1383,8 @@ function waitForModelReady(abortSignal?: AbortSignal): Promise<void> {
  */
 // Cap cascade so broken cached repos can't spam /api/inference/load.
 const MAX_AUTO_LOAD_ATTEMPTS = 3;
+const DEFAULT_AUTO_LOAD_MODEL_ID = "unsloth/Qwen3.5-4B-MTP-GGUF";
+const DEFAULT_AUTO_LOAD_GGUF_VARIANT = "UD-Q4_K_XL";
 const BIG_ENDIAN_GGUF_FILENAME_RE = /(^|[-_])be(?:[._-]|$)/gi;
 const GGUF_KNOWN_QUANT_RE =
   /(UD-)?(MXFP[0-9]+(?:_[A-Z0-9]+)*|IQ[0-9]+_[A-Z]+(?:_[A-Z0-9]+)?|TQ[0-9]+_[0-9]+|Q[0-9]+_K_[A-Z]+|Q[0-9]+_[0-9]+|Q[0-9]+_K|BF16|F16|F32)/i;
@@ -1447,10 +1450,11 @@ function isAutoLoadableGgufVariant(variant: GgufVariantDetail | null): boolean {
   return !hasBigEndianGgufMarker(filename, variant.quant);
 }
 
-async function autoLoadSmallestModel(): Promise<{
+async function autoLoadSmallestModel(abortSignal: AbortSignal): Promise<{
   loaded: boolean;
   blockedByTrustRemoteCode: boolean;
 }> {
+  abortSignal.throwIfAborted();
   if (await tryAdoptServerActiveModel()) {
     return { loaded: true, blockedByTrustRemoteCode: false };
   }
@@ -1965,10 +1969,13 @@ async function autoLoadSmallestModel(): Promise<{
       };
     }
 
-    // No cached models — try downloading a small default GGUF.
+    // No cached models: download the default through the global manager first.
+    // Keeping transfer and inference load as separate phases makes the download
+    // visible/cancellable and prevents /api/inference/load from owning a hidden
+    // multi-gigabyte fetch.
     updateAutoLoadToast(
       "Downloading a small model…",
-      "No downloaded models found. Fetching Qwen3.5-4B-MTP (UD-Q4_K_XL).",
+      "Fetching Qwen3.5-4B-MTP (UD-Q4_K_XL). Track or cancel it in Downloads.",
     );
     try {
       const rt = useChatRuntimeStore.getState();
@@ -1981,10 +1988,10 @@ async function autoLoadSmallestModel(): Promise<{
       );
       if (
         !(await canAutoLoad({
-          model_path: "unsloth/Qwen3.5-4B-MTP-GGUF",
+          model_path: DEFAULT_AUTO_LOAD_MODEL_ID,
           max_seq_length: 0,
           is_lora: false,
-          gguf_variant: "UD-Q4_K_XL",
+          gguf_variant: DEFAULT_AUTO_LOAD_GGUF_VARIANT,
           // The same live-store GPU pick the load below sends (a fresh default
           // model has no remembered settings to prefer).
           gpu_ids: defaultGpuIds ?? undefined,
@@ -1994,9 +2001,39 @@ async function autoLoadSmallestModel(): Promise<{
         toast.dismiss(toastId);
         return { loaded: false, blockedByTrustRemoteCode };
       }
+
+      const downloadResult = await downloadModelWithManager(
+        {
+          repoId: DEFAULT_AUTO_LOAD_MODEL_ID,
+          variant: DEFAULT_AUTO_LOAD_GGUF_VARIANT,
+          expectedBytes: 0,
+        },
+        abortSignal,
+      );
+      if (downloadResult !== "complete") {
+        toast.dismiss(toastId);
+        if (downloadResult === "conflict") {
+          toast.info("Resume this download from Models", {
+            description:
+              "An earlier partial download used a different transport. Open the Model hub tab to resume or restart it.",
+          });
+        } else if (downloadResult === "busy") {
+          toast.info("Another model download is already in progress", {
+            description: "Wait for it to finish, then retry your message.",
+          });
+        }
+        hadNonTrustFailure = true;
+        return { loaded: false, blockedByTrustRemoteCode: false };
+      }
+
+      abortSignal.throwIfAborted();
+      updateAutoLoadToast(
+        "Starting model…",
+        "Download complete. Loading Qwen3.5-4B-MTP into memory.",
+      );
       loadAttempts += 1;
       const loadResp = await loadModel({
-        model_path: "unsloth/Qwen3.5-4B-MTP-GGUF",
+        model_path: DEFAULT_AUTO_LOAD_MODEL_ID,
         hf_token: hfToken,
         // Model default under both modes: Auto layers + no pin means
         // resolveFitMaxSeqLength returns 0 for every mode (the canAutoLoad
@@ -2004,7 +2041,7 @@ async function autoLoadSmallestModel(): Promise<{
         max_seq_length: 0,
         load_in_4bit: true,
         is_lora: false,
-        gguf_variant: "UD-Q4_K_XL",
+        gguf_variant: DEFAULT_AUTO_LOAD_GGUF_VARIANT,
         trust_remote_code: trustRemoteCode,
         speculative_type: specSettings.speculativeType,
         spec_draft_n_max: specSettings.specDraftNMax,
@@ -2024,7 +2061,10 @@ async function autoLoadSmallestModel(): Promise<{
       persistGpuMemoryModeOnLoad(loadResp, rt.gpuMemoryMode);
       useChatRuntimeStore
         .getState()
-        .setCheckpoint("unsloth/Qwen3.5-4B-MTP-GGUF", "UD-Q4_K_XL");
+        .setCheckpoint(
+          DEFAULT_AUTO_LOAD_MODEL_ID,
+          DEFAULT_AUTO_LOAD_GGUF_VARIANT,
+        );
       const store = useChatRuntimeStore.getState();
       store.setModelRequiresTrustRemoteCode(
         loadResp.requires_trust_remote_code ?? false,
@@ -2034,13 +2074,13 @@ async function autoLoadSmallestModel(): Promise<{
         maxTokens: loadResp.context_length ?? 131072,
       });
       const defaultModel: ChatModelSummary = {
-        id: "unsloth/Qwen3.5-4B-MTP-GGUF",
+        id: DEFAULT_AUTO_LOAD_MODEL_ID,
         name: loadResp.display_name ?? "Qwen3.5-4B-MTP-GGUF",
         isVision: loadResp.is_vision ?? false,
         isLora: false,
         isGguf: true,
       };
-      if (!store.models.some((m) => m.id === "unsloth/Qwen3.5-4B-MTP-GGUF")) {
+      if (!store.models.some((m) => m.id === DEFAULT_AUTO_LOAD_MODEL_ID)) {
         store.setModels([...store.models, defaultModel]);
       }
       useChatRuntimeStore.setState({
@@ -2073,14 +2113,15 @@ async function autoLoadSmallestModel(): Promise<{
         ...resolveLoadedSpeculativeSettings(loadResp),
       });
       recordLastLocalModelLoad({
-        id: "unsloth/Qwen3.5-4B-MTP-GGUF",
+        id: DEFAULT_AUTO_LOAD_MODEL_ID,
         kind: "gguf",
-        ggufVariant: "UD-Q4_K_XL",
+        ggufVariant: DEFAULT_AUTO_LOAD_GGUF_VARIANT,
       });
       showAutoLoadSuccess("Loaded Qwen3.5-4B-MTP (UD-Q4_K_XL)");
       return { loaded: true, blockedByTrustRemoteCode: false };
-    } catch {
+    } catch (error) {
       toast.dismiss(toastId);
+      if (abortSignal.aborted) throw error;
       hadNonTrustFailure = true;
       return {
         loaded: false,
@@ -2088,8 +2129,9 @@ async function autoLoadSmallestModel(): Promise<{
           blockedByTrustRemoteCode && !hadNonTrustFailure,
       };
     }
-  } catch {
+  } catch (error) {
     toast.dismiss(toastId);
+    if (abortSignal.aborted) throw error;
     hadNonTrustFailure = true;
     return {
       loaded: false,
@@ -2133,7 +2175,7 @@ export function createOpenAIStreamAdapter(
         }
         if (!useChatRuntimeStore.getState().params.checkpoint) {
           const { loaded, blockedByTrustRemoteCode } =
-            await autoLoadSmallestModel();
+            await autoLoadSmallestModel(abortSignal);
           if (!loaded) {
             toast.error(
               blockedByTrustRemoteCode
@@ -2426,7 +2468,7 @@ export function createOpenAIStreamAdapter(
         let blockedByTrustRemoteCode: boolean;
         try {
           ({ loaded, blockedByTrustRemoteCode } =
-            await autoLoadSmallestModel());
+            await autoLoadSmallestModel(abortSignal));
         } catch (error) {
           clearSelectedImageEditReference();
           throw error;

--- a/studio/frontend/src/features/chat/api/chat-adapter.ts
+++ b/studio/frontend/src/features/chat/api/chat-adapter.ts
@@ -1501,26 +1501,29 @@ async function autoLoadSmallestModel(abortSignal: AbortSignal): Promise<{
   let loadAttempts = 0;
   const skippedAutoLoadCandidates = new Set<string>();
 
-  async function canAutoLoad(payload: {
-    model_path: string;
-    max_seq_length: number;
-    is_lora: boolean;
-    gguf_variant?: string | null;
-    // GGUF-only: scopes the training guard to the same placement policy /load
-    // will use. Manual mode must match because it makes placement user-owned.
-    // The layer/MoE/split/KV/spec knobs are deliberately not sent: Auto mode's
-    // guard sizes conservatively, while Manual mode bypasses that estimate.
-    // The safetensors fallback omits both fields and uses HF auto-placement.
-    gpu_ids?: number[];
-    gpu_memory_mode?: "auto" | "manual";
-    cache_type_kv?: string | null;
-    tensor_parallel?: boolean | null;
-  }): Promise<boolean> {
+  async function canAutoLoad(
+    payload: {
+      model_path: string;
+      max_seq_length: number;
+      is_lora: boolean;
+      gguf_variant?: string | null;
+      // GGUF-only: scopes the training guard to the same placement policy /load
+      // will use. Manual mode must match because it makes placement user-owned.
+      // The layer/MoE/split/KV/spec knobs are deliberately not sent: Auto mode's
+      // guard sizes conservatively, while Manual mode bypasses that estimate.
+      // The safetensors fallback omits both fields and uses HF auto-placement.
+      gpu_ids?: number[];
+      gpu_memory_mode?: "auto" | "manual";
+      cache_type_kv?: string | null;
+      tensor_parallel?: boolean | null;
+    },
+    auth = { hfToken, trustRemoteCode },
+  ): Promise<boolean> {
     const validation = await validateModel({
       ...payload,
-      hf_token: hfToken,
+      hf_token: auth.hfToken,
       load_in_4bit: true,
-      trust_remote_code: trustRemoteCode,
+      trust_remote_code: auth.trustRemoteCode,
     });
     // Background auto-load never runs a repo's custom code or loads Hub-flagged unsafe
     // files on its own; both are deferred to the explicit consent dialog instead.
@@ -1982,7 +1985,7 @@ async function autoLoadSmallestModel(abortSignal: AbortSignal): Promise<{
       if (rt.selectedGpuIds != null) {
         await ensureGpuDeviceCache();
       }
-      const defaultGpuIds = reconcilePersistedGpuIds(
+      const preflightGpuIds = reconcilePersistedGpuIds(
         rt.selectedGpuIds,
         rt.selectedGpuIndexKind,
       );
@@ -1994,7 +1997,7 @@ async function autoLoadSmallestModel(abortSignal: AbortSignal): Promise<{
           gguf_variant: DEFAULT_AUTO_LOAD_GGUF_VARIANT,
           // The same live-store GPU pick the load below sends (a fresh default
           // model has no remembered settings to prefer).
-          gpu_ids: defaultGpuIds ?? undefined,
+          gpu_ids: preflightGpuIds ?? undefined,
           gpu_memory_mode: rt.gpuMemoryMode,
         }))
       ) {
@@ -2041,6 +2044,108 @@ async function autoLoadSmallestModel(abortSignal: AbortSignal): Promise<{
           blockedByTrustRemoteCode: false,
         };
       }
+      let defaultGpuIds: number[] | null = null;
+      let defaultGpuMemoryMode = useChatRuntimeStore.getState().gpuMemoryMode;
+      let defaultHfToken: string | null = null;
+      let defaultTrustRemoteCode = false;
+      let defaultSpecSettings = resolveSpeculativeSettingsForLoad();
+      let placementStable = false;
+      const sameGpuIds = (
+        left: number[] | null,
+        right: number[] | null,
+      ): boolean =>
+        left === right ||
+        (left != null &&
+          right != null &&
+          left.length === right.length &&
+          left.every((value, index) => value === right[index]));
+
+      // Validation is asynchronous and the picker remains editable while the
+      // transfer runs. Only load from a snapshot that is still current after
+      // validation, otherwise retry with the latest placement and credentials.
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        let current = useChatRuntimeStore.getState();
+        if (current.selectedGpuIds != null) {
+          await ensureGpuDeviceCache();
+          current = useChatRuntimeStore.getState();
+        }
+        if (current.params.checkpoint || current.modelLoading) {
+          toast.dismiss(toastId);
+          if (current.modelLoading) {
+            await waitForModelReady(abortSignal);
+          }
+          return {
+            loaded: Boolean(useChatRuntimeStore.getState().params.checkpoint),
+            blockedByTrustRemoteCode: false,
+          };
+        }
+
+        const currentRawGpuIds = current.selectedGpuIds;
+        const currentGpuIndexKind = current.selectedGpuIndexKind;
+        const currentGpuIds = reconcilePersistedGpuIds(
+          currentRawGpuIds,
+          currentGpuIndexKind,
+        );
+        const currentGpuMemoryMode = current.gpuMemoryMode;
+        const currentHfToken = current.hfToken || null;
+        const currentTrustRemoteCode = current.params.trustRemoteCode ?? false;
+        const currentSpecSettings = resolveSpeculativeSettingsForLoad();
+        const allowed = await canAutoLoad(
+          {
+            model_path: DEFAULT_AUTO_LOAD_MODEL_ID,
+            max_seq_length: 0,
+            is_lora: false,
+            gguf_variant: DEFAULT_AUTO_LOAD_GGUF_VARIANT,
+            gpu_ids: currentGpuIds ?? undefined,
+            gpu_memory_mode: currentGpuMemoryMode,
+          },
+          {
+            hfToken: currentHfToken,
+            trustRemoteCode: currentTrustRemoteCode,
+          },
+        );
+
+        const latest = useChatRuntimeStore.getState();
+        const latestSpecSettings = resolveSpeculativeSettingsForLoad();
+        if (latest.params.checkpoint || latest.modelLoading) {
+          toast.dismiss(toastId);
+          if (latest.modelLoading) {
+            await waitForModelReady(abortSignal);
+          }
+          return {
+            loaded: Boolean(useChatRuntimeStore.getState().params.checkpoint),
+            blockedByTrustRemoteCode: false,
+          };
+        }
+        const unchanged =
+          sameGpuIds(latest.selectedGpuIds, currentRawGpuIds) &&
+          latest.selectedGpuIndexKind === currentGpuIndexKind &&
+          latest.gpuMemoryMode === currentGpuMemoryMode &&
+          (latest.hfToken || null) === currentHfToken &&
+          (latest.params.trustRemoteCode ?? false) === currentTrustRemoteCode &&
+          latestSpecSettings.speculativeType ===
+            currentSpecSettings.speculativeType &&
+          latestSpecSettings.specDraftNMax ===
+            currentSpecSettings.specDraftNMax;
+        if (!unchanged) continue;
+        if (!allowed) {
+          toast.dismiss(toastId);
+          return { loaded: false, blockedByTrustRemoteCode };
+        }
+
+        defaultGpuIds = currentGpuIds;
+        defaultGpuMemoryMode = currentGpuMemoryMode;
+        defaultHfToken = currentHfToken;
+        defaultTrustRemoteCode = currentTrustRemoteCode;
+        defaultSpecSettings = currentSpecSettings;
+        placementStable = true;
+        break;
+      }
+      if (!placementStable) {
+        toast.dismiss(toastId);
+        return { loaded: false, blockedByTrustRemoteCode };
+      }
+
       updateAutoLoadToast(
         "Starting model…",
         "Download complete. Loading Qwen3.5-4B-MTP into memory.",
@@ -2048,7 +2153,7 @@ async function autoLoadSmallestModel(abortSignal: AbortSignal): Promise<{
       loadAttempts += 1;
       const loadResp = await loadModel({
         model_path: DEFAULT_AUTO_LOAD_MODEL_ID,
-        hf_token: hfToken,
+        hf_token: defaultHfToken,
         // Model default under both modes: Auto layers + no pin means
         // resolveFitMaxSeqLength returns 0 for every mode (the canAutoLoad
         // preflight above sends the same).
@@ -2056,9 +2161,9 @@ async function autoLoadSmallestModel(abortSignal: AbortSignal): Promise<{
         load_in_4bit: true,
         is_lora: false,
         gguf_variant: DEFAULT_AUTO_LOAD_GGUF_VARIANT,
-        trust_remote_code: trustRemoteCode,
-        speculative_type: specSettings.speculativeType,
-        spec_draft_n_max: specSettings.specDraftNMax,
+        trust_remote_code: defaultTrustRemoteCode,
+        speculative_type: defaultSpecSettings.speculativeType,
+        spec_draft_n_max: defaultSpecSettings.specDraftNMax,
         // GPU Memory mode is a standing preference, so honor it on auto-load.
         // The layer/MoE/split knobs and the context pin are per-model: the live
         // store may hold edits drafted for a staged pick, and a fresh default
@@ -2066,13 +2171,13 @@ async function autoLoadSmallestModel(abortSignal: AbortSignal): Promise<{
         // the cached-candidate path. The GPU pick deliberately differs (it's the
         // picker's current on-screen selection, which the canAutoLoad preflight
         // above already committed to).
-        gpu_memory_mode: rt.gpuMemoryMode,
+        gpu_memory_mode: defaultGpuMemoryMode,
         gpu_layers: GPU_LAYERS_AUTO,
         n_cpu_moe: 0,
         gpu_ids: defaultGpuIds ?? undefined,
       });
-      saveSpeculativeType(specSettings.speculativeType);
-      persistGpuMemoryModeOnLoad(loadResp, rt.gpuMemoryMode);
+      saveSpeculativeType(defaultSpecSettings.speculativeType);
+      persistGpuMemoryModeOnLoad(loadResp, defaultGpuMemoryMode);
       useChatRuntimeStore
         .getState()
         .setCheckpoint(

--- a/studio/frontend/src/features/chat/api/managed-model-download-bridge.ts
+++ b/studio/frontend/src/features/chat/api/managed-model-download-bridge.ts
@@ -17,7 +17,7 @@ export function downloadModelWithManager(
   signal: AbortSignal,
 ): Promise<ManagedModelDownloadResult> {
   return coordinateManagedModelDownload(request, signal, {
-    requestStart: downloadManager.requestStart,
+    requestStart: downloadManager.requestStartWithOwnership,
     cancel: downloadManager.cancel,
     subscribe: subscribeJobListeners,
     jobKey: jobKeyOf,

--- a/studio/frontend/src/features/chat/api/managed-model-download-bridge.ts
+++ b/studio/frontend/src/features/chat/api/managed-model-download-bridge.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import {
+  downloadManager,
+  jobKeyOf,
+  subscribeJobListeners,
+} from "@/features/hub";
+import {
+  type ManagedModelDownloadRequest,
+  type ManagedModelDownloadResult,
+  coordinateManagedModelDownload,
+} from "./managed-model-download";
+
+export function downloadModelWithManager(
+  request: ManagedModelDownloadRequest,
+  signal: AbortSignal,
+): Promise<ManagedModelDownloadResult> {
+  return coordinateManagedModelDownload(request, signal, {
+    requestStart: downloadManager.requestStart,
+    cancel: downloadManager.cancel,
+    subscribe: subscribeJobListeners,
+    jobKey: jobKeyOf,
+  });
+}

--- a/studio/frontend/src/features/chat/api/managed-model-download.ts
+++ b/studio/frontend/src/features/chat/api/managed-model-download.ts
@@ -40,6 +40,17 @@ export interface ManagedModelDownloadDependencies {
   jobKey: (kind: "model", repoId: string, variant: string | null) => string;
 }
 
+type SharedDownloadLifecycle = {
+  consumers: Set<symbol>;
+  startPromise: Promise<DownloadStartOutcome> | null;
+  startSettled: boolean;
+  owned: boolean;
+  cancelWhenOwned: boolean;
+  cancellation: Promise<void> | null;
+};
+
+const sharedDownloads = new Map<string, SharedDownloadLifecycle>();
+
 function sameVariant(left: string | null, right: string | null): boolean {
   return (
     (left?.trim().toLowerCase() ?? "") === (right?.trim().toLowerCase() ?? "")
@@ -52,12 +63,60 @@ function abortReason(signal: AbortSignal): unknown {
   );
 }
 
+function waitForPromiseOrAbort(
+  promise: Promise<void>,
+  signal: AbortSignal,
+): Promise<void> {
+  if (signal.aborted) {
+    return Promise.reject(abortReason(signal));
+  }
+  return new Promise((resolve, reject) => {
+    const cleanup = () => signal.removeEventListener("abort", onAbort);
+    const onAbort = () => {
+      cleanup();
+      reject(abortReason(signal));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      () => {
+        cleanup();
+        resolve();
+      },
+      () => {
+        cleanup();
+        resolve();
+      },
+    );
+  });
+}
+
+function beginCancellation(
+  key: string,
+  shared: SharedDownloadLifecycle,
+  dependencies: ManagedModelDownloadDependencies,
+): Promise<void> {
+  if (shared.cancellation) {
+    return shared.cancellation;
+  }
+  const cancellation = Promise.resolve(dependencies.cancel(key))
+    .catch(() => undefined)
+    .then(() => undefined)
+    .finally(() => {
+      if (sharedDownloads.get(key) === shared) {
+        sharedDownloads.delete(key);
+      }
+    });
+  shared.cancellation = cancellation;
+  return cancellation;
+}
+
 /**
  * Start (or attach to) a Download Manager model job and wait for its terminal
- * event. The listener is registered before requestStart so a fast backend
- * completion cannot be missed. Aborting the chat cancels the exact managed job.
+ * event. Concurrent consumers of the exact job share ownership: one consumer
+ * leaving cannot cancel work another still needs, and a successor cannot start
+ * until cancellation of the previous owned generation has finished.
  */
-export function coordinateManagedModelDownload(
+export async function coordinateManagedModelDownload(
   request: ManagedModelDownloadRequest,
   signal: AbortSignal,
   dependencies: ManagedModelDownloadDependencies,
@@ -68,38 +127,77 @@ export function coordinateManagedModelDownload(
     managedRequest.repoId,
     managedRequest.variant,
   );
+  const prior = sharedDownloads.get(key);
+  if (prior?.cancellation) {
+    await waitForPromiseOrAbort(prior.cancellation, signal);
+    return coordinateManagedModelDownload(request, signal, dependencies);
+  }
+
+  const existing = sharedDownloads.get(key);
+  const shared: SharedDownloadLifecycle = existing ?? {
+    consumers: new Set<symbol>(),
+    startPromise: null,
+    startSettled: false,
+    owned: false,
+    cancelWhenOwned: false,
+    cancellation: null,
+  };
+  if (!existing) {
+    sharedDownloads.set(key, shared);
+  }
+  const consumer = Symbol(key);
+  shared.consumers.add(consumer);
 
   return new Promise((resolve, reject) => {
     let settled = false;
     let unsubscribe: (() => void) | null = null;
-    let startOutcome: DownloadStartOutcome | null = null;
 
     const cleanup = () => {
       signal.removeEventListener("abort", onAbort);
       unsubscribe?.();
       unsubscribe = null;
     };
-    const settle = (result: ManagedModelDownloadResult) => {
-      if (settled) {
-        return;
+    const detach = (cancelIfLast: boolean): Promise<void> | null => {
+      shared.consumers.delete(consumer);
+      if (shared.consumers.size > 0) {
+        return null;
       }
+      if (!shared.startSettled) {
+        shared.cancelWhenOwned ||= cancelIfLast;
+        return null;
+      }
+      if (cancelIfLast && shared.owned) {
+        return beginCancellation(key, shared, dependencies);
+      }
+      if (sharedDownloads.get(key) === shared) {
+        sharedDownloads.delete(key);
+      }
+      return null;
+    };
+    const settle = (result: ManagedModelDownloadResult) => {
+      if (settled) return;
       settled = true;
       cleanup();
+      detach(false);
       resolve(result);
     };
     const fail = (error: unknown) => {
-      if (settled) {
-        return;
-      }
+      if (settled) return;
       settled = true;
       cleanup();
+      detach(false);
       reject(error);
     };
     const onAbort = () => {
-      if (startOutcome === "started") {
-        Promise.resolve(dependencies.cancel(key)).catch(() => undefined);
+      if (settled) return;
+      settled = true;
+      cleanup();
+      const cancellation = detach(true);
+      if (cancellation) {
+        cancellation.finally(() => reject(abortReason(signal)));
+      } else {
+        reject(abortReason(signal));
       }
-      fail(abortReason(signal));
     };
 
     if (signal.aborted) {
@@ -112,41 +210,44 @@ export function coordinateManagedModelDownload(
       managedRequest.repoId,
       {
         onComplete: (variant) => {
-          if (sameVariant(variant, managedRequest.variant)) {
-            settle("complete");
-          }
+          if (sameVariant(variant, managedRequest.variant)) settle("complete");
         },
         onCancelled: (variant) => {
-          if (sameVariant(variant, managedRequest.variant)) {
-            settle("cancelled");
-          }
+          if (sameVariant(variant, managedRequest.variant)) settle("cancelled");
         },
         onError: (variant) => {
-          if (sameVariant(variant, managedRequest.variant)) {
-            settle("error");
-          }
+          if (sameVariant(variant, managedRequest.variant)) settle("error");
         },
       },
     );
     signal.addEventListener("abort", onAbort, { once: true });
 
-    dependencies
-      .requestStart(managedRequest)
+    shared.startPromise ??= dependencies.requestStart(managedRequest);
+    shared.startPromise
       .then((outcome) => {
-        startOutcome = outcome;
-        // The abort may have landed while requestStart was still running its
-        // async preflight, before ownership was known. Cancel only when this
-        // request actually started the job, never when it attached to one.
-        if (signal.aborted) {
-          if (outcome === "started") {
-            Promise.resolve(dependencies.cancel(key)).catch(() => undefined);
+        shared.startSettled = true;
+        shared.owned = outcome === "started";
+        if (shared.consumers.size === 0) {
+          if (shared.owned && shared.cancelWhenOwned) {
+            beginCancellation(key, shared, dependencies);
+          } else if (sharedDownloads.get(key) === shared) {
+            sharedDownloads.delete(key);
           }
-          return;
         }
-        if (outcome !== "started" && outcome !== "existing") {
+        if (!settled && outcome !== "started" && outcome !== "existing") {
           settle(outcome);
         }
       })
-      .catch(() => settle("error"));
+      .catch(() => {
+        shared.startSettled = true;
+        shared.owned = false;
+        if (
+          shared.consumers.size === 0 &&
+          sharedDownloads.get(key) === shared
+        ) {
+          sharedDownloads.delete(key);
+        }
+        settle("error");
+      });
   });
 }

--- a/studio/frontend/src/features/chat/api/managed-model-download.ts
+++ b/studio/frontend/src/features/chat/api/managed-model-download.ts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+export type ManagedModelDownloadResult =
+  | "complete"
+  | "cancelled"
+  | "conflict"
+  | "busy"
+  | "error";
+
+export type ManagedModelDownloadRequest = {
+  repoId: string;
+  variant: string | null;
+  expectedBytes: number;
+};
+
+type ManagedDownloadRequest = ManagedModelDownloadRequest & { kind: "model" };
+type DownloadStartOutcome = "started" | "conflict" | "busy" | "error";
+type JobListeners = {
+  onComplete?: (variant: string | null, bytes: number) => unknown;
+  onCancelled?: (variant: string | null) => unknown;
+  onError?: (variant: string | null) => unknown;
+};
+
+export interface ManagedModelDownloadDependencies {
+  requestStart: (
+    request: ManagedDownloadRequest,
+  ) => Promise<DownloadStartOutcome>;
+  cancel: (key: string) => void | Promise<void>;
+  subscribe: (
+    kind: "model",
+    repoId: string,
+    listeners: JobListeners,
+  ) => () => void;
+  jobKey: (kind: "model", repoId: string, variant: string | null) => string;
+}
+
+function sameVariant(left: string | null, right: string | null): boolean {
+  return (
+    (left?.trim().toLowerCase() ?? "") === (right?.trim().toLowerCase() ?? "")
+  );
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return (
+    signal.reason ?? new DOMException("Model download cancelled.", "AbortError")
+  );
+}
+
+/**
+ * Start (or attach to) a Download Manager model job and wait for its terminal
+ * event. The listener is registered before requestStart so a fast backend
+ * completion cannot be missed. Aborting the chat cancels the exact managed job.
+ */
+export function coordinateManagedModelDownload(
+  request: ManagedModelDownloadRequest,
+  signal: AbortSignal,
+  dependencies: ManagedModelDownloadDependencies,
+): Promise<ManagedModelDownloadResult> {
+  const managedRequest: ManagedDownloadRequest = { kind: "model", ...request };
+  const key = dependencies.jobKey(
+    managedRequest.kind,
+    managedRequest.repoId,
+    managedRequest.variant,
+  );
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let unsubscribe: (() => void) | null = null;
+
+    const cleanup = () => {
+      signal.removeEventListener("abort", onAbort);
+      unsubscribe?.();
+      unsubscribe = null;
+    };
+    const settle = (result: ManagedModelDownloadResult) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve(result);
+    };
+    const fail = (error: unknown) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const onAbort = () => {
+      Promise.resolve(dependencies.cancel(key)).catch(() => undefined);
+      fail(abortReason(signal));
+    };
+
+    if (signal.aborted) {
+      fail(abortReason(signal));
+      return;
+    }
+
+    unsubscribe = dependencies.subscribe(
+      managedRequest.kind,
+      managedRequest.repoId,
+      {
+        onComplete: (variant) => {
+          if (sameVariant(variant, managedRequest.variant)) {
+            settle("complete");
+          }
+        },
+        onCancelled: (variant) => {
+          if (sameVariant(variant, managedRequest.variant)) {
+            settle("cancelled");
+          }
+        },
+        onError: (variant) => {
+          if (sameVariant(variant, managedRequest.variant)) {
+            settle("error");
+          }
+        },
+      },
+    );
+    signal.addEventListener("abort", onAbort, { once: true });
+
+    dependencies
+      .requestStart(managedRequest)
+      .then((outcome) => {
+        // The abort may have landed while requestStart was still running its
+        // async preflight, before a cancellable job existed. If that preflight
+        // subsequently starts this job, cancel it again now that it is live.
+        if (signal.aborted) {
+          if (outcome === "started") {
+            Promise.resolve(dependencies.cancel(key)).catch(() => undefined);
+          }
+          return;
+        }
+        if (outcome !== "started") {
+          settle(outcome);
+        }
+      })
+      .catch(() => settle("error"));
+  });
+}

--- a/studio/frontend/src/features/chat/api/managed-model-download.ts
+++ b/studio/frontend/src/features/chat/api/managed-model-download.ts
@@ -15,7 +15,12 @@ export type ManagedModelDownloadRequest = {
 };
 
 type ManagedDownloadRequest = ManagedModelDownloadRequest & { kind: "model" };
-type DownloadStartOutcome = "started" | "conflict" | "busy" | "error";
+type DownloadStartOutcome =
+  | "started"
+  | "existing"
+  | "conflict"
+  | "busy"
+  | "error";
 type JobListeners = {
   onComplete?: (variant: string | null, bytes: number) => unknown;
   onCancelled?: (variant: string | null) => unknown;
@@ -67,6 +72,7 @@ export function coordinateManagedModelDownload(
   return new Promise((resolve, reject) => {
     let settled = false;
     let unsubscribe: (() => void) | null = null;
+    let startOutcome: DownloadStartOutcome | null = null;
 
     const cleanup = () => {
       signal.removeEventListener("abort", onAbort);
@@ -90,7 +96,9 @@ export function coordinateManagedModelDownload(
       reject(error);
     };
     const onAbort = () => {
-      Promise.resolve(dependencies.cancel(key)).catch(() => undefined);
+      if (startOutcome === "started") {
+        Promise.resolve(dependencies.cancel(key)).catch(() => undefined);
+      }
       fail(abortReason(signal));
     };
 
@@ -125,16 +133,17 @@ export function coordinateManagedModelDownload(
     dependencies
       .requestStart(managedRequest)
       .then((outcome) => {
+        startOutcome = outcome;
         // The abort may have landed while requestStart was still running its
-        // async preflight, before a cancellable job existed. If that preflight
-        // subsequently starts this job, cancel it again now that it is live.
+        // async preflight, before ownership was known. Cancel only when this
+        // request actually started the job, never when it attached to one.
         if (signal.aborted) {
           if (outcome === "started") {
             Promise.resolve(dependencies.cancel(key)).catch(() => undefined);
           }
           return;
         }
-        if (outcome !== "started") {
+        if (outcome !== "started" && outcome !== "existing") {
           settle(outcome);
         }
       })

--- a/studio/frontend/src/features/chat/api/single-flight.ts
+++ b/studio/frontend/src/features/chat/api/single-flight.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+function abortReason(signal: AbortSignal): unknown {
+  return (
+    signal.reason ?? new DOMException("Operation cancelled.", "AbortError")
+  );
+}
+
+function waitForPromiseOrAbort<T>(
+  promise: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(abortReason(signal));
+  }
+  return new Promise((resolve, reject) => {
+    const cleanup = () => signal.removeEventListener("abort", onAbort);
+    const onAbort = () => {
+      cleanup();
+      reject(abortReason(signal));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
+
+export type SingleFlight<T> = {
+  run: (signal: AbortSignal, start: () => Promise<T>) => Promise<T>;
+};
+
+export function createSingleFlight<T>(): SingleFlight<T> {
+  let active: Promise<T> | null = null;
+
+  return {
+    run(signal, start) {
+      if (signal.aborted) {
+        return Promise.reject(abortReason(signal));
+      }
+      if (!active) {
+        let created: Promise<T>;
+        try {
+          created = Promise.resolve(start());
+        } catch (error) {
+          created = Promise.reject(error);
+        }
+        active = created;
+        const clear = () => {
+          if (active === created) {
+            active = null;
+          }
+        };
+        created.then(clear, clear);
+      }
+      return waitForPromiseOrAbort(active, signal);
+    },
+  };
+}

--- a/studio/frontend/src/features/hub/download-manager/api.ts
+++ b/studio/frontend/src/features/hub/download-manager/api.ts
@@ -52,6 +52,9 @@ export interface DownloadStartResult {
   state: DownloadStartState;
   accepted: boolean;
   generation?: number;
+  // Older backends omit this additive ownership signal. Treat omission as a
+  // fresh start so mixed-version desktop updates preserve existing behavior.
+  created?: boolean;
 }
 
 export interface ActiveModelDownload {

--- a/studio/frontend/src/features/hub/download-manager/api.ts
+++ b/studio/frontend/src/features/hub/download-manager/api.ts
@@ -52,8 +52,8 @@ export interface DownloadStartResult {
   state: DownloadStartState;
   accepted: boolean;
   generation?: number;
-  // Older backends omit this additive ownership signal. Treat omission as a
-  // fresh start so mixed-version desktop updates preserve existing behavior.
+  // Older backends omit this additive ownership signal. Callers that make
+  // ownership-sensitive decisions must treat omission as non-ownership.
   created?: boolean;
 }
 

--- a/studio/frontend/src/features/hub/download-manager/download-manager-controller.ts
+++ b/studio/frontend/src/features/hub/download-manager/download-manager-controller.ts
@@ -16,6 +16,7 @@ import { runtimeRegistry } from "./runtime-registry";
 import {
   cancelConflict,
   requestStart,
+  requestStartWithOwnership,
   restartConflict,
   resumeConflict,
 } from "./transport-conflict";
@@ -45,6 +46,7 @@ export function __resetDownloadManagerForTests(): void {
 
 export interface DownloadManagerController {
   requestStart: typeof requestStart;
+  requestStartWithOwnership: typeof requestStartWithOwnership;
   cancel: typeof cancelJob;
   probeAndAdopt: typeof probeAndAdopt;
   setExpected: typeof setExpected;
@@ -56,6 +58,7 @@ export interface DownloadManagerController {
 
 export const downloadManager: DownloadManagerController = {
   requestStart,
+  requestStartWithOwnership,
   cancel: cancelJob,
   probeAndAdopt,
   setExpected,

--- a/studio/frontend/src/features/hub/download-manager/poll-loop.ts
+++ b/studio/frontend/src/features/hub/download-manager/poll-loop.ts
@@ -69,6 +69,7 @@ import {
   repoKeyOf,
   scheduleRemoval,
   setExpectedBytesForJob,
+  useDownloadManagerStore,
 } from "./download-manager-state";
 import {
   clearWatchdog,
@@ -842,6 +843,27 @@ async function probeCancelOutcome(
   }
 }
 
+function cancellationAttemptSettled(key: string, epoch: number): boolean {
+  const live = runtimeRegistry.runtimes.get(key);
+  if (live && live.epoch !== epoch) return true;
+  const job = getState().jobs[key];
+  return !job || job.state !== "cancelling";
+}
+
+function waitForCancellationAttempt(key: string, epoch: number): Promise<void> {
+  if (cancellationAttemptSettled(key, epoch)) return Promise.resolve();
+  return new Promise((resolve) => {
+    let unsubscribe: () => void = () => undefined;
+    const finish = () => {
+      if (!cancellationAttemptSettled(key, epoch)) return;
+      unsubscribe();
+      resolve();
+    };
+    unsubscribe = useDownloadManagerStore.subscribe(finish);
+    finish();
+  });
+}
+
 export async function cancelJob(key: string): Promise<void> {
   const job = getState().jobs[key];
   if (!job) return;
@@ -852,41 +874,45 @@ export async function cancelJob(key: string): Promise<void> {
   clearWatchdog(rt);
   if (rt) armCancelWatchdog(key, rt, cancelEpoch);
   try {
-    const result = await withDownloadTimeout<{ state: DownloadJobState }>(
-      (signal) => apiCancel(job, signal),
-    );
-    applyCancelResult(key, cancelEpoch, result);
-  } catch (err) {
-    const liveAtError = runtimeRegistry.runtimes.get(key);
-    if (rt && liveAtError && liveAtError.epoch !== cancelEpoch) return;
-    // apiCancel failed; the probe below is authoritative. Disarm the watchdog so
-    // it can't finalize "cancelled" mid-probe and tear down a still-running worker.
-    clearWatchdog(liveAtError);
+    try {
+      const result = await withDownloadTimeout<{ state: DownloadJobState }>(
+        (signal) => apiCancel(job, signal),
+      );
+      applyCancelResult(key, cancelEpoch, result);
+    } catch (err) {
+      const liveAtError = runtimeRegistry.runtimes.get(key);
+      if (rt && liveAtError && liveAtError.epoch !== cancelEpoch) return;
+      // apiCancel failed; the probe below is authoritative. Disarm the watchdog so
+      // it can't finalize "cancelled" mid-probe and tear down a still-running worker.
+      clearWatchdog(liveAtError);
 
-    const probe = await probeCancelOutcome(key, job, rt, cancelEpoch);
-    if (probe === "stale") return;
+      const probe = await probeCancelOutcome(key, job, rt, cancelEpoch);
+      if (probe === "stale") return;
 
-    const live = runtimeRegistry.runtimes.get(key);
-    if (rt && (!live || live.epoch !== cancelEpoch)) return;
+      const live = runtimeRegistry.runtimes.get(key);
+      if (rt && (!live || live.epoch !== cancelEpoch)) return;
 
-    if (probe.terminal !== null) {
-      if (probe.terminal === "complete") {
-        const current = getState().jobs[key];
-        finalize(key, "complete", { bytes: current?.downloadedBytes ?? 0 });
-      } else if (probe.terminal === "error") {
-        finalize(key, "error", { error: probe.error });
-      } else {
-        finalize(key, "cancelled");
+      if (probe.terminal !== null) {
+        if (probe.terminal === "complete") {
+          const current = getState().jobs[key];
+          finalize(key, "complete", { bytes: current?.downloadedBytes ?? 0 });
+        } else if (probe.terminal === "error") {
+          finalize(key, "error", { error: probe.error });
+        } else {
+          finalize(key, "cancelled");
+        }
+        return;
       }
-      return;
-    }
 
-    if (live) {
-      live.cancelRequested = false;
+      if (live) {
+        live.cancelRequested = false;
+      }
+      patchJob(key, { state: "running" });
+      toast.error("Couldn't cancel the download. It's still running.");
+      console.warn("Failed to cancel download", err);
     }
-    patchJob(key, { state: "running" });
-    toast.error("Couldn't cancel the download. It's still running.");
-    console.warn("Failed to cancel download", err);
+  } finally {
+    await waitForCancellationAttempt(key, cancelEpoch);
   }
 }
 

--- a/studio/frontend/src/features/hub/download-manager/poll-loop.ts
+++ b/studio/frontend/src/features/hub/download-manager/poll-loop.ts
@@ -76,6 +76,10 @@ import {
   teardownRuntime,
 } from "./runtime-registry";
 import { getTransportMode } from "./transport-preference";
+import {
+  type JobStartOwnership,
+  ownershipFromStartResult,
+} from "./start-ownership";
 
 function notify(
   job: ManagedDownload,
@@ -587,8 +591,6 @@ function reissueDroppedStartCancel(
   }).catch(() => {});
 }
 
-export type JobStartOwnership = "started" | "existing" | "inactive";
-
 export async function startJob(
   req: DownloadRequest,
   opts: {
@@ -682,7 +684,6 @@ export async function startJob(
   });
 
   if (!opts.adopt) {
-    let ownership: JobStartOwnership = "started";
     let result;
     try {
       result = await apiStart(req, mode === TRANSPORT.XET, hfToken);
@@ -706,7 +707,7 @@ export async function startJob(
     if (Number.isSafeInteger(result.generation)) {
       patchJob(key, { serverGeneration: result.generation });
     }
-    if (result.created === false) ownership = "existing";
+    const ownership = ownershipFromStartResult(result);
     beginPolling(key, rt);
     return ownership;
   }

--- a/studio/frontend/src/features/hub/download-manager/poll-loop.ts
+++ b/studio/frontend/src/features/hub/download-manager/poll-loop.ts
@@ -587,6 +587,8 @@ function reissueDroppedStartCancel(
   }).catch(() => {});
 }
 
+export type JobStartOwnership = "started" | "existing" | "inactive";
+
 export async function startJob(
   req: DownloadRequest,
   opts: {
@@ -595,14 +597,14 @@ export async function startJob(
     generation?: number;
     state?: DownloadJobState;
   } = {},
-): Promise<void> {
+): Promise<JobStartOwnership> {
   const key = jobKeyOf(req.kind, req.repoId, req.variant);
   // Peer guard stops a FRESH start from double-starting a variant already
   // downloading (or colliding with a no-variant snapshot). Skipped when ADOPTING:
   // the restored own entry would look like a peer and freeze the bar; adoptJob's
   // `pollingStarted` guard already prevents double-polling the same key.
   if (!opts.adopt && hasActiveRepoPeer(req.kind, req.repoId, key, req.variant)) {
-    return;
+    return "inactive";
   }
   const nextEpoch = (runtimeRegistry.runtimes.get(key)?.epoch ?? 0) + 1;
   teardownRuntime(key);
@@ -658,7 +660,7 @@ export async function startJob(
     : undefined;
   if (!opts.adopt && hasActiveRepoPeer(req.kind, req.repoId, key, req.variant)) {
     teardownRuntime(key);
-    return;
+    return "inactive";
   }
   putJob({
     key,
@@ -680,32 +682,37 @@ export async function startJob(
   });
 
   if (!opts.adopt) {
+    let ownership: JobStartOwnership = "started";
     let result;
     try {
       result = await apiStart(req, mode === TRANSPORT.XET, hfToken);
     } catch (err) {
-      if (!isCurrent(key, epoch)) return;
+      if (!isCurrent(key, epoch)) return "inactive";
       finalize(key, "error", {
         error: normalizeDownloadError(err),
       });
-      return;
+      return "inactive";
     }
     // A cancel during this apiStart round-trip can land before the job is
     // claimable; re-issue against the accepted generation.
     if (rt.cancelRequested && result.accepted) {
       reissueDroppedStartCancel(req, result.generation);
     }
-    if (!isCurrent(key, epoch)) return;
+    if (!isCurrent(key, epoch)) return "inactive";
     if (!result.accepted) {
       finalize(key, "error", { error: describeUnacceptedStart(result.state) });
-      return;
+      return "inactive";
     }
     if (Number.isSafeInteger(result.generation)) {
       patchJob(key, { serverGeneration: result.generation });
     }
+    if (result.created === false) ownership = "existing";
+    beginPolling(key, rt);
+    return ownership;
   }
 
   beginPolling(key, rt);
+  return "existing";
 }
 
 function armCancelWatchdog(

--- a/studio/frontend/src/features/hub/download-manager/start-ownership.ts
+++ b/studio/frontend/src/features/hub/download-manager/start-ownership.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+export type JobStartOwnership = "started" | "existing" | "inactive";
+
+export function ownershipFromStartResult(result: {
+  created?: boolean;
+}): Exclude<JobStartOwnership, "inactive"> {
+  // Cancellation ownership requires affirmative evidence that this caller
+  // created the backend job. Older backends omit this field, so fail closed.
+  return result.created === true ? "started" : "existing";
+}

--- a/studio/frontend/src/features/hub/download-manager/transport-conflict.ts
+++ b/studio/frontend/src/features/hub/download-manager/transport-conflict.ts
@@ -9,19 +9,23 @@ import {
   apiTransportStatusWithRetry,
   effectiveTransportMode,
 } from "./download-api-adapter";
-import type { DownloadRequest } from "./download-manager-types";
+import {
+  ACTIVE_STATES,
+  TRANSPORT_STATUS_TIMEOUT_MS,
+} from "./download-manager-config";
 import {
   findActiveJobForRepo,
   getState,
   hasVariantRepoActivity,
   jobKeyOf,
+  removeJob,
   repoKeyOf,
   setConflict,
 } from "./download-manager-state";
-import { startJob } from "./poll-loop";
+import type { DownloadRequest } from "./download-manager-types";
+import { probeAndAdopt, startJob } from "./poll-loop";
 import { runtimeRegistry } from "./runtime-registry";
 import { getTransportMode } from "./transport-preference";
-import { ACTIVE_STATES, TRANSPORT_STATUS_TIMEOUT_MS } from "./download-manager-config";
 
 function reportConflictStartError(error: unknown): void {
   const description =
@@ -100,6 +104,28 @@ function isJobActiveFor(req: DownloadRequest): boolean {
   return Boolean(job && ACTIVE_STATES.has(job.state));
 }
 
+async function ensureActiveJobRuntime(req: DownloadRequest): Promise<boolean> {
+  const key = jobKeyOf(req.kind, req.repoId, req.variant);
+  if (!isJobActiveFor(req)) return false;
+  if (runtimeRegistry.runtimes.has(key)) return true;
+
+  const timeout = disposableTimeoutSignal(TRANSPORT_STATUS_TIMEOUT_MS);
+  try {
+    await probeAndAdopt(req.kind, req.repoId, timeout.signal, {
+      includeVariants: req.kind === "model",
+      fresh: true,
+    });
+  } finally {
+    timeout.dispose();
+  }
+  if (runtimeRegistry.runtimes.has(key)) return true;
+
+  // A persisted active mirror without a runtime cannot make progress. Remove it
+  // and let the backend start response authoritatively create or adopt the job.
+  removeJob(key);
+  return false;
+}
+
 async function runWithPendingStartGuard(
   req: DownloadRequest,
   action: () => Promise<DownloadStartOwnershipOutcome>,
@@ -108,7 +134,8 @@ async function runWithPendingStartGuard(
   // Distinguish attaching to an exact live transfer from creating one so a
   // caller can avoid cancelling a shared job that it does not own.
   if (hasActiveOrPendingStart(req)) {
-    return isJobActiveFor(req) ? "existing" : "busy";
+    if (!isJobActiveFor(req)) return "busy";
+    if (await ensureActiveJobRuntime(req)) return "existing";
   }
   runtimeRegistry.pendingStartRepoKeys.add(startKey);
   try {

--- a/studio/frontend/src/features/hub/download-manager/transport-conflict.ts
+++ b/studio/frontend/src/features/hub/download-manager/transport-conflict.ts
@@ -102,7 +102,7 @@ function isJobActiveFor(req: DownloadRequest): boolean {
 
 async function runWithPendingStartGuard(
   req: DownloadRequest,
-  action: () => Promise<DownloadStartOutcome>,
+  action: () => Promise<DownloadStartOwnershipOutcome>,
 ): Promise<DownloadStartOwnershipOutcome> {
   const startKey = pendingStartKey(req);
   // Distinguish attaching to an exact live transfer from creating one so a
@@ -189,16 +189,22 @@ export function requestStartWithOwnership(
           description:
             "Starting with HTTP so an existing partial is not discarded. Switch transport to retry with Xet.",
         });
-        await startJob(req, { useXet: false });
-        return isJobActiveFor(req) ? "started" : "error";
+        const ownership = await startJob(req, { useXet: false });
+        return isJobActiveFor(req) && ownership !== "inactive"
+          ? ownership
+          : "error";
       }
       toast.warning("Couldn't verify existing partial download", {
         description:
           "Starting with the selected transport. If a partial from another transport exists, it may be restarted from the beginning.",
       });
     }
-    await startJob(req, { useXet: mode === TRANSPORT.XET });
-    return isJobActiveFor(req) ? "started" : "error";
+    const ownership = await startJob(req, {
+      useXet: mode === TRANSPORT.XET,
+    });
+    return isJobActiveFor(req) && ownership !== "inactive"
+      ? ownership
+      : "error";
   });
 }
 

--- a/studio/frontend/src/features/hub/download-manager/transport-conflict.ts
+++ b/studio/frontend/src/features/hub/download-manager/transport-conflict.ts
@@ -88,6 +88,7 @@ async function activeSiblingTransport(
 // repo is occupied by a sibling variant/snapshot/pending start that is not this
 // transfer; "error" means the start failed or was refused.
 export type DownloadStartOutcome = "started" | "conflict" | "busy" | "error";
+export type DownloadStartOwnershipOutcome = DownloadStartOutcome | "existing";
 
 // A start can no-op without throwing: the backend can refuse it (startJob
 // finalizes "error"), startJob's peer guard can skip it, or
@@ -102,12 +103,12 @@ function isJobActiveFor(req: DownloadRequest): boolean {
 async function runWithPendingStartGuard(
   req: DownloadRequest,
   action: () => Promise<DownloadStartOutcome>,
-): Promise<DownloadStartOutcome> {
+): Promise<DownloadStartOwnershipOutcome> {
   const startKey = pendingStartKey(req);
-  // Already active or pending for the repo: only report "started" when this
-  // exact request is the live transfer; a peer/snapshot/pending start has not.
+  // Distinguish attaching to an exact live transfer from creating one so a
+  // caller can avoid cancelling a shared job that it does not own.
   if (hasActiveOrPendingStart(req)) {
-    return isJobActiveFor(req) ? "started" : "busy";
+    return isJobActiveFor(req) ? "existing" : "busy";
   }
   runtimeRegistry.pendingStartRepoKeys.add(startKey);
   try {
@@ -120,9 +121,9 @@ async function runWithPendingStartGuard(
   }
 }
 
-export async function requestStart(
+export function requestStartWithOwnership(
   req: DownloadRequest,
-): Promise<DownloadStartOutcome> {
+): Promise<DownloadStartOwnershipOutcome> {
   return runWithPendingStartGuard(req, async () => {
     let mode: TransportMode = getTransportMode();
     try {
@@ -199,6 +200,14 @@ export async function requestStart(
     await startJob(req, { useXet: mode === TRANSPORT.XET });
     return isJobActiveFor(req) ? "started" : "error";
   });
+}
+
+export async function requestStart(
+  req: DownloadRequest,
+): Promise<DownloadStartOutcome> {
+  const outcome = await requestStartWithOwnership(req);
+  // Preserve the established controller contract for existing callers.
+  return outcome === "existing" ? "started" : outcome;
 }
 
 export function resumeConflict(conflictKey: string): void {

--- a/studio/frontend/tests/download-start-ownership.test.ts
+++ b/studio/frontend/tests/download-start-ownership.test.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ownershipFromStartResult } from "../src/features/hub/download-manager/start-ownership.ts";
+
+test("grants ownership only when the backend confirms this caller created the job", () => {
+  assert.equal(ownershipFromStartResult({ created: true }), "started");
+  assert.equal(ownershipFromStartResult({ created: false }), "existing");
+  assert.equal(ownershipFromStartResult({}), "existing");
+});

--- a/studio/frontend/tests/managed-model-download.test.ts
+++ b/studio/frontend/tests/managed-model-download.test.ts
@@ -16,7 +16,7 @@ const REQUEST = {
 };
 
 function createHarness(
-  outcome: "started" | "conflict" | "busy" | "error" = "started",
+  outcome: "started" | "existing" | "conflict" | "busy" | "error" = "started",
 ) {
   const order: string[] = [];
   const cancelledKeys: string[] = [];
@@ -96,6 +96,23 @@ test("chat abort cancels the exact manager job and preserves the abort reason", 
   assert.equal(harness.unsubscribed(), true);
 });
 
+test("chat abort does not cancel a pre-existing managed download", async () => {
+  const harness = createHarness("existing");
+  const controller = new AbortController();
+  const pending = coordinateManagedModelDownload(
+    REQUEST,
+    controller.signal,
+    harness.dependencies,
+  );
+  const reason = new Error("Stopped by user");
+
+  controller.abort(reason);
+
+  await assert.rejects(pending, (error) => error === reason);
+  assert.deepEqual(harness.cancelledKeys, []);
+  assert.equal(harness.unsubscribed(), true);
+});
+
 test("chat abort re-cancels a job that starts after async preflight", async () => {
   const harness = createHarness();
   const controller = new AbortController();
@@ -113,14 +130,11 @@ test("chat abort re-cancels a job that starts after async preflight", async () =
 
   controller.abort(reason);
   await assert.rejects(pending, (error) => error === reason);
-  assert.deepEqual(harness.cancelledKeys, [
-    `model:${REQUEST.repoId}#${REQUEST.variant}`,
-  ]);
+  assert.deepEqual(harness.cancelledKeys, []);
 
   finishStart?.("started");
   await Promise.resolve();
   assert.deepEqual(harness.cancelledKeys, [
-    `model:${REQUEST.repoId}#${REQUEST.variant}`,
     `model:${REQUEST.repoId}#${REQUEST.variant}`,
   ]);
 });

--- a/studio/frontend/tests/managed-model-download.test.ts
+++ b/studio/frontend/tests/managed-model-download.test.ts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  type ManagedModelDownloadDependencies,
+  coordinateManagedModelDownload,
+} from "../src/features/chat/api/managed-model-download.ts";
+
+const REQUEST = {
+  repoId: "unsloth/Qwen3.5-4B-MTP-GGUF",
+  variant: "UD-Q4_K_XL",
+  expectedBytes: 0,
+};
+
+function createHarness(
+  outcome: "started" | "conflict" | "busy" | "error" = "started",
+) {
+  const order: string[] = [];
+  const cancelledKeys: string[] = [];
+  let listeners: Parameters<ManagedModelDownloadDependencies["subscribe"]>[2] =
+    {};
+  let unsubscribed = false;
+  const dependencies: ManagedModelDownloadDependencies = {
+    requestStart: async (request) => {
+      order.push("start");
+      assert.deepEqual(request, { kind: "model", ...REQUEST });
+      return outcome;
+    },
+    cancel: async (key) => {
+      cancelledKeys.push(key);
+    },
+    subscribe: (kind, repoId, nextListeners) => {
+      order.push("subscribe");
+      assert.equal(kind, "model");
+      assert.equal(repoId, REQUEST.repoId);
+      listeners = nextListeners;
+      return () => {
+        unsubscribed = true;
+      };
+    },
+    jobKey: (kind, repoId, variant) => `${kind}:${repoId}#${variant}`,
+  };
+  return {
+    dependencies,
+    order,
+    cancelledKeys,
+    listeners: () => listeners,
+    unsubscribed: () => unsubscribed,
+  };
+}
+
+test("subscribes before start and completes only for the requested variant", async () => {
+  const harness = createHarness();
+  const controller = new AbortController();
+  const pending = coordinateManagedModelDownload(
+    REQUEST,
+    controller.signal,
+    harness.dependencies,
+  );
+
+  assert.deepEqual(harness.order, ["subscribe", "start"]);
+  let settled = false;
+  void pending.then(() => {
+    settled = true;
+  });
+  harness.listeners().onComplete?.("Q8_0", 123);
+  await Promise.resolve();
+  assert.equal(settled, false);
+
+  harness.listeners().onComplete?.("ud-q4_k_xl", 456);
+  assert.equal(await pending, "complete");
+  assert.equal(harness.unsubscribed(), true);
+});
+
+test("chat abort cancels the exact manager job and preserves the abort reason", async () => {
+  const harness = createHarness();
+  const controller = new AbortController();
+  const pending = coordinateManagedModelDownload(
+    REQUEST,
+    controller.signal,
+    harness.dependencies,
+  );
+  const reason = new Error("Stopped by user");
+
+  controller.abort(reason);
+
+  await assert.rejects(pending, (error) => error === reason);
+  const expectedKey = `model:${REQUEST.repoId}#${REQUEST.variant}`;
+  assert.ok(harness.cancelledKeys.length >= 1);
+  assert.ok(
+    harness.cancelledKeys.every((cancelledKey) => cancelledKey === expectedKey),
+  );
+  assert.equal(harness.unsubscribed(), true);
+});
+
+test("chat abort re-cancels a job that starts after async preflight", async () => {
+  const harness = createHarness();
+  const controller = new AbortController();
+  let finishStart: ((outcome: "started") => void) | undefined;
+  harness.dependencies.requestStart = () =>
+    new Promise((resolve) => {
+      finishStart = resolve;
+    });
+  const pending = coordinateManagedModelDownload(
+    REQUEST,
+    controller.signal,
+    harness.dependencies,
+  );
+  const reason = new Error("Stopped during preflight");
+
+  controller.abort(reason);
+  await assert.rejects(pending, (error) => error === reason);
+  assert.deepEqual(harness.cancelledKeys, [
+    `model:${REQUEST.repoId}#${REQUEST.variant}`,
+  ]);
+
+  finishStart?.("started");
+  await Promise.resolve();
+  assert.deepEqual(harness.cancelledKeys, [
+    `model:${REQUEST.repoId}#${REQUEST.variant}`,
+    `model:${REQUEST.repoId}#${REQUEST.variant}`,
+  ]);
+});
+
+test("manager cancellation settles the waiting first chat", async () => {
+  const harness = createHarness();
+  const pending = coordinateManagedModelDownload(
+    REQUEST,
+    new AbortController().signal,
+    harness.dependencies,
+  );
+
+  harness.listeners().onCancelled?.(REQUEST.variant);
+
+  assert.equal(await pending, "cancelled");
+  assert.equal(harness.unsubscribed(), true);
+});
+
+for (const outcome of ["conflict", "busy", "error"] as const) {
+  test(`returns ${outcome} without waiting for a terminal event`, async () => {
+    const harness = createHarness(outcome);
+    const result = await coordinateManagedModelDownload(
+      REQUEST,
+      new AbortController().signal,
+      harness.dependencies,
+    );
+
+    assert.equal(result, outcome);
+    assert.equal(harness.unsubscribed(), true);
+  });
+}
+
+test("turns an unexpected start rejection into a managed error", async () => {
+  const harness = createHarness();
+  harness.dependencies.requestStart = async () => {
+    throw new Error("start failed");
+  };
+
+  assert.equal(
+    await coordinateManagedModelDownload(
+      REQUEST,
+      new AbortController().signal,
+      harness.dependencies,
+    ),
+    "error",
+  );
+  assert.equal(harness.unsubscribed(), true);
+});

--- a/studio/frontend/tests/managed-model-download.test.ts
+++ b/studio/frontend/tests/managed-model-download.test.ts
@@ -183,3 +183,157 @@ test("turns an unexpected start rejection into a managed error", async () => {
   );
   assert.equal(harness.unsubscribed(), true);
 });
+
+test("one consumer abort cannot cancel a shared owned download", async () => {
+  const listeners: Array<
+    Parameters<ManagedModelDownloadDependencies["subscribe"]>[2]
+  > = [];
+  const cancelledKeys: string[] = [];
+  let starts = 0;
+  const dependencies: ManagedModelDownloadDependencies = {
+    requestStart: async () => {
+      starts += 1;
+      return "started";
+    },
+    cancel: async (key) => {
+      cancelledKeys.push(key);
+    },
+    subscribe: (_kind, _repoId, nextListeners) => {
+      listeners.push(nextListeners);
+      return () => undefined;
+    },
+    jobKey: (kind, repoId, variant) => `${kind}:${repoId}#${variant}`,
+  };
+  const firstController = new AbortController();
+  const secondController = new AbortController();
+  const first = coordinateManagedModelDownload(
+    REQUEST,
+    firstController.signal,
+    dependencies,
+  );
+  const second = coordinateManagedModelDownload(
+    REQUEST,
+    secondController.signal,
+    dependencies,
+  );
+  await Promise.resolve();
+
+  firstController.abort(new Error("first consumer left"));
+  await assert.rejects(first);
+  assert.equal(starts, 1);
+  assert.deepEqual(cancelledKeys, []);
+
+  for (const listener of listeners) {
+    listener.onComplete?.(REQUEST.variant, 123);
+  }
+  assert.equal(await second, "complete");
+  assert.deepEqual(cancelledKeys, []);
+});
+
+test("the last shared consumer cancels an owned download exactly once", async () => {
+  const cancelledKeys: string[] = [];
+  const dependencies: ManagedModelDownloadDependencies = {
+    requestStart: async () => "started",
+    cancel: async (key) => {
+      cancelledKeys.push(key);
+    },
+    subscribe: () => () => undefined,
+    jobKey: (kind, repoId, variant) => `${kind}:${repoId}#${variant}`,
+  };
+  const firstController = new AbortController();
+  const secondController = new AbortController();
+  const first = coordinateManagedModelDownload(
+    REQUEST,
+    firstController.signal,
+    dependencies,
+  );
+  const second = coordinateManagedModelDownload(
+    REQUEST,
+    secondController.signal,
+    dependencies,
+  );
+  await Promise.resolve();
+
+  firstController.abort();
+  await assert.rejects(first);
+  assert.deepEqual(cancelledKeys, []);
+
+  secondController.abort();
+  await assert.rejects(second);
+  assert.deepEqual(cancelledKeys, [
+    `model:${REQUEST.repoId}#${REQUEST.variant}`,
+  ]);
+});
+
+test("a successor waits for owned cancellation before starting", async () => {
+  const listeners: Array<
+    Parameters<ManagedModelDownloadDependencies["subscribe"]>[2]
+  > = [];
+  let starts = 0;
+  let finishCancellation: (() => void) | undefined;
+  const cancellation = new Promise<void>((resolve) => {
+    finishCancellation = resolve;
+  });
+  const dependencies: ManagedModelDownloadDependencies = {
+    requestStart: async () => {
+      starts += 1;
+      return "started";
+    },
+    cancel: () => cancellation,
+    subscribe: (_kind, _repoId, nextListeners) => {
+      listeners.push(nextListeners);
+      return () => undefined;
+    },
+    jobKey: (kind, repoId, variant) => `${kind}:${repoId}#${variant}`,
+  };
+  const firstController = new AbortController();
+  const first = coordinateManagedModelDownload(
+    REQUEST,
+    firstController.signal,
+    dependencies,
+  );
+  await Promise.resolve();
+  firstController.abort(new Error("restart"));
+  let firstSettled = false;
+  void first.catch(() => {
+    firstSettled = true;
+  });
+
+  const successor = coordinateManagedModelDownload(
+    REQUEST,
+    new AbortController().signal,
+    dependencies,
+  );
+  await Promise.resolve();
+  assert.equal(starts, 1);
+  assert.equal(firstSettled, false);
+
+  finishCancellation?.();
+  await assert.rejects(first);
+  await Promise.resolve();
+  assert.equal(starts, 2);
+
+  listeners.at(-1)?.onComplete?.(REQUEST.variant, 123);
+  assert.equal(await successor, "complete");
+});
+
+
+test("a terminal event during start preflight does not request cancellation", async () => {
+  const harness = createHarness();
+  let finishStart: ((outcome: "started") => void) | undefined;
+  harness.dependencies.requestStart = () =>
+    new Promise((resolve) => {
+      finishStart = resolve;
+    });
+  const pending = coordinateManagedModelDownload(
+    REQUEST,
+    new AbortController().signal,
+    harness.dependencies,
+  );
+
+  harness.listeners().onComplete?.(REQUEST.variant, 123);
+  assert.equal(await pending, "complete");
+  finishStart?.("started");
+  await Promise.resolve();
+  assert.deepEqual(harness.cancelledKeys, []);
+});

--- a/studio/frontend/tests/single-flight.test.ts
+++ b/studio/frontend/tests/single-flight.test.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createSingleFlight } from "../src/features/chat/api/single-flight.ts";
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (error: unknown) => void = () => undefined;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
+test("concurrent callers share one operation and its committed result", async () => {
+  const flight = createSingleFlight<{ committed: boolean }>();
+  const operation = deferred<{ committed: boolean }>();
+  let starts = 0;
+  const start = () => {
+    starts += 1;
+    return operation.promise;
+  };
+
+  const first = flight.run(new AbortController().signal, start);
+  const second = flight.run(new AbortController().signal, start);
+  assert.equal(starts, 1);
+
+  operation.resolve({ committed: true });
+  assert.deepEqual(await first, { committed: true });
+  assert.deepEqual(await second, { committed: true });
+});
+
+test("an aborted waiter does not cancel or poison the shared operation", async () => {
+  const flight = createSingleFlight<string>();
+  const operation = deferred<string>();
+  const firstController = new AbortController();
+  const secondController = new AbortController();
+  const reason = new Error("first caller stopped");
+  let starts = 0;
+  const start = () => {
+    starts += 1;
+    return operation.promise;
+  };
+
+  const first = flight.run(firstController.signal, start);
+  const second = flight.run(secondController.signal, start);
+  firstController.abort(reason);
+
+  await assert.rejects(first, (error) => error === reason);
+  operation.resolve("loaded");
+  assert.equal(await second, "loaded");
+  assert.equal(starts, 1);
+});
+
+test("an already-aborted caller never starts the operation", async () => {
+  const flight = createSingleFlight<void>();
+  const controller = new AbortController();
+  const reason = new Error("stopped before claim");
+  controller.abort(reason);
+  let starts = 0;
+
+  await assert.rejects(
+    flight.run(controller.signal, async () => {
+      starts += 1;
+    }),
+    (error) => error === reason,
+  );
+  assert.equal(starts, 0);
+});
+
+test("a failed operation clears the slot for one fresh retry", async () => {
+  const flight = createSingleFlight<string>();
+  const failure = new Error("load failed");
+  let starts = 0;
+  const fail = () => {
+    starts += 1;
+    return Promise.reject(failure);
+  };
+
+  const first = flight.run(new AbortController().signal, fail);
+  const second = flight.run(new AbortController().signal, fail);
+  await assert.rejects(first, (error) => error === failure);
+  await assert.rejects(second, (error) => error === failure);
+  assert.equal(starts, 1);
+
+  assert.equal(
+    await flight.run(new AbortController().signal, async () => {
+      starts += 1;
+      return "retried";
+    }),
+    "retried",
+  );
+  assert.equal(starts, 2);
+});

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -122,10 +122,7 @@ def test_first_chat_default_autoload_yields_to_an_explicit_model_load():
 
     state_refresh = "const runtimeAfterDownload = useChatRuntimeStore.getState();"
     assert state_refresh in compact
-    state_guard = (
-        "runtimeAfterDownload.params.checkpoint || "
-        "runtimeAfterDownload.modelLoading"
-    )
+    state_guard = "runtimeAfterDownload.params.checkpoint || runtimeAfterDownload.modelLoading"
     assert state_guard in compact
     assert "await waitForModelReady(abortSignal);" in before_default_load
     result_guard = "Boolean(useChatRuntimeStore.getState().params.checkpoint)"

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -1221,3 +1221,52 @@ def test_vulkan_inference_devices_are_the_pickable_set():
         'data?.device_backend === "cuda" || data?.device_backend === "rocm";' in src
     )
     assert 'diffusionPinnable: diffusionBackend && d.index_kind === "physical",' in src
+
+
+def test_first_chat_default_autoload_revalidates_final_load_snapshot():
+    """The load must validate and consume one stable post-transfer snapshot."""
+    src = _read("features/chat/api/chat-adapter.ts")
+    after_download = src.split(
+        "const downloadResult = await downloadModelWithManager", 1
+    )[1]
+    before_load, load_and_after = after_download.split(
+        "const loadResp = await loadModel", 1
+    )
+
+    assert "for (let attempt = 0; attempt < 3; attempt += 1)" in before_load
+    assert "const allowed = await canAutoLoad(" in before_load
+    assert "const latest = useChatRuntimeStore.getState();" in before_load
+    assert "if (!unchanged) continue;" in before_load
+    assert "hf_token: defaultHfToken" in load_and_after
+    assert "trust_remote_code: defaultTrustRemoteCode" in load_and_after
+    assert "gpu_memory_mode: defaultGpuMemoryMode" in load_and_after
+    assert "gpu_ids: defaultGpuIds ?? undefined" in load_and_after
+
+
+def test_download_manager_start_adopts_or_discards_active_mirrors():
+    """An active persisted mirror cannot be treated as attached without runtime."""
+    src = _read("features/hub/download-manager/transport-conflict.ts")
+    guard = src.split("async function runWithPendingStartGuard", 1)[1]
+    guard = guard.split("export function requestStartWithOwnership", 1)[0]
+
+    assert "await ensureActiveJobRuntime(req)" in guard
+    helper = src.split("async function ensureActiveJobRuntime", 1)[1]
+    helper = helper.split("async function runWithPendingStartGuard", 1)[0]
+    assert "await probeAndAdopt(" in helper
+    assert "runtimeRegistry.runtimes.has(key)" in helper
+    assert "removeJob(key)" in helper
+
+
+def test_download_manager_cancel_resolves_after_cancelling_state_exits():
+    """Callers awaiting cancel receive a generation-scoped completion barrier."""
+    src = _read("features/hub/download-manager/poll-loop.ts")
+    cancel = src.split("export async function cancelJob", 1)[1]
+    cancel = cancel.split("export function adoptJob", 1)[0]
+
+    assert "finally {" in cancel
+    assert "await waitForCancellationAttempt(key, cancelEpoch);" in cancel
+    helper = src.split("function cancellationAttemptSettled", 1)[1]
+    helper = helper.split("export async function cancelJob", 1)[0]
+    assert 'job.state !== "cancelling"' in helper
+    assert "live.epoch !== epoch" in helper
+    assert "useDownloadManagerStore.subscribe(finish)" in helper

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -993,9 +993,7 @@ def test_parallel_slots_control_cleared_when_the_load_never_sent_them():
 
     fresh_default = adapter.split("const downloadResult = await downloadModelWithManager", 1)[
         1
-    ].split(
-        'showAutoLoadSuccess("Loaded Qwen', 1
-    )[0]
+    ].split('showAutoLoadSuccess("Loaded Qwen', 1)[0]
     # The fresh-default download omits the slots, so its success state clears both,
     # or the control reads as an unapplied edit against the seeded baseline.
     assert "n_parallel" not in fresh_default.split("saveSpeculativeType", 1)[0]

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -1266,3 +1266,21 @@ def test_download_manager_cancel_resolves_after_cancelling_state_exits():
     assert 'job.state !== "cancelling"' in helper
     assert "live.epoch !== epoch" in helper
     assert "useDownloadManagerStore.subscribe(finish)" in helper
+
+
+def test_first_chat_default_autoload_claims_one_abort_safe_load():
+    """The final non-abortable load is claimed only after the last abort check."""
+    src = _read("features/chat/api/chat-adapter.ts")
+    final_phase = src.split("if (!placementStable)", 1)[1]
+    final_phase = final_phase.split("} catch (error)", 1)[0]
+
+    abort_check = final_phase.index("abortSignal.throwIfAborted();")
+    flight_claim = final_phase.index("defaultAutoLoadFlight.run(")
+    load_claim = final_phase.index("setModelLoading(true);")
+    load_call = final_phase.index("const loadResp = await loadModel")
+    persisted = final_phase.index("recordLastLocalModelLoad({")
+    release = final_phase.index("setModelLoading(false);")
+
+    assert abort_check < flight_claim < load_claim < load_call
+    assert load_call < persisted < release
+    assert "await waitForModelReady();" in final_phase

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -991,7 +991,9 @@ def test_parallel_slots_control_cleared_when_the_load_never_sent_them():
     assert "nParallel: null," in non_gguf_branch
     assert "loadedNParallel: null," in non_gguf_branch
 
-    fresh_default = adapter.split("No downloaded models found. Fetching", 1)[1].split(
+    fresh_default = adapter.split("const downloadResult = await downloadModelWithManager", 1)[
+        1
+    ].split(
         'showAutoLoadSuccess("Loaded Qwen', 1
     )[0]
     # The fresh-default download omits the slots, so its success state clears both,

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -106,6 +106,32 @@ def test_chat_autoload_toast_is_persistent_and_dismissible():
     assert "duration: Infinity" in explicit_load
 
 
+def test_first_chat_default_autoload_yields_to_an_explicit_model_load():
+    """A user pick made during the managed download owns the next load.
+
+    The fallback must re-read runtime state after that long await, wait for an
+    in-flight explicit load to settle, and never start its default load from the
+    stale pre-download snapshot.
+    """
+    src = _read("features/chat/api/chat-adapter.ts")
+    manager_call = "const downloadResult = await downloadModelWithManager"
+    after_download = src.split(manager_call, 1)[1]
+    default_load = "const loadResp = await loadModel"
+    before_default_load = after_download.split(default_load, 1)[0]
+    compact = " ".join(before_default_load.split())
+
+    state_refresh = "const runtimeAfterDownload = useChatRuntimeStore.getState();"
+    assert state_refresh in compact
+    state_guard = (
+        "runtimeAfterDownload.params.checkpoint || "
+        "runtimeAfterDownload.modelLoading"
+    )
+    assert state_guard in compact
+    assert "await waitForModelReady(abortSignal);" in before_default_load
+    result_guard = "Boolean(useChatRuntimeStore.getState().params.checkpoint)"
+    assert result_guard in compact
+
+
 def test_recipe_model_load_toast_is_persistent_and_dismissible():
     """Recipe model loading uses the same dismissible persistent lifecycle as
     chat loading because both call the non-abortable loadModel API."""

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -1226,12 +1226,8 @@ def test_vulkan_inference_devices_are_the_pickable_set():
 def test_first_chat_default_autoload_revalidates_final_load_snapshot():
     """The load must validate and consume one stable post-transfer snapshot."""
     src = _read("features/chat/api/chat-adapter.ts")
-    after_download = src.split(
-        "const downloadResult = await downloadModelWithManager", 1
-    )[1]
-    before_load, load_and_after = after_download.split(
-        "const loadResp = await loadModel", 1
-    )
+    after_download = src.split("const downloadResult = await downloadModelWithManager", 1)[1]
+    before_load, load_and_after = after_download.split("const loadResp = await loadModel", 1)
 
     assert "for (let attempt = 0; attempt < 3; attempt += 1)" in before_load
     assert "const allowed = await canAutoLoad(" in before_load


### PR DESCRIPTION
## Summary

Route the automatic model download triggered by the first chat message through Studio's global Download Manager. Users can now see its progress and cancel it from Downloads before inference loading begins.

## Motivation

When no model was installed, the first chat message called `/api/inference/load` directly for `unsloth/Qwen3.5-4B-MTP-GGUF`. The backend could download several gigabytes without creating a Download Manager job, leaving users without visible progress or cancellation controls.

## Changes

- Start the default `UD-Q4_K_XL` download through the global Download Manager in `studio/frontend/src/features/chat/api/chat-adapter.ts`.
- Wait for the managed download to complete before calling `/api/inference/load`.
- Add `managed-model-download.ts` to coordinate start outcomes, terminal events, exact GGUF variants, and chat cancellation.
- Handle cancellation that occurs while the Download Manager is still performing its asynchronous start preflight.
- Surface existing conflict and busy states through the first-chat flow.
- Update the loading toast to point users to Downloads.
- Add eight lifecycle tests covering completion, variant filtering, cancellation, delayed-start cancellation, conflicts, busy jobs, and errors.

## How to test

```bash
cd studio/frontend
npm run typecheck
node --experimental-strip-types --test tests/managed-model-download.test.ts
npm run build