### PR TITLE
 Studio: select CUDA wheels by GPU architecture

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2678,12 +2678,12 @@ _probe_amd_gfx_arch() {
 # provide a conservative architecture set.
 _visible_nvidia_compute_caps() {
     _vncc_smi="$1"
-    [ -n "$_vncc_smi" ] || return 2
+    [ -n "$_vncc_smi" ] || return 0
     if ! _vncc_rows=$(_run_bounded "$_vncc_smi" \
         --query-gpu=index,uuid,compute_cap --format=csv,noheader,nounits 2>/dev/null); then
-        return 2
+        return 0
     fi
-    [ -n "$_vncc_rows" ] || return 2
+    [ -n "$_vncc_rows" ] || return 0
 
     _vncc_mask_set=0
     _vncc_mask=""
@@ -2713,10 +2713,10 @@ _visible_nvidia_compute_caps() {
             cap[row_count] = trim($3)
         }
         END {
-            if (inventory_invalid) exit 2
+            if (inventory_invalid) exit
             if (!mask_set) {
                 for (row = 1; row <= row_count; row++) {
-                    if (cap[row] !~ /^[0-9]+\.[0-9]+$/) exit 2
+                    if (cap[row] !~ /^[0-9]+\.[0-9]+$/) exit
                 }
                 for (row = 1; row <= row_count; row++) {
                     print cap[row]
@@ -2758,15 +2758,15 @@ _visible_nvidia_compute_caps() {
             }
             if (unresolved_mask) {
                 for (row = 1; row <= row_count; row++) {
-                    if (cap[row] !~ /^[0-9]+\.[0-9]+$/) exit 2
+                    if (cap[row] !~ /^[0-9]+\.[0-9]+$/) exit
                 }
                 for (row = 1; row <= row_count; row++) {
                     print cap[row]
                 }
-                exit 2
+                exit
             }
             for (i = 1; i <= selected_count; i++) {
-                if (selected_cap[i] !~ /^[0-9]+\.[0-9]+$/) exit 2
+                if (selected_cap[i] !~ /^[0-9]+\.[0-9]+$/) exit
             }
             for (i = 1; i <= selected_count; i++) {
                 print selected_cap[i]
@@ -3014,8 +3014,7 @@ get_torch_index_url() {
             -e 's/.*CUDA UMD Version:[[:space:]]*\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' \
             -e 's/.*CUDA Version:[[:space:]]*\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' \
         | head -1)
-    # Unresolved visibility can still return conservative physical caps.
-    if ! _compute_caps=$(_visible_nvidia_compute_caps "$_smi"); then :; fi
+    _compute_caps=$(_visible_nvidia_compute_caps "$_smi")
     if [ -z "$_cuda_ver" ]; then
         echo "[WARN] Could not determine CUDA version from nvidia-smi, using the cu126 driver fallback" >&2
         _major=""

--- a/install.sh
+++ b/install.sh
@@ -2672,6 +2672,179 @@ _probe_amd_gfx_arch() {
     printf '%s\n' "$_pg"
 }
 
+# Print the compute capabilities for NVIDIA GPUs visible to CUDA. Querying index
+# and UUID lets a partial CUDA_VISIBLE_DEVICES mask select the same physical rows
+# that torch will see. When exact mask resolution is unsafe, all physical rows
+# provide a conservative architecture set.
+_visible_nvidia_compute_caps() {
+    _vncc_smi="$1"
+    [ -n "$_vncc_smi" ] || return 2
+    if ! _vncc_rows=$(_run_bounded "$_vncc_smi" \
+        --query-gpu=index,uuid,compute_cap --format=csv,noheader,nounits 2>/dev/null); then
+        return 2
+    fi
+    [ -n "$_vncc_rows" ] || return 2
+
+    _vncc_mask_set=0
+    _vncc_mask=""
+    if [ "${CUDA_VISIBLE_DEVICES+set}" = "set" ]; then
+        _vncc_mask_set=1
+        _vncc_mask="$CUDA_VISIBLE_DEVICES"
+    fi
+    printf '%s\n' "$_vncc_rows" | awk -F',' \
+        -v mask_set="$_vncc_mask_set" -v mask="$_vncc_mask" \
+        -v device_order="${CUDA_DEVICE_ORDER-PCI_BUS_ID}" '
+        function trim(value) {
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+            return value
+        }
+        BEGIN {
+            if (mask_set) {
+                count = split(mask, raw_tokens, ",")
+                for (i = 1; i <= count; i++) {
+                    tokens[++token_count] = tolower(trim(raw_tokens[i]))
+                }
+            }
+        }
+        {
+            if (NF != 3) inventory_invalid = 1
+            gpu_index[++row_count] = trim($1)
+            uuid[row_count] = tolower(trim($2))
+            cap[row_count] = trim($3)
+        }
+        END {
+            if (inventory_invalid) exit 2
+            if (!mask_set) {
+                for (row = 1; row <= row_count; row++) {
+                    if (cap[row] !~ /^[0-9]+\.[0-9]+$/) exit 2
+                }
+                for (row = 1; row <= row_count; row++) {
+                    print cap[row]
+                }
+                exit
+            }
+            for (i = 1; i <= token_count; i++) {
+                token = tokens[i]
+                matched_row = 0
+                match_count = 0
+                if (token ~ /^[0-9]+$/) {
+                    if (toupper(device_order) != "PCI_BUS_ID") {
+                        unresolved_mask = 1
+                        break
+                    }
+                    for (row = 1; row <= row_count; row++) {
+                        if (token == gpu_index[row]) {
+                            matched_row = row
+                            match_count = 1
+                            break
+                        }
+                    }
+                } else if (token ~ /^gpu-/) {
+                    for (row = 1; row <= row_count; row++) {
+                        if (index(uuid[row], token) == 1) {
+                            matched_row = row
+                            match_count++
+                        }
+                    }
+                } else if (token ~ /^mig-/) {
+                    unresolved_mask = 1
+                    break
+                }
+                # CUDA exposes the valid prefix and stops at an invalid,
+                # ambiguous, or duplicate token.
+                if (match_count != 1 || seen[matched_row]) break
+                seen[matched_row] = 1
+                selected_cap[++selected_count] = cap[matched_row]
+            }
+            if (unresolved_mask) {
+                for (row = 1; row <= row_count; row++) {
+                    if (cap[row] !~ /^[0-9]+\.[0-9]+$/) exit 2
+                }
+                for (row = 1; row <= row_count; row++) {
+                    print cap[row]
+                }
+                exit 2
+            }
+            for (i = 1; i <= selected_count; i++) {
+                if (selected_cap[i] !~ /^[0-9]+\.[0-9]+$/) exit 2
+            }
+            for (i = 1; i <= selected_count; i++) {
+                print selected_cap[i]
+            }
+        }
+    '
+}
+
+# Driver compatibility is only an upper bound. PyTorch 2.11's cu128/cu130
+# wheels start at sm_75, while cu126 is the current family that still contains
+# Maxwell, Pascal, and Volta kernels. No 2.11 family spans those legacy GPUs and
+# Blackwell, so require the user to choose a compatible visible GPU set.
+_cuda_torch_tag_for_host() {
+    _cttfh_major="$1"
+    _cttfh_minor="$2"
+    _cttfh_caps="$3"
+
+    _cttfh_driver_known=1
+    if [ -z "$_cttfh_major" ] || [ -z "$_cttfh_minor" ]; then
+        _cttfh_driver_known=0
+        _cttfh_major=12
+        _cttfh_minor=6
+    fi
+    if [ "$_cttfh_major" -ge 13 ]; then _cttfh_tag="cu130"
+    elif [ "$_cttfh_major" -eq 12 ] && [ "$_cttfh_minor" -ge 8 ]; then _cttfh_tag="cu128"
+    elif [ "$_cttfh_major" -eq 12 ] && [ "$_cttfh_minor" -ge 6 ]; then _cttfh_tag="cu126"
+    elif [ "$_cttfh_major" -ge 12 ]; then _cttfh_tag="cu124"
+    elif [ "$_cttfh_major" -ge 11 ]; then _cttfh_tag="cu118"
+    else _cttfh_tag="cpu"
+    fi
+
+    # This cutoff is the PyTorch 2.11 Linux x86_64 wheel matrix. Other
+    # architectures retain the existing driver-only selection.
+    case "$(uname -s):${_ARCH:-$(uname -m)}" in
+        Linux:x86_64|Linux:amd64) ;;
+        *) printf '%s\n' "$_cttfh_tag"; return ;;
+    esac
+    [ -n "$_cttfh_caps" ] || { printf '%s\n' "$_cttfh_tag"; return; }
+    _cttfh_flags=$(printf '%s\n' "$_cttfh_caps" | awk -F. '
+        /^[0-9]+\.[0-9]+$/ {
+            sm = ($1 * 10) + $2
+            if (sm < 75) legacy = 1
+            if (sm >= 100) blackwell = 1
+        }
+        END { print legacy + 0, blackwell + 0 }
+    ')
+    _cttfh_legacy=${_cttfh_flags%% *}
+    _cttfh_blackwell=${_cttfh_flags#* }
+    if [ "$_cttfh_legacy" -eq 1 ] && [ "$_cttfh_blackwell" -eq 1 ]; then
+        echo "[ERROR] The visible NVIDIA GPUs include both pre-Turing (sm_<75) and Blackwell (sm_>=100) devices." >&2
+        echo "[ERROR] PyTorch 2.11 has no CUDA wheel family that supports both. Set CUDA_VISIBLE_DEVICES to a compatible GPU group and re-run the installer." >&2
+        return 1
+    fi
+    if [ "$_cttfh_legacy" -eq 1 ]; then
+        case "$_cttfh_tag" in
+            cu128|cu130)
+                echo "[WARN] A pre-Turing NVIDIA GPU was detected; selecting cu126 because PyTorch 2.11 cu128/cu130 require sm_75 or newer." >&2
+                _cttfh_tag="cu126"
+                ;;
+        esac
+    fi
+    if [ "$_cttfh_blackwell" -eq 1 ]; then
+        case "$_cttfh_tag" in
+            cu118|cu124|cu126)
+                if [ "$_cttfh_driver_known" -eq 0 ]; then
+                    echo "[ERROR] The visible NVIDIA GPUs require cu128 or newer, but the NVIDIA driver's CUDA compatibility could not be determined." >&2
+                    echo "[ERROR] Verify or update the NVIDIA driver and re-run the installer." >&2
+                else
+                    echo "[ERROR] The visible NVIDIA GPUs require cu128 or newer, but the installed driver supports only $_cttfh_tag." >&2
+                    echo "[ERROR] Update the NVIDIA driver and re-run the installer." >&2
+                fi
+                return 1
+                ;;
+        esac
+    fi
+    printf '%s\n' "$_cttfh_tag"
+}
+
 # ── Detect GPU and choose PyTorch index URL ──
 # Mirrors Get-TorchIndexUrl in install.ps1.
 # On CPU-only machines this returns the cpu index, avoiding the solver
@@ -2841,18 +3014,18 @@ get_torch_index_url() {
             -e 's/.*CUDA UMD Version:[[:space:]]*\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' \
             -e 's/.*CUDA Version:[[:space:]]*\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' \
         | head -1)
+    # Unresolved visibility can still return conservative physical caps.
+    if ! _compute_caps=$(_visible_nvidia_compute_caps "$_smi"); then :; fi
     if [ -z "$_cuda_ver" ]; then
-        echo "[WARN] Could not determine CUDA version from nvidia-smi, defaulting to cu126" >&2
-        echo "$_base/cu126"; return
+        echo "[WARN] Could not determine CUDA version from nvidia-smi, using the cu126 driver fallback" >&2
+        _major=""
+        _minor=""
+    else
+        _major=${_cuda_ver%%.*}
+        _minor=${_cuda_ver#*.}
     fi
-    _major=${_cuda_ver%%.*}
-    _minor=${_cuda_ver#*.}
-    if [ "$_major" -ge 13 ]; then echo "$_base/cu130"
-    elif [ "$_major" -eq 12 ] && [ "$_minor" -ge 8 ]; then echo "$_base/cu128"
-    elif [ "$_major" -eq 12 ] && [ "$_minor" -ge 6 ]; then echo "$_base/cu126"
-    elif [ "$_major" -ge 12 ]; then echo "$_base/cu124"
-    elif [ "$_major" -ge 11 ]; then echo "$_base/cu118"
-    else echo "$_base/cpu"; fi
+    _cuda_tag=$(_cuda_torch_tag_for_host "$_major" "$_minor" "$_compute_caps") || return 1
+    echo "$_base/$_cuda_tag"
 }
 
 # ── Torch flavor helpers (to repair a stale CPU / wrong-CUDA wheel) ──

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -1187,7 +1187,7 @@ def normalized_requested_llama_tag(requested_tag: str | None) -> str:
 normalize_compute_cap = _core.normalize_compute_cap
 normalize_compute_caps = _core.normalize_compute_caps
 parse_cuda_visible_devices = _core.parse_cuda_visible_devices
-supports_explicit_visible_device_matching = _core.supports_explicit_visible_device_matching
+can_resolve_cuda_visible_device_tokens = _core.can_resolve_cuda_visible_device_tokens
 select_visible_gpu_rows = _core.select_visible_gpu_rows
 dir_provides_exact_library = _core.dir_provides_exact_library
 
@@ -2383,24 +2383,36 @@ def detect_host() -> HostInfo:
                 ],
                 timeout = 20,
             )
-            visible_gpu_rows: list[tuple[str, str, str]] = []
+            gpu_rows: list[tuple[str, str, str]] = []
+            inventory_complete = True
             for raw in caps.stdout.splitlines():
                 parts = [part.strip() for part in raw.split(",")]
                 if len(parts) != 3:
-                    continue
+                    inventory_complete = False
+                    break
                 index, uuid, cap = parts
-                visible_gpu_row = select_visible_gpu_rows(
-                    [(index, uuid, cap)],
+                gpu_rows.append((index, uuid, cap))
+
+            tokens_resolvable = visible_device_tokens is None or not visible_device_tokens or (
+                can_resolve_cuda_visible_device_tokens(
                     visible_device_tokens,
+                    os.environ.get("CUDA_DEVICE_ORDER", "PCI_BUS_ID"),
                 )
-                if not visible_gpu_row:
-                    continue
-                visible_gpu_rows.extend(visible_gpu_row)
-                normalized_cap = normalize_compute_cap(cap)
-                if normalized_cap is None:
-                    continue
-                if normalized_cap not in compute_caps:
-                    compute_caps.append(normalized_cap)
+            )
+            inventory_resolved = inventory_complete and bool(gpu_rows) and tokens_resolvable
+            if inventory_resolved:
+                visible_gpu_rows = select_visible_gpu_rows(gpu_rows, visible_device_tokens)
+            elif inventory_complete and gpu_rows and not tokens_resolvable:
+                # Exact ordinal/MIG mapping is unavailable. All physical rows
+                # conservatively cover every GPU the mask could expose.
+                visible_gpu_rows = gpu_rows
+            else:
+                visible_gpu_rows = []
+            normalized_caps = [normalize_compute_cap(row[2]) for row in visible_gpu_rows]
+            if all(cap is not None for cap in normalized_caps):
+                compute_caps.extend(
+                    cap for cap in normalized_caps if cap is not None and cap not in compute_caps
+                )
 
             if visible_gpu_rows:
                 has_usable_nvidia = True
@@ -2412,7 +2424,7 @@ def detect_host() -> HostInfo:
                     has_physical_nvidia = True
             elif visible_device_tokens == []:
                 has_usable_nvidia = False
-            elif supports_explicit_visible_device_matching(visible_device_tokens):
+            elif inventory_resolved:
                 has_usable_nvidia = False
             elif has_physical_nvidia:
                 has_usable_nvidia = True

--- a/studio/install_python_stack.py
+++ b/studio/install_python_stack.py
@@ -30,6 +30,13 @@ if str(_BACKEND_DIR) not in sys.path:
 
 # setup.sh/setup.ps1 invoke this by path, so its directory is sys.path[0].
 import install_manifest  # noqa: E402
+from prebuilt_core import (  # noqa: E402
+    can_resolve_cuda_visible_device_tokens,
+    normalize_compute_cap,
+    normalize_compute_caps,
+    parse_cuda_visible_devices,
+    select_visible_gpu_rows,
+)
 
 from backend.utils.wheel_utils import (
     flash_attn_package_version,
@@ -46,6 +53,9 @@ IS_MACOS = sys.platform == "darwin"
 IS_MAC_INTEL = IS_MACOS and platform.machine() == "x86_64"
 IS_MAC_ARM = IS_MACOS and platform.machine() == "arm64"
 IS_LINUX = sys.platform.startswith("linux")
+_VISIBLE_NVIDIA_CAPS_CACHE: dict[
+    tuple[str, str | None, str | None], tuple[tuple[str, ...], bool]
+] = {}
 
 # amd-smi auto-elevates on Windows (UAC/DiskPart prompt mid-install). This installer
 # only spawns probes and pip/uv (no elevation), so set __COMPAT_LAYER=RunAsInvoker
@@ -1327,14 +1337,207 @@ def _install_bnb_windows_rocm() -> bool:
     return True
 
 
-def _detect_cuda_torch_index_url() -> str:
-    """Return the pytorch.org CUDA wheel index URL for the host's NVIDIA driver.
+def _cuda_torch_tag_for_host(
+    driver_version: tuple[int, int] | None,
+    compute_caps: list[str],
+) -> str:
+    """Choose a wheel family supported by the driver and every visible GPU."""
+    major, minor = driver_version or (12, 6)
+    if major >= 13:
+        tag = "cu130"
+    elif major == 12 and minor >= 8:
+        tag = "cu128"
+    elif major == 12 and minor >= 6:
+        tag = "cu126"
+    elif major >= 12:
+        tag = "cu124"
+    elif major >= 11:
+        tag = "cu118"
+    else:
+        return "cpu"
+
+    if not IS_LINUX or platform.machine().lower() not in {"x86_64", "amd64"}:
+        return tag
+    sms = [int(cap) for cap in normalize_compute_caps(compute_caps)]
+    has_legacy = any(sm < 75 for sm in sms)
+    has_blackwell = any(sm >= 100 for sm in sms)
+    if has_legacy and has_blackwell:
+        raise RuntimeError(
+            "The visible NVIDIA GPUs include both pre-Turing (sm_<75) and Blackwell "
+            "(sm_>=100) devices. PyTorch 2.11 has no CUDA wheel family that supports "
+            "both. Set CUDA_VISIBLE_DEVICES to a compatible GPU group and retry."
+        )
+    if _cuda_torch_family_supports_compute_caps(tag, compute_caps):
+        return tag
+    if has_legacy:
+        return "cu126"
+    if driver_version is None:
+        raise RuntimeError(
+            "The visible NVIDIA GPUs require cu128 or newer, but the NVIDIA "
+            "driver's CUDA compatibility could not be determined. Verify or "
+            "update the NVIDIA driver and retry."
+        )
+    raise RuntimeError(
+        f"The visible NVIDIA GPUs require cu128 or newer, but the installed "
+        f"driver supports only {tag}. Update the NVIDIA driver and retry."
+    )
+
+
+def _visible_nvidia_compute_caps(exe: str) -> tuple[list[str], bool]:
+    """Return visible capabilities and whether the inventory was fully resolved."""
+    visible_value = os.environ.get("CUDA_VISIBLE_DEVICES")
+    # Studio defaults CUDA to PCI ordering before runtime GPU use. Mirror that
+    # default here so numeric masks name the same nvidia-smi rows.
+    device_order = os.environ.get("CUDA_DEVICE_ORDER", "PCI_BUS_ID")
+    cache_key = (exe, visible_value, device_order)
+    if cache_key in _VISIBLE_NVIDIA_CAPS_CACHE:
+        cached_caps, cached_resolved = _VISIBLE_NVIDIA_CAPS_CACHE[cache_key]
+        return list(cached_caps), cached_resolved
+
+    try:
+        result = subprocess.run(
+            [
+                exe,
+                "--query-gpu=index,uuid,compute_cap",
+                "--format=csv,noheader,nounits",
+            ],
+            stdout = subprocess.PIPE,
+            stderr = subprocess.DEVNULL,
+            text = True,
+            timeout = 10,
+        )
+    except Exception:
+        result = None
+
+    if result is None or result.returncode != 0:
+        return [], False
+
+    rows: list[tuple[str, str, str]] = []
+    for line in result.stdout.splitlines():
+        parts = [part.strip() for part in line.split(",")]
+        if len(parts) != 3:
+            return [], False
+        rows.append((parts[0], parts[1], parts[2]))
+    if not rows:
+        return [], False
+
+    visible_devices = parse_cuda_visible_devices(visible_value)
+    if visible_devices and visible_devices[0].isdigit() and (
+        int(visible_devices[0]) >= len(rows)
+    ):
+        _VISIBLE_NVIDIA_CAPS_CACHE[cache_key] = ((), True)
+        return [], True
+    if visible_devices is not None and visible_devices and not (
+        can_resolve_cuda_visible_device_tokens(visible_devices, device_order)
+    ):
+        # The exact ordinal or MIG parent is unknown. Evaluating every physical
+        # row is conservative: the chosen family can serve any possible subset.
+        normalized_rows: list[str] = []
+        for _, _, raw_cap in rows:
+            normalized_cap = normalize_compute_cap(raw_cap)
+            if normalized_cap is None:
+                return [], False
+            normalized_rows.append(normalized_cap)
+        caps = normalize_compute_caps(normalized_rows)
+        _VISIBLE_NVIDIA_CAPS_CACHE[cache_key] = (tuple(caps), False)
+        return caps, False
+    selected = select_visible_gpu_rows(rows, visible_devices)
+    normalized_selected: list[str] = []
+    for _, _, raw_cap in selected:
+        normalized_cap = normalize_compute_cap(raw_cap)
+        if normalized_cap is None:
+            return [], False
+        normalized_selected.append(normalized_cap)
+    caps = normalize_compute_caps(normalized_selected)
+    _VISIBLE_NVIDIA_CAPS_CACHE[cache_key] = (tuple(caps), True)
+    return caps, True
+
+
+def _nvidia_driver_cuda_version(exe: str) -> tuple[int, int] | None:
+    try:
+        result = subprocess.run(
+            [exe],
+            stdout = subprocess.PIPE,
+            stderr = subprocess.DEVNULL,
+            text = True,
+            timeout = 10,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    match = re.search(r"CUDA(?: UMD)? Version:\s*(\d+)\.(\d+)", result.stdout)
+    if match is None:
+        return None
+    return int(match.group(1)), int(match.group(2))
+
+
+def _cuda_torch_family_within_driver(
+    family: str,
+    driver_version: tuple[int, int],
+) -> bool:
+    family_match = re.fullmatch(r"cu(\d+)", family)
+    driver_family = _cuda_torch_tag_for_host(driver_version, [])
+    driver_match = re.fullmatch(r"cu(\d+)", driver_family)
+    return bool(
+        family_match
+        and driver_match
+        and int(family_match.group(1)) <= int(driver_match.group(1))
+    )
+
+
+def _cuda_torch_family_supports_compute_caps(
+    family: str,
+    compute_caps: list[str],
+    torch_version: str | None = None,
+) -> bool:
+    """Whether a PyTorch 2.11 CUDA family crosses a known architecture cutoff."""
+    if not IS_LINUX or platform.machine().lower() not in {"x86_64", "amd64"}:
+        return True
+    sms = [int(cap) for cap in normalize_compute_caps(compute_caps)]
+    if not sms:
+        return True
+    match = re.fullmatch(r"cu(\d+)", family)
+    if match is None:
+        return False
+    family_number = int(match.group(1))
+    if family_number >= 128:
+        version_match = re.match(r"(\d+)\.(\d+)", torch_version or "")
+        if (
+            family_number < 130
+            and version_match is not None
+            and (int(version_match.group(1)), int(version_match.group(2))) < (2, 11)
+        ):
+            return all(sm >= 70 for sm in sms)
+        return all(sm >= 75 for sm in sms)
+    return all(sm < 100 for sm in sms)
+
+
+def _cuda_torch_index_url_for_host(
+    driver_version: tuple[int, int] | None,
+    compute_caps: list[str],
+) -> str:
+    tag = _cuda_torch_tag_for_host(driver_version, compute_caps)
+    if compute_caps and tag == "cu126" and driver_version is not None:
+        major, minor = driver_version
+        if major >= 13 or (major == 12 and minor >= 8):
+            print(
+                "   pre-Turing NVIDIA GPU detected; selecting cu126 because "
+                "PyTorch 2.11 cu128/cu130 require sm_75 or newer"
+            )
+    return f"{_PYTORCH_WHL_BASE}/{tag}"
+
+
+def _detect_cuda_torch_index_url(compute_caps: list[str] | None = None) -> str:
+    """Return the pytorch.org CUDA wheel index URL for the NVIDIA host.
 
     Mirrors install.sh::get_torch_index_url's CUDA ladder so `studio update` repairs
     to the same wheel family a fresh install would pick. Honours the explicit
     overrides first (UNSLOTH_TORCH_INDEX_URL / _FAMILY) so a headless / CI install
     never lets the host GPU decide. Otherwise probes nvidia-smi (parsing both "CUDA
-    Version:" and "CUDA UMD Version:"), defaulting to cu126 when unreadable.
+    Version:" and "CUDA UMD Version:"). Driver support is an upper bound; the
+    visible GPU architectures can cap the family at cu126. Defaults to cu126
+    when the driver version is unreadable.
     """
     _override_url = os.environ.get("UNSLOTH_TORCH_INDEX_URL", "").strip()
     if _override_url:
@@ -1345,35 +1548,13 @@ def _detect_cuda_torch_index_url() -> str:
     exe = shutil.which("nvidia-smi")
     if not exe and os.path.isfile("/usr/bin/nvidia-smi"):
         exe = "/usr/bin/nvidia-smi"
-    tag = "cu126"  # default when the driver CUDA version cannot be read
+    driver_version: tuple[int, int] | None = None
+    visible_caps = compute_caps or []
     if exe:
-        try:
-            result = subprocess.run(
-                [exe],
-                stdout = subprocess.PIPE,
-                stderr = subprocess.DEVNULL,
-                text = True,
-                timeout = 10,
-            )
-            if result.returncode == 0:
-                m = re.search(r"CUDA(?: UMD)? Version:\s*(\d+)\.(\d+)", result.stdout)
-                if m:
-                    major, minor = int(m.group(1)), int(m.group(2))
-                    if major >= 13:
-                        tag = "cu130"
-                    elif major == 12 and minor >= 8:
-                        tag = "cu128"
-                    elif major == 12 and minor >= 6:
-                        tag = "cu126"
-                    elif major >= 12:
-                        tag = "cu124"
-                    elif major >= 11:
-                        tag = "cu118"
-                    else:
-                        tag = "cpu"  # ancient driver: no usable CUDA wheels
-        except Exception:
-            pass
-    return f"{_PYTORCH_WHL_BASE}/{tag}"
+        driver_version = _nvidia_driver_cuda_version(exe)
+        if compute_caps is None:
+            visible_caps, _ = _visible_nvidia_compute_caps(exe)
+    return _cuda_torch_index_url_for_host(driver_version, visible_caps)
 
 
 def _explicit_torch_index_url() -> "str | None":
@@ -1528,7 +1709,7 @@ def _explicit_unknown_family_torch_index_url() -> "str | None":
 
 
 def _ensure_cuda_torch() -> None:
-    """Repair a venv whose torch is a ROCm build on an NVIDIA host.
+    """Repair a venv whose torch backend or CUDA family cannot serve the host.
 
     Counterpart to _ensure_rocm_torch. A venv poisoned by the pre-fix KFD
     gpu_id false positive (ROCm torch installed on an NVIDIA-only machine)
@@ -1536,8 +1717,8 @@ def _ensure_cuda_torch() -> None:
     satisfies the version constraint and nothing force-reinstalls it. This
     detects that exact case and reinstalls CUDA torch.
 
-    Only repairs when torch actually links against HIP/ROCm. Healthy CUDA
-    torch and deliberate CPU-only torch are left untouched.
+    Repairs a ROCm build on NVIDIA and a CUDA family whose published kernels do
+    not cover the visible GPUs. Healthy CUDA and deliberate CPU builds stay.
     """
     # Respect install.sh's backend: only "" (standalone update) or "cuda" force CUDA
     # wheels; "rocm"/"cpu"/unrecognised are deliberate.
@@ -1578,8 +1759,11 @@ def _ensure_cuda_torch() -> None:
                     "cuda = getattr(torch.version, 'cuda', '') or ''; "
                     "ver = getattr(torch, '__version__', '').lower(); "
                     "m = re.search(r'\\+(cu\\d+)', ver); "
+                    "runtime = cuda.replace('.', '') if cuda else ''; "
+                    "family = m.group(1) if m else (('cu' + runtime) if runtime else ''); "
                     "marker = 'hip' if (hip or 'rocm' in ver) else ('cuda' if cuda else 'cpu'); "
-                    "print(marker + '|' + (m.group(1) if m else ''))"
+                    "release = ver.split('+', 1)[0]; "
+                    "print(marker + '|' + family + '|' + release)"
                 ),
             ],
             stdout = subprocess.PIPE,
@@ -1618,13 +1802,36 @@ def _ensure_cuda_torch() -> None:
     ]
     if not _marker_lines:
         return
-    _marker, _, _installed_cu = _marker_lines[-1].partition("|")
+    _installed_parts = _marker_lines[-1].split("|", 2)
+    _marker = _installed_parts[0]
+    _installed_cu = _installed_parts[1] if len(_installed_parts) > 1 else ""
+    _installed_torch_version = _installed_parts[2] if len(_installed_parts) > 2 else ""
     # Reinstall CUDA torch on a ROCm build on an NVIDIA host (poisoning signature), or when a
     # CUDA index is pinned but the venv has the wrong family (CPU or a different cuXXX). A
     # healthy match, or a CPU wheel with no CUDA pin, is left alone.
     _pin = _explicit_torch_index_url()
     _pin_leaf = _torch_index_leaf(_pin) if _pin else ""
     _pinned_cuda = _is_cuda_family_leaf(_pin_leaf)
+    _architecture_policy_host = IS_LINUX and platform.machine().lower() in {
+        "x86_64",
+        "amd64",
+    }
+    if _marker == "cuda" and not _pinned_cuda and not _architecture_policy_host:
+        return
+    _smi: str | None = None
+    _compute_caps: list[str] = []
+    _caps_resolved = False
+    _driver_version: tuple[int, int] | None = None
+    if _marker in {"hip", "cuda"} and not _pinned_cuda:
+        _smi = shutil.which("nvidia-smi")
+        if not _smi and os.path.isfile("/usr/bin/nvidia-smi"):
+            _smi = "/usr/bin/nvidia-smi"
+        if _smi:
+            _compute_caps, _caps_resolved = _visible_nvidia_compute_caps(_smi)
+            _driver_version = _nvidia_driver_cuda_version(_smi)
+            if _architecture_policy_host and _caps_resolved and not _compute_caps:
+                return
+    index_url: str | None = None
     if _marker == "hip":
         _why = "torch is a ROCm build on an NVIDIA host"
     elif _marker == "cpu" and _pinned_cuda:
@@ -1634,10 +1841,36 @@ def _ensure_cuda_torch() -> None:
         # the family can't be confirmed, so reinstall to enforce it (idempotent).
         _installed_desc = _installed_cu if _installed_cu else "an untagged CUDA build"
         _why = f"torch is {_installed_desc} but the pinned CUDA index is {_pin_leaf}"
+    elif _marker == "cuda" and not _pinned_cuda:
+        _architecture_compatible = _cuda_torch_family_supports_compute_caps(
+            _installed_cu, _compute_caps, _installed_torch_version
+        )
+        _driver_compatible = _driver_version is None or _cuda_torch_family_within_driver(
+            _installed_cu, _driver_version
+        )
+        if _architecture_compatible and _driver_compatible:
+            return
+        index_url = _cuda_torch_index_url_for_host(_driver_version, _compute_caps)
+        _expected_leaf = _torch_index_leaf(index_url)
+        _installed_desc = _installed_cu or "an unknown CUDA family"
+        if not _architecture_compatible:
+            _why = (
+                f"torch is {_installed_desc} but the visible GPU architectures "
+                f"require {_expected_leaf}"
+            )
+        else:
+            _why = (
+                f"torch is {_installed_desc} but the NVIDIA driver supports only "
+                f"{_expected_leaf}"
+            )
     else:
         return  # healthy CUDA torch matching the pin, or a deliberate CPU wheel
 
-    index_url = _detect_cuda_torch_index_url()
+    if index_url is None:
+        if not _pinned_cuda and _marker == "hip":
+            index_url = _cuda_torch_index_url_for_host(_driver_version, _compute_caps)
+        else:
+            index_url = _detect_cuda_torch_index_url()
     _torch_pkg, _vision_pkg, _audio_pkg = _CUDA_TORCH_PKG_SPEC
     print(
         f"   {_why} -- reinstalling CUDA torch from {_strip_index_url_credentials(index_url)}\n"

--- a/studio/prebuilt_core.py
+++ b/studio/prebuilt_core.py
@@ -1183,17 +1183,33 @@ def parse_cuda_visible_devices(value: str | None) -> list[str] | None:
     raw = value.strip()
     if not raw or raw == "-1":
         return []
-    return [token.strip() for token in raw.split(",") if token.strip()]
+    # Preserve empty and invalid tokens. CUDA stops enumerating at the first
+    # invalid entry, so dropping one could expose a later GPU that CUDA hides.
+    return [token.strip() for token in raw.split(",")]
 
 
-def supports_explicit_visible_device_matching(visible_devices: list[str] | None) -> bool:
+def can_resolve_cuda_visible_device_tokens(
+    visible_devices: list[str] | None,
+    cuda_device_order: str | None = None,
+) -> bool:
     if not visible_devices:
         return False
     for token in visible_devices:
         lowered = token.lower()
-        if token.isdigit() or lowered.startswith("gpu-"):
+        if token.isdigit() and (cuda_device_order or "").upper() != "PCI_BUS_ID":
+            # Numeric CUDA ordinals can differ from nvidia-smi indices under
+            # FASTEST_FIRST. Only match them when both use PCI ordering.
+            return False
+        if token.isdigit():
             continue
-        return False
+        if lowered.startswith("mig-"):
+            # The physical-GPU query cannot identify the MIG instance's parent
+            # or model driver-dependent mixed MIG and non-MIG enumeration.
+            return False
+        if lowered.startswith("gpu-"):
+            continue
+        # Any other token is invalid, so CUDA ignores it and the suffix.
+        return True
     return True
 
 
@@ -1207,23 +1223,21 @@ def select_visible_gpu_rows(
         return []
 
     by_index = {index: (index, uuid, cap) for index, uuid, cap in rows}
-    by_uuid = {uuid.lower(): (index, uuid, cap) for index, uuid, cap in rows}
     selected: list[tuple[str, str, str]] = []
     seen_indices: set[str] = set()
     for token in visible_devices:
-        row = by_index.get(token)
-        if row is None:
+        row = by_index.get(str(int(token))) if token.isdigit() else None
+        if row is None and token.lower().startswith("gpu-"):
             normalized_token = token.lower()
-            row = by_uuid.get(normalized_token)
-            if row is None and normalized_token.startswith("gpu-"):
-                row = by_uuid.get(normalized_token)
-            if row is None and not normalized_token.startswith("gpu-"):
-                row = by_uuid.get("gpu-" + normalized_token)
+            uuid_matches = [
+                candidate for candidate in rows if candidate[1].lower().startswith(normalized_token)
+            ]
+            row = uuid_matches[0] if len(uuid_matches) == 1 else None
         if row is None:
-            continue
+            break
         index = row[0]
         if index in seen_indices:
-            continue
+            break
         seen_indices.add(index)
         selected.append(row)
     return selected

--- a/tests/sh/test_get_torch_index_url.sh
+++ b/tests/sh/test_get_torch_index_url.sh
@@ -49,6 +49,10 @@ _FAKE_ROCM_DIR=$(mktemp -d)
     echo ""
     sed -n '/^_trim_index_path_slashes()/,/^}/p' "$INSTALL_SH"
     echo ""
+    sed -n '/^_visible_nvidia_compute_caps()/,/^}/p' "$INSTALL_SH"
+    echo ""
+    sed -n '/^_cuda_torch_tag_for_host()/,/^}/p' "$INSTALL_SH"
+    echo ""
     sed -n '/^get_torch_index_url()/,/^}/p' "$INSTALL_SH"
 } | sed -e "s|/usr/bin/nvidia-smi|$_FAKE_SMI_DIR/nvidia-smi-absent|g" \
       -e "s|/opt/rocm|$_FAKE_ROCM_DIR|g" \
@@ -73,11 +77,15 @@ assert_eq() {
 # _has_usable_nvidia_gpu sees a valid GPU.
 make_mock_smi() {
     _dir=$(mktemp -d)
+    _cap="${2:-8.6}"
     cat > "$_dir/nvidia-smi" <<MOCK
 #!/bin/sh
 case "\$1" in
     -L)
         echo "GPU 0: NVIDIA GeForce RTX 3090 (UUID: GPU-fake-uuid)"
+        ;;
+    --query-gpu=index,uuid,compute_cap)
+        echo "0, GPU-fake-uuid, $_cap"
         ;;
     *)
         cat <<'SMI_OUT'
@@ -96,11 +104,15 @@ MOCK
 # layout used by newer NVIDIA drivers (e.g. 610.x on Windows).  See issue #5812.
 make_mock_smi_umd() {
     _dir=$(mktemp -d)
+    _cap="${2:-12.0}"
     cat > "$_dir/nvidia-smi" <<MOCK
 #!/bin/sh
 case "\$1" in
     -L)
         echo "GPU 0: NVIDIA GeForce RTX 5090 Laptop GPU (UUID: GPU-fake-uuid)"
+        ;;
+    --query-gpu=index,uuid,compute_cap)
+        echo "0, GPU-fake-uuid, $_cap"
         ;;
     *)
         cat <<'SMI_OUT'
@@ -108,6 +120,53 @@ case "\$1" in
 | NVIDIA-SMI 610.47                 KMD Version: 610.47        CUDA UMD Version: $1     |
 +-----------------------------------------------------------------------------------------+
 SMI_OUT
+        ;;
+esac
+MOCK
+    chmod +x "$_dir/nvidia-smi"
+    echo "$_dir"
+}
+
+# Helper: create a mixed Volta + Blackwell host for visibility and coverage tests.
+make_mock_smi_mixed() {
+    _dir=$(mktemp -d)
+    cat > "$_dir/nvidia-smi" <<'MOCK'
+#!/bin/sh
+case "$1" in
+    -L)
+        echo "GPU 0: NVIDIA Tesla V100 (UUID: GPU-volta)"
+        echo "GPU 1: NVIDIA B200 (UUID: GPU-blackwell)"
+        ;;
+    --query-gpu=index,uuid,compute_cap)
+        echo "0, GPU-volta, 7.0"
+        echo "1, GPU-blackwell, 10.0"
+        ;;
+    *)
+        echo "| NVIDIA-SMI 580.00 Driver Version: 580.00 CUDA Version: 13.0 |"
+        ;;
+esac
+MOCK
+    chmod +x "$_dir/nvidia-smi"
+    echo "$_dir"
+}
+
+make_mock_smi_partial_caps() {
+    _dir=$(mktemp -d)
+    _query_rc="${1:-0}"
+    cat > "$_dir/nvidia-smi" <<MOCK
+#!/bin/sh
+case "\$1" in
+    -L)
+        echo "GPU 0: NVIDIA Tesla V100 (UUID: GPU-volta)"
+        echo "GPU 1: NVIDIA GPU (UUID: GPU-unknown)"
+        ;;
+    --query-gpu=index,uuid,compute_cap)
+        echo "0, GPU-volta, 7.0"
+        echo "1, GPU-unknown, N/A"
+        exit $_query_rc
+        ;;
+    *)
+        echo "| NVIDIA-SMI 580.00 Driver Version: 580.00 CUDA Version: 13.0 |"
         ;;
 esac
 MOCK
@@ -156,12 +215,17 @@ run_func() {
     else
         _cvd_setup="unset CUDA_VISIBLE_DEVICES"
     fi
+    if [ "$#" -ge 3 ]; then
+        _order_setup="export CUDA_DEVICE_ORDER='$3'"
+    else
+        _order_setup="unset CUDA_DEVICE_ORDER"
+    fi
     if [ "$_mock_dir" = "none" ]; then
         # Minimal PATH with only basic tools, no nvidia-smi anywhere
-        PATH="$_TOOLS_DIR" bash -c "$_cvd_setup; . '$_FUNC_FILE'; get_torch_index_url" 2>/dev/null
+        PATH="$_TOOLS_DIR" bash -c "$_cvd_setup; $_order_setup; . '$_FUNC_FILE'; get_torch_index_url" 2>/dev/null
     else
         # Put mock nvidia-smi dir first, then basic tools
-        PATH="$_mock_dir:$_TOOLS_DIR" bash -c "$_cvd_setup; . '$_FUNC_FILE'; get_torch_index_url" 2>/dev/null
+        PATH="$_mock_dir:$_TOOLS_DIR" bash -c "$_cvd_setup; $_order_setup; . '$_FUNC_FILE'; get_torch_index_url" 2>/dev/null
     fi
 }
 
@@ -355,7 +419,7 @@ assert_eq "CUDA UMD Version 12.8 -> cu128" "https://download.pytorch.org/whl/cu1
 rm -rf "$_dir"
 
 # 31) "CUDA UMD Version: 11.8" header (newer layout on an older driver) -> cu118
-_dir=$(make_mock_smi_umd "11.8")
+_dir=$(make_mock_smi_umd "11.8" "8.6")
 _result=$(run_func "$_dir")
 assert_eq "CUDA UMD Version 11.8 -> cu118" "https://download.pytorch.org/whl/cu118" "$_result"
 rm -rf "$_dir"
@@ -370,6 +434,89 @@ rm -rf "$_dir"
 _dir=$(make_mock_smi "13.7")
 _result=$(run_func "$_dir")
 assert_eq "CUDA Version 13.7 -> cu130" "https://download.pytorch.org/whl/cu130" "$_result"
+rm -rf "$_dir"
+
+# A CUDA 13 driver can run older wheel families, and PyTorch 2.11 cu126 is
+#      the current family that still includes Volta sm_70 kernels.
+_dir=$(make_mock_smi "13.0" "7.0")
+_result=$(run_func "$_dir")
+assert_eq "CUDA 13.0 + Volta sm_70 -> cu126" "https://download.pytorch.org/whl/cu126" "$_result"
+_result=$(run_func "$_dir" "0" "FASTEST_FIRST")
+assert_eq "single Volta FASTEST_FIRST mask -> cu126" "https://download.pytorch.org/whl/cu126" "$_result"
+_result=$(_ARCH=aarch64 run_func "$_dir")
+assert_eq "aarch64 retains driver-only selection" "https://download.pytorch.org/whl/cu130" "$_result"
+rm -rf "$_dir"
+
+# Turing is the minimum architecture in PyTorch 2.11 cu130.
+_dir=$(make_mock_smi "13.0" "7.5")
+_result=$(run_func "$_dir")
+assert_eq "CUDA 13.0 + Turing sm_75 -> cu130" "https://download.pytorch.org/whl/cu130" "$_result"
+rm -rf "$_dir"
+
+# Blackwell needs a wheel family that a CUDA 12.6 driver cannot run.
+_dir=$(make_mock_smi "12.6" "12.0")
+set +e
+run_func "$_dir" >/dev/null
+_blackwell_old_driver_rc=$?
+set -e
+assert_eq "CUDA 12.6 + Blackwell rejected" "1" "$_blackwell_old_driver_rc"
+rm -rf "$_dir"
+
+_dir=$(make_mock_smi "" "12.0")
+set +e
+run_func "$_dir" >/dev/null
+_blackwell_unknown_driver_rc=$?
+set -e
+assert_eq "unreadable driver + Blackwell rejected" "1" "$_blackwell_unknown_driver_rc"
+rm -rf "$_dir"
+
+# A partial visibility mask selects a compatible family for that GPU. With
+#      both incompatible generations visible, no PyTorch 2.11 family covers all.
+_dir=$(make_mock_smi_mixed)
+_result=$(run_func "$_dir" "0" "PCI_BUS_ID")
+assert_eq "mixed host CVD=0 (Volta) -> cu126" "https://download.pytorch.org/whl/cu126" "$_result"
+_result=$(run_func "$_dir" "1" "PCI_BUS_ID")
+assert_eq "mixed host CVD=1 (Blackwell) -> cu130" "https://download.pytorch.org/whl/cu130" "$_result"
+_result=$(run_func "$_dir" "GPU-vol")
+assert_eq "abbreviated Volta UUID -> cu126" "https://download.pytorch.org/whl/cu126" "$_result"
+_result=$(run_func "$_dir" "0,-1,1" "PCI_BUS_ID")
+assert_eq "invalid CVD token stops after Volta" "https://download.pytorch.org/whl/cu126" "$_result"
+set +e
+run_func "$_dir" "0" "FASTEST_FIRST" >/dev/null
+_fastest_mixed_rc=$?
+run_func "$_dir" "0" "" >/dev/null
+_empty_order_mixed_rc=$?
+run_func "$_dir" "0,MIG-bogus" "PCI_BUS_ID" >/dev/null
+_mig_mixed_rc=$?
+set -e
+assert_eq "FASTEST_FIRST mixed mask rejected" "1" "$_fastest_mixed_rc"
+assert_eq "empty CUDA_DEVICE_ORDER mixed mask rejected" "1" "$_empty_order_mixed_rc"
+assert_eq "unresolved MIG mixed mask rejected" "1" "$_mig_mixed_rc"
+_result=$(run_func "$_dir" "GPU-vol,-1,1" "FASTEST_FIRST")
+assert_eq "invalid token shields later numeric token" "https://download.pytorch.org/whl/cu126" "$_result"
+set +e
+run_func "$_dir" >/dev/null
+_mixed_rc=$?
+set -e
+assert_eq "mixed Volta + Blackwell rejected" "1" "$_mixed_rc"
+rm -rf "$_dir"
+
+# If compute capability cannot be read, retain the existing driver-only fallback.
+_dir=$(make_mock_smi "13.0" "unknown")
+_result=$(run_func "$_dir")
+assert_eq "unreadable compute capability -> cu130" "https://download.pytorch.org/whl/cu130" "$_result"
+rm -rf "$_dir"
+
+_dir=$(make_mock_smi_partial_caps)
+_result=$(run_func "$_dir")
+assert_eq "partial compute capability inventory -> cu130" "https://download.pytorch.org/whl/cu130" "$_result"
+_result=$(run_func "$_dir" "0" "PCI_BUS_ID")
+assert_eq "hidden unreadable capability does not poison Volta" "https://download.pytorch.org/whl/cu126" "$_result"
+rm -rf "$_dir"
+
+_dir=$(make_mock_smi_partial_caps 1)
+_result=$(run_func "$_dir")
+assert_eq "failed capability query discards partial output" "https://download.pytorch.org/whl/cu130" "$_result"
 rm -rf "$_dir"
 
 # 34) CUDA_VISIBLE_DEVICES="" hides the NVIDIA GPU -> cpu (no AMD present)

--- a/tests/sh/test_get_torch_index_url.sh
+++ b/tests/sh/test_get_torch_index_url.sh
@@ -222,10 +222,10 @@ run_func() {
     fi
     if [ "$_mock_dir" = "none" ]; then
         # Minimal PATH with only basic tools, no nvidia-smi anywhere
-        PATH="$_TOOLS_DIR" bash -c "$_cvd_setup; $_order_setup; . '$_FUNC_FILE'; get_torch_index_url" 2>/dev/null
+        PATH="$_TOOLS_DIR" sh -c "$_cvd_setup; $_order_setup; . '$_FUNC_FILE'; get_torch_index_url" 2>/dev/null
     else
         # Put mock nvidia-smi dir first, then basic tools
-        PATH="$_mock_dir:$_TOOLS_DIR" bash -c "$_cvd_setup; $_order_setup; . '$_FUNC_FILE'; get_torch_index_url" 2>/dev/null
+        PATH="$_mock_dir:$_TOOLS_DIR" sh -c "$_cvd_setup; $_order_setup; . '$_FUNC_FILE'; get_torch_index_url" 2>/dev/null
     fi
 }
 

--- a/tests/studio/install/test_cuda_repair.py
+++ b/tests/studio/install/test_cuda_repair.py
@@ -23,11 +23,13 @@ _STACK_SPEC.loader.exec_module(stack_mod)
 
 _ensure_cuda_torch = stack_mod._ensure_cuda_torch
 _detect_cuda_torch_index_url = stack_mod._detect_cuda_torch_index_url
+_cuda_torch_tag_for_host = stack_mod._cuda_torch_tag_for_host
 
 
 def _make_run(
     torch_state = "hip",
     cuda_version = "12.8",
+    compute_caps = ("8.6",),
     torch_rc = 0,
     smi_rc = 0,
 ):
@@ -41,9 +43,15 @@ def _make_run(
             result.returncode = torch_rc
             result.stdout = (torch_state + "\n").encode()
             return result
-        # nvidia-smi version probe (text = True)
+        # nvidia-smi version / compute-capability probes (text = True)
         result.returncode = smi_rc
-        out = f"CUDA Version: {cuda_version}\n" if cuda_version else "No devices found\n"
+        if len(cmd) > 1 and cmd[1] == "--query-gpu=index,uuid,compute_cap":
+            out = "".join(
+                f"{index}, GPU-fake-{index}, {cap}\n"
+                for index, cap in enumerate(compute_caps)
+            )
+        else:
+            out = f"CUDA Version: {cuda_version}\n" if cuda_version else "No devices found\n"
         result.stdout = out if kwargs.get("text") else out.encode()
         return result
 
@@ -56,6 +64,7 @@ def _run_cuda_repair(
     nvidia = True,
     torch_state = "hip",
     cuda_version = "12.8",
+    compute_caps = ("8.6",),
     torch_rc = 0,
     smi_rc = 0,
     is_macos = False,
@@ -64,6 +73,7 @@ def _run_cuda_repair(
     rocm_marker = False,
     smi_path = "/usr/bin/nvidia-smi",
     cvd = None,
+    device_order = None,
     index_family = None,
     index_url = None,
 ):
@@ -77,6 +87,8 @@ def _run_cuda_repair(
         env["UNSLOTH_ROCM_TORCH_INSTALLED"] = "1"
     if cvd is not None:
         env["CUDA_VISIBLE_DEVICES"] = cvd
+    if device_order is not None:
+        env["CUDA_DEVICE_ORDER"] = device_order
     if index_family is not None:
         env["UNSLOTH_TORCH_INDEX_FAMILY"] = index_family
     if index_url is not None:
@@ -92,6 +104,7 @@ def _run_cuda_repair(
         patch.object(stack_mod, "IS_MACOS", is_macos),
         patch.object(stack_mod, "IS_WINDOWS", is_windows),
         patch.object(stack_mod, "NO_TORCH", no_torch),
+        patch.object(stack_mod, "_VISIBLE_NVIDIA_CAPS_CACHE", {}),
         patch.object(stack_mod, "_has_usable_nvidia_gpu", return_value = nvidia),
         patch.object(stack_mod.shutil, "which", side_effect = _which),
         patch.object(stack_mod.os.path, "isfile", return_value = bool(smi_path)),
@@ -99,7 +112,9 @@ def _run_cuda_repair(
         patch.object(
             stack_mod.subprocess,
             "run",
-            side_effect = _make_run(torch_state, cuda_version, torch_rc, smi_rc),
+            side_effect = _make_run(
+                torch_state, cuda_version, compute_caps, torch_rc, smi_rc
+            ),
         ),
         patch.dict(stack_mod.os.environ, env, clear = False),
     ):
@@ -107,6 +122,8 @@ def _run_cuda_repair(
             stack_mod.os.environ.pop("UNSLOTH_ROCM_TORCH_INSTALLED", None)
         if cvd is None:
             stack_mod.os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+        if device_order is None:
+            stack_mod.os.environ.pop("CUDA_DEVICE_ORDER", None)
         if index_family is None:
             stack_mod.os.environ.pop("UNSLOTH_TORCH_INDEX_FAMILY", None)
         if index_url is None:
@@ -209,7 +226,7 @@ class TestCudaRepairFires:
 
 class TestCudaRepairSkips:
     def test_healthy_cuda_torch_no_repair(self):
-        mock_pip = _run_cuda_repair(torch_state = "cuda")
+        mock_pip = _run_cuda_repair(torch_state = "cuda|cu128")
         mock_pip.assert_not_called()
 
     def test_deliberate_cpu_wheel_no_repair(self):
@@ -375,11 +392,236 @@ class TestTorchBackendDerivationFromPin:
 
 
 class TestCudaIndexResolution:
+    def test_failed_capability_probe_is_retried(self):
+        success = MagicMock(
+            returncode = 0,
+            stdout = "0, GPU-fake-0, 7.0\n",
+        )
+        with (
+            patch.object(stack_mod, "_VISIBLE_NVIDIA_CAPS_CACHE", {}),
+            patch.object(
+                stack_mod.subprocess,
+                "run",
+                side_effect = [OSError("transient failure"), success],
+            ) as mock_run,
+            patch.dict(stack_mod.os.environ, {}, clear = False),
+        ):
+            stack_mod.os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+            stack_mod.os.environ.pop("CUDA_DEVICE_ORDER", None)
+            assert stack_mod._visible_nvidia_compute_caps("nvidia-smi") == ([], False)
+            assert stack_mod._visible_nvidia_compute_caps("nvidia-smi") == (["70"], True)
+        assert mock_run.call_count == 2
+
+    def test_complete_conservative_inventory_is_cached(self):
+        success = MagicMock(
+            returncode = 0,
+            stdout = "0, GPU-fake-0, 7.0\n",
+        )
+        with (
+            patch.object(stack_mod, "_VISIBLE_NVIDIA_CAPS_CACHE", {}),
+            patch.object(stack_mod.subprocess, "run", return_value = success) as mock_run,
+            patch.dict(
+                stack_mod.os.environ,
+                {"CUDA_VISIBLE_DEVICES": "0", "CUDA_DEVICE_ORDER": "FASTEST_FIRST"},
+                clear = False,
+            ),
+        ):
+            expected = (["70"], False)
+            assert stack_mod._visible_nvidia_compute_caps("nvidia-smi") == expected
+            assert stack_mod._visible_nvidia_compute_caps("nvidia-smi") == expected
+        assert mock_run.call_count == 1
+
     def test_cuda_128_selects_cu128(self):
         assert "cu128" in _index_url(_run_cuda_repair(cuda_version = "12.8"))
 
     def test_cuda_130_selects_cu130(self):
         assert "cu130" in _index_url(_run_cuda_repair(cuda_version = "13.0"))
+
+    def test_cuda_130_volta_selects_cu126(self):
+        assert "cu126" in _index_url(
+            _run_cuda_repair(cuda_version = "13.0", compute_caps = ("7.0",))
+        )
+
+    def test_incompatible_cuda_family_is_repaired_for_volta(self):
+        mock_pip = _run_cuda_repair(
+            torch_state = "cuda|cu130",
+            cuda_version = "13.0",
+            compute_caps = ("7.0",),
+        )
+        assert mock_pip.call_count == 1
+        assert "cu126" in _index_url(mock_pip)
+
+    def test_cuda_129_family_is_repaired_for_volta(self):
+        mock_pip = _run_cuda_repair(
+            torch_state = "cuda|cu129",
+            cuda_version = "13.0",
+            compute_caps = ("7.0",),
+        )
+        assert mock_pip.call_count == 1
+        assert "cu126" in _index_url(mock_pip)
+
+    def test_pre_211_cu128_volta_build_is_retained(self):
+        mock_pip = _run_cuda_repair(
+            torch_state = "cuda|cu128|2.10.0",
+            cuda_version = "13.0",
+            compute_caps = ("7.0",),
+        )
+        assert mock_pip.call_count == 0
+
+    def test_cuda_126_family_is_repaired_for_blackwell(self):
+        mock_pip = _run_cuda_repair(
+            torch_state = "cuda|cu126",
+            cuda_version = "13.0",
+            compute_caps = ("12.0",),
+        )
+        assert mock_pip.call_count == 1
+        assert "cu130" in _index_url(mock_pip)
+
+    def test_family_newer_than_driver_is_repaired(self):
+        cu130 = _run_cuda_repair(
+            torch_state = "cuda|cu130",
+            cuda_version = "12.8",
+            compute_caps = ("8.6",),
+        )
+        assert "cu128" in _index_url(cu130)
+
+        cu128 = _run_cuda_repair(
+            torch_state = "cuda|cu128",
+            cuda_version = "12.6",
+            compute_caps = ("8.6",),
+        )
+        assert "cu126" in _index_url(cu128)
+
+    def test_mixed_volta_blackwell_is_rejected(self):
+        with pytest.raises(RuntimeError, match = "no CUDA wheel family"):
+            _run_cuda_repair(
+                cuda_version = "13.0",
+                compute_caps = ("7.0", "12.0"),
+            )
+
+    def test_blackwell_with_old_driver_is_rejected(self):
+        with pytest.raises(RuntimeError, match = "driver supports only cu126"):
+            _run_cuda_repair(
+                cuda_version = "12.6",
+                compute_caps = ("12.0",),
+            )
+
+    def test_blackwell_with_unreadable_driver_is_rejected(self):
+        with pytest.raises(RuntimeError, match = "could not be determined"):
+            _run_cuda_repair(
+                torch_state = "cuda|cu126",
+                cuda_version = "",
+                compute_caps = ("12.0",),
+            )
+
+    def test_visibility_mask_selects_one_mixed_generation(self):
+        volta = _run_cuda_repair(
+            cuda_version = "13.0",
+            compute_caps = ("7.0", "12.0"),
+            cvd = "0",
+        )
+        assert "cu126" in _index_url(volta)
+
+        blackwell = _run_cuda_repair(
+            cuda_version = "13.0",
+            compute_caps = ("7.0", "12.0"),
+            cvd = "1",
+            device_order = "PCI_BUS_ID",
+        )
+        assert "cu130" in _index_url(blackwell)
+
+        abbreviated_uuid = _run_cuda_repair(
+            cuda_version = "13.0",
+            compute_caps = ("7.0",),
+            cvd = "GPU-f",
+        )
+        assert "cu126" in _index_url(abbreviated_uuid)
+
+        stopped_at_invalid = _run_cuda_repair(
+            cuda_version = "13.0",
+            compute_caps = ("7.0", "12.0"),
+            cvd = "0,-1,1",
+            device_order = "PCI_BUS_ID",
+        )
+        assert "cu126" in _index_url(stopped_at_invalid)
+
+    def test_unresolved_numeric_mask_uses_conservative_inventory(self):
+        with pytest.raises(RuntimeError, match = "no CUDA wheel family"):
+            _run_cuda_repair(
+                cuda_version = "13.0",
+                compute_caps = ("7.0", "12.0"),
+                cvd = "0",
+                device_order = "FASTEST_FIRST",
+            )
+
+        volta = _run_cuda_repair(
+            cuda_version = "13.0",
+            compute_caps = ("7.0",),
+            cvd = "0",
+            device_order = "FASTEST_FIRST",
+        )
+        assert "cu126" in _index_url(volta)
+
+    def test_mig_mask_uses_conservative_inventory(self):
+        with pytest.raises(RuntimeError, match = "no CUDA wheel family"):
+            _run_cuda_repair(
+                cuda_version = "13.0",
+                compute_caps = ("7.0", "12.0"),
+                cvd = "0,MIG-bogus",
+                device_order = "PCI_BUS_ID",
+            )
+
+    def test_resolved_empty_mask_does_not_force_cuda(self):
+        mock_pip = _run_cuda_repair(
+            torch_state = "hip",
+            cuda_version = "13.0",
+            compute_caps = ("7.0", "12.0"),
+            cvd = "99",
+            device_order = "PCI_BUS_ID",
+        )
+        assert mock_pip.call_count == 0
+
+        fastest_first = _run_cuda_repair(
+            torch_state = "hip",
+            cuda_version = "13.0",
+            compute_caps = ("7.0",),
+            cvd = "99",
+            device_order = "FASTEST_FIRST",
+        )
+        assert fastest_first.call_count == 0
+
+    def test_partial_capability_inventory_uses_driver_fallback(self):
+        mock_pip = _run_cuda_repair(
+            cuda_version = "13.0",
+            compute_caps = ("7.0", "N/A"),
+        )
+        assert "cu130" in _index_url(mock_pip)
+
+    def test_hidden_unreadable_capability_does_not_poison_selected_gpu(self):
+        mock_pip = _run_cuda_repair(
+            cuda_version = "13.0",
+            compute_caps = ("7.0", "N/A"),
+            cvd = "0",
+            device_order = "PCI_BUS_ID",
+        )
+        assert "cu126" in _index_url(mock_pip)
+
+    def test_unreadable_compute_capability_keeps_driver_family(self):
+        assert "cu130" in _index_url(
+            _run_cuda_repair(cuda_version = "13.0", compute_caps = ())
+        )
+
+    def test_non_linux_and_non_x86_hosts_keep_driver_family(self):
+        with patch.object(stack_mod, "IS_LINUX", False):
+            assert _cuda_torch_tag_for_host((13, 0), ["70"]) == "cu130"
+        with patch.object(stack_mod.platform, "machine", return_value = "aarch64"):
+            assert _cuda_torch_tag_for_host((13, 0), ["70"]) == "cu130"
+            mock_pip = _run_cuda_repair(
+                torch_state = "cuda|cu130",
+                cuda_version = "12.8",
+                compute_caps = ("8.6",),
+            )
+            assert mock_pip.call_count == 0
 
     def test_cuda_126_selects_cu126(self):
         assert "cu126" in _index_url(_run_cuda_repair(cuda_version = "12.6"))

--- a/tests/studio/install/test_prebuilt_core.py
+++ b/tests/studio/install/test_prebuilt_core.py
@@ -804,6 +804,8 @@ def test_normalize_compute_caps(values, expected):
         ("0", ["0"]),
         ("0,1,2", ["0", "1", "2"]),
         (" 0 , 1 ", ["0", "1"]),
+        ("0,,2", ["0", "", "2"]),
+        ("0,-1,2", ["0", "-1", "2"]),
     ],
 )
 def test_parse_cuda_visible_devices(value, expected):
@@ -811,17 +813,23 @@ def test_parse_cuda_visible_devices(value, expected):
 
 
 @pytest.mark.parametrize(
-    "visible,expected",
+    "visible,device_order,expected",
     [
-        (["0", "1", "2"], True),
-        (["GPU-abc123"], True),
-        (None, False),
-        ([], False),
-        (["0", "MIG-device"], False),
+        (["0", "1", "2"], "PCI_BUS_ID", True),
+        (["0", "1", "2"], "FASTEST_FIRST", False),
+        (["0", "1", "2"], None, False),
+        (["GPU-abc123"], None, True),
+        (["0", "-1", "1"], "PCI_BUS_ID", True),
+        (["0", "bad", "1"], "PCI_BUS_ID", True),
+        (["GPU-abc123", "-1", "0"], "FASTEST_FIRST", True),
+        (None, None, False),
+        ([], None, False),
+        (["MIG-device"], None, False),
+        (["GPU-abc123", "MIG-device"], None, False),
     ],
 )
-def test_supports_explicit_visible_device_matching(visible, expected):
-    assert core.supports_explicit_visible_device_matching(visible) is expected
+def test_can_resolve_cuda_visible_device_tokens(visible, device_order, expected):
+    assert core.can_resolve_cuda_visible_device_tokens(visible, device_order) is expected
 
 
 _GPU_ROWS = [
@@ -837,8 +845,13 @@ _GPU_ROWS = [
         (None, [0, 1, 2]),  # no filter returns all
         ([], []),
         (["0", "2"], [0, 2]),  # filter by index
+        (["00"], [0]),  # integer tokens may contain leading zeroes
         (["gpu-bbb"], [1]),  # UUID match is case insensitive
-        (["0", "0"], [0]),  # same device requested twice is deduplicated
+        (["GPU-b"], [1]),  # unique abbreviated GPU UUID
+        (["GPU-"], []),  # ambiguous UUID prefix is invalid
+        (["0", "0"], [0]),  # duplicate stops after the first visible device
+        (["0", "-1", "2"], [0]),  # CUDA stops at the first invalid token
+        (["0", "", "2"], [0]),  # empty tokens are invalid too
         (["99"], []),  # unknown token matches nothing
     ],
 )

--- a/tests/studio/install/test_selection_logic.py
+++ b/tests/studio/install/test_selection_logic.py
@@ -456,7 +456,7 @@ def test_core_helper_aliases_bound_to_prebuilt_core():
         "normalize_compute_cap",
         "normalize_compute_caps",
         "parse_cuda_visible_devices",
-        "supports_explicit_visible_device_matching",
+        "can_resolve_cuda_visible_device_tokens",
         "select_visible_gpu_rows",
         "compatible_linux_runtime_lines",
         "runtime_line_from_cuda_version",


### PR DESCRIPTION
## Summary

A Tesla V100 with a CUDA 13 capable driver received PyTorch 2.11's `cu130` wheel, even though that wheel starts at `sm_75` and the V100 is `sm_70`.

This PR makes unpinned Linux x86_64 CUDA selection intersect the driver's runtime capability with the architectures of the GPUs visible to CUDA. A V100 on a recent driver now receives `cu126`, the current PyTorch 2.11 family that still contains its kernels.

Related to #7765.

## Root cause

The installer selected the PyTorch wheel family only from the maximum CUDA version reported by the NVIDIA driver. That version is an upper bound on runtime compatibility, not a statement that the selected wheel contains kernels for the installed GPU.

Fresh installs and Studio updates also used separate selection paths, so both must enforce the same compatibility rule.

## What changed

- Query NVIDIA GPU indices, UUIDs, and compute capabilities during Linux installation and updates.
- Apply GPU UUID and PCI-ordered numeric `CUDA_VISIBLE_DEVICES` masks before evaluating architecture coverage.
- Evaluate the complete physical inventory when explicit device ordering or MIG identifiers prevent exact mask resolution.
- Select `cu126` when pre-Turing GPUs would otherwise receive PyTorch 2.11 `cu128` or `cu130` wheels.
- Keep the highest driver-compatible family for Turing through Hopper and for Blackwell-capable hosts.
- Reject visible pre-Turing plus Blackwell groups because no PyTorch 2.11 CUDA family covers both.
- Reject Blackwell when the installed driver cannot run a Blackwell-capable wheel family.
- Repair an existing CUDA torch family when it does not cover the visible GPUs or exceeds the known driver ceiling.
- Retain a compatible pre-2.11 `cu128` Volta build during updates.
- Preserve explicit torch index overrides and the existing driver-only fallback when the capability inventory cannot be read completely.

## Scope

- The architecture policy applies only to Linux x86_64, matching the relevant PyTorch 2.11 wheel matrix.
- Windows, Linux aarch64, AMD, CPU-only, macOS, and explicit-index policies are unchanged.
- llama.cpp runtime library discovery is unchanged. Its host probe only adopts the corrected shared CUDA visibility resolution.

## Testing

- `bash tests/sh/test_get_torch_index_url.sh` (68 passed)
- `python -m pytest tests/studio/install/test_cuda_repair.py tests/studio/install/test_prebuilt_core.py tests/studio/install/test_selection_logic.py tests/python/test_install_python_stack.py -q` (417 passed)
- `python -m pytest tests/studio/install/test_rocm_support.py tests/studio/install/test_probe_timeouts.py -q` (410 passed, 3 skipped)
- `bash tests/sh/test_torch_flavor.sh` (69 passed)
- `bash tests/sh/test_previous_torch_pin.sh` (46 passed)
- `bash tests/sh/test_mac_intel_compat.sh` (56 passed)
- Ruff, Python compilation, shell syntax, and `git diff --check`

## Validation notes

Verified the policy against PyTorch 2.11's published Linux x86_64 CUDA build matrix. No V100 was available for a hardware run, so the regression cases use mocked `nvidia-smi` output while executing the real fresh-selection and update-repair paths.
