### PR TITLE
Desktop: restore the confirmations that only worked in the browser

### DIFF
--- a/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
+++ b/studio/frontend/src/features/chat/chat-mcp-servers-dialog.tsx
@@ -7,6 +7,16 @@ import { Delete02Icon, Edit03Icon, PlusSignIcon } from "@hugeicons/core-free-ico
 import { HugeiconsIcon } from "@hugeicons/react";
 import { RefreshCwIcon, UploadIcon } from "lucide-react";
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -197,6 +207,9 @@ export function ChatMcpServersDialog({
   const [testing, setTesting] = useState(false);
   const [importing, setImporting] = useState(false);
   const [refreshingId, setRefreshingId] = useState<string | null>(null);
+  const [confirmingDelete, setConfirmingDelete] = useState<McpServerConfig | null>(
+    null,
+  );
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const refresh = useCallback(async () => {
@@ -362,8 +375,6 @@ export function ChatMcpServersDialog({
   }
 
   async function removeServer(server: McpServerConfig) {
-    const ok = window.confirm(`Delete MCP server "${server.display_name}"?`);
-    if (!ok) return;
     try {
       await deleteMcpServer(server.id);
       await refresh();
@@ -612,7 +623,7 @@ export function ChatMcpServersDialog({
                         type="button"
                         variant="ghost"
                         size="icon"
-                        onClick={() => removeServer(server)}
+                        onClick={() => setConfirmingDelete(server)}
                         aria-label="Delete server"
                       >
                         <HugeiconsIcon icon={Delete02Icon} size={14} />
@@ -625,6 +636,38 @@ export function ChatMcpServersDialog({
           </div>
         )}
       </DialogContent>
+      <AlertDialog
+        open={confirmingDelete !== null}
+        onOpenChange={(next) => {
+          if (!next) setConfirmingDelete(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete MCP server</AlertDialogTitle>
+            <AlertDialogDescription>
+              Delete{" "}
+              <span className="font-medium text-foreground">
+                &quot;{confirmingDelete?.display_name}&quot;
+              </span>
+              ? Its tools stop being available to chats. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={() => {
+                const server = confirmingDelete;
+                setConfirmingDelete(null);
+                if (server) void removeServer(server);
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Dialog>
   );
 }

--- a/studio/frontend/src/features/rag/components/knowledge-base-dialog.tsx
+++ b/studio/frontend/src/features/rag/components/knowledge-base-dialog.tsx
@@ -10,6 +10,16 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { ChevronLeftIcon, UploadIcon } from "lucide-react";
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -56,6 +66,9 @@ export function KnowledgeBaseDialog({
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [saving, setSaving] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState<KnowledgeBase | null>(
+    null,
+  );
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -125,13 +138,6 @@ export function KnowledgeBaseDialog({
   }
 
   async function removeKb(kb: KnowledgeBase) {
-    if (
-      !window.confirm(
-        `Delete knowledge base "${kb.name}" and all its documents?`,
-      )
-    ) {
-      return;
-    }
     try {
       await deleteKnowledgeBase(kb.id);
       await refresh();
@@ -242,7 +248,7 @@ export function KnowledgeBaseDialog({
                         type="button"
                         variant="ghost"
                         size="icon"
-                        onClick={() => removeKb(kb)}
+                        onClick={() => setConfirmingDelete(kb)}
                         aria-label="Delete knowledge base"
                       >
                         <HugeiconsIcon icon={Delete02Icon} size={14} />
@@ -255,6 +261,38 @@ export function KnowledgeBaseDialog({
           </div>
         )}
       </DialogContent>
+      <AlertDialog
+        open={confirmingDelete !== null}
+        onOpenChange={(next) => {
+          if (!next) setConfirmingDelete(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete knowledge base</AlertDialogTitle>
+            <AlertDialogDescription>
+              Delete{" "}
+              <span className="font-medium text-foreground">
+                &quot;{confirmingDelete?.name}&quot;
+              </span>{" "}
+              and all its documents? This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={() => {
+                const kb = confirmingDelete;
+                setConfirmingDelete(null);
+                if (kb) void removeKb(kb);
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Dialog>
   );
 }

--- a/studio/frontend/src/features/training/hooks/use-training-unload-guard.ts
+++ b/studio/frontend/src/features/training/hooks/use-training-unload-guard.ts
@@ -2,9 +2,18 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { useEffect } from "react";
+import { isTauri } from "@/lib/api-base";
 import { useTrainingRuntimeStore } from "../stores/training-runtime-store";
 
 let currentHandler: ((e: BeforeUnloadEvent) => void) | null = null;
+
+// Desktop quit never fires beforeunload; Rust asks from the tray instead.
+function publishTrainingActive(active: boolean): void {
+  if (!isTauri) return;
+  void import("@tauri-apps/api/core")
+    .then(({ invoke }) => invoke("set_training_active", { active }))
+    .catch(() => {});
+}
 
 /**
  * Mounts a beforeunload guard that warns the user if training is running.
@@ -28,6 +37,17 @@ export function useTrainingUnloadGuard() {
       window.removeEventListener("beforeunload", handler);
     };
   }, []);
+
+  useEffect(() => {
+    publishTrainingActive(
+      useTrainingRuntimeStore.getState().isTrainingRunning,
+    );
+    return useTrainingRuntimeStore.subscribe((state, previous) => {
+      if (state.isTrainingRunning !== previous.isTrainingRunning) {
+        publishTrainingActive(state.isTrainingRunning);
+      }
+    });
+  }, []);
 }
 
 /**
@@ -40,4 +60,5 @@ export function removeTrainingUnloadGuard() {
     window.removeEventListener("beforeunload", currentHandler);
     currentHandler = null;
   }
+  publishTrainingActive(false);
 }

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -85,6 +85,44 @@ fn setup_custom_titlebar(app: &tauri::App) -> Result<(), Box<dyn std::error::Err
     Ok(())
 }
 
+/// A Tauri quit never fires beforeunload, so the frontend mirrors run state here.
+pub type TrainingActivityState = std::sync::Arc<std::sync::Mutex<bool>>;
+
+fn new_training_activity_state() -> TrainingActivityState {
+    std::sync::Arc::new(std::sync::Mutex::new(false))
+}
+
+#[tauri::command]
+fn set_training_active(state: tauri::State<'_, TrainingActivityState>, active: bool) {
+    if let Ok(mut running) = state.lock() {
+        *running = active;
+    }
+}
+
+/// Ask before quitting mid-training (true to proceed). Tray Quit only, as below.
+fn confirm_quit_during_training(app: &tauri::AppHandle) -> bool {
+    use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
+
+    let Some(state) = app.try_state::<TrainingActivityState>() else {
+        return true;
+    };
+    if !state.lock().map(|running| *running).unwrap_or(false) {
+        return true;
+    }
+    app.dialog()
+        .message(
+            "Training is still running. Quitting now stops the run and the \
+             progress since the last checkpoint is lost.",
+        )
+        .kind(MessageDialogKind::Warning)
+        .title("Training in progress")
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Quit anyway".to_string(),
+            "Keep training".to_string(),
+        ))
+        .blocking_show()
+}
+
 /// Ask before quitting mid-install (true to proceed): `cleanup_child_processes` SIGTERMs the
 /// installer, leaving a venv that looks healthy but cannot start. Tray Quit only, since
 /// RunEvent::Exit must never block on a dialog nobody can answer.
@@ -168,6 +206,9 @@ fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                     if !confirm_quit_during_install(&app_handle) {
                         return;
                     }
+                    if !confirm_quit_during_training(&app_handle) {
+                        return;
+                    }
                     cleanup_child_processes(&app_handle);
                     app_handle.exit(0);
                 });
@@ -225,11 +266,13 @@ fn main() {
         )
         .manage(diagnostics::new_diagnostics_state())
         .manage(install::new_install_state())
+        .manage(new_training_activity_state())
         .manage(native_intents::new_native_intake_state())
         .manage(new_backend_state())
         .manage(process::new_shutdown_flag())
         .manage(update::new_update_state())
         .invoke_handler(tauri::generate_handler![
+            set_training_active,
             app_layout::has_initialized_app_window_layout,
             app_layout::mark_app_window_layout_initialized,
             app_layout::reset_app_window_layout_initialized,


### PR DESCRIPTION
window.confirm() silently returns true in the Tauri webview, so "Delete knowledge base" and "Delete MCP server" deleted immediately with no prompt  a misclick on the trash icon destroyed a knowledge base and all its documents with no undo.
Both now use the app's AlertDialog, like every other destructive action. No window.confirm/alert/prompt calls remain in the frontend.

Quitting the desktop app never fires beforeunload, so the training guard that warns in the browser could not run. The frontend now mirrors run state into Rust and tray Quit asks before stopping a run, matching the existing install guard.