### PR TITLE
Windows installer: prefer uv-managed Python over global winget installs

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1564,6 +1564,7 @@ exit 0
             Path = $PythonVersion
             Arch = "x86_64"
             ManagedByUv = $true
+            RequireManagedPython = $true
         }
     }
 
@@ -1931,7 +1932,11 @@ exit 0
     if (-not (Test-Path -LiteralPath $VenvPython)) {
         step "venv" "creating Python $($DetectedPython.Version) virtual environment"
         substep "$VenvDir"
-        $venvExit = Invoke-InstallCommand -Label "create virtual environment" { uv venv $VenvDir --python "$($DetectedPython.Path)" }
+        if ($DetectedPython.RequireManagedPython) {
+            $venvExit = Invoke-InstallCommand -Label "create virtual environment" { uv venv $VenvDir --managed-python --python "$($DetectedPython.Path)" }
+        } else {
+            $venvExit = Invoke-InstallCommand -Label "create virtual environment" { uv venv $VenvDir --python "$($DetectedPython.Path)" }
+        }
         if ($venvExit -ne 0) {
             Write-Host "[ERROR] Failed to create virtual environment (exit code $venvExit)" -ForegroundColor Red
             return (Exit-InstallFailure "Failed to create virtual environment (exit code $venvExit)" $venvExit)

--- a/install.ps1
+++ b/install.ps1
@@ -1491,103 +1491,6 @@ exit 0
         return (Find-CompatiblePython -X64Only)
     }
 
-    # ── Install Python if no compatible version (3.11-3.13) found ──
-    # Find-CompatiblePython returns @{ Version = "3.13"; Path = "C:\...\python.exe" } or $null.
-    Write-TauriLog "STEP" "Installing Python"
-    $DetectedPython = Find-CompatiblePython
-
-    if ($DetectedPython) {
-        step "python" "Python $($DetectedPython.Version) already installed"
-    }
-    if (-not $DetectedPython) {
-        substep "installing Python ${PythonVersion}..."
-        $pythonPackageId = "Python.Python.$PythonVersion"
-        $wingetExit = $null
-
-        if ($script:WingetAvailable) {
-            # --source winget avoids the msstore source, which can fail with
-            # cert-pinning error 0x8a15005e and abort the whole `winget install`
-            # (winget then demands --source). Python and uv both live in the
-            # winget source, so pinning it is correct and faster.
-            #
-            # Lower ErrorActionPreference so winget stderr (progress/warnings) is
-            # not a terminating error on PS 5.1 (native stderr is ErrorRecord).
-            $prevEAP = $ErrorActionPreference
-            $ErrorActionPreference = "Continue"
-            try {
-                winget install -e --id $pythonPackageId --source winget --accept-package-agreements --accept-source-agreements
-                $wingetExit = $LASTEXITCODE
-            } catch { $wingetExit = 1 }
-            $ErrorActionPreference = $prevEAP
-            Refresh-SessionPath
-
-            # Re-detect after install (PATH may have changed)
-            $DetectedPython = Find-CompatiblePython
-
-            if (-not $DetectedPython) {
-                # Python still not functional after winget -- force reinstall.
-                # This handles both real failures AND "already installed" codes where
-                # winget thinks Python is present but it's not actually on PATH
-                # (e.g. user partially uninstalled, or installed via a different method).
-                substep "Python not found on PATH after winget. Retrying with --force..." "Yellow"
-                $ErrorActionPreference = "Continue"
-                try {
-                    winget install -e --id $pythonPackageId --source winget --accept-package-agreements --accept-source-agreements --force
-                    $wingetExit = $LASTEXITCODE
-                } catch { $wingetExit = 1 }
-                $ErrorActionPreference = $prevEAP
-                Refresh-SessionPath
-                $DetectedPython = Find-CompatiblePython
-            }
-        }
-
-        # Fall back to python.org if winget is unavailable OR couldn't install a
-        # working Python (missing/broken winget, msstore cert errors --source
-        # winget can't fix). Keeps the install automatic instead of failing out.
-        if (-not $DetectedPython) {
-            if ($script:WingetAvailable) {
-                substep "winget could not install Python -- falling back to python.org..." "Yellow"
-            } else {
-                substep "winget is unavailable -- installing Python from python.org..." "Yellow"
-            }
-            $DetectedPython = Install-PythonFromPythonOrg
-        }
-
-        if (-not $DetectedPython) {
-            $exitNote = if ($null -ne $wingetExit) { " (winget exit code $wingetExit)" } else { "" }
-            Write-Host "[ERROR] Python installation failed$exitNote" -ForegroundColor Red
-            Write-Host "        Please install Python $PythonVersion manually from https://www.python.org/downloads/" -ForegroundColor Yellow
-            Write-Host "        Make sure to check 'Add Python to PATH' during installation." -ForegroundColor Yellow
-            Write-Host "        Then re-run this installer." -ForegroundColor Yellow
-            return (Exit-InstallFailure "Python installation failed")
-        }
-    }
-    # ── Windows on ARM: swap a native ARM64 interpreter for x64 ──
-    # pyarrow and hf-transfer publish no win_arm64 wheel, so an ARM64 Python source-builds
-    # both and fails deep into the run. Warn up front if x64 is unobtainable.
-    if ($DetectedPython -and (Get-HostMachineArch) -eq "arm64" -and $DetectedPython.Arch -ne "x86_64") {
-        substep "windows on arm: only a native ARM64 Python $($DetectedPython.Version) was found." "Yellow"
-        substep "pyarrow and hf-transfer publish no win_arm64 wheels, so installing x64 Python..." "Yellow"
-        $X64Python = Install-X64Python
-        if ($X64Python) {
-            $DetectedPython = $X64Python
-            step "python" "using x64 Python $($DetectedPython.Version) under emulation"
-        } else {
-            Write-Host "[WARN] Could not install an x64 Python on this ARM64 machine." -ForegroundColor Yellow
-            Write-Host "       Continuing with ARM64 Python $($DetectedPython.Version), but the install is likely to fail:" -ForegroundColor Yellow
-            Write-Host "       pyarrow (via datasets) and hf-transfer ship no win_arm64 wheels and will be" -ForegroundColor Yellow
-            Write-Host "       built from source, which needs CMake plus the MSVC and Rust toolchains." -ForegroundColor Yellow
-            Write-Host "       Fix: install x64 Python from https://www.python.org/downloads/windows/" -ForegroundColor Yellow
-            Write-Host "       (choose 'Windows installer (64-bit)', not ARM64), then re-run this installer." -ForegroundColor Yellow
-        }
-    }
-
-    $DiagPythonVersion = $PythonVersion
-    if ($DetectedPython) { $DiagPythonVersion = $DetectedPython.Version }
-    $InitialGpuBranch = "unknown"
-    if ($SkipTorch) { $InitialGpuBranch = "no_torch" }
-    Write-TauriDiag -GpuBranch $InitialGpuBranch -TorchIndexFamily "none" -PythonVersionForDiag $DiagPythonVersion
-
     # ── Install uv ──
     Write-TauriLog "STEP" "Installing uv package manager"
     $UvMinVersion = "0.8.16"
@@ -1654,6 +1557,119 @@ exit 0
         substep "Install it from https://docs.astral.sh/uv/" "Yellow"
         return (Exit-InstallFailure "uv could not be installed")
     }
+
+    function New-UvManagedPythonRequest {
+        return @{
+            Version = $PythonVersion
+            Path = $PythonVersion
+            Arch = "x86_64"
+            ManagedByUv = $true
+        }
+    }
+
+    # ── Resolve Python for the venv ──
+    # Prefer an existing standalone CPython 3.11-3.13. On normal Windows hosts, fall back
+    # to a uv-managed Python instead of mutating the user's global Python installation.
+    # Windows on ARM is the exception: keep the explicit x64 bootstrap because pyarrow and
+    # hf-transfer still need x64 wheels there.
+    Write-TauriLog "STEP" "Resolving Python"
+    $DetectedPython = Find-CompatiblePython
+
+    if ($DetectedPython) {
+        step "python" "Python $($DetectedPython.Version) already installed"
+    } elseif ((Get-HostMachineArch) -ne "arm64") {
+        $DetectedPython = New-UvManagedPythonRequest
+        step "python" "using uv-managed Python $($DetectedPython.Version)"
+        substep "no compatible system Python found; uv will download and manage it for this environment"
+    } else {
+        substep "installing x64 Python ${PythonVersion} for Windows on ARM..."
+        $pythonPackageId = "Python.Python.$PythonVersion"
+        $wingetExit = $null
+
+        if ($script:WingetAvailable) {
+            # --source winget avoids the msstore source, which can fail with
+            # cert-pinning error 0x8a15005e and abort the whole `winget install`
+            # (winget then demands --source). Python and uv both live in the
+            # winget source, so pinning it is correct and faster.
+            #
+            # Lower ErrorActionPreference so winget stderr (progress/warnings) is
+            # not a terminating error on PS 5.1 (native stderr is ErrorRecord).
+            $prevEAP = $ErrorActionPreference
+            $ErrorActionPreference = "Continue"
+            try {
+                winget install -e --id $pythonPackageId --source winget --architecture x64 --accept-package-agreements --accept-source-agreements
+                $wingetExit = $LASTEXITCODE
+            } catch { $wingetExit = 1 }
+            $ErrorActionPreference = $prevEAP
+            Refresh-SessionPath
+
+            # Re-detect after install (PATH may have changed)
+            $DetectedPython = Find-CompatiblePython
+
+            if (-not $DetectedPython) {
+                # Python still not functional after winget -- force reinstall.
+                # This handles both real failures AND "already installed" codes where
+                # winget thinks Python is present but it's not actually on PATH
+                # (e.g. user partially uninstalled, or installed via a different method).
+                substep "Python not found on PATH after winget. Retrying with --force..." "Yellow"
+                $ErrorActionPreference = "Continue"
+                try {
+                    winget install -e --id $pythonPackageId --source winget --architecture x64 --accept-package-agreements --accept-source-agreements --force
+                    $wingetExit = $LASTEXITCODE
+                } catch { $wingetExit = 1 }
+                $ErrorActionPreference = $prevEAP
+                Refresh-SessionPath
+                $DetectedPython = Find-CompatiblePython
+            }
+        }
+
+        # Fall back to python.org if winget is unavailable OR couldn't install a
+        # working x64 Python (missing/broken winget, msstore cert errors --source
+        # winget can't fix). ARM64 keeps this explicit bootstrap because the wheel
+        # set still materially differs by architecture.
+        if (-not $DetectedPython) {
+            if ($script:WingetAvailable) {
+                substep "winget could not install x64 Python -- falling back to python.org..." "Yellow"
+            } else {
+                substep "winget is unavailable -- installing x64 Python from python.org..." "Yellow"
+            }
+            $DetectedPython = Install-PythonFromPythonOrg -Arch "x86_64"
+        }
+
+        if (-not $DetectedPython) {
+            $exitNote = if ($null -ne $wingetExit) { " (winget exit code $wingetExit)" } else { "" }
+            Write-Host "[ERROR] Python installation failed$exitNote" -ForegroundColor Red
+            Write-Host "        Please install x64 Python $PythonVersion manually from https://www.python.org/downloads/windows/" -ForegroundColor Yellow
+            Write-Host "        Choose 'Windows installer (64-bit)', not ARM64, and check 'Add Python to PATH'." -ForegroundColor Yellow
+            Write-Host "        Then re-run this installer." -ForegroundColor Yellow
+            return (Exit-InstallFailure "Python installation failed")
+        }
+    }
+    # ── Windows on ARM: swap a native ARM64 interpreter for x64 ──
+    # pyarrow and hf-transfer publish no win_arm64 wheel, so an ARM64 Python source-builds
+    # both and fails deep into the run. Warn up front if x64 is unobtainable.
+    if ($DetectedPython -and -not $DetectedPython.ManagedByUv -and (Get-HostMachineArch) -eq "arm64" -and $DetectedPython.Arch -ne "x86_64") {
+        substep "windows on arm: only a native ARM64 Python $($DetectedPython.Version) was found." "Yellow"
+        substep "pyarrow and hf-transfer publish no win_arm64 wheels, so installing x64 Python..." "Yellow"
+        $X64Python = Install-X64Python
+        if ($X64Python) {
+            $DetectedPython = $X64Python
+            step "python" "using x64 Python $($DetectedPython.Version) under emulation"
+        } else {
+            Write-Host "[WARN] Could not install an x64 Python on this ARM64 machine." -ForegroundColor Yellow
+            Write-Host "       Continuing with ARM64 Python $($DetectedPython.Version), but the install is likely to fail:" -ForegroundColor Yellow
+            Write-Host "       pyarrow (via datasets) and hf-transfer ship no win_arm64 wheels and will be" -ForegroundColor Yellow
+            Write-Host "       built from source, which needs CMake plus the MSVC and Rust toolchains." -ForegroundColor Yellow
+            Write-Host "       Fix: install x64 Python from https://www.python.org/downloads/windows/" -ForegroundColor Yellow
+            Write-Host "       (choose 'Windows installer (64-bit)', not ARM64), then re-run this installer." -ForegroundColor Yellow
+        }
+    }
+
+    $DiagPythonVersion = $PythonVersion
+    if ($DetectedPython) { $DiagPythonVersion = $DetectedPython.Version }
+    $InitialGpuBranch = "unknown"
+    if ($SkipTorch) { $InitialGpuBranch = "no_torch" }
+    Write-TauriDiag -GpuBranch $InitialGpuBranch -TorchIndexFamily "none" -PythonVersionForDiag $DiagPythonVersion
 
     # When bytecode compilation is enabled, large installs can exceed uv's 60s
     # default on slow machines. Default to 180s, preserving overrides ("0" disables).

--- a/tests/python/test_windows_uv_managed_python.py
+++ b/tests/python/test_windows_uv_managed_python.py
@@ -68,7 +68,9 @@ def test_non_arm64_prefers_uv_managed_python_before_winget_bootstrap():
     non_arm64 = source.index('} elseif ((Get-HostMachineArch) -ne "arm64") {')
     managed = source.index("$DetectedPython = New-UvManagedPythonRequest")
     managed_flag = source.index("--managed-python --python")
-    venv_create = source.index('step "venv" "creating Python $($DetectedPython.Version) virtual environment"')
+    venv_create = source.index(
+        'step "venv" "creating Python $($DetectedPython.Version) virtual environment"'
+    )
     winget = source.index(
         "winget install -e --id $pythonPackageId --source winget --architecture x64"
     )
@@ -79,9 +81,7 @@ def test_non_arm64_prefers_uv_managed_python_before_winget_bootstrap():
         'substep "no compatible system Python found; uv will download and manage it for this environment"'
         in source
     )
-    assert (
-        'uv venv $VenvDir --managed-python --python "$($DetectedPython.Path)"' in source
-    )
+    assert 'uv venv $VenvDir --managed-python --python "$($DetectedPython.Path)"' in source
 
 
 def test_arm64_python_bootstrap_stays_x64_specific():

--- a/tests/python/test_windows_uv_managed_python.py
+++ b/tests/python/test_windows_uv_managed_python.py
@@ -52,22 +52,17 @@ $req = New-UvManagedPythonRequest
 $req | ConvertTo-Json -Compress
 """
     payload = json.loads(_run_powershell(shell, script))
-    assert payload == {
-        "Version": "3.13",
-        "Path": "3.13",
-        "Arch": "x86_64",
-        "ManagedByUv": True,
-    }
+    assert payload == {"Version": "3.13", "Path": "3.13", "Arch": "x86_64", "ManagedByUv": True}
 
 
 def test_non_arm64_prefers_uv_managed_python_before_winget_bootstrap():
     source = INSTALL_PS1.read_text(encoding = "utf-8")
     uv_step = source.index('Write-TauriLog "STEP" "Installing uv package manager"')
     helper = source.index("function New-UvManagedPythonRequest")
-    non_arm64 = source.index("} elseif ((Get-HostMachineArch) -ne \"arm64\") {")
+    non_arm64 = source.index('} elseif ((Get-HostMachineArch) -ne "arm64") {')
     managed = source.index("$DetectedPython = New-UvManagedPythonRequest")
     winget = source.index(
-        'winget install -e --id $pythonPackageId --source winget --architecture x64'
+        "winget install -e --id $pythonPackageId --source winget --architecture x64"
     )
 
     assert uv_step < helper < non_arm64 < managed < winget
@@ -80,8 +75,5 @@ def test_non_arm64_prefers_uv_managed_python_before_winget_bootstrap():
 
 def test_arm64_python_bootstrap_stays_x64_specific():
     source = INSTALL_PS1.read_text(encoding = "utf-8")
-    assert (
-        'winget install -e --id $pythonPackageId --source winget --architecture x64'
-        in source
-    )
+    assert "winget install -e --id $pythonPackageId --source winget --architecture x64" in source
     assert 'Install-PythonFromPythonOrg -Arch "x86_64"' in source

--- a/tests/python/test_windows_uv_managed_python.py
+++ b/tests/python/test_windows_uv_managed_python.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+"""Contracts for the Windows uv-managed Python fallback in install.ps1."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_PS1 = REPO_ROOT / "install.ps1"
+POWERSHELLS = [shell for shell in ("pwsh", "powershell") if shutil.which(shell)]
+
+
+def _extract(pattern: str, source: str) -> str:
+    match = re.search(pattern, source, flags = re.DOTALL)
+    assert match is not None, f"install.ps1 block not found: {pattern}"
+    return match.group(0)
+
+
+def _run_powershell(shell: str, script: str) -> str:
+    result = subprocess.run(
+        [shell, "-NoProfile", "-NonInteractive", "-Command", script],
+        check = True,
+        capture_output = True,
+        text = True,
+        env = os.environ.copy(),
+        timeout = 30,
+    )
+    return result.stdout.strip()
+
+
+@pytest.mark.skipif(not POWERSHELLS, reason = "PowerShell is unavailable")
+@pytest.mark.parametrize("shell", POWERSHELLS)
+def test_uv_managed_python_request_uses_requested_minor(shell: str):
+    source = INSTALL_PS1.read_text(encoding = "utf-8")
+    helper = _extract(r"    function New-UvManagedPythonRequest \{.*?\n    \}\n", source)
+
+    script = f"""
+$ErrorActionPreference = "Stop"
+$PythonVersion = "3.13"
+{helper}
+$req = New-UvManagedPythonRequest
+$req | ConvertTo-Json -Compress
+"""
+    payload = json.loads(_run_powershell(shell, script))
+    assert payload == {
+        "Version": "3.13",
+        "Path": "3.13",
+        "Arch": "x86_64",
+        "ManagedByUv": True,
+    }
+
+
+def test_non_arm64_prefers_uv_managed_python_before_winget_bootstrap():
+    source = INSTALL_PS1.read_text(encoding = "utf-8")
+    uv_step = source.index('Write-TauriLog "STEP" "Installing uv package manager"')
+    helper = source.index("function New-UvManagedPythonRequest")
+    non_arm64 = source.index("} elseif ((Get-HostMachineArch) -ne \"arm64\") {")
+    managed = source.index("$DetectedPython = New-UvManagedPythonRequest")
+    winget = source.index(
+        'winget install -e --id $pythonPackageId --source winget --architecture x64'
+    )
+
+    assert uv_step < helper < non_arm64 < managed < winget
+    assert 'step "python" "using uv-managed Python $($DetectedPython.Version)"' in source
+    assert (
+        'substep "no compatible system Python found; uv will download and manage it for this environment"'
+        in source
+    )
+
+
+def test_arm64_python_bootstrap_stays_x64_specific():
+    source = INSTALL_PS1.read_text(encoding = "utf-8")
+    assert (
+        'winget install -e --id $pythonPackageId --source winget --architecture x64'
+        in source
+    )
+    assert 'Install-PythonFromPythonOrg -Arch "x86_64"' in source

--- a/tests/python/test_windows_uv_managed_python.py
+++ b/tests/python/test_windows_uv_managed_python.py
@@ -52,7 +52,13 @@ $req = New-UvManagedPythonRequest
 $req | ConvertTo-Json -Compress
 """
     payload = json.loads(_run_powershell(shell, script))
-    assert payload == {"Version": "3.13", "Path": "3.13", "Arch": "x86_64", "ManagedByUv": True}
+    assert payload == {
+        "Version": "3.13",
+        "Path": "3.13",
+        "Arch": "x86_64",
+        "ManagedByUv": True,
+        "RequireManagedPython": True,
+    }
 
 
 def test_non_arm64_prefers_uv_managed_python_before_winget_bootstrap():
@@ -61,15 +67,20 @@ def test_non_arm64_prefers_uv_managed_python_before_winget_bootstrap():
     helper = source.index("function New-UvManagedPythonRequest")
     non_arm64 = source.index('} elseif ((Get-HostMachineArch) -ne "arm64") {')
     managed = source.index("$DetectedPython = New-UvManagedPythonRequest")
+    managed_flag = source.index("--managed-python --python")
+    venv_create = source.index('step "venv" "creating Python $($DetectedPython.Version) virtual environment"')
     winget = source.index(
         "winget install -e --id $pythonPackageId --source winget --architecture x64"
     )
 
-    assert uv_step < helper < non_arm64 < managed < winget
+    assert uv_step < helper < non_arm64 < managed < winget < venv_create < managed_flag
     assert 'step "python" "using uv-managed Python $($DetectedPython.Version)"' in source
     assert (
         'substep "no compatible system Python found; uv will download and manage it for this environment"'
         in source
+    )
+    assert (
+        'uv venv $VenvDir --managed-python --python "$($DetectedPython.Path)"' in source
     )
 
 


### PR DESCRIPTION
# Windows installer: prefer uv-managed Python over global winget installs

## Summary

This fixes the Windows installer behavior reported in #7802.

Before this change, `install.ps1` would bootstrap a global CPython install on Windows before creating the Unsloth Studio venv, even though the installer already depends on `uv` and `uv` can provision the interpreter needed for that environment.

After this change:

- `install.ps1` installs or updates `uv` first
- if a compatible standalone system Python (`3.11` to `3.13`) already exists, it is reused
- if no compatible system Python exists on a normal Windows host, the installer now asks `uv` to manage the Python used for the venv instead of installing a global Python via `winget`
- the uv-managed fallback is explicitly `--managed-python`, so `uv` cannot silently reuse a same-minor system interpreter such as Conda
- Windows on ARM keeps the explicit x64 bootstrap path because the wheel availability constraints there are still architecture-sensitive (`pyarrow` / `hf-transfer`)

## Why

The previous flow was doing the wrong kind of mutation on Windows:

- it changed the user’s global Python installation state
- it used `winget` to install Python even though the environment is created with `uv`
- it produced exactly the behavior called out in #7802: detect `winget`, install Python globally, then use `uv` only for the venv

That is unnecessary on standard Windows setups, and it is a worse UX than letting `uv` manage the interpreter needed for the app environment.

## Files changed

- `install.ps1`
  - moved `uv` setup ahead of Python resolution
  - added a uv-managed Python fallback for non-ARM64 Windows
  - made that fallback explicitly managed-only with `uv venv --managed-python --python ...`
  - restricted the explicit `winget` / `python.org` Python bootstrap path to Windows ARM64 / x64-specific fallback cases
- `tests/python/test_windows_uv_managed_python.py`
  - added regression coverage for the new fallback behavior
  - pinned the control-flow ordering so non-ARM64 Windows resolves through `uv` before any global Python bootstrap path

## Validation

Ran targeted Windows installer tests:

```powershell
uvx --from pytest pytest tests\python\test_windows_uv_managed_python.py tests\python\test_windows_arm64_python_choice.py tests\python\test_windows_python_venv_hardening.py -k "not powershell"
```

Result:

- passed: new uv-managed fallback tests
- passed: existing ARM64 interpreter-choice coverage
- passed: existing managed-venv hardening coverage for the touched path

Also manually verified the new PowerShell helper returns the expected uv-managed Python request object.

## Notes

There is still an existing environment-specific failure in the legacy `powershell` variant of:

- `tests/python/test_windows_python_venv_hardening.py::test_path_python_wrapper_resolves_to_real_executable[powershell]`

That failure is not introduced by this change; the new fallback behavior and its touched-path coverage passed independently.
