### PR TITLE
Fix `validate_dataset` KeyError on default (tokenized) RawTextDataLoader output

### DIFF
--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -566,7 +566,11 @@ def test_validate_dataset_streams_instead_of_materialising_columns():
             return self.rows
 
     class Tokenizer:
-        def decode(self, token_ids, skip_special_tokens = False):
+        def decode(
+            self,
+            token_ids,
+            skip_special_tokens = False,
+        ):
             return " ".join(f"word_{i}" for i in token_ids)
 
     dataset = BatchedDataset([[1, 2, 3], [4, 5, 6], [7, 8, 9]])

--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -540,6 +540,46 @@ def test_validate_dataset_accepts_objects_without_column_names():
     return True
 
 
+def test_validate_dataset_streams_instead_of_materialising_columns():
+    """Columns must be streamed via Dataset.iter(), not copied whole.
+
+    dataset[column] pulls every row into Python objects at once, which for token
+    ids is the bulk of peak memory and grows with the dataset.
+    """
+
+    class BatchedDataset:
+        column_names = ["input_ids"]
+
+        def __init__(self, rows):
+            self.rows = rows
+            self.materialised = 0
+
+        def __len__(self):
+            return len(self.rows)
+
+        def iter(self, batch_size):
+            for start in range(0, len(self.rows), batch_size):
+                yield {"input_ids": self.rows[start : start + batch_size]}
+
+        def __getitem__(self, key):
+            self.materialised += 1
+            return self.rows
+
+    class Tokenizer:
+        def decode(self, token_ids, skip_special_tokens = False):
+            return " ".join(f"word_{i}" for i in token_ids)
+
+    dataset = BatchedDataset([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    stats = TextPreprocessor().validate_dataset(dataset, tokenizer = Tokenizer())
+
+    assert stats["total_samples"] == 3, stats
+    assert stats["empty_samples"] == 0, stats
+    assert dataset.materialised == 0, "column was materialised instead of streamed"
+
+    print("test_validate_dataset_streams_instead_of_materialising_columns passed")
+    return True
+
+
 if __name__ == "__main__":
     success = test_raw_text_loader()
     success = test_smart_chunk_text_single_chunk_no_eos_returns_plain_list() and success
@@ -548,4 +588,5 @@ if __name__ == "__main__":
     success = test_load_from_files_all_empty_raises() and success
     success = test_validate_dataset_handles_tokenized_and_text_columns() and success
     success = test_validate_dataset_accepts_objects_without_column_names() and success
+    success = test_validate_dataset_streams_instead_of_materialising_columns() and success
     sys.exit(0 if success else 1)

--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -496,6 +496,50 @@ def test_validate_dataset_handles_tokenized_and_text_columns():
         os.unlink(test_file)
 
 
+def test_validate_dataset_accepts_objects_without_column_names():
+    """Dispatching on `column_names` must not narrow the accepted input types.
+
+    validate_dataset() read dataset["text"] directly, so it worked for any
+    mapping-like object: DataFrames, plain dicts, custom __getitem__ wrappers.
+    """
+
+    preprocessor = TextPreprocessor()
+    texts = ["first sample with enough characters", "second sample with enough characters"]
+    longest = max(len(t) for t in texts)
+
+    class DuckTypedDataset:
+        # Only __len__ + __getitem__, i.e. the pre-existing implicit contract.
+        def __init__(self, data):
+            self.data = data
+
+        def __len__(self):
+            return len(next(iter(self.data.values())))
+
+        def __getitem__(self, key):
+            return self.data[key]
+
+    stats = preprocessor.validate_dataset(DuckTypedDataset({"text": texts}))
+    assert stats["total_samples"] == 2, stats
+    assert stats["empty_samples"] == 0, stats
+    assert stats["max_length"] == longest, stats
+
+    stats = preprocessor.validate_dataset({"text": texts})
+    assert stats["max_length"] == longest, stats
+
+    try:
+        import pandas as pd
+    except ImportError:
+        pd = None
+
+    if pd is not None:
+        stats = preprocessor.validate_dataset(pd.DataFrame({"text": texts}))
+        assert stats["total_samples"] == 2, stats
+        assert stats["max_length"] == longest, stats
+
+    print("test_validate_dataset_accepts_objects_without_column_names passed")
+    return True
+
+
 if __name__ == "__main__":
     success = test_raw_text_loader()
     success = test_smart_chunk_text_single_chunk_no_eos_returns_plain_list() and success
@@ -503,4 +547,5 @@ if __name__ == "__main__":
     success = test_smart_chunk_text_empty_input_returns_no_chunks() and success
     success = test_load_from_files_all_empty_raises() and success
     success = test_validate_dataset_handles_tokenized_and_text_columns() and success
+    success = test_validate_dataset_accepts_objects_without_column_names() and success
     sys.exit(0 if success else 1)

--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -401,6 +401,7 @@ def test_load_from_files_all_empty_raises():
     print("test_load_from_files_all_empty_raises passed")
     return True
 
+
 def test_validate_dataset_handles_tokenized_and_text_columns():
     """validate_dataset() must work for both dataset shapes:
     - text-column datasets (return_tokenized=False), no tokenizer needed
@@ -409,47 +410,61 @@ def test_validate_dataset_handles_tokenized_and_text_columns():
     Also asserts the clear ValueError when input_ids is present but no
     tokenizer was passed, and when neither column exists.
     """
- 
+
     class MockTokenizer:
         def __init__(self):
             self.eos_token = "</s>"
             self.eos_token_id = 2
- 
-        def __call__(self, text, return_tensors = None, add_special_tokens = False):
+
+        def __call__(
+            self,
+            text,
+            return_tensors = None,
+            add_special_tokens = False,
+        ):
             words = text.split()
             token_ids = list(range(len(words)))
- 
+
             if return_tensors == "pt":
+
                 class MockTensor:
                     def __init__(self, data):
                         self.data = data
+
                     def __getitem__(self, idx):
                         return self.data
+
                     def __len__(self):
                         return len(self.data)
+
                     def tolist(self):
                         return self.data
+
                 return {"input_ids": [MockTensor(token_ids)]}
             return {"input_ids": token_ids}
- 
-        def decode(self, token_ids, skip_special_tokens = False):
+
+        def decode(
+            self,
+            token_ids,
+            skip_special_tokens = False,
+        ):
             return " ".join(f"word_{i}" for i in token_ids)
- 
+
     tokenizer = MockTokenizer()
     loader = RawTextDataLoader(tokenizer, chunk_size = 5, stride = 2)
     preprocessor = TextPreprocessor()
- 
+
     test_content = "This is a test file for raw text training. " * 10
     with tempfile.NamedTemporaryFile(mode = "w", suffix = ".txt", delete = False) as f:
         f.write(test_content)
         test_file = f.name
- 
+
     try:
         text_dataset = loader.load_from_file(test_file, return_tokenized = False)
         stats = preprocessor.validate_dataset(text_dataset)
         assert stats["total_samples"] > 0, "Should count samples from text column"
         assert "warnings" in stats
- 
+
         tokenized_dataset = loader.load_from_file(test_file, return_tokenized = True)
         stats = preprocessor.validate_dataset(tokenized_dataset, tokenizer = tokenizer)
         assert stats["total_samples"] > 0, "Should count samples decoded from input_ids"
@@ -464,18 +479,19 @@ def test_validate_dataset_handles_tokenized_and_text_columns():
 
         class FakeEmptyDataset:
             column_names = ["some_other_column"]
+
             def __len__(self):
                 return 0
- 
+
         try:
             preprocessor.validate_dataset(FakeEmptyDataset())
             assert False, "Should raise ValueError when neither text nor input_ids column exists"
         except ValueError as e:
             assert "text" in str(e).lower() and "input_ids" in str(e).lower(), str(e)
- 
+
         print("test_validate_dataset_handles_tokenized_and_text_columns passed")
         return True
- 
+
     finally:
         os.unlink(test_file)
 

--- a/tests/test_raw_text.py
+++ b/tests/test_raw_text.py
@@ -401,6 +401,84 @@ def test_load_from_files_all_empty_raises():
     print("test_load_from_files_all_empty_raises passed")
     return True
 
+def test_validate_dataset_handles_tokenized_and_text_columns():
+    """validate_dataset() must work for both dataset shapes:
+    - text-column datasets (return_tokenized=False), no tokenizer needed
+    - input_ids-column datasets (return_tokenized=True, the default), which
+      require a tokenizer to decode back to text for validation
+    Also asserts the clear ValueError when input_ids is present but no
+    tokenizer was passed, and when neither column exists.
+    """
+ 
+    class MockTokenizer:
+        def __init__(self):
+            self.eos_token = "</s>"
+            self.eos_token_id = 2
+ 
+        def __call__(self, text, return_tensors = None, add_special_tokens = False):
+            words = text.split()
+            token_ids = list(range(len(words)))
+ 
+            if return_tensors == "pt":
+                class MockTensor:
+                    def __init__(self, data):
+                        self.data = data
+                    def __getitem__(self, idx):
+                        return self.data
+                    def __len__(self):
+                        return len(self.data)
+                    def tolist(self):
+                        return self.data
+                return {"input_ids": [MockTensor(token_ids)]}
+            return {"input_ids": token_ids}
+ 
+        def decode(self, token_ids, skip_special_tokens = False):
+            return " ".join(f"word_{i}" for i in token_ids)
+ 
+    tokenizer = MockTokenizer()
+    loader = RawTextDataLoader(tokenizer, chunk_size = 5, stride = 2)
+    preprocessor = TextPreprocessor()
+ 
+    test_content = "This is a test file for raw text training. " * 10
+    with tempfile.NamedTemporaryFile(mode = "w", suffix = ".txt", delete = False) as f:
+        f.write(test_content)
+        test_file = f.name
+ 
+    try:
+        text_dataset = loader.load_from_file(test_file, return_tokenized = False)
+        stats = preprocessor.validate_dataset(text_dataset)
+        assert stats["total_samples"] > 0, "Should count samples from text column"
+        assert "warnings" in stats
+ 
+        tokenized_dataset = loader.load_from_file(test_file, return_tokenized = True)
+        stats = preprocessor.validate_dataset(tokenized_dataset, tokenizer = tokenizer)
+        assert stats["total_samples"] > 0, "Should count samples decoded from input_ids"
+        assert "warnings" in stats
+        assert stats["max_length"] > 0
+
+        try:
+            preprocessor.validate_dataset(tokenized_dataset)
+            assert False, "Should raise ValueError when input_ids present but no tokenizer given"
+        except ValueError as e:
+            assert "tokenizer" in str(e).lower(), str(e)
+
+        class FakeEmptyDataset:
+            column_names = ["some_other_column"]
+            def __len__(self):
+                return 0
+ 
+        try:
+            preprocessor.validate_dataset(FakeEmptyDataset())
+            assert False, "Should raise ValueError when neither text nor input_ids column exists"
+        except ValueError as e:
+            assert "text" in str(e).lower() and "input_ids" in str(e).lower(), str(e)
+ 
+        print("test_validate_dataset_handles_tokenized_and_text_columns passed")
+        return True
+ 
+    finally:
+        os.unlink(test_file)
+
 
 if __name__ == "__main__":
     success = test_raw_text_loader()
@@ -408,4 +486,5 @@ if __name__ == "__main__":
     success = test_load_from_file_skips_non_object_json_lines() and success
     success = test_smart_chunk_text_empty_input_returns_no_chunks() and success
     success = test_load_from_files_all_empty_raises() and success
+    success = test_validate_dataset_handles_tokenized_and_text_columns() and success
     sys.exit(0 if success else 1)

--- a/unsloth/dataprep/raw_text.py
+++ b/unsloth/dataprep/raw_text.py
@@ -327,7 +327,7 @@ class TextPreprocessor:
         text = self._CODE_BLOCK_PATTERN.sub(r"<|code|\1|>\2<|/code|>", text)
         return text
 
-    def validate_dataset(self, dataset):
+    def validate_dataset(self, dataset, tokenizer = None):
         """
         Check for:
         - Minimum/maximum sequence lengths
@@ -346,7 +346,21 @@ class TextPreprocessor:
             "warnings": [],
         }
 
-        texts = dataset["text"]
+        if "text" in dataset.column_names:
+            texts = dataset['text']
+        
+        elif "input_ids" in dataset.column_names:
+            if tokenizer is None:
+                raise ValueError(
+                    "Dataset has 'input_ids' but no 'text' column; "
+                    "pass `tokenizer=` to validate_dataset() to decode it for validation."
+                )
+            texts = [tokenizer.decode(ids, skip_special_tokens = True) for ids in dataset["input_ids"]]
+            
+        else:
+            raise ValueError("Dataset must have either 'text' or 'input_ids' column")
+            
+            
         text_lengths = []
         seen_texts = set()
 

--- a/unsloth/dataprep/raw_text.py
+++ b/unsloth/dataprep/raw_text.py
@@ -287,6 +287,22 @@ class RawTextDataLoader:
         return ""
 
 
+def _iter_column(dataset, column):
+    """Yield one column value at a time.
+
+    `dataset[column]` copies the whole column into Python objects, which for token
+    ids dominates validate_dataset's peak memory on datasets<4 (4.x returns a lazy
+    Column). Dataset.iter() streams Arrow batches instead; anything without it
+    (DataFrames, dicts, custom __getitem__) falls back to plain indexing.
+    """
+    batched = getattr(dataset, "iter", None)
+    if callable(batched):
+        for batch in batched(batch_size = 256):
+            yield from batch[column]
+    else:
+        yield from dataset[column]
+
+
 class TextPreprocessor:
     # Compile regex patterns once for better performance
     _WHITESPACE_PATTERN = re.compile(r"[^\S\n]+")
@@ -350,14 +366,11 @@ class TextPreprocessor:
             "warnings": [],
         }
 
-        # `column_names` is HF Dataset-only, so fall back to plain indexing to keep
-        # accepting mapping-likes (DataFrames, dicts, custom __getitem__) as before.
+        # `column_names` is HF Dataset-only; None means a mapping-like (DataFrame,
+        # dict, custom __getitem__), which this method has always accepted.
         column_names = getattr(dataset, "column_names", None)
-        if column_names is None:
-            texts = dataset["text"]
-
-        elif "text" in column_names:
-            texts = dataset["text"]
+        if column_names is None or "text" in column_names:
+            texts = _iter_column(dataset, "text")
 
         elif "input_ids" in column_names:
             if tokenizer is None:
@@ -365,9 +378,11 @@ class TextPreprocessor:
                     "Dataset has 'input_ids' but no 'text' column; "
                     "pass `tokenizer=` to validate_dataset() to decode it for validation."
                 )
-            texts = [
-                tokenizer.decode(ids, skip_special_tokens = True) for ids in dataset["input_ids"]
-            ]
+            # Generator, not a list: decoded text is consumed once by the loop below.
+            texts = (
+                tokenizer.decode(ids, skip_special_tokens = True)
+                for ids in _iter_column(dataset, "input_ids")
+            )
 
         else:
             raise ValueError("Dataset must have either 'text' or 'input_ids' column")

--- a/unsloth/dataprep/raw_text.py
+++ b/unsloth/dataprep/raw_text.py
@@ -327,7 +327,11 @@ class TextPreprocessor:
         text = self._CODE_BLOCK_PATTERN.sub(r"<|code|\1|>\2<|/code|>", text)
         return text
 
-    def validate_dataset(self, dataset, tokenizer = None):
+    def validate_dataset(
+        self,
+        dataset,
+        tokenizer = None,
+    ):
         """
         Check for:
         - Minimum/maximum sequence lengths
@@ -347,20 +351,21 @@ class TextPreprocessor:
         }
 
         if "text" in dataset.column_names:
-            texts = dataset['text']
-        
+            texts = dataset["text"]
+
         elif "input_ids" in dataset.column_names:
             if tokenizer is None:
                 raise ValueError(
                     "Dataset has 'input_ids' but no 'text' column; "
                     "pass `tokenizer=` to validate_dataset() to decode it for validation."
                 )
-            texts = [tokenizer.decode(ids, skip_special_tokens = True) for ids in dataset["input_ids"]]
-            
+            texts = [
+                tokenizer.decode(ids, skip_special_tokens = True) for ids in dataset["input_ids"]
+            ]
+
         else:
             raise ValueError("Dataset must have either 'text' or 'input_ids' column")
-            
-            
+
         text_lengths = []
         seen_texts = set()
 

--- a/unsloth/dataprep/raw_text.py
+++ b/unsloth/dataprep/raw_text.py
@@ -350,10 +350,16 @@ class TextPreprocessor:
             "warnings": [],
         }
 
-        if "text" in dataset.column_names:
+        # `column_names` is HF Dataset-only, so fall back to plain indexing to keep
+        # accepting mapping-likes (DataFrames, dicts, custom __getitem__) as before.
+        column_names = getattr(dataset, "column_names", None)
+        if column_names is None:
             texts = dataset["text"]
 
-        elif "input_ids" in dataset.column_names:
+        elif "text" in column_names:
+            texts = dataset["text"]
+
+        elif "input_ids" in column_names:
             if tokenizer is None:
                 raise ValueError(
                     "Dataset has 'input_ids' but no 'text' column; "


### PR DESCRIPTION
## Summary

`TextPreprocessor.validate_dataset()` assumed every dataset has a `"text"` column, but `RawTextDataLoader` defaults to `return_tokenized=True`, which produces datasets with `input_ids` / `attention_mask` / `labels` instead. Calling `validate_dataset()` on the default (tokenized) output raises `KeyError: 'text'`.

## Fix

`validate_dataset()` now accepts an optional `tokenizer` argument and handles both dataset shapes:
- `"text"` column present -> validated directly (unchanged behavior).
- `"input_ids"` column present, no `"text"` -> decoded via the passed `tokenizer` before validation.
- `"input_ids"` present but no `tokenizer` passed -> raises a clear `ValueError` instead of an unrelated `AttributeError`.
- Neither column present -> raises `ValueError` (unchanged).

`tokenizer` is a method parameter rather than a constructor/instance attribute, since `TextPreprocessor` is otherwise stateless and used standalone for text cleaning without any tokenizer context -- keeping it optional and non-breaking for existing callers.

## Repro (before fix)

```python
loader = RawTextDataLoader(tokenizer)        # default return_tokenized=True
ds = loader.load_from_file("some.txt")
TextPreprocessor().validate_dataset(ds)         # KeyError: 'text'
```

## Testing

Added `test_validate_dataset_handles_tokenized_and_text_columns` covering:
- text-column dataset (backward compatible, no tokenizer needed)
- input_ids-column dataset with tokenizer passed
- input_ids-column dataset without tokenizer -> clear `ValueError`
- dataset with neither column -> clear `ValueError`


```
6 passed, 6 warnings in 0.07s
```

(warnings are pytest's return-value-from-test notice, pre-existing in this file's style, unrelated to this change)