### PR TITLE
Add 2026.7.7 release notes to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,25 @@ rename the heading at release time.
 
 ## Unreleased
 
+## 2026.7.7
+
+### What's Changed
+
+- Documents drag and drop into a chat on desktop, instead of being rejected
+  as non-GGUF.
+- Kimi K3 loads with thinking on, with corrected sampling defaults.
+- Reasoning is preserved across turns for Qwen3.x, and MoE models are sized
+  by total parameters so thinking is no longer switched off for them.
+- Coding agents run in the project you started them from, so a turn edits
+  your own files.
+- Gemma 4 MTP drafters inside a model's `MTP/` folder are detected, and a
+  large model load survives a proxy timeout under `--secure`.
+- Desktop no longer leaves a backend running after a crash, a force quit or a
+  `SIGTERM`, and macOS ships a notarized disk image.
+- Training reports its running status instead of "Starting training...", and
+  packing warns when it cannot be applied.
+- The uninstaller rejects unrecognized arguments instead of uninstalling.
+
 ## 2026.7.6
 
 ### What's Changed


### PR DESCRIPTION
`CHANGELOG.md` stops at `2026.7.6`, so the 29 PRs merged since the version bump on 29 July have no notes anywhere. This adds a `2026.7.7` section covering them, so the notes are in place before that version ships rather than after the popup starts offering it.

The empty `## Unreleased` heading stays above it as the staging spot for the next batch.

## Contents

One flat list, kept short. The bigger items lead, since the collapsed popup previews the first four bullets:

- Documents drag and drop into a chat on desktop (#7668).
- Kimi K3 thinking and sampling defaults (#7619).
- Qwen3.x reasoning across turns, and MoE sizing by total parameters (#7289).
- Agents running in the launched project (#7568).
- MTP drafters in a model's `MTP/` folder (#7385) and slow loads surviving a `--secure` proxy timeout (#7635).
- Desktop backend cleanup on crash and signals (#7655, #7614) and macOS DMG notarization (#7615).
- Training status reporting (#7613) and the packing warning (#7234).
- The uninstaller argument guard (#7631).

Test and CI-only changes are left out, matching the existing sections.

## Verification

- `parse_changelog` returns `['2026.7.7', '2026.7.6', '2026.7.5']`, so the new section is bounded correctly. The `2026.7.6` and `2026.7.5` bodies are unchanged at 3487 and 2213 chars, so nothing leaked across the boundary.
- `find_release_notes` resolves `2026.7.7`, `2026.07.7` and `v2026.7.7` to the same 877 char section, and `2026.7.8` returns nothing rather than the nearest match.
- `releaseNotesPreview` gives 4 headline items with a clean lead and `+4 more`. I reworded three bullets after a first pass: they were long enough to clamp at 120 chars with nothing left to dim, which reads as a truncated fragment in the collapsed popup.
- `tests/studio/test_update_release_notes.py`: 162 passed.

Content only, so packaging is unaffected: `_changelog_build.py` copies the file verbatim into the studio package, and the section is far under the 20,000 char cap.
