### PR TITLE
Stop and send buttons on the chat dictation bar

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -1259,7 +1259,7 @@ export function AppSidebar() {
                         useChatSearchStore.getState().open();
                         closeMobileIfOpen();
                       }}
-                      className="inline-flex h-[33px] w-[28px] cursor-pointer items-center justify-center rounded-[10px] text-nav-icon-idle dark:text-nav-fg-muted transition-colors hover:bg-nav-surface-hover hover:text-black dark:hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                      className="inline-flex size-[28px] cursor-pointer items-center justify-center rounded-full text-nav-icon-idle dark:text-nav-fg-muted transition-colors hover:bg-nav-surface-hover hover:text-black dark:hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                       aria-label={t("shell.navigation.search")}
                     >
                       <HugeiconsIcon icon={Search01Icon} strokeWidth={1.75} className="size-icon" />
@@ -1283,7 +1283,7 @@ export function AppSidebar() {
                       <button
                         type="button"
                         onClick={togglePinned}
-                        className="inline-flex h-[33px] w-[28px] cursor-pointer items-center justify-center rounded-[10px] text-nav-icon-idle dark:text-nav-fg-muted transition-colors hover:bg-nav-surface-hover hover:text-black dark:hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                        className="inline-flex size-[28px] cursor-pointer items-center justify-center rounded-full text-nav-icon-idle dark:text-nav-fg-muted transition-colors hover:bg-nav-surface-hover hover:text-black dark:hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                         aria-label={t("shell.aria.closeSidebar")}
                       >
                         <HugeiconsIcon icon={LayoutAlignLeftIcon} strokeWidth={1.75} className="size-icon" />

--- a/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
+++ b/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
@@ -166,18 +166,16 @@ export const ChatDictationBar: FC<{
     };
   }, [isDictating]);
 
-  // No discard button, so Escape drops a recording without transcribing.
+  // No discard button, so Escape drops a recording without transcribing. It
+  // stays live while transcribing: cancel aborts the request, and both buttons
+  // are disabled, so it is the only way out of a stalled one.
   useEffect(() => {
     if (!isDictating) {
       return;
     }
     const onKeyDown = (event: KeyboardEvent) => {
       // defaultPrevented: an open dialog or menu already claimed this Escape.
-      if (
-        event.key !== "Escape" ||
-        event.defaultPrevented ||
-        transcribingRef.current
-      ) {
+      if (event.key !== "Escape" || event.defaultPrevented) {
         return;
       }
       cancelActiveStudioDictation();

--- a/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
+++ b/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
@@ -249,7 +249,7 @@ export const ChatDictationBar: FC<{
           disabled={transcribing !== null}
           // Neutral grey in both themes: --secondary is brand green on the
           // default light palette, and too close to --card on dark.
-          className="size-8 rounded-full bg-accent text-foreground hover:bg-accent/70 dark:bg-white/10 dark:hover:bg-white/[0.16]"
+          className="size-9 rounded-full bg-accent text-foreground hover:bg-accent/70 dark:bg-white/10 dark:hover:bg-white/[0.16]"
         >
           {transcribing === "stop" ? (
             <Spinner className="size-3.5" />
@@ -264,12 +264,12 @@ export const ChatDictationBar: FC<{
           variant="default"
           onClick={send}
           disabled={transcribing !== null || sendDisabled}
-          className="aui-composer-send size-8 rounded-full"
+          className="aui-composer-send size-9 rounded-full"
         >
           {transcribing === "send" ? (
             <Spinner className="size-[18px]" />
           ) : (
-            <ArrowUpIcon className="aui-composer-send-icon size-[21px] stroke-2" />
+            <ArrowUpIcon className="unsloth-send-icon aui-composer-send-icon size-[21px] stroke-2" />
           )}
         </TooltipIconButton>
       </div>

--- a/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
+++ b/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
@@ -37,7 +37,8 @@ function formatElapsed(ms: number): string {
 /**
  * Recording UI shown in place of the composer input: a live waveform with stop
  * and send on the right. Stop transcribes into the composer for editing; send
- * transcribes and submits. Escape discards without transcribing.
+ * transcribes and submits. Escape discards without transcribing, as does a
+ * second press of stop once transcription is under way.
  */
 export const ChatDictationBar: FC<{
   /** Transcribe, then submit the composer. Falls back to stop when absent. */
@@ -167,8 +168,7 @@ export const ChatDictationBar: FC<{
   }, [isDictating]);
 
   // No discard button, so Escape drops a recording without transcribing. It
-  // stays live while transcribing: cancel aborts the request, and both buttons
-  // are disabled, so it is the only way out of a stalled one.
+  // stays live while transcribing too, where cancel aborts the request.
   useEffect(() => {
     if (!isDictating) {
       return;
@@ -194,8 +194,14 @@ export const ChatDictationBar: FC<{
     setTranscribing(source);
   };
 
-  // Transcript lands in the composer, ready to edit.
+  // Transcript lands in the composer, ready to edit. A second press while
+  // transcribing discards it instead, as Compare's does: Escape is otherwise
+  // the only way out, which touch has no way to press.
   const stop = () => {
+    if (transcribing !== null) {
+      cancelActiveStudioDictation();
+      return;
+    }
     freeze("stop");
     aui.composer().stopDictation();
   };
@@ -240,11 +246,14 @@ export const ChatDictationBar: FC<{
       <div className="flex shrink-0 items-center gap-2.5">
         <TooltipIconButton
           type="button"
-          tooltip={transcribing === "stop" ? "Transcribing…" : "Stop recording"}
-          aria-label="Stop recording"
+          tooltip={
+            transcribing !== null ? "Cancel transcription" : "Stop recording"
+          }
+          aria-label={
+            transcribing !== null ? "Cancel transcription" : "Stop recording"
+          }
           variant="ghost"
           onClick={stop}
-          disabled={transcribing !== null}
           // Neutral grey in both themes: --secondary is brand green on the
           // default light palette, and too close to --card on dark.
           className="size-9 rounded-full bg-accent text-foreground hover:bg-accent/70 dark:bg-white/10 dark:hover:bg-white/[0.16]"

--- a/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
+++ b/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
@@ -7,7 +7,7 @@ import {
   subscribeDictationLevel,
 } from "@/features/chat";
 import { useAui, useAuiState } from "@assistant-ui/react";
-import { CheckIcon, XIcon } from "lucide-react";
+import { ArrowUpIcon, SquareIcon } from "lucide-react";
 import { type FC, useEffect, useRef, useState } from "react";
 import { TooltipIconButton } from "./tooltip-icon-button";
 
@@ -35,14 +35,20 @@ function formatElapsed(ms: number): string {
 }
 
 /**
- * Recording UI shown in place of the composer input: a live waveform with
- * discard and confirm on the right. Confirm transcribes; discard keeps the
- * existing composer text.
+ * Recording UI shown in place of the composer input: a live waveform with stop
+ * and send on the right. Stop transcribes into the composer for editing; send
+ * transcribes and submits. Escape discards without transcribing.
  */
-export const ChatDictationBar: FC = () => {
+export const ChatDictationBar: FC<{
+  /** Transcribe, then submit the composer. Falls back to stop when absent. */
+  onSend?: () => void;
+}> = ({ onSend }) => {
   const aui = useAui();
   const isDictating = useAuiState((s) => s.composer.dictation != null);
-  const [transcribing, setTranscribing] = useState(false);
+  // Which button started transcription, so only it shows the spinner.
+  const [transcribing, setTranscribing] = useState<"stop" | "send" | null>(
+    null,
+  );
   const [elapsed, setElapsed] = useState(0);
   const transcribingRef = useRef(false);
   // Extra slot: newest sample lands here; the last visible bar slides toward it.
@@ -152,26 +158,52 @@ export const ChatDictationBar: FC = () => {
       unsub();
       cancelAnimationFrame(raf);
       transcribingRef.current = false;
-      setTranscribing(false);
+      setTranscribing(null);
       setElapsed(0);
       barsRef.current = new Array(BAR_COUNT + 1).fill(0);
     };
+  }, [isDictating]);
+
+  // No discard button, so Escape drops a recording without transcribing.
+  useEffect(() => {
+    if (!isDictating) {
+      return;
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape" || transcribingRef.current) {
+        return;
+      }
+      event.preventDefault();
+      cancelActiveStudioDictation();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
   }, [isDictating]);
 
   if (!isDictating) {
     return null;
   }
 
-  const discard = () => {
-    cancelActiveStudioDictation();
+  // Freeze the timer + waveform while the transcription round trip runs.
+  const freeze = (source: "stop" | "send") => {
+    transcribingRef.current = true;
+    setTranscribing(source);
   };
 
-  const confirm = () => {
-    // Freeze the timer + waveform before the transcription round trip completes
-    // and the session ends.
-    transcribingRef.current = true;
-    setTranscribing(true);
+  // Transcript lands in the composer, ready to edit.
+  const stop = () => {
+    freeze("stop");
     aui.composer().stopDictation();
+  };
+
+  // Same transcription, then the message submits on its own.
+  const send = () => {
+    if (!onSend) {
+      stop();
+      return;
+    }
+    freeze("send");
+    onSend();
   };
 
   return (
@@ -199,30 +231,35 @@ export const ChatDictationBar: FC = () => {
       <span className="shrink-0 tabular-nums text-sm text-muted-foreground">
         {formatElapsed(elapsed)}
       </span>
-      <div className="flex shrink-0 items-center gap-1">
+      <div className="flex shrink-0 items-center gap-1.5">
         <TooltipIconButton
           type="button"
-          tooltip="Discard recording"
-          aria-label="Discard recording"
-          variant="ghost"
-          onClick={discard}
-          className="size-8 rounded-full text-muted-foreground hover:text-foreground"
+          tooltip={transcribing === "stop" ? "Transcribing…" : "Stop recording"}
+          aria-label="Stop recording"
+          variant="secondary"
+          onClick={stop}
+          disabled={transcribing !== null}
+          className="size-8 rounded-full"
         >
-          <XIcon className="size-5" />
+          {transcribing === "stop" ? (
+            <Spinner className="size-3.5" />
+          ) : (
+            <SquareIcon className="size-3 fill-current" />
+          )}
         </TooltipIconButton>
         <TooltipIconButton
           type="button"
-          tooltip={transcribing ? "Transcribing…" : "Stop and transcribe"}
-          aria-label="Stop and transcribe"
+          tooltip={transcribing === "send" ? "Transcribing…" : "Send message"}
+          aria-label="Send message"
           variant="default"
-          onClick={confirm}
-          disabled={transcribing}
-          className="size-8 rounded-full"
+          onClick={send}
+          disabled={transcribing !== null}
+          className="aui-composer-send size-8 rounded-full"
         >
-          {transcribing ? (
-            <Spinner className="size-4" />
+          {transcribing === "send" ? (
+            <Spinner className="size-[18px]" />
           ) : (
-            <CheckIcon className="size-5" />
+            <ArrowUpIcon className="aui-composer-send-icon size-[21px] stroke-2" />
           )}
         </TooltipIconButton>
       </div>

--- a/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
+++ b/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
@@ -170,10 +170,14 @@ export const ChatDictationBar: FC<{
       return;
     }
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "Escape" || transcribingRef.current) {
+      // defaultPrevented: an open dialog or menu already claimed this Escape.
+      if (
+        event.key !== "Escape" ||
+        event.defaultPrevented ||
+        transcribingRef.current
+      ) {
         return;
       }
-      event.preventDefault();
       cancelActiveStudioDictation();
     };
     window.addEventListener("keydown", onKeyDown);

--- a/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
+++ b/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
@@ -215,7 +215,7 @@ export const ChatDictationBar: FC<{
       <div
         ref={rowRef}
         aria-hidden="true"
-        className="unsloth-dictation-wave grid h-10 min-w-0 flex-1 items-center overflow-hidden px-2"
+        className="unsloth-dictation-wave grid h-10 min-w-0 flex-1 items-center overflow-hidden px-4"
         style={{
           gridTemplateColumns: `repeat(${BAR_COUNT}, minmax(1px, 3px))`,
           justifyContent: "space-between",
@@ -231,15 +231,17 @@ export const ChatDictationBar: FC<{
       <span className="shrink-0 tabular-nums text-sm text-muted-foreground">
         {formatElapsed(elapsed)}
       </span>
-      <div className="flex shrink-0 items-center gap-1.5">
+      <div className="flex shrink-0 items-center gap-3">
         <TooltipIconButton
           type="button"
           tooltip={transcribing === "stop" ? "Transcribing…" : "Stop recording"}
           aria-label="Stop recording"
-          variant="secondary"
+          variant="ghost"
           onClick={stop}
           disabled={transcribing !== null}
-          className="size-8 rounded-full"
+          // Neutral grey in both themes: --secondary is brand green on the
+          // default light palette, and too close to --card on dark.
+          className="size-8 rounded-full bg-accent text-foreground hover:bg-accent/70 dark:bg-white/10 dark:hover:bg-white/[0.16]"
         >
           {transcribing === "stop" ? (
             <Spinner className="size-3.5" />

--- a/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
+++ b/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
@@ -42,7 +42,9 @@ function formatElapsed(ms: number): string {
 export const ChatDictationBar: FC<{
   /** Transcribe, then submit the composer. Falls back to stop when absent. */
   onSend?: () => void;
-}> = ({ onSend }) => {
+  /** Send is unavailable (e.g. an attachment is still uploading). */
+  sendDisabled?: boolean;
+}> = ({ onSend, sendDisabled }) => {
   const aui = useAui();
   const isDictating = useAuiState((s) => s.composer.dictation != null);
   // Which button started transcription, so only it shows the spinner.
@@ -202,6 +204,7 @@ export const ChatDictationBar: FC<{
 
   // Same transcription, then the message submits on its own.
   const send = () => {
+    if (sendDisabled) return;
     if (!onSend) {
       stop();
       return;
@@ -260,7 +263,7 @@ export const ChatDictationBar: FC<{
           aria-label="Send message"
           variant="default"
           onClick={send}
-          disabled={transcribing !== null}
+          disabled={transcribing !== null || sendDisabled}
           className="aui-composer-send size-8 rounded-full"
         >
           {transcribing === "send" ? (

--- a/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
+++ b/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
@@ -213,13 +213,14 @@ export const ChatDictationBar: FC<{
   return (
     <fieldset
       // order-2 places the bar in the input's slot after the left "+" tools.
-      className="unsloth-dictation-bar order-2 m-0 flex min-w-0 flex-1 items-center gap-2 border-0 p-0"
+      // No row gap: the wave padding and the timer margin set the spacing.
+      className="unsloth-dictation-bar order-2 m-0 flex min-w-0 flex-1 items-center gap-0 border-0 p-0"
       aria-label="Voice recording"
     >
       <div
         ref={rowRef}
         aria-hidden="true"
-        className="unsloth-dictation-wave grid h-10 min-w-0 flex-1 items-center overflow-hidden px-4"
+        className="unsloth-dictation-wave grid h-10 min-w-0 flex-1 items-center overflow-hidden pl-4 pr-2"
         style={{
           gridTemplateColumns: `repeat(${BAR_COUNT}, minmax(1px, 3px))`,
           justifyContent: "space-between",
@@ -232,7 +233,7 @@ export const ChatDictationBar: FC<{
           />
         ))}
       </div>
-      <span className="shrink-0 tabular-nums text-sm text-muted-foreground">
+      <span className="mr-4 shrink-0 tabular-nums text-sm text-muted-foreground">
         {formatElapsed(elapsed)}
       </span>
       <div className="flex shrink-0 items-center gap-3">

--- a/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
+++ b/studio/frontend/src/components/assistant-ui/chat-dictation-bar.tsx
@@ -236,7 +236,7 @@ export const ChatDictationBar: FC<{
       <span className="mr-4 shrink-0 tabular-nums text-sm text-muted-foreground">
         {formatElapsed(elapsed)}
       </span>
-      <div className="flex shrink-0 items-center gap-3">
+      <div className="flex shrink-0 items-center gap-2.5">
         <TooltipIconButton
           type="button"
           tooltip={transcribing === "stop" ? "Transcribing…" : "Stop recording"}

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -111,7 +111,10 @@ import {
   writeComposerDraft,
 } from "@/features/chat";
 import { deleteThreadMessage } from "@/features/chat/utils/delete-thread-message";
-import { shouldSubmitDictation } from "@/features/chat/utils/dictation-send";
+import {
+  dictationSendBlocked,
+  shouldSubmitDictation,
+} from "@/features/chat/utils/dictation-send";
 import { listThreadDocuments } from "@/features/rag/api/rag-api";
 import { ThreadDocumentsBar } from "@/features/rag/components/thread-documents-bar";
 import { KnowledgeBaseComposerButton } from "@/features/rag/components/knowledge-base-composer-button";
@@ -1857,6 +1860,18 @@ const Composer: FC<{
     aui.composer().stopDictation();
   }, [aui, composerIdentity]);
 
+  // One gate for the recording bar's send: it greys the button out, and holds
+  // a pending send when the composer changes under it after the press.
+  const dictationBlocked = dictationSendBlocked({
+    composerDisabled: Boolean(disabled),
+    uploading: hasPendingAttachments,
+    researchActive: isResearchActive,
+    runActive: threadIsRunning || promptQueueActive,
+    queueDisabled: Boolean(disableQueue),
+    hasOverlay: Boolean(overlay),
+    hasAttachments,
+    hasPendingAudio,
+  });
   const wasDictatingRef = useRef(false);
   useEffect(() => {
     if (isDictating) {
@@ -1872,30 +1887,32 @@ const Composer: FC<{
     }
     wasDictatingRef.current = false;
     if (!sendAfterDictationRef.current) return;
-    // The plus stays live while transcribing, so an upload can start after
-    // send was pressed. handleSubmit would reject it, so hold the intent
-    // (still set) until the upload lands and this effect runs again.
-    if (hasPendingAttachments) return;
-    sendAfterDictationRef.current = false;
     // A partial transcript (a failed chunk, or an engine error after one
     // landed) belongs in the composer, but must not send half a message.
-    if (dictationFailed()) return;
     // Silence, a thread switch mid-transcription, or a plus-menu insertion
-    // with no speech: keep the draft, submit nothing.
+    // with no speech: keep the draft, submit nothing. Settled before the hold
+    // below, so nothing to send never leaves an intent pending.
     const { text } = aui.composer().getState();
-    if (
-      !shouldSubmitDictation({
+    const sendable =
+      !dictationFailed() &&
+      shouldSubmitDictation({
         originComposer: dictationComposerRef.current,
         currentComposer: composerIdentity,
         producedTranscript: dictationProducedTranscript(),
         baseText: dictationBaseTextRef.current,
         text,
-      })
-    ) {
+      });
+    if (!sendable) {
+      sendAfterDictationRef.current = false;
       return;
     }
+    // The plus stays live while transcribing, so an upload or an attachment
+    // can appear after the press. Keep the intent until the composer accepts
+    // a submit again, rather than spending it on one that would bounce.
+    if (dictationBlocked) return;
+    sendAfterDictationRef.current = false;
     formRef.current?.requestSubmit();
-  }, [isDictating, aui, composerIdentity, hasPendingAttachments]);
+  }, [isDictating, aui, composerIdentity, dictationBlocked]);
 
   const handleSubmit = useCallback(
     (event: Parameters<NonNullable<ComponentProps<"form">["onSubmit"]>>[0]) => {
@@ -2091,16 +2108,7 @@ const Composer: FC<{
             // Every state handleSubmit rejects, since it would reject after
             // transcription with the send intent already spent. Text presence
             // is left out: the transcript supplies it.
-            sendDisabled={
-              disabled ||
-              hasPendingAttachments ||
-              isResearchActive ||
-              ((threadIsRunning || promptQueueActive) &&
-                (disableQueue ||
-                  Boolean(overlay) ||
-                  hasAttachments ||
-                  hasPendingAudio))
-            }
+            sendDisabled={dictationBlocked}
           />
         ) : (
           <>

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -104,6 +104,7 @@ import {
   PLUS_MENU_ORDER,
   composerDraftKey,
   dictationFailed,
+  dictationProducedTranscript,
   readComposerDraft,
   type PlusMenuItemId,
   usePlusMenuPrefsStore,
@@ -1869,16 +1870,17 @@ const Composer: FC<{
     // A partial transcript (a failed chunk, or an engine error after one
     // landed) belongs in the composer, but must not send half a message.
     if (dictationFailed()) return;
-    // Silence, a failed transcription, or a thread switch mid-transcription:
-    // keep the draft, submit nothing.
+    // Silence, a thread switch mid-transcription, or a plus-menu insertion
+    // with no speech: keep the draft, submit nothing.
     const { text } = aui.composer().getState();
     if (
-      !shouldSubmitDictation(
-        dictationComposerRef.current,
-        composerIdentity,
-        dictationBaseTextRef.current,
+      !shouldSubmitDictation({
+        originComposer: dictationComposerRef.current,
+        currentComposer: composerIdentity,
+        producedTranscript: dictationProducedTranscript(),
+        baseText: dictationBaseTextRef.current,
         text,
-      )
+      })
     ) {
       return;
     }

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -3679,7 +3679,7 @@ const ComposerRightControls: FC<{
     <div className="aui-composer-action-wrapper flex shrink-0 items-center gap-1.5">
       <ReasoningToggle side={menuSide} />
       {/* Starts dictation; the recording bar then covers the input row and owns
-          the stop and discard actions. */}
+          the stop and send actions. */}
       <ComposerPrimitive.If dictation={false}>
         <TooltipIconButton
           tooltip="Dictate"
@@ -3689,7 +3689,8 @@ const ComposerRightControls: FC<{
           className="size-8 rounded-full text-foreground"
           onClick={startDictation}
         >
-          <MicIcon className="size-[22px]" />
+          {/* size-[22px] is the fallback; unsloth-dictate-icon sets the size. */}
+          <MicIcon className="unsloth-dictate-icon size-[22px]" />
         </TooltipIconButton>
       </ComposerPrimitive.If>
       <AuiIf
@@ -3708,13 +3709,13 @@ const ComposerRightControls: FC<{
             // disabled only once a send is parked.
             disabled={disabled || pendingSend}
             onClick={(event) => onSendClick?.(event)}
-            className="aui-composer-send ml-1.5 size-8 rounded-full"
+            className="aui-composer-send ml-1.5 size-9 rounded-full"
             aria-label="Send message"
           >
             {pendingSend ? (
               <Spinner className="size-[18px]" />
             ) : (
-              <ArrowUpIcon className="aui-composer-send-icon size-[21px] stroke-2" />
+              <ArrowUpIcon className="unsloth-send-icon aui-composer-send-icon size-[21px] stroke-2" />
             )}
           </TooltipIconButton>
         </ComposerPrimitive.Send>
@@ -3729,10 +3730,10 @@ const ComposerRightControls: FC<{
             size="icon"
             disabled={disabled || queueDisabled}
             onClick={onQueueClick}
-            className="aui-composer-send ml-1.5 size-8 rounded-full"
+            className="aui-composer-send ml-1.5 size-9 rounded-full"
             aria-label="Queue message"
           >
-            <ArrowUpIcon className="aui-composer-send-icon size-[21px] stroke-2" />
+            <ArrowUpIcon className="unsloth-send-icon aui-composer-send-icon size-[21px] stroke-2" />
           </TooltipIconButton>
         </AuiIf>
       ) : null}
@@ -3741,7 +3742,7 @@ const ComposerRightControls: FC<{
           type="button"
           variant="default"
           size="icon"
-          className="aui-composer-cancel ml-1.5 size-8 rounded-full"
+          className="aui-composer-cancel ml-1.5 size-9 rounded-full"
           aria-label={researchStopping ? "Stopping research" : "Stop research"}
           disabled={researchStopping}
           onClick={stop}
@@ -3761,7 +3762,7 @@ const ComposerRightControls: FC<{
                 type="button"
                 variant="default"
                 size="icon"
-                className="aui-composer-cancel size-8 rounded-full"
+                className="aui-composer-cancel size-9 rounded-full"
                 aria-label="Stop generating"
                 onClick={stop}
               >
@@ -3777,10 +3778,10 @@ const ComposerRightControls: FC<{
               size="icon"
               disabled={queueDisabled}
               onClick={onQueueClick}
-              className="aui-composer-send size-8 rounded-full"
+              className="aui-composer-send size-9 rounded-full"
               aria-label="Queue message"
             >
-              <ArrowUpIcon className="aui-composer-send-icon size-[21px] stroke-2" />
+              <ArrowUpIcon className="unsloth-send-icon aui-composer-send-icon size-[21px] stroke-2" />
             </TooltipIconButton>
             )}
           </div>
@@ -4609,7 +4610,7 @@ const BranchPicker: FC<BranchPickerPrimitive.Root.Props> = ({
           aria-label="Previous"
           className="aui-branch-chevron-btn"
         >
-          <ChevronLeftIcon strokeWidth={1.25} className="size-[36px]" />
+          <ChevronLeftIcon strokeWidth={1.25} className="size-9" />
         </button>
       </BranchPickerPrimitive.Previous>
       <span className="aui-branch-picker-state font-mono text-ui-13 tabular-nums">
@@ -4621,7 +4622,7 @@ const BranchPicker: FC<BranchPickerPrimitive.Root.Props> = ({
           aria-label="Next"
           className="aui-branch-chevron-btn"
         >
-          <ChevronRightIcon strokeWidth={1.25} className="size-[36px]" />
+          <ChevronRightIcon strokeWidth={1.25} className="size-9" />
         </button>
       </BranchPickerPrimitive.Next>
     </BranchPickerPrimitive.Root>

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1857,15 +1857,25 @@ const Composer: FC<{
     aui.composer().stopDictation();
   }, [aui, composerIdentity]);
 
+  const wasDictatingRef = useRef(false);
   useEffect(() => {
     if (isDictating) {
+      if (wasDictatingRef.current) return;
+      wasDictatingRef.current = true;
+      // A new recording supersedes a send still held for an upload.
+      sendAfterDictationRef.current = false;
       // Text at session start is the dictation base. Anchor on it, not on the
       // text when send was pressed: the browser engine streams interim results
       // into the composer, so a final matching its interim would look unchanged.
       dictationBaseTextRef.current = aui.composer().getState().text;
       return;
     }
+    wasDictatingRef.current = false;
     if (!sendAfterDictationRef.current) return;
+    // The plus stays live while transcribing, so an upload can start after
+    // send was pressed. handleSubmit would reject it, so hold the intent
+    // (still set) until the upload lands and this effect runs again.
+    if (hasPendingAttachments) return;
     sendAfterDictationRef.current = false;
     // A partial transcript (a failed chunk, or an engine error after one
     // landed) belongs in the composer, but must not send half a message.
@@ -1885,7 +1895,7 @@ const Composer: FC<{
       return;
     }
     formRef.current?.requestSubmit();
-  }, [isDictating, aui, composerIdentity]);
+  }, [isDictating, aui, composerIdentity, hasPendingAttachments]);
 
   const handleSubmit = useCallback(
     (event: Parameters<NonNullable<ComponentProps<"form">["onSubmit"]>>[0]) => {

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1846,8 +1846,10 @@ const Composer: FC<{
   const dictationBaseTextRef = useRef("");
   const dictationComposerRef = useRef("");
   // Thread switches reuse this composer, so the send has to know where it
-  // started to avoid submitting the destination thread's draft.
-  const composerIdentity = `${threadListItemId ?? ""}:${referenceThreadId ?? ""}`;
+  // started to avoid submitting the destination thread's draft. The list item
+  // id, not referenceThreadId: that one moves from null to the remote id when
+  // a new chat first persists, which is the same composer.
+  const composerIdentity = threadListItemId ?? "";
   const sendAfterDictation = useCallback(() => {
     sendAfterDictationRef.current = true;
     dictationComposerRef.current = composerIdentity;

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -4642,7 +4642,7 @@ const BranchPicker: FC<BranchPickerPrimitive.Root.Props> = ({
           aria-label="Previous"
           className="aui-branch-chevron-btn"
         >
-          <ChevronLeftIcon strokeWidth={1.25} className="size-9" />
+          <ChevronLeftIcon strokeWidth={1.25} className="size-[36px]" />
         </button>
       </BranchPickerPrimitive.Previous>
       <span className="aui-branch-picker-state font-mono text-ui-13 tabular-nums">
@@ -4654,7 +4654,7 @@ const BranchPicker: FC<BranchPickerPrimitive.Root.Props> = ({
           aria-label="Next"
           className="aui-branch-chevron-btn"
         >
-          <ChevronRightIcon strokeWidth={1.25} className="size-9" />
+          <ChevronRightIcon strokeWidth={1.25} className="size-[36px]" />
         </button>
       </BranchPickerPrimitive.Next>
     </BranchPickerPrimitive.Root>

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1895,7 +1895,7 @@ const Composer: FC<{
     // Silence, a thread switch mid-transcription, or a plus-menu insertion
     // with no speech: keep the draft, submit nothing. Settled before the hold
     // below, so nothing to send never leaves an intent pending.
-    const { text } = aui.composer().getState();
+    const text = composerText;
     const sendable =
       !dictationFailed() &&
       shouldSubmitDictation({

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -110,7 +110,7 @@ import {
   writeComposerDraft,
 } from "@/features/chat";
 import { deleteThreadMessage } from "@/features/chat/utils/delete-thread-message";
-import { dictationProducedText } from "@/features/chat/utils/dictation-send";
+import { shouldSubmitDictation } from "@/features/chat/utils/dictation-send";
 import { listThreadDocuments } from "@/features/rag/api/rag-api";
 import { ThreadDocumentsBar } from "@/features/rag/components/thread-documents-bar";
 import { KnowledgeBaseComposerButton } from "@/features/rag/components/knowledge-base-composer-button";
@@ -1844,10 +1844,15 @@ const Composer: FC<{
   const formRef = useRef<HTMLFormElement | null>(null);
   const sendAfterDictationRef = useRef(false);
   const dictationBaseTextRef = useRef("");
+  const dictationComposerRef = useRef("");
+  // Thread switches reuse this composer, so the send has to know where it
+  // started to avoid submitting the destination thread's draft.
+  const composerIdentity = `${threadListItemId ?? ""}:${referenceThreadId ?? ""}`;
   const sendAfterDictation = useCallback(() => {
     sendAfterDictationRef.current = true;
+    dictationComposerRef.current = composerIdentity;
     aui.composer().stopDictation();
-  }, [aui]);
+  }, [aui, composerIdentity]);
 
   useEffect(() => {
     if (isDictating) {
@@ -1862,11 +1867,21 @@ const Composer: FC<{
     // A partial transcript (a failed chunk, or an engine error after one
     // landed) belongs in the composer, but must not send half a message.
     if (dictationFailed()) return;
-    // Silence or a failed transcription: keep the draft, submit nothing.
+    // Silence, a failed transcription, or a thread switch mid-transcription:
+    // keep the draft, submit nothing.
     const { text } = aui.composer().getState();
-    if (!dictationProducedText(dictationBaseTextRef.current, text)) return;
+    if (
+      !shouldSubmitDictation(
+        dictationComposerRef.current,
+        composerIdentity,
+        dictationBaseTextRef.current,
+        text,
+      )
+    ) {
+      return;
+    }
     formRef.current?.requestSubmit();
-  }, [isDictating, aui]);
+  }, [isDictating, aui, composerIdentity]);
 
   const handleSubmit = useCallback(
     (event: Parameters<NonNullable<ComponentProps<"form">["onSubmit"]>>[0]) => {

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -103,6 +103,7 @@ import { PROMPT_QUEUE_STOP_EVENT } from "@/features/chat/utils/prompt-queue-boun
 import {
   PLUS_MENU_ORDER,
   composerDraftKey,
+  dictationFailed,
   readComposerDraft,
   type PlusMenuItemId,
   usePlusMenuPrefsStore,
@@ -1858,6 +1859,9 @@ const Composer: FC<{
     }
     if (!sendAfterDictationRef.current) return;
     sendAfterDictationRef.current = false;
+    // A partial transcript (a failed chunk, or an engine error after one
+    // landed) belongs in the composer, but must not send half a message.
+    if (dictationFailed()) return;
     // Silence or a failed transcription: keep the draft, submit nothing.
     const { text } = aui.composer().getState();
     if (!dictationProducedText(dictationBaseTextRef.current, text)) return;
@@ -2055,9 +2059,19 @@ const Composer: FC<{
           // left plus stays visible alongside it.
           <ChatDictationBar
             onSend={sendAfterDictation}
-            // Same gate as the regular send: handleSubmit would otherwise
-            // reject the submit after transcription, with no way to retry.
-            sendDisabled={disabled || hasPendingAttachments}
+            // Every state handleSubmit rejects, since it would reject after
+            // transcription with the send intent already spent. Text presence
+            // is left out: the transcript supplies it.
+            sendDisabled={
+              disabled ||
+              hasPendingAttachments ||
+              isResearchActive ||
+              ((threadIsRunning || promptQueueActive) &&
+                (disableQueue ||
+                  Boolean(overlay) ||
+                  hasAttachments ||
+                  hasPendingAudio))
+            }
           />
         ) : (
           <>

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1366,7 +1366,8 @@ const ThreadWelcome: FC<{
         <div className="aui-thread-welcome-message flex w-full flex-col justify-center gap-9 px-4">
           {/* Center the greeting (sloth + title) over the composer. */}
           <div className="flex flex-row items-center justify-center gap-[15px]">
-            {showGreetingSloth && (
+            {/* Temporary chat keeps the title on its own, no mascot. */}
+            {showGreetingSloth && !incognito && (
               <MascotImg
                 src={currentEmojiSrc}
                 className="size-[44px] -translate-y-[2px]"

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1873,12 +1873,15 @@ const Composer: FC<{
     hasPendingAudio,
   });
   const wasDictatingRef = useRef(false);
+  // Composer text while a send waits on dictationBlocked, so an edit can drop it.
+  const heldTextRef = useRef<string | null>(null);
   useEffect(() => {
     if (isDictating) {
       if (wasDictatingRef.current) return;
       wasDictatingRef.current = true;
       // A new recording supersedes a send still held for an upload.
       sendAfterDictationRef.current = false;
+      heldTextRef.current = null;
       // Text at session start is the dictation base. Anchor on it, not on the
       // text when send was pressed: the browser engine streams interim results
       // into the composer, so a final matching its interim would look unchanged.
@@ -1904,15 +1907,28 @@ const Composer: FC<{
       });
     if (!sendable) {
       sendAfterDictationRef.current = false;
+      heldTextRef.current = null;
       return;
     }
     // The plus stays live while transcribing, so an upload or an attachment
     // can appear after the press. Keep the intent until the composer accepts
     // a submit again, rather than spending it on one that would bounce.
-    if (dictationBlocked) return;
+    if (dictationBlocked) {
+      // The bar is gone by now, so the hold is invisible. It lasts only as
+      // long as the transcript it was pressed for: editing hands control
+      // back, rather than sending that edit when the block clears.
+      if (heldTextRef.current === null) {
+        heldTextRef.current = text;
+      } else if (heldTextRef.current !== text) {
+        sendAfterDictationRef.current = false;
+        heldTextRef.current = null;
+      }
+      return;
+    }
     sendAfterDictationRef.current = false;
+    heldTextRef.current = null;
     formRef.current?.requestSubmit();
-  }, [isDictating, aui, composerIdentity, dictationBlocked]);
+  }, [isDictating, aui, composerIdentity, dictationBlocked, composerText]);
 
   const handleSubmit = useCallback(
     (event: Parameters<NonNullable<ComponentProps<"form">["onSubmit"]>>[0]) => {

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -3675,7 +3675,7 @@ const ComposerRightControls: FC<{
           className="size-8 rounded-full text-foreground"
           onClick={startDictation}
         >
-          <MicIcon className="size-5" />
+          <MicIcon className="size-[21px]" />
         </TooltipIconButton>
       </ComposerPrimitive.If>
       <AuiIf

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -3675,7 +3675,9 @@ const ComposerRightControls: FC<{
           className="size-8 rounded-full text-foreground"
           onClick={startDictation}
         >
-          <MicIcon className="size-[24px]" />
+          {/* Glyph fills its viewBox, so it reads larger than a lucide icon
+              at the same px. */}
+          <MicIcon className="size-[23px]" />
         </TooltipIconButton>
       </ComposerPrimitive.If>
       <AuiIf

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -109,6 +109,7 @@ import {
   writeComposerDraft,
 } from "@/features/chat";
 import { deleteThreadMessage } from "@/features/chat/utils/delete-thread-message";
+import { dictationProducedText } from "@/features/chat/utils/dictation-send";
 import { listThreadDocuments } from "@/features/rag/api/rag-api";
 import { ThreadDocumentsBar } from "@/features/rag/components/thread-documents-bar";
 import { KnowledgeBaseComposerButton } from "@/features/rag/components/knowledge-base-composer-button";
@@ -1840,17 +1841,25 @@ const Composer: FC<{
   // clearing identical to a typed send.
   const formRef = useRef<HTMLFormElement | null>(null);
   const sendAfterDictationRef = useRef(false);
+  const dictationBaseTextRef = useRef("");
   const sendAfterDictation = useCallback(() => {
     sendAfterDictationRef.current = true;
     aui.composer().stopDictation();
   }, [aui]);
 
   useEffect(() => {
-    if (isDictating || !sendAfterDictationRef.current) return;
+    if (isDictating) {
+      // Text at session start is the dictation base. Anchor on it, not on the
+      // text when send was pressed: the browser engine streams interim results
+      // into the composer, so a final matching its interim would look unchanged.
+      dictationBaseTextRef.current = aui.composer().getState().text;
+      return;
+    }
+    if (!sendAfterDictationRef.current) return;
     sendAfterDictationRef.current = false;
-    // Silence or a failed transcription: leave the composer untouched.
-    const { text, attachments } = aui.composer().getState();
-    if (text.trim().length === 0 && attachments.length === 0) return;
+    // Silence or a failed transcription: keep the draft, submit nothing.
+    const { text } = aui.composer().getState();
+    if (!dictationProducedText(dictationBaseTextRef.current, text)) return;
     formRef.current?.requestSubmit();
   }, [isDictating, aui]);
 
@@ -2043,7 +2052,12 @@ const Composer: FC<{
         {isDictating ? (
           // The recording UI replaces the input and send controls; only the
           // left plus stays visible alongside it.
-          <ChatDictationBar onSend={sendAfterDictation} />
+          <ChatDictationBar
+            onSend={sendAfterDictation}
+            // Same gate as the regular send: handleSubmit would otherwise
+            // reject the submit after transcription, with no way to retry.
+            sendDisabled={disabled || hasPendingAttachments}
+          />
         ) : (
           <>
             <ComposerPrimitive.Input

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -1835,6 +1835,25 @@ const Composer: FC<{
     [],
   );
 
+  // Recording bar's send: stop dictating, then submit once the transcript
+  // lands. Going through the form keeps queueing, indexing holds and draft
+  // clearing identical to a typed send.
+  const formRef = useRef<HTMLFormElement | null>(null);
+  const sendAfterDictationRef = useRef(false);
+  const sendAfterDictation = useCallback(() => {
+    sendAfterDictationRef.current = true;
+    aui.composer().stopDictation();
+  }, [aui]);
+
+  useEffect(() => {
+    if (isDictating || !sendAfterDictationRef.current) return;
+    sendAfterDictationRef.current = false;
+    // Silence or a failed transcription: leave the composer untouched.
+    const { text, attachments } = aui.composer().getState();
+    if (text.trim().length === 0 && attachments.length === 0) return;
+    formRef.current?.requestSubmit();
+  }, [isDictating, aui]);
+
   const handleSubmit = useCallback(
     (event: Parameters<NonNullable<ComponentProps<"form">["onSubmit"]>>[0]) => {
       if (isResearchActive) {
@@ -2024,7 +2043,7 @@ const Composer: FC<{
         {isDictating ? (
           // The recording UI replaces the input and send controls; only the
           // left plus stays visible alongside it.
-          <ChatDictationBar />
+          <ChatDictationBar onSend={sendAfterDictation} />
         ) : (
           <>
             <ComposerPrimitive.Input
@@ -2086,6 +2105,7 @@ const Composer: FC<{
   return (
     <PromptQueueContext.Provider value={queueContextValue}>
     <ComposerPrimitive.Root
+      ref={formRef}
       className="aui-composer-root relative flex w-full flex-col"
       aria-disabled={disabled}
       onSubmit={handleSubmit}

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -3675,7 +3675,7 @@ const ComposerRightControls: FC<{
           className="size-8 rounded-full text-foreground"
           onClick={startDictation}
         >
-          <MicIcon className="size-[21px]" />
+          <MicIcon className="size-[22px]" />
         </TooltipIconButton>
       </ComposerPrimitive.If>
       <AuiIf

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -3675,7 +3675,7 @@ const ComposerRightControls: FC<{
           className="size-8 rounded-full text-foreground"
           onClick={startDictation}
         >
-          <MicIcon className="size-[22px]" />
+          <MicIcon className="size-[24px]" />
         </TooltipIconButton>
       </ComposerPrimitive.If>
       <AuiIf

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -3675,9 +3675,7 @@ const ComposerRightControls: FC<{
           className="size-8 rounded-full text-foreground"
           onClick={startDictation}
         >
-          {/* Glyph fills its viewBox, so it reads larger than a lucide icon
-              at the same px. */}
-          <MicIcon className="size-[23px]" />
+          <MicIcon className="size-5" />
         </TooltipIconButton>
       </ComposerPrimitive.If>
       <AuiIf

--- a/studio/frontend/src/components/assistant-ui/thread.tsx
+++ b/studio/frontend/src/components/assistant-ui/thread.tsx
@@ -3675,7 +3675,7 @@ const ComposerRightControls: FC<{
           className="size-8 rounded-full text-foreground"
           onClick={startDictation}
         >
-          <MicIcon className="size-5" />
+          <MicIcon className="size-[22px]" />
         </TooltipIconButton>
       </ComposerPrimitive.If>
       <AuiIf

--- a/studio/frontend/src/features/chat/adapters/dictation-outcome.ts
+++ b/studio/frontend/src/features/chat/adapters/dictation-outcome.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * Whether the dictation that just ended lost transcript to an error.
+ *
+ * Both engines can end holding a partial transcript: the browser one keeps
+ * finalized chunks through a recognition error, the local model one keeps the
+ * segments that did transcribe. That text still belongs in the composer, but
+ * the recording bar's send must not submit it on its own.
+ *
+ * Module state, not session state, because the recording bar reads it after
+ * the session object is gone.
+ */
+let failed = false;
+
+/** Start a session. Clears the previous session's result. */
+export function resetDictationFailure(): void {
+  failed = false;
+}
+
+/** A transcript chunk, or the session itself, failed. */
+export function markDictationFailed(): void {
+  failed = true;
+}
+
+/** Whether the last dictation reported a failure. */
+export function dictationFailed(): boolean {
+  return failed;
+}

--- a/studio/frontend/src/features/chat/adapters/dictation-outcome.ts
+++ b/studio/frontend/src/features/chat/adapters/dictation-outcome.ts
@@ -2,24 +2,36 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 /**
- * Whether the dictation that just ended lost transcript to an error.
+ * What the dictation that just ended actually produced.
  *
- * Both engines can end holding a partial transcript: the browser one keeps
- * finalized chunks through a recognition error, the local model one keeps the
- * segments that did transcribe. That text still belongs in the composer, but
- * the recording bar's send must not submit it on its own.
- *
- * Module state, not session state, because the recording bar reads it after
- * the session object is gone.
+ * The recording bar's send needs both answers, and cannot get them from the
+ * composer: text can change while recording (the plus menu can insert a saved
+ * prompt), and a partial transcript still lands there. Module state, not
+ * session state, because the bar reads it once the session is gone.
  */
+let producedTranscript = false;
 let failed = false;
 
 /** Start a session. Clears the previous session's result. */
-export function resetDictationFailure(): void {
+export function beginDictationSession(): void {
+  producedTranscript = false;
   failed = false;
 }
 
-/** A transcript chunk, or the session itself, failed. */
+/** A final transcript was published to the composer. */
+export function markDictationTranscript(): void {
+  producedTranscript = true;
+}
+
+/** Whether the last dictation published any transcript. */
+export function dictationProducedTranscript(): boolean {
+  return producedTranscript;
+}
+
+/**
+ * A transcript chunk, or the session itself, failed. Both engines can still
+ * publish what did transcribe, so the text is partial rather than absent.
+ */
 export function markDictationFailed(): void {
   failed = true;
 }

--- a/studio/frontend/src/features/chat/adapters/studio-dictation-adapter.tsx
+++ b/studio/frontend/src/features/chat/adapters/studio-dictation-adapter.tsx
@@ -14,9 +14,9 @@ import {
   StudioWebSpeechDictationAdapter,
 } from "./studio-web-speech-dictation-adapter";
 
-// The one live dictation session, so the recording bar's discard (X) can cancel
-// it without going through assistant-ui (which only exposes stop, i.e.
-// transcribe). Cancelling emits no transcript, so composer text is untouched.
+// The one live dictation session, so Escape can discard it without going
+// through assistant-ui (which only exposes stop, i.e. transcribe). Cancelling
+// emits no transcript, so composer text is untouched.
 let activeSession: StudioDictationSession | null = null;
 
 /** Discard the current dictation without transcribing. Safe to call when idle. */

--- a/studio/frontend/src/features/chat/adapters/studio-model-dictation-adapter.ts
+++ b/studio/frontend/src/features/chat/adapters/studio-model-dictation-adapter.ts
@@ -334,8 +334,6 @@ export class StudioModelDictationAdapter implements DictationAdapter {
     const reportTranscriptionError = (error: unknown) => {
       if (reportedTranscriptionError || cancelled || ended) return;
       reportedTranscriptionError = true;
-      // Transcribed segments are kept, so the send must not fire on them.
-      markDictationFailed();
       const message =
         error instanceof Error && error.message
           ? error.message
@@ -410,6 +408,9 @@ export class StudioModelDictationAdapter implements DictationAdapter {
         } catch (error) {
           if (!cancelled && !abortController.signal.aborted) {
             // Keep transcribed segments, but never hide that part was lost.
+            // Only a lost segment is partial: the model preload shares this
+            // reporter and can fail without costing any audio.
+            markDictationFailed();
             reportTranscriptionError(error);
           }
         } finally {

--- a/studio/frontend/src/features/chat/adapters/studio-model-dictation-adapter.ts
+++ b/studio/frontend/src/features/chat/adapters/studio-model-dictation-adapter.ts
@@ -14,8 +14,9 @@ import type { DictationAdapter } from "@assistant-ui/react";
 import { toast } from "sonner";
 import { startDictationLevelMeter } from "./dictation-level";
 import {
+  beginDictationSession,
   markDictationFailed,
-  resetDictationFailure,
+  markDictationTranscript,
 } from "./dictation-outcome";
 import {
   type StudioDictationSession,
@@ -269,7 +270,7 @@ export class StudioModelDictationAdapter implements DictationAdapter {
     if (!StudioModelDictationAdapter.isSupported()) {
       throw new Error("Recording is not supported in this browser.");
     }
-    resetDictationFailure();
+    beginDictationSession();
 
     // Pin the model, language, and linked chat chosen when recording began, so a
     // mid-session settings change or thread switch cannot affect later segments
@@ -367,6 +368,7 @@ export class StudioModelDictationAdapter implements DictationAdapter {
       stream = null;
       const corrected = transcript ? applyDictationDictionary(transcript) : "";
       if (reason !== "cancelled" && corrected) {
+        markDictationTranscript();
         for (const callback of speechCallbacks) {
           callback({ transcript: corrected, isFinal: true });
         }

--- a/studio/frontend/src/features/chat/adapters/studio-model-dictation-adapter.ts
+++ b/studio/frontend/src/features/chat/adapters/studio-model-dictation-adapter.ts
@@ -14,6 +14,10 @@ import type { DictationAdapter } from "@assistant-ui/react";
 import { toast } from "sonner";
 import { startDictationLevelMeter } from "./dictation-level";
 import {
+  markDictationFailed,
+  resetDictationFailure,
+} from "./dictation-outcome";
+import {
   type StudioDictationSession,
   isMissingDeviceError,
   resolveDictationChatId,
@@ -265,6 +269,7 @@ export class StudioModelDictationAdapter implements DictationAdapter {
     if (!StudioModelDictationAdapter.isSupported()) {
       throw new Error("Recording is not supported in this browser.");
     }
+    resetDictationFailure();
 
     // Pin the model, language, and linked chat chosen when recording began, so a
     // mid-session settings change or thread switch cannot affect later segments
@@ -329,6 +334,8 @@ export class StudioModelDictationAdapter implements DictationAdapter {
     const reportTranscriptionError = (error: unknown) => {
       if (reportedTranscriptionError || cancelled || ended) return;
       reportedTranscriptionError = true;
+      // Transcribed segments are kept, so the send must not fire on them.
+      markDictationFailed();
       const message =
         error instanceof Error && error.message
           ? error.message

--- a/studio/frontend/src/features/chat/adapters/studio-web-speech-dictation-adapter.ts
+++ b/studio/frontend/src/features/chat/adapters/studio-web-speech-dictation-adapter.ts
@@ -12,6 +12,10 @@ import type { DictationAdapter } from "@assistant-ui/react";
 import { toast } from "sonner";
 import { useChatRuntimeStore } from "../stores/chat-runtime-store";
 import { startDictationLevelMeter } from "./dictation-level";
+import {
+  markDictationFailed,
+  resetDictationFailure,
+} from "./dictation-outcome";
 
 /** Chat open while dictating, so the saved dictation can link back to it. */
 export function activeDictationChatId(): string | undefined {
@@ -139,6 +143,7 @@ export class StudioWebSpeechDictationAdapter implements DictationAdapter {
       throw new Error("Speech recognition is not supported in this browser.");
     }
 
+    resetDictationFailure();
     const recognition = new SpeechRecognitionAPI();
     recognition.lang = this.language ?? resolveDictationLanguage();
     recognition.continuous = this.continuous;
@@ -371,6 +376,8 @@ export class StudioWebSpeechDictationAdapter implements DictationAdapter {
       } else {
         toast.error(description);
       }
+      // Any finalized chunks stay in the composer, but must not send alone.
+      markDictationFailed();
       finish("error");
     });
 

--- a/studio/frontend/src/features/chat/adapters/studio-web-speech-dictation-adapter.ts
+++ b/studio/frontend/src/features/chat/adapters/studio-web-speech-dictation-adapter.ts
@@ -13,8 +13,9 @@ import { toast } from "sonner";
 import { useChatRuntimeStore } from "../stores/chat-runtime-store";
 import { startDictationLevelMeter } from "./dictation-level";
 import {
+  beginDictationSession,
   markDictationFailed,
-  resetDictationFailure,
+  markDictationTranscript,
 } from "./dictation-outcome";
 
 /** Chat open while dictating, so the saved dictation can link back to it. */
@@ -143,7 +144,7 @@ export class StudioWebSpeechDictationAdapter implements DictationAdapter {
       throw new Error("Speech recognition is not supported in this browser.");
     }
 
-    resetDictationFailure();
+    beginDictationSession();
     const recognition = new SpeechRecognitionAPI();
     recognition.lang = this.language ?? resolveDictationLanguage();
     recognition.continuous = this.continuous;
@@ -279,6 +280,7 @@ export class StudioWebSpeechDictationAdapter implements DictationAdapter {
       stream = null;
       const transcript = reason === "cancelled" ? "" : finalTranscript;
       if (transcript) {
+        markDictationTranscript();
         for (const callback of speechCallbacks) {
           callback({ transcript, isFinal: true });
         }

--- a/studio/frontend/src/features/chat/chat-page.tsx
+++ b/studio/frontend/src/features/chat/chat-page.tsx
@@ -3276,16 +3276,6 @@ export function ChatPage({
                 className="max-w-[62vw] !pr-3 sm:max-w-none !h-[var(--studio-chat-control-height,34px)]"
               />
             )}
-            {incognito && view.mode === "single" && (
-              <div className="flex h-[var(--studio-chat-control-height,34px)] shrink-0 items-center gap-1.5 self-center rounded-full bg-primary/10 px-2.5 font-medium text-ui-13 text-primary">
-                <HugeiconsIcon
-                  icon={BubbleChatTemporaryIcon}
-                  strokeWidth={2}
-                  className="size-3.5"
-                />
-                <span>Temporary</span>
-              </div>
-            )}
             {view.mode !== "compare" && currentProjectId && (
               <nav
                 aria-label="Project location"
@@ -3353,7 +3343,7 @@ export function ChatPage({
               </div>
             ) : null}
           </div>
-          <div className="pointer-events-auto ml-auto flex items-center gap-2">
+          <div className="pointer-events-auto ml-auto flex items-center gap-1">
             {view.mode === "single" && contextUsage ? (
               <ContextUsageBar
                 used={contextUsage.totalTokens}
@@ -3373,7 +3363,7 @@ export function ChatPage({
                     type="button"
                     onClick={toggleIncognito}
                     className={cn(
-                      "flex size-[var(--studio-chat-control-height,34px)] cursor-pointer items-center justify-center rounded-[12px] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                      "flex size-[var(--studio-chat-control-height,34px)] cursor-pointer items-center justify-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
                       incognito
                         ? "bg-primary/10 text-primary hover:bg-primary/15"
                         : "text-nav-fg hover:bg-nav-surface-hover hover:text-black dark:hover:text-white",
@@ -3411,7 +3401,7 @@ export function ChatPage({
                       closeArtifactSurface();
                       openResearchPanel(latestResearchRun.id);
                     }}
-                    className="relative flex size-[var(--studio-chat-control-height,34px)] cursor-pointer items-center justify-center rounded-[12px] text-nav-fg transition-colors hover:bg-nav-surface-hover hover:text-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:hover:text-white"
+                    className="relative flex size-[var(--studio-chat-control-height,34px)] cursor-pointer items-center justify-center rounded-full text-nav-fg transition-colors hover:bg-nav-surface-hover hover:text-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:hover:text-white"
                     aria-label="Open research activity"
                     aria-pressed={openResearchRunId === latestResearchRun.id}
                   >
@@ -3439,7 +3429,7 @@ export function ChatPage({
                       useResearchRunStore.getState().closePanel();
                       setSettingsOpen(true);
                     }}
-                    className="flex size-[var(--studio-chat-control-height,34px)] translate-x-[2px] cursor-pointer items-center justify-center rounded-[12px] text-nav-fg transition-colors hover:bg-nav-surface-hover hover:text-black dark:hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                    className="flex size-[var(--studio-chat-control-height,34px)] cursor-pointer items-center justify-center rounded-full text-nav-fg transition-colors hover:bg-nav-surface-hover hover:text-black dark:hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                     aria-label="Open run settings"
                   >
                     <HugeiconsIcon

--- a/studio/frontend/src/features/chat/index.ts
+++ b/studio/frontend/src/features/chat/index.ts
@@ -139,6 +139,7 @@ export {
   useChatProjects,
 } from "./hooks/use-chat-projects";
 export { subscribeDictationLevel } from "./adapters/dictation-level";
+export { dictationFailed } from "./adapters/dictation-outcome";
 export {
   StudioDictationAdapter,
   cancelActiveStudioDictation,

--- a/studio/frontend/src/features/chat/index.ts
+++ b/studio/frontend/src/features/chat/index.ts
@@ -139,7 +139,10 @@ export {
   useChatProjects,
 } from "./hooks/use-chat-projects";
 export { subscribeDictationLevel } from "./adapters/dictation-level";
-export { dictationFailed } from "./adapters/dictation-outcome";
+export {
+  dictationFailed,
+  dictationProducedTranscript,
+} from "./adapters/dictation-outcome";
 export {
   StudioDictationAdapter,
   cancelActiveStudioDictation,

--- a/studio/frontend/src/features/chat/shared-composer.tsx
+++ b/studio/frontend/src/features/chat/shared-composer.tsx
@@ -2280,7 +2280,7 @@ export function SharedComposer({
                   onClick={startDictation}
                   aria-label="Dictate"
                 >
-                  <MicIcon className="size-4" />
+                  <MicIcon className="unsloth-dictate-icon size-4" />
                 </TooltipIconButton>
               ) : (
                 <TooltipIconButton
@@ -2329,7 +2329,7 @@ export function SharedComposer({
               type="button"
               variant="default"
               size="icon"
-              className="ml-1.5 size-8 rounded-full"
+              className="ml-1.5 size-9 rounded-full"
               onClick={stop}
             >
               <SquareIcon className="size-3 fill-current" />
@@ -2340,12 +2340,12 @@ export function SharedComposer({
               side="bottom"
               variant="default"
               size="icon"
-              className="ml-1.5 size-8 rounded-full"
+              className="ml-1.5 size-9 rounded-full"
               onClick={send}
               disabled={!canSend}
               aria-label="Send message"
             >
-              <ArrowUpIcon className="size-[22px] stroke-2" />
+              <ArrowUpIcon className="unsloth-send-icon size-[22px] stroke-2" />
             </TooltipIconButton>
           )}
         </div>

--- a/studio/frontend/src/features/chat/utils/dictation-send.ts
+++ b/studio/frontend/src/features/chat/utils/dictation-send.ts
@@ -15,3 +15,23 @@ export function dictationProducedText(before: string, after: string): boolean {
   const trimmed = after.trim();
   return trimmed.length > 0 && trimmed !== before.trim();
 }
+
+/**
+ * Whether a pending dictation send may submit now.
+ *
+ * The composer is reused across thread switches, so a send pressed in one
+ * thread can land after the user has moved to another. Submitting there would
+ * send that thread's draft, so the intent is dropped instead.
+ *
+ * @param originComposer composer identity when send was pressed
+ * @param currentComposer composer identity now that the session has ended
+ */
+export function shouldSubmitDictation(
+  originComposer: string,
+  currentComposer: string,
+  baseText: string,
+  text: string,
+): boolean {
+  if (originComposer !== currentComposer) return false;
+  return dictationProducedText(baseText, text);
+}

--- a/studio/frontend/src/features/chat/utils/dictation-send.ts
+++ b/studio/frontend/src/features/chat/utils/dictation-send.ts
@@ -17,6 +17,43 @@ export function dictationProducedText(before: string, after: string): boolean {
 }
 
 /**
+ * Every state the composer's submit rejects.
+ *
+ * One definition for both jobs: greying out the recording bar's send, and
+ * deciding whether a pending send waits rather than being spent on a submit
+ * that would bounce. Text presence is not here, since the transcript supplies
+ * it after the button is pressed.
+ */
+export function dictationSendBlocked(state: {
+  /** The composer itself is unavailable. */
+  composerDisabled: boolean;
+  /** An attachment is still uploading. */
+  uploading: boolean;
+  /** A deep research run owns the composer. */
+  researchActive: boolean;
+  /** A response is streaming or the prompt queue is going. */
+  runActive: boolean;
+  /** This composer never queues, it asks the user to wait. */
+  queueDisabled: boolean;
+  /** An image edit overlay is open. */
+  hasOverlay: boolean;
+  /** Only text can be queued, so these block while a run is active. */
+  hasAttachments: boolean;
+  hasPendingAudio: boolean;
+}): boolean {
+  if (state.composerDisabled || state.uploading || state.researchActive) {
+    return true;
+  }
+  if (!state.runActive) return false;
+  return (
+    state.queueDisabled ||
+    state.hasOverlay ||
+    state.hasAttachments ||
+    state.hasPendingAudio
+  );
+}
+
+/**
  * Whether a pending dictation send may submit now.
  *
  * Three ways it must not. The composer is reused across thread switches, so a

--- a/studio/frontend/src/features/chat/utils/dictation-send.ts
+++ b/studio/frontend/src/features/chat/utils/dictation-send.ts
@@ -19,19 +19,25 @@ export function dictationProducedText(before: string, after: string): boolean {
 /**
  * Whether a pending dictation send may submit now.
  *
- * The composer is reused across thread switches, so a send pressed in one
- * thread can land after the user has moved to another. Submitting there would
- * send that thread's draft, so the intent is dropped instead.
- *
- * @param originComposer composer identity when send was pressed
- * @param currentComposer composer identity now that the session has ended
+ * Three ways it must not. The composer is reused across thread switches, so a
+ * send pressed in one thread can land after a move to another, where it would
+ * submit that thread's draft. The plus menu stays open to the user while
+ * recording and can insert a saved prompt, which changes the text without any
+ * speech. And silence leaves whatever was already there.
  */
-export function shouldSubmitDictation(
-  originComposer: string,
-  currentComposer: string,
-  baseText: string,
-  text: string,
-): boolean {
-  if (originComposer !== currentComposer) return false;
-  return dictationProducedText(baseText, text);
+export function shouldSubmitDictation(input: {
+  /** Composer identity when send was pressed. */
+  originComposer: string;
+  /** Composer identity now that the session has ended. */
+  currentComposer: string;
+  /** The engine published a final transcript. */
+  producedTranscript: boolean;
+  /** Composer text at session start. */
+  baseText: string;
+  /** Composer text now. */
+  text: string;
+}): boolean {
+  if (input.originComposer !== input.currentComposer) return false;
+  if (!input.producedTranscript) return false;
+  return dictationProducedText(input.baseText, input.text);
 }

--- a/studio/frontend/src/features/chat/utils/dictation-send.ts
+++ b/studio/frontend/src/features/chat/utils/dictation-send.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * Whether the recording bar's send should submit once dictation ends.
+ *
+ * Only when this recording actually added text: silence and failed
+ * transcription leave a pre-recording draft in place rather than sending it
+ * half-finished.
+ *
+ * @param before composer text captured when send was pressed
+ * @param after composer text once the session ended
+ */
+export function dictationProducedText(before: string, after: string): boolean {
+  const trimmed = after.trim();
+  return trimmed.length > 0 && trimmed !== before.trim();
+}

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2870,6 +2870,12 @@ html[data-chat-font] .aui-root {
 		width: calc(var(--ui-icon-size) * 1.15);
 		height: calc(var(--ui-icon-size) * 1.15);
 	}
+	/* Composer plus keeps its pre-#7400 22px base (1.375x the token is the same
+	   curve a 22px glyph would follow), so only its scaling changed. */
+	& .unsloth-composer-plus svg {
+		width: calc(var(--ui-icon-size) * 1.375);
+		height: calc(var(--ui-icon-size) * 1.375);
+	}
 	& svg.size-\[36px\] { width: min(calc(36px * var(--ui-font-scale, 1)), calc(18px + 18px * var(--ui-font-scale, 1))); height: min(calc(36px * var(--ui-font-scale, 1)), calc(18px + 18px * var(--ui-font-scale, 1))); }
 	& svg.w-3 { width: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); }
 	& svg.h-3 { height: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); }

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1671,8 +1671,10 @@ html[data-chat-font] .aui-root {
 		@apply mt-2 mb-1 mx-3 min-h-12 w-[calc(100%-1.5rem)] resize-none overflow-y-auto bg-transparent pl-2 pr-4 pt-2 pb-3 text-sm font-[450] outline-none placeholder:text-muted-foreground focus-visible:ring-0;
 	}
 
+	/* Same 10px corner gap as the single composer, over this surface's px-1
+	   and no pb. */
 	.composer-action-wrapper {
-		@apply relative mx-2 mb-2 flex items-center justify-between;
+		@apply relative ml-2 mr-1.5 mb-2.5 flex items-center justify-between;
 	}
 
 	.composer-footer-note {
@@ -1680,9 +1682,11 @@ html[data-chat-font] .aui-root {
 		font-family: var(--font-sans);
 	}
 
-	/* Pill composer; own classes so compare-mode keeps its stacked layout. */
+	/* Pill composer; own classes so compare-mode keeps its stacked layout. pb
+	   10px matches the send circle's gap to the right edge, so it tucks evenly
+	   into the 32px corner. */
 	.unsloth-composer-surface {
-		@apply relative flex w-full flex-col rounded-[32px] bg-background dark:bg-card px-3 py-3 outline-none transition-shadow;
+		@apply relative flex w-full flex-col rounded-[32px] bg-background dark:bg-card px-3 pt-3 pb-2.5 outline-none transition-shadow;
 		container-type: inline-size;
 		font-family: var(--font-sans);
 		background-clip: padding-box;
@@ -1736,8 +1740,8 @@ html[data-chat-font] .aui-root {
 	.unsloth-composer-line .aui-composer-action-wrapper {
 		order: 3;
 		margin-left: auto;
-		/* Inset the send circle from the edge, Gemini-style. */
-		margin-right: -0.125rem;
+		/* 12px surface + 4px line padding minus this = 10px edge gap. */
+		margin-right: -0.375rem;
 	}
 
 	.unsloth-composer-line[data-expanded="true"] .unsloth-composer-input {
@@ -2855,6 +2859,17 @@ html[data-chat-font] .aui-root {
 	& svg.size-\[20px\] { width: var(--ui-icon-size); height: var(--ui-icon-size); }
 	& svg.size-\[21px\] { width: var(--ui-icon-size); height: var(--ui-icon-size); }
 	& svg.size-\[22px\] { width: var(--ui-icon-size); height: var(--ui-icon-size); }
+	/* Mic and send arrow sit above the shared glyph size: both fill their
+	   viewBox, so they read smaller than the stroked icons beside them. Keep
+	   after the size-[NN] rules they override. */
+	& svg.unsloth-dictate-icon {
+		width: calc(var(--ui-icon-size) * 1.2);
+		height: calc(var(--ui-icon-size) * 1.2);
+	}
+	& svg.unsloth-send-icon {
+		width: calc(var(--ui-icon-size) * 1.15);
+		height: calc(var(--ui-icon-size) * 1.15);
+	}
 	& svg.size-\[36px\] { width: min(calc(36px * var(--ui-font-scale, 1)), calc(18px + 18px * var(--ui-font-scale, 1))); height: min(calc(36px * var(--ui-font-scale, 1)), calc(18px + 18px * var(--ui-font-scale, 1))); }
 	& svg.w-3 { width: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); }
 	& svg.h-3 { height: min(calc(0.75rem * var(--ui-font-scale, 1)), calc(0.375rem + 0.375rem * var(--ui-font-scale, 1))); }

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -1671,10 +1671,10 @@ html[data-chat-font] .aui-root {
 		@apply mt-2 mb-1 mx-3 min-h-12 w-[calc(100%-1.5rem)] resize-none overflow-y-auto bg-transparent pl-2 pr-4 pt-2 pb-3 text-sm font-[450] outline-none placeholder:text-muted-foreground focus-visible:ring-0;
 	}
 
-	/* Same 10px corner gap as the single composer, over this surface's px-1
+	/* Same 12px corner gap as the single composer, over this surface's px-1
 	   and no pb. */
 	.composer-action-wrapper {
-		@apply relative ml-2 mr-1.5 mb-2.5 flex items-center justify-between;
+		@apply relative mx-2 mb-3 flex items-center justify-between;
 	}
 
 	.composer-footer-note {
@@ -1682,11 +1682,11 @@ html[data-chat-font] .aui-root {
 		font-family: var(--font-sans);
 	}
 
-	/* Pill composer; own classes so compare-mode keeps its stacked layout. pb
-	   10px matches the send circle's gap to the right edge, so it tucks evenly
-	   into the 32px corner. */
+	/* Pill composer; own classes so compare-mode keeps its stacked layout. py
+	   12px matches the send circle's gap to the right edge, so it sits evenly
+	   inside the 32px corner. */
 	.unsloth-composer-surface {
-		@apply relative flex w-full flex-col rounded-[32px] bg-background dark:bg-card px-3 pt-3 pb-2.5 outline-none transition-shadow;
+		@apply relative flex w-full flex-col rounded-[32px] bg-background dark:bg-card px-3 py-3 outline-none transition-shadow;
 		container-type: inline-size;
 		font-family: var(--font-sans);
 		background-clip: padding-box;
@@ -1740,8 +1740,8 @@ html[data-chat-font] .aui-root {
 	.unsloth-composer-line .aui-composer-action-wrapper {
 		order: 3;
 		margin-left: auto;
-		/* 12px surface + 4px line padding minus this = 10px edge gap. */
-		margin-right: -0.375rem;
+		/* 12px surface + 4px line padding minus this = 12px edge gap. */
+		margin-right: -0.25rem;
 	}
 
 	.unsloth-composer-line[data-expanded="true"] .unsloth-composer-input {

--- a/studio/frontend/tests/dictation-outcome.test.ts
+++ b/studio/frontend/tests/dictation-outcome.test.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  dictationFailed,
+  markDictationFailed,
+  resetDictationFailure,
+} from "../src/features/chat/adapters/dictation-outcome.ts";
+
+test("a fresh session reports no failure", () => {
+  resetDictationFailure();
+  assert.equal(dictationFailed(), false);
+});
+
+test("a reported failure is visible after the session ends", () => {
+  resetDictationFailure();
+  markDictationFailed();
+  assert.equal(dictationFailed(), true);
+});
+
+// The recording bar reads the flag once the session is gone, so it has to
+// survive until the next session starts rather than clearing on end.
+test("the failure survives until the next session starts", () => {
+  resetDictationFailure();
+  markDictationFailed();
+  assert.equal(dictationFailed(), true);
+  resetDictationFailure();
+  assert.equal(dictationFailed(), false);
+});
+
+test("repeated failures in one session stay set", () => {
+  resetDictationFailure();
+  markDictationFailed();
+  markDictationFailed();
+  assert.equal(dictationFailed(), true);
+});

--- a/studio/frontend/tests/dictation-outcome.test.ts
+++ b/studio/frontend/tests/dictation-outcome.test.ts
@@ -5,35 +5,57 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  beginDictationSession,
   dictationFailed,
+  dictationProducedTranscript,
   markDictationFailed,
-  resetDictationFailure,
+  markDictationTranscript,
 } from "../src/features/chat/adapters/dictation-outcome.ts";
 
-test("a fresh session reports no failure", () => {
-  resetDictationFailure();
+test("a fresh session has produced nothing and failed at nothing", () => {
+  beginDictationSession();
+  assert.equal(dictationProducedTranscript(), false);
   assert.equal(dictationFailed(), false);
+});
+
+test("a published transcript is visible after the session ends", () => {
+  beginDictationSession();
+  markDictationTranscript();
+  assert.equal(dictationProducedTranscript(), true);
 });
 
 test("a reported failure is visible after the session ends", () => {
-  resetDictationFailure();
+  beginDictationSession();
   markDictationFailed();
   assert.equal(dictationFailed(), true);
 });
 
-// The recording bar reads the flag once the session is gone, so it has to
-// survive until the next session starts rather than clearing on end.
-test("the failure survives until the next session starts", () => {
-  resetDictationFailure();
+// A partial transcript is both: text was published, and some was lost.
+test("a partial transcript reports both", () => {
+  beginDictationSession();
+  markDictationTranscript();
   markDictationFailed();
+  assert.equal(dictationProducedTranscript(), true);
   assert.equal(dictationFailed(), true);
-  resetDictationFailure();
+});
+
+// The recording bar reads these once the session is gone, so they have to
+// survive until the next one starts rather than clearing on end.
+test("both survive until the next session starts", () => {
+  beginDictationSession();
+  markDictationTranscript();
+  markDictationFailed();
+  beginDictationSession();
+  assert.equal(dictationProducedTranscript(), false);
   assert.equal(dictationFailed(), false);
 });
 
-test("repeated failures in one session stay set", () => {
-  resetDictationFailure();
+test("repeated marks in one session stay set", () => {
+  beginDictationSession();
+  markDictationTranscript();
+  markDictationTranscript();
   markDictationFailed();
   markDictationFailed();
+  assert.equal(dictationProducedTranscript(), true);
   assert.equal(dictationFailed(), true);
 });

--- a/studio/frontend/tests/dictation-send.test.ts
+++ b/studio/frontend/tests/dictation-send.test.ts
@@ -4,7 +4,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { dictationProducedText } from "../src/features/chat/utils/dictation-send.ts";
+import {
+  dictationProducedText,
+  shouldSubmitDictation,
+} from "../src/features/chat/utils/dictation-send.ts";
 
 test("a transcript into an empty composer sends", () => {
   assert.equal(dictationProducedText("", "hello there"), true);
@@ -32,4 +35,34 @@ test("a final transcript matching its interim still sends", () => {
 test("a whitespace-only transcript does not count as text", () => {
   assert.equal(dictationProducedText("draft", "draft  "), false);
   assert.equal(dictationProducedText("", "   "), false);
+});
+
+test("a transcript submits in the composer the send started in", () => {
+  assert.equal(
+    shouldSubmitDictation("t1:t1", "t1:t1", "", "hello there"),
+    true,
+  );
+});
+
+// The composer is reused across thread switches, so a send that lands after
+// the move would otherwise submit the destination thread's draft.
+test("a thread switch during transcription drops the send", () => {
+  assert.equal(
+    shouldSubmitDictation("t1:t1", "t2:t2", "", "someone else's draft"),
+    false,
+  );
+});
+
+test("a thread switch drops the send even with a real transcript", () => {
+  assert.equal(
+    shouldSubmitDictation("t1:t1", "t2:t2", "", "hello there"),
+    false,
+  );
+});
+
+test("silence in the original composer still sends nothing", () => {
+  assert.equal(
+    shouldSubmitDictation("t1:t1", "t1:t1", "draft", "draft"),
+    false,
+  );
 });

--- a/studio/frontend/tests/dictation-send.test.ts
+++ b/studio/frontend/tests/dictation-send.test.ts
@@ -66,3 +66,12 @@ test("silence in the original composer still sends nothing", () => {
     false,
   );
 });
+
+// The identity has to survive a new chat's first persist, which moves
+// activeThreadId from null to the remote id without changing the composer.
+test("hydrating a new chat keeps the pending send alive", () => {
+  assert.equal(
+    shouldSubmitDictation("item-1", "item-1", "", "hello there"),
+    true,
+  );
+});

--- a/studio/frontend/tests/dictation-send.test.ts
+++ b/studio/frontend/tests/dictation-send.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 
 import {
   dictationProducedText,
+  dictationSendBlocked,
   shouldSubmitDictation,
 } from "../src/features/chat/utils/dictation-send.ts";
 
@@ -96,6 +97,62 @@ test("a menu insertion with no transcript sends nothing", () => {
 test("a menu insertion alongside a real transcript still sends", () => {
   assert.equal(
     shouldSubmitDictation({ ...base, text: "an inserted prompt hello there" }),
+    true,
+  );
+});
+
+const open = {
+  composerDisabled: false,
+  uploading: false,
+  researchActive: false,
+  runActive: false,
+  queueDisabled: false,
+  hasOverlay: false,
+  hasAttachments: false,
+  hasPendingAudio: false,
+};
+
+test("an idle composer accepts the dictation send", () => {
+  assert.equal(dictationSendBlocked(open), false);
+});
+
+test("the composer's own unavailable states block regardless of a run", () => {
+  assert.equal(dictationSendBlocked({ ...open, composerDisabled: true }), true);
+  assert.equal(dictationSendBlocked({ ...open, uploading: true }), true);
+  assert.equal(dictationSendBlocked({ ...open, researchActive: true }), true);
+});
+
+// Plain text queues while a response runs, which is what the bar exists for.
+test("a running response alone does not block", () => {
+  assert.equal(dictationSendBlocked({ ...open, runActive: true }), false);
+});
+
+// Only text can be queued, so these block a send that would have to queue.
+test("non-queueable content blocks only while a run is active", () => {
+  for (const key of [
+    "queueDisabled",
+    "hasOverlay",
+    "hasAttachments",
+    "hasPendingAudio",
+  ] as const) {
+    assert.equal(dictationSendBlocked({ ...open, [key]: true }), false);
+    assert.equal(
+      dictationSendBlocked({ ...open, runActive: true, [key]: true }),
+      true,
+    );
+  }
+});
+
+// The case the button gate cannot cover: an attachment added after the press,
+// whose upload finishes before transcription does.
+test("an attachment completing mid-transcription blocks a queued send", () => {
+  assert.equal(
+    dictationSendBlocked({
+      ...open,
+      runActive: true,
+      uploading: false,
+      hasAttachments: true,
+    }),
     true,
   );
 });

--- a/studio/frontend/tests/dictation-send.test.ts
+++ b/studio/frontend/tests/dictation-send.test.ts
@@ -37,32 +37,27 @@ test("a whitespace-only transcript does not count as text", () => {
   assert.equal(dictationProducedText("", "   "), false);
 });
 
+const base = {
+  originComposer: "item-1",
+  currentComposer: "item-1",
+  producedTranscript: true,
+  baseText: "",
+  text: "hello there",
+};
+
 test("a transcript submits in the composer the send started in", () => {
-  assert.equal(
-    shouldSubmitDictation("t1:t1", "t1:t1", "", "hello there"),
-    true,
-  );
+  assert.equal(shouldSubmitDictation(base), true);
 });
 
 // The composer is reused across thread switches, so a send that lands after
 // the move would otherwise submit the destination thread's draft.
 test("a thread switch during transcription drops the send", () => {
   assert.equal(
-    shouldSubmitDictation("t1:t1", "t2:t2", "", "someone else's draft"),
-    false,
-  );
-});
-
-test("a thread switch drops the send even with a real transcript", () => {
-  assert.equal(
-    shouldSubmitDictation("t1:t1", "t2:t2", "", "hello there"),
-    false,
-  );
-});
-
-test("silence in the original composer still sends nothing", () => {
-  assert.equal(
-    shouldSubmitDictation("t1:t1", "t1:t1", "draft", "draft"),
+    shouldSubmitDictation({
+      ...base,
+      currentComposer: "item-2",
+      text: "someone else's draft",
+    }),
     false,
   );
 });
@@ -70,8 +65,37 @@ test("silence in the original composer still sends nothing", () => {
 // The identity has to survive a new chat's first persist, which moves
 // activeThreadId from null to the remote id without changing the composer.
 test("hydrating a new chat keeps the pending send alive", () => {
+  assert.equal(shouldSubmitDictation(base), true);
+});
+
+test("silence in the original composer sends nothing", () => {
   assert.equal(
-    shouldSubmitDictation("item-1", "item-1", "", "hello there"),
+    shouldSubmitDictation({
+      ...base,
+      producedTranscript: false,
+      baseText: "draft",
+      text: "draft",
+    }),
+    false,
+  );
+});
+
+// The plus menu stays open while recording: inserting a saved prompt changes
+// the composer without any speech, which text alone cannot tell apart.
+test("a menu insertion with no transcript sends nothing", () => {
+  assert.equal(
+    shouldSubmitDictation({
+      ...base,
+      producedTranscript: false,
+      text: "an inserted saved prompt",
+    }),
+    false,
+  );
+});
+
+test("a menu insertion alongside a real transcript still sends", () => {
+  assert.equal(
+    shouldSubmitDictation({ ...base, text: "an inserted prompt hello there" }),
     true,
   );
 });

--- a/studio/frontend/tests/dictation-send.test.ts
+++ b/studio/frontend/tests/dictation-send.test.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { dictationProducedText } from "../src/features/chat/utils/dictation-send.ts";
+
+test("a transcript into an empty composer sends", () => {
+  assert.equal(dictationProducedText("", "hello there"), true);
+});
+
+test("a transcript appended to a draft sends", () => {
+  assert.equal(dictationProducedText("draft", "draft hello there"), true);
+});
+
+test("silence with an empty composer sends nothing", () => {
+  assert.equal(dictationProducedText("", ""), false);
+});
+
+test("silence keeps a pre-recording draft instead of sending it", () => {
+  assert.equal(dictationProducedText("draft", "draft"), false);
+});
+
+// Anchored on the text at session start, so a final result identical to the
+// interim the browser engine already streamed in still counts as produced.
+test("a final transcript matching its interim still sends", () => {
+  assert.equal(dictationProducedText("", "hello there"), true);
+  assert.equal(dictationProducedText("draft", "draft hello there"), true);
+});
+
+test("a whitespace-only transcript does not count as text", () => {
+  assert.equal(dictationProducedText("draft", "draft  "), false);
+  assert.equal(dictationProducedText("", "   "), false);
+});


### PR DESCRIPTION
The voice recording bar in chat currently ends with a check and a cross. This swaps them for the two controls people expect from other chat apps: a stop button and the normal send button.

### Behaviour

- **Stop** (grey, square icon) ends the recording and drops the transcript into the composer, so it can be edited before sending. This is what the check used to do.
- **Send** (arrow up, same styling as the composer's send button) transcribes and submits the message in one action.
- Each button shows its own spinner while its transcription finishes, and both are disabled until it lands.
- The cross is gone, so **Escape** now discards a recording without transcribing.

### Notes

The send path stops dictation, waits for the transcript to reach the composer, then submits through the composer form rather than calling `composer.send()` directly. That keeps prompt queueing while a response is running, the hold on sending while documents index, and draft clearing behaving exactly as they do for a typed message. An empty transcript (silence, or a failed round trip) sends nothing and leaves the composer alone.

The stop button sets its own neutral grey rather than using the `secondary` variant: `--secondary` is brand green on the default light palette, and sits too close to `--card` to read on dark. The waveform also gets more padding, and the two buttons a wider gap between them.

### Testing

`npm run typecheck`, `npm run build` and `npm test` (78 passing) in `studio/frontend`.