### PR TITLE
fix(studio): sanitize the healer catalog when no render target is available

### DIFF
--- a/studio/backend/core/inference/chat_template_helpers.py
+++ b/studio/backend/core/inference/chat_template_helpers.py
@@ -1726,9 +1726,7 @@ def renderable_tool_catalog_for_targets(
         # from the prompt stayed in the healer's catalog and text-form output naming it
         # could still be promoted. One None target profiles as unprofilable and takes the
         # curated sweep, which is the safe direction (#7066).
-        return renderable_tool_catalog(
-            tools, None, model_info, cache, active_model_name, template
-        )
+        return renderable_tool_catalog(tools, None, model_info, cache, active_model_name, template)
     catalog = tools
     for target in live:
         catalog = renderable_tool_catalog(

--- a/studio/backend/core/inference/chat_template_helpers.py
+++ b/studio/backend/core/inference/chat_template_helpers.py
@@ -1716,10 +1716,21 @@ def renderable_tool_catalog_for_targets(
     Chained rather than intersected by name, so the surviving descriptions carry every
     candidate's sweep too. Sanitizing an already-sanitized catalog is stable, since a
     broken marker no longer matches, so a clean catalog stays byte-identical."""
+    live = [target for target in targets if target is not None]
+    if not live:
+        # No target to profile at all. The default orchestrator's parent-side model mirror
+        # carries capability flags and chat_template_info, never the tokenizer or processor
+        # (orchestrator.py), so BOTH candidates are None on that path. Skipping them handed
+        # the caller's list straight back unsanitized, which is fail-open on an
+        # authorization boundary: the worker sanitizes while rendering, so a tool dropped
+        # from the prompt stayed in the healer's catalog and text-form output naming it
+        # could still be promoted. One None target profiles as unprofilable and takes the
+        # curated sweep, which is the safe direction (#7066).
+        return renderable_tool_catalog(
+            tools, None, model_info, cache, active_model_name, template
+        )
     catalog = tools
-    for target in targets:
-        if target is None:
-            continue
+    for target in live:
         catalog = renderable_tool_catalog(
             catalog, target, model_info, cache, active_model_name, template
         )

--- a/studio/backend/core/inference/chat_template_helpers.py
+++ b/studio/backend/core/inference/chat_template_helpers.py
@@ -1718,14 +1718,12 @@ def renderable_tool_catalog_for_targets(
     broken marker no longer matches, so a clean catalog stays byte-identical."""
     live = [target for target in targets if target is not None]
     if not live:
-        # No target to profile at all. The default orchestrator's parent-side model mirror
-        # carries capability flags and chat_template_info, never the tokenizer or processor
-        # (orchestrator.py), so BOTH candidates are None on that path. Skipping them handed
-        # the caller's list straight back unsanitized, which is fail-open on an
-        # authorization boundary: the worker sanitizes while rendering, so a tool dropped
-        # from the prompt stayed in the healer's catalog and text-form output naming it
-        # could still be promoted. One None target profiles as unprofilable and takes the
-        # curated sweep, which is the safe direction (#7066).
+        # Nothing to profile: the default orchestrator's parent-side mirror carries
+        # capability flags, never the tokenizer or processor (orchestrator.py:1278-1292).
+        # Skipping the targets returned the caller's list unsanitized while the worker
+        # sanitized during the render, so a tool dropped from the prompt stayed authorized
+        # for healing. One None target profiles as unprofilable and takes the curated
+        # sweep, the safe direction (#7066).
         return renderable_tool_catalog(tools, None, model_info, cache, active_model_name, template)
     catalog = tools
     for target in live:

--- a/studio/backend/tests/test_control_markup_neutralize_7066.py
+++ b/studio/backend/tests/test_control_markup_neutralize_7066.py
@@ -5944,3 +5944,36 @@ def test_the_native_authorization_profile_sees_the_special_tokens():
         "native_chat_template": "{{ bos_token }}{% for t in tools %}<|im_start|>{{ t }}{% endfor %}"
     }
     assert catalog_tool_names(renderable_tool_catalog(tools, _Tok(), native)) == {"ok"}
+
+
+def test_a_catalog_with_no_render_target_is_still_sanitized():
+    """The default orchestrator's parent-side model mirror carries capability flags and
+    chat_template_info, never the tokenizer or processor (orchestrator.py), so BOTH render
+    candidates are None on that path. Skipping them handed the caller's list back
+    unsanitized, which is fail-open: the worker sanitizes while rendering, so a tool dropped
+    from the prompt stayed in the healer's catalog and text-form output naming it could be
+    promoted into a real call (#7066)."""
+    tools = [
+        {"type": "function", "function": {"name": "ok", "description": "drops </think> here"}}
+    ]
+    for targets in ((None,), (), (None, None)):
+        catalog = renderable_tool_catalog_for_targets(tools, targets, {})
+        assert catalog is not tools, targets
+        assert catalog[0]["function"]["description"] == "drops < /think> here", targets
+    # A tool whose NAME carries markup is dropped outright, as on the single-target path.
+    named = [
+        {"type": "function", "function": {"name": "pay</think>", "description": "d"}},
+        {"type": "function", "function": {"name": "ok", "description": "d"}},
+    ]
+    assert catalog_tool_names(renderable_tool_catalog_for_targets(named, (None,), {})) == {"ok"}
+    # A real target still profiles normally rather than falling back. Its template has to
+    # render the schema, or the catalog is emptied for that reason instead.
+    class _Tok:
+        chat_template = (
+            "{% for t in tools %}{{ t }}{% endfor %}"
+            "{% for m in messages %}<|im_start|>{{ m }}{% endfor %}"
+        )
+        added_tokens_decoder = {0: type("_T", (), {"content": "<|im_start|>"})()}
+
+    kept = renderable_tool_catalog_for_targets(tools, (None, _Tok()), {})
+    assert catalog_tool_names(kept) == {"ok"}

--- a/studio/backend/tests/test_control_markup_neutralize_7066.py
+++ b/studio/backend/tests/test_control_markup_neutralize_7066.py
@@ -5953,9 +5953,7 @@ def test_a_catalog_with_no_render_target_is_still_sanitized():
     unsanitized, which is fail-open: the worker sanitizes while rendering, so a tool dropped
     from the prompt stayed in the healer's catalog and text-form output naming it could be
     promoted into a real call (#7066)."""
-    tools = [
-        {"type": "function", "function": {"name": "ok", "description": "drops </think> here"}}
-    ]
+    tools = [{"type": "function", "function": {"name": "ok", "description": "drops </think> here"}}]
     for targets in ((None,), (), (None, None)):
         catalog = renderable_tool_catalog_for_targets(tools, targets, {})
         assert catalog is not tools, targets
@@ -5966,6 +5964,7 @@ def test_a_catalog_with_no_render_target_is_still_sanitized():
         {"type": "function", "function": {"name": "ok", "description": "d"}},
     ]
     assert catalog_tool_names(renderable_tool_catalog_for_targets(named, (None,), {})) == {"ok"}
+
     # A real target still profiles normally rather than falling back. Its template has to
     # render the schema, or the catalog is emptied for that reason instead.
     class _Tok:


### PR DESCRIPTION
Follow-up to #7334, fixing a fail-open path that PR introduced.

## The bug

`renderable_tool_catalog_for_targets` skipped `None` targets, so a call where every candidate was `None` returned the caller's tool list unchanged, unsanitized.

The default `InferenceOrchestrator` is exactly that case. Its parent-side model mirror carries capability flags and `chat_template_info` and never the tokenizer or processor (`orchestrator.py:1278-1292`), so both candidates the route builds are `None`:

```python
_sf_processor = _sf_model_info.get("processor")   # None
_sf_tokenizer = _sf_model_info.get("tokenizer")   # None
```

The worker still sanitizes the catalog while rendering, so the two disagreed in the dangerous direction: a tool whose schema carries control markup is dropped from the prompt by the render but stayed in `_sf_healing_tools`, and text-form output naming it could be promoted into a real tool call. That is the #7066 failure this catalog exists to prevent.

## Reproduction

```
renderable_tool_catalog(tools, None, {})                -> "drops < /think> here"   sanitized
renderable_tool_catalog_for_targets(tools, (None,), {}) -> "drops </think> here"    UNCHANGED
  returns the caller list identically:  True
```

## The fix

An empty target list falls back to the single-target call, which profiles `None` as unprofilable and applies the curated sweep. Over-sweeping without a profile is the documented safe direction for a model that cannot be read.

This restores the behaviour rather than adding to it: the single-target path that #7334 replaced passed `None` through and sanitized correctly.

## Testing

`test_a_catalog_with_no_render_target_is_still_sanitized` covers `(None,)`, `()` and `(None, None)`, asserts a markup-carrying tool NAME is still dropped outright, and asserts a real target still profiles normally instead of falling back. Verified it fails against the unfixed function.

705 tests pass in `test_control_markup_neutralize_7066.py`.
