### PR TITLE
Desktop: preserve first app window size after setup

### DIFF
--- a/studio/frontend/src/app/provider.tsx
+++ b/studio/frontend/src/app/provider.tsx
@@ -42,11 +42,19 @@ interface AppProviderProps {
 
 type TauriWindowMode = "setup" | "app";
 type WindowLayoutGuard = () => boolean;
+type LogicalWindowSize = {
+  width: number;
+  height: number;
+};
 
 const MIN_WINDOW_WIDTH = 900;
 const MIN_WINDOW_HEIGHT = 600;
 const SETUP_WINDOW_WIDTH = 760;
 const SETUP_WINDOW_HEIGHT = 560;
+const MINIMUM_APP_WINDOW_SIZE: LogicalWindowSize = {
+  width: MIN_WINDOW_WIDTH,
+  height: MIN_WINDOW_HEIGHT,
+};
 
 async function showSetupWindow(isCurrent: WindowLayoutGuard): Promise<void> {
   const { getCurrentWindow, LogicalSize } = await import(
@@ -73,6 +81,7 @@ async function enforceMinimumWindowSize(
   >,
   LogicalSize: typeof import("@tauri-apps/api/window")["LogicalSize"],
   isCurrent: WindowLayoutGuard,
+  requestedSize: LogicalWindowSize = MINIMUM_APP_WINDOW_SIZE,
 ): Promise<void> {
   const [innerSize, scaleFactor] = await Promise.all([
     win.innerSize(),
@@ -82,8 +91,19 @@ async function enforceMinimumWindowSize(
 
   const logicalWidth = Math.round(innerSize.width / scaleFactor);
   const logicalHeight = Math.round(innerSize.height / scaleFactor);
-  const nextWidth = Math.max(logicalWidth, MIN_WINDOW_WIDTH);
-  const nextHeight = Math.max(logicalHeight, MIN_WINDOW_HEIGHT);
+  // Linux reports innerSize from a cache updated by configure events. The
+  // AppImage's bundled GTK can deliver that event after this check, leaving the
+  // old setup size in the cache even though the first app resize has completed.
+  const nextWidth = Math.max(
+    logicalWidth,
+    MIN_WINDOW_WIDTH,
+    requestedSize.width,
+  );
+  const nextHeight = Math.max(
+    logicalHeight,
+    MIN_WINDOW_HEIGHT,
+    requestedSize.height,
+  );
   if (nextWidth !== logicalWidth || nextHeight !== logicalHeight) {
     await win.setSize(new LogicalSize(nextWidth, nextHeight));
   }
@@ -115,6 +135,7 @@ async function applyAppWindowLayout(
   await win.setResizable(true);
   if (!isCurrent()) return;
 
+  let requestedSize: LogicalWindowSize | undefined;
   if (hasInitializedAppLayout && hasSavedState) {
     // Subsequent launch: plugin restores size/position/maximized, with built-in
     // off-screen protection for positions saved on a now-disconnected display.
@@ -135,6 +156,7 @@ async function applyAppWindowLayout(
       const targetH = Math.max(MIN_WINDOW_HEIGHT, Math.round(finalW / 1.618));
       finalH = Math.min(targetH, Math.round(screenH * 0.85));
     }
+    requestedSize = { width: finalW, height: finalH };
     await win.setSize(new LogicalSize(finalW, finalH));
     if (!isCurrent()) return;
     await win.center();
@@ -149,7 +171,7 @@ async function applyAppWindowLayout(
     minHeight: MIN_WINDOW_HEIGHT,
   });
   if (!isCurrent()) return;
-  await enforceMinimumWindowSize(win, LogicalSize, isCurrent);
+  await enforceMinimumWindowSize(win, LogicalSize, isCurrent, requestedSize);
 
   if (!isCurrent()) return;
   await invoke("mark_app_window_layout_initialized");

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -197,6 +197,24 @@ def test_full_app_layout_uses_its_own_initialized_marker():
     assert "hasInitializedAppLayout && hasSavedState" in source
 
 
+def test_first_app_layout_survives_a_stale_setup_window_size():
+    source = APP_PROVIDER.read_text(encoding = "utf-8")
+    minimum_helper = source.split(
+        "async function enforceMinimumWindowSize", 1
+    )[1].split("async function applyAppWindowLayout", 1)[0]
+    app_layout = source.split("async function applyAppWindowLayout", 1)[1].split(
+        "async function showWindowFallback", 1
+    )[0]
+
+    assert "requestedSize.width" in minimum_helper
+    assert "requestedSize.height" in minimum_helper
+    assert "requestedSize = { width: finalW, height: finalH };" in app_layout
+    assert (
+        "enforceMinimumWindowSize(win, LogicalSize, isCurrent, requestedSize)"
+        in app_layout
+    )
+
+
 def test_expanded_titlebar_button_and_corner_match_sidebar_edge():
     source = TITLEBAR.read_text(encoding = "utf-8")
 

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -199,9 +199,9 @@ def test_full_app_layout_uses_its_own_initialized_marker():
 
 def test_first_app_layout_survives_a_stale_setup_window_size():
     source = APP_PROVIDER.read_text(encoding = "utf-8")
-    minimum_helper = source.split(
-        "async function enforceMinimumWindowSize", 1
-    )[1].split("async function applyAppWindowLayout", 1)[0]
+    minimum_helper = source.split("async function enforceMinimumWindowSize", 1)[1].split(
+        "async function applyAppWindowLayout", 1
+    )[0]
     app_layout = source.split("async function applyAppWindowLayout", 1)[1].split(
         "async function showWindowFallback", 1
     )[0]
@@ -209,10 +209,7 @@ def test_first_app_layout_survives_a_stale_setup_window_size():
     assert "requestedSize.width" in minimum_helper
     assert "requestedSize.height" in minimum_helper
     assert "requestedSize = { width: finalW, height: finalH };" in app_layout
-    assert (
-        "enforceMinimumWindowSize(win, LogicalSize, isCurrent, requestedSize)"
-        in app_layout
-    )
+    assert "enforceMinimumWindowSize(win, LogicalSize, isCurrent, requestedSize)" in app_layout
 
 
 def test_expanded_titlebar_button_and_corner_match_sidebar_edge():


### PR DESCRIPTION
## Summary

After first-run setup, the Linux AppImage can replace the monitor-sized Studio window with a 900x600 window. On a 1920x1080 display the visible sequence was:

```text
setup: 760x560
main:  1440x890
final: 900x600
```

The deb stayed at 1440x890 under the same controlled transition.

Keep the calculated first-app layout when the minimum-size check runs, while preserving the existing saved-state behavior on subsequent launches.

## Root cause

The first app layout requests 1440x890 and then immediately calls the minimum-size safeguard. On Linux, Tauri reads `innerSize()` from Tao's cached window dimensions, which are updated by the GTK configure event.

With the AppImage's bundled GTK, that event can arrive after the safeguard reads the cache. The read therefore still returns the setup size, 760x560. The safeguard interprets it as an undersized main window and explicitly calls `setSize(900, 600)`, overwriting the correct layout it just requested.

The deb's system GTK delivered the configure event before the read in live testing, so it did not enter the bad branch. Direct AppImage launches into the main app and AppImage saved-state restoration also stayed at 1440x890. The failure is specific to the setup-to-first-app transition.

## Fix

- Carry the known monitor-derived first-app size into the minimum-size safeguard.
- Clamp against the reported size, the 900x600 application minimum, and that requested size.
- Keep restored windows on the existing minimum-only path, so saved geometry is not replaced with a newly calculated first-run layout.
- Add a regression contract that keeps the requested size wired through the first-layout path and the safeguard.

This does not add a timeout or depend on configure-event timing. If the size read is current, the behavior is unchanged. If it is stale, the safeguard reasserts the layout the app already selected instead of shrinking it.

## Testing

- `python3 -m pytest tests/studio/test_desktop_reliability_frontend_contract.py -q` (12 passed)
- `npm test` (70 passed)
- `npm run typecheck`
- `npm run build`
- `cargo test --no-fail-fast` (104 passed)
- `git diff --check`

## Runtime validation

Linux on X11, 1920x1080 at scale factor 1:

- Reproduced with the released 0.1.51 AppImage: 760x560, then 1440x890, then 900x600.
- The installed deb stayed at 1440x890 through the same setup-to-main transition.
- A direct AppImage app-mode launch stayed at 1440x890.
- AppImage saved-state restoration stayed at 1440x890.
- A newly built fixed AppImage transitioned from 760x560 to 1440x890 and stayed there.
- Repeated the fixed test with the exact GTK, GLib, WebKit, and other packaged libraries from the failing 0.1.51 AppImage, changing only the rebuilt application binary. It stayed at 1440x890, with no 900x600 configure event.

## Scope

The setup window remains 760x560 and non-resizable. The full app minimum remains 900x600. Saved window restoration, monitor selection, centering, maximized state, the deb package, and non-Linux platform-specific window behavior are otherwise unchanged.
