### PR TITLE
Desktop: bypass proxies for loopback requests

### DIFF
--- a/studio/src-tauri/src/commands.rs
+++ b/studio/src-tauri/src/commands.rs
@@ -276,9 +276,7 @@ pub async fn check_health(port: u16) -> Result<bool, String> {
 
 async fn check_health_inner(port: u16) -> Result<bool, reqwest::Error> {
     let url = format!("http://127.0.0.1:{}/api/health", port);
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(2))
-        .build()?;
+    let client = crate::loopback_http::client(std::time::Duration::from_secs(2))?;
     let resp = client.get(&url).send().await?;
     let json: serde_json::Value = resp.json().await?;
 

--- a/studio/src-tauri/src/desktop_auth.rs
+++ b/studio/src-tauri/src/desktop_auth.rs
@@ -335,9 +335,7 @@ async fn desktop_auth_inner(
     if backend.source == PortSource::Discovered {
         diagnostics::record_attached_external_backend(diagnostics, backend.port);
     }
-    let client = Client::builder()
-        .timeout(std::time::Duration::from_secs(5))
-        .build()
+    let client = crate::loopback_http::client(std::time::Duration::from_secs(5))
         .map_err(|e| format!("Desktop auth failed: {}", e))?;
 
     for attempt in 0..2 {

--- a/studio/src-tauri/src/desktop_backend_owner.rs
+++ b/studio/src-tauri/src/desktop_backend_owner.rs
@@ -559,9 +559,7 @@ async fn health_ready_status(port: u16) -> OwnedBackendReadiness {
 }
 
 async fn fetch_liveness(port: u16) -> Result<Option<DesktopLiveness>, reqwest::Error> {
-    let client = reqwest::Client::builder()
-        .timeout(LOCAL_HTTP_TIMEOUT)
-        .build()?;
+    let client = crate::loopback_http::client(LOCAL_HTTP_TIMEOUT)?;
     for path in ["/api/liveness", "/api/health"] {
         let response = client
             .get(format!("http://127.0.0.1:{port}{path}"))
@@ -594,10 +592,7 @@ fn fetch_liveness_blocking(port: u16) -> Result<Option<DesktopLiveness>, String>
     Ok(None)
 }
 async fn fetch_health(port: u16) -> Result<Option<HealthResponse>, String> {
-    let client = reqwest::Client::builder()
-        .timeout(LOCAL_HTTP_TIMEOUT)
-        .build()
-        .map_err(|e| e.to_string())?;
+    let client = crate::loopback_http::client(LOCAL_HTTP_TIMEOUT).map_err(|e| e.to_string())?;
     let response = client
         .get(format!("http://127.0.0.1:{port}/api/health"))
         .send()
@@ -614,10 +609,7 @@ async fn fetch_health(port: u16) -> Result<Option<HealthResponse>, String> {
 }
 
 async fn desktop_login_route_compatible(port: u16) -> bool {
-    let client = match reqwest::Client::builder()
-        .timeout(LOCAL_HTTP_TIMEOUT)
-        .build()
-    {
+    let client = match crate::loopback_http::client(LOCAL_HTTP_TIMEOUT) {
         Ok(client) => client,
         Err(_) => return false,
     };
@@ -636,10 +628,7 @@ async fn desktop_login_route_compatible(port: u16) -> bool {
 
 async fn desktop_secret_login_compatible(port: u16) -> Result<(), String> {
     let secret = read_desktop_secret()?.ok_or_else(|| "desktop_auth_secret_missing".to_string())?;
-    let client = reqwest::Client::builder()
-        .timeout(LOCAL_HTTP_TIMEOUT)
-        .build()
-        .map_err(|e| e.to_string())?;
+    let client = crate::loopback_http::client(LOCAL_HTTP_TIMEOUT).map_err(|e| e.to_string())?;
     let response = client
         .post(format!("http://127.0.0.1:{port}/api/auth/desktop-login"))
         .json(&DesktopLoginPayload { secret: &secret })

--- a/studio/src-tauri/src/diagnostics/mod.rs
+++ b/studio/src-tauri/src/diagnostics/mod.rs
@@ -134,10 +134,7 @@ async fn collect_backend_health(port: u16) -> report::BackendHealthSection {
         fields: Vec::new(),
         warning: None,
     };
-    let client = match reqwest::Client::builder()
-        .timeout(Duration::from_millis(750))
-        .build()
-    {
+    let client = match crate::loopback_http::client(Duration::from_millis(750)) {
         Ok(client) => client,
         Err(error) => {
             section.warning = Some(format!("health client unavailable: {error}"));

--- a/studio/src-tauri/src/loopback_http.rs
+++ b/studio/src-tauri/src/loopback_http.rs
@@ -1,0 +1,64 @@
+use std::time::Duration;
+
+pub(crate) fn client(timeout: Duration) -> Result<reqwest::Client, reqwest::Error> {
+    reqwest::Client::builder()
+        .no_proxy()
+        .timeout(timeout)
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::process::Command;
+    use std::time::Duration;
+
+    const CHILD_ENV: &str = "UNSLOTH_TEST_LOOPBACK_HTTP_CHILD";
+
+    #[test]
+    fn client_ignores_system_proxy() {
+        if std::env::var_os(CHILD_ENV).is_none() {
+            let current_thread = std::thread::current();
+            let test_name = current_thread.name().unwrap();
+            let status = Command::new(std::env::current_exe().unwrap())
+                .args(["--exact", test_name, "--nocapture"])
+                .env(CHILD_ENV, "1")
+                .env("HTTP_PROXY", "http://127.0.0.1:1")
+                .env("http_proxy", "http://127.0.0.1:1")
+                .env_remove("HTTPS_PROXY")
+                .env_remove("https_proxy")
+                .env_remove("ALL_PROXY")
+                .env_remove("all_proxy")
+                .env_remove("NO_PROXY")
+                .env_remove("no_proxy")
+                .status()
+                .unwrap();
+            assert!(status.success());
+            return;
+        }
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request).unwrap();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+                .unwrap();
+        });
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let response = runtime.block_on(async {
+            super::client(Duration::from_secs(2))
+                .unwrap()
+                .get(format!("http://127.0.0.1:{port}/health"))
+                .send()
+                .await
+                .unwrap()
+        });
+        assert!(response.status().is_success());
+        server.join().unwrap();
+    }
+}

--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -7,6 +7,7 @@ mod desktop_backend_owner;
 mod desktop_update_policy;
 mod diagnostics;
 mod install;
+mod loopback_http;
 mod native_backend_lease;
 mod native_clipboard;
 mod native_file_dialogs;

--- a/studio/src-tauri/src/preflight.rs
+++ b/studio/src-tauri/src/preflight.rs
@@ -752,7 +752,7 @@ exit 1
     ) -> BackendProbe {
         install_test_owner();
         let port = backend_server(health_body, route_status).await;
-        let client = reqwest::Client::new();
+        let client = crate::loopback_http::client(std::time::Duration::from_secs(2)).unwrap();
         let health = backend_health(&client, port).await.unwrap();
         backend_desktop_auth_status(&client, port, &health, Some(EXPECTED_ROOT_ID)).await
     }
@@ -764,7 +764,7 @@ exit 1
             "401 Unauthorized",
         )
         .await;
-        let client = reqwest::Client::new();
+        let client = crate::loopback_http::client(std::time::Duration::from_secs(2)).unwrap();
 
         assert!(backend_health(&client, port).await.is_some());
     }
@@ -891,7 +891,7 @@ exit 1
     async fn backend_expected_root_id_missing_is_external_conflict_before_auth_probe() {
         install_test_owner();
         let port = backend_server(desktop_ready_health(EXPECTED_ROOT_ID), "401 Unauthorized").await;
-        let client = reqwest::Client::new();
+        let client = crate::loopback_http::client(std::time::Duration::from_secs(2)).unwrap();
         let health = backend_health(&client, port).await.unwrap();
 
         assert!(matches!(

--- a/studio/src-tauri/src/preflight/backend.rs
+++ b/studio/src-tauri/src/preflight/backend.rs
@@ -170,10 +170,7 @@ struct DesktopLoginProbe<'a> {
 }
 
 pub(super) async fn probe_ownerless_spawned_backend(port: u16) -> BackendProbe {
-    let client = match reqwest::Client::builder()
-        .timeout(Duration::from_secs(2))
-        .build()
-    {
+    let client = match crate::loopback_http::client(Duration::from_secs(2)) {
         Ok(client) => client,
         Err(_) => return BackendProbe::Missing,
     };
@@ -294,10 +291,7 @@ pub(super) async fn backend_desktop_auth_status(
 }
 
 pub(super) async fn probe_existing_backends(ignored_ports: &[u16]) -> BackendProbe {
-    let client = match reqwest::Client::builder()
-        .timeout(Duration::from_secs(2))
-        .build()
-    {
+    let client = match crate::loopback_http::client(Duration::from_secs(2)) {
         Ok(client) => client,
         Err(_) => return BackendProbe::Missing,
     };

--- a/studio/src-tauri/src/process.rs
+++ b/studio/src-tauri/src/process.rs
@@ -740,10 +740,7 @@ pub fn start_backend(
 
 async fn generic_backend_health_ok(port: u16) -> bool {
     let started = std::time::Instant::now();
-    let client = match reqwest::Client::builder()
-        .timeout(Duration::from_secs(2))
-        .build()
-    {
+    let client = match crate::loopback_http::client(Duration::from_secs(2)) {
         Ok(client) => client,
         Err(error) => {
             warn!("Could not build backend validation client: {}", error);


### PR DESCRIPTION
## Summary

Studio desktop starts its backend locally, then validates the reported port before publishing it to the frontend. These validation requests used the default reqwest proxy configuration.

On systems where proxy settings also apply to loopback traffic, requests to `127.0.0.1` could be sent to the proxy instead. The backend would be running and healthy, but Studio would reject its port, leave the frontend on `Starting server...`, and eventually terminate the backend after the startup grace period.

## Fix

- Add a shared reqwest client for loopback requests that disables system and environment proxies while preserving each request's existing timeout.
- Use it for startup validation, backend discovery and ownership checks, watchdog health checks, desktop authentication, and support diagnostics.
- Keep internet-facing update requests on the normal proxy-aware client.
- Add a regression test that configures an unusable HTTP proxy with no `NO_PROXY` entry and verifies that a real request to a local TCP server still succeeds.

## Testing

- `cargo test` (111 passed)
- `cargo build`
- `npm run build`
- Targeted `rustfmt --check` on every changed Rust file
- `git diff --check`

## Runtime validation

Ran the desktop app against the real managed backend with `HTTP_PROXY` pointing to an unusable endpoint and no `NO_PROXY` value:

- Main started a healthy backend but failed the loopback validation and never published its port.
- This branch validated the backend, published its port, completed desktop authentication, loaded frontend data, and continued successful watchdog health checks.
