### PR TITLE
Assert chat tracking in em, not in pixels at a 16px base

### DIFF
--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1217,6 +1217,9 @@ with sync_playwright() as p:
                     return {
                         fontWeight: [...new Set(styles.map((style) => style.fontWeight))],
                         letterSpacing: [...new Set(styles.map((style) => style.letterSpacing))],
+                        // The tracking is authored in em, so it only means anything next to the
+                        // size it resolved against.
+                        fontSize: [...new Set(styles.map((style) => style.fontSize))],
                     };
                 };
                 return {
@@ -1240,11 +1243,15 @@ with sync_playwright() as p:
         if typography["actualRenderLinux"] != typography["isDesktopLinux"]:
             fail(f"desktop Linux detection mismatch: {typography!r}")
         is_dark = typography["isDark"]
-        expected_spacing = "0.31px" if is_dark else "0.155px"
+        # Tracking is authored in em (thread.tsx tracking-[0.01em] / dark:tracking-[0.02em], and
+        # 0.023em for the lighter dark-mode instance on Linux), so assert the em and let the size
+        # come from the element. Pinning px assumed a 16px base and broke the moment the product
+        # default became 15px (--ui-font-scale in index.css), which any font-size preference does too.
+        expected_em = 0.02 if is_dark else 0.01
         if typography["isDesktopLinux"] and not typography["usesBaselineTypography"]:
             expected_weight = "350" if is_dark else "390"
             if is_dark:
-                expected_spacing = "0.3565px"
+                expected_em = 0.023
         else:
             expected_weight = "410"
         for role in ("assistant", "user"):
@@ -1254,10 +1261,17 @@ with sync_playwright() as p:
                     f"chat font weight {label}/{role}: expected {expected_weight}, "
                     f"got {actual['fontWeight']!r}"
                 )
-            if actual["letterSpacing"] != [expected_spacing]:
+            if len(actual["fontSize"]) != 1:
+                fail(f"chat font size {label}/{role}: not uniform, got {actual['fontSize']!r}")
+            font_size = float(actual["fontSize"][0].removesuffix("px"))
+            expected_spacing = expected_em * font_size
+            spacings = [float(v.removesuffix("px")) for v in actual["letterSpacing"]]
+            # Sub-pixel tolerance only: the browser reports the exact product, so anything larger
+            # would stop the check from noticing a changed tracking value.
+            if len(spacings) != 1 or abs(spacings[0] - expected_spacing) > 0.005:
                 fail(
-                    f"chat letter spacing {label}/{role}: expected {expected_spacing}, "
-                    f"got {actual['letterSpacing']!r}"
+                    f"chat letter spacing {label}/{role}: expected {expected_em}em of "
+                    f"{font_size}px = {expected_spacing:g}px, got {actual['letterSpacing']!r}"
                 )
 
     # ─────────────────────────────────────────────────────


### PR DESCRIPTION
`Chat UI Tests` has been red on `main` since `aa4e6af`, on both macOS and Linux runners:

```
macOS  [ui] FAIL: chat letter spacing theme-cycle-1/assistant: expected 0.31px,   got 0.290625px
Linux  [ui] FAIL: chat letter spacing theme-cycle-1/assistant: expected 0.3565px, got 0.334219px
```

Both are exactly 15/16 of what the test wanted, and the reason is in the product source:

```css
/* The authored typography tokens use a 16px CSS base; the product default
   is 15px. An explicit user preference overrides this inline. */
--ui-font-scale: 0.9375;
```

The chat message roots carry `text-ui-15p5` (`0.96875rem`) and `tracking-[0.01em] dark:tracking-[0.02em]`, with `0.023em` for the lighter dark-mode instance on Linux. Tracking authored in `em` resolves against the element's own size, so when the default base moved from 16px to 15px every computed value scaled with it: `0.02em` of `15.5px` is `0.31px`, and `0.02em` of `14.53125px` is `0.290625px`. The product is correct; the test was pinning the product of a tracking value and a base it did not measure.

So this reads the size off the element and asserts the em:

```python
expected_spacing = expected_em * font_size
```

Checked against every real observation, including the ones from before the default changed:

| case | em | size | expected | reported |
| --- | --- | --- | --- | --- |
| macOS dark, 15px default | 0.02 | 14.53125px | 0.290625px | 0.290625px |
| Linux dark, 15px default | 0.023 | 14.53125px | 0.334219px | 0.334219px |
| macOS dark, 16px base | 0.02 | 15.5px | 0.31px | 0.31px |
| Linux dark, 16px base | 0.023 | 15.5px | 0.3565px | 0.3565px |
| light mode, either base | 0.01 | 15.5 / 14.53125px | 0.155 / 0.145313px | matches |

It also passes under a user font-size preference (20px, scale 1.25) rather than only at the default, which the pinned values never could. The tolerance is 0.005px, sub-pixel on purpose: substituting a genuinely wrong tracking (0.01em or 0.023em where 0.02em is required) still fails, so the check keeps its teeth.

Test-only change, no product code touched.
