### PR TITLE
Add 2026.7.6 release notes to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,88 @@ rename the heading at release time.
 
 ## Unreleased
 
+## 2026.7.6
+
+### What's Changed
+
+- Kimi K3 runs locally with Unsloth Dynamic GGUFs. Moonshot AI's 2.8T
+  parameter MoE has 104B active parameters, native vision and a 1M context
+  window.
+- Parallel chat keeps several conversations generating at once, so a new chat
+  no longer interrupts the answer already streaming.
+- Deep Research turns a local model into a full research workflow that plans,
+  searches, organizes evidence and writes a cited report.
+- AMD support covers more GPUs, with more reliable ROCm inference and
+  training on Windows, WSL and Linux.
+- Intel XPU brings local chat and training to Intel Arc and Data Center GPUs,
+  and DoRA is selectable alongside LoRA and full fine-tuning.
+
+### Kimi K3
+
+Kimi K3 is thinking-only, and low, high and max reasoning efforts are all
+supported. Multi-GPU setups are detected automatically and expert layers can
+be offloaded to system memory.
+
+It is a very large model, so plan hardware accordingly:
+
+- `UD-IQ1_S` is 595GB on disk.
+- `UD-Q4_K_XL` is 1.51TB on disk.
+- `UD-Q8_K_XL` is 1.56TB on disk, for lossless inference.
+
+Read the [Kimi K3 guide](https://unsloth.ai/docs/models/kimi-k3) and learn
+more about
+[Unsloth Dynamic 2.0 GGUFs](https://unsloth.ai/docs/basics/unsloth-dynamic-2.0-ggufs).
+
+### Parallel chat
+
+- 4 llama-server slots by default, adjustable in the web UI.
+- Tools, uploads, self-healing and agents stay isolated between chats.
+- Stop one chat without interrupting others or restarting the server.
+- The slot count is reduced automatically when memory is limited.
+- Reloading a model still stops active chats after confirmation.
+
+### Deep Research
+
+- Review and edit the plan before research begins.
+- Follow progress and collected sources while it works.
+- Resume or cancel without losing completed research.
+- Allow or block websites to control source selection.
+- Sources and citations stay saved with each run.
+- Unsupported claims, contradictions and unresolved gaps are checked before
+  writing, and recommendations without direct evidence are marked as testable
+  inferences.
+
+One run can be active per chat, and Deep Research currently works with local
+models. Optional full-page grounding reads top search results into temporary
+RAG before synthesis; enable it with `UNSLOTH_RESEARCH_AUTO_SCRAPE=1`. It is
+off by default because it adds scraping time and needs extra context.
+
+### Improved AMD support
+
+This builds on the initial
+[AMD release and setup guide](https://unsloth.ai/docs/basics/amd):
+
+- Detection is better for RDNA2, Radeon, Ryzen, Strix Halo and workstation
+  GPUs.
+- MI50 and Radeon VII support 16-bit LoRA and full fine-tuning on Linux.
+- 4-bit NaNs, library conflicts and long RDNA startup stalls are fixed.
+- Unsupported Windows HIP GPUs can fall back to Vulkan.
+- Vulkan devices show their real names and can be selected individually.
+- Clean Windows installs no longer require Winget or developer tools.
+
+### Also in this release
+
+- Large exports can use every visible GPU, avoiding GPU 0 memory limits.
+- MLX gains streaming datasets, continued pretraining, callbacks and better
+  VLM and LoRA support.
+- Incorrect `flash_attention_2` model output is fixed.
+- Unsloth and its saving utilities now work without bitsandbytes.
+- `.json` datasets and the Qwen3.5 / Qwen3.6 MoE and GRPO notebook setup are
+  fixed.
+- Hub download folders are easier to find and open.
+- `unsloth start --as-subagent` lets Codex, Claude Code and Pi delegate tasks
+  to a local Unsloth model.
+
 ## 2026.7.5
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,9 @@ rename the heading at release time.
 
 ### Kimi K3
 
-Kimi K3 is thinking-only, and low, high and max reasoning efforts are all
-supported. Multi-GPU setups are detected automatically and expert layers can
-be offloaded to system memory.
+Kimi K3 loads with thinking on, and low, high and max reasoning efforts are
+all supported. Multi-GPU setups are detected automatically and expert layers
+can be offloaded to system memory.
 
 It is a very large model, so plan hardware accordingly:
 
@@ -106,15 +106,15 @@ This builds on the initial
 ### Also in this release
 
 - Large exports can use every visible GPU, avoiding GPU 0 memory limits.
-- MLX gains streaming datasets, continued pretraining, callbacks and better
-  VLM and LoRA support.
+- MLX gains better VLM and LoRA support, and the inference sidecar is
+  activated before detection.
 - Incorrect `flash_attention_2` model output is fixed.
 - Unsloth and its saving utilities now work without bitsandbytes.
 - `.json` datasets and the Qwen3.5 / Qwen3.6 MoE and GRPO notebook setup are
   fixed.
 - Hub download folders are easier to find and open.
-- `unsloth start --as-subagent` lets Codex, Claude Code and Pi delegate tasks
-  to a local Unsloth model.
+- `unsloth start <agent> --as-subagent` lets Claude Code, Codex, OpenCode and
+  Pi delegate tasks to a local Unsloth model.
 
 ## 2026.7.5
 
@@ -123,12 +123,8 @@ This builds on the initial
 - AMD support is here. Train, run RL, chat with and deploy 500+ models on
   Radeon, Instinct, Ryzen and data center GPUs across Windows, WSL and Linux,
   up to 2x faster with 70% less VRAM and no accuracy loss.
-- Intel XPU support lands in Studio, so Arc and Data Center GPUs run chat and
-  training alongside the NVIDIA, AMD and Apple paths.
 - Local speech to text dictation runs fully offline, with slim Whisper bundles
   and a picker for custom models.
-- DoRA training is available in Studio, selectable next to LoRA and full
-  fine-tuning in the training tab.
 - The update popup previews release notes inline, pulled from this file and
   matched to the exact version being offered.
 


### PR DESCRIPTION
`CHANGELOG.md` has no `2026.7.6` section, so the update popup has nothing to render for the version it is currently offering. Notes are matched to one exact version, so a missing section means the popup links out to the online changelog instead of showing the notes inline. This adds that section.

`2026.7.6` is the version the popup asks for: it is the current PyPI latest for the `unsloth` distribution, and `get_studio_update_status` is called with `package_version("unsloth")`. Note that `unsloth.__version__` reports `2026.7.7` because it aliases `unsloth_zoo.__version__`, which is not what the update check compares.

Content comes from the `v0.1.51-beta` release and follows the `2026.7.5` layout: a `What's Changed` list of headline bullets, then sections for Kimi K3, parallel chat, Deep Research, AMD, and everything else. Every mention reads "Unsloth" rather than "Studio".

The section goes below `## Unreleased` so staged notes stay at the top and the newest release stays first among releases.

### Verification

- `parse_changelog` returns `['2026.7.6', '2026.7.5']`, so the new section is bounded correctly and does not run into 2026.7.5.
- `get_release_notes("2026.7.6")` resolves to heading `2026.7.6`, source `local`, 3463 chars, no error. `2026.07.6` and `v2026.7.6` match the same section.
- `get_studio_update_status("2026.7.5")` gives `update_available: true` with `latest_version: 2026.7.6`, and the notes resolve for that exact version, so anyone updating from an older release sees them inline.
- `releaseNotesPreview` produces 4 headline items with a clean lead and rest split, 28 remaining. The collapsed popup highlights "Kimi K3 runs locally with Unsloth Dynamic GGUFs." and dims the rest.
- `tests/studio/test_update_release_notes.py`: 162 passed.

Content only, so packaging is unaffected: `_changelog_build.py` copies the file verbatim into the studio package, and the section is well under the 20,000 char cap.
