### PR TITLE
fix(studio): preserve regeneration branch history on reload

### DIFF
--- a/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
+++ b/studio/frontend/src/features/chat/prompt-storage/prompt-storage-dialog.tsx
@@ -55,6 +55,7 @@ import {
   saveStoredChatThread,
   syncStoredChatMessages,
 } from "../utils/chat-history-storage";
+import { orderByParentChain } from "../utils/chat-message-tree";
 import { notifyChatHistoryUpdated } from "../api/chat-api";
 import { toolResultModelText } from "../api/chat-adapter";
 import { usePlusMenuPrefsStore } from "../stores/plus-menu-prefs-store";
@@ -191,42 +192,6 @@ function contentBlocksToText(content: unknown): string {
 // Order via parentId chain: createdAt misorders turns (GPT response slots
 // predate the user's next message); the parent chain is timestamp-independent.
 type _Msg = { id: string; parentId?: string | null; createdAt?: number };
-
-function orderByParentChain<T extends _Msg>(
-  messages: T[],
-  options: {
-    /** Append messages off the selected chain (abandoned branches) at the
-     *  end. Full exports keep everything; fine-tune conversion must not,
-     *  since alternate replies would merge into one conversation. */
-    includeSiblings?: boolean;
-  } = {},
-): T[] {
-  const { includeSiblings = true } = options;
-  const byId = new Map<string, T>(messages.map((m) => [m.id, m]));
-  const childrenOf = new Map<string | null, T[]>();
-  for (const m of messages) {
-    const pid = m.parentId ?? null;
-    if (!childrenOf.has(pid)) childrenOf.set(pid, []);
-    childrenOf.get(pid)!.push(m);
-  }
-
-  const result: T[] = [];
-  let cur: string | null = null;
-  while (childrenOf.has(cur)) {
-    const children: T[] = childrenOf.get(cur)!;
-    const next: T = children.reduce((a: T, b: T) =>
-      (a.createdAt ?? 0) >= (b.createdAt ?? 0) ? a : b,
-    );
-    result.push(next);
-    cur = next.id;
-    byId.delete(next.id);
-  }
-
-  if (includeSiblings) {
-    for (const [, m] of byId) result.push(m);
-  }
-  return result;
-}
 
 async function loadConversationMessages(threadId: string) {
   const raw = await listStoredChatMessages(threadId);

--- a/studio/frontend/src/features/chat/runtime-provider.tsx
+++ b/studio/frontend/src/features/chat/runtime-provider.tsx
@@ -106,6 +106,11 @@ import {
 } from "./utils/chat-thread-tombstones";
 import { chatHistoryClearBoundary } from "./utils/chat-history-clear-boundary";
 import { fallbackTitleFromUserText } from "./utils/chat-title";
+import {
+  prepareBranchedMessagesForImport,
+  repairAssistantParentIds,
+  resolveHeadMessageId,
+} from "./utils/chat-message-tree";
 import { syncExportedRepositoryToBackend } from "./utils/delete-thread-message";
 import { getImageInputUnavailableReason } from "./utils/image-input-support";
 import { isAssistantLocalThreadId } from "./utils/thread-ids";
@@ -1370,15 +1375,18 @@ function useStudioRuntimeAdapters(
           void refreshContextUsage({ threadId: remoteId });
         }
 
-        // If any message has a stored parentId, reconstruct the tree so
-        // retries/regenerations load as branches rather than a flat list. For
-        // mixed legacy/new threads, infer sequential parents for old messages to
-        // preserve the chain. Fall back to fromArray for fully legacy threads.
+        // Reconstruct the branch tree for retries/regenerations. Repair assistant
+        // rows that lost parentId (they were chained under the prior assistant
+        // and resetHead dropped middle branches — #7732), order siblings for
+        // import, and pass headId so MessageRepository picks the active leaf.
         const hasParentIds = msgs.some((m) => m.parentId != null);
         if (hasParentIds) {
+          const prepared = prepareBranchedMessagesForImport(msgs);
+          const headId = resolveHeadMessageId(prepared);
           let previousId: string | null = null;
           return {
-            messages: msgs.map((m) => {
+            ...(headId ? { headId } : {}),
+            messages: prepared.map((m) => {
               const parentId = m.parentId != null ? m.parentId : previousId;
               previousId = m.id;
               return {

--- a/studio/frontend/src/features/chat/utils/chat-message-tree.ts
+++ b/studio/frontend/src/features/chat/utils/chat-message-tree.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import type { MessageRecord } from "../types";
+
+type ParentChainMessage = {
+  id: string;
+  parentId?: string | null;
+  createdAt?: number;
+  role?: string;
+};
+
+const ROLE_ORDER: Record<string, number> = {
+  system: 0,
+  user: 1,
+  assistant: 2,
+};
+
+export function sortChatMessages<T extends ParentChainMessage>(
+  messages: T[],
+): T[] {
+  return [...messages].sort((a, b) => {
+    if ((a.createdAt ?? 0) !== (b.createdAt ?? 0)) {
+      return (a.createdAt ?? 0) - (b.createdAt ?? 0);
+    }
+    const aOrder = ROLE_ORDER[a.role ?? ""] ?? 99;
+    const bOrder = ROLE_ORDER[b.role ?? ""] ?? 99;
+    if (aOrder !== bOrder) return aOrder - bOrder;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+}
+
+/**
+ * Order messages for tree import: walk the newest-child chain first, then
+ * append abandoned sibling branches. Matches export/import expectations for
+ * regeneration history (see #7732).
+ */
+export function orderByParentChain<T extends ParentChainMessage>(
+  messages: T[],
+  options: { includeSiblings?: boolean } = {},
+): T[] {
+  const { includeSiblings = true } = options;
+  const byId = new Map<string, T>(messages.map((m) => [m.id, m]));
+  const childrenOf = new Map<string | null, T[]>();
+  for (const m of messages) {
+    const pid = m.parentId ?? null;
+    if (!childrenOf.has(pid)) childrenOf.set(pid, []);
+    childrenOf.get(pid)!.push(m);
+  }
+
+  const result: T[] = [];
+  let cur: string | null = null;
+  while (childrenOf.has(cur)) {
+    const children = childrenOf.get(cur)!;
+    if (children.length === 0) break;
+    const next = children.reduce((a, b) =>
+      (a.createdAt ?? 0) >= (b.createdAt ?? 0) ? a : b,
+    );
+    result.push(next);
+    cur = next.id;
+    byId.delete(next.id);
+  }
+
+  if (includeSiblings) {
+    for (const [, m] of byId) result.push(m);
+  }
+  return result;
+}
+
+/**
+ * Regeneration siblings must share the prompting user as parent. Legacy rows
+ * with null parentId were previously chained under the prior assistant, which
+ * makes resetHead drop middle branches and leaves only 1/2 in the picker.
+ */
+export function repairAssistantParentIds<T extends ParentChainMessage>(
+  messages: T[],
+): T[] {
+  const sorted = sortChatMessages(messages);
+  if (!sorted.some((m) => m.parentId != null)) {
+    return sorted;
+  }
+
+  const users = sorted.filter((m) => m.role === "user");
+  return sorted.map((message) => {
+    if (message.role !== "assistant" || message.parentId != null) {
+      return message;
+    }
+    let parent: T | undefined;
+    for (const user of users) {
+      if ((user.createdAt ?? 0) <= (message.createdAt ?? 0)) {
+        parent = user;
+      } else {
+        break;
+      }
+    }
+    if (!parent) {
+      return message;
+    }
+    return { ...message, parentId: parent.id };
+  });
+}
+
+/** Leaf of the newest-child chain; used as MessageRepository headId on import. */
+export function resolveHeadMessageId(
+  messages: Array<Pick<ParentChainMessage, "id" | "parentId" | "createdAt">>,
+): string | null {
+  const ordered = orderByParentChain(messages, { includeSiblings: false });
+  return ordered.at(-1)?.id ?? null;
+}
+
+export function prepareBranchedMessagesForImport(
+  messages: MessageRecord[],
+): MessageRecord[] {
+  const repaired = repairAssistantParentIds(messages);
+  return orderByParentChain(repaired, { includeSiblings: true });
+}

--- a/studio/frontend/src/features/chat/utils/chat-message-tree.ts
+++ b/studio/frontend/src/features/chat/utils/chat-message-tree.ts
@@ -136,7 +136,7 @@ export function resolveHeadMessageId(
 ): string | null {
   if (messages.length === 0) return null;
   const sorted = sortChatMessages(messages);
-  const childrenOf = new Map<string, ParentChainMessage[]>();
+  const childrenOf = new Map<string | null, ParentChainMessage[]>();
   for (const message of messages) {
     const parentId = message.parentId ?? null;
     if (!childrenOf.has(parentId)) childrenOf.set(parentId, []);

--- a/studio/frontend/src/features/chat/utils/chat-message-tree.ts
+++ b/studio/frontend/src/features/chat/utils/chat-message-tree.ts
@@ -51,9 +51,9 @@ export function orderByParentChain<T extends ParentChainMessage>(
   const result: T[] = [];
   let cur: string | null = null;
   while (childrenOf.has(cur)) {
-    const children = childrenOf.get(cur)!;
+    const children: T[] = childrenOf.get(cur)!;
     if (children.length === 0) break;
-    const next = children.reduce((a, b) =>
+    const next: T = children.reduce((a: T, b: T) =>
       (a.createdAt ?? 0) >= (b.createdAt ?? 0) ? a : b,
     );
     result.push(next);

--- a/studio/frontend/src/features/chat/utils/chat-message-tree.ts
+++ b/studio/frontend/src/features/chat/utils/chat-message-tree.ts
@@ -31,6 +31,29 @@ export function sortChatMessages<T extends ParentChainMessage>(
 }
 
 /**
+ * Legacy rows may still have null parentId on user turns. Infer those from the
+ * prior message before branch ordering so mixed threads keep their chain.
+ */
+export function inferSequentialParentIds<T extends ParentChainMessage>(
+  messages: T[],
+): T[] {
+  const sorted = sortChatMessages(messages);
+  let previousId: string | null = null;
+  return sorted.map((message) => {
+    if (message.parentId != null) {
+      previousId = message.id;
+      return message;
+    }
+    if (message.role === "assistant") {
+      return message;
+    }
+    const inferred = { ...message, parentId: previousId };
+    previousId = message.id;
+    return inferred;
+  });
+}
+
+/**
  * Order messages for tree import: walk the newest-child chain first, then
  * append abandoned sibling branches. Matches export/import expectations for
  * regeneration history (see #7732).
@@ -80,37 +103,65 @@ export function repairAssistantParentIds<T extends ParentChainMessage>(
     return sorted;
   }
 
-  const users = sorted.filter((m) => m.role === "user");
-  return sorted.map((message) => {
+  const parentForOrphanAssistant = (index: number): string | null => {
+    for (let i = index - 1; i >= 0; i--) {
+      const prev = sorted[i];
+      if (prev.role === "assistant" && prev.parentId) {
+        return prev.parentId;
+      }
+      if (prev.role === "user") {
+        return prev.id;
+      }
+    }
+    return null;
+  };
+
+  return sorted.map((message, index) => {
     if (message.role !== "assistant" || message.parentId != null) {
       return message;
     }
-    let parent: T | undefined;
-    for (const user of users) {
-      if ((user.createdAt ?? 0) <= (message.createdAt ?? 0)) {
-        parent = user;
-      } else {
-        break;
-      }
-    }
-    if (!parent) {
+    const parentId = parentForOrphanAssistant(index);
+    if (!parentId) {
       return message;
     }
-    return { ...message, parentId: parent.id };
+    return { ...message, parentId };
   });
 }
 
-/** Leaf of the newest-child chain; used as MessageRepository headId on import. */
+/** Leaf on the branch anchored by the latest user turn (active conversation). */
 export function resolveHeadMessageId(
-  messages: Array<Pick<ParentChainMessage, "id" | "parentId" | "createdAt">>,
+  messages: Array<
+    Pick<ParentChainMessage, "id" | "parentId" | "createdAt" | "role">
+  >,
 ): string | null {
-  const ordered = orderByParentChain(messages, { includeSiblings: false });
-  return ordered.at(-1)?.id ?? null;
+  if (messages.length === 0) return null;
+  const sorted = sortChatMessages(messages);
+  const childrenOf = new Map<string, ParentChainMessage[]>();
+  for (const message of messages) {
+    const parentId = message.parentId ?? null;
+    if (!childrenOf.has(parentId)) childrenOf.set(parentId, []);
+    childrenOf.get(parentId)!.push(message);
+  }
+
+  const users = sorted.filter((message) => message.role === "user");
+  const anchor =
+    users.length > 0 ? users[users.length - 1] : sorted[sorted.length - 1];
+
+  let currentId = anchor.id;
+  while (true) {
+    const children = childrenOf.get(currentId) ?? [];
+    if (children.length === 0) return currentId;
+    const next = children.reduce((a, b) =>
+      (a.createdAt ?? 0) >= (b.createdAt ?? 0) ? a : b,
+    );
+    currentId = next.id;
+  }
 }
 
 export function prepareBranchedMessagesForImport(
   messages: MessageRecord[],
 ): MessageRecord[] {
-  const repaired = repairAssistantParentIds(messages);
+  const sequential = inferSequentialParentIds(messages);
+  const repaired = repairAssistantParentIds(sequential);
   return orderByParentChain(repaired, { includeSiblings: true });
 }

--- a/studio/frontend/src/features/chat/utils/delete-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/delete-thread-message.ts
@@ -24,14 +24,11 @@ import {
   ensureStoredChatThread,
   syncStoredChatMessages,
 } from "./chat-history-storage";
-<<<<<<< HEAD
+import { repairAssistantParentIds } from "./chat-message-tree";
 import {
   hasResearchMetadata,
   reconcileServerManagedMessages,
 } from "./research-message-sync";
-=======
-import { repairAssistantParentIds } from "./chat-message-tree";
->>>>>>> e13968c38 (fix(studio): preserve regeneration branch history on reload (#7732))
 
 function cloneContent(
   content: ThreadMessage["content"],
@@ -116,18 +113,15 @@ export async function syncExportedRepositoryToBackend(
   await ensureStoredChatThread(remoteId);
   const records = exp.messages.map(({ message, parentId }) =>
     exportedItemToRecord(remoteId, parentId, message),
-<<<<<<< HEAD
   );
   await syncStoredChatMessages(
     remoteId,
-    await withStoredResearchMessages(remoteId, records),
+    await withStoredResearchMessages(
+      remoteId,
+      repairAssistantParentIds(records),
+    ),
     { pruneMissing: options.pruneMissing },
-=======
->>>>>>> e13968c38 (fix(studio): preserve regeneration branch history on reload (#7732))
   );
-  await syncStoredChatMessages(remoteId, repairAssistantParentIds(records), {
-    pruneMissing: options.pruneMissing,
-  });
 }
 
 type ThreadImportExport = {

--- a/studio/frontend/src/features/chat/utils/delete-thread-message.ts
+++ b/studio/frontend/src/features/chat/utils/delete-thread-message.ts
@@ -24,10 +24,14 @@ import {
   ensureStoredChatThread,
   syncStoredChatMessages,
 } from "./chat-history-storage";
+<<<<<<< HEAD
 import {
   hasResearchMetadata,
   reconcileServerManagedMessages,
 } from "./research-message-sync";
+=======
+import { repairAssistantParentIds } from "./chat-message-tree";
+>>>>>>> e13968c38 (fix(studio): preserve regeneration branch history on reload (#7732))
 
 function cloneContent(
   content: ThreadMessage["content"],
@@ -112,12 +116,18 @@ export async function syncExportedRepositoryToBackend(
   await ensureStoredChatThread(remoteId);
   const records = exp.messages.map(({ message, parentId }) =>
     exportedItemToRecord(remoteId, parentId, message),
+<<<<<<< HEAD
   );
   await syncStoredChatMessages(
     remoteId,
     await withStoredResearchMessages(remoteId, records),
     { pruneMissing: options.pruneMissing },
+=======
+>>>>>>> e13968c38 (fix(studio): preserve regeneration branch history on reload (#7732))
   );
+  await syncStoredChatMessages(remoteId, repairAssistantParentIds(records), {
+    pruneMissing: options.pruneMissing,
+  });
 }
 
 type ThreadImportExport = {

--- a/tests/studio/test_chat_message_tree_7732.py
+++ b/tests/studio/test_chat_message_tree_7732.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Regression for #7732: regeneration branches must survive load/import."""
+
+import json
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+WORKDIR = Path(__file__).resolve().parents[2]
+CHAT_TREE = WORKDIR / "studio" / "frontend" / "src" / "features" / "chat" / "utils" / "chat-message-tree.ts"
+FRONTEND_DIR = WORKDIR / "studio" / "frontend"
+TEMP = WORKDIR / "temp" / "chat_message_tree_7732"
+
+
+def _require_node():
+    if shutil.which("node") is None:
+        pytest.skip("node not available")
+    if not CHAT_TREE.exists():
+        pytest.skip("chat-message-tree.ts not present")
+    result = subprocess.run(
+        ["node", "--experimental-strip-types", "--version"],
+        capture_output = True,
+        text = True,
+        timeout = 5,
+    )
+    if result.returncode != 0:
+        pytest.skip("node --experimental-strip-types not available")
+
+
+def _ensure_harness():
+    TEMP.mkdir(parents = True, exist_ok = True)
+    (FRONTEND_DIR / "register.mjs").write_text(
+        "import { register } from 'node:module';\nregister('./loader.mjs', import.meta.url);\n"
+    )
+    (FRONTEND_DIR / "loader.mjs").write_text(
+        "export function resolve(specifier, context, next) {\n"
+        "  if (specifier.endsWith('/types')) return next(specifier + '.ts', context);\n"
+        "  return next(specifier, context);\n"
+        "}\n"
+    )
+
+
+def _run(script: str) -> dict:
+    _require_node()
+    _ensure_harness()
+    script_path = FRONTEND_DIR / "temp_chat_message_tree_run.mts"
+    script_path.write_text(script)
+    env = dict(os.environ, NODE_NO_WARNINGS = "1")
+    result = subprocess.run(
+        [
+            "node",
+            "--experimental-strip-types",
+            "--import=./register.mjs",
+            "--no-warnings",
+            "temp_chat_message_tree_run.mts",
+        ],
+        cwd = str(FRONTEND_DIR),
+        capture_output = True,
+        text = True,
+        timeout = 30,
+        env = env,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+    last = [line for line in result.stdout.strip().splitlines() if line.strip()][-1]
+    return json.loads(last)
+
+
+def _tree_path():
+    rel = os.path.relpath(CHAT_TREE, FRONTEND_DIR).replace("\\", "/")
+    return f"./{rel}"
+
+
+def test_repair_assistant_parent_ids_restores_sibling_branches():
+    rel = _tree_path()
+    out = _run(
+        textwrap.dedent(
+            f"""
+            import {{ repairAssistantParentIds, resolveHeadMessageId }} from '{rel}';
+            import {{ MessageRepository }} from '@assistant-ui/core/internal';
+
+            const userId = 'user-1';
+            let t = 1000;
+            const stored = [
+              {{ id: userId, role: 'user', parentId: null, createdAt: t }},
+              {{ id: 'asst-1', role: 'assistant', parentId: userId, createdAt: t += 100 }},
+            ];
+            for (let i = 2; i <= 6; i++) {{
+              t += 100;
+              stored.push({{ id: `asst-${{i}}`, role: 'assistant', parentId: null, createdAt: t }});
+            }}
+
+            const repaired = repairAssistantParentIds(stored);
+            const headId = resolveHeadMessageId(repaired);
+            const repo = new MessageRepository();
+            repo.import({{
+              headId,
+              messages: repaired.map((m) => ({{
+                parentId: m.parentId ?? null,
+                message: {{
+                  id: m.id,
+                  role: m.role,
+                  content: [{{ type: 'text', text: m.id }}],
+                  status: {{ type: 'complete', reason: 'unknown' }},
+                  metadata: {{ custom: {{}} }},
+                  createdAt: new Date(m.createdAt),
+                  attachments: [],
+                }},
+              }})),
+            }});
+
+            console.log(JSON.stringify({{
+              branchCount: repo.getBranches('asst-6').length,
+              exported: repo.export().messages.length,
+            }}));
+            """
+        )
+    )
+    assert out["branchCount"] == 6
+    assert out["exported"] == 7
+
+
+def test_partial_db_loss_still_reports_two_when_only_ends_remain():
+    """When only the first and latest regen rows survive storage, picker shows 1/2."""
+    rel = _tree_path()
+    out = _run(
+        textwrap.dedent(
+            f"""
+            import {{ MessageRepository }} from '@assistant-ui/core/internal';
+
+            const userId = 'user-1';
+            const stored = [
+              {{ id: userId, role: 'user', parentId: null, createdAt: 1000 }},
+              {{ id: 'asst-1', role: 'assistant', parentId: userId, createdAt: 1100 }},
+              {{ id: 'asst-6', role: 'assistant', parentId: userId, createdAt: 1600 }},
+            ];
+            const repo = new MessageRepository();
+            for (const m of stored) {{
+              repo.addOrUpdateMessage(m.parentId, {{
+                id: m.id,
+                role: m.role,
+                content: [{{ type: 'text', text: m.id }}],
+                status: {{ type: 'complete', reason: 'unknown' }},
+                metadata: {{ custom: {{}} }},
+                createdAt: new Date(m.createdAt),
+                attachments: [],
+              }});
+            }}
+            repo.resetHead('asst-6');
+            console.log(JSON.stringify({{ branchCount: repo.getBranches('asst-6').length }}));
+            """
+        )
+    )
+    assert out["branchCount"] == 2

--- a/tests/studio/test_chat_message_tree_7732.py
+++ b/tests/studio/test_chat_message_tree_7732.py
@@ -13,7 +13,9 @@ from pathlib import Path
 import pytest
 
 WORKDIR = Path(__file__).resolve().parents[2]
-CHAT_TREE = WORKDIR / "studio" / "frontend" / "src" / "features" / "chat" / "utils" / "chat-message-tree.ts"
+CHAT_TREE = (
+    WORKDIR / "studio" / "frontend" / "src" / "features" / "chat" / "utils" / "chat-message-tree.ts"
+)
 FRONTEND_DIR = WORKDIR / "studio" / "frontend"
 TEMP = WORKDIR / "temp" / "chat_message_tree_7732"
 

--- a/tests/studio/test_chat_message_tree_7732.py
+++ b/tests/studio/test_chat_message_tree_7732.py
@@ -36,13 +36,15 @@ def _require_node():
 def _ensure_harness():
     TEMP.mkdir(parents = True, exist_ok = True)
     (FRONTEND_DIR / "register.mjs").write_text(
-        "import { register } from 'node:module';\nregister('./loader.mjs', import.meta.url);\n"
+        "import { register } from 'node:module';\nregister('./loader.mjs', import.meta.url);\n",
+        encoding = "utf-8",
     )
     (FRONTEND_DIR / "loader.mjs").write_text(
         "export function resolve(specifier, context, next) {\n"
         "  if (specifier.endsWith('/types')) return next(specifier + '.ts', context);\n"
         "  return next(specifier, context);\n"
-        "}\n"
+        "}\n",
+        encoding = "utf-8",
     )
 
 
@@ -50,7 +52,7 @@ def _run(script: str) -> dict:
     _require_node()
     _ensure_harness()
     script_path = FRONTEND_DIR / "temp_chat_message_tree_run.mts"
-    script_path.write_text(script)
+    script_path.write_text(script, encoding = "utf-8")
     env = dict(os.environ, NODE_NO_WARNINGS = "1")
     result = subprocess.run(
         [
@@ -157,3 +159,45 @@ def test_partial_db_loss_still_reports_two_when_only_ends_remain():
         )
     )
     assert out["branchCount"] == 2
+
+
+def test_resolve_head_prefers_continued_branch_over_newer_regen_sibling():
+    rel = _tree_path()
+    out = _run(
+        textwrap.dedent(
+            f"""
+            import {{ prepareBranchedMessagesForImport, resolveHeadMessageId }} from '{rel}';
+            import {{ MessageRepository }} from '@assistant-ui/core/internal';
+
+            const userId = 'user-1';
+            const stored = [
+              {{ id: userId, role: 'user', parentId: null, createdAt: 1000 }},
+              {{ id: 'asst-1', role: 'assistant', parentId: userId, createdAt: 1100 }},
+              {{ id: 'asst-2', role: 'assistant', parentId: userId, createdAt: 1500 }},
+              {{ id: 'user-2', role: 'user', parentId: 'asst-1', createdAt: 1200 }},
+              {{ id: 'asst-3', role: 'assistant', parentId: 'user-2', createdAt: 1300 }},
+            ];
+            const prepared = prepareBranchedMessagesForImport(stored);
+            const headId = resolveHeadMessageId(prepared);
+            const repo = new MessageRepository();
+            repo.import({{
+              headId,
+              messages: prepared.map((m) => ({{
+                parentId: m.parentId ?? null,
+                message: {{
+                  id: m.id,
+                  role: m.role,
+                  content: [{{ type: 'text', text: m.id }}],
+                  status: {{ type: 'complete', reason: 'unknown' }},
+                  metadata: {{ custom: {{}} }},
+                  createdAt: new Date(m.createdAt),
+                  attachments: [],
+                }},
+              }})),
+            }});
+            console.log(JSON.stringify({{ headId, active: repo.getHeadId() }}));
+            """
+        )
+    )
+    assert out["headId"] == "asst-3"
+    assert out["active"] == "asst-3"

--- a/tests/studio/test_chat_message_tree_7732.py
+++ b/tests/studio/test_chat_message_tree_7732.py
@@ -195,7 +195,7 @@ def test_resolve_head_prefers_continued_branch_over_newer_regen_sibling():
                 }},
               }})),
             }});
-            console.log(JSON.stringify({{ headId, active: repo.getHeadId() }}));
+            console.log(JSON.stringify({{ headId, active: repo.headId }}));
             """
         )
     )


### PR DESCRIPTION
Fixes #7732

## Problem
After several response regenerations (Refresh), the branch picker showed **1/2** instead of **1/6** — only the first and latest branches survived reload.

## Root cause
Regeneration siblings should share the same `parentId` (the prompting user message). When middle assistant rows lost `parentId` (null), `history.load()` chained them under the prior assistant via `previousId` inference. `MessageRepository.import()` + `resetHead()` then dropped chained descendants, leaving only first + latest as siblings.

## Fix
- Add shared `chat-message-tree.ts` utilities:
  - `repairAssistantParentIds` — reattach orphan assistant rows to the correct user parent
  - `orderByParentChain` / `resolveHeadMessageId` — order messages and pick the active leaf for import
  - `prepareBranchedMessagesForImport` — repair + order on load
- `runtime-provider.tsx` `history.load()` uses the helpers and passes `headId` to `MessageRepository`
- `syncExportedRepositoryToBackend` repairs `parentId` before autosave so storage stays consistent
- Deduplicate `orderByParentChain` from `prompt-storage-dialog.tsx`

## Testing
```bash
.venv/bin/python -m pytest tests/studio/test_chat_message_tree_7732.py -v
```

Both regression tests pass (6-branch repair + partial DB loss still reports 1/2).