### PR TITLE
fix(tests): build padding-free collator with TRL 1.9.2-compatible kwargs (#7708)

### DIFF
--- a/tests/utils/test_packing.py
+++ b/tests/utils/test_packing.py
@@ -899,22 +899,25 @@ class _DummyModel(torch.nn.Module):
 class _DummyTrainer:
     def __init__(self):
         self.args = SimpleNamespace(remove_unused_columns = True)
-        collator_args = {
-            "pad_token_id": 0,
-            "completion_only_loss": False,
-            "return_tensors": "pt",
-        }
-        optional_flags = [
-            {"padding_free": True, "return_position_ids": False},
-            {"padding_free": True},
+        collator_attempts = [
+            {"pad_token_id": 0, "padding_free": True, "return_position_ids": False},
+            {"pad_token_id": 0, "padding_free": True},
+            {"pad_token_id": 0},
             {},
         ]
-        for extra in optional_flags:
+        last_error = None
+        for kwargs in collator_attempts:
             try:
-                self.data_collator = DataCollatorForLanguageModeling(**collator_args, **extra)
+                self.data_collator = DataCollatorForLanguageModeling(**kwargs)
                 break
-            except TypeError:
+            except TypeError as exc:
+                last_error = exc
                 continue
+        else:
+            raise RuntimeError(
+                "Could not construct DataCollatorForLanguageModeling with any "
+                f"supported keyword set; last error: {last_error}"
+            ) from last_error
         # Ensure attributes exist even if the constructor rejected the flags.
         if not hasattr(self.data_collator, "padding_free"):
             self.data_collator.padding_free = True


### PR DESCRIPTION
## Problem

The `Core (HF=latest + TRL=latest)` CI job fails on `main` with:

```
FAILED tests/utils/test_packing.py::test_enable_sample_packing
E   AttributeError: '_DummyTrainer' object has no attribute 'data_collator'
```

That job installs `trl==1.9.2`. In TRL 1.9.2, `DataCollatorForLanguageModeling` no longer accepts `completion_only_loss` (or `return_position_ids`). Because `_DummyTrainer` always passed those kwargs, every constructor attempt raised `TypeError`, `self.data_collator` was never assigned, and the following `hasattr(self.data_collator, ...)` line surfaced a confusing `AttributeError` several lines away from the real cause.

Fixes #7708

## Fix

1. Try progressively smaller, universally-valid keyword sets (`pad_token_id` + `padding_free` first, then fall back).
2. If no combination works, raise a descriptive `RuntimeError` naming the last `TypeError` instead of falling into an unrelated `AttributeError`.

## Verification

Reproduced under `trl==1.9.2`:
- Old `_DummyTrainer` kwargs fail with `unexpected keyword argument 'completion_only_loss'`.
- New fallback builds `DataCollatorForLanguageModeling(pad_token_id=0, padding_free=True)` and `test_enable_sample_packing` passes on CPU.