### PR TITLE
Fix the chat autoload gate tests broken by the MLX audio work

### DIFF
--- a/tests/studio/test_chat_autoload_failure_gate.py
+++ b/tests/studio/test_chat_autoload_failure_gate.py
@@ -103,6 +103,13 @@ const toast: any = Object.assign(
 );
 
 async function tryAdoptServerActiveModel() { return false; }
+// Upserts the loaded model into the catalog; undefined here made a successful load
+// throw, which the sweep then read as a failure.
+function syncModelCapabilities(id: string, resp: any) {
+  if (!STORE.models.some((m: any) => m.id === id)) {
+    STORE.setModels([...STORE.models, { id, name: resp?.display_name ?? id }]);
+  }
+}
 function resolveSpeculativeSettingsForLoad() {
   return { speculativeType: null, specDraftNMax: 0 };
 }

--- a/tests/studio/test_chat_autoload_failure_gate.py
+++ b/tests/studio/test_chat_autoload_failure_gate.py
@@ -10,6 +10,7 @@ cached repo whose load rejected fell through to fetching an unrelated default mo
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -115,6 +116,10 @@ function resolveSpeculativeSettingsForLoad() {
 }
 function readLastLocalModelLoad() { return SCENARIO.lastLoaded; }
 function recordLastLocalModelLoad(_x: any) {}
+// Only reached for a GGUF with an explicit GPU pin or tensor parallel; neutral
+// defaults so a scenario that does pin one gets a plain answer, not a throw.
+async function prepareHfTokenForUse(token: any) { return { proceed: true, token }; }
+async function fetchGgufStagedMetadata(_payload: any) { return { isDiffusion: false }; }
 function resolveInitialConfig(_id: string, _variant: any) {
   return { config: {
     customContextLength: null, maxSeqLength: null, gpuMemoryMode: null,
@@ -221,9 +226,25 @@ def _require_node():
         pytest.skip("node --experimental-strip-types not available")
 
 
+_IMPORT_BLOCK = re.compile(r"\bimport\s+(?:type\s+)?\{([^}]*)\}\s*from\s*[\"'][^\"']+[\"']")
+
+
+def _imported_names(source: str) -> set[str]:
+    """Bare identifiers the adapter pulls in across the module boundary."""
+    names: set[str] = set()
+    for block in _IMPORT_BLOCK.findall(source):
+        for piece in block.split(","):
+            piece = piece.strip().removeprefix("type ").strip()
+            piece = piece.split(" as ")[-1].strip()
+            if piece.isidentifier():
+                names.add(piece)
+    return names
+
+
 def _build_harness(run_dir: Path):
     """Slice autoLoadSmallestModel and its helpers verbatim out of the adapter."""
-    lines = ADAPTER.read_text(encoding = "utf-8").splitlines()
+    source = ADAPTER.read_text(encoding = "utf-8")
+    lines = source.splitlines()
     start = next(
         (i for i, line in enumerate(lines) if line.startswith("const MAX_AUTO_LOAD_ATTEMPTS")),
         None,
@@ -241,6 +262,21 @@ def _build_harness(run_dir: Path):
     ), "could not locate the auto-load region in chat-adapter.ts"
     body = "\n".join(lines[start:end])
     assert "async function autoLoadSmallestModel" in body
+    # PREAMBLE supplies the module boundary by hand. An import the slice calls but
+    # PREAMBLE never stubs throws a ReferenceError inside the sweep, and the sweep's
+    # catches are parameterless, so it is swallowed and reads as exactly the fall-through
+    # this file guards. Name the missing stub instead of counterfeiting that bug.
+    unstubbed = sorted(
+        name
+        for name in _imported_names(source)
+        if re.search(rf"\b{re.escape(name)}\b", body)
+        and not re.search(rf"\b{re.escape(name)}\b", PREAMBLE)
+    )
+    assert not unstubbed, (
+        f"chat-adapter.ts imports {unstubbed}, which the auto-load region calls but "
+        "PREAMBLE does not stub; add a stub for each, or these tests fail as a false "
+        "auto-load regression"
+    )
     (run_dir / "harness.ts").write_text(
         "// @ts-nocheck\n" + PREAMBLE + "\n" + body + "\nexport { autoLoadSmallestModel };\n",
         encoding = "utf-8",


### PR DESCRIPTION
`tests/studio/test_chat_autoload_failure_gate.py` has been failing on main since #7699, and every open PR inherits it.

The harness slices the `autoLoadSmallestModel` region out of `chat-adapter.ts` and prepends stubs for everything that region calls. #7699 replaced the inline catalog append with a call to `syncModelCapabilities`, imported from `../hooks/use-chat-model-runtime`, which is outside the sliced region and has no stub. The identifier is undefined at run time, so a load that has already succeeded throws, the sweep reads that as a failed load, and it falls through to downloading the default model. That is exactly the behaviour #7375 added these tests to prevent, so three of them fail:

```
test_a_later_cached_model_can_still_load_after_an_earlier_failure
test_a_complete_cached_row_is_still_attempted
test_a_rejected_validation_still_lets_a_later_cached_model_load
```

Bisected to confirm: green at `2419ff1^`, red at `2419ff1`.

Only the harness is affected. In the app the import resolves normally, so there is no user-visible bug here and no product code changes.

The stub upserts into the fake store the same way the code it replaced did, so the assertions still see the real catalog behaviour rather than a no-op.

`tests/studio/test_chat_autoload_failure_gate.py`: 16 passed.


## Second commit: the rest of the boundary, and a guard

`syncModelCapabilities` was not the only missing stub. `prepareHfTokenForUse` and `fetchGgufStagedMetadata` are unstubbed too. Nothing fails today because both sit behind a `candidate.kind === "gguf" && (config.selectedGpuIds != null || config.tensorParallel === true)` branch, and the harness's `resolveInitialConfig` returns neither, so no current scenario reaches them. The first test that pins a GPU would hit the same swallowed ReferenceError.

Both now have neutral stubs, and `_build_harness` asserts that every name `chat-adapter.ts` imports and the sliced region calls is present in `PREAMBLE`:

```
chat-adapter.ts imports ['syncModelCapabilities'], which the auto-load region calls
but PREAMBLE does not stub; add a stub for each, or these tests fail as a false
auto-load regression
```

That matters more than the stubs themselves. The sweep's catches are parameterless, so an undefined import is swallowed and reshaped into a fall-through to the default model, meaning the harness fails by imitating the exact regression it is built to catch. Naming the missing stub turns a misleading three-test failure into one line.

Checks:

- 16 passed on the current adapter.
- Delete the `syncModelCapabilities` stub: the guard names it, rather than three tests failing as a false regression.
- Point the adapter back at `bc702f7f2` (before #7375): 8 tests fail on their real assertions with the guard silent, so it is not masking the behaviour these tests exist to check.
- Full `tests/studio`: 2304 passed, 3 skipped.

One limit worth stating: the guard parses brace imports only. The adapter uses those exclusively today, all 100 names, so the boundary is covered, but a future default import would not be.

Also rebased onto main to pick up #7772. The red `Chat UI Tests` on the previous head was the model-config driver failure that predated that merge, not anything from this branch.
