### PR TITLE
Model picker: show row actions on collapsed quant rows and align the GGUF tag

### DIFF
--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -3171,8 +3171,7 @@ export function HubModelPicker({
               className={downloadedRowButtonClassName}
             />
           </div>
-          {/* Reserves the settings and menu buttons the other rows carry, so
-              every row's GGUF tag lands in the same place. */}
+          {/* Stands in for the other rows' buttons, so the tags line up. */}
           <span aria-hidden="true" className="mr-1 h-6 w-[42px] shrink-0" />
         </div>
         {expanderOpen && (

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -3084,51 +3084,49 @@ export function HubModelPicker({
             className={downloadedRowButtonClassName}
           />
         </div>
-        <span className="mr-1 flex shrink-0 items-center opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100">
-          {onConfigure && (
-            <ModelLoadSettingsAction
-              ariaLabel={`Inference settings for ${c.repo_id} ${variant.quant}`}
-              onConfigure={() => onConfigure(c.repo_id, selectMeta)}
-            />
-          )}
-          <ModelRowMenu
-            ariaLabel={`More options for ${c.repo_id} ${variant.quant}`}
-            iconClassName="size-3"
-            cachePath={{ repoId: c.repo_id, variant: variant.quant }}
-            pin={{
-              pinned: isPinned,
-              pinLabel: "Pin to top",
-              unpinLabel: "Unpin",
-              onToggle: () => togglePinned(c.repo_id, variant.quant),
-            }}
-            del={{
-              title: "Delete cached model?",
-              description: (
-                <>
-                  This will remove{" "}
-                  <span className="font-medium text-foreground">
-                    {c.repo_id} ({variant.quant})
-                  </span>{" "}
-                  from disk. You can re-download it later.
-                </>
-              ),
-              successMessage: `Deleted ${c.repo_id} ${variant.quant}`,
-              disabled: deleteDisabled,
-              onConfirm: async () => {
-                await deleteCachedModel(
-                  c.repo_id,
-                  variant.quant,
-                  hfToken || undefined,
-                  c.cache_path || undefined,
-                );
-                // The file is gone, so drop its pin too.
-                if (isPinned) togglePinned(c.repo_id, variant.quant);
-                prunePinnedQuantValidation(c.repo_id, variant.quant);
-                refreshCachedLists();
-              },
-            }}
+        {onConfigure && (
+          <ModelLoadSettingsAction
+            ariaLabel={`Inference settings for ${c.repo_id} ${variant.quant}`}
+            onConfigure={() => onConfigure(c.repo_id, selectMeta)}
           />
-        </span>
+        )}
+        <ModelRowMenu
+          ariaLabel={`More options for ${c.repo_id} ${variant.quant}`}
+          buttonClassName="mr-1"
+          cachePath={{ repoId: c.repo_id, variant: variant.quant }}
+          pin={{
+            pinned: isPinned,
+            pinLabel: "Pin to top",
+            unpinLabel: "Unpin",
+            onToggle: () => togglePinned(c.repo_id, variant.quant),
+          }}
+          del={{
+            title: "Delete cached model?",
+            description: (
+              <>
+                This will remove{" "}
+                <span className="font-medium text-foreground">
+                  {c.repo_id} ({variant.quant})
+                </span>{" "}
+                from disk. You can re-download it later.
+              </>
+            ),
+            successMessage: `Deleted ${c.repo_id} ${variant.quant}`,
+            disabled: deleteDisabled,
+            onConfirm: async () => {
+              await deleteCachedModel(
+                c.repo_id,
+                variant.quant,
+                hfToken || undefined,
+                c.cache_path || undefined,
+              );
+              // The file is gone, so drop its pin too.
+              if (isPinned) togglePinned(c.repo_id, variant.quant);
+              prunePinnedQuantValidation(c.repo_id, variant.quant);
+              refreshCachedLists();
+            },
+          }}
+        />
       </div>
     );
   };
@@ -3173,7 +3171,9 @@ export function HubModelPicker({
               className={downloadedRowButtonClassName}
             />
           </div>
-          <span aria-hidden="true" className="mr-1 h-6 w-[26px] shrink-0" />
+          {/* Reserves the settings and menu buttons the other rows carry, so
+              every row's GGUF tag lands in the same place. */}
+          <span aria-hidden="true" className="mr-1 h-6 w-[42px] shrink-0" />
         </div>
         {expanderOpen && (
           <GgufVariantExpander


### PR DESCRIPTION
Follow up to #7736.

### Row actions

A GGUF repo holding a single quant now renders as one row, and that row's settings and menu buttons only appeared on hover. The Safetensors rows sitting next to it keep theirs visible at all times, so the collapsed rows looked like they had no actions at all.

The collapsed row now uses the same markup as the Safetensors rows: same two buttons, same sizes, always visible. The hover gate and the smaller `size-3` menu icon are gone.

### GGUF tag alignment

Repos holding more than one quant stay expandable, and those rows have no action buttons, so they reserve a fixed-width spacer instead. The spacer was 26px while the buttons it stands in for are 42px (settings 20px plus menu 22px), which pulled the row's label and its `GGUF` tag left of every other row.

Widened the spacer to 42px so all three row types reserve the same trailing width and the tags line up down the list.

### Testing

- `npm run typecheck` clean
- `npm test`: 286 passing, 0 failing
- `npm run build` clean
- `biome check` on the touched file reports the same 1 error and 20 warnings as `main`, all pre-existing