### PR TITLE
Windows: guard the source-build and whisper.cpp probes on an unreadable install tree

### DIFF
--- a/studio/backend/core/inference/stt_ggml_sidecar.py
+++ b/studio/backend/core/inference/stt_ggml_sidecar.py
@@ -172,7 +172,13 @@ def _is_runnable(p: Path) -> bool:
     """A real whisper-server is an executable file. On Windows os.access(X_OK) is
     effectively an existence check; on Unix it rejects a non-executable stub so a
     half-written or wrong-mode file isn't mistaken for the server."""
-    return p.is_file() and (sys.platform == "win32" or os.access(p, os.X_OK))
+    try:
+        return p.is_file() and (sys.platform == "win32" or os.access(p, os.X_OK))
+    except OSError:
+        # is_file() propagates EACCES. An unreadable install dir must read as
+        # engine-unavailable, the same as a missing one, never a 500 out of
+        # /api/inference/audio/stt/status.
+        return False
 
 
 def _whisper_install_marker(binary: str) -> Optional[dict]:

--- a/studio/backend/core/inference/stt_ggml_sidecar.py
+++ b/studio/backend/core/inference/stt_ggml_sidecar.py
@@ -175,9 +175,8 @@ def _is_runnable(p: Path) -> bool:
     try:
         return p.is_file() and (sys.platform == "win32" or os.access(p, os.X_OK))
     except OSError:
-        # is_file() propagates EACCES. An unreadable install dir must read as
-        # engine-unavailable, the same as a missing one, never a 500 out of
-        # /api/inference/audio/stt/status.
+        # is_file() propagates EACCES: an unreadable install dir must read as
+        # engine-unavailable, like a missing one, never a 500 out of stt/status.
         return False
 
 

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -2950,7 +2950,11 @@ function Test-StudioOwnedAdoptable {
 function Assert-StudioOwnedOrAbsent {
     param(
         [Parameter(Mandatory = $true)][string]$Path,
-        [Parameter(Mandatory = $true)][string]$Label
+        [Parameter(Mandatory = $true)][string]$Label,
+        # whisper.cpp is non-fatal by contract and needs the denial handed back
+        # rather than exiting. Only this mode returns a value, so the other
+        # callers keep emitting nothing.
+        [switch]$NonFatal
     )
     # Denied is not Absent: a root we cannot read cannot be proven ours, and
     # returning here would let the caller replace it. Both stops stay gated on
@@ -2959,17 +2963,20 @@ function Assert-StudioOwnedOrAbsent {
     $pathState = Get-PathState -Path $Path -PathType Container
     if ($pathState -ne "Present") {
         if ($StudioHomeIsCustom -and $pathState -eq "Denied") {
+            if ($NonFatal) { return "Denied" }
             Exit-PathAccessDenied -Path $Path -Label $Label -OwnershipUnverified
         }
         return
     }
     $markerState = Get-PathState -Path (Join-Path $Path $StudioOwnedMarker) -PathType Leaf
     if ($StudioHomeIsCustom -and $markerState -eq "Denied") {
+        if ($NonFatal) { return "Denied" }
         Exit-PathAccessDenied -Path $Path -Label $Label -OwnershipUnverified
     }
     if ($StudioHomeIsCustom -and $markerState -ne "Present") {
         $adoptState = Get-StudioAdoptableState -Path $Path
         if ($adoptState -eq "Denied") {
+            if ($NonFatal) { return "Denied" }
             Exit-PathAccessDenied -Path $Path -Label $Label -OwnershipUnverified
         }
         if ($adoptState -eq "Yes") {
@@ -4333,6 +4340,12 @@ if ($env:WHISPER_SERVER_PATH -or $env:UNSLOTH_WHISPER_CPP_PATH) {
     substep "whisper.cpp: using a user-configured binary/dir; skipping managed install"
 } elseif ($env:UNSLOTH_SKIP_WHISPER_INSTALL -eq "1") {
     substep "whisper.cpp: install skipped (UNSLOTH_SKIP_WHISPER_INSTALL=1)"
+} elseif ($StudioHomeIsCustom -and (Test-Path -LiteralPath $WhisperInstaller) -and
+        (Assert-StudioOwnedOrAbsent -Path $WhisperCppDir -Label "whisper.cpp install" -NonFatal) -eq "Denied") {
+    # Never fatal, per the phase header: the guard below would exit the whole run
+    # on an unreadable tree, taking llama.cpp inference down with it. Only the
+    # denial is caught here; an unowned tree still stops, as it did before.
+    step "whisper.cpp" "install directory cannot be read: access is denied; curated whisper.cpp dictation is unavailable; restore access to $WhisperCppDir or move it aside, then re-run setup; browser and Transformers dictation remain available" "Yellow"
 } elseif (Test-Path -LiteralPath $WhisperInstaller) {
     # The installer's atomic activation replaces the whole directory, so the
     # custom-home ownership guard must run first (mirrors the llama block).
@@ -4372,7 +4385,7 @@ if ($env:WHISPER_SERVER_PATH -or $env:UNSLOTH_WHISPER_CPP_PATH) {
         } else {
             step "whisper.cpp" "prebuilt installed"
         }
-        if ($StudioHomeIsCustom -and (Test-Path -LiteralPath $WhisperCppDir -PathType Container)) {
+        if ($StudioHomeIsCustom -and (Test-PathQuiet $WhisperCppDir "Container")) {
             Mark-StudioOwned -Path $WhisperCppDir
         }
     } elseif ($whisperExit -eq 3) {
@@ -4466,10 +4479,27 @@ $HasGitForBuild = $null -ne (Get-Command git -ErrorAction SilentlyContinue)
 # Check if existing llama-server matches current GPU mode. A CUDA-built binary
 # on a now-CPU-only machine (or vice versa) needs to be rebuilt.
 $NeedRebuild = $false
-if (Test-Path -LiteralPath $LlamaServerBin) {
+# Phase 3.4's denial guard runs only on the prebuilt path, and a forced compile,
+# a pinned PR or a custom source skips that path entirely. So this can be the
+# first probe to read inside the tree, and it reads under "Stop". A linked local
+# dir is skipped: it reads through the junction into the user's own checkout, and
+# nothing here is consumed on that path anyway.
+$llamaBinState = if ($LocalLlamaCppLinked) { "Absent" } else { Get-PathState -Path $LlamaServerBin -PathType Leaf }
+if ($llamaBinState -eq "Denied") {
+    # Nothing has proven this tree is ours on the forced-compile route, so under a
+    # custom home do not advise deleting it.
+    Exit-PathAccessDenied -Path $LlamaCppDir -Label "llama.cpp install" -OwnershipUnverified:$StudioHomeIsCustom
+}
+if ($llamaBinState -eq "Present") {
     $CmakeCacheFile = Join-Path $BuildDir "CMakeCache.txt"
-    if (Test-Path -LiteralPath $CmakeCacheFile) {
-        $cachedCuda = Select-String -LiteralPath $CmakeCacheFile -Pattern 'GGML_CUDA:BOOL=ON' -Quiet
+    if (Test-PathQuiet $CmakeCacheFile "Leaf") {
+        # A listed file can still deny the read, which Test-PathQuiet cannot see.
+        try {
+            $cachedCuda = Select-String -LiteralPath $CmakeCacheFile -Pattern 'GGML_CUDA:BOOL=ON' -Quiet
+        } catch {
+            if (-not (Test-AccessDeniedError $_)) { throw }
+            Exit-PathAccessDenied -Path $LlamaCppDir -Label "llama.cpp install" -OwnershipUnverified:$StudioHomeIsCustom
+        }
         if ($HasNvidiaSmi -and -not $cachedCuda) {
             Write-Host "   Existing llama-server is CPU-only but GPU is available -- rebuilding" -ForegroundColor Yellow
             $NeedRebuild = $true
@@ -4485,7 +4515,7 @@ if (Test-Path -LiteralPath $LlamaServerBin) {
 # build runs only when needed and no usable binary is already present. A linked
 # local dir sets $NeedLlamaSourceBuild = $false, so this no-ops for that path.
 $WillBuildLlamaFromSource = $NeedLlamaSourceBuild -and `
-    -not ((Test-Path -LiteralPath $LlamaServerBin) -and -not $NeedRebuild -and $RequestedLlamaTag -ne "master")
+    -not ((Test-PathQuiet $LlamaServerBin "Leaf") -and -not $NeedRebuild -and $RequestedLlamaTag -ne "master")
 if ($WillBuildLlamaFromSource) {
     if (-not $HasGitForBuild) {
         # Phase 1 keeps git optional, so only the automatic fallback after a failed prebuilt
@@ -4519,7 +4549,7 @@ if ($LocalLlamaCppLinked) {
 } elseif (-not $NeedLlamaSourceBuild) {
     Write-Host ""
     step "llama.cpp" "prebuilt (validated)"
-} elseif ((Test-Path -LiteralPath $LlamaServerBin) -and -not $NeedRebuild -and $RequestedLlamaTag -ne "master") {
+} elseif ((Test-PathQuiet $LlamaServerBin "Leaf") -and -not $NeedRebuild -and $RequestedLlamaTag -ne "master") {
     # Skip rebuild only for pinned tags (e.g. b8635).  When the requested
     # tag is "master" (a moving target), always rebuild so the binary picks
     # up new model architecture support (e.g. Gemma 4).
@@ -5063,16 +5093,16 @@ if ($LocalLlamaCppLinked) {
     $totalSec = [math]::Round($totalSw.Elapsed.TotalSeconds % 60, 1)
 
     # -- Summary --
-    if ($BuildOk -and (Test-Path -LiteralPath $LlamaServerBin)) {
+    if ($BuildOk -and (Test-PathQuiet $LlamaServerBin "Leaf")) {
         step "llama.cpp" "built"
         $QuantizeBin = Join-Path $BuildDir "bin\Release\llama-quantize.exe"
-        if (Test-Path -LiteralPath $QuantizeBin) {
+        if (Test-PathQuiet $QuantizeBin "Leaf") {
             step "llama-quantize" "built"
         }
         step "build time" "${totalMin}m ${totalSec}s" "DarkGray"
     } else {
         $altBin = Join-Path $BuildDir "bin\llama-server.exe"
-        if ($BuildOk -and (Test-Path -LiteralPath $altBin)) {
+        if ($BuildOk -and (Test-PathQuiet $altBin "Leaf")) {
             step "llama.cpp" "built"
             step "build time" "${totalMin}m ${totalSec}s" "DarkGray"
         } else {

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -2941,9 +2941,8 @@ function Get-StudioAdoptableState {
     }
     if ($denied) { return "Denied" }
     # Windows reports a MISSING child of an unreadable directory as absent, so the
-    # probes above cannot tell "no markers here" from "cannot look". Listing the
-    # directory itself can. Without this a denied tree reads as unowned and the
-    # caller reports the wrong cause, fatally, on the platform this all targets.
+    # probes above cannot tell "no markers here" from "cannot look"; listing the
+    # directory itself can. Without this a denied tree reads as unowned.
     try { $null = @(Get-ChildItem -LiteralPath $Path -Force -ErrorAction Stop | Select-Object -First 1) }
     catch {
         if (Test-AccessDeniedError $_) { return "Denied" }
@@ -2960,9 +2959,8 @@ function Assert-StudioOwnedOrAbsent {
     param(
         [Parameter(Mandatory = $true)][string]$Path,
         [Parameter(Mandatory = $true)][string]$Label,
-        # whisper.cpp is non-fatal by contract and needs the denial handed back
-        # rather than exiting. Only this mode returns a value, so the other
-        # callers keep emitting nothing.
+        # whisper.cpp is non-fatal by contract, so it needs the denial handed back
+        # rather than exited on. Only this mode returns a value.
         [switch]$NonFatal
     )
     # Denied is not Absent: a root we cannot read cannot be proven ours, and
@@ -4352,8 +4350,8 @@ if ($env:WHISPER_SERVER_PATH -or $env:UNSLOTH_WHISPER_CPP_PATH) {
 } elseif ($StudioHomeIsCustom -and (Test-Path -LiteralPath $WhisperInstaller) -and
         (Assert-StudioOwnedOrAbsent -Path $WhisperCppDir -Label "whisper.cpp install" -NonFatal) -eq "Denied") {
     # Never fatal, per the phase header: the guard below would exit the whole run
-    # on an unreadable tree, taking llama.cpp inference down with it. Only the
-    # denial is caught here; an unowned tree still stops, as it did before.
+    # on an unreadable tree, taking llama.cpp down with it. Only the denial is
+    # caught here; an unowned tree still stops.
     step "whisper.cpp" "install directory cannot be read: access is denied; curated whisper.cpp dictation is unavailable; restore access to $WhisperCppDir or move it aside, then re-run setup; browser and Transformers dictation remain available" "Yellow"
 } elseif (Test-Path -LiteralPath $WhisperInstaller) {
     # The installer's atomic activation replaces the whole directory, so the
@@ -4488,15 +4486,13 @@ $HasGitForBuild = $null -ne (Get-Command git -ErrorAction SilentlyContinue)
 # Check if existing llama-server matches current GPU mode. A CUDA-built binary
 # on a now-CPU-only machine (or vice versa) needs to be rebuilt.
 $NeedRebuild = $false
-# Phase 3.4's denial guard runs only on the prebuilt path, and a forced compile,
-# a pinned PR or a custom source skips that path entirely. So this can be the
-# first probe to read inside the tree, and it reads under "Stop". A linked local
-# dir is skipped: it reads through the junction into the user's own checkout, and
-# nothing here is consumed on that path anyway.
+# A forced compile, a pinned PR or a custom source skips the prebuilt path and its
+# phase 3.4 denial guard, so this can be the first probe to read inside the tree.
+# A linked local dir is skipped: it reads through the junction into the user's own
+# checkout, and nothing here is consumed on that path anyway.
 $llamaBinState = if ($LocalLlamaCppLinked) { "Absent" } else { Get-PathState -Path $LlamaServerBin -PathType Leaf }
 if ($llamaBinState -eq "Denied") {
-    # Nothing has proven this tree is ours on the forced-compile route, so under a
-    # custom home do not advise deleting it.
+    # Nothing proved this tree is ours here, so do not advise deleting it.
     Exit-PathAccessDenied -Path $LlamaCppDir -Label "llama.cpp install" -OwnershipUnverified:$StudioHomeIsCustom
 }
 if ($llamaBinState -eq "Present") {

--- a/studio/setup.ps1
+++ b/studio/setup.ps1
@@ -2940,6 +2940,15 @@ function Get-StudioAdoptableState {
         }
     }
     if ($denied) { return "Denied" }
+    # Windows reports a MISSING child of an unreadable directory as absent, so the
+    # probes above cannot tell "no markers here" from "cannot look". Listing the
+    # directory itself can. Without this a denied tree reads as unowned and the
+    # caller reports the wrong cause, fatally, on the platform this all targets.
+    try { $null = @(Get-ChildItem -LiteralPath $Path -Force -ErrorAction Stop | Select-Object -First 1) }
+    catch {
+        if (Test-AccessDeniedError $_) { return "Denied" }
+        # Anything else was not adoptable before either; this must not throw.
+    }
     return "No"
 }
 # Boolean view for callers that only gate a cosmetic cleanup on adoption.

--- a/tests/studio/install/test_setup_denied_install_tree.py
+++ b/tests/studio/install/test_setup_denied_install_tree.py
@@ -102,7 +102,7 @@ def test_ownership_guard_distinguishes_denied_from_unowned():
     # unreadable; it must stay for the genuinely-unowned case only.
     assert "is not marked as an Unsloth-owned $Label" in guard
     # Both stops stay gated, so default-home installs behave exactly as before.
-    assert guard.count("$StudioHomeIsCustom -and") == 3
+    assert guard.count("$StudioHomeIsCustom -and") >= 3
 
 
 def test_no_bare_test_path_probes_inside_the_llama_install_tree():
@@ -236,7 +236,7 @@ def test_the_ownership_guard_never_advises_deleting_an_unverified_tree():
     the tree is ours. It already says "move it aside" when it can prove it."""
     guard = SETUP_PS1.split("function Assert-StudioOwnedOrAbsent", 1)[1].split("\nfunction ", 1)[0]
     calls = [line.strip() for line in guard.splitlines() if "Exit-PathAccessDenied" in line]
-    assert len(calls) == 3, calls
+    assert len(calls) >= 3, calls
     for line in calls:
         assert "-OwnershipUnverified" in line, line
     body = SETUP_PS1.split("function Exit-PathAccessDenied", 1)[1].split("\nfunction ", 1)[0]
@@ -274,12 +274,10 @@ def test_the_temp_dir_swap_checks_both_of_its_destructive_steps():
 def test_the_source_build_phase_probes_the_tree_three_state():
     """A forced compile, a pinned PR or a custom source skips the prebuilt phase
     and its denial guard, so the rebuild check is the first read inside the tree."""
-    anchor = "$llamaBinState = "
-    assert anchor in SETUP_PS1
-    build = SETUP_PS1.split(anchor, 1)[1].split("# -- Summary --", 1)[0]
-    assert "Get-PathState -Path $LlamaServerBin -PathType Leaf" in SETUP_PS1
-    assert '$llamaBinState -eq "Denied"' in SETUP_PS1
-    assert '$llamaBinState -eq "Present"' in SETUP_PS1
+    build = _slice("$llamaBinState = ", "# -- Summary --")
+    assert "Get-PathState -Path $LlamaServerBin -PathType Leaf" in build, build
+    assert '$llamaBinState -eq "Denied"' in build, build
+    assert '$llamaBinState -eq "Present"' in build, build
     assert "Test-Path -LiteralPath $LlamaServerBin" not in build, build
 
 
@@ -293,18 +291,17 @@ def test_the_source_build_probe_skips_a_linked_local_dir():
 def test_the_source_build_denial_never_advises_deleting_an_unproven_tree():
     """Nothing on this route ran the ownership guard, so under a custom home the
     tree cannot be proven ours and the delete advice must stay suppressed."""
-    block = SETUP_PS1.split("$llamaBinState = ", 1)[1].split("$WillBuildLlamaFromSource", 1)[0]
+    block = _slice("$llamaBinState = ", "$WillBuildLlamaFromSource")
     denials = [ln.strip() for ln in block.splitlines() if "Exit-PathAccessDenied" in ln]
     assert len(denials) >= 2, denials
     assert all(d.endswith("-OwnershipUnverified:$StudioHomeIsCustom") for d in denials), denials
+    assert all(d.startswith("Exit-PathAccessDenied -Path $LlamaCppDir ") for d in denials), denials
 
 
 def test_the_cmake_cache_read_is_guarded_not_just_its_probe():
     """Test-PathQuiet only proves the entry is listed; a deny ACE on the file
     itself leaves the probe true and throws on the read below it."""
-    anchor = "$CmakeCacheFile = Join-Path"
-    assert anchor in SETUP_PS1
-    block = SETUP_PS1.split(anchor, 1)[1].split("$WillBuildLlamaFromSource", 1)[0]
+    block = _slice("$CmakeCacheFile = Join-Path", "$WillBuildLlamaFromSource")
     read = "Select-String -LiteralPath $CmakeCacheFile"
     assert read in block, block
     before, after = block.split(read, 1)
@@ -313,15 +310,19 @@ def test_the_cmake_cache_read_is_guarded_not_just_its_probe():
     assert "Exit-PathAccessDenied" in after, after
 
 
+def _slice(start: str, end: str) -> str:
+    """Both bounds asserted: an unasserted terminator does not fail, it silently
+    widens the window to end-of-file and makes everything inside it near-vacuous."""
+    assert start in SETUP_PS1, start
+    assert end in SETUP_PS1, end
+    return SETUP_PS1.split(start, 1)[1].split(end, 1)[0]
+
+
 def _whisper_phase() -> str:
     """The whisper phase body. Both anchors are asserted so a phase renumbering
     fails as an assertion instead of an IndexError, and cannot silently widen
     the window to end-of-file."""
-    start = "Install the whisper.cpp prebuilt"
-    end = "PHASE 3.5"
-    assert start in SETUP_PS1
-    assert end in SETUP_PS1
-    return SETUP_PS1.split(start, 1)[1].split(end, 1)[0]
+    return _slice("Install the whisper.cpp prebuilt", "PHASE 3.5")
 
 
 def test_the_whisper_phase_survives_an_unreadable_whisper_tree():
@@ -329,14 +330,31 @@ def test_the_whisper_phase_survives_an_unreadable_whisper_tree():
     exits the whole run, which would take llama.cpp inference down with it."""
     guard = SETUP_PS1.split("function Assert-StudioOwnedOrAbsent", 1)[1].split("\nfunction ", 1)[0]
     assert "[switch]$NonFatal" in guard
+    # Ordering, not just presence: below its exit the return is dead code, and
+    # above the custom-home gate it would report a fresh install as unreadable.
+    paired = re.findall(
+        r'if \(\$NonFatal\) \{ return "Denied" \}\n\s*Exit-PathAccessDenied -Path \$Path', guard
+    )
+    assert len(paired) == guard.count("Exit-PathAccessDenied -Path $Path"), guard
+    # No unpaired return either: one above the custom-home gate would report a
+    # fresh install as unreadable.
+    assert len(paired) == guard.count('if ($NonFatal) { return "Denied" }'), guard
+    assert len(paired) >= 3, guard
     # Only the denial is handed back; an unowned tree must still stop.
-    assert guard.count('if ($NonFatal) { return "Denied" }') >= 3, guard
     assert 'Exit-SetupFailure "$Label path is not an Unsloth-owned install' in guard
     whisper = _whisper_phase()
     assert '-Label "whisper.cpp install" -NonFatal) -eq "Denied"' in whisper, whisper
-    # Pin the new message, not prose the phase already contained.
-    assert "install directory cannot be read: access is denied" in whisper, whisper
-    assert "browser and Transformers dictation remain available" in whisper
+    # Scoped to the new branch: both phrases already occur elsewhere in the phase,
+    # so a phase-wide match is satisfied no matter what this branch does.
+    marker = '-NonFatal) -eq "Denied") {'
+    assert marker in whisper, whisper
+    denial = whisper.split(marker, 1)[1].split("\n} elseif", 1)[0]
+    assert re.search(r'^\s*step "whisper\.cpp" ', denial, re.M), denial
+    assert "install directory cannot be read: access is denied" in denial, denial
+    assert "browser and Transformers dictation remain available" in denial, denial
+    # The whole point is that this stays non-fatal.
+    assert "Exit-SetupFailure" not in denial, denial
+    assert not re.search(r"\bexit \d", denial), denial
     # The skip has to come before the branch whose guard would exit. Anchor on
     # that branch's body, which survives a hardening of its own probe.
     body = "$whisperArgs = @("
@@ -347,6 +365,14 @@ def test_the_whisper_phase_survives_an_unreadable_whisper_tree():
 def test_the_whisper_skip_stays_behind_the_installer_gate():
     """The guard used to live inside the installer branch, so a tree without the
     installer was a no-op. Hoisting it must not make that case fatal."""
-    branch = _whisper_phase().split("-NonFatal) -eq", 1)[0].rsplit("} elseif", 1)[1]
-    # Anchor on the variable, not the probe form: that probe may be hardened later.
-    assert "$WhisperInstaller" in branch, branch
+    marker = "-NonFatal) -eq"
+    whisper = _whisper_phase()
+    assert marker in whisper, whisper
+    head = whisper.split(marker, 1)[0]
+    assert "} elseif" in head, head
+    branch = head.rsplit("} elseif", 1)[1]
+    # A conjunct, not merely present: -or or a negation reopens the case this
+    # test is named for. Anchored on the variable so the probe can be hardened.
+    assert re.search(r"-and\s*\([^\n]*\$WhisperInstaller[^\n]*\)\s*-and", branch), branch
+    assert "-not (Test-Path" not in branch, branch
+    assert " -or " not in branch, branch

--- a/tests/studio/install/test_setup_denied_install_tree.py
+++ b/tests/studio/install/test_setup_denied_install_tree.py
@@ -330,22 +330,21 @@ def test_the_whisper_phase_survives_an_unreadable_whisper_tree():
     exits the whole run, which would take llama.cpp inference down with it."""
     guard = SETUP_PS1.split("function Assert-StudioOwnedOrAbsent", 1)[1].split("\nfunction ", 1)[0]
     assert "[switch]$NonFatal" in guard
-    # Ordering, not just presence: below its exit the return is dead code, and
-    # above the custom-home gate it would report a fresh install as unreadable.
+    # Ordering, not just presence: below its exit the return is dead code.
     paired = re.findall(
         r'if \(\$NonFatal\) \{ return "Denied" \}\n\s*Exit-PathAccessDenied -Path \$Path', guard
     )
     assert len(paired) == guard.count("Exit-PathAccessDenied -Path $Path"), guard
-    # No unpaired return either: one above the custom-home gate would report a
-    # fresh install as unreadable.
+    # No unpaired return: one above the custom-home gate would call a fresh
+    # install unreadable.
     assert len(paired) == guard.count('if ($NonFatal) { return "Denied" }'), guard
     assert len(paired) >= 3, guard
     # Only the denial is handed back; an unowned tree must still stop.
     assert 'Exit-SetupFailure "$Label path is not an Unsloth-owned install' in guard
     whisper = _whisper_phase()
     assert '-Label "whisper.cpp install" -NonFatal) -eq "Denied"' in whisper, whisper
-    # Scoped to the new branch: both phrases already occur elsewhere in the phase,
-    # so a phase-wide match is satisfied no matter what this branch does.
+    # Scoped to the new branch: both phrases occur elsewhere in the phase, so a
+    # phase-wide match proves nothing about this branch.
     marker = '-NonFatal) -eq "Denied") {'
     assert marker in whisper, whisper
     denial = whisper.split(marker, 1)[1].split("\n} elseif", 1)[0]
@@ -355,8 +354,8 @@ def test_the_whisper_phase_survives_an_unreadable_whisper_tree():
     # The whole point is that this stays non-fatal.
     assert "Exit-SetupFailure" not in denial, denial
     assert not re.search(r"\bexit \d", denial), denial
-    # The skip has to come before the branch whose guard would exit. Anchor on
-    # that branch's body, which survives a hardening of its own probe.
+    # The skip must precede the branch whose guard would exit. Anchored on that
+    # branch's body, which survives a hardening of its own probe.
     body = "$whisperArgs = @("
     assert body in whisper, whisper
     assert whisper.index("-NonFatal") < whisper.index(body)
@@ -371,8 +370,7 @@ def test_the_whisper_skip_stays_behind_the_installer_gate():
     head = whisper.split(marker, 1)[0]
     assert "} elseif" in head, head
     branch = head.rsplit("} elseif", 1)[1]
-    # A conjunct, not merely present: -or or a negation reopens the case this
-    # test is named for. Anchored on the variable so the probe can be hardened.
+    # A conjunct, not merely present: -or or a negation reopens this case.
     assert re.search(r"-and\s*\([^\n]*\$WhisperInstaller[^\n]*\)\s*-and", branch), branch
     assert "-not (Test-Path" not in branch, branch
     assert " -or " not in branch, branch

--- a/tests/studio/install/test_setup_denied_install_tree.py
+++ b/tests/studio/install/test_setup_denied_install_tree.py
@@ -109,12 +109,16 @@ def test_no_bare_test_path_probes_inside_the_llama_install_tree():
     """Probes that read *inside* a tree whose permissions we do not control are
     the ones that throw; they must all go through the guarded helpers."""
     inside_tree = re.compile(
-        r"Test-Path\b[^\n]*(\$existingMetaPath|\$llamaMarker|\$_cand|Join-Path \$LlamaCppDir)"
+        r"Test-Path\b[^\n]*("
+        r"\$existingMetaPath|\$llamaMarker|\$_cand|Join-Path \$LlamaCppDir"
+        r"|\$LlamaServerBin|\$CmakeCacheFile|\$QuantizeBin|\$altBin"
+        r"|Join-Path \$BuildDir)"
     )
+    # A comment naming a probe is not a probe.
     offenders = [
         f"{index}: {line.strip()}"
         for index, line in enumerate(SETUP_PS1.splitlines(), start = 1)
-        if inside_tree.search(line)
+        if inside_tree.search(line.split("#", 1)[0])
     ]
     assert not offenders, offenders
 
@@ -265,3 +269,84 @@ def test_the_temp_dir_swap_checks_both_of_its_destructive_steps():
     # And catch a move that silently did not happen.
     assert '(Get-PathState -Path $LlamaCppDir) -ne "Absent"' in swap.split(move, 1)[1], swap
     assert "Test-Path -LiteralPath $OriginalLlamaCppDir" not in swap, swap
+
+
+def test_the_source_build_phase_probes_the_tree_three_state():
+    """A forced compile, a pinned PR or a custom source skips the prebuilt phase
+    and its denial guard, so the rebuild check is the first read inside the tree."""
+    anchor = "$llamaBinState = "
+    assert anchor in SETUP_PS1
+    build = SETUP_PS1.split(anchor, 1)[1].split("# -- Summary --", 1)[0]
+    assert "Get-PathState -Path $LlamaServerBin -PathType Leaf" in SETUP_PS1
+    assert '$llamaBinState -eq "Denied"' in SETUP_PS1
+    assert '$llamaBinState -eq "Present"' in SETUP_PS1
+    assert "Test-Path -LiteralPath $LlamaServerBin" not in build, build
+
+
+def test_the_source_build_probe_skips_a_linked_local_dir():
+    """$LlamaCppDir is a junction onto the user's checkout there, so probing it
+    reads their tree, and nothing this block computes is consumed on that path."""
+    flat = " ".join(SETUP_PS1.split())
+    assert '$llamaBinState = if ($LocalLlamaCppLinked) { "Absent" }' in flat
+
+
+def test_the_source_build_denial_never_advises_deleting_an_unproven_tree():
+    """Nothing on this route ran the ownership guard, so under a custom home the
+    tree cannot be proven ours and the delete advice must stay suppressed."""
+    block = SETUP_PS1.split("$llamaBinState = ", 1)[1].split("$WillBuildLlamaFromSource", 1)[0]
+    denials = [ln.strip() for ln in block.splitlines() if "Exit-PathAccessDenied" in ln]
+    assert len(denials) >= 2, denials
+    assert all(d.endswith("-OwnershipUnverified:$StudioHomeIsCustom") for d in denials), denials
+
+
+def test_the_cmake_cache_read_is_guarded_not_just_its_probe():
+    """Test-PathQuiet only proves the entry is listed; a deny ACE on the file
+    itself leaves the probe true and throws on the read below it."""
+    anchor = "$CmakeCacheFile = Join-Path"
+    assert anchor in SETUP_PS1
+    block = SETUP_PS1.split(anchor, 1)[1].split("$WillBuildLlamaFromSource", 1)[0]
+    read = "Select-String -LiteralPath $CmakeCacheFile"
+    assert read in block, block
+    before, after = block.split(read, 1)
+    assert "try {" in before, before
+    assert "Test-AccessDeniedError" in after, after
+    assert "Exit-PathAccessDenied" in after, after
+
+
+def _whisper_phase() -> str:
+    """The whisper phase body. Both anchors are asserted so a phase renumbering
+    fails as an assertion instead of an IndexError, and cannot silently widen
+    the window to end-of-file."""
+    start = "Install the whisper.cpp prebuilt"
+    end = "PHASE 3.5"
+    assert start in SETUP_PS1
+    assert end in SETUP_PS1
+    return SETUP_PS1.split(start, 1)[1].split(end, 1)[0]
+
+
+def test_the_whisper_phase_survives_an_unreadable_whisper_tree():
+    """The phase header promises failure is never fatal, but the ownership guard
+    exits the whole run, which would take llama.cpp inference down with it."""
+    guard = SETUP_PS1.split("function Assert-StudioOwnedOrAbsent", 1)[1].split("\nfunction ", 1)[0]
+    assert "[switch]$NonFatal" in guard
+    # Only the denial is handed back; an unowned tree must still stop.
+    assert guard.count('if ($NonFatal) { return "Denied" }') >= 3, guard
+    assert 'Exit-SetupFailure "$Label path is not an Unsloth-owned install' in guard
+    whisper = _whisper_phase()
+    assert '-Label "whisper.cpp install" -NonFatal) -eq "Denied"' in whisper, whisper
+    # Pin the new message, not prose the phase already contained.
+    assert "install directory cannot be read: access is denied" in whisper, whisper
+    assert "browser and Transformers dictation remain available" in whisper
+    # The skip has to come before the branch whose guard would exit. Anchor on
+    # that branch's body, which survives a hardening of its own probe.
+    body = "$whisperArgs = @("
+    assert body in whisper, whisper
+    assert whisper.index("-NonFatal") < whisper.index(body)
+
+
+def test_the_whisper_skip_stays_behind_the_installer_gate():
+    """The guard used to live inside the installer branch, so a tree without the
+    installer was a no-op. Hoisting it must not make that case fatal."""
+    branch = _whisper_phase().split("-NonFatal) -eq", 1)[0].rsplit("} elseif", 1)[1]
+    # Anchor on the variable, not the probe form: that probe may be hardened later.
+    assert "$WhisperInstaller" in branch, branch

--- a/tests/studio/test_path_probe_access_denied.ps1
+++ b/tests/studio/test_path_probe_access_denied.ps1
@@ -310,21 +310,28 @@ if ($assertSrc -and $markSrc) {
             # this cannot go through the marker probe there and has to be caught
             # by the adoptable-state read instead. Either route is fine; anything
             # other than Denied is not.
-            $nfBare = Join-Path $nfRoot "bare"
-            New-Item -ItemType Directory -Force -Path (Join-Path $nfBare "sub") | Out-Null
+            # Two shapes. chmod 000 blocks the child probes outright; chmod 111
+            # allows stat of a named child but forbids listing, which is exactly
+            # what Windows does and the only shape that reaches the directory
+            # listing in Get-StudioAdoptableState.
             $bareWho = "$env:USERDOMAIN\$env:USERNAME"
-            if ($onWindows) { icacls $nfBare /deny "${bareWho}:(OI)(CI)(RX)" *>$null }
-            else { chmod 000 $nfBare }
-            try {
-                $out = $null
-                $threw = $false
-                try { $out = @(Assert-StudioOwnedOrAbsent -Path $nfBare -Label "whisper.cpp install" -NonFatal) }
-                catch { $threw = $true }
-                Check "-NonFatal hands back a denied tree that has no marker" (
-                    -not $threw -and $out.Count -eq 1 -and $out[0] -eq "Denied")
-            } finally {
-                if ($onWindows) { icacls $nfBare /remove:d "$bareWho" *>$null }
-                else { chmod 755 $nfBare }
+            $bareModes = if ($onWindows) { @("acl") } else { @("000", "111") }
+            foreach ($mode in $bareModes) {
+                $nfBare = Join-Path $nfRoot "bare_$mode"
+                New-Item -ItemType Directory -Force -Path (Join-Path $nfBare "sub") | Out-Null
+                if ($mode -eq "acl") { icacls $nfBare /deny "${bareWho}:(OI)(CI)(RX)" *>$null }
+                else { chmod $mode $nfBare }
+                try {
+                    $out = $null
+                    $threw = $false
+                    try { $out = @(Assert-StudioOwnedOrAbsent -Path $nfBare -Label "whisper.cpp install" -NonFatal) }
+                    catch { $threw = $true }
+                    Check "-NonFatal hands back a denied tree that has no marker ($mode)" (
+                        -not $threw -and $out.Count -eq 1 -and $out[0] -eq "Denied")
+                } finally {
+                    if ($mode -eq "acl") { icacls $nfBare /remove:d "$bareWho" *>$null }
+                    else { chmod 755 $nfBare }
+                }
             }
         }
         # -NonFatal rescues the denial only: someone else's folder must still stop.

--- a/tests/studio/test_path_probe_access_denied.ps1
+++ b/tests/studio/test_path_probe_access_denied.ps1
@@ -257,7 +257,13 @@ if ($assertSrc -and $markSrc) {
     $nfRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("uns_nf_" + [guid]::NewGuid().ToString("N"))
     $nfDenied = Join-Path $nfRoot "whisper.cpp"
     $nfUnowned = Join-Path $nfRoot "unowned"
-    New-Item -ItemType Directory -Force -Path (Join-Path $nfDenied "sub") | Out-Null
+    $nfInner = Join-Path $nfDenied "inner"
+    $nfMarker = Join-Path $nfDenied $StudioOwnedMarker
+    # Populate before locking. Windows returns $false for a MISSING child of a
+    # denied directory instead of throwing, so a probe target that does not
+    # exist makes the negative control read as "this host cannot deny".
+    New-Item -ItemType Directory -Force -Path $nfInner | Out-Null
+    Set-Content -LiteralPath $nfMarker -Value ""
     New-Item -ItemType Directory -Force -Path $nfUnowned | Out-Null
     Set-Content -LiteralPath (Join-Path $nfUnowned "someone-elses.txt") -Value "x"
     function Set-NfDenied([bool]$on) {
@@ -273,7 +279,7 @@ if ($assertSrc -and $markSrc) {
         Set-NfDenied $true
         # Same environment gate as above: no real denial means no real test.
         $nfReal = $false
-        try { $null = Test-Path (Join-Path $nfDenied $StudioOwnedMarker) } catch { $nfReal = $true }
+        try { $null = Test-Path $nfMarker } catch { $nfReal = $true }
         Check "the host can actually deny a read (negative control)" $nfReal
         if ($nfReal) {
             $threw = $false
@@ -292,13 +298,34 @@ if ($assertSrc -and $markSrc) {
             # A locked directory still probes Present from its readable parent, so
             # the case above only covers the marker read. Lock the parent to reach
             # the root probe itself.
-            $nfInner = Join-Path $nfDenied "inner"
             $out = $null
             $threw = $false
             try { $out = @(Assert-StudioOwnedOrAbsent -Path $nfInner -Label "whisper.cpp install" -NonFatal) }
             catch { $threw = $true }
             Check "-NonFatal hands back a tree whose parent is unreadable" (
                 -not $threw -and $out.Count -eq 1 -and $out[0] -eq "Denied")
+
+            # The realistic fresh-custom-home case: no marker was ever written.
+            # Windows reports a MISSING child of a denied directory as Absent, so
+            # this cannot go through the marker probe there and has to be caught
+            # by the adoptable-state read instead. Either route is fine; anything
+            # other than Denied is not.
+            $nfBare = Join-Path $nfRoot "bare"
+            New-Item -ItemType Directory -Force -Path (Join-Path $nfBare "sub") | Out-Null
+            $bareWho = "$env:USERDOMAIN\$env:USERNAME"
+            if ($onWindows) { icacls $nfBare /deny "${bareWho}:(OI)(CI)(RX)" *>$null }
+            else { chmod 000 $nfBare }
+            try {
+                $out = $null
+                $threw = $false
+                try { $out = @(Assert-StudioOwnedOrAbsent -Path $nfBare -Label "whisper.cpp install" -NonFatal) }
+                catch { $threw = $true }
+                Check "-NonFatal hands back a denied tree that has no marker" (
+                    -not $threw -and $out.Count -eq 1 -and $out[0] -eq "Denied")
+            } finally {
+                if ($onWindows) { icacls $nfBare /remove:d "$bareWho" *>$null }
+                else { chmod 755 $nfBare }
+            }
         }
         # -NonFatal rescues the denial only: someone else's folder must still stop.
         $threw = $false

--- a/tests/studio/test_path_probe_access_denied.ps1
+++ b/tests/studio/test_path_probe_access_denied.ps1
@@ -236,6 +236,80 @@ Check "a wrapped UnauthorizedAccessException classifies as access denied" (
 Check "an unrelated exception does not classify as access denied" (
     -not (Test-AccessDeniedError ([System.IO.FileNotFoundException]::new("missing"))))
 
+# -- Assert-StudioOwnedOrAbsent -NonFatal, run for real --
+# whisper.cpp promises "failure is never fatal", so a denied tree there must be
+# handed back to the caller instead of exiting the run and taking llama.cpp
+# inference with it. Everything else about the guard has to stay fatal.
+$assertSrc = Get-FunctionSource -Path $setupPath -Name Assert-StudioOwnedOrAbsent
+$markSrc = Get-FunctionSource -Path $setupPath -Name Mark-StudioOwned
+Check "setup.ps1 defines Assert-StudioOwnedOrAbsent" ($null -ne $assertSrc)
+if ($assertSrc -and $markSrc) {
+    . ([scriptblock]::Create($assertSrc))
+    . ([scriptblock]::Create($markSrc))
+    # Reaching either of these is the failure the -NonFatal mode exists to avoid.
+    function Exit-PathAccessDenied { param($Path, $Label, [switch]$UserSupplied, [switch]$OwnershipUnverified) throw "EXIT-DENIED" }
+    function Exit-SetupFailure { param($Message, $Code) throw "EXIT-SETUP" }
+    function step { param($a, $b, $c) }
+    function substep { param($a, $b) }
+    $StudioOwnedMarker = ".unsloth-studio-owned"
+    $StudioHomeIsCustom = $true
+
+    $nfRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("uns_nf_" + [guid]::NewGuid().ToString("N"))
+    $nfDenied = Join-Path $nfRoot "whisper.cpp"
+    $nfUnowned = Join-Path $nfRoot "unowned"
+    New-Item -ItemType Directory -Force -Path (Join-Path $nfDenied "sub") | Out-Null
+    New-Item -ItemType Directory -Force -Path $nfUnowned | Out-Null
+    Set-Content -LiteralPath (Join-Path $nfUnowned "someone-elses.txt") -Value "x"
+    function Set-NfDenied([bool]$on) {
+        if ($onWindows) {
+            $who = "$env:USERDOMAIN\$env:USERNAME"
+            if ($on) { icacls $nfDenied /deny "${who}:(OI)(CI)(RX)" *>$null }
+            else { icacls $nfDenied /remove:d "$who" *>$null }
+        } else {
+            if ($on) { chmod 000 $nfDenied } else { chmod 755 $nfDenied }
+        }
+    }
+    try {
+        Set-NfDenied $true
+        # Same environment gate as above: no real denial means no real test.
+        $nfReal = $false
+        try { $null = Test-Path (Join-Path $nfDenied $StudioOwnedMarker) } catch { $nfReal = $true }
+        Check "the host can actually deny a read (negative control)" $nfReal
+        if ($nfReal) {
+            $threw = $false
+            $out = $null
+            try { $out = @(Assert-StudioOwnedOrAbsent -Path $nfDenied -Label "whisper.cpp install" -NonFatal) }
+            catch { $threw = $true }
+            Check "-NonFatal hands a denied tree back instead of exiting" (-not $threw)
+            # One bare string, not an array: a stray emit would break the caller's -eq.
+            Check "-NonFatal returns exactly one value" ($out.Count -eq 1)
+            Check "-NonFatal returns Denied" ($out.Count -eq 1 -and $out[0] -eq "Denied")
+
+            $threw = $false
+            try { $null = Assert-StudioOwnedOrAbsent -Path $nfDenied -Label "whisper.cpp install" } catch { $threw = $true }
+            Check "without -NonFatal a denied tree still stops setup" $threw
+
+            # A locked directory still probes Present from its readable parent, so
+            # the case above only covers the marker read. Lock the parent to reach
+            # the root probe itself.
+            $nfInner = Join-Path $nfDenied "inner"
+            $out = $null
+            $threw = $false
+            try { $out = @(Assert-StudioOwnedOrAbsent -Path $nfInner -Label "whisper.cpp install" -NonFatal) }
+            catch { $threw = $true }
+            Check "-NonFatal hands back a tree whose parent is unreadable" (
+                -not $threw -and $out.Count -eq 1 -and $out[0] -eq "Denied")
+        }
+        # -NonFatal rescues the denial only: someone else's folder must still stop.
+        $threw = $false
+        try { $null = Assert-StudioOwnedOrAbsent -Path $nfUnowned -Label "whisper.cpp install" -NonFatal } catch { $threw = $true }
+        Check "-NonFatal does not excuse an unowned tree" $threw
+    } finally {
+        Set-NfDenied $false
+        Remove-Item -Recurse -Force -LiteralPath $nfRoot -ErrorAction SilentlyContinue
+    }
+}
+
 if ($script:failures -gt 0) {
     Write-Host "$($script:failures) check(s) failed" -ForegroundColor Red
     exit 1

--- a/tests/studio/test_path_probe_access_denied.ps1
+++ b/tests/studio/test_path_probe_access_denied.ps1
@@ -237,9 +237,8 @@ Check "an unrelated exception does not classify as access denied" (
     -not (Test-AccessDeniedError ([System.IO.FileNotFoundException]::new("missing"))))
 
 # -- Assert-StudioOwnedOrAbsent -NonFatal, run for real --
-# whisper.cpp promises "failure is never fatal", so a denied tree there must be
-# handed back to the caller instead of exiting the run and taking llama.cpp
-# inference with it. Everything else about the guard has to stay fatal.
+# whisper.cpp promises "failure is never fatal", so a denied tree there is handed
+# back instead of exiting the run. Everything else about the guard stays fatal.
 $assertSrc = Get-FunctionSource -Path $setupPath -Name Assert-StudioOwnedOrAbsent
 $markSrc = Get-FunctionSource -Path $setupPath -Name Mark-StudioOwned
 Check "setup.ps1 defines Assert-StudioOwnedOrAbsent" ($null -ne $assertSrc)
@@ -259,9 +258,9 @@ if ($assertSrc -and $markSrc) {
     $nfUnowned = Join-Path $nfRoot "unowned"
     $nfInner = Join-Path $nfDenied "inner"
     $nfMarker = Join-Path $nfDenied $StudioOwnedMarker
-    # Populate before locking. Windows returns $false for a MISSING child of a
-    # denied directory instead of throwing, so a probe target that does not
-    # exist makes the negative control read as "this host cannot deny".
+    # Populate before locking: Windows returns $false for a MISSING child of a
+    # denied directory instead of throwing, so a probe target that does not exist
+    # makes the negative control read as "this host cannot deny".
     New-Item -ItemType Directory -Force -Path $nfInner | Out-Null
     Set-Content -LiteralPath $nfMarker -Value ""
     New-Item -ItemType Directory -Force -Path $nfUnowned | Out-Null
@@ -296,8 +295,7 @@ if ($assertSrc -and $markSrc) {
             Check "without -NonFatal a denied tree still stops setup" $threw
 
             # A locked directory still probes Present from its readable parent, so
-            # the case above only covers the marker read. Lock the parent to reach
-            # the root probe itself.
+            # the case above only covers the marker read; lock the parent instead.
             $out = $null
             $threw = $false
             try { $out = @(Assert-StudioOwnedOrAbsent -Path $nfInner -Label "whisper.cpp install" -NonFatal) }
@@ -305,15 +303,13 @@ if ($assertSrc -and $markSrc) {
             Check "-NonFatal hands back a tree whose parent is unreadable" (
                 -not $threw -and $out.Count -eq 1 -and $out[0] -eq "Denied")
 
-            # The realistic fresh-custom-home case: no marker was ever written.
-            # Windows reports a MISSING child of a denied directory as Absent, so
-            # this cannot go through the marker probe there and has to be caught
-            # by the adoptable-state read instead. Either route is fine; anything
-            # other than Denied is not.
-            # Two shapes. chmod 000 blocks the child probes outright; chmod 111
-            # allows stat of a named child but forbids listing, which is exactly
-            # what Windows does and the only shape that reaches the directory
-            # listing in Get-StudioAdoptableState.
+            # The fresh-custom-home case: no marker was ever written. Windows
+            # reports a MISSING child of a denied directory as Absent, so there the
+            # adoptable-state read catches this, not the marker probe. Either route
+            # is fine; anything other than Denied is not.
+            # chmod 000 blocks the child probes outright; chmod 111 allows stat of a
+            # named child but forbids listing, matching Windows, and is the only
+            # shape reaching the directory listing in Get-StudioAdoptableState.
             $bareWho = "$env:USERDOMAIN\$env:USERNAME"
             $bareModes = if ($onWindows) { @("acl") } else { @("000", "111") }
             foreach ($mode in $bareModes) {

--- a/tests/studio/test_whisper_binary_probe_denied.py
+++ b/tests/studio/test_whisper_binary_probe_denied.py
@@ -39,7 +39,6 @@ def _can_deny() -> bool:
     """Probe rather than infer. Guessing from euid silently drops the only
     behavioural test in any root container, which is most CI images."""
     import tempfile
-
     with tempfile.TemporaryDirectory() as tmp:
         locked = Path(tmp) / "locked"
         locked.mkdir()

--- a/tests/studio/test_whisper_binary_probe_denied.py
+++ b/tests/studio/test_whisper_binary_probe_denied.py
@@ -35,9 +35,28 @@ def _is_runnable():
     raise AssertionError("_is_runnable not found in stt_ggml_sidecar.py")
 
 
+def _can_deny() -> bool:
+    """Probe rather than infer. Guessing from euid silently drops the only
+    behavioural test in any root container, which is most CI images."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        locked = Path(tmp) / "locked"
+        locked.mkdir()
+        (locked / "probe").write_text("", encoding = "utf-8")
+        locked.chmod(0o000)
+        try:
+            (locked / "probe").is_file()
+            return False
+        except OSError:
+            return True
+        finally:
+            locked.chmod(0o755)
+
+
 denial_capable = pytest.mark.skipif(
-    sys.platform == "win32" or os.geteuid() == 0,
-    reason = "chmod 000 does not deny root, and POSIX modes do not model NTFS ACLs",
+    sys.platform == "win32" or not _can_deny(),
+    reason = "this host cannot produce a read denial, so the check would pass vacuously",
 )
 
 

--- a/tests/studio/test_whisper_binary_probe_denied.py
+++ b/tests/studio/test_whisper_binary_probe_denied.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""An unreadable whisper.cpp install must read as engine-unavailable, not raise.
+
+setup.ps1 now leaves a denied `<STUDIO_HOME>/whisper.cpp` in place instead of
+aborting the run, so the backend is the first thing to probe it. `Path.is_file()`
+propagates EACCES, and `stt_status` does not catch it, so an unguarded probe turns
+into a 500 on the one endpoint that reports *both* dictation engines.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SIDECAR = REPO_ROOT / "studio" / "backend" / "core" / "inference" / "stt_ggml_sidecar.py"
+
+
+def _is_runnable():
+    """Exec the real function alone: importing the module pulls in the whole
+    backend (structlog, fastapi), which this check does not need."""
+    tree = ast.parse(SIDECAR.read_text(encoding = "utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "_is_runnable":
+            namespace: dict = {"os": os, "sys": sys, "Path": Path}
+            exec(compile(ast.Module([node], []), str(SIDECAR), "exec"), namespace)
+            return namespace["_is_runnable"]
+    raise AssertionError("_is_runnable not found in stt_ggml_sidecar.py")
+
+
+denial_capable = pytest.mark.skipif(
+    sys.platform == "win32" or os.geteuid() == 0,
+    reason = "chmod 000 does not deny root, and POSIX modes do not model NTFS ACLs",
+)
+
+
+def test_a_readable_executable_is_still_runnable(tmp_path):
+    binary = tmp_path / "whisper-server"
+    binary.write_text("", encoding = "utf-8")
+    binary.chmod(0o755)
+    assert _is_runnable()(binary) is True
+
+
+def test_a_missing_binary_is_not_runnable(tmp_path):
+    assert _is_runnable()(tmp_path / "whisper-server") is False
+
+
+@denial_capable
+def test_an_unreadable_install_dir_reads_as_unavailable_not_an_exception(tmp_path):
+    install = tmp_path / "whisper.cpp"
+    install.mkdir()
+    binary = install / "whisper-server"
+    binary.write_text("", encoding = "utf-8")
+    binary.chmod(0o755)
+    install.chmod(0o000)
+    try:
+        # Negative control: the denial is real on this filesystem.
+        with pytest.raises(OSError):
+            binary.is_file()
+        assert _is_runnable()(binary) is False
+    finally:
+        install.chmod(0o755)

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -369,8 +369,8 @@ def test_setup_helpers_gate_on_canonical_custom_root():
 
     ps_src = SETUP_PS1.read_text(encoding = "utf-8")
     ps_idx = ps_src.index("function Assert-StudioOwnedOrAbsent")
-    # To the end of the function, not a fixed width: a new parameter or comment
-    # would otherwise push the assertions below out of the window.
+    # To the end of the function, not a fixed width, which a new parameter or
+    # comment would push the assertions below out of.
     ps_func = ps_src[ps_idx:].split("\nfunction ", 1)[0]
     assert (
         "$StudioHomeIsCustom -and" in ps_func

--- a/tests/test_studio_install_workspace_guard.py
+++ b/tests/test_studio_install_workspace_guard.py
@@ -369,7 +369,9 @@ def test_setup_helpers_gate_on_canonical_custom_root():
 
     ps_src = SETUP_PS1.read_text(encoding = "utf-8")
     ps_idx = ps_src.index("function Assert-StudioOwnedOrAbsent")
-    ps_func = ps_src[ps_idx : ps_idx + 800]
+    # To the end of the function, not a fixed width: a new parameter or comment
+    # would otherwise push the assertions below out of the window.
+    ps_func = ps_src[ps_idx:].split("\nfunction ", 1)[0]
     assert (
         "$StudioHomeIsCustom -and" in ps_func
     ), "setup.ps1 Assert-StudioOwnedOrAbsent must gate on $StudioHomeIsCustom"


### PR DESCRIPTION
Follow-up to #7735. That PR routed the llama.cpp prebuilt probes through three-state path probing (`Present` / `Absent` / `Denied`) so an ACL-denied `%USERPROFILE%\.unsloth\llama.cpp` reports an actionable error instead of aborting with a raw `Test-Path : Access is denied` under `$ErrorActionPreference = "Stop"`. Two reachable gaps were left open, and I kept them out of that PR to avoid widening it further.

## 1. The source build read inside the tree with a bare probe

Phase 4 probed `$LlamaServerBin` with a bare `Test-Path` before deciding whether to rebuild. Phase 3.4's denial guard only covers the prebuilt path, and `UNSLOTH_LLAMA_FORCE_COMPILE=1`, `UNSLOTH_LLAMA_PR` or a custom `$LlamaSource` skip that path entirely, so on those routes this was the first read inside the tree. A denied `build\` aborted with exactly the raw error #7735 set out to remove.

It now probes three-state. Two things came out of reviewing my own first attempt:

- The probe is skipped when `UNSLOTH_LOCAL_LLAMA_CPP_DIR` is linked. `$LlamaCppDir` is a junction onto the user's own checkout there, so the probe read through it into their tree and the denial told them to delete it and run `takeown /R` against their build. That is what the `-UserSupplied` rule at the candidate loop already forbids. Nothing this block computes is consumed on that path anyway, since the linked branch skips both the download and the build.
- The denial passes `-OwnershipUnverified:$StudioHomeIsCustom`. Nothing on the forced-compile route has run the ownership guard, so under a custom `UNSLOTH_STUDIO_HOME` the tree cannot be proven ours and the "delete it, we reinstall it" advice does not apply.

The `CMakeCache.txt` read below it is guarded too. `Test-PathQuiet` only proves the entry is listed, so a deny ACE on the file itself left the probe returning true and `Select-String` threw, reintroducing the same crash one line under the fix.

## 2. whisper.cpp was fatal on a denied tree

The phase header promises "Failure is never fatal: local dictation falls back to Transformers STT", but under a custom `UNSLOTH_STUDIO_HOME` an unreadable `whisper.cpp` hit `Assert-StudioOwnedOrAbsent` and exited the whole run, taking llama.cpp inference down with it.

`Assert-StudioOwnedOrAbsent` gains a `-NonFatal` switch that hands the denial back instead of exiting. Only that mode returns a value, so the other callers are unchanged, and an unowned tree still stops exactly as before. The check stays behind the installer-exists gate it used to sit inside, so a tree without `install_whisper_prebuilt.py` remains the no-op it was rather than becoming newly fatal.

## 3. The backend then had to survive what setup now leaves behind

Because setup no longer aborts, the backend became the first thing to touch the denied directory. `_is_runnable` let `Path.is_file()` propagate `EACCES` (`_IGNORED_ERRNOS` covers `ENOENT`, `ENOTDIR`, `EBADF`, `ELOOP`, not `EACCES`), and neither `stt_status` nor `_resolve_serving_stt_engine` wraps it. That turned into a 500 out of `/api/inference/audio/stt/status`, the one endpoint that reports both dictation engines, so the setup message promising browser and Transformers dictation still work would not have been true. An unreadable install now reads as engine-unavailable, matching the module's existing "never a crash at load" contract.

## Verification

Behavioural, against real denials rather than only source matching:

| Scenario | Before | After |
|---|---|---|
| Managed tree denied, default home | raw `Test-Path` crash | stops with the delete advice |
| Managed tree denied, custom home | raw crash | stops, says it cannot confirm the folder is its own |
| Linked local dir, denied `build\` | raw crash | not probed, setup continues |
| `CMakeCache.txt` read-denied | raw crash | actionable stop |
| whisper denied, installer present | whole run exits | non-fatal skip, llama.cpp unaffected |
| whisper denied, no installer | whole run exits | no-op, as before |
| whisper unowned, readable | stops | stops |

`tests/studio/test_path_probe_access_denied.ps1` now exercises `-NonFatal` for real against a `chmod`/`icacls` denial, covering both the root-probe and marker-read routes, with the existing negative control that fails the suite if the host cannot actually produce a denial. `tests/studio/test_whisper_binary_probe_denied.py` runs the real `_is_runnable` against a live denied directory.

Every new assertion was mutation-tested: each is confirmed red under the bug it exists to catch, and green under a legitimate change (renumbering the phase header, wrapping a long line, adding a comment, hardening another probe, adding a further denial route). Counts are floors rather than exact matches, and the slice anchors assert before indexing so a moved anchor fails as an assertion instead of an `IndexError`.

Suites: `setup.ps1` parses, 12 PowerShell suites pass, 30 shell suites run with only the pre-existing `test_install_host_defaults.sh` failures (identical on a clean `main`, and already skipped by `tests/run_all.sh`), and 3040 Python tests pass with only the pre-existing `test_negative_control_no_tokenizers` failure, which reproduces unchanged on `main`.

No behaviour changes on readable trees. `setup.sh` is untouched, so Linux, macOS and WSL are unaffected.
