### PR TITLE
Fix the deterministic macOS failure in the floating monitor geometry test

### DIFF
--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -335,6 +335,54 @@ def exercise_floating_monitor_geometry(page):
             and box["y"] + box["height"] <= surface["height"] - inset + tolerance
         )
 
+    # Every assertion below compares heights sampled seconds apart against this
+    # baseline, so the panel must already be showing its final row set. Until the
+    # first /api/system response is applied the panel paints use-system.ts's
+    # zero-filled DEFAULT_SYSTEM, which has no GPU: on a host that reports one
+    # (macos-14 reports a single MLX device) the VRAM row then appears and adds
+    # ~59px permanently. The caller only waited for the /api/system *request*, so
+    # sampling here can capture the pre-payload height -- a height the panel never
+    # returns to, which "content shrink" would then wait out its whole deadline
+    # chasing. Wait for the payload itself, and for the panel to have finished
+    # resizing to it.
+    try:
+        page.wait_for_function(
+            r"""() => {
+                const monitor = document.querySelector(
+                    '[data-testid="floating-monitor"]'
+                );
+                const content = document.querySelector(
+                    '[data-testid="floating-monitor-content"]'
+                );
+                if (!(monitor && content)) return false;
+                // DEFAULT_SYSTEM reports a 0 GiB RAM total; a real payload never does.
+                const readout = content.innerText.match(
+                    /([\d.]+)\s*GiB\s*\/\s*([\d.]+)\s*GiB/
+                );
+                if (!readout || !(Number.parseFloat(readout[2]) > 0)) return false;
+                // The rows commit a pass before the panel resizes to them, so the
+                // panel is only done reacting once its scroll region exactly fits
+                // the content it was reconciled against.
+                const scroll = content.parentElement;
+                const monitorHeight = monitor.getBoundingClientRect().height;
+                const contentHeight = content.getBoundingClientRect().height;
+                const scrollHeight = scroll.getBoundingClientRect().height;
+                if (Math.abs(scrollHeight - contentHeight) > 1) return false;
+                // Row insertion also lands a frame before the gap between rows
+                // does, and that intermediate state is self-consistent. Require
+                // the geometry to hold for two consecutive animation frames --
+                // this runs under the default polling="raf", and it is how
+                // Playwright itself defines a stable element.
+                const signature = monitorHeight + "x" + contentHeight;
+                const settled = window.__unslothMonitorGeometry === signature;
+                window.__unslothMonitorGeometry = signature;
+                return settled;
+            }""",
+            timeout = 30_000,
+        )
+    except Exception as exc:
+        fail(f"floating monitor never settled on an /api/system payload: {exc!r}")
+
     initial_box = monitor_box("initial placement")
     expect_close(
         initial_box["x"] + initial_box["width"],


### PR DESCRIPTION
`Chat UI Tests` has been red across the repo's open PRs. It is not flaky: it fails deterministically on macOS, and the appearance of flakiness comes from three separate workflows publishing the same check name.

On #7686, the three checks named `Chat UI Tests` are three different runners:

| job | runner | result |
|---|---|---|
| 91316909182 | `macos-14` | fail |
| 91316909276 | `ubuntu-latest` | pass |
| 91316909316 | `windows-latest` | pass |

So "one of three parallel runs failed" reads as a flake but is one consistently broken platform. Every mac failure emits the identical box, `{'x': 1008, 'y': 712, 'width': 256, 'height': 172}`.

## The race

In `exercise_floating_monitor_geometry`, the caller gates on the `/api/system` **request**, not its response, because `ctx.on("request", ...)` fires when the request is issued:

```python
monitor_deadline = time.time() + 10
while len(system_requests) == login_system_request_count and time.time() < monitor_deadline:
    page.wait_for_timeout(100)
```

`initial_box` is then sampled a couple of IPC round trips later with no further gate. Until the response is applied, the panel paints `use-system.ts`'s `DEFAULT_SYSTEM`, whose `gpu` is `{available: false, devices: []}`. On macOS `detect_hardware()` returns `DeviceType.MLX` and `hardware.py:2705` reports `"available": True` with one device, so `hasGpu` flips and `floating-monitor.tsx:469` renders a VRAM row. The panel's natural height changes permanently.

That makes the later predicate unsatisfiable:

```python
lambda box: (
    abs(box["height"] - initial_box["height"]) <= tolerance
    and abs(box["y"] + box["height"] - viewport["height"] + inset) <= tolerance
)
```

The bottom-anchor half passes (712 + 172 = 884 = 900 - 16); only the height comparison against the stale baseline fails, which is exactly the reported box. The growth check is satisfied by the VRAM row alone, which is why growth completes in 0.4s and the shrink burns its whole deadline.

Measured against the real component with the real stylesheet: RAM alone renders 113.5px, RAM plus one VRAM row renders exactly 172.0px at y=712.

## The fix

Wait for the real signal before sampling the baseline, via one `wait_for_function` with three conditions: a non-zero RAM total (proving a real payload replaced `DEFAULT_SYSTEM`), the scroll region exactly fitting the content it was reconciled against (proving the ResizeObserver pass landed), and that geometry holding for two consecutive animation frames.

The frame-stability condition is load-bearing. There is an intermediate state where both rows exist but the `space-y-3` gap has not been applied, and that state is self-consistent, so an instantaneous check latches onto it. Two frames is how Playwright itself defines a stable element, and `wait_for_function` defaults to `polling="raf"`, so consecutive polls are consecutive frames.

No sleeps added and no timeout raised.

## Verification

The real `exercise_floating_monitor_geometry` was extracted from `git show HEAD:` (before) and the working tree (after) and run against the live component with the `/api/system` response held back by a randomised delay:

| scenario | before | after |
|---|---|---|
| GPU-reporting host, delay 0-500ms | 24/25 failed | 0/25 failed |
| GPU-reporting host, delay 0-60ms | 40/40 failed | 0/40 failed |
| no-GPU host (ubuntu/windows control) | 0/20 failed | 0/20 failed |

Every "before" failure reproduced the byte-identical CI string including `'height': 172`. The no-GPU control explains why ubuntu and windows pass and confirms the fix does not regress them.

## Scope

Test-only; no frontend or backend file is touched.

Two things this was not able to establish locally: the suite was not run end to end (the harness renders the real `FloatingMonitor` from the worktree through the project's own vite server and executes the real test function, but it is not the whole suite), and it was not run on macOS, so the MLX-implies-`available: True` step rests on the backend source plus the platform correlation of the failing jobs rather than on a mac run. CI on this PR covers both.
