### PR TITLE
Escape caller template text spliced into Jinja string literals

### DIFF
--- a/tests/python/test_construct_chat_template_validation.py
+++ b/tests/python/test_construct_chat_template_validation.py
@@ -258,8 +258,7 @@ _APOSTROPHE_CHAT_TEMPLATE = (
         "Answer the user's question.",
         r"Put the answer in \boxed{}.",
         r"Files live in C:\Users\me",
-        # A template authored on Windows arrives with CRLF; Jinja rewrites a raw
-        # carriage return to \n before unescaping, so \r needs escaping as well.
+        # Windows CRLF: Jinja rewrites a raw \r to \n before unescaping.
         "Answer briefly.\r\nBe polite.",
     ],
 )

--- a/tests/python/test_construct_chat_template_validation.py
+++ b/tests/python/test_construct_chat_template_validation.py
@@ -117,6 +117,7 @@ def _render(
     jinja_template,
     messages,
     add_generation_prompt = False,
+    bos_token = "<s>",
 ):
     from jinja2.sandbox import ImmutableSandboxedEnvironment
 
@@ -124,7 +125,7 @@ def _render(
     env.globals["raise_exception"] = lambda message: (_ for _ in ()).throw(RuntimeError(message))
     return env.from_string(jinja_template).render(
         messages = messages,
-        bos_token = "<s>",
+        bos_token = bos_token,
         eos_token = "</s>",
         add_generation_prompt = add_generation_prompt,
     )
@@ -257,6 +258,9 @@ _APOSTROPHE_CHAT_TEMPLATE = (
         "Answer the user's question.",
         r"Put the answer in \boxed{}.",
         r"Files live in C:\Users\me",
+        # A template authored on Windows arrives with CRLF; Jinja rewrites a raw
+        # carriage return to \n before unescaping, so \r needs escaping as well.
+        "Answer briefly.\r\nBe polite.",
     ],
 )
 def test_quotes_and_backslashes_survive_into_the_jinja_template(default_system_message):
@@ -284,3 +288,33 @@ def test_quotes_and_backslashes_survive_into_the_jinja_template(default_system_m
         add_generation_prompt = True,
     )
     assert prompted.endswith("### Bot's reply: ")
+
+
+class _BosFakeTokenizer(_SuccessFakeTokenizer):
+    """A bos_token carrying characters the Jinja escaper rewrites."""
+
+    bos_token = "<s'\\a>"
+
+    def __call__(self, text):
+        # input_ids[0] == bos_token_id takes the BOS-handling branch.
+        return SimpleNamespace(input_ids = [1])
+
+
+def test_bos_token_with_quote_or_backslash_is_not_emitted_twice():
+    """The BOS is stripped from the system section so it is only rendered once, via
+    `{{ bos_token }}`. Stripping it after process() had escaped the section left it
+    unmatched, and the caller-system branch then emitted it a second time."""
+    bos = _BosFakeTokenizer.bos_token
+    _, jinja_template, _, _ = construct_chat_template(
+        tokenizer = _BosFakeTokenizer(),
+        chat_template = bos + _APOSTROPHE_CHAT_TEMPLATE,
+        default_system_message = "Be helpful.",
+        extra_eos_tokens = ["</s>"],
+    )
+
+    for messages in (
+        [{"role": "user", "content": "Hi"}],
+        [{"role": "system", "content": "Sysmsg"}, {"role": "user", "content": "Hi"}],
+    ):
+        rendered = _render(jinja_template, messages, bos_token = bos)
+        assert rendered.count(bos) == 1, rendered

--- a/tests/python/test_construct_chat_template_validation.py
+++ b/tests/python/test_construct_chat_template_validation.py
@@ -113,7 +113,11 @@ _SYSTEM_CHAT_TEMPLATE = (
 )
 
 
-def _render(jinja_template, messages, add_generation_prompt = False):
+def _render(
+    jinja_template,
+    messages,
+    add_generation_prompt = False,
+):
     from jinja2.sandbox import ImmutableSandboxedEnvironment
 
     env = ImmutableSandboxedEnvironment()
@@ -275,6 +279,8 @@ def test_quotes_and_backslashes_survive_into_the_jinja_template(default_system_m
 
     # The generation prompt is spliced from its own literal, not through process().
     prompted = _render(
-        jinja_template, [{"role": "user", "content": "Hi"}], add_generation_prompt = True,
+        jinja_template,
+        [{"role": "user", "content": "Hi"}],
+        add_generation_prompt = True,
     )
     assert prompted.endswith("### Bot's reply: ")

--- a/tests/python/test_construct_chat_template_validation.py
+++ b/tests/python/test_construct_chat_template_validation.py
@@ -258,7 +258,7 @@ _APOSTROPHE_CHAT_TEMPLATE = (
         "Answer the user's question.",
         r"Put the answer in \boxed{}.",
         r"Files live in C:\Users\me",
-        # Windows CRLF: Jinja rewrites a raw \r to \n before unescaping.
+        # Windows CRLF: Jinja rewrites a raw \r to \n.
         "Answer briefly.\r\nBe polite.",
     ],
 )
@@ -280,7 +280,7 @@ def test_quotes_and_backslashes_survive_into_the_jinja_template(default_system_m
     assert default_system_message in rendered
     assert "### User's turn: Hi" in rendered
 
-    # The generation prompt is spliced from its own literal, not through process().
+    # The generation prompt uses its own literal, not process().
     prompted = _render(
         jinja_template,
         [{"role": "user", "content": "Hi"}],

--- a/tests/python/test_construct_chat_template_validation.py
+++ b/tests/python/test_construct_chat_template_validation.py
@@ -113,7 +113,7 @@ _SYSTEM_CHAT_TEMPLATE = (
 )
 
 
-def _render(jinja_template, messages):
+def _render(jinja_template, messages, add_generation_prompt = False):
     from jinja2.sandbox import ImmutableSandboxedEnvironment
 
     env = ImmutableSandboxedEnvironment()
@@ -122,7 +122,7 @@ def _render(jinja_template, messages):
         messages = messages,
         bos_token = "<s>",
         eos_token = "</s>",
-        add_generation_prompt = False,
+        add_generation_prompt = add_generation_prompt,
     )
 
 
@@ -238,3 +238,43 @@ def test_input_boundary_prefers_the_longest_eos_token():
 
     rendered_user_turn = _render(jinja_template, [{"role": "user", "content": "Hi"}])
     assert rendered_user_turn == "### User: Hi</s>extra"
+
+
+_APOSTROPHE_CHAT_TEMPLATE = (
+    "{SYSTEM}\n"
+    "### User's turn: {INPUT}\n### Bot's reply: {OUTPUT}</s>"
+    "### User's turn: {INPUT}\n### Bot's reply: {OUTPUT}</s>"
+)
+
+
+@pytest.mark.parametrize(
+    "default_system_message",
+    [
+        "Answer the user's question.",
+        r"Put the answer in \boxed{}.",
+        r"Files live in C:\Users\me",
+    ],
+)
+def test_quotes_and_backslashes_survive_into_the_jinja_template(default_system_message):
+    """Template text is concatenated into Jinja `'...'` literals, so it has to be
+    escaped on the way in. An apostrophe used to close the literal early
+    (TemplateSyntaxError: expected token 'end of print statement'), and a backslash was
+    read as a Jinja escape, so `\\boxed` silently became a backspace character and
+    `C:\\Users` raised `truncated \\UXXXXXXXX escape`. Covers the system message and
+    the instruction/response sections, which are spliced by three separate call sites."""
+    _, jinja_template, _, _ = construct_chat_template(
+        tokenizer = _SuccessFakeTokenizer(),
+        chat_template = _APOSTROPHE_CHAT_TEMPLATE,
+        default_system_message = default_system_message,
+        extra_eos_tokens = ["</s>"],
+    )
+
+    rendered = _render(jinja_template, [{"role": "user", "content": "Hi"}])
+    assert default_system_message in rendered
+    assert "### User's turn: Hi" in rendered
+
+    # The generation prompt is spliced from its own literal, not through process().
+    prompted = _render(
+        jinja_template, [{"role": "user", "content": "Hi"}], add_generation_prompt = True,
+    )
+    assert prompted.endswith("### Bot's reply: ")

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -2617,14 +2617,14 @@ extra_eos_tokens = None,
         part + '\n\n' + ollama_eos
 
     # HF Jinja Chat template
-    # Caller text is concatenated into Jinja '...' literals, where a quote closes
-    # the literal early, a backslash is read as an escape, and a raw \r is
-    # rewritten to \n. Backslash first, or the quote's own escape gets doubled.
+    # Caller text is spliced into Jinja '...' literals, where a bare quote closes
+    # the literal and a backslash is read as an escape, and \r is normalised to \n
+    # before unescaping. Backslash first, else it re-escapes the ones added after.
     def escape_jinja_literal(text):
         return text.replace("\\", "\\\\").replace("'", "\\'").replace("\r", "\\r")
 
     def process(part, which, content = "message['content']"):
-        # Escape before the placeholder becomes a concatenation whose quotes must survive.
+        # Escape the literal pieces only; the placeholder becomes Jinja syntax below.
         part = which.join(escape_jinja_literal(piece) for piece in part.split(which))
         if part.endswith(which):
             part = "'" + part[:part.find(which)] + f"' + {content}"

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -2617,17 +2617,14 @@ extra_eos_tokens = None,
         part + '\n\n' + ollama_eos
 
     # HF Jinja Chat template
-    # Every piece of the caller's template below is concatenated into a Jinja
-    # '...' literal, so a single quote in it closes the literal early and a
-    # backslash is read as a Jinja escape. Escape the backslash first, or the
-    # one added for the quote gets doubled. A raw \r is rewritten to \n before
-    # unescaping, so it only survives as an escape too.
+    # Caller text is concatenated into Jinja '...' literals, where a quote closes
+    # the literal early, a backslash is read as an escape, and a raw \r is
+    # rewritten to \n. Backslash first, or the quote's own escape gets doubled.
     def escape_jinja_literal(text):
         return text.replace("\\", "\\\\").replace("'", "\\'").replace("\r", "\\r")
 
     def process(part, which, content = "message['content']"):
-        # Escape the literal text only, before the placeholder is swapped for the
-        # ' + message['content'] + ' concatenation, whose quotes must survive.
+        # Escape before the placeholder becomes a concatenation whose quotes must survive.
         part = which.join(escape_jinja_literal(piece) for piece in part.split(which))
         if part.endswith(which):
             part = "'" + part[:part.find(which)] + f"' + {content}"
@@ -2656,8 +2653,7 @@ extra_eos_tokens = None,
 
     # Now add system prompt to jinja
     if len(system_part) != 0:
-        # Separate the BOS while the text is still raw: a bos_token holding a
-        # quote or backslash no longer matches once process() has escaped it.
+        # Strip the BOS while raw: an escaped bos_token no longer matches.
         if has_bos_token:
             system_part = system_part.replace(tokenizer.bos_token, "", 1)
         partial_system = process(system_part, "{SYSTEM}", "messages[0]['content']")

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -2617,7 +2617,17 @@ extra_eos_tokens = None,
         part + '\n\n' + ollama_eos
 
     # HF Jinja Chat template
+    # Every piece of the caller's template below is concatenated into a Jinja
+    # '...' literal, so a single quote in it closes the literal early and a
+    # backslash is read as a Jinja escape. Escape the backslash first, or the
+    # one added for the quote gets doubled.
+    def escape_jinja_literal(text):
+        return text.replace("\\", "\\\\").replace("'", "\\'")
+
     def process(part, which, content = "message['content']"):
+        # Escape the literal text only, before the placeholder is swapped for the
+        # ' + message['content'] + ' concatenation, whose quotes must survive.
+        part = which.join(escape_jinja_literal(piece) for piece in part.split(which))
         if part.endswith(which):
             part = "'" + part[:part.find(which)] + f"' + {content}"
         elif part.startswith(which):
@@ -2640,7 +2650,7 @@ extra_eos_tokens = None,
             "{% endif %}"\
         "{% endfor %}"\
         "{% if add_generation_prompt %}"\
-            "{{ '" + output_part[:output_part.find("{OUTPUT}")] + "' }}"\
+            "{{ '" + escape_jinja_literal(output_part[:output_part.find("{OUTPUT}")]) + "' }}"\
         "{% endif %}"
 
     # Now add system prompt to jinja
@@ -2662,7 +2672,7 @@ extra_eos_tokens = None,
                 "{{ " + partial_system + " }}"\
                 "{% set loop_messages = messages[1:] %}"
         if default_system_message is not None:
-            full_system = system_part.replace("{SYSTEM}", default_system_message)
+            full_system = escape_jinja_literal(system_part.replace("{SYSTEM}", default_system_message))
             if "{SYSTEM}" in system_part:
                 modelfile += '\nSYSTEM "' + default_system_message + '"'
             partial_system += "{% else %}"\

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -2620,9 +2620,10 @@ extra_eos_tokens = None,
     # Every piece of the caller's template below is concatenated into a Jinja
     # '...' literal, so a single quote in it closes the literal early and a
     # backslash is read as a Jinja escape. Escape the backslash first, or the
-    # one added for the quote gets doubled.
+    # one added for the quote gets doubled. A raw \r is rewritten to \n before
+    # unescaping, so it only survives as an escape too.
     def escape_jinja_literal(text):
-        return text.replace("\\", "\\\\").replace("'", "\\'")
+        return text.replace("\\", "\\\\").replace("'", "\\'").replace("\r", "\\r")
 
     def process(part, which, content = "message['content']"):
         # Escape the literal text only, before the placeholder is swapped for the
@@ -2655,17 +2656,16 @@ extra_eos_tokens = None,
 
     # Now add system prompt to jinja
     if len(system_part) != 0:
+        # Separate the BOS while the text is still raw: a bos_token holding a
+        # quote or backslash no longer matches once process() has escaped it.
+        if has_bos_token:
+            system_part = system_part.replace(tokenizer.bos_token, "", 1)
         partial_system = process(system_part, "{SYSTEM}", "messages[0]['content']")
         partial_system = partial_system.replace("{SYSTEM}", "")
 
         if "{SYSTEM}" in partial_system:
             if default_system_message is None:
                 raise RuntimeError("Unsloth: Please specify a default system message!")
-
-        # Separate the BOS
-        if has_bos_token:
-            partial_system = partial_system.replace(tokenizer.bos_token, "", 1)
-            system_part    = system_part   .replace(tokenizer.bos_token, "", 1)
 
         partial_system = \
             "{% if messages[0]['role'] == 'system' %}"\


### PR DESCRIPTION
## The bug

`construct_chat_template` builds the HF Jinja template by concatenating the caller's template text straight into Jinja `'...'` string literals. Three places do this and none of them escape:

```python
part = "'" + part.replace(which, f"' + {content} + '") + "'"          # process()
"{{ '" + output_part[:output_part.find("{OUTPUT}")] + "' }}"          # add_generation_prompt
full_system = system_part.replace("{SYSTEM}", default_system_message) # system branch
```

So whatever the caller passes is read as Jinja source. A single quote closes the literal early, and a backslash is decoded as a Jinja escape.

Running against `main` at `3f2fc5af`, with a passing control in the same run so the harness is not what is failing:

```
control              : 'Be helpful.\n### User: Hi\n'
apostrophe in system : TemplateSyntaxError: expected token 'end of print statement', got 's'
backslash in system  : 'Put the answer in \x08oxed{}.\n### User: Hi\n'
windows path         : TemplateSyntaxError: truncated \UXXXXXXXX escape
apostrophe in prompt : TemplateSyntaxError: expected token 'end of print statement', got 's'
```

Line 3 is the one that worries me most. `default_system_message = r"Put the answer in \boxed{}."` is an ordinary math-SFT system prompt. There is no error and no warning; Jinja just decodes `\b` to `0x08`, and every sample built by `formatting_prompts_func` over `dataset.map` carries a backspace character where `\boxed` was meant to be.

It is not only the system message. `process()` handles the instruction and response sections too, so an apostrophe anywhere in the template breaks it. The last line above is `"### User's turn: {INPUT}\n### Assistant: {OUTPUT}</s>"` with an untouched `default_system_message`.

This is reachable through the public API: `apply_chat_template` (in `__all__`) calls `construct_chat_template`, assigns the result to `tokenizer.chat_template`, and `formatting_prompts_func` then calls `tokenizer.apply_chat_template` on every row. That is exactly the traceback in issue #3667.

## Prior art, and how this relates to what is already open

This class of bug has been hit before and patched at the symptom each time:

- Issue #3667 reported the identical `expected token 'end of print statement', got 's'` for `get_chat_template("vicuna")`. Merged PR #5357 fixed it by hand-escaping the constant, and `DEFAULT_SYSTEM_MESSAGE["vicuna"]` on `main` still carries the literal `user\\'s` (line 221, and again at 251 for `vicuna_old`).
- **PR #4222 is open and touches the same theme**, so to be explicit that this is not competing with it: its `chat_templates.py` hunk is entirely inside `_change_system_message` (line 1667), which is the `get_chat_template` preset path. It never reaches `construct_chat_template` (line 2374), which is the custom-template path this PR fixes. It also escapes only `'`, not `\`, so the `\boxed` corruption above survives it. The two are complementary; happy to rebase onto it or fold this in if you would rather land one change.

No open or closed PR covers `construct_chat_template` escaping. The four PRs that have touched this function (#6531, #6008, #7199, #5763) are about placeholder leaks, trailing whitespace, and `loop_messages` binding.

## The fix

Escape backslashes first, then single quotes, in each literal chunk before it is concatenated.

In `process()` the text is split on the `{INPUT}` / `{OUTPUT}` / `{SYSTEM}` sentinel before escaping, so the `' + message['content'] + '` markers that `process()` inserts on the next line keep their quotes. That ordering is the whole trick; escaping after the substitution would break the concatenation instead.

The `add_generation_prompt` literal needs its own call rather than riding on `process()`: it re-slices `output_part` independently, so fixing only `process()` still leaves the template unparseable.

After:

```
control              : 'Be helpful.\n### User: Hi\n'
apostrophe in system : "Answer the user's question.\n### User: Hi\n"
backslash in system  : 'Put the answer in \\boxed{}.\n### User: Hi\n'
windows path         : 'Files live in C:\\Users\\me\n### User: Hi\n'
apostrophe in prompt : "Be helpful.\n### User's turn: Hi\n"
```

**Deliberately out of scope:** the Ollama modelfile splices `default_system_message` into a double-quoted `SYSTEM "..."` line with the same absence of escaping. That is a different format with different rules, so I left it rather than guess at modelfile quoting in a PR about Jinja. Say the word if you want it in the same change.

**One thing to double check on review:** the "Check if system part is the same!" `re.sub` further down matches the system literal in both arms with a `\1` backreference. Both arms now carry the same escaped string, so the backreference still matches and the collapse still fires; the 14 existing tests in the file cover that path and pass unchanged.

## Tests

Added `test_quotes_and_backslashes_survive_into_the_jinja_template` to the existing `tests/python/test_construct_chat_template_validation.py`, parametrized over an apostrophe, `\boxed{}` and a Windows path. It uses a template that also puts an apostrophe in the instruction and response sections, so it covers all three splice sites, and it renders once with `add_generation_prompt = True` to pin the third one specifically. `_render` grew an `add_generation_prompt` keyword defaulting to `False`, so no existing caller changes.

Ran with pytest against the real `chat_templates.py` (only `transformers.utils.logging` stubbed, `ollama_template_mappers` loaded for real), three runs:

```
control  upstream chat_templates.py + upstream tests   14 passed
before   upstream chat_templates.py + these tests       3 failed, 14 passed
after    this branch                                   17 passed
```

The 3 failures before are the new parametrizations, and the 14 pre-existing tests are unaffected by the change.

This file is picked up by `Repo tests (CPU)` in `studio-backend-ci.yml`, which auto-discovers `tests/` and does not ignore `tests/python/`, so the new test runs in CI without a workflow change.

Lint: `chat_templates.py` is in `extend-exclude` in `pyproject.toml`, so ruff does not cover it; `ruff 0.15.12` (the pinned version) is clean on the test file. `codespell` reports the same three pre-existing `datas` hits on the unmodified file, so nothing new.
