### PR TITLE
Studio: stop a clicked tooltip from hanging over dialogs

### DIFF
--- a/studio/frontend/src/components/ui/tooltip-modal-layer.ts
+++ b/studio/frontend/src/components/ui/tooltip-modal-layer.ts
@@ -2,14 +2,17 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 /**
- * Radix's DismissableLayer sets pointer-events:none on layers below the active
- * modal and pointer-events:auto on layers that belong to it. Reading the
- * tooltip layer itself avoids guessing which dialog, sheet, or menu owns its
- * trigger.
+ * Radix's DismissableLayer sets pointer-events:none on the body while a modal
+ * is up, and pointer-events:auto on the active layer. A trigger inside that
+ * layer therefore computes "auto" and one outside computes "none", which is
+ * what says whether a tooltip belongs to the modal.
+ *
+ * Read the trigger, never the tooltip content: layers rank by mount order, so
+ * content opened after the modal reads "auto" wherever its trigger sits.
  */
-export function isTooltipLayerBlocked(element: HTMLElement): boolean {
+export function isBlockedByActiveModal(element: HTMLElement): boolean {
   return (
-    element.ownerDocument.defaultView?.getComputedStyle(element).pointerEvents ===
-    "none"
+    element.ownerDocument.defaultView?.getComputedStyle(element)
+      .pointerEvents === "none"
   );
 }

--- a/studio/frontend/src/components/ui/tooltip-modal-layer.ts
+++ b/studio/frontend/src/components/ui/tooltip-modal-layer.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/**
+ * Radix's DismissableLayer sets pointer-events:none on layers below the active
+ * modal and pointer-events:auto on layers that belong to it. Reading the
+ * tooltip layer itself avoids guessing which dialog, sheet, or menu owns its
+ * trigger.
+ */
+export function isTooltipLayerBlocked(element: HTMLElement): boolean {
+  return (
+    element.ownerDocument.defaultView?.getComputedStyle(element).pointerEvents ===
+    "none"
+  );
+}

--- a/studio/frontend/src/components/ui/tooltip-modal-layer.ts
+++ b/studio/frontend/src/components/ui/tooltip-modal-layer.ts
@@ -2,17 +2,25 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 /**
- * Radix's DismissableLayer sets pointer-events:none on the body while a modal
- * is up, and pointer-events:auto on the active layer. A trigger inside that
- * layer therefore computes "auto" and one outside computes "none", which is
- * what says whether a tooltip belongs to the modal.
+ * Whether a tooltip trigger sits below the active modal rather than inside it.
+ *
+ * Radix's DismissableLayer writes `pointer-events` inline: `none` on the body
+ * while a modal is up, `auto` on the active layer, `none` on the layers under
+ * it. Walking the ancestors for the nearest of those answers which layer owns
+ * the trigger.
+ *
+ * The trigger's own style is deliberately skipped. A trigger can be authored
+ * `pointer-events: none` and still belong to the modal, which is exactly what
+ * the hint anchors inside the MCP dropdown rows do.
  *
  * Read the trigger, never the tooltip content: layers rank by mount order, so
- * content opened after the modal reads "auto" wherever its trigger sits.
+ * content opened after the modal reads `auto` wherever its trigger sits.
  */
 export function isBlockedByActiveModal(element: HTMLElement): boolean {
-  return (
-    element.ownerDocument.defaultView?.getComputedStyle(element)
-      .pointerEvents === "none"
-  );
+  for (let node = element.parentElement; node; node = node.parentElement) {
+    const pointerEvents = node.style?.pointerEvents;
+    if (pointerEvents === "auto") return false;
+    if (pointerEvents === "none") return true;
+  }
+  return false;
 }

--- a/studio/frontend/src/components/ui/tooltip-open-state.ts
+++ b/studio/frontend/src/components/ui/tooltip-open-state.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+/** What a tooltip renders, given everything that can hold it open or shut.
+ *
+ * Radix is always given a boolean so it keeps no open state of its own that
+ * could survive a modal and resurface after it closes.
+ */
+export function resolveTooltipOpen(state: {
+  /** A modal owns the screen and this tooltip's trigger is not inside it. */
+  blocked: boolean;
+  /** The consumer's `open`, or undefined when this tooltip is uncontrolled. */
+  controlledOpen?: boolean;
+  /** A modal blocked it and the owner has not said false since. */
+  dismissedUntilOwnerResets: boolean;
+  /** Radix's hover/focus state, tracked here rather than left inside it. */
+  hoverOpen: boolean;
+  /** Pinned by a tap, which has no hover to close it. */
+  clickOpen: boolean;
+}): boolean {
+  if (state.blocked) return false;
+  if (state.controlledOpen !== undefined) {
+    // An owner with no onOpenChange (panel-resize-handle) never learns its
+    // trigger lost the pointer, so its `open` is still true when the modal
+    // closes. Honour it again only after it has gone false once.
+    return state.controlledOpen && !state.dismissedUntilOwnerResets;
+  }
+  return state.hoverOpen || state.clickOpen;
+}

--- a/studio/frontend/src/components/ui/tooltip.tsx
+++ b/studio/frontend/src/components/ui/tooltip.tsx
@@ -13,6 +13,7 @@ import {
 import type * as React from "react";
 
 import { isBlockedByActiveModal } from "@/components/ui/tooltip-modal-layer";
+import { resolveTooltipOpen } from "@/components/ui/tooltip-open-state";
 import { cn } from "@/lib/utils";
 
 type ToggleFn = () => void;
@@ -177,6 +178,11 @@ function Tooltip({
   // dialog, with the pointer somewhere else entirely.
   const [hoverOpen, setHoverOpen] = useState(false);
   const [clickOpen, setClickOpen] = useState(false);
+  // A controlled tooltip's owner cannot be reset from here, and it never saw
+  // the pointerleave a modal swallowed, so its `open` is still true when the
+  // modal closes. Stay shut until the owner says false at least once.
+  const [dismissedUntilOwnerResets, setDismissedUntilOwnerResets] =
+    useState(false);
   const [modalBlockStore] = useState(createModalBlockStore);
   const blocked = useSyncExternalStore(
     modalBlockStore.subscribe,
@@ -204,8 +210,16 @@ function Tooltip({
     if (!blocked) return;
     setHoverOpen(false);
     setClickOpen(false);
+    setDismissedUntilOwnerResets(true);
     controlledOnOpenChange?.(false);
   }, [blocked, controlledOnOpenChange]);
+
+  // `panel-resize-handle.tsx` passes `open` with no onOpenChange, so telling it
+  // does nothing and its `hovered` stays true. Releasing on its say-so alone
+  // would put the tooltip back with the pointer somewhere else entirely.
+  useEffect(() => {
+    if (controlledOpen === false) setDismissedUntilOwnerResets(false);
+  }, [controlledOpen]);
 
   // A pin must not outlive its interaction: once a dialog covers the trigger,
   // pointerleave never fires and Radix can no longer close it. Presses on a
@@ -249,9 +263,13 @@ function Tooltip({
           data-slot="tooltip"
           // Always a boolean, so Radix keeps no separate open state that could
           // survive a modal and resurface after it closes.
-          open={
-            blocked ? false : isControlled ? controlledOpen : hoverOpen || clickOpen
-          }
+          open={resolveTooltipOpen({
+            blocked,
+            controlledOpen,
+            dismissedUntilOwnerResets,
+            hoverOpen,
+            clickOpen,
+          })}
           onOpenChange={onOpenChange}
           {...props}
         />

--- a/studio/frontend/src/components/ui/tooltip.tsx
+++ b/studio/frontend/src/components/ui/tooltip.tsx
@@ -51,9 +51,14 @@ function getModalLayer(): boolean {
   return modalLayerUp;
 }
 
-/** Tap-to-pin is for touch, which has no hover. Read at click time so hybrid
- * devices answer for the pointer in use. */
-function isCoarsePointer(): boolean {
+/** Tap-to-pin is for touch, which has no hover. The click's own pointerType is
+ * the only thing that answers for the pointer actually used: the media query
+ * reports the primary device, so on a hybrid it mislabels every event from the
+ * other one. Keyboard activation reports "", which correctly does not pin. */
+function isTouchClick(event: React.MouseEvent): boolean {
+  const pointerType = (event.nativeEvent as Partial<PointerEvent>).pointerType;
+  if (typeof pointerType === "string") return pointerType === "touch";
+  // No PointerEvent (older WebViews): fall back to the device class.
   return (
     typeof window !== "undefined" &&
     typeof window.matchMedia === "function" &&
@@ -139,7 +144,8 @@ function Tooltip({
   }, [clickOpen]);
 
   return (
-    <TooltipToggleCtx.Provider value={toggle}>
+    // Controlled tooltips own their open state; pinning would never render.
+    <TooltipToggleCtx.Provider value={isControlled ? null : toggle}>
       <TooltipPrimitive.Root
         data-slot="tooltip"
         // false, not undefined: a hovered tooltip has to be forced shut when a
@@ -167,12 +173,13 @@ function TooltipTrigger({
       // action is skipped if the event is already default-prevented.
       onClick?.(e);
       // With a mouse, hover already shows it and pinning only strands it. Let
-      // Radix's own close-on-click run instead.
-      if (!isCoarsePointer()) return;
+      // Radix's own close-on-click run instead. `toggle` is absent when the
+      // consumer controls `open`, where a pin would be dead state anyway.
+      if (!toggle || !isTouchClick(e)) return;
       // preventDefault keeps Radix Tooltip's internal close-on-click from
       // undoing the tap-toggle below (its composed handler checks it).
       e.preventDefault();
-      toggle?.();
+      toggle();
     },
     [toggle, onClick],
   );

--- a/studio/frontend/src/components/ui/tooltip.tsx
+++ b/studio/frontend/src/components/ui/tooltip.tsx
@@ -12,10 +12,17 @@ import {
 } from "react";
 import type * as React from "react";
 
+import { isTooltipLayerBlocked } from "@/components/ui/tooltip-modal-layer";
 import { cn } from "@/lib/utils";
 
 type ToggleFn = () => void;
 const TooltipToggleCtx = createContext<ToggleFn | null>(null);
+type TooltipContentElement = React.ComponentRef<
+  typeof TooltipPrimitive.Content
+>;
+const TooltipContentElementCtx = createContext<
+  (element: TooltipContentElement | null) => void
+>(() => undefined);
 
 // Radix sets body pointer-events to none while a modal layer is up. That is also
 // when a hovered trigger stops receiving pointerleave, so a tooltip already on
@@ -26,19 +33,37 @@ const modalLayerListeners = new Set<() => void>();
 let modalLayerObserver: MutationObserver | null = null;
 
 function readModalLayer(): void {
-  const next = document.body.style.pointerEvents === "none";
-  if (next === modalLayerUp) return;
-  modalLayerUp = next;
+  modalLayerUp = document.body.style.pointerEvents === "none";
   for (const listener of modalLayerListeners) listener();
+}
+
+function readPointerEvents(style: string | null): string {
+  return (
+    /(?:^|;)\s*pointer-events\s*:\s*([^;]+)/.exec(style ?? "")?.[1]?.trim() ??
+    ""
+  );
+}
+
+function readRelevantLayerMutations(records: MutationRecord[]): void {
+  const pointerEventsChanged = records.some(
+    (record) =>
+      readPointerEvents(record.oldValue) !==
+      readPointerEvents(
+        (record.target as Element).getAttribute?.("style") ?? null,
+      ),
+  );
+  if (pointerEventsChanged) readModalLayer();
 }
 
 function subscribeModalLayer(listener: () => void): () => void {
   modalLayerListeners.add(listener);
   if (!modalLayerObserver && typeof MutationObserver !== "undefined") {
-    modalLayerObserver = new MutationObserver(readModalLayer);
+    modalLayerObserver = new MutationObserver(readRelevantLayerMutations);
     modalLayerObserver.observe(document.body, {
       attributes: true,
       attributeFilter: ["style"],
+      attributeOldValue: true,
+      subtree: true,
     });
     readModalLayer();
   }
@@ -49,6 +74,67 @@ function subscribeModalLayer(listener: () => void): () => void {
 
 function getModalLayer(): boolean {
   return modalLayerUp;
+}
+
+function assignRef<T>(ref: React.Ref<T> | undefined, value: T | null): void {
+  if (typeof ref === "function") {
+    ref(value);
+  } else if (ref) {
+    ref.current = value;
+  }
+}
+
+type ModalBlockStore = {
+  getSnapshot: () => boolean;
+  setContentElement: (element: TooltipContentElement | null) => void;
+  subscribe: (listener: () => void) => () => void;
+};
+
+function createModalBlockStore(releasePin: () => void): ModalBlockStore {
+  let contentElement: TooltipContentElement | null = null;
+  let blocked = false;
+  let unsubscribeModalLayer: (() => void) | null = null;
+  const listeners = new Set<() => void>();
+
+  const update = () => {
+    // Preserve `true` after forced closure unmounts the content. Releasing it
+    // here would hand control back to Radix's still-open hover state.
+    const next = !getModalLayer()
+      ? false
+      : contentElement
+        ? isTooltipLayerBlocked(contentElement)
+        : blocked;
+    if (next === blocked) return;
+    blocked = next;
+    if (blocked) releasePin();
+    for (const listener of listeners) listener();
+  };
+
+  return {
+    getSnapshot: () => blocked,
+    setContentElement: (element) => {
+      contentElement = element;
+      update();
+    },
+    subscribe: (listener) => {
+      listeners.add(listener);
+      if (listeners.size === 1) {
+        unsubscribeModalLayer = subscribeModalLayer(update);
+      }
+      update();
+      return () => {
+        listeners.delete(listener);
+        if (listeners.size === 0) {
+          unsubscribeModalLayer?.();
+          unsubscribeModalLayer = null;
+        }
+      };
+    },
+  };
+}
+
+function getServerModalBlock(): boolean {
+  return false;
 }
 
 /** Tap-to-pin is for touch, which has no hover. The click's own pointerType is
@@ -90,11 +176,15 @@ function Tooltip({
 }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
   const isControlled = controlledOpen !== undefined;
   const [clickOpen, setClickOpen] = useState(false);
-  const modalUp = useSyncExternalStore(
-    subscribeModalLayer,
-    getModalLayer,
-    () => false,
+  const [modalBlockStore] = useState(() =>
+    createModalBlockStore(() => setClickOpen(false)),
   );
+  const modalBlock = useSyncExternalStore(
+    modalBlockStore.subscribe,
+    modalBlockStore.getSnapshot,
+    getServerModalBlock,
+  );
+  const blockedByModal = !isControlled && modalBlock;
 
   const onOpenChange = useCallback(
     (nextOpen: boolean) => {
@@ -107,11 +197,6 @@ function Tooltip({
   const toggle = useCallback(() => {
     setClickOpen((prev) => !prev);
   }, []);
-
-  // Drop the pin too, so it does not reappear when the dialog closes.
-  useEffect(() => {
-    if (modalUp) setClickOpen(false);
-  }, [modalUp]);
 
   // A pin must not outlive its interaction: once a dialog covers the trigger,
   // pointerleave never fires and Radix can no longer close it. Presses on a
@@ -145,18 +230,26 @@ function Tooltip({
 
   return (
     // Controlled tooltips own their open state; pinning would never render.
-    <TooltipToggleCtx.Provider value={isControlled ? null : toggle}>
-      <TooltipPrimitive.Root
-        data-slot="tooltip"
-        // false, not undefined: a hovered tooltip has to be forced shut when a
-        // dialog opens, and stay shut until it closes.
-        open={
-          isControlled ? controlledOpen : modalUp ? false : clickOpen || undefined
-        }
-        onOpenChange={onOpenChange}
-        {...props}
-      />
-    </TooltipToggleCtx.Provider>
+    <TooltipContentElementCtx.Provider
+      value={modalBlockStore.setContentElement}
+    >
+      <TooltipToggleCtx.Provider value={isControlled ? null : toggle}>
+        <TooltipPrimitive.Root
+          data-slot="tooltip"
+          // false, not undefined: a hovered tooltip outside the active modal
+          // must stay shut until that modal closes.
+          open={
+            isControlled
+              ? controlledOpen
+              : blockedByModal
+                ? false
+                : clickOpen || undefined
+          }
+          onOpenChange={onOpenChange}
+          {...props}
+        />
+      </TooltipToggleCtx.Provider>
+    </TooltipContentElementCtx.Provider>
   );
 }
 
@@ -204,16 +297,20 @@ function TooltipContent({
   className,
   sideOffset = 0,
   children,
+  ref,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content> & {
   variant?: TooltipVariant;
 }) {
+  const setContentElement = useContext(TooltipContentElementCtx);
   // Single-line compact tooltips render as a full pill; wrapped ones keep
   // the squarer corners so tall pills do not look like capsules. A ref
   // callback measures on mount: Radix mounts the portal content without
   // re-rendering this wrapper, so an effect here would never see the node.
-  const measureRef = useCallback(
-    (el: HTMLDivElement | null) => {
+  const contentRef = useCallback(
+    (el: TooltipContentElement | null) => {
+      assignRef(ref, el);
+      setContentElement(el);
       if (!el || variant !== "default") return;
       const cs = getComputedStyle(el);
       const lineHeight = Number.parseFloat(cs.lineHeight) || 16;
@@ -223,12 +320,12 @@ function TooltipContent({
         Number.parseFloat(cs.paddingBottom);
       el.classList.toggle("rounded-full!", innerHeight < lineHeight * 1.5);
     },
-    [variant],
+    [ref, setContentElement, variant],
   );
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
-        ref={measureRef}
+        ref={contentRef}
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(

--- a/studio/frontend/src/components/ui/tooltip.tsx
+++ b/studio/frontend/src/components/ui/tooltip.tsx
@@ -2,13 +2,29 @@
 // Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
 
 import { Tooltip as TooltipPrimitive } from "radix-ui";
-import { createContext, useCallback, useContext, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 import type * as React from "react";
 
 import { cn } from "@/lib/utils";
 
 type ToggleFn = () => void;
 const TooltipToggleCtx = createContext<ToggleFn | null>(null);
+
+/** Tap-to-pin is for touch, which has no hover. Read at click time so hybrid
+ * devices answer for the pointer in use. */
+function isCoarsePointer(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(pointer: coarse)").matches
+  );
+}
 
 // Default to instant open (no hover delay). Most tooltips in the app —
 // chat-area icon labels, sidebar nav labels, the context/token
@@ -47,6 +63,36 @@ function Tooltip({
     setClickOpen((prev) => !prev);
   }, []);
 
+  // A pin must not outlive its interaction: once a dialog covers the trigger,
+  // pointerleave never fires and Radix can no longer close it. Presses on a
+  // trigger are skipped so tapping the same one still toggles it shut.
+  useEffect(() => {
+    if (!clickOpen) return;
+    const release = (event: Event) => {
+      const target = event.target as Element | null;
+      if (
+        target?.closest?.(
+          '[data-slot="tooltip-trigger"],[data-slot="tooltip-content"]',
+        )
+      ) {
+        return;
+      }
+      setClickOpen(false);
+    };
+    const releaseOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setClickOpen(false);
+    };
+    const releaseNow = () => setClickOpen(false);
+    document.addEventListener("pointerdown", release, true);
+    document.addEventListener("keydown", releaseOnEscape, true);
+    window.addEventListener("blur", releaseNow);
+    return () => {
+      document.removeEventListener("pointerdown", release, true);
+      document.removeEventListener("keydown", releaseOnEscape, true);
+      window.removeEventListener("blur", releaseNow);
+    };
+  }, [clickOpen]);
+
   return (
     <TooltipToggleCtx.Provider value={toggle}>
       <TooltipPrimitive.Root
@@ -71,6 +117,9 @@ function TooltipTrigger({
       // trigger (e.g. DialogTrigger around an attachment tile), that trigger's
       // action is skipped if the event is already default-prevented.
       onClick?.(e);
+      // With a mouse, hover already shows it and pinning only strands it. Let
+      // Radix's own close-on-click run instead.
+      if (!isCoarsePointer()) return;
       // preventDefault keeps Radix Tooltip's internal close-on-click from
       // undoing the tap-toggle below (its composed handler checks it).
       e.preventDefault();

--- a/studio/frontend/src/components/ui/tooltip.tsx
+++ b/studio/frontend/src/components/ui/tooltip.tsx
@@ -83,6 +83,7 @@ function assignRef<T>(ref: React.Ref<T> | undefined, value: T | null): void {
 
 type ModalBlockStore = {
   getSnapshot: () => boolean;
+  getTriggerElement: () => HTMLElement | null;
   setTriggerElement: (element: HTMLElement | null) => void;
   subscribe: (listener: () => void) => () => void;
 };
@@ -106,6 +107,7 @@ function createModalBlockStore(): ModalBlockStore {
 
   return {
     getSnapshot: () => blocked,
+    getTriggerElement: () => triggerElement,
     setTriggerElement: (element) => {
       triggerElement = element;
       update();
@@ -211,11 +213,16 @@ function Tooltip({
   useEffect(() => {
     if (!clickOpen) return;
     const release = (event: Event) => {
-      const target = event.target as Element | null;
+      const target = event.target as Node | null;
+      // The trigger is matched by element, not by data-slot: an `asChild` child
+      // can drop the attribute (a component that does not spread props), and
+      // then a press on this very trigger read as outside, cleared the pin, and
+      // the click handler toggled it straight back on.
+      if (target && modalBlockStore.getTriggerElement()?.contains(target)) {
+        return;
+      }
       if (
-        target?.closest?.(
-          '[data-slot="tooltip-trigger"],[data-slot="tooltip-content"]',
-        )
+        (target as Element | null)?.closest?.('[data-slot="tooltip-content"]')
       ) {
         return;
       }
@@ -233,7 +240,7 @@ function Tooltip({
       document.removeEventListener("keydown", releaseOnEscape, true);
       window.removeEventListener("blur", releaseNow);
     };
-  }, [clickOpen]);
+  }, [clickOpen, modalBlockStore]);
 
   return (
     <TooltipTriggerElementCtx.Provider value={modalBlockStore.setTriggerElement}>

--- a/studio/frontend/src/components/ui/tooltip.tsx
+++ b/studio/frontend/src/components/ui/tooltip.tsx
@@ -12,17 +12,14 @@ import {
 } from "react";
 import type * as React from "react";
 
-import { isTooltipLayerBlocked } from "@/components/ui/tooltip-modal-layer";
+import { isBlockedByActiveModal } from "@/components/ui/tooltip-modal-layer";
 import { cn } from "@/lib/utils";
 
 type ToggleFn = () => void;
 const TooltipToggleCtx = createContext<ToggleFn | null>(null);
-type TooltipContentElement = React.ComponentRef<
-  typeof TooltipPrimitive.Content
->;
-const TooltipContentElementCtx = createContext<
-  (element: TooltipContentElement | null) => void
->(() => undefined);
+const TooltipTriggerElementCtx = createContext<(element: HTMLElement | null) => void>(
+  () => undefined,
+);
 
 // Radix sets body pointer-events to none while a modal layer is up. That is also
 // when a hovered trigger stops receiving pointerleave, so a tooltip already on
@@ -86,34 +83,31 @@ function assignRef<T>(ref: React.Ref<T> | undefined, value: T | null): void {
 
 type ModalBlockStore = {
   getSnapshot: () => boolean;
-  setContentElement: (element: TooltipContentElement | null) => void;
+  setTriggerElement: (element: HTMLElement | null) => void;
   subscribe: (listener: () => void) => () => void;
 };
 
-function createModalBlockStore(releasePin: () => void): ModalBlockStore {
-  let contentElement: TooltipContentElement | null = null;
+function createModalBlockStore(): ModalBlockStore {
+  let triggerElement: HTMLElement | null = null;
   let blocked = false;
   let unsubscribeModalLayer: (() => void) | null = null;
   const listeners = new Set<() => void>();
 
   const update = () => {
-    // Preserve `true` after forced closure unmounts the content. Releasing it
-    // here would hand control back to Radix's still-open hover state.
-    const next = !getModalLayer()
-      ? false
-      : contentElement
-        ? isTooltipLayerBlocked(contentElement)
-        : blocked;
+    // No trigger to ask (a child that drops the ref) falls back to the whole
+    // modal: leaving it shut beats leaving it stranded over the dialog.
+    const next =
+      getModalLayer() &&
+      (triggerElement === null || isBlockedByActiveModal(triggerElement));
     if (next === blocked) return;
     blocked = next;
-    if (blocked) releasePin();
     for (const listener of listeners) listener();
   };
 
   return {
     getSnapshot: () => blocked,
-    setContentElement: (element) => {
-      contentElement = element;
+    setTriggerElement: (element) => {
+      triggerElement = element;
       update();
     },
     subscribe: (listener) => {
@@ -175,19 +169,22 @@ function Tooltip({
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
   const isControlled = controlledOpen !== undefined;
+  // Radix's own open state is never handed back once a modal forces the
+  // tooltip shut, so hover is tracked here and `open` is always supplied.
+  // Falling back to `undefined` would re-expose a `true` from before the
+  // dialog, with the pointer somewhere else entirely.
+  const [hoverOpen, setHoverOpen] = useState(false);
   const [clickOpen, setClickOpen] = useState(false);
-  const [modalBlockStore] = useState(() =>
-    createModalBlockStore(() => setClickOpen(false)),
-  );
-  const modalBlock = useSyncExternalStore(
+  const [modalBlockStore] = useState(createModalBlockStore);
+  const blocked = useSyncExternalStore(
     modalBlockStore.subscribe,
     modalBlockStore.getSnapshot,
     getServerModalBlock,
   );
-  const blockedByModal = !isControlled && modalBlock;
 
   const onOpenChange = useCallback(
     (nextOpen: boolean) => {
+      setHoverOpen(nextOpen);
       if (!nextOpen) setClickOpen(false);
       controlledOnOpenChange?.(nextOpen);
     },
@@ -197,6 +194,16 @@ function Tooltip({
   const toggle = useCallback(() => {
     setClickOpen((prev) => !prev);
   }, []);
+
+  // Drop what is open when a modal takes over, so closing the dialog does not
+  // bring the tooltip back on its own. Owners of a controlled tooltip are told,
+  // since their state (a `hovered` flag) never sees the pointerleave either.
+  useEffect(() => {
+    if (!blocked) return;
+    setHoverOpen(false);
+    setClickOpen(false);
+    controlledOnOpenChange?.(false);
+  }, [blocked, controlledOnOpenChange]);
 
   // A pin must not outlive its interaction: once a dialog covers the trigger,
   // pointerleave never fires and Radix can no longer close it. Presses on a
@@ -229,35 +236,40 @@ function Tooltip({
   }, [clickOpen]);
 
   return (
-    // Controlled tooltips own their open state; pinning would never render.
-    <TooltipContentElementCtx.Provider
-      value={modalBlockStore.setContentElement}
-    >
+    <TooltipTriggerElementCtx.Provider value={modalBlockStore.setTriggerElement}>
       <TooltipToggleCtx.Provider value={isControlled ? null : toggle}>
         <TooltipPrimitive.Root
           data-slot="tooltip"
-          // false, not undefined: a hovered tooltip outside the active modal
-          // must stay shut until that modal closes.
+          // Always a boolean, so Radix keeps no separate open state that could
+          // survive a modal and resurface after it closes.
           open={
-            isControlled
-              ? controlledOpen
-              : blockedByModal
-                ? false
-                : clickOpen || undefined
+            blocked ? false : isControlled ? controlledOpen : hoverOpen || clickOpen
           }
           onOpenChange={onOpenChange}
           {...props}
         />
       </TooltipToggleCtx.Provider>
-    </TooltipContentElementCtx.Provider>
+    </TooltipTriggerElementCtx.Provider>
   );
 }
 
 function TooltipTrigger({
   onClick,
+  ref,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
   const toggle = useContext(TooltipToggleCtx);
+  const setTriggerElement = useContext(TooltipTriggerElementCtx);
+
+  // The trigger says which layer this tooltip belongs to, and unlike the
+  // content it is mounted the whole time, so the answer never goes missing.
+  const triggerRef = useCallback(
+    (el: HTMLElement | null) => {
+      assignRef(ref, el);
+      setTriggerElement(el);
+    },
+    [ref, setTriggerElement],
+  );
 
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -279,6 +291,7 @@ function TooltipTrigger({
 
   return (
     <TooltipPrimitive.Trigger
+      ref={triggerRef}
       data-slot="tooltip-trigger"
       onClick={handleClick}
       {...props}
@@ -302,15 +315,13 @@ function TooltipContent({
 }: React.ComponentProps<typeof TooltipPrimitive.Content> & {
   variant?: TooltipVariant;
 }) {
-  const setContentElement = useContext(TooltipContentElementCtx);
   // Single-line compact tooltips render as a full pill; wrapped ones keep
   // the squarer corners so tall pills do not look like capsules. A ref
   // callback measures on mount: Radix mounts the portal content without
   // re-rendering this wrapper, so an effect here would never see the node.
   const contentRef = useCallback(
-    (el: TooltipContentElement | null) => {
+    (el: React.ComponentRef<typeof TooltipPrimitive.Content> | null) => {
       assignRef(ref, el);
-      setContentElement(el);
       if (!el || variant !== "default") return;
       const cs = getComputedStyle(el);
       const lineHeight = Number.parseFloat(cs.lineHeight) || 16;
@@ -320,7 +331,7 @@ function TooltipContent({
         Number.parseFloat(cs.paddingBottom);
       el.classList.toggle("rounded-full!", innerHeight < lineHeight * 1.5);
     },
-    [ref, setContentElement, variant],
+    [ref, variant],
   );
   return (
     <TooltipPrimitive.Portal>

--- a/studio/frontend/src/components/ui/tooltip.tsx
+++ b/studio/frontend/src/components/ui/tooltip.tsx
@@ -8,6 +8,7 @@ import {
   useContext,
   useEffect,
   useState,
+  useSyncExternalStore,
 } from "react";
 import type * as React from "react";
 
@@ -15,6 +16,40 @@ import { cn } from "@/lib/utils";
 
 type ToggleFn = () => void;
 const TooltipToggleCtx = createContext<ToggleFn | null>(null);
+
+// Radix sets body pointer-events to none while a modal layer is up. That is also
+// when a hovered trigger stops receiving pointerleave, so a tooltip already on
+// screen hangs over the dialog with nothing able to close it. One observer
+// serves every tooltip.
+let modalLayerUp = false;
+const modalLayerListeners = new Set<() => void>();
+let modalLayerObserver: MutationObserver | null = null;
+
+function readModalLayer(): void {
+  const next = document.body.style.pointerEvents === "none";
+  if (next === modalLayerUp) return;
+  modalLayerUp = next;
+  for (const listener of modalLayerListeners) listener();
+}
+
+function subscribeModalLayer(listener: () => void): () => void {
+  modalLayerListeners.add(listener);
+  if (!modalLayerObserver && typeof MutationObserver !== "undefined") {
+    modalLayerObserver = new MutationObserver(readModalLayer);
+    modalLayerObserver.observe(document.body, {
+      attributes: true,
+      attributeFilter: ["style"],
+    });
+    readModalLayer();
+  }
+  return () => {
+    modalLayerListeners.delete(listener);
+  };
+}
+
+function getModalLayer(): boolean {
+  return modalLayerUp;
+}
 
 /** Tap-to-pin is for touch, which has no hover. Read at click time so hybrid
  * devices answer for the pointer in use. */
@@ -50,6 +85,11 @@ function Tooltip({
 }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
   const isControlled = controlledOpen !== undefined;
   const [clickOpen, setClickOpen] = useState(false);
+  const modalUp = useSyncExternalStore(
+    subscribeModalLayer,
+    getModalLayer,
+    () => false,
+  );
 
   const onOpenChange = useCallback(
     (nextOpen: boolean) => {
@@ -62,6 +102,11 @@ function Tooltip({
   const toggle = useCallback(() => {
     setClickOpen((prev) => !prev);
   }, []);
+
+  // Drop the pin too, so it does not reappear when the dialog closes.
+  useEffect(() => {
+    if (modalUp) setClickOpen(false);
+  }, [modalUp]);
 
   // A pin must not outlive its interaction: once a dialog covers the trigger,
   // pointerleave never fires and Radix can no longer close it. Presses on a
@@ -97,7 +142,11 @@ function Tooltip({
     <TooltipToggleCtx.Provider value={toggle}>
       <TooltipPrimitive.Root
         data-slot="tooltip"
-        open={isControlled ? controlledOpen : clickOpen || undefined}
+        // false, not undefined: a hovered tooltip has to be forced shut when a
+        // dialog opens, and stay shut until it closes.
+        open={
+          isControlled ? controlledOpen : modalUp ? false : clickOpen || undefined
+        }
         onOpenChange={onOpenChange}
         {...props}
       />

--- a/studio/frontend/tests/tooltip-modal-layer.test.ts
+++ b/studio/frontend/tests/tooltip-modal-layer.test.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isTooltipLayerBlocked } from "../src/components/ui/tooltip-modal-layer.ts";
+
+function tooltipLayer(pointerEvents: string): HTMLElement {
+  return {
+    ownerDocument: {
+      defaultView: {
+        getComputedStyle: () => ({ pointerEvents }),
+      },
+    },
+  } as unknown as HTMLElement;
+}
+
+test("a tooltip below the active modal is blocked", () => {
+  assert.equal(isTooltipLayerBlocked(tooltipLayer("none")), true);
+});
+
+test("a tooltip inside the active modal remains available", () => {
+  assert.equal(isTooltipLayerBlocked(tooltipLayer("auto")), false);
+});

--- a/studio/frontend/tests/tooltip-modal-layer.test.ts
+++ b/studio/frontend/tests/tooltip-modal-layer.test.ts
@@ -6,27 +6,46 @@ import test from "node:test";
 
 import { isBlockedByActiveModal } from "../src/components/ui/tooltip-modal-layer.ts";
 
-function element(pointerEvents: string): HTMLElement {
+/** A trigger plus its ancestors, nearest first, by inline pointer-events. */
+function trigger(own: string, ...ancestors: string[]): HTMLElement {
+  let parent: HTMLElement | null = null;
+  for (const pointerEvents of [...ancestors].reverse()) {
+    const node = { style: { pointerEvents }, parentElement: parent };
+    parent = node as unknown as HTMLElement;
+  }
   return {
-    ownerDocument: {
-      defaultView: {
-        getComputedStyle: () => ({ pointerEvents }),
-      },
-    },
+    style: { pointerEvents: own },
+    parentElement: parent,
   } as unknown as HTMLElement;
 }
 
-test("a trigger below the active modal is blocked", () => {
-  assert.equal(isBlockedByActiveModal(element("none")), true);
+test("a trigger under the modal is blocked by the body", () => {
+  // sidebar button -> ... -> body(none)
+  assert.equal(isBlockedByActiveModal(trigger("", "none")), true);
 });
 
-test("a trigger inside the active modal remains available", () => {
-  assert.equal(isBlockedByActiveModal(element("auto")), false);
+test("a trigger inside the active layer is not blocked", () => {
+  // dialog content(auto) sits between the trigger and body(none)
+  assert.equal(isBlockedByActiveModal(trigger("", "auto", "none")), false);
 });
 
-test("a detached view answers no rather than throwing", () => {
-  const orphan = {
-    ownerDocument: { defaultView: null },
-  } as unknown as HTMLElement;
-  assert.equal(isBlockedByActiveModal(orphan), false);
+test("a trigger on a layer beneath the modal is blocked", () => {
+  assert.equal(isBlockedByActiveModal(trigger("", "none", "none")), true);
+});
+
+test("no modal anywhere means nothing is blocked", () => {
+  assert.equal(isBlockedByActiveModal(trigger("", "", "")), false);
+});
+
+test("the trigger's own pointer-events is not modal ownership", () => {
+  // The MCP dropdown hint anchor is authored pointer-events-none so the row
+  // stays clickable. It is still inside the dropdown's layer.
+  assert.equal(isBlockedByActiveModal(trigger("none", "auto", "none")), false);
+});
+
+test("a detached element answers no rather than throwing", () => {
+  assert.equal(
+    isBlockedByActiveModal({ parentElement: null } as unknown as HTMLElement),
+    false,
+  );
 });

--- a/studio/frontend/tests/tooltip-modal-layer.test.ts
+++ b/studio/frontend/tests/tooltip-modal-layer.test.ts
@@ -4,9 +4,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { isTooltipLayerBlocked } from "../src/components/ui/tooltip-modal-layer.ts";
+import { isBlockedByActiveModal } from "../src/components/ui/tooltip-modal-layer.ts";
 
-function tooltipLayer(pointerEvents: string): HTMLElement {
+function element(pointerEvents: string): HTMLElement {
   return {
     ownerDocument: {
       defaultView: {
@@ -16,10 +16,17 @@ function tooltipLayer(pointerEvents: string): HTMLElement {
   } as unknown as HTMLElement;
 }
 
-test("a tooltip below the active modal is blocked", () => {
-  assert.equal(isTooltipLayerBlocked(tooltipLayer("none")), true);
+test("a trigger below the active modal is blocked", () => {
+  assert.equal(isBlockedByActiveModal(element("none")), true);
 });
 
-test("a tooltip inside the active modal remains available", () => {
-  assert.equal(isTooltipLayerBlocked(tooltipLayer("auto")), false);
+test("a trigger inside the active modal remains available", () => {
+  assert.equal(isBlockedByActiveModal(element("auto")), false);
+});
+
+test("a detached view answers no rather than throwing", () => {
+  const orphan = {
+    ownerDocument: { defaultView: null },
+  } as unknown as HTMLElement;
+  assert.equal(isBlockedByActiveModal(orphan), false);
 });

--- a/studio/frontend/tests/tooltip-open-state.test.ts
+++ b/studio/frontend/tests/tooltip-open-state.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright 2026-present the Unsloth AI Inc. team. All rights reserved. See /studio/LICENSE.AGPL-3.0
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveTooltipOpen } from "../src/components/ui/tooltip-open-state.ts";
+
+const base = {
+  blocked: false,
+  dismissedUntilOwnerResets: false,
+  hoverOpen: false,
+  clickOpen: false,
+};
+
+test("hover and a tap pin both open an uncontrolled tooltip", () => {
+  assert.equal(resolveTooltipOpen({ ...base, hoverOpen: true }), true);
+  assert.equal(resolveTooltipOpen({ ...base, clickOpen: true }), true);
+  assert.equal(resolveTooltipOpen(base), false);
+});
+
+test("a modal shuts one whose trigger is outside it", () => {
+  assert.equal(
+    resolveTooltipOpen({ ...base, blocked: true, hoverOpen: true }),
+    false,
+  );
+  assert.equal(
+    resolveTooltipOpen({ ...base, blocked: true, controlledOpen: true }),
+    false,
+  );
+});
+
+test("a controlled tooltip follows its owner", () => {
+  assert.equal(resolveTooltipOpen({ ...base, controlledOpen: true }), true);
+  assert.equal(resolveTooltipOpen({ ...base, controlledOpen: false }), false);
+});
+
+test("a controlled tooltip stays shut after a modal until its owner resets", () => {
+  // The resize handle keeps `hovered` true because no pointerleave arrived, so
+  // honouring `open` again would put the tooltip back with the pointer gone.
+  assert.equal(
+    resolveTooltipOpen({
+      ...base,
+      controlledOpen: true,
+      dismissedUntilOwnerResets: true,
+    }),
+    false,
+  );
+});
+
+test("an uncontrolled tooltip is not held by that latch", () => {
+  // Its own hover state was cleared when the modal opened, so a real hover
+  // afterwards must show it immediately.
+  assert.equal(
+    resolveTooltipOpen({
+      ...base,
+      hoverOpen: true,
+      dismissedUntilOwnerResets: true,
+    }),
+    true,
+  );
+});


### PR DESCRIPTION
## The bug

Open the Model Hub in the desktop app, click a model row, then open the delete confirmation. The row's status tooltip stays on screen, floating over the dialog, and nothing dismisses it. Clicking elsewhere does not help.

## Why it happens

`TooltipTrigger` pinned a tooltip open on **every** click, mouse included:

```tsx
onClick?.(e);
e.preventDefault();
toggle?.();      // sets clickOpen = true, on mouse clicks too
```

That tap-to-pin exists for touch, where there is no hover to rely on. But Hub rows are clickable, so selecting a model both selected it and pinned its tooltip. Then the dialog opened, Radix Dialog set `pointer-events: none` on everything outside the modal, the row stopped receiving `pointerleave`, and Radix had no way left to close the tooltip.

## The fix

**No pinning on a mouse.** `isCoarsePointer()` is read at click time rather than at module load, so a hybrid device answers for the pointer actually in use. With a fine pointer the handler returns early, leaving Radix's own close-on-click intact, so a click dismisses the tooltip instead of pinning it and it follows hover alone.

**A pin can no longer be stranded.** While pinned, the tooltip releases on a press outside any tooltip, on Escape, and on window blur. Presses on a trigger are deliberately skipped so tapping the same one still toggles it shut on touch.

Both changes are in the primitive rather than at the call sites, so this covers all five Hub tooltips that had the same defect (`CatalogRow`, the three in `models-table.tsx`, and `model-card.tsx`) plus anywhere else in the app with a clickable trigger.

## Testing

Typecheck and build clean. Frontend suite unchanged at 333/334, with the one failure being the pre-existing `sidebar-spinner-column` assertion against `app-sidebar.tsx`, which this does not touch.

This is interaction behaviour rather than rendering, so it is worth a manual pass on touch as well: tapping a trigger should still open the tooltip, and tapping it again should still close it.
