### PR TITLE
Studio: share GGUF recommendation policy across pickers

### DIFF
--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -61,6 +61,7 @@ import {
   ggufFilenamesMatch,
   ggufSelectionOverrideMatchesIntent,
 } from "../lib/gguf-filename";
+import { recommendedDownloadableGgufVariant } from "../lib/gguf-recommendation";
 import {
   ggufVariantDisplayLabel,
   ggufVariantDownloadSizeBytes,
@@ -437,6 +438,7 @@ const GgufVariantMenuRow = memo(function GgufVariantMenuRow({
   selected,
   loaded,
   liveActive,
+  recommended,
   showFitInfo,
   onSelect,
   onDelete,
@@ -446,6 +448,7 @@ const GgufVariantMenuRow = memo(function GgufVariantMenuRow({
   selected: boolean;
   loaded: boolean;
   liveActive: boolean;
+  recommended: boolean;
   showFitInfo: boolean;
   onSelect: (quant: string) => void;
   onDelete: (quant: string) => void;
@@ -512,6 +515,11 @@ const GgufVariantMenuRow = memo(function GgufVariantMenuRow({
                 : "Partial download. Select it to continue."}
             </TooltipContent>
           </Tooltip>
+        )}
+        {recommended && (
+          <span className="shrink-0 text-ui-9 font-sans font-medium text-primary/70">
+            recommended
+          </span>
         )}
       </span>
       <span className="ml-auto flex shrink-0 items-center gap-1.5">
@@ -640,6 +648,16 @@ export function GgufDownloadCard({
     () => createGgufVariantMenuItems(sortedVariants, { gpuGb, systemRamGb }),
     [gpuGb, sortedVariants, systemRamGb],
   );
+  const recommendedVariant = useMemo(
+    () =>
+      sortedVariants
+        ? recommendedDownloadableGgufVariant(sortedVariants)
+        : null,
+    [sortedVariants],
+  );
+  const recommendedVariantKey = recommendedVariant
+    ? normalizeGgufVariantIdentity(recommendedVariant.quant)
+    : null;
 
   const selectedQuant =
     (selectedQuantOverride
@@ -986,6 +1004,11 @@ export function GgufDownloadCard({
                     </TooltipContent>
                   </Tooltip>
                 )}
+                {selectedVariantKey === recommendedVariantKey && (
+                  <span className="shrink-0 text-ui-9 font-sans font-medium text-primary/70">
+                    recommended
+                  </span>
+                )}
                 <DotTag tone="gguf" label="GGUF" />
                 {selected &&
                   selectedDownloadSizeLabel &&
@@ -1020,6 +1043,7 @@ export function GgufDownloadCard({
                     selected={item.key === selectedVariantKey}
                     loaded={isActive && item.key === activeVariantKey}
                     liveActive={liveActive}
+                    recommended={item.key === recommendedVariantKey}
                     showFitInfo={showFitInfo}
                     onSelect={handleSelectVariant}
                     onDelete={handleDeleteVariant}

--- a/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
+++ b/studio/frontend/src/features/hub/catalog/gguf-download-card.tsx
@@ -61,7 +61,10 @@ import {
   ggufFilenamesMatch,
   ggufSelectionOverrideMatchesIntent,
 } from "../lib/gguf-filename";
-import { recommendedDownloadableGgufVariant } from "../lib/gguf-recommendation";
+import {
+  recommendedGgufVariant,
+  shouldShowGgufRecommendation,
+} from "../lib/gguf-recommendation";
 import {
   ggufVariantDisplayLabel,
   ggufVariantDownloadSizeBytes,
@@ -432,6 +435,14 @@ export function QuantOptionsMenu({
   );
 }
 
+function GgufRecommendationLabel() {
+  return (
+    <span className="shrink-0 text-ui-9 font-sans font-medium text-primary/70">
+      recommended
+    </span>
+  );
+}
+
 const GgufVariantMenuRow = memo(function GgufVariantMenuRow({
   repoId,
   item,
@@ -516,11 +527,7 @@ const GgufVariantMenuRow = memo(function GgufVariantMenuRow({
             </TooltipContent>
           </Tooltip>
         )}
-        {recommended && (
-          <span className="shrink-0 text-ui-9 font-sans font-medium text-primary/70">
-            recommended
-          </span>
-        )}
+        {recommended && <GgufRecommendationLabel />}
       </span>
       <span className="ml-auto flex shrink-0 items-center gap-1.5">
         <span className={cn(CHIP_BASE, CHIP_DEFAULT)}>
@@ -583,7 +590,7 @@ export function GgufDownloadCard({
   const hfToken = useHfTokenStore((s) => s.token);
   const online = useOnlineStatus();
   const localVariantPath = cachePath?.trim() || null;
-  const { variants, loading, error, refreshError, refresh } =
+  const { variants, defaultVariant, loading, error, refreshError, refresh } =
     useGgufVariantFetchState({
       repoId,
       hfToken,
@@ -651,14 +658,15 @@ export function GgufDownloadCard({
   const recommendedVariant = useMemo(
     () =>
       sortedVariants
-        ? recommendedDownloadableGgufVariant(sortedVariants)
+        ? recommendedGgufVariant(
+            sortedVariants,
+            defaultVariant,
+            (sizeBytes) =>
+              classifyGgufFit(sizeBytes, { gpuGb, systemRamGb }) !== "oom",
+          )
         : null,
-    [sortedVariants],
+    [defaultVariant, gpuGb, sortedVariants, systemRamGb],
   );
-  const recommendedVariantKey = recommendedVariant
-    ? normalizeGgufVariantIdentity(recommendedVariant.quant)
-    : null;
-
   const selectedQuant =
     (selectedQuantOverride
       ? sortedVariants?.find((v) =>
@@ -1004,10 +1012,8 @@ export function GgufDownloadCard({
                     </TooltipContent>
                   </Tooltip>
                 )}
-                {selectedVariantKey === recommendedVariantKey && (
-                  <span className="shrink-0 text-ui-9 font-sans font-medium text-primary/70">
-                    recommended
-                  </span>
+                {shouldShowGgufRecommendation(selected, recommendedVariant) && (
+                  <GgufRecommendationLabel />
                 )}
                 <DotTag tone="gguf" label="GGUF" />
                 {selected &&
@@ -1043,7 +1049,10 @@ export function GgufDownloadCard({
                     selected={item.key === selectedVariantKey}
                     loaded={isActive && item.key === activeVariantKey}
                     liveActive={liveActive}
-                    recommended={item.key === recommendedVariantKey}
+                    recommended={shouldShowGgufRecommendation(
+                      item,
+                      recommendedVariant,
+                    )}
                     showFitInfo={showFitInfo}
                     onSelect={handleSelectVariant}
                     onDelete={handleDeleteVariant}

--- a/studio/frontend/src/features/hub/index.ts
+++ b/studio/frontend/src/features/hub/index.ts
@@ -113,6 +113,7 @@ export {
 export { ggufVariantDisplayLabel } from "./lib/gguf-variant-sort";
 export { EMBEDDING_TAGS, isGgufLike } from "./lib/hf-model-meta";
 export { matchTokens, tokenizeQuery } from "./lib/search-text";
+export { recommendedGgufVariant } from "./lib/gguf-recommendation";
 export {
   DeleteConfirmDialog,
   UpdateConfirmDialog,

--- a/studio/frontend/src/features/hub/lib/gguf-recommendation.ts
+++ b/studio/frontend/src/features/hub/lib/gguf-recommendation.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+type DownloadableVariant = {
+  downloaded?: boolean;
+  partial?: boolean;
+};
+
+export function recommendedDownloadableGgufVariant<
+  Variant extends DownloadableVariant,
+>(sortedVariants: readonly Variant[]): Variant | null {
+  return (
+    sortedVariants.find(
+      (variant) => !(variant.downloaded || variant.partial),
+    ) ?? null
+  );
+}

--- a/studio/frontend/src/features/hub/lib/gguf-recommendation.ts
+++ b/studio/frontend/src/features/hub/lib/gguf-recommendation.ts
@@ -1,17 +1,65 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-type DownloadableVariant = {
+type RecommendableGgufVariant = {
+  quant: string;
+  size_bytes: number;
+};
+
+type DownloadableGgufVariant = {
+  quant: string;
   downloaded?: boolean;
   partial?: boolean;
 };
 
-export function recommendedDownloadableGgufVariant<
-  Variant extends DownloadableVariant,
->(sortedVariants: readonly Variant[]): Variant | null {
-  return (
-    sortedVariants.find(
-      (variant) => !(variant.downloaded || variant.partial),
-    ) ?? null
+/**
+ * Shared recommendation rule for both GGUF pickers: prefer the default variant
+ * when it fits, otherwise the largest fitting one, otherwise the smallest.
+ *
+ * `fitsInMemory` is injected so each surface keeps its own fit thresholds and
+ * stays internally consistent with the fit indicator it renders.
+ */
+export function recommendedGgufVariant<
+  Variant extends RecommendableGgufVariant,
+>(
+  variants: readonly Variant[],
+  defaultVariant: string | null,
+  fitsInMemory: (sizeBytes: number) => boolean,
+): Variant | null {
+  if (variants.length === 0) {
+    return null;
+  }
+
+  const defaultCandidate = defaultVariant
+    ? (variants.find((variant) => variant.quant === defaultVariant) ?? null)
+    : null;
+  if (defaultCandidate && fitsInMemory(defaultCandidate.size_bytes)) {
+    return defaultCandidate;
+  }
+
+  const fitting = variants.filter((variant) =>
+    fitsInMemory(variant.size_bytes),
+  );
+  if (fitting.length > 0) {
+    return fitting.reduce((largest, variant) =>
+      variant.size_bytes > largest.size_bytes ? variant : largest,
+    );
+  }
+
+  return variants.reduce((smallest, variant) =>
+    variant.size_bytes < smallest.size_bytes ? variant : smallest,
+  );
+}
+
+export function shouldShowGgufRecommendation(
+  variant: DownloadableGgufVariant | null,
+  recommendedVariant: Pick<DownloadableGgufVariant, "quant"> | null,
+): boolean {
+  return Boolean(
+    variant &&
+      recommendedVariant &&
+      variant.quant === recommendedVariant.quant &&
+      !variant.downloaded &&
+      !variant.partial,
   );
 }

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -43,6 +43,7 @@ import {
   ggufVariantDisplayLabel,
   invalidateGgufVariantsCache,
   listGgufVariants as listGgufVariantsCached,
+  recommendedGgufVariant,
   useGgufVariantsCacheVersions,
   useHubInfiniteScroll,
 } from "@/features/hub";
@@ -1355,18 +1356,13 @@ function GgufVariantExpander({
     ) {
       return defaultVariant;
     }
-    const defaultV = variants.find((v) => v.quant === defaultVariant);
-    if (defaultV && getGgufFit(defaultV.size_bytes) !== "oom")
-      return defaultVariant;
-    // Largest non-OOM variant (best quality that fits)
-    const fitting = variants.filter((v) => getGgufFit(v.size_bytes) !== "oom");
-    if (fitting.length > 0) {
-      fitting.sort((a, b) => b.size_bytes - a.size_bytes);
-      return fitting[0].quant;
-    }
-    // All OOM -- recommend smallest (most likely to partially run)
-    const sorted = [...variants].sort((a, b) => a.size_bytes - b.size_bytes);
-    return sorted[0]?.quant ?? defaultVariant;
+    return (
+      recommendedGgufVariant(
+        variants,
+        defaultVariant,
+        (sizeBytes) => getGgufFit(sizeBytes) !== "oom",
+      )?.quant ?? defaultVariant
+    );
   }, [variants, defaultVariant, totalBudgetGb, budgetKnown, getGgufFit]);
 
   const sortedVariants = useMemo(() => {

--- a/studio/frontend/tests/gguf-recommended-variant.test.ts
+++ b/studio/frontend/tests/gguf-recommended-variant.test.ts
@@ -5,88 +5,233 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import ts from "typescript";
 
-import { recommendedDownloadableGgufVariant } from "../src/features/hub/lib/gguf-recommendation.ts";
+import {
+  recommendedGgufVariant,
+  shouldShowGgufRecommendation,
+} from "../src/features/hub/lib/gguf-recommendation.ts";
 
-const DOWNLOAD_CARD_SOURCE = readFileSync(
-  fileURLToPath(
-    new URL(
-      "../src/features/hub/catalog/gguf-download-card.tsx",
-      import.meta.url,
-    ),
+const GIBIBYTE = 1024 ** 3;
+const FIT_LIMIT_GB = 8;
+const PICKERS_SOURCE_PATH = fileURLToPath(
+  new URL(
+    "../src/features/model-picker/components/model-selector/pickers.tsx",
+    import.meta.url,
   ),
-  "utf8",
 );
-const COLLAPSED_RECOMMENDATION =
-  /selectedVariantKey === recommendedVariantKey[\s\S]*?recommended/;
-const EXPANDED_RECOMMENDATION_PROP =
-  /recommended=\{item\.key === recommendedVariantKey\}/;
-const EXPANDED_RECOMMENDATION_LABEL = /recommended && \([\s\S]*?recommended/;
 
 type TestVariant = {
   quant: string;
-  filename: string;
+  size_bytes: number;
   downloaded?: boolean;
   partial?: boolean;
 };
 
 function variant(
   quant: string,
+  sizeGb: number,
   overrides: Partial<TestVariant> = {},
 ): TestVariant {
   return {
     quant,
-    filename: `${quant}.gguf`,
+    size_bytes: sizeGb * GIBIBYTE,
     ...overrides,
   };
 }
 
-test("recommends the first eligible variant from the fit-sorted list", () => {
-  const downloaded = variant("Q8_0", { downloaded: true });
-  const bestFit = variant("Q6_K");
-  const smallerFit = variant("Q4_K_M");
+const fitsUnder = (limitGb: number) => (sizeBytes: number) =>
+  sizeBytes <= limitGb * GIBIBYTE;
+
+function effectiveRecommendationInitializer(): ts.Expression | null {
+  const source = ts.createSourceFile(
+    PICKERS_SOURCE_PATH,
+    readFileSync(PICKERS_SOURCE_PATH, "utf8"),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  let initializer: ts.Expression | null = null;
+  function visit(node: ts.Node): void {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === "effectiveRecommended"
+    ) {
+      initializer = node.initializer ?? null;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(source);
+  return initializer;
+}
+
+function containsRecommendationIntegration(node: ts.Node): boolean {
+  if (
+    ts.isCallExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    node.expression.text === "recommendedGgufVariant" &&
+    node.arguments.length === 3
+  ) {
+    const predicate = node.arguments[2];
+    if (
+      !ts.isArrowFunction(predicate) ||
+      predicate.parameters.length !== 1 ||
+      !ts.isIdentifier(predicate.parameters[0].name) ||
+      !ts.isBinaryExpression(predicate.body) ||
+      predicate.body.operatorToken.kind !==
+        ts.SyntaxKind.ExclamationEqualsEqualsToken ||
+      !ts.isCallExpression(predicate.body.left) ||
+      !ts.isIdentifier(predicate.body.left.expression) ||
+      predicate.body.left.expression.text !== "getGgufFit" ||
+      predicate.body.left.arguments.length !== 1 ||
+      !ts.isIdentifier(predicate.body.left.arguments[0]) ||
+      !ts.isStringLiteral(predicate.body.right) ||
+      predicate.body.right.text !== "oom"
+    ) {
+      return false;
+    }
+
+    const parameterName = predicate.parameters[0].name.text;
+    return predicate.body.left.arguments[0].text === parameterName;
+  }
+  return node.getChildren().some(containsRecommendationIntegration);
+}
+
+test("prefers the default variant when it fits", () => {
+  const largerFit = variant("Q6_K", 6);
+  const defaultFit = variant("Q4_K_M", 4);
 
   assert.equal(
-    recommendedDownloadableGgufVariant([downloaded, bestFit, smallerFit]),
-    bestFit,
+    recommendedGgufVariant(
+      [largerFit, defaultFit],
+      defaultFit.quant,
+      fitsUnder(FIT_LIMIT_GB),
+    ),
+    defaultFit,
   );
 });
 
-test("does not recommend partial variants", () => {
-  const partial = variant("Q6_K", { partial: true });
-  const completeCandidate = variant("Q4_K_M");
+test("uses the largest non-OOM variant when the default is OOM", () => {
+  const smallerFit = variant("Q4_K_M", 4);
+  const largestFit = variant("Q6_K", 6);
+  const defaultOom = variant("Q8_0", 20);
 
   assert.equal(
-    recommendedDownloadableGgufVariant([partial, completeCandidate]),
-    completeCandidate,
+    recommendedGgufVariant(
+      [smallerFit, defaultOom, largestFit],
+      defaultOom.quant,
+      fitsUnder(FIT_LIMIT_GB),
+    ),
+    largestFit,
   );
 });
 
-test("falls back to the smallest variant when every candidate exceeds memory", () => {
-  const largest = variant("Q8_0");
-  const smallest = variant("Q2_K");
+test("uses the largest fitting variant when no default is provided", () => {
+  const smallerFit = variant("Q4_K_M", 4);
+  const largestFit = variant("Q6_K", 6);
 
   assert.equal(
-    recommendedDownloadableGgufVariant([smallest, largest]),
-    smallest,
+    recommendedGgufVariant(
+      [largestFit, smallerFit],
+      null,
+      fitsUnder(FIT_LIMIT_GB),
+    ),
+    largestFit,
   );
 });
 
-test("returns null when every variant is downloaded or partial", () => {
+test("uses the largest fitting variant when the named default is absent", () => {
+  const smallerFit = variant("Q4_K_M", 4);
+  const largestFit = variant("Q6_K", 6);
+
   assert.equal(
-    recommendedDownloadableGgufVariant([
-      variant("Q6_K", { downloaded: true }),
-      variant("Q4_K_M", { partial: true }),
-    ]),
-    null,
+    recommendedGgufVariant(
+      [largestFit, smallerFit],
+      "MISSING",
+      fitsUnder(FIT_LIMIT_GB),
+    ),
+    largestFit,
   );
 });
 
-test("shows the recommendation in the collapsed variant trigger", () => {
-  assert.match(DOWNLOAD_CARD_SOURCE, COLLAPSED_RECOMMENDATION);
+test("keeps a downloaded fitting variant as the recommendation instead of promoting an OOM download", () => {
+  const downloadedFit = variant("Q4_K_M", 4, { downloaded: true });
+  const unavailableOom = variant("Q8_0", 20);
+
+  assert.equal(
+    recommendedGgufVariant(
+      [unavailableOom, downloadedFit],
+      downloadedFit.quant,
+      fitsUnder(FIT_LIMIT_GB),
+    ),
+    downloadedFit,
+  );
 });
 
-test("shows the recommendation beside its expanded variant row", () => {
-  assert.match(DOWNLOAD_CARD_SOURCE, EXPANDED_RECOMMENDATION_PROP);
-  assert.match(DOWNLOAD_CARD_SOURCE, EXPANDED_RECOMMENDATION_LABEL);
+test("keeps a partial fitting variant as the recommendation instead of promoting an OOM download", () => {
+  const partialFit = variant("Q4_K_M", 4, { partial: true });
+  const unavailableOom = variant("Q8_0", 20);
+
+  assert.equal(
+    recommendedGgufVariant(
+      [unavailableOom, partialFit],
+      partialFit.quant,
+      fitsUnder(FIT_LIMIT_GB),
+    ),
+    partialFit,
+  );
+});
+
+test("falls back to the smallest variant when every candidate is OOM", () => {
+  const largestOom = variant("Q8_0", 20);
+  const middleOom = variant("Q5_K_M", 19);
+  const smallestOom = variant("Q6_K", 18);
+
+  assert.equal(
+    recommendedGgufVariant(
+      [largestOom, smallestOom, middleOom],
+      null,
+      fitsUnder(1),
+    ),
+    smallestOom,
+  );
+});
+
+test("returns null when there are no variants", () => {
+  assert.equal(recommendedGgufVariant([], null, fitsUnder(FIT_LIMIT_GB)), null);
+});
+
+test("the chat picker delegates its executable recommendation to the shared rule", () => {
+  const initializer = effectiveRecommendationInitializer();
+
+  assert.ok(initializer, "effectiveRecommended initializer was not found");
+  assert.equal(containsRecommendationIntegration(initializer), true);
+});
+
+test("shows the badge only for the matching downloadable recommendation", () => {
+  const recommended = variant("Q4_K_M", 4);
+
+  assert.equal(shouldShowGgufRecommendation(recommended, recommended), true);
+  assert.equal(
+    shouldShowGgufRecommendation(
+      { ...recommended, downloaded: true },
+      recommended,
+    ),
+    false,
+  );
+  assert.equal(
+    shouldShowGgufRecommendation(
+      { ...recommended, partial: true },
+      recommended,
+    ),
+    false,
+  );
+  assert.equal(
+    shouldShowGgufRecommendation(variant("Q6_K", 6), recommended),
+    false,
+  );
+  assert.equal(shouldShowGgufRecommendation(recommended, null), false);
+  assert.equal(shouldShowGgufRecommendation(null, null), false);
 });

--- a/studio/frontend/tests/gguf-recommended-variant.test.ts
+++ b/studio/frontend/tests/gguf-recommended-variant.test.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { recommendedDownloadableGgufVariant } from "../src/features/hub/lib/gguf-recommendation.ts";
+
+const DOWNLOAD_CARD_SOURCE = readFileSync(
+  fileURLToPath(
+    new URL(
+      "../src/features/hub/catalog/gguf-download-card.tsx",
+      import.meta.url,
+    ),
+  ),
+  "utf8",
+);
+const COLLAPSED_RECOMMENDATION =
+  /selectedVariantKey === recommendedVariantKey[\s\S]*?recommended/;
+const EXPANDED_RECOMMENDATION_PROP =
+  /recommended=\{item\.key === recommendedVariantKey\}/;
+const EXPANDED_RECOMMENDATION_LABEL = /recommended && \([\s\S]*?recommended/;
+
+type TestVariant = {
+  quant: string;
+  filename: string;
+  downloaded?: boolean;
+  partial?: boolean;
+};
+
+function variant(
+  quant: string,
+  overrides: Partial<TestVariant> = {},
+): TestVariant {
+  return {
+    quant,
+    filename: `${quant}.gguf`,
+    ...overrides,
+  };
+}
+
+test("recommends the first eligible variant from the fit-sorted list", () => {
+  const downloaded = variant("Q8_0", { downloaded: true });
+  const bestFit = variant("Q6_K");
+  const smallerFit = variant("Q4_K_M");
+
+  assert.equal(
+    recommendedDownloadableGgufVariant([downloaded, bestFit, smallerFit]),
+    bestFit,
+  );
+});
+
+test("does not recommend partial variants", () => {
+  const partial = variant("Q6_K", { partial: true });
+  const completeCandidate = variant("Q4_K_M");
+
+  assert.equal(
+    recommendedDownloadableGgufVariant([partial, completeCandidate]),
+    completeCandidate,
+  );
+});
+
+test("falls back to the smallest variant when every candidate exceeds memory", () => {
+  const largest = variant("Q8_0");
+  const smallest = variant("Q2_K");
+
+  assert.equal(
+    recommendedDownloadableGgufVariant([smallest, largest]),
+    smallest,
+  );
+});
+
+test("returns null when every variant is downloaded or partial", () => {
+  assert.equal(
+    recommendedDownloadableGgufVariant([
+      variant("Q6_K", { downloaded: true }),
+      variant("Q4_K_M", { partial: true }),
+    ]),
+    null,
+  );
+});
+
+test("shows the recommendation in the collapsed variant trigger", () => {
+  assert.match(DOWNLOAD_CARD_SOURCE, COLLAPSED_RECOMMENDATION);
+});
+
+test("shows the recommendation beside its expanded variant row", () => {
+  assert.match(DOWNLOAD_CARD_SOURCE, EXPANDED_RECOMMENDATION_PROP);
+  assert.match(DOWNLOAD_CARD_SOURCE, EXPANDED_RECOMMENDATION_LABEL);
+});


### PR DESCRIPTION
## Summary

- share one GGUF recommendation policy across the Hub download card and chat model picker
- prefer the default variant when it fits, otherwise the largest fitting variant, then the smallest all-OOM fallback
- preserve each surface's existing fit thresholds by injecting its own fit predicate
- show the Hub recommendation on the collapsed trigger and beside the corresponding row when expanded, while suppressing the badge for downloaded or partial variants

Closes #7646

## Test verification (RED → GREEN)

**RED on the previous PR implementation:** a downloaded fitting `Q4_K_M` was skipped and the remaining OOM `Q8_0` was incorrectly recommended:

```text
not ok - keeps a downloaded fitting variant as the recommendation instead of promoting an OOM download
expected: Q4_K_M (downloaded, fitting)
actual:   Q8_0 (OOM)
```

**GREEN after the patch:**

- focused recommendation suite: 10/10
- helper coverage: 100% lines, branches, and functions
- full frontend suite: 194/194
- TypeScript typecheck and production build pass
- Chromium/Playwright: verified the Hub card on the collapsed trigger and corresponding expanded row; verified the chat picker recommends a fitting variant rather than an OOM variant

The chat-picker integration test parses the executable TSX AST. An adversarial run with the expected expression present only in a comment fails, while the restored executable predicate passes.

## AI assistance disclosure

This contribution was assisted by OpenAI Codex. I reviewed and understood the final patch and verified it with automated tests and Chromium.
