### PR TITLE
Fix and harden the model-config Playwright job, and pin the hooks it drives

### DIFF
--- a/.github/workflows/studio-ui-smoke.yml
+++ b/.github/workflows/studio-ui-smoke.yml
@@ -35,7 +35,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Never on main: pushes land in bursts, so cancelling superseded runs there means
+  # a deterministic failure can go unreported for as long as the bursts continue.
+  # The collapsed-row break below sat on main for 14 hours behind four cancelled
+  # runs. On a PR branch cancelling is still what you want.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read

--- a/tests/studio/playwright_model_config.py
+++ b/tests/studio/playwright_model_config.py
@@ -375,7 +375,13 @@ with sync_playwright() as p:
         except Exception:
             pass
 
-    def select_on_device_row(popover, hint):
+    def find_on_device_row(popover, hint):
+        """Locate the row without clicking it.
+
+        Since single-quant rows collapse (#7736) the row loads its quant in one
+        click and the picker closes, so selecting first would dismiss the gear
+        this is about to press.
+        """
         od = page.get_by_role("tab", name = "On Device").first
         if _count(od):
             od.click()
@@ -389,16 +395,18 @@ with sync_playwright() as p:
                 search.fill(hint)
                 page.wait_for_timeout(700)
                 row = popover.locator("[data-model-picker-option]", has_text = hint).first
-        if _count(row) == 0:
-            return None
-        row.click()
-        page.wait_for_timeout(800)
-        return row
+        return row if _count(row) else None
 
     def open_config(popover, hint):
-        if select_on_device_row(popover, hint) is None:
+        if find_on_device_row(popover, hint) is None:
             return None
-        gear = popover.locator('button[aria-label^="Inference settings for"]').first
+        # data-model-picker-option sits on the row button; the gear is its
+        # sibling, so it cannot be reached through the row. Match it by the model
+        # its own label names, which also keeps this from pressing the gear of
+        # whichever row happens to come first.
+        gear = popover.locator(
+            f'button[aria-label^="Inference settings for"][aria-label*="{hint}"]'
+        ).first
         if _count(gear) == 0:
             return None
         gear.click()

--- a/tests/studio/playwright_model_config.py
+++ b/tests/studio/playwright_model_config.py
@@ -397,17 +397,38 @@ with sync_playwright() as p:
                 row = popover.locator("[data-model-picker-option]", has_text = hint).first
         return row if _count(row) else None
 
-    def open_config(popover, hint):
-        if find_on_device_row(popover, hint) is None:
-            return None
+    def find_gear(popover, hint, tries = 6):
         # data-model-picker-option sits on the row button; the gear is its
         # sibling, so it cannot be reached through the row. Match it by the model
         # its own label names, which also keeps this from pressing the gear of
         # whichever row happens to come first.
-        gear = popover.locator(
-            f'button[aria-label^="Inference settings for"][aria-label*="{hint}"]'
-        ).first
-        if _count(gear) == 0:
+        #
+        # Polled rather than read once: a row waiting on its sole-quant probe
+        # renders with no gear at all for a moment, and a single miss there would
+        # read as "this model has no run-settings".
+        sel = f'button[aria-label^="Inference settings for"][aria-label*="{hint}"]'
+        for _ in range(tries):
+            gear = popover.locator(sel).first
+            if _count(gear):
+                return gear
+            page.wait_for_timeout(500)
+        return None
+
+    def open_config(popover, hint):
+        row = find_on_device_row(popover, hint)
+        if row is None:
+            return None
+        gear = find_gear(popover, hint)
+        if gear is None:
+            # No gear on the row itself means this is a multi-quant parent, which
+            # mounts one per variant only once expanded. Clicking it is safe here
+            # and only here: the parent's onClick is toggleGgufExpanded, while the
+            # collapsed single-quant row -- the one that loads and closes the
+            # picker -- is exactly the row that already had a gear above.
+            row.click()
+            page.wait_for_timeout(800)
+            gear = find_gear(popover, hint)
+        if gear is None:
             return None
         gear.click()
         page.wait_for_timeout(800)

--- a/tests/studio/playwright_model_config.py
+++ b/tests/studio/playwright_model_config.py
@@ -260,9 +260,7 @@ with sync_playwright() as p:
             # Scoping is meaningful, so an empty result is a real answer: returning
             # every entry here is what let another model's value satisfy these checks.
             return [
-                cfg[k]
-                for k in recognised
-                if needle in str(k).lower() and isinstance(cfg[k], dict)
+                cfg[k] for k in recognised if needle in str(k).lower() and isinstance(cfg[k], dict)
             ]
         return config_entries(cfg)
 
@@ -417,7 +415,9 @@ with sync_playwright() as p:
         rows = []
         try:
             opts = page.locator("[data-model-picker-option]")
-            rows = [(opts.nth(i).inner_text() or "").strip()[:60] for i in range(min(opts.count(), 12))]
+            rows = [
+                (opts.nth(i).inner_text() or "").strip()[:60] for i in range(min(opts.count(), 12))
+            ]
         except Exception:
             pass
         gears = []

--- a/tests/studio/playwright_model_config.py
+++ b/tests/studio/playwright_model_config.py
@@ -43,6 +43,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _playwright_robust import (  # noqa: E402
     chromium_launch_args,
     click_and_wait_for_response,
+    dump_diagnostics,
     evaluate_fetch,
     install_view_transition_killer,
     install_wall_clock_watchdog,
@@ -67,6 +68,15 @@ MODEL_HINT = os.environ.get("STUDIO_MODEL_HINT", "gemma-3-270m")
 # Context Length, clearly not a default, so persistence is unambiguous.
 DISTINCT_CTX = int(os.environ.get("STUDIO_DISTINCT_CTX", "4096"))
 ART_DIR = os.environ.get("PW_ART_DIR", "logs/playwright_modelcfg")
+# Settle window after run-settings opens, before staging an edit. An edit made in
+# the panel's first moments is silently discarded: it re-derives its baseline once
+# mount-time work lands and drops whatever was staged, so Save reports "Default
+# settings kept" and stores nothing. Measured on gemma-3-270m: fails at 0ms, passes
+# from 500ms. The panel exposes no readiness signal to poll -- the input value, the
+# Reset state and the primary button label are all identical before and after -- so
+# this is a bounded wait rather than a condition. A person cannot open the panel,
+# read it, type and click inside half a second; only a driver can.
+CONFIG_SETTLE_MS = int(os.environ.get("STUDIO_CONFIG_SETTLE_MS", "1000"))
 ART = Path(ART_DIR)
 ART.mkdir(parents = True, exist_ok = True)
 STRICT = os.environ.get("STUDIO_UI_STRICT", "0") == "1"
@@ -107,9 +117,17 @@ def runtime_warn(m: str) -> None:
 
 
 def _count(loc) -> int:
+    """Number of matches, or 0.
+
+    A raise here is not the same as no match: a closed page or a lost execution
+    context also throws, and reporting that as "selector missing" sends the reader
+    after the markup instead of the crash. Say so, then still return 0 so callers
+    that only branch on emptiness keep working.
+    """
     try:
         return loc.count()
-    except Exception:
+    except Exception as exc:
+        info(f"WARN: locator raised (not a missing element): {type(exc).__name__}: {exc}")
         return 0
 
 
@@ -204,19 +222,49 @@ with sync_playwright() as p:
             info(f"WARN: screenshot {name} failed: {_shoot_err}")
 
     def read_configs() -> dict:
-        """Return the parsed unsloth_model_configs map (or {} if absent/invalid)."""
+        """Return the parsed unsloth_model_configs map (or {} if absent/invalid).
+
+        Absent and unreadable are not the same: "no entry" is what several assertions
+        below treat as success, so storage that failed to read must be said out loud
+        rather than passed off as a clean slate.
+        """
         raw = robust_evaluate(page, "() => localStorage.getItem('unsloth_model_configs')")
         if not raw:
             return {}
         try:
             data = json.loads(raw)
-            return data if isinstance(data, dict) else {}
-        except Exception:
+        except Exception as exc:
+            fail(f"unsloth_model_configs is unreadable ({exc}); raw={str(raw)[:200]!r}")
             return {}
+        if not isinstance(data, dict):
+            fail(f"unsloth_model_configs is not an object: {type(data).__name__}")
+            return {}
+        return data
 
     def config_entries(cfg: dict) -> list[dict]:
         """The per-model entries (dict values) of the stored map, schema-tolerant."""
         return [v for v in cfg.values() if isinstance(v, dict)]
+
+    def entries_for_model(cfg: dict) -> list[dict]:
+        """Only the entries keyed to the model under test.
+
+        The keys embed the repo id and quant (`v2:["<repo>","<quant>"]`), so scanning
+        every entry lets a value belonging to a different model satisfy a persistence,
+        reset or migration assertion. Falls back to all entries only when the key shape
+        is unrecognised, so a schema change degrades to the old behaviour rather than
+        silently asserting nothing.
+        """
+        needle = GGUF_REPO.lower()
+        recognised = [k for k in cfg if re.match(r"^v\d+:\[", str(k).lower())]
+        if recognised:
+            # Scoping is meaningful, so an empty result is a real answer: returning
+            # every entry here is what let another model's value satisfy these checks.
+            return [
+                cfg[k]
+                for k in recognised
+                if needle in str(k).lower() and isinstance(cfg[k], dict)
+            ]
+        return config_entries(cfg)
 
     # ─────────────────────────────────────────────────────
     # Setup: authenticate + model load.
@@ -359,6 +407,34 @@ with sync_playwright() as p:
     POPOVER = '[data-tour="chat-model-selector-popover"]'
     TRIGGER = '[data-tour="chat-model-selector"]'
 
+    def diagnose(name, selector):
+        """Screenshot + JSON sidecar (URL, body, storage) for a selector that missed.
+
+        Without this a miss reaches the log as one line naming a selector, and the
+        artifact holds no record of what the picker was actually showing -- which is
+        how a picker that had closed itself read as a missing gear.
+        """
+        rows = []
+        try:
+            opts = page.locator("[data-model-picker-option]")
+            rows = [(opts.nth(i).inner_text() or "").strip()[:60] for i in range(min(opts.count(), 12))]
+        except Exception:
+            pass
+        gears = []
+        try:
+            g = page.locator(GEAR_ANY)
+            gears = [g.nth(i).get_attribute("aria-label") for i in range(min(g.count(), 12))]
+        except Exception:
+            pass
+        dump_diagnostics(
+            page,
+            ART,
+            name,
+            info = info,
+            extra = {"missed_selector": selector, "option_rows": rows, "gear_labels": gears},
+        )
+        info(f"DIAG {name}: {len(rows)} option row(s), {len(gears)} gear(s); see {name}.json")
+
     def open_picker():
         popover = page.locator(POPOVER).first
         if _count(popover) == 0 or not popover.is_visible():
@@ -397,18 +473,25 @@ with sync_playwright() as p:
                 row = popover.locator("[data-model-picker-option]", has_text = hint).first
         return row if _count(row) else None
 
-    # `i`: find_on_device_row matches with has_text, which is case-insensitive,
-    # so without it the two disagree on a hint whose case differs from the repo id
-    # -- and STUDIO_MODEL_HINT is an env var. The row would be found, the gear
-    # missed, and the fallback below would then click a row that loads.
+    # The gear is not reachable through the row: data-model-picker-option sits on the
+    # row button, and the gear is that button's sibling at only 2 of its 11 render
+    # sites -- at the other 9 it is an uncle (shell > div.min-w-0.flex-1 > option,
+    # gear a direct child of the shell). Matching on its own label sidesteps the DOM
+    # shape entirely, and naming the model keeps this off another row's gear.
+    #
+    # `i`: find_on_device_row matches with has_text, which is case-insensitive, so
+    # without it the two disagree on a hint whose case differs from the repo id --
+    # and STUDIO_MODEL_HINT is an env var. The row would be found, the gear missed,
+    # and the fallback below would then click a row that loads.
     GEAR = 'button[aria-label^="Inference settings for" i][aria-label*="{h}" i]'
+    # Unfiltered, for diagnostics: what gears exist at all when one was not found.
+    GEAR_ANY = 'button[aria-label^="Inference settings for" i]'
 
-    def find_gear(scope, hint, timeout = 3000):
-        # data-model-picker-option sits on the row button; the gear is its
-        # sibling, so it cannot be reached through the row. Match it by the model
-        # its own label names, which also keeps this from pressing the gear of
-        # whichever row happens to come first.
-        #
+    def find_gear(
+        scope,
+        hint,
+        timeout = 3000,
+    ):
         # Waited for rather than read once: a row still resolving its sole-quant
         # probe renders with no gear at all for a moment, and a single miss there
         # would read as "this model has no run-settings". wait_for returns as soon
@@ -420,18 +503,24 @@ with sync_playwright() as p:
             return None
         return gear
 
+    def config_is_open(popover):
+        """Back is unique to the config page and always rendered inside the picker."""
+        return _count(popover.get_by_role("button", name = "Back to model list")) > 0
+
     def open_config(popover, hint):
         row = find_on_device_row(popover, hint)
         if row is None:
+            diagnose("open-config-no-row", f"[data-model-picker-option] has_text={hint!r}")
             return None
         gear = find_gear(popover, hint)
         if gear is None:
-            # No gear beside the row means a multi-quant parent, which mounts one
-            # per variant only once expanded. Clicking is safe here and only here:
-            # every gearless row in this section expands rather than loads, while
-            # the collapsed single-quant row -- the one that loads and closes the
-            # picker -- is exactly the row that already had a gear above. So the
-            # absence of a gear is itself what makes this click safe.
+            # No gear beside the row means a multi-quant parent, which renders an
+            # aria-hidden 42px spacer in its place and mounts one gear per variant
+            # only once expanded. So the absence is the row-kind signal, not a miss,
+            # and clicking is safe here and only here: the parent's onClick is
+            # toggleGgufExpanded, while the collapsed single-quant row -- the one
+            # that loads and closes the picker -- is exactly the row that would
+            # have had a gear above.
             row.click()
             page.wait_for_timeout(800)
             # Scoped to this row's group first: after expanding, every variant
@@ -441,10 +530,18 @@ with sync_playwright() as p:
             group = row.locator("xpath=ancestor::div[1]")
             gear = find_gear(group, hint, timeout = 2000) or find_gear(popover, hint)
         if gear is None:
+            diagnose("open-config-no-gear", GEAR.format(h = hint))
             return None
         gear.click()
-        page.wait_for_timeout(800)
-        return popover
+        # Gate on the page itself rather than a sleep, so a slow mount is waited out
+        # and a failed open is not mistaken for a missing Context Length input below.
+        for _ in range(20):
+            if config_is_open(popover):
+                page.wait_for_timeout(CONFIG_SETTLE_MS)
+                return popover
+            page.wait_for_timeout(250)
+        diagnose("open-config-not-open", 'button[name="Back to model list"]')
+        return None
 
     def context_input(popover):
         for role in ("textbox", "spinbutton"):
@@ -455,8 +552,12 @@ with sync_playwright() as p:
         return loc if _count(loc) else None
 
     def primary_button(popover):
+        # exact: get_by_role matches the accessible name as a substring by default, so
+        # "Load model" also matches "Reload model" -- and it is swept first, so the
+        # reload case would be found under the wrong name. The panel shows exactly one
+        # of these four.
         for name in ("Load model", "Reload model", "Save settings", "Forget settings"):
-            b = popover.get_by_role("button", name = name).first
+            b = popover.get_by_role("button", name = name, exact = True).first
             if _count(b):
                 return b
         return None
@@ -470,6 +571,19 @@ with sync_playwright() as p:
     needles = ["bge-small-en-v1.5", "stories260"]
     tabs = ["Recommended", "On Device", "Connected"]
     hidden_ok = True
+    # This step asserts an absence, so it passes for free if the picker renders no rows
+    # at all -- which is exactly the state a broken picker is in. Prove it is populated
+    # first, or "hidden" means nothing.
+    od_tab = page.get_by_role("tab", name = "On Device").first
+    if _count(od_tab):
+        od_tab.click()
+        page.wait_for_timeout(400)
+    populated = _count(popover.locator("[data-model-picker-option]"))
+    if populated == 0:
+        fail("picker shows no rows at all, so the hidden-model check below proves nothing")
+        diagnose("hidden-check-empty-picker", "[data-model-picker-option]")
+    else:
+        info(f"picker populated: {populated} option row(s) before the hidden check")
     for needle in needles:
         for tab_name in tabs:
             tab = page.get_by_role("tab", name = tab_name).first
@@ -540,7 +654,7 @@ with sync_playwright() as p:
 
                 # (a) localStorage stored the distinctive context.
                 cfg = read_configs()
-                entries = config_entries(cfg)
+                entries = entries_for_model(cfg)
                 got_ls = any(e.get("customContextLength") == DISTINCT_CTX for e in entries)
                 if got_ls:
                     info(f"OK persist(localStorage): customContextLength={DISTINCT_CTX} stored")
@@ -614,7 +728,7 @@ with sync_playwright() as p:
             page.wait_for_timeout(1500)
         cfg = read_configs()
         pinned = any(
-            _as_int(e.get("customContextLength")) == DISTINCT_CTX for e in config_entries(cfg)
+            _as_int(e.get("customContextLength")) == DISTINCT_CTX for e in entries_for_model(cfg)
         )
         if pinned:
             fail("Reset left the distinctive context pinned in unsloth_model_configs")
@@ -630,10 +744,21 @@ with sync_playwright() as p:
     # number, or doing so before a Reset, recreates a phantom context pin.
     # ─────────────────────────────────────────────────────
     step("re-typing the shown context does not pin an override")
-    ctx_in = context_input(popover)
-    native_default = _as_int(ctx_in.input_value()) if ctx_in else None
+    # Own its state instead of inheriting the step above: the previous step commits a
+    # Reset, which can close the picker, and inheriting turned that into a silent skip
+    # that let this regression go unchecked.
+    popover = open_picker()
+    if open_config(popover, MODEL_HINT) is None:
+        fail("could not open run-settings for the re-type-shown check")
+        ctx_in = None
+        native_default = None
+    else:
+        ctx_in = context_input(popover)
+        native_default = _as_int(ctx_in.input_value()) if ctx_in else None
     if ctx_in is None or native_default is None:
-        info("skip re-type-shown: Context Length input has no numeric default")
+        # A skip here is not a pass: this step is the only guard on the phantom-pin
+        # regression, so say so at the level STRICT gates rather than as prose.
+        soft_fail("re-type-shown did not run: Context Length input has no numeric default")
     else:
         remember = popover.get_by_label("Remember for this model").first
         if _count(remember):
@@ -652,7 +777,7 @@ with sync_playwright() as p:
             page.wait_for_timeout(1500)
         cfg = read_configs()
         pinned = any(
-            _as_int(e.get("customContextLength")) == native_default for e in config_entries(cfg)
+            _as_int(e.get("customContextLength")) == native_default for e in entries_for_model(cfg)
         )
         if pinned:
             fail(
@@ -703,7 +828,7 @@ with sync_playwright() as p:
                 page.wait_for_timeout(1500)
             cfg = read_configs()
             has_adv = any(
-                e.get("tensorParallel") or e.get("kvCacheDtype") for e in config_entries(cfg)
+                e.get("tensorParallel") or e.get("kvCacheDtype") for e in entries_for_model(cfg)
             )
             if toggled and has_adv:
                 info("OK advanced: tensorParallel/kvCacheDtype persisted")
@@ -754,7 +879,7 @@ with sync_playwright() as p:
         page.wait_for_timeout(800)
         cfg_first = read_configs()
         migrated_ctx = any(
-            e.get("customContextLength") == DISTINCT_CTX for e in config_entries(cfg_first)
+            e.get("customContextLength") == DISTINCT_CTX for e in entries_for_model(cfg_first)
         )
         if migrated_ctx:
             info(f"OK migration: legacy context {DISTINCT_CTX} preserved after migrating")
@@ -794,7 +919,7 @@ with sync_playwright() as p:
             keys_second = set(cfg_second.keys())
             new_keys = keys_second - keys_first
             still_has_ctx = any(
-                e.get("customContextLength") == DISTINCT_CTX for e in config_entries(cfg_second)
+                e.get("customContextLength") == DISTINCT_CTX for e in entries_for_model(cfg_second)
             )
             if new_keys:
                 soft_fail(

--- a/tests/studio/playwright_model_config.py
+++ b/tests/studio/playwright_model_config.py
@@ -91,6 +91,44 @@ _n = [0]
 _failed: list[str] = []
 
 
+# Ported from features/hub/lib/local-path.ts and features/hub/lib/model-identity.ts.
+_LOCAL_PATH_PREFIX_RE = re.compile(
+    r"^(?:/|\.{1,2}(?:$|[\\/])|~(?:$|[\\/])|~[^\\/]+[\\/]|[A-Za-z]:[\\/]|\\\\)"
+)
+_WINDOWS_DRIVE_PATH_RE = re.compile(r"^[A-Za-z]:[\\/]")
+_WSL_DRIVE_PATH_RE = re.compile(r"^/mnt/[A-Za-z](?:/|$)")
+
+
+def _normalize_case_insensitive_path(path: str, min_length: int) -> str:
+    slashed = path.replace("\\", "/")
+    end = len(slashed)
+    while end > min_length and slashed[end - 1] == "/":
+        end -= 1
+    return slashed[:end].lower()
+
+
+def _normalize_model_identity(model_id: str) -> str:
+    """Mirror of normalizeModelIdentity in features/hub/lib/model-identity.ts.
+
+    Case folding is not unconditional there: a plain POSIX path keeps its case,
+    because /models/Foo.gguf and /models/foo.gguf are different files. Only a hub
+    id and the case-insensitive roots -- a Windows drive, a UNC share, a WSL mount
+    -- fold. Lowercasing everything here merged paths the app keeps apart, so an
+    entry belonging to one could satisfy a check that the other had saved.
+    """
+    trimmed = model_id.strip()
+    if not (trimmed and _LOCAL_PATH_PREFIX_RE.match(trimmed)):
+        return trimmed.lower()
+    slash_path = trimmed.replace("\\", "/")
+    if _WINDOWS_DRIVE_PATH_RE.match(trimmed):
+        return _normalize_case_insensitive_path(trimmed, 3)
+    if slash_path.startswith("//"):
+        return _normalize_case_insensitive_path(trimmed, 2)
+    if _WSL_DRIVE_PATH_RE.match(slash_path):
+        return _normalize_case_insensitive_path(trimmed, 6)
+    return trimmed
+
+
 def step(s: str) -> None:
     print(f"[ui-modelcfg] STEP {s}", flush = True)
 
@@ -255,7 +293,7 @@ with sync_playwright() as p:
         shape, so a schema change degrades to the old behaviour rather than silently
         asserting nothing.
         """
-        want = (GGUF_REPO.strip().lower(), GGUF_VARIANT.strip().lower())
+        want = (_normalize_model_identity(GGUF_REPO), GGUF_VARIANT.strip().lower())
         recognised = [k for k in cfg if re.match(r"^v\d+:\[", str(k))]
         if not recognised:
             return config_entries(cfg)
@@ -270,7 +308,8 @@ with sync_playwright() as p:
                 continue
             if not isinstance(parts, list) or not parts:
                 continue
-            got = tuple(str(x).strip().lower() for x in (list(parts) + [""])[:2])
+            raw = (list(parts) + [""])[:2]
+            got = (_normalize_model_identity(str(raw[0])), str(raw[1]).strip().lower())
             if got == want and isinstance(cfg[key], dict):
                 matched.append(cfg[key])
         # Scoping is meaningful, so an empty result is a real answer: returning every
@@ -514,7 +553,12 @@ with sync_playwright() as p:
         # variant and they all carry the repo id.
         sel = GEAR.format(h = hint)
         if quant:
-            sel += f'[aria-label*="{quant}" i]'
+            # Ends-with, not contains: every label is "<repo> <quant>", so the quant
+            # is the final token, and an unbounded substring lets F16 match BF16 --
+            # whereupon `.first` among independently ordered variants can open the
+            # other one, and the exact-key storage checks then fail on a quant that
+            # was working.
+            sel += f'[aria-label$=" {quant}" i]'
         gear = scope.locator(sel).first
         try:
             gear.wait_for(state = "attached", timeout = timeout)

--- a/tests/studio/playwright_model_config.py
+++ b/tests/studio/playwright_model_config.py
@@ -397,26 +397,28 @@ with sync_playwright() as p:
                 row = popover.locator("[data-model-picker-option]", has_text = hint).first
         return row if _count(row) else None
 
-    def find_gear(
-        popover,
-        hint,
-        tries = 6,
-    ):
+    # `i`: find_on_device_row matches with has_text, which is case-insensitive,
+    # so without it the two disagree on a hint whose case differs from the repo id
+    # -- and STUDIO_MODEL_HINT is an env var. The row would be found, the gear
+    # missed, and the fallback below would then click a row that loads.
+    GEAR = 'button[aria-label^="Inference settings for" i][aria-label*="{h}" i]'
+
+    def find_gear(scope, hint, timeout = 3000):
         # data-model-picker-option sits on the row button; the gear is its
         # sibling, so it cannot be reached through the row. Match it by the model
         # its own label names, which also keeps this from pressing the gear of
         # whichever row happens to come first.
         #
-        # Polled rather than read once: a row waiting on its sole-quant probe
-        # renders with no gear at all for a moment, and a single miss there would
-        # read as "this model has no run-settings".
-        sel = f'button[aria-label^="Inference settings for"][aria-label*="{hint}"]'
-        for _ in range(tries):
-            gear = popover.locator(sel).first
-            if _count(gear):
-                return gear
-            page.wait_for_timeout(500)
-        return None
+        # Waited for rather than read once: a row still resolving its sole-quant
+        # probe renders with no gear at all for a moment, and a single miss there
+        # would read as "this model has no run-settings". wait_for returns as soon
+        # as it mounts rather than sleeping out a fixed poll.
+        gear = scope.locator(GEAR.format(h = hint)).first
+        try:
+            gear.wait_for(state = "attached", timeout = timeout)
+        except Exception:
+            return None
+        return gear
 
     def open_config(popover, hint):
         row = find_on_device_row(popover, hint)
@@ -424,14 +426,20 @@ with sync_playwright() as p:
             return None
         gear = find_gear(popover, hint)
         if gear is None:
-            # No gear on the row itself means this is a multi-quant parent, which
-            # mounts one per variant only once expanded. Clicking it is safe here
-            # and only here: the parent's onClick is toggleGgufExpanded, while the
-            # collapsed single-quant row -- the one that loads and closes the
-            # picker -- is exactly the row that already had a gear above.
+            # No gear beside the row means a multi-quant parent, which mounts one
+            # per variant only once expanded. Clicking is safe here and only here:
+            # every gearless row in this section expands rather than loads, while
+            # the collapsed single-quant row -- the one that loads and closes the
+            # picker -- is exactly the row that already had a gear above. So the
+            # absence of a gear is itself what makes this click safe.
             row.click()
             page.wait_for_timeout(800)
-            gear = find_gear(popover, hint)
+            # Scoped to this row's group first: after expanding, every variant
+            # mounts a gear and all of them carry the repo id, so `.first` over
+            # the whole popover would configure an arbitrary quant, possibly one
+            # that is not even downloaded.
+            group = row.locator("xpath=ancestor::div[1]")
+            gear = find_gear(group, hint, timeout = 2000) or find_gear(popover, hint)
         if gear is None:
             return None
         gear.click()

--- a/tests/studio/playwright_model_config.py
+++ b/tests/studio/playwright_model_config.py
@@ -397,7 +397,11 @@ with sync_playwright() as p:
                 row = popover.locator("[data-model-picker-option]", has_text = hint).first
         return row if _count(row) else None
 
-    def find_gear(popover, hint, tries = 6):
+    def find_gear(
+        popover,
+        hint,
+        tries = 6,
+    ):
         # data-model-picker-option sits on the row button; the gear is its
         # sibling, so it cannot be reached through the row. Match it by the model
         # its own label names, which also keeps this from pressing the gear of

--- a/tests/studio/playwright_model_config.py
+++ b/tests/studio/playwright_model_config.py
@@ -249,20 +249,33 @@ with sync_playwright() as p:
         """Only the entries keyed to the model under test.
 
         The keys embed the repo id and quant (`v2:["<repo>","<quant>"]`), so scanning
-        every entry lets a value belonging to a different model satisfy a persistence,
-        reset or migration assertion. Falls back to all entries only when the key shape
-        is unrecognised, so a schema change degrades to the old behaviour rather than
-        silently asserting nothing.
+        every entry lets a value belonging to a different model -- or to another quant
+        of this one -- satisfy a persistence, reset or migration assertion. Both halves
+        have to match. Falls back to all entries only when no key has the versioned
+        shape, so a schema change degrades to the old behaviour rather than silently
+        asserting nothing.
         """
-        needle = GGUF_REPO.lower()
-        recognised = [k for k in cfg if re.match(r"^v\d+:\[", str(k).lower())]
-        if recognised:
-            # Scoping is meaningful, so an empty result is a real answer: returning
-            # every entry here is what let another model's value satisfy these checks.
-            return [
-                cfg[k] for k in recognised if needle in str(k).lower() and isinstance(cfg[k], dict)
-            ]
-        return config_entries(cfg)
+        want = (GGUF_REPO.strip().lower(), GGUF_VARIANT.strip().lower())
+        recognised = [k for k in cfg if re.match(r"^v\d+:\[", str(k))]
+        if not recognised:
+            return config_entries(cfg)
+        matched = []
+        for key in recognised:
+            # Parse the key rather than substring-searching its serialised form: the
+            # repo alone also matches this repo's *other* quants, so a stale entry for
+            # one quant could stand in for the one under test and mask its failed save.
+            try:
+                parts = json.loads(str(key).split(":", 1)[1])
+            except Exception:
+                continue
+            if not isinstance(parts, list) or not parts:
+                continue
+            got = tuple(str(x).strip().lower() for x in (list(parts) + [""])[:2])
+            if got == want and isinstance(cfg[key], dict):
+                matched.append(cfg[key])
+        # Scoping is meaningful, so an empty result is a real answer: returning every
+        # entry here is what let another model's value satisfy these checks.
+        return matched
 
     # ─────────────────────────────────────────────────────
     # Setup: authenticate + model load.
@@ -490,13 +503,19 @@ with sync_playwright() as p:
     def find_gear(
         scope,
         hint,
+        quant = None,
         timeout = 3000,
     ):
         # Waited for rather than read once: a row still resolving its sole-quant
         # probe renders with no gear at all for a moment, and a single miss there
         # would read as "this model has no run-settings". wait_for returns as soon
         # as it mounts rather than sleeping out a fixed poll.
-        gear = scope.locator(GEAR.format(h = hint)).first
+        # A quant narrows the label to one variant; the expander mounts one gear per
+        # variant and they all carry the repo id.
+        sel = GEAR.format(h = hint)
+        if quant:
+            sel += f'[aria-label*="{quant}" i]'
+        gear = scope.locator(sel).first
         try:
             gear.wait_for(state = "attached", timeout = timeout)
         except Exception:
@@ -523,12 +542,18 @@ with sync_playwright() as p:
             # have had a gear above.
             row.click()
             page.wait_for_timeout(800)
-            # Scoped to this row's group first: after expanding, every variant
-            # mounts a gear and all of them carry the repo id, so `.first` over
-            # the whole popover would configure an arbitrary quant, possibly one
-            # that is not even downloaded.
+            # Every expanded variant mounts its own gear and all of them carry the
+            # repo id, so the repo hint alone leaves `.first` to pick an arbitrary
+            # quant -- possibly one that is not downloaded. Each label is
+            # "<repo> <quant>", so name the quant under test. Scoping to the row's
+            # group as well keeps another repo's expander out of it.
             group = row.locator("xpath=ancestor::div[1]")
-            gear = find_gear(group, hint, timeout = 2000) or find_gear(popover, hint)
+            gear = (
+                find_gear(group, hint, quant = GGUF_VARIANT, timeout = 2000)
+                or find_gear(popover, hint, quant = GGUF_VARIANT, timeout = 2000)
+                or find_gear(group, hint, timeout = 2000)
+                or find_gear(popover, hint)
+            )
         if gear is None:
             diagnose("open-config-no-gear", GEAR.format(h = hint))
             return None

--- a/tests/studio/playwright_model_config.py
+++ b/tests/studio/playwright_model_config.py
@@ -531,7 +531,16 @@ with sync_playwright() as p:
         if row is None:
             diagnose("open-config-no-row", f"[data-model-picker-option] has_text={hint!r}")
             return None
-        gear = find_gear(popover, hint)
+        # The quant first, here too, not only in the expansion branch below. With
+        # "Expand quantizations" on, the expander is already mounted, so a repo-only
+        # lookup finds a gear straight away and never reaches that branch -- and
+        # GgufVariantExpander orders variants by fit and recommendation, not by
+        # GGUF_VARIANT, so `.first` among them opens an arbitrary quant. Repo-only
+        # stays as the fallback for the single-quant row, whose label still carries
+        # its own quant but need not be the one this job names.
+        gear = find_gear(popover, hint, quant = GGUF_VARIANT, timeout = 2000) or find_gear(
+            popover, hint
+        )
         if gear is None:
             # No gear beside the row means a multi-quant parent, which renders an
             # aria-hidden 42px spacer in its place and mounts one gear per variant

--- a/tests/studio/playwright_model_config.py
+++ b/tests/studio/playwright_model_config.py
@@ -612,6 +612,17 @@ with sync_playwright() as p:
     if _count(od_tab):
         od_tab.click()
         page.wait_for_timeout(400)
+    # Waited for, not counted once: until cachedReady flips the picker renders the
+    # loading state with no rows at all, so a fixed pause turns a slow cache scan
+    # into a hard failure. A populated picker attaches a row as soon as it has one,
+    # so this returns immediately in the normal case and only spends the timeout
+    # when there is genuinely nothing -- which is the case worth failing on.
+    try:
+        popover.locator("[data-model-picker-option]").first.wait_for(
+            state = "attached", timeout = 20_000
+        )
+    except Exception:
+        pass
     populated = _count(popover.locator("[data-model-picker-option]"))
     if populated == 0:
         fail("picker shows no rows at all, so the hidden-model check below proves nothing")

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -2005,9 +2005,13 @@ def test_picker_rows_keep_their_automation_attributes():
 
 
 def test_picker_popover_and_trigger_keep_their_tour_hooks():
+    """Both props by name. The trigger's value is a prefix of the popover's, so any
+    assertion that falls back to the bare substring is satisfied by the popover alone
+    and would pass with the trigger hook deleted -- while the driver's very first
+    click, page.locator(TRIGGER), would be the thing that fails."""
     chat = _read("features/chat/chat-page.tsx")
-    assert "chat-model-selector-popover" in chat
-    assert 'dataTour="chat-model-selector"' in chat or "chat-model-selector" in chat
+    assert 'triggerDataTour="chat-model-selector"' in chat
+    assert 'contentDataTour="chat-model-selector-popover"' in chat
 
 
 def test_run_settings_gear_label_names_its_model():
@@ -2031,10 +2035,16 @@ def test_a_multi_quant_parent_row_still_has_no_gear():
 def test_run_settings_page_keeps_its_identifying_controls():
     page = _read("features/model-picker/components/model-config-page.tsx")
     # How the driver knows run-settings actually opened.
-    assert '"Back to model list"' in page or "Back to model list" in page
+    assert 'aria-label="Back to model list"' in page
     assert 'ariaLabel="Context Length"' in page
     assert 'aria-label="Context Length"' in page
-    assert ">\n            Reset" in page or "Reset" in page
+    # The button, not the word: "Reset" also appears in this file's own comments, so a
+    # raw source search passes with the control deleted and the Playwright reset gate
+    # only finds out 25 minutes later.
+    assert re.search(
+        r"onClick=\{\(\) => setConfig\(\{ \.\.\.DEFAULT_PER_MODEL_CONFIG \}\)\}\s*>\s*Reset\s*</Button>",
+        page,
+    ), "the Reset button's JSX is gone or no longer named Reset"
 
 
 def test_the_primary_action_keeps_its_four_labels():

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -1982,3 +1982,65 @@ def test_clearing_the_log_keeps_a_request_that_is_still_running():
     zero and the finish or fail that follows has no entry left to land on."""
     monitor = " ".join(_read_backend("core/inference/api_monitor.py").split())
     assert 'if entry.shared or entry.subject != subject or entry.status == "running"' in monitor
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test hooks the Playwright driver depends on.
+#
+# tests/studio/playwright_model_config.py drives the picker through these exact
+# attributes and accessible names. Renaming one is a source-only edit that type
+# checks, lints and passes every unit test, and then fails a 25-minute browser job
+# with "selector not found" -- which is how the collapsed-row regression (#7736)
+# sat on main. Pin them here so that break costs two seconds instead.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_picker_rows_keep_their_automation_attributes():
+    pickers = _read("features/model-picker/components/model-selector/pickers.tsx")
+    # On the row button itself, not a wrapper: the driver scopes row text to it.
+    assert '"data-model-picker-option": true;' in pickers
+    assert '"data-model-picker-option": true,' in pickers
+    assert "data-model-picker-search-input" in pickers
+    assert "data-model-picker-list" in pickers
+
+
+def test_picker_popover_and_trigger_keep_their_tour_hooks():
+    chat = _read("features/chat/chat-page.tsx")
+    assert 'chat-model-selector-popover' in chat
+    assert 'dataTour="chat-model-selector"' in chat or "chat-model-selector" in chat
+
+
+def test_run_settings_gear_label_names_its_model():
+    """The driver cannot reach the gear through the row -- it is a sibling at 2 of its
+    render sites and an uncle at the rest -- so it matches on this label, and the model
+    name in it is what keeps it off another row's gear."""
+    pickers = _read("features/model-picker/components/model-selector/pickers.tsx")
+    assert "Inference settings for ${" in pickers
+    action = _read(
+        "features/model-picker/components/model-selector/model-load-settings-action.tsx"
+    )
+    assert "aria-label={ariaLabel}" in action
+
+
+def test_a_multi_quant_parent_row_still_has_no_gear():
+    """The driver reads the absence of a gear as "this row expands rather than loads".
+    Give the parent row a gear and that inference silently inverts."""
+    pickers = _read("features/model-picker/components/model-selector/pickers.tsx")
+    assert 'aria-hidden="true"' in pickers
+    assert "w-[42px]" in pickers
+
+
+def test_run_settings_page_keeps_its_identifying_controls():
+    page = _read("features/model-picker/components/model-config-page.tsx")
+    # How the driver knows run-settings actually opened.
+    assert '"Back to model list"' in page or "Back to model list" in page
+    assert 'ariaLabel="Context Length"' in page
+    assert 'aria-label="Context Length"' in page
+    assert ">\n            Reset" in page or "Reset" in page
+
+
+def test_the_primary_action_keeps_its_four_labels():
+    """The driver sweeps these names to find the one button the panel shows."""
+    page = _read("features/model-picker/components/model-config-page.tsx")
+    for label in ('"Save settings"', '"Forget settings"', '"Reload model"', '"Load model"'):
+        assert label in page, label

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -2006,7 +2006,7 @@ def test_picker_rows_keep_their_automation_attributes():
 
 def test_picker_popover_and_trigger_keep_their_tour_hooks():
     chat = _read("features/chat/chat-page.tsx")
-    assert 'chat-model-selector-popover' in chat
+    assert "chat-model-selector-popover" in chat
     assert 'dataTour="chat-model-selector"' in chat or "chat-model-selector" in chat
 
 
@@ -2016,9 +2016,7 @@ def test_run_settings_gear_label_names_its_model():
     name in it is what keeps it off another row's gear."""
     pickers = _read("features/model-picker/components/model-selector/pickers.tsx")
     assert "Inference settings for ${" in pickers
-    action = _read(
-        "features/model-picker/components/model-selector/model-load-settings-action.tsx"
-    )
+    action = _read("features/model-picker/components/model-selector/model-load-settings-action.tsx")
     assert "aria-label={ariaLabel}" in action
 
 

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -2050,8 +2050,14 @@ def test_a_multi_quant_parent_row_still_has_no_gear():
     start = pickers.index("const renderDownloadedGgufRow")
     parent = pickers[start : pickers.index("const renderDownloadedModelRow", start)]
     parent_row = parent[: parent.index("{expanderOpen && (")]
+    # The gutter by reference, not by width. Pinning "w-[42px]" pinned two things
+    # the driver does not care about: the exact pixel width, and the fact that it
+    # was spelled inline. main has since moved to w-[38px] behind ROW_ACTIONS_CLASS,
+    # which is the same spacer doing the same job, and this assertion would have
+    # failed the moment the two met -- reporting a lost spacer that is still there.
+    gutter = "ROW_ACTIONS_CLASS" in parent_row or re.search(r"w-\[\d+px\]", parent_row)
     assert (
-        'aria-hidden="true"' in parent_row and "w-[42px]" in parent_row
+        'aria-hidden="true"' in parent_row and gutter
     ), "the multi-quant parent row lost the spacer that stands in for a gear"
     assert "ModelLoadSettingsAction" not in parent_row, (
         "the multi-quant parent row grew a gear, so the driver's 'no gear means "

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -2002,6 +2002,16 @@ def test_picker_rows_keep_their_automation_attributes():
     assert '"data-model-picker-option": true,' in pickers
     assert "data-model-picker-search-input" in pickers
     assert "data-model-picker-list" in pickers
+    # And that ModelRow still spreads them onto the button. Without this the two
+    # above only prove the props are declared and returned: ModelRow reads
+    # optionProps?.onKeyDown separately, so the prop stays used and type checks
+    # while data-model-picker-option leaves the DOM and every row lookup in the
+    # driver fails.
+    row_button = re.search(r"const content = \(\s*<button\b(.*?)>", pickers, re.S)
+    assert row_button, "ModelRow no longer renders its content as a <button>"
+    assert "{...optionProps}" in row_button.group(1), (
+        "ModelRow stopped spreading optionProps onto the row button"
+    )
 
 
 def test_picker_popover_and_trigger_keep_their_tour_hooks():
@@ -2019,7 +2029,13 @@ def test_run_settings_gear_label_names_its_model():
     render sites and an uncle at the rest -- so it matches on this label, and the model
     name in it is what keeps it off another row's gear."""
     pickers = _read("features/model-picker/components/model-selector/pickers.tsx")
-    assert "Inference settings for ${" in pickers
+    # The expander's own label, not any of them: pickers.tsx interpolates this
+    # string at five sites, so a file-wide match stays green while the one the
+    # driver depends on drops its repo or its quant. That is the only label with
+    # both, and naming the quant is how the driver tells one variant from another.
+    assert "ariaLabel={`Inference settings for ${repoId} ${v.quant}`}" in pickers, (
+        "the variant gear label no longer names both the repo and the quant"
+    )
     action = _read("features/model-picker/components/model-selector/model-load-settings-action.tsx")
     assert "aria-label={ariaLabel}" in action
 
@@ -2028,8 +2044,19 @@ def test_a_multi_quant_parent_row_still_has_no_gear():
     """The driver reads the absence of a gear as "this row expands rather than loads".
     Give the parent row a gear and that inference silently inverts."""
     pickers = _read("features/model-picker/components/model-selector/pickers.tsx")
-    assert 'aria-hidden="true"' in pickers
-    assert "w-[42px]" in pickers
+    # Inside the parent row, not anywhere in the file. Adding a gear to the parent
+    # while leaving the spacer in place satisfies a file-wide search, and that is
+    # exactly the change that would invert the driver's inference.
+    start = pickers.index("const renderDownloadedGgufRow")
+    parent = pickers[start:pickers.index("const renderDownloadedModelRow", start)]
+    parent_row = parent[: parent.index("{expanderOpen && (")]
+    assert 'aria-hidden="true"' in parent_row and "w-[42px]" in parent_row, (
+        "the multi-quant parent row lost the spacer that stands in for a gear"
+    )
+    assert "ModelLoadSettingsAction" not in parent_row, (
+        "the multi-quant parent row grew a gear, so the driver's 'no gear means "
+        "this row expands rather than loads' inference is now wrong"
+    )
 
 
 def test_run_settings_page_keeps_its_identifying_controls():
@@ -2052,3 +2079,15 @@ def test_the_primary_action_keeps_its_four_labels():
     page = _read("features/model-picker/components/model-config-page.tsx")
     for label in ('"Save settings"', '"Forget settings"', '"Reload model"', '"Load model"'):
         assert label in page, label
+    # And that the label is rendered by a button the driver can press. The four
+    # literals above live in the primaryActionLabel calculation, so they survive
+    # the button being deleted or turned into a non-button, and get_by_role finds
+    # nothing while this stays green.
+    # Whole elements, then the one that is both: other props on the opening tag
+    # contain braces of their own, so a pattern that tries to reach onClick
+    # through a negated class stops at the first `disabled={...}`.
+    primary = any(
+        "onClick={handleRun}" in el.group(0) and "{primaryActionLabel}" in el.group(0)
+        for el in re.finditer(r"<Button\b.*?</Button>", page, re.S)
+    )
+    assert primary, "primaryActionLabel is no longer rendered inside the handleRun Button"

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -2009,9 +2009,9 @@ def test_picker_rows_keep_their_automation_attributes():
     # driver fails.
     row_button = re.search(r"const content = \(\s*<button\b(.*?)>", pickers, re.S)
     assert row_button, "ModelRow no longer renders its content as a <button>"
-    assert "{...optionProps}" in row_button.group(1), (
-        "ModelRow stopped spreading optionProps onto the row button"
-    )
+    assert "{...optionProps}" in row_button.group(
+        1
+    ), "ModelRow stopped spreading optionProps onto the row button"
 
 
 def test_picker_popover_and_trigger_keep_their_tour_hooks():
@@ -2033,9 +2033,9 @@ def test_run_settings_gear_label_names_its_model():
     # string at five sites, so a file-wide match stays green while the one the
     # driver depends on drops its repo or its quant. That is the only label with
     # both, and naming the quant is how the driver tells one variant from another.
-    assert "ariaLabel={`Inference settings for ${repoId} ${v.quant}`}" in pickers, (
-        "the variant gear label no longer names both the repo and the quant"
-    )
+    assert (
+        "ariaLabel={`Inference settings for ${repoId} ${v.quant}`}" in pickers
+    ), "the variant gear label no longer names both the repo and the quant"
     action = _read("features/model-picker/components/model-selector/model-load-settings-action.tsx")
     assert "aria-label={ariaLabel}" in action
 
@@ -2048,11 +2048,11 @@ def test_a_multi_quant_parent_row_still_has_no_gear():
     # while leaving the spacer in place satisfies a file-wide search, and that is
     # exactly the change that would invert the driver's inference.
     start = pickers.index("const renderDownloadedGgufRow")
-    parent = pickers[start:pickers.index("const renderDownloadedModelRow", start)]
+    parent = pickers[start : pickers.index("const renderDownloadedModelRow", start)]
     parent_row = parent[: parent.index("{expanderOpen && (")]
-    assert 'aria-hidden="true"' in parent_row and "w-[42px]" in parent_row, (
-        "the multi-quant parent row lost the spacer that stands in for a gear"
-    )
+    assert (
+        'aria-hidden="true"' in parent_row and "w-[42px]" in parent_row
+    ), "the multi-quant parent row lost the spacer that stands in for a gear"
     assert "ModelLoadSettingsAction" not in parent_row, (
         "the multi-quant parent row grew a gear, so the driver's 'no gear means "
         "this row expands rather than loads' inference is now wrong"


### PR DESCRIPTION
The model-config Playwright job has been failing on `main` since #7736, so it fails on every PR branched after it for reasons unrelated to what those PRs change. That is how I found it.

```
FAIL: could not open run-settings for a model matching 'gemma-3-270m'
FAIL: could not reopen run-settings after reload
FAIL: Reset button not found in run-settings
```

The behaviour is intentional and the test had not followed it. #7736 collapses a single-quant row and, as its own comment puts it, the row "loads it in one click". The helper clicked the row first and then went looking for the gear, so by that point the model was loading and the picker had closed. The three failures are one cause: the first is that click, and the other two follow from run-settings never opening.

The gear cannot be reached through the row -- it is the row button's sibling at 2 of its 11 render sites and an uncle at the other 9 -- so it is now matched by the model its own `aria-label` names. That drops the row click and fixes a second latent bug in the same line: `.first` pressed whichever gear came first in the popover rather than the one belonging to the model under test.

I reproduced the failure locally against a real Studio before changing anything, and the run now passes end to end. Getting there exposed what the cascade had been hiding.

## What the cascade was hiding

**A staged edit made in run-settings' first moments is silently discarded.** The panel re-derives its baseline once mount-time work lands and drops whatever was staged, so Save reports "Default settings kept" and stores nothing. Measured on gemma-3-270m: fails at 0 ms, passes from 500 ms. Neither the input value, the Reset state nor the primary button label differs across that window, so there is nothing to poll -- hence a bounded settle wait with the measurement written down rather than a magic number. I have not changed the frontend for this: a person cannot open the panel, read it, type and click inside half a second, so it is reachable by a driver and not by a user. Worth its own look, not a fix wedged into a CI repair.

**Steps 3 and 3b inherited the popover from step 2.** That is why one root cause reported as three failures, and why the re-type-shown regression -- the only guard on the phantom-pin bug -- had been silently skipping. Each step opens its own state now, and the skip is a `soft_fail` rather than prose.

## False passes

These let the job report PASS while proving nothing, which is worse than the failure being fixed:

- The hidden-model step asserts an **absence**, so it passed for free when the picker rendered no rows at all -- exactly the state a broken picker is in. It now proves the picker is populated first.
- Persistence, reset and migration scanned **every** stored entry, so a value belonging to a different model satisfied them. Scoped to the entry under test; the fallback only fires when no key has the versioned shape. Verified against the old assertion: it accepts another model's value, the scoped one rejects it.
- `read_configs()` turned unreadable storage into `{}`, which several assertions treat as success.
- `_count()` turned a closed page or a lost execution context into "0 matches", so an infrastructure failure read as a missing selector. That is precisely how this root cause surfaced as a misleading message.
- `primary_button()` swept `"Load model"` first, which substring-matches `"Reload model"`, so the reload case was found under the wrong name.

A miss now writes a diagnostics sidecar naming the selector that missed and the option rows and gear labels actually present, via `dump_diagnostics()` -- which already existed in `_playwright_robust.py` and no driver was calling.

## Pinning the hooks

`test_model_picker_contracts.py` is a CPU-only source-contract suite whose docstring says it pairs with the Playwright checks, yet it pinned exactly one `aria-label` and none of the picker's test hooks. Renaming one used to type check, lint, pass every unit test, and then fail a 25-minute browser job. The new pins cover `data-model-picker-option`, the search input, the list container, the gear label prefix, `Back to model list`, `Context Length`, and the four primary-action labels. Confirmed against a scratch copy with three hooks renamed: they fail in about a second.

## Why nobody noticed for 14 hours

`Unsloth UI CI` cancelled in-progress runs on `main`. Pushes land there in bursts, and four cancelled runs are why a deterministic failure went unreported. `cancel-in-progress` is now off for `main` only; PR branches still cancel. 32 other workflows share the pattern -- a separate PR, not a silent expansion of this one.

## Verification

Against a real Studio on a local install, gemma-3-270m-it-GGUF UD-Q4_K_XL:

- Unmodified driver at `main`: the same three failures as CI.
- After: `RESULT: PASS`, every step running rather than skipping.
- `test_model_picker_contracts.py`: 114 passed; 3 fail when the hooks are renamed.
- `ruff check tests/studio/`: clean.