### PR TITLE
Lint CI: scope the import-hoist check to the PR's own commits

### DIFF
--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -105,26 +105,42 @@ jobs:
         # exactly where a hoist refactor lives, and it skips brand-new
         # files whose re-export imports would otherwise look "unused".
         #
-        # Diff against the true merge-base, not the base tip. A two-dot
-        # diff against the tip re-lints every file the base branch
-        # changed after the PR branched, comparing newer base code
-        # (BEFORE) against the PR's older snapshot (AFTER) - a
-        # time-reversed comparison that flags the base branch's own
-        # refactors as blockers on PRs that never touched those files.
-        # The compare API returns the merge-base without needing local
-        # history, and fetching that single commit by SHA keeps the
-        # shallow (fetch-depth: 1) clone.
+        # Diff the merge-base against the PR HEAD, and pin BOTH ends
+        # explicitly.
+        #
+        # The base tip is the wrong BEFORE: a two-dot diff against it
+        # re-lints every file the base branch changed after the PR
+        # branched, comparing newer base code (BEFORE) against the PR's
+        # older snapshot (AFTER) - a time-reversed comparison that flags
+        # the base branch's own refactors as blockers.
+        #
+        # `HEAD` is the wrong AFTER for the same reason. On a
+        # pull_request event the checkout is refs/pull/N/merge, i.e.
+        # merge(PR head, base tip), so `$MERGE_BASE..HEAD` still spans
+        # every base commit since the branch point and reintroduces the
+        # exact false positives the merge-base was chosen to avoid.
+        # Naming the PR head SHA makes the range the PR's own commits
+        # and nothing else.
+        #
+        # Both endpoints are fetched by SHA so the shallow
+        # (fetch-depth: 1) clone is preserved; the verifier reads each
+        # revision with `git show REF:path` and never needs a checkout.
         if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           MERGE_BASE=$(gh api \
             "repos/${{ github.repository }}/compare/${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" \
             --jq .merge_base_commit.sha)
+          # A fork PR's head is not on origin as a branch, but it is
+          # always reachable as refs/pull/N/head.
           git fetch --no-tags --depth=1 origin "$MERGE_BASE"
+          git fetch --no-tags --depth=1 origin \
+            "refs/pull/${{ github.event.pull_request.number }}/head"
           mapfile -t CHANGED < <(
             git diff --name-only --diff-filter=M \
-              "$MERGE_BASE" HEAD -- '*.py' \
+              "$MERGE_BASE" "$HEAD_SHA" -- '*.py' \
               | grep -vE '(^|/)(unsloth_compiled_cache|node_modules|build|dist)/' || true
           )
           if [ "${#CHANGED[@]}" -eq 0 ]; then
@@ -132,10 +148,11 @@ jobs:
             exit 0
           fi
           printf 'merge base: %s\n' "$MERGE_BASE"
+          printf 'pr head:    %s\n' "$HEAD_SHA"
           printf 'checking %d file(s):\n' "${#CHANGED[@]}"
           printf '  %s\n' "${CHANGED[@]}"
           python scripts/verify_import_hoist.py \
-            --before "$MERGE_BASE" --after HEAD "${CHANGED[@]}"
+            --before "$MERGE_BASE" --after "$HEAD_SHA" "${CHANGED[@]}"
 
       - name: No leftover debugger / pdb / breakpoint calls
         # Catches the "I'll just stick a breakpoint() here" mistake


### PR DESCRIPTION
## Problem

The `Import-hoist / alias-rename safety` step in `lint-ci.yml` computes its file list as:

```
git diff --name-only --diff-filter=M "$MERGE_BASE" HEAD -- '*.py'
```

On a `pull_request` event the checkout is `refs/pull/N/merge`, i.e. `merge(PR head, base tip)`. So `$MERGE_BASE..HEAD` spans **every commit that landed on main since the PR branched**, not just the PR's own. The step then lints, and can fail on, files the PR never touched.

The existing comment shows the merge-base was chosen precisely to avoid this class of false positive. Pinning only the BEFORE end fixed half of it; the AFTER end still pulls the base branch back in.

### It is failing PRs today

#7734 changes only TypeScript and CSS, zero Python files. Its Source lint run reported `checking 78 file(s)` and failed with 3 blockers that all originate from #6880 (`AttentionMaskConverter` moving to `unsloth/models/_attn_mask_compat`):

```
[BLOCKER] unsloth/models/_utils.py: TARGET-CHANGED name 'AttentionMaskConverter' ...
[BLOCKER] unsloth/models/llama.py:  TARGET-CHANGED name 'AttentionMaskConverter' ...
[BLOCKER] unsloth/models/qwen3.py:  HOISTED-IMPORT-UNUSED '_prepare_4d_causal_attention_mask_for_sdpa' ...
OVERALL: FAIL (blockers found)
```

Any PR that branched before #6880 and has not rebased hits this, whatever it touches. It also short-circuits the job, so every later step in the same job (debugger calls, shell parse, YAML/JSON parse, codespell, shellcheck, ruff format drift) is skipped and never runs.

## Fix

Pin the AFTER end to `github.event.pull_request.head.sha` so the range is exactly the PR's own commits, and fetch that SHA via `refs/pull/N/head` (which exists for fork PRs too). The verifier reads each revision with `git show REF:path`, so no checkout is needed and `fetch-depth: 1` still holds.

## Validation

Three PRs on a staging fork, same branch point, differing only as noted:

| arm | lint-ci.yml | branch touches .py? | files checked | result |
|---|---|---|---|---|
| buggy | current | no | 67 | **fail** (3 blockers belonging to main) |
| fixed | this PR | no | 0 | **pass** ("no in-place-modified Python files to check") |
| catch | this PR | yes, one unused hoisted import injected | 1 | **fail**, correctly |

The third arm is the important one: it confirms the narrower range still catches a genuine blocker rather than silently disabling the check.

Cross-checked against open PRs that do change Python, comparing the current range with the fixed one:

| PR | current | fixed |
|---|---|---|
| #7717 | 5 files | 5 files |
| #7735 | 2 files | 2 files |
| #7721 | 27 files | 2 files |

Coverage of each PR's own Python changes is unchanged; only the inherited files drop out.