### PR TITLE
Linux/macOS: tell an unreadable llama.cpp install apart from someone else's

### DIFF
--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -608,6 +608,39 @@ _studio_owned_adoptable() {
     [ -f "$1/UNSLOTH_WHISPER_PREBUILT_INFO.json" ] && return 0
     return 1
 }
+# A directory we cannot search. Every probe inside one reports "absent", so an
+# install that is ours reads as somebody else's. Search (+x) is the permission
+# the marker probes need; read (+r) is not enough and not required.
+_studio_dir_unsearchable() {
+    [ -d "$1" ] || return 1
+    ( cd "$1" ) 2>/dev/null && return 1
+    return 0
+}
+
+# Mirrors Exit-PathAccessDenied in setup.ps1. Pass owner-unverified when the
+# caller could not read the marker, so it cannot claim the tree is ours either
+# and must not tell the user to delete it.
+_path_access_denied() {
+    _pad_dir="$1"
+    _pad_label="$2"
+    _pad_mode="${3:-}"
+    step "permissions" "$_pad_label at $_pad_dir cannot be read: permission denied" "$C_ERR"
+    if [ "$_pad_mode" = "owner-unverified" ]; then
+        substep "Unsloth cannot confirm this folder is its own install while it is unreadable, so it will not tell you to remove it" "$C_WARN"
+        substep "Restore access, or move the folder aside, then re-run setup:" "$C_WARN"
+    else
+        substep "This folder lives outside the app, so reinstalling Unsloth Studio reuses it and fails the same way" "$C_WARN"
+        substep "Simplest fix: delete or rename $_pad_dir, then re-run setup (it is a managed cache and gets reinstalled)" "$C_WARN"
+        substep "If deleting is denied too, it belongs to another user; restore access with:" "$C_WARN"
+    fi
+    substep "ls -ld \"$_pad_dir\"" "$C_WARN"
+    substep "chmod -R u+rwX \"$_pad_dir\"" "$C_WARN"
+    if [ "$_pad_mode" = "owner-unverified" ]; then
+        setup_fail 1 "Permission denied reading $_pad_label at $_pad_dir. Unsloth cannot confirm that folder is its own install while it is unreadable: restore access, or move it aside, then re-run setup."
+    fi
+    setup_fail 1 "Permission denied reading the existing $_pad_label at $_pad_dir. Delete or rename that folder (Unsloth reinstalls it) or restore access, then re-run setup. Reinstalling the app does not reset it."
+}
+
 _assert_studio_owned_or_absent() {
     _aso_dir="$1"
     _aso_label="$2"
@@ -616,6 +649,11 @@ _assert_studio_owned_or_absent() {
         if _studio_owned_adoptable "$_aso_dir"; then
             : > "$_aso_dir/$_STUDIO_OWNED_MARKER" 2>/dev/null || true
             return 0
+        fi
+        # An unsearchable tree hides its own marker, so it is indistinguishable
+        # here from somebody else's folder. Report the permissions, not ownership.
+        if _studio_dir_unsearchable "$_aso_dir"; then
+            _path_access_denied "$_aso_dir" "$_aso_label" owner-unverified
         fi
         echo "ERROR: $_aso_dir already exists and is not marked as an Unsloth-owned $_aso_label." >&2
         echo "       Move it aside or choose an empty UNSLOTH_STUDIO_HOME before re-running." >&2
@@ -1444,7 +1482,14 @@ if [ -n "${UNSLOTH_LOCAL_LLAMA_CPP_DIR:-}" ]; then
         if [ "$_STUDIO_HOME_IS_CUSTOM" = true ]; then
             _assert_studio_owned_or_absent "$LLAMA_CPP_DIR" "llama.cpp install"
         fi
-        rm -rf "$LLAMA_CPP_DIR"
+        rm -rf "$LLAMA_CPP_DIR" 2>/dev/null || true
+        if [ -e "$LLAMA_CPP_DIR" ]; then
+            if _studio_dir_unsearchable "$LLAMA_CPP_DIR"; then
+                _path_access_denied "$LLAMA_CPP_DIR" "llama.cpp install"
+            fi
+            step "llama.cpp" "the existing install could not be replaced with a link" "$C_ERR"
+            setup_fail 3 "$LLAMA_CPP_DIR could not be replaced with a link to $_RESOLVED_LOCAL."
+        fi
         ln -sfn "$_RESOLVED_LOCAL" "$LLAMA_CPP_DIR"
         _link_local_llama_quantize_shim "$LLAMA_CPP_DIR"
         step "llama.cpp" "linked local directory: $_RESOLVED_LOCAL"
@@ -2140,7 +2185,16 @@ else
         # Swap only after build succeeds -- preserves existing install on failure
         if [ "$BUILD_OK" = true ]; then
             _assert_studio_owned_or_absent "$LLAMA_CPP_DIR" "llama.cpp install"
-            rm -rf "$LLAMA_CPP_DIR"
+            # Without this the raw rm error aborts under errexit and the desktop
+            # app shows a bare exit code, with the fresh build silently stranded.
+            rm -rf "$LLAMA_CPP_DIR" 2>/dev/null || true
+            if [ -e "$LLAMA_CPP_DIR" ]; then
+                if _studio_dir_unsearchable "$LLAMA_CPP_DIR"; then
+                    _path_access_denied "$LLAMA_CPP_DIR" "llama.cpp install"
+                fi
+                step "llama.cpp" "built, but the existing install could not be replaced" "$C_ERR"
+                setup_fail 3 "The llama.cpp build succeeded but $LLAMA_CPP_DIR could not be replaced. The new build is at $_BUILD_TMP."
+            fi
             mv "$_BUILD_TMP" "$LLAMA_CPP_DIR"
             : > "$LLAMA_CPP_DIR/$_STUDIO_OWNED_MARKER" 2>/dev/null || true
             # Symlink to llama.cpp root -- check_llama_cpp() looks for the binary there

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -608,18 +608,16 @@ _studio_owned_adoptable() {
     [ -f "$1/UNSLOTH_WHISPER_PREBUILT_INFO.json" ] && return 0
     return 1
 }
-# A directory we cannot search. Every probe inside one reports "absent", so an
-# install that is ours reads as somebody else's. Search (+x) is the permission
-# the marker probes need; read (+r) is not enough and not required.
+# Search (+x), not read (+r), is what the marker probes need: inside a directory
+# we cannot search every probe reports absent, so our own install reads as someone else's.
 _studio_dir_unsearchable() {
     [ -d "$1" ] || return 1
     ( cd "$1" ) 2>/dev/null && return 1
     return 0
 }
 
-# Mirrors Exit-PathAccessDenied in setup.ps1. Pass owner-unverified when the
-# caller could not read the marker, so it cannot claim the tree is ours either
-# and must not tell the user to delete it.
+# Mirrors Exit-PathAccessDenied in setup.ps1. owner-unverified means the marker
+# was unreadable, so do not claim the tree is ours or advise deleting it.
 _path_access_denied() {
     _pad_dir="$1"
     _pad_label="$2"
@@ -650,8 +648,8 @@ _assert_studio_owned_or_absent() {
             : > "$_aso_dir/$_STUDIO_OWNED_MARKER" 2>/dev/null || true
             return 0
         fi
-        # An unsearchable tree hides its own marker, so it is indistinguishable
-        # here from somebody else's folder. Report the permissions, not ownership.
+        # An unsearchable tree hides its own marker and so looks like someone else's:
+        # report permissions, not ownership.
         if _studio_dir_unsearchable "$_aso_dir"; then
             _path_access_denied "$_aso_dir" "$_aso_label" owner-unverified
         fi
@@ -2185,9 +2183,8 @@ else
         # Swap only after build succeeds -- preserves existing install on failure
         if [ "$BUILD_OK" = true ]; then
             _assert_studio_owned_or_absent "$LLAMA_CPP_DIR" "llama.cpp install"
-            # Without the || true the raw rm error aborts under errexit and the
-            # desktop app shows a bare exit code, with the fresh build stranded.
-            # stderr is kept: rm names the exact subpath, which we cannot.
+            # || true: without it a raw rm error aborts under errexit to a bare exit
+            # code, build stranded. Keep stderr: rm names the exact subpath, we cannot.
             rm -rf "$LLAMA_CPP_DIR" || true
             if [ -e "$LLAMA_CPP_DIR" ]; then
                 if _studio_dir_unsearchable "$LLAMA_CPP_DIR"; then

--- a/studio/setup.sh
+++ b/studio/setup.sh
@@ -1482,7 +1482,7 @@ if [ -n "${UNSLOTH_LOCAL_LLAMA_CPP_DIR:-}" ]; then
         if [ "$_STUDIO_HOME_IS_CUSTOM" = true ]; then
             _assert_studio_owned_or_absent "$LLAMA_CPP_DIR" "llama.cpp install"
         fi
-        rm -rf "$LLAMA_CPP_DIR" 2>/dev/null || true
+        rm -rf "$LLAMA_CPP_DIR" || true
         if [ -e "$LLAMA_CPP_DIR" ]; then
             if _studio_dir_unsearchable "$LLAMA_CPP_DIR"; then
                 _path_access_denied "$LLAMA_CPP_DIR" "llama.cpp install"
@@ -2185,9 +2185,10 @@ else
         # Swap only after build succeeds -- preserves existing install on failure
         if [ "$BUILD_OK" = true ]; then
             _assert_studio_owned_or_absent "$LLAMA_CPP_DIR" "llama.cpp install"
-            # Without this the raw rm error aborts under errexit and the desktop
-            # app shows a bare exit code, with the fresh build silently stranded.
-            rm -rf "$LLAMA_CPP_DIR" 2>/dev/null || true
+            # Without the || true the raw rm error aborts under errexit and the
+            # desktop app shows a bare exit code, with the fresh build stranded.
+            # stderr is kept: rm names the exact subpath, which we cannot.
+            rm -rf "$LLAMA_CPP_DIR" || true
             if [ -e "$LLAMA_CPP_DIR" ]; then
                 if _studio_dir_unsearchable "$LLAMA_CPP_DIR"; then
                     _path_access_denied "$LLAMA_CPP_DIR" "llama.cpp install"

--- a/tests/sh/test_setup_sh_denied_install_tree.sh
+++ b/tests/sh/test_setup_sh_denied_install_tree.sh
@@ -1,17 +1,13 @@
 #!/bin/bash
-# studio/setup.sh must tell an unreadable install tree apart from somebody
-# else's install, and must not abort with a raw rm error when it cannot replace
-# one. setup.ps1 learned both in #7735/#7757; this is the POSIX side.
+# studio/setup.sh must tell an unreadable install tree apart from somebody else's,
+# and must not abort with a raw rm error when it cannot replace one. setup.ps1
+# learned both in #7735/#7757; this is the POSIX side.
 #
-# The failure this pins: a tree that IS ours, carrying our own marker, becomes
-# unsearchable (left owned by another user, say). Every probe inside it reports
-# "absent", so the ownership guard reported "not marked as an Unsloth-owned
-# install. Move it aside or choose an empty UNSLOTH_STUDIO_HOME" -- the wrong
-# cause and the wrong remedy, since the fix is a permission change.
-#
-# Search (+x) is the permission the marker probes need. A directory can be
-# readable and still unsearchable (mode 444), and searchable but unreadable
-# (mode 111), so the probe must test search, not read.
+# Pins: a tree that IS ours goes unsearchable, every probe inside reports "absent",
+# and the ownership guard blamed ownership ("Move it aside or choose an empty
+# UNSLOTH_STUDIO_HOME") when the fix is a permission change. The marker probes need
+# search (+x), and a directory can be readable but unsearchable (444) or the reverse
+# (111), so probe search, not read.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -30,8 +26,8 @@ echo "=== setup.sh: the guards exist and probe the right permission ==="
 
 assert_contains "defines the unsearchable-directory probe" \
     "$SETUP_SH" "_studio_dir_unsearchable() {"
-# cd needs +x, which is exactly what a probe of a named child needs. ls needs
-# +r, which is neither sufficient nor necessary, so pin the cd form.
+# cd needs +x, exactly what the marker probes need; ls needs +r, which is neither
+# sufficient nor necessary. Pin the cd form.
 assert_contains "the probe tests search (cd), not read (ls)" \
     "$SETUP_SH" '( cd "$1" ) 2>/dev/null && return 1'
 assert_contains "defines the denial reporter" \
@@ -44,15 +40,14 @@ assert_contains "an unverifiable tree is never described as not ours" \
 echo ""
 echo "=== setup.sh: neither destructive replace runs blind ==="
 
-# rm -rf failing under errexit aborts with a raw "Permission denied" and no
-# [TAURI:ERROR], so the desktop app shows a bare exit code.
+# A failing rm -rf under errexit aborts with no [TAURI:ERROR], so the desktop app
+# shows a bare exit code.
 if [ "$(grep -c 'rm -rf "$LLAMA_CPP_DIR" || true' "$SETUP_SH")" -ge 2 ]; then
     ok "both replace sites tolerate a failing rm instead of aborting raw"
 else
     bad "both replace sites tolerate a failing rm instead of aborting raw"
 fi
-# rm names the exact subpath that refused to go; the messages below can only
-# name the install root, so discarding its stderr loses the useful half.
+# rm names the exact failing subpath; our messages can only name the install root.
 if grep -q 'rm -rf "$LLAMA_CPP_DIR" 2>/dev/null' "$SETUP_SH"; then
     bad "the failing rm keeps its stderr"
 else
@@ -79,8 +74,7 @@ echo "=== behaviour against a genuinely unsearchable tree ==="
 WORK="$(mktemp -d)"
 trap 'chmod -R u+rwX "$WORK" 2>/dev/null; rm -rf "$WORK"' EXIT
 
-# Pull the real functions out of setup.sh; it executes install steps at load,
-# so it cannot be sourced whole.
+# setup.sh runs install steps at load, so extract the real functions instead.
 python3 - "$SETUP_SH" "$WORK/helpers.sh" <<'PY'
 import sys, pathlib
 src = pathlib.Path(sys.argv[1]).read_text()
@@ -121,8 +115,7 @@ case "$out" in
 esac
 
 chmod 000 "$OURS"
-# Environment gate and negative control in one: if the host cannot deny (root),
-# the checks below would pass vacuously.
+# Gate and negative control in one: as root the checks below pass vacuously.
 if [ -f "$OURS/.unsloth-studio-owned" ]; then
     echo "  SKIP: this host cannot make a directory unsearchable (running as root?)"
 else

--- a/tests/sh/test_setup_sh_denied_install_tree.sh
+++ b/tests/sh/test_setup_sh_denied_install_tree.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# studio/setup.sh must tell an unreadable install tree apart from somebody
+# else's install, and must not abort with a raw rm error when it cannot replace
+# one. setup.ps1 learned both in #7735/#7757; this is the POSIX side.
+#
+# The failure this pins: a tree that IS ours, carrying our own marker, becomes
+# unsearchable (left owned by another user, say). Every probe inside it reports
+# "absent", so the ownership guard reported "not marked as an Unsloth-owned
+# install. Move it aside or choose an empty UNSLOTH_STUDIO_HOME" -- the wrong
+# cause and the wrong remedy, since the fix is a permission change.
+#
+# Search (+x) is the permission the marker probes need. A directory can be
+# readable and still unsearchable (mode 444), and searchable but unreadable
+# (mode 111), so the probe must test search, not read.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SETUP_SH="$SCRIPT_DIR/../../studio/setup.sh"
+PASS=0
+FAIL=0
+
+ok()   { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+bad()  { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+assert_contains() {
+    if grep -qF -- "$3" "$2"; then ok "$1"; else bad "$1 (expected '$3')"; fi
+}
+
+echo ""
+echo "=== setup.sh: the guards exist and probe the right permission ==="
+
+assert_contains "defines the unsearchable-directory probe" \
+    "$SETUP_SH" "_studio_dir_unsearchable() {"
+# cd needs +x, which is exactly what a probe of a named child needs. ls needs
+# +r, which is neither sufficient nor necessary, so pin the cd form.
+assert_contains "the probe tests search (cd), not read (ls)" \
+    "$SETUP_SH" '( cd "$1" ) 2>/dev/null && return 1'
+assert_contains "defines the denial reporter" \
+    "$SETUP_SH" "_path_access_denied() {"
+assert_contains "the ownership guard checks readability before blaming ownership" \
+    "$SETUP_SH" '_path_access_denied "$_aso_dir" "$_aso_label" owner-unverified'
+assert_contains "an unverifiable tree is never described as not ours" \
+    "$SETUP_SH" "Unsloth cannot confirm this folder is its own install while it is unreadable"
+
+echo ""
+echo "=== setup.sh: neither destructive replace runs blind ==="
+
+# rm -rf failing under errexit aborts with a raw "Permission denied" and no
+# [TAURI:ERROR], so the desktop app shows a bare exit code.
+if [ "$(grep -c 'rm -rf "$LLAMA_CPP_DIR" 2>/dev/null || true' "$SETUP_SH")" -ge 2 ]; then
+    ok "both replace sites tolerate a failing rm instead of aborting raw"
+else
+    bad "both replace sites tolerate a failing rm instead of aborting raw"
+fi
+if [ "$(grep -c 'if \[ -e "$LLAMA_CPP_DIR" \]; then' "$SETUP_SH")" -ge 2 ]; then
+    ok "both replace sites check the postcondition"
+else
+    bad "both replace sites check the postcondition"
+fi
+assert_contains "a stranded build reports where it was left" \
+    "$SETUP_SH" 'The new build is at $_BUILD_TMP.'
+assert_contains "a bare rm -rf of the install dir is gone" \
+    "$SETUP_SH" 'rm -rf "$LLAMA_CPP_DIR" 2>/dev/null || true'
+if grep -qE '^\s*rm -rf "\$LLAMA_CPP_DIR"\s*$' "$SETUP_SH"; then
+    bad "no unguarded rm -rf of the install dir remains"
+else
+    ok "no unguarded rm -rf of the install dir remains"
+fi
+
+echo ""
+echo "=== behaviour against a genuinely unsearchable tree ==="
+
+WORK="$(mktemp -d)"
+trap 'chmod -R u+rwX "$WORK" 2>/dev/null; rm -rf "$WORK"' EXIT
+
+# Pull the real functions out of setup.sh; it executes install steps at load,
+# so it cannot be sourced whole.
+python3 - "$SETUP_SH" "$WORK/helpers.sh" <<'PY'
+import sys, pathlib
+src = pathlib.Path(sys.argv[1]).read_text()
+out = []
+for name in ("_studio_owned_adoptable", "_studio_dir_unsearchable",
+             "_path_access_denied", "_assert_studio_owned_or_absent"):
+    i = src.index(name + "() {")
+    out.append(src[i:src.index("\n}\n", i) + 3])
+pathlib.Path(sys.argv[2]).write_text("\n".join(out))
+PY
+
+cat > "$WORK/drive.sh" <<'EOF'
+set -uo pipefail
+C_ERR= C_WARN= C_DIM= C_OK= C_RST=
+step()    { printf 'STEP|%s|%s\n' "$1" "$2"; }
+substep() { printf 'SUBSTEP|%s\n' "$1"; }
+setup_fail() { printf 'FAIL|%s|%s\n' "$1" "$2"; exit "$1"; }
+_STUDIO_OWNED_MARKER=".unsloth-studio-owned"
+_STUDIO_HOME_IS_CUSTOM=true
+. "$1"
+_assert_studio_owned_or_absent "$2" "llama.cpp install"
+echo "ACCEPTED"
+EOF
+
+OURS="$WORK/ours"; mkdir -p "$OURS"; : > "$OURS/.unsloth-studio-owned"
+THEIRS="$WORK/theirs"; mkdir -p "$THEIRS"; : > "$THEIRS/someone-elses.txt"
+
+out=$(bash "$WORK/drive.sh" "$WORK/helpers.sh" "$OURS" 2>&1)
+case "$out" in
+    *ACCEPTED*) ok "a readable tree of ours is still accepted" ;;
+    *) bad "a readable tree of ours is still accepted (got: $out)" ;;
+esac
+
+out=$(bash "$WORK/drive.sh" "$WORK/helpers.sh" "$THEIRS" 2>&1)
+case "$out" in
+    *"not marked as an Unsloth-owned"*) ok "an unowned readable tree still stops on ownership" ;;
+    *) bad "an unowned readable tree still stops on ownership (got: $out)" ;;
+esac
+
+chmod 000 "$OURS"
+# Environment gate and negative control in one: if the host cannot deny (root),
+# the checks below would pass vacuously.
+if [ -f "$OURS/.unsloth-studio-owned" ]; then
+    echo "  SKIP: this host cannot make a directory unsearchable (running as root?)"
+else
+    ok "the host really cannot search the tree (negative control)"
+    out=$(bash "$WORK/drive.sh" "$WORK/helpers.sh" "$OURS" 2>&1)
+    case "$out" in
+        *"cannot be read: permission denied"*) ok "an unreadable tree reports permissions" ;;
+        *) bad "an unreadable tree reports permissions (got: $out)" ;;
+    esac
+    case "$out" in
+        *"not marked as an Unsloth-owned"*) bad "it must not also blame ownership" ;;
+        *) ok "it does not blame ownership" ;;
+    esac
+    case "$out" in
+        *"delete or rename"*|*"Delete or rename"*) bad "it must not advise deleting an unverified tree" ;;
+        *) ok "it does not advise deleting an unverified tree" ;;
+    esac
+fi
+chmod 755 "$OURS"
+
+echo ""
+echo "=== Results ==="
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+if [ "$FAIL" -gt 0 ]; then echo "FAILED"; exit 1; fi
+echo "ALL PASSED"

--- a/tests/sh/test_setup_sh_denied_install_tree.sh
+++ b/tests/sh/test_setup_sh_denied_install_tree.sh
@@ -46,10 +46,17 @@ echo "=== setup.sh: neither destructive replace runs blind ==="
 
 # rm -rf failing under errexit aborts with a raw "Permission denied" and no
 # [TAURI:ERROR], so the desktop app shows a bare exit code.
-if [ "$(grep -c 'rm -rf "$LLAMA_CPP_DIR" 2>/dev/null || true' "$SETUP_SH")" -ge 2 ]; then
+if [ "$(grep -c 'rm -rf "$LLAMA_CPP_DIR" || true' "$SETUP_SH")" -ge 2 ]; then
     ok "both replace sites tolerate a failing rm instead of aborting raw"
 else
     bad "both replace sites tolerate a failing rm instead of aborting raw"
+fi
+# rm names the exact subpath that refused to go; the messages below can only
+# name the install root, so discarding its stderr loses the useful half.
+if grep -q 'rm -rf "$LLAMA_CPP_DIR" 2>/dev/null' "$SETUP_SH"; then
+    bad "the failing rm keeps its stderr"
+else
+    ok "the failing rm keeps its stderr"
 fi
 if [ "$(grep -c 'if \[ -e "$LLAMA_CPP_DIR" \]; then' "$SETUP_SH")" -ge 2 ]; then
     ok "both replace sites check the postcondition"
@@ -59,7 +66,7 @@ fi
 assert_contains "a stranded build reports where it was left" \
     "$SETUP_SH" 'The new build is at $_BUILD_TMP.'
 assert_contains "a bare rm -rf of the install dir is gone" \
-    "$SETUP_SH" 'rm -rf "$LLAMA_CPP_DIR" 2>/dev/null || true'
+    "$SETUP_SH" 'rm -rf "$LLAMA_CPP_DIR" || true'
 if grep -qE '^\s*rm -rf "\$LLAMA_CPP_DIR"\s*$' "$SETUP_SH"; then
     bad "no unguarded rm -rf of the install dir remains"
 else


### PR DESCRIPTION
`setup.ps1` learned to handle an unreadable llama.cpp install in #7735 and #7757. `setup.sh` never did, and it fails differently rather than better: POSIX probes return false instead of throwing, so the failure is a wrong answer rather than a crash.

## An install that is ours reads as somebody else's

`_assert_studio_owned_or_absent` decides ownership by probing for `.unsloth-studio-owned` inside the tree. A directory that cannot be searched reports every child absent, so a tree that IS ours, with our marker sitting in it, produces:

```
ERROR: <dir> already exists and is not marked as an Unsloth-owned llama.cpp install.
       Move it aside or choose an empty UNSLOTH_STUDIO_HOME before re-running.
```

Wrong cause and wrong remedy: nothing needs moving aside, the permissions need fixing. Driving the real function against the same directory before and after a `chmod 000` shows it flip from accepted to rejected with no change to its contents. This is the same misdiagnosis `Get-StudioAdoptableState` had on Windows until #7757.

Search (`+x`) is the permission those probes need, not read (`+r`), and the two are independent:

| mode | `[ -f dir/marker ]` | `( cd dir )` | `ls -A dir` |
|---|---|---|---|
| 000 | false | fail | fail |
| 111 | true | ok | fail |
| 444 | false | fail | ok |
| 755 | true | ok | ok |

A read probe would be wrong in both directions, so the new helper tests search.

## Both destructive replaces ran blind

```sh
rm -rf "$LLAMA_CPP_DIR"
mv "$_BUILD_TMP" "$LLAMA_CPP_DIR"
```

and the `--with-llama-cpp-dir` equivalent with `ln -sfn`. Neither checked that the remove worked. Under `set -euo pipefail` a failing `rm -rf` aborts on a raw

```
/bin/rm: cannot remove '<dir>/...': Permission denied
```

with no `[TAURI:ERROR]`, so the desktop app shows a bare exit code with no reason, and a llama.cpp build that just succeeded is left in `$_BUILD_TMP` with nothing saying where. That is the same user-visible symptom #7735 removed on Windows.

Both sites now tolerate the failed remove, check the directory is actually gone, and report either the permission problem or where the new build was left. A build that succeeded but could not be installed exits 3, matching the Windows side; `setup.sh` already uses that code.

Neither new message tells the user to delete a folder Unsloth cannot prove is its own, which is the rule the Windows guard follows.

## Tests

`tests/sh/test_setup_sh_denied_install_tree.sh`, 16 checks: static anchors for both guards, plus behaviour driven against a real `chmod 000` tree using the functions extracted from `setup.sh` itself. It asserts a readable tree of ours is still accepted, an unowned readable tree still stops on ownership exactly as before, and an unreadable tree reports permissions without blaming ownership or advising deletion. It carries a negative control that skips rather than passing vacuously if the host cannot make a directory unsearchable.

Each guard was mutation-tested and is load-bearing:

| mutation | result |
|---|---|
| drop the readability check from the ownership guard | red |
| probe read (`ls`) instead of search (`cd`) | red |
| drop the swap postcondition | red |
| advise deleting an unverified tree | red |

Windows is untouched. `bash -n` clean, and the shell suite runs 31 files with only the pre-existing `test_install_host_defaults.sh` failure, which is unrelated and already quarantined in `tests/run_all.sh`.
