### PR TITLE
fix(studio tests): give GGUF companion fixtures a non-zero size

### DIFF
--- a/studio/backend/tests/test_vision_cache.py
+++ b/studio/backend/tests/test_vision_cache.py
@@ -144,6 +144,13 @@ class TestVisionCacheSubprocessPath:
 # ---------------------------------------------------------------------------
 
 
+# ``detect_mmproj_file`` skips zero-length GGUFs as interrupted downloads
+# (an empty file cannot be a projector), so companion fixtures need a byte in
+# them to be seen at all. The contents are never parsed - only the size gate
+# and the filename matter for these tests.
+_GGUF_STUB = b"GGUF"
+
+
 class TestLocalGgufVisionDetection:
     @patch(
         "utils.models.model_config._is_vision_model_subprocess",
@@ -151,8 +158,8 @@ class TestLocalGgufVisionDetection:
     )
     def test_qwen36_gguf_with_mmproj_skips_transformers(self, mock_subprocess, tmp_path):
         model = tmp_path / "Qwen3.6-27B-UD-Q4_K_XL-MTP.gguf"
-        model.write_bytes(b"")
-        (tmp_path / "mmproj-F32.gguf").write_bytes(b"")
+        model.write_bytes(_GGUF_STUB)
+        (tmp_path / "mmproj-F32.gguf").write_bytes(_GGUF_STUB)
 
         assert is_vision_model(str(model)) is True
         mock_subprocess.assert_not_called()
@@ -165,8 +172,8 @@ class TestLocalGgufVisionDetection:
         variant_dir = tmp_path / "BF16"
         variant_dir.mkdir()
         model = variant_dir / "Qwen3.6-27B-UD-Q4_K_XL-MTP.gguf"
-        model.write_bytes(b"")
-        (tmp_path / "mmproj-F32.gguf").write_bytes(b"")
+        model.write_bytes(_GGUF_STUB)
+        (tmp_path / "mmproj-F32.gguf").write_bytes(_GGUF_STUB)
 
         assert is_vision_model(str(model)) is True
         mock_subprocess.assert_not_called()
@@ -177,17 +184,17 @@ class TestLocalGgufVisionDetection:
     )
     def test_qwen36_gguf_without_mmproj_skips_transformers(self, mock_subprocess, tmp_path):
         model = tmp_path / "Qwen3.6-27B-UD-Q4_K_XL-MTP.gguf"
-        model.write_bytes(b"")
+        model.write_bytes(_GGUF_STUB)
 
         assert is_vision_model(str(model)) is False
         mock_subprocess.assert_not_called()
 
     def test_local_gguf_check_observes_mmproj_added_later(self, tmp_path):
         model = tmp_path / "Qwen3.6-27B-UD-Q4_K_XL-MTP.gguf"
-        model.write_bytes(b"")
+        model.write_bytes(_GGUF_STUB)
 
         assert is_vision_model(str(model)) is False
-        (tmp_path / "mmproj-F32.gguf").write_bytes(b"")
+        (tmp_path / "mmproj-F32.gguf").write_bytes(_GGUF_STUB)
         assert is_vision_model(str(model)) is True
 
     @patch(
@@ -196,9 +203,9 @@ class TestLocalGgufVisionDetection:
     )
     def test_ui_selection_returns_local_gguf_config(self, mock_subprocess, tmp_path):
         model = tmp_path / "Qwen3.6-27B-UD-Q4_K_XL-MTP.gguf"
-        model.write_bytes(b"")
+        model.write_bytes(_GGUF_STUB)
         mmproj = tmp_path / "mmproj-F32.gguf"
-        mmproj.write_bytes(b"")
+        mmproj.write_bytes(_GGUF_STUB)
 
         config = ModelConfig.from_ui_selection(str(model), None)
 
@@ -218,9 +225,9 @@ class TestLocalGgufVisionDetection:
         variant_dir = tmp_path / "BF16"
         variant_dir.mkdir()
         model = variant_dir / "Qwen3.6-27B-UD-Q4_K_XL-MTP.gguf"
-        model.write_bytes(b"")
+        model.write_bytes(_GGUF_STUB)
         mmproj = tmp_path / "mmproj-F32.gguf"
-        mmproj.write_bytes(b"")
+        mmproj.write_bytes(_GGUF_STUB)
 
         config = ModelConfig.from_ui_selection(str(model), None)
 


### PR DESCRIPTION
`d36e3e1c` (#7375) added an interrupted-download guard to `detect_mmproj_file`:

```python
# Interrupted download: llama-server cannot open it, ...
if resolved.stat().st_size <= 0:
    continue
```

That guard is right — an empty file cannot be a projector. But every fixture in `TestLocalGgufVisionDetection` writes its GGUFs with `write_bytes(b"")`, so the guard now discards the mmproj the test just created, and `is_vision_model` returns `False`.

**Five tests fail on `main` because of this, which means on every open PR.** Confirmed identical failures on `main@3f2fc5af` and on an unrelated PR branch:

```
FAILED test_vision_cache.py::TestLocalGgufVisionDetection::test_qwen36_gguf_with_mmproj_skips_transformers
FAILED test_vision_cache.py::TestLocalGgufVisionDetection::test_direct_gguf_in_variant_subdir_finds_snapshot_mmproj
FAILED test_vision_cache.py::TestLocalGgufVisionDetection::test_local_gguf_check_observes_mmproj_added_later
FAILED test_vision_cache.py::TestLocalGgufVisionDetection::test_ui_selection_returns_local_gguf_config
FAILED test_vision_cache.py::TestLocalGgufVisionDetection::test_ui_selection_direct_gguf_in_variant_subdir_keeps_mmproj
```

Isolated the size gate as the whole cause — same directory layout, only the file size varying:

| fixture size | `detect_mmproj_file` |
|---|---|
| 0 bytes | `None` |
| 1 byte | `.../mmproj-F32.gguf` |
| 4096 bytes | `.../mmproj-F32.gguf` |

`detect_gguf_model` still returns the weight path in all three cases, so the weight is found and only the projector disappears — which is why the symptom is `is_vision is False` rather than the model not being detected at all.

These tests exercise detection, not download completeness, so the fix is on the fixture side rather than weakening the guard. The deliberately empty files in `test_cached_gguf_routes.py` are untouched — `test_a_zero_byte_first_gguf_leaves_the_quant_incomplete` needs them to stay at zero.

`tests/test_vision_cache.py`: 45 passed.

**Scope.** This does not cover the sixth failure on `main`, `test_cached_gguf_routes.py::test_legacy_custom_inventory_filters_registered_mtp_root`. That one already uses non-empty fixtures and fails in `collect_local_models` — a registered `MTP/` scan root stops filtering a companion-only directory out of the inventory. Same commit range, different code path, and #7375 is large enough that I didn't want to guess at it in the same change. Happy to look at it separately if nobody's on it.

One observation while in there, not a request: the size gate applies to projectors but not to weights, so a 0-byte `.gguf` is still accepted by `detect_gguf_model` as a model. The comment suggests that's intentional — the inventory reports such a row text-only — but the asymmetry surprised me at first.