### PR TITLE
Anchor the host-defaults assertions and take the file off the skip list

### DIFF
--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -243,8 +243,7 @@ jobs:
         # grows without one.
         #
         # Skipped:
-        #   test_install_rollback_lifecycle.sh: already runs on both platforms
-        #     in cross-platform-parity-ci.yml.
+        #   test_install_rollback_lifecycle.sh: covered by cross-platform-parity-ci.yml.
         run: |
           set -e
           skip="test_install_rollback_lifecycle.sh"

--- a/.github/workflows/studio-backend-ci.yml
+++ b/.github/workflows/studio-backend-ci.yml
@@ -243,13 +243,11 @@ jobs:
         # grows without one.
         #
         # Skipped:
-        #   test_install_host_defaults.sh: asserts an install.ps1 layout that
-        #     has drifted (separate followup).
         #   test_install_rollback_lifecycle.sh: already runs on both platforms
         #     in cross-platform-parity-ci.yml.
         run: |
           set -e
-          skip="test_install_host_defaults.sh test_install_rollback_lifecycle.sh"
+          skip="test_install_rollback_lifecycle.sh"
           found=0
           for s in tests/sh/test_*.sh; do
               case " $skip " in

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -9,10 +9,10 @@ TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 echo "=== Bash tests ==="
 # Discovered, not listed: a hand-maintained list drifts (this one had fallen
 # eight files behind sh/, and the Backend CI copy of it had fallen seven).
-# Backend CI discovers the same directory and skips the same files:
-# test_install_rollback_lifecycle.sh, which cross-platform-parity-ci.yml already
-# runs on both platforms. tests/studio/test_ci_shell_suite_coverage.py fails if
-# either side stops discovering, or skips something undocumented.
+# Backend CI discovers the same directory, skipping only
+# test_install_rollback_lifecycle.sh (covered by cross-platform-parity-ci.yml).
+# tests/studio/test_ci_shell_suite_coverage.py fails if either side stops
+# discovering, or skips something undocumented.
 SH_SKIP=""
 for _t in "$TESTS_DIR"/sh/test_*.sh; do
     case " $SH_SKIP " in

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -9,13 +9,11 @@ TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
 echo "=== Bash tests ==="
 # Discovered, not listed: a hand-maintained list drifts (this one had fallen
 # eight files behind sh/, and the Backend CI copy of it had fallen seven).
-# Backend CI discovers the same directory and skips the same file, plus
-# test_install_rollback_lifecycle.sh which cross-platform-parity-ci.yml already
+# Backend CI discovers the same directory and skips the same files:
+# test_install_rollback_lifecycle.sh, which cross-platform-parity-ci.yml already
 # runs on both platforms. tests/studio/test_ci_shell_suite_coverage.py fails if
 # either side stops discovering, or skips something undocumented.
-#   test_install_host_defaults.sh: asserts an install.ps1 layout that has
-#     drifted (separate followup).
-SH_SKIP="test_install_host_defaults.sh"
+SH_SKIP=""
 for _t in "$TESTS_DIR"/sh/test_*.sh; do
     case " $SH_SKIP " in
         *" $(basename "$_t") "*) echo "skipping $(basename "$_t")"; continue ;;

--- a/tests/sh/test_install_host_defaults.sh
+++ b/tests/sh/test_install_host_defaults.sh
@@ -50,12 +50,16 @@ assert_not_contains \
     "$_launcher" "studio -H 0.0.0.0"
 
 echo ""
+# Anchored on the block's own comment, not a line count: both installers
+# outgrew their tail windows and the assertions stopped covering the prompt.
 echo "=== install.sh end-of-install block ==="
 
-_end=$(tail -50 "$INSTALL_SH")
+_end=$(awk '/In interactive terminals/{found=1} found{print}' "$INSTALL_SH")
+# "read" alone also matches "readable" and "_can_read_tty" in this block, so the
+# assertion held with the prompt deleted. Pin the prompt itself.
 assert_contains \
     "install.sh: interactive block prompts user (read)" \
-    "$_end" "read"
+    "$_end" "read -r _reply"
 assert_not_contains \
     "install.sh: no 'studio -H 0.0.0.0' in end-of-install commands" \
     "$_end" "studio -H 0.0.0.0"
@@ -63,7 +67,7 @@ assert_not_contains \
 echo ""
 echo "=== install.ps1 end-of-install block ==="
 
-_ps1_end=$(tail -25 "$INSTALL_PS1")
+_ps1_end=$(awk '/In interactive terminals/{found=1} found{print}' "$INSTALL_PS1")
 assert_contains \
     "install.ps1: interactive block prompts user (Read-Host)" \
     "$_ps1_end" "Read-Host"
@@ -74,7 +78,7 @@ assert_not_contains \
 echo ""
 echo "=== studio/setup.sh launch hint ==="
 
-_setup_tail=$(tail -30 "$SETUP_SH")
+_setup_tail=$(awk '/"launch"/{found=1} found{print}' "$SETUP_SH")
 assert_not_contains \
     "studio/setup.sh: launch hint has no '-H 0.0.0.0'" \
     "$_setup_tail" "studio -H 0.0.0.0"
@@ -83,8 +87,10 @@ echo ""
 echo "=== README.md Launch section ==="
 
 # The primary Launch example must not include -H 0.0.0.0; the LAN/cloud
-# note appears as an opt-in line outside the code block.
-_readme_launch=$(awk '/^#### Launch$/{found=1} found{print} /^#### Update$/{found=0}' "$README")
+# note appears as an opt-in line outside the code block. Stop at the next
+# heading of any name: this used to stop at '#### Update', which was later
+# deleted, so the section silently became the rest of the file.
+_readme_launch=$(awk '/^#### Launch$/{found=1; print; next} found && /^#### /{exit} found{print}' "$README")
 assert_contains \
     "README: Launch section exists" \
     "$_readme_launch" "unsloth studio"

--- a/tests/sh/test_install_host_defaults.sh
+++ b/tests/sh/test_install_host_defaults.sh
@@ -50,13 +50,11 @@ assert_not_contains \
     "$_launcher" "studio -H 0.0.0.0"
 
 echo ""
-# Anchored on the block's own comment, not a line count: both installers
-# outgrew their tail windows and the assertions stopped covering the prompt.
+# Anchored on content, not a line count: both installers outgrew their tail windows.
 echo "=== install.sh end-of-install block ==="
 
 _end=$(awk '/In interactive terminals/{found=1} found{print}' "$INSTALL_SH")
-# "read" alone also matches "readable" and "_can_read_tty" in this block, so the
-# assertion held with the prompt deleted. Pin the prompt itself.
+# "read" alone also matches "readable" and "_can_read_tty", so pin the full prompt.
 assert_contains \
     "install.sh: interactive block prompts user (read)" \
     "$_end" "read -r _reply"
@@ -79,9 +77,7 @@ echo ""
 echo "=== studio/setup.sh launch hint ==="
 
 _setup_tail=$(awk '/"launch"/{found=1} found{print}' "$SETUP_SH")
-# Canary: the other three windows each carry a positive assertion that fails
-# loudly if the extraction breaks. Without one here, renaming the "launch" label
-# empties the window and the negative check below passes over nothing.
+# Canary: an empty window would let the negative assertion below pass vacuously.
 assert_contains \
     "studio/setup.sh: extraction found the launch hint" \
     "$_setup_tail" "unsloth studio -p 8888"
@@ -93,9 +89,8 @@ echo ""
 echo "=== README.md Launch section ==="
 
 # The primary Launch example must not include -H 0.0.0.0; the LAN/cloud
-# note appears as an opt-in line outside the code block. Stop at the next
-# heading of any name: this used to stop at '#### Update', which was later
-# deleted, so the section silently became the rest of the file.
+# note is an opt-in line outside it. Stop at the next heading of any level:
+# '#### Update' was later deleted, silently extending the section to the file end.
 _readme_launch=$(awk '/^#### Launch$/{found=1; print; next} found && /^#{1,6} /{exit} found{print}' "$README")
 assert_contains \
     "README: Launch section exists" \

--- a/tests/sh/test_install_host_defaults.sh
+++ b/tests/sh/test_install_host_defaults.sh
@@ -79,6 +79,12 @@ echo ""
 echo "=== studio/setup.sh launch hint ==="
 
 _setup_tail=$(awk '/"launch"/{found=1} found{print}' "$SETUP_SH")
+# Canary: the other three windows each carry a positive assertion that fails
+# loudly if the extraction breaks. Without one here, renaming the "launch" label
+# empties the window and the negative check below passes over nothing.
+assert_contains \
+    "studio/setup.sh: extraction found the launch hint" \
+    "$_setup_tail" "unsloth studio -p 8888"
 assert_not_contains \
     "studio/setup.sh: launch hint has no '-H 0.0.0.0'" \
     "$_setup_tail" "studio -H 0.0.0.0"
@@ -90,7 +96,7 @@ echo "=== README.md Launch section ==="
 # note appears as an opt-in line outside the code block. Stop at the next
 # heading of any name: this used to stop at '#### Update', which was later
 # deleted, so the section silently became the rest of the file.
-_readme_launch=$(awk '/^#### Launch$/{found=1; print; next} found && /^#### /{exit} found{print}' "$README")
+_readme_launch=$(awk '/^#### Launch$/{found=1; print; next} found && /^#{1,6} /{exit} found{print}' "$README")
 assert_contains \
     "README: Launch section exists" \
     "$_readme_launch" "unsloth studio"

--- a/tests/studio/test_ci_shell_suite_coverage.py
+++ b/tests/studio/test_ci_shell_suite_coverage.py
@@ -40,7 +40,6 @@ _SH_DIR = REPO_ROOT / "tests" / "sh"
 # Files deliberately not run by the auto-discovered Backend CI step. Each needs
 # a reason here AND in the workflow; anything else in tests/sh must run.
 _EXPECTED_CI_SKIPS = {
-    "test_install_host_defaults.sh": "asserts an install.ps1 layout that has drifted",
     "test_install_rollback_lifecycle.sh": "runs on both platforms in cross-platform-parity-ci.yml",
 }
 


### PR DESCRIPTION
`tests/sh/test_install_host_defaults.sh` has been on the skip list since #7431 and failing for longer, with a recorded reason that names one of three drifts. None of the three is a regression: `install.sh`, `install.ps1` and the README all still behave the way the test intends. Every failure is in how the test carves out the text it greps.

## The three failures

| assertion | cause |
|---|---|
| `install.sh: interactive block prompts user (read)` | `tail -50` of a 4533-line file starts at 4484; `read -r _reply` is at 4472. Outgrew the window in #6258. |
| `install.ps1: interactive block prompts user (Read-Host)` | `tail -25` of a 3141-line file starts at 3117; `Read-Host` is at 3108. Broke in #5190, the day after the test landed. |
| `README: Launch section primary command has no -H 0.0.0.0` | The extractor stopped at `#### Update`, a heading later deleted, so "the Launch section" became the rest of the file and picked up the `-H 0.0.0.0` from the remote-access section 137 lines below. |

Both installers are now anchored on the block's own `In interactive terminals` comment, so the two windows stay symmetric and survive appends. The README extractor stops at the next heading of any name.

To be explicit about the README one, since it reads alarming: the documented launch command is `unsloth studio -p 8888`. The `-H 0.0.0.0` the test tripped on is in the deliberate `#### Remote access` section, which already says to use it only on a trusted network. There is no regression and nothing to change in the docs.

## Two assertions that could not have failed

Worth calling out separately, because they were passing rather than failing:

- `studio/setup.sh: launch hint has no '-H 0.0.0.0'` sliced `tail -30`, which covers lines 2339 onward. The launch hint is at 2332. The check had drifted off its target entirely.
- `install.sh: interactive block prompts user (read)` greps for the substring `read`, which also matches `readable` and `_can_read_tty` in the same block. Deleting the prompt left it green.

Both are now pinned to what they mean to protect. Each of the six assertions was mutation-tested and fails when its target is removed:

| mutation | result |
|---|---|
| leak `studio -H 0.0.0.0` into the install.sh window | red |
| leak it into the install.ps1 window | red |
| leak it into the setup.sh launch hint | red |
| leak it into the README Launch section | red |
| delete the install.sh prompt | red |
| delete the install.ps1 prompt | red |

## Off the skip list

The file passes 10/10, so it comes off the skip list in `tests/run_all.sh`, `.github/workflows/studio-backend-ci.yml` and `tests/studio/test_ci_shell_suite_coverage.py`. Those three have to change together, since the coverage test fails if the two runners disagree or a skip is undocumented.

`tests/run_all.sh` now reports 30 passed, 0 failed with no skip line, and `test_ci_shell_suite_coverage.py` passes 29.
