### PR TITLE
Desktop: exit the backend when the app that spawned it dies

### DIFF
--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -2055,6 +2055,11 @@ def run_server(
     # The headless `run --api-only` path opts out so it does not leak this line.
     if api_only and emit_tauri_port:
         print(f"TAURI_PORT={port}", flush = True)
+        # If the desktop app dies without running its cleanup (crash, force
+        # quit, killed dev session), exit instead of orphaning on the port.
+        from utils.parent_watchdog import start_parent_watchdog
+
+        start_parent_watchdog(_trigger_shutdown)
 
     # Free trycloudflare.com tunnel for wildcard binds (the raw ip:port is often
     # unreachable). Started pre-banner and even when silent so the CLI banner can

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -2055,10 +2055,20 @@ def run_server(
     # The headless `run --api-only` path opts out so it does not leak this line.
     if api_only and emit_tauri_port:
         print(f"TAURI_PORT={port}", flush = True)
-        # If the desktop app dies without running its cleanup (crash, force
-        # quit, killed dev session), exit instead of orphaning on the port.
-        from utils.parent_watchdog import start_parent_watchdog
-        start_parent_watchdog(_trigger_shutdown)
+        # Desktop-owned backends only (the owner env handshake): a headless
+        # `unsloth studio --api-only` has no app to bind its lifetime to and
+        # must survive its terminal (e.g. nohup). If the app dies without
+        # running its cleanup, exit instead of orphaning on the port.
+        from main import _desktop_owner
+
+        if _desktop_owner() is not None:
+            from utils.parent_watchdog import start_parent_watchdog
+
+            owner_pid = os.environ.pop("UNSLOTH_STUDIO_DESKTOP_OWNER_PID", "")
+            start_parent_watchdog(
+                _trigger_shutdown,
+                parent_pid = int(owner_pid) if owner_pid.isdigit() else None,
+            )
 
     # Free trycloudflare.com tunnel for wildcard binds (the raw ip:port is often
     # unreachable). Started pre-banner and even when silent so the CLI banner can

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -2058,7 +2058,6 @@ def run_server(
         # If the desktop app dies without running its cleanup (crash, force
         # quit, killed dev session), exit instead of orphaning on the port.
         from utils.parent_watchdog import start_parent_watchdog
-
         start_parent_watchdog(_trigger_shutdown)
 
     # Free trycloudflare.com tunnel for wildcard binds (the raw ip:port is often

--- a/studio/backend/run.py
+++ b/studio/backend/run.py
@@ -2060,10 +2060,8 @@ def run_server(
         # must survive its terminal (e.g. nohup). If the app dies without
         # running its cleanup, exit instead of orphaning on the port.
         from main import _desktop_owner
-
         if _desktop_owner() is not None:
             from utils.parent_watchdog import start_parent_watchdog
-
             owner_pid = os.environ.pop("UNSLOTH_STUDIO_DESKTOP_OWNER_PID", "")
             start_parent_watchdog(
                 _trigger_shutdown,

--- a/studio/backend/tests/test_parent_watchdog.py
+++ b/studio/backend/tests/test_parent_watchdog.py
@@ -94,7 +94,10 @@ def _exit():
     open({str(marker)!r}, "w").write("fired")
     os._exit(0)
 
-start_parent_watchdog(_exit, poll_seconds = 0.05)
+# Explicit owner pid, like the production handshake: under a child-subreaper
+# the parent can die and reparent us before this line runs, and a getppid
+# sample here would watch the subreaper forever.
+start_parent_watchdog(_exit, parent_pid = int(sys.argv[1]), poll_seconds = 0.05)
 time.sleep(30)
 os._exit(1)
 """
@@ -102,8 +105,8 @@ os._exit(1)
     parent = tmp_path / "parent.py"
     parent.write_text(
         f"""
-import subprocess, sys
-subprocess.Popen([sys.executable, {str(watcher)!r}])
+import os, subprocess, sys
+subprocess.Popen([sys.executable, {str(watcher)!r}, str(os.getpid())])
 """
     )
 

--- a/studio/backend/tests/test_parent_watchdog.py
+++ b/studio/backend/tests/test_parent_watchdog.py
@@ -43,6 +43,7 @@ def test_fires_immediately_when_already_orphaned(monkeypatch):
     assert fired.is_set()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason = "dispatches to the Windows watcher, which opens the real pid")
 def test_stop_event_ends_the_watch(monkeypatch):
     monkeypatch.setattr(pw.os, "getppid", lambda: 4242)
     fired = threading.Event()
@@ -60,34 +61,15 @@ def test_callback_exception_is_contained():
     pw._fire(_boom)  # must not raise
 
 
-def test_explicit_owner_pid_uses_a_liveness_probe(monkeypatch):
-    # Not our direct parent (e.g. a wrapper in between): probe the owner pid.
-    monkeypatch.setattr(pw.os, "getppid", lambda: 4242)
-
-    def _dead(pid, sig):
-        raise ProcessLookupError
-
-    monkeypatch.setattr(pw.os, "kill", _dead)
+def test_fires_immediately_when_the_owner_is_not_the_current_parent(monkeypatch):
+    # Explicit owner pid but already reparented: the owner died during backend
+    # startup (reaped or zombie alike). Must fire before the first wait.
+    monkeypatch.setattr(pw.os, "getppid", lambda: 7777)
     fired = threading.Event()
-    pw._watch_unix(9999, fired.set, threading.Event(), poll_seconds = 0.01)
+    started = time.monotonic()
+    pw._watch_unix(4242, fired.set, threading.Event(), poll_seconds = 30)
     assert fired.is_set()
-
-
-def test_liveness_probe_treats_eperm_as_alive(monkeypatch):
-    monkeypatch.setattr(pw.os, "getppid", lambda: 4242)
-    calls = {"n": 0}
-
-    def _kill(pid, sig):
-        calls["n"] += 1
-        if calls["n"] < 3:
-            raise PermissionError  # exists, owned by someone else: alive
-        raise ProcessLookupError
-
-    monkeypatch.setattr(pw.os, "kill", _kill)
-    fired = threading.Event()
-    pw._watch_unix(9999, fired.set, threading.Event(), poll_seconds = 0.01)
-    assert fired.is_set()
-    assert calls["n"] == 3
+    assert time.monotonic() - started < 1
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason = "unix reparenting path")

--- a/studio/backend/tests/test_parent_watchdog.py
+++ b/studio/backend/tests/test_parent_watchdog.py
@@ -60,8 +60,42 @@ def test_callback_exception_is_contained():
     pw._fire(_boom)  # must not raise
 
 
+def test_explicit_owner_pid_uses_a_liveness_probe(monkeypatch):
+    # Not our direct parent (e.g. a wrapper in between): probe the owner pid.
+    monkeypatch.setattr(pw.os, "getppid", lambda: 4242)
+
+    def _dead(pid, sig):
+        raise ProcessLookupError
+
+    monkeypatch.setattr(pw.os, "kill", _dead)
+    fired = threading.Event()
+    pw._watch_unix(9999, fired.set, threading.Event(), poll_seconds = 0.01)
+    assert fired.is_set()
+
+
+def test_liveness_probe_treats_eperm_as_alive(monkeypatch):
+    monkeypatch.setattr(pw.os, "getppid", lambda: 4242)
+    calls = {"n": 0}
+
+    def _kill(pid, sig):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise PermissionError  # exists, owned by someone else: alive
+        raise ProcessLookupError
+
+    monkeypatch.setattr(pw.os, "kill", _kill)
+    fired = threading.Event()
+    pw._watch_unix(9999, fired.set, threading.Event(), poll_seconds = 0.01)
+    assert fired.is_set()
+    assert calls["n"] == 3
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason = "unix reparenting path")
 def test_process_exits_when_parent_dies(tmp_path):
+    # The callback writes a marker before exiting: liveness cannot be probed
+    # with kill(pid, 0), which also succeeds while the child is an unreaped
+    # zombie under a non-reaping init.
+    marker = tmp_path / "fired"
     watcher = tmp_path / "watcher.py"
     watcher.write_text(
         f"""
@@ -71,32 +105,31 @@ stub = types.ModuleType("loggers")
 stub.get_logger = lambda name: logging.getLogger(name)
 sys.modules.setdefault("loggers", stub)
 from utils.parent_watchdog import start_parent_watchdog
-start_parent_watchdog(lambda: os._exit(0), poll_seconds = 0.05)
+
+def _exit():
+    open({str(marker)!r}, "w").write("fired")
+    os._exit(0)
+
+start_parent_watchdog(_exit, poll_seconds = 0.05)
 time.sleep(30)
 os._exit(1)
 """
     )
     parent = tmp_path / "parent.py"
-    pidfile = tmp_path / "watcher.pid"
     parent.write_text(
         f"""
 import subprocess, sys
-proc = subprocess.Popen([sys.executable, {str(watcher)!r}])
-open({str(pidfile)!r}, "w").write(str(proc.pid))
+subprocess.Popen([sys.executable, {str(watcher)!r}])
 """
     )
 
     # The intermediate parent spawns the watcher and exits immediately,
     # orphaning it; the watchdog must notice and exit the watcher.
     subprocess.run([sys.executable, str(parent)], check = True, timeout = 15)
-    watcher_pid = int(pidfile.read_text())
 
     deadline = time.monotonic() + 10
     while time.monotonic() < deadline:
-        try:
-            os.kill(watcher_pid, 0)
-        except ProcessLookupError:
+        if marker.exists():
             return
         time.sleep(0.1)
-    os.kill(watcher_pid, 9)
-    pytest.fail("watcher outlived its dead parent")
+    pytest.fail("watchdog never fired after the parent died")

--- a/studio/backend/tests/test_parent_watchdog.py
+++ b/studio/backend/tests/test_parent_watchdog.py
@@ -43,7 +43,9 @@ def test_fires_immediately_when_already_orphaned(monkeypatch):
     assert fired.is_set()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason = "dispatches to the Windows watcher, which opens the real pid")
+@pytest.mark.skipif(
+    sys.platform == "win32", reason = "dispatches to the Windows watcher, which opens the real pid"
+)
 def test_stop_event_ends_the_watch(monkeypatch):
     monkeypatch.setattr(pw.os, "getppid", lambda: 4242)
     fired = threading.Event()

--- a/studio/backend/tests/test_parent_watchdog.py
+++ b/studio/backend/tests/test_parent_watchdog.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+import threading
+import time
+import types as _types
+
+import pytest
+
+
+_BACKEND_DIR = str(Path(__file__).resolve().parent.parent)
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+_loggers_stub = _types.ModuleType("loggers")
+_loggers_stub.get_logger = lambda name: __import__("logging").getLogger(name)
+sys.modules.setdefault("loggers", _loggers_stub)
+
+from utils import parent_watchdog as pw
+
+
+def test_fires_when_reparented(monkeypatch):
+    calls = {"n": 0}
+
+    def _ppid():
+        calls["n"] += 1
+        return 4242 if calls["n"] < 3 else 1
+
+    monkeypatch.setattr(pw.os, "getppid", _ppid)
+    fired = threading.Event()
+    pw._watch_unix(4242, fired.set, threading.Event(), poll_seconds = 0.01)
+    assert fired.is_set()
+
+
+def test_fires_immediately_when_already_orphaned(monkeypatch):
+    monkeypatch.setattr(pw.os, "getppid", lambda: 1)
+    fired = threading.Event()
+    assert pw.start_parent_watchdog(fired.set) is None
+    assert fired.is_set()
+
+
+def test_stop_event_ends_the_watch(monkeypatch):
+    monkeypatch.setattr(pw.os, "getppid", lambda: 4242)
+    fired = threading.Event()
+    stop = pw.start_parent_watchdog(fired.set, poll_seconds = 0.01)
+    assert stop is not None
+    stop.set()
+    time.sleep(0.05)
+    assert not fired.is_set()
+
+
+def test_callback_exception_is_contained():
+    def _boom():
+        raise RuntimeError("shutdown failed")
+
+    pw._fire(_boom)  # must not raise
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason = "unix reparenting path")
+def test_process_exits_when_parent_dies(tmp_path):
+    watcher = tmp_path / "watcher.py"
+    watcher.write_text(
+        f"""
+import logging, os, sys, time, types
+sys.path.insert(0, {_BACKEND_DIR!r})
+stub = types.ModuleType("loggers")
+stub.get_logger = lambda name: logging.getLogger(name)
+sys.modules.setdefault("loggers", stub)
+from utils.parent_watchdog import start_parent_watchdog
+start_parent_watchdog(lambda: os._exit(0), poll_seconds = 0.05)
+time.sleep(30)
+os._exit(1)
+"""
+    )
+    parent = tmp_path / "parent.py"
+    pidfile = tmp_path / "watcher.pid"
+    parent.write_text(
+        f"""
+import subprocess, sys
+proc = subprocess.Popen([sys.executable, {str(watcher)!r}])
+open({str(pidfile)!r}, "w").write(str(proc.pid))
+"""
+    )
+
+    # The intermediate parent spawns the watcher and exits immediately,
+    # orphaning it; the watchdog must notice and exit the watcher.
+    subprocess.run([sys.executable, str(parent)], check = True, timeout = 15)
+    watcher_pid = int(pidfile.read_text())
+
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        try:
+            os.kill(watcher_pid, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.1)
+    os.kill(watcher_pid, 9)
+    pytest.fail("watcher outlived its dead parent")

--- a/studio/backend/utils/parent_watchdog.py
+++ b/studio/backend/utils/parent_watchdog.py
@@ -28,23 +28,46 @@ def _fire(on_parent_exit: Callable[[], None]) -> None:
 
 
 def _watch_unix(parent_pid, on_parent_exit, stop, poll_seconds) -> None:
-    # Reparenting (to init or a subreaper) is the death signal; pids are never
-    # probed, so pid reuse cannot fool this.
+    # Direct child: reparenting is the death signal, immune to pid reuse.
+    # Explicit owner pid with an intermediary in between: liveness-probe it
+    # instead (kill 0); EPERM still means alive.
+    direct_child = os.getppid() == parent_pid
     while not stop.wait(poll_seconds):
-        if os.getppid() != parent_pid:
-            _fire(on_parent_exit)
-            return
+        if direct_child:
+            if os.getppid() != parent_pid:
+                _fire(on_parent_exit)
+                return
+        else:
+            try:
+                os.kill(parent_pid, 0)
+            except ProcessLookupError:
+                _fire(on_parent_exit)
+                return
+            except OSError:
+                pass
 
 
 def _watch_windows(parent_pid, on_parent_exit, stop, poll_seconds) -> None:
     import ctypes
+    from ctypes import wintypes
 
     kernel32 = ctypes.windll.kernel32
+    # Explicit signatures: handles are pointer-sized and would be truncated by
+    # the c_int defaults on 64-bit, leaving the wait on an invalid handle.
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    kernel32.WaitForSingleObject.restype = wintypes.DWORD
+    kernel32.WaitForSingleObject.argtypes = (wintypes.HANDLE, wintypes.DWORD)
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+
     SYNCHRONIZE = 0x00100000
     WAIT_OBJECT_0 = 0
     handle = kernel32.OpenProcess(SYNCHRONIZE, False, parent_pid)
     if not handle:
-        logger.debug("parent_watchdog: OpenProcess(%s) failed", parent_pid)
+        # A same-user owner is always openable, so failure means the parent
+        # already died and its pid went stale: exit, don't abandon the watch.
+        _fire(on_parent_exit)
         return
     try:
         # Bounded waits so a stop request is honored.
@@ -56,13 +79,16 @@ def _watch_windows(parent_pid, on_parent_exit, stop, poll_seconds) -> None:
         kernel32.CloseHandle(handle)
 
 
-# Returns the stop event, or None when the parent was already gone (the
-# callback fires immediately: reparented to init means the app died before
-# the watch could arm, e.g. during a slow backend startup).
+# Watches parent_pid (the spawning app's own pid when it passes one, else the
+# direct parent). Returns the stop event, or None when the parent was already
+# gone at arm time, in which case the callback fires immediately.
 def start_parent_watchdog(
-    on_parent_exit: Callable[[], None], poll_seconds: float = _DEFAULT_POLL_SECONDS
+    on_parent_exit: Callable[[], None],
+    parent_pid: Optional[int] = None,
+    poll_seconds: float = _DEFAULT_POLL_SECONDS,
 ) -> Optional[threading.Event]:
-    parent_pid = os.getppid()
+    if parent_pid is None:
+        parent_pid = os.getppid()
     if parent_pid <= 1:
         _fire(on_parent_exit)
         return None

--- a/studio/backend/utils/parent_watchdog.py
+++ b/studio/backend/utils/parent_watchdog.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+# Exits a desktop-owned backend when the app that spawned it dies without
+# running its cleanup. The orphan would otherwise keep the port and make the
+# next launch's preflight refuse to start.
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+from typing import Callable, Optional
+
+from loggers import get_logger
+
+logger = get_logger(__name__)
+
+_DEFAULT_POLL_SECONDS = 2.0
+
+
+def _fire(on_parent_exit: Callable[[], None]) -> None:
+    logger.info("parent_watchdog.parent_exited: shutting down")
+    try:
+        on_parent_exit()
+    except Exception as exc:
+        logger.warning("parent_watchdog: shutdown callback failed: %s", exc)
+
+
+def _watch_unix(parent_pid, on_parent_exit, stop, poll_seconds) -> None:
+    # Reparenting (to init or a subreaper) is the death signal; pids are never
+    # probed, so pid reuse cannot fool this.
+    while not stop.wait(poll_seconds):
+        if os.getppid() != parent_pid:
+            _fire(on_parent_exit)
+            return
+
+
+def _watch_windows(parent_pid, on_parent_exit, stop, poll_seconds) -> None:
+    import ctypes
+
+    kernel32 = ctypes.windll.kernel32
+    SYNCHRONIZE = 0x00100000
+    WAIT_OBJECT_0 = 0
+    handle = kernel32.OpenProcess(SYNCHRONIZE, False, parent_pid)
+    if not handle:
+        logger.debug("parent_watchdog: OpenProcess(%s) failed", parent_pid)
+        return
+    try:
+        # Bounded waits so a stop request is honored.
+        while not stop.is_set():
+            if kernel32.WaitForSingleObject(handle, int(poll_seconds * 1000)) == WAIT_OBJECT_0:
+                _fire(on_parent_exit)
+                return
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+# Returns the stop event, or None when the parent was already gone (the
+# callback fires immediately: reparented to init means the app died before
+# the watch could arm, e.g. during a slow backend startup).
+def start_parent_watchdog(
+    on_parent_exit: Callable[[], None],
+    poll_seconds: float = _DEFAULT_POLL_SECONDS,
+) -> Optional[threading.Event]:
+    parent_pid = os.getppid()
+    if parent_pid <= 1:
+        _fire(on_parent_exit)
+        return None
+    stop = threading.Event()
+    watch = _watch_windows if sys.platform == "win32" else _watch_unix
+    thread = threading.Thread(
+        target = watch,
+        args = (parent_pid, on_parent_exit, stop, poll_seconds),
+        name = "unsloth-parent-watchdog",
+        daemon = True,
+    )
+    thread.start()
+    logger.info("parent_watchdog.started ppid=%s", parent_pid)
+    return stop

--- a/studio/backend/utils/parent_watchdog.py
+++ b/studio/backend/utils/parent_watchdog.py
@@ -60,8 +60,7 @@ def _watch_windows(parent_pid, on_parent_exit, stop, poll_seconds) -> None:
 # callback fires immediately: reparented to init means the app died before
 # the watch could arm, e.g. during a slow backend startup).
 def start_parent_watchdog(
-    on_parent_exit: Callable[[], None],
-    poll_seconds: float = _DEFAULT_POLL_SECONDS,
+    on_parent_exit: Callable[[], None], poll_seconds: float = _DEFAULT_POLL_SECONDS
 ) -> Optional[threading.Event]:
     parent_pid = os.getppid()
     if parent_pid <= 1:

--- a/studio/backend/utils/parent_watchdog.py
+++ b/studio/backend/utils/parent_watchdog.py
@@ -28,23 +28,17 @@ def _fire(on_parent_exit: Callable[[], None]) -> None:
 
 
 def _watch_unix(parent_pid, on_parent_exit, stop, poll_seconds) -> None:
-    # Direct child: reparenting is the death signal, immune to pid reuse.
-    # Explicit owner pid with an intermediary in between: liveness-probe it
-    # instead (kill 0); EPERM still means alive.
-    direct_child = os.getppid() == parent_pid
-    while not stop.wait(poll_seconds):
-        if direct_child:
-            if os.getppid() != parent_pid:
-                _fire(on_parent_exit)
-                return
-        else:
-            try:
-                os.kill(parent_pid, 0)
-            except ProcessLookupError:
-                _fire(on_parent_exit)
-                return
-            except OSError:
-                pass
+    # The app spawns the backend as its direct child on Unix, so "my parent is
+    # no longer the owner pid" is the death signal: kernel truth, immune to pid
+    # reuse, and indifferent to whether the corpse was reaped (a kill-0 probe
+    # would count an unreaped zombie as alive). Checked before the first wait
+    # so an owner that died during backend startup is caught immediately.
+    while True:
+        if os.getppid() != parent_pid:
+            _fire(on_parent_exit)
+            return
+        if stop.wait(poll_seconds):
+            return
 
 
 def _watch_windows(parent_pid, on_parent_exit, stop, poll_seconds) -> None:

--- a/studio/src-tauri/src/desktop_backend_owner.rs
+++ b/studio/src-tauri/src/desktop_backend_owner.rs
@@ -14,6 +14,9 @@ static TEST_METADATA: std::sync::Mutex<Option<DesktopBackendMetadata>> =
 
 pub(crate) const OWNER_TOKEN_ENV: &str = "UNSLOTH_STUDIO_DESKTOP_OWNER_TOKEN";
 pub(crate) const OWNER_KIND_ENV: &str = "UNSLOTH_STUDIO_DESKTOP_OWNER_KIND";
+// The app's own pid, so the backend can watch the exact owner process instead
+// of sampling getppid (racy under a subreaper when the app dies mid-startup).
+pub(crate) const OWNER_PID_ENV: &str = "UNSLOTH_STUDIO_DESKTOP_OWNER_PID";
 pub(crate) const OWNER_KIND_TAURI: &str = "tauri";
 
 const METADATA_SCHEMA_VERSION: u8 = 1;

--- a/studio/src-tauri/src/process.rs
+++ b/studio/src-tauri/src/process.rs
@@ -594,6 +594,10 @@ pub fn start_backend(
             crate::desktop_backend_owner::OWNER_KIND_ENV,
             crate::desktop_backend_owner::OWNER_KIND_TAURI,
         );
+        cmd.env(
+            crate::desktop_backend_owner::OWNER_PID_ENV,
+            std::process::id().to_string(),
+        );
     }
 
     // AppImage sets LD_LIBRARY_PATH to its bundled libs, which breaks the spawned


### PR DESCRIPTION
If the desktop app dies without running its cleanup (crash, force quit, killed dev session), the backend it spawned keeps running and holds port 8888. The next launch then finds the stale backend and refuses to start with the "backend is too old" screen.

This adds a parent watchdog, armed only for the desktop-owned spawn (--api-only with the TAURI_PORT handshake). It detects parent death via reparenting on Unix and a process-handle wait on Windows, then runs the existing graceful shutdown so the port is released and subprocesses are cleaned up. If the app is already gone by the time the backend finishes starting, it shuts down immediately. Headless unsloth studio run servers opt out of the handshake and are unaffected.