### PR TITLE
Fix cached models missing from chat picker

### DIFF
--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -131,6 +131,7 @@ import {
   taskForMediaPick,
   taskPickerRowMatches,
 } from "./audio-picker-policy";
+import { pickerLocalModelMatchesQuery } from "../../inventory/chat-picker-inventory-sources";
 import { FolderBrowser } from "./folder-browser";
 import {
   type ModelCapabilities,
@@ -3586,10 +3587,7 @@ export function HubModelPicker({
   // Each local section's search is scoped to its own models (matched by name).
   const localQuery = normalizeForSearch(debouncedQuery.trim());
   const matchesLocalQuery = (m: LocalModelInfo) =>
-    !localQuery ||
-    normalizeForSearch(
-      `${m.model_id ?? ""} ${m.display_name} ${m.id}`,
-    ).includes(localQuery);
+    pickerLocalModelMatchesQuery(m, localQuery);
   const sortedLmStudio = useMemo(
     () =>
       sortLocalModels(

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -123,6 +123,7 @@ import {
   taskForMediaPick,
   taskPickerRowMatches,
 } from "./audio-picker-policy";
+import { pickerLocalModelMatchesQuery } from "../../inventory/chat-picker-inventory-sources";
 import { FolderBrowser } from "./folder-browser";
 import {
   type ModelCapabilities,
@@ -3507,10 +3508,7 @@ export function HubModelPicker({
   // Each local section's search is scoped to its own models (matched by name).
   const localQuery = normalizeForSearch(debouncedQuery.trim());
   const matchesLocalQuery = (m: LocalModelInfo) =>
-    !localQuery ||
-    normalizeForSearch(
-      `${m.model_id ?? ""} ${m.display_name} ${m.id}`,
-    ).includes(localQuery);
+    pickerLocalModelMatchesQuery(m, localQuery);
   const sortedLmStudio = useMemo(
     () =>
       sortLocalModels(

--- a/studio/frontend/src/features/model-picker/inventory/chat-picker-inventory-sources.ts
+++ b/studio/frontend/src/features/model-picker/inventory/chat-picker-inventory-sources.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { LOCAL_MODEL_SOURCE } from "../../hub/inventory/constants.ts";
+
+// Minimal structural shapes so these helpers stay pure and unit-testable without
+// pulling in the full hub inventory row types (CachedInventoryRow / LocalInventoryRow
+// are structurally assignable to these).
+export interface CachedKeyRow {
+  repoId: string;
+  modelFormat: string;
+  partial?: boolean;
+  liveDownload?: boolean;
+}
+
+export interface LocalKeyRow {
+  source: string;
+  repoId: string | null;
+  modelFormat: string;
+}
+
+interface SearchableLocalModel {
+  id: string;
+  display_name: string;
+  model_id?: string | null;
+}
+
+function normalizeForSearch(value: string): string {
+  return value.toLowerCase().replace(/[\s_.-]/g, "");
+}
+
+// A cached model and an hf_cache local row describe the same weights when repo id
+// and format match; identity is compared case- and whitespace-insensitively.
+function inventoryKey(repoId: string, modelFormat: string): string {
+  return `${repoId.trim().toLowerCase()}\n${modelFormat.trim().toLowerCase()}`;
+}
+
+// Keys of cached models that are fully materialized. A partial or still-downloading
+// row is NOT a duplicate — the hf_cache copy is the only loadable one until it finishes.
+export function completeCachedModelKeys(
+  cachedRows: readonly CachedKeyRow[],
+): ReadonlySet<string> {
+  return new Set(
+    cachedRows
+      .filter((row) => !row.partial && !row.liveDownload)
+      .map((row) => inventoryKey(row.repoId, row.modelFormat)),
+  );
+}
+
+// An hf_cache row is a duplicate only when the same model is already surfaced as a
+// complete cached entry; dropping it stops the picker from listing the model twice.
+export function isHfCacheDuplicate(
+  row: LocalKeyRow,
+  completeCachedKeys: ReadonlySet<string>,
+): boolean {
+  return (
+    row.source === LOCAL_MODEL_SOURCE.HF_CACHE &&
+    row.repoId !== null &&
+    completeCachedKeys.has(inventoryKey(row.repoId, row.modelFormat))
+  );
+}
+
+export function pickerLocalModelMatchesQuery(
+  model: SearchableLocalModel,
+  query: string,
+): boolean {
+  const normalizedQuery = normalizeForSearch(query.trim());
+  if (!normalizedQuery) return true;
+  return normalizeForSearch(
+    `${model.model_id ?? ""} ${model.display_name} ${model.id}`,
+  ).includes(normalizedQuery);
+}

--- a/studio/frontend/src/features/model-picker/inventory/use-chat-picker-inventory.ts
+++ b/studio/frontend/src/features/model-picker/inventory/use-chat-picker-inventory.ts
@@ -17,11 +17,19 @@ import {
 } from "@/features/hub";
 import { useMemo } from "react";
 import { allowedHiddenModelIdMatches } from "../components/model-selector/audio-picker-policy";
+import {
+  completeCachedModelKeys,
+  isHfCacheDuplicate,
+} from "./chat-picker-inventory-sources";
 
 const PICKER_LOCAL_SOURCES: ReadonlySet<LocalSource> = new Set([
   "lmstudio",
   "models_dir",
   "ollama",
+  // A cached Hugging Face repo materialized on disk is a loadable local model; without it
+  // the chat picker hid every model that only exists in the HF cache. Duplicates against a
+  // complete cached entry are dropped below via isHfCacheDuplicate.
+  "hf_cache",
   "custom",
 ]);
 
@@ -65,8 +73,12 @@ function toLocalModelInfo(row: LocalInventoryRow): LocalModelInfo {
   return {
     id: row.loadId,
     display_name: row.displayName ?? row.title,
+    // A cached HF repo on disk loads exactly like a models-dir entry; presenting it under its
+    // own "hf_cache" source would leak an origin the chat loader/UI does not special-case.
+    source: (row.source === "hf_cache"
+      ? "models_dir"
+      : row.source) as LocalModelInfo["source"],
     path: row.path,
-    source: row.source as LocalModelInfo["source"],
     model_id: row.modelId ?? row.repoId,
     model_format: row.modelFormat,
     updated_at: epochMillisecondsToSeconds(row.updatedAt),
@@ -133,27 +145,29 @@ export function useChatPickerInventory(
         .map(toCachedModelRepo),
     [inventory.cachedRows, options.allowedHiddenModelIds],
   );
-  const localModels = useMemo(
-    () =>
-      inventory.localRows
-        .filter(
-          (row) =>
-            PICKER_LOCAL_SOURCES.has(row.source) &&
-            // Skip non-chat rows (a folder with only config.json classifies "unknown" -> canChat false); selecting one would load a weightless path.
-            // toLocalModelInfo drops capabilities, so this is the only place the guard can live. A row the backend classified as a generation task is
-            // exempt: canChat is about the chat loader, and dropping it here hid every on-device diffusion model from the pickers that CAN load it.
-            (row.capabilities.canChat ||
-              studioPageForTask(row.task) !== undefined) &&
-            (!isHiddenModelId(row.modelId, row.repoId, row.path) ||
-              allowedHiddenModelIdMatches(
-                options.allowedHiddenModelIds,
-                row.modelId,
-                row.repoId,
-              )),
-        )
-        .map(toLocalModelInfo),
-    [inventory.localRows, options.allowedHiddenModelIds],
-  );
+  const localModels = useMemo(() => {
+    // A cached model already surfaced above makes its hf_cache twin redundant; key the
+    // complete cached entries once so the row filter can drop the duplicates.
+    const completeCachedKeys = completeCachedModelKeys(inventory.cachedRows);
+    return inventory.localRows
+      .filter(
+        (row) =>
+          PICKER_LOCAL_SOURCES.has(row.source) &&
+          // Skip non-chat rows (a folder with only config.json classifies "unknown" -> canChat false); selecting one would load a weightless path.
+          // toLocalModelInfo drops capabilities, so this is the only place the guard can live. A row the backend classified as a generation task is
+          // exempt: canChat is about the chat loader, and dropping it here hid every on-device diffusion model from the pickers that CAN load it.
+          (row.capabilities.canChat ||
+            studioPageForTask(row.task) !== undefined) &&
+          (!isHiddenModelId(row.modelId, row.repoId, row.path) ||
+            allowedHiddenModelIdMatches(
+              options.allowedHiddenModelIds,
+              row.modelId,
+              row.repoId,
+            )) &&
+          !isHfCacheDuplicate(row, completeCachedKeys),
+      )
+      .map(toLocalModelInfo);
+  }, [inventory.localRows, inventory.cachedRows, options.allowedHiddenModelIds]);
 
   return {
     cachedGguf,

--- a/studio/frontend/src/features/model-picker/inventory/use-chat-picker-inventory.ts
+++ b/studio/frontend/src/features/model-picker/inventory/use-chat-picker-inventory.ts
@@ -16,10 +16,18 @@ import {
 } from "@/features/hub";
 import { useMemo } from "react";
 import { allowedHiddenModelIdMatches } from "../components/model-selector/audio-picker-policy";
+import {
+  completeCachedModelKeys,
+  isHfCacheDuplicate,
+} from "./chat-picker-inventory-sources";
 
 const PICKER_LOCAL_SOURCES: ReadonlySet<LocalSource> = new Set([
   "lmstudio",
   "models_dir",
+  // A cached Hugging Face repo materialized on disk is a loadable local model; without it
+  // the chat picker hid every model that only exists in the HF cache. Duplicates against a
+  // complete cached entry are dropped below via isHfCacheDuplicate.
+  "hf_cache",
   "custom",
 ]);
 
@@ -61,8 +69,12 @@ function toLocalModelInfo(row: LocalInventoryRow): LocalModelInfo {
   return {
     id: row.loadId,
     display_name: row.displayName ?? row.title,
+    // A cached HF repo on disk loads exactly like a models-dir entry; presenting it under its
+    // own "hf_cache" source would leak an origin the chat loader/UI does not special-case.
+    source: (row.source === "hf_cache"
+      ? "models_dir"
+      : row.source) as LocalModelInfo["source"],
     path: row.path,
-    source: row.source as LocalModelInfo["source"],
     model_id: row.modelId ?? row.repoId,
     model_format: row.modelFormat,
     updated_at: row.updatedAt,
@@ -128,27 +140,33 @@ export function useChatPickerInventory(
         .map(toCachedModelRepo),
     [inventory.cachedRows, options.allowedHiddenModelIds],
   );
-  const localModels = useMemo(
-    () =>
-      inventory.localRows
-        .filter(
-          (row) =>
-            PICKER_LOCAL_SOURCES.has(row.source) &&
-            // Skip non-chat rows (a folder with only config.json classifies "unknown" -> canChat false); selecting one would load a weightless path.
-            // toLocalModelInfo drops capabilities, so this is the only place the guard can live. A row the backend classified as a generation task is
-            // exempt: canChat is about the chat loader, and dropping it here hid every on-device diffusion model from the pickers that CAN load it.
-            (row.capabilities.canChat ||
-              studioPageForTask(row.task) !== undefined) &&
-            (!isHiddenModelId(row.modelId, row.repoId, row.path) ||
-              allowedHiddenModelIdMatches(
-                options.allowedHiddenModelIds,
-                row.modelId,
-                row.repoId,
-              )),
-        )
-        .map(toLocalModelInfo),
-    [inventory.localRows, options.allowedHiddenModelIds],
-  );
+  const localModels = useMemo(() => {
+    // A cached model already surfaced above makes its hf_cache twin redundant; key the
+    // complete cached entries once so the row filter can drop the duplicates.
+    const completeCachedKeys = completeCachedModelKeys(inventory.cachedRows);
+    return inventory.localRows
+      .filter(
+        (row) =>
+          PICKER_LOCAL_SOURCES.has(row.source) &&
+          // Skip non-chat rows (a folder with only config.json classifies "unknown" -> canChat false); selecting one would load a weightless path.
+          // toLocalModelInfo drops capabilities, so this is the only place the guard can live. A row the backend classified as a generation task is
+          // exempt: canChat is about the chat loader, and dropping it here hid every on-device diffusion model from the pickers that CAN load it.
+          (row.capabilities.canChat ||
+            studioPageForTask(row.task) !== undefined) &&
+          (!isHiddenModelId(row.modelId, row.repoId, row.path) ||
+            allowedHiddenModelIdMatches(
+              options.allowedHiddenModelIds,
+              row.modelId,
+              row.repoId,
+            )) &&
+          !isHfCacheDuplicate(row, completeCachedKeys),
+      )
+      .map(toLocalModelInfo);
+  }, [
+    inventory.cachedRows,
+    inventory.localRows,
+    options.allowedHiddenModelIds,
+  ]);
 
   return {
     cachedGguf,

--- a/studio/frontend/tests/chat-picker-inventory-sources.test.ts
+++ b/studio/frontend/tests/chat-picker-inventory-sources.test.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  completeCachedModelKeys,
+  isHfCacheDuplicate,
+  pickerLocalModelMatchesQuery,
+} from "../src/features/model-picker/inventory/chat-picker-inventory-sources.ts";
+
+const SOURCE_HF_CACHE = "hf_cache";
+const SOURCE_MODELS_DIR = "models_dir";
+const MODEL_FORMAT = "gguf";
+const SAFETENSORS_FORMAT = "safetensors";
+const ACTIVE_REPO_ID = "owao/Nanbeige4.2-3B-GGUF";
+const UNSEEN_REPO_ID = "other/never-cached-GGUF";
+
+function cachedRow(
+  repoId: string,
+  state: { partial?: boolean; liveDownload?: boolean } = {},
+  modelFormat = MODEL_FORMAT,
+) {
+  return { repoId, modelFormat, ...state };
+}
+
+function localRow(
+  repoId: string | null,
+  source = SOURCE_HF_CACHE,
+  modelFormat = MODEL_FORMAT,
+) {
+  return { source, repoId, modelFormat };
+}
+
+test("keys only fully materialized cached models", () => {
+  const keys = completeCachedModelKeys([
+    cachedRow(ACTIVE_REPO_ID),
+    cachedRow("partial/model-GGUF", { partial: true }),
+    cachedRow("live/model-GGUF", { liveDownload: true }),
+  ]);
+
+  assert.equal(keys.size, 1);
+  assert.equal(isHfCacheDuplicate(localRow(ACTIVE_REPO_ID), keys), true);
+});
+
+test("dedupes an hf_cache row only against a matching complete cached twin", () => {
+  // Keying is whitespace- and case-insensitive on the repo id.
+  const keys = completeCachedModelKeys([cachedRow(` ${ACTIVE_REPO_ID} `)]);
+
+  assert.equal(isHfCacheDuplicate(localRow(ACTIVE_REPO_ID), keys), true);
+  // A different local source is never a cache duplicate, even at the same repo.
+  assert.equal(
+    isHfCacheDuplicate(localRow(ACTIVE_REPO_ID, SOURCE_MODELS_DIR), keys),
+    false,
+  );
+  // Format is part of identity: a safetensors local copy is not the cached GGUF.
+  assert.equal(
+    isHfCacheDuplicate(
+      localRow(ACTIVE_REPO_ID, SOURCE_HF_CACHE, SAFETENSORS_FORMAT),
+      keys,
+    ),
+    false,
+  );
+  // A repo-less local row cannot be matched against the cache.
+  assert.equal(isHfCacheDuplicate(localRow(null), keys), false);
+  // An hf_cache row with no cached twin stays visible.
+  assert.equal(isHfCacheDuplicate(localRow(UNSEEN_REPO_ID), keys), false);
+});
+
+test("an incomplete cached entry does not hide its hf_cache copy", () => {
+  const keys = completeCachedModelKeys([
+    cachedRow(ACTIVE_REPO_ID, { partial: true }),
+  ]);
+
+  assert.equal(isHfCacheDuplicate(localRow(ACTIVE_REPO_ID), keys), false);
+});
+
+test("normalizes local search and accepts an empty query", () => {
+  const model = {
+    id: ACTIVE_REPO_ID,
+    display_name: ACTIVE_REPO_ID,
+    model_id: ACTIVE_REPO_ID,
+  };
+
+  assert.equal(pickerLocalModelMatchesQuery(model, ""), true);
+  assert.equal(pickerLocalModelMatchesQuery(model, " NANBEIGE4_2-3B "), true);
+  assert.equal(pickerLocalModelMatchesQuery(model, "missing"), false);
+});
+
+test("falls back to display name when repository metadata is absent", () => {
+  const model = {
+    id: "/models/local-model",
+    display_name: "Local Model",
+    model_id: null,
+  };
+
+  assert.equal(pickerLocalModelMatchesQuery(model, "localmodel"), true);
+  assert.equal(pickerLocalModelMatchesQuery(model, "absent"), false);
+});


### PR DESCRIPTION
## Summary

- include usable Hugging Face cache-only models in the chat model picker
- preserve active repository IDs and inactive snapshot load paths
- deduplicate only complete cache entries with the same repository and model format
- make projected local models searchable through the existing local sections

## Validation

- RED → GREEN: removing `hf_cache` projection fails with the reported model absent; restoring it passes.
- RED → GREEN: repository-only dedup removes the GGUF fallback beside cached Safetensors; repository-plus-format keeps it.
- RED → GREEN: untrimmed repository IDs leak a duplicate; normalized IDs deduplicate it.
- `npm test` (77/77 passing)
- `npm run typecheck`
- `npm run build`
- ESLint and Biome checks for all changed files
- 100% statements, branches, functions, and lines for the new inventory projector
- Chromium verification of search, inactive load-path preservation, and duplicate suppression

Full local suite: passed.

Closes #7676
