### PR TITLE
fix(studio): content-check unclassified scan-folder dirs before registering them

### DIFF
--- a/studio/backend/routes/models.py
+++ b/studio/backend/routes/models.py
@@ -874,7 +874,13 @@ def collect_local_models(models_root: Path) -> List[LocalModelInfo]:
             ]
             custom_models = []
             for model in _generic:
-                if model.model_format != "gguf" or model.partial:
+                # An unclassified directory (``model_format is None``) still has to be
+                # content-checked. Since #7648 a folder whose only GGUF is an MTP drafter
+                # no longer classifies as ``"gguf"``, and treating that as "some other
+                # format, keep it" would register the companion directory as a model.
+                if (
+                    model.model_format is not None and model.model_format != "gguf"
+                ) or model.partial:
                     custom_models.append(model)
                     continue
                 path = Path(model.path)

--- a/studio/backend/tests/test_vision_cache.py
+++ b/studio/backend/tests/test_vision_cache.py
@@ -144,6 +144,13 @@ class TestVisionCacheSubprocessPath:
 # ---------------------------------------------------------------------------
 
 
+# ``detect_mmproj_file`` skips zero-length GGUFs as interrupted downloads
+# (an empty file cannot be a projector), so companion fixtures need a byte in
+# them to be seen at all. The contents are never parsed - only the size gate
+# and the filename matter for these tests.
+_GGUF_STUB = b"GGUF"
+
+
 class TestLocalGgufVisionDetection:
     @patch(
         "utils.models.model_config._is_vision_model_subprocess",
@@ -151,8 +158,8 @@ class TestLocalGgufVisionDetection:
     )
     def test_qwen36_gguf_with_mmproj_skips_transformers(self, mock_subprocess, tmp_path):
         model = tmp_path / "Qwen3.6-27B-UD-Q4_K_XL-MTP.gguf"
-        model.write_bytes(b"")
-        (tmp_path / "mmproj-F32.gguf").write_bytes(b"")
+        model.write_bytes(_GGUF_STUB)
+        (tmp_path / "mmproj-F32.gguf").write_bytes(_GGUF_STUB)
 
         assert is_vision_model(str(model)) is True
         mock_subprocess.assert_not_called()
@@ -165,8 +172,8 @@ class TestLocalGgufVisionDetection:
         variant_dir = tmp_path / "BF16"
         variant_dir.mkdir()
         model = variant_dir / "Qwen3.6-27B-UD-Q4_K_XL-MTP.gguf"
-        model.write_bytes(b"")
-        (tmp_path / "mmproj-F32.gguf").write_bytes(b"")
+        model.write_bytes(_GGUF_STUB)
+        (tmp_path / "mmproj-F32.gguf").write_bytes(_GGUF_STUB)
 
         assert is_vision_model(str(model)) is True
         mock_subprocess.assert_not_called()
@@ -177,17 +184,17 @@ class TestLocalGgufVisionDetection:
     )
     def test_qwen36_gguf_without_mmproj_skips_transformers(self, mock_subprocess, tmp_path):
         model = tmp_path / "Qwen3.6-27B-UD-Q4_K_XL-MTP.gguf"
-        model.write_bytes(b"")
+        model.write_bytes(_GGUF_STUB)
 
         assert is_vision_model(str(model)) is False
         mock_subprocess.assert_not_called()
 
     def test_local_gguf_check_observes_mmproj_added_later(self, tmp_path):
         model = tmp_path / "Qwen3.6-27B-UD-Q4_K_XL-MTP.gguf"
-        model.write_bytes(b"")
+        model.write_bytes(_GGUF_STUB)
 
         assert is_vision_model(str(model)) is False
-        (tmp_path / "mmproj-F32.gguf").write_bytes(b"")
+        (tmp_path / "mmproj-F32.gguf").write_bytes(_GGUF_STUB)
         assert is_vision_model(str(model)) is True
 
     @patch(
@@ -196,9 +203,9 @@ class TestLocalGgufVisionDetection:
     )
     def test_ui_selection_returns_local_gguf_config(self, mock_subprocess, tmp_path):
         model = tmp_path / "Qwen3.6-27B-UD-Q4_K_XL-MTP.gguf"
-        model.write_bytes(b"")
+        model.write_bytes(_GGUF_STUB)
         mmproj = tmp_path / "mmproj-F32.gguf"
-        mmproj.write_bytes(b"")
+        mmproj.write_bytes(_GGUF_STUB)
 
         config = ModelConfig.from_ui_selection(str(model), None)
 
@@ -218,9 +225,9 @@ class TestLocalGgufVisionDetection:
         variant_dir = tmp_path / "BF16"
         variant_dir.mkdir()
         model = variant_dir / "Qwen3.6-27B-UD-Q4_K_XL-MTP.gguf"
-        model.write_bytes(b"")
+        model.write_bytes(_GGUF_STUB)
         mmproj = tmp_path / "mmproj-F32.gguf"
-        mmproj.write_bytes(b"")
+        mmproj.write_bytes(_GGUF_STUB)
 
         config = ModelConfig.from_ui_selection(str(model), None)
 


### PR DESCRIPTION
`tests/test_cached_gguf_routes.py::test_legacy_custom_inventory_filters_registered_mtp_root` has been failing on `main` for a while, so it fails on every open PR. Together with the five `TestLocalGgufVisionDetection` failures in #7726 it accounts for all six red tests in the `(Python 3.x)` matrix.

## Bisect

```
37c6491  (#7648, added the test)   1 passed
d36e3e1  (#7375)                   1 failed
3f2fc5a  (current main)            1 failed
```

## Cause

`d36e3e1c` tightened `_is_main_gguf_filename` in `routes/models.py`:

```diff
-return _is_gguf_filename(name) and not _is_mmproj_filename(name)
+return _is_gguf_filename(name) and not _is_mmproj_filename(name) and not _is_mtp_drafter(name)
```

That is correct on its own terms. An MTP drafter is a companion to the main model, not a selectable quant, and it should not be counted as a main weight.

The side effect is one level up. `_scan_models_dir` uses that predicate to decide whether a directory is a GGUF model directory, so a directory whose only direct `.gguf` is a drafter stops classifying as `"gguf"` and comes back with `model_format = None`. I confirmed that by dumping the scanner output for the fixture tree:

```
_scan_models_dir:
    src=models_dir fmt=None  companion-only        <- was "gguf" before d36e3e1
    src=models_dir fmt=gguf  model
    src=models_dir fmt=gguf  gemma-4-12b-it-Q8_0-MTP.gguf
    src=models_dir fmt=gguf  Qwen3.6-27B-MTP-Q6_K.gguf
```

`collect_local_models` then reads `None` as "some format other than gguf, nothing to verify" and keeps the row unconditionally:

```python
if model.model_format != "gguf" or model.partial:
    custom_models.append(model)
    continue
```

so the `detect_gguf_model` content check below it, the thing that used to reject `companion-only/` because its only direct GGUF is a drafter, never runs. The tightening moved that directory from the verified path onto the unverified one, which is the opposite of what it was meant to do.

`detect_gguf_model` itself is fine and still rejects the drafter. It simply is not being asked.

## Fix

Only skip the content check for a format the scanner actually recognised. `None` means it could not classify the directory, which is a reason to look inside rather than to trust it.

```python
if (model.model_format is not None and model.model_format != "gguf") or model.partial:
```

`companion-only/` now falls through to the `path.is_dir()` branch, gets globbed, and is rejected because its only direct `.gguf` is `mtp-*`. The real model in `companion-only/other/` is unaffected; it is registered on its own by the LM Studio scanner, which is what the test's remaining assertions already pin.

## Verification

```
tests/test_cached_gguf_routes.py    64 passed
```

Reverting only the `and not _is_mtp_drafter(name)` clause on `main` also makes the test pass, which pins the cause, but that is not the fix we want since the tightening is deliberate.

Running `test_cached_gguf_routes.py` and `test_vision_cache.py` together on this branch leaves exactly the five `TestLocalGgufVisionDetection` failures and nothing else, and those are the ones #7726 addresses. The two together take the matrix from six failures to zero.
