### PR TITLE
Desktop: fix dictation failing with a blocked speech service

### DIFF
--- a/studio/frontend/src/features/chat/adapters/studio-model-dictation-adapter.ts
+++ b/studio/frontend/src/features/chat/adapters/studio-model-dictation-adapter.ts
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { useSettingsDialogStore } from "@/features/settings/stores/settings-dialog-store";
 import { authFetch } from "@/features/auth";
 import { hubTokenHeader } from "@/features/hub/lib/hub-token-header";
+import { useSettingsDialogStore } from "@/features/settings/stores/settings-dialog-store";
 import {
   applyDictationDictionary,
   isCuratedSttModel,

--- a/studio/frontend/src/features/chat/adapters/studio-model-dictation-adapter.ts
+++ b/studio/frontend/src/features/chat/adapters/studio-model-dictation-adapter.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { useSettingsDialogStore } from "@/features/settings/stores/settings-dialog-store";
 import { authFetch } from "@/features/auth";
 import { hubTokenHeader } from "@/features/hub/lib/hub-token-header";
 import {
@@ -340,7 +341,12 @@ export class StudioModelDictationAdapter implements DictationAdapter {
           ? error.message
           : "A recorded segment could not be transcribed.";
       console.error("STT transcription error:", error);
-      toast.error(message);
+      toast.error(message, {
+        action: {
+          label: "Open Voice settings",
+          onClick: () => useSettingsDialogStore.getState().openDialog("voice"),
+        },
+      });
     };
 
     const buildTranscript = () =>

--- a/studio/frontend/src/features/chat/adapters/studio-web-speech-dictation-adapter.ts
+++ b/studio/frontend/src/features/chat/adapters/studio-web-speech-dictation-adapter.ts
@@ -133,8 +133,8 @@ export class StudioWebSpeechDictationAdapter implements DictationAdapter {
   static isSupported(): boolean {
     return (
       typeof window !== "undefined" &&
-      // The webview exposes the API but Apple's speech service refuses it
-      // (service-not-allowed), so the mic would render and then fail.
+      // WKWebView exposes the API but Apple's service refuses it
+      // (service-not-allowed); WebView2 and webkit2gtk have no engine at all.
       !isTauri &&
       window.isSecureContext &&
       getSpeechRecognitionAPI() !== undefined &&

--- a/studio/frontend/src/features/chat/adapters/studio-web-speech-dictation-adapter.ts
+++ b/studio/frontend/src/features/chat/adapters/studio-web-speech-dictation-adapter.ts
@@ -8,6 +8,7 @@ import {
   resolveDictationLanguage,
   useVoiceSettingsStore,
 } from "@/features/settings/stores/voice-settings-store";
+import { isTauri } from "@/lib/api-base";
 import type { DictationAdapter } from "@assistant-ui/react";
 import { toast } from "sonner";
 import { useChatRuntimeStore } from "../stores/chat-runtime-store";
@@ -132,6 +133,9 @@ export class StudioWebSpeechDictationAdapter implements DictationAdapter {
   static isSupported(): boolean {
     return (
       typeof window !== "undefined" &&
+      // The webview exposes the API but Apple's speech service refuses it
+      // (service-not-allowed), so the mic would render and then fail.
+      !isTauri &&
       window.isSecureContext &&
       getSpeechRecognitionAPI() !== undefined &&
       navigator.mediaDevices?.getUserMedia !== undefined

--- a/studio/frontend/src/features/settings/stores/voice-settings-store.ts
+++ b/studio/frontend/src/features/settings/stores/voice-settings-store.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { isTauri } from "@/lib/api-base";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
@@ -199,7 +200,7 @@ export const useVoiceSettingsStore = create<VoiceSettingsState>()(
       micDeviceId: "default",
       setMicDeviceId: (micDeviceId) => set({ micDeviceId }),
 
-      dictationEngine: "browser",
+      dictationEngine: isTauri ? "model" : "browser",
       setDictationEngine: (dictationEngine) => set({ dictationEngine }),
 
       sttModel: DEFAULT_STT_MODEL,
@@ -321,8 +322,10 @@ export const useVoiceSettingsStore = create<VoiceSettingsState>()(
         // "gguf" was a short-lived separate engine choice; both local
         // backends now live under "model".
         const savedEngine = saved?.dictationEngine as string | undefined;
+        // Desktop has no working browser speech service, so it always resolves
+        // to the local model.
         const dictationEngine: DictationEngine =
-          savedEngine === "model" || savedEngine === "gguf"
+          isTauri || savedEngine === "model" || savedEngine === "gguf"
             ? "model"
             : "browser";
         const savedSttModel = normalizeSttModel(saved?.sttModel);

--- a/studio/frontend/src/features/settings/stores/voice-settings-store.ts
+++ b/studio/frontend/src/features/settings/stores/voice-settings-store.ts
@@ -322,8 +322,7 @@ export const useVoiceSettingsStore = create<VoiceSettingsState>()(
         // "gguf" was a short-lived separate engine choice; both local
         // backends now live under "model".
         const savedEngine = saved?.dictationEngine as string | undefined;
-        // Desktop has no working browser speech service, so it always resolves
-        // to the local model.
+        // Desktop has no browser speech engine, so always resolve to "model".
         const dictationEngine: DictationEngine =
           isTauri || savedEngine === "model" || savedEngine === "gguf"
             ? "model"

--- a/studio/frontend/src/features/settings/tabs/voice-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/voice-tab.tsx
@@ -834,40 +834,44 @@ export function VoiceTab() {
               : t("settings.voice.dictation.engineBrowserDescription")
           }
         >
-          <Select
-            value={dictationEngine}
-            onValueChange={(value) => {
-              const next = value === "model" ? "model" : "browser";
-              if (next !== dictationEngine) {
-                // Unload whichever backend was resident for the old engine.
-                void unloadSttModel().catch(() => {});
-                if (next === "model") {
-                  setSttPhase("checking");
-                  setSttDevice(null);
-                  setSttDownload(null);
+          {isTauri ? (
+            <span className="text-sm text-muted-foreground">
+              {t("settings.voice.dictation.engineModel")}
+            </span>
+          ) : (
+            <Select
+              value={dictationEngine}
+              onValueChange={(value) => {
+                const next = value === "model" ? "model" : "browser";
+                if (next !== dictationEngine) {
+                  // Unload whichever backend was resident for the old engine.
+                  void unloadSttModel().catch(() => {});
+                  if (next === "model") {
+                    setSttPhase("checking");
+                    setSttDevice(null);
+                    setSttDownload(null);
+                  }
                 }
-              }
-              setDictationEngine(next);
-            }}
-          >
-            <SelectTrigger
-              aria-label="Dictation engine"
-              className="w-56"
-              size="sm"
+                setDictationEngine(next);
+              }}
             >
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {isTauri ? null : (
+              <SelectTrigger
+                aria-label="Dictation engine"
+                className="w-56"
+                size="sm"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
                 <SelectItem value="browser">
                   {t("settings.voice.dictation.engineBrowser")}
                 </SelectItem>
-              )}
-              <SelectItem value="model">
-                {t("settings.voice.dictation.engineModel")}
-              </SelectItem>
-            </SelectContent>
-          </Select>
+                <SelectItem value="model">
+                  {t("settings.voice.dictation.engineModel")}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          )}
         </SettingsRow>
 
         {isLocalEngine ? (

--- a/studio/frontend/src/features/settings/tabs/voice-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/voice-tab.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
+import { isTauri } from "@/lib/api-base";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -857,9 +858,11 @@ export function VoiceTab() {
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="browser">
-                {t("settings.voice.dictation.engineBrowser")}
-              </SelectItem>
+              {isTauri ? null : (
+                <SelectItem value="browser">
+                  {t("settings.voice.dictation.engineBrowser")}
+                </SelectItem>
+              )}
               <SelectItem value="model">
                 {t("settings.voice.dictation.engineModel")}
               </SelectItem>

--- a/studio/frontend/src/features/settings/tabs/voice-tab.tsx
+++ b/studio/frontend/src/features/settings/tabs/voice-tab.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-import { isTauri } from "@/lib/api-base";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -40,6 +39,7 @@ import {
 } from "@/features/hub";
 import { useDebouncedValue, useWheelScrollRef } from "@/hooks";
 import { useT } from "@/i18n";
+import { isTauri } from "@/lib/api-base";
 import { ChevronDownStandardIcon } from "@/lib/chevron-icons";
 import { MicIcon } from "@/lib/mic-icon";
 import { toast } from "@/lib/toast";


### PR DESCRIPTION
Clicking the mic in the desktop app failed with "Speech recognition is blocked by the browser speech service."

The webview exposes the speech API, so the support check passed and the mic button rendered but Apple's speech service refuses embedded webviews, so it only failed once you used it.

- Don't report browser speech as supported on desktop
- Default to the local STT model there, including for existing "browser" settings
- Show the engine as text in Voice settings instead of a one-option dropdown