### PR TITLE
Model picker: follow the UI font size preference

### DIFF
--- a/studio/frontend/src/features/model-picker/components/model-selector.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector.tsx
@@ -521,9 +521,12 @@ function ModelSelectorContent({
               "pt-4 pb-0 pl-4",
               // Sized so the left-packed row keeps uniform gaps and the last
               // dropdown's right gap matches the pill's left gap (pl-4 vs pr-4).
+              // Split into the chrome that never moves (padding, gaps, and the
+              // controls' own icons and padding) and the labels that follow the
+              // font size, or the tuned single-line row wraps once text grows.
               hasExternal
-                ? "w-[min(614px,calc(100vw-1rem))] pr-4"
-                : "w-[min(506px,calc(100vw-1rem))] pr-2",
+                ? "w-[min(calc(323px+291px*var(--ui-font-scale,1)),calc(100vw-1rem))] pr-4"
+                : "w-[min(calc(260px+246px*var(--ui-font-scale,1)),calc(100vw-1rem))] pr-2",
             ),
         className,
       )}

--- a/studio/frontend/src/features/model-picker/components/model-selector.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector.tsx
@@ -186,9 +186,11 @@ function ModelSelectorTrigger({
             "rounded-full bg-muted hover:bg-muted/80 has-[[data-eject-hit]:hover]:!bg-muted",
           // More left padding than right; the chevron is pulled close to the
           // label (below) so the trigger reads balanced around the text.
-          size === "sm" && "h-8 pl-3 pr-1.5 text-xs",
-          size === "default" && "h-9 pl-4 pr-2 text-sm",
-          size === "lg" && "h-10 pl-4.5 pr-2.5 text-sm",
+          size === "sm" &&
+            "h-[calc(2rem*var(--ui-font-scale,1))] pl-3 pr-1.5 text-xs",
+          size === "default" && "h-(--picker-control-h) pl-4 pr-2 text-sm",
+          size === "lg" &&
+            "h-[calc(2.5rem*var(--ui-font-scale,1))] pl-4.5 pr-2.5 text-sm",
           className,
         )}
       >
@@ -864,13 +866,13 @@ function ExternalModelPicker({
       <div className="relative">
         <HugeiconsIcon
           icon={Search01Icon}
-          className="pointer-events-none absolute left-2.5 top-2.5 size-4 text-muted-foreground"
+          className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
         />
         <Input
           value={query}
           onChange={(event) => setQuery(event.target.value)}
           placeholder="Search models"
-          className="h-9 pl-8"
+          className="h-(--picker-control-h) pl-8"
         />
       </div>
       <div className="-mr-1.5 max-h-72 overflow-y-auto pr-1.5">

--- a/studio/frontend/src/features/model-picker/components/model-selector.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector.tsx
@@ -521,9 +521,8 @@ function ModelSelectorContent({
               "pt-4 pb-0 pl-4",
               // Sized so the left-packed row keeps uniform gaps and the last
               // dropdown's right gap matches the pill's left gap (pl-4 vs pr-4).
-              // Split into the chrome that never moves (padding, gaps, and the
-              // controls' own icons and padding) and the labels that follow the
-              // font size, or the tuned single-line row wraps once text grows.
+              // Chrome that never moves plus the labels that scale, so the
+              // tuned single-line row does not wrap once text grows.
               hasExternal
                 ? "w-[min(calc(323px+291px*var(--ui-font-scale,1)),calc(100vw-1rem))] pr-4"
                 : "w-[min(calc(260px+246px*var(--ui-font-scale,1)),calc(100vw-1rem))] pr-2",

--- a/studio/frontend/src/features/model-picker/components/model-selector.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector.tsx
@@ -186,11 +186,11 @@ function ModelSelectorTrigger({
             "rounded-full bg-muted hover:bg-muted/80 has-[[data-eject-hit]:hover]:!bg-muted",
           // More left padding than right; the chevron is pulled close to the
           // label (below) so the trigger reads balanced around the text.
-          size === "sm" &&
-            "h-[calc(2rem*var(--ui-font-scale,1))] pl-3 pr-1.5 text-xs",
-          size === "default" && "h-(--picker-control-h) pl-4 pr-2 text-sm",
-          size === "lg" &&
-            "h-[calc(2.5rem*var(--ui-font-scale,1))] pl-4.5 pr-2.5 text-sm",
+          // Height stays pinned: both call sites force the chat header's own
+          // --studio-chat-control-height, which its fixed header cannot grow.
+          size === "sm" && "h-8 pl-3 pr-1.5 text-xs",
+          size === "default" && "h-9 pl-4 pr-2 text-sm",
+          size === "lg" && "h-10 pl-4.5 pr-2.5 text-sm",
           className,
         )}
       >
@@ -521,11 +521,11 @@ function ModelSelectorContent({
               "pt-4 pb-0 pl-4",
               // Sized so the left-packed row keeps uniform gaps and the last
               // dropdown's right gap matches the pill's left gap (pl-4 vs pr-4).
-              // Chrome that never moves plus the labels that scale, so the
-              // tuned single-line row does not wrap once text grows.
+              // Widths track the controls they hold, so the tuned single-line
+              // row does not wrap once text and icons grow.
               hasExternal
-                ? "w-[min(calc(323px+291px*var(--ui-font-scale,1)),calc(100vw-1rem))] pr-4"
-                : "w-[min(calc(260px+246px*var(--ui-font-scale,1)),calc(100vw-1rem))] pr-2",
+                ? "w-[min(var(--picker-panel-w-external),calc(100vw-1rem))] pr-4"
+                : "w-[min(var(--picker-panel-w),calc(100vw-1rem))] pr-2",
             ),
         className,
       )}

--- a/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pickers.tsx
@@ -3042,7 +3042,7 @@ export function HubModelPicker({
   // and stay visible while searching. Fixed width matches the Search Hub button
   // so it and the format dropdown line up. Trigger label clips; the menu shows full.
   const sortTriggerClassName =
-    "w-[110px] shrink-0 justify-between pr-2.5 !border-0 text-xs [&>span]:!text-clip";
+    "h-(--picker-control-h) w-(--picker-control-w) shrink-0 justify-between pr-2.5 !border-0 text-xs [&>span]:!text-clip";
   // Tighter menu (less padding, text-xs) matching the trigger. Keep the option's
   // right padding so the selected-item checkmark never overlaps the label.
   const sortMenuContentClassName =
@@ -3560,7 +3560,7 @@ export function HubModelPicker({
           <div className="relative flex-1">
             <HugeiconsIcon
               icon={Search01Icon}
-              className="pointer-events-none absolute left-2.5 top-2.5 size-4 text-muted-foreground"
+              className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
             />
             <Input
               value={query}
@@ -3571,10 +3571,10 @@ export function HubModelPicker({
                   : "Search Unsloth models"
               }
               data-model-picker-search-input={true}
-              className="field-soft h-9 border-0 pl-8 pr-8"
+              className="field-soft h-(--picker-control-h) border-0 pl-8 pr-8"
             />
             {isLoading && (
-              <Spinner className="pointer-events-none absolute right-2.5 top-2.5 size-4 text-muted-foreground" />
+              <Spinner className="pointer-events-none absolute right-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
             )}
           </div>
           {onBrowseHub ? (
@@ -3584,7 +3584,7 @@ export function HubModelPicker({
                   type="button"
                   onClick={onBrowseHub}
                   aria-label="Search more models on the Hub"
-                  className="hub-tab-toggle-pill flex h-9 w-[110px] shrink-0 items-center justify-center gap-[5px] rounded-full border-0 text-xs text-foreground transition-colors"
+                  className="hub-tab-toggle-pill flex h-(--picker-control-h) w-(--picker-control-w) shrink-0 items-center justify-center gap-[5px] rounded-full border-0 text-xs text-foreground transition-colors"
                 >
                   <HugeiconsIcon
                     icon={DashboardCircleIcon}

--- a/studio/frontend/src/features/model-picker/components/model-selector/pill-tabs.tsx
+++ b/studio/frontend/src/features/model-picker/components/model-selector/pill-tabs.tsx
@@ -43,7 +43,7 @@ export function PillTabs({
       aria-label={ariaLabel}
       className={cn(
         "hub-menu-trigger hub-tab-toggle relative inline-flex items-center rounded-full",
-        compact ? "h-7" : "h-9",
+        compact ? "h-7" : "h-(--picker-control-h)",
         // Don't stretch to fill a flex-column parent (the popover) in fit mode,
         // and never compress so the last tab keeps its padding.
         fit && "w-fit max-w-full shrink-0 self-start",
@@ -86,7 +86,9 @@ export function PillTabs({
           className={cn(
             "relative z-10 inline-flex items-center justify-center gap-1.5 rounded-full transition-colors",
             fit ? "min-w-0 shrink" : "min-w-0 flex-1",
-            compact ? "h-7 px-2.5 text-ui-11" : "h-9 px-3 text-ui-12p5",
+            compact
+              ? "h-7 px-2.5 text-ui-11"
+              : "h-(--picker-control-h) px-3 text-ui-12p5",
             value === tab.value
               ? "text-foreground"
               : "text-muted-foreground hover:text-foreground",

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -305,6 +305,12 @@
 	   18px), so icons read slightly smaller than enlarged text. */
 	--ui-icon-size: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1)));
 	--icon-size: var(--ui-icon-size);
+	/* Model picker header controls. Their labels come from scaled text tokens
+	   while --spacing stays pinned, so a fixed box clips "Trending" at the
+	   large setting and swims around it at the small one. Same values as the
+	   h-9 / w-[110px] they replace at the 16px default. */
+	--picker-control-h: calc(2.25rem * var(--ui-font-scale, 1));
+	--picker-control-w: calc(6.875rem * var(--ui-font-scale, 1));
 	/* Inset of a centered .size-icon glyph within a 2rem (size-8) action
 	   button — i.e. (32px − icon-size) / 2. Use as a negative margin on a
 	   chat-message action bar so the leftmost icon's visual edge aligns

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -305,12 +305,20 @@
 	   18px), so icons read slightly smaller than enlarged text. */
 	--ui-icon-size: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1)));
 	--icon-size: var(--ui-icon-size);
-	/* Model picker header controls. Padding, gaps and icons come from the
-	   pinned --spacing, so only the label's share scales; scaling the whole
-	   box starves the label (64px of the 110px trigger is chrome). Both match
-	   the h-9 / w-[110px] they replace at the 16px default. */
+	/* Mirrors the size-3.5 rule applied inside popovers (see the icon block
+	   below), so widths that reserve room for those icons track them. */
+	--ui-icon-size-sm: min(calc(0.875rem * var(--ui-font-scale, 1)), calc(0.4375rem + 0.4375rem * var(--ui-font-scale, 1)));
+	/* Model picker header controls. Padding and gaps come from the pinned
+	   --spacing, the icons and label both scale, so reserve each separately.
+	   The trigger is 2.25rem of padding and gaps, two icons, then the label.
+	   All match the h-9 / w-[110px] / 506px they replace at the 16px default. */
 	--picker-control-h: calc(1.125rem + 1.125rem * var(--ui-font-scale, 1));
-	--picker-control-w: calc(4rem + 2.875rem * var(--ui-font-scale, 1));
+	--picker-control-w: calc(2.25rem + 2 * var(--ui-icon-size-sm) + 2.875rem * var(--ui-font-scale, 1));
+	/* Panel: pl-4, two gaps and pr-2, the pills' padding, their two icons and
+	   label, then the two dropdowns. */
+	--picker-panel-w: calc(6.25rem + 2 * var(--ui-icon-size-sm) + 9.875rem * var(--ui-font-scale, 1) + 2 * var(--picker-control-w));
+	/* Provider row adds one more control; split like the rest. */
+	--picker-panel-w-external: calc(var(--picker-panel-w) + 4rem + 2.75rem * var(--ui-font-scale, 1));
 	/* Inset of a centered .size-icon glyph within a 2rem (size-8) action
 	   button — i.e. (32px − icon-size) / 2. Use as a negative margin on a
 	   chat-message action bar so the leftmost icon's visual edge aligns

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -305,12 +305,13 @@
 	   18px), so icons read slightly smaller than enlarged text. */
 	--ui-icon-size: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1)));
 	--icon-size: var(--ui-icon-size);
-	/* Model picker header controls. Their labels come from scaled text tokens
-	   while --spacing stays pinned, so a fixed box clips "Trending" at the
-	   large setting and swims around it at the small one. Same values as the
-	   h-9 / w-[110px] they replace at the 16px default. */
-	--picker-control-h: calc(2.25rem * var(--ui-font-scale, 1));
-	--picker-control-w: calc(6.875rem * var(--ui-font-scale, 1));
+	/* Model picker header controls. Only the label scales: the padding, gaps
+	   and 16px icons around it come from the pinned --spacing, so scaling the
+	   whole box starves the label at the small setting (64px of the 110px
+	   trigger is chrome). Hold the chrome, scale the label's share. Both are
+	   the h-9 / w-[110px] they replace at the 16px default. */
+	--picker-control-h: calc(1.125rem + 1.125rem * var(--ui-font-scale, 1));
+	--picker-control-w: calc(4rem + 2.875rem * var(--ui-font-scale, 1));
 	/* Inset of a centered .size-icon glyph within a 2rem (size-8) action
 	   button — i.e. (32px − icon-size) / 2. Use as a negative margin on a
 	   chat-message action bar so the leftmost icon's visual edge aligns

--- a/studio/frontend/src/index.css
+++ b/studio/frontend/src/index.css
@@ -305,10 +305,9 @@
 	   18px), so icons read slightly smaller than enlarged text. */
 	--ui-icon-size: min(calc(1rem * var(--ui-font-scale, 1)), calc(0.5rem + 0.5rem * var(--ui-font-scale, 1)));
 	--icon-size: var(--ui-icon-size);
-	/* Model picker header controls. Only the label scales: the padding, gaps
-	   and 16px icons around it come from the pinned --spacing, so scaling the
-	   whole box starves the label at the small setting (64px of the 110px
-	   trigger is chrome). Hold the chrome, scale the label's share. Both are
+	/* Model picker header controls. Padding, gaps and icons come from the
+	   pinned --spacing, so only the label's share scales; scaling the whole
+	   box starves the label (64px of the 110px trigger is chrome). Both match
 	   the h-9 / w-[110px] they replace at the 16px default. */
 	--picker-control-h: calc(1.125rem + 1.125rem * var(--ui-font-scale, 1));
 	--picker-control-w: calc(4rem + 2.875rem * var(--ui-font-scale, 1));


### PR DESCRIPTION
### The problem

`--ui-font-scale` reaches text through the `--text-*` / `--text-ui-*` / `--leading-*` tokens, and a separate rule scales icon sizes inside popovers, but `--spacing` stays pinned at `0.25rem` by design so layout geometry does not move with the preference. The model picker's controls take their labels and icons from the scaled tokens and their boxes from the pinned scale, so the two drift apart: labels clipped at the large setting, and the boxes sat oversized around small text.

### The change

A control is part chrome, part label, part icon, and only two of those scale. The sort trigger is `2.25rem` of padding and gaps that never move, two `size-3.5` icons that the popover icon rule scales from 14px to 15.75px, and a label that follows the font size. Each is reserved separately:

```css
--ui-icon-size-sm: min(calc(0.875rem * var(--ui-font-scale, 1)), calc(0.4375rem + 0.4375rem * var(--ui-font-scale, 1)));
--picker-control-h: calc(1.125rem + 1.125rem * var(--ui-font-scale, 1));
--picker-control-w: calc(2.25rem + 2 * var(--ui-icon-size-sm) + 2.875rem * var(--ui-font-scale, 1));
```

That keeps label room equal to label width across the range. Scaling whole boxes instead starves the label at the small setting; treating the chrome as flat leaves it short at the large one, because the icons inside it grew.

The tokens apply to the search field, the Search Hub button, the format and sort dropdowns, and the section pills. The search icons now centre on the field instead of sitting at a fixed `top-2.5` inset that only suited a 36px height.

The panel width was a tuned fixed value, sized so the control row fits on one line at 16px, so it wrapped once labels grew. It is now expressed in terms of the controls it holds, reserving the pills' icons the same way, so it stays in step with them.

Padding and gaps stay on the pinned spacing scale, so layout geometry still does not move with the preference, which is the existing rule.

### What is deliberately not included

The selector trigger's own height stays pinned. Both call sites append `!h-[var(--studio-chat-control-height,34px)]`, which compiles to `height: ... !important` and wins over any class the component sets, and that variable is 33px. Scaling it would need the chat header's geometry to move too: the header is a fixed 44px, 48px with custom chrome, with 7px of padding, so a 37.75px control at the 20px setting overflows it. That is a larger change than this PR should carry, so the plain heights stay with a comment saying why.

### Compatibility

Every value collapses to exactly what it replaces at the 16px default: control width 110px, panel 506px, panel with providers 614px. Nothing moves for anyone who has not changed the setting. The range is 12px to 20px, a scale of 0.75 to 1.25.

`tailwind-merge` resolves `h-(--picker-control-h)` over the shared dropdown's own `h-9`, so the dropdown height follows too. Verified against the installed version rather than assumed.

The provider-row panel adds one more control and is split proportionally rather than derived element by element. The row keeps `flex-wrap`, so if that is slightly off it wraps as it does today rather than clipping.

### Testing

- Checked label room against label width at 0.75, 0.875, 1.0, 1.125 and 1.25: they match at every step, and every value is unchanged at 1.0
- Confirmed the build emits all four token definitions and the utility rules that consume them
- Confirmed from the compiled CSS that the call-site height override is `!important`, which is why the trigger height was reverted
- `npm run typecheck` clean
- `npm run build` clean
- `npm test`: 331 passing, 1 failing. The failure is `sidebar-spinner-column.test.ts`, which scans `app-sidebar.tsx` and already fails the same way on a clean `main`. This PR does not touch that file.
- `biome check` on all four touched files matches `main` exactly