### PR TITLE
Align the sidebar nav and Recents spinners on one column

### DIFF
--- a/studio/frontend/src/components/app-sidebar.tsx
+++ b/studio/frontend/src/components/app-sidebar.tsx
@@ -323,7 +323,9 @@ function NavItem({
           <HugeiconsIcon icon={icon} strokeWidth={1.75} className="size-icon! shrink-0 group-hover/menu-button:animate-icon-pop" />
           <span className="text-ui-14p5 leading-ui-19 tracking-nav">{label}</span>
           {spinner && (
-            <Spinner className="ml-auto size-3.5 shrink-0 text-muted-foreground group-data-[collapsible=icon]:hidden" />
+            // mr-1.5 over the row's pr-2.5 = 16px, matching the chat rows'
+            // pr-4 so nav and Recents spinners share one column.
+            <Spinner className="ml-auto mr-1.5 size-3.5 shrink-0 text-muted-foreground group-data-[collapsible=icon]:hidden" />
           )}
         </SidebarMenuButton>
         {spinner && (

--- a/studio/frontend/tests/sidebar-spinner-column.test.ts
+++ b/studio/frontend/tests/sidebar-spinner-column.test.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFile } from "node:fs/promises";
+
+// Both spinners are ml-auto, so each one sits at its row's padding-right plus
+// its own margin-right. The two rows carry different padding, so the margins
+// have to make up the difference or the column visibly steps.
+const TAILWIND_UNIT = 4;
+
+function inset(classes: string, prefix: string): number {
+  const m = new RegExp(`(?:^| )${prefix}-([0-9.]+)(?: |$)`).exec(classes);
+  return m ? Number(m[1]) * TAILWIND_UNIT : 0;
+}
+
+function grab(source: string, pattern: RegExp, what: string): string {
+  const m = pattern.exec(source);
+  assert.ok(m, `could not find ${what} in app-sidebar.tsx`);
+  return m[1];
+}
+
+test("nav and Recents spinners land on one trailing column", async () => {
+  const source = await readFile(
+    new URL("../src/components/app-sidebar.tsx", import.meta.url),
+    "utf8",
+  );
+
+  const navRow = grab(
+    source,
+    /className="(sidebar-nav-btn h-\[33px\] rounded-full[^"]*)"/,
+    "NavItem row",
+  );
+  const navSpinner = grab(
+    source,
+    /<Spinner className="(ml-auto[^"]*group-data-\[collapsible=icon\]:hidden)"/,
+    "NavItem spinner",
+  );
+  const chatRow = grab(
+    source,
+    /"(sidebar-nav-btn h-\[33px\] cursor-pointer rounded-full[^"]*)"/,
+    "Recents chat row",
+  );
+  const chatSpinner = grab(
+    source,
+    /data-testid="chat-row-spinner"[\s\S]{0,200}?className="(ml-auto[^"]*)"/,
+    "Recents chat spinner",
+  );
+
+  const nav = inset(navRow, "pr") + inset(navSpinner, "mr");
+  const chat = inset(chatRow, "pr") + inset(chatSpinner, "mr");
+
+  assert.equal(nav, chat, `nav spinner sits ${nav}px in, chat spinner ${chat}px`);
+  assert.equal(nav, 16);
+});


### PR DESCRIPTION
## Problem

Running a training job and two chats at the same time puts three spinners in the sidebar at once, and they do not line up. The Train spinner sits slightly right of the two Recents ones.

The nav rows and the Recents chat rows carry different trailing padding, and both spinners are `ml-auto`, so each one parks at its own row's content edge:

| Row | padding-right | spinner right edge |
| --- | --- | --- |
| `NavItem` (Train, Recipes, Export, New chat) | 10px (`pr-2.5`) | 262 |
| Recents chat row | 16px (`pr-4`) | 256 |

Edges measured on a 1440px viewport. Everything else about the two sections already matches (`pl-3` rows, `pr-1.75` group content, `size-3.5` glyphs), which is why the left edges line up perfectly and only the right side steps.

## Fix

Give the `NavItem` spinner `mr-1.5`, so its 10px row padding plus 6px margin equals the chat rows' 16px. The margin is on the spinner element rather than the row, so nav rows that are not showing a spinner keep their current padding.

## Verification

Measured against a running Studio by injecting the real classes into the live rows and reading `getBoundingClientRect`:

```
BEFORE  distinct spinner right edges: [256, 262]  spread=6.00px
AFTER   distinct spinner right edges: [256]       spread=0.00px
```

- `npm run typecheck` clean
- `npm run test` 243 passing, including the new one
- biome and eslint report the same counts on this file before and after the change, so nothing new is introduced
- the new test fails on the pre-fix source with `nav spinner sits 10px in, chat spinner 16px`, and an AST diff of the component confirms the edit changes one string literal and leaves the JSX structure identical

## Follow up, not in this PR

Hovering a Recents row that is generating bumps it to `pr-6` (24px), which slides the spinner 8px further left while the kebab fades in over the same area. `.sidebar-row-action` puts its `size-6` glyph in the rightmost 30px, so the two overlap by about 6px. The `pr-6` looks deliberate given the comment about the title keeping one more character, so I left that call alone here.
