### PR TITLE
Fix the six backend tests blocking every PR: companion-only GGUF folders, and vision fixtures on empty projectors

### DIFF
--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -285,6 +285,25 @@ def _has_non_gguf_weights(path: Path) -> bool:
         return False
 
 
+def _is_gguf_companion_only_dir(path: Path) -> bool:
+    """True for a folder whose entire content is GGUF companions -- a lone mmproj adapter, an
+    MTP drafter, or both -- with nothing servable beside them.
+
+    The scanners report ``model_format = None`` for such a folder, because neither companion is a
+    primary weight, and that is also what a plain checkpoint reports. The custom-folder scan below
+    validates GGUF rows through ``detect_gguf_model`` and waves the rest through, so without this
+    the folder is published as a model that no loader can start.
+    """
+    try:
+        if not path.is_dir():
+            return False
+        if (path / "config.json").exists() or (path / "adapter_config.json").exists():
+            return False
+        return any(path.glob("*.gguf")) and not _has_non_gguf_weights(path)
+    except OSError:
+        return False
+
+
 def _scan_models_dir(models_dir: Path, *, limit: int | None = None) -> List[LocalModelInfo]:
     if not models_dir.exists() or not models_dir.is_dir():
         return []
@@ -874,10 +893,11 @@ def collect_local_models(models_root: Path) -> List[LocalModelInfo]:
             ]
             custom_models = []
             for model in _generic:
-                if model.model_format != "gguf" or model.partial:
+                path = Path(model.path)
+                is_gguf_row = model.model_format == "gguf" or _is_gguf_companion_only_dir(path)
+                if not is_gguf_row or model.partial:
                     custom_models.append(model)
                     continue
-                path = Path(model.path)
                 if path.is_dir():
                     patterns = ("*", "*/*") if model.source == "hf_cache" else ("*",)
                     if any(

--- a/studio/backend/tests/test_vision_cache.py
+++ b/studio/backend/tests/test_vision_cache.py
@@ -145,6 +145,10 @@ class TestVisionCacheSubprocessPath:
 
 
 class TestLocalGgufVisionDetection:
+    """``detect_mmproj_file`` skips a zero-byte projector as an interrupted download, so every
+    projector fixture here is written non-empty; the byte content itself is never read (there is
+    no GGUF header, so pairing falls back to the filename)."""
+
     @patch(
         "utils.models.model_config._is_vision_model_subprocess",
         side_effect = AssertionError("GGUF must not use Transformers vision detection"),
@@ -152,7 +156,7 @@ class TestLocalGgufVisionDetection:
     def test_qwen36_gguf_with_mmproj_skips_transformers(self, mock_subprocess, tmp_path):
         model = tmp_path / "Qwen3.6-27B-UD-Q4_K_XL-MTP.gguf"
         model.write_bytes(b"")
-        (tmp_path / "mmproj-F32.gguf").write_bytes(b"")
+        (tmp_path / "mmproj-F32.gguf").write_bytes(b"\0" * 32)
 
         assert is_vision_model(str(model)) is True
         mock_subprocess.assert_not_called()
@@ -166,7 +170,7 @@ class TestLocalGgufVisionDetection:
         variant_dir.mkdir()
         model = variant_dir / "Qwen3.6-27B-UD-Q4_K_XL-MTP.gguf"
         model.write_bytes(b"")
-        (tmp_path / "mmproj-F32.gguf").write_bytes(b"")
+        (tmp_path / "mmproj-F32.gguf").write_bytes(b"\0" * 32)
 
         assert is_vision_model(str(model)) is True
         mock_subprocess.assert_not_called()
@@ -187,7 +191,7 @@ class TestLocalGgufVisionDetection:
         model.write_bytes(b"")
 
         assert is_vision_model(str(model)) is False
-        (tmp_path / "mmproj-F32.gguf").write_bytes(b"")
+        (tmp_path / "mmproj-F32.gguf").write_bytes(b"\0" * 32)
         assert is_vision_model(str(model)) is True
 
     @patch(
@@ -198,7 +202,7 @@ class TestLocalGgufVisionDetection:
         model = tmp_path / "Qwen3.6-27B-UD-Q4_K_XL-MTP.gguf"
         model.write_bytes(b"")
         mmproj = tmp_path / "mmproj-F32.gguf"
-        mmproj.write_bytes(b"")
+        mmproj.write_bytes(b"\0" * 32)
 
         config = ModelConfig.from_ui_selection(str(model), None)
 
@@ -220,7 +224,7 @@ class TestLocalGgufVisionDetection:
         model = variant_dir / "Qwen3.6-27B-UD-Q4_K_XL-MTP.gguf"
         model.write_bytes(b"")
         mmproj = tmp_path / "mmproj-F32.gguf"
-        mmproj.write_bytes(b"")
+        mmproj.write_bytes(b"\0" * 32)
 
         config = ModelConfig.from_ui_selection(str(model), None)
 


### PR DESCRIPTION
Backend CI is red on `main` and blocks every open PR. Six tests fail, from two distinct causes, both introduced by #7375.

Bisected:

| commit | result |
|---|---|
| `9fe5dd9eb` (parent) | 87 passed |
| `d36e3e1c4` (#7375) | 6 failed, 103 passed |

## A registered folder of GGUF companions is published as a model

`test_cached_gguf_routes.py::test_legacy_custom_inventory_filters_registered_mtp_root`. The test is byte-identical before and after #7375, so this is a pure behaviour regression.

#7375 tightened `_is_main_gguf_filename` so an MTP drafter no longer counts as a primary weight. That is correct on its own, but `_scan_models_dir` derives `model_format` from the same predicate, so a folder holding only a drafter went from `"gguf"` to `None`. `collect_local_models` reads `model_format != "gguf"` as "definitely a checkpoint" and appends the row without the `detect_gguf_model` validation that used to drop it:

```python
if model.model_format != "gguf" or model.partial:
    custom_models.append(model)
    continue
```

So the folder reaches `GET /api/models/local` and `GET /v1/models` as a selectable model with no format, and selecting it routes to the non-GGUF checkpoint loader over a directory with nothing servable. The mmproj form of this hole predates #7375; the drafter form is what tripped the test.

Fixed by classifying a companion-only folder as a GGUF row so it goes through the same validation. The `config.json` / `adapter_config.json` guard keeps a real checkpoint that happens to sit beside a stray companion GGUF out of the new branch. I deliberately did not revert `_is_main_gguf_filename`: excluding drafters there is right, and is relied on by `_repo_gguf_size_bytes`, `_repo_gguf_last_modified` and standalone-file scanning.

## Five vision tests assert vision on a zero-byte projector

`TestLocalGgufVisionDetection`, five tests. Each writes its projector as `write_bytes(b"")`. #7375 made `detect_mmproj_file` skip zero-byte GGUFs as interrupted downloads, so the projector is skipped and `is_vision_model` returns `False`.

That behaviour is deliberate and #7375 shipped its own coverage for it in `test_detect_mmproj_file.py`, where the same PR moved that file's `_touch` helper off `b""` for exactly this reason and added `test_a_zero_byte_projector_is_not_offered_to_the_loader` and `test_a_zero_byte_projector_does_not_shadow_a_whole_one`. The `test_vision_cache.py` fixtures were simply missed.

These tests mean to assert that a projector beside a GGUF implies vision, not anything about empty files, so only the fixture changes: the projector is written non-empty, matching the convention #7375 established. No assertion is altered, and the model-weight fixtures stay `b""` since only the projector is size-gated. A zero-byte GGUF cannot be opened by llama-server, so there is no user-facing vision loss here, unlike the first cause.

## Verification

Target files `tests/test_vision_cache.py tests/test_cached_gguf_routes.py`: 109 passed, from 6 failed / 103 passed.

Full backend suite, deselecting the two files that fail collection on missing optional deps identically everywhere:

| revision | result |
|---|---|
| `9fe5dd9eb` (parent of the break) | 26 failed, 13162 passed, 70 errors |
| `3f2fc5afe` (current main) | 32 failed, 13431 passed, 70 errors |
| this branch | 26 failed, 13437 passed, 70 errors |

Exactly minus 6 failures against main, and the failure and error node id sets match the parent's, not just the counts. Those remaining 26 and 70 are environment-dependent and predate all of this.

Each fix reverted alone fails exactly its own tests and nothing else: without the `models.py` change, 1 failed / 108 passed; without the fixture change, 5 failed / 104 passed; with both, 109 passed. Ruff clean.
