### PR TITLE
Model picker: drop the green box around the downloaded icon

### DIFF
--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -482,7 +482,7 @@ function DownloadedBadge() {
     <span
       title="Already downloaded"
       aria-label="Already downloaded"
-      className="flex h-[18px] shrink-0 items-center justify-center rounded-md border border-status-success/40 px-1.5 text-status-success"
+      className="flex h-[18px] shrink-0 items-center justify-center text-status-success"
     >
       <HugeiconsIcon
         icon={Download01Icon}


### PR DESCRIPTION
The "Already downloaded" badge in the model picker draws a green outline around the download arrow. Next to the plain bordered badges beside it (parameter count, vision, OOM) the green box reads as a button you can click rather than a status indicator.

Before:

```
rounded-md border border-status-success/40 px-1.5 text-status-success
```

After:

```
text-status-success
```

The arrow keeps its green. The box goes, and with it the padding and rounding that only existed to shape that box.

`DownloadedBadge` is used in both column layouts added in #7770, so both are covered. No logic change.

Typecheck and build are clean and the 302 frontend tests pass.
