### PR TITLE
Fix `unsloth run` on Windows: the venv entry point is unsloth.exe

### DIFF
--- a/tests/studio/test_run_windows_entry_point.py
+++ b/tests/studio/test_run_windows_entry_point.py
@@ -27,7 +27,11 @@ def _studio_bin_value() -> ast.expr:
         if not isinstance(node, ast.Assign):
             continue
         for target in node.targets:
-            if isinstance(target, ast.Name) and target.id == "studio_bin" and node.value is not None:
+            if (
+                isinstance(target, ast.Name)
+                and target.id == "studio_bin"
+                and node.value is not None
+            ):
                 if not (isinstance(node.value, ast.Constant) and node.value.value is None):
                     return node.value
     raise AssertionError("`run` never assigns a studio_bin path")
@@ -44,9 +48,10 @@ def test_the_entry_point_name_is_chosen_per_platform():
         for node in ast.walk(value.right)
         if isinstance(node, ast.Constant) and isinstance(node.value, str)
     }
-    assert {"unsloth", "unsloth.exe"} <= names, (
-        f"studio_bin must pick between 'unsloth' and 'unsloth.exe'; got {sorted(names)}"
-    )
+    assert {
+        "unsloth",
+        "unsloth.exe",
+    } <= names, f"studio_bin must pick between 'unsloth' and 'unsloth.exe'; got {sorted(names)}"
 
 
 def test_the_windows_branch_is_the_exe():

--- a/tests/studio/test_run_windows_entry_point.py
+++ b/tests/studio/test_run_windows_entry_point.py
@@ -1,0 +1,63 @@
+"""AST test that `unsloth run` looks for the console script Windows actually ships.
+
+The venv's entry point is `unsloth.exe` on Windows, so resolving the bare name made
+`studio_bin.is_file()` false on every Windows install and aborted with "Unsloth venv
+missing 'unsloth' entry point". Pinned by AST because reaching the assignment at
+runtime means standing up a studio venv.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_STUDIO = Path(__file__).resolve().parents[2] / "unsloth_cli" / "commands" / "studio.py"
+
+
+def _run_function() -> ast.FunctionDef:
+    tree = ast.parse(_STUDIO.read_text(encoding = "utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "run":
+            return node
+    raise AssertionError("no top-level `run` command in unsloth_cli/commands/studio.py")
+
+
+def _studio_bin_value() -> ast.expr:
+    for node in ast.walk(_run_function()):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "studio_bin" and node.value is not None:
+                if not (isinstance(node.value, ast.Constant) and node.value.value is None):
+                    return node.value
+    raise AssertionError("`run` never assigns a studio_bin path")
+
+
+def test_the_entry_point_name_is_chosen_per_platform():
+    value = _studio_bin_value()
+    assert isinstance(value, ast.BinOp) and isinstance(value.op, ast.Div), (
+        "expected studio_bin to be built as `studio_python.parent / <name>`, got "
+        f"{ast.dump(value)}"
+    )
+    names = {
+        node.value
+        for node in ast.walk(value.right)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
+    assert {"unsloth", "unsloth.exe"} <= names, (
+        f"studio_bin must pick between 'unsloth' and 'unsloth.exe'; got {sorted(names)}"
+    )
+
+
+def test_the_windows_branch_is_the_exe():
+    """A swapped conditional would still hold the two names but break both platforms."""
+    branch = next(
+        node for node in ast.walk(_studio_bin_value().right) if isinstance(node, ast.IfExp)
+    )
+    assert isinstance(branch.body, ast.Constant) and branch.body.value == "unsloth.exe"
+    assert isinstance(branch.orelse, ast.Constant) and branch.orelse.value == "unsloth"
+    assert "Windows" in {
+        node.value
+        for node in ast.walk(branch.test)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }, "the .exe branch must be gated on platform.system() == 'Windows'"

--- a/unsloth_cli/commands/studio.py
+++ b/unsloth_cli/commands/studio.py
@@ -2123,8 +2123,12 @@ def run(
         if not studio_python:
             typer.echo("Unsloth Studio not set up. Run install.sh first.")
             raise typer.Exit(1)
-        # Re-exec via the studio venv's `unsloth` console-script.
-        studio_bin = studio_python.parent / "unsloth"
+        # Re-exec via the studio venv's `unsloth` console-script. Windows ships it as
+        # unsloth.exe, so the bare name is never a file there and `unsloth run` aborted
+        # with "venv missing 'unsloth' entry point" on a perfectly good install.
+        studio_bin = studio_python.parent / (
+            "unsloth.exe" if platform.system() == "Windows" else "unsloth"
+        )
         if not studio_bin.is_file():
             typer.echo("Unsloth venv missing 'unsloth' entry point. Re-run: unsloth studio setup")
             raise typer.Exit(1)


### PR DESCRIPTION
`unsloth run` is unusable on Windows.

When it is not already inside the studio venv it re-execs through that venv's console script, and it resolved the path as:

```python
studio_bin = studio_python.parent / "unsloth"
```

Windows installs that console script as `unsloth.exe`, and only as `unsloth.exe`. `install.ps1` writes `Scripts\unsloth.exe` (a distlib launcher) and hardlinks it to `%STUDIO_HOME%\bin\unsloth.exe`; no extensionless file, no `.bat` and no `.cmd` is ever created. So the bare name could never be a file, `studio_bin.is_file()` was always false, and the command bailed out with

```
Unsloth venv missing 'unsloth' entry point. Re-run: unsloth studio setup
```

on an install that was perfectly healthy. Re-running setup does not help, because setup was never the problem.

### When it is reached

Worth being precise, because the happy path hides it. Launching through the installer's own shim puts `sys.prefix` inside the studio venv, so `in_studio_venv` is true and this whole block is skipped. The failure needs `unsloth run` to be invoked from outside that venv, which is the shadowed-PATH case: a separately `pip install`ed `unsloth` earlier on PATH than the installer's shim. `studio/backend/run.py` already calls that scenario out by name ("another 'unsloth' on PATH is shadowing the installer's binary"), so it is a real configuration rather than a hypothetical one, and on Windows it was fatal where on Linux and macOS it works.

Fixed by picking the name per platform, the same way `_looks_like_installer_managed_studio_home` already does a few lines above in the same file:

```python
shim_name = "unsloth.exe" if platform.system() == "Windows" else "unsloth"
```

### Testing

`tests/studio/test_run_windows_entry_point.py`, 2 tests. They are AST based, following the existing `tests/studio/test_cli_run_alias.py`, because reaching that assignment at runtime means standing up a real studio venv. One pins that the name is chosen between `unsloth` and `unsloth.exe`, the other that the `.exe` branch is the one gated on `platform.system() == "Windows"`, so a swapped conditional does not slip through.

Both fail against the previous line and pass with it. Verified end to end on `windows-latest` with an installed desktop bundle, where `unsloth run` now starts and serves instead of aborting.
