### PR TITLE
Escape the system message spliced into predefined chat templates

### DIFF
--- a/tests/python/test_change_system_message.py
+++ b/tests/python/test_change_system_message.py
@@ -72,11 +72,11 @@ def test_predefined_template_uses_default_then_override():
 
 
 def test_predefined_template_escapes_but_custom_does_not():
-    # Our own templates hold {system_message} inside a Jinja literal, so it is escaped;
+    # Predefined templates hold {system_message} inside a Jinja literal, so it is escaped;
     # a custom template's placeholder may be raw text, so it stays verbatim.
     fn = _load_change_system_message()
     msg = """it's a \\test "x"."""
     predefined, used = fn("System: {system_message}", "unsloth", msg)
     assert predefined == """System: it\\'s a \\\\test \\"x\\"."""
-    assert used == msg  # the returned message is the raw one, not the escaped source
+    assert used == msg  # returned message is the raw one, not the escaped source
     assert fn("System: {system_message}", CUSTOM, msg)[0] == f"System: {msg}"

--- a/tests/python/test_change_system_message.py
+++ b/tests/python/test_change_system_message.py
@@ -13,7 +13,8 @@ def _load_change_system_message():
     funcs = [
         node
         for node in tree.body
-        if isinstance(node, ast.FunctionDef) and node.name == "_change_system_message"
+        if isinstance(node, ast.FunctionDef)
+        and node.name in ("_change_system_message", "_escape_jinja_literal")
     ]
     namespace = {
         "re": re,
@@ -62,10 +63,20 @@ def test_custom_template_without_placeholder_unchanged():
 
 
 def test_predefined_template_uses_default_then_override():
-    # Predefined templates with a default are unaffected.
     fn = _load_change_system_message()
     t1, u1 = fn("System: {system_message}", "unsloth", None)
     assert t1 == "System: You are a helpful assistant to the user"
     t2, u2 = fn("System: {system_message}", "unsloth", "Custom override")
     assert t2 == "System: Custom override"
     assert u2 == "Custom override"
+
+
+def test_predefined_template_escapes_but_custom_does_not():
+    # Our own templates hold {system_message} inside a Jinja literal, so it is escaped;
+    # a custom template's placeholder may be raw text, so it stays verbatim.
+    fn = _load_change_system_message()
+    msg = """it's a \\test "x"."""
+    predefined, used = fn("System: {system_message}", "unsloth", msg)
+    assert predefined == """System: it\\'s a \\\\test \\"x\\"."""
+    assert used == msg  # the returned message is the raw one, not the escaped source
+    assert fn("System: {system_message}", CUSTOM, msg)[0] == f"System: {msg}"

--- a/tests/python/test_get_chat_template_escaping.py
+++ b/tests/python/test_get_chat_template_escaping.py
@@ -43,7 +43,7 @@ MESSAGES = [
 
 def _render(template):
     # No system turn in `messages`, so the template falls back to the baked-in
-    # {system_message} literal, which is the path under test.
+    # {system_message} literal, the path under test.
     environment = ImmutableSandboxedEnvironment(trim_blocks = True, lstrip_blocks = True)
     return environment.from_string(template).render(
         messages = [{"role": "user", "content": "Hi"}],
@@ -54,7 +54,7 @@ def _render(template):
 
 
 def test_templates_with_system_message_were_found():
-    # Guard the discovery above: an empty list would make every case below vacuous.
+    # An empty discovery list would make every case below vacuous.
     assert len(TEMPLATES_WITH_SYSTEM_MESSAGE) >= 10
 
 
@@ -68,7 +68,7 @@ def test_system_message_survives_the_jinja_literal(name, label, system_message):
 
 @pytest.mark.parametrize("name", TEMPLATES_WITH_SYSTEM_MESSAGE)
 def test_default_system_message_renders_verbatim(name):
-    # The defaults used to be hand-escaped in the source; escaping them again would
+    # Defaults are no longer hand-escaped in the source; escaping them twice would
     # surface a literal backslash to the user.
     default = DEFAULT_SYSTEM_MESSAGE[name]
     template, _ = _change_system_message(CHAT_TEMPLATES[name][0], name, None)
@@ -86,7 +86,7 @@ def test_vicuna_default_has_a_plain_apostrophe(name):
 @pytest.mark.parametrize("quote", ["'", '"'])
 @pytest.mark.parametrize("label, text", MESSAGES, ids = [m[0] for m in MESSAGES])
 def test_escape_round_trips_in_either_quote_style(quote, label, text):
-    # get_chat_template also splices the ShareGPT `mapping` values into literals, and
-    # llama-3.1 uses "..." where the rest use '...', so one escaper has to cover both.
+    # get_chat_template also splices ShareGPT `mapping` values into literals, and
+    # llama-3.1 uses "..." where the rest use '...', so one escaper must cover both.
     template = "{{ " + quote + _escape_jinja_literal(text) + quote + " }}"
     assert jinja2.Environment().from_string(template).render() == text

--- a/tests/python/test_get_chat_template_escaping.py
+++ b/tests/python/test_get_chat_template_escaping.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+"""Escaping tests for the predefined chat templates' {system_message} placeholder.
+
+Every predefined template holds {system_message} inside a Jinja string literal, so a
+system message carrying a quote or a backslash has to be escaped on the way in. Without
+it a quote closes the literal (TemplateSyntaxError) and a backslash is read as an escape,
+which silently rewrites the text (\\boxed -> \\x08oxed). Rendering, not just compiling,
+is asserted here: the corrupting cases compile fine.
+"""
+
+import jinja2
+import pytest
+from jinja2.sandbox import ImmutableSandboxedEnvironment
+
+from unsloth.chat_templates import (
+    CHAT_TEMPLATES,
+    DEFAULT_SYSTEM_MESSAGE,
+    _change_system_message,
+    _escape_jinja_literal,
+)
+
+
+# Discovered, not hardcoded, so a new predefined template is covered on arrival.
+TEMPLATES_WITH_SYSTEM_MESSAGE = sorted(
+    name for name, entry in CHAT_TEMPLATES.items()
+    if isinstance(entry[0], str) and "{system_message}" in entry[0]
+)
+
+MESSAGES = [
+    ("apostrophe",  "Answer the user's question."),
+    ("double",      'He said "hi" today.'),
+    ("both_quotes", """mix ' and " here"""),
+    ("latex",       r"Put it in \boxed{\frac{1}{2}}."),
+    ("windows",     r"C:\Users\me"),
+    ("trailing",    "ends with a backslash \\"),
+    ("crlf",        "line one\r\nline two"),
+    ("group_ref",   r"use \1 for the group"),
+    ("jinja",       "{{ 7*6 }} and {% raw %}x{% endraw %}"),
+]
+
+
+def _render(template):
+    # No system turn in `messages`, so the template falls back to the baked-in
+    # {system_message} literal, which is the path under test.
+    environment = ImmutableSandboxedEnvironment(trim_blocks = True, lstrip_blocks = True)
+    return environment.from_string(template).render(
+        messages = [{"role": "user", "content": "Hi"}],
+        bos_token = "<s>",
+        eos_token = "</s>",
+        add_generation_prompt = False,
+    )
+
+
+def test_templates_with_system_message_were_found():
+    # Guard the discovery above: an empty list would make every case below vacuous.
+    assert len(TEMPLATES_WITH_SYSTEM_MESSAGE) >= 10
+
+
+@pytest.mark.parametrize("name", TEMPLATES_WITH_SYSTEM_MESSAGE)
+@pytest.mark.parametrize("label, system_message", MESSAGES, ids = [m[0] for m in MESSAGES])
+def test_system_message_survives_the_jinja_literal(name, label, system_message):
+    template, used = _change_system_message(CHAT_TEMPLATES[name][0], name, system_message)
+    assert used == system_message, "the returned message must be the raw one"
+    assert system_message in _render(template)
+
+
+@pytest.mark.parametrize("name", TEMPLATES_WITH_SYSTEM_MESSAGE)
+def test_default_system_message_renders_verbatim(name):
+    # The defaults used to be hand-escaped in the source; escaping them again would
+    # surface a literal backslash to the user.
+    default = DEFAULT_SYSTEM_MESSAGE[name]
+    template, _ = _change_system_message(CHAT_TEMPLATES[name][0], name, None)
+    assert default in _render(template)
+
+
+@pytest.mark.parametrize("name", ["vicuna", "vicuna_old", "vicuna old"])
+def test_vicuna_default_has_a_plain_apostrophe(name):
+    assert "\\" not in DEFAULT_SYSTEM_MESSAGE[name]
+    assert "'s questions." in _render(_change_system_message(CHAT_TEMPLATES[name][0], name, None)[0])
+
+
+@pytest.mark.parametrize("quote", ["'", '"'])
+@pytest.mark.parametrize("label, text", MESSAGES, ids = [m[0] for m in MESSAGES])
+def test_escape_round_trips_in_either_quote_style(quote, label, text):
+    # get_chat_template also splices the ShareGPT `mapping` values into literals, and
+    # llama-3.1 uses "..." where the rest use '...', so one escaper has to cover both.
+    template = "{{ " + quote + _escape_jinja_literal(text) + quote + " }}"
+    assert jinja2.Environment().from_string(template).render() == text

--- a/tests/python/test_get_chat_template_escaping.py
+++ b/tests/python/test_get_chat_template_escaping.py
@@ -23,20 +23,21 @@ from unsloth.chat_templates import (
 
 # Discovered, not hardcoded, so a new predefined template is covered on arrival.
 TEMPLATES_WITH_SYSTEM_MESSAGE = sorted(
-    name for name, entry in CHAT_TEMPLATES.items()
+    name
+    for name, entry in CHAT_TEMPLATES.items()
     if isinstance(entry[0], str) and "{system_message}" in entry[0]
 )
 
 MESSAGES = [
-    ("apostrophe",  "Answer the user's question."),
-    ("double",      'He said "hi" today.'),
+    ("apostrophe", "Answer the user's question."),
+    ("double", 'He said "hi" today.'),
     ("both_quotes", """mix ' and " here"""),
-    ("latex",       r"Put it in \boxed{\frac{1}{2}}."),
-    ("windows",     r"C:\Users\me"),
-    ("trailing",    "ends with a backslash \\"),
-    ("crlf",        "line one\r\nline two"),
-    ("group_ref",   r"use \1 for the group"),
-    ("jinja",       "{{ 7*6 }} and {% raw %}x{% endraw %}"),
+    ("latex", r"Put it in \boxed{\frac{1}{2}}."),
+    ("windows", r"C:\Users\me"),
+    ("trailing", "ends with a backslash \\"),
+    ("crlf", "line one\r\nline two"),
+    ("group_ref", r"use \1 for the group"),
+    ("jinja", "{{ 7*6 }} and {% raw %}x{% endraw %}"),
 ]
 
 
@@ -77,7 +78,9 @@ def test_default_system_message_renders_verbatim(name):
 @pytest.mark.parametrize("name", ["vicuna", "vicuna_old", "vicuna old"])
 def test_vicuna_default_has_a_plain_apostrophe(name):
     assert "\\" not in DEFAULT_SYSTEM_MESSAGE[name]
-    assert "'s questions." in _render(_change_system_message(CHAT_TEMPLATES[name][0], name, None)[0])
+    assert "'s questions." in _render(
+        _change_system_message(CHAT_TEMPLATES[name][0], name, None)[0]
+    )
 
 
 @pytest.mark.parametrize("quote", ["'", '"'])

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -1810,10 +1810,9 @@ yi_chat_template_eos_token = "<|endoftext|>"
 CHAT_TEMPLATES["yi-chat"] = (yi_chat_template, yi_chat_template_eos_token, False, yi_chat_ollama)
 DEFAULT_SYSTEM_MESSAGE["yi-chat"] = None
 
-# Caller text is spliced into Jinja '...' / "..." literals, where a bare quote closes
-# the literal and a backslash is read as an escape, and \r is normalised to \n before
-# unescaping. Backslash first, else it re-escapes the ones added after. Escaping both
-# quotes is safe in either literal style, so the caller need not know which is in use.
+# Caller text is spliced into Jinja '...' / "..." literals: a bare quote closes the
+# literal, a backslash reads as an escape, and \r becomes \n before unescaping. Backslash
+# first, else it re-escapes the rest; escaping both quotes is safe in either style.
 def _escape_jinja_literal(text):
     return text.replace("\\", "\\\\").replace("'", "\\'").replace('"', '\\"').replace("\r", "\\r")
 
@@ -1841,8 +1840,8 @@ def _change_system_message(template: str, type_chat_template: str, system_messag
 
     # For predefined templates with default system message
     message_to_use = system_message if system_message is not None else default_system_message
-    # Our own templates hold {system_message} inside a Jinja literal, so escape it here.
-    # Custom templates (above) are filled verbatim: their placeholder may sit in raw text.
+    # Predefined templates hold {system_message} inside a Jinja literal, so escape it.
+    # Custom ones (above) are filled verbatim: their placeholder may sit in raw text.
     new_template = template.replace("{system_message}", _escape_jinja_literal(message_to_use))
 
     return new_template, message_to_use
@@ -2063,7 +2062,7 @@ def get_chat_template(
         chat_template = "{{ bos_token }}" + chat_template
 
     # For ShareGPT role -> from and content -> value
-    # Keys land inside Jinja literals, so escape them like any other spliced text.
+    # The spliced values land inside Jinja literals, so escape them.
     new_chat_template = chat_template\
         .replace("'role'",      "'" + _escape_jinja_literal(mapping["role"])      + "'")\
         .replace("'content'",   "'" + _escape_jinja_literal(mapping["content"])   + "'")\

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -218,7 +218,7 @@ vicuna_ollama = _ollama_template("vicuna")
 
 vicuna_eos_token = "eos_token"
 CHAT_TEMPLATES["vicuna"] = (vicuna_template, vicuna_eos_token, False, vicuna_ollama,)
-DEFAULT_SYSTEM_MESSAGE["vicuna"] = "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the user\\'s questions."
+DEFAULT_SYSTEM_MESSAGE["vicuna"] = "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the user's questions."
 
 # =========================================== Vicuna Old
 # https://github.com/lm-sys/FastChat/blob/main/docs/vicuna_weights_version.md#prompt-template
@@ -248,7 +248,7 @@ vicuna_old_ollama = _ollama_template("vicuna_old")
 
 vicuna_old_eos_token = "eos_token"
 CHAT_TEMPLATES["vicuna_old"] = (vicuna_old_template, vicuna_old_eos_token, False, vicuna_old_ollama,)
-DEFAULT_SYSTEM_MESSAGE["vicuna_old"] = "A chat between a curious human and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the human\\'s questions."
+DEFAULT_SYSTEM_MESSAGE["vicuna_old"] = "A chat between a curious human and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the human's questions."
 
 CHAT_TEMPLATES["vicuna old"] = CHAT_TEMPLATES["vicuna_old"]
 DEFAULT_SYSTEM_MESSAGE["vicuna old"] = DEFAULT_SYSTEM_MESSAGE["vicuna_old"]
@@ -1810,6 +1810,14 @@ yi_chat_template_eos_token = "<|endoftext|>"
 CHAT_TEMPLATES["yi-chat"] = (yi_chat_template, yi_chat_template_eos_token, False, yi_chat_ollama)
 DEFAULT_SYSTEM_MESSAGE["yi-chat"] = None
 
+# Caller text is spliced into Jinja '...' / "..." literals, where a bare quote closes
+# the literal and a backslash is read as an escape, and \r is normalised to \n before
+# unescaping. Backslash first, else it re-escapes the ones added after. Escaping both
+# quotes is safe in either literal style, so the caller need not know which is in use.
+def _escape_jinja_literal(text):
+    return text.replace("\\", "\\\\").replace("'", "\\'").replace('"', '\\"').replace("\r", "\\r")
+
+
 def _change_system_message(template: str, type_chat_template: str, system_message: str = None):
     # For predefined templates, check if default system message exists
     default_system_message = DEFAULT_SYSTEM_MESSAGE.get(f"{type_chat_template}", None)
@@ -1833,7 +1841,9 @@ def _change_system_message(template: str, type_chat_template: str, system_messag
 
     # For predefined templates with default system message
     message_to_use = system_message if system_message is not None else default_system_message
-    new_template = template.replace("{system_message}", message_to_use)
+    # Our own templates hold {system_message} inside a Jinja literal, so escape it here.
+    # Custom templates (above) are filled verbatim: their placeholder may sit in raw text.
+    new_template = template.replace("{system_message}", _escape_jinja_literal(message_to_use))
 
     return new_template, message_to_use
 
@@ -2053,11 +2063,12 @@ def get_chat_template(
         chat_template = "{{ bos_token }}" + chat_template
 
     # For ShareGPT role -> from and content -> value
+    # Keys land inside Jinja literals, so escape them like any other spliced text.
     new_chat_template = chat_template\
-        .replace("'role'",      "'" + mapping["role"]      + "'")\
-        .replace("'content'",   "'" + mapping["content"]   + "'")\
-        .replace("'user'",      "'" + mapping["user"]      + "'")\
-        .replace("'assistant'", "'" + mapping["assistant"] + "'")
+        .replace("'role'",      "'" + _escape_jinja_literal(mapping["role"])      + "'")\
+        .replace("'content'",   "'" + _escape_jinja_literal(mapping["content"])   + "'")\
+        .replace("'user'",      "'" + _escape_jinja_literal(mapping["user"])      + "'")\
+        .replace("'assistant'", "'" + _escape_jinja_literal(mapping["assistant"]) + "'")
 
     if use_zoo_tokenizer_patch:
         # Unsloth MLX avoids the model-utils tokenizer wrapper because that
@@ -2617,15 +2628,9 @@ extra_eos_tokens = None,
         part + '\n\n' + ollama_eos
 
     # HF Jinja Chat template
-    # Caller text is spliced into Jinja '...' literals, where a bare quote closes
-    # the literal and a backslash is read as an escape, and \r is normalised to \n
-    # before unescaping. Backslash first, else it re-escapes the ones added after.
-    def escape_jinja_literal(text):
-        return text.replace("\\", "\\\\").replace("'", "\\'").replace("\r", "\\r")
-
     def process(part, which, content = "message['content']"):
         # Escape the literal pieces only; the placeholder becomes Jinja syntax below.
-        part = which.join(escape_jinja_literal(piece) for piece in part.split(which))
+        part = which.join(_escape_jinja_literal(piece) for piece in part.split(which))
         if part.endswith(which):
             part = "'" + part[:part.find(which)] + f"' + {content}"
         elif part.startswith(which):
@@ -2648,7 +2653,7 @@ extra_eos_tokens = None,
             "{% endif %}"\
         "{% endfor %}"\
         "{% if add_generation_prompt %}"\
-            "{{ '" + escape_jinja_literal(output_part[:output_part.find("{OUTPUT}")]) + "' }}"\
+            "{{ '" + _escape_jinja_literal(output_part[:output_part.find("{OUTPUT}")]) + "' }}"\
         "{% endif %}"
 
     # Now add system prompt to jinja
@@ -2668,7 +2673,7 @@ extra_eos_tokens = None,
                 "{{ " + partial_system + " }}"\
                 "{% set loop_messages = messages[1:] %}"
         if default_system_message is not None:
-            full_system = escape_jinja_literal(system_part.replace("{SYSTEM}", default_system_message))
+            full_system = _escape_jinja_literal(system_part.replace("{SYSTEM}", default_system_message))
             if "{SYSTEM}" in system_part:
                 modelfile += '\nSYSTEM "' + default_system_message + '"'
             partial_system += "{% else %}"\


### PR DESCRIPTION
Follow-up to #7731, which fixed this class of bug on the custom-template path (`construct_chat_template`). The same hazard is still live on the predefined path, which is the one most people hit:

```python
tokenizer = get_chat_template(tokenizer, chat_template = "vicuna", system_message = "Answer the user's question.")
```

All 15 `CHAT_TEMPLATES` keys that carry a `{system_message}` placeholder put it inside a Jinja string literal, and `_change_system_message` substitutes the caller's text in raw. A quote closes the literal and a backslash is read as an escape:

```
vicuna   "Answer the user's question."  -> TemplateSyntaxError: expected token 'end of print statement', got 's'
vicuna   r"Put it in \boxed{}."         -> renders '<s>Put it in \x08oxed{}. USER: Hi '
vicuna   r"C:\Users\me"                 -> TemplateSyntaxError: truncated \UXXXXXXXX escape
llama-31 'He said "hi" today.'          -> TemplateSyntaxError: expected token 'end of statement block', got 'hi'
```

The second one is the dangerous shape: it compiles, so nothing is raised, and every formatted row silently gets `\x08oxed` instead of `\boxed`. Nine of the templates land in that bucket. This is the remaining half of #3667, which was closed by #5357 hand-escaping the vicuna constant rather than the substitution itself.

## What changed

`unsloth/chat_templates.py` only.

- Promoted #7731's `escape_jinja_literal` out of `construct_chat_template` to a module-level `_escape_jinja_literal`, and added `"` to what it escapes. Python's `unicode-escape` decodes `\"` regardless of the enclosing delimiter, so one quote-agnostic escaper covers `llama-3.1`'s `{%- set system_message = "{system_message}" %}` as well as the `'...'` the other 14 use, with no delimiter detection.
- Applied it on the predefined branch of `_change_system_message`. The custom branch added by #6735 is deliberately left verbatim: there the caller owns the template and the placeholder may sit in raw text outside any literal. `test_custom_template_preserves_backslashes` still pins that.
- The returned `message_to_use` stays raw, so `tokenizer._system_message` is unaffected.
- Applied it to the four ShareGPT `mapping` values, which are also spliced into `'...'` unescaped.
- Dropped the hand-escaping from `DEFAULT_SYSTEM_MESSAGE["vicuna"]` and `["vicuna_old"]` (`user\'s`, `human\'s`). Those were the workaround for this bug; leaving them would now escape twice and surface a literal backslash.

## Verification

| Check | Before | After |
|---|---|---|
| 15 predefined templates x 12 messages, rendered and compared byte-exactly | 76/180 | 180/180 |
| Cross-engine: jinja2 + [google/minja](https://github.com/google/minja) + llama.cpp `common/jinja` agree | 54/108 | 108/108 |
| Native engines return the raw message | | 315/315 |
| `construct_chat_template`, 250-case differential vs `main` | | 0 behaviour changes |
| Escape kernel, Python 3.9-3.14 x jinja2 3.0-main, 20k-case fuzz each | | 41/41 cells clean |
| Repo tests (CPU) | | 3746 passed, 0 failed |

The cross-engine numbers matter for GGUF: the template is carried into the GGUF metadata by `convert_hf_to_gguf.py`, so a template that only jinja2 tolerates still fails to load under llama.cpp. On the 250-case `construct_chat_template` corpus the generated template bytes differ in 12 cases (those containing a double quote) and every one renders identically under all three engines.

On jinja2 2.11.3 the escaper leaves U+2028 / U+2029 normalised to `\n`, which is pre-existing jinja2 2.x behaviour and byte-identical to the escaper already on `main`. transformers requires jinja2 >= 3.1, so no supported install sees it.

## Compatibility

Generation-side only, so nothing already saved changes. The one visible difference is for anyone who worked around the bug by passing a pre-escaped `system_message` such as `"user\\'s"`: they now get a literal backslash and should pass the raw text. That is the same trade-off #7731 took, and the two vicuna constants above were Unsloth's own instance of that workaround.

## Tests

- `tests/python/test_get_chat_template_escaping.py` (new). Parametrised over every `CHAT_TEMPLATES` key carrying `{system_message}`, discovered at runtime rather than hardcoded, so a future template is covered on arrival. Each case renders and asserts the message comes back byte-exactly, not merely that the template compiles, which is what let the corrupting cases through. Also pins the two vicuna defaults as plain apostrophes and round-trips the escaper in both quote styles.
- `tests/python/test_change_system_message.py`: widened the AST loader to pick up the new helper, and added a case pinning that the predefined branch escapes while the custom branch does not.

Against `main` with the escaper stubbed out to identity, the new file reports 121 failures, so it is not vacuous.
