### PR TITLE
Desktop: open Data Recipes without triggering an update

### DIFF
--- a/studio/frontend/src/features/studio/sections/dataset-section.tsx
+++ b/studio/frontend/src/features/studio/sections/dataset-section.tsx
@@ -678,6 +678,10 @@ export function DatasetSection() {
     void navigate({ to: "/data-recipes" });
   }, [navigate]);
 
+  const handleOpenDataRecipes = useCallback(() => {
+    void navigate({ to: "/data-recipes" });
+  }, [navigate]);
+
   return (
     <div data-tour="studio-dataset" className="min-w-0">
       <SectionCard
@@ -967,13 +971,12 @@ export function DatasetSection() {
                                     </p>
                                     {localDatasets.length === 0 ? (
                                       <Button
-                                        asChild={true}
+                                        type="button"
                                         size="sm"
                                         variant="outline"
+                                        onClick={handleOpenDataRecipes}
                                       >
-                                        <a href="/data-recipes">
-                                          {t("studio.dataset.openDataRecipes")}
-                                        </a>
+                                        {t("studio.dataset.openDataRecipes")}
                                       </Button>
                                     ) : null}
                                   </div>

--- a/studio/frontend/tests/dataset-data-recipes-navigation.test.ts
+++ b/studio/frontend/tests/dataset-data-recipes-navigation.test.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import ts from "typescript";
+
+const DATASET_SECTION_PATH = fileURLToPath(
+  new URL(
+    "../src/features/studio/sections/dataset-section.tsx",
+    import.meta.url,
+  ),
+);
+const sourceText = readFileSync(DATASET_SECTION_PATH, "utf8");
+const sourceFile = ts.createSourceFile(
+  DATASET_SECTION_PATH,
+  sourceText,
+  ts.ScriptTarget.ESNext,
+  true,
+  ts.ScriptKind.TSX,
+);
+
+function findOpenDataRecipesButton(): ts.JsxElement | null {
+  let result: ts.JsxElement | null = null;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isJsxElement(node) &&
+      node.openingElement.tagName.getText(sourceFile) === "Button" &&
+      node.getText(sourceFile).includes('t("studio.dataset.openDataRecipes")')
+    ) {
+      result = node;
+      return;
+    }
+    node.forEachChild(visit);
+  };
+  sourceFile.forEachChild(visit);
+  return result;
+}
+
+function attribute(
+  opening: ts.JsxOpeningElement,
+  name: string,
+): ts.JsxAttribute | null {
+  for (const property of opening.attributes.properties) {
+    if (
+      ts.isJsxAttribute(property) &&
+      property.name.getText(sourceFile) === name
+    ) {
+      return property;
+    }
+  }
+  return null;
+}
+
+function findVariableDeclaration(name: string): ts.VariableDeclaration | null {
+  let result: ts.VariableDeclaration | null = null;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === name
+    ) {
+      result = node;
+      return;
+    }
+    node.forEachChild(visit);
+  };
+  sourceFile.forEachChild(visit);
+  return result;
+}
+
+test("the empty local-dataset action uses side-effect-free SPA navigation", () => {
+  const button = findOpenDataRecipesButton();
+  assert.ok(button, "Open Data Recipes must be rendered by a Button");
+
+  const onClick = attribute(button.openingElement, "onClick");
+  assert.equal(
+    onClick?.initializer?.getText(sourceFile),
+    "{handleOpenDataRecipes}",
+  );
+  assert.equal(
+    attribute(button.openingElement, "type")?.initializer?.getText(sourceFile),
+    '"button"',
+  );
+  assert.equal(attribute(button.openingElement, "asChild"), null);
+  assert.doesNotMatch(
+    button.getText(sourceFile),
+    /<a\b|href\s*=/,
+    "the action must not fall back to a full-document anchor",
+  );
+
+  const handler = findVariableDeclaration("handleOpenDataRecipes");
+  assert.ok(handler, "Open Data Recipes must have a dedicated SPA handler");
+  const handlerText = handler.getText(sourceFile);
+  assert.match(
+    handlerText,
+    /navigate\s*\(\s*\{\s*to:\s*["']\/data-recipes["']/,
+  );
+  assert.doesNotMatch(
+    handlerText,
+    /sessionStorage|OPEN_LEARNING_RECIPES_ON_ARRIVAL_KEY|setDocumentRedirectOpen/,
+    "opening Data Recipes must not force the Learning Recipes dialog",
+  );
+});
+
+test("the dataset section has no raw Data Recipes document navigation", () => {
+  assert.doesNotMatch(sourceText, /href\s*=\s*["']\/data-recipes["']/);
+});

--- a/studio/src-tauri/src/desktop_backend_owner.rs
+++ b/studio/src-tauri/src/desktop_backend_owner.rs
@@ -561,11 +561,19 @@ async fn health_ready_status(
                 .as_ref()
                 .and_then(|health| health.version.as_deref())
                 .filter(|version| !version.is_empty());
-            if access_token.is_some() && authenticated_version.is_none() {
-                Err("desktop_auth_health_unverified".to_string())
-            } else {
-                Ok(ready_for_use_status(health.as_ref()))
+            if access_token.is_some() {
+                let Some(version) = authenticated_version else {
+                    return Err("desktop_auth_health_unverified".to_string());
+                };
+                return match crate::preflight::backend_version_stale_reason(Some(version)) {
+                    None => Ok(OwnedBackendReadiness::Ready),
+                    Some(reason) if reason == "desktop_backend_version_too_old" => {
+                        Ok(OwnedBackendReadiness::Stale { reason })
+                    }
+                    Some(reason) => Err(reason),
+                };
             }
+            Ok(ready_for_use_status(health.as_ref()))
         }
         Err(reason) if access_token.is_some() => Err(reason),
         Err(reason) => Ok(OwnedBackendReadiness::Stale { reason }),
@@ -1123,6 +1131,20 @@ mod tests {
             OwnedBackendReadiness::Stale { reason }
                 if reason == "desktop_backend_version_too_old"
         ));
+    }
+
+    #[tokio::test]
+    async fn authenticated_health_rejects_malformed_version() {
+        let (port, _, server) = http_sequence_server(vec![
+            ("200 OK", r#"{"access_token":"test-access-token"}"#),
+            ("200 OK", r#"{"version":"not-a-version"}"#),
+        ])
+        .await;
+
+        let result = authenticated_health_ready_status(port, "desktop-test-secret").await;
+        server.await.unwrap();
+
+        assert_eq!(result.unwrap_err(), "desktop_backend_version_invalid");
     }
 
     #[tokio::test]

--- a/studio/src-tauri/src/desktop_backend_owner.rs
+++ b/studio/src-tauri/src/desktop_backend_owner.rs
@@ -556,8 +556,18 @@ async fn health_ready_status(
     access_token: Option<&str>,
 ) -> Result<OwnedBackendReadiness, String> {
     match fetch_health(port, access_token).await {
-        Ok(health) => Ok(ready_for_use_status(health.as_ref())),
-        Err(reason) if reason == "desktop_auth_token_rejected" => Err(reason),
+        Ok(health) => {
+            let authenticated_version = health
+                .as_ref()
+                .and_then(|health| health.version.as_deref())
+                .filter(|version| !version.is_empty());
+            if access_token.is_some() && authenticated_version.is_none() {
+                Err("desktop_auth_health_unverified".to_string())
+            } else {
+                Ok(ready_for_use_status(health.as_ref()))
+            }
+        }
+        Err(reason) if access_token.is_some() => Err(reason),
         Err(reason) => Ok(OwnedBackendReadiness::Stale { reason }),
     }
 }
@@ -1138,6 +1148,23 @@ mod tests {
         server.await.unwrap();
 
         assert_eq!(result.unwrap_err(), "desktop_auth_token_rejected");
+    }
+
+    #[tokio::test]
+    async fn authenticated_health_rejects_public_payload_without_version() {
+        let (port, _, server) = http_sequence_server(vec![
+            ("200 OK", r#"{"access_token":"test-access-token"}"#),
+            (
+                "200 OK",
+                r#"{"status":"healthy","service":"Unsloth UI Backend","supports_desktop_auth":true}"#,
+            ),
+        ])
+        .await;
+
+        let result = authenticated_health_ready_status(port, "desktop-test-secret").await;
+        server.await.unwrap();
+
+        assert_eq!(result.unwrap_err(), "desktop_auth_health_unverified");
     }
 
     #[test]

--- a/studio/src-tauri/src/desktop_backend_owner.rs
+++ b/studio/src-tauri/src/desktop_backend_owner.rs
@@ -551,10 +551,14 @@ fn ready_for_use_status(health: Option<&HealthResponse>) -> OwnedBackendReadines
     }
 }
 
-async fn health_ready_status(port: u16) -> OwnedBackendReadiness {
-    match fetch_health(port).await {
-        Ok(health) => ready_for_use_status(health.as_ref()),
-        Err(reason) => OwnedBackendReadiness::Stale { reason },
+async fn health_ready_status(
+    port: u16,
+    access_token: Option<&str>,
+) -> Result<OwnedBackendReadiness, String> {
+    match fetch_health(port, access_token).await {
+        Ok(health) => Ok(ready_for_use_status(health.as_ref())),
+        Err(reason) if reason == "desktop_auth_token_rejected" => Err(reason),
+        Err(reason) => Ok(OwnedBackendReadiness::Stale { reason }),
     }
 }
 
@@ -591,13 +595,24 @@ fn fetch_liveness_blocking(port: u16) -> Result<Option<DesktopLiveness>, String>
     }
     Ok(None)
 }
-async fn fetch_health(port: u16) -> Result<Option<HealthResponse>, String> {
+async fn fetch_health(
+    port: u16,
+    access_token: Option<&str>,
+) -> Result<Option<HealthResponse>, String> {
     let client = crate::loopback_http::client(LOCAL_HTTP_TIMEOUT).map_err(|e| e.to_string())?;
-    let response = client
-        .get(format!("http://127.0.0.1:{port}/api/health"))
-        .send()
-        .await
-        .map_err(|e| e.to_string())?;
+    let mut request = client.get(format!("http://127.0.0.1:{port}/api/health"));
+    if let Some(access_token) = access_token {
+        request = request.bearer_auth(access_token);
+    }
+    let response = request.send().await.map_err(|e| e.to_string())?;
+    if access_token.is_some()
+        && matches!(
+            response.status(),
+            reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN
+        )
+    {
+        return Err("desktop_auth_token_rejected".to_string());
+    }
     if !response.status().is_success() {
         return Ok(None);
     }
@@ -626,25 +641,36 @@ async fn desktop_login_route_compatible(port: u16) -> bool {
     }
 }
 
-async fn desktop_secret_login_compatible(port: u16) -> Result<(), String> {
-    let secret = read_desktop_secret()?.ok_or_else(|| "desktop_auth_secret_missing".to_string())?;
+async fn desktop_secret_login(port: u16, secret: &str) -> Result<String, String> {
     let client = crate::loopback_http::client(LOCAL_HTTP_TIMEOUT).map_err(|e| e.to_string())?;
     let response = client
         .post(format!("http://127.0.0.1:{port}/api/auth/desktop-login"))
-        .json(&DesktopLoginPayload { secret: &secret })
+        .json(&DesktopLoginPayload { secret })
         .send()
         .await
         .map_err(|_| "desktop_auth_secret_probe_failed".to_string())?;
-    if response.status().is_success() {
-        Ok(())
-    } else if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+    if response.status() == reqwest::StatusCode::UNAUTHORIZED {
         Err("desktop_auth_secret_rejected".to_string())
-    } else {
+    } else if !response.status().is_success() {
         Err(format!(
             "desktop_auth_secret_probe_http_{}",
             response.status()
         ))
+    } else {
+        response
+            .json::<TokenResponse>()
+            .await
+            .map(|tokens| tokens.access_token)
+            .map_err(|_| "desktop_auth_token_response_invalid".to_string())
     }
+}
+
+async fn authenticated_health_ready_status(
+    port: u16,
+    secret: &str,
+) -> Result<OwnedBackendReadiness, String> {
+    let access_token = desktop_secret_login(port, secret).await?;
+    health_ready_status(port, Some(&access_token)).await
 }
 
 pub(crate) async fn probe_owned_backend_state(
@@ -681,12 +707,28 @@ pub(crate) async fn probe_owned_backend_state(
                 reason: "desktop_login_probe_failed".to_string(),
             };
         }
-        if require_desktop_secret {
-            if let Err(reason) = desktop_secret_login_compatible(port).await {
-                return OwnedBackendProbe::Unmanageable { port, reason };
+        let readiness = if require_desktop_secret {
+            let secret = match read_desktop_secret() {
+                Ok(Some(secret)) => secret,
+                Ok(None) => {
+                    return OwnedBackendProbe::Unmanageable {
+                        port,
+                        reason: "desktop_auth_secret_missing".to_string(),
+                    }
+                }
+                Err(reason) => return OwnedBackendProbe::Unmanageable { port, reason },
+            };
+            match authenticated_health_ready_status(port, &secret).await {
+                Ok(readiness) => readiness,
+                Err(reason) => return OwnedBackendProbe::Unmanageable { port, reason },
             }
-        }
-        verified.push((port, health_ready_status(port).await));
+        } else {
+            // Spawned backends were launched from the already-probed managed
+            // install. Adopted backends pass `true` on their initial probe;
+            // later watchdog checks only need ownership and liveness.
+            OwnedBackendReadiness::Ready
+        };
+        verified.push((port, readiness));
     }
 
     if verified.len() != 1 {
@@ -927,6 +969,61 @@ mod tests {
     const ROOT_ID: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     const TOKEN: &str = "desktop-owner-token";
 
+    async fn http_sequence_server(
+        responses: Vec<(&'static str, &'static str)>,
+    ) -> (
+        u16,
+        std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let seen_task = seen.clone();
+        let task = tokio::spawn(async move {
+            for (status, body) in responses {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut raw = Vec::new();
+                loop {
+                    let mut chunk = [0u8; 2048];
+                    let count = socket.read(&mut chunk).await.unwrap();
+                    if count == 0 {
+                        break;
+                    }
+                    raw.extend_from_slice(&chunk[..count]);
+                    let Some(header_end) = raw.windows(4).position(|w| w == b"\r\n\r\n") else {
+                        continue;
+                    };
+                    let headers = String::from_utf8_lossy(&raw[..header_end]);
+                    let content_length = headers
+                        .lines()
+                        .find_map(|line| {
+                            line.to_ascii_lowercase()
+                                .strip_prefix("content-length:")
+                                .and_then(|value| value.trim().parse::<usize>().ok())
+                        })
+                        .unwrap_or(0);
+                    if raw.len() >= header_end + 4 + content_length {
+                        break;
+                    }
+                }
+                seen_task
+                    .lock()
+                    .unwrap()
+                    .push(String::from_utf8_lossy(&raw).into_owned());
+                let response = format!(
+                    "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                socket.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+        (port, seen, task)
+    }
+
     fn metadata(app_pid: u32, port: Option<u16>) -> DesktopBackendMetadata {
         DesktopBackendMetadata {
             schema_version: METADATA_SCHEMA_VERSION,
@@ -975,6 +1072,72 @@ mod tests {
         let port = listener.local_addr().unwrap().port();
         drop(listener);
         port
+    }
+
+    #[tokio::test]
+    async fn authenticated_health_uses_login_bearer_and_accepts_ready_version() {
+        let (port, seen, server) = http_sequence_server(vec![
+            ("200 OK", r#"{"access_token":"test-access-token"}"#),
+            ("200 OK", r#"{"version":"2026.5.3"}"#),
+        ])
+        .await;
+
+        let readiness = authenticated_health_ready_status(port, "desktop-test-secret")
+            .await
+            .unwrap();
+        server.await.unwrap();
+
+        assert!(matches!(readiness, OwnedBackendReadiness::Ready));
+        let seen = seen.lock().unwrap();
+        assert!(seen[0].contains(r#""secret":"desktop-test-secret""#));
+        assert!(seen[1]
+            .to_ascii_lowercase()
+            .contains("authorization: bearer test-access-token"));
+    }
+
+    #[tokio::test]
+    async fn authenticated_health_preserves_genuinely_old_version_as_stale() {
+        let (port, _, server) = http_sequence_server(vec![
+            ("200 OK", r#"{"access_token":"test-access-token"}"#),
+            ("200 OK", r#"{"version":"2026.5.2"}"#),
+        ])
+        .await;
+
+        let readiness = authenticated_health_ready_status(port, "desktop-test-secret")
+            .await
+            .unwrap();
+        server.await.unwrap();
+
+        assert!(matches!(
+            readiness,
+            OwnedBackendReadiness::Stale { reason }
+                if reason == "desktop_backend_version_too_old"
+        ));
+    }
+
+    #[tokio::test]
+    async fn rejected_desktop_secret_fails_before_health() {
+        let (port, seen, server) = http_sequence_server(vec![("401 Unauthorized", "{}")]).await;
+
+        let result = authenticated_health_ready_status(port, "wrong-secret").await;
+        server.await.unwrap();
+
+        assert_eq!(result.unwrap_err(), "desktop_auth_secret_rejected");
+        assert_eq!(seen.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn rejected_health_bearer_is_not_downgraded_to_auto_repairable_stale() {
+        let (port, _, server) = http_sequence_server(vec![
+            ("200 OK", r#"{"access_token":"test-access-token"}"#),
+            ("401 Unauthorized", "{}"),
+        ])
+        .await;
+
+        let result = authenticated_health_ready_status(port, "desktop-test-secret").await;
+        server.await.unwrap();
+
+        assert_eq!(result.unwrap_err(), "desktop_auth_token_rejected");
     }
 
     #[test]

--- a/studio/src-tauri/src/update.rs
+++ b/studio/src-tauri/src/update.rs
@@ -7,6 +7,10 @@ use std::process::{Command, ExitStatus, Stdio};
 use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Emitter};
 
+#[cfg(windows)]
+const WINDOWS_CLI_ENTRYPOINT: &str =
+    "import sys; sys.argv[0] = 'unsloth'; from unsloth_cli import app; app()";
+
 // ── Types ──
 
 pub struct UpdateProcess {
@@ -32,6 +36,31 @@ pub fn new_update_state() -> UpdateState {
 }
 
 // ── Spawn ──
+fn build_update_command(bin: &std::path::Path) -> Result<Command, String> {
+    #[cfg(windows)]
+    {
+        let python = bin
+            .parent()
+            .ok_or_else(|| "Managed Unsloth executable has no parent directory.".to_string())?
+            .join("python.exe");
+        if !python.is_file() {
+            return Err(format!(
+                "Managed Python interpreter not found beside Unsloth: {}",
+                python.display()
+            ));
+        }
+        let mut cmd = Command::new(python);
+        cmd.args(["-c", WINDOWS_CLI_ENTRYPOINT, "studio", "update"]);
+        Ok(cmd)
+    }
+
+    #[cfg(not(windows))]
+    {
+        let mut cmd = Command::new(bin);
+        cmd.args(["studio", "update"]);
+        Ok(cmd)
+    }
+}
 
 fn spawn_update(
     bin: &std::path::Path,
@@ -49,10 +78,8 @@ fn spawn_update(
     }
     update.intentional_stop = false;
 
-    let mut cmd = Command::new(bin);
-    cmd.args(["studio", "update"])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+    let mut cmd = build_update_command(bin)?;
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 
     // AppImage sets LD_LIBRARY_PATH to its bundled libs, which breaks Python
     #[cfg(target_os = "linux")]
@@ -430,5 +457,45 @@ mod tests {
         .unwrap();
 
         assert_eq!(lines, ["bad\u{fffd}", "[TAURI:STEP] next"]);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_update_command_uses_python_not_replaceable_console_stub() {
+        use std::ffi::OsString;
+
+        let dir =
+            std::env::temp_dir().join(format!("unsloth-update-command-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let python = dir.join("python.exe");
+        let bin = dir.join("unsloth.exe");
+        std::fs::write(&python, b"").unwrap();
+
+        let cmd = build_update_command(&bin).unwrap();
+
+        assert_eq!(cmd.get_program(), python.as_os_str());
+        assert_ne!(cmd.get_program(), bin.as_os_str());
+        assert_eq!(
+            cmd.get_args().map(OsString::from).collect::<Vec<_>>(),
+            vec![
+                OsString::from("-c"),
+                OsString::from(WINDOWS_CLI_ENTRYPOINT),
+                OsString::from("studio"),
+                OsString::from("update")
+            ]
+        );
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_update_command_fails_closed_without_managed_python() {
+        let bin = std::env::temp_dir()
+            .join("missing-managed-python")
+            .join("unsloth.exe");
+        assert!(build_update_command(&bin)
+            .unwrap_err()
+            .contains("python.exe"));
     }
 }

--- a/studio/src-tauri/src/update.rs
+++ b/studio/src-tauri/src/update.rs
@@ -50,7 +50,11 @@ fn build_update_command(bin: &std::path::Path) -> Result<Command, String> {
             ));
         }
         let mut cmd = Command::new(python);
-        cmd.args(["-c", WINDOWS_CLI_ENTRYPOINT, "studio", "update"]);
+        // Isolated mode prevents a project-local unsloth_cli module or an
+        // inherited Python search path from shadowing the managed package.
+        cmd.args(["-I", "-c", WINDOWS_CLI_ENTRYPOINT, "studio", "update"]);
+        cmd.env_remove("PYTHONHOME");
+        cmd.env_remove("PYTHONPATH");
         Ok(cmd)
     }
 
@@ -462,7 +466,7 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn windows_update_command_uses_python_not_replaceable_console_stub() {
-        use std::ffi::OsString;
+        use std::ffi::{OsStr, OsString};
 
         let dir =
             std::env::temp_dir().join(format!("unsloth-update-command-{}", std::process::id()));
@@ -479,12 +483,18 @@ mod tests {
         assert_eq!(
             cmd.get_args().map(OsString::from).collect::<Vec<_>>(),
             vec![
+                OsString::from("-I"),
                 OsString::from("-c"),
                 OsString::from(WINDOWS_CLI_ENTRYPOINT),
                 OsString::from("studio"),
                 OsString::from("update")
             ]
         );
+        for name in ["PYTHONHOME", "PYTHONPATH"] {
+            assert!(cmd
+                .get_envs()
+                .any(|(key, value)| key == OsStr::new(name) && value.is_none()));
+        }
         std::fs::remove_dir_all(dir).unwrap();
     }
 


### PR DESCRIPTION
## Summary

Opening Data Recipes from an empty local dataset search now uses in-app navigation instead of reloading the Tauri window. This prevents the navigation action from being mistaken for a backend repair that starts the Studio updater and cancels active model downloads.

## Motivation

Clicking "Open Data Recipes" caused the Desktop window to disappear and the updater to start. The raw `/data-recipes` anchor performed a full-document navigation, which re-entered Desktop startup and backend repair logic.

The repair checks also treated failed backend authentication as an outdated backend, allowing an unsafe automatic repair attempt.

## Changes

- Replace the raw Data Recipes anchor with TanStack Router navigation in `studio/frontend/src/features/studio/sections/dataset-section.tsx`.
- Add an AST-based regression test that rejects full-document Data Recipes navigation and unrelated Learning Recipes side effects.
- Authenticate the backend health check with the token returned by the Desktop login endpoint.
- Treat rejected tokens, missing authenticated version data, and invalid authentication responses as unmanageable instead of auto-repairable.
- Preserve automatic repair for backends that authenticate successfully and report a genuinely outdated version.
- On Windows, run updates through the managed `python.exe` in isolated mode instead of the replaceable `unsloth.exe` console stub.
- Remove `PYTHONHOME` and `PYTHONPATH` from the Windows updater environment so local modules cannot shadow the managed CLI.
- Add Rust coverage for successful authentication, old backend versions, rejected credentials, public health payloads, and Windows command construction.

## How to test

Frontend regression:

```powershell
cd studio/frontend
node --experimental-strip-types --test tests/dataset-data-recipes-navigation.test.ts
npm run typecheck