### PR TITLE
Reduce the Windows false positive surface: no Bypass/Hidden PowerShell, no in-process remote script, complete VERSIONINFO

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -20,9 +20,9 @@ function Install-UnslothStudio {
     $ErrorActionPreference = "Stop"
     $script:UnslothVerbose = ($env:UNSLOTH_VERBOSE -eq "1")
 
-    # Same fix as studio/setup.ps1, for the same reason. This script also runs
-    # astral's uv installer in-process (Invoke-Expression, below), and that
-    # installer calls Get-ExecutionPolicy out of Microsoft.PowerShell.Security.
+    # Same fix as studio/setup.ps1, for the same reason. This script also calls
+    # Expand-Archive (Microsoft.PowerShell.Archive) and Get-ExecutionPolicy
+    # (Microsoft.PowerShell.Security), both of which resolve via PSModulePath.
     # The desktop app reaches here as Tauri -> Rust -> powershell.exe
     # (studio/src-tauri/src/install.rs), and PowerShell only rewrites
     # PSModulePath for a direct pwsh -> powershell.exe hop, so the Rust process
@@ -1607,6 +1607,91 @@ exit 0
         }
     }
 
+    # Fallback for hosts without winget. Does what astral's install.ps1 does --
+    # same archive, destination and user-PATH prepend -- but the only thing
+    # fetched is a data file with a pinned SHA-256, never script text run
+    # in-process, which is what AMSI and cloud ML scanners score hardest.
+    # Bumping $UvPinnedVersion means bumping all three hashes with it:
+    #   curl -sL https://github.com/astral-sh/uv/releases/download/<ver>/uv-<arch>-pc-windows-msvc.zip.sha256
+    $UvPinnedVersion = "0.12.1"
+    $UvPinnedAssets = @{
+        "x86_64" = @{ Asset = "uv-x86_64-pc-windows-msvc.zip";  Sha256 = "8FCB0CB46E1229065E344758980924E569BEF5882EF45F46FADA8FB24E06B74A" }
+        "arm64"  = @{ Asset = "uv-aarch64-pc-windows-msvc.zip"; Sha256 = "9BC7C18E616230FA2DC6FB24BC3AFDE18A95C2B5C9433DE747E9502C66041568" }
+        "x86"    = @{ Asset = "uv-i686-pc-windows-msvc.zip";    Sha256 = "9B51C33D307A8AB9E9DFD88D4AE1491761F63DE0BFFA3CEC96BEC536491C9B97" }
+    }
+
+    function Install-UvFromRelease {
+        $arch = Get-HostMachineArch
+        if (-not $UvPinnedAssets.ContainsKey($arch)) {
+            substep "No uv build is published for this architecture ($arch)." "Yellow"
+            return $false
+        }
+        $asset  = $UvPinnedAssets[$arch].Asset
+        $wanted = $UvPinnedAssets[$arch].Sha256
+
+        # Same destination priority as astral's installer, so an existing uv is
+        # replaced in place and the PATH probe further below still finds it.
+        $destDir = $null
+        foreach ($candidate in @($env:UV_INSTALL_DIR, $env:UV_UNMANAGED_INSTALL, $env:XDG_BIN_HOME)) {
+            if ($candidate) { $destDir = $candidate; break }
+        }
+        if (-not $destDir -and $env:XDG_DATA_HOME) { $destDir = Join-Path $env:XDG_DATA_HOME "../bin" }
+        if (-not $destDir) {
+            $userHome = if ($env:USERPROFILE) { $env:USERPROFILE } else { $HOME }
+            if (-not $userHome) {
+                substep "Could not determine a home directory to install uv into." "Yellow"
+                return $false
+            }
+            $destDir = Join-Path $userHome ".local\bin"
+        }
+
+        $work = Join-Path ([System.IO.Path]::GetTempPath()) ("unsloth-uv-" + [guid]::NewGuid().ToString('N').Substring(0, 8))
+        $zip  = Join-Path $work $asset
+        try {
+            [System.IO.Directory]::CreateDirectory($work) | Out-Null
+            substep "downloading uv $UvPinnedVersion ($arch) from github.com/astral-sh/uv..." "Yellow"
+            try {
+                Invoke-WebRequest -UseBasicParsing -OutFile $zip `
+                    -Uri "https://github.com/astral-sh/uv/releases/download/$UvPinnedVersion/$asset"
+            } catch {
+                substep "uv download failed: $($_.Exception.Message)" "Yellow"
+                return $false
+            }
+
+            $actual = (Get-FileHash -LiteralPath $zip -Algorithm SHA256).Hash
+            if ($actual -ne $wanted) {
+                substep "uv download failed checksum verification -- discarding it." "Red"
+                substep "expected $wanted, got $actual" "Red"
+                return $false
+            }
+
+            # The Windows archives are flat: uv.exe, uvx.exe, uvw.exe at the root.
+            Expand-Archive -LiteralPath $zip -DestinationPath $work -Force
+            [System.IO.Directory]::CreateDirectory($destDir) | Out-Null
+            $haveUv = $false
+            foreach ($exe in @("uv.exe", "uvx.exe", "uvw.exe")) {
+                $src = Join-Path $work $exe
+                if (Test-Path -LiteralPath $src) {
+                    Copy-Item -LiteralPath $src -Destination (Join-Path $destDir $exe) -Force
+                    if ($exe -eq "uv.exe") { $haveUv = $true }
+                }
+            }
+            if (-not $haveUv) {
+                substep "uv.exe was not present in $asset." "Yellow"
+                return $false
+            }
+        } finally {
+            Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue
+        }
+
+        # Same PATH treatment and opt-out variable astral's installer uses.
+        if (-not $env:UV_NO_MODIFY_PATH) {
+            Add-ToUserPath -Directory $destDir -Position Prepend | Out-Null
+        }
+        $env:PATH = "$destDir;$env:PATH"
+        return $true
+    }
+
     if (-not (Test-UvVersionOk)) {
         if (Get-Command uv -ErrorAction SilentlyContinue) {
             substep "updating uv package manager..."
@@ -1623,13 +1708,12 @@ exit 0
             $ErrorActionPreference = $prevEAP
             Refresh-SessionPath
         }
-        # Fallback: if winget is unavailable or didn't put uv on PATH,
-        # use Astral's official PowerShell installer. This is the only
-        # supported path on hosts without winget (Windows ARM64 runners,
-        # corporate machines without the Store, etc.).
+        # Fallback: if winget is unavailable or didn't put uv on PATH, install
+        # the pinned uv release directly. This is the only supported path on
+        # hosts without winget (Windows ARM64 runners, corporate machines
+        # without the Store, etc.).
         if (-not (Test-UvVersionOk)) {
-            substep "installing uv via https://astral.sh/uv/install.ps1..." "Yellow"
-            Invoke-Expression (Invoke-RestMethod -Uri "https://astral.sh/uv/install.ps1")
+            Install-UvFromRelease | Out-Null
             Refresh-SessionPath
         }
     }

--- a/install.ps1
+++ b/install.ps1
@@ -1645,18 +1645,35 @@ exit 0
             $destDir = Join-Path $userHome ".local\bin"
         }
 
+        # Same mirrors and precedence astral's installer uses. Each serves the
+        # identical release asset, so the pinned hash below holds across all of
+        # them. UV_DOWNLOAD_URL is deliberately not honoured: it points at an
+        # arbitrary version, which the pin would then correctly reject.
+        $uvBase = if ($env:UV_INSTALLER_GHE_BASE_URL) {
+            @("$($env:UV_INSTALLER_GHE_BASE_URL.TrimEnd('/'))/astral-sh/uv/releases/download/$UvPinnedVersion")
+        } elseif ($env:UV_INSTALLER_GITHUB_BASE_URL) {
+            @("$($env:UV_INSTALLER_GITHUB_BASE_URL.TrimEnd('/'))/astral-sh/uv/releases/download/$UvPinnedVersion")
+        } else {
+            @("https://releases.astral.sh/github/uv/releases/download/$UvPinnedVersion",
+              "https://github.com/astral-sh/uv/releases/download/$UvPinnedVersion")
+        }
+
         $work = Join-Path ([System.IO.Path]::GetTempPath()) ("unsloth-uv-" + [guid]::NewGuid().ToString('N').Substring(0, 8))
         $zip  = Join-Path $work $asset
         try {
             [System.IO.Directory]::CreateDirectory($work) | Out-Null
-            substep "downloading uv $UvPinnedVersion ($arch) from github.com/astral-sh/uv..." "Yellow"
-            try {
-                Invoke-WebRequest -UseBasicParsing -OutFile $zip `
-                    -Uri "https://github.com/astral-sh/uv/releases/download/$UvPinnedVersion/$asset"
-            } catch {
-                substep "uv download failed: $($_.Exception.Message)" "Yellow"
-                return $false
+            $downloaded = $false
+            foreach ($base in $uvBase) {
+                substep "downloading uv $UvPinnedVersion ($arch) from $base..." "Yellow"
+                try {
+                    Invoke-WebRequest -UseBasicParsing -OutFile $zip -Uri "$base/$asset"
+                    $downloaded = $true
+                    break
+                } catch {
+                    substep "uv download failed: $($_.Exception.Message)" "Yellow"
+                }
             }
+            if (-not $downloaded) { return $false }
 
             $actual = (Get-FileHash -LiteralPath $zip -Algorithm SHA256).Hash
             if ($actual -ne $wanted) {
@@ -1684,11 +1701,15 @@ exit 0
             Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue
         }
 
-        # Same PATH treatment and opt-out variable astral's installer uses.
-        if (-not $env:UV_NO_MODIFY_PATH) {
+        # Same PATH treatment and opt-outs astral's installer uses: an unmanaged
+        # install forces no-modify-path there, so it must here too.
+        if (-not $env:UV_NO_MODIFY_PATH -and -not $env:UV_UNMANAGED_INSTALL) {
             Add-ToUserPath -Directory $destDir -Position Prepend | Out-Null
         }
         $env:PATH = "$destDir;$env:PATH"
+        # Refresh-SessionPath rebuilds PATH machine-first and drops that prepend,
+        # so record where uv actually landed for the probe below.
+        $script:UvInstallDestDir = $destDir
         return $true
     }
 
@@ -1722,7 +1743,7 @@ exit 0
     # venv, Scoop/pipx shim). Prefer a just-installed uv from a known location.
     if (-not (Test-UvVersionOk)) {
         $origPath = $env:PATH
-        foreach ($d in @($env:UV_INSTALL_DIR, $env:XDG_BIN_HOME,
+        foreach ($d in @($script:UvInstallDestDir, $env:UV_INSTALL_DIR, $env:XDG_BIN_HOME,
                          (Join-Path $env:USERPROFILE ".local\bin"),
                          (Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links"))) {
             if ($d -and (Test-Path $d)) {

--- a/studio/src-tauri/src/install.rs
+++ b/studio/src-tauri/src/install.rs
@@ -324,15 +324,17 @@ fn spawn_script(
 
     #[cfg(windows)]
     let mut cmd = Command::new("powershell.exe");
+    // No -WindowStyle Hidden, no -ExecutionPolicy Bypass: CREATE_NO_WINDOW below
+    // already suppresses the console, and NSIS writes resources without a
+    // mark-of-the-web so RemoteSigned loads the script. The pair changes nothing
+    // here and is the command line Microsoft ships as a detection test.
     #[cfg(windows)]
     cmd.args([
         "-NoLogo",
         "-NoProfile",
         "-NonInteractive",
-        "-WindowStyle",
-        "Hidden",
         "-ExecutionPolicy",
-        "Bypass",
+        "RemoteSigned",
         "-File",
     ])
     .arg(script)

--- a/studio/src-tauri/windows/installer.nsi
+++ b/studio/src-tauri/windows/installer.nsi
@@ -102,6 +102,12 @@ InstallDir "${PLACEHOLDER_INSTALL_DIR}"
 VIProductVersion "${VERSIONWITHBUILD}"
 VIAddVersionKey "ProductName" "${PRODUCTNAME}"
 VIAddVersionKey "FileDescription" "${PRODUCTNAME}"
+; Not in upstream's template. ${MANUFACTURER} is bundle.publisher and is already
+; written as the Add/Remove Programs Publisher value, so these cannot be empty
+; and cannot disagree with it. An installer with no CompanyName reads as
+; unattributed to reputation checks.
+VIAddVersionKey "CompanyName" "${MANUFACTURER}"
+VIAddVersionKey "InternalName" "${INSTALLIDENTITY}"
 VIAddVersionKey "LegalCopyright" "${COPYRIGHT}"
 VIAddVersionKey "FileVersion" "${VERSION}"
 VIAddVersionKey "ProductVersion" "${VERSION}"


### PR DESCRIPTION
Follow-up to #7813, #7819 and #7820. Same goal: stop handing Defender's cloud model reasons to score a fresh, low prevalence installer as a dropper. None of this changes what the product does.

### 1. Stop launching the install script with `-WindowStyle Hidden -ExecutionPolicy Bypass`

`studio/src-tauri/src/install.rs` spawns:

```
powershell.exe -NoLogo -NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File <bundled install.ps1> --tauri
```

That flag pair is the single highest scoring edge in the product for behaviour monitoring, because it is a literal token match against published detection logic. Microsoft's own Defender for Endpoint onboarding test is `powershell.exe -NoExit -ExecutionPolicy Bypass -WindowStyle Hidden`, shipped as a command line that should raise an alert. A low reputation parent EXE spawning it is exactly the chain that gets scored.

Both flags are dead weight here:

- `CREATE_NO_WINDOW` is already set a few lines below and both handles are piped, so no console exists to hide.
- NSIS writes bundle resources with plain file APIs and does not attach a `Zone.Identifier` stream, so the extracted `install.ps1` has no mark of the web and loads under `RemoteSigned`. Where Group Policy sets the execution policy, the `-ExecutionPolicy` parameter is overridden regardless of its value, so `Bypass` was buying nothing there either.

`RemoteSigned` is the ceiling, not `AllSigned`: with `-NonInteractive`, `AllSigned` fails outright rather than prompting when the publisher is not in the machine's Trusted Publishers store.

### 2. Install uv from a pinned, checksum verified archive instead of `iex (irm ...)`

`install.ps1` fell back to:

```powershell
Invoke-Expression (Invoke-RestMethod -Uri "https://astral.sh/uv/install.ps1")
```

Fetching a script and evaluating it in process is the construct AMSI is instrumented for, and it is scored on both the copy inside the bundle and the copy served from unsloth.ai for `irm https://unsloth.ai/install.ps1 | iex`.

The replacement performs what Astral's installer performs: the same archive, the same destination priority (`UV_INSTALL_DIR`, `UV_UNMANAGED_INSTALL`, `XDG_BIN_HOME`, `XDG_DATA_HOME/../bin`, then `%USERPROFILE%\.local\bin`), the same user PATH prepend, and the same `UV_NO_MODIFY_PATH` opt out. The only thing fetched is a data file whose SHA-256 is pinned in the script, and nothing fetched is interpreted as code.

Pinned rather than resolved at runtime on purpose. Fetching the `.sha256` sidecar at install time is close to worthless as a supply chain control, since it comes from the same host as the archive. A hardcoded digest is the only form of verification that means anything. Bumping `$UvPinnedVersion` means bumping all three hashes with it, and the pinned version must stay at or above `$UvMinVersion`; the comment says so. This is a fallback path, reached only when winget is unavailable or did not put uv on PATH.

One behaviour change worth naming: no `uv-receipt.json` is written, so `uv self update` reports that self updates are disabled. That already happens on the winget path today, and `install.ps1` manages uv's version itself.

### 3. Fill in the installer's `CompanyName` and `InternalName`

Upstream Tauri's NSIS template sets `ProductName`, `FileDescription`, `LegalCopyright`, `FileVersion` and `ProductVersion` and nothing else, so every Tauri NSIS installer ships with an empty `CompanyName`. `${MANUFACTURER}` is `bundle.publisher` and is already written as the Add/Remove Programs `Publisher` value, so these cannot be empty and cannot disagree with what the user sees.

I want to be straight about the evidence here: it is thin. The open static PE ML feature formats do not extract version resource strings at all, so this will not by itself flip a cloud verdict. It costs one line, it is what every reputable publisher's installer looks like, and an unattributed binary is a stated reputation signal.

`OriginalFilename` is deliberately not added. `${OUTFILE}` expands to the literal `nsis-output.exe`, because tauri-bundler hardcodes that and renames afterwards, and the release workflow renames the asset a second time before publication. Any value we could write would match nothing the user downloads, and a mismatched `OriginalFilename` is itself a weak negative signal in some engines.

### Validation

- `install.ps1` parses clean: `[System.Management.Automation.Language.Parser]::ParseFile` reports 0 errors over 17130 tokens.
- All three pinned uv digests re-verified against Astral's published `.sha256` files for 0.12.1.
- The `install.rs` change is checked end to end on a Windows runner: the extracted `install.ps1` is asserted to carry no `Zone.Identifier` stream, and unmarked and mark of the web stamped control scripts confirm that the stream is what `RemoteSigned` blocks.
- `VIAddVersionKey` output is read back off the built installer with `(Get-Item ...).VersionInfo` and asserted non-empty.

### One narrow case worth naming, and why #7819 closes it

`RemoteSigned` only requires a signature for scripts in the Internet or Untrusted zone. `MyComputer`, `Intranet` and `Trusted` are all permitted unsigned, which is why the extracted `install.ps1` loads fine.

The one population where `Bypass` was doing real work is a machine hardened to the DISA STIG or CIS benchmark, both of which mandate `UNCAsIntranet = 0`, putting UNC paths in the Internet zone. If a user then picks a UNC or mapped network install directory on the NSIS directory page, `RemoteSigned` would block a script that `Bypass` would have run. That is narrow (it needs a network install path for a per-user WebView2 desktop app, which this installer does not support well for unrelated reasons), but it is not nothing.

It disappears entirely once #7819 lands, because that PR Authenticode signs the bundled `install.ps1` with the same Trusted Signing identity as the rest of the bundle, and a validly signed script satisfies `RemoteSigned` in any zone. **Merge #7819 first.**

For completeness on the other direction: Group Policy beats the `-ExecutionPolicy` parameter outright (`MachinePolicy`, `UserPolicy`, `Process`, `CurrentUser`, `LocalMachine`, first non-Undefined wins), so under an `AllSigned` or `Restricted` policy the old and new command lines behave identically. `Bypass` was never buying anything there.

### Not included

- Authenticode signing the bundled `install.ps1` and extending the #7819 gate to `.ps1`. Worth doing, but it depends on whether `trusted-signing-cli` accepts a non-PE subject interface package; that is being measured separately.
- Moving the Defender scan into a shared script so the nightly clean machine job runs the same one. That is a refactor of #7813 and belongs after it lands.
