### PR TITLE
Fix the TRL-latest packing test failure blocking CI on every PR

### DIFF
--- a/tests/utils/test_packing.py
+++ b/tests/utils/test_packing.py
@@ -26,6 +26,7 @@ from unsloth.utils.packing import (
     patch_hybrid_linear_attention_varlen,
 )
 
+import inspect
 import logging
 from contextlib import ExitStack
 from types import SimpleNamespace
@@ -903,30 +904,42 @@ class _DummyModel(torch.nn.Module):
         self.generation_config = SimpleNamespace(attn_implementation = "sdpa")
 
 
+def _build_trl_language_modeling_collator():
+    """Build TRL's SFT collator with only the fields the installed TRL accepts.
+
+    The dataclass fields drift between TRL releases, so hardcoding a kwarg set
+    breaks whenever upstream drops one: ``return_position_ids`` only existed
+    around TRL 0.22, and ``completion_only_loss`` was removed from this collator
+    in TRL 1.7.0 (huggingface/trl#6037, commit f9aeb59) when label masking moved
+    into dataset preparation. Filtering against the live signature keeps the
+    dummy trainer faithful to whatever TRL is installed.
+    """
+    wanted = {
+        "pad_token_id": 0,
+        "completion_only_loss": False,
+        "return_tensors": "pt",
+        "padding_free": True,
+        "return_position_ids": False,
+    }
+    try:
+        accepted = set(inspect.signature(DataCollatorForLanguageModeling).parameters)
+    except (TypeError, ValueError):
+        accepted = {"pad_token_id"}
+    collator = DataCollatorForLanguageModeling(
+        **{key: value for key, value in wanted.items() if key in accepted}
+    )
+    # Ensure attributes exist even when this TRL has no such field.
+    if not hasattr(collator, "padding_free"):
+        collator.padding_free = True
+    if not hasattr(collator, "return_position_ids"):
+        collator.return_position_ids = False
+    return collator
+
+
 class _DummyTrainer:
     def __init__(self):
         self.args = SimpleNamespace(remove_unused_columns = True)
-        collator_args = {
-            "pad_token_id": 0,
-            "completion_only_loss": False,
-            "return_tensors": "pt",
-        }
-        optional_flags = [
-            {"padding_free": True, "return_position_ids": False},
-            {"padding_free": True},
-            {},
-        ]
-        for extra in optional_flags:
-            try:
-                self.data_collator = DataCollatorForLanguageModeling(**collator_args, **extra)
-                break
-            except TypeError:
-                continue
-        # Ensure attributes exist even if the constructor rejected the flags.
-        if not hasattr(self.data_collator, "padding_free"):
-            self.data_collator.padding_free = True
-        if not hasattr(self.data_collator, "return_position_ids"):
-            self.data_collator.return_position_ids = False
+        self.data_collator = _build_trl_language_modeling_collator()
 
 
 class _PaddingFreeCollator:
@@ -978,6 +991,37 @@ def test_enable_sample_packing():
     assert batch["input_ids"].shape == (1, 6)
     expected_positions = torch.tensor([0, 1, 0, 0, 1, 2], dtype = torch.long)
     assert torch.equal(batch["position_ids"].view(-1)[:6], expected_positions)
+
+
+def test_enable_sample_packing_only_requires_torch_call():
+    """Packing must not depend on optional TRL collator fields.
+
+    TRL keeps adding and removing fields on its SFT collator, so
+    ``enable_sample_packing`` is only allowed to require ``torch_call``.
+    """
+
+    class _MinimalCollator:
+        def torch_call(self, examples):
+            return {"input_ids": torch.tensor([[0, 1, 2, 3, 4, 5]], dtype = torch.long)}
+
+    trainer = SimpleNamespace(
+        args = SimpleNamespace(remove_unused_columns = True),
+        data_collator = _MinimalCollator(),
+    )
+
+    enable_sample_packing(_DummyModel(), trainer)
+
+    collator = trainer.data_collator
+    assert getattr(collator, "_unsloth_packing_wrapped") is True
+    assert trainer.args.remove_unused_columns is False
+
+    batch = collator.torch_call(
+        [
+            {"input_ids": [0, 1, 2], "seq_lengths": [2, 1]},
+            {"input_ids": [3, 4, 5], "seq_lengths": [3]},
+        ]
+    )
+    assert torch.equal(batch["packed_seq_lengths"], torch.tensor([2, 1, 3], dtype = torch.int32))
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
`Core (HF=latest + TRL=latest)` has been red on every open PR in the repo, including ones that touch nothing near packing. The failure is in the test, not in the library.

## What breaks

`tests/utils/test_packing.py::_DummyTrainer` builds TRL's `DataCollatorForLanguageModeling` from a hardcoded kwarg set and then walks a ladder of `try`/`except TypeError` fallbacks for the optional flags. `completion_only_loss` was in the always-passed group, so when TRL removed that field from this collator the first constructor call raised `TypeError` and every rung of the ladder raised it too. The dummy trainer then has no `data_collator` at all, and the test fails with an `AttributeError` that names neither TRL nor the removed field.

Upstream removal: huggingface/trl commit `f9aeb59` (huggingface/trl#6037), which moved completion-only label masking into dataset preparation. First released in TRL v1.7.0.

## The fix

Build the collator from the installed TRL's live signature instead of guessing:

```python
accepted = set(inspect.signature(DataCollatorForLanguageModeling).parameters)
collator = DataCollatorForLanguageModeling(
    **{k: v for k, v in wanted.items() if k in accepted}
)
```

This subsumes the fallback ladder: any field TRL adds or drops is handled by the same filter, rather than by another rung. The post-hoc `hasattr` defaults are kept so the dummy still presents the attributes the packing code checks for.

Also adds `test_enable_sample_packing_only_requires_torch_call`, which pins the contract the test was implicitly relying on: `enable_sample_packing` may require nothing of a collator beyond `torch_call`. That is what stops the next TRL field change from turning into a red CI run.

## Scope

Test-only. Production is already defensive and was never affected:

- `unsloth/utils/packing.py` reads the collator via `getattr(trainer, "data_collator", None)` and guards every optional field with `hasattr` before assigning.
- `unsloth/models/rl.py` references the **transformers** `DataCollatorForLanguageModeling`, not TRL's, so the upstream removal does not reach it.

## Verification

`tests/utils/test_packing.py` passes on TRL 0.22.2, 0.25.1, 0.29.1, 1.6.0, 1.7.1 and 1.9.2 (52 passed on the version installed here, 0.25.1). Both the pre-1.7 and post-1.7 field sets are covered, so this is not a fix that trades one pinned version for another.
