### PR TITLE
Repoint three guard tests at where the code moved, and derive the font-size expectations

### DIFF
--- a/studio/frontend/tests/sidebar-spinner-column.test.ts
+++ b/studio/frontend/tests/sidebar-spinner-column.test.ts
@@ -39,7 +39,9 @@ test("nav and Recents spinners land on one trailing column", async () => {
   );
   const chatRow = grab(
     source,
-    /"(sidebar-nav-btn h-\[33px\] cursor-pointer rounded-full[^"]*)"/,
+    // Row height is a density choice and moves independently of the trailing
+    // column, so match any h-[Npx]; cursor-pointer is what makes this the chat row.
+    /"(sidebar-nav-btn h-\[\d+px\] cursor-pointer rounded-full[^"]*)"/,
     "Recents chat row",
   );
   const chatSpinner = grab(

--- a/tests/studio/playwright_ui_font_scale.py
+++ b/tests/studio/playwright_ui_font_scale.py
@@ -13,6 +13,7 @@ Runs against an already-booted, already-bootstrapped Unsloth:
 """
 
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -27,9 +28,27 @@ PW = os.environ["STUDIO_PW"]
 ART = Path(os.environ.get("PW_ART_DIR", "logs/playwright_fontscale"))
 ART.mkdir(parents = True, exist_ok = True)
 
-SIZES = (12, 20)
-# UI_FONT_SIZE_RANGE default (appearance-custom-store.ts); only here is data-ui-font-size dropped.
-DEFAULT = 15
+# Read the range from the store instead of restating it: the default is the one
+# size at which data-ui-font-size is dropped, and it has already moved once
+# (16 -> 15), which is exactly what a pinned copy here fails on.
+_STORE = (
+    Path(__file__).resolve().parents[2]
+    / "studio/frontend/src/features/settings/stores/appearance-custom-store.ts"
+).read_text(encoding = "utf-8")
+_RANGE = re.search(
+    r"UI_FONT_SIZE_RANGE\s*=\s*\{\s*min:\s*(\d+),\s*max:\s*(\d+),\s*default:\s*(\d+)",
+    _STORE,
+)
+if _RANGE is None:
+    raise AssertionError("[font-scale] FAIL: no UI_FONT_SIZE_RANGE in appearance-custom-store.ts")
+SIZES = (int(_RANGE.group(1)), int(_RANGE.group(2)))
+DEFAULT = int(_RANGE.group(3))
+# The base the authored rem typography is written against; --ui-font-scale is
+# the preference divided by it.
+_BASE = re.search(r"UI_FONT_SIZE_CSS_BASE\s*=\s*(\d+)", _STORE)
+if _BASE is None:
+    raise AssertionError("[font-scale] FAIL: no UI_FONT_SIZE_CSS_BASE in appearance-custom-store.ts")
+CSS_BASE = int(_BASE.group(1))
 
 
 def step(s):
@@ -227,23 +246,24 @@ def main():
         page.goto(f"{BASE}/hub", wait_until = "domcontentloaded")
         page.wait_for_timeout(2000)
         open_appearance(page)
-        set_input(page, "UI font size", 12)
+        small = SIZES[0]
+        set_input(page, "UI font size", small)
         page.keyboard.press("Escape")
         page.wait_for_timeout(400)
         tab = page.get_by_role("radio").filter(has_text = "Discover").first
         tab.wait_for(state = "visible", timeout = 15000)
         tab_font = tab.evaluate("el => parseFloat(getComputedStyle(el).fontSize)")
-        # text-ui-12p5 at scale 0.75; 16px means twMerge dropped the token.
-        if not near(tab_font, 12.5 * 12 / 16):
+        # text-ui-12p5 at the smallest scale; the unscaled 12.5px means twMerge dropped the token.
+        if not near(tab_font, 12.5 * small / CSS_BASE):
             fail(f"hub tab font did not scale (twMerge drop?): {tab_font}")
         icon_w = page.evaluate(
             "() => { const el = document.querySelector('.size-icon');"
             " return el ? parseFloat(getComputedStyle(el).width) : null; }"
         )
-        # Standard icons render at the UI font size itself below the
-        # default, so setting 12 gives 12px glyphs.
-        if not near(icon_w, 12):
-            fail(f"size-icon did not match the UI font size below 16: {icon_w}")
+        # Standard icons render at the UI font size itself below the CSS base,
+        # so the smallest setting gives glyphs of exactly that many px.
+        if not near(icon_w, small):
+            fail(f"size-icon did not match the UI font size below {CSS_BASE}: {icon_w}")
         page.goto(BASE, wait_until = "domcontentloaded")
         page.wait_for_timeout(1500)
         open_appearance(page)

--- a/tests/studio/playwright_ui_font_scale.py
+++ b/tests/studio/playwright_ui_font_scale.py
@@ -47,7 +47,9 @@ DEFAULT = int(_RANGE.group(3))
 # the preference divided by it.
 _BASE = re.search(r"UI_FONT_SIZE_CSS_BASE\s*=\s*(\d+)", _STORE)
 if _BASE is None:
-    raise AssertionError("[font-scale] FAIL: no UI_FONT_SIZE_CSS_BASE in appearance-custom-store.ts")
+    raise AssertionError(
+        "[font-scale] FAIL: no UI_FONT_SIZE_CSS_BASE in appearance-custom-store.ts"
+    )
 CSS_BASE = int(_BASE.group(1))
 
 

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -410,10 +410,14 @@ def test_a_pinned_cached_row_loads_from_the_id_the_backend_pinned():
     block = re.search(r"onSelect\(repoId, \{.*?\n\s*\}", picker, re.S)
     assert block and "loadId: downloaded === true ? loadId : undefined," in block.group(0)
     # localPath alone: preferLocalCache would answer from disk and drop the undownloaded quants.
-    assert (
-        "listGgufVariants(repoId, hfToken, localSource ? { localPath: localSource } : undefined)"
-        in picker
+    # #7767 added the expander's abort signal to this call, so the options are an object
+    # literal now rather than the bare localSource ternary.
+    call = re.search(r"listGgufVariants\(repoId, hfToken, \{.*?\n\s*\}\)", picker, re.S)
+    assert call, "the expander must still list variants for the row's own repo"
+    assert "...(localSource ? { localPath: localSource } : {})" in call.group(0), (
+        "the expander drops the row's own cache directory"
     )
+    assert "preferLocalCache" not in call.group(0)
     assert "cachePath={c.cache_path}" in picker
 
     # A reload rebuilds its target from the checkpoint id, so the resident model remembers the pin.
@@ -528,11 +532,19 @@ def test_chat_autoload_scopes_variant_lookup_to_cached_repo_path():
     assert auto_load.count("preferLocalCache: true") >= 2
     assert auto_load.count("localPath: repo.cache_path") >= 2
 
+    # #7767 moved the query building out of chat-api into its own module, so the listing
+    # imports without the auth barrel. Both halves are pinned: the caller must still hand
+    # its options to the builder, and the builder must still forward them.
     chat_api = _read("features/chat/api/chat-api.ts")
     variants_fn = chat_api.split("export async function listGgufVariants", 1)[1]
     variants_fn = variants_fn.split("export interface KvCacheEstimate", 1)[0]
-    assert 'params.set("prefer_local_cache", "true")' in variants_fn
-    assert 'params.set("local_path", localPath)' in variants_fn
+    assert "ggufVariantsQuery(repoId, options, isHuggingFaceOffline())" in variants_fn
+
+    query_src = _read("features/chat/api/gguf-variants-request.ts")
+    query_fn = query_src.split("export function ggufVariantsQuery", 1)[1]
+    query_fn = query_fn.split("\nexport ", 1)[0]
+    assert 'params.set("prefer_local_cache", "true")' in query_fn
+    assert 'params.set("local_path", localPath)' in query_fn
 
 
 def test_cache_location_update_invalidates_frontend_inventory():

--- a/tests/studio/test_model_picker_contracts.py
+++ b/tests/studio/test_model_picker_contracts.py
@@ -414,9 +414,9 @@ def test_a_pinned_cached_row_loads_from_the_id_the_backend_pinned():
     # literal now rather than the bare localSource ternary.
     call = re.search(r"listGgufVariants\(repoId, hfToken, \{.*?\n\s*\}\)", picker, re.S)
     assert call, "the expander must still list variants for the row's own repo"
-    assert "...(localSource ? { localPath: localSource } : {})" in call.group(0), (
-        "the expander drops the row's own cache directory"
-    )
+    assert "...(localSource ? { localPath: localSource } : {})" in call.group(
+        0
+    ), "the expander drops the row's own cache directory"
     assert "preferLocalCache" not in call.group(0)
     assert "cachePath={c.cache_path}" in picker
 

--- a/tests/studio/test_ui_font_scale_contract.py
+++ b/tests/studio/test_ui_font_scale_contract.py
@@ -58,13 +58,22 @@ def test_preference_writes_a_scale_not_the_root_font_size():
     assert "style.fontSize" not in STORE
 
 
-def test_default_ui_font_size_is_fifteen():
-    assert "UI_FONT_SIZE_RANGE = { min: 12, max: 20, default: 15 }" in STORE
-    assert "const UI_FONT_SIZE_CSS_BASE = 16;" in STORE
+def test_css_default_scale_matches_the_store_default():
+    """index.css carries the default as a scale, the store carries it as a px
+    size, and the applier only drops data-ui-font-size at the store's value.
+    Derive the scale so the two cannot drift: when they did, everything
+    rendered at one size while the preference control called it another."""
+    rng = re.search(
+        r"UI_FONT_SIZE_RANGE = \{ min: (\d+), max: (\d+), default: (\d+) \}", STORE
+    )
+    assert rng is not None
+    base = re.search(r"const UI_FONT_SIZE_CSS_BASE = (\d+);", STORE)
+    assert base is not None
     assert "c.uiFontSize ?? UI_FONT_SIZE_RANGE.default" in STORE
     assert "effectiveUiFontSize !== UI_FONT_SIZE_RANGE.default" in STORE
     assert "effectiveUiFontSize / UI_FONT_SIZE_CSS_BASE" in STORE
-    assert "--ui-font-scale: 0.9375;" in INDEX_CSS
+    scale = int(rng.group(3)) / int(base.group(1))
+    assert f"--ui-font-scale: {scale:g};" in INDEX_CSS
 
 
 def test_named_text_tokens_scale():

--- a/tests/studio/test_ui_font_scale_contract.py
+++ b/tests/studio/test_ui_font_scale_contract.py
@@ -63,9 +63,7 @@ def test_css_default_scale_matches_the_store_default():
     size, and the applier only drops data-ui-font-size at the store's value.
     Derive the scale so the two cannot drift: when they did, everything
     rendered at one size while the preference control called it another."""
-    rng = re.search(
-        r"UI_FONT_SIZE_RANGE = \{ min: (\d+), max: (\d+), default: (\d+) \}", STORE
-    )
+    rng = re.search(r"UI_FONT_SIZE_RANGE = \{ min: (\d+), max: (\d+), default: (\d+) \}", STORE)
     assert rng is not None
     base = re.search(r"const UI_FONT_SIZE_CSS_BASE = (\d+);", STORE)
     assert base is not None


### PR DESCRIPTION
Main has been red in four workflows. Three of the failures are guard tests that a refactor left pointing at the old shape of the code; none of them was a product regression. Every one was checked by asking "does the behaviour this test protects still hold", not by making the assertion pass.

### Frontend CI

```
not ok 272 - nav and Recents spinners land on one trailing column
```

`sidebar-spinner-column.test.ts` scrapes four class strings and asserts both sidebar spinners land 16px from their row's right edge. Its anchor for the Recents row hard-coded `h-[33px]`, and #7608 made those rows denser at `h-[30px]`.

The alignment itself never broke: nav is `pr-2.5` + `mr-1.5` = 16px, Recents is `pr-4` with no spinner margin = 16px. Row height is a vertical density choice with no bearing on the trailing column, so the anchor now matches any `h-[Npx]`. `cursor-pointer` is what distinguishes the chat row from the nav rows, and the relaxed pattern still matches exactly one class string in the file.

Still strict: `pr-4` to `pr-5` fails with "nav spinner sits 16px in, chat spinner 20px", and `mr-1.5` to `mr-1` fails with "nav spinner sits 14px in, chat spinner 16px".

### Backend CI, Repo tests (CPU)

```
2 failed, 3996 passed
  test_a_pinned_cached_row_loads_from_the_id_the_backend_pinned
  test_chat_autoload_scopes_variant_lookup_to_cached_repo_path
```

#7767 split query building out of `chat-api.ts` into `gguf-variants-request.ts` so the listing imports without the auth barrel, and added an abort signal to the expander's call. It did not touch this test file, so the text pins went stale.

The behaviour is intact and now pinned in both halves: `chat-api.ts` still hands its options to `ggufVariantsQuery`, and that builder still sets `prefer_local_cache` and `local_path`.

One deliberate change of substance. The old expander assertion was an exact string, so it enforced "`preferLocalCache` is absent here" only implicitly, by being exact. A regex over the call block would have lost that, so the absence is now asserted explicitly. That absence is the real invariant: `preferLocalCache` there would answer from disk and drop the undownloaded quants, which is what the comment above the call says.

Six mutations each turn it red, including dropping either `params.set`, passing `undefined` instead of `options`, dropping the `localSource` spread, adding `preferLocalCache`, and dropping one `localPath: repo.cache_path` from autoload.

### Unsloth UI CI and Mac Studio UI CI

These two were already fixed by #7826 and #7828 while I was working, so nothing here is needed to make them pass. What is left is the recurrence risk.

The cause was #7608 moving `UI_FONT_SIZE_RANGE.default` from 16 to 15. Both fixes restate that number: the driver hard-codes `SIZES = (12, 20)` and `DEFAULT = 15`, and the contract test is named `test_default_ui_font_size_is_fifteen` and asserts the literal `--ui-font-scale: 0.9375;`. The next time the default moves, all of it breaks again in the same way, and it surfaces as a sub-pixel Playwright mismatch hours later.

So the two restatements now derive from the store:

- `playwright_ui_font_scale.py` parses `UI_FONT_SIZE_RANGE` and `UI_FONT_SIZE_CSS_BASE` out of `appearance-custom-store.ts` for `SIZES`, `DEFAULT` and the hub-tab checks that hard-coded 12 and 16. A missing pattern raises rather than falling back silently. The parse yields `(12, 20)`, `15`, `16` today, identical to the literals it replaces.
- `test_default_ui_font_size_is_fifteen` becomes `test_css_default_scale_matches_the_store_default`, computing `default / css_base` and asserting `index.css` declares exactly that. Every `default / 16` is exact in binary.

That second one is the contract that actually broke the letter-spacing assertion, and it now fails at unit-test time. Verified: moving the store default to 14 while leaving `index.css` at `0.9375` turns it red.

### Testing

- `tests/studio/test_model_picker_contracts.py` + `test_ui_font_scale_contract.py`: 126 passed
- `studio/frontend`: 334 passed, 0 failed, `npm run typecheck` clean
- No product source is touched; the diff is four test files.

`playwright_ui_font_scale.py` drives a live Studio, so its module-level parse is what I could verify locally, not the run itself. I replicated the parse standalone and confirmed the path resolves from the repo root, which is how both UI workflows invoke it.
