### PR TITLE
Wait for the floating monitor to stop moving, not just stop growing

### DIFF
--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -373,7 +373,21 @@ def exercise_floating_monitor_geometry(page):
                 // the geometry to hold for two consecutive animation frames --
                 // this runs under the default polling="raf", and it is how
                 // Playwright itself defines a stable element.
-                const signature = monitorHeight + "x" + contentHeight;
+                //
+                // Position belongs in the signature as well as size. An undragged
+                // panel is bottom-anchored by re-clamping its top against the new
+                // height, and that lands a frame AFTER the height it reacts to, so
+                // a size-only signature reports settled while the panel is still
+                // where the shorter version put it. Sampling there reads a bottom
+                // inset that is exactly the growth too low. Deliberately not
+                // waiting on the expected inset itself: that would gate on the
+                // very thing the assertions below check and turn a real
+                // misplacement into a timeout instead of a failure.
+                const rect = monitor.getBoundingClientRect();
+                const signature = [
+                    monitorHeight, contentHeight,
+                    Math.round(rect.top), Math.round(rect.left),
+                ].join("x");
                 const settled = window.__unslothMonitorGeometry === signature;
                 window.__unslothMonitorGeometry = signature;
                 return settled;


### PR DESCRIPTION
`Chat UI Tests` in `Mac Studio UI CI` fails intermittently on:

```
AssertionError: [ui] FAIL: initial bottom inset: expected 884, got 930.5
```

It fails on unrelated branches and on `main` itself, and passes when re-run, so it is not attributable to whatever PR happens to be red. It has cost a re-run on 2 of the last 4 staging cycles I have driven.

## Cause

The settle gate before the geometry assertions waits on size only:

```js
const signature = monitorHeight + "x" + contentHeight;
```

An undragged panel is bottom-anchored: `reconcileGeometry` re-clamps `top` against the current height, so the move lands a frame *after* the height it reacts to. In between, the panel is a self-consistent size sitting where the shorter version put it. The gate calls that settled, and the sample reads a bottom inset exactly the growth too low.

The numbers match that: the container is `inset-4`, so the expected bottom is `16 + (900 - 32) = 884`, and 930.5 is 46.5px lower. The comment already in this function describes the VRAM row on a host that reports a GPU as adding about 59px, which is the growth that has not been re-clamped yet.

## Change

Position joins size in the signature, so the wait ends once the panel has stopped moving as well as stopped resizing.

It deliberately does **not** wait on the expected inset. Gating on the value the assertions below check would make them unfalsifiable and turn a genuine misplacement into a 30s timeout instead of a clear failure. If the panel really does come to rest in the wrong place, this still fails, and still says where it landed.

## Validation

An intermittent failure is not proven fixed by one green run, so this was run repeatedly on the affected workflow; results in the thread below.
