### PR TITLE
Stop the atexit teardown printing tracebacks after the run has ended

### DIFF
--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -12,6 +12,7 @@ import atexit
 import contextlib
 import functools
 import json
+import logging
 import math
 import os
 import re
@@ -10591,6 +10592,17 @@ class LlamaCppBackend:
         self._diffusion_requested_ngl = None
         if self._process is None:
             return
+        # Not every _process is a Popen. Tests stand one in to mean "a server is
+        # loaded" without spawning anything, and a backend torn down mid-start can
+        # hold whatever __init__ got as far as. Terminating what cannot be
+        # terminated is not an error worth reporting -- the state still has to be
+        # cleared either way, which the finally below does.
+        if not hasattr(self._process, "terminate"):
+            logger.debug("no terminable llama-server process to kill; clearing state")
+            self._process = None
+            self._clear_server_pid()
+            self._healthy = False
+            return
         try:
             self._process.terminate()
             self._process.wait(timeout = 5)
@@ -11006,8 +11018,25 @@ class LlamaCppBackend:
         return killed
 
     def _cleanup(self):
-        """atexit handler to ensure llama-server is terminated."""
-        self._kill_process()
+        """atexit handler to ensure llama-server is terminated.
+
+        Nothing here may report a failure through the logging machinery. By the
+        time atexit runs, the streams the handlers write to can already be closed,
+        and logging then prints its own traceback about that on top of whatever it
+        was trying to say -- so a warning about a kill that did not work turns into
+        several unrelated tracebacks after the test summary, which is how this was
+        found. raiseExceptions is the switch logging provides for exactly this, and
+        the process is ending, so restoring it is a formality rather than a need.
+        """
+        raise_exceptions = logging.raiseExceptions
+        logging.raiseExceptions = False
+        try:
+            self._kill_process()
+        except Exception:
+            # atexit swallows this anyway, and there is nowhere left to report it.
+            pass
+        finally:
+            logging.raiseExceptions = raise_exceptions
 
     @staticmethod
     def _fit_off_retry_eligible(cmd: "list[str]", use_fit: bool) -> bool:

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -10592,24 +10592,26 @@ class LlamaCppBackend:
         self._diffusion_requested_ngl = None
         if self._process is None:
             return
-        # Not every _process is a Popen. Tests stand one in to mean "a server is
-        # loaded" without spawning anything, and a backend torn down mid-start can
-        # hold whatever __init__ got as far as. Terminating what cannot be
-        # terminated is not an error worth reporting -- the state still has to be
-        # cleared either way, which the finally below does.
-        if not hasattr(self._process, "terminate"):
+        # Not every _process is a Popen: tests stand one in to mean "a server is
+        # loaded" without spawning anything. Terminating what cannot be terminated
+        # is not an error worth reporting, but everything else still has to happen,
+        # so this skips only the signalling and falls through to the finally rather
+        # than returning early and duplicating part of it.
+        terminable = hasattr(self._process, "terminate")
+        if not terminable:
             logger.debug("no terminable llama-server process to kill; clearing state")
-            self._process = None
-            self._clear_server_pid()
-            self._healthy = False
-            return
         try:
-            self._process.terminate()
-            self._process.wait(timeout = 5)
+            if terminable:
+                self._process.terminate()
+                self._process.wait(timeout = 5)
         except subprocess.TimeoutExpired:
-            logger.warning("llama-server did not exit on SIGTERM, sending SIGKILL")
+            # Signal first, report after. logger here is a structlog PrintLogger
+            # writing straight to stdout, so a closed stream raises out of the
+            # warning; doing it first meant SIGKILL was skipped and the server
+            # left running with the reference about to be dropped below.
             self._process.kill()
             self._process.wait(timeout = 5)
+            logger.warning("llama-server did not exit on SIGTERM, sent SIGKILL")
         except Exception as e:
             logger.warning(f"Error killing llama-server process: {e}")
         finally:
@@ -11022,11 +11024,16 @@ class LlamaCppBackend:
 
         Nothing here may report a failure through the logging machinery. By the
         time atexit runs, the streams the handlers write to can already be closed,
-        and logging then prints its own traceback about that on top of whatever it
-        was trying to say -- so a warning about a kill that did not work turns into
-        several unrelated tracebacks after the test summary, which is how this was
-        found. raiseExceptions is the switch logging provides for exactly this, and
-        the process is ending, so restoring it is a formality rather than a need.
+        and a write then fails -- which is how this was found, as several unrelated
+        tracebacks printed after the test summary.
+
+        Two different mechanisms, because there are two kinds of logger in play.
+        This module's own logger is a structlog PrintLogger writing straight to
+        stdout (loggers/config.py), which has no error handling of its own and does
+        not consult raiseExceptions at all, so only the except below covers it.
+        raiseExceptions covers the stdlib loggers other libraries install, which
+        report a broken handler by printing their own traceback instead of raising.
+        Neither one alone is enough.
         """
         raise_exceptions = logging.raiseExceptions
         logging.raiseExceptions = False

--- a/studio/backend/core/inference/llama_cpp.py
+++ b/studio/backend/core/inference/llama_cpp.py
@@ -10610,8 +10610,13 @@ class LlamaCppBackend:
             # warning; doing it first meant SIGKILL was skipped and the server
             # left running with the reference about to be dropped below.
             self._process.kill()
-            self._process.wait(timeout = 5)
+            # Between the two, deliberately. After kill() so the signal never
+            # depends on a log write, and before this wait() because a second
+            # TimeoutExpired raised in here is not caught by the handler it is
+            # raised from -- it escapes, and a truly unkillable server would then
+            # be reported by nothing at all.
             logger.warning("llama-server did not exit on SIGTERM, sent SIGKILL")
+            self._process.wait(timeout = 5)
         except Exception as e:
             logger.warning(f"Error killing llama-server process: {e}")
         finally:

--- a/studio/backend/tests/test_llama_cpp_atexit_quiet.py
+++ b/studio/backend/tests/test_llama_cpp_atexit_quiet.py
@@ -16,6 +16,8 @@ import os
 import subprocess
 import sys
 
+import pytest
+
 _backend = os.path.join(os.path.dirname(__file__), "..")
 sys.path.insert(0, _backend)
 
@@ -60,19 +62,38 @@ class _RecordingLogger:
         return sink
 
 
-def test_a_process_that_cannot_be_terminated_is_not_an_error(monkeypatch):
+class _Reader:
+    def __init__(self):
+        self.joined = False
+
+    def join(self, timeout = None):
+        self.joined = True
+
+
+def test_a_process_that_cannot_be_terminated_is_not_an_error(monkeypatch, tmp_path):
     from core.inference import llama_cpp as mod
 
     recorder = _RecordingLogger()
     monkeypatch.setattr(mod, "logger", recorder)
     backend = _stub()
     backend._process = _Unterminable()
+    log_fh = open(tmp_path / "llama.log", "w")
+    reader = _Reader()
+    backend._llama_log_fh = log_fh
+    backend._stdout_thread = reader
 
     backend._kill_process()
 
     assert backend._process is None, "the state has to be cleared either way"
     assert backend._healthy is False
     assert recorder.warnings == [], f"warned about a non-process: {recorder.warnings}"
+    # The whole finalizer, not the three assignments an earlier version of this
+    # duplicated: the log handle has to be closed and the reader joined, or a
+    # teardown that takes this path leaks them.
+    assert log_fh.closed, "the log handle was left open"
+    assert backend._llama_log_fh is None
+    assert reader.joined, "the stdout reader was never joined"
+    assert backend._stdout_thread is None
 
 
 class _RaisingLogger:
@@ -164,6 +185,32 @@ def test_sigkill_still_happens_when_the_log_write_fails(monkeypatch):
         pass  # the write still fails; what matters is that it failed after the kill
 
     assert proc.killed, "SIGKILL was skipped because the warning raised first"
+
+
+class _UnkillableProcess(_StubbornProcess):
+    """Ignores SIGKILL too, e.g. stuck in an uninterruptible wait."""
+
+    def wait(self, timeout = None):
+        raise subprocess.TimeoutExpired("llama-server", timeout)
+
+
+def test_an_unkillable_server_is_still_reported(monkeypatch):
+    """The second wait raises from inside the handler it was raised from, so it is
+    not caught there and escapes. If the warning came after it, the one case an
+    operator most needs to see would be reported by nothing at all."""
+    from core.inference import llama_cpp as mod
+
+    recorder = _RecordingLogger()
+    monkeypatch.setattr(mod, "logger", recorder)
+    backend = _stub()
+    backend._process = _UnkillableProcess()
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        backend._kill_process()
+
+    assert any("SIGKILL" in w for w in recorder.warnings), (
+        "an unkillable server was dropped without a word about it"
+    )
 
 
 def test_the_handler_leaves_raise_exceptions_as_it_found_it(monkeypatch):

--- a/studio/backend/tests/test_llama_cpp_atexit_quiet.py
+++ b/studio/backend/tests/test_llama_cpp_atexit_quiet.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""The atexit teardown must not print tracebacks after the program has ended.
+
+_cleanup runs from atexit, by which point the streams the log handlers write to
+can already be closed. Logging then prints its own traceback about the closed
+stream on top of whatever it was trying to report, so one warning about a kill
+that did not work became several unrelated tracebacks after the pytest summary --
+which is how this was found, by them burying the summary line.
+"""
+
+import io
+import logging
+import os
+import sys
+
+_backend = os.path.join(os.path.dirname(__file__), "..")
+sys.path.insert(0, _backend)
+
+from core.inference.llama_cpp import LlamaCppBackend  # noqa: E402
+
+
+def _stub() -> LlamaCppBackend:
+    backend = LlamaCppBackend.__new__(LlamaCppBackend)
+    backend._process = None
+    backend._healthy = True
+    return backend
+
+
+class _Unterminable:
+    """What a backend can be holding: something that is not a Popen.
+
+    Tests stand one in to mean "a server is loaded" without spawning anything, and
+    a backend torn down mid-start holds whatever __init__ got as far as.
+    """
+
+
+class _RecordingLogger:
+    """Stands in for the module logger, which is a structlog bound logger rather
+    than a stdlib one -- caplog never sees it, so an assertion against caplog would
+    hold however loudly this warned."""
+
+    def __init__(self):
+        self.warnings = []
+        self.other = []
+
+    def warning(self, msg, *a, **k):
+        self.warnings.append(str(msg))
+
+    def __getattr__(self, name):
+        def sink(msg = "", *a, **k):
+            self.other.append((name, str(msg)))
+        return sink
+
+
+def test_a_process_that_cannot_be_terminated_is_not_an_error(monkeypatch):
+    from core.inference import llama_cpp as mod
+
+    recorder = _RecordingLogger()
+    monkeypatch.setattr(mod, "logger", recorder)
+    backend = _stub()
+    backend._process = _Unterminable()
+
+    backend._kill_process()
+
+    assert backend._process is None, "the state has to be cleared either way"
+    assert backend._healthy is False
+    assert recorder.warnings == [], f"warned about a non-process: {recorder.warnings}"
+
+
+def test_the_atexit_handler_writes_nothing_to_a_closed_stream(monkeypatch, capsys):
+    """The failure mode itself: a handler whose stream has gone, which is the state
+    the interpreter leaves them in by the time atexit runs."""
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    stream.close()
+
+    from core.inference import llama_cpp as mod
+
+    monkeypatch.setattr(mod, "logger", logging.getLogger("unsloth-atexit-test"))
+    mod.logger.addHandler(handler)
+    mod.logger.propagate = False
+    try:
+        backend = _stub()
+        backend._process = _Unterminable()
+
+        backend._cleanup()
+
+        # Logging reports a broken handler by printing to stderr itself, so that
+        # is where the noise lands rather than in caplog.
+        assert capsys.readouterr().err == ""
+    finally:
+        mod.logger.removeHandler(handler)
+        mod.logger.propagate = True
+
+
+def test_the_handler_leaves_raise_exceptions_as_it_found_it(monkeypatch):
+    """Only atexit gets the quiet treatment; a live run must still surface a
+    broken logging handler."""
+    from core.inference import llama_cpp as mod
+
+    monkeypatch.setattr(logging, "raiseExceptions", True)
+    backend = _stub()
+    backend._process = _Unterminable()
+
+    backend._cleanup()
+
+    assert logging.raiseExceptions is True
+
+
+def test_a_failing_kill_does_not_escape_the_atexit_handler(monkeypatch):
+    """atexit swallows it anyway, and there is nowhere left to report it."""
+    backend = _stub()
+
+    def boom():
+        raise RuntimeError("teardown went wrong")
+
+    monkeypatch.setattr(backend, "_kill_process", boom)
+
+    backend._cleanup()

--- a/studio/backend/tests/test_llama_cpp_atexit_quiet.py
+++ b/studio/backend/tests/test_llama_cpp_atexit_quiet.py
@@ -13,6 +13,7 @@ which is how this was found, by them burying the summary line.
 import io
 import logging
 import os
+import subprocess
 import sys
 
 _backend = os.path.join(os.path.dirname(__file__), "..")
@@ -74,30 +75,94 @@ def test_a_process_that_cannot_be_terminated_is_not_an_error(monkeypatch):
     assert recorder.warnings == [], f"warned about a non-process: {recorder.warnings}"
 
 
-def test_the_atexit_handler_writes_nothing_to_a_closed_stream(monkeypatch, capsys):
-    """The failure mode itself: a handler whose stream has gone, which is the state
-    the interpreter leaves them in by the time atexit runs."""
+class _RaisingLogger:
+    """A logger whose writes fail, like the real one once stdout is closed.
+
+    The module logger is a structlog PrintLogger writing straight to stdout, so a
+    closed stream raises ValueError out of the call. Deliberately not a stdlib
+    logger: that reports a broken handler by printing its own traceback rather
+    than raising, so a stdlib stand-in exercises raiseExceptions and proves
+    nothing about the path this module actually takes.
+    """
+
+    def __getattr__(self, name):
+        def boom(*a, **k):
+            raise ValueError("I/O operation on closed file")
+        return boom
+
+
+def test_a_logger_that_raises_does_not_escape_the_atexit_handler(monkeypatch):
+    from core.inference import llama_cpp as mod
+
+    monkeypatch.setattr(mod, "logger", _RaisingLogger())
+    backend = _stub()
+    backend._process = _Unterminable()
+
+    backend._cleanup()
+
+
+def test_the_atexit_handler_quiets_stdlib_loggers_too(monkeypatch, capsys):
+    """Other libraries install stdlib loggers that fire during teardown, and those
+    print their own traceback about a closed handler rather than raising, so the
+    except above never sees them."""
     stream = io.StringIO()
     handler = logging.StreamHandler(stream)
     stream.close()
+    other = logging.getLogger("unsloth-atexit-test-stdlib")
+    other.addHandler(handler)
+    other.propagate = False
 
     from core.inference import llama_cpp as mod
 
-    monkeypatch.setattr(mod, "logger", logging.getLogger("unsloth-atexit-test"))
-    mod.logger.addHandler(handler)
-    mod.logger.propagate = False
+    def kill_and_log():
+        other.warning("something a dependency logs at exit")
+
+    backend = _stub()
+    monkeypatch.setattr(backend, "_kill_process", kill_and_log)
     try:
-        backend = _stub()
-        backend._process = _Unterminable()
-
         backend._cleanup()
-
-        # Logging reports a broken handler by printing to stderr itself, so that
-        # is where the noise lands rather than in caplog.
         assert capsys.readouterr().err == ""
     finally:
-        mod.logger.removeHandler(handler)
-        mod.logger.propagate = True
+        other.removeHandler(handler)
+        other.propagate = True
+
+
+class _StubbornProcess:
+    """A llama-server that ignores SIGTERM, which is what SIGKILL is for."""
+
+    def __init__(self):
+        self.killed = False
+
+    def terminate(self):
+        pass
+
+    def wait(self, timeout = None):
+        if not self.killed:
+            raise subprocess.TimeoutExpired("llama-server", timeout)
+
+    def kill(self):
+        self.killed = True
+
+
+def test_sigkill_still_happens_when_the_log_write_fails(monkeypatch):
+    """The escalation must not depend on a log write succeeding. logger here is a
+    structlog PrintLogger straight to stdout, so a closed stream raises out of the
+    warning, and reporting first meant the kill was skipped while the finally
+    dropped the last reference to the process -- leaving the server running with
+    nothing left to kill it."""
+    from core.inference import llama_cpp as mod
+
+    monkeypatch.setattr(mod, "logger", _RaisingLogger())
+    backend = _stub()
+    proc = _StubbornProcess()
+    backend._process = proc
+
+    try:
+        backend._kill_process()
+    except ValueError:
+        pass  # the write still fails; what matters is that it failed after the kill
+
+    assert proc.killed, "SIGKILL was skipped because the warning raised first"
 
 
 def test_the_handler_leaves_raise_exceptions_as_it_found_it(monkeypatch):

--- a/studio/backend/tests/test_llama_cpp_atexit_quiet.py
+++ b/studio/backend/tests/test_llama_cpp_atexit_quiet.py
@@ -49,8 +49,13 @@ class _RecordingLogger:
         self.warnings.append(str(msg))
 
     def __getattr__(self, name):
-        def sink(msg = "", *a, **k):
+        def sink(
+            msg = "",
+            *a,
+            **k,
+        ):
             self.other.append((name, str(msg)))
+
         return sink
 
 

--- a/studio/backend/tests/test_llama_cpp_atexit_quiet.py
+++ b/studio/backend/tests/test_llama_cpp_atexit_quiet.py
@@ -208,9 +208,9 @@ def test_an_unkillable_server_is_still_reported(monkeypatch):
     with pytest.raises(subprocess.TimeoutExpired):
         backend._kill_process()
 
-    assert any("SIGKILL" in w for w in recorder.warnings), (
-        "an unkillable server was dropped without a word about it"
-    )
+    assert any(
+        "SIGKILL" in w for w in recorder.warnings
+    ), "an unkillable server was dropped without a word about it"
 
 
 def test_the_handler_leaves_raise_exceptions_as_it_found_it(monkeypatch):

--- a/studio/backend/tests/test_llama_cpp_atexit_quiet.py
+++ b/studio/backend/tests/test_llama_cpp_atexit_quiet.py
@@ -88,6 +88,7 @@ class _RaisingLogger:
     def __getattr__(self, name):
         def boom(*a, **k):
             raise ValueError("I/O operation on closed file")
+
         return boom
 
 


### PR DESCRIPTION
Two faults compounding. Neither fails a test, which is why they have survived; together they print several unrelated tracebacks after the pytest summary and push it out of the last screen of CI output, which is how I ran into them.

**A process that cannot be terminated is treated as a failed kill.** `_kill_process` calls `.terminate()` on whatever `_process` holds. Five test files stand a plain sentinel in to mean "a server is loaded" without spawning anything (`backend._process = object()`), and a backend torn down mid-`__init__` holds whatever it got as far as. The `AttributeError` is caught and then reported as a warning. It now clears the state and returns, which is what the `finally` did anyway.

**That warning is emitted from the atexit handler.** By then the streams the log handlers write to can already be closed, and logging prints its own traceback about that on top of the message it was trying to write:

```
AttributeError: 'object' object has no attribute 'terminate'
--- Logging error ---
ValueError: I/O operation on closed file.
Call stack:
  ... in _cleanup
    self._kill_process()
```

`_cleanup` now turns `logging.raiseExceptions` off for its duration, which is the switch logging provides for exactly this case, and swallows anything escaping, since atexit discards it and there is nowhere left to report to. It is restored afterwards so a live run still surfaces a broken handler.

**On the tests.** They watch a stand-in for the module logger rather than `caplog`. `logger` here comes from `get_logger` and is a structlog bound logger, so `caplog` never sees it. My first version asserted `caplog.records == []` and passed with and without the fix, which is to say it asserted nothing. It would also have held however loudly the code warned.

Checked each of the four fails without the change it pins, and that the five files using the sentinel still pass. The unrelated failures in my local run (`test_desktop_auth`, `test_mcp_stdio_*`, `test_rag_captioning`, `test_secure_tools_execute::test_web_search_tool_runs_with_mocked_fetch`) reproduce identically on unmodified `main` here and are missing optional deps in my environment, not this change.