### PR TITLE
Windows: move the installer out of System32 instead of failing in it

### DIFF
--- a/.github/workflows/cross-platform-parity-ci.yml
+++ b/.github/workflows/cross-platform-parity-ci.yml
@@ -19,6 +19,7 @@ on:
     paths:
       - 'install.sh'
       - 'install.ps1'
+      - 'unsloth_cli/__init__.py'
       - 'tests/test_installer_skip_autostart.py'
       - 'tests/test_installer_system32_guard.py'
       - 'tests/python/test_cross_platform_parity.py'
@@ -30,6 +31,7 @@ on:
     paths:
       - 'install.sh'
       - 'install.ps1'
+      - 'unsloth_cli/__init__.py'
       - 'tests/test_installer_skip_autostart.py'
       - 'tests/test_installer_system32_guard.py'
       - 'tests/python/test_cross_platform_parity.py'

--- a/.github/workflows/cross-platform-parity-ci.yml
+++ b/.github/workflows/cross-platform-parity-ci.yml
@@ -20,6 +20,7 @@ on:
       - 'install.sh'
       - 'install.ps1'
       - 'tests/test_installer_skip_autostart.py'
+      - 'tests/test_installer_system32_guard.py'
       - 'tests/python/test_cross_platform_parity.py'
       - 'tests/sh/test_install_rollback_lifecycle.sh'
       - 'tests/studio/test_install_rollback_lifecycle.ps1'
@@ -30,6 +31,7 @@ on:
       - 'install.sh'
       - 'install.ps1'
       - 'tests/test_installer_skip_autostart.py'
+      - 'tests/test_installer_system32_guard.py'
       - 'tests/python/test_cross_platform_parity.py'
       - 'tests/sh/test_install_rollback_lifecycle.sh'
       - 'tests/studio/test_install_rollback_lifecycle.ps1'
@@ -68,6 +70,7 @@ jobs:
           python -m pytest
           tests/python/test_cross_platform_parity.py
           tests/test_installer_skip_autostart.py
+          tests/test_installer_system32_guard.py
           -q
       - name: PowerShell rollback lifecycle tests
         if: runner.os == 'Windows'

--- a/install.ps1
+++ b/install.ps1
@@ -1138,9 +1138,10 @@ exit 0
     # run (unsloth_cli/__init__.py) only after PyTorch has downloaded, then rolls back.
     # Relocate rather than fail: nothing here reads the caller's directory ($RepoRoot
     # comes from $PSCommandPath, $StudioHome from the environment, both resolved above),
-    # so only a relative --with-llama-cpp-dir needs pinning first. Not restored at the
-    # end, same reason as the PSModulePath fix at the top: the interactive path ends
-    # running Studio in the foreground, so a finally would not fire until it stops.
+    # so --with-llama-cpp-dir is the only consumer input needing a rebase first. Not
+    # restored at the end, same reason as the PSModulePath fix at the top: the
+    # interactive path ends running Studio in the foreground, so a finally would not
+    # fire until it stops.
     $SystemRootDir = if ($env:SystemRoot) { $env:SystemRoot } else { "C:\Windows" }
     $SystemRootDir = [System.IO.Path]::GetFullPath($SystemRootDir).TrimEnd('\')
     $CurrentDir = $null
@@ -1162,7 +1163,9 @@ exit 0
             $WithLlamaCppDir = Join-Path $CurrentDir $WithLlamaCppDir
         }
         # SYSTEM's profile is C:\Windows\System32\config\systemprofile, so a candidate
-        # under the Windows directory is no better than where we already are.
+        # under the Windows directory is no better than where we already are. Prefix
+        # match with no trailing separator, deliberately: it also skips a sibling like
+        # C:\Windows.old, and losing a candidate is safe where accepting one is not.
         $SafeDirCandidates = @($env:USERPROFILE, $HOME, $env:PUBLIC, $env:TEMP) |
             Where-Object {
                 $_ -and (Test-Path -LiteralPath $_ -PathType Container) -and

--- a/install.ps1
+++ b/install.ps1
@@ -1159,8 +1159,18 @@ exit 0
         $CurrentDir.StartsWith($SystemRootDir + '\', [System.StringComparison]::OrdinalIgnoreCase)
     )
     if ($InSystemDir) {
-        if ($WithLlamaCppDir -and -not [System.IO.Path]::IsPathRooted($WithLlamaCppDir)) {
-            $WithLlamaCppDir = Join-Path $CurrentDir $WithLlamaCppDir
+        if ($WithLlamaCppDir) {
+            # Anchor to the location the user typed it against. Covers the partially
+            # qualified forms (C:llama.cpp, \llama.cpp) that IsPathRooted calls rooted
+            # while Set-Location still moves them, and not [System.IO.Path]::GetFullPath,
+            # which resolves against [Environment]::CurrentDirectory -- a different
+            # directory that Set-Location never updates.
+            try {
+                $WithLlamaCppDir =
+                    $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($WithLlamaCppDir)
+            } catch {
+                $WithLlamaCppDir = Join-Path $CurrentDir $WithLlamaCppDir
+            }
         }
         # SYSTEM's profile is C:\Windows\System32\config\systemprofile, so a candidate
         # under the Windows directory is no better than where we already are. Prefix

--- a/install.ps1
+++ b/install.ps1
@@ -1207,11 +1207,16 @@ exit 0
             Write-Host "        working directory, which Windows blocks there." -ForegroundColor Yellow
             Write-Host "        'Run as administrator' opens PowerShell in System32, which is how" -ForegroundColor Yellow
             Write-Host "        most people land here." -ForegroundColor Yellow
-            Write-Host "        Change to a normal folder and run the installer again:" -ForegroundColor Yellow
-            Write-Host "          cd `$env:USERPROFILE" -ForegroundColor Cyan
+            # USERPROFILE was one of the candidates just rejected, so naming it here would
+            # send the user back into the same tree. A service or SYSTEM account is the
+            # usual reason nothing qualified, and its profile is where Studio would install.
+            Write-Host "        Nothing outside $SystemRootDir was usable either (USERPROFILE," -ForegroundColor Yellow
+            Write-Host "        HOME, PUBLIC, TEMP), which normally means a service or the SYSTEM" -ForegroundColor Yellow
+            Write-Host "        account. Sign in as a normal user, open PowerShell there, and run" -ForegroundColor Yellow
+            Write-Host "        the installer again:" -ForegroundColor Yellow
             Write-Host "          irm https://unsloth.ai/install.ps1 | iex" -ForegroundColor Cyan
             Write-Host ""
-            return (Exit-InstallFailure "Refusing to install from the Windows system directory $CurrentDir. cd to a normal folder (for example `$env:USERPROFILE) and re-run the installer.")
+            return (Exit-InstallFailure "Refusing to install from the Windows system directory $CurrentDir, and no folder outside $SystemRootDir was usable. Run the installer from a normal user account.")
         }
     }
 

--- a/install.ps1
+++ b/install.ps1
@@ -1193,6 +1193,24 @@ exit 0
                 continue
             }
         }
+        # $StudioHome came from USERPROFILE, resolved long before this block, so a SYSTEM
+        # account would keep installing into C:\Windows\System32\config\systemprofile while
+        # we report having escaped. Rebasing it would orphan the install -- the runtime
+        # resolvers recompute the root from USERPROFILE -- so stop, which is what happened
+        # before this block existed, only with a reason attached.
+        $StudioHomeFull = ""
+        try { $StudioHomeFull = [System.IO.Path]::GetFullPath($StudioHome).TrimEnd('\') } catch {}
+        if ($SafeDir -and $StudioHomeFull.StartsWith($SystemRootDir, [System.StringComparison]::OrdinalIgnoreCase)) {
+            Write-Host ""
+            Write-Host "[ERROR] Unsloth would install into $StudioHomeFull," -ForegroundColor Red
+            Write-Host "        which is inside $SystemRootDir." -ForegroundColor Yellow
+            Write-Host "        That is where a service or the SYSTEM account keeps its profile." -ForegroundColor Yellow
+            Write-Host "        Sign in as a normal user, open PowerShell there, and run the" -ForegroundColor Yellow
+            Write-Host "        installer again:" -ForegroundColor Yellow
+            Write-Host "          irm https://unsloth.ai/install.ps1 | iex" -ForegroundColor Cyan
+            Write-Host ""
+            return (Exit-InstallFailure "Refusing to install into $StudioHomeFull, which is inside $SystemRootDir. Run the installer from a normal user account.")
+        }
         if ($SafeDir) {
             Write-TauriLog "STEP" "Left system directory $CurrentDir for $SafeDir"
             step "directory" "$CurrentDir is a Windows system folder" "Yellow"

--- a/install.ps1
+++ b/install.ps1
@@ -1144,6 +1144,9 @@ exit 0
     # fire until it stops.
     $SystemRootDir = if ($env:SystemRoot) { $env:SystemRoot } else { "C:\Windows" }
     $SystemRootDir = [System.IO.Path]::GetFullPath($SystemRootDir).TrimEnd('\')
+    # Every containment test below compares against this, never the bare root: a prefix
+    # without the separator also swallows siblings like C:\Windows.old and C:\WindowsStudio.
+    $SystemRootPrefix = $SystemRootDir + [System.IO.Path]::DirectorySeparatorChar
     $CurrentDir = $null
     try {
         # -PSProvider FileSystem: a caller on HKLM:\ still has the filesystem
@@ -1154,10 +1157,14 @@ exit 0
     } catch {
         $CurrentDir = $null
     }
-    $InSystemDir = $CurrentDir -and (
-        $CurrentDir.Equals($SystemRootDir, [System.StringComparison]::OrdinalIgnoreCase) -or
-        $CurrentDir.StartsWith($SystemRootDir + '\', [System.StringComparison]::OrdinalIgnoreCase)
-    )
+    function Test-UnderSystemRoot {
+        param([string]$Path)
+        return $Path -and (
+            $Path.Equals($SystemRootDir, [System.StringComparison]::OrdinalIgnoreCase) -or
+            $Path.StartsWith($SystemRootPrefix, [System.StringComparison]::OrdinalIgnoreCase)
+        )
+    }
+    $InSystemDir = Test-UnderSystemRoot $CurrentDir
     if ($InSystemDir) {
         if ($WithLlamaCppDir) {
             # Anchor to the location the user typed it against. Covers the partially
@@ -1173,15 +1180,11 @@ exit 0
             }
         }
         # SYSTEM's profile is C:\Windows\System32\config\systemprofile, so a candidate
-        # under the Windows directory is no better than where we already are. Prefix
-        # match with no trailing separator, deliberately: it also skips a sibling like
-        # C:\Windows.old, and losing a candidate is safe where accepting one is not.
+        # under the Windows directory is no better than where we already are.
         $SafeDirCandidates = @($env:USERPROFILE, $HOME, $env:PUBLIC, $env:TEMP) |
             Where-Object {
                 $_ -and (Test-Path -LiteralPath $_ -PathType Container) -and
-                -not ([System.IO.Path]::GetFullPath($_).TrimEnd('\')).StartsWith(
-                    $SystemRootDir, [System.StringComparison]::OrdinalIgnoreCase
-                )
+                -not (Test-UnderSystemRoot ([System.IO.Path]::GetFullPath($_).TrimEnd('\')))
             }
         $SafeDir = $null
         foreach ($candidate in $SafeDirCandidates) {
@@ -1200,7 +1203,7 @@ exit 0
         # before this block existed, only with a reason attached.
         $StudioHomeFull = ""
         try { $StudioHomeFull = [System.IO.Path]::GetFullPath($StudioHome).TrimEnd('\') } catch {}
-        if ($SafeDir -and $StudioHomeFull.StartsWith($SystemRootDir, [System.StringComparison]::OrdinalIgnoreCase)) {
+        if ($SafeDir -and (Test-UnderSystemRoot $StudioHomeFull)) {
             Write-Host ""
             Write-Host "[ERROR] Unsloth would install into $StudioHomeFull," -ForegroundColor Red
             Write-Host "        which is inside $SystemRootDir." -ForegroundColor Yellow

--- a/install.ps1
+++ b/install.ps1
@@ -1132,6 +1132,76 @@ exit 0
         return
     }
 
+    # ── Leave Windows system directories before installing ──
+    # "Run as administrator" opens PowerShell in C:\Windows\System32, so `irm ... | iex`
+    # installs from there, and `unsloth studio setup` below inherits it and refuses to
+    # run (unsloth_cli/__init__.py) only after PyTorch has downloaded, then rolls back.
+    # Relocate rather than fail: nothing here reads the caller's directory ($RepoRoot
+    # comes from $PSCommandPath, $StudioHome from the environment, both resolved above),
+    # so only a relative --with-llama-cpp-dir needs pinning first. Not restored at the
+    # end, same reason as the PSModulePath fix at the top: the interactive path ends
+    # running Studio in the foreground, so a finally would not fire until it stops.
+    $SystemRootDir = if ($env:SystemRoot) { $env:SystemRoot } else { "C:\Windows" }
+    $SystemRootDir = [System.IO.Path]::GetFullPath($SystemRootDir).TrimEnd('\')
+    $CurrentDir = $null
+    try {
+        # -PSProvider FileSystem: a caller on HKLM:\ still has the filesystem
+        # location that child processes inherit.
+        $CurrentDir = [System.IO.Path]::GetFullPath(
+            (Get-Location -PSProvider FileSystem -ErrorAction Stop).ProviderPath
+        ).TrimEnd('\')
+    } catch {
+        $CurrentDir = $null
+    }
+    $InSystemDir = $CurrentDir -and (
+        $CurrentDir.Equals($SystemRootDir, [System.StringComparison]::OrdinalIgnoreCase) -or
+        $CurrentDir.StartsWith($SystemRootDir + '\', [System.StringComparison]::OrdinalIgnoreCase)
+    )
+    if ($InSystemDir) {
+        if ($WithLlamaCppDir -and -not [System.IO.Path]::IsPathRooted($WithLlamaCppDir)) {
+            $WithLlamaCppDir = Join-Path $CurrentDir $WithLlamaCppDir
+        }
+        # SYSTEM's profile is C:\Windows\System32\config\systemprofile, so a candidate
+        # under the Windows directory is no better than where we already are.
+        $SafeDirCandidates = @($env:USERPROFILE, $HOME, $env:PUBLIC, $env:TEMP) |
+            Where-Object {
+                $_ -and (Test-Path -LiteralPath $_ -PathType Container) -and
+                -not ([System.IO.Path]::GetFullPath($_).TrimEnd('\')).StartsWith(
+                    $SystemRootDir, [System.StringComparison]::OrdinalIgnoreCase
+                )
+            }
+        $SafeDir = $null
+        foreach ($candidate in $SafeDirCandidates) {
+            try {
+                Set-Location -LiteralPath $candidate -ErrorAction Stop
+                $SafeDir = (Get-Location -PSProvider FileSystem).ProviderPath
+                break
+            } catch {
+                continue
+            }
+        }
+        if ($SafeDir) {
+            Write-TauriLog "STEP" "Left system directory $CurrentDir for $SafeDir"
+            step "directory" "$CurrentDir is a Windows system folder" "Yellow"
+            substep "Unsloth cannot install or run from there, so this install continues in:" "Yellow"
+            substep "  $SafeDir" "Yellow"
+            substep "This is normal: 'Run as administrator' opens PowerShell in System32." "Yellow"
+        } else {
+            Write-Host ""
+            Write-Host "[ERROR] Unsloth cannot be installed from $CurrentDir." -ForegroundColor Red
+            Write-Host "        That is a Windows system folder, and Unsloth writes its virtual" -ForegroundColor Yellow
+            Write-Host "        environment caches, model downloads and build files into the" -ForegroundColor Yellow
+            Write-Host "        working directory, which Windows blocks there." -ForegroundColor Yellow
+            Write-Host "        'Run as administrator' opens PowerShell in System32, which is how" -ForegroundColor Yellow
+            Write-Host "        most people land here." -ForegroundColor Yellow
+            Write-Host "        Change to a normal folder and run the installer again:" -ForegroundColor Yellow
+            Write-Host "          cd `$env:USERPROFILE" -ForegroundColor Cyan
+            Write-Host "          irm https://unsloth.ai/install.ps1 | iex" -ForegroundColor Cyan
+            Write-Host ""
+            return (Exit-InstallFailure "Refusing to install from the Windows system directory $CurrentDir. cd to a normal folder (for example `$env:USERPROFILE) and re-run the installer.")
+        }
+    }
+
     # ── Check winget ──
     # winget is only needed to install Python or uv. If both are
     # already on PATH (Windows ARM64 GitHub-hosted runners, manual

--- a/install.ps1
+++ b/install.ps1
@@ -1133,24 +1133,20 @@ exit 0
     }
 
     # ── Leave Windows system directories before installing ──
-    # "Run as administrator" opens PowerShell in C:\Windows\System32, so `irm ... | iex`
-    # installs from there, and `unsloth studio setup` below inherits it and refuses to
-    # run (unsloth_cli/__init__.py) only after PyTorch has downloaded, then rolls back.
-    # Relocate rather than fail: nothing here reads the caller's directory ($RepoRoot
-    # comes from $PSCommandPath, $StudioHome from the environment, both resolved above),
-    # so --with-llama-cpp-dir is the only consumer input needing a rebase first. Not
-    # restored at the end, same reason as the PSModulePath fix at the top: the
-    # interactive path ends running Studio in the foreground, so a finally would not
-    # fire until it stops.
+    # "Run as administrator" starts in C:\Windows\System32, so `irm ... | iex` installs
+    # from there and `unsloth studio setup` refuses only after PyTorch has downloaded,
+    # then rolls back. Relocating is safe: nothing here reads the caller's directory
+    # ($RepoRoot from $PSCommandPath, $StudioHome from the environment), so only
+    # --with-llama-cpp-dir needs a rebase first. Not restored at the end, same reason as
+    # the PSModulePath fix at the top: the interactive path ends running Studio in the
+    # foreground, so a finally would not fire until it stops.
     $SystemRootDir = if ($env:SystemRoot) { $env:SystemRoot } else { "C:\Windows" }
     $SystemRootDir = [System.IO.Path]::GetFullPath($SystemRootDir).TrimEnd('\')
-    # Every containment test below compares against this, never the bare root: a prefix
-    # without the separator also swallows siblings like C:\Windows.old and C:\WindowsStudio.
+    # Separator included, or siblings like C:\Windows.old and C:\WindowsStudio match too.
     $SystemRootPrefix = $SystemRootDir + [System.IO.Path]::DirectorySeparatorChar
     $CurrentDir = $null
     try {
-        # -PSProvider FileSystem: a caller on HKLM:\ still has the filesystem
-        # location that child processes inherit.
+        # FileSystem provider: a caller parked on HKLM:\ still has the location children inherit.
         $CurrentDir = [System.IO.Path]::GetFullPath(
             (Get-Location -PSProvider FileSystem -ErrorAction Stop).ProviderPath
         ).TrimEnd('\')
@@ -1167,11 +1163,10 @@ exit 0
     $InSystemDir = Test-UnderSystemRoot $CurrentDir
     if ($InSystemDir) {
         if ($WithLlamaCppDir) {
-            # Anchor to the location the user typed it against. Covers the partially
-            # qualified forms (C:llama.cpp, \llama.cpp) that IsPathRooted calls rooted
-            # while Set-Location still moves them, and not [System.IO.Path]::GetFullPath,
-            # which resolves against [Environment]::CurrentDirectory -- a different
-            # directory that Set-Location never updates.
+            # Anchor to the directory the user typed it against, including the partially
+            # qualified forms (C:llama.cpp, \llama.cpp). Not [System.IO.Path]::GetFullPath,
+            # which resolves against [Environment]::CurrentDirectory, a separate location
+            # that Set-Location never updates.
             try {
                 $WithLlamaCppDir =
                     $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($WithLlamaCppDir)
@@ -1180,7 +1175,7 @@ exit 0
             }
         }
         # SYSTEM's profile is C:\Windows\System32\config\systemprofile, so a candidate
-        # under the Windows directory is no better than where we already are.
+        # inside the Windows directory is no better than where we already are.
         $SafeDirCandidates = @($env:USERPROFILE, $HOME, $env:PUBLIC, $env:TEMP) |
             Where-Object {
                 $_ -and (Test-Path -LiteralPath $_ -PathType Container) -and
@@ -1196,11 +1191,10 @@ exit 0
                 continue
             }
         }
-        # $StudioHome came from USERPROFILE, resolved long before this block, so a SYSTEM
-        # account would keep installing into C:\Windows\System32\config\systemprofile while
-        # we report having escaped. Rebasing it would orphan the install -- the runtime
-        # resolvers recompute the root from USERPROFILE -- so stop, which is what happened
-        # before this block existed, only with a reason attached.
+        # $StudioHome came from USERPROFILE far above, so a SYSTEM account would keep
+        # installing into C:\Windows\System32\config\systemprofile while we report having
+        # escaped. Rebasing it would orphan the install (the runtime resolvers recompute
+        # the root from USERPROFILE), so stop instead.
         $StudioHomeFull = ""
         try { $StudioHomeFull = [System.IO.Path]::GetFullPath($StudioHome).TrimEnd('\') } catch {}
         if ($SafeDir -and (Test-UnderSystemRoot $StudioHomeFull)) {
@@ -1228,9 +1222,8 @@ exit 0
             Write-Host "        working directory, which Windows blocks there." -ForegroundColor Yellow
             Write-Host "        'Run as administrator' opens PowerShell in System32, which is how" -ForegroundColor Yellow
             Write-Host "        most people land here." -ForegroundColor Yellow
-            # USERPROFILE was one of the candidates just rejected, so naming it here would
-            # send the user back into the same tree. A service or SYSTEM account is the
-            # usual reason nothing qualified, and its profile is where Studio would install.
+            # USERPROFILE was just rejected as a candidate, so naming it here would send
+            # the user back into the same tree.
             Write-Host "        Nothing outside $SystemRootDir was usable either (USERPROFILE," -ForegroundColor Yellow
             Write-Host "        HOME, PUBLIC, TEMP), which normally means a service or the SYSTEM" -ForegroundColor Yellow
             Write-Host "        account. Sign in as a normal user, open PowerShell there, and run" -ForegroundColor Yellow

--- a/tests/test_installer_system32_guard.py
+++ b/tests/test_installer_system32_guard.py
@@ -33,7 +33,7 @@ def _install_ps1() -> str:
 def test_install_ps1_leaves_system_directory_before_installing():
     """The guard must fire before winget/Python/uv/venv/PyTorch, not after the download."""
     src = _install_ps1()
-    guard_idx = src.index("$InSystemDir = $CurrentDir -and (")
+    guard_idx = src.index("$InSystemDir = Test-UnderSystemRoot $CurrentDir")
     for marker in (
         'step "winget" "available"',
         "uv venv $VenvDir --python",
@@ -59,7 +59,7 @@ def test_install_ps1_guard_covers_the_whole_windows_directory():
 
 def test_install_ps1_guard_relocates_and_keeps_relative_llama_cpp_dir():
     src = _install_ps1()
-    idx = src.index("$InSystemDir = $CurrentDir -and (")
+    idx = src.index("$InSystemDir = Test-UnderSystemRoot $CurrentDir")
     block = src[idx : idx + 3000]
     assert "Set-Location -LiteralPath $candidate" in block, "the guard must relocate, not just warn"
     llama_idx = block.index("GetUnresolvedProviderPathFromPSPath($WithLlamaCppDir)")
@@ -79,7 +79,7 @@ def test_install_ps1_guard_rejects_candidates_inside_the_windows_directory():
     idx = src.index("$SafeDirCandidates = @(")
     block = src[idx : idx + 700]
     assert (
-        "StartsWith(" in block and "$SystemRootDir" in block
+        "Test-UnderSystemRoot" in block
     ), "candidate directories under %SystemRoot% must be filtered out"
 
 
@@ -99,9 +99,16 @@ def test_install_ps1_guard_failure_message_is_actionable():
     assert "SYSTEM" in block, "name the account type that actually lands here"
 
 
+def _extract_helper() -> str:
+    """install.ps1's Test-UnderSystemRoot, verbatim, so the tests cannot drift from it."""
+    src = _install_ps1()
+    start = src.index("    function Test-UnderSystemRoot {")
+    return src[start : src.index("\n    }\n", start) + len("\n    }\n")]
+
+
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
 @pytest.mark.parametrize(
-    ("current_dir", "expected"),
+    ("path", "expected"),
     [
         (r"C:\Windows\System32", "True"),
         (r"c:\windows\system32", "True"),
@@ -109,24 +116,22 @@ def test_install_ps1_guard_failure_message_is_actionable():
         (r"C:\Windows\SysWOW64", "True"),
         (r"C:\Windows", "True"),
         (r"C:\Users\me", "False"),
+        # Siblings sharing the prefix. Rejecting these would abort an install with a
+        # supported absolute UNSLOTH_STUDIO_HOME override.
         (r"C:\Windows2", "False"),
         (r"C:\WindowsApps\stuff", "False"),
+        (r"C:\WindowsStudio", "False"),
+        (r"C:\Windows.old\Users\me", "False"),
     ],
 )
-def test_install_ps1_system_dir_match(current_dir: str, expected: str):
-    """Run the extracted match expression against Windows-shaped paths (works on any pwsh host)."""
-    src = _install_ps1()
-    match = re.search(
-        r"\$InSystemDir = \$CurrentDir -and \(\n.*?\n    \)\n",
-        src,
-        flags = re.DOTALL,
-    )
-    assert match is not None, "install.ps1 $InSystemDir expression not found"
+def test_install_ps1_under_system_root(path: str, expected: str):
+    """Windows-shaped paths through the real helper; the separator is injected, since a
+    pwsh on Linux reports / for DirectorySeparatorChar."""
     script = (
-        f"$SystemRootDir = 'C:\\Windows'\n"
-        f"$CurrentDir = '{current_dir}'\n"
-        f"{match.group(0)}"
-        '"RESULT=$InSystemDir"\n'
+        "$SystemRootDir = 'C:\\Windows'\n"
+        "$SystemRootPrefix = 'C:\\Windows\\'\n"
+        f"{_extract_helper()}"
+        f"\"RESULT=$(Test-UnderSystemRoot '{path}')\"\n"
     )
     result = subprocess.run(
         ["pwsh", "-NoProfile", "-NonInteractive", "-Command", script],
@@ -136,6 +141,15 @@ def test_install_ps1_system_dir_match(current_dir: str, expected: str):
     )
     assert result.returncode == 0, result.stderr
     assert f"RESULT={expected}" in result.stdout, result.stdout
+
+
+def test_install_ps1_containment_has_a_path_boundary():
+    src = _install_ps1()
+    assert (
+        "$SystemRootPrefix = $SystemRootDir + [System.IO.Path]::DirectorySeparatorChar" in src
+    ), "the prefix must carry a separator so siblings are not swallowed"
+    helper = _extract_helper()
+    assert "$SystemRootPrefix" in helper and "$SystemRootDir + '\\'" not in helper
 
 
 def _extract_relocation_block() -> str:
@@ -169,6 +183,8 @@ def _run_relocation_block(
         + f"$CurrentDir = '{current_dir}'\n"
         + f"$WithLlamaCppDir = '{with_llama_cpp_dir}'\n"
         + f"$StudioHome = '{studio_home or (home_env / '.unsloth' / 'studio')}'\n"
+        + "$SystemRootPrefix = $SystemRootDir + [System.IO.Path]::DirectorySeparatorChar\n"
+        + _extract_helper()
         + "Set-Location -LiteralPath $CurrentDir\n"
         + _extract_relocation_block()
         + '\nWrite-Host "CWD:$((Get-Location).ProviderPath)"\n'
@@ -249,6 +265,26 @@ def test_relocation_block_refuses_a_studio_home_under_the_system_root(tmp_path):
     assert "would install into" in res.stdout
     assert "normal user account" in res.stdout
     assert "FAILED:" in res.stdout, "must route through Exit-InstallFailure for rollback"
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
+def test_relocation_block_allows_a_studio_home_beside_the_system_root(tmp_path):
+    """UNSLOTH_STUDIO_HOME=C:\\WindowsStudio is a supported absolute override, not a descendant."""
+    system_root = tmp_path / "Windows"
+    current_dir = system_root / "System32"
+    current_dir.mkdir(parents = True)
+    home = tmp_path / "home"
+    home.mkdir()
+    res = _run_relocation_block(
+        tmp_path,
+        system_root,
+        current_dir,
+        home,
+        studio_home = tmp_path / "WindowsStudio",
+    )
+    assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr!r}"
+    assert "would install into" not in res.stdout, "a sibling of the Windows directory is fine"
+    assert f"CWD:{home}" in res.stdout
 
 
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")

--- a/tests/test_installer_system32_guard.py
+++ b/tests/test_installer_system32_guard.py
@@ -62,10 +62,14 @@ def test_install_ps1_guard_relocates_and_keeps_relative_llama_cpp_dir():
     idx = src.index("$InSystemDir = $CurrentDir -and (")
     block = src[idx : idx + 3000]
     assert "Set-Location -LiteralPath $candidate" in block, "the guard must relocate, not just warn"
-    llama_idx = block.index("$WithLlamaCppDir = Join-Path $CurrentDir $WithLlamaCppDir")
+    llama_idx = block.index("GetUnresolvedProviderPathFromPSPath($WithLlamaCppDir)")
     set_loc_idx = block.index("Set-Location -LiteralPath $candidate")
     assert llama_idx < set_loc_idx, (
-        "a relative --with-llama-cpp-dir must be pinned to the original directory before Set-Location"
+        "--with-llama-cpp-dir must be pinned to the original directory before Set-Location"
+    )
+    assert "GetFullPath($WithLlamaCppDir)" not in block, (
+        "GetFullPath resolves against [Environment]::CurrentDirectory, which Set-Location "
+        "does not update; the PSPath resolver follows the PowerShell location"
     )
 
 
@@ -208,6 +212,23 @@ def test_relocation_block_moves_out_and_rebases_relative_llama_cpp_dir(tmp_path)
 
 
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
+def test_relocation_block_leaves_a_fully_qualified_llama_cpp_dir_alone(tmp_path):
+    system_root = tmp_path / "Windows"
+    current_dir = system_root / "System32"
+    current_dir.mkdir(parents = True)
+    home = tmp_path / "home"
+    home.mkdir()
+    absolute = tmp_path / "elsewhere" / "llama.cpp"
+    res = _run_relocation_block(
+        tmp_path, system_root, current_dir, home, with_llama_cpp_dir = str(absolute)
+    )
+    assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr!r}"
+    assert f"LLAMA:{absolute}" in res.stdout, (
+        "an already qualified path must pass through untouched"
+    )
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
 def test_relocation_block_fails_fast_when_every_candidate_is_a_system_directory(tmp_path):
     """No safe directory (SYSTEM account: profile lives under System32) must fail before any install work."""
     system_root = tmp_path / "Windows"
@@ -234,6 +255,7 @@ def _run_cli_guard(
     cwd: str,
     argv: list[str] | None = None,
     userprofile: str = r"C:\Users\me",
+    public: str | None = None,
 ) -> tuple[str | None, int | None]:
     """Exec the CLI's win32 guard block with ntpath semantics; returns (message, exit code)."""
     src = CLI_INIT.read_text(encoding = "utf-8")
@@ -252,12 +274,23 @@ def _run_cli_guard(
     ):
         captured["message"] = message
 
+    environ = {"WINDIR": r"C:\Windows", "USERPROFILE": userprofile}
+    if public is not None:
+        environ["PUBLIC"] = public
     fake_typer = types.SimpleNamespace(secho = _secho, Exit = _FakeExit)
+    # ntpath for the path semantics, but expanduser has to be pinned: the real one reads
+    # the host's HOME, and on Windows "~" is USERPROFILE, SYSTEM's included.
+    fake_path = types.SimpleNamespace(
+        normcase = ntpath.normcase,
+        normpath = ntpath.normpath,
+        join = ntpath.join,
+        expanduser = lambda _p: userprofile,
+    )
     fake_os = types.SimpleNamespace(
-        path = ntpath,
+        path = fake_path,
         sep = "\\",
         getcwd = lambda: cwd,
-        environ = {"WINDIR": r"C:\Windows", "USERPROFILE": userprofile},
+        environ = environ,
     )
     fake_sys = types.SimpleNamespace(platform = "win32", argv = argv or ["unsloth", "studio", "setup"])
 
@@ -347,6 +380,31 @@ def test_cli_guard_cd_lines_are_quoted(profile_name: str):
     assert message is not None
     assert _cd_line(message, "PowerShell") == "cd '" + profile.replace("'", "''") + "'"
     assert _cd_line(message, "cmd.exe") == 'cd /d "' + profile + '"'
+
+
+def test_cli_guard_skips_a_system_account_home():
+    """SYSTEM's USERPROFILE is under System32, so the cd would land back in the guard."""
+    message, code = _run_cli_guard(
+        r"C:\Windows\System32",
+        userprofile = r"C:\Windows\System32\config\systemprofile",
+        public = r"C:\Users\Public",
+    )
+    assert code == 1
+    assert message is not None
+    assert "systemprofile" not in message, "must not advertise a home inside the Windows tree"
+    assert _cd_line(message, "PowerShell") == "cd 'C:\\Users\\Public'"
+
+
+def test_cli_guard_omits_the_cd_line_when_every_home_is_a_system_directory():
+    message, code = _run_cli_guard(
+        r"C:\Windows\System32",
+        userprofile = r"C:\Windows\System32\config\systemprofile",
+        public = r"C:\Windows\Temp",
+    )
+    assert code == 1
+    assert message is not None
+    assert "cd " not in message, "no pasteable path is better than one that fails again"
+    assert r"any folder outside C:\Windows" in message
 
 
 def test_cli_guard_message_repeats_the_actual_command():

--- a/tests/test_installer_system32_guard.py
+++ b/tests/test_installer_system32_guard.py
@@ -51,9 +51,9 @@ def test_install_ps1_guard_covers_the_whole_windows_directory():
     idx = src.index("$SystemRootDir = if ($env:SystemRoot)")
     block = src[idx : idx + 2500]
     assert '{ "C:\\Windows" }' in block, "SystemRoot must fall back to C:\\Windows"
-    assert "Get-Location -PSProvider FileSystem" in block, (
-        "the guard must read the filesystem location so a caller parked on HKLM:\\ is still checked"
-    )
+    assert (
+        "Get-Location -PSProvider FileSystem" in block
+    ), "the guard must read the filesystem location so a caller parked on HKLM:\\ is still checked"
     assert "OrdinalIgnoreCase" in block, "Windows paths compare case-insensitively"
 
 
@@ -64,9 +64,9 @@ def test_install_ps1_guard_relocates_and_keeps_relative_llama_cpp_dir():
     assert "Set-Location -LiteralPath $candidate" in block, "the guard must relocate, not just warn"
     llama_idx = block.index("GetUnresolvedProviderPathFromPSPath($WithLlamaCppDir)")
     set_loc_idx = block.index("Set-Location -LiteralPath $candidate")
-    assert llama_idx < set_loc_idx, (
-        "--with-llama-cpp-dir must be pinned to the original directory before Set-Location"
-    )
+    assert (
+        llama_idx < set_loc_idx
+    ), "--with-llama-cpp-dir must be pinned to the original directory before Set-Location"
     assert "GetFullPath($WithLlamaCppDir)" not in block, (
         "GetFullPath resolves against [Environment]::CurrentDirectory, which Set-Location "
         "does not update; the PSPath resolver follows the PowerShell location"
@@ -78,9 +78,9 @@ def test_install_ps1_guard_rejects_candidates_inside_the_windows_directory():
     src = _install_ps1()
     idx = src.index("$SafeDirCandidates = @(")
     block = src[idx : idx + 700]
-    assert "StartsWith(" in block and "$SystemRootDir" in block, (
-        "candidate directories under %SystemRoot% must be filtered out"
-    )
+    assert (
+        "StartsWith(" in block and "$SystemRootDir" in block
+    ), "candidate directories under %SystemRoot% must be filtered out"
 
 
 def test_install_ps1_guard_failure_message_is_actionable():
@@ -210,9 +210,9 @@ def test_relocation_block_moves_out_and_rebases_relative_llama_cpp_dir(tmp_path)
     assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr!r}"
     assert f"CWD:{home}" in res.stdout, f"must relocate to the home directory; got {res.stdout!r}"
     assert "Windows system folder" in res.stdout, "the user must be told why the directory changed"
-    assert f"LLAMA:{current_dir / 'llama.cpp'}" in res.stdout, (
-        "a relative --with-llama-cpp-dir must still resolve against the original directory"
-    )
+    assert (
+        f"LLAMA:{current_dir / 'llama.cpp'}" in res.stdout
+    ), "a relative --with-llama-cpp-dir must still resolve against the original directory"
 
 
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
@@ -227,9 +227,9 @@ def test_relocation_block_leaves_a_fully_qualified_llama_cpp_dir_alone(tmp_path)
         tmp_path, system_root, current_dir, home, with_llama_cpp_dir = str(absolute)
     )
     assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr!r}"
-    assert f"LLAMA:{absolute}" in res.stdout, (
-        "an already qualified path must pass through untouched"
-    )
+    assert (
+        f"LLAMA:{absolute}" in res.stdout
+    ), "an already qualified path must pass through untouched"
 
 
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
@@ -416,6 +416,6 @@ def test_cli_guard_message_repeats_the_actual_command():
         r"C:\Windows\System32", argv = ["unsloth", "train", "--model", "my model"]
     )
     assert message is not None
-    assert 'unsloth train --model "my model"' in message, (
-        "the retry line must reproduce the invoked command, re-quoting arguments with spaces"
-    )
+    assert (
+        'unsloth train --model "my model"' in message
+    ), "the retry line must reproduce the invoked command, re-quoting arguments with spaces"

--- a/tests/test_installer_system32_guard.py
+++ b/tests/test_installer_system32_guard.py
@@ -50,9 +50,9 @@ def test_install_ps1_guard_covers_the_whole_windows_directory():
     idx = src.index("$SystemRootDir = if ($env:SystemRoot)")
     block = src[idx : idx + 2500]
     assert '{ "C:\\Windows" }' in block, "SystemRoot must fall back to C:\\Windows"
-    assert "Get-Location -PSProvider FileSystem" in block, (
-        "the guard must read the filesystem location so a caller parked on HKLM:\\ is still checked"
-    )
+    assert (
+        "Get-Location -PSProvider FileSystem" in block
+    ), "the guard must read the filesystem location so a caller parked on HKLM:\\ is still checked"
     assert "OrdinalIgnoreCase" in block, "Windows paths compare case-insensitively"
 
 
@@ -63,9 +63,9 @@ def test_install_ps1_guard_relocates_and_keeps_relative_llama_cpp_dir():
     assert "Set-Location -LiteralPath $candidate" in block, "the guard must relocate, not just warn"
     llama_idx = block.index("$WithLlamaCppDir = Join-Path $CurrentDir $WithLlamaCppDir")
     set_loc_idx = block.index("Set-Location -LiteralPath $candidate")
-    assert llama_idx < set_loc_idx, (
-        "a relative --with-llama-cpp-dir must be pinned to the original directory before Set-Location"
-    )
+    assert (
+        llama_idx < set_loc_idx
+    ), "a relative --with-llama-cpp-dir must be pinned to the original directory before Set-Location"
 
 
 def test_install_ps1_guard_rejects_candidates_inside_the_windows_directory():
@@ -73,9 +73,9 @@ def test_install_ps1_guard_rejects_candidates_inside_the_windows_directory():
     src = _install_ps1()
     idx = src.index("$SafeDirCandidates = @(")
     block = src[idx : idx + 700]
-    assert "StartsWith(" in block and "$SystemRootDir" in block, (
-        "candidate directories under %SystemRoot% must be filtered out"
-    )
+    assert (
+        "StartsWith(" in block and "$SystemRootDir" in block
+    ), "candidate directories under %SystemRoot% must be filtered out"
 
 
 def test_install_ps1_guard_failure_message_is_actionable():
@@ -192,9 +192,9 @@ def test_relocation_block_moves_out_and_rebases_relative_llama_cpp_dir(tmp_path)
     assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr!r}"
     assert f"CWD:{home}" in res.stdout, f"must relocate to the home directory; got {res.stdout!r}"
     assert "Windows system folder" in res.stdout, "the user must be told why the directory changed"
-    assert f"LLAMA:{current_dir / 'llama.cpp'}" in res.stdout, (
-        "a relative --with-llama-cpp-dir must still resolve against the original directory"
-    )
+    assert (
+        f"LLAMA:{current_dir / 'llama.cpp'}" in res.stdout
+    ), "a relative --with-llama-cpp-dir must still resolve against the original directory"
 
 
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
@@ -292,6 +292,6 @@ def test_cli_guard_message_repeats_the_actual_command():
         r"C:\Windows\System32", argv = ["unsloth", "train", "--model", "my model"]
     )
     assert message is not None
-    assert 'unsloth train --model "my model"' in message, (
-        "the retry line must reproduce the invoked command, re-quoting arguments with spaces"
-    )
+    assert (
+        'unsloth train --model "my model"' in message
+    ), "the retry line must reproduce the invoked command, re-quoting arguments with spaces"

--- a/tests/test_installer_system32_guard.py
+++ b/tests/test_installer_system32_guard.py
@@ -9,6 +9,7 @@ to get out of it."""
 from __future__ import annotations
 
 import ntpath
+import os
 import re
 import shutil
 import subprocess
@@ -163,13 +164,22 @@ def _run_relocation_block(
         + '\nWrite-Host "CWD:$((Get-Location).ProviderPath)"\n'
         + 'Write-Host "LLAMA:$WithLlamaCppDir"\n'
     )
-    env = {
-        "PATH": "/usr/bin:/bin",
-        "HOME": str(home_env),
-        "USERPROFILE": str(home_env),
-        "PUBLIC": str(home_env),
-        "TEMP": str(home_env),
-    }
+    # Inherit the real environment (pwsh needs PATH and SystemRoot on Windows) and point
+    # every home-ish variable at the fixture. HOMEDRIVE/HOMEPATH too: that pair is where
+    # PowerShell gets $HOME on Windows, and a stale one would look like a safe directory.
+    env = dict(os.environ)
+    drive, tail = os.path.splitdrive(str(home_env))
+    env.update(
+        {
+            "HOME": str(home_env),
+            "USERPROFILE": str(home_env),
+            "PUBLIC": str(home_env),
+            "TEMP": str(home_env),
+            "TMP": str(home_env),
+            "HOMEDRIVE": drive,
+            "HOMEPATH": tail,
+        }
+    )
     return subprocess.run(
         ["pwsh", "-NoProfile", "-NonInteractive", "-Command", script],
         capture_output = True,

--- a/tests/test_installer_system32_guard.py
+++ b/tests/test_installer_system32_guard.py
@@ -160,6 +160,7 @@ def _run_relocation_block(
     current_dir: Path,
     home_env: Path,
     with_llama_cpp_dir: str = "",
+    studio_home: Path | None = None,
 ) -> subprocess.CompletedProcess:
     """Run the relocation body on the host's own filesystem (no '\\' concatenation in it)."""
     script = (
@@ -167,6 +168,7 @@ def _run_relocation_block(
         + f"$SystemRootDir = '{system_root}'\n"
         + f"$CurrentDir = '{current_dir}'\n"
         + f"$WithLlamaCppDir = '{with_llama_cpp_dir}'\n"
+        + f"$StudioHome = '{studio_home or (home_env / '.unsloth' / 'studio')}'\n"
         + "Set-Location -LiteralPath $CurrentDir\n"
         + _extract_relocation_block()
         + '\nWrite-Host "CWD:$((Get-Location).ProviderPath)"\n'
@@ -230,6 +232,23 @@ def test_relocation_block_leaves_a_fully_qualified_llama_cpp_dir_alone(tmp_path)
     assert (
         f"LLAMA:{absolute}" in res.stdout
     ), "an already qualified path must pass through untouched"
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
+def test_relocation_block_refuses_a_studio_home_under_the_system_root(tmp_path):
+    """Relocating the CWD does not move $StudioHome, which SYSTEM resolves to
+    C:\\Windows\\System32\\config\\systemprofile\\.unsloth\\studio: fail rather than install there."""
+    system_root = tmp_path / "Windows"
+    current_dir = system_root / "System32"
+    current_dir.mkdir(parents = True)
+    home = tmp_path / "home"
+    home.mkdir()
+    studio_home = system_root / "System32" / "config" / "systemprofile" / ".unsloth" / "studio"
+    res = _run_relocation_block(tmp_path, system_root, current_dir, home, studio_home = studio_home)
+    assert res.returncode == 42, f"stdout={res.stdout!r} stderr={res.stderr!r}"
+    assert "would install into" in res.stdout
+    assert "normal user account" in res.stdout
+    assert "FAILED:" in res.stdout, "must route through Exit-InstallFailure for rollback"
 
 
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")

--- a/tests/test_installer_system32_guard.py
+++ b/tests/test_installer_system32_guard.py
@@ -51,9 +51,9 @@ def test_install_ps1_guard_covers_the_whole_windows_directory():
     idx = src.index("$SystemRootDir = if ($env:SystemRoot)")
     block = src[idx : idx + 2500]
     assert '{ "C:\\Windows" }' in block, "SystemRoot must fall back to C:\\Windows"
-    assert "Get-Location -PSProvider FileSystem" in block, (
-        "the guard must read the filesystem location so a caller parked on HKLM:\\ is still checked"
-    )
+    assert (
+        "Get-Location -PSProvider FileSystem" in block
+    ), "the guard must read the filesystem location so a caller parked on HKLM:\\ is still checked"
     assert "OrdinalIgnoreCase" in block, "Windows paths compare case-insensitively"
 
 
@@ -64,9 +64,9 @@ def test_install_ps1_guard_relocates_and_keeps_relative_llama_cpp_dir():
     assert "Set-Location -LiteralPath $candidate" in block, "the guard must relocate, not just warn"
     llama_idx = block.index("GetUnresolvedProviderPathFromPSPath($WithLlamaCppDir)")
     set_loc_idx = block.index("Set-Location -LiteralPath $candidate")
-    assert llama_idx < set_loc_idx, (
-        "--with-llama-cpp-dir must be pinned to the original directory before Set-Location"
-    )
+    assert (
+        llama_idx < set_loc_idx
+    ), "--with-llama-cpp-dir must be pinned to the original directory before Set-Location"
     assert "GetFullPath($WithLlamaCppDir)" not in block, (
         "GetFullPath resolves against [Environment]::CurrentDirectory, which Set-Location "
         "does not update; the PSPath resolver follows the PowerShell location"
@@ -78,9 +78,9 @@ def test_install_ps1_guard_rejects_candidates_inside_the_windows_directory():
     src = _install_ps1()
     idx = src.index("$SafeDirCandidates = @(")
     block = src[idx : idx + 700]
-    assert "StartsWith(" in block and "$SystemRootDir" in block, (
-        "candidate directories under %SystemRoot% must be filtered out"
-    )
+    assert (
+        "StartsWith(" in block and "$SystemRootDir" in block
+    ), "candidate directories under %SystemRoot% must be filtered out"
 
 
 def test_install_ps1_guard_failure_message_is_actionable():
@@ -206,9 +206,9 @@ def test_relocation_block_moves_out_and_rebases_relative_llama_cpp_dir(tmp_path)
     assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr!r}"
     assert f"CWD:{home}" in res.stdout, f"must relocate to the home directory; got {res.stdout!r}"
     assert "Windows system folder" in res.stdout, "the user must be told why the directory changed"
-    assert f"LLAMA:{current_dir / 'llama.cpp'}" in res.stdout, (
-        "a relative --with-llama-cpp-dir must still resolve against the original directory"
-    )
+    assert (
+        f"LLAMA:{current_dir / 'llama.cpp'}" in res.stdout
+    ), "a relative --with-llama-cpp-dir must still resolve against the original directory"
 
 
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
@@ -223,9 +223,9 @@ def test_relocation_block_leaves_a_fully_qualified_llama_cpp_dir_alone(tmp_path)
         tmp_path, system_root, current_dir, home, with_llama_cpp_dir = str(absolute)
     )
     assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr!r}"
-    assert f"LLAMA:{absolute}" in res.stdout, (
-        "an already qualified path must pass through untouched"
-    )
+    assert (
+        f"LLAMA:{absolute}" in res.stdout
+    ), "an already qualified path must pass through untouched"
 
 
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
@@ -412,6 +412,6 @@ def test_cli_guard_message_repeats_the_actual_command():
         r"C:\Windows\System32", argv = ["unsloth", "train", "--model", "my model"]
     )
     assert message is not None
-    assert 'unsloth train --model "my model"' in message, (
-        "the retry line must reproduce the invoked command, re-quoting arguments with spaces"
-    )
+    assert (
+        'unsloth train --model "my model"' in message
+    ), "the retry line must reproduce the invoked command, re-quoting arguments with spaces"

--- a/tests/test_installer_system32_guard.py
+++ b/tests/test_installer_system32_guard.py
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""Regression tests for the System32 working-directory guards: install.ps1 must leave C:\\Windows before it
-spends minutes on PyTorch (elevated PowerShell starts in System32, so `irm ... | iex` used to fail there with
-"unsloth studio setup failed (exit code 1)" plus a rollback), and the CLI guard must say which folder and how
-to get out of it."""
+"""Regression tests for the System32 working-directory guards: elevated PowerShell starts in System32, so
+install.ps1 must leave C:\\Windows before spending minutes on PyTorch (it used to fail there only after the
+download, then roll back), and the CLI guard must name the folder and how to get out of it."""
 
 from __future__ import annotations
 
@@ -84,7 +83,7 @@ def test_install_ps1_guard_rejects_candidates_inside_the_windows_directory():
 
 
 def test_install_ps1_guard_failure_message_is_actionable():
-    """With nowhere safe to go, the error must say where the user is, why, and what to type."""
+    """With nowhere safe to go, say where the user is, why, and what to type."""
     src = _install_ps1()
     idx = src.index("[ERROR] Unsloth cannot be installed from $CurrentDir.")
     block = src[idx : src.index("\n        }\n", idx)]
@@ -116,7 +115,7 @@ def _extract_helper() -> str:
         (r"C:\Windows\SysWOW64", "True"),
         (r"C:\Windows", "True"),
         (r"C:\Users\me", "False"),
-        # Siblings sharing the prefix. Rejecting these would abort an install with a
+        # Siblings sharing the prefix: rejecting these would abort an install with a
         # supported absolute UNSLOTH_STUDIO_HOME override.
         (r"C:\Windows2", "False"),
         (r"C:\WindowsApps\stuff", "False"),
@@ -125,8 +124,7 @@ def _extract_helper() -> str:
     ],
 )
 def test_install_ps1_under_system_root(path: str, expected: str):
-    """Windows-shaped paths through the real helper; the separator is injected, since a
-    pwsh on Linux reports / for DirectorySeparatorChar."""
+    """The separator is injected because pwsh on Linux reports / for DirectorySeparatorChar."""
     script = (
         "$SystemRootDir = 'C:\\Windows'\n"
         "$SystemRootPrefix = 'C:\\Windows\\'\n"
@@ -190,9 +188,9 @@ def _run_relocation_block(
         + '\nWrite-Host "CWD:$((Get-Location).ProviderPath)"\n'
         + 'Write-Host "LLAMA:$WithLlamaCppDir"\n'
     )
-    # Inherit the real environment (pwsh needs PATH and SystemRoot on Windows) and point
-    # every home-ish variable at the fixture. HOMEDRIVE/HOMEPATH too: that pair is where
-    # PowerShell gets $HOME on Windows, and a stale one would look like a safe directory.
+    # Inherit the real environment (pwsh needs PATH and SystemRoot) and repoint every
+    # home-ish variable at the fixture. HOMEDRIVE/HOMEPATH too: PowerShell builds $HOME
+    # from that pair on Windows, and a stale one would look like a safe directory.
     env = dict(os.environ)
     drive, tail = os.path.splitdrive(str(home_env))
     env.update(
@@ -252,8 +250,8 @@ def test_relocation_block_leaves_a_fully_qualified_llama_cpp_dir_alone(tmp_path)
 
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
 def test_relocation_block_refuses_a_studio_home_under_the_system_root(tmp_path):
-    """Relocating the CWD does not move $StudioHome, which SYSTEM resolves to
-    C:\\Windows\\System32\\config\\systemprofile\\.unsloth\\studio: fail rather than install there."""
+    """Relocating the CWD does not move $StudioHome, which SYSTEM resolves under
+    System32\\config\\systemprofile: fail rather than install there."""
     system_root = tmp_path / "Windows"
     current_dir = system_root / "System32"
     current_dir.mkdir(parents = True)
@@ -289,7 +287,7 @@ def test_relocation_block_allows_a_studio_home_beside_the_system_root(tmp_path):
 
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
 def test_relocation_block_fails_fast_when_every_candidate_is_a_system_directory(tmp_path):
-    """No safe directory (SYSTEM account: profile lives under System32) must fail before any install work."""
+    """A SYSTEM account's profile lives under System32, so nothing qualifies: fail before any install work."""
     system_root = tmp_path / "Windows"
     current_dir = system_root / "System32"
     current_dir.mkdir(parents = True)
@@ -337,8 +335,8 @@ def _run_cli_guard(
     if public is not None:
         environ["PUBLIC"] = public
     fake_typer = types.SimpleNamespace(secho = _secho, Exit = _FakeExit)
-    # ntpath for the path semantics, but expanduser has to be pinned: the real one reads
-    # the host's HOME, and on Windows "~" is USERPROFILE, SYSTEM's included.
+    # ntpath for the path semantics, with expanduser pinned: the real one reads the host's
+    # HOME, and on Windows "~" is USERPROFILE, SYSTEM's included.
     fake_path = types.SimpleNamespace(
         normcase = ntpath.normcase,
         normpath = ntpath.normpath,
@@ -403,17 +401,14 @@ def _cd_line(message: str, shell: str) -> str:
     "profile_name",
     [
         "me",
-        "Jane Doe",  # a space: `cd C:\Users\Jane Doe` binds 'Doe' as a second argument
-        "O'Brien",  # an apostrophe: single quotes must be escaped by doubling
+        "Jane Doe",  # space: `cd C:\Users\Jane Doe` binds 'Doe' as a second argument
+        "O'Brien",  # apostrophe: single quotes must be escaped by doubling
     ],
 )
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
 def test_cli_guard_cd_line_actually_runs_in_powershell(profile_name: str, tmp_path):
-    """The advertised recovery command must survive a paste, not just read well.
-
-    Set-Location takes one -Path, so an unquoted profile with a space fails with
-    "A positional parameter cannot be found that accepts argument 'Doe'".
-    """
+    """The advertised recovery command must survive a paste: Set-Location takes one -Path,
+    so an unquoted profile with a space fails."""
     profile = tmp_path / profile_name
     profile.mkdir()
     message, _ = _run_cli_guard(r"C:\Windows\System32", userprofile = str(profile))
@@ -431,9 +426,8 @@ def test_cli_guard_cd_line_actually_runs_in_powershell(profile_name: str, tmp_pa
 
 @pytest.mark.parametrize("profile_name", ["me", "Jane Doe", "O'Brien"])
 def test_cli_guard_cd_lines_are_quoted(profile_name: str):
-    """Both shells get a quoted path; " is not legal in a Windows path, so cmd's
-    double quotes cannot be broken out of, and PowerShell's single quotes are
-    verbatim (no $var expansion) with '' escaping an embedded apostrophe."""
+    """Both shells get a quoted path: cmd's double quotes cannot be broken out of (" is not
+    legal in a Windows path) and PowerShell's are verbatim, with '' escaping an apostrophe."""
     profile = "C:\\Users\\" + profile_name
     message, _ = _run_cli_guard(r"C:\Windows\System32", userprofile = profile)
     assert message is not None

--- a/tests/test_installer_system32_guard.py
+++ b/tests/test_installer_system32_guard.py
@@ -1,0 +1,297 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Regression tests for the System32 working-directory guards: install.ps1 must leave C:\\Windows before it
+spends minutes on PyTorch (elevated PowerShell starts in System32, so `irm ... | iex` used to fail there with
+"unsloth studio setup failed (exit code 1)" plus a rollback), and the CLI guard must say which folder and how
+to get out of it."""
+
+from __future__ import annotations
+
+import ntpath
+import re
+import shutil
+import subprocess
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_PS1 = REPO_ROOT / "install.ps1"
+CLI_INIT = REPO_ROOT / "unsloth_cli" / "__init__.py"
+
+
+# ── install.ps1: relocate before doing any work ──
+
+
+def _install_ps1() -> str:
+    return INSTALL_PS1.read_text(encoding = "utf-8")
+
+
+def test_install_ps1_leaves_system_directory_before_installing():
+    """The guard must fire before winget/Python/uv/venv/PyTorch, not after the download."""
+    src = _install_ps1()
+    guard_idx = src.index("$InSystemDir = $CurrentDir -and (")
+    for marker in (
+        'step "winget" "available"',
+        "uv venv $VenvDir --python",
+        'step "setup" "running unsloth studio setup..."',
+    ):
+        assert guard_idx < src.index(marker), (
+            f"the system-directory guard must run before {marker!r}; installing from System32 "
+            "otherwise fails only after PyTorch has downloaded"
+        )
+
+
+def test_install_ps1_guard_covers_the_whole_windows_directory():
+    """%SystemRoot%, not just System32: SysWOW64 and WinSxS are equally unusable."""
+    src = _install_ps1()
+    idx = src.index("$SystemRootDir = if ($env:SystemRoot)")
+    block = src[idx : idx + 2500]
+    assert '{ "C:\\Windows" }' in block, "SystemRoot must fall back to C:\\Windows"
+    assert "Get-Location -PSProvider FileSystem" in block, (
+        "the guard must read the filesystem location so a caller parked on HKLM:\\ is still checked"
+    )
+    assert "OrdinalIgnoreCase" in block, "Windows paths compare case-insensitively"
+
+
+def test_install_ps1_guard_relocates_and_keeps_relative_llama_cpp_dir():
+    src = _install_ps1()
+    idx = src.index("$InSystemDir = $CurrentDir -and (")
+    block = src[idx : idx + 3000]
+    assert "Set-Location -LiteralPath $candidate" in block, "the guard must relocate, not just warn"
+    llama_idx = block.index("$WithLlamaCppDir = Join-Path $CurrentDir $WithLlamaCppDir")
+    set_loc_idx = block.index("Set-Location -LiteralPath $candidate")
+    assert llama_idx < set_loc_idx, (
+        "a relative --with-llama-cpp-dir must be pinned to the original directory before Set-Location"
+    )
+
+
+def test_install_ps1_guard_rejects_candidates_inside_the_windows_directory():
+    """SYSTEM's profile is C:\\Windows\\System32\\config\\systemprofile: relocating there fixes nothing."""
+    src = _install_ps1()
+    idx = src.index("$SafeDirCandidates = @(")
+    block = src[idx : idx + 700]
+    assert "StartsWith(" in block and "$SystemRootDir" in block, (
+        "candidate directories under %SystemRoot% must be filtered out"
+    )
+
+
+def test_install_ps1_guard_failure_message_is_actionable():
+    """With nowhere safe to go, the error must say where the user is, why, and what to type."""
+    src = _install_ps1()
+    idx = src.index("[ERROR] Unsloth cannot be installed from $CurrentDir.")
+    block = src[idx : idx + 1500]
+    assert "Windows system folder" in block
+    assert "Run as administrator" in block, "explain how the user got into System32"
+    assert "cd `$env:USERPROFILE" in block, "give the exact cd command"
+    assert "irm https://unsloth.ai/install.ps1 | iex" in block, "give the exact re-run command"
+    assert "Exit-InstallFailure" in block, "must go through the rollback-aware failure path"
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
+@pytest.mark.parametrize(
+    ("current_dir", "expected"),
+    [
+        (r"C:\Windows\System32", "True"),
+        (r"c:\windows\system32", "True"),
+        (r"C:\Windows\System32\drivers\etc", "True"),
+        (r"C:\Windows\SysWOW64", "True"),
+        (r"C:\Windows", "True"),
+        (r"C:\Users\me", "False"),
+        (r"C:\Windows2", "False"),
+        (r"C:\WindowsApps\stuff", "False"),
+    ],
+)
+def test_install_ps1_system_dir_match(current_dir: str, expected: str):
+    """Run the extracted match expression against Windows-shaped paths (works on any pwsh host)."""
+    src = _install_ps1()
+    match = re.search(
+        r"\$InSystemDir = \$CurrentDir -and \(\n.*?\n    \)\n",
+        src,
+        flags = re.DOTALL,
+    )
+    assert match is not None, "install.ps1 $InSystemDir expression not found"
+    script = (
+        f"$SystemRootDir = 'C:\\Windows'\n"
+        f"$CurrentDir = '{current_dir}'\n"
+        f"{match.group(0)}"
+        '"RESULT=$InSystemDir"\n'
+    )
+    result = subprocess.run(
+        ["pwsh", "-NoProfile", "-NonInteractive", "-Command", script],
+        capture_output = True,
+        text = True,
+        timeout = 60,
+    )
+    assert result.returncode == 0, result.stderr
+    assert f"RESULT={expected}" in result.stdout, result.stdout
+
+
+def _extract_relocation_block() -> str:
+    src = _install_ps1()
+    start = src.index("    if ($InSystemDir) {")
+    end = src.index("\n    # ── Check winget ──", start)
+    return src[start:end]
+
+
+_PS_STUBS = (
+    "function Write-TauriLog { param([string]$Tag, [string]$Message) }\n"
+    'function step { param($Label, $Value, $Color) Write-Host "STEP:$Label|$Value" }\n'
+    'function substep { param($Message, $Color) Write-Host "SUBSTEP:$Message" }\n'
+    'function Exit-InstallFailure { param($Message, $Code = 1) Write-Host "FAILED:$Message"; exit 42 }\n'
+    "$InSystemDir = $true\n"
+)
+
+
+def _run_relocation_block(
+    tmp_path: Path,
+    system_root: Path,
+    current_dir: Path,
+    home_env: Path,
+    with_llama_cpp_dir: str = "",
+) -> subprocess.CompletedProcess:
+    """Run the relocation body on the host's own filesystem (no '\\' concatenation in it)."""
+    script = (
+        _PS_STUBS
+        + f"$SystemRootDir = '{system_root}'\n"
+        + f"$CurrentDir = '{current_dir}'\n"
+        + f"$WithLlamaCppDir = '{with_llama_cpp_dir}'\n"
+        + "Set-Location -LiteralPath $CurrentDir\n"
+        + _extract_relocation_block()
+        + '\nWrite-Host "CWD:$((Get-Location).ProviderPath)"\n'
+        + 'Write-Host "LLAMA:$WithLlamaCppDir"\n'
+    )
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "HOME": str(home_env),
+        "USERPROFILE": str(home_env),
+        "PUBLIC": str(home_env),
+        "TEMP": str(home_env),
+    }
+    return subprocess.run(
+        ["pwsh", "-NoProfile", "-NonInteractive", "-Command", script],
+        capture_output = True,
+        text = True,
+        timeout = 60,
+        env = env,
+    )
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
+def test_relocation_block_moves_out_and_rebases_relative_llama_cpp_dir(tmp_path):
+    system_root = tmp_path / "Windows"
+    current_dir = system_root / "System32"
+    current_dir.mkdir(parents = True)
+    home = tmp_path / "home"
+    home.mkdir()
+    res = _run_relocation_block(
+        tmp_path, system_root, current_dir, home, with_llama_cpp_dir = "llama.cpp"
+    )
+    assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr!r}"
+    assert f"CWD:{home}" in res.stdout, f"must relocate to the home directory; got {res.stdout!r}"
+    assert "Windows system folder" in res.stdout, "the user must be told why the directory changed"
+    assert f"LLAMA:{current_dir / 'llama.cpp'}" in res.stdout, (
+        "a relative --with-llama-cpp-dir must still resolve against the original directory"
+    )
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
+def test_relocation_block_fails_fast_when_every_candidate_is_a_system_directory(tmp_path):
+    """No safe directory (SYSTEM account: profile lives under System32) must fail before any install work."""
+    system_root = tmp_path / "Windows"
+    current_dir = system_root / "System32"
+    current_dir.mkdir(parents = True)
+    home = system_root / "System32" / "config" / "systemprofile"
+    home.mkdir(parents = True)
+    res = _run_relocation_block(tmp_path, system_root, current_dir, home)
+    assert res.returncode == 42, f"stdout={res.stdout!r} stderr={res.stderr!r}"
+    assert "cannot be installed from" in res.stdout
+    assert "irm https://unsloth.ai/install.ps1 | iex" in res.stdout
+    assert "FAILED:" in res.stdout, "must route through Exit-InstallFailure for rollback"
+
+
+# ── unsloth_cli: the message the user actually reads ──
+
+
+class _FakeExit(Exception):
+    def __init__(self, code: int = 0):
+        self.code = code
+
+
+def _run_cli_guard(cwd: str, argv: list[str] | None = None) -> tuple[str | None, int | None]:
+    """Exec the CLI's win32 guard block with ntpath semantics; returns (message, exit code)."""
+    src = CLI_INIT.read_text(encoding = "utf-8")
+    start = src.index('    if (\n        _sys.platform == "win32"\n    ):')
+    end = src.index("\n\n", src.index("raise typer.Exit(code = 1)", start))
+    block = "\n".join(
+        line[4:] if line.startswith("    ") else line for line in src[start:end].split("\n")
+    )
+
+    captured: dict[str, object] = {}
+
+    def _secho(
+        message,
+        fg = None,
+        err = False,
+    ):
+        captured["message"] = message
+
+    fake_typer = types.SimpleNamespace(secho = _secho, Exit = _FakeExit)
+    fake_os = types.SimpleNamespace(
+        path = ntpath,
+        sep = "\\",
+        getcwd = lambda: cwd,
+        environ = {"WINDIR": r"C:\Windows", "USERPROFILE": r"C:\Users\me"},
+    )
+    fake_sys = types.SimpleNamespace(platform = "win32", argv = argv or ["unsloth", "studio", "setup"])
+
+    namespace = {"_os": fake_os, "_sys": fake_sys, "typer": fake_typer}
+    try:
+        exec(compile(block, "cli_guard", "exec"), namespace)
+    except _FakeExit as exit_signal:
+        return captured.get("message"), exit_signal.code
+    return captured.get("message"), None
+
+
+@pytest.mark.parametrize(
+    "cwd",
+    [
+        r"C:\Windows\System32",
+        r"c:\windows\system32",
+        r"C:\Windows\System32\config",
+        r"C:\Windows\SysWOW64",
+    ],
+)
+def test_cli_guard_refuses_system_directories(cwd: str):
+    message, code = _run_cli_guard(cwd)
+    assert code == 1, f"{cwd} must exit non-zero"
+    assert message is not None
+
+
+@pytest.mark.parametrize("cwd", [r"C:\Users\me", r"C:\Windows2\System32x", r"D:\work"])
+def test_cli_guard_allows_normal_directories(cwd: str):
+    message, code = _run_cli_guard(cwd)
+    assert code is None, f"{cwd} must not be refused"
+    assert message is None
+
+
+def test_cli_guard_message_names_the_folder_and_the_fix():
+    message, _ = _run_cli_guard(r"C:\Windows\System32", argv = ["unsloth", "studio", "setup"])
+    assert message is not None
+    assert r"C:\Windows\System32" in message, "the message must name the offending directory"
+    assert "Run as administrator" in message, "explain how the user got here"
+    assert r"cd C:\Users\me" in message, "hand back a cd the user can paste"
+    assert "cmd.exe" in message, "cmd needs cd /d, PowerShell does not"
+    assert "unsloth studio setup" in message, "repeat the command being retried"
+
+
+def test_cli_guard_message_repeats_the_actual_command():
+    message, _ = _run_cli_guard(
+        r"C:\Windows\System32", argv = ["unsloth", "train", "--model", "my model"]
+    )
+    assert message is not None
+    assert 'unsloth train --model "my model"' in message, (
+        "the retry line must reproduce the invoked command, re-quoting arguments with spaces"
+    )

--- a/tests/test_installer_system32_guard.py
+++ b/tests/test_installer_system32_guard.py
@@ -51,9 +51,9 @@ def test_install_ps1_guard_covers_the_whole_windows_directory():
     idx = src.index("$SystemRootDir = if ($env:SystemRoot)")
     block = src[idx : idx + 2500]
     assert '{ "C:\\Windows" }' in block, "SystemRoot must fall back to C:\\Windows"
-    assert (
-        "Get-Location -PSProvider FileSystem" in block
-    ), "the guard must read the filesystem location so a caller parked on HKLM:\\ is still checked"
+    assert "Get-Location -PSProvider FileSystem" in block, (
+        "the guard must read the filesystem location so a caller parked on HKLM:\\ is still checked"
+    )
     assert "OrdinalIgnoreCase" in block, "Windows paths compare case-insensitively"
 
 
@@ -64,9 +64,9 @@ def test_install_ps1_guard_relocates_and_keeps_relative_llama_cpp_dir():
     assert "Set-Location -LiteralPath $candidate" in block, "the guard must relocate, not just warn"
     llama_idx = block.index("GetUnresolvedProviderPathFromPSPath($WithLlamaCppDir)")
     set_loc_idx = block.index("Set-Location -LiteralPath $candidate")
-    assert (
-        llama_idx < set_loc_idx
-    ), "--with-llama-cpp-dir must be pinned to the original directory before Set-Location"
+    assert llama_idx < set_loc_idx, (
+        "--with-llama-cpp-dir must be pinned to the original directory before Set-Location"
+    )
     assert "GetFullPath($WithLlamaCppDir)" not in block, (
         "GetFullPath resolves against [Environment]::CurrentDirectory, which Set-Location "
         "does not update; the PSPath resolver follows the PowerShell location"
@@ -78,21 +78,25 @@ def test_install_ps1_guard_rejects_candidates_inside_the_windows_directory():
     src = _install_ps1()
     idx = src.index("$SafeDirCandidates = @(")
     block = src[idx : idx + 700]
-    assert (
-        "StartsWith(" in block and "$SystemRootDir" in block
-    ), "candidate directories under %SystemRoot% must be filtered out"
+    assert "StartsWith(" in block and "$SystemRootDir" in block, (
+        "candidate directories under %SystemRoot% must be filtered out"
+    )
 
 
 def test_install_ps1_guard_failure_message_is_actionable():
     """With nowhere safe to go, the error must say where the user is, why, and what to type."""
     src = _install_ps1()
     idx = src.index("[ERROR] Unsloth cannot be installed from $CurrentDir.")
-    block = src[idx : idx + 1500]
+    block = src[idx : src.index("\n        }\n", idx)]
     assert "Windows system folder" in block
     assert "Run as administrator" in block, "explain how the user got into System32"
-    assert "cd `$env:USERPROFILE" in block, "give the exact cd command"
     assert "irm https://unsloth.ai/install.ps1 | iex" in block, "give the exact re-run command"
     assert "Exit-InstallFailure" in block, "must go through the rollback-aware failure path"
+    assert "$env:USERPROFILE" not in block, (
+        "this branch is only reached once USERPROFILE was rejected as a candidate, so "
+        "naming it would send the user back into the same tree"
+    )
+    assert "SYSTEM" in block, "name the account type that actually lands here"
 
 
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
@@ -206,9 +210,9 @@ def test_relocation_block_moves_out_and_rebases_relative_llama_cpp_dir(tmp_path)
     assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr!r}"
     assert f"CWD:{home}" in res.stdout, f"must relocate to the home directory; got {res.stdout!r}"
     assert "Windows system folder" in res.stdout, "the user must be told why the directory changed"
-    assert (
-        f"LLAMA:{current_dir / 'llama.cpp'}" in res.stdout
-    ), "a relative --with-llama-cpp-dir must still resolve against the original directory"
+    assert f"LLAMA:{current_dir / 'llama.cpp'}" in res.stdout, (
+        "a relative --with-llama-cpp-dir must still resolve against the original directory"
+    )
 
 
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
@@ -223,9 +227,9 @@ def test_relocation_block_leaves_a_fully_qualified_llama_cpp_dir_alone(tmp_path)
         tmp_path, system_root, current_dir, home, with_llama_cpp_dir = str(absolute)
     )
     assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr!r}"
-    assert (
-        f"LLAMA:{absolute}" in res.stdout
-    ), "an already qualified path must pass through untouched"
+    assert f"LLAMA:{absolute}" in res.stdout, (
+        "an already qualified path must pass through untouched"
+    )
 
 
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
@@ -412,6 +416,6 @@ def test_cli_guard_message_repeats_the_actual_command():
         r"C:\Windows\System32", argv = ["unsloth", "train", "--model", "my model"]
     )
     assert message is not None
-    assert (
-        'unsloth train --model "my model"' in message
-    ), "the retry line must reproduce the invoked command, re-quoting arguments with spaces"
+    assert 'unsloth train --model "my model"' in message, (
+        "the retry line must reproduce the invoked command, re-quoting arguments with spaces"
+    )

--- a/tests/test_installer_system32_guard.py
+++ b/tests/test_installer_system32_guard.py
@@ -51,9 +51,9 @@ def test_install_ps1_guard_covers_the_whole_windows_directory():
     idx = src.index("$SystemRootDir = if ($env:SystemRoot)")
     block = src[idx : idx + 2500]
     assert '{ "C:\\Windows" }' in block, "SystemRoot must fall back to C:\\Windows"
-    assert (
-        "Get-Location -PSProvider FileSystem" in block
-    ), "the guard must read the filesystem location so a caller parked on HKLM:\\ is still checked"
+    assert "Get-Location -PSProvider FileSystem" in block, (
+        "the guard must read the filesystem location so a caller parked on HKLM:\\ is still checked"
+    )
     assert "OrdinalIgnoreCase" in block, "Windows paths compare case-insensitively"
 
 
@@ -64,9 +64,9 @@ def test_install_ps1_guard_relocates_and_keeps_relative_llama_cpp_dir():
     assert "Set-Location -LiteralPath $candidate" in block, "the guard must relocate, not just warn"
     llama_idx = block.index("$WithLlamaCppDir = Join-Path $CurrentDir $WithLlamaCppDir")
     set_loc_idx = block.index("Set-Location -LiteralPath $candidate")
-    assert (
-        llama_idx < set_loc_idx
-    ), "a relative --with-llama-cpp-dir must be pinned to the original directory before Set-Location"
+    assert llama_idx < set_loc_idx, (
+        "a relative --with-llama-cpp-dir must be pinned to the original directory before Set-Location"
+    )
 
 
 def test_install_ps1_guard_rejects_candidates_inside_the_windows_directory():
@@ -74,9 +74,9 @@ def test_install_ps1_guard_rejects_candidates_inside_the_windows_directory():
     src = _install_ps1()
     idx = src.index("$SafeDirCandidates = @(")
     block = src[idx : idx + 700]
-    assert (
-        "StartsWith(" in block and "$SystemRootDir" in block
-    ), "candidate directories under %SystemRoot% must be filtered out"
+    assert "StartsWith(" in block and "$SystemRootDir" in block, (
+        "candidate directories under %SystemRoot% must be filtered out"
+    )
 
 
 def test_install_ps1_guard_failure_message_is_actionable():
@@ -202,9 +202,9 @@ def test_relocation_block_moves_out_and_rebases_relative_llama_cpp_dir(tmp_path)
     assert res.returncode == 0, f"stdout={res.stdout!r} stderr={res.stderr!r}"
     assert f"CWD:{home}" in res.stdout, f"must relocate to the home directory; got {res.stdout!r}"
     assert "Windows system folder" in res.stdout, "the user must be told why the directory changed"
-    assert (
-        f"LLAMA:{current_dir / 'llama.cpp'}" in res.stdout
-    ), "a relative --with-llama-cpp-dir must still resolve against the original directory"
+    assert f"LLAMA:{current_dir / 'llama.cpp'}" in res.stdout, (
+        "a relative --with-llama-cpp-dir must still resolve against the original directory"
+    )
 
 
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
@@ -230,7 +230,11 @@ class _FakeExit(Exception):
         self.code = code
 
 
-def _run_cli_guard(cwd: str, argv: list[str] | None = None) -> tuple[str | None, int | None]:
+def _run_cli_guard(
+    cwd: str,
+    argv: list[str] | None = None,
+    userprofile: str = r"C:\Users\me",
+) -> tuple[str | None, int | None]:
     """Exec the CLI's win32 guard block with ntpath semantics; returns (message, exit code)."""
     src = CLI_INIT.read_text(encoding = "utf-8")
     start = src.index('    if (\n        _sys.platform == "win32"\n    ):')
@@ -253,7 +257,7 @@ def _run_cli_guard(cwd: str, argv: list[str] | None = None) -> tuple[str | None,
         path = ntpath,
         sep = "\\",
         getcwd = lambda: cwd,
-        environ = {"WINDIR": r"C:\Windows", "USERPROFILE": r"C:\Users\me"},
+        environ = {"WINDIR": r"C:\Windows", "USERPROFILE": userprofile},
     )
     fake_sys = types.SimpleNamespace(platform = "win32", argv = argv or ["unsloth", "studio", "setup"])
 
@@ -292,9 +296,57 @@ def test_cli_guard_message_names_the_folder_and_the_fix():
     assert message is not None
     assert r"C:\Windows\System32" in message, "the message must name the offending directory"
     assert "Run as administrator" in message, "explain how the user got here"
-    assert r"cd C:\Users\me" in message, "hand back a cd the user can paste"
+    assert r"cd 'C:\Users\me'" in message, "hand back a cd the user can paste"
     assert "cmd.exe" in message, "cmd needs cd /d, PowerShell does not"
     assert "unsloth studio setup" in message, "repeat the command being retried"
+
+
+def _cd_line(message: str, shell: str) -> str:
+    """The pasteable `cd ...` out of the recovery block, minus its `(shell)` label."""
+    line = next(line for line in message.splitlines() if line.strip().endswith(f"({shell})"))
+    return line.strip()[: -len(f"({shell})")].strip()
+
+
+@pytest.mark.parametrize(
+    "profile_name",
+    [
+        "me",
+        "Jane Doe",  # a space: `cd C:\Users\Jane Doe` binds 'Doe' as a second argument
+        "O'Brien",  # an apostrophe: single quotes must be escaped by doubling
+    ],
+)
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason = "PowerShell is unavailable")
+def test_cli_guard_cd_line_actually_runs_in_powershell(profile_name: str, tmp_path):
+    """The advertised recovery command must survive a paste, not just read well.
+
+    Set-Location takes one -Path, so an unquoted profile with a space fails with
+    "A positional parameter cannot be found that accepts argument 'Doe'".
+    """
+    profile = tmp_path / profile_name
+    profile.mkdir()
+    message, _ = _run_cli_guard(r"C:\Windows\System32", userprofile = str(profile))
+    assert message is not None
+    command = _cd_line(message, "PowerShell")
+    result = subprocess.run(
+        ["pwsh", "-NoProfile", "-NonInteractive", "-Command", f"{command}; (Get-Location).Path"],
+        capture_output = True,
+        text = True,
+        timeout = 60,
+    )
+    assert result.returncode == 0, f"{command!r} failed: {result.stderr!r}"
+    assert str(profile) in result.stdout, f"{command!r} landed in {result.stdout!r}"
+
+
+@pytest.mark.parametrize("profile_name", ["me", "Jane Doe", "O'Brien"])
+def test_cli_guard_cd_lines_are_quoted(profile_name: str):
+    """Both shells get a quoted path; " is not legal in a Windows path, so cmd's
+    double quotes cannot be broken out of, and PowerShell's single quotes are
+    verbatim (no $var expansion) with '' escaping an embedded apostrophe."""
+    profile = "C:\\Users\\" + profile_name
+    message, _ = _run_cli_guard(r"C:\Windows\System32", userprofile = profile)
+    assert message is not None
+    assert _cd_line(message, "PowerShell") == "cd '" + profile.replace("'", "''") + "'"
+    assert _cd_line(message, "cmd.exe") == 'cd /d "' + profile + '"'
 
 
 def test_cli_guard_message_repeats_the_actual_command():
@@ -302,6 +354,6 @@ def test_cli_guard_message_repeats_the_actual_command():
         r"C:\Windows\System32", argv = ["unsloth", "train", "--model", "my model"]
     )
     assert message is not None
-    assert (
-        'unsloth train --model "my model"' in message
-    ), "the retry line must reproduce the invoked command, re-quoting arguments with spaces"
+    assert 'unsloth train --model "my model"' in message, (
+        "the retry line must reproduce the invoked command, re-quoting arguments with spaces"
+    )

--- a/unsloth_cli/__init__.py
+++ b/unsloth_cli/__init__.py
@@ -88,11 +88,9 @@ def main(
         _cwd_raw = _os.getcwd()
         _cwd = _os.path.normcase(_os.path.normpath(_cwd_raw))
         if any(_cwd == _dir or _cwd.startswith(_dir + _os.sep) for _dir in _system_dirs):
-            # Name the folder and hand back a runnable fix: users get here via
-            # "Run as administrator", so the directory is the last thing they suspect.
-            # SYSTEM's USERPROFILE is C:\Windows\System32\config\systemprofile, which
-            # would send the user straight back here, so take the first home outside the
-            # Windows tree and print none rather than a bad one (install.ps1 does the same).
+            # Users land here via "Run as administrator", so name the folder and hand back
+            # a runnable fix. SYSTEM's USERPROFILE is under System32 and would send them
+            # straight back, so take the first home outside the Windows tree, or none.
             _windir_norm = _os.path.normcase(_os.path.normpath(_windir))
             _home = None
             for _candidate in (
@@ -105,10 +103,9 @@ def main(
                     _home = _candidate
                     break
             if _home:
-                # Quote it, or C:\Users\Jane Doe reaches Set-Location as two arguments and
-                # the one line we hand out does not run. PowerShell single quotes are
-                # verbatim ('' escapes an apostrophe, C:\Users\O'Brien); cmd needs double
-                # quotes once extensions are off. " is not legal in a Windows path.
+                # Quote it, or C:\Users\Jane Doe reaches Set-Location as two arguments.
+                # PowerShell single quotes are verbatim ('' escapes an apostrophe); cmd
+                # needs double quotes once extensions are off. " is not legal in a path.
                 _home_ps = "'" + _home.replace("'", "''") + "'"
                 _home_cmd = '"' + _home + '"'
                 _cd_lines = (

--- a/unsloth_cli/__init__.py
+++ b/unsloth_cli/__init__.py
@@ -90,13 +90,33 @@ def main(
         if any(_cwd == _dir or _cwd.startswith(_dir + _os.sep) for _dir in _system_dirs):
             # Name the folder and hand back a runnable fix: users get here via
             # "Run as administrator", so the directory is the last thing they suspect.
-            _home = _os.environ.get("USERPROFILE") or _os.path.expanduser("~")
-            # Quote it, or C:\Users\Jane Doe reaches Set-Location as two arguments and
-            # the one line we hand out does not run. PowerShell single quotes are
-            # verbatim ('' escapes an apostrophe, C:\Users\O'Brien); cmd needs double
-            # quotes once extensions are off. " is not legal in a Windows path.
-            _home_ps = "'" + _home.replace("'", "''") + "'"
-            _home_cmd = '"' + _home + '"'
+            # SYSTEM's USERPROFILE is C:\Windows\System32\config\systemprofile, which
+            # would send the user straight back here, so take the first home outside the
+            # Windows tree and print none rather than a bad one (install.ps1 does the same).
+            _windir_norm = _os.path.normcase(_os.path.normpath(_windir))
+            _home = None
+            for _candidate in (
+                _os.environ.get("USERPROFILE"),
+                _os.environ.get("PUBLIC"),
+                _os.path.expanduser("~"),
+            ):
+                _norm = _os.path.normcase(_os.path.normpath(_candidate)) if _candidate else ""
+                if _norm and _norm != _windir_norm and not _norm.startswith(_windir_norm + _os.sep):
+                    _home = _candidate
+                    break
+            if _home:
+                # Quote it, or C:\Users\Jane Doe reaches Set-Location as two arguments and
+                # the one line we hand out does not run. PowerShell single quotes are
+                # verbatim ('' escapes an apostrophe, C:\Users\O'Brien); cmd needs double
+                # quotes once extensions are off. " is not legal in a Windows path.
+                _home_ps = "'" + _home.replace("'", "''") + "'"
+                _home_cmd = '"' + _home + '"'
+                _cd_lines = (
+                    f"    cd {_home_ps}          (PowerShell)\n"
+                    f"    cd /d {_home_cmd}       (cmd.exe)\n"
+                )
+            else:
+                _cd_lines = f"    (any folder outside {_windir})\n"
             _argv = " ".join((f'"{_arg}"' if " " in _arg else _arg) for _arg in _sys.argv[1:])
             _retry = ("unsloth " + _argv).rstrip()
             typer.secho(
@@ -108,8 +128,7 @@ def main(
                 "this one, which is how most people end up here.\n"
                 "\n"
                 "Change to a normal folder and run the command again:\n"
-                f"    cd {_home_ps}          (PowerShell)\n"
-                f"    cd /d {_home_cmd}       (cmd.exe)\n"
+                f"{_cd_lines}"
                 f"    {_retry}",
                 fg = "red",
                 err = True,

--- a/unsloth_cli/__init__.py
+++ b/unsloth_cli/__init__.py
@@ -91,6 +91,12 @@ def main(
             # Name the folder and hand back a runnable fix: users get here via
             # "Run as administrator", so the directory is the last thing they suspect.
             _home = _os.environ.get("USERPROFILE") or _os.path.expanduser("~")
+            # Quote it, or C:\Users\Jane Doe reaches Set-Location as two arguments and
+            # the one line we hand out does not run. PowerShell single quotes are
+            # verbatim ('' escapes an apostrophe, C:\Users\O'Brien); cmd needs double
+            # quotes once extensions are off. " is not legal in a Windows path.
+            _home_ps = "'" + _home.replace("'", "''") + "'"
+            _home_cmd = '"' + _home + '"'
             _argv = " ".join((f'"{_arg}"' if " " in _arg else _arg) for _arg in _sys.argv[1:])
             _retry = ("unsloth " + _argv).rstrip()
             typer.secho(
@@ -102,8 +108,8 @@ def main(
                 "this one, which is how most people end up here.\n"
                 "\n"
                 "Change to a normal folder and run the command again:\n"
-                f"    cd {_home}          (PowerShell)\n"
-                f"    cd /d {_home}       (cmd.exe)\n"
+                f"    cd {_home_ps}          (PowerShell)\n"
+                f"    cd /d {_home_cmd}       (cmd.exe)\n"
                 f"    {_retry}",
                 fg = "red",
                 err = True,

--- a/unsloth_cli/__init__.py
+++ b/unsloth_cli/__init__.py
@@ -79,14 +79,32 @@ def main(
     if (
         _sys.platform == "win32"
     ):  # this block catches unsloth running inside of System32 or any subdirs, this WILL cause errors if not prevented.
-        _cwd = _os.path.normcase(_os.path.normpath(_os.getcwd()))
-        _system32 = _os.path.normcase(
-            _os.path.normpath(_os.path.join(_os.environ.get("WINDIR", r"C:\Windows"), "System32"))
-        )
-        if _cwd == _system32 or _cwd.startswith(_system32 + _os.sep):
+        _windir = _os.environ.get("WINDIR", r"C:\Windows")
+        # SysWOW64 too: a 32-bit elevated shell opens there, same unwritable folder.
+        _system_dirs = [
+            _os.path.normcase(_os.path.normpath(_os.path.join(_windir, _name)))
+            for _name in ("System32", "SysWOW64")
+        ]
+        _cwd_raw = _os.getcwd()
+        _cwd = _os.path.normcase(_os.path.normpath(_cwd_raw))
+        if any(_cwd == _dir or _cwd.startswith(_dir + _os.sep) for _dir in _system_dirs):
+            # Name the folder and hand back a runnable fix: users get here via
+            # "Run as administrator", so the directory is the last thing they suspect.
+            _home = _os.environ.get("USERPROFILE") or _os.path.expanduser("~")
+            _argv = " ".join((f'"{_arg}"' if " " in _arg else _arg) for _arg in _sys.argv[1:])
+            _retry = ("unsloth " + _argv).rstrip()
             typer.secho(
-                "Refusing to run Unsloth inside System32 as it will lead to Errors.\n"
-                "cd to a normal working directory and try again.",
+                f"Unsloth cannot run from {_cwd_raw}\n"
+                "\n"
+                "That is a Windows system folder. Unsloth writes caches, configs and model\n"
+                "downloads into the current working directory, and Windows blocks that here.\n"
+                "Opening a terminal with 'Run as administrator' starts you in a folder like\n"
+                "this one, which is how most people end up here.\n"
+                "\n"
+                "Change to a normal folder and run the command again:\n"
+                f"    cd {_home}          (PowerShell)\n"
+                f"    cd /d {_home}       (cmd.exe)\n"
+                f"    {_retry}",
                 fg = "red",
                 err = True,
             )


### PR DESCRIPTION
### Problem

"Run as administrator" opens PowerShell in `C:\WINDOWS\system32`, so the install one liner from the docs runs from there:

```
PS C:\WINDOWS\system32> irm https://unsloth.ai/install.ps1 | iex
```

`install.ps1` never changes directory, so the install runs all the way through winget, Python, the venv, PyTorch and unsloth, and only then hands off to `unsloth studio setup`, which inherits System32 and refuses to start (the guard added in #5934):

```
  unsloth        2026.7.6 installed
  setup          running unsloth studio setup...
Refusing to run Unsloth inside System32 as it will lead to Errors.
cd to a normal working directory and try again.
[ERROR] unsloth studio setup failed (exit code 1)
                 restoring previous environment after failed install...
                 restored previous environment
unsloth studio setup failed (exit code 1)
At line:153 char:9
+         throw $Message
```

Everything is then rolled back, so several minutes of downloads are thrown away. The one line that explains why is buried between the setup step and the PowerShell `throw` trace, and the last line the user reads says only "exit code 1". Reported in https://www.reddit.com/r/unsloth/comments/1vcniox/installation_and_setup/, where it took another user to work out that the terminal was open in System32.

### install.ps1: leave the system directory before installing anything

Added right before the winget check, so ahead of every download. If the working directory is at or under `%SystemRoot%` (System32, SysWOW64, WinSxS), the installer moves to the first usable of `$env:USERPROFILE`, `$HOME`, `$env:PUBLIC`, `$env:TEMP` and carries on:

```
  directory      C:\WINDOWS\system32 is a Windows system folder
                 Unsloth cannot install or run from there, so this install continues in:
                   C:\Users\me
                 This is normal: 'Run as administrator' opens PowerShell in System32.
```

Relocating is safe because nothing in the script reads the caller's directory: `$RepoRoot` comes from `$PSCommandPath` and `$StudioHome` from the environment, both resolved earlier. The one caller relative input, `--with-llama-cpp-dir`, is pinned to the original directory first. `unsloth studio setup` inherits the new location, so the CLI guard no longer trips.

Candidates under `%SystemRoot%` are skipped, since the SYSTEM account's profile is `C:\Windows\System32\config\systemprofile`. If none of them is usable the installer stops immediately, before PyTorch and therefore before there is anything to roll back:

```
[ERROR] Unsloth cannot be installed from C:\WINDOWS\system32.
        That is a Windows system folder, and Unsloth writes its virtual
        environment caches, model downloads and build files into the
        working directory, which Windows blocks there.
        'Run as administrator' opens PowerShell in System32, which is how
        most people land here.
        Change to a normal folder and run the installer again:
          cd $env:USERPROFILE
          irm https://unsloth.ai/install.ps1 | iex
```

The directory is not restored at the end, for the same reason as the `PSModulePath` fix at the top of the function: the interactive path finishes by running Studio in the foreground, so a `finally` would not fire until the server stops. Being left in the home directory is also exactly what the user would have done by hand.

### unsloth_cli: an error that says which folder and how to get out of it

Anyone who runs `unsloth` directly from an elevated prompt still hits the guard, so it now names the directory and prints commands that can be pasted. It also covers SysWOW64, where a 32 bit elevated shell starts.

Before:

```
Refusing to run Unsloth inside System32 as it will lead to Errors.
cd to a normal working directory and try again.
```

After:

```
Unsloth cannot run from C:\Windows\System32

That is a Windows system folder. Unsloth writes caches, configs and model
downloads into the current working directory, and Windows blocks that here.
Opening a terminal with 'Run as administrator' starts you in a folder like
this one, which is how most people end up here.

Change to a normal folder and run the command again:
    cd C:\Users\me          (PowerShell)
    cd /d C:\Users\me       (cmd.exe)
    unsloth studio setup
```

The last line repeats whatever was actually invoked, re-quoting arguments that contain spaces.

### Tests

`tests/test_installer_system32_guard.py`, 24 tests:

- ordering, that the guard precedes `step "winget"`, `uv venv` and `studio setup`, so the failure can never come after a download again
- the match expression run through `pwsh` against Windows shaped paths: `C:\Windows\System32`, `c:\windows\system32`, `C:\Windows\System32\drivers\etc`, `C:\Windows\SysWOW64` and `C:\Windows` match, `C:\Users\me`, `C:\Windows2` and `C:\WindowsApps\stuff` do not
- the relocation body executed under `pwsh` against a fake system root: it moves out, rebases a relative `--with-llama-cpp-dir` onto the original directory, and routes through `Exit-InstallFailure` when every candidate lives under the system root
- the CLI guard block executed with `ntpath` semantics, so System32, SysWOW64 and their subdirectories exit 1 while normal directories pass, plus the contents of the message

`install.ps1` parses clean through `[System.Management.Automation.Language.Parser]::ParseFile`, the Python files through `ast.parse`, and `ruff check` plus `scripts/run_ruff_format.py` are clean. The existing installer suites (`test_installer_skip_autostart.py`, `test_studio_install_workspace_guard.py`, `test_installer_shortcut_icons.py`, `test_installer_unsloth_version.py`, `security/test_new_install_scripts.py`) still pass, 109 tests in total with the new file.
