### PR TITLE
Fix the three CI failures blocking every open PR

### DIFF
--- a/.github/workflows/clean-machine-install-ci.yml
+++ b/.github/workflows/clean-machine-install-ci.yml
@@ -1561,6 +1561,18 @@ jobs:
             -Overlay "$overlayArg" *>&1 | Tee-Object -FilePath logs/install-outer.log
           exit $LASTEXITCODE
 
+      # Both rows. A `docker exec` that lost its container also exits 0, so the exit code
+      # alone cannot tell a completed harness from one that never ran. Read the harness's
+      # own verdict instead. Needs no `if:`, because a failed Install skips it.
+      - name: Assert the in-container harness reported passing
+        shell: pwsh
+        run: |
+          $log = Get-Content logs/install-outer.log -Raw
+          if (-not ($log -match 'VIRGIN WINDOWS CONTAINER INSTALL PASSED')) {
+            Write-Host '::error::the install step exited 0 but the in-container harness never printed its passing verdict'
+            exit 1
+          }
+
       # The overlay row runs this ref's studio/setup.ps1, so it carries #7549 and must
       # install end to end. The in-container harness already asserts the venv interpreter,
       # the CLI, `import torch`, the no-winget path, the overlay marker and nobuild, exiting
@@ -1571,12 +1583,6 @@ jobs:
         shell: pwsh
         run: |
           $log = Get-Content logs/install-outer.log -Raw
-          # A `docker exec` that lost its container also exits 0, so read the harness's own
-          # verdict rather than trust the exit code alone.
-          if (-not ($log -match 'VIRGIN WINDOWS CONTAINER INSTALL PASSED')) {
-            Write-Host '::error::the install step exited 0 but the in-container harness never printed its passing verdict'
-            exit 1
-          }
           # The overlay hook is this PR's own feature and gates unconditionally: without it
           # this row is indistinguishable from the released-wheel one.
           if (-not ($log -match 'CI: overlaying source checkout')) {

--- a/.github/workflows/clean-machine-install-ci.yml
+++ b/.github/workflows/clean-machine-install-ci.yml
@@ -1476,8 +1476,9 @@ jobs:
       matrix:
         include:
           # The consumer path: install.ps1 from this ref, unsloth from PyPI, so
-          # studio/setup.ps1 comes out of the RELEASED wheel -- which is why this row and the
-          # overlay one below do not reach the same place. See the pin on the Install step.
+          # studio/setup.ps1 comes out of the RELEASED wheel rather than this ref's. That is
+          # the difference from the overlay row below; both are expected to install end to
+          # end and both gate.
           - overlay: false
           # This ref's studio/setup.ps1 and install_python_stack.py, via
           # UNSLOTH_CI_SOURCE_OVERLAY (install.ps1:2643). Without it a branch changing
@@ -1546,16 +1547,13 @@ jobs:
       - name: Install into the virgin container
         id: install
         shell: pwsh
-        # RELEASE-LAG PIN, overlay=false only. A Server Core container has no Microsoft Store
-        # and so no winget, ever, and studio/setup.ps1 used to hard-stop on a winget-only git
-        # gate and reach for winget again for the VC++ runtime. #7549 relaxed both and this
-        # branch has it, the released wheel does not: unpacking unsloth 2026.7.5 (uploaded
-        # 2026-07-23, #7549 landed on the 28th) shows its setup.ps1 still carrying the old
-        # gate, so the row that installs from PyPI on purpose cannot get past it. Release
-        # lag, not a product gap: only the next RELEASE clears it, not a merge. The overlay
-        # row runs the same install against this ref's setup.ps1 and gates unconditionally,
-        # and the step below accepts only that signature, erroring the moment it catches up.
-        continue-on-error: ${{ !matrix.overlay }}
+        # Both rows gate. This used to carry a RELEASE-LAG PIN for overlay=false: a Server
+        # Core container has no Microsoft Store and so no winget, ever, and the RELEASED
+        # studio/setup.ps1 hard-stopped on a winget-only git gate and reached for winget
+        # again for the VC++ runtime, so the row that installs from PyPI on purpose could
+        # not get past it. #7549 relaxed both, and unsloth 2026.7.6 (uploaded 2026-07-29,
+        # after #7549 merged) is the first wheel to ship them, so the row now installs end
+        # to end and the pin's own tripwire fired to say so. Nothing is tolerated here.
         run: |
           $overlayArg = if ('${{ matrix.overlay }}' -eq 'true') { 'C:\ci' } else { '' }
           docker exec virgin powershell.exe -NoLogo -NoProfile -NonInteractive `
@@ -1610,63 +1608,6 @@ jobs:
           # The harness already ran `import torch` against the managed interpreter, which
           # needs VCRUNTIME140_1.dll; this says the DLL got there rather than always being.
           Write-Host '::notice::no Store, no winget, no git and no preinstalled VC++ runtime, and the install completed anyway'
-
-      # RELEASE-LAG PIN (overlay=false). See the Install step: this row installs from PyPI on
-      # purpose and the released setup.ps1 predates #7549. continue-on-error would otherwise
-      # tolerate a bootstrap outage or an unrelated early exit like the intended diagnostic,
-      # so every branch but the pinned failure exits 1 and fails the (required) job.
-      - name: Assert the released-wheel row failed only on release lag
-        if: always() && !matrix.overlay && steps.install.outcome != 'skipped'
-        shell: pwsh
-        run: |
-          if ('${{ steps.install.outcome }}' -eq 'success') {
-            Write-Host '::error::the released wheel now installs in a virgin container, so it carries the relaxed #7549 gates. Delete this pin and drop continue-on-error from the Install step so this row gates.'
-            exit 1
-          }
-          if (-not (Test-Path logs/install-outer.log)) {
-            Write-Host '::error::the container install produced no log'
-            exit 1
-          }
-          $log = Get-Content logs/install-outer.log -Raw
-          # The pinned signature is the OLD gate wording #7549 deleted; its disappearance
-          # from a released wheel is the flip condition, and anything else stays red.
-          $gitGate = $log -match 'Git is required but could not be installed automatically'
-          $vcGate  = $log -match 'torch failed to import'
-          if (-not ($gitGate -or $vcGate)) {
-            Write-Host '::error::the container install failed at neither the released winget-only git gate nor the missing VC++ runtime; this is a new failure'
-            exit 1
-          }
-          # `-or` alone is too generous: virgin-windows-install.ps1:97 runs the torch
-          # assertion whenever the venv interpreter exists, and this image has no VC++
-          # runtime, so ANY post-venv failure -- a Node download, a setup step, a bad
-          # prebuilt -- arrives carrying the $vcGate text and was accepted as the pin.
-          # Enumerate what the harness recorded instead: one `::error::<reason>` per entry of
-          # its $failures list (that script:151), each of which must be a pinned gate.
-          # Anchored, because it also dumps the log tail indented two spaces.
-          $recorded = @(Get-Content logs/install-outer.log |
-            ForEach-Object { if ($_ -match '^::error::(.+)$') { $Matches[1].Trim() } })
-          Write-Host "recorded failures: $($recorded.Count)"
-          $recorded | ForEach-Object { Write-Host "  $_" }
-          if ($recorded.Count -eq 0) {
-            Write-Host '::error::the container install failed but recorded no ::error:: line, so nothing identifies which gate stopped it'
-            exit 1
-          }
-          # The git gate makes install.ps1 exit non-zero, the missing runtime makes the
-          # torch assert fail. Nothing else is pinned.
-          $pinned = @('^installer exited \d+$', '^torch failed to import from the managed Python')
-          $unexpected = @($recorded | Where-Object { $r = $_; -not ($pinned | Where-Object { $r -match $_ }) })
-          if ($unexpected.Count -gt 0) {
-            Write-Host "::error::the container install recorded a failure outside the pinned gates: $($unexpected -join '; '); this is a new failure"
-            exit 1
-          }
-          # And a non-zero exit has to BE the git gate, or a post-venv failure that also
-          # exits 1 is indistinguishable from the pinned one.
-          if (($recorded | Where-Object { $_ -like 'installer exited*' }) -and
-              -not ($gitGate -and ($log -match 'unsloth studio setup failed \(exit code 1\)'))) {
-            Write-Host '::error::the installer exited non-zero somewhere other than the winget-only git gate in the released studio/setup.ps1; this is a new failure'
-            exit 1
-          }
-          Write-Host '::notice::known outcome: the released wheel still carries the winget-only git gate and the winget-only Ensure-VCRedist that #7549 replaced. Retire this pin with the next release.'
 
       - name: Recover the install log from the container
         if: always()

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -335,6 +335,54 @@ def exercise_floating_monitor_geometry(page):
             and box["y"] + box["height"] <= surface["height"] - inset + tolerance
         )
 
+    # Every assertion below compares heights sampled seconds apart against this
+    # baseline, so the panel must already be showing its final row set. Until the
+    # first /api/system response is applied the panel paints use-system.ts's
+    # zero-filled DEFAULT_SYSTEM, which has no GPU: on a host that reports one
+    # (macos-14 reports a single MLX device) the VRAM row then appears and adds
+    # ~59px permanently. The caller only waited for the /api/system *request*, so
+    # sampling here can capture the pre-payload height -- a height the panel never
+    # returns to, which "content shrink" would then wait out its whole deadline
+    # chasing. Wait for the payload itself, and for the panel to have finished
+    # resizing to it.
+    try:
+        page.wait_for_function(
+            r"""() => {
+                const monitor = document.querySelector(
+                    '[data-testid="floating-monitor"]'
+                );
+                const content = document.querySelector(
+                    '[data-testid="floating-monitor-content"]'
+                );
+                if (!(monitor && content)) return false;
+                // DEFAULT_SYSTEM reports a 0 GiB RAM total; a real payload never does.
+                const readout = content.innerText.match(
+                    /([\d.]+)\s*GiB\s*\/\s*([\d.]+)\s*GiB/
+                );
+                if (!readout || !(Number.parseFloat(readout[2]) > 0)) return false;
+                // The rows commit a pass before the panel resizes to them, so the
+                // panel is only done reacting once its scroll region exactly fits
+                // the content it was reconciled against.
+                const scroll = content.parentElement;
+                const monitorHeight = monitor.getBoundingClientRect().height;
+                const contentHeight = content.getBoundingClientRect().height;
+                const scrollHeight = scroll.getBoundingClientRect().height;
+                if (Math.abs(scrollHeight - contentHeight) > 1) return false;
+                // Row insertion also lands a frame before the gap between rows
+                // does, and that intermediate state is self-consistent. Require
+                // the geometry to hold for two consecutive animation frames --
+                // this runs under the default polling="raf", and it is how
+                // Playwright itself defines a stable element.
+                const signature = monitorHeight + "x" + contentHeight;
+                const settled = window.__unslothMonitorGeometry === signature;
+                window.__unslothMonitorGeometry = signature;
+                return settled;
+            }""",
+            timeout = 30_000,
+        )
+    except Exception as exc:
+        fail(f"floating monitor never settled on an /api/system payload: {exc!r}")
+
     initial_box = monitor_box("initial placement")
     expect_close(
         initial_box["x"] + initial_box["width"],

--- a/tests/utils/test_packing.py
+++ b/tests/utils/test_packing.py
@@ -26,6 +26,7 @@ from unsloth.utils.packing import (
     patch_hybrid_linear_attention_varlen,
 )
 
+import inspect
 import logging
 from contextlib import ExitStack
 from types import SimpleNamespace
@@ -903,30 +904,42 @@ class _DummyModel(torch.nn.Module):
         self.generation_config = SimpleNamespace(attn_implementation = "sdpa")
 
 
+def _build_trl_language_modeling_collator():
+    """Build TRL's SFT collator with only the fields the installed TRL accepts.
+
+    The dataclass fields drift between TRL releases, so hardcoding a kwarg set
+    breaks whenever upstream drops one: ``return_position_ids`` only existed
+    around TRL 0.22, and ``completion_only_loss`` was removed from this collator
+    in TRL 1.7.0 (huggingface/trl#6037, commit f9aeb59) when label masking moved
+    into dataset preparation. Filtering against the live signature keeps the
+    dummy trainer faithful to whatever TRL is installed.
+    """
+    wanted = {
+        "pad_token_id": 0,
+        "completion_only_loss": False,
+        "return_tensors": "pt",
+        "padding_free": True,
+        "return_position_ids": False,
+    }
+    try:
+        accepted = set(inspect.signature(DataCollatorForLanguageModeling).parameters)
+    except (TypeError, ValueError):
+        accepted = {"pad_token_id"}
+    collator = DataCollatorForLanguageModeling(
+        **{key: value for key, value in wanted.items() if key in accepted}
+    )
+    # Ensure attributes exist even when this TRL has no such field.
+    if not hasattr(collator, "padding_free"):
+        collator.padding_free = True
+    if not hasattr(collator, "return_position_ids"):
+        collator.return_position_ids = False
+    return collator
+
+
 class _DummyTrainer:
     def __init__(self):
         self.args = SimpleNamespace(remove_unused_columns = True)
-        collator_args = {
-            "pad_token_id": 0,
-            "completion_only_loss": False,
-            "return_tensors": "pt",
-        }
-        optional_flags = [
-            {"padding_free": True, "return_position_ids": False},
-            {"padding_free": True},
-            {},
-        ]
-        for extra in optional_flags:
-            try:
-                self.data_collator = DataCollatorForLanguageModeling(**collator_args, **extra)
-                break
-            except TypeError:
-                continue
-        # Ensure attributes exist even if the constructor rejected the flags.
-        if not hasattr(self.data_collator, "padding_free"):
-            self.data_collator.padding_free = True
-        if not hasattr(self.data_collator, "return_position_ids"):
-            self.data_collator.return_position_ids = False
+        self.data_collator = _build_trl_language_modeling_collator()
 
 
 class _PaddingFreeCollator:
@@ -978,6 +991,37 @@ def test_enable_sample_packing():
     assert batch["input_ids"].shape == (1, 6)
     expected_positions = torch.tensor([0, 1, 0, 0, 1, 2], dtype = torch.long)
     assert torch.equal(batch["position_ids"].view(-1)[:6], expected_positions)
+
+
+def test_enable_sample_packing_only_requires_torch_call():
+    """Packing must not depend on optional TRL collator fields.
+
+    TRL keeps adding and removing fields on its SFT collator, so
+    ``enable_sample_packing`` is only allowed to require ``torch_call``.
+    """
+
+    class _MinimalCollator:
+        def torch_call(self, examples):
+            return {"input_ids": torch.tensor([[0, 1, 2, 3, 4, 5]], dtype = torch.long)}
+
+    trainer = SimpleNamespace(
+        args = SimpleNamespace(remove_unused_columns = True),
+        data_collator = _MinimalCollator(),
+    )
+
+    enable_sample_packing(_DummyModel(), trainer)
+
+    collator = trainer.data_collator
+    assert getattr(collator, "_unsloth_packing_wrapped") is True
+    assert trainer.args.remove_unused_columns is False
+
+    batch = collator.torch_call(
+        [
+            {"input_ids": [0, 1, 2], "seq_lengths": [2, 1]},
+            {"input_ids": [3, 4, 5], "seq_lengths": [3]},
+        ]
+    )
+    assert torch.equal(batch["packed_seq_lengths"], torch.tensor([2, 1, 3], dtype = torch.int32))
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Three unrelated CI failures are red on every open PR in the repo, so nothing can go green on its own merits. This combines the three fixes into one change: each was reviewed separately, and the files here are byte-identical to those reviewed heads. Supersedes #7713, #7712 and #7714.

None of the three is a flake, and none is caused by the PRs they were failing on.

---

## 1. `Core (HF=latest + TRL=latest)` — `tests/utils/test_packing.py`

`_DummyTrainer` built TRL's `DataCollatorForLanguageModeling` from a hardcoded kwarg set, then walked a ladder of `try`/`except TypeError` fallbacks for the optional flags. `completion_only_loss` was in the always-passed group, so when TRL removed that field the first constructor call raised `TypeError` and so did every rung of the ladder. The dummy trainer ended up with no `data_collator` at all, and the test failed with an `AttributeError` naming neither TRL nor the removed field.

Upstream removal: huggingface/trl commit `f9aeb59` (huggingface/trl#6037), which moved completion-only label masking into dataset preparation. First released in TRL v1.7.0.

The collator is now built from the installed TRL's live signature, which subsumes the fallback ladder:

```python
accepted = set(inspect.signature(DataCollatorForLanguageModeling).parameters)
collator = DataCollatorForLanguageModeling(**{k: v for k, v in wanted.items() if k in accepted})
```

Adds `test_enable_sample_packing_only_requires_torch_call`, pinning the contract the test was implicitly relying on: `enable_sample_packing` may require nothing of a collator beyond `torch_call`.

**Test-only.** Production was never affected: `unsloth/utils/packing.py` reads the collator via `getattr(trainer, "data_collator", None)` and guards every optional field with `hasattr`, and `unsloth/models/rl.py` references the *transformers* class, not TRL's.

Verified on TRL 0.22.2, 0.25.1, 0.29.1, 1.6.0, 1.7.1 and 1.9.2, so both the pre-1.7 and post-1.7 field sets are covered.

## 2. `virgin win container / overlay=false` — `clean-machine-install-ci.yml`

The released-wheel row carried `continue-on-error` plus a tripwire step asserting the install had failed, both there for a release lag that has since passed. The released wheel now installs end to end, so a step demanding failure fails.

Removing the tripwire alone would have left a hole: the only check for the `VIRGIN WINDOWS CONTAINER INSTALL PASSED` marker sat behind `if: matrix.overlay`, and every later step is `if: always()` and exits 0, so the released row would have been gated on `docker exec`'s exit code alone — the case the file's own comment anticipates, since an exec that loses its container also exits 0. The marker check is hoisted into its own ungated step; the overlay-specific assertions stay gated.

## 3. `Chat UI Tests` — `tests/studio/playwright_chat_ui.py`

This one reads as a flake but is deterministic. Three separate workflows publish the check name `Chat UI Tests`, so one consistently broken platform looks like "one of three parallel runs failed at random". On #7686 the three are three different runners, and it is always the mac:

| job | runner | result |
|---|---|---|
| 91316909182 | `macos-14` | fail |
| 91316909276 | `ubuntu-latest` | pass |
| 91316909316 | `windows-latest` | pass |

Every mac failure emits the identical box, `{'x': 1008, 'y': 712, 'width': 256, 'height': 172}`.

In `exercise_floating_monitor_geometry`, the caller gates on the `/api/system` **request** rather than its response, because `ctx.on("request", ...)` fires when the request is issued. `initial_box` is then sampled with no further gate. Until the response is applied the panel paints `use-system.ts`'s `DEFAULT_SYSTEM`, whose `gpu` is `{available: false, devices: []}`. On macOS `detect_hardware()` returns `DeviceType.MLX` and `hardware.py:2705` reports one available device, so `hasGpu` flips and `floating-monitor.tsx:469` renders a VRAM row, changing the panel's natural height permanently.

The later predicate then cannot be satisfied: the bottom-anchor half passes (712 + 172 = 884 = 900 - 16), only the height comparison against the stale baseline fails. The growth check is satisfied by the VRAM row alone, which is why growth completes in 0.4s and the shrink burns its whole deadline. Measured against the real component: RAM alone renders 113.5px, RAM plus one VRAM row renders exactly 172.0px at y=712.

The fix waits for the real signal before baselining, in one `wait_for_function`: a non-zero RAM total, the scroll region exactly fitting the content it was reconciled against, and that geometry holding for two consecutive animation frames. The frame-stability condition is load-bearing, because an intermediate state exists where both rows are present but the `space-y-3` gap is not yet applied, and that state is self-consistent. Two frames is how Playwright defines a stable element, and `wait_for_function` defaults to `polling="raf"`. No sleeps added, no timeout raised.

Before and after, running the real function against the live component with the response held back by a randomised delay:

| scenario | before | after |
|---|---|---|
| GPU-reporting host, delay 0-500ms | 24/25 failed | 0/25 failed |
| GPU-reporting host, delay 0-60ms | 40/40 failed | 0/40 failed |
| no-GPU host (ubuntu/windows control) | 0/20 failed | 0/20 failed |

Every "before" failure reproduced the byte-identical CI string. The no-GPU control explains why ubuntu and windows pass and confirms the fix does not regress them.

Confirmed on the real runner: all three `Chat UI Tests` jobs pass on #7714, including `macos-14`.

---

## Scope

Two test files and one workflow. No production code path is touched.

Not established locally: the chat UI suite was not run end to end (the harness renders the real `FloatingMonitor` through the project's own vite server and executes the real test function, but it is not the whole suite), and it was not run on macOS, so the MLX step rests on the backend source plus the platform correlation of the failing jobs. CI here covers both.
