### PR TITLE
Unsloth Studio: fix sidebar rail bottom fade rendering as a lighter block in dark mode

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1184,7 +1184,9 @@ export function AppSidebar() {
       collapsible="icon"
       variant="sidebar"
       className={cn(
-        "font-heading group-data-[collapsible=icon]:[&_[data-sidebar=sidebar]]:bg-white dark:group-data-[collapsible=icon]:[&_[data-sidebar=sidebar]]:bg-background",
+        // Rail background comes from --sidebar-surface (index.css) so the
+        // footer fade below can match it in every theme.
+        "font-heading group-data-[collapsible=icon]:[&_[data-sidebar=sidebar]]:bg-[var(--sidebar-surface)]",
         usesNativeMacTitlebar &&
           "group-data-[collapsible=icon]:[&_[data-sidebar=sidebar]]:border-r-0",
       )}
@@ -1861,7 +1863,7 @@ export function AppSidebar() {
         <div
           aria-hidden="true"
           className={cn(
-            "pointer-events-none absolute left-0 right-2 bottom-full bg-gradient-to-t from-[var(--sidebar)] to-[rgb(from_var(--sidebar)_r_g_b/0)] transition-opacity duration-200",
+            "pointer-events-none absolute left-0 right-2 bottom-full bg-gradient-to-t from-[var(--sidebar-surface)] to-[rgb(from_var(--sidebar-surface)_r_g_b/0)] transition-opacity duration-200",
             // Shorter fade when the update card sits above the profile so the
             // list reads closer to it.
             showUpdateCard ? "h-3" : "h-10",

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -16,6 +16,18 @@
 @custom-variant dark (&:is(.dark *));
 
 @layer components {
+	/* The surface the sidebar panel actually paints. The collapsed icon rail
+	   repaints it, so gradients fading into the panel must read this rather
+	   than --sidebar, or they render as a block instead of a fade. */
+	[data-sidebar="sidebar"] {
+		--sidebar-surface: var(--sidebar);
+	}
+	[data-collapsible="icon"] [data-sidebar="sidebar"] {
+		--sidebar-surface: #ffffff;
+	}
+	.dark [data-collapsible="icon"] [data-sidebar="sidebar"] {
+		--sidebar-surface: var(--background);
+	}
 	/* Sidebar scroll area (Gemini-style). The BOTTOM edge always fades so the
 	   last rows dissolve into the profile footer (no divider line). Once
 	   scrolled, the TOP edge also fades so rows dissolve as they pass under the
@@ -47,8 +59,8 @@
 		   black), which shows a grey midtone in Safari 27 Liquid Glass. */
 		background: linear-gradient(
 			to top,
-			var(--sidebar),
-			rgb(from var(--sidebar) r g b / 0)
+			var(--sidebar-surface),
+			rgb(from var(--sidebar-surface) r g b / 0)
 		);
 	}
 	/* Model picker list: once scrolled, the top edge fades so rows dissolve as


### PR DESCRIPTION
Fixes #7672

### Problem

In dark mode, with the sidebar collapsed to the icon rail, a faint lighter-grey rectangle shows at the bottom of the rail just above the settings cog and profile avatar. It appears only while the chat list overflows, which is why it seems intermittent.

The collapsed rail repaints the sidebar panel off its normal token (`app-sidebar.tsx`):

```
group-data-[collapsible=icon]:[&_[data-sidebar=sidebar]]:bg-white
dark:group-data-[collapsible=icon]:[&_[data-sidebar=sidebar]]:bg-background
```

but the footer scroll fade still faded to the original one:

```
bg-gradient-to-t from-[var(--sidebar)] to-[rgb(from_var(--sidebar)_r_g_b/0)]
```

In dark themes `--background` is `#181818` and `--sidebar` is `#1f1f1f`, so the gradient starts 7 levels lighter than the surface it sits on and reads as a 40px block rather than a fade. It's inset 8px from the right edge (`right-2`, the scrollbar gutter), which is why the patch is narrower than the rail. Light palettes set both to `#ffffff`, so they never showed it.

### Fix

Introduce `--sidebar-surface`: the colour the sidebar panel actually paints. It defaults to `var(--sidebar)` and is overridden once, where the rail override already lives. The rail background and the fade now both read it, so they can't drift apart in any theme or palette.

Also points `.sidebar-bottom-fade` at the same variable. That rule is currently unreferenced but carries the same hardcoded `var(--sidebar)`; happy to drop that hunk if you'd prefer a tighter diff.

### Testing

- `vite build` passes.
- Emitted CSS confirms the three-rule cascade resolves correctly:

```
[data-sidebar=sidebar]{--sidebar-surface:var(--sidebar)}
[data-collapsible=icon] [data-sidebar=sidebar]{--sidebar-surface:#fff}
.dark [data-collapsible=icon] [data-sidebar=sidebar]{--sidebar-surface:var(--background)}
```

Before/after screenshots to follow.
