### PR TITLE
fix(tests): build the padding-free collator with TRL-1.9.2-compatible kwargs (#7708)

### DIFF
--- a/tests/utils/test_packing.py
+++ b/tests/utils/test_packing.py
@@ -178,22 +178,34 @@ class _DummyModel(torch.nn.Module):
 class _DummyTrainer:
     def __init__(self):
         self.args = SimpleNamespace(remove_unused_columns = True)
-        collator_args = {
-            "pad_token_id": 0,
-            "completion_only_loss": False,
-            "return_tensors": "pt",
-        }
-        optional_flags = [
-            {"padding_free": True, "return_position_ids": False},
-            {"padding_free": True},
-            {},
+        # Only ``pad_token_id`` and ``padding_free`` are accepted by every
+        # released ``DataCollatorForLanguageModeling``. Other keywords have
+        # moved between collator classes / TRL versions (e.g. TRL 1.9.2 drops
+        # ``completion_only_loss`` from this collator), so try the richest
+        # keyword set first and fall back to progressively smaller ones.
+        collator_attempts = [
+            {"pad_token_id": 0, "completion_only_loss": False, "return_tensors": "pt",
+             "padding_free": True, "return_position_ids": False},
+            {"pad_token_id": 0, "completion_only_loss": False, "return_tensors": "pt",
+             "padding_free": True},
+            {"pad_token_id": 0, "return_tensors": "pt", "padding_free": True},
+            {"pad_token_id": 0, "padding_free": True},
         ]
-        for extra in optional_flags:
+        self.data_collator = None
+        last_error = None
+        for collator_kwargs in collator_attempts:
             try:
-                self.data_collator = DataCollatorForLanguageModeling(**collator_args, **extra)
+                self.data_collator = DataCollatorForLanguageModeling(**collator_kwargs)
                 break
-            except TypeError:
+            except TypeError as error:
+                last_error = error
                 continue
+        if self.data_collator is None:
+            raise RuntimeError(
+                "Could not construct DataCollatorForLanguageModeling with any "
+                "known keyword combination; the installed TRL version may have "
+                f"changed its signature (last error: {last_error})"
+            )
         # Ensure attributes exist even if the constructor rejected them.
         if not hasattr(self.data_collator, "padding_free"):
             self.data_collator.padding_free = True


### PR DESCRIPTION
### Problem

The `Core (HF=latest + TRL=latest)` CI job fails on `main`, so every open PR shows one red CPU job (`tests/utils/test_packing.py::test_enable_sample_packing`) unrelated to its changes:

```
AttributeError: '_DummyTrainer' object has no attribute 'data_collator'
```

That variant installs `trl-1.9.2`. In TRL 1.9.2, `DataCollatorForLanguageModeling` is a dataclass whose fields are `pad_token_id`, `padding_free`, `pad_to_multiple_of`, `return_tensors` — it **no longer accepts `completion_only_loss`** (that keyword now lives on a different collator class). Because `_DummyTrainer` puts `completion_only_loss` in the shared `collator_args`, *every* attempt in the loop raises `TypeError`, `self.data_collator` is never assigned, and the following `hasattr(self.data_collator, ...)` line raises the confusing `AttributeError` several lines away from the real cause — exactly the two problems @vineethsaivs described in #7708.

### Fix

Both suggestions from the issue, together:

1. **Real incompatibility (2):** only `pad_token_id` + `padding_free` are accepted by every released collator, so try the richest keyword set first and fall back to progressively smaller, universally-valid combinations. `DataCollatorForLanguageModeling(pad_token_id=0, padding_free=True)` builds a real padding-free collator on TRL 1.9.2 as well as older versions, and `completion_only_loss=False`/`return_tensors="pt"` are the defaults anyway, so dropping them when unsupported changes nothing semantically.
2. **Loud failure (1):** if no combination works, raise a descriptive `RuntimeError` naming the last `TypeError` instead of falling into an unrelated `AttributeError`.

### Verification

Reproduced under a fresh `trl==1.9.2` env: the current loop raises `unexpected keyword argument 'completion_only_loss'` on all three attempts; the new fallback builds a `DataCollatorForLanguageModeling` with `padding_free=True`, and `torch_call` produces the padding-free `position_ids` (`input_ids` shape `(1, 6)`, `position_ids [0,1,2,0,1,2]`) that `test_enable_sample_packing` relies on.

Fixes #7708

🤖 Generated with [Claude Code](https://claude.com/claude-code)
