### PR TITLE
docs: fix `--quantization` flag in unsloth-cli.py usage example

### DIFF
--- a/unsloth-cli.py
+++ b/unsloth-cli.py
@@ -12,7 +12,7 @@ Usage (most options have sensible defaults; this is an extended example):
     --random_state 3407 --use_rslora --per_device_train_batch_size 4 --gradient_accumulation_steps 8 \
     --warmup_steps 5 --max_steps 400 --learning_rate 2e-6 --logging_steps 1 --optim "adamw_8bit" \
     --weight_decay 0.005 --lr_scheduler_type "linear" --seed 3407 --output_dir "outputs" \
-    --report_to "tensorboard" --save_model --save_path "model" --quantization_method "f16" \
+    --report_to "tensorboard" --save_model --save_path "model" --quantization "f16" \
     --push_model --hub_path "hf/model" --hub_token "your_hf_token"
 
 Run `python unsloth-cli.py --help` for the full list of options.


### PR DESCRIPTION
The usage example in the `unsloth-cli.py` module docstring passes:

```
--quantization_method "f16"
```

but the CLI defines the argument as `--quantization` (argparse in `unsloth-cli.py`, read as `args.quantization`). There is no `--quantization_method` argument, so copy-pasting the documented command fails with:

```
unsloth-cli.py: error: unrecognized arguments: --quantization_method f16
```

This fixes the example to `--quantization`. Note the Python `quantization_method` kwarg passed to `save_pretrained_gguf` elsewhere in the file is a different thing and is left unchanged. One-token docs fix.