### PR TITLE
Studio: handle a deleted dataset file instead of failing with a 500

### DIFF
--- a/studio/backend/routes/datasets.py
+++ b/studio/backend/routes/datasets.py
@@ -529,8 +529,7 @@ def check_format(request: CheckFormatRequest, current_subject: str = Depends(get
         dataset_path = resolve_dataset_path(request.dataset_name)
         total_rows = None
 
-        # An absolute path is a local file, never a HuggingFace repo id. Saying so
-        # beats failing later as a repo lookup with a 500.
+        # An absolute path is a local file, never a HuggingFace repo id.
         if not dataset_path.exists() and Path(request.dataset_name).is_absolute():
             raise HTTPException(
                 status_code = 404,

--- a/studio/backend/routes/datasets.py
+++ b/studio/backend/routes/datasets.py
@@ -538,9 +538,8 @@ def check_format(request: CheckFormatRequest, current_subject: str = Depends(get
         dataset_path = resolve_dataset_path(request.dataset_name)
         total_rows = None
 
-        # Local uploads and recipes are always sent as absolute paths, so a missing
-        # one is a deleted file rather than a Hub repo id. One stat() for both
-        # branches, or a file deleted in between would fall through both.
+        # Uploads and recipes always arrive as absolute paths, so a missing one is a
+        # deleted file, not a Hub repo id. One stat() for both branches.
         dataset_exists = dataset_path.exists()
         if not dataset_exists and _is_local_dataset_ref(request.dataset_name):
             raise HTTPException(status_code = 404, detail = _MISSING_DATASET_DETAIL)

--- a/studio/backend/routes/datasets.py
+++ b/studio/backend/routes/datasets.py
@@ -505,6 +505,17 @@ async def get_dataset_download_progress(
     )
 
 
+def _is_local_dataset_reference(raw: str) -> bool:
+    """Local upload/recipe reference, absolute or relative, vs a HuggingFace repo id."""
+    path = Path(raw)
+    if path.is_absolute():
+        return True
+    parts = [part for part in path.parts if part not in ("", ".")]
+    if parts[:2] == ["assets", "datasets"]:
+        parts = parts[2:]
+    return bool(parts) and parts[0] in ("uploads", "recipes")
+
+
 @router.post("/check-format", response_model = CheckFormatResponse)
 def check_format(request: CheckFormatRequest, current_subject: str = Depends(get_current_subject)):
     """Check if a dataset requires manual column mapping.
@@ -529,8 +540,7 @@ def check_format(request: CheckFormatRequest, current_subject: str = Depends(get
         dataset_path = resolve_dataset_path(request.dataset_name)
         total_rows = None
 
-        # An absolute path is a local file, never a HuggingFace repo id.
-        if not dataset_path.exists() and Path(request.dataset_name).is_absolute():
+        if not dataset_path.exists() and _is_local_dataset_reference(request.dataset_name):
             raise HTTPException(
                 status_code = 404,
                 detail = (

--- a/studio/backend/routes/datasets.py
+++ b/studio/backend/routes/datasets.py
@@ -510,30 +510,6 @@ _MISSING_DATASET_DETAIL = (
 )
 
 
-def _is_local_dataset_reference(raw: str) -> bool:
-    """Looks like a local upload/recipe reference. A Hub repo id can share the
-    `uploads/`-style prefix, so this only picks the error message after a failed
-    Hub lookup; an absolute path is decided up front."""
-    path = Path(raw)
-    if path.is_absolute():
-        return True
-    parts = [part for part in path.parts if part not in ("", ".")]
-    if parts[:2] == ["assets", "datasets"]:
-        parts = parts[2:]
-    return bool(parts) and parts[0] in ("uploads", "recipes")
-
-
-def _local_dataset_missing(raw: str) -> bool:
-    """Only true when the reference is local AND its file is really gone, so a
-    parse failure on a file that still exists keeps its own error."""
-    if not _is_local_dataset_reference(raw):
-        return False
-    try:
-        return not resolve_dataset_path(raw).exists()
-    except ValueError:
-        return False
-
-
 @router.post("/check-format", response_model = CheckFormatResponse)
 def check_format(request: CheckFormatRequest, current_subject: str = Depends(get_current_subject)):
     """Check if a dataset requires manual column mapping.
@@ -558,6 +534,8 @@ def check_format(request: CheckFormatRequest, current_subject: str = Depends(get
         dataset_path = resolve_dataset_path(request.dataset_name)
         total_rows = None
 
+        # Local uploads and recipes are always sent as absolute paths, so a missing
+        # one is a deleted file rather than a Hub repo id.
         if not dataset_path.exists() and Path(request.dataset_name).is_absolute():
             raise HTTPException(status_code = 404, detail = _MISSING_DATASET_DETAIL)
 
@@ -703,8 +681,6 @@ def check_format(request: CheckFormatRequest, current_subject: str = Depends(get
         raise
     except Exception as e:
         logger.error(f"Error checking dataset format: {e}", exc_info = True)
-        if _local_dataset_missing(request.dataset_name):
-            raise HTTPException(status_code = 404, detail = _MISSING_DATASET_DETAIL) from e
         raise HTTPException(status_code = 500, detail = "Failed to check dataset format")
 
 

--- a/studio/backend/routes/datasets.py
+++ b/studio/backend/routes/datasets.py
@@ -529,6 +529,17 @@ def check_format(request: CheckFormatRequest, current_subject: str = Depends(get
         dataset_path = resolve_dataset_path(request.dataset_name)
         total_rows = None
 
+        # An absolute path is a local file, never a HuggingFace repo id. Saying so
+        # beats failing later as a repo lookup with a 500.
+        if not dataset_path.exists() and Path(request.dataset_name).is_absolute():
+            raise HTTPException(
+                status_code = 404,
+                detail = (
+                    "This dataset file no longer exists. Upload it again or pick "
+                    "another dataset."
+                ),
+            )
+
         if dataset_path.exists():
             # ── Local file ──────────────────────────────────────────
             train_split = request.train_split or "train"

--- a/studio/backend/routes/datasets.py
+++ b/studio/backend/routes/datasets.py
@@ -505,9 +505,7 @@ async def get_dataset_download_progress(
     )
 
 
-_MISSING_DATASET_DETAIL = (
-    "This dataset is no longer on disk. Add it again or pick another dataset."
-)
+_MISSING_DATASET_DETAIL = "This dataset is no longer on disk. Add it again or pick another dataset."
 
 
 def _is_local_dataset_ref(dataset_name: str) -> bool:

--- a/studio/backend/routes/datasets.py
+++ b/studio/backend/routes/datasets.py
@@ -506,8 +506,14 @@ async def get_dataset_download_progress(
 
 
 _MISSING_DATASET_DETAIL = (
-    "This dataset file no longer exists. Upload it again or pick another dataset."
+    "This dataset is no longer on disk. Add it again or pick another dataset."
 )
+
+
+def _is_local_dataset_ref(dataset_name: str) -> bool:
+    """Absolute means local. Normalised like resolve_dataset_path, so a '~' or
+    space-padded spelling is not mistaken for a Hub repo id."""
+    return Path(str(dataset_name or "").strip()).expanduser().is_absolute()
 
 
 @router.post("/check-format", response_model = CheckFormatResponse)
@@ -535,11 +541,13 @@ def check_format(request: CheckFormatRequest, current_subject: str = Depends(get
         total_rows = None
 
         # Local uploads and recipes are always sent as absolute paths, so a missing
-        # one is a deleted file rather than a Hub repo id.
-        if not dataset_path.exists() and Path(request.dataset_name).is_absolute():
+        # one is a deleted file rather than a Hub repo id. One stat() for both
+        # branches, or a file deleted in between would fall through both.
+        dataset_exists = dataset_path.exists()
+        if not dataset_exists and _is_local_dataset_ref(request.dataset_name):
             raise HTTPException(status_code = 404, detail = _MISSING_DATASET_DETAIL)
 
-        if dataset_path.exists():
+        if dataset_exists:
             # ── Local file ──────────────────────────────────────────
             train_split = request.train_split or "train"
             preview_slice, total_rows = _load_local_preview_slice(

--- a/studio/backend/routes/datasets.py
+++ b/studio/backend/routes/datasets.py
@@ -505,8 +505,15 @@ async def get_dataset_download_progress(
     )
 
 
+_MISSING_DATASET_DETAIL = (
+    "This dataset file no longer exists. Upload it again or pick another dataset."
+)
+
+
 def _is_local_dataset_reference(raw: str) -> bool:
-    """Local upload/recipe reference, absolute or relative, vs a HuggingFace repo id."""
+    """Looks like a local upload/recipe reference. A Hub repo id can share the
+    `uploads/`-style prefix, so this only picks the error message after a failed
+    Hub lookup; an absolute path is decided up front."""
     path = Path(raw)
     if path.is_absolute():
         return True
@@ -540,14 +547,8 @@ def check_format(request: CheckFormatRequest, current_subject: str = Depends(get
         dataset_path = resolve_dataset_path(request.dataset_name)
         total_rows = None
 
-        if not dataset_path.exists() and _is_local_dataset_reference(request.dataset_name):
-            raise HTTPException(
-                status_code = 404,
-                detail = (
-                    "This dataset file no longer exists. Upload it again or pick "
-                    "another dataset."
-                ),
-            )
+        if not dataset_path.exists() and Path(request.dataset_name).is_absolute():
+            raise HTTPException(status_code = 404, detail = _MISSING_DATASET_DETAIL)
 
         if dataset_path.exists():
             # ── Local file ──────────────────────────────────────────
@@ -691,6 +692,8 @@ def check_format(request: CheckFormatRequest, current_subject: str = Depends(get
         raise
     except Exception as e:
         logger.error(f"Error checking dataset format: {e}", exc_info = True)
+        if _is_local_dataset_reference(request.dataset_name):
+            raise HTTPException(status_code = 404, detail = _MISSING_DATASET_DETAIL) from e
         raise HTTPException(status_code = 500, detail = "Failed to check dataset format")
 
 

--- a/studio/backend/routes/datasets.py
+++ b/studio/backend/routes/datasets.py
@@ -523,6 +523,17 @@ def _is_local_dataset_reference(raw: str) -> bool:
     return bool(parts) and parts[0] in ("uploads", "recipes")
 
 
+def _local_dataset_missing(raw: str) -> bool:
+    """Only true when the reference is local AND its file is really gone, so a
+    parse failure on a file that still exists keeps its own error."""
+    if not _is_local_dataset_reference(raw):
+        return False
+    try:
+        return not resolve_dataset_path(raw).exists()
+    except ValueError:
+        return False
+
+
 @router.post("/check-format", response_model = CheckFormatResponse)
 def check_format(request: CheckFormatRequest, current_subject: str = Depends(get_current_subject)):
     """Check if a dataset requires manual column mapping.
@@ -692,7 +703,7 @@ def check_format(request: CheckFormatRequest, current_subject: str = Depends(get
         raise
     except Exception as e:
         logger.error(f"Error checking dataset format: {e}", exc_info = True)
-        if _is_local_dataset_reference(request.dataset_name):
+        if _local_dataset_missing(request.dataset_name):
             raise HTTPException(status_code = 404, detail = _MISSING_DATASET_DETAIL) from e
         raise HTTPException(status_code = 500, detail = "Failed to check dataset format")
 

--- a/studio/backend/tests/test_dataset_check_format_missing.py
+++ b/studio/backend/tests/test_dataset_check_format_missing.py
@@ -23,6 +23,35 @@ def isolated_studio_home(tmp_path, monkeypatch):
     return tmp_path
 
 
+@pytest.fixture
+def no_hub(monkeypatch):
+    """Fail every Hub lookup in-process, recording what was asked for.
+
+    HF_HUB_OFFLINE is read into huggingface_hub.constants at import time, so
+    setting it from a test is a no-op and the lookups still dial out.
+    """
+    import huggingface_hub
+
+    attempts: list[str] = []
+
+    class _NoHubApi:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def list_repo_files(self, repo_id, **kwargs):
+            attempts.append(repo_id)
+            raise ConnectionError("Hub is unavailable in tests")
+
+    def _no_load_dataset(*args, **kwargs):
+        path = kwargs.get("path", args[0] if args else None)
+        attempts.append(str(path))
+        raise ConnectionError("Hub is unavailable in tests")
+
+    monkeypatch.setattr(huggingface_hub, "HfApi", _NoHubApi)
+    monkeypatch.setattr("datasets.load_dataset", _no_load_dataset)
+    return attempts
+
+
 def _check(dataset_name: str) -> HTTPException:
     request = datasets_route.CheckFormatRequest(dataset_name = dataset_name)
     with pytest.raises(HTTPException) as exc:
@@ -30,32 +59,61 @@ def _check(dataset_name: str) -> HTTPException:
     return exc.value
 
 
-def test_missing_upload_reports_404():
+def test_missing_upload_reports_404(no_hub):
     from utils.paths import dataset_uploads_root
 
     missing = dataset_uploads_root() / "deleted-upload-test-fixture.jsonl"
     assert not missing.exists()
     error = _check(str(missing))
     assert error.status_code == 404
-    assert "no longer exists" in error.detail
+    assert "no longer on disk" in error.detail
+    assert no_hub == [], "a local path must never be sent to the Hub as a repo id"
 
 
-def test_corrupt_local_file_keeps_its_own_error(monkeypatch):
+@pytest.mark.parametrize(
+    "spelling",
+    [
+        pytest.param("{path}", id = "as-sent-by-the-ui"),
+        pytest.param(" {path}", id = "leading-whitespace"),
+        pytest.param("{path} ", id = "trailing-whitespace"),
+    ],
+)
+def test_every_spelling_of_a_missing_upload_reports_404(spelling, no_hub):
+    """resolve_dataset_path strips before testing absoluteness, so a guard on the
+    raw string disagrees here and ships the local path to the Hub as a repo id."""
     from utils.paths import dataset_uploads_root
 
-    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
-    monkeypatch.setenv("HF_DATASETS_OFFLINE", "1")
+    missing = dataset_uploads_root() / "deleted-upload-test-fixture.jsonl"
+    error = _check(spelling.format(path = missing))
+    assert error.status_code == 404
+    assert no_hub == []
+
+
+def test_a_tilde_spelling_is_still_a_local_file(tmp_path, monkeypatch, no_hub):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path / ".unsloth" / "studio"))
+
+    error = _check("~/.unsloth/studio/assets/datasets/uploads/deleted.jsonl")
+    assert error.status_code == 404
+    assert no_hub == []
+
+
+def test_corrupt_local_file_keeps_its_own_error(no_hub):
+    from utils.paths import dataset_uploads_root
+
     corrupt = dataset_uploads_root() / "corrupt-test-fixture.jsonl"
     corrupt.parent.mkdir(parents = True, exist_ok = True)
     corrupt.write_text("{not valid json at all\n")
-    try:
-        assert _check(str(corrupt)).status_code != 404
-    finally:
-        corrupt.unlink(missing_ok = True)
+
+    error = _check(str(corrupt))
+    assert error.status_code == 500, "an unreadable file is not a missing one"
+    assert "no longer on disk" not in str(error.detail)
 
 
-def test_hub_repo_id_never_reports_a_deleted_file(monkeypatch):
-    # A repo id under an "uploads" namespace must keep its own Hub error.
-    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
-    monkeypatch.setenv("HF_DATASETS_OFFLINE", "1")
-    assert _check("uploads/private-or-unreachable").status_code != 404
+def test_hub_repo_id_never_reports_a_deleted_file(no_hub):
+    """A relative reference stays a Hub lookup, however local it looks."""
+    error = _check("uploads/private-or-unreachable")
+
+    assert error.status_code != 404
+    assert no_hub, "the Hub branch is where a relative reference belongs"

--- a/studio/backend/tests/test_dataset_check_format_missing.py
+++ b/studio/backend/tests/test_dataset_check_format_missing.py
@@ -16,6 +16,13 @@ if str(_BACKEND_ROOT) not in sys.path:
 from routes import datasets as datasets_route  # noqa: E402
 
 
+@pytest.fixture(autouse = True)
+def isolated_studio_home(tmp_path, monkeypatch):
+    """Keep fixtures out of the developer's real Studio uploads directory."""
+    monkeypatch.setenv("UNSLOTH_STUDIO_HOME", str(tmp_path))
+    return tmp_path
+
+
 def _check(dataset_name: str) -> HTTPException:
     request = datasets_route.CheckFormatRequest(dataset_name = dataset_name)
     with pytest.raises(HTTPException) as exc:

--- a/studio/backend/tests/test_dataset_check_format_missing.py
+++ b/studio/backend/tests/test_dataset_check_format_missing.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""A deleted upload must report itself, not fail as a repo lookup."""
+"""A deleted upload must report itself, without swallowing other failures."""
 
 import sys
 from pathlib import Path
@@ -16,49 +16,21 @@ if str(_BACKEND_ROOT) not in sys.path:
 from routes import datasets as datasets_route  # noqa: E402
 
 
-def _expect_missing_file_404(dataset_name: str) -> None:
+def _check(dataset_name: str) -> HTTPException:
     request = datasets_route.CheckFormatRequest(dataset_name = dataset_name)
     with pytest.raises(HTTPException) as exc:
         datasets_route.check_format(request, current_subject = "test")
-    assert exc.value.status_code == 404
-    assert "no longer exists" in exc.value.detail
+    return exc.value
 
 
-def test_missing_absolute_upload_reports_404():
+def test_missing_upload_reports_404():
     from utils.paths import dataset_uploads_root
 
     missing = dataset_uploads_root() / "deleted-upload-test-fixture.jsonl"
     assert not missing.exists()
-    _expect_missing_file_404(str(missing))
-
-
-# Relative refs can also be Hub repo ids, so they only become the missing-file
-# error once the Hub lookup fails; offline mode makes that failure deterministic.
-def test_missing_relative_upload_reports_404(monkeypatch):
-    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
-    monkeypatch.setenv("HF_DATASETS_OFFLINE", "1")
-    _expect_missing_file_404("uploads/deleted-upload-test-fixture.jsonl")
-
-
-def test_missing_relative_recipe_reports_404(monkeypatch):
-    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
-    monkeypatch.setenv("HF_DATASETS_OFFLINE", "1")
-    _expect_missing_file_404("recipes/deleted-recipe-test-fixture/parquet-files")
-
-
-@pytest.mark.parametrize(
-    "dataset_name, expected",
-    [
-        ("/tmp/some/upload.jsonl", True),
-        ("uploads/foo.jsonl", True),
-        ("assets/datasets/uploads/foo.jsonl", True),
-        ("recipes/foo/parquet-files", True),
-        ("unsloth/LaTeX_OCR", False),
-        ("squad", False),
-    ],
-)
-def test_local_reference_detection(dataset_name, expected):
-    assert datasets_route._is_local_dataset_reference(dataset_name) is expected
+    error = _check(str(missing))
+    assert error.status_code == 404
+    assert "no longer exists" in error.detail
 
 
 def test_corrupt_local_file_keeps_its_own_error(monkeypatch):
@@ -70,9 +42,13 @@ def test_corrupt_local_file_keeps_its_own_error(monkeypatch):
     corrupt.parent.mkdir(parents = True, exist_ok = True)
     corrupt.write_text("{not valid json at all\n")
     try:
-        request = datasets_route.CheckFormatRequest(dataset_name = str(corrupt))
-        with pytest.raises(HTTPException) as exc:
-            datasets_route.check_format(request, current_subject = "test")
-        assert exc.value.status_code != 404
+        assert _check(str(corrupt)).status_code != 404
     finally:
         corrupt.unlink(missing_ok = True)
+
+
+def test_hub_repo_id_never_reports_a_deleted_file(monkeypatch):
+    # A repo id under an "uploads" namespace must keep its own Hub error.
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("HF_DATASETS_OFFLINE", "1")
+    assert _check("uploads/private-or-unreachable").status_code != 404

--- a/studio/backend/tests/test_dataset_check_format_missing.py
+++ b/studio/backend/tests/test_dataset_check_format_missing.py
@@ -32,11 +32,17 @@ def test_missing_absolute_upload_reports_404():
     _expect_missing_file_404(str(missing))
 
 
-def test_missing_relative_upload_reports_404():
+# Relative refs can also be Hub repo ids, so they only become the missing-file
+# error once the Hub lookup fails; offline mode makes that failure deterministic.
+def test_missing_relative_upload_reports_404(monkeypatch):
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("HF_DATASETS_OFFLINE", "1")
     _expect_missing_file_404("uploads/deleted-upload-test-fixture.jsonl")
 
 
-def test_missing_relative_recipe_reports_404():
+def test_missing_relative_recipe_reports_404(monkeypatch):
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("HF_DATASETS_OFFLINE", "1")
     _expect_missing_file_404("recipes/deleted-recipe-test-fixture/parquet-files")
 
 

--- a/studio/backend/tests/test_dataset_check_format_missing.py
+++ b/studio/backend/tests/test_dataset_check_format_missing.py
@@ -16,24 +16,40 @@ if str(_BACKEND_ROOT) not in sys.path:
 from routes import datasets as datasets_route  # noqa: E402
 
 
-def test_missing_local_dataset_file_reports_404():
-    from utils.paths import dataset_uploads_root
-
-    missing = dataset_uploads_root() / "deleted-upload-test-fixture.jsonl"
-    assert not missing.exists()
-    request = datasets_route.CheckFormatRequest(dataset_name = str(missing))
-
+def _expect_missing_file_404(dataset_name: str) -> None:
+    request = datasets_route.CheckFormatRequest(dataset_name = dataset_name)
     with pytest.raises(HTTPException) as exc:
         datasets_route.check_format(request, current_subject = "test")
-
     assert exc.value.status_code == 404
     assert "no longer exists" in exc.value.detail
 
 
-def test_hf_repo_id_is_not_treated_as_a_missing_file():
-    request = datasets_route.CheckFormatRequest(dataset_name = "unsloth/does-not-exist")
+def test_missing_absolute_upload_reports_404():
+    from utils.paths import dataset_uploads_root
 
-    with pytest.raises(HTTPException) as exc:
-        datasets_route.check_format(request, current_subject = "test")
+    missing = dataset_uploads_root() / "deleted-upload-test-fixture.jsonl"
+    assert not missing.exists()
+    _expect_missing_file_404(str(missing))
 
-    assert exc.value.status_code != 404
+
+def test_missing_relative_upload_reports_404():
+    _expect_missing_file_404("uploads/deleted-upload-test-fixture.jsonl")
+
+
+def test_missing_relative_recipe_reports_404():
+    _expect_missing_file_404("recipes/deleted-recipe-test-fixture/parquet-files")
+
+
+@pytest.mark.parametrize(
+    "dataset_name, expected",
+    [
+        ("/tmp/some/upload.jsonl", True),
+        ("uploads/foo.jsonl", True),
+        ("assets/datasets/uploads/foo.jsonl", True),
+        ("recipes/foo/parquet-files", True),
+        ("unsloth/LaTeX_OCR", False),
+        ("squad", False),
+    ],
+)
+def test_local_reference_detection(dataset_name, expected):
+    assert datasets_route._is_local_dataset_reference(dataset_name) is expected

--- a/studio/backend/tests/test_dataset_check_format_missing.py
+++ b/studio/backend/tests/test_dataset_check_format_missing.py
@@ -59,3 +59,20 @@ def test_missing_relative_recipe_reports_404(monkeypatch):
 )
 def test_local_reference_detection(dataset_name, expected):
     assert datasets_route._is_local_dataset_reference(dataset_name) is expected
+
+
+def test_corrupt_local_file_keeps_its_own_error(monkeypatch):
+    from utils.paths import dataset_uploads_root
+
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("HF_DATASETS_OFFLINE", "1")
+    corrupt = dataset_uploads_root() / "corrupt-test-fixture.jsonl"
+    corrupt.parent.mkdir(parents = True, exist_ok = True)
+    corrupt.write_text("{not valid json at all\n")
+    try:
+        request = datasets_route.CheckFormatRequest(dataset_name = str(corrupt))
+        with pytest.raises(HTTPException) as exc:
+            datasets_route.check_format(request, current_subject = "test")
+        assert exc.value.status_code != 404
+    finally:
+        corrupt.unlink(missing_ok = True)

--- a/studio/backend/tests/test_dataset_check_format_missing.py
+++ b/studio/backend/tests/test_dataset_check_format_missing.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""A deleted upload must report itself, not fail as a HuggingFace repo lookup."""
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(_BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_ROOT))
+
+from routes import datasets as datasets_route  # noqa: E402
+
+
+def test_missing_local_dataset_file_reports_404():
+    from utils.paths import dataset_uploads_root
+
+    missing = dataset_uploads_root() / "deleted-upload-test-fixture.jsonl"
+    assert not missing.exists()
+    request = datasets_route.CheckFormatRequest(dataset_name = str(missing))
+
+    with pytest.raises(HTTPException) as exc:
+        datasets_route.check_format(request, current_subject = "test")
+
+    assert exc.value.status_code == 404
+    assert "no longer exists" in exc.value.detail
+
+
+def test_hf_repo_id_is_not_treated_as_a_missing_file():
+    request = datasets_route.CheckFormatRequest(dataset_name = "unsloth/does-not-exist")
+
+    with pytest.raises(HTTPException) as exc:
+        datasets_route.check_format(request, current_subject = "test")
+
+    assert exc.value.status_code != 404

--- a/studio/backend/tests/test_dataset_check_format_missing.py
+++ b/studio/backend/tests/test_dataset_check_format_missing.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
-"""A deleted upload must report itself, not fail as a HuggingFace repo lookup."""
+"""A deleted upload must report itself, not fail as a repo lookup."""
 
 import sys
 from pathlib import Path

--- a/studio/frontend/src/features/studio/sections/dataset-preview-dialog.tsx
+++ b/studio/frontend/src/features/studio/sections/dataset-preview-dialog.tsx
@@ -14,7 +14,11 @@ import { DataTable } from "@/components/ui/data-table";
 import { Badge } from "@/components/ui/badge";
 import { Spinner } from "@/components/ui/spinner";
 import { useTrainingActions, useTrainingConfigStore } from "@/features/training";
-import { checkDatasetFormat } from "@/features/training/api/datasets-api";
+import {
+  checkDatasetFormat,
+  DatasetFormatError,
+} from "@/features/training/api/datasets-api";
+import { clearDeletedDataset } from "@/features/training/stores/training-config-store";
 import { isRawTextDatasetFormat } from "@/features/training/lib/training-methods";
 import type { CheckFormatResponse } from "@/features/training/types/datasets";
 import type { DatasetSource } from "@/types/training";
@@ -217,6 +221,10 @@ export function DatasetPreviewDialog({
         }
       })
       .catch((err) => {
+        // Preview is a third way to learn the file is gone, so clear here too.
+        if (err instanceof DatasetFormatError && err.status === 404) {
+          clearDeletedDataset(datasetName);
+        }
         if (!cancelled) setError(err.message || "Failed to load preview");
       })
       .finally(() => {

--- a/studio/frontend/src/features/training/api/datasets-api.ts
+++ b/studio/frontend/src/features/training/api/datasets-api.ts
@@ -9,6 +9,16 @@ import type {
 import { authFetch } from "@/features/auth";
 import { readFastApiError } from "@/lib/format-fastapi-error";
 
+export class DatasetFormatError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "DatasetFormatError";
+    this.status = status;
+  }
+}
+
 type CheckDatasetFormatArgs = {
   datasetName: string;
   hfToken: string | null;
@@ -37,7 +47,7 @@ export async function checkDatasetFormat({
   });
 
   if (!res.ok) {
-    throw new Error(await readFastApiError(res));
+    throw new DatasetFormatError(await readFastApiError(res), res.status);
   }
 
   return res.json();

--- a/studio/frontend/src/features/training/hooks/use-training-actions.ts
+++ b/studio/frontend/src/features/training/hooks/use-training-actions.ts
@@ -6,7 +6,7 @@ import { prepareHfTokenForUse } from "@/features/hf-auth";
 import { confirmRemoteCodeIfNeeded } from "@/features/security";
 import { useCallback } from "react";
 import { toast } from "@/lib/toast";
-import { checkDatasetFormat } from "../api/datasets-api";
+import { checkDatasetFormat, DatasetFormatError } from "../api/datasets-api";
 import { emitTrainingRunsChanged } from "../events";
 import { getTrainingRun } from "../api/history-api";
 import { buildTrainingStartPayload } from "../api/mappers";
@@ -15,7 +15,7 @@ import { isRawTextDatasetFormat } from "../lib/training-methods";
 import { syncTrainingRuntimeFromBackend } from "../lib/sync-runtime";
 import { validateTrainingConfig } from "../lib/validation";
 import { useDatasetPreviewDialogStore } from "../stores/dataset-preview-dialog-store";
-import { useTrainingConfigStore } from "../stores/training-config-store";
+import { clearDeletedDataset, useTrainingConfigStore } from "../stores/training-config-store";
 import { useTrainingRuntimeStore } from "../stores/training-runtime-store";
 import type { TrainingStartRequest } from "../types/api";
 import type { TrainingConfigState } from "../types/config";
@@ -182,6 +182,10 @@ export function useTrainingActions() {
       await syncTrainingRuntimeFromBackend();
       return true;
     } catch (error) {
+      // A dataset deleted since the last check must not stay startable.
+      if (error instanceof DatasetFormatError && error.status === 404) {
+        clearDeletedDataset(getDatasetName(config) ?? "");
+      }
       const rawMessage =
         error instanceof Error ? error.message : "Failed to start training";
       const safeMessage = normalizeTrainingStartError(rawMessage);

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -1044,13 +1044,20 @@ if (import.meta.hot) {
   import.meta.hot.dispose(unsubscribeHfTokenMirror);
 }
 
+/** POSIX, Windows drive, UNC or extended-length path. A Hub repo id is never one. */
+function isLocalDatasetPath(datasetName: string): boolean {
+  return /^([/\\]|[A-Za-z]:[\\/])/.test(datasetName.trim());
+}
+
 /** Drop a selection whose file the backend reports as gone (404). */
 export function clearDeletedDataset(datasetName: string): void {
+  // Only a local file can be deleted, so an unrelated 404 cannot wipe a good pick.
+  if (!isLocalDatasetPath(datasetName)) return;
   const { dataset, uploadedFile, setDataset, selectLocalDataset } =
     useTrainingConfigStore.getState();
-  if (dataset === datasetName) {
-    setDataset(null);
-  } else if (uploadedFile === datasetName) {
+  if (uploadedFile === datasetName) {
     selectLocalDataset(null);
+  } else if (dataset === datasetName) {
+    setDataset(null);
   }
 }

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -520,12 +520,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             if (controller.signal.aborted) return;
             // Otherwise a deleted dataset stays selected and re-fails every visit.
             if (error instanceof DatasetFormatError && error.status === 404) {
-              const { dataset, uploadedFile, setDataset, selectLocalDataset } = get();
-              if (dataset === datasetName) {
-                setDataset(null);
-              } else if (uploadedFile === datasetName) {
-                selectLocalDataset(null);
-              }
+              clearDeletedDataset(datasetName);
               toast.error(error.message);
             }
             set({ isDatasetImage: null, isCheckingDataset: false });
@@ -1047,4 +1042,15 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
 const unsubscribeHfTokenMirror = mirrorHfTokenInto(useTrainingConfigStore);
 if (import.meta.hot) {
   import.meta.hot.dispose(unsubscribeHfTokenMirror);
+}
+
+/** Drop a selection whose file the backend reports as gone (404). */
+export function clearDeletedDataset(datasetName: string): void {
+  const { dataset, uploadedFile, setDataset, selectLocalDataset } =
+    useTrainingConfigStore.getState();
+  if (dataset === datasetName) {
+    setDataset(null);
+  } else if (uploadedFile === datasetName) {
+    selectLocalDataset(null);
+  }
 }

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -518,8 +518,7 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
           })
           .catch((error: unknown) => {
             if (controller.signal.aborted) return;
-            // A deleted upload stays selected forever otherwise, re-failing on
-            // every visit.
+            // Otherwise a deleted upload stays selected and re-fails every visit.
             if (error instanceof DatasetFormatError && error.status === 404) {
               if (get().dataset === datasetName) {
                 get().setDataset("");

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -10,7 +10,7 @@ import type { ModelType, StepNumber, TrainingMethod } from "@/types/training";
 import { toast } from "sonner";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import { checkDatasetFormat } from "../api/datasets-api";
+import { checkDatasetFormat, DatasetFormatError } from "../api/datasets-api";
 import { checkVisionModel, getModelConfig } from "../api/models-api";
 import { mapBackendModelConfigToTrainingPatch } from "../lib/model-defaults";
 import { isRawTextDatasetFormat } from "../lib/training-methods";
@@ -516,8 +516,17 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
             }
             set(updates);
           })
-          .catch(() => {
+          .catch((error: unknown) => {
             if (controller.signal.aborted) return;
+            // A deleted upload stays selected forever otherwise, re-failing on
+            // every visit.
+            if (error instanceof DatasetFormatError && error.status === 404) {
+              if (get().dataset === datasetName) {
+                get().setDataset("");
+                toast.error(error.message);
+              }
+              return;
+            }
             set({ isDatasetImage: null, isCheckingDataset: false });
           });
       };

--- a/studio/frontend/src/features/training/stores/training-config-store.ts
+++ b/studio/frontend/src/features/training/stores/training-config-store.ts
@@ -518,13 +518,15 @@ export const useTrainingConfigStore = create<TrainingConfigStore>()(
           })
           .catch((error: unknown) => {
             if (controller.signal.aborted) return;
-            // Otherwise a deleted upload stays selected and re-fails every visit.
+            // Otherwise a deleted dataset stays selected and re-fails every visit.
             if (error instanceof DatasetFormatError && error.status === 404) {
-              if (get().dataset === datasetName) {
-                get().setDataset("");
-                toast.error(error.message);
+              const { dataset, uploadedFile, setDataset, selectLocalDataset } = get();
+              if (dataset === datasetName) {
+                setDataset(null);
+              } else if (uploadedFile === datasetName) {
+                selectLocalDataset(null);
               }
-              return;
+              toast.error(error.message);
             }
             set({ isDatasetImage: null, isCheckingDataset: false });
           });


### PR DESCRIPTION
Selecting a dataset whose file was since deleted returned HTTP 500 with a raw FileNotFoundError traceback. The training page kept the dead selection, showed no error, and left Start Training enabled so users could start a run against a file
that doesn't exist.

An absolute path is a local file, never a HuggingFace repo id, so a missing one is now reported directly instead of falling through to a repo lookup.

- Backend returns 404: "This dataset file no longer exists. Upload it again or pick another dataset."
- The training page clears the selection on that 404 and shows the message