### PR TITLE
studio: pair slim whisper bundles on the ggml tree id, not the -mix- tag suffix

### DIFF
--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -535,16 +535,6 @@ _LLAMA_PHASE_WEIGHT = 0.7
 _WHISPER_PHASE_WEIGHT = 0.3
 
 
-def _marker_needs_ggml_tree(marker: dict | None) -> bool:
-    """True when the install predates ggml_tree and must be refreshed to record it.
-
-    install_whisper_prebuilt refuses a slim bundle whose required tree cannot be
-    checked, so reporting "up to date" here would strand that install: the llama
-    installer, which backfills the marker on its reuse path, would never run.
-    """
-    return isinstance(marker, dict) and not marker.get("ggml_tree")
-
-
 def _plan_llama_phase() -> dict:
     """Decide how the llama phase of a combined update runs. Returns {"spec"}
     when llama should install, else {"skip_reason", "refusal"}: skip_reason
@@ -583,7 +573,7 @@ def _plan_llama_phase() -> dict:
         # start an install when the latest is not actually newer (force a fresh
         # check so a stale 24h cache can't wrongly block a real update either).
         status = _llama_only_status(force_refresh = True)
-        if not status.get("update_available") and not _marker_needs_ggml_tree(marker):
+        if not status.get("update_available"):
             return {
                 "skip_reason": "up_to_date",
                 "refusal": {
@@ -624,7 +614,7 @@ def _plan_llama_phase() -> dict:
                     ),
                 },
             }
-        if not src.get("update_available") and not _marker_needs_ggml_tree(marker):
+        if not src.get("update_available"):
             return {
                 "skip_reason": "up_to_date",
                 "refusal": {

--- a/studio/backend/utils/llama_cpp_update.py
+++ b/studio/backend/utils/llama_cpp_update.py
@@ -535,6 +535,16 @@ _LLAMA_PHASE_WEIGHT = 0.7
 _WHISPER_PHASE_WEIGHT = 0.3
 
 
+def _marker_needs_ggml_tree(marker: dict | None) -> bool:
+    """True when the install predates ggml_tree and must be refreshed to record it.
+
+    install_whisper_prebuilt refuses a slim bundle whose required tree cannot be
+    checked, so reporting "up to date" here would strand that install: the llama
+    installer, which backfills the marker on its reuse path, would never run.
+    """
+    return isinstance(marker, dict) and not marker.get("ggml_tree")
+
+
 def _plan_llama_phase() -> dict:
     """Decide how the llama phase of a combined update runs. Returns {"spec"}
     when llama should install, else {"skip_reason", "refusal"}: skip_reason
@@ -573,7 +583,7 @@ def _plan_llama_phase() -> dict:
         # start an install when the latest is not actually newer (force a fresh
         # check so a stale 24h cache can't wrongly block a real update either).
         status = _llama_only_status(force_refresh = True)
-        if not status.get("update_available"):
+        if not status.get("update_available") and not _marker_needs_ggml_tree(marker):
             return {
                 "skip_reason": "up_to_date",
                 "refusal": {
@@ -614,7 +624,7 @@ def _plan_llama_phase() -> dict:
                     ),
                 },
             }
-        if not src.get("update_available"):
+        if not src.get("update_available") and not _marker_needs_ggml_tree(marker):
             return {
                 "skip_reason": "up_to_date",
                 "refusal": {

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -434,7 +434,7 @@ class ApprovedReleaseChecksums:
     source_commit: str | None = None
     source_commit_short: str | None = None
     # git tree id of ggml/ in the built source: changes exactly when ggml does,
-    # so it is the real ABI key for slim whisper bundles.
+    # so it is the ABI key for slim whisper bundles.
     ggml_tree: str | None = None
     artifacts: dict[str, ApprovedArtifactHash] = field(default_factory = dict)
 
@@ -5808,13 +5808,11 @@ def sync_marker_llama_backend(install_dir: Path, llama_backend: str | None) -> N
 def recorded_ggml_tree(
     approved_checksums: ApprovedReleaseChecksums, choice: AssetChoice
 ) -> str | None:
-    """The ggml tree to record for an install, or None when it does not describe it.
+    """The ggml tree to record, or None when it does not describe this install.
 
-    The tree comes from the fork release's own source checkout, so it only
-    describes binaries built from that release. A fork plan can install an
-    approved ggml-org archive instead (choice.repo differs), whose ggml is
-    upstream's; recording the fork tree there would let a slim whisper bundle
-    pair with a runtime a pinned PR may have changed under ggml/.
+    The tree comes from the fork release's own checkout. A fork plan can install
+    an approved ggml-org archive instead (choice.repo differs), built from
+    upstream ggml, so the fork tree must not be recorded for it.
     """
     tree = approved_checksums.ggml_tree
     if not isinstance(tree, str) or not tree:
@@ -5825,11 +5823,10 @@ def recorded_ggml_tree(
 def sync_marker_ggml_tree(install_dir: Path, ggml_tree: str | None) -> None:
     """Backfill the ggml tree id when the bundle is reused unchanged.
 
-    write_prebuilt_metadata only runs on a real install, and the fingerprint does
-    not hash ggml_tree, so an already-current install would keep a tree-less
-    marker forever and install_whisper_prebuilt would stay on the "-mix-" suffix
-    this key exists to replace. Unlike llama_backend, a None tree is "the release
-    did not declare one" (upstream ggml-org tags), not "clear it".
+    write_prebuilt_metadata only runs on a real install, so without this an
+    already-current install would keep a tree-less marker forever. Unlike
+    llama_backend, None means "the release declared none" (upstream ggml-org
+    tags), not "clear it".
     """
     if not isinstance(ggml_tree, str) or not ggml_tree:
         return
@@ -5948,7 +5945,7 @@ def installed_llama_runtime(install_dir: Path | None = None) -> tuple[Path, str,
 
 def installed_llama_ggml_tree(install_dir: Path | None = None) -> str | None:
     """ggml tree id of the managed llama.cpp install; None for installs predating
-    it. Separate from installed_llama_runtime() to keep that tuple's shape."""
+    it. Kept out of installed_llama_runtime() to keep that tuple's shape."""
     root = install_dir if install_dir is not None else default_managed_llama_dir()
     metadata = load_prebuilt_metadata(root)
     if metadata is None:
@@ -7000,8 +6997,8 @@ def install_prebuilt(
                             llama_backend = persist_llama_backend,
                         )
                     except ExistingInstallSatisfied as satisfied:
-                        # Third reuse path: validate_prebuilt_attempts skipped the
-                        # reinstall, so write_prebuilt_metadata never runs here either.
+                        # Third reuse path: the reinstall was skipped, so
+                        # write_prebuilt_metadata does not run here either.
                         sync_marker_ggml_tree(
                             install_dir,
                             recorded_ggml_tree(plan.approved_checksums, satisfied.choice),

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -433,8 +433,8 @@ class ApprovedReleaseChecksums:
     resolved_source_ref: str | None = None
     source_commit: str | None = None
     source_commit_short: str | None = None
-    # git tree id of ggml/ in the built source. Changes exactly when ggml
-    # changes, so it is the real ABI key for slim whisper bundles.
+    # git tree id of ggml/ in the built source: changes exactly when ggml does,
+    # so it is the real ABI key for slim whisper bundles.
     ggml_tree: str | None = None
     artifacts: dict[str, ApprovedArtifactHash] = field(default_factory = dict)
 
@@ -5902,9 +5902,8 @@ def installed_llama_runtime(install_dir: Path | None = None) -> tuple[Path, str,
 
 
 def installed_llama_ggml_tree(install_dir: Path | None = None) -> str | None:
-    """ggml tree id of the managed llama.cpp install, or None for installs made
-    before it was recorded. Kept separate from installed_llama_runtime() so that
-    tuple keeps its shape for existing callers."""
+    """ggml tree id of the managed llama.cpp install; None for installs predating
+    it. Separate from installed_llama_runtime() to keep that tuple's shape."""
     root = install_dir if install_dir is not None else default_managed_llama_dir()
     metadata = load_prebuilt_metadata(root)
     if metadata is None:

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5684,7 +5684,7 @@ def write_prebuilt_metadata(
         "requested_source_ref": approved_checksums.requested_source_ref,
         "resolved_source_ref": approved_checksums.resolved_source_ref,
         # Read back by install_whisper_prebuilt.py to pair slim bundles.
-        "ggml_tree": approved_checksums.ggml_tree,
+        "ggml_tree": recorded_ggml_tree(approved_checksums, choice),
         "bundle_profile": choice.bundle_profile,
         "runtime_line": choice.runtime_line,
         "coverage_class": choice.coverage_class,
@@ -5803,6 +5803,21 @@ def sync_marker_llama_backend(install_dir: Path, llama_backend: str | None) -> N
         )
         return
     log(f"existing install reused; recorded llama_backend={llama_backend!r} from this run")
+
+
+def recorded_ggml_tree(approved_checksums: ApprovedReleaseChecksums, choice: AssetChoice) -> str | None:
+    """The ggml tree to record for an install, or None when it does not describe it.
+
+    The tree comes from the fork release's own source checkout, so it only
+    describes binaries built from that release. A fork plan can install an
+    approved ggml-org archive instead (choice.repo differs), whose ggml is
+    upstream's; recording the fork tree there would let a slim whisper bundle
+    pair with a runtime a pinned PR may have changed under ggml/.
+    """
+    tree = approved_checksums.ggml_tree
+    if not isinstance(tree, str) or not tree:
+        return None
+    return tree if choice.repo == approved_checksums.repo else None
 
 
 def sync_marker_ggml_tree(install_dir: Path, ggml_tree: str | None) -> None:
@@ -6926,7 +6941,10 @@ def install_prebuilt(
                         install_dir,
                         persisted_llama_backend(persist_llama_backend, current.attempts[0]),
                     )
-                    sync_marker_ggml_tree(install_dir, current.approved_checksums.ggml_tree)
+                    sync_marker_ggml_tree(
+                        install_dir,
+                        recorded_ggml_tree(current.approved_checksums, current.attempts[0]),
+                    )
                     return
             with scratch_dir("unsloth-llama-prebuilt-") as work_dir:
                 probe_path = work_dir / "stories260K.gguf"
@@ -6951,7 +6969,10 @@ def install_prebuilt(
                                 install_dir,
                                 persisted_llama_backend(persist_llama_backend, choice),
                             )
-                            sync_marker_ggml_tree(install_dir, plan.approved_checksums.ggml_tree)
+                            sync_marker_ggml_tree(
+                                install_dir,
+                                recorded_ggml_tree(plan.approved_checksums, choice),
+                            )
                             return
                     log(
                         "selected "
@@ -6976,7 +6997,13 @@ def install_prebuilt(
                             force_cpu = persist_force_cpu,
                             llama_backend = persist_llama_backend,
                         )
-                    except ExistingInstallSatisfied:
+                    except ExistingInstallSatisfied as satisfied:
+                        # Third reuse path: validate_prebuilt_attempts skipped the
+                        # reinstall, so write_prebuilt_metadata never runs here either.
+                        sync_marker_ggml_tree(
+                            install_dir,
+                            recorded_ggml_tree(plan.approved_checksums, satisfied.choice),
+                        )
                         return
                     except PrebuiltFallback as exc:
                         if _environment_fatal_reason(exc):

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5805,7 +5805,9 @@ def sync_marker_llama_backend(install_dir: Path, llama_backend: str | None) -> N
     log(f"existing install reused; recorded llama_backend={llama_backend!r} from this run")
 
 
-def recorded_ggml_tree(approved_checksums: ApprovedReleaseChecksums, choice: AssetChoice) -> str | None:
+def recorded_ggml_tree(
+    approved_checksums: ApprovedReleaseChecksums, choice: AssetChoice
+) -> str | None:
     """The ggml tree to record for an install, or None when it does not describe it.
 
     The tree comes from the fork release's own source checkout, so it only

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -433,6 +433,9 @@ class ApprovedReleaseChecksums:
     resolved_source_ref: str | None = None
     source_commit: str | None = None
     source_commit_short: str | None = None
+    # git tree id of ggml/ in the built source. Changes exactly when ggml
+    # changes, so it is the real ABI key for slim whisper bundles.
+    ggml_tree: str | None = None
     artifacts: dict[str, ApprovedArtifactHash] = field(default_factory = dict)
 
 
@@ -1430,6 +1433,7 @@ def parse_approved_release_checksums(
 
     source_commit = normalize_source_commit(payload.get("source_commit"))
     source_commit_short = payload.get("source_commit_short")
+    ggml_tree = payload.get("ggml_tree")
     source_repo = payload.get("source_repo")
     source_repo_url = payload.get("source_repo_url")
     source_ref_kind = normalize_source_ref_kind(payload.get("source_ref_kind"))
@@ -1454,6 +1458,7 @@ def parse_approved_release_checksums(
         source_commit_short = source_commit_short
         if isinstance(source_commit_short, str) and source_commit_short
         else None,
+        ggml_tree = ggml_tree if isinstance(ggml_tree, str) and ggml_tree else None,
         artifacts = artifacts,
     )
 
@@ -5678,6 +5683,8 @@ def write_prebuilt_metadata(
         "source_ref_kind": approved_checksums.source_ref_kind,
         "requested_source_ref": approved_checksums.requested_source_ref,
         "resolved_source_ref": approved_checksums.resolved_source_ref,
+        # Read back by install_whisper_prebuilt.py to pair slim bundles.
+        "ggml_tree": approved_checksums.ggml_tree,
         "bundle_profile": choice.bundle_profile,
         "runtime_line": choice.runtime_line,
         "coverage_class": choice.coverage_class,
@@ -5892,6 +5899,18 @@ def installed_llama_runtime(install_dir: Path | None = None) -> tuple[Path, str,
         return None
     profile = metadata.get("bundle_profile")
     return bin_dir, release_tag, profile if isinstance(profile, str) else ""
+
+
+def installed_llama_ggml_tree(install_dir: Path | None = None) -> str | None:
+    """ggml tree id of the managed llama.cpp install, or None for installs made
+    before it was recorded. Kept separate from installed_llama_runtime() so that
+    tuple keeps its shape for existing callers."""
+    root = install_dir if install_dir is not None else default_managed_llama_dir()
+    metadata = load_prebuilt_metadata(root)
+    if metadata is None:
+        return None
+    tree = metadata.get("ggml_tree")
+    return tree if isinstance(tree, str) and tree else None
 
 
 def runtime_payload_health_groups(choice: AssetChoice) -> list[list[str]]:

--- a/studio/install_llama_prebuilt.py
+++ b/studio/install_llama_prebuilt.py
@@ -5805,6 +5805,34 @@ def sync_marker_llama_backend(install_dir: Path, llama_backend: str | None) -> N
     log(f"existing install reused; recorded llama_backend={llama_backend!r} from this run")
 
 
+def sync_marker_ggml_tree(install_dir: Path, ggml_tree: str | None) -> None:
+    """Backfill the ggml tree id when the bundle is reused unchanged.
+
+    write_prebuilt_metadata only runs on a real install, and the fingerprint does
+    not hash ggml_tree, so an already-current install would keep a tree-less
+    marker forever and install_whisper_prebuilt would stay on the "-mix-" suffix
+    this key exists to replace. Unlike llama_backend, a None tree is "the release
+    did not declare one" (upstream ggml-org tags), not "clear it".
+    """
+    if not isinstance(ggml_tree, str) or not ggml_tree:
+        return
+    marker_path = install_dir / "UNSLOTH_PREBUILT_INFO.json"
+    try:
+        marker = json.loads(marker_path.read_text(encoding = "utf-8"))
+    except (OSError, ValueError):
+        return
+    if not isinstance(marker, dict) or marker.get("ggml_tree") == ggml_tree:
+        return
+    marker["ggml_tree"] = ggml_tree
+    if not _write_marker(marker_path, marker):
+        log(
+            f"WARNING: could not record ggml_tree={ggml_tree!r} in {marker_path}; "
+            "slim whisper pairing will fall back to the tag suffix"
+        )
+        return
+    log(f"existing install reused; recorded ggml_tree={ggml_tree!r} from this run")
+
+
 def expected_install_fingerprint(
     *,
     llama_tag: str,
@@ -6898,6 +6926,7 @@ def install_prebuilt(
                         install_dir,
                         persisted_llama_backend(persist_llama_backend, current.attempts[0]),
                     )
+                    sync_marker_ggml_tree(install_dir, current.approved_checksums.ggml_tree)
                     return
             with scratch_dir("unsloth-llama-prebuilt-") as work_dir:
                 probe_path = work_dir / "stories260K.gguf"
@@ -6922,6 +6951,7 @@ def install_prebuilt(
                                 install_dir,
                                 persisted_llama_backend(persist_llama_backend, choice),
                             )
+                            sync_marker_ggml_tree(install_dir, plan.approved_checksums.ggml_tree)
                             return
                     log(
                         "selected "

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -366,8 +366,10 @@ def llama_runtime_pairs(
     if installed_tag == required_tag:
         return True
     if (
-        isinstance(installed_ggml_tree, str) and installed_ggml_tree
-        and isinstance(required_ggml_tree, str) and required_ggml_tree
+        isinstance(installed_ggml_tree, str)
+        and installed_ggml_tree
+        and isinstance(required_ggml_tree, str)
+        and required_ggml_tree
     ):
         return installed_ggml_tree == required_ggml_tree
     commit = _llama_ggml_commit(installed_tag)

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -339,10 +339,10 @@ def artifacts_for_host(
 def _llama_ggml_commit(tag: str) -> str | None:
     """The "-mix-" suffix of a fork tag "b<upstream_build>-mix-<suffix>".
 
-    Despite the name this is NOT a ggml commit: it hashes the pinned PR set, so
-    it stays constant while the base tag, and ggml with it, moves (one value
-    covered b9909..b10001, whose ggml trees differ). Fallback only, for releases
-    predating ggml_tree."""
+    Despite the name this is NOT a ggml commit: it hashes the pinned PR set and
+    stays constant while the base tag, and ggml with it, moves (one value covered
+    b9909..b10001, whose ggml trees differ). Fallback for releases predating
+    ggml_tree."""
     marker = "-mix-"
     idx = tag.rfind(marker)
     end = idx + len(marker)
@@ -357,17 +357,17 @@ def llama_runtime_pairs(
     required_ggml_tree: Any = None,
 ) -> bool:
     """Whether an installed llama tag can back a slim bundle needing required_tag.
-    An exact tag always pairs. Otherwise prefer the ggml tree ids, which change
-    exactly when ggml does; the "-mix-" suffix does not track ggml at all (see
-    _llama_ggml_commit), so it is only used when either tree is missing.
+    An exact tag always pairs; otherwise the ggml tree ids decide, since they
+    change exactly when ggml does. The "-mix-" suffix does not track ggml at all
+    (see _llama_ggml_commit) and is only used when either tree is missing.
     requires_ggml_sonames stays the per-file ABI gate."""
     if not isinstance(required_tag, str):
         return False
     if installed_tag == required_tag:
         return True
-    # Both trees present is the only case we can decide on the ABI key. Refusing
-    # when the install predates ggml_tree would strand it: nothing in the update
-    # path can backfill a marker without a llama release to install.
+    # Only decidable with both trees. Refusing when the install predates
+    # ggml_tree would strand it: nothing can backfill a tree-less marker
+    # without a llama release to install.
     if (
         isinstance(installed_ggml_tree, str)
         and installed_ggml_tree
@@ -511,8 +511,8 @@ def _slim_release_incompatibility(manifest: dict[str, Any], host: HostInfo) -> s
         return None
     installed_tag = runtime[1]
     installed_tree = installed_llama_ggml_tree()
-    # Normalise the tree here: llama_runtime_pairs treats a non-string as absent,
-    # and an unhashable one (list/dict) would blow up the set instead.
+    # Normalise the tree: llama_runtime_pairs treats a non-string as absent, but
+    # an unhashable one (list/dict) would blow up the set first.
     required_pairs = {
         (
             artifact.get("requires_llama_tag"),

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -508,8 +508,15 @@ def _slim_release_incompatibility(manifest: dict[str, Any], host: HostInfo) -> s
         return None
     installed_tag = runtime[1]
     installed_tree = installed_llama_ggml_tree()
+    # Normalise the tree here: llama_runtime_pairs treats a non-string as absent,
+    # and an unhashable one (list/dict) would blow up the set instead.
     required_pairs = {
-        (artifact.get("requires_llama_tag"), artifact.get("requires_ggml_tree"))
+        (
+            artifact.get("requires_llama_tag"),
+            artifact["requires_ggml_tree"]
+            if isinstance(artifact.get("requires_ggml_tree"), str)
+            else None,
+        )
         for artifact in os_compatible
         if isinstance(artifact.get("requires_llama_tag"), str)
     }

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -363,15 +363,18 @@ def llama_runtime_pairs(
     requires_ggml_sonames stays the per-file ABI gate."""
     if not isinstance(required_tag, str):
         return False
-    # An artifact that states its ABI key is only ever paired on that key. Falling
-    # back to the tag here would accept a runtime we cannot vouch for: matching
-    # tags do not imply matching ggml (a fork release can install an upstream
-    # archive), and the "-mix-" suffix does not track ggml at all. Refusing costs
-    # a Transformers fallback; guessing loads an incompatible libggml.
-    if isinstance(required_ggml_tree, str) and required_ggml_tree:
-        return required_ggml_tree == installed_ggml_tree
     if installed_tag == required_tag:
         return True
+    # Both trees present is the only case we can decide on the ABI key. Refusing
+    # when the install predates ggml_tree would strand it: nothing in the update
+    # path can backfill a marker without a llama release to install.
+    if (
+        isinstance(installed_ggml_tree, str)
+        and installed_ggml_tree
+        and isinstance(required_ggml_tree, str)
+        and required_ggml_tree
+    ):
+        return installed_ggml_tree == required_ggml_tree
     commit = _llama_ggml_commit(installed_tag)
     return commit is not None and commit == _llama_ggml_commit(required_tag)
 

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -363,15 +363,15 @@ def llama_runtime_pairs(
     requires_ggml_sonames stays the per-file ABI gate."""
     if not isinstance(required_tag, str):
         return False
+    # An artifact that states its ABI key is only ever paired on that key. Falling
+    # back to the tag here would accept a runtime we cannot vouch for: matching
+    # tags do not imply matching ggml (a fork release can install an upstream
+    # archive), and the "-mix-" suffix does not track ggml at all. Refusing costs
+    # a Transformers fallback; guessing loads an incompatible libggml.
+    if isinstance(required_ggml_tree, str) and required_ggml_tree:
+        return required_ggml_tree == installed_ggml_tree
     if installed_tag == required_tag:
         return True
-    if (
-        isinstance(installed_ggml_tree, str)
-        and installed_ggml_tree
-        and isinstance(required_ggml_tree, str)
-        and required_ggml_tree
-    ):
-        return installed_ggml_tree == required_ggml_tree
     commit = _llama_ggml_commit(installed_tag)
     return commit is not None and commit == _llama_ggml_commit(required_tag)
 

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -95,6 +95,7 @@ InstallSelection = core.InstallSelection
 ReleaseBundle = core.ReleaseBundle
 llama_detect_host = llama.detect_host
 installed_llama_runtime = llama.installed_llama_runtime
+installed_llama_ggml_tree = llama.installed_llama_ggml_tree
 
 # Late-binding seam for prebuilt_core: name lookups hit this module's globals
 # first (so monkeypatches apply), then the core defaults.
@@ -336,26 +337,39 @@ def artifacts_for_host(
 
 # ── Slim selection (paired with the installed llama.cpp ggml runtime) ──
 def _llama_ggml_commit(tag: str) -> str | None:
-    """The ggml commit a llama.cpp fork tag was built against. Fork tags are
-    "b<upstream_build>-mix-<ggml_commit>"; the ggml commit after "-mix-" fixes
-    the ggml ABI the slim whisper bundle links against, while the build number
-    only tracks upstream llama / fork PRs outside ggml. None when the tag has no
-    "-mix-" marker (then only an exact tag pairs)."""
+    """The "-mix-" suffix of a fork tag "b<upstream_build>-mix-<suffix>".
+
+    Despite the name this is NOT a ggml commit: it hashes the pinned PR set, so
+    it stays constant while the base tag, and ggml with it, moves. One value
+    covered eight releases spanning b9909..b10001, whose ggml trees differ.
+    Kept only as a fallback for releases predating ggml_tree; prefer that."""
     marker = "-mix-"
     idx = tag.rfind(marker)
     end = idx + len(marker)
     return tag[end:] if idx >= 0 and end < len(tag) else None
 
 
-def llama_runtime_pairs(installed_tag: str, required_tag: Any) -> bool:
+def llama_runtime_pairs(
+    installed_tag: str,
+    required_tag: Any,
+    *,
+    installed_ggml_tree: Any = None,
+    required_ggml_tree: Any = None,
+) -> bool:
     """Whether an installed llama tag can back a slim bundle needing required_tag.
-    An exact tag always pairs; so does a shared ggml commit, since a newer llama
-    build with the same ggml ships an ABI-identical runtime. requires_ggml_sonames
-    stays the real per-file ABI gate."""
+    An exact tag always pairs. Otherwise prefer the ggml tree ids, which change
+    exactly when ggml does; fall back to the "-mix-" suffix only when either
+    side omits one, since that suffix does not track ggml at all (see
+    _llama_ggml_commit). requires_ggml_sonames stays the per-file ABI gate."""
     if not isinstance(required_tag, str):
         return False
     if installed_tag == required_tag:
         return True
+    if (
+        isinstance(installed_ggml_tree, str) and installed_ggml_tree
+        and isinstance(required_ggml_tree, str) and required_ggml_tree
+    ):
+        return installed_ggml_tree == required_ggml_tree
     commit = _llama_ggml_commit(installed_tag)
     return commit is not None and commit == _llama_ggml_commit(required_tag)
 
@@ -373,7 +387,12 @@ def slim_pairing_for_artifact(
         return None
     llama_bin_dir, llama_tag, _profile = runtime
     requires_tag = artifact.get("requires_llama_tag")
-    if not llama_runtime_pairs(llama_tag, requires_tag):
+    if not llama_runtime_pairs(
+        llama_tag,
+        requires_tag,
+        installed_ggml_tree = installed_llama_ggml_tree(),
+        required_ggml_tree = artifact.get("requires_ggml_tree"),
+    ):
         log(
             f"slim_selection: {asset} skipped: installed llama tag {llama_tag!r} "
             f"does not pair with required {requires_tag!r}"
@@ -486,12 +505,19 @@ def _slim_release_incompatibility(manifest: dict[str, Any], host: HostInfo) -> s
     if runtime is None:
         return None
     installed_tag = runtime[1]
-    required_tags = {
-        artifact.get("requires_llama_tag")
+    installed_tree = installed_llama_ggml_tree()
+    required_pairs = {
+        (artifact.get("requires_llama_tag"), artifact.get("requires_ggml_tree"))
         for artifact in os_compatible
         if isinstance(artifact.get("requires_llama_tag"), str)
     }
-    if required_tags and not any(llama_runtime_pairs(installed_tag, tag) for tag in required_tags):
+    required_tags = {tag for tag, _tree in required_pairs}
+    if required_tags and not any(
+        llama_runtime_pairs(
+            installed_tag, tag, installed_ggml_tree = installed_tree, required_ggml_tree = tree
+        )
+        for tag, tree in required_pairs
+    ):
         required_tag = sorted(required_tags)[0]
         return (
             f"slim bundle requires llama.cpp {required_tag}; installed llama.cpp is {installed_tag}"
@@ -844,7 +870,12 @@ def selection_from_artifact(
     # A slim selection carries its pairing so the install wiring and marker know
     # which llama runtime provides the ggml libraries.
     runtime = installed_llama_runtime()
-    if runtime is None or not llama_runtime_pairs(runtime[1], artifact.get("requires_llama_tag")):
+    if runtime is None or not llama_runtime_pairs(
+        runtime[1],
+        artifact.get("requires_llama_tag"),
+        installed_ggml_tree = installed_llama_ggml_tree(),
+        required_ggml_tree = artifact.get("requires_ggml_tree"),
+    ):
         raise PrebuiltFallback(
             "the paired llama.cpp runtime changed underneath the slim whisper selection"
         )

--- a/studio/install_whisper_prebuilt.py
+++ b/studio/install_whisper_prebuilt.py
@@ -340,9 +340,9 @@ def _llama_ggml_commit(tag: str) -> str | None:
     """The "-mix-" suffix of a fork tag "b<upstream_build>-mix-<suffix>".
 
     Despite the name this is NOT a ggml commit: it hashes the pinned PR set, so
-    it stays constant while the base tag, and ggml with it, moves. One value
-    covered eight releases spanning b9909..b10001, whose ggml trees differ.
-    Kept only as a fallback for releases predating ggml_tree; prefer that."""
+    it stays constant while the base tag, and ggml with it, moves (one value
+    covered b9909..b10001, whose ggml trees differ). Fallback only, for releases
+    predating ggml_tree."""
     marker = "-mix-"
     idx = tag.rfind(marker)
     end = idx + len(marker)
@@ -358,9 +358,9 @@ def llama_runtime_pairs(
 ) -> bool:
     """Whether an installed llama tag can back a slim bundle needing required_tag.
     An exact tag always pairs. Otherwise prefer the ggml tree ids, which change
-    exactly when ggml does; fall back to the "-mix-" suffix only when either
-    side omits one, since that suffix does not track ggml at all (see
-    _llama_ggml_commit). requires_ggml_sonames stays the per-file ABI gate."""
+    exactly when ggml does; the "-mix-" suffix does not track ggml at all (see
+    _llama_ggml_commit), so it is only used when either tree is missing.
+    requires_ggml_sonames stays the per-file ABI gate."""
     if not isinstance(required_tag, str):
         return False
     if installed_tag == required_tag:

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3922,8 +3922,7 @@ def test_recorded_ggml_tree_only_for_binaries_from_that_release():
     """The fork's tree describes the fork's own bundles, not a ggml-org archive.
 
     A fork plan can install an approved upstream archive instead; recording the
-    fork tree there would pair a slim whisper bundle against upstream ggml even
-    when a pinned PR changed ggml/.
+    fork tree there would pair a slim whisper bundle against upstream ggml.
     """
 
     def choice(repo):
@@ -3950,9 +3949,9 @@ def test_recorded_ggml_tree_only_for_binaries_from_that_release():
 def test_reused_install_backfills_the_ggml_tree(tmp_path):
     """An install made before ggml_tree existed must gain it on reuse.
 
-    write_prebuilt_metadata only runs on a real install and the fingerprint does
-    not hash ggml_tree, so without this the marker stays tree-less forever and
-    slim whisper pairing silently falls back to the "-mix-" suffix.
+    write_prebuilt_metadata only runs on a real install, so without this the
+    marker stays tree-less forever and slim whisper pairing silently falls back
+    to the "-mix-" suffix.
     """
     install_dir = tmp_path / "llama.cpp"
     (install_dir / "build" / "bin").mkdir(parents = True)

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3911,7 +3911,9 @@ TREE_A = "8f3c6e197debb027f500df9f76e710e137f9fe68"
 
 def _checksums(tree, repo = "unslothai/llama.cpp"):
     return INSTALL_LLAMA_PREBUILT.ApprovedReleaseChecksums(
-        repo = repo, release_tag = "b10173-mix-2c8b9c1", upstream_tag = "b10173",
+        repo = repo,
+        release_tag = "b10173-mix-2c8b9c1",
+        upstream_tag = "b10173",
         ggml_tree = tree,
     )
 
@@ -3923,12 +3925,19 @@ def test_recorded_ggml_tree_only_for_binaries_from_that_release():
     fork tree there would pair a slim whisper bundle against upstream ggml even
     when a pinned PR changed ggml/.
     """
+
     def choice(repo):
         return AssetChoice(
-            repo = repo, tag = "b10173", name = "bundle.tar.gz", url = "https://x/bundle",
+            repo = repo,
+            tag = "b10173",
+            name = "bundle.tar.gz",
+            url = "https://x/bundle",
             source_label = "fork" if repo == "unslothai/llama.cpp" else "upstream",
-            is_ready_bundle = True, install_kind = "linux-cpu",
-            bundle_profile = "cpu", runtime_line = "cpu", expected_sha256 = "0" * 64,
+            is_ready_bundle = True,
+            install_kind = "linux-cpu",
+            bundle_profile = "cpu",
+            runtime_line = "cpu",
+            expected_sha256 = "0" * 64,
         )
 
     fork = choice("unslothai/llama.cpp")
@@ -3936,7 +3945,6 @@ def test_recorded_ggml_tree_only_for_binaries_from_that_release():
     assert INSTALL_LLAMA_PREBUILT.recorded_ggml_tree(_checksums(TREE_A), fork) == TREE_A
     assert INSTALL_LLAMA_PREBUILT.recorded_ggml_tree(_checksums(TREE_A), upstream) is None
     assert INSTALL_LLAMA_PREBUILT.recorded_ggml_tree(_checksums(None), fork) is None
-
 
 
 def test_reused_install_backfills_the_ggml_tree(tmp_path):

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3925,7 +3925,7 @@ def test_reused_install_backfills_the_ggml_tree(tmp_path):
 
     payload = json.loads(marker.read_text(encoding = "utf-8"))
     assert payload["ggml_tree"] == TREE_A
-    assert payload["release_tag"] == "b10173-mix-2c8b9c1"   # nothing else lost
+    assert payload["release_tag"] == "b10173-mix-2c8b9c1"  # nothing else lost
     assert INSTALL_LLAMA_PREBUILT.installed_llama_ggml_tree(install_dir) == TREE_A
 
 

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3909,6 +3909,36 @@ def test_marker_sync_strands_no_temp_file_when_the_first_write_fails(tmp_path, m
 TREE_A = "8f3c6e197debb027f500df9f76e710e137f9fe68"
 
 
+def _checksums(tree, repo = "unslothai/llama.cpp"):
+    return INSTALL_LLAMA_PREBUILT.ApprovedReleaseChecksums(
+        repo = repo, release_tag = "b10173-mix-2c8b9c1", upstream_tag = "b10173",
+        ggml_tree = tree,
+    )
+
+
+def test_recorded_ggml_tree_only_for_binaries_from_that_release():
+    """The fork's tree describes the fork's own bundles, not a ggml-org archive.
+
+    A fork plan can install an approved upstream archive instead; recording the
+    fork tree there would pair a slim whisper bundle against upstream ggml even
+    when a pinned PR changed ggml/.
+    """
+    def choice(repo):
+        return AssetChoice(
+            repo = repo, tag = "b10173", name = "bundle.tar.gz", url = "https://x/bundle",
+            source_label = "fork" if repo == "unslothai/llama.cpp" else "upstream",
+            is_ready_bundle = True, install_kind = "linux-cpu",
+            bundle_profile = "cpu", runtime_line = "cpu", expected_sha256 = "0" * 64,
+        )
+
+    fork = choice("unslothai/llama.cpp")
+    upstream = choice("ggml-org/llama.cpp")
+    assert INSTALL_LLAMA_PREBUILT.recorded_ggml_tree(_checksums(TREE_A), fork) == TREE_A
+    assert INSTALL_LLAMA_PREBUILT.recorded_ggml_tree(_checksums(TREE_A), upstream) is None
+    assert INSTALL_LLAMA_PREBUILT.recorded_ggml_tree(_checksums(None), fork) is None
+
+
+
 def test_reused_install_backfills_the_ggml_tree(tmp_path):
     """An install made before ggml_tree existed must gain it on reuse.
 

--- a/tests/studio/install/test_install_llama_prebuilt_logic.py
+++ b/tests/studio/install/test_install_llama_prebuilt_logic.py
@@ -3906,6 +3906,45 @@ def test_marker_sync_strands_no_temp_file_when_the_first_write_fails(tmp_path, m
     assert [q.name for q in install_dir.iterdir() if ".tmp-" in q.name] == []
 
 
+TREE_A = "8f3c6e197debb027f500df9f76e710e137f9fe68"
+
+
+def test_reused_install_backfills_the_ggml_tree(tmp_path):
+    """An install made before ggml_tree existed must gain it on reuse.
+
+    write_prebuilt_metadata only runs on a real install and the fingerprint does
+    not hash ggml_tree, so without this the marker stays tree-less forever and
+    slim whisper pairing silently falls back to the "-mix-" suffix.
+    """
+    install_dir = tmp_path / "llama.cpp"
+    (install_dir / "build" / "bin").mkdir(parents = True)
+    marker = install_dir / "UNSLOTH_PREBUILT_INFO.json"
+    marker.write_text(json.dumps({"release_tag": "b10173-mix-2c8b9c1"}) + "\n", encoding = "utf-8")
+
+    INSTALL_LLAMA_PREBUILT.sync_marker_ggml_tree(install_dir, TREE_A)
+
+    payload = json.loads(marker.read_text(encoding = "utf-8"))
+    assert payload["ggml_tree"] == TREE_A
+    assert payload["release_tag"] == "b10173-mix-2c8b9c1"   # nothing else lost
+    assert INSTALL_LLAMA_PREBUILT.installed_llama_ggml_tree(install_dir) == TREE_A
+
+
+@pytest.mark.parametrize("declared", [None, ""])
+def test_reused_install_keeps_the_ggml_tree_when_the_release_declares_none(tmp_path, declared):
+    """A release with no ggml_tree (upstream ggml-org tags) must not erase one."""
+    install_dir = tmp_path / "llama.cpp"
+    install_dir.mkdir()
+    marker = install_dir / "UNSLOTH_PREBUILT_INFO.json"
+    marker.write_text(
+        json.dumps({"release_tag": "b10173-mix-2c8b9c1", "ggml_tree": TREE_A}) + "\n",
+        encoding = "utf-8",
+    )
+
+    INSTALL_LLAMA_PREBUILT.sync_marker_ggml_tree(install_dir, declared)
+
+    assert json.loads(marker.read_text(encoding = "utf-8"))["ggml_tree"] == TREE_A
+
+
 @pytest.mark.skipif(os.name == "nt", reason = "Windows st_mode carries no POSIX mode bits")
 @pytest.mark.parametrize("mode", [0o444, 0o644, 0o664])
 def test_marker_sync_preserves_the_marker_mode(tmp_path, mode):

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -828,7 +828,7 @@ def test_llama_runtime_pairs_falls_back_to_mix_suffix(installed, required, pairs
     assert M.llama_runtime_pairs(installed, required) is pairs
 
 
-# Real releases: both carry -mix-2c8b9c1, but their ggml trees genuinely differ.
+# Real releases: same -mix-2c8b9c1 suffix, but genuinely different ggml trees.
 SUFFIX_SHARED_A = "b10173-mix-2c8b9c1"
 SUFFIX_SHARED_B = "b10181-mix-2c8b9c1"
 TREE_A = "8f3c6e197debb027f500df9f76e710e137f9fe68"
@@ -838,11 +838,11 @@ TREE_B = "e96ffb0e063f66952b0c54796a74755b6041c867"
 @pytest.mark.parametrize(
     "installed,required,installed_tree,required_tree,pairs",
     [
-        # The bug this replaces: a shared suffix is not a shared ggml.
+        # The bug this fixes: a shared suffix is not a shared ggml.
         (SUFFIX_SHARED_A, SUFFIX_SHARED_B, TREE_A, TREE_B, False),
         # Different suffixes, same ggml: ABI-identical, so it pairs.
         ("b10241-mix-89aa77b", "b10225-mix-345e1e3", TREE_A, TREE_A, True),
-        # Either side missing a tree falls back to the suffix.
+        # A missing tree on either side falls back to the suffix.
         (SUFFIX_SHARED_A, SUFFIX_SHARED_B, None, TREE_B, True),
         (SUFFIX_SHARED_A, SUFFIX_SHARED_B, TREE_A, None, True),
         (SUFFIX_SHARED_A, SUFFIX_SHARED_B, "", "", True),

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -824,7 +824,7 @@ NEWER_LLAMA_TAG = "b10079-mix-fb3d4ca"
     ],
 )
 def test_llama_runtime_pairs_falls_back_to_mix_suffix(installed, required, pairs):
-    # No tree ids on either side, so the legacy suffix comparison still applies.
+    # No tree ids either side, so the legacy suffix comparison applies.
     assert M.llama_runtime_pairs(installed, required) is pairs
 
 
@@ -840,10 +840,10 @@ TREE_B = "e96ffb0e063f66952b0c54796a74755b6041c867"
     [
         # The bug this fixes: a shared suffix is not a shared ggml.
         (SUFFIX_SHARED_A, SUFFIX_SHARED_B, TREE_A, TREE_B, False),
-        # Different suffixes, same ggml: ABI-identical, so it pairs.
+        # Different suffixes, same ggml: ABI-identical.
         ("b10241-mix-89aa77b", "b10225-mix-345e1e3", TREE_A, TREE_A, True),
-        # A missing tree on either side falls back to the suffix: an install made
-        # before ggml_tree existed must keep working, not be stranded.
+        # A missing tree either side falls back to the suffix, so installs
+        # predating ggml_tree are not stranded.
         (SUFFIX_SHARED_A, SUFFIX_SHARED_B, None, TREE_B, True),
         (SUFFIX_SHARED_A, SUFFIX_SHARED_B, TREE_A, None, True),
         (SUFFIX_SHARED_A, SUFFIX_SHARED_B, "", "", True),

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -823,8 +823,69 @@ NEWER_LLAMA_TAG = "b10079-mix-fb3d4ca"
         ("b10070", "b10069", False),  # tag without -mix-, no shared key
     ],
 )
-def test_llama_runtime_pairs_keys_on_ggml_commit(installed, required, pairs):
+def test_llama_runtime_pairs_falls_back_to_mix_suffix(installed, required, pairs):
+    # No tree ids on either side, so the legacy suffix comparison still applies.
     assert M.llama_runtime_pairs(installed, required) is pairs
+
+
+# Real releases: both carry -mix-2c8b9c1, but their ggml trees genuinely differ.
+SUFFIX_SHARED_A = "b10173-mix-2c8b9c1"
+SUFFIX_SHARED_B = "b10181-mix-2c8b9c1"
+TREE_A = "8f3c6e197debb027f500df9f76e710e137f9fe68"
+TREE_B = "e96ffb0e063f66952b0c54796a74755b6041c867"
+
+
+@pytest.mark.parametrize(
+    "installed,required,installed_tree,required_tree,pairs",
+    [
+        # The bug this replaces: a shared suffix is not a shared ggml.
+        (SUFFIX_SHARED_A, SUFFIX_SHARED_B, TREE_A, TREE_B, False),
+        # Different suffixes, same ggml: ABI-identical, so it pairs.
+        ("b10241-mix-89aa77b", "b10225-mix-345e1e3", TREE_A, TREE_A, True),
+        # Either side missing a tree falls back to the suffix.
+        (SUFFIX_SHARED_A, SUFFIX_SHARED_B, None, TREE_B, True),
+        (SUFFIX_SHARED_A, SUFFIX_SHARED_B, TREE_A, None, True),
+        (SUFFIX_SHARED_A, SUFFIX_SHARED_B, "", "", True),
+        # An exact tag pairs before trees are consulted.
+        (SUFFIX_SHARED_A, SUFFIX_SHARED_A, TREE_A, TREE_B, True),
+    ],
+)
+def test_llama_runtime_pairs_prefers_ggml_tree(
+    installed, required, installed_tree, required_tree, pairs
+):
+    assert M.llama_runtime_pairs(
+        installed,
+        required,
+        installed_ggml_tree = installed_tree,
+        required_ggml_tree = required_tree,
+    ) is pairs
+
+
+def test_installed_llama_ggml_tree_reads_marker(tmp_path):
+    root = tmp_path / "llama.cpp"
+    root.mkdir()
+    (root / "UNSLOTH_PREBUILT_INFO.json").write_text(
+        json.dumps({"release_tag": SLIM_LLAMA_TAG, "ggml_tree": TREE_A})
+    )
+    assert M.llama.installed_llama_ggml_tree(root) == TREE_A
+
+
+@pytest.mark.parametrize(
+    "prepare",
+    [
+        lambda root: None,  # no marker: installs predating ggml_tree
+        lambda root: (root / "UNSLOTH_PREBUILT_INFO.json").write_text("{}"),
+        lambda root: (root / "UNSLOTH_PREBUILT_INFO.json").write_text(
+            json.dumps({"ggml_tree": ""})
+        ),
+        lambda root: (root / "UNSLOTH_PREBUILT_INFO.json").write_text("not json"),
+    ],
+)
+def test_installed_llama_ggml_tree_absent_is_none(tmp_path, prepare):
+    root = tmp_path / "llama.cpp"
+    root.mkdir()
+    prepare(root)
+    assert M.llama.installed_llama_ggml_tree(root) is None
 
 
 def test_slim_pairs_across_llama_build_bump_with_same_ggml(tmp_path, monkeypatch):

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -853,12 +853,15 @@ TREE_B = "e96ffb0e063f66952b0c54796a74755b6041c867"
 def test_llama_runtime_pairs_prefers_ggml_tree(
     installed, required, installed_tree, required_tree, pairs
 ):
-    assert M.llama_runtime_pairs(
-        installed,
-        required,
-        installed_ggml_tree = installed_tree,
-        required_ggml_tree = required_tree,
-    ) is pairs
+    assert (
+        M.llama_runtime_pairs(
+            installed,
+            required,
+            installed_ggml_tree = installed_tree,
+            required_ggml_tree = required_tree,
+        )
+        is pairs
+    )
 
 
 def test_installed_llama_ggml_tree_reads_marker(tmp_path):

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -842,17 +842,13 @@ TREE_B = "e96ffb0e063f66952b0c54796a74755b6041c867"
         (SUFFIX_SHARED_A, SUFFIX_SHARED_B, TREE_A, TREE_B, False),
         # Different suffixes, same ggml: ABI-identical, so it pairs.
         ("b10241-mix-89aa77b", "b10225-mix-345e1e3", TREE_A, TREE_A, True),
-        # An artifact that declares a tree is paired on that key alone: an install
-        # with no recorded tree cannot be vouched for, so it refuses rather than
-        # falling back to the suffix.
-        (SUFFIX_SHARED_A, SUFFIX_SHARED_B, None, TREE_B, False),
-        # ... and a matching tag does not override it, since a fork release can
-        # install an upstream archive whose ggml is not the fork's.
-        (SUFFIX_SHARED_A, SUFFIX_SHARED_A, TREE_A, TREE_B, False),
-        (SUFFIX_SHARED_A, SUFFIX_SHARED_A, TREE_A, TREE_A, True),
-        # Only when the artifact declares no tree does the suffix still decide.
+        # A missing tree on either side falls back to the suffix: an install made
+        # before ggml_tree existed must keep working, not be stranded.
+        (SUFFIX_SHARED_A, SUFFIX_SHARED_B, None, TREE_B, True),
         (SUFFIX_SHARED_A, SUFFIX_SHARED_B, TREE_A, None, True),
         (SUFFIX_SHARED_A, SUFFIX_SHARED_B, "", "", True),
+        # An exact tag pairs before trees are consulted.
+        (SUFFIX_SHARED_A, SUFFIX_SHARED_A, TREE_A, TREE_B, True),
     ],
 )
 def test_llama_runtime_pairs_prefers_ggml_tree(

--- a/tests/studio/install/test_install_whisper_prebuilt_logic.py
+++ b/tests/studio/install/test_install_whisper_prebuilt_logic.py
@@ -842,12 +842,17 @@ TREE_B = "e96ffb0e063f66952b0c54796a74755b6041c867"
         (SUFFIX_SHARED_A, SUFFIX_SHARED_B, TREE_A, TREE_B, False),
         # Different suffixes, same ggml: ABI-identical, so it pairs.
         ("b10241-mix-89aa77b", "b10225-mix-345e1e3", TREE_A, TREE_A, True),
-        # A missing tree on either side falls back to the suffix.
-        (SUFFIX_SHARED_A, SUFFIX_SHARED_B, None, TREE_B, True),
+        # An artifact that declares a tree is paired on that key alone: an install
+        # with no recorded tree cannot be vouched for, so it refuses rather than
+        # falling back to the suffix.
+        (SUFFIX_SHARED_A, SUFFIX_SHARED_B, None, TREE_B, False),
+        # ... and a matching tag does not override it, since a fork release can
+        # install an upstream archive whose ggml is not the fork's.
+        (SUFFIX_SHARED_A, SUFFIX_SHARED_A, TREE_A, TREE_B, False),
+        (SUFFIX_SHARED_A, SUFFIX_SHARED_A, TREE_A, TREE_A, True),
+        # Only when the artifact declares no tree does the suffix still decide.
         (SUFFIX_SHARED_A, SUFFIX_SHARED_B, TREE_A, None, True),
         (SUFFIX_SHARED_A, SUFFIX_SHARED_B, "", "", True),
-        # An exact tag pairs before trees are consulted.
-        (SUFFIX_SHARED_A, SUFFIX_SHARED_A, TREE_A, TREE_B, True),
     ],
 )
 def test_llama_runtime_pairs_prefers_ggml_tree(


### PR DESCRIPTION
Studio setup has been reporting `no compatible prebuilt` and falling back to Transformers dictation, because slim whisper bundles are paired against a key that does not track ggml.

## The bug

`_llama_ggml_commit()` takes the `-mix-` suffix off a fork tag and its docstring says that suffix is "the ggml commit ... fixes the ggml ABI the slim whisper bundle links against". It is not a ggml commit. In `unslothai/llama.cpp` the suffix is a hash of the pinned PR set:

```bash
SETHASH="$(jq -r 'map("\(.repo)#\(.number):\(.sha)") | join("\n")' <<<"$PRS" | sha256sum | cut -c1-7)"
TAG="${BASE}-mix-${SETHASH}"
```

The base tag is the prefix and is not part of the hash, so while the pins hold still the suffix is constant as the base tag, and ggml with it, moves daily. In the live release list one suffix covered eight releases spanning b9909 to b10001. Those are genuinely different ggml trees:

```
b10173  8f3c6e197debb027f500df9f76e710e137f9fe68
b10181  e96ffb0e063f66952b0c54796a74755b6041c867
```

Both are `-mix-2c8b9c1`, so `llama_runtime_pairs` called them ABI-identical. That is wrong in both directions: it pairs bundles across real ggml changes, and it refuses to pair across a pin edit that did not touch ggml at all.

## The fix

`unslothai/llama.cpp` now records `git rev-parse HEAD:ggml` in its release metadata, and `unslothai/whisper.cpp` records the tree its bundles were compiled against as `requires_ggml_tree`. A tree id changes exactly when the contents of `ggml/` change, so it is the actual ABI key. Both are already published: the current release pair agrees on `3a6f8d357cd340acd4113298855da16de645469c`.

So:

- `install_llama_prebuilt.py` reads `ggml_tree` from the published checksum asset into `ApprovedReleaseChecksums` and writes it to `UNSLOTH_PREBUILT_INFO.json`. New `installed_llama_ggml_tree()` reads it back. It is deliberately separate from `installed_llama_runtime()` so that tuple keeps its shape for existing callers and tests.
- `install_whisper_prebuilt.py` compares tree ids when both sides record one, and falls back to the old suffix comparison when either side does not.

## Compatibility

An exact tag match still short-circuits first. The suffix path is untouched and still runs for any install predating `ggml_tree` in the marker, and for releases published before the field existed, so no existing install is invalidated and no reinstall is required. `requires_ggml_sonames` remains the per-file ABI gate. The new arguments are keyword-only with `None` defaults, so every existing call site and monkeypatch keeps working.

`_llama_ggml_commit` keeps its name and its job as the fallback, but the docstring no longer claims the suffix is a ggml commit, since that claim is what made this look correct.

## Tests

85 pass in `test_install_whisper_prebuilt_logic.py`, 74 of which existed before and are unchanged. The 11 new ones cover the tree comparison, both fallback directions, and the marker accessor.

The one that matters is the regression case, using the two real releases above: same `-mix-` suffix, different ggml trees, must not pair. Under the old logic that returned `True`.

Full `tests/studio/install` run: 1562 passed. The 3 failures in `test_managed_node_runtime.py` are about Node runtime directories and reproduce on a clean `main` with these changes stashed.
