### PR TITLE
fix(install): run the Python 3.13.8 torch guard on every platform, not just macOS arm64

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2384,20 +2384,47 @@ if [ -x "$VENV_DIR/bin/python" ]; then
     : > "$VENV_DIR/.unsloth-studio-owned" 2>/dev/null || true
 fi
 
-# Guard against two independent Apple Silicon venv problems, in order:
-#   1. uv may create the venv from a cached x86_64 (Rosetta) Python when a
-#      same-version x86_64 build is already cached (often because uv itself
-#      is an x86_64 build). That venv reports x86_64 to wheel resolvers, and
-#      PyTorch ships no macOS wheels on the CPU index for any architecture,
-#      so the torch install can never resolve. Recreate it with an
-#      arch-explicit arm64 CPython.
-#   2. Python 3.13.8 has a known torch import bug.
+# Python 3.13.8 ships a CPython regression (gh-139783) that breaks `import
+# torch`: inspect.getsourcelines() mis-reads a decorator followed by a comment,
+# which is exactly the shape of torch/nn/modules/rnn.py's @_overload_method
+# blocks, and torch parses those at import time. 3.13.9 was expedited with only
+# that fix, so it is the floor rather than a retreat to 3.12.
+_PY_TORCH_BROKEN="3.13.8"
+_PY_TORCH_FIXED="3.13.9"
+# 3.12 predates the regression entirely and every supported uv can produce it.
+_PY_TORCH_FALLBACK="3.12"
+
+# Interpreter spec for `uv venv --python`. Apple Silicon must pin the arch so uv
+# cannot reuse a cached x86_64 (Rosetta) build; every other platform lets uv
+# resolve its own native download, which is why the hardcoded macos-aarch64
+# spec below could not simply be un-gated (#7803).
+_uv_python_spec() {
+    if [ "$OS" = "macos" ] && [ "$_ARCH" = "arm64" ]; then
+        printf 'cpython-%s-macos-aarch64-none' "$1"
+    else
+        printf '%s' "$1"
+    fi
+}
+
+# Guard against two independent venv problems, in order:
+#   1. (Apple Silicon only) uv may create the venv from a cached x86_64
+#      (Rosetta) Python when a same-version x86_64 build is already cached
+#      (often because uv itself is an x86_64 build). That venv reports x86_64
+#      to wheel resolvers, and PyTorch ships no macOS wheels on the CPU index
+#      for any architecture, so the torch install can never resolve. Recreate
+#      it with an arch-explicit arm64 CPython.
+#   2. (every platform) the venv landed on Python 3.13.8. PYTHON_VERSION is
+#      "3.13" off Intel Mac and uv chooses the patch, so a uv whose manifest
+#      predates 3.13.9 (released four days after uv 0.9.2) puts Linux and WSL
+#      on 3.13.8 too. Studio then falls back to CPU with Train/Export silently
+#      disabled while the install still reports success, so this check must not
+#      stay behind the macOS gate it was first written under.
 # The two are independent: a venv may be x86_64 and, once recreated, still
 # land on 3.13.8. So we re-inspect the interpreter between the checks instead
 # of chaining them with elif, guaranteeing both invariants hold on whatever
 # venv we end up with. Skip both when the user explicitly chose an interpreter
 # via --python.
-if [ -z "$_USER_PYTHON" ] && [ "$OS" = "macos" ] && [ "$_ARCH" = "arm64" ]; then
+if [ -z "$_USER_PYTHON" ]; then
     _inspect_venv() {
         "$VENV_DIR/bin/python" -c \
             "import platform, sys; print(platform.machine(), '{}.{}.{}'.format(*sys.version_info[:3]))" \
@@ -2406,44 +2433,58 @@ if [ -z "$_USER_PYTHON" ] && [ "$OS" = "macos" ] && [ "$_ARCH" = "arm64" ]; then
     _info=$(_inspect_venv)
     _VENV_ARCH=${_info%% *}
     _PY_VER=${_info##* }
-    # If the interpreter could not be executed (an x86_64 venv python on a Mac
-    # without Rosetta installed), the probe above yields an empty arch. Fall
-    # back to reading the binary's Mach-O arch statically so the x86_64
-    # recreate below still triggers instead of letting uv fail later.
-    if [ -z "$_VENV_ARCH" ] && [ -x "$VENV_DIR/bin/python" ]; then
-        # uv symlinks bin/python to the base interpreter, so dereference with
-        # file -L (lipo already follows the link). Trailing || true keeps the
-        # installer alive under set -e when neither tool is present.
-        _archs=$(lipo -archs "$VENV_DIR/bin/python" 2>/dev/null \
-            || file -L "$VENV_DIR/bin/python" 2>/dev/null || true)
-        case "$_archs" in
-            *arm64*)  _VENV_ARCH=arm64 ;;
-            *x86_64*) _VENV_ARCH=x86_64 ;;
-        esac
-    fi
 
-    if [ "$_VENV_ARCH" = "x86_64" ]; then
-        echo "  WARNING: venv was created with an x86_64 (Rosetta) Python on Apple Silicon."
-        echo "  Recreating venv with native arm64 Python ${PYTHON_VERSION}..."
-        rm -rf "$VENV_DIR"
-        run_install_cmd "recreate venv (arm64)" uv venv "$VENV_DIR" \
-            --python "cpython-${PYTHON_VERSION}-macos-aarch64-none"
-        if [ -x "$VENV_DIR/bin/python" ]; then
-            : > "$VENV_DIR/.unsloth-studio-owned" 2>/dev/null || true
+    if [ "$OS" = "macos" ] && [ "$_ARCH" = "arm64" ]; then
+        # If the interpreter could not be executed (an x86_64 venv python on a
+        # Mac without Rosetta installed), the probe above yields an empty arch.
+        # Fall back to reading the binary's Mach-O arch statically so the
+        # x86_64 recreate below still triggers instead of letting uv fail later.
+        if [ -z "$_VENV_ARCH" ] && [ -x "$VENV_DIR/bin/python" ]; then
+            # uv symlinks bin/python to the base interpreter, so dereference with
+            # file -L (lipo already follows the link). Trailing || true keeps the
+            # installer alive under set -e when neither tool is present.
+            _archs=$(lipo -archs "$VENV_DIR/bin/python" 2>/dev/null \
+                || file -L "$VENV_DIR/bin/python" 2>/dev/null || true)
+            case "$_archs" in
+                *arm64*)  _VENV_ARCH=arm64 ;;
+                *x86_64*) _VENV_ARCH=x86_64 ;;
+            esac
         fi
-        # Re-inspect: the recreated arm64 venv may still be 3.13.8.
-        _info=$(_inspect_venv)
-        _VENV_ARCH=${_info%% *}
-        _PY_VER=${_info##* }
+
+        if [ "$_VENV_ARCH" = "x86_64" ]; then
+            echo "  WARNING: venv was created with an x86_64 (Rosetta) Python on Apple Silicon."
+            echo "  Recreating venv with native arm64 Python ${PYTHON_VERSION}..."
+            rm -rf "$VENV_DIR"
+            run_install_cmd "recreate venv (arm64)" uv venv "$VENV_DIR" \
+                --python "$(_uv_python_spec "$PYTHON_VERSION")"
+            if [ -x "$VENV_DIR/bin/python" ]; then
+                : > "$VENV_DIR/.unsloth-studio-owned" 2>/dev/null || true
+            fi
+            # Re-inspect: the recreated arm64 venv may still be 3.13.8.
+            _info=$(_inspect_venv)
+            _VENV_ARCH=${_info%% *}
+            _PY_VER=${_info##* }
+        fi
     fi
 
-    if [ "$_PY_VER" = "3.13.8" ]; then
-        echo "  WARNING: Python 3.13.8 has a known torch import bug."
-        echo "  Recreating venv with Python 3.12..."
+    if [ "$_PY_VER" = "$_PY_TORCH_BROKEN" ]; then
+        echo "  WARNING: Python ${_PY_TORCH_BROKEN} has a known torch import bug (CPython gh-139783)."
+        echo "  Recreating venv with Python ${_PY_TORCH_FIXED}..."
         rm -rf "$VENV_DIR"
-        PYTHON_VERSION="3.12"
-        run_install_cmd "recreate venv" uv venv "$VENV_DIR" \
-            --python "cpython-${PYTHON_VERSION}-macos-aarch64-none"
+        # Tried in an if-condition so set -e does not abort the install: a uv
+        # older than 3.13.9's release has no such build in its manifest, and
+        # that is the same stale uv that produced 3.13.8 in the first place.
+        if run_install_cmd "recreate venv" uv venv "$VENV_DIR" \
+                --python "$(_uv_python_spec "$_PY_TORCH_FIXED")"; then
+            PYTHON_VERSION="$_PY_TORCH_FIXED"
+        else
+            echo "  Python ${_PY_TORCH_FIXED} is unavailable (uv's manifest predates it)."
+            echo "  Recreating venv with Python ${_PY_TORCH_FALLBACK} instead..."
+            rm -rf "$VENV_DIR"
+            PYTHON_VERSION="$_PY_TORCH_FALLBACK"
+            run_install_cmd "recreate venv" uv venv "$VENV_DIR" \
+                --python "$(_uv_python_spec "$_PY_TORCH_FALLBACK")"
+        fi
         if [ -x "$VENV_DIR/bin/python" ]; then
             : > "$VENV_DIR/.unsloth-studio-owned" 2>/dev/null || true
         fi

--- a/tests/sh/test_install_py3138_guard.sh
+++ b/tests/sh/test_install_py3138_guard.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+#
+# Behavioural test for the Python 3.13.8 venv guard in install.sh (#7803).
+#
+# 3.13.8 carries a CPython regression (gh-139783) that breaks `import torch`.
+# The guard that recreates such a venv used to sit behind an `OS = macos` /
+# `_ARCH = arm64` gate, so Linux and WSL -- which default to "3.13" and let uv
+# pick the patch -- never reached it and silently degraded Studio to CPU.
+#
+# The guard block is extracted from install.sh and executed against stubs, so
+# these assertions cover behaviour rather than the presence of source text.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALL_SH="$SCRIPT_DIR/../../install.sh"
+PASS=0
+FAIL=0
+
+assert_eq() {
+    _label="$1"; _got="$2"; _want="$3"
+    if [ "$_got" = "$_want" ]; then
+        echo "  PASS: $_label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $_label (want '$_want', got '$_got')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    _label="$1"; _haystack="$2"; _needle="$3"
+    if echo "$_haystack" | grep -qF -- "$_needle"; then
+        echo "  PASS: $_label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $_label (expected to find '$_needle' in '$_haystack')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    _label="$1"; _haystack="$2"; _needle="$3"
+    if echo "$_haystack" | grep -qF -- "$_needle"; then
+        echo "  FAIL: $_label (found '$_needle' but should not)"
+        FAIL=$((FAIL + 1))
+    else
+        echo "  PASS: $_label"
+        PASS=$((PASS + 1))
+    fi
+}
+
+# Extract the guard: from the 3.13.8 constants down to the column-0 `fi` that
+# closes `if [ -z "$_USER_PYTHON" ]`. Every `fi` inside the block is indented.
+GUARD=$(awk '
+    /^_PY_TORCH_BROKEN=/ { found = 1 }
+    found                { print }
+    found && /^fi$/      { exit }
+' "$INSTALL_SH")
+
+if [ -z "$GUARD" ]; then
+    echo "  FAIL: could not extract the 3.13.8 guard from install.sh"
+    exit 1
+fi
+echo "=== extracted guard ($(echo "$GUARD" | wc -l | tr -d ' ') lines) ==="
+
+# Runs the guard once in a scratch HOME.
+#   $1 OS            $2 _ARCH        $3 venv's reported "arch version"
+#   $4 _USER_PYTHON  $5 "ok" if the stub uv can build 3.13.9, else "no-3139"
+# Echoes: "<resulting PYTHON_VERSION>|<newline-free log of uv --python specs>"
+run_guard() {
+    _t=$(mktemp -d)
+    (
+        set -e
+        OS="$1"; _ARCH="$2"; _reported="$3"; _USER_PYTHON="$4"; _uv_mode="$5"
+        VENV_DIR="$_t/venv"
+        PYTHON_VERSION="3.13"
+        CALLS="$_t/calls"
+        : > "$CALLS"
+
+        mkdir -p "$VENV_DIR/bin"
+        _make_python() {
+            printf '#!/bin/sh\necho "%s"\n' "$1" > "$VENV_DIR/bin/python"
+            chmod +x "$VENV_DIR/bin/python"
+        }
+        _make_python "$_reported"
+
+        # Stub for the real installer helper. Records the --python spec it was
+        # asked for, refuses 3.13.9 when the scenario says uv is too old, and
+        # otherwise "creates" a venv reporting the requested version.
+        run_install_cmd() {
+            shift  # label
+            _spec=""
+            while [ $# -gt 0 ]; do
+                if [ "$1" = "--python" ]; then _spec="$2"; fi
+                shift
+            done
+            echo "$_spec" >> "$CALLS"
+            if [ "$_uv_mode" = "no-3139" ] && case "$_spec" in *3.13.9*) true ;; *) false ;; esac; then
+                return 1
+            fi
+            mkdir -p "$VENV_DIR/bin"
+            case "$_spec" in
+                *3.13.9*) _make_python "x86_64 3.13.9" ;;
+                *3.12*)   _make_python "x86_64 3.12.10" ;;
+                *)        _make_python "x86_64 3.13.8" ;;
+            esac
+            return 0
+        }
+
+        # The guard narrates to stdout; only the summary line below is parsed.
+        # shellcheck disable=SC2034
+        eval "$GUARD" > /dev/null
+
+        printf '%s|%s\n' "$PYTHON_VERSION" "$(tr '\n' ' ' < "$CALLS")"
+    )
+    _rc=$?
+    rm -rf "$_t"
+    return $_rc
+}
+
+echo ""
+echo "=== Linux/WSL on 3.13.8: the guard must fire (the #7803 regression) ==="
+out=$(run_guard linux x86_64 "x86_64 3.13.8" "" ok)
+ver=${out%%|*}; calls=${out#*|}
+assert_eq        "linux: venv is rebuilt on 3.13.9, not 3.12" "$ver" "3.13.9"
+assert_contains  "linux: uv asked for a plain 3.13.9 spec"    "$calls" "3.13.9"
+assert_not_contains \
+    "linux: no macOS-only interpreter spec leaks onto Linux" "$calls" "macos-aarch64"
+assert_not_contains "linux: does not fall back to 3.12 when 3.13.9 exists" "$calls" "3.12"
+
+echo ""
+echo "=== Linux/WSL on 3.13.8 with a uv too old for 3.13.9 ==="
+out=$(run_guard linux x86_64 "x86_64 3.13.8" "" no-3139)
+ver=${out%%|*}; calls=${out#*|}
+assert_eq       "stale uv: install still completes on the 3.12 fallback" "$ver" "3.12"
+assert_contains "stale uv: 3.13.9 is attempted first" "$calls" "3.13.9"
+assert_contains "stale uv: 3.12 is attempted second" "$calls" "3.12"
+
+echo ""
+echo "=== Apple Silicon keeps its arch-explicit spec ==="
+out=$(run_guard macos arm64 "arm64 3.13.8" "" ok)
+ver=${out%%|*}; calls=${out#*|}
+assert_eq       "macos arm64: rebuilt on 3.13.9" "$ver" "3.13.9"
+assert_contains "macos arm64: spec stays arch-pinned" "$calls" "cpython-3.13.9-macos-aarch64-none"
+
+echo ""
+echo "=== The guard stays out of the way when it should ==="
+out=$(run_guard linux x86_64 "x86_64 3.13.9" "" ok)
+ver=${out%%|*}; calls=${out#*|}
+assert_eq "healthy 3.13.9 venv: left alone" "$ver" "3.13"
+assert_eq "healthy 3.13.9 venv: uv not called" "$(echo "$calls" | tr -d ' ')" ""
+
+out=$(run_guard linux x86_64 "x86_64 3.13.8" "3.13.8" ok)
+ver=${out%%|*}; calls=${out#*|}
+assert_eq "--python override: user's choice is honoured, guard skipped" \
+    "$(echo "$calls" | tr -d ' ')" ""
+
+echo ""
+echo "=== Summary: $PASS passed, $FAIL failed ==="
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+echo "ALL PASSED"


### PR DESCRIPTION
Fixes #7803.

## The gap

`install.sh` already knows Python 3.13.8 breaks `import torch` and rebuilds the venv when it sees it — but the whole block is gated on `OS = macos && _ARCH = arm64`, so Linux and WSL never reach it.

They get there the same way macOS did: `PYTHON_VERSION` defaults to `"3.13"` off Intel Mac and `uv venv --python 3.13` lets uv choose the patch. uv 0.9.2 shipped 2025-10-10, 3.13.9 landed 2025-10-14, so that uv's manifest tops out at 3.13.8 — and `UV_MIN_VERSION="0.8.16"` keeps any uv at or above 0.8.16 without refreshing it. That is why it looks machine-dependent.

The failure is quiet: torch raises `IndentationError` at import, Studio falls back to CPU, Train/Export go away, and the install still reports success.

Root cause is CPython [gh-139783](https://github.com/python/cpython/issues/139783) — `inspect.getsourcelines()` mis-reads a decorator followed by a comment, exactly the shape of the `@_overload_method` blocks in `torch/nn/modules/rnn.py`, which torch parses at import time. 3.13.9 was expedited a week later containing only that fix.

## Changes

Three of the issue's suggestions, all in the guard:

- **Un-gate the 3.13.8 check.** Only the x86_64/Rosetta recreate stays macOS-arm64-specific; the interpreter probe and the version check now run everywhere. The two remain independent (a venv can be x86_64 *and*, once recreated, still land on 3.13.8), so the re-inspect between them is unchanged.
- **`_uv_python_spec()` for the interpreter spec.** Apple Silicon keeps `cpython-<v>-macos-aarch64-none` so uv cannot reuse a cached Rosetta build; every other platform gets a plain version and lets uv resolve its native download. As the issue notes, un-gating alone was not enough — it would have handed the macOS-only spec to Linux.
- **Rebuild on 3.13.9 rather than retreating to 3.12.** The 3.12 fallback was right when written, before 3.13.9 existed. It is kept only for the case that produced the bug in the first place: a uv too old to know about 3.13.9. That attempt runs in an `if` condition so `set -e` cannot abort the install, and the install still completes on 3.12.

I left out the fourth suggestion — failing the install when a post-install `import torch` fails instead of degrading to chat-only. It turns installs that currently succeed into hard failures, which reads like your call rather than mine. Happy to add it here or in a follow-up.

## Tests

`tests/sh/test_install_py3138_guard.sh` extracts the guard from `install.sh` and executes it against a stubbed `run_install_cmd` and a fake venv interpreter, so it asserts behaviour rather than source text. 12 assertions:

| scenario | asserted |
|---|---|
| Linux/WSL on 3.13.8 | guard fires, rebuilds on 3.13.9, plain spec, no `macos-aarch64` leak, no needless 3.12 |
| Linux/WSL, uv too old for 3.13.9 | 3.13.9 tried first, install completes on the 3.12 fallback |
| Apple Silicon on 3.13.8 | spec stays `cpython-3.13.9-macos-aarch64-none` |
| healthy 3.13.9 venv | untouched, uv never called |
| `--python` override | user's choice honoured, guard skipped |

It is picked up automatically — both `tests/run_all.sh` and `studio-backend-ci.yml` glob `tests/sh/test_*.sh` — so no workflow change is needed.

Against `main` the test fails (the guard cannot even be extracted); with this change it is 12/12. I also ran the whole `tests/sh` suite and `test_cross_platform_parity.py` / `test_tokenizers_and_torch_constraint.py` / `test_ci_shell_suite_coverage.py` before and after: identical results, no new failures.

Credit to @Sneakr, who diagnosed the 3.13.8 / macOS-gate shape, and @LeoBorcherding for the write-up and the version bisect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
