### PR TITLE
Fix division by zero and type safety in fast_cross_entropy_loss

### DIFF
--- a/unsloth/kernels/cross_entropy_loss.py
+++ b/unsloth/kernels/cross_entropy_loss.py
@@ -444,8 +444,12 @@ def fast_cross_entropy_loss(
     )
     if n_items is None:
         n_items = torch.count_nonzero(labels != -100)
-    if torch.is_tensor(n_items):
-        n_items = n_items.to(device)
+    if not torch.is_tensor(n_items):
+        n_items = torch.tensor(n_items, dtype = torch.float32, device = device)
+    else:
+        n_items = n_items.to(dtype = torch.float32, device = device)
+    # Prevent division by zero when all labels are padding (-100)
+    n_items = n_items.clamp(min = 1.0)
     return loss.sum() / n_items
 
 


### PR DESCRIPTION
## Issue Reference
Fixes division by zero and type inconsistency in fast_cross_entropy_loss when all labels are padding

## Problem
When all labels are padding tokens (-100), \
_items\ becomes 0, causing division by zero in the loss calculation. Additionally, \
_items\ can be either a tensor or scalar, leading to type inconsistencies.

## Solution
- Convert \
_items\ to float32 tensor consistently (handles both tensor and scalar inputs)
- Add \clamp(min=1.0)\ to prevent division by zero
- Ensures numerical stability when all labels are padding

## Changes
- File: \unsloth/kernels/cross_entropy_loss.py\
- Lines: 445-453
- Unified type conversion to float32 tensor
- Added safety clamp before division

## Testing
Due to local environment constraints (Windows, no GPU access), I was unable to run the full test suite. However, the fix addresses the specific edge case where:
- All labels are -100 (padding)
- \
_items\ would be 0
- Division by zero would occur

The clamp ensures minimum value of 1.0, preventing the error while maintaining correct behavior for normal cases.

## Apology
I apologize that I could not verify this fix with comprehensive tests due to local environment limitations. The change is minimal and focused on the specific issue, but please verify with your test suite before merging.