### PR TITLE
Bound dataset_num_proc by memory, and stop treating 1 as "no multiprocessing"

### DIFF
--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -353,6 +353,24 @@ jobs:
             tests/utils/test_prepare_inputs_leftpad.py \
             tests/utils/test_rope_scaling_drift.py
 
+      - name: dataset_num_proc worker bounds (HARD GATE)
+        # Guards for #2693: Dataset.map() dying with "One of the subprocesses
+        # has abruptly died", which is the OOM killer reaping tokenizer workers
+        # that nothing bounded. These assert the policy that replaced the
+        # unbounded cpu_count + 4 -> 64 heuristic -- the memory clamp, the
+        # 1 -> None normalisation (datasets >= 4.1 builds a Pool(1)), the
+        # non-fork and macOS vetoes, and the UNSLOTH_DATASET_NUM_PROC hatch.
+        #
+        # Their own step rather than Bucket-A: they need no accelerator and no
+        # model, they import the module standalone by path (so they cannot be
+        # masked by unrelated import breakage), and their assertions are pinned
+        # against simulated CPU counts and memory so the result is identical on
+        # a 4-vCPU runner and a 192-core box.
+        run: |
+          python -m pytest -v --tb=short \
+            tests/utils/test_dataset_num_proc.py \
+            tests/utils/test_train_on_responses_only_num_proc.py
+
       - name: unsloth Bucket-A — CPU tests not in Repo tests (CPU)
         # CPU tests across 6 files under tests/saving/, tests/utils/, tests/python/
         # that Repo tests (CPU) --ignores. AST/protobuf/regex plus tiny CPU model
@@ -2136,6 +2154,7 @@ jobs:
           echo "::endgroup::"
           echo "Consolidated job done. Coverage:"
           echo "  - 17 unsloth Bucket-A tests under tests/saving/ + tests/utils/"
+          echo "  - 87 dataset_num_proc worker-bound guards (#2693)"
           echo "  - unsloth_zoo @ ${UNSLOTH_ZOO_REF} pytest tests/ (5 GPU cases deselected)"
           echo "  - unsloth_zoo.compiler.test_apply_fused_lm_head"
 

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -366,10 +366,19 @@ jobs:
         # masked by unrelated import breakage), and their assertions are pinned
         # against simulated CPU counts and memory so the result is identical on
         # a 4-vCPU runner and a 192-core box.
+        #
+        # The Studio file runs here rather than in studio-backend-ci: that job
+        # installs studio.txt, which carries no unsloth_zoo, so every case that
+        # reaches the shared policy importorskips away -- 14 of 32, and with no
+        # policy installed the survivors fall back to the pre-PR safe_num_proc,
+        # so they would pass with the whole wiring deleted. This job has the
+        # editable unsloth_zoo those cases need.
         run: |
           python -m pytest -v --tb=short \
             tests/utils/test_dataset_num_proc.py \
             tests/utils/test_train_on_responses_only_num_proc.py
+          PYTHONPATH=studio/backend python -m pytest -v --tb=short \
+            studio/backend/tests/test_dataset_map_num_proc.py
 
       - name: unsloth Bucket-A — CPU tests not in Repo tests (CPU)
         # CPU tests across 6 files under tests/saving/, tests/utils/, tests/python/
@@ -2154,7 +2163,7 @@ jobs:
           echo "::endgroup::"
           echo "Consolidated job done. Coverage:"
           echo "  - 17 unsloth Bucket-A tests under tests/saving/ + tests/utils/"
-          echo "  - 87 dataset_num_proc worker-bound guards (#2693)"
+          echo "  - 168 dataset_num_proc worker-bound guards (#2693)"
           echo "  - unsloth_zoo @ ${UNSLOTH_ZOO_REF} pytest tests/ (5 GPU cases deselected)"
           echo "  - unsloth_zoo.compiler.test_apply_fused_lm_head"
 

--- a/.github/workflows/consolidated-tests-ci.yml
+++ b/.github/workflows/consolidated-tests-ci.yml
@@ -367,12 +367,13 @@ jobs:
         # against simulated CPU counts and memory so the result is identical on
         # a 4-vCPU runner and a 192-core box.
         #
-        # The Studio file runs here rather than in studio-backend-ci: that job
-        # installs studio.txt, which carries no unsloth_zoo, so every case that
-        # reaches the shared policy importorskips away -- 14 of 32, and with no
-        # policy installed the survivors fall back to the pre-PR safe_num_proc,
-        # so they would pass with the whole wiring deleted. This job has the
-        # editable unsloth_zoo those cases need.
+        # The Studio file runs here rather than in studio-backend-ci, which
+        # installs studio.txt and so has no unsloth_zoo at all. Note the policy
+        # module is not on unsloth_zoo main either until the companion PR lands,
+        # and this job clones UNSLOTH_ZOO_REF (main by default) -- so those cases
+        # reach the policy through _shared_policy, which falls back to this
+        # repo's own copy. Skipping instead would leave the 14 cases that matter
+        # green while the wiring they guard was inert.
         run: |
           python -m pytest -v --tb=short \
             tests/utils/test_dataset_num_proc.py \

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -3250,9 +3250,7 @@ class UnslothTrainer:
                 # skips that. Studio's own caps still apply to whatever it
                 # chooses.
                 "dataset_num_proc": dataset_map_num_proc(
-                    1
-                    if (self.is_audio or self.is_audio_vlm or self._cuda_audio_used)
-                    else None,
+                    1 if (self.is_audio or self.is_audio_vlm or self._cuda_audio_used) else None,
                     serial_as_none = False,
                 ),
                 "max_seq_length": training_args.get("max_seq_length", 2048),

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -3238,10 +3238,16 @@ class UnslothTrainer:
                 "output_dir": output_dir,
                 "report_to": _build_report_targets(training_args),
                 "include_num_input_tokens_seen": True,  # Enable token counting
+                # serial_as_none = False: this is a config boundary, not a map()
+                # call site. The audio paths ask for 1 to keep dataset workers
+                # off a process holding audio/CUDA state, and a config `None`
+                # reads as "auto-size me" downstream, which turns that request
+                # into a full worker set instead.
                 "dataset_num_proc": dataset_map_num_proc(
                     1
                     if (self.is_audio or self.is_audio_vlm or self._cuda_audio_used)
-                    else max(1, (os.cpu_count() or 1) // 4)
+                    else max(1, (os.cpu_count() or 1) // 4),
+                    serial_as_none = False,
                 ),
                 "max_seq_length": training_args.get("max_seq_length", 2048),
             }

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -35,7 +35,6 @@ if sys.platform in ("win32", "darwin"):
 import torch
 from utils.hardware import (
     clear_gpu_cache,
-    safe_num_proc,
     dataset_map_num_proc,
     get_device_map,
     raise_if_offloaded,

--- a/studio/backend/core/training/trainer.py
+++ b/studio/backend/core/training/trainer.py
@@ -3243,10 +3243,16 @@ class UnslothTrainer:
                 # off a process holding audio/CUDA state, and a config `None`
                 # reads as "auto-size me" downstream, which turns that request
                 # into a full worker set instead.
+                # None, not a count, for the ordinary case: the shared policy
+                # sizes an auto request from this process's CPU affinity and
+                # cgroup quota, while any integer computed here comes from the
+                # host's os.cpu_count() and reads as an explicit request that
+                # skips that. Studio's own caps still apply to whatever it
+                # chooses.
                 "dataset_num_proc": dataset_map_num_proc(
                     1
                     if (self.is_audio or self.is_audio_vlm or self._cuda_audio_used)
-                    else max(1, (os.cpu_count() or 1) // 4),
+                    else None,
                     serial_as_none = False,
                 ),
                 "max_seq_length": training_args.get("max_seq_length", 2048),

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -2634,7 +2634,7 @@ def run_training_process(*, event_queue: Any, stop_queue: Any, config: dict) -> 
     # No start-method override here. Forcing stdlib multiprocessing onto "fork"
     # never reached Dataset.map(), which does `from multiprocess import Pool` and
     # so keeps its own default context; the guard it did flip now asks
-    # multiprocess directly (unsloth/utils/dataset_num_proc.py). Linux defaults
+    # multiprocess directly (unsloth_zoo/dataset_num_proc.py). Linux defaults
     # to fork anyway, so dropping it changes no behaviour and stops overriding a
     # process-wide setting for every later pool in this worker.
 

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -2631,12 +2631,9 @@ def run_training_process(*, event_queue: Any, stop_queue: Any, config: dict) -> 
         )
         return
 
-    # No start-method override here. Forcing stdlib multiprocessing onto "fork"
-    # never reached Dataset.map(), which does `from multiprocess import Pool` and
-    # so keeps its own default context; the guard it did flip now asks
-    # multiprocess directly (unsloth_zoo/dataset_num_proc.py). Linux defaults
-    # to fork anyway, so dropping it changes no behaviour and stops overriding a
-    # process-wide setting for every later pool in this worker.
+    # No start-method override: Dataset.map() imports Pool from `multiprocess`,
+    # so forcing stdlib multiprocessing onto "fork" never reached it. Linux forks
+    # by default, and the guard now asks multiprocess directly.
 
     # ── 1c. On Windows, check Triton availability (must be before import torch) ──
     if sys.platform == "win32":

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -2631,15 +2631,12 @@ def run_training_process(*, event_queue: Any, stop_queue: Any, config: dict) -> 
         )
         return
 
-    # No start-method override here. This used to force stdlib multiprocessing
-    # onto "fork" so dataset.map() could multiprocess, but datasets does
-    # `from multiprocess import Pool` (arrow_dataset.py) and multiprocess keeps
-    # its own default context, so the call never reached Dataset.map(). Its only
-    # live effect was flipping the stdlib-reading guard the compiled trainer used
-    # to carry; that guard now asks multiprocess directly (see
-    # unsloth/utils/dataset_num_proc.py). Linux already defaults to fork, so
-    # dropping it changes no behaviour and stops overriding a process-wide
-    # setting on every later pool in this worker.
+    # No start-method override here. Forcing stdlib multiprocessing onto "fork"
+    # never reached Dataset.map(), which does `from multiprocess import Pool` and
+    # so keeps its own default context; the guard it did flip now asks
+    # multiprocess directly (unsloth/utils/dataset_num_proc.py). Linux defaults
+    # to fork anyway, so dropping it changes no behaviour and stops overriding a
+    # process-wide setting for every later pool in this worker.
 
     # ── 1c. On Windows, check Triton availability (must be before import torch) ──
     if sys.platform == "win32":

--- a/studio/backend/core/training/worker.py
+++ b/studio/backend/core/training/worker.py
@@ -2631,15 +2631,15 @@ def run_training_process(*, event_queue: Any, stop_queue: Any, config: dict) -> 
         )
         return
 
-    # ── 1c. Set fork start method so dataset.map() can multiprocess ──
-    # The compiled SFTTrainer disables num_proc if start method isn't "fork".
-    # Linux only and safe here (no CUDA context yet); macOS/Windows excluded.
-    if sys.platform == "linux":
-        import multiprocessing as _mp
-        try:
-            _mp.set_start_method("fork", force = True)
-        except RuntimeError:
-            pass  # Already set
+    # No start-method override here. This used to force stdlib multiprocessing
+    # onto "fork" so dataset.map() could multiprocess, but datasets does
+    # `from multiprocess import Pool` (arrow_dataset.py) and multiprocess keeps
+    # its own default context, so the call never reached Dataset.map(). Its only
+    # live effect was flipping the stdlib-reading guard the compiled trainer used
+    # to carry; that guard now asks multiprocess directly (see
+    # unsloth/utils/dataset_num_proc.py). Linux already defaults to fork, so
+    # dropping it changes no behaviour and stops overriding a process-wide
+    # setting on every later pool in this worker.
 
     # ── 1c. On Windows, check Triton availability (must be before import torch) ──
     if sys.platform == "win32":

--- a/studio/backend/tests/test_dataset_map_num_proc.py
+++ b/studio/backend/tests/test_dataset_map_num_proc.py
@@ -303,6 +303,6 @@ def test_the_cap_no_longer_advertises_an_override_it_cannot_honour():
         if isinstance(node, ast.Call) and ast.unparse(node.func).startswith("logger.")
     ]
     assert logged, "the cap stopped logging; re-check what this is guarding"
-    assert not any("UNSLOTH_DATASET_NUM_PROC" in line for line in logged), (
-        "safe_num_proc tells the user to set an override it never reads"
-    )
+    assert not any(
+        "UNSLOTH_DATASET_NUM_PROC" in line for line in logged
+    ), "safe_num_proc tells the user to set an override it never reads"

--- a/studio/backend/tests/test_dataset_map_num_proc.py
+++ b/studio/backend/tests/test_dataset_map_num_proc.py
@@ -25,7 +25,12 @@ import pytest
 import utils.hardware.hardware as hw
 
 
-def _patch_device(monkeypatch, device, *, visible_gpus: int = 1):
+def _patch_device(
+    monkeypatch,
+    device,
+    *,
+    visible_gpus: int = 1,
+):
     monkeypatch.setattr(hw, "get_device", lambda: device)
     monkeypatch.setattr(hw, "get_visible_gpu_count", lambda: visible_gpus)
 
@@ -43,9 +48,7 @@ def _patch_runtime(monkeypatch, name, *, is_initialized):
     else:
         probe = lambda: is_initialized  # noqa: E731
 
-    monkeypatch.setattr(
-        torch, name, types.SimpleNamespace(is_initialized = probe), raising = False
-    )
+    monkeypatch.setattr(torch, name, types.SimpleNamespace(is_initialized = probe), raising = False)
 
 
 # ---------- CUDA: initialization must NOT disable workers ----------

--- a/studio/backend/tests/test_dataset_map_num_proc.py
+++ b/studio/backend/tests/test_dataset_map_num_proc.py
@@ -26,6 +26,18 @@ import pytest
 
 import utils.hardware.hardware as hw
 
+try:
+    # Imported here, before the fixture below spoofs sys.platform. multiprocess
+    # chooses its concrete contexts at import time from sys.platform, so a first
+    # import under a spoofed one hands a Windows runner the POSIX fork contexts,
+    # and the pool then dies reaching for os.WNOHANG.
+    import multiprocess  # noqa: F401
+except ImportError:
+    pass
+
+# The real one, read before anything can lie about it.
+_HOST_PLATFORM = sys.platform
+
 
 @pytest.fixture(autouse = True)
 def _fork_platform(monkeypatch):
@@ -48,7 +60,7 @@ def _require_fork(multiprocess):
     handle, os.WNOHANG missing). The version split they assert is checked
     without processes in tests/utils/test_dataset_num_proc.py.
     """
-    if "fork" not in multiprocess.get_all_start_methods():
+    if _HOST_PLATFORM == "win32" or "fork" not in multiprocess.get_all_start_methods():
         pytest.skip("needs fork to build a real worker pool")
 
 

--- a/studio/backend/tests/test_dataset_map_num_proc.py
+++ b/studio/backend/tests/test_dataset_map_num_proc.py
@@ -578,9 +578,9 @@ def test_the_trainer_leaves_the_ordinary_case_to_the_policy():
     import ast
     from pathlib import Path
 
-    source = (
-        Path(__file__).resolve().parents[1] / "core" / "training" / "trainer.py"
-    ).read_text(encoding = "utf-8")
+    source = (Path(__file__).resolve().parents[1] / "core" / "training" / "trainer.py").read_text(
+        encoding = "utf-8"
+    )
 
     calls = [
         value

--- a/studio/backend/tests/test_dataset_map_num_proc.py
+++ b/studio/backend/tests/test_dataset_map_num_proc.py
@@ -12,7 +12,9 @@ There is deliberately no CUDA-initialized guard here; see the note in
 ``dataset_map_num_proc``'s docstring. The XPU guard is pre-existing behaviour and
 is covered below so it cannot regress.
 
-The probes are monkeypatched so this runs on any host, GPU or not.
+The device probes, the platform and torch itself are all substituted, so this
+runs identically on a GPU box, a CPU-only Linux runner, and the macOS and
+Windows legs where the function short-circuits to None.
 """
 
 from __future__ import annotations
@@ -25,6 +27,17 @@ import pytest
 import utils.hardware.hardware as hw
 
 
+@pytest.fixture(autouse = True)
+def _fork_platform(monkeypatch):
+    """Pin a platform where workers are possible.
+
+    ``dataset_map_num_proc`` returns None outright on win32 and darwin, so every
+    assertion below that expects a count is really an assertion about Linux. The
+    parametrised platform test sets its own value after this, which wins.
+    """
+    monkeypatch.setattr(sys, "platform", "linux")
+
+
 def _patch_device(
     monkeypatch,
     device,
@@ -35,13 +48,30 @@ def _patch_device(
     monkeypatch.setattr(hw, "get_visible_gpu_count", lambda: visible_gpus)
 
 
+def _torch_module(monkeypatch):
+    """The real torch, or a stand-in when the runner has none.
+
+    ``dataset_map_num_proc`` imports torch to read ``<device>.is_initialized()``
+    and reads an ImportError as "runtime not touched yet". On a torch-less
+    runner that turns the XPU guard into a no-op, so these tests would fail
+    where they expect None and pass for the wrong reason elsewhere.
+    """
+    try:
+        import torch
+        return torch
+    except ImportError:
+        stub = types.ModuleType("torch")
+        monkeypatch.setitem(sys.modules, "torch", stub)
+        return stub
+
+
 def _patch_runtime(monkeypatch, name, *, is_initialized):
     """Install a fake ``torch.<name>`` whose is_initialized() we control.
 
     ``is_initialized`` may be a bool or a callable that raises, to model a probe
     that fails rather than answering.
     """
-    import torch
+    torch = _torch_module(monkeypatch)
 
     if callable(is_initialized):
         probe = is_initialized

--- a/studio/backend/tests/test_dataset_map_num_proc.py
+++ b/studio/backend/tests/test_dataset_map_num_proc.py
@@ -318,6 +318,10 @@ def test_the_cap_no_longer_advertises_an_override_it_cannot_honour():
 
 def test_a_serial_request_survives_the_config_round_trip(monkeypatch):
     """The audio paths ask for 1; the config layer must still see a request for 1."""
+    # The map-site half of this needs the policy: without it
+    # _bounded_by_the_shared_policy returns the count unchanged by design, so a
+    # runner with no unsloth_zoo reads 1 rather than None.
+    pytest.importorskip("unsloth_zoo.dataset_num_proc")
     _patch_device(monkeypatch, hw.DeviceType.CPU)
     assert hw.dataset_map_num_proc(1, serial_as_none = False) == 1
     # The map-site default is what turns it back into "no pool" at the call.
@@ -365,6 +369,7 @@ def test_spawn_platforms_keep_none_at_either_layer(monkeypatch, platform):
 
 def test_every_other_caller_keeps_the_map_site_default(monkeypatch):
     """Only the config boundary opts in; the seven map-site callers must not."""
+    pytest.importorskip("unsloth_zoo.dataset_num_proc")
     _patch_device(monkeypatch, hw.DeviceType.CPU)
     assert hw.dataset_map_num_proc(1) is None
     assert hw.dataset_map_num_proc(4) == 4

--- a/studio/backend/tests/test_dataset_map_num_proc.py
+++ b/studio/backend/tests/test_dataset_map_num_proc.py
@@ -47,6 +47,21 @@ def _fork_platform(monkeypatch):
     monkeypatch.setattr(sys, "platform", "linux")
 
 
+@pytest.fixture(autouse = True)
+def _memory_headroom(monkeypatch):
+    """Pin the memory ceiling the shared policy applies.
+
+    Every count these tests assert is bounded by free RAM, so on a small runner
+    ``dataset_map_num_proc(4) == 4`` quietly becomes a test of the clamp. The
+    cases that are about the clamp pin their own value afterwards, which wins.
+    """
+    try:
+        import unsloth_zoo.dataset_num_proc as policy
+    except ImportError:
+        return
+    monkeypatch.setattr(policy, "_affordable_workers", lambda: 64)
+
+
 def _require_fork(multiprocess):
     """Skip when this host cannot fork.
 

--- a/studio/backend/tests/test_dataset_map_num_proc.py
+++ b/studio/backend/tests/test_dataset_map_num_proc.py
@@ -4,17 +4,15 @@
 """Tests for ``dataset_map_num_proc()``.
 
 ``None``, not ``1``, is the disable sentinel: on ``datasets`` >= 4.1 (Studio pins
-4.3.0) ``map()`` takes the pool branch for any ``num_proc >= 1``, so ``1`` still
-builds a ``Pool(1)``. ``datasets`` 3.x runs ``1`` in-process, so the version
-split is asserted per installed release rather than hard-coded.
+4.3.0) ``map()`` takes the pool branch for any ``num_proc >= 1``, while 3.x runs
+``1`` in-process, so that split is asserted per installed release.
 
-There is deliberately no CUDA-initialized guard here; see the note in
-``dataset_map_num_proc``'s docstring. The XPU guard is pre-existing behaviour and
-is covered below so it cannot regress.
+There is deliberately no CUDA-initialized guard; see ``dataset_map_num_proc``'s
+docstring. The XPU guard is pre-existing and covered so it cannot regress.
 
-The device probes, the platform and torch itself are all substituted, so this
-runs identically on a GPU box, a CPU-only Linux runner, and the macOS and
-Windows legs where the function short-circuits to None.
+The device probes, the platform and torch itself are substituted, so this runs
+identically on a GPU box, a CPU-only Linux runner, and the macOS and Windows
+legs where the function short-circuits to None.
 """
 
 from __future__ import annotations
@@ -27,10 +25,10 @@ import pytest
 import utils.hardware.hardware as hw
 
 try:
-    # Imported here, before the fixture below spoofs sys.platform. multiprocess
-    # chooses its concrete contexts at import time from sys.platform, so a first
-    # import under a spoofed one hands a Windows runner the POSIX fork contexts,
-    # and the pool then dies reaching for os.WNOHANG.
+    # Before the fixture below spoofs sys.platform: multiprocess picks its
+    # concrete contexts from sys.platform at import time, so a first import under
+    # a spoofed one hands a Windows runner the POSIX fork contexts and the pool
+    # then dies reaching for os.WNOHANG.
     import multiprocess  # noqa: F401
 except ImportError:
     pass
@@ -44,8 +42,8 @@ def _fork_platform(monkeypatch):
     """Pin a platform where workers are possible.
 
     ``dataset_map_num_proc`` returns None outright on win32 and darwin, so every
-    assertion below that expects a count is really an assertion about Linux. The
-    parametrised platform test sets its own value after this, which wins.
+    assertion expecting a count is really about Linux. The parametrised platform
+    test sets its own value after this, which wins.
     """
     monkeypatch.setattr(sys, "platform", "linux")
 
@@ -53,12 +51,10 @@ def _fork_platform(monkeypatch):
 def _require_fork(multiprocess):
     """Skip when this host cannot fork.
 
-    The two tests below build real worker processes to observe whether
-    ``datasets`` takes its pool branch. That is a claim about the num_proc
-    guard, not about any particular start method, and under spawn inside pytest
-    the pool itself fails for unrelated reasons (WinError 10038 closing a
-    handle, os.WNOHANG missing). The version split they assert is checked
-    without processes in tests/utils/test_dataset_num_proc.py.
+    The two tests below build real workers to observe whether ``datasets`` takes
+    its pool branch -- a claim about the num_proc guard, not about any start
+    method, and under spawn inside pytest the pool fails for unrelated reasons
+    (WinError 10038, missing os.WNOHANG).
     """
     if _HOST_PLATFORM == "win32" or "fork" not in multiprocess.get_all_start_methods():
         pytest.skip("needs fork to build a real worker pool")
@@ -78,9 +74,8 @@ def _torch_module(monkeypatch):
     """The real torch, or a stand-in when the runner has none.
 
     ``dataset_map_num_proc`` imports torch to read ``<device>.is_initialized()``
-    and reads an ImportError as "runtime not touched yet". On a torch-less
-    runner that turns the XPU guard into a no-op, so these tests would fail
-    where they expect None and pass for the wrong reason elsewhere.
+    and reads an ImportError as "runtime not touched yet", which on a torch-less
+    runner would turn the XPU guard into a no-op.
     """
     try:
         import torch
@@ -113,12 +108,11 @@ def _patch_runtime(monkeypatch, name, *, is_initialized):
 def test_dataset_map_num_proc_parallelizes_on_initialized_cuda(monkeypatch):
     """An initialized CUDA context must not disable dataset workers.
 
-    Forking after torch.cuda._lazy_init() is a real hazard in general, but the
-    map child only runs the tokenizer and never touches CUDA. 300 forced-fork
-    map() runs on an initialized context produced no failures, and since
-    detect_hardware() always initializes CUDA, a guard here would serialize
-    tokenization for every CUDA training run. Pinned so it is not added back
-    without new evidence.
+    Forking after torch.cuda._lazy_init() is a hazard in general, but the map
+    child only runs the tokenizer, and 300 forced-fork map() runs on an
+    initialized context produced no failures. Since detect_hardware() always
+    initializes CUDA, a guard would serialize tokenization for every CUDA run.
+    Pinned so it is not added back without new evidence.
     """
     _patch_device(monkeypatch, hw.DeviceType.CUDA)
     _patch_runtime(monkeypatch, "cuda", is_initialized = True)
@@ -170,8 +164,8 @@ def test_dataset_map_num_proc_cpu_host_parallelizes(monkeypatch):
 def test_none_builds_no_pool_but_a_count_does(monkeypatch):
     """The disable sentinel must actually reach ``datasets`` as "no pool".
 
-    This is the property the whole module rests on, so assert it against the
-    installed ``datasets`` rather than trusting the docstring.
+    The property the whole module rests on, so assert it against the installed
+    ``datasets`` rather than trusting the docstring.
     """
     datasets = pytest.importorskip("datasets")
     multiprocess = pytest.importorskip("multiprocess")
@@ -202,10 +196,9 @@ def test_none_builds_no_pool_but_a_count_does(monkeypatch):
 def test_num_proc_one_is_not_a_disable_sentinel():
     """Pin the reason ``dataset_map_num_proc`` returns ``None`` and never ``1``.
 
-    ``datasets`` changed this: 3.x runs ``num_proc=1`` in-process, 4.x (Studio
-    pins 4.3.0) takes the pool branch for any ``num_proc >= 1`` and builds a
-    ``Pool(1)``. Only ``None`` is in-process on both, so this asserts per
-    installed version rather than picking one and hard-coding it.
+    ``datasets`` 3.x runs ``num_proc=1`` in-process; 4.x (Studio pins 4.3.0)
+    builds a ``Pool(1)``. Only ``None`` is in-process on both, so assert per
+    installed version rather than hard-coding one.
     """
     datasets = pytest.importorskip("datasets")
     multiprocess = pytest.importorskip("multiprocess")

--- a/studio/backend/tests/test_dataset_map_num_proc.py
+++ b/studio/backend/tests/test_dataset_map_num_proc.py
@@ -407,3 +407,124 @@ def test_the_trainer_config_asks_for_the_config_sentinel():
             "so a serial request will be read back as 'auto-size me': "
             f"{ast.unparse(call)}"
         )
+
+
+# ---------- the request reaches the policy as the caller wrote it ----------
+
+
+def _unexpected_auto_sizing(desired = None):
+    if desired is None:
+        raise AssertionError("the auto request was materialized before the policy saw it")
+    return desired
+
+
+def test_an_auto_request_is_sized_by_the_policy_not_by_the_host_cpu_count(monkeypatch):
+    """``safe_num_proc(None)`` reads ``os.cpu_count()``; the policy reads this process.
+
+    Materializing the auto request before the policy saw it hid the affinity
+    mask and the cgroup quota, so a 2-core container on a 64-core box asked for
+    ``cpu_count // 3`` workers and was bounded only by memory.
+    """
+    policy = pytest.importorskip("unsloth_zoo.dataset_num_proc")
+    _patch_device(monkeypatch, hw.DeviceType.CPU)
+    monkeypatch.setattr(policy, "multiprocessing_start_method", lambda: "fork")
+    monkeypatch.setattr(policy, "_usable_cpus", lambda: 2)
+    monkeypatch.setattr(policy, "_affordable_workers", lambda: 64)
+    monkeypatch.setattr(hw, "safe_num_proc", _unexpected_auto_sizing)
+
+    # min(max(2 // 2, 2), cap) = 2, against os.cpu_count() // 3 on the host.
+    assert hw.dataset_map_num_proc() == 2
+
+
+def test_studio_caps_still_apply_to_a_policy_chosen_count(monkeypatch):
+    """The multi-GPU fork-deadlock cap is knowledge the policy does not have."""
+    policy = pytest.importorskip("unsloth_zoo.dataset_num_proc")
+    _patch_device(monkeypatch, hw.DeviceType.CUDA, visible_gpus = 2)
+    monkeypatch.setattr(policy, "multiprocessing_start_method", lambda: "fork")
+    monkeypatch.setattr(policy, "_usable_cpus", lambda: 64)
+    monkeypatch.setattr(policy, "_affordable_workers", lambda: 64)
+    assert hw.dataset_map_num_proc() == 4
+
+
+# ---------- the escape hatch ----------
+
+
+@pytest.mark.parametrize("platform", ["win32", "darwin"])
+def test_the_override_is_honoured_on_spawn_platforms(monkeypatch, platform):
+    """The policy calls it unvetoed, so the platform veto must not swallow it.
+
+    A user who has read the dead-worker message and set this has accepted spawn
+    workers; silently ignoring it makes the documented remedy a no-op.
+    """
+    policy = pytest.importorskip("unsloth_zoo.dataset_num_proc")
+    policy.reset_warning_state()
+    monkeypatch.setattr(sys, "platform", platform)
+    monkeypatch.setenv("UNSLOTH_DATASET_NUM_PROC", "2")
+    assert hw.dataset_map_num_proc(8) == 2
+
+    # Unset, the veto stands.
+    monkeypatch.delenv("UNSLOTH_DATASET_NUM_PROC")
+    assert hw.dataset_map_num_proc(8) is None
+
+
+def test_the_override_is_not_capped_by_the_studio_heuristics(monkeypatch):
+    """Uncapped by contract, including by the multi-GPU cap Studio adds after."""
+    policy = pytest.importorskip("unsloth_zoo.dataset_num_proc")
+    policy.reset_warning_state()
+    _patch_device(monkeypatch, hw.DeviceType.CUDA, visible_gpus = 4)
+    monkeypatch.setenv("UNSLOTH_DATASET_NUM_PROC", "16")
+    assert hw.dataset_map_num_proc(2) == 16
+
+
+# ---------- the local fallback copy ----------
+
+
+def test_an_older_zoo_falls_back_to_the_unsloth_copy(monkeypatch):
+    """unsloth.dataset_num_proc is the same policy; Studio should use it too.
+
+    Only when unsloth is already imported: importing it from here would make
+    hardware detection patch torch and pull in the model stack.
+    """
+    import builtins
+
+    calls = []
+    stub = types.ModuleType("unsloth.dataset_num_proc")
+    stub.NUM_PROC_ENV_VAR = "UNSLOTH_DATASET_NUM_PROC"
+    stub.get_dataset_num_proc = lambda desired = None, *, serial_as_none = True: (
+        calls.append((desired, serial_as_none)) or 3
+    )
+    package = types.ModuleType("unsloth")
+    package.dataset_num_proc = stub
+
+    monkeypatch.setitem(sys.modules, "unsloth", package)
+    monkeypatch.setitem(sys.modules, "unsloth.dataset_num_proc", stub)
+
+    real_import = builtins.__import__
+
+    def _no_zoo_policy(name, *args, **kwargs):
+        if name == "unsloth_zoo.dataset_num_proc":
+            raise ImportError("older unsloth_zoo")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_zoo_policy)
+    _patch_device(monkeypatch, hw.DeviceType.CPU)
+
+    assert hw.dataset_map_num_proc(8) == 3
+    assert calls == [(8, True)], calls
+
+
+def test_no_policy_anywhere_keeps_the_previous_behaviour(monkeypatch):
+    """Neither module importable: the pre-policy Studio count, not a crash."""
+    import builtins
+
+    monkeypatch.delitem(sys.modules, "unsloth", raising = False)
+    real_import = builtins.__import__
+
+    def _no_policy(name, *args, **kwargs):
+        if name.endswith("dataset_num_proc"):
+            raise ImportError("no policy here")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_policy)
+    _patch_device(monkeypatch, hw.DeviceType.CPU)
+    assert hw.dataset_map_num_proc(4) == 4

--- a/studio/backend/tests/test_dataset_map_num_proc.py
+++ b/studio/backend/tests/test_dataset_map_num_proc.py
@@ -55,9 +55,8 @@ def _memory_headroom(monkeypatch):
     ``dataset_map_num_proc(4) == 4`` quietly becomes a test of the clamp. The
     cases that are about the clamp pin their own value afterwards, which wins.
     """
-    try:
-        import unsloth_zoo.dataset_num_proc as policy
-    except ImportError:
+    policy = hw._shared_policy()
+    if policy is None:
         return
     monkeypatch.setattr(policy, "_affordable_workers", lambda: 64)
 
@@ -72,6 +71,21 @@ def _require_fork(multiprocess):
     """
     if _HOST_PLATFORM == "win32" or "fork" not in multiprocess.get_all_start_methods():
         pytest.skip("needs fork to build a real worker pool")
+
+
+def _policy_or_skip():
+    """The policy module the production code will actually consult.
+
+    Not `importorskip("unsloth_zoo.dataset_num_proc")`: that module only exists
+    in the companion zoo PR, so on CI -- which clones unsloth_zoo main -- every
+    case that reached the policy skipped, and the ones that stayed exercised the
+    pre-PR path. `_shared_policy` finds this repo's own fallback copy, and
+    returning the same object it uses is also what makes monkeypatching it bite.
+    """
+    policy = hw._shared_policy()
+    if policy is None:
+        pytest.skip("no dataset_num_proc policy on this installation")
+    return policy
 
 
 def _patch_device(
@@ -258,7 +272,7 @@ def test_a_low_memory_host_gets_no_workers(monkeypatch):
     tokenizer workers to Dataset.map, which is the OOM the policy exists to stop.
     """
     _patch_device(monkeypatch, hw.DeviceType.CPU)
-    policy = pytest.importorskip("unsloth_zoo.dataset_num_proc")
+    policy = _policy_or_skip()
     monkeypatch.setattr(policy, "_affordable_workers", lambda: 0)
     monkeypatch.setattr(policy, "multiprocessing_start_method", lambda: "fork")
     assert hw.dataset_map_num_proc(8) is None
@@ -266,7 +280,7 @@ def test_a_low_memory_host_gets_no_workers(monkeypatch):
 
 def test_the_memory_clamp_reduces_rather_than_refuses(monkeypatch):
     _patch_device(monkeypatch, hw.DeviceType.CPU)
-    policy = pytest.importorskip("unsloth_zoo.dataset_num_proc")
+    policy = _policy_or_skip()
     monkeypatch.setattr(policy, "_affordable_workers", lambda: 3)
     monkeypatch.setattr(policy, "multiprocessing_start_method", lambda: "fork")
     assert hw.dataset_map_num_proc(8) == 3
@@ -275,7 +289,7 @@ def test_the_memory_clamp_reduces_rather_than_refuses(monkeypatch):
 def test_the_env_override_reaches_these_callers(monkeypatch):
     # The cap's log line used to advertise this on a path that never read it.
     _patch_device(monkeypatch, hw.DeviceType.CPU)
-    policy = pytest.importorskip("unsloth_zoo.dataset_num_proc")
+    policy = _policy_or_skip()
     monkeypatch.setattr(policy, "multiprocessing_start_method", lambda: "fork")
     policy.reset_warning_state()
 
@@ -336,7 +350,7 @@ def test_a_serial_request_survives_the_config_round_trip(monkeypatch):
     # The map-site half of this needs the policy: without it
     # _bounded_by_the_shared_policy returns the count unchanged by design, so a
     # runner with no unsloth_zoo reads 1 rather than None.
-    pytest.importorskip("unsloth_zoo.dataset_num_proc")
+    _policy_or_skip()
     _patch_device(monkeypatch, hw.DeviceType.CPU)
     assert hw.dataset_map_num_proc(1, serial_as_none = False) == 1
     # The map-site default is what turns it back into "no pool" at the call.
@@ -345,7 +359,7 @@ def test_a_serial_request_survives_the_config_round_trip(monkeypatch):
 
 def test_the_config_value_is_still_in_process_after_the_layer_reads_it(monkeypatch):
     """End to end: what Studio stores, read back the way the SFT config layer reads it."""
-    policy = pytest.importorskip("unsloth_zoo.dataset_num_proc")
+    policy = _policy_or_skip()
     _patch_device(monkeypatch, hw.DeviceType.CPU)
 
     stored = hw.dataset_map_num_proc(1, serial_as_none = False)
@@ -384,7 +398,7 @@ def test_spawn_platforms_keep_none_at_either_layer(monkeypatch, platform):
 
 def test_every_other_caller_keeps_the_map_site_default(monkeypatch):
     """Only the config boundary opts in; the seven map-site callers must not."""
-    pytest.importorskip("unsloth_zoo.dataset_num_proc")
+    _policy_or_skip()
     _patch_device(monkeypatch, hw.DeviceType.CPU)
     assert hw.dataset_map_num_proc(1) is None
     assert hw.dataset_map_num_proc(4) == 4
@@ -440,7 +454,7 @@ def test_an_auto_request_is_sized_by_the_policy_not_by_the_host_cpu_count(monkey
     mask and the cgroup quota, so a 2-core container on a 64-core box asked for
     ``cpu_count // 3`` workers and was bounded only by memory.
     """
-    policy = pytest.importorskip("unsloth_zoo.dataset_num_proc")
+    policy = _policy_or_skip()
     _patch_device(monkeypatch, hw.DeviceType.CPU)
     monkeypatch.setattr(policy, "multiprocessing_start_method", lambda: "fork")
     monkeypatch.setattr(policy, "_usable_cpus", lambda: 2)
@@ -453,7 +467,7 @@ def test_an_auto_request_is_sized_by_the_policy_not_by_the_host_cpu_count(monkey
 
 def test_studio_caps_still_apply_to_a_policy_chosen_count(monkeypatch):
     """The multi-GPU fork-deadlock cap is knowledge the policy does not have."""
-    policy = pytest.importorskip("unsloth_zoo.dataset_num_proc")
+    policy = _policy_or_skip()
     _patch_device(monkeypatch, hw.DeviceType.CUDA, visible_gpus = 2)
     monkeypatch.setattr(policy, "multiprocessing_start_method", lambda: "fork")
     monkeypatch.setattr(policy, "_usable_cpus", lambda: 64)
@@ -471,7 +485,7 @@ def test_the_override_is_honoured_on_spawn_platforms(monkeypatch, platform):
     A user who has read the dead-worker message and set this has accepted spawn
     workers; silently ignoring it makes the documented remedy a no-op.
     """
-    policy = pytest.importorskip("unsloth_zoo.dataset_num_proc")
+    policy = _policy_or_skip()
     policy.reset_warning_state()
     monkeypatch.setattr(sys, "platform", platform)
     monkeypatch.setenv("UNSLOTH_DATASET_NUM_PROC", "2")
@@ -484,7 +498,7 @@ def test_the_override_is_honoured_on_spawn_platforms(monkeypatch, platform):
 
 def test_the_override_is_not_capped_by_the_studio_heuristics(monkeypatch):
     """Uncapped by contract, including by the multi-GPU cap Studio adds after."""
-    policy = pytest.importorskip("unsloth_zoo.dataset_num_proc")
+    policy = _policy_or_skip()
     policy.reset_warning_state()
     _patch_device(monkeypatch, hw.DeviceType.CUDA, visible_gpus = 4)
     monkeypatch.setenv("UNSLOTH_DATASET_NUM_PROC", "16")
@@ -551,7 +565,7 @@ def test_the_override_is_honoured_after_xpu_init(monkeypatch):
     The XPU guard exists because fork corrupts the Level-Zero context, but a
     user who has read the dead-worker message and set this has accepted that.
     """
-    policy = pytest.importorskip("unsloth_zoo.dataset_num_proc")
+    policy = _policy_or_skip()
     policy.reset_warning_state()
     _patch_device(monkeypatch, hw.DeviceType.XPU)
     _patch_runtime(monkeypatch, "xpu", is_initialized = True)
@@ -572,7 +586,7 @@ def test_an_ignored_override_does_not_skip_the_studio_caps(monkeypatch, raw):
     Treating any non-empty value as an active override let a typo skip the
     multi-GPU fork-deadlock cap while contributing nothing in its place.
     """
-    policy = pytest.importorskip("unsloth_zoo.dataset_num_proc")
+    policy = _policy_or_skip()
     policy.reset_warning_state()
     monkeypatch.setattr(policy, "multiprocessing_start_method", lambda: "fork")
     monkeypatch.setattr(policy, "_affordable_workers", lambda: 64)

--- a/studio/backend/tests/test_dataset_map_num_proc.py
+++ b/studio/backend/tests/test_dataset_map_num_proc.py
@@ -3,7 +3,7 @@
 
 """Tests for ``dataset_map_num_proc()``.
 
-``None``, not ``1``, is the disable sentinel: on ``datasets`` >= 4.0 (Studio pins
+``None``, not ``1``, is the disable sentinel: on ``datasets`` >= 4.1 (Studio pins
 4.3.0) ``map()`` takes the pool branch for any ``num_proc >= 1``, so ``1`` still
 builds a ``Pool(1)``. ``datasets`` 3.x runs ``1`` in-process, so the version
 split is asserted per installed release rather than hard-coded.
@@ -97,7 +97,7 @@ def test_dataset_map_num_proc_parallel_before_xpu_init(monkeypatch):
 
 @pytest.mark.parametrize("platform", ["win32", "darwin"])
 def test_dataset_map_num_proc_none_on_spawn_platforms(monkeypatch, platform):
-    # Must be None and never 1: datasets >= 4.0 builds a Pool(1) for num_proc=1.
+    # Must be None and never 1: datasets >= 4.1 builds a Pool(1) for num_proc=1.
     monkeypatch.setattr(sys, "platform", platform)
     assert hw.dataset_map_num_proc(4) is None
 
@@ -175,7 +175,7 @@ def test_num_proc_one_is_not_a_disable_sentinel():
     finally:
         datasets.arrow_dataset.Pool = original
 
-    if Version(datasets.__version__) >= Version("4.0.0"):
+    if Version(datasets.__version__) >= Version("4.1.0"):
         assert built_for_one == 1, (
             f"datasets {datasets.__version__} was expected to build a Pool(1); "
             "if that changed, dataset_map_num_proc's docstring needs updating"

--- a/studio/backend/tests/test_dataset_map_num_proc.py
+++ b/studio/backend/tests/test_dataset_map_num_proc.py
@@ -231,3 +231,78 @@ def test_num_proc_one_is_not_a_disable_sentinel():
         )
     else:
         assert built_for_one == 0
+
+
+# ---------- the value that reaches Dataset.map is bounded like any other ----------
+
+
+def test_a_low_memory_host_gets_no_workers(monkeypatch):
+    """format_conversion.py and chat_templates.py call this directly.
+
+    Without the shared policy a 2GB container with eight cores still handed eight
+    tokenizer workers to Dataset.map, which is the OOM the policy exists to stop.
+    """
+    _patch_device(monkeypatch, hw.DeviceType.CPU)
+    policy = pytest.importorskip("unsloth_zoo.dataset_num_proc")
+    monkeypatch.setattr(policy, "_affordable_workers", lambda: 0)
+    monkeypatch.setattr(policy, "multiprocessing_start_method", lambda: "fork")
+    assert hw.dataset_map_num_proc(8) is None
+
+
+def test_the_memory_clamp_reduces_rather_than_refuses(monkeypatch):
+    _patch_device(monkeypatch, hw.DeviceType.CPU)
+    policy = pytest.importorskip("unsloth_zoo.dataset_num_proc")
+    monkeypatch.setattr(policy, "_affordable_workers", lambda: 3)
+    monkeypatch.setattr(policy, "multiprocessing_start_method", lambda: "fork")
+    assert hw.dataset_map_num_proc(8) == 3
+
+
+def test_the_env_override_reaches_these_callers(monkeypatch):
+    # The cap's log line used to advertise this on a path that never read it.
+    _patch_device(monkeypatch, hw.DeviceType.CPU)
+    policy = pytest.importorskip("unsloth_zoo.dataset_num_proc")
+    monkeypatch.setattr(policy, "multiprocessing_start_method", lambda: "fork")
+    policy.reset_warning_state()
+
+    monkeypatch.setenv("UNSLOTH_DATASET_NUM_PROC", "2")
+    assert hw.dataset_map_num_proc(8) == 2
+
+    monkeypatch.setenv("UNSLOTH_DATASET_NUM_PROC", "0")
+    assert hw.dataset_map_num_proc(8) is None
+
+
+def test_an_older_unsloth_zoo_keeps_the_previous_behaviour(monkeypatch):
+    # The policy is a lazy, guarded import: hardware detection must not start
+    # depending on the training package.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_policy(name, *args, **kwargs):
+        if name == "unsloth_zoo.dataset_num_proc":
+            raise ImportError("older unsloth_zoo")
+        return real_import(name, *args, **kwargs)
+
+    _patch_device(monkeypatch, hw.DeviceType.CPU)
+    monkeypatch.setattr(builtins, "__import__", _no_policy)
+    assert hw.dataset_map_num_proc(4) == 4
+
+
+def test_the_cap_no_longer_advertises_an_override_it_cannot_honour():
+    """safe_num_proc returns an int >= 1, so it cannot express in-process.
+
+    Naming the variable there told users to set something that path never read.
+    """
+    import ast
+    import inspect
+
+    tree = ast.parse(inspect.getsource(hw.safe_num_proc))
+    logged = [
+        ast.unparse(node)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and ast.unparse(node.func).startswith("logger.")
+    ]
+    assert logged, "the cap stopped logging; re-check what this is guarding"
+    assert not any("UNSLOTH_DATASET_NUM_PROC" in line for line in logged), (
+        "safe_num_proc tells the user to set an override it never reads"
+    )

--- a/studio/backend/tests/test_dataset_map_num_proc.py
+++ b/studio/backend/tests/test_dataset_map_num_proc.py
@@ -528,3 +528,75 @@ def test_no_policy_anywhere_keeps_the_previous_behaviour(monkeypatch):
     monkeypatch.setattr(builtins, "__import__", _no_policy)
     _patch_device(monkeypatch, hw.DeviceType.CPU)
     assert hw.dataset_map_num_proc(4) == 4
+
+
+def test_the_override_is_honoured_after_xpu_init(monkeypatch):
+    """Same contract as the spawn platforms: the hatch is unvetoed.
+
+    The XPU guard exists because fork corrupts the Level-Zero context, but a
+    user who has read the dead-worker message and set this has accepted that.
+    """
+    policy = pytest.importorskip("unsloth_zoo.dataset_num_proc")
+    policy.reset_warning_state()
+    _patch_device(monkeypatch, hw.DeviceType.XPU)
+    _patch_runtime(monkeypatch, "xpu", is_initialized = True)
+
+    monkeypatch.setenv("UNSLOTH_DATASET_NUM_PROC", "2")
+    assert hw.dataset_map_num_proc(8) == 2
+
+    # Unset, the veto stands at both layers.
+    monkeypatch.delenv("UNSLOTH_DATASET_NUM_PROC")
+    assert hw.dataset_map_num_proc(8) is None
+    assert hw.dataset_map_num_proc(8, serial_as_none = False) == 1
+
+
+@pytest.mark.parametrize("raw", ["-1", "not-a-number"])
+def test_an_ignored_override_does_not_skip_the_studio_caps(monkeypatch, raw):
+    """The policy warns and ignores these, so they are not the hatch.
+
+    Treating any non-empty value as an active override let a typo skip the
+    multi-GPU fork-deadlock cap while contributing nothing in its place.
+    """
+    policy = pytest.importorskip("unsloth_zoo.dataset_num_proc")
+    policy.reset_warning_state()
+    monkeypatch.setattr(policy, "multiprocessing_start_method", lambda: "fork")
+    monkeypatch.setattr(policy, "_affordable_workers", lambda: 64)
+    _patch_device(monkeypatch, hw.DeviceType.CUDA, visible_gpus = 4)
+
+    monkeypatch.setenv("UNSLOTH_DATASET_NUM_PROC", raw)
+    assert hw.dataset_map_num_proc(16) == 4
+
+
+def test_the_trainer_leaves_the_ordinary_case_to_the_policy():
+    """The non-audio branch must be None, not a host-derived count.
+
+    ``get_dataset_num_proc`` reads any integer as an explicit request and skips
+    its own auto path, which is the only one that consults this process's CPU
+    affinity and cgroup quota. A count computed from ``os.cpu_count()`` here
+    therefore hides the container from the policy.
+    """
+    import ast
+    from pathlib import Path
+
+    source = (
+        Path(__file__).resolve().parents[1] / "core" / "training" / "trainer.py"
+    ).read_text(encoding = "utf-8")
+
+    calls = [
+        value
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Dict)
+        for key, value in zip(node.keys, node.values)
+        if isinstance(key, ast.Constant)
+        and key.value == "dataset_num_proc"
+        and isinstance(value, ast.Call)
+        and ast.unparse(value.func) == "dataset_map_num_proc"
+    ]
+    assert calls, "the SFTConfig dataset_num_proc entry moved; re-check this guard"
+    for call in calls:
+        requested = ast.unparse(call.args[0])
+        assert "cpu_count" not in requested, (
+            "the ordinary case is being sized from the host CPU count before the "
+            f"policy can see it: {requested}"
+        )
+        assert requested.rstrip().endswith("None"), requested

--- a/studio/backend/tests/test_dataset_map_num_proc.py
+++ b/studio/backend/tests/test_dataset_map_num_proc.py
@@ -38,6 +38,20 @@ def _fork_platform(monkeypatch):
     monkeypatch.setattr(sys, "platform", "linux")
 
 
+def _require_fork(multiprocess):
+    """Skip when this host cannot fork.
+
+    The two tests below build real worker processes to observe whether
+    ``datasets`` takes its pool branch. That is a claim about the num_proc
+    guard, not about any particular start method, and under spawn inside pytest
+    the pool itself fails for unrelated reasons (WinError 10038 closing a
+    handle, os.WNOHANG missing). The version split they assert is checked
+    without processes in tests/utils/test_dataset_num_proc.py.
+    """
+    if "fork" not in multiprocess.get_all_start_methods():
+        pytest.skip("needs fork to build a real worker pool")
+
+
 def _patch_device(
     monkeypatch,
     device,
@@ -148,7 +162,8 @@ def test_none_builds_no_pool_but_a_count_does(monkeypatch):
     installed ``datasets`` rather than trusting the docstring.
     """
     datasets = pytest.importorskip("datasets")
-    import multiprocess
+    multiprocess = pytest.importorskip("multiprocess")
+    _require_fork(multiprocess)
 
     pools_built = []
     real_pool = multiprocess.Pool
@@ -181,7 +196,8 @@ def test_num_proc_one_is_not_a_disable_sentinel():
     installed version rather than picking one and hard-coding it.
     """
     datasets = pytest.importorskip("datasets")
-    import multiprocess  # noqa: F401
+    multiprocess = pytest.importorskip("multiprocess")
+    _require_fork(multiprocess)
     from packaging.version import Version
 
     pools_built = []

--- a/studio/backend/tests/test_dataset_map_num_proc.py
+++ b/studio/backend/tests/test_dataset_map_num_proc.py
@@ -306,3 +306,99 @@ def test_the_cap_no_longer_advertises_an_override_it_cannot_honour():
     assert not any(
         "UNSLOTH_DATASET_NUM_PROC" in line for line in logged
     ), "safe_num_proc tells the user to set an override it never reads"
+
+
+# ---------- the config boundary spells "in-process" as 1, not None ----------
+#
+# trainer.py writes this value into SFTConfig.dataset_num_proc rather than
+# handing it to map(). Every downstream reader treats a config None as
+# "auto-size me", so a serial request stored as None comes back out as a full
+# worker set: dataset_map_num_proc(1) -> None -> SFTConfig -> 8.
+
+
+def test_a_serial_request_survives_the_config_round_trip(monkeypatch):
+    """The audio paths ask for 1; the config layer must still see a request for 1."""
+    _patch_device(monkeypatch, hw.DeviceType.CPU)
+    assert hw.dataset_map_num_proc(1, serial_as_none = False) == 1
+    # The map-site default is what turns it back into "no pool" at the call.
+    assert hw.dataset_map_num_proc(1) is None
+
+
+def test_the_config_value_is_still_in_process_after_the_layer_reads_it(monkeypatch):
+    """End to end: what Studio stores, read back the way the SFT config layer reads it."""
+    policy = pytest.importorskip("unsloth_zoo.dataset_num_proc")
+    _patch_device(monkeypatch, hw.DeviceType.CPU)
+
+    stored = hw.dataset_map_num_proc(1, serial_as_none = False)
+    # rl.py generates serial_as_none = False for sft_trainer, then the map-site
+    # rewrite converts the config value for the actual Dataset.map call.
+    from_config = policy.get_dataset_num_proc(stored, serial_as_none = False)
+    at_the_map_site = policy.get_dataset_num_proc(from_config)
+    assert (stored, from_config, at_the_map_site) == (1, 1, None)
+
+
+def test_xpu_initialized_stays_serial_through_a_config(monkeypatch):
+    """The one guard where a config None is actively dangerous.
+
+    Unlike the spawn platforms, forking still works here, so an auto-sizer
+    reading a config None would fork the corrupted Level-Zero context this
+    guard exists to protect.
+    """
+    _patch_device(monkeypatch, hw.DeviceType.XPU)
+    _patch_runtime(monkeypatch, "xpu", is_initialized = True)
+    assert hw.dataset_map_num_proc(4, serial_as_none = False) == 1
+    assert hw.dataset_map_num_proc(4) is None
+
+
+@pytest.mark.parametrize("platform", ["win32", "darwin"])
+def test_spawn_platforms_keep_none_at_either_layer(monkeypatch, platform):
+    """None is safe to store here: no reader can inflate it.
+
+    Workers are unusable on a spawn platform, so every auto-sizer vetoes. A 1
+    would be worse: only the SFT map site is rewritten, so DPO/KTO/CPO/ORPO and
+    friends would hand that 1 to Dataset.map and get a Pool(1) whose child
+    re-imports the user's __main__ (#3211 / #3397).
+    """
+    monkeypatch.setattr(sys, "platform", platform)
+    assert hw.dataset_map_num_proc(4, serial_as_none = False) is None
+
+
+def test_every_other_caller_keeps_the_map_site_default(monkeypatch):
+    """Only the config boundary opts in; the seven map-site callers must not."""
+    _patch_device(monkeypatch, hw.DeviceType.CPU)
+    assert hw.dataset_map_num_proc(1) is None
+    assert hw.dataset_map_num_proc(4) == 4
+
+
+def test_the_trainer_config_asks_for_the_config_sentinel():
+    """The call that builds SFTConfig must pass serial_as_none = False.
+
+    Dropping it is silent: the run still trains, just with a worker set where
+    the audio paths asked for none.
+    """
+    import ast
+    from pathlib import Path
+
+    source = (
+        Path(__file__).resolve().parents[1] / "core" / "training" / "trainer.py"
+    ).read_text(encoding = "utf-8")
+    tree = ast.parse(source)
+
+    config_calls = [
+        value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Dict)
+        for key, value in zip(node.keys, node.values)
+        if isinstance(key, ast.Constant)
+        and key.value == "dataset_num_proc"
+        and isinstance(value, ast.Call)
+        and ast.unparse(value.func) == "dataset_map_num_proc"
+    ]
+    assert config_calls, "the SFTConfig dataset_num_proc entry moved; re-check this guard"
+    for call in config_calls:
+        keywords = {kw.arg: ast.unparse(kw.value) for kw in call.keywords}
+        assert keywords.get("serial_as_none") == "False", (
+            "a config-boundary dataset_map_num_proc call lost serial_as_none = False, "
+            "so a serial request will be read back as 'auto-size me': "
+            f"{ast.unparse(call)}"
+        )

--- a/studio/backend/tests/test_dataset_map_num_proc.py
+++ b/studio/backend/tests/test_dataset_map_num_proc.py
@@ -25,10 +25,9 @@ import pytest
 import utils.hardware.hardware as hw
 
 try:
-    # Before the fixture below spoofs sys.platform: multiprocess picks its
-    # concrete contexts from sys.platform at import time, so a first import under
-    # a spoofed one hands a Windows runner the POSIX fork contexts and the pool
-    # then dies reaching for os.WNOHANG.
+    # Import before the fixture below spoofs sys.platform: multiprocess picks its
+    # contexts at import time, so a Windows runner would get POSIX fork contexts
+    # and the pool would then die reaching for os.WNOHANG.
     import multiprocess  # noqa: F401
 except ImportError:
     pass
@@ -108,11 +107,10 @@ def _patch_runtime(monkeypatch, name, *, is_initialized):
 def test_dataset_map_num_proc_parallelizes_on_initialized_cuda(monkeypatch):
     """An initialized CUDA context must not disable dataset workers.
 
-    Forking after torch.cuda._lazy_init() is a hazard in general, but the map
-    child only runs the tokenizer, and 300 forced-fork map() runs on an
+    The map child only runs the tokenizer, and 300 forced-fork map() runs on an
     initialized context produced no failures. Since detect_hardware() always
-    initializes CUDA, a guard would serialize tokenization for every CUDA run.
-    Pinned so it is not added back without new evidence.
+    initializes CUDA, a guard would serialize every CUDA run. Pinned so it is
+    not added back without new evidence.
     """
     _patch_device(monkeypatch, hw.DeviceType.CUDA)
     _patch_runtime(monkeypatch, "cuda", is_initialized = True)

--- a/studio/backend/tests/test_dataset_map_num_proc.py
+++ b/studio/backend/tests/test_dataset_map_num_proc.py
@@ -379,9 +379,9 @@ def test_the_trainer_config_asks_for_the_config_sentinel():
     import ast
     from pathlib import Path
 
-    source = (
-        Path(__file__).resolve().parents[1] / "core" / "training" / "trainer.py"
-    ).read_text(encoding = "utf-8")
+    source = (Path(__file__).resolve().parents[1] / "core" / "training" / "trainer.py").read_text(
+        encoding = "utf-8"
+    )
     tree = ast.parse(source)
 
     config_calls = [

--- a/studio/backend/tests/test_dataset_map_num_proc.py
+++ b/studio/backend/tests/test_dataset_map_num_proc.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+"""Tests for ``dataset_map_num_proc()``.
+
+``None``, not ``1``, is the disable sentinel: on ``datasets`` >= 4.0 (Studio pins
+4.3.0) ``map()`` takes the pool branch for any ``num_proc >= 1``, so ``1`` still
+builds a ``Pool(1)``. ``datasets`` 3.x runs ``1`` in-process, so the version
+split is asserted per installed release rather than hard-coded.
+
+There is deliberately no CUDA-initialized guard here; see the note in
+``dataset_map_num_proc``'s docstring. The XPU guard is pre-existing behaviour and
+is covered below so it cannot regress.
+
+The probes are monkeypatched so this runs on any host, GPU or not.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+import utils.hardware.hardware as hw
+
+
+def _patch_device(monkeypatch, device, *, visible_gpus: int = 1):
+    monkeypatch.setattr(hw, "get_device", lambda: device)
+    monkeypatch.setattr(hw, "get_visible_gpu_count", lambda: visible_gpus)
+
+
+def _patch_runtime(monkeypatch, name, *, is_initialized):
+    """Install a fake ``torch.<name>`` whose is_initialized() we control.
+
+    ``is_initialized`` may be a bool or a callable that raises, to model a probe
+    that fails rather than answering.
+    """
+    import torch
+
+    if callable(is_initialized):
+        probe = is_initialized
+    else:
+        probe = lambda: is_initialized  # noqa: E731
+
+    monkeypatch.setattr(
+        torch, name, types.SimpleNamespace(is_initialized = probe), raising = False
+    )
+
+
+# ---------- CUDA: initialization must NOT disable workers ----------
+
+
+def test_dataset_map_num_proc_parallelizes_on_initialized_cuda(monkeypatch):
+    """An initialized CUDA context must not disable dataset workers.
+
+    Forking after torch.cuda._lazy_init() is a real hazard in general, but the
+    map child only runs the tokenizer and never touches CUDA. 300 forced-fork
+    map() runs on an initialized context produced no failures, and since
+    detect_hardware() always initializes CUDA, a guard here would serialize
+    tokenization for every CUDA training run. Pinned so it is not added back
+    without new evidence.
+    """
+    _patch_device(monkeypatch, hw.DeviceType.CUDA)
+    _patch_runtime(monkeypatch, "cuda", is_initialized = True)
+    assert hw.dataset_map_num_proc(4) == 4
+
+
+def test_dataset_map_num_proc_cuda_respects_multi_gpu_cap(monkeypatch):
+    # CUDA still routes through safe_num_proc, which caps to 4 on multi-GPU.
+    _patch_device(monkeypatch, hw.DeviceType.CUDA)
+    _patch_runtime(monkeypatch, "cuda", is_initialized = True)
+    monkeypatch.setattr(hw, "get_visible_gpu_count", lambda: 2)
+    assert hw.dataset_map_num_proc(16) == 4
+
+
+# ---------- XPU (regression guard: the pre-existing behaviour must not move) ----------
+
+
+def test_dataset_map_num_proc_none_after_xpu_init(monkeypatch):
+    _patch_device(monkeypatch, hw.DeviceType.XPU)
+    _patch_runtime(monkeypatch, "xpu", is_initialized = True)
+    assert hw.dataset_map_num_proc(4) is None
+
+
+def test_dataset_map_num_proc_parallel_before_xpu_init(monkeypatch):
+    _patch_device(monkeypatch, hw.DeviceType.XPU)
+    _patch_runtime(monkeypatch, "xpu", is_initialized = False)
+    assert hw.dataset_map_num_proc(4) == 4
+
+
+# ---------- platform ----------
+
+
+@pytest.mark.parametrize("platform", ["win32", "darwin"])
+def test_dataset_map_num_proc_none_on_spawn_platforms(monkeypatch, platform):
+    # Must be None and never 1: datasets >= 4.0 builds a Pool(1) for num_proc=1.
+    monkeypatch.setattr(sys, "platform", platform)
+    assert hw.dataset_map_num_proc(4) is None
+
+
+def test_dataset_map_num_proc_cpu_host_parallelizes(monkeypatch):
+    # No accelerator to corrupt, so preprocessing may use workers.
+    _patch_device(monkeypatch, hw.DeviceType.CPU)
+    assert hw.dataset_map_num_proc(4) == 4
+
+
+# ---------- the value actually reaches datasets as "no pool" ----------
+
+
+def test_none_builds_no_pool_but_a_count_does(monkeypatch):
+    """The disable sentinel must actually reach ``datasets`` as "no pool".
+
+    This is the property the whole module rests on, so assert it against the
+    installed ``datasets`` rather than trusting the docstring.
+    """
+    datasets = pytest.importorskip("datasets")
+    import multiprocess
+
+    pools_built = []
+    real_pool = multiprocess.Pool
+
+    def _spy_pool(*args, **kwargs):
+        pools_built.append((args, kwargs))
+        return real_pool(*args, **kwargs)
+
+    monkeypatch.setattr(multiprocess, "Pool", _spy_pool)
+    monkeypatch.setattr(datasets.arrow_dataset, "Pool", _spy_pool, raising = False)
+
+    dataset = datasets.Dataset.from_dict({"text": [f"row {i}" for i in range(8)]})
+    _count = lambda batch: {"n": [len(t) for t in batch["text"]]}  # noqa: E731
+
+    mapped = dataset.map(_count, batched = True, num_proc = None)
+    assert len(mapped) == 8
+    assert pools_built == [], f"Dataset.map built a worker pool: {pools_built}"
+
+    # Control: the spy is live, so the assertion above means something.
+    dataset.map(_count, batched = True, num_proc = 2)
+    assert len(pools_built) == 1, "Pool spy never fired; the no-pool check is vacuous"
+
+
+def test_num_proc_one_is_not_a_disable_sentinel():
+    """Pin the reason ``dataset_map_num_proc`` returns ``None`` and never ``1``.
+
+    ``datasets`` changed this: 3.x runs ``num_proc=1`` in-process, 4.x (Studio
+    pins 4.3.0) takes the pool branch for any ``num_proc >= 1`` and builds a
+    ``Pool(1)``. Only ``None`` is in-process on both, so this asserts per
+    installed version rather than picking one and hard-coding it.
+    """
+    datasets = pytest.importorskip("datasets")
+    import multiprocess  # noqa: F401
+    from packaging.version import Version
+
+    pools_built = []
+    real_pool = datasets.arrow_dataset.Pool
+
+    def _spy_pool(*args, **kwargs):
+        pools_built.append((args, kwargs))
+        return real_pool(*args, **kwargs)
+
+    dataset = datasets.Dataset.from_dict({"text": [f"row {i}" for i in range(8)]})
+    _count = lambda batch: {"n": [len(t) for t in batch["text"]]}  # noqa: E731
+
+    original = datasets.arrow_dataset.Pool
+    datasets.arrow_dataset.Pool = _spy_pool
+    try:
+        dataset.map(_count, batched = True, num_proc = None)
+        assert pools_built == [], "num_proc=None must always run in-process"
+
+        dataset.map(_count, batched = True, num_proc = 1)
+        built_for_one = len(pools_built)
+    finally:
+        datasets.arrow_dataset.Pool = original
+
+    if Version(datasets.__version__) >= Version("4.0.0"):
+        assert built_for_one == 1, (
+            f"datasets {datasets.__version__} was expected to build a Pool(1); "
+            "if that changed, dataset_map_num_proc's docstring needs updating"
+        )
+    else:
+        assert built_for_one == 0

--- a/studio/backend/tests/test_dataset_map_num_proc.py
+++ b/studio/backend/tests/test_dataset_map_num_proc.py
@@ -232,18 +232,24 @@ def test_num_proc_one_is_not_a_disable_sentinel():
     _require_fork(multiprocess)
     from packaging.version import Version
 
-    pools_built = []
-    real_pool = datasets.arrow_dataset.Pool
+    # Counted at the Pool class rather than at datasets.arrow_dataset.Pool:
+    # 3.x and 4.x do `from multiprocess import Pool`, but 5.x calls `mp.Pool()`
+    # and a spawn context instead, so the module attribute is simply absent
+    # there and patching it is an AttributeError. Every one of those routes
+    # constructs this class.
+    import multiprocess.pool
 
-    def _spy_pool(*args, **kwargs):
+    pools_built = []
+    real_init = multiprocess.pool.Pool.__init__
+
+    def _spy_init(self, *args, **kwargs):
         pools_built.append((args, kwargs))
-        return real_pool(*args, **kwargs)
+        return real_init(self, *args, **kwargs)
 
     dataset = datasets.Dataset.from_dict({"text": [f"row {i}" for i in range(8)]})
     _count = lambda batch: {"n": [len(t) for t in batch["text"]]}  # noqa: E731
 
-    original = datasets.arrow_dataset.Pool
-    datasets.arrow_dataset.Pool = _spy_pool
+    multiprocess.pool.Pool.__init__ = _spy_init
     try:
         dataset.map(_count, batched = True, num_proc = None)
         assert pools_built == [], "num_proc=None must always run in-process"
@@ -251,7 +257,7 @@ def test_num_proc_one_is_not_a_disable_sentinel():
         dataset.map(_count, batched = True, num_proc = 1)
         built_for_one = len(pools_built)
     finally:
-        datasets.arrow_dataset.Pool = original
+        multiprocess.pool.Pool.__init__ = real_init
 
     if Version(datasets.__version__) >= Version("4.1.0"):
         assert built_for_one == 1, (

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -3255,6 +3255,14 @@ def get_torch_device_str() -> str:
     return "cpu"
 
 
+# Mirrors AUTO_NUM_PROC_CAP in unsloth.utils.dataset_num_proc. Duplicated rather
+# than imported because that import pulls in unsloth's whole __init__, and this
+# module is loaded during hardware detection long before any of it is needed;
+# tests/utils/test_dataset_num_proc.py carries a canary that fails if the two
+# ever drift, the same arrangement the Zoo's row threshold already uses.
+_STUDIO_NUM_PROC_CAP = 8
+
+
 def safe_num_proc(desired: Optional[int] = None) -> int:
     """
     Return a safe ``num_proc`` for ``dataset.map()`` calls.
@@ -3282,6 +3290,23 @@ def safe_num_proc(desired: Optional[int] = None) -> int:
 
     if desired is None or not isinstance(desired, int):
         desired = max(1, (os.cpu_count() or 1) // 3)
+
+    # Bound it. Every number reaching here is a backend heuristic, not something
+    # a user typed: the line above is cpu_count // 3 and trainer.py asks for
+    # cpu_count // 4, so a 64-core host produces 16 and a 192-core one 48.
+    # unsloth.utils.dataset_num_proc reads an explicit int as a deliberate
+    # request and only clamps it by free memory, so on a large machine with RAM
+    # to spare those counts survive all the way to Dataset.map -- which is the
+    # shape of issue #2693, and slower besides: 32 workers measured 14.2s
+    # against 6.3s in-process, at ~1GB each. UNSLOTH_DATASET_NUM_PROC still
+    # overrides, since it is read downstream and bypasses this entirely.
+    if desired > _STUDIO_NUM_PROC_CAP:
+        logger.info(
+            f"num_proc {desired} -> {_STUDIO_NUM_PROC_CAP}: tokenization stops "
+            f"scaling well before this and each worker holds its own tokenizer "
+            f"copy. Set UNSLOTH_DATASET_NUM_PROC to override."
+        )
+        desired = _STUDIO_NUM_PROC_CAP
 
     visible = get_visible_gpu_count()
     if visible > 1:

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -3403,9 +3403,7 @@ def dataset_map_num_proc(
     return _bounded_by_the_shared_policy(safe_num_proc(desired), serial_as_none)
 
 
-def _bounded_by_the_shared_policy(
-    num_proc: int, serial_as_none: bool = True
-) -> Optional[int]:
+def _bounded_by_the_shared_policy(num_proc: int, serial_as_none: bool = True) -> Optional[int]:
     """Apply the training-side num_proc policy to a Studio-computed count.
 
     ``format_conversion.py`` and ``chat_templates.py`` hand this straight to

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -3399,6 +3399,11 @@ def dataset_map_num_proc(
         if callable(is_initialized):
             try:
                 if is_initialized():
+                    # Same reading as the spawn branch above: the hatch is
+                    # unvetoed by contract, so someone who has accepted the
+                    # risk on XPU is not overruled here without a word.
+                    if _num_proc_override_is_set():
+                        return _bounded_by_the_shared_policy(desired, serial_as_none)
                     # Unlike the spawn platforms above, forking is still
                     # available here, so a config ``None`` WOULD be auto-sized
                     # back up and fork the corrupted Level-Zero context this
@@ -3437,10 +3442,26 @@ def _shared_policy():
 
 
 def _num_proc_override_is_set() -> bool:
+    """Whether the escape hatch decided the count, not merely whether it is set.
+
+    The policy ignores an unparseable or negative value with a warning, so
+    reading the variable directly would let ``UNSLOTH_DATASET_NUM_PROC=-1``
+    skip the multi-GPU cap while contributing nothing.
+    """
     policy = _shared_policy()
     if policy is None:
         return False
-    return bool(os.environ.get(policy.NUM_PROC_ENV_VAR, "").strip())
+    parsed = getattr(policy, "environment_override", None)
+    if parsed is None:
+        # A policy that predates the public reader: presence is the best
+        # available answer, and it errs toward honouring the hatch.
+        return bool(os.environ.get(policy.NUM_PROC_ENV_VAR, "").strip())
+    try:
+        was_set, _value = parsed()
+    except Exception as e:
+        logger.debug("dataset_num_proc override unreadable: %s", e)
+        return False
+    return bool(was_set)
 
 
 def _bounded_by_the_shared_policy(

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -3320,7 +3320,7 @@ def dataset_map_num_proc(desired: Optional[int] = None) -> Optional[int]:
     Return a safe ``num_proc`` for ``Dataset.map()`` and ``Dataset.filter()``.
 
     Returns ``None`` on spawn platforms (Windows, macOS). ``None`` -- not ``1``
-    -- is the disable sentinel: on ``datasets`` >= 4.0 (Studio pins 4.3.0)
+    -- is the disable sentinel: on ``datasets`` >= 4.1 (Studio pins 4.3.0)
     ``map()`` takes the pool branch for any ``num_proc >= 1``, so ``num_proc=1``
     still builds a ``Pool(1)``. Older ``datasets`` (the 3.x range the library
     extra still allows) does run ``num_proc=1`` in-process, but only ``None``

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -3319,14 +3319,26 @@ def dataset_map_num_proc(desired: Optional[int] = None) -> Optional[int]:
     """
     Return a safe ``num_proc`` for ``Dataset.map()`` and ``Dataset.filter()``.
 
-    Returns ``None`` on spawn platforms (Windows, macOS) because ``datasets``
-    treats ``num_proc=1`` as multiprocessing (creates ``Pool(1)``); only
-    ``num_proc=None`` guarantees in-process execution.
+    Returns ``None`` on spawn platforms (Windows, macOS). ``None`` -- not ``1``
+    -- is the disable sentinel: on ``datasets`` >= 4.0 (Studio pins 4.3.0)
+    ``map()`` takes the pool branch for any ``num_proc >= 1``, so ``num_proc=1``
+    still builds a ``Pool(1)``. Older ``datasets`` (the 3.x range the library
+    extra still allows) does run ``num_proc=1`` in-process, but only ``None``
+    is in-process on every supported version.
 
     Also returns ``None`` on XPU once its runtime is initialized in this
     process: ``os.fork()`` corrupts the Level-Zero context, making Triton
     kernels fail with "Pointer argument doesn't reference XPU device memory".
     Pre-init XPU hosts can still parallelize CPU-side preprocessing.
+
+    There is deliberately no CUDA equivalent. Forking after
+    ``torch.cuda._lazy_init()`` is a real hazard in general, but the child here
+    only runs the tokenizer and never touches CUDA, and 300 forced-fork map()
+    runs on an initialized CUDA context produced no failures. Since
+    ``detect_hardware()`` always initializes CUDA, adding the guard would force
+    in-process tokenization for every CUDA training run -- a throughput cost
+    with no measured benefit. The worker-count bound in
+    ``unsloth.utils.dataset_num_proc`` is what actually addresses issue #2693.
     """
     if sys.platform in ("win32", "darwin"):
         return None

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -3255,10 +3255,9 @@ def get_torch_device_str() -> str:
     return "cpu"
 
 
-# Mirrors AUTO_NUM_PROC_CAP in unsloth_zoo.dataset_num_proc. Duplicated rather
-# than imported: that import pulls in a whole training package, and this module
-# loads during hardware detection long before any of it is needed. A canary in
-# tests/utils/test_dataset_num_proc.py fails if the two ever drift.
+# Mirrors AUTO_NUM_PROC_CAP in unsloth_zoo.dataset_num_proc; copied rather than
+# imported to keep hardware detection free of the training package. A canary in
+# tests/utils/test_dataset_num_proc.py fails if the two drift.
 _STUDIO_NUM_PROC_CAP = 8
 
 
@@ -3290,13 +3289,11 @@ def safe_num_proc(desired: Optional[int] = None) -> int:
     if desired is None or not isinstance(desired, int):
         desired = max(1, (os.cpu_count() or 1) // 3)
 
-    # Bound it. Every number reaching here is a backend heuristic, not user
-    # intent: cpu_count // 3 above and cpu_count // 4 from trainer.py, so a
-    # 64-core host produces 16 and a 192-core one 48. Downstream those look like
-    # deliberate requests and are only clamped by free memory, so on a roomy
-    # machine they reach Dataset.map intact -- the shape of issue #2693, and
-    # slower besides (32 workers measured 14.2s against 6.3s in-process, ~1GB
-    # each). UNSLOTH_DATASET_NUM_PROC is read downstream and still overrides.
+    # Every number reaching here is a backend heuristic (cpu_count // 3 above,
+    # cpu_count // 4 from trainer.py), but downstream it looks like user intent
+    # and is only clamped by free memory, so a 64-core host sends 16 workers to
+    # Dataset.map -- the shape of issue #2693, and slower besides (32 workers
+    # measured 14.2s against 6.3s in-process, ~1GB each).
     if desired > _STUDIO_NUM_PROC_CAP:
         logger.info(
             f"num_proc {desired} -> {_STUDIO_NUM_PROC_CAP}: tokenization stops "
@@ -3342,22 +3339,19 @@ def dataset_map_num_proc(desired: Optional[int] = None) -> Optional[int]:
     Return a safe ``num_proc`` for ``Dataset.map()`` and ``Dataset.filter()``.
 
     Returns ``None`` on spawn platforms (Windows, macOS). ``None`` -- not ``1``
-    -- is the disable sentinel: on ``datasets`` >= 4.1 (Studio pins 4.3.0)
-    ``map()`` takes the pool branch for any ``num_proc >= 1``, so ``num_proc=1``
-    still builds a ``Pool(1)``. Only ``None`` is in-process on every version the
-    library extra allows.
+    -- is the disable sentinel: ``datasets`` >= 4.1 (Studio pins 4.3.0) takes
+    the pool branch for any ``num_proc >= 1``, so ``1`` still builds a
+    ``Pool(1)``.
 
     Also returns ``None`` on XPU once its runtime is initialized in this
     process: ``os.fork()`` corrupts the Level-Zero context, making Triton
     kernels fail with "Pointer argument doesn't reference XPU device memory".
     Pre-init XPU hosts can still parallelize CPU-side preprocessing.
 
-    There is deliberately no CUDA equivalent. Forking after
-    ``torch.cuda._lazy_init()`` is a hazard in general, but the child here only
-    runs the tokenizer, and 300 forced-fork map() runs on an initialized CUDA
-    context produced no failures. Since ``detect_hardware()`` always initializes
-    CUDA, the guard would serialize tokenization for every CUDA run at no
-    measured benefit. The worker-count bound in
+    There is deliberately no CUDA equivalent: the child only runs the tokenizer,
+    and 300 forced-fork map() runs on an initialized CUDA context produced no
+    failures. Since ``detect_hardware()`` always initializes CUDA, such a guard
+    would serialize every CUDA run for nothing. The worker-count bound in
     ``unsloth_zoo.dataset_num_proc`` is what addresses issue #2693.
     """
     if sys.platform in ("win32", "darwin"):

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -3255,8 +3255,8 @@ def get_torch_device_str() -> str:
     return "cpu"
 
 
-# Mirrors AUTO_NUM_PROC_CAP in unsloth.utils.dataset_num_proc. Duplicated rather
-# than imported: that import pulls in unsloth's whole __init__, and this module
+# Mirrors AUTO_NUM_PROC_CAP in unsloth_zoo.dataset_num_proc. Duplicated rather
+# than imported: that import pulls in a whole training package, and this module
 # loads during hardware detection long before any of it is needed. A canary in
 # tests/utils/test_dataset_num_proc.py fails if the two ever drift.
 _STUDIO_NUM_PROC_CAP = 8
@@ -3358,7 +3358,7 @@ def dataset_map_num_proc(desired: Optional[int] = None) -> Optional[int]:
     context produced no failures. Since ``detect_hardware()`` always initializes
     CUDA, the guard would serialize tokenization for every CUDA run at no
     measured benefit. The worker-count bound in
-    ``unsloth.utils.dataset_num_proc`` is what addresses issue #2693.
+    ``unsloth_zoo.dataset_num_proc`` is what addresses issue #2693.
     """
     if sys.platform in ("win32", "darwin"):
         return None

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -3295,10 +3295,13 @@ def safe_num_proc(desired: Optional[int] = None) -> int:
     # Dataset.map -- the shape of issue #2693, and slower besides (32 workers
     # measured 14.2s against 6.3s in-process, ~1GB each).
     if desired > _STUDIO_NUM_PROC_CAP:
+        # No mention of UNSLOTH_DATASET_NUM_PROC here: this function returns an
+        # int >= 1 and cannot express the in-process the hatch promises. The
+        # hatch is read in dataset_map_num_proc, which is the path whose value
+        # reaches Dataset.map.
         logger.info(
             f"num_proc {desired} -> {_STUDIO_NUM_PROC_CAP}: tokenization stops "
-            f"scaling well before this and each worker holds its own tokenizer "
-            f"copy. Set UNSLOTH_DATASET_NUM_PROC to override."
+            f"scaling well before this and each worker holds its own tokenizer copy."
         )
         desired = _STUDIO_NUM_PROC_CAP
 
@@ -3376,4 +3379,25 @@ def dataset_map_num_proc(desired: Optional[int] = None) -> Optional[int]:
                 # pre-init CPU preprocessing can still parallelize.
                 logger.debug("torch.xpu.is_initialized() probe failed: %s", e)
 
-    return safe_num_proc(desired)
+    return _bounded_by_the_shared_policy(safe_num_proc(desired))
+
+
+def _bounded_by_the_shared_policy(num_proc: int) -> Optional[int]:
+    """Apply the training-side num_proc policy to a Studio-computed count.
+
+    ``format_conversion.py`` and ``chat_templates.py`` hand this straight to
+    ``Dataset.map``, so without it a container with 2GB and eight cores still got
+    eight tokenizer workers -- the OOM this policy exists to stop -- and
+    ``UNSLOTH_DATASET_NUM_PROC`` did nothing on those paths. The import is lazy
+    and guarded: hardware detection must not depend on the training package, and
+    an older unsloth_zoo keeps the previous behaviour.
+    """
+    try:
+        from unsloth_zoo.dataset_num_proc import get_dataset_num_proc
+    except Exception:
+        return num_proc
+    try:
+        return get_dataset_num_proc(num_proc)
+    except Exception as e:
+        logger.debug("dataset_num_proc policy unavailable: %s", e)
+        return num_proc

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -3369,6 +3369,13 @@ def dataset_map_num_proc(
     map site turns it back into ``None``.
     """
     if sys.platform in ("win32", "darwin"):
+        # ``UNSLOTH_DATASET_NUM_PROC`` is an unvetoed escape hatch in the shared
+        # policy, so a user who has read the dead-worker message and accepted
+        # spawn workers must not be overruled here without a word. Only the
+        # hatch can produce a count on this platform; everything else falls
+        # through to the veto below.
+        if _num_proc_override_is_set():
+            return _bounded_by_the_shared_policy(desired, serial_as_none)
         # ``None`` is safe at either layer here: workers are unusable on a spawn
         # platform, so every auto-sizer that reads a config ``None`` vetoes too
         # and nothing can inflate it. A ``1`` would be worse -- only the SFT map
@@ -3382,8 +3389,10 @@ def dataset_map_num_proc(
             import torch
         except Exception:
             # No torch means no active XPU runtime, so CPU-side dataset
-            # parallelism is still safe.
-            return safe_num_proc(desired)
+            # parallelism is still safe -- but it is still bounded, or a
+            # torch-less container would be the one path that ignores the
+            # memory ceiling and the escape hatch.
+            return _bounded_by_the_shared_policy(desired, serial_as_none)
 
         xpu = getattr(torch, "xpu", None)
         is_initialized = getattr(xpu, "is_initialized", None)
@@ -3400,25 +3409,69 @@ def dataset_map_num_proc(
                 # pre-init CPU preprocessing can still parallelize.
                 logger.debug("torch.xpu.is_initialized() probe failed: %s", e)
 
-    return _bounded_by_the_shared_policy(safe_num_proc(desired), serial_as_none)
+    return _bounded_by_the_shared_policy(desired, serial_as_none)
 
 
-def _bounded_by_the_shared_policy(num_proc: int, serial_as_none: bool = True) -> Optional[int]:
-    """Apply the training-side num_proc policy to a Studio-computed count.
+def _shared_policy():
+    """The shared num_proc policy module, or None on an installation without it.
+
+    The Zoo owns it. ``unsloth.dataset_num_proc`` is a byte-identical fallback
+    for a Zoo that predates the module, but it is only used when the training
+    package is already imported: importing it here would make *hardware
+    detection* patch torch and load the model stack, and the callers that reach
+    this line (format conversion, chat templates, the trainer) all run in a
+    process that has imported unsloth already.
+    """
+    try:
+        import unsloth_zoo.dataset_num_proc as policy
+        return policy
+    except Exception:
+        pass
+    if "unsloth" in sys.modules:
+        try:
+            import unsloth.dataset_num_proc as policy
+            return policy
+        except Exception as e:
+            logger.debug("local dataset_num_proc fallback unavailable: %s", e)
+    return None
+
+
+def _num_proc_override_is_set() -> bool:
+    policy = _shared_policy()
+    if policy is None:
+        return False
+    return bool(os.environ.get(policy.NUM_PROC_ENV_VAR, "").strip())
+
+
+def _bounded_by_the_shared_policy(
+    desired: Optional[int], serial_as_none: bool = True
+) -> Optional[int]:
+    """Apply the training-side num_proc policy to a Studio request.
 
     ``format_conversion.py`` and ``chat_templates.py`` hand this straight to
     ``Dataset.map``, so without it a container with 2GB and eight cores still got
     eight tokenizer workers -- the OOM this policy exists to stop -- and
-    ``UNSLOTH_DATASET_NUM_PROC`` did nothing on those paths. The import is lazy
-    and guarded: hardware detection must not depend on the training package, and
-    an older unsloth_zoo keeps the previous behaviour.
+    ``UNSLOTH_DATASET_NUM_PROC`` did nothing on those paths.
+
+    ``desired`` is passed through as the caller wrote it. Materializing an auto
+    request with ``safe_num_proc`` first would hide it from the policy, whose
+    auto path reads this process's CPU affinity and cgroup quota while
+    ``safe_num_proc`` reads the host's ``os.cpu_count()``: a 2-core container on
+    a 64-core box asked for 21 workers and got them bounded only by memory.
+    Studio's own caps are then applied to whatever the policy chose, since the
+    multi-GPU fork-deadlock cap is knowledge the policy does not have -- except
+    over the escape hatch, which is uncapped by contract.
     """
+    policy = _shared_policy()
+    if policy is None:
+        return safe_num_proc(desired)  # the behaviour before the shared policy
+
     try:
-        from unsloth_zoo.dataset_num_proc import get_dataset_num_proc
-    except Exception:
-        return num_proc
-    try:
-        return get_dataset_num_proc(num_proc, serial_as_none = serial_as_none)
+        bounded = policy.get_dataset_num_proc(desired, serial_as_none = serial_as_none)
     except Exception as e:
         logger.debug("dataset_num_proc policy unavailable: %s", e)
-        return num_proc
+        return safe_num_proc(desired)
+
+    if isinstance(bounded, int) and bounded > 1 and not _num_proc_override_is_set():
+        bounded = safe_num_proc(bounded)
+    return bounded

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -3417,15 +3417,24 @@ def dataset_map_num_proc(
     return _bounded_by_the_shared_policy(desired, serial_as_none)
 
 
+# sys.modules key for the copy loaded off disk below. Not "unsloth.dataset_num_proc":
+# that name belongs to the package, and claiming it would make a later real import
+# of unsloth return this module instead.
+_LOCAL_POLICY_MODULE = "unsloth_studio_local_dataset_num_proc"
+
+
 def _shared_policy():
     """The shared num_proc policy module, or None on an installation without it.
 
     The Zoo owns it. ``unsloth.dataset_num_proc`` is a byte-identical fallback
-    for a Zoo that predates the module, but it is only used when the training
-    package is already imported: importing it here would make *hardware
-    detection* patch torch and load the model stack, and the callers that reach
-    this line (format conversion, chat templates, the trainer) all run in a
-    process that has imported unsloth already.
+    for a Zoo that predates the module. ``import unsloth.dataset_num_proc``
+    would run the package __init__, which patches torch and loads the model
+    stack -- unacceptable from inside hardware detection -- so that form is used
+    only when the package is already imported. Otherwise the file is loaded
+    straight off disk, which is safe because the module is stdlib-only by
+    design: the API process reaches format conversion without importing unsloth
+    at all, and leaving it with no policy there is what the 2GB container with
+    eight cores used to hit.
     """
     try:
         import unsloth_zoo.dataset_num_proc as policy
@@ -3438,6 +3447,31 @@ def _shared_policy():
             return policy
         except Exception as e:
             logger.debug("local dataset_num_proc fallback unavailable: %s", e)
+            return None
+    # Memoised through sys.modules: the policy warns once per process about a
+    # vetoed count, and re-executing the file on every map() call would reset
+    # that and re-read the cgroup tree each time.
+    cached = sys.modules.get(_LOCAL_POLICY_MODULE)
+    if cached is not None:
+        return cached
+    try:
+        import importlib.util
+
+        # find_spec does not execute a top-level package, so this locates
+        # unsloth/ without importing it.
+        package = importlib.util.find_spec("unsloth")
+        if package is None or not package.submodule_search_locations:
+            return None
+        path = Path(list(package.submodule_search_locations)[0]) / "dataset_num_proc.py"
+        if not path.is_file():
+            return None
+        spec = importlib.util.spec_from_file_location(_LOCAL_POLICY_MODULE, path)
+        policy = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(policy)
+        sys.modules[_LOCAL_POLICY_MODULE] = policy
+        return policy
+    except Exception as e:
+        logger.debug("local dataset_num_proc fallback unavailable: %s", e)
     return None
 
 

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -3337,7 +3337,9 @@ def safe_thread_num_proc(desired: Optional[int] = None) -> int:
     return max(1, desired)
 
 
-def dataset_map_num_proc(desired: Optional[int] = None) -> Optional[int]:
+def dataset_map_num_proc(
+    desired: Optional[int] = None, *, serial_as_none: bool = True
+) -> Optional[int]:
     """
     Return a safe ``num_proc`` for ``Dataset.map()`` and ``Dataset.filter()``.
 
@@ -3356,8 +3358,23 @@ def dataset_map_num_proc(desired: Optional[int] = None) -> Optional[int]:
     failures. Since ``detect_hardware()`` always initializes CUDA, such a guard
     would serialize every CUDA run for nothing. The worker-count bound in
     ``unsloth_zoo.dataset_num_proc`` is what addresses issue #2693.
+
+    ``serial_as_none`` says how to spell "run in-process" for the layer that
+    reads the value back, exactly as in ``unsloth_zoo.dataset_num_proc``. Leave
+    it True at a ``map()`` call site, where ``None`` is the only value that
+    builds no pool. Pass **False when the result is written into a config**
+    (``SFTConfig.dataset_num_proc``): a config ``None`` means "auto-size me" to
+    every downstream reader, so a serial request stored as ``None`` comes back
+    out as a full worker set. Only ``1`` survives that round trip, and the SFT
+    map site turns it back into ``None``.
     """
     if sys.platform in ("win32", "darwin"):
+        # ``None`` is safe at either layer here: workers are unusable on a spawn
+        # platform, so every auto-sizer that reads a config ``None`` vetoes too
+        # and nothing can inflate it. A ``1`` would be worse -- only the SFT map
+        # site is rewritten, so DPO/KTO/CPO/ORPO/Reward/PRM would hand that 1
+        # straight to Dataset.map and get a Pool(1) whose child re-imports the
+        # user's __main__ (#3211 / #3397).
         return None
 
     if get_device() == DeviceType.XPU:
@@ -3373,16 +3390,22 @@ def dataset_map_num_proc(desired: Optional[int] = None) -> Optional[int]:
         if callable(is_initialized):
             try:
                 if is_initialized():
-                    return None
+                    # Unlike the spawn platforms above, forking is still
+                    # available here, so a config ``None`` WOULD be auto-sized
+                    # back up and fork the corrupted Level-Zero context this
+                    # guard exists to protect. Encode serial for the layer.
+                    return None if serial_as_none else 1
             except Exception as e:
                 # Treat a failing probe as "runtime not touched yet" so
                 # pre-init CPU preprocessing can still parallelize.
                 logger.debug("torch.xpu.is_initialized() probe failed: %s", e)
 
-    return _bounded_by_the_shared_policy(safe_num_proc(desired))
+    return _bounded_by_the_shared_policy(safe_num_proc(desired), serial_as_none)
 
 
-def _bounded_by_the_shared_policy(num_proc: int) -> Optional[int]:
+def _bounded_by_the_shared_policy(
+    num_proc: int, serial_as_none: bool = True
+) -> Optional[int]:
     """Apply the training-side num_proc policy to a Studio-computed count.
 
     ``format_conversion.py`` and ``chat_templates.py`` hand this straight to
@@ -3397,7 +3420,7 @@ def _bounded_by_the_shared_policy(num_proc: int) -> Optional[int]:
     except Exception:
         return num_proc
     try:
-        return get_dataset_num_proc(num_proc)
+        return get_dataset_num_proc(num_proc, serial_as_none = serial_as_none)
     except Exception as e:
         logger.debug("dataset_num_proc policy unavailable: %s", e)
         return num_proc

--- a/studio/backend/utils/hardware/hardware.py
+++ b/studio/backend/utils/hardware/hardware.py
@@ -3256,10 +3256,9 @@ def get_torch_device_str() -> str:
 
 
 # Mirrors AUTO_NUM_PROC_CAP in unsloth.utils.dataset_num_proc. Duplicated rather
-# than imported because that import pulls in unsloth's whole __init__, and this
-# module is loaded during hardware detection long before any of it is needed;
-# tests/utils/test_dataset_num_proc.py carries a canary that fails if the two
-# ever drift, the same arrangement the Zoo's row threshold already uses.
+# than imported: that import pulls in unsloth's whole __init__, and this module
+# loads during hardware detection long before any of it is needed. A canary in
+# tests/utils/test_dataset_num_proc.py fails if the two ever drift.
 _STUDIO_NUM_PROC_CAP = 8
 
 
@@ -3291,15 +3290,13 @@ def safe_num_proc(desired: Optional[int] = None) -> int:
     if desired is None or not isinstance(desired, int):
         desired = max(1, (os.cpu_count() or 1) // 3)
 
-    # Bound it. Every number reaching here is a backend heuristic, not something
-    # a user typed: the line above is cpu_count // 3 and trainer.py asks for
-    # cpu_count // 4, so a 64-core host produces 16 and a 192-core one 48.
-    # unsloth.utils.dataset_num_proc reads an explicit int as a deliberate
-    # request and only clamps it by free memory, so on a large machine with RAM
-    # to spare those counts survive all the way to Dataset.map -- which is the
-    # shape of issue #2693, and slower besides: 32 workers measured 14.2s
-    # against 6.3s in-process, at ~1GB each. UNSLOTH_DATASET_NUM_PROC still
-    # overrides, since it is read downstream and bypasses this entirely.
+    # Bound it. Every number reaching here is a backend heuristic, not user
+    # intent: cpu_count // 3 above and cpu_count // 4 from trainer.py, so a
+    # 64-core host produces 16 and a 192-core one 48. Downstream those look like
+    # deliberate requests and are only clamped by free memory, so on a roomy
+    # machine they reach Dataset.map intact -- the shape of issue #2693, and
+    # slower besides (32 workers measured 14.2s against 6.3s in-process, ~1GB
+    # each). UNSLOTH_DATASET_NUM_PROC is read downstream and still overrides.
     if desired > _STUDIO_NUM_PROC_CAP:
         logger.info(
             f"num_proc {desired} -> {_STUDIO_NUM_PROC_CAP}: tokenization stops "
@@ -3347,9 +3344,8 @@ def dataset_map_num_proc(desired: Optional[int] = None) -> Optional[int]:
     Returns ``None`` on spawn platforms (Windows, macOS). ``None`` -- not ``1``
     -- is the disable sentinel: on ``datasets`` >= 4.1 (Studio pins 4.3.0)
     ``map()`` takes the pool branch for any ``num_proc >= 1``, so ``num_proc=1``
-    still builds a ``Pool(1)``. Older ``datasets`` (the 3.x range the library
-    extra still allows) does run ``num_proc=1`` in-process, but only ``None``
-    is in-process on every supported version.
+    still builds a ``Pool(1)``. Only ``None`` is in-process on every version the
+    library extra allows.
 
     Also returns ``None`` on XPU once its runtime is initialized in this
     process: ``os.fork()`` corrupts the Level-Zero context, making Triton
@@ -3357,13 +3353,12 @@ def dataset_map_num_proc(desired: Optional[int] = None) -> Optional[int]:
     Pre-init XPU hosts can still parallelize CPU-side preprocessing.
 
     There is deliberately no CUDA equivalent. Forking after
-    ``torch.cuda._lazy_init()`` is a real hazard in general, but the child here
-    only runs the tokenizer and never touches CUDA, and 300 forced-fork map()
-    runs on an initialized CUDA context produced no failures. Since
-    ``detect_hardware()`` always initializes CUDA, adding the guard would force
-    in-process tokenization for every CUDA training run -- a throughput cost
-    with no measured benefit. The worker-count bound in
-    ``unsloth.utils.dataset_num_proc`` is what actually addresses issue #2693.
+    ``torch.cuda._lazy_init()`` is a hazard in general, but the child here only
+    runs the tokenizer, and 300 forced-fork map() runs on an initialized CUDA
+    context produced no failures. Since ``detect_hardware()`` always initializes
+    CUDA, the guard would serialize tokenization for every CUDA run at no
+    measured benefit. The worker-count bound in
+    ``unsloth.utils.dataset_num_proc`` is what addresses issue #2693.
     """
     if sys.platform in ("win32", "darwin"):
         return None

--- a/tests/python/test_mlx_public_trainer_api.py
+++ b/tests/python/test_mlx_public_trainer_api.py
@@ -920,10 +920,9 @@ def test_mlx_compatibility_shims_are_installed():
     assert issubclass(trl.SFTConfig, unsloth.UnslothTrainingArguments)
     assert trainer_module.UnslothTrainer is unsloth.UnslothTrainer
     assert trainer_module.UnslothVisionDataCollator is unsloth.UnslothVisionDataCollator
-    # chat_templates wraps the zoo function to bound its dataset.map() worker
-    # count (issue #2693), so the re-export is no longer the same object. The
-    # contract this asserts is that it still resolves to the zoo's function,
-    # which functools.wraps records on __wrapped__.
+    # chat_templates now wraps the zoo function to bound its dataset.map() worker
+    # count (issue #2693), so the re-export is no longer the same object; assert
+    # it still resolves to the zoo's, which functools.wraps records on __wrapped__.
     assert (
         getattr(
             chat_templates.train_on_responses_only,

--- a/tests/python/test_mlx_public_trainer_api.py
+++ b/tests/python/test_mlx_public_trainer_api.py
@@ -920,7 +920,18 @@ def test_mlx_compatibility_shims_are_installed():
     assert issubclass(trl.SFTConfig, unsloth.UnslothTrainingArguments)
     assert trainer_module.UnslothTrainer is unsloth.UnslothTrainer
     assert trainer_module.UnslothVisionDataCollator is unsloth.UnslothVisionDataCollator
-    assert chat_templates.train_on_responses_only is dataset_utils.train_on_responses_only
+    # chat_templates wraps the zoo function to bound its dataset.map() worker
+    # count (issue #2693), so the re-export is no longer the same object. The
+    # contract this asserts is that it still resolves to the zoo's function,
+    # which functools.wraps records on __wrapped__.
+    assert (
+        getattr(
+            chat_templates.train_on_responses_only,
+            "__wrapped__",
+            chat_templates.train_on_responses_only,
+        )
+        is dataset_utils.train_on_responses_only
+    )
     assert callable(unsloth.train_on_responses_only)
 
 

--- a/tests/python/test_mlx_public_trainer_api.py
+++ b/tests/python/test_mlx_public_trainer_api.py
@@ -920,9 +920,8 @@ def test_mlx_compatibility_shims_are_installed():
     assert issubclass(trl.SFTConfig, unsloth.UnslothTrainingArguments)
     assert trainer_module.UnslothTrainer is unsloth.UnslothTrainer
     assert trainer_module.UnslothVisionDataCollator is unsloth.UnslothVisionDataCollator
-    # chat_templates now wraps the zoo function to bound its dataset.map() worker
-    # count (issue #2693), so the re-export is no longer the same object; assert
-    # it still resolves to the zoo's, which functools.wraps records on __wrapped__.
+    # chat_templates now wraps the zoo function (issue #2693), so the re-export
+    # is no longer the same object; functools.wraps records the original.
     assert (
         getattr(
             chat_templates.train_on_responses_only,

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -518,9 +518,9 @@ def test_rl_codegen_imports_the_module_that_exists():
     snippet = _rl_num_proc_snippet()
     assert f"from {GENERATED_IMPORT_MODULE} import {GENERATED_IMPORT_NAME}" in snippet
     assert f"from {GENERATED_FALLBACK_MODULE} import {GENERATED_IMPORT_NAME}" in snippet
-    assert snippet.index(GENERATED_IMPORT_MODULE) < snippet.index(GENERATED_FALLBACK_MODULE), (
-        "the zoo has to be tried first; the unsloth copy is only the fallback"
-    )
+    assert snippet.index(GENERATED_IMPORT_MODULE) < snippet.index(
+        GENERATED_FALLBACK_MODULE
+    ), "the zoo has to be tried first; the unsloth copy is only the fallback"
     assert MODULE_PATH.is_file()
     module = _load_module()
     assert callable(getattr(module, GENERATED_IMPORT_NAME))
@@ -549,9 +549,9 @@ def test_generated_source_reaches_for_the_zoo_before_unsloth():
     assert len(reaching) == 2, "expected the num_proc selection and the map() wrapper"
     for text in reaching:
         assert f"from {GENERATED_IMPORT_MODULE} import" in text
-        assert text.index(GENERATED_IMPORT_MODULE) < text.index(GENERATED_FALLBACK_MODULE), (
-            f"this injection imports unsloth before the zoo:\n{text}"
-        )
+        assert text.index(GENERATED_IMPORT_MODULE) < text.index(
+            GENERATED_FALLBACK_MODULE
+        ), f"this injection imports unsloth before the zoo:\n{text}"
 
 
 def test_the_two_copies_have_not_drifted():
@@ -571,11 +571,17 @@ def test_the_two_copies_have_not_drifted():
     def _shape(path):
         tree = ast.parse(path.read_text(encoding = "utf-8"))
         for node in ast.walk(tree):
-            if not isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if not isinstance(
+                node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+            ):
                 continue
             body = node.body
-            if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant) \
-                    and isinstance(body[0].value.value, str):
+            if (
+                body
+                and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)
+            ):
                 node.body = body[1:] or [ast.Pass()]
         return ast.dump(ast.parse(ast.unparse(tree)))
 

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -16,7 +16,10 @@ from __future__ import annotations
 
 import ast
 import importlib.util
+import re
 import sys
+import textwrap
+import types
 from pathlib import Path
 
 import pytest
@@ -491,43 +494,101 @@ def test_rl_codegen_only_sft_gets_the_config_sentinel():
     assert '_serial_as_none = "False" if trainer_file == "sft_trainer" else "True"' in source
 
 
-def test_zoo_sft_prepare_dataset_anchor_has_not_drifted():
-    """unsloth/models/rl_replacements.py rewrites unsloth_zoo's
-    sft_prepare_dataset by exact string match. A Zoo release that touches those
-    lines makes _require_replace raise at import time, so catch drift here."""
-    # find_spec resolves the package path without executing its __init__, so this
-    # canary still runs where torch/unsloth_zoo cannot import.
+# ---------- the map-site rewrite and the anchors it hangs on ----------
+
+# The tag rl_replacements.py gives the num_proc edit; both anchors share it, so a
+# rename shows up as a missing call rather than a silently unpinned anchor.
+NUM_PROC_WHERE = "sft_prepare_dataset dataset_num_proc selection"
+
+# The helpers that decide whether a source edit lands. Named here so the tests
+# below fail loudly if they are renamed rather than quietly testing nothing.
+ANCHOR_HELPERS = ("_require_replace", "_replace_or_fallback")
+
+# The module-level regex the narrow fallback anchor uses.
+NARROW_ANCHOR_NAME = "_ZOO_MAP_NUM_PROC_ASSIGNMENT"
+
+
+def _zoo_dataset_utils_source():
+    # find_spec resolves the package path without executing its __init__, so these
+    # canaries still run where torch/unsloth_zoo cannot import.
     spec = importlib.util.find_spec("unsloth_zoo")
     if spec is None or not spec.submodule_search_locations:
         pytest.skip("unsloth_zoo not installed")
     zoo_file = Path(list(spec.submodule_search_locations)[0]) / "dataset_utils.py"
     if not zoo_file.is_file():
         pytest.skip("unsloth_zoo.dataset_utils not found")
-    source = zoo_file.read_text(encoding = "utf-8")
+    return zoo_file.read_text(encoding = "utf-8")
 
-    rr_tree = ast.parse(RL_PATH.with_name("rl_replacements.py").read_text(encoding = "utf-8"))
 
-    def _anchor_and_count(where):
-        found = [
-            (
-                ast.literal_eval(node.args[1]),
-                next(
-                    (ast.literal_eval(k.value) for k in node.keywords if k.arg == "count"),
-                    1,
-                ),
-            )
-            for node in ast.walk(rr_tree)
-            if isinstance(node, ast.Call)
-            and getattr(node.func, "id", "") == "_require_replace"
-            and any(k.arg == "where" and ast.literal_eval(k.value) == where for k in node.keywords)
-        ]
-        assert len(found) == 1, f"expected exactly one _require_replace for {where!r}"
-        return found[0]
+def _rl_replacements_tree():
+    return ast.parse(RL_PATH.with_name("rl_replacements.py").read_text(encoding = "utf-8"))
+
+
+def _anchor_calls(where):
+    return [
+        node
+        for node in ast.walk(_rl_replacements_tree())
+        if isinstance(node, ast.Call)
+        and getattr(node.func, "id", "") in ANCHOR_HELPERS
+        and any(k.arg == "where" and ast.literal_eval(k.value) == where for k in node.keywords)
+    ]
+
+
+def _anchor_and_count(where):
+    """The (anchor, expected occurrences) of the source edit tagged ``where``."""
+    found = _anchor_calls(where)
+    assert len(found) == 1, f"expected exactly one anchored edit for {where!r}"
+    node = found[0]
+    count = next((ast.literal_eval(k.value) for k in node.keywords if k.arg == "count"), 1)
+    return ast.literal_eval(node.args[1]), count
+
+
+def _keyword(where, name):
+    node = _anchor_calls(where)[0]
+    value = next(k.value for k in node.keywords if k.arg == name)
+    return value
+
+
+def _narrow_num_proc_pattern():
+    """The compiled fallback regex, read out of rl_replacements.py by name.
+
+    Read from the module-level ``re.compile`` rather than re-typed here: a test
+    holding its own copy of the pattern would keep passing after the real one
+    drifted away from the Zoo.
+    """
+    name = _keyword(NUM_PROC_WHERE, "fallback_pattern")
+    assert (
+        getattr(name, "id", "") == NARROW_ANCHOR_NAME
+    ), f"the num_proc fallback no longer uses {NARROW_ANCHOR_NAME}"
+    for node in ast.walk(_rl_replacements_tree()):
+        if (
+            isinstance(node, ast.Assign)
+            and any(getattr(t, "id", None) == NARROW_ANCHOR_NAME for t in node.targets)
+            and isinstance(node.value, ast.Call)
+        ):
+            args = [ast.literal_eval(a) for a in node.value.args]
+            flags = next((k for k in node.value.keywords if k.arg == "flags"), None)
+            assert flags is not None and "MULTILINE" in ast.dump(
+                flags.value
+            ), "the narrow anchor must be MULTILINE to match a line in a block"
+            return re.compile(args[0], flags = re.MULTILINE)
+    raise AssertionError(f"{NARROW_ANCHOR_NAME} not found in rl_replacements.py")
+
+
+def _narrow_num_proc_replacement():
+    return ast.literal_eval(_keyword(NUM_PROC_WHERE, "fallback_new"))
+
+
+def test_zoo_sft_prepare_dataset_anchor_has_not_drifted():
+    """unsloth/models/rl_replacements.py rewrites unsloth_zoo's
+    sft_prepare_dataset by exact string match. A Zoo release that touches those
+    lines makes _require_replace raise at import time, so catch drift here."""
+    source = _zoo_dataset_utils_source()
 
     # _require_replace raises on a missing anchor but cannot notice a count = 2
     # anchor dropping to one occurrence, so assert the counts here.
     for where in (
-        "sft_prepare_dataset dataset_num_proc selection",
+        NUM_PROC_WHERE,
         "sft_prepare_dataset tokenizing map() calls",
     ):
         anchor, count = _anchor_and_count(where)
@@ -535,6 +596,188 @@ def test_zoo_sft_prepare_dataset_anchor_has_not_drifted():
             f"unsloth_zoo.dataset_utils has {source.count(anchor)} occurrences of "
             f"the {where!r} anchor, expected {count}; update rl_replacements.py"
         )
+
+
+def test_the_narrow_num_proc_anchor_still_matches_the_installed_zoo():
+    """The num_proc site has a second, narrower anchor; it needs its own canary.
+
+    The block anchor drifting is survivable precisely because this regex catches
+    the assignment the block ends on. If the Zoo ever renames or restructures
+    that line too, both anchors are gone and nothing rewrites the worker count --
+    so pin it here, in CI, rather than discovering it from a user's Pool(1).
+    """
+    source = _zoo_dataset_utils_source()
+    pattern = _narrow_num_proc_pattern()
+
+    matches = pattern.findall(source)
+    assert len(matches) == 1, (
+        f"unsloth_zoo.dataset_utils has {len(matches)} lines matching the narrow "
+        f"num_proc anchor {pattern.pattern!r}, expected 1; update rl_replacements.py"
+    )
+
+    # The block anchor and the narrow anchor have to describe the same site, or
+    # the fallback would rewrite something the primary edit never touched.
+    block_anchor, _ = _anchor_and_count(NUM_PROC_WHERE)
+    assert pattern.search(block_anchor) is not None
+
+    # And the fallback has to leave the file parseable at the Zoo's indentation.
+    rewritten = pattern.sub(_narrow_num_proc_replacement(), source)
+    assert rewritten != source
+    ast.parse(rewritten)
+
+
+# ---------- what the layered anchor actually does to a drifted Zoo ----------
+
+
+def _load_anchor_helpers():
+    """Exec just the anchor helpers out of rl_replacements.py.
+
+    That module imports torch and trl at its top and this file is torch-free by
+    design, so lift the definitions the anchor logic needs instead of copying
+    them: a test carrying its own copy would keep passing after the real helper
+    changed. Returns the namespace plus the list the fake logger warns into.
+    """
+    tree = _rl_replacements_tree()
+    wanted = set(ANCHOR_HELPERS) | {"_warn_once", "_WARNED_MISSING_ANCHORS", NARROW_ANCHOR_NAME}
+    kept = [
+        node
+        for node in tree.body
+        if (isinstance(node, ast.FunctionDef) and node.name in wanted)
+        or (
+            isinstance(node, ast.Assign)
+            and any(getattr(t, "id", None) in wanted for t in node.targets)
+        )
+    ]
+    assert {node.name for node in kept if isinstance(node, ast.FunctionDef)} >= set(
+        ANCHOR_HELPERS
+    ), "the anchor helpers were renamed"
+
+    warnings = []
+    namespace = {
+        "re": re,
+        "logger": types.SimpleNamespace(warning = warnings.append),
+    }
+    module = ast.fix_missing_locations(ast.Module(body = kept, type_ignores = []))
+    exec(compile(module, str(RL_PATH.with_name("rl_replacements.py")), "exec"), namespace)  # noqa: S102
+    return namespace, warnings
+
+
+def _apply_num_proc_edit(source):
+    """Run the real layered edit for NUM_PROC_WHERE over ``source``."""
+    namespace, warnings = _load_anchor_helpers()
+    node = _anchor_calls(NUM_PROC_WHERE)[0]
+    assert (
+        getattr(node.func, "id", "") == "_replace_or_fallback"
+    ), "the num_proc edit lost its fallback and is a plain replace again"
+    result = namespace["_replace_or_fallback"](
+        source,
+        ast.literal_eval(node.args[1]),
+        ast.literal_eval(node.args[2]),
+        fallback_pattern = namespace[NARROW_ANCHOR_NAME],
+        fallback_new = _narrow_num_proc_replacement(),
+        where = NUM_PROC_WHERE,
+    )
+    return result, warnings
+
+
+def test_the_block_anchor_is_used_when_the_zoo_has_not_moved():
+    source = _zoo_dataset_utils_source()
+    result, warnings = _apply_num_proc_edit(source)
+    assert "_unsloth_get_dataset_num_proc" in result
+    assert 'map_kwargs["num_proc"] = dataset_num_proc' not in result
+    # The block replacement takes the Zoo's own sizing with it; the fallback,
+    # which only rewrites the assignment, leaves it standing.
+    block_anchor, _ = _anchor_and_count(NUM_PROC_WHERE)
+    assert block_anchor not in result
+    assert warnings == [], f"a matching anchor must not warn: {warnings}"
+    ast.parse(result)
+
+
+def test_the_narrow_anchor_takes_over_when_the_block_drifts():
+    """A Zoo that rewrites the block but keeps the assignment must still be fixed.
+
+    This is the case `required = False` used to swallow: the edit no-ops, the Zoo
+    reads the config `1` the config layer writes for "serial", and datasets >= 4.1
+    turns that into a Pool(1) on the host that asked for no workers.
+    """
+    source = _zoo_dataset_utils_source()
+    # Drift the block without touching the line the fallback keys on.
+    drifted = source.replace(
+        "            import multiprocessing as _mp\n",
+        "            import multiprocessing as _mp  # zoo refactor\n",
+        1,
+    )
+    assert drifted != source
+    assert _narrow_num_proc_pattern().findall(drifted)
+
+    result, warnings = _apply_num_proc_edit(drifted)
+    assert "_unsloth_get_dataset_num_proc" in result, "the fallback anchor did not apply"
+    assert 'map_kwargs["num_proc"] = dataset_num_proc' not in result
+    # Only the assignment was rewritten, so the Zoo's own sizing is still there,
+    # computing a value nothing reads. That is the price of the narrow anchor.
+    assert "if _mp.get_start_method() != 'fork':" in result
+    assert len(warnings) == 1 and "moved in this unsloth_zoo" in warnings[0]
+    ast.parse(result)
+
+
+def test_neither_anchor_matching_only_warns():
+    """The remaining escape hatch stays a warning, not a raise.
+
+    Hard-failing here would break every SFT run on a Zoo whose text merely moved,
+    which is a far bigger blast radius than the one worker at stake.
+    """
+    source = (
+        _zoo_dataset_utils_source()
+        .replace(
+            '            map_kwargs["num_proc"] = dataset_num_proc\n',
+            '            map_kwargs.update({"num_proc": dataset_num_proc})\n',
+            1,
+        )
+        .replace(
+            "            import multiprocessing as _mp\n",
+            "            import multiprocessing as _mp  # zoo refactor\n",
+            1,
+        )
+    )
+    assert not _narrow_num_proc_pattern().findall(source)
+
+    result, warnings = _apply_num_proc_edit(source)
+    assert result == source, "nothing should be rewritten when both anchors miss"
+    assert len(warnings) == 1 and "anchor not found" in warnings[0]
+
+
+def test_the_narrow_anchor_keeps_indentation_and_yields_none(monkeypatch):
+    """The injected fallback has to run, at the Zoo's indentation, and give None.
+
+    Indentation comes from the match, so a Zoo that nests the assignment deeper
+    still gets valid source; and the value it computes for a config `1` -- what
+    the config layer writes for "serial" -- has to be None, never 1.
+    """
+    module = _load_module()
+    module.reset_warning_state()
+    monkeypatch.delenv(module.NUM_PROC_ENV_VAR, raising = False)
+    # The injected snippet imports the zoo copy first; point that name at the
+    # copy under test so this stays a torch-free, offline assertion.
+    if "unsloth_zoo" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "unsloth_zoo", types.ModuleType("unsloth_zoo"))
+    monkeypatch.setitem(sys.modules, "unsloth_zoo.dataset_num_proc", module)
+
+    pattern = _narrow_num_proc_pattern()
+    replacement = _narrow_num_proc_replacement()
+
+    for indent in ("            ", "                    "):
+        snippet = pattern.sub(replacement, f'{indent}map_kwargs["num_proc"] = dataset_num_proc')
+        for line in snippet.split("\n"):
+            assert line.startswith(indent), f"lost the {len(indent)}-space indent: {line!r}"
+
+        namespace = {
+            "map_kwargs": {},
+            "args": types.SimpleNamespace(dataset_num_proc = 1),
+        }
+        exec(compile(textwrap.dedent(snippet), "<fallback>", "exec"), namespace)  # noqa: S102
+        assert (
+            namespace["map_kwargs"]["num_proc"] is None
+        ), "a config 1 has to become None at the map site; 1 is a Pool(1) on datasets >= 4.1"
 
 
 def test_rl_codegen_imports_the_module_that_exists():
@@ -559,18 +802,23 @@ def test_generated_source_reaches_for_the_zoo_before_unsloth():
     packing -> attention_dispatch -> models._utils (torch and the model stack)
     into a module needing none of it. Both call sites must try the zoo first.
     """
-    source = RL_PATH.with_name("rl_replacements.py").read_text(encoding = "utf-8")
-    tree = ast.parse(source)
-    injected = [
-        ast.literal_eval(node.args[2])
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Call)
-        and getattr(node.func, "id", "") == "_require_replace"
-        and len(node.args) >= 3
-        and isinstance(node.args[2], ast.Constant)
-    ]
+    tree = _rl_replacements_tree()
+    injected = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or getattr(node.func, "id", "") not in ANCHOR_HELPERS:
+            continue
+        if len(node.args) >= 3 and isinstance(node.args[2], ast.Constant):
+            injected.append(ast.literal_eval(node.args[2]))
+        # The narrow fallback injects source too, as an re.sub template.
+        injected += [
+            ast.literal_eval(k.value)
+            for k in node.keywords
+            if k.arg == "fallback_new" and isinstance(k.value, ast.Constant)
+        ]
     reaching = [text for text in injected if "dataset_num_proc" in text]
-    assert len(reaching) == 2, "expected the num_proc selection and the map() wrapper"
+    assert (
+        len(reaching) == 3
+    ), "expected the num_proc selection, its narrow fallback and the map() wrapper"
     for text in reaching:
         assert f"from {GENERATED_IMPORT_MODULE} import" in text
         assert text.index(GENERATED_IMPORT_MODULE) < text.index(
@@ -1061,33 +1309,149 @@ def test_a_readable_limit_with_no_readable_usage_still_binds(monkeypatch, dnp, t
     assert dnp._cgroup_free_bytes() == 2 * 1024**3
 
 
-def test_missing_cgroup_readers_fall_back_to_the_limit_alone(monkeypatch, dnp):
-    """An older unsloth_zoo has no such private helpers.
-
-    The public limit reader alone can only overstate what is free, never
-    understate it, so the ceiling still binds.
-    """
+def _old_zoo(monkeypatch, memory_limit = None):
+    """An unsloth_zoo predating the private cgroup helpers, with only the public reader."""
     import types
 
     fake = types.ModuleType("unsloth_zoo.hf_xet_tuning")
-    fake.cgroup_memory_limit = lambda: 4 * 1024**3
+    fake.cgroup_memory_limit = lambda: memory_limit
     fake.cgroup_cpu_limit = lambda: None
     monkeypatch.setitem(sys.modules, "unsloth_zoo.hf_xet_tuning", fake)
+    return fake
+
+
+def test_the_unaided_reader_subtracts_usage_too(monkeypatch, dnp, tmp_path):
+    """An older unsloth_zoo must not turn the ceiling back into the raw limit.
+
+    cgroup_memory_limit() alone reports an 8GB cgroup holding 6GB as 8GB free,
+    which is the one case the ceiling exists for: sizing workers off memory that
+    is already spent is how #2693's map() children get OOM-killed.
+    """
+    _old_zoo(monkeypatch, memory_limit = 8 * 1024**3)
+    leaf = tmp_path / "kubepods" / "podabc"
+    leaf.mkdir(parents = True)
+    (leaf / "memory.max").write_text("8589934592\n")
+    (leaf / "memory.current").write_text("6442450944\n")
+
+    monkeypatch.setattr(dnp, "CGROUP_ROOT", str(tmp_path))
+    monkeypatch.setattr(dnp, "_proc_self_cgroup", lambda: ["0::/kubepods/podabc"])
+    assert dnp._cgroup_free_bytes() == 2 * 1024**3
+
+
+def test_the_unaided_reader_walks_to_the_binding_ancestor(monkeypatch, dnp, tmp_path):
+    """Same pairing rule as the helper-backed path: the slice's limit binds, with the slice's usage."""
+    _old_zoo(monkeypatch)
+    slice_dir = tmp_path / "user.slice"
+    leaf = slice_dir / "session.scope"
+    leaf.mkdir(parents = True)
+    (slice_dir / "memory.max").write_text("34359738368\n")
+    (slice_dir / "memory.current").write_text("32212254720\n")
+    (leaf / "memory.max").write_text("17179869184\n")
+    (leaf / "memory.current").write_text("1073741824\n")
+
+    monkeypatch.setattr(dnp, "CGROUP_ROOT", str(tmp_path))
+    monkeypatch.setattr(dnp, "_proc_self_cgroup", lambda: ["0::/user.slice/session.scope"])
+    assert dnp._cgroup_free_bytes() == 2 * 1024**3
+
+
+def test_the_unaided_reader_handles_cgroup_v1(monkeypatch, dnp, tmp_path):
+    _old_zoo(monkeypatch)
+    leaf = tmp_path / "memory" / "slurm" / "job_1"
+    leaf.mkdir(parents = True)
+    (leaf / "memory.limit_in_bytes").write_text("4294967296\n")
+    (leaf / "memory.usage_in_bytes").write_text("3221225472\n")
+
+    monkeypatch.setattr(dnp, "CGROUP_ROOT", str(tmp_path))
+    monkeypatch.setattr(
+        dnp, "_proc_self_cgroup", lambda: ["7:memory,blkio:/slurm/job_1"],
+    )
+    assert dnp._cgroup_free_bytes() == 1024**3
+
+
+def test_the_unaided_reader_ignores_the_unlimited_sentinels(monkeypatch, dnp, tmp_path):
+    _old_zoo(monkeypatch)
+    v2 = tmp_path / "scope"
+    v2.mkdir()
+    (v2 / "memory.max").write_text("max\n")
+    (v2 / "memory.current").write_text("1073741824\n")
+    v1 = tmp_path / "memory"
+    v1.mkdir()
+    # v1's "unlimited": a near-2^63 sentinel, not a 8-exabyte ceiling.
+    (v1 / "memory.limit_in_bytes").write_text("9223372036854771712\n")
+    (v1 / "memory.usage_in_bytes").write_text("1073741824\n")
+
+    monkeypatch.setattr(dnp, "CGROUP_ROOT", str(tmp_path))
+    monkeypatch.setattr(dnp, "_proc_self_cgroup", lambda: ["0::/scope", "7:memory:/"])
+    assert dnp._cgroup_free_bytes() is None
+
+
+def test_the_unaided_reader_is_never_negative(monkeypatch, dnp, tmp_path):
+    _old_zoo(monkeypatch)
+    leaf = tmp_path / "scope"
+    leaf.mkdir()
+    (leaf / "memory.max").write_text("1073741824\n")
+    (leaf / "memory.current").write_text("2147483648\n")
+    monkeypatch.setattr(dnp, "CGROUP_ROOT", str(tmp_path))
+    monkeypatch.setattr(dnp, "_proc_self_cgroup", lambda: ["0::/scope"])
+    assert dnp._cgroup_free_bytes() == 0
+
+
+def test_the_unaided_reader_keeps_the_public_limit_as_a_last_resort(monkeypatch, dnp, tmp_path):
+    """No readable cgroup tree here, but an older zoo may still find one its own way.
+
+    A limit with no usage beside it is still a ceiling, and is a tighter one than
+    psutil's host-wide view inside a container.
+    """
+    _old_zoo(monkeypatch, memory_limit = 4 * 1024**3)
+    monkeypatch.setattr(dnp, "CGROUP_ROOT", str(tmp_path / "absent"))
+    monkeypatch.setattr(dnp, "_proc_self_cgroup", lambda: [])
     assert dnp._cgroup_free_bytes() == 4 * 1024**3
 
 
-def test_no_unsloth_zoo_at_all_is_not_a_ceiling(monkeypatch, dnp):
+def test_the_unaided_reader_never_raises(monkeypatch, dnp):
+    """It runs on every auto-sizing call under an older zoo, on hosts with no cgroup at all."""
+    _old_zoo(monkeypatch)
+    free = dnp._cgroup_free_bytes_unaided()
+    assert free is None or (isinstance(free, int) and free >= 0)
+
+
+def _no_hf_xet_tuning(monkeypatch):
+    """Neither the private helpers nor the public readers: no unsloth_zoo at all."""
     import builtins
 
     real_import = builtins.__import__
 
-    def _no_hf_xet(name, *args, **kwargs):
+    def _blocked(name, *args, **kwargs):
         if name == "unsloth_zoo.hf_xet_tuning":
             raise ImportError("older unsloth_zoo")
         return real_import(name, *args, **kwargs)
 
-    monkeypatch.setattr(builtins, "__import__", _no_hf_xet)
+    monkeypatch.setattr(builtins, "__import__", _blocked)
+
+
+def test_no_unsloth_zoo_and_no_cgroup_is_not_a_ceiling(monkeypatch, dnp, tmp_path):
+    # The cgroup tree is pointed away from the host's on purpose: the unaided
+    # reader needs no unsloth_zoo, so leaving it on the real /sys/fs/cgroup would
+    # make the assertion depend on whether the runner is itself in a limited
+    # container, which is how this test would fail on CI and pass on a laptop.
+    _no_hf_xet_tuning(monkeypatch)
+    monkeypatch.setattr(dnp, "CGROUP_ROOT", str(tmp_path / "absent"))
+    monkeypatch.setattr(dnp, "_proc_self_cgroup", lambda: [])
     assert dnp._cgroup_free_bytes() is None
+    assert dnp._cgroup_cpu_quota() is None
+
+
+def test_no_unsloth_zoo_still_reads_the_cgroup(monkeypatch, dnp, tmp_path):
+    """The point of the unaided reader: the ceiling survives having no zoo to ask."""
+    _no_hf_xet_tuning(monkeypatch)
+    leaf = tmp_path / "scope"
+    leaf.mkdir()
+    (leaf / "memory.max").write_text("8589934592\n")
+    (leaf / "memory.current").write_text("6442450944\n")
+    monkeypatch.setattr(dnp, "CGROUP_ROOT", str(tmp_path))
+    monkeypatch.setattr(dnp, "_proc_self_cgroup", lambda: ["0::/scope"])
+    assert dnp._cgroup_free_bytes() == 2 * 1024**3
+    # The CPU quota reader has no unaided path, so it stays silent.
     assert dnp._cgroup_cpu_quota() is None
 
 

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -363,6 +363,13 @@ def test_env_override_is_uncapped(monkeypatch, dnp):
     _force_start_method(monkeypatch, dnp, "fork")
     monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, "100")
     assert dnp.get_dataset_num_proc(None) == 100
+    # Above the auto cap is the easy half. The memory clamp is the one that
+    # matters: the fixture leaves room for 512 workers, so without pinning it
+    # this asserts nothing about the exemption. map_failure_diagnostics points
+    # users at this hatch on exactly the host where the clamp would bite.
+    monkeypatch.setattr(dnp, "_affordable_workers", lambda: 2)
+    assert dnp.get_dataset_num_proc(None) == 100
+    assert dnp.get_dataset_num_proc(4) == 100
 
 
 def test_invalid_env_override_is_ignored_with_a_warning(monkeypatch, dnp, capsys):
@@ -493,6 +500,23 @@ def test_start_method_probe_matches_the_pool_multiprocess_would_build(dnp):
 # ---------- the generated trainer's import must match the real module ----------
 
 
+def _rl_serial_as_none(tree, source, trainer_file):
+    """Evaluate rl.py's own serial_as_none rule rather than restating it.
+
+    Restating it made every codegen case below self-fulfilling: they passed
+    whatever rl.py decided, so flipping SFT to True -- losing the config
+    sentinel these modules exist to protect -- was caught only by the one test
+    that matches the emitted literal, which is the line a developer would edit
+    in the same change.
+    """
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and getattr(node.targets[0], "id", "") == "_serial_as_none":
+            return eval(  # noqa: S307
+                ast.get_source_segment(source, node.value), {"trainer_file": trainer_file}
+            )
+    raise AssertionError("_serial_as_none assignment not found in unsloth/models/rl.py")
+
+
 def _rl_num_proc_snippet(trainer_file = "sft_trainer"):
     """The snippet rl.py would splice into that trainer's generated config.
 
@@ -507,8 +531,9 @@ def _rl_num_proc_snippet(trainer_file = "sft_trainer"):
             # Parenthesised: the segment starts at the first literal, so its
             # continuation lines are an IndentationError on their own.
             expression = "(" + ast.get_source_segment(source, node.value) + ")"
-            serial_as_none = "False" if trainer_file == "sft_trainer" else "True"
-            return eval(expression, {"_serial_as_none": serial_as_none})  # noqa: S307
+            return eval(  # noqa: S307
+                expression, {"_serial_as_none": _rl_serial_as_none(tree, source, trainer_file)}
+            )
     raise AssertionError("num_proc_check literal not found in unsloth/models/rl.py")
 
 
@@ -990,6 +1015,17 @@ def test_unrelated_errors_pass_through_untouched(dnp):
         with dnp.map_failure_diagnostics(4):
             raise key
     assert caught_key.value is key
+
+    # The identity assertions above hold under `except Exception` as well, since
+    # the guard re-raises the same object. This one does not: it carries the
+    # dead-worker text, so a widened clause would rewrite it into a RuntimeError.
+    lookalike = ValueError(
+        "One of the subprocesses has abruptly died during map operation."
+    )
+    with pytest.raises(ValueError) as caught_other:
+        with dnp.map_failure_diagnostics(4):
+            raise lookalike
+    assert caught_other.value is lookalike
 
 
 def test_successful_map_is_not_disturbed(dnp):

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -30,6 +30,15 @@ from pathlib import Path
 
 import pytest
 
+try:
+    # Imported here, before the dnp fixture spoofs sys.platform. multiprocess
+    # chooses its concrete contexts at import time from sys.platform, so a first
+    # import under a spoofed one would hand a Windows runner the POSIX fork
+    # contexts and the tests below would then be reading a fiction.
+    import multiprocess  # noqa: F401
+except ImportError:
+    pass
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MODULE_PATH = REPO_ROOT / "unsloth" / "utils" / "dataset_num_proc.py"

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -54,6 +54,12 @@ def dnp(monkeypatch):
     module = _load_module()
     module.reset_warning_state()
     monkeypatch.delenv(module.NUM_PROC_ENV_VAR, raising = False)
+    # Pin the platform. macOS is refused by policy whatever the start method
+    # says, so every assertion below that expects a worker count is really an
+    # assertion about a forking platform; without this they pass on the Linux
+    # runner and fail on the macOS one. Tests about the platform itself set
+    # their own value afterwards, which wins.
+    monkeypatch.setattr(module.sys, "platform", "linux")
     return module
 
 
@@ -339,6 +345,10 @@ def test_start_method_probe_prefers_multiprocess_and_has_no_side_effects(dnp):
 
     method = dnp.multiprocessing_start_method()
 
+    # Must name a method this host actually offers. Windows offers only spawn,
+    # and the private default-context chain the probe reads has been seen to
+    # answer "fork" there; taking that at face value would read Windows as
+    # forkable and let workers through.
     assert method in multiprocess.get_all_start_methods()
     assert multiprocess.get_start_method(allow_none = True) == before_mp
     assert multiprocessing.get_start_method(allow_none = True) == before_std
@@ -717,3 +727,32 @@ def test_the_advice_matches_what_the_resolver_actually_returns(dnp, monkeypatch)
     )
     assert over == 1, "over the threshold the best expressible request is one worker"
     assert under is None, "under it the Zoo's own guard already goes in-process"
+
+
+def test_probe_rejects_a_start_method_the_host_does_not_offer(monkeypatch, dnp):
+    """The private default-context chain is not trustworthy on its own.
+
+    On a Windows runner it answered "fork" while get_all_start_methods() was
+    ["spawn"]. A start method the platform does not offer cannot be the one in
+    use, and believing it read Windows as forkable: _workers_unusable_reason()
+    returned None and workers were allowed through, which is the spawn
+    re-import loop of #3211 / #3397 that this module exists to prevent.
+    """
+    import sys as _sys
+    import types
+
+    fake = types.ModuleType("multiprocess")
+    fake.get_start_method = lambda allow_none = False: None
+    fake.get_all_start_methods = lambda: ["spawn"]
+    context = types.ModuleType("multiprocess.context")
+    context._default_context = types.SimpleNamespace(
+        _default_context = types.SimpleNamespace(_name = "fork"),
+    )
+    fake.context = context
+    monkeypatch.setitem(_sys.modules, "multiprocess", fake)
+
+    assert dnp.multiprocessing_start_method() == "spawn"
+
+    monkeypatch.setattr(dnp.sys, "platform", "win32")
+    assert dnp.get_dataset_num_proc(8) is None
+    assert dnp.get_dataset_num_proc(8, serial_as_none = False) is None

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -1,17 +1,16 @@
-# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Tests for unsloth.utils.dataset_num_proc.
 
@@ -118,18 +117,14 @@ def test_serial_as_none_false_preserves_an_explicit_one(monkeypatch, dnp):
     assert dnp.get_dataset_num_proc(-4, serial_as_none = False) == 1
 
 
-def test_config_layer_never_returns_none(monkeypatch, dnp):
-    """No path may write None back to a config, whatever the reason for it.
+def test_config_layer_never_returns_none_while_forking_is_available(monkeypatch, dnp):
+    """On a fork host no path may write None back to a config.
 
-    None means "auto-size me" downstream, so any route to it -- start-method
-    veto, memory clamp, explicit serial -- would silently re-inflate.
+    None means "auto-size me" downstream, so any route to it -- memory clamp,
+    explicit serial -- would silently re-inflate.
     """
     psutil = pytest.importorskip("psutil")
     monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 64)
-
-    # start-method veto
-    _force_start_method(monkeypatch, dnp, "spawn")
-    assert dnp.get_dataset_num_proc(16, serial_as_none = False) == 1
 
     # memory clamp all the way down to serial
     _force_start_method(monkeypatch, dnp, "fork")
@@ -138,6 +133,33 @@ def test_config_layer_never_returns_none(monkeypatch, dnp):
     )
     assert dnp.get_dataset_num_proc(16, serial_as_none = False) == 1
     assert dnp.get_dataset_num_proc(None, serial_as_none = False) == 1
+
+
+@pytest.mark.parametrize("method", ["spawn", "forkserver", None])
+@pytest.mark.parametrize("desired", [None, 1, 16])
+def test_config_layer_is_none_not_one_on_a_non_fork_start_method(monkeypatch, dnp, method, desired):
+    """Regression: the config sentinel 1 reached unpatched TRL map() call sites.
+
+    Only SFT gets its map site rewritten (rl_replacements.py). DPO, KTO, CPO,
+    ORPO, Reward and PRM pass ``args.dataset_num_proc`` straight into
+    ``Dataset.map``, and on ``datasets`` >= 4.0 a ``1`` there builds a
+    ``Pool(1)`` whose spawned child re-imports the user's ``__main__`` -- the
+    Windows spawn loop (#3211 / #3397) this veto exists to prevent. Before this
+    module those configs carried ``None`` on spawn hosts; they must still.
+
+    Writing None back is safe here precisely because forking is unavailable:
+    every auto-sizer that reads the config vetoes on a non-fork start method
+    too, so there is nothing left to inflate it.
+    """
+    _force_start_method(monkeypatch, dnp, method)
+    assert dnp.get_dataset_num_proc(desired, serial_as_none = False) is None
+
+
+def test_config_layer_env_forced_serial_is_none_on_a_non_fork_start_method(monkeypatch, dnp):
+    """UNSLOTH_DATASET_NUM_PROC=0 must not build a Pool(1) either."""
+    _force_start_method(monkeypatch, dnp, "spawn")
+    monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, "0")
+    assert dnp.get_dataset_num_proc(None, serial_as_none = False) is None
 
 
 def test_layering_config_then_map_site_is_correct(monkeypatch, dnp):

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -81,7 +81,7 @@ def test_non_fork_start_method_warns_once(monkeypatch, dnp, capsys):
     dnp.get_dataset_num_proc(8)
     dnp.get_dataset_num_proc(8)
     out = capsys.readouterr().out
-    assert out.count("needs the 'fork' start method") == 1
+    assert out.count("uses the 'spawn' start method") == 1
     assert "dataset_num_proc = 8" in out
 
 
@@ -353,6 +353,94 @@ def test_start_method_probe_reports_an_explicit_setting(monkeypatch, dnp):
     fake.get_all_start_methods = lambda: ["fork", "spawn", "forkserver"]
     monkeypatch.setitem(_sys.modules, "multiprocess", fake)
     assert dnp.multiprocessing_start_method() == "forkserver"
+
+
+def _fake_multiprocess(listed, default_name):
+    """A multiprocess stand-in with nothing pinned yet."""
+    import types
+
+    fake = types.ModuleType("multiprocess")
+    fake.get_start_method = lambda allow_none = False: None
+    fake.get_all_start_methods = lambda: list(listed)
+    if default_name is not None:
+        context = types.ModuleType("multiprocess.context")
+        context._default_context = types.SimpleNamespace(
+            _default_context = types.SimpleNamespace(_name = default_name),
+            _actual_context = None,
+        )
+        fake.context = context
+    return fake
+
+
+def test_start_method_probe_prefers_the_real_default_over_list_order(monkeypatch, dnp):
+    """macOS: multiprocess lists 'spawn' first but its default context is fork.
+
+    ``multiprocess`` copies the stdlib ``get_all_start_methods()`` verbatim,
+    darwin branch included, but keeps ``fork`` as its ``_default_context`` on
+    every POSIX platform (``#FIXME: spawn`` in multiprocess/context.py). Since
+    ``datasets`` builds its pool from ``multiprocess``, trusting the list would
+    tell us 'spawn' on macOS while ``Dataset.map`` actually forks -- vetoing
+    every worker and printing the wrong start method in the dead-worker
+    diagnostics that exist to stop exactly that kind of misreport.
+    """
+    import sys as _sys
+
+    darwin_order = ["spawn", "fork", "forkserver"]
+    fake = _fake_multiprocess(darwin_order, "fork")
+    monkeypatch.setitem(_sys.modules, "multiprocess", fake)
+    assert dnp.multiprocessing_start_method() == "fork"
+
+
+def test_macos_stays_in_process_even_though_multiprocess_forks(monkeypatch, dnp, capsys):
+    """The probe reports fork on macOS; policy still refuses to use it.
+
+    These are deliberately two separate things. ``multiprocess`` really does
+    fork on darwin, so the diagnostics must say so, but CPython moved the macOS
+    stdlib default to spawn in 3.8 (bpo-33725) on the grounds that forking there
+    "can lead to crashes of the subprocess as macOS system libraries may start
+    threads" -- and this parent has already loaded Torch and a threaded BLAS.
+    Fixing the probe without this guard would have taken macOS from
+    always-serial to up to AUTO_NUM_PROC_CAP forked workers.
+    """
+    _force_start_method(monkeypatch, dnp, "fork")
+    # Pin memory so the contrast below is about the platform policy and not
+    # about how much RAM the runner happens to have free.
+    monkeypatch.setattr(dnp, "_affordable_workers", lambda: 1000)
+    monkeypatch.setattr(dnp.sys, "platform", "darwin")
+
+    # Serial at a map() call site, and None -- not 1 -- at the config layer, so
+    # no Pool is built on datasets >= 4.1 either way.
+    assert dnp.get_dataset_num_proc(8) is None
+    assert dnp.get_dataset_num_proc(8, serial_as_none = False) is None
+    assert dnp.get_dataset_num_proc(None) is None
+    assert "macOS" in capsys.readouterr().out
+
+    # The escape hatch still overrides it, and Linux is unaffected.
+    monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, "4")
+    assert dnp.get_dataset_num_proc(8) == 4
+    monkeypatch.delenv(dnp.NUM_PROC_ENV_VAR)
+    monkeypatch.setattr(dnp.sys, "platform", "linux")
+    assert dnp.get_dataset_num_proc(8) == 8
+
+
+def test_start_method_probe_falls_back_to_list_order(monkeypatch, dnp):
+    """The default context is private, so an unreadable one must not raise."""
+    import sys as _sys
+
+    fake = _fake_multiprocess(["spawn", "fork"], None)
+    monkeypatch.setitem(_sys.modules, "multiprocess", fake)
+    assert dnp.multiprocessing_start_method() == "spawn"
+
+
+def test_start_method_probe_matches_the_pool_multiprocess_would_build(dnp):
+    """The probe must agree with multiprocess's own default on this host."""
+    multiprocess = pytest.importorskip("multiprocess")
+    if multiprocess.get_start_method(allow_none = True) is not None:
+        pytest.skip("a start method is already pinned in this process")
+    assert (
+        dnp.multiprocessing_start_method()
+        == multiprocess.context._default_context._default_context._name
+    )
 
 
 # ---------- the generated trainer's import must match the real module ----------

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -1,0 +1,493 @@
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for unsloth.utils.dataset_num_proc.
+
+The module under test is stdlib-only by design, and is loaded here straight off
+disk rather than via ``import unsloth``. That keeps the policy tests meaningful
+on a host whose torch/unsloth_zoo pair cannot import -- these assertions are
+about worker-count arithmetic, not about the model stack. The separate
+``test_rl_codegen_*`` cases below tie the module back to the import path that
+``unsloth/models/rl.py`` actually generates, so a rename cannot slip through.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "unsloth" / "utils" / "dataset_num_proc.py"
+RL_PATH = REPO_ROOT / "unsloth" / "models" / "rl.py"
+
+# The dotted path unsloth/models/rl.py bakes into every generated trainer.
+GENERATED_IMPORT_MODULE = "unsloth.utils.dataset_num_proc"
+GENERATED_IMPORT_NAME = "get_dataset_num_proc"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "unsloth_dataset_num_proc_under_test", MODULE_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def dnp(monkeypatch):
+    module = _load_module()
+    module.reset_warning_state()
+    monkeypatch.delenv(module.NUM_PROC_ENV_VAR, raising = False)
+    return module
+
+
+def _force_start_method(monkeypatch, dnp, method):
+    monkeypatch.setattr(dnp, "multiprocessing_start_method", lambda: method)
+
+
+# ---------- start-method veto ----------
+
+
+@pytest.mark.parametrize("method", ["spawn", "forkserver", None])
+def test_non_fork_start_method_disables_multiprocessing(monkeypatch, dnp, method):
+    # datasets ships the map function to workers as a dill pickle. Under
+    # spawn/forkserver the child must also re-import the dynamically generated
+    # trainer module, which has no importable name, so workers cannot run.
+    _force_start_method(monkeypatch, dnp, method)
+    assert dnp.get_dataset_num_proc(8) is None
+    assert dnp.get_dataset_num_proc(None) is None
+
+
+def test_non_fork_start_method_warns_once(monkeypatch, dnp, capsys):
+    # Regression for eeffa4c065: an explicitly supplied value used to sail
+    # straight through the guard. It must be vetoed, and the veto must be visible.
+    _force_start_method(monkeypatch, dnp, "spawn")
+    dnp.get_dataset_num_proc(8)
+    dnp.get_dataset_num_proc(8)
+    out = capsys.readouterr().out
+    assert out.count("needs the 'fork' start method") == 1
+    assert "dataset_num_proc = 8" in out
+
+
+def test_fork_start_method_honours_explicit_value(monkeypatch, dnp):
+    _force_start_method(monkeypatch, dnp, "fork")
+    assert dnp.get_dataset_num_proc(6) == 6
+
+
+# ---------- the 1 -> None normalisation ----------
+
+
+@pytest.mark.parametrize("value", [1, 0, -4])
+def test_non_positive_and_one_normalise_to_none(monkeypatch, dnp, value):
+    # `1` is a trap: callers pass it meaning "serial" and datasets >= 4.0 gives
+    # them a Pool(1) instead. Only None is in-process on every supported release.
+    _force_start_method(monkeypatch, dnp, "fork")
+    assert dnp.get_dataset_num_proc(value) is None
+
+
+def test_serial_as_none_false_preserves_an_explicit_one(monkeypatch, dnp):
+    """The config layer must not collapse 1 to None.
+
+    unsloth_zoo.sft_prepare_dataset reads a config ``None`` as "auto-size me",
+    so writing None back for a user who asked for 1 would inflate it to the auto
+    worker count -- the opposite of what they asked for.
+    """
+    _force_start_method(monkeypatch, dnp, "fork")
+    assert dnp.get_dataset_num_proc(1, serial_as_none = False) == 1
+    # 0 and negatives are not a coherent request, but they still mean "not
+    # parallel", so they must land on the config layer's serial sentinel (1) and
+    # not on None, which would auto-size them back up.
+    assert dnp.get_dataset_num_proc(0, serial_as_none = False) == 1
+    assert dnp.get_dataset_num_proc(-4, serial_as_none = False) == 1
+
+
+def test_config_layer_never_returns_none(monkeypatch, dnp):
+    """No path may write None back to a config, whatever the reason for it.
+
+    None means "auto-size me" downstream, so any route to it -- start-method
+    veto, memory clamp, explicit serial -- would silently re-inflate.
+    """
+    psutil = pytest.importorskip("psutil")
+    monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 64)
+
+    # start-method veto
+    _force_start_method(monkeypatch, dnp, "spawn")
+    assert dnp.get_dataset_num_proc(16, serial_as_none = False) == 1
+
+    # memory clamp all the way down to serial
+    _force_start_method(monkeypatch, dnp, "fork")
+    monkeypatch.setattr(
+        psutil, "virtual_memory", lambda: type("m", (), {"available": 1 * 1024 ** 3})()
+    )
+    assert dnp.get_dataset_num_proc(16, serial_as_none = False) == 1
+    assert dnp.get_dataset_num_proc(None, serial_as_none = False) == 1
+
+
+def test_layering_config_then_map_site_is_correct(monkeypatch, dnp):
+    """Composing the two layers must land on the right value for each intent."""
+    _force_start_method(monkeypatch, dnp, "fork")
+    psutil = pytest.importorskip("psutil")
+    monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 32)
+    monkeypatch.setattr(
+        psutil,
+        "virtual_memory",
+        lambda: type("m", (), {"available": 256 * 1024 ** 3})(),
+    )
+    cfg = lambda v: dnp.get_dataset_num_proc(v, serial_as_none = False)  # noqa: E731
+    site = dnp.get_dataset_num_proc
+
+    # user asked for serial -> stays serial, never auto-inflated
+    assert site(cfg(1)) is None
+    # user asked for a specific count -> honoured end to end
+    assert site(cfg(6)) == 6
+    # user asked for nothing -> capped auto, and re-applying is idempotent
+    assert cfg(None) == dnp.AUTO_NUM_PROC_CAP
+    assert site(cfg(None)) == dnp.AUTO_NUM_PROC_CAP
+
+
+def test_low_memory_auto_path_returns_none_not_one(monkeypatch, dnp):
+    # The old heuristic returned 1 here, which still forked a Pool(1).
+    _force_start_method(monkeypatch, dnp, "fork")
+    psutil = pytest.importorskip("psutil")
+    monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 32)
+    monkeypatch.setattr(
+        psutil,
+        "virtual_memory",
+        lambda: type("m", (), {"available": 1 * 1024 ** 3})(),
+    )
+    assert dnp.get_dataset_num_proc(None) is None
+
+
+# ---------- auto sizing ----------
+
+
+def test_auto_value_is_capped(monkeypatch, dnp):
+    # Was min(max(cpu_count + 4, 2), 64) -- up to 64 forked workers, each handed
+    # its own dill-pickled tokenizer closure.
+    _force_start_method(monkeypatch, dnp, "fork")
+    psutil = pytest.importorskip("psutil")
+    monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 128)
+    monkeypatch.setattr(
+        psutil,
+        "virtual_memory",
+        lambda: type("m", (), {"available": 512 * 1024 ** 3})(),
+    )
+    assert dnp.get_dataset_num_proc(None) == dnp.AUTO_NUM_PROC_CAP
+    assert dnp.AUTO_NUM_PROC_CAP < 64
+
+
+def test_auto_value_clamped_by_available_memory(monkeypatch, dnp):
+    _force_start_method(monkeypatch, dnp, "fork")
+    psutil = pytest.importorskip("psutil")
+    monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 64)
+    monkeypatch.setattr(
+        psutil,
+        "virtual_memory",
+        lambda: type("m", (), {"available": 10 * 1024 ** 3})(),
+    )
+    # 10 GB free, half of it budgeted, ~1 GB per worker -> 5.
+    assert dnp.get_dataset_num_proc(None) == 5
+
+
+def test_explicit_value_is_clamped_by_memory(monkeypatch, dnp, capsys):
+    """The gap that actually caused issue #2693.
+
+    Studio passes an explicit ``max(1, cpu_count // 4)``, which on a big-core
+    machine is dozens of workers at ~680 MB each. The old heuristic capped only
+    the auto path, so an explicit request sailed through no matter how little
+    RAM there was.
+    """
+    _force_start_method(monkeypatch, dnp, "fork")
+    psutil = pytest.importorskip("psutil")
+    monkeypatch.setattr(
+        psutil,
+        "virtual_memory",
+        lambda: type("m", (), {"available": 16 * 1024 ** 3})(),
+    )
+    assert dnp.get_dataset_num_proc(48) == 8
+    assert "reducing dataset_num_proc 48 -> 8" in capsys.readouterr().out
+
+
+def test_explicit_value_is_not_capped_by_the_auto_cap(monkeypatch, dnp):
+    # AUTO_NUM_PROC_CAP bounds auto-sizing only. A user who asks for 32 and has
+    # the memory for it gets 32.
+    _force_start_method(monkeypatch, dnp, "fork")
+    psutil = pytest.importorskip("psutil")
+    monkeypatch.setattr(
+        psutil,
+        "virtual_memory",
+        lambda: type("m", (), {"available": 512 * 1024 ** 3})(),
+    )
+    assert dnp.get_dataset_num_proc(32) == 32
+    assert 32 > dnp.AUTO_NUM_PROC_CAP
+
+
+def test_memory_clamp_is_skipped_without_psutil(monkeypatch, dnp):
+    # No psutil means no memory reading. Honour the request rather than
+    # silently serialising on a machine that may be perfectly capable.
+    monkeypatch.setattr(dnp, "_affordable_workers", lambda: None)
+    _force_start_method(monkeypatch, dnp, "fork")
+    assert dnp.get_dataset_num_proc(32) == 32
+
+
+def test_bool_is_not_treated_as_an_int(monkeypatch, dnp):
+    _force_start_method(monkeypatch, dnp, "fork")
+    psutil = pytest.importorskip("psutil")
+    monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 8)
+    monkeypatch.setattr(
+        psutil,
+        "virtual_memory",
+        lambda: type("m", (), {"available": 64 * 1024 ** 3})(),
+    )
+    assert dnp.get_dataset_num_proc(True) == 4
+
+
+# ---------- environment escape hatch ----------
+
+
+def test_env_override_beats_start_method_veto(monkeypatch, dnp):
+    # A user who knows their workload is fork-safe is never silently downgraded.
+    _force_start_method(monkeypatch, dnp, "spawn")
+    monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, "24")
+    assert dnp.get_dataset_num_proc(None) == 24
+
+
+@pytest.mark.parametrize("raw", ["0", "none", "None", "false", ""])
+def test_env_override_can_force_in_process(monkeypatch, dnp, raw):
+    _force_start_method(monkeypatch, dnp, "fork")
+    monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, raw)
+    assert dnp.get_dataset_num_proc(16) is None
+
+
+def test_env_override_is_uncapped(monkeypatch, dnp):
+    _force_start_method(monkeypatch, dnp, "fork")
+    monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, "100")
+    assert dnp.get_dataset_num_proc(None) == 100
+
+
+def test_invalid_env_override_is_ignored_with_a_warning(monkeypatch, dnp, capsys):
+    _force_start_method(monkeypatch, dnp, "fork")
+    monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, "banana")
+    assert dnp.get_dataset_num_proc(4) == 4
+    assert "is not an integer" in capsys.readouterr().out
+
+
+# ---------- start-method probing must not mutate global state ----------
+
+
+def test_start_method_probe_prefers_multiprocess_and_has_no_side_effects(dnp):
+    """datasets does `from multiprocess import Pool`, so `multiprocess` -- not
+    stdlib multiprocessing -- decides how map() spawns. Reading it must also not
+    pin the context, which would make a later set_start_method() raise."""
+    multiprocess = pytest.importorskip("multiprocess")
+    import multiprocessing
+
+    before_mp = multiprocess.get_start_method(allow_none = True)
+    before_std = multiprocessing.get_start_method(allow_none = True)
+
+    method = dnp.multiprocessing_start_method()
+
+    assert method in multiprocess.get_all_start_methods()
+    assert multiprocess.get_start_method(allow_none = True) == before_mp
+    assert multiprocessing.get_start_method(allow_none = True) == before_std
+
+
+def test_start_method_probe_reports_an_explicit_setting(monkeypatch, dnp):
+    import sys as _sys
+    import types
+
+    fake = types.ModuleType("multiprocess")
+    fake.get_start_method = lambda allow_none = False: "forkserver"
+    fake.get_all_start_methods = lambda: ["fork", "spawn", "forkserver"]
+    monkeypatch.setitem(_sys.modules, "multiprocess", fake)
+    assert dnp.multiprocessing_start_method() == "forkserver"
+
+
+# ---------- the generated trainer's import must match the real module ----------
+
+
+def _rl_num_proc_snippet():
+    tree = ast.parse(RL_PATH.read_text(encoding = "utf-8"))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and getattr(node.targets[0], "id", "") == "num_proc_check"
+        ):
+            return ast.literal_eval(node.value)
+    raise AssertionError("num_proc_check literal not found in unsloth/models/rl.py")
+
+
+def test_rl_codegen_writes_back_without_collapsing_serial():
+    # The config layer must pass serial_as_none = False; see the layering test.
+    snippet = _rl_num_proc_snippet()
+    assert "serial_as_none = False" in snippet
+
+
+def test_zoo_sft_prepare_dataset_anchor_has_not_drifted():
+    """unsloth/models/rl_replacements.py rewrites unsloth_zoo's
+    sft_prepare_dataset by exact string match. A Zoo release that touches those
+    lines makes _require_replace raise at import time, so catch drift here."""
+    # Locate the file without importing unsloth_zoo: find_spec resolves the
+    # package's path without executing its __init__, so this canary still runs
+    # on a host whose torch/unsloth_zoo pair cannot import.
+    spec = importlib.util.find_spec("unsloth_zoo")
+    if spec is None or not spec.submodule_search_locations:
+        pytest.skip("unsloth_zoo not installed")
+    zoo_file = Path(list(spec.submodule_search_locations)[0]) / "dataset_utils.py"
+    if not zoo_file.is_file():
+        pytest.skip("unsloth_zoo.dataset_utils not found")
+    source = zoo_file.read_text(encoding = "utf-8")
+
+    rr_tree = ast.parse(RL_PATH.with_name("rl_replacements.py").read_text(encoding = "utf-8"))
+
+    def _anchor_and_count(where):
+        found = [
+            (
+                ast.literal_eval(node.args[1]),
+                next(
+                    (
+                        ast.literal_eval(k.value)
+                        for k in node.keywords
+                        if k.arg == "count"
+                    ),
+                    1,
+                ),
+            )
+            for node in ast.walk(rr_tree)
+            if isinstance(node, ast.Call)
+            and getattr(node.func, "id", "") == "_require_replace"
+            and any(
+                k.arg == "where" and ast.literal_eval(k.value) == where
+                for k in node.keywords
+            )
+        ]
+        assert len(found) == 1, f"expected exactly one _require_replace for {where!r}"
+        return found[0]
+
+    # Both edits this module owns. _require_replace raises when an anchor is
+    # missing entirely, but it cannot notice that a count = 2 anchor dropped to
+    # one occurrence, so assert the counts here.
+    for where in (
+        "sft_prepare_dataset dataset_num_proc selection",
+        "sft_prepare_dataset tokenizing map() calls",
+    ):
+        anchor, count = _anchor_and_count(where)
+        assert source.count(anchor) == count, (
+            f"unsloth_zoo.dataset_utils has {source.count(anchor)} occurrences of "
+            f"the {where!r} anchor, expected {count}; update rl_replacements.py"
+        )
+
+
+def test_rl_codegen_imports_the_module_that_exists():
+    # The snippet is spliced into generated source as text, so a rename here is
+    # only caught at trainer-construction time in production. Catch it now.
+    snippet = _rl_num_proc_snippet()
+    assert f"from {GENERATED_IMPORT_MODULE} import {GENERATED_IMPORT_NAME}" in snippet
+    assert MODULE_PATH.is_file()
+    module = _load_module()
+    assert callable(getattr(module, GENERATED_IMPORT_NAME))
+
+
+def test_rl_codegen_snippet_is_valid_python_at_method_indent():
+    # rl.py re-indents extra_args to 8 spaces and drops it into __init__.
+    snippet = _rl_num_proc_snippet()
+    body = "\n".join(" " * 8 + line for line in snippet.split("\n"))
+    source = "class C:\n    def __init__(self, dataset_num_proc = None):\n" + body + "\n        pass\n"
+    ast.parse(source)
+
+
+def test_rl_codegen_snippet_survives_an_unimportable_helper():
+    # A generated file can outlive an unsloth downgrade. Constructing a config
+    # must still work; it just leaves the caller's value alone.
+    snippet = _rl_num_proc_snippet()
+    namespace = {"dataset_num_proc": 7}
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _blocked(name, *args, **kwargs):
+        if name.startswith("unsloth"):
+            raise ImportError("simulated downgrade")
+        return real_import(name, *args, **kwargs)
+
+    builtins.__import__ = _blocked
+    try:
+        exec(snippet, namespace)
+    finally:
+        builtins.__import__ = real_import
+    assert namespace["dataset_num_proc"] == 7
+
+
+# ---------- worker-death diagnostics ----------
+
+
+_DATASETS_MESSAGE = (
+    "One of the subprocesses has abruptly died during map operation."
+    "To debug the error, disable multiprocessing."
+)
+
+
+def test_worker_death_is_reraised_with_context(dnp):
+    # datasets discards the child's exit status, so the original message cannot
+    # distinguish an OOM kill from anything else. Supply what it dropped.
+    with pytest.raises(RuntimeError) as caught:
+        with dnp.map_failure_diagnostics(8):
+            raise RuntimeError(_DATASETS_MESSAGE)
+
+    message = str(caught.value)
+    assert "dataset_num_proc = 8" in message
+    assert "8 workers" in message
+    assert "8GB" in message, "should estimate what those workers cost"
+    assert dnp.NUM_PROC_ENV_VAR in message, "must name the escape hatch"
+    assert "out-of-memory" in message
+    # The child's traceback must survive for anyone who wants it.
+    assert isinstance(caught.value.__cause__, RuntimeError)
+    assert _DATASETS_MESSAGE in str(caught.value.__cause__)
+
+
+def test_worker_death_diagnostics_handles_in_process_runs(dnp):
+    # num_proc=None still reaches the wrapper; it must not divide by a None.
+    with pytest.raises(RuntimeError) as caught:
+        with dnp.map_failure_diagnostics(None):
+            raise RuntimeError(_DATASETS_MESSAGE)
+    assert "dataset_num_proc = None" in str(caught.value)
+    assert "1 worker," in str(caught.value)
+
+
+def test_unrelated_errors_pass_through_untouched(dnp):
+    # Only the dead-worker message is rewritten; nothing else is swallowed or
+    # reworded, and non-RuntimeError types are not caught at all.
+    original = RuntimeError("CUDA out of memory")
+    with pytest.raises(RuntimeError) as caught:
+        with dnp.map_failure_diagnostics(4):
+            raise original
+    assert caught.value is original
+
+    key = KeyError("text")
+    with pytest.raises(KeyError) as caught_key:
+        with dnp.map_failure_diagnostics(4):
+            raise key
+    assert caught_key.value is key
+
+
+def test_successful_map_is_not_disturbed(dnp):
+    with dnp.map_failure_diagnostics(4):
+        result = "tokenized"
+    assert result == "tokenized"

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -661,3 +661,59 @@ def test_studio_bounds_its_own_computed_worker_count(dnp):
         "safe_num_proc no longer bounds its result; studio would send "
         "cpu_count // 3 workers straight to Dataset.map"
     )
+
+
+def test_the_recovery_advice_does_not_promise_more_than_it_delivers(dnp):
+    """UNSLOTH_DATASET_NUM_PROC=0 is not in-process on every path.
+
+    The dead-worker message is the one place a user is told what to do next, so
+    it has to be true. On fork, train_on_responses_only with a split at or over
+    the Zoo's threshold gets ``1`` rather than ``None`` -- deliberately, since a
+    bare None there is read as "size it for me" and would inflate to the Zoo's
+    uncapped count -- and ``datasets`` >= 4.1 turns that into a Pool(1). So the
+    advice is in-process almost everywhere and one worker in that one case, and
+    saying "tokenize in-process" flatly was wrong for exactly the large-dataset
+    runs that die in the first place.
+    """
+    with pytest.raises(RuntimeError) as excinfo:
+        with dnp.map_failure_diagnostics(8):
+            raise RuntimeError("One of the subprocesses has abruptly died during map operation.")
+    message = str(excinfo.value)
+    assert f"{dnp.NUM_PROC_ENV_VAR}=0" in message
+    assert "one worker" in message, "the exception to in-process has to be stated"
+    assert "train_on_responses_only" in message, "and which path it applies to"
+    assert f"{dnp.ZOO_MIN_ROWS_FOR_MULTIPROC:,}" in message, "and above which size"
+
+
+def test_the_advice_matches_what_the_resolver_actually_returns(dnp, monkeypatch):
+    """Executed, not just read: the claim above is checked against the code.
+
+    A message asserting a behaviour the resolver does not have would be worse
+    than the vague one it replaced, so drive both branches and compare.
+    """
+
+    class _Split:
+        def __init__(self, n):
+            self.n = n
+
+        def __len__(self):
+            return self.n
+
+    class _Trainer:
+        def __init__(self, split):
+            self.train_dataset = split
+            self.eval_dataset = None
+
+    monkeypatch.setattr(dnp, "multiprocessing_start_method", lambda: "fork")
+    monkeypatch.setattr(dnp, "_affordable_workers", lambda: 1000)
+    monkeypatch.setattr(dnp.sys, "platform", "linux")
+    monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, "0")
+
+    over = dnp.resolve_responses_only_num_proc(
+        _Trainer(_Split(dnp.ZOO_MIN_ROWS_FOR_MULTIPROC + 1)), None
+    )
+    under = dnp.resolve_responses_only_num_proc(
+        _Trainer(_Split(dnp.ZOO_MIN_ROWS_FOR_MULTIPROC - 1)), None
+    )
+    assert over == 1, "over the threshold the best expressible request is one worker"
+    assert under is None, "under it the Zoo's own guard already goes in-process"

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -76,6 +76,17 @@ def _force_start_method(monkeypatch, dnp, method):
     monkeypatch.setattr(dnp, "multiprocessing_start_method", lambda: method)
 
 
+def _force_cpus(monkeypatch, dnp, count):
+    """Pin the CPU count the auto path sizes from.
+
+    Patching psutil alone is not enough: the count is the smallest of the host's
+    CPUs, this process's affinity mask and any cgroup quota, so on a 4-vCPU runner
+    a "128 CPU host" would still come out as 4.
+    """
+    monkeypatch.setattr(dnp, "_usable_cpus", lambda: count)
+
+
+
 # ---------- start-method veto ----------
 
 
@@ -135,7 +146,7 @@ def test_config_layer_never_returns_none_while_forking_is_available(monkeypatch,
     explicit serial -- would re-inflate.
     """
     psutil = pytest.importorskip("psutil")
-    monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 64)
+    _force_cpus(monkeypatch, dnp, 64)
 
     # memory clamp all the way down to serial
     _force_start_method(monkeypatch, dnp, "fork")
@@ -172,7 +183,7 @@ def test_layering_config_then_map_site_is_correct(monkeypatch, dnp):
     """Composing the two layers must land on the right value for each intent."""
     _force_start_method(monkeypatch, dnp, "fork")
     psutil = pytest.importorskip("psutil")
-    monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 32)
+    _force_cpus(monkeypatch, dnp, 32)
     monkeypatch.setattr(
         psutil,
         "virtual_memory",
@@ -194,7 +205,7 @@ def test_low_memory_auto_path_returns_none_not_one(monkeypatch, dnp):
     # The old heuristic returned 1 here, which still forked a Pool(1).
     _force_start_method(monkeypatch, dnp, "fork")
     psutil = pytest.importorskip("psutil")
-    monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 32)
+    _force_cpus(monkeypatch, dnp, 32)
     monkeypatch.setattr(
         psutil,
         "virtual_memory",
@@ -210,7 +221,7 @@ def test_auto_value_is_capped(monkeypatch, dnp):
     # Was min(max(cpu_count + 4, 2), 64) -- up to 64 forked workers.
     _force_start_method(monkeypatch, dnp, "fork")
     psutil = pytest.importorskip("psutil")
-    monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 128)
+    _force_cpus(monkeypatch, dnp, 128)
     monkeypatch.setattr(
         psutil,
         "virtual_memory",
@@ -223,7 +234,7 @@ def test_auto_value_is_capped(monkeypatch, dnp):
 def test_auto_value_clamped_by_available_memory(monkeypatch, dnp):
     _force_start_method(monkeypatch, dnp, "fork")
     psutil = pytest.importorskip("psutil")
-    monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 64)
+    _force_cpus(monkeypatch, dnp, 64)
     monkeypatch.setattr(
         psutil,
         "virtual_memory",
@@ -274,7 +285,7 @@ def test_memory_clamp_is_skipped_without_psutil(monkeypatch, dnp):
 def test_bool_is_not_treated_as_an_int(monkeypatch, dnp):
     _force_start_method(monkeypatch, dnp, "fork")
     psutil = pytest.importorskip("psutil")
-    monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 8)
+    _force_cpus(monkeypatch, dnp, 8)
     monkeypatch.setattr(
         psutil,
         "virtual_memory",
@@ -804,3 +815,150 @@ def test_probe_rejects_a_start_method_the_host_does_not_offer(monkeypatch, dnp):
     monkeypatch.setattr(dnp.sys, "platform", "win32")
     assert dnp.get_dataset_num_proc(8) is None
     assert dnp.get_dataset_num_proc(8, serial_as_none = False) is None
+
+
+class _Split:
+    """Minimal sized stand-in for a datasets.Dataset."""
+
+    def __init__(self, n):
+        self.n = n
+
+    def __len__(self):
+        return self.n
+
+
+# ---------- containers: the host is not what this process may use ----------
+
+
+def test_memory_budget_follows_the_cgroup_not_the_host(monkeypatch, dnp):
+    """psutil reports the HOST inside a container.
+
+    A 2GB pod on a 512GB box read as having room for the full worker set and got
+    OOM-killed, which is the failure the memory ceiling exists to prevent.
+    """
+    psutil = pytest.importorskip("psutil")
+    _force_start_method(monkeypatch, dnp, "fork")
+    _force_cpus(monkeypatch, dnp, 64)
+    monkeypatch.setattr(
+        psutil, "virtual_memory", lambda: type("m", (), {"available": 512 * 1024**3})()
+    )
+    monkeypatch.setattr(dnp, "_cgroup_memory_used", lambda: 0)
+
+    monkeypatch.setattr(dnp, "_cgroup_limits", lambda: (None, None))
+    assert dnp.get_dataset_num_proc(None) == dnp.AUTO_NUM_PROC_CAP
+
+    monkeypatch.setattr(dnp, "_cgroup_limits", lambda: (2 * 1024**3, None))
+    assert dnp.get_dataset_num_proc(None) is None, "a 2GB container has no room for workers"
+
+    monkeypatch.setattr(dnp, "_cgroup_limits", lambda: (8 * 1024**3, None))
+    assert dnp.get_dataset_num_proc(None) == 4
+
+
+def test_memory_already_spent_in_the_container_is_not_counted_as_free(monkeypatch, dnp):
+    # Otherwise a container that has already spent most of its limit still reads
+    # as having the whole thing available.
+    psutil = pytest.importorskip("psutil")
+    _force_start_method(monkeypatch, dnp, "fork")
+    _force_cpus(monkeypatch, dnp, 64)
+    monkeypatch.setattr(
+        psutil, "virtual_memory", lambda: type("m", (), {"available": 512 * 1024**3})()
+    )
+    monkeypatch.setattr(dnp, "_cgroup_limits", lambda: (32 * 1024**3, None))
+
+    monkeypatch.setattr(dnp, "_cgroup_memory_used", lambda: 0)
+    assert dnp.get_dataset_num_proc(None) == dnp.AUTO_NUM_PROC_CAP
+
+    monkeypatch.setattr(dnp, "_cgroup_memory_used", lambda: 30 * 1024**3)
+    assert dnp.get_dataset_num_proc(None) is None
+
+
+def test_cpu_count_follows_the_affinity_mask(monkeypatch, dnp):
+    # Under taskset or Slurm pinning the host count is not what this process can
+    # run on, and workers would only contend for the cores it does have.
+    psutil = pytest.importorskip("psutil")
+    monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 128)
+    monkeypatch.setattr(dnp, "_cgroup_limits", lambda: (None, None))
+    monkeypatch.setattr(dnp.os, "sched_getaffinity", lambda pid: set(range(4)), raising = False)
+    assert dnp._usable_cpus() == 4
+
+
+def test_cpu_count_follows_a_fractional_cgroup_quota(monkeypatch, dnp):
+    # Kubernetes "cpu: 500m" is cpu.max "50000 100000" = 0.5 cores. Requiring a
+    # whole core would fall back to the host count, so a half-core pod would size
+    # workers from every core on the machine.
+    psutil = pytest.importorskip("psutil")
+    monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 128)
+    monkeypatch.setattr(dnp.os, "sched_getaffinity", lambda pid: set(range(128)), raising = False)
+    monkeypatch.setattr(dnp, "_cgroup_limits", lambda: (None, 0.5))
+    assert dnp._usable_cpus() == 1
+
+
+def test_a_single_usable_cpu_tokenizes_in_process(monkeypatch, dnp):
+    _force_start_method(monkeypatch, dnp, "fork")
+    _force_cpus(monkeypatch, dnp, 1)
+    assert dnp.get_dataset_num_proc(None) is None
+
+
+def test_the_cgroup_readers_never_raise(dnp):
+    # They run on every auto-sizing call, on hosts with no cgroup at all.
+    limit, quota = dnp._cgroup_limits()
+    assert limit is None or isinstance(limit, int)
+    assert quota is None or isinstance(quota, float)
+    used = dnp._cgroup_memory_used()
+    assert used is None or isinstance(used, int)
+
+
+# ---------- the zoo reads the other module ----------
+
+
+def _force_stdlib_start_method(monkeypatch, dnp, method):
+    real = dnp._module_start_method
+    monkeypatch.setattr(
+        dnp,
+        "_module_start_method",
+        lambda name: method if name == "multiprocessing" else real(name),
+    )
+
+
+def test_serial_is_one_when_the_two_modules_disagree(monkeypatch, dnp, capsys):
+    """A None handed to train_on_responses_only is "size it for me" to it.
+
+    Its auto path asks stdlib multiprocessing. Where that says fork while
+    multiprocess says spawn, None is not serial: it picks cpu_count + 4 workers,
+    and datasets then builds that pool on the spawn context -- the #3211 / #3397
+    re-import loop, multiplied.
+    """
+    _force_start_method(monkeypatch, dnp, "spawn")
+    _force_stdlib_start_method(monkeypatch, dnp, "fork")
+
+    trainer = type("t", (), {"train_dataset": _Split(dnp.ZOO_MIN_ROWS_FOR_MULTIPROC * 2)})()
+    assert dnp.resolve_responses_only_num_proc(trainer, None) == 1
+    assert dnp.resolve_responses_only_num_proc(trainer, 16) == 1
+    assert "disagree about the start method" in capsys.readouterr().out
+
+
+def test_serial_stays_none_when_the_zoo_would_refuse_workers_too(monkeypatch, dnp):
+    # macOS: multiprocess forks, stdlib spawns. Its own veto fires, so None is
+    # genuinely in-process there and 1 would be a pool it did not need.
+    _force_start_method(monkeypatch, dnp, "fork")
+    monkeypatch.setattr(dnp.sys, "platform", "darwin")
+    _force_stdlib_start_method(monkeypatch, dnp, "spawn")
+
+    trainer = type("t", (), {"train_dataset": _Split(dnp.ZOO_MIN_ROWS_FOR_MULTIPROC * 2)})()
+    assert dnp.resolve_responses_only_num_proc(trainer, None) is None
+    assert dnp.resolve_responses_only_num_proc(trainer, 16) is None
+
+
+def test_agreeing_modules_are_left_alone(monkeypatch, dnp):
+    _force_start_method(monkeypatch, dnp, "fork")
+    _force_stdlib_start_method(monkeypatch, dnp, "fork")
+    _force_cpus(monkeypatch, dnp, 32)
+    psutil = pytest.importorskip("psutil")
+    monkeypatch.setattr(
+        psutil, "virtual_memory", lambda: type("m", (), {"available": 256 * 1024**3})()
+    )
+    monkeypatch.setattr(dnp, "_cgroup_limits", lambda: (None, None))
+
+    trainer = type("t", (), {"train_dataset": _Split(dnp.ZOO_MIN_ROWS_FOR_MULTIPROC * 2)})()
+    assert dnp.resolve_responses_only_num_proc(trainer, None) == dnp.AUTO_NUM_PROC_CAP
+    assert dnp.resolve_responses_only_num_proc(trainer, 1) == 1

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -1,16 +1,5 @@
-# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
 """Tests for unsloth.dataset_num_proc, the fallback copy of the policy.
 

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -75,18 +75,31 @@ def dnp(monkeypatch):
         )
     except ImportError:
         pass
-    # Point both cgroup readers at a path that does not exist rather than
-    # stubbing the readers themselves, so the tests that are about those
-    # readers can still install a fixture tree and win.
+    # Point this module's cgroup reader at a path that does not exist rather than
+    # stubbing the reader itself, so the tests that are about it can still
+    # install a fixture tree and win.
     monkeypatch.setattr(module, "CGROUP_ROOT", "/nonexistent-cgroup-root-for-tests")
+    # unsloth_zoo's readers are neutralised by name instead, and without
+    # requiring the name to be there: pinning hf_xet_tuning.CGROUP_ROOT alone
+    # only works on a zoo that has that global. An older zoo still exposes the
+    # private dir helpers this module prefers, monkeypatch finds no attribute to
+    # pin, and the policy reads the runner's real cgroup -- which in a
+    # memory-limited container turns a test about the start method into a test
+    # of the clamp. The tests that are about these readers install their own
+    # unsloth_zoo.hf_xet_tuning in sys.modules, so they are unaffected.
     try:
-        from pathlib import Path
         from unsloth_zoo import hf_xet_tuning
-        monkeypatch.setattr(
-            hf_xet_tuning, "CGROUP_ROOT", Path("/nonexistent-cgroup-root-for-tests")
-        )
     except Exception:
-        pass
+        hf_xet_tuning = None
+    if hf_xet_tuning is not None:
+        for name, neutral in (
+            ("CGROUP_ROOT", Path("/nonexistent-cgroup-root-for-tests")),
+            ("_cgroup_v2_dirs", lambda: []),
+            ("_cgroup_v1_dirs", lambda controller: []),
+            ("cgroup_memory_limit", lambda: None),
+            ("cgroup_cpu_limit", lambda: None),
+        ):
+            monkeypatch.setattr(hf_xet_tuning, name, neutral, raising = False)
     return module
 
 

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -14,12 +14,11 @@
 
 """Tests for unsloth.utils.dataset_num_proc.
 
-The module under test is stdlib-only by design, and is loaded here straight off
-disk rather than via ``import unsloth``. That keeps the policy tests meaningful
-on a host whose torch/unsloth_zoo pair cannot import -- these assertions are
-about worker-count arithmetic, not about the model stack. The separate
-``test_rl_codegen_*`` cases below tie the module back to the import path that
-``unsloth/models/rl.py`` actually generates, so a rename cannot slip through.
+The module is stdlib-only by design and is loaded straight off disk rather than
+via ``import unsloth``, so these worker-count assertions stay meaningful on a
+host whose torch/unsloth_zoo pair cannot import. The ``test_rl_codegen_*`` cases
+tie it back to the import path ``unsloth/models/rl.py`` generates, so a rename
+cannot slip through.
 """
 
 from __future__ import annotations
@@ -31,10 +30,9 @@ from pathlib import Path
 import pytest
 
 try:
-    # Imported here, before the dnp fixture spoofs sys.platform. multiprocess
-    # chooses its concrete contexts at import time from sys.platform, so a first
-    # import under a spoofed one would hand a Windows runner the POSIX fork
-    # contexts and the tests below would then be reading a fiction.
+    # Before the dnp fixture spoofs sys.platform: multiprocess picks its concrete
+    # contexts from sys.platform at import time, so a first import under a spoofed
+    # one hands a Windows runner the POSIX fork contexts.
     import multiprocess  # noqa: F401
 except ImportError:
     pass
@@ -63,11 +61,9 @@ def dnp(monkeypatch):
     module = _load_module()
     module.reset_warning_state()
     monkeypatch.delenv(module.NUM_PROC_ENV_VAR, raising = False)
-    # Pin the platform. macOS is refused by policy whatever the start method
-    # says, so every assertion below that expects a worker count is really an
-    # assertion about a forking platform; without this they pass on the Linux
-    # runner and fail on the macOS one. Tests about the platform itself set
-    # their own value afterwards, which wins.
+    # Pin the platform: macOS is refused by policy whatever the start method says,
+    # so every assertion expecting a worker count is really about a forking
+    # platform. Platform tests set their own value afterwards, which wins.
     monkeypatch.setattr(module.sys, "platform", "linux")
     return module
 
@@ -81,8 +77,7 @@ def _force_start_method(monkeypatch, dnp, method):
 
 @pytest.mark.parametrize("method", ["spawn", "forkserver", None])
 def test_non_fork_start_method_disables_multiprocessing(monkeypatch, dnp, method):
-    # datasets ships the map function to workers as a dill pickle. Under
-    # spawn/forkserver the child must also re-import the dynamically generated
+    # Under spawn/forkserver the child must re-import the dynamically generated
     # trainer module, which has no importable name, so workers cannot run.
     _force_start_method(monkeypatch, dnp, method)
     assert dnp.get_dataset_num_proc(8) is None
@@ -90,8 +85,8 @@ def test_non_fork_start_method_disables_multiprocessing(monkeypatch, dnp, method
 
 
 def test_non_fork_start_method_warns_once(monkeypatch, dnp, capsys):
-    # Regression for eeffa4c065: an explicitly supplied value used to sail
-    # straight through the guard. It must be vetoed, and the veto must be visible.
+    # Regression for eeffa4c065: an explicit value used to sail through the
+    # guard. It must be vetoed, and the veto must be visible.
     _force_start_method(monkeypatch, dnp, "spawn")
     dnp.get_dataset_num_proc(8)
     dnp.get_dataset_num_proc(8)
@@ -110,8 +105,7 @@ def test_fork_start_method_honours_explicit_value(monkeypatch, dnp):
 
 @pytest.mark.parametrize("value", [1, 0, -4])
 def test_non_positive_and_one_normalise_to_none(monkeypatch, dnp, value):
-    # `1` is a trap: callers pass it meaning "serial" and datasets >= 4.0 gives
-    # them a Pool(1) instead. Only None is in-process on every supported release.
+    # `1` is a trap: callers mean "serial", datasets >= 4.0 gives a Pool(1).
     _force_start_method(monkeypatch, dnp, "fork")
     assert dnp.get_dataset_num_proc(value) is None
 
@@ -120,14 +114,12 @@ def test_serial_as_none_false_preserves_an_explicit_one(monkeypatch, dnp):
     """The config layer must not collapse 1 to None.
 
     unsloth_zoo.sft_prepare_dataset reads a config ``None`` as "auto-size me",
-    so writing None back for a user who asked for 1 would inflate it to the auto
-    worker count -- the opposite of what they asked for.
+    so writing None back for a user who asked for 1 would inflate it.
     """
     _force_start_method(monkeypatch, dnp, "fork")
     assert dnp.get_dataset_num_proc(1, serial_as_none = False) == 1
-    # 0 and negatives are not a coherent request, but they still mean "not
-    # parallel", so they must land on the config layer's serial sentinel (1) and
-    # not on None, which would auto-size them back up.
+    # 0 and negatives are incoherent requests but still mean "not parallel", so
+    # they land on the config serial sentinel (1), not on None.
     assert dnp.get_dataset_num_proc(0, serial_as_none = False) == 1
     assert dnp.get_dataset_num_proc(-4, serial_as_none = False) == 1
 
@@ -136,7 +128,7 @@ def test_config_layer_never_returns_none_while_forking_is_available(monkeypatch,
     """On a fork host no path may write None back to a config.
 
     None means "auto-size me" downstream, so any route to it -- memory clamp,
-    explicit serial -- would silently re-inflate.
+    explicit serial -- would re-inflate.
     """
     psutil = pytest.importorskip("psutil")
     monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 64)
@@ -155,16 +147,14 @@ def test_config_layer_never_returns_none_while_forking_is_available(monkeypatch,
 def test_config_layer_is_none_not_one_on_a_non_fork_start_method(monkeypatch, dnp, method, desired):
     """Regression: the config sentinel 1 reached unpatched TRL map() call sites.
 
-    Only SFT gets its map site rewritten (rl_replacements.py). DPO, KTO, CPO,
+    Only SFT gets its map site rewritten (rl_replacements.py); DPO, KTO, CPO,
     ORPO, Reward and PRM pass ``args.dataset_num_proc`` straight into
-    ``Dataset.map``, and on ``datasets`` >= 4.0 a ``1`` there builds a
-    ``Pool(1)`` whose spawned child re-imports the user's ``__main__`` -- the
-    Windows spawn loop (#3211 / #3397) this veto exists to prevent. Before this
-    module those configs carried ``None`` on spawn hosts; they must still.
+    ``Dataset.map``, where a ``1`` builds a ``Pool(1)`` whose spawned child
+    re-imports the user's ``__main__`` (#3211 / #3397). Those configs carried
+    ``None`` on spawn hosts before this module; they must still.
 
-    Writing None back is safe here precisely because forking is unavailable:
-    every auto-sizer that reads the config vetoes on a non-fork start method
-    too, so there is nothing left to inflate it.
+    None is safe here precisely because forking is unavailable: every auto-sizer
+    reading the config vetoes on a non-fork start method too.
     """
     _force_start_method(monkeypatch, dnp, method)
     assert dnp.get_dataset_num_proc(desired, serial_as_none = False) is None
@@ -216,8 +206,7 @@ def test_low_memory_auto_path_returns_none_not_one(monkeypatch, dnp):
 
 
 def test_auto_value_is_capped(monkeypatch, dnp):
-    # Was min(max(cpu_count + 4, 2), 64) -- up to 64 forked workers, each handed
-    # its own dill-pickled tokenizer closure.
+    # Was min(max(cpu_count + 4, 2), 64) -- up to 64 forked workers.
     _force_start_method(monkeypatch, dnp, "fork")
     psutil = pytest.importorskip("psutil")
     monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 128)
@@ -244,12 +233,12 @@ def test_auto_value_clamped_by_available_memory(monkeypatch, dnp):
 
 
 def test_explicit_value_is_clamped_by_memory(monkeypatch, dnp, capsys):
-    """The gap that actually caused issue #2693.
+    """The gap that caused issue #2693.
 
-    Studio passes an explicit ``max(1, cpu_count // 4)``, which on a big-core
-    machine is dozens of workers at ~680 MB each. The old heuristic capped only
-    the auto path, so an explicit request sailed through no matter how little
-    RAM there was.
+    Studio passes an explicit ``max(1, cpu_count // 4)``, dozens of workers at
+    ~680 MB each on a big-core machine, and the old heuristic capped only the
+    auto path -- so an explicit request sailed through however little RAM there
+    was.
     """
     _force_start_method(monkeypatch, dnp, "fork")
     psutil = pytest.importorskip("psutil")
@@ -263,8 +252,7 @@ def test_explicit_value_is_clamped_by_memory(monkeypatch, dnp, capsys):
 
 
 def test_explicit_value_is_not_capped_by_the_auto_cap(monkeypatch, dnp):
-    # AUTO_NUM_PROC_CAP bounds auto-sizing only. A user who asks for 32 and has
-    # the memory for it gets 32.
+    # AUTO_NUM_PROC_CAP bounds auto-sizing only.
     _force_start_method(monkeypatch, dnp, "fork")
     psutil = pytest.importorskip("psutil")
     monkeypatch.setattr(
@@ -277,8 +265,7 @@ def test_explicit_value_is_not_capped_by_the_auto_cap(monkeypatch, dnp):
 
 
 def test_memory_clamp_is_skipped_without_psutil(monkeypatch, dnp):
-    # No psutil means no memory reading. Honour the request rather than
-    # silently serialising on a machine that may be perfectly capable.
+    # No psutil means no memory reading, so honour the request.
     monkeypatch.setattr(dnp, "_affordable_workers", lambda: None)
     _force_start_method(monkeypatch, dnp, "fork")
     assert dnp.get_dataset_num_proc(32) == 32
@@ -300,7 +287,7 @@ def test_bool_is_not_treated_as_an_int(monkeypatch, dnp):
 
 
 def test_env_override_beats_start_method_veto(monkeypatch, dnp):
-    # A user who knows their workload is fork-safe is never silently downgraded.
+    # A user who knows their workload is fork-safe is never downgraded.
     _force_start_method(monkeypatch, dnp, "spawn")
     monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, "24")
     assert dnp.get_dataset_num_proc(None) == 24
@@ -315,12 +302,10 @@ def test_env_override_can_force_in_process(monkeypatch, dnp, raw):
 
 @pytest.mark.parametrize("raw", ["0", "none", "None", "false", "", "1"])
 def test_env_override_in_process_is_encoded_for_the_config_layer(monkeypatch, dnp, raw):
-    # Regression: the env override used to return before _serial(), so asking
-    # for in-process tokenization wrote None into the *config*, which
-    # unsloth_zoo.sft_prepare_dataset reads as "auto-size me" and inflates back
-    # to its own uncapped cpu_count + 4 -> 64. The escape hatch the dead-worker
-    # message recommends would have raised the worker count instead of removing
-    # it. At the config layer serial is 1, never None.
+    # Regression: the env override used to return before _serial(), writing None
+    # into the *config*, which unsloth_zoo.sft_prepare_dataset reads as
+    # "auto-size me" -- so the hatch the dead-worker message recommends raised
+    # the worker count instead of removing it. Config serial is 1, never None.
     _force_start_method(monkeypatch, dnp, "fork")
     monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, raw)
     assert dnp.get_dataset_num_proc(16, serial_as_none = False) == 1
@@ -354,10 +339,9 @@ def test_start_method_probe_prefers_multiprocess_and_has_no_side_effects(dnp):
 
     method = dnp.multiprocessing_start_method()
 
-    # Must name a method this host actually offers. Windows offers only spawn,
-    # and the private default-context chain the probe reads has been seen to
-    # answer "fork" there; taking that at face value would read Windows as
-    # forkable and let workers through.
+    # Must name a method this host offers. The private default-context chain has
+    # answered "fork" on Windows, which offers only spawn; believing it would
+    # read Windows as forkable and let workers through.
     assert method in multiprocess.get_all_start_methods()
     assert multiprocess.get_start_method(allow_none = True) == before_mp
     assert multiprocessing.get_start_method(allow_none = True) == before_std
@@ -394,13 +378,12 @@ def _fake_multiprocess(listed, default_name):
 def test_start_method_probe_prefers_the_real_default_over_list_order(monkeypatch, dnp):
     """macOS: multiprocess lists 'spawn' first but its default context is fork.
 
-    ``multiprocess`` copies the stdlib ``get_all_start_methods()`` verbatim,
-    darwin branch included, but keeps ``fork`` as its ``_default_context`` on
-    every POSIX platform (``#FIXME: spawn`` in multiprocess/context.py). Since
-    ``datasets`` builds its pool from ``multiprocess``, trusting the list would
-    tell us 'spawn' on macOS while ``Dataset.map`` actually forks -- vetoing
-    every worker and printing the wrong start method in the dead-worker
-    diagnostics that exist to stop exactly that kind of misreport.
+    It copies stdlib ``get_all_start_methods()`` verbatim, darwin branch
+    included, while keeping ``fork`` as its ``_default_context`` on every POSIX
+    platform (``#FIXME: spawn`` in multiprocess/context.py). Since ``datasets``
+    pools come from ``multiprocess``, trusting the list would say 'spawn' while
+    ``Dataset.map`` forks -- vetoing every worker and misreporting the start
+    method in the dead-worker diagnostics.
     """
     import sys as _sys
 
@@ -413,22 +396,20 @@ def test_start_method_probe_prefers_the_real_default_over_list_order(monkeypatch
 def test_macos_stays_in_process_even_though_multiprocess_forks(monkeypatch, dnp, capsys):
     """The probe reports fork on macOS; policy still refuses to use it.
 
-    These are deliberately two separate things. ``multiprocess`` really does
-    fork on darwin, so the diagnostics must say so, but CPython moved the macOS
-    stdlib default to spawn in 3.8 (bpo-33725) on the grounds that forking there
-    "can lead to crashes of the subprocess as macOS system libraries may start
-    threads" -- and this parent has already loaded Torch and a threaded BLAS.
-    Fixing the probe without this guard would have taken macOS from
-    always-serial to up to AUTO_NUM_PROC_CAP forked workers.
+    Two separate things on purpose. ``multiprocess`` really does fork on darwin,
+    so the diagnostics must say so, but CPython moved the macOS default to spawn
+    in 3.8 (bpo-33725) because forking there "can lead to crashes of the
+    subprocess as macOS system libraries may start threads" -- and this parent
+    holds Torch and a threaded BLAS. Fixing the probe without this guard would
+    take macOS from always-serial to AUTO_NUM_PROC_CAP forked workers.
     """
     _force_start_method(monkeypatch, dnp, "fork")
-    # Pin memory so the contrast below is about the platform policy and not
-    # about how much RAM the runner happens to have free.
+    # Pin memory so the contrast is about policy, not the runner's free RAM.
     monkeypatch.setattr(dnp, "_affordable_workers", lambda: 1000)
     monkeypatch.setattr(dnp.sys, "platform", "darwin")
 
-    # Serial at a map() call site, and None -- not 1 -- at the config layer, so
-    # no Pool is built on datasets >= 4.1 either way.
+    # Serial at a map() call site, None -- not 1 -- at the config layer, so no
+    # Pool is built on datasets >= 4.1 either way.
     assert dnp.get_dataset_num_proc(8) is None
     assert dnp.get_dataset_num_proc(8, serial_as_none = False) is None
     assert dnp.get_dataset_num_proc(None) is None
@@ -483,9 +464,8 @@ def test_zoo_sft_prepare_dataset_anchor_has_not_drifted():
     """unsloth/models/rl_replacements.py rewrites unsloth_zoo's
     sft_prepare_dataset by exact string match. A Zoo release that touches those
     lines makes _require_replace raise at import time, so catch drift here."""
-    # Locate the file without importing unsloth_zoo: find_spec resolves the
-    # package's path without executing its __init__, so this canary still runs
-    # on a host whose torch/unsloth_zoo pair cannot import.
+    # find_spec resolves the package path without executing its __init__, so this
+    # canary still runs where torch/unsloth_zoo cannot import.
     spec = importlib.util.find_spec("unsloth_zoo")
     if spec is None or not spec.submodule_search_locations:
         pytest.skip("unsloth_zoo not installed")
@@ -513,9 +493,8 @@ def test_zoo_sft_prepare_dataset_anchor_has_not_drifted():
         assert len(found) == 1, f"expected exactly one _require_replace for {where!r}"
         return found[0]
 
-    # Both edits this module owns. _require_replace raises when an anchor is
-    # missing entirely, but it cannot notice that a count = 2 anchor dropped to
-    # one occurrence, so assert the counts here.
+    # _require_replace raises on a missing anchor but cannot notice a count = 2
+    # anchor dropping to one occurrence, so assert the counts here.
     for where in (
         "sft_prepare_dataset dataset_num_proc selection",
         "sft_prepare_dataset tokenizing map() calls",
@@ -528,8 +507,8 @@ def test_zoo_sft_prepare_dataset_anchor_has_not_drifted():
 
 
 def test_rl_codegen_imports_the_module_that_exists():
-    # The snippet is spliced into generated source as text, so a rename here is
-    # only caught at trainer-construction time in production. Catch it now.
+    # The snippet is spliced into generated source as text, so a rename would
+    # otherwise surface only at trainer-construction time in production.
     snippet = _rl_num_proc_snippet()
     assert f"from {GENERATED_IMPORT_MODULE} import {GENERATED_IMPORT_NAME}" in snippet
     assert MODULE_PATH.is_file()
@@ -548,8 +527,8 @@ def test_rl_codegen_snippet_is_valid_python_at_method_indent():
 
 
 def test_rl_codegen_snippet_survives_an_unimportable_helper():
-    # A generated file can outlive an unsloth downgrade. Constructing a config
-    # must still work; it just leaves the caller's value alone.
+    # A generated file can outlive an unsloth downgrade: constructing a config
+    # must still work, just leaving the caller's value alone.
     snippet = _rl_num_proc_snippet()
     namespace = {"dataset_num_proc": 7}
     import builtins
@@ -580,7 +559,7 @@ _DATASETS_MESSAGE = (
 
 def test_worker_death_is_reraised_with_context(dnp):
     # datasets discards the child's exit status, so the original message cannot
-    # distinguish an OOM kill from anything else. Supply what it dropped.
+    # distinguish an OOM kill from anything else.
     with pytest.raises(RuntimeError) as caught:
         with dnp.map_failure_diagnostics(8):
             raise RuntimeError(_DATASETS_MESSAGE)
@@ -606,8 +585,8 @@ def test_worker_death_diagnostics_handles_in_process_runs(dnp):
 
 
 def test_unrelated_errors_pass_through_untouched(dnp):
-    # Only the dead-worker message is rewritten; nothing else is swallowed or
-    # reworded, and non-RuntimeError types are not caught at all.
+    # Only the dead-worker message is rewritten, and non-RuntimeError types are
+    # not caught at all.
     original = RuntimeError("CUDA out of memory")
     with pytest.raises(RuntimeError) as caught:
         with dnp.map_failure_diagnostics(4):
@@ -630,11 +609,10 @@ def test_successful_map_is_not_disturbed(dnp):
 def test_studio_num_proc_cap_has_not_drifted(dnp):
     """Studio duplicates AUTO_NUM_PROC_CAP; the two must stay equal.
 
-    hardware.py cannot import this module -- that would pull in unsloth's whole
-    __init__ during hardware detection -- so it carries its own copy, the same
-    arrangement ZOO_MIN_ROWS_FOR_MULTIPROC uses in the other direction. Read it
-    out of the source rather than importing studio, which needs a backend
-    environment this suite does not have.
+    hardware.py cannot import this module without pulling unsloth's whole
+    __init__ into hardware detection, so it carries its own copy. Read it out of
+    the source rather than importing studio, which needs a backend environment
+    this suite does not have.
     """
     hardware = REPO_ROOT / "studio" / "backend" / "utils" / "hardware" / "hardware.py"
     if not hardware.is_file():
@@ -660,9 +638,8 @@ def test_studio_bounds_its_own_computed_worker_count(dnp):
 
     trainer.py asks for cpu_count // 4 and safe_num_proc's auto path is
     cpu_count // 3, so a 64-core host produced 16 workers and a 192-core one 48.
-    Those are explicit ints by the time this module sees them, so it treated
-    them as deliberate and only clamped them by free memory -- meaning a large
-    machine with RAM to spare kept all 48. Nothing about that is user intent.
+    Those arrive here as explicit ints, so they were treated as deliberate and
+    only clamped by free memory -- a roomy machine kept all 48.
     """
     hardware = REPO_ROOT / "studio" / "backend" / "utils" / "hardware" / "hardware.py"
     if not hardware.is_file():
@@ -686,13 +663,11 @@ def test_the_recovery_advice_does_not_promise_more_than_it_delivers(dnp):
     """UNSLOTH_DATASET_NUM_PROC=0 is not in-process on every path.
 
     The dead-worker message is the one place a user is told what to do next, so
-    it has to be true. On fork, train_on_responses_only with a split at or over
-    the Zoo's threshold gets ``1`` rather than ``None`` -- deliberately, since a
-    bare None there is read as "size it for me" and would inflate to the Zoo's
-    uncapped count -- and ``datasets`` >= 4.1 turns that into a Pool(1). So the
-    advice is in-process almost everywhere and one worker in that one case, and
-    saying "tokenize in-process" flatly was wrong for exactly the large-dataset
-    runs that die in the first place.
+    it has to be true. On fork, train_on_responses_only over the Zoo's threshold
+    gets ``1`` rather than ``None`` -- deliberately, since a bare None reads as
+    "size it for me" and would inflate to the Zoo's uncapped count -- which
+    ``datasets`` >= 4.1 turns into a Pool(1). Saying "tokenize in-process"
+    flatly was wrong for exactly the large-dataset runs that die.
     """
     with pytest.raises(RuntimeError) as excinfo:
         with dnp.map_failure_diagnostics(8):
@@ -705,10 +680,10 @@ def test_the_recovery_advice_does_not_promise_more_than_it_delivers(dnp):
 
 
 def test_the_advice_matches_what_the_resolver_actually_returns(dnp, monkeypatch):
-    """Executed, not just read: the claim above is checked against the code.
+    """Executed, not just read: drive both branches of the claim above.
 
     A message asserting a behaviour the resolver does not have would be worse
-    than the vague one it replaced, so drive both branches and compare.
+    than the vague one it replaced.
     """
 
     class _Split:
@@ -742,10 +717,9 @@ def test_probe_rejects_a_start_method_the_host_does_not_offer(monkeypatch, dnp):
     """The private default-context chain is not trustworthy on its own.
 
     On a Windows runner it answered "fork" while get_all_start_methods() was
-    ["spawn"]. A start method the platform does not offer cannot be the one in
-    use, and believing it read Windows as forkable: _workers_unusable_reason()
-    returned None and workers were allowed through, which is the spawn
-    re-import loop of #3211 / #3397 that this module exists to prevent.
+    ["spawn"]. Believing it read Windows as forkable, so
+    _workers_unusable_reason() returned None and workers were let through --
+    the spawn re-import loop of #3211 / #3397.
     """
     import sys as _sys
     import types

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -86,7 +86,6 @@ def _force_cpus(monkeypatch, dnp, count):
     monkeypatch.setattr(dnp, "_usable_cpus", lambda: count)
 
 
-
 # ---------- start-method veto ----------
 
 

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for unsloth.utils.dataset_num_proc, the fallback copy of the policy.
+"""Tests for unsloth.dataset_num_proc, the fallback copy of the policy.
 
 unsloth_zoo.dataset_num_proc owns it; this copy only runs on a zoo that predates
 the module, and ``test_the_two_copies_have_not_drifted`` holds them together.
@@ -41,14 +41,14 @@ except ImportError:
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-MODULE_PATH = REPO_ROOT / "unsloth" / "utils" / "dataset_num_proc.py"
+MODULE_PATH = REPO_ROOT / "unsloth" / "dataset_num_proc.py"
 RL_PATH = REPO_ROOT / "unsloth" / "models" / "rl.py"
 
 # The dotted paths unsloth/models/rl.py bakes into every generated trainer: the
 # zoo first, so generated source does not import back into unsloth, then this
 # package as the fallback for a zoo that predates the module.
 GENERATED_IMPORT_MODULE = "unsloth_zoo.dataset_num_proc"
-GENERATED_FALLBACK_MODULE = "unsloth.utils.dataset_num_proc"
+GENERATED_FALLBACK_MODULE = "unsloth.dataset_num_proc"
 GENERATED_IMPORT_NAME = "get_dataset_num_proc"
 
 
@@ -456,18 +456,50 @@ def test_start_method_probe_matches_the_pool_multiprocess_would_build(dnp):
 # ---------- the generated trainer's import must match the real module ----------
 
 
-def _rl_num_proc_snippet():
-    tree = ast.parse(RL_PATH.read_text(encoding = "utf-8"))
+def _rl_num_proc_snippet(trainer_file = "sft_trainer"):
+    """The snippet rl.py would splice into that trainer's generated config.
+
+    The expression is evaluated rather than literal_eval'd because it is no
+    longer one literal: the serial encoding depends on the trainer being
+    patched, and the point of these tests is what each one ends up with.
+    """
+    source = RL_PATH.read_text(encoding = "utf-8")
+    tree = ast.parse(source)
     for node in ast.walk(tree):
         if isinstance(node, ast.Assign) and getattr(node.targets[0], "id", "") == "num_proc_check":
-            return ast.literal_eval(node.value)
+            # Parenthesised: the segment starts at the first literal, so its
+            # continuation lines are an IndentationError on their own.
+            expression = "(" + ast.get_source_segment(source, node.value) + ")"
+            serial_as_none = "False" if trainer_file == "sft_trainer" else "True"
+            return eval(expression, {"_serial_as_none": serial_as_none})  # noqa: S307
     raise AssertionError("num_proc_check literal not found in unsloth/models/rl.py")
 
 
 def test_rl_codegen_writes_back_without_collapsing_serial():
-    # The config layer must pass serial_as_none = False; see the layering test.
-    snippet = _rl_num_proc_snippet()
-    assert "serial_as_none = False" in snippet
+    # SFT's config is read by an auto-sizer, so serial has to survive as 1.
+    assert "serial_as_none = False" in _rl_num_proc_snippet("sft_trainer")
+
+
+@pytest.mark.parametrize(
+    "trainer_file",
+    ["dpo_trainer", "kto_trainer", "cpo_trainer", "orpo_trainer", "reward_trainer", "prm_trainer"],
+)
+def test_rl_codegen_keeps_serial_as_none_where_the_config_reaches_map(trainer_file):
+    """Only SFT has a downstream auto-sizer to defend the sentinel against.
+
+    These trainers hand args.dataset_num_proc straight to Dataset.map, so a
+    config `1` is a Pool(1) on datasets >= 4.1 -- one worker holding its own
+    tokenizer copy, on the low-memory host that just refused workers. Nothing
+    inflates a None there, so None is what serial must be.
+    """
+    assert "serial_as_none = True" in _rl_num_proc_snippet(trainer_file)
+
+
+def test_rl_codegen_only_sft_gets_the_config_sentinel():
+    # Pin the discriminator itself: a rename of the trainer file would silently
+    # give every trainer the None encoding, including the one that must not have it.
+    source = RL_PATH.read_text(encoding = "utf-8")
+    assert '_serial_as_none = "False" if trainer_file == "sft_trainer" else "True"' in source
 
 
 def test_zoo_sft_prepare_dataset_anchor_has_not_drifted():
@@ -589,7 +621,7 @@ def test_the_two_copies_have_not_drifted():
         return ast.dump(ast.parse(ast.unparse(tree)))
 
     assert _shape(MODULE_PATH) == _shape(zoo_file), (
-        "unsloth/utils/dataset_num_proc.py and unsloth_zoo/dataset_num_proc.py "
+        "unsloth/dataset_num_proc.py and unsloth_zoo/dataset_num_proc.py "
         "have diverged; the zoo copy is the source of truth"
     )
 
@@ -842,15 +874,13 @@ def test_memory_budget_follows_the_cgroup_not_the_host(monkeypatch, dnp):
     monkeypatch.setattr(
         psutil, "virtual_memory", lambda: type("m", (), {"available": 512 * 1024**3})()
     )
-    monkeypatch.setattr(dnp, "_cgroup_memory_used", lambda: 0)
-
-    monkeypatch.setattr(dnp, "_cgroup_limits", lambda: (None, None))
+    monkeypatch.setattr(dnp, "_cgroup_free_bytes", lambda: None)
     assert dnp.get_dataset_num_proc(None) == dnp.AUTO_NUM_PROC_CAP
 
-    monkeypatch.setattr(dnp, "_cgroup_limits", lambda: (2 * 1024**3, None))
+    monkeypatch.setattr(dnp, "_cgroup_free_bytes", lambda: 2 * 1024**3)
     assert dnp.get_dataset_num_proc(None) is None, "a 2GB container has no room for workers"
 
-    monkeypatch.setattr(dnp, "_cgroup_limits", lambda: (8 * 1024**3, None))
+    monkeypatch.setattr(dnp, "_cgroup_free_bytes", lambda: 8 * 1024**3)
     assert dnp.get_dataset_num_proc(None) == 4
 
 
@@ -863,12 +893,11 @@ def test_memory_already_spent_in_the_container_is_not_counted_as_free(monkeypatc
     monkeypatch.setattr(
         psutil, "virtual_memory", lambda: type("m", (), {"available": 512 * 1024**3})()
     )
-    monkeypatch.setattr(dnp, "_cgroup_limits", lambda: (32 * 1024**3, None))
-
-    monkeypatch.setattr(dnp, "_cgroup_memory_used", lambda: 0)
+    monkeypatch.setattr(dnp, "_cgroup_free_bytes", lambda: 32 * 1024**3)
     assert dnp.get_dataset_num_proc(None) == dnp.AUTO_NUM_PROC_CAP
 
-    monkeypatch.setattr(dnp, "_cgroup_memory_used", lambda: 30 * 1024**3)
+    # 30 of the 32GB already spent leaves 2, which is not enough for workers.
+    monkeypatch.setattr(dnp, "_cgroup_free_bytes", lambda: 2 * 1024**3)
     assert dnp.get_dataset_num_proc(None) is None
 
 
@@ -877,7 +906,7 @@ def test_cpu_count_follows_the_affinity_mask(monkeypatch, dnp):
     # run on, and workers would only contend for the cores it does have.
     psutil = pytest.importorskip("psutil")
     monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 128)
-    monkeypatch.setattr(dnp, "_cgroup_limits", lambda: (None, None))
+    monkeypatch.setattr(dnp, "_cgroup_cpu_quota", lambda: None)
     monkeypatch.setattr(dnp.os, "sched_getaffinity", lambda pid: set(range(4)), raising = False)
     assert dnp._usable_cpus() == 4
 
@@ -889,7 +918,7 @@ def test_cpu_count_follows_a_fractional_cgroup_quota(monkeypatch, dnp):
     psutil = pytest.importorskip("psutil")
     monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 128)
     monkeypatch.setattr(dnp.os, "sched_getaffinity", lambda pid: set(range(128)), raising = False)
-    monkeypatch.setattr(dnp, "_cgroup_limits", lambda: (None, 0.5))
+    monkeypatch.setattr(dnp, "_cgroup_cpu_quota", lambda: 0.5)
     assert dnp._usable_cpus() == 1
 
 
@@ -901,11 +930,10 @@ def test_a_single_usable_cpu_tokenizes_in_process(monkeypatch, dnp):
 
 def test_the_cgroup_readers_never_raise(dnp):
     # They run on every auto-sizing call, on hosts with no cgroup at all.
-    limit, quota = dnp._cgroup_limits()
-    assert limit is None or isinstance(limit, int)
+    free = dnp._cgroup_free_bytes()
+    assert free is None or (isinstance(free, int) and free >= 0)
+    quota = dnp._cgroup_cpu_quota()
     assert quota is None or isinstance(quota, float)
-    used = dnp._cgroup_memory_used()
-    assert used is None or isinstance(used, int)
 
 
 # ---------- the zoo reads the other module ----------
@@ -957,39 +985,105 @@ def test_agreeing_modules_are_left_alone(monkeypatch, dnp):
     monkeypatch.setattr(
         psutil, "virtual_memory", lambda: type("m", (), {"available": 256 * 1024**3})()
     )
-    monkeypatch.setattr(dnp, "_cgroup_limits", lambda: (None, None))
+    monkeypatch.setattr(dnp, "_cgroup_free_bytes", lambda: None)
 
     trainer = type("t", (), {"train_dataset": _Split(dnp.ZOO_MIN_ROWS_FOR_MULTIPROC * 2)})()
     assert dnp.resolve_responses_only_num_proc(trainer, None) == dnp.AUTO_NUM_PROC_CAP
     assert dnp.resolve_responses_only_num_proc(trainer, 1) == 1
 
 
-def test_cgroup_usage_is_read_from_the_directory_that_set_the_limit(monkeypatch, dnp, tmp_path):
-    """Not from /sys/fs/cgroup/memory.current.
-
-    At the root that file is the whole machine's usage. Subtracting it from a
-    systemd unit's own MemoryMax would leave every run with nothing free and
-    silently serialise tokenization on ordinary hosts.
-    """
+def _fake_cgroup_module(monkeypatch, v2_dirs = (), v1_dirs = ()):
     import types
 
-    inner = tmp_path / "user.slice" / "session.scope"
-    inner.mkdir(parents = True)
-    (inner / "memory.current").write_text("3221225472\n")  # 3 GB, this unit
-    (tmp_path / "memory.current").write_text("400000000000\n")  # 400 GB, the box
+    def _read_first_line(path):
+        return path.read_text() if path.is_file() else None
+
+    def _parse_limit(raw):
+        if not raw or raw.strip() == "max":
+            return None
+        try:
+            return int(raw.strip())
+        except ValueError:
+            return None
 
     fake = types.ModuleType("unsloth_zoo.hf_xet_tuning")
-    fake._cgroup_v2_dirs = lambda: [inner, tmp_path]
-    fake._cgroup_v1_dirs = lambda controller: []
-    fake._read_first_line = lambda path: path.read_text() if path.is_file() else None
+    fake._cgroup_v2_dirs = lambda: list(v2_dirs)
+    fake._cgroup_v1_dirs = lambda controller: list(v1_dirs)
+    fake._read_first_line = _read_first_line
+    fake._parse_limit = _parse_limit
+    fake.cgroup_memory_limit = lambda: None
+    fake.cgroup_cpu_limit = lambda: None
     monkeypatch.setitem(sys.modules, "unsloth_zoo.hf_xet_tuning", fake)
+    return fake
 
-    assert dnp._cgroup_memory_used() == 3 * 1024**3
+
+def test_free_memory_pairs_each_limit_with_its_own_usage(monkeypatch, dnp, tmp_path):
+    """The binding limit is often an ancestor's, and so is the usage that fills it.
+
+    A leaf's usage against a slice's limit reports memory that siblings have
+    already spent as free. The other direction is worse: the root
+    memory.current is the whole machine, and against a unit's own MemoryMax it
+    leaves every run with nothing.
+    """
+    slice_dir = tmp_path / "user.slice"
+    leaf = slice_dir / "session.scope"
+    leaf.mkdir(parents = True)
+
+    # The slice caps 32GB and 30 of them are spent, mostly by a sibling; this
+    # leaf has a 16GB cap of its own and has spent 1.
+    (slice_dir / "memory.max").write_text("34359738368\n")
+    (slice_dir / "memory.current").write_text("32212254720\n")
+    (leaf / "memory.max").write_text("17179869184\n")
+    (leaf / "memory.current").write_text("1073741824\n")
+
+    _fake_cgroup_module(monkeypatch, v2_dirs = [leaf, slice_dir])
+    # 34 - 32 = 2GB from the slice, 16 - 1 = 15GB from the leaf. The slice binds.
+    assert dnp._cgroup_free_bytes() == 2 * 1024**3
+
+
+def test_free_memory_is_never_negative(monkeypatch, dnp, tmp_path):
+    # An over-committed cgroup reports more usage than its limit under pressure.
+    leaf = tmp_path / "scope"
+    leaf.mkdir()
+    (leaf / "memory.max").write_text("1073741824\n")
+    (leaf / "memory.current").write_text("2147483648\n")
+    _fake_cgroup_module(monkeypatch, v2_dirs = [leaf])
+    assert dnp._cgroup_free_bytes() == 0
+
+
+def test_an_unlimited_cgroup_is_not_a_ceiling(monkeypatch, dnp, tmp_path):
+    leaf = tmp_path / "scope"
+    leaf.mkdir()
+    (leaf / "memory.max").write_text("max\n")
+    (leaf / "memory.current").write_text("1073741824\n")
+    _fake_cgroup_module(monkeypatch, v2_dirs = [leaf])
+    assert dnp._cgroup_free_bytes() is None
+
+
+def test_a_readable_limit_with_no_readable_usage_still_binds(monkeypatch, dnp, tmp_path):
+    leaf = tmp_path / "scope"
+    leaf.mkdir()
+    (leaf / "memory.max").write_text("2147483648\n")
+    _fake_cgroup_module(monkeypatch, v2_dirs = [leaf])
+    assert dnp._cgroup_free_bytes() == 2 * 1024**3
 
 
 def test_missing_cgroup_readers_fall_back_to_the_limit_alone(monkeypatch, dnp):
-    # An older unsloth_zoo has no such helpers. Subtracting nothing is never
-    # worse than not subtracting, so the limit still binds.
+    """An older unsloth_zoo has no such private helpers.
+
+    The public limit reader alone can only overstate what is free, never
+    understate it, so the ceiling still binds.
+    """
+    import types
+
+    fake = types.ModuleType("unsloth_zoo.hf_xet_tuning")
+    fake.cgroup_memory_limit = lambda: 4 * 1024**3
+    fake.cgroup_cpu_limit = lambda: None
+    monkeypatch.setitem(sys.modules, "unsloth_zoo.hf_xet_tuning", fake)
+    assert dnp._cgroup_free_bytes() == 4 * 1024**3
+
+
+def test_no_unsloth_zoo_at_all_is_not_a_ceiling(monkeypatch, dnp):
     import builtins
 
     real_import = builtins.__import__
@@ -1000,4 +1094,77 @@ def test_missing_cgroup_readers_fall_back_to_the_limit_alone(monkeypatch, dnp):
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", _no_hf_xet)
-    assert dnp._cgroup_memory_used() is None
+    assert dnp._cgroup_free_bytes() is None
+    assert dnp._cgroup_cpu_quota() is None
+
+
+def test_env_forced_serial_is_in_process_on_a_small_split(monkeypatch, dnp):
+    """The documented recovery has to actually recover.
+
+    UNSLOTH_DATASET_NUM_PROC=0 with the config sentinel 1 arriving as an explicit
+    count used to return 1, which bypasses the small-split guard and builds a
+    Pool(1) on datasets >= 4.1. Under the threshold the guard is in-process, so
+    None is what expresses the request exactly.
+    """
+    _force_start_method(monkeypatch, dnp, "fork")
+    _force_stdlib_start_method(monkeypatch, dnp, "fork")
+    monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, "0")
+
+    small = type("t", (), {"train_dataset": _Split(100)})()
+    assert dnp.resolve_responses_only_num_proc(small, 1) is None
+    assert dnp.resolve_responses_only_num_proc(small, None) is None
+
+    # Over the threshold the guard is gone, and 1 is the least it can be given.
+    big = type("t", (), {"train_dataset": _Split(dnp.ZOO_MIN_ROWS_FOR_MULTIPROC * 2)})()
+    assert dnp.resolve_responses_only_num_proc(big, 1) == 1
+
+
+def test_a_memory_starved_explicit_count_is_in_process_on_a_small_split(monkeypatch, dnp):
+    # Same shape without the env var: the memory clamp resolves to serial, and
+    # under the threshold that has an exact encoding.
+    _force_start_method(monkeypatch, dnp, "fork")
+    _force_stdlib_start_method(monkeypatch, dnp, "fork")
+    monkeypatch.setattr(dnp, "_affordable_workers", lambda: 0)
+
+    small = type("t", (), {"train_dataset": _Split(100)})()
+    assert dnp.resolve_responses_only_num_proc(small, 16) is None
+
+
+def test_an_explicit_count_the_host_can_afford_is_untouched_by_the_row_guard(monkeypatch, dnp):
+    _force_start_method(monkeypatch, dnp, "fork")
+    _force_stdlib_start_method(monkeypatch, dnp, "fork")
+    monkeypatch.setattr(dnp, "_affordable_workers", lambda: 1000)
+
+    small = type("t", (), {"train_dataset": _Split(100)})()
+    assert dnp.resolve_responses_only_num_proc(small, 4) == 4
+
+
+def test_the_fallback_does_not_sit_behind_a_torch_import():
+    """MLX hosts have no torch, and reach this module through chat_templates.
+
+    unsloth/utils/__init__.py imports .packing, which imports torch, and
+    .attention_dispatch, which imports unsloth.models._utils on top. A fallback
+    under that package would raise on the torch-free host it exists to serve, so
+    it lives at the top level and every reference to it has to stay there.
+    """
+    assert MODULE_PATH.parent.name == "unsloth", (
+        "the fallback moved back under a package whose __init__ imports torch"
+    )
+
+    utils_init = REPO_ROOT / "unsloth" / "utils" / "__init__.py"
+    reached = {
+        node.module.split(".")[0] if isinstance(node, ast.ImportFrom) and node.level == 0
+        else (node.module or "").lstrip(".")
+        for node in ast.parse(utils_init.read_text(encoding = "utf-8")).body
+        if isinstance(node, ast.ImportFrom)
+    }
+    assert reached, "unsloth/utils/__init__.py stopped importing anything; re-check the premise"
+
+    for path in (
+        REPO_ROOT / "unsloth" / "chat_templates.py",
+        REPO_ROOT / "unsloth" / "models" / "rl.py",
+        REPO_ROOT / "unsloth" / "models" / "rl_replacements.py",
+    ):
+        source = path.read_text(encoding = "utf-8")
+        assert "unsloth.utils.dataset_num_proc" not in source, f"{path.name} reaches it via unsloth.utils"
+        assert ".utils.dataset_num_proc" not in source, f"{path.name} reaches it via unsloth.utils"

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -1363,7 +1363,9 @@ def test_the_unaided_reader_handles_cgroup_v1(monkeypatch, dnp, tmp_path):
 
     monkeypatch.setattr(dnp, "CGROUP_ROOT", str(tmp_path))
     monkeypatch.setattr(
-        dnp, "_proc_self_cgroup", lambda: ["7:memory,blkio:/slurm/job_1"],
+        dnp,
+        "_proc_self_cgroup",
+        lambda: ["7:memory,blkio:/slurm/job_1"],
     )
     assert dnp._cgroup_free_bytes() == 1024**3
 

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -992,7 +992,11 @@ def test_agreeing_modules_are_left_alone(monkeypatch, dnp):
     assert dnp.resolve_responses_only_num_proc(trainer, 1) == 1
 
 
-def _fake_cgroup_module(monkeypatch, v2_dirs = (), v1_dirs = ()):
+def _fake_cgroup_module(
+    monkeypatch,
+    v2_dirs = (),
+    v1_dirs = (),
+):
     import types
 
     def _read_first_line(path):
@@ -1147,13 +1151,14 @@ def test_the_fallback_does_not_sit_behind_a_torch_import():
     under that package would raise on the torch-free host it exists to serve, so
     it lives at the top level and every reference to it has to stay there.
     """
-    assert MODULE_PATH.parent.name == "unsloth", (
-        "the fallback moved back under a package whose __init__ imports torch"
-    )
+    assert (
+        MODULE_PATH.parent.name == "unsloth"
+    ), "the fallback moved back under a package whose __init__ imports torch"
 
     utils_init = REPO_ROOT / "unsloth" / "utils" / "__init__.py"
     reached = {
-        node.module.split(".")[0] if isinstance(node, ast.ImportFrom) and node.level == 0
+        node.module.split(".")[0]
+        if isinstance(node, ast.ImportFrom) and node.level == 0
         else (node.module or "").lstrip(".")
         for node in ast.parse(utils_init.read_text(encoding = "utf-8")).body
         if isinstance(node, ast.ImportFrom)
@@ -1166,5 +1171,7 @@ def test_the_fallback_does_not_sit_behind_a_torch_import():
         REPO_ROOT / "unsloth" / "models" / "rl_replacements.py",
     ):
         source = path.read_text(encoding = "utf-8")
-        assert "unsloth.utils.dataset_num_proc" not in source, f"{path.name} reaches it via unsloth.utils"
+        assert (
+            "unsloth.utils.dataset_num_proc" not in source
+        ), f"{path.name} reaches it via unsloth.utils"
         assert ".utils.dataset_num_proc" not in source, f"{path.name} reaches it via unsloth.utils"

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -975,7 +975,7 @@ def test_cgroup_usage_is_read_from_the_directory_that_set_the_limit(monkeypatch,
 
     inner = tmp_path / "user.slice" / "session.scope"
     inner.mkdir(parents = True)
-    (inner / "memory.current").write_text("3221225472\n")     # 3 GB, this unit
+    (inner / "memory.current").write_text("3221225472\n")  # 3 GB, this unit
     (tmp_path / "memory.current").write_text("400000000000\n")  # 400 GB, the box
 
     fake = types.ModuleType("unsloth_zoo.hf_xet_tuning")

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import ast
 import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
@@ -961,3 +962,42 @@ def test_agreeing_modules_are_left_alone(monkeypatch, dnp):
     trainer = type("t", (), {"train_dataset": _Split(dnp.ZOO_MIN_ROWS_FOR_MULTIPROC * 2)})()
     assert dnp.resolve_responses_only_num_proc(trainer, None) == dnp.AUTO_NUM_PROC_CAP
     assert dnp.resolve_responses_only_num_proc(trainer, 1) == 1
+
+
+def test_cgroup_usage_is_read_from_the_directory_that_set_the_limit(monkeypatch, dnp, tmp_path):
+    """Not from /sys/fs/cgroup/memory.current.
+
+    At the root that file is the whole machine's usage. Subtracting it from a
+    systemd unit's own MemoryMax would leave every run with nothing free and
+    silently serialise tokenization on ordinary hosts.
+    """
+    import types
+
+    inner = tmp_path / "user.slice" / "session.scope"
+    inner.mkdir(parents = True)
+    (inner / "memory.current").write_text("3221225472\n")     # 3 GB, this unit
+    (tmp_path / "memory.current").write_text("400000000000\n")  # 400 GB, the box
+
+    fake = types.ModuleType("unsloth_zoo.hf_xet_tuning")
+    fake._cgroup_v2_dirs = lambda: [inner, tmp_path]
+    fake._cgroup_v1_dirs = lambda controller: []
+    fake._read_first_line = lambda path: path.read_text() if path.is_file() else None
+    monkeypatch.setitem(sys.modules, "unsloth_zoo.hf_xet_tuning", fake)
+
+    assert dnp._cgroup_memory_used() == 3 * 1024**3
+
+
+def test_missing_cgroup_readers_fall_back_to_the_limit_alone(monkeypatch, dnp):
+    # An older unsloth_zoo has no such helpers. Subtracting nothing is never
+    # worse than not subtracting, so the limit still binds.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_hf_xet(name, *args, **kwargs):
+        if name == "unsloth_zoo.hf_xet_tuning":
+            raise ImportError("older unsloth_zoo")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_hf_xet)
+    assert dnp._cgroup_memory_used() is None

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -276,6 +276,19 @@ def test_env_override_can_force_in_process(monkeypatch, dnp, raw):
     assert dnp.get_dataset_num_proc(16) is None
 
 
+@pytest.mark.parametrize("raw", ["0", "none", "None", "false", "", "1"])
+def test_env_override_in_process_is_encoded_for_the_config_layer(monkeypatch, dnp, raw):
+    # Regression: the env override used to return before _serial(), so asking
+    # for in-process tokenization wrote None into the *config*, which
+    # unsloth_zoo.sft_prepare_dataset reads as "auto-size me" and inflates back
+    # to its own uncapped cpu_count + 4 -> 64. The escape hatch the dead-worker
+    # message recommends would have raised the worker count instead of removing
+    # it. At the config layer serial is 1, never None.
+    _force_start_method(monkeypatch, dnp, "fork")
+    monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, raw)
+    assert dnp.get_dataset_num_proc(16, serial_as_none = False) == 1
+
+
 def test_env_override_is_uncapped(monkeypatch, dnp):
     _force_start_method(monkeypatch, dnp, "fork")
     monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, "100")

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for unsloth.utils.dataset_num_proc.
+"""Tests for unsloth.utils.dataset_num_proc, the fallback copy of the policy.
+
+unsloth_zoo.dataset_num_proc owns it; this copy only runs on a zoo that predates
+the module, and ``test_the_two_copies_have_not_drifted`` holds them together.
 
 The module is stdlib-only by design and is loaded straight off disk rather than
 via ``import unsloth``, so these worker-count assertions stay meaningful on a
@@ -42,8 +45,11 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 MODULE_PATH = REPO_ROOT / "unsloth" / "utils" / "dataset_num_proc.py"
 RL_PATH = REPO_ROOT / "unsloth" / "models" / "rl.py"
 
-# The dotted path unsloth/models/rl.py bakes into every generated trainer.
-GENERATED_IMPORT_MODULE = "unsloth.utils.dataset_num_proc"
+# The dotted paths unsloth/models/rl.py bakes into every generated trainer: the
+# zoo first, so generated source does not import back into unsloth, then this
+# package as the fallback for a zoo that predates the module.
+GENERATED_IMPORT_MODULE = "unsloth_zoo.dataset_num_proc"
+GENERATED_FALLBACK_MODULE = "unsloth.utils.dataset_num_proc"
 GENERATED_IMPORT_NAME = "get_dataset_num_proc"
 
 
@@ -511,9 +517,72 @@ def test_rl_codegen_imports_the_module_that_exists():
     # otherwise surface only at trainer-construction time in production.
     snippet = _rl_num_proc_snippet()
     assert f"from {GENERATED_IMPORT_MODULE} import {GENERATED_IMPORT_NAME}" in snippet
+    assert f"from {GENERATED_FALLBACK_MODULE} import {GENERATED_IMPORT_NAME}" in snippet
+    assert snippet.index(GENERATED_IMPORT_MODULE) < snippet.index(GENERATED_FALLBACK_MODULE), (
+        "the zoo has to be tried first; the unsloth copy is only the fallback"
+    )
     assert MODULE_PATH.is_file()
     module = _load_module()
     assert callable(getattr(module, GENERATED_IMPORT_NAME))
+
+
+def test_generated_source_reaches_for_the_zoo_before_unsloth():
+    """Generated trainer source must not import back into unsloth.
+
+    unsloth/__init__.py is what generates that source, so a `from unsloth...`
+    there is an import of the package mid-flight; it also drags
+    unsloth/utils/__init__.py -> packing -> attention_dispatch -> models._utils,
+    i.e. torch and the model stack, into a module that needs none of it. Both
+    call sites in rl_replacements.py must therefore try unsloth_zoo first.
+    """
+    source = RL_PATH.with_name("rl_replacements.py").read_text(encoding = "utf-8")
+    tree = ast.parse(source)
+    injected = [
+        ast.literal_eval(node.args[2])
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and getattr(node.func, "id", "") == "_require_replace"
+        and len(node.args) >= 3
+        and isinstance(node.args[2], ast.Constant)
+    ]
+    reaching = [text for text in injected if "dataset_num_proc" in text]
+    assert len(reaching) == 2, "expected the num_proc selection and the map() wrapper"
+    for text in reaching:
+        assert f"from {GENERATED_IMPORT_MODULE} import" in text
+        assert text.index(GENERATED_IMPORT_MODULE) < text.index(GENERATED_FALLBACK_MODULE), (
+            f"this injection imports unsloth before the zoo:\n{text}"
+        )
+
+
+def test_the_two_copies_have_not_drifted():
+    """The zoo owns the policy; this package keeps a fallback copy.
+
+    Two copies can disagree, and the failure would be silent: whichever import
+    wins decides the worker count. Compare them with docstrings stripped, so
+    prose may differ per repo but no branch, constant or message may.
+    """
+    spec = importlib.util.find_spec("unsloth_zoo")
+    if spec is None or not spec.submodule_search_locations:
+        pytest.skip("unsloth_zoo not installed")
+    zoo_file = Path(list(spec.submodule_search_locations)[0]) / "dataset_num_proc.py"
+    if not zoo_file.is_file():
+        pytest.skip("this unsloth_zoo predates dataset_num_proc")
+
+    def _shape(path):
+        tree = ast.parse(path.read_text(encoding = "utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                continue
+            body = node.body
+            if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant) \
+                    and isinstance(body[0].value.value, str):
+                node.body = body[1:] or [ast.Pass()]
+        return ast.dump(ast.parse(ast.unparse(tree)))
+
+    assert _shape(MODULE_PATH) == _shape(zoo_file), (
+        "unsloth/utils/dataset_num_proc.py and unsloth_zoo/dataset_num_proc.py "
+        "have diverged; the zoo copy is the source of truth"
+    )
 
 
 def test_rl_codegen_snippet_is_valid_python_at_method_indent():

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -511,8 +511,12 @@ def _rl_serial_as_none(tree, source, trainer_file):
     """
     for node in ast.walk(tree):
         if isinstance(node, ast.Assign) and getattr(node.targets[0], "id", "") == "_serial_as_none":
+            # Parenthesised for the same reason as the sibling below: a
+            # formatter may reflow the ternary, and the segment's continuation
+            # lines are an IndentationError on their own.
             return eval(  # noqa: S307
-                ast.get_source_segment(source, node.value), {"trainer_file": trainer_file}
+                "(" + ast.get_source_segment(source, node.value) + ")",
+                {"trainer_file": trainer_file},
             )
     raise AssertionError("_serial_as_none assignment not found in unsloth/models/rl.py")
 
@@ -1629,3 +1633,48 @@ def test_the_fixture_really_neutralises_the_zoo_readers(dnp):
     assert str(module.CGROUP_ROOT).startswith("/nonexistent"), module.CGROUP_ROOT
     assert module._cgroup_v2_dirs() == []
     assert module._cgroup_v1_dirs("memory") == []
+
+
+def test_the_unaided_reader_picks_its_own_v1_line_too(monkeypatch, dnp, tmp_path):
+    """The other half of the scan: a v1 line that is not the first line.
+
+    The hybrid case above puts the memory controller first, so taking line 0
+    would still land on it. Here a pids line comes first and the memory
+    controller sits at a different path, which is what a Slurm step looks like:
+    reading line 0 walks a directory that does not exist and loses the ceiling
+    the step was given.
+    """
+    _no_hf_xet_tuning(monkeypatch)
+    v2_leaf = tmp_path / "user.slice" / "app.scope"
+    v2_leaf.mkdir(parents = True)
+    (v2_leaf / "memory.max").write_text("8589934592\n")
+    (v2_leaf / "memory.current").write_text("6442450944\n")
+    # 4GB capped, 3 spent: 1GB free, which is less than the v2 side's 2GB.
+    v1_leaf = tmp_path / "memory" / "slurm" / "job_1"
+    v1_leaf.mkdir(parents = True)
+    (v1_leaf / "memory.limit_in_bytes").write_text("4294967296\n")
+    (v1_leaf / "memory.usage_in_bytes").write_text("3221225472\n")
+
+    monkeypatch.setattr(dnp, "CGROUP_ROOT", str(tmp_path))
+    monkeypatch.setattr(
+        dnp,
+        "_proc_self_cgroup",
+        lambda: [
+            "11:pids:/user.slice/user-1000.slice/session-3.scope",
+            "10:memory:/slurm/job_1",
+            "0::/user.slice/app.scope",
+        ],
+    )
+    assert dnp._cgroup_free_bytes() == 1024**3
+
+
+def test_the_hatch_wins_on_a_small_split_too(monkeypatch, dnp):
+    """A split under the threshold is where the resolver would otherwise stand
+    down, and standing down there would silently discard the count a user set
+    by hand to get workers on a small dataset."""
+    _force_start_method(monkeypatch, dnp, "fork")
+    _force_stdlib_start_method(monkeypatch, dnp, "fork")
+    monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, "16")
+
+    small = type("t", (), {"train_dataset": _Split(100)})()
+    assert dnp.resolve_responses_only_num_proc(small, None) == 16

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -90,7 +90,14 @@ def dnp(monkeypatch):
     try:
         from unsloth_zoo import hf_xet_tuning
     except Exception:
-        hf_xet_tuning = None
+        # Importing the package can fail long after it has imported this
+        # submodule (__init__ pulls in hf_xet_tuning near the top and only
+        # raises "Please install Unsloth" at the end), and the failure removes
+        # unsloth_zoo from sys.modules while leaving unsloth_zoo.hf_xet_tuning
+        # behind. The module under test reaches it through exactly that cache
+        # entry, so treating the failure as absence would leave the real readers
+        # live on the runner's own /sys/fs/cgroup.
+        hf_xet_tuning = sys.modules.get("unsloth_zoo.hf_xet_tuning")
     if hf_xet_tuning is not None:
         for name, neutral in (
             ("CGROUP_ROOT", Path("/nonexistent-cgroup-root-for-tests")),
@@ -1570,3 +1577,21 @@ def test_the_fallback_does_not_sit_behind_a_torch_import():
             "unsloth.utils.dataset_num_proc" not in source
         ), f"{path.name} reaches it via unsloth.utils"
         assert ".utils.dataset_num_proc" not in source, f"{path.name} reaches it via unsloth.utils"
+
+
+def test_the_fixture_really_neutralises_the_zoo_readers(dnp):
+    """The fixture's patching must survive a package __init__ that raises.
+
+    unsloth_zoo/__init__ imports hf_xet_tuning near the top and can raise at the
+    end, which drops the package from sys.modules but leaves the submodule
+    cached -- and that cache entry is what the policy imports. Patching only on
+    a clean `from unsloth_zoo import hf_xet_tuning` leaves the real readers live
+    on the runner's own /sys/fs/cgroup, so every sizing assertion silently
+    becomes a test of the container's memory limit.
+    """
+    module = sys.modules.get("unsloth_zoo.hf_xet_tuning")
+    if module is None:
+        pytest.skip("unsloth_zoo.hf_xet_tuning is not reachable here")
+    assert str(module.CGROUP_ROOT).startswith("/nonexistent"), module.CGROUP_ROOT
+    assert module._cgroup_v2_dirs() == []
+    assert module._cgroup_v1_dirs("memory") == []

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -1019,9 +1019,7 @@ def test_unrelated_errors_pass_through_untouched(dnp):
     # The identity assertions above hold under `except Exception` as well, since
     # the guard re-raises the same object. This one does not: it carries the
     # dead-worker text, so a widened clause would rewrite it into a RuntimeError.
-    lookalike = ValueError(
-        "One of the subprocesses has abruptly died during map operation."
-    )
+    lookalike = ValueError("One of the subprocesses has abruptly died during map operation.")
     with pytest.raises(ValueError) as caught_other:
         with dnp.map_failure_diagnostics(4):
             raise lookalike

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -606,3 +606,58 @@ def test_successful_map_is_not_disturbed(dnp):
     with dnp.map_failure_diagnostics(4):
         result = "tokenized"
     assert result == "tokenized"
+
+
+def test_studio_num_proc_cap_has_not_drifted(dnp):
+    """Studio duplicates AUTO_NUM_PROC_CAP; the two must stay equal.
+
+    hardware.py cannot import this module -- that would pull in unsloth's whole
+    __init__ during hardware detection -- so it carries its own copy, the same
+    arrangement ZOO_MIN_ROWS_FOR_MULTIPROC uses in the other direction. Read it
+    out of the source rather than importing studio, which needs a backend
+    environment this suite does not have.
+    """
+    hardware = REPO_ROOT / "studio" / "backend" / "utils" / "hardware" / "hardware.py"
+    if not hardware.is_file():
+        pytest.skip("studio backend not present")
+
+    tree = ast.parse(hardware.read_text(encoding = "utf-8"))
+    found = [
+        node.value.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        and any(getattr(t, "id", "") == "_STUDIO_NUM_PROC_CAP" for t in node.targets)
+        and isinstance(node.value, ast.Constant)
+    ]
+    assert len(found) == 1, "expected exactly one _STUDIO_NUM_PROC_CAP assignment"
+    assert found[0] == dnp.AUTO_NUM_PROC_CAP, (
+        f"studio caps dataset workers at {found[0]} while this module caps the "
+        f"auto path at {dnp.AUTO_NUM_PROC_CAP}; they must agree"
+    )
+
+
+def test_studio_bounds_its_own_computed_worker_count(dnp):
+    """A backend heuristic must not outrank the cap.
+
+    trainer.py asks for cpu_count // 4 and safe_num_proc's auto path is
+    cpu_count // 3, so a 64-core host produced 16 workers and a 192-core one 48.
+    Those are explicit ints by the time this module sees them, so it treated
+    them as deliberate and only clamped them by free memory -- meaning a large
+    machine with RAM to spare kept all 48. Nothing about that is user intent.
+    """
+    hardware = REPO_ROOT / "studio" / "backend" / "utils" / "hardware" / "hardware.py"
+    if not hardware.is_file():
+        pytest.skip("studio backend not present")
+    source = hardware.read_text(encoding = "utf-8")
+
+    tree = ast.parse(source)
+    safe = next(
+        (n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == "safe_num_proc"),
+        None,
+    )
+    assert safe is not None, "safe_num_proc is where every studio map() count is decided"
+    body = ast.dump(safe)
+    assert "_STUDIO_NUM_PROC_CAP" in body, (
+        "safe_num_proc no longer bounds its result; studio would send "
+        "cpu_count // 3 workers straight to Dataset.map"
+    )

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -18,10 +18,9 @@ unsloth_zoo.dataset_num_proc owns it; this copy only runs on a zoo that predates
 the module, and ``test_the_two_copies_have_not_drifted`` holds them together.
 
 The module is stdlib-only by design and is loaded straight off disk rather than
-via ``import unsloth``, so these worker-count assertions stay meaningful on a
-host whose torch/unsloth_zoo pair cannot import. The ``test_rl_codegen_*`` cases
-tie it back to the import path ``unsloth/models/rl.py`` generates, so a rename
-cannot slip through.
+via ``import unsloth``, so these assertions stay meaningful on a host whose
+torch/unsloth_zoo pair cannot import. The ``test_rl_codegen_*`` cases tie it back
+to the import path ``unsloth/models/rl.py`` generates, catching a rename.
 """
 
 from __future__ import annotations
@@ -33,9 +32,8 @@ from pathlib import Path
 import pytest
 
 try:
-    # Before the dnp fixture spoofs sys.platform: multiprocess picks its concrete
-    # contexts from sys.platform at import time, so a first import under a spoofed
-    # one hands a Windows runner the POSIX fork contexts.
+    # Import before the dnp fixture spoofs sys.platform: multiprocess picks its
+    # contexts at import time, so a Windows runner would get POSIX fork contexts.
     import multiprocess  # noqa: F401
 except ImportError:
     pass
@@ -156,11 +154,8 @@ def test_config_layer_is_none_not_one_on_a_non_fork_start_method(monkeypatch, dn
     Only SFT gets its map site rewritten (rl_replacements.py); DPO, KTO, CPO,
     ORPO, Reward and PRM pass ``args.dataset_num_proc`` straight into
     ``Dataset.map``, where a ``1`` builds a ``Pool(1)`` whose spawned child
-    re-imports the user's ``__main__`` (#3211 / #3397). Those configs carried
-    ``None`` on spawn hosts before this module; they must still.
-
-    None is safe here precisely because forking is unavailable: every auto-sizer
-    reading the config vetoes on a non-fork start method too.
+    re-imports the user's ``__main__`` (#3211 / #3397). None is safe here
+    precisely because forking is unavailable, so every auto-sizer vetoes too.
     """
     _force_start_method(monkeypatch, dnp, method)
     assert dnp.get_dataset_num_proc(desired, serial_as_none = False) is None
@@ -242,9 +237,8 @@ def test_explicit_value_is_clamped_by_memory(monkeypatch, dnp, capsys):
     """The gap that caused issue #2693.
 
     Studio passes an explicit ``max(1, cpu_count // 4)``, dozens of workers at
-    ~680 MB each on a big-core machine, and the old heuristic capped only the
-    auto path -- so an explicit request sailed through however little RAM there
-    was.
+    ~680 MB each on a big-core machine, and the old heuristic bounded only the
+    auto path, so that sailed through however little RAM there was.
     """
     _force_start_method(monkeypatch, dnp, "fork")
     psutil = pytest.importorskip("psutil")
@@ -387,9 +381,8 @@ def test_start_method_probe_prefers_the_real_default_over_list_order(monkeypatch
     It copies stdlib ``get_all_start_methods()`` verbatim, darwin branch
     included, while keeping ``fork`` as its ``_default_context`` on every POSIX
     platform (``#FIXME: spawn`` in multiprocess/context.py). Since ``datasets``
-    pools come from ``multiprocess``, trusting the list would say 'spawn' while
-    ``Dataset.map`` forks -- vetoing every worker and misreporting the start
-    method in the dead-worker diagnostics.
+    pools come from ``multiprocess``, trusting the list would veto every worker
+    and misreport the start method in the dead-worker diagnostics.
     """
     import sys as _sys
 
@@ -402,12 +395,12 @@ def test_start_method_probe_prefers_the_real_default_over_list_order(monkeypatch
 def test_macos_stays_in_process_even_though_multiprocess_forks(monkeypatch, dnp, capsys):
     """The probe reports fork on macOS; policy still refuses to use it.
 
-    Two separate things on purpose. ``multiprocess`` really does fork on darwin,
-    so the diagnostics must say so, but CPython moved the macOS default to spawn
-    in 3.8 (bpo-33725) because forking there "can lead to crashes of the
-    subprocess as macOS system libraries may start threads" -- and this parent
-    holds Torch and a threaded BLAS. Fixing the probe without this guard would
-    take macOS from always-serial to AUTO_NUM_PROC_CAP forked workers.
+    ``multiprocess`` really does fork on darwin, so the diagnostics must say so,
+    but CPython moved the macOS default to spawn in 3.8 (bpo-33725) because
+    forking there "can lead to crashes of the subprocess as macOS system
+    libraries may start threads" -- and this parent holds Torch and a threaded
+    BLAS. Fixing the probe without the guard would take macOS from always-serial
+    to AUTO_NUM_PROC_CAP forked workers.
     """
     _force_start_method(monkeypatch, dnp, "fork")
     # Pin memory so the contrast is about policy, not the runner's free RAM.
@@ -529,11 +522,10 @@ def test_rl_codegen_imports_the_module_that_exists():
 def test_generated_source_reaches_for_the_zoo_before_unsloth():
     """Generated trainer source must not import back into unsloth.
 
-    unsloth/__init__.py is what generates that source, so a `from unsloth...`
-    there is an import of the package mid-flight; it also drags
-    unsloth/utils/__init__.py -> packing -> attention_dispatch -> models._utils,
-    i.e. torch and the model stack, into a module that needs none of it. Both
-    call sites in rl_replacements.py must therefore try unsloth_zoo first.
+    unsloth/__init__.py generates that source, so a `from unsloth...` there is an
+    import of the package mid-flight, and it drags unsloth/utils/__init__.py ->
+    packing -> attention_dispatch -> models._utils (torch and the model stack)
+    into a module needing none of it. Both call sites must try the zoo first.
     """
     source = RL_PATH.with_name("rl_replacements.py").read_text(encoding = "utf-8")
     tree = ast.parse(source)
@@ -686,8 +678,7 @@ def test_studio_num_proc_cap_has_not_drifted(dnp):
 
     hardware.py cannot import this module without pulling unsloth's whole
     __init__ into hardware detection, so it carries its own copy. Read it out of
-    the source rather than importing studio, which needs a backend environment
-    this suite does not have.
+    the source, since importing studio needs a backend environment this lacks.
     """
     hardware = REPO_ROOT / "studio" / "backend" / "utils" / "hardware" / "hardware.py"
     if not hardware.is_file():
@@ -713,8 +704,8 @@ def test_studio_bounds_its_own_computed_worker_count(dnp):
 
     trainer.py asks for cpu_count // 4 and safe_num_proc's auto path is
     cpu_count // 3, so a 64-core host produced 16 workers and a 192-core one 48.
-    Those arrive here as explicit ints, so they were treated as deliberate and
-    only clamped by free memory -- a roomy machine kept all 48.
+    Those arrive downstream as explicit ints, only clamped by free memory, so a
+    roomy machine kept all 48.
     """
     hardware = REPO_ROOT / "studio" / "backend" / "utils" / "hardware" / "hardware.py"
     if not hardware.is_file():
@@ -739,8 +730,7 @@ def test_the_recovery_advice_does_not_promise_more_than_it_delivers(dnp):
 
     The dead-worker message is the one place a user is told what to do next, so
     it has to be true. On fork, train_on_responses_only over the Zoo's threshold
-    gets ``1`` rather than ``None`` -- deliberately, since a bare None reads as
-    "size it for me" and would inflate to the Zoo's uncapped count -- which
+    gets ``1`` -- a bare None would read as "size it for me" -- which
     ``datasets`` >= 4.1 turns into a Pool(1). Saying "tokenize in-process"
     flatly was wrong for exactly the large-dataset runs that die.
     """
@@ -792,9 +782,9 @@ def test_probe_rejects_a_start_method_the_host_does_not_offer(monkeypatch, dnp):
     """The private default-context chain is not trustworthy on its own.
 
     On a Windows runner it answered "fork" while get_all_start_methods() was
-    ["spawn"]. Believing it read Windows as forkable, so
-    _workers_unusable_reason() returned None and workers were let through --
-    the spawn re-import loop of #3211 / #3397.
+    ["spawn"]. Believing it reads Windows as forkable, so
+    _workers_unusable_reason() returns None and workers get through -- the spawn
+    re-import loop of #3211 / #3397.
     """
     import sys as _sys
     import types

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -134,7 +134,7 @@ def test_config_layer_never_returns_none(monkeypatch, dnp):
     # memory clamp all the way down to serial
     _force_start_method(monkeypatch, dnp, "fork")
     monkeypatch.setattr(
-        psutil, "virtual_memory", lambda: type("m", (), {"available": 1 * 1024 ** 3})()
+        psutil, "virtual_memory", lambda: type("m", (), {"available": 1 * 1024**3})()
     )
     assert dnp.get_dataset_num_proc(16, serial_as_none = False) == 1
     assert dnp.get_dataset_num_proc(None, serial_as_none = False) == 1
@@ -148,7 +148,7 @@ def test_layering_config_then_map_site_is_correct(monkeypatch, dnp):
     monkeypatch.setattr(
         psutil,
         "virtual_memory",
-        lambda: type("m", (), {"available": 256 * 1024 ** 3})(),
+        lambda: type("m", (), {"available": 256 * 1024**3})(),
     )
     cfg = lambda v: dnp.get_dataset_num_proc(v, serial_as_none = False)  # noqa: E731
     site = dnp.get_dataset_num_proc
@@ -170,7 +170,7 @@ def test_low_memory_auto_path_returns_none_not_one(monkeypatch, dnp):
     monkeypatch.setattr(
         psutil,
         "virtual_memory",
-        lambda: type("m", (), {"available": 1 * 1024 ** 3})(),
+        lambda: type("m", (), {"available": 1 * 1024**3})(),
     )
     assert dnp.get_dataset_num_proc(None) is None
 
@@ -187,7 +187,7 @@ def test_auto_value_is_capped(monkeypatch, dnp):
     monkeypatch.setattr(
         psutil,
         "virtual_memory",
-        lambda: type("m", (), {"available": 512 * 1024 ** 3})(),
+        lambda: type("m", (), {"available": 512 * 1024**3})(),
     )
     assert dnp.get_dataset_num_proc(None) == dnp.AUTO_NUM_PROC_CAP
     assert dnp.AUTO_NUM_PROC_CAP < 64
@@ -200,7 +200,7 @@ def test_auto_value_clamped_by_available_memory(monkeypatch, dnp):
     monkeypatch.setattr(
         psutil,
         "virtual_memory",
-        lambda: type("m", (), {"available": 10 * 1024 ** 3})(),
+        lambda: type("m", (), {"available": 10 * 1024**3})(),
     )
     # 10 GB free, half of it budgeted, ~1 GB per worker -> 5.
     assert dnp.get_dataset_num_proc(None) == 5
@@ -219,7 +219,7 @@ def test_explicit_value_is_clamped_by_memory(monkeypatch, dnp, capsys):
     monkeypatch.setattr(
         psutil,
         "virtual_memory",
-        lambda: type("m", (), {"available": 16 * 1024 ** 3})(),
+        lambda: type("m", (), {"available": 16 * 1024**3})(),
     )
     assert dnp.get_dataset_num_proc(48) == 8
     assert "reducing dataset_num_proc 48 -> 8" in capsys.readouterr().out
@@ -233,7 +233,7 @@ def test_explicit_value_is_not_capped_by_the_auto_cap(monkeypatch, dnp):
     monkeypatch.setattr(
         psutil,
         "virtual_memory",
-        lambda: type("m", (), {"available": 512 * 1024 ** 3})(),
+        lambda: type("m", (), {"available": 512 * 1024**3})(),
     )
     assert dnp.get_dataset_num_proc(32) == 32
     assert 32 > dnp.AUTO_NUM_PROC_CAP
@@ -254,7 +254,7 @@ def test_bool_is_not_treated_as_an_int(monkeypatch, dnp):
     monkeypatch.setattr(
         psutil,
         "virtual_memory",
-        lambda: type("m", (), {"available": 64 * 1024 ** 3})(),
+        lambda: type("m", (), {"available": 64 * 1024**3})(),
     )
     assert dnp.get_dataset_num_proc(True) == 4
 
@@ -326,10 +326,7 @@ def test_start_method_probe_reports_an_explicit_setting(monkeypatch, dnp):
 def _rl_num_proc_snippet():
     tree = ast.parse(RL_PATH.read_text(encoding = "utf-8"))
     for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Assign)
-            and getattr(node.targets[0], "id", "") == "num_proc_check"
-        ):
+        if isinstance(node, ast.Assign) and getattr(node.targets[0], "id", "") == "num_proc_check":
             return ast.literal_eval(node.value)
     raise AssertionError("num_proc_check literal not found in unsloth/models/rl.py")
 
@@ -362,21 +359,14 @@ def test_zoo_sft_prepare_dataset_anchor_has_not_drifted():
             (
                 ast.literal_eval(node.args[1]),
                 next(
-                    (
-                        ast.literal_eval(k.value)
-                        for k in node.keywords
-                        if k.arg == "count"
-                    ),
+                    (ast.literal_eval(k.value) for k in node.keywords if k.arg == "count"),
                     1,
                 ),
             )
             for node in ast.walk(rr_tree)
             if isinstance(node, ast.Call)
             and getattr(node.func, "id", "") == "_require_replace"
-            and any(
-                k.arg == "where" and ast.literal_eval(k.value) == where
-                for k in node.keywords
-            )
+            and any(k.arg == "where" and ast.literal_eval(k.value) == where for k in node.keywords)
         ]
         assert len(found) == 1, f"expected exactly one _require_replace for {where!r}"
         return found[0]
@@ -409,7 +399,9 @@ def test_rl_codegen_snippet_is_valid_python_at_method_indent():
     # rl.py re-indents extra_args to 8 spaces and drops it into __init__.
     snippet = _rl_num_proc_snippet()
     body = "\n".join(" " * 8 + line for line in snippet.split("\n"))
-    source = "class C:\n    def __init__(self, dataset_num_proc = None):\n" + body + "\n        pass\n"
+    source = (
+        "class C:\n    def __init__(self, dataset_num_proc = None):\n" + body + "\n        pass\n"
+    )
     ast.parse(source)
 
 

--- a/tests/utils/test_dataset_num_proc.py
+++ b/tests/utils/test_dataset_num_proc.py
@@ -62,6 +62,31 @@ def dnp(monkeypatch):
     # so every assertion expecting a worker count is really about a forking
     # platform. Platform tests set their own value afterwards, which wins.
     monkeypatch.setattr(module.sys, "platform", "linux")
+    # Pin the memory ceiling too, at its two sources rather than at the reader,
+    # so the memory tests can still patch either and win. Every count this
+    # module returns is clamped by free RAM and by the cgroup budget, so on a
+    # memory-limited runner a test about the start method or about an explicit
+    # value silently becomes a test of the clamp instead:
+    # `get_dataset_num_proc(6) == 6` returns 4 in a small container.
+    try:
+        import psutil
+        monkeypatch.setattr(
+            psutil, "virtual_memory", lambda: type("m", (), {"available": 1024 * 1024**3})()
+        )
+    except ImportError:
+        pass
+    # Point both cgroup readers at a path that does not exist rather than
+    # stubbing the readers themselves, so the tests that are about those
+    # readers can still install a fixture tree and win.
+    monkeypatch.setattr(module, "CGROUP_ROOT", "/nonexistent-cgroup-root-for-tests")
+    try:
+        from pathlib import Path
+        from unsloth_zoo import hf_xet_tuning
+        monkeypatch.setattr(
+            hf_xet_tuning, "CGROUP_ROOT", Path("/nonexistent-cgroup-root-for-tests")
+        )
+    except Exception:
+        pass
     return module
 
 
@@ -1006,20 +1031,22 @@ def test_studio_bounds_its_own_computed_worker_count(dnp):
 
 
 def test_the_recovery_advice_does_not_promise_more_than_it_delivers(dnp):
-    """UNSLOTH_DATASET_NUM_PROC=0 is not in-process on every path.
+    """UNSLOTH_DATASET_NUM_PROC=0 is not in-process on every installation.
 
     The dead-worker message is the one place a user is told what to do next, so
     it has to be true. On fork, train_on_responses_only over the Zoo's threshold
-    gets ``1`` -- a bare None would read as "size it for me" -- which
-    ``datasets`` >= 4.1 turns into a Pool(1). Saying "tokenize in-process"
-    flatly was wrong for exactly the large-dataset runs that die.
+    gets ``1`` -- a bare None would read as "size it for me". The Zoo release
+    that ships with this reads that ``1`` as in-process, but an older one turns
+    it into a Pool(1), and generated code runs against whichever Zoo is
+    installed. Saying "tokenize in-process" flatly was wrong for exactly the
+    large-dataset runs that die.
     """
     with pytest.raises(RuntimeError) as excinfo:
         with dnp.map_failure_diagnostics(8):
             raise RuntimeError("One of the subprocesses has abruptly died during map operation.")
     message = str(excinfo.value)
     assert f"{dnp.NUM_PROC_ENV_VAR}=0" in message
-    assert "one worker" in message, "the exception to in-process has to be stated"
+    assert "single worker" in message, "the exception to in-process has to be stated"
     assert "train_on_responses_only" in message, "and which path it applies to"
     assert f"{dnp.ZOO_MIN_ROWS_FOR_MULTIPROC:,}" in message, "and above which size"
 

--- a/tests/utils/test_train_on_responses_only_num_proc.py
+++ b/tests/utils/test_train_on_responses_only_num_proc.py
@@ -76,13 +76,19 @@ SMALL = dnp.ZOO_MIN_ROWS_FOR_MULTIPROC - 1
 def _reset(monkeypatch):
     dnp.reset_warning_state()
     monkeypatch.delenv(dnp.NUM_PROC_ENV_VAR, raising = False)
-    # Pin CPUs, memory and start method so the assertions are about the wrapper,
-    # not this machine. Auto is min(max(cpu_count // 2, 2), AUTO_NUM_PROC_CAP),
-    # so reaching the cap needs >= 2 * AUTO_NUM_PROC_CAP logical CPUs.
-    psutil = pytest.importorskip("psutil")
-    monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 64)
+    # Pin CPUs, memory and both start methods so the assertions are about the
+    # wrapper, not this machine. Auto is min(max(cpus // 2, AUTO_NUM_PROC_CAP)),
+    # so reaching the cap needs >= 2 * AUTO_NUM_PROC_CAP usable CPUs -- and
+    # "usable" is the smallest of the host, the affinity mask and any cgroup
+    # quota, so patching psutil alone would still read a 4-vCPU runner as 4.
+    pytest.importorskip("psutil")
+    monkeypatch.setattr(dnp, "_usable_cpus", lambda: 64)
     monkeypatch.setattr(dnp, "_affordable_workers", lambda: 1000)
     monkeypatch.setattr(dnp, "multiprocessing_start_method", lambda: "fork")
+    # The zoo's own auto path reads stdlib multiprocessing; agreeing here keeps
+    # these cases about the row thresholds. The disagreement is covered in
+    # test_dataset_num_proc.py.
+    monkeypatch.setattr(dnp, "_zoo_auto_sizer_forks", lambda: True)
     yield
     dnp.reset_warning_state()
 
@@ -246,7 +252,18 @@ def test_env_override_wins_on_the_split_size_shortcut(monkeypatch, trainer):
 
 @pytest.fixture
 def _spawn(monkeypatch):
+    # Both modules on spawn, the ordinary Windows host. The interesting case is
+    # when they disagree, which is what _split below covers.
     monkeypatch.setattr(dnp, "multiprocessing_start_method", lambda: "spawn")
+    monkeypatch.setattr(dnp, "_zoo_auto_sizer_forks", lambda: False)
+
+
+@pytest.fixture
+def _split(monkeypatch):
+    # multiprocess on spawn, stdlib still on fork: a None here is "size it for
+    # me" to the zoo, and datasets then builds that pool on the spawn context.
+    monkeypatch.setattr(dnp, "multiprocessing_start_method", lambda: "spawn")
+    monkeypatch.setattr(dnp, "_zoo_auto_sizer_forks", lambda: True)
 
 
 @pytest.mark.parametrize(
@@ -260,9 +277,25 @@ def test_serial_is_none_not_one_on_spawn(_spawn, requested):
     ``1`` is not in-process on ``datasets`` >= 4.1, and under spawn each of those
     children re-imports the user's ``__main__`` (#3211 / #3397). ``None`` is safe
     precisely because it is *not* serial to the zoo: its auto path runs its own
-    non-fork veto and lands in-process.
+    non-fork veto and lands in-process. That holds only while the zoo's check
+    agrees, which is why _spawn pins both modules.
     """
     assert dnp.resolve_responses_only_num_proc(_Trainer(_Split(BIG)), requested) is None
+
+
+@pytest.mark.parametrize(
+    "requested",
+    [None, 32, 1],
+    ids = ["auto", "explicit-count", "explicit-one"],
+)
+def test_one_worker_when_only_multiprocess_is_on_spawn(_split, requested):
+    """The zoo's veto reads stdlib multiprocessing, so it would not fire here.
+
+    A None would be auto-sized to cpu_count + 4 and datasets would build that
+    pool on the spawn context. One worker is the smallest request the zoo honours
+    verbatim: still a Pool(1), but not dozens of them.
+    """
+    assert dnp.resolve_responses_only_num_proc(_Trainer(_Split(BIG)), requested) == 1
 
 
 def test_env_forced_serial_on_a_large_split_is_one_on_fork(monkeypatch):

--- a/tests/utils/test_train_on_responses_only_num_proc.py
+++ b/tests/utils/test_train_on_responses_only_num_proc.py
@@ -31,7 +31,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 def _load_helper():
     spec = importlib.util.spec_from_file_location(
-        "_unsloth_dnp", REPO_ROOT / "unsloth" / "utils" / "dataset_num_proc.py"
+        "_unsloth_dnp", REPO_ROOT / "unsloth" / "dataset_num_proc.py"
     )
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)

--- a/tests/utils/test_train_on_responses_only_num_proc.py
+++ b/tests/utils/test_train_on_responses_only_num_proc.py
@@ -76,8 +76,15 @@ SMALL = dnp.ZOO_MIN_ROWS_FOR_MULTIPROC - 1
 def _reset(monkeypatch):
     dnp.reset_warning_state()
     monkeypatch.delenv(dnp.NUM_PROC_ENV_VAR, raising = False)
-    # Pin memory and start method so the assertions are about the wrapper's
-    # policy, not about whatever this machine happens to have free.
+    # Pin CPUs, memory and start method so the assertions are about the
+    # wrapper's policy, not about whatever this machine happens to have.
+    # The CPU count matters: the auto count is min(max(cpu_count // 2, 2),
+    # AUTO_NUM_PROC_CAP), so every assertion below that expects the cap needs
+    # >= 2 * AUTO_NUM_PROC_CAP logical CPUs to reach it. Without this the six
+    # large-split tests pass on a big host and fail on any smaller one -- a
+    # 4-core GitHub runner yields 2, not 8.
+    psutil = pytest.importorskip("psutil")
+    monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 64)
     monkeypatch.setattr(dnp, "_affordable_workers", lambda: 1000)
     monkeypatch.setattr(dnp, "multiprocessing_start_method", lambda: "fork")
     yield
@@ -241,6 +248,49 @@ def test_env_override_wins_on_the_split_size_shortcut(monkeypatch, trainer):
     """
     monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, "3")
     assert dnp.resolve_responses_only_num_proc(trainer, None) == 3
+
+
+# ── Serial is encoded for the zoo, which reads None as "auto" ──
+
+
+@pytest.fixture
+def _spawn(monkeypatch):
+    monkeypatch.setattr(dnp, "multiprocessing_start_method", lambda: "spawn")
+
+
+@pytest.mark.parametrize(
+    "requested",
+    [None, 32, 1],
+    ids = ["auto", "explicit-count", "explicit-one"],
+)
+def test_serial_is_none_not_one_on_spawn(_spawn, requested):
+    """On spawn the zoo must be left to veto, not handed a Pool(1).
+
+    ``1`` is not in-process on ``datasets`` >= 4.1 (num_proc >= 1 takes the
+    Pool branch), and under spawn every one of those children re-imports the
+    user's ``__main__`` -- the loop in #3211 / #3397 that this policy exists to
+    prevent. ``None`` is safe here precisely because it is *not* serial to the
+    zoo: its auto path runs its own non-fork veto and lands in-process.
+    """
+    assert dnp.resolve_responses_only_num_proc(_Trainer(_Split(BIG)), requested) is None
+
+
+def test_env_forced_serial_on_a_large_split_is_one_on_fork(monkeypatch):
+    """The fork side of the same branch, where 1 is the best available value.
+
+    The zoo's row guard cannot help on a large split, and None would be read as
+    "auto" and inflated to its uncapped count, so one forked worker is the floor
+    this wrapper can express. Pinned so the spawn tests above cannot be
+    "fixed" by making every start method return None.
+    """
+    monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, "0")
+    assert dnp.resolve_responses_only_num_proc(_Trainer(_Split(BIG)), None) == 1
+
+
+def test_env_explicit_count_is_not_downgraded_on_spawn(_spawn, monkeypatch):
+    """The escape hatch is deliberate, so it keeps bypassing the veto."""
+    monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, "3")
+    assert dnp.resolve_responses_only_num_proc(_Trainer(_Split(BIG)), None) == 3
 
 
 @pytest.mark.parametrize("raw", ["0", "none", "false"])

--- a/tests/utils/test_train_on_responses_only_num_proc.py
+++ b/tests/utils/test_train_on_responses_only_num_proc.py
@@ -1,16 +1,5 @@
-# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
 
 """The worker-count bound applied to unsloth_zoo's train_on_responses_only.
 

--- a/tests/utils/test_train_on_responses_only_num_proc.py
+++ b/tests/utils/test_train_on_responses_only_num_proc.py
@@ -14,10 +14,10 @@
 
 """The worker-count bound applied to unsloth_zoo's train_on_responses_only.
 
-The zoo sizes its own dataset.map() workers with the uncapped heuristic that
-issue #2693 is about, so unsloth.chat_templates wraps it. These tests pin the
-two things that make the wrapper non-obvious: None means "auto" to the zoo (not
-"in-process"), and an explicit count switches off the zoo's small-split guard.
+The zoo sizes its own dataset.map() workers with the uncapped heuristic issue
+#2693 is about, so unsloth.chat_templates wraps it. These tests pin the two
+things that make the wrapper non-obvious: None means "auto" to the zoo, not
+"in-process", and an explicit count switches off its small-split guard.
 """
 
 import importlib.util
@@ -76,13 +76,10 @@ SMALL = dnp.ZOO_MIN_ROWS_FOR_MULTIPROC - 1
 def _reset(monkeypatch):
     dnp.reset_warning_state()
     monkeypatch.delenv(dnp.NUM_PROC_ENV_VAR, raising = False)
-    # Pin CPUs, memory and start method so the assertions are about the
-    # wrapper's policy, not about whatever this machine happens to have.
-    # The CPU count matters: the auto count is min(max(cpu_count // 2, 2),
-    # AUTO_NUM_PROC_CAP), so every assertion below that expects the cap needs
-    # >= 2 * AUTO_NUM_PROC_CAP logical CPUs to reach it. Without this the six
-    # large-split tests pass on a big host and fail on any smaller one -- a
-    # 4-core GitHub runner yields 2, not 8.
+    # Pin CPUs, memory and start method so the assertions are about the wrapper's
+    # policy, not this machine. The CPU count matters: auto is
+    # min(max(cpu_count // 2, 2), AUTO_NUM_PROC_CAP), so reaching the cap needs
+    # >= 2 * AUTO_NUM_PROC_CAP logical CPUs -- a 4-core runner yields 2, not 8.
     psutil = pytest.importorskip("psutil")
     monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 64)
     monkeypatch.setattr(dnp, "_affordable_workers", lambda: 1000)
@@ -98,11 +95,10 @@ def _zoo_source():
     """Read unsloth_zoo's dataset_utils source without importing it.
 
     Importing the package pulls torch, which is not always loadable in a test
-    environment, and these two checks only need the text.
+    environment, and these two checks only need the text. find_spec on the
+    submodule would import unsloth_zoo, so locate the top level package (which
+    is not executed) and read the file off disk.
     """
-    # find_spec on the submodule would import the unsloth_zoo package, which
-    # patches torch on import and fails on some environments. Locate the top
-    # level package (which is not executed) and read the file off disk.
     spec = importlib.util.find_spec("unsloth_zoo")
     locations = list(getattr(spec, "submodule_search_locations", None) or [])
     if spec is None or not locations:
@@ -116,8 +112,8 @@ def _zoo_source():
 def test_zoo_threshold_constant_has_not_drifted():
     """ZOO_MIN_ROWS_FOR_MULTIPROC mirrors a local inside the zoo function.
 
-    It cannot be imported, so if the zoo ever changes it this canary is the only
-    thing standing between us and silently removing its small-split guard.
+    It cannot be imported, so this canary is the only thing between a zoo change
+    and silently removing its small-split guard.
     """
     match = re.search(r"_MIN_ROWS_FOR_MULTIPROC\s*=\s*([0-9_]+)", _zoo_source())
     assert match is not None, (
@@ -195,13 +191,11 @@ def test_auto_unsized_split_passes_none_through():
 def test_an_unsized_split_does_not_hide_a_large_sized_one(trainer):
     """Regression: one unsized split disabled the bound for every other split.
 
-    An unsized split used to abandon the whole measurement, so this returned
-    None -- and the zoo reads None as "auto", not as "in-process". It then sized
-    the *sized* split with its own uncapped min(max(cpu_count + 4, 2), 64): on a
-    192-core host that is 64 forked workers, the exact failure this wrapper
-    exists to bound. The unsized split itself can never use workers (the zoo's
-    IterableDataset branch passes no num_proc), so it must be skipped, not
-    treated as a veto.
+    An unsized split used to abandon the measurement and return None, which the
+    zoo reads as "auto", not "in-process" -- so it sized the *sized* split with
+    its own uncapped min(max(cpu_count + 4, 2), 64), 64 forked workers on a
+    192-core host. The unsized split can never use workers anyway (the zoo's
+    IterableDataset branch passes no num_proc), so skip it, do not veto on it.
     """
     assert dnp.resolve_responses_only_num_proc(trainer, None) == dnp.AUTO_NUM_PROC_CAP
 
@@ -243,8 +237,8 @@ def test_env_override_wins_on_the_split_size_shortcut(monkeypatch, trainer):
     """The escape hatch must win everywhere, including the early return.
 
     The shortcut for splits the zoo would not have parallelized used to return
-    before UNSLOTH_DATASET_NUM_PROC was read, so an explicit count set by a user
-    who had just been told to set it was dropped.
+    before UNSLOTH_DATASET_NUM_PROC was read, dropping a count set by a user who
+    had just been told to set it.
     """
     monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, "3")
     assert dnp.resolve_responses_only_num_proc(trainer, None) == 3
@@ -266,11 +260,10 @@ def _spawn(monkeypatch):
 def test_serial_is_none_not_one_on_spawn(_spawn, requested):
     """On spawn the zoo must be left to veto, not handed a Pool(1).
 
-    ``1`` is not in-process on ``datasets`` >= 4.1 (num_proc >= 1 takes the
-    Pool branch), and under spawn every one of those children re-imports the
-    user's ``__main__`` -- the loop in #3211 / #3397 that this policy exists to
-    prevent. ``None`` is safe here precisely because it is *not* serial to the
-    zoo: its auto path runs its own non-fork veto and lands in-process.
+    ``1`` is not in-process on ``datasets`` >= 4.1, and under spawn each of those
+    children re-imports the user's ``__main__`` (#3211 / #3397). ``None`` is safe
+    precisely because it is *not* serial to the zoo: its auto path runs its own
+    non-fork veto and lands in-process.
     """
     assert dnp.resolve_responses_only_num_proc(_Trainer(_Split(BIG)), requested) is None
 
@@ -278,10 +271,10 @@ def test_serial_is_none_not_one_on_spawn(_spawn, requested):
 def test_env_forced_serial_on_a_large_split_is_one_on_fork(monkeypatch):
     """The fork side of the same branch, where 1 is the best available value.
 
-    The zoo's row guard cannot help on a large split, and None would be read as
-    "auto" and inflated to its uncapped count, so one forked worker is the floor
-    this wrapper can express. Pinned so the spawn tests above cannot be
-    "fixed" by making every start method return None.
+    The zoo's row guard cannot help on a large split and None would be read as
+    "auto" and inflated, so one forked worker is the floor this wrapper can
+    express. Pinned so the spawn tests above cannot be "fixed" by making every
+    start method return None.
     """
     monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, "0")
     assert dnp.resolve_responses_only_num_proc(_Trainer(_Split(BIG)), None) == 1
@@ -297,10 +290,9 @@ def test_env_explicit_count_is_not_downgraded_on_spawn(_spawn, monkeypatch):
 def test_env_forced_in_process_leaves_the_zoo_guard_in_charge(monkeypatch, raw):
     """UNSLOTH_DATASET_NUM_PROC=0 must not turn into a Pool(1) on a small split.
 
-    The zoo's own guard already yields None for a split under its threshold, and
-    None -- not the 1 this function can express -- is the only value datasets
-    runs in-process on every release. So the hatch is honoured by leaving the
-    value alone here, not by substituting a count.
+    The zoo's guard already yields None under its threshold, and None -- not the
+    1 this function can express -- is the only value datasets runs in-process on
+    every release, so honour the hatch by leaving the value alone.
     """
     monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, raw)
     assert dnp.resolve_responses_only_num_proc(_Trainer(_Split(SMALL)), None) is None

--- a/tests/utils/test_train_on_responses_only_num_proc.py
+++ b/tests/utils/test_train_on_responses_only_num_proc.py
@@ -1,0 +1,206 @@
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""The worker-count bound applied to unsloth_zoo's train_on_responses_only.
+
+The zoo sizes its own dataset.map() workers with the uncapped heuristic that
+issue #2693 is about, so unsloth.chat_templates wraps it. These tests pin the
+two things that make the wrapper non-obvious: None means "auto" to the zoo (not
+"in-process"), and an explicit count switches off the zoo's small-split guard.
+"""
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_helper():
+    spec = importlib.util.spec_from_file_location(
+        "_unsloth_dnp", REPO_ROOT / "unsloth" / "utils" / "dataset_num_proc.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+dnp = _load_helper()
+
+
+class _Split:
+    """Minimal sized stand-in for a datasets.Dataset."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def __len__(self):
+        return self._rows
+
+
+class _Unsized:
+    """Stands in for an IterableDataset, whose length the zoo cannot read."""
+
+    def __len__(self):
+        raise TypeError("unsized")
+
+
+class _Trainer:
+    def __init__(
+        self,
+        train_dataset = None,
+        eval_dataset = None,
+    ):
+        self.train_dataset = train_dataset
+        self.eval_dataset = eval_dataset
+
+
+BIG = dnp.ZOO_MIN_ROWS_FOR_MULTIPROC
+SMALL = dnp.ZOO_MIN_ROWS_FOR_MULTIPROC - 1
+
+
+@pytest.fixture(autouse = True)
+def _reset(monkeypatch):
+    dnp.reset_warning_state()
+    monkeypatch.delenv(dnp.NUM_PROC_ENV_VAR, raising = False)
+    # Pin memory and start method so the assertions are about the wrapper's
+    # policy, not about whatever this machine happens to have free.
+    monkeypatch.setattr(dnp, "_affordable_workers", lambda: 1000)
+    monkeypatch.setattr(dnp, "multiprocessing_start_method", lambda: "fork")
+    yield
+    dnp.reset_warning_state()
+
+
+# ── The zoo's threshold, duplicated in ZOO_MIN_ROWS_FOR_MULTIPROC ──
+
+
+def _zoo_source():
+    """Read unsloth_zoo's dataset_utils source without importing it.
+
+    Importing the package pulls torch, which is not always loadable in a test
+    environment, and these two checks only need the text.
+    """
+    # find_spec on the submodule would import the unsloth_zoo package, which
+    # patches torch on import and fails on some environments. Locate the top
+    # level package (which is not executed) and read the file off disk.
+    spec = importlib.util.find_spec("unsloth_zoo")
+    locations = list(getattr(spec, "submodule_search_locations", None) or [])
+    if spec is None or not locations:
+        pytest.skip("unsloth_zoo is not installed")
+    source = Path(locations[0]) / "dataset_utils.py"
+    if not source.is_file():
+        pytest.skip("unsloth_zoo.dataset_utils not found on disk")
+    return source.read_text()
+
+
+def test_zoo_threshold_constant_has_not_drifted():
+    """ZOO_MIN_ROWS_FOR_MULTIPROC mirrors a local inside the zoo function.
+
+    It cannot be imported, so if the zoo ever changes it this canary is the only
+    thing standing between us and silently removing its small-split guard.
+    """
+    match = re.search(r"_MIN_ROWS_FOR_MULTIPROC\s*=\s*([0-9_]+)", _zoo_source())
+    assert match is not None, (
+        "unsloth_zoo no longer defines _MIN_ROWS_FOR_MULTIPROC; "
+        "resolve_responses_only_num_proc assumes it exists to decide when "
+        "substituting a worker count is safe"
+    )
+    assert int(match.group(1).replace("_", "")) == dnp.ZOO_MIN_ROWS_FOR_MULTIPROC
+
+
+def test_zoo_still_treats_none_as_auto_not_serial():
+    """The reason None cannot be forwarded to the zoo as an in-process request."""
+    assert "_num_proc_was_auto = num_proc is None or type(num_proc) is not int" in _zoo_source()
+
+
+# ── Explicit counts ──
+
+
+def test_explicit_count_is_bounded(monkeypatch):
+    monkeypatch.setattr(dnp, "_affordable_workers", lambda: 4)
+    assert dnp.resolve_responses_only_num_proc(_Trainer(_Split(BIG)), 64) == 4
+
+
+def test_explicit_count_survives_when_memory_allows():
+    assert dnp.resolve_responses_only_num_proc(_Trainer(_Split(BIG)), 6) == 6
+
+
+def test_explicit_one_stays_one_and_never_becomes_none():
+    """None would read as 'auto' to the zoo and inflate to the auto count."""
+    assert dnp.resolve_responses_only_num_proc(_Trainer(_Split(BIG)), 1) == 1
+
+
+def test_explicit_count_serialised_by_memory_becomes_one_not_none(monkeypatch):
+    monkeypatch.setattr(dnp, "_affordable_workers", lambda: 0)
+    assert dnp.resolve_responses_only_num_proc(_Trainer(_Split(BIG)), 32) == 1
+
+
+def test_explicit_count_ignores_split_size():
+    """The zoo already skips its guard for explicit counts, so we take nothing."""
+    assert dnp.resolve_responses_only_num_proc(_Trainer(_Split(SMALL)), 6) == 6
+
+
+# ── Auto counts: the zoo's small-split guard must survive ──
+
+
+def test_auto_small_split_passes_none_through():
+    assert dnp.resolve_responses_only_num_proc(_Trainer(_Split(SMALL)), None) is None
+
+
+def test_auto_large_split_gets_the_bounded_count():
+    resolved = dnp.resolve_responses_only_num_proc(_Trainer(_Split(BIG)), None)
+    assert resolved == dnp.AUTO_NUM_PROC_CAP
+
+
+def test_auto_uses_the_largest_split_not_the_smallest():
+    """A big train split must still be bounded when eval is small."""
+    trainer = _Trainer(train_dataset = _Split(BIG), eval_dataset = _Split(10))
+    assert dnp.resolve_responses_only_num_proc(trainer, None) == dnp.AUTO_NUM_PROC_CAP
+
+
+def test_auto_unsized_split_passes_none_through():
+    trainer = _Trainer(train_dataset = _Unsized())
+    assert dnp.resolve_responses_only_num_proc(trainer, None) is None
+
+
+def test_auto_unsized_eval_split_is_conservative():
+    trainer = _Trainer(train_dataset = _Split(BIG), eval_dataset = _Unsized())
+    assert dnp.resolve_responses_only_num_proc(trainer, None) is None
+
+
+def test_auto_dict_eval_dataset_is_unpacked():
+    trainer = _Trainer(train_dataset = _Split(10), eval_dataset = {"a": _Split(BIG)})
+    assert dnp.resolve_responses_only_num_proc(trainer, None) == dnp.AUTO_NUM_PROC_CAP
+
+
+def test_no_trainer_passes_none_through():
+    assert dnp.resolve_responses_only_num_proc(None, None) is None
+
+
+def test_trainer_without_datasets_passes_none_through():
+    assert dnp.resolve_responses_only_num_proc(_Trainer(), None) is None
+
+
+def test_bool_is_treated_as_auto_like_the_zoo_does():
+    """type(True) is not int by the zoo's test, so it counts as auto."""
+    assert dnp.resolve_responses_only_num_proc(_Trainer(_Split(SMALL)), True) is True
+
+
+def test_env_override_still_wins_for_explicit_values(monkeypatch):
+    monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, "16")
+    monkeypatch.setattr(dnp, "_affordable_workers", lambda: 2)
+    assert dnp.resolve_responses_only_num_proc(_Trainer(_Split(BIG)), 4) == 16

--- a/tests/utils/test_train_on_responses_only_num_proc.py
+++ b/tests/utils/test_train_on_responses_only_num_proc.py
@@ -76,10 +76,9 @@ SMALL = dnp.ZOO_MIN_ROWS_FOR_MULTIPROC - 1
 def _reset(monkeypatch):
     dnp.reset_warning_state()
     monkeypatch.delenv(dnp.NUM_PROC_ENV_VAR, raising = False)
-    # Pin CPUs, memory and start method so the assertions are about the wrapper's
-    # policy, not this machine. The CPU count matters: auto is
-    # min(max(cpu_count // 2, 2), AUTO_NUM_PROC_CAP), so reaching the cap needs
-    # >= 2 * AUTO_NUM_PROC_CAP logical CPUs -- a 4-core runner yields 2, not 8.
+    # Pin CPUs, memory and start method so the assertions are about the wrapper,
+    # not this machine. Auto is min(max(cpu_count // 2, 2), AUTO_NUM_PROC_CAP),
+    # so reaching the cap needs >= 2 * AUTO_NUM_PROC_CAP logical CPUs.
     psutil = pytest.importorskip("psutil")
     monkeypatch.setattr(psutil, "cpu_count", lambda *a, **k: 64)
     monkeypatch.setattr(dnp, "_affordable_workers", lambda: 1000)
@@ -94,10 +93,9 @@ def _reset(monkeypatch):
 def _zoo_source():
     """Read unsloth_zoo's dataset_utils source without importing it.
 
-    Importing the package pulls torch, which is not always loadable in a test
-    environment, and these two checks only need the text. find_spec on the
-    submodule would import unsloth_zoo, so locate the top level package (which
-    is not executed) and read the file off disk.
+    Importing the package pulls torch, which is not always loadable here, and
+    these two checks only need the text. find_spec on the submodule would import
+    unsloth_zoo, so locate the top level package and read the file off disk.
     """
     spec = importlib.util.find_spec("unsloth_zoo")
     locations = list(getattr(spec, "submodule_search_locations", None) or [])
@@ -192,10 +190,9 @@ def test_an_unsized_split_does_not_hide_a_large_sized_one(trainer):
     """Regression: one unsized split disabled the bound for every other split.
 
     An unsized split used to abandon the measurement and return None, which the
-    zoo reads as "auto", not "in-process" -- so it sized the *sized* split with
-    its own uncapped min(max(cpu_count + 4, 2), 64), 64 forked workers on a
-    192-core host. The unsized split can never use workers anyway (the zoo's
-    IterableDataset branch passes no num_proc), so skip it, do not veto on it.
+    zoo reads as "auto", not "in-process", so it sized the *sized* split with its
+    own uncapped min(max(cpu_count + 4, 2), 64). The unsized one can never use
+    workers anyway (the zoo's IterableDataset branch passes no num_proc).
     """
     assert dnp.resolve_responses_only_num_proc(trainer, None) == dnp.AUTO_NUM_PROC_CAP
 

--- a/tests/utils/test_train_on_responses_only_num_proc.py
+++ b/tests/utils/test_train_on_responses_only_num_proc.py
@@ -1,17 +1,16 @@
-# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """The worker-count bound applied to unsloth_zoo's train_on_responses_only.
 
@@ -177,9 +176,27 @@ def test_auto_unsized_split_passes_none_through():
     assert dnp.resolve_responses_only_num_proc(trainer, None) is None
 
 
-def test_auto_unsized_eval_split_is_conservative():
-    trainer = _Trainer(train_dataset = _Split(BIG), eval_dataset = _Unsized())
-    assert dnp.resolve_responses_only_num_proc(trainer, None) is None
+@pytest.mark.parametrize(
+    "trainer",
+    [
+        _Trainer(train_dataset = _Split(BIG), eval_dataset = _Unsized()),
+        _Trainer(train_dataset = _Unsized(), eval_dataset = _Split(BIG)),
+        _Trainer(train_dataset = _Split(BIG), eval_dataset = {"a": _Unsized()}),
+    ],
+    ids = ["unsized-eval", "unsized-train", "unsized-eval-dict"],
+)
+def test_an_unsized_split_does_not_hide_a_large_sized_one(trainer):
+    """Regression: one unsized split disabled the bound for every other split.
+
+    An unsized split used to abandon the whole measurement, so this returned
+    None -- and the zoo reads None as "auto", not as "in-process". It then sized
+    the *sized* split with its own uncapped min(max(cpu_count + 4, 2), 64): on a
+    192-core host that is 64 forked workers, the exact failure this wrapper
+    exists to bound. The unsized split itself can never use workers (the zoo's
+    IterableDataset branch passes no num_proc), so it must be skipped, not
+    treated as a veto.
+    """
+    assert dnp.resolve_responses_only_num_proc(trainer, None) == dnp.AUTO_NUM_PROC_CAP
 
 
 def test_auto_dict_eval_dataset_is_unpacked():
@@ -204,3 +221,36 @@ def test_env_override_still_wins_for_explicit_values(monkeypatch):
     monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, "16")
     monkeypatch.setattr(dnp, "_affordable_workers", lambda: 2)
     assert dnp.resolve_responses_only_num_proc(_Trainer(_Split(BIG)), 4) == 16
+
+
+@pytest.mark.parametrize(
+    "trainer",
+    [
+        _Trainer(train_dataset = _Split(SMALL)),
+        _Trainer(train_dataset = _Unsized()),
+        _Trainer(),
+    ],
+    ids = ["small-split", "unsized-split", "no-splits"],
+)
+def test_env_override_wins_on_the_split_size_shortcut(monkeypatch, trainer):
+    """The escape hatch must win everywhere, including the early return.
+
+    The shortcut for splits the zoo would not have parallelized used to return
+    before UNSLOTH_DATASET_NUM_PROC was read, so an explicit count set by a user
+    who had just been told to set it was dropped.
+    """
+    monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, "3")
+    assert dnp.resolve_responses_only_num_proc(trainer, None) == 3
+
+
+@pytest.mark.parametrize("raw", ["0", "none", "false"])
+def test_env_forced_in_process_leaves_the_zoo_guard_in_charge(monkeypatch, raw):
+    """UNSLOTH_DATASET_NUM_PROC=0 must not turn into a Pool(1) on a small split.
+
+    The zoo's own guard already yields None for a split under its threshold, and
+    None -- not the 1 this function can express -- is the only value datasets
+    runs in-process on every release. So the hatch is honoured by leaving the
+    value alone here, not by substituting a count.
+    """
+    monkeypatch.setenv(dnp.NUM_PROC_ENV_VAR, raw)
+    assert dnp.resolve_responses_only_num_proc(_Trainer(_Split(SMALL)), None) is None

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -1314,7 +1314,16 @@ if _IS_MLX:
 
     def train_on_responses_only(*args, **kwargs):
         """Mask non-response tokens through the shared zoo dataset helper."""
-        from unsloth_zoo.dataset_utils import train_on_responses_only as _train_on_responses_only
+        # Prefer the chat_templates export, which bounds the zoo's dataset.map()
+        # worker count (issue #2693). It is None on a torch-free host, where
+        # dataset_utils cannot import, so fall back to the raw zoo helper and let
+        # it raise its own ImportError rather than "NoneType is not callable".
+        from .chat_templates import train_on_responses_only as _train_on_responses_only
+
+        if _train_on_responses_only is None:
+            from unsloth_zoo.dataset_utils import (
+                train_on_responses_only as _train_on_responses_only,
+            )
         return _train_on_responses_only(*args, **kwargs)
 
     def _safe_mlx_trl_star_exports(_trl):

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -1315,9 +1315,8 @@ if _IS_MLX:
     def train_on_responses_only(*args, **kwargs):
         """Mask non-response tokens through the shared zoo dataset helper."""
         # Prefer the chat_templates export, which bounds the zoo's dataset.map()
-        # worker count (issue #2693). It is None on a torch-free host, so fall
-        # back to the raw zoo helper and let it raise its own ImportError rather
-        # than "NoneType is not callable".
+        # worker count (issue #2693). It is None on a torch-free host; fall back
+        # so the zoo raises its own ImportError, not "NoneType is not callable".
         from .chat_templates import train_on_responses_only as _train_on_responses_only
 
         if _train_on_responses_only is None:

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -1315,9 +1315,9 @@ if _IS_MLX:
     def train_on_responses_only(*args, **kwargs):
         """Mask non-response tokens through the shared zoo dataset helper."""
         # Prefer the chat_templates export, which bounds the zoo's dataset.map()
-        # worker count (issue #2693). It is None on a torch-free host, where
-        # dataset_utils cannot import, so fall back to the raw zoo helper and let
-        # it raise its own ImportError rather than "NoneType is not callable".
+        # worker count (issue #2693). It is None on a torch-free host, so fall
+        # back to the raw zoo helper and let it raise its own ImportError rather
+        # than "NoneType is not callable".
         from .chat_templates import train_on_responses_only as _train_on_responses_only
 
         if _train_on_responses_only is None:

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -58,23 +58,21 @@ else:
     @_functools.wraps(_zoo_train_on_responses_only)
     def train_on_responses_only(*args, **kwargs):
         # The zoo still sizes its own dataset.map() workers with the uncapped
-        # min(max(cpu_count + 4, 2), 64) heuristic, so on a large host this call
-        # forks dozens of workers that each get a dill-pickled tokenizer copy
-        # (issue #2693). It is a separate package, so bound the count on the way
-        # in. resolve_responses_only_num_proc explains how "in-process" has to
-        # be encoded for the zoo (it reads None as "auto") and why the row count
-        # matters.
+        # min(max(cpu_count + 4, 2), 64) heuristic, forking dozens of workers
+        # that each get a dill-pickled tokenizer copy (issue #2693). It is a
+        # separate package, so bound the count on the way in;
+        # resolve_responses_only_num_proc explains how "in-process" has to be
+        # encoded for the zoo, which reads None as "auto".
         from .utils.dataset_num_proc import resolve_responses_only_num_proc
 
         try:
             bound = _ZOO_RESPONSES_ONLY_SIGNATURE.bind_partial(*args, **kwargs)
         except TypeError:
-            # Signature drift, or a genuinely bad call. Either way let the zoo
-            # raise its own error rather than masking it with ours.
+            # Signature drift, or a bad call. Let the zoo raise its own error.
             return _zoo_train_on_responses_only(*args, **kwargs)
 
-        # return_function returns the masking closure before the zoo ever reads
-        # num_proc, so there is nothing to bound on that path.
+        # return_function hands back the masking closure before the zoo reads
+        # num_proc, so there is nothing to bound.
         if bound.arguments.get("return_function", False):
             return _zoo_train_on_responses_only(*args, **kwargs)
 

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -61,8 +61,9 @@ else:
         # min(max(cpu_count + 4, 2), 64) heuristic, so on a large host this call
         # forks dozens of workers that each get a dill-pickled tokenizer copy
         # (issue #2693). It is a separate package, so bound the count on the way
-        # in. resolve_responses_only_num_proc explains why None cannot be used
-        # to mean "in-process" here and why the row count matters.
+        # in. resolve_responses_only_num_proc explains how "in-process" has to
+        # be encoded for the zoo (it reads None as "auto") and why the row count
+        # matters.
         from .utils.dataset_num_proc import resolve_responses_only_num_proc
 
         try:

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -57,14 +57,11 @@ else:
 
     @_functools.wraps(_zoo_train_on_responses_only)
     def train_on_responses_only(*args, **kwargs):
-        # The zoo still sizes its own dataset.map() workers with the uncapped
-        # min(max(cpu_count + 4, 2), 64) heuristic, forking dozens of workers
-        # that each get a dill-pickled tokenizer copy (issue #2693). It is a
-        # separate package, so bound the count on the way in;
-        # resolve_responses_only_num_proc explains how "in-process" has to be
-        # encoded for the zoo, which reads None as "auto". It lives in the zoo,
-        # beside the helper it bounds; the local copy is the fallback for a zoo
-        # predating it.
+        # The zoo still auto-sizes its dataset.map() workers with the uncapped
+        # min(max(cpu_count + 4, 2), 64) heuristic (issue #2693) and is a
+        # separate package, so bound the count on the way in. See
+        # resolve_responses_only_num_proc; the local copy is only the fallback
+        # for a zoo predating it.
         try:
             from unsloth_zoo.dataset_num_proc import resolve_responses_only_num_proc
         except ImportError:
@@ -76,8 +73,7 @@ else:
             # Signature drift, or a bad call. Let the zoo raise its own error.
             return _zoo_train_on_responses_only(*args, **kwargs)
 
-        # return_function hands back the masking closure before the zoo reads
-        # num_proc, so there is nothing to bound.
+        # The zoo returns the masking closure before reading num_proc.
         if bound.arguments.get("return_function", False):
             return _zoo_train_on_responses_only(*args, **kwargs)
 

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -62,8 +62,13 @@ else:
         # that each get a dill-pickled tokenizer copy (issue #2693). It is a
         # separate package, so bound the count on the way in;
         # resolve_responses_only_num_proc explains how "in-process" has to be
-        # encoded for the zoo, which reads None as "auto".
-        from .utils.dataset_num_proc import resolve_responses_only_num_proc
+        # encoded for the zoo, which reads None as "auto". It lives in the zoo,
+        # beside the helper it bounds; the local copy is the fallback for a zoo
+        # predating it.
+        try:
+            from unsloth_zoo.dataset_num_proc import resolve_responses_only_num_proc
+        except ImportError:
+            from .utils.dataset_num_proc import resolve_responses_only_num_proc
 
         try:
             bound = _ZOO_RESPONSES_ONLY_SIGNATURE.bind_partial(*args, **kwargs)

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -39,13 +39,52 @@ import re
 from .ollama_template_mappers import OLLAMA_TEMPLATES
 try:
     from unsloth_zoo.dataset_utils import (
-        train_on_responses_only,
+        train_on_responses_only as _zoo_train_on_responses_only,
         standardize_data_formats,
     )
 except ImportError:
     # dataset_utils pulls torch; keep chat_templates importable on torch-free
     # (MLX) hosts, which expose these via the backend-specific wrappers instead.
-    train_on_responses_only = standardize_data_formats = None
+    _zoo_train_on_responses_only = standardize_data_formats = None
+
+if _zoo_train_on_responses_only is None:
+    train_on_responses_only = None
+else:
+    import functools as _functools
+    import inspect as _inspect
+
+    _ZOO_RESPONSES_ONLY_SIGNATURE = _inspect.signature(_zoo_train_on_responses_only)
+
+    @_functools.wraps(_zoo_train_on_responses_only)
+    def train_on_responses_only(*args, **kwargs):
+        # The zoo still sizes its own dataset.map() workers with the uncapped
+        # min(max(cpu_count + 4, 2), 64) heuristic, so on a large host this call
+        # forks dozens of workers that each get a dill-pickled tokenizer copy
+        # (issue #2693). It is a separate package, so bound the count on the way
+        # in. resolve_responses_only_num_proc explains why None cannot be used
+        # to mean "in-process" here and why the row count matters.
+        from .utils.dataset_num_proc import resolve_responses_only_num_proc
+
+        try:
+            bound = _ZOO_RESPONSES_ONLY_SIGNATURE.bind_partial(*args, **kwargs)
+        except TypeError:
+            # Signature drift, or a genuinely bad call. Either way let the zoo
+            # raise its own error rather than masking it with ours.
+            return _zoo_train_on_responses_only(*args, **kwargs)
+
+        # return_function returns the masking closure before the zoo ever reads
+        # num_proc, so there is nothing to bound on that path.
+        if bound.arguments.get("return_function", False):
+            return _zoo_train_on_responses_only(*args, **kwargs)
+
+        arguments = dict(bound.arguments)
+        arguments["num_proc"] = resolve_responses_only_num_proc(
+            arguments.get("trainer"),
+            arguments.get("num_proc"),
+        )
+        trainer = arguments.pop("trainer", None)
+        return _zoo_train_on_responses_only(trainer, **arguments)
+
 standardize_sharegpt = standardize_data_formats
 CHAT_TEMPLATES = {}
 DEFAULT_SYSTEM_MESSAGE = {}

--- a/unsloth/chat_templates.py
+++ b/unsloth/chat_templates.py
@@ -61,11 +61,12 @@ else:
         # min(max(cpu_count + 4, 2), 64) heuristic (issue #2693) and is a
         # separate package, so bound the count on the way in. See
         # resolve_responses_only_num_proc; the local copy is only the fallback
-        # for a zoo predating it.
+        # for a zoo predating it. Top level, not under unsloth.utils, whose
+        # __init__ imports torch: this path has to stay MLX-safe.
         try:
             from unsloth_zoo.dataset_num_proc import resolve_responses_only_num_proc
         except ImportError:
-            from .utils.dataset_num_proc import resolve_responses_only_num_proc
+            from .dataset_num_proc import resolve_responses_only_num_proc
 
         try:
             bound = _ZOO_RESPONSES_ONLY_SIGNATURE.bind_partial(*args, **kwargs)

--- a/unsloth/dataset_num_proc.py
+++ b/unsloth/dataset_num_proc.py
@@ -187,7 +187,10 @@ CGROUP_ROOT = "/sys/fs/cgroup"
 
 def _cgroup_first_line(path: str) -> Optional[str]:
     try:
-        with open(path, "r") as f:
+        # encoding named explicitly: these are ASCII kernel files, but a
+        # locale-dependent read crashes or produces mojibake on a Windows
+        # console codepage, and CI polices every read/write for it.
+        with open(path, "r", encoding = "utf-8") as f:
             return f.readline().strip()
     except OSError:
         return None
@@ -228,7 +231,7 @@ def _cgroup_dirs(root: str, rel: Optional[str]) -> list:
 
 def _proc_self_cgroup() -> list:
     try:
-        with open("/proc/self/cgroup", "r") as f:
+        with open("/proc/self/cgroup", "r", encoding = "utf-8") as f:
             return [line.strip() for line in f if line.strip()]
     except OSError:
         return []  # not Linux, or procfs is hidden

--- a/unsloth/dataset_num_proc.py
+++ b/unsloth/dataset_num_proc.py
@@ -584,8 +584,9 @@ def map_failure_diagnostics(num_proc: Optional[int]) -> "Iterator[None]":
             f"model. The most common cause is the out-of-memory killer.\n"
             f"  Retry with {NUM_PROC_ENV_VAR}=0 for the fewest workers this path "
             f"can use, or {NUM_PROC_ENV_VAR}=<n> to choose a count. That is "
-            f"in-process everywhere except train_on_responses_only on a split "
-            f"over {ZOO_MIN_ROWS_FOR_MULTIPROC:,} rows, where it is one worker: "
+            f"in-process everywhere, though on an unsloth_zoo older than the one "
+            f"that reads 1 as in-process, train_on_responses_only still forks a "
+            f"single worker on a split over {ZOO_MIN_ROWS_FOR_MULTIPROC:,} rows: "
             f"a bare None there reads as 'size it for me'.\n"
             f"  Original error: {exception}"
         ) from exception
@@ -642,8 +643,9 @@ def _serial_for_the_zoo(value: Optional[int]) -> Optional[int]:
 
     ``None`` only means "no workers" to ``train_on_responses_only`` while its own
     check refuses them too. When it would not, ``1`` is the smallest request it
-    honours verbatim: still a ``Pool(1)`` on ``datasets`` >= 4.1, but one child
-    instead of the ``cpu_count + 4`` its auto path would have chosen.
+    honours verbatim, and that helper now reads ``1`` as in-process; on a release
+    that predates this it is a ``Pool(1)``, still one child rather than the
+    ``cpu_count + 4`` its auto path would have chosen.
     """
     if value is not None or not _zoo_auto_sizer_forks():
         return value
@@ -669,8 +671,8 @@ def resolve_responses_only_num_proc(trainer, num_proc):
     * **Serial is the config-layer sentinel, not the call-site one.** That helper
       reads ``None`` as "size it for me", so on ``fork`` handing it ``None``
       would *inflate* the count rather than remove it; ``1`` is the closest
-      expressible request, and one forked worker is not the OOM this guards
-      against. Under spawn the trade flips -- each ``Pool(1)`` child re-imports
+      expressible request, and it is in-process on any release that reads it as
+      such. Under spawn the trade flips -- each ``Pool(1)`` child re-imports
       the user's ``__main__`` (#3211 / #3397), while ``None`` is safe because its
       auto path vetoes non-fork itself. That is exactly what
       ``serial_as_none = False`` encodes, so defer to it -- then re-check with
@@ -690,10 +692,10 @@ def resolve_responses_only_num_proc(trainer, num_proc):
         resolved = get_dataset_num_proc(num_proc, serial_as_none = False)
         if resolved == 1 and small:
             # Serial, and every split is under the threshold, so the helper's own
-            # guard runs each of them in-process -- which is more serial than the
-            # 1 expressible here, and the only place a serial request can be met
-            # exactly. Reaching this with UNSLOTH_DATASET_NUM_PROC=0 and a config
-            # sentinel of 1 was the escape hatch still building a Pool(1).
+            # guard runs each of them in-process, which an older unsloth_zoo
+            # would not do for the 1 expressible here: reaching this with
+            # UNSLOTH_DATASET_NUM_PROC=0 and a config sentinel of 1 was the
+            # escape hatch still building a Pool(1) there.
             return None
         return _serial_for_the_zoo(resolved)
 

--- a/unsloth/dataset_num_proc.py
+++ b/unsloth/dataset_num_proc.py
@@ -270,7 +270,9 @@ def _cgroup_free_bytes_unaided() -> Optional[int]:
                 break
         for directory in _cgroup_dirs(v1_root, rel):
             used = _cgroup_int(_cgroup_first_line(os.path.join(directory, "memory.usage_in_bytes")))
-            limit = _cgroup_limit(_cgroup_first_line(os.path.join(directory, "memory.limit_in_bytes")))
+            limit = _cgroup_limit(
+                _cgroup_first_line(os.path.join(directory, "memory.limit_in_bytes"))
+            )
             if limit is not None:
                 free.append(limit if used is None else limit - used)
 

--- a/unsloth/dataset_num_proc.py
+++ b/unsloth/dataset_num_proc.py
@@ -1,16 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-only
 # Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 """Fallback copy of the ``dataset_num_proc`` policy for ``Dataset.map()``.
 
@@ -191,6 +180,110 @@ def _cgroup_cpu_quota() -> Optional[float]:
         return None
 
 
+# Module constant so tests can point the unaided reader at a fixture tree.
+CGROUP_ROOT = "/sys/fs/cgroup"
+
+
+def _cgroup_first_line(path: str) -> Optional[str]:
+    try:
+        with open(path, "r") as f:
+            return f.readline().strip()
+    except OSError:
+        return None
+
+
+def _cgroup_int(raw: Optional[str]) -> Optional[int]:
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def _cgroup_limit(raw: Optional[str]) -> Optional[int]:
+    """``"max"`` (or an unparseable value) means unlimited."""
+    value = _cgroup_int(raw)
+    if value is None:
+        return None
+    # cgroup v1 spells "unlimited" as a near-2^63 sentinel.
+    return value if 0 < value < (1 << 62) else None
+
+
+def _cgroup_dirs(root: str, rel: Optional[str]) -> list:
+    """``root/rel`` and every ancestor up to *root*, innermost first.
+
+    A parent slice's limit binds this process just as its own does.
+    """
+    dirs = []
+    if rel and rel != "/":
+        current = os.path.normpath(os.path.join(root, rel.lstrip("/")))
+        while current.startswith(root + os.sep):
+            dirs.append(current)
+            current = os.path.dirname(current)
+    dirs.append(root)
+    return dirs
+
+
+def _proc_self_cgroup() -> list:
+    try:
+        with open("/proc/self/cgroup", "r") as f:
+            return [line.strip() for line in f if line.strip()]
+    except OSError:
+        return []  # not Linux, or procfs is hidden
+
+
+def _cgroup_free_bytes_unaided() -> Optional[int]:
+    """``_cgroup_free_bytes`` without unsloth_zoo's private cgroup helpers.
+
+    Only reached on an older unsloth_zoo, and only ever a fallback: the pairing
+    rule, the "unlimited" sentinels and the innermost-first walk are the ones
+    documented on ``_cgroup_free_bytes``. Reading the public ``cgroup_memory_limit``
+    alone is the last resort, since a limit is still a ceiling even unpaired.
+    """
+    lines = _proc_self_cgroup()
+    free = []
+
+    if os.path.isdir(CGROUP_ROOT):
+        rel = None
+        # The v2 line is "0::<path>"; under systemd hybrid mode v1 lines share
+        # the file, so scan rather than taking the first.
+        for line in lines:
+            if line.startswith("0::"):
+                rel = line[3:].strip()
+                break
+        for directory in _cgroup_dirs(CGROUP_ROOT, rel):
+            used = _cgroup_int(_cgroup_first_line(os.path.join(directory, "memory.current")))
+            for name in ("memory.max", "memory.high"):
+                limit = _cgroup_limit(_cgroup_first_line(os.path.join(directory, name)))
+                if limit is not None:
+                    free.append(limit if used is None else limit - used)
+
+    v1_root = os.path.join(CGROUP_ROOT, "memory")
+    if os.path.isdir(v1_root):
+        rel = None
+        for line in lines:
+            # "<id>:<controllers>:<path>"; mounts are often combined.
+            parts = line.split(":", 2)
+            if len(parts) == 3 and "memory" in parts[1].split(","):
+                rel = parts[2]
+                break
+        for directory in _cgroup_dirs(v1_root, rel):
+            used = _cgroup_int(_cgroup_first_line(os.path.join(directory, "memory.usage_in_bytes")))
+            limit = _cgroup_limit(_cgroup_first_line(os.path.join(directory, "memory.limit_in_bytes")))
+            if limit is not None:
+                free.append(limit if used is None else limit - used)
+
+    if free:
+        return max(min(free), 0)
+
+    try:
+        from unsloth_zoo.hf_xet_tuning import cgroup_memory_limit
+        return cgroup_memory_limit()
+    except Exception:
+        return None
+
+
 def _cgroup_free_bytes() -> Optional[int]:
     """Bytes free under the binding cgroup memory limit, or None outside one.
 
@@ -210,13 +303,11 @@ def _cgroup_free_bytes() -> Optional[int]:
             _read_first_line,
         )
     except Exception:
-        # An older unsloth_zoo. Fall back to the limit alone, which can only
-        # overstate what is free, never understate it.
-        try:
-            from unsloth_zoo.hf_xet_tuning import cgroup_memory_limit
-            return cgroup_memory_limit()
-        except Exception:
-            return None
+        # An older unsloth_zoo has no such private helpers. Do the same pairing
+        # here rather than reading the public limit alone: an 8GB cgroup with 6GB
+        # already resident would otherwise report 8GB free, and memory pressure
+        # is the one condition this ceiling exists for.
+        return _cgroup_free_bytes_unaided()
 
     def _used(path):
         raw = _read_first_line(path)

--- a/unsloth/dataset_num_proc.py
+++ b/unsloth/dataset_num_proc.py
@@ -35,6 +35,7 @@ __all__ = [
     "NUM_PROC_ENV_VAR",
     "WORKER_MEMORY_BUDGET_GB",
     "ZOO_MIN_ROWS_FOR_MULTIPROC",
+    "environment_override",
     "get_dataset_num_proc",
     "map_failure_diagnostics",
     "multiprocessing_start_method",
@@ -490,6 +491,19 @@ def _from_environment() -> "tuple[bool, Optional[int]]":
     if value <= 1:
         return True, None
     return True, value
+
+
+def environment_override() -> "tuple[bool, Optional[int]]":
+    """Whether NUM_PROC_ENV_VAR decided the count, and what it asked for.
+
+    ``(was_set_and_valid, value)``, with ``value = None`` meaning "in-process".
+    Public because a caller that layers its own caps on top of this module needs
+    to know whether the hatch chose the answer: the hatch is uncapped by
+    contract, and an unparseable or negative value is *not* the hatch, it is
+    ignored with a warning. Reading the variable directly cannot tell those
+    apart.
+    """
+    return _from_environment()
 
 
 def get_dataset_num_proc(

--- a/unsloth/dataset_num_proc.py
+++ b/unsloth/dataset_num_proc.py
@@ -176,51 +176,71 @@ def _workers_unusable_reason() -> Optional[str]:
     return None
 
 
-def _cgroup_limits() -> "tuple[Optional[int], Optional[float]]":
-    """This process's cgroup memory ceiling in bytes and CPU ceiling in cores.
+def _cgroup_cpu_quota() -> Optional[float]:
+    """This process's cgroup CPU ceiling in cores, or None outside one.
 
-    ``(None, None)`` off Linux or outside a container. Reuses the readers in
-    ``hf_xet_tuning`` rather than parsing ``/sys/fs/cgroup`` again: they already
-    handle v1 against v2, the ``/proc/self/cgroup`` path walk and the "unlimited"
-    sentinels. Imported lazily, so this module still loads on its own.
+    Reuses the reader in ``hf_xet_tuning`` rather than parsing ``/sys/fs/cgroup``
+    again: it already handles v1 against v2, the ``/proc/self/cgroup`` path walk
+    and the "unlimited" sentinels. Imported lazily, so this module still loads on
+    its own.
     """
     try:
-        from unsloth_zoo.hf_xet_tuning import cgroup_cpu_limit, cgroup_memory_limit
-        return cgroup_memory_limit(), cgroup_cpu_limit()
+        from unsloth_zoo.hf_xet_tuning import cgroup_cpu_limit
+        return cgroup_cpu_limit()
     except Exception:
-        return None, None
+        return None
 
 
-def _cgroup_memory_used() -> Optional[int]:
-    """Bytes this cgroup is already using, or None when that cannot be read.
+def _cgroup_free_bytes() -> Optional[int]:
+    """Bytes free under the binding cgroup memory limit, or None outside one.
 
-    Without it the whole limit looks free on a container that has spent most of
-    it, and the model is usually what spent it. Read from the same directories
-    the limit came from, innermost first, rather than from
-    ``/sys/fs/cgroup/memory.current``: at the root that file is the WHOLE
-    machine's usage, and subtracting it from a systemd unit's own MemoryMax would
-    leave every run with nothing free.
+    Each limit is paired with the usage of the directory that set it. The binding
+    limit is often an ancestor's -- a systemd slice, a Slurm job step -- and that
+    ancestor's usage counts siblings this process cannot see from its own leaf,
+    so pairing a leaf's usage with an ancestor's limit would report memory that
+    is already spent as free. The reverse pairing is worse still: the root
+    ``memory.current`` is the whole machine, and subtracting it from a unit's own
+    MemoryMax leaves every run with nothing.
     """
     try:
         from unsloth_zoo.hf_xet_tuning import (
             _cgroup_v1_dirs,
             _cgroup_v2_dirs,
+            _parse_limit,
             _read_first_line,
         )
     except Exception:
-        return None  # limit-only, which is never worse than not subtracting
+        # An older unsloth_zoo. Fall back to the limit alone, which can only
+        # overstate what is free, never understate it.
+        try:
+            from unsloth_zoo.hf_xet_tuning import cgroup_memory_limit
+            return cgroup_memory_limit()
+        except Exception:
+            return None
 
-    candidates = [(d, "memory.current") for d in _cgroup_v2_dirs()]
-    candidates += [(d, "memory.usage_in_bytes") for d in _cgroup_v1_dirs("memory")]
-    for directory, name in candidates:
-        raw = _read_first_line(directory / name)
+    def _used(path):
+        raw = _read_first_line(path)
         if not raw:
-            continue
+            return None
         try:
             return int(raw.strip())
         except ValueError:
-            continue
-    return None
+            return None
+
+    free = []
+    for directory in _cgroup_v2_dirs():
+        used = _used(directory / "memory.current")
+        for name in ("memory.max", "memory.high"):
+            limit = _parse_limit(_read_first_line(directory / name))
+            if limit is not None:
+                free.append(limit if used is None else limit - used)
+    for directory in _cgroup_v1_dirs("memory"):
+        used = _used(directory / "memory.usage_in_bytes")
+        limit = _parse_limit(_read_first_line(directory / "memory.limit_in_bytes"))
+        if limit is not None:
+            free.append(limit if used is None else limit - used)
+
+    return max(min(free), 0) if free else None
 
 
 def _available_memory_gb() -> Optional[float]:
@@ -236,11 +256,9 @@ def _available_memory_gb() -> Optional[float]:
     except Exception:
         return None
 
-    limit, _ = _cgroup_limits()
-    if limit is not None:
-        used = _cgroup_memory_used()
-        free = limit - used if used is not None else limit
-        available_gb = min(available_gb, max(free, 0) / (1024**3))
+    free = _cgroup_free_bytes()
+    if free is not None:
+        available_gb = min(available_gb, free / (1024**3))
     return available_gb
 
 
@@ -264,7 +282,7 @@ def _usable_cpus() -> Optional[int]:
     except (AttributeError, OSError):
         pass  # not Linux, or the call is unavailable: the host count stands
 
-    _, quota = _cgroup_limits()
+    quota = _cgroup_cpu_quota()
     if quota is not None and quota > 0:
         # A fractional quota still binds: Kubernetes "cpu: 500m" is 0.5 cores.
         cpus = min(cpus, max(1, int(quota)))
@@ -572,13 +590,21 @@ def resolve_responses_only_num_proc(trainer, num_proc):
     # Mirror that helper's own test, so "explicit" means the same on both sides
     # (it treats bools as auto, since type(True) is not int).
     was_auto = num_proc is None or type(num_proc) is not int
+    rows = _largest_split_rows(trainer)
+    small = rows is None or rows < ZOO_MIN_ROWS_FOR_MULTIPROC
 
     if not was_auto:
-        # Explicit counts already bypass the small-split guard.
-        return _serial_for_the_zoo(get_dataset_num_proc(num_proc, serial_as_none = False))
+        resolved = get_dataset_num_proc(num_proc, serial_as_none = False)
+        if resolved == 1 and small:
+            # Serial, and every split is under the threshold, so the helper's own
+            # guard runs each of them in-process -- which is more serial than the
+            # 1 expressible here, and the only place a serial request can be met
+            # exactly. Reaching this with UNSLOTH_DATASET_NUM_PROC=0 and a config
+            # sentinel of 1 was the escape hatch still building a Pool(1).
+            return None
+        return _serial_for_the_zoo(resolved)
 
-    rows = _largest_split_rows(trainer)
-    if rows is None or rows < ZOO_MIN_ROWS_FOR_MULTIPROC:
+    if small:
         # The escape hatch must win here too.
         env_set, env_value = _from_environment()
         if env_set and env_value is not None:

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -1429,18 +1429,28 @@ def _patch_trl_rl_trainers_impl(trainer_file = "grpo_trainer"):
         extra_args += saving_check
 
     # Edit dataset_num_proc
+    # The policy lives in unsloth.utils.dataset_num_proc, not inline here, because
+    # this heuristic had drifted into four copies and two of them were wrong: they
+    # asked stdlib `multiprocessing` about the start method when `datasets` uses
+    # `multiprocess`, and they used `1` as the "no multiprocessing" sentinel when
+    # only `None` is in-process on datasets >= 4.0 (`1` still builds a Pool(1)).
+    #
+    # serial_as_none = False: this writes back to the *config*, and
+    # unsloth_zoo.sft_prepare_dataset reads a config `None` as "auto-size me".
+    # Collapsing an explicit 1 to None here would therefore inflate it to the
+    # auto worker count downstream. The config keeps the user's intent; the
+    # map() call site (patched in rl_replacements.py) makes it safe.
+    #
+    # The import is guarded so a generated file that outlives an unsloth downgrade
+    # degrades to the caller's own value rather than failing to construct a config.
     if "dataset_num_proc" in call_args:
         num_proc_check = (
-            "import multiprocessing as _mp\n"
-            "if dataset_num_proc is None:\n"
-            "    if _mp.get_start_method() != 'fork':\n"
-            "        dataset_num_proc = None\n"
-            "    else:\n"
-            "        import psutil\n"
-            "        dataset_num_proc = min(max((psutil.cpu_count() or 1)+4, 2), 64)\n"
-            "        memory_gb_left = psutil.virtual_memory().available / (1024**3)\n"
-            "        if memory_gb_left <= 2: dataset_num_proc = 1\n"
-            "        else: dataset_num_proc = min(dataset_num_proc, int(memory_gb_left))\n"
+            "try:\n"
+            "    from unsloth.utils.dataset_num_proc import get_dataset_num_proc as _unsloth_get_dataset_num_proc\n"
+            "except Exception:\n"
+            "    _unsloth_get_dataset_num_proc = None\n"
+            "if _unsloth_get_dataset_num_proc is not None:\n"
+            "    dataset_num_proc = _unsloth_get_dataset_num_proc(dataset_num_proc, serial_as_none = False)\n"
         )
         extra_args += num_proc_check
 

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -1429,20 +1429,19 @@ def _patch_trl_rl_trainers_impl(trainer_file = "grpo_trainer"):
         extra_args += saving_check
 
     # Edit dataset_num_proc
-    # The policy lives in unsloth.utils.dataset_num_proc, not inline here, because
-    # this heuristic had drifted into four copies and two of them were wrong: they
-    # asked stdlib `multiprocessing` about the start method when `datasets` uses
-    # `multiprocess`, and they used `1` as the "no multiprocessing" sentinel when
-    # only `None` is in-process on datasets >= 4.1 (`1` still builds a Pool(1)).
+    # The policy lives in unsloth.utils.dataset_num_proc rather than inline: this
+    # heuristic had drifted into four copies, two of them wrong (stdlib
+    # `multiprocessing` asked about a start method `datasets` takes from
+    # `multiprocess`, and `1` used as the serial sentinel when it builds a Pool(1)
+    # on datasets >= 4.1).
     #
-    # serial_as_none = False: this writes back to the *config*, and
-    # unsloth_zoo.sft_prepare_dataset reads a config `None` as "auto-size me".
-    # Collapsing an explicit 1 to None here would therefore inflate it to the
-    # auto worker count downstream. The config keeps the user's intent; the
-    # map() call site (patched in rl_replacements.py) makes it safe.
+    # serial_as_none = False because this writes back to the *config*, where
+    # unsloth_zoo.sft_prepare_dataset reads `None` as "auto-size me": collapsing
+    # an explicit 1 would inflate it downstream. The config keeps the user's
+    # intent; the map() call site (rl_replacements.py) makes it safe.
     #
-    # The import is guarded so a generated file that outlives an unsloth downgrade
-    # degrades to the caller's own value rather than failing to construct a config.
+    # The import is guarded so a generated file outliving an unsloth downgrade
+    # degrades to the caller's value rather than failing to build a config.
     if "dataset_num_proc" in call_args:
         num_proc_check = (
             "try:\n"

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -1433,7 +1433,7 @@ def _patch_trl_rl_trainers_impl(trainer_file = "grpo_trainer"):
     # this heuristic had drifted into four copies and two of them were wrong: they
     # asked stdlib `multiprocessing` about the start method when `datasets` uses
     # `multiprocess`, and they used `1` as the "no multiprocessing" sentinel when
-    # only `None` is in-process on datasets >= 4.0 (`1` still builds a Pool(1)).
+    # only `None` is in-process on datasets >= 4.1 (`1` still builds a Pool(1)).
     #
     # serial_as_none = False: this writes back to the *config*, and
     # unsloth_zoo.sft_prepare_dataset reads a config `None` as "auto-size me".

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -1429,22 +1429,16 @@ def _patch_trl_rl_trainers_impl(trainer_file = "grpo_trainer"):
         extra_args += saving_check
 
     # Edit dataset_num_proc
-    # The policy lives in unsloth_zoo.dataset_num_proc rather than inline: this
-    # heuristic had drifted into four copies, two of them wrong (stdlib
-    # `multiprocessing` asked about a start method `datasets` takes from
-    # `multiprocess`, and `1` used as the serial sentinel when it builds a Pool(1)
-    # on datasets >= 4.1).
-    #
-    # The zoo, not unsloth, so that generated trainer source never imports back
-    # into the package that generated it. unsloth.utils.dataset_num_proc is the
-    # fallback for a zoo predating the module, and the whole ladder is guarded so
-    # a generated file that outlives either degrades to the caller's value rather
-    # than failing to build a config.
-    #
-    # serial_as_none = False because this writes back to the *config*, where
-    # unsloth_zoo.sft_prepare_dataset reads `None` as "auto-size me": collapsing
-    # an explicit 1 would inflate it downstream. The config keeps the user's
-    # intent; the map() call site (rl_replacements.py) makes it safe.
+    # The policy lives in unsloth_zoo.dataset_num_proc: it had drifted into four
+    # inline copies, two wrong (stdlib `multiprocessing` asked about a start
+    # method `datasets` takes from `multiprocess`, and `1` used as the serial
+    # sentinel when datasets >= 4.1 builds a Pool(1) for it). The zoo rather than
+    # unsloth, so generated source never imports back into its generator;
+    # unsloth.utils.dataset_num_proc is the fallback for an older zoo, and the
+    # ladder is guarded so a stale generated file degrades to the caller's value.
+    # serial_as_none = False since this writes to the *config*, where
+    # unsloth_zoo.sft_prepare_dataset reads `None` as "auto-size me"; the map()
+    # call site (rl_replacements.py) is what makes it safe.
     if "dataset_num_proc" in call_args:
         num_proc_check = (
             "try:\n"

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -1434,22 +1434,29 @@ def _patch_trl_rl_trainers_impl(trainer_file = "grpo_trainer"):
     # method `datasets` takes from `multiprocess`, and `1` used as the serial
     # sentinel when datasets >= 4.1 builds a Pool(1) for it). The zoo rather than
     # unsloth, so generated source never imports back into its generator;
-    # unsloth.utils.dataset_num_proc is the fallback for an older zoo, and the
+    # unsloth.dataset_num_proc is the fallback for an older zoo, and the
     # ladder is guarded so a stale generated file degrades to the caller's value.
-    # serial_as_none = False since this writes to the *config*, where
-    # unsloth_zoo.sft_prepare_dataset reads `None` as "auto-size me"; the map()
-    # call site (rl_replacements.py) is what makes it safe.
+    # serial_as_none depends on who reads the value back. Only SFT has a
+    # downstream auto-sizer: unsloth_zoo.sft_prepare_dataset reads a config
+    # `None` as "auto-size me", so serial has to be written as `1` there and the
+    # map() call site (rl_replacements.py) turns it back into None. DPO, KTO,
+    # CPO, ORPO, Reward and PRM hand args.dataset_num_proc straight to
+    # Dataset.map, where nothing can inflate a None but a `1` is a Pool(1) on
+    # datasets >= 4.1 -- one worker with its own tokenizer copy, on a host the
+    # memory clamp had just declared too small for workers.
     if "dataset_num_proc" in call_args:
+        _serial_as_none = "False" if trainer_file == "sft_trainer" else "True"
         num_proc_check = (
             "try:\n"
             "    from unsloth_zoo.dataset_num_proc import get_dataset_num_proc as _unsloth_get_dataset_num_proc\n"
             "except Exception:\n"
             "    try:\n"
-            "        from unsloth.utils.dataset_num_proc import get_dataset_num_proc as _unsloth_get_dataset_num_proc\n"
+            "        from unsloth.dataset_num_proc import get_dataset_num_proc as _unsloth_get_dataset_num_proc\n"
             "    except Exception:\n"
             "        _unsloth_get_dataset_num_proc = None\n"
             "if _unsloth_get_dataset_num_proc is not None:\n"
-            "    dataset_num_proc = _unsloth_get_dataset_num_proc(dataset_num_proc, serial_as_none = False)\n"
+            "    dataset_num_proc = _unsloth_get_dataset_num_proc("
+            f"dataset_num_proc, serial_as_none = {_serial_as_none})\n"
         )
         extra_args += num_proc_check
 

--- a/unsloth/models/rl.py
+++ b/unsloth/models/rl.py
@@ -1429,25 +1429,31 @@ def _patch_trl_rl_trainers_impl(trainer_file = "grpo_trainer"):
         extra_args += saving_check
 
     # Edit dataset_num_proc
-    # The policy lives in unsloth.utils.dataset_num_proc rather than inline: this
+    # The policy lives in unsloth_zoo.dataset_num_proc rather than inline: this
     # heuristic had drifted into four copies, two of them wrong (stdlib
     # `multiprocessing` asked about a start method `datasets` takes from
     # `multiprocess`, and `1` used as the serial sentinel when it builds a Pool(1)
     # on datasets >= 4.1).
     #
+    # The zoo, not unsloth, so that generated trainer source never imports back
+    # into the package that generated it. unsloth.utils.dataset_num_proc is the
+    # fallback for a zoo predating the module, and the whole ladder is guarded so
+    # a generated file that outlives either degrades to the caller's value rather
+    # than failing to build a config.
+    #
     # serial_as_none = False because this writes back to the *config*, where
     # unsloth_zoo.sft_prepare_dataset reads `None` as "auto-size me": collapsing
     # an explicit 1 would inflate it downstream. The config keeps the user's
     # intent; the map() call site (rl_replacements.py) makes it safe.
-    #
-    # The import is guarded so a generated file outliving an unsloth downgrade
-    # degrades to the caller's value rather than failing to build a config.
     if "dataset_num_proc" in call_args:
         num_proc_check = (
             "try:\n"
-            "    from unsloth.utils.dataset_num_proc import get_dataset_num_proc as _unsloth_get_dataset_num_proc\n"
+            "    from unsloth_zoo.dataset_num_proc import get_dataset_num_proc as _unsloth_get_dataset_num_proc\n"
             "except Exception:\n"
-            "    _unsloth_get_dataset_num_proc = None\n"
+            "    try:\n"
+            "        from unsloth.utils.dataset_num_proc import get_dataset_num_proc as _unsloth_get_dataset_num_proc\n"
+            "    except Exception:\n"
+            "        _unsloth_get_dataset_num_proc = None\n"
             "if _unsloth_get_dataset_num_proc is not None:\n"
             "    dataset_num_proc = _unsloth_get_dataset_num_proc(dataset_num_proc, serial_as_none = False)\n"
         )

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -552,6 +552,56 @@ def sft_trainer_prepare_dataset(function_name, function):
         )""",
                 where = "sft_prepare_dataset pack_dataset call",
             )
+            # why: this is the map() call site, so it -- not the config -- is where
+            # the worker count must be made safe. Two defects in the Zoo copy:
+            # it asks stdlib `multiprocessing` for the start method while datasets
+            # uses `multiprocess` (independent default contexts), and its
+            # low-memory branch yields 1, which still builds a Pool(1) on
+            # datasets >= 4.0. Route it through the one shared helper instead, so
+            # a config value of None auto-sizes with the same capped policy rather
+            # than the Zoo's uncapped `cpu_count + 4 -> 64`.
+            function = _require_replace(
+                function,
+                """if not isinstance(dataset, IterableDataset):
+            import multiprocessing as _mp
+            dataset_num_proc = getattr(args, "dataset_num_proc", None)
+            if dataset_num_proc is None:
+                if _mp.get_start_method() != 'fork':
+                    dataset_num_proc = None
+                else:
+                    import psutil
+                    dataset_num_proc = min(max((psutil.cpu_count() or 1)+4, 2), 64)
+                    memory_gb_left = psutil.virtual_memory().available / (1024**3)
+                    if memory_gb_left <= 2:
+                        dataset_num_proc = 1
+                    else:
+                        dataset_num_proc = min(dataset_num_proc, int(memory_gb_left))
+            map_kwargs["num_proc"] = dataset_num_proc""",
+                """if not isinstance(dataset, IterableDataset):
+            from unsloth.utils.dataset_num_proc import get_dataset_num_proc as _unsloth_get_dataset_num_proc
+            map_kwargs["num_proc"] = _unsloth_get_dataset_num_proc(
+                getattr(args, "dataset_num_proc", None)
+            )""",
+                where = "sft_prepare_dataset dataset_num_proc selection",
+            )
+            # why: datasets flattens every worker death -- OOM kill, segfault,
+            # real exception -- into "One of the subprocesses has abruptly died
+            # during map operation", because it compares pool PIDs and never
+            # reads the child's exit status. Wrap both tokenizing map() calls so
+            # the user gets the worker count, the start method and the memory
+            # those workers implied, instead of having to guess. count = 2: the
+            # anchor is the prompt-completion branch and the plain-text branch,
+            # and the drift canary asserts both are still there.
+            function = _require_replace(
+                function,
+                """            with _w.catch_warnings():
+                _w.filterwarnings("ignore", message=".*couldn't be hashed properly.*")""",
+                """            from unsloth.utils.dataset_num_proc import map_failure_diagnostics as _unsloth_map_diagnostics
+            with _w.catch_warnings(), _unsloth_map_diagnostics(map_kwargs.get("num_proc")):
+                _w.filterwarnings("ignore", message=".*couldn't be hashed properly.*")""",
+                count = 2,
+                where = "sft_prepare_dataset tokenizing map() calls",
+            )
             function = function.split("\n")
             function = "\n".join(" " * 4 + x for x in function)
             function = function.replace("def sft_prepare_dataset", "def _prepare_dataset")

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -553,13 +553,12 @@ def sft_trainer_prepare_dataset(function_name, function):
                 where = "sft_prepare_dataset pack_dataset call",
             )
             # why: this is the map() call site, so it -- not the config -- is where
-            # the worker count must be made safe. Two defects in the Zoo copy:
-            # it asks stdlib `multiprocessing` for the start method while datasets
-            # uses `multiprocess` (independent default contexts), and its
-            # low-memory branch yields 1, which still builds a Pool(1) on
-            # datasets >= 4.1. Route it through the one shared helper instead, so
-            # a config value of None auto-sizes with the same capped policy rather
-            # than the Zoo's uncapped `cpu_count + 4 -> 64`.
+            # the worker count must be made safe. Two defects in the Zoo copy: it
+            # asks stdlib `multiprocessing` for the start method while datasets
+            # takes it from `multiprocess`, and its low-memory branch yields 1,
+            # which still builds a Pool(1) on datasets >= 4.1. Route it through the
+            # shared helper so a config None auto-sizes with the capped policy
+            # instead of the Zoo's uncapped `cpu_count + 4 -> 64`.
             function = _require_replace(
                 function,
                 """if not isinstance(dataset, IterableDataset):
@@ -583,23 +582,21 @@ def sft_trainer_prepare_dataset(function_name, function):
                 getattr(args, "dataset_num_proc", None)
             )""",
                 where = "sft_prepare_dataset dataset_num_proc selection",
-                # required = False, unlike the edits above: this is the one anchor
-                # whose absence is harmless. unsloth_zoo is a floor dependency, not
-                # a pin, and this is the block we just changed the policy of, so it
-                # is likelier to drift upstream than the rest. If it does, the Zoo
-                # falls back to reading args.dataset_num_proc -- which the config
-                # layer has already bounded -- so the memory ceiling that fixes
-                # #2693 still holds. Hard-failing here would break every install on
-                # a newer Zoo to recover an optimisation, not a correctness fix.
+                # required = False, unlike the edits above: this anchor is the one
+                # whose absence is harmless, and the likeliest to drift since
+                # unsloth_zoo is a floor dependency and this is the block whose
+                # policy just changed. If it drifts the Zoo reads
+                # args.dataset_num_proc, which the config layer already bounded, so
+                # the memory ceiling that fixes #2693 still holds. Hard-failing
+                # would break every install on a newer Zoo over an optimisation.
                 required = False,
             )
-            # why: datasets flattens every worker death -- OOM kill, segfault,
-            # real exception -- into "One of the subprocesses has abruptly died
-            # during map operation", because it compares pool PIDs and never
-            # reads the child's exit status. Wrap both tokenizing map() calls so
-            # the user gets the worker count, the start method and the memory
-            # those workers implied, instead of having to guess. count = 2: the
-            # anchor is the prompt-completion branch and the plain-text branch,
+            # why: datasets compares pool PIDs and never reads the child's exit
+            # status, so every worker death -- OOM kill, segfault, real exception
+            # -- flattens into "One of the subprocesses has abruptly died during
+            # map operation". Wrap both tokenizing map() calls so the user gets
+            # the worker count, start method and implied memory instead of a
+            # guess. count = 2 is the prompt-completion and plain-text branches,
             # and the drift canary asserts both are still there.
             function = _require_replace(
                 function,

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -452,6 +452,13 @@ _WRAPPED_PACKING_SETUP = (
 _WARNED_MISSING_ANCHORS = set()
 
 
+def _warn_once(where, message):
+    if where in _WARNED_MISSING_ANCHORS:
+        return
+    _WARNED_MISSING_ANCHORS.add(where)
+    logger.warning(message)
+
+
 def _require_replace(
     function,
     old,
@@ -476,11 +483,70 @@ def _require_replace(
                 f"Unsloth: source anchor not found{detail}; the patched function is out "
                 "of sync with this TRL / unsloth_zoo version. Please file a bug report."
             )
-        if where not in _WARNED_MISSING_ANCHORS:
-            _WARNED_MISSING_ANCHORS.add(where)
-            logger.warning(f"Unsloth: skipped an optional source edit{detail} (anchor not found).")
+        _warn_once(
+            where,
+            f"Unsloth: skipped an optional source edit{detail} (anchor not found).",
+        )
         return function
     return function.replace(old, new, count)
+
+
+# The one line every unsloth_zoo revision of sft_prepare_dataset ends its worker
+# count on, as a regex so a renamed right-hand side still matches and the
+# indentation is carried into the replacement. `git log -S` on the Zoo says this
+# line last changed in Aug 2025 (#257) and has survived 24 later commits to
+# dataset_utils.py, while the block around it was rewritten three times in 2026
+# alone (#473, #553, #733) -- which is why it is the fallback rather than the
+# primary anchor.
+_ZOO_MAP_NUM_PROC_ASSIGNMENT = re.compile(
+    r"^(?P<indent>[ \t]*)map_kwargs\[\"num_proc\"\][ \t]*=[ \t]*[^\n]+$",
+    flags = re.MULTILINE,
+)
+
+
+def _replace_or_fallback(
+    function,
+    old,
+    new,
+    *,
+    fallback_pattern,
+    fallback_new,
+    where = "",
+):
+    """str.replace over a wide anchor, with a narrower anchor to fall back on.
+
+    One literal anchor is all-or-nothing, and neither outcome is acceptable here.
+    `required = True` hard-fails every SFT run on a Zoo whose text merely moved.
+    `required = False` leaves the un-rewritten Zoo logic in place, and for the
+    worker count that is not the no-op it looks like: the config layer writes
+    "run in-process" as `args.dataset_num_proc = 1` (a config `None` means
+    "auto-size me" to the Zoo), the Zoo reads that `1` as an explicit count, and
+    `datasets` >= 4.1 builds a `Pool(1)` for it -- forking a tokenizer worker on
+    exactly the host, or the `UNSLOTH_DATASET_NUM_PROC=0`, that asked for none.
+
+    So: try the wide anchor, then a narrow one that survives more drift, and warn
+    only when both miss. `fallback_new` is an `re.sub` template, so it can carry
+    the matched indentation over with `\\g<indent>`.
+    """
+    if old in function:
+        return function.replace(old, new, 1)
+
+    function, applied = fallback_pattern.subn(fallback_new, function)
+    if applied:
+        _warn_once(
+            where,
+            f"Unsloth: the source block for {where} moved in this unsloth_zoo; "
+            "applied the narrower anchor instead. Please file a bug report.",
+        )
+        return function
+
+    _warn_once(
+        where,
+        f"Unsloth: skipped an optional source edit ({where}) (anchor not found); "
+        "dataset tokenization may fork a worker process this host asked it not "
+        "to. Please file a bug report.",
+    )
+    return function
 
 
 # Fix tokenizer double BOS
@@ -560,7 +626,7 @@ def sft_trainer_prepare_dataset(function_name, function):
             # the Zoo's uncapped `cpu_count + 4 -> 64`. Imported from the Zoo so
             # generated source never imports back into its generator;
             # unsloth.dataset_num_proc is only the fallback for an older Zoo.
-            function = _require_replace(
+            function = _replace_or_fallback(
                 function,
                 """if not isinstance(dataset, IterableDataset):
             import multiprocessing as _mp
@@ -585,13 +651,26 @@ def sft_trainer_prepare_dataset(function_name, function):
             map_kwargs["num_proc"] = _unsloth_get_dataset_num_proc(
                 getattr(args, "dataset_num_proc", None)
             )""",
+                # This block is the likeliest anchor in the file to drift -- the
+                # Zoo rewrote it three times in 2026 -- but its absence is not
+                # harmless, so it cannot simply be optional: the config layer
+                # encodes serial as `1` for this site to turn back into None, and
+                # an un-rewritten Zoo hands that `1` to Dataset.map. The fallback
+                # keys on the assignment the block ends with, which has not
+                # changed since Aug 2025, and reads args rather than the Zoo's
+                # own local so it is the same computation the block anchor above
+                # installs; the Zoo's now-dead sizing runs and is discarded.
+                # Hard-failing instead would break every install on a newer Zoo,
+                # which is a far larger blast radius than one worker.
+                fallback_pattern = _ZOO_MAP_NUM_PROC_ASSIGNMENT,
+                fallback_new = r"""\g<indent>try:
+\g<indent>    from unsloth_zoo.dataset_num_proc import get_dataset_num_proc as _unsloth_get_dataset_num_proc
+\g<indent>except ImportError:
+\g<indent>    from unsloth.dataset_num_proc import get_dataset_num_proc as _unsloth_get_dataset_num_proc
+\g<indent>map_kwargs["num_proc"] = _unsloth_get_dataset_num_proc(
+\g<indent>    getattr(args, "dataset_num_proc", None)
+\g<indent>)""",
                 where = "sft_prepare_dataset dataset_num_proc selection",
-                # required = False, unlike the edits above: this anchor is the
-                # likeliest to drift and its absence is harmless -- the Zoo then
-                # reads args.dataset_num_proc, which the config layer already
-                # bounded, so the #2693 memory ceiling still holds. Hard-failing
-                # would break every install on a newer Zoo over an optimisation.
-                required = False,
             )
             # why: datasets never reads the child's exit status, so every worker
             # death -- OOM kill, segfault, real exception -- flattens into "One

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -559,7 +559,7 @@ def sft_trainer_prepare_dataset(function_name, function):
             # datasets >= 4.1. The shared helper caps a config None instead of
             # the Zoo's uncapped `cpu_count + 4 -> 64`. Imported from the Zoo so
             # generated source never imports back into its generator;
-            # unsloth.utils.dataset_num_proc is only the fallback for an older Zoo.
+            # unsloth.dataset_num_proc is only the fallback for an older Zoo.
             function = _require_replace(
                 function,
                 """if not isinstance(dataset, IterableDataset):
@@ -581,7 +581,7 @@ def sft_trainer_prepare_dataset(function_name, function):
             try:
                 from unsloth_zoo.dataset_num_proc import get_dataset_num_proc as _unsloth_get_dataset_num_proc
             except ImportError:
-                from unsloth.utils.dataset_num_proc import get_dataset_num_proc as _unsloth_get_dataset_num_proc
+                from unsloth.dataset_num_proc import get_dataset_num_proc as _unsloth_get_dataset_num_proc
             map_kwargs["num_proc"] = _unsloth_get_dataset_num_proc(
                 getattr(args, "dataset_num_proc", None)
             )""",
@@ -606,11 +606,17 @@ def sft_trainer_prepare_dataset(function_name, function):
                 """            try:
                 from unsloth_zoo.dataset_num_proc import map_failure_diagnostics as _unsloth_map_diagnostics
             except ImportError:
-                from unsloth.utils.dataset_num_proc import map_failure_diagnostics as _unsloth_map_diagnostics
+                from unsloth.dataset_num_proc import map_failure_diagnostics as _unsloth_map_diagnostics
             with _w.catch_warnings(), _unsloth_map_diagnostics(map_kwargs.get("num_proc")):
                 _w.filterwarnings("ignore", message=".*couldn't be hashed properly.*")""",
                 count = 2,
                 where = "sft_prepare_dataset tokenizing map() calls",
+                # required = False, like the selection above: this only improves the
+                # message a dead worker produces, and a diagnostic must not be able
+                # to fail a training run because a Zoo release moved the line it
+                # anchors on. test_zoo_sft_prepare_dataset_anchor_has_not_drifted is
+                # what notices, in CI rather than in someone's run.
+                required = False,
             )
             function = function.split("\n")
             function = "\n".join(" " * 4 + x for x in function)

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -557,7 +557,7 @@ def sft_trainer_prepare_dataset(function_name, function):
             # it asks stdlib `multiprocessing` for the start method while datasets
             # uses `multiprocess` (independent default contexts), and its
             # low-memory branch yields 1, which still builds a Pool(1) on
-            # datasets >= 4.0. Route it through the one shared helper instead, so
+            # datasets >= 4.1. Route it through the one shared helper instead, so
             # a config value of None auto-sizes with the same capped policy rather
             # than the Zoo's uncapped `cpu_count + 4 -> 64`.
             function = _require_replace(

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -583,6 +583,15 @@ def sft_trainer_prepare_dataset(function_name, function):
                 getattr(args, "dataset_num_proc", None)
             )""",
                 where = "sft_prepare_dataset dataset_num_proc selection",
+                # required = False, unlike the edits above: this is the one anchor
+                # whose absence is harmless. unsloth_zoo is a floor dependency, not
+                # a pin, and this is the block we just changed the policy of, so it
+                # is likelier to drift upstream than the rest. If it does, the Zoo
+                # falls back to reading args.dataset_num_proc -- which the config
+                # layer has already bounded -- so the memory ceiling that fixes
+                # #2693 still holds. Hard-failing here would break every install on
+                # a newer Zoo to recover an optimisation, not a correctness fix.
+                required = False,
             )
             # why: datasets flattens every worker death -- OOM kill, segfault,
             # real exception -- into "One of the subprocesses has abruptly died

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -552,18 +552,14 @@ def sft_trainer_prepare_dataset(function_name, function):
         )""",
                 where = "sft_prepare_dataset pack_dataset call",
             )
-            # why: this is the map() call site, so it -- not the config -- is where
-            # the worker count must be made safe. Two defects in the Zoo copy: it
-            # asks stdlib `multiprocessing` for the start method while datasets
-            # takes it from `multiprocess`, and its low-memory branch yields 1,
-            # which still builds a Pool(1) on datasets >= 4.1. Route it through the
-            # shared helper so a config None auto-sizes with the capped policy
-            # instead of the Zoo's uncapped `cpu_count + 4 -> 64`.
-            #
-            # The helper is imported from the Zoo, not from unsloth, so generated
-            # trainer source never imports back into the package that generated
-            # it; unsloth.utils.dataset_num_proc is only the fallback for a Zoo
-            # predating the module.
+            # why: the map() call site -- not the config -- is where the worker
+            # count must be made safe. The Zoo copy asks stdlib `multiprocessing`
+            # for a start method datasets takes from `multiprocess`, and its
+            # low-memory branch yields 1, which still builds a Pool(1) on
+            # datasets >= 4.1. The shared helper caps a config None instead of
+            # the Zoo's uncapped `cpu_count + 4 -> 64`. Imported from the Zoo so
+            # generated source never imports back into its generator;
+            # unsloth.utils.dataset_num_proc is only the fallback for an older Zoo.
             function = _require_replace(
                 function,
                 """if not isinstance(dataset, IterableDataset):
@@ -590,22 +586,19 @@ def sft_trainer_prepare_dataset(function_name, function):
                 getattr(args, "dataset_num_proc", None)
             )""",
                 where = "sft_prepare_dataset dataset_num_proc selection",
-                # required = False, unlike the edits above: this anchor is the one
-                # whose absence is harmless, and the likeliest to drift since
-                # unsloth_zoo is a floor dependency and this is the block whose
-                # policy just changed. If it drifts the Zoo reads
-                # args.dataset_num_proc, which the config layer already bounded, so
-                # the memory ceiling that fixes #2693 still holds. Hard-failing
+                # required = False, unlike the edits above: this anchor is the
+                # likeliest to drift and its absence is harmless -- the Zoo then
+                # reads args.dataset_num_proc, which the config layer already
+                # bounded, so the #2693 memory ceiling still holds. Hard-failing
                 # would break every install on a newer Zoo over an optimisation.
                 required = False,
             )
-            # why: datasets compares pool PIDs and never reads the child's exit
-            # status, so every worker death -- OOM kill, segfault, real exception
-            # -- flattens into "One of the subprocesses has abruptly died during
-            # map operation". Wrap both tokenizing map() calls so the user gets
-            # the worker count, start method and implied memory instead of a
-            # guess. count = 2 is the prompt-completion and plain-text branches,
-            # and the drift canary asserts both are still there.
+            # why: datasets never reads the child's exit status, so every worker
+            # death -- OOM kill, segfault, real exception -- flattens into "One
+            # of the subprocesses has abruptly died during map operation". Wrap
+            # both tokenizing map() calls (count = 2: the prompt-completion and
+            # plain-text branches) so the user gets the worker count, start
+            # method and implied memory instead.
             function = _require_replace(
                 function,
                 """            with _w.catch_warnings():

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -559,6 +559,11 @@ def sft_trainer_prepare_dataset(function_name, function):
             # which still builds a Pool(1) on datasets >= 4.1. Route it through the
             # shared helper so a config None auto-sizes with the capped policy
             # instead of the Zoo's uncapped `cpu_count + 4 -> 64`.
+            #
+            # The helper is imported from the Zoo, not from unsloth, so generated
+            # trainer source never imports back into the package that generated
+            # it; unsloth.utils.dataset_num_proc is only the fallback for a Zoo
+            # predating the module.
             function = _require_replace(
                 function,
                 """if not isinstance(dataset, IterableDataset):
@@ -577,7 +582,10 @@ def sft_trainer_prepare_dataset(function_name, function):
                         dataset_num_proc = min(dataset_num_proc, int(memory_gb_left))
             map_kwargs["num_proc"] = dataset_num_proc""",
                 """if not isinstance(dataset, IterableDataset):
-            from unsloth.utils.dataset_num_proc import get_dataset_num_proc as _unsloth_get_dataset_num_proc
+            try:
+                from unsloth_zoo.dataset_num_proc import get_dataset_num_proc as _unsloth_get_dataset_num_proc
+            except ImportError:
+                from unsloth.utils.dataset_num_proc import get_dataset_num_proc as _unsloth_get_dataset_num_proc
             map_kwargs["num_proc"] = _unsloth_get_dataset_num_proc(
                 getattr(args, "dataset_num_proc", None)
             )""",
@@ -602,7 +610,10 @@ def sft_trainer_prepare_dataset(function_name, function):
                 function,
                 """            with _w.catch_warnings():
                 _w.filterwarnings("ignore", message=".*couldn't be hashed properly.*")""",
-                """            from unsloth.utils.dataset_num_proc import map_failure_diagnostics as _unsloth_map_diagnostics
+                """            try:
+                from unsloth_zoo.dataset_num_proc import map_failure_diagnostics as _unsloth_map_diagnostics
+            except ImportError:
+                from unsloth.utils.dataset_num_proc import map_failure_diagnostics as _unsloth_map_diagnostics
             with _w.catch_warnings(), _unsloth_map_diagnostics(map_kwargs.get("num_proc")):
                 _w.filterwarnings("ignore", message=".*couldn't be hashed properly.*")""",
                 count = 2,

--- a/unsloth/utils/dataset_num_proc.py
+++ b/unsloth/utils/dataset_num_proc.py
@@ -57,26 +57,27 @@ __all__ = [
 # start-method veto), "0"/"none" forces in-process tokenization.
 NUM_PROC_ENV_VAR = "UNSLOTH_DATASET_NUM_PROC"
 
-# Bounds the *auto* count only; raise it via NUM_PROC_ENV_VAR. The old
-# min(max(cpu_count + 4, 2), 64) allowed 64 forked workers, each handed its own
-# dill-pickled tokenizer closure and an Arrow shard over a pipe. Measured on 8000
-# rows, Qwen2.5 fast tokenizer, 3 reps: None 6.3s, 1 9.5s, 8 8.1s, 32 14.2s, 64
-# 21.7s -- more workers were slower than none at every size.
+# Upper bound for the *auto* count only; raise it via NUM_PROC_ENV_VAR. The old
+# min(max(cpu_count + 4, 2), 64) forked up to 64 workers, each handed its own
+# dill-pickled tokenizer closure and an Arrow shard over a pipe. Measured on
+# 8000 rows, Qwen2.5 fast tokenizer, 3 reps: None 6.3s, 1 9.5s, 8 8.1s,
+# 32 14.2s, 64 21.7s -- more workers were slower than none at every size.
 AUTO_NUM_PROC_CAP = 8
 
-# Peak RSS per worker on that run: ~680 MB, flat across worker counts. Budget
-# 1 GB so a larger tokenizer or shard does not immediately invalidate this.
+# ~680 MB peak RSS per worker on that run, flat across counts; 1 GB for headroom.
 WORKER_MEMORY_BUDGET_GB = 1.0
 
 # Share of *available* RAM tokenization may spend; the rest belongs to the run
-# that follows. This is what bounds issue #2693, where workers are OOM-killed and
-# datasets reports only "subprocesses has abruptly died", the real cause lost.
+# that follows. This is what bounds issue #2693, where OOM-killed workers
+# surface only as "One of the subprocesses has abruptly died during map
+# operation", the real cause discarded.
 MEMORY_BUDGET_FRACTION = 0.5
 
-# Mirrors _MIN_ROWS_FOR_MULTIPROC, a local (so unimportable) inside
-# unsloth_zoo.dataset_utils.train_on_responses_only: under it the Zoo maps a
-# split in-process unless given an explicit count, a guard
-# resolve_responses_only_num_proc must not take away. A canary test catches drift.
+# Mirrors _MIN_ROWS_FOR_MULTIPROC, a local inside
+# dataset_utils.train_on_responses_only (hence not importable): below it that
+# helper maps a split in-process, unless handed an explicit count.
+# resolve_responses_only_num_proc needs the threshold to keep that guard; a
+# canary in tests/test_dataset_num_proc.py catches drift.
 ZOO_MIN_ROWS_FOR_MULTIPROC = 5_000
 
 # Warn at most once per process per distinct reason.
@@ -99,16 +100,13 @@ def _unpinned_default_start_method(module) -> Optional[str]:
     """The default start method of a module that has not pinned one yet.
 
     ``get_all_start_methods()[0]`` is the documented default, but ``multiprocess``
-    copied that function verbatim -- darwin listing ``spawn`` first -- without the
-    darwin default that goes with it (``context.py`` line 326 on macOS)::
-
-        multiprocessing:  _default_context = DefaultContext(_concrete_contexts['spawn'])
-        multiprocess:     _default_context = DefaultContext(_concrete_contexts['fork'])  #FIXME: spawn
-
-    So its list says ``spawn`` while its ``Pool`` forks. Read the default
-    context's own name instead: unlike ``get_context()`` it does not assign
-    ``_actual_context``, keeping the probe side-effect free. Private, hence the
-    fallback.
+    copies that function verbatim -- darwin branch listing ``spawn`` first --
+    without copying the darwin default that goes with it, keeping ``fork`` as its
+    ``_default_context`` (``#FIXME: spawn`` in its ``context.py``). So its list
+    says ``spawn`` while its ``Pool`` forks, and ``datasets`` builds from
+    ``multiprocess``. Read the default context's own name instead; unlike
+    ``get_context()`` it does not assign ``_actual_context``, keeping the probe
+    side-effect free. Private attributes, hence the fallback.
     """
     try:
         methods = module.get_all_start_methods()
@@ -117,9 +115,9 @@ def _unpinned_default_start_method(module) -> Optional[str]:
 
     try:
         name = module.context._default_context._default_context._name
-        # Only if the platform offers it: a Windows runner answered 'fork' while
-        # get_all_start_methods() was ['spawn'], and believing that reads Windows
-        # as forkable -- the spawn re-import loop of #3211 / #3397.
+        # Only if the platform actually offers it: a Windows runner answered
+        # 'fork' while get_all_start_methods() was ['spawn'], which would read
+        # Windows as forkable -- the spawn re-import loop of #3211 / #3397.
         if isinstance(name, str) and name and (not methods or name in methods):
             return name
     except Exception:
@@ -127,25 +125,30 @@ def _unpinned_default_start_method(module) -> Optional[str]:
     return methods[0] if methods else None
 
 
+def _module_start_method(module_name: str) -> Optional[str]:
+    """One module's start method. Raises if the module cannot be read at all.
+
+    Observing must not mutate: ``get_start_method(allow_none = False)`` pins
+    ``_actual_context``, which would make a later ``set_start_method()`` raise.
+    """
+    module = __import__(module_name)
+    method = module.get_start_method(allow_none = True)
+    if method is None:
+        method = _unpinned_default_start_method(module)
+    return method
+
+
 def multiprocessing_start_method() -> Optional[str]:
     """Return the start method ``datasets`` will actually use, or None.
 
     ``datasets.arrow_dataset`` does ``from multiprocess import Pool``, so
     ``multiprocess`` -- not stdlib ``multiprocessing`` -- decides how
-    ``Dataset.map(num_proc = ...)`` spawns workers; falls back to the stdlib
-    module, then to None (forking then treated as unavailable).
-
-    Observing must not mutate: ``get_start_method(allow_none = False)`` pins
-    ``_actual_context``, making a later ``set_start_method()`` raise. So ask with
-    ``allow_none = True``, then see ``_unpinned_default_start_method``.
+    ``Dataset.map(num_proc = ...)`` spawns workers. Falls back to the stdlib
+    module, then to None (the caller then treats forking as unavailable).
     """
     for module_name in ("multiprocess", "multiprocessing"):
         try:
-            module = __import__(module_name)
-            method = module.get_start_method(allow_none = True)
-            if method is None:
-                method = _unpinned_default_start_method(module)
-            return method
+            return _module_start_method(module_name)
         except Exception:
             continue
     return None
@@ -160,9 +163,10 @@ def _workers_unusable_reason() -> Optional[str]:
     * **macOS, whatever the start method says.** CPython moved the macOS default
       to ``spawn`` in 3.8 (bpo-33725) because forking there "can lead to crashes
       of the subprocess as macOS system libraries may start threads".
-      ``multiprocess`` never copied that, so ``datasets`` really does fork on
-      macOS out of a parent already holding Torch and a threaded BLAS. So macOS
-      stays in-process as stated policy, not as a side effect of the probe.
+      ``multiprocess`` never copied that, so ``datasets`` genuinely forks on
+      macOS out of a parent holding Torch and a threaded BLAS. Reporting that
+      truthfully is right; acting on it is not, so macOS stays in-process as a
+      stated policy rather than as a side effect of the probe.
     """
     start_method = multiprocessing_start_method()
     if start_method != "fork":
@@ -172,12 +176,89 @@ def _workers_unusable_reason() -> Optional[str]:
     return None
 
 
-def _affordable_workers() -> Optional[int]:
-    """How many workers free RAM can cover, or None when it cannot be read."""
+def _cgroup_limits() -> "tuple[Optional[int], Optional[float]]":
+    """This process's cgroup memory ceiling in bytes and CPU ceiling in cores.
+
+    ``(None, None)`` off Linux or outside a container. Reuses the readers in
+    ``hf_xet_tuning`` rather than parsing ``/sys/fs/cgroup`` again: they already
+    handle v1 against v2, the ``/proc/self/cgroup`` path walk and the "unlimited"
+    sentinels. Imported lazily, so this module still loads on its own.
+    """
+    try:
+        from unsloth_zoo.hf_xet_tuning import cgroup_cpu_limit, cgroup_memory_limit
+        return cgroup_memory_limit(), cgroup_cpu_limit()
+    except Exception:
+        return None, None
+
+
+def _cgroup_memory_used() -> Optional[int]:
+    """Bytes this cgroup is already using, or None when that cannot be read.
+
+    Only the well-known roots: runc bind-mounts the container's own cgroup there,
+    which is the case this exists for. Without it the whole limit would look free
+    on a container that has already spent most of it.
+    """
+    for path in ("/sys/fs/cgroup/memory.current", "/sys/fs/cgroup/memory/memory.usage_in_bytes"):
+        try:
+            with open(path, "r") as handle:
+                return int(handle.readline().strip())
+        except Exception:
+            continue
+    return None
+
+
+def _available_memory_gb() -> Optional[float]:
+    """Free RAM this process may actually use, or None when it cannot be read.
+
+    ``psutil.virtual_memory().available`` reports the HOST inside a container, so
+    a 2GB pod on a 512GB box read as having room for the full worker set and got
+    OOM-killed -- the exact failure the memory ceiling exists to prevent.
+    """
     try:
         import psutil
         available_gb = psutil.virtual_memory().available / (1024**3)
     except Exception:
+        return None
+
+    limit, _ = _cgroup_limits()
+    if limit is not None:
+        used = _cgroup_memory_used()
+        free = limit - used if used is not None else limit
+        available_gb = min(available_gb, max(free, 0) / (1024**3))
+    return available_gb
+
+
+def _usable_cpus() -> Optional[int]:
+    """CPUs this process may actually run on, or None when that cannot be read.
+
+    ``cpu_count()`` is the host's, so under ``taskset``, Slurm pinning or a
+    Kubernetes CPU quota a one-core job would auto-size workers that then contend
+    for that one core, making tokenization slower than doing it in-process.
+    """
+    try:
+        import psutil
+        cpus = psutil.cpu_count()
+    except Exception:
+        cpus = os.cpu_count()
+    if not cpus:
+        return None
+
+    try:
+        cpus = min(cpus, len(os.sched_getaffinity(0)))
+    except (AttributeError, OSError):
+        pass  # not Linux, or the call is unavailable: the host count stands
+
+    _, quota = _cgroup_limits()
+    if quota is not None and quota > 0:
+        # A fractional quota still binds: Kubernetes "cpu: 500m" is 0.5 cores.
+        cpus = min(cpus, max(1, int(quota)))
+    return cpus
+
+
+def _affordable_workers() -> Optional[int]:
+    """How many workers free RAM can cover, or None when it cannot be read."""
+    available_gb = _available_memory_gb()
+    if available_gb is None:
         return None
     budget_gb = available_gb * MEMORY_BUDGET_FRACTION
     return int(budget_gb / WORKER_MEMORY_BUDGET_GB)
@@ -186,14 +267,14 @@ def _affordable_workers() -> Optional[int]:
 def _clamp_by_memory(num_proc: int) -> Optional[int]:
     """Bound a worker count by RAM. None means "do not use workers at all".
 
-    Applies to explicit counts too. The old heuristic capped only the auto path,
+    Applies to explicit counts too: the old heuristic capped only the auto path,
     so a caller passing a number (Studio passes ``max(1, cpu_count // 4)``) could
     ask for dozens of workers on a machine with no room. That is what OOMs.
     """
     affordable = _affordable_workers()
     if affordable is None:
-        # No psutil, so no memory reading. Honour the request rather than
-        # serialising a machine that may be perfectly capable.
+        # No memory reading, so honour the request rather than serialising a
+        # machine that may be perfectly capable.
         return num_proc
 
     if affordable < 2:
@@ -219,13 +300,19 @@ def _clamp_by_memory(num_proc: int) -> Optional[int]:
 def _auto_num_proc() -> Optional[int]:
     """Worker count to use when the caller did not ask for a specific one."""
     try:
-        import psutil
-        cpu_count = psutil.cpu_count() or 1
+        import psutil  # noqa: F401  the memory clamp below needs it to mean anything
     except Exception:
-        # No psutil means no CPU reading; stay conservative.
+        # No psutil means no memory reading; stay conservative.
         return None
 
-    return _clamp_by_memory(min(max(cpu_count // 2, 2), AUTO_NUM_PROC_CAP))
+    cpus = _usable_cpus()
+    if cpus is None:
+        return None
+    if cpus <= 1:
+        # Workers would only contend for the single core they are pinned to.
+        return None
+
+    return _clamp_by_memory(min(max(cpus // 2, 2), AUTO_NUM_PROC_CAP))
 
 
 def _serial(serial_as_none: bool) -> Optional[int]:
@@ -233,15 +320,15 @@ def _serial(serial_as_none: bool) -> Optional[int]:
 
     At a ``map()`` call site that is ``None``, the only value ``datasets`` runs
     in-process on every supported release. At the *config* layer it is ``1``,
-    since a config ``None`` reads downstream as "auto-size me" and would inflate
-    a serial request; the call site turns that ``1`` back into ``None``.
+    because a config ``None`` is read downstream as "auto-size me" and would
+    inflate a serial request; the call site turns that ``1`` back into ``None``.
 
-    Only while workers are usable, hence the ``_workers_unusable_reason`` check.
-    Where they are not, nothing can inflate a config ``None`` -- every auto-sizer
-    vetoes too -- while ``1`` is unsafe: only the SFT map site is rewritten by
-    ``rl_replacements.py``, and TRL's DPO, KTO, CPO, ORPO, Reward and PRM
-    trainers hand ``args.dataset_num_proc`` straight to ``Dataset.map``, whose
-    ``Pool(1)`` child re-imports the user's ``__main__`` (#3211 / #3397).
+    That only holds while workers are usable, hence the veto check. Where they
+    are not, nothing can inflate a config ``None`` -- every auto-sizer that reads
+    it vetoes too -- while ``1`` is unsafe, since only the SFT map site is
+    rewritten by ``rl_replacements.py``: TRL's DPO, KTO, CPO, ORPO, Reward and
+    PRM trainers hand ``args.dataset_num_proc`` straight to ``Dataset.map``,
+    whose ``Pool(1)`` child re-imports the user's ``__main__`` (#3211 / #3397).
     """
     if serial_as_none:
         return None
@@ -292,8 +379,9 @@ def get_dataset_num_proc(
         desired: The worker count the caller asked for, or None to auto-size.
         serial_as_none: How to encode "run in-process". True at a ``map()`` call
             site, yielding ``None``. **False when writing back to a config**,
-            yielding ``1``, since ``unsloth_zoo.sft_prepare_dataset`` reads a
-            config ``None`` as "auto-size me" and would inflate a user's ``1``.
+            yielding ``1``, because downstream readers
+            (``dataset_utils.sft_prepare_dataset``) treat a config ``None`` as
+            "auto-size me" and would inflate a user's ``1``.
 
     Returns:
         A worker count >= 2, or this layer's in-process sentinel (``None`` at a
@@ -303,14 +391,13 @@ def get_dataset_num_proc(
     #    so a user who knows their workload is fork-safe is never downgraded.
     env_set, env_value = _from_environment()
     if env_set:
-        # A bare None written into a *config* reads downstream as "auto-size me",
-        # so UNSLOTH_DATASET_NUM_PROC=0 would inflate the count instead of
-        # removing it -- and that is the hatch the dead-worker message names.
+        # In-process still has to be encoded for this layer, or
+        # UNSLOTH_DATASET_NUM_PROC=0 -- the hatch the dead-worker message
+        # recommends -- would inflate a config instead of removing workers.
         return _serial(serial_as_none) if env_value is None else env_value
 
-    # 2. Under spawn/forkserver the child cannot re-import the dynamically
-    #    generated trainer module, so workers are unusable whatever was asked.
-    #    macOS is refused for a separate reason; see `_workers_unusable_reason`.
+    # 2. Workers are unusable whatever was requested; see
+    #    `_workers_unusable_reason` for the two refusals.
     unusable = _workers_unusable_reason()
     if unusable is not None:
         if isinstance(desired, int) and not isinstance(desired, bool) and desired > 1:
@@ -339,9 +426,9 @@ def get_dataset_num_proc(
     return num_proc
 
 
-# The message datasets raises when a pool worker dies. It compares pool PIDs and
-# never reads the child's exit status, so an OOM kill, a segfault and a genuine
-# exception all arrive as this one string -- which is why #2693 looks untraceable.
+# The message datasets raises when a pool worker dies. It never reads the child's
+# exit status, so an OOM kill, a segfault and a genuine exception all arrive as
+# this one string -- which is why #2693 looks untraceable.
 _WORKER_DIED = "subprocesses has abruptly died"
 
 
@@ -349,9 +436,8 @@ _WORKER_DIED = "subprocesses has abruptly died"
 def map_failure_diagnostics(num_proc: Optional[int]) -> "Iterator[None]":
     """Re-raise a dead-worker error from ``Dataset.map`` with usable context.
 
-    Names the start method, the worker count and roughly what they cost, so an
-    out-of-memory kill can be told apart from anything else -- none of which
-    survives the original message. The cause is chained.
+    Names the start method, the worker count and roughly what they cost, none of
+    which survives the original message. The cause is chained.
     """
     try:
         yield
@@ -379,13 +465,13 @@ def map_failure_diagnostics(num_proc: Optional[int]) -> "Iterator[None]":
 
 
 def _largest_split_rows(trainer) -> Optional[int]:
-    """Rows in the biggest *sized* split ``train_on_responses_only`` maps over.
+    """Rows in the biggest *sized* split ``train_on_responses_only`` will map over.
 
-    None only when no split has a readable length. An unsized split is skipped
-    rather than abandoning the measurement: the Zoo sizes per split and an
-    unsized one can never use workers anyway, so letting it hide a large sized
-    sibling left that sibling on the Zoo's uncapped auto count. ``eval_dataset``
-    may be a dict of named splits, so unpack that too.
+    None only when no split has a readable length at all. Unsized splits are
+    skipped rather than abandoning the measurement, since sizing is per split and
+    an unsized one can never use workers anyway; letting one hide a large sized
+    sibling left that sibling on the uncapped auto count. ``eval_dataset`` may be
+    a dict of named splits, so unpack that too.
     """
     if trainer is None:
         return None
@@ -403,53 +489,88 @@ def _largest_split_rows(trainer) -> Optional[int]:
             try:
                 rows = len(split)
             except Exception:
-                # The Zoo cannot parallelize this split either way, so skip it
-                # rather than let it mask a sized sibling that it would.
+                # Skip rather than let it mask a sized sibling.
                 continue
             measured = True
             largest = max(largest, rows)
     return largest if measured else None
 
 
+def _zoo_auto_sizer_forks() -> bool:
+    """Whether ``train_on_responses_only`` would pick workers for a bare ``None``.
+
+    Its auto path asks stdlib ``multiprocessing``, not ``multiprocess`` -- the
+    split this whole module is about. Where the two disagree, ``None`` is not
+    "serial" to it, it is "size it for me", and ``datasets`` then builds that pool
+    on the non-fork ``multiprocess`` context.
+    """
+    try:
+        return _module_start_method("multiprocessing") == "fork"
+    except Exception:
+        return False
+
+
+def _serial_for_the_zoo(value: Optional[int]) -> Optional[int]:
+    """Re-encode a serial ``None`` for a reader that decides on the other module.
+
+    ``None`` only means "no workers" to ``train_on_responses_only`` while its own
+    check refuses them too. When it would not, ``1`` is the smallest request it
+    honours verbatim: still a ``Pool(1)`` on ``datasets`` >= 4.1, but one child
+    instead of the ``cpu_count + 4`` its auto path would have chosen.
+    """
+    if value is not None or not _zoo_auto_sizer_forks():
+        return value
+    _warn_once(
+        "start_method_split",
+        "'multiprocess' and 'multiprocessing' disagree about the start method "
+        f"({multiprocessing_start_method()!r} against 'fork'), so "
+        "train_on_responses_only is being held to one worker rather than left to "
+        f"size itself. Set {NUM_PROC_ENV_VAR} to override.",
+    )
+    return 1
+
+
 def resolve_responses_only_num_proc(trainer, num_proc):
     """Bound the worker count ``train_on_responses_only`` hands to ``map()``.
 
-    ``unsloth_zoo.dataset_utils.train_on_responses_only`` still auto-sizes with
-    the uncapped ``min(max(cpu_count + 4, 2), 64)`` heuristic this module
-    replaces everywhere else -- the shape behind issue #2693. The Zoo is a
-    separate package, so the bound goes on from outside, and two properties of
-    its API constrain what can be expressed:
+    ``dataset_utils.train_on_responses_only`` still auto-sizes with the uncapped
+    ``min(max(cpu_count + 4, 2), 64)`` heuristic this module replaces everywhere
+    else -- the shape behind issue #2693. Until that copy is wired onto this
+    module the bound is applied from outside, and two properties of its API
+    constrain what can be expressed:
 
-    * **Serial is the config-layer sentinel, not the call-site one.** The Zoo
-      reads ``None`` as "size it for me", so on ``fork`` that would *inflate* the
-      count; ``1`` is the closest expressible request, and one ``Pool(1)`` worker
-      is not the OOM this guards against. Under spawn the trade flips -- a
-      ``Pool(1)`` child re-imports the user's ``__main__`` (#3211 / #3397) while
-      ``None`` is safe, the Zoo's auto path vetoing non-fork itself. That is
-      exactly what ``get_dataset_num_proc(..., serial_as_none = False)`` encodes.
-    * **An explicit count disables the Zoo's per-split small-split guard.** A
-      small eval split alongside a large train split then picks up workers it
-      would not have had: a second or two against tens of GB, worth it only when
-      a split is big enough for the Zoo to have parallelized at all, which is
-      what the row check below establishes.
+    * **Serial is the config-layer sentinel, not the call-site one.** That helper
+      reads ``None`` as "size it for me", so on ``fork`` handing it ``None``
+      would *inflate* the count rather than remove it; ``1`` is the closest
+      expressible request, and one forked worker is not the OOM this guards
+      against. Under spawn the trade flips -- each ``Pool(1)`` child re-imports
+      the user's ``__main__`` (#3211 / #3397), while ``None`` is safe because its
+      auto path vetoes non-fork itself. That is exactly what
+      ``serial_as_none = False`` encodes, so defer to it -- then re-check with
+      ``_serial_for_the_zoo``, since that veto reads the other module.
+    * **An explicit count disables its per-split small-split guard.** A small
+      eval split alongside a large train split then picks up workers it would not
+      have had: worth it only when a split is big enough to have been
+      parallelized at all, which is what the row check below establishes.
     """
-    # Mirror the Zoo's own test, so "explicit" means the same on both sides (it
-    # treats bools as auto, since type(True) is not int).
+    # Mirror that helper's own test, so "explicit" means the same on both sides
+    # (it treats bools as auto, since type(True) is not int).
     was_auto = num_proc is None or type(num_proc) is not int
 
     if not was_auto:
-        # Explicit counts already bypass the Zoo's small-split guard, so
-        # bounding one takes nothing away.
-        return get_dataset_num_proc(num_proc, serial_as_none = False)
+        # Explicit counts already bypass the small-split guard.
+        return _serial_for_the_zoo(get_dataset_num_proc(num_proc, serial_as_none = False))
 
     rows = _largest_split_rows(trainer)
     if rows is None or rows < ZOO_MIN_ROWS_FOR_MULTIPROC:
-        # The escape hatch must win here too, not be lost to this shortcut.
+        # The escape hatch must win here too.
         env_set, env_value = _from_environment()
         if env_set and env_value is not None:
             return env_value
-        # Otherwise the Zoo goes in-process anyway, via a None more in-process
-        # than the 1 expressible here, so leave the value for its guard.
+        # Otherwise it would have gone in-process anyway, and its guard yields
+        # None, which is more in-process than the 1 expressible here. Safe whatever
+        # the start method: every split here is under the threshold, so its own
+        # per-split guard serialises them all.
         return num_proc
 
-    return get_dataset_num_proc(None, serial_as_none = False)
+    return _serial_for_the_zoo(get_dataset_num_proc(None, serial_as_none = False))

--- a/unsloth/utils/dataset_num_proc.py
+++ b/unsloth/utils/dataset_num_proc.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import sys
 from typing import Iterator, Optional
 
 __all__ = [
@@ -107,6 +108,35 @@ def _warn_once(key: str, message: str) -> None:
     print(f"Unsloth: {message}")
 
 
+def _unpinned_default_start_method(module) -> Optional[str]:
+    """The default start method of a module that has not pinned one yet.
+
+    ``get_all_start_methods()`` documents its first element as the default, and
+    in the standard library it is. ``multiprocess`` copies that function
+    verbatim -- including the darwin branch that lists ``spawn`` first -- but
+    does **not** copy the darwin default that goes with it. Compare line 326 of
+    each ``context.py`` on macOS::
+
+        multiprocessing:  _default_context = DefaultContext(_concrete_contexts['spawn'])
+        multiprocess:     _default_context = DefaultContext(_concrete_contexts['fork'])  #FIXME: spawn
+
+    So on macOS ``multiprocess.get_all_start_methods()[0]`` says ``spawn`` while
+    ``multiprocess.Pool`` actually forks, and since ``datasets`` builds its pool
+    from ``multiprocess`` the list order is simply the wrong source. Read the
+    default context's own name instead. Unlike ``get_context()`` that does not
+    assign ``_actual_context``, so it keeps the no-side-effects property the
+    caller depends on. Private attributes, hence the fallback.
+    """
+    try:
+        name = module.context._default_context._default_context._name
+        if isinstance(name, str) and name:
+            return name
+    except Exception:
+        pass
+    methods = module.get_all_start_methods()
+    return methods[0] if methods else None
+
+
 def multiprocessing_start_method() -> Optional[str]:
     """Return the start method ``datasets`` will actually use, or None.
 
@@ -119,19 +149,46 @@ def multiprocessing_start_method() -> Optional[str]:
     Observing must not mutate: ``get_start_method(allow_none = False)`` pins
     ``_actual_context`` as a side effect, which would make a later
     ``set_start_method()`` raise. So ask with ``allow_none = True`` and, when
-    nothing has been pinned yet, read the platform default off
-    ``get_all_start_methods()``, whose first element is documented to be it.
+    nothing has been pinned yet, read the platform default off the module's own
+    default context (see ``_unpinned_default_start_method``).
     """
     for module_name in ("multiprocess", "multiprocessing"):
         try:
             module = __import__(module_name)
             method = module.get_start_method(allow_none = True)
             if method is None:
-                methods = module.get_all_start_methods()
-                method = methods[0] if methods else None
+                method = _unpinned_default_start_method(module)
             return method
         except Exception:
             continue
+    return None
+
+
+def _workers_unusable_reason() -> Optional[str]:
+    """Why ``datasets`` workers cannot be used here, or None when they can.
+
+    Two independent refusals, kept apart because they have different causes and
+    only one of them is a property of the start method:
+
+    * **Not ``fork``.** The child receives the tokenizer closure through a dill
+      pickle and must re-import the dynamically generated trainer module, which
+      is not importable by name, so a worker cannot come up at all.
+
+    * **macOS, whatever the start method says.** CPython moved the macOS default
+      from ``fork`` to ``spawn`` in 3.8 (bpo-33725) because "the fork start
+      method should be considered unsafe as it can lead to crashes of the
+      subprocess as macOS system libraries may start threads". ``multiprocess``
+      never copied that change -- see ``_unpinned_default_start_method`` -- so
+      ``datasets`` genuinely does fork on macOS, out of a parent that has
+      already loaded Torch and its threaded BLAS. Reporting that truthfully is
+      right; acting on it is not, so macOS stays in-process as a stated policy
+      rather than as a side effect of a probe that happened to read ``spawn``.
+    """
+    start_method = multiprocessing_start_method()
+    if start_method != "fork":
+        return f"this process uses the {start_method!r} start method"
+    if sys.platform == "darwin":
+        return "'multiprocess' forks on macOS, which CPython documents as unsafe there (bpo-33725)"
     return None
 
 
@@ -201,11 +258,13 @@ def _serial(serial_as_none: bool) -> Optional[int]:
     ``None`` there would inflate a serial request back up to the auto worker
     count. The call site then turns that ``1`` into ``None``.
 
-    That reasoning only holds while forking is available, so the config sentinel
-    is conditioned on it. Under spawn/forkserver nothing can inflate a config
-    ``None``: every auto-sizer that reads it vetoes on a non-fork start method
-    too (this module at step 2 below, and ``unsloth_zoo.sft_prepare_dataset``'s
-    own copy). Meanwhile ``1`` is actively unsafe there, because only the SFT
+    That reasoning only holds while workers are usable at all, so the config
+    sentinel is conditioned on ``_workers_unusable_reason``. Where they are not,
+    nothing can inflate a config ``None``: every auto-sizer that reads it vetoes
+    as well (this module at step 2 below, and the three copies in
+    ``unsloth_zoo.dataset_utils``, which read stdlib ``multiprocessing`` and so
+    see ``spawn`` on both Windows and macOS). Meanwhile ``1`` is unsafe there,
+    because only the SFT
     map site is rewritten by ``rl_replacements.py`` -- TRL's DPO, KTO, CPO,
     ORPO, Reward and PRM trainers hand ``args.dataset_num_proc`` straight to
     ``Dataset.map``, where ``datasets`` >= 4.1 turns ``1`` into a ``Pool(1)``
@@ -216,7 +275,7 @@ def _serial(serial_as_none: bool) -> Optional[int]:
     """
     if serial_as_none:
         return None
-    return 1 if multiprocessing_start_method() == "fork" else None
+    return None if _workers_unusable_reason() is not None else 1
 
 
 def _from_environment() -> "tuple[bool, Optional[int]]":
@@ -291,16 +350,16 @@ def get_dataset_num_proc(
     # 2. `datasets` workers receive the tokenizer closure through a dill pickle
     #    over a pipe. Under spawn/forkserver the child must also re-import the
     #    dynamically generated trainer module, which is not importable by name,
-    #    so multiprocessing is unusable regardless of what was requested.
-    start_method = multiprocessing_start_method()
-    if start_method != "fork":
+    #    so multiprocessing is unusable regardless of what was requested. macOS
+    #    is refused for a separate reason -- see `_workers_unusable_reason`.
+    unusable = _workers_unusable_reason()
+    if unusable is not None:
         if isinstance(desired, int) and not isinstance(desired, bool) and desired > 1:
             _warn_once(
                 "start_method",
-                f"dataset_num_proc = {desired} needs the 'fork' start method, "
-                f"but this process uses {start_method!r}. Falling back to "
-                f"single-process tokenization. Set {NUM_PROC_ENV_VAR} to "
-                f"override.",
+                f"dataset_num_proc = {desired} cannot be used because "
+                f"{unusable}. Falling back to single-process tokenization. "
+                f"Set {NUM_PROC_ENV_VAR} to override.",
             )
         return _serial(serial_as_none)
 
@@ -408,12 +467,19 @@ def resolve_responses_only_num_proc(trainer, num_proc):
 
     Two properties of the Zoo's API constrain what can be expressed here:
 
-    * **None cannot mean "in-process".** The Zoo reads ``None`` as "size it for
-      me", so handing it the ``None`` that means serial elsewhere in this module
-      would *inflate* the count to the auto value instead of removing it. ``1``
-      is the closest expressible request. It still builds a ``Pool(1)`` on
-      ``datasets`` >= 4.1, which cannot be fixed without changing the Zoo, but
-      one worker is not the out-of-memory failure this guards against.
+    * **Serial is the config-layer sentinel, not the call-site one.** The Zoo
+      reads ``None`` as "size it for me", so on ``fork`` handing it the ``None``
+      that means serial at a ``map()`` call site would *inflate* the count to the
+      auto value instead of removing it; ``1`` is the closest expressible
+      request there. It still builds a ``Pool(1)`` on ``datasets`` >= 4.1, which
+      cannot be fixed without changing the Zoo, but one forked worker is not the
+      out-of-memory failure this guards against. Under spawn/forkserver that
+      trade flips: ``1`` is the *worse* value, because each ``Pool(1)`` child
+      re-imports the user's ``__main__`` (the spawn loops in #3211 / #3397),
+      while ``None`` is safe -- the Zoo's auto path vetoes on a non-fork start
+      method of its own accord and ends up in-process. That is exactly the
+      distinction ``get_dataset_num_proc(..., serial_as_none = False)`` encodes,
+      so this function defers to it rather than mapping serial to ``1`` by hand.
     * **An explicit count disables the Zoo's small-split guard**, which it
       applies per split. A trainer with a large train split and a small eval
       split would see the eval map pick up workers it would not have had. That
@@ -429,8 +495,7 @@ def resolve_responses_only_num_proc(trainer, num_proc):
     if not was_auto:
         # Explicit counts already bypass the Zoo's small-split guard, so
         # bounding one takes nothing away that the caller had.
-        bounded = get_dataset_num_proc(num_proc)
-        return 1 if bounded is None else bounded
+        return get_dataset_num_proc(num_proc, serial_as_none = False)
 
     rows = _largest_split_rows(trainer)
     if rows is None or rows < ZOO_MIN_ROWS_FOR_MULTIPROC:
@@ -446,5 +511,4 @@ def resolve_responses_only_num_proc(trainer, num_proc):
         # a count that would switch multiprocessing back on for a small split.
         return num_proc
 
-    bounded = get_dataset_num_proc(None)
-    return 1 if bounded is None else bounded
+    return get_dataset_num_proc(None, serial_as_none = False)

--- a/unsloth/utils/dataset_num_proc.py
+++ b/unsloth/utils/dataset_num_proc.py
@@ -43,10 +43,12 @@ __all__ = [
     "MEMORY_BUDGET_FRACTION",
     "NUM_PROC_ENV_VAR",
     "WORKER_MEMORY_BUDGET_GB",
+    "ZOO_MIN_ROWS_FOR_MULTIPROC",
     "get_dataset_num_proc",
     "map_failure_diagnostics",
     "multiprocessing_start_method",
     "reset_warning_state",
+    "resolve_responses_only_num_proc",
 ]
 
 # Environment escape hatch. Set to a positive integer to force that worker count
@@ -78,6 +80,16 @@ WORKER_MEMORY_BUDGET_GB = 1.0
 # has abruptly died during map operation" with the real cause discarded
 # (datasets/utils/py_utils.py compares pool PIDs and never reads exit status).
 MEMORY_BUDGET_FRACTION = 0.5
+
+# Mirrors _MIN_ROWS_FOR_MULTIPROC in unsloth_zoo.dataset_utils.
+# train_on_responses_only. Below this it runs a split in-process, because the
+# workers cost more than they save -- but only when it picked the worker count
+# itself; an explicit count skips that guard. resolve_responses_only_num_proc
+# has to know the threshold to avoid taking the guard away. It cannot be
+# imported: it is a local inside the Zoo function, so the duplication is
+# unavoidable and a canary in tests/utils/test_dataset_num_proc.py fails if the
+# Zoo ever moves it.
+ZOO_MIN_ROWS_FOR_MULTIPROC = 5_000
 
 # Warn at most once per process per distinct reason, so a script that builds
 # several configs does not print the same line repeatedly.
@@ -332,3 +344,81 @@ def map_failure_diagnostics(num_proc: Optional[int]) -> "Iterator[None]":
             f"count with {NUM_PROC_ENV_VAR}=<n>.\n"
             f"  Original error: {exception}"
         ) from exception
+
+
+def _largest_split_rows(trainer) -> Optional[int]:
+    """Rows in the biggest split ``train_on_responses_only`` will map over.
+
+    Returns None when any split's size is unknown, matching the Zoo, which
+    treats an unsized dataset (an ``IterableDataset``) as "do not parallelize".
+    ``eval_dataset`` may be a dict of named splits, so unpack that too.
+    """
+    if trainer is None:
+        return None
+
+    largest = 0
+    measured = False
+    for attribute in ("train_dataset", "eval_dataset"):
+        dataset = getattr(trainer, attribute, None)
+        if dataset is None:
+            continue
+        splits = list(dataset.values()) if isinstance(dataset, dict) else [dataset]
+        for split in splits:
+            if split is None:
+                continue
+            try:
+                rows = len(split)
+            except Exception:
+                # Unsized, or a length that raises. Either way the Zoo would not
+                # have parallelized it, so say so rather than guessing.
+                return None
+            measured = True
+            largest = max(largest, rows)
+    return largest if measured else None
+
+
+def resolve_responses_only_num_proc(trainer, num_proc):
+    """Bound the worker count ``train_on_responses_only`` hands to ``map()``.
+
+    ``unsloth_zoo.dataset_utils.train_on_responses_only`` still computes its own
+    count with the uncapped ``min(max(cpu_count + 4, 2), 64)`` heuristic this
+    module replaces everywhere else, so on a large host it forks dozens of
+    workers that each receive a dill-pickled tokenizer closure. That is the
+    shape behind issue #2693, and this function is what keeps it bounded. The
+    Zoo is a separate package, so the fix has to work from the outside.
+
+    Two properties of the Zoo's API constrain what can be expressed here:
+
+    * **None cannot mean "in-process".** The Zoo reads ``None`` as "size it for
+      me", so handing it the ``None`` that means serial elsewhere in this module
+      would *inflate* the count to the auto value instead of removing it. ``1``
+      is the closest expressible request. It still builds a ``Pool(1)`` on
+      ``datasets`` >= 4.0, which cannot be fixed without changing the Zoo, but
+      one worker is not the out-of-memory failure this guards against.
+    * **An explicit count disables the Zoo's small-split guard**, which it
+      applies per split. A trainer with a large train split and a small eval
+      split would see the eval map pick up workers it would not have had. That
+      is a second or two on the small split against tens of GB on the large one,
+      so it is worth it -- but only when a split is actually big enough for the
+      Zoo to have parallelized in the first place, which is what the row check
+      below establishes.
+    """
+    # Mirror the Zoo's own test exactly (bools are not ints by this rule, and it
+    # treats them as auto), so "explicit" means the same thing on both sides.
+    was_auto = num_proc is None or type(num_proc) is not int
+
+    if not was_auto:
+        # Explicit counts already bypass the Zoo's small-split guard, so
+        # bounding one takes nothing away that the caller had.
+        bounded = get_dataset_num_proc(num_proc)
+        return 1 if bounded is None else bounded
+
+    rows = _largest_split_rows(trainer)
+    if rows is None or rows < ZOO_MIN_ROWS_FOR_MULTIPROC:
+        # The Zoo would have gone in-process anyway. Leave the value untouched
+        # so its guard keeps deciding, rather than substituting a count that
+        # would switch multiprocessing back on for a small split.
+        return num_proc
+
+    bounded = get_dataset_num_proc(None)
+    return 1 if bounded is None else bounded

--- a/unsloth/utils/dataset_num_proc.py
+++ b/unsloth/utils/dataset_num_proc.py
@@ -128,12 +128,22 @@ def _unpinned_default_start_method(module) -> Optional[str]:
     caller depends on. Private attributes, hence the fallback.
     """
     try:
+        methods = module.get_all_start_methods()
+    except Exception:
+        methods = []
+
+    try:
         name = module.context._default_context._default_context._name
-        if isinstance(name, str) and name:
+        # Only if it is actually available here. These are private attributes and
+        # they are not consistent across builds: on a Windows runner this chain
+        # answered 'fork' while get_all_start_methods() was ['spawn'], and a
+        # start method the platform does not offer cannot be the one in use.
+        # Believing it would have read Windows as forkable and let workers
+        # through, which is the spawn re-import loop of #3211 / #3397.
+        if isinstance(name, str) and name and (not methods or name in methods):
             return name
     except Exception:
         pass
-    methods = module.get_all_start_methods()
     return methods[0] if methods else None
 
 

--- a/unsloth/utils/dataset_num_proc.py
+++ b/unsloth/utils/dataset_num_proc.py
@@ -413,8 +413,11 @@ def map_failure_diagnostics(num_proc: Optional[int]) -> "Iterator[None]":
             f"  Each worker holds its own copy of the tokenizer and its dataset "
             f"shard, so this run needed roughly {estimated_gb:g}GB on top of the "
             f"model. The most common cause is the out-of-memory killer.\n"
-            f"  Tokenize in-process with {NUM_PROC_ENV_VAR}=0, or pick a worker "
-            f"count with {NUM_PROC_ENV_VAR}=<n>.\n"
+            f"  Retry with {NUM_PROC_ENV_VAR}=0 for the fewest workers this path "
+            f"can use, or {NUM_PROC_ENV_VAR}=<n> to choose a count. That is "
+            f"in-process everywhere except train_on_responses_only on a split "
+            f"over {ZOO_MIN_ROWS_FOR_MULTIPROC:,} rows, where it is one worker: "
+            f"the Zoo reads a bare None there as 'size it for me'.\n"
             f"  Original error: {exception}"
         ) from exception
 

--- a/unsloth/utils/dataset_num_proc.py
+++ b/unsloth/utils/dataset_num_proc.py
@@ -1,17 +1,16 @@
-# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Lesser General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# You should have received a copy of the GNU Lesser General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Single source of truth for the ``dataset_num_proc`` used by ``Dataset.map()``.
 
@@ -201,8 +200,23 @@ def _serial(serial_as_none: bool) -> Optional[int]:
     because a config ``None`` is read downstream as "auto-size me" -- writing
     ``None`` there would inflate a serial request back up to the auto worker
     count. The call site then turns that ``1`` into ``None``.
+
+    That reasoning only holds while forking is available, so the config sentinel
+    is conditioned on it. Under spawn/forkserver nothing can inflate a config
+    ``None``: every auto-sizer that reads it vetoes on a non-fork start method
+    too (this module at step 2 below, and ``unsloth_zoo.sft_prepare_dataset``'s
+    own copy). Meanwhile ``1`` is actively unsafe there, because only the SFT
+    map site is rewritten by ``rl_replacements.py`` -- TRL's DPO, KTO, CPO,
+    ORPO, Reward and PRM trainers hand ``args.dataset_num_proc`` straight to
+    ``Dataset.map``, where ``datasets`` >= 4.1 turns ``1`` into a ``Pool(1)``
+    and each spawned child re-imports the user's ``__main__`` (the Windows
+    spawn loops in unsloth #3211 / #3397). ``None`` is what those configs
+    carried before this module existed, and it is the only value that builds no
+    pool at all.
     """
-    return None if serial_as_none else 1
+    if serial_as_none:
+        return None
+    return 1 if multiprocessing_start_method() == "fork" else None
 
 
 def _from_environment() -> "tuple[bool, Optional[int]]":
@@ -291,7 +305,7 @@ def get_dataset_num_proc(
         return _serial(serial_as_none)
 
     # 3. Normalise the "no multiprocessing" requests. `1` in particular is a
-    #    trap: callers pass it meaning "serial", and datasets >= 4.0 hands them
+    #    trap: callers pass it meaning "serial", and datasets >= 4.1 hands them
     #    a Pool(1) instead. Nothing to clamp here, so return straight away.
     if isinstance(desired, int) and not isinstance(desired, bool) and desired <= 1:
         return _serial(serial_as_none)
@@ -347,11 +361,15 @@ def map_failure_diagnostics(num_proc: Optional[int]) -> "Iterator[None]":
 
 
 def _largest_split_rows(trainer) -> Optional[int]:
-    """Rows in the biggest split ``train_on_responses_only`` will map over.
+    """Rows in the biggest *sized* split ``train_on_responses_only`` will map over.
 
-    Returns None when any split's size is unknown, matching the Zoo, which
-    treats an unsized dataset (an ``IterableDataset``) as "do not parallelize".
-    ``eval_dataset`` may be a dict of named splits, so unpack that too.
+    Returns None only when no split has a readable length at all. An unsized
+    split is skipped rather than abandoning the whole measurement: the Zoo picks
+    a worker count per split, and an unsized one can never use workers whatever
+    it is handed (its ``IterableDataset`` branch passes no ``num_proc``, and
+    ``_effective_num_proc`` returns None when ``len()`` raises). Letting one hide
+    a large sized sibling is what left that sibling on the Zoo's uncapped auto
+    count. ``eval_dataset`` may be a dict of named splits, so unpack that too.
     """
     if trainer is None:
         return None
@@ -369,9 +387,10 @@ def _largest_split_rows(trainer) -> Optional[int]:
             try:
                 rows = len(split)
             except Exception:
-                # Unsized, or a length that raises. Either way the Zoo would not
-                # have parallelized it, so say so rather than guessing.
-                return None
+                # Unsized, or a length that raises. The Zoo cannot parallelize
+                # this split either way, so skip it -- do not let it mask a
+                # sized sibling that the Zoo *would* parallelize.
+                continue
             measured = True
             largest = max(largest, rows)
     return largest if measured else None
@@ -393,7 +412,7 @@ def resolve_responses_only_num_proc(trainer, num_proc):
       me", so handing it the ``None`` that means serial elsewhere in this module
       would *inflate* the count to the auto value instead of removing it. ``1``
       is the closest expressible request. It still builds a ``Pool(1)`` on
-      ``datasets`` >= 4.0, which cannot be fixed without changing the Zoo, but
+      ``datasets`` >= 4.1, which cannot be fixed without changing the Zoo, but
       one worker is not the out-of-memory failure this guards against.
     * **An explicit count disables the Zoo's small-split guard**, which it
       applies per split. A trainer with a large train split and a small eval
@@ -415,9 +434,16 @@ def resolve_responses_only_num_proc(trainer, num_proc):
 
     rows = _largest_split_rows(trainer)
     if rows is None or rows < ZOO_MIN_ROWS_FOR_MULTIPROC:
-        # The Zoo would have gone in-process anyway. Leave the value untouched
-        # so its guard keeps deciding, rather than substituting a count that
-        # would switch multiprocessing back on for a small split.
+        # An explicit escape hatch has to win here too, or the count the user
+        # asked for is dropped on the floor by a shortcut they cannot see.
+        env_set, env_value = _from_environment()
+        if env_set and env_value is not None:
+            return env_value
+        # Otherwise the Zoo would have gone in-process anyway (that is also what
+        # UNSLOTH_DATASET_NUM_PROC=0 asks for, and its guard yields None, which
+        # is more in-process than the 1 this function can express). Leave the
+        # value untouched so its guard keeps deciding, rather than substituting
+        # a count that would switch multiprocessing back on for a small split.
         return num_proc
 
     bounded = get_dataset_num_proc(None)

--- a/unsloth/utils/dataset_num_proc.py
+++ b/unsloth/utils/dataset_num_proc.py
@@ -128,8 +128,7 @@ def _affordable_workers() -> Optional[int]:
     """How many workers free RAM can cover, or None when it cannot be read."""
     try:
         import psutil
-
-        available_gb = psutil.virtual_memory().available / (1024 ** 3)
+        available_gb = psutil.virtual_memory().available / (1024**3)
     except Exception:
         return None
     budget_gb = available_gb * MEMORY_BUDGET_FRACTION
@@ -174,7 +173,6 @@ def _auto_num_proc() -> Optional[int]:
     """Worker count to use when the caller did not ask for a specific one."""
     try:
         import psutil
-
         cpu_count = psutil.cpu_count() or 1
     except Exception:
         # No psutil means no CPU reading; stay conservative rather than guessing.
@@ -226,9 +224,7 @@ def _from_environment() -> "tuple[bool, Optional[int]]":
 
 
 def get_dataset_num_proc(
-    desired: Optional[int] = None,
-    *,
-    serial_as_none: bool = True,
+    desired: Optional[int] = None, *, serial_as_none: bool = True
 ) -> Optional[int]:
     """Return a safe ``num_proc`` for ``Dataset.map()`` / ``Dataset.filter()``.
 

--- a/unsloth/utils/dataset_num_proc.py
+++ b/unsloth/utils/dataset_num_proc.py
@@ -14,21 +14,18 @@
 
 """Single source of truth for the ``dataset_num_proc`` used by ``Dataset.map()``.
 
-This used to be four copies of the same heuristic pasted into generated trainer
-source (``unsloth/models/rl.py``) and into ``unsloth_zoo.dataset_utils``. They
-drifted, and two of the copies were wrong in ways that produced the crash in
-https://github.com/unslothai/unsloth/issues/2693:
+Replaces four drifted copies of the same heuristic (generated trainer source in
+``unsloth/models/rl.py``, plus ``unsloth_zoo.dataset_utils``), two of which were
+wrong in ways that produced https://github.com/unslothai/unsloth/issues/2693:
 
 1. They asked ``multiprocessing.get_start_method()`` whether forking was
-   available. ``datasets`` does not use ``multiprocessing`` -- ``Dataset.map``
-   imports ``Pool`` from ``multiprocess`` (the dill fork), which keeps its own
-   independent default context. Setting the stdlib start method therefore told
-   the guard one thing while ``datasets`` did another.
+   available, but ``Dataset.map`` imports ``Pool`` from ``multiprocess`` (the
+   dill fork), which keeps its own independent default context. The guard and
+   ``datasets`` were reading different settings.
 
-2. They used ``1`` as the "disable multiprocessing" sentinel. That is only true
-   on older ``datasets``. On ``datasets`` 4.3.0 (the Studio pin) ``map()`` takes
-   the pool branch for any ``num_proc >= 1``, so ``num_proc = 1`` still forks a
-   ``Pool(1)``. Only ``None`` is in-process on every supported version.
+2. They used ``1`` as the "disable multiprocessing" sentinel. On ``datasets``
+   >= 4.1 (Studio pins 4.3.0) ``map()`` takes the pool branch for any
+   ``num_proc >= 1``, so only ``None`` is in-process on every supported version.
 """
 
 from __future__ import annotations
@@ -51,48 +48,35 @@ __all__ = [
     "resolve_responses_only_num_proc",
 ]
 
-# Environment escape hatch. Set to a positive integer to force that worker count
-# verbatim (no capping, no start-method veto), or to "0"/"none" to force
-# in-process tokenization. Deliberate power users are never silently overridden.
+# Escape hatch: a positive integer forces that count verbatim (no cap, no
+# start-method veto), "0"/"none" forces in-process tokenization.
 NUM_PROC_ENV_VAR = "UNSLOTH_DATASET_NUM_PROC"
 
-# Upper bound for the *auto* worker count. The previous heuristic allowed
-# min(max(cpu_count + 4, 2), 64) -- up to 64 forked workers, each of which is
-# handed its own dill-pickled copy of the tokenizer closure and an Arrow shard
-# over a pipe. Tokenization stops scaling long before that and the memory and
-# fork pressure is what users actually hit. Raise it via NUM_PROC_ENV_VAR.
-#
-# Measured on an 8000-row Arrow dataset with a Qwen2.5 fast tokenizer, 3 reps:
-# num_proc None 6.3s, 1 9.5s, 8 8.1s, 32 14.2s, 64 21.7s. More workers were
-# slower than none at every size tried, because each task ships a 5.4 MB dill
-# pickle of the closure down a pipe.
+# Upper bound for the *auto* count only; raise it via NUM_PROC_ENV_VAR. The old
+# min(max(cpu_count + 4, 2), 64) allowed 64 forked workers, each handed its own
+# dill-pickled tokenizer closure and an Arrow shard over a pipe. Measured on
+# 8000 rows with a Qwen2.5 fast tokenizer, 3 reps: None 6.3s, 1 9.5s, 8 8.1s,
+# 32 14.2s, 64 21.7s -- more workers were slower than none at every size.
 AUTO_NUM_PROC_CAP = 8
 
-# Peak RSS of a single tokenization worker, measured on the run above: ~680 MB,
-# and flat across worker counts (each child gets its own full copy). Budget 1 GB
-# apiece so a larger tokenizer or shard does not immediately invalidate this.
+# Peak RSS per worker on that run: ~680 MB, flat across worker counts. Budget
+# 1 GB so a larger tokenizer or shard does not immediately invalidate this.
 WORKER_MEMORY_BUDGET_GB = 1.0
 
-# Share of *available* RAM that tokenization workers may spend. Tokenization is
-# a preparation step, not the job, so leave most of the machine to the run that
-# follows. This is what actually bounds the failure in issue #2693: workers get
-# SIGKILLed by the OOM killer, and datasets reports only "One of the subprocesses
-# has abruptly died during map operation" with the real cause discarded
-# (datasets/utils/py_utils.py compares pool PIDs and never reads exit status).
+# Share of *available* RAM tokenization may spend; the rest belongs to the run
+# that follows. This is what bounds issue #2693: workers get SIGKILLed by the
+# OOM killer and datasets reports only "One of the subprocesses has abruptly
+# died during map operation", the real cause discarded.
 MEMORY_BUDGET_FRACTION = 0.5
 
-# Mirrors _MIN_ROWS_FOR_MULTIPROC in unsloth_zoo.dataset_utils.
-# train_on_responses_only. Below this it runs a split in-process, because the
-# workers cost more than they save -- but only when it picked the worker count
-# itself; an explicit count skips that guard. resolve_responses_only_num_proc
-# has to know the threshold to avoid taking the guard away. It cannot be
-# imported: it is a local inside the Zoo function, so the duplication is
-# unavoidable and a canary in tests/utils/test_dataset_num_proc.py fails if the
-# Zoo ever moves it.
+# Mirrors _MIN_ROWS_FOR_MULTIPROC, a local inside
+# unsloth_zoo.dataset_utils.train_on_responses_only (hence not importable):
+# below it the Zoo maps a split in-process, unless handed an explicit count.
+# resolve_responses_only_num_proc needs the threshold to avoid taking that guard
+# away; a canary in tests/utils/test_dataset_num_proc.py catches Zoo drift.
 ZOO_MIN_ROWS_FOR_MULTIPROC = 5_000
 
-# Warn at most once per process per distinct reason, so a script that builds
-# several configs does not print the same line repeatedly.
+# Warn at most once per process per distinct reason.
 _WARNED: set = set()
 
 
@@ -111,21 +95,18 @@ def _warn_once(key: str, message: str) -> None:
 def _unpinned_default_start_method(module) -> Optional[str]:
     """The default start method of a module that has not pinned one yet.
 
-    ``get_all_start_methods()`` documents its first element as the default, and
-    in the standard library it is. ``multiprocess`` copies that function
-    verbatim -- including the darwin branch that lists ``spawn`` first -- but
-    does **not** copy the darwin default that goes with it. Compare line 326 of
+    ``get_all_start_methods()[0]`` is the documented default, but ``multiprocess``
+    copies that function verbatim -- darwin branch listing ``spawn`` first --
+    without copying the darwin default that goes with it. Compare line 326 of
     each ``context.py`` on macOS::
 
         multiprocessing:  _default_context = DefaultContext(_concrete_contexts['spawn'])
         multiprocess:     _default_context = DefaultContext(_concrete_contexts['fork'])  #FIXME: spawn
 
-    So on macOS ``multiprocess.get_all_start_methods()[0]`` says ``spawn`` while
-    ``multiprocess.Pool`` actually forks, and since ``datasets`` builds its pool
-    from ``multiprocess`` the list order is simply the wrong source. Read the
-    default context's own name instead. Unlike ``get_context()`` that does not
-    assign ``_actual_context``, so it keeps the no-side-effects property the
-    caller depends on. Private attributes, hence the fallback.
+    So its list says ``spawn`` while its ``Pool`` forks, and ``datasets`` builds
+    from ``multiprocess``. Read the default context's own name instead; unlike
+    ``get_context()`` it does not assign ``_actual_context``, keeping the probe
+    side-effect free. Private attributes, hence the fallback.
     """
     try:
         methods = module.get_all_start_methods()
@@ -134,12 +115,10 @@ def _unpinned_default_start_method(module) -> Optional[str]:
 
     try:
         name = module.context._default_context._default_context._name
-        # Only if it is actually available here. These are private attributes and
-        # they are not consistent across builds: on a Windows runner this chain
-        # answered 'fork' while get_all_start_methods() was ['spawn'], and a
-        # start method the platform does not offer cannot be the one in use.
-        # Believing it would have read Windows as forkable and let workers
-        # through, which is the spawn re-import loop of #3211 / #3397.
+        # Only if the platform actually offers it. These private attributes vary
+        # across builds: a Windows runner answered 'fork' while
+        # get_all_start_methods() was ['spawn'], and believing that would read
+        # Windows as forkable -- the spawn re-import loop of #3211 / #3397.
         if isinstance(name, str) and name and (not methods or name in methods):
             return name
     except Exception:
@@ -151,16 +130,14 @@ def multiprocessing_start_method() -> Optional[str]:
     """Return the start method ``datasets`` will actually use, or None.
 
     ``datasets.arrow_dataset`` does ``from multiprocess import Pool``, so
-    ``multiprocess`` -- not stdlib ``multiprocessing`` -- is what decides how
-    ``Dataset.map(num_proc = ...)`` spawns workers. Fall back to the stdlib
-    module only when ``multiprocess`` is absent, and to None when neither can
-    answer (in which case the caller treats forking as unavailable).
+    ``multiprocess`` -- not stdlib ``multiprocessing`` -- decides how
+    ``Dataset.map(num_proc = ...)`` spawns workers. Falls back to the stdlib
+    module, then to None (the caller then treats forking as unavailable).
 
     Observing must not mutate: ``get_start_method(allow_none = False)`` pins
-    ``_actual_context`` as a side effect, which would make a later
-    ``set_start_method()`` raise. So ask with ``allow_none = True`` and, when
-    nothing has been pinned yet, read the platform default off the module's own
-    default context (see ``_unpinned_default_start_method``).
+    ``_actual_context``, which would make a later ``set_start_method()`` raise.
+    So ask with ``allow_none = True`` and read the unpinned default off the
+    module's own default context (see ``_unpinned_default_start_method``).
     """
     for module_name in ("multiprocess", "multiprocessing"):
         try:
@@ -177,22 +154,19 @@ def multiprocessing_start_method() -> Optional[str]:
 def _workers_unusable_reason() -> Optional[str]:
     """Why ``datasets`` workers cannot be used here, or None when they can.
 
-    Two independent refusals, kept apart because they have different causes and
-    only one of them is a property of the start method:
+    Two independent refusals; only one is a property of the start method:
 
-    * **Not ``fork``.** The child receives the tokenizer closure through a dill
-      pickle and must re-import the dynamically generated trainer module, which
-      is not importable by name, so a worker cannot come up at all.
+    * **Not ``fork``.** The child gets the tokenizer closure as a dill pickle and
+      must re-import the dynamically generated trainer module, which has no
+      importable name, so a worker cannot come up at all.
 
     * **macOS, whatever the start method says.** CPython moved the macOS default
-      from ``fork`` to ``spawn`` in 3.8 (bpo-33725) because "the fork start
-      method should be considered unsafe as it can lead to crashes of the
-      subprocess as macOS system libraries may start threads". ``multiprocess``
-      never copied that change -- see ``_unpinned_default_start_method`` -- so
-      ``datasets`` genuinely does fork on macOS, out of a parent that has
-      already loaded Torch and its threaded BLAS. Reporting that truthfully is
-      right; acting on it is not, so macOS stays in-process as a stated policy
-      rather than as a side effect of a probe that happened to read ``spawn``.
+      to ``spawn`` in 3.8 (bpo-33725) because forking there "can lead to crashes
+      of the subprocess as macOS system libraries may start threads".
+      ``multiprocess`` never copied that, so ``datasets`` genuinely forks on
+      macOS out of a parent already holding Torch and a threaded BLAS. Reporting
+      that truthfully is right; acting on it is not, so macOS stays in-process
+      as a stated policy rather than as a side effect of the probe.
     """
     start_method = multiprocessing_start_method()
     if start_method != "fork":
@@ -216,15 +190,14 @@ def _affordable_workers() -> Optional[int]:
 def _clamp_by_memory(num_proc: int) -> Optional[int]:
     """Bound a worker count by RAM. None means "do not use workers at all".
 
-    This applies to explicitly requested counts as well as auto-sized ones. The
-    old heuristic capped only the auto path, so a caller that passed a number --
-    Studio passes ``max(1, cpu_count // 4)`` -- could ask for dozens of workers
-    on a machine with no room for them. That is the shape that OOMs.
+    Applies to explicit counts too. The old heuristic capped only the auto path,
+    so a caller passing a number (Studio passes ``max(1, cpu_count // 4)``) could
+    ask for dozens of workers on a machine with no room. That is what OOMs.
     """
     affordable = _affordable_workers()
     if affordable is None:
         # No psutil, so no memory reading. Honour the request rather than
-        # silently serialising on a machine that may be perfectly capable.
+        # serialising a machine that may be perfectly capable.
         return num_proc
 
     if affordable < 2:
@@ -253,7 +226,7 @@ def _auto_num_proc() -> Optional[int]:
         import psutil
         cpu_count = psutil.cpu_count() or 1
     except Exception:
-        # No psutil means no CPU reading; stay conservative rather than guessing.
+        # No psutil means no CPU reading; stay conservative.
         return None
 
     return _clamp_by_memory(min(max(cpu_count // 2, 2), AUTO_NUM_PROC_CAP))
@@ -264,24 +237,16 @@ def _serial(serial_as_none: bool) -> Optional[int]:
 
     At a ``map()`` call site that is ``None``, the only value ``datasets`` runs
     in-process on every supported release. At the *config* layer it is ``1``,
-    because a config ``None`` is read downstream as "auto-size me" -- writing
-    ``None`` there would inflate a serial request back up to the auto worker
-    count. The call site then turns that ``1`` into ``None``.
+    because a config ``None`` is read downstream as "auto-size me" and would
+    inflate a serial request; the call site turns that ``1`` back into ``None``.
 
-    That reasoning only holds while workers are usable at all, so the config
-    sentinel is conditioned on ``_workers_unusable_reason``. Where they are not,
-    nothing can inflate a config ``None``: every auto-sizer that reads it vetoes
-    as well (this module at step 2 below, and the three copies in
-    ``unsloth_zoo.dataset_utils``, which read stdlib ``multiprocessing`` and so
-    see ``spawn`` on both Windows and macOS). Meanwhile ``1`` is unsafe there,
-    because only the SFT
-    map site is rewritten by ``rl_replacements.py`` -- TRL's DPO, KTO, CPO,
-    ORPO, Reward and PRM trainers hand ``args.dataset_num_proc`` straight to
-    ``Dataset.map``, where ``datasets`` >= 4.1 turns ``1`` into a ``Pool(1)``
-    and each spawned child re-imports the user's ``__main__`` (the Windows
-    spawn loops in unsloth #3211 / #3397). ``None`` is what those configs
-    carried before this module existed, and it is the only value that builds no
-    pool at all.
+    That only holds while workers are usable, hence the
+    ``_workers_unusable_reason`` check. Where they are not, nothing can inflate a
+    config ``None`` -- every auto-sizer that reads it vetoes too -- while ``1``
+    is unsafe, since only the SFT map site is rewritten by
+    ``rl_replacements.py``: TRL's DPO, KTO, CPO, ORPO, Reward and PRM trainers
+    hand ``args.dataset_num_proc`` straight to ``Dataset.map``, whose ``Pool(1)``
+    child re-imports the user's ``__main__`` (#3211 / #3397).
     """
     if serial_as_none:
         return None
@@ -323,45 +288,38 @@ def get_dataset_num_proc(
 ) -> Optional[int]:
     """Return a safe ``num_proc`` for ``Dataset.map()`` / ``Dataset.filter()``.
 
-    ``None`` means "run in-process". It is the only value that avoids building a
-    worker pool on every supported ``datasets`` release -- ``1`` does not, since
-    ``datasets`` 4.x takes the pool branch for any ``num_proc >= 1``.
-
-    Whatever is returned is bounded by free memory, including a count the caller
-    asked for explicitly. Only ``NUM_PROC_ENV_VAR`` is exempt.
+    ``None`` means "run in-process" -- the only value that builds no worker pool
+    on every supported ``datasets`` release, since 4.x pools for any
+    ``num_proc >= 1``. Everything returned is bounded by free memory, explicit
+    counts included; only ``NUM_PROC_ENV_VAR`` is exempt.
 
     Args:
         desired: The worker count the caller asked for, or None to auto-size.
-        serial_as_none: How to encode "run in-process". True at a ``map()``
-            call site, which yields ``None``. **False when writing back to a
-            config**, which yields ``1``, because downstream readers
+        serial_as_none: How to encode "run in-process". True at a ``map()`` call
+            site, yielding ``None``. **False when writing back to a config**,
+            yielding ``1``, because downstream readers
             (``unsloth_zoo.dataset_utils.sft_prepare_dataset``) treat a config
-            ``None`` as "auto-size me", so storing ``None`` for a user who asked
-            for ``1`` would silently inflate it to the auto worker count. The
+            ``None`` as "auto-size me" and would inflate a user's ``1``. The
             config keeps the user's intent; the call site makes it safe.
 
     Returns:
-        A worker count >= 2, or the in-process sentinel for this layer (``None``
-        at a call site, ``1`` at the config layer).
+        A worker count >= 2, or this layer's in-process sentinel (``None`` at a
+        call site, ``1`` at the config layer).
     """
-    # 1. Explicit environment override wins over everything, uncapped and
-    #    without the start-method veto, so a user who knows their workload is
-    #    fork-safe is never silently downgraded.
+    # 1. The environment override wins over everything, uncapped and unvetoed,
+    #    so a user who knows their workload is fork-safe is never downgraded.
     env_set, env_value = _from_environment()
     if env_set:
-        # env_value None means the user asked for in-process, so it has to be
-        # encoded for this layer like every other serial path. Returning a bare
-        # None here would write None into the *config*, which downstream reads
-        # as "auto-size me" -- so UNSLOTH_DATASET_NUM_PROC=0, the escape hatch
-        # the dead-worker message tells people to use, would have inflated the
-        # worker count instead of removing it.
+        # In-process still has to be encoded for this layer: a bare None written
+        # into a *config* reads downstream as "auto-size me", so
+        # UNSLOTH_DATASET_NUM_PROC=0 would inflate the count instead of removing
+        # it -- and that is the hatch the dead-worker message recommends.
         return _serial(serial_as_none) if env_value is None else env_value
 
-    # 2. `datasets` workers receive the tokenizer closure through a dill pickle
-    #    over a pipe. Under spawn/forkserver the child must also re-import the
-    #    dynamically generated trainer module, which is not importable by name,
-    #    so multiprocessing is unusable regardless of what was requested. macOS
-    #    is refused for a separate reason -- see `_workers_unusable_reason`.
+    # 2. Under spawn/forkserver the child must re-import the dynamically
+    #    generated trainer module, which is not importable by name, so workers
+    #    are unusable whatever was requested. macOS is refused for a separate
+    #    reason -- see `_workers_unusable_reason`.
     unusable = _workers_unusable_reason()
     if unusable is not None:
         if isinstance(desired, int) and not isinstance(desired, bool) and desired > 1:
@@ -373,14 +331,13 @@ def get_dataset_num_proc(
             )
         return _serial(serial_as_none)
 
-    # 3. Normalise the "no multiprocessing" requests. `1` in particular is a
-    #    trap: callers pass it meaning "serial", and datasets >= 4.1 hands them
-    #    a Pool(1) instead. Nothing to clamp here, so return straight away.
+    # 3. Normalise "no multiprocessing" requests. `1` is the trap: callers pass
+    #    it meaning "serial" and datasets >= 4.1 hands them a Pool(1).
     if isinstance(desired, int) and not isinstance(desired, bool) and desired <= 1:
         return _serial(serial_as_none)
 
     # 4. Auto-size when no usable request was made, then bound by memory. A
-    #    non-int (or a bool, which is an int subclass) is not a request.
+    #    non-int, or a bool (an int subclass), is not a request.
     if desired is None or not isinstance(desired, int) or isinstance(desired, bool):
         num_proc = _auto_num_proc()
     else:
@@ -393,8 +350,7 @@ def get_dataset_num_proc(
 
 # The message datasets raises when a pool worker dies. It compares pool PIDs and
 # never reads the child's exit status, so an OOM kill, a segfault and a genuine
-# exception all arrive as this one string with the real cause discarded. That is
-# why issue #2693 looks random and untraceable.
+# exception all arrive as this one string -- which is why #2693 looks untraceable.
 _WORKER_DIED = "subprocesses has abruptly died"
 
 
@@ -402,10 +358,9 @@ _WORKER_DIED = "subprocesses has abruptly died"
 def map_failure_diagnostics(num_proc: Optional[int]) -> "Iterator[None]":
     """Re-raise a dead-worker error from ``Dataset.map`` with usable context.
 
-    Names the start method, the worker count, and roughly what those workers
-    cost, so the reader can tell an out-of-memory kill from anything else --
-    none of which survives the original message. The cause is chained, so the
-    child's traceback is still there for anyone who wants it.
+    Names the start method, the worker count and roughly what they cost, so an
+    out-of-memory kill can be told apart from anything else -- none of which
+    survives the original message. The cause is chained.
     """
     try:
         yield
@@ -435,12 +390,10 @@ def map_failure_diagnostics(num_proc: Optional[int]) -> "Iterator[None]":
 def _largest_split_rows(trainer) -> Optional[int]:
     """Rows in the biggest *sized* split ``train_on_responses_only`` will map over.
 
-    Returns None only when no split has a readable length at all. An unsized
-    split is skipped rather than abandoning the whole measurement: the Zoo picks
-    a worker count per split, and an unsized one can never use workers whatever
-    it is handed (its ``IterableDataset`` branch passes no ``num_proc``, and
-    ``_effective_num_proc`` returns None when ``len()`` raises). Letting one hide
-    a large sized sibling is what left that sibling on the Zoo's uncapped auto
+    None only when no split has a readable length at all. An unsized split is
+    skipped rather than abandoning the measurement: the Zoo sizes per split, and
+    an unsized one can never use workers whatever it is handed, so letting it
+    hide a large sized sibling left that sibling on the Zoo's uncapped auto
     count. ``eval_dataset`` may be a dict of named splits, so unpack that too.
     """
     if trainer is None:
@@ -459,9 +412,8 @@ def _largest_split_rows(trainer) -> Optional[int]:
             try:
                 rows = len(split)
             except Exception:
-                # Unsized, or a length that raises. The Zoo cannot parallelize
-                # this split either way, so skip it -- do not let it mask a
-                # sized sibling that the Zoo *would* parallelize.
+                # The Zoo cannot parallelize this split either way, so skip it
+                # rather than let it mask a sized sibling that it would.
                 continue
             measured = True
             largest = max(largest, rows)
@@ -471,57 +423,48 @@ def _largest_split_rows(trainer) -> Optional[int]:
 def resolve_responses_only_num_proc(trainer, num_proc):
     """Bound the worker count ``train_on_responses_only`` hands to ``map()``.
 
-    ``unsloth_zoo.dataset_utils.train_on_responses_only`` still computes its own
-    count with the uncapped ``min(max(cpu_count + 4, 2), 64)`` heuristic this
-    module replaces everywhere else, so on a large host it forks dozens of
-    workers that each receive a dill-pickled tokenizer closure. That is the
-    shape behind issue #2693, and this function is what keeps it bounded. The
-    Zoo is a separate package, so the fix has to work from the outside.
-
-    Two properties of the Zoo's API constrain what can be expressed here:
+    ``unsloth_zoo.dataset_utils.train_on_responses_only`` still auto-sizes with
+    the uncapped ``min(max(cpu_count + 4, 2), 64)`` heuristic this module
+    replaces everywhere else, forking dozens of workers that each receive a
+    dill-pickled tokenizer closure -- the shape behind issue #2693. The Zoo is a
+    separate package, so the bound has to be applied from outside, and two
+    properties of its API constrain what can be expressed:
 
     * **Serial is the config-layer sentinel, not the call-site one.** The Zoo
-      reads ``None`` as "size it for me", so on ``fork`` handing it the ``None``
-      that means serial at a ``map()`` call site would *inflate* the count to the
-      auto value instead of removing it; ``1`` is the closest expressible
-      request there. It still builds a ``Pool(1)`` on ``datasets`` >= 4.1, which
-      cannot be fixed without changing the Zoo, but one forked worker is not the
-      out-of-memory failure this guards against. Under spawn/forkserver that
-      trade flips: ``1`` is the *worse* value, because each ``Pool(1)`` child
-      re-imports the user's ``__main__`` (the spawn loops in #3211 / #3397),
-      while ``None`` is safe -- the Zoo's auto path vetoes on a non-fork start
-      method of its own accord and ends up in-process. That is exactly the
-      distinction ``get_dataset_num_proc(..., serial_as_none = False)`` encodes,
-      so this function defers to it rather than mapping serial to ``1`` by hand.
-    * **An explicit count disables the Zoo's small-split guard**, which it
-      applies per split. A trainer with a large train split and a small eval
-      split would see the eval map pick up workers it would not have had. That
-      is a second or two on the small split against tens of GB on the large one,
-      so it is worth it -- but only when a split is actually big enough for the
-      Zoo to have parallelized in the first place, which is what the row check
-      below establishes.
+      reads ``None`` as "size it for me", so on ``fork`` handing it ``None``
+      would *inflate* the count rather than remove it; ``1`` is the closest
+      expressible request, and though it still builds a ``Pool(1)`` on
+      ``datasets`` >= 4.1, one forked worker is not the OOM this guards against.
+      Under spawn the trade flips -- each ``Pool(1)`` child re-imports the user's
+      ``__main__`` (#3211 / #3397), while ``None`` is safe because the Zoo's auto
+      path vetoes non-fork itself and lands in-process. That is exactly what
+      ``get_dataset_num_proc(..., serial_as_none = False)`` encodes, so defer to
+      it rather than mapping serial to ``1`` by hand.
+    * **An explicit count disables the Zoo's per-split small-split guard.** A
+      small eval split alongside a large train split then picks up workers it
+      would not have had: a second or two against tens of GB, worth it only when
+      a split is big enough for the Zoo to have parallelized at all, which is
+      what the row check below establishes.
     """
-    # Mirror the Zoo's own test exactly (bools are not ints by this rule, and it
-    # treats them as auto), so "explicit" means the same thing on both sides.
+    # Mirror the Zoo's own test, so "explicit" means the same on both sides (it
+    # treats bools as auto, since type(True) is not int).
     was_auto = num_proc is None or type(num_proc) is not int
 
     if not was_auto:
         # Explicit counts already bypass the Zoo's small-split guard, so
-        # bounding one takes nothing away that the caller had.
+        # bounding one takes nothing away.
         return get_dataset_num_proc(num_proc, serial_as_none = False)
 
     rows = _largest_split_rows(trainer)
     if rows is None or rows < ZOO_MIN_ROWS_FOR_MULTIPROC:
-        # An explicit escape hatch has to win here too, or the count the user
-        # asked for is dropped on the floor by a shortcut they cannot see.
+        # The escape hatch must win here too, not be dropped by a shortcut the
+        # user cannot see.
         env_set, env_value = _from_environment()
         if env_set and env_value is not None:
             return env_value
-        # Otherwise the Zoo would have gone in-process anyway (that is also what
-        # UNSLOTH_DATASET_NUM_PROC=0 asks for, and its guard yields None, which
-        # is more in-process than the 1 this function can express). Leave the
-        # value untouched so its guard keeps deciding, rather than substituting
-        # a count that would switch multiprocessing back on for a small split.
+        # Otherwise the Zoo would have gone in-process anyway, and its guard
+        # yields None, which is more in-process than the 1 expressible here. So
+        # leave the value alone and let that guard keep deciding.
         return num_proc
 
     return get_dataset_num_proc(None, serial_as_none = False)

--- a/unsloth/utils/dataset_num_proc.py
+++ b/unsloth/utils/dataset_num_proc.py
@@ -14,27 +14,23 @@
 
 """Fallback copy of the ``dataset_num_proc`` policy for ``Dataset.map()``.
 
-The source of truth is ``unsloth_zoo.dataset_num_proc``: generated trainer
-source must not import back into the package that generated it, and the three
-remaining copies of this heuristic live in ``unsloth_zoo.dataset_utils``. Every
-caller here tries the zoo first and only falls back to this module on a zoo that
-predates it, so this copy exists solely so that upgrading unsloth alone still
-fixes the bug. ``test_the_two_copies_have_not_drifted`` compares the two
-whenever both are importable; delete this file once the zoo floor guarantees
-the module.
+``unsloth_zoo.dataset_num_proc`` is the source of truth, since generated trainer
+source must not import back into the package that generated it. Every caller
+tries the zoo first, so this copy exists only so that upgrading unsloth alone
+still fixes the bug; ``test_the_two_copies_have_not_drifted`` keeps the two in
+step, and this file can go once the zoo floor guarantees the module.
 
-Replaces four drifted copies of the same heuristic (generated trainer source in
-``unsloth/models/rl.py``, plus ``unsloth_zoo.dataset_utils``), two of which were
-wrong in ways that produced https://github.com/unslothai/unsloth/issues/2693:
+It replaces four drifted copies of the heuristic (generated source in
+``unsloth/models/rl.py``, plus ``unsloth_zoo.dataset_utils``), two of them wrong
+in ways that produced https://github.com/unslothai/unsloth/issues/2693:
 
-1. They asked ``multiprocessing.get_start_method()`` whether forking was
-   available, but ``Dataset.map`` imports ``Pool`` from ``multiprocess`` (the
-   dill fork), which keeps its own independent default context. The guard and
-   ``datasets`` were reading different settings.
+1. They asked ``multiprocessing.get_start_method()`` about forking, but
+   ``Dataset.map`` imports ``Pool`` from ``multiprocess`` (the dill fork), which
+   keeps its own default context. The two read different settings.
 
-2. They used ``1`` as the "disable multiprocessing" sentinel. On ``datasets``
-   >= 4.1 (Studio pins 4.3.0) ``map()`` takes the pool branch for any
-   ``num_proc >= 1``, so only ``None`` is in-process on every supported version.
+2. They used ``1`` as the "disable multiprocessing" sentinel, but ``datasets``
+   >= 4.1 (Studio pins 4.3.0) pools for any ``num_proc >= 1``, so only ``None``
+   is in-process on every supported version.
 """
 
 from __future__ import annotations
@@ -61,11 +57,11 @@ __all__ = [
 # start-method veto), "0"/"none" forces in-process tokenization.
 NUM_PROC_ENV_VAR = "UNSLOTH_DATASET_NUM_PROC"
 
-# Upper bound for the *auto* count only; raise it via NUM_PROC_ENV_VAR. The old
+# Bounds the *auto* count only; raise it via NUM_PROC_ENV_VAR. The old
 # min(max(cpu_count + 4, 2), 64) allowed 64 forked workers, each handed its own
-# dill-pickled tokenizer closure and an Arrow shard over a pipe. Measured on
-# 8000 rows with a Qwen2.5 fast tokenizer, 3 reps: None 6.3s, 1 9.5s, 8 8.1s,
-# 32 14.2s, 64 21.7s -- more workers were slower than none at every size.
+# dill-pickled tokenizer closure and an Arrow shard over a pipe. Measured on 8000
+# rows, Qwen2.5 fast tokenizer, 3 reps: None 6.3s, 1 9.5s, 8 8.1s, 32 14.2s, 64
+# 21.7s -- more workers were slower than none at every size.
 AUTO_NUM_PROC_CAP = 8
 
 # Peak RSS per worker on that run: ~680 MB, flat across worker counts. Budget
@@ -73,16 +69,14 @@ AUTO_NUM_PROC_CAP = 8
 WORKER_MEMORY_BUDGET_GB = 1.0
 
 # Share of *available* RAM tokenization may spend; the rest belongs to the run
-# that follows. This is what bounds issue #2693: workers get SIGKILLed by the
-# OOM killer and datasets reports only "One of the subprocesses has abruptly
-# died during map operation", the real cause discarded.
+# that follows. This is what bounds issue #2693, where workers are OOM-killed and
+# datasets reports only "subprocesses has abruptly died", the real cause lost.
 MEMORY_BUDGET_FRACTION = 0.5
 
-# Mirrors _MIN_ROWS_FOR_MULTIPROC, a local inside
-# unsloth_zoo.dataset_utils.train_on_responses_only (hence not importable):
-# below it the Zoo maps a split in-process, unless handed an explicit count.
-# resolve_responses_only_num_proc needs the threshold to avoid taking that guard
-# away; a canary in tests/utils/test_dataset_num_proc.py catches Zoo drift.
+# Mirrors _MIN_ROWS_FOR_MULTIPROC, a local (so unimportable) inside
+# unsloth_zoo.dataset_utils.train_on_responses_only: under it the Zoo maps a
+# split in-process unless given an explicit count, a guard
+# resolve_responses_only_num_proc must not take away. A canary test catches drift.
 ZOO_MIN_ROWS_FOR_MULTIPROC = 5_000
 
 # Warn at most once per process per distinct reason.
@@ -105,17 +99,16 @@ def _unpinned_default_start_method(module) -> Optional[str]:
     """The default start method of a module that has not pinned one yet.
 
     ``get_all_start_methods()[0]`` is the documented default, but ``multiprocess``
-    copies that function verbatim -- darwin branch listing ``spawn`` first --
-    without copying the darwin default that goes with it. Compare line 326 of
-    each ``context.py`` on macOS::
+    copied that function verbatim -- darwin listing ``spawn`` first -- without the
+    darwin default that goes with it (``context.py`` line 326 on macOS)::
 
         multiprocessing:  _default_context = DefaultContext(_concrete_contexts['spawn'])
         multiprocess:     _default_context = DefaultContext(_concrete_contexts['fork'])  #FIXME: spawn
 
-    So its list says ``spawn`` while its ``Pool`` forks, and ``datasets`` builds
-    from ``multiprocess``. Read the default context's own name instead; unlike
-    ``get_context()`` it does not assign ``_actual_context``, keeping the probe
-    side-effect free. Private attributes, hence the fallback.
+    So its list says ``spawn`` while its ``Pool`` forks. Read the default
+    context's own name instead: unlike ``get_context()`` it does not assign
+    ``_actual_context``, keeping the probe side-effect free. Private, hence the
+    fallback.
     """
     try:
         methods = module.get_all_start_methods()
@@ -124,10 +117,9 @@ def _unpinned_default_start_method(module) -> Optional[str]:
 
     try:
         name = module.context._default_context._default_context._name
-        # Only if the platform actually offers it. These private attributes vary
-        # across builds: a Windows runner answered 'fork' while
-        # get_all_start_methods() was ['spawn'], and believing that would read
-        # Windows as forkable -- the spawn re-import loop of #3211 / #3397.
+        # Only if the platform offers it: a Windows runner answered 'fork' while
+        # get_all_start_methods() was ['spawn'], and believing that reads Windows
+        # as forkable -- the spawn re-import loop of #3211 / #3397.
         if isinstance(name, str) and name and (not methods or name in methods):
             return name
     except Exception:
@@ -140,13 +132,12 @@ def multiprocessing_start_method() -> Optional[str]:
 
     ``datasets.arrow_dataset`` does ``from multiprocess import Pool``, so
     ``multiprocess`` -- not stdlib ``multiprocessing`` -- decides how
-    ``Dataset.map(num_proc = ...)`` spawns workers. Falls back to the stdlib
-    module, then to None (the caller then treats forking as unavailable).
+    ``Dataset.map(num_proc = ...)`` spawns workers; falls back to the stdlib
+    module, then to None (forking then treated as unavailable).
 
     Observing must not mutate: ``get_start_method(allow_none = False)`` pins
-    ``_actual_context``, which would make a later ``set_start_method()`` raise.
-    So ask with ``allow_none = True`` and read the unpinned default off the
-    module's own default context (see ``_unpinned_default_start_method``).
+    ``_actual_context``, making a later ``set_start_method()`` raise. So ask with
+    ``allow_none = True``, then see ``_unpinned_default_start_method``.
     """
     for module_name in ("multiprocess", "multiprocessing"):
         try:
@@ -163,19 +154,15 @@ def multiprocessing_start_method() -> Optional[str]:
 def _workers_unusable_reason() -> Optional[str]:
     """Why ``datasets`` workers cannot be used here, or None when they can.
 
-    Two independent refusals; only one is a property of the start method:
-
-    * **Not ``fork``.** The child gets the tokenizer closure as a dill pickle and
-      must re-import the dynamically generated trainer module, which has no
-      importable name, so a worker cannot come up at all.
+    * **Not ``fork``.** The child must re-import the dynamically generated
+      trainer module, which has no importable name, so it cannot come up at all.
 
     * **macOS, whatever the start method says.** CPython moved the macOS default
       to ``spawn`` in 3.8 (bpo-33725) because forking there "can lead to crashes
       of the subprocess as macOS system libraries may start threads".
-      ``multiprocess`` never copied that, so ``datasets`` genuinely forks on
-      macOS out of a parent already holding Torch and a threaded BLAS. Reporting
-      that truthfully is right; acting on it is not, so macOS stays in-process
-      as a stated policy rather than as a side effect of the probe.
+      ``multiprocess`` never copied that, so ``datasets`` really does fork on
+      macOS out of a parent already holding Torch and a threaded BLAS. So macOS
+      stays in-process as stated policy, not as a side effect of the probe.
     """
     start_method = multiprocessing_start_method()
     if start_method != "fork":
@@ -246,16 +233,15 @@ def _serial(serial_as_none: bool) -> Optional[int]:
 
     At a ``map()`` call site that is ``None``, the only value ``datasets`` runs
     in-process on every supported release. At the *config* layer it is ``1``,
-    because a config ``None`` is read downstream as "auto-size me" and would
-    inflate a serial request; the call site turns that ``1`` back into ``None``.
+    since a config ``None`` reads downstream as "auto-size me" and would inflate
+    a serial request; the call site turns that ``1`` back into ``None``.
 
-    That only holds while workers are usable, hence the
-    ``_workers_unusable_reason`` check. Where they are not, nothing can inflate a
-    config ``None`` -- every auto-sizer that reads it vetoes too -- while ``1``
-    is unsafe, since only the SFT map site is rewritten by
-    ``rl_replacements.py``: TRL's DPO, KTO, CPO, ORPO, Reward and PRM trainers
-    hand ``args.dataset_num_proc`` straight to ``Dataset.map``, whose ``Pool(1)``
-    child re-imports the user's ``__main__`` (#3211 / #3397).
+    Only while workers are usable, hence the ``_workers_unusable_reason`` check.
+    Where they are not, nothing can inflate a config ``None`` -- every auto-sizer
+    vetoes too -- while ``1`` is unsafe: only the SFT map site is rewritten by
+    ``rl_replacements.py``, and TRL's DPO, KTO, CPO, ORPO, Reward and PRM
+    trainers hand ``args.dataset_num_proc`` straight to ``Dataset.map``, whose
+    ``Pool(1)`` child re-imports the user's ``__main__`` (#3211 / #3397).
     """
     if serial_as_none:
         return None
@@ -306,10 +292,8 @@ def get_dataset_num_proc(
         desired: The worker count the caller asked for, or None to auto-size.
         serial_as_none: How to encode "run in-process". True at a ``map()`` call
             site, yielding ``None``. **False when writing back to a config**,
-            yielding ``1``, because downstream readers
-            (``unsloth_zoo.dataset_utils.sft_prepare_dataset``) treat a config
-            ``None`` as "auto-size me" and would inflate a user's ``1``. The
-            config keeps the user's intent; the call site makes it safe.
+            yielding ``1``, since ``unsloth_zoo.sft_prepare_dataset`` reads a
+            config ``None`` as "auto-size me" and would inflate a user's ``1``.
 
     Returns:
         A worker count >= 2, or this layer's in-process sentinel (``None`` at a
@@ -319,16 +303,14 @@ def get_dataset_num_proc(
     #    so a user who knows their workload is fork-safe is never downgraded.
     env_set, env_value = _from_environment()
     if env_set:
-        # In-process still has to be encoded for this layer: a bare None written
-        # into a *config* reads downstream as "auto-size me", so
-        # UNSLOTH_DATASET_NUM_PROC=0 would inflate the count instead of removing
-        # it -- and that is the hatch the dead-worker message recommends.
+        # A bare None written into a *config* reads downstream as "auto-size me",
+        # so UNSLOTH_DATASET_NUM_PROC=0 would inflate the count instead of
+        # removing it -- and that is the hatch the dead-worker message names.
         return _serial(serial_as_none) if env_value is None else env_value
 
-    # 2. Under spawn/forkserver the child must re-import the dynamically
-    #    generated trainer module, which is not importable by name, so workers
-    #    are unusable whatever was requested. macOS is refused for a separate
-    #    reason -- see `_workers_unusable_reason`.
+    # 2. Under spawn/forkserver the child cannot re-import the dynamically
+    #    generated trainer module, so workers are unusable whatever was asked.
+    #    macOS is refused for a separate reason; see `_workers_unusable_reason`.
     unusable = _workers_unusable_reason()
     if unusable is not None:
         if isinstance(desired, int) and not isinstance(desired, bool) and desired > 1:
@@ -397,13 +379,13 @@ def map_failure_diagnostics(num_proc: Optional[int]) -> "Iterator[None]":
 
 
 def _largest_split_rows(trainer) -> Optional[int]:
-    """Rows in the biggest *sized* split ``train_on_responses_only`` will map over.
+    """Rows in the biggest *sized* split ``train_on_responses_only`` maps over.
 
-    None only when no split has a readable length at all. An unsized split is
-    skipped rather than abandoning the measurement: the Zoo sizes per split, and
-    an unsized one can never use workers whatever it is handed, so letting it
-    hide a large sized sibling left that sibling on the Zoo's uncapped auto
-    count. ``eval_dataset`` may be a dict of named splits, so unpack that too.
+    None only when no split has a readable length. An unsized split is skipped
+    rather than abandoning the measurement: the Zoo sizes per split and an
+    unsized one can never use workers anyway, so letting it hide a large sized
+    sibling left that sibling on the Zoo's uncapped auto count. ``eval_dataset``
+    may be a dict of named splits, so unpack that too.
     """
     if trainer is None:
         return None
@@ -434,21 +416,17 @@ def resolve_responses_only_num_proc(trainer, num_proc):
 
     ``unsloth_zoo.dataset_utils.train_on_responses_only`` still auto-sizes with
     the uncapped ``min(max(cpu_count + 4, 2), 64)`` heuristic this module
-    replaces everywhere else, forking dozens of workers that each receive a
-    dill-pickled tokenizer closure -- the shape behind issue #2693. The Zoo is a
-    separate package, so the bound has to be applied from outside, and two
-    properties of its API constrain what can be expressed:
+    replaces everywhere else -- the shape behind issue #2693. The Zoo is a
+    separate package, so the bound goes on from outside, and two properties of
+    its API constrain what can be expressed:
 
     * **Serial is the config-layer sentinel, not the call-site one.** The Zoo
-      reads ``None`` as "size it for me", so on ``fork`` handing it ``None``
-      would *inflate* the count rather than remove it; ``1`` is the closest
-      expressible request, and though it still builds a ``Pool(1)`` on
-      ``datasets`` >= 4.1, one forked worker is not the OOM this guards against.
-      Under spawn the trade flips -- each ``Pool(1)`` child re-imports the user's
-      ``__main__`` (#3211 / #3397), while ``None`` is safe because the Zoo's auto
-      path vetoes non-fork itself and lands in-process. That is exactly what
-      ``get_dataset_num_proc(..., serial_as_none = False)`` encodes, so defer to
-      it rather than mapping serial to ``1`` by hand.
+      reads ``None`` as "size it for me", so on ``fork`` that would *inflate* the
+      count; ``1`` is the closest expressible request, and one ``Pool(1)`` worker
+      is not the OOM this guards against. Under spawn the trade flips -- a
+      ``Pool(1)`` child re-imports the user's ``__main__`` (#3211 / #3397) while
+      ``None`` is safe, the Zoo's auto path vetoing non-fork itself. That is
+      exactly what ``get_dataset_num_proc(..., serial_as_none = False)`` encodes.
     * **An explicit count disables the Zoo's per-split small-split guard.** A
       small eval split alongside a large train split then picks up workers it
       would not have had: a second or two against tens of GB, worth it only when
@@ -466,14 +444,12 @@ def resolve_responses_only_num_proc(trainer, num_proc):
 
     rows = _largest_split_rows(trainer)
     if rows is None or rows < ZOO_MIN_ROWS_FOR_MULTIPROC:
-        # The escape hatch must win here too, not be dropped by a shortcut the
-        # user cannot see.
+        # The escape hatch must win here too, not be lost to this shortcut.
         env_set, env_value = _from_environment()
         if env_set and env_value is not None:
             return env_value
-        # Otherwise the Zoo would have gone in-process anyway, and its guard
-        # yields None, which is more in-process than the 1 expressible here. So
-        # leave the value alone and let that guard keep deciding.
+        # Otherwise the Zoo goes in-process anyway, via a None more in-process
+        # than the 1 expressible here, so leave the value for its guard.
         return num_proc
 
     return get_dataset_num_proc(None, serial_as_none = False)

--- a/unsloth/utils/dataset_num_proc.py
+++ b/unsloth/utils/dataset_num_proc.py
@@ -194,15 +194,31 @@ def _cgroup_limits() -> "tuple[Optional[int], Optional[float]]":
 def _cgroup_memory_used() -> Optional[int]:
     """Bytes this cgroup is already using, or None when that cannot be read.
 
-    Only the well-known roots: runc bind-mounts the container's own cgroup there,
-    which is the case this exists for. Without it the whole limit would look free
-    on a container that has already spent most of it.
+    Without it the whole limit looks free on a container that has spent most of
+    it, and the model is usually what spent it. Read from the same directories
+    the limit came from, innermost first, rather than from
+    ``/sys/fs/cgroup/memory.current``: at the root that file is the WHOLE
+    machine's usage, and subtracting it from a systemd unit's own MemoryMax would
+    leave every run with nothing free.
     """
-    for path in ("/sys/fs/cgroup/memory.current", "/sys/fs/cgroup/memory/memory.usage_in_bytes"):
+    try:
+        from unsloth_zoo.hf_xet_tuning import (
+            _cgroup_v1_dirs,
+            _cgroup_v2_dirs,
+            _read_first_line,
+        )
+    except Exception:
+        return None  # limit-only, which is never worse than not subtracting
+
+    candidates = [(d, "memory.current") for d in _cgroup_v2_dirs()]
+    candidates += [(d, "memory.usage_in_bytes") for d in _cgroup_v1_dirs("memory")]
+    for directory, name in candidates:
+        raw = _read_first_line(directory / name)
+        if not raw:
+            continue
         try:
-            with open(path, "r") as handle:
-                return int(handle.readline().strip())
-        except Exception:
+            return int(raw.strip())
+        except ValueError:
             continue
     return None
 

--- a/unsloth/utils/dataset_num_proc.py
+++ b/unsloth/utils/dataset_num_proc.py
@@ -254,7 +254,13 @@ def get_dataset_num_proc(
     #    fork-safe is never silently downgraded.
     env_set, env_value = _from_environment()
     if env_set:
-        return env_value
+        # env_value None means the user asked for in-process, so it has to be
+        # encoded for this layer like every other serial path. Returning a bare
+        # None here would write None into the *config*, which downstream reads
+        # as "auto-size me" -- so UNSLOTH_DATASET_NUM_PROC=0, the escape hatch
+        # the dead-worker message tells people to use, would have inflated the
+        # worker count instead of removing it.
+        return _serial(serial_as_none) if env_value is None else env_value
 
     # 2. `datasets` workers receive the tokenizer closure through a dill pickle
     #    over a pipe. Under spawn/forkserver the child must also re-import the

--- a/unsloth/utils/dataset_num_proc.py
+++ b/unsloth/utils/dataset_num_proc.py
@@ -12,7 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Single source of truth for the ``dataset_num_proc`` used by ``Dataset.map()``.
+"""Fallback copy of the ``dataset_num_proc`` policy for ``Dataset.map()``.
+
+The source of truth is ``unsloth_zoo.dataset_num_proc``: generated trainer
+source must not import back into the package that generated it, and the three
+remaining copies of this heuristic live in ``unsloth_zoo.dataset_utils``. Every
+caller here tries the zoo first and only falls back to this module on a zoo that
+predates it, so this copy exists solely so that upgrading unsloth alone still
+fixes the bug. ``test_the_two_copies_have_not_drifted`` compares the two
+whenever both are importable; delete this file once the zoo floor guarantees
+the module.
 
 Replaces four drifted copies of the same heuristic (generated trainer source in
 ``unsloth/models/rl.py``, plus ``unsloth_zoo.dataset_utils``), two of which were
@@ -382,7 +391,7 @@ def map_failure_diagnostics(num_proc: Optional[int]) -> "Iterator[None]":
             f"can use, or {NUM_PROC_ENV_VAR}=<n> to choose a count. That is "
             f"in-process everywhere except train_on_responses_only on a split "
             f"over {ZOO_MIN_ROWS_FOR_MULTIPROC:,} rows, where it is one worker: "
-            f"the Zoo reads a bare None there as 'size it for me'.\n"
+            f"a bare None there reads as 'size it for me'.\n"
             f"  Original error: {exception}"
         ) from exception
 

--- a/unsloth/utils/dataset_num_proc.py
+++ b/unsloth/utils/dataset_num_proc.py
@@ -1,0 +1,332 @@
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Single source of truth for the ``dataset_num_proc`` used by ``Dataset.map()``.
+
+This used to be four copies of the same heuristic pasted into generated trainer
+source (``unsloth/models/rl.py``) and into ``unsloth_zoo.dataset_utils``. They
+drifted, and two of the copies were wrong in ways that produced the crash in
+https://github.com/unslothai/unsloth/issues/2693:
+
+1. They asked ``multiprocessing.get_start_method()`` whether forking was
+   available. ``datasets`` does not use ``multiprocessing`` -- ``Dataset.map``
+   imports ``Pool`` from ``multiprocess`` (the dill fork), which keeps its own
+   independent default context. Setting the stdlib start method therefore told
+   the guard one thing while ``datasets`` did another.
+
+2. They used ``1`` as the "disable multiprocessing" sentinel. That is only true
+   on older ``datasets``. On ``datasets`` 4.3.0 (the Studio pin) ``map()`` takes
+   the pool branch for any ``num_proc >= 1``, so ``num_proc = 1`` still forks a
+   ``Pool(1)``. Only ``None`` is in-process on every supported version.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from typing import Iterator, Optional
+
+__all__ = [
+    "AUTO_NUM_PROC_CAP",
+    "MEMORY_BUDGET_FRACTION",
+    "NUM_PROC_ENV_VAR",
+    "WORKER_MEMORY_BUDGET_GB",
+    "get_dataset_num_proc",
+    "map_failure_diagnostics",
+    "multiprocessing_start_method",
+    "reset_warning_state",
+]
+
+# Environment escape hatch. Set to a positive integer to force that worker count
+# verbatim (no capping, no start-method veto), or to "0"/"none" to force
+# in-process tokenization. Deliberate power users are never silently overridden.
+NUM_PROC_ENV_VAR = "UNSLOTH_DATASET_NUM_PROC"
+
+# Upper bound for the *auto* worker count. The previous heuristic allowed
+# min(max(cpu_count + 4, 2), 64) -- up to 64 forked workers, each of which is
+# handed its own dill-pickled copy of the tokenizer closure and an Arrow shard
+# over a pipe. Tokenization stops scaling long before that and the memory and
+# fork pressure is what users actually hit. Raise it via NUM_PROC_ENV_VAR.
+#
+# Measured on an 8000-row Arrow dataset with a Qwen2.5 fast tokenizer, 3 reps:
+# num_proc None 6.3s, 1 9.5s, 8 8.1s, 32 14.2s, 64 21.7s. More workers were
+# slower than none at every size tried, because each task ships a 5.4 MB dill
+# pickle of the closure down a pipe.
+AUTO_NUM_PROC_CAP = 8
+
+# Peak RSS of a single tokenization worker, measured on the run above: ~680 MB,
+# and flat across worker counts (each child gets its own full copy). Budget 1 GB
+# apiece so a larger tokenizer or shard does not immediately invalidate this.
+WORKER_MEMORY_BUDGET_GB = 1.0
+
+# Share of *available* RAM that tokenization workers may spend. Tokenization is
+# a preparation step, not the job, so leave most of the machine to the run that
+# follows. This is what actually bounds the failure in issue #2693: workers get
+# SIGKILLed by the OOM killer, and datasets reports only "One of the subprocesses
+# has abruptly died during map operation" with the real cause discarded
+# (datasets/utils/py_utils.py compares pool PIDs and never reads exit status).
+MEMORY_BUDGET_FRACTION = 0.5
+
+# Warn at most once per process per distinct reason, so a script that builds
+# several configs does not print the same line repeatedly.
+_WARNED: set = set()
+
+
+def reset_warning_state() -> None:
+    """Clear the once-per-process warning memo. Intended for tests."""
+    _WARNED.clear()
+
+
+def _warn_once(key: str, message: str) -> None:
+    if key in _WARNED:
+        return
+    _WARNED.add(key)
+    print(f"Unsloth: {message}")
+
+
+def multiprocessing_start_method() -> Optional[str]:
+    """Return the start method ``datasets`` will actually use, or None.
+
+    ``datasets.arrow_dataset`` does ``from multiprocess import Pool``, so
+    ``multiprocess`` -- not stdlib ``multiprocessing`` -- is what decides how
+    ``Dataset.map(num_proc = ...)`` spawns workers. Fall back to the stdlib
+    module only when ``multiprocess`` is absent, and to None when neither can
+    answer (in which case the caller treats forking as unavailable).
+
+    Observing must not mutate: ``get_start_method(allow_none = False)`` pins
+    ``_actual_context`` as a side effect, which would make a later
+    ``set_start_method()`` raise. So ask with ``allow_none = True`` and, when
+    nothing has been pinned yet, read the platform default off
+    ``get_all_start_methods()``, whose first element is documented to be it.
+    """
+    for module_name in ("multiprocess", "multiprocessing"):
+        try:
+            module = __import__(module_name)
+            method = module.get_start_method(allow_none = True)
+            if method is None:
+                methods = module.get_all_start_methods()
+                method = methods[0] if methods else None
+            return method
+        except Exception:
+            continue
+    return None
+
+
+def _affordable_workers() -> Optional[int]:
+    """How many workers free RAM can cover, or None when it cannot be read."""
+    try:
+        import psutil
+
+        available_gb = psutil.virtual_memory().available / (1024 ** 3)
+    except Exception:
+        return None
+    budget_gb = available_gb * MEMORY_BUDGET_FRACTION
+    return int(budget_gb / WORKER_MEMORY_BUDGET_GB)
+
+
+def _clamp_by_memory(num_proc: int) -> Optional[int]:
+    """Bound a worker count by RAM. None means "do not use workers at all".
+
+    This applies to explicitly requested counts as well as auto-sized ones. The
+    old heuristic capped only the auto path, so a caller that passed a number --
+    Studio passes ``max(1, cpu_count // 4)`` -- could ask for dozens of workers
+    on a machine with no room for them. That is the shape that OOMs.
+    """
+    affordable = _affordable_workers()
+    if affordable is None:
+        # No psutil, so no memory reading. Honour the request rather than
+        # silently serialising on a machine that may be perfectly capable.
+        return num_proc
+
+    if affordable < 2:
+        _warn_once(
+            "memory_serial",
+            "not enough free memory for dataset tokenization workers "
+            f"(~{WORKER_MEMORY_BUDGET_GB:g}GB each); tokenizing in-process.",
+        )
+        return None
+
+    if affordable < num_proc:
+        _warn_once(
+            "memory_clamp",
+            f"reducing dataset_num_proc {num_proc} -> {affordable} to fit free "
+            f"memory (~{WORKER_MEMORY_BUDGET_GB:g}GB per worker). Set "
+            f"{NUM_PROC_ENV_VAR} to override.",
+        )
+        return affordable
+
+    return num_proc
+
+
+def _auto_num_proc() -> Optional[int]:
+    """Worker count to use when the caller did not ask for a specific one."""
+    try:
+        import psutil
+
+        cpu_count = psutil.cpu_count() or 1
+    except Exception:
+        # No psutil means no CPU reading; stay conservative rather than guessing.
+        return None
+
+    return _clamp_by_memory(min(max(cpu_count // 2, 2), AUTO_NUM_PROC_CAP))
+
+
+def _serial(serial_as_none: bool) -> Optional[int]:
+    """The value meaning "run in-process", encoded for the calling layer.
+
+    At a ``map()`` call site that is ``None``, the only value ``datasets`` runs
+    in-process on every supported release. At the *config* layer it is ``1``,
+    because a config ``None`` is read downstream as "auto-size me" -- writing
+    ``None`` there would inflate a serial request back up to the auto worker
+    count. The call site then turns that ``1`` into ``None``.
+    """
+    return None if serial_as_none else 1
+
+
+def _from_environment() -> "tuple[bool, Optional[int]]":
+    """Read NUM_PROC_ENV_VAR. Returns (was_set_and_valid, value)."""
+    raw = os.environ.get(NUM_PROC_ENV_VAR)
+    if raw is None:
+        return False, None
+
+    text = raw.strip()
+    if text.lower() in ("", "0", "none", "null", "false"):
+        return True, None
+
+    try:
+        value = int(text)
+    except ValueError:
+        _warn_once(
+            "env_invalid",
+            f"{NUM_PROC_ENV_VAR}={raw!r} is not an integer, ignoring it.",
+        )
+        return False, None
+
+    if value < 0:
+        _warn_once(
+            "env_negative",
+            f"{NUM_PROC_ENV_VAR}={raw!r} is negative, ignoring it.",
+        )
+        return False, None
+    if value <= 1:
+        return True, None
+    return True, value
+
+
+def get_dataset_num_proc(
+    desired: Optional[int] = None,
+    *,
+    serial_as_none: bool = True,
+) -> Optional[int]:
+    """Return a safe ``num_proc`` for ``Dataset.map()`` / ``Dataset.filter()``.
+
+    ``None`` means "run in-process". It is the only value that avoids building a
+    worker pool on every supported ``datasets`` release -- ``1`` does not, since
+    ``datasets`` 4.x takes the pool branch for any ``num_proc >= 1``.
+
+    Whatever is returned is bounded by free memory, including a count the caller
+    asked for explicitly. Only ``NUM_PROC_ENV_VAR`` is exempt.
+
+    Args:
+        desired: The worker count the caller asked for, or None to auto-size.
+        serial_as_none: How to encode "run in-process". True at a ``map()``
+            call site, which yields ``None``. **False when writing back to a
+            config**, which yields ``1``, because downstream readers
+            (``unsloth_zoo.dataset_utils.sft_prepare_dataset``) treat a config
+            ``None`` as "auto-size me", so storing ``None`` for a user who asked
+            for ``1`` would silently inflate it to the auto worker count. The
+            config keeps the user's intent; the call site makes it safe.
+
+    Returns:
+        A worker count >= 2, or the in-process sentinel for this layer (``None``
+        at a call site, ``1`` at the config layer).
+    """
+    # 1. Explicit environment override wins over everything, uncapped and
+    #    without the start-method veto, so a user who knows their workload is
+    #    fork-safe is never silently downgraded.
+    env_set, env_value = _from_environment()
+    if env_set:
+        return env_value
+
+    # 2. `datasets` workers receive the tokenizer closure through a dill pickle
+    #    over a pipe. Under spawn/forkserver the child must also re-import the
+    #    dynamically generated trainer module, which is not importable by name,
+    #    so multiprocessing is unusable regardless of what was requested.
+    start_method = multiprocessing_start_method()
+    if start_method != "fork":
+        if isinstance(desired, int) and not isinstance(desired, bool) and desired > 1:
+            _warn_once(
+                "start_method",
+                f"dataset_num_proc = {desired} needs the 'fork' start method, "
+                f"but this process uses {start_method!r}. Falling back to "
+                f"single-process tokenization. Set {NUM_PROC_ENV_VAR} to "
+                f"override.",
+            )
+        return _serial(serial_as_none)
+
+    # 3. Normalise the "no multiprocessing" requests. `1` in particular is a
+    #    trap: callers pass it meaning "serial", and datasets >= 4.0 hands them
+    #    a Pool(1) instead. Nothing to clamp here, so return straight away.
+    if isinstance(desired, int) and not isinstance(desired, bool) and desired <= 1:
+        return _serial(serial_as_none)
+
+    # 4. Auto-size when no usable request was made, then bound by memory. A
+    #    non-int (or a bool, which is an int subclass) is not a request.
+    if desired is None or not isinstance(desired, int) or isinstance(desired, bool):
+        num_proc = _auto_num_proc()
+    else:
+        num_proc = _clamp_by_memory(desired)
+
+    if num_proc is None:
+        return _serial(serial_as_none)
+    return num_proc
+
+
+# The message datasets raises when a pool worker dies. It compares pool PIDs and
+# never reads the child's exit status, so an OOM kill, a segfault and a genuine
+# exception all arrive as this one string with the real cause discarded. That is
+# why issue #2693 looks random and untraceable.
+_WORKER_DIED = "subprocesses has abruptly died"
+
+
+@contextlib.contextmanager
+def map_failure_diagnostics(num_proc: Optional[int]) -> "Iterator[None]":
+    """Re-raise a dead-worker error from ``Dataset.map`` with usable context.
+
+    Names the start method, the worker count, and roughly what those workers
+    cost, so the reader can tell an out-of-memory kill from anything else --
+    none of which survives the original message. The cause is chained, so the
+    child's traceback is still there for anyone who wants it.
+    """
+    try:
+        yield
+    except RuntimeError as exception:
+        if _WORKER_DIED not in str(exception):
+            raise
+
+        workers = num_proc if isinstance(num_proc, int) else 1
+        estimated_gb = workers * WORKER_MEMORY_BUDGET_GB
+        raise RuntimeError(
+            f"Unsloth: tokenization failed because a dataset worker died.\n"
+            f"  dataset_num_proc = {num_proc!r} "
+            f"({workers} worker{'' if workers == 1 else 's'}, "
+            f"start method {multiprocessing_start_method()!r})\n"
+            f"  Each worker holds its own copy of the tokenizer and its dataset "
+            f"shard, so this run needed roughly {estimated_gb:g}GB on top of the "
+            f"model. The most common cause is the out-of-memory killer.\n"
+            f"  Tokenize in-process with {NUM_PROC_ENV_VAR}=0, or pick a worker "
+            f"count with {NUM_PROC_ENV_VAR}=<n>.\n"
+            f"  Original error: {exception}"
+        ) from exception


### PR DESCRIPTION
Addresses #2693 and a Studio report of the same failure.

Training intermittently dies with `RuntimeError: One of the subprocesses has abruptly died during map operation.` and then succeeds on the next run.

## What I measured

I built a reproducer over the tokenization `map()`: 1,510 `Dataset.map()` calls across CUDA-init state, `num_proc`, start method, live parent threads, and both pinned `datasets` versions.

**The suspected mechanism is not real.** The tokenizer dill round-trip was byte-identical in all 1,510 cells. "Tokenizer state corrupted while deserializing" does not survive testing.

**What is real:**

| `num_proc` | Pool built | dill payloads per map | peak RSS per worker | 3 reps, 8000 rows |
|---|---|---|---|---|
| `None` | no | 0 | 0 MB | **6.3s** |
| `1` | **yes** | 1 | 683 MB | 9.5s |
| `8` | yes | 8 | 681 MB | 8.1s |
| `32` | yes | 32 | 682 MB | 14.2s |
| `64` | yes | 64 | 681 MB | 21.7s |

- Each pool task dill-pickles the tokenizer closure over a pipe, **5,369,755 bytes**, once per worker per map. This happens under `fork` too: `datasets` does `from multiprocess import Pool`, and `multiprocess/queues.py:389-391` pickles every task regardless of start method.
- Each worker peaks around **680 MB RSS**. The old auto count was `min(max(cpu_count + 4, 2), 64)`, so a large host forked up to 64 workers for roughly **43 GB** resident. On a smaller box the OOM killer takes one.
- `datasets/utils/py_utils.py:616-621` only compares pool PIDs and never reads the child's exit status, so every cause is flattened into that one message with the real reason discarded. Killing a worker with SIGKILL or SIGSEGV reproduces the reported error character for character, at any `num_proc` **including 1**.

This matches #2693 exactly, including the reply that it is "hardware specific, on my hardware it's 4".

## Two further defects

- **The guard read the wrong module.** It asked stdlib `multiprocessing` for the start method while `datasets` uses `multiprocess`, which keeps an independent default context.
- **`num_proc=1` was the "no multiprocessing" sentinel.** On `datasets` 4.3.0 (the Studio pin) `map()` takes the pool branch for any `num_proc >= 1` (`arrow_dataset.py:3236,3318-3319`), so `1` still builds a `Pool(1)`. 3.6.0 does run it in-process (`:3066`), so the two pinned ranges genuinely disagree and only `None` is safe on both. Measured, `1` is **51% slower than `None`** while buying no parallelism.

## Changes

- **`unsloth/dataset_num_proc.py`**, one policy replacing four drifted copies. It asks `multiprocess` about the start method, caps the auto count at 8, and bounds any count, **explicit ones included**, by available memory at roughly 1 GB per worker over half of free RAM. Studio's explicit `cpu_count // 4` previously bypassed every bound, which is how a 192-core host reached 48 workers. `UNSLOTH_DATASET_NUM_PROC` remains an uncapped escape hatch.
- **The config layer records intent; the `map()` call site makes it safe.** These cannot be collapsed: `unsloth_zoo.sft_prepare_dataset` re-derives the count whenever `args.dataset_num_proc is None`, so a config `None` means "auto-size me". Writing `None` for a user who asked for `1` would have inflated it to the auto count.
- **`worker.py` no longer forces stdlib multiprocessing onto `fork`.** It never reached `Dataset.map`, and Linux already defaults to fork. Its only live effect was flipping the stdlib-reading guard, which is gone.
- **A dead worker now raises with context**: the start method, the worker count, the approximate memory cost, and the escape hatch, chained from the original so the traceback survives.

## No CUDA guard

I expected fork-after-`torch.cuda._lazy_init()` to be the cause, since `dataset_map_num_proc` already guards this for XPU and `detect_hardware()` always initializes CUDA before the map. It is not: 300 forced-fork runs on an initialized CUDA context produced zero failures, with the child running only the tokenizer and never touching CUDA. That negative is from one host and one `datasets` version, and does not disprove the crash on WSL2.

On what the vendors actually say, since "we measured zero failures" is a weak argument on its own:

- **PyTorch enforces the restriction child-side.** `torch/cuda/__init__.py` raises `Cannot re-initialize CUDA in forked subprocess` from `_lazy_init()` only when the child actually initializes CUDA, so a CUDA-free child never trips it. Its written guidance is broader ("Avoid initializing the accelerator in the main process before forking child processes"). We are inside what the runtime enforces and outside what the docs recommend.
- **NVIDIA's only statement on fork** covers *managed* memory, blesses just fork-plus-`exec()`, and extends the hazard to the parent. PyTorch's default caching allocator uses `cudaMalloc`, not `cudaMallocManaged`, so it does not directly govern this. It was also removed from the CUDA C++ Programming Guide after 12.2, so there is no current NVIDIA text on the subject.

The stronger argument against the guard is that the residual hazard is **not CUDA-specific**: `import torch` alone leaves the parent with roughly 64 threads and CUDA init adds about 3, so a `torch.cuda.is_initialized()` probe would not have addressed the generic multi-threaded-fork risk that remains either way. It would cost every CUDA training run its tokenization parallelism to fix nothing. `hardware.py` is therefore AST-identical to `main` modulo docstrings (verified mechanically), the only change being the `Pool(1)` docstring, which was version-specific and did not say so.

If the WSL2 reports persist, the right lever is a start-method change (`forkserver`), not a CUDA probe.

## Tests

46 new tests. Each fix was reverted individually to confirm the tests bite:

| mutation | result |
|---|---|
| explicit bypasses the memory clamp | 2 failed |
| auto cap back to 64 | 3 failed |
| config layer emits `None` for serial | 3 failed |
| start-method probe asks stdlib first | 1 failed |
| diagnostics stop rewriting worker death | 2 failed |
| CUDA guard re-added | 2 failed |

Also 104 passed in the Studio backend suite, 66 in the XPU pipeline tests. All five `_require_replace` anchors match their expected counts against the installed `unsloth_zoo`, and the patched `_prepare_dataset` re-indents and `ast.parse`s cleanly.

Worker counts on a 192-core, 1448 GB host: auto goes 64 -> 8; an explicit 48 stays 48, because there is genuinely room. At a simulated 16 GB free, 48 -> 8 with a warning; at 3 GB everything drops to in-process. The bound is memory-proportional, so it correctly does nothing on a large machine.

## Known gaps

- The `1 -> None` normalisation reaches **SFT only**, since that is the path `sft_prepare_dataset` owns. DPO, KTO, CPO, ORPO, Reward, PRM, PPO and BCO read `args.dataset_num_proc` in their own `_prepare_dataset`, so an explicit `1` there still builds a `Pool(1)`. The memory bound runs at config construction and so applies to all of them, meaning the OOM mechanism is covered everywhere; only the serial-means-`Pool(1)` inefficiency remains. Closing it needs per-trainer call-site patches.
- `import unsloth` fails in my environment on an unrelated `unsloth_zoo` and torch 2.9.1 mismatch (`torch.nn.functional.ScalingType`). I confirmed it fails identically on unmodified `main`, so it is pre-existing, but it means no live trainer was constructed and the codegen is verified structurally via AST rather than by import.
- The diagnostics wrapper is unit-tested against a synthetic dead-worker error, not a real killed worker.

Reported by Eyera, who traced it to the introducing commit and the full call chain.
