### PR TITLE
Model picker: remember the Run Settings advanced toggle across models

### DIFF
--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -768,18 +768,14 @@ export function ModelConfigPage({
   const advancedPreference = useSyncExternalStore(
     subscribeAdvancedSettingsOpen,
     readAdvancedSettingsOpen,
-    () => false,
+    () => null,
   );
-  // A model carrying non-default advanced values opens the section on its own
-  // so those stay visible, until the switch is used.
-  const [autoOpenAdvanced, setAutoOpenAdvanced] = useState(() =>
-    hasNonDefaultAdvanced(config),
-  );
-  const showAdvanced = advancedPreference || autoOpenAdvanced;
-  const toggleAdvanced = (open: boolean) => {
-    setAutoOpenAdvanced(false);
-    saveAdvancedSettingsOpen(open);
-  };
+  // Until the switch is used anywhere, a model carrying non-default advanced
+  // values opens the section on its own so those stay visible. Frozen at mount
+  // so editing a field back to its default cannot close the section underfoot.
+  const [autoOpenAdvanced] = useState(() => hasNonDefaultAdvanced(config));
+  const showAdvanced = advancedPreference ?? autoOpenAdvanced;
+  const toggleAdvanced = saveAdvancedSettingsOpen;
   const contextInputRef = useRef<NumericValueInputHandle>(null);
   const maxSeqLengthInputRef = useRef<NumericValueInputHandle>(null);
   const gpuLayersInputRef = useRef<NumericValueInputHandle>(null);

--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -65,7 +65,9 @@ import {
   isDefaultConfig,
   normalizeMaxSeqLength,
   normalizePerModelConfig,
+  readAdvancedSettingsOpen,
   resolveInitialConfig,
+  saveAdvancedSettingsOpen,
   savePerModelConfig,
 } from "../model-config/per-model-config";
 import { ChatTemplateEditorDialog } from "./chat-template-editor-dialog";
@@ -759,9 +761,15 @@ export function ModelConfigPage({
   const [savedRemember, setSavedRemember] = useState(() => initial.remembered);
   const [speculativeFallback] = useState(readPersistedSpeculativeType);
   const [templateOpen, setTemplateOpen] = useState(false);
-  const [showAdvanced, setShowAdvanced] = useState(() =>
-    hasNonDefaultAdvanced(config),
+  // Follows the standing preference, and still opens on its own for a model
+  // carrying non-default advanced values so those stay visible.
+  const [showAdvanced, setShowAdvanced] = useState(
+    () => readAdvancedSettingsOpen() || hasNonDefaultAdvanced(config),
   );
+  const toggleAdvanced = (open: boolean) => {
+    setShowAdvanced(open);
+    saveAdvancedSettingsOpen(open);
+  };
   const contextInputRef = useRef<NumericValueInputHandle>(null);
   const maxSeqLengthInputRef = useRef<NumericValueInputHandle>(null);
   const gpuLayersInputRef = useRef<NumericValueInputHandle>(null);
@@ -1217,7 +1225,7 @@ export function ModelConfigPage({
               <Switch
                 className="panel-switch shrink-0"
                 checked={showAdvanced}
-                onCheckedChange={setShowAdvanced}
+                onCheckedChange={toggleAdvanced}
                 aria-label="Show advanced settings"
               />
             </div>

--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -40,6 +40,7 @@ import {
   useId,
   useRef,
   useState,
+  useSyncExternalStore,
 } from "react";
 import { syncModelOverride } from "../api/model-overrides";
 import {
@@ -69,6 +70,7 @@ import {
   resolveInitialConfig,
   saveAdvancedSettingsOpen,
   savePerModelConfig,
+  subscribeAdvancedSettingsOpen,
 } from "../model-config/per-model-config";
 import { ChatTemplateEditorDialog } from "./chat-template-editor-dialog";
 import type { ModelPickTarget } from "./model-selector/types";
@@ -761,13 +763,21 @@ export function ModelConfigPage({
   const [savedRemember, setSavedRemember] = useState(() => initial.remembered);
   const [speculativeFallback] = useState(readPersistedSpeculativeType);
   const [templateOpen, setTemplateOpen] = useState(false);
-  // Follows the standing preference, and still opens on its own for a model
-  // carrying non-default advanced values so those stay visible.
-  const [showAdvanced, setShowAdvanced] = useState(
-    () => readAdvancedSettingsOpen() || hasNonDefaultAdvanced(config),
+  // Read live, not snapshotted at mount: the sidebar copy of Run Settings stays
+  // mounted while collapsed, so it has to follow a toggle made in the picker.
+  const advancedPreference = useSyncExternalStore(
+    subscribeAdvancedSettingsOpen,
+    readAdvancedSettingsOpen,
+    () => false,
   );
+  // A model carrying non-default advanced values opens the section on its own
+  // so those stay visible, until the switch is used.
+  const [autoOpenAdvanced, setAutoOpenAdvanced] = useState(() =>
+    hasNonDefaultAdvanced(config),
+  );
+  const showAdvanced = advancedPreference || autoOpenAdvanced;
   const toggleAdvanced = (open: boolean) => {
-    setShowAdvanced(open);
+    setAutoOpenAdvanced(false);
     saveAdvancedSettingsOpen(open);
   };
   const contextInputRef = useRef<NumericValueInputHandle>(null);

--- a/studio/frontend/src/features/model-picker/model-config/per-model-config.ts
+++ b/studio/frontend/src/features/model-picker/model-config/per-model-config.ts
@@ -214,20 +214,34 @@ function canUseStorage(): boolean {
 // quant. Closed until asked for.
 export const ADVANCED_SETTINGS_OPEN_KEY = "unsloth_model_advanced_settings";
 
-export function readAdvancedSettingsOpen(): boolean {
+function loadAdvancedSettingsOpen(): boolean | null {
   if (!canUseStorage()) {
-    return false;
+    return null;
   }
   try {
-    return localStorage.getItem(ADVANCED_SETTINGS_OPEN_KEY) === "true";
+    const raw = localStorage.getItem(ADVANCED_SETTINGS_OPEN_KEY);
+    return raw === "true" ? true : raw === "false" ? false : null;
   } catch {
-    return false;
+    return null;
   }
 }
 
+// Memory is the source of truth. A browser that refuses the write still gets a
+// working switch, it just forgets the choice next launch. undefined = unread.
+let advancedOpen: boolean | null | undefined;
 const advancedOpenListeners = new Set<() => void>();
 
+/** null until the switch is used, so an untouched panel is free to open the
+ *  section for a model that carries non-default advanced values. */
+export function readAdvancedSettingsOpen(): boolean | null {
+  if (advancedOpen === undefined) {
+    advancedOpen = loadAdvancedSettingsOpen();
+  }
+  return advancedOpen;
+}
+
 export function saveAdvancedSettingsOpen(open: boolean): void {
+  advancedOpen = open;
   if (canUseStorage()) {
     try {
       localStorage.setItem(ADVANCED_SETTINGS_OPEN_KEY, open ? "true" : "false");
@@ -256,6 +270,7 @@ export function subscribeAdvancedSettingsOpen(
   const onStorage = (event: StorageEvent) => {
     // A null key is a clear(), which drops this preference too.
     if (event.key === null || event.key === ADVANCED_SETTINGS_OPEN_KEY) {
+      advancedOpen = loadAdvancedSettingsOpen();
       onChange();
     }
   };

--- a/studio/frontend/src/features/model-picker/model-config/per-model-config.ts
+++ b/studio/frontend/src/features/model-picker/model-config/per-model-config.ts
@@ -226,29 +226,37 @@ function loadAdvancedSettingsOpen(): boolean | null {
   }
 }
 
-// Memory is the source of truth. A browser that refuses the write still gets a
-// working switch, it just forgets the choice next launch. undefined = unread.
-let advancedOpen: boolean | null | undefined;
+// Set only when a write is refused, so the switch keeps working in a browser
+// with storage disabled, sandboxed or full. Cleared by the next write that
+// sticks, which puts storage back in charge.
+let unpersisted: { open: boolean } | null = null;
 const advancedOpenListeners = new Set<() => void>();
 
 /** null until the switch is used, so an untouched panel is free to open the
- *  section for a model that carries non-default advanced values. */
+ *  section for a model that carries non-default advanced values.
+ *
+ *  Read straight from storage rather than cached: a write from another tab
+ *  while every panel was unmounted has no listener to catch it, and its
+ *  storage event is not replayed on the next mount. */
 export function readAdvancedSettingsOpen(): boolean | null {
-  if (advancedOpen === undefined) {
-    advancedOpen = loadAdvancedSettingsOpen();
+  return unpersisted ? unpersisted.open : loadAdvancedSettingsOpen();
+}
+
+/** True when the choice reached storage. */
+function writeAdvancedSettingsOpen(open: boolean): boolean {
+  if (!canUseStorage()) {
+    return false;
   }
-  return advancedOpen;
+  try {
+    localStorage.setItem(ADVANCED_SETTINGS_OPEN_KEY, open ? "true" : "false");
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function saveAdvancedSettingsOpen(open: boolean): void {
-  advancedOpen = open;
-  if (canUseStorage()) {
-    try {
-      localStorage.setItem(ADVANCED_SETTINGS_OPEN_KEY, open ? "true" : "false");
-    } catch {
-      // ignore
-    }
-  }
+  unpersisted = writeAdvancedSettingsOpen(open) ? null : { open };
   // Run Settings is mounted on several surfaces at once, and the sidebar copy
   // stays mounted while collapsed, so tell them all rather than let them keep
   // a snapshot taken at mount.
@@ -270,7 +278,6 @@ export function subscribeAdvancedSettingsOpen(
   const onStorage = (event: StorageEvent) => {
     // A null key is a clear(), which drops this preference too.
     if (event.key === null || event.key === ADVANCED_SETTINGS_OPEN_KEY) {
-      advancedOpen = loadAdvancedSettingsOpen();
       onChange();
     }
   };

--- a/studio/frontend/src/features/model-picker/model-config/per-model-config.ts
+++ b/studio/frontend/src/features/model-picker/model-config/per-model-config.ts
@@ -228,8 +228,9 @@ function loadAdvancedSettingsOpen(): boolean | null {
 
 // Set only when a write is refused, so the switch keeps working in a browser
 // with storage disabled, sandboxed or full. Cleared by the next write that
-// sticks, which puts storage back in charge.
-let unpersisted: { open: boolean } | null = null;
+// sticks, which puts storage back in charge. `stored` is what storage held at
+// the time, the one signal that tells a later write by someone else apart.
+let unpersisted: { open: boolean; stored: boolean | null } | null = null;
 const advancedOpenListeners = new Set<() => void>();
 
 /** null until the switch is used, so an untouched panel is free to open the
@@ -239,7 +240,18 @@ const advancedOpenListeners = new Set<() => void>();
  *  while every panel was unmounted has no listener to catch it, and its
  *  storage event is not replayed on the next mount. */
 export function readAdvancedSettingsOpen(): boolean | null {
-  return unpersisted ? unpersisted.open : loadAdvancedSettingsOpen();
+  const stored = loadAdvancedSettingsOpen();
+  if (!unpersisted) {
+    return stored;
+  }
+  // Storage moved since the refused write, so someone made a newer choice and
+  // it outranks the fallback. Checked on read, not on the storage event, so it
+  // still holds for an event that landed while nothing was mounted.
+  if (stored !== unpersisted.stored) {
+    unpersisted = null;
+    return stored;
+  }
+  return unpersisted.open;
 }
 
 /** True when the choice reached storage. */
@@ -256,7 +268,9 @@ function writeAdvancedSettingsOpen(open: boolean): boolean {
 }
 
 export function saveAdvancedSettingsOpen(open: boolean): void {
-  unpersisted = writeAdvancedSettingsOpen(open) ? null : { open };
+  unpersisted = writeAdvancedSettingsOpen(open)
+    ? null
+    : { open, stored: loadAdvancedSettingsOpen() };
   // Run Settings is mounted on several surfaces at once, and the sidebar copy
   // stays mounted while collapsed, so tell them all rather than let them keep
   // a snapshot taken at mount.

--- a/studio/frontend/src/features/model-picker/model-config/per-model-config.ts
+++ b/studio/frontend/src/features/model-picker/model-config/per-model-config.ts
@@ -209,6 +209,33 @@ function canUseStorage(): boolean {
   return typeof window !== "undefined";
 }
 
+// Whether Run Settings shows its advanced section is a standing preference,
+// not a per-model one: opening it once keeps it open for every model and
+// quant. Closed until asked for.
+export const ADVANCED_SETTINGS_OPEN_KEY = "unsloth_model_advanced_settings";
+
+export function readAdvancedSettingsOpen(): boolean {
+  if (!canUseStorage()) {
+    return false;
+  }
+  try {
+    return localStorage.getItem(ADVANCED_SETTINGS_OPEN_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function saveAdvancedSettingsOpen(open: boolean): void {
+  if (!canUseStorage()) {
+    return;
+  }
+  try {
+    localStorage.setItem(ADVANCED_SETTINGS_OPEN_KEY, open ? "true" : "false");
+  } catch {
+    // ignore
+  }
+}
+
 function serializedByteLength(value: string): number {
   return typeof TextEncoder !== "undefined"
     ? new TextEncoder().encode(value).byteLength

--- a/studio/frontend/src/features/model-picker/model-config/per-model-config.ts
+++ b/studio/frontend/src/features/model-picker/model-config/per-model-config.ts
@@ -225,15 +225,45 @@ export function readAdvancedSettingsOpen(): boolean {
   }
 }
 
+const advancedOpenListeners = new Set<() => void>();
+
 export function saveAdvancedSettingsOpen(open: boolean): void {
+  if (canUseStorage()) {
+    try {
+      localStorage.setItem(ADVANCED_SETTINGS_OPEN_KEY, open ? "true" : "false");
+    } catch {
+      // ignore
+    }
+  }
+  // Run Settings is mounted on several surfaces at once, and the sidebar copy
+  // stays mounted while collapsed, so tell them all rather than let them keep
+  // a snapshot taken at mount.
+  for (const listener of [...advancedOpenListeners]) {
+    listener();
+  }
+}
+
+/** Follow the preference while mounted, including a change from another tab. */
+export function subscribeAdvancedSettingsOpen(
+  onChange: () => void,
+): () => void {
+  advancedOpenListeners.add(onChange);
   if (!canUseStorage()) {
-    return;
+    return () => {
+      advancedOpenListeners.delete(onChange);
+    };
   }
-  try {
-    localStorage.setItem(ADVANCED_SETTINGS_OPEN_KEY, open ? "true" : "false");
-  } catch {
-    // ignore
-  }
+  const onStorage = (event: StorageEvent) => {
+    // A null key is a clear(), which drops this preference too.
+    if (event.key === null || event.key === ADVANCED_SETTINGS_OPEN_KEY) {
+      onChange();
+    }
+  };
+  window.addEventListener("storage", onStorage);
+  return () => {
+    advancedOpenListeners.delete(onChange);
+    window.removeEventListener("storage", onStorage);
+  };
 }
 
 function serializedByteLength(value: string): number {

--- a/studio/frontend/src/features/settings/tabs/general-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/general-tab.tsx
@@ -95,6 +95,7 @@ const PREFS_KEYS: string[] = [
   "unsloth_model_configs",
   "unsloth_model_configs_migrated",
   "unsloth_load_settings",
+  "unsloth_model_advanced_settings",
   "unsloth_chat_load_on_selection",
   // Model selector settings ("Select model settings" group)
   "unsloth_chat_expand_quantizations",

--- a/studio/frontend/tests/advanced-settings-preference.test.ts
+++ b/studio/frontend/tests/advanced-settings-preference.test.ts
@@ -93,6 +93,47 @@ test("a refused write still moves the switch", () => {
   }
 });
 
+test("a newer choice elsewhere takes over from a refused write", () => {
+  // The quota frees up and another tab writes. Storage now holds a choice made
+  // after the one this tab could not persist, so it wins.
+  const setItem = storage.setItem;
+  storage.setItem = () => {
+    throw new Error("QuotaExceededError");
+  };
+  try {
+    saveAdvancedSettingsOpen(true);
+    assert.equal(readAdvancedSettingsOpen(), true);
+  } finally {
+    storage.setItem = setItem;
+  }
+
+  // No storage event and nothing mounted to hear one: the next read still has
+  // to notice, since events are not replayed.
+  store.set(ADVANCED_SETTINGS_OPEN_KEY, "false");
+  assert.equal(readAdvancedSettingsOpen(), false);
+
+  // And it stays handed back to storage rather than flipping around.
+  store.delete(ADVANCED_SETTINGS_OPEN_KEY);
+  assert.equal(readAdvancedSettingsOpen(), null);
+});
+
+test("a refused write holds while storage stays put", () => {
+  store.set(ADVANCED_SETTINGS_OPEN_KEY, "false");
+  const setItem = storage.setItem;
+  storage.setItem = () => {
+    throw new Error("QuotaExceededError");
+  };
+  try {
+    saveAdvancedSettingsOpen(true);
+    // Nobody else wrote, so the fallback is still the newest choice there is.
+    assert.equal(readAdvancedSettingsOpen(), true);
+    assert.equal(readAdvancedSettingsOpen(), true);
+  } finally {
+    storage.setItem = setItem;
+    store.delete(ADVANCED_SETTINGS_OPEN_KEY);
+  }
+});
+
 test("every mounted panel hears a toggle made on another surface", () => {
   // The sidebar copy stays mounted while collapsed, so a toggle in the picker
   // has to reach it rather than leave it on its mount-time snapshot.

--- a/studio/frontend/tests/advanced-settings-preference.test.ts
+++ b/studio/frontend/tests/advanced-settings-preference.test.ts
@@ -2,6 +2,7 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import {
@@ -70,11 +71,9 @@ test("closing it is remembered as closed, not as untouched", () => {
 });
 
 test("a value it cannot parse counts as untouched", () => {
-  const panel = mounted();
   store.set(ADVANCED_SETTINGS_OPEN_KEY, "yes");
-  fromAnotherTab(ADVANCED_SETTINGS_OPEN_KEY);
   assert.equal(readAdvancedSettingsOpen(), null);
-  panel.unmount();
+  store.delete(ADVANCED_SETTINGS_OPEN_KEY);
 });
 
 test("a refused write still moves the switch", () => {
@@ -123,7 +122,7 @@ test("an unmounted panel stops hearing them", () => {
   assert.equal(panel.changes(), 0);
 });
 
-test("a toggle in another tab reaches mounted panels", () => {
+test("a toggle in another tab repaints mounted panels", () => {
   const panel = mounted();
 
   store.set(ADVANCED_SETTINGS_OPEN_KEY, "false");
@@ -135,13 +134,36 @@ test("a toggle in another tab reaches mounted panels", () => {
   store.delete(ADVANCED_SETTINGS_OPEN_KEY);
   fromAnotherTab(null);
   assert.equal(panel.changes(), 2);
-  assert.equal(readAdvancedSettingsOpen(), null);
 
   // An unrelated key does not.
   fromAnotherTab("unsloth_model_configs");
   assert.equal(panel.changes(), 2);
 
   panel.unmount();
+});
+
+test("a toggle in another tab lands even with no panel mounted to hear it", () => {
+  // Nothing is subscribed, so no storage event is caught, and events are not
+  // replayed. The next panel to mount still has to see the new value.
+  saveAdvancedSettingsOpen(true);
+  store.set(ADVANCED_SETTINGS_OPEN_KEY, "false");
+  assert.equal(readAdvancedSettingsOpen(), false);
+
+  store.delete(ADVANCED_SETTINGS_OPEN_KEY);
+  assert.equal(readAdvancedSettingsOpen(), null);
+});
+
+test("the reset in Settings > General clears it", async () => {
+  const source = await readFile(
+    new URL("../src/features/settings/tabs/general-tab.tsx", import.meta.url),
+    "utf8",
+  );
+  const start = source.indexOf("const PREFS_KEYS");
+  const keys = source.slice(start, source.indexOf("];", start));
+  assert.ok(
+    keys.includes(`"${ADVANCED_SETTINGS_OPEN_KEY}"`),
+    `${ADVANCED_SETTINGS_OPEN_KEY} missing from PREFS_KEYS`,
+  );
 });
 
 test("unsubscribing detaches the cross-tab listener too", () => {

--- a/studio/frontend/tests/advanced-settings-preference.test.ts
+++ b/studio/frontend/tests/advanced-settings-preference.test.ts
@@ -12,10 +12,32 @@ import {
 registerBundlerResolver();
 const { store } = installLocalStorageFake();
 
+// The preference subscribes to cross-tab writes, so the fake window needs the
+// listener pair a browser has.
+const storageHandlers = new Set<(event: StorageEvent) => void>();
+Object.assign(globalThis.window, {
+  addEventListener: (type: string, fn: (event: StorageEvent) => void) => {
+    if (type === "storage") {
+      storageHandlers.add(fn);
+    }
+  },
+  removeEventListener: (type: string, fn: (event: StorageEvent) => void) => {
+    if (type === "storage") {
+      storageHandlers.delete(fn);
+    }
+  },
+});
+const fromAnotherTab = (key: string | null) => {
+  for (const fn of [...storageHandlers]) {
+    fn({ key } as StorageEvent);
+  }
+};
+
 const {
   ADVANCED_SETTINGS_OPEN_KEY,
   readAdvancedSettingsOpen,
   saveAdvancedSettingsOpen,
+  subscribeAdvancedSettingsOpen,
 } = await import(
   "../src/features/model-picker/model-config/per-model-config.ts"
 );
@@ -40,4 +62,68 @@ test("closing it again is remembered too", () => {
 test("an unreadable value falls back to closed", () => {
   store.set(ADVANCED_SETTINGS_OPEN_KEY, "yes");
   assert.equal(readAdvancedSettingsOpen(), false);
+});
+
+test("every mounted panel hears a toggle made on another surface", () => {
+  // The sidebar copy stays mounted while collapsed, so a toggle in the picker
+  // has to reach it rather than leave it on its mount-time snapshot.
+  let sidebar = 0;
+  let hub = 0;
+  const stopSidebar = subscribeAdvancedSettingsOpen(() => {
+    sidebar += 1;
+  });
+  const stopHub = subscribeAdvancedSettingsOpen(() => {
+    hub += 1;
+  });
+
+  saveAdvancedSettingsOpen(true);
+  assert.equal(sidebar, 1);
+  assert.equal(hub, 1);
+  assert.equal(readAdvancedSettingsOpen(), true);
+
+  stopSidebar();
+  stopHub();
+});
+
+test("an unmounted panel stops hearing them", () => {
+  let calls = 0;
+  const stop = subscribeAdvancedSettingsOpen(() => {
+    calls += 1;
+  });
+  stop();
+  saveAdvancedSettingsOpen(false);
+  assert.equal(calls, 0);
+});
+
+test("a toggle in another tab reaches mounted panels", () => {
+  let calls = 0;
+  const stop = subscribeAdvancedSettingsOpen(() => {
+    calls += 1;
+  });
+
+  store.set(ADVANCED_SETTINGS_OPEN_KEY, "true");
+  fromAnotherTab(ADVANCED_SETTINGS_OPEN_KEY);
+  assert.equal(calls, 1);
+  assert.equal(readAdvancedSettingsOpen(), true);
+
+  // A cleared profile drops this key too, so it counts.
+  fromAnotherTab(null);
+  assert.equal(calls, 2);
+
+  // An unrelated key does not.
+  fromAnotherTab("unsloth_model_configs");
+  assert.equal(calls, 2);
+
+  stop();
+});
+
+test("unsubscribing detaches the cross-tab listener too", () => {
+  const before = storageHandlers.size;
+  const noop = () => {
+    // only its registration matters here
+  };
+  const stop = subscribeAdvancedSettingsOpen(noop);
+  assert.equal(storageHandlers.size, before + 1);
+  stop();
+  assert.equal(storageHandlers.size, before);
 });

--- a/studio/frontend/tests/advanced-settings-preference.test.ts
+++ b/studio/frontend/tests/advanced-settings-preference.test.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  installLocalStorageFake,
+  registerBundlerResolver,
+} from "./helpers/kit.ts";
+
+registerBundlerResolver();
+const { store } = installLocalStorageFake();
+
+const {
+  ADVANCED_SETTINGS_OPEN_KEY,
+  readAdvancedSettingsOpen,
+  saveAdvancedSettingsOpen,
+} = await import(
+  "../src/features/model-picker/model-config/per-model-config.ts"
+);
+
+test("a fresh profile keeps the advanced section closed", () => {
+  store.delete(ADVANCED_SETTINGS_OPEN_KEY);
+  assert.equal(readAdvancedSettingsOpen(), false);
+});
+
+test("opening it once is remembered", () => {
+  saveAdvancedSettingsOpen(true);
+  // What the next model, quant, or reload reads.
+  assert.equal(readAdvancedSettingsOpen(), true);
+});
+
+test("closing it again is remembered too", () => {
+  saveAdvancedSettingsOpen(true);
+  saveAdvancedSettingsOpen(false);
+  assert.equal(readAdvancedSettingsOpen(), false);
+});
+
+test("an unreadable value falls back to closed", () => {
+  store.set(ADVANCED_SETTINGS_OPEN_KEY, "yes");
+  assert.equal(readAdvancedSettingsOpen(), false);
+});

--- a/studio/frontend/tests/advanced-settings-preference.test.ts
+++ b/studio/frontend/tests/advanced-settings-preference.test.ts
@@ -10,7 +10,7 @@ import {
 } from "./helpers/kit.ts";
 
 registerBundlerResolver();
-const { store } = installLocalStorageFake();
+const { store, storage } = installLocalStorageFake();
 
 // The preference subscribes to cross-tab writes, so the fake window needs the
 // listener pair a browser has.
@@ -42,88 +42,112 @@ const {
   "../src/features/model-picker/model-config/per-model-config.ts"
 );
 
-test("a fresh profile keeps the advanced section closed", () => {
-  store.delete(ADVANCED_SETTINGS_OPEN_KEY);
-  assert.equal(readAdvancedSettingsOpen(), false);
+/** Subscribed so the cross-tab handler is registered, as a mounted panel is. */
+function mounted(): { changes: () => number; unmount: () => void } {
+  let seen = 0;
+  const stop = subscribeAdvancedSettingsOpen(() => {
+    seen += 1;
+  });
+  return { changes: () => seen, unmount: stop };
+}
+
+test("an untouched profile leaves the section to the model", () => {
+  // null, not false: a model carrying non-default advanced values may still
+  // open the section for itself.
+  assert.equal(readAdvancedSettingsOpen(), null);
 });
 
-test("opening it once is remembered", () => {
+test("opening it is remembered", () => {
   saveAdvancedSettingsOpen(true);
-  // What the next model, quant, or reload reads.
   assert.equal(readAdvancedSettingsOpen(), true);
+  assert.equal(store.get(ADVANCED_SETTINGS_OPEN_KEY), "true");
 });
 
-test("closing it again is remembered too", () => {
-  saveAdvancedSettingsOpen(true);
+test("closing it is remembered as closed, not as untouched", () => {
   saveAdvancedSettingsOpen(false);
+  // The difference that stops a non-default model reopening it.
   assert.equal(readAdvancedSettingsOpen(), false);
 });
 
-test("an unreadable value falls back to closed", () => {
+test("a value it cannot parse counts as untouched", () => {
+  const panel = mounted();
   store.set(ADVANCED_SETTINGS_OPEN_KEY, "yes");
-  assert.equal(readAdvancedSettingsOpen(), false);
+  fromAnotherTab(ADVANCED_SETTINGS_OPEN_KEY);
+  assert.equal(readAdvancedSettingsOpen(), null);
+  panel.unmount();
+});
+
+test("a refused write still moves the switch", () => {
+  // Storage disabled, sandboxed or full. The choice is not remembered next
+  // launch, but the controls have to stay reachable this session.
+  const setItem = storage.setItem;
+  storage.setItem = () => {
+    throw new Error("QuotaExceededError");
+  };
+  try {
+    saveAdvancedSettingsOpen(true);
+    assert.equal(readAdvancedSettingsOpen(), true);
+    saveAdvancedSettingsOpen(false);
+    assert.equal(readAdvancedSettingsOpen(), false);
+  } finally {
+    storage.setItem = setItem;
+  }
 });
 
 test("every mounted panel hears a toggle made on another surface", () => {
   // The sidebar copy stays mounted while collapsed, so a toggle in the picker
   // has to reach it rather than leave it on its mount-time snapshot.
-  let sidebar = 0;
-  let hub = 0;
-  const stopSidebar = subscribeAdvancedSettingsOpen(() => {
-    sidebar += 1;
-  });
-  const stopHub = subscribeAdvancedSettingsOpen(() => {
-    hub += 1;
-  });
+  const sidebar = mounted();
+  const hub = mounted();
 
   saveAdvancedSettingsOpen(true);
-  assert.equal(sidebar, 1);
-  assert.equal(hub, 1);
+  assert.equal(sidebar.changes(), 1);
+  assert.equal(hub.changes(), 1);
   assert.equal(readAdvancedSettingsOpen(), true);
 
-  stopSidebar();
-  stopHub();
+  // Closing on one surface closes it on the other, including a panel that
+  // opened itself for a non-default model: an explicit choice outranks that.
+  saveAdvancedSettingsOpen(false);
+  assert.equal(sidebar.changes(), 2);
+  assert.equal(hub.changes(), 2);
+  assert.equal(readAdvancedSettingsOpen(), false);
+
+  sidebar.unmount();
+  hub.unmount();
 });
 
 test("an unmounted panel stops hearing them", () => {
-  let calls = 0;
-  const stop = subscribeAdvancedSettingsOpen(() => {
-    calls += 1;
-  });
-  stop();
-  saveAdvancedSettingsOpen(false);
-  assert.equal(calls, 0);
+  const panel = mounted();
+  panel.unmount();
+  saveAdvancedSettingsOpen(true);
+  assert.equal(panel.changes(), 0);
 });
 
 test("a toggle in another tab reaches mounted panels", () => {
-  let calls = 0;
-  const stop = subscribeAdvancedSettingsOpen(() => {
-    calls += 1;
-  });
+  const panel = mounted();
 
-  store.set(ADVANCED_SETTINGS_OPEN_KEY, "true");
+  store.set(ADVANCED_SETTINGS_OPEN_KEY, "false");
   fromAnotherTab(ADVANCED_SETTINGS_OPEN_KEY);
-  assert.equal(calls, 1);
-  assert.equal(readAdvancedSettingsOpen(), true);
+  assert.equal(panel.changes(), 1);
+  assert.equal(readAdvancedSettingsOpen(), false);
 
   // A cleared profile drops this key too, so it counts.
+  store.delete(ADVANCED_SETTINGS_OPEN_KEY);
   fromAnotherTab(null);
-  assert.equal(calls, 2);
+  assert.equal(panel.changes(), 2);
+  assert.equal(readAdvancedSettingsOpen(), null);
 
   // An unrelated key does not.
   fromAnotherTab("unsloth_model_configs");
-  assert.equal(calls, 2);
+  assert.equal(panel.changes(), 2);
 
-  stop();
+  panel.unmount();
 });
 
 test("unsubscribing detaches the cross-tab listener too", () => {
   const before = storageHandlers.size;
-  const noop = () => {
-    // only its registration matters here
-  };
-  const stop = subscribeAdvancedSettingsOpen(noop);
+  const panel = mounted();
   assert.equal(storageHandlers.size, before + 1);
-  stop();
+  panel.unmount();
   assert.equal(storageHandlers.size, before);
 });


### PR DESCRIPTION
### Before

`Advanced settings` in the model picker's Run Settings panel reset every time. The state lived only in component state, seeded from whether the model happened to carry non-default advanced values, so switching model or quant, or reopening the panel, closed the section again. Anyone who works in KV Cache Dtype or GPU Memory had to switch it back on for every model.

### After

The toggle is a standing preference with three states rather than two:

- unset, the default, leaves the decision to the panel, so a model carrying non-default advanced values still opens the section for itself and those values stay visible
- on or off is an explicit choice and wins outright, for every model and quant, until it is changed

Run Settings is mounted on three surfaces (the picker, the chat sidebar, the hub settings view), and the sidebar copy stays mounted while collapsed, so the preference is read through a subscription rather than snapshotted at mount. Every mounted panel follows a toggle made on any of them, and writes from another tab are picked up as well. This follows the pattern in `use-sidebar-pin.ts`.

The value is read from storage rather than cached, so a change made in another tab while every panel was unmounted is still seen on the next mount. Storage events are not replayed, so a cache would have gone stale there.

A browser that refuses the write (storage disabled, sandboxed, or full) still gets a working switch, backed by memory for that session. That fallback records what storage held at the time, so if storage later moves, a newer choice made elsewhere takes over rather than being ignored.

`Settings > General > Reset all local preferences` clears the key, which its explicit key list would otherwise have skipped.

### Notes

The helpers live in `per-model-config.ts` next to the rest of the model config storage rather than in the chat runtime store, which keeps them importable from tests.

The auto-open check is frozen at mount rather than recomputed, otherwise editing a field back to its default would close the section while it was being used.

The section is GGUF only, as before. Nothing about how a model loads changes, only which rows the panel draws.

### Testing

`tests/advanced-settings-preference.test.ts`, 13 tests: untouched profile reads as unset, open remembered, close remembered as closed rather than untouched, unparseable value counts as untouched, a refused write still moves the switch, a refused write holds while storage stays put, a newer choice elsewhere takes over from a refused write, all mounted panels notified on both open and close, unsubscribe stops delivery, cross-tab event including a null key from a clear and an unrelated key, a cross-tab write seen with no panel mounted to hear it, the key present in the Settings reset list, and listener detach on unmount.

Every fix is mutation checked against the tests that cover it:

- restoring the cache fails the two cross-tab tests plus three others
- dropping the refused-write fallback fails only `a refused write still moves the switch`
- reconciling that fallback on the storage event instead of on read fails the cross-tab takeover test, since events are not replayed to a panel that was unmounted
- always dropping the fallback fails the two tests that keep the switch usable while storage refuses writes
- collapsing the tri-state back to a boolean fails the three tests that need unset distinct from closed
- removing the key from `PREFS_KEYS` fails only the reset test

- `npm run typecheck` clean
- `npm test`: 299 passing, 0 failing
- `npm run build` clean
- `biome check` on all three touched source files matches `main` exactly, and the new test file carries the same `noNodejsModules` warnings `sidebar-width.test.ts` does for the same reason