### PR TITLE
test(studio): bound the chat font size and accept a normal tracking

### DIFF
--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1264,8 +1264,19 @@ with sync_playwright() as p:
             if len(actual["fontSize"]) != 1:
                 fail(f"chat font size {label}/{role}: not uniform, got {actual['fontSize']!r}")
             font_size = float(actual["fontSize"][0].removesuffix("px"))
+            # Asserting the em means the size itself is no longer checked, where the old px
+            # literal caught it implicitly. Bound it: loose enough that a deliberate scale
+            # change or a font-size preference passes, tight enough that chat text rendering
+            # at a heading or caption size does not.
+            if not 12.0 <= font_size <= 18.0:
+                fail(f"chat font size {label}/{role}: {font_size}px is outside 12-18px")
             expected_spacing = expected_em * font_size
-            spacings = [float(v.removesuffix("px")) for v in actual["letterSpacing"]]
+            # "normal" is how a zero tracking is reported, and float() raises on it, which
+            # would surface as a test error rather than this check failing.
+            spacings = [
+                0.0 if v.strip() == "normal" else float(v.removesuffix("px"))
+                for v in actual["letterSpacing"]
+            ]
             # Sub-pixel tolerance only: the browser reports the exact product, so anything larger
             # would stop the check from noticing a changed tracking value.
             if len(spacings) != 1 or abs(spacings[0] - expected_spacing) > 0.005:

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1273,11 +1273,10 @@ with sync_playwright() as p:
             if len(actual["fontSize"]) != 1:
                 fail(f"chat font size {label}/{role}: not uniform, got {actual['fontSize']!r}")
             font_size = float(actual["fontSize"][0].removesuffix("px"))
-            # Asserting the em means the size itself is no longer checked, where the old px
-            # literal caught it implicitly. Assert the token rather than a range: chat is
-            # text-ui-15p5, which is 15.5px scaled by --ui-font-scale, so this holds at
-            # every supported preference (12 to 20, i.e. 11.625px to 19.375px) while still
-            # catching a swap to a neighbouring token that a range would admit.
+            # Asserting the em leaves the size itself unchecked, which the old px literal
+            # caught implicitly. Pin the token, not a range: a range wide enough for every
+            # supported preference (12 to 20, so 11.625px to 19.375px) also admits the
+            # neighbouring tokens it was meant to catch.
             try:
                 ui_font_scale = float(typography.get("uiFontScale") or "1")
             except ValueError:

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1242,8 +1242,7 @@ with sync_playwright() as p:
             }""",
         )
 
-    # The unscaled size of the text-ui-15p5 token chat renders at (index.css:
-    # --text-ui-15p5: calc(0.96875rem * var(--ui-font-scale, 1))).
+    # text-ui-15p5 unscaled (index.css: calc(0.96875rem * var(--ui-font-scale, 1))).
     _TEXT_UI_15P5_PX = 15.5
 
     def assert_chat_typography(label, typography):
@@ -1273,10 +1272,8 @@ with sync_playwright() as p:
             if len(actual["fontSize"]) != 1:
                 fail(f"chat font size {label}/{role}: not uniform, got {actual['fontSize']!r}")
             font_size = float(actual["fontSize"][0].removesuffix("px"))
-            # Asserting the em leaves the size itself unchecked, which the old px literal
-            # caught implicitly. Pin the token, not a range: a range wide enough for every
-            # supported preference (12 to 20, so 11.625px to 19.375px) also admits the
-            # neighbouring tokens it was meant to catch.
+            # Pin the token, not a range: one spanning every preference (12 to 20, so
+            # 11.625px to 19.375px) also admits the neighbouring tokens.
             try:
                 ui_font_scale = float(typography.get("uiFontScale") or "1")
             except ValueError:
@@ -1291,8 +1288,7 @@ with sync_playwright() as p:
                     f"got {font_size}px"
                 )
             expected_spacing = expected_em * font_size
-            # "normal" is how a zero tracking is reported, and float() raises on it, which
-            # would surface as a test error rather than this check failing.
+            # float() raises on "normal", which is how zero tracking is reported.
             spacings = [
                 0.0 if v.strip() == "normal" else float(v.removesuffix("px"))
                 for v in actual["letterSpacing"]

--- a/tests/studio/playwright_chat_ui.py
+++ b/tests/studio/playwright_chat_ui.py
@@ -1223,6 +1223,11 @@ with sync_playwright() as p:
                     };
                 };
                 return {
+                    // The scale the size tokens are multiplied by: index.css sets the 15px
+                    // product default, and the appearance store overrides it inline as
+                    // preference / 16 for any other size.
+                    uiFontScale: getComputedStyle(root)
+                        .getPropertyValue('--ui-font-scale').trim(),
                     actualRenderLinux: root.classList.contains('render-linux'),
                     isDesktopLinux: ua.includes('linux') && !ua.includes('android'),
                     isDark: root.classList.contains('dark'),
@@ -1236,6 +1241,10 @@ with sync_playwright() as p:
                 };
             }""",
         )
+
+    # The unscaled size of the text-ui-15p5 token chat renders at (index.css:
+    # --text-ui-15p5: calc(0.96875rem * var(--ui-font-scale, 1))).
+    _TEXT_UI_15P5_PX = 15.5
 
     def assert_chat_typography(label, typography):
         if typography.get("error"):
@@ -1265,11 +1274,23 @@ with sync_playwright() as p:
                 fail(f"chat font size {label}/{role}: not uniform, got {actual['fontSize']!r}")
             font_size = float(actual["fontSize"][0].removesuffix("px"))
             # Asserting the em means the size itself is no longer checked, where the old px
-            # literal caught it implicitly. Bound it: loose enough that a deliberate scale
-            # change or a font-size preference passes, tight enough that chat text rendering
-            # at a heading or caption size does not.
-            if not 12.0 <= font_size <= 18.0:
-                fail(f"chat font size {label}/{role}: {font_size}px is outside 12-18px")
+            # literal caught it implicitly. Assert the token rather than a range: chat is
+            # text-ui-15p5, which is 15.5px scaled by --ui-font-scale, so this holds at
+            # every supported preference (12 to 20, i.e. 11.625px to 19.375px) while still
+            # catching a swap to a neighbouring token that a range would admit.
+            try:
+                ui_font_scale = float(typography.get("uiFontScale") or "1")
+            except ValueError:
+                ui_font_scale = None
+            if ui_font_scale is None:
+                fail(f"chat font size {label}/{role}: unreadable --ui-font-scale")
+            expected_size = _TEXT_UI_15P5_PX * ui_font_scale
+            if abs(font_size - expected_size) > 0.01:
+                fail(
+                    f"chat font size {label}/{role}: expected text-ui-15p5, "
+                    f"{_TEXT_UI_15P5_PX}px * {ui_font_scale} = {expected_size:g}px, "
+                    f"got {font_size}px"
+                )
             expected_spacing = expected_em * font_size
             # "normal" is how a zero tracking is reported, and float() raises on it, which
             # would surface as a test error rather than this check failing.

--- a/tests/studio/playwright_ui_font_scale.py
+++ b/tests/studio/playwright_ui_font_scale.py
@@ -28,8 +28,7 @@ ART = Path(os.environ.get("PW_ART_DIR", "logs/playwright_fontscale"))
 ART.mkdir(parents = True, exist_ok = True)
 
 SIZES = (12, 20)
-# UI_FONT_SIZE_RANGE in appearance-custom-store.ts: the store only drops
-# data-ui-font-size when the preference equals this default.
+# UI_FONT_SIZE_RANGE default (appearance-custom-store.ts); only here is data-ui-font-size dropped.
 DEFAULT = 15
 
 

--- a/tests/studio/playwright_ui_font_scale.py
+++ b/tests/studio/playwright_ui_font_scale.py
@@ -28,7 +28,9 @@ ART = Path(os.environ.get("PW_ART_DIR", "logs/playwright_fontscale"))
 ART.mkdir(parents = True, exist_ok = True)
 
 SIZES = (12, 20)
-DEFAULT = 16
+# UI_FONT_SIZE_RANGE in appearance-custom-store.ts: the store only drops
+# data-ui-font-size when the preference equals this default.
+DEFAULT = 15
 
 
 def step(s):


### PR DESCRIPTION
Three small follow-ups to #7826, which is otherwise the right fix. The first two were split out of #7821, which I closed as superseded; the third is a separate stale constant in the same family that the first two came from.

## The font size is no longer checked

Asserting the em means the size it resolves against is read rather than verified. The px literal it replaced caught that implicitly: `0.3565px` only matched at a 15.5px body, so a size regression showed up as a tracking failure. After the change, chat text rendering at a caption or heading size passes silently, because the expectation moves with it.

The check now asserts the token rather than a range: chat text is `text-ui-15p5`, so the size has to be `15.5px * --ui-font-scale`, read from the same root the product computes it on. That holds at every font-size preference and fails on any other token.

- a scale change passes, which is the thing that broke the literal
- every preference from 12 to 20 passes
- a swap to `text-ui-13` or `text-ui-18` does not

## `float("normal")` raises

`"normal"` is how a browser reports a zero tracking, and `float("normal".removesuffix("px"))` raises `ValueError`. That path would surface as a test error rather than as this check failing with its own message. Only reachable if a tracking ever becomes 0, so this is defensive rather than a live bug.

## The font-scale test uses a default the store does not have

`playwright_ui_font_scale.py` drives the size input to `DEFAULT = 16` and then asserts `data-ui-font-size` has been dropped. The store only removes that attribute when the preference equals `UI_FONT_SIZE_RANGE.default`, which is 15, so the attribute is still there and the test fails:

```
[font-scale] FAIL: data-ui-font-size present at default: 16
```

16 is the root font size, not the UI font size default. The static `--ui-font-scale: 0.9375` in `index.css` is the same `15 / 16`. This is the same shape of staleness as #7826 fixed, left behind by #7359. The ratio math in the test is relative to `DEFAULT`, so it stays correct at 15.

## Verification

Exercised against the values that actually occur:

```
current dark Linux         -> pass
current dark               -> pass
current light              -> pass
pre-#7359 15.5px body      -> pass
preference 12 (0.75)       -> pass
preference 20 (1.25)       -> pass
zero tracking as normal    -> pass
wrong tracking             -> tracking [0.290625] != 0.334219
text-ui-13 swap            -> expected text-ui-15p5, 15.5px * 0.9375 = 14.5312px, got 12.1875px
text-ui-18 swap            -> expected text-ui-15p5, 15.5px * 0.9375 = 14.5312px, got 16.875px
```

Only the last three fail, each with the message that names the cause.
