### PR TITLE
Studio: accept x-api-key authentication

### DIFF
--- a/studio/backend/auth/authentication.py
+++ b/studio/backend/auth/authentication.py
@@ -156,8 +156,7 @@ def reload_secret() -> None:
 
 
 def _resolve_credentials(
-    credentials: Optional[HTTPAuthorizationCredentials],
-    x_api_key: Optional[str],
+    credentials: Optional[HTTPAuthorizationCredentials], x_api_key: Optional[str]
 ) -> HTTPAuthorizationCredentials:
     if credentials is not None:
         return credentials

--- a/studio/backend/auth/authentication.py
+++ b/studio/backend/auth/authentication.py
@@ -321,21 +321,36 @@ def reload_secret() -> None:
     load_jwt_secret()
 
 
+def _normalise_x_api_key_dependency(x_api_key: Any) -> Optional[str]:
+    return x_api_key if isinstance(x_api_key, str) else None
+
+
+def _x_api_key_keeps_keyless_admission(x_api_key: str) -> bool:
+    from utils.keyless_api_access import APPROVED_DUMMY_BEARERS
+
+    return x_api_key in APPROVED_DUMMY_BEARERS
+
+
 def _resolve_credentials(
-    credentials: Optional[HTTPAuthorizationCredentials], x_api_key: Optional[str]
+    credentials: Optional[HTTPAuthorizationCredentials], x_api_key: Any
 ) -> HTTPAuthorizationCredentials:
-    if credentials is not None:
+    resolved_x_api_key = _normalise_x_api_key_dependency(x_api_key)
+    if credentials is not None and not is_keyless(credentials):
         return credentials
-    if x_api_key is not None:
-        if not x_api_key.startswith(API_KEY_PREFIX):
+    if resolved_x_api_key is not None:
+        if is_keyless(credentials) and _x_api_key_keeps_keyless_admission(resolved_x_api_key):
+            return credentials
+        if not resolved_x_api_key.startswith(API_KEY_PREFIX):
             raise HTTPException(
                 status_code = status.HTTP_401_UNAUTHORIZED,
-                detail = _invalid_api_key_detail(x_api_key),
+                detail = _invalid_api_key_detail(resolved_x_api_key),
             )
         return HTTPAuthorizationCredentials(
             scheme = X_API_KEY_HEADER,
-            credentials = x_api_key,
+            credentials = resolved_x_api_key,
         )
+    if credentials is not None:
+        return credentials
     raise HTTPException(
         status_code = status.HTTP_401_UNAUTHORIZED,
         detail = NOT_AUTHENTICATED_DETAIL,
@@ -380,9 +395,12 @@ async def authenticated_via_api_key(
     caller too: it is the same programmatic surface, only without the key, so every
     guard an API key faces still applies to it.
     """
-    if is_keyless(credentials):
+    resolved_x_api_key = _normalise_x_api_key_dependency(x_api_key)
+    if is_keyless(credentials) and (
+        resolved_x_api_key is None or _x_api_key_keeps_keyless_admission(resolved_x_api_key)
+    ):
         return True
-    resolved = _resolve_credentials(credentials, x_api_key)
+    resolved = _resolve_credentials(credentials, resolved_x_api_key)
     return resolved.credentials.startswith(API_KEY_PREFIX)
 
 
@@ -414,9 +432,14 @@ async def credentials_for_token(
 
 
 async def authenticated_without_credential(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+    x_api_key: Optional[str] = Depends(x_api_key_security),
 ) -> bool:
     """Dependency form of ``admitted_without_credential``."""
+    resolved_x_api_key = _normalise_x_api_key_dependency(x_api_key)
+    if resolved_x_api_key is not None:
+        resolved = _resolve_credentials(credentials, resolved_x_api_key)
+        return admitted_without_credential(resolved)
     return admitted_without_credential(credentials)
 
 
@@ -447,13 +470,15 @@ async def allow_ambient_hf_token(via_api_key: bool = Depends(authenticated_via_a
 
 
 async def authenticated_via_desktop_jwt(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
 ) -> bool:
     """True when the caller is the local desktop app, not a browser session or API key.
 
     Lets routes treat the desktop as an authority of its own: it authenticates
     with a local secret rather than the account password.
     """
+    if credentials is None or is_keyless(credentials):
+        return False
     return await run_in_threadpool(is_desktop_access_token, credentials.credentials)
 
 

--- a/studio/backend/auth/authentication.py
+++ b/studio/backend/auth/authentication.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Optional, Tuple
 
 from fastapi import Depends, HTTPException, Request, status
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
 from fastapi.security.utils import get_authorization_scheme_param
 import jwt
 from starlette.concurrency import run_in_threadpool
@@ -26,6 +26,8 @@ from .storage import (
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60
 REFRESH_TOKEN_EXPIRE_DAYS = 7
+X_API_KEY_HEADER = "x-api-key"
+NOT_AUTHENTICATED_DETAIL = "Not authenticated"
 
 # internal schemes, never sent by a client: no token at all, and a token to ignore if unusable
 KEYLESS_SCHEME = "Keyless"
@@ -187,7 +189,11 @@ class _BearerOrKeyless(HTTPBearer):
 
 
 # scheme_name pinned so the OpenAPI securitySchemes entry keeps its published name
-security = _BearerOrKeyless(scheme_name = "HTTPBearer")  # Reads Authorization: Bearer <token>
+security = _BearerOrKeyless(
+    auto_error = False,
+    scheme_name = "HTTPBearer",
+)  # Reads Authorization: Bearer <token>
+x_api_key_security = APIKeyHeader(name = X_API_KEY_HEADER, auto_error = False)
 
 
 def _get_secret_for_subject(subject: str) -> str:
@@ -315,17 +321,43 @@ def reload_secret() -> None:
     load_jwt_secret()
 
 
-async def get_current_subject(credentials: HTTPAuthorizationCredentials = Depends(security)) -> str:
+def _resolve_credentials(
+    credentials: Optional[HTTPAuthorizationCredentials],
+    x_api_key: Optional[str],
+) -> HTTPAuthorizationCredentials:
+    if credentials is not None:
+        return credentials
+    if x_api_key is not None:
+        if not x_api_key.startswith(API_KEY_PREFIX):
+            raise HTTPException(
+                status_code = status.HTTP_401_UNAUTHORIZED,
+                detail = _invalid_api_key_detail(x_api_key),
+            )
+        return HTTPAuthorizationCredentials(
+            scheme = X_API_KEY_HEADER,
+            credentials = x_api_key,
+        )
+    raise HTTPException(
+        status_code = status.HTTP_401_UNAUTHORIZED,
+        detail = NOT_AUTHENTICATED_DETAIL,
+    )
+
+
+async def get_current_subject(
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+    x_api_key: Optional[str] = Depends(x_api_key_security),
+) -> str:
     """Validate JWT and require the password-change flow to be completed."""
     subject, _generation = await _get_current_credential(
-        credentials,
+        _resolve_credentials(credentials, x_api_key),
         allow_password_change = False,
     )
     return subject
 
 
 async def get_current_credential(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+    x_api_key: Optional[str] = Depends(x_api_key_security),
 ) -> Tuple[str, Optional[str]]:
     """As get_current_subject, but also returns the credential generation.
 
@@ -333,13 +365,14 @@ async def get_current_credential(
     a concurrent reset has revoked.
     """
     return await _get_current_credential(
-        credentials,
+        _resolve_credentials(credentials, x_api_key),
         allow_password_change = False,
     )
 
 
 async def authenticated_via_api_key(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+    x_api_key: Optional[str] = Depends(x_api_key_security),
 ) -> bool:
     """True when the caller used an sk-unsloth API key, not a UI session JWT.
 
@@ -350,7 +383,8 @@ async def authenticated_via_api_key(
     """
     if is_keyless(credentials):
         return True
-    return bool(credentials and credentials.credentials.startswith(API_KEY_PREFIX))
+    resolved = _resolve_credentials(credentials, x_api_key)
+    return resolved.credentials.startswith(API_KEY_PREFIX)
 
 
 async def credentials_for_token(
@@ -425,11 +459,12 @@ async def authenticated_via_desktop_jwt(
 
 
 async def get_current_subject_allow_password_change(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+    x_api_key: Optional[str] = Depends(x_api_key_security),
 ) -> str:
     """Validate JWT but allow access to the password-change endpoint."""
     subject, _generation = await _get_current_credential(
-        credentials,
+        _resolve_credentials(credentials, x_api_key),
         allow_password_change = True,
     )
     return subject

--- a/studio/backend/auth/authentication.py
+++ b/studio/backend/auth/authentication.py
@@ -322,8 +322,7 @@ def reload_secret() -> None:
 
 
 def _resolve_credentials(
-    credentials: Optional[HTTPAuthorizationCredentials],
-    x_api_key: Optional[str],
+    credentials: Optional[HTTPAuthorizationCredentials], x_api_key: Optional[str]
 ) -> HTTPAuthorizationCredentials:
     if credentials is not None:
         return credentials

--- a/studio/backend/auth/authentication.py
+++ b/studio/backend/auth/authentication.py
@@ -327,7 +327,6 @@ def _normalise_x_api_key_dependency(x_api_key: Any) -> Optional[str]:
 
 def _x_api_key_keeps_keyless_admission(x_api_key: str) -> bool:
     from utils.keyless_api_access import APPROVED_DUMMY_BEARERS
-
     return x_api_key in APPROVED_DUMMY_BEARERS
 
 

--- a/studio/backend/auth/authentication.py
+++ b/studio/backend/auth/authentication.py
@@ -27,6 +27,7 @@ ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60
 REFRESH_TOKEN_EXPIRE_DAYS = 7
 X_API_KEY_HEADER = "x-api-key"
+X_API_KEY_HEADER_NAME = X_API_KEY_HEADER.encode("ascii")
 NOT_AUTHENTICATED_DETAIL = "Not authenticated"
 
 # internal schemes, never sent by a client: no token at all, and a token to ignore if unusable
@@ -185,7 +186,12 @@ class _BearerOrKeyless(HTTPBearer):
             )
         if usable_bearer:
             return HTTPAuthorizationCredentials(scheme = scheme, credentials = token)
-        return await super().__call__(request)
+        has_x_api_key = any(
+            bytes(name).lower() == X_API_KEY_HEADER_NAME for name, _value in raw_headers
+        )
+        if has_x_api_key:
+            return None
+        return await strict_bearer_security(request)
 
 
 # scheme_name pinned so the OpenAPI securitySchemes entry keeps its published name
@@ -194,6 +200,7 @@ security = _BearerOrKeyless(
     scheme_name = "HTTPBearer",
 )  # Reads Authorization: Bearer <token>
 x_api_key_security = APIKeyHeader(name = X_API_KEY_HEADER, auto_error = False)
+strict_bearer_security = HTTPBearer(auto_error = True, scheme_name = "HTTPBearer")
 
 
 def _get_secret_for_subject(subject: str) -> str:

--- a/studio/backend/auth/authentication.py
+++ b/studio/backend/auth/authentication.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional, Tuple
 
 from fastapi import Depends, HTTPException, status
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
 import jwt
 
 from .storage import (
@@ -23,8 +23,11 @@ from .storage import (
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60
 REFRESH_TOKEN_EXPIRE_DAYS = 7
+X_API_KEY_HEADER = "x-api-key"
+NOT_AUTHENTICATED_DETAIL = "Not authenticated"
 
-security = HTTPBearer()  # Reads Authorization: Bearer <token>
+security = HTTPBearer(auto_error = False)  # Reads Authorization: Bearer <token>
+x_api_key_security = APIKeyHeader(name = X_API_KEY_HEADER, auto_error = False)
 
 
 def _get_secret_for_subject(subject: str) -> str:
@@ -152,17 +155,43 @@ def reload_secret() -> None:
     load_jwt_secret()
 
 
-async def get_current_subject(credentials: HTTPAuthorizationCredentials = Depends(security)) -> str:
+def _resolve_credentials(
+    credentials: Optional[HTTPAuthorizationCredentials],
+    x_api_key: Optional[str],
+) -> HTTPAuthorizationCredentials:
+    if credentials is not None:
+        return credentials
+    if x_api_key is not None:
+        if not x_api_key.startswith(API_KEY_PREFIX):
+            raise HTTPException(
+                status_code = status.HTTP_401_UNAUTHORIZED,
+                detail = _invalid_api_key_detail(x_api_key),
+            )
+        return HTTPAuthorizationCredentials(
+            scheme = X_API_KEY_HEADER,
+            credentials = x_api_key,
+        )
+    raise HTTPException(
+        status_code = status.HTTP_401_UNAUTHORIZED,
+        detail = NOT_AUTHENTICATED_DETAIL,
+    )
+
+
+async def get_current_subject(
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+    x_api_key: Optional[str] = Depends(x_api_key_security),
+) -> str:
     """Validate JWT and require the password-change flow to be completed."""
     subject, _generation = await _get_current_credential(
-        credentials,
+        _resolve_credentials(credentials, x_api_key),
         allow_password_change = False,
     )
     return subject
 
 
 async def get_current_credential(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+    x_api_key: Optional[str] = Depends(x_api_key_security),
 ) -> Tuple[str, Optional[str]]:
     """As get_current_subject, but also returns the credential generation.
 
@@ -170,20 +199,22 @@ async def get_current_credential(
     a concurrent reset has revoked.
     """
     return await _get_current_credential(
-        credentials,
+        _resolve_credentials(credentials, x_api_key),
         allow_password_change = False,
     )
 
 
 async def authenticated_via_api_key(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+    x_api_key: Optional[str] = Depends(x_api_key_security),
 ) -> bool:
     """True when the caller used an sk-unsloth API key, not a UI session JWT.
 
     Lets routes treat programmatic API callers differently from the Unsloth UI
     (e.g. refuse a teardown the UI would allow).
     """
-    return bool(credentials and credentials.credentials.startswith(API_KEY_PREFIX))
+    resolved = _resolve_credentials(credentials, x_api_key)
+    return resolved.credentials.startswith(API_KEY_PREFIX)
 
 
 def require_ui_session_for_local_commands(via_api_key: bool) -> None:
@@ -224,11 +255,12 @@ async def authenticated_via_desktop_jwt(
 
 
 async def get_current_subject_allow_password_change(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+    x_api_key: Optional[str] = Depends(x_api_key_security),
 ) -> str:
     """Validate JWT but allow access to the password-change endpoint."""
     subject, _generation = await _get_current_credential(
-        credentials,
+        _resolve_credentials(credentials, x_api_key),
         allow_password_change = True,
     )
     return subject

--- a/studio/backend/tests/test_keyless_api_access.py
+++ b/studio/backend/tests/test_keyless_api_access.py
@@ -28,6 +28,7 @@ from auth.authentication import (
 )
 from utils.keyless_api_access import (
     KeylessToolPolicyMiddleware,
+    X_API_KEY_HEADER_NAME,
     KEYLESS_ADMISSION_STATE_KEY,
     KEYLESS_API_ACCESS_SETTING_KEY,
     _reset_scope_cache,
@@ -781,6 +782,13 @@ def test_credentials_never_downgrade_to_keyless():
             asgi_scope(headers = {"x-api-key": token}),
             ("inference", False),
         )
+    duplicate_x_api_key_scope = asgi_scope()
+    duplicate_x_api_key_scope["headers"] = [
+        (X_API_KEY_HEADER_NAME, b"not-needed"),
+        (X_API_KEY_HEADER_NAME, b"not-needed"),
+    ]
+    assert not asgi_request_is_keyless(duplicate_x_api_key_scope, ("inference", False))
+
     set_keyless_api_access("inference")
     with pytest.raises(HTTPException):
         subject_of(bearer_request("not-needed", path = "/v1/load"))

--- a/studio/backend/tests/test_keyless_api_access.py
+++ b/studio/backend/tests/test_keyless_api_access.py
@@ -777,6 +777,10 @@ def test_credentials_never_downgrade_to_keyless():
     assert resolve(request_for()).scheme == KEYLESS_SCHEME
     for token in ("not-needed", "lm-studio", "ollama"):
         assert resolve(bearer_request(token)).scheme == KEYLESS_FALLBACK_SCHEME
+        assert asgi_request_is_keyless(
+            asgi_scope(headers = {"x-api-key": token}),
+            ("inference", False),
+        )
     set_keyless_api_access("inference")
     with pytest.raises(HTTPException):
         subject_of(bearer_request("not-needed", path = "/v1/load"))
@@ -803,6 +807,10 @@ def test_credentials_never_downgrade_to_keyless():
     valid, _ = storage.create_api_key(
         username = storage.DEFAULT_ADMIN_USERNAME, name = "valid", expires_at = None)
     assert subject_of(bearer_request(valid)) == storage.DEFAULT_ADMIN_USERNAME
+    assert not asgi_request_is_keyless(
+        asgi_scope(headers = {"x-api-key": valid}),
+        ("inference", False),
+    )
     for name, expires in (
         ("expired", (datetime.now(timezone.utc) - timedelta(days = 1)).isoformat()),
         ("revoked", None),

--- a/studio/backend/tests/test_x_api_key_auth.py
+++ b/studio/backend/tests/test_x_api_key_auth.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+from fastapi import Depends, FastAPI, status
+from fastapi.testclient import TestClient
+
+from auth import authentication
+
+
+API_KEY = f"{authentication.API_KEY_PREFIX}office"
+CREDENTIAL_SECRET = "credential-secret"
+INVALID_API_KEY = f"{authentication.API_KEY_PREFIX}invalid"
+JWT_LIKE_TOKEN = "header.payload.signature"
+SUBJECT = "office-user"
+TEST_PATH = "/protected"
+VIA_API_KEY_PATH = "/via-api-key"
+CREDENTIAL_PATH = "/credential"
+PASSWORD_CHANGE_PATH = "/password-change"
+
+
+def _protected_route(subject: str = Depends(authentication.get_current_subject)) -> dict[str, str]:
+    return {"subject": subject}
+
+
+def _via_api_key_route(
+    via_api_key: bool = Depends(authentication.authenticated_via_api_key),
+) -> dict[str, bool]:
+    return {"via_api_key": via_api_key}
+
+
+def _credential_route(
+    credential: tuple[str, str | None] = Depends(authentication.get_current_credential),
+) -> dict[str, str | None]:
+    subject, generation = credential
+    return {"subject": subject, "generation": generation}
+
+
+def _password_change_route(
+    subject: str = Depends(authentication.get_current_subject_allow_password_change),
+) -> dict[str, str]:
+    return {"subject": subject}
+
+
+def test_x_api_key_authenticates_protected_routes(monkeypatch) -> None:
+    app = FastAPI()
+    app.get(TEST_PATH)(_protected_route)
+    monkeypatch.setattr(
+        authentication,
+        "validate_api_key_with_credential",
+        lambda token: (SUBJECT, CREDENTIAL_SECRET) if token == API_KEY else None,
+    )
+
+    response = TestClient(app).get(
+        TEST_PATH,
+        headers = {authentication.X_API_KEY_HEADER: API_KEY},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"subject": SUBJECT}
+
+
+def test_x_api_key_is_reported_as_programmatic_auth() -> None:
+    app = FastAPI()
+    app.get(VIA_API_KEY_PATH)(_via_api_key_route)
+
+    response = TestClient(app).get(
+        VIA_API_KEY_PATH,
+        headers = {authentication.X_API_KEY_HEADER: API_KEY},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"via_api_key": True}
+
+
+def test_x_api_key_preserves_credential_generation(monkeypatch) -> None:
+    app = FastAPI()
+    app.get(CREDENTIAL_PATH)(_credential_route)
+    monkeypatch.setattr(
+        authentication,
+        "validate_api_key_with_credential",
+        lambda token: (SUBJECT, CREDENTIAL_SECRET) if token == API_KEY else None,
+    )
+
+    response = TestClient(app).get(
+        CREDENTIAL_PATH,
+        headers = {authentication.X_API_KEY_HEADER: API_KEY},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {
+        "subject": SUBJECT,
+        "generation": authentication.credential_generation(CREDENTIAL_SECRET),
+    }
+
+
+def test_x_api_key_allows_password_change_dependency(monkeypatch) -> None:
+    app = FastAPI()
+    app.get(PASSWORD_CHANGE_PATH)(_password_change_route)
+    monkeypatch.setattr(
+        authentication,
+        "validate_api_key_with_credential",
+        lambda token: (SUBJECT, CREDENTIAL_SECRET) if token == API_KEY else None,
+    )
+
+    response = TestClient(app).get(
+        PASSWORD_CHANGE_PATH,
+        headers = {authentication.X_API_KEY_HEADER: API_KEY},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"subject": SUBJECT}
+
+
+def test_invalid_x_api_key_is_rejected(monkeypatch) -> None:
+    app = FastAPI()
+    app.get(TEST_PATH)(_protected_route)
+    monkeypatch.setattr(authentication, "validate_api_key_with_credential", lambda _token: None)
+
+    response = TestClient(app).get(
+        TEST_PATH,
+        headers = {authentication.X_API_KEY_HEADER: INVALID_API_KEY},
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == {"detail": authentication._invalid_api_key_detail(INVALID_API_KEY)}
+
+
+def test_x_api_key_header_rejects_session_tokens() -> None:
+    app = FastAPI()
+    app.get(TEST_PATH)(_protected_route)
+
+    response = TestClient(app).get(
+        TEST_PATH,
+        headers = {authentication.X_API_KEY_HEADER: JWT_LIKE_TOKEN},
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == {"detail": authentication._invalid_api_key_detail(JWT_LIKE_TOKEN)}
+
+
+def test_missing_credentials_are_rejected() -> None:
+    app = FastAPI()
+    app.get(TEST_PATH)(_protected_route)
+
+    response = TestClient(app).get(TEST_PATH)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.json() == {"detail": authentication.NOT_AUTHENTICATED_DETAIL}

--- a/studio/backend/tests/test_x_api_key_auth.py
+++ b/studio/backend/tests/test_x_api_key_auth.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+from __future__ import annotations
+
 import asyncio
 
 from fastapi import Depends, FastAPI, HTTPException, status

--- a/studio/backend/tests/test_x_api_key_auth.py
+++ b/studio/backend/tests/test_x_api_key_auth.py
@@ -1,7 +1,10 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-from fastapi import Depends, FastAPI, status
+import asyncio
+
+from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials
 from fastapi.testclient import TestClient
 
 from auth import authentication
@@ -9,6 +12,8 @@ from auth import authentication
 
 API_KEY = f"{authentication.API_KEY_PREFIX}office"
 CREDENTIAL_SECRET = "credential-secret"
+KEYLESS_ADMIN_SECRET = "keyless-admin-secret"
+DUMMY_X_API_KEY = "not-needed"
 INVALID_API_KEY = f"{authentication.API_KEY_PREFIX}invalid"
 JWT_LIKE_TOKEN = "header.payload.signature"
 SUBJECT = "office-user"
@@ -16,6 +21,8 @@ TEST_PATH = "/protected"
 VIA_API_KEY_PATH = "/via-api-key"
 CREDENTIAL_PATH = "/credential"
 PASSWORD_CHANGE_PATH = "/password-change"
+DESKTOP_ONLY_PATH = "/desktop-only"
+DESKTOP_REQUIRED_DETAIL = "This action requires the Unsloth desktop app."
 
 
 def _protected_route(subject: str = Depends(authentication.get_current_subject)) -> dict[str, str]:
@@ -38,6 +45,18 @@ def _credential_route(
 def _password_change_route(
     subject: str = Depends(authentication.get_current_subject_allow_password_change),
 ) -> dict[str, str]:
+    return {"subject": subject}
+
+
+def _desktop_only_route(
+    subject: str = Depends(authentication.get_current_subject_allow_password_change),
+    is_desktop: bool = Depends(authentication.authenticated_via_desktop_jwt),
+) -> dict[str, str]:
+    if not is_desktop:
+        raise HTTPException(
+            status_code = status.HTTP_403_FORBIDDEN,
+            detail = DESKTOP_REQUIRED_DETAIL,
+        )
     return {"subject": subject}
 
 
@@ -72,6 +91,19 @@ def test_x_api_key_is_reported_as_programmatic_auth() -> None:
     assert response.json() == {"via_api_key": True}
 
 
+def test_bearer_api_key_is_still_reported_as_programmatic_auth() -> None:
+    app = FastAPI()
+    app.get(VIA_API_KEY_PATH)(_via_api_key_route)
+
+    response = TestClient(app).get(
+        VIA_API_KEY_PATH,
+        headers = {"Authorization": f"Bearer {API_KEY}"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"via_api_key": True}
+
+
 def test_x_api_key_preserves_credential_generation(monkeypatch) -> None:
     app = FastAPI()
     app.get(CREDENTIAL_PATH)(_credential_route)
@@ -93,6 +125,113 @@ def test_x_api_key_preserves_credential_generation(monkeypatch) -> None:
     }
 
 
+def test_x_api_key_takes_precedence_over_keyless_admission(monkeypatch) -> None:
+    monkeypatch.setattr(
+        authentication,
+        "validate_api_key_with_credential",
+        lambda token: (SUBJECT, CREDENTIAL_SECRET) if token == API_KEY else None,
+    )
+    monkeypatch.setattr(
+        authentication,
+        "get_user_and_secret",
+        lambda username: (
+            ("salt", "hash", KEYLESS_ADMIN_SECRET, False)
+            if username == authentication.DEFAULT_ADMIN_USERNAME
+            else None
+        ),
+    )
+
+    subject, generation = asyncio.run(
+        authentication.get_current_credential(authentication._KEYLESS_CREDENTIALS, API_KEY)
+    )
+
+    assert subject == SUBJECT
+    assert generation == authentication.credential_generation(CREDENTIAL_SECRET)
+
+
+def test_x_api_key_is_not_reported_as_credentialless_keyless_auth() -> None:
+    assert (
+        asyncio.run(
+            authentication.authenticated_without_credential(
+                authentication._KEYLESS_CREDENTIALS,
+                API_KEY,
+            )
+        )
+        is False
+    )
+
+
+def test_keyless_admission_still_resolves_to_admin_without_x_api_key(monkeypatch) -> None:
+    monkeypatch.setattr(
+        authentication,
+        "get_user_and_secret",
+        lambda username: (
+            ("salt", "hash", KEYLESS_ADMIN_SECRET, False)
+            if username == authentication.DEFAULT_ADMIN_USERNAME
+            else None
+        ),
+    )
+
+    subject, generation = asyncio.run(
+        authentication.get_current_credential(authentication._KEYLESS_CREDENTIALS)
+    )
+
+    assert subject == authentication.DEFAULT_ADMIN_USERNAME
+    assert generation == authentication.credential_generation(KEYLESS_ADMIN_SECRET)
+
+
+def test_keyless_admission_still_counts_as_programmatic_without_x_api_key() -> None:
+    assert asyncio.run(authentication.authenticated_via_api_key(authentication._KEYLESS_CREDENTIALS))
+
+
+def test_dummy_x_api_key_keeps_keyless_admission(monkeypatch) -> None:
+    monkeypatch.setattr(
+        authentication,
+        "get_user_and_secret",
+        lambda username: (
+            ("salt", "hash", KEYLESS_ADMIN_SECRET, False)
+            if username == authentication.DEFAULT_ADMIN_USERNAME
+            else None
+        ),
+    )
+
+    subject, generation = asyncio.run(
+        authentication.get_current_credential(
+            authentication._KEYLESS_CREDENTIALS,
+            DUMMY_X_API_KEY,
+        )
+    )
+
+    assert subject == authentication.DEFAULT_ADMIN_USERNAME
+    assert generation == authentication.credential_generation(KEYLESS_ADMIN_SECRET)
+    assert (
+        asyncio.run(
+            authentication.authenticated_without_credential(
+                authentication._KEYLESS_CREDENTIALS,
+                DUMMY_X_API_KEY,
+            )
+        )
+        is True
+    )
+
+
+def test_bearer_credentials_take_precedence_over_dummy_x_api_key() -> None:
+    credentials = HTTPAuthorizationCredentials(
+        scheme = "Bearer",
+        credentials = API_KEY,
+    )
+
+    assert (
+        asyncio.run(
+            authentication.authenticated_without_credential(
+                credentials,
+                DUMMY_X_API_KEY,
+            )
+        )
+        is False
+    )
+
+
 def test_x_api_key_allows_password_change_dependency(monkeypatch) -> None:
     app = FastAPI()
     app.get(PASSWORD_CHANGE_PATH)(_password_change_route)
@@ -109,6 +248,24 @@ def test_x_api_key_allows_password_change_dependency(monkeypatch) -> None:
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {"subject": SUBJECT}
+
+
+def test_x_api_key_password_change_routes_reach_desktop_guard(monkeypatch) -> None:
+    app = FastAPI()
+    app.get(DESKTOP_ONLY_PATH)(_desktop_only_route)
+    monkeypatch.setattr(
+        authentication,
+        "validate_api_key_with_credential",
+        lambda token: (SUBJECT, CREDENTIAL_SECRET) if token == API_KEY else None,
+    )
+
+    response = TestClient(app, raise_server_exceptions = False).get(
+        DESKTOP_ONLY_PATH,
+        headers = {authentication.X_API_KEY_HEADER: API_KEY},
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.json() == {"detail": DESKTOP_REQUIRED_DETAIL}
 
 
 def test_invalid_x_api_key_is_rejected(monkeypatch) -> None:

--- a/studio/backend/tests/test_x_api_key_auth.py
+++ b/studio/backend/tests/test_x_api_key_auth.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
 from fastapi import Depends, FastAPI, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials
 from fastapi.testclient import TestClient
@@ -60,6 +61,15 @@ def _desktop_only_route(
             detail = DESKTOP_REQUIRED_DETAIL,
         )
     return {"subject": subject}
+
+
+def test_reload_secret_delegates_to_loader(monkeypatch) -> None:
+    observed = []
+    monkeypatch.setattr(authentication, "load_jwt_secret", lambda: observed.append(True))
+
+    authentication.reload_secret()
+
+    assert observed == [True]
 
 
 def test_x_api_key_authenticates_protected_routes(monkeypatch) -> None:
@@ -307,3 +317,11 @@ def test_missing_credentials_are_rejected() -> None:
 
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     assert response.json() == {"detail": authentication.NOT_AUTHENTICATED_DETAIL}
+
+
+def test_dependency_rejects_missing_credentials_when_security_yields_none() -> None:
+    with pytest.raises(HTTPException) as caught:
+        asyncio.run(authentication.get_current_subject(None, None))
+
+    assert caught.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert caught.value.detail == authentication.NOT_AUTHENTICATED_DETAIL

--- a/studio/backend/tests/test_x_api_key_auth.py
+++ b/studio/backend/tests/test_x_api_key_auth.py
@@ -181,7 +181,9 @@ def test_keyless_admission_still_resolves_to_admin_without_x_api_key(monkeypatch
 
 
 def test_keyless_admission_still_counts_as_programmatic_without_x_api_key() -> None:
-    assert asyncio.run(authentication.authenticated_via_api_key(authentication._KEYLESS_CREDENTIALS))
+    assert asyncio.run(
+        authentication.authenticated_via_api_key(authentication._KEYLESS_CREDENTIALS)
+    )
 
 
 def test_dummy_x_api_key_keeps_keyless_admission(monkeypatch) -> None:

--- a/studio/backend/utils/keyless_api_access.py
+++ b/studio/backend/utils/keyless_api_access.py
@@ -42,6 +42,8 @@ KEYLESS_SCOPES = (KEYLESS_SCOPE_OFF, KEYLESS_SCOPE_INFERENCE, KEYLESS_SCOPE_FULL
 DEFAULT_KEYLESS_API_ACCESS_SCOPE = KEYLESS_SCOPE_OFF
 APPROVED_DUMMY_BEARERS = frozenset({"not-needed", "lm-studio", "ollama"})
 KEYLESS_ADMISSION_STATE_KEY = "keyless_api_admitted"
+AUTHORIZATION_HEADER_NAME = b"authorization"
+X_API_KEY_HEADER_NAME = b"x-api-key"
 
 # Named by method and normalized path: /v1 also aliases model loading, media,
 # sandbox, validation, and streaming side-effect routes.
@@ -681,11 +683,14 @@ def asgi_request_is_keyless(asgi_scope, settings: Optional[tuple[str, bool]] = N
     )
     if not allowed:
         return False
-    authorization = [
-        bytes(value).decode("latin-1")
-        for name, value in asgi_scope.get("headers") or ()
-        if bytes(name).lower() == b"authorization"
-    ]
+    headers = asgi_scope.get("headers") or ()
+    authorization = _asgi_header_values(headers, AUTHORIZATION_HEADER_NAME)
+    x_api_keys = _asgi_header_values(headers, X_API_KEY_HEADER_NAME)
+    if len(x_api_keys) > 1:
+        return False
+    if x_api_keys:
+        if x_api_keys[0] not in APPROVED_DUMMY_BEARERS:
+            return False
     if not authorization:
         return True
     if len(authorization) != 1:
@@ -700,3 +705,11 @@ def asgi_request_is_keyless(asgi_scope, settings: Optional[tuple[str, bool]] = N
 
     scheme, token = get_authorization_scheme_param(authorization[0])
     return bool(scheme.lower() == "bearer" and token in APPROVED_DUMMY_BEARERS)
+
+
+def _asgi_header_values(headers: Any, name_to_match: bytes) -> list[str]:
+    return [
+        bytes(value).decode("latin-1")
+        for name, value in headers
+        if bytes(name).lower() == name_to_match
+    ]


### PR DESCRIPTION
## Summary

- accept Studio API keys from the `x-api-key` header while preserving Bearer authentication
- route header credentials through the existing API-key validation and credential-generation checks
- keep rebased keyless API access semantics consistent: real `sk-unsloth` header keys authenticate as credentials, dummy SDK keys stay keyless, and desktop-only guards treat header-key callers as non-desktop instead of erroring
- expose both authentication alternatives in FastAPI/OpenAPI and cover invalid, missing, session-token, keyless, and dual-header cases

Closes #6399

## Test verification (RED -> GREEN)

RED before the follow-up fix:

- `tests/test_x_api_key_auth.py::test_x_api_key_password_change_routes_reach_desktop_guard` failed with `assert 500 == 403`, reproducing the reviewer's missing-bearer `authenticated_via_desktop_jwt` failure for an `x-api-key` password-change route.
- `tests/test_x_api_key_auth.py::test_x_api_key_takes_precedence_over_keyless_admission` failed with `assert 'unsloth' == 'office-user'`, showing synthetic keyless credentials shadowed a real header API key after the rebase.
- `tests/test_x_api_key_auth.py::test_dummy_x_api_key_keeps_keyless_admission` raised `HTTPException: 401`, showing dummy SDK `x-api-key` values no longer stayed keyless.
- `tests/test_keyless_api_access.py::test_credentials_never_downgrade_to_keyless` failed because `asgi_request_is_keyless(...)` returned `True` for a real `sk-unsloth` `x-api-key`.

GREEN after the fix:

- `./run-ci.sh` final: 18 passed, 1 warning; Ruff and `py_compile` passed for the changed auth/keyless modules and tests; Python changed-line coverage passed at 40/40 changed executable lines.
- Keyless regression replay: `test_tool_policy_and_api_identity`, `test_scope_off_is_refused_by_the_security_dependency_not_only_the_predicate`, and `test_the_asgi_twin_agrees_with_the_dependency_on_header_shapes` passed locally after preserving strict Bearer failures when no `x-api-key` is present.

- `python -m pytest -v --tb=short tests/test_python39_compatibility.py::test_studio_evaluated_unions_do_not_grow`: passed locally after adding the required future annotations import.

- `./run-ci.sh` baseline on `origin/main`: applicable syntax/lint passed; existing keyless auth test passed; the new x-api-key test file is absent on baseline.

Earlier branch validation remains relevant for the original PR scope:

- real `GET /v1/models` HTTP smoke with `x-api-key` and no Bearer header: passed
- targeted auth/desktop suite: passed before the rebase follow-up; the rebased local gate above covers the reviewed auth/keyless paths
- repo CPU suite had the documented pre-existing environment-dependent disk-space failure (`test_window_without_kv_dims_still_saves`) on both upstream `main` and this branch; this follow-up does not touch the root `unsloth/` package



