### PR TITLE
feat(studio): support XLSX attachments in Chat

### DIFF
--- a/studio/frontend/package-lock.json
+++ b/studio/frontend/package-lock.json
@@ -61,6 +61,7 @@
         "react-dom": "^19.2.4",
         "react-pdf": "10.4.1",
         "react-resizable-panels": "^4.6.4",
+        "read-excel-file": "9.3.5",
         "recharts": "3.7.0",
         "shadcn": "^4.2.0",
         "sonner": "^2.0.7",
@@ -12615,6 +12616,11 @@
         "node": ">= 6.13.0"
       }
     },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
+    },
     "node_modules/node-releases": {
       "version": "2.0.38",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
@@ -13699,6 +13705,20 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/read-excel-file": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/read-excel-file/-/read-excel-file-9.3.5.tgz",
+      "integrity": "sha512-A4EbaJxFrqzBNdU4Lw0g6wzme3m7ywW3MsPLLuBiGPUWJbxETyVDT5vyqsOnl/AW48OGM4MGoOgKFsEZNMMVVw==",
+      "dependencies": {
+        "fflate": "^0.8.3",
+        "saxen": "^11.1.0",
+        "unzipper-esm": "^0.13.3",
+        "worker-f": "^0.1.12"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -14150,6 +14170,14 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxen": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/saxen/-/saxen-11.1.1.tgz",
+      "integrity": "sha512-J4BkmJFaM7VgE7pgkFGsNEcqqM3h7+Mz80vfLWFhx7uNOCOXIu6LLjQHYWNejdst3pf/3JUaBIG9+pkk1umlow==",
+      "engines": {
+        "node": ">= 20.12"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -15207,6 +15235,18 @@
         "url": "https://github.com/sponsors/kettanaito"
       }
     },
+    "node_modules/unzipper-esm": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/unzipper-esm/-/unzipper-esm-0.13.3.tgz",
+      "integrity": "sha512-LUO6VZ6fCzkDbdMev0/fOhoIeVGKaOkTIOoYxVLE0SQjfvmAHK+oywl7lfhloSZIsdGJ25mJ18Mtd9CyTASjrA==",
+      "dependencies": {
+        "graceful-fs": "^4.2.2",
+        "node-int64": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -15596,6 +15636,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/worker-f": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/worker-f/-/worker-f-0.1.13.tgz",
+      "integrity": "sha512-wAtKSRQjuaUueG/rZEN19aJEp9nY4fUEM+HoFidN7qpicB/wSf9fbyQ7Q3gAcJqoWvXHMxQ4kATPFxlLiD6rbQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/wrap-ansi": {

--- a/studio/frontend/package.json
+++ b/studio/frontend/package.json
@@ -71,6 +71,7 @@
     "react-dom": "^19.2.4",
     "react-pdf": "10.4.1",
     "react-resizable-panels": "^4.6.4",
+    "read-excel-file": "9.3.5",
     "recharts": "3.7.0",
     "shadcn": "^4.2.0",
     "sonner": "^2.0.7",

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -57,6 +57,11 @@ import {
   readActiveOpenDocumentAttachmentContent,
   readOpenDocumentAttachmentContent,
 } from "./open-document";
+import {
+  XLSX_WORKBOOK_MIME,
+  readActiveXlsxAttachmentText,
+  readXlsxAttachmentText,
+} from "./xlsx-attachment";
 import { AudioAttachmentAdapter } from "./audio-attachment-adapter";
 import { useChatRuntimeStore } from "./stores/chat-runtime-store";
 import { ToolPaneScopeContext, toolPaneScope } from "./tool-output-scope";
@@ -412,6 +417,83 @@ class OpenDocumentAttachmentAdapter implements AttachmentAdapter {
         contentType: attachment.contentType,
         content: [
           { type: "text", text: `[${label}: ${attachment.name}]\n${text}` },
+        ],
+        status: { type: "complete" },
+      };
+    } finally {
+      this.active.delete(attachment.id);
+      this.content.delete(attachment.id);
+      this.sending.delete(attachment.id);
+    }
+  }
+
+  remove(attachment: { id: string }): Promise<void> {
+    this.active.delete(attachment.id);
+    this.sending.delete(attachment.id);
+    this.content.delete(attachment.id);
+    return Promise.resolve();
+  }
+}
+
+class XlsxAttachmentAdapter implements AttachmentAdapter {
+  private readonly active = new Set<string>();
+  private readonly sending = new Set<string>();
+  private readonly content = new Map<string, Promise<string | null>>();
+
+  accept = [".xlsx", XLSX_WORKBOOK_MIME].join(",");
+
+  async *add({
+    file,
+  }: { file: File }): AsyncGenerator<PendingAttachment, void> {
+    const id = crypto.randomUUID();
+    this.active.add(id);
+    const attachment = {
+      id,
+      type: "document",
+      name: file.name,
+      contentType: file.type,
+      file,
+      status: { type: "running", reason: "uploading", progress: 0 },
+    } satisfies PendingAttachment;
+
+    yield attachment;
+    const content = readActiveXlsxAttachmentText(file, () =>
+      this.active.has(id),
+    );
+    this.content.set(id, content);
+
+    try {
+      if ((await content) && this.active.has(id) && !this.sending.has(id)) {
+        yield {
+          ...attachment,
+          status: { type: "requires-action", reason: "composer-send" },
+        };
+      }
+    } catch {
+      this.active.delete(id);
+      this.content.delete(id);
+      if (!this.sending.has(id)) {
+        yield {
+          ...attachment,
+          status: { type: "incomplete", reason: "error" },
+        };
+      }
+    }
+  }
+
+  async send(attachment: PendingAttachment): Promise<CompleteAttachment> {
+    this.sending.add(attachment.id);
+    try {
+      const text =
+        (await this.content.get(attachment.id)) ??
+        (await readXlsxAttachmentText(attachment.file));
+      return {
+        id: attachment.id,
+        type: "document",
+        name: attachment.name,
+        contentType: attachment.contentType,
+        content: [
+          { type: "text", text: `[XLSX: ${attachment.name}]\n${text}` },
         ],
         status: { type: "complete" },
       };
@@ -1302,6 +1384,7 @@ function useStudioRuntimeAdapters(
         new PDFAttachmentAdapter(),
         new DocxAttachmentAdapter(),
         new OpenDocumentAttachmentAdapter(),
+        new XlsxAttachmentAdapter(),
       ]),
     [],
   );

--- a/studio/frontend/src/features/chat/xlsx-attachment.ts
+++ b/studio/frontend/src/features/chat/xlsx-attachment.ts
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import { unzipSync } from "fflate";
+
+export const XLSX_WORKBOOK_MIME =
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+const MAX_XLSX_ARCHIVE_BYTES = 50 * 1024 * 1024;
+
+export type XlsxArchiveLimits = {
+  maxEntries: number;
+  maxXmlEntryBytes: number;
+  maxXmlBytes: number;
+};
+
+const DEFAULT_XLSX_ARCHIVE_LIMITS: XlsxArchiveLimits = {
+  maxEntries: 2_000,
+  maxXmlEntryBytes: 25 * 1024 * 1024,
+  maxXmlBytes: 100 * 1024 * 1024,
+};
+
+export type XlsxFormatLimits = {
+  maxSheets: number;
+  maxRows: number;
+  maxColumns: number;
+  maxCharacters: number;
+};
+
+const DEFAULT_XLSX_FORMAT_LIMITS: XlsxFormatLimits = {
+  maxSheets: 100,
+  maxRows: 20_000,
+  maxColumns: 1_000,
+  maxCharacters: 250_000,
+};
+
+export type ChatXlsxSheet = {
+  sheet: string;
+  data: unknown[][];
+};
+
+const TRUNCATION_NOTICE = "[Workbook content truncated for chat.]";
+
+export async function readXlsxAttachmentText(file: File): Promise<string> {
+  if (file.size > MAX_XLSX_ARCHIVE_BYTES) {
+    throw new Error(`XLSX archive is too large: ${file.name}`);
+  }
+
+  const [{ default: readXlsxFile }, buffer] = await Promise.all([
+    import("read-excel-file/browser"),
+    file.arrayBuffer(),
+  ]);
+  assertXlsxArchiveSafety(new Uint8Array(buffer), file.name);
+
+  let sheets: ChatXlsxSheet[];
+  try {
+    sheets = (await readXlsxFile(buffer)) as ChatXlsxSheet[];
+  } catch (error) {
+    const detail = error instanceof Error ? `: ${error.message}` : "";
+    throw new Error(`Failed to parse XLSX workbook: ${file.name}${detail}`, {
+      cause: error,
+    });
+  }
+
+  return formatXlsxWorkbookForChat(sheets);
+}
+
+export async function readActiveXlsxAttachmentText(
+  file: File,
+  isActive: () => boolean,
+): Promise<string | null> {
+  try {
+    const text = await readXlsxAttachmentText(file);
+    return isActive() ? text : null;
+  } catch (error) {
+    if (!isActive()) return null;
+    throw error;
+  }
+}
+
+export function assertXlsxArchiveSafety(
+  bytes: Uint8Array,
+  filename: string,
+  limits: XlsxArchiveLimits = DEFAULT_XLSX_ARCHIVE_LIMITS,
+): void {
+  let entries = 0;
+  let xmlBytes = 0;
+  let hasWorkbook = false;
+
+  try {
+    unzipSync(bytes, {
+      filter: (entry) => {
+        entries++;
+        if (entries > limits.maxEntries) {
+          throw new Error(`XLSX archive has too many entries: ${filename}`);
+        }
+
+        if (entry.name === "xl/workbook.xml") hasWorkbook = true;
+        if (!isXlsxXmlEntry(entry.name)) return false;
+
+        if (entry.originalSize > limits.maxXmlEntryBytes) {
+          throw new Error(
+            `XLSX XML entry is too large: ${filename}:${entry.name}`,
+          );
+        }
+        xmlBytes += entry.originalSize;
+        if (xmlBytes > limits.maxXmlBytes) {
+          throw new Error(`XLSX XML content is too large: ${filename}`);
+        }
+        return false;
+      },
+    });
+  } catch (error) {
+    if (isXlsxSafetyError(error)) throw error;
+    throw new Error(`Failed to read XLSX archive: ${filename}`, {
+      cause: error,
+    });
+  }
+
+  if (!hasWorkbook) {
+    throw new Error(`XLSX archive is missing xl/workbook.xml: ${filename}`);
+  }
+}
+
+export function formatXlsxWorkbookForChat(
+  sheets: ChatXlsxSheet[],
+  limits: XlsxFormatLimits = DEFAULT_XLSX_FORMAT_LIMITS,
+): string {
+  if (sheets.length === 0) return "(Workbook contains no worksheets.)";
+
+  const lines: string[] = [];
+  let characters = 0;
+  let rows = 0;
+  let truncated = false;
+
+  const appendLine = (line: string): boolean => {
+    const addedLength = line.length + (lines.length > 0 ? 1 : 0);
+    if (characters + addedLength > limits.maxCharacters) {
+      const remaining = Math.max(
+        0,
+        limits.maxCharacters - characters - (lines.length > 0 ? 1 : 0),
+      );
+      if (remaining > 0) lines.push(line.slice(0, remaining).trimEnd());
+      truncated = true;
+      return false;
+    }
+    lines.push(line);
+    characters += addedLength;
+    return true;
+  };
+
+  sheetLoop: for (const [sheetIndex, sheet] of sheets.entries()) {
+    if (sheetIndex >= limits.maxSheets) {
+      truncated = true;
+      break;
+    }
+
+    if (lines.length > 0 && !appendLine("")) break;
+    const sheetName =
+      normalizeXlsxCellText(sheet.sheet) || `Sheet ${sheetIndex + 1}`;
+    if (!appendLine(`[Sheet: ${sheetName}]`)) break;
+
+    let sheetHasRows = false;
+    for (const row of sheet.data) {
+      const cells = row.slice(0, limits.maxColumns).map(formatXlsxCellForChat);
+      while (cells.length > 0 && cells.at(-1) === "") cells.pop();
+      if (cells.length === 0) continue;
+
+      if (rows >= limits.maxRows) {
+        truncated = true;
+        break sheetLoop;
+      }
+      if (row.length > limits.maxColumns) truncated = true;
+      if (!appendLine(cells.join("\t"))) break sheetLoop;
+      rows++;
+      sheetHasRows = true;
+    }
+
+    if (!sheetHasRows && !appendLine("(empty sheet)")) break;
+  }
+
+  if (truncated) {
+    if (lines.at(-1) !== "") lines.push("");
+    lines.push(TRUNCATION_NOTICE);
+  }
+  return lines.join("\n");
+}
+
+function isXlsxXmlEntry(name: string): boolean {
+  const lower = name.toLowerCase();
+  return lower.endsWith(".xml") || lower.endsWith(".xml.rels");
+}
+
+function isXlsxSafetyError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message.startsWith("XLSX archive has too many entries:") ||
+      error.message.startsWith("XLSX XML entry is too large:") ||
+      error.message.startsWith("XLSX XML content is too large:"))
+  );
+}
+
+function formatXlsxCellForChat(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? "" : value.toISOString();
+  }
+  return normalizeXlsxCellText(String(value));
+}
+
+function normalizeXlsxCellText(value: string): string {
+  return value
+    .replace(/\r\n?/g, "\n")
+    .replace(/\t/g, "    ")
+    .replace(/\n/g, " ⏎ ")
+    .trim();
+}

--- a/studio/frontend/tests/xlsx-attachment.test.ts
+++ b/studio/frontend/tests/xlsx-attachment.test.ts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { strToU8, zipSync } from "fflate";
+import {
+  XLSX_WORKBOOK_MIME,
+  assertXlsxArchiveSafety,
+  formatXlsxWorkbookForChat,
+  readXlsxAttachmentText,
+} from "../src/features/chat/xlsx-attachment.ts";
+
+function minimalXlsxArchive(): Uint8Array {
+  return zipSync({
+    "xl/workbook.xml": strToU8(
+      [
+        '<?xml version="1.0"?>',
+        '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"',
+        ' xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">',
+        '<sheets><sheet name="Data" sheetId="1" r:id="rId1"/></sheets>',
+        "</workbook>",
+      ].join(""),
+    ),
+    "xl/_rels/workbook.xml.rels": strToU8(
+      [
+        '<?xml version="1.0"?>',
+        '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">',
+        '<Relationship Id="rId1"',
+        ' Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"',
+        ' Target="worksheets/sheet1.xml"/>',
+        "</Relationships>",
+      ].join(""),
+    ),
+    "xl/worksheets/sheet1.xml": strToU8(
+      [
+        '<?xml version="1.0"?>',
+        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">',
+        '<sheetData><row r="1">',
+        '<c r="A1" t="inlineStr"><is><t>value</t></is></c>',
+        '<c r="B1"><v>42</v></c>',
+        "</row></sheetData></worksheet>",
+      ].join(""),
+    ),
+    "xl/styles.xml": strToU8(
+      [
+        '<?xml version="1.0"?>',
+        '<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">',
+        '<cellXfs count="1"><xf numFmtId="0"/></cellXfs>',
+        "</styleSheet>",
+      ].join(""),
+    ),
+  });
+}
+
+test("formats every worksheet and common cell value", () => {
+  const text = formatXlsxWorkbookForChat([
+    {
+      sheet: "Revenue",
+      data: [
+        ["Name", "Amount", "Active", "When"],
+        ["Alice", 12.5, true, new Date("2026-07-31T12:30:00.000Z")],
+        [],
+      ],
+    },
+    {
+      sheet: "Notes\n2026",
+      data: [["Line 1\nLine 2", "tab\tvalue"]],
+    },
+  ]);
+
+  assert.equal(
+    text,
+    [
+      "[Sheet: Revenue]",
+      "Name\tAmount\tActive\tWhen",
+      "Alice\t12.5\ttrue\t2026-07-31T12:30:00.000Z",
+      "",
+      "[Sheet: Notes ⏎ 2026]",
+      "Line 1 ⏎ Line 2\ttab    value",
+    ].join("\n"),
+  );
+});
+
+test("marks workbook text when chat limits truncate it", () => {
+  const text = formatXlsxWorkbookForChat(
+    [{ sheet: "Sheet 1", data: [["first"], ["second"]] }],
+    { maxSheets: 10, maxRows: 1, maxColumns: 10, maxCharacters: 1_000 },
+  );
+
+  assert.match(text, /^\[Sheet: Sheet 1\]\nfirst/);
+  assert.match(text, /\[Workbook content truncated for chat\.\]$/);
+  assert.doesNotMatch(text, /second/);
+});
+
+test("preflights XLSX archives before parsing", () => {
+  const archive = minimalXlsxArchive();
+  assert.doesNotThrow(() => assertXlsxArchiveSafety(archive, "workbook.xlsx"));
+  assert.throws(
+    () =>
+      assertXlsxArchiveSafety(archive, "workbook.xlsx", {
+        maxEntries: 100,
+        maxXmlEntryBytes: 10,
+        maxXmlBytes: 1_000,
+      }),
+    /XLSX XML entry is too large/,
+  );
+  assert.throws(
+    () =>
+      assertXlsxArchiveSafety(
+        zipSync({ "xl/worksheets/sheet1.xml": strToU8("<worksheet/>") }),
+        "not-a-workbook.xlsx",
+      ),
+    /missing xl\/workbook\.xml/,
+  );
+});
+
+test("parses and formats a real XLSX archive", async () => {
+  const archive = minimalXlsxArchive();
+  const file = new File([archive.buffer as ArrayBuffer], "fixture.xlsx", {
+    type: XLSX_WORKBOOK_MIME,
+  });
+
+  const text = await readXlsxAttachmentText(file);
+  assert.equal(text, "[Sheet: Data]\nvalue\t42");
+});

--- a/studio/src-tauri/src/native_clipboard.rs
+++ b/studio/src-tauri/src/native_clipboard.rs
@@ -79,6 +79,7 @@ fn clipboard_file_mime_type(path: &Path) -> Option<&'static str> {
         "gif" => "image/gif",
         "pdf" => "application/pdf",
         "docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         "odt" => "application/vnd.oasis.opendocument.text",
         "ods" => "application/vnd.oasis.opendocument.spreadsheet",
         "mp3" => "audio/mpeg",
@@ -359,7 +360,7 @@ mod tests {
     }
 
     #[test]
-    fn clipboard_file_mime_types_cover_text_attachments() {
+    fn clipboard_file_mime_types_cover_chat_attachments() {
         assert_eq!(
             clipboard_file_mime_type(Path::new("data.json")),
             Some("application/json")
@@ -367,6 +368,12 @@ mod tests {
         assert_eq!(
             clipboard_file_mime_type(Path::new("notes.md")),
             Some("text/markdown")
+        );
+        assert_eq!(
+            clipboard_file_mime_type(Path::new("workbook.xlsx")),
+            Some(
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            )
         );
         assert_eq!(clipboard_file_mime_type(Path::new("unknown.bin")), None);
     }


### PR DESCRIPTION
## Summary

- add `.xlsx` uploads to the regular Chat attachment adapter
- parse every worksheet into labelled, tab-separated text for the model
- validate archive expansion and bound the generated chat context
- recognize copied `.xlsx` files in the desktop native clipboard path
- add focused coverage, including a real minimal XLSX archive

## Why

Regular Chat supported text, PDF, DOCX, and OpenDocument attachments but had no adapter capable of parsing Excel workbooks. Selecting an `.xlsx` file therefore was not available even though its worksheet data can be supplied directly as chat context.

## Scope

This PR intentionally covers regular Chat only. Compare Chat and Chat with Files/RAG use separate attachment and indexing implementations and can be handled in follow-up PRs. Legacy `.xls` and `.xlsb` formats are also out of scope.

## Safety and behavior

- rejects archives larger than 50 MiB
- preflights entry count and expanded XML sizes before parsing
- caps rendered workbook context at 100 sheets, 20,000 rows, 1,000 columns per row, and 250,000 characters
- clearly marks workbook content when a chat-context limit truncates it

## Validation

- frontend tests: 163 passed
- application TypeScript check passed
- test TypeScript check passed
- production Vite build passed
- Rust clipboard MIME assertion added; the Rust test suite was not run locally because the environment did not have Cargo/rustfmt installed
