### PR TITLE
Studio: Fix hub search input overlapping the format filter at narrow widths

### DIFF
--- a/studio/frontend/src/features/hub/catalog/models-toolbar.tsx
+++ b/studio/frontend/src/features/hub/catalog/models-toolbar.tsx
@@ -172,7 +172,7 @@ export const ModelsToolbar = memo(function ModelsToolbar({
     "focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:border-border",
   );
   return (
-    <div className="flex min-w-0 flex-col gap-2 lg:flex-row lg:flex-nowrap lg:items-center">
+    <div className="flex min-w-0 flex-col gap-2 lg:flex-row lg:flex-wrap lg:items-center">
       <div
         className={cn(
           "hub-menu-trigger hub-tab-toggle relative inline-flex h-9 w-full shrink-0 items-center rounded-full lg:w-[280px]",
@@ -218,7 +218,7 @@ export const ModelsToolbar = memo(function ModelsToolbar({
         </button>
       </div>
 
-      <div className="relative min-w-0 flex-1 lg:flex-[1_1_360px]">
+      <div className="relative min-w-0 flex-1 lg:min-w-[220px] lg:flex-[1_1_220px]">
         <HugeiconsIcon
           icon={Search01Icon}
           strokeWidth={1.8}

--- a/studio/frontend/src/features/hub/catalog/models-toolbar.tsx
+++ b/studio/frontend/src/features/hub/catalog/models-toolbar.tsx
@@ -20,7 +20,7 @@ import {
   SlidersHorizontalIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { memo, useMemo, useState } from "react";
+import { memo, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
   clearRecentSearches,
   recordRecentSearch,
@@ -106,6 +106,31 @@ export const ModelsToolbar = memo(function ModelsToolbar({
     query.trim() === "" &&
     recentSearches.length > 0;
 
+  // Anchored to the toolbar bottom so wrapped filter rows stay clickable.
+  const toolbarRef = useRef<HTMLDivElement | null>(null);
+  const searchWrapRef = useRef<HTMLDivElement | null>(null);
+  const [recentPanelTop, setRecentPanelTop] = useState<number | undefined>();
+  useLayoutEffect(() => {
+    if (!showRecentSearches) {
+      return;
+    }
+    const measure = () => {
+      const toolbar = toolbarRef.current;
+      const wrap = searchWrapRef.current;
+      if (!(toolbar && wrap)) {
+        return;
+      }
+      setRecentPanelTop(
+        toolbar.getBoundingClientRect().bottom -
+          wrap.getBoundingClientRect().top,
+      );
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(toolbarRef.current as HTMLDivElement);
+    return () => observer.disconnect();
+  }, [showRecentSearches]);
+
   const isDataset = resourceType === "datasets";
   const hasTrailing = Boolean(query) || (isDiscover && isLoading);
   const formatOptions = useMemo<HubOption<FormatMenuValue>[]>(() => {
@@ -172,7 +197,10 @@ export const ModelsToolbar = memo(function ModelsToolbar({
     "focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:border-border",
   );
   return (
-    <div className="flex min-w-0 flex-col gap-2 lg:flex-row lg:flex-wrap lg:items-center">
+    <div
+      ref={toolbarRef}
+      className="flex min-w-0 flex-col gap-2 lg:flex-row lg:flex-wrap lg:items-center"
+    >
       <div
         className={cn(
           "hub-menu-trigger hub-tab-toggle relative inline-flex h-9 w-full shrink-0 items-center rounded-full lg:w-[280px]",
@@ -218,7 +246,10 @@ export const ModelsToolbar = memo(function ModelsToolbar({
         </button>
       </div>
 
-      <div className="relative min-w-0 flex-1 lg:min-w-[220px] lg:flex-[1_1_220px]">
+      <div
+        ref={searchWrapRef}
+        className="relative min-w-0 flex-1 lg:min-w-[220px] lg:flex-[1_1_220px]"
+      >
         <HugeiconsIcon
           icon={Search01Icon}
           strokeWidth={1.8}
@@ -286,6 +317,7 @@ export const ModelsToolbar = memo(function ModelsToolbar({
         ) : null}
         {showRecentSearches && (
           <RecentSearches
+            top={recentPanelTop}
             searches={recentSearches}
             onSelect={(value) => {
               recordRecentSearch(value);

--- a/studio/frontend/src/features/hub/catalog/recent-searches.tsx
+++ b/studio/frontend/src/features/hub/catalog/recent-searches.tsx
@@ -14,11 +14,13 @@ export function RecentSearches({
   onSelect,
   onRemove,
   onClear,
+  top,
 }: {
   searches: string[];
   onSelect: (query: string) => void;
   onRemove: (query: string) => void;
   onClear: () => void;
+  top?: number;
 }) {
   if (searches.length === 0) {
     return null;
@@ -26,6 +28,7 @@ export function RecentSearches({
   return (
     <div
       className="hub-recent-panel menu-soft-surface absolute inset-x-0 top-full z-50 mt-2 overflow-hidden rounded-[16px] p-1.5"
+      style={top === undefined ? undefined : { top }}
       aria-label="Recent searches"
       onMouseDown={(event) => event.preventDefault()}
     >


### PR DESCRIPTION
At window widths where the Model hub toolbar couldn't fit everything on one row (~1050–1300px), the search field's flex container collapsed below the input's 56px padding floor, so the input bled underneath the GGUF format dropdown. Both use the translucent field-soft background, so the overlap rendered as a lighter blob between the search icon and the dropdown label.

Before:
<img width="1246" height="813" alt="Screenshot 2026-07-31 at 2 15 00 AM" src="https://github.com/user-attachments/assets/dcc08681-737e-41ad-895e-e8e3ee15a34f" />

After:
<img width="1246" height="813" alt="Screenshot 2026-07-31 at 2 49 25 AM" src="https://github.com/user-attachments/assets/81515e80-a97b-4383-9435-ad5a60f8c18d" />
