### PR TITLE
Follow the third load site in the pinned-row contract test

### DIFF
--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -395,8 +395,15 @@ def test_a_pinned_cached_row_loads_from_the_id_the_backend_pinned():
 
     picker = _read("features/model-picker/components/model-selector/pickers.tsx")
     assert "loadId={c.load_id}" in picker, "the quant list cannot pass on a pin it never gets"
-    # Both rows and the gear beside each: Run reloads through the same meta.
-    assert picker.count("loadId: c.load_id") == 2, "the safetensors row and its gear need the pin"
+    # Every row that can start a load, and every gear beside one, reloads through
+    # the same meta and so has to carry the pin. Counted rather than matched
+    # loosely, so a new row that forgets it is a failure here rather than a load
+    # that silently follows the default ref. #7736 added the third: the collapsed
+    # single-quant GGUF row, which is a load site like the other two.
+    assert picker.count("loadId: c.load_id") == 3, (
+        "a row or gear that can start a load is missing the pin, or a new one was "
+        "added and this count needs to follow it"
+    )
     block = re.search(r"onConfigure\(repoId, \{.*?\n\s*\}", picker, re.S)
     assert block and "loadId," in block.group(0), "the GGUF gear drops the pin"
     # The variant click withholds it: a quant outside the pinned snapshot lands in a different one.


### PR DESCRIPTION
main has been red since #7736. `tests/studio/test_model_picker_contracts.py::test_a_pinned_cached_row_loads_from_the_id_the_backend_pinned` fails on every PR branched after it, for reasons unrelated to what those PRs change, which is how I ran into it.

```
assert picker.count("loadId: c.load_id") == 2
E   AssertionError: the safetensors row and its gear need the pin
E   assert 3 == 2
```

The assertion counts the sites that pass the pinned snapshot id into the load meta, and expected two: the safetensors row and the gear beside it. #7736 added a third, the collapsed single-quant GGUF row, and that row is a load site like the other two and correctly carries the pin. So the code is right and the count was stale.

Bisected: `3742317f7` passes, `63307b17f` (#7736) fails.

Counted rather than matched loosely on purpose, so a row that forgets the pin fails here instead of silently loading from the repo default ref. I kept it that way and moved the count, rather than relaxing it to `>= 2` and giving up the property. Checked that it still fails if any one of the three sites drops the pin.