### PR TITLE
Studio: bump anyhow and event-listener for RustSec advisories

### DIFF
--- a/studio/src-tauri/Cargo.lock
+++ b/studio/src-tauri/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -1151,11 +1151,10 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]


### PR DESCRIPTION
## Summary

Two patch-level bumps in `studio/src-tauri/Cargo.lock` that clear RustSec advisories. Lockfile only, no `Cargo.toml` change, no Studio UI surface.

| crate | from | to | advisory |
|---|---|---|---|
| anyhow | 1.0.102 | 1.0.104 | RUSTSEC-2026-0190, unsoundness in `Error::downcast_mut()`, fixed in 1.0.103 |
| event-listener | 5.4.1 | 5.4.2 | RUSTSEC-2026-0221, `!Send` tags crossing thread boundaries via `StackSlot`, fixed in 5.4.2 |

Both are transitive, both are auxiliary rather than user facing, and neither touches the GTK/Tauri rendering path. Applied with `cargo update -p <crate> --precise <version>` so nothing else in the graph moves.

## Note on the diff

`event-listener` 5.4.2 drops `concurrent-queue` from its dependency list upstream, so that line disappears from its lock entry. The crate itself stays in the tree, still required by `async-channel`, `async-executor`, `async-io` and `polling`.

## Verification

- `cargo metadata --locked` exits 0, so the lockfile is consistent with `Cargo.toml`.
- Full OSV rescan of `studio/src-tauri/Cargo.lock` goes from 25 affected crates to 23. Both target advisories report clear.
- Diff is 4 insertions and 5 deletions across a single file.

## Not included here

Two things turned up in the same scan and are deliberately left out:

- `quick-xml` RUSTSEC-2026-0194 and RUSTSEC-2026-0195, both CVSS 7.5 denial of service, fixed in 0.41.0. Three copies are in the tree (0.37.5, 0.38.4, 0.39.2) via `plist`, `tauri-winrt-notification` and `wayland-scanner`. Reachability is low: plist parses our own app bundles, tauri-winrt-notification builds toast XML from our own strings, and wayland-scanner is build time codegen. Moving it needs upstream tauri and plist to bump first, so it belongs in its own change.
- The GTK3 stack unmaintained warnings (RUSTSEC-2024-0411 through -0420) have no fixed version published and are inherent to Tauri v2 on Linux.
