### PR TITLE
Sign the NSIS plugin DLLs, and fail the release on any unsigned file

### DIFF
--- a/.github/scripts/assert-bundle-signed.ps1
+++ b/.github/scripts/assert-bundle-signed.ps1
@@ -1,15 +1,13 @@
-# Fail if any executable inside a Windows bundle is unsigned.
-#
-# Signing the installer is not the same as signing what it drops on disk: NSIS
-# extracts its plugin DLLs to $PLUGINSDIR and runs them from there. Reports every
-# offender rather than stopping at the first.
+# Fail if any executable inside a Windows bundle is unsigned, reporting every
+# offender: NSIS extracts its plugin DLLs to $PLUGINSDIR and runs them there, so
+# signing the installer says nothing about what it drops on disk.
 
 param(
-    # Bundles to check; each is unpacked and every PE inside verified.
+    # Bundles to unpack; every PE inside is verified.
     [Parameter(Mandatory = $true)][string[]] $Path,
     # 7-Zip, preinstalled on windows-latest.
     [string] $SevenZip = '7z',
-    # Known-unsigned files to accept, by leaf name. Keep empty where possible.
+    # Known-unsigned leaf names to accept. Keep empty where possible.
     [string[]] $Allow = @()
 )
 
@@ -40,8 +38,7 @@ foreach ($bundle in $Path) {
     $dest = Join-Path $env:RUNNER_TEMP ("sigcheck-" + [System.IO.Path]::GetFileNameWithoutExtension($name))
     Remove-Item $dest -Recurse -Force -ErrorAction SilentlyContinue
     & $SevenZip x -y "-o$dest" $bundle | Out-Null
-    # 7-Zip still leaves a partial tree behind on error, so a created
-    # directory proves nothing. 1 is a warning, 2 and up are fatal.
+    # 7-Zip leaves a partial tree behind on error, so a created dir proves nothing.
     if ($LASTEXITCODE -ne 0) {
         Write-Host "::error::7-Zip exited $LASTEXITCODE unpacking $name; contents not verified"
         exit 1
@@ -53,8 +50,8 @@ foreach ($bundle in $Path) {
 
     $inner = Get-ChildItem $dest -Recurse -File |
         Where-Object { $exeExtensions -contains $_.Extension.ToLower() }
-    # Nothing to check means 7-Zip fell back to its PE handler and dumped
-    # sections instead of the payload, not that the payload is clean.
+    # No hits means 7-Zip dumped PE sections instead of the payload, not that
+    # the payload is clean.
     if (-not $inner) {
         Write-Host "::error::no executable payload found inside $name; contents not verified"
         exit 1
@@ -68,8 +65,8 @@ foreach ($bundle in $Path) {
         } elseif ($Allow -contains $f.Name) {
             Write-Host ("  ALLOWED   {0}  ({1}) - explicitly accepted as unsigned" -f $f.Name, $s.Status)
         } else {
-            # StatusMessage is the only thing separating "no signature" from
-            # "chain could not be built"; both report as UnknownError.
+            # "no signature" and "chain not built" both report UnknownError;
+            # only StatusMessage tells them apart.
             Write-Host ("  UNSIGNED  {0}  ({1})  {2}" -f $f.Name, $s.Status, $s.StatusMessage)
             $unsigned += [pscustomobject]@{ Bundle = $name; File = $f.Name; Status = [string]$s.Status }
         }

--- a/.github/scripts/assert-bundle-signed.ps1
+++ b/.github/scripts/assert-bundle-signed.ps1
@@ -1,6 +1,5 @@
-# Fail if any executable inside a Windows bundle is unsigned, reporting every
-# offender: NSIS extracts its plugin DLLs to $PLUGINSDIR and runs them there, so
-# signing the installer says nothing about what it drops on disk.
+# Fail if any executable inside a Windows bundle is unsigned. NSIS runs its
+# plugin DLLs from $PLUGINSDIR, so a signed installer proves nothing about them.
 
 param(
     # Bundles to unpack; every PE inside is verified.
@@ -12,10 +11,8 @@ param(
 )
 
 $ErrorActionPreference = 'Continue'
-# .ps1/.psm1 are here on purpose: install.ps1 ships as a bundle resource and is
-# what the app executes on first run, so it is as much "what the installer drops
-# on disk" as any DLL. Authenticode covers scripts and Smart App Control checks
-# them.
+# .ps1/.psm1 included: install.ps1 ships as a bundle resource and runs on first
+# launch. Authenticode covers scripts, and Smart App Control checks them.
 $exeExtensions = @('.exe', '.dll', '.sys', '.ocx', '.cpl', '.scr', '.ps1', '.psm1')
 
 $unsigned = @()
@@ -54,8 +51,7 @@ foreach ($bundle in $Path) {
 
     $inner = Get-ChildItem $dest -Recurse -File |
         Where-Object { $exeExtensions -contains $_.Extension.ToLower() }
-    # No hits means 7-Zip dumped PE sections instead of the payload, not that
-    # the payload is clean.
+    # No hits means 7-Zip dumped PE sections, not that the payload is clean.
     if (-not $inner) {
         Write-Host "::error::no executable payload found inside $name; contents not verified"
         exit 1
@@ -69,8 +65,7 @@ foreach ($bundle in $Path) {
         } elseif ($Allow -contains $f.Name) {
             Write-Host ("  ALLOWED   {0}  ({1}) - explicitly accepted as unsigned" -f $f.Name, $s.Status)
         } else {
-            # "no signature" and "chain not built" both report UnknownError;
-            # only StatusMessage tells them apart.
+            # UnknownError = no signature or unbuilt chain; StatusMessage tells which.
             Write-Host ("  UNSIGNED  {0}  ({1})  {2}" -f $f.Name, $s.Status, $s.StatusMessage)
             $unsigned += [pscustomobject]@{ Bundle = $name; File = $f.Name; Status = [string]$s.Status }
         }

--- a/.github/scripts/assert-bundle-signed.ps1
+++ b/.github/scripts/assert-bundle-signed.ps1
@@ -1,0 +1,86 @@
+# Fail if any executable inside a Windows bundle is unsigned.
+#
+# Signing the installer is not the same as signing what it drops on disk: NSIS
+# extracts its plugin DLLs to $PLUGINSDIR and runs them from there. Reports every
+# offender rather than stopping at the first.
+
+param(
+    # Bundles to check; each is unpacked and every PE inside verified.
+    [Parameter(Mandatory = $true)][string[]] $Path,
+    # 7-Zip, preinstalled on windows-latest.
+    [string] $SevenZip = '7z',
+    # Known-unsigned files to accept, by leaf name. Keep empty where possible.
+    [string[]] $Allow = @()
+)
+
+$ErrorActionPreference = 'Continue'
+$exeExtensions = @('.exe', '.dll', '.sys', '.ocx', '.cpl', '.scr')
+
+$unsigned = @()
+$checked = 0
+
+foreach ($bundle in $Path) {
+    if (-not (Test-Path $bundle -PathType Leaf)) {
+        Write-Host "::error::bundle not found: $bundle"
+        exit 1
+    }
+    $name = Split-Path $bundle -Leaf
+    Write-Host ''
+    Write-Host "=== $name ==="
+
+    $sig = Get-AuthenticodeSignature $bundle
+    $checked++
+    if ($sig.Status -ne 'Valid') {
+        Write-Host "  UNSIGNED  $name  ($($sig.Status))"
+        $unsigned += [pscustomobject]@{ Bundle = $name; File = $name; Status = [string]$sig.Status }
+    } else {
+        Write-Host "  signed    $name  <- $($sig.SignerCertificate.Subject)"
+    }
+
+    $dest = Join-Path $env:RUNNER_TEMP ("sigcheck-" + [System.IO.Path]::GetFileNameWithoutExtension($name))
+    Remove-Item $dest -Recurse -Force -ErrorAction SilentlyContinue
+    & $SevenZip x -y "-o$dest" $bundle | Out-Null
+    if (-not (Test-Path $dest)) {
+        Write-Host "::error::could not unpack $name; cannot verify its contents"
+        exit 1
+    }
+
+    $inner = Get-ChildItem $dest -Recurse -File |
+        Where-Object { $exeExtensions -contains $_.Extension.ToLower() }
+    if (-not $inner) {
+        Write-Host "::warning::no executable payload found inside $name"
+    }
+
+    foreach ($f in ($inner | Sort-Object Name)) {
+        $checked++
+        $s = Get-AuthenticodeSignature $f.FullName
+        if ($s.Status -eq 'Valid') {
+            Write-Host ("  signed    {0}" -f $f.Name)
+        } elseif ($Allow -contains $f.Name) {
+            Write-Host ("  ALLOWED   {0}  ({1}) - explicitly accepted as unsigned" -f $f.Name, $s.Status)
+        } else {
+            Write-Host ("  UNSIGNED  {0}  ({1})" -f $f.Name, $s.Status)
+            $unsigned += [pscustomobject]@{ Bundle = $name; File = $f.Name; Status = [string]$s.Status }
+        }
+    }
+    Remove-Item $dest -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ''
+Write-Host "checked $checked file(s) across $($Path.Count) bundle(s)"
+
+if (-not $unsigned) {
+    Write-Host 'Every executable in every bundle is validly signed.'
+    exit 0
+}
+
+Write-Host ''
+Write-Host '================ UNSIGNED FILES ================'
+$unsigned | Format-Table Bundle, File, Status -AutoSize | Out-String | Write-Host
+foreach ($u in $unsigned) {
+    Write-Host "::error file=$($u.File)::$($u.File) in $($u.Bundle) is $($u.Status) and needs signing"
+}
+Write-Host ''
+Write-Host 'These ship inside the installer and land on the user machine.'
+Write-Host 'For NSIS plugin DLLs see the NSISPLUGINS note in windows/installer.nsi.'
+exit 1

--- a/.github/scripts/assert-bundle-signed.ps1
+++ b/.github/scripts/assert-bundle-signed.ps1
@@ -40,6 +40,12 @@ foreach ($bundle in $Path) {
     $dest = Join-Path $env:RUNNER_TEMP ("sigcheck-" + [System.IO.Path]::GetFileNameWithoutExtension($name))
     Remove-Item $dest -Recurse -Force -ErrorAction SilentlyContinue
     & $SevenZip x -y "-o$dest" $bundle | Out-Null
+    # 7-Zip still leaves a partial tree behind on error, so a created
+    # directory proves nothing. 1 is a warning, 2 and up are fatal.
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "::error::7-Zip exited $LASTEXITCODE unpacking $name; contents not verified"
+        exit 1
+    }
     if (-not (Test-Path $dest)) {
         Write-Host "::error::could not unpack $name; cannot verify its contents"
         exit 1
@@ -47,8 +53,11 @@ foreach ($bundle in $Path) {
 
     $inner = Get-ChildItem $dest -Recurse -File |
         Where-Object { $exeExtensions -contains $_.Extension.ToLower() }
+    # Nothing to check means 7-Zip fell back to its PE handler and dumped
+    # sections instead of the payload, not that the payload is clean.
     if (-not $inner) {
-        Write-Host "::warning::no executable payload found inside $name"
+        Write-Host "::error::no executable payload found inside $name; contents not verified"
+        exit 1
     }
 
     foreach ($f in ($inner | Sort-Object Name)) {
@@ -59,7 +68,9 @@ foreach ($bundle in $Path) {
         } elseif ($Allow -contains $f.Name) {
             Write-Host ("  ALLOWED   {0}  ({1}) - explicitly accepted as unsigned" -f $f.Name, $s.Status)
         } else {
-            Write-Host ("  UNSIGNED  {0}  ({1})" -f $f.Name, $s.Status)
+            # StatusMessage is the only thing separating "no signature" from
+            # "chain could not be built"; both report as UnknownError.
+            Write-Host ("  UNSIGNED  {0}  ({1})  {2}" -f $f.Name, $s.Status, $s.StatusMessage)
             $unsigned += [pscustomobject]@{ Bundle = $name; File = $f.Name; Status = [string]$s.Status }
         }
     }

--- a/.github/scripts/assert-bundle-signed.ps1
+++ b/.github/scripts/assert-bundle-signed.ps1
@@ -12,7 +12,11 @@ param(
 )
 
 $ErrorActionPreference = 'Continue'
-$exeExtensions = @('.exe', '.dll', '.sys', '.ocx', '.cpl', '.scr')
+# .ps1/.psm1 are here on purpose: install.ps1 ships as a bundle resource and is
+# what the app executes on first run, so it is as much "what the installer drops
+# on disk" as any DLL. Authenticode covers scripts and Smart App Control checks
+# them.
+$exeExtensions = @('.exe', '.dll', '.sys', '.ocx', '.cpl', '.scr', '.ps1', '.psm1')
 
 $unsigned = @()
 $checked = 0

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -814,10 +814,9 @@ jobs:
             "$dmg_path"
 
       # ── Windows: build + sign ──
-      # install.ps1 is a bundle resource, so the bundler never signs it, yet it
-      # is the first thing the app runs after install. Sign it before the build
-      # packs it in. The signature is an appended comment block, so the repo copy
-      # served for `irm ... | iex` is unaffected.
+      # install.ps1 is a bundle resource the bundler never signs, yet the app
+      # runs it first. Sign before the build packs it in; the signature is an
+      # appended comment block, so the repo copy for `irm ... | iex` is unaffected.
       - name: Sign the bundled install script
         if: matrix.platform == 'windows-latest'
         shell: pwsh
@@ -1051,8 +1050,7 @@ jobs:
           retention-days: 7
 
       # ── Windows: every executable in the bundle must be signed ──
-      # NSIS runs its plugin DLLs from $PLUGINSDIR, which a signed installer
-      # says nothing about.
+      # NSIS runs its plugin DLLs from $PLUGINSDIR; signing the installer misses them.
       - name: Verify every executable in the Windows bundles is signed
         if: matrix.platform == 'windows-latest'
         shell: pwsh

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1030,8 +1030,8 @@ jobs:
           retention-days: 7
 
       # ── Windows: every executable in the bundle must be signed ──
-      # NSIS runs its plugin DLLs from $PLUGINSDIR, so the installer being signed
-      # says nothing about what it drops on disk.
+      # NSIS runs its plugin DLLs from $PLUGINSDIR, which a signed installer
+      # says nothing about.
       - name: Verify every executable in the Windows bundles is signed
         if: matrix.platform == 'windows-latest'
         shell: pwsh

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -814,6 +814,27 @@ jobs:
             "$dmg_path"
 
       # ── Windows: build + sign ──
+      # install.ps1 is a bundle resource, so the bundler never signs it, yet it
+      # is the first thing the app runs after install. Sign it before the build
+      # packs it in. The signature is an appended comment block, so the repo copy
+      # served for `irm ... | iex` is unaffected.
+      - name: Sign the bundled install script
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_TRUSTED_SIGNING_ACCOUNT_NAME: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
+          AZURE_CERTIFICATE_PROFILE_NAME: ${{ secrets.AZURE_CERTIFICATE_PROFILE_NAME }}
+        run: |
+          $script = (Resolve-Path 'install.ps1').Path
+          studio/src-tauri/windows/sign-with-trusted-signing.ps1 -Path $script
+          if ($LASTEXITCODE -ne 0) { Write-Host "::error::could not sign install.ps1 (exit $LASTEXITCODE)"; exit 1 }
+          $sig = Get-AuthenticodeSignature $script
+          Write-Host "install.ps1 -> $($sig.Status) $($sig.SignerCertificate.Subject)"
+          if ($sig.Status -ne 'Valid') { Write-Host "::error::install.ps1 is $($sig.Status) after signing"; exit 1 }
+
       - name: Build Windows app
         id: build_windows
         if: matrix.platform == 'windows-latest'

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1029,6 +1029,20 @@ jobs:
           compression-level: 0
           retention-days: 7
 
+      # ── Windows: every executable in the bundle must be signed ──
+      # NSIS runs its plugin DLLs from $PLUGINSDIR, so the installer being signed
+      # says nothing about what it drops on disk.
+      - name: Verify every executable in the Windows bundles is signed
+        if: matrix.platform == 'windows-latest'
+        shell: pwsh
+        env:
+          ARTIFACT_PATHS: ${{ steps.build_windows.outputs.artifactPaths }}
+        run: |
+          $paths = @($env:ARTIFACT_PATHS | ConvertFrom-Json) |
+                   Where-Object { $_ -like '*-setup.exe' }
+          if (-not $paths) { Write-Host '::error::no Windows installer to verify'; exit 1 }
+          .github/scripts/assert-bundle-signed.ps1 -Path $paths
+
       # ── Windows: assemble a Microsoft false-positive submission packet ──
       # The WDSI portal is a web form with no API, so this cannot be automated,
       # but pre-filling the lookups makes submitting a build take seconds.

--- a/install.ps1
+++ b/install.ps1
@@ -20,9 +20,9 @@ function Install-UnslothStudio {
     $ErrorActionPreference = "Stop"
     $script:UnslothVerbose = ($env:UNSLOTH_VERBOSE -eq "1")
 
-    # Same fix as studio/setup.ps1, for the same reason. This script also runs
-    # astral's uv installer in-process (Invoke-Expression, below), and that
-    # installer calls Get-ExecutionPolicy out of Microsoft.PowerShell.Security.
+    # Same fix as studio/setup.ps1, for the same reason. This script also calls
+    # Expand-Archive (Microsoft.PowerShell.Archive) and Get-ExecutionPolicy
+    # (Microsoft.PowerShell.Security), both of which resolve via PSModulePath.
     # The desktop app reaches here as Tauri -> Rust -> powershell.exe
     # (studio/src-tauri/src/install.rs), and PowerShell only rewrites
     # PSModulePath for a direct pwsh -> powershell.exe hop, so the Rust process
@@ -1607,6 +1607,91 @@ exit 0
         }
     }
 
+    # Fallback for hosts without winget. Does what astral's install.ps1 does --
+    # same archive, destination and user-PATH prepend -- but the only thing
+    # fetched is a data file with a pinned SHA-256, never script text run
+    # in-process, which is what AMSI and cloud ML scanners score hardest.
+    # Bumping $UvPinnedVersion means bumping all three hashes with it:
+    #   curl -sL https://github.com/astral-sh/uv/releases/download/<ver>/uv-<arch>-pc-windows-msvc.zip.sha256
+    $UvPinnedVersion = "0.12.1"
+    $UvPinnedAssets = @{
+        "x86_64" = @{ Asset = "uv-x86_64-pc-windows-msvc.zip";  Sha256 = "8FCB0CB46E1229065E344758980924E569BEF5882EF45F46FADA8FB24E06B74A" }
+        "arm64"  = @{ Asset = "uv-aarch64-pc-windows-msvc.zip"; Sha256 = "9BC7C18E616230FA2DC6FB24BC3AFDE18A95C2B5C9433DE747E9502C66041568" }
+        "x86"    = @{ Asset = "uv-i686-pc-windows-msvc.zip";    Sha256 = "9B51C33D307A8AB9E9DFD88D4AE1491761F63DE0BFFA3CEC96BEC536491C9B97" }
+    }
+
+    function Install-UvFromRelease {
+        $arch = Get-HostMachineArch
+        if (-not $UvPinnedAssets.ContainsKey($arch)) {
+            substep "No uv build is published for this architecture ($arch)." "Yellow"
+            return $false
+        }
+        $asset  = $UvPinnedAssets[$arch].Asset
+        $wanted = $UvPinnedAssets[$arch].Sha256
+
+        # Same destination priority as astral's installer, so an existing uv is
+        # replaced in place and the PATH probe further below still finds it.
+        $destDir = $null
+        foreach ($candidate in @($env:UV_INSTALL_DIR, $env:UV_UNMANAGED_INSTALL, $env:XDG_BIN_HOME)) {
+            if ($candidate) { $destDir = $candidate; break }
+        }
+        if (-not $destDir -and $env:XDG_DATA_HOME) { $destDir = Join-Path $env:XDG_DATA_HOME "../bin" }
+        if (-not $destDir) {
+            $userHome = if ($env:USERPROFILE) { $env:USERPROFILE } else { $HOME }
+            if (-not $userHome) {
+                substep "Could not determine a home directory to install uv into." "Yellow"
+                return $false
+            }
+            $destDir = Join-Path $userHome ".local\bin"
+        }
+
+        $work = Join-Path ([System.IO.Path]::GetTempPath()) ("unsloth-uv-" + [guid]::NewGuid().ToString('N').Substring(0, 8))
+        $zip  = Join-Path $work $asset
+        try {
+            [System.IO.Directory]::CreateDirectory($work) | Out-Null
+            substep "downloading uv $UvPinnedVersion ($arch) from github.com/astral-sh/uv..." "Yellow"
+            try {
+                Invoke-WebRequest -UseBasicParsing -OutFile $zip `
+                    -Uri "https://github.com/astral-sh/uv/releases/download/$UvPinnedVersion/$asset"
+            } catch {
+                substep "uv download failed: $($_.Exception.Message)" "Yellow"
+                return $false
+            }
+
+            $actual = (Get-FileHash -LiteralPath $zip -Algorithm SHA256).Hash
+            if ($actual -ne $wanted) {
+                substep "uv download failed checksum verification -- discarding it." "Red"
+                substep "expected $wanted, got $actual" "Red"
+                return $false
+            }
+
+            # The Windows archives are flat: uv.exe, uvx.exe, uvw.exe at the root.
+            Expand-Archive -LiteralPath $zip -DestinationPath $work -Force
+            [System.IO.Directory]::CreateDirectory($destDir) | Out-Null
+            $haveUv = $false
+            foreach ($exe in @("uv.exe", "uvx.exe", "uvw.exe")) {
+                $src = Join-Path $work $exe
+                if (Test-Path -LiteralPath $src) {
+                    Copy-Item -LiteralPath $src -Destination (Join-Path $destDir $exe) -Force
+                    if ($exe -eq "uv.exe") { $haveUv = $true }
+                }
+            }
+            if (-not $haveUv) {
+                substep "uv.exe was not present in $asset." "Yellow"
+                return $false
+            }
+        } finally {
+            Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue
+        }
+
+        # Same PATH treatment and opt-out variable astral's installer uses.
+        if (-not $env:UV_NO_MODIFY_PATH) {
+            Add-ToUserPath -Directory $destDir -Position Prepend | Out-Null
+        }
+        $env:PATH = "$destDir;$env:PATH"
+        return $true
+    }
+
     if (-not (Test-UvVersionOk)) {
         if (Get-Command uv -ErrorAction SilentlyContinue) {
             substep "updating uv package manager..."
@@ -1623,13 +1708,12 @@ exit 0
             $ErrorActionPreference = $prevEAP
             Refresh-SessionPath
         }
-        # Fallback: if winget is unavailable or didn't put uv on PATH,
-        # use Astral's official PowerShell installer. This is the only
-        # supported path on hosts without winget (Windows ARM64 runners,
-        # corporate machines without the Store, etc.).
+        # Fallback: if winget is unavailable or didn't put uv on PATH, install
+        # the pinned uv release directly. This is the only supported path on
+        # hosts without winget (Windows ARM64 runners, corporate machines
+        # without the Store, etc.).
         if (-not (Test-UvVersionOk)) {
-            substep "installing uv via https://astral.sh/uv/install.ps1..." "Yellow"
-            Invoke-Expression (Invoke-RestMethod -Uri "https://astral.sh/uv/install.ps1")
+            Install-UvFromRelease | Out-Null
             Refresh-SessionPath
         }
     }

--- a/install.ps1
+++ b/install.ps1
@@ -21,8 +21,7 @@ function Install-UnslothStudio {
     $script:UnslothVerbose = ($env:UNSLOTH_VERBOSE -eq "1")
 
     # Same fix as studio/setup.ps1, for the same reason. This script also calls
-    # Expand-Archive (Microsoft.PowerShell.Archive) and Get-ExecutionPolicy
-    # (Microsoft.PowerShell.Security), both of which resolve via PSModulePath.
+    # Expand-Archive and Get-ExecutionPolicy, which resolve via PSModulePath.
     # The desktop app reaches here as Tauri -> Rust -> powershell.exe
     # (studio/src-tauri/src/install.rs), and PowerShell only rewrites
     # PSModulePath for a direct pwsh -> powershell.exe hop, so the Rust process
@@ -1607,11 +1606,10 @@ exit 0
         }
     }
 
-    # Fallback for hosts without winget. Does what astral's install.ps1 does --
-    # same archive, destination and user-PATH prepend -- but the only thing
-    # fetched is a data file with a pinned SHA-256, never script text run
-    # in-process, which is what AMSI and cloud ML scanners score hardest.
-    # Bumping $UvPinnedVersion means bumping all three hashes with it:
+    # Fallback for hosts without winget. Same archive, destination and user-PATH
+    # prepend as astral's install.ps1, but it fetches a data file with a pinned
+    # SHA-256 instead of script text run in-process, which is what AMSI and cloud
+    # ML scanners score hardest. Bumping the version means bumping all 3 hashes:
     #   curl -sL https://github.com/astral-sh/uv/releases/download/<ver>/uv-<arch>-pc-windows-msvc.zip.sha256
     $UvPinnedVersion = "0.12.1"
     $UvPinnedAssets = @{
@@ -1645,10 +1643,9 @@ exit 0
             $destDir = Join-Path $userHome ".local\bin"
         }
 
-        # Same mirrors and precedence astral's installer uses. Each serves the
-        # identical release asset, so the pinned hash below holds across all of
-        # them. UV_DOWNLOAD_URL is deliberately not honoured: it points at an
-        # arbitrary version, which the pin would then correctly reject.
+        # Same mirrors and precedence as astral's installer; each serves the
+        # identical asset, so the pin holds across all of them. UV_DOWNLOAD_URL is
+        # not honoured: it points at an arbitrary version the pin would reject.
         $uvBase = if ($env:UV_INSTALLER_GHE_BASE_URL) {
             @("$($env:UV_INSTALLER_GHE_BASE_URL.TrimEnd('/'))/astral-sh/uv/releases/download/$UvPinnedVersion")
         } elseif ($env:UV_INSTALLER_GITHUB_BASE_URL) {
@@ -1729,10 +1726,8 @@ exit 0
             $ErrorActionPreference = $prevEAP
             Refresh-SessionPath
         }
-        # Fallback: if winget is unavailable or didn't put uv on PATH, install
-        # the pinned uv release directly. This is the only supported path on
-        # hosts without winget (Windows ARM64 runners, corporate machines
-        # without the Store, etc.).
+        # winget unavailable or it didn't put uv on PATH: install the pinned
+        # release directly (ARM64 runners, machines without the Store).
         if (-not (Test-UvVersionOk)) {
             Install-UvFromRelease | Out-Null
             Refresh-SessionPath

--- a/install.ps1
+++ b/install.ps1
@@ -1645,18 +1645,35 @@ exit 0
             $destDir = Join-Path $userHome ".local\bin"
         }
 
+        # Same mirrors and precedence astral's installer uses. Each serves the
+        # identical release asset, so the pinned hash below holds across all of
+        # them. UV_DOWNLOAD_URL is deliberately not honoured: it points at an
+        # arbitrary version, which the pin would then correctly reject.
+        $uvBase = if ($env:UV_INSTALLER_GHE_BASE_URL) {
+            @("$($env:UV_INSTALLER_GHE_BASE_URL.TrimEnd('/'))/astral-sh/uv/releases/download/$UvPinnedVersion")
+        } elseif ($env:UV_INSTALLER_GITHUB_BASE_URL) {
+            @("$($env:UV_INSTALLER_GITHUB_BASE_URL.TrimEnd('/'))/astral-sh/uv/releases/download/$UvPinnedVersion")
+        } else {
+            @("https://releases.astral.sh/github/uv/releases/download/$UvPinnedVersion",
+              "https://github.com/astral-sh/uv/releases/download/$UvPinnedVersion")
+        }
+
         $work = Join-Path ([System.IO.Path]::GetTempPath()) ("unsloth-uv-" + [guid]::NewGuid().ToString('N').Substring(0, 8))
         $zip  = Join-Path $work $asset
         try {
             [System.IO.Directory]::CreateDirectory($work) | Out-Null
-            substep "downloading uv $UvPinnedVersion ($arch) from github.com/astral-sh/uv..." "Yellow"
-            try {
-                Invoke-WebRequest -UseBasicParsing -OutFile $zip `
-                    -Uri "https://github.com/astral-sh/uv/releases/download/$UvPinnedVersion/$asset"
-            } catch {
-                substep "uv download failed: $($_.Exception.Message)" "Yellow"
-                return $false
+            $downloaded = $false
+            foreach ($base in $uvBase) {
+                substep "downloading uv $UvPinnedVersion ($arch) from $base..." "Yellow"
+                try {
+                    Invoke-WebRequest -UseBasicParsing -OutFile $zip -Uri "$base/$asset"
+                    $downloaded = $true
+                    break
+                } catch {
+                    substep "uv download failed: $($_.Exception.Message)" "Yellow"
+                }
             }
+            if (-not $downloaded) { return $false }
 
             $actual = (Get-FileHash -LiteralPath $zip -Algorithm SHA256).Hash
             if ($actual -ne $wanted) {
@@ -1684,11 +1701,15 @@ exit 0
             Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue
         }
 
-        # Same PATH treatment and opt-out variable astral's installer uses.
-        if (-not $env:UV_NO_MODIFY_PATH) {
+        # Same PATH treatment and opt-outs astral's installer uses: an unmanaged
+        # install forces no-modify-path there, so it must here too.
+        if (-not $env:UV_NO_MODIFY_PATH -and -not $env:UV_UNMANAGED_INSTALL) {
             Add-ToUserPath -Directory $destDir -Position Prepend | Out-Null
         }
         $env:PATH = "$destDir;$env:PATH"
+        # Refresh-SessionPath rebuilds PATH machine-first and drops that prepend,
+        # so record where uv actually landed for the probe below.
+        $script:UvInstallDestDir = $destDir
         return $true
     }
 
@@ -1722,7 +1743,7 @@ exit 0
     # venv, Scoop/pipx shim). Prefer a just-installed uv from a known location.
     if (-not (Test-UvVersionOk)) {
         $origPath = $env:PATH
-        foreach ($d in @($env:UV_INSTALL_DIR, $env:XDG_BIN_HOME,
+        foreach ($d in @($script:UvInstallDestDir, $env:UV_INSTALL_DIR, $env:XDG_BIN_HOME,
                          (Join-Path $env:USERPROFILE ".local\bin"),
                          (Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links"))) {
             if ($d -and (Test-Path $d)) {

--- a/studio/src-tauri/src/install.rs
+++ b/studio/src-tauri/src/install.rs
@@ -324,15 +324,17 @@ fn spawn_script(
 
     #[cfg(windows)]
     let mut cmd = Command::new("powershell.exe");
+    // No -WindowStyle Hidden, no -ExecutionPolicy Bypass: CREATE_NO_WINDOW below
+    // already suppresses the console, and NSIS writes resources without a
+    // mark-of-the-web so RemoteSigned loads the script. The pair changes nothing
+    // here and is the command line Microsoft ships as a detection test.
     #[cfg(windows)]
     cmd.args([
         "-NoLogo",
         "-NoProfile",
         "-NonInteractive",
-        "-WindowStyle",
-        "Hidden",
         "-ExecutionPolicy",
-        "Bypass",
+        "RemoteSigned",
         "-File",
     ])
     .arg(script)

--- a/studio/src-tauri/src/install.rs
+++ b/studio/src-tauri/src/install.rs
@@ -324,10 +324,9 @@ fn spawn_script(
 
     #[cfg(windows)]
     let mut cmd = Command::new("powershell.exe");
-    // No -WindowStyle Hidden, no -ExecutionPolicy Bypass: CREATE_NO_WINDOW below
-    // already suppresses the console, and NSIS writes resources without a
-    // mark-of-the-web so RemoteSigned loads the script. The pair changes nothing
-    // here and is the command line Microsoft ships as a detection test.
+    // No -WindowStyle Hidden / -ExecutionPolicy Bypass: that pair is a Microsoft
+    // detection signature, CREATE_NO_WINDOW below already hides the console, and
+    // NSIS writes resources without a mark-of-the-web so RemoteSigned loads them.
     #[cfg(windows)]
     cmd.args([
         "-NoLogo",

--- a/studio/src-tauri/windows/installer.nsi
+++ b/studio/src-tauri/windows/installer.nsi
@@ -23,12 +23,10 @@ ManifestDPIAwareness PerMonitorV2
   SetCompressor /SOLID "{{compression}}"
 !endif
 
-; Signed NSIS plugins. tauri-bundler signs a copy of the plugins and exports its
-; path as NSISPLUGINS, but no template consumes it, so only nsis_tauri_utils.dll
-; (via ADDITIONALPLUGINSPATH) ships signed while NSISdl/System/StartMenu/nsDialogs
-; do not, and unsigned DLLs run from $PLUGINSDIR trigger AV false positives.
-; Must precede any plugin use, else the copy conflicts with an already packed
-; default. A missing directory is a silent no-op, so unsigned builds still work.
+; Signed NSIS plugins. tauri-bundler signs a copy and exports NSISPLUGINS, but no
+; template consumes it, so only nsis_tauri_utils.dll ships signed and the rest
+; (NSISdl/System/StartMenu/nsDialogs) run unsigned from $PLUGINSDIR, tripping AV.
+; Must precede any plugin use; a missing directory is a silent no-op.
 !addplugindir "$%NSISPLUGINS%\x86-unicode"
 
 !include MUI2.nsh

--- a/studio/src-tauri/windows/installer.nsi
+++ b/studio/src-tauri/windows/installer.nsi
@@ -23,12 +23,11 @@ ManifestDPIAwareness PerMonitorV2
   SetCompressor /SOLID "{{compression}}"
 !endif
 
-; Signed NSIS plugins.
-; tauri-bundler signs a copy of the plugins and exports its path as NSISPLUGINS,
-; but no template references it, so only nsis_tauri_utils.dll (reached via
-; ADDITIONALPLUGINSPATH) ships signed and NSISdl/System/StartMenu/nsDialogs do
-; not. Unsigned DLLs run from $PLUGINSDIR are a known AV false positive trigger.
-; Must precede any plugin use, or the copy conflicts with an already packed
+; Signed NSIS plugins. tauri-bundler signs a copy of the plugins and exports its
+; path as NSISPLUGINS, but no template consumes it, so only nsis_tauri_utils.dll
+; (via ADDITIONALPLUGINSPATH) ships signed while NSISdl/System/StartMenu/nsDialogs
+; do not, and unsigned DLLs run from $PLUGINSDIR trigger AV false positives.
+; Must precede any plugin use, else the copy conflicts with an already packed
 ; default. A missing directory is a silent no-op, so unsigned builds still work.
 !addplugindir "$%NSISPLUGINS%\x86-unicode"
 

--- a/studio/src-tauri/windows/installer.nsi
+++ b/studio/src-tauri/windows/installer.nsi
@@ -100,10 +100,9 @@ InstallDir "${PLACEHOLDER_INSTALL_DIR}"
 VIProductVersion "${VERSIONWITHBUILD}"
 VIAddVersionKey "ProductName" "${PRODUCTNAME}"
 VIAddVersionKey "FileDescription" "${PRODUCTNAME}"
-; Not in upstream's template. ${MANUFACTURER} is bundle.publisher and is already
-; written as the Add/Remove Programs Publisher value, so these cannot be empty
-; and cannot disagree with it. An installer with no CompanyName reads as
-; unattributed to reputation checks.
+; Not in upstream's template. ${MANUFACTURER} is bundle.publisher, already written
+; as the Add/Remove Programs Publisher, so these cannot be empty or disagree with
+; it. An installer with no CompanyName reads as unattributed to reputation checks.
 VIAddVersionKey "CompanyName" "${MANUFACTURER}"
 VIAddVersionKey "InternalName" "${INSTALLIDENTITY}"
 VIAddVersionKey "LegalCopyright" "${COPYRIGHT}"

--- a/studio/src-tauri/windows/installer.nsi
+++ b/studio/src-tauri/windows/installer.nsi
@@ -23,6 +23,15 @@ ManifestDPIAwareness PerMonitorV2
   SetCompressor /SOLID "{{compression}}"
 !endif
 
+; Signed NSIS plugins.
+; tauri-bundler signs a copy of the plugins and exports its path as NSISPLUGINS,
+; but no template references it, so only nsis_tauri_utils.dll (reached via
+; ADDITIONALPLUGINSPATH) ships signed and NSISdl/System/StartMenu/nsDialogs do
+; not. Unsigned DLLs run from $PLUGINSDIR are a known AV false positive trigger.
+; Must precede any plugin use, or the copy conflicts with an already packed
+; default. A missing directory is a silent no-op, so unsigned builds still work.
+!addplugindir "$%NSISPLUGINS%\x86-unicode"
+
 !include MUI2.nsh
 !include FileFunc.nsh
 !include x64.nsh
@@ -97,16 +106,6 @@ VIAddVersionKey "FileDescription" "${PRODUCTNAME}"
 VIAddVersionKey "LegalCopyright" "${COPYRIGHT}"
 VIAddVersionKey "FileVersion" "${VERSION}"
 VIAddVersionKey "ProductVersion" "${VERSION}"
-
-; Signed NSIS plugins.
-; tauri-bundler signs a copy of the plugins and exports its path as NSISPLUGINS,
-; but no template references it, so only nsis_tauri_utils.dll (reached via
-; ADDITIONALPLUGINSPATH) ships signed and NSISdl/System/StartMenu/nsDialogs do
-; not. Unsigned DLLs run from $PLUGINSDIR are a known AV false positive trigger.
-; Guarded: NSISPLUGINS is only set when signing is configured.
-!if "$%NSISPLUGINS%" != ""
-  !addplugindir "$%NSISPLUGINS%\x86-unicode"
-!endif
 
 # additional plugins
 !addplugindir "${ADDITIONALPLUGINSPATH}"

--- a/studio/src-tauri/windows/installer.nsi
+++ b/studio/src-tauri/windows/installer.nsi
@@ -100,6 +100,12 @@ InstallDir "${PLACEHOLDER_INSTALL_DIR}"
 VIProductVersion "${VERSIONWITHBUILD}"
 VIAddVersionKey "ProductName" "${PRODUCTNAME}"
 VIAddVersionKey "FileDescription" "${PRODUCTNAME}"
+; Not in upstream's template. ${MANUFACTURER} is bundle.publisher and is already
+; written as the Add/Remove Programs Publisher value, so these cannot be empty
+; and cannot disagree with it. An installer with no CompanyName reads as
+; unattributed to reputation checks.
+VIAddVersionKey "CompanyName" "${MANUFACTURER}"
+VIAddVersionKey "InternalName" "${INSTALLIDENTITY}"
 VIAddVersionKey "LegalCopyright" "${COPYRIGHT}"
 VIAddVersionKey "FileVersion" "${VERSION}"
 VIAddVersionKey "ProductVersion" "${VERSION}"

--- a/studio/src-tauri/windows/installer.nsi
+++ b/studio/src-tauri/windows/installer.nsi
@@ -98,6 +98,16 @@ VIAddVersionKey "LegalCopyright" "${COPYRIGHT}"
 VIAddVersionKey "FileVersion" "${VERSION}"
 VIAddVersionKey "ProductVersion" "${VERSION}"
 
+; Signed NSIS plugins.
+; tauri-bundler signs a copy of the plugins and exports its path as NSISPLUGINS,
+; but no template references it, so only nsis_tauri_utils.dll (reached via
+; ADDITIONALPLUGINSPATH) ships signed and NSISdl/System/StartMenu/nsDialogs do
+; not. Unsigned DLLs run from $PLUGINSDIR are a known AV false positive trigger.
+; Guarded: NSISPLUGINS is only set when signing is configured.
+!if "$%NSISPLUGINS%" != ""
+  !addplugindir "$%NSISPLUGINS%\x86-unicode"
+!endif
+
 # additional plugins
 !addplugindir "${ADDITIONALPLUGINSPATH}"
 


### PR DESCRIPTION
## What is wrong

Both `0.1.51-beta` and `0.1.512-beta` ship four unsigned DLLs inside the installer:

| file | 0.1.51-beta | 0.1.512-beta |
|---|---|---|
| `nsis_tauri_utils.dll` | signed, `Unsloth AI Inc.` | signed, `Unsloth AI Inc.` |
| `NSISdl.dll` | **unsigned** | **unsigned** |
| `System.dll` | **unsigned** | **unsigned** |
| `StartMenu.dll` | **unsigned** | **unsigned** |
| `nsDialogs.dll` | **unsigned** | **unsigned** |

NSIS extracts these to `$PLUGINSDIR` at install time and runs them from there. An unsigned DLL appearing in a temp directory and being loaded by an installer is a well known false positive trigger, and it is the exact shape reported in [tauri-apps/tauri#11673](https://github.com/tauri-apps/tauri/issues/11673), where signing the plugins stopped Defender blocking, and in [tauri-apps/nsis-tauri-utils#37](https://github.com/tauri-apps/nsis-tauri-utils/issues/37).

## Why it happens

This is not a misconfiguration on our side. `tauri-bundler` already does the work and then discards it.

In `crates/tauri-bundler/src/bundle/windows/nsis/mod.rs`, when a signing identity is configured the bundler:

1. copies `Plugins/x86-unicode` aside so it does not modify the system install,
2. signs all five files listed in `NSIS_PLUGIN_FILES`, which is exactly `NSISdl.dll`, `StartMenu.dll`, `System.dll`, `nsDialogs.dll` and `additional/nsis_tauri_utils.dll`,
3. exports the copy's path to `makensis` as the `NSISPLUGINS` environment variable.

Nothing consumes it. No NSIS template, upstream or ours, references `$%NSISPLUGINS%`. The only plugin directory added is `ADDITIONALPLUGINSPATH`, and that points at the copy's `additional` subdirectory, which contains exactly one file. So `nsis_tauri_utils.dll` resolves from the signed copy and the other four fall back to the default, unsigned plugin directory.

That predicts precisely the signed and unsigned split measured in both shipped bundles.

## The fix

Three lines in our template, guarded because `NSISPLUGINS` is only set when signing is configured:

```nsis
!if "$%NSISPLUGINS%" != ""
  !addplugindir "$%NSISPLUGINS%\x86-unicode"
!endif
```

Plus `assert-bundle-signed.ps1`, wired into the Windows release leg: it unpacks each bundle and fails listing every unsigned executable rather than stopping at the first, so one run gives the whole list.

## Verified

Tested on `windows-latest` with a minimal NSIS script and a self signed certificate, which isolates the variable properly, no Rust and no frontend:

| case | expectation | result |
|---|---|---|
| `NSISPLUGINS` set, with this fix | embedded plugins come from the signed copy | `System.dll` and `nsDialogs.dll` embed with `signer='CN=NSIS Plugin Signing Test'` |
| `NSISPLUGINS` unset | still compiles, unsigned builds unaffected | compiles clean, `System.dll -> status=NotSigned` |

The second case matters: without the guard this would break every local and unsigned build.

A full end to end run is also in flight on a real Tauri build with all of this applied, checking the four DLLs come out signed and the bundle still installs and launches. I will follow up with the result.

## Notes

This is worth reporting upstream as well. Any Tauri app that signs its Windows installer currently ships four unsigned plugin DLLs, and the signing work is already being done and thrown away.

Stacked on #7813 because both touch `release-desktop.yml`. Merge that first.


## Update: the bundled install script is now signed too

Same problem, different file. `install.ps1` ships as a Tauri `bundle.resources` entry, lands on disk at install, and is the first thing the app executes on first run, but the bundler never signs resources and the gate only looked at PE extensions. So the release could pass a gate named "no unsigned file ships" while shipping exactly that.

Two halves, and they have to land together or the gate fails the release:

- a step that signs `install.ps1` with the existing `sign-with-trusted-signing.ps1` before the bundler packs it, asserting the result is `Valid`
- `.ps1` and `.psm1` added to the checked extension set

Checked on a `windows-latest` runner rather than assumed: `signtool` signs a `.ps1` (exit 0, `Successfully signed`, signer subject readable via `Get-AuthenticodeSignature`), and `trusted-signing-cli` lists `ps1` among its supported types and does not filter by extension by default.

The signature is an appended comment block and is applied in CI only, so the repo copy served for `irm https://unsloth.ai/install.ps1 | iex` is untouched and its behaviour is unchanged.

`install.sh` stays out of the checked set: Authenticode does not cover shell scripts, so requiring it would be a false failure.
