### PR TITLE
Studio frontend: override brace-expansion 5.0.8 and fast-uri 3.1.4

### DIFF
--- a/studio/frontend/package-lock.json
+++ b/studio/frontend/package-lock.json
@@ -6551,15 +6551,15 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@ts-morph/common/node_modules/minimatch": {
@@ -7199,16 +7199,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -9534,9 +9534,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/studio/frontend/package.json
+++ b/studio/frontend/package.json
@@ -90,7 +90,8 @@
     "hono": "4.12.25",
     "qs": "6.15.2",
     "ip-address": "10.1.1",
-    "brace-expansion@5.0.5": "5.0.6"
+    "brace-expansion@^5": "5.0.8",
+    "fast-uri@^3": "3.1.4"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",


### PR DESCRIPTION
## Summary

Clears four high-severity npm advisories in the Studio frontend through the existing `overrides` block.

| package | main | here | advisories cleared |
|---|---|---|---|
| brace-expansion (5.x) | 5.0.6 | 5.0.8 | GHSA-3jxr-9vmj-r5cp / CVE-2026-13149, GHSA-mh99-v99m-4gvg / CVE-2026-14257 |
| fast-uri | 3.1.2 | 3.1.4 | GHSA-4c8g-83qw-93j6 / CVE-2026-13676, GHSA-v2hh-gcrm-f6hx / CVE-2026-16221 |

`npm audit` goes from 11 findings and 5 high to 9 and 3. The `fast-uri` finding disappears entirely, and `brace-expansion` narrows from `<=1.1.16 || 3.0.0 - 5.0.7` to just `<=1.1.16`.

## Why overrides and not a direct dependency

Neither package is imported anywhere. Grep for `brace-expansion`, `fast-uri`, `ajv`, `ajv-formats`, `ts-morph`, `minimatch` and `@modelcontextprotocol/sdk` across `studio/frontend/src` and `studio/frontend/tests` returns nothing. They are purely transitive, so the fix belongs in `overrides`, which is what the block is already there for.

The stale `"brace-expansion@5.0.5": "5.0.6"` pin is replaced rather than kept. It had become the blocker: it held both 5.x copies at 5.0.6 and stopped npm resolving them forward on its own.

```diff
-    "brace-expansion@5.0.5": "5.0.6"
+    "brace-expansion@^5": "5.0.8",
+    "fast-uri@^3": "3.1.4"
```

Adding either package to `dependencies` instead would misstate the manifest and, with `save-exact=true`, hard pin a package we do not use and block the next patch.

## Reachability

Nothing here reaches the browser bundle. `brace-expansion` arrives via `minimatch` under `eslint`, `typescript-eslint` and `shadcn` -> `ts-morph`. `fast-uri` arrives via `ajv` under `shadcn`. Those paths only show as production because `shadcn` sits in `dependencies` rather than `devDependencies`, which is worth a separate look.

Patching them is still correct: `security-audit.yml` runs `npm audit --audit-level=high` without `--omit=dev` on purpose, since a dev-only dependency can still reach a CI runner.

## Version choice

5.0.8 and 3.1.4 are the newest releases older than the 7 day `min-release-age` floor in `studio/frontend/.npmrc`. The newer 5.0.9 and 3.1.5 were published 2 to 3 days ago and would be refused at install time.

## Follow-up

The dev-only 1.x line is not covered here. `node_modules/brace-expansion` 1.1.14, reached through eslint's `minimatch@3`, needs 1.1.17 or newer for CVE-2026-14257. 1.1.17 is 4 days old, so it lands once it clears the same cooldown. That is the remaining `<=1.1.16` entry in the audit output above.

## Verification

Run in `studio/frontend`:

- `npm ci --strict-allow-scripts` is clean, and `git diff` afterwards is empty, so the manifest and lockfile agree.
- `scripts/lockfile_supply_chain_audit.py`: 0 findings across 3 npm and 1 cargo lockfile.
- `scripts/sync_allow_scripts_pins.py --check`: 3 entries in sync.
- `scripts/check_frontend_dep_removal.py --base origin/main`: no dependencies removed.
- `npm run typecheck`, `npm test` and `npm run build` all pass.
- Diff is 22 lockfile lines and 3 manifest lines, touching only the three affected lock entries.

## On the engines change in the diff

brace-expansion 5.0.8 narrows its own `engines` from `"18 || 20 || >=22"` to `"20 || >=22"`. That is an upstream decision, not something this PR chooses, and it changes nothing for us:

- `studio/frontend/package.json` already declares `"engines": {"node": "^20.19.0 || >=22.12.0"}`, so our floor was above Node 18 well before this bump.
- `decide_node_source` already treats Node 18 as unusable and installs a bundled runtime instead. See the `node18 -> bundled` case in `tests/sh/test_node_decision.sh` and `tests/studio/test_node_decision.ps1`.
- CI never runs Node 18: 29 workflow jobs pin `node-version: '22'` and two pin 24.
- `engine-strict` is not set in `.npmrc`, so engines stay advisory regardless.
