### PR TITLE
Studio: fix the hub download rate estimator and bound long ETAs

### DIFF
--- a/studio/frontend/src/features/chat/hooks/use-transfer-stats.ts
+++ b/studio/frontend/src/features/chat/hooks/use-transfer-stats.ts
@@ -18,13 +18,13 @@
 import { useEffect, useRef, useState } from "react";
 
 import {
-  appendSample,
-  computeTransferStats,
   type TransferSample,
   type TransferStats,
-} from "../utils/transfer-stats";
+  appendSample,
+  computeTransferStats,
+} from "@/lib/transfer-stats";
 
-export type { TransferStats } from "../utils/transfer-stats";
+export type { TransferStats } from "@/lib/transfer-stats";
 
 export function useTransferStats(
   bytes: number | null | undefined,

--- a/studio/frontend/src/features/hub/download-manager/download-manager-config.ts
+++ b/studio/frontend/src/features/hub/download-manager/download-manager-config.ts
@@ -15,7 +15,6 @@ export const POLL_DEGRADED_AFTER_MS = 30_000;
 export const POLL_DEGRADED_MESSAGE =
   "Couldn't update download status. The download may still be running.";
 export const TRANSPORT_STATUS_TIMEOUT_MS = 3_000;
-export const SPEED_EMA_WEIGHT = 0.7;
 export const MAX_PROGRESS_FRACTION = 0.99;
 export const CANCEL_WATCHDOG_MS = 20_000;
 export const IDLE_EVICT_GRACE_MS = 60_000;

--- a/studio/frontend/src/features/hub/download-manager/download-manager-types.ts
+++ b/studio/frontend/src/features/hub/download-manager/download-manager-types.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import type { TransferSample } from "@/lib/transfer-stats";
 import type { InventoryHint } from "../inventory/types";
 import type { DownloadJobState } from "./api";
 import type { DownloadKind } from "./constants";
@@ -63,7 +64,8 @@ export interface JobRuntime {
   inFlight: boolean;
   cancelRequested: boolean;
   watchdog: number | null;
-  speedSample: { bytes: number; tMs: number } | null;
+  /** Rolling byte samples behind the stability-gated rate/ETA. */
+  speedSamples: TransferSample[];
   idleSinceMs: number | null;
   lastProgressPollAt: number | null;
   pollFailureStartedAt: number | null;

--- a/studio/frontend/src/features/hub/download-manager/poll-loop.ts
+++ b/studio/frontend/src/features/hub/download-manager/poll-loop.ts
@@ -5,6 +5,7 @@ import { invalidateGgufVariantsCache } from "../inventory/api";
 import { getHfToken } from "../stores/hf-token-store";
 import { bumpInventoryVersion } from "../stores/inventory-events";
 import { toast } from "@/lib/toast";
+import { appendSample, computeTransferStats } from "@/lib/transfer-stats";
 import {
   getActiveModelDownloads,
   getDatasetDownloadStatus,
@@ -28,7 +29,6 @@ import {
   POLL_JITTER_MS,
   PROGRESS_POLL_BACKOFF_INTERVAL_MS,
   PROGRESS_POLL_INTERVAL_MS,
-  SPEED_EMA_WEIGHT,
   ACTIVE_STATES,
   TERMINAL_DISPLAY_STATES,
 } from "./download-manager-config";
@@ -234,7 +234,7 @@ function markPollFailure(key: string, rt: JobRuntime): void {
   const now = Date.now();
   rt.pollFailureStartedAt ??= now;
   if (now - rt.pollFailureStartedAt < POLL_DEGRADED_AFTER_MS) return;
-  rt.speedSample = null;
+  rt.speedSamples.length = 0;
   patchJob(key, {
     error: POLL_DEGRADED_MESSAGE,
     bytesPerSec: 0,
@@ -364,27 +364,19 @@ async function finalizeTerminalStatus(
   }
 }
 
+// Rolling-window rate, withheld until the window is trustworthy. The old EMA
+// published its first sample verbatim and decayed toward -- never reaching --
+// zero while stalled, so ramp-up and idle ticks produced "753d 5h left" (#7667).
+// 0 hides both labels, as the training-start overlay already does.
 function applySpeedSample(
   rt: JobRuntime,
-  current: ManagedDownload,
   downloadedBytes: number,
+  expectedBytes: number,
   nowMs: number,
 ): number {
-  const last = rt.speedSample;
-  let bytesPerSec = last ? current.bytesPerSec : 0;
-  if (last) {
-    const dt = (nowMs - last.tMs) / 1000;
-    const db = Math.max(0, downloadedBytes - last.bytes);
-    if (dt > 0) {
-      const sample = db / dt;
-      bytesPerSec =
-        bytesPerSec > 0
-          ? bytesPerSec * SPEED_EMA_WEIGHT + sample * (1 - SPEED_EMA_WEIGHT)
-          : sample;
-    }
-  }
-  rt.speedSample = { bytes: downloadedBytes, tMs: nowMs };
-  return bytesPerSec;
+  appendSample(rt.speedSamples, nowMs / 1000, downloadedBytes);
+  const stats = computeTransferStats(rt.speedSamples, expectedBytes);
+  return stats.stable ? stats.rateBytesPerSecond : 0;
 }
 
 function reconcileProgressAndSpeed(
@@ -398,7 +390,7 @@ function reconcileProgressAndSpeed(
     resolveProgressUpdate(current, progressResp, {
       resetMonotonic: generationChanged,
     });
-  const bytesPerSec = applySpeedSample(rt, current, downloadedBytes, Date.now());
+  const bytesPerSec = applySpeedSample(rt, downloadedBytes, expected, Date.now());
   patchJob(key, {
     expectedBytes: expected,
     downloadedBytes,
@@ -457,7 +449,7 @@ async function tick(key: string): Promise<void> {
     return;
   }
   if (typeof document !== "undefined" && document.hidden) {
-    rt.speedSample = null;
+    rt.speedSamples.length = 0;
     return;
   }
   if (rt.inFlight) return;
@@ -622,7 +614,7 @@ export async function startJob(
     inFlight: false,
     cancelRequested: adoptingCancel,
     watchdog: null,
-    speedSample: null,
+    speedSamples: [],
     idleSinceMs: null,
     lastProgressPollAt: null,
     pollFailureStartedAt: null,

--- a/studio/frontend/src/features/hub/lib/format.ts
+++ b/studio/frontend/src/features/hub/lib/format.ts
@@ -30,10 +30,12 @@ export function formatRate(bytesPerSec: number): string {
   return `${formatBytes(bytesPerSec)}/s`;
 }
 
+// A day or more collapses to "> 24h left": a precise multi-day figure reads as
+// broken, but hiding it leaves a genuinely slow download with no estimate.
 export function formatEta(seconds: number): string {
   if (!Number.isFinite(seconds) || seconds <= 0) return "";
   const s = Math.round(seconds);
-  if (s >= MAX_DISPLAYABLE_ETA_SECONDS) return "";
+  if (s >= MAX_DISPLAYABLE_ETA_SECONDS) return `> ${HOURS_PER_DAY}h left`;
   if (s < SECONDS_PER_MINUTE) return `${s}s left`;
   if (s < SECONDS_PER_HOUR) {
     const m = Math.floor(s / SECONDS_PER_MINUTE);

--- a/studio/frontend/src/features/hub/lib/format.ts
+++ b/studio/frontend/src/features/hub/lib/format.ts
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+const SECONDS_PER_MINUTE = 60;
+const MINUTES_PER_HOUR = 60;
+const HOURS_PER_DAY = 24;
+const SECONDS_PER_HOUR = SECONDS_PER_MINUTE * MINUTES_PER_HOUR;
+const MAX_DISPLAYABLE_ETA_SECONDS = HOURS_PER_DAY * SECONDS_PER_HOUR;
+
 export function formatBytes(bytes: number): string {
   if (!Number.isFinite(bytes) || bytes < 0) return "N/A";
   if (bytes === 0) return "0 B";
@@ -27,20 +33,16 @@ export function formatRate(bytesPerSec: number): string {
 export function formatEta(seconds: number): string {
   if (!Number.isFinite(seconds) || seconds <= 0) return "";
   const s = Math.round(seconds);
-  if (s < 60) return `${s}s left`;
-  if (s < 3600) {
-    const m = Math.floor(s / 60);
-    const rem = s % 60;
+  if (s >= MAX_DISPLAYABLE_ETA_SECONDS) return "";
+  if (s < SECONDS_PER_MINUTE) return `${s}s left`;
+  if (s < SECONDS_PER_HOUR) {
+    const m = Math.floor(s / SECONDS_PER_MINUTE);
+    const rem = s % SECONDS_PER_MINUTE;
     return rem ? `${m}m ${rem}s left` : `${m}m left`;
   }
-  if (s < 86400) {
-    const h = Math.floor(s / 3600);
-    const rem = Math.floor((s % 3600) / 60);
-    return rem ? `${h}h ${rem}m left` : `${h}h left`;
-  }
-  const d = Math.floor(s / 86400);
-  const rem = Math.floor((s % 86400) / 3600);
-  return rem ? `${d}d ${rem}h left` : `${d}d left`;
+  const h = Math.floor(s / SECONDS_PER_HOUR);
+  const rem = Math.floor((s % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE);
+  return rem ? `${h}h ${rem}m left` : `${h}h left`;
 }
 
 export function ownerOf(id: string): string {

--- a/studio/frontend/src/lib/transfer-stats.ts
+++ b/studio/frontend/src/lib/transfer-stats.ts
@@ -5,8 +5,8 @@
  * Pure, framework-free math behind {@link useTransferStats}.
  *
  * Split out for unit-testing without React, and so the training-start overlay,
- * chat download toast, and model-load UI share identical rate/ETA semantics.
- * No React/timers -- the caller owns the sample buffer and clock.
+ * chat download toast, model-load UI and hub download manager share identical
+ * rate/ETA semantics. No React/timers -- the caller owns the buffer and clock.
  */
 
 export type TransferSample = { t: number; b: number };

--- a/studio/frontend/tests/hub-download-rate.test.ts
+++ b/studio/frontend/tests/hub-download-rate.test.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// The hub download manager now derives its rate from the shared rolling-window
+// estimator instead of an EMA seeded by the first sample (#7667). These pin the
+// gating the progress bar relies on: no rate (and so no ETA) until the window is
+// trustworthy, and no tiny positive rate while a transfer is stalled.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  type TransferSample,
+  appendSample,
+  computeTransferStats,
+} from "../src/lib/transfer-stats.ts";
+
+const TOTAL = 6.8e9;
+const MB = 1e6;
+
+/** Mirrors poll-loop's applySpeedSample: the rate published to the UI. */
+function publishedRate(
+  samples: TransferSample[],
+  t: number,
+  b: number,
+): number {
+  appendSample(samples, t, b);
+  const stats = computeTransferStats(samples, TOTAL);
+  return stats.stable ? stats.rateBytesPerSecond : 0;
+}
+
+test("connection ramp-up publishes no rate until the window is trustworthy", () => {
+  const samples: TransferSample[] = [];
+  assert.equal(publishedRate(samples, 0, 0), 0);
+  assert.equal(publishedRate(samples, 1, 100), 0);
+  assert.equal(publishedRate(samples, 2, 200), 0);
+  // Only now are there 3 samples spanning 3s of forward progress.
+  assert.ok(publishedRate(samples, 3, 30 * MB) > 0);
+});
+
+test("a steady transfer reports its true rate", () => {
+  const samples: TransferSample[] = [];
+  let rate = 0;
+  for (let t = 0; t <= 10; t++) rate = publishedRate(samples, t, t * 20 * MB);
+  assert.ok(Math.abs(rate - 20 * MB) < 1);
+});
+
+test("a stall reports no rate instead of decaying toward zero", () => {
+  const samples: TransferSample[] = [];
+  for (let t = 0; t <= 10; t++) publishedRate(samples, t, t * 20 * MB);
+  let rate = 0;
+  for (let t = 11; t <= 40; t++) rate = publishedRate(samples, t, 10 * 20 * MB);
+  assert.equal(rate, 0);
+});
+
+test("a restart drops the samples from the previous run", () => {
+  const samples: TransferSample[] = [];
+  for (let t = 0; t <= 10; t++) publishedRate(samples, t, t * 20 * MB);
+  assert.equal(publishedRate(samples, 11, 0), 0);
+  assert.equal(samples.length, 1);
+});

--- a/studio/frontend/tests/hub-format.test.ts
+++ b/studio/frontend/tests/hub-format.test.ts
@@ -6,25 +6,48 @@ import test from "node:test";
 
 import { formatEta } from "../src/features/hub/lib/format.ts";
 
-const SECONDS_PER_MINUTE = 60;
-const MINUTES_PER_HOUR = 60;
-const HOURS_PER_DAY = 24;
-const REPRO_ETA_DAYS = 753;
-const REPRO_ETA_HOURS = 5;
-const SECONDS_PER_HOUR = SECONDS_PER_MINUTE * MINUTES_PER_HOUR;
-const MAX_DISPLAYABLE_ETA_SECONDS = HOURS_PER_DAY * SECONDS_PER_HOUR;
-const REPRO_ETA_SECONDS =
-  (REPRO_ETA_DAYS * HOURS_PER_DAY + REPRO_ETA_HOURS) * SECONDS_PER_HOUR;
+const MINUTE = 60;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+// The reported case: 6.8 GB left at 102 B/s rendered "753d 5h left".
+const REPRO_SECONDS = (753 * 24 + 5) * HOUR;
 
-test("download ETA hides estimates that are too uncertain to be useful", () => {
+test("sub-hour ETAs keep their seconds and minutes", () => {
+  assert.equal(formatEta(1), "1s left");
+  assert.equal(formatEta(MINUTE - 1), "59s left");
+  assert.equal(formatEta(MINUTE), "1m left");
+  assert.equal(formatEta(MINUTE + 1), "1m 1s left");
+  assert.equal(formatEta(HOUR - 1), "59m 59s left");
+});
+
+test("hour ETAs drop the seconds", () => {
+  assert.equal(formatEta(HOUR), "1h left");
+  assert.equal(formatEta(HOUR + MINUTE), "1h 1m left");
+  assert.equal(formatEta(DAY - 1), "23h 59m left");
+});
+
+test("an ETA of a day or more collapses to a bound instead of a day count", () => {
+  assert.equal(formatEta(DAY), "> 24h left");
+  assert.equal(formatEta(DAY + 1), "> 24h left");
+  assert.equal(formatEta(REPRO_SECONDS), "> 24h left");
+  assert.equal(formatEta(Number.MAX_SAFE_INTEGER), "> 24h left");
+});
+
+test("the cutoff applies to the rounded value, so it starts at 86399.5s", () => {
+  assert.equal(formatEta(DAY - 0.51), "23h 59m left");
+  assert.equal(formatEta(DAY - 0.5), "> 24h left");
+});
+
+test("unusable inputs render nothing rather than a bogus estimate", () => {
   assert.equal(formatEta(Number.NaN), "");
+  assert.equal(formatEta(Number.POSITIVE_INFINITY), "");
+  assert.equal(formatEta(Number.NEGATIVE_INFINITY), "");
   assert.equal(formatEta(0), "");
-  assert.equal(formatEta(SECONDS_PER_MINUTE - 1), "59s left");
-  assert.equal(formatEta(SECONDS_PER_MINUTE), "1m left");
-  assert.equal(formatEta(SECONDS_PER_MINUTE + 1), "1m 1s left");
-  assert.equal(formatEta(SECONDS_PER_HOUR), "1h left");
-  assert.equal(formatEta(SECONDS_PER_HOUR + SECONDS_PER_MINUTE), "1h 1m left");
-  assert.equal(formatEta(REPRO_ETA_SECONDS), "");
-  assert.equal(formatEta(MAX_DISPLAYABLE_ETA_SECONDS - 1), "23h 59m left");
-  assert.equal(formatEta(MAX_DISPLAYABLE_ETA_SECONDS), "");
+  assert.equal(formatEta(-1), "");
+});
+
+test("no ETA is ever reported in days", () => {
+  for (let s = 1; s <= 3 * DAY; s += 137) {
+    assert.doesNotMatch(formatEta(s), /\d+d\b/);
+  }
 });

--- a/studio/frontend/tests/hub-format.test.ts
+++ b/studio/frontend/tests/hub-format.test.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatEta } from "../src/features/hub/lib/format.ts";
+
+const SECONDS_PER_MINUTE = 60;
+const MINUTES_PER_HOUR = 60;
+const HOURS_PER_DAY = 24;
+const REPRO_ETA_DAYS = 753;
+const REPRO_ETA_HOURS = 5;
+const SECONDS_PER_HOUR = SECONDS_PER_MINUTE * MINUTES_PER_HOUR;
+const MAX_DISPLAYABLE_ETA_SECONDS = HOURS_PER_DAY * SECONDS_PER_HOUR;
+const REPRO_ETA_SECONDS =
+  (REPRO_ETA_DAYS * HOURS_PER_DAY + REPRO_ETA_HOURS) * SECONDS_PER_HOUR;
+
+test("download ETA hides estimates that are too uncertain to be useful", () => {
+  assert.equal(formatEta(Number.NaN), "");
+  assert.equal(formatEta(0), "");
+  assert.equal(formatEta(SECONDS_PER_MINUTE - 1), "59s left");
+  assert.equal(formatEta(SECONDS_PER_MINUTE), "1m left");
+  assert.equal(formatEta(SECONDS_PER_MINUTE + 1), "1m 1s left");
+  assert.equal(formatEta(SECONDS_PER_HOUR), "1h left");
+  assert.equal(formatEta(SECONDS_PER_HOUR + SECONDS_PER_MINUTE), "1h 1m left");
+  assert.equal(formatEta(REPRO_ETA_SECONDS), "");
+  assert.equal(formatEta(MAX_DISPLAYABLE_ETA_SECONDS - 1), "23h 59m left");
+  assert.equal(formatEta(MAX_DISPLAYABLE_ETA_SECONDS), "");
+});


### PR DESCRIPTION
## Summary

Addresses part of #7667.

- suppress hub download ETA labels at or above 24 hours instead of rendering misleading multi-day estimates
- retain the existing seconds, minutes, and hours formatting below the cutoff
- cover the reported 753d 5h case and both sides of the 24-hour boundary

This is intentionally a display safeguard only. It does not change the download manager's rate estimator or claim to resolve its startup/stall stability.

## Verification

- [x] Full local validation suite passes
- [x] Upstream RED: the reported case rendered `753d 5h left`
- [x] Patched GREEN: the targeted regression test passes
- [x] Frontend tests: 73/73 pass
- [x] TypeScript typecheck passes
- [x] Production build passes
- [x] ESLint and Biome checks pass
- [x] Changed production lines: 100% covered (14/14)
- [x] Chromium UI check: `102 B/s` remains visible while `753d 5h left` is absent
- [x] Independent and OCR-assisted reviews found no blocking issues

## Files changed

| File | Change |
|------|--------|
| `studio/frontend/src/features/hub/lib/format.ts` | Cap displayable ETA labels below 24 hours and replace time literals with named constants |
| `studio/frontend/tests/hub-format.test.ts` | Add regression and cutoff-boundary coverage |

AI-assisted with Codex; reviewed and tested by the contributor.


---

## Maintainer update

Follow-up commit pushed on top of the above. The scope is now the root cause rather than the label alone:

| File | Change |
|------|--------|
| `studio/frontend/src/features/hub/download-manager/poll-loop.ts` | Derive the rate from the shared rolling-window estimator instead of the EMA, so ramp-up and stalls report no rate rather than a tiny positive one |
| `studio/frontend/src/lib/transfer-stats.ts` | Moved out of `features/chat/utils/`; it is shared by the chat, training and hub surfaces |
| `studio/frontend/src/features/hub/lib/format.ts` | Long ETAs render `> 24h left` instead of disappearing |
| `studio/frontend/tests/hub-format.test.ts` | Split into cases, plus the rounding boundary and non-finite inputs |
| `studio/frontend/tests/hub-download-rate.test.ts` | New: ramp-up, steady state, stall and restart gating |

Measured effect and the cross-platform, cross-engine verification are in the comment below.
