### PR TITLE
CI: compare the workflow path as posix so the Pester guard passes on Windows

### DIFF
--- a/tests/studio/test_pester_bootstrap_hardening.py
+++ b/tests/studio/test_pester_bootstrap_hardening.py
@@ -110,7 +110,9 @@ def test_the_guard_runs_from_the_workflow_it_guards():
     """No pytest workflow filters on this file, so the job must run the guard itself."""
     workflow = yaml.safe_load(_WORKFLOW.read_text(encoding = "utf-8"))
     on = workflow.get("on") or workflow.get(True)
-    assert str(_WORKFLOW.relative_to(REPO_ROOT)) in on["pull_request"]["paths"]
+    # as_posix(), not str(): this runs on windows-latest, where str() would give
+    # backslashes and never match the forward-slash paths in the YAML.
+    assert _WORKFLOW.relative_to(REPO_ROOT).as_posix() in on["pull_request"]["paths"]
     steps = workflow["jobs"]["pester"]["steps"]
     assert any(
         Path(__file__).name in (s.get("run") or "") for s in steps


### PR DESCRIPTION
## Problem

The `Guard the Pester bootstrap` step added in #7743 fails on `windows-latest`, so `setup.ps1 unit tests (VS 2026 / CMake guard)` now fails on every PR that touches this workflow's `paths` (`studio/**`, `unsloth/**`, `unsloth_cli/**`, `install.ps1`, `pyproject.toml`, `tests/studio_setup_ps1/**`).

`Path.relative_to()` renders Windows separators, while the paths in the workflow YAML use forward slashes, so the membership check could never match:

```
E  AssertionError: assert '.github\\workflows\\studio-windows-inference-smoke.yml' in
   ['studio/**', 'unsloth/**', 'unsloth_cli/**', 'install.ps1', 'pyproject.toml', ...]
```

The guard itself is correct. Only the path comparison was platform-dependent, and it was written and run on Linux, where `str()` and `as_posix()` happen to agree.

## Fix

Compare with `as_posix()`.

## Verification

Reproduced and confirmed on the real `windows-latest` runner rather than only locally:

- Before: `Guard the Pester bootstrap` fails, `Install Pester v5` and `Run Pester suite` skipped, job red.
- After: job green, guard passes, and the Pester suite it gates runs as before.

The other seven assertions in the file are substring checks against the step body and are unaffected by path separators.
