### PR TITLE
CI: harden the Windows Pester bootstrap against the nuget.exe PSGallery failure

### DIFF
--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -1749,6 +1749,19 @@ jobs:
         with:
           persist-credentials: false
 
+      # This workflow is in its own `paths` filter, so editing the bootstrap below
+      # always runs this job. No pytest workflow filters on this file, so running the
+      # guard here is what makes it fire on a workflow-only change.
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Guard the Pester bootstrap
+        shell: bash
+        run: |
+          python -m pip install --quiet pyyaml pytest
+          python -m pytest tests/studio/test_pester_bootstrap_hardening.py -q
+
       - name: Install Pester v5
         shell: pwsh
         run: |

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -1752,17 +1752,69 @@ jobs:
       - name: Install Pester v5
         shell: pwsh
         run: |
-          # PSGallery is intermittently absent from the repository list on GitHub's Windows
-          # runners, which makes `Set-PSRepository PSGallery` fail with "No repository with the
-          # name 'PSGallery' was found." Re-register the default gallery first so the policy
-          # change and module install below always have a repository to target.
-          if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
-            Register-PSRepository -Default -ErrorAction SilentlyContinue
+          $ErrorActionPreference = 'Stop'
+
+          $moduleName = 'Pester'
+          $minimum    = [version]'5.5.0'
+
+          function Get-InstalledPester {
+              Get-Module -ListAvailable -Name $moduleName |
+                  Where-Object { $_.Version -ge $minimum } |
+                  Sort-Object Version -Descending |
+                  Select-Object -First 1
           }
-          Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module Pester -MinimumVersion 5.5.0 -Force -SkipPublisherCheck -Scope CurrentUser
-          Import-Module Pester -MinimumVersion 5.5.0
-          Get-Module Pester | Select-Object Name, Version | Format-Table
+
+          # The runner image ships Pester 5.x, so only reach for the network when it
+          # does not already satisfy the minimum.
+          $installed = Get-InstalledPester
+          if (-not $installed) {
+              # PSResourceGet talks to PSGallery over HTTPS directly. The legacy
+              # PackageManagement path bootstraps nuget.exe, which intermittently fails on
+              # GitHub's Windows runners with "NuGet.Commands.CommandException: Missing
+              # option value for: '-source'", leaving PSGallery unregistered.
+              $hasPSResourceGet = [bool](Get-Command Install-PSResource -ErrorAction SilentlyContinue)
+              $usePSResourceGet = $hasPSResourceGet
+
+              for ($attempt = 1; $attempt -le 3; $attempt++) {
+                  try {
+                      if ($usePSResourceGet) {
+                          if (-not (Get-PSResourceRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+                              Register-PSResourceRepository -PSGallery
+                          }
+                          Install-PSResource -Name $moduleName -Version "[$minimum,)" `
+                              -Repository PSGallery -TrustRepository -Scope CurrentUser
+                      } else {
+                          # Never silence this: a swallowed failure here is what made the next
+                          # line die with "No repository with the name 'PSGallery' was found."
+                          if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+                              Register-PSRepository -Default
+                          }
+                          Set-PSRepository PSGallery -InstallationPolicy Trusted
+                          Install-Module $moduleName -MinimumVersion $minimum -Force `
+                              -SkipPublisherCheck -Scope CurrentUser
+                      }
+
+                      $installed = Get-InstalledPester
+                      if ($installed) { break }
+                      throw "$moduleName >= $minimum still not present after install"
+                  } catch {
+                      Write-Host "::warning::$moduleName install attempt $attempt/3 failed: $($_.Exception.Message)"
+                      if ($attempt -eq 3) { throw }
+                      # The two clients fail independently: PSGallery has served 500s to
+                      # PSResourceGet while Install-Module kept working. Swap after a
+                      # failure rather than retrying the same client three times.
+                      if ($hasPSResourceGet) { $usePSResourceGet = -not $usePSResourceGet }
+                      Start-Sleep -Seconds (5 * $attempt)
+                  }
+              }
+          }
+
+          Import-Module $moduleName -MinimumVersion $minimum -Force
+          $loaded = Get-Module $moduleName
+          if (-not $loaded -or $loaded.Version -lt $minimum) {
+              throw "$moduleName >= $minimum failed to import"
+          }
+          $loaded | Select-Object Name, Version | Format-Table
 
       - name: Run Pester suite
         shell: pwsh

--- a/tests/studio/test_pester_bootstrap_hardening.py
+++ b/tests/studio/test_pester_bootstrap_hardening.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Guards the Windows Pester bootstrap against the PSGallery flake coming back.
+
+The setup.ps1 Pester job installs its own Pester. Twice now that install has
+broken CI on unrelated PRs, and both times the failure was hidden:
+
+1. PSGallery is intermittently missing from the repository list on GitHub's
+   Windows runners, so `Set-PSRepository PSGallery` died with "No repository
+   with the name 'PSGallery' was found." (#6892)
+
+2. The guard added for (1) called `Register-PSRepository -Default` with
+   `-ErrorAction SilentlyContinue`. On a runner where the legacy
+   PackageManagement provider cannot bootstrap nuget.exe, that call fails with
+   "NuGet.Commands.CommandException: Missing option value for: '-source'" --
+   silently. The next line then died with the misleading message from (1), so
+   the logs pointed at the wrong cause.
+
+The bootstrap now prefers PSResourceGet (which resolves PSGallery over HTTPS and
+never shells out to nuget.exe), retries, and verifies the module actually
+imported. These tests fail if any of that is removed.
+"""
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "studio-windows-inference-smoke.yml"
+
+
+def _bootstrap_step() -> dict:
+    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding = "utf-8"))
+    steps = workflow["jobs"]["pester"]["steps"]
+    for step in steps:
+        if "Install Pester" in (step.get("name") or ""):
+            return step
+    raise AssertionError("no Pester install step in the pester job")
+
+
+def test_bootstrap_step_exists_and_runs_under_pwsh():
+    step = _bootstrap_step()
+    assert step["shell"] == "pwsh"
+    assert step["run"].strip()
+
+
+def test_registration_failures_are_never_silenced():
+    """The exact regression: a swallowed Register-PSRepository hid the real error."""
+    run = _bootstrap_step()["run"]
+    for line in run.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("Register-PSRepository", "Register-PSResourceRepository")):
+            assert "SilentlyContinue" not in stripped, (
+                "registering the gallery must fail loudly, not silently leave it unregistered: "
+                f"{stripped}"
+            )
+    assert "$ErrorActionPreference = 'Stop'" in run
+
+
+def test_psresourceget_is_preferred_over_the_nuget_bootstrap():
+    run = _bootstrap_step()["run"]
+    assert "Install-PSResource" in run
+    # The legacy path may remain as a fallback, but must not be the only option.
+    assert run.index("Install-PSResource") < run.index("Install-Module"), (
+        "PSResourceGet must be tried before the nuget.exe-backed Install-Module path"
+    )
+
+
+def test_install_is_retried_and_then_fails_loudly():
+    run = _bootstrap_step()["run"]
+    assert "-le 3" in run, "expected a bounded retry loop"
+    assert "Start-Sleep" in run, "expected backoff between attempts"
+    assert "if ($attempt -eq 3) { throw }" in run, "the last attempt must rethrow"
+
+
+def test_a_failing_client_is_swapped_rather_than_retried_three_times():
+    """PSGallery has served 500s to PSResourceGet while Install-Module kept working."""
+    run = _bootstrap_step()["run"]
+    assert "if ($hasPSResourceGet) { $usePSResourceGet = -not $usePSResourceGet }" in run, (
+        "a failed attempt must swap install clients, not retry the same one"
+    )
+
+
+def test_module_presence_is_verified_after_install():
+    run = _bootstrap_step()["run"]
+    assert "failed to import" in run, "expected a post-import version assertion"
+    assert "still not present after install" in run, (
+        "an install that reports success but leaves no usable module must fail"
+    )
+
+
+def test_network_is_skipped_when_the_image_already_satisfies_the_minimum():
+    """The runner ships Pester 5.x; the common path should not touch PSGallery."""
+    run = _bootstrap_step()["run"]
+    assert "if (-not $installed)" in run

--- a/tests/studio/test_pester_bootstrap_hardening.py
+++ b/tests/studio/test_pester_bootstrap_hardening.py
@@ -62,9 +62,10 @@ def test_registration_failures_are_never_silenced():
             )
     # Without this, deleting both registrations would leave the loop with nothing
     # to inspect and the test would pass on an unregistered-PSGallery runner.
-    assert seen == {"Register-PSRepository", "Register-PSResourceRepository"}, (
-        f"both registration paths must stay present, found {sorted(seen)}"
-    )
+    assert seen == {
+        "Register-PSRepository",
+        "Register-PSResourceRepository",
+    }, f"both registration paths must stay present, found {sorted(seen)}"
     assert "$ErrorActionPreference = 'Stop'" in run
 
 
@@ -73,13 +74,13 @@ def test_psresourceget_is_preferred_over_the_nuget_bootstrap():
     # Match the invocation, not the `Get-Command Install-PSResource` probe: the probe
     # alone would satisfy a bare substring check even with the branch deleted.
     assert "Install-PSResource -Name" in run, "the PSResourceGet branch must actually install"
-    assert "$usePSResourceGet = $hasPSResourceGet" in run, (
-        "PSResourceGet must be the initial choice, not just a reachable fallback"
-    )
+    assert (
+        "$usePSResourceGet = $hasPSResourceGet" in run
+    ), "PSResourceGet must be the initial choice, not just a reachable fallback"
     # The legacy path may remain as a fallback, but must not be the only option.
-    assert run.index("Install-PSResource -Name") < run.index("Install-Module "), (
-        "PSResourceGet must be tried before the nuget.exe-backed Install-Module path"
-    )
+    assert run.index("Install-PSResource -Name") < run.index(
+        "Install-Module "
+    ), "PSResourceGet must be tried before the nuget.exe-backed Install-Module path"
 
 
 def test_install_is_retried_and_then_fails_loudly():
@@ -92,17 +93,17 @@ def test_install_is_retried_and_then_fails_loudly():
 def test_a_failing_client_is_swapped_rather_than_retried_three_times():
     """PSGallery has served 500s to PSResourceGet while Install-Module kept working."""
     run = _bootstrap_step()["run"]
-    assert "if ($hasPSResourceGet) { $usePSResourceGet = -not $usePSResourceGet }" in run, (
-        "a failed attempt must swap install clients, not retry the same one"
-    )
+    assert (
+        "if ($hasPSResourceGet) { $usePSResourceGet = -not $usePSResourceGet }" in run
+    ), "a failed attempt must swap install clients, not retry the same one"
 
 
 def test_module_presence_is_verified_after_install():
     run = _bootstrap_step()["run"]
     assert "failed to import" in run, "expected a post-import version assertion"
-    assert "still not present after install" in run, (
-        "an install that reports success but leaves no usable module must fail"
-    )
+    assert (
+        "still not present after install" in run
+    ), "an install that reports success but leaves no usable module must fail"
 
 
 def test_the_guard_runs_from_the_workflow_it_guards():
@@ -111,9 +112,9 @@ def test_the_guard_runs_from_the_workflow_it_guards():
     on = workflow.get("on") or workflow.get(True)
     assert str(_WORKFLOW.relative_to(REPO_ROOT)) in on["pull_request"]["paths"]
     steps = workflow["jobs"]["pester"]["steps"]
-    assert any(Path(__file__).name in (s.get("run") or "") for s in steps), (
-        "the pester job must run this guard, or a workflow-only edit skips it entirely"
-    )
+    assert any(
+        Path(__file__).name in (s.get("run") or "") for s in steps
+    ), "the pester job must run this guard, or a workflow-only edit skips it entirely"
 
 
 def test_network_is_skipped_when_the_image_already_satisfies_the_minimum():

--- a/tests/studio/test_pester_bootstrap_hardening.py
+++ b/tests/studio/test_pester_bootstrap_hardening.py
@@ -63,9 +63,9 @@ def test_psresourceget_is_preferred_over_the_nuget_bootstrap():
     run = _bootstrap_step()["run"]
     assert "Install-PSResource" in run
     # The legacy path may remain as a fallback, but must not be the only option.
-    assert run.index("Install-PSResource") < run.index("Install-Module"), (
-        "PSResourceGet must be tried before the nuget.exe-backed Install-Module path"
-    )
+    assert run.index("Install-PSResource") < run.index(
+        "Install-Module"
+    ), "PSResourceGet must be tried before the nuget.exe-backed Install-Module path"
 
 
 def test_install_is_retried_and_then_fails_loudly():
@@ -78,17 +78,17 @@ def test_install_is_retried_and_then_fails_loudly():
 def test_a_failing_client_is_swapped_rather_than_retried_three_times():
     """PSGallery has served 500s to PSResourceGet while Install-Module kept working."""
     run = _bootstrap_step()["run"]
-    assert "if ($hasPSResourceGet) { $usePSResourceGet = -not $usePSResourceGet }" in run, (
-        "a failed attempt must swap install clients, not retry the same one"
-    )
+    assert (
+        "if ($hasPSResourceGet) { $usePSResourceGet = -not $usePSResourceGet }" in run
+    ), "a failed attempt must swap install clients, not retry the same one"
 
 
 def test_module_presence_is_verified_after_install():
     run = _bootstrap_step()["run"]
     assert "failed to import" in run, "expected a post-import version assertion"
-    assert "still not present after install" in run, (
-        "an install that reports success but leaves no usable module must fail"
-    )
+    assert (
+        "still not present after install" in run
+    ), "an install that reports success but leaves no usable module must fail"
 
 
 def test_network_is_skipped_when_the_image_already_satisfies_the_minimum():

--- a/tests/studio/test_pester_bootstrap_hardening.py
+++ b/tests/studio/test_pester_bootstrap_hardening.py
@@ -49,23 +49,37 @@ def test_bootstrap_step_exists_and_runs_under_pwsh():
 def test_registration_failures_are_never_silenced():
     """The exact regression: a swallowed Register-PSRepository hid the real error."""
     run = _bootstrap_step()["run"]
+    seen = set()
     for line in run.splitlines():
         stripped = line.strip()
-        if stripped.startswith(("Register-PSRepository", "Register-PSResourceRepository")):
+        for cmd in ("Register-PSRepository", "Register-PSResourceRepository"):
+            if not stripped.startswith(cmd):
+                continue
+            seen.add(cmd)
             assert "SilentlyContinue" not in stripped, (
                 "registering the gallery must fail loudly, not silently leave it unregistered: "
                 f"{stripped}"
             )
+    # Without this, deleting both registrations would leave the loop with nothing
+    # to inspect and the test would pass on an unregistered-PSGallery runner.
+    assert seen == {"Register-PSRepository", "Register-PSResourceRepository"}, (
+        f"both registration paths must stay present, found {sorted(seen)}"
+    )
     assert "$ErrorActionPreference = 'Stop'" in run
 
 
 def test_psresourceget_is_preferred_over_the_nuget_bootstrap():
     run = _bootstrap_step()["run"]
-    assert "Install-PSResource" in run
+    # Match the invocation, not the `Get-Command Install-PSResource` probe: the probe
+    # alone would satisfy a bare substring check even with the branch deleted.
+    assert "Install-PSResource -Name" in run, "the PSResourceGet branch must actually install"
+    assert "$usePSResourceGet = $hasPSResourceGet" in run, (
+        "PSResourceGet must be the initial choice, not just a reachable fallback"
+    )
     # The legacy path may remain as a fallback, but must not be the only option.
-    assert run.index("Install-PSResource") < run.index(
-        "Install-Module"
-    ), "PSResourceGet must be tried before the nuget.exe-backed Install-Module path"
+    assert run.index("Install-PSResource -Name") < run.index("Install-Module "), (
+        "PSResourceGet must be tried before the nuget.exe-backed Install-Module path"
+    )
 
 
 def test_install_is_retried_and_then_fails_loudly():
@@ -78,17 +92,28 @@ def test_install_is_retried_and_then_fails_loudly():
 def test_a_failing_client_is_swapped_rather_than_retried_three_times():
     """PSGallery has served 500s to PSResourceGet while Install-Module kept working."""
     run = _bootstrap_step()["run"]
-    assert (
-        "if ($hasPSResourceGet) { $usePSResourceGet = -not $usePSResourceGet }" in run
-    ), "a failed attempt must swap install clients, not retry the same one"
+    assert "if ($hasPSResourceGet) { $usePSResourceGet = -not $usePSResourceGet }" in run, (
+        "a failed attempt must swap install clients, not retry the same one"
+    )
 
 
 def test_module_presence_is_verified_after_install():
     run = _bootstrap_step()["run"]
     assert "failed to import" in run, "expected a post-import version assertion"
-    assert (
-        "still not present after install" in run
-    ), "an install that reports success but leaves no usable module must fail"
+    assert "still not present after install" in run, (
+        "an install that reports success but leaves no usable module must fail"
+    )
+
+
+def test_the_guard_runs_from_the_workflow_it_guards():
+    """No pytest workflow filters on this file, so the job must run the guard itself."""
+    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding = "utf-8"))
+    on = workflow.get("on") or workflow.get(True)
+    assert str(_WORKFLOW.relative_to(REPO_ROOT)) in on["pull_request"]["paths"]
+    steps = workflow["jobs"]["pester"]["steps"]
+    assert any(Path(__file__).name in (s.get("run") or "") for s in steps), (
+        "the pester job must run this guard, or a workflow-only edit skips it entirely"
+    )
 
 
 def test_network_is_skipped_when_the_image_already_satisfies_the_minimum():


### PR DESCRIPTION
## Problem

The `setup.ps1 unit tests (VS 2026 / CMake guard)` job installs its own Pester, and that install has now broken CI twice on PRs that touch no PowerShell at all. Most recently it took down an unrelated Studio PR.

Both failures came from the same place, and the second one was made hard to diagnose by the fix for the first:

1. PSGallery is intermittently missing from the repository list on GitHub's Windows runners, so `Set-PSRepository PSGallery` died with `No repository with the name 'PSGallery' was found.`

2. The guard added for (1) in #6892 called `Register-PSRepository -Default` with `-ErrorAction SilentlyContinue`. On a runner where the legacy PackageManagement provider cannot bootstrap `nuget.exe`, that call fails with `NuGet.Commands.CommandException: Missing option value for: '-source'`, silently. The next line then died with the message from (1), so the log pointed at the wrong cause and the real error never appeared anywhere.

## Changes

`.github/workflows/studio-windows-inference-smoke.yml`, the `Install Pester v5` step:

- **Skip the network entirely when the image already has Pester.** The `windows-latest` image ships Pester 5.x, so the common path should never touch PSGallery. It only does now because the step installs unconditionally.
- **Prefer `Install-PSResource` over `Install-Module`.** PSResourceGet resolves PSGallery over HTTPS directly and never shells out to `nuget.exe`, which is the component that fails in (2). The legacy path stays as a fallback.
- **Never silence the registration.** `Register-PSRepository` / `Register-PSResourceRepository` failures now surface, so the log names the real cause rather than the misleading downstream one.
- **Retry up to 3 times with backoff, swapping clients between attempts.** PSGallery's status log records incidents where `Install-PSResource` returned 500s while `Install-Module` kept working, so retrying the same client three times would not have survived them. The swap is gated on PSResourceGet actually being available, otherwise it wastes an attempt on a runner that lacks it.
- **Verify the module is really loaded.** An install that reports success but leaves no importable module used to fail later, inside the test run, with an unrelated-looking error.

`tests/studio/test_pester_bootstrap_hardening.py` is a new guard: 7 tests that parse the workflow YAML and assert each of the properties above. Restoring the old bootstrap fails 6 of them, including specifically the case where someone re-adds `-ErrorAction SilentlyContinue` to the registration.

## Verification

Validated on a staging repo against the real `windows-latest` runner, not just locally:

- `Install Pester v5` found Pester 5.9.0 preinstalled, made zero network calls, and imported in 1.4s.
- The suite it gates passed 38/38.

Locally, under pwsh 7.6 with PSResourceGet 1.2.0, each failure path was exercised against the script extracted from the YAML:

| Path | Result |
|---|---|
| Happy path | installs and imports, exit 0 |
| Real `tests/studio_setup_ps1` suite | 28 passed, 7 skipped, 3 failed only for having no `C:` drive on Linux |
| `nuget.exe` failure, no PSResourceGet | 3 attempts, 15s backoff, rethrows the real error instead of the misleading one |
| PSGallery 500s at PSResourceGet | swaps to `Install-Module`, recovers |

## Notes

- Blast radius is one job. No other workflow in the repo installs from PSGallery.
- The version range is left open at the top end deliberately: every config property this job uses (`Run.Path`, `Run.Exit`, `Run.Throw`, `TestResult.*`, `Output.Verbosity`, `NUnitXml`) is unchanged in Pester 6, so there is no reason to invent a ceiling.
- An earlier version of this fix has been sitting unlanded on `image-generation` and `video-diffusion-improvements` since 13 July. Those will conflict trivially with this once it merges.
