### PR TITLE
Desktop: open uploaded files via the OS instead of window.open

### DIFF
--- a/studio/backend/storage/studio_db.py
+++ b/studio/backend/storage/studio_db.py
@@ -2765,13 +2765,16 @@ def _content_part_attachments(content_json: Optional[str]) -> list[dict]:
         seen.add(attachment_id)
         kind, value = payload
         content_type = None
-        if kind == "image" and isinstance(value, str):
+        part_name = part.get("name")
+        if isinstance(value, str) and value[:5].lower() == "data:":
             content_type = value[5:].split(";", 1)[0].split(",", 1)[0] or None
         out.append(
             {
                 "id": attachment_id,
                 "type": kind,
-                "name": "Chat image" if kind == "image" else "Chat audio",
+                "name": part_name if isinstance(part_name, str) and part_name else (
+                    "Chat image" if kind == "image" else "Chat audio"
+                ),
                 "contentType": content_type,
                 "content": [part],
             }

--- a/studio/backend/storage/studio_db.py
+++ b/studio/backend/storage/studio_db.py
@@ -2772,9 +2772,9 @@ def _content_part_attachments(content_json: Optional[str]) -> list[dict]:
             {
                 "id": attachment_id,
                 "type": kind,
-                "name": part_name if isinstance(part_name, str) and part_name else (
-                    "Chat image" if kind == "image" else "Chat audio"
-                ),
+                "name": part_name
+                if isinstance(part_name, str) and part_name
+                else ("Chat image" if kind == "image" else "Chat audio"),
                 "contentType": content_type,
                 "content": [part],
             }

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -143,7 +143,7 @@ import {
 export type CompareMessagePart =
   | { type: "text"; text: string }
   | { type: "image"; image: string }
-  | { type: "audio"; audio: string };
+  | { type: "audio"; audio: string; name: string };
 
 export interface CompareHandle {
   append: (content: CompareMessagePart[]) => void;
@@ -489,6 +489,7 @@ export function SharedComposer({
   const [pendingAudio, setPendingAudio] = useState<{
     name: string;
     base64: string;
+    contentType: string;
   } | null>(null);
   const [dragging, setDragging] = useState(false);
   const [isComposing, setIsComposing] = useState(false);
@@ -853,7 +854,7 @@ export function SharedComposer({
         // Handle audio files
         if (file.type.match(/^audio\//i) && file.size <= MAX_AUDIO_SIZE) {
           fileToBase64(file).then((base64) => {
-            setPendingAudio({ name: file.name, base64 });
+            setPendingAudio({ name: file.name, base64, contentType: file.type });
             setPendingAudioStore(base64, file.name);
           });
           continue;
@@ -983,7 +984,11 @@ export function SharedComposer({
       }
     }
     if (pendingAudio) {
-      content.push({ type: "audio", audio: pendingAudio.base64 });
+      content.push({
+        type: "audio",
+        name: pendingAudio.name,
+        audio: `data:${pendingAudio.contentType};base64,${pendingAudio.base64}`,
+      });
     }
     if (msg) {
       content.push({ type: "text", text: msg });

--- a/studio/frontend/src/features/rag/api/rag-api.ts
+++ b/studio/frontend/src/features/rag/api/rag-api.ts
@@ -2,6 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { authFetch } from "@/features/auth";
+import { apiUrl } from "@/lib/api-base";
 import { formatFastApiDetail } from "@/lib/format-fastapi-error";
 import type {
   DocumentUploadResult,
@@ -288,10 +289,12 @@ export function getPreviewTarget(
   );
 }
 
-// Signed URL (no bearer) so pdf.js can issue Range requests.
+// Signed URL (no bearer) so pdf.js can issue Range requests. Absolute because
+// consumers bypass authFetch, and a relative path under Tauri resolves against
+// the webview origin.
 export async function getDocumentFileUrl(documentId: string): Promise<string> {
   const data = await ragRequest<{ url: string }>(
     `/documents/${encodeURIComponent(documentId)}/file-url`,
   );
-  return data.url;
+  return apiUrl(data.url);
 }

--- a/studio/frontend/src/features/settings/components/uploaded-files-dialog.tsx
+++ b/studio/frontend/src/features/settings/components/uploaded-files-dialog.tsx
@@ -25,6 +25,8 @@ import {
   listAllDocuments,
   type UploadedDocument,
 } from "@/features/rag";
+import { isTauri } from "@/lib/api-base";
+import { downloadFile, isDownloadCancelled } from "@/lib/native-files";
 import { toast } from "@/lib/toast";
 import {
   ArrowUpRight01Icon,
@@ -189,8 +191,15 @@ function toSortTime(value: string | number | null | undefined): number {
 // Safari and Firefox block window.open after an await (the user gesture is
 // gone), so open a blank tab synchronously and point it at the URL once
 // resolved. A blocked synchronous open is surfaced instead of silently losing
-// the file after the asynchronous URL lookup.
+// the file after the asynchronous URL lookup. The Tauri webview has no
+// window.open at all, so it goes through the OS opener.
 async function openResolvedUrl(resolve: () => Promise<string>): Promise<void> {
+  if (isTauri) {
+    const url = await resolve();
+    const { openUrl } = await import("@tauri-apps/plugin-opener");
+    await openUrl(url);
+    return;
+  }
   const win = window.open("", "_blank");
   if (!win) {
     throw new Error(
@@ -230,6 +239,45 @@ function ragRow(doc: UploadedDocument): UploadedFileRow {
   };
 }
 
+const EXT_BY_MIME: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/webp": "webp",
+  "image/gif": "gif",
+  "audio/wav": "wav",
+  "audio/x-wav": "wav",
+  "audio/mpeg": "mp3",
+  "audio/mp4": "m4a",
+  "audio/x-m4a": "m4a",
+  "audio/webm": "webm",
+  "audio/ogg": "ogg",
+  "audio/flac": "flac",
+};
+
+// Name the save after the bytes the route actually returns. Uploaded documents
+// come back as extracted text (TextAttachmentAdapter also wraps it in
+// <attachment name=...>), so text/plain is .txt whatever the upload was called.
+// Managed content parts arrive named "Chat image"/"Chat audio" with no
+// extension at all, which the OS cannot recognise.
+// A dot at index 0 is a dotfile (.env), not an extension: treating it as one
+// would strip the whole name and save a bare ".txt".
+function extensionStart(name: string): number {
+  const dot = name.lastIndexOf(".");
+  return dot > 0 ? dot : -1;
+}
+
+function savedAttachmentName(name: string, blobType: string): string {
+  const mime = blobType.split(";")[0].trim().toLowerCase();
+  const dot = extensionStart(name);
+  if (mime === "text/plain") {
+    if (name.toLowerCase().endsWith(".txt")) return name;
+    return `${dot === -1 ? name : name.slice(0, dot)}.txt`;
+  }
+  if (dot !== -1) return name;
+  const ext = EXT_BY_MIME[mime];
+  return ext ? `${name}.${ext}` : name;
+}
+
 function chatAttachmentRow(att: ChatAttachmentRecord): UploadedFileRow {
   const isImage =
     att.type === "image" || Boolean(att.contentType?.startsWith("image/"));
@@ -249,14 +297,27 @@ function chatAttachmentRow(att: ChatAttachmentRecord): UploadedFileRow {
     ) : (
       <FileIconThumb />
     ),
-    open: () =>
-      openResolvedUrl(async () => {
+    // Bearer-gated bytes: no URL the OS can fetch, so desktop saves instead.
+    // The fetch stays inside the resolver on web, where openResolvedUrl must
+    // reach window.open while the click's user activation is still live.
+    open: async () => {
+      if (isTauri) {
+        const blob = await fetchChatAttachmentBlob(att.messageId, att.id);
+        await downloadFile(
+          blob,
+          savedAttachmentName(att.name, blob.type),
+          blob.type || undefined,
+        );
+        return;
+      }
+      await openResolvedUrl(async () => {
         const blob = await fetchChatAttachmentBlob(att.messageId, att.id);
         const url = URL.createObjectURL(blob);
         // Give the new tab time to load the blob before revoking.
         setTimeout(() => URL.revokeObjectURL(url), 60_000);
         return url;
-      }),
+      });
+    },
     remove: async () => {
       await deleteChatAttachment(att.messageId, att.id);
       // Patch any loaded runtime copy so a later repo sync cannot write the
@@ -412,6 +473,7 @@ export function UploadedFilesView() {
     try {
       await row.open();
     } catch (err) {
+      if (isDownloadCancelled(err)) return;
       toast.error("Failed to open file", {
         description: err instanceof Error ? err.message : undefined,
       });

--- a/studio/src-tauri/src/native_file_dialogs.rs
+++ b/studio/src-tauri/src/native_file_dialogs.rs
@@ -50,11 +50,25 @@ fn save_filter(file_name: &str) -> (&'static str, Vec<&'static str>) {
         Some("py") => ("Python", vec!["py"]),
         Some("sh") => ("Shell script", vec!["sh"]),
         Some("zip") => ("ZIP archive", vec!["zip"]),
+        // Saved chat attachments, not just exports: a name outside the active
+        // filter can be rejected or silently re-extensioned by the OS dialog.
+        Some("txt") | Some("log") => ("Text", vec!["txt", "log"]),
+        Some("png") => ("PNG image", vec!["png"]),
+        Some("jpg") | Some("jpeg") => ("JPEG image", vec!["jpg", "jpeg"]),
+        Some("webp") => ("WebP image", vec!["webp"]),
+        Some("gif") => ("GIF image", vec!["gif"]),
+        Some("wav") => ("WAV audio", vec!["wav"]),
+        Some("mp3") => ("MP3 audio", vec!["mp3"]),
+        Some("m4a") | Some("mp4") => ("MPEG-4 audio", vec!["m4a", "mp4"]),
+        Some("ogg") | Some("oga") => ("Ogg audio", vec!["ogg", "oga"]),
+        Some("flac") => ("FLAC audio", vec!["flac"]),
+        Some("webm") => ("WebM audio", vec!["webm"]),
         _ => (
             "Export files",
             vec![
                 "json", "jsonl", "ndjson", "csv", "md", "markdown", "html", "htm", "py", "sh",
-                "zip",
+                "zip", "txt", "log", "png", "jpg", "jpeg", "webp", "gif", "wav", "mp3", "m4a",
+                "mp4", "ogg", "oga", "flac", "webm",
             ],
         ),
     }
@@ -278,10 +292,23 @@ mod tests {
     }
 
     #[test]
+    fn saved_chat_attachments_keep_their_own_extension() {
+        // Settings > Data saves attachments here; a name outside the filter can
+        // be rejected or re-extensioned by the OS dialog.
+        assert_eq!(save_filter("report.txt"), ("Text", vec!["txt", "log"]));
+        assert_eq!(save_filter("photo.PNG"), ("PNG image", vec!["png"]));
+        assert_eq!(save_filter("shot.jpeg"), ("JPEG image", vec!["jpg", "jpeg"]));
+        assert_eq!(save_filter("clip.wav"), ("WAV audio", vec!["wav"]));
+        assert_eq!(save_filter("voice.webm"), ("WebM audio", vec!["webm"]));
+    }
+
+    #[test]
     fn generic_fallback_covers_every_tool_download_name() {
         let (name, extensions) = save_filter("no-extension");
         assert_eq!(name, "Export files");
-        for wanted in ["py", "sh", "json", "jsonl", "csv", "md", "html", "zip"] {
+        for wanted in [
+            "py", "sh", "json", "jsonl", "csv", "md", "html", "zip", "txt", "png", "jpg", "wav",
+        ] {
             assert!(extensions.contains(&wanted), "fallback lost {wanted}");
         }
     }


### PR DESCRIPTION
The Tauri webview has no window.open it returns null  so every Open action in Settings > Data failed with "Your browser blocked the new tab. Allow popups and retry.", advice a desktop user cannot act on. Desktop now hands the resolved URL to the OS via the opener plugin. Chat attachments sit behind a bearer-gated route, so those save through the existing native chooser instead, and dismissing it is no longer reported as a failure. getDocumentFileUrl now returns an absolute URL: consumers pass it to pdf.js and the OS rather than authFetch, and a backend-relative path resolved against tauri://localhost was serving the bundled SPA which also broke PDF citation previews. Web behaviour is unchanged.