### PR TITLE
Scan Windows desktop bundles with Defender before publishing

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -858,13 +858,30 @@ jobs:
           Write-Host "engine $($status.AMEngineVersion), signatures $($status.AntivirusSignatureVersion) ($($status.AntivirusSignatureLastUpdated))"
 
           # Set-MpPreference can return cleanly and still be ignored, so verify.
+          # Split by whether the gap invalidates the verdict: cloud-delivered
+          # protection is inactive without active mode, MAPS and block-at-first-
+          # sight, and "!ml" is a cloud verdict, so a clean result without them
+          # cannot see what this gate exists to catch. Leftover exclusions only
+          # weaken it, since -DisableRemediation ignores file exclusions.
+          $fatal = @()
           $degraded = @()
-          if (-not $status.RealTimeProtectionEnabled) { $degraded += "RealTimeProtectionEnabled=false (AMRunningMode=$($status.AMRunningMode))" }
-          if ([int]$pref.MAPSReporting -ne 2)         { $degraded += "MAPSReporting=$($pref.MAPSReporting), expected 2 (Advanced)" }
+          if (-not $status.RealTimeProtectionEnabled) { $fatal += "RealTimeProtectionEnabled=false (AMRunningMode=$($status.AMRunningMode))" }
+          if ([int]$pref.MAPSReporting -ne 2)         { $fatal += "MAPSReporting=$($pref.MAPSReporting), expected 2 (Advanced)" }
+          if ($pref.DisableBlockAtFirstSeen)          { $fatal += 'DisableBlockAtFirstSeen=true' }
           if ([int]$pref.SubmitSamplesConsent -ne 3)  { $degraded += "SubmitSamplesConsent=$($pref.SubmitSamplesConsent), expected 3 (SendAllSamples)" }
-          if ($pref.DisableBlockAtFirstSeen)          { $degraded += 'DisableBlockAtFirstSeen=true' }
           if ([int]$pref.CloudBlockLevel -eq 0)       { $degraded += "CloudBlockLevel=$($pref.CloudBlockLevel), expected High" }
           if ($pref.ExclusionPath)                    { $degraded += "exclusions remain: $($pref.ExclusionPath -join ',')" }
+
+          # Configuration is not connectivity. Retried, so one network blip does
+          # not block a release.
+          $maps = $false
+          foreach ($try in 1..3) {
+            $mapsOut = (& $mp -ValidateMapsConnection 2>&1 | Out-String)
+            if ($LASTEXITCODE -eq 0) { $maps = $true; break }
+            Write-Host "  MAPS check $try failed: $($mapsOut.Trim())"
+            Start-Sleep -Seconds (5 * $try)
+          }
+          if (-not $maps) { $fatal += 'cannot reach the Defender cloud service' }
 
           # Positive control: clean and broken-scanner look identical. Split into
           # fragments so this file is not itself a sample.
@@ -884,10 +901,14 @@ jobs:
             Write-Host 'EICAR positive control blocked on write; real-time protection is live.'
             $controlPassed = $true
           }
-          if (-not $controlPassed) { $degraded += 'EICAR positive control did not fire' }
+          if (-not $controlPassed) { $fatal += 'EICAR positive control did not fire' }
 
           if ($degraded) {
-            Write-Host "::warning::Defender is degraded on this runner ($($degraded -join '; ')). Scanning anyway, but a clean result below is not authoritative."
+            Write-Host "::warning::Defender is not fully configured on this runner ($($degraded -join '; ')). Scanning anyway."
+          }
+          if ($fatal) {
+            Write-Host "::error::Defender cannot give an authoritative verdict here ($($fatal -join '; ')); refusing to publish on a scan that cannot see the detection class this gate exists for"
+            exit 1
           }
 
           # Fatal, not a warning: exiting 0 here would pass an unscanned release.
@@ -919,6 +940,14 @@ jobs:
           $work = Join-Path $env:RUNNER_TEMP 'defender-scan'
           Remove-Item $work -Recurse -Force -ErrorAction SilentlyContinue
           New-Item -ItemType Directory -Force -Path $work | Out-Null
+
+          # Real-time protection acts on open and on write, and -DisableRemediation
+          # governs only the explicit scan, so a hit would quarantine the bundle
+          # mid-copy and leave the failure handler nothing to upload. Exempt both
+          # ends of the copy. The verdict is unaffected: -DisableRemediation
+          # ignores file exclusions. Left in place, since the copies must survive
+          # until the failure-gated preserve step runs.
+          Add-MpPreference -ExclusionPath (@($work) + @($paths | Split-Path -Parent | Sort-Object -Unique)) -ErrorAction Continue
 
           $detected = @()
           $unscanned = @()

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -947,7 +947,18 @@ jobs:
           # ends of the copy. The verdict is unaffected: -DisableRemediation
           # ignores file exclusions. Left in place, since the copies must survive
           # until the failure-gated preserve step runs.
-          Add-MpPreference -ExclusionPath (@($work) + @($paths | Split-Path -Parent | Sort-Object -Unique)) -ErrorAction Continue
+          $exclude = @($work) + @($paths | Split-Path -Parent | Sort-Object -Unique)
+          Add-MpPreference -ExclusionPath $exclude -ErrorAction Continue
+
+          # -ErrorAction Continue does not stop on a rejected exclusion, so read
+          # it back. Defender stores these verbatim; normalise anyway.
+          $norm = { param($p) $p.TrimEnd('\').ToLowerInvariant() }
+          $applied = @(@((Get-MpPreference).ExclusionPath) | ForEach-Object { & $norm $_ })
+          $notApplied = @($exclude | Where-Object { $applied -notcontains (& $norm $_) })
+          if ($notApplied) {
+            Write-Host "::error::Defender refused these exclusions: $($notApplied -join ', '); a detection would quarantine the bundle mid-copy and leave nothing to submit"
+            exit 1
+          }
 
           $detected = @()
           $unscanned = @()

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -817,6 +817,164 @@ jobs:
           tauriScript: npx --prefix . tauri
           args: -v ${{ matrix.args }}
 
+      # ── Windows: scan the signed bundles with Defender before publishing ──
+      # 0.1.512-beta shipped and users hit "Trojan:Win32/Wacatac.B!ml" on first
+      # download. That build was clean, but nothing here looked, so it took two
+      # days to say so. Three things this has to get right: the runner image
+      # disables Defender and excludes both drive roots, so restore it and check
+      # the restore took; "!ml" is a cloud verdict, so MAPS must be on; and
+      # MpCmdRun exit codes are ambiguous, so read the output text.
+      - name: Scan Windows bundles with Defender
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        env:
+          ARTIFACT_PATHS: ${{ steps.build_windows.outputs.artifactPaths }}
+        run: |
+          $ErrorActionPreference = 'Continue'
+
+          $atp = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows Advanced Threat Protection'
+          if (Test-Path $atp) { Remove-ItemProperty -Path $atp -Name 'ForceDefenderPassiveMode' -ErrorAction SilentlyContinue }
+          Start-Service -Name WinDefend -ErrorAction SilentlyContinue
+
+          foreach ($x in @((Get-MpPreference).ExclusionPath)) {
+            if ($x) { Remove-MpPreference -ExclusionPath $x -ErrorAction SilentlyContinue }
+          }
+          Set-MpPreference `
+            -DisableRealtimeMonitoring $false -DisableIOAVProtection $false `
+            -DisableScriptScanning $false -DisableBehaviorMonitoring $false `
+            -DisableArchiveScanning $false -MAPSReporting Advanced `
+            -SubmitSamplesConsent SendAllSamples -CloudBlockLevel High `
+            -CloudExtendedTimeout 50 -DisableBlockAtFirstSeen $false -ErrorAction Continue
+
+          $mp = "$env:ProgramFiles\Windows Defender\MpCmdRun.exe"
+          $plat = Get-ChildItem 'C:\ProgramData\Microsoft\Windows Defender\Platform' -Directory -ErrorAction SilentlyContinue |
+                  Sort-Object Name -Descending | Select-Object -First 1
+          if ($plat -and (Test-Path "$($plat.FullName)\MpCmdRun.exe")) { $mp = "$($plat.FullName)\MpCmdRun.exe" }
+          Update-MpSignature -UpdateSource MicrosoftUpdateServer -ErrorAction Continue
+          & $mp -SignatureUpdate 2>&1 | Write-Host
+
+          $status = Get-MpComputerStatus
+          $pref = Get-MpPreference
+          Write-Host "engine $($status.AMEngineVersion), signatures $($status.AntivirusSignatureVersion) ($($status.AntivirusSignatureLastUpdated))"
+
+          # Set-MpPreference can return cleanly and still be ignored, so verify.
+          $degraded = @()
+          if (-not $status.RealTimeProtectionEnabled) { $degraded += "RealTimeProtectionEnabled=false (AMRunningMode=$($status.AMRunningMode))" }
+          if ([int]$pref.MAPSReporting -ne 2)         { $degraded += "MAPSReporting=$($pref.MAPSReporting), expected 2 (Advanced)" }
+          if ($pref.ExclusionPath)                    { $degraded += "exclusions remain: $($pref.ExclusionPath -join ',')" }
+
+          # Positive control, or "clean" and "scanner broken" look identical.
+          # Assembled from fragments so this file is not itself a sample.
+          $eicarPath = Join-Path $env:RUNNER_TEMP 'defender-selftest.com'
+          [System.IO.File]::WriteAllText(
+            $eicarPath,
+            'X5O!P%@AP[4\PZX54(P^)7CC)7}' + '$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!' + '$H+H*')
+          $controlPassed = $true
+          if (Test-Path $eicarPath) {
+            $controlOut = (& $mp -Scan -ScanType 3 -File $eicarPath -DisableRemediation 2>&1 | Out-String)
+            $controlPassed = [bool](($controlOut -match 'found\s+\d+\s+threat') -or ($controlOut -match 'EICAR'))
+            Remove-Item $eicarPath -Force -ErrorAction SilentlyContinue
+          }
+          if (-not $controlPassed) { $degraded += 'EICAR positive control did not fire' }
+
+          if ($degraded) {
+            Write-Host "::warning::Defender is degraded on this runner ($($degraded -join '; ')). Scanning anyway, but a clean result below is not authoritative."
+          }
+
+          # Fatal, not a warning: an earlier draft exited 0 here and a self-test
+          # caught it passing a release it had never scanned.
+          if ([string]::IsNullOrWhiteSpace($env:ARTIFACT_PATHS)) {
+            Write-Host '::error::tauri-action produced no artifactPaths output; refusing to publish unscanned bundles'
+            exit 1
+          }
+          try {
+            $paths = @($env:ARTIFACT_PATHS | ConvertFrom-Json)
+          } catch {
+            Write-Host "::error::could not parse artifactPaths ($($_.Exception.Message)); refusing to publish unscanned bundles"
+            exit 1
+          }
+          $missing = @($paths | Where-Object { $_ -and -not (Test-Path $_ -PathType Leaf) })
+          if ($missing) {
+            Write-Host "::error::artifactPaths lists files that do not exist: $($missing -join ', ')"
+            exit 1
+          }
+          $paths = @($paths | Where-Object { $_ })
+          if (-not $paths) {
+            Write-Host '::error::artifactPaths resolved to an empty list; refusing to publish unscanned bundles'
+            exit 1
+          }
+          Write-Host "scanning $($paths.Count) Windows bundle(s)"
+
+          $detected = @()
+          foreach ($f in $paths) {
+            # Block-at-first-sight only consults the cloud for internet-zone
+            # files, so stamp mark-of-the-web or this is not the user path.
+            "[ZoneTransfer]`nZoneId=3" | Set-Content -Path $f -Stream Zone.Identifier -Encoding Ascii -ErrorAction SilentlyContinue
+
+            $out = & $mp -Scan -ScanType 3 -File $f -DisableRemediation 2>&1
+            $text = ($out | Out-String)
+            $out | ForEach-Object { Write-Host "  $_" }
+
+            # Exit codes are ambiguous; read the output text.
+            if ($text -match 'found\s+\d+\s+threat') {
+              $names = [regex]::Matches($text, '((?:Trojan|Virus|Worm|Backdoor|Ransom|HackTool|PUA|Behavior|Program|Misleading)[:\w\./!\-]+)') |
+                       ForEach-Object { $_.Groups[1].Value } | Sort-Object -Unique
+              Write-Host "::error::Defender flagged $(Split-Path $f -Leaf): $($names -join ', ')"
+              $detected += "$(Split-Path $f -Leaf) [$($names -join ', ')]"
+            } else {
+              Write-Host "clean: $(Split-Path $f -Leaf)"
+            }
+          }
+
+          if ($detected) {
+            Write-Host "::error::Refusing to publish a Windows bundle Defender flags: $($detected -join '; ')"
+            Write-Host 'If this is a false positive, submit it at https://www.microsoft.com/en-us/wdsi/filesubmission (Software developer -> incorrectly detected) and re-run once cleared.'
+            exit 1
+          }
+          Write-Host "All $($paths.Count) Windows bundle(s) scanned clean."
+
+      # ── Windows: assemble a Microsoft false-positive submission packet ──
+      # There is no submission API; the WDSI portal is a web form. This cannot be
+      # automated, but it can remove the lookup work so pre-submitting a build
+      # before announcing it takes seconds.
+      - name: Prepare Microsoft submission packet
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        env:
+          ARTIFACT_PATHS: ${{ steps.build_windows.outputs.artifactPaths }}
+        run: |
+          $paths = @($env:ARTIFACT_PATHS | ConvertFrom-Json) |
+                   Where-Object { $_ -like '*-setup.exe' }
+          $md = @(
+            '## Microsoft submission packet',
+            '',
+            'Submit at <https://www.microsoft.com/en-us/wdsi/filesubmission> before announcing this release.',
+            'Choose **Software developer** -> **Incorrectly detected as malware/malicious**.',
+            'The 50 MB upload cap applies; if a bundle exceeds it, submit the extracted main binary instead.',
+            ''
+          )
+          foreach ($f in $paths) {
+            $item = Get-Item $f
+            $sig = Get-AuthenticodeSignature $f
+            $md += "### $($item.Name)"
+            $md += ''
+            $md += '| field | value |'
+            $md += '|---|---|'
+            $md += "| SHA-256 | ``$((Get-FileHash -Algorithm SHA256 $f).Hash)`` |"
+            $md += "| SHA-1 | ``$((Get-FileHash -Algorithm SHA1 $f).Hash)`` |"
+            $md += "| Size | $($item.Length) bytes |"
+            $md += "| Signature | $($sig.Status) |"
+            $md += "| Signer | $($sig.SignerCertificate.Subject) |"
+            $md += "| Product | $($env:APP_VERSION) |"
+            $md += ''
+          }
+          $md += '> Clearance is per hash. It fixes the release you submit and nothing after it,'
+          $md += '> so this is a complement to signing, not a substitute.'
+          $out = "$env:RUNNER_TEMP\ms-submission-packet.md"
+          $md -join "`n" | Out-File $out -Encoding utf8
+          $md -join "`n" | Out-File $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          Write-Host ($md -join "`n")
+
       - name: Stage release assets
         shell: bash
         env:

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -818,12 +818,10 @@ jobs:
           args: -v ${{ matrix.args }}
 
       # ── Windows: scan the signed bundles with Defender before publishing ──
-      # 0.1.512-beta shipped and users hit "Trojan:Win32/Wacatac.B!ml" on first
-      # download. That build was clean, but nothing here looked, so it took two
-      # days to say so. Three things this has to get right: the runner image
-      # disables Defender and excludes both drive roots, so restore it and check
-      # the restore took; "!ml" is a cloud verdict, so MAPS must be on; and
-      # MpCmdRun exit codes are ambiguous, so read the output text.
+      # 0.1.512-beta shipped a "Trojan:Win32/Wacatac.B!ml" false positive nothing
+      # here caught. The runner disables Defender and excludes both drive roots,
+      # so restore it and verify the restore took; "!ml" is a cloud verdict, so
+      # MAPS must be on; MpCmdRun exit codes are ambiguous, so read the output.
       - name: Scan Windows bundles with Defender
         if: matrix.platform == 'windows-latest'
         # A custom MpCmdRun scan defaults to a one-day timeout.
@@ -868,11 +866,10 @@ jobs:
           if ([int]$pref.CloudBlockLevel -eq 0)       { $degraded += "CloudBlockLevel=$($pref.CloudBlockLevel), expected High" }
           if ($pref.ExclusionPath)                    { $degraded += "exclusions remain: $($pref.ExclusionPath -join ',')" }
 
-          # Positive control, or "clean" and "scanner broken" look identical.
-          # Assembled from fragments so this file is not itself a sample.
+          # Positive control: clean and broken-scanner look identical. Split into
+          # fragments so this file is not itself a sample.
           $eicarPath = Join-Path $env:RUNNER_TEMP 'defender-selftest.com'
-          # Real-time protection may block the write or quarantine the file before
-          # the scan runs. That is the control passing, so treat it as a pass.
+          # Real-time protection may block the write; that is the control passing.
           $controlPassed = $false
           try {
             [System.IO.File]::WriteAllText(
@@ -893,8 +890,7 @@ jobs:
             Write-Host "::warning::Defender is degraded on this runner ($($degraded -join '; ')). Scanning anyway, but a clean result below is not authoritative."
           }
 
-          # Fatal, not a warning: an earlier draft exited 0 here and a self-test
-          # caught it passing a release it had never scanned.
+          # Fatal, not a warning: exiting 0 here would pass an unscanned release.
           if ([string]::IsNullOrWhiteSpace($env:ARTIFACT_PATHS)) {
             Write-Host '::error::tauri-action produced no artifactPaths output; refusing to publish unscanned bundles'
             exit 1
@@ -917,10 +913,9 @@ jobs:
           }
           Write-Host "scanning $($paths.Count) Windows bundle(s)"
 
-          # Scan copies. Real-time protection is live now, so a detection would
-          # otherwise delete the release artifact itself. The copies double as the
-          # false-positive submission material: signing is timestamped, so a
-          # rebuild has a different hash and clearance is per hash.
+          # Scan copies: real-time protection is live, so a detection would delete
+          # the release artifact itself. Copies double as submission material,
+          # since clearance is per hash and a rebuild hashes differently.
           $work = Join-Path $env:RUNNER_TEMP 'defender-scan'
           Remove-Item $work -Recurse -Force -ErrorAction SilentlyContinue
           New-Item -ItemType Directory -Force -Path $work | Out-Null
@@ -932,8 +927,8 @@ jobs:
             $copy = Join-Path $work $leaf
             Copy-Item $f $copy -Force
 
-            # Block-at-first-sight only consults the cloud for internet-zone
-            # files, so stamp mark-of-the-web or this is not the user path.
+            # Block-at-first-sight only consults the cloud for internet-zone files,
+            # so stamp mark-of-the-web or this is not the user path.
             "[ZoneTransfer]`nZoneId=3" | Set-Content -Path $copy -Stream Zone.Identifier -Encoding Ascii -ErrorAction SilentlyContinue
 
             $out = & $mp -Scan -ScanType 3 -File $copy -DisableRemediation 2>&1
@@ -941,8 +936,8 @@ jobs:
             $text = ($out | Out-String)
             $out | ForEach-Object { Write-Host "  $_" }
 
-            # 2 means a detection or a scan error, so read the output text too.
-            # 0 is the only documented clean code; nothing else counts as clean.
+            # Exit 2 is a detection or a scan error, and 0 is the only documented
+            # clean code, so read the output text too.
             if ($text -match 'found\s+\d+\s+threat') {
               $names = @([regex]::Matches($text, '((?:Trojan|Virus|Worm|Backdoor|Ransom|HackTool|PUA|Behavior|Program|Misleading)[:\w\./!\-]+)') |
                          ForEach-Object { $_.Groups[1].Value } | Sort-Object -Unique)
@@ -968,8 +963,8 @@ jobs:
           Remove-Item $work -Recurse -Force -ErrorAction SilentlyContinue
           Write-Host "All $($paths.Count) Windows bundle(s) scanned clean."
 
-      # The scan step exits nonzero on a detection, and every later step carries
-      # an implicit success(), so the flagged file would leave with the runner.
+      # Later steps carry an implicit success(), so on a detection the flagged
+      # bundle would be discarded with the runner.
       - name: Preserve flagged Windows bundles
         if: failure() && matrix.platform == 'windows-latest'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -981,9 +976,8 @@ jobs:
           retention-days: 7
 
       # ── Windows: assemble a Microsoft false-positive submission packet ──
-      # There is no submission API; the WDSI portal is a web form. This cannot be
-      # automated, but it can remove the lookup work so pre-submitting a build
-      # before announcing it takes seconds.
+      # The WDSI portal is a web form with no API, so this cannot be automated,
+      # but pre-filling the lookups makes submitting a build take seconds.
       - name: Prepare Microsoft submission packet
         if: (success() || failure()) && matrix.platform == 'windows-latest' && steps.build_windows.outcome == 'success'
         shell: pwsh

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -826,6 +826,8 @@ jobs:
       # MpCmdRun exit codes are ambiguous, so read the output text.
       - name: Scan Windows bundles with Defender
         if: matrix.platform == 'windows-latest'
+        # A custom MpCmdRun scan defaults to a one-day timeout.
+        timeout-minutes: 20
         shell: pwsh
         env:
           ARTIFACT_PATHS: ${{ steps.build_windows.outputs.artifactPaths }}
@@ -861,19 +863,29 @@ jobs:
           $degraded = @()
           if (-not $status.RealTimeProtectionEnabled) { $degraded += "RealTimeProtectionEnabled=false (AMRunningMode=$($status.AMRunningMode))" }
           if ([int]$pref.MAPSReporting -ne 2)         { $degraded += "MAPSReporting=$($pref.MAPSReporting), expected 2 (Advanced)" }
+          if ([int]$pref.SubmitSamplesConsent -ne 3)  { $degraded += "SubmitSamplesConsent=$($pref.SubmitSamplesConsent), expected 3 (SendAllSamples)" }
+          if ($pref.DisableBlockAtFirstSeen)          { $degraded += 'DisableBlockAtFirstSeen=true' }
+          if ([int]$pref.CloudBlockLevel -eq 0)       { $degraded += "CloudBlockLevel=$($pref.CloudBlockLevel), expected High" }
           if ($pref.ExclusionPath)                    { $degraded += "exclusions remain: $($pref.ExclusionPath -join ',')" }
 
           # Positive control, or "clean" and "scanner broken" look identical.
           # Assembled from fragments so this file is not itself a sample.
           $eicarPath = Join-Path $env:RUNNER_TEMP 'defender-selftest.com'
-          [System.IO.File]::WriteAllText(
-            $eicarPath,
-            'X5O!P%@AP[4\PZX54(P^)7CC)7}' + '$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!' + '$H+H*')
-          $controlPassed = $true
+          # Real-time protection may block the write or quarantine the file before
+          # the scan runs. That is the control passing, so treat it as a pass.
+          $controlPassed = $false
+          try {
+            [System.IO.File]::WriteAllText(
+              $eicarPath,
+              'X5O!P%@AP[4\PZX54(P^)7CC)7}' + '$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!' + '$H+H*')
+          } catch { }
           if (Test-Path $eicarPath) {
             $controlOut = (& $mp -Scan -ScanType 3 -File $eicarPath -DisableRemediation 2>&1 | Out-String)
             $controlPassed = [bool](($controlOut -match 'found\s+\d+\s+threat') -or ($controlOut -match 'EICAR'))
             Remove-Item $eicarPath -Force -ErrorAction SilentlyContinue
+          } else {
+            Write-Host 'EICAR positive control blocked on write; real-time protection is live.'
+            $controlPassed = $true
           }
           if (-not $controlPassed) { $degraded += 'EICAR positive control did not fire' }
 
@@ -905,40 +917,75 @@ jobs:
           }
           Write-Host "scanning $($paths.Count) Windows bundle(s)"
 
+          # Scan copies. Real-time protection is live now, so a detection would
+          # otherwise delete the release artifact itself. The copies double as the
+          # false-positive submission material: signing is timestamped, so a
+          # rebuild has a different hash and clearance is per hash.
+          $work = Join-Path $env:RUNNER_TEMP 'defender-scan'
+          Remove-Item $work -Recurse -Force -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Force -Path $work | Out-Null
+
           $detected = @()
+          $unscanned = @()
           foreach ($f in $paths) {
+            $leaf = Split-Path $f -Leaf
+            $copy = Join-Path $work $leaf
+            Copy-Item $f $copy -Force
+
             # Block-at-first-sight only consults the cloud for internet-zone
             # files, so stamp mark-of-the-web or this is not the user path.
-            "[ZoneTransfer]`nZoneId=3" | Set-Content -Path $f -Stream Zone.Identifier -Encoding Ascii -ErrorAction SilentlyContinue
+            "[ZoneTransfer]`nZoneId=3" | Set-Content -Path $copy -Stream Zone.Identifier -Encoding Ascii -ErrorAction SilentlyContinue
 
-            $out = & $mp -Scan -ScanType 3 -File $f -DisableRemediation 2>&1
+            $out = & $mp -Scan -ScanType 3 -File $copy -DisableRemediation 2>&1
+            $code = $LASTEXITCODE
             $text = ($out | Out-String)
             $out | ForEach-Object { Write-Host "  $_" }
 
-            # Exit codes are ambiguous; read the output text.
+            # 2 means a detection or a scan error, so read the output text too.
+            # 0 is the only documented clean code; nothing else counts as clean.
             if ($text -match 'found\s+\d+\s+threat') {
-              $names = [regex]::Matches($text, '((?:Trojan|Virus|Worm|Backdoor|Ransom|HackTool|PUA|Behavior|Program|Misleading)[:\w\./!\-]+)') |
-                       ForEach-Object { $_.Groups[1].Value } | Sort-Object -Unique
-              Write-Host "::error::Defender flagged $(Split-Path $f -Leaf): $($names -join ', ')"
-              $detected += "$(Split-Path $f -Leaf) [$($names -join ', ')]"
+              $names = @([regex]::Matches($text, '((?:Trojan|Virus|Worm|Backdoor|Ransom|HackTool|PUA|Behavior|Program|Misleading)[:\w\./!\-]+)') |
+                         ForEach-Object { $_.Groups[1].Value } | Sort-Object -Unique)
+              if (-not $names) { $names = @('unnamed detection') }
+              Write-Host "::error::Defender flagged ${leaf}: $($names -join ', ')"
+              $detected += "$leaf [$($names -join ', ')]"
+            } elseif ($code -ne 0) {
+              Write-Host "::error::Defender did not complete a scan of $leaf (MpCmdRun exit $code)"
+              $unscanned += "$leaf [exit $code]"
             } else {
-              Write-Host "clean: $(Split-Path $f -Leaf)"
+              Write-Host "clean: $leaf"
             }
           }
 
+          if ($unscanned) {
+            Write-Host "::error::Refusing to publish bundles Defender could not scan: $($unscanned -join '; ')"
+          }
           if ($detected) {
             Write-Host "::error::Refusing to publish a Windows bundle Defender flags: $($detected -join '; ')"
             Write-Host 'If this is a false positive, submit it at https://www.microsoft.com/en-us/wdsi/filesubmission (Software developer -> incorrectly detected) and re-run once cleared.'
-            exit 1
           }
+          if ($detected -or $unscanned) { exit 1 }
+          Remove-Item $work -Recurse -Force -ErrorAction SilentlyContinue
           Write-Host "All $($paths.Count) Windows bundle(s) scanned clean."
+
+      # The scan step exits nonzero on a detection, and every later step carries
+      # an implicit success(), so the flagged file would leave with the runner.
+      - name: Preserve flagged Windows bundles
+        if: failure() && matrix.platform == 'windows-latest'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: flagged-windows-bundles-${{ matrix.artifact }}
+          path: ${{ runner.temp }}/defender-scan/*
+          if-no-files-found: ignore
+          compression-level: 0
+          retention-days: 7
 
       # ── Windows: assemble a Microsoft false-positive submission packet ──
       # There is no submission API; the WDSI portal is a web form. This cannot be
       # automated, but it can remove the lookup work so pre-submitting a build
       # before announcing it takes seconds.
       - name: Prepare Microsoft submission packet
-        if: matrix.platform == 'windows-latest'
+        if: (success() || failure()) && matrix.platform == 'windows-latest' && steps.build_windows.outcome == 'success'
         shell: pwsh
         env:
           ARTIFACT_PATHS: ${{ steps.build_windows.outputs.artifactPaths }}
@@ -950,7 +997,9 @@ jobs:
             '',
             'Submit at <https://www.microsoft.com/en-us/wdsi/filesubmission> before announcing this release.',
             'Choose **Software developer** -> **Incorrectly detected as malware/malicious**.',
-            'The 50 MB upload cap applies; if a bundle exceeds it, submit the extracted main binary instead.',
+            'The portal caps uploads at 50 MB. Clearance is per hash, so never substitute a',
+            'different file: for a larger bundle use <https://security.microsoft.com/reportsubmission>,',
+            'which takes 500 MB.',
             ''
           )
           foreach ($f in $paths) {


### PR DESCRIPTION
## Why

`0.1.512-beta` shipped and users hit `Trojan:Win32/Wacatac.B!ml`, alert level Severe, on first download. It took two days of forensics to establish that the build was fine. Nothing in the release process had looked at the bundles it was publishing, so there was no evidence either way at the moment it mattered.

That investigation is worth summarising, because it is also the argument for this change:

- Both `0.1.51-beta` and `0.1.512-beta` are validly Authenticode-signed by the same Azure Trusted Signing identity. Signature status is identical per inner PE.
- The NSIS payload inventory is identical file-for-file; four files differ in size.
- On a `windows-latest` runner with Defender fully restored (real-time protection, behaviour monitoring, IOAV, cloud/MAPS on, fresh signatures, mark-of-the-web stamped) and an EICAR positive control passing: both installers, all 22 unpacked components, and all seven historical `install.ps1` versions across the window scan **clean**. The flagged installer silent-installs and launches with zero Defender events.

So the detection was a cloud machine-learning false positive on a brand-new, zero-prevalence file hash, not a code change. No commit needs reverting.

What is worth fixing is that we could not answer the question from the release itself.

## What this does

Adds one step to the Windows leg of `release-desktop.yml`, after the signed build and before staging: scan every produced bundle with Defender and refuse to publish if it flags one.

Three details it would be easy to get wrong, and which the step handles explicitly:

- **The runner image disables Defender.** `actions/runner-images` sets `DisableRealtimeMonitoring`, `MAPSReporting = 0`, and `ExclusionPath = @("D:\", "C:\")` at image build time. A scan that does not undo this reports clean unconditionally.
- **Cloud protection is not optional.** The `!ml` suffix means the verdict comes from a cloud classifier. With MAPS off, the exact class of detection this step exists to catch cannot fire.
- **Exit codes are ambiguous.** Per the `MpCmdRun` reference, `0` covers both "clean" and "found and remediated", and `2` covers "found", "needs user action" and "scan failed". The step reads the output text instead.

It also stamps mark-of-the-web on each bundle before scanning, because block-at-first-sight only consults the cloud for internet-zone files, and runs an EICAR positive control so that "clean" and "the scanner is not working" are distinguishable. If the environment comes back degraded it warns rather than failing the release on a fiction.

## Verified

The step's `run:` block was copied verbatim into a staging repo and driven both ways on `windows-latest`:

- the two real installers, including the one flagged in the wild: **passes**
- a known-bad file: **fails the gate**

Both assertions green. A gate that cannot fail is not a gate, and the blanket exclusions above make that a live risk rather than a theoretical one.

## Not included

No revert of any commit in the window. `#7692`, `#7744`, `#7705` and `#7608` were each measured directly and are all exonerated.

One piece of optional hardening I deliberately left out: `bundle.windows.webviewInstallMode.type` is Tauri's default `downloadBootstrapper`, which makes the installer download an EXE and `ExecWait` it. That is the strongest dropper-shaped feature in the NSIS template, but it is present in both builds and no measurement here shows it changes a verdict, so it would be a speculative change and is better argued separately.

## The self-test found a bug in this PR

Worth recording, since it is the reason the test exists. The first run passed the clean-bundle case **having scanned nothing**: `artifactPaths` failed to parse, the step warned, and exited 0. A release would have gone out unscanned with a green check next to it.

Fixed in the second commit: an empty, unparseable, or non-existent bundle list is now fatal. The self-test grew two cases to cover it, and all four now assert correctly:

```
negative (real bundles)  got=success  want=success  OK
positive (known-bad)     got=failure  want=failure  OK
unparseable paths        got=failure  want=failure  OK
empty paths              got=failure  want=failure  OK
```

with the clean case demonstrably scanning for real:

```
scanning 2 Windows bundle(s)
clean: old_0.1.51.exe
clean: new_0.1.512.exe
All 2 Windows bundle(s) scanned clean.
```
