### PR TITLE
Defer a fixed-tier sidecar repair while a worker may be using the overlay

### DIFF
--- a/studio/backend/tests/test_transformers_latest.py
+++ b/studio/backend/tests/test_transformers_latest.py
@@ -498,7 +498,7 @@ class TestLatestVenvProvisioning:
         monkeypatch.setattr(tv, "_VENV_T5_LATEST_DIR", str(venv_dir))
         recorded = {}
 
-        def _fake_ensure(dir_, packages, label):
+        def _fake_ensure(dir_, packages, label, **_):
             recorded["dir"] = dir_
             recorded["packages"] = packages
             Path(dir_).mkdir(parents = True, exist_ok = True)
@@ -567,7 +567,7 @@ class TestLatestVenvProvisioning:
         monkeypatch.setattr(tv, "_venv_dir_is_valid", lambda *a: False)
         recorded = {}
 
-        def _fake_ensure(dir_, packages, label):
+        def _fake_ensure(dir_, packages, label, **_):
             recorded["dir"] = dir_
             recorded["packages"] = packages
             Path(dir_).mkdir(parents = True, exist_ok = True)
@@ -1089,7 +1089,7 @@ def test_failed_staging_install_removes_staging_dir(tmp_path, monkeypatch):
     venv_dir = tmp_path / ".venv_t5_latest"
     monkeypatch.setattr(tv, "_VENV_T5_LATEST_DIR", str(venv_dir))
 
-    def _fake_ensure(dir_, packages, label):
+    def _fake_ensure(dir_, packages, label, **_):
         Path(dir_).mkdir(parents = True, exist_ok = True)
         (Path(dir_) / "partial").write_text("x")
         return False

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -2002,6 +2002,81 @@ class TestVenvDirFileIntegrity:
         assert installed == ["transformers==5.3.0"], "damaged sidecar was not reinstalled"
         assert not (venv_dir / "transformers").exists(), "damaged tree was not wiped first"
 
+    def _damage_and_watch(self, tmp_path: Path, monkeypatch, name: str):
+        """A damaged fixed-tier sidecar plus a record of whether it got reinstalled."""
+        venv_dir = self._make_venv(tmp_path / name)
+        (venv_dir / "transformers" / "__init__.py").write_text("x")
+        installed: list = []
+        monkeypatch.setattr(
+            "utils.transformers_version._install_to_dir",
+            lambda pkg, target: (installed.append(pkg), True)[-1],
+        )
+        return venv_dir, installed
+
+    def test_damage_repair_defers_while_a_worker_may_be_using_the_overlay(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """The fixed-tier wipe is not staged: it deletes the live directory and refills
+        it over a multi-minute pip run. A worker lazy-importing in that window dies on a
+        half-present tree, possibly over damage in a file it would never have touched."""
+        import multiprocessing
+
+        import utils.transformers_version as tv
+
+        for label, in_child, busy in (
+            ("worker child cannot see its siblings", True, False),
+            ("parent can see a live worker", False, True),
+        ):
+            venv_dir, installed = self._damage_and_watch(tmp_path, monkeypatch, label[:12])
+            monkeypatch.setattr(
+                multiprocessing, "parent_process", lambda: object() if in_child else None
+            )
+            monkeypatch.setattr(tv, "_workers_active_for_repair", lambda: busy)
+
+            # True, not False: callers raise RuntimeError on False and _probe_tier drops
+            # the tier, so refusing would be worse than the damage it is deferring.
+            assert _ensure_venv_dir(str(venv_dir), ("transformers==5.3.0",), "t") is True, label
+            assert installed == [], label
+            assert (venv_dir / "transformers" / "__init__.py").read_text() == "x", label
+
+    def test_a_deferred_repair_runs_as_soon_as_nobody_is_active(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """Stateless by design: nothing records the deferral, so nothing has to clear
+        it. Any 'repair me later' record is the shape that deadlocked the latest tier."""
+        import multiprocessing
+
+        import utils.transformers_version as tv
+
+        venv_dir, installed = self._damage_and_watch(tmp_path, monkeypatch, "venv")
+        monkeypatch.setattr(multiprocessing, "parent_process", lambda: None)
+        monkeypatch.setattr(tv, "_workers_active_for_repair", lambda: True)
+        assert _ensure_venv_dir(str(venv_dir), ("transformers==5.3.0",), "t") is True
+        assert installed == []
+
+        monkeypatch.setattr(tv, "_workers_active_for_repair", lambda: False)
+        assert _ensure_venv_dir(str(venv_dir), ("transformers==5.3.0",), "t") is True
+        assert installed == ["transformers==5.3.0"], "the deferral outlived the workers"
+
+    def test_a_child_still_provisions_a_missing_fixed_tier(self, tmp_path: Path, monkeypatch):
+        """Only damage defers. Fixed tiers are legitimately created by a worker on first
+        use when setup never provisioned them, so a blanket child refusal would break
+        fresh installs."""
+        import multiprocessing
+
+        import utils.transformers_version as tv
+
+        installed: list = []
+        monkeypatch.setattr(
+            "utils.transformers_version._install_to_dir",
+            lambda pkg, target: (installed.append(pkg), True)[-1],
+        )
+        monkeypatch.setattr(multiprocessing, "parent_process", lambda: object())
+        monkeypatch.setattr(tv, "_workers_active_for_repair", lambda: True)
+
+        assert _ensure_venv_dir(str(tmp_path / "absent"), ("transformers==5.3.0",), "t") is True
+        assert installed == ["transformers==5.3.0"]
+
     def test_ensure_venv_dir_restores_the_studio_owned_marker(self, tmp_path: Path, monkeypatch):
         """The wipe takes setup.sh's ownership marker with the old directory. Without a
         new one, the next `unsloth studio update` under a custom UNSLOTH_STUDIO_HOME
@@ -3444,7 +3519,7 @@ class TestStageAndSwapBeforeSwap:
         live = tmp_path / "venv_latest"
         monkeypatch.setattr(tv, "_VENV_T5_LATEST_DIR", str(live))
 
-        def _fake_build(target, packages, label):
+        def _fake_build(target, packages, label, **_):
             if build_ok:
                 Path(target).mkdir(parents = True, exist_ok = True)
             return build_ok

--- a/studio/backend/tests/test_transformers_version.py
+++ b/studio/backend/tests/test_transformers_version.py
@@ -2039,9 +2039,7 @@ class TestVenvDirFileIntegrity:
             assert installed == [], label
             assert (venv_dir / "transformers" / "__init__.py").read_text() == "x", label
 
-    def test_a_deferred_repair_runs_as_soon_as_nobody_is_active(
-        self, tmp_path: Path, monkeypatch
-    ):
+    def test_a_deferred_repair_runs_as_soon_as_nobody_is_active(self, tmp_path: Path, monkeypatch):
         """Stateless by design: nothing records the deferral, so nothing has to clear
         it. Any 'repair me later' record is the shape that deadlocked the latest tier."""
         import multiprocessing

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2373,7 +2373,11 @@ def _repair_would_disturb_a_live_worker() -> bool:
 
 
 def _ensure_venv_dir(
-    venv_dir: str, packages: tuple[str, ...], label: str, *, shared: bool = True
+    venv_dir: str,
+    packages: tuple[str, ...],
+    label: str,
+    *,
+    shared: bool = True,
 ) -> bool:
     """Ensure *venv_dir* exists with all *packages*. Install if missing.
 

--- a/studio/backend/utils/transformers_version.py
+++ b/studio/backend/utils/transformers_version.py
@@ -2354,10 +2354,55 @@ def _mark_studio_owned(venv_dir: str) -> None:
         pass
 
 
-def _ensure_venv_dir(venv_dir: str, packages: tuple[str, ...], label: str) -> bool:
-    """Ensure *venv_dir* exists with all *packages*. Install if missing."""
-    if _venv_dir_is_valid_and_undamaged(venv_dir, packages):
-        return True
+def _repair_would_disturb_a_live_worker() -> bool:
+    """Whether wiping a shared overlay right now could pull it out from under someone.
+
+    True in a worker child, which cannot see its live siblings at all, and in a parent
+    that can see a chat, training or export worker running. Deliberately stateless:
+    the answer is recomputed per call, so a deferral simply retries on the next one.
+    Any record of "repair me later" would have to be cleared by something, and that is
+    exactly the shape that deadlocked the latest tier.
+    """
+    try:
+        import multiprocessing as _mp
+        if _mp.parent_process() is not None:
+            return True
+    except Exception:
+        pass
+    return _workers_active_for_repair()
+
+
+def _ensure_venv_dir(
+    venv_dir: str, packages: tuple[str, ...], label: str, *, shared: bool = True
+) -> bool:
+    """Ensure *venv_dir* exists with all *packages*. Install if missing.
+
+    *shared* marks a directory other processes may already be importing from, where a
+    file-damage repair is deferred while anyone could be using it. Pass False for a
+    private directory such as a staging tree, which nothing else can have open.
+    """
+    if _venv_dir_is_valid(venv_dir, packages):
+        damaged, _ = _sidecar_scan(venv_dir)
+        if not damaged:
+            return True
+        if shared and _repair_would_disturb_a_live_worker():
+            # The wipe below is not staged: it deletes the live directory and
+            # repopulates it over a multi-minute pip run, so a worker that lazy-imports
+            # in that window dies on a tree that is half there -- possibly over damage
+            # in a file it would never have touched. Leaving it is what happened before
+            # the damage was detectable at all, so this is a floor, not a regression,
+            # and the next call with nobody active repairs it.
+            logger.warning(
+                "%s has damaged files but may be in use; deferring the repair: %s",
+                venv_dir,
+                "; ".join(damaged),
+            )
+            return True
+        logger.warning(
+            "%s has damaged files -- venv will be wiped and reinstalled: %s",
+            venv_dir,
+            "; ".join(damaged),
+        )
 
     logger.warning("%s not found or incomplete at %s -- installing at runtime", label, venv_dir)
     shutil.rmtree(venv_dir, ignore_errors = True)
@@ -2706,7 +2751,11 @@ def _stage_and_swap_latest_venv(
     retired = _VENV_T5_LATEST_DIR + ".old"
     shutil.rmtree(staging, ignore_errors = True)
     try:
-        if not _ensure_venv_dir(staging, packages, f"transformers {version} (latest)"):
+        # Private tree, just deleted above and not yet swapped in, so nothing can be
+        # importing from it and a deferral here would strand the repair it is part of.
+        if not _ensure_venv_dir(
+            staging, packages, f"transformers {version} (latest)", shared = False
+        ):
             # No exception, so the except cleanup below never runs; drop the partial dir.
             shutil.rmtree(staging, ignore_errors = True)
             return False


### PR DESCRIPTION
Follow-up to #7725, raised there in review and deliberately left out of it.

## The window

The fixed tiers are repaired in place:

```python
logger.warning("%s not found or incomplete at %s -- installing at runtime", label, venv_dir)
shutil.rmtree(venv_dir, ignore_errors = True)
os.makedirs(venv_dir, exist_ok = True)
```

None of the guards the `latest` tier has apply: no stage-and-swap, no swap reservation, no active-worker check. `.venv_t5_530/550/510` are shared by every worker on that tier, so a chat, training or export worker that lazy-imports during the multi-minute pip run sees a tree that is half there. The damage that triggered the repair may be in a file that worker would never have touched.

Both routes in are real: a parent-side `_probe_tier` calls `ensure_fn()` per tier, and `activate_transformers_for_subprocess` calls the same from a second worker, with no child refusal on this path.

## Why now, when the wipe is not new

Being explicit, since this could be read as fixing something #7725 broke: it did not. `_ensure_venv_dir`'s wipe is unchanged from before, and it already fired whenever a package-level check failed. What changed is that file damage now reaches it too, which is a far more common state than a missing package, so the window is worth closing.

## The fix

A **damage-only** repair waits while the overlay may be in use: in a worker child, which cannot see its live siblings at all, or in a parent that can see an active worker. A missing or wrong-version sidecar still installs immediately, so a worker provisioning a tier `setup.sh` never created is unaffected.

Four things this had to get right, each of which rules out an easier version:

- **Deferring returns `True`, not `False`.** Callers raise `RuntimeError` on `False` and `_probe_tier` drops the tier, so refusing would make the tier unavailable for as long as any worker lives, which is worse than the damage. `True` is exactly what shipped before the damage was detectable.
- **It is stateless.** Nothing records the deferral, so nothing has to clear it, and the next call with no one active repairs. A "repair me later" record is precisely the shape that deadlocked the `latest` tier during #7725.
- **The swap reservation is not reused.** It is single-slot, and `_stage_and_swap_latest_venv` already holds it while building its staging tree *through this function*, so taking it here would deadlock against itself. That staging tree passes `shared = False`, being private and not yet swapped in.
- **The child check is damage-only.** A blanket child refusal, as `latest` does, would break fresh installs of fixed tiers.

## The honest cost

A damaged fixed-tier sidecar does not self-heal while any worker is alive, so on a permanently busy system the repair waits for an idle moment. That is strictly better than the pre-#7725 behaviour, where it never healed at all, but it is not free and is worth stating.

## Verification

| scenario | before | after |
|---|---|---|
| parent, nobody active | wipes | wipes |
| parent, worker active | wipes | defers |
| worker child | wipes | defers |
| undamaged | no-op | no-op |
| deferred, then workers idle | n/a | repairs |
| fresh install in a child | installs | installs |

`363 passed`. Two of the three new tests fail with the deferral disabled; the third passes either way by design, since it guards that fresh installs still work. Ruff clean, and the RECORD scan still reports zero findings against the three real sidecars on a live install.

The three `_fake_ensure` / `_fake_build` stubs take `**_` now, since `_ensure_venv_dir` grew a keyword-only argument. No assertion changed.
