### PR TITLE
Fix STT model download progress reporting

### DIFF
--- a/studio/backend/core/inference/stt_sidecar.py
+++ b/studio/backend/core/inference/stt_sidecar.py
@@ -21,9 +21,10 @@ import os
 import re
 import threading
 import uuid
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Iterator, Optional
 
 from loggers import get_logger
 
@@ -83,6 +84,71 @@ class _SelectedHubFile:
 class _CachedSttSnapshot:
     path: Optional[Path]
     is_multilingual: Optional[bool]
+
+
+class _HfByteProgress:
+    """Small tqdm-compatible sink for Hugging Face transport byte updates."""
+
+    def __init__(self, report: Callable[[int], None], initial: int = 0) -> None:
+        self._report = report
+        self._lock = threading.Lock()
+        self._bytes = max(int(initial), 0)
+        self._safe_report(self._bytes)
+
+    def _safe_report(self, value: int) -> None:
+        try:
+            self._report(value)
+        except Exception:
+            # Progress is best-effort and must never fail the actual download.
+            pass
+
+    def update(self, amount: float = 1) -> None:
+        with self._lock:
+            self._bytes += max(int(amount), 0)
+            value = self._bytes
+        self._safe_report(value)
+
+
+_HF_PROGRESS_PATCH_LOCK = threading.RLock()
+
+
+@contextmanager
+def _capture_hf_download_progress(
+    report: Callable[[int], None],
+) -> Iterator[None]:
+    """Route Hugging Face's byte progress for this thread into ``report``.
+
+    ``hf_hub_download`` does not expose its transport progress callback. Both
+    HTTP and Xet do, however, create their tqdm sink through one internal
+    helper. Temporarily intercept that helper for the calling thread and leave
+    every unrelated Hub download on the original path.
+    """
+    from huggingface_hub import file_download
+
+    original = getattr(file_download, "_get_progress_bar_context", None)
+    if not callable(original):
+        # Compatibility fallback for a future Hub release that moves the
+        # helper. Cache-file accounting below still provides coarse progress.
+        yield
+        return
+
+    owner_thread = threading.get_ident()
+
+    def progress_context(**kwargs):
+        if threading.get_ident() != owner_thread:
+            return original(**kwargs)
+        return nullcontext(_HfByteProgress(report, initial = kwargs.get("initial", 0)))
+
+    # The patched function is process-global, so serialize the short scoped
+    # replacement. Other Hub threads are not blocked; the wrapper delegates
+    # them to the original implementation.
+    with _HF_PROGRESS_PATCH_LOCK:
+        file_download._get_progress_bar_context = progress_context
+        try:
+            yield
+        finally:
+            if file_download._get_progress_bar_context is progress_context:
+                file_download._get_progress_bar_context = original
 
 
 class SttUnavailableError(RuntimeError):
@@ -423,7 +489,7 @@ def validate_remote_model(model: Optional[str], hf_token: Optional[str] = None) 
             f"Could not resolve an immutable revision for STT model '{model_id}'."
         )
     # The commit that was validated; the download pins to it so the repo cannot
-    # be swapped between validation and snapshot_download (TOCTOU).
+    # be swapped between validation and the file downloads (TOCTOU).
     return {"model": model_id, "repo": repo, "revision": revision}
 
 
@@ -490,10 +556,10 @@ def is_model_downloaded(model: Optional[str]) -> bool:
 
 
 class _SnapshotDownloadState:
-    """Tracks one background snapshot_download of a dictation repository.
+    """Tracks one background download of a dictation repository snapshot.
 
     Like stt_ggml_sidecar's tracker, but a Transformers checkpoint is a whole
-    repo, so progress is the byte count of its cache blobs.
+    repo, so progress combines its transport callbacks and cache state.
     """
 
     def __init__(self) -> None:
@@ -501,9 +567,11 @@ class _SnapshotDownloadState:
         self._thread: Optional[threading.Thread] = None
         self._model_id: Optional[str] = None
         self._repo: Optional[str] = None
+        self._revision: Optional[str] = None
         self._error: Optional[str] = None
         self._total_bytes: Optional[int] = None
         self._selected_files: tuple[_SelectedHubFile, ...] = ()
+        self._transport_bytes = 0
         self._complete = False
 
     def status(self) -> dict:
@@ -515,33 +583,46 @@ class _SnapshotDownloadState:
                 "model": self._model_id if downloading else None,
                 "error": self._error,
                 "bytes_total": self._total_bytes if show_progress else None,
-                "bytes_done": self._blob_bytes() if show_progress else None,
+                "bytes_done": self._downloaded_bytes() if show_progress else None,
             }
 
-    def _blob_bytes(self) -> Optional[int]:
-        """Best-effort progress: bytes in the repo's HF cache blobs.
+    def _downloaded_bytes(self) -> Optional[int]:
+        """Best-effort progress from the transport and repo's HF cache.
 
-        Counts only the selected support files and one selected weight format,
-        including in-progress ``.incomplete`` blobs.
+        Counts only the selected support files and weight format. Transport
+        callbacks cover Xet's chunk transfer; finalized blobs, in-progress
+        ``.incomplete`` files, and Windows snapshot copies are fallbacks.
         """
         try:
             # Caller may hold the non-reentrant self._lock; a bare read is safe.
             repo = self._repo
+            revision = self._revision
             selected_files = self._selected_files
             if not repo or not selected_files:
                 return None
-            blobs = _repo_cache_dir(repo) / "blobs"
-            if not blobs.is_dir():
-                return 0
+            repo_cache = _repo_cache_dir(repo)
+            blobs = repo_cache / "blobs"
+            snapshot = repo_cache / "snapshots" / revision if revision else None
             done = 0
             for selected in selected_files:
-                if not selected.blob_key:
-                    continue
-                complete = blobs / selected.blob_key
-                incomplete = blobs / f"{selected.blob_key}.incomplete"
-                candidate = complete if complete.is_file() else incomplete
-                if candidate.is_file():
+                candidate = None
+                if selected.blob_key:
+                    complete = blobs / selected.blob_key
+                    incomplete = blobs / f"{selected.blob_key}.incomplete"
+                    if complete.is_file():
+                        candidate = complete
+                    elif incomplete.is_file():
+                        candidate = incomplete
+                # Without Windows Developer Mode, huggingface_hub cannot make
+                # snapshot symlinks and copies completed files directly. Count
+                # that copy only when its blob is absent, avoiding duplicates.
+                if candidate is None and snapshot is not None:
+                    snapshot_file = snapshot / selected.path
+                    if snapshot_file.is_file():
+                        candidate = snapshot_file
+                if candidate is not None:
                     done += min(candidate.stat().st_size, selected.size)
+            done = max(done, self._transport_bytes)
             total = self._total_bytes
             return min(done, total) if total is not None else done
         except Exception:
@@ -564,9 +645,11 @@ class _SnapshotDownloadState:
                 )
             self._model_id = model_id
             self._repo = resolve_model_repo(model_id)
+            self._revision = None
             self._error = None
             self._total_bytes = None
             self._selected_files = ()
+            self._transport_bytes = 0
             self._complete = False
             thread = threading.Thread(
                 target = self._run, args = (self._repo, hf_token, revision), daemon = True
@@ -581,8 +664,9 @@ class _SnapshotDownloadState:
         revision: Optional[str] = None,
     ) -> None:
         try:
-            from huggingface_hub import HfApi, hf_hub_download, snapshot_download
+            from huggingface_hub import HfApi, hf_hub_download
 
+            cache_dir = str(_active_hf_hub_cache())
             info = HfApi(token = hf_token or None).model_info(
                 repo,
                 revision = revision,
@@ -595,6 +679,8 @@ class _SnapshotDownloadState:
                 raise SttModelCompatibilityError(
                     f"Could not resolve an immutable revision for STT model '{repo}'."
                 )
+            with self._lock:
+                self._revision = revision
 
             def load_index(filename: str) -> dict:
                 path = hf_hub_download(
@@ -602,6 +688,7 @@ class _SnapshotDownloadState:
                     filename = filename,
                     revision = revision,
                     token = hf_token or None,
+                    cache_dir = cache_dir,
                 )
                 return _read_json_object(Path(path))
 
@@ -610,13 +697,38 @@ class _SnapshotDownloadState:
             with self._lock:
                 self._selected_files = selected_files
                 self._total_bytes = total or None
-            snapshot = Path(
-                snapshot_download(
-                    repo_id = repo,
-                    revision = revision,
-                    allow_patterns = [selected.path for selected in selected_files],
-                    token = hf_token or None,
-                )
+            # Keep transfers on this dedicated worker thread. snapshot_download
+            # moves each file into a shared executor, where a progress hook
+            # could not distinguish this STT job from unrelated Hub downloads.
+            completed = 0
+            for selected in selected_files:
+                def report_file_progress(
+                    file_bytes: int,
+                    *,
+                    base: int = completed,
+                    size: int = selected.size,
+                ) -> None:
+                    with self._lock:
+                        current = base + min(max(file_bytes, 0), size)
+                        self._transport_bytes = max(self._transport_bytes, current)
+
+                with _capture_hf_download_progress(report_file_progress):
+                    hf_hub_download(
+                        repo_id = repo,
+                        filename = selected.path,
+                        revision = revision,
+                        token = hf_token or None,
+                        cache_dir = cache_dir,
+                    )
+                completed += selected.size
+                with self._lock:
+                    self._transport_bytes = max(self._transport_bytes, completed)
+
+            snapshot = (
+                Path(cache_dir)
+                / f"models--{repo.replace('/', '--')}"
+                / "snapshots"
+                / revision
             )
             if not _snapshot_is_complete(snapshot):
                 raise SttModelCompatibilityError(

--- a/studio/backend/core/inference/stt_sidecar.py
+++ b/studio/backend/core/inference/stt_sidecar.py
@@ -89,7 +89,11 @@ class _CachedSttSnapshot:
 class _HfByteProgress:
     """Small tqdm-compatible sink for Hugging Face transport byte updates."""
 
-    def __init__(self, report: Callable[[int], None], initial: int = 0) -> None:
+    def __init__(
+        self,
+        report: Callable[[int], None],
+        initial: int = 0,
+    ) -> None:
         self._report = report
         self._lock = threading.Lock()
         self._bytes = max(int(initial), 0)
@@ -113,9 +117,7 @@ _HF_PROGRESS_PATCH_LOCK = threading.RLock()
 
 
 @contextmanager
-def _capture_hf_download_progress(
-    report: Callable[[int], None],
-) -> Iterator[None]:
+def _capture_hf_download_progress(report: Callable[[int], None]) -> Iterator[None]:
     """Route Hugging Face's byte progress for this thread into ``report``.
 
     ``hf_hub_download`` does not expose its transport progress callback. Both
@@ -702,6 +704,7 @@ class _SnapshotDownloadState:
             # could not distinguish this STT job from unrelated Hub downloads.
             completed = 0
             for selected in selected_files:
+
                 def report_file_progress(
                     file_bytes: int,
                     *,
@@ -725,10 +728,7 @@ class _SnapshotDownloadState:
                     self._transport_bytes = max(self._transport_bytes, completed)
 
             snapshot = (
-                Path(cache_dir)
-                / f"models--{repo.replace('/', '--')}"
-                / "snapshots"
-                / revision
+                Path(cache_dir) / f"models--{repo.replace('/', '--')}" / "snapshots" / revision
             )
             if not _snapshot_is_complete(snapshot):
                 raise SttModelCompatibilityError(

--- a/studio/backend/routes/inference.py
+++ b/studio/backend/routes/inference.py
@@ -8082,13 +8082,13 @@ async def stt_download(
     module = stt_ggml_sidecar if engine == "gguf" else stt_sidecar
     try:
         # Transformers accepts custom `owner/model` repos, so confirm the repo is
-        # a Whisper checkpoint (metadata-only) before snapshot_download pulls a
+        # a Whisper checkpoint (metadata-only) before downloading a
         # possibly-large non-STT repo into the shared cache. Curated ids
         # short-circuit; GGUF only accepts curated ids, so it needs no check.
         if engine != "gguf":
             validated = await asyncio.to_thread(validate_remote_model, payload.model, hf_token)
             # Pin the download to the commit that was just validated so the
-            # repo cannot be swapped between validation and snapshot_download.
+            # repo cannot be swapped between validation and the file downloads.
             await asyncio.to_thread(
                 module.start_model_download,
                 payload.model,

--- a/studio/backend/tests/test_stt_review_fixes_2.py
+++ b/studio/backend/tests/test_stt_review_fixes_2.py
@@ -11,7 +11,7 @@
 3. _snapshot_is_complete must require tokenizer assets (tokenizer.json or
    vocab.json + merges.txt); weights + config alone decode to blank text.
 4. Custom-repo downloads must pin the revision validated beforehand and
-   restrict snapshot_download to the model/tokenizer/config/preprocessor file
+   restrict downloads to the model/tokenizer/config/preprocessor file
    classes (TOCTOU + unbounded-download hardening).
 5. The GGML sidecar's readiness probe must not treat an arbitrary local HTTP
    responder as whisper-server (mic audio would be posted to it), and the port
@@ -221,13 +221,13 @@ def test_validate_remote_model_returns_the_validated_revision(monkeypatch):
 
 
 def test_download_pins_revision_and_limits_patterns(monkeypatch):
-    captured = {}
+    captured = []
     validated_revision = "a" * 40
     head_revision = "b" * 40
 
-    def fake_snapshot_download(**kwargs):
-        captured.update(kwargs)
-        return "/cached"
+    def fake_hf_hub_download(**kwargs):
+        captured.append(kwargs)
+        return f"/cached/{kwargs['filename']}"
 
     class _FakeApi:
         def __init__(self, token = None):
@@ -254,22 +254,22 @@ def test_download_pins_revision_and_limits_patterns(monkeypatch):
     import huggingface_hub
 
     monkeypatch.setattr(huggingface_hub, "HfApi", _FakeApi)
-    monkeypatch.setattr(huggingface_hub, "snapshot_download", fake_snapshot_download)
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download", fake_hf_hub_download)
 
     state = stt_sidecar_module._SnapshotDownloadState()
     # The revision resolved at validation time wins over the current head.
     state._run("someone/custom-whisper", None, revision = validated_revision)
-    assert captured["revision"] == validated_revision
-    patterns = captured["allow_patterns"]
-    assert "model.safetensors" in patterns and "tokenizer.json" in patterns
-    # No wildcard that would admit arbitrary repo contents.
-    assert "*" not in patterns
+    assert captured
+    assert all(call["revision"] == validated_revision for call in captured)
+    filenames = {call["filename"] for call in captured}
+    assert "model.safetensors" in filenames and "tokenizer.json" in filenames
+    assert "pytorch_model.bin" not in filenames
 
     # Without a validated revision (curated repos), pin to the metadata head.
     captured.clear()
     state._run("someone/custom-whisper", None)
-    assert captured["revision"] == head_revision
-    assert captured["allow_patterns"]
+    assert captured
+    assert all(call["revision"] == head_revision for call in captured)
 
 
 # 5. GGML readiness must identify whisper-server --------------------------------

--- a/studio/backend/tests/test_stt_sidecar.py
+++ b/studio/backend/tests/test_stt_sidecar.py
@@ -9,6 +9,7 @@ import threading
 import time
 import wave
 import weakref
+from contextlib import nullcontext
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -47,10 +48,6 @@ def stub_audio_decoder(monkeypatch):
         stt_sidecar_module,
         "_decode_audio_bounded",
         lambda _audio: np.zeros(8000, dtype = np.float32),
-    )
-    monkeypatch.setattr(
-        "huggingface_hub.snapshot_download",
-        lambda **_kwargs: "/cached/model",
     )
     monkeypatch.setattr(
         stt_sidecar_module,
@@ -1108,8 +1105,98 @@ def test_progress_counts_only_selected_blobs_and_caps_incomplete_files(monkeypat
     assert status["bytes_done"] == 30
 
 
-def test_download_metadata_and_snapshot_use_the_same_revision(monkeypatch, tmp_path):
+def test_progress_counts_selected_snapshot_files_when_windows_cannot_symlink(monkeypatch, tmp_path):
+    revision = "d" * 40
+    monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "hub"))
+    snapshot = (
+        tmp_path
+        / "hub"
+        / "models--owner--whisper"
+        / "snapshots"
+        / revision
+    )
+    snapshot.mkdir(parents = True)
+    (snapshot / "config.json").write_bytes(b"x" * 10)
+    state = stt_sidecar_module._SnapshotDownloadState()
+    state._repo = "owner/whisper"
+    state._revision = revision
+    state._selected_files = (
+        stt_sidecar_module._SelectedHubFile("config.json", 10, "one"),
+        stt_sidecar_module._SelectedHubFile("model.safetensors", 20, "two"),
+    )
+    state._total_bytes = 30
+    state._complete = True
+
+    status = state.status()
+
+    assert status["bytes_total"] == 30
+    assert status["bytes_done"] == 10
+
+
+def test_hf_progress_capture_reports_transport_bytes():
+    from huggingface_hub import file_download
+
+    reported = []
+    with stt_sidecar_module._capture_hf_download_progress(reported.append):
+        progress_context = file_download._get_progress_bar_context(
+            desc = "model.safetensors",
+            log_level = 20,
+            total = 100,
+            initial = 5,
+            name = "huggingface_hub.xet_get",
+        )
+        with progress_context as progress:
+            progress.update(35)
+
+    assert reported == [5, 40]
+
+
+def test_hf_progress_capture_is_thread_scoped_and_restored(monkeypatch):
+    from huggingface_hub import file_download
+
+    delegated_threads = []
+
+    def original_context(**_kwargs):
+        delegated_threads.append(threading.get_ident())
+        return nullcontext("original")
+
+    monkeypatch.setattr(file_download, "_get_progress_bar_context", original_context)
+    reported = []
+    other_result = []
+
+    def use_progress_from_another_thread():
+        with file_download._get_progress_bar_context() as progress:
+            other_result.append(progress)
+
+    with stt_sidecar_module._capture_hf_download_progress(reported.append):
+        worker = threading.Thread(target = use_progress_from_another_thread)
+        worker.start()
+        worker.join(timeout = 2)
+        with file_download._get_progress_bar_context(initial = 3) as progress:
+            progress.update(4)
+
+    assert worker.is_alive() is False
+    assert other_result == ["original"]
+    assert len(delegated_threads) == 1
+    assert reported == [3, 7]
+    assert file_download._get_progress_bar_context is original_context
+
+
+def test_hf_progress_capture_restores_hook_after_failure(monkeypatch):
+    from huggingface_hub import file_download
+
+    original_context = file_download._get_progress_bar_context
+    with pytest.raises(RuntimeError, match = "forced"):
+        with stt_sidecar_module._capture_hf_download_progress(lambda _value: None):
+            raise RuntimeError("forced")
+
+    assert file_download._get_progress_bar_context is original_context
+
+
+def test_download_metadata_and_files_use_the_same_revision(monkeypatch, tmp_path):
     revision = "e" * 40
+    hub_cache = tmp_path / "hub"
+    monkeypatch.setenv("HF_HUB_CACHE", str(hub_cache))
     calls = []
     siblings = [
         _sibling("config.json", 10, "config"),
@@ -1127,19 +1214,16 @@ def test_download_metadata_and_snapshot_use_the_same_revision(monkeypatch, tmp_p
             calls.append(("info", repo, kwargs))
             return SimpleNamespace(sha = revision, siblings = siblings)
 
-    def fake_snapshot_download(**kwargs):
-        calls.append(("snapshot", kwargs))
+    def fake_hf_hub_download(**kwargs):
+        calls.append(("download", kwargs))
         return str(tmp_path)
 
     monkeypatch.setattr("huggingface_hub.HfApi", FakeApi)
-    monkeypatch.setattr("huggingface_hub.snapshot_download", fake_snapshot_download)
-    monkeypatch.setattr(
-        "huggingface_hub.hf_hub_download",
-        lambda **_kwargs: pytest.fail("unsharded selection must not load an index"),
-    )
+    monkeypatch.setattr("huggingface_hub.hf_hub_download", fake_hf_hub_download)
     monkeypatch.setattr(stt_sidecar_module, "_snapshot_is_complete", lambda _path: True)
     monkeypatch.setattr(stt_sidecar_module, "_write_revision_record", lambda *_args: None)
     state = stt_sidecar_module._SnapshotDownloadState()
+    state._repo = "owner/whisper"
 
     state._run("owner/whisper", None, revision)
 
@@ -1148,10 +1232,18 @@ def test_download_metadata_and_snapshot_use_the_same_revision(monkeypatch, tmp_p
         "owner/whisper",
         {"revision": revision, "files_metadata": True, "timeout": 30},
     )
-    assert calls[1][0] == "snapshot"
-    assert calls[1][1]["revision"] == revision
-    assert "model.safetensors" in calls[1][1]["allow_patterns"]
-    assert "pytorch_model.bin" not in calls[1][1]["allow_patterns"]
+    downloads = [kwargs for kind, kwargs in calls[1:] if kind == "download"]
+    assert {call["filename"] for call in downloads} == {
+        "config.json",
+        "preprocessor_config.json",
+        "tokenizer.json",
+        "model.safetensors",
+    }
+    assert all(call["revision"] == revision for call in downloads)
+    assert all(call["repo_id"] == "owner/whisper" for call in downloads)
+    assert all(call["cache_dir"] == str(hub_cache) for call in downloads)
+    assert state.status()["bytes_done"] == 160
+    assert state.status()["bytes_total"] == 160
 
 
 def test_download_status_is_idle_before_any_download():

--- a/studio/backend/tests/test_stt_sidecar.py
+++ b/studio/backend/tests/test_stt_sidecar.py
@@ -1108,13 +1108,7 @@ def test_progress_counts_only_selected_blobs_and_caps_incomplete_files(monkeypat
 def test_progress_counts_selected_snapshot_files_when_windows_cannot_symlink(monkeypatch, tmp_path):
     revision = "d" * 40
     monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "hub"))
-    snapshot = (
-        tmp_path
-        / "hub"
-        / "models--owner--whisper"
-        / "snapshots"
-        / revision
-    )
+    snapshot = tmp_path / "hub" / "models--owner--whisper" / "snapshots" / revision
     snapshot.mkdir(parents = True)
     (snapshot / "config.json").write_bytes(b"x" * 10)
     state = stt_sidecar_module._SnapshotDownloadState()


### PR DESCRIPTION
## What

- Report live Hugging Face transport bytes while the Transformers STT model is downloading.
- Keep progress scoped to the STT worker thread and restore the Hub progress hook after each file.
- Fall back to selected cache blobs, incomplete files, and Windows snapshot copies.
- Preserve immutable revision pinning and download only the selected model/support files.

## Why

The Studio download status only counted files visible in the Hugging Face blob cache. With Xet-backed downloads, transferred chunks may not update those files until late in the download; on Windows without cache symlinks, completed support files may exist only in the snapshot. The backend therefore kept returning `bytes_done: 0`, leaving the UI at `Downloading... 0%` even while the cache was growing.

`hf_hub_download` does not expose a public byte-progress callback in the Studio-pinned `huggingface-hub==0.36.2`. This change uses its shared progress-context hook within a guarded, thread-scoped context. Calls from unrelated Hub threads still delegate to the original handler, and the handler is restored in `finally`. If that private helper changes in a future Hub release, cache accounting remains as a coarse fallback.

Files are downloaded sequentially on the dedicated STT worker because `snapshot_download` delegates files to a shared executor, where callback ownership cannot be attributed safely. Model weights dominate the transfer, so the isolation and accurate progress are preferable to parallelizing the small support files.

## Validation

- Real fresh Windows/Xet download of Whisper Tiny: `155,434,424` bytes, 22 positive progress changes, exact final total.
- Live Studio UI through Playwright: observed 2%, 8%, 9%, 27%, and 98%, including rate/ETA; no browser errors.
- `studio/backend/tests/test_stt_sidecar.py`: 83 passed (2 unrelated Windows-only environment cases deselected: POSIX literal path expectation and unavailable symlink privilege).
- Focused revision/validation tests: 6 passed.
- Focused progress tests: 6 passed.
- Ruff and `git diff --check`: passed.

Reproduces and fixes https://github.com/unsloth-test/unsloth-test/issues/4
