### PR TITLE
Fix the model-config Playwright driver for the collapsed single-quant row

### DIFF
--- a/tests/studio/playwright_model_config.py
+++ b/tests/studio/playwright_model_config.py
@@ -400,15 +400,9 @@ with sync_playwright() as p:
         page.wait_for_timeout(800)
         return row
 
-    # The collapsed single-quant row appears only once the picker's sole-quant
-    # probe lands, and that is a real /api/hub/gguf-variants fetch restarted on
-    # every reload. Until then the row carries no gear, so "no gear" means either
-    # a multi-quant repo or a probe still in flight. Waiting instead of sleeping
-    # keeps a slow probe from being read as multi-quant.
-    # Same budget the rest of this driver allows a slow page (open_picker, the
-    # networkidle waits). A pending probe and a genuine multi-quant repo render
-    # through the same branch, so there is no DOM state to wait on instead; only
-    # a multi-quant repo pays this, and it pays it once per open_config.
+    # The collapsed sole-quant row appears only after an async probe lands, so an absent
+    # gear means either a multi-quant repo or a probe in flight, with no DOM state to
+    # tell them apart. Only a multi-quant repo pays the full wait, once per open_config.
     SOLE_QUANT_SETTLE_MS = 30_000
 
     def row_gear(
@@ -416,9 +410,8 @@ with sync_playwright() as p:
         hint,
         timeout_ms = SOLE_QUANT_SETTLE_MS,
     ):
-        # The gear is a sibling of the row, not inside [data-model-picker-option],
-        # so scope it by the repo id its aria-label carries. Matched
-        # case-insensitively, like the has_text lookup that found the row.
+        # The gear is a sibling of the row, not inside [data-model-picker-option], so
+        # scope it by repo id; case-insensitive to match the has_text row lookup.
         gear = popover.get_by_role(
             "button",
             name = re.compile(f"^Inference settings for .*{re.escape(hint)}", re.IGNORECASE),
@@ -432,17 +425,15 @@ with sync_playwright() as p:
     def open_config(popover, hint):
         if reveal_on_device_row(popover, hint) is None:
             return None
-        # A repo with one quant on disk renders as a single collapsed row whose
-        # click selects the model and closes the picker, so its gear has to be
-        # clicked without touching the row. A multi-quant repo still shows its
-        # gears only once the row is expanded.
+        # A sole-quant repo is a collapsed row whose click selects the model and closes
+        # the picker, so click its gear without touching the row; a multi-quant repo
+        # shows gears only once the row is expanded.
         gear = row_gear(popover, hint)
         if gear is None:
             if select_on_device_row(popover, hint) is None:
                 return None
             if not popover.is_visible():
-                # The probe landed while the row was being clicked, so the click
-                # hit the collapsed row and selected the model. Reopen and use
+                # The probe landed mid-click, so the row selected the model; reopen for
                 # the gear that is now there.
                 popover = open_picker()
                 if reveal_on_device_row(popover, hint) is None:

--- a/tests/studio/playwright_model_config.py
+++ b/tests/studio/playwright_model_config.py
@@ -405,7 +405,11 @@ with sync_playwright() as p:
     # every reload. Until then the row carries no gear, so "no gear" means either
     # a multi-quant repo or a probe still in flight. Waiting instead of sleeping
     # keeps a slow probe from being read as multi-quant.
-    SOLE_QUANT_SETTLE_MS = 6_000
+    # Same budget the rest of this driver allows a slow page (open_picker, the
+    # networkidle waits). A pending probe and a genuine multi-quant repo render
+    # through the same branch, so there is no DOM state to wait on instead; only
+    # a multi-quant repo pays this, and it pays it once per open_config.
+    SOLE_QUANT_SETTLE_MS = 30_000
 
     def row_gear(
         popover,
@@ -413,9 +417,11 @@ with sync_playwright() as p:
         timeout_ms = SOLE_QUANT_SETTLE_MS,
     ):
         # The gear is a sibling of the row, not inside [data-model-picker-option],
-        # so scope it by the repo id its aria-label carries.
-        gear = popover.locator(
-            f'button[aria-label^="Inference settings for"][aria-label*="{hint}"]'
+        # so scope it by the repo id its aria-label carries. Matched
+        # case-insensitively, like the has_text lookup that found the row.
+        gear = popover.get_by_role(
+            "button",
+            name = re.compile(f"^Inference settings for .*{re.escape(hint)}", re.IGNORECASE),
         ).first
         try:
             gear.wait_for(state = "visible", timeout = timeout_ms)

--- a/tests/studio/playwright_model_config.py
+++ b/tests/studio/playwright_model_config.py
@@ -400,13 +400,24 @@ with sync_playwright() as p:
         page.wait_for_timeout(800)
         return row
 
-    def row_gear(popover, hint):
+    # The collapsed single-quant row appears only once the picker's sole-quant
+    # probe lands, and that is a real /api/hub/gguf-variants fetch restarted on
+    # every reload. Until then the row carries no gear, so "no gear" means either
+    # a multi-quant repo or a probe still in flight. Waiting instead of sleeping
+    # keeps a slow probe from being read as multi-quant.
+    SOLE_QUANT_SETTLE_MS = 6_000
+
+    def row_gear(popover, hint, timeout_ms = SOLE_QUANT_SETTLE_MS):
         # The gear is a sibling of the row, not inside [data-model-picker-option],
         # so scope it by the repo id its aria-label carries.
         gear = popover.locator(
             f'button[aria-label^="Inference settings for"][aria-label*="{hint}"]'
         ).first
-        return gear if _count(gear) else None
+        try:
+            gear.wait_for(state = "visible", timeout = timeout_ms)
+        except Exception:
+            return None
+        return gear
 
     def open_config(popover, hint):
         if reveal_on_device_row(popover, hint) is None:
@@ -419,6 +430,13 @@ with sync_playwright() as p:
         if gear is None:
             if select_on_device_row(popover, hint) is None:
                 return None
+            if not popover.is_visible():
+                # The probe landed while the row was being clicked, so the click
+                # hit the collapsed row and selected the model. Reopen and use
+                # the gear that is now there.
+                popover = open_picker()
+                if reveal_on_device_row(popover, hint) is None:
+                    return None
             gear = row_gear(popover, hint)
         if gear is None:
             return None

--- a/tests/studio/playwright_model_config.py
+++ b/tests/studio/playwright_model_config.py
@@ -375,7 +375,8 @@ with sync_playwright() as p:
         except Exception:
             pass
 
-    def select_on_device_row(popover, hint):
+    def reveal_on_device_row(popover, hint):
+        """Bring the row into view without clicking it."""
         od = page.get_by_role("tab", name = "On Device").first
         if _count(od):
             od.click()
@@ -389,17 +390,37 @@ with sync_playwright() as p:
                 search.fill(hint)
                 page.wait_for_timeout(700)
                 row = popover.locator("[data-model-picker-option]", has_text = hint).first
-        if _count(row) == 0:
+        return row if _count(row) else None
+
+    def select_on_device_row(popover, hint):
+        row = reveal_on_device_row(popover, hint)
+        if row is None:
             return None
         row.click()
         page.wait_for_timeout(800)
         return row
 
+    def row_gear(popover, hint):
+        # The gear is a sibling of the row, not inside [data-model-picker-option],
+        # so scope it by the repo id its aria-label carries.
+        gear = popover.locator(
+            f'button[aria-label^="Inference settings for"][aria-label*="{hint}"]'
+        ).first
+        return gear if _count(gear) else None
+
     def open_config(popover, hint):
-        if select_on_device_row(popover, hint) is None:
+        if reveal_on_device_row(popover, hint) is None:
             return None
-        gear = popover.locator('button[aria-label^="Inference settings for"]').first
-        if _count(gear) == 0:
+        # A repo with one quant on disk renders as a single collapsed row whose
+        # click selects the model and closes the picker, so its gear has to be
+        # clicked without touching the row. A multi-quant repo still shows its
+        # gears only once the row is expanded.
+        gear = row_gear(popover, hint)
+        if gear is None:
+            if select_on_device_row(popover, hint) is None:
+                return None
+            gear = row_gear(popover, hint)
+        if gear is None:
             return None
         gear.click()
         page.wait_for_timeout(800)

--- a/tests/studio/playwright_model_config.py
+++ b/tests/studio/playwright_model_config.py
@@ -407,7 +407,11 @@ with sync_playwright() as p:
     # keeps a slow probe from being read as multi-quant.
     SOLE_QUANT_SETTLE_MS = 6_000
 
-    def row_gear(popover, hint, timeout_ms = SOLE_QUANT_SETTLE_MS):
+    def row_gear(
+        popover,
+        hint,
+        timeout_ms = SOLE_QUANT_SETTLE_MS,
+    ):
         # The gear is a sibling of the row, not inside [data-model-picker-option],
         # so scope it by the repo id its aria-label carries.
         gear = popover.locator(


### PR DESCRIPTION
`Chat UI Tests` has been red on `main` since #7736, so every PR since has carried a red check that has nothing to do with it.

## What broke

#7736 made a GGUF repo with a single quant on disk render as one collapsed row (`renderSoleQuantGgufRow`, `pickers.tsx`) and flipped `CHAT_SHOW_ALL_QUANTIZATIONS_KEY` to default false. That row's click handler changed from expanding the group to selecting the model:

```tsx
onClick={() => onSelect(c.repo_id, selectMeta)}
```

and selecting closes the picker (`model-selector.tsx`, `handleSelect` calls `setOpen(false)`).

`playwright_model_config.py` still did click-the-row-then-find-the-gear. By the time it looked, the popover was unmounted, so `open_config` returned `None` and three checks failed:

```
[ui-modelcfg] FAIL: could not open run-settings for a model matching 'gemma-3-270m'
[ui-modelcfg] FAIL: could not reopen run-settings after reload
[ui-modelcfg] FAIL: Reset button not found in run-settings
```

The third is a cascade of the second, not an independent finding.

## It is the driver, not the product

Both controls are still there. The gear is rendered on the collapsed row (`ariaLabel={\`Inference settings for ${c.repo_id} ${variant.quant}\`}`) and Reset is still in `model-config-page.tsx`. The CI screenshot from the failing run shows the row with its gear visible, and the server log records no request at all during the failing step, which is what you would expect if no expander was ever mounted.

The structural detail that matters: `ModelLoadSettingsAction` is a **sibling** of `ModelRow` inside the row shell, so it is not under `[data-model-picker-option]` and cannot be found by scoping into the row.

## The fix

Split "bring the row into view" from "click the row", locate the gear by the repo id in its aria-label, and click it without touching the row. Repos with several quants still expand first, so that path is unchanged.

## Validation

This one cannot be run locally: it needs a live Studio, a GGUF download and Playwright. I am validating it on staging CI, which runs the same `Unsloth UI CI` workflow, and will report the result on this PR before asking for a merge.

Regression window, for the record: last green on `main` was run `30743116312` (sha `aa4ea7585`); first red was `30753984758`. Of the commits in between, only #7736 touches the picker, and its own pre-merge run `30748550544` failed with the byte-identical three assertions, so it was merged red.
