### PR TITLE
Improve toast layout

### DIFF
--- a/studio/frontend/src/features/chat/adapters/studio-dictation-adapter.tsx
+++ b/studio/frontend/src/features/chat/adapters/studio-dictation-adapter.tsx
@@ -114,26 +114,13 @@ export function notifyStudioDictationUnavailable(
     toast.error("Voice recording isn't available in this browser.");
     return;
   }
-  // Browser Web Speech is missing (e.g. Firefox). Stack text and button so the
-  // action sits below, not squeezed into a side column.
-  const toastId = toast.error("Voice typing isn't available in this browser.", {
-    description: (
-      <div className="mt-0.5 flex flex-col items-start gap-2 pb-1.5">
-        <span>
-          Choose the local speech-to-text model in Voice settings to dictate
-          here.
-        </span>
-        <button
-          type="button"
-          onClick={() => {
-            useSettingsDialogStore.getState().openDialog("voice");
-            toast.dismiss(toastId);
-          }}
-          className="rounded-full bg-foreground px-2.5 pt-1 pb-1.5 text-xs font-medium text-background transition-colors hover:bg-foreground/90"
-        >
-          Open Voice settings
-        </button>
-      </div>
-    ),
+  // Browser Web Speech is missing (e.g. Firefox).
+  toast.error("Voice typing isn't available in this browser.", {
+    description:
+      "Choose the local speech-to-text model in Voice settings to dictate here.",
+    action: {
+      label: "Open Voice settings",
+      onClick: () => useSettingsDialogStore.getState().openDialog("voice"),
+    },
   });
 }

--- a/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
+++ b/studio/frontend/src/features/chat/hooks/use-chat-model-runtime.ts
@@ -113,17 +113,14 @@ function rememberApprovedRemoteCode(
   if (fingerprint) approvedRemoteCodeFingerprints.set(checkpoint, fingerprint);
 }
 
+// Class carries the progress-bar spacing; layout is shared CSS now.
 const MODEL_LOAD_TOAST_CLASSNAMES = {
-  toast: "chat-model-load-toast items-center gap-2.5",
+  toast: "chat-model-load-toast",
   content: "gap-0.5 flex-1 min-w-0",
   title: "leading-5",
   description: "mt-0 w-full",
   cancelButton:
     "!h-auto !rounded-none !border-0 !bg-transparent !px-1 !text-ui-11 !font-normal !text-muted-foreground hover:!bg-transparent hover:!text-destructive focus-visible:!text-destructive",
-} as const;
-
-const MODEL_LOADED_TOAST_CLASSNAMES = {
-  toast: "chat-model-loaded-toast items-center gap-2.5",
 } as const;
 
 const LORA_SUFFIX_RE = /_(\d{9,})$/;
@@ -1677,7 +1674,6 @@ export function useChatModelRuntime() {
           if (abortCtrl.signal.aborted) return;
           if (loadToastDismissedRef.current) {
             toast.success(`${toastDisplayName} loaded`, {
-              classNames: MODEL_LOADED_TOAST_CLASSNAMES,
               closeButton: true,
               duration: 8000,
             });
@@ -1686,7 +1682,6 @@ export function useChatModelRuntime() {
               id: toastId,
               description: undefined,
               cancel: undefined,
-              classNames: MODEL_LOADED_TOAST_CLASSNAMES,
               closeButton: true,
               duration: 8000,
               onDismiss: undefined,

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -2367,45 +2367,55 @@ html[data-chat-font] .aui-root {
    !important because Sonner injects its base rules at runtime. */
 [data-sonner-toast][data-styled='true'] {
 	padding: 12px 18px !important;
+	align-items: start !important;
+	gap: 10px !important;
 	box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.16) !important;
 }
 
-[data-sonner-toast][data-styled='true']:has([data-close-button]):not(:has([data-cancel])) {
+[data-sonner-toast][data-styled='true'] [data-icon] {
+	margin: 2px 0 0 !important;
+}
+
+[data-sonner-toast][data-styled='true'] [data-content] {
+	min-width: 0;
+}
+
+[data-sonner-toast][data-styled='true']:has([data-button]) {
+	display: grid !important;
+	grid-template-columns: 16px minmax(0, 1fr);
+	align-items: start !important;
+	column-gap: 10px !important;
+	row-gap: 10px !important;
+}
+
+[data-sonner-toast][data-styled='true']:has([data-button]) [data-icon] {
+	grid-column: 1;
+	grid-row: 1;
+}
+
+[data-sonner-toast][data-styled='true']:has([data-button]) [data-content] {
+	grid-column: 2;
+}
+
+[data-sonner-toast][data-styled='true']:has([data-button]) [data-button] {
+	grid-column: 2;
+	justify-self: start;
+	margin: 0 !important;
+}
+
+[data-sonner-toast][data-styled='true']:has([data-close-button]) {
 	padding-right: 48px !important;
 }
 
-[data-sonner-toast][data-styled='true']:has([data-cancel]):has([data-close-button]) {
-	padding-right: 88px !important;
-}
-
-[data-sonner-toast][data-styled='true'].chat-model-load-toast,
-[data-sonner-toast][data-styled='true'].chat-model-loaded-toast {
+/* Loading toast keeps its own vertical padding from #7683. */
+[data-sonner-toast][data-styled='true'].chat-model-load-toast {
 	padding-top: 14px !important;
 	padding-bottom: 14px !important;
 }
 
-/* Downloading state shows a progress bar as the last row; give it a little
-   extra breathing room below the bar. */
+/* Progress bar is the last row; give it room below. */
 [data-sonner-toast][data-styled='true'].chat-model-load-toast:has([role='progressbar']) {
 	padding-bottom: 18px !important;
-}
-
-[data-sonner-toast][data-styled='true'].chat-model-loaded-toast [data-close-button] {
-	top: calc(50% - 0.25px) !important;
-	transform: translateY(-50%) !important;
-}
-
-[data-sonner-toast][data-styled='true'].chat-model-load-toast:not(:has([data-cancel])) [data-close-button] {
-	top: calc(50% - 0.25px) !important;
-	transform: translateY(-50%) !important;
-}
-
-[data-sonner-toast][data-styled="true"]:has([data-cancel]) [data-cancel] {
-	position: absolute !important;
-	right: 36px !important;
-	top: 50% !important;
-	transform: translateY(-50%) !important;
-	margin: 0 !important;
 }
 
 /* Dark toasts share the chatbox surface color (.chat-composer-surface


### PR DESCRIPTION
## Summary

- Lay toasts out on a grid so a long message and its action button get their own rows instead of competing for one.
- Drop the absolute positioning and the compensating right padding the cancel button used to need.
- Keep the model loading toast's dedicated progress bar spacing from #7683.
- Switch the Firefox voice typing toast to Sonner's `action` rather than a hand rolled button inside the description, so it flows through the same layout.

## Notes

The composer spacing and send icon work that was originally on this branch has been dropped, so this is toast only now. #7683 has landed in `main`, so the diff is just the three files above.

## Validation

`npm run typecheck`, `npm test` (242 passing) and `npm run build` in `studio/frontend`.
