### PR TITLE
Model picker: lay the rows out in columns

### DIFF
--- a/studio/frontend/src/features/hub/catalog/models-catalog-rows.tsx
+++ b/studio/frontend/src/features/hub/catalog/models-catalog-rows.tsx
@@ -744,7 +744,7 @@ export const InventoryRow = memo(function InventoryRow({
     deletableRepoId || settingsAction ? (
       <ModelRowMenu
         ariaLabel={`More options for ${deletableRepoId ?? rowModelId}`}
-        buttonClassName="pointer-events-auto hub-modal-pe-guard p-2 opacity-0 transition-opacity group-hover/row:opacity-100 focus-visible:opacity-100 data-[state=open]:opacity-100 [@media(pointer:coarse)]:opacity-100"
+        buttonClassName="pointer-events-auto hub-modal-pe-guard size-8 opacity-0 transition-opacity group-hover/row:opacity-100 focus-visible:opacity-100 data-[state=open]:opacity-100 [@media(pointer:coarse)]:opacity-100"
         iconClassName="size-4"
         settings={settingsAction}
         pin={

--- a/studio/frontend/src/features/model-picker/components/model-selector/model-delete-action.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/model-delete-action.tsx
@@ -62,7 +62,8 @@ export function ModelDeleteAction({
         aria-label={ariaLabel}
         disabled={disabled}
         className={cn(
-          "shrink-0 rounded-md p-1.5 text-muted-foreground/60 transition-colors hover:bg-destructive/10 hover:text-destructive",
+          // Fixed box, matching the gear and dots menu it sits beside.
+          "flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground/60 transition-colors hover:bg-destructive/10 hover:text-destructive",
           disabled &&
             "cursor-not-allowed opacity-40 hover:bg-transparent hover:text-muted-foreground/60",
           buttonClassName,

--- a/studio/frontend/src/features/model-picker/components/model-selector/model-load-settings-action.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/model-load-settings-action.tsx
@@ -30,10 +30,13 @@ export function ModelLoadSettingsAction({
           }}
           aria-label={ariaLabel}
           className={cn(
-            "shrink-0 rounded-md p-1 text-muted-foreground/60 transition-colors hover:bg-black/5 hover:text-foreground dark:hover:bg-white/10",
+            // Fixed box, not padding around the glyph, so this and the dots
+            // menu hover as one size. Callers can still size it up.
+            "flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground/60 transition-colors hover:bg-black/5 hover:text-foreground dark:hover:bg-white/10",
             className,
           )}
         >
+          {/* A size down from the dots: the gear fills its whole box. */}
           <HugeiconsIcon
             icon={Settings02Icon}
             strokeWidth={1.75}

--- a/studio/frontend/src/features/model-picker/components/model-selector/model-row-menu.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/model-row-menu.tsx
@@ -182,7 +182,8 @@ export function ModelRowMenu({
             onClick={(e) => e.stopPropagation()}
             aria-label={ariaLabel}
             className={cn(
-              "shrink-0 rounded-md p-1 text-muted-foreground/60 transition-colors hover:bg-black/5 hover:text-foreground dark:hover:bg-white/10",
+              // Fixed box, matching ModelLoadSettingsAction beside it.
+              "flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground/60 transition-colors hover:bg-black/5 hover:text-foreground dark:hover:bg-white/10",
               buttonClassName,
             )}
           >

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -3639,7 +3639,9 @@ export function HubModelPicker({
               ) : (
                 connectedGroups.map((group) => (
                   <div key={group.providerId}>
-                    <div className="flex items-center gap-2 px-2.5 py-1.5 text-ui-10 font-semibold uppercase tracking-wider text-muted-foreground">
+                    {/* Same spacing as the On Device section labels, so a
+                        provider's name sits clear of the rows above it. */}
+                    <div className="flex items-center gap-2 px-2.5 pb-1 pt-3 text-ui-10 font-semibold uppercase tracking-wider text-muted-foreground">
                       <ApiProviderLogo
                         providerType={group.providerType}
                         className="size-3.5"

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -605,7 +605,7 @@ const META_COLUMN = {
 const ROW_ACTIONS_BASE =
   "mr-0.5 flex w-[38px] shrink-0 items-center justify-end -space-x-0.5";
 const ROW_HOVER_ONLY =
-  "opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:none)]:opacity-100";
+  "opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100 has-[[data-state=open]]:opacity-100 [@media(hover:none)]:opacity-100";
 const ROW_ACTIONS_CLASS = `${ROW_ACTIONS_BASE} ${ROW_HOVER_ONLY}`;
 
 function ModelRow({
@@ -863,21 +863,35 @@ function ModelRow({
     </span>
   ) : null;
 
+  // The dot names its format on hover only, which keyboard focus never
+  // reaches, so the row tooltip carries it too.
+  const formatLine = formatDot ? (
+    <span className="block text-ui-10 mt-1">{formatDot.label}</span>
+  ) : null;
+
   const tooltipBody = vramTooltipText ? (
     <>
       {label}
       <span className="block text-ui-10 mt-1">{vramTooltipText}</span>
+      {formatLine}
       {hubUrlLine}
     </>
   ) : tooltipText ? (
     <>
       {tooltipText}
+      {formatLine}
       {hubUrlLine}
     </>
   ) : hubUrl ? (
     <>
       <span className="block break-words">{label}</span>
+      {formatLine}
       {hubUrlLine}
+    </>
+  ) : formatLine ? (
+    <>
+      <span className="block break-words">{label}</span>
+      {formatLine}
     </>
   ) : null;
 
@@ -3189,7 +3203,6 @@ export function HubModelPicker({
       "pinned-quant",
       pinKey(entry.repoId, entry.quant),
     );
-    const { owner, name } = splitRepoLabel(entry.repoId);
     const isSelected =
       value === entry.repoId && activeGgufVariant === entry.quant;
     const isLoaded =
@@ -3198,52 +3211,30 @@ export function HubModelPicker({
       ggufVariantsMatchForPicker(activeGgufVariant, entry.quant);
     return (
       <div key={optionKey} className={downloadedRowShellClassName(isSelected)}>
-        <button
-          type="button"
-          {...hubModelList.getOptionProps(optionKey, isSelected)}
-          onClick={() =>
-            onSelect(entry.repoId, {
-              source: "hub",
-              isLora: false,
-              ggufVariant: entry.quant,
-              isDownloaded: true,
-            })
-          }
-          className={cn(
-            "flex min-w-0 flex-1 items-center gap-2 rounded-full px-2 py-1.5 text-left text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/45",
-            downloadedRowButtonClassName,
-          )}
-          title={`${entry.repoId} (${entry.quant})`}
-        >
-          <span className="flex min-w-0 flex-1 items-baseline">
-            {owner && !isUnslothOwner(owner) ? (
-              <span className="inline-flex min-w-0 max-w-[45%] shrink items-baseline text-ui-13 text-muted-foreground/90">
-                <span className="truncate">{owner}</span>
-                <span className="shrink-0 text-muted-foreground/45">/</span>
-              </span>
-            ) : null}
-            <span className="min-w-0 flex-1 truncate">{name}</span>
-            {isLoaded && (
-              <DotTag
-                tone="success"
-                label="Loaded"
-                className="ml-2 h-[18px] shrink-0 gap-1 rounded-md px-1.5"
-                dotClassName="size-[5px]"
-              />
-            )}
-          </span>
-          {/* Same quant column as the sections below. */}
-          <span
-            className={cn(
-              "flex shrink-0 items-baseline font-mono text-ui-10",
-              META_COLUMN.quant,
-            )}
-          >
-            <span className="max-w-full truncate rounded-md bg-black/[0.06] px-1.5 py-px text-muted-foreground dark:bg-white/[0.1]">
-              {entry.quant}
-            </span>
-          </span>
-        </button>
+        {/* Through ModelRow, so a pinned quant lands in the same columns as
+            the rows below it. */}
+        <div className="min-w-0 flex-1">
+          <ModelRow
+            label={entry.repoId}
+            tooltipText={`${entry.repoId} (${entry.quant})`}
+            meta="GGUF"
+            quantChip={entry.quant}
+            alignMeta="device"
+            selected={isSelected}
+            loaded={isLoaded}
+            optionProps={hubModelList.getOptionProps(optionKey, isSelected)}
+            onClick={() =>
+              onSelect(entry.repoId, {
+                source: "hub",
+                isLora: false,
+                ggufVariant: entry.quant,
+                isDownloaded: true,
+              })
+            }
+            vramStatus={null}
+            className={downloadedRowButtonClassName}
+          />
+        </div>
         <span className={ROW_ACTIONS_CLASS}>
           {onConfigure && (
             <ModelLoadSettingsAction

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -514,6 +514,22 @@ function VramBadge({ status }: { status?: VramFitStatus | null }) {
 
 const SIZE_PARTS_RE = /^(~?)([\d.]+)\s*([A-Za-z]+)$/;
 
+/** Marks a row that opens into its quants. The row itself is the toggle. */
+function ExpandChevron({ open }: { open: boolean }) {
+  return (
+    <span
+      aria-hidden="true"
+      className="flex size-5 shrink-0 items-center justify-center text-muted-foreground/60"
+    >
+      {open ? (
+        <ChevronDownIcon className="size-3" />
+      ) : (
+        <ChevronRightIcon className="size-3" />
+      )}
+    </span>
+  );
+}
+
 /** A size in mono: the dot pulled in, a hair of air before the unit. */
 function SizeText({ value }: { value: string }) {
   const parts = SIZE_PARTS_RE.exec(value);
@@ -585,9 +601,12 @@ const META_COLUMN = {
 } as const;
 
 // One gutter for every row, gear or no gear, so the columns never shift by a
-// button. The buttons show on hover; the gutter stays open so nothing moves.
-const ROW_ACTIONS_CLASS =
-  "mr-0.5 flex w-[38px] shrink-0 items-center justify-end -space-x-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:none)]:opacity-100";
+// button. The gutter stays open; what sits in it shows on hover.
+const ROW_ACTIONS_BASE =
+  "mr-0.5 flex w-[38px] shrink-0 items-center justify-end -space-x-0.5";
+const ROW_HOVER_ONLY =
+  "opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:none)]:opacity-100";
+const ROW_ACTIONS_CLASS = `${ROW_ACTIONS_BASE} ${ROW_HOVER_ONLY}`;
 
 function ModelRow({
   label,
@@ -609,6 +628,7 @@ function ModelRow({
   quantChip,
   alignMeta,
   showSize,
+  expander,
   className,
 }: {
   label: string;
@@ -643,6 +663,9 @@ function ModelRow({
   /** Hold the size column open. Hub rows pass this on the MLX and Safetensors
    *  filters, where a repo is one download with one size. */
   showSize?: boolean;
+  /** Trailing chevron for rows that open into their quants. "none" holds the
+   *  slot without a glyph, so a list of mixed rows still lines up. */
+  expander?: "open" | "closed" | "none";
   className?: string;
 }) {
   const exceeds = vramStatus === "exceeds";
@@ -823,6 +846,11 @@ function ModelRow({
             <SizeText value={parsed.size} />
           </span>
         ) : null}
+        {expander === undefined ? null : expander === "none" ? (
+          <span aria-hidden="true" className="size-5 shrink-0" />
+        ) : (
+          <ExpandChevron open={expander === "open"} />
+        )}
       </span>
     </button>
   );
@@ -3406,8 +3434,10 @@ export function HubModelPicker({
               className={downloadedRowButtonClassName}
             />
           </div>
-          {/* Stands in for the other rows' buttons, so the tags line up. */}
-          <span aria-hidden="true" className={cn(ROW_ACTIONS_CLASS, "h-6")} />
+          {/* Sits where the other rows' buttons do, so the tags line up. */}
+          <span className={cn(ROW_ACTIONS_CLASS, "h-6 opacity-100")}>
+            <ExpandChevron open={expanderOpen} />
+          </span>
         </div>
         {expanderOpen && (
           <GgufVariantExpander
@@ -4180,7 +4210,15 @@ export function HubModelPicker({
                                   vramStatus={null}
                                 />
                               </div>
-                              <span className={ROW_ACTIONS_CLASS}>
+                              <span
+                                className={cn(
+                                  ROW_ACTIONS_CLASS,
+                                  isGguf && !isDirectGguf && "opacity-100",
+                                )}
+                              >
+                                {isGguf && !isDirectGguf ? (
+                                  <ExpandChevron open={isGgufExpanded(m.id)} />
+                                ) : null}
                                 {isDirectGguf && onConfigure && (
                                   <ModelLoadSettingsAction
                                     ariaLabel={`Inference settings for ${
@@ -4311,7 +4349,15 @@ export function HubModelPicker({
                                   vramStatus={null}
                                 />
                               </div>
-                              <span className={ROW_ACTIONS_CLASS}>
+                              <span
+                                className={cn(
+                                  ROW_ACTIONS_CLASS,
+                                  isGguf && !isGgufFile && "opacity-100",
+                                )}
+                              >
+                                {isGguf && !isGgufFile ? (
+                                  <ExpandChevron open={isGgufExpanded(m.id)} />
+                                ) : null}
                                 {isGgufFile && onConfigure && (
                                   <ModelLoadSettingsAction
                                     ariaLabel={`Inference settings for ${
@@ -4430,7 +4476,15 @@ export function HubModelPicker({
                                   vramStatus={null}
                                 />
                               </div>
-                              <span className={ROW_ACTIONS_CLASS}>
+                              <span
+                                className={cn(
+                                  ROW_ACTIONS_CLASS,
+                                  isGguf && !isGgufFile && "opacity-100",
+                                )}
+                              >
+                                {isGguf && !isGgufFile ? (
+                                  <ExpandChevron open={isGgufExpanded(m.id)} />
+                                ) : null}
                                 {isGgufFile && onConfigure && (
                                   <ModelLoadSettingsAction
                                     ariaLabel={`Inference settings for ${
@@ -4510,6 +4564,13 @@ export function HubModelPicker({
                               hubUrl={hubRepoUrl(id)}
                               alignMeta="hub"
                               showSize={hubRowsShowSize}
+                              expander={
+                                isG
+                                  ? expandedGguf === id
+                                    ? "open"
+                                    : "closed"
+                                  : "none"
+                              }
                               hideOwner={true}
                               downloaded={downloadedSet.has(id.toLowerCase())}
                               capabilities={capsById.get(id)}
@@ -4621,6 +4682,13 @@ export function HubModelPicker({
                             hubUrl={hubRepoUrl(id)}
                             alignMeta="hub"
                             showSize={hubRowsShowSize}
+                            expander={
+                              isKnownGgufRepo(id)
+                                ? expandedGguf === id
+                                  ? "open"
+                                  : "closed"
+                                : "none"
+                            }
                             capabilities={capsById.get(id)}
                             meta={
                               isKnownGgufRepo(id)
@@ -4735,6 +4803,13 @@ export function HubModelPicker({
                               hubUrl={hubRepoUrl(id)}
                               alignMeta="hub"
                               showSize={hubRowsShowSize}
+                              expander={
+                                isSearchGguf
+                                  ? expandedGguf === id
+                                    ? "open"
+                                    : "closed"
+                                  : "none"
+                              }
                               capabilities={capsById.get(id)}
                               meta={
                                 isSearchGguf
@@ -4988,38 +5063,48 @@ function FineTunedRows({
                   alignMeta="device"
                 />
               </div>
-              <span className={ROW_ACTIONS_CLASS}>
-                {canConfigure && onConfigure && (
-                  <ModelLoadSettingsAction
-                    ariaLabel={`Inference settings for ${adapter.name}`}
-                    onConfigure={() => onConfigure(adapter.id, selectionMeta)}
-                  />
-                )}
-                {canDelete && (
-                  <ModelDeleteAction
-                    ariaLabel={`Delete ${adapter.name}`}
-                    title="Delete fine-tuned model?"
-                    description={
-                      <>
-                        This will remove{" "}
-                        <span className="font-medium text-foreground">
-                          {adapter.name}
-                        </span>{" "}
-                        from disk. This cannot be undone.
-                      </>
-                    }
-                    successMessage={`Deleted ${adapter.name}`}
-                    disabled={deleteDisabled}
-                    onConfirm={() =>
-                      deleteFineTunedModel({
-                        modelPath: adapter.id,
-                        source: isExported ? "exported" : "training",
-                        exportType: adapter.exportType,
-                      })
-                    }
-                    onDeleted={() => onModelsChange?.({ id: adapter.id })}
-                  />
-                )}
+              <span className={ROW_ACTIONS_BASE}>
+                {isLocalGgufDir || isExportedGguf ? (
+                  <ExpandChevron open={expandedGguf === adapter.id} />
+                ) : null}
+                <span
+                  className={cn(
+                    "flex items-center -space-x-0.5",
+                    ROW_HOVER_ONLY,
+                  )}
+                >
+                  {canConfigure && onConfigure && (
+                    <ModelLoadSettingsAction
+                      ariaLabel={`Inference settings for ${adapter.name}`}
+                      onConfigure={() => onConfigure(adapter.id, selectionMeta)}
+                    />
+                  )}
+                  {canDelete && (
+                    <ModelDeleteAction
+                      ariaLabel={`Delete ${adapter.name}`}
+                      title="Delete fine-tuned model?"
+                      description={
+                        <>
+                          This will remove{" "}
+                          <span className="font-medium text-foreground">
+                            {adapter.name}
+                          </span>{" "}
+                          from disk. This cannot be undone.
+                        </>
+                      }
+                      successMessage={`Deleted ${adapter.name}`}
+                      disabled={deleteDisabled}
+                      onConfirm={() =>
+                        deleteFineTunedModel({
+                          modelPath: adapter.id,
+                          source: isExported ? "exported" : "training",
+                          exportType: adapter.exportType,
+                        })
+                      }
+                      onDeleted={() => onModelsChange?.({ id: adapter.id })}
+                    />
+                  )}
+                </span>
               </span>
             </div>
             {expandedGguf === adapter.id && (

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -125,7 +125,12 @@ import {
   modelIdsMatchForPicker,
   soleQuantRowState,
 } from "./row-identity";
-import { parseMetaTokens, splitRepoLabel } from "./row-meta";
+import {
+  type FormatTone,
+  isUnslothOwner,
+  parseMetaTokens,
+  splitRepoLabel,
+} from "./row-meta";
 import {
   type SoleQuantEntry,
   type SoleQuantTarget,
@@ -384,7 +389,8 @@ function formatBytes(bytes: number): string {
     value /= 1000;
     i += 1;
   }
-  return `${value.toFixed(value < 10 ? 1 : 0)} ${units[i]}`;
+  // No space: "145MB" reads as one value beside the quant chip.
+  return `${value.toFixed(value < 10 ? 1 : 0)}${units[i]}`;
 }
 
 // Small icon badges for what a model can do (vision / reasoning / audio).
@@ -410,6 +416,111 @@ function CapabilityIcons({ caps }: { caps: ModelCapabilities }) {
   );
 }
 
+/** "This model reads images", from the GGUF metadata (On Device rows). */
+function VisionBadge() {
+  return (
+    <Tooltip delayDuration={0}>
+      <TooltipTrigger asChild={true}>
+        <span
+          aria-label="Vision"
+          className="flex h-[18px] shrink-0 items-center justify-center rounded-md border border-border/60 px-1.5 text-indigo-700 dark:text-indigo-300"
+        >
+          <HugeiconsIcon icon={ViewIcon} className="size-3" strokeWidth={1.8} />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="tooltip-compact">
+        This model can process image inputs
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+/** Parameter count chip ("27B"). */
+function ParamChip({ label }: { label: string }) {
+  return (
+    <span className="whitespace-nowrap rounded-md border border-border/60 px-1.5 py-px text-ui-10 font-medium text-muted-foreground tabular-nums">
+      {label}
+    </span>
+  );
+}
+
+// Format colours: gguf blue, mlx amber, safetensors/checkpoint pink, adapter.
+const FORMAT_TONE_DOT: Record<FormatTone, string> = {
+  gguf: "bg-format-gguf",
+  mlx: "bg-format-mlx",
+  checkpoint: "bg-format-checkpoint",
+  adapter: "bg-format-adapter",
+};
+
+/** Format as a coloured dot ahead of the name, named on hover. A word like
+ *  "Safetensors" is wide enough to shove the rest of the row around. */
+function FormatTag({ tone, label }: { tone: FormatTone; label: string }) {
+  return (
+    <Tooltip delayDuration={0}>
+      <TooltipTrigger asChild={true}>
+        {/* Hit area, so hovering the dot is not a pixel hunt. */}
+        <span
+          aria-label={label}
+          className="flex size-[14px] shrink-0 items-center justify-center"
+        >
+          <span
+            aria-hidden="true"
+            className={cn("size-[5px] rounded-full", FORMAT_TONE_DOT[tone])}
+          />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="tooltip-compact">
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+/** "Already on disk", shown on Hub rows that are also downloaded. */
+function DownloadedBadge() {
+  return (
+    <span
+      title="Already downloaded"
+      aria-label="Already downloaded"
+      className="flex h-[18px] shrink-0 items-center justify-center rounded-md border border-status-success/40 px-1.5 text-status-success"
+    >
+      <HugeiconsIcon
+        icon={Download01Icon}
+        className="size-3"
+        strokeWidth={1.8}
+      />
+    </span>
+  );
+}
+
+/** VRAM verdict for Hub rows: over budget, or a tight fit. */
+function VramBadge({ status }: { status?: VramFitStatus | null }) {
+  if (status === "exceeds") {
+    return (
+      <span className="whitespace-nowrap text-ui-9 font-medium !text-red-700 !bg-red-50 dark:!text-red-300 dark:!bg-red-500/15 px-1.5 py-0.5 rounded">
+        OOM
+      </span>
+    );
+  }
+  if (status === "tight") {
+    return (
+      <span className="whitespace-nowrap text-ui-9 font-medium !text-amber-400">
+        TIGHT
+      </span>
+    );
+  }
+  return null;
+}
+
+/** The one quant a row loads, as a compact mono chip. */
+function QuantChip({ label }: { label: string }) {
+  return (
+    <span className="inline-flex h-[18px] max-w-full items-center overflow-hidden rounded-md bg-black/[0.06] px-1 font-mono text-ui-9 text-muted-foreground dark:bg-white/[0.1]">
+      {label}
+    </span>
+  );
+}
+
 function isRuntimeLoadedModel(
   loadedModelId: string | undefined,
   activeGgufVariant: string | null | undefined,
@@ -426,6 +537,32 @@ function isRuntimeLoadedModel(
     ? hasActiveGgufVariant
     : !hasActiveGgufVariant;
 }
+
+// Shared row columns, so the meta lines up down the list instead of drifting
+// with each name's length. Widths are em of the slot's own text, so they
+// follow the UI font scale, and collapse below the picker's full width.
+// min-w-min means a width is the column held open, not a clamp: an outsized
+// badge grows its own slot rather than spilling over the next one.
+const META_COLUMN = {
+  // Fits "UD-Q4_K_XL"; a hard cap, so longer quants clip.
+  quant: "min-[560px]:w-[7.2em]",
+  // One capability / vision / downloaded badge.
+  badge: "min-w-min min-[560px]:w-[24px]",
+  // The "OOM" pill, wider than bare "TIGHT" (Hub rows).
+  vram: "min-w-min min-[560px]:w-[4em]",
+  // "235B" on device rows; Hub rows report "2779.5B", hence paramWide.
+  param: "min-w-min min-[560px]:w-[3.6em]",
+  paramWide: "min-w-min min-[560px]:w-[5.2em]",
+  // "536 MB".
+  size: "min-w-min min-[560px]:w-[4.2em]",
+  // The format dot that leads the row; the name lives in its tooltip.
+  format: "min-[560px]:w-[14px]",
+} as const;
+
+// One gutter for every row, gear or no gear, so the columns never shift by a
+// button. The buttons show on hover; the gutter stays open so nothing moves.
+const ROW_ACTIONS_CLASS =
+  "mr-0.5 flex w-[38px] shrink-0 items-center justify-end -space-x-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:none)]:opacity-100";
 
 function ModelRow({
   label,
@@ -445,6 +582,7 @@ function ModelRow({
   downloaded,
   showVision,
   quantChip,
+  alignMeta,
   className,
 }: {
   label: string;
@@ -473,6 +611,9 @@ function ModelRow({
   showVision?: boolean;
   /** Grey chip beside the name, for rows that load one specific quant. */
   quantChip?: string | null;
+  /** Column layout (see META_COLUMN): "device" reserves the quant chip,
+   *  "hub" the download and VRAM badges those lists carry instead. */
+  alignMeta?: "device" | "hub";
   className?: string;
 }) {
   const exceeds = vramStatus === "exceeds";
@@ -488,12 +629,24 @@ function ModelRow({
       : null;
 
   const { owner, name } = splitRepoLabel(label);
+  // Drop our own owner: the list is nearly all unsloth/, so it is noise.
+  // Other owners still show, which is what tells the two apart.
+  const showOwner = !!owner && !hideOwner && !isUnslothOwner(owner);
   const parsed = parseMetaTokens(meta);
   // Param chip from meta, else derived from the name so GGUF rows show it too.
   const paramLabel = parsed.param ?? extractParamLabel(name) ?? null;
   // Use the passed-in capabilities (tag-aware) or infer from the repo name.
   const caps = capabilities ?? detectCapabilities({ id: label });
   const showCaps = hasAnyCapability(caps);
+  const aligned = alignMeta !== undefined;
+  // One dot per row. A second format shares the first's colour anyway, so it
+  // rides along in the tooltip instead of pushing the name out of line.
+  const formatDot = parsed.formats[0]
+    ? {
+        tone: parsed.formats[0].tone,
+        label: parsed.formats.map((f) => f.label).join(" · "),
+      }
+    : null;
 
   const content = (
     <button
@@ -514,93 +667,131 @@ function ModelRow({
       )}
     >
       <span className="flex min-w-0 flex-1 items-baseline">
-        {owner && !hideOwner ? (
+        {/* Fixed slot, so names start on one line with or without a dot. */}
+        {aligned ? (
+          <span
+            className={cn(
+              "mr-1 flex shrink-0 items-center self-center",
+              META_COLUMN.format,
+            )}
+          >
+            {formatDot ? <FormatTag {...formatDot} /> : null}
+          </span>
+        ) : formatDot ? (
+          <span className="mr-1 flex shrink-0 items-center self-center">
+            <FormatTag {...formatDot} />
+          </span>
+        ) : null}
+        {showOwner ? (
           <span className="inline-flex min-w-0 max-w-[45%] shrink items-baseline text-ui-13 text-muted-foreground/90">
             <span className="truncate">{owner}</span>
             <span className="shrink-0 text-muted-foreground/45">/</span>
           </span>
         ) : null}
         <span className="min-w-0 flex-1 truncate">{name}</span>
-        {quantChip ? (
+        {/* Here it eats name width instead of moving the meta columns. */}
+        {aligned && loaded && (
+          <DotTag
+            tone="success"
+            label="Loaded"
+            className="ml-2 h-[18px] shrink-0 gap-1 rounded-md px-1.5"
+            dotClassName="size-[5px]"
+          />
+        )}
+        {alignMeta === "device" ? (
+          <span
+            className={cn(
+              "ml-1.5 flex shrink-0 items-center self-center text-ui-9",
+              META_COLUMN.quant,
+            )}
+          >
+            {quantChip ? <QuantChip label={quantChip} /> : null}
+          </span>
+        ) : quantChip ? (
           <span className="ml-2 shrink-0 rounded-md bg-black/[0.06] px-1.5 py-px font-mono text-ui-10 text-muted-foreground dark:bg-white/[0.1]">
             {quantChip}
           </span>
         ) : null}
       </span>
-      <span className="ml-auto flex shrink-0 items-center gap-1.5">
-        {showCaps && <CapabilityIcons caps={caps} />}
-        {showVision && (
-          <Tooltip delayDuration={0}>
-            <TooltipTrigger asChild={true}>
-              <span
-                aria-label="Vision"
-                className="flex h-[18px] shrink-0 items-center justify-center rounded-md border border-border/60 px-1.5 text-indigo-700 dark:text-indigo-300"
-              >
-                <HugeiconsIcon
-                  icon={ViewIcon}
-                  className="size-3"
-                  strokeWidth={1.8}
-                />
-              </span>
-            </TooltipTrigger>
-            <TooltipContent side="top" className="tooltip-compact">
-              This model can process image inputs
-            </TooltipContent>
-          </Tooltip>
+      <span
+        className={cn(
+          "ml-auto flex shrink-0 items-center",
+          aligned ? "gap-1" : "gap-1.5",
         )}
-        {loaded && (
-          <DotTag
-            tone="success"
-            label="Loaded"
-            className="h-[18px] gap-1 rounded-md px-1.5"
-            dotClassName="size-[5px]"
-          />
-        )}
-        {downloaded && !loaded && (
+      >
+        {/* Capabilities, vision and the Hub lists' "on disk" mark share one
+            column; two of them widen the slot rather than overlap. */}
+        {aligned ? (
           <span
-            title="Already downloaded"
-            aria-label="Already downloaded"
-            className="flex h-[18px] shrink-0 items-center justify-center rounded-md border border-border/60 px-1.5 text-muted-foreground"
+            className={cn(
+              "flex shrink-0 items-center justify-center gap-1 text-ui-10",
+              META_COLUMN.badge,
+            )}
           >
-            <HugeiconsIcon
-              icon={Download01Icon}
-              className="size-3"
-              strokeWidth={1.8}
-            />
+            {showCaps && <CapabilityIcons caps={caps} />}
+            {showVision && <VisionBadge />}
+            {downloaded && !loaded ? <DownloadedBadge /> : null}
           </span>
+        ) : (
+          <>
+            {showCaps && <CapabilityIcons caps={caps} />}
+            {showVision && <VisionBadge />}
+            {loaded && (
+              <DotTag
+                tone="success"
+                label="Loaded"
+                className="h-[18px] gap-1 rounded-md px-1.5"
+                dotClassName="size-[5px]"
+              />
+            )}
+            {downloaded && !loaded ? <DownloadedBadge /> : null}
+          </>
         )}
-        {vramStatus === "exceeds" && (
-          <span className="text-ui-9 font-medium !text-red-700 !bg-red-50 dark:!text-red-300 dark:!bg-red-500/15 px-1.5 py-0.5 rounded">
-            OOM
+        {alignMeta === "hub" ? (
+          <span
+            className={cn(
+              "flex shrink-0 items-center justify-end text-ui-9",
+              META_COLUMN.vram,
+            )}
+          >
+            <VramBadge status={vramStatus} />
           </span>
+        ) : (
+          <VramBadge status={vramStatus} />
         )}
-        {vramStatus === "tight" && (
-          <span className="text-ui-9 font-medium !text-amber-400">TIGHT</span>
-        )}
-        {paramLabel ? (
-          <span className="rounded-md border border-border/60 px-1.5 py-px text-ui-10 font-medium text-muted-foreground tabular-nums">
-            {paramLabel}
+        {aligned ? (
+          <span
+            className={cn(
+              "flex shrink-0 justify-end text-ui-10",
+              alignMeta === "hub" ? META_COLUMN.paramWide : META_COLUMN.param,
+            )}
+          >
+            {paramLabel ? <ParamChip label={paramLabel} /> : null}
           </span>
+        ) : paramLabel ? (
+          <ParamChip label={paramLabel} />
         ) : null}
         {parsed.texts.map((text) => (
           <span key={text} className="text-ui-10 text-muted-foreground">
             {text}
           </span>
         ))}
-        {parsed.size !== undefined ? (
-          <span className="text-ui-10 text-muted-foreground tabular-nums">
+        {/* Hub rows skip the size: only the odd safetensors repo reports one
+            unexpanded, so the column would be an empty gap. */}
+        {alignMeta === "device" ? (
+          <span
+            className={cn(
+              "shrink-0 whitespace-nowrap text-right font-mono text-ui-10 text-muted-foreground tabular-nums",
+              META_COLUMN.size,
+            )}
+          >
+            {parsed.size}
+          </span>
+        ) : alignMeta === "hub" ? null : parsed.size !== undefined ? (
+          <span className="font-mono text-ui-10 text-muted-foreground tabular-nums">
             {parsed.size}
           </span>
         ) : null}
-        {parsed.formats.map((f) => (
-          <DotTag
-            key={f.label}
-            tone={f.tone}
-            label={f.label}
-            className="h-[18px] gap-[3px] rounded-md px-1.5"
-            dotClassName="size-[5px]"
-          />
-        ))}
       </span>
     </button>
   );
@@ -1189,7 +1380,7 @@ function GgufVariantExpander({
                     TIGHT
                   </span>
                 )}
-                <span className="text-ui-10 text-muted-foreground">
+                <span className="font-mono text-ui-10 text-muted-foreground tabular-nums">
                   {formatBytes(v.size_bytes)}
                 </span>
               </span>
@@ -2962,28 +3153,36 @@ export function HubModelPicker({
           )}
           title={`${entry.repoId} (${entry.quant})`}
         >
-          <span className="flex min-w-0 items-baseline">
-            {owner ? (
+          <span className="flex min-w-0 flex-1 items-baseline">
+            {owner && !isUnslothOwner(owner) ? (
               <span className="inline-flex min-w-0 max-w-[45%] shrink items-baseline text-ui-13 text-muted-foreground/90">
                 <span className="truncate">{owner}</span>
                 <span className="shrink-0 text-muted-foreground/45">/</span>
               </span>
             ) : null}
-            <span className="min-w-0 truncate">{name}</span>
+            <span className="min-w-0 flex-1 truncate">{name}</span>
+            {isLoaded && (
+              <DotTag
+                tone="success"
+                label="Loaded"
+                className="ml-2 h-[18px] shrink-0 gap-1 rounded-md px-1.5"
+                dotClassName="size-[5px]"
+              />
+            )}
           </span>
-          <span className="shrink-0 rounded-md bg-black/[0.06] px-1.5 py-px font-mono text-ui-10 text-muted-foreground dark:bg-white/[0.1]">
-            {entry.quant}
+          {/* Same quant column as the sections below. */}
+          <span
+            className={cn(
+              "flex shrink-0 items-baseline font-mono text-ui-10",
+              META_COLUMN.quant,
+            )}
+          >
+            <span className="max-w-full truncate rounded-md bg-black/[0.06] px-1.5 py-px text-muted-foreground dark:bg-white/[0.1]">
+              {entry.quant}
+            </span>
           </span>
-          {isLoaded && (
-            <DotTag
-              tone="success"
-              label="Loaded"
-              className="ml-auto h-[18px] shrink-0 gap-1 rounded-md px-1.5"
-              dotClassName="size-[5px]"
-            />
-          )}
         </button>
-        <span className="mr-1 flex shrink-0 items-center opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100">
+        <span className={ROW_ACTIONS_CLASS}>
           {onConfigure && (
             <ModelLoadSettingsAction
               ariaLabel={`Inference settings for ${entry.repoId} ${entry.quant}`}
@@ -3000,7 +3199,6 @@ export function HubModelPicker({
           )}
           <ModelRowMenu
             ariaLabel={`More options for ${entry.repoId} ${entry.quant}`}
-            iconClassName="size-3"
             cachePath={{ repoId: entry.repoId, variant: entry.quant }}
             pin={{
               pinned: true,
@@ -3078,55 +3276,57 @@ export function HubModelPicker({
             showVision={c.has_vision || sole.hasVision}
             selected={isSelected}
             loaded={rowState.loaded}
+            alignMeta="device"
             optionProps={hubModelList.getOptionProps(optionKey, isSelected)}
             onClick={() => onSelect(c.repo_id, selectMeta)}
             vramStatus={null}
             className={downloadedRowButtonClassName}
           />
         </div>
-        {onConfigure && (
-          <ModelLoadSettingsAction
-            ariaLabel={`Inference settings for ${c.repo_id} ${variant.quant}`}
-            onConfigure={() => onConfigure(c.repo_id, selectMeta)}
+        <span className={ROW_ACTIONS_CLASS}>
+          {onConfigure && (
+            <ModelLoadSettingsAction
+              ariaLabel={`Inference settings for ${c.repo_id} ${variant.quant}`}
+              onConfigure={() => onConfigure(c.repo_id, selectMeta)}
+            />
+          )}
+          <ModelRowMenu
+            ariaLabel={`More options for ${c.repo_id} ${variant.quant}`}
+            cachePath={{ repoId: c.repo_id, variant: variant.quant }}
+            pin={{
+              pinned: isPinned,
+              pinLabel: "Pin to top",
+              unpinLabel: "Unpin",
+              onToggle: () => togglePinned(c.repo_id, variant.quant),
+            }}
+            del={{
+              title: "Delete cached model?",
+              description: (
+                <>
+                  This will remove{" "}
+                  <span className="font-medium text-foreground">
+                    {c.repo_id} ({variant.quant})
+                  </span>{" "}
+                  from disk. You can re-download it later.
+                </>
+              ),
+              successMessage: `Deleted ${c.repo_id} ${variant.quant}`,
+              disabled: deleteDisabled,
+              onConfirm: async () => {
+                await deleteCachedModel(
+                  c.repo_id,
+                  variant.quant,
+                  hfToken || undefined,
+                  c.cache_path || undefined,
+                );
+                // The file is gone, so drop its pin too.
+                if (isPinned) togglePinned(c.repo_id, variant.quant);
+                prunePinnedQuantValidation(c.repo_id, variant.quant);
+                refreshCachedLists();
+              },
+            }}
           />
-        )}
-        <ModelRowMenu
-          ariaLabel={`More options for ${c.repo_id} ${variant.quant}`}
-          buttonClassName="mr-1"
-          cachePath={{ repoId: c.repo_id, variant: variant.quant }}
-          pin={{
-            pinned: isPinned,
-            pinLabel: "Pin to top",
-            unpinLabel: "Unpin",
-            onToggle: () => togglePinned(c.repo_id, variant.quant),
-          }}
-          del={{
-            title: "Delete cached model?",
-            description: (
-              <>
-                This will remove{" "}
-                <span className="font-medium text-foreground">
-                  {c.repo_id} ({variant.quant})
-                </span>{" "}
-                from disk. You can re-download it later.
-              </>
-            ),
-            successMessage: `Deleted ${c.repo_id} ${variant.quant}`,
-            disabled: deleteDisabled,
-            onConfirm: async () => {
-              await deleteCachedModel(
-                c.repo_id,
-                variant.quant,
-                hfToken || undefined,
-                c.cache_path || undefined,
-              );
-              // The file is gone, so drop its pin too.
-              if (isPinned) togglePinned(c.repo_id, variant.quant);
-              prunePinnedQuantValidation(c.repo_id, variant.quant);
-              refreshCachedLists();
-            },
-          }}
-        />
+        </span>
       </div>
     );
   };
@@ -3153,6 +3353,7 @@ export function HubModelPicker({
               tooltipText={localPathTooltip(c.repo_id, c.cache_path)}
               meta="GGUF"
               showVision={c.has_vision ?? visionByRepo[c.repo_id]}
+              alignMeta="device"
               selected={isSelected}
               loaded={isRuntimeLoadedModel(
                 loadedModelId,
@@ -3172,7 +3373,7 @@ export function HubModelPicker({
             />
           </div>
           {/* Stands in for the other rows' buttons, so the tags line up. */}
-          <span aria-hidden="true" className="mr-1 h-6 w-[42px] shrink-0" />
+          <span aria-hidden="true" className={cn(ROW_ACTIONS_CLASS, "h-6")} />
         </div>
         {expanderOpen && (
           <GgufVariantExpander
@@ -3226,6 +3427,7 @@ export function HubModelPicker({
               c.size_bytes,
             )}`}
             selected={isSelected}
+            alignMeta="device"
             loaded={isRuntimeLoadedModel(
               loadedModelId,
               activeGgufVariant,
@@ -3245,55 +3447,58 @@ export function HubModelPicker({
             className={downloadedRowButtonClassName}
           />
         </div>
-        {onConfigure && (
-          <ModelLoadSettingsAction
-            ariaLabel={`Inference settings for ${c.repo_id}`}
-            onConfigure={() =>
-              onConfigure(c.repo_id, {
-                source: "hub",
-                isLora: false,
-                loadId: c.load_id,
-                isDownloaded: true,
-                isGguf: false,
-              })
-            }
-          />
-        )}
-        <ModelRowMenu
-          ariaLabel={`More options for ${c.repo_id}`}
-          buttonClassName="mr-1"
-          cachePath={{ repoId: c.repo_id }}
-          pin={{
-            pinned: pinnedSet.has(pinKey(c.repo_id)),
-            pinLabel: "Pin to top",
-            unpinLabel: "Unpin",
-            onToggle: () => togglePinned(c.repo_id),
-          }}
-          del={{
-            title: "Delete cached model?",
-            description: (
-              <>
-                This will remove{" "}
-                <span className="font-medium text-foreground">{c.repo_id}</span>{" "}
-                from disk. You can re-download it later.
-              </>
-            ),
-            successMessage: `Deleted ${c.repo_id}`,
-            disabled: deleteDisabled,
-            onConfirm: async () => {
-              await deleteCachedModel(
-                c.repo_id,
-                undefined,
-                hfToken || undefined,
-                c.cache_path || undefined,
-              );
-              if (pinnedSet.has(pinKey(c.repo_id))) {
-                togglePinned(c.repo_id);
+        <span className={ROW_ACTIONS_CLASS}>
+          {onConfigure && (
+            <ModelLoadSettingsAction
+              ariaLabel={`Inference settings for ${c.repo_id}`}
+              onConfigure={() =>
+                onConfigure(c.repo_id, {
+                  source: "hub",
+                  isLora: false,
+                  loadId: c.load_id,
+                  isDownloaded: true,
+                  isGguf: false,
+                })
               }
-            },
-            onDeleted: refreshCachedLists,
-          }}
-        />
+            />
+          )}
+          <ModelRowMenu
+            ariaLabel={`More options for ${c.repo_id}`}
+            cachePath={{ repoId: c.repo_id }}
+            pin={{
+              pinned: pinnedSet.has(pinKey(c.repo_id)),
+              pinLabel: "Pin to top",
+              unpinLabel: "Unpin",
+              onToggle: () => togglePinned(c.repo_id),
+            }}
+            del={{
+              title: "Delete cached model?",
+              description: (
+                <>
+                  This will remove{" "}
+                  <span className="font-medium text-foreground">
+                    {c.repo_id}
+                  </span>{" "}
+                  from disk. You can re-download it later.
+                </>
+              ),
+              successMessage: `Deleted ${c.repo_id}`,
+              disabled: deleteDisabled,
+              onConfirm: async () => {
+                await deleteCachedModel(
+                  c.repo_id,
+                  undefined,
+                  hfToken || undefined,
+                  c.cache_path || undefined,
+                );
+                if (pinnedSet.has(pinKey(c.repo_id))) {
+                  togglePinned(c.repo_id);
+                }
+              },
+              onDeleted: refreshCachedLists,
+            }}
+          />
+        </span>
       </div>
     );
   };
@@ -3572,9 +3777,9 @@ export function HubModelPicker({
                         </>
                       }
                     >
-                      {/* When other providers (LM Studio/Ollama) also show here, name
-                    this group "Unsloth" so the two are easy to tell apart. */}
-                      {sortedLmStudio.length > 0 ? "Unsloth" : "Downloaded"}
+                      {/* Rows drop the unsloth/ prefix; the heading carries
+                    it for the group. */}
+                      Unsloth
                     </ListLabel>
                     {!downloadedCollapsed &&
                       unslothCachedGguf.map(renderDownloadedGgufRow)}
@@ -3893,7 +4098,7 @@ export function HubModelPicker({
                         );
                         return (
                           <div key={m.id}>
-                            <div className="flex items-center gap-0.5">
+                            <div className="group flex items-center">
                               <div className="min-w-0 flex-1">
                                 <ModelRow
                                   label={m.model_id ?? m.display_name}
@@ -3937,29 +4142,32 @@ export function HubModelPicker({
                                         }
                                       : undefined
                                   }
+                                  alignMeta="device"
                                   vramStatus={null}
                                 />
                               </div>
-                              {isDirectGguf && onConfigure && (
-                                <ModelLoadSettingsAction
-                                  ariaLabel={`Inference settings for ${
-                                    m.model_id ?? m.display_name
-                                  }`}
-                                  onConfigure={() =>
-                                    onConfigure(m.id, localDirectGgufMeta())
-                                  }
-                                />
-                              )}
-                              {!isGguf && onConfigure && (
-                                <ModelLoadSettingsAction
-                                  ariaLabel={`Inference settings for ${
-                                    m.model_id ?? m.display_name
-                                  }`}
-                                  onConfigure={() =>
-                                    onConfigure(m.id, localModelMeta())
-                                  }
-                                />
-                              )}
+                              <span className={ROW_ACTIONS_CLASS}>
+                                {isDirectGguf && onConfigure && (
+                                  <ModelLoadSettingsAction
+                                    ariaLabel={`Inference settings for ${
+                                      m.model_id ?? m.display_name
+                                    }`}
+                                    onConfigure={() =>
+                                      onConfigure(m.id, localDirectGgufMeta())
+                                    }
+                                  />
+                                )}
+                                {!isGguf && onConfigure && (
+                                  <ModelLoadSettingsAction
+                                    ariaLabel={`Inference settings for ${
+                                      m.model_id ?? m.display_name
+                                    }`}
+                                    onConfigure={() =>
+                                      onConfigure(m.id, localModelMeta())
+                                    }
+                                  />
+                                )}
+                              </span>
                             </div>
                             {isGguf &&
                               !isDirectGguf &&
@@ -4021,7 +4229,7 @@ export function HubModelPicker({
                         const optionKey = makeModelOptionKey("lm-studio", m.id);
                         return (
                           <div key={m.id}>
-                            <div className="flex items-center gap-0.5">
+                            <div className="group flex items-center">
                               <div className="min-w-0 flex-1">
                                 <ModelRow
                                   label={m.model_id ?? m.display_name}
@@ -4065,29 +4273,32 @@ export function HubModelPicker({
                                         }
                                       : undefined
                                   }
+                                  alignMeta="device"
                                   vramStatus={null}
                                 />
                               </div>
-                              {isGgufFile && onConfigure && (
-                                <ModelLoadSettingsAction
-                                  ariaLabel={`Inference settings for ${
-                                    m.model_id ?? m.display_name
-                                  }`}
-                                  onConfigure={() =>
-                                    onConfigure(m.id, localDirectGgufMeta())
-                                  }
-                                />
-                              )}
-                              {!isGguf && onConfigure && (
-                                <ModelLoadSettingsAction
-                                  ariaLabel={`Inference settings for ${
-                                    m.model_id ?? m.display_name
-                                  }`}
-                                  onConfigure={() =>
-                                    onConfigure(m.id, localModelMeta())
-                                  }
-                                />
-                              )}
+                              <span className={ROW_ACTIONS_CLASS}>
+                                {isGgufFile && onConfigure && (
+                                  <ModelLoadSettingsAction
+                                    ariaLabel={`Inference settings for ${
+                                      m.model_id ?? m.display_name
+                                    }`}
+                                    onConfigure={() =>
+                                      onConfigure(m.id, localDirectGgufMeta())
+                                    }
+                                  />
+                                )}
+                                {!isGguf && onConfigure && (
+                                  <ModelLoadSettingsAction
+                                    ariaLabel={`Inference settings for ${
+                                      m.model_id ?? m.display_name
+                                    }`}
+                                    onConfigure={() =>
+                                      onConfigure(m.id, localModelMeta())
+                                    }
+                                  />
+                                )}
+                              </span>
                             </div>
                             {isGguf && !isGgufFile && isGgufExpanded(m.id) && (
                               <GgufVariantExpander
@@ -4141,7 +4352,7 @@ export function HubModelPicker({
                         const optionKey = makeModelOptionKey("local-dir", m.id);
                         return (
                           <div key={m.id}>
-                            <div className="flex items-center gap-0.5">
+                            <div className="group flex items-center">
                               <div className="min-w-0 flex-1">
                                 <ModelRow
                                   label={m.model_id ?? m.display_name}
@@ -4181,29 +4392,32 @@ export function HubModelPicker({
                                       ? () => focusFirstChildOption(optionKey)
                                       : undefined
                                   }
+                                  alignMeta="device"
                                   vramStatus={null}
                                 />
                               </div>
-                              {isGgufFile && onConfigure && (
-                                <ModelLoadSettingsAction
-                                  ariaLabel={`Inference settings for ${
-                                    m.model_id ?? m.display_name
-                                  }`}
-                                  onConfigure={() =>
-                                    onConfigure(m.id, localDirectGgufMeta())
-                                  }
-                                />
-                              )}
-                              {!isGguf && onConfigure && (
-                                <ModelLoadSettingsAction
-                                  ariaLabel={`Inference settings for ${
-                                    m.model_id ?? m.display_name
-                                  }`}
-                                  onConfigure={() =>
-                                    onConfigure(m.id, localModelMeta())
-                                  }
-                                />
-                              )}
+                              <span className={ROW_ACTIONS_CLASS}>
+                                {isGgufFile && onConfigure && (
+                                  <ModelLoadSettingsAction
+                                    ariaLabel={`Inference settings for ${
+                                      m.model_id ?? m.display_name
+                                    }`}
+                                    onConfigure={() =>
+                                      onConfigure(m.id, localDirectGgufMeta())
+                                    }
+                                  />
+                                )}
+                                {!isGguf && onConfigure && (
+                                  <ModelLoadSettingsAction
+                                    ariaLabel={`Inference settings for ${
+                                      m.model_id ?? m.display_name
+                                    }`}
+                                    onConfigure={() =>
+                                      onConfigure(m.id, localModelMeta())
+                                    }
+                                  />
+                                )}
+                              </span>
                             </div>
                             {isGguf && !isGgufFile && isGgufExpanded(m.id) && (
                               <GgufVariantExpander
@@ -4260,6 +4474,7 @@ export function HubModelPicker({
                             <ModelRow
                               label={id}
                               hubUrl={hubRepoUrl(id)}
+                              alignMeta="hub"
                               hideOwner={true}
                               downloaded={downloadedSet.has(id.toLowerCase())}
                               capabilities={capsById.get(id)}
@@ -4369,6 +4584,7 @@ export function HubModelPicker({
                           <ModelRow
                             label={id}
                             hubUrl={hubRepoUrl(id)}
+                            alignMeta="hub"
                             capabilities={capsById.get(id)}
                             meta={
                               isKnownGgufRepo(id)
@@ -4481,6 +4697,7 @@ export function HubModelPicker({
                             <ModelRow
                               label={id}
                               hubUrl={hubRepoUrl(id)}
+                              alignMeta="hub"
                               capabilities={capsById.get(id)}
                               meta={
                                 isSearchGguf
@@ -4690,7 +4907,7 @@ function FineTunedRows({
               : tag;
         return (
           <div key={adapter.id}>
-            <div className="flex items-center gap-0.5">
+            <div className="group flex items-center">
               <div className="min-w-0 flex-1">
                 <ModelRow
                   label={adapter.name}
@@ -4731,39 +4948,42 @@ function FineTunedRows({
                         }
                       : undefined
                   }
+                  alignMeta="device"
                 />
               </div>
-              {canConfigure && onConfigure && (
-                <ModelLoadSettingsAction
-                  ariaLabel={`Inference settings for ${adapter.name}`}
-                  onConfigure={() => onConfigure(adapter.id, selectionMeta)}
-                />
-              )}
-              {canDelete && (
-                <ModelDeleteAction
-                  ariaLabel={`Delete ${adapter.name}`}
-                  title="Delete fine-tuned model?"
-                  description={
-                    <>
-                      This will remove{" "}
-                      <span className="font-medium text-foreground">
-                        {adapter.name}
-                      </span>{" "}
-                      from disk. This cannot be undone.
-                    </>
-                  }
-                  successMessage={`Deleted ${adapter.name}`}
-                  disabled={deleteDisabled}
-                  onConfirm={() =>
-                    deleteFineTunedModel({
-                      modelPath: adapter.id,
-                      source: isExported ? "exported" : "training",
-                      exportType: adapter.exportType,
-                    })
-                  }
-                  onDeleted={() => onModelsChange?.({ id: adapter.id })}
-                />
-              )}
+              <span className={ROW_ACTIONS_CLASS}>
+                {canConfigure && onConfigure && (
+                  <ModelLoadSettingsAction
+                    ariaLabel={`Inference settings for ${adapter.name}`}
+                    onConfigure={() => onConfigure(adapter.id, selectionMeta)}
+                  />
+                )}
+                {canDelete && (
+                  <ModelDeleteAction
+                    ariaLabel={`Delete ${adapter.name}`}
+                    title="Delete fine-tuned model?"
+                    description={
+                      <>
+                        This will remove{" "}
+                        <span className="font-medium text-foreground">
+                          {adapter.name}
+                        </span>{" "}
+                        from disk. This cannot be undone.
+                      </>
+                    }
+                    successMessage={`Deleted ${adapter.name}`}
+                    disabled={deleteDisabled}
+                    onConfirm={() =>
+                      deleteFineTunedModel({
+                        modelPath: adapter.id,
+                        source: isExported ? "exported" : "training",
+                        exportType: adapter.exportType,
+                      })
+                    }
+                    onDeleted={() => onModelsChange?.({ id: adapter.id })}
+                  />
+                )}
+              </span>
             </div>
             {expandedGguf === adapter.id && (
               <GgufVariantExpander

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -3639,9 +3639,9 @@ export function HubModelPicker({
               ) : (
                 connectedGroups.map((group) => (
                   <div key={group.providerId}>
-                    {/* Same spacing as the On Device section labels, so a
-                        provider's name sits clear of the rows above it. */}
-                    <div className="flex items-center gap-2 px-2.5 pb-1 pt-3 text-ui-10 font-semibold uppercase tracking-wider text-muted-foreground">
+                    {/* Wider than the On Device section labels: nothing
+                        divides these groups but the gap. */}
+                    <div className="flex items-center gap-2 px-2.5 pb-1 pt-5 text-ui-10 font-semibold uppercase tracking-wider text-muted-foreground">
                       <ApiProviderLogo
                         providerType={group.providerType}
                         className="size-3.5"

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -512,6 +512,31 @@ function VramBadge({ status }: { status?: VramFitStatus | null }) {
   return null;
 }
 
+const SIZE_PARTS_RE = /^(~?)([\d.]+)\s*([A-Za-z]+)$/;
+
+/** A size in mono: the dot pulled in, a hair of air before the unit. */
+function SizeText({ value }: { value: string }) {
+  const parts = SIZE_PARTS_RE.exec(value);
+  if (!parts) {
+    return <>{value}</>;
+  }
+  const [, approx, digits, unit] = parts;
+  const [whole, fraction] = digits.split(".");
+  return (
+    <>
+      {approx}
+      {whole}
+      {fraction === undefined ? null : (
+        <>
+          <span className="mx-[-0.1em]">.</span>
+          {fraction}
+        </>
+      )}
+      <span className="ml-[0.14em]">{unit}</span>
+    </>
+  );
+}
+
 /** The one quant a row loads, as a compact mono chip. */
 function QuantChip({ label }: { label: string }) {
   return (
@@ -583,6 +608,7 @@ function ModelRow({
   showVision,
   quantChip,
   alignMeta,
+  showSize,
   className,
 }: {
   label: string;
@@ -614,6 +640,9 @@ function ModelRow({
   /** Column layout (see META_COLUMN): "device" reserves the quant chip,
    *  "hub" the download and VRAM badges those lists carry instead. */
   alignMeta?: "device" | "hub";
+  /** Hold the size column open. Hub rows pass this on the MLX and Safetensors
+   *  filters, where a repo is one download with one size. */
+  showSize?: boolean;
   className?: string;
 }) {
   const exceeds = vramStatus === "exceeds";
@@ -776,20 +805,22 @@ function ModelRow({
             {text}
           </span>
         ))}
-        {/* Hub rows skip the size: only the odd safetensors repo reports one
-            unexpanded, so the column would be an empty gap. */}
-        {alignMeta === "device" ? (
+        {/* GGUF repos hold several quants of different sizes, so their rows
+            report one only once expanded, leaving the column an empty gap. */}
+        {alignMeta === "device" || showSize ? (
           <span
             className={cn(
               "shrink-0 whitespace-nowrap text-right font-mono text-ui-10 text-muted-foreground tabular-nums",
               META_COLUMN.size,
             )}
           >
-            {parsed.size}
+            {parsed.size === undefined ? null : (
+              <SizeText value={parsed.size} />
+            )}
           </span>
-        ) : alignMeta === "hub" ? null : parsed.size !== undefined ? (
+        ) : aligned ? null : parsed.size !== undefined ? (
           <span className="font-mono text-ui-10 text-muted-foreground tabular-nums">
-            {parsed.size}
+            <SizeText value={parsed.size} />
           </span>
         ) : null}
       </span>
@@ -1381,7 +1412,7 @@ function GgufVariantExpander({
                   </span>
                 )}
                 <span className="font-mono text-ui-10 text-muted-foreground tabular-nums">
-                  {formatBytes(v.size_bytes)}
+                  <SizeText value={formatBytes(v.size_bytes)} />
                 </span>
               </span>
             </button>
@@ -2187,6 +2218,9 @@ export function HubModelPicker({
   const [customSort, setCustomSort] = useState<LocalSortKey>("recent");
   // Format filter toggle for the Unsloth listing.
   const [formatFilter, setFormatFilter] = useState<FormatFilter>("all");
+  // MLX and Safetensors repos are one download, so a row can name its size.
+  const hubRowsShowSize =
+    formatFilter === "mlx" || formatFilter === "safetensors";
 
   // Recommended suggests GGUF anywhere; on Mac also MLX and safetensors. The
   // "recommended" sort also drops models too big for the device. Already-
@@ -4475,6 +4509,7 @@ export function HubModelPicker({
                               label={id}
                               hubUrl={hubRepoUrl(id)}
                               alignMeta="hub"
+                              showSize={hubRowsShowSize}
                               hideOwner={true}
                               downloaded={downloadedSet.has(id.toLowerCase())}
                               capabilities={capsById.get(id)}
@@ -4585,6 +4620,7 @@ export function HubModelPicker({
                             label={id}
                             hubUrl={hubRepoUrl(id)}
                             alignMeta="hub"
+                            showSize={hubRowsShowSize}
                             capabilities={capsById.get(id)}
                             meta={
                               isKnownGgufRepo(id)
@@ -4698,6 +4734,7 @@ export function HubModelPicker({
                               label={id}
                               hubUrl={hubRepoUrl(id)}
                               alignMeta="hub"
+                              showSize={hubRowsShowSize}
                               capabilities={capsById.get(id)}
                               meta={
                                 isSearchGguf

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -519,7 +519,9 @@ function ExpandChevron({ open }: { open: boolean }) {
   return (
     <span
       aria-hidden="true"
-      className="flex size-5 shrink-0 items-center justify-center text-muted-foreground/60"
+      // The chevron's glyph is wider than the dots menu's, so on its own at the
+      // end of a row it needs a nudge left to sit under it.
+      className="flex size-5 shrink-0 items-center justify-center text-muted-foreground/60 last:mr-1"
     >
       {open ? (
         <ChevronDownIcon className="size-3" />

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -514,24 +514,6 @@ function VramBadge({ status }: { status?: VramFitStatus | null }) {
 
 const SIZE_PARTS_RE = /^(~?)([\d.]+)\s*([A-Za-z]+)$/;
 
-/** Marks a row that opens into its quants. The row itself is the toggle. */
-function ExpandChevron({ open }: { open: boolean }) {
-  return (
-    <span
-      aria-hidden="true"
-      // The chevron's glyph is wider than the dots menu's, so on its own at the
-      // end of a row it needs a nudge left to sit under it.
-      className="flex size-5 shrink-0 items-center justify-center text-muted-foreground/60 last:mr-1"
-    >
-      {open ? (
-        <ChevronDownIcon className="size-3" />
-      ) : (
-        <ChevronRightIcon className="size-3" />
-      )}
-    </span>
-  );
-}
-
 /** A size in mono: the dot pulled in, a hair of air before the unit. */
 function SizeText({ value }: { value: string }) {
   const parts = SIZE_PARTS_RE.exec(value);
@@ -603,12 +585,10 @@ const META_COLUMN = {
 } as const;
 
 // One gutter for every row, gear or no gear, so the columns never shift by a
-// button. The gutter stays open; what sits in it shows on hover.
-const ROW_ACTIONS_BASE =
-  "mr-0.5 flex w-[38px] shrink-0 items-center justify-end -space-x-0.5";
-const ROW_HOVER_ONLY =
-  "opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100 has-[[data-state=open]]:opacity-100 [@media(hover:none)]:opacity-100";
-const ROW_ACTIONS_CLASS = `${ROW_ACTIONS_BASE} ${ROW_HOVER_ONLY}`;
+// button. The buttons show on the hovered row, or while their menu is open;
+// the gutter stays open so nothing moves as they appear.
+const ROW_ACTIONS_CLASS =
+  "mr-0.5 flex w-[38px] shrink-0 items-center justify-end -space-x-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100 group-focus-within:opacity-100 has-[[data-state=open]]:opacity-100 [@media(hover:none)]:opacity-100";
 
 function ModelRow({
   label,
@@ -630,7 +610,6 @@ function ModelRow({
   quantChip,
   alignMeta,
   showSize,
-  expander,
   className,
 }: {
   label: string;
@@ -665,9 +644,6 @@ function ModelRow({
   /** Hold the size column open. Hub rows pass this on the MLX and Safetensors
    *  filters, where a repo is one download with one size. */
   showSize?: boolean;
-  /** Trailing chevron for rows that open into their quants. "none" holds the
-   *  slot without a glyph, so a list of mixed rows still lines up. */
-  expander?: "open" | "closed" | "none";
   className?: string;
 }) {
   const exceeds = vramStatus === "exceeds";
@@ -848,11 +824,6 @@ function ModelRow({
             <SizeText value={parsed.size} />
           </span>
         ) : null}
-        {expander === undefined ? null : expander === "none" ? (
-          <span aria-hidden="true" className="size-5 shrink-0" />
-        ) : (
-          <ExpandChevron open={expander === "open"} />
-        )}
       </span>
     </button>
   );
@@ -3427,10 +3398,8 @@ export function HubModelPicker({
               className={downloadedRowButtonClassName}
             />
           </div>
-          {/* Sits where the other rows' buttons do, so the tags line up. */}
-          <span className={cn(ROW_ACTIONS_CLASS, "h-6 opacity-100")}>
-            <ExpandChevron open={expanderOpen} />
-          </span>
+          {/* Stands in for the other rows' buttons, so the tags line up. */}
+          <span aria-hidden="true" className={cn(ROW_ACTIONS_CLASS, "h-6")} />
         </div>
         {expanderOpen && (
           <GgufVariantExpander
@@ -4203,15 +4172,7 @@ export function HubModelPicker({
                                   vramStatus={null}
                                 />
                               </div>
-                              <span
-                                className={cn(
-                                  ROW_ACTIONS_CLASS,
-                                  isGguf && !isDirectGguf && "opacity-100",
-                                )}
-                              >
-                                {isGguf && !isDirectGguf ? (
-                                  <ExpandChevron open={isGgufExpanded(m.id)} />
-                                ) : null}
+                              <span className={ROW_ACTIONS_CLASS}>
                                 {isDirectGguf && onConfigure && (
                                   <ModelLoadSettingsAction
                                     ariaLabel={`Inference settings for ${
@@ -4342,15 +4303,7 @@ export function HubModelPicker({
                                   vramStatus={null}
                                 />
                               </div>
-                              <span
-                                className={cn(
-                                  ROW_ACTIONS_CLASS,
-                                  isGguf && !isGgufFile && "opacity-100",
-                                )}
-                              >
-                                {isGguf && !isGgufFile ? (
-                                  <ExpandChevron open={isGgufExpanded(m.id)} />
-                                ) : null}
+                              <span className={ROW_ACTIONS_CLASS}>
                                 {isGgufFile && onConfigure && (
                                   <ModelLoadSettingsAction
                                     ariaLabel={`Inference settings for ${
@@ -4469,15 +4422,7 @@ export function HubModelPicker({
                                   vramStatus={null}
                                 />
                               </div>
-                              <span
-                                className={cn(
-                                  ROW_ACTIONS_CLASS,
-                                  isGguf && !isGgufFile && "opacity-100",
-                                )}
-                              >
-                                {isGguf && !isGgufFile ? (
-                                  <ExpandChevron open={isGgufExpanded(m.id)} />
-                                ) : null}
+                              <span className={ROW_ACTIONS_CLASS}>
                                 {isGgufFile && onConfigure && (
                                   <ModelLoadSettingsAction
                                     ariaLabel={`Inference settings for ${
@@ -4557,13 +4502,6 @@ export function HubModelPicker({
                               hubUrl={hubRepoUrl(id)}
                               alignMeta="hub"
                               showSize={hubRowsShowSize}
-                              expander={
-                                isG
-                                  ? expandedGguf === id
-                                    ? "open"
-                                    : "closed"
-                                  : "none"
-                              }
                               hideOwner={true}
                               downloaded={downloadedSet.has(id.toLowerCase())}
                               capabilities={capsById.get(id)}
@@ -4675,13 +4613,6 @@ export function HubModelPicker({
                             hubUrl={hubRepoUrl(id)}
                             alignMeta="hub"
                             showSize={hubRowsShowSize}
-                            expander={
-                              isKnownGgufRepo(id)
-                                ? expandedGguf === id
-                                  ? "open"
-                                  : "closed"
-                                : "none"
-                            }
                             capabilities={capsById.get(id)}
                             meta={
                               isKnownGgufRepo(id)
@@ -4796,13 +4727,6 @@ export function HubModelPicker({
                               hubUrl={hubRepoUrl(id)}
                               alignMeta="hub"
                               showSize={hubRowsShowSize}
-                              expander={
-                                isSearchGguf
-                                  ? expandedGguf === id
-                                    ? "open"
-                                    : "closed"
-                                  : "none"
-                              }
                               capabilities={capsById.get(id)}
                               meta={
                                 isSearchGguf
@@ -5056,48 +4980,38 @@ function FineTunedRows({
                   alignMeta="device"
                 />
               </div>
-              <span className={ROW_ACTIONS_BASE}>
-                {isLocalGgufDir || isExportedGguf ? (
-                  <ExpandChevron open={expandedGguf === adapter.id} />
-                ) : null}
-                <span
-                  className={cn(
-                    "flex items-center -space-x-0.5",
-                    ROW_HOVER_ONLY,
-                  )}
-                >
-                  {canConfigure && onConfigure && (
-                    <ModelLoadSettingsAction
-                      ariaLabel={`Inference settings for ${adapter.name}`}
-                      onConfigure={() => onConfigure(adapter.id, selectionMeta)}
-                    />
-                  )}
-                  {canDelete && (
-                    <ModelDeleteAction
-                      ariaLabel={`Delete ${adapter.name}`}
-                      title="Delete fine-tuned model?"
-                      description={
-                        <>
-                          This will remove{" "}
-                          <span className="font-medium text-foreground">
-                            {adapter.name}
-                          </span>{" "}
-                          from disk. This cannot be undone.
-                        </>
-                      }
-                      successMessage={`Deleted ${adapter.name}`}
-                      disabled={deleteDisabled}
-                      onConfirm={() =>
-                        deleteFineTunedModel({
-                          modelPath: adapter.id,
-                          source: isExported ? "exported" : "training",
-                          exportType: adapter.exportType,
-                        })
-                      }
-                      onDeleted={() => onModelsChange?.({ id: adapter.id })}
-                    />
-                  )}
-                </span>
+              <span className={ROW_ACTIONS_CLASS}>
+                {canConfigure && onConfigure && (
+                  <ModelLoadSettingsAction
+                    ariaLabel={`Inference settings for ${adapter.name}`}
+                    onConfigure={() => onConfigure(adapter.id, selectionMeta)}
+                  />
+                )}
+                {canDelete && (
+                  <ModelDeleteAction
+                    ariaLabel={`Delete ${adapter.name}`}
+                    title="Delete fine-tuned model?"
+                    description={
+                      <>
+                        This will remove{" "}
+                        <span className="font-medium text-foreground">
+                          {adapter.name}
+                        </span>{" "}
+                        from disk. This cannot be undone.
+                      </>
+                    }
+                    successMessage={`Deleted ${adapter.name}`}
+                    disabled={deleteDisabled}
+                    onConfirm={() =>
+                      deleteFineTunedModel({
+                        modelPath: adapter.id,
+                        source: isExported ? "exported" : "training",
+                        exportType: adapter.exportType,
+                      })
+                    }
+                    onDeleted={() => onModelsChange?.({ id: adapter.id })}
+                  />
+                )}
               </span>
             </div>
             {expandedGguf === adapter.id && (

--- a/studio/frontend/src/features/model-picker/components/model-selector/row-meta.ts
+++ b/studio/frontend/src/features/model-picker/components/model-selector/row-meta.ts
@@ -33,6 +33,12 @@ export function splitRepoLabel(label: string): {
   return { owner: label.slice(0, slash), name: label.slice(slash + 1) };
 }
 
+/** Our own repos. Rows drop the "unsloth/" prefix, since nearly every model
+ *  listed is ours; the full repo id stays in the row tooltip. */
+export function isUnslothOwner(owner: string | null | undefined): boolean {
+  return owner?.toLowerCase() === "unsloth";
+}
+
 export type MetaToken =
   | { kind: "format"; label: string; tone: FormatTone }
   | { kind: "size"; label: string }

--- a/studio/frontend/tests/model-row-owner.test.ts
+++ b/studio/frontend/tests/model-row-owner.test.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+// Rows drop the "unsloth/" prefix but keep every other owner, which is what
+// tells the two apart.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  isUnslothOwner,
+  splitRepoLabel,
+} from "../src/features/model-picker/components/model-selector/row-meta.ts";
+
+test("unsloth is the owner whose prefix rows hide", () => {
+  assert.equal(
+    isUnslothOwner(splitRepoLabel("unsloth/gemma-4-26b").owner),
+    true,
+  );
+  // Case as the Hub listing returns it.
+  assert.equal(isUnslothOwner("Unsloth"), true);
+});
+
+test("other owners keep their prefix", () => {
+  assert.equal(isUnslothOwner(splitRepoLabel("Qwen/Qwen3-8B").owner), false);
+  assert.equal(isUnslothOwner("unsloth-community"), false);
+  // A bare model name has no owner to hide.
+  assert.equal(isUnslothOwner(splitRepoLabel("gemma-4-26b").owner), false);
+});


### PR DESCRIPTION
## What

The model picker packed each row's meta to the right at its natural width, so whatever a row happened to carry decided where its chips landed. A missing vision badge, a longer size string or the wider `Safetensors` tag slid everything on that row sideways, and rows holding a single quant on disk read as the worst of it: the quant chip sat wherever the badges left it.

Rows now share fixed columns, in one order across both lists:

```
[format dot] name [quant chip]   [badges] [params] [size]   [gear ⋮]
```

Widths are `em` of each slot's own text, so they follow the UI font scale rather than being pinned to 10px, and every badge column carries `min-w-min`. That last part matters: a width is the column held open, not a clamp. Recommended reports exact parameter counts, so `2779.5B` needs more room than On Device's `27B`, and under a hard width it painted straight over the `OOM` pill next to it. Now it widens its own slot and the rest of the row stays put. Below the picker's full width the slots collapse back to their content, so narrow windows stay compact.

## Also in here

- **Names drop the `unsloth/` prefix**, since nearly every model listed is ours, and the section is titled `Unsloth` rather than `Downloaded`. Other owners keep their prefix, which is what tells the two apart, and the full repo id stays in the row tooltip.
- **Format is a coloured dot ahead of the name**, named on hover and in the row tooltip, instead of a `GGUF` / `Safetensors` / `MLX` pill. The word was wide enough to shove the rest of the row around, and `Safetensors` was the only reason that column was ever wide.
- **Row actions show on hover** for the row the pointer is on, and stay put while their menu is open, in a gutter every row holds open so nothing shifts as they appear. The gear, dots menu and delete button now share one 20px hover box; they were 20px, 22px and 26px, and the last two overflowed the gutter on a fine-tuned row carrying both.
- **Sizes are mono**, with no space before the unit, the decimal point pulled in on both sides and a hair of air before the unit, so `4.7GB` reads as a number rather than three spaced tokens.
- **Recommended shows a size only where a row can name one.** A GGUF repo holds several quants, so it has no single size until you expand it, and the column was an empty gap on nearly every row. It stays out of the All and GGUF filters, and comes back on MLX and Safetensors, where a repo is one download with one size. An already downloaded repo is marked in green rather than grey.
- **Pinned quants render through `ModelRow`** rather than their own markup, which is what puts their chip in the same column as the rows below them.

Touch outside the picker is one line: the Hub catalog's dots trigger is pinned to `size-8`, since it was getting its box from padding that the shared button no longer applies.

## Testing

`npm run typecheck`, `npm run build` and `npm test` (302 passing, including two new cases covering which owner gets dropped from a row name).
