### PR TITLE
Studio: fix Python chart previews in desktop app

### DIFF
--- a/studio/frontend/src/components/assistant-ui/tool-ui-python.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-ui-python.tsx
@@ -3,27 +3,28 @@
 
 "use client";
 
-import { getAuthToken } from "@/features/auth/session";
-import type { ToolCallMessagePartComponent } from "@assistant-ui/react";
-import { useToolArgsStatus } from "@assistant-ui/react";
-import { CodeIcon } from "lucide-react";
 import { Spinner } from "@/components/ui/spinner";
-import { memo } from "react";
-import {
-  ToolFallbackContent,
-  ToolFallbackRoot,
-  ToolFallbackTrigger,
-} from "./tool-fallback";
-import { CopyBtn, ToolCodeCell } from "./tool-code-cell";
-import { ToolLiveOutput } from "./tool-live-output";
-import { ToolResultOutput } from "./tool-result-output";
-import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
+import { getAuthToken } from "@/features/auth/session";
 import {
   preferFullToolOutput,
   useToolAwaitingApproval,
   useToolOutputFor,
   useToolPaneScope,
 } from "@/features/chat";
+import { useChatRuntimeStore } from "@/features/chat/stores/chat-runtime-store";
+import { apiUrl } from "@/lib/api-base";
+import type { ToolCallMessagePartComponent } from "@assistant-ui/react";
+import { useToolArgsStatus } from "@assistant-ui/react";
+import { CodeIcon } from "lucide-react";
+import { memo } from "react";
+import { CopyBtn, ToolCodeCell } from "./tool-code-cell";
+import {
+  ToolFallbackContent,
+  ToolFallbackRoot,
+  ToolFallbackTrigger,
+} from "./tool-fallback";
+import { ToolLiveOutput } from "./tool-live-output";
+import { ToolResultOutput } from "./tool-result-output";
 
 interface StructuredResult {
   text: string;
@@ -129,7 +130,9 @@ const PythonToolUIImpl: ToolCallMessagePartComponent = ({
           ) : displayOutput ? (
             <div className="mt-2 border-t border-dashed pt-2">
               <div className="flex items-center justify-between">
-                <span className="text-xs font-medium text-muted-foreground">output</span>
+                <span className="text-xs font-medium text-muted-foreground">
+                  output
+                </span>
                 <CopyBtn text={displayOutput} />
               </div>
               <ToolResultOutput text={displayOutput} />
@@ -142,7 +145,9 @@ const PythonToolUIImpl: ToolCallMessagePartComponent = ({
               {images.map((filename) => (
                 <img
                   key={filename}
-                  src={`/api/inference/sandbox/${encodeURIComponent(sessionId)}/${encodeURIComponent(filename)}${authToken ? `?token=${encodeURIComponent(authToken)}` : ""}`}
+                  src={apiUrl(
+                    `/api/inference/sandbox/${encodeURIComponent(sessionId)}/${encodeURIComponent(filename)}${authToken ? `?token=${encodeURIComponent(authToken)}` : ""}`,
+                  )}
                   alt={filename}
                   loading="lazy"
                   className="max-w-full rounded border border-border"

--- a/studio/frontend/tests/python-tool-desktop-image.test.ts
+++ b/studio/frontend/tests/python-tool-desktop-image.test.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("Python sandbox images target the desktop backend and pass the Tauri CSP", async () => {
+  const component = await readFile(
+    new URL(
+      "../src/components/assistant-ui/tool-ui-python.tsx",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const config = JSON.parse(
+    await readFile(
+      new URL("../../src-tauri/tauri.conf.json", import.meta.url),
+      "utf8",
+    ),
+  ) as { app?: { security?: { csp?: string } } };
+
+  assert.ok(component.includes('import { apiUrl } from "@/lib/api-base";'));
+  assert.ok(
+    component.includes("src={apiUrl(") &&
+      component.includes("`/api/inference/sandbox/"),
+    "the image URL must use the dynamically selected desktop backend origin",
+  );
+
+  const csp = config.app?.security?.csp ?? "";
+  const imgSrc = csp
+    .split(";")
+    .map((directive) => directive.trim())
+    .find((directive) => directive.startsWith("img-src "));
+  assert.ok(imgSrc, "desktop CSP must define img-src");
+  assert.ok(
+    imgSrc.split(" ").includes("http://127.0.0.1:*"),
+    "desktop CSP must allow sandbox images from the loopback backend",
+  );
+});

--- a/studio/src-tauri/tauri.conf.json
+++ b/studio/src-tauri/tauri.conf.json
@@ -16,7 +16,7 @@
   "app": {
     "withGlobalTauri": true,
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost http://localhost:* ws://localhost:* ws://127.0.0.1:* http://127.0.0.1:* https://huggingface.co https://*.huggingface.co https://datasets-server.huggingface.co; img-src 'self' data: blob: https:; media-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; frame-src 'self' http://localhost:* http://127.0.0.1:*"
+      "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost http://localhost:* ws://localhost:* ws://127.0.0.1:* http://127.0.0.1:* https://huggingface.co https://*.huggingface.co https://datasets-server.huggingface.co; img-src 'self' data: blob: https: http://127.0.0.1:*; media-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; frame-src 'self' http://localhost:* http://127.0.0.1:*"
     },
     "windows": [
       {


### PR DESCRIPTION
## Summary
- route Python sandbox image requests through the desktop-aware API base
- allow loopback backend images in the packaged Tauri CSP
- add regression coverage for the URL and CSP requirements

## Testing
- `node --experimental-strip-types --test tests/python-tool-desktop-image.test.ts`
- `npm run typecheck`
- `npm run build`