### PR TITLE
Fix formatting_func race in UnslothVisionDataCollator without a lock

### DIFF
--- a/tests/test_video_path_validation.py
+++ b/tests/test_video_path_validation.py
@@ -4,14 +4,13 @@ Fixtures AST-extract the function from vision.py so logic tests run without
 the full unsloth import chain (triton/CUDA kernels).
 """
 
-import threading
-import time
 import ast
 import os
 import tempfile
+import threading
 import warnings
-from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 
 import pytest
 
@@ -499,7 +498,6 @@ def _make_real_collator(real_collator_classes, formatting_func = None):
     collator = subclass.__new__(subclass)
     collator.formatting_func = formatting_func
     collator._checked_video_paths = set()
-    collator._formatting_lock = threading.Lock()
     return collator
 
 
@@ -572,50 +570,60 @@ def test_real_collator_restores_formatting_func_when_super_raises(
     assert collator.formatting_func is fmt
 
 
-def test_vision_collator_thread_safety(monkeypatch):
-    """
-    Ensure concurrent access to the same collator instance does not lose
-    formatter applications while temporarily disabling formatting_func
-    before delegating to the parent collator.
-    """
-    from unsloth.trainer import UnslothVisionDataCollator
+def test_vision_collator_thread_safety(real_collator_classes, monkeypatch):
+    """Concurrent callers must never see formatting_func blanked on the shared
+    instance. Patches the zoo base, so the real trainer.py __call__ runs."""
+    _, zoo_base = real_collator_classes
 
-    calls = 0
-    calls_lock = threading.Lock()
+    num_threads, num_examples = 32, 3
+    formatted, formatted_lock = [], threading.Lock()
+    base_saw, base_saw_lock = [], threading.Lock()
 
     def formatter(example):
-        nonlocal calls
-        with calls_lock:
-            calls += 1
+        with formatted_lock:
+            formatted.append(example["tag"])
         return example
 
-    collator = object.__new__(UnslothVisionDataCollator)
-    collator.formatting_func = formatter
-    collator._checked_video_paths = set()
-    collator._formatting_lock = threading.Lock()
+    leader_parked, release_leader = threading.Event(), threading.Event()
+    first_entry, entered = threading.Lock(), []
 
-    parent = UnslothVisionDataCollator
-
-    def fake_parent_call(self, examples):
-        if self.formatting_func is not None:
-            examples = [self.formatting_func(x) for x in examples]
-
-        time.sleep(0.001)
+    def fake_base(self, examples):
+        with base_saw_lock:
+            base_saw.append(self.formatting_func)
+        park = False
+        with first_entry:
+            if not entered:
+                entered.append(True)
+                park = True
+        if park:
+            # Hold the window open: unsynchronised code lets every follower
+            # read the temporary None and skip formatting entirely.
+            leader_parked.set()
+            release_leader.wait(10)
         return examples
 
-    monkeypatch.setattr(parent, "__call__", fake_parent_call)
+    monkeypatch.setattr(zoo_base, "__call__", fake_base)
+    collator = _make_real_collator(real_collator_classes, formatting_func = formatter)
 
-    examples = [{"x": 1}, {"x": 2}, {"x": 3}]
+    # Fresh examples per thread, so an in-place formatter races on collator
+    # state rather than on shared user data.
+    def work(thread_id):
+        return collator([{"tag": (thread_id, i)} for i in range(num_examples)])
 
-    num_threads = 32
-    expected_calls = num_threads * len(examples)
+    try:
+        with ThreadPoolExecutor(max_workers = num_threads) as executor:
+            leader = executor.submit(work, 0)
+            assert leader_parked.wait(10), "leader never reached the base collator"
+            followers = [executor.submit(work, i) for i in range(1, num_threads)]
+            release_leader.set()
+            leader.result(timeout = 30)
+            for future in followers:
+                future.result(timeout = 30)
+    finally:
+        release_leader.set()
 
-    def worker():
-        collator(examples)
-
-    with ThreadPoolExecutor(max_workers = num_threads) as executor:
-        futures = [executor.submit(worker) for _ in range(num_threads)]
-        for future in futures:
-            future.result()
-
-    assert calls == expected_calls
+    expected = num_threads * num_examples
+    assert len(formatted) == expected
+    assert len(set(formatted)) == expected  # each example formatted exactly once
+    assert base_saw == [None] * num_threads
+    assert collator.formatting_func is formatter

--- a/tests/test_video_path_validation.py
+++ b/tests/test_video_path_validation.py
@@ -571,6 +571,7 @@ def test_real_collator_restores_formatting_func_when_super_raises(
         collator([{"anything": 1}])
     assert collator.formatting_func is fmt
 
+
 def test_vision_collator_thread_safety(monkeypatch):
     """
     Ensure concurrent access to the same collator instance does not lose
@@ -591,7 +592,7 @@ def test_vision_collator_thread_safety(monkeypatch):
     collator = object.__new__(UnslothVisionDataCollator)
     collator.formatting_func = formatter
     collator._checked_video_paths = set()
-    collator._formatting_lock = threading.Lock() 
+    collator._formatting_lock = threading.Lock()
 
     parent = UnslothVisionDataCollator
 
@@ -612,7 +613,7 @@ def test_vision_collator_thread_safety(monkeypatch):
     def worker():
         collator(examples)
 
-    with ThreadPoolExecutor(max_workers=num_threads) as executor:
+    with ThreadPoolExecutor(max_workers = num_threads) as executor:
         futures = [executor.submit(worker) for _ in range(num_threads)]
         for future in futures:
             future.result()

--- a/tests/test_video_path_validation.py
+++ b/tests/test_video_path_validation.py
@@ -4,11 +4,14 @@ Fixtures AST-extract the function from vision.py so logic tests run without
 the full unsloth import chain (triton/CUDA kernels).
 """
 
+import threading
+import time
 import ast
 import os
 import tempfile
 import warnings
 from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -496,6 +499,7 @@ def _make_real_collator(real_collator_classes, formatting_func = None):
     collator = subclass.__new__(subclass)
     collator.formatting_func = formatting_func
     collator._checked_video_paths = set()
+    collator._formatting_lock = threading.Lock()
     return collator
 
 
@@ -566,3 +570,51 @@ def test_real_collator_restores_formatting_func_when_super_raises(
     with pytest.raises(RuntimeError):
         collator([{"anything": 1}])
     assert collator.formatting_func is fmt
+
+def test_vision_collator_thread_safety(monkeypatch):
+    """
+    Ensure concurrent access to the same collator instance does not lose
+    formatter applications while temporarily disabling formatting_func
+    before delegating to the parent collator.
+    """
+    from unsloth.trainer import UnslothVisionDataCollator
+
+    calls = 0
+    calls_lock = threading.Lock()
+
+    def formatter(example):
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+        return example
+
+    collator = object.__new__(UnslothVisionDataCollator)
+    collator.formatting_func = formatter
+    collator._checked_video_paths = set()
+    collator._formatting_lock = threading.Lock() 
+
+    parent = UnslothVisionDataCollator
+
+    def fake_parent_call(self, examples):
+        if self.formatting_func is not None:
+            examples = [self.formatting_func(x) for x in examples]
+
+        time.sleep(0.001)
+        return examples
+
+    monkeypatch.setattr(parent, "__call__", fake_parent_call)
+
+    examples = [{"x": 1}, {"x": 2}, {"x": 3}]
+
+    num_threads = 32
+    expected_calls = num_threads * len(examples)
+
+    def worker():
+        collator(examples)
+
+    with ThreadPoolExecutor(max_workers=num_threads) as executor:
+        futures = [executor.submit(worker) for _ in range(num_threads)]
+        for future in futures:
+            future.result()
+
+    assert calls == expected_calls

--- a/tests/test_video_path_validation.py
+++ b/tests/test_video_path_validation.py
@@ -489,6 +489,10 @@ def real_collator_classes():
         )
     except Exception as exc:  # noqa: BLE001 - skip on any import failure
         pytest.skip(f"full unsloth import unavailable: {exc!r}")
+    # On Apple Silicon MLX, unsloth.trainer is a shim and this name is a
+    # placeholder whose __call__ raises, not the zoo subclass under test.
+    if not issubclass(UnslothVisionDataCollator, ZooBase):
+        pytest.skip("MLX placeholder collator, not the torch subclass")
     return UnslothVisionDataCollator, ZooBase
 
 

--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import threading
 import logging
 import os
 import psutil
@@ -66,32 +67,35 @@ class UnslothVisionDataCollator(_UnslothVisionDataCollatorBase):
     of silently training on empty video tensors (issue #5085).
     """
 
-    __slots__ = ("_checked_video_paths",)
+    __slots__ = ("_checked_video_paths", "_formatting_lock")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._checked_video_paths = set()
+        self._formatting_lock = threading.Lock()
 
     def __call__(self, examples):
-        formatting_func = self.formatting_func
-        if formatting_func is not None:
-            examples = [formatting_func(example) for example in examples]
+        with self._formatting_lock:
+            formatting_func = self.formatting_func
 
-        check_dataset_for_missing_videos(
-            examples,
-            raise_error = True,
-            checked = self._checked_video_paths,
-        )
+            if formatting_func is not None:
+                examples = [formatting_func(example) for example in examples]
 
-        if formatting_func is None:
-            return super().__call__(examples)
+            check_dataset_for_missing_videos(
+                examples,
+                raise_error=True,
+                checked=self._checked_video_paths,
+            )
 
-        # why: base __call__ would reapply formatting_func; applied above.
-        self.formatting_func = None
-        try:
-            return super().__call__(examples)
-        finally:
-            self.formatting_func = formatting_func
+            if formatting_func is None:
+                return super().__call__(examples)
+
+            # why: base __call__ would reapply formatting_func; applied above.
+            self.formatting_func = None
+            try:
+                return super().__call__(examples)
+            finally:
+                self.formatting_func = formatting_func
 
 
 _AUTO_PADDING_FREE_ENV_DISABLED = os.environ.get(

--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -83,8 +83,8 @@ class UnslothVisionDataCollator(_UnslothVisionDataCollatorBase):
 
             check_dataset_for_missing_videos(
                 examples,
-                raise_error=True,
-                checked=self._checked_video_paths,
+                raise_error = True,
+                checked = self._checked_video_paths,
             )
 
             if formatting_func is None:

--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import threading
+import copy
 import logging
 import os
 import psutil
@@ -67,35 +67,32 @@ class UnslothVisionDataCollator(_UnslothVisionDataCollatorBase):
     of silently training on empty video tensors (issue #5085).
     """
 
-    __slots__ = ("_checked_video_paths", "_formatting_lock")
+    __slots__ = ("_checked_video_paths",)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._checked_video_paths = set()
-        self._formatting_lock = threading.Lock()
 
     def __call__(self, examples):
-        with self._formatting_lock:
-            formatting_func = self.formatting_func
+        formatting_func = self.formatting_func
+        if formatting_func is not None:
+            examples = [formatting_func(example) for example in examples]
 
-            if formatting_func is not None:
-                examples = [formatting_func(example) for example in examples]
+        check_dataset_for_missing_videos(
+            examples,
+            raise_error = True,
+            checked = self._checked_video_paths,
+        )
 
-            check_dataset_for_missing_videos(
-                examples,
-                raise_error = True,
-                checked = self._checked_video_paths,
-            )
+        if formatting_func is None:
+            return super().__call__(examples)
 
-            if formatting_func is None:
-                return super().__call__(examples)
-
-            # why: base __call__ would reapply formatting_func; applied above.
-            self.formatting_func = None
-            try:
-                return super().__call__(examples)
-            finally:
-                self.formatting_func = formatting_func
+        # why: base __call__ would reapply formatting_func; applied above. A
+        # per-call shallow view shares every other attribute by reference, so a
+        # concurrent caller can never observe formatting_func blanked on self.
+        view = copy.copy(self)
+        view.formatting_func = None
+        return super(UnslothVisionDataCollator, view).__call__(examples)
 
 
 _AUTO_PADDING_FREE_ENV_DISABLED = os.environ.get(


### PR DESCRIPTION
## Summary

`UnslothVisionDataCollator.__call__` applies `formatting_func` itself, then blanks
`self.formatting_func` for the duration of the base call so the zoo collator does not
apply it a second time, restoring it in a `finally`. That is correct single threaded.
When two threads share one collator instance, the second reads the blanked value, skips
formatting, and hands a raw row to the base.

Original diagnosis and report by @adinfarel. The fix and the test were reworked during
review, see the commits and the discussion below.

## How bad it is

Real Qwen2VL processor, 8 threads, 320 batches, no timing tricks:

| version | ok | bad |
|---|---:|---:|
| before | 5 (1.6%) | 315 (98.4%), `KeyError` |
| after | 320 (100%) | 0 |

Real collation takes about 2 ms, so the window the blanking leaves open is wide enough
that the race is the normal outcome rather than a rare interleaving. The unformatted row
reaches `_select_messages_or_raw`, which fails on `messages[0]`. On free threaded builds
(3.13t, 3.14t) it also shows up without any real work in the base: 62 to 125 of 300
batches silently unformatted, and 3.13t additionally raises
`TypeError: 'NoneType' object is not callable` when the blank lands between the base's
`is not None` check and the call.

Reaching this at all requires sharing one collator across Python threads. `Trainer`
passes the collator straight to `DataLoader`; with `dataloader_num_workers=0` collation
is sequential, and with workers each process has its own copy. So standard training is
unaffected.

## Fix

Stop mutating shared state. A per-call shallow view carries `formatting_func=None` into
the base while `self` is left alone:

```python
view = copy.copy(self)
view.formatting_func = None
return super(UnslothVisionDataCollator, view).__call__(examples)
```

`copy.copy` on a `__slots__` object shares `processor`, `size_func` and
`_checked_video_paths` by reference, so only `formatting_func` differs on the throwaway
view and the video path dedup cache still accumulates on the original.

A lock was tried first and rejected. Because the base reads `self.formatting_func` for
its whole call, a narrow lock still races, so the lock has to span the entire collate.
That costs more than it buys: `threading.Lock` is not picklable, so `copy.deepcopy` and
`cloudpickle` of the collator stop working, which breaks
`Trainer.hyperparameter_search(backend="ray")` since Ray ships the whole Trainer through
its object store; a `formatting_func` that re-enters the collator deadlocks; and threaded
throughput drops below the single thread rate.

## Test

`test_vision_collator_thread_safety` patches the zoo base, which is what
`super().__call__` resolves to, parks a leader inside the mutation window, releases 31
followers behind it, and asserts every example is formatted exactly once. It fails with
`assert 3 == 96` against the old body and passes 10 runs out of 10 with the fix.

`real_collator_classes` now also skips when `unsloth.trainer` resolves to the Apple
Silicon MLX placeholder rather than the zoo subclass. That placeholder's `__call__`
raises, so `test_real_collator_blocks_super_on_missing_video` and
`test_real_collator_calls_super_with_formatting_disabled` have been failing on `macos-14`
on main; they now skip.

## Verification

- 36 tests in `tests/test_video_path_validation.py` pass
- Qwen2-VL-2B LoRA, 20 steps, seed 3407: losses, grad norms and peak memory element-wise
  identical to main, with `dataloader_num_workers` 0 and 2
- collator throughput with a real processor: 505 batches/s at 4 threads against 94 for the
  lock version; single thread per-call cost 1.995 ms against 1.798 ms on main
- CPython 3.9 through 3.15 plus free threaded 3.13t and 3.14t
- `ubuntu-latest`, `macos-14` and `windows-latest` runners, all green, compared against a
  matching no-PR baseline on the same runners
- `pickle`, `deepcopy` and `cloudpickle` behave exactly as on main, on all three platforms

Note for context: `DataLoader` workers under `spawn` (the default on Windows and macOS)
cannot pickle this collator either way, because `unsloth_zoo/vision_utils.py` stores a
local lambda in `size_func`. That predates this PR and is not addressed here.
