### PR TITLE
Embed the WebView2 bootstrapper instead of downloading it at install time

### DIFF
--- a/studio/src-tauri/tauri.conf.json
+++ b/studio/src-tauri/tauri.conf.json
@@ -69,6 +69,10 @@
       "icons/icon.icns"
     ],
     "windows": {
+      "webviewInstallMode": {
+        "type": "embedBootstrapper",
+        "silent": true
+      },
       "nsis": {
         "installerHooks": "./windows/hooks.nsh",
         "template": "./windows/installer.nsi",


### PR DESCRIPTION
## What this changes

`bundle.windows.webviewInstallMode` is currently Tauri's default, `downloadBootstrapper`. This switches it to `embedBootstrapper`.

## Why

With the default, when WebView2 is missing the installer does this (`studio/src-tauri/windows/installer.nsi`):

```nsis
NSISdl::download "https://go.microsoft.com/fwlink/p/?LinkId=2124703" "$TEMP\MicrosoftEdgeWebview2Setup.exe"
...
ExecWait "$6 ${WEBVIEW2INSTALLERARGS} /install" $1
```

Fetch an executable from the internet, then run it silently. That is the most dropper shaped behaviour in the bundle, and it is a heuristic cost paid on every release regardless of whether the download ever happens.

`embedBootstrapper` ships the bootstrapper inside the installer instead, for about 1.8MB. Whatever downloading remains is done by a Microsoft signed binary rather than by our NSIS stub.

`offlineInstaller` would remove the network requirement entirely, but it costs about 127MB, which would also push the bundle past the 50MB cap on Microsoft false positive submissions.

## Scope

The registry check ahead of it is unchanged:

```nsis
ReadRegStr $4 HKLM "SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\${WEBVIEW2APPGUID}" "pv"
${If} $4 == ""
```

WebView2 ships preinstalled on Windows 11 and was rolled out to Windows 10, so on the large majority of machines none of this path runs at all. This is about the fallback.

## Honest framing

This is hardening, not a fix for a specific report. The behaviour is present in both `0.1.51-beta` and `0.1.512-beta`, so it does not explain any difference between them, and I have no measurement showing it flips a scanner verdict. It removes a download and execute step we do not need to own, and 1.8MB is a fair price for that.
