### PR TITLE
Retire the virgin container release-lag pin now that the released wheel carries #7549

### DIFF
--- a/.github/workflows/clean-machine-install-ci.yml
+++ b/.github/workflows/clean-machine-install-ci.yml
@@ -1561,6 +1561,18 @@ jobs:
             -Overlay "$overlayArg" *>&1 | Tee-Object -FilePath logs/install-outer.log
           exit $LASTEXITCODE
 
+      # Both rows. A `docker exec` that lost its container also exits 0, so the exit code
+      # alone cannot tell a completed harness from one that never ran. Read the harness's
+      # own verdict instead. Needs no `if:`, because a failed Install skips it.
+      - name: Assert the in-container harness reported passing
+        shell: pwsh
+        run: |
+          $log = Get-Content logs/install-outer.log -Raw
+          if (-not ($log -match 'VIRGIN WINDOWS CONTAINER INSTALL PASSED')) {
+            Write-Host '::error::the install step exited 0 but the in-container harness never printed its passing verdict'
+            exit 1
+          }
+
       # The overlay row runs this ref's studio/setup.ps1, so it carries #7549 and must
       # install end to end. The in-container harness already asserts the venv interpreter,
       # the CLI, `import torch`, the no-winget path, the overlay marker and nobuild, exiting
@@ -1571,12 +1583,6 @@ jobs:
         shell: pwsh
         run: |
           $log = Get-Content logs/install-outer.log -Raw
-          # A `docker exec` that lost its container also exits 0, so read the harness's own
-          # verdict rather than trust the exit code alone.
-          if (-not ($log -match 'VIRGIN WINDOWS CONTAINER INSTALL PASSED')) {
-            Write-Host '::error::the install step exited 0 but the in-container harness never printed its passing verdict'
-            exit 1
-          }
           # The overlay hook is this PR's own feature and gates unconditionally: without it
           # this row is indistinguishable from the released-wheel one.
           if (-not ($log -match 'CI: overlaying source checkout')) {

--- a/.github/workflows/clean-machine-install-ci.yml
+++ b/.github/workflows/clean-machine-install-ci.yml
@@ -1476,8 +1476,9 @@ jobs:
       matrix:
         include:
           # The consumer path: install.ps1 from this ref, unsloth from PyPI, so
-          # studio/setup.ps1 comes out of the RELEASED wheel -- which is why this row and the
-          # overlay one below do not reach the same place. See the pin on the Install step.
+          # studio/setup.ps1 comes out of the RELEASED wheel rather than this ref's. That is
+          # the difference from the overlay row below; both are expected to install end to
+          # end and both gate.
           - overlay: false
           # This ref's studio/setup.ps1 and install_python_stack.py, via
           # UNSLOTH_CI_SOURCE_OVERLAY (install.ps1:2643). Without it a branch changing
@@ -1546,16 +1547,13 @@ jobs:
       - name: Install into the virgin container
         id: install
         shell: pwsh
-        # RELEASE-LAG PIN, overlay=false only. A Server Core container has no Microsoft Store
-        # and so no winget, ever, and studio/setup.ps1 used to hard-stop on a winget-only git
-        # gate and reach for winget again for the VC++ runtime. #7549 relaxed both and this
-        # branch has it, the released wheel does not: unpacking unsloth 2026.7.5 (uploaded
-        # 2026-07-23, #7549 landed on the 28th) shows its setup.ps1 still carrying the old
-        # gate, so the row that installs from PyPI on purpose cannot get past it. Release
-        # lag, not a product gap: only the next RELEASE clears it, not a merge. The overlay
-        # row runs the same install against this ref's setup.ps1 and gates unconditionally,
-        # and the step below accepts only that signature, erroring the moment it catches up.
-        continue-on-error: ${{ !matrix.overlay }}
+        # Both rows gate. This used to carry a RELEASE-LAG PIN for overlay=false: a Server
+        # Core container has no Microsoft Store and so no winget, ever, and the RELEASED
+        # studio/setup.ps1 hard-stopped on a winget-only git gate and reached for winget
+        # again for the VC++ runtime, so the row that installs from PyPI on purpose could
+        # not get past it. #7549 relaxed both, and unsloth 2026.7.6 (uploaded 2026-07-29,
+        # after #7549 merged) is the first wheel to ship them, so the row now installs end
+        # to end and the pin's own tripwire fired to say so. Nothing is tolerated here.
         run: |
           $overlayArg = if ('${{ matrix.overlay }}' -eq 'true') { 'C:\ci' } else { '' }
           docker exec virgin powershell.exe -NoLogo -NoProfile -NonInteractive `
@@ -1610,63 +1608,6 @@ jobs:
           # The harness already ran `import torch` against the managed interpreter, which
           # needs VCRUNTIME140_1.dll; this says the DLL got there rather than always being.
           Write-Host '::notice::no Store, no winget, no git and no preinstalled VC++ runtime, and the install completed anyway'
-
-      # RELEASE-LAG PIN (overlay=false). See the Install step: this row installs from PyPI on
-      # purpose and the released setup.ps1 predates #7549. continue-on-error would otherwise
-      # tolerate a bootstrap outage or an unrelated early exit like the intended diagnostic,
-      # so every branch but the pinned failure exits 1 and fails the (required) job.
-      - name: Assert the released-wheel row failed only on release lag
-        if: always() && !matrix.overlay && steps.install.outcome != 'skipped'
-        shell: pwsh
-        run: |
-          if ('${{ steps.install.outcome }}' -eq 'success') {
-            Write-Host '::error::the released wheel now installs in a virgin container, so it carries the relaxed #7549 gates. Delete this pin and drop continue-on-error from the Install step so this row gates.'
-            exit 1
-          }
-          if (-not (Test-Path logs/install-outer.log)) {
-            Write-Host '::error::the container install produced no log'
-            exit 1
-          }
-          $log = Get-Content logs/install-outer.log -Raw
-          # The pinned signature is the OLD gate wording #7549 deleted; its disappearance
-          # from a released wheel is the flip condition, and anything else stays red.
-          $gitGate = $log -match 'Git is required but could not be installed automatically'
-          $vcGate  = $log -match 'torch failed to import'
-          if (-not ($gitGate -or $vcGate)) {
-            Write-Host '::error::the container install failed at neither the released winget-only git gate nor the missing VC++ runtime; this is a new failure'
-            exit 1
-          }
-          # `-or` alone is too generous: virgin-windows-install.ps1:97 runs the torch
-          # assertion whenever the venv interpreter exists, and this image has no VC++
-          # runtime, so ANY post-venv failure -- a Node download, a setup step, a bad
-          # prebuilt -- arrives carrying the $vcGate text and was accepted as the pin.
-          # Enumerate what the harness recorded instead: one `::error::<reason>` per entry of
-          # its $failures list (that script:151), each of which must be a pinned gate.
-          # Anchored, because it also dumps the log tail indented two spaces.
-          $recorded = @(Get-Content logs/install-outer.log |
-            ForEach-Object { if ($_ -match '^::error::(.+)$') { $Matches[1].Trim() } })
-          Write-Host "recorded failures: $($recorded.Count)"
-          $recorded | ForEach-Object { Write-Host "  $_" }
-          if ($recorded.Count -eq 0) {
-            Write-Host '::error::the container install failed but recorded no ::error:: line, so nothing identifies which gate stopped it'
-            exit 1
-          }
-          # The git gate makes install.ps1 exit non-zero, the missing runtime makes the
-          # torch assert fail. Nothing else is pinned.
-          $pinned = @('^installer exited \d+$', '^torch failed to import from the managed Python')
-          $unexpected = @($recorded | Where-Object { $r = $_; -not ($pinned | Where-Object { $r -match $_ }) })
-          if ($unexpected.Count -gt 0) {
-            Write-Host "::error::the container install recorded a failure outside the pinned gates: $($unexpected -join '; '); this is a new failure"
-            exit 1
-          }
-          # And a non-zero exit has to BE the git gate, or a post-venv failure that also
-          # exits 1 is indistinguishable from the pinned one.
-          if (($recorded | Where-Object { $_ -like 'installer exited*' }) -and
-              -not ($gitGate -and ($log -match 'unsloth studio setup failed \(exit code 1\)'))) {
-            Write-Host '::error::the installer exited non-zero somewhere other than the winget-only git gate in the released studio/setup.ps1; this is a new failure'
-            exit 1
-          }
-          Write-Host '::notice::known outcome: the released wheel still carries the winget-only git gate and the winget-only Ensure-VCRedist that #7549 replaced. Retire this pin with the next release.'
 
       - name: Recover the install log from the container
         if: always()


### PR DESCRIPTION
The `virgin win container / overlay=false` job has been failing on every PR that runs it, with a message the workflow writes itself:

```
##[error]the released wheel now installs in a virgin container, so it carries the relaxed
#7549 gates. Delete this pin and drop continue-on-error from the Install step so this row gates.
```

That is a deliberate tripwire, not a defect. It fires when the condition the pin was working around has gone away, so this PR does exactly what it asks.

## What the pin was

All three pieces live in `clean-machine-install-ci.yml`, job `windows_container_install`:

- `continue-on-error: ${{ !matrix.overlay }}` on the Install step, with a `RELEASE-LAG PIN` comment
- the `Assert the released-wheel row failed only on release lag` step, whose first branch is the tripwire above

A Windows Server Core container has no Microsoft Store and therefore no winget, ever. Before #7549 the released wheel could not install there, so the row was allowed to fail.

## Why it is safe to retire now

#7549 ("Windows: unblock the consumer install on clean and no-winget machines", merged 2026-07-29) relaxed the two gates that blocked this lane: git stopped being a hard failure on the consumer path, and `Ensure-VCRedist` stopped being winget-only by downloading `vc_redist` directly.

I did not take the workflow's word for the flip. Unpacking the wheels from PyPI:

- `unsloth 2026.7.5` was uploaded 2026-07-23, before the merge.
- `unsloth 2026.7.6` was uploaded 2026-07-29, after it, and is the first wheel that could carry the change.
- In `unsloth-2026.7.6-py3-none-any.whl`, `studio/setup.ps1` no longer contains the pinned old wording `Git is required but could not be installed automatically`, and does contain both post-#7549 markers (`so git is not needed`, and the direct `aka.ms/vs/17/release/vc_redist.x64.exe` download).

## Removing continue-on-error will not turn the row red for a different reason

The Install step itself already passes; only the tripwire was failing the job. Across the four most recent runs of this workflow:

| run | `overlay=false` job | Install step |
| --- | --- | --- |
| 30665929139 | success | success |
| 30651753971 | failure | success |
| 30648796387 | failure | success |
| 30646523183 | failure | success |

Run 30665929139 is the org's own `image-generation` branch, which has already made this same change; its `overlay=false` job is green. I diffed this job against that branch's job on every executable field (step names, `if`, `continue-on-error`, `run` bodies) and all 10 steps are identical. The only difference is comments: that branch left an orphaned `RELEASE-LAG PIN` block above a later step, this one does not.

## Validation

- `yaml.safe_load` parses; the job has 10 steps and no step carries `continue-on-error`.
- `actionlint 1.7.7` reports only 3 pre-existing `runner-label` warnings (`macos-26`, `macos-15-intel`, `windows-11-arm`), identical in count and kind on pristine `main`.
- No orphaned references: `released-wheel row` and `failed only on release` have zero hits repo-wide, and the deleted step was the only consumer of `steps.install.outcome` inside this job.

Net 10 insertions, 69 deletions; the only YAML key removed is `continue-on-error`. `id: install` is left in place as a harmless anchor, matching the sibling branch.

I have not run this workflow from this branch; the green evidence above comes from the sibling branch carrying the equivalent change.
