### PR TITLE
fix python tool images not rendering in the desktop app

### DIFF
--- a/studio/frontend/src/components/assistant-ui/tool-ui-python.tsx
+++ b/studio/frontend/src/components/assistant-ui/tool-ui-python.tsx
@@ -4,6 +4,7 @@
 "use client";
 
 import { getAuthToken } from "@/features/auth/session";
+import { apiUrl } from "@/lib/api-base";
 import type { ToolCallMessagePartComponent } from "@assistant-ui/react";
 import { useToolArgsStatus } from "@assistant-ui/react";
 import { CodeIcon } from "lucide-react";
@@ -142,7 +143,7 @@ const PythonToolUIImpl: ToolCallMessagePartComponent = ({
               {images.map((filename) => (
                 <img
                   key={filename}
-                  src={`/api/inference/sandbox/${encodeURIComponent(sessionId)}/${encodeURIComponent(filename)}${authToken ? `?token=${encodeURIComponent(authToken)}` : ""}`}
+                  src={apiUrl(`/api/inference/sandbox/${encodeURIComponent(sessionId)}/${encodeURIComponent(filename)}${authToken ? `?token=${encodeURIComponent(authToken)}` : ""}`)}
                   alt={filename}
                   loading="lazy"
                   className="max-w-full rounded border border-border"

--- a/studio/src-tauri/tauri.conf.json
+++ b/studio/src-tauri/tauri.conf.json
@@ -16,7 +16,7 @@
   "app": {
     "withGlobalTauri": true,
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost http://localhost:* ws://localhost:* ws://127.0.0.1:* http://127.0.0.1:* https://huggingface.co https://*.huggingface.co https://datasets-server.huggingface.co; img-src 'self' data: blob: https:; media-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; frame-src 'self' http://localhost:* http://127.0.0.1:*"
+      "csp": "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost http://localhost:* ws://localhost:* ws://127.0.0.1:* http://127.0.0.1:* https://huggingface.co https://*.huggingface.co https://datasets-server.huggingface.co; img-src 'self' data: blob: https: http://localhost:* http://127.0.0.1:*; media-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; frame-src 'self' http://localhost:* http://127.0.0.1:*"
     },
     "windows": [
       {


### PR DESCRIPTION
Python tool results render images via `<img src="/api/inference/sandbox/{sessionId}/{filename}">` in `studio/frontend/src/components/assistant-ui/tool-ui-python.tsx`. In the desktop app the webview origin is the tauri asset origin, so the relative src resolves against the asset server instead of the FastAPI backend and 404s, showing a broken image. Web is unaffected because the frontend is served from the backend origin. Native image generation works because it embeds base64 data URIs.

Changes:
- `tool-ui-python.tsx`: build the sandbox src with `apiUrl()` from `@/lib/api-base`, same as every other API call. In Tauri production this becomes `http://127.0.0.1:8888/api/...`; in web and vite dev it stays relative.
- `studio/src-tauri/tauri.conf.json`: add `http://localhost:* http://127.0.0.1:*` to `img-src`. `connect-src` already allowed these origins but `img-src` did not, so WKWebView would CSP-block the absolute URL.

Testing:
- Ran `tauri dev` on macOS and re-ran a code-generation prompt that saves a PNG; the image now renders in the chat.
- `npm run typecheck` in `studio/frontend` passes.
- Web behavior unchanged: outside Tauri `apiBase` is empty, so the URL stays same-origin relative.

MCP tool images and native image_generation ship base64 data URIs, so they were never affected by this bug.