### PR TITLE
Desktop: reopen hidden macOS window from Dock

### DIFF
--- a/studio/src-tauri/src/main.rs
+++ b/studio/src-tauri/src/main.rs
@@ -211,6 +211,14 @@ fn setup_unix_termination_signals(app: &tauri::App) -> Result<(), Box<dyn std::e
     Ok(())
 }
 
+fn show_main_window(app: &tauri::AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.show();
+        let _ = window.unminimize();
+        let _ = window.set_focus();
+    }
+}
+
 fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     let open = MenuItemBuilder::with_id("open", "Open Unsloth").build(app)?;
     let toggle = MenuItemBuilder::with_id("toggle", "Start/Stop Server").build(app)?;
@@ -224,12 +232,7 @@ fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         .tooltip("Unsloth Studio (Desktop)")
         .icon(app.default_window_icon().unwrap().clone())
         .on_menu_event(move |app, event| match event.id().as_ref() {
-            "open" => {
-                if let Some(window) = app.get_webview_window("main") {
-                    let _ = window.show();
-                    let _ = window.set_focus();
-                }
-            }
+            "open" => show_main_window(app),
             "toggle" => {
                 let _ = app.emit("tray-toggle-server", ());
             }
@@ -256,10 +259,7 @@ fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 ..
             } = event
             {
-                if let Some(window) = tray.app_handle().get_webview_window("main") {
-                    let _ = window.show();
-                    let _ = window.set_focus();
-                }
+                show_main_window(tray.app_handle());
             }
         })
         .build(app)?;
@@ -279,11 +279,7 @@ fn main() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
-            if let Some(window) = app.get_webview_window("main") {
-                let _ = window.show();
-                let _ = window.unminimize();
-                let _ = window.set_focus();
-            }
+            show_main_window(app);
         }))
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_process::init())
@@ -377,13 +373,19 @@ fn main() {
         })
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
-        .run(|app, event| {
-            if let tauri::RunEvent::Exit = event {
+        .run(|app, event| match event {
+            #[cfg(target_os = "macos")]
+            tauri::RunEvent::Reopen {
+                has_visible_windows: false,
+                ..
+            } => show_main_window(app),
+            tauri::RunEvent::Exit => {
                 // Safety net for framework-driven exits. When another path already owns
                 // cleanup, this blocks the main event-loop thread until that path is
                 // done: worst case roughly 15s, waiting on the graceful-then-force stop
                 // of the installer (5s), the updater (5s) and the backend (5s).
                 cleanup_child_processes(app);
             }
+            _ => {}
         });
 }

--- a/tests/studio/test_desktop_reliability_frontend_contract.py
+++ b/tests/studio/test_desktop_reliability_frontend_contract.py
@@ -171,6 +171,19 @@ def test_native_clipboard_bridge_is_bounded_and_registered():
     assert "native_clipboard::read_native_clipboard_png" in tauri_main
 
 
+def test_mac_dock_reopens_hidden_main_window():
+    source = TAURI_MAIN.read_text(encoding = "utf-8")
+    show_helper = source.split("fn show_main_window", 1)[1].split("\n}\n", 1)[0]
+    run_handler = source.split(".run(|app, event|", 1)[1]
+
+    for action in ("window.show()", "window.unminimize()", "window.set_focus()"):
+        assert action in show_helper
+    assert "tauri::RunEvent::Reopen" in run_handler
+    assert "has_visible_windows: false" in run_handler
+    reopen_handler = run_handler.split("tauri::RunEvent::Reopen", 1)[1].split("=>", 1)[1]
+    assert "show_main_window(app)" in reopen_handler
+
+
 def test_desktop_startup_waits_for_auth_without_intermediate_handoff():
     source = APP_PROVIDER.read_text(encoding = "utf-8")
 


### PR DESCRIPTION
## Summary
- handle macOS Dock activation through Tauri `RunEvent::Reopen`
- restore and focus the hidden main window through the shared Dock, tray, and single-instance path
- add regression coverage for the Dock reopen lifecycle

## Testing
- `uvx --from pytest pytest tests/studio/test_desktop_reliability_frontend_contract.py -q` (13 passed)
- `npm run build --prefix studio/frontend`
- `cargo check --manifest-path studio/src-tauri/Cargo.toml --locked`
- `rustfmt --edition 2021 --check < studio/src-tauri/src/main.rs`

## Not run
- packaged macOS smoke test, since the current host is Linux
