### PR TITLE
Add layer-wise LR decay to UnslothTrainer

### DIFF
--- a/tests/test_layerwise_lr_decay.py
+++ b/tests/test_layerwise_lr_decay.py
@@ -155,22 +155,30 @@ def test_num_layers_uses_full_model_depth():
     base, decay = 1e-3, 0.9
     # Only layer 0 is trainable, but the real model has 32 layers.
     groups = make_groups(
-        build_model(1), lr = base, weight_decay = 0.0, layerwise_lr_decay = decay,
-        num_layers = 32, verbose = False,
+        build_model(1),
+        lr = base,
+        weight_decay = 0.0,
+        layerwise_lr_decay = decay,
+        num_layers = 32,
+        verbose = False,
     )
-    assert lr_by_tag(groups)["layer0"] == pytest.approx(base * decay ** 31)
+    assert lr_by_tag(groups)["layer0"] == pytest.approx(base * decay**31)
 
 
 def test_num_layers_clamped_to_seen_indices():
     base, decay = 1e-3, 0.9
     # A too-small num_layers must not produce negative exponents (lr > base).
     groups = make_groups(
-        build_model(4), lr = base, weight_decay = 0.0, layerwise_lr_decay = decay,
-        num_layers = 2, verbose = False,
+        build_model(4),
+        lr = base,
+        weight_decay = 0.0,
+        layerwise_lr_decay = decay,
+        num_layers = 2,
+        verbose = False,
     )
     lrs = lr_by_tag(groups)
     assert lrs["layer3"] == pytest.approx(base)
-    assert lrs["layer0"] == pytest.approx(base * decay ** 3)
+    assert lrs["layer0"] == pytest.approx(base * decay**3)
 
 
 def test_compat_check_rejects_q_galore_combo():
@@ -194,11 +202,15 @@ def test_separate_stacks_decay_independently():
         )
     # config depth (decoder) must not leak into the vision stack.
     groups = make_groups(
-        FakeModel(named), lr = base, weight_decay = 0.0, layerwise_lr_decay = decay,
-        num_layers = 4, verbose = False,
+        FakeModel(named),
+        lr = base,
+        weight_decay = 0.0,
+        layerwise_lr_decay = decay,
+        num_layers = 4,
+        verbose = False,
     )
     lrs = lr_by_tag(groups)
-    assert lrs["dec3"] == pytest.approx(base)               # decoder top = base
-    assert lrs["dec0"] == pytest.approx(base * decay ** 3)  # decoder depth 4
-    assert lrs["vis5"] == pytest.approx(base)               # vision top = base
-    assert lrs["vis0"] == pytest.approx(base * decay ** 5)  # vision depth 6, independent
+    assert lrs["dec3"] == pytest.approx(base)  # decoder top = base
+    assert lrs["dec0"] == pytest.approx(base * decay**3)  # decoder depth 4
+    assert lrs["vis5"] == pytest.approx(base)  # vision top = base
+    assert lrs["vis0"] == pytest.approx(base * decay**5)  # vision depth 6, independent

--- a/tests/test_layerwise_lr_decay.py
+++ b/tests/test_layerwise_lr_decay.py
@@ -23,6 +23,7 @@ def _load_module():
 mod = _load_module()
 make_groups = mod.make_layerwise_lr_param_groups
 get_layer_index = mod.get_layer_index
+check_compat = mod.check_layerwise_lr_compat
 
 
 class FakeParam:
@@ -148,3 +149,56 @@ def test_groups_sorted_and_weight_decay_propagated():
 def test_invalid_decay_raises(bad):
     with pytest.raises(ValueError):
         make_groups(build_model(2), lr = 1e-3, weight_decay = 0.0, layerwise_lr_decay = bad)
+
+
+def test_num_layers_uses_full_model_depth():
+    base, decay = 1e-3, 0.9
+    # Only layer 0 is trainable, but the real model has 32 layers.
+    groups = make_groups(
+        build_model(1), lr = base, weight_decay = 0.0, layerwise_lr_decay = decay,
+        num_layers = 32, verbose = False,
+    )
+    assert lr_by_tag(groups)["layer0"] == pytest.approx(base * decay ** 31)
+
+
+def test_num_layers_clamped_to_seen_indices():
+    base, decay = 1e-3, 0.9
+    # A too-small num_layers must not produce negative exponents (lr > base).
+    groups = make_groups(
+        build_model(4), lr = base, weight_decay = 0.0, layerwise_lr_decay = decay,
+        num_layers = 2, verbose = False,
+    )
+    lrs = lr_by_tag(groups)
+    assert lrs["layer3"] == pytest.approx(base)
+    assert lrs["layer0"] == pytest.approx(base * decay ** 3)
+
+
+def test_compat_check_rejects_q_galore_combo():
+    with pytest.raises(ValueError):
+        check_compat(0.9, object())
+
+
+@pytest.mark.parametrize("decay,q_galore", [(None, object()), (1.0, object()), (0.9, None)])
+def test_compat_check_allows(decay, q_galore):
+    check_compat(decay, q_galore)
+
+
+def test_separate_stacks_decay_independently():
+    base, decay = 1e-3, 0.9
+    named = []
+    for i in range(4):  # 4-layer decoder
+        named.append((f"model.layers.{i}.self_attn.q_proj.weight", FakeParam(f"dec{i}")))
+    for i in range(6):  # deeper 6-layer vision tower
+        named.append(
+            (f"vision_tower.vision_model.encoder.layers.{i}.mlp.fc1.weight", FakeParam(f"vis{i}"))
+        )
+    # config depth (decoder) must not leak into the vision stack.
+    groups = make_groups(
+        FakeModel(named), lr = base, weight_decay = 0.0, layerwise_lr_decay = decay,
+        num_layers = 4, verbose = False,
+    )
+    lrs = lr_by_tag(groups)
+    assert lrs["dec3"] == pytest.approx(base)               # decoder top = base
+    assert lrs["dec0"] == pytest.approx(base * decay ** 3)  # decoder depth 4
+    assert lrs["vis5"] == pytest.approx(base)               # vision top = base
+    assert lrs["vis0"] == pytest.approx(base * decay ** 5)  # vision depth 6, independent

--- a/tests/test_layerwise_lr_decay.py
+++ b/tests/test_layerwise_lr_decay.py
@@ -1,0 +1,124 @@
+"""CPU tests for layer-wise LR decay param grouping.
+
+Loads the stdlib-only module directly so no GPU / unsloth import is needed.
+"""
+
+import importlib.util
+import os
+
+import pytest
+
+MODULE_PATH = os.path.join(
+    os.path.dirname(__file__), os.pardir, "unsloth", "optimizers", "layerwise_lr.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("_layerwise_lr_standalone", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load_module()
+make_groups = mod.make_layerwise_lr_param_groups
+get_layer_index = mod.get_layer_index
+
+
+class FakeParam:
+    def __init__(self, tag, requires_grad = True):
+        self.tag = tag
+        self.requires_grad = requires_grad
+
+
+class FakeModel:
+    def __init__(self, named):
+        self._named = named
+
+    def named_parameters(self):
+        return list(self._named)
+
+
+def build_model(num_layers = 4, with_head = True, with_embedding = True, frozen_layer = None):
+    named = []
+    for i in range(num_layers):
+        rg = not (frozen_layer is not None and i == frozen_layer)
+        name = f"base_model.model.model.layers.{i}.self_attn.q_proj.lora_A.default.weight"
+        named.append((name, FakeParam(f"layer{i}", requires_grad = rg)))
+    if with_head:
+        named.append(("base_model.model.lm_head.weight", FakeParam("lm_head")))
+    if with_embedding:
+        named.append((
+            "base_model.model.model.embed_tokens.modules_to_save.default.weight",
+            FakeParam("embed"),
+        ))
+    return FakeModel(named)
+
+
+def lr_by_tag(groups):
+    out = {}
+    for group in groups:
+        for param in group["params"]:
+            out[param.tag] = group["lr"]
+    return out
+
+
+def test_layer_index_parsing():
+    assert get_layer_index("a.layers.7.b") == 7
+    assert get_layer_index("model.layers.0.mlp") == 0
+    assert get_layer_index("layers.3.q_proj.weight") == 3  # top-level stack, no prefix
+    assert get_layer_index("model.embed_tokens.weight") is None
+
+
+def test_decay_math_and_boundaries():
+    base, decay = 1e-3, 0.9
+    groups = make_groups(build_model(4), lr = base, weight_decay = 0.01,
+                         layerwise_lr_decay = decay, verbose = False)
+    lrs = lr_by_tag(groups)
+    assert lrs["layer3"] == pytest.approx(base)              # top layer = base
+    assert lrs["layer2"] == pytest.approx(base * decay ** 1)
+    assert lrs["layer1"] == pytest.approx(base * decay ** 2)
+    assert lrs["layer0"] == pytest.approx(base * decay ** 3)  # deepest decay
+    assert lrs["lm_head"] == pytest.approx(base)              # non-block = top
+    assert lrs["embed"] == pytest.approx(base * decay ** 3)   # inherits shallowest
+
+
+def test_each_trainable_param_in_exactly_one_group():
+    groups = make_groups(build_model(4), lr = 1e-3, weight_decay = 0.0,
+                         layerwise_lr_decay = 0.9, verbose = False)
+    tags = [p.tag for g in groups for p in g["params"]]
+    assert sorted(tags) == sorted(["layer0", "layer1", "layer2", "layer3", "lm_head", "embed"])
+    assert len(tags) == len(set(tags))
+
+
+def test_frozen_params_excluded():
+    groups = make_groups(build_model(4, frozen_layer = 1), lr = 1e-3, weight_decay = 0.0,
+                         layerwise_lr_decay = 0.9, verbose = False)
+    assert "layer1" not in lr_by_tag(groups)
+
+
+def test_embedding_lr_overrides_decay():
+    groups = make_groups(build_model(4), lr = 1e-3, weight_decay = 0.0,
+                         layerwise_lr_decay = 0.9, embedding_lr = 7e-6, verbose = False)
+    assert lr_by_tag(groups)["embed"] == pytest.approx(7e-6)
+
+
+def test_decay_one_is_flat():
+    base = 1e-3
+    groups = make_groups(build_model(4), lr = base, weight_decay = 0.0,
+                         layerwise_lr_decay = 1.0, verbose = False)
+    assert all(v == pytest.approx(base) for v in lr_by_tag(groups).values())
+
+
+def test_groups_sorted_and_weight_decay_propagated():
+    groups = make_groups(build_model(4), lr = 1e-3, weight_decay = 0.05,
+                         layerwise_lr_decay = 0.9, verbose = False)
+    rates = [g["lr"] for g in groups]
+    assert rates == sorted(rates)
+    assert all(g["weight_decay"] == 0.05 for g in groups)
+
+
+@pytest.mark.parametrize("bad", [0.0, -0.1, 1.5])
+def test_invalid_decay_raises(bad):
+    with pytest.raises(ValueError):
+        make_groups(build_model(2), lr = 1e-3, weight_decay = 0.0, layerwise_lr_decay = bad)

--- a/tests/test_layerwise_lr_decay.py
+++ b/tests/test_layerwise_lr_decay.py
@@ -26,7 +26,11 @@ get_layer_index = mod.get_layer_index
 
 
 class FakeParam:
-    def __init__(self, tag, requires_grad = True):
+    def __init__(
+        self,
+        tag,
+        requires_grad = True,
+    ):
         self.tag = tag
         self.requires_grad = requires_grad
 
@@ -39,7 +43,12 @@ class FakeModel:
         return list(self._named)
 
 
-def build_model(num_layers = 4, with_head = True, with_embedding = True, frozen_layer = None):
+def build_model(
+    num_layers = 4,
+    with_head = True,
+    with_embedding = True,
+    frozen_layer = None,
+):
     named = []
     for i in range(num_layers):
         rg = not (frozen_layer is not None and i == frozen_layer)
@@ -48,10 +57,12 @@ def build_model(num_layers = 4, with_head = True, with_embedding = True, frozen_
     if with_head:
         named.append(("base_model.model.lm_head.weight", FakeParam("lm_head")))
     if with_embedding:
-        named.append((
-            "base_model.model.model.embed_tokens.modules_to_save.default.weight",
-            FakeParam("embed"),
-        ))
+        named.append(
+            (
+                "base_model.model.model.embed_tokens.modules_to_save.default.weight",
+                FakeParam("embed"),
+            )
+        )
     return FakeModel(named)
 
 
@@ -72,47 +83,62 @@ def test_layer_index_parsing():
 
 def test_decay_math_and_boundaries():
     base, decay = 1e-3, 0.9
-    groups = make_groups(build_model(4), lr = base, weight_decay = 0.01,
-                         layerwise_lr_decay = decay, verbose = False)
+    groups = make_groups(
+        build_model(4), lr = base, weight_decay = 0.01, layerwise_lr_decay = decay, verbose = False
+    )
     lrs = lr_by_tag(groups)
-    assert lrs["layer3"] == pytest.approx(base)              # top layer = base
-    assert lrs["layer2"] == pytest.approx(base * decay ** 1)
-    assert lrs["layer1"] == pytest.approx(base * decay ** 2)
-    assert lrs["layer0"] == pytest.approx(base * decay ** 3)  # deepest decay
-    assert lrs["lm_head"] == pytest.approx(base)              # non-block = top
-    assert lrs["embed"] == pytest.approx(base * decay ** 3)   # inherits shallowest
+    assert lrs["layer3"] == pytest.approx(base)  # top layer = base
+    assert lrs["layer2"] == pytest.approx(base * decay**1)
+    assert lrs["layer1"] == pytest.approx(base * decay**2)
+    assert lrs["layer0"] == pytest.approx(base * decay**3)  # deepest decay
+    assert lrs["lm_head"] == pytest.approx(base)  # non-block = top
+    assert lrs["embed"] == pytest.approx(base * decay**3)  # inherits shallowest
 
 
 def test_each_trainable_param_in_exactly_one_group():
-    groups = make_groups(build_model(4), lr = 1e-3, weight_decay = 0.0,
-                         layerwise_lr_decay = 0.9, verbose = False)
+    groups = make_groups(
+        build_model(4), lr = 1e-3, weight_decay = 0.0, layerwise_lr_decay = 0.9, verbose = False
+    )
     tags = [p.tag for g in groups for p in g["params"]]
     assert sorted(tags) == sorted(["layer0", "layer1", "layer2", "layer3", "lm_head", "embed"])
     assert len(tags) == len(set(tags))
 
 
 def test_frozen_params_excluded():
-    groups = make_groups(build_model(4, frozen_layer = 1), lr = 1e-3, weight_decay = 0.0,
-                         layerwise_lr_decay = 0.9, verbose = False)
+    groups = make_groups(
+        build_model(4, frozen_layer = 1),
+        lr = 1e-3,
+        weight_decay = 0.0,
+        layerwise_lr_decay = 0.9,
+        verbose = False,
+    )
     assert "layer1" not in lr_by_tag(groups)
 
 
 def test_embedding_lr_overrides_decay():
-    groups = make_groups(build_model(4), lr = 1e-3, weight_decay = 0.0,
-                         layerwise_lr_decay = 0.9, embedding_lr = 7e-6, verbose = False)
+    groups = make_groups(
+        build_model(4),
+        lr = 1e-3,
+        weight_decay = 0.0,
+        layerwise_lr_decay = 0.9,
+        embedding_lr = 7e-6,
+        verbose = False,
+    )
     assert lr_by_tag(groups)["embed"] == pytest.approx(7e-6)
 
 
 def test_decay_one_is_flat():
     base = 1e-3
-    groups = make_groups(build_model(4), lr = base, weight_decay = 0.0,
-                         layerwise_lr_decay = 1.0, verbose = False)
+    groups = make_groups(
+        build_model(4), lr = base, weight_decay = 0.0, layerwise_lr_decay = 1.0, verbose = False
+    )
     assert all(v == pytest.approx(base) for v in lr_by_tag(groups).values())
 
 
 def test_groups_sorted_and_weight_decay_propagated():
-    groups = make_groups(build_model(4), lr = 1e-3, weight_decay = 0.05,
-                         layerwise_lr_decay = 0.9, verbose = False)
+    groups = make_groups(
+        build_model(4), lr = 1e-3, weight_decay = 0.05, layerwise_lr_decay = 0.9, verbose = False
+    )
     rates = [g["lr"] for g in groups]
     assert rates == sorted(rates)
     assert all(g["weight_decay"] == 0.05 for g in groups)

--- a/unsloth/optimizers/__init__.py
+++ b/unsloth/optimizers/__init__.py
@@ -14,8 +14,10 @@
 
 from .q_galore_projector import GaLoreProjector
 from .q_galore_adamw import QGaLoreAdamW8bit
+from .layerwise_lr import make_layerwise_lr_param_groups, get_layer_index
 
 __all__ = [
     "GaLoreProjector",
     "QGaLoreAdamW8bit",
+    "make_layerwise_lr_param_groups",
 ]

--- a/unsloth/optimizers/__init__.py
+++ b/unsloth/optimizers/__init__.py
@@ -12,12 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .q_galore_projector import GaLoreProjector
-from .q_galore_adamw import QGaLoreAdamW8bit
-from .layerwise_lr import make_layerwise_lr_param_groups as make_layerwise_lr_param_groups
+import importlib
 
 __all__ = [
     "GaLoreProjector",
     "QGaLoreAdamW8bit",
     "make_layerwise_lr_param_groups",
 ]
+
+# Lazy so importing layerwise_lr (stdlib-only) doesn't also pull in Q-GaLore/bitsandbytes.
+_ATTR_TO_MODULE = {
+    "GaLoreProjector": "q_galore_projector",
+    "QGaLoreAdamW8bit": "q_galore_adamw",
+    "make_layerwise_lr_param_groups": "layerwise_lr",
+}
+
+
+def __getattr__(name):
+    module_name = _ATTR_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = importlib.import_module(f".{module_name}", __name__)
+    return getattr(module, name)

--- a/unsloth/optimizers/__init__.py
+++ b/unsloth/optimizers/__init__.py
@@ -14,7 +14,7 @@
 
 from .q_galore_projector import GaLoreProjector
 from .q_galore_adamw import QGaLoreAdamW8bit
-from .layerwise_lr import make_layerwise_lr_param_groups, get_layer_index
+from .layerwise_lr import make_layerwise_lr_param_groups as make_layerwise_lr_param_groups
 
 __all__ = [
     "GaLoreProjector",

--- a/unsloth/optimizers/__init__.py
+++ b/unsloth/optimizers/__init__.py
@@ -12,25 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import importlib
+from .q_galore_projector import GaLoreProjector
+from .q_galore_adamw import QGaLoreAdamW8bit
+from .layerwise_lr import make_layerwise_lr_param_groups
 
 __all__ = [
     "GaLoreProjector",
     "QGaLoreAdamW8bit",
     "make_layerwise_lr_param_groups",
 ]
-
-# Lazy so importing layerwise_lr (stdlib-only) doesn't also pull in Q-GaLore/bitsandbytes.
-_ATTR_TO_MODULE = {
-    "GaLoreProjector": "q_galore_projector",
-    "QGaLoreAdamW8bit": "q_galore_adamw",
-    "make_layerwise_lr_param_groups": "layerwise_lr",
-}
-
-
-def __getattr__(name):
-    module_name = _ATTR_TO_MODULE.get(name)
-    if module_name is None:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-    module = importlib.import_module(f".{module_name}", __name__)
-    return getattr(module, name)

--- a/unsloth/optimizers/layerwise_lr.py
+++ b/unsloth/optimizers/layerwise_lr.py
@@ -19,7 +19,7 @@ Stdlib-only so the grouping logic is testable without importing unsloth.
 
 import re
 
-__all__ = ["get_layer_index", "make_layerwise_lr_param_groups"]
+__all__ = ["get_layer_index", "make_layerwise_lr_param_groups", "check_layerwise_lr_compat"]
 
 _LAYER_INDEX_RE = re.compile(r"(?:^|\.)layers\.(\d+)\.")
 
@@ -29,8 +29,26 @@ def get_layer_index(name):
     return int(match.group(1)) if match is not None else None
 
 
+def get_layer_key(name):
+    # (stack prefix, index): decoder and vision towers are independent stacks.
+    match = _LAYER_INDEX_RE.search(name)
+    return (name[: match.start()], int(match.group(1))) if match is not None else None
+
+
 def _is_embedding_param(name):
     return name.endswith("modules_to_save.default.weight")
+
+
+def check_layerwise_lr_compat(layerwise_lr_decay, q_galore_config):
+    if (
+        layerwise_lr_decay is not None
+        and layerwise_lr_decay != 1.0
+        and q_galore_config is not None
+    ):
+        raise ValueError(
+            "Unsloth: layerwise_lr_decay is not supported together with q_galore_config. "
+            "Set one of them to None."
+        )
 
 
 def make_layerwise_lr_param_groups(
@@ -39,6 +57,7 @@ def make_layerwise_lr_param_groups(
     weight_decay,
     layerwise_lr_decay,
     embedding_lr = None,
+    num_layers = None,
     verbose = True,
 ):
     if not (0.0 < layerwise_lr_decay <= 1.0):
@@ -52,12 +71,22 @@ def make_layerwise_lr_param_groups(
         if getattr(param, "requires_grad", False)
     ]
 
-    layer_indices = [
-        idx for idx in (get_layer_index(name) for name, _ in trainable) if idx is not None
-    ]
-    num_layers = max(layer_indices) + 1 if layer_indices else 0
-    # Embeddings inherit the shallowest layer's rate unless overridden.
-    shallowest_lr = lr * (layerwise_lr_decay ** (num_layers - 1)) if num_layers else lr
+    # Depth per stack (prefix before ".layers.N."), so a deeper vision tower
+    # never rescales the decoder and vice-versa.
+    stack_depth = {}
+    for name, _ in trainable:
+        key = get_layer_key(name)
+        if key is not None:
+            prefix, idx = key
+            stack_depth[prefix] = max(stack_depth.get(prefix, 0), idx + 1)
+    # num_layers (model config depth) is only unambiguous with a single stack;
+    # use it as a floor there for partial adapters, else per-stack derived depth.
+    if num_layers is not None and len(stack_depth) == 1:
+        prefix = next(iter(stack_depth))
+        stack_depth[prefix] = max(stack_depth[prefix], num_layers)
+    max_depth = max(stack_depth.values(), default = 0)
+    # Embeddings inherit the most-decayed (deepest-stack) rate unless overridden.
+    shallowest_lr = lr * (layerwise_lr_decay ** (max_depth - 1)) if max_depth else lr
 
     groups = {}
 
@@ -72,19 +101,21 @@ def make_layerwise_lr_param_groups(
         if _is_embedding_param(name):
             _bucket(embedding_lr if embedding_lr is not None else shallowest_lr, param)
             continue
-        idx = get_layer_index(name)
-        if idx is None:
+        key = get_layer_key(name)
+        if key is None:
             # Non-block params (final norm, lm_head, ...) train at the top rate.
             _bucket(lr, param)
         else:
-            _bucket(lr * (layerwise_lr_decay ** (num_layers - 1 - idx)), param)
+            prefix, idx = key
+            _bucket(lr * (layerwise_lr_decay ** (stack_depth[prefix] - 1 - idx)), param)
 
     param_groups = sorted(groups.values(), key = lambda g: g["lr"])
 
     if verbose:
         rates = [g["lr"] for g in param_groups]
         print(
-            f"Unsloth: Layer-wise LR decay = {layerwise_lr_decay} across {num_layers} "
-            f"layers -> {len(param_groups)} groups, lr in [{min(rates):.2e}, {max(rates):.2e}]."
+            f"Unsloth: Layer-wise LR decay = {layerwise_lr_decay} across {len(stack_depth)} "
+            f"stack(s), max depth {max_depth} -> {len(param_groups)} groups, "
+            f"lr in [{min(rates):.2e}, {max(rates):.2e}]."
         )
     return param_groups

--- a/unsloth/optimizers/layerwise_lr.py
+++ b/unsloth/optimizers/layerwise_lr.py
@@ -40,11 +40,7 @@ def _is_embedding_param(name):
 
 
 def check_layerwise_lr_compat(layerwise_lr_decay, q_galore_config):
-    if (
-        layerwise_lr_decay is not None
-        and layerwise_lr_decay != 1.0
-        and q_galore_config is not None
-    ):
+    if layerwise_lr_decay is not None and layerwise_lr_decay != 1.0 and q_galore_config is not None:
         raise ValueError(
             "Unsloth: layerwise_lr_decay is not supported together with q_galore_config. "
             "Set one of them to None."

--- a/unsloth/optimizers/layerwise_lr.py
+++ b/unsloth/optimizers/layerwise_lr.py
@@ -53,14 +53,14 @@ def make_layerwise_lr_param_groups(
     ]
 
     layer_indices = [
-        idx for idx in (get_layer_index(name) for name, _ in trainable)
-        if idx is not None
+        idx for idx in (get_layer_index(name) for name, _ in trainable) if idx is not None
     ]
     num_layers = max(layer_indices) + 1 if layer_indices else 0
     # Embeddings inherit the shallowest layer's rate unless overridden.
     shallowest_lr = lr * (layerwise_lr_decay ** (num_layers - 1)) if num_layers else lr
 
     groups = {}
+
     def _bucket(group_lr, param):
         group = groups.get(group_lr)
         if group is None:

--- a/unsloth/optimizers/layerwise_lr.py
+++ b/unsloth/optimizers/layerwise_lr.py
@@ -1,0 +1,90 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Layer-wise learning-rate decay: lr(i) = base_lr * decay ** (num_layers - 1 - i).
+
+Stdlib-only so the grouping logic is testable without importing unsloth.
+"""
+
+import re
+
+__all__ = ["get_layer_index", "make_layerwise_lr_param_groups"]
+
+_LAYER_INDEX_RE = re.compile(r"(?:^|\.)layers\.(\d+)\.")
+
+
+def get_layer_index(name):
+    match = _LAYER_INDEX_RE.search(name)
+    return int(match.group(1)) if match is not None else None
+
+
+def _is_embedding_param(name):
+    return name.endswith("modules_to_save.default.weight")
+
+
+def make_layerwise_lr_param_groups(
+    model,
+    lr,
+    weight_decay,
+    layerwise_lr_decay,
+    embedding_lr = None,
+    verbose = True,
+):
+    if not (0.0 < layerwise_lr_decay <= 1.0):
+        raise ValueError(
+            f"Unsloth: layerwise_lr_decay must be in (0, 1], got {layerwise_lr_decay}."
+        )
+
+    trainable = [
+        (name, param)
+        for name, param in model.named_parameters()
+        if getattr(param, "requires_grad", False)
+    ]
+
+    layer_indices = [
+        idx for idx in (get_layer_index(name) for name, _ in trainable)
+        if idx is not None
+    ]
+    num_layers = max(layer_indices) + 1 if layer_indices else 0
+    # Embeddings inherit the shallowest layer's rate unless overridden.
+    shallowest_lr = lr * (layerwise_lr_decay ** (num_layers - 1)) if num_layers else lr
+
+    groups = {}
+    def _bucket(group_lr, param):
+        group = groups.get(group_lr)
+        if group is None:
+            group = {"params": [], "lr": group_lr, "weight_decay": weight_decay}
+            groups[group_lr] = group
+        group["params"].append(param)
+
+    for name, param in trainable:
+        if _is_embedding_param(name):
+            _bucket(embedding_lr if embedding_lr is not None else shallowest_lr, param)
+            continue
+        idx = get_layer_index(name)
+        if idx is None:
+            # Non-block params (final norm, lm_head, ...) train at the top rate.
+            _bucket(lr, param)
+        else:
+            _bucket(lr * (layerwise_lr_decay ** (num_layers - 1 - idx)), param)
+
+    param_groups = sorted(groups.values(), key = lambda g: g["lr"])
+
+    if verbose:
+        rates = [g["lr"] for g in param_groups]
+        print(
+            f"Unsloth: Layer-wise LR decay = {layerwise_lr_decay} across {num_layers} "
+            f"layers -> {len(param_groups)} groups, lr in [{min(rates):.2e}, {max(rates):.2e}]."
+        )
+    return param_groups

--- a/unsloth/optimizers/layerwise_lr.py
+++ b/unsloth/optimizers/layerwise_lr.py
@@ -21,7 +21,7 @@ import re
 
 __all__ = ["get_layer_index", "make_layerwise_lr_param_groups", "check_layerwise_lr_compat"]
 
-_LAYER_INDEX_RE = re.compile(r"(?:^|\.)layers\.(\d+)\.")
+_LAYER_INDEX_RE = re.compile(r"(?:^|\.)(?:layers|blocks)\.(\d+)\.")
 
 
 def get_layer_index(name):

--- a/unsloth/optimizers/q_galore_adamw.py
+++ b/unsloth/optimizers/q_galore_adamw.py
@@ -32,7 +32,8 @@ try:
     import bitsandbytes.functional as bnb_F
     from bitsandbytes.optim.optimizer import Optimizer2State
     _HAS_BNB = True
-except ImportError:
+except Exception:
+    # Broad: a broken bitsandbytes install can raise native-load errors, not just ImportError.
     _HAS_BNB = False
     # Fallback base so the module can still be imported.
     Optimizer2State = torch.optim.Optimizer

--- a/unsloth/optimizers/q_galore_adamw.py
+++ b/unsloth/optimizers/q_galore_adamw.py
@@ -32,8 +32,7 @@ try:
     import bitsandbytes.functional as bnb_F
     from bitsandbytes.optim.optimizer import Optimizer2State
     _HAS_BNB = True
-except Exception:
-    # Broad: a broken bitsandbytes install can raise native-load errors, not just ImportError.
+except ImportError:
     _HAS_BNB = False
     # Fallback base so the module can still be imported.
     Optimizer2State = torch.optim.Optimizer

--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -437,20 +437,26 @@ def _create_unsloth_optimizer(
 
 class UnslothTrainer(SFTTrainer):
     def create_optimizer(self):
-        # --- Q-GaLore optimizer ---
         q_galore_config = getattr(self.args, "q_galore_config", None)
-        if q_galore_config is not None and self.optimizer is None:
-            embedding_lr = getattr(self.args, "embedding_learning_rate", None)
-            return self._create_q_galore_optimizer(q_galore_config, embedding_lr)
-
         embedding_learning_rate = getattr(self.args, "embedding_learning_rate", None)
         layerwise_lr_decay = getattr(self.args, "layerwise_lr_decay", None)
+
+        from unsloth.optimizers.layerwise_lr import (
+            check_layerwise_lr_compat,
+            make_layerwise_lr_param_groups,
+        )
+
+        check_layerwise_lr_compat(layerwise_lr_decay, q_galore_config)
+
+        # --- Q-GaLore optimizer ---
+        if q_galore_config is not None and self.optimizer is None:
+            return self._create_q_galore_optimizer(q_galore_config, embedding_learning_rate)
 
         # --- Layer-wise LR decay optimizer (composes with embedding_lr) ---
         if layerwise_lr_decay is not None and layerwise_lr_decay != 1.0:
             if self.optimizer is None:
-                from unsloth.optimizers.layerwise_lr import make_layerwise_lr_param_groups
-
+                config = getattr(self.model, "config", None)
+                num_layers = getattr(config, "num_hidden_layers", None)
                 optimizer_cls, optimizer_kwargs = SFTTrainer.get_optimizer_cls_and_kwargs(self.args)
                 param_groups = make_layerwise_lr_param_groups(
                     self.model,
@@ -458,6 +464,7 @@ class UnslothTrainer(SFTTrainer):
                     weight_decay = optimizer_kwargs.get("weight_decay", 0.0),
                     layerwise_lr_decay = layerwise_lr_decay,
                     embedding_lr = embedding_learning_rate,
+                    num_layers = num_layers,
                 )
                 self.optimizer = optimizer_cls(param_groups, **optimizer_kwargs)
             return self.optimizer

--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -379,14 +379,17 @@ class UnslothTrainingArguments(TrainingArguments):
     def __init__(
         self,
         embedding_learning_rate: float = None,
+        layerwise_lr_decay: float = None,
         q_galore_config: Optional[QGaloreConfig] = None,
         *args,
         **kwargs,
     ):
         self.q_galore_config = q_galore_config
         self.embedding_learning_rate = embedding_learning_rate
+        self.layerwise_lr_decay = layerwise_lr_decay
         super().__init__(*args, **kwargs)
         self.embedding_learning_rate = embedding_learning_rate
+        self.layerwise_lr_decay = layerwise_lr_decay
 
 
 def _create_unsloth_optimizer(
@@ -440,8 +443,25 @@ class UnslothTrainer(SFTTrainer):
             embedding_lr = getattr(self.args, "embedding_learning_rate", None)
             return self._create_q_galore_optimizer(q_galore_config, embedding_lr)
 
-        # --- Embedding-LR optimizer ---
         embedding_learning_rate = getattr(self.args, "embedding_learning_rate", None)
+        layerwise_lr_decay = getattr(self.args, "layerwise_lr_decay", None)
+
+        # --- Layer-wise LR decay optimizer (composes with embedding_lr) ---
+        if layerwise_lr_decay is not None and layerwise_lr_decay != 1.0:
+            if self.optimizer is None:
+                from unsloth.optimizers.layerwise_lr import make_layerwise_lr_param_groups
+                optimizer_cls, optimizer_kwargs = SFTTrainer.get_optimizer_cls_and_kwargs(self.args)
+                param_groups = make_layerwise_lr_param_groups(
+                    self.model,
+                    lr = optimizer_kwargs["lr"],
+                    weight_decay = optimizer_kwargs.get("weight_decay", 0.0),
+                    layerwise_lr_decay = layerwise_lr_decay,
+                    embedding_lr = embedding_learning_rate,
+                )
+                self.optimizer = optimizer_cls(param_groups, **optimizer_kwargs)
+            return self.optimizer
+
+        # --- Embedding-LR optimizer ---
         if embedding_learning_rate is None:
             return super().create_optimizer()
 

--- a/unsloth/trainer.py
+++ b/unsloth/trainer.py
@@ -450,6 +450,7 @@ class UnslothTrainer(SFTTrainer):
         if layerwise_lr_decay is not None and layerwise_lr_decay != 1.0:
             if self.optimizer is None:
                 from unsloth.optimizers.layerwise_lr import make_layerwise_lr_param_groups
+
                 optimizer_cls, optimizer_kwargs = SFTTrainer.get_optimizer_cls_and_kwargs(self.args)
                 param_groups = make_layerwise_lr_param_groups(
                     self.model,


### PR DESCRIPTION
Adds an opt-in `layerwise_lr_decay` arg to `UnslothTrainingArguments`, where deeper layers get a higher LR, shallower layers lower, decaying by depth (`lr(i) = base_lr * decay ** (num_layers - 1 - i)`). This is a Classic fine-tuning trick where it helps stability on small datasets.

Off by default (None/1.0 = flat LR, no behavior change), composes with the existing embedding_lr, and works with LoRA. Grouping logic is stdlib-only so it's unit-tested on CPU (10 tests).