### PR TITLE
Fix unbounded cache growth in packing utilities

### DIFF
--- a/unsloth/utils/packing.py
+++ b/unsloth/utils/packing.py
@@ -40,13 +40,16 @@ _XFORMERS_MASK_CACHE_MAXSIZE = 32
 _XFORMERS_MASK_CACHE: OrderedDict[Tuple[Tuple[int, ...], int], Any] = OrderedDict()
 
 # Cache per device for get_packed_info_from_kwargs to avoid repeated D2H sync across layers
-_PACKED_INFO_CACHE: dict = {}
+_PACKED_INFO_CACHE_MAXSIZE = 32
+_PACKED_INFO_CACHE: OrderedDict = OrderedDict()
 
 # Cache per device for build_sdpa_packed_attention_mask to avoid repeated D2H sync across layers
-_SDPA_MASK_CACHE: dict = {}
+_SDPA_MASK_CACHE_MAXSIZE = 32
+_SDPA_MASK_CACHE: OrderedDict = OrderedDict()
 
 # Cache per device for build_xformers_block_causal_mask to avoid repeated D2H sync across layers
-_XFORMERS_BLOCK_MASK_CACHE: dict = {}
+_XFORMERS_BLOCK_MASK_CACHE_MAXSIZE = 32
+_XFORMERS_BLOCK_MASK_CACHE: OrderedDict = OrderedDict()
 
 
 def _window_cache_key(sliding_window: Optional[int]) -> int:
@@ -531,6 +534,7 @@ def get_packed_info_from_kwargs(
 
     entry = _PACKED_INFO_CACHE.get(device)
     if entry is not None and entry["seq_lengths"] is seq_lengths:
+        _PACKED_INFO_CACHE.move_to_end(device)
         return entry["result"]
 
     lengths = seq_lengths.to(device = device, dtype = torch.int32, non_blocking = True)
@@ -540,6 +544,8 @@ def get_packed_info_from_kwargs(
     max_seqlen = int(lengths.max().item())
     result = (lengths, cu_seqlens, max_seqlen)
     _PACKED_INFO_CACHE[device] = {"seq_lengths": seq_lengths, "result": result}
+    if len(_PACKED_INFO_CACHE) > _PACKED_INFO_CACHE_MAXSIZE:
+        _PACKED_INFO_CACHE.popitem(last = False)
     return result
 
 
@@ -558,6 +564,7 @@ def build_xformers_block_causal_mask(
         params = (sliding_window,)
         entry = _XFORMERS_BLOCK_MASK_CACHE.get(device)
         if entry is not None and entry["seq_lengths"] is seq_lengths and entry["params"] == params:
+            _XFORMERS_BLOCK_MASK_CACHE.move_to_end(device)
             return entry["mask"]
 
         lengths_tensor = seq_lengths.to("cpu", torch.int32)
@@ -571,6 +578,8 @@ def build_xformers_block_causal_mask(
             "params": params,
             "mask": mask,
         }
+        if len(_XFORMERS_BLOCK_MASK_CACHE) > _XFORMERS_BLOCK_MASK_CACHE_MAXSIZE:
+            _XFORMERS_BLOCK_MASK_CACHE.popitem(last = False)
     else:
         mask = base_mask
 
@@ -596,6 +605,7 @@ def build_sdpa_packed_attention_mask(
     params = (dtype, sliding_window)
     entry = _SDPA_MASK_CACHE.get(device)
     if entry is not None and entry["seq_lengths"] is seq_lengths and entry["params"] == params:
+        _SDPA_MASK_CACHE.move_to_end(device)
         return entry["mask"]
 
     total_tokens = int(seq_lengths.sum().item())
@@ -627,6 +637,8 @@ def build_sdpa_packed_attention_mask(
         "params": params,
         "mask": result,
     }
+    if len(_SDPA_MASK_CACHE) > _SDPA_MASK_CACHE_MAXSIZE:
+        _SDPA_MASK_CACHE.popitem(last = False)
     return result
 
 


### PR DESCRIPTION
## Problem
The packing utility caches (\_PACKED_INFO_CACHE\, \_SDPA_MASK_CACHE\, \_XFORMERS_BLOCK_MASK_CACHE\) use plain dictionaries without size limits. In long-running training with varying sequence configurations, these caches can grow unbounded, leading to GPU memory leaks.

## Solution
Convert all three caches from \dict\ to \OrderedDict\ with a maximum size limit (32 entries). When the cache exceeds the limit, the least recently used entry is evicted using \popitem(last=False)\. On cache hits, \move_to_end()\ updates the entry to mark it as recently used.

## Changes
- File: \unsloth/utils/packing.py\
- Lines: 43-52, 534-548, 565-582, 605-641
- Converted \_PACKED_INFO_CACHE\, \_SDPA_MASK_CACHE\, \_XFORMERS_BLOCK_MASK_CACHE\ to \OrderedDict\
- Added max size constants (32 entries each)
- Added LRU eviction logic on cache insertion
- Added \move_to_end()\ on cache hits to maintain LRU order

## Testing
Due to local environment constraints (Windows, no GPU access), I was unable to run comprehensive tests. However, the implementation follows the same pattern already used in \_XFORMERS_MASK_CACHE\ (lines 39-78), which has been working correctly.

## Apology
I apologize that I could not verify this fix with comprehensive tests due to local environment limitations. The change is minimal and follows existing patterns in the codebase, but please verify with your test suite before merging.