### PR TITLE
Model picker: context length hint, and the preset note as a tooltip

### DIFF
--- a/studio/frontend/src/features/chat/chat-settings-sheet.tsx
+++ b/studio/frontend/src/features/chat/chat-settings-sheet.tsx
@@ -901,6 +901,25 @@ export function ChatSettingsPanel({
 
         <CollapsibleSection
           label="Preset"
+          headerAction={
+            <InfoHint>
+              Saving a preset also stores current load settings (context length,
+              KV cache dtype, speculative decoding, GPU layers).
+              {currentLoadSummary ? (
+                <>
+                  {" "}
+                  Active now: {currentLoadSummary}.
+                </>
+              ) : null}
+              {activePresetLoadSummary &&
+              activePresetLoadSummary !== currentLoadSummary ? (
+                <>
+                  {" "}
+                  Saved in preset: {activePresetLoadSummary}.
+                </>
+              ) : null}
+            </InfoHint>
+          }
           defaultOpen={true}
           first={!hasModelContent && !modelConfig}
         >
@@ -1022,23 +1041,6 @@ export function ChatSettingsPanel({
                 Delete
               </Button>
             </div>
-            <p className="text-ui-11 leading-relaxed text-muted-foreground">
-              Saving a preset also stores current load settings (context length,
-              KV cache dtype, speculative decoding, GPU layers).
-              {currentLoadSummary ? (
-                <>
-                  {" "}
-                  Active now: {currentLoadSummary}.
-                </>
-              ) : null}
-              {activePresetLoadSummary &&
-              activePresetLoadSummary !== currentLoadSummary ? (
-                <>
-                  {" "}
-                  Saved in preset: {activePresetLoadSummary}.
-                </>
-              ) : null}
-            </p>
           </div>
         </CollapsibleSection>
 

--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -1191,6 +1191,10 @@ export function ModelConfigPage({
                   aria-label="Context Length"
                 />
               ) : null}
+              <p className="text-ui-11 leading-relaxed text-muted-foreground">
+                Unsloth automatically uses 95% of your device's maximum
+                supported context, but you can adjust it.
+              </p>
               {isActiveModel &&
                 loadedMaxContextLength != null &&
                 contextValue > loadedMaxContextLength && (

--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -1192,8 +1192,8 @@ export function ModelConfigPage({
                 />
               ) : null}
               <p className="text-ui-11 leading-relaxed text-muted-foreground">
-                Unsloth automatically uses 95% of your device's maximum
-                supported context, but you can adjust it.
+                By default, Unsloth uses the maximum context supported by your
+                device.
               </p>
               {isActiveModel &&
                 loadedMaxContextLength != null &&

--- a/studio/frontend/src/features/model-picker/components/model-config-page.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-config-page.tsx
@@ -1192,8 +1192,8 @@ export function ModelConfigPage({
                 />
               ) : null}
               <p className="text-ui-11 leading-relaxed text-muted-foreground">
-                By default, Unsloth uses the maximum context supported by your
-                device.
+                By default, Unsloth uses the model's full context, lowering it
+                only if it will not fit your device's memory.
               </p>
               {isActiveModel &&
                 loadedMaxContextLength != null &&


### PR DESCRIPTION
### Context Length hint

Adds a line under the Context Length slider saying where the number came from:

> By default, Unsloth uses the model's full context, lowering it only if it will not fit your device's memory.

That matches the loader: the field defaults to the model's native context, and `_fit_context_to_vram` reduces it to the largest context that fits the memory budget, returning the request verbatim when KV metadata is unavailable or the cache is offloaded to CPU RAM.

The model picker and the Run Settings sidebar render the same block, so both surfaces get it from the one change. It sits under the slider and above the existing VRAM warning, which keeps the amber line next to the value it refers to, and uses the muted helper style the panel already uses for descriptions.

### Preset note

The note about what a preset stores was a paragraph under the Save and Delete buttons. It is read once and then takes up height on every visit, and it was the only explanation in the panel not behind the usual info affordance.

It moves to an `InfoHint` on the Preset section header, passed through `headerAction`, which exists for this and keeps the control a sibling of the label and chevron rather than a button inside a button. The dynamic parts are unchanged: the active load summary and, when it differs, the summary saved in the preset both still show inside the tooltip.

The panel's tooltip trigger toggles on click as well as hover, so the note stays reachable on touch.

### Testing

- `npm run typecheck` clean
- `npm test`: 300 passing, 0 failing
- `npm run build` clean
- `biome check` on both touched files matches `main` exactly