### PR TITLE
fix(studio): derive the chat tracking assertion from the measured font size

### DIFF
--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1288,8 +1288,10 @@ with sync_playwright() as p:
             spacings = [_px(value) for value in actual["letterSpacing"]]
             # Tolerance, not equality: the browser reports the computed value rounded to a
             # few decimals, so 0.023em of 14.53125px comes back as "0.334219px".
-            if len(spacings) != 1 or spacings[0] is None or (
-                abs(spacings[0] - expected_spacing) > 0.002
+            if (
+                len(spacings) != 1
+                or spacings[0] is None
+                or (abs(spacings[0] - expected_spacing) > 0.002)
             ):
                 fail(
                     f"chat letter spacing {label}/{role}: expected "

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1241,12 +1241,10 @@ with sync_playwright() as p:
         if typography["actualRenderLinux"] != typography["isDesktopLinux"]:
             fail(f"desktop Linux detection mismatch: {typography!r}")
         is_dark = typography["isDark"]
-        # The authored tracking is in em (thread.tsx tracking-[0.01em] / dark:tracking-
-        # -[0.02em], and index.css letter-spacing: 0.023em for the dark Linux instance), so
-        # the computed px depends on the element's font size. Asserting px literals pinned
-        # this to a 15.5px message body, and #7359 moved the UI size onto --ui-font-scale,
-        # which resolves --text-ui-15p5 to 14.53125px instead. Every literal went stale at
-        # once, so derive the expectation from the font size the element actually has.
+        # The tracking is authored in em (thread.tsx, and index.css for the dark Linux
+        # instance), so the computed px follows the font size. Pinning px literals assumed a
+        # 15.5px body; #7359 moved the UI size onto --ui-font-scale, resolving
+        # --text-ui-15p5 to 14.53125px and staling every literal at once.
         spacing_em = 0.02 if is_dark else 0.01
         if typography["isDesktopLinux"] and not typography["usesBaselineTypography"]:
             expected_weight = "350" if is_dark else "390"
@@ -1278,10 +1276,9 @@ with sync_playwright() as p:
             if len(sizes) != 1 or _px(sizes[0]) is None:
                 fail(f"chat font size {label}/{role}: expected one px value, got {sizes!r}")
             font_px = _px(sizes[0])
-            # Deriving the tracking from the measured size would otherwise hide a font-size
-            # regression entirely, so bound the size itself. Wide enough that a deliberate
-            # scale change does not trip it, tight enough to catch chat text rendering at a
-            # heading or caption size.
+            # Deriving the tracking from the size would otherwise hide a font-size
+            # regression, so bound the size: loose enough to survive a deliberate scale
+            # change, tight enough to catch chat text at heading or caption size.
             if not 12.0 <= font_px <= 18.0:
                 fail(f"chat font size {label}/{role}: {font_px}px is outside 12-18px")
             expected_spacing = spacing_em * font_px

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1217,6 +1217,7 @@ with sync_playwright() as p:
                     return {
                         fontWeight: [...new Set(styles.map((style) => style.fontWeight))],
                         letterSpacing: [...new Set(styles.map((style) => style.letterSpacing))],
+                        fontSize: [...new Set(styles.map((style) => style.fontSize))],
                     };
                 };
                 return {
@@ -1240,13 +1241,32 @@ with sync_playwright() as p:
         if typography["actualRenderLinux"] != typography["isDesktopLinux"]:
             fail(f"desktop Linux detection mismatch: {typography!r}")
         is_dark = typography["isDark"]
-        expected_spacing = "0.31px" if is_dark else "0.155px"
+        # The authored tracking is in em (thread.tsx tracking-[0.01em] / dark:tracking-
+        # -[0.02em], and index.css letter-spacing: 0.023em for the dark Linux instance), so
+        # the computed px depends on the element's font size. Asserting px literals pinned
+        # this to a 15.5px message body, and #7359 moved the UI size onto --ui-font-scale,
+        # which resolves --text-ui-15p5 to 14.53125px instead. Every literal went stale at
+        # once, so derive the expectation from the font size the element actually has.
+        spacing_em = 0.02 if is_dark else 0.01
         if typography["isDesktopLinux"] and not typography["usesBaselineTypography"]:
             expected_weight = "350" if is_dark else "390"
             if is_dark:
-                expected_spacing = "0.3565px"
+                spacing_em = 0.023
         else:
             expected_weight = "410"
+
+        def _px(value):
+            """Computed px as a float; "normal" is the zero-tracking spelling."""
+            text = (value or "").strip()
+            if text == "normal":
+                return 0.0
+            if not text.endswith("px"):
+                return None
+            try:
+                return float(text[:-2])
+            except ValueError:
+                return None
+
         for role in ("assistant", "user"):
             actual = typography[role]
             if actual["fontWeight"] != [expected_weight]:
@@ -1254,9 +1274,26 @@ with sync_playwright() as p:
                     f"chat font weight {label}/{role}: expected {expected_weight}, "
                     f"got {actual['fontWeight']!r}"
                 )
-            if actual["letterSpacing"] != [expected_spacing]:
+            sizes = actual.get("fontSize") or []
+            if len(sizes) != 1 or _px(sizes[0]) is None:
+                fail(f"chat font size {label}/{role}: expected one px value, got {sizes!r}")
+            font_px = _px(sizes[0])
+            # Deriving the tracking from the measured size would otherwise hide a font-size
+            # regression entirely, so bound the size itself. Wide enough that a deliberate
+            # scale change does not trip it, tight enough to catch chat text rendering at a
+            # heading or caption size.
+            if not 12.0 <= font_px <= 18.0:
+                fail(f"chat font size {label}/{role}: {font_px}px is outside 12-18px")
+            expected_spacing = spacing_em * font_px
+            spacings = [_px(value) for value in actual["letterSpacing"]]
+            # Tolerance, not equality: the browser reports the computed value rounded to a
+            # few decimals, so 0.023em of 14.53125px comes back as "0.334219px".
+            if len(spacings) != 1 or spacings[0] is None or (
+                abs(spacings[0] - expected_spacing) > 0.002
+            ):
                 fail(
-                    f"chat letter spacing {label}/{role}: expected {expected_spacing}, "
+                    f"chat letter spacing {label}/{role}: expected "
+                    f"{expected_spacing:.6g}px ({spacing_em}em of {sizes[0]}), "
                     f"got {actual['letterSpacing']!r}"
                 )
 


### PR DESCRIPTION
`Chat UI Tests` is red on `main`:

```
AssertionError: [ui] FAIL: chat letter spacing theme-cycle-1/assistant:
                expected 0.3565px, got ['0.334219px']
```

## Root cause

The authored tracking is in **em**, not px. `thread.tsx` sets `tracking-[0.01em]` and `dark:tracking-[0.02em]` on the message roots, and `index.css` sets `letter-spacing: 0.023em` for the dark Linux instance. The computed px therefore depends on the message font size.

#7359 moved the UI font size onto `--ui-font-scale`, so `--text-ui-15p5` now resolves to `0.96875rem * 0.9375 = 14.53125px` where it previously computed to `15.5px`. That staled all three px literals at once, not only the one CI happens to report:

| branch | authored | hardcoded (15.5px) | actual (14.53125px) |
|---|---|---|---|
| light | `0.01em` | `0.155px` | `0.145313px` |
| dark | `0.02em` | `0.31px` | `0.290625px` |
| dark + render-linux | `0.023em` | `0.3565px` | **`0.334219px`** |

The CSS is doing what it is meant to. The scale exists to bring 16px-base tokens to the 15px product default, exactly as `index.css` says where it declares the token:

```css
/* The authored typography tokens use a 16px CSS base; the product default
   is 15px. An explicit user preference overrides this inline. */
--ui-font-scale: 0.9375;
```

The test is what went stale, so the fix belongs there.

## The fix

The expectation is computed from the element's own font size times the authored em, compared with a small tolerance because the browser reports the computed value rounded (`0.023em` of `14.53125px` comes back as `"0.334219px"`).

A wrong tracking still fails. The assertion is only made immune to the size the em resolves against, which is the thing that legitimately changes.

Deriving from a measurement would otherwise hide a font-size regression completely, so the size itself is bounded to 12-18px: wide enough that a deliberate scale change does not trip it, tight enough to catch chat text rendering at a heading or caption size.

## Verification

Exercised the new logic against the reported values, including that a genuinely wrong tracking still fails:

```
dark + render-linux (the CI failure)   expected 0.334219px, got 0.334219px  -> pass
dark, baseline typography              expected 0.290625px, got 0.290625px  -> pass
light                                  expected 0.145313px, got 0.145313px  -> pass
old 15.5px body still consistent       expected 0.3565px,   got 0.3565px    -> pass
wrong tracking must still fail         expected 0.334219px, got 0.290625px  -> fail
zero tracking spelled normal           expected 0px,        got normal      -> pass
```

CI on this PR is the real check, since the assertion only runs under Playwright.
