### PR TITLE
Studio setup: report a missing llama.cpp in Tauri mode instead of aborting the install

### DIFF
--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -4851,5 +4851,17 @@ Write-Host ""
 # failure. Direct 'unsloth studio update' does not set SKIP_STUDIO_BASE,
 # so it keeps degraded installs successful.
 if ($script:LlamaCppDegraded -and $env:SKIP_STUDIO_BASE -eq "1") {
-    Exit-SetupFailure "llama.cpp setup did not produce a usable server"
+    # Tauri mode reports instead of aborting, exactly as setup.sh does. install.ps1
+    # turns any non-zero status from here into Exit-InstallFailure, and install.rs
+    # turns that into "Installation failed", so on Windows too a single transient
+    # prebuilt download failure would throw away a first-launch install whose own
+    # footer just said complete. [TAURI:PROGRESS] (not [TAURI:STEP], which would
+    # push the frontend step counter past the seven INSTALL_STEPS entries) reaches
+    # the user as install-progress-detail text.
+    if (@("1", "true") -contains $env:UNSLOTH_TAURI_MODE) {
+        [Console]::Out.WriteLine("[TAURI:PROGRESS] llama.cpp unavailable; GGUF inference is disabled until 'unsloth studio update' succeeds")
+        [Console]::Out.Flush()
+    } else {
+        Exit-SetupFailure "llama.cpp setup did not produce a usable server"
+    }
 }

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2335,5 +2335,19 @@ echo ""
 # successful -- the footer above already reports the limitation and Unsloth
 # is still usable for non-GGUF workflows.
 if [ "$_LLAMA_CPP_DEGRADED" = true ] && [ "${SKIP_STUDIO_BASE:-0}" = "1" ]; then
-    setup_fail 1 "llama.cpp setup did not produce a usable server"
+    # In Tauri mode a non-zero exit is not "report", it is "abort": install.rs turns the
+    # error into "Installation failed", so one transient prebuilt download failure (a
+    # single HTTP 403 rate limit will do it) fails the whole first-launch install of an
+    # app whose own footer just said Installed. Everything except GGUF inference works,
+    # and whisper.cpp in this same script already degrades rather than failing for
+    # exactly this case. Match it, and say what is missing and how to get it back.
+    case "${UNSLOTH_TAURI_MODE:-0}" in
+        1|true)
+            printf '[TAURI:STEP] %s\n' \
+                "llama.cpp unavailable; GGUF inference is disabled until 'unsloth studio update' succeeds"
+            ;;
+        *)
+            setup_fail 1 "llama.cpp setup did not produce a usable server"
+            ;;
+    esac
 fi

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -2341,9 +2341,15 @@ if [ "$_LLAMA_CPP_DEGRADED" = true ] && [ "${SKIP_STUDIO_BASE:-0}" = "1" ]; then
     # app whose own footer just said Installed. Everything except GGUF inference works,
     # and whisper.cpp in this same script already degrades rather than failing for
     # exactly this case. Match it, and say what is missing and how to get it back.
+    #
+    # PROGRESS, not STEP: install.rs maps [TAURI:STEP] to the install-step event, and
+    # use-tauri-backend.ts counts those against the seven-entry INSTALL_STEPS list that
+    # install.sh already emits in full, so an eighth marker renders "Step 8 of 7" and
+    # discards the payload. [TAURI:PROGRESS] becomes install-progress-detail, which
+    # InstallingContent renders verbatim, so the user actually reads the limitation.
     case "${UNSLOTH_TAURI_MODE:-0}" in
         1|true)
-            printf '[TAURI:STEP] %s\n' \
+            printf '[TAURI:PROGRESS] %s\n' \
                 "llama.cpp unavailable; GGUF inference is disabled until 'unsloth studio update' succeeds"
             ;;
         *)

--- a/tests/sh/test_llama_degraded_tauri_mode.sh
+++ b/tests/sh/test_llama_degraded_tauri_mode.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+# setup.sh's final llama.cpp verdict: report in Tauri mode, still fail elsewhere.
+#
+# The trailing block is top-level code, not a function, so it is extracted and run with
+# setup_fail stubbed. That keeps the contract pinned without executing an install.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SETUP_SH="$SCRIPT_DIR/../../studio/setup.sh"
+PASS=0
+FAIL=0
+
+_BLOCK=$(mktemp)
+sed -n '/^if \[ "\$_LLAMA_CPP_DEGRADED" = true \] && \[ "\${SKIP_STUDIO_BASE:-0}" = "1" \]; then/,/^fi$/p' \
+    "$SETUP_SH" > "$_BLOCK"
+if [ ! -s "$_BLOCK" ]; then
+    echo "FAIL: could not find the llama.cpp degraded block in setup.sh"
+    exit 1
+fi
+
+# degraded, skip_base, tauri_mode -> expected rc, expected substring ("" means no output)
+run_case() {
+    _label="$1"; _degraded="$2"; _skip="$3"; _tauri="$4"; _rc_want="$5"; _want="$6"
+    set +e
+    _out=$(
+        _LLAMA_CPP_DEGRADED="$_degraded" \
+        SKIP_STUDIO_BASE="$_skip" \
+        UNSLOTH_TAURI_MODE="$_tauri" \
+        bash -c 'setup_fail() { printf "SETUP_FAIL: %s\n" "$*"; exit "$1"; }; . "$1"' _ "$_BLOCK" 2>&1
+    )
+    _rc=$?
+    set -e
+    if [ "$_rc" != "$_rc_want" ]; then
+        echo "  FAIL: $_label (expected rc $_rc_want, got $_rc; output: $_out)"; FAIL=$((FAIL + 1)); return
+    fi
+    case "$_want" in
+        "") [ -z "$_out" ] || { echo "  FAIL: $_label (expected no output, got: $_out)"; FAIL=$((FAIL + 1)); return; } ;;
+        *)  case "$_out" in *"$_want"*) ;; *) echo "  FAIL: $_label (expected '$_want' in: $_out)"; FAIL=$((FAIL + 1)); return ;; esac ;;
+    esac
+    echo "  PASS: $_label"; PASS=$((PASS + 1))
+}
+
+echo "=== llama.cpp degraded verdict ==="
+# The fix: a transient prebuilt failure must not abort the desktop first-launch install.
+run_case "tauri mode reports instead of aborting" true 1 1 0 "[TAURI:STEP]"
+run_case "tauri mode names the recovery command" true 1 true 0 "unsloth studio update"
+# The half that must not regress: install.sh still needs the non-zero exit.
+run_case "shell install still fails"             true 1 0 1 "SETUP_FAIL"
+run_case "unset tauri mode still fails"          true 1 "" 1 "SETUP_FAIL"
+# Untouched paths.
+run_case "direct 'studio update' stays silent"   true 0 1 0 ""
+run_case "a healthy llama.cpp says nothing"      false 1 1 0 ""
+
+rm -f "$_BLOCK"
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/sh/test_llama_degraded_tauri_mode.sh
+++ b/tests/sh/test_llama_degraded_tauri_mode.sh
@@ -44,7 +44,7 @@ run_case() {
 
 echo "=== llama.cpp degraded verdict ==="
 # The fix: a transient prebuilt failure must not abort the desktop first-launch install.
-run_case "tauri mode reports instead of aborting" true 1 1 0 "[TAURI:STEP]"
+run_case "tauri mode reports instead of aborting" true 1 1 0 "[TAURI:PROGRESS]"
 run_case "tauri mode names the recovery command" true 1 true 0 "unsloth studio update"
 # The half that must not regress: install.sh still needs the non-zero exit.
 run_case "shell install still fails"             true 1 0 1 "SETUP_FAIL"
@@ -52,6 +52,38 @@ run_case "unset tauri mode still fails"          true 1 "" 1 "SETUP_FAIL"
 # Untouched paths.
 run_case "direct 'studio update' stays silent"   true 0 1 0 ""
 run_case "a healthy llama.cpp says nothing"      false 1 1 0 ""
+
+# [TAURI:STEP] would be counted by use-tauri-backend.ts against the seven-entry
+# INSTALL_STEPS list install.sh already fills, rendering "Step 8 of 7" and throwing
+# the text away. The notice has to ride the progress-detail channel instead.
+_step_out=$(
+    _LLAMA_CPP_DEGRADED=true SKIP_STUDIO_BASE=1 UNSLOTH_TAURI_MODE=1 \
+    bash -c 'setup_fail() { exit "$1"; }; . "$1"' _ "$_BLOCK" 2>&1
+)
+case "$_step_out" in
+    *"[TAURI:STEP]"*)
+        echo "  FAIL: notice must not use [TAURI:STEP] (got: $_step_out)"; FAIL=$((FAIL + 1)) ;;
+    *)
+        echo "  PASS: notice does not consume an install step"; PASS=$((PASS + 1)) ;;
+esac
+
+# ── Windows parity: setup.ps1 must degrade the same way (static check) ──
+# install.ps1 turns any non-zero setup.ps1 status into Exit-InstallFailure, which
+# install.rs reports as "Installation failed", so an unconditional
+# Exit-SetupFailure here aborts the Windows first-launch install for the same
+# transient download failure this test pins as survivable on Unix.
+SETUP_PS1="$SCRIPT_DIR/../../studio/setup.ps1"
+_PS_BLOCK=$(sed -n '/^if (\$script:LlamaCppDegraded -and \$env:SKIP_STUDIO_BASE -eq "1") {/,/^}$/p' "$SETUP_PS1")
+if [ -z "$_PS_BLOCK" ]; then
+    echo "  FAIL: could not find the llama.cpp degraded block in setup.ps1"; FAIL=$((FAIL + 1))
+else
+    case "$_PS_BLOCK" in
+        *'UNSLOTH_TAURI_MODE'*'[TAURI:PROGRESS]'*'Exit-SetupFailure'*)
+            echo "  PASS: setup.ps1 degrades in Tauri mode and still fails elsewhere"; PASS=$((PASS + 1)) ;;
+        *)
+            echo "  FAIL: setup.ps1 does not mirror the Tauri degraded handling"; FAIL=$((FAIL + 1)) ;;
+    esac
+fi
 
 rm -f "$_BLOCK"
 echo ""


### PR DESCRIPTION
**This is a behaviour change to first-launch install, so it wants a look before merging.** After this, a desktop install whose llama.cpp prebuilt failed to download succeeds without GGUF inference, where today it fails outright.

### The problem

`setup.sh` ends with:

```sh
if [ "$_LLAMA_CPP_DEGRADED" = true ] && [ "${SKIP_STUDIO_BASE:-0}" = "1" ]; then
    setup_fail 1 "llama.cpp setup did not produce a usable server"
fi
```

The intent is right for the shell installer. `install.sh` needs the non-zero exit so it can finish PATH and shortcut setup and only then report the GGUF failure. The comment above the block says exactly that.

In Tauri mode it does something else. `install.rs` turns the resulting error into `Installation failed`, so the whole first-launch install of the desktop app is aborted. One transient prebuilt download failure is enough, and a single HTTP 403 rate limit will do it.

The result the user sees is a contradiction: `setup.sh`'s own footer prints the Installed banner and the usage hints, and then the app reports that installation failed. Nothing is repaired by retrying the install, because the venv, the frontend, the shortcuts and every non-GGUF workflow were all set up correctly. Only the llama.cpp binary is missing, and `unsloth studio update` fetches it later.

whisper.cpp in this same script already handles its own prebuilt failure this way. It prints a warning naming what is unavailable and what still works, and does not fail the install.

### The change

Tauri mode emits a `[TAURI:PROGRESS]` line saying what is missing and how to get it back:

```
llama.cpp unavailable; GGUF inference is disabled until 'unsloth studio update' succeeds
```

Every other caller keeps `setup_fail 1` exactly as before. `install.sh` is unaffected.

`setup.ps1` gets the same treatment, because Windows had the identical defect: `install.ps1` sets both `SKIP_STUDIO_BASE=1` and `UNSLOTH_TAURI_MODE`, then turns any non-zero `setup.ps1` status into `Exit-InstallFailure`, which `install.rs` reports as "Installation failed". The guard is the same `@("1", "true") -contains $env:UNSLOTH_TAURI_MODE` form that `Exit-SetupFailure` already uses at the top of that file.

### Why the progress channel and not the step channel

The first version of this used `[TAURI:STEP]`, which was wrong twice over:

- `install.rs` maps it to `install-step`, and `use-tauri-backend.ts` only increments a counter with it. The payload is never stored, so the text was silently discarded.
- `install.sh` already emits exactly 7 unique STEP markers, against a 7-entry `INSTALL_STEPS` list in `startup-screen.tsx`. An eighth marker pushes `currentStepIndex` past the end, and `stepNum` is not clamped, so the screen renders "Step 8 of 7".

`[TAURI:PROGRESS]` becomes `install-progress-detail`, which `setProgressDetail` stores and the installing screen renders verbatim below the step line. It also leaves the step counter alone.

### Testing

`tests/sh/test_llama_degraded_tauri_mode.sh`, 8 cases, all passing. It extracts the block and runs it with `setup_fail` stubbed, so the contract is pinned without executing an install:

- Tauri mode reports instead of aborting, and names the recovery command
- the shell installer still gets its non-zero exit, with `UNSLOTH_TAURI_MODE` unset or 0
- a direct `unsloth studio update` (`SKIP_STUDIO_BASE=0`) is still silent
- a healthy llama.cpp still says nothing
- the notice never emits `[TAURI:STEP]`, so it cannot consume an install step
- `setup.ps1` gates on `UNSLOTH_TAURI_MODE`, emits the progress line, and still reaches `Exit-SetupFailure` otherwise

The first two cases fail against the current `setup.sh` and pass with this change. The file is picked up automatically by the discovery-based Backend CI shell step, and `tests/studio/test_ci_shell_suite_coverage.py` still passes 15/15.
