### PR TITLE
Dependabot: pin glib and gdk-pixbuf to the GTK3 0.18 line

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,15 +67,13 @@ updates:
       default-days: 7
       semver-minor-days: 3
       semver-patch-days: 3
-    # Tauri v2 renders Studio on Linux through GTK3, and the gtk-rs
-    # GTK3 bindings are frozen: `gtk` and `gdk` ended at 0.18.2 and
-    # will never ship a 0.19+. `glib` and `gdk-pixbuf` DO keep
-    # releasing, so Dependabot happily proposes 0.22 for them while
-    # `gtk`/`gdk` stay on 0.18. That lands two incompatible copies of
-    # glib in one tree and native_clipboard.rs stops compiling, since
-    # it hands a gdk_pixbuf::Pixbuf to a gtk::Clipboard. Pin both to
-    # the 0.18 line so 0.18.x patches still flow. Revisit only when
-    # Tauri moves off GTK3.
+    # Tauri renders Studio on Linux through GTK3 and the gtk-rs GTK3
+    # bindings are archived at 0.18.2, so `gtk`/`gdk` will never ship
+    # 0.19+. Moving `glib`/`gdk-pixbuf` past 0.18 puts two
+    # incompatible copies in the tree and native_clipboard.rs stops
+    # compiling: `gtk::Clipboard::wait_for_image` returns a 0.18
+    # `Pixbuf` our `gdk_pixbuf` no longer accepts. This also
+    # suppresses security PRs above 0.18, leaving alerts only.
     ignore:
       - dependency-name: "glib"
         versions: [">= 0.19"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,6 +67,20 @@ updates:
       default-days: 7
       semver-minor-days: 3
       semver-patch-days: 3
+    # Tauri v2 renders Studio on Linux through GTK3, and the gtk-rs
+    # GTK3 bindings are frozen: `gtk` and `gdk` ended at 0.18.2 and
+    # will never ship a 0.19+. `glib` and `gdk-pixbuf` DO keep
+    # releasing, so Dependabot happily proposes 0.22 for them while
+    # `gtk`/`gdk` stay on 0.18. That lands two incompatible copies of
+    # glib in one tree and native_clipboard.rs stops compiling, since
+    # it hands a gdk_pixbuf::Pixbuf to a gtk::Clipboard. Pin both to
+    # the 0.18 line so 0.18.x patches still flow. Revisit only when
+    # Tauri moves off GTK3.
+    ignore:
+      - dependency-name: "glib"
+        versions: [">= 0.19"]
+      - dependency-name: "gdk-pixbuf"
+        versions: [">= 0.19"]
     groups:
       cargo-tauri:
         patterns: ["*"]


### PR DESCRIPTION
## Summary

Stops Dependabot proposing `glib` and `gdk-pixbuf` past the 0.18 line, which is a bump that cannot ever compile.

Tauri v2 renders Studio on Linux through GTK3, and the gtk-rs GTK3 bindings are end of life: `gtk` and `gdk` stopped at 0.18.2 (last published 2024-12-09, and `gtk-rs/gtk3-rs` is archived) so there will never be a 0.19+. `glib` and `gdk-pixbuf` are shared with the GTK4 stack and keep releasing, so Dependabot sees 0.22 available and proposes it while `gtk` and `gdk` stay pinned at 0.18.

That lands two incompatible copies in one tree. #7673 is a live example, and its `Tauri Linux debug build` job fails with cargo exit 101:

| crate | main | #7673 |
|---|---|---|
| glib | 0.18.5 | 0.18.5 **and** 0.22.8 |
| gdk-pixbuf | 0.18.5 | 0.18.5 **and** 0.22.0 |
| gdk / gtk | 0.18.2 | 0.18.2 (unchanged, no 0.22 exists) |

The concrete break is in `studio/src-tauri/src/native_clipboard.rs`, which reads images off the GTK clipboard:

```rust
let image = match clipboard.wait_for_image() {
    Some(image) => image,                        // Pixbuf from gtk 0.18's transitive gdk-pixbuf
    None => read_gtk_clipboard_file_image()?,    // -> our DIRECT gdk_pixbuf::Pixbuf
};
encode_clipboard_pixbuf(&image)                  // takes &gdk_pixbuf::Pixbuf
```

Move the direct `gdk-pixbuf` to 0.22 and the two match arms are different types, and the argument no longer matches `encode_clipboard_pixbuf`. Two E0308s. In total #7673 introduces 12 newly duplicated crates including `gio`, `gio-sys`, `gobject-sys`, `glib-sys` and `glib-macros`.

## Change

An `ignore` block on the cargo entry in `.github/dependabot.yml`:

```yaml
ignore:
  - dependency-name: "glib"
    versions: [">= 0.19"]
  - dependency-name: "gdk-pixbuf"
    versions: [">= 0.19"]
```

Scoped to `>= 0.19` rather than a blanket ignore. `gtk` and `gdk` need no entry: upstream has no newer release, so Dependabot cannot propose one.

## What this costs

A `versions` range on `ignore` suppresses **security** updates too, not only version updates. Only `update-types` is exempt from that (`dependabot-core`, `common/lib/dependabot/config/ignore_condition.rb`: `ignored_versions` returns `versions` verbatim when `security_updates_only`). So a future `glib` or `gdk-pixbuf` advisory fixed in 0.19+ will raise a Dependabot alert but will not open a PR from the `cargo-tauri-security` group.

That is the right trade here, because such a PR could not be merged anyway while Tauri is on GTK3. It is called out in the config comment so nobody reads the pin as free.

Note the 0.18 lines are themselves closed: `glib` and `gdk-pixbuf` both ended at 0.18.5 on 2023-12-30 and moved to 0.19.0 on 2024-02-04. The `>= 0.19` bound is what keeps the resolver on a working tree, not a promise of further 0.18 patches.

## On the glib advisory

`glib` 0.18.5 carries RUSTSEC-2024-0429 / GHSA-wrw7-89jp-8q8g, fixed in 0.20.0. It is moderate, and it is unsoundness in the `Iterator` and `DoubleEndedIterator` impls for `glib::VariantStrIter` rather than a remotely reachable flaw. We never touch that API: `VariantStrIter`, `Variant::` and `iter_str` have zero hits across `studio/src-tauri/src`. The only glib calls are `glib::filename_from_uri` and `glib::MainContext::default()`. Trading a working Linux build for an unreachable moderate unsoundness is not a good deal, so this stays pinned until Tauri moves off GTK3.

The rest of the GTK3 stack (`gtk`, `gdk`, `atk`, `gdkx11`, `gdkwayland-sys`, `gtk3-macros` and their `-sys` crates) is flagged unmaintained by RUSTSEC-2024-0411 through -0420, with no fixed version published for any of them. That is inherent to Tauri v2 on Linux and there is nothing actionable there either.

## Verification

- `.github/dependabot.yml` parses, and validates against SchemaStore's `dependabot-2.0.json` (draft-07, `additionalProperties: false`) with 0 errors.
- `">= 0.19"` is passed through verbatim to `Gem::Requirement` by `dependabot-core/cargo/lib/dependabot/cargo/requirement.rb`, and the two-segment `0.19` parses under that ecosystem's `VERSION_PATTERN`. It matches 0.19.0 through 0.22.8 and not 0.18.x.
- `ignore` does not empty the `cargo-tauri` group: that needs `completely_ignored?`, which tests for `>= 0`, and this supplies a bounded range.
- Config only. No build or runtime surface.
